### PR TITLE
fix: Issue preventing DB from restarting with no records

### DIFF
--- a/db/collection.go
+++ b/db/collection.go
@@ -287,7 +287,6 @@ func (c *collection) GetAllDocKeys(ctx context.Context) (<-chan client.DocKeysRe
 	if err != nil {
 		return nil, err
 	}
-	defer c.discardImplicitTxn(ctx, txn)
 
 	return c.getAllDocKeysChan(ctx, txn)
 }
@@ -314,6 +313,7 @@ func (c *collection) getAllDocKeysChan(
 				log.ErrorE(ctx, "Failed to close AllDocKeys query", err)
 			}
 			close(resCh)
+			c.discardImplicitTxn(ctx, txn)
 		}()
 		for res := range q.Next() {
 			// check for Done on context first


### PR DESCRIPTION
Fixes #386 

Simple fix. `GetAllDocKeys` returns a channel that will return results, but the same func also discards the transaction in a defer statement, which gets called after the return of the channel.

Moved the transaction discard into the cleanup routine of the subprocedure that handles the original channel cleanup.