### PR TITLE
ci: Fix the linter version to `v1.47`

### DIFF
--- a/.github/workflows/lint-then-benchmark.yml
+++ b/.github/workflows/lint-then-benchmark.yml
@@ -49,7 +49,7 @@ jobs:
           # Required: the version of golangci-lint is required.
           # Note: The version should not pick the patch version as the latest patch
           #  version is what will always be used.
-          version: latest
+          version: v1.47
 
           # Optional: working directory, useful for monorepos or if we wanted to run this
           #  on a non-root directory.

--- a/tools/configs/golangci.yaml
+++ b/tools/configs/golangci.yaml
@@ -55,6 +55,11 @@ run:
   # If false (default) - golangci-lint acquires file lock on start.
   allow-parallel-runners: false
 
+  # Define the Go version limit.
+  # Mainly related to generics support since go1.18.
+  # Default: use Go version from the go.mod file, fallback on the env var `GOVERSION`, fallback on 1.18
+  go: "1.18"
+
 #=====================================================================================[ Output Configuration Options ]
 output:
   # colored-line-number|line-number|json|tab|checkstyle|code-climate|junit-xml|github-actions


### PR DESCRIPTION
## Relevant issue(s)

Resolves #727 

## Description
Since the release of golangci-lint `v1.48` the github action's pre-compiled version pick up GoLang v1.19 gofmt linter rules, despite explicitly setting v1.18. This PR would fix it to be `v1.47` for now.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?
CI

Specify the platform(s) on which this was tested:
- Ubuntu
