### PR TITLE
tools: Disable auto-fixing linter issues by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,6 +111,10 @@ validate\:circleci:
 lint:
 	golangci-lint run --config tools/configs/golangci.yaml
 
+.PHONY: lint\:fix
+lint\:fix:
+	golangci-lint run --config tools/configs/golangci.yaml --fix
+
 .PHONY: lint\:todo
 lint\:todo:
 	rg "nolint" -g '!{Makefile}'

--- a/tools/configs/golangci.yaml
+++ b/tools/configs/golangci.yaml
@@ -194,14 +194,8 @@ issues:
   # of integration: much better don't allow issues in new code.
   new: false
 
-  # Show only new issues created after git revision `REV`
-  # new-from-rev: REV
-
-  # Show only new issues created in git patch with set file path.
-  # new-from-patch: path/to/patch/file
-
-  # Fix found issues (if it's supported by the linter)
-  fix: true
+  # Don't auto-fix found issues by default (even if it's supported by the linter).
+  fix: false
 
 
 #==================================================================[ All Settings Of Specific Linters We Have Enabled]


### PR DESCRIPTION
## RELATED ISSUES(S):
Resolves #428 

## DESCRIPTION:
- Changes `make lint` to be a read-only lint operation.
- Adds a `make lint:fix` rule to do auto-fixing using linters.