### PR TITLE
fix: Ensure Makefile compatibility with macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # For compatibility, prerequisites are instead explicit calls to make.
 
 ifndef VERBOSE
-MAKEFLAGS += --no-print-directory
+MAKEFLAGS+=--no-print-directory
 endif
 
 default:


### PR DESCRIPTION
## Relevant issue(s)

Resolves #515 

## Description

Simply replaces `\:` by `-` as separator element of targets.  It is uglier, but it solves the issue.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

CI.

Specify the platform(s) on which this was tested:
- MacOS
- Debian Linux
