### PR TITLE
refactor: Remove all deadcode and add tests

### DIFF
--- a/cli/defradb/cmd/config.go
+++ b/cli/defradb/cmd/config.go
@@ -24,7 +24,6 @@ type Config struct {
 type Options struct {
 	Address string
 	Store   string
-	Memory  MemoryOptions
 	Badger  BadgerOptions
 }
 
@@ -32,11 +31,6 @@ type Options struct {
 type BadgerOptions struct {
 	Path string
 	*badgerds.Options
-}
-
-// MemoryOptions for the memory instance of the backing datastore
-type MemoryOptions struct {
-	Size uint64
 }
 
 type NetOptions struct {
@@ -54,11 +48,8 @@ type BaseLoggerOptions struct {
 }
 
 type NamedLoggerOptions struct {
-	Name             string
-	Level            *string
-	EnableStackTrace *bool
-	EncoderFormat    *string
-	OutputPaths      *[]string
+	Name  string
+	Level *string
 }
 
 func (o BaseLoggerOptions) toLogConfig() logging.Config {

--- a/client/collection.go
+++ b/client/collection.go
@@ -25,32 +25,32 @@ import (
 type Collection interface {
 	// Description returns the CollectionDescription of this Collection.
 	Description() CollectionDescription
+
 	// Name returns the name of this collection.
 	Name() string
+
 	// Schema returns the SchemaDescription used to define this Collection.
 	Schema() SchemaDescription
+
 	// ID returns the ID of this Collection.
 	ID() uint32
+
 	// SchemaID returns the ID of the Schema used to define this Collection.
 	SchemaID() string
 
 	// Indexes returns all the indexes defined on this Collection.
 	Indexes() []IndexDescription
-	// PrimaryIndex returns the primary index for the this Collection.
-	PrimaryIndex() IndexDescription
-	// Index returns the index with the given index ID.
-	//
-	// If no index is found with the given ID an ErrIndexNotFound error will be returned.
-	Index(uint32) (IndexDescription, error)
 
 	// Create a new document.
 	//
 	// Will verify the DocKey/CID to ensure that the new document is correctly formatted.
 	Create(context.Context, *Document) error
+
 	// CreateMany new documents.
 	//
 	// Will verify the DocKeys/CIDs to ensure that the new documents are correctly formatted.
 	CreateMany(context.Context, []*Document) error
+
 	// Update an existing document with the new values.
 	//
 	// Any field that needs to be removed or cleared should call doc.Clear(field) before.
@@ -58,37 +58,27 @@ type Collection interface {
 	//
 	// Will return a ErrDocumentNotFound error if the given document is not found.
 	Update(context.Context, *Document) error
+
 	// Save the given document in the database.
 	//
 	// If a document exists with the given DocKey it will update it. Otherwise a new document
 	// will be created.
 	Save(context.Context, *Document) error
+
 	// Delete will attempt to delete a document by key.
 	//
 	// Will return true if a deletion is successful, and return false along with an error
 	// if it cannot. If the document doesn't exist, then it will return false and a ErrDocumentNotFound error.
-	// This operation will hard-delete all state relating to the given DocKey. This includes data, block, and head storage.
+	// This operation will hard-delete all state relating to the given DocKey.
+	// This includes data, block, and head storage.
 	Delete(context.Context, DocKey) (bool, error)
-	// Exists checks if a given document exists with supplied DocKey.
-	//
-	// Will return true if a matching document exists, otherwise will return false.
-	Exists(context.Context, DocKey) (bool, error)
 
-	// UpdateWith updates a target document using the given updater type.
-	//
-	// Target can be a Filter statement, a single docKey, a single document,
-	// an array of docKeys, or an array of documents.
-	// It is recommened to use the respective typed versions of Update
-	// (e.g. UpdateWithFilter or UpdateWithKey) over this function if you can.
-	//
-	// Returns an ErrInvalidUpdateTarget error if the target type is not supported.
-	// Returns an ErrInvalidUpdater error if the updater type is not supported.
-	UpdateWith(ctx context.Context, target interface{}, updater interface{}) (*UpdateResult, error)
 	// UpdateWithFilter updates using a filter to target documents for update.
 	//
 	// The provided updater must be a string Patch, string Merge Patch, a parsed Patch, or parsed Merge Patch
 	// else an ErrInvalidUpdater will be returned.
 	UpdateWithFilter(ctx context.Context, filter interface{}, updater interface{}) (*UpdateResult, error)
+
 	// UpdateWithKey updates using a DocKey to target a single document for update.
 	//
 	// The provided updater must be a string Patch, string Merge Patch, a parsed Patch, or parsed Merge Patch
@@ -96,6 +86,7 @@ type Collection interface {
 	//
 	// Returns an ErrDocumentNotFound if a document matching the given DocKey is not found.
 	UpdateWithKey(ctx context.Context, key DocKey, updater interface{}) (*UpdateResult, error)
+
 	// UpdateWithKeys updates documents matching the given DocKeys.
 	//
 	// The provided updater must be a string Patch, string Merge Patch, a parsed Patch, or parsed Merge Patch
@@ -104,28 +95,24 @@ type Collection interface {
 	// Returns an ErrDocumentNotFound if a document is not found for any given DocKey.
 	UpdateWithKeys(context.Context, []DocKey, interface{}) (*UpdateResult, error)
 
-	// DeleteWith deletes a target document.
-	//
-	// Target can be a Filter statement, a single docKey, a single document, an array of docKeys,
-	// or an array of documents. It is recommened to use the respective typed versions of Delete
-	// (e.g. DeleteWithFilter or DeleteWithKey) over this function if you can.
-	// This operation will hard-delete all state relating to the given DocKey. This includes data, block, and head storage.
-	//
-	// Returns an ErrInvalidDeleteTarget if the target type is not supported.
-	DeleteWith(ctx context.Context, target interface{}) (*DeleteResult, error)
 	// DeleteWithFilter deletes documents matching the given filter.
 	//
-	// This operation will hard-delete all state relating to the given DocKey. This includes data, block, and head storage.
+	// This operation will hard-delete all state relating to the given DocKey.
+	// This includes data, block, and head storage.
 	DeleteWithFilter(ctx context.Context, filter interface{}) (*DeleteResult, error)
+
 	// DeleteWithKey deletes using a DocKey to target a single document for delete.
 	//
-	// This operation will hard-delete all state relating to the given DocKey. This includes data, block, and head storage.
+	// This operation will hard-delete all state relating to the given DocKey.
+	// This includes data, block, and head storage.
 	//
 	// Returns an ErrDocumentNotFound if a document matching the given DocKey is not found.
 	DeleteWithKey(context.Context, DocKey) (*DeleteResult, error)
+
 	// DeleteWithKeys deletes documents matching the given DocKeys.
 	//
-	// This operation will hard-delete all state relating to the given DocKey. This includes data, block, and head storage.
+	// This operation will hard-delete all state relating to the given DocKey.
+	// This includes data, block, and head storage.
 	//
 	// Returns an ErrDocumentNotFound if a document is not found for any given DocKey.
 	DeleteWithKeys(context.Context, []DocKey) (*DeleteResult, error)

--- a/client/descriptions.go
+++ b/client/descriptions.go
@@ -40,56 +40,20 @@ func (col CollectionDescription) GetField(name string) (FieldDescription, bool) 
 	return FieldDescription{}, false
 }
 
-func (c CollectionDescription) GetPrimaryIndex() IndexDescription {
-	return c.Indexes[0]
-}
-
 // IndexDescription describes an Index on a Collection
 // and its associated metadata.
 type IndexDescription struct {
-	Name     string
-	ID       uint32
-	Primary  bool
-	Unique   bool
-	FieldIDs []uint32
-
-	// Junction is a special field, it indicates if this Index is
-	// being used as a junction table for a Many-to-Many relation.
-	// A Junction index needs to index the DocKey from two different
-	// collections, so the usual method of storing the indexed fields
-	// in the FieldIDs property won't work, since thats scoped to the
-	// local schema.
-	//
-	// The Junction stores the DocKey of the type its assigned to,
-	// and the DocKey of the target relation type. Moreover, since
-	// we use a Composite Key Index system, the ordering of the keys
-	// affects how we can use in the index. The initial Junction
-	// Index for a type, needs to be assigned to the  "Primary"
-	// type in the Many-to-Many relation. This is usually the type
-	// that expects more reads from.
-	//
-	// Eg:
-	// A Book type can have many Categories,
-	// and Categories can belong to many Books.
-	//
-	// If we query more for Books, then Categories directly, then
-	// we can set the Book type as the Primary type.
-	Junction bool
-	// RelationType is only used in the Index is a Junction Index.
-	// It specifies what the other type is in the Many-to-Many
-	// relationship.
-	RelationType string
-}
-
-func (index IndexDescription) IDString() string {
-	return fmt.Sprint(index.ID)
+	Name    string
+	ID      uint32
+	Primary bool
+	Unique  bool
 }
 
 type SchemaDescription struct {
 	ID   uint32
 	Name string
-	Key  []byte // DocKey for versioned source schema
-	// Schema schema.Schema
+	// DocKey for versioned source schema
+	Key      []byte // is said to be unused  (but is serialized so not removing right now)
 	FieldIDs []uint32
 	Fields   []FieldDescription
 }
@@ -122,10 +86,10 @@ const (
 	FieldKind_FLOAT_ARRAY  FieldKind = 7
 	FieldKind_DECIMAL      FieldKind = 8
 	FieldKind_DATE         FieldKind = 9
-	FieldKind_TIMESTAMP    FieldKind = 10
+	FieldKind_TIMESTAMP    FieldKind = 10 // unused but marking for now to discuss in PR for completeness
 	FieldKind_STRING       FieldKind = 11
 	FieldKind_STRING_ARRAY FieldKind = 12
-	FieldKind_BYTES        FieldKind = 13
+	FieldKind_BYTES        FieldKind = 13 // unused but marking for now to discuss in PR for completeness
 
 	// Embedded object within the type
 	FieldKind_OBJECT FieldKind = 14

--- a/client/dockey.go
+++ b/client/dockey.go
@@ -93,22 +93,10 @@ func NewDocKeyFromString(key string) (DocKey, error) {
 	}, nil
 }
 
-// UUID returns the doc key in UUID form
-func (key DocKey) UUID() uuid.UUID {
-	return key.uuid
-}
-
 // UUID returns the doc key in string form
 func (key DocKey) String() string {
 	buf := make([]byte, 1)
 	binary.PutUvarint(buf, uint64(key.version))
 	versionStr, _ := mbase.Encode(mbase.Base32, buf)
 	return versionStr + "-" + key.uuid.String()
-}
-
-// Bytes returns the DocKey in Byte format
-func (key DocKey) Bytes() []byte {
-	buf := make([]byte, binary.MaxVarintLen16)
-	binary.PutUvarint(buf, uint64(key.version))
-	return append(buf, key.uuid.Bytes()...)
 }

--- a/client/document.go
+++ b/client/document.go
@@ -136,12 +136,6 @@ func NewDocFromJSON(obj []byte) (*Document, error) {
 	return NewDocFromMap(data)
 }
 
-func (doc *Document) Head() cid.Cid {
-	doc.mu.RLock()
-	defer doc.mu.RUnlock()
-	return doc.head
-}
-
 func (doc *Document) SetHead(head cid.Cid) {
 	doc.mu.Lock()
 	defer doc.mu.Unlock()
@@ -365,13 +359,6 @@ func (doc *Document) Fields() map[string]Field {
 	return doc.fields
 }
 
-// Values gets the document values as a map
-func (doc *Document) Values() map[Field]Value {
-	doc.mu.RLock()
-	defer doc.mu.RUnlock()
-	return doc.values
-}
-
 // Bytes returns the document as a serialzed byte array
 // using CBOR encoding
 func (doc *Document) Bytes() ([]byte, error) {
@@ -387,24 +374,6 @@ func (doc *Document) Bytes() ([]byte, error) {
 		return nil, err
 	}
 	return em.Marshal(docMap)
-}
-
-// String returns the document as a stringified JSON Object.
-// Note: This representation should not be used for any
-// cryptographic operations, such as signatures, or hashes
-// as it does not guarantee canonical representation or
-// ordering.
-func (doc *Document) String() string {
-	docMap, err := doc.toMap()
-	if err != nil {
-		panic(err) //should we return (string, error)?
-	}
-
-	j, err := json.MarshalIndent(docMap, "", "\t")
-	if err != nil {
-		panic(err) // same as above
-	}
-	return string(j)
 }
 
 // ToMap returns the document as a map[string]interface{}

--- a/client/errors.go
+++ b/client/errors.go
@@ -17,12 +17,9 @@ import "errors"
 // This list is incomplete and undefined errors may also be returned.
 // Errors returned from this package may be tested against these errors with errors.Is.
 var (
-	ErrFieldNotExist       = errors.New("The given field does not exist")
-	ErrFieldNotObject      = errors.New("Trying to access field on a non object type")
-	ErrValueTypeMismatch   = errors.New("Value does not match indicated type")
-	ErrIndexNotFound       = errors.New("No index found for given ID")
-	ErrDocumentNotFound    = errors.New("No document for the given key exists")
-	ErrInvalidUpdateTarget = errors.New("The target document to update is of invalid type")
-	ErrInvalidUpdater      = errors.New("The updater of a document is of invalid type")
-	ErrInvalidDeleteTarget = errors.New("The target document to delete is of invalid type")
+	ErrFieldNotExist     = errors.New("The given field does not exist")
+	ErrFieldNotObject    = errors.New("Trying to access field on a non object type")
+	ErrValueTypeMismatch = errors.New("Value does not match indicated type")
+	ErrDocumentNotFound  = errors.New("No document for the given key exists")
+	ErrInvalidUpdater    = errors.New("The updater of a document is of invalid type")
 )

--- a/client/field.go
+++ b/client/field.go
@@ -14,7 +14,6 @@ package client
 type Field interface {
 	Name() string
 	Type() CType //TODO Abstract into a Field Type interface
-	SchemaType() string
 }
 
 type simpleField struct {
@@ -40,8 +39,4 @@ func (field simpleField) Name() string {
 
 func (field simpleField) Type() CType {
 	return field.crdtType
-}
-
-func (field simpleField) SchemaType() string {
-	return field.schemaType
 }

--- a/client/value.go
+++ b/client/value.go
@@ -37,12 +37,6 @@ type WriteableValue interface {
 	Bytes() ([]byte, error)
 }
 
-type ReadableValue interface {
-	Value
-
-	Read() (interface{}, error)
-}
-
 type simpleValue struct {
 	t       CType
 	value   interface{}

--- a/core/crdt/lwwreg.go
+++ b/core/crdt/lwwreg.go
@@ -85,10 +85,6 @@ type LWWRegister struct {
 func NewLWWRegister(store datastore.DSReaderWriter, key core.DataStoreKey) LWWRegister {
 	return LWWRegister{
 		baseCRDT: newBaseCRDT(store, key),
-		// id:    id,
-		// data:  data,
-		// ts:    ts,
-		// clock: clock,
 	}
 }
 

--- a/core/data.go
+++ b/core/data.go
@@ -14,14 +14,13 @@ import "strings"
 
 // Span is a range of keys from [Start, End)
 type Span interface {
+
 	// Start returns the starting key of the Span
 	Start() DataStoreKey
+
 	// End returns the ending key of the Span
 	End() DataStoreKey
-	// Contains returns true of the Span contains the provided Span's range
-	Contains(Span) bool
-	// Equal returns true if the provided Span is equal to the current
-	Equal(Span) bool
+
 	// Compare returns -1 if the provided span is less, 0 if it is equal, and 1 if its greater
 	Compare(Span) SpanComparisonResult
 }
@@ -47,16 +46,6 @@ func (s span) Start() DataStoreKey {
 // End returns the ending key of the Span
 func (s span) End() DataStoreKey {
 	return s.end
-}
-
-// Contains returns true of the Span contains the provided Span's range
-func (s span) Contains(s2 Span) bool {
-	panic("not implemented") // TODO: Implement
-}
-
-// Equal returns true if the provided Span is equal to the current
-func (s span) Equal(s2 Span) bool {
-	panic("not implemented") // TODO: Implement
 }
 
 type SpanComparisonResult uint

--- a/core/key.go
+++ b/core/key.go
@@ -20,13 +20,6 @@ import (
 	"github.com/sourcenetwork/defradb/client"
 )
 
-var (
-	// KeyMin is a minimum key value which sorts before all other keys.
-	KeyMin = []byte{}
-	// KeyMax is a maximum key value which sorts after all other keys.
-	KeyMax = []byte{0xff, 0xff}
-)
-
 type InstanceType string
 
 const (
@@ -62,39 +55,27 @@ type PrimaryDataStoreKey struct {
 	DocKey       string
 }
 
-var _ Key = (*PrimaryDataStoreKey)(nil)
-
 type HeadStoreKey struct {
 	DocKey  string
 	FieldId string //can be 'C'
 	Cid     cid.Cid
 }
 
-var _ Key = (*HeadStoreKey)(nil)
-
 type CollectionKey struct {
 	CollectionName string
 }
-
-var _ Key = (*CollectionKey)(nil)
 
 type CollectionSchemaKey struct {
 	SchemaId string
 }
 
-var _ Key = (*CollectionSchemaKey)(nil)
-
 type SchemaKey struct {
 	SchemaName string
 }
 
-var _ Key = (*SchemaKey)(nil)
-
 type SequenceKey struct {
 	SequenceName string
 }
-
-var _ Key = (*SequenceKey)(nil)
 
 // Creates a new DataStoreKey from a string as best as it can,
 // splitting the input using '/' as a field deliminater.  It assumes
@@ -256,22 +237,11 @@ func (k DataStoreKey) ToDS() ds.Key {
 	return ds.NewKey(k.ToString())
 }
 
-func (k DataStoreKey) Equal(other DataStoreKey) bool {
-	return k.CollectionId == other.CollectionId &&
-		k.DocKey == other.DocKey &&
-		k.FieldId == other.FieldId &&
-		k.InstanceType == other.InstanceType
-}
-
 func (k PrimaryDataStoreKey) ToDataStoreKey() DataStoreKey {
 	return DataStoreKey{
 		CollectionId: k.CollectionId,
 		DocKey:       k.DocKey,
 	}
-}
-
-func (k PrimaryDataStoreKey) Bytes() []byte {
-	return []byte(k.ToString())
 }
 
 func (k PrimaryDataStoreKey) ToDS() ds.Key {
@@ -302,10 +272,6 @@ func (k CollectionKey) ToString() string {
 	return result
 }
 
-func (k CollectionKey) Bytes() []byte {
-	return []byte(k.ToString())
-}
-
 func (k CollectionKey) ToDS() ds.Key {
 	return ds.NewKey(k.ToString())
 }
@@ -318,10 +284,6 @@ func (k CollectionSchemaKey) ToString() string {
 	}
 
 	return result
-}
-
-func (k CollectionSchemaKey) Bytes() []byte {
-	return []byte(k.ToString())
 }
 
 func (k CollectionSchemaKey) ToDS() ds.Key {
@@ -338,10 +300,6 @@ func (k SchemaKey) ToString() string {
 	return result
 }
 
-func (k SchemaKey) Bytes() []byte {
-	return []byte(k.ToString())
-}
-
 func (k SchemaKey) ToDS() ds.Key {
 	return ds.NewKey(k.ToString())
 }
@@ -354,10 +312,6 @@ func (k SequenceKey) ToString() string {
 	}
 
 	return result
-}
-
-func (k SequenceKey) Bytes() []byte {
-	return []byte(k.ToString())
 }
 
 func (k SequenceKey) ToDS() ds.Key {
@@ -378,10 +332,6 @@ func (k HeadStoreKey) ToString() string {
 	}
 
 	return result
-}
-
-func (k HeadStoreKey) Bytes() []byte {
-	return []byte(k.ToString())
 }
 
 func (k HeadStoreKey) ToDS() ds.Key {

--- a/core/net/broadcaster.go
+++ b/core/net/broadcaster.go
@@ -10,14 +10,9 @@
 
 package net
 
-import "time"
-
 // A Broadcaster provides a way to send (notify) an opaque payload to
 // all replicas and to retrieve payloads broadcasted.
 type Broadcaster interface {
 	// Send broadcasts a message without blocking
 	Send(v interface{}) error
-
-	// SendWithTimeout broadcasts a message, blocks up to timeout duration
-	SendWithTimeout(v interface{}, d time.Duration) error
 }

--- a/core/node.go
+++ b/core/node.go
@@ -11,25 +11,11 @@
 package core
 
 import (
-	"context"
-
-	cid "github.com/ipfs/go-cid"
 	ipld "github.com/ipfs/go-ipld-format"
 )
-
-// NodeDeltaPair is a Node with its underlying delta
-// already extracted. Used in a channel response for streaming
-type NodeDeltaPair interface {
-	GetNode() ipld.Node
-	GetDelta() Delta
-	Error() error
-}
 
 // A NodeGetter extended from ipld.NodeGetter with delta related
 // functions
 type NodeGetter interface {
 	ipld.NodeGetter
-	GetDelta(context.Context, cid.Cid) (ipld.Node, Delta, error)
-	GetDeltas(context.Context, []cid.Cid) <-chan NodeDeltaPair
-	GetPriority(context.Context, cid.Cid) (uint64, error)
 }

--- a/core/replicated.go
+++ b/core/replicated.go
@@ -14,7 +14,6 @@ import (
 	"context"
 	"errors"
 
-	cid "github.com/ipfs/go-cid"
 	ipld "github.com/ipfs/go-ipld-format"
 )
 
@@ -32,14 +31,3 @@ type ReplicatedData interface {
 	DeltaDecode(node ipld.Node) (Delta, error) // possibly rename to just Decode
 	Value(ctx context.Context) ([]byte, error)
 }
-
-// PersistedReplicatedData persists a ReplicatedData to an underlying datastore
-type PersistedReplicatedData interface {
-	ReplicatedData
-	Publish(Delta) (cid.Cid, error)
-}
-
-// type EmbedableReplicatedData interface {
-// 	ReplicatedData
-// 	Apply(Operation) error
-// }

--- a/datastore/blockstore.go
+++ b/datastore/blockstore.go
@@ -44,11 +44,6 @@ import (
 // is different than expected.
 var ErrHashMismatch = errors.New("block in storage has different hash than requested")
 
-// defradb/store.ErrNotFound => error
-// ipfs-blockstore.ErrNotFound => error
-// ErrNotFound is an error returned when a block is not found.
-var ErrNotFound = errors.New("blockstore: block not found")
-
 // NewBlockstore returns a default Blockstore implementation
 // using the provided datastore.Batching backend.
 func NewBlockstore(store DSReaderWriter) blockstore.Blockstore {

--- a/datastore/txn.go
+++ b/datastore/txn.go
@@ -35,7 +35,6 @@ type Txn interface {
 	Discard(ctx context.Context)
 
 	OnSuccess(fn func())
-	OnError(fn func())
 }
 
 type txn struct {
@@ -117,13 +116,6 @@ func (txn *txn) OnSuccess(fn func()) {
 		return
 	}
 	txn.successFns = append(txn.successFns, fn)
-}
-
-func (txn *txn) OnError(fn func()) {
-	if fn == nil {
-		return
-	}
-	txn.errorFns = append(txn.errorFns, fn)
 }
 
 func (txn *txn) runErrorFns(ctx context.Context) {

--- a/db/base/encoding.go
+++ b/db/base/encoding.go
@@ -10,9 +10,4 @@
 
 package base
 
-type DataEncoding uint32
-
-const (
-	// Indicates that the data is encoded using the CBOR encoding for values.
-	DataEncoding_VALUE_CBOR DataEncoding = 0
-)
+// whole file can be deleted?

--- a/db/collection.go
+++ b/db/collection.go
@@ -377,22 +377,6 @@ func (c *collection) Indexes() []client.IndexDescription {
 	return c.desc.Indexes
 }
 
-// PrimaryIndex returns the primary index for the given collection
-func (c *collection) PrimaryIndex() client.IndexDescription {
-	return c.desc.Indexes[0]
-}
-
-// Index returns the index with the given index ID
-func (c *collection) Index(id uint32) (client.IndexDescription, error) {
-	for _, index := range c.desc.Indexes {
-		if index.ID == id {
-			return index, nil
-		}
-	}
-
-	return client.IndexDescription{}, client.ErrIndexNotFound
-}
-
 func (c *collection) SchemaID() string {
 	return c.schemaID
 }
@@ -688,22 +672,6 @@ func (c *collection) delete(
 	}
 
 	return true, nil
-}
-
-// Exists checks if a given document exists with supplied DocKey
-func (c *collection) Exists(ctx context.Context, key client.DocKey) (bool, error) {
-	txn, err := c.getTxn(ctx, false)
-	if err != nil {
-		return false, err
-	}
-	defer c.discardImplicitTxn(ctx, txn)
-
-	dsKey := c.getPrimaryKeyFromDocKey(key)
-	exists, err := c.exists(ctx, txn, dsKey)
-	if err != nil && err != ds.ErrNotFound {
-		return false, err
-	}
-	return exists, c.commitImplicitTxn(ctx, txn)
 }
 
 // check if a document exists with the given key

--- a/db/collection_delete.go
+++ b/db/collection_delete.go
@@ -12,7 +12,6 @@ package db
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	block "github.com/ipfs/go-block-format"
@@ -28,31 +27,6 @@ import (
 	"github.com/sourcenetwork/defradb/merkle/clock"
 	"github.com/sourcenetwork/defradb/query/graphql/parser"
 )
-
-var (
-	ErrDeleteTargetEmpty = errors.New("The doc delete targeter cannot be empty")
-	ErrDeleteEmpty       = errors.New("The doc delete cannot be empty")
-)
-
-// DeleteWith deletes a target document. Target can be a Filter statement,
-//  a single docKey, a single document, an array of docKeys, or an array of documents.
-// If you want more type safety, use the respective typed versions of Delete.
-// Eg: DeleteWithFilter or DeleteWithKey
-func (c *collection) DeleteWith(
-	ctx context.Context,
-	target interface{},
-) (*client.DeleteResult, error) {
-	switch t := target.(type) {
-	case string, map[string]interface{}, *parser.Filter:
-		return c.DeleteWithFilter(ctx, t)
-	case client.DocKey:
-		return c.DeleteWithKey(ctx, t)
-	case []client.DocKey:
-		return c.DeleteWithKeys(ctx, t)
-	default:
-		return nil, client.ErrInvalidDeleteTarget
-	}
-}
 
 // DeleteWithKey deletes using a DocKey to target a single document for delete.
 func (c *collection) DeleteWithKey(

--- a/db/collection_update.go
+++ b/db/collection_update.go
@@ -28,34 +28,11 @@ import (
 )
 
 var (
-	ErrUpdateTargetEmpty     = errors.New("The doc update targeter cannot be empty")
 	ErrUpdateEmpty           = errors.New("The doc update cannot be empty")
 	ErrInvalidMergeValueType = errors.New(
 		"The type of value in the merge patch doesn't match the schema",
 	)
 )
-
-// UpdateWith updates a target document using the given updater type. Target
-// can be a Filter statement, a single docKey, a single document,
-// an array of docKeys, or an array of documents.
-// If you want more type safety, use the respective typed versions of Update.
-// Eg: UpdateWithFilter or UpdateWithKey
-func (c *collection) UpdateWith(
-	ctx context.Context,
-	target interface{},
-	updater interface{},
-) (*client.UpdateResult, error) {
-	switch t := target.(type) {
-	case string, map[string]interface{}, *parser.Filter:
-		return c.UpdateWithFilter(ctx, t, updater)
-	case client.DocKey:
-		return c.UpdateWithKey(ctx, t, updater)
-	case []client.DocKey:
-		return c.UpdateWithKeys(ctx, t, updater)
-	default:
-		return nil, client.ErrInvalidUpdateTarget
-	}
-}
 
 // UpdateWithFilter updates using a filter to target documents for update.
 // An updater value is provided, which could be a string Patch, string Merge Patch

--- a/db/db.go
+++ b/db/db.go
@@ -36,8 +36,6 @@ var (
 	// ErrDocVerification occurs when a documents contents fail the verification during a Create()
 	// call against the supplied Document Key
 	ErrDocVerification = errors.New("The document verification failed")
-
-	ErrOptionsEmpty = errors.New("Empty options configuration provided")
 )
 
 // make sure we match our client interface
@@ -177,10 +175,6 @@ func (db *db) initialize(ctx context.Context) error {
 
 func (db *db) PrintDump(ctx context.Context) {
 	printStore(ctx, db.multistore.Rootstore())
-}
-
-func (db *db) Executor() *planner.QueryExecutor {
-	return db.queryExecutor
 }
 
 func (db *db) GetRelationshipIdField(fieldName, targetType, thisType string) (string, error) {

--- a/db/fetcher/dag.go
+++ b/db/fetcher/dag.go
@@ -23,10 +23,7 @@ import (
 	dsq "github.com/ipfs/go-datastore/query"
 )
 
-// @todo: Generalize all Fetchers into an shared Fetcher utility
-
-type BlockFetcher struct {
-}
+// @todo: Generalize all Fetchers into an shared Fetcher utility: `type BlockFetcher struct {}`
 
 // HeadFetcher is a utility to incrementally fetch all the MerkleCRDT
 // heads of a given doc/field

--- a/db/fetcher/encoded_doc.go
+++ b/db/fetcher/encoded_doc.go
@@ -17,8 +17,6 @@ import (
 	"github.com/sourcenetwork/defradb/client"
 )
 
-type EPTuple []encProperty
-
 // EncProperty is an encoded property of a EncodedDocument
 type encProperty struct {
 	Desc client.FieldDescription

--- a/db/fetcher/fetcher.go
+++ b/db/fetcher/fetcher.go
@@ -182,26 +182,6 @@ func (df *DocumentFetcher) startNextSpan(ctx context.Context) (bool, error) {
 	return err == nil, err
 }
 
-func (df *DocumentFetcher) KVEnd() bool {
-	return df.kvEnd
-}
-
-func (df *DocumentFetcher) KV() *core.KeyValue {
-	return df.kv
-}
-
-func (df *DocumentFetcher) NextKey(ctx context.Context) (docDone bool, err error) {
-	return df.nextKey(ctx)
-}
-
-func (df *DocumentFetcher) NextKV() (iterDone bool, kv *core.KeyValue, err error) {
-	return df.nextKV()
-}
-
-func (df *DocumentFetcher) ProcessKV(kv *core.KeyValue) error {
-	return df.processKV(kv)
-}
-
 // nextKey gets the next kv. It sets both kv and kvEnd internally.
 // It returns true if the current doc is completed
 func (df *DocumentFetcher) nextKey(ctx context.Context) (docDone bool, err error) {

--- a/db/fetcher/versioned.go
+++ b/db/fetcher/versioned.go
@@ -171,10 +171,6 @@ func (vf *VersionedFetcher) Start(ctx context.Context, txn datastore.Txn, spans 
 	return vf.DocumentFetcher.Start(ctx, vf.store, nil)
 }
 
-func (vf *VersionedFetcher) Rootstore() ds.Datastore {
-	return vf.root
-}
-
 // Start a fetcher with the needed info (cid embedded in a span)
 
 /*

--- a/node/options.go
+++ b/node/options.go
@@ -59,26 +59,6 @@ func ListenP2PAddrStrings(addrs ...string) NodeOpt {
 	}
 }
 
-// ListenP2PAddrStrings sets the address to listen on given as strings
-func ListenTCPAddrStrings(addr string) NodeOpt {
-	return func(opt *Options) error {
-		a, err := ma.NewMultiaddr(addr)
-		if err != nil {
-			return err
-		}
-		opt.ListenAddrs = append(opt.ListenAddrs, a)
-		return nil
-	}
-}
-
-// ListenAddrs sets the address to listen on given as MultiAddr(s)
-func ListenAddrs(addrs ...ma.Multiaddr) NodeOpt {
-	return func(opt *Options) error {
-		opt.ListenAddrs = addrs
-		return nil
-	}
-}
-
 // DefaultOpts returns a set of sane defaults for a Node
 func DefaultOpts() NodeOpt {
 	return func(opt *Options) error {

--- a/query/graphql/parser/commit.go
+++ b/query/graphql/parser/commit.go
@@ -19,8 +19,7 @@ import (
 type CommitType int
 
 const (
-	NoneCommitType = CommitType(iota)
-	LatestCommits
+	LatestCommits = CommitType(iota)
 	AllCommits
 	OneCommit
 )
@@ -54,10 +53,6 @@ type CommitSelect struct {
 
 func (c CommitSelect) GetRoot() SelectionType {
 	return CommitSelection
-}
-
-func (c CommitSelect) GetStatement() ast.Node {
-	return c.Statement
 }
 
 func (c CommitSelect) GetName() string {

--- a/query/graphql/parser/mutation.go
+++ b/query/graphql/parser/mutation.go
@@ -11,7 +11,6 @@
 package parser
 
 import (
-	"encoding/json"
 	"errors"
 	"strings"
 
@@ -21,8 +20,7 @@ import (
 type MutationType int
 
 const (
-	NoneMutationType = MutationType(iota)
-	CreateObjects
+	CreateObjects = MutationType(iota)
 	UpdateObjects
 	DeleteObjects
 )
@@ -38,44 +36,6 @@ var (
 var (
 	ErrEmptyDataPayload = errors.New("given data payload is empty")
 )
-
-type ObjectPayload struct {
-	Object map[string]interface{}
-	Array  []interface{}
-}
-
-// NewObjectPayload parses a given payload string as JSON
-// and returns a ObjectPayload struct decoded with either
-// a JSON object, or JSON array.
-func NewObjectPayload(payload string) (ObjectPayload, error) {
-	obj := ObjectPayload{}
-	if payload == "" {
-		return obj, errors.New("Object payload value cannot be empty")
-	}
-	var d interface{}
-	err := json.Unmarshal([]byte(payload), &d)
-	if err != nil {
-		return obj, err
-	}
-
-	switch v := d.(type) {
-
-	// array usually means its a JSON PATCH object, unless its a create, then its
-	//  just multiple documents
-	case []interface{}:
-		obj.Array = v
-
-	case map[string]interface{}:
-		obj.Object = v
-
-	default:
-		return obj, errors.New(
-			"Object payload value has unknown structure, must be a JSON object or array",
-		)
-	}
-
-	return obj, nil
-}
 
 // Mutation is a field on the MutationType
 // of a graphql query. It includes all the possible
@@ -103,10 +63,6 @@ type Mutation struct {
 
 func (m Mutation) GetRoot() SelectionType {
 	return ObjectSelection
-}
-
-func (m Mutation) GetStatement() ast.Node {
-	return m.Statement
 }
 
 func (m Mutation) GetSelections() []Selection {

--- a/query/graphql/parser/parser.go
+++ b/query/graphql/parser/parser.go
@@ -10,10 +10,4 @@
 
 package parser
 
-import (
-	"github.com/graphql-go/graphql/language/ast"
-)
-
-type Statement interface {
-	GetStatement() ast.Node
-}
+type Statement interface{}

--- a/query/graphql/parser/query.go
+++ b/query/graphql/parser/query.go
@@ -21,8 +21,7 @@ import (
 type SelectionType int
 
 const (
-	NoneSelection = iota
-	ObjectSelection
+	ObjectSelection = iota
 	CommitSelection
 
 	VersionFieldName = "_version"
@@ -67,19 +66,11 @@ type Query struct {
 	Statement *ast.Document
 }
 
-func (q Query) GetStatement() ast.Node {
-	return q.Statement
-}
-
 type OperationDefinition struct {
 	Name       string
 	Selections []Selection
 
 	Statement *ast.OperationDefinition
-}
-
-func (q OperationDefinition) GetStatement() ast.Node {
-	return q.Statement
 }
 
 // type SelectionSet struct {
@@ -91,7 +82,6 @@ type Selection interface {
 	GetName() string
 	GetAlias() string
 	GetSelections() []Selection
-	GetRoot() SelectionType
 }
 
 // Select is a complex Field with strong typing
@@ -124,14 +114,6 @@ type Select struct {
 	Statement *ast.Field
 }
 
-func (s Select) GetRoot() SelectionType {
-	return s.Root
-}
-
-func (s Select) GetStatement() ast.Node {
-	return s.Statement
-}
-
 func (s Select) GetSelections() []Selection {
 	return s.Fields
 }
@@ -155,10 +137,6 @@ type Field struct {
 	Statement *ast.Field
 }
 
-func (c Field) GetRoot() SelectionType {
-	return c.Root
-}
-
 // GetSelectionSet implements Selection
 func (f Field) GetSelections() []Selection {
 	return []Selection{}
@@ -170,10 +148,6 @@ func (f Field) GetName() string {
 
 func (f Field) GetAlias() string {
 	return f.Alias
-}
-
-func (f Field) GetStatement() ast.Node {
-	return f.Statement
 }
 
 type GroupBy struct {

--- a/query/graphql/planner/multi.go
+++ b/query/graphql/planner/multi.go
@@ -33,7 +33,6 @@ type MultiNode interface {
 	planNode
 	Children() []planNode
 	AddChild(string, planNode) error
-	ReplaceChildAt(int, string, planNode) error
 }
 
 // mergeNode is a special interface for the MultiNode
@@ -285,16 +284,6 @@ func (p *parallelNode) Children() []planNode {
 func (p *parallelNode) AddChild(field string, node planNode) error {
 	p.children = append(p.children, node)
 	p.childFields = append(p.childFields, field)
-	return nil
-}
-
-func (p *parallelNode) ReplaceChildAt(i int, field string, node planNode) error {
-	if i >= len(p.children) {
-		return errors.New("Index to replace child node at doesn't exist (out of bounds)")
-	}
-
-	p.children[i] = node
-	p.childFields[i] = field
 	return nil
 }
 

--- a/query/graphql/planner/planner.go
+++ b/query/graphql/planner/planner.go
@@ -62,35 +62,6 @@ type planNode interface {
 	Close() error
 }
 
-// basic plan Node that implements the planNode interface
-// can be added to any struct to turn it into a planNode
-type baseNode struct { //nolint:unused
-	plan planNode
-}
-
-func (n *baseNode) Init() error                    { return n.plan.Init() }   //nolint:unused
-func (n *baseNode) Start() error                   { return n.plan.Start() }  //nolint:unused
-func (n *baseNode) Next() (bool, error)            { return n.plan.Next() }   //nolint:unused
-func (n *baseNode) Spans(spans core.Spans)         { n.plan.Spans(spans) }    //nolint:unused
-func (n *baseNode) Values() map[string]interface{} { return n.plan.Values() } //nolint:unused
-func (n *baseNode) Close() error                   { return n.plan.Close() }  //nolint:unused
-func (n *baseNode) Source() planNode               { return n.plan }          //nolint:unused
-
-type ExecutionContext struct {
-	context.Context
-}
-
-type PlanContext struct {
-	context.Context
-}
-
-type Statement struct {
-	// Commenting out because unused code (structcheck) according to linter.
-	// requestString   string
-	// requestDocument *ast.Document parser.Statement -> parser.Query - >
-	// requestQuery    parser.Query
-}
-
 // Planner combines session state and database state to
 // produce a query plan, which is run by the execution context.
 type Planner struct {
@@ -99,9 +70,6 @@ type Planner struct {
 
 	ctx     context.Context
 	evalCtx parser.EvalContext
-
-	// isFinalized bool
-
 }
 
 func makePlanner(ctx context.Context, db client.DB, txn datastore.Txn) *Planner {
@@ -448,10 +416,6 @@ func (p *Planner) queryDocs(
 
 	err = plan.Close()
 	return docs, err
-}
-
-func (p *Planner) MakePlan(query *parser.Query) (planNode, error) {
-	return p.makePlan(query)
 }
 
 func copyMap(m map[string]interface{}) map[string]interface{} {

--- a/query/graphql/planner/values.go
+++ b/query/graphql/planner/values.go
@@ -14,7 +14,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/sourcenetwork/defradb/core"
 	"github.com/sourcenetwork/defradb/db/base"
 	"github.com/sourcenetwork/defradb/db/container"
 	"github.com/sourcenetwork/defradb/query/graphql/parser"
@@ -45,9 +44,6 @@ func (p *Planner) newContainerValuesNode(ordering []parser.SortCondition) *value
 	}
 }
 
-func (n *valuesNode) Init() error            { return nil }
-func (n *valuesNode) Start() error           { return nil }
-func (n *valuesNode) Spans(spans core.Spans) {}
 func (n *valuesNode) Close() {
 	if n.docs != nil {
 		n.docs.Close()
@@ -66,21 +62,9 @@ func (n *valuesNode) Values() map[string]interface{} {
 	return n.docs.At(n.docIndex)
 }
 
-func (n *valuesNode) Source() planNode { return nil }
-
 // SortAll actually sorts all the data within the docContainer object
 func (n *valuesNode) SortAll() {
 	sort.Sort(n)
-}
-
-// Less implements the golang sort.Sort interface.
-// It compares the values the ith and jth index
-// within the docContainer.
-// returns true if i < j.
-// returns false if i > j.
-func (n *valuesNode) Less(i, j int) bool {
-	da, db := n.docs.At(i), n.docs.At(j)
-	return n.docValueLess(da, db)
 }
 
 // docValueLess extracts and compare field values of a document
@@ -103,6 +87,16 @@ func (n *valuesNode) docValueLess(da, db map[string]interface{}) bool {
 	}
 
 	return true
+}
+
+// Less implements the golang sort.Sort interface.
+// It compares the values the ith and jth index
+// within the docContainer.
+// returns true if i < j.
+// returns false if i > j.
+func (n *valuesNode) Less(i, j int) bool {
+	da, db := n.docs.At(i), n.docs.At(j)
+	return n.docValueLess(da, db)
 }
 
 // Swap implements the golang sort.Sort interface.

--- a/query/graphql/planner/versionedscan.go
+++ b/query/graphql/planner/versionedscan.go
@@ -10,129 +10,131 @@
 
 package planner
 
-import (
-	"errors"
+// This entire file is Dormant Code????
 
-	"github.com/sourcenetwork/defradb/client"
-	"github.com/sourcenetwork/defradb/core"
-	"github.com/sourcenetwork/defradb/db/fetcher"
-	"github.com/sourcenetwork/defradb/query/graphql/parser"
-
-	"github.com/ipfs/go-cid"
-)
-
-var (
-	emptyCID = cid.Cid{}
-)
-
-// scans an index for records
-type versionedScanNode struct {
-	p *Planner
-
-	// versioned data
-	key     core.DataStoreKey
-	version cid.Cid
-
-	desc client.CollectionDescription
-
-	fields []*client.FieldDescription
-	doc    map[string]interface{}
-	docKey []byte
-
-	reverse bool
-
-	// filter data
-	filter *parser.Filter
-
-	scanInitialized bool
-
-	fetcher fetcher.VersionedFetcher
-}
-
-func (n *versionedScanNode) Init() error {
-	// init the fetcher
-	if err := n.fetcher.Init(&n.desc, n.fields, n.reverse); err != nil {
-		return err
-	}
-	return n.initScan()
-}
-
-// Start starts the internal logic of the scanner
-// like the DocumentFetcher, and more.
-func (n *versionedScanNode) Start() error {
-	return nil // noop
-}
-
-func (n *versionedScanNode) initScan() error {
-	if n.key.DocKey == "" || n.version.Equals(emptyCID) {
-		return errors.New("VersionedScan is missing either a DocKey or VersionCID")
-	}
-
-	// create a span of the form {DocKey, VersionCID}
-	// spans := core.Spans{core.NewSpan(n.key, core.NewKey(n.version.String()))}
-	spans := fetcher.NewVersionedSpan(n.key, n.version)
-	err := n.fetcher.Start(n.p.ctx, n.p.txn, spans)
-	if err != nil {
-		return err
-	}
-
-	n.scanInitialized = true
-	return nil
-}
-
-// Next gets the next result.
-// Returns true, if there is a result,
-// and false otherwise.
-func (n *versionedScanNode) Next() (bool, error) {
-	// if !n.scanInitialized {
-	// 	if err := n.initScan(); err != nil {
-	// 		return false, err
-	// 	}
-	// }
-
-	// keep scanning until we find a doc that passes the filter
-	for {
-		var err error
-		n.docKey, n.doc, err = n.fetcher.FetchNextMap(n.p.ctx)
-		if err != nil {
-			return false, err
-		}
-		if n.doc == nil {
-			return false, nil
-		}
-
-		passed, err := parser.RunFilter(n.doc, n.filter, n.p.evalCtx)
-		if err != nil {
-			return false, err
-		}
-		if passed {
-			return true, nil
-		}
-	}
-}
-
-func (n *versionedScanNode) Spans(spans core.Spans) {
-	// n.spans = spans
-	// we expect 1 span that includes both the DocKey and VersionCID
-	// if len(spans) != 1 {
-	// 	return
-	// }
-}
-
-// Values returns the most recent result from Next()
-func (n *versionedScanNode) Values() map[string]interface{} {
-	return n.doc
-}
-
-func (n *versionedScanNode) Close() error {
-	return n.fetcher.Close()
-}
-
-func (n *versionedScanNode) Source() planNode { return nil }
-
-// Merge implements mergeNode
-func (n *versionedScanNode) Merge() bool { return true }
-
-func (p *Planner) VersionedScan() *versionedScanNode {
-	return &versionedScanNode{p: p}
-}
+//import (
+//	"errors"
+//
+//	"github.com/sourcenetwork/defradb/client"
+//	"github.com/sourcenetwork/defradb/core"
+//	"github.com/sourcenetwork/defradb/db/fetcher"
+//	"github.com/sourcenetwork/defradb/query/graphql/parser"
+//
+//	"github.com/ipfs/go-cid"
+//)
+//
+//var (
+//	emptyCID = cid.Cid{}
+//)
+//
+//// scans an index for records
+//type versionedScanNode struct {
+//	p *Planner
+//
+//	// versioned data
+//	key     core.DataStoreKey
+//	version cid.Cid
+//
+//	desc client.CollectionDescription
+//
+//	fields []*client.FieldDescription
+//	doc    map[string]interface{}
+//	docKey []byte
+//
+//	reverse bool
+//
+//	// filter data
+//	filter *parser.Filter
+//
+//	scanInitialized bool
+//
+//	fetcher fetcher.VersionedFetcher
+//}
+//
+//func (n *versionedScanNode) Init() error {
+//	// init the fetcher
+//	if err := n.fetcher.Init(&n.desc, n.fields, n.reverse); err != nil {
+//		return err
+//	}
+//	return n.initScan()
+//}
+//
+//// Start starts the internal logic of the scanner
+//// like the DocumentFetcher, and more.
+//func (n *versionedScanNode) Start() error {
+//	return nil // noop
+//}
+//
+//func (n *versionedScanNode) initScan() error {
+//	if n.key.DocKey == "" || n.version.Equals(emptyCID) {
+//		return errors.New("VersionedScan is missing either a DocKey or VersionCID")
+//	}
+//
+//	// create a span of the form {DocKey, VersionCID}
+//	// spans := core.Spans{core.NewSpan(n.key, core.NewKey(n.version.String()))}
+//	spans := fetcher.NewVersionedSpan(n.key, n.version)
+//	err := n.fetcher.Start(n.p.ctx, n.p.txn, spans)
+//	if err != nil {
+//		return err
+//	}
+//
+//	n.scanInitialized = true
+//	return nil
+//}
+//
+//// Next gets the next result.
+//// Returns true, if there is a result,
+//// and false otherwise.
+//func (n *versionedScanNode) Next() (bool, error) {
+//	// if !n.scanInitialized {
+//	// 	if err := n.initScan(); err != nil {
+//	// 		return false, err
+//	// 	}
+//	// }
+//
+//	// keep scanning until we find a doc that passes the filter
+//	for {
+//		var err error
+//		n.docKey, n.doc, err = n.fetcher.FetchNextMap(n.p.ctx)
+//		if err != nil {
+//			return false, err
+//		}
+//		if n.doc == nil {
+//			return false, nil
+//		}
+//
+//		passed, err := parser.RunFilter(n.doc, n.filter, n.p.evalCtx)
+//		if err != nil {
+//			return false, err
+//		}
+//		if passed {
+//			return true, nil
+//		}
+//	}
+//}
+//
+//func (n *versionedScanNode) Spans(spans core.Spans) {
+//	// n.spans = spans
+//	// we expect 1 span that includes both the DocKey and VersionCID
+//	// if len(spans) != 1 {
+//	// 	return
+//	// }
+//}
+//
+//// Values returns the most recent result from Next()
+//func (n *versionedScanNode) Values() map[string]interface{} {
+//	return n.doc
+//}
+//
+//func (n *versionedScanNode) Close() error {
+//	return n.fetcher.Close()
+//}
+//
+//func (n *versionedScanNode) Source() planNode { return nil }
+//
+//// Merge implements mergeNode
+//func (n *versionedScanNode) Merge() bool { return true }
+//
+//func (p *Planner) VersionedScan() *versionedScanNode {
+//	return &versionedScanNode{p: p}
+//}

--- a/query/graphql/schema/generate.go
+++ b/query/graphql/schema/generate.go
@@ -26,16 +26,6 @@ import (
 	"github.com/graphql-go/graphql/language/source"
 )
 
-// Given a basic developer defined schema in GraphQL Schema Definition Language
-// create a fully DefraDB complaint GraphQL schema using a "code-first" dynamic
-// approach
-
-// Type represents a developer defined type, and its associated graphQL generated types
-type Type struct {
-	gql.ObjectConfig
-	Object *gql.Object
-}
-
 // Generator creates all the necessary typed schema definitions from an AST Document
 // and adds them to the Schema via the SchemaManager
 type Generator struct {
@@ -990,13 +980,6 @@ func (g *Generator) genTypeQueryableFieldList(
 	}
 
 	return field
-}
-
-// Reset the stateful data within a Generator.
-// Usually called after a round of type generation
-func (g *Generator) Reset() {
-	g.typeDefs = make([]*gql.Object, 0)
-	g.expandedFields = make(map[string]bool)
 }
 
 func newArgConfig(t gql.Input) *gql.ArgumentConfig {

--- a/query/graphql/schema/relations.go
+++ b/query/graphql/schema/relations.go
@@ -42,8 +42,6 @@ func NewRelationManager() *RelationManager {
 	}
 }
 
-func (rm *RelationManager) GetRelations() {}
-
 func (rm *RelationManager) GetRelation(name string) (*Relation, error) {
 	rel, ok := rm.relations[name]
 	if !ok {
@@ -69,10 +67,6 @@ func (rm *RelationManager) GetRelationByDescription(
 	return nil
 }
 
-func (rm *RelationManager) NumRelations() int {
-	return len(rm.relations)
-}
-
 // validate ensures that all the relations are finalized.
 // It returns any relations that aren't. Returns true if
 // everything is valid
@@ -87,11 +81,6 @@ func (rm *RelationManager) validate() ([]*Relation, bool) {
 		return unfinalized, false
 	}
 	return nil, true
-}
-
-func (rm *RelationManager) Exists(name string) bool {
-	_, exists := rm.relations[name]
-	return exists
 }
 
 // RegisterSingle is used if you only know a single side of the relation
@@ -158,28 +147,6 @@ func (rm *RelationManager) RegisterSingle(
 	return true, nil
 }
 
-// RegisterRelation adds a new relation to the RelationManager
-// if it doesn't already exist.
-func (rm *RelationManager) RegisterOneToOne(
-	name, primaryType, primaryField, secondaryType, secondaryField string,
-) (bool, error) {
-	return rm.register(nil)
-}
-
-func (rm *RelationManager) RegisterOneToMany(
-	name, oneType, oneField, manyType, manyField string,
-) (bool, error) {
-	return rm.register(nil)
-}
-
-func (rm *RelationManager) RegisterManyToMany(name, type1, type2 string) (bool, error) {
-	return rm.register(nil)
-}
-
-func (rm *RelationManager) register(rel *Relation) (bool, error) {
-	return true, nil
-}
-
 type Relation struct {
 	name        string
 	relType     client.RelationType
@@ -237,17 +204,9 @@ func (r *Relation) finalize() error {
 	return nil
 }
 
-func (r Relation) GetFields() []string {
-	return r.fields
-}
-
 // Type returns what kind of relation it is
 func (r Relation) Kind() client.RelationType {
 	return r.relType
-}
-
-func (r Relation) Valid() bool {
-	return r.finalized
 }
 
 // SchemaTypeIsPrimary returns true if the provided type of the relation
@@ -260,30 +219,6 @@ func (r Relation) SchemaTypeIsPrimary(t string) bool {
 
 	relType := r.types[i]
 	return relType.IsSet(client.Relation_Type_Primary)
-}
-
-// SchemaTypeIsOne returns true if the provided type of the relation
-// is the primary type. Only one-to-one and one-to-many have primaries.
-func (r Relation) SchemaTypeIsOne(t string) bool {
-	i, ok := r.schemaTypeExists(t)
-	if !ok {
-		return false
-	}
-
-	relType := r.types[i]
-	return relType.IsSet(client.Relation_Type_ONE)
-}
-
-// SchemaTypeIsMany returns true if the provided type of the relation
-// is the primary type. Only one-to-one and one-to-many have primaries.
-func (r Relation) SchemaTypeIsMany(t string) bool {
-	i, ok := r.schemaTypeExists(t)
-	if !ok {
-		return false
-	}
-
-	relType := r.types[i]
-	return relType.IsSet(client.Relation_Type_MANY)
 }
 
 func (r Relation) schemaTypeExists(t string) (int, bool) {
@@ -327,11 +262,6 @@ func genRelationName(t1, t2 string) (string, error) {
 
 }
 
-// IsPrimary returns true if the Relation_Primary bit is set
-func IsPrimary(fieldmeta client.RelationType) bool {
-	return fieldmeta.IsSet(client.Relation_Type_Primary)
-}
-
 // IsOne returns true if the Relation_ONE bit is set
 func IsOne(fieldmeta client.RelationType) bool {
 	return fieldmeta.IsSet(client.Relation_Type_ONE)
@@ -340,11 +270,6 @@ func IsOne(fieldmeta client.RelationType) bool {
 // IsOneToOne returns true if the Relation_ONEONE bit is set
 func IsOneToOne(fieldmeta client.RelationType) bool {
 	return fieldmeta.IsSet(client.Relation_Type_ONEONE)
-}
-
-// IsMany returns true if the Relation_MANY bit is set
-func IsMany(fieldmeta client.RelationType) bool {
-	return fieldmeta.IsSet(client.Relation_Type_MANY)
 }
 
 // IsOneToMany returns true if the Relation_ONEMANY is set

--- a/utils/proxystore.go
+++ b/utils/proxystore.go
@@ -10,97 +10,90 @@
 
 package utils
 
-import (
-	"context"
+// Dormant code?
 
-	"github.com/ipfs/go-datastore"
-	ds "github.com/ipfs/go-datastore"
-	"github.com/ipfs/go-datastore/query"
-)
-
-// Proxy store implements the ds.Datastore interface
-// and provides proxy functionality from a 'frontend'
-// datastore to one or more 'backend' datastores.
-type ProxyStore struct {
-	frontend ds.Datastore
-	backends []ds.Datastore
-}
-
-// NewProxyStore returns a ds.Datastore implemented by a ProxyStore with
-// the configured frontend and backends
-func NewProxyStore(frontend ds.Datastore, backends ...ds.Datastore) ds.Datastore {
-	return &ProxyStore{
-		frontend: frontend,
-		backends: backends,
-	}
-}
-
-// Get retrieves the object `value` named by `key`.
-// Get will return ErrNotFound if the key is not mapped to a value.
-func (p *ProxyStore) Get(ctx context.Context, key datastore.Key) (value []byte, err error) {
-	panic("not implemented") // TODO: Implement
-}
-
-// Has returns whether the `key` is mapped to a `value`.
-// In some contexts, it may be much cheaper only to check for existence of
-// a value, rather than retrieving the value itself. (e.g. HTTP HEAD).
-// The default implementation is found in `GetBackedHas`.
-func (p *ProxyStore) Has(ctx context.Context, key datastore.Key) (exists bool, err error) {
-	panic("not implemented") // TODO: Implement
-}
-
-// GetSize returns the size of the `value` named by `key`.
-// In some contexts, it may be much cheaper to only get the size of the
-// value rather than retrieving the value itself.
-func (p *ProxyStore) GetSize(ctx context.Context, key datastore.Key) (size int, err error) {
-	panic("not implemented") // TODO: Implement
-}
-
-// Query searches the datastore and returns a query result. This function
-// may return before the query actually runs. To wait for the query:
+// import (
+// 	"context"
 //
-//   result, _ := ds.Query(q)
+// 	"github.com/ipfs/go-datastore"
+// 	ds "github.com/ipfs/go-datastore"
+// 	"github.com/ipfs/go-datastore/query"
+// )
 //
-//   // use the channel interface; result may come in at different times
-//   for entry := range result.Next() { ... }
+// // Proxy store implements the ds.Datastore interface
+// // and provides proxy functionality from a 'frontend'
+// // datastore to one or more 'backend' datastores.
+// type ProxyStore struct {
+// 	frontend ds.Datastore
+// 	backends []ds.Datastore
+// }
 //
-//   // or wait for the query to be completely done
-//   entries, _ := result.Rest()
-//   for entry := range entries { ... }
+// // Get retrieves the object `value` named by `key`.
+// // Get will return ErrNotFound if the key is not mapped to a value.
+// func (p *ProxyStore) Get(ctx context.Context, key datastore.Key) (value []byte, err error) {
+// 	panic("not implemented") // TODO: Implement
+// }
 //
-func (p *ProxyStore) Query(ctx context.Context, q query.Query) (query.Results, error) {
-	panic("not implemented") // TODO: Implement
-}
-
-// Put stores the object `value` named by `key`.
+// // Has returns whether the `key` is mapped to a `value`.
+// // In some contexts, it may be much cheaper only to check for existence of
+// // a value, rather than retrieving the value itself. (e.g. HTTP HEAD).
+// // The default implementation is found in `GetBackedHas`.
+// func (p *ProxyStore) Has(ctx context.Context, key datastore.Key) (exists bool, err error) {
+// 	panic("not implemented") // TODO: Implement
+// }
 //
-// The generalized Datastore interface does not impose a value type,
-// allowing various datastore middleware implementations (which do not
-// handle the values directly) to be composed together.
+// // GetSize returns the size of the `value` named by `key`.
+// // In some contexts, it may be much cheaper to only get the size of the
+// // value rather than retrieving the value itself.
+// func (p *ProxyStore) GetSize(ctx context.Context, key datastore.Key) (size int, err error) {
+// 	panic("not implemented") // TODO: Implement
+// }
 //
-// Ultimately, the lowest-level datastore will need to do some value checking
-// or risk getting incorrect values. It may also be useful to expose a more
-// type-safe interface to your application, and do the checking up-front.
-func (p *ProxyStore) Put(ctx context.Context, key datastore.Key, value []byte) error {
-	panic("not implemented") // TODO: Implement
-}
-
-// Delete removes the value for given `key`. If the key is not in the
-// datastore, this method returns no error.
-func (p *ProxyStore) Delete(ctx context.Context, key datastore.Key) error {
-	panic("not implemented") // TODO: Implement
-}
-
-// Sync guarantees that any Put or Delete calls under prefix that returned
-// before Sync(prefix) was called will be observed after Sync(prefix)
-// returns, even if the program crashes. If Put/Delete operations already
-// satisfy these requirements then Sync may be a no-op.
+// // Query searches the datastore and returns a query result. This function
+// // may return before the query actually runs. To wait for the query:
+// //
+// //   result, _ := ds.Query(q)
+// //
+// //   // use the channel interface; result may come in at different times
+// //   for entry := range result.Next() { ... }
+// //
+// //   // or wait for the query to be completely done
+// //   entries, _ := result.Rest()
+// //   for entry := range entries { ... }
+// //
+// func (p *ProxyStore) Query(ctx context.Context, q query.Query) (query.Results, error) {
+// 	panic("not implemented") // TODO: Implement
+// }
 //
-// If the prefix fails to Sync this method returns an error.
-func (p *ProxyStore) Sync(ctx context.Context, prefix datastore.Key) error {
-	panic("not implemented") // TODO: Implement
-}
-
-func (p *ProxyStore) Close() error {
-	panic("not implemented") // TODO: Implement
-}
+// // Put stores the object `value` named by `key`.
+// //
+// // The generalized Datastore interface does not impose a value type,
+// // allowing various datastore middleware implementations (which do not
+// // handle the values directly) to be composed together.
+// //
+// // Ultimately, the lowest-level datastore will need to do some value checking
+// // or risk getting incorrect values. It may also be useful to expose a more
+// // type-safe interface to your application, and do the checking up-front.
+// func (p *ProxyStore) Put(ctx context.Context, key datastore.Key, value []byte) error {
+// 	panic("not implemented") // TODO: Implement
+// }
+//
+// // Delete removes the value for given `key`. If the key is not in the
+// // datastore, this method returns no error.
+// func (p *ProxyStore) Delete(ctx context.Context, key datastore.Key) error {
+// 	panic("not implemented") // TODO: Implement
+// }
+//
+// // Sync guarantees that any Put or Delete calls under prefix that returned
+// // before Sync(prefix) was called will be observed after Sync(prefix)
+// // returns, even if the program crashes. If Put/Delete operations already
+// // satisfy these requirements then Sync may be a no-op.
+// //
+// // If the prefix fails to Sync this method returns an error.
+// func (p *ProxyStore) Sync(ctx context.Context, prefix datastore.Key) error {
+// 	panic("not implemented") // TODO: Implement
+// }
+//
+// func (p *ProxyStore) Close() error {
+// 	panic("not implemented") // TODO: Implement
+// }


### PR DESCRIPTION
Resolves: #368 

This is a different kind of PR.

Don't look at lines removed as that "they are removed". The removal is to highlight that the code compiles and passes all the tests with all those removed and we should have a discussion on everything we want to keep or remove from this diff. I am guessing 99% of changes under `client` will not be removed but inorder to stay, there should be associated test cases added or a mark / comment / document of some sort the purpose of the dormant / unused (i.e. "for external use").

I may have ripped out too much (do call out those pieces please, as I think in some cases if you remove methods from an interface but not the structs implementing the interface then it still compiles? and passes the test.)

Maybe to begin, we can start by marking everything that is okay to remove in a PR review comment like so `remove`.

Then we can get into more `keep` and `keep, and add test`, `keep, but comment out`, etc.

When I started here were the main exported-unused lines I had to fix:

<details>
  <summary>Click to expand!</summary>

bench/fixtures/data.go:24:2 field Name is unused (EU1002)
bench/fixtures/data.go:25:2 field Age is unused (EU1002)
bench/fixtures/data.go:26:2 field Points is unused (EU1002)
bench/fixtures/data.go:27:2 field Verified is unused (EU1002)
bench/fixtures/fixtures.go:37:6 function ForSchema is used in test only (EU1001)
bench/fixtures/fixtures.go:51:20 method (Generator).Type is unused (EU1002)
cli/defradb/cmd/config.go:27:2 field Memory is unused (EU1002)
cli/defradb/cmd/config.go:39:2 field Size is unused (EU1002)
cli/defradb/cmd/config.go:59:2 field EnableStackTrace is unused (EU1002)
cli/defradb/cmd/config.go:60:2 field EncoderFormat is unused (EU1002)
cli/defradb/cmd/config.go:61:2 field OutputPaths is unused (EU1002)
client/collection.go:71:2 method Delete is used in test only (EU1001)
client/collection.go:115:2 method DeleteWith is unused (EU1002)
client/collection.go:75:2 method Exists is unused (EU1002)
client/collection.go:33:2 method ID is used in test only (EU1001)
client/collection.go:44:2 method Index is unused (EU1002)
client/collection.go:38:2 method Indexes is used in test only (EU1001)
client/collection.go:40:2 method PrimaryIndex is unused (EU1002)
client/collection.go:60:2 method Update is used in test only (EU1001)
client/collection.go:86:2 method UpdateWith is unused (EU1002)
client/descriptions.go:43:32 method (CollectionDescription).GetPrimaryIndex is unused (EU1002)
client/descriptions.go:54:2 field FieldIDs is unused (EU1002)
client/descriptions.go:77:2 field Junction is unused (EU1002)
client/descriptions.go:81:2 field RelationType is unused (EU1002)
client/descriptions.go:84:31 method (IndexDescription).IDString is unused (EU1002)
client/descriptions.go:89:2 field ID is used in test only (EU1001)
client/descriptions.go:91:2 field Key is unused (EU1002)
client/descriptions.go:125:2 constant FieldKind_TIMESTAMP is unused (EU1002)
client/descriptions.go:128:2 constant FieldKind_BYTES is unused (EU1002)
client/dockey.go:97:19 method (DocKey).UUID is unused (EU1002)
client/dockey.go:110:19 method (DocKey).Bytes is unused (EU1002)
client/document.go:139:22 method (*Document).Head is unused (EU1002)
client/document.go:164:22 method (*Document).Get is used in test only (EU1001)
client/document.go:369:22 method (*Document).Values is unused (EU1002)
client/document.go:397:22 method (*Document).String is unused (EU1002)
client/field.go:17:2 method SchemaType is unused (EU1002)
client/field.go:45:26 method (simpleField).SchemaType is unused (EU1002)
client/value.go:40:6 interface ReadableValue is unused (EU1002)
client/value.go:43:2 method Read is unused (EU1002)
core/crdt/composite.go:41:33 method (*CompositeDAGDelta).GetPriority is unused (EU1002)
core/crdt/lwwreg.go:52:27 method (*LWWRegDelta).SetPriority is used in test only (EU1001)
core/data.go:22:2 method Contains is unused (EU1002)
core/data.go:24:2 method Equal is unused (EU1002)
core/data.go:53:15 method (span).Contains is unused (EU1002)
core/data.go:58:15 method (span).Equal is unused (EU1002)
core/key.go:25:2 variable KeyMin is unused (EU1002)
core/key.go:27:2 variable KeyMax is unused (EU1002)
core/key.go:214:23 method (HeadStoreKey).WithDocKey is used in test only (EU1001)
core/key.go:226:23 method (HeadStoreKey).WithFieldId is used in test only (EU1001)
core/key.go:259:23 method (DataStoreKey).Equal is unused (EU1002)
core/key.go:273:30 method (PrimaryDataStoreKey).Bytes is unused (EU1002)
core/key.go:305:24 method (CollectionKey).Bytes is unused (EU1002)
core/key.go:323:30 method (CollectionSchemaKey).Bytes is unused (EU1002)
core/key.go:341:20 method (SchemaKey).Bytes is unused (EU1002)
core/key.go:359:22 method (SequenceKey).Bytes is unused (EU1002)
core/key.go:383:23 method (HeadStoreKey).Bytes is unused (EU1002)
core/net/broadcaster.go:22:2 method SendWithTimeout is unused (EU1002)
core/node.go:25:2 method Error is unused (EU1002)
core/node.go:24:2 method GetDelta is unused (EU1002)
core/node.go:23:2 method GetNode is unused (EU1002)
core/node.go:33:2 method GetDeltas is unused (EU1002)
core/node.go:34:2 method GetPriority is unused (EU1002)
core/replicated.go:37:6 interface PersistedReplicatedData is unused (EU1002)
core/replicated.go:39:2 method Publish is unused (EU1002)
datastore/badger/v3/compat_logger.go:14:29 method (*compatLogger).Warning is unused (EU1002)
datastore/badger/v3/compat_logger.go:20:29 method (*compatLogger).Warningf is unused (EU1002)
datastore/badger/v3/datastore.go:261:21 method (*Datastore).Sync is unused (EU1002)
datastore/badger/v3/datastore.go:275:21 method (*Datastore).PutWithTTL is unused (EU1002)
datastore/badger/v3/datastore.go:297:21 method (*Datastore).SetTTL is unused (EU1002)
datastore/badger/v3/datastore.go:314:21 method (*Datastore).GetExpiration is unused (EU1002)
datastore/badger/v3/datastore.go:397:21 method (*Datastore).DiskUsage is unused (EU1002)
datastore/badger/v3/datastore.go:440:21 method (*Datastore).CollectGarbage is unused (EU1002)
datastore/badger/v3/datastore.go:513:17 method (*batch).Cancel is unused (EU1002)
datastore/badger/v3/datastore.go:545:15 method (*txn).Sync is unused (EU1002)
datastore/badger/v3/datastore.go:555:15 method (*txn).PutWithTTL is unused (EU1002)
datastore/badger/v3/datastore.go:568:15 method (*txn).GetExpiration is unused (EU1002)
datastore/badger/v3/datastore.go:588:15 method (*txn).SetTTL is unused (EU1002)
datastore/blockstore.go:50:5 variable ErrNotFound is unused (EU1002)
datastore/blockstore.go:66:19 method (*bstore).HashOnRead is unused (EU1002)
datastore/blockstore.go:108:19 method (*bstore).PutMany is unused (EU1002)
datastore/blockstore.go:128:19 method (*bstore).GetSize is unused (EU1002)
datastore/blockstore.go:144:19 method (*bstore).AllKeysChan is used in test only (EU1001)
datastore/txn.go:38:2 method OnError is unused (EU1002)
datastore/txn.go:122:17 method (*txn).OnError is unused (EU1002)
datastore/txn.go:186:24 method (ShimTxnStore).Sync is unused (EU1002)
db/base/encoding.go:17:2 constant DataEncoding_VALUE_CBOR is unused (EU1002)
db/collection.go:370:22 method (*collection).ID is used in test only (EU1001)
db/collection.go:376:22 method (*collection).Indexes is used in test only (EU1001)
db/collection.go:381:22 method (*collection).PrimaryIndex is unused (EU1002)
db/collection.go:386:22 method (*collection).Index is unused (EU1002)
db/collection.go:494:22 method (*collection).Update is used in test only (EU1001)
db/collection.go:637:22 method (*collection).Delete is used in test only (EU1001)
db/collection.go:694:22 method (*collection).Exists is unused (EU1002)
db/collection_delete.go:33:2 variable ErrDeleteTargetEmpty is unused (EU1002)
db/collection_delete.go:34:2 variable ErrDeleteEmpty is unused (EU1002)
db/collection_delete.go:41:22 method (*collection).DeleteWith is unused (EU1002)
db/collection_update.go:31:2 variable ErrUpdateTargetEmpty is unused (EU1002)
db/collection_update.go:43:22 method (*collection).UpdateWith is unused (EU1002)
db/db.go:40:2 variable ErrOptionsEmpty is unused (EU1002)
db/db.go:182:15 method (*db).Executor is unused (EU1002)
db/fetcher/dag.go:28:6 struct BlockFetcher is unused (EU1002)
db/fetcher/encoded_doc.go:20:6 variable EPTuple is unused (EU1002)
db/fetcher/fetcher.go:185:28 method (*DocumentFetcher).KVEnd is unused (EU1002)
db/fetcher/fetcher.go:189:28 method (*DocumentFetcher).KV is unused (EU1002)
db/fetcher/fetcher.go:193:28 method (*DocumentFetcher).NextKey is unused (EU1002)
db/fetcher/fetcher.go:197:28 method (*DocumentFetcher).NextKV is unused (EU1002)
db/fetcher/fetcher.go:201:28 method (*DocumentFetcher).ProcessKV is unused (EU1002)
db/fetcher/versioned.go:174:29 method (*VersionedFetcher).Rootstore is unused (EU1002)
db/fetcher/versioned.go:193:29 method (*VersionedFetcher).SeekTo is used in test only (EU1001)
db/tests/mutation/inline_array/utils.go:29:6 function ExecuteTestCase is used in test only (EU1001)
db/tests/mutation/relation/utils.go:41:6 function ExecuteTestCase is used in test only (EU1001)
db/tests/mutation/simple/utils.go:28:6 function ExecuteTestCase is used in test only (EU1001)
logging/logger.go:96:18 method (*logger).Flush is unused (EU1002)
logging/logging.go:37:2 method Flush is used in test only (EU1001)
merkle/clock/clock.go:213:24 method (*MerkleClock).Heads is used in test only (EU1001)
merkle/clock/heads.go:91:18 method (*heads).Len is used in test only (EU1001)
merkle/clock/ipld.go:53:27 method (*CrdtNodeGetter).GetPriority is unused (EU1002)
merkle/clock/ipld.go:67:22 method (DeltaEntry).GetNode is unused (EU1002)
merkle/clock/ipld.go:71:22 method (DeltaEntry).GetDelta is unused (EU1002)
merkle/clock/ipld.go:75:22 method (DeltaEntry).Error is unused (EU1002)
merkle/clock/ipld.go:80:27 method (*CrdtNodeGetter).GetDeltas is unused (EU1002)
merkle/crdt/factory.go:70:24 method (Factory).Instance is used in test only (EU1001)
merkle/crdt/factory.go:111:25 method (*Factory).SetStores is used in test only (EU1001)
merkle/crdt/merklecrdt.go:54:29 method (*baseMerkleCRDT).Clock is unused (EU1002)
net/api/pb/api.pb.go:34:32 method (*AddReplicatorRequest).Reset is unused (EU1002)
net/api/pb/api.pb.go:35:32 method (*AddReplicatorRequest).String is unused (EU1002)
net/api/pb/api.pb.go:36:30 method (*AddReplicatorRequest).ProtoMessage is unused (EU1002)
net/api/pb/api.pb.go:37:30 method (*AddReplicatorRequest).Descriptor is unused (EU1002)
net/api/pb/api.pb.go:40:32 method (*AddReplicatorRequest).XXX_Unmarshal is unused (EU1002)
net/api/pb/api.pb.go:43:32 method (*AddReplicatorRequest).XXX_Marshal is unused (EU1002)
net/api/pb/api.pb.go:55:32 method (*AddReplicatorRequest).XXX_Merge is unused (EU1002)
net/api/pb/api.pb.go:58:32 method (*AddReplicatorRequest).XXX_Size is unused (EU1002)
net/api/pb/api.pb.go:61:32 method (*AddReplicatorRequest).XXX_DiscardUnknown is unused (EU1002)
net/api/pb/api.pb.go:67:32 method (*AddReplicatorRequest).GetCollection is unused (EU1002)
net/api/pb/api.pb.go:74:32 method (*AddReplicatorRequest).GetAddr is unused (EU1002)
net/api/pb/api.pb.go:85:30 method (*AddReplicatorReply).Reset is unused (EU1002)
net/api/pb/api.pb.go:86:30 method (*AddReplicatorReply).String is unused (EU1002)
net/api/pb/api.pb.go:87:28 method (*AddReplicatorReply).ProtoMessage is unused (EU1002)
net/api/pb/api.pb.go:88:28 method (*AddReplicatorReply).Descriptor is unused (EU1002)
net/api/pb/api.pb.go:91:30 method (*AddReplicatorReply).XXX_Unmarshal is unused (EU1002)
net/api/pb/api.pb.go:94:30 method (*AddReplicatorReply).XXX_Marshal is unused (EU1002)
net/api/pb/api.pb.go:106:30 method (*AddReplicatorReply).XXX_Merge is unused (EU1002)
net/api/pb/api.pb.go:109:30 method (*AddReplicatorReply).XXX_Size is unused (EU1002)
net/api/pb/api.pb.go:112:30 method (*AddReplicatorReply).XXX_DiscardUnknown is unused (EU1002)
net/api/pb/api.pb.go:118:30 method (*AddReplicatorReply).GetPeerID is unused (EU1002)
net/api/pb/api.pb.go:230:32 method (*AddReplicatorRequest).Marshal is unused (EU1002)
net/api/pb/api.pb.go:240:32 method (*AddReplicatorRequest).MarshalTo is unused (EU1002)
net/api/pb/api.pb.go:267:30 method (*AddReplicatorReply).Marshal is unused (EU1002)
net/api/pb/api.pb.go:277:30 method (*AddReplicatorReply).MarshalTo is unused (EU1002)
net/client.go:31:2 variable PullTimeout is unused (EU1002)
net/dag.go:39:2 method HasBlock is unused (EU1002)
net/pb/custom.go:51:23 method (ProtoPeerID).MarshalTo is unused (EU1002)
net/pb/custom.go:55:23 method (ProtoPeerID).MarshalJSON is unused (EU1002)
net/pb/custom.go:65:24 method (*ProtoPeerID).UnmarshalJSON is unused (EU1002)
net/pb/custom.go:74:23 method (ProtoPeerID).Size is unused (EU1002)
net/pb/custom.go:90:20 method (ProtoAddr).MarshalTo is unused (EU1002)
net/pb/custom.go:94:20 method (ProtoAddr).MarshalJSON is unused (EU1002)
net/pb/custom.go:104:21 method (*ProtoAddr).UnmarshalJSON is unused (EU1002)
net/pb/custom.go:113:20 method (ProtoAddr).Size is unused (EU1002)
net/pb/custom.go:132:19 method (ProtoCid).MarshalJSON is unused (EU1002)
net/pb/custom.go:146:20 method (*ProtoCid).UnmarshalJSON is unused (EU1002)
net/pb/custom.go:174:22 method (ProtoDocKey).MarshalJSON is unused (EU1002)
net/pb/custom.go:184:23 method (*ProtoDocKey).UnmarshalJSON is unused (EU1002)
net/pb/net.pb.go:38:20 method (*Document).Reset is unused (EU1002)
net/pb/net.pb.go:39:20 method (*Document).String is unused (EU1002)
net/pb/net.pb.go:40:18 method (*Document).ProtoMessage is unused (EU1002)
net/pb/net.pb.go:41:18 method (*Document).Descriptor is unused (EU1002)
net/pb/net.pb.go:44:20 method (*Document).XXX_Unmarshal is unused (EU1002)
net/pb/net.pb.go:47:20 method (*Document).XXX_Marshal is unused (EU1002)
net/pb/net.pb.go:59:20 method (*Document).XXX_Merge is unused (EU1002)
net/pb/net.pb.go:62:20 method (*Document).XXX_Size is unused (EU1002)
net/pb/net.pb.go:65:20 method (*Document).XXX_DiscardUnknown is unused (EU1002)
net/pb/net.pb.go:77:24 method (*Document_Log).Reset is unused (EU1002)
net/pb/net.pb.go:78:24 method (*Document_Log).String is unused (EU1002)
net/pb/net.pb.go:79:22 method (*Document_Log).ProtoMessage is unused (EU1002)
net/pb/net.pb.go:80:22 method (*Document_Log).Descriptor is unused (EU1002)
net/pb/net.pb.go:83:24 method (*Document_Log).XXX_Unmarshal is unused (EU1002)
net/pb/net.pb.go:86:24 method (*Document_Log).XXX_Marshal is unused (EU1002)
net/pb/net.pb.go:98:24 method (*Document_Log).XXX_Merge is unused (EU1002)
net/pb/net.pb.go:101:24 method (*Document_Log).XXX_Size is unused (EU1002)
net/pb/net.pb.go:104:24 method (*Document_Log).XXX_DiscardUnknown is unused (EU1002)
net/pb/net.pb.go:110:24 method (*Document_Log).GetBlock is unused (EU1002)
net/pb/net.pb.go:120:30 method (*GetDocGraphRequest).Reset is unused (EU1002)
net/pb/net.pb.go:121:30 method (*GetDocGraphRequest).String is unused (EU1002)
net/pb/net.pb.go:122:28 method (*GetDocGraphRequest).ProtoMessage is unused (EU1002)
net/pb/net.pb.go:123:28 method (*GetDocGraphRequest).Descriptor is unused (EU1002)
net/pb/net.pb.go:126:30 method (*GetDocGraphRequest).XXX_Unmarshal is unused (EU1002)
net/pb/net.pb.go:129:30 method (*GetDocGraphRequest).XXX_Marshal is unused (EU1002)
net/pb/net.pb.go:141:30 method (*GetDocGraphRequest).XXX_Merge is unused (EU1002)
net/pb/net.pb.go:144:30 method (*GetDocGraphRequest).XXX_Size is unused (EU1002)
net/pb/net.pb.go:147:30 method (*GetDocGraphRequest).XXX_DiscardUnknown is unused (EU1002)
net/pb/net.pb.go:156:28 method (*GetDocGraphReply).Reset is unused (EU1002)
net/pb/net.pb.go:157:28 method (*GetDocGraphReply).String is unused (EU1002)
net/pb/net.pb.go:158:26 method (*GetDocGraphReply).ProtoMessage is unused (EU1002)
net/pb/net.pb.go:159:26 method (*GetDocGraphReply).Descriptor is unused (EU1002)
net/pb/net.pb.go:162:28 method (*GetDocGraphReply).XXX_Unmarshal is unused (EU1002)
net/pb/net.pb.go:165:28 method (*GetDocGraphReply).XXX_Marshal is unused (EU1002)
net/pb/net.pb.go:177:28 method (*GetDocGraphReply).XXX_Merge is unused (EU1002)
net/pb/net.pb.go:180:28 method (*GetDocGraphReply).XXX_Size is unused (EU1002)
net/pb/net.pb.go:183:28 method (*GetDocGraphReply).XXX_DiscardUnknown is unused (EU1002)
net/pb/net.pb.go:192:31 method (*PushDocGraphRequest).Reset is unused (EU1002)
net/pb/net.pb.go:193:31 method (*PushDocGraphRequest).String is unused (EU1002)
net/pb/net.pb.go:194:29 method (*PushDocGraphRequest).ProtoMessage is unused (EU1002)
net/pb/net.pb.go:195:29 method (*PushDocGraphRequest).Descriptor is unused (EU1002)
net/pb/net.pb.go:198:31 method (*PushDocGraphRequest).XXX_Unmarshal is unused (EU1002)
net/pb/net.pb.go:201:31 method (*PushDocGraphRequest).XXX_Marshal is unused (EU1002)
net/pb/net.pb.go:213:31 method (*PushDocGraphRequest).XXX_Merge is unused (EU1002)
net/pb/net.pb.go:216:31 method (*PushDocGraphRequest).XXX_Size is unused (EU1002)
net/pb/net.pb.go:219:31 method (*PushDocGraphRequest).XXX_DiscardUnknown is unused (EU1002)
net/pb/net.pb.go:228:29 method (*PushDocGraphReply).Reset is unused (EU1002)
net/pb/net.pb.go:229:29 method (*PushDocGraphReply).String is unused (EU1002)
net/pb/net.pb.go:230:27 method (*PushDocGraphReply).ProtoMessage is unused (EU1002)
net/pb/net.pb.go:231:27 method (*PushDocGraphReply).Descriptor is unused (EU1002)
net/pb/net.pb.go:234:29 method (*PushDocGraphReply).XXX_Unmarshal is unused (EU1002)
net/pb/net.pb.go:237:29 method (*PushDocGraphReply).XXX_Marshal is unused (EU1002)
net/pb/net.pb.go:249:29 method (*PushDocGraphReply).XXX_Merge is unused (EU1002)
net/pb/net.pb.go:252:29 method (*PushDocGraphReply).XXX_Size is unused (EU1002)
net/pb/net.pb.go:255:29 method (*PushDocGraphReply).XXX_DiscardUnknown is unused (EU1002)
net/pb/net.pb.go:264:25 method (*GetLogRequest).Reset is unused (EU1002)
net/pb/net.pb.go:265:25 method (*GetLogRequest).String is unused (EU1002)
net/pb/net.pb.go:266:23 method (*GetLogRequest).ProtoMessage is unused (EU1002)
net/pb/net.pb.go:267:23 method (*GetLogRequest).Descriptor is unused (EU1002)
net/pb/net.pb.go:270:25 method (*GetLogRequest).XXX_Unmarshal is unused (EU1002)
net/pb/net.pb.go:273:25 method (*GetLogRequest).XXX_Marshal is unused (EU1002)
net/pb/net.pb.go:285:25 method (*GetLogRequest).XXX_Merge is unused (EU1002)
net/pb/net.pb.go:288:25 method (*GetLogRequest).XXX_Size is unused (EU1002)
net/pb/net.pb.go:291:25 method (*GetLogRequest).XXX_DiscardUnknown is unused (EU1002)
net/pb/net.pb.go:300:23 method (*GetLogReply).Reset is unused (EU1002)
net/pb/net.pb.go:301:23 method (*GetLogReply).String is unused (EU1002)
net/pb/net.pb.go:302:21 method (*GetLogReply).ProtoMessage is unused (EU1002)
net/pb/net.pb.go:303:21 method (*GetLogReply).Descriptor is unused (EU1002)
net/pb/net.pb.go:306:23 method (*GetLogReply).XXX_Unmarshal is unused (EU1002)
net/pb/net.pb.go:309:23 method (*GetLogReply).XXX_Marshal is unused (EU1002)
net/pb/net.pb.go:321:23 method (*GetLogReply).XXX_Merge is unused (EU1002)
net/pb/net.pb.go:324:23 method (*GetLogReply).XXX_Size is unused (EU1002)
net/pb/net.pb.go:327:23 method (*GetLogReply).XXX_DiscardUnknown is unused (EU1002)
net/pb/net.pb.go:337:26 method (*PushLogRequest).Reset is unused (EU1002)
net/pb/net.pb.go:338:26 method (*PushLogRequest).String is unused (EU1002)
net/pb/net.pb.go:339:24 method (*PushLogRequest).ProtoMessage is unused (EU1002)
net/pb/net.pb.go:340:24 method (*PushLogRequest).Descriptor is unused (EU1002)
net/pb/net.pb.go:343:26 method (*PushLogRequest).XXX_Unmarshal is unused (EU1002)
net/pb/net.pb.go:346:26 method (*PushLogRequest).XXX_Marshal is unused (EU1002)
net/pb/net.pb.go:358:26 method (*PushLogRequest).XXX_Merge is unused (EU1002)
net/pb/net.pb.go:361:26 method (*PushLogRequest).XXX_Size is unused (EU1002)
net/pb/net.pb.go:364:26 method (*PushLogRequest).XXX_DiscardUnknown is unused (EU1002)
net/pb/net.pb.go:370:26 method (*PushLogRequest).GetBody is unused (EU1002)
net/pb/net.pb.go:388:31 method (*PushLogRequest_Body).Reset is unused (EU1002)
net/pb/net.pb.go:389:31 method (*PushLogRequest_Body).String is unused (EU1002)
net/pb/net.pb.go:390:29 method (*PushLogRequest_Body).ProtoMessage is unused (EU1002)
net/pb/net.pb.go:391:29 method (*PushLogRequest_Body).Descriptor is unused (EU1002)
net/pb/net.pb.go:394:31 method (*PushLogRequest_Body).XXX_Unmarshal is unused (EU1002)
net/pb/net.pb.go:397:31 method (*PushLogRequest_Body).XXX_Marshal is unused (EU1002)
net/pb/net.pb.go:409:31 method (*PushLogRequest_Body).XXX_Merge is unused (EU1002)
net/pb/net.pb.go:412:31 method (*PushLogRequest_Body).XXX_Size is unused (EU1002)
net/pb/net.pb.go:415:31 method (*PushLogRequest_Body).XXX_DiscardUnknown is unused (EU1002)
net/pb/net.pb.go:421:31 method (*PushLogRequest_Body).GetSchemaID is unused (EU1002)
net/pb/net.pb.go:428:31 method (*PushLogRequest_Body).GetLog is unused (EU1002)
net/pb/net.pb.go:438:29 method (*GetHeadLogRequest).Reset is unused (EU1002)
net/pb/net.pb.go:439:29 method (*GetHeadLogRequest).String is unused (EU1002)
net/pb/net.pb.go:440:27 method (*GetHeadLogRequest).ProtoMessage is unused (EU1002)
net/pb/net.pb.go:441:27 method (*GetHeadLogRequest).Descriptor is unused (EU1002)
net/pb/net.pb.go:444:29 method (*GetHeadLogRequest).XXX_Unmarshal is unused (EU1002)
net/pb/net.pb.go:447:29 method (*GetHeadLogRequest).XXX_Marshal is unused (EU1002)
net/pb/net.pb.go:459:29 method (*GetHeadLogRequest).XXX_Merge is unused (EU1002)
net/pb/net.pb.go:462:29 method (*GetHeadLogRequest).XXX_Size is unused (EU1002)
net/pb/net.pb.go:465:29 method (*GetHeadLogRequest).XXX_DiscardUnknown is unused (EU1002)
net/pb/net.pb.go:474:24 method (*PushLogReply).Reset is unused (EU1002)
net/pb/net.pb.go:475:24 method (*PushLogReply).String is unused (EU1002)
net/pb/net.pb.go:476:22 method (*PushLogReply).ProtoMessage is unused (EU1002)
net/pb/net.pb.go:477:22 method (*PushLogReply).Descriptor is unused (EU1002)
net/pb/net.pb.go:480:24 method (*PushLogReply).XXX_Unmarshal is unused (EU1002)
net/pb/net.pb.go:483:24 method (*PushLogReply).XXX_Marshal is unused (EU1002)
net/pb/net.pb.go:495:24 method (*PushLogReply).XXX_Merge is unused (EU1002)
net/pb/net.pb.go:498:24 method (*PushLogReply).XXX_Size is unused (EU1002)
net/pb/net.pb.go:501:24 method (*PushLogReply).XXX_DiscardUnknown is unused (EU1002)
net/pb/net.pb.go:510:27 method (*GetHeadLogReply).Reset is unused (EU1002)
net/pb/net.pb.go:511:27 method (*GetHeadLogReply).String is unused (EU1002)
net/pb/net.pb.go:512:25 method (*GetHeadLogReply).ProtoMessage is unused (EU1002)
net/pb/net.pb.go:513:25 method (*GetHeadLogReply).Descriptor is unused (EU1002)
net/pb/net.pb.go:516:27 method (*GetHeadLogReply).XXX_Unmarshal is unused (EU1002)
net/pb/net.pb.go:519:27 method (*GetHeadLogReply).XXX_Marshal is unused (EU1002)
net/pb/net.pb.go:531:27 method (*GetHeadLogReply).XXX_Merge is unused (EU1002)
net/pb/net.pb.go:534:27 method (*GetHeadLogReply).XXX_Size is unused (EU1002)
net/pb/net.pb.go:537:27 method (*GetHeadLogReply).XXX_DiscardUnknown is unused (EU1002)
net/pb/net.pb.go:607:2 method GetDocGraph is unused (EU1002)
net/pb/net.pb.go:615:2 method GetHeadLog is unused (EU1002)
net/pb/net.pb.go:611:2 method GetLog is unused (EU1002)
net/pb/net.pb.go:609:2 method PushDocGraph is unused (EU1002)
net/pb/net.pb.go:626:25 method (*serviceClient).GetDocGraph is unused (EU1002)
net/pb/net.pb.go:635:25 method (*serviceClient).PushDocGraph is unused (EU1002)
net/pb/net.pb.go:644:25 method (*serviceClient).GetLog is unused (EU1002)
net/pb/net.pb.go:662:25 method (*serviceClient).GetHeadLog is unused (EU1002)
net/pb/net.pb.go:828:20 method (*Document).Marshal is unused (EU1002)
net/pb/net.pb.go:838:20 method (*Document).MarshalTo is unused (EU1002)
net/pb/net.pb.go:875:24 method (*Document_Log).Marshal is unused (EU1002)
net/pb/net.pb.go:885:24 method (*Document_Log).MarshalTo is unused (EU1002)
net/pb/net.pb.go:905:30 method (*GetDocGraphRequest).Marshal is unused (EU1002)
net/pb/net.pb.go:915:30 method (*GetDocGraphRequest).MarshalTo is unused (EU1002)
net/pb/net.pb.go:928:28 method (*GetDocGraphReply).Marshal is unused (EU1002)
net/pb/net.pb.go:938:28 method (*GetDocGraphReply).MarshalTo is unused (EU1002)
net/pb/net.pb.go:951:31 method (*PushDocGraphRequest).Marshal is unused (EU1002)
net/pb/net.pb.go:961:31 method (*PushDocGraphRequest).MarshalTo is unused (EU1002)
net/pb/net.pb.go:974:29 method (*PushDocGraphReply).Marshal is unused (EU1002)
net/pb/net.pb.go:984:29 method (*PushDocGraphReply).MarshalTo is unused (EU1002)
net/pb/net.pb.go:997:25 method (*GetLogRequest).Marshal is unused (EU1002)
net/pb/net.pb.go:1007:25 method (*GetLogRequest).MarshalTo is unused (EU1002)
net/pb/net.pb.go:1020:23 method (*GetLogReply).Marshal is unused (EU1002)
net/pb/net.pb.go:1030:23 method (*GetLogReply).MarshalTo is unused (EU1002)
net/pb/net.pb.go:1053:26 method (*PushLogRequest).MarshalTo is unused (EU1002)
net/pb/net.pb.go:1078:31 method (*PushLogRequest_Body).Marshal is unused (EU1002)
net/pb/net.pb.go:1088:31 method (*PushLogRequest_Body).MarshalTo is unused (EU1002)
net/pb/net.pb.go:1144:29 method (*GetHeadLogRequest).Marshal is unused (EU1002)
net/pb/net.pb.go:1154:29 method (*GetHeadLogRequest).MarshalTo is unused (EU1002)
net/pb/net.pb.go:1167:24 method (*PushLogReply).Marshal is unused (EU1002)
net/pb/net.pb.go:1177:24 method (*PushLogReply).MarshalTo is unused (EU1002)
net/pb/net.pb.go:1190:27 method (*GetHeadLogReply).Marshal is unused (EU1002)
net/pb/net.pb.go:1200:27 method (*GetHeadLogReply).MarshalTo is unused (EU1002)
net/server.go:357:15 method (addr).Network is unused (EU1002)
net/utils/util.go:27:6 function DefaultBoostrapPeers is unused (EU1002)
node/options.go:63:6 function ListenTCPAddrStrings is unused (EU1002)
node/options.go:75:6 function ListenAddrs is unused (EU1002)
query/graphql/parser/commit.go:22:2 constant NoneCommitType is unused (EU1002)
query/graphql/parser/commit.go:59:23 method (CommitSelect).GetStatement is unused (EU1002)
query/graphql/parser/mutation.go:24:2 constant NoneMutationType is unused (EU1002)
query/graphql/parser/mutation.go:50:6 function NewObjectPayload is unused (EU1002)
query/graphql/parser/mutation.go:108:19 method (Mutation).GetStatement is unused (EU1002)
query/graphql/parser/parser.go:18:2 method GetStatement is unused (EU1002)
query/graphql/parser/query.go:24:2 constant NoneSelection is unused (EU1002)
query/graphql/parser/query.go:70:16 method (Query).GetStatement is unused (EU1002)
query/graphql/parser/query.go:81:30 method (OperationDefinition).GetStatement is unused (EU1002)
query/graphql/parser/query.go:127:17 method (Select).GetRoot is unused (EU1002)
query/graphql/parser/query.go:131:17 method (Select).GetStatement is unused (EU1002)
query/graphql/parser/query.go:158:16 method (Field).GetRoot is unused (EU1002)
query/graphql/parser/query.go:175:16 method (Field).GetStatement is unused (EU1002)
query/graphql/planner/commit.go:187:31 method (*commitSelectTopNode).Append is unused (EU1002)
query/graphql/planner/multi.go:36:2 method ReplaceChildAt is unused (EU1002)
query/graphql/planner/multi.go:291:24 method (*parallelNode).ReplaceChildAt is unused (EU1002)
query/graphql/planner/planner.go:79:6 struct ExecutionContext is unused (EU1002)
query/graphql/planner/planner.go:83:6 struct PlanContext is unused (EU1002)
query/graphql/planner/planner.go:87:6 struct Statement is unused (EU1002)
query/graphql/planner/planner.go:453:19 method (*Planner).MakePlan is unused (EU1002)
query/graphql/planner/scan.go:123:20 method (*scanNode).Merge is unused (EU1002)
query/graphql/planner/type_join.go:127:25 method (*typeIndexJoin).Merge is unused (EU1002)

</details>

I did total 3 passes of this so far, but all aren't necessarily accurate indication of unused symbols.

Note: I know some interfaces have too much removed from them, fixing that soon.