### PR TITLE
tools: Include all touched packages in code coverage

### DIFF
--- a/.github/workflows/code-test-coverage.yml
+++ b/.github/workflows/code-test-coverage.yml
@@ -19,14 +19,14 @@ jobs:
           check-latest: true
 
       - name: Generate full test coverage report using go-acc
-        run: make test:coverage-full
+        run: make test:coverage
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
-          files: ./coverage-full.txt
+          files: ./coverage.txt
           flags: defra-tests
           name: codecov-umbrella
           verbose: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,8 @@
-build/*
-cover.out
-coverage-full.txt
-coverage-quick.txt
-tests/bench/*.log
-tests/bench/*.svg
 .vscode
-coverage.out
+build/*
 cmd/defradb/defradb
 cmd/genclidocs/genclidocs
 cmd/genmanpages/genmanpages
+coverage.txt
+tests/bench/*.log
+tests/bench/*.svg


### PR DESCRIPTION
## Relevant issue(s)

Resolves #672 

## Description

Ensures the empty packages aren't left out (because previously packages with 0 tests won't be included in the coverage). This should help avoid seeing the random coverage drops we see in PRs that are actually introducing tests.

Moreover:
- Removes the make rule `make test:coverage-quick`.
- Change make rule `make test:coverage-full` to `make test:coverage`
- Adds the ability to also provide `path=...` to `make test:coverage` like we had for `make test:coverage-html`.
- Account for integration test coverage for the rule `make test:coverage-html`.

### Limitation
Using `-coverpkg` does not actually help if the package is never called in any test at all. `-coverpkg` is a cover-up that allows packages from a different package to provide coverage for this package.
So, say package `a` has no tests, and thus no coverage. But package `b` has tests, and those tests call into `a`. As a result, if you start using a `-coverpkg` that covers both packages, the tests from package `b` will report its coverage of package `a` as coverage for `a`.
However, if we have a package `c` that is never called by either `a` or `b` then that package will still be left out in the dry, even if it would match the `-coverpkg` given.
Reference: https://github.com/golang/go/issues/24570

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?
Individually tested all changed / updated make rules. CI will also need to pass (specially codecov action).

Specify the platform(s) on which this was tested:
- Manjaro
