### PR TITLE
refactor: Rename NewCidV1_SHA2_256 to mixedCaps

### DIFF
--- a/core/cid.go
+++ b/core/cid.go
@@ -15,7 +15,7 @@ import (
 	mh "github.com/multiformats/go-multihash"
 )
 
-func NewCidV1_SHA2_256(data []byte) (cid.Cid, error) {
+func NewSHA256CidV1(data []byte) (cid.Cid, error) {
 	pref := cid.Prefix{
 		Version:  1,
 		Codec:    cid.Raw,

--- a/db/collection.go
+++ b/db/collection.go
@@ -159,7 +159,7 @@ func (db *db) CreateCollection(
 	}
 
 	// add a reference to this DB by desc hash
-	cid, err := core.NewCidV1_SHA2_256(buf)
+	cid, err := core.NewSHA256CidV1(buf)
 	if err != nil {
 		return nil, err
 	}
@@ -203,7 +203,7 @@ func (db *db) GetCollectionByName(ctx context.Context, name string) (client.Coll
 	}
 
 	// add a reference to this DB by desc hash
-	cid, err := core.NewCidV1_SHA2_256(buf)
+	cid, err := core.NewSHA256CidV1(buf)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Resolves #414

A small style change to make NewCidV1_SHA2_256 more idiomatic.