### PR TITLE
fix: Remove _like filter operator

### DIFF
--- a/query/graphql/schema/examples/root.schema.gql
+++ b/query/graphql/schema/examples/root.schema.gql
@@ -17,7 +17,6 @@ enum ValueOperatorInput {
     _lte    # Less than or equal to
     _in     # In the list
     _nin    # Non in the list
-    _like   # sub string like
 }
 
 # Generic definition for all query input options
@@ -55,7 +54,6 @@ scalar DateTime # Formatted DateTime value RFC (TODO)
 input StringOperatorBlock {
     _eq: String
     _neq: String
-    _like: String
     _in: [String!]
     _nin: [String!]
 }
@@ -88,7 +86,6 @@ input FloatOperatorBlock {
 input BooleanOperatorBlock {
     _eq: Boolean
     _neq: Boolean
-    _like: Boolean
     _in: [Boolean!]
     _nin: [Boolean!]
 }

--- a/query/graphql/schema/root.go
+++ b/query/graphql/schema/root.go
@@ -37,9 +37,6 @@ var booleanOperatorBlock = gql.NewInputObject(gql.InputObjectConfig{
 		"_ne": &gql.InputObjectFieldConfig{
 			Type: gql.Boolean,
 		},
-		"_like": &gql.InputObjectFieldConfig{
-			Type: gql.Boolean,
-		},
 		"_in": &gql.InputObjectFieldConfig{
 			Type: gql.NewList(gql.Boolean),
 		},
@@ -231,9 +228,6 @@ var stringOperatorBlock = gql.NewInputObject(gql.InputObjectConfig{
 			Type: gql.String,
 		},
 		"_ne": &gql.InputObjectFieldConfig{
-			Type: gql.String,
-		},
-		"_like": &gql.InputObjectFieldConfig{
 			Type: gql.String,
 		},
 		"_in": &gql.InputObjectFieldConfig{

--- a/tests/integration/schema/aggregates/inline_array_test.go
+++ b/tests/integration/schema/aggregates/inline_array_test.go
@@ -499,12 +499,6 @@ func TestSchemaAggregateInlineArrayCreatesUsersNillableBooleanCountFilter(t *tes
 														},
 													},
 													map[string]interface{}{
-														"name": "_like",
-														"type": map[string]interface{}{
-															"name": "Boolean",
-														},
-													},
-													map[string]interface{}{
 														"name": "_ne",
 														"type": map[string]interface{}{
 															"name": "Boolean",
@@ -1330,12 +1324,6 @@ func TestSchemaAggregateInlineArrayCreatesUsersNillableStringCountFilter(t *test
 														"name": "_in",
 														"type": map[string]interface{}{
 															"name": nil,
-														},
-													},
-													map[string]interface{}{
-														"name": "_like",
-														"type": map[string]interface{}{
-															"name": "String",
 														},
 													},
 													map[string]interface{}{


### PR DESCRIPTION
Does not function

## Relevant issue(s)

Resolves #780 

## Description

Removes '_like' filter gql type. It does nothing and the feature does not exist.

Specify the platform(s) on which this was tested:
- Debian Linux
