### PR TITLE
chore: ignore vscode config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ coverage-full.txt
 coverage-quick.txt
 bench/*.log
 bench/*.svg
+.vscode


### PR DESCRIPTION
Just a little detail: vscode keeps creating this folder that wants to be part of commits. git ignoring it. closes #342 