### PR TITLE
tools: Adhere to `gofumpt` linter.

### DIFF
--- a/api/http/api.go
+++ b/api/http/api.go
@@ -29,9 +29,7 @@ import (
 	"github.com/sourcenetwork/defradb/logging"
 )
 
-var (
-	log = logging.MustNewLogger("defra.http")
-)
+var log = logging.MustNewLogger("defra.http")
 
 type Server struct {
 	db     client.DB

--- a/bench/bench_util.go
+++ b/bench/bench_util.go
@@ -129,7 +129,6 @@ func SetupDBAndCollections(
 	}
 
 	return db, collections, nil
-
 }
 
 // Loads the given test database using the provided fixture context.
@@ -226,7 +225,6 @@ func BackfillBenchmarkDB(
 	case err := <-errCh:
 		return nil, err
 	}
-
 }
 
 type dbInfo interface {

--- a/bench/fixtures/data.go
+++ b/bench/fixtures/data.go
@@ -10,15 +10,13 @@
 
 package fixtures
 
-var (
-	gTypeToGQLType = map[string]string{
-		"int":     "Int",
-		"string":  "String",
-		"float64": "Float",
-		"float32": "Float",
-		"bool":    "Boolean",
-	}
-)
+var gTypeToGQLType = map[string]string{
+	"int":     "Int",
+	"string":  "String",
+	"float64": "Float",
+	"float32": "Float",
+	"bool":    "Boolean",
+}
 
 type User struct {
 	Name     string `faker:"name"`

--- a/bench/fixtures/fixtures.go
+++ b/bench/fixtures/fixtures.go
@@ -21,11 +21,9 @@ import (
 	"github.com/bxcodec/faker"
 )
 
-var (
-	registeredFixtures = map[string][]interface{}{
-		"user_simple": {User{}},
-	}
-)
+var registeredFixtures = map[string][]interface{}{
+	"user_simple": {User{}},
+}
 
 type Generator struct {
 	ctx context.Context

--- a/bench/query/planner/simple_test.go
+++ b/bench/query/planner/simple_test.go
@@ -17,8 +17,7 @@ import (
 	"github.com/sourcenetwork/defradb/bench/fixtures"
 )
 
-var (
-	userSimpleQuery = `
+var userSimpleQuery = `
 	query {
 		User {
 			_key
@@ -29,7 +28,6 @@ var (
 		}
 	}
 	`
-)
 
 func Benchmark_Planner_UserSimple_ParseQuery(b *testing.B) {
 	ctx := context.Background()

--- a/bench/query/simple/simple_test.go
+++ b/bench/query/simple/simple_test.go
@@ -17,8 +17,7 @@ import (
 	"github.com/sourcenetwork/defradb/bench/fixtures"
 )
 
-var (
-	userSimpleQuery = `
+var userSimpleQuery = `
 	query {
 		User {
 			_key
@@ -29,7 +28,6 @@ var (
 		}
 	}
 	`
-)
 
 func Benchmark_Query_UserSimple_Query_Sync_1(b *testing.B) {
 	ctx := context.Background()

--- a/bench/query/simple/utils.go
+++ b/bench/query/simple/utils.go
@@ -23,7 +23,7 @@ import (
 )
 
 var (
-//log = logging.MustNewLogger("defra.bench")
+// log = logging.MustNewLogger("defra.bench")
 )
 
 func runQueryBenchGet(

--- a/bench/query/simple/with_filter_test.go
+++ b/bench/query/simple/with_filter_test.go
@@ -17,8 +17,7 @@ import (
 	"github.com/sourcenetwork/defradb/bench/fixtures"
 )
 
-var (
-	userSimpleWithFilterQuery = `
+var userSimpleWithFilterQuery = `
 	query {
 		User(filter: {Age: {_gt: 10}}) {
 			_key
@@ -29,7 +28,6 @@ var (
 		}
 	}
 	`
-)
 
 func Benchmark_Query_UserSimple_Query_WithFilter_Sync_1(b *testing.B) {
 	ctx := context.Background()

--- a/bench/query/simple/with_limit_offset_test.go
+++ b/bench/query/simple/with_limit_offset_test.go
@@ -17,8 +17,7 @@ import (
 	"github.com/sourcenetwork/defradb/bench/fixtures"
 )
 
-var (
-	userSimpleWithLimitOffsetQuery = `
+var userSimpleWithLimitOffsetQuery = `
 	query {
 		User(limit: 10, offset: 5) {
 			_key
@@ -29,7 +28,6 @@ var (
 		}
 	}
 	`
-)
 
 func Benchmark_Query_UserSimple_Query_WithLimitOffset_Sync_1(b *testing.B) {
 	ctx := context.Background()

--- a/bench/query/simple/with_multi_lookup_test.go
+++ b/bench/query/simple/with_multi_lookup_test.go
@@ -17,9 +17,8 @@ import (
 	"github.com/sourcenetwork/defradb/bench/fixtures"
 )
 
-var (
-	// 10x dockey will be replaced in the bench runner func
-	userSimpleWithMultiLookupQuery = `
+// 10x dockey will be replaced in the bench runner func
+var userSimpleWithMultiLookupQuery = `
 	query {
 		User(dockeys: ["{{dockey}}", "{{dockey}}", "{{dockey}}", "{{dockey}}", "{{dockey}}", "{{dockey}}", "{{dockey}}", "{{dockey}}", "{{dockey}}", "{{dockey}}"]) {
 			_key
@@ -30,7 +29,6 @@ var (
 		}
 	}
 	`
-)
 
 func Benchmark_Query_UserSimple_Query_WithMultiLookup_Sync_10(b *testing.B) {
 	ctx := context.Background()

--- a/bench/query/simple/with_single_lookup_test.go
+++ b/bench/query/simple/with_single_lookup_test.go
@@ -17,9 +17,8 @@ import (
 	"github.com/sourcenetwork/defradb/bench/fixtures"
 )
 
-var (
-	// dockey will be replaced in the bench runner func
-	userSimpleWithSingleLookupQuery = `
+// dockey will be replaced in the bench runner func
+var userSimpleWithSingleLookupQuery = `
 	query {
 		User(dockey: "{{dockey}}") {
 			_key
@@ -30,7 +29,6 @@ var (
 		}
 	}
 	`
-)
 
 func Benchmark_Query_UserSimple_Query_WithSingleLookup_Sync_1(b *testing.B) {
 	ctx := context.Background()

--- a/bench/query/simple/with_sort_test.go
+++ b/bench/query/simple/with_sort_test.go
@@ -17,8 +17,7 @@ import (
 	"github.com/sourcenetwork/defradb/bench/fixtures"
 )
 
-var (
-	userSimpleWithSortQuery = `
+var userSimpleWithSortQuery = `
 	query {
 		User(order: {Age: ASC}) {
 			_key
@@ -29,7 +28,6 @@ var (
 		}
 	}
 	`
-)
 
 func Benchmark_Query_UserSimple_Query_WithSort_Sync_1(b *testing.B) {
 	ctx := context.Background()

--- a/bench/storage/get_test.go
+++ b/bench/storage/get_test.go
@@ -16,11 +16,9 @@ import (
 	"testing"
 )
 
-var (
-	valueSize = []int{
-		64, 128, 256, 512, 1024,
-	}
-)
+var valueSize = []int{
+	64, 128, 256, 512, 1024,
+}
 
 func Benchmark_Storage_Simple_Read_Sync_1_1(b *testing.B) {
 	for _, vsz := range valueSize {

--- a/bench/storage/put_many_test.go
+++ b/bench/storage/put_many_test.go
@@ -17,7 +17,6 @@ import (
 )
 
 func Benchmark_Storage_Simple_WriteMany_Sync_0_1(b *testing.B) {
-
 	for _, vsz := range valueSize {
 		b.Run(fmt.Sprintf("ValueSize:%04d", vsz), func(b *testing.B) {
 			ctx := context.Background()
@@ -30,7 +29,6 @@ func Benchmark_Storage_Simple_WriteMany_Sync_0_1(b *testing.B) {
 }
 
 func Benchmark_Storage_Simple_WriteMany_Sync_0_10(b *testing.B) {
-
 	for _, vsz := range valueSize {
 		b.Run(fmt.Sprintf("ValueSize:%04d", vsz), func(b *testing.B) {
 			ctx := context.Background()
@@ -43,7 +41,6 @@ func Benchmark_Storage_Simple_WriteMany_Sync_0_10(b *testing.B) {
 }
 
 func Benchmark_Storage_Simple_WriteMany_Sync_0_100(b *testing.B) {
-
 	for _, vsz := range valueSize {
 		b.Run(fmt.Sprintf("ValueSize:%04d", vsz), func(b *testing.B) {
 			ctx := context.Background()
@@ -56,7 +53,6 @@ func Benchmark_Storage_Simple_WriteMany_Sync_0_100(b *testing.B) {
 }
 
 func Benchmark_Storage_Simple_WriteMany_Sync_100_1(b *testing.B) {
-
 	for _, vsz := range valueSize {
 		b.Run(fmt.Sprintf("ValueSize:%04d", vsz), func(b *testing.B) {
 			ctx := context.Background()
@@ -69,7 +65,6 @@ func Benchmark_Storage_Simple_WriteMany_Sync_100_1(b *testing.B) {
 }
 
 func Benchmark_Storage_Simple_WriteMany_Sync_100_10(b *testing.B) {
-
 	for _, vsz := range valueSize {
 		b.Run(fmt.Sprintf("ValueSize:%04d", vsz), func(b *testing.B) {
 			ctx := context.Background()
@@ -82,7 +77,6 @@ func Benchmark_Storage_Simple_WriteMany_Sync_100_10(b *testing.B) {
 }
 
 func Benchmark_Storage_Simple_WriteMany_Sync_100_100(b *testing.B) {
-
 	for _, vsz := range valueSize {
 		b.Run(fmt.Sprintf("ValueSize:%04d", vsz), func(b *testing.B) {
 			ctx := context.Background()

--- a/bench/storage/put_test.go
+++ b/bench/storage/put_test.go
@@ -17,7 +17,6 @@ import (
 )
 
 func Benchmark_Storage_Simple_Write_Sync_0_1(b *testing.B) {
-
 	for _, vsz := range valueSize {
 		b.Run(fmt.Sprintf("ValueSize:%04d", vsz), func(b *testing.B) {
 			ctx := context.Background()
@@ -30,7 +29,6 @@ func Benchmark_Storage_Simple_Write_Sync_0_1(b *testing.B) {
 }
 
 func Benchmark_Storage_Simple_Write_Sync_0_10(b *testing.B) {
-
 	for _, vsz := range valueSize {
 		b.Run(fmt.Sprintf("ValueSize:%04d", vsz), func(b *testing.B) {
 			ctx := context.Background()
@@ -43,7 +41,6 @@ func Benchmark_Storage_Simple_Write_Sync_0_10(b *testing.B) {
 }
 
 func Benchmark_Storage_Simple_Write_Sync_0_100(b *testing.B) {
-
 	for _, vsz := range valueSize {
 		b.Run(fmt.Sprintf("ValueSize:%04d", vsz), func(b *testing.B) {
 			ctx := context.Background()
@@ -56,7 +53,6 @@ func Benchmark_Storage_Simple_Write_Sync_0_100(b *testing.B) {
 }
 
 func Benchmark_Storage_Simple_Write_Sync_100_1(b *testing.B) {
-
 	for _, vsz := range valueSize {
 		b.Run(fmt.Sprintf("ValueSize:%04d", vsz), func(b *testing.B) {
 			ctx := context.Background()
@@ -69,7 +65,6 @@ func Benchmark_Storage_Simple_Write_Sync_100_1(b *testing.B) {
 }
 
 func Benchmark_Storage_Simple_Write_Sync_100_10(b *testing.B) {
-
 	for _, vsz := range valueSize {
 		b.Run(fmt.Sprintf("ValueSize:%04d", vsz), func(b *testing.B) {
 			ctx := context.Background()
@@ -82,7 +77,6 @@ func Benchmark_Storage_Simple_Write_Sync_100_10(b *testing.B) {
 }
 
 func Benchmark_Storage_Simple_Write_Sync_100_100(b *testing.B) {
-
 	for _, vsz := range valueSize {
 		b.Run(fmt.Sprintf("ValueSize:%04d", vsz), func(b *testing.B) {
 			ctx := context.Background()

--- a/bench/storage/utils.go
+++ b/bench/storage/utils.go
@@ -64,7 +64,6 @@ func runStorageBenchTxnGet(
 	doSync bool,
 ) error {
 	db, err := benchutils.NewTestDB(ctx, b)
-
 	if err != nil {
 		return err
 	}
@@ -104,7 +103,6 @@ func runStorageBenchTxnIterator(
 	doSync bool,
 ) error {
 	db, err := benchutils.NewTestDB(ctx, b)
-
 	if err != nil {
 		return err
 	}
@@ -217,7 +215,7 @@ func runStorageBenchPutMany(
 		return err
 	}
 
-	//shuffle keys
+	// shuffle keys
 	// rand.Shuffle(len(keys), func(i, j int) {
 	// 	keys[i], keys[j] = keys[j], keys[i]
 	// })

--- a/cli/defradb/cmd/config.go
+++ b/cli/defradb/cmd/config.go
@@ -112,18 +112,16 @@ func getLogLevelFromString(logLevel string) logging.LogLevelOption {
 	}
 }
 
-var (
-	defaultConfig = Config{
-		Database: Options{
-			Address: "localhost:9181",
-			Store:   "badger",
-			Badger: BadgerOptions{
-				Path: "$HOME/.defradb/data",
-			},
+var defaultConfig = Config{
+	Database: Options{
+		Address: "localhost:9181",
+		Store:   "badger",
+		Badger: BadgerOptions{
+			Path: "$HOME/.defradb/data",
 		},
-		Net: NetOptions{
-			P2PAddress: "/ip4/0.0.0.0/tcp/9171",
-			TCPAddress: "/ip4/0.0.0.0/tcp/9161",
-		},
-	}
-)
+	},
+	Net: NetOptions{
+		P2PAddress: "/ip4/0.0.0.0/tcp/9171",
+		TCPAddress: "/ip4/0.0.0.0/tcp/9161",
+	},
+}

--- a/cli/defradb/cmd/schema_add.go
+++ b/cli/defradb/cmd/schema_add.go
@@ -25,9 +25,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-var (
-	schemaFile string
-)
+var schemaFile string
 
 // addCmd represents the add command
 var addCmd = &cobra.Command{

--- a/cli/defradb/cmd/version.go
+++ b/cli/defradb/cmd/version.go
@@ -34,7 +34,6 @@ func (v versionInfo) FullVersion() string {
 		color.GreenString(DefraVersion.Commit),
 		color.YellowString(DefraVersion.Date),
 	)
-
 }
 
 func (v versionInfo) JsonVersion() (string, error) {

--- a/client/descriptions.go
+++ b/client/descriptions.go
@@ -94,7 +94,7 @@ type SchemaDescription struct {
 	Fields   []FieldDescription
 }
 
-//IsEmpty returns true if the SchemaDescription is empty and uninitialized
+// IsEmpty returns true if the SchemaDescription is empty and uninitialized
 func (sd SchemaDescription) IsEmpty() bool {
 	return len(sd.Fields) == 0
 }

--- a/client/dockey.go
+++ b/client/dockey.go
@@ -31,13 +31,11 @@ var validVersions = map[uint16]bool{
 	v0: true,
 }
 
-var (
-	// NamespaceSDNDocKeyV0 reserved domain namespace for Source Data Network (SDN)
-	// Design a more appropriate system for future proofing doc key versions, ensuring
-	// backwards compatability. RE: CID
-	// *At the moment this is an random uuidV4
-	namespaceSDNDocKeyV0 = uuid.Must(uuid.FromString("c94acbfa-dd53-40d0-97f3-29ce16c333fc"))
-)
+// NamespaceSDNDocKeyV0 reserved domain namespace for Source Data Network (SDN)
+// Design a more appropriate system for future proofing doc key versions, ensuring
+// backwards compatability. RE: CID
+// *At the moment this is an random uuidV4
+var namespaceSDNDocKeyV0 = uuid.Must(uuid.FromString("c94acbfa-dd53-40d0-97f3-29ce16c333fc"))
 
 // versionToNamespace is a convenience for mapping between Version number and its UUID Namespace
 // nolint

--- a/client/document.go
+++ b/client/document.go
@@ -300,13 +300,13 @@ func (doc *Document) setAndParseType(field string, value interface{}) error {
 		// case int64:
 
 		// Check if its actually a float or just an int
-		if float64(int64(val)) == val { //int
+		if float64(int64(val)) == val { // int
 			err := doc.setCBOR(LWW_REGISTER, field, int64(val))
 			if err != nil {
 				return err
 			}
 
-		} else { //float
+		} else { // float
 			err := doc.setCBOR(LWW_REGISTER, field, val)
 			if err != nil {
 				return err
@@ -397,7 +397,7 @@ func (doc *Document) Bytes() ([]byte, error) {
 func (doc *Document) String() string {
 	docMap, err := doc.toMap()
 	if err != nil {
-		panic(err) //should we return (string, error)?
+		panic(err) // should we return (string, error)?
 	}
 
 	j, err := json.MarshalIndent(docMap, "", "\t")
@@ -445,7 +445,6 @@ func (doc *Document) toMap() (map[string]interface{}, error) {
 			}
 			docMap[k] = subDocMap
 		} else {
-
 		}
 		docMap[k] = value.Value()
 	}
@@ -471,7 +470,6 @@ func (doc *Document) toMapWithKey() (map[string]interface{}, error) {
 			}
 			docMap[k] = subDocMap
 		} else {
-
 		}
 		docMap[k] = value.Value()
 	}

--- a/client/document_test.go
+++ b/client/document_test.go
@@ -69,21 +69,21 @@ func TestNewFromJSON(t *testing.T) {
 	assert.Equal(t, doc.fields["Address"].Name(), "Address")
 	assert.Equal(t, doc.fields["Address"].Type(), OBJECT)
 
-	//values
+	// values
 	assert.Equal(t, doc.values[doc.fields["Name"]].Value(), "John")
 	assert.Equal(t, doc.values[doc.fields["Name"]].IsDocument(), false)
 	assert.Equal(t, doc.values[doc.fields["Age"]].Value(), int64(26))
 	assert.Equal(t, doc.values[doc.fields["Age"]].IsDocument(), false)
 	assert.Equal(t, doc.values[doc.fields["Address"]].IsDocument(), true)
 
-	//subdoc fields
+	// subdoc fields
 	subDoc := doc.values[doc.fields["Address"]].Value().(*Document)
 	assert.Equal(t, subDoc.fields["Street"].Name(), "Street")
 	assert.Equal(t, subDoc.fields["Street"].Type(), LWW_REGISTER)
 	assert.Equal(t, subDoc.fields["City"].Name(), "City")
 	assert.Equal(t, subDoc.fields["City"].Type(), LWW_REGISTER)
 
-	//subdoc values
+	// subdoc values
 	assert.Equal(t, subDoc.values[subDoc.fields["Street"]].Value(), "Main")
 	assert.Equal(t, subDoc.values[subDoc.fields["Street"]].IsDocument(), false)
 	assert.Equal(t, subDoc.values[subDoc.fields["City"]].Value(), "Toronto")
@@ -132,14 +132,14 @@ func TestSetWithJSON(t *testing.T) {
 	assert.Equal(t, doc.fields["Address"].Name(), "Address")
 	assert.Equal(t, doc.fields["Address"].Type(), OBJECT)
 
-	//values
+	// values
 	assert.Equal(t, doc.values[doc.fields["Name"]].Value(), "Alice")
 	assert.Equal(t, doc.values[doc.fields["Name"]].IsDocument(), false)
 	assert.Equal(t, doc.values[doc.fields["Age"]].Value(), int64(27))
 	assert.Equal(t, doc.values[doc.fields["Age"]].IsDocument(), false)
 	assert.Equal(t, doc.values[doc.fields["Address"]].IsDelete(), true)
 
-	//subdoc fields
+	// subdoc fields
 	// subDoc := doc.values[doc.fields["Address"]].Value().(*Document)
 	// assert.Equal(t, subDoc.fields["Street"].Name(), "Street")
 	// assert.Equal(t, subDoc.fields["Street"].Type(), client.LWW_REGISTER)

--- a/client/field.go
+++ b/client/field.go
@@ -13,7 +13,7 @@ package client
 // Field is an interface to interact with Fields inside a document
 type Field interface {
 	Name() string
-	Type() CType //TODO Abstract into a Field Type interface
+	Type() CType // TODO Abstract into a Field Type interface
 	SchemaType() string
 }
 

--- a/client/value.go
+++ b/client/value.go
@@ -22,7 +22,7 @@ type Value interface {
 	Type() CType
 	IsDirty() bool
 	Clean()
-	IsDelete() bool //todo: Update IsDelete naming
+	IsDelete() bool // todo: Update IsDelete naming
 	Delete()
 }
 

--- a/core/crdt/lwwreg.go
+++ b/core/crdt/lwwreg.go
@@ -15,9 +15,8 @@ import (
 
 	"bytes"
 	"context"
-	"fmt"
-
 	"errors"
+	"fmt"
 
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/core"

--- a/core/key.go
+++ b/core/key.go
@@ -66,7 +66,7 @@ var _ Key = (*PrimaryDataStoreKey)(nil)
 
 type HeadStoreKey struct {
 	DocKey  string
-	FieldId string //can be 'C'
+	FieldId string // can be 'C'
 	Cid     cid.Cid
 }
 

--- a/core/key_test.go
+++ b/core/key_test.go
@@ -44,7 +44,8 @@ func TestNewDataStoreKey_ReturnsCollectionIdAndIndexIdAndDocKeyAndFieldIdAndInst
 			CollectionId: collectionId,
 			DocKey:       docKey,
 			FieldId:      fieldId,
-			InstanceType: InstanceType(instanceType)},
+			InstanceType: InstanceType(instanceType),
+		},
 		result)
 	assert.Equal(t, "/"+collectionId+"/"+instanceType+"/"+docKey+"/"+fieldId, resultString)
 }

--- a/core/replicated.go
+++ b/core/replicated.go
@@ -18,10 +18,8 @@ import (
 	ipld "github.com/ipfs/go-ipld-format"
 )
 
-var (
-	// ErrMismatchedMergeType - Tying to merge two ReplicatedData of different types
-	ErrMismatchedMergeType = errors.New("Given type to merge does not match source")
-)
+// ErrMismatchedMergeType - Tying to merge two ReplicatedData of different types
+var ErrMismatchedMergeType = errors.New("Given type to merge does not match source")
 
 // ReplicatedData is a data type that allows concurrent writers
 // to deterministically merge other replicated data so as to

--- a/datastore/badger/v3/datastore.go
+++ b/datastore/badger/v3/datastore.go
@@ -112,11 +112,13 @@ func init() {
 		DefaultOptions.Options.MaxTableSize = 16 << 20*/
 }
 
-var _ ds.Datastore = (*Datastore)(nil)
-var _ ds.TxnDatastore = (*Datastore)(nil)
-var _ ds.TTLDatastore = (*Datastore)(nil)
-var _ ds.GCDatastore = (*Datastore)(nil)
-var _ ds.Batching = (*Datastore)(nil)
+var (
+	_ ds.Datastore    = (*Datastore)(nil)
+	_ ds.TxnDatastore = (*Datastore)(nil)
+	_ ds.TTLDatastore = (*Datastore)(nil)
+	_ ds.GCDatastore  = (*Datastore)(nil)
+	_ ds.Batching     = (*Datastore)(nil)
+)
 
 // NewDatastore creates a new badger datastore.
 //
@@ -526,8 +528,10 @@ func (b *batch) cancel() {
 	runtime.SetFinalizer(b, nil)
 }
 
-var _ ds.Datastore = (*txn)(nil)
-var _ ds.TTLDatastore = (*txn)(nil)
+var (
+	_ ds.Datastore    = (*txn)(nil)
+	_ ds.TTLDatastore = (*txn)(nil)
+)
 
 func (t *txn) Put(ctx context.Context, key ds.Key, value []byte) error {
 	t.ds.closeLk.RLock()
@@ -603,7 +607,6 @@ func (t *txn) setTTL(key ds.Key, ttl time.Duration) error {
 	return item.Value(func(data []byte) error {
 		return t.putWithTTL(key, data, ttl)
 	})
-
 }
 
 func (t *txn) Get(ctx context.Context, key ds.Key) ([]byte, error) {
@@ -758,7 +761,6 @@ func (t *txn) query(q dsq.Query) (dsq.Results, error) {
 				case <-qrb.Process.Closing():
 				}
 			}
-
 		}()
 		if t.ds.closed {
 			closedEarly = true

--- a/datastore/badger/v3/iterator.go
+++ b/datastore/badger/v3/iterator.go
@@ -109,7 +109,6 @@ func (iterator *BadgerIterator) IteratePrefix(
 				case <-iterator.resultsBuilder.Process.Closing():
 				}
 			}
-
 		}()
 		if iterator.txn.ds.closed {
 			iterator.closedEarly = true

--- a/datastore/blockstore.go
+++ b/datastore/blockstore.go
@@ -142,7 +142,6 @@ func (bs *bstore) DeleteBlock(ctx context.Context, k cid.Cid) error {
 //
 // AllKeysChan respects context.
 func (bs *bstore) AllKeysChan(ctx context.Context) (<-chan cid.Cid, error) {
-
 	// KeysOnly, because that would be _a lot_ of data.
 	q := dsq.Query{KeysOnly: true}
 	res, err := bs.store.Query(ctx, q)

--- a/datastore/store.go
+++ b/datastore/store.go
@@ -17,9 +17,7 @@ import (
 	"github.com/sourcenetwork/defradb/logging"
 )
 
-var (
-	log = logging.MustNewLogger("defradb.store")
-)
+var log = logging.MustNewLogger("defradb.store")
 
 // MultiStore is an interface wrapper around the 3 main types of stores needed for
 // MerkleCRDTs

--- a/datastore/wrappedStore.go
+++ b/datastore/wrappedStore.go
@@ -110,7 +110,6 @@ func (w *wrappedStore) Query(ctx context.Context, q dsq.Query) (dsq.Results, err
 // Split the query into a child query and a naive query. That way, we can make
 // the child datastore do as much work as possible.
 func (w *wrappedStore) prepareQuery(q dsq.Query) (naive, child dsq.Query) {
-
 	// First, put everything in the child query. Then, start taking things
 	// out.
 	child = q

--- a/db/base/compare.go
+++ b/db/base/compare.go
@@ -56,6 +56,7 @@ func compareBool(a, b bool) int {
 	}
 	return -1
 }
+
 func compareInt(a, b int64) int {
 	if a == b {
 		return 0
@@ -64,6 +65,7 @@ func compareInt(a, b int64) int {
 	}
 	return -1
 }
+
 func compareUint(a, b uint64) int {
 	if a == b {
 		return 0
@@ -72,6 +74,7 @@ func compareUint(a, b uint64) int {
 	}
 	return -1
 }
+
 func compareFloat(a, b float64) int {
 	if a == b {
 		return 0
@@ -80,6 +83,7 @@ func compareFloat(a, b float64) int {
 	}
 	return -1
 }
+
 func compareTime(a, b time.Time) int {
 	if a.Equal(b) {
 		return 0
@@ -88,9 +92,11 @@ func compareTime(a, b time.Time) int {
 	}
 	return -1
 }
+
 func compareString(a, b string) int {
 	return strings.Compare(a, b)
 }
+
 func compareBytes(a, b []byte) int {
 	return bytes.Compare(a, b)
 }

--- a/db/collection.go
+++ b/db/collection.go
@@ -13,6 +13,7 @@ package db
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/fxamacker/cbor/v2"
@@ -23,8 +24,6 @@ import (
 	"github.com/sourcenetwork/defradb/logging"
 	"github.com/sourcenetwork/defradb/merkle/crdt"
 	"github.com/sourcenetwork/defradb/utils"
-
-	"errors"
 
 	"github.com/ipfs/go-cid"
 	ds "github.com/ipfs/go-datastore"
@@ -748,7 +747,8 @@ func (c *collection) saveValueToMerkleCRDT(
 	txn datastore.Txn,
 	key core.DataStoreKey,
 	ctype client.CType,
-	args ...interface{}) (cid.Cid, error) {
+	args ...interface{},
+) (cid.Cid, error) {
 	switch ctype {
 	case client.LWW_REGISTER:
 		datatype, err := c.db.crdtFactory.InstanceWithStores(

--- a/db/collection_delete.go
+++ b/db/collection_delete.go
@@ -59,7 +59,6 @@ func (c *collection) DeleteWithKey(
 	ctx context.Context,
 	key client.DocKey,
 ) (*client.DeleteResult, error) {
-
 	txn, err := c.getTxn(ctx, false)
 	if err != nil {
 		return nil, err
@@ -81,7 +80,6 @@ func (c *collection) DeleteWithKeys(
 	ctx context.Context,
 	keys []client.DocKey,
 ) (*client.DeleteResult, error) {
-
 	txn, err := c.getTxn(ctx, false)
 	if err != nil {
 		return nil, err
@@ -102,7 +100,6 @@ func (c *collection) DeleteWithFilter(
 	ctx context.Context,
 	filter interface{},
 ) (*client.DeleteResult, error) {
-
 	txn, err := c.getTxn(ctx, false)
 	if err != nil {
 		return nil, err
@@ -116,7 +113,6 @@ func (c *collection) DeleteWithFilter(
 	}
 
 	return res, c.commitImplicitTxn(ctx, txn)
-
 }
 
 func (c *collection) deleteWithKey(
@@ -154,7 +150,6 @@ func (c *collection) deleteWithKeys(
 	txn datastore.Txn,
 	keys []client.DocKey,
 ) (*client.DeleteResult, error) {
-
 	results := &client.DeleteResult{
 		DocKeys: make([]string, 0),
 	}
@@ -164,7 +159,6 @@ func (c *collection) deleteWithKeys(
 
 		// Check this docKey actually exists.
 		found, err := c.exists(ctx, txn, dsKey)
-
 		if err != nil {
 			return nil, err
 		}
@@ -193,7 +187,6 @@ func (c *collection) deleteWithFilter(
 	txn datastore.Txn,
 	filter interface{},
 ) (*client.DeleteResult, error) {
-
 	// Do a selection query to scan through documents using the given filter.
 	query, err := c.makeSelectionQuery(ctx, txn, filter)
 	if err != nil {
@@ -272,8 +265,8 @@ func newDagDeleter(bstore datastore.DAGStore) dagDeleter {
 //   3) Deleting headstore state.
 func (c *collection) applyFullDelete(
 	ctx context.Context,
-	txn datastore.Txn, dockey core.PrimaryDataStoreKey) error {
-
+	txn datastore.Txn, dockey core.PrimaryDataStoreKey,
+) error {
 	// Check the docKey we have been given to delete with actually has a corresponding
 	//  document (i.e. document actually exists in the collection).
 	found, err := c.exists(ctx, txn, dockey)
@@ -356,7 +349,6 @@ func (d dagDeleter) run(ctx context.Context, targetCid cid.Cid) error {
 		// (A:x) --> (B:x) --> (C:x) --> (D:x) |
 		//                                     | --> (F:d) HEAD#2->cid2
 		return nil
-
 	} else if err != nil {
 		return err
 	}
@@ -372,8 +364,8 @@ func (d dagDeleter) run(ctx context.Context, targetCid cid.Cid) error {
 func (d dagDeleter) delete(
 	ctx context.Context,
 	targetCid cid.Cid,
-	targetBlock block.Block) error {
-
+	targetBlock block.Block,
+) error {
 	targetNode, err := dag.DecodeProtobuf(targetBlock.RawData())
 	if err != nil {
 		return err

--- a/db/collection_update.go
+++ b/db/collection_update.go
@@ -220,7 +220,6 @@ func (c *collection) updateWithFilter(
 	filter interface{},
 	updater interface{},
 ) (*client.UpdateResult, error) {
-
 	patch, err := parseUpdater(updater)
 	if err != nil {
 		return nil, err
@@ -545,7 +544,8 @@ func (c *collection) applyMergePatchOp( //nolint:unused
 	docKey string,
 	field string,
 	currentVal interface{},
-	targetVal interface{}) error {
+	targetVal interface{},
+) error {
 	return nil
 }
 
@@ -628,7 +628,6 @@ func (c *collection) getTargetKeyForPatchPath(
 	if length == 0 {
 		return "", errors.New("Invalid patch op path")
 	} else if length > 0 {
-
 	}
 	return "", nil
 }

--- a/db/db.go
+++ b/db/db.go
@@ -216,7 +216,6 @@ func printStore(ctx context.Context, store datastore.DSReaderWriter) {
 	}
 
 	results, err := store.Query(ctx, q)
-
 	if err != nil {
 		panic(err)
 	}

--- a/db/fetcher/dag.go
+++ b/db/fetcher/dag.go
@@ -25,13 +25,11 @@ import (
 
 // @todo: Generalize all Fetchers into an shared Fetcher utility
 
-type BlockFetcher struct {
-}
+type BlockFetcher struct{}
 
 // HeadFetcher is a utility to incrementally fetch all the MerkleCRDT
 // heads of a given doc/field
 type HeadFetcher struct {
-
 	// Commented because this code is not used yet according to the linter.
 	// txn   datastore.Txn
 
@@ -93,7 +91,6 @@ func (hf *HeadFetcher) nextKey() (bool, error) {
 	hf.kvEnd = done
 	if hf.kvEnd {
 		return true, nil
-
 	}
 	return false, nil
 }

--- a/db/fetcher/fetcher.go
+++ b/db/fetcher/fetcher.go
@@ -37,9 +37,7 @@ type Fetcher interface {
 	Close() error
 }
 
-var (
-	_ Fetcher = (*DocumentFetcher)(nil)
-)
+var _ Fetcher = (*DocumentFetcher)(nil)
 
 type DocumentFetcher struct {
 	col     *client.CollectionDescription

--- a/db/fetcher/versioned.go
+++ b/db/fetcher/versioned.go
@@ -28,10 +28,8 @@ import (
 	"github.com/pkg/errors"
 )
 
-var (
-	// interface check
-	_ Fetcher = (*VersionedFetcher)(nil)
-)
+// interface check
+var _ Fetcher = (*VersionedFetcher)(nil)
 
 // HistoryFetcher is like the normal DocumentFetcher, except it is able to traverse
 // to a specific version in the documents history graph, and return the fetched
@@ -113,7 +111,6 @@ func (vf *VersionedFetcher) Init(
 	// run the DF init, VersionedFetchers only supports the Primary (0) index
 	vf.DocumentFetcher = new(DocumentFetcher)
 	return vf.DocumentFetcher.Init(col, fields, reverse)
-
 }
 
 // Start serializes the correct state accoriding to the Key and CID

--- a/db/fetcher/versioned_test.go
+++ b/db/fetcher/versioned_test.go
@@ -32,61 +32,59 @@ type update struct {
 	cid     string
 }
 
-var (
-	testStates = []update{
-		{
-			payload: []byte(`{
+var testStates = []update{
+	{
+		payload: []byte(`{
 				"name": "Alice",
 				"age": 31,
 				"points": 100,
 				"verified": true
-			}`),
-			// cid: "Qmcv2iU3myUBwuFCHe3w97sBMMER2FTY2rpbNBP6cqWb4S",
-			cid: "bafybeigxazren4cw3fla22hvs3773udxynn53mk4hwezobv3fbirusgxnq",
-		},
-		{
-			payload: []byte(`{
+		}`),
+		// cid: "Qmcv2iU3myUBwuFCHe3w97sBMMER2FTY2rpbNBP6cqWb4S",
+		cid: "bafybeigxazren4cw3fla22hvs3773udxynn53mk4hwezobv3fbirusgxnq",
+	},
+	{
+		payload: []byte(`{
 				"name": "Pete",
 				"age": 31,
 				"points": 99.9,
 				"verified": true
-			}`),
-			diffOps: map[string]interface{}{
-				"name":   "Pete",
-				"points": 99.9,
-			},
-			// cid: "QmPgnQvhPuLGwVU4ZEcbRy7RNCxSkeS72eKwXusUrAEEXR",
-			cid: "bafybeies2gdj2xzswz4jdxev3bouuefo6q5f377ur7a3ly2jursh5kgkyu",
+		}`),
+		diffOps: map[string]interface{}{
+			"name":   "Pete",
+			"points": 99.9,
 		},
-		{
-			payload: []byte(`{
+		// cid: "QmPgnQvhPuLGwVU4ZEcbRy7RNCxSkeS72eKwXusUrAEEXR",
+		cid: "bafybeies2gdj2xzswz4jdxev3bouuefo6q5f377ur7a3ly2jursh5kgkyu",
+	},
+	{
+		payload: []byte(`{
 				"name": "Pete",
 				"age": 22,
 				"points": 99.9,
 				"verified": false
-			}`),
-			diffOps: map[string]interface{}{
-				"verified": false,
-				"age":      22,
-			},
-			// cid: "QmRpMfTzExGrXat5W9uCAEtnSpRTvWBcd1hBYNWVPdN9Xh",
-			cid: "bafybeia2gx47ypcpwd3bt4xl26det6mw7pxevcw7sh4njnjcfh4z7wh5fa",
+		}`),
+		diffOps: map[string]interface{}{
+			"verified": false,
+			"age":      22,
 		},
-		{
-			payload: []byte(`{
+		// cid: "QmRpMfTzExGrXat5W9uCAEtnSpRTvWBcd1hBYNWVPdN9Xh",
+		cid: "bafybeia2gx47ypcpwd3bt4xl26det6mw7pxevcw7sh4njnjcfh4z7wh5fa",
+	},
+	{
+		payload: []byte(`{
 				"name": "Pete",
 				"age": 22,
 				"points": 129.99,
 				"verified": false
-			}`),
-			diffOps: map[string]interface{}{
-				"points": 129.99,
-			},
-			// cid: "QmRWYwKadjWqHLrzPKd7MdS4EoQuT2RzWVTaBxxVkeSjFH",
-			cid: "bafybeif45vokvqg47ahuvgfbhuayw54pmjidwjefonzrlakesbi2v4aeki",
+		}`),
+		diffOps: map[string]interface{}{
+			"points": 129.99,
 		},
-	}
-)
+		// cid: "QmRWYwKadjWqHLrzPKd7MdS4EoQuT2RzWVTaBxxVkeSjFH",
+		cid: "bafybeif45vokvqg47ahuvgfbhuayw54pmjidwjefonzrlakesbi2v4aeki",
+	},
+}
 
 func newMemoryDB(ctx context.Context) (client.DB, error) {
 	rootstore := ds.NewMapDatastore()

--- a/db/fetcher_test.go
+++ b/db/fetcher_test.go
@@ -57,7 +57,6 @@ func newTestCollectionDescription() client.CollectionDescription {
 			},
 		},
 	}
-
 }
 
 func newTestFetcher() (*fetcher.DocumentFetcher, error) {

--- a/db/tests/mutation/inline_array/update/simple_test.go
+++ b/db/tests/mutation/inline_array/update/simple_test.go
@@ -32,7 +32,8 @@ func TestMutationInlineArrayUpdateWithBooleans(t *testing.T) {
 					(`{
 						"Name": "John",
 						"LikedIndexes": [true, true, false, true]
-					}`)},
+					}`),
+				},
 			},
 			Results: []map[string]interface{}{
 				{
@@ -54,7 +55,8 @@ func TestMutationInlineArrayUpdateWithBooleans(t *testing.T) {
 					(`{
 						"Name": "John",
 						"LikedIndexes": [true, true, false, true]
-					}`)},
+					}`),
+				},
 			},
 			Results: []map[string]interface{}{
 				{
@@ -76,7 +78,8 @@ func TestMutationInlineArrayUpdateWithBooleans(t *testing.T) {
 					(`{
 						"Name": "John",
 						"LikedIndexes": [true, true, false, true]
-					}`)},
+					}`),
+				},
 			},
 			Results: []map[string]interface{}{
 				{
@@ -98,7 +101,8 @@ func TestMutationInlineArrayUpdateWithBooleans(t *testing.T) {
 					(`{
 						"Name": "John",
 						"LikedIndexes": [true, true, false, true]
-					}`)},
+					}`),
+				},
 			},
 			Results: []map[string]interface{}{
 				{
@@ -120,7 +124,8 @@ func TestMutationInlineArrayUpdateWithBooleans(t *testing.T) {
 					(`{
 						"Name": "John",
 						"LikedIndexes": [true, true, false, true]
-					}`)},
+					}`),
+				},
 			},
 			Results: []map[string]interface{}{
 				{
@@ -151,7 +156,8 @@ func TestMutationInlineArrayUpdateWithIntegers(t *testing.T) {
 					(`{
 						"Name": "John",
 						"FavouriteIntegers": [1, 2, 3, 5, 8]
-					}`)},
+					}`),
+				},
 			},
 			Results: []map[string]interface{}{
 				{
@@ -173,7 +179,8 @@ func TestMutationInlineArrayUpdateWithIntegers(t *testing.T) {
 					(`{
 						"Name": "John",
 						"FavouriteIntegers": [1, 2, 3, 5, 8]
-					}`)},
+					}`),
+				},
 			},
 			Results: []map[string]interface{}{
 				{
@@ -195,7 +202,8 @@ func TestMutationInlineArrayUpdateWithIntegers(t *testing.T) {
 					(`{
 						"Name": "John",
 						"FavouriteIntegers": [1, 2, 3, 5, 8]
-					}`)},
+					}`),
+				},
 			},
 			Results: []map[string]interface{}{
 				{
@@ -217,7 +225,8 @@ func TestMutationInlineArrayUpdateWithIntegers(t *testing.T) {
 					(`{
 						"Name": "John",
 						"FavouriteIntegers": [1, 2, 3, 5, 8]
-					}`)},
+					}`),
+				},
 			},
 			Results: []map[string]interface{}{
 				{
@@ -239,7 +248,8 @@ func TestMutationInlineArrayUpdateWithIntegers(t *testing.T) {
 					(`{
 						"Name": "John",
 						"FavouriteIntegers": [1, 2, 3, 5, 8]
-					}`)},
+					}`),
+				},
 			},
 			Results: []map[string]interface{}{
 				{
@@ -261,7 +271,8 @@ func TestMutationInlineArrayUpdateWithIntegers(t *testing.T) {
 					(`{
 						"Name": "John",
 						"FavouriteIntegers": [1, 2, 3, 5, 8]
-					}`)},
+					}`),
+				},
 			},
 			Results: []map[string]interface{}{
 				{
@@ -292,7 +303,8 @@ func TestMutationInlineArrayUpdateWithFloats(t *testing.T) {
 					(`{
 						"Name": "John",
 						"FavouriteFloats": [3.1425, 0.00000000001, 10]
-					}`)},
+					}`),
+				},
 			},
 			Results: []map[string]interface{}{
 				{
@@ -314,7 +326,8 @@ func TestMutationInlineArrayUpdateWithFloats(t *testing.T) {
 					(`{
 						"Name": "John",
 						"FavouriteFloats": [3.1425, 0.00000000001, 10]
-					}`)},
+					}`),
+				},
 			},
 			Results: []map[string]interface{}{
 				{
@@ -336,7 +349,8 @@ func TestMutationInlineArrayUpdateWithFloats(t *testing.T) {
 					(`{
 						"Name": "John",
 						"FavouriteFloats": [3.1425, 0.00000000001, 10]
-					}`)},
+					}`),
+				},
 			},
 			Results: []map[string]interface{}{
 				{
@@ -358,7 +372,8 @@ func TestMutationInlineArrayUpdateWithFloats(t *testing.T) {
 					(`{
 						"Name": "John",
 						"FavouriteFloats": [3.1425, 0.00000000001, 10]
-					}`)},
+					}`),
+				},
 			},
 			Results: []map[string]interface{}{
 				{
@@ -380,7 +395,8 @@ func TestMutationInlineArrayUpdateWithFloats(t *testing.T) {
 					(`{
 						"Name": "John",
 						"FavouriteFloats": [3.1425, 0.00000000001, 10]
-					}`)},
+					}`),
+				},
 			},
 			Results: []map[string]interface{}{
 				{
@@ -411,7 +427,8 @@ func TestMutationInlineArrayUpdateWithStrings(t *testing.T) {
 					(`{
 						"Name": "John",
 						"PreferredStrings": ["", "the previous", "the first", "empty string"]
-					}`)},
+					}`),
+				},
 			},
 			Results: []map[string]interface{}{
 				{
@@ -433,7 +450,8 @@ func TestMutationInlineArrayUpdateWithStrings(t *testing.T) {
 					(`{
 						"Name": "John",
 						"PreferredStrings": ["", "the previous", "the first", "empty string"]
-					}`)},
+					}`),
+				},
 			},
 			Results: []map[string]interface{}{
 				{
@@ -455,7 +473,8 @@ func TestMutationInlineArrayUpdateWithStrings(t *testing.T) {
 					(`{
 						"Name": "John",
 						"PreferredStrings": ["", "the previous", "the first", "empty string"]
-					}`)},
+					}`),
+				},
 			},
 			Results: []map[string]interface{}{
 				{
@@ -477,7 +496,8 @@ func TestMutationInlineArrayUpdateWithStrings(t *testing.T) {
 					(`{
 						"Name": "John",
 						"PreferredStrings": ["", "the previous", "the first", "empty string"]
-					}`)},
+					}`),
+				},
 			},
 			Results: []map[string]interface{}{
 				{
@@ -499,7 +519,8 @@ func TestMutationInlineArrayUpdateWithStrings(t *testing.T) {
 					(`{
 						"Name": "John",
 						"PreferredStrings": ["", "the previous", "the first", "empty string"]
-					}`)},
+					}`),
+				},
 			},
 			Results: []map[string]interface{}{
 				{

--- a/db/tests/mutation/relation/delete/single_id_test.go
+++ b/db/tests/mutation/relation/delete/single_id_test.go
@@ -19,7 +19,6 @@ import (
 
 func TestRelationalDeletionOfADocumentUsingSingleKey_Success(t *testing.T) {
 	tests := []testUtils.QueryTestCase{
-
 		{
 			Description: "Relational delete mutation where one element exists.",
 			Query: `mutation {
@@ -35,7 +34,8 @@ func TestRelationalDeletionOfADocumentUsingSingleKey_Success(t *testing.T) {
 					"name": "100 Go Mistakes to Avoid.",
 					"rating": 4.8,
 					"publisher_id": "bae-176ebdf0-77e7-5b2f-91ae-f620e37a29e3"
-				}`)},
+				}`),
+				},
 				// Authors
 				1: {
 					// bae-2f80f359-535d-508e-ba58-088a309ce3c3
@@ -44,14 +44,16 @@ func TestRelationalDeletionOfADocumentUsingSingleKey_Success(t *testing.T) {
 					"age": 48,
 					"verified": true,
 					"wrote_id": "bae-80eded16-ee4b-5c9d-b33f-6a7b83958af2"
-				}`)},
+				}`),
+				},
 				// Publishers
 				2: {
 					// bae-176ebdf0-77e7-5b2f-91ae-f620e37a29e3
 					(`{
 					"name": "Manning Early Access Program (MEAP)",
 					"address": "Online"
-				}`)},
+				}`),
+				},
 			},
 			Results: []map[string]interface{}{
 				{
@@ -76,7 +78,8 @@ func TestRelationalDeletionOfADocumentUsingSingleKey_Success(t *testing.T) {
 					"name": "100 Go Mistakes to Avoid.",
 					"rating": 4.8,
 					"publisher_id": "bae-176ebdf0-77e7-5b2f-91ae-f620e37a29e3"
-				}`)},
+				}`),
+				},
 				// Authors
 				1: {
 					// bae-2f80f359-535d-508e-ba58-088a309ce3c3
@@ -85,14 +88,16 @@ func TestRelationalDeletionOfADocumentUsingSingleKey_Success(t *testing.T) {
 					"age": 48,
 					"verified": true,
 					"wrote_id": "bae-80eded16-ee4b-5c9d-b33f-6a7b83958af2"
-				}`)},
+				}`),
+				},
 				// Publishers
 				2: {
 					// bae-176ebdf0-77e7-5b2f-91ae-f620e37a29e3
 					(`{
 					"name": "Manning Early Access Program (MEAP)",
 					"address": "Online"
-				}`)},
+				}`),
+				},
 			},
 			Results: []map[string]interface{}{
 				{
@@ -152,7 +157,8 @@ func TestRelationalDeletionOfADocumentUsingSingleKey_Success(t *testing.T) {
 					(`{
 						"name": "Rust in Action.",
 						"publisher_id": "bae-5c599633-d6d2-56ae-b3f0-1b65b4cee9fe"
-					}`)},
+					}`),
+				},
 			},
 			Results: []map[string]interface{}{
 				{

--- a/db/tests/mutation/simple/create/simple_test.go
+++ b/db/tests/mutation/simple/create/simple_test.go
@@ -55,7 +55,8 @@ func TestMutationCreateSimpleDoesNotCreateDocGivenDuplicate(t *testing.T) {
 				(`{
 				"name": "John",
 				"age": 27
-			}`)},
+			}`),
+			},
 		},
 		ExpectedError: "A document with the given key already exists",
 	}

--- a/db/tests/mutation/simple/delete/multi_ids_test.go
+++ b/db/tests/mutation/simple/delete/multi_ids_test.go
@@ -19,7 +19,6 @@ import (
 
 func TestDeletionOfMultipleDocumentUsingMultipleKeys_Success(t *testing.T) {
 	tests := []testUtils.QueryTestCase{
-
 		{
 			Description: "Simple multi-key delete mutation with one key that exists.",
 			Query: `mutation {

--- a/db/tests/mutation/simple/delete/single_id_test.go
+++ b/db/tests/mutation/simple/delete/single_id_test.go
@@ -19,7 +19,6 @@ import (
 
 func TestDeletionOfADocumentUsingSingleKey_Success(t *testing.T) {
 	tests := []testUtils.QueryTestCase{
-
 		{
 			Description: "Simple delete mutation where one element exists.",
 			Query: `mutation {

--- a/db/tests/mutation/simple/delete/with_filter_test.go
+++ b/db/tests/mutation/simple/delete/with_filter_test.go
@@ -19,7 +19,6 @@ import (
 
 func TestDeletionOfDocumentsWithFilter_Success(t *testing.T) {
 	tests := []testUtils.QueryTestCase{
-
 		{
 			Description: "Delete using filter - One matching document, that exists.",
 

--- a/db/tests/mutation/simple/mix/with_txn_test.go
+++ b/db/tests/mutation/simple/mix/with_txn_test.go
@@ -125,7 +125,8 @@ func TestMutationWithTxnDoesUpdateUserGivenSameTransactions(t *testing.T) {
 				(`{
 				"name": "John",
 				"age": 27
-			}`)},
+			}`),
+			},
 		},
 		TransactionalQueries: []testUtils.TransactionQuery{
 			{
@@ -174,7 +175,8 @@ func TestMutationWithTxnDoesNotUpdateUserGivenDifferentTransactions(t *testing.T
 				(`{
 				"name": "John",
 				"age": 27
-			}`)},
+			}`),
+			},
 		},
 		TransactionalQueries: []testUtils.TransactionQuery{
 			{
@@ -227,7 +229,8 @@ func TestMutationWithTxnDoesNotAllowUpdateInSecondTransactionUser(t *testing.T) 
 				(`{
 				"name": "John",
 				"age": 27
-			}`)},
+			}`),
+			},
 		},
 		TransactionalQueries: []testUtils.TransactionQuery{
 			{

--- a/db/tests/mutation/simple/update/with_filter_test.go
+++ b/db/tests/mutation/simple/update/with_filter_test.go
@@ -35,7 +35,8 @@ func TestSimpleMutationUpdateWithBooleanFilter(t *testing.T) {
 						"age": 27,
 						"verified": true,
 						"points": 42.1
-					}`)},
+					}`),
+				},
 			},
 			Results: []map[string]interface{}{
 				{
@@ -67,7 +68,8 @@ func TestSimpleMutationUpdateWithBooleanFilter(t *testing.T) {
 					"age": 39,
 					"verified": false,
 					"points": 66.6
-				}`)},
+				}`),
+				},
 			},
 			Results: []map[string]interface{}{
 				{
@@ -99,7 +101,8 @@ func TestSimpleMutationUpdateWithBooleanFilter(t *testing.T) {
 					"age": 39,
 					"verified": true,
 					"points": 66.6
-				}`)},
+				}`),
+				},
 			},
 			Results: []map[string]interface{}{
 				{
@@ -144,7 +147,8 @@ func TestSimpleMutationUpdateWithIdInFilter(t *testing.T) {
 				"age": 39,
 				"verified": false,
 				"points": 66.6
-			}`)},
+			}`),
+			},
 		},
 		Results: []map[string]interface{}{
 			{
@@ -186,7 +190,8 @@ func TestSimpleMutationUpdateWithIdEqualsFilter(t *testing.T) {
 				"age": 39,
 				"verified": false,
 				"points": 66.6
-			}`)},
+			}`),
+			},
 		},
 		Results: []map[string]interface{}{
 			{

--- a/db/tests/query/all_commits/simple_test.go
+++ b/db/tests/query/all_commits/simple_test.go
@@ -33,7 +33,8 @@ func TestQueryAllCommitsSingleDAG(t *testing.T) {
 				(`{
 				"Name": "John",
 				"Age": 21
-			}`)},
+			}`),
+			},
 		},
 		Results: []map[string]interface{}{
 			{
@@ -69,7 +70,8 @@ func TestQueryAllCommitsMultipleDAG(t *testing.T) {
 				(`{
 				"Name": "John",
 				"Age": 21
-			}`)},
+			}`),
+			},
 		},
 		Updates: map[int][]string{
 			0: {

--- a/db/tests/query/all_commits/with_count_test.go
+++ b/db/tests/query/all_commits/with_count_test.go
@@ -30,7 +30,8 @@ func TestQueryAllCommitsSingleDAGWithLinkCount(t *testing.T) {
 				(`{
 				"Name": "John",
 				"Age": 21
-			}`)},
+			}`),
+			},
 		},
 		Results: []map[string]interface{}{
 			{

--- a/db/tests/query/commit/simple_test.go
+++ b/db/tests/query/commit/simple_test.go
@@ -31,7 +31,8 @@ func TestQueryOneCommit(t *testing.T) {
 				(`{
 				"Name": "John",
 				"Age": 21
-			}`)},
+			}`),
+			},
 		},
 		Results: []map[string]interface{}{
 			{

--- a/db/tests/query/complex/simple_test.go
+++ b/db/tests/query/complex/simple_test.go
@@ -31,15 +31,16 @@ func TestQueryComplex(t *testing.T) {
 			}
 		}`,
 		Docs: map[int][]string{
-			//books
+			// books
 			0: {
 				// bae-7e5ae688-3a77-5b4f-a74c-59301bd1eb25
 				(`{
 					"name": "The Coffee Table Book",
 					"rating": 4.9,
 					"publisher_id": "bae-81804a20-4d08-509e-a3e8-fd770622a356"
-				}`)},
-			//authors
+				}`),
+			},
+			// authors
 			1: {
 				// bae-5eae6a8a-0c52-535c-9c20-df42b7044e20
 				(`{
@@ -47,14 +48,16 @@ func TestQueryComplex(t *testing.T) {
 					"age": 44,
 					"verified": true,
 					"wrote_id": "bae-7e5ae688-3a77-5b4f-a74c-59301bd1eb25"
-				}`)},
+				}`),
+			},
 			// publishers
 			2: {
 				// bae-81804a20-4d08-509e-a3e8-fd770622a356
 				(`{
 					"name": "Pendant Publishing",
 					"address": "600 Madison Ave., New York, New York"
-				}`)},
+				}`),
+			},
 		},
 		Results: []map[string]interface{}{
 			{

--- a/db/tests/query/complex/with_sum_test.go
+++ b/db/tests/query/complex/with_sum_test.go
@@ -32,13 +32,15 @@ func TestQueryComplexWithSumOnInlineAndManyToMany(t *testing.T) {
 					"name": "The Coffee Table Book",
 					"rating": 4.9,
 					"publisher_id": "bae-09468fb6-b7c6-57df-898e-8de473d114b3"
-				}`)},
+				}`),
+			},
 			2: {
 				(`{
 					"name": "Pendant Publishing",
 					"address": "600 Madison Ave., New York, New York",
 					"favouritePageNumbers": [-1, 2, -1, 1, 0]
-				}`)},
+				}`),
+			},
 		},
 		Results: []map[string]interface{}{
 			{

--- a/db/tests/query/inline_array/simple_test.go
+++ b/db/tests/query/inline_array/simple_test.go
@@ -31,7 +31,8 @@ func TestQueryInlineArrayWithBooleans(t *testing.T) {
 					(`{
 					"Name": "John",
 					"LikedIndexes": null
-				}`)},
+				}`),
+				},
 			},
 			Results: []map[string]interface{}{
 				{
@@ -53,7 +54,8 @@ func TestQueryInlineArrayWithBooleans(t *testing.T) {
 					(`{
 					"Name": "John",
 					"LikedIndexes": []
-				}`)},
+				}`),
+				},
 			},
 			Results: []map[string]interface{}{
 				{
@@ -75,7 +77,8 @@ func TestQueryInlineArrayWithBooleans(t *testing.T) {
 					(`{
 					"Name": "John",
 					"LikedIndexes": [true, true, false, true]
-				}`)},
+				}`),
+				},
 			},
 			Results: []map[string]interface{}{
 				{
@@ -106,7 +109,8 @@ func TestQueryInlineArrayWithIntegers(t *testing.T) {
 					(`{
 					"Name": "John",
 					"FavouriteIntegers": null
-				}`)},
+				}`),
+				},
 			},
 			Results: []map[string]interface{}{
 				{
@@ -128,7 +132,8 @@ func TestQueryInlineArrayWithIntegers(t *testing.T) {
 					(`{
 					"Name": "John",
 					"FavouriteIntegers": []
-				}`)},
+				}`),
+				},
 			},
 			Results: []map[string]interface{}{
 				{
@@ -150,7 +155,8 @@ func TestQueryInlineArrayWithIntegers(t *testing.T) {
 					(`{
 					"Name": "John",
 					"FavouriteIntegers": [1, 2, 3, 5, 8]
-				}`)},
+				}`),
+				},
 			},
 			Results: []map[string]interface{}{
 				{
@@ -172,7 +178,8 @@ func TestQueryInlineArrayWithIntegers(t *testing.T) {
 					(`{
 					"Name": "Andy",
 					"FavouriteIntegers": [-1, -2, -3, -5, -8]
-				}`)},
+				}`),
+				},
 			},
 			Results: []map[string]interface{}{
 				{
@@ -194,7 +201,8 @@ func TestQueryInlineArrayWithIntegers(t *testing.T) {
 					(`{
 					"Name": "Shahzad",
 					"FavouriteIntegers": [-1, 2, -1, 1, 0]
-				}`)},
+				}`),
+				},
 			},
 			Results: []map[string]interface{}{
 				{
@@ -225,7 +233,8 @@ func TestQueryInlineArrayWithFloats(t *testing.T) {
 					(`{
 					"Name": "John",
 					"FavouriteFloats": null
-				}`)},
+				}`),
+				},
 			},
 			Results: []map[string]interface{}{
 				{
@@ -247,7 +256,8 @@ func TestQueryInlineArrayWithFloats(t *testing.T) {
 					(`{
 					"Name": "John",
 					"FavouriteFloats": []
-				}`)},
+				}`),
+				},
 			},
 			Results: []map[string]interface{}{
 				{
@@ -269,7 +279,8 @@ func TestQueryInlineArrayWithFloats(t *testing.T) {
 					(`{
 					"Name": "John",
 					"FavouriteFloats": [3.1425, 0.00000000001, 10]
-				}`)},
+				}`),
+				},
 			},
 			Results: []map[string]interface{}{
 				{
@@ -300,7 +311,8 @@ func TestQueryInlineArrayWithStrings(t *testing.T) {
 					(`{
 					"Name": "John",
 					"PreferredStrings": null
-				}`)},
+				}`),
+				},
 			},
 			Results: []map[string]interface{}{
 				{
@@ -322,7 +334,8 @@ func TestQueryInlineArrayWithStrings(t *testing.T) {
 					(`{
 					"Name": "John",
 					"PreferredStrings": []
-				}`)},
+				}`),
+				},
 			},
 			Results: []map[string]interface{}{
 				{
@@ -344,7 +357,8 @@ func TestQueryInlineArrayWithStrings(t *testing.T) {
 					(`{
 					"Name": "John",
 					"PreferredStrings": ["", "the previous", "the first", "empty string"]
-				}`)},
+				}`),
+				},
 			},
 			Results: []map[string]interface{}{
 				{

--- a/db/tests/query/inline_array/with_average_sum_test.go
+++ b/db/tests/query/inline_array/with_average_sum_test.go
@@ -35,7 +35,8 @@ func TestQueryInlineIntegerArrayWithAverageAndSum(t *testing.T) {
 				(`{
 				"Name": "John",
 				"FavouriteIntegers": [-1, 0, 9, 0]
-			}`)},
+			}`),
+			},
 		},
 		Results: []map[string]interface{}{
 			{

--- a/db/tests/query/inline_array/with_average_test.go
+++ b/db/tests/query/inline_array/with_average_test.go
@@ -30,7 +30,8 @@ func TestQueryInlineIntegerArrayWithsWithAverageAndNullArray(t *testing.T) {
 				(`{
 				"Name": "John",
 				"FavouriteIntegers": null
-			}`)},
+			}`),
+			},
 		},
 		Results: []map[string]interface{}{
 			{
@@ -57,7 +58,8 @@ func TestQueryInlineIntegerArrayWithsWithAverageAndEmptyArray(t *testing.T) {
 				(`{
 				"Name": "John",
 				"FavouriteIntegers": []
-			}`)},
+			}`),
+			},
 		},
 		Results: []map[string]interface{}{
 			{
@@ -84,7 +86,8 @@ func TestQueryInlineIntegerArrayWithsWithAverageAndZeroArray(t *testing.T) {
 				(`{
 				"Name": "John",
 				"FavouriteIntegers": [0, 0, 0]
-			}`)},
+			}`),
+			},
 		},
 		Results: []map[string]interface{}{
 			{
@@ -111,7 +114,8 @@ func TestQueryInlineIntegerArrayWithsWithAverageAndPopulatedArray(t *testing.T) 
 				(`{
 				"Name": "John",
 				"FavouriteIntegers": [-1, 0, 9, 0]
-			}`)},
+			}`),
+			},
 		},
 		Results: []map[string]interface{}{
 			{
@@ -138,7 +142,8 @@ func TestQueryInlineFloatArrayWithsWithAverageAndNullArray(t *testing.T) {
 				(`{
 				"Name": "John",
 				"FavouriteFloats": null
-			}`)},
+			}`),
+			},
 		},
 		Results: []map[string]interface{}{
 			{
@@ -165,7 +170,8 @@ func TestQueryInlineFloatArrayWithsWithAverageAndEmptyArray(t *testing.T) {
 				(`{
 				"Name": "John",
 				"FavouriteFloats": []
-			}`)},
+			}`),
+			},
 		},
 		Results: []map[string]interface{}{
 			{
@@ -192,7 +198,8 @@ func TestQueryInlineFloatArrayWithsWithAverageAndZeroArray(t *testing.T) {
 				(`{
 				"Name": "John",
 				"FavouriteFloats": [0, 0, 0]
-			}`)},
+			}`),
+			},
 		},
 		Results: []map[string]interface{}{
 			{
@@ -219,7 +226,8 @@ func TestQueryInlineFloatArrayWithsWithAverageAndPopulatedArray(t *testing.T) {
 				(`{
 				"Name": "John",
 				"FavouriteFloats": [-0.1, 0, 0.9, 0]
-			}`)},
+			}`),
+			},
 		},
 		Results: []map[string]interface{}{
 			{

--- a/db/tests/query/inline_array/with_count_test.go
+++ b/db/tests/query/inline_array/with_count_test.go
@@ -30,7 +30,8 @@ func TestQueryInlineIntegerArrayWithsWithCountAndNullArray(t *testing.T) {
 				(`{
 				"Name": "John",
 				"FavouriteIntegers": null
-			}`)},
+			}`),
+			},
 		},
 		Results: []map[string]interface{}{
 			{
@@ -57,7 +58,8 @@ func TestQueryInlineIntegerArrayWithsWithCountAndEmptyArray(t *testing.T) {
 				(`{
 				"Name": "John",
 				"FavouriteIntegers": []
-			}`)},
+			}`),
+			},
 		},
 		Results: []map[string]interface{}{
 			{
@@ -84,7 +86,8 @@ func TestQueryInlineIntegerArrayWithsWithCountAndPopulatedArray(t *testing.T) {
 				(`{
 				"Name": "Shahzad",
 				"FavouriteIntegers": [-1, 2, -1, 1, 0]
-			}`)},
+			}`),
+			},
 		},
 		Results: []map[string]interface{}{
 			{

--- a/db/tests/query/inline_array/with_sum_test.go
+++ b/db/tests/query/inline_array/with_sum_test.go
@@ -30,7 +30,8 @@ func TestQueryInlineIntegerArrayWithsWithSumAndNullArray(t *testing.T) {
 				(`{
 				"Name": "John",
 				"FavouriteIntegers": null
-			}`)},
+			}`),
+			},
 		},
 		Results: []map[string]interface{}{
 			{
@@ -57,7 +58,8 @@ func TestQueryInlineIntegerArrayWithsWithSumAndEmptyArray(t *testing.T) {
 				(`{
 				"Name": "John",
 				"FavouriteIntegers": []
-			}`)},
+			}`),
+			},
 		},
 		Results: []map[string]interface{}{
 			{
@@ -84,7 +86,8 @@ func TestQueryInlineIntegerArrayWithsWithSumAndPopulatedArray(t *testing.T) {
 				(`{
 				"Name": "Shahzad",
 				"FavouriteIntegers": [-1, 2, -1, 1, 0]
-			}`)},
+			}`),
+			},
 		},
 		Results: []map[string]interface{}{
 			{
@@ -111,7 +114,8 @@ func TestQueryInlineFloatArrayWithsWithSumAndNullArray(t *testing.T) {
 				(`{
 				"Name": "John",
 				"FavouriteFloats": null
-			}`)},
+			}`),
+			},
 		},
 		Results: []map[string]interface{}{
 			{
@@ -138,7 +142,8 @@ func TestQueryInlineFloatArrayWithsWithSumAndEmptyArray(t *testing.T) {
 				(`{
 				"Name": "John",
 				"FavouriteFloats": []
-			}`)},
+			}`),
+			},
 		},
 		Results: []map[string]interface{}{
 			{
@@ -165,7 +170,8 @@ func TestQueryInlineFloatArrayWithsWithSumAndPopulatedArray(t *testing.T) {
 				(`{
 				"Name": "John",
 				"FavouriteFloats": [3.1425, 0.00000000001, 10]
-			}`)},
+			}`),
+			},
 		},
 		Results: []map[string]interface{}{
 			{

--- a/db/tests/query/latest_commits/simple_test.go
+++ b/db/tests/query/latest_commits/simple_test.go
@@ -33,7 +33,8 @@ func TestQueryLatestCommits(t *testing.T) {
 				(`{
 				"Name": "John",
 				"Age": 21
-			}`)},
+			}`),
+			},
 		},
 		Results: []map[string]interface{}{
 			{

--- a/db/tests/query/one_to_many/simple_test.go
+++ b/db/tests/query/one_to_many/simple_test.go
@@ -31,14 +31,14 @@ func TestQueryOneToMany(t *testing.T) {
 						}
 					}`,
 			Docs: map[int][]string{
-				//books
+				// books
 				0: { // bae-fd541c25-229e-5280-b44b-e5c2af3e374d
 					(`{
 					"name": "Painted House",
 					"rating": 4.9,
 					"author_id": "bae-41598f0c-19bc-5da6-813b-e80f14a10df3"
 				}`)},
-				//authors
+				// authors
 				1: { // bae-41598f0c-19bc-5da6-813b-e80f14a10df3
 					(`{
 					"name": "John Grisham",
@@ -70,7 +70,7 @@ func TestQueryOneToMany(t *testing.T) {
 				}
 			}`,
 			Docs: map[int][]string{
-				//books
+				// books
 				0: { // bae-fd541c25-229e-5280-b44b-e5c2af3e374d
 					(`{
 						"name": "Painted House",
@@ -88,7 +88,7 @@ func TestQueryOneToMany(t *testing.T) {
 						"author_id": "bae-b769708d-f552-5c3d-a402-ccfd7ac7fb04"
 					}`),
 				},
-				//authors
+				// authors
 				1: {
 					// bae-41598f0c-19bc-5da6-813b-e80f14a10df3
 					(`{

--- a/db/tests/query/one_to_many/with_count_limit_offset_test.go
+++ b/db/tests/query/one_to_many/with_count_limit_offset_test.go
@@ -29,7 +29,7 @@ func TestQueryOneToManyWithCountAndLimitAndOffset(t *testing.T) {
 				}
 			}`,
 		Docs: map[int][]string{
-			//books
+			// books
 			0: {
 				(`{
 					"name": "Painted House",
@@ -57,7 +57,7 @@ func TestQueryOneToManyWithCountAndLimitAndOffset(t *testing.T) {
 					"author_id": "bae-b769708d-f552-5c3d-a402-ccfd7ac7fb04"
 				}`),
 			},
-			//authors
+			// authors
 			1: {
 				// bae-41598f0c-19bc-5da6-813b-e80f14a10df3
 				(`{

--- a/db/tests/query/one_to_many/with_count_limit_test.go
+++ b/db/tests/query/one_to_many/with_count_limit_test.go
@@ -29,7 +29,7 @@ func TestQueryOneToManyWithCountAndLimit(t *testing.T) {
 				}
 			}`,
 		Docs: map[int][]string{
-			//books
+			// books
 			0: { // bae-fd541c25-229e-5280-b44b-e5c2af3e374d
 				(`{
 					"name": "Painted House",
@@ -47,7 +47,7 @@ func TestQueryOneToManyWithCountAndLimit(t *testing.T) {
 					"author_id": "bae-b769708d-f552-5c3d-a402-ccfd7ac7fb04"
 				}`),
 			},
-			//authors
+			// authors
 			1: {
 				// bae-41598f0c-19bc-5da6-813b-e80f14a10df3
 				(`{

--- a/db/tests/query/one_to_many/with_count_test.go
+++ b/db/tests/query/one_to_many/with_count_test.go
@@ -27,7 +27,7 @@ func TestQueryOneToManyWithCount(t *testing.T) {
 				}
 			}`,
 			Docs: map[int][]string{
-				//authors
+				// authors
 				1: {
 					(`{
 					"name": "John Grisham",
@@ -52,7 +52,7 @@ func TestQueryOneToManyWithCount(t *testing.T) {
 				}
 			}`,
 			Docs: map[int][]string{
-				//books
+				// books
 				0: { // bae-fd541c25-229e-5280-b44b-e5c2af3e374d
 					(`{
 					"name": "Painted House",
@@ -70,7 +70,7 @@ func TestQueryOneToManyWithCount(t *testing.T) {
 					"author_id": "bae-b769708d-f552-5c3d-a402-ccfd7ac7fb04"
 				}`),
 				},
-				//authors
+				// authors
 				1: {
 					// bae-41598f0c-19bc-5da6-813b-e80f14a10df3
 					(`{

--- a/db/tests/query/one_to_many/with_filter_test.go
+++ b/db/tests/query/one_to_many/with_filter_test.go
@@ -30,7 +30,7 @@ func TestQueryOneToManyWithNumericGreaterThanFilterOnParent(t *testing.T) {
 			}
 		}`,
 		Docs: map[int][]string{
-			//books
+			// books
 			0: { // bae-fd541c25-229e-5280-b44b-e5c2af3e374d
 				(`{
 					"name": "Painted House",
@@ -48,7 +48,7 @@ func TestQueryOneToManyWithNumericGreaterThanFilterOnParent(t *testing.T) {
 					"author_id": "bae-b769708d-f552-5c3d-a402-ccfd7ac7fb04"
 				}`),
 			},
-			//authors
+			// authors
 			1: {
 				// bae-41598f0c-19bc-5da6-813b-e80f14a10df3
 				(`{
@@ -99,7 +99,7 @@ func TestQueryOneToManyWithNumericGreaterThanFilterOnParentAndChild(t *testing.T
 			}
 		}`,
 		Docs: map[int][]string{
-			//books
+			// books
 			0: { // bae-fd541c25-229e-5280-b44b-e5c2af3e374d
 				(`{
 					"name": "Painted House",
@@ -117,7 +117,7 @@ func TestQueryOneToManyWithNumericGreaterThanFilterOnParentAndChild(t *testing.T
 					"author_id": "bae-b769708d-f552-5c3d-a402-ccfd7ac7fb04"
 				}`),
 			},
-			//authors
+			// authors
 			1: {
 				// bae-41598f0c-19bc-5da6-813b-e80f14a10df3
 				(`{

--- a/db/tests/query/one_to_many/with_group_filter_test.go
+++ b/db/tests/query/one_to_many/with_group_filter_test.go
@@ -33,7 +33,7 @@ func TestQueryOneToManyWithParentJoinGroupNumberAndNumberFilterOnJoin(t *testing
 				}
 			}`,
 			Docs: map[int][]string{
-				//books
+				// books
 				0: { // bae-fd541c25-229e-5280-b44b-e5c2af3e374d
 					(`{
 						"name": "Painted House",
@@ -66,7 +66,7 @@ func TestQueryOneToManyWithParentJoinGroupNumberAndNumberFilterOnJoin(t *testing
 						"author_id": "bae-09d33399-197a-5b98-b135-4398f2b6de4c"
 					}`),
 				},
-				//authors
+				// authors
 				1: {
 					// bae-41598f0c-19bc-5da6-813b-e80f14a10df3
 					(`{
@@ -151,7 +151,7 @@ func TestQueryOneToManyWithParentJoinGroupNumberAndNumberFilterOnGroup(t *testin
 				}
 			}`,
 			Docs: map[int][]string{
-				//books
+				// books
 				0: { // bae-fd541c25-229e-5280-b44b-e5c2af3e374d
 					(`{
 						"name": "Painted House",
@@ -184,7 +184,7 @@ func TestQueryOneToManyWithParentJoinGroupNumberAndNumberFilterOnGroup(t *testin
 						"author_id": "bae-09d33399-197a-5b98-b135-4398f2b6de4c"
 					}`),
 				},
-				//authors
+				// authors
 				1: {
 					// bae-41598f0c-19bc-5da6-813b-e80f14a10df3
 					(`{
@@ -273,7 +273,7 @@ func TestQueryOneToManyWithParentJoinGroupNumberAndNumberFilterOnGroupAndOnGroup
 				}
 			}`,
 			Docs: map[int][]string{
-				//books
+				// books
 				0: { // bae-fd541c25-229e-5280-b44b-e5c2af3e374d
 					(`{
 						"name": "Painted House",
@@ -306,7 +306,7 @@ func TestQueryOneToManyWithParentJoinGroupNumberAndNumberFilterOnGroupAndOnGroup
 						"author_id": "bae-09d33399-197a-5b98-b135-4398f2b6de4c"
 					}`),
 				},
-				//authors
+				// authors
 				1: {
 					// bae-41598f0c-19bc-5da6-813b-e80f14a10df3
 					(`{

--- a/db/tests/query/one_to_many/with_group_test.go
+++ b/db/tests/query/one_to_many/with_group_test.go
@@ -33,7 +33,7 @@ func TestQueryOneToManyWithInnerJoinGroupNumber(t *testing.T) {
 				}
 			}`,
 			Docs: map[int][]string{
-				//books
+				// books
 				0: { // bae-fd541c25-229e-5280-b44b-e5c2af3e374d
 					(`{
 						"name": "Painted House",
@@ -56,7 +56,7 @@ func TestQueryOneToManyWithInnerJoinGroupNumber(t *testing.T) {
 						"author_id": "bae-b769708d-f552-5c3d-a402-ccfd7ac7fb04"
 					}`),
 				},
-				//authors
+				// authors
 				1: {
 					// bae-41598f0c-19bc-5da6-813b-e80f14a10df3
 					(`{
@@ -138,7 +138,7 @@ func TestQueryOneToManyWithParentJoinGroupNumber(t *testing.T) {
 				}
 			}`,
 			Docs: map[int][]string{
-				//books
+				// books
 				0: { // bae-fd541c25-229e-5280-b44b-e5c2af3e374d
 					(`{
 						"name": "Painted House",
@@ -171,7 +171,7 @@ func TestQueryOneToManyWithParentJoinGroupNumber(t *testing.T) {
 						"author_id": "bae-09d33399-197a-5b98-b135-4398f2b6de4c"
 					}`),
 				},
-				//authors
+				// authors
 				1: {
 					// bae-41598f0c-19bc-5da6-813b-e80f14a10df3
 					(`{

--- a/db/tests/query/one_to_many/with_same_field_name_test.go
+++ b/db/tests/query/one_to_many/with_same_field_name_test.go
@@ -45,13 +45,13 @@ func TestQueryOneToManyWithSameFieldName(t *testing.T) {
 						}
 					}`,
 			Docs: map[int][]string{
-				//books
+				// books
 				0: { // bae-9217906d-e8c5-533d-8520-71c754590844
 					(`{
 					"name": "Painted House",
 					"relationship1_id": "bae-2edb7fdd-cad7-5ad4-9c7d-6920245a96ed"
 				}`)},
-				//authors
+				// authors
 				1: { // bae-2edb7fdd-cad7-5ad4-9c7d-6920245a96ed
 					(`{
 					"name": "John Grisham"
@@ -77,13 +77,13 @@ func TestQueryOneToManyWithSameFieldName(t *testing.T) {
 						}
 					}`,
 			Docs: map[int][]string{
-				//books
+				// books
 				0: { // bae-9217906d-e8c5-533d-8520-71c754590844
 					(`{
 					"name": "Painted House",
 					"relationship1_id": "bae-2edb7fdd-cad7-5ad4-9c7d-6920245a96ed"
 				}`)},
-				//authors
+				// authors
 				1: { // bae-2edb7fdd-cad7-5ad4-9c7d-6920245a96ed
 					(`{
 					"name": "John Grisham"

--- a/db/tests/query/one_to_many/with_sort_filter_limit_test.go
+++ b/db/tests/query/one_to_many/with_sort_filter_limit_test.go
@@ -32,7 +32,7 @@ func TestQueryOneToManyWithNumericGreaterThanFilterOnParentAndNumericSortAscendi
 			}
 		}`,
 		Docs: map[int][]string{
-			//books
+			// books
 			0: { // bae-fd541c25-229e-5280-b44b-e5c2af3e374d
 				(`{
 					"name": "Painted House",
@@ -50,7 +50,7 @@ func TestQueryOneToManyWithNumericGreaterThanFilterOnParentAndNumericSortAscendi
 					"author_id": "bae-b769708d-f552-5c3d-a402-ccfd7ac7fb04"
 				}`),
 			},
-			//authors
+			// authors
 			1: {
 				// bae-41598f0c-19bc-5da6-813b-e80f14a10df3
 				(`{

--- a/db/tests/query/one_to_many/with_sort_filter_test.go
+++ b/db/tests/query/one_to_many/with_sort_filter_test.go
@@ -32,7 +32,7 @@ func TestQueryOneToManyWithNumericGreaterThanFilterOnParentAndNumericSortAscendi
 			}
 		}`,
 		Docs: map[int][]string{
-			//books
+			// books
 			0: {
 				(`{
 					"name": "Painted House",
@@ -50,7 +50,7 @@ func TestQueryOneToManyWithNumericGreaterThanFilterOnParentAndNumericSortAscendi
 					"author_id": "bae-b769708d-f552-5c3d-a402-ccfd7ac7fb04"
 				}`),
 			},
-			//authors
+			// authors
 			1: {
 				// bae-41598f0c-19bc-5da6-813b-e80f14a10df3
 				(`{
@@ -101,7 +101,7 @@ func TestQueryOneToManyWithNumericGreaterThanFilterAndNumericSortDescendingOnChi
 			}
 		}`,
 		Docs: map[int][]string{
-			//books
+			// books
 			0: { // bae-fd541c25-229e-5280-b44b-e5c2af3e374d
 				(`{
 					"name": "Painted House",
@@ -119,7 +119,7 @@ func TestQueryOneToManyWithNumericGreaterThanFilterAndNumericSortDescendingOnChi
 					"author_id": "bae-b769708d-f552-5c3d-a402-ccfd7ac7fb04"
 				}`),
 			},
-			//authors
+			// authors
 			1: {
 				// bae-41598f0c-19bc-5da6-813b-e80f14a10df3
 				(`{

--- a/db/tests/query/one_to_many_multiple/with_count_test.go
+++ b/db/tests/query/one_to_many_multiple/with_count_test.go
@@ -27,7 +27,7 @@ func TestQueryOneToManyMultipleWithCount(t *testing.T) {
 				}
 			}`,
 		Docs: map[int][]string{
-			//articles
+			// articles
 			0: {
 				(`{
 					"name": "After Guantánamo, Another Injustice",
@@ -42,7 +42,7 @@ func TestQueryOneToManyMultipleWithCount(t *testing.T) {
 					"author_id": "bae-b769708d-f552-5c3d-a402-ccfd7ac7fb04"
 				}`),
 			},
-			//books
+			// books
 			1: {
 				(`{
 					"name": "Painted House",
@@ -57,7 +57,7 @@ func TestQueryOneToManyMultipleWithCount(t *testing.T) {
 					"author_id": "bae-b769708d-f552-5c3d-a402-ccfd7ac7fb04"
 				}`),
 			},
-			//authors
+			// authors
 			2: {
 				// bae-41598f0c-19bc-5da6-813b-e80f14a10df3
 				(`{

--- a/db/tests/query/one_to_one/simple_test.go
+++ b/db/tests/query/one_to_one/simple_test.go
@@ -31,13 +31,13 @@ func TestQueryOneToOne(t *testing.T) {
 						}
 					}`,
 			Docs: map[int][]string{
-				//books
+				// books
 				0: { // bae-fd541c25-229e-5280-b44b-e5c2af3e374d
 					(`{
 					"name": "Painted House",
 					"rating": 4.9
 				}`)},
-				//authors
+				// authors
 				1: { // bae-41598f0c-19bc-5da6-813b-e80f14a10df3
 					(`{
 					"name": "John Grisham",
@@ -70,14 +70,14 @@ func TestQueryOneToOne(t *testing.T) {
 						}
 					}`,
 			Docs: map[int][]string{
-				//books
+				// books
 				0: { // bae-fd541c25-229e-5280-b44b-e5c2af3e374d
 					(`{
 					"name": "Painted House",
 					"rating": 4.9
 					}`),
 				},
-				//authors
+				// authors
 				1: { // bae-41598f0c-19bc-5da6-813b-e80f14a10df3
 					(`{
 					"name": "John Grisham",

--- a/db/tests/query/one_to_one/with_filter_test.go
+++ b/db/tests/query/one_to_one/with_filter_test.go
@@ -30,13 +30,13 @@ func TestQueryOneToOneWithNumericFilterOnParent(t *testing.T) {
 					}
 				}`,
 		Docs: map[int][]string{
-			//books
+			// books
 			0: { // bae-fd541c25-229e-5280-b44b-e5c2af3e374d
 				(`{
 				"name": "Painted House",
 				"rating": 4.9
 			}`)},
-			//authors
+			// authors
 			1: { // bae-41598f0c-19bc-5da6-813b-e80f14a10df3
 				(`{
 				"name": "John Grisham",
@@ -74,13 +74,13 @@ func TestQueryOneToOneWithStringFilterOnChild(t *testing.T) {
 					}
 				}`,
 		Docs: map[int][]string{
-			//books
+			// books
 			0: { // bae-fd541c25-229e-5280-b44b-e5c2af3e374d
 				(`{
 				"name": "Painted House",
 				"rating": 4.9
 			}`)},
-			//authors
+			// authors
 			1: { // bae-41598f0c-19bc-5da6-813b-e80f14a10df3
 				(`{
 				"name": "John Grisham",
@@ -118,13 +118,13 @@ func TestQueryOneToOneWithBooleanFilterOnChild(t *testing.T) {
 					}
 				}`,
 		Docs: map[int][]string{
-			//books
+			// books
 			0: { // bae-fd541c25-229e-5280-b44b-e5c2af3e374d
 				(`{
 				"name": "Painted House",
 				"rating": 4.9
 			}`)},
-			//authors
+			// authors
 			1: { // bae-41598f0c-19bc-5da6-813b-e80f14a10df3
 				(`{
 				"name": "John Grisham",

--- a/db/tests/query/one_to_one/with_sort_test.go
+++ b/db/tests/query/one_to_one/with_sort_test.go
@@ -30,7 +30,7 @@ func TestQueryOneToOneWithChildBooleanSortDescending(t *testing.T) {
 			}
 		}`,
 		Docs: map[int][]string{
-			//books
+			// books
 			0: {
 				// bae-fd541c25-229e-5280-b44b-e5c2af3e374d
 				(`{
@@ -43,7 +43,7 @@ func TestQueryOneToOneWithChildBooleanSortDescending(t *testing.T) {
 				"rating": 4.8
 				}`),
 			},
-			//authors
+			// authors
 			1: {
 				// bae-41598f0c-19bc-5da6-813b-e80f14a10df3
 				(`{

--- a/db/tests/query/one_to_two_many/simple_test.go
+++ b/db/tests/query/one_to_two_many/simple_test.go
@@ -34,7 +34,7 @@ func TestQueryOneToTwoManyWithNilUnnamedRelationship(t *testing.T) {
 						}
 					}`,
 			Docs: map[int][]string{
-				//books
+				// books
 				0: {
 					(`{
 						"name": "Painted House",
@@ -55,7 +55,7 @@ func TestQueryOneToTwoManyWithNilUnnamedRelationship(t *testing.T) {
 						"reviewedBy_id": "bae-41598f0c-19bc-5da6-813b-e80f14a10df3"
 					}`),
 				},
-				//authors
+				// authors
 				1: {
 					// bae-41598f0c-19bc-5da6-813b-e80f14a10df3
 					(`{
@@ -123,7 +123,7 @@ func TestQueryOneToTwoManyWithNilUnnamedRelationship(t *testing.T) {
 				}
 			}`,
 			Docs: map[int][]string{
-				//books
+				// books
 				0: { // bae-fd541c25-229e-5280-b44b-e5c2af3e374d
 					(`{
 						"name": "Painted House",
@@ -144,7 +144,7 @@ func TestQueryOneToTwoManyWithNilUnnamedRelationship(t *testing.T) {
 						"reviewedBy_id": "bae-41598f0c-19bc-5da6-813b-e80f14a10df3"
 					}`),
 				},
-				//authors
+				// authors
 				1: {
 					// bae-41598f0c-19bc-5da6-813b-e80f14a10df3
 					(`{
@@ -229,7 +229,7 @@ func TestQueryOneToTwoManyWithNamedAndUnnamedRelationships(t *testing.T) {
 						}
 					}`,
 			Docs: map[int][]string{
-				//books
+				// books
 				0: {
 					(`{
 						"name": "Painted House",
@@ -253,7 +253,7 @@ func TestQueryOneToTwoManyWithNamedAndUnnamedRelationships(t *testing.T) {
 						"price_id": "bae-fcc7a01d-6855-5e7a-abdd-261a46dcb9bd"
 					}`),
 				},
-				//authors
+				// authors
 				1: {
 					// bae-41598f0c-19bc-5da6-813b-e80f14a10df3
 					(`{
@@ -348,7 +348,7 @@ func TestQueryOneToTwoManyWithNamedAndUnnamedRelationships(t *testing.T) {
 				}
 			}`,
 			Docs: map[int][]string{
-				//books
+				// books
 				0: {
 					(`{
 						"name": "Painted House",
@@ -372,7 +372,7 @@ func TestQueryOneToTwoManyWithNamedAndUnnamedRelationships(t *testing.T) {
 						"price_id": "bae-fcc7a01d-6855-5e7a-abdd-261a46dcb9bd"
 					}`),
 				},
-				//authors
+				// authors
 				1: {
 					// bae-41598f0c-19bc-5da6-813b-e80f14a10df3
 					(`{

--- a/db/tests/query/one_to_two_many/with_sort_test.go
+++ b/db/tests/query/one_to_two_many/with_sort_test.go
@@ -33,7 +33,7 @@ func TestQueryOneToTwoManyWithSort(t *testing.T) {
 						}
 					}`,
 			Docs: map[int][]string{
-				//books
+				// books
 				0: {
 					(`{
 						"name": "Painted House",
@@ -54,7 +54,7 @@ func TestQueryOneToTwoManyWithSort(t *testing.T) {
 						"reviewedBy_id": "bae-41598f0c-19bc-5da6-813b-e80f14a10df3"
 					}`),
 				},
-				//authors
+				// authors
 				1: {
 					// bae-41598f0c-19bc-5da6-813b-e80f14a10df3
 					(`{

--- a/db/tests/query/simple/simple_test.go
+++ b/db/tests/query/simple/simple_test.go
@@ -31,7 +31,8 @@ func TestQuerySimple(t *testing.T) {
 				(`{
 				"Name": "John",
 				"Age": 21
-			}`)},
+			}`),
+			},
 		},
 		Results: []map[string]interface{}{
 			{
@@ -59,7 +60,8 @@ func TestQuerySimpleWithAlias(t *testing.T) {
 				(`{
 				"Name": "John",
 				"Age": 21
-			}`)},
+			}`),
+			},
 		},
 		Results: []map[string]interface{}{
 			{
@@ -90,7 +92,8 @@ func TestQuerySimpleWithMultipleRows(t *testing.T) {
 				(`{
 				"Name": "Bob",
 				"Age": 27
-			}`)},
+			}`),
+			},
 		},
 		Results: []map[string]interface{}{
 			{

--- a/db/tests/query/simple/with_filter_test.go
+++ b/db/tests/query/simple/with_filter_test.go
@@ -31,7 +31,8 @@ func TestQuerySimpleWithDocKeyFilter(t *testing.T) {
 					(`{
 					"Name": "John",
 					"Age": 21
-				}`)},
+				}`),
+				},
 			},
 			Results: []map[string]interface{}{
 				{
@@ -53,7 +54,8 @@ func TestQuerySimpleWithDocKeyFilter(t *testing.T) {
 					(`{
 					"Name": "John",
 					"Age": 21
-				}`)},
+				}`),
+				},
 			},
 			Results: []map[string]interface{}{},
 		},
@@ -74,7 +76,8 @@ func TestQuerySimpleWithDocKeyFilter(t *testing.T) {
 					(`{
 						"Name": "Bob",
 						"Age": 32
-					}`)},
+					}`),
+				},
 			},
 			Results: []map[string]interface{}{
 				{
@@ -105,7 +108,8 @@ func TestQuerySimpleWithDocKeysFilter(t *testing.T) {
 					(`{
 					"Name": "John",
 					"Age": 21
-				}`)},
+				}`),
+				},
 			},
 			Results: []map[string]interface{}{
 				{
@@ -127,7 +131,8 @@ func TestQuerySimpleWithDocKeysFilter(t *testing.T) {
 					(`{
 					"Name": "John",
 					"Age": 21
-				}`)},
+				}`),
+				},
 			},
 			Results: []map[string]interface{}{},
 		},
@@ -148,7 +153,8 @@ func TestQuerySimpleWithDocKeysFilter(t *testing.T) {
 					(`{
 						"Name": "Bob",
 						"Age": 32
-					}`)},
+					}`),
+				},
 			},
 			Results: []map[string]interface{}{
 				{
@@ -178,7 +184,8 @@ func TestQuerySimpleWithDocKeysFilter(t *testing.T) {
 					(`{
 						"Name": "Jim",
 						"Age": 27
-					}`)},
+					}`),
+				},
 			},
 			Results: []map[string]interface{}{
 				{
@@ -212,7 +219,8 @@ func TestQuerySimpleWithKeyFilterBlock(t *testing.T) {
 				(`{
 				"Name": "John",
 				"Age": 21
-			}`)},
+			}`),
+			},
 		},
 		Results: []map[string]interface{}{
 			{
@@ -239,7 +247,8 @@ func TestQuerySimpleWithStringFilterBlock(t *testing.T) {
 				(`{
 				"Name": "John",
 				"Age": 21
-			}`)},
+			}`),
+			},
 		},
 		Results: []map[string]interface{}{
 			{
@@ -266,7 +275,8 @@ func TestQuerySimpleWithStringFilterBlockAndSelect(t *testing.T) {
 					(`{
 					"Name": "John",
 					"Age": 21
-				}`)},
+				}`),
+				},
 			},
 			Results: []map[string]interface{}{
 				{
@@ -286,7 +296,8 @@ func TestQuerySimpleWithStringFilterBlockAndSelect(t *testing.T) {
 					(`{
 					"Name": "John",
 					"Age": 21
-				}`)},
+				}`),
+				},
 			},
 			Results: []map[string]interface{}{
 				{
@@ -307,7 +318,8 @@ func TestQuerySimpleWithStringFilterBlockAndSelect(t *testing.T) {
 					(`{
 					"Name": "John",
 					"Age": 21
-				}`)},
+				}`),
+				},
 			},
 			Results: []map[string]interface{}{},
 		},
@@ -332,7 +344,8 @@ func TestQuerySimpleWithNumberEqualsFilterBlock(t *testing.T) {
 				(`{
 				"Name": "John",
 				"Age": 21
-			}`)},
+			}`),
+			},
 		},
 		Results: []map[string]interface{}{
 			{
@@ -360,7 +373,8 @@ func TestQuerySimpleWithNumberGreaterThanFilterBlock(t *testing.T) {
 					(`{
 					"Name": "John",
 					"Age": 21
-				}`)},
+				}`),
+				},
 			},
 			Results: []map[string]interface{}{
 				{
@@ -386,7 +400,8 @@ func TestQuerySimpleWithNumberGreaterThanFilterBlock(t *testing.T) {
 					(`{
 					"Name": "Bob",
 					"Age": 32
-				}`)},
+				}`),
+				},
 			},
 			Results: []map[string]interface{}{},
 		},
