### PR TITLE
Only log errors and above when benchmarking

### DIFF
--- a/bench/bench_util.go
+++ b/bench/bench_util.go
@@ -44,6 +44,8 @@ var (
 )
 
 func init() {
+	logging.SetConfig(logging.Config{Level: logging.NewLogLevelOption(logging.Error)})
+
 	// create a consistent seed value for the random package
 	// so we don't have random fluctuations between runs
 	// (specifically thinking about the fixture generation stuff)


### PR DESCRIPTION
Closes https://github.com/sourcenetwork/defradb/issues/260

Is very easy to disable it entirely if preferred, setting the config.outputPaths to empty instead (with a couple of tweaks in the config code) - let me know 