### PR TITLE
test: Add tests for inline array grouping

### DIFF
--- a/tests/integration/query/inline_array/with_group_test.go
+++ b/tests/integration/query/inline_array/with_group_test.go
@@ -1,0 +1,111 @@
+// Copyright 2022 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package inline_array
+
+import (
+	"testing"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+func TestQueryInlineArrayWithGroupByString(t *testing.T) {
+	test := testUtils.QueryTestCase{
+		Description: "Simple inline array with no filter, mixed integers, group by string",
+		Query: `query {
+					users (groupBy: [Name]) {
+						Name
+						_group {
+							FavouriteIntegers
+						}
+					}
+				}`,
+		Docs: map[int][]string{
+			0: {
+				`{
+					"Name": "Shahzad",
+					"FavouriteIntegers": [-1, 2, -1, 1, 0]
+				}`,
+				`{
+					"Name": "Shahzad",
+					"FavouriteIntegers": [1, -2, 1, -1, 0]
+				}`,
+			},
+		},
+		Results: []map[string]interface{}{
+			{
+				"Name": "Shahzad",
+				"_group": []map[string]interface{}{
+					{
+						"FavouriteIntegers": []int64{-1, 2, -1, 1, 0},
+					},
+					{
+						"FavouriteIntegers": []int64{1, -2, 1, -1, 0},
+					},
+				},
+			},
+		},
+	}
+
+	executeTestCase(t, test)
+}
+
+func TestQueryInlineArrayWithGroupByArray(t *testing.T) {
+	test := testUtils.QueryTestCase{
+		Description: "Simple inline array with no filter, mixed integers, group by array",
+		Query: `query {
+					users (groupBy: [FavouriteIntegers]) {
+						FavouriteIntegers
+						_group {
+							Name
+						}
+					}
+				}`,
+		Docs: map[int][]string{
+			0: {
+				`{
+					"Name": "Andy",
+					"FavouriteIntegers": [-1, 2, -1, 1, 0]
+				}`,
+				`{
+					"Name": "Shahzad",
+					"FavouriteIntegers": [-1, 2, -1, 1, 0]
+				}`,
+				`{
+					"Name": "John",
+					"FavouriteIntegers": [1, 2, 3]
+				}`,
+			},
+		},
+		Results: []map[string]interface{}{
+			{
+				"FavouriteIntegers": []int64{-1, 2, -1, 1, 0},
+				"_group": []map[string]interface{}{
+					{
+						"Name": "Shahzad",
+					},
+					{
+						"Name": "Andy",
+					},
+				},
+			},
+			{
+				"FavouriteIntegers": []int64{1, 2, 3},
+				"_group": []map[string]interface{}{
+					{
+						"Name": "John",
+					},
+				},
+			},
+		},
+	}
+
+	executeTestCase(t, test)
+}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #391

## Description

Adds tests for inline array grouping.  Ticket originally thought there was a gap in joins, however this was a misunderstanding and we already had coverage.

Specify the platform(s) on which this was tested:
- Debian Linux
