### PR TITLE
chore: Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 # Build stage
-FROM golang:1.17 AS BUILD
+FROM docker.io/golang:1.17 AS BUILD
 
 WORKDIR /app
 
@@ -14,7 +14,7 @@ RUN make build
 FROM gcr.io/distroless/base-debian11
 WORKDIR /
 
-COPY --from=build /app/build/defradb /defradb
+COPY --from=BUILD /app/build/defradb /defradb
 
 EXPOSE 9161
 EXPOSE 9171


### PR DESCRIPTION
## RELEVANT ISSUE(S)

Resolves #516 

## DESCRIPTION

Introducing a Dockerfile.

We use a multistage approach which doesn't include the build environment in the resulting container.

This depends on https://github.com/GoogleContainerTools/distroless which we may not want to do. What we gain from this is a very small container.

I'd prefer using the new and more general terminology _Containerfile_ but _Dockerfile_ is very established, and DefraDB already brings a lot of new stuff.

Question: Should it live at the top-level or in a sub-directory?

I think this should be tested a bit more manually.

### HOW HAS THIS BEEN TESTED?

- [x] macOS: built & ran with `DOCKER_BUILDKIT=1` on and off
- [x] podman
- [x] podman rootless
- [ ] on actual cloud platform

### CHECKLIST:

- [x] I have commented the code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the repo-held documentation.
- [x] I have made sure that the PR title adheres to the conventional commit style (subset of the ones we use can be found under: [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)

### ENVIRONMENT / OS THIS WAS TESTED ON?

Please specify which of the following was this tested on (remove or add your own):
- [ ] Arch Linux
- [ ] Debian Linux
- [x] MacOS
- [ ] Windows
