### PR TITLE
Ensure OperationDefinition case has at least one selection

### DIFF
--- a/query/graphql/planner/planner.go
+++ b/query/graphql/planner/planner.go
@@ -119,7 +119,10 @@ func (p *Planner) newPlan(stmt parser.Statement) (planNode, error) {
 			return nil, errors.New("Query is missing query or mutation statements")
 		}
 	case *parser.OperationDefinition:
-		return p.newPlan(n.Selections[0]) // @todo: ensure parser.QueryDefinition has at least 1 selection
+		if len(n.Selections) == 0 {
+			return nil, errors.New("OperationDefinition is missing selections")
+		}
+		return p.newPlan(n.Selections[0])
 	case *parser.Select:
 		return p.Select(n)
 	case *parser.CommitSelect:


### PR DESCRIPTION
Posibly theoretical, but is an easy todo to kill off and its better to have the defensive code than a panic