@@ -407,7 +422,8 @@ func TestQuerySimpleWithNumberGreaterThanFilterBlock(t *testing.T) {
 					(`{
 					"Name": "Bob",
 					"Age": 32
-				}`)},
+				}`),
+				},
 			},
 			Results: []map[string]interface{}{
 				{
@@ -453,7 +469,8 @@ func TestQuerySimpleWithNumberGreaterThanAndNumberLessThanFilter(t *testing.T) {
 				(`{
 				"Name": "Alice",
 				"Age": 19
-			}`)},
+			}`),
+			},
 		},
 		Results: []map[string]interface{}{
 			{
@@ -496,7 +513,8 @@ func TestQuerySimpleWithNumberEqualToXOrYFilter(t *testing.T) {
 				(`{
 				"Name": "Alice",
 				"Age": 19
-			}`)},
+			}`),
+			},
 		},
 		Results: []map[string]interface{}{
 			{
@@ -539,7 +557,8 @@ func TestQuerySimpleWithNumberInFilter(t *testing.T) {
 				(`{
 				"Name": "Alice",
 				"Age": 19
-			}`)},
+			}`),
+			},
 		},
 		Results: []map[string]interface{}{
 			{

--- a/db/tests/query/simple/with_group_average_count_test.go
+++ b/db/tests/query/simple/with_group_average_count_test.go
@@ -44,7 +44,8 @@ func TestQuerySimpleWithGroupByStringWithoutRenderedGroupAndChildIntegerAverageA
 				(`{
 				"Name": "Alice",
 				"Age": -19
-			}`)},
+			}`),
+			},
 		},
 		Results: []map[string]interface{}{
 			{

--- a/db/tests/query/simple/with_group_average_sum_test.go
+++ b/db/tests/query/simple/with_group_average_sum_test.go
@@ -55,7 +55,8 @@ func TestQuerySimpleWithGroupByStringWithInnerGroupBooleanAndSumOfCountOfInt(t *
 				"Name": "Alice",
 				"Age": 19,
 				"Verified": false
-			}`)},
+			}`),
+			},
 		},
 		Results: []map[string]interface{}{
 			{
@@ -126,7 +127,8 @@ func TestQuerySimpleWithGroupByStringWithoutRenderedGroupAndChildIntegerAverageA
 				(`{
 				"Name": "Alice",
 				"Age": -19
-			}`)},
+			}`),
+			},
 		},
 		Results: []map[string]interface{}{
 			{

--- a/db/tests/query/simple/with_group_average_test.go
+++ b/db/tests/query/simple/with_group_average_test.go
@@ -30,7 +30,8 @@ func TestQuerySimpleWithGroupByStringWithoutRenderedGroupAndAverageOfUndefined(t
 				(`{
 				"Name": "John",
 				"Age": 32
-			}`)},
+			}`),
+			},
 		},
 		ExpectedError: "Aggregate must be provided with a property to aggregate.",
 	}
@@ -61,7 +62,8 @@ func TestQuerySimpleWithGroupByStringWithoutRenderedGroupAndChildIntegerAverage(
 				(`{
 				"Name": "Alice",
 				"Age": -19
-			}`)},
+			}`),
+			},
 		},
 		Results: []map[string]interface{}{
 			{
@@ -100,7 +102,8 @@ func TestQuerySimpleWithGroupByStringWithoutRenderedGroupAndChildNilAverage(t *t
 				(`{
 				"Name": "Alice",
 				"Age": 19
-			}`)},
+			}`),
+			},
 		},
 		Results: []map[string]interface{}{
 			{
@@ -156,7 +159,8 @@ func TestQuerySimpleWithGroupByStringWithInnerGroupBooleanAndAverageOfAverageOfI
 				"Name": "Alice",
 				"Age": 19,
 				"Verified": false
-			}`)},
+			}`),
+			},
 		},
 		Results: []map[string]interface{}{
 			{
@@ -220,7 +224,8 @@ func TestQuerySimpleWithGroupByStringWithoutRenderedGroupAndChildEmptyFloatAvera
 			}`),
 				(`{
 				"Name": "Alice"
-			}`)},
+			}`),
+			},
 		},
 		Results: []map[string]interface{}{
 			{
@@ -259,7 +264,8 @@ func TestQuerySimpleWithGroupByStringWithoutRenderedGroupAndChildFloatAverage(t 
 				(`{
 				"Name": "Alice",
 				"HeightM": 2.04
-			}`)},
+			}`),
+			},
 		},
 		Results: []map[string]interface{}{
 			{
@@ -315,7 +321,8 @@ func TestQuerySimpleWithGroupByStringWithInnerGroupBooleanAndAverageOfAverageOfF
 				"Name": "Alice",
 				"HeightM": 2.04,
 				"Verified": false
-			}`)},
+			}`),
+			},
 		},
 		Results: []map[string]interface{}{
 			{
@@ -406,7 +413,8 @@ func TestQuerySimpleWithGroupByStringWithInnerGroupBooleanAndAverageOfAverageOfA
 				"HeightM": 2.04,
 				"Age": 19,
 				"Verified": false
-			}`)},
+			}`),
+			},
 		},
 		Results: []map[string]interface{}{
 			{

--- a/db/tests/query/simple/with_group_count_sum_test.go
+++ b/db/tests/query/simple/with_group_count_sum_test.go
@@ -55,7 +55,8 @@ func TestQuerySimpleWithGroupByStringWithInnerGroupBooleanAndSumOfCount(t *testi
 				"Name": "Alice",
 				"Age": 19,
 				"Verified": false
-			}`)},
+			}`),
+			},
 		},
 		Results: []map[string]interface{}{
 			{

--- a/db/tests/query/simple/with_group_count_test.go
+++ b/db/tests/query/simple/with_group_count_test.go
@@ -38,7 +38,8 @@ func TestQuerySimpleWithGroupByNumberWithoutRenderedGroupAndChildCount(t *testin
 				(`{
 				"Name": "Alice",
 				"Age": 19
-			}`)},
+			}`),
+			},
 		},
 		Results: []map[string]interface{}{
 			{
@@ -80,7 +81,8 @@ func TestQuerySimpleWithGroupByNumberWithRenderedGroupAndChildCount(t *testing.T
 				(`{
 				"Name": "Alice",
 				"Age": 19
-			}`)},
+			}`),
+			},
 		},
 		Results: []map[string]interface{}{
 			{
@@ -132,7 +134,8 @@ func TestQuerySimpleWithGroupByNumberWithUndefinedField(t *testing.T) {
 				(`{
 				"Name": "Alice",
 				"Age": 19
-			}`)},
+			}`),
+			},
 		},
 		ExpectedError: "Aggregate must be provided with a property to aggregate.",
 	}
@@ -162,7 +165,8 @@ func TestQuerySimpleWithGroupByNumberWithoutRenderedGroupAndAliasesChildCount(t 
 				(`{
 				"Name": "Alice",
 				"Age": 19
-			}`)},
+			}`),
+			},
 		},
 		Results: []map[string]interface{}{
 			{
@@ -204,7 +208,8 @@ func TestQuerySimpleWithGroupByNumberWithoutRenderedGroupAndDuplicatedAliasedChi
 				(`{
 				"Name": "Alice",
 				"Age": 19
-			}`)},
+			}`),
+			},
 		},
 		Results: []map[string]interface{}{
 			{

--- a/db/tests/query/simple/with_group_filter_test.go
+++ b/db/tests/query/simple/with_group_filter_test.go
@@ -44,7 +44,8 @@ func TestQuerySimpleWithGroupByStringWithGroupNumberFilter(t *testing.T) {
 				(`{
 				"Name": "Alice",
 				"Age": 19
-			}`)},
+			}`),
+			},
 		},
 		Results: []map[string]interface{}{
 			{
@@ -101,7 +102,8 @@ func TestQuerySimpleWithGroupByStringWithGroupNumberWithParentFilter(t *testing.
 				(`{
 				"Name": "Alice",
 				"Age": 19
-			}`)},
+			}`),
+			},
 		},
 		Results: []map[string]interface{}{
 			{
@@ -168,7 +170,8 @@ func TestQuerySimpleWithGroupByStringWithInnerGroupBooleanThenInnerNumberFilterT
 				"Name": "Alice",
 				"Age": 19,
 				"Verified": false
-			}`)},
+			}`),
+			},
 		},
 		Results: []map[string]interface{}{
 			{

--- a/db/tests/query/simple/with_group_sort_test.go
+++ b/db/tests/query/simple/with_group_sort_test.go
@@ -44,7 +44,8 @@ func TestQuerySimpleWithGroupByStringWithGroupNumberWithGroupSort(t *testing.T) 
 				(`{
 				"Name": "Alice",
 				"Age": 19
-			}`)},
+			}`),
+			},
 		},
 		Results: []map[string]interface{}{
 			{
@@ -108,7 +109,8 @@ func TestQuerySimpleWithGroupByStringWithGroupNumberWithGroupSortDescending(t *t
 				(`{
 				"Name": "Alice",
 				"Age": 19
-			}`)},
+			}`),
+			},
 		},
 		Results: []map[string]interface{}{
 			{
@@ -172,7 +174,8 @@ func TestQuerySimpleWithGroupByStringAndOrderDescendingWithGroupNumberWithGroupS
 				(`{
 				"Name": "Alice",
 				"Age": 19
-			}`)},
+			}`),
+			},
 		},
 		Results: []map[string]interface{}{
 			{
@@ -248,7 +251,8 @@ func TestQuerySimpleWithGroupByStringWithInnerGroupBooleanThenInnerSortDescendin
 				"Name": "Alice",
 				"Age": 19,
 				"Verified": false
-			}`)},
+			}`),
+			},
 		},
 		Results: []map[string]interface{}{
 			{
@@ -349,7 +353,8 @@ func TestQuerySimpleWithGroupByStringWithInnerGroupBooleanAndOrderAscendingThenI
 				"Name": "Alice",
 				"Age": 19,
 				"Verified": false
-			}`)},
+			}`),
+			},
 		},
 		Results: []map[string]interface{}{
 			{

--- a/db/tests/query/simple/with_group_sum_test.go
+++ b/db/tests/query/simple/with_group_sum_test.go
@@ -30,7 +30,8 @@ func TestQuerySimpleWithGroupByStringWithoutRenderedGroupAndSumOfUndefined(t *te
 				(`{
 				"Name": "John",
 				"Age": 32
-			}`)},
+			}`),
+			},
 		},
 		ExpectedError: "Aggregate must be provided with a property to aggregate.",
 	}
@@ -61,7 +62,8 @@ func TestQuerySimpleWithGroupByStringWithoutRenderedGroupAndChildIntegerSum(t *t
 				(`{
 				"Name": "Alice",
 				"Age": -19
-			}`)},
+			}`),
+			},
 		},
 		Results: []map[string]interface{}{
 			{
@@ -100,7 +102,8 @@ func TestQuerySimpleWithGroupByStringWithoutRenderedGroupAndChildNilSum(t *testi
 				(`{
 				"Name": "Alice",
 				"Age": 19
-			}`)},
+			}`),
+			},
 		},
 		Results: []map[string]interface{}{
 			{
@@ -156,7 +159,8 @@ func TestQuerySimpleWithGroupByStringWithInnerGroupBooleanAndSumOfSumOfInt(t *te
 				"Name": "Alice",
 				"Age": 19,
 				"Verified": false
-			}`)},
+			}`),
+			},
 		},
 		Results: []map[string]interface{}{
 			{
@@ -220,7 +224,8 @@ func TestQuerySimpleWithGroupByStringWithoutRenderedGroupAndChildEmptyFloatSum(t
 			}`),
 				(`{
 				"Name": "Alice"
-			}`)},
+			}`),
+			},
 		},
 		Results: []map[string]interface{}{
 			{
@@ -259,7 +264,8 @@ func TestQuerySimpleWithGroupByStringWithoutRenderedGroupAndChildFloatSum(t *tes
 				(`{
 				"Name": "Alice",
 				"HeightM": 2.04
-			}`)},
+			}`),
+			},
 		},
 		Results: []map[string]interface{}{
 			{
@@ -315,7 +321,8 @@ func TestQuerySimpleWithGroupByStringWithInnerGroupBooleanAndSumOfSumOfFloat(t *
 				"Name": "Alice",
 				"HeightM": 2.04,
 				"Verified": false
-			}`)},
+			}`),
+			},
 		},
 		Results: []map[string]interface{}{
 			{
@@ -406,7 +413,8 @@ func TestQuerySimpleWithGroupByStringWithInnerGroupBooleanAndSumOfSumOfSumOfFloa
 				"HeightM": 2.04,
 				"Age": 19,
 				"Verified": false
-			}`)},
+			}`),
+			},
 		},
 		Results: []map[string]interface{}{
 			{

--- a/db/tests/query/simple/with_group_test.go
+++ b/db/tests/query/simple/with_group_test.go
@@ -41,7 +41,8 @@ func TestQuerySimpleWithGroupByNumber(t *testing.T) {
 				(`{
 				"Name": "Alice",
 				"Age": 19
-			}`)},
+			}`),
+			},
 		},
 		Results: []map[string]interface{}{
 			{
@@ -87,7 +88,8 @@ func TestQuerySimpleWithGroupByNumberWithGroupString(t *testing.T) {
 				(`{
 				"Name": "Alice",
 				"Age": 19
-			}`)},
+			}`),
+			},
 		},
 		Results: []map[string]interface{}{
 			{
@@ -151,7 +153,8 @@ func TestQuerySimpleWithGroupByString(t *testing.T) {
 				(`{
 				"Name": "Alice",
 				"Age": 19
-			}`)},
+			}`),
+			},
 		},
 		Results: []map[string]interface{}{
 			{
@@ -227,7 +230,8 @@ func TestQuerySimpleWithGroupByStringWithInnerGroupBoolean(t *testing.T) {
 				"Name": "Alice",
 				"Age": 19,
 				"Verified": false
-			}`)},
+			}`),
+			},
 		},
 		Results: []map[string]interface{}{
 			{
@@ -324,7 +328,8 @@ func TestQuerySimpleWithGroupByStringThenBoolean(t *testing.T) {
 				"Name": "Alice",
 				"Age": 19,
 				"Verified": false
-			}`)},
+			}`),
+			},
 		},
 		Results: []map[string]interface{}{
 			{
@@ -410,7 +415,8 @@ func TestQuerySimpleWithGroupByBooleanThenNumber(t *testing.T) {
 				"Name": "Alice",
 				"Age": 19,
 				"Verified": false
-			}`)},
+			}`),
+			},
 		},
 		Results: []map[string]interface{}{
 			{

--- a/db/tests/query/simple/with_limit_offset_test.go
+++ b/db/tests/query/simple/with_limit_offset_test.go
@@ -35,7 +35,8 @@ func TestQuerySimpleWithLimit(t *testing.T) {
 					(`{
 					"Name": "Bob",
 					"Age": 32
-				}`)},
+				}`),
+				},
 			},
 			Results: []map[string]interface{}{
 				{
@@ -69,7 +70,8 @@ func TestQuerySimpleWithLimit(t *testing.T) {
 					(`{
 					"Name": "Alice",
 					"Age": 19
-				}`)},
+				}`),
+				},
 			},
 			Results: []map[string]interface{}{
 				{
@@ -108,7 +110,8 @@ func TestQuerySimpleWithLimitAndOffset(t *testing.T) {
 					(`{
 					"Name": "Bob",
 					"Age": 32
-				}`)},
+				}`),
+				},
 			},
 			Results: []map[string]interface{}{
 				{
@@ -142,7 +145,8 @@ func TestQuerySimpleWithLimitAndOffset(t *testing.T) {
 					(`{
 					"Name": "Alice",
 					"Age": 19
-				}`)},
+				}`),
+				},
 			},
 			Results: []map[string]interface{}{
 				{

--- a/db/tests/query/simple/with_sort_filter_test.go
+++ b/db/tests/query/simple/with_sort_filter_test.go
@@ -42,7 +42,8 @@ func TestQuerySimpleWithNumericGreaterThanFilterAndNumericSortDescending(t *test
 				(`{
 				"Name": "Alice",
 				"Age": 19
-			}`)},
+			}`),
+			},
 		},
 		Results: []map[string]interface{}{
 			{

--- a/db/tests/query/simple/with_sort_test.go
+++ b/db/tests/query/simple/with_sort_test.go
@@ -42,7 +42,8 @@ func TestQuerySimpleWithNumericSortAscending(t *testing.T) {
 				(`{
 				"Name": "Alice",
 				"Age": 19
-			}`)},
+			}`),
+			},
 		},
 		Results: []map[string]interface{}{
 			{
@@ -93,7 +94,8 @@ func TestQuerySimpleWithNumericSortDescending(t *testing.T) {
 				(`{
 				"Name": "Alice",
 				"Age": 19
-			}`)},
+			}`),
+			},
 		},
 		Results: []map[string]interface{}{
 			{
@@ -149,7 +151,8 @@ func TestQuerySimpleWithNumericSortDescendingAndBooleanSortAscending(t *testing.
 				"Name": "Alice",
 				"Age": 19,
 				"Verified": false
-			}`)},
+			}`),
+			},
 		},
 		Results: []map[string]interface{}{
 			{

--- a/db/tests/query/simple/with_version_test.go
+++ b/db/tests/query/simple/with_version_test.go
@@ -37,7 +37,8 @@ func TestQuerySimpleWithEmbeddedLatestCommit(t *testing.T) {
 				(`{
 				"Name": "John",
 				"Age": 21
-			}`)},
+			}`),
+			},
 		},
 		Results: []map[string]interface{}{
 			{

--- a/db/tests/utils.go
+++ b/db/tests/utils.go
@@ -125,10 +125,12 @@ For each test:
 */
 var detectDbChanges bool
 
-var detectDbChangesCodeDir string
-var setupOnly bool
-var areDatabaseFormatChangesDocumented bool
-var previousTestCaseTestName string
+var (
+	detectDbChangesCodeDir             string
+	setupOnly                          bool
+	areDatabaseFormatChangesDocumented bool
+	previousTestCaseTestName           string
+)
 
 func init() {
 	// We use environment variables instead of flags `go test ./...` throws for all packages
@@ -549,7 +551,6 @@ func setupDatabaseUsingTargetBranch(
 		fileBadgerPathEnvName+"="+dbi.path,
 	)
 	out, err := goTestCmd.Output()
-
 	if err != nil {
 		// If file is not found - this must be a new test and
 		// doesn't exist in the target branch, so we pass it

--- a/logging/config.go
+++ b/logging/config.go
@@ -10,11 +10,13 @@
 
 package logging
 
-type EncoderFormat = int8
-type EncoderFormatOption struct {
-	EncoderFormat EncoderFormat
-	HasValue      bool
-}
+type (
+	EncoderFormat       = int8
+	EncoderFormatOption struct {
+		EncoderFormat EncoderFormat
+		HasValue      bool
+	}
+)
 
 func NewEncoderFormatOption(v EncoderFormat) EncoderFormatOption {
 	return EncoderFormatOption{
@@ -28,11 +30,13 @@ const (
 	CSV
 )
 
-type LogLevel = int8
-type LogLevelOption struct {
-	LogLevel LogLevel
-	HasValue bool
-}
+type (
+	LogLevel       = int8
+	LogLevelOption struct {
+		LogLevel LogLevel
+		HasValue bool
+	}
+)
 
 func NewLogLevelOption(v LogLevel) LogLevelOption {
 	return LogLevelOption{

--- a/logging/registry.go
+++ b/logging/registry.go
@@ -14,11 +14,15 @@ import (
 	"sync"
 )
 
-var configMutex sync.RWMutex
-var cachedConfig Config
+var (
+	configMutex  sync.RWMutex
+	cachedConfig Config
+)
 
-var registryMutex sync.Mutex
-var registry map[string][]Logger = map[string][]Logger{}
+var (
+	registryMutex sync.Mutex
+	registry      map[string][]Logger = map[string][]Logger{}
+)
 
 func register(name string, logger Logger) {
 	registryMutex.Lock()

--- a/merkle/clock/clock.go
+++ b/merkle/clock/clock.go
@@ -23,9 +23,7 @@ import (
 	"github.com/sourcenetwork/defradb/logging"
 )
 
-var (
-	log = logging.MustNewLogger("defra.merkleclock")
-)
+var log = logging.MustNewLogger("defra.merkleclock")
 
 type MerkleClock struct {
 	headstore datastore.DSReaderWriter

--- a/merkle/clock/heads.go
+++ b/merkle/clock/heads.go
@@ -14,10 +14,9 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"sort"
-
-	"errors"
 
 	"github.com/sourcenetwork/defradb/core"
 	"github.com/sourcenetwork/defradb/datastore"

--- a/merkle/clock/heads_test.go
+++ b/merkle/clock/heads_test.go
@@ -276,5 +276,4 @@ func TestHeaddsList(t *testing.T) {
 		t.Errorf("Invalid max height from List, have %v, want %v", h, uint64(2))
 		return
 	}
-
 }

--- a/merkle/crdt/composite.go
+++ b/merkle/crdt/composite.go
@@ -23,26 +23,24 @@ import (
 	"github.com/ipfs/go-cid"
 )
 
-var (
-	compFactoryFn = MerkleCRDTFactory(
-		func(
-			mstore datastore.MultiStore,
-			schemaID string,
-			bs corenet.Broadcaster,
-		) MerkleCRDTInitFn {
-			return func(key core.DataStoreKey) MerkleCRDT {
-				return NewMerkleCompositeDAG(
-					mstore.Datastore(),
-					mstore.Headstore(),
-					mstore.DAGstore(),
-					schemaID,
-					bs,
-					core.DataStoreKey{},
-					key,
-				)
-			}
-		},
-	)
+var compFactoryFn = MerkleCRDTFactory(
+	func(
+		mstore datastore.MultiStore,
+		schemaID string,
+		bs corenet.Broadcaster,
+	) MerkleCRDTInitFn {
+		return func(key core.DataStoreKey) MerkleCRDT {
+			return NewMerkleCompositeDAG(
+				mstore.Datastore(),
+				mstore.Headstore(),
+				mstore.DAGstore(),
+				schemaID,
+				bs,
+				core.DataStoreKey{},
+				key,
+			)
+		}
+	},
 )
 
 func init() {

--- a/merkle/crdt/factory.go
+++ b/merkle/crdt/factory.go
@@ -19,9 +19,7 @@ import (
 	"github.com/sourcenetwork/defradb/datastore"
 )
 
-var (
-	ErrFactoryTypeNoExist = errors.New("No such factory for the given type exists")
-)
+var ErrFactoryTypeNoExist = errors.New("No such factory for the given type exists")
 
 // MerkleCRDTInitFn instantiates a MerkleCRDT with a given key
 type MerkleCRDTInitFn func(core.DataStoreKey) MerkleCRDT
@@ -42,12 +40,10 @@ type Factory struct {
 	multistore datastore.MultiStore
 }
 
-var (
-	// DefaultFactory is instantiated with no stores
-	// It is recommended to use this only after you call
-	// WithStores(...) so you get a new non-shared instance
-	DefaultFactory = NewFactory(nil)
-)
+// DefaultFactory is instantiated with no stores
+// It is recommended to use this only after you call
+// WithStores(...) so you get a new non-shared instance
+var DefaultFactory = NewFactory(nil)
 
 // NewFactory returns a newly instanciated factory object with the assigned stores
 // It may be called with all stores set to nil

--- a/merkle/crdt/lwwreg.go
+++ b/merkle/crdt/lwwreg.go
@@ -25,20 +25,18 @@ import (
 	"github.com/ipfs/go-cid"
 )
 
-var (
-	lwwFactoryFn = MerkleCRDTFactory(
-		func(mstore datastore.MultiStore, _ string, _ corenet.Broadcaster) MerkleCRDTInitFn {
-			return func(key core.DataStoreKey) MerkleCRDT {
-				return NewMerkleLWWRegister(
-					mstore.Datastore(),
-					mstore.Headstore(),
-					mstore.DAGstore(),
-					core.DataStoreKey{},
-					key,
-				)
-			}
-		},
-	)
+var lwwFactoryFn = MerkleCRDTFactory(
+	func(mstore datastore.MultiStore, _ string, _ corenet.Broadcaster) MerkleCRDTInitFn {
+		return func(key core.DataStoreKey) MerkleCRDT {
+			return NewMerkleLWWRegister(
+				mstore.Datastore(),
+				mstore.Headstore(),
+				mstore.DAGstore(),
+				core.DataStoreKey{},
+				key,
+			)
+		}
+	},
 )
 
 func init() {

--- a/merkle/crdt/merklecrdt.go
+++ b/merkle/crdt/merklecrdt.go
@@ -23,9 +23,7 @@ import (
 	"github.com/sourcenetwork/defradb/logging"
 )
 
-var (
-	log = logging.MustNewLogger("defra.merklecrdt")
-)
+var log = logging.MustNewLogger("defra.merklecrdt")
 
 // MerkleCRDT is the implementation of a Merkle Clock along with a
 // CRDT payload. It implements the ReplicatedData interface
@@ -35,10 +33,8 @@ type MerkleCRDT interface {
 	Clock() core.MerkleClock
 }
 
-var (
-	// defaultMerkleCRDTs                     = make(map[Type]MerkleCRDTFactory)
-	_ core.ReplicatedData = (*baseMerkleCRDT)(nil)
-)
+// defaultMerkleCRDTs                     = make(map[Type]MerkleCRDTFactory)
+var _ core.ReplicatedData = (*baseMerkleCRDT)(nil)
 
 // The baseMerkleCRDT handles the merkle crdt overhead functions
 // that aren't CRDT specific like the mutations and state retrieval

--- a/merkle/crdt/merklecrdt_test.go
+++ b/merkle/crdt/merklecrdt_test.go
@@ -67,7 +67,6 @@ func printStore(ctx context.Context, store datastore.DSReaderWriter) {
 	}
 
 	results, err := store.Query(ctx, q)
-
 	if err != nil {
 		panic(err)
 	}

--- a/net/api/service.go
+++ b/net/api/service.go
@@ -25,9 +25,7 @@ import (
 	pb "github.com/sourcenetwork/defradb/net/api/pb"
 )
 
-var (
-	log = logging.Logger("netapi")
-)
+var log = logging.Logger("netapi")
 
 type Service struct {
 	peer *net.Peer

--- a/net/dag.go
+++ b/net/dag.go
@@ -25,9 +25,7 @@ import (
 	"github.com/sourcenetwork/defradb/logging"
 )
 
-var (
-	DAGSyncTimeout = time.Second * 60
-)
+var DAGSyncTimeout = time.Second * 60
 
 // A DAGSyncer is an abstraction to an IPLD-based p2p storage layer.  A
 // DAGSyncer is a DAGService with the ability to publish new ipld nodes to the
@@ -106,7 +104,6 @@ func (p *Peer) dagWorker() {
 			job.node,
 			job.nodeGetter,
 		)
-
 		if err != nil {
 			log.ErrorE(
 				p.ctx,

--- a/net/dialer.go
+++ b/net/dialer.go
@@ -29,10 +29,8 @@ import (
 	pb "github.com/sourcenetwork/defradb/net/pb"
 )
 
-var (
-	// DialTimeout is the max time duration to wait when dialing a peer.
-	DialTimeout = time.Second * 10
-)
+// DialTimeout is the max time duration to wait when dialing a peer.
+var DialTimeout = time.Second * 10
 
 // dial attempts to open a gRPC connection over libp2p to a peer.
 // nolint

--- a/net/net.go
+++ b/net/net.go
@@ -16,6 +16,4 @@ import (
 	"github.com/sourcenetwork/defradb/logging"
 )
 
-var (
-	log = logging.MustNewLogger("defra.net")
-)
+var log = logging.MustNewLogger("defra.net")

--- a/net/peer.go
+++ b/net/peer.go
@@ -38,14 +38,12 @@ import (
 	pb "github.com/sourcenetwork/defradb/net/pb"
 )
 
-var (
-	numWorkers = 5
-)
+var numWorkers = 5
 
 // Peer is a DefraDB Peer node which exposes all the LibP2P host/peer functionality
 // to the underlying DefraDB instance.
 type Peer struct {
-	//config??
+	// config??
 
 	db client.DB
 

--- a/net/process.go
+++ b/net/process.go
@@ -40,7 +40,8 @@ func (p *Peer) processLog(
 	c cid.Cid,
 	field string,
 	nd ipld.Node,
-	getter format.NodeGetter) ([]cid.Cid, error) {
+	getter format.NodeGetter,
+) ([]cid.Cid, error) {
 	log.Debug(ctx, "Running processLog")
 
 	txn, err := p.db.NewTxn(ctx, false)

--- a/net/server.go
+++ b/net/server.go
@@ -74,7 +74,6 @@ func newServer(p *Peer, db client.DB, opts ...grpc.DialOption) (*server, error) 
 
 		i := 0
 		if keyResults != nil {
-
 			for key := range keyResults {
 				if key.Err != nil {
 					log.ErrorE(p.ctx, "Failed to get a key to register pubsub topic", key.Err)
@@ -308,7 +307,6 @@ func (s *server) pubSubEventHandler(from libpeer.ID, topic string, msg []byte) {
 }
 
 func (s *server) listAllDocKeys() (<-chan client.DocKeysResult, error) {
-
 	// get all collections
 	cols, err := s.db.GetAllCollections(s.peer.ctx)
 	if err != nil {

--- a/net/utils/util.go
+++ b/net/utils/util.go
@@ -20,9 +20,7 @@ import (
 	ma "github.com/multiformats/go-multiaddr"
 )
 
-var (
-	bootstrapPeers = []string{}
-)
+var bootstrapPeers = []string{}
 
 func DefaultBoostrapPeers() []peer.AddrInfo {
 	ipfspeers := ipfslite.DefaultBootstrapPeers()

--- a/node/node.go
+++ b/node/node.go
@@ -41,9 +41,7 @@ Basically it combines db/DB, net/Peer, and net/Server into a single Node
 object.
 */
 
-var (
-	log = logging.MustNewLogger("defra.node")
-)
+var log = logging.MustNewLogger("defra.node")
 
 type Node struct {
 	// embed the DB interface into the node
@@ -178,7 +176,7 @@ func getHostKey(keypath string) (crypto.PrivKey, error) {
 		if err := os.MkdirAll(keypath, os.ModePerm); err != nil {
 			return nil, err
 		}
-		if err = os.WriteFile(pth, bytes, 0400); err != nil {
+		if err = os.WriteFile(pth, bytes, 0o400); err != nil {
 			return nil, err
 		}
 		return key, nil

--- a/query/graphql/parser/filter_test.go
+++ b/query/graphql/parser/filter_test.go
@@ -40,7 +40,7 @@ func TestNewFilterFromString(t *testing.T) {
 }
 
 func TestParseConditions_Empty(t *testing.T) {
-	var query = (`
+	query := (`
 	query {
 		users(filter: {})
 	}`)

--- a/query/graphql/parser/mutation.go
+++ b/query/graphql/parser/mutation.go
@@ -27,17 +27,13 @@ const (
 	DeleteObjects
 )
 
-var (
-	mutationNameToType = map[string]MutationType{
-		"create": CreateObjects,
-		"update": UpdateObjects,
-		"delete": DeleteObjects,
-	}
-)
+var mutationNameToType = map[string]MutationType{
+	"create": CreateObjects,
+	"update": UpdateObjects,
+	"delete": DeleteObjects,
+}
 
-var (
-	ErrEmptyDataPayload = errors.New("given data payload is empty")
-)
+var ErrEmptyDataPayload = errors.New("given data payload is empty")
 
 type ObjectPayload struct {
 	Object map[string]interface{}

--- a/query/graphql/parser/mutation_test.go
+++ b/query/graphql/parser/mutation_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestMutationParse_Create_Simple(t *testing.T) {
-	var query = (`
+	query := (`
 	mutation {
 		create_Book(data: "{\"a\": 1}") {
 			_key
@@ -50,7 +50,7 @@ func TestMutationParse_Create_Simple(t *testing.T) {
 }
 
 func TestMutationParse_Create_Error_Missing_Data(t *testing.T) {
-	var query = (`
+	query := (`
 	mutation {
 		create_Book(data: "") {
 			_key
@@ -81,7 +81,7 @@ func TestMutationParse_Create_Error_Missing_Data(t *testing.T) {
 }
 
 func TestMutationParse_Error_Invalid_Mutation(t *testing.T) {
-	var query = (`
+	query := (`
 	mutation {
 		dostuff_Book(data: "") {
 			_key
@@ -112,7 +112,7 @@ func TestMutationParse_Error_Invalid_Mutation(t *testing.T) {
 }
 
 func TestMutationParse_Update_Simple_Object(t *testing.T) {
-	var query = (`
+	query := (`
 	mutation {
 		update_Book(data: "{\"a\": 1}") {
 			_key
@@ -143,7 +143,7 @@ func TestMutationParse_Update_Simple_Object(t *testing.T) {
 }
 
 func TestMutationParse_Update_Simple_Array(t *testing.T) {
-	var query = (`
+	query := (`
 	mutation {
 		update_Book(data: "[{\"a\": 1}]") {
 			_key
@@ -177,7 +177,7 @@ func TestMutationParse_Update_Simple_Array(t *testing.T) {
 }
 
 func TestMutationParse_Update_Filter(t *testing.T) {
-	var query = (`
+	query := (`
 	mutation {
 		update_Book(filter: {rating: {_gt: 4.5}}, data: "{\"a\": 1}") {
 			_key
@@ -214,7 +214,7 @@ func TestMutationParse_Update_Filter(t *testing.T) {
 }
 
 func TestMutationParse_Update_Simple_UnderscoreName(t *testing.T) {
-	var query = (`
+	query := (`
 	mutation {
 		update_my_book(data: "{\"a\": 1}") {
 			_key
@@ -245,7 +245,7 @@ func TestMutationParse_Update_Simple_UnderscoreName(t *testing.T) {
 }
 
 func TestMutationParse_Delete_Simple(t *testing.T) {
-	var query = (`
+	query := (`
 	mutation {
 		delete_Book(data: "{\"a\": 1}") {
 			_key

--- a/query/graphql/parser/query.go
+++ b/query/graphql/parser/query.go
@@ -190,12 +190,10 @@ const (
 	DESC SortDirection = "DESC"
 )
 
-var (
-	NameToSortDirection = map[string]SortDirection{
-		"ASC":  ASC,
-		"DESC": DESC,
-	}
-)
+var NameToSortDirection = map[string]SortDirection{
+	"ASC":  ASC,
+	"DESC": DESC,
+}
 
 type SortCondition struct {
 	// field may be a compound field statement

--- a/query/graphql/parser/query_test.go
+++ b/query/graphql/parser/query_test.go
@@ -23,7 +23,7 @@ import (
 // }
 
 func TestQueryParse_Limit_Limit(t *testing.T) {
-	var query = (`
+	query := (`
 	query {
 		users(limit: 10)
 	}`)
@@ -45,7 +45,7 @@ func TestQueryParse_Limit_Limit(t *testing.T) {
 }
 
 func TestQueryParse_FindByDockey(t *testing.T) {
-	var query = (`
+	query := (`
 	query {
 		users(dockey: "test")
 	}`)
@@ -66,7 +66,7 @@ func TestQueryParse_FindByDockey(t *testing.T) {
 }
 
 func TestQueryParse_Offset(t *testing.T) {
-	var query = (`
+	query := (`
 	query {
 		users(offset: 100)
 	}`)
@@ -88,7 +88,7 @@ func TestQueryParse_Offset(t *testing.T) {
 }
 
 func TestQueryParse_Limit_Offset(t *testing.T) {
-	var query = (`
+	query := (`
 	query {
 		users(limit: 1, offset: 100)
 	}`)
@@ -110,7 +110,7 @@ func TestQueryParse_Limit_Offset(t *testing.T) {
 }
 
 func TestQueryParse_Commit_Latest(t *testing.T) {
-	var query = (`
+	query := (`
 	query {
 		latestCommits(dockey: "baf123") {
 			cid

--- a/query/graphql/planner/dagscan.go
+++ b/query/graphql/planner/dagscan.go
@@ -158,6 +158,7 @@ func (n *dagScanNode) Init() error {
 	}
 	return nil
 }
+
 func (n *dagScanNode) Start() error {
 	if n.headset != nil {
 		return n.headset.Start()
@@ -270,7 +271,6 @@ func (n *dagScanNode) Next() (bool, error) {
 			// queue our found heads
 			n.queuedCids.PushFront(h.Cid)
 		}
-
 	}
 	n.cid = nil // clear cid for next round
 	return true, nil

--- a/query/graphql/planner/executor.go
+++ b/query/graphql/planner/executor.go
@@ -19,7 +19,7 @@ import (
 	"github.com/sourcenetwork/defradb/query/graphql/parser"
 	"github.com/sourcenetwork/defradb/query/graphql/schema"
 
-	//github.com/uber-go/multierr
+	// github.com/uber-go/multierr
 	gql "github.com/graphql-go/graphql"
 	gqlp "github.com/graphql-go/graphql/language/parser"
 	"github.com/graphql-go/graphql/language/source"

--- a/query/graphql/planner/planner.go
+++ b/query/graphql/planner/planner.go
@@ -22,9 +22,7 @@ import (
 	"github.com/sourcenetwork/defradb/query/graphql/parser"
 )
 
-var (
-	log = logging.MustNewLogger("defra.query.planner")
-)
+var log = logging.MustNewLogger("defra.query.planner")
 
 // planNode is an interface all nodes in the plan tree need to implement
 type planNode interface {
@@ -108,7 +106,6 @@ type Planner struct {
 	evalCtx parser.EvalContext
 
 	// isFinalized bool
-
 }
 
 func makePlanner(ctx context.Context, db client.DB, txn datastore.Txn) *Planner {
@@ -155,7 +152,6 @@ func (p *Planner) newObjectMutationPlan(stmt *parser.Mutation) (planNode, error)
 	default:
 		return nil, fmt.Errorf("unknown mutation action %T", stmt.Type)
 	}
-
 }
 
 func (p *Planner) makePlan(stmt parser.Statement) (planNode, error) {

--- a/query/graphql/planner/type_join.go
+++ b/query/graphql/planner/type_join.go
@@ -176,7 +176,7 @@ func (p *Planner) makeTypeJoinOne(
 	source planNode,
 	subType *parser.Select,
 ) (*typeJoinOne, error) {
-	//ignore recurse for now.
+	// ignore recurse for now.
 	typeJoin := &typeJoinOne{
 		p:    p,
 		root: source,
@@ -313,7 +313,6 @@ func (n *typeJoinOne) valuesPrimary(doc map[string]interface{}) map[string]inter
 	// or if we encounter an error just return the base doc,
 	// with an empty map for the subdoc
 	next, err := n.subType.Next()
-
 	if err != nil {
 		log.ErrorE(n.p.ctx, "Sub-type initalization error at scan node reset", err)
 		return doc
@@ -359,7 +358,7 @@ func (p *Planner) makeTypeJoinMany(
 	source planNode,
 	subType *parser.Select,
 ) (*typeJoinMany, error) {
-	//ignore recurse for now.
+	// ignore recurse for now.
 	typeJoin := &typeJoinMany{
 		p:    p,
 		root: source,

--- a/query/graphql/planner/versionedscan.go
+++ b/query/graphql/planner/versionedscan.go
@@ -21,9 +21,7 @@ import (
 	"github.com/ipfs/go-cid"
 )
 
-var (
-	emptyCID = cid.Cid{}
-)
+var emptyCID = cid.Cid{}
 
 // scans an index for records
 type versionedScanNode struct {

--- a/query/graphql/schema/generate.go
+++ b/query/graphql/schema/generate.go
@@ -86,7 +86,6 @@ func (g *Generator) FromAST(ctx context.Context, document *ast.Document) ([]*gql
 	}
 
 	result, err := g.fromAST(ctx, document)
-
 	if err != nil {
 		// - If there is an error we should drop any new objects as they may be partial, polluting
 		//   the in-memory cache.
@@ -258,7 +257,7 @@ func (g *Generator) expandInputArgument(obj *gql.Object) error {
 				obj.AddFieldConfig(f, expandedField)
 			}
 			// @todo: check if NonNull is possible here
-			//case *gql.NonNull:
+			// case *gql.NonNull:
 			// get subtype
 		}
 	}

--- a/query/graphql/schema/generate_test.go
+++ b/query/graphql/schema/generate_test.go
@@ -15,7 +15,6 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
-
 	"strings"
 	"testing"
 
@@ -81,7 +80,8 @@ func Test_Generator_buildTypesFromAST_SingleScalarField(t *testing.T) {
 							Type: gql.String,
 						},
 					}, nil
-				})},
+				}),
+			},
 			),
 		}, "")
 }
@@ -146,7 +146,8 @@ func Test_Generator_buildTypesFromAST_SingleNonNullScalarField(t *testing.T) {
 							Type: gql.NewNonNull(gql.String),
 						},
 					}, nil
-				})},
+				}),
+			},
 			),
 		}, "")
 }
@@ -194,7 +195,8 @@ func Test_Generator_buildTypesFromAST_SingleListScalarField(t *testing.T) {
 							Type: gql.NewList(gql.String),
 						},
 					}, nil
-				})},
+				}),
+			},
 			),
 		}, "")
 }
@@ -242,7 +244,8 @@ func Test_Generator_buildTypesFromAST_SingleListNonNullScalarField(t *testing.T)
 							Type: gql.NewList(gql.NewNonNull(gql.String)),
 						},
 					}, nil
-				})},
+				}),
+			},
 			),
 		}, "")
 }
@@ -290,7 +293,8 @@ func Test_Generator_buildTypesFromAST_SingleNonNullListScalarField(t *testing.T)
 							Type: gql.NewNonNull(gql.NewList(gql.String)),
 						},
 					}, nil
-				})},
+				}),
+			},
 			),
 		}, "")
 }
