### PR TITLE
fix: Handle errors generated during input object thunks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,6 @@ replace (
 	github.com/SierraSoftworks/connor => github.com/sourcenetwork/connor v1.0.3-0.20210312091030-4823d0411a12
 
 	// temp bug fixing
-	github.com/graphql-go/graphql => github.com/sourcenetwork/graphql v0.7.10-0.20211201133854-7e4c02b364c3
+	github.com/graphql-go/graphql => github.com/sourcenetwork/graphql v0.7.10-0.20220122211559-2fe60b2360cc
 // github.com/graphql-go/graphql => github.com/sourcenetwork/graphql v0.7.10-0.20210211004004-07fce0d1409f
 )

--- a/go.sum
+++ b/go.sum
@@ -913,8 +913,8 @@ github.com/sourcegraph/annotate v0.0.0-20160123013949-f4cad6c6324d/go.mod h1:Udh
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
 github.com/sourcenetwork/connor v1.0.3-0.20210312091030-4823d0411a12 h1:MELz22GoPeecJnBS5RT4i52bNY/wlpvbGW3L4lLuBTU=
 github.com/sourcenetwork/connor v1.0.3-0.20210312091030-4823d0411a12/go.mod h1:IimP/qkAJro1hXbVA8xOMDdkUeWkVw8rF40XrZq5YX0=
-github.com/sourcenetwork/graphql v0.7.10-0.20211201133854-7e4c02b364c3 h1:tlzloRd2CwVQmUUKp+xnZ8ydOgI/D0h/BooFNrDFNGg=
-github.com/sourcenetwork/graphql v0.7.10-0.20211201133854-7e4c02b364c3/go.mod h1:3Ty9EMes+aoxl8xS0CsuCGQZ4JEsOlC5yqQDLOKoBRw=
+github.com/sourcenetwork/graphql v0.7.10-0.20220122211559-2fe60b2360cc h1:Jl+vKL3i+wE+T95aHU0wGVUWf17NxeS+1ku+IQT6ZdU=
+github.com/sourcenetwork/graphql v0.7.10-0.20220122211559-2fe60b2360cc/go.mod h1:3Ty9EMes+aoxl8xS0CsuCGQZ4JEsOlC5yqQDLOKoBRw=
 github.com/spacemonkeygo/openssl v0.0.0-20181017203307-c2dcc5cca94a/go.mod h1:7AyxJNCJ7SBZ1MfVQCWD6Uqo2oubI2Eq2y2eqf+A5r0=
 github.com/spacemonkeygo/spacelog v0.0.0-20180420211403-2296661a0572 h1:RC6RW7j+1+HkWaX/Yh71Ee5ZHaHYt7ZP4sQgUrm6cDU=
 github.com/spacemonkeygo/spacelog v0.0.0-20180420211403-2296661a0572/go.mod h1:w0SWMsp6j9O/dk4/ZpIhL+3CkG8ofA2vuv7k+ltqUMc=

--- a/query/graphql/schema/generate.go
+++ b/query/graphql/schema/generate.go
@@ -615,7 +615,7 @@ func (g *Generator) genTypeFilterArgInput(obj *gql.Object) *gql.InputObject {
 	inputCfg := gql.InputObjectConfig{
 		Name: genTypeName(obj, "FilterArg"),
 	}
-	fieldThunk := (gql.InputObjectConfigFieldMapThunk)(func() gql.InputObjectConfigFieldMap {
+	fieldThunk := (gql.InputObjectConfigFieldMapThunk)(func() (gql.InputObjectConfigFieldMap, error) {
 		fields := gql.InputObjectConfigFieldMap{}
 
 		// conditionals
@@ -650,7 +650,7 @@ func (g *Generator) genTypeFilterArgInput(obj *gql.Object) *gql.InputObject {
 
 		// fmt.Println("#####################")
 		// spew.Dump(fields)
-		return fields
+		return fields, nil
 	})
 
 	// add the fields thunker
@@ -721,7 +721,7 @@ func (g *Generator) genTypeOrderArgInput(obj *gql.Object) *gql.InputObject {
 	inputCfg := gql.InputObjectConfig{
 		Name: genTypeName(obj, "OrderArg"),
 	}
-	fieldThunk := (gql.InputObjectConfigFieldMapThunk)(func() gql.InputObjectConfigFieldMap {
+	fieldThunk := (gql.InputObjectConfigFieldMapThunk)(func() (gql.InputObjectConfigFieldMap, error) {
 		fields := gql.InputObjectConfigFieldMap{}
 
 		for f, field := range obj.Fields() {
@@ -739,7 +739,7 @@ func (g *Generator) genTypeOrderArgInput(obj *gql.Object) *gql.InputObject {
 			}
 		}
 
-		return fields
+		return fields, nil
 	})
 
 	inputCfg.Fields = fieldThunk


### PR DESCRIPTION
Closes #112 

Also includes a fix for a hidden issue where errors were being silently generated during many of our tests but being ignored (see commit `Generate Filter base args for all objects before resolving`). Note that fixing this issue removes any currently generateable errors from the current thunks, however I believe we should still have support for this lest we later introduce more hidden errors.

Dependent on https://github.com/sourcenetwork/graphql-go/pull/3

Todo:

- [x] Update go.mod once graphql-go fork PR is merged
