### PR TITLE
fix: Change log level enum to use iota

### DIFF
--- a/logging/config.go
+++ b/logging/config.go
@@ -46,11 +46,13 @@ func NewLogLevelOption(v LogLevel) LogLevelOption {
 }
 
 const (
-	Debug LogLevel = -1
-	Info  LogLevel = 0
-	Warn  LogLevel = 1
-	Error LogLevel = 2
-	Fatal LogLevel = 5
+	Debug LogLevel = iota - 1
+	Info
+	Warn
+	Error
+	_
+	_
+	Fatal
 )
 
 type EnableStackTraceOption struct {


### PR DESCRIPTION
## Description
This is a very small change proposal on something I spotted in the logging package. It's simply changing a hand defined enum to an iota defined one. Let me know what you think.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?
N/A

Specify the platform(s) on which this was tested:
- MacOS
