### PR TITLE
ci: Add makefile target to verify the local module cache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,21 @@ dev\:start:
 	@$(MAKE) build
 	DEFRA_ENV=dev ./build/defradb start
 
+# Note: In some situations `verify` can modify `go.sum` file, but until a
+#       read-only version is available we have to rely on this.
+# Here are some relevant issues:
+#   - https://github.com/golang/go/issues/31372
+#   - https://github.com/cosmos/cosmos-sdk/issues/4165
+.PHONY: verify
+verify:
+	@if go mod verify | grep -q 'all modules verified'; then \
+		echo "Success!";                                     \
+	else                                                     \
+		echo "Failure:";                                     \
+		go mod verify;                                       \
+		exit 2;                                              \
+	fi;
+
 .PHONY: tidy
 tidy:
 	go mod tidy -go=1.18


### PR DESCRIPTION
Resolves #762 

## Description
- Introduces a Makefile target that will fail when `go mod verify` reports any changes to module cache, because by default the `go mod verify` command just prints the modules that were tampered with (doesn't fail or return an error).

### Limitations
No way to specify `go mod verify` to be a read-only op (i.e. in some cases might modify `go.sum` file.
- https://github.com/golang/go/issues/31372
- https://github.com/cosmos/cosmos-sdk/issues/4165


## How has this been tested?
Ensured that CI will fail upon 

Specify the platform(s) on which this was tested:
- Manjaro WSL2
