### PR TITLE
tools: Limit lines to 120 characters

### DIFF
--- a/.golangci.sourceinc.yaml
+++ b/.golangci.sourceinc.yaml
@@ -559,7 +559,7 @@ linters-settings:
   lll:
     # max line length, lines longer will be reported.
     # '\t' is counted as 1 character by default, and can be changed with the tab-width option
-    line-length: 100
+    line-length: 120
     # tab width in spaces. Default to 1.
     tab-width: 1
 


### PR DESCRIPTION
Resolves: #344 

Based on the feedback from devs.

Increase line length limit to 120, with tabs treated as a single character.

If your editor treats tabs as 4 spaces and counts, one tab as 4 characters then:

The line character limit really is = 120 + (4 * (tabs in that line))