### PR TITLE
feat: Configurable caller option of logger

### DIFF
--- a/logging/config.go
+++ b/logging/config.go
@@ -10,11 +10,13 @@
 
 package logging
 
-type EncoderFormat = int8
-type EncoderFormatOption struct {
-	EncoderFormat EncoderFormat
-	HasValue      bool
-}
+type (
+	EncoderFormat       = int8
+	EncoderFormatOption struct {
+		EncoderFormat EncoderFormat
+		HasValue      bool
+	}
+)
 
 func NewEncoderFormatOption(v EncoderFormat) EncoderFormatOption {
 	return EncoderFormatOption{
@@ -28,11 +30,13 @@ const (
 	CSV
 )
 
-type LogLevel = int8
-type LogLevelOption struct {
-	LogLevel LogLevel
-	HasValue bool
-}
+type (
+	LogLevel       = int8
+	LogLevelOption struct {
+		LogLevel LogLevel
+		HasValue bool
+	}
+)
 
 func NewLogLevelOption(v LogLevel) LogLevelOption {
 	return LogLevelOption{
@@ -54,6 +58,11 @@ type EnableStackTraceOption struct {
 	HasValue         bool
 }
 
+type EnableCallerOption struct {
+	EnableCaller bool
+	HasValue     bool
+}
+
 func NewEnableStackTraceOption(enable bool) EnableStackTraceOption {
 	return EnableStackTraceOption{
 		EnableStackTrace: enable,
@@ -61,18 +70,27 @@ func NewEnableStackTraceOption(enable bool) EnableStackTraceOption {
 	}
 }
 
+func NewEnableCallerOption(enable bool) EnableCallerOption {
+	return EnableCallerOption{
+		EnableCaller: enable,
+		HasValue:     true,
+	}
+}
+
 type Config struct {
 	Level                 LogLevelOption
-	EnableStackTrace      EnableStackTraceOption
 	EncoderFormat         EncoderFormatOption
+	EnableStackTrace      EnableStackTraceOption
+	EnableCaller          EnableCallerOption
 	OutputPaths           []string
 	OverridesByLoggerName map[string]OverrideConfig
 }
 
 type OverrideConfig struct {
 	Level            LogLevelOption
-	EnableStackTrace EnableStackTraceOption
 	EncoderFormat    EncoderFormatOption
+	EnableStackTrace EnableStackTraceOption
+	EnableCaller     EnableCallerOption
 	OutputPaths      []string
 }
 
@@ -80,6 +98,7 @@ func (c Config) forLogger(name string) Config {
 	loggerConfig := Config{
 		Level:            c.Level,
 		EnableStackTrace: c.EnableStackTrace,
+		EnableCaller:     c.EnableCaller,
 		EncoderFormat:    c.EncoderFormat,
 		OutputPaths:      c.OutputPaths,
 	}
@@ -90,6 +109,9 @@ func (c Config) forLogger(name string) Config {
 		}
 		if override.EnableStackTrace.HasValue {
 			loggerConfig.EnableStackTrace = override.EnableStackTrace
+		}
+		if override.EnableCaller.HasValue {
+			loggerConfig.EnableCaller = override.EnableCaller
 		}
 		if override.EncoderFormat.HasValue {
 			loggerConfig.EncoderFormat = override.EncoderFormat
@@ -118,6 +140,7 @@ func (c Config) copy() Config {
 		EnableStackTrace:      c.EnableStackTrace,
 		EncoderFormat:         c.EncoderFormat,
 		OutputPaths:           c.OutputPaths,
+		EnableCaller:          c.EnableCaller,
 		OverridesByLoggerName: overridesByLoggerName,
 	}
 }
@@ -131,6 +154,10 @@ func (oldConfig Config) with(newConfigOptions Config) Config {
 
 	if newConfigOptions.EnableStackTrace.HasValue {
 		newConfig.EnableStackTrace = newConfigOptions.EnableStackTrace
+	}
+
+	if newConfigOptions.EnableCaller.HasValue {
+		newConfig.EnableCaller = newConfigOptions.EnableCaller
 	}
 
 	if newConfigOptions.EncoderFormat.HasValue {
@@ -147,6 +174,7 @@ func (oldConfig Config) with(newConfigOptions Config) Config {
 		newConfig.OverridesByLoggerName[k] = OverrideConfig{
 			Level:            o.Level,
 			EnableStackTrace: o.EnableStackTrace,
+			EnableCaller:     o.EnableCaller,
 			EncoderFormat:    o.EncoderFormat,
 			OutputPaths:      o.OutputPaths,
 		}

--- a/logging/logger.go
+++ b/logging/logger.go
@@ -127,6 +127,7 @@ func buildZapLogger(name string, config Config) (*zap.Logger, error) {
 	defaultConfig.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
 	defaultConfig.EncoderConfig.EncodeLevel = zapcore.CapitalColorLevelEncoder
 	defaultConfig.DisableStacktrace = true
+	defaultConfig.DisableCaller = true
 
 	if config.Level.HasValue {
 		defaultConfig.Level = zap.NewAtomicLevelAt(zapcore.Level(config.Level.LogLevel))
@@ -134,6 +135,10 @@ func buildZapLogger(name string, config Config) (*zap.Logger, error) {
 
 	if config.EnableStackTrace.HasValue {
 		defaultConfig.DisableStacktrace = !config.EnableStackTrace.EnableStackTrace
+	}
+
+	if config.EnableCaller.HasValue {
+		defaultConfig.DisableCaller = !config.EnableCaller.EnableCaller
 	}
 
 	if config.EncoderFormat.HasValue {

--- a/logging/logging_test.go
+++ b/logging/logging_test.go
@@ -52,7 +52,8 @@ func TestLogWritesFatalMessageToLogAndKillsProcess(t *testing.T) {
 	assert.Equal(t, logMessage, logLines[0]["msg"])
 	assert.Equal(t, "FATAL", logLines[0]["level"])
 	assert.Equal(t, "TestLogName", logLines[0]["logger"])
-	assert.Contains(t, logLines[0]["caller"], "logging_test.go")
+	// caller is disabled by default
+	assert.NotContains(t, logLines[0], "logging_test.go")
 	// stacktrace is disabled by default
 	assert.NotContains(t, logLines[0], "stacktrace")
 }
@@ -88,8 +89,9 @@ func TestLogWritesFatalMessageWithStackTraceToLogAndKillsProcessGivenStackTraceE
 	assert.Equal(t, logMessage, logLines[0]["msg"])
 	assert.Equal(t, "FATAL", logLines[0]["level"])
 	assert.Equal(t, "TestLogName", logLines[0]["logger"])
-	assert.Contains(t, logLines[0]["caller"], "logging_test.go")
 	assert.Contains(t, logLines[0], "stacktrace")
+	// caller is disabled by default
+	assert.NotContains(t, logLines[0], "logging_test.go")
 }
 
 func TestLogWritesFatalEMessageToLogAndKillsProcess(t *testing.T) {
@@ -122,7 +124,8 @@ func TestLogWritesFatalEMessageToLogAndKillsProcess(t *testing.T) {
 	assert.Equal(t, logMessage, logLines[0]["msg"])
 	assert.Equal(t, "FATAL", logLines[0]["level"])
 	assert.Equal(t, "TestLogName", logLines[0]["logger"])
-	assert.Contains(t, logLines[0]["caller"], "logging_test.go")
+	// caller is disabled by default
+	assert.NotContains(t, logLines[0], "logging_test.go")
 	// stacktrace is disabled by default
 	assert.NotContains(t, logLines[0], "stacktrace")
 }
@@ -158,8 +161,9 @@ func TestLogWritesFatalEMessageWithStackTraceToLogAndKillsProcessGivenStackTrace
 	assert.Equal(t, logMessage, logLines[0]["msg"])
 	assert.Equal(t, "FATAL", logLines[0]["level"])
 	assert.Equal(t, "TestLogName", logLines[0]["logger"])
-	assert.Contains(t, logLines[0]["caller"], "logging_test.go")
 	assert.Contains(t, logLines[0], "stacktrace")
+	// caller is disabled by default
+	assert.NotContains(t, logLines[0], "logging_test.go")
 }
 
 type LogLevelTestCase struct {
@@ -168,6 +172,7 @@ type LogLevelTestCase struct {
 	ExpectedLogLevel string
 	WithStackTrace   bool
 	ExpectStackTrace bool
+	WithCaller       bool
 }
 
 func logDebug(l Logger, c context.Context, m string)  { l.Debug(c, m) }
@@ -178,39 +183,44 @@ func logErrorE(l Logger, c context.Context, m string) { l.ErrorE(c, m, fmt.Error
 
 func getLogLevelTestCase() []LogLevelTestCase {
 	return []LogLevelTestCase{
-		{Debug, logDebug, "DEBUG", false, false},
-		{Debug, logInfo, "INFO", false, false},
-		{Debug, logWarn, "WARN", false, false},
-		{Debug, logError, "ERROR", false, false},
-		{Debug, logError, "ERROR", true, true},
-		{Debug, logErrorE, "ERROR", false, false},
-		{Debug, logErrorE, "ERROR", true, true},
-		{Info, logDebug, "", false, false},
-		{Info, logInfo, "INFO", false, false},
-		{Info, logWarn, "WARN", false, false},
-		{Info, logError, "ERROR", false, false},
-		{Info, logError, "ERROR", true, true},
-		{Info, logErrorE, "ERROR", false, false},
-		{Info, logErrorE, "ERROR", true, true},
-		{Warn, logDebug, "", false, false},
-		{Warn, logInfo, "", false, false},
-		{Warn, logWarn, "WARN", false, false},
-		{Warn, logError, "ERROR", false, false},
-		{Warn, logError, "ERROR", true, true},
-		{Warn, logErrorE, "ERROR", false, false},
-		{Warn, logErrorE, "ERROR", true, true},
-		{Error, logDebug, "", false, false},
-		{Error, logInfo, "", false, false},
-		{Error, logWarn, "", false, false},
-		{Error, logError, "ERROR", false, false},
-		{Error, logError, "ERROR", true, true},
-		{Error, logErrorE, "ERROR", false, false},
-		{Error, logErrorE, "ERROR", true, true},
-		{Fatal, logDebug, "", false, false},
-		{Fatal, logInfo, "", false, false},
-		{Fatal, logWarn, "", false, false},
-		{Fatal, logError, "", false, false},
-		{Fatal, logErrorE, "", false, false},
+		{Debug, logDebug, "DEBUG", false, false, true},
+		{Debug, logDebug, "DEBUG", false, false, false},
+		{Debug, logInfo, "INFO", false, false, false},
+		{Debug, logWarn, "WARN", false, false, false},
+		{Debug, logError, "ERROR", false, false, false},
+		{Debug, logError, "ERROR", true, true, false},
+		{Debug, logErrorE, "ERROR", false, false, false},
+		{Debug, logErrorE, "ERROR", true, true, false},
+		{Info, logDebug, "", false, false, false},
+		{Info, logInfo, "INFO", false, false, true},
+		{Info, logInfo, "INFO", false, false, false},
+		{Info, logWarn, "WARN", false, false, false},
+		{Info, logError, "ERROR", false, false, false},
+		{Info, logError, "ERROR", true, true, false},
+		{Info, logErrorE, "ERROR", false, false, false},
+		{Info, logErrorE, "ERROR", true, true, false},
+		{Warn, logDebug, "", false, false, false},
+		{Warn, logInfo, "", false, false, false},
+		{Warn, logWarn, "WARN", false, false, true},
+		{Warn, logWarn, "WARN", false, false, false},
+		{Warn, logError, "ERROR", false, false, false},
+		{Warn, logError, "ERROR", true, true, false},
+		{Warn, logErrorE, "ERROR", false, false, false},
+		{Warn, logErrorE, "ERROR", true, true, false},
+		{Error, logDebug, "", false, false, false},
+		{Error, logInfo, "", false, false, false},
+		{Error, logWarn, "", false, false, false},
+		{Error, logError, "ERROR", false, false, true},
+		{Error, logError, "ERROR", false, false, false},
+		{Error, logError, "ERROR", true, true, false},
+		{Error, logErrorE, "ERROR", false, false, false},
+		{Error, logErrorE, "ERROR", true, true, false},
+		{Fatal, logDebug, "", false, false, true},
+		{Fatal, logDebug, "", false, false, false},
+		{Fatal, logInfo, "", false, false, false},
+		{Fatal, logWarn, "", false, false, false},
+		{Fatal, logError, "", false, false, false},
+		{Fatal, logErrorE, "", false, false, false},
 	}
 }
 
@@ -220,6 +230,7 @@ func TestLogWritesMessagesToLog(t *testing.T) {
 		logger, logPath := getLogger(t, func(c *Config) {
 			c.Level = NewLogLevelOption(tc.LogLevel)
 			c.EnableStackTrace = NewEnableStackTraceOption(tc.WithStackTrace)
+			c.EnableCaller = NewEnableCallerOption(tc.WithCaller)
 		})
 		logMessage := "test log message"
 
@@ -238,7 +249,8 @@ func TestLogWritesMessagesToLog(t *testing.T) {
 			assert.Equal(t, "TestLogName", logLines[0]["logger"])
 			_, hasStackTrace := logLines[0]["stacktrace"]
 			assert.Equal(t, tc.ExpectStackTrace, hasStackTrace)
-			assert.Contains(t, logLines[0]["caller"], "logging_test.go")
+			_, hasCaller := logLines[0]["caller"]
+			assert.Equal(t, tc.WithCaller, hasCaller)
 		}
 	}
 }
@@ -252,6 +264,7 @@ func TestLogWritesMessagesToLogGivenUpdatedLogLevel(t *testing.T) {
 		SetConfig(Config{
 			Level:            NewLogLevelOption(tc.LogLevel),
 			EnableStackTrace: NewEnableStackTraceOption(tc.WithStackTrace),
+			EnableCaller:     NewEnableCallerOption(tc.WithCaller),
 		})
 		logMessage := "test log message"
 
@@ -270,7 +283,8 @@ func TestLogWritesMessagesToLogGivenUpdatedLogLevel(t *testing.T) {
 			assert.Equal(t, "TestLogName", logLines[0]["logger"])
 			_, hasStackTrace := logLines[0]["stacktrace"]
 			assert.Equal(t, tc.ExpectStackTrace, hasStackTrace)
-			assert.Contains(t, logLines[0]["caller"], "logging_test.go")
+			_, hasCaller := logLines[0]["caller"]
+			assert.Equal(t, tc.WithCaller, hasCaller)
 		}
 	}
 }
@@ -287,6 +301,7 @@ func TestLogWritesMessagesToLogGivenUpdatedContextLogLevel(t *testing.T) {
 		SetConfig(Config{
 			Level:            NewLogLevelOption(tc.LogLevel),
 			EnableStackTrace: NewEnableStackTraceOption(tc.WithStackTrace),
+			EnableCaller:     NewEnableCallerOption(tc.WithCaller),
 		})
 		logMessage := "test log message"
 
@@ -305,7 +320,8 @@ func TestLogWritesMessagesToLogGivenUpdatedContextLogLevel(t *testing.T) {
 			assert.Equal(t, "TestLogName", logLines[0]["logger"])
 			_, hasStackTrace := logLines[0]["stacktrace"]
 			assert.Equal(t, tc.ExpectStackTrace, hasStackTrace)
-			assert.Contains(t, logLines[0]["caller"], "logging_test.go")
+			_, hasCaller := logLines[0]["caller"]
+			assert.Equal(t, tc.WithCaller, hasCaller)
 		}
 	}
 }
@@ -355,7 +371,6 @@ func TestLogWritesMessagesToLogGivenUpdatedLogPath(t *testing.T) {
 			assert.Equal(t, logMessage, logLines[0]["msg"])
 			assert.Equal(t, tc.ExpectedLogLevel, logLines[0]["level"])
 			assert.Equal(t, "TestLogName", logLines[0]["logger"])
-			assert.Contains(t, logLines[0]["caller"], "logging_test.go")
 		}
 	}
 }
@@ -399,7 +414,8 @@ func TestLogWritesMessagesToLogGivenOverrideForLoggerReducingLogLevel(t *testing
 	assert.Equal(t, logMessage, logLines[0]["msg"])
 	assert.Equal(t, "WARN", logLines[0]["level"])
 	assert.Equal(t, "TestLogName", logLines[0]["logger"])
-	assert.Contains(t, logLines[0]["caller"], "logging_test.go")
+	// caller is disabled by default
+	assert.NotContains(t, logLines[0], "logging_test.go")
 }
 
 func TestLogWritesMessagesToLogGivenOverrideForLoggerRaisingLogLevel(t *testing.T) {
@@ -422,7 +438,8 @@ func TestLogWritesMessagesToLogGivenOverrideForLoggerRaisingLogLevel(t *testing.
 	assert.Equal(t, logMessage, logLines[0]["msg"])
 	assert.Equal(t, "WARN", logLines[0]["level"])
 	assert.Equal(t, "TestLogName", logLines[0]["logger"])
-	assert.Contains(t, logLines[0]["caller"], "logging_test.go")
+	// caller is disabled by default
+	assert.NotContains(t, logLines[0], "logging_test.go")
 }
 
 func TestLogDoesNotWriteMessagesToLogGivenOverrideForLoggerRaisingLogLevel(t *testing.T) {
@@ -487,7 +504,8 @@ func TestLogWritesMessagesToLogGivenOverrideUpdatedForLoggerReducingLogLevel(t *
 	assert.Equal(t, logMessage, logLines[0]["msg"])
 	assert.Equal(t, "WARN", logLines[0]["level"])
 	assert.Equal(t, "TestLogName", logLines[0]["logger"])
-	assert.Contains(t, logLines[0]["caller"], "logging_test.go")
+	// caller is disabled by default
+	assert.NotContains(t, logLines[0], "logging_test.go")
 }
 
 func TestLogWritesMessagesToLogGivenOverrideUpdatedForAnotherLoggerRaisingLogLevel(t *testing.T) {
@@ -512,7 +530,8 @@ func TestLogWritesMessagesToLogGivenOverrideUpdatedForAnotherLoggerRaisingLogLev
 	assert.Equal(t, logMessage, logLines[0]["msg"])
 	assert.Equal(t, "WARN", logLines[0]["level"])
 	assert.Equal(t, "TestLogName", logLines[0]["logger"])
-	assert.Contains(t, logLines[0]["caller"], "logging_test.go")
+	// caller is disabled by default
+	assert.NotContains(t, logLines[0], "logging_test.go")
 }
 
 func TestLogDoesNotWriteMessagesToLogGivenOverrideUpdatedForLoggerRaisingLogLevel(t *testing.T) {


### PR DESCRIPTION
Adds the `EnableCaller` option to the logger configuration. Disables it by default for a more readable default log output.

The reasoning is that usual users of defradb don't benefit from the code file & line number information.

A short subsequent PR will make it configurable via config file, CLI flag, env. variable, after #389 merges.

----

from
```
2022-05-06T10:45:21.851-0400, INFO, defra.cli, cmd/start.go:58, Starting DefraDB process...
2022-05-06T10:45:21.851-0400, INFO, defra.cli, cmd/start.go:68, opening badger store, {"Path": "/Users/o/.defradb/data"}
2022-05-06T10:45:21.887-0400, INFO, defra.cli, cmd/start.go:104, Starting P2P node, {"tcp address": "/ip4/0.0.0.0/tcp/9161"}
2022-05-06T10:45:21.890-0400, INFO, defra.node, node/node.go:110, Created LibP2P host, {"PeerId": "12D3KooWAsGqxLjQTxzHebhgziT8B4147grxqGAzddC2sXTk4YFX", "Address": ["/ip4/0.0.0.0/tcp/9171"]}
```

going to 
```
2022-05-06T10:44:54.922-0400, INFO, defra.cli, Starting DefraDB process...
2022-05-06T10:44:54.922-0400, INFO, defra.cli, opening badger store, {"Path": "/Users/o/.defradb/data"}
2022-05-06T10:44:54.946-0400, INFO, defra.cli, Starting P2P node, {"tcp address": "/ip4/0.0.0.0/tcp/9161"}
2022-05-06T10:44:54.950-0400, INFO, defra.node, Created LibP2P host, {"PeerId": "12D3KooWAsGqxLjQTxzHebhgziT8B4147grxqGAzddC2sXTk4YFX", "Address": ["/ip4/0.0.0.0/tcp/9171"]}
```