### PR TITLE
refactor: Simplify count logic by `any` to `[]any` conversion

### DIFF
--- a/client/any.go
+++ b/client/any.go
@@ -1,0 +1,32 @@
+// Copyright 2022 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package client
+
+import (
+	"errors"
+	"reflect"
+)
+
+// AnyToAnyList converts `any` to `[]any` if underlying type of `any` is a slice or an array (a list).
+// This is because otherwise when doing a.([]any) where `a` is of type `any` we always get an error,
+// it also returns an empty [] instead of preserving the elements of the underlying type `a`.
+func AnyToAnyList(a any) ([]any, error) {
+	switch value := reflect.ValueOf(a); value.Kind() {
+	case reflect.Slice, reflect.Array:
+		anyList := make([]any, value.Len(), value.Cap())
+		for i := 0; i < value.Len(); i++ {
+			anyList[i] = value.Index(i).Interface()
+		}
+		return anyList, nil
+	default:
+		return nil, errors.New("underlying type of `any` is not a list type.")
+	}
+}

--- a/query/graphql/planner/count.go
+++ b/query/graphql/planner/count.go
@@ -17,6 +17,7 @@ package planner
 import (
 	"reflect"
 
+	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/core"
 	"github.com/sourcenetwork/defradb/query/graphql/mapper"
 )
@@ -99,24 +100,11 @@ func (n *countNode) Next() (bool, error) {
 		// v.Len will panic if v is not one of these types, we don't want it to panic
 		case reflect.Array, reflect.Chan, reflect.Map, reflect.Slice, reflect.String:
 			if source.Filter != nil {
-				var arrayCount int
-				var err error
-				switch array := property.(type) {
-				case []core.Doc:
-					arrayCount, err = countItems(array, source.Filter)
-
-				case []bool:
-					arrayCount, err = countItems(array, source.Filter)
-
-				case []int64:
-					arrayCount, err = countItems(array, source.Filter)
-
-				case []float64:
-					arrayCount, err = countItems(array, source.Filter)
-
-				case []string:
-					arrayCount, err = countItems(array, source.Filter)
+				array, err := client.AnyToAnyList(property)
+				if err != nil {
+					return false, err
 				}
+				arrayCount, err := countItems(array, source.Filter)
 				if err != nil {
 					return false, err
 				}


### PR DESCRIPTION
## Relevant issue(s)
Resolves #760 

## Description
Inspired and continued based on the refactor of #633, attempting to use the `any` to `[]any` conversation as the normal cast from `any.([]any)` behaves improperly with always returning an error, and also throwing away list elements of `any` object and returning a new type `[]any` with empty elements. 

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?
Local and CI

Specify the platform(s) on which this was tested:
- Majaro (wsl2)
