### PR TITLE
tools: Exclude testing and benchmark files from coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -38,16 +38,6 @@ comment:
   require_changes: true
 
 ignore:
-  - "docs"
-  - ".circleci"
-  - ".github"
-  - "build"
-  - "**/*.graphql"
-  - "**/*.md"
-  - "**/*.txt"
-  - "licenses"
-  - ".gitignore"
-  - ".golangci.sourceinc.yaml"
-  - "Makefile"
-  # - "**/*_test.go"
-  # - "db/tests"
+  - "bench"
+  - "db/tests"
+  - "**/*_test.go"


### PR DESCRIPTION
Ignores testing and benchmark files that don't need to included in the code coverage report.