### PR TITLE
test: Test filter in filter tests

### DIFF
--- a/tests/integration/query/simple/with_filter_test.go
+++ b/tests/integration/query/simple/with_filter_test.go
@@ -212,6 +212,10 @@ func TestQuerySimpleWithKeyFilterBlock(t *testing.T) {
 				(`{
 				"Name": "John",
 				"Age": 21
+				}`),
+				(`{
+				"Name": "Bob",
+				"Age": 32
 			}`)},
 		},
 		Results: []map[string]interface{}{
@@ -239,6 +243,10 @@ func TestQuerySimpleWithStringFilterBlock(t *testing.T) {
 				(`{
 				"Name": "John",
 				"Age": 21
+				}`),
+				(`{
+				"Name": "Bob",
+				"Age": 32
 			}`)},
 		},
 		Results: []map[string]interface{}{
@@ -266,6 +274,10 @@ func TestQuerySimpleWithStringFilterBlockAndSelect(t *testing.T) {
 					(`{
 					"Name": "John",
 					"Age": 21
+					}`),
+					(`{
+					"Name": "Bob",
+					"Age": 32
 				}`)},
 			},
 			Results: []map[string]interface{}{
@@ -286,6 +298,10 @@ func TestQuerySimpleWithStringFilterBlockAndSelect(t *testing.T) {
 					(`{
 					"Name": "John",
 					"Age": 21
+					}`),
+					(`{
+					"Name": "Bob",
+					"Age": 32
 				}`)},
 			},
 			Results: []map[string]interface{}{
@@ -332,6 +348,10 @@ func TestQuerySimpleWithNumberEqualsFilterBlock(t *testing.T) {
 				(`{
 				"Name": "John",
 				"Age": 21
+				}`),
+				(`{
+				"Name": "Bob",
+				"Age": 32
 			}`)},
 		},
 		Results: []map[string]interface{}{
@@ -360,6 +380,10 @@ func TestQuerySimpleWithNumberGreaterThanFilterBlock(t *testing.T) {
 					(`{
 					"Name": "John",
 					"Age": 21
+					}`),
+					(`{
+					"Name": "Bob",
+					"Age": 19
 				}`)},
 			},
 			Results: []map[string]interface{}{


### PR DESCRIPTION
## RELEVANT ISSUE(S)

Resolves #472

## DESCRIPTION

Previously filter tests would pass if the filter does nothing (i.e. filter code was non-existant), as the full set of data was expected to be returned, this PR adds records to be filtered out by test queries causing them to fail should the filter not run.

### HOW HAS THIS BEEN TESTED?

Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.

### CHECKLIST:

- [x] I have commented the code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the repo-held documentation.
- [x] I have made sure that the PR title adheres to the conventional commit style (subset of the ones we use can be found under: [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)

### ENVIRONMENT / OS THIS WAS TESTED ON?

Please specify which of the following was this tested on (remove or add your own):
- [ ] Arch Linux
- [x] Debian Linux
- [ ] MacOS
- [ ] Windows
