### PR TITLE
fix: Concurrency control of Document using RWMutex

### DIFF
--- a/document/document.go
+++ b/document/document.go
@@ -75,11 +75,6 @@ type Document struct {
 	isDirty bool
 }
 
-// New returns a newly instanciated Document
-func New() *Document {
-	return newEmptyDoc()
-}
-
 func NewWithKey(key key.DocKey) *Document {
 	doc := newEmptyDoc()
 	doc.key = key


### PR DESCRIPTION
Inclusion of a [reader/writer mutual exclusion lock](https://pkg.go.dev/sync#RWMutex) on `Document` and its `set` operation.

Submitting as draft PR as to obtain feedback first, then iterate & submit as normal PR.