### PR TITLE
feat: 2-liner for quick code coverage for now

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 cli/defradb/defradb
 cli/defradb/defradb.exe
 build/defradb*
+cover.out

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,11 @@ test:
 test\:bench:
 	go test -bench
 
+.PHONY: test\:coverage
+test\:coverage:
+	go test ./... -coverprofile cover.out
+	go tool cover -func cover.out | grep total | awk '{print $$3}'
+
 .PHONY: lint
 lint:
 	golangci-lint run --config .golangci.sourceinc.yaml


### PR DESCRIPTION
We can have a proper Circle-Ci code coverage with a badge once we open-source because then we can use some good tools for free that come with some neat graphs for better visualizations. For now this lil 2 liner can give us a quick over view.

related #54 