### PR TITLE
test: Add tests for aggs with nil filters

### DIFF
--- a/tests/integration/query/one_to_many/utils.go
+++ b/tests/integration/query/one_to_many/utils.go
@@ -16,6 +16,8 @@ import (
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
 )
 
+type dataMap = map[string]any
+
 var bookAuthorGQLSchema = (`
 	type book {
 		name: String

--- a/tests/integration/query/one_to_many/with_average_filter_test.go
+++ b/tests/integration/query/one_to_many/with_average_filter_test.go
@@ -1,0 +1,114 @@
+// Copyright 2022 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package one_to_many
+
+import (
+	"testing"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+// This test asserts that only a single join is used - the _avg reuses the rendered join as they
+// have matching filters (average adds a ne nil filter).
+func TestQueryOneToManyWithAverageAndChildNeNilFilterSharesJoinField(t *testing.T) {
+	test := testUtils.QueryTestCase{
+		Description: "One-to-many relation query from many side with average",
+		Query: `query @explain {
+			author {
+				name
+				_avg(published: {field: rating})
+				published(filter: {rating: {_ne: null}}){
+					name
+				}
+			}
+		}`,
+		Results: []dataMap{
+			{
+				"explain": dataMap{
+					"selectTopNode": dataMap{
+						"averageNode": dataMap{
+							"countNode": dataMap{
+								"sources": []dataMap{
+									{
+										"filter": dataMap{
+											"rating": dataMap{
+												"_ne": nil,
+											},
+										},
+										"fieldName": "published",
+									},
+								},
+								"sumNode": dataMap{
+									"sources": []dataMap{
+										{
+											"filter": dataMap{
+												"rating": dataMap{
+													"_ne": nil,
+												},
+											},
+											"fieldName":      "published",
+											"childFieldName": "rating",
+										},
+									},
+									"selectNode": dataMap{
+										"filter": nil,
+										"typeIndexJoin": dataMap{
+											"joinType": "typeJoinMany",
+											"rootName": "author",
+											"root": dataMap{
+												"scanNode": dataMap{
+													"filter":         nil,
+													"collectionID":   "2",
+													"collectionName": "author",
+													"spans": []dataMap{
+														{
+															"start": "/2",
+															"end":   "/3",
+														},
+													},
+												},
+											},
+											"subTypeName": "published",
+											"subType": dataMap{
+												"selectTopNode": dataMap{
+													"selectNode": dataMap{
+														"filter": nil,
+														"scanNode": dataMap{
+															"filter": dataMap{
+																"rating": dataMap{
+																	"_ne": nil,
+																},
+															},
+															"collectionID":   "1",
+															"collectionName": "book",
+															"spans": []dataMap{
+																{
+																	"start": "/1",
+																	"end":   "/2",
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	executeTestCase(t, test)
+}

--- a/tests/integration/query/one_to_many/with_count_filter_test.go
+++ b/tests/integration/query/one_to_many/with_count_filter_test.go
@@ -74,3 +74,284 @@ func TestQueryOneToManyWithCountWithFilter(t *testing.T) {
 
 	executeTestCase(t, test)
 }
+
+func TestQueryOneToManyWithCountWithFilterAndChildFilter(t *testing.T) {
+	test := testUtils.QueryTestCase{
+		Description: "One-to-many relation query from many side with count with filter",
+		Query: `query {
+			author {
+				name
+				_count(published: {filter: {rating: {_ne: null}}})
+				published(filter: {rating: {_ne: null}}){
+					name
+				}
+			}
+		}`,
+		Docs: map[int][]string{
+			//books
+			0: { // bae-fd541c25-229e-5280-b44b-e5c2af3e374d
+				`{
+					"name": "Painted House",
+					"rating": 4.9,
+					"author_id": "bae-41598f0c-19bc-5da6-813b-e80f14a10df3"
+				}`,
+				`{
+					"name": "A Time for Mercy",
+					"rating": 4.5,
+					"author_id": "bae-41598f0c-19bc-5da6-813b-e80f14a10df3"
+				}`,
+				`{
+					"name": "The Associate",
+					"author_id": "bae-41598f0c-19bc-5da6-813b-e80f14a10df3"
+				}`,
+				`{
+					"name": "Theif Lord",
+					"rating": 4.8,
+					"author_id": "bae-b769708d-f552-5c3d-a402-ccfd7ac7fb04"
+				}`,
+			},
+			//authors
+			1: {
+				// bae-41598f0c-19bc-5da6-813b-e80f14a10df3
+				`{
+					"name": "John Grisham",
+					"age": 65,
+					"verified": true
+				}`,
+				// bae-b769708d-f552-5c3d-a402-ccfd7ac7fb04
+				`{
+					"name": "Cornelia Funke",
+					"age": 62,
+					"verified": false
+				}`,
+			},
+		},
+		Results: []map[string]any{
+			{
+				"name":   "John Grisham",
+				"_count": 2,
+				"published": []map[string]any{
+					{
+						"name": "Painted House",
+					},
+					{
+						"name": "A Time for Mercy",
+					},
+				},
+			},
+			{
+				"name":   "Cornelia Funke",
+				"_count": 1,
+				"published": []map[string]any{
+					{
+						"name": "Theif Lord",
+					},
+				},
+			},
+		},
+	}
+
+	executeTestCase(t, test)
+}
+
+// This test asserts that only a single join is used - the _count reuses the rendered join as they
+// have matching filters.
+func TestQueryOneToManyWithCountWithFilterAndChildFilterSharesJoinField(t *testing.T) {
+	test := testUtils.QueryTestCase{
+		Description: "One-to-many relation query from many side with count with filter",
+		Query: `query @explain {
+			author {
+				name
+				_count(published: {filter: {rating: {_ne: null}}})
+				published(filter: {rating: {_ne: null}}){
+					name
+				}
+			}
+		}`,
+		Results: []dataMap{
+			{
+				"explain": dataMap{
+					"selectTopNode": dataMap{
+						"countNode": dataMap{
+							"sources": []dataMap{
+								{
+									"filter": dataMap{
+										"rating": dataMap{
+											"_ne": nil,
+										},
+									},
+									"fieldName": "published",
+								},
+							},
+							"selectNode": dataMap{
+								"filter": nil,
+								"typeIndexJoin": dataMap{
+									"joinType": "typeJoinMany",
+									"rootName": "author",
+									"root": dataMap{
+										"scanNode": dataMap{
+											"filter":         nil,
+											"collectionID":   "2",
+											"collectionName": "author",
+											"spans": []dataMap{
+												{
+													"start": "/2",
+													"end":   "/3",
+												},
+											},
+										},
+									},
+									"subTypeName": "published",
+									"subType": dataMap{
+										"selectTopNode": dataMap{
+											"selectNode": dataMap{
+												"filter": nil,
+												"scanNode": dataMap{
+													"filter": dataMap{
+														"rating": dataMap{
+															"_ne": nil,
+														},
+													},
+													"collectionID":   "1",
+													"collectionName": "book",
+													"spans": []dataMap{
+														{
+															"start": "/1",
+															"end":   "/2",
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	executeTestCase(t, test)
+}
+
+// This test asserts that two joins are used - the _count cannot reuse the rendered join as they
+// dont have matching filters.
+func TestQueryOneToManyWithCountAndChildFilterDoesNotShareJoinField(t *testing.T) {
+	test := testUtils.QueryTestCase{
+		Description: "One-to-many relation query from many side with count",
+		Query: `query @explain {
+			author {
+				name
+				_count(published: {})
+				published(filter: {rating: {_ne: null}}){
+					name
+				}
+			}
+		}`,
+		Results: []dataMap{
+			{
+				"explain": dataMap{
+					"selectTopNode": dataMap{
+						"countNode": dataMap{
+							"selectNode": dataMap{
+								"filter": nil,
+								"parallelNode": []dataMap{
+									{
+										"typeIndexJoin": dataMap{
+											"joinType": "typeJoinMany",
+											"root": dataMap{
+												"scanNode": dataMap{
+													"collectionID":   "2",
+													"collectionName": "author",
+													"filter":         nil,
+													"spans": []dataMap{
+														{
+															"end":   "/3",
+															"start": "/2",
+														},
+													},
+												},
+											},
+											"rootName": "author",
+											"subType": dataMap{
+												"selectTopNode": dataMap{
+													"selectNode": dataMap{
+														"filter": nil,
+														"scanNode": dataMap{
+															"collectionID":   "1",
+															"collectionName": "book",
+															"filter": dataMap{
+																"rating": dataMap{
+																	"_ne": nil,
+																},
+															},
+															"spans": []dataMap{
+																{
+																	"end":   "/2",
+																	"start": "/1",
+																},
+															},
+														},
+													},
+												},
+											},
+											"subTypeName": "published",
+										},
+									},
+									{
+										"typeIndexJoin": dataMap{
+											"joinType": "typeJoinMany",
+											"root": dataMap{
+												"scanNode": dataMap{
+													"collectionID":   "2",
+													"collectionName": "author",
+													"filter":         nil,
+													"spans": []dataMap{
+														{
+															"end":   "/3",
+															"start": "/2",
+														},
+													},
+												},
+											},
+											"rootName": "author",
+											"subType": dataMap{
+												"selectTopNode": dataMap{
+													"selectNode": dataMap{
+														"filter": nil,
+														"scanNode": dataMap{
+															"collectionID":   "1",
+															"collectionName": "book",
+															"filter":         nil,
+															"spans": []dataMap{
+																{
+																	"end":   "/2",
+																	"start": "/1",
+																},
+															},
+														},
+													},
+												},
+											},
+											"subTypeName": "published",
+										},
+									},
+								},
+							},
+							"sources": []dataMap{
+								{
+									"fieldName": "published",
+									"filter":    nil,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	executeTestCase(t, test)
+}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #790

## Description

Add tests for aggregates targetting rendered relation/array with ne nill filter.  Uses explain to assert that the field reuse logic is functioning correctly - note - these are not explain tests, but tests that use explain to assert query behaviour.
