### PR TITLE
fix: Correctly parse dockey in broadcast log event.

### DIFF
--- a/db/collection.go
+++ b/db/collection.go
@@ -630,7 +630,6 @@ func (c *collection) save(
 		return cid.Undef, nil
 	}
 
-	fmt.Println("Update: dockey:", primaryKey, primaryKey.ToDataStoreKey(), primaryKey.ToDataStoreKey().ToDS())
 	headCID, err := c.saveValueToMerkleCRDT(
 		ctx,
 		txn,

--- a/db/collection_update.go
+++ b/db/collection_update.go
@@ -395,7 +395,6 @@ func (c *collection) applyMerge(
 	if err != nil {
 		return err
 	}
-	fmt.Println("Update: dockey:", key, key.ToDataStoreKey(), key.ToDataStoreKey().ToDS())
 	if _, err := c.saveValueToMerkleCRDT(
 		ctx,
 		txn,


### PR DESCRIPTION
## Relevant issue(s)

Resolves #508 & Resolves #629 

## Description

This fixes two outstanding issues, a malformed doc key as a result of manually trying to parse the dockey from the CRDT ID field on the core.CRDT instead of using the proper `core.MakeDocKey` calls. This work also exposed #629. 

Technically it doesn't 100% resolve this race condition, but it does kick the can down the hill and drastically increases the reliability of the race-condition executing in our favor. This will need to be properly solved by re-engineering the broadcast mechanics. This future work will be tracked in #630. 

## Tasks

- [ ] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?
Manually, 

Specify the platform(s) on which this was tested:
- WSL2 Linux
