### PR TITLE
fix: Remove portSyncLock deadlock condition

### DIFF
--- a/tests/integration/net/utils.go
+++ b/tests/integration/net/utils.go
@@ -314,9 +314,9 @@ func newPort() int {
 	portSyncLock.Lock()
 	defer portSyncLock.Unlock()
 
-	p := rand.Intn(999) + 9000
+	p := rand.Intn(1000) + 9000
 	for usedPorts[p] {
-		p = rand.Intn(999) + 9000
+		p = rand.Intn(1000) + 9000
 	}
 	usedPorts[p] = true
 


### PR DESCRIPTION
## Relevant issue(s)

Resolves #670 

## Description

This PR fixes a possible deadlock condition on the random port number generator.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

integration test

Specify the platform(s) on which this was tested:
- MacOS