@@ -338,7 +342,8 @@ func Test_Generator_buildTypesFromAST_SingleNonNullListNonNullScalarField(t *tes
 							Type: gql.NewNonNull(gql.NewList(gql.NewNonNull(gql.String))),
 						},
 					}, nil
-				})},
+				}),
+			},
 			),
 		}, "")
 }
@@ -411,7 +416,8 @@ func Test_Generator_buildTypesFromAST_MultiScalarField(t *testing.T) {
 							Type: gql.ID,
 						},
 					}, nil
-				})},
+				}),
+			},
 			),
 		}, "")
 }
@@ -463,7 +469,8 @@ func Test_Generator_buildTypesFromAST_MultiObjectSingleScalarField(t *testing.T)
 							Type: gql.String,
 						},
 					}, nil
-				})},
+				}),
+			},
 			),
 			gql.NewObject(gql.ObjectConfig{
 				Name: "OtherObject",
@@ -498,7 +505,8 @@ func Test_Generator_buildTypesFromAST_MultiObjectSingleScalarField(t *testing.T)
 							Type: gql.Boolean,
 						},
 					}, nil
-				})},
+				}),
+			},
 			),
 		}, "")
 }
@@ -556,7 +564,8 @@ func Test_Generator_buildTypesFromAST_MultiObjectMultiScalarField(t *testing.T) 
 							Type: gql.Int,
 						},
 					}, nil
