### PR TITLE
fix: Use cases for titling instead of strings to handle deprecation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -51,6 +51,7 @@ require (
 	github.com/fatih/color v1.13.0
 	github.com/go-chi/chi/v5 v5.0.7
 	github.com/pkg/errors v0.9.1
+	golang.org/x/text v0.3.7
 )
 
 require (
@@ -211,7 +212,6 @@ require (
 	golang.org/x/net v0.0.0-20220418201149-a630d4f3e7a2 // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	golang.org/x/sys v0.0.0-20220412211240-33da011f77ad // indirect
-	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/tools v0.1.10 // indirect
 	golang.org/x/xerrors v0.0.0-20220411194840-2f41105eb62f // indirect
 	google.golang.org/genproto v0.0.0-20220204002441-d6cc3cc0770e // indirect

--- a/query/graphql/schema/generate.go
+++ b/query/graphql/schema/generate.go
@@ -14,12 +14,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/logging"
 	"github.com/sourcenetwork/defradb/query/graphql/parser"
 	"github.com/sourcenetwork/defradb/query/graphql/schema/types"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 
 	gql "github.com/graphql-go/graphql"
 	"github.com/graphql-go/graphql/language/ast"
@@ -552,15 +553,15 @@ func (g *Generator) genAggregateFields(ctx context.Context) error {
 
 func (g *Generator) genCountFieldConfig(obj *gql.Object) (gql.Field, error) {
 	childTypesByFieldName := map[string]*gql.InputObject{}
+	caser := cases.Title(language.Und)
 
 	for _, field := range obj.Fields() {
 		// Only lists can be counted
 		if _, isList := field.Type.(*gql.List); !isList {
 			continue
 		}
-
 		countableObject := gql.NewInputObject(gql.InputObjectConfig{
-			Name: fmt.Sprintf("%s%s%s", obj.Name(), strings.Title(field.Name), "CountInputObj"),
+			Name: fmt.Sprintf("%s%s%s", obj.Name(), caser.String(field.Name), "CountInputObj"),
 			Fields: gql.InputObjectConfigFieldMap{
 				"_": &gql.InputObjectFieldConfig{
 					Type:        gql.Int,
@@ -669,6 +670,7 @@ func (g *Generator) genAverageFieldConfig(obj *gql.Object, numBaseArgs map[strin
 
 func (g *Generator) genNumericInlineArraySelectorObject(obj *gql.Object) []*gql.InputObject {
 	objects := []*gql.InputObject{}
+	caser := cases.Title(language.Und)
 	for _, field := range obj.Fields() {
 		// we can only act on list items
 		listType, isList := field.Type.(*gql.List)
@@ -680,7 +682,7 @@ func (g *Generator) genNumericInlineArraySelectorObject(obj *gql.Object) []*gql.
 			// If it is an inline scalar array then we require an empty
 			//  object as an argument due to the lack of union input types
 			selectorObject := gql.NewInputObject(gql.InputObjectConfig{
-				Name: genNumericInlineArraySelectorName(obj.Name(), strings.Title(field.Name)),
+				Name: genNumericInlineArraySelectorName(obj.Name(), caser.String(field.Name)),
 				Fields: gql.InputObjectConfigFieldMap{
 					"_": &gql.InputObjectFieldConfig{
 						Type:        gql.Int,
@@ -696,7 +698,8 @@ func (g *Generator) genNumericInlineArraySelectorObject(obj *gql.Object) []*gql.
 }
 
 func genNumericInlineArraySelectorName(hostName string, fieldName string) string {
-	return fmt.Sprintf("%s%s%s", hostName, strings.Title(fieldName), "NumericInlineArraySelector")
+	caser := cases.Title(language.Und)
+	return fmt.Sprintf("%s%s%s", hostName, caser.String(fieldName), "NumericInlineArraySelector")
 }
 
 // Generates the base (numeric-only) aggregate input object-type for the give gql object,


### PR DESCRIPTION
## RELEVANT ISSUE(S)

Resolves #454 

## DESCRIPTION

Handle deprecation of `strings.Title`

### HOW HAS THIS BEEN TESTED?

Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.

### CHECKLIST:

- [ ] I have commented the code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the repo-held documentation.
- [x] I have made sure that the PR title adheres to the conventional commit style (subset of the ones we use can be found under: [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)

### ENVIRONMENT / OS THIS WAS TESTED ON?

Please specify which of the following was this tested on (remove or add your own):
- [ ] Arch Linux
- [ ] Debian Linux
- [x] MacOS
- [ ] Windows
