### PR TITLE
fix: Handle filter input field argument being nil

### DIFF
--- a/tests/integration/schema/filter_test.go
+++ b/tests/integration/schema/filter_test.go
@@ -281,7 +281,7 @@ var defaultBookArgsWithoutFilter = trimFields(
 		buildOrderArg("book", []argDef{
 			{
 				fieldName: "author",
-				typeName:  "",
+				typeName:  "authorOrderArg",
 			},
 			{
 				fieldName: "author_id",


### PR DESCRIPTION
## Relevant issue(s)
Resolves #784 
Similar to #701 (PR), #700 (ISSUE)

## Description
- In `generate.go`.genTypeFilterArgInput where if a [field.Type + "FilterArg"] key didn't exist in the `typeMap` it would return nil and pass that to `InputObjectFieldConfig` as Type.
- Additionally, with help from @jsimnz we modify the way `AppendType` was being used in `genTypeQueryableFieldList`. We do direct manipulation of the TypeMap, such that it won't cause any errors. We do still get the benefits of `AppendType` because of our `ResolveType` function (we want to avoid resolving `FieldThunk` too early),
- Another schema type generation bug was fixed by the above change where the `OrderArg` for the relation field name would have the type as empty string `""` instead of `"XOrderArg"`.

## How has this been tested?
Local & CI

Specify the platform(s) on which this was tested:
- Arch Linux
