### PR TITLE
fix: Add stdout validation when setting logging output path

### DIFF
--- a/logging/config.go
+++ b/logging/config.go
@@ -259,12 +259,12 @@ func validatePaths(paths []string) []string {
 	return validatedPaths
 }
 
-func willOutputToStderr(paths []string) bool {
+func willOutputToStderrOrStdout(paths []string) bool {
 	if len(paths) == 0 {
 		return true
 	}
 	for _, p := range paths {
-		if p == stderr {
+		if p == stderr || p == stdout {
 			return true
 		}
 	}

--- a/logging/logger.go
+++ b/logging/logger.go
@@ -150,7 +150,7 @@ func (l *logger) ApplyConfig(config Config) {
 	_ = l.logger.Sync()
 	l.logger = newLogger
 
-	if !willOutputToStderr(config.OutputPaths) {
+	if !willOutputToStderrOrStdout(config.OutputPaths) {
 		if config.pipe != nil { // for testing purposes only
 			l.consoleLogger = stdlog.New(config.pipe, "", 0)
 		} else {
@@ -209,7 +209,7 @@ func buildZapLogger(name string, config Config) (*zap.Logger, error) {
 		return nil, err
 	}
 
-	if willOutputToStderr(defaultConfig.OutputPaths) && config.pipe != nil {
+	if willOutputToStderrOrStdout(defaultConfig.OutputPaths) && config.pipe != nil {
 		newLogger = newLogger.WithOptions(zap.WrapCore(func(zapcore.Core) zapcore.Core {
 			cfg := zap.NewProductionEncoderConfig()
 			cfg.ConsoleSeparator = defaultConfig.EncoderConfig.ConsoleSeparator


### PR DESCRIPTION
## Relevant issue(s)

Resolves #665 

## Description

This PR fixes the outpath validation for the logging package. It ensures an stdout file isn't created during validation.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

manual testing

Specify the platform(s) on which this was tested:
- MacOS
