### PR TITLE
ci: Allow PR titles to end with a number

### DIFF
--- a/tools/scripts/scripts_test.sh
+++ b/tools/scripts/scripts_test.sh
@@ -37,6 +37,7 @@ TestReturnCode "${T1} 'ci: Last character should not be period.'" 8;
 TestReturnCode "${T1} 'ci: Last character is not lowercase alphabeT'" 8;
 TestReturnCode "${T1} 'ci: Last character is a space '" 8;
 TestReturnCode "${T1} 'bug: This is an invalid label'" 9;
+TestReturnCode "${T1} 'ci: Last character is a number v1.5.0'" 0;
 TestReturnCode "${T1} 'chore: This is a valid title'" 0;
 TestReturnCode "${T1} 'ci: This is a valid title'" 0;
 TestReturnCode "${T1} 'docs: This is a valid title'" 0;

--- a/tools/scripts/validate-conventional-style.sh
+++ b/tools/scripts/validate-conventional-style.sh
@@ -57,7 +57,7 @@ fi
 
 CHECK_SPACE="${DESCRIPTION::1}"; # First character
 CHECK_FIRST_UPPER_CASE="${DESCRIPTION:1:1}"; # Second character
-CHECK_LAST_LOWER_CASE="${DESCRIPTION: -1}"; # Last character
+CHECK_LAST_LOWER_CASE_OR_NUM="${DESCRIPTION: -1}"; # Last character
 
 # Validate that there is a space between the label and description.
 if [ "${CHECK_SPACE}" != " " ]; then
@@ -71,9 +71,9 @@ if [[ "${CHECK_FIRST_UPPER_CASE}" != [A-Z] ]]; then
     exit 7;
 fi
 
-# Validate that the last character of the description is a lower case alphabet character.
-if [[ "${CHECK_LAST_LOWER_CASE}" != [a-z] ]]; then
-    printf "Error: Last character of the description is not a lowercase alphabet.\n";
+# Validate that the last character is a lower case alphabet or a number character.
+if [[ "${CHECK_LAST_LOWER_CASE_OR_NUM}" != [a-z0-9] ]]; then
+    printf "Error: Last character is neither a lowercase alphabet nor a number.\n";
     exit 8;
 fi
 


### PR DESCRIPTION
## Relevant issue(s)
Resolves #744 

## Description
Allow PR Title to end with a number character.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?
PR title, CI, locally

Specify the platform(s) on which this was tested:
- Arch Linux
