### PR TITLE
ci: Add benchmark performance comparisons

### DIFF
--- a/.github/workflows/lint-then-benchmark.yml
+++ b/.github/workflows/lint-then-benchmark.yml
@@ -242,7 +242,7 @@ jobs:
           github.base_ref == 'develop'
         run: >
           make deps:bench &&
-          $GOPATH/bin/benchstat bench-artifact-${{ steps.last_successful_upload_on_develop.outputs.commit_hash }}.txt bench.txt
+          $GOPATH/bin/benchstat -alpha 1.1 bench-artifact-${{ steps.last_successful_upload_on_develop.outputs.commit_hash }}.txt bench.txt
       # --- At this point the comparison result is dumped in the console.
       # ---  @TODO: Dump the result as a comment on the PR:
       #               - If no comment before then create a new one.


### PR DESCRIPTION
## DESCRIPTION
### This PR modifies the CI flow as follows:
- In addition to skipping the benchmarking when the `action/no-benchmark` label is present, now if the PR is going into a branch that is NOT `develop` branch (base reference != `develop`) then the benchmarks will not run.
- In the case that PR is opened and pushes to the PR are happening (synchronize event) or if a new PR is opened (where in both the cases the PR's base branch is `develop`) and the benchmarks are supposed to run, then CI will go fetch the latest artifact from the most recent build on `develop` that passes the `lint-then-benchmark.yml` workflow (ensures artifact was uploaded) and run the benchmark comparisons using benchstat.

## ISSUE
Closes #212 

---

#### Rough Notes On Tools Explored:
- `benchstat`: is really simple and we can use built in github action cache to store the previous bench stats (rather than their way) and just run the comparisons and see the results through the CI run workflow (not fun to look at).

- `github-action-benchmark` and `gobenchdata`: both are very similar but the github action benchmark gives you ability to have the benchmarks publish to lets say the `docs` folder inside the `master` branch. However output of gobench seems much cleaner (one downside is that we can't really or rather should not run this on PR because it will modify a branch).

- `gobencher`: I enabled this github app to generate PR results the tackle the problem of not being able to run `gobenchdata` or `github-action-benchmark` on PRs. This creates a very nice comparison on the PR check itself. One down side is that we can't control this with labels