### PR TITLE
fix: Return without an error if relation is finalized

### DIFF
--- a/query/graphql/schema/generate.go
+++ b/query/graphql/schema/generate.go
@@ -445,7 +445,7 @@ func (g *Generator) buildTypesFromAST(
 							relType,
 						)
 						if err != nil {
-							log.ErrorE(ctx, "Error while registering single relation", err)
+							log.ErrorE(ctx, "Error while registering single relation for object", err)
 						}
 
 					case *gql.List:
@@ -464,7 +464,7 @@ func (g *Generator) buildTypesFromAST(
 								client.Relation_Type_MANY,
 							)
 							if err != nil {
-								log.ErrorE(ctx, "Error while registering single relation", err)
+								log.ErrorE(ctx, "Error while registering single relation for list", err)
 							}
 						}
 					}


### PR DESCRIPTION
## Relevant issue(s)
Resolves #697 

## Description
Fixes the following errors that took over when starting up `defradb` server with loaded schemas.
```
Error while registering single relation, {"Error": "Cannot update a relation that is already finalized"}
```

### Other Info
I do see issue #574 was resolved in PR #638 but the error is still happening, hence the purpose of this PR.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?
Local and CI

Specify the platform(s) on which this was tested:
- Manjaro WSL2
