### PR TITLE
fix: Separate out iotas in their own blocks.

### DIFF
--- a/query/graphql/parser/types/types.go
+++ b/query/graphql/parser/types/types.go
@@ -72,10 +72,14 @@ const (
 
 	ASC  = SortDirection("ASC")
 	DESC = SortDirection("DESC")
+)
 
+const (
 	ScanQuery = iota
 	VersionedScanQuery
+)
 
+const (
 	NoneSelection = iota
 	ObjectSelection
 	CommitSelection


### PR DESCRIPTION
## RELEVANT ISSUE(S)
Resolves #463 

## DESCRIPTION
Separate out iotas in their own blocks.

### HOW HAS THIS BEEN TESTED?
Locally.

### ENVIRONMENT / OS THIS WAS TESTED ON?

Please specify which of the following was this tested on (remove or add your own):
- [x] Arch Linux (Manjaro)
