### PR TITLE
refactor: Alias internal doc object

### DIFF
--- a/core/doc.go
+++ b/core/doc.go
@@ -1,0 +1,13 @@
+// Copyright 2022 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package core
+
+type Doc = map[string]interface{}

--- a/db/container/container.go
+++ b/db/container/container.go
@@ -10,6 +10,10 @@
 
 package container
 
+import (
+	"github.com/sourcenetwork/defradb/core"
+)
+
 // DocumentContainer is a specialized buffer to store potentially
 // thousands of document value maps. Its used by the Planner system
 // to store documents that need to have logic applied to all of them.
@@ -19,7 +23,7 @@ package container
 // Close() is called if you want to free all the memory associated
 // with the container
 type DocumentContainer struct {
-	docs    []map[string]interface{}
+	docs    []core.Doc
 	numDocs int
 }
 
@@ -28,13 +32,13 @@ type DocumentContainer struct {
 // A capacity of 0 ignores any initial pre-allocation.
 func NewDocumentContainer(capacity int) *DocumentContainer {
 	return &DocumentContainer{
-		docs:    make([]map[string]interface{}, capacity),
+		docs:    make([]core.Doc, capacity),
 		numDocs: 0,
 	}
 }
 
 // At returns the document at the specified index.
-func (c *DocumentContainer) At(index int) map[string]interface{} {
+func (c *DocumentContainer) At(index int) core.Doc {
 	if index < 0 || index >= c.numDocs {
 		panic("Invalid index for document container")
 	}
@@ -47,12 +51,12 @@ func (c *DocumentContainer) Len() int {
 
 // AddDoc adds a new document to the DocumentContainer.
 // It makes a deep copy before its added
-func (c *DocumentContainer) AddDoc(doc map[string]interface{}) error {
+func (c *DocumentContainer) AddDoc(doc core.Doc) error {
 	if doc == nil {
 		return nil
 	}
 	// append to docs slice
-	copyDoc := copyMap(doc)
+	copyDoc := copyDoc(doc)
 	c.docs = append(c.docs, copyDoc)
 	c.numDocs++
 	return nil
@@ -75,12 +79,18 @@ func (c *DocumentContainer) Close() {
 	c.numDocs = 0
 }
 
-func copyMap(m map[string]interface{}) map[string]interface{} {
-	cp := make(map[string]interface{})
+func copyDoc(m core.Doc) core.Doc {
+	cp := make(core.Doc)
 	for k, v := range m {
-		vm, ok := v.(map[string]interface{})
+		vm, ok := v.(core.Doc)
 		if ok {
-			cp[k] = copyMap(vm)
+			cp[k] = copyDoc(vm)
+		} else if innerDocs, isDocArray := v.([]core.Doc); isDocArray {
+			innerMaps := make([]core.Doc, len(innerDocs))
+			for i, d := range innerDocs {
+				innerMaps[i] = copyDoc(d)
+			}
+			cp[k] = innerMaps
 		} else {
 			cp[k] = v
 		}

--- a/db/fetcher/encoded_doc.go
+++ b/db/fetcher/encoded_doc.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/fxamacker/cbor/v2"
 	"github.com/sourcenetwork/defradb/client"
+	"github.com/sourcenetwork/defradb/core"
 )
 
 type EPTuple []encProperty
@@ -154,8 +155,8 @@ func (encdoc *encodedDocument) Decode() (*client.Document, error) {
 
 // DecodeToMap returns a decoded document as a
 // map of field/value pairs
-func (encdoc *encodedDocument) DecodeToMap() (map[string]interface{}, error) {
-	doc := make(map[string]interface{})
+func (encdoc *encodedDocument) DecodeToMap() (core.Doc, error) {
+	doc := make(core.Doc)
 	doc["_key"] = string(encdoc.Key)
 	for fieldDesc, prop := range encdoc.Properties {
 		_, val, err := prop.Decode()

--- a/db/fetcher/fetcher.go
+++ b/db/fetcher/fetcher.go
@@ -33,7 +33,7 @@ type Fetcher interface {
 	Start(ctx context.Context, txn datastore.Txn, spans core.Spans) error
 	FetchNext(ctx context.Context) (*encodedDocument, error)
 	FetchNextDecoded(ctx context.Context) (*client.Document, error)
-	FetchNextMap(ctx context.Context) ([]byte, map[string]interface{}, error)
+	FetchNextMap(ctx context.Context) ([]byte, core.Doc, error)
 	Close() error
 }
 
@@ -367,11 +367,11 @@ func (df *DocumentFetcher) FetchNextDecoded(ctx context.Context) (*client.Docume
 	return df.decodedDoc, nil
 }
 
-// FetchNextMap returns the next document as a map[string]interface{}
+// FetchNextMap returns the next document as a core.Doc
 // The first return value is the parsed document key
 func (df *DocumentFetcher) FetchNextMap(
 	ctx context.Context,
-) ([]byte, map[string]interface{}, error) {
+) ([]byte, core.Doc, error) {
 	encdoc, err := df.FetchNext(ctx)
 	if err != nil {
 		return nil, nil, err

--- a/query/graphql/parser/filter.go
+++ b/query/graphql/parser/filter.go
@@ -21,6 +21,7 @@ import (
 	"github.com/graphql-go/graphql/language/ast"
 	gqlp "github.com/graphql-go/graphql/language/parser"
 	gqls "github.com/graphql-go/graphql/language/source"
+	"github.com/sourcenetwork/defradb/core"
 )
 
 type EvalContext struct {
@@ -224,7 +225,7 @@ func parseVal(val ast.Value, recurseFn parseFn) (interface{}, error) {
 
 // RunFilter runs the given filter expression
 // using the document, and evaluates.
-func RunFilter(doc map[string]interface{}, filter *Filter, ctx EvalContext) (bool, error) {
+func RunFilter(doc core.Doc, filter *Filter, ctx EvalContext) (bool, error) {
 	if filter == nil {
 		return true, nil
 	}

--- a/query/graphql/planner/commit.go
+++ b/query/graphql/planner/commit.go
@@ -167,12 +167,12 @@ type commitSelectTopNode struct {
 	plan planNode
 }
 
-func (n *commitSelectTopNode) Init() error                   { return n.plan.Init() }
-func (n *commitSelectTopNode) Start() error                  { return n.plan.Start() }
-func (n *commitSelectTopNode) Next() (bool, error)           { return n.plan.Next() }
-func (n *commitSelectTopNode) Spans(spans core.Spans)        { n.plan.Spans(spans) }
-func (n *commitSelectTopNode) Value() map[string]interface{} { return n.plan.Value() }
-func (n *commitSelectTopNode) Source() planNode              { return n.plan }
+func (n *commitSelectTopNode) Init() error            { return n.plan.Init() }
+func (n *commitSelectTopNode) Start() error           { return n.plan.Start() }
+func (n *commitSelectTopNode) Next() (bool, error)    { return n.plan.Next() }
+func (n *commitSelectTopNode) Spans(spans core.Spans) { n.plan.Spans(spans) }
+func (n *commitSelectTopNode) Value() core.Doc        { return n.plan.Value() }
+func (n *commitSelectTopNode) Source() planNode       { return n.plan }
 func (n *commitSelectTopNode) Close() error {
 	if n.plan == nil {
 		return nil

--- a/query/graphql/planner/count.go
+++ b/query/graphql/planner/count.go
@@ -76,7 +76,7 @@ func (n *countNode) Next() (bool, error) {
 			// so this is fine here now, but may need to be moved later once external
 			// count filter support is added.
 			if count > 0 && n.filter != nil {
-				docArray, isDocArray := property.([]map[string]interface{})
+				docArray, isDocArray := property.([]core.Doc)
 				if isDocArray {
 					count = 0
 					for _, doc := range docArray {

--- a/query/graphql/planner/delete.go
+++ b/query/graphql/planner/delete.go
@@ -74,7 +74,7 @@ func (n *deleteNode) Next() (bool, error) {
 
 		// Consume the deletes into our valuesNode
 		for _, resKey := range results.DocKeys {
-			err := n.deleteIter.docs.AddDoc(map[string]interface{}{"_key": resKey})
+			err := n.deleteIter.docs.AddDoc(core.Doc{"_key": resKey})
 			if err != nil {
 				return false, err
 			}
@@ -89,7 +89,7 @@ func (n *deleteNode) Next() (bool, error) {
 	return n.deleteIter.Next()
 }
 
-func (n *deleteNode) Value() map[string]interface{} {
+func (n *deleteNode) Value() core.Doc {
 	return n.deleteIter.Value()
 }
 

--- a/query/graphql/planner/group.go
+++ b/query/graphql/planner/group.go
@@ -31,7 +31,7 @@ type groupNode struct {
 	// The data sources that this node will draw data from.
 	dataSources []*dataSource
 
-	values       []map[string]interface{}
+	values       []core.Doc
 	currentIndex int
 }
 
@@ -129,7 +129,7 @@ func (n *groupNode) Next() (bool, error) {
 					continue
 				}
 
-				childDocs := subSelect.([]map[string]interface{})
+				childDocs := subSelect.([]core.Doc)
 				if childSelect.Limit != nil {
 					l := int64(len(childDocs))
 

--- a/query/graphql/planner/limit.go
+++ b/query/graphql/planner/limit.go
@@ -45,10 +45,10 @@ func (n *hardLimitNode) Init() error {
 	return n.plan.Init()
 }
 
-func (n *hardLimitNode) Start() error                  { return n.plan.Start() }
-func (n *hardLimitNode) Spans(spans core.Spans)        { n.plan.Spans(spans) }
-func (n *hardLimitNode) Close() error                  { return n.plan.Close() }
-func (n *hardLimitNode) Value() map[string]interface{} { return n.plan.Value() }
+func (n *hardLimitNode) Start() error           { return n.plan.Start() }
+func (n *hardLimitNode) Spans(spans core.Spans) { n.plan.Spans(spans) }
+func (n *hardLimitNode) Close() error           { return n.plan.Close() }
+func (n *hardLimitNode) Value() core.Doc        { return n.plan.Value() }
 
 func (n *hardLimitNode) Next() (bool, error) {
 	// check if we're passed the limit

--- a/query/graphql/planner/multi.go
+++ b/query/graphql/planner/multi.go
@@ -123,7 +123,7 @@ func (p *parallelNode) Close() error {
 // It only needs a single child plan to return true for it
 // to return true. Same with errors.
 func (p *parallelNode) Next() (bool, error) {
-	p.currentValue = make(map[string]interface{})
+	p.currentValue = make(core.Doc)
 	var orNext bool
 	for i, plan := range p.children {
 		var next bool
@@ -216,7 +216,7 @@ func (p *parallelNode) nextAppend(index int, plan appendNode) (bool, error) {
 		return false, nil
 	}
 
-	results := make([]map[string]interface{}, 0)
+	results := make([]core.Doc, 0)
 	for {
 		next, err := plan.Next()
 		if err != nil {

--- a/query/graphql/planner/pipe.go
+++ b/query/graphql/planner/pipe.go
@@ -73,6 +73,26 @@ func (n *pipeNode) Next() (bool, error) {
 
 	// Values must be copied out of the node, in case consumers mutate the item
 	// for example: when rendering
-	n.currentValue = copyMap(n.docs.At(n.docIndex))
+	n.currentValue = copyDoc(n.docs.At(n.docIndex))
 	return true, nil
+}
+
+func copyDoc(m core.Doc) core.Doc {
+	cp := make(core.Doc)
+	for k, v := range m {
+		vm, ok := v.(core.Doc)
+		if ok {
+			cp[k] = copyDoc(vm)
+		} else if innerDocs, isDocArray := v.([]core.Doc); isDocArray {
+			innerMaps := make([]core.Doc, len(innerDocs))
+			for i, d := range innerDocs {
+				innerMaps[i] = copyDoc(d)
+			}
+			cp[k] = innerMaps
+		} else {
+			cp[k] = v
+		}
+	}
+
+	return cp
 }

--- a/query/graphql/planner/render.go
+++ b/query/graphql/planner/render.go
@@ -104,7 +104,7 @@ func (n *renderNode) Next() (bool, error) {
 		return n.Next()
 	}
 
-	n.currentValue = map[string]interface{}{}
+	n.currentValue = core.Doc{}
 	for _, renderInfo := range n.renderInfo.children {
 		renderInfo.render(doc, n.currentValue)
 	}
@@ -117,13 +117,13 @@ func (n *renderNode) Source() planNode       { return n.plan }
 
 // Renders the source document into the destination document using the given renderInfo.
 // Function recursively handles any nested children defined in the render info.
-func (r *renderInfo) render(src map[string]interface{}, destination map[string]interface{}) {
+func (r *renderInfo) render(src core.Doc, destination core.Doc) {
 	var resultValue interface{}
 	if val, ok := src[r.sourceFieldName]; ok {
 		switch v := val.(type) {
 		// If the current property is itself a map, we should render any properties of the child
-		case map[string]interface{}:
-			inner := map[string]interface{}{}
+		case core.Doc:
+			inner := core.Doc{}
 
 			if _, isHidden := v[parser.HiddenFieldName]; isHidden {
 				return
@@ -134,14 +134,14 @@ func (r *renderInfo) render(src map[string]interface{}, destination map[string]i
 			}
 			resultValue = inner
 		// If the current property is an array of maps, we should render each child map
-		case []map[string]interface{}:
-			subdocs := make([]map[string]interface{}, 0)
+		case []core.Doc:
+			subdocs := make([]core.Doc, 0)
 			for _, subv := range v {
 				if _, isHidden := subv[parser.HiddenFieldName]; isHidden {
 					continue
 				}
 
-				inner := map[string]interface{}{}
+				inner := core.Doc{}
 				for _, child := range r.children {
 					child.render(subv, inner)
 				}

--- a/query/graphql/planner/select.go
+++ b/query/graphql/planner/select.go
@@ -65,12 +65,12 @@ type selectTopNode struct {
 	// ... source -> MultiNode -> TypeJoinNode.plan = (typeJoinOne | typeJoinMany) -> scanNode
 }
 
-func (n *selectTopNode) Init() error                   { return n.plan.Init() }
-func (n *selectTopNode) Start() error                  { return n.plan.Start() }
-func (n *selectTopNode) Next() (bool, error)           { return n.plan.Next() }
-func (n *selectTopNode) Spans(spans core.Spans)        { n.plan.Spans(spans) }
-func (n *selectTopNode) Value() map[string]interface{} { return n.plan.Value() }
-func (n *selectTopNode) Source() planNode              { return n.source }
+func (n *selectTopNode) Init() error            { return n.plan.Init() }
+func (n *selectTopNode) Start() error           { return n.plan.Start() }
+func (n *selectTopNode) Next() (bool, error)    { return n.plan.Next() }
+func (n *selectTopNode) Spans(spans core.Spans) { n.plan.Spans(spans) }
+func (n *selectTopNode) Value() core.Doc        { return n.plan.Value() }
+func (n *selectTopNode) Source() planNode       { return n.source }
 func (n *selectTopNode) Close() error {
 	if n.plan == nil {
 		return nil

--- a/query/graphql/planner/sort.go
+++ b/query/graphql/planner/sort.go
@@ -20,7 +20,7 @@ import (
 // in value generation and retrieval.
 type valueIterator interface {
 	Next() (bool, error)
-	Value() map[string]interface{}
+	Value() core.Doc
 	Close()
 }
 
@@ -30,7 +30,7 @@ type sortingStrategy interface {
 	// copies data if its needed.
 	// Ideally stores inside a valuesNode
 	// rowContainer buffer.
-	Add(map[string]interface{}) error
+	Add(core.Doc) error
 	// Finish finalizes and applies the actual
 	// sorting mechanism to all the stored data.
 	Finish()
@@ -82,7 +82,7 @@ func (n *sortNode) Init() error {
 func (n *sortNode) Start() error           { return n.plan.Start() }
 func (n *sortNode) Spans(spans core.Spans) { n.plan.Spans(spans) }
 
-func (n *sortNode) Value() map[string]interface{} {
+func (n *sortNode) Value() core.Doc {
 	return n.valueIter.Value()
 }
 
@@ -154,7 +154,7 @@ func newAllSortStrategy(v *valuesNode) *allSortStrategy {
 }
 
 // Add adds a new document to underlying valueNode
-func (s *allSortStrategy) Add(doc map[string]interface{}) error {
+func (s *allSortStrategy) Add(doc core.Doc) error {
 	err := s.valueNode.docs.AddDoc(doc)
 	return err
 }
@@ -170,7 +170,7 @@ func (s *allSortStrategy) Next() (bool, error) {
 }
 
 // Values returns the values of the next doc from the underliny valueNode
-func (s *allSortStrategy) Value() map[string]interface{} {
+func (s *allSortStrategy) Value() core.Doc {
 	return s.valueNode.Value()
 }
 

--- a/query/graphql/planner/sum.go
+++ b/query/graphql/planner/sum.go
@@ -219,7 +219,7 @@ func (n *sumNode) Next() (bool, error) {
 
 	if child, hasProperty := n.currentValue[n.sourceCollection]; hasProperty {
 		switch childCollection := child.(type) {
-		case []map[string]interface{}:
+		case []core.Doc:
 			for _, childItem := range childCollection {
 				passed, err := parser.RunFilter(childItem, n.filter, n.p.evalCtx)
 				if err != nil {

--- a/query/graphql/planner/type_join.go
+++ b/query/graphql/planner/type_join.go
@@ -113,7 +113,7 @@ func (n *typeIndexJoin) Next() (bool, error) {
 	return n.joinPlan.Next()
 }
 
-func (n *typeIndexJoin) Value() map[string]interface{} {
+func (n *typeIndexJoin) Value() core.Doc {
 	return n.joinPlan.Value()
 }
 
@@ -255,7 +255,7 @@ func (n *typeJoinOne) Next() (bool, error) {
 	return true, nil
 }
 
-func (n *typeJoinOne) valuesSecondary(doc map[string]interface{}) map[string]interface{} {
+func (n *typeJoinOne) valuesSecondary(doc core.Doc) core.Doc {
 	docKey := doc["_key"].(string)
 	filter := map[string]interface{}{
 		n.subTypeFieldName + "_id": docKey,
@@ -266,7 +266,7 @@ func (n *typeJoinOne) valuesSecondary(doc map[string]interface{}) map[string]int
 		return nil
 	}
 
-	doc[n.subTypeName] = make(map[string]interface{})
+	doc[n.subTypeName] = make(core.Doc)
 	next, err := n.subType.Next()
 	if !next || err != nil {
 		return doc
@@ -277,7 +277,7 @@ func (n *typeJoinOne) valuesSecondary(doc map[string]interface{}) map[string]int
 	return doc
 }
 
-func (n *typeJoinOne) valuesPrimary(doc map[string]interface{}) map[string]interface{} {
+func (n *typeJoinOne) valuesPrimary(doc core.Doc) core.Doc {
 	// get the subtype doc key
 	subDocKey, ok := doc[n.subTypeName+"_id"]
 	if !ok {
@@ -290,7 +290,7 @@ func (n *typeJoinOne) valuesPrimary(doc map[string]interface{}) map[string]inter
 	}
 
 	subDocField := n.subTypeName
-	doc[subDocField] = map[string]interface{}{}
+	doc[subDocField] = core.Doc{}
 
 	// create the collection key for the sub doc
 	slct := n.subType.(*selectTopNode).source.(*selectNode)
@@ -423,7 +423,7 @@ func (n *typeJoinMany) Next() (bool, error) {
 	// check if theres an index
 	// if there is, scan and aggregate resuts
 	// if not, then manually scan the subtype table
-	subdocs := make([]map[string]interface{}, 0)
+	subdocs := make([]core.Doc, 0)
 	if n.index != nil {
 		// @todo: handle index for one-to-many setup
 	} else {

--- a/query/graphql/planner/update.go
+++ b/query/graphql/planner/update.go
@@ -79,7 +79,7 @@ func (n *updateNode) Next() (bool, error) {
 
 		// consume the updates into our valuesNode
 		for _, resKey := range results.DocKeys {
-			err := n.updateIter.docs.AddDoc(map[string]interface{}{"_key": resKey})
+			err := n.updateIter.docs.AddDoc(core.Doc{"_key": resKey})
 			if err != nil {
 				return false, err
 			}

--- a/query/graphql/planner/values.go
+++ b/query/graphql/planner/values.go
@@ -62,7 +62,7 @@ func (n *valuesNode) Next() (bool, error) {
 	return true, nil
 }
 
-func (n *valuesNode) Value() map[string]interface{} {
+func (n *valuesNode) Value() core.Doc {
 	return n.docs.At(n.docIndex)
 }
 
@@ -84,7 +84,7 @@ func (n *valuesNode) Less(i, j int) bool {
 }
 
 // docValueLess extracts and compare field values of a document
-func (n *valuesNode) docValueLess(da, db map[string]interface{}) bool {
+func (n *valuesNode) docValueLess(da, db core.Doc) bool {
 	var ra, rb interface{}
 	for _, order := range n.ordering {
 		if order.Direction == parser.ASC {
@@ -126,7 +126,7 @@ func (n *valuesNode) Len() int {
 // case of nested objects. The key delimeter is a ".".
 // Eg.
 // prop = "author.name" -> {author: {name: ...}}
-func getMapProp(obj map[string]interface{}, prop string) interface{} {
+func getMapProp(obj core.Doc, prop string) interface{} {
 	if prop == "" {
 		return nil
 	}
@@ -135,7 +135,7 @@ func getMapProp(obj map[string]interface{}, prop string) interface{} {
 	return getMapPropList(obj, props, numProps)
 }
 
-func getMapPropList(obj map[string]interface{}, props []string, numProps int) interface{} {
+func getMapPropList(obj core.Doc, props []string, numProps int) interface{} {
 	if numProps == 1 {
 		val, ok := obj[props[0]]
 		if !ok {
@@ -148,7 +148,7 @@ func getMapPropList(obj map[string]interface{}, props []string, numProps int) in
 	if !ok {
 		return nil
 	}
-	subObj, ok := val.(map[string]interface{})
+	subObj, ok := val.(core.Doc)
 	if !ok {
 		return nil
 	}


### PR DESCRIPTION
## RELEVANT ISSUE(S)

Resolves #444 

## DESCRIPTION

Aliases all internal `map[string]interface{}` references for internal documents.  This should make converting/managing the type a bit easier as we can more easily find it (and change the underlying type).   The public functions in executor.go return the `map[string]interface{}` type, as that is *my* current long-term intention. 

Also contains a couple of bug fixes (not exposed to consumer I think) in the `copyMap` functions where they only copied the ref to inner slices instead of a proper deep copy.

Changes are perhaps small enough to not require merging just yet (and could wait for the actual doc-type change), but might be nice to have in it's own right (I think I prefer this over the original code, even if the compiler doesnt care if you accidentally use a map[string] somewhere).  Let me know!

### HOW HAS THIS BEEN TESTED?

Accidentally tested by defining `Doc` as a new type (not just an alias), and fixing our `connor` (filter) fork to work as desired with any type of map/slice.  That is not really needed atm and is not part of this review.  

### CHECKLIST:

- [x] I have commented the code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the repo-held documentation.
- [x] I have made sure that the PR title adheres to the conventional commit style (subset of the ones we use can be found under: [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)

### ENVIRONMENT / OS THIS WAS TESTED ON?

Please specify which of the following was this tested on (remove or add your own):
- [ ] Arch Linux
- [x] Debian Linux
- [ ] MacOS
- [ ] Windows
