### PR TITLE
feat: Add ability to explain `sumNode` attribute(s). 

### DIFF
--- a/tests/integration/query/explain/utils.go
+++ b/tests/integration/query/explain/utils.go
@@ -22,12 +22,14 @@ var bookAuthorGQLSchema = (`
 	type article {
 		name: String
 		author: author
+		pages: Int
 	}
 
 	type book {
 		name: String
 		author: author
 		pages: Int
+		chapterPages: [Int]
 	}
 
 	type author {

--- a/tests/integration/query/explain/with_sum_test.go
+++ b/tests/integration/query/explain/with_sum_test.go
@@ -23,59 +23,48 @@ func TestExplainQuerySumOfRelatedOneToManyField(t *testing.T) {
 			author {
 				name
 				_key
-				TotalPages: _sum(books: {field: pages})
+				TotalPages: _sum(
+					books: {field: pages}
+				)
 			}
 		}`,
 
 		Docs: map[int][]string{
-			// articles
-			0: {
-				(`{
-					"name": "After Guantánamo, Another Injustice",
-					"author_id": "bae-25fafcc7-f251-58c1-9495-ead73e676fb8"
-				}`),
-				(`{
-					"name": "To my dear readers",
-					"author_id": "bae-3dddb519-3612-5e43-86e5-49d6295d4f84"
-					}`),
-				(`{
-					"name": "Twinklestar's Favourite Xmas Cookie",
-					"author_id": "bae-3dddb519-3612-5e43-86e5-49d6295d4f84"
-				}`),
-			},
 			// books
 			1: {
-				(`{
+				`{
 					"name": "Painted House",
 					"author_id": "bae-25fafcc7-f251-58c1-9495-ead73e676fb8",
 					"pages": 22
-				}`),
-				(`{
+				}`,
+				`{
 					"name": "A Time for Mercy",
 					"author_id": "bae-25fafcc7-f251-58c1-9495-ead73e676fb8",
 					"pages": 101
-					}`),
-				(`{
+				}`,
+				`{
 					"name": "Theif Lord",
 					"author_id": "bae-3dddb519-3612-5e43-86e5-49d6295d4f84",
 					"pages": 321
-				}`),
+				}`,
 			},
+
+			// authors
 			2: {
 				// _key: "bae-25fafcc7-f251-58c1-9495-ead73e676fb8"
-				(`{
+				`{
 					"name": "John Grisham",
 					"age": 65,
 					"verified": true,
 					"contact_id": "bae-1fe427b8-ab8d-56c3-9df2-826a6ce86fed"
-				}`),
+				}`,
 				// _key: "bae-3dddb519-3612-5e43-86e5-49d6295d4f84"
-				(`{
+				`{
 					"name": "Cornelia Funke",
 					"age": 62,
 					"verified": false,
 					"contact_id": "bae-c0960a29-b704-5c37-9c2e-59e1249e4559"
-				}`),
+				}`,
 			},
 		},
 
@@ -83,42 +72,423 @@ func TestExplainQuerySumOfRelatedOneToManyField(t *testing.T) {
 			{
 				"explain": dataMap{
 					"selectTopNode": dataMap{
-						"renderNode": dataMap{
-							"sumNode": dataMap{
-								"sourceCollection": "books",
-								"sourceProperty":   "pages",
-								"filter":           nil,
-								"selectNode": dataMap{
-									"filter": nil,
-									"typeIndexJoin": dataMap{
-										"joinType": "typeJoinMany",
-										"rootName": "author",
-										"root": dataMap{
-											"scanNode": dataMap{
-												"collectionID":   "3",
-												"collectionName": "author",
-												"filter":         nil,
-												"spans": []dataMap{
-													{
-														"start": "/3",
-														"end":   "/4",
+						"sumNode": dataMap{
+							"sources": []dataMap{
+								{
+									"fieldName":      "books",
+									"childFieldName": "pages",
+									"filter":         nil,
+								},
+							},
+							"selectNode": dataMap{
+								"filter": nil,
+								"typeIndexJoin": dataMap{
+									"joinType": "typeJoinMany",
+									"rootName": "author",
+									"root": dataMap{
+										"scanNode": dataMap{
+											"collectionID":   "3",
+											"collectionName": "author",
+											"filter":         nil,
+											"spans": []dataMap{
+												{
+													"start": "/3",
+													"end":   "/4",
+												},
+											},
+										},
+									},
+									"subTypeName": "books",
+									"subType": dataMap{
+										"selectTopNode": dataMap{
+											"selectNode": dataMap{
+												"filter": nil,
+												"scanNode": dataMap{
+													"collectionID":   "2",
+													"collectionName": "book",
+													"filter":         nil,
+													"spans": []dataMap{
+														{
+															"start": "/2",
+															"end":   "/3",
+														},
 													},
 												},
 											},
 										},
-										"subTypeName": "books",
-										"subType": dataMap{
-											"selectTopNode": dataMap{
-												"selectNode": dataMap{
-													"filter": nil,
-													"scanNode": dataMap{
-														"collectionID":   "2",
-														"collectionName": "book",
-														"filter":         nil,
-														"spans": []dataMap{
-															{
-																"start": "/2",
-																"end":   "/3",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	executeTestCase(t, test)
+}
+
+func TestExplainQuerySumOfRelatedOneToManyFieldWithFilter(t *testing.T) {
+	test := testUtils.QueryTestCase{
+		Description: "Explain a simple sum query of a One-to-Many realted sub-type with a filter.",
+		Query: `query @explain {
+			author {
+				name
+				TotalPages: _sum(
+					articles: {
+						field: pages,
+						filter: {
+							name: {
+								_eq: "To my dear readers"
+							}
+						}
+					}
+				)
+			}
+		}`,
+
+		Docs: map[int][]string{
+			// articles
+			0: {
+				`{
+					"name": "After Guantánamo, Another Injustice",
+					"author_id": "bae-25fafcc7-f251-58c1-9495-ead73e676fb8",
+					"pages": 2
+				}`,
+				`{
+					"name": "To my dear readers",
+					"author_id": "bae-3dddb519-3612-5e43-86e5-49d6295d4f84",
+					"pages": 11
+				}`,
+				`{
+					"name": "Twinklestar's Favourite Xmas Cookie",
+					"author_id": "bae-3dddb519-3612-5e43-86e5-49d6295d4f84",
+					"pages": 31
+				}`,
+			},
+
+			// authors
+			2: {
+				// _key: "bae-25fafcc7-f251-58c1-9495-ead73e676fb8"
+				`{
+					"name": "John Grisham",
+					"age": 65,
+					"verified": true,
+					"contact_id": "bae-1fe427b8-ab8d-56c3-9df2-826a6ce86fed"
+				}`,
+				// _key: "bae-3dddb519-3612-5e43-86e5-49d6295d4f84"
+				`{
+					"name": "Cornelia Funke",
+					"age": 62,
+					"verified": false,
+					"contact_id": "bae-c0960a29-b704-5c37-9c2e-59e1249e4559"
+				}`,
+			},
+		},
+
+		Results: []dataMap{
+			{
+				"explain": dataMap{
+					"selectTopNode": dataMap{
+						"sumNode": dataMap{
+							"sources": []dataMap{
+								{
+									"fieldName":      "articles",
+									"childFieldName": "pages",
+									"filter": dataMap{
+										"name": dataMap{
+											"$eq": "To my dear readers",
+										},
+									},
+								},
+							},
+							"selectNode": dataMap{
+								"filter": nil,
+								"typeIndexJoin": dataMap{
+									"joinType": "typeJoinMany",
+									"rootName": "author",
+									"root": dataMap{
+										"scanNode": dataMap{
+											"collectionID":   "3",
+											"collectionName": "author",
+											"filter":         nil,
+											"spans": []dataMap{
+												{
+													"start": "/3",
+													"end":   "/4",
+												},
+											},
+										},
+									},
+									"subTypeName": "articles",
+									"subType": dataMap{
+										"selectTopNode": dataMap{
+											"selectNode": dataMap{
+												"filter": nil,
+												"scanNode": dataMap{
+													"collectionID":   "1",
+													"collectionName": "article",
+													"filter": dataMap{
+														"name": dataMap{
+															"$eq": "To my dear readers",
+														},
+													},
+													"spans": []dataMap{
+														{
+															"start": "/1",
+															"end":   "/2",
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	executeTestCase(t, test)
+}
+
+func TestExplainQuerySumOfInlineArrayField_ShouldHaveEmptyChildField(t *testing.T) {
+	test := testUtils.QueryTestCase{
+		Description: "Explain a simple sum query on an  inline array field (childFieldName is nil).",
+		Query: `query @explain {
+			book {
+				name
+				NotSureWhySomeoneWouldSumTheChapterPagesButHereItIs: _sum(chapterPages: {})
+			}
+		}`,
+
+		Docs: map[int][]string{
+			// books
+			1: {
+				`{
+					"name": "Painted House",
+					"author_id": "bae-25fafcc7-f251-58c1-9495-ead73e676fb8",
+					"pages": 77,
+					"chapterPages": [1, 22, 33, 44, 55, 66]
+				}`, // sum of chapterPages == 221
+
+				`{
+					"name": "A Time for Mercy",
+					"author_id": "bae-25fafcc7-f251-58c1-9495-ead73e676fb8",
+					"pages": 55,
+					"chapterPages": [1, 22]
+				}`, // sum of chapterPages == 23
+
+				`{
+					"name": "Theif Lord",
+					"author_id": "bae-3dddb519-3612-5e43-86e5-49d6295d4f84",
+					"pages": 321,
+					"chapterPages": [10, 50, 100, 200, 300]
+				}`, // sum of chapterPages == 660
+			},
+		},
+
+		Results: []dataMap{
+			{
+				"explain": dataMap{
+					"selectTopNode": dataMap{
+						"sumNode": dataMap{
+							"sources": []dataMap{
+								{
+									"fieldName":      "chapterPages",
+									"childFieldName": nil,
+									"filter":         nil,
+								},
+							},
+							"selectNode": dataMap{
+								"filter": nil,
+								"scanNode": dataMap{
+									"collectionID":   "2",
+									"collectionName": "book",
+									"filter":         nil,
+									"spans": []dataMap{
+										{
+											"start": "/2",
+											"end":   "/3",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	executeTestCase(t, test)
+}
+
+func TestExplainQuerySumOfRelatedOneToManyFieldWithManySources(t *testing.T) {
+	test := testUtils.QueryTestCase{
+		Description: "Explain a simple sum query of a One-to-Many realted sub-type with many sources.",
+		Query: `query @explain {
+			author {
+				name
+				TotalPages: _sum(
+					books: {field: pages},
+					articles: {field: pages}
+				)
+			}
+		}`,
+
+		Docs: map[int][]string{
+			// articles
+			0: {
+				`{
+					"name": "After Guantánamo, Another Injustice",
+					"author_id": "bae-25fafcc7-f251-58c1-9495-ead73e676fb8",
+					"pages": 2
+				}`,
+				`{
+					"name": "To my dear readers",
+					"author_id": "bae-3dddb519-3612-5e43-86e5-49d6295d4f84",
+					"pages": 11
+				}`,
+				`{
+					"name": "Twinklestar's Favourite Xmas Cookie",
+					"author_id": "bae-3dddb519-3612-5e43-86e5-49d6295d4f84",
+					"pages": 31
+				}`,
+			},
+
+			// books
+			1: {
+				`{
+					"name": "Painted House",
+					"author_id": "bae-25fafcc7-f251-58c1-9495-ead73e676fb8",
+					"pages": 22
+				}`,
+				`{
+					"name": "A Time for Mercy",
+					"author_id": "bae-25fafcc7-f251-58c1-9495-ead73e676fb8",
+					"pages": 101
+				}`,
+				`{
+					"name": "Theif Lord",
+					"author_id": "bae-3dddb519-3612-5e43-86e5-49d6295d4f84",
+					"pages": 321
+				}`,
+			},
+
+			// authors
+			2: {
+				// _key: "bae-25fafcc7-f251-58c1-9495-ead73e676fb8"
+				`{
+					"name": "John Grisham",
+					"age": 65,
+					"verified": true,
+					"contact_id": "bae-1fe427b8-ab8d-56c3-9df2-826a6ce86fed"
+				}`,
+				// _key: "bae-3dddb519-3612-5e43-86e5-49d6295d4f84"
+				`{
+					"name": "Cornelia Funke",
+					"age": 62,
+					"verified": false,
+					"contact_id": "bae-c0960a29-b704-5c37-9c2e-59e1249e4559"
+				}`,
+			},
+		},
+
+		Results: []dataMap{
+			{
+				"explain": dataMap{
+					"selectTopNode": dataMap{
+						"sumNode": dataMap{
+							"sources": []dataMap{
+								{
+									"childFieldName": "pages",
+									"fieldName":      "books",
+									"filter":         nil,
+								},
+
+								{
+									"childFieldName": "pages",
+									"fieldName":      "articles",
+									"filter":         nil,
+								},
+							},
+							"selectNode": dataMap{
+								"filter": nil,
+								"parallelNode": []dataMap{
+									{
+										"typeIndexJoin": dataMap{
+											"joinType": "typeJoinMany",
+											"rootName": "author",
+											"root": dataMap{
+												"scanNode": dataMap{
+													"collectionID":   "3",
+													"collectionName": "author",
+													"filter":         nil,
+													"spans": []dataMap{
+														{
+															"start": "/3",
+															"end":   "/4",
+														},
+													},
+												},
+											},
+											"subTypeName": "books",
+											"subType": dataMap{
+												"selectTopNode": dataMap{
+													"selectNode": dataMap{
+														"filter": nil,
+														"scanNode": dataMap{
+															"collectionID":   "2",
+															"collectionName": "book",
+															"filter":         nil,
+															"spans": []dataMap{
+																{
+																	"start": "/2",
+																	"end":   "/3",
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+									{
+										"typeIndexJoin": dataMap{
+											"joinType": "typeJoinMany",
+											"rootName": "author",
+											"root": dataMap{
+												"scanNode": dataMap{
+													"collectionID":   "3",
+													"collectionName": "author",
+													"filter":         nil,
+													"spans": []dataMap{
+														{
+															"start": "/3",
+															"end":   "/4",
+														},
+													},
+												},
+											},
+											"subTypeName": "articles",
+											"subType": dataMap{
+												"selectTopNode": dataMap{
+													"selectNode": dataMap{
+														"filter": nil,
+														"scanNode": dataMap{
+															"collectionID":   "1",
+															"collectionName": "article",
+															"filter":         nil,
+															"spans": []dataMap{
+																{
+																	"start": "/1",
+																	"end":   "/2",
+																},
 															},
 														},
 													},


### PR DESCRIPTION
## Relevant issue(s)

Resolves #482.

## Description

Adds the attributes for `sumNode` to be included in the returned explain graph response.
In this PR we are introducing 3 attributes:
1) `fieldName`
2) `childFieldName`
3) `filter`

### Example:

#### Request:
```
query @explain {
  author {
    name
    _key
    TotalPages: _sum(books: {field: pages})
  }
}
```

#### Response:
```
{
  "explain": {
    "selectTopNode": {
      "sumNode": {
        "sources": []{
		  {
		    "fieldName":      "books",
			"childFieldName": "pages",
			"filter":         nil,
		  }
		},
        "selectNode": {
          "filter": null,
          "typeIndexJoin": {
            "joinType": "typeJoinMany",
            "rootName": "author",
            "root": {
              "scanNode": {
                "collectionID":   "3",
                "collectionName": "author",
                "filter":         null,
                "spans": []{
                  {
                    "start": "/3",
                    "end":   "/4",
                  }
                }
              }
            }
            "subTypeName": "books",
            "subType": {
              "selectTopNode": {
                "selectNode": {
                  "filter": null,
                  "scanNode": {
                    "collectionID":   "2",
                    "collectionName": "book",
                    "filter":         null,
                    "spans": []{
                      {
                        "start": "/2",
                        "end":   "/3",
                      }
                    }
                  }
                }
              }
            }
          }
        }
      }
    }
  }
}
```

## Tasks

- [x] I made sure the code is well commented, particularly in hard-to-understand areas.
- [ ] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?
Integration tests locally and only CI. Specifically `make test`.

Specify the platform(s) on which this was tested:
- Manjaro Flavor of Arch Linux Running in WSL2 on Windows 11

