### PR TITLE
fix: Binary install named defradb

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ default:
 
 .PHONY: install
 install:
-	go install cli/defradb/main.go
+	go install ./cli/defradb/
 
 .PHONY: build
 build:


### PR DESCRIPTION
closes #189 

Useful for consistency and the "Getting started" experience.