### PR TITLE
fix: Remove having gql types

### DIFF
--- a/query/graphql/schema/examples/example.schema.gql
+++ b/query/graphql/schema/examples/example.schema.gql
@@ -147,6 +147,6 @@ input AuthorOrderArg {
 }
 
 type Query {
-    books(filter: BookFilterArg, groupBy: [BookFields!], having: BookHavingArg, order: BookOrderArg, limit: Int, offset: Int) [Book]
-    authors(filter: AuthorFilterArg, groupBy: [AuthorFields!], having: AuthorHavingArg, order: AuthorOrderArg, limit: Int, offset: Int) [Author]
+    books(filter: BookFilterArg, groupBy: [BookFields!], order: BookOrderArg, limit: Int, offset: Int) [Book]
+    authors(filter: AuthorFilterArg, groupBy: [AuthorFields!], order: AuthorOrderArg, limit: Int, offset: Int) [Author]
 }

--- a/query/graphql/schema/examples/root.schema.gql
+++ b/query/graphql/schema/examples/root.schema.gql
@@ -25,7 +25,6 @@ enum ValueOperatorInput {
 input GenericQueryInput {
     filter: GenericFilterArg
     groupBy: [GenericGroupByArg]
-    having: GenericHavingArg
     order: GenericOrderArg
     limit: GenericLimitArg
     offset: GenericOffsetArg

--- a/query/graphql/schema/type.schema.gen.gql.template
+++ b/query/graphql/schema/type.schema.gen.gql.template
@@ -74,5 +74,5 @@ input {TYPE_NAME}OrderArg {
 }
 
 extend type Query {
-    {collection_name}(filter: {TYPE_NAME}FilterArg, groupBy: [{TYPE_NAME}Fields!], having: {TYPE_NAME}HavingArg, order: {TYPE_NAME}OrderArg, limit: Int, offset: Int) [{TYPE_NAME}]
+    {collection_name}(filter: {TYPE_NAME}FilterArg, groupBy: [{TYPE_NAME}Fields!], order: {TYPE_NAME}OrderArg, limit: Int, offset: Int) [{TYPE_NAME}]
 }

--- a/tests/integration/schema/default_fields.go
+++ b/tests/integration/schema/default_fields.go
@@ -165,29 +165,6 @@ var offsetArg = field{
 	},
 }
 
-func buildHavingArg(objectName string, fields ...string) field {
-	havingBlockName := objectName + "HavingBlock"
-	inputFields := []any{
-		makeInputObject("_avg", havingBlockName, nil),
-		makeInputObject("_count", havingBlockName, nil),
-		makeInputObject("_key", havingBlockName, nil),
-		makeInputObject("_sum", havingBlockName, nil),
-	}
-
-	for _, field := range fields {
-		inputFields = append(inputFields, makeInputObject(field, havingBlockName, nil))
-	}
-
-	return field{
-		"name": "having",
-		"type": field{
-			"name":        objectName + "HavingArg",
-			"ofType":      nil,
-			"inputFields": inputFields,
-		},
-	}
-}
-
 type argDef struct {
 	fieldName string
 	typeName  string

--- a/tests/integration/schema/filter_test.go
+++ b/tests/integration/schema/filter_test.go
@@ -131,7 +131,6 @@ var defaultUserArgsWithoutFilter = trimFields(
 		groupByArg,
 		limitArg,
 		offsetArg,
-		buildHavingArg("users", "name"),
 		buildOrderArg("users", []argDef{
 			{
 				fieldName: "name",
@@ -279,7 +278,6 @@ var defaultBookArgsWithoutFilter = trimFields(
 		groupByArg,
 		limitArg,
 		offsetArg,
-		buildHavingArg("book", "author_id", "name"),
 		buildOrderArg("book", []argDef{
 			{
 				fieldName: "author",

--- a/tests/integration/schema/input_type_test.go
+++ b/tests/integration/schema/input_type_test.go
@@ -172,7 +172,6 @@ var defaultGroupArgsWithoutOrder = trimFields(
 			},
 		}),
 		groupByArg,
-		buildHavingArg("author", "age", "name", "verified", "wrote_id"),
 		limitArg,
 		offsetArg,
 	},


### PR DESCRIPTION
## Relevant issue(s)

Resolves #776

## Description

Removes having gql types. The having parameter exists only in our gql type system and is undocumented and non-functional, it was adding overhead to development of functional features and so is being removed. 

Specify the platform(s) on which this was tested:
- Debian Linux
