### PR TITLE
tools: Use `gotestsum` over `go test`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,8 +36,7 @@ commands:
             - run:
                 name: Run tests
                 command: |
-                  mkdir -p /tmp/test-reports
-                  gotestsum --junitfile /tmp/test-reports/unit-tests.xml -- ./... -race -shuffle=on
+                  make test:verbose
                 environment:
                   DEFRA_BADGER_MEMORY: true
                   DEFRA_BADGER_FILE: true
@@ -48,15 +47,14 @@ commands:
             not: << parameters.no_change_detection >>
           steps:
             - run:
-                name: Run tests and detect
+                name: Run tests with change detection
                 command: |
-                  mkdir -p /tmp/test-reports
-                  gotestsum --junitfile /tmp/test-reports/unit-tests.xml -- ./... -p 1
+                  make test:changes
                 environment:
                   DEFRA_DETECT_DATABASE_CHANGES: true
 
       - store_test_results:
-          path: /tmp/test-reports
+          path: "/tmp/defradb-dev"
 
 
 #============================================================================================================[ JOBS ]


### PR DESCRIPTION
## Relevant issue(s)

Resolves #624

## Description
- uses `gotestsum` over `go test`
- change `golang-ci` dependency building rule to use `go install`.
- use the test rule in `Makefile` for ci test run.
- use the existing change detection rule in `Makefile` for change detection in ci.
- remove `golines` dependency as it isn't needed.
- remove `mkdir -p /tmp/test-reports` from `.circleci` config file as it's not needed.
- add `make test:watch` target to watch tests while developing.

### Limitations
Through this PR found that the change detection rule (`make test:changes`) fails randomly at times (despite the checks here passing we should investigate this, making an issue here: #623).

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?
- CI checks and all the make rules that were changed were tested locally.

Specify the platform(s) on which this was tested:
- Manjaro (WSL2)
