### PR TITLE
tools: Add the `gofmt` linter rule.

### DIFF
--- a/tools/configs/golangci.yaml
+++ b/tools/configs/golangci.yaml
@@ -24,7 +24,7 @@ run:
   # "/" will be replaced by current OS file path separator to properly work
   # on Windows.
   skip-dirs:
-    - src/external_libs
+    - net/
 
   # Enables skipping of directories:
   #   vendor$, third_party$, testdata$, examples$, Godeps$, builtin$
@@ -168,7 +168,6 @@ issues:
       text: "SA9003:"
 
     # Exclude running header check in these paths
-    # - path: '(net|datastore)'
     - path: '(net|datastore/badger/v3/compat_logger.go|datastore/badger/v3/datastore.go)'
       linters:
         - goheader
@@ -249,6 +248,10 @@ linters-settings:
     exclude_godoc_examples: false
 
 
+  gofmt:
+    simplify: true
+
+
   goheader:
     values:
       const:
@@ -274,6 +277,7 @@ linters-settings:
     template-path:
       # also as alternative of directive 'template' you may put the path to file with the template source
 
+
   gosimple:
     # Select the Go version to target.
     go: '1.17'
@@ -282,6 +286,7 @@ linters-settings:
     # Turn on all except (these are disabled):
     # - S1038 - Unnecessarily complex way of printing formatted string. Which said
     #   instead of using fmt.Print(fmt.Sprintf(...)), one can use fmt.Printf(...).
+
 
   govet:
     # report about shadowed variables
@@ -331,24 +336,6 @@ linters-settings:
     go: '1.17'
     # https://staticcheck.io/docs/options#checks
     checks: [ "all" ]
-
-
-  stylecheck:
-    # Select the Go version to target.
-    go: '1.17'
-    # https://staticcheck.io/docs/options#checks
-    checks: [ "all", "-ST1000", "-ST1003", "-ST1016", "-ST1020", "-ST1021", "-ST1022" ]
-    # https://staticcheck.io/docs/options#dot_import_whitelist
-    dot-import-whitelist:
-      - fmt
-    # https://staticcheck.io/docs/options#initialisms
-    initialisms: [ "ACL", "API", "ASCII", "CPU", "CSS", "DNS", "EOF",
-      "GUID", "HTML", "HTTP", "HTTPS", "ID", "IP", "JSON", "QPS", "RAM",
-      "RPC", "SLA", "SMTP", "SQL", "SSH", "TCP", "TLS", "TTL", "UDP", "UI",
-      "GID", "UID", "UUID", "URI", "URL", "UTF8", "VM", "XML", "XMPP", "XSRF", "XSS"
-    ]
-    # https://staticcheck.io/docs/options#http_status_code_whitelist
-    http-status-code-whitelist: [ "200", "400", "404", "500" ]
 
 
   unused:


### PR DESCRIPTION
### RELATED ISSUE(S):
Resolves #404 

### DESCRIPTION:
Adds the linter `gofmt` to ensure we have `gofmt` ran on all the go files (as sometimes if an IDE or text editor's `gofmt` is tripping up or disabled).
