### PR TITLE
tools: Cleanup linter config file

### DIFF
--- a/tools/configs/golangci.yaml
+++ b/tools/configs/golangci.yaml
@@ -4,7 +4,7 @@
 run:
   concurrency: 8
 
-  # timeout for analysis.
+  # timeout for analysis, example 30s, 5m.
   timeout: 5m
 
   # exit code when at least one issue was found.


### PR DESCRIPTION
### RELATED ISSUE(S):
Resolves #399

### DESCRIPTION:
Removed all unused linters from the `golangci.yaml` config file to keep it in a clean state. From now on only add configs for the linters we do need.