### PR TITLE
feat: Add support to explain `countNode` attributes.

### DIFF
--- a/query/graphql/planner/count.go
+++ b/query/graphql/planner/count.go
@@ -78,9 +78,6 @@ func (n *countNode) Explain() (map[string]interface{}, error) {
 	// Add the source property.
 	explainerMap["sourceProperty"] = n.sourceProperty
 
-	// Add the virtual field id of this countNode.
-	explainerMap["virtualFieldId"] = n.virtualFieldId
-
 	return explainerMap, nil
 }
 

--- a/query/graphql/planner/planner.go
+++ b/query/graphql/planner/planner.go
@@ -206,12 +206,12 @@ func (p *Planner) expandPlan(plan planNode, parentPlan *selectTopNode) error {
 }
 
 func (p *Planner) expandSelectTopNodePlan(plan *selectTopNode, parentPlan *selectTopNode) error {
-	if err := p.expandPlan(plan.source, plan); err != nil {
+	if err := p.expandPlan(plan.selectnode, plan); err != nil {
 		return err
 	}
 
 	// wire up source to plan
-	plan.plan = plan.source
+	plan.plan = plan.selectnode
 
 	// if group
 	if plan.group != nil {
@@ -300,7 +300,7 @@ func (p *Planner) expandGroupNodePlan(plan *selectTopNode) error {
 			childSelect,
 			pipe,
 			false,
-			&plan.source.(*selectNode).sourceInfo,
+			&plan.selectnode.sourceInfo,
 		)
 		if err != nil {
 			return err

--- a/query/graphql/planner/select.go
+++ b/query/graphql/planner/select.go
@@ -56,8 +56,8 @@ type selectTopNode struct {
 	render     *renderNode
 	aggregates []aggregateNode
 
-	// source is used pre-wiring of the plan (before expansion and all).
-	source planNode
+	// selectnode is used pre-wiring of the plan (before expansion and all).
+	selectnode *selectNode
 
 	// plan is the top of the plan graph (the wired and finalized plan graph).
 	plan planNode
@@ -571,7 +571,7 @@ func (p *Planner) SelectFromSource(
 	}
 
 	top := &selectTopNode{
-		source:     s,
+		selectnode: s,
 		render:     p.render(parsed),
 		limit:      limitPlan,
 		sort:       sortPlan,
@@ -612,7 +612,7 @@ func (p *Planner) Select(parsed *parser.Select) (planNode, error) {
 	}
 
 	top := &selectTopNode{
-		source:     s,
+		selectnode: s,
 		render:     p.render(parsed),
 		limit:      limitPlan,
 		sort:       sortPlan,

--- a/query/graphql/planner/type_join.go
+++ b/query/graphql/planner/type_join.go
@@ -314,7 +314,7 @@ func (n *typeJoinOne) valuesPrimary(doc map[string]interface{}) map[string]inter
 	doc[subDocField] = map[string]interface{}{}
 
 	// create the collection key for the sub doc
-	slct := n.subType.(*selectTopNode).source.(*selectNode)
+	slct := n.subType.(*selectTopNode).selectnode
 	desc := slct.sourceInfo.collectionDescription
 	subKeyIndexKey := base.MakeDocKey(desc, subDocKeyStr)
 

--- a/tests/integration/query/explain/with_count_test.go
+++ b/tests/integration/query/explain/with_count_test.go
@@ -87,7 +87,6 @@ func TestExplainQueryOneToManyWithACount(t *testing.T) {
 						"countNode": dataMap{
 							"filter":         nil,
 							"sourceProperty": "books",
-							"virtualFieldId": "_agg1",
 							"selectNode": dataMap{
 								"filter": nil,
 								"typeIndexJoin": dataMap{
@@ -123,7 +122,15 @@ func TestExplainQueryOneToManyMultipleWithCounts(t *testing.T) {
 				author {
 					name
 					numberOfBooks: _count(books: {})
-					numberOfArticles: _count(articles: {})
+					numberOfArticles: _count(
+						articles: {
+							filter: {
+								name: {
+									_eq: "After Guantánamo, Another Injustice"
+								}
+							}
+						}
+					)
 				}
 			}`,
 
@@ -195,11 +202,13 @@ func TestExplainQueryOneToManyMultipleWithCounts(t *testing.T) {
 						"countNode": dataMap{
 							"filter":         nil,
 							"sourceProperty": "books",
-							"virtualFieldId": "_agg1",
 							"countNode": dataMap{
-								"filter":         nil,
+								"filter": dataMap{
+									"name": dataMap{
+										"$eq": "After Guantánamo, Another Injustice",
+									},
+								},
 								"sourceProperty": "articles",
-								"virtualFieldId": "_agg2",
 								"selectNode": dataMap{
 									"filter": nil,
 									"parallelNode": []dataMap{


### PR DESCRIPTION
## RELEVANT ISSUE(S)

Resolves #478 

## DESCRIPTION

- Adds ability to explain attributes of `countNode`.
- Fixes a bug which was omitting the aggregate nodes.

Request:
```
query @explain {
	author {
		name
		numberOfBooks: _count(books: {})
	}
}
```

Response:
```
{
	"explain": {
		"selectTopNode": {
			"countNode": {
				"filter":         nil,
				"sourceProperty": "books",
				"selectNode": {
					"filter": nil,
					"typeIndexJoin": {
						"scanNode": {
							"collectionID":   "3",
							"collectionName": "author",
							"filter":         nil,
							"spans": []{
								{
									"start": "/3",
									"end":   "/4",
								}
							}
						}
					}
				}
			}
		}
	}
}
```


### HOW HAS THIS BEEN TESTED?

Integration tests.

### CHECKLIST:

- [x] I have commented the code, particularly in hard-to-understand areas.
- [x] I have made sure that the PR title adheres to the conventional commit style (subset of the ones we use can be found under: [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)

### ENVIRONMENT / OS THIS WAS TESTED ON?

Please specify which of the following was this tested on (remove or add your own):
- [x] Arch Linux

