### PR TITLE
feat: Add support for and-or inline array aggregate filters

### DIFF
--- a/query/graphql/schema/manager.go
+++ b/query/graphql/schema/manager.go
@@ -128,6 +128,19 @@ func defaultDirectivesType() []*gql.Directive {
 	}
 }
 
+func inlineArrayTypes() []gql.Type {
+	return []gql.Type{
+		gql.Boolean,
+		gql.Float,
+		gql.Int,
+		gql.String,
+		gql.NewNonNull(gql.Boolean),
+		gql.NewNonNull(gql.Float),
+		gql.NewNonNull(gql.Int),
+		gql.NewNonNull(gql.String),
+	}
+}
+
 // default type map includes all the native scalar types
 func defaultTypes() []gql.Type {
 	return []gql.Type{

--- a/tests/integration/query/inline_array/with_count_filter_test.go
+++ b/tests/integration/query/inline_array/with_count_filter_test.go
@@ -128,6 +128,33 @@ func TestQueryInlineNillableIntegerArrayWithCountWithFilter(t *testing.T) {
 	executeTestCase(t, test)
 }
 
+func TestQueryInlineIntegerArrayWithsWithCountWithAndFilterAndPopulatedArray(t *testing.T) {
+	test := testUtils.QueryTestCase{
+		Description: "Simple inline array, filtered count of integer array",
+		Query: `query {
+					users {
+						Name
+						_count(FavouriteIntegers: {filter: {_and: [{_gt: -2}, {_lt: 2}]}})
+					}
+				}`,
+		Docs: map[int][]string{
+			0: {
+				(`{
+				"Name": "Shahzad",
+				"FavouriteIntegers": [-1, 2, -1, 1, 0, -2]
+			}`)},
+		},
+		Results: []map[string]interface{}{
+			{
+				"Name":   "Shahzad",
+				"_count": 4,
+			},
+		},
+	}
+
+	executeTestCase(t, test)
+}
+
 func TestQueryInlineFloatArrayWithCountWithFilter(t *testing.T) {
 	test := testUtils.QueryTestCase{
 		Description: "Simple inline array, filtered count of float array",

--- a/tests/integration/schema/aggregates/inline_array_test.go
+++ b/tests/integration/schema/aggregates/inline_array_test.go
@@ -62,7 +62,7 @@ func TestSchemaAggregateInlineArrayCreatesUsersCount(t *testing.T) {
 										map[string]interface{}{
 											"name": "filter",
 											"type": map[string]interface{}{
-												"name": "NotNullIntOperatorBlock",
+												"name": "NotNullIntFilterArg",
 											},
 										},
 										map[string]interface{}{
@@ -164,7 +164,7 @@ func TestSchemaAggregateInlineArrayCreatesUsersSum(t *testing.T) {
 										map[string]interface{}{
 											"name": "filter",
 											"type": map[string]interface{}{
-												"name": "NotNullFloatOperatorBlock",
+												"name": "NotNullFloatFilterArg",
 											},
 										},
 										map[string]interface{}{
@@ -258,7 +258,7 @@ func TestSchemaAggregateInlineArrayCreatesUsersAverage(t *testing.T) {
 										map[string]interface{}{
 											"name": "filter",
 											"type": map[string]interface{}{
-												"name": "NotNullIntOperatorBlock",
+												"name": "NotNullIntFilterArg",
 											},
 										},
 										map[string]interface{}{
@@ -296,6 +296,1098 @@ func TestSchemaAggregateInlineArrayCreatesUsersAverage(t *testing.T) {
 									},
 								},
 							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteQueryTestCase(t, test)
+}
+
+var aggregateGroupArg = map[string]interface{}{
+	"name": "_group",
+	"type": map[string]interface{}{
+		"name": "users__CountSelector",
+		"inputFields": []interface{}{
+			map[string]interface{}{
+				"name": "filter",
+				"type": map[string]interface{}{
+					"name": "usersFilterArg",
+					"inputFields": []interface{}{
+						map[string]interface{}{
+							"name": "_and",
+							"type": map[string]interface{}{
+								"name": nil,
+							},
+						},
+						map[string]interface{}{
+							"name": "_key",
+							"type": map[string]interface{}{
+								"name": "IDOperatorBlock",
+							},
+						},
+						map[string]interface{}{
+							"name": "_not",
+							"type": map[string]interface{}{
+								"name": "usersFilterArg",
+							},
+						},
+						map[string]interface{}{
+							"name": "_or",
+							"type": map[string]interface{}{
+								"name": nil,
+							},
+						},
+					},
+				},
+			},
+			map[string]interface{}{
+				"name": "limit",
+				"type": map[string]interface{}{
+					"name":        "Int",
+					"inputFields": nil,
+				},
+			},
+		},
+	},
+}
+
+var aggregateVersionArg = map[string]interface{}{
+	"name": "_version",
+	"type": map[string]interface{}{
+		"name": "users___version__CountSelector",
+		"inputFields": []interface{}{
+			map[string]interface{}{
+				"name": "limit",
+				"type": map[string]interface{}{
+					"name":        "Int",
+					"inputFields": nil,
+				},
+			},
+		},
+	},
+}
+
+func TestSchemaAggregateInlineArrayCreatesUsersNillableBooleanCountFilter(t *testing.T) {
+	test := testUtils.QueryTestCase{
+		Schema: []string{
+			`
+				type users {
+					Favourites: [Boolean]
+				}
+			`,
+		},
+		IntrospectionQuery: `
+			query IntrospectionQuery {
+				__type (name: "users") {
+					name
+					fields {
+						name
+						args {
+							name
+							type {
+								name
+								inputFields {
+									name
+									type {
+										name
+										inputFields {
+											name
+											type {
+												name
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		`,
+		ContainsData: map[string]interface{}{
+			"__type": map[string]interface{}{
+				"name": "users",
+				"fields": []interface{}{
+					map[string]interface{}{
+						"name": "_count",
+						"args": []interface{}{
+							map[string]interface{}{
+								"name": "Favourites",
+								"type": map[string]interface{}{
+									"name": "users__Favourites__CountSelector",
+									"inputFields": []interface{}{
+										map[string]interface{}{
+											"name": "filter",
+											"type": map[string]interface{}{
+												"name": "BooleanFilterArg",
+												"inputFields": []interface{}{
+													map[string]interface{}{
+														"name": "_and",
+														"type": map[string]interface{}{
+															"name": nil,
+														},
+													},
+													map[string]interface{}{
+														"name": "_eq",
+														"type": map[string]interface{}{
+															"name": "Boolean",
+														},
+													},
+													map[string]interface{}{
+														"name": "_in",
+														"type": map[string]interface{}{
+															"name": nil,
+														},
+													},
+													map[string]interface{}{
+														"name": "_like",
+														"type": map[string]interface{}{
+															"name": "Boolean",
+														},
+													},
+													map[string]interface{}{
+														"name": "_ne",
+														"type": map[string]interface{}{
+															"name": "Boolean",
+														},
+													},
+													map[string]interface{}{
+														"name": "_nin",
+														"type": map[string]interface{}{
+															"name": nil,
+														},
+													},
+													map[string]interface{}{
+														"name": "_or",
+														"type": map[string]interface{}{
+															"name": nil,
+														},
+													},
+												},
+											},
+										},
+										map[string]interface{}{
+											"name": "limit",
+											"type": map[string]interface{}{
+												"name":        "Int",
+												"inputFields": nil,
+											},
+										},
+									},
+								},
+							},
+							aggregateGroupArg,
+							aggregateVersionArg,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteQueryTestCase(t, test)
+}
+
+func TestSchemaAggregateInlineArrayCreatesUsersBooleanCountFilter(t *testing.T) {
+	test := testUtils.QueryTestCase{
+		Schema: []string{
+			`
+				type users {
+					Favourites: [Boolean!]
+				}
+			`,
+		},
+		IntrospectionQuery: `
+			query IntrospectionQuery {
+				__type (name: "users") {
+					name
+					fields {
+						name
+						args {
+							name
+							type {
+								name
+								inputFields {
+									name
+									type {
+										name
+										inputFields {
+											name
+											type {
+												name
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		`,
+		ContainsData: map[string]interface{}{
+			"__type": map[string]interface{}{
+				"name": "users",
+				"fields": []interface{}{
+					map[string]interface{}{
+						"name": "_count",
+						"args": []interface{}{
+							map[string]interface{}{
+								"name": "Favourites",
+								"type": map[string]interface{}{
+									"name": "users__Favourites__CountSelector",
+									"inputFields": []interface{}{
+										map[string]interface{}{
+											"name": "filter",
+											"type": map[string]interface{}{
+												"name": "NotNullBooleanFilterArg",
+												"inputFields": []interface{}{
+													map[string]interface{}{
+														"name": "_and",
+														"type": map[string]interface{}{
+															"name": nil,
+														},
+													},
+													map[string]interface{}{
+														"name": "_eq",
+														"type": map[string]interface{}{
+															"name": "Boolean",
+														},
+													},
+													map[string]interface{}{
+														"name": "_in",
+														"type": map[string]interface{}{
+															"name": nil,
+														},
+													},
+													map[string]interface{}{
+														"name": "_ne",
+														"type": map[string]interface{}{
+															"name": "Boolean",
+														},
+													},
+													map[string]interface{}{
+														"name": "_nin",
+														"type": map[string]interface{}{
+															"name": nil,
+														},
+													},
+													map[string]interface{}{
+														"name": "_or",
+														"type": map[string]interface{}{
+															"name": nil,
+														},
+													},
+												},
+											},
+										},
+										map[string]interface{}{
+											"name": "limit",
+											"type": map[string]interface{}{
+												"name":        "Int",
+												"inputFields": nil,
+											},
+										},
+									},
+								},
+							},
+							aggregateGroupArg,
+							aggregateVersionArg,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteQueryTestCase(t, test)
+}
+
+func TestSchemaAggregateInlineArrayCreatesUsersNillableIntegerCountFilter(t *testing.T) {
+	test := testUtils.QueryTestCase{
+		Schema: []string{
+			`
+				type users {
+					Favourites: [Int]
+				}
+			`,
+		},
+		IntrospectionQuery: `
+			query IntrospectionQuery {
+				__type (name: "users") {
+					name
+					fields {
+						name
+						args {
+							name
+							type {
+								name
+								inputFields {
+									name
+									type {
+										name
+										inputFields {
+											name
+											type {
+												name
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		`,
+		ContainsData: map[string]interface{}{
+			"__type": map[string]interface{}{
+				"name": "users",
+				"fields": []interface{}{
+					map[string]interface{}{
+						"name": "_count",
+						"args": []interface{}{
+							map[string]interface{}{
+								"name": "Favourites",
+								"type": map[string]interface{}{
+									"name": "users__Favourites__CountSelector",
+									"inputFields": []interface{}{
+										map[string]interface{}{
+											"name": "filter",
+											"type": map[string]interface{}{
+												"name": "IntFilterArg",
+												"inputFields": []interface{}{
+													map[string]interface{}{
+														"name": "_and",
+														"type": map[string]interface{}{
+															"name": nil,
+														},
+													},
+													map[string]interface{}{
+														"name": "_eq",
+														"type": map[string]interface{}{
+															"name": "Int",
+														},
+													},
+													map[string]interface{}{
+														"name": "_ge",
+														"type": map[string]interface{}{
+															"name": "Int",
+														},
+													},
+													map[string]interface{}{
+														"name": "_gt",
+														"type": map[string]interface{}{
+															"name": "Int",
+														},
+													},
+													map[string]interface{}{
+														"name": "_in",
+														"type": map[string]interface{}{
+															"name": nil,
+														},
+													},
+													map[string]interface{}{
+														"name": "_le",
+														"type": map[string]interface{}{
+															"name": "Int",
+														},
+													},
+													map[string]interface{}{
+														"name": "_lt",
+														"type": map[string]interface{}{
+															"name": "Int",
+														},
+													},
+													map[string]interface{}{
+														"name": "_ne",
+														"type": map[string]interface{}{
+															"name": "Int",
+														},
+													},
+													map[string]interface{}{
+														"name": "_nin",
+														"type": map[string]interface{}{
+															"name": nil,
+														},
+													},
+													map[string]interface{}{
+														"name": "_or",
+														"type": map[string]interface{}{
+															"name": nil,
+														},
+													},
+												},
+											},
+										},
+										map[string]interface{}{
+											"name": "limit",
+											"type": map[string]interface{}{
+												"name":        "Int",
+												"inputFields": nil,
+											},
+										},
+									},
+								},
+							},
+							aggregateGroupArg,
+							aggregateVersionArg,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteQueryTestCase(t, test)
+}
+
+func TestSchemaAggregateInlineArrayCreatesUsersIntegerCountFilter(t *testing.T) {
+	test := testUtils.QueryTestCase{
+		Schema: []string{
+			`
+				type users {
+					Favourites: [Int!]
+				}
+			`,
+		},
+		IntrospectionQuery: `
+			query IntrospectionQuery {
+				__type (name: "users") {
+					name
+					fields {
+						name
+						args {
+							name
+							type {
+								name
+								inputFields {
+									name
+									type {
+										name
+										inputFields {
+											name
+											type {
+												name
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		`,
+		ContainsData: map[string]interface{}{
+			"__type": map[string]interface{}{
+				"name": "users",
+				"fields": []interface{}{
+					map[string]interface{}{
+						"name": "_count",
+						"args": []interface{}{
+							map[string]interface{}{
+								"name": "Favourites",
+								"type": map[string]interface{}{
+									"name": "users__Favourites__CountSelector",
+									"inputFields": []interface{}{
+										map[string]interface{}{
+											"name": "filter",
+											"type": map[string]interface{}{
+												"name": "NotNullIntFilterArg",
+												"inputFields": []interface{}{
+													map[string]interface{}{
+														"name": "_and",
+														"type": map[string]interface{}{
+															"name": nil,
+														},
+													},
+													map[string]interface{}{
+														"name": "_eq",
+														"type": map[string]interface{}{
+															"name": "Int",
+														},
+													},
+													map[string]interface{}{
+														"name": "_ge",
+														"type": map[string]interface{}{
+															"name": "Int",
+														},
+													},
+													map[string]interface{}{
+														"name": "_gt",
+														"type": map[string]interface{}{
+															"name": "Int",
+														},
+													},
+													map[string]interface{}{
+														"name": "_in",
+														"type": map[string]interface{}{
+															"name": nil,
+														},
+													},
+													map[string]interface{}{
+														"name": "_le",
+														"type": map[string]interface{}{
+															"name": "Int",
+														},
+													},
+													map[string]interface{}{
+														"name": "_lt",
+														"type": map[string]interface{}{
+															"name": "Int",
+														},
+													},
+													map[string]interface{}{
+														"name": "_ne",
+														"type": map[string]interface{}{
+															"name": "Int",
+														},
+													},
+													map[string]interface{}{
+														"name": "_nin",
+														"type": map[string]interface{}{
+															"name": nil,
+														},
+													},
+													map[string]interface{}{
+														"name": "_or",
+														"type": map[string]interface{}{
+															"name": nil,
+														},
+													},
+												},
+											},
+										},
+										map[string]interface{}{
+											"name": "limit",
+											"type": map[string]interface{}{
+												"name":        "Int",
+												"inputFields": nil,
+											},
+										},
+									},
+								},
+							},
+							aggregateGroupArg,
+							aggregateVersionArg,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteQueryTestCase(t, test)
+}
+
+func TestSchemaAggregateInlineArrayCreatesUsersNillableFloatCountFilter(t *testing.T) {
+	test := testUtils.QueryTestCase{
+		Schema: []string{
+			`
+				type users {
+					Favourites: [Float]
+				}
+			`,
+		},
+		IntrospectionQuery: `
+			query IntrospectionQuery {
+				__type (name: "users") {
+					name
+					fields {
+						name
+						args {
+							name
+							type {
+								name
+								inputFields {
+									name
+									type {
+										name
+										inputFields {
+											name
+											type {
+												name
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		`,
+		ContainsData: map[string]interface{}{
+			"__type": map[string]interface{}{
+				"name": "users",
+				"fields": []interface{}{
+					map[string]interface{}{
+						"name": "_count",
+						"args": []interface{}{
+							map[string]interface{}{
+								"name": "Favourites",
+								"type": map[string]interface{}{
+									"name": "users__Favourites__CountSelector",
+									"inputFields": []interface{}{
+										map[string]interface{}{
+											"name": "filter",
+											"type": map[string]interface{}{
+												"name": "FloatFilterArg",
+												"inputFields": []interface{}{
+													map[string]interface{}{
+														"name": "_and",
+														"type": map[string]interface{}{
+															"name": nil,
+														},
+													},
+													map[string]interface{}{
+														"name": "_eq",
+														"type": map[string]interface{}{
+															"name": "Float",
+														},
+													},
+													map[string]interface{}{
+														"name": "_ge",
+														"type": map[string]interface{}{
+															"name": "Float",
+														},
+													},
+													map[string]interface{}{
+														"name": "_gt",
+														"type": map[string]interface{}{
+															"name": "Float",
+														},
+													},
+													map[string]interface{}{
+														"name": "_in",
+														"type": map[string]interface{}{
+															"name": nil,
+														},
+													},
+													map[string]interface{}{
+														"name": "_le",
+														"type": map[string]interface{}{
+															"name": "Float",
+														},
+													},
+													map[string]interface{}{
+														"name": "_lt",
+														"type": map[string]interface{}{
+															"name": "Float",
+														},
+													},
+													map[string]interface{}{
+														"name": "_ne",
+														"type": map[string]interface{}{
+															"name": "Float",
+														},
+													},
+													map[string]interface{}{
+														"name": "_nin",
+														"type": map[string]interface{}{
+															"name": nil,
+														},
+													},
+													map[string]interface{}{
+														"name": "_or",
+														"type": map[string]interface{}{
+															"name": nil,
+														},
+													},
+												},
+											},
+										},
+										map[string]interface{}{
+											"name": "limit",
+											"type": map[string]interface{}{
+												"name":        "Int",
+												"inputFields": nil,
+											},
+										},
+									},
+								},
+							},
+							aggregateGroupArg,
+							aggregateVersionArg,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteQueryTestCase(t, test)
+}
+
+func TestSchemaAggregateInlineArrayCreatesUsersFloatCountFilter(t *testing.T) {
+	test := testUtils.QueryTestCase{
+		Schema: []string{
+			`
+				type users {
+					Favourites: [Float!]
+				}
+			`,
+		},
+		IntrospectionQuery: `
+			query IntrospectionQuery {
+				__type (name: "users") {
+					name
+					fields {
+						name
+						args {
+							name
+							type {
+								name
+								inputFields {
+									name
+									type {
+										name
+										inputFields {
+											name
+											type {
+												name
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		`,
+		ContainsData: map[string]interface{}{
+			"__type": map[string]interface{}{
+				"name": "users",
+				"fields": []interface{}{
+					map[string]interface{}{
+						"name": "_count",
+						"args": []interface{}{
+							map[string]interface{}{
+								"name": "Favourites",
+								"type": map[string]interface{}{
+									"name": "users__Favourites__CountSelector",
+									"inputFields": []interface{}{
+										map[string]interface{}{
+											"name": "filter",
+											"type": map[string]interface{}{
+												"name": "NotNullFloatFilterArg",
+												"inputFields": []interface{}{
+													map[string]interface{}{
+														"name": "_and",
+														"type": map[string]interface{}{
+															"name": nil,
+														},
+													},
+													map[string]interface{}{
+														"name": "_eq",
+														"type": map[string]interface{}{
+															"name": "Float",
+														},
+													},
+													map[string]interface{}{
+														"name": "_ge",
+														"type": map[string]interface{}{
+															"name": "Float",
+														},
+													},
+													map[string]interface{}{
+														"name": "_gt",
+														"type": map[string]interface{}{
+															"name": "Float",
+														},
+													},
+													map[string]interface{}{
+														"name": "_in",
+														"type": map[string]interface{}{
+															"name": nil,
+														},
+													},
+													map[string]interface{}{
+														"name": "_le",
+														"type": map[string]interface{}{
+															"name": "Float",
+														},
+													},
+													map[string]interface{}{
+														"name": "_lt",
+														"type": map[string]interface{}{
+															"name": "Float",
+														},
+													},
+													map[string]interface{}{
+														"name": "_ne",
+														"type": map[string]interface{}{
+															"name": "Float",
+														},
+													},
+													map[string]interface{}{
+														"name": "_nin",
+														"type": map[string]interface{}{
+															"name": nil,
+														},
+													},
+													map[string]interface{}{
+														"name": "_or",
+														"type": map[string]interface{}{
+															"name": nil,
+														},
+													},
+												},
+											},
+										},
+										map[string]interface{}{
+											"name": "limit",
+											"type": map[string]interface{}{
+												"name":        "Int",
+												"inputFields": nil,
+											},
+										},
+									},
+								},
+							},
+							aggregateGroupArg,
+							aggregateVersionArg,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteQueryTestCase(t, test)
+}
+
+func TestSchemaAggregateInlineArrayCreatesUsersNillableStringCountFilter(t *testing.T) {
+	test := testUtils.QueryTestCase{
+		Schema: []string{
+			`
+				type users {
+					Favourites: [String]
+				}
+			`,
+		},
+		IntrospectionQuery: `
+			query IntrospectionQuery {
+				__type (name: "users") {
+					name
+					fields {
+						name
+						args {
+							name
+							type {
+								name
+								inputFields {
+									name
+									type {
+										name
+										inputFields {
+											name
+											type {
+												name
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		`,
+		ContainsData: map[string]interface{}{
+			"__type": map[string]interface{}{
+				"name": "users",
+				"fields": []interface{}{
+					map[string]interface{}{
+						"name": "_count",
+						"args": []interface{}{
+							map[string]interface{}{
+								"name": "Favourites",
+								"type": map[string]interface{}{
+									"name": "users__Favourites__CountSelector",
+									"inputFields": []interface{}{
+										map[string]interface{}{
+											"name": "filter",
+											"type": map[string]interface{}{
+												"name": "StringFilterArg",
+												"inputFields": []interface{}{
+													map[string]interface{}{
+														"name": "_and",
+														"type": map[string]interface{}{
+															"name": nil,
+														},
+													},
+													map[string]interface{}{
+														"name": "_eq",
+														"type": map[string]interface{}{
+															"name": "String",
+														},
+													},
+													map[string]interface{}{
+														"name": "_in",
+														"type": map[string]interface{}{
+															"name": nil,
+														},
+													},
+													map[string]interface{}{
+														"name": "_like",
+														"type": map[string]interface{}{
+															"name": "String",
+														},
+													},
+													map[string]interface{}{
+														"name": "_ne",
+														"type": map[string]interface{}{
+															"name": "String",
+														},
+													},
+													map[string]interface{}{
+														"name": "_nin",
+														"type": map[string]interface{}{
+															"name": nil,
+														},
+													},
+													map[string]interface{}{
+														"name": "_or",
+														"type": map[string]interface{}{
+															"name": nil,
+														},
+													},
+												},
+											},
+										},
+										map[string]interface{}{
+											"name": "limit",
+											"type": map[string]interface{}{
+												"name":        "Int",
+												"inputFields": nil,
+											},
+										},
+									},
+								},
+							},
+							aggregateGroupArg,
+							aggregateVersionArg,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteQueryTestCase(t, test)
+}
+
+func TestSchemaAggregateInlineArrayCreatesUsersStringCountFilter(t *testing.T) {
+	test := testUtils.QueryTestCase{
+		Schema: []string{
+			`
+				type users {
+					Favourites: [String!]
+				}
+			`,
+		},
+		IntrospectionQuery: `
+			query IntrospectionQuery {
+				__type (name: "users") {
+					name
+					fields {
+						name
+						args {
+							name
+							type {
+								name
+								inputFields {
+									name
+									type {
+										name
+										inputFields {
+											name
+											type {
+												name
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		`,
+		ContainsData: map[string]interface{}{
+			"__type": map[string]interface{}{
+				"name": "users",
+				"fields": []interface{}{
+					map[string]interface{}{
+						"name": "_count",
+						"args": []interface{}{
+							map[string]interface{}{
+								"name": "Favourites",
+								"type": map[string]interface{}{
+									"name": "users__Favourites__CountSelector",
+									"inputFields": []interface{}{
+										map[string]interface{}{
+											"name": "filter",
+											"type": map[string]interface{}{
+												"name": "NotNullStringFilterArg",
+												"inputFields": []interface{}{
+													map[string]interface{}{
+														"name": "_and",
+														"type": map[string]interface{}{
+															"name": nil,
+														},
+													},
+													map[string]interface{}{
+														"name": "_eq",
+														"type": map[string]interface{}{
+															"name": "String",
+														},
+													},
+													map[string]interface{}{
+														"name": "_in",
+														"type": map[string]interface{}{
+															"name": nil,
+														},
+													},
+													map[string]interface{}{
+														"name": "_ne",
+														"type": map[string]interface{}{
+															"name": "String",
+														},
+													},
+													map[string]interface{}{
+														"name": "_nin",
+														"type": map[string]interface{}{
+															"name": nil,
+														},
+													},
+													map[string]interface{}{
+														"name": "_or",
+														"type": map[string]interface{}{
+															"name": nil,
+														},
+													},
+												},
+											},
+										},
+										map[string]interface{}{
+											"name": "limit",
+											"type": map[string]interface{}{
+												"name":        "Int",
+												"inputFields": nil,
+											},
+										},
+									},
+								},
+							},
+							aggregateGroupArg,
+							aggregateVersionArg,
 						},
 					},
 				},


### PR DESCRIPTION
## Relevant issue(s)

Resolves #621

## Description

Adds support for and-or in inline array aggregate filters.  Also fixes a bug where the underling type (e.g. Int) was set as the type param for normal-non-aggregate filters on inline arrays (tested via tests when adding the main feature, fix-commit does not contain tests that covers this).

Specify the platform(s) on which this was tested:
- Debian Linux
