### PR TITLE
fix: Delete mutations not correct persisting all keys

### DIFF
--- a/db/collection.go
+++ b/db/collection.go
@@ -686,7 +686,6 @@ func (c *collection) delete(
 	txn datastore.Txn,
 	key core.PrimaryDataStoreKey,
 ) (bool, error) {
-	fmt.Println("DELETING:", key.ToDS())
 	err := txn.Datastore().Delete(ctx, key.ToDS())
 	if err != nil {
 		return false, err

--- a/tests/integration/mutation/simple/delete/multi_ids_test.go
+++ b/tests/integration/mutation/simple/delete/multi_ids_test.go
@@ -22,11 +22,6 @@ func TestDeletionOfMultipleDocumentUsingMultipleKeys_Success(t *testing.T) {
 
 		{
 			Description: "Simple multi-key delete mutation with one key that exists.",
-			Query: `mutation {
-						delete_user(ids: ["bae-6a6482a8-24e1-5c73-a237-ca569e41507d"]) {
-							_key
-						}
-					}`,
 			Docs: map[int][]string{
 				0: {
 					`{
@@ -37,12 +32,32 @@ func TestDeletionOfMultipleDocumentUsingMultipleKeys_Success(t *testing.T) {
 					}`,
 				},
 			},
-			Results: []map[string]interface{}{
+			TransactionalQueries: []testUtils.TransactionQuery{
 				{
-					"_key": "bae-6a6482a8-24e1-5c73-a237-ca569e41507d",
+					TransactionId: 0,
+					Query: `mutation {
+						delete_user(ids: ["bae-6a6482a8-24e1-5c73-a237-ca569e41507d"]) {
+							_key
+						}
+					}`,
+					Results: []map[string]interface{}{
+						{
+							"_key": "bae-6a6482a8-24e1-5c73-a237-ca569e41507d",
+						},
+					},
+				},
+				{
+					TransactionId: 0,
+					Query: `query {
+						user(dockeys: ["bae-6a6482a8-24e1-5c73-a237-ca569e41507d"]) {
+							_key
+						}
+					}`,
+					Results: []map[string]interface{}{},
 				},
 			},
-			ExpectedError: "",
+			// Map store does not support transactions
+			DisableMapStore: true,
 		},
 
 		{

--- a/tests/integration/mutation/simple/delete/single_id_test.go
+++ b/tests/integration/mutation/simple/delete/single_id_test.go
@@ -22,11 +22,6 @@ func TestDeletionOfADocumentUsingSingleKey_Success(t *testing.T) {
 
 		{
 			Description: "Simple delete mutation where one element exists.",
-			Query: `mutation {
-						delete_user(id: "bae-8ca944fd-260e-5a44-b88f-326d9faca810") {
-							_key
-						}
-					}`,
 			Docs: map[int][]string{
 				0: {
 					`{
@@ -37,31 +32,55 @@ func TestDeletionOfADocumentUsingSingleKey_Success(t *testing.T) {
 					}`,
 				},
 			},
-			Results: []map[string]interface{}{
+			TransactionalQueries: []testUtils.TransactionQuery{
 				{
-					"_key": "bae-8ca944fd-260e-5a44-b88f-326d9faca810",
+					TransactionId: 0,
+					Query: `mutation {
+								delete_user(id: "bae-8ca944fd-260e-5a44-b88f-326d9faca810") {
+									_key
+								}
+							}`,
+					Results: []map[string]interface{}{
+						{
+							"_key": "bae-8ca944fd-260e-5a44-b88f-326d9faca810",
+						},
+					},
+				},
+				{
+					TransactionId: 0,
+					Query: `query {
+								user(dockey: "bae-8ca944fd-260e-5a44-b88f-326d9faca810") {
+									_key
+								}
+							}`,
+
+					// explicitly empty
+					Results: []map[string]interface{}{},
 				},
 			},
-			ExpectedError: "",
+
+			// Map store does not support transactions
+			DisableMapStore: true,
 		},
 
 		{
 			Description: "Simple delete mutation with an aliased _key name.",
+			Docs: map[int][]string{
+				0: {
+					`{
+						"name": "Shahzad",
+						"age":  26,
+						"points": 48.5,
+						"verified": true
+					}`,
+				},
+			},
 			Query: `mutation {
 						delete_user(id: "bae-8ca944fd-260e-5a44-b88f-326d9faca810") {
 							FancyKey: _key
 						}
 					}`,
-			Docs: map[int][]string{
-				0: {
-					`{
-						"name": "Shahzad",
-						"age":  26,
-						"points": 48.5,
-						"verified": true
-					}`,
-				},
-			},
+
 			Results: []map[string]interface{}{
 				{
 					"FancyKey": "bae-8ca944fd-260e-5a44-b88f-326d9faca810",


### PR DESCRIPTION
## Relevant issue(s)

Resolves #730 

## Description

There was a problem with the `delete` mutation not correctly deleting all the key/value pairs necessary to fully delete a document. Due to a previous change, we moved the instance type, but that change in question didn't get updated in the `collection.delete` API.

This PR fixes that, so it correctly gets all the priority/value instance types, and applies deletes for all associated key-value pairs that make up a document,

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Added transactional tests to the current delete integration test suite, so it can run delete/query requests together to verify deleted state.

Specify the platform(s) on which this was tested:
- Ubuntu via WSL2
