### PR TITLE
chore: Remove the S1038 rule of the gosimple linter.

### DIFF
--- a/.golangci.sourceinc.yaml
+++ b/.golangci.sourceinc.yaml
@@ -440,7 +440,10 @@ linters-settings:
     # Select the Go version to target. The default is '1.13'.
     go: "1.15"
     # https://staticcheck.io/docs/options#checks
-    checks: [ "all" ]
+    checks: [ "all", "-S1038" ]
+    # Turn on all except (these are disabled):
+    # - S1038 - Unnecessarily complex way of printing formatted string. Which said
+    #   instead of using fmt.Print(fmt.Sprintf(...)), one can use fmt.Printf(...).
 
   govet:
     # report about shadowed variables

--- a/db/tests/utils.go
+++ b/db/tests/utils.go
@@ -117,7 +117,6 @@ func ExecuteQueryTestCase(t *testing.T, schema string, collectionNames []string,
 
 	for _, dbi := range dbs {
 		fmt.Println("--------------")
-		//nolint:gosimple
 		fmt.Println(fmt.Sprintf("Running tests with database type: %s", dbi.name))
 
 		db := dbi.db


### PR DESCRIPTION
Turn off the S1038 of `gosimple`.

- S1038 : Unnecessarily complex way of printing formatted string. Which said instead of using fmt.Print(fmt.Sprintf(...)), one can use fmt.Printf(...).