### PR TITLE
ci: Add rule to only run benchmark if other check are successful

### DIFF
--- a/.github/workflows/benchmark-ec2-runner.yml
+++ b/.github/workflows/benchmark-ec2-runner.yml
@@ -71,8 +71,8 @@ jobs:
     runs-on: ${{ needs.start-runner.outputs.label }} # run the job on the newly created runner
 
     steps:
-      - name: Setup benchmarks
-        run: echo 'Replace with Johns Benchmarking Command Steps'
+      - name: Start Running the bechmarks
+        run: make test:bench
 
   # Step-4: Stop the runner once the benchmarks have ran.
   stop-runner:

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ test\:clean: clean\:test test
 
 .PHONY: test\:bench
 test\:bench:
-	go test ./... -race -bench=.
+	make -C ./bench/ bench
 
 # This also takes integration tests into account.
 .PHONY: test\:coverage-full


### PR DESCRIPTION
Add a check to only run the benchmark ec2 runner workflow if the other GitHub workflows are successful.