### PR TITLE
feat: Add license CLI command

### DIFF
--- a/cli/license.go
+++ b/cli/license.go
@@ -1,0 +1,30 @@
+// Copyright 2022 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package cli
+
+import (
+	"github.com/sourcenetwork/defradb/licenses"
+	"github.com/spf13/cobra"
+)
+
+var licenseCmd = &cobra.Command{
+	Use:   "license",
+	Short: "Display license information",
+	Long: `Display the license information of DefraDB, which uses a parametric license model called
+the Business Source License (BSL).`,
+	Run: func(cmd *cobra.Command, args []string) {
+		cmd.Println(licenses.LicenseBSL)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(licenseCmd)
+}

--- a/licenses/licenses.go
+++ b/licenses/licenses.go
@@ -1,0 +1,16 @@
+// Copyright 2022 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package licenses
+
+import _ "embed"
+
+//go:embed BSL.txt
+var LicenseBSL string


### PR DESCRIPTION
## Relevant issue(s)

Resolves #581 

## Description

Add a `defradb license` command which displays DefraDB's license information, via embedding the license text in a `licenses` package, leveraging the existing folder. The `embed`only works with files or folders *within* a module.
Downside of this is the embedding of the license file which is 4.5 KB.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Manual.

Specify the platform(s) on which this was tested:
- MacOS
