### PR TITLE
fix: Error nicely on missing field specifier

### DIFF
--- a/query/graphql/schema/generate.go
+++ b/query/graphql/schema/generate.go
@@ -905,7 +905,7 @@ func (g *Generator) genNumericAggregateBaseArgInputs(obj *gql.Object) *gql.Input
 
 		return gql.InputObjectConfigFieldMap{
 			"field": &gql.InputObjectFieldConfig{
-				Type: fieldsEnum,
+				Type: gql.NewNonNull(fieldsEnum),
 			},
 			parserTypes.LimitClause: &gql.InputObjectFieldConfig{
 				Type:        gql.Int,

--- a/tests/integration/query/simple/with_average_test.go
+++ b/tests/integration/query/simple/with_average_test.go
@@ -16,13 +16,25 @@ import (
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
 )
 
-func TestQuerySimpleWithAverageOnUndefined(t *testing.T) {
+func TestQuerySimpleWithAverageOnUndefinedObject(t *testing.T) {
 	test := testUtils.QueryTestCase{
-		Description: "Simple query, average on undefined",
+		Description: "Simple query, average on undefined object",
 		Query: `query {
 					_avg
 				}`,
 		ExpectedError: "Aggregate must be provided with a property to aggregate.",
+	}
+
+	executeTestCase(t, test)
+}
+
+func TestQuerySimpleWithAverageOnUndefinedField(t *testing.T) {
+	test := testUtils.QueryTestCase{
+		Description: "Simple query, average on undefined field",
+		Query: `query {
+					_avg(users: {})
+				}`,
+		ExpectedError: "Argument \"users\" has invalid value {}.\nIn field \"field\": Expected \"usersNumericFieldsArg!\", found null.",
 	}
 
 	executeTestCase(t, test)

--- a/tests/integration/query/simple/with_sum_test.go
+++ b/tests/integration/query/simple/with_sum_test.go
@@ -16,13 +16,25 @@ import (
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
 )
 
-func TestQuerySimpleWithSumOnUndefined(t *testing.T) {
+func TestQuerySimpleWithSumOnUndefinedObject(t *testing.T) {
 	test := testUtils.QueryTestCase{
-		Description: "Simple query, sum on undefined",
+		Description: "Simple query, sum on undefined object",
 		Query: `query {
 					_sum
 				}`,
 		ExpectedError: "Aggregate must be provided with a property to aggregate.",
+	}
+
+	executeTestCase(t, test)
+}
+
+func TestQuerySimpleWithSumOnUndefinedField(t *testing.T) {
+	test := testUtils.QueryTestCase{
+		Description: "Simple query, sum on undefined field",
+		Query: `query {
+					_sum(users: {})
+				}`,
+		ExpectedError: "Argument \"users\" has invalid value {}.\nIn field \"field\": Expected \"usersNumericFieldsArg!\", found null.",
 	}
 
 	executeTestCase(t, test)

--- a/tests/integration/schema/aggregates/inline_array_test.go
+++ b/tests/integration/schema/aggregates/inline_array_test.go
@@ -208,7 +208,7 @@ func TestSchemaAggregateInlineArrayCreatesUsersSum(t *testing.T) {
 										map[string]interface{}{
 											"name": "field",
 											"type": map[string]interface{}{
-												"name": "usersNumericFieldsArg",
+												"name": nil,
 											},
 										},
 										map[string]interface{}{
@@ -314,7 +314,7 @@ func TestSchemaAggregateInlineArrayCreatesUsersAverage(t *testing.T) {
 										map[string]interface{}{
 											"name": "field",
 											"type": map[string]interface{}{
-												"name": "usersNumericFieldsArg",
+												"name": nil,
 											},
 										},
 										map[string]interface{}{

--- a/tests/integration/schema/aggregates/simple_test.go
+++ b/tests/integration/schema/aggregates/simple_test.go
@@ -129,6 +129,10 @@ func TestSchemaAggregateSimpleCreatesUsersSum(t *testing.T) {
 									name
 									type {
 										name
+										kind
+										ofType {
+											name
+										}
 									}
 								}
 							}
@@ -152,25 +156,35 @@ func TestSchemaAggregateSimpleCreatesUsersSum(t *testing.T) {
 										map[string]interface{}{
 											"name": "field",
 											"type": map[string]interface{}{
-												"name": "usersNumericFieldsArg",
+												"name": nil,
+												"kind": "NON_NULL",
+												"ofType": map[string]interface{}{
+													"name": "usersNumericFieldsArg",
+												},
 											},
 										},
 										map[string]interface{}{
 											"name": "filter",
 											"type": map[string]interface{}{
-												"name": "usersFilterArg",
+												"name":   "usersFilterArg",
+												"kind":   "INPUT_OBJECT",
+												"ofType": nil,
 											},
 										},
 										map[string]interface{}{
 											"name": "limit",
 											"type": map[string]interface{}{
-												"name": "Int",
+												"name":   "Int",
+												"kind":   "SCALAR",
+												"ofType": nil,
 											},
 										},
 										map[string]interface{}{
 											"name": "offset",
 											"type": map[string]interface{}{
-												"name": "Int",
+												"name":   "Int",
+												"kind":   "SCALAR",
+												"ofType": nil,
 											},
 										},
 									},
@@ -207,6 +221,10 @@ func TestSchemaAggregateSimpleCreatesUsersAverage(t *testing.T) {
 									name
 									type {
 										name
+										kind
+										ofType {
+											name
+										}
 									}
 								}
 							}
@@ -230,25 +248,35 @@ func TestSchemaAggregateSimpleCreatesUsersAverage(t *testing.T) {
 										map[string]interface{}{
 											"name": "field",
 											"type": map[string]interface{}{
-												"name": "usersNumericFieldsArg",
+												"name": nil,
+												"kind": "NON_NULL",
+												"ofType": map[string]interface{}{
+													"name": "usersNumericFieldsArg",
+												},
 											},
 										},
 										map[string]interface{}{
 											"name": "filter",
 											"type": map[string]interface{}{
-												"name": "usersFilterArg",
+												"name":   "usersFilterArg",
+												"kind":   "INPUT_OBJECT",
+												"ofType": nil,
 											},
 										},
 										map[string]interface{}{
 											"name": "limit",
 											"type": map[string]interface{}{
-												"name": "Int",
+												"name":   "Int",
+												"kind":   "SCALAR",
+												"ofType": nil,
 											},
 										},
 										map[string]interface{}{
 											"name": "offset",
 											"type": map[string]interface{}{
-												"name": "Int",
+												"name":   "Int",
+												"kind":   "SCALAR",
+												"ofType": nil,
 											},
 										},
 									},

--- a/tests/integration/schema/aggregates/top_level_test.go
+++ b/tests/integration/schema/aggregates/top_level_test.go
@@ -111,6 +111,10 @@ func TestSchemaAggregateTopLevelCreatesSumGivenSchema(t *testing.T) {
 										name
 										type {
 											name
+											kind
+											ofType {
+												name
+											}
 										}
 									}
 								}
@@ -135,25 +139,35 @@ func TestSchemaAggregateTopLevelCreatesSumGivenSchema(t *testing.T) {
 											map[string]interface{}{
 												"name": "field",
 												"type": map[string]interface{}{
-													"name": "usersNumericFieldsArg",
+													"name": nil,
+													"kind": "NON_NULL",
+													"ofType": map[string]interface{}{
+														"name": "usersNumericFieldsArg",
+													},
 												},
 											},
 											map[string]interface{}{
 												"name": "filter",
 												"type": map[string]interface{}{
-													"name": "usersFilterArg",
+													"name":   "usersFilterArg",
+													"kind":   "INPUT_OBJECT",
+													"ofType": nil,
 												},
 											},
 											map[string]interface{}{
 												"name": "limit",
 												"type": map[string]interface{}{
-													"name": "Int",
+													"name":   "Int",
+													"kind":   "SCALAR",
+													"ofType": nil,
 												},
 											},
 											map[string]interface{}{
 												"name": "offset",
 												"type": map[string]interface{}{
-													"name": "Int",
+													"name":   "Int",
+													"kind":   "SCALAR",
+													"ofType": nil,
 												},
 											},
 										},
@@ -191,6 +205,10 @@ func TestSchemaAggregateTopLevelCreatesAverageGivenSchema(t *testing.T) {
 										name
 										type {
 											name
+											kind
+											ofType {
+												name
+											}
 										}
 									}
 								}
@@ -215,25 +233,35 @@ func TestSchemaAggregateTopLevelCreatesAverageGivenSchema(t *testing.T) {
 											map[string]interface{}{
 												"name": "field",
 												"type": map[string]interface{}{
-													"name": "usersNumericFieldsArg",
+													"name": nil,
+													"kind": "NON_NULL",
+													"ofType": map[string]interface{}{
+														"name": "usersNumericFieldsArg",
+													},
 												},
 											},
 											map[string]interface{}{
 												"name": "filter",
 												"type": map[string]interface{}{
-													"name": "usersFilterArg",
+													"name":   "usersFilterArg",
+													"kind":   "INPUT_OBJECT",
+													"ofType": nil,
 												},
 											},
 											map[string]interface{}{
 												"name": "limit",
 												"type": map[string]interface{}{
-													"name": "Int",
+													"name":   "Int",
+													"kind":   "SCALAR",
+													"ofType": nil,
 												},
 											},
 											map[string]interface{}{
 												"name": "offset",
 												"type": map[string]interface{}{
-													"name": "Int",
+													"name":   "Int",
+													"kind":   "SCALAR",
+													"ofType": nil,
 												},
 											},
 										},


### PR DESCRIPTION
## Relevant issue(s)

Resolves #707

## Description

Makes the field input item mandatory in the numericAggregate args (used for non-inline-arrays for sum and average, but not count which doesn't operate at field level).  Results in a gql error instead of whatever breaks first in defra, and will be visible in gql clients.

Specify the platform(s) on which this was tested:
- Debian Linux
