### PR TITLE
fix: Add config and registry clearing to TestLogWritesMessagesToFeedbackLog

### DIFF
--- a/logging/logging_test.go
+++ b/logging/logging_test.go
@@ -580,6 +580,8 @@ func getFeedbackLogLevelTestCase() []LogLevelTestCase {
 }
 
 func TestLogWritesMessagesToFeedbackLog(t *testing.T) {
+	defer clearConfig()
+	defer clearRegistry("TestLogName")
 	for i, tc := range getFeedbackLogLevelTestCase() {
 		ctx := context.Background()
 		b := &bytes.Buffer{}
@@ -616,6 +618,8 @@ func TestLogWritesMessagesToFeedbackLog(t *testing.T) {
 		}
 
 		assert.Equal(t, logMessage+"\n", b.String())
+
+		clearRegistry("TestLogName")
 	}
 }
 


### PR DESCRIPTION
## Relevant issue(s)

Resolves #595 

## Description

This PR fixes an issues where the troubled test function, when running before another test function that specified an empty log path slice, would cause the config global to keep an invalid output path in memory.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Unit testing

Specify the platform(s) on which this was tested:
- MacOS
