### PR TITLE
tools: Ban the usage of `ioutil` package

### DIFF
--- a/api/http/handler_test.go
+++ b/api/http/handler_test.go
@@ -13,7 +13,7 @@ package http
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"io"
 	"math"
 	"net/http"
 	"net/http/httptest"
@@ -141,7 +141,7 @@ func TestSendJSONWithNoErrors(t *testing.T) {
 
 	sendJSON(context.Background(), rec, obj, 200)
 
-	body, err := ioutil.ReadAll(rec.Result().Body)
+	body, err := io.ReadAll(rec.Result().Body)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -12,7 +12,6 @@ package config
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -183,11 +182,16 @@ func TestLoadNonExistingConfigFile(t *testing.T) {
 func TestLoadInvalidConfigFile(t *testing.T) {
 	cfg := DefaultConfig()
 	dir := t.TempDir()
-	ioutil.WriteFile(filepath.Join(dir, DefaultDefraDBConfigFileName), []byte("{"), 0644)
 
-	err := cfg.Load(dir)
+	errWrite := os.WriteFile(
+		filepath.Join(dir, DefaultDefraDBConfigFileName),
+		[]byte("{"),
+		0644,
+	)
+	assert.NoError(t, errWrite)
 
-	assert.Error(t, err)
+	errLoad := cfg.Load(dir)
+	assert.Error(t, errLoad)
 }
 
 func TestInvalidEnvVars(t *testing.T) {
@@ -241,7 +245,6 @@ func TestValidRPCTimeoutDuration(t *testing.T) {
 	cfg.LoadWithoutRootDir()
 	_, err := cfg.Net.RPCTimeoutDuration()
 
-	assert.NoError(t, err)
 	assert.NoError(t, err)
 }
 

--- a/tools/configs/golangci.yaml
+++ b/tools/configs/golangci.yaml
@@ -214,6 +214,8 @@ linters-settings:
     # Forbid the following identifiers (identifiers are written using regexp):
     forbid:
       - 'fmt\.Print.*'
+      - 'ioutil\.*'
+
     # Exclude godoc examples from forbidigo checks.
     exclude_godoc_examples: false
 


### PR DESCRIPTION
## Relevant issue(s)
Resolves #746

## Description
We did remove all usage of `ioutil` in: https://github.com/sourcenetwork/defradb/pull/376
However, over time it has crept back in a few times, this PR will enforce that it stays banned through the linter.

## Tasks
- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?
CI & Locally

Specify the platform(s) on which this was tested:
- Manjaro