-				})},
+				}),
+			},
 			),
 			gql.NewObject(gql.ObjectConfig{
 				Name: "OtherObject",
@@ -595,7 +604,8 @@ func Test_Generator_buildTypesFromAST_MultiObjectMultiScalarField(t *testing.T) 
 							Type: gql.Float,
 						},
 					}, nil
-				})},
+				}),
+			},
 			),
 		}, "")
 }
@@ -636,7 +646,8 @@ func Test_Generator_buildTypesFromAST_MultiObjectSingleObjectField(t *testing.T)
 					Type: gql.String,
 				},
 			}, nil
-		})},
+		}),
+	},
 	)
 
 	runTestConfigForbuildTypesFromASTSuite(t, g,
@@ -688,7 +699,8 @@ func Test_Generator_buildTypesFromAST_MultiObjectSingleObjectField(t *testing.T)
 							Type: gql.ID,
 						},
 					}, nil
-				})},
+				}),
+			},
 			),
 		}, "")
 }
@@ -754,7 +766,8 @@ func Test_Generator_buildTypesFromAST_MissingObject(t *testing.T) {
 							Type: gql.ID,
 						},
 					}, nil
-				})},
+				}),
+			},
 			),
 		}, "No type found for given name: UndefinedObject")
 }
@@ -762,7 +775,6 @@ func Test_Generator_buildTypesFromAST_MissingObject(t *testing.T) {
 func runTestConfigForbuildTypesFromASTSuite(t *testing.T, g *Generator, schema string, typeDefs []*gql.Object, expectedError string) {
 	ctx := context.Background()
 	_, _, err := g.FromSDL(ctx, schema)
-
 	if err != nil {
 		assertError(t, err, expectedError)
 		return

--- a/query/graphql/schema/relations.go
+++ b/query/graphql/schema/relations.go
@@ -324,7 +324,6 @@ func genRelationName(t1, t2 string) (string, error) {
 		return fmt.Sprintf("%s_%s", t1, t2), nil
 	}
 	return fmt.Sprintf("%s_%s", t2, t1), nil
-
 }
 
 // IsPrimary returns true if the Relation_Primary bit is set

--- a/query/graphql/schema/schema.go
+++ b/query/graphql/schema/schema.go
@@ -14,6 +14,4 @@ import (
 	"github.com/sourcenetwork/defradb/logging"
 )
 
-var (
-	log = logging.MustNewLogger("defra.query.schema")
-)
+var log = logging.MustNewLogger("defra.query.schema")

--- a/query/graphql/schema/types/types.go
+++ b/query/graphql/schema/types/types.go
@@ -94,5 +94,4 @@ var (
 )
 
 func init() {
-
 }

--- a/tools/configs/golangci.yaml
+++ b/tools/configs/golangci.yaml
@@ -84,28 +84,29 @@ linters:
   disable-all: true
   enable:
     - deadcode
+    - errcheck
+    - forbidigo
+    - gofumpt
+    - goheader
     - gosimple
     - govet
     - ineffassign
+    - lll
+    - revive
     - staticcheck
     - structcheck
     - typecheck
     - unused
     - varcheck
-    - errcheck
-    - forbidigo
-    - lll
-    - revive
-    - goheader
-   # - wrapcheck
     # - errorlint
-    # - gci
     # - exportloopref
-    # - megacheck
+    # - gci
     # - govet
-    # - wsl
+    # - megacheck
     # - nilerr
     # - nilnil
+    # - wrapcheck
+    # - wsl
   enable-all: false
   disable:
     # - maligned


### PR DESCRIPTION
### RELATED ISSUE(S):
Resolves #406

### DESCRIPTION:
More consistent go formatting that is compatible with `gofmt`, so much so that running `gofmt` wouldn't change anything as `gofumpt` is a stricter subset of `gofmt`. 