### PR TITLE
chore: Update APL to refer to D2 Foundation

### DIFF
--- a/licenses/APL.txt
+++ b/licenses/APL.txt
@@ -176,7 +176,7 @@
 
    END OF TERMS AND CONDITIONS
 
-   Copyright 2021 Source Inc.
+   Copyright 2022 Democratized Data (D2) Foundation.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Relevant issue(s)

Resolves #204 

## Description

Simple text replacement of "Source Inc" to "Democratized Data Foundation" in the referenced APL license.
