### PR TITLE
feat: Add support for dockey filters in child joins

### DIFF
--- a/query/graphql/schema/generate.go
+++ b/query/graphql/schema/generate.go
@@ -350,7 +350,9 @@ func (g *Generator) createExpandedFieldList(
 		Name: f.Name,
 		Type: gql.NewList(t),
 		Args: gql.FieldConfigArgument{
-			"filter": schemaTypes.NewArgConfig(g.manager.schema.TypeMap()[typeName+"FilterArg"]),
+			"dockey":  schemaTypes.NewArgConfig(gql.String),
+			"dockeys": schemaTypes.NewArgConfig(gql.NewList(gql.NewNonNull(gql.String))),
+			"filter":  schemaTypes.NewArgConfig(g.manager.schema.TypeMap()[typeName+"FilterArg"]),
 			"groupBy": schemaTypes.NewArgConfig(
 				gql.NewList(gql.NewNonNull(g.manager.schema.TypeMap()[typeName+"Fields"])),
 			),

--- a/tests/integration/query/one_to_many/with_dockey_test.go
+++ b/tests/integration/query/one_to_many/with_dockey_test.go
@@ -1,0 +1,68 @@
+// Copyright 2022 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package one_to_many
+
+import (
+	"testing"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+func TestQueryOneToManyWithChildDocKey(t *testing.T) {
+	test := testUtils.QueryTestCase{
+		Description: "One-to-many relation query from one side with child dockey",
+		Query: `query {
+					author {
+						name
+						published (
+								dockey: "bae-b9b83269-1f28-5c3b-ae75-3fb4c00d559d"
+							) {
+							name
+						}
+					}
+				}`,
+		Docs: map[int][]string{
+			//books
+			0: { // bae-b9b83269-1f28-5c3b-ae75-3fb4c00d559d
+				`{
+					"name": "Painted House",
+					"rating": 4.9,
+					"author_id": "bae-41598f0c-19bc-5da6-813b-e80f14a10df3"
+				}`,
+				`{
+					"name": "A Time for Mercy",
+					"rating": 4.5,
+					"author_id": "bae-41598f0c-19bc-5da6-813b-e80f14a10df3"
+				}`,
+			},
+			//authors
+			1: { // bae-41598f0c-19bc-5da6-813b-e80f14a10df3
+				`{
+					"name": "John Grisham",
+					"age": 65,
+					"verified": true
+				}`,
+			},
+		},
+		Results: []map[string]any{
+			{
+				"name": "John Grisham",
+				"published": []map[string]any{
+					{
+						"name": "Painted House",
+					},
+				},
+			},
+		},
+	}
+
+	executeTestCase(t, test)
+}

--- a/tests/integration/query/one_to_many/with_dockeys_test.go
+++ b/tests/integration/query/one_to_many/with_dockeys_test.go
@@ -1,0 +1,83 @@
+// Copyright 2022 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package one_to_many
+
+import (
+	"testing"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+func TestQueryOneToManyWithChildDocKeys(t *testing.T) {
+	test := testUtils.QueryTestCase{
+		Description: "One-to-many relation query from one side with child dockeys",
+		Query: `query {
+					author {
+						name
+						published (
+								dockeys: ["bae-b9b83269-1f28-5c3b-ae75-3fb4c00d559d", "bae-4fb9e3e9-d1d3-5404-bf15-10e4c995d9ca"]
+							) {
+							name
+						}
+					}
+				}`,
+		Docs: map[int][]string{
+			//books
+			0: {
+				// bae-b9b83269-1f28-5c3b-ae75-3fb4c00d559d
+				`{
+					"name": "Painted House",
+					"rating": 4.9,
+					"author_id": "bae-41598f0c-19bc-5da6-813b-e80f14a10df3"
+				}`,
+				`{
+					"name": "A Time for Mercy",
+					"rating": 4.5,
+					"author_id": "bae-41598f0c-19bc-5da6-813b-e80f14a10df3"
+				}`,
+				// bae-4fb9e3e9-d1d3-5404-bf15-10e4c995d9ca
+				`{
+					"name": "The Associate",
+					"rating": 4.2,
+					"author_id": "bae-41598f0c-19bc-5da6-813b-e80f14a10df3"
+				}`,
+				`{
+					"name": "A Time for Mercy",
+					"rating": 4.5,
+					"author_id": "bae-41598f0c-19bc-5da6-813b-e80f14a10df3"
+				}`,
+			},
+			//authors
+			1: { // bae-41598f0c-19bc-5da6-813b-e80f14a10df3
+				`{
+					"name": "John Grisham",
+					"age": 65,
+					"verified": true
+				}`,
+			},
+		},
+		Results: []map[string]any{
+			{
+				"name": "John Grisham",
+				"published": []map[string]any{
+					{
+						"name": "The Associate",
+					},
+					{
+						"name": "Painted House",
+					},
+				},
+			},
+		},
+	}
+
+	executeTestCase(t, test)
+}

--- a/tests/integration/query/simple/with_group_dockey_test.go
+++ b/tests/integration/query/simple/with_group_dockey_test.go
@@ -1,0 +1,64 @@
+// Copyright 2022 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package simple
+
+import (
+	"testing"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+func TestQuerySimpleWithGroupByWithGroupWithDocKey(t *testing.T) {
+	test := testUtils.QueryTestCase{
+		Description: "Simple query with DocKey filter on _group",
+		Query: `query {
+					users(groupBy: [Age]) {
+						Age
+						_group(dockey: "bae-52b9170d-b77a-5887-b877-cbdbb99b009f") {
+							Name
+						}
+					}
+				}`,
+		Docs: map[int][]string{
+			0: {
+				// bae-52b9170d-b77a-5887-b877-cbdbb99b009f
+				`{
+					"Name": "John",
+					"Age": 21
+				}`,
+				`{
+					"Name": "Bob",
+					"Age": 32
+				}`,
+				`{
+					"Name": "Fred",
+					"Age": 21
+				}`,
+			},
+		},
+		Results: []map[string]any{
+			{
+				"Age":    uint64(32),
+				"_group": []map[string]any{},
+			},
+			{
+				"Age": uint64(21),
+				"_group": []map[string]any{
+					{
+						"Name": "John",
+					},
+				},
+			},
+		},
+	}
+
+	executeTestCase(t, test)
+}

--- a/tests/integration/query/simple/with_group_dockeys_test.go
+++ b/tests/integration/query/simple/with_group_dockeys_test.go
@@ -1,0 +1,72 @@
+// Copyright 2022 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package simple
+
+import (
+	"testing"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+func TestQuerySimpleWithGroupByWithGroupWithDocKeys(t *testing.T) {
+	test := testUtils.QueryTestCase{
+		Description: "Simple query with DocKeys filter on _group",
+		Query: `query {
+					users(groupBy: [Age]) {
+						Age
+						_group(dockeys: ["bae-52b9170d-b77a-5887-b877-cbdbb99b009f", "bae-9b2e1434-9d61-5eb1-b3b9-82e8e40729a7"]) {
+							Name
+						}
+					}
+				}`,
+		Docs: map[int][]string{
+			0: {
+				// bae-52b9170d-b77a-5887-b877-cbdbb99b009f
+				`{
+					"Name": "John",
+					"Age": 21
+				}`,
+				`{
+					"Name": "Bob",
+					"Age": 32
+				}`,
+				// bae-9b2e1434-9d61-5eb1-b3b9-82e8e40729a7
+				`{
+					"Name": "Fred",
+					"Age": 21
+				}`,
+				`{
+					"Name": "Shahzad",
+					"Age": 21
+				}`,
+			},
+		},
+		Results: []map[string]any{
+			{
+				"Age":    uint64(32),
+				"_group": []map[string]any{},
+			},
+			{
+				"Age": uint64(21),
+				"_group": []map[string]any{
+					{
+						"Name": "John",
+					},
+					{
+						"Name": "Fred",
+					},
+				},
+			},
+		},
+	}
+
+	executeTestCase(t, test)
+}

--- a/tests/integration/schema/default_fields.go
+++ b/tests/integration/schema/default_fields.go
@@ -132,6 +132,10 @@ var dockeysArg = field{
 	"type": map[string]any{
 		"name":        nil,
 		"inputFields": nil,
+		"ofType": map[string]any{
+			"kind": "NON_NULL",
+			"name": nil,
+		},
 	},
 }
 

--- a/tests/integration/schema/input_type_test.go
+++ b/tests/integration/schema/input_type_test.go
@@ -149,6 +149,8 @@ var testInputTypeOfOrderFieldWhereSchemaHasRelationTypeArgProps = map[string]any
 
 var defaultGroupArgsWithoutOrder = trimFields(
 	fields{
+		dockeyArg,
+		dockeysArg,
 		buildFilterArg("author", []argDef{
 			{
 				fieldName: "age",


### PR DESCRIPTION
## Relevant issue(s)

Resolves #537

## Description

Add support for dockey and dockeys filters in child joins. Brings inner selects closer to feature parity with top level (cid is still missing, but I didnt want to do that int this PR, is a ticket https://github.com/sourcenetwork/defradb/issues/538). Has to be done in the Select or it wont work for _group.

Specify the platform(s) on which this was tested:
- Debian Linux
