### PR TITLE
fix: Resolve failing HTTP API tests via cleanup

### DIFF
--- a/api/http/errors_test.go
+++ b/api/http/errors_test.go
@@ -21,7 +21,12 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func CleanupEnv() {
+	env = ""
+}
+
 func TestFormatError(t *testing.T) {
+	t.Cleanup(CleanupEnv)
 	env = "prod"
 	s := formatError(errors.New("test error"))
 	assert.Equal(t, "", s)
@@ -33,6 +38,7 @@ func TestFormatError(t *testing.T) {
 }
 
 func TestHandleErrOnBadRequest(t *testing.T) {
+	t.Cleanup(CleanupEnv)
 	env = "dev"
 	f := func(rw http.ResponseWriter, req *http.Request) {
 		handleErr(req.Context(), rw, errors.New("test error"), http.StatusBadRequest)
@@ -65,6 +71,7 @@ func TestHandleErrOnBadRequest(t *testing.T) {
 }
 
 func TestHandleErrOnInternalServerError(t *testing.T) {
+	t.Cleanup(CleanupEnv)
 	env = "dev"
 	f := func(rw http.ResponseWriter, req *http.Request) {
 		handleErr(req.Context(), rw, errors.New("test error"), http.StatusInternalServerError)
@@ -96,6 +103,7 @@ func TestHandleErrOnInternalServerError(t *testing.T) {
 }
 
 func TestHandleErrOnNotFound(t *testing.T) {
+	t.Cleanup(CleanupEnv)
 	env = "dev"
 	f := func(rw http.ResponseWriter, req *http.Request) {
 		handleErr(req.Context(), rw, errors.New("test error"), http.StatusNotFound)
@@ -128,6 +136,7 @@ func TestHandleErrOnNotFound(t *testing.T) {
 }
 
 func TestHandleErrOnDefault(t *testing.T) {
+	t.Cleanup(CleanupEnv)
 	env = "dev"
 	f := func(rw http.ResponseWriter, req *http.Request) {
 		handleErr(req.Context(), rw, errors.New("Unauthorized"), http.StatusUnauthorized)

--- a/api/http/handlerfuncs_test.go
+++ b/api/http/handlerfuncs_test.go
@@ -115,6 +115,8 @@ func TestDumpHandlerWithNoError(t *testing.T) {
 }
 
 func TestDumpHandlerWithDBError(t *testing.T) {
+	t.Cleanup(CleanupEnv)
+	env = "dev"
 	errResponse := errorResponse{}
 	testRequest(testOptions{
 		Testing:        t,
@@ -132,6 +134,8 @@ func TestDumpHandlerWithDBError(t *testing.T) {
 }
 
 func TestExecGQLWithNilBody(t *testing.T) {
+	t.Cleanup(CleanupEnv)
+	env = "dev"
 	errResponse := errorResponse{}
 	testRequest(testOptions{
 		Testing:        t,
@@ -150,6 +154,8 @@ func TestExecGQLWithNilBody(t *testing.T) {
 }
 
 func TestExecGQLWithEmptyBody(t *testing.T) {
+	t.Cleanup(CleanupEnv)
+	env = "dev"
 	errResponse := errorResponse{}
 	testRequest(testOptions{
 		Testing:        t,
@@ -177,6 +183,8 @@ func (m *mockReadCloser) Read(p []byte) (n int, err error) {
 }
 
 func TestExecGQLWithMockBody(t *testing.T) {
+	t.Cleanup(CleanupEnv)
+	env = "dev"
 	mockReadCloser := mockReadCloser{}
 	// if Read is called, it will return error
 	mockReadCloser.On("Read", mock.AnythingOfType("[]uint8")).Return(0, fmt.Errorf("error reading"))
@@ -199,6 +207,8 @@ func TestExecGQLWithMockBody(t *testing.T) {
 }
 
 func TestExecGQLWithNoDB(t *testing.T) {
+	t.Cleanup(CleanupEnv)
+	env = "dev"
 	errResponse := errorResponse{}
 	stmt := `
 mutation {
@@ -224,6 +234,8 @@ mutation {
 }
 
 func TestExecGQLHandlerContentTypeJSONWithJSONError(t *testing.T) {
+	t.Cleanup(CleanupEnv)
+	env = "dev"
 	// statement with JSON formatting error
 	stmt := `
 [
@@ -302,6 +314,8 @@ func TestExecGQLHandlerContentTypeJSON(t *testing.T) {
 }
 
 func TestExecGQLHandlerContentTypeFormURLEncoded(t *testing.T) {
+	t.Cleanup(CleanupEnv)
+	env = "dev"
 	errResponse := errorResponse{}
 	testRequest(testOptions{
 		Testing:        t,
@@ -388,6 +402,8 @@ mutation {
 }
 
 func TestLoadSchemaHandlerWithReadBodyError(t *testing.T) {
+	t.Cleanup(CleanupEnv)
+	env = "dev"
 	mockReadCloser := mockReadCloser{}
 	// if Read is called, it will return error
 	mockReadCloser.On("Read", mock.AnythingOfType("[]uint8")).Return(0, fmt.Errorf("error reading"))
@@ -410,6 +426,8 @@ func TestLoadSchemaHandlerWithReadBodyError(t *testing.T) {
 }
 
 func TestLoadSchemaHandlerWithoutDB(t *testing.T) {
+	t.Cleanup(CleanupEnv)
+	env = "dev"
 	stmt := `
 type user {
 	name: String 
@@ -438,6 +456,8 @@ type user {
 }
 
 func TestLoadSchemaHandlerWithAddSchemaError(t *testing.T) {
+	t.Cleanup(CleanupEnv)
+	env = "dev"
 	ctx := context.Background()
 	defra := testNewInMemoryDB(t, ctx)
 
@@ -508,6 +528,8 @@ type user {
 }
 
 func TestGetBlockHandlerWithMultihashError(t *testing.T) {
+	t.Cleanup(CleanupEnv)
+	env = "dev"
 	errResponse := errorResponse{}
 	testRequest(testOptions{
 		Testing:        t,
@@ -524,7 +546,10 @@ func TestGetBlockHandlerWithMultihashError(t *testing.T) {
 	assert.Equal(t, "Bad Request", errResponse.Errors[0].Extensions.HTTPError)
 	assert.Equal(t, "illegal base32 data at input byte 0", errResponse.Errors[0].Message)
 }
+
 func TestGetBlockHandlerWithDSKeyWithNoDB(t *testing.T) {
+	t.Cleanup(CleanupEnv)
+	env = "dev"
 	cID, err := cid.Parse("bafybeidembipteezluioakc2zyke4h5fnj4rr3uaougfyxd35u3qzefzhm")
 	if err != nil {
 		t.Fatal(err)
@@ -549,6 +574,8 @@ func TestGetBlockHandlerWithDSKeyWithNoDB(t *testing.T) {
 }
 
 func TestGetBlockHandlerWithNoDB(t *testing.T) {
+	t.Cleanup(CleanupEnv)
+	env = "dev"
 	errResponse := errorResponse{}
 	testRequest(testOptions{
 		Testing:        t,
@@ -567,6 +594,8 @@ func TestGetBlockHandlerWithNoDB(t *testing.T) {
 }
 
 func TestGetBlockHandlerWithGetBlockstoreError(t *testing.T) {
+	t.Cleanup(CleanupEnv)
+	env = "dev"
 	ctx := context.Background()
 	defra := testNewInMemoryDB(t, ctx)
 


### PR DESCRIPTION
## Relevant issue(s)

Resolves #555 

## Description

Various tests of the HTTP API were failing because they were assuming `env` was defined (to value `dev`), which is the case in the normal execution order as some previous tests set the global to that value, but not in a random execution order of tests.

This PR simply, whenever it is required, sets the `env` value  and cleans it up afterwards.

I suggest that a future PR should improve on the global `env` pattern, e.g. after the config PR merges...

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Int. tests.

Specify the platform(s) on which this was tested:
- MacOS