### PR TITLE
refactor: Initialize database in constructor

### DIFF
--- a/bench/bench_util.go
+++ b/bench/bench_util.go
@@ -98,7 +98,7 @@ func SetupCollections(b *testing.B, ctx context.Context, db *defradb.DB, fixture
 }
 
 func SetupDBAndCollections(b *testing.B, ctx context.Context, fixture fixtures.Generator) (*defradb.DB, []client.Collection, error) {
-	db, err := NewTestDB(b)
+	db, err := NewTestDB(ctx, b)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -204,28 +204,28 @@ type dbInfo interface {
 	DB() *db.DB
 }
 
-func NewTestDB(t testing.TB) (*db.DB, error) {
+func NewTestDB(ctx context.Context, t testing.TB) (*db.DB, error) {
 	//nolint
-	dbi, err := newBenchStoreInfo(t)
+	dbi, err := newBenchStoreInfo(ctx, t)
 	return dbi.DB(), err
 }
 
-func NewTestStorage(t testing.TB) (ds.Batching, error) {
-	dbi, err := newBenchStoreInfo(t)
+func NewTestStorage(ctx context.Context, t testing.TB) (ds.Batching, error) {
+	dbi, err := newBenchStoreInfo(ctx, t)
 	return dbi.Rootstore(), err
 }
 
-func newBenchStoreInfo(t testing.TB) (dbInfo, error) {
+func newBenchStoreInfo(ctx context.Context, t testing.TB) (dbInfo, error) {
 	var dbi dbInfo
 	var err error
 
 	switch storage {
 	case "memory":
-		dbi, err = testutils.NewBadgerMemoryDB()
+		dbi, err = testutils.NewBadgerMemoryDB(ctx)
 	case "badger":
-		dbi, err = testutils.NewBadgerFileDB(t)
+		dbi, err = testutils.NewBadgerFileDB(ctx, t)
 	case "memorymap":
-		dbi, err = testutils.NewMapDB()
+		dbi, err = testutils.NewMapDB(ctx)
 	default:
 		return nil, fmt.Errorf("invalid storage engine backend: %s", storage)
 	}

--- a/bench/storage/utils.go
+++ b/bench/storage/utils.go
@@ -21,7 +21,7 @@ import (
 )
 
 func runStorageBenchGet(b *testing.B, ctx context.Context, valueSize, objCount, opCount int, doSync bool) error {
-	db, err := benchutils.NewTestStorage(b)
+	db, err := benchutils.NewTestStorage(ctx, b)
 	if err != nil {
 		return err
 	}
@@ -49,7 +49,7 @@ func runStorageBenchGet(b *testing.B, ctx context.Context, valueSize, objCount, 
 }
 
 func runStorageBenchPut(b *testing.B, ctx context.Context, valueSize, objCount, opCount int, doSync bool) error {
-	db, err := benchutils.NewTestStorage(b)
+	db, err := benchutils.NewTestStorage(ctx, b)
 	if err != nil {
 		return err
 	}
@@ -85,7 +85,7 @@ func runStorageBenchPut(b *testing.B, ctx context.Context, valueSize, objCount, 
 }
 
 func runStorageBenchPutMany(b *testing.B, ctx context.Context, valueSize, objCount, opCount int, doSync bool) error {
-	db, err := benchutils.NewTestStorage(b)
+	db, err := benchutils.NewTestStorage(ctx, b)
 	if err != nil {
 		return err
 	}

--- a/cli/defradb/cmd/serverdump.go
+++ b/cli/defradb/cmd/serverdump.go
@@ -47,14 +47,9 @@ var srvDumpCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		db, err := db.NewDB(rootstore)
+		db, err := db.NewDB(ctx, rootstore)
 		if err != nil {
 			log.Error("Failed to initiate database:", err)
-			os.Exit(1)
-		}
-		if err := db.Start(ctx); err != nil {
-			log.Error("Failed to start the database: ", err)
-			db.Close()
 			os.Exit(1)
 		}
 

--- a/cli/defradb/cmd/start.go
+++ b/cli/defradb/cmd/start.go
@@ -84,14 +84,9 @@ var startCmd = &cobra.Command{
 			options = append(options, db.WithBroadcaster(bs))
 		}
 
-		db, err := db.NewDB(rootstore, options...)
+		db, err := db.NewDB(ctx, rootstore, options...)
 		if err != nil {
 			log.Error("Failed to initiate database:", err)
-			os.Exit(1)
-		}
-		if err := db.Start(ctx); err != nil {
-			log.Error("Failed to start the database: ", err)
-			db.Close()
 			os.Exit(1)
 		}
 

--- a/db/collection_test.go
+++ b/db/collection_test.go
@@ -61,7 +61,7 @@ func createNewTestCollection(ctx context.Context, db *DB) (client.Collection, er
 
 func TestNewCollection_ReturnsError_GivenNoSchema(t *testing.T) {
 	ctx := context.Background()
-	db, err := newMemoryDB()
+	db, err := newMemoryDB(ctx)
 	assert.NoError(t, err)
 
 	_, err = createNewTestCollection(ctx, db)
@@ -70,7 +70,7 @@ func TestNewCollection_ReturnsError_GivenNoSchema(t *testing.T) {
 
 func TestNewCollectionWithSchema(t *testing.T) {
 	ctx := context.Background()
-	db, err := newMemoryDB()
+	db, err := newMemoryDB(ctx)
 	assert.NoError(t, err)
 
 	col, err := newTestCollectionWithSchema(ctx, db)
@@ -95,7 +95,7 @@ func TestNewCollectionWithSchema(t *testing.T) {
 
 func TestNewCollectionReturnsErrorGivenDuplicateSchema(t *testing.T) {
 	ctx := context.Background()
-	db, err := newMemoryDB()
+	db, err := newMemoryDB(ctx)
 	assert.NoError(t, err)
 
 	_, err = newTestCollectionWithSchema(ctx, db)
@@ -107,7 +107,7 @@ func TestNewCollectionReturnsErrorGivenDuplicateSchema(t *testing.T) {
 
 func TestNewCollectionReturnsErrorGivenNoFields(t *testing.T) {
 	ctx := context.Background()
-	db, err := newMemoryDB()
+	db, err := newMemoryDB(ctx)
 	assert.NoError(t, err)
 
 	desc := base.CollectionDescription{
@@ -123,7 +123,7 @@ func TestNewCollectionReturnsErrorGivenNoFields(t *testing.T) {
 
 func TestNewCollectionReturnsErrorGivenNoName(t *testing.T) {
 	ctx := context.Background()
-	db, err := newMemoryDB()
+	db, err := newMemoryDB(ctx)
 	assert.NoError(t, err)
 
 	desc := base.CollectionDescription{
@@ -139,7 +139,7 @@ func TestNewCollectionReturnsErrorGivenNoName(t *testing.T) {
 
 func TestNewCollectionReturnsErrorGivenNoKeyField(t *testing.T) {
 	ctx := context.Background()
-	db, err := newMemoryDB()
+	db, err := newMemoryDB(ctx)
 	assert.NoError(t, err)
 
 	desc := base.CollectionDescription{
@@ -161,7 +161,7 @@ func TestNewCollectionReturnsErrorGivenNoKeyField(t *testing.T) {
 
 func TestNewCollectionReturnsErrorGivenKeyFieldIsNotFirstField(t *testing.T) {
 	ctx := context.Background()
-	db, err := newMemoryDB()
+	db, err := newMemoryDB(ctx)
 	assert.NoError(t, err)
 
 	desc := base.CollectionDescription{
@@ -187,7 +187,7 @@ func TestNewCollectionReturnsErrorGivenKeyFieldIsNotFirstField(t *testing.T) {
 
 func TestNewCollectionReturnsErrorGivenFieldWithNoName(t *testing.T) {
 	ctx := context.Background()
-	db, err := newMemoryDB()
+	db, err := newMemoryDB(ctx)
 	assert.NoError(t, err)
 
 	desc := base.CollectionDescription{
@@ -213,7 +213,7 @@ func TestNewCollectionReturnsErrorGivenFieldWithNoName(t *testing.T) {
 
 func TestNewCollectionReturnsErrorGivenFieldWithNoKind(t *testing.T) {
 	ctx := context.Background()
-	db, err := newMemoryDB()
+	db, err := newMemoryDB(ctx)
 	assert.NoError(t, err)
 
 	desc := base.CollectionDescription{
@@ -238,7 +238,7 @@ func TestNewCollectionReturnsErrorGivenFieldWithNoKind(t *testing.T) {
 
 func TestNewCollectionReturnsErrorGivenFieldWithNoType(t *testing.T) {
 	ctx := context.Background()
-	db, err := newMemoryDB()
+	db, err := newMemoryDB(ctx)
 	assert.NoError(t, err)
 
 	desc := base.CollectionDescription{
@@ -263,7 +263,7 @@ func TestNewCollectionReturnsErrorGivenFieldWithNoType(t *testing.T) {
 
 func TestGetCollection(t *testing.T) {
 	ctx := context.Background()
-	db, err := newMemoryDB()
+	db, err := newMemoryDB(ctx)
 	assert.NoError(t, err)
 
 	_, err = newTestCollectionWithSchema(ctx, db)
@@ -291,7 +291,7 @@ func TestGetCollection(t *testing.T) {
 
 func TestGetCollectionReturnsErrorGivenNonExistantCollection(t *testing.T) {
 	ctx := context.Background()
-	db, err := newMemoryDB()
+	db, err := newMemoryDB(ctx)
 	assert.NoError(t, err)
 
 	_, err = db.GetCollection(ctx, "doesNotExist")
@@ -300,7 +300,7 @@ func TestGetCollectionReturnsErrorGivenNonExistantCollection(t *testing.T) {
 
 func TestGetCollectionReturnsErrorGivenEmptyString(t *testing.T) {
 	ctx := context.Background()
-	db, err := newMemoryDB()
+	db, err := newMemoryDB(ctx)
 	assert.NoError(t, err)
 
 	_, err = db.GetCollection(ctx, "")

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -29,16 +29,17 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func newMemoryDB() (*DB, error) {
+func newMemoryDB(ctx context.Context) (*DB, error) {
 	opts := badgerds.Options{Options: badger.DefaultOptions("").WithInMemory(true)}
 	rootstore, err := badgerds.NewDatastore("", &opts)
 	if err != nil {
 		return nil, err
 	}
-	return NewDB(rootstore)
+	return NewDB(ctx, rootstore)
 }
 
 func TestNewDB(t *testing.T) {
+	ctx := context.Background()
 	opts := badgerds.Options{Options: badger.DefaultOptions("").WithInMemory(true)}
 	rootstore, err := badgerds.NewDatastore("", &opts)
 	if err != nil {
@@ -46,7 +47,7 @@ func TestNewDB(t *testing.T) {
 		return
 	}
 
-	_, err = NewDB(rootstore)
+	_, err = NewDB(ctx, rootstore)
 	if err != nil {
 		t.Error(err)
 	}
@@ -56,7 +57,7 @@ func TestNewDBWithCollection_Errors_GivenNoSchema(t *testing.T) {
 	ctx := context.Background()
 	rootstore := ds.NewMapDatastore()
 
-	db, err := NewDB(rootstore)
+	db, err := NewDB(ctx, rootstore)
 	if err != nil {
 		t.Error(err)
 	}
@@ -70,7 +71,7 @@ func TestNewDBWithCollection_Errors_GivenNoSchema(t *testing.T) {
 
 func TestDBSaveSimpleDocument(t *testing.T) {
 	ctx := context.Background()
-	db, err := newMemoryDB()
+	db, err := newMemoryDB(ctx)
 	assert.NoError(t, err)
 	col, err := newTestCollectionWithSchema(ctx, db)
 	assert.NoError(t, err)
@@ -112,7 +113,7 @@ func TestDBSaveSimpleDocument(t *testing.T) {
 
 func TestDBUpdateDocument(t *testing.T) {
 	ctx := context.Background()
-	db, err := newMemoryDB()
+	db, err := newMemoryDB(ctx)
 	assert.NoError(t, err)
 	col, err := newTestCollectionWithSchema(ctx, db)
 	assert.NoError(t, err)
@@ -165,7 +166,7 @@ func TestDBUpdateDocument(t *testing.T) {
 
 func TestDBUpdateNonExistingDocument(t *testing.T) {
 	ctx := context.Background()
-	db, err := newMemoryDB()
+	db, err := newMemoryDB(ctx)
 	assert.NoError(t, err)
 	col, err := newTestCollectionWithSchema(ctx, db)
 	assert.NoError(t, err)
@@ -188,7 +189,7 @@ func TestDBUpdateNonExistingDocument(t *testing.T) {
 
 func TestDBUpdateExistingDocument(t *testing.T) {
 	ctx := context.Background()
-	db, err := newMemoryDB()
+	db, err := newMemoryDB(ctx)
 	assert.NoError(t, err)
 	col, err := newTestCollectionWithSchema(ctx, db)
 	assert.NoError(t, err)
@@ -231,7 +232,7 @@ func TestDBUpdateExistingDocument(t *testing.T) {
 
 func TestDBGetDocument(t *testing.T) {
 	ctx := context.Background()
-	db, err := newMemoryDB()
+	db, err := newMemoryDB(ctx)
 	assert.NoError(t, err)
 	col, err := newTestCollectionWithSchema(ctx, db)
 	assert.NoError(t, err)
@@ -276,7 +277,7 @@ func TestDBGetDocument(t *testing.T) {
 
 func TestDBGetNotFoundDocument(t *testing.T) {
 	ctx := context.Background()
-	db, err := newMemoryDB()
+	db, err := newMemoryDB(ctx)
 	assert.NoError(t, err)
 	col, err := newTestCollectionWithSchema(ctx, db)
 	assert.NoError(t, err)
@@ -289,7 +290,7 @@ func TestDBGetNotFoundDocument(t *testing.T) {
 
 func TestDBDeleteDocument(t *testing.T) {
 	ctx := context.Background()
-	db, err := newMemoryDB()
+	db, err := newMemoryDB(ctx)
 	assert.NoError(t, err)
 	col, err := newTestCollectionWithSchema(ctx, db)
 	assert.NoError(t, err)
@@ -315,7 +316,7 @@ func TestDBDeleteDocument(t *testing.T) {
 
 func TestDBDeleteNotFoundDocument(t *testing.T) {
 	ctx := context.Background()
-	db, err := newMemoryDB()
+	db, err := newMemoryDB(ctx)
 	assert.NoError(t, err)
 	col, err := newTestCollectionWithSchema(ctx, db)
 	assert.NoError(t, err)
@@ -329,7 +330,7 @@ func TestDBDeleteNotFoundDocument(t *testing.T) {
 
 func TestDocumentMerkleDAG(t *testing.T) {
 	ctx := context.Background()
-	db, err := newMemoryDB()
+	db, err := newMemoryDB(ctx)
 	assert.NoError(t, err)
 	col, err := newTestCollectionWithSchema(ctx, db)
 	assert.NoError(t, err)
@@ -416,7 +417,7 @@ func TestDocumentMerkleDAG(t *testing.T) {
 // collection with schema
 func TestDBSchemaSaveSimpleDocument(t *testing.T) {
 	ctx := context.Background()
-	db, err := newMemoryDB()
+	db, err := newMemoryDB(ctx)
 	assert.NoError(t, err)
 	col, err := newTestCollectionWithSchema(ctx, db)
 	assert.NoError(t, err)
@@ -449,7 +450,7 @@ func TestDBSchemaSaveSimpleDocument(t *testing.T) {
 
 func TestDBUpdateDocWithFilter(t *testing.T) {
 	ctx := context.Background()
-	db, err := newMemoryDB()
+	db, err := newMemoryDB(ctx)
 	assert.NoError(t, err)
 	col, err := newTestCollectionWithSchema(ctx, db)
 	assert.NoError(t, err)

--- a/db/fetcher/versioned_test.go
+++ b/db/fetcher/versioned_test.go
@@ -90,13 +90,14 @@ var (
 	}
 )
 
-func newMemoryDB() (*db.DB, error) {
+func newMemoryDB(ctx context.Context) (*db.DB, error) {
 	rootstore := ds.NewMapDatastore()
-	return db.NewDB(rootstore)
+	return db.NewDB(ctx, rootstore)
 }
 
 func TestVersionedFetcherInit(t *testing.T) {
-	db, err := newMemoryDB()
+	ctx := context.Background()
+	db, err := newMemoryDB(ctx)
 	assert.NoError(t, err)
 
 	col, err := newTestCollectionWithSchema(db)
@@ -110,7 +111,7 @@ func TestVersionedFetcherInit(t *testing.T) {
 
 func TestVersionedFetcherStart(t *testing.T) {
 	ctx := context.Background()
-	db, err := newMemoryDB()
+	db, err := newMemoryDB(ctx)
 	assert.NoError(t, err)
 
 	col, err := newTestCollectionWithSchema(db)
@@ -153,7 +154,7 @@ func TestVersionedFetcherStart(t *testing.T) {
 
 func TestVersionedFetcherNextMap(t *testing.T) {
 	ctx := context.Background()
-	db, err := newMemoryDB()
+	db, err := newMemoryDB(ctx)
 	assert.NoError(t, err)
 
 	col, err := newTestCollectionWithSchema(db)
@@ -196,7 +197,7 @@ func TestVersionedFetcherNextMap(t *testing.T) {
 
 func TestVersionedFetcherNextMapV1(t *testing.T) {
 	ctx := context.Background()
-	db, err := newMemoryDB()
+	db, err := newMemoryDB(ctx)
 	assert.NoError(t, err)
 
 	col, err := newTestCollectionWithSchema(db)
@@ -239,7 +240,7 @@ func TestVersionedFetcherNextMapV1(t *testing.T) {
 
 func TestVersionedFetcherNextMapV2(t *testing.T) {
 	ctx := context.Background()
-	db, err := newMemoryDB()
+	db, err := newMemoryDB(ctx)
 	assert.NoError(t, err)
 
 	col, err := newTestCollectionWithSchema(db)
@@ -282,7 +283,7 @@ func TestVersionedFetcherNextMapV2(t *testing.T) {
 
 func TestVersionedFetcherNextMapV3(t *testing.T) {
 	ctx := context.Background()
-	db, err := newMemoryDB()
+	db, err := newMemoryDB(ctx)
 	assert.NoError(t, err)
 
 	col, err := newTestCollectionWithSchema(db)
@@ -324,7 +325,7 @@ func TestVersionedFetcherNextMapV3(t *testing.T) {
 
 func TestVersionedFetcherIncrementalSeekTo(t *testing.T) {
 	ctx := context.Background()
-	db, err := newMemoryDB()
+	db, err := newMemoryDB(ctx)
 	assert.NoError(t, err)
 
 	col, err := newTestCollectionWithSchema(db)

--- a/db/fetcher_test.go
+++ b/db/fetcher_test.go
@@ -78,7 +78,7 @@ func TestFetcherInit(t *testing.T) {
 
 func TestFetcherStart(t *testing.T) {
 	ctx := context.Background()
-	db, err := newMemoryDB()
+	db, err := newMemoryDB(ctx)
 	if err != nil {
 		t.Error(err)
 		return
@@ -97,7 +97,7 @@ func TestFetcherStart(t *testing.T) {
 
 func TestFetcherStartWithoutInit(t *testing.T) {
 	ctx := context.Background()
-	db, err := newMemoryDB()
+	db, err := newMemoryDB(ctx)
 	if err != nil {
 		t.Error(err)
 		return
@@ -120,7 +120,7 @@ func TestMakeIndexPrefixKey(t *testing.T) {
 
 func TestFetcherGetAllPrimaryIndexEncodedDocSingle(t *testing.T) {
 	ctx := context.Background()
-	db, err := newMemoryDB()
+	db, err := newMemoryDB(ctx)
 	assert.NoError(t, err)
 
 	col, err := newTestCollectionWithSchema(ctx, db)
@@ -170,7 +170,7 @@ func TestFetcherGetAllPrimaryIndexEncodedDocSingle(t *testing.T) {
 
 func TestFetcherGetAllPrimaryIndexEncodedDocMultiple(t *testing.T) {
 	ctx := context.Background()
-	db, err := newMemoryDB()
+	db, err := newMemoryDB(ctx)
 	assert.NoError(t, err)
 
 	col, err := newTestCollectionWithSchema(ctx, db)
@@ -232,7 +232,7 @@ func TestFetcherGetAllPrimaryIndexEncodedDocMultiple(t *testing.T) {
 
 func TestFetcherGetAllPrimaryIndexDecodedSingle(t *testing.T) {
 	ctx := context.Background()
-	db, err := newMemoryDB()
+	db, err := newMemoryDB(ctx)
 	assert.NoError(t, err)
 
 	col, err := newTestCollectionWithSchema(ctx, db)
@@ -277,7 +277,7 @@ func TestFetcherGetAllPrimaryIndexDecodedSingle(t *testing.T) {
 
 func TestFetcherGetAllPrimaryIndexDecodedMultiple(t *testing.T) {
 	ctx := context.Background()
-	db, err := newMemoryDB()
+	db, err := newMemoryDB(ctx)
 	assert.NoError(t, err)
 
 	col, err := newTestCollectionWithSchema(ctx, db)
@@ -342,7 +342,7 @@ func TestFetcherGetAllPrimaryIndexDecodedMultiple(t *testing.T) {
 
 func TestFetcherGetOnePrimaryIndexDecoded(t *testing.T) {
 	ctx := context.Background()
-	db, err := newMemoryDB()
+	db, err := newMemoryDB(ctx)
 	assert.NoError(t, err)
 
 	col, err := newTestCollectionWithSchema(ctx, db)

--- a/db/tests/utils.go
+++ b/db/tests/utils.go
@@ -103,14 +103,14 @@ func init() {
 	}
 }
 
-func NewBadgerMemoryDB() (databaseInfo, error) {
+func NewBadgerMemoryDB(ctx context.Context) (databaseInfo, error) {
 	opts := badgerds.Options{Options: badger.DefaultOptions("").WithInMemory(true)}
 	rootstore, err := badgerds.NewDatastore("", &opts)
 	if err != nil {
 		return databaseInfo{}, err
 	}
 
-	db, err := db.NewDB(rootstore)
+	db, err := db.NewDB(ctx, rootstore)
 	if err != nil {
 		return databaseInfo{}, err
 	}
@@ -122,9 +122,9 @@ func NewBadgerMemoryDB() (databaseInfo, error) {
 	}, nil
 }
 
-func NewMapDB() (databaseInfo, error) {
+func NewMapDB(ctx context.Context) (databaseInfo, error) {
 	rootstore := ds.NewMapDatastore()
-	db, err := db.NewDB(rootstore)
+	db, err := db.NewDB(ctx, rootstore)
 	if err != nil {
 		return databaseInfo{}, err
 	}
@@ -136,7 +136,7 @@ func NewMapDB() (databaseInfo, error) {
 	}, nil
 }
 
-func NewBadgerFileDB(t testing.TB) (databaseInfo, error) {
+func NewBadgerFileDB(ctx context.Context, t testing.TB) (databaseInfo, error) {
 	path := t.TempDir()
 
 	opts := badgerds.Options{Options: badger.DefaultOptions(path)}
@@ -145,7 +145,7 @@ func NewBadgerFileDB(t testing.TB) (databaseInfo, error) {
 		return databaseInfo{}, err
 	}
 
-	db, err := db.NewDB(rootstore)
+	db, err := db.NewDB(ctx, rootstore)
 	if err != nil {
 		return databaseInfo{}, err
 	}
@@ -157,11 +157,11 @@ func NewBadgerFileDB(t testing.TB) (databaseInfo, error) {
 	}, nil
 }
 
-func getDatabases(t *testing.T, test QueryTestCase) ([]databaseInfo, error) {
+func getDatabases(ctx context.Context, t *testing.T, test QueryTestCase) ([]databaseInfo, error) {
 	databases := []databaseInfo{}
 
 	if badgerInMemory {
-		badgerIMDatabase, err := NewBadgerMemoryDB()
+		badgerIMDatabase, err := NewBadgerMemoryDB(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -169,7 +169,7 @@ func getDatabases(t *testing.T, test QueryTestCase) ([]databaseInfo, error) {
 	}
 
 	if badgerFile {
-		badgerIMDatabase, err := NewBadgerFileDB(t)
+		badgerIMDatabase, err := NewBadgerFileDB(ctx, t)
 		if err != nil {
 			return nil, err
 		}
@@ -177,7 +177,7 @@ func getDatabases(t *testing.T, test QueryTestCase) ([]databaseInfo, error) {
 	}
 
 	if !test.DisableMapStore && mapStore {
-		mapDatabase, err := NewMapDB()
+		mapDatabase, err := NewMapDB(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -189,7 +189,7 @@ func getDatabases(t *testing.T, test QueryTestCase) ([]databaseInfo, error) {
 
 func ExecuteQueryTestCase(t *testing.T, schema string, collectionNames []string, test QueryTestCase) {
 	ctx := context.Background()
-	dbs, err := getDatabases(t, test)
+	dbs, err := getDatabases(ctx, t, test)
 	if assertError(t, test.Description, err, test.ExpectedError) {
 		return
 	}


### PR DESCRIPTION
Closes #156 

Makes it much harder to forget to initialize database (lots of functionality can partially work without doing so, leading to failures being detected later than need be - such as not loading existing schemas)