### PR TITLE
test: Restructure schema defaults under a separate package

### DIFF
--- a/tests/integration/schema/defaults/args.go
+++ b/tests/integration/schema/defaults/args.go
@@ -10,14 +10,6 @@
 
 package defaults
 
-var allDefaultGroupArgs = []Field{
-	FilterArg,
-	GroupByArg,
-	LimitArg,
-	OffsetArg,
-	OrderArg,
-}
-
 var allDefaultArgs = []Field{
 	FilterArg,
 	GroupByArg,
@@ -40,154 +32,36 @@ var DefaultFields = Concat(
 	aggregateFields,
 )
 
-var keyField = Field{
-	"name": "_key",
-	"type": map[string]interface{}{
-		"kind": "SCALAR",
-		"name": "ID",
-	},
+func makeNameTypeImplicit(name, iType any) Field {
+	return makeNameType(Yes(name), Yes(iType))
 }
 
-var versionField = Field{
-	"name": "_version",
-	"type": map[string]interface{}{
-		"kind": "LIST",
-		"name": nil,
-	},
-}
-
-var groupField = Field{
-	"name": "_group",
-	"type": map[string]interface{}{
-		"kind": "LIST",
-		"name": nil,
-	},
-}
+var keyField = makeNameTypeImplicit("_key", scalarIDKind)
+var versionField = makeNameTypeImplicit("_version", listKind)
+var groupField = makeNameTypeImplicit("_group", listKind)
 
 var aggregateFields = Fields{
-	map[string]interface{}{
-		"name": "_avg",
-		"type": map[string]interface{}{
-			"kind": "SCALAR",
-			"name": "Float",
-		},
-	},
-	map[string]interface{}{
-		"name": "_count",
-		"type": map[string]interface{}{
-			"kind": "SCALAR",
-			"name": "Int",
-		},
-	},
-	map[string]interface{}{
-		"name": "_sum",
-		"type": map[string]interface{}{
-			"kind": "SCALAR",
-			"name": "Float",
-		},
-	},
+	avgField,
+	countField,
+	sumField,
 }
 
-var FilterArg = Field{
-	"name": "filter",
-	"type": filterArgType,
-}
+var avgField = makeNameTypeImplicit("_avg", scalarFloatKind)
+var countField = makeNameTypeImplicit("_count", scalarIntKind)
+var sumField = makeNameTypeImplicit("_sum", scalarFloatKind)
 
-var GroupByArg = Field{
-	"name": "groupBy",
-	"type": groupByArgType,
-}
+var FilterArg = makeNameTypeImplicit("filter", filterArgType)
+var GroupByArg = makeNameTypeImplicit("groupBy", groupByArgType)
+var LimitArg = makeNameTypeImplicit("limit", intArgType)
+var OffsetArg = makeNameTypeImplicit("offset", intArgType)
+var OrderArg = makeNameTypeImplicit("order", orderArgType)
+var CidArg = makeNameTypeImplicit("cid", stringArgType)
+var DockeyArg = makeNameTypeImplicit("dockey", stringArgType)
+var DockeysArg = makeNameTypeImplicit("dockeys", nilArgType)
 
-var LimitArg = Field{
-	"name": "limit",
-	"type": intArgType,
-}
-
-var OffsetArg = Field{
-	"name": "offset",
-	"type": intArgType,
-}
-
-var OrderArg = Field{
-	"name": "order",
-	"type": orderArgType,
-}
-
-var CidArg = Field{
-	"name": "cid",
-	"type": stringArgType,
-}
-
-var DockeyArg = Field{
-	"name": "dockey",
-	"type": stringArgType,
-}
-
-var DockeysArg = Field{
-	"name": "dockeys",
-	"type": nilArgType,
-}
-
-var groupByArgType = Field{
-	"name":        nil,
-	"inputFields": nil,
-	"ofType": Field{
-		"kind": "NON_NULL",
-		"name": nil,
-	},
-}
-
-var intArgType = Field{
-	"inputFields": nil,
-	"name":        "Int",
-	"ofType":      nil,
-}
-
-var stringArgType = Field{
-	"inputFields": nil,
-	"name":        "String",
-}
-
-var nilArgType = Field{
-	"name":        nil,
-	"inputFields": nil,
-}
-
-var filterArgType = Field{
-	"name":   "authorFilterArg",
-	"ofType": nil,
-	"inputFields": []any{
-		makeOuterType(Yes("_and"), Yes(nil), Yes(inputObjectAuthorFilterArg), No()),
-		makeOuterType(Yes("_key"), Yes("IDOperatorBlock"), Yes(nil), No()),
-		makeOuterType(Yes("_not"), Yes("authorFilterArg"), Yes(nil), No()),
-		makeOuterType(Yes("_or"), Yes(nil), Yes(inputObjectAuthorFilterArg), No()),
-
-		// Following can probably reworked to be dynamically added based on the schema.
-		makeOuterType(Yes("age"), Yes("IntOperatorBlock"), Yes(nil), No()),
-		makeOuterType(Yes("name"), Yes("StringOperatorBlock"), Yes(nil), No()),
-		makeOuterType(Yes("verified"), Yes("BooleanOperatorBlock"), Yes(nil), No()),
-		makeOuterType(Yes("wrote"), Yes("bookFilterArg"), Yes(nil), No()),
-		makeOuterType(Yes("wrote_id"), Yes("IDOperatorBlock"), Yes(nil), No()),
-	},
-}
-
-var orderArgType = Field{
-	"name":   "authorOrderArg",
-	"ofType": nil,
-	"inputFields": []any{
-		makeAuthorOrdering("_key"),
-
-		// Following can probably reworked to be dynamically added based on the schema.
-		makeAuthorOrdering("age"),
-		makeAuthorOrdering("name"),
-		makeAuthorOrdering("verified"),
-
-		// Without the relation type we won't have the following ordering type(s).
-		makeOuterType(Yes("wrote"), Yes("bookOrderArg"), Yes(nil), No()),
-		makeAuthorOrdering("wrote_id"),
-	},
-}
-
-func makeAuthorOrdering(name any) Field {
-	return makeOuterType(Yes(name), Yes("Ordering"), Yes(nil), No())
-}
+var intArgType = makeType(Yes("Int"), Yes(nil), Yes(nil))
+var stringArgType = makeType(Yes("String"), No(), Yes(nil))
+var groupByArgType = makeType(Yes(nil), Yes(nonNullKind), Yes(nil))
+var nilArgType = makeType(Yes(nil), No(), Yes(nil))
+var filterArgType = makeType(Yes("authorFilterArg"), Yes(nil), Yes(filterInputFieldsStatic))
+var orderArgType = makeType(Yes("authorOrderArg"), Yes(nil), Yes(orderInputFieldsStatic))

--- a/tests/integration/schema/defaults/args.go
+++ b/tests/integration/schema/defaults/args.go
@@ -10,7 +10,15 @@
 
 package defaults
 
-var allDefaultArgs = []any{
+var allDefaultGroupArgs = []Field{
+	FilterArg,
+	GroupByArg,
+	LimitArg,
+	OffsetArg,
+	OrderArg,
+}
+
+var allDefaultArgs = []Field{
 	FilterArg,
 	GroupByArg,
 	LimitArg,
@@ -21,12 +29,63 @@ var allDefaultArgs = []any{
 	DockeysArg,
 }
 
-var allDefaultGroupArgs = []any{
-	FilterArg,
-	GroupByArg,
-	LimitArg,
-	OffsetArg,
-	OrderArg,
+// DefaultFields contains the list of fields every
+// defra schema-object should have.
+var DefaultFields = Concat(
+	Fields{
+		keyField,
+		versionField,
+		groupField,
+	},
+	aggregateFields,
+)
+
+var keyField = Field{
+	"name": "_key",
+	"type": map[string]interface{}{
+		"kind": "SCALAR",
+		"name": "ID",
+	},
+}
+
+var versionField = Field{
+	"name": "_version",
+	"type": map[string]interface{}{
+		"kind": "LIST",
+		"name": nil,
+	},
+}
+
+var groupField = Field{
+	"name": "_group",
+	"type": map[string]interface{}{
+		"kind": "LIST",
+		"name": nil,
+	},
+}
+
+var aggregateFields = Fields{
+	map[string]interface{}{
+		"name": "_avg",
+		"type": map[string]interface{}{
+			"kind": "SCALAR",
+			"name": "Float",
+		},
+	},
+	map[string]interface{}{
+		"name": "_count",
+		"type": map[string]interface{}{
+			"kind": "SCALAR",
+			"name": "Int",
+		},
+	},
+	map[string]interface{}{
+		"name": "_sum",
+		"type": map[string]interface{}{
+			"kind": "SCALAR",
+			"name": "Float",
+		},
+	},
 }
 
 var FilterArg = Field{
@@ -70,8 +129,8 @@ var DockeysArg = Field{
 }
 
 var groupByArgType = Field{
-	"inputFields": nil,
 	"name":        nil,
+	"inputFields": nil,
 	"ofType": Field{
 		"kind": "NON_NULL",
 		"name": nil,
@@ -98,17 +157,17 @@ var filterArgType = Field{
 	"name":   "authorFilterArg",
 	"ofType": nil,
 	"inputFields": []any{
-		makeInputObject(Yes("_and"), Yes(nil), Yes(inputObjectAuthorFilterArg), No()),
-		makeInputObject(Yes("_key"), Yes("IDOperatorBlock"), Yes(nil), No()),
-		makeInputObject(Yes("_not"), Yes("authorFilterArg"), Yes(nil), No()),
-		makeInputObject(Yes("_or"), Yes(nil), Yes(inputObjectAuthorFilterArg), No()),
+		makeOuterType(Yes("_and"), Yes(nil), Yes(inputObjectAuthorFilterArg), No()),
+		makeOuterType(Yes("_key"), Yes("IDOperatorBlock"), Yes(nil), No()),
+		makeOuterType(Yes("_not"), Yes("authorFilterArg"), Yes(nil), No()),
+		makeOuterType(Yes("_or"), Yes(nil), Yes(inputObjectAuthorFilterArg), No()),
 
 		// Following can probably reworked to be dynamically added based on the schema.
-		makeInputObject(Yes("age"), Yes("IntOperatorBlock"), Yes(nil), No()),
-		makeInputObject(Yes("name"), Yes("StringOperatorBlock"), Yes(nil), No()),
-		makeInputObject(Yes("verified"), Yes("BooleanOperatorBlock"), Yes(nil), No()),
-		makeInputObject(Yes("wrote"), Yes("bookFilterArg"), Yes(nil), No()),
-		makeInputObject(Yes("wrote_id"), Yes("IDOperatorBlock"), Yes(nil), No()),
+		makeOuterType(Yes("age"), Yes("IntOperatorBlock"), Yes(nil), No()),
+		makeOuterType(Yes("name"), Yes("StringOperatorBlock"), Yes(nil), No()),
+		makeOuterType(Yes("verified"), Yes("BooleanOperatorBlock"), Yes(nil), No()),
+		makeOuterType(Yes("wrote"), Yes("bookFilterArg"), Yes(nil), No()),
+		makeOuterType(Yes("wrote_id"), Yes("IDOperatorBlock"), Yes(nil), No()),
 	},
 }
 
@@ -124,7 +183,11 @@ var orderArgType = Field{
 		makeAuthorOrdering("verified"),
 
 		// Without the relation type we won't have the following ordering type(s).
-		makeInputObject(Yes("wrote"), Yes("bookOrderArg"), Yes(nil), No()),
+		makeOuterType(Yes("wrote"), Yes("bookOrderArg"), Yes(nil), No()),
 		makeAuthorOrdering("wrote_id"),
 	},
+}
+
+func makeAuthorOrdering(name any) Field {
+	return makeOuterType(Yes(name), Yes("Ordering"), Yes(nil), No())
 }

--- a/tests/integration/schema/defaults/args.go
+++ b/tests/integration/schema/defaults/args.go
@@ -1,0 +1,122 @@
+// Copyright 2022 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package defaults
+
+var allDefaultGroupArgs = []any{
+	filterArg,
+	groupByArg,
+	limitArg,
+	offsetArg,
+	orderArg,
+	cidArg,
+	dockeyArg,
+	dockeysArg,
+}
+
+var filterArg = field{
+	"name": "filter",
+	"type": filterArgType,
+}
+
+var groupByArg = field{
+	"name": "groupBy",
+	"type": groupByArgType,
+}
+
+var limitArg = field{
+	"name": "limit",
+	"type": intArgType,
+}
+
+var offsetArg = field{
+	"name": "offset",
+	"type": intArgType,
+}
+
+var orderArg = field{
+	"name": "order",
+	"type": orderArgType,
+}
+
+var cidArg = field{
+	"name": "cid",
+	"type": stringArgType,
+}
+
+var dockeyArg = field{
+	"name": "dockey",
+	"type": stringArgType,
+}
+
+var dockeysArg = field{
+	"name": "dockeys",
+	"type": nilArgType,
+}
+
+var groupByArgType = field{
+	"inputFields": nil,
+	"name":        nil,
+	"ofType": field{
+		"kind": "NON_NULL",
+		"name": nil,
+	},
+}
+
+var intArgType = field{
+	"inputFields": nil,
+	"name":        "Int",
+	"ofType":      nil,
+}
+
+var stringArgType = field{
+	"inputFields": nil,
+	"name":        "String",
+}
+
+var nilArgType = field{
+	"name":        nil,
+	"inputFields": nil,
+}
+
+var filterArgType = field{
+	"name":   "authorFilterArg",
+	"ofType": nil,
+	"inputFields": []any{
+		makeInputObject("_and", nil, inputObjectAuthorFilterArg),
+		makeInputObject("_key", "IDOperatorBlock", nil),
+		makeInputObject("_not", "authorFilterArg", nil),
+		makeInputObject("_or", nil, inputObjectAuthorFilterArg),
+
+		// Following can probably reworked to be dynamically added based on the schema.
+		makeInputObject("age", "IntOperatorBlock", nil),
+		makeInputObject("name", "StringOperatorBlock", nil),
+		makeInputObject("verified", "BooleanOperatorBlock", nil),
+		makeInputObject("wrote", "bookFilterBaseArg", nil),
+		makeInputObject("wrote_id", "IDOperatorBlock", nil),
+	},
+}
+
+var orderArgType = field{
+	"name":   "authorOrderArg",
+	"ofType": nil,
+	"inputFields": []any{
+		makeAuthorOrdering("_key"),
+
+		// Following can probably reworked to be dynamically added based on the schema.
+		makeAuthorOrdering("age"),
+		makeAuthorOrdering("name"),
+		makeAuthorOrdering("verified"),
+
+		// Without the relation type we won't have the following ordering type(s).
+		makeInputObject("wrote", "bookOrderArg", nil),
+		makeAuthorOrdering("wrote_id"),
+	},
+}

--- a/tests/integration/schema/defaults/args.go
+++ b/tests/integration/schema/defaults/args.go
@@ -11,82 +11,82 @@
 package defaults
 
 var allDefaultGroupArgs = []any{
-	filterArg,
-	groupByArg,
-	limitArg,
-	offsetArg,
-	orderArg,
-	cidArg,
-	dockeyArg,
-	dockeysArg,
+	FilterArg,
+	GroupByArg,
+	LimitArg,
+	OffsetArg,
+	OrderArg,
+	CidArg,
+	DockeyArg,
+	DockeysArg,
 }
 
-var filterArg = field{
+var FilterArg = Field{
 	"name": "filter",
 	"type": filterArgType,
 }
 
-var groupByArg = field{
+var GroupByArg = Field{
 	"name": "groupBy",
 	"type": groupByArgType,
 }
 
-var limitArg = field{
+var LimitArg = Field{
 	"name": "limit",
 	"type": intArgType,
 }
 
-var offsetArg = field{
+var OffsetArg = Field{
 	"name": "offset",
 	"type": intArgType,
 }
 
-var orderArg = field{
+var OrderArg = Field{
 	"name": "order",
 	"type": orderArgType,
 }
 
-var cidArg = field{
+var CidArg = Field{
 	"name": "cid",
 	"type": stringArgType,
 }
 
-var dockeyArg = field{
+var DockeyArg = Field{
 	"name": "dockey",
 	"type": stringArgType,
 }
 
-var dockeysArg = field{
+var DockeysArg = Field{
 	"name": "dockeys",
 	"type": nilArgType,
 }
 
-var groupByArgType = field{
+var groupByArgType = Field{
 	"inputFields": nil,
 	"name":        nil,
-	"ofType": field{
+	"ofType": Field{
 		"kind": "NON_NULL",
 		"name": nil,
 	},
 }
 
-var intArgType = field{
+var intArgType = Field{
 	"inputFields": nil,
 	"name":        "Int",
 	"ofType":      nil,
 }
 
-var stringArgType = field{
+var stringArgType = Field{
 	"inputFields": nil,
 	"name":        "String",
 }
 
-var nilArgType = field{
+var nilArgType = Field{
 	"name":        nil,
 	"inputFields": nil,
 }
 
-var filterArgType = field{
+var filterArgType = Field{
 	"name":   "authorFilterArg",
 	"ofType": nil,
 	"inputFields": []any{
@@ -104,7 +104,7 @@ var filterArgType = field{
 	},
 }
 
-var orderArgType = field{
+var orderArgType = Field{
 	"name":   "authorOrderArg",
 	"ofType": nil,
 	"inputFields": []any{

--- a/tests/integration/schema/defaults/args.go
+++ b/tests/integration/schema/defaults/args.go
@@ -10,7 +10,7 @@
 
 package defaults
 
-var allDefaultGroupArgs = []any{
+var allDefaultArgs = []any{
 	FilterArg,
 	GroupByArg,
 	LimitArg,
@@ -19,6 +19,14 @@ var allDefaultGroupArgs = []any{
 	CidArg,
 	DockeyArg,
 	DockeysArg,
+}
+
+var allDefaultGroupArgs = []any{
+	FilterArg,
+	GroupByArg,
+	LimitArg,
+	OffsetArg,
+	OrderArg,
 }
 
 var FilterArg = Field{
@@ -90,17 +98,17 @@ var filterArgType = Field{
 	"name":   "authorFilterArg",
 	"ofType": nil,
 	"inputFields": []any{
-		makeInputObject("_and", nil, inputObjectAuthorFilterArg),
-		makeInputObject("_key", "IDOperatorBlock", nil),
-		makeInputObject("_not", "authorFilterArg", nil),
-		makeInputObject("_or", nil, inputObjectAuthorFilterArg),
+		makeInputObject(Yes("_and"), Yes(nil), Yes(inputObjectAuthorFilterArg), No()),
+		makeInputObject(Yes("_key"), Yes("IDOperatorBlock"), Yes(nil), No()),
+		makeInputObject(Yes("_not"), Yes("authorFilterArg"), Yes(nil), No()),
+		makeInputObject(Yes("_or"), Yes(nil), Yes(inputObjectAuthorFilterArg), No()),
 
 		// Following can probably reworked to be dynamically added based on the schema.
-		makeInputObject("age", "IntOperatorBlock", nil),
-		makeInputObject("name", "StringOperatorBlock", nil),
-		makeInputObject("verified", "BooleanOperatorBlock", nil),
-		makeInputObject("wrote", "bookFilterBaseArg", nil),
-		makeInputObject("wrote_id", "IDOperatorBlock", nil),
+		makeInputObject(Yes("age"), Yes("IntOperatorBlock"), Yes(nil), No()),
+		makeInputObject(Yes("name"), Yes("StringOperatorBlock"), Yes(nil), No()),
+		makeInputObject(Yes("verified"), Yes("BooleanOperatorBlock"), Yes(nil), No()),
+		makeInputObject(Yes("wrote"), Yes("bookFilterArg"), Yes(nil), No()),
+		makeInputObject(Yes("wrote_id"), Yes("IDOperatorBlock"), Yes(nil), No()),
 	},
 }
 
@@ -116,7 +124,7 @@ var orderArgType = Field{
 		makeAuthorOrdering("verified"),
 
 		// Without the relation type we won't have the following ordering type(s).
-		makeInputObject("wrote", "bookOrderArg", nil),
+		makeInputObject(Yes("wrote"), Yes("bookOrderArg"), Yes(nil), No()),
 		makeAuthorOrdering("wrote_id"),
 	},
 }

--- a/tests/integration/schema/defaults/factory.go
+++ b/tests/integration/schema/defaults/factory.go
@@ -1,0 +1,65 @@
+// Copyright 2022 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package defaults
+
+// makeInputObject retrned a properly made input field type
+// using name (outer), name of type (inner), and types ofType.
+func makeInputObject(
+	name string,
+	typeName any,
+	ofType any,
+) field {
+	return field{
+		"name": name,
+		"type": field{
+			"name":   typeName,
+			"ofType": ofType,
+		},
+	}
+}
+
+func makeAuthorOrdering(name string) field {
+	return makeInputObject(name, "Ordering", nil)
+}
+
+func MakeDefaultGroupArgsWithout(skipThese []string) []field {
+	defaultsWithSomeSkipped := make(
+		[]map[string]any,
+		0,
+		len(allDefaultGroupArgs)-len(skipThese),
+	)
+
+ArgLoop:
+	for _, argAny := range allDefaultGroupArgs {
+		arg, ok := argAny.(field)
+		if !ok {
+			panic("wrong usage of testing schema factory method.")
+		}
+
+		argName, found := arg["name"]
+		if !found {
+			panic("`name` not found in the default group arg.")
+		}
+
+		for _, toSkip := range skipThese {
+			if toSkip == argName {
+				continue ArgLoop
+			}
+		}
+
+		// If we make it till here we, don't want to skip this arg.
+		defaultsWithSomeSkipped = append(defaultsWithSomeSkipped, arg)
+
+	}
+
+	return defaultsWithSomeSkipped
+
+}

--- a/tests/integration/schema/defaults/factory.go
+++ b/tests/integration/schema/defaults/factory.go
@@ -16,30 +16,30 @@ func makeInputObject(
 	name string,
 	typeName any,
 	ofType any,
-) field {
-	return field{
+) Field {
+	return Field{
 		"name": name,
-		"type": field{
+		"type": Field{
 			"name":   typeName,
 			"ofType": ofType,
 		},
 	}
 }
 
-func makeAuthorOrdering(name string) field {
+func makeAuthorOrdering(name string) Field {
 	return makeInputObject(name, "Ordering", nil)
 }
 
-func MakeDefaultGroupArgsWithout(skipThese []string) []field {
+func MakeDefaultGroupArgsWithout(skipThese []string) []any {
 	defaultsWithSomeSkipped := make(
-		[]map[string]any,
+		[]any,
 		0,
 		len(allDefaultGroupArgs)-len(skipThese),
 	)
 
 ArgLoop:
 	for _, argAny := range allDefaultGroupArgs {
-		arg, ok := argAny.(field)
+		arg, ok := argAny.(Field)
 		if !ok {
 			panic("wrong usage of testing schema factory method.")
 		}
@@ -56,10 +56,8 @@ ArgLoop:
 		}
 
 		// If we make it till here we, don't want to skip this arg.
-		defaultsWithSomeSkipped = append(defaultsWithSomeSkipped, arg)
-
+		defaultsWithSomeSkipped = append(defaultsWithSomeSkipped, argAny)
 	}
 
 	return defaultsWithSomeSkipped
-
 }

--- a/tests/integration/schema/defaults/factory.go
+++ b/tests/integration/schema/defaults/factory.go
@@ -16,13 +16,13 @@ func BuildFilterArg(objectName string, fields []ArgDef) Field {
 	filterArgName := objectName + "FilterArg"
 
 	inputFields := []any{
-		makeInputObject(Yes("_and"), Yes(nil), Yes(map[string]any{
+		makeOuterType(Yes("_and"), Yes(nil), Yes(map[string]any{
 			"kind": "INPUT_OBJECT",
 			"name": filterArgName,
 		}), No()),
-		makeInputObject(Yes("_key"), Yes("IDOperatorBlock"), Yes(nil), No()),
-		makeInputObject(Yes("_not"), Yes("authorFilterArg"), Yes(nil), No()),
-		makeInputObject(Yes("_or"), Yes(nil), Yes(map[string]any{
+		makeOuterType(Yes("_key"), Yes("IDOperatorBlock"), Yes(nil), No()),
+		makeOuterType(Yes("_not"), Yes("authorFilterArg"), Yes(nil), No()),
+		makeOuterType(Yes("_or"), Yes(nil), Yes(map[string]any{
 			"kind": "INPUT_OBJECT",
 			"name": filterArgName,
 		}), No()),
@@ -31,15 +31,11 @@ func BuildFilterArg(objectName string, fields []ArgDef) Field {
 	for _, field := range fields {
 		inputFields = append(
 			inputFields,
-			makeInputObject(Yes(field.FieldName), Yes(field.TypeName), Yes(nil), No()),
+			makeOuterType(Yes(field.FieldName), Yes(field.TypeName), Yes(nil), No()),
 		)
 	}
 
-	return makeInputObject(Yes("filter"), Yes(filterArgName), Yes(nil), Yes(inputFields))
-}
-
-func makeAuthorOrdering(name any) Field {
-	return makeInputObject(Yes(name), Yes("Ordering"), Yes(nil), No())
+	return makeOuterType(Yes("filter"), Yes(filterArgName), Yes(nil), Yes(inputFields))
 }
 
 type Opt = client.Option[any]
@@ -52,53 +48,66 @@ func No() Opt {
 	return client.None[any]()
 }
 
-// makeInputObject retrned a properly made input field type
-// using name (outer), name of type (inner), and types ofType.
-func makeInputObject(name Opt, typeName Opt, ofType Opt, inputFields Opt) Field {
+// makeType returns the smallest inner type with all option keys that have value,
+// the options that don't have values are skipped from the returned type.
+func makeType(name, ofType, inputFields Opt) Field {
+	inner := Field{}
+
+	if name.HasValue() {
+		inner["name"] = name.Value()
+	}
+
+	if ofType.HasValue() {
+		inner["ofType"] = ofType.Value()
+	}
+
+	if inputFields.HasValue() {
+		inner["inputFields"] = inputFields.Value()
+	}
+
+	return inner
+}
+
+// makeNameType returns a pair of name and pair type if both inputs have values,
+// otherwise options that are invalid (i.e. `No()`) are ignored.
+func makeNameType(name, innerType Opt) Field {
 	result := Field{}
 
 	if name.HasValue() {
 		result["name"] = name.Value()
 	}
 
-	typeValue := Field{}
-	if typeName.HasValue() {
-		typeValue["name"] = typeName.Value()
+	if innerType.HasValue() {
+		result["type"] = innerType.Value()
 	}
-	if ofType.HasValue() {
-		typeValue["ofType"] = ofType.Value()
-	}
-	if inputFields.HasValue() {
-		typeValue["inputFields"] = inputFields.Value()
-	}
-	result["type"] = typeValue
 
 	return result
 }
 
+// makeOuterType returns the outer object type where all options that HasValue() == true
+// are populated, and others are skipped.
+//
+// The retuned obeject always contains the "type" key (AKA the inner-type).
+func makeOuterType(name, typeName, ofType, inputFields Opt) Field {
+	return makeNameType(name, Yes(makeType(typeName, ofType, inputFields)))
+}
+
 func BuildOrderArg(objectName string, fields []ArgDef) Field {
 	inputFields := []any{
-		makeInputObject(Yes("_key"), Yes("Ordering"), Yes(nil), No()),
+		makeOuterType(Yes("_key"), Yes("Ordering"), Yes(nil), No()),
 	}
 
 	for _, field := range fields {
 		inputFields = append(
 			inputFields,
-			makeInputObject(Yes(field.FieldName), Yes(field.TypeName), Yes(nil), No()),
+			makeOuterType(Yes(field.FieldName), Yes(field.TypeName), Yes(nil), No()),
 		)
 	}
 
-	return Field{
-		"name": "order",
-		"type": Field{
-			"name":        objectName + "OrderArg",
-			"ofType":      nil,
-			"inputFields": inputFields,
-		},
-	}
+	return makeOuterType(Yes("order"), Yes(objectName+"OrderArg"), Yes(nil), Yes(inputFields))
 }
 
-func MakeDefaultGroupArgsWithout(skipThese []string) []any {
+func MakeDefaultsWithout(skipThese []string) []any {
 	defaultsWithSomeSkipped := make(
 		[]any,
 		0,
@@ -106,12 +115,7 @@ func MakeDefaultGroupArgsWithout(skipThese []string) []any {
 	)
 
 ArgLoop:
-	for _, argAny := range allDefaultGroupArgs {
-		arg, ok := argAny.(map[string]any)
-		if !ok {
-			panic("wrong usage of testing schema factory method.")
-		}
-
+	for _, arg := range allDefaultGroupArgs {
 		argName, found := arg["name"]
 		if !found {
 			panic("`name` not found in the default group arg.")
@@ -124,7 +128,7 @@ ArgLoop:
 		}
 
 		// If we make it till here we, don't want to skip this arg.
-		defaultsWithSomeSkipped = append(defaultsWithSomeSkipped, argAny)
+		defaultsWithSomeSkipped = append(defaultsWithSomeSkipped, arg)
 	}
 
 	return defaultsWithSomeSkipped

--- a/tests/integration/schema/defaults/factory.go
+++ b/tests/integration/schema/defaults/factory.go
@@ -10,24 +10,92 @@
 
 package defaults
 
-// makeInputObject retrned a properly made input field type
-// using name (outer), name of type (inner), and types ofType.
-func makeInputObject(
-	name string,
-	typeName any,
-	ofType any,
-) Field {
-	return Field{
-		"name": name,
-		"type": Field{
-			"name":   typeName,
-			"ofType": ofType,
-		},
+import "github.com/sourcenetwork/defradb/client"
+
+func BuildFilterArg(objectName string, fields []ArgDef) Field {
+	filterArgName := objectName + "FilterArg"
+
+	inputFields := []any{
+		makeInputObject(Yes("_and"), Yes(nil), Yes(map[string]any{
+			"kind": "INPUT_OBJECT",
+			"name": filterArgName,
+		}), No()),
+		makeInputObject(Yes("_key"), Yes("IDOperatorBlock"), Yes(nil), No()),
+		makeInputObject(Yes("_not"), Yes("authorFilterArg"), Yes(nil), No()),
+		makeInputObject(Yes("_or"), Yes(nil), Yes(map[string]any{
+			"kind": "INPUT_OBJECT",
+			"name": filterArgName,
+		}), No()),
 	}
+
+	for _, field := range fields {
+		inputFields = append(
+			inputFields,
+			makeInputObject(Yes(field.FieldName), Yes(field.TypeName), Yes(nil), No()),
+		)
+	}
+
+	return makeInputObject(Yes("filter"), Yes(filterArgName), Yes(nil), Yes(inputFields))
 }
 
-func makeAuthorOrdering(name string) Field {
-	return makeInputObject(name, "Ordering", nil)
+func makeAuthorOrdering(name any) Field {
+	return makeInputObject(Yes(name), Yes("Ordering"), Yes(nil), No())
+}
+
+type Opt = client.Option[any]
+
+func Yes(yes any) Opt {
+	return client.Some(yes)
+}
+
+func No() Opt {
+	return client.None[any]()
+}
+
+// makeInputObject retrned a properly made input field type
+// using name (outer), name of type (inner), and types ofType.
+func makeInputObject(name Opt, typeName Opt, ofType Opt, inputFields Opt) Field {
+	result := Field{}
+
+	if name.HasValue() {
+		result["name"] = name.Value()
+	}
+
+	typeValue := Field{}
+	if typeName.HasValue() {
+		typeValue["name"] = typeName.Value()
+	}
+	if ofType.HasValue() {
+		typeValue["ofType"] = ofType.Value()
+	}
+	if inputFields.HasValue() {
+		typeValue["inputFields"] = inputFields.Value()
+	}
+	result["type"] = typeValue
+
+	return result
+}
+
+func BuildOrderArg(objectName string, fields []ArgDef) Field {
+	inputFields := []any{
+		makeInputObject(Yes("_key"), Yes("Ordering"), Yes(nil), No()),
+	}
+
+	for _, field := range fields {
+		inputFields = append(
+			inputFields,
+			makeInputObject(Yes(field.FieldName), Yes(field.TypeName), Yes(nil), No()),
+		)
+	}
+
+	return Field{
+		"name": "order",
+		"type": Field{
+			"name":        objectName + "OrderArg",
+			"ofType":      nil,
+			"inputFields": inputFields,
+		},
+	}
 }
 
 func MakeDefaultGroupArgsWithout(skipThese []string) []any {
@@ -39,7 +107,7 @@ func MakeDefaultGroupArgsWithout(skipThese []string) []any {
 
 ArgLoop:
 	for _, argAny := range allDefaultGroupArgs {
-		arg, ok := argAny.(Field)
+		arg, ok := argAny.(map[string]any)
 		if !ok {
 			panic("wrong usage of testing schema factory method.")
 		}

--- a/tests/integration/schema/defaults/fields.go
+++ b/tests/integration/schema/defaults/fields.go
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-package schema
+package defaults
 
 import "sort"
 
@@ -113,58 +113,6 @@ var aggregateFields = fields{
 	},
 }
 
-var cidArg = field{
-	"name": "cid",
-	"type": map[string]any{
-		"name":        "String",
-		"inputFields": nil,
-	},
-}
-var dockeyArg = field{
-	"name": "dockey",
-	"type": map[string]any{
-		"name":        "String",
-		"inputFields": nil,
-	},
-}
-var dockeysArg = field{
-	"name": "dockeys",
-	"type": map[string]any{
-		"name":        nil,
-		"inputFields": nil,
-	},
-}
-
-var groupByArg = field{
-	"name": "groupBy",
-	"type": map[string]any{
-		"name":        nil,
-		"inputFields": nil,
-		"ofType": map[string]any{
-			"kind": "NON_NULL",
-			"name": nil,
-		},
-	},
-}
-
-var limitArg = field{
-	"name": "limit",
-	"type": map[string]any{
-		"name":        "Int",
-		"inputFields": nil,
-		"ofType":      nil,
-	},
-}
-
-var offsetArg = field{
-	"name": "offset",
-	"type": map[string]any{
-		"name":        "Int",
-		"inputFields": nil,
-		"ofType":      nil,
-	},
-}
-
 type argDef struct {
 	fieldName string
 	typeName  string
@@ -252,20 +200,4 @@ func trimFields(fullDefaultFields fields, properties map[string]any) fields {
 		result = append(result, trimField(field, properties))
 	}
 	return result
-}
-
-// makeInputObject retrned a properly made input field type
-// using name (outer), name of type (inner), and types ofType.
-func makeInputObject(
-	name string,
-	typeName any,
-	ofType any,
-) map[string]any {
-	return map[string]any{
-		"name": name,
-		"type": map[string]any{
-			"name":   typeName,
-			"ofType": ofType,
-		},
-	}
 }

--- a/tests/integration/schema/defaults/fields.go
+++ b/tests/integration/schema/defaults/fields.go
@@ -118,55 +118,6 @@ type ArgDef struct {
 	TypeName  string
 }
 
-func BuildOrderArg(objectName string, fields []ArgDef) Field {
-	inputFields := []any{
-		makeInputObject("_key", "Ordering", nil),
-	}
-
-	for _, field := range fields {
-		inputFields = append(inputFields, makeInputObject(field.FieldName, field.TypeName, nil))
-	}
-
-	return Field{
-		"name": "order",
-		"type": Field{
-			"name":        objectName + "OrderArg",
-			"ofType":      nil,
-			"inputFields": inputFields,
-		},
-	}
-}
-
-func BuildFilterArg(objectName string, fields []ArgDef) Field {
-	filterArgName := objectName + "FilterArg"
-
-	inputFields := []any{
-		makeInputObject("_and", nil, map[string]any{
-			"kind": "INPUT_OBJECT",
-			"name": filterArgName,
-		}),
-		makeInputObject("_key", "IDOperatorBlock", nil),
-		makeInputObject("_not", "authorFilterArg", nil),
-		makeInputObject("_or", nil, map[string]any{
-			"kind": "INPUT_OBJECT",
-			"name": filterArgName,
-		}),
-	}
-
-	for _, field := range fields {
-		inputFields = append(inputFields, makeInputObject(field.FieldName, field.TypeName, nil))
-	}
-
-	return Field{
-		"name": "filter",
-		"type": Field{
-			"name":        filterArgName,
-			"ofType":      nil,
-			"inputFields": inputFields,
-		},
-	}
-}
-
 // TrimField creates a new object using the provided defaults, but only containing
 // the provided properties. Function is recursive and will respect inner properties.
 func TrimField(fullDefault Field, properties map[string]any) Field {

--- a/tests/integration/schema/defaults/fields.go
+++ b/tests/integration/schema/defaults/fields.go
@@ -54,65 +54,6 @@ func (fieldSet Fields) Array() []interface{} {
 	return result
 }
 
-// DefaultFields contains the list of fields every
-// defra schema-object should have.
-var DefaultFields = Concat(
-	Fields{
-		keyField,
-		versionField,
-		groupField,
-	},
-	aggregateFields,
-)
-
-var keyField = Field{
-	"name": "_key",
-	"type": map[string]interface{}{
-		"kind": "SCALAR",
-		"name": "ID",
-	},
-}
-
-var versionField = Field{
-	"name": "_version",
-	"type": map[string]interface{}{
-		"kind": "LIST",
-		"name": nil,
-	},
-}
-
-var groupField = Field{
-	"name": "_group",
-	"type": map[string]interface{}{
-		"kind": "LIST",
-		"name": nil,
-	},
-}
-
-var aggregateFields = Fields{
-	map[string]interface{}{
-		"name": "_avg",
-		"type": map[string]interface{}{
-			"kind": "SCALAR",
-			"name": "Float",
-		},
-	},
-	map[string]interface{}{
-		"name": "_count",
-		"type": map[string]interface{}{
-			"kind": "SCALAR",
-			"name": "Int",
-		},
-	},
-	map[string]interface{}{
-		"name": "_sum",
-		"type": map[string]interface{}{
-			"kind": "SCALAR",
-			"name": "Float",
-		},
-	},
-}
-
 type ArgDef struct {
 	FieldName string
 	TypeName  string

--- a/tests/integration/schema/defaults/input.go
+++ b/tests/integration/schema/defaults/input.go
@@ -1,0 +1,16 @@
+// Copyright 2022 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package defaults
+
+var inputObjectAuthorFilterArg = map[string]any{
+	"kind": "INPUT_OBJECT",
+	"name": "authorFilterArg",
+}

--- a/tests/integration/schema/defaults/input.go
+++ b/tests/integration/schema/defaults/input.go
@@ -14,3 +14,65 @@ var inputObjectAuthorFilterArg = map[string]any{
 	"kind": "INPUT_OBJECT",
 	"name": "authorFilterArg",
 }
+
+func makeOuterTypeImplicit(name, typeName, ofType any) Field {
+	return makeOuterType(Yes(name), Yes(typeName), Yes(ofType), No())
+}
+
+// The default known input type fields for order.
+var orderInputFieldsStatic = []any{
+	makeOuterTypeImplicit("_key", "Ordering", nil),
+
+	//	makeOrderingInput("age"),
+	//	makeOrderingInput("name"),
+	//	makeOrderingInput("verified"),
+	//	makeOuterType(Yes("wrote"), Yes("bookOrderArg"), Yes(nil), No()),
+	//	makeOrderingInput("wrote_id"),
+}
+
+// The default known input type fields for filter
+var filterInputFieldsStatic = []any{
+	makeOuterTypeImplicit("_and", nil, inputObjectAuthorFilterArg),
+	makeOuterTypeImplicit("_key", "IDOperatorBlock", nil),
+	makeOuterTypeImplicit("_not", "authorFilterArg", nil),
+	makeOuterTypeImplicit("_or", nil, inputObjectAuthorFilterArg),
+
+	makeOuterTypeImplicit("age", "IntOperatorBlock", nil),
+	makeOuterTypeImplicit("name", "StringOperatorBlock", nil),
+	makeOuterTypeImplicit("verified", "BooleanOperatorBlock", nil),
+	makeOuterTypeImplicit("wrote", "bookFilterArg", nil),
+	makeOuterTypeImplicit("wrote_id", "IDOperatorBlock", nil),
+}
+
+// BuildAllOrderInputFields builds order related dynamic fields with the
+// known static / default fields.
+func BuildAllOrderInputFields(objectName string, fields []ArgDef) Field {
+	// Start from our already known default fields, and keep building.
+	allInputFields := orderInputFieldsStatic
+
+	// Add the dynamic fields.
+	for _, field := range fields {
+		allInputFields = append(
+			allInputFields,
+			makeOuterType(Yes(field.FieldName), Yes(field.TypeName), Yes(nil), No()),
+		)
+	}
+
+	return makeOuterType(Yes("order"), Yes(objectName+"OrderArg"), Yes(nil), Yes(allInputFields))
+}
+
+// BuildAllFilterInputFields builds all filter related dynamic fields with the
+// known static / default fields.
+func BuildAllFilterInputFields(objectName string, fields []ArgDef) Field {
+	// Start from our already known default fields, and keep building.
+	allInputFields := filterInputFieldsStatic
+
+	for _, field := range fields {
+		allInputFields = append(
+			allInputFields,
+			makeOuterType(Yes(field.FieldName), Yes(field.TypeName), Yes(nil), No()),
+		)
+	}
+
+	return makeOuterType(Yes("filter"), Yes(objectName+"FilterArg"), Yes(nil), Yes(allInputFields))
+}

--- a/tests/integration/schema/defaults/kind.go
+++ b/tests/integration/schema/defaults/kind.go
@@ -1,0 +1,21 @@
+// Copyright 2022 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package defaults
+
+func makeNameKind(name, kind any) Field {
+	return makeNameKindType(Yes(name), No(), Yes(kind))
+}
+
+var listKind = makeNameKind(nil, "LIST")
+var scalarFloatKind = makeNameKind("Float", "SCALAR")
+var scalarIDKind = makeNameKind("ID", "SCALAR")
+var scalarIntKind = makeNameKind("Int", "SCALAR")
+var nonNullKind = makeNameKind(nil, "NON_NULL")

--- a/tests/integration/schema/filter_test.go
+++ b/tests/integration/schema/filter_test.go
@@ -125,7 +125,7 @@ var testFilterForSimpleSchemaArgProps = map[string]any{
 
 var defaultUserArgsWithoutFilter = trimFields(
 	fields{
-		cidArg,
+		defaults.cidArg,
 		dockeyArg,
 		dockeysArg,
 		groupByArg,

--- a/tests/integration/schema/filter_test.go
+++ b/tests/integration/schema/filter_test.go
@@ -133,7 +133,7 @@ var defaultUserArgsWithoutFilter = defaults.TrimFields(
 		defaults.GroupByArg,
 		defaults.LimitArg,
 		defaults.OffsetArg,
-		defaults.BuildOrderArg("users", []defaults.ArgDef{
+		defaults.BuildAllOrderInputFields("users", []defaults.ArgDef{
 			{
 				FieldName: "name",
 				TypeName:  "Ordering",
@@ -280,7 +280,7 @@ var defaultBookArgsWithoutFilter = defaults.TrimFields(
 		defaults.GroupByArg,
 		defaults.LimitArg,
 		defaults.OffsetArg,
-		defaults.BuildOrderArg("book", []defaults.ArgDef{
+		defaults.BuildAllOrderInputFields("book", []defaults.ArgDef{
 			{
 				FieldName: "author",
 				TypeName:  "",

--- a/tests/integration/schema/filter_test.go
+++ b/tests/integration/schema/filter_test.go
@@ -127,9 +127,9 @@ var testFilterForSimpleSchemaArgProps = map[string]any{
 
 var defaultUserArgsWithoutFilter = defaults.TrimFields(
 	defaults.Fields{
-		defaults.CidArg,
 		defaults.DockeyArg,
 		defaults.DockeysArg,
+		defaults.CidArg,
 		defaults.GroupByArg,
 		defaults.LimitArg,
 		defaults.OffsetArg,

--- a/tests/integration/schema/filter_test.go
+++ b/tests/integration/schema/filter_test.go
@@ -12,6 +12,8 @@ package schema
 
 import (
 	"testing"
+
+	"github.com/sourcenetwork/defradb/tests/integration/schema/defaults"
 )
 
 func TestFilterForSimpleSchema(t *testing.T) {
@@ -104,7 +106,7 @@ func TestFilterForSimpleSchema(t *testing.T) {
 										},
 									},
 								},
-							).tidy(),
+							).Tidy(),
 						},
 					},
 				},
@@ -123,18 +125,18 @@ var testFilterForSimpleSchemaArgProps = map[string]any{
 	},
 }
 
-var defaultUserArgsWithoutFilter = trimFields(
-	fields{
-		defaults.cidArg,
-		dockeyArg,
-		dockeysArg,
-		groupByArg,
-		limitArg,
-		offsetArg,
-		buildOrderArg("users", []argDef{
+var defaultUserArgsWithoutFilter = defaults.TrimFields(
+	defaults.Fields{
+		defaults.CidArg,
+		defaults.DockeyArg,
+		defaults.DockeysArg,
+		defaults.GroupByArg,
+		defaults.LimitArg,
+		defaults.OffsetArg,
+		defaults.BuildOrderArg("users", []defaults.ArgDef{
 			{
-				fieldName: "name",
-				typeName:  "Ordering",
+				FieldName: "name",
+				TypeName:  "Ordering",
 			},
 		}),
 	},
@@ -251,7 +253,7 @@ func TestFilterForOneToOneSchema(t *testing.T) {
 										},
 									},
 								},
-							).tidy(),
+							).Tidy(),
 						},
 					},
 				},
@@ -270,26 +272,26 @@ var testFilterForOneToOneSchemaArgProps = map[string]any{
 	},
 }
 
-var defaultBookArgsWithoutFilter = trimFields(
-	fields{
-		cidArg,
-		dockeyArg,
-		dockeysArg,
-		groupByArg,
-		limitArg,
-		offsetArg,
-		buildOrderArg("book", []argDef{
+var defaultBookArgsWithoutFilter = defaults.TrimFields(
+	defaults.Fields{
+		defaults.CidArg,
+		defaults.DockeyArg,
+		defaults.DockeysArg,
+		defaults.GroupByArg,
+		defaults.LimitArg,
+		defaults.OffsetArg,
+		defaults.BuildOrderArg("book", []defaults.ArgDef{
 			{
-				fieldName: "author",
-				typeName:  "",
+				FieldName: "author",
+				TypeName:  "",
 			},
 			{
-				fieldName: "author_id",
-				typeName:  "Ordering",
+				FieldName: "author_id",
+				TypeName:  "Ordering",
 			},
 			{
-				fieldName: "name",
-				typeName:  "Ordering",
+				FieldName: "name",
+				TypeName:  "Ordering",
 			},
 		}),
 	},

--- a/tests/integration/schema/input_type_test.go
+++ b/tests/integration/schema/input_type_test.go
@@ -19,6 +19,9 @@ import (
 var defaultGroupArgsWithoutOrder = defaults.MakeDefaultsWithout(
 	[]string{
 		"order",
+		"cid",
+		"dockey",
+		"dockeys",
 	},
 )
 

--- a/tests/integration/schema/input_type_test.go
+++ b/tests/integration/schema/input_type_test.go
@@ -12,6 +12,8 @@ package schema
 
 import (
 	"testing"
+
+	"github.com/sourcenetwork/defradb/tests/integration/schema/defaults"
 )
 
 func TestInputTypeOfOrderFieldWhereSchemaHasRelationType(t *testing.T) {
@@ -125,7 +127,7 @@ func TestInputTypeOfOrderFieldWhereSchemaHasRelationType(t *testing.T) {
 									},
 								},
 							},
-						).tidy(),
+						),
 					},
 				},
 			},
@@ -147,33 +149,6 @@ var testInputTypeOfOrderFieldWhereSchemaHasRelationTypeArgProps = map[string]any
 	},
 }
 
-var defaultGroupArgsWithoutOrder = trimFields(
-	fields{
-		buildFilterArg("author", []argDef{
-			{
-				fieldName: "age",
-				typeName:  "IntOperatorBlock",
-			},
-			{
-				fieldName: "name",
-				typeName:  "StringOperatorBlock",
-			},
-			{
-				fieldName: "verified",
-				typeName:  "BooleanOperatorBlock",
-			},
-			{
-				fieldName: "wrote",
-				typeName:  "bookFilterArg",
-			},
-			{
-				fieldName: "wrote_id",
-				typeName:  "IDOperatorBlock",
-			},
-		}),
-		groupByArg,
-		limitArg,
-		offsetArg,
-	},
-	testInputTypeOfOrderFieldWhereSchemaHasRelationTypeArgProps,
+var defaultGroupArgsWithoutOrder = defaults.MakeDefaultGroupArgsWithout(
+	[]string{"order"},
 )

--- a/tests/integration/schema/input_type_test.go
+++ b/tests/integration/schema/input_type_test.go
@@ -16,6 +16,12 @@ import (
 	"github.com/sourcenetwork/defradb/tests/integration/schema/defaults"
 )
 
+var defaultGroupArgsWithoutOrder = defaults.MakeDefaultGroupArgsWithout(
+	[]string{
+		"order",
+	},
+)
+
 func TestInputTypeOfOrderFieldWhereSchemaHasRelationType(t *testing.T) {
 	test := QueryTestCase{
 		Schema: []string{
@@ -136,19 +142,3 @@ func TestInputTypeOfOrderFieldWhereSchemaHasRelationType(t *testing.T) {
 
 	ExecuteQueryTestCase(t, test)
 }
-
-var testInputTypeOfOrderFieldWhereSchemaHasRelationTypeArgProps = map[string]any{
-	"name": struct{}{},
-	"type": map[string]any{
-		"name": struct{}{},
-		"ofType": map[string]any{
-			"kind": struct{}{},
-			"name": struct{}{},
-		},
-		"inputFields": struct{}{},
-	},
-}
-
-var defaultGroupArgsWithoutOrder = defaults.MakeDefaultGroupArgsWithout(
-	[]string{"order"},
-)

--- a/tests/integration/schema/input_type_test.go
+++ b/tests/integration/schema/input_type_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/sourcenetwork/defradb/tests/integration/schema/defaults"
 )
 
-var defaultGroupArgsWithoutOrder = defaults.MakeDefaultGroupArgsWithout(
+var defaultGroupArgsWithoutOrder = defaults.MakeDefaultsWithout(
 	[]string{
 		"order",
 	},

--- a/tests/integration/schema/simple_test.go
+++ b/tests/integration/schema/simple_test.go
@@ -12,6 +12,8 @@ package schema
 
 import (
 	"testing"
+
+	"github.com/sourcenetwork/defradb/tests/integration/schema/defaults"
 )
 
 func TestSchemaSimpleCreatesSchemaGivenEmptyType(t *testing.T) {
@@ -112,7 +114,7 @@ func TestSchemaSimpleCreatesSchemaWithDefaultFieldsGivenEmptyType(t *testing.T) 
 		ExpectedData: map[string]interface{}{
 			"__type": map[string]interface{}{
 				"name":   "users",
-				"fields": defaultFields.tidy(),
+				"fields": defaults.DefaultFields.Tidy(),
 			},
 		},
 	}
@@ -168,15 +170,15 @@ func TestSchemaSimpleCreatesSchemaGivenTypeWithStringField(t *testing.T) {
 		ExpectedData: map[string]interface{}{
 			"__type": map[string]interface{}{
 				"name": "users",
-				"fields": defaultFields.append(
-					field{
+				"fields": defaults.DefaultFields.Append(
+					defaults.Field{
 						"name": "Name",
 						"type": map[string]interface{}{
 							"kind": "SCALAR",
 							"name": "String",
 						},
 					},
-				).tidy(),
+				).Tidy(),
 			},
 		},
 	}


### PR DESCRIPTION
Resolves #TBD (once feedback is received)

## Description
This PR is inspired by a discussion I had with @AndrewSisley. Attempts to move the "defaults" of schema testing logic into a separate folder / package as it can grow massive over time.

The scope of this PR isn't and shouldn't be to resolve all limitations of the schema testing package, but only to move the defaults we currently have into the default package, and split it into logical source files.

