### PR TITLE
chore: Remove fmt.println from core package

### DIFF
--- a/core/crdt/composite.go
+++ b/core/crdt/composite.go
@@ -133,7 +133,6 @@ func (c CompositeDAG) DeltaDecode(node ipld.Node) (core.Delta, error) {
 		return nil, errors.New("Failed to cast ipld.Node to ProtoNode")
 	}
 	data := pbNode.Data()
-	// fmt.Println(data)
 	h := &codec.CborHandle{}
 	dec := codec.NewDecoderBytes(data, h)
 	err := dec.Decode(delta)

--- a/core/crdt/lwwreg.go
+++ b/core/crdt/lwwreg.go
@@ -180,7 +180,6 @@ func (reg LWWRegister) DeltaDecode(node ipld.Node) (core.Delta, error) {
 		return nil, errors.New("Failed to cast ipld.Node to ProtoNode")
 	}
 	data := pbNode.Data()
-	// fmt.Println(data)
 	h := &codec.CborHandle{}
 	dec := codec.NewDecoderBytes(data, h)
 	err := dec.Decode(delta)

--- a/core/crdt/lwwreg_test.go
+++ b/core/crdt/lwwreg_test.go
@@ -157,8 +157,6 @@ func TestLWWRegisterDeltaMarshal(t *testing.T) {
 		return
 	}
 
-	// fmt.Println(bytes)
-
 	h := &codec.CborHandle{}
 	dec := codec.NewDecoderBytes(bytes, h)
 	unmarshaledDelta := &LWWRegDelta{}
@@ -187,8 +185,7 @@ func makeNode(delta core.Delta, heads []cid.Cid) (ipld.Node, error) {
 			return nil, err
 		}
 	}
-	// data = []byte("test")
-	// fmt.Println("PRE", data)
+
 	nd := dag.NodeWithData(data)
 	// The cid builder defaults to v0, we want to be using v1 CIDs
 	nd.SetCidBuilder(
@@ -204,8 +201,7 @@ func makeNode(delta core.Delta, heads []cid.Cid) (ipld.Node, error) {
 			return nil, err
 		}
 	}
-	// data2 := nd.Data()
-	// fmt.Println("POST", data2)
+
 	return nd, nil
 }
 

--- a/core/key.go
+++ b/core/key.go
@@ -59,7 +59,6 @@ func (k Key) PrefixEnd() Key {
 // An error is returned if it can't correct convert the
 // field to a uint32.
 func (k Key) FieldID() (uint32, error) {
-	// fmt.Println(k.String())
 	fieldIDStr := k.Type()
 	fieldID, err := strconv.Atoi(fieldIDStr)
 	if err != nil {

--- a/document/document.go
+++ b/document/document.go
@@ -141,7 +141,6 @@ func NewFromMap(data map[string]interface{}, schema ...base.SchemaDescription) (
 		if err != nil {
 			return nil, err
 		}
-		// fmt.Println(c)
 		doc.key = key.NewDocKeyV0(c)
 	}
 
@@ -230,8 +229,7 @@ func (doc *Document) SetWithJSON(patch []byte) error {
 	}
 
 	for k, v := range patchObj {
-		fmt.Println(k, v)
-		if v == nil { // needs deletion
+		if v == nil {
 			err = doc.Delete(k)
 		} else {
 			err = doc.Set(k, v)


### PR DESCRIPTION
Would probably like a linter rule to ban fmt.Print[ln] at somepoint

Were only two in document package, so a chucked them in here too