### PR TITLE
fix: Support relationships where both fields have the same name

### DIFF
--- a/db/tests/query/one_to_many/with_same_field_name_test.go
+++ b/db/tests/query/one_to_many/with_same_field_name_test.go
@@ -1,0 +1,107 @@
+// Copyright 2020 Source Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+package one_to_many
+
+import (
+	"testing"
+
+	testUtils "github.com/sourcenetwork/defradb/db/tests"
+)
+
+var sameFieldNameGQLSchema = (`
+	type book {
+		name: String
+		relationship1: author
+	}
+
+	type author {
+		name: String
+		relationship1: [book]
+	}
+`)
+
+func executeSameFieldNameTestCase(t *testing.T, test testUtils.QueryTestCase) {
+	testUtils.ExecuteQueryTestCase(t, sameFieldNameGQLSchema, []string{"book", "author"}, test)
+}
+
+func TestQueryOneToManyWithSameFieldName(t *testing.T) {
+	tests := []testUtils.QueryTestCase{
+		{
+			Description: "One-to-many relation query from one side, same field name",
+			Query: `query {
+						book {
+							name
+							relationship1 {
+								name
+							}
+						}
+					}`,
+			Docs: map[int][]string{
+				//books
+				0: { // bae-9217906d-e8c5-533d-8520-71c754590844
+					(`{
+					"name": "Painted House",
+					"relationship1_id": "bae-2edb7fdd-cad7-5ad4-9c7d-6920245a96ed"
+				}`)},
+				//authors
+				1: { // bae-2edb7fdd-cad7-5ad4-9c7d-6920245a96ed
+					(`{
+					"name": "John Grisham"
+				}`)},
+			},
+			Results: []map[string]interface{}{
+				{
+					"name": "Painted House",
+					"relationship1": map[string]interface{}{
+						"name": "John Grisham",
+					},
+				},
+			},
+		},
+		{
+			Description: "One-to-many relation query from many side, same field name",
+			Query: `query {
+						author {
+							name
+							relationship1 {
+								name
+							}
+						}
+					}`,
+			Docs: map[int][]string{
+				//books
+				0: { // bae-9217906d-e8c5-533d-8520-71c754590844
+					(`{
+					"name": "Painted House",
+					"relationship1_id": "bae-2edb7fdd-cad7-5ad4-9c7d-6920245a96ed"
+				}`)},
+				//authors
+				1: { // bae-2edb7fdd-cad7-5ad4-9c7d-6920245a96ed
+					(`{
+					"name": "John Grisham"
+				}`)},
+			},
+			Results: []map[string]interface{}{
+				{
+					"name": "John Grisham",
+					"relationship1": []map[string]interface{}{
+						{
+							"name": "Painted House",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		executeSameFieldNameTestCase(t, test)
+	}
+}

--- a/query/graphql/planner/type_join.go
+++ b/query/graphql/planner/type_join.go
@@ -349,13 +349,24 @@ func (p *Planner) makeTypeJoinMany(parent *selectNode, source planNode, subType 
 	}
 	subType.CollectionName = subTypeFieldDesc.Schema
 
+	// get relation
+	rm := p.db.SchemaManager().Relations
+	rel := rm.GetRelationByDescription(subType.Name, subTypeFieldDesc.Schema, desc.Name)
+	if rel == nil {
+		return nil, errors.New("Relation does not exists")
+	}
+	subTypeLookupFieldName, _, ok := rel.GetFieldFromSchemaType(subTypeFieldDesc.Schema)
+	if !ok {
+		return nil, errors.New("Relation is missing referenced field")
+	}
+
 	selectPlan, err := p.SubSelect(subType)
 	if err != nil {
 		return nil, err
 	}
 	typeJoin.subType = selectPlan
 	typeJoin.subTypeName = subTypeFieldDesc.Name
-	typeJoin.rootName = desc.Name
+	typeJoin.rootName = subTypeLookupFieldName
 
 	// split filter
 	if scan, ok := source.(*scanNode); ok {

--- a/query/graphql/schema/descriptions.go
+++ b/query/graphql/schema/descriptions.go
@@ -128,7 +128,7 @@ func (g *Generator) CreateDescriptions(types []*gql.Object) ([]base.CollectionDe
 					return nil, errors.New("Field missing associated relation")
 				}
 
-				_, fieldRelationType, ok := rel.GetField(fname)
+				_, fieldRelationType, ok := rel.GetField(schemaName, fname)
 				if !ok {
 					return nil, errors.New("Relation is missing field")
 				}

--- a/query/graphql/schema/relations.go
+++ b/query/graphql/schema/relations.go
@@ -281,9 +281,9 @@ func (r Relation) schemaTypeExists(t string) (int, bool) {
 	return -1, false
 }
 
-func (r Relation) GetField(field string) (string, uint8, bool) {
+func (r Relation) GetField(schemaType string, field string) (string, uint8, bool) {
 	for i, f := range r.fields {
-		if f == field {
+		if f == field && r.schemaTypes[i] == schemaType {
 			return f, r.types[i], true
 		}
 	}


### PR DESCRIPTION
Closes #107 

Technically two issues here I think:

On the one-many side: Relation.GetField was just returning the first with the same name, making the functionality dependent on golang's randomized map ordering.

On the many-one side: typeJoinMany was just using the schema name + id as the foreign key field name, causing the lookup to fail if the relationship was not named after the other schema.