### PR TITLE
fix: Reset scan node for each join

### DIFF
--- a/query/graphql/planner/type_join.go
+++ b/query/graphql/planner/type_join.go
@@ -331,6 +331,13 @@ func (n *typeJoinOne) valuesSecondary(doc core.Doc) core.Doc {
 	filter := map[connor.FilterKey]any{
 		fkIndex: doc.GetKey(),
 	}
+
+	// We have to reset the scan node after appending the new key-filter
+	if err := n.subType.Init(); err != nil {
+		log.ErrorE(n.p.ctx, "Sub-type initialization error at scan node reset", err)
+		return doc
+	}
+
 	// using the doc._key as a filter
 	err := appendFilterToScanNode(n.subType, filter)
 	if err != nil {

--- a/tests/integration/query/one_to_one/simple_test.go
+++ b/tests/integration/query/one_to_one/simple_test.go
@@ -106,3 +106,65 @@ func TestQueryOneToOne(t *testing.T) {
 		executeTestCase(t, test)
 	}
 }
+
+func TestQueryOneToOneWithMultipleRecords(t *testing.T) {
+	test := testUtils.QueryTestCase{
+		Description: "One-to-one relation primary direction, multiple records",
+		Query: `query {
+			book {
+				name
+				author {
+					name
+				}
+			}
+		}`,
+		Docs: map[int][]string{
+			//books
+			0: {
+				// bae-fd541c25-229e-5280-b44b-e5c2af3e374d
+				`{
+					"name": "Painted House",
+					"rating": 4.9
+				}`,
+				// "bae-d3bc0f38-a2e1-5a26-9cc9-5b3fdb41c6db"
+				`{
+					"name": "Go Guide for Rust developers",
+					"rating": 5.0
+				}`,
+			},
+			//authors
+			1: {
+				// "bae-3bfe0092-e31f-5ebe-a3ba-fa18fac448a6"
+				`{
+					"name": "John Grisham",
+					"age": 65,
+					"verified": true,
+					"published_id": "bae-fd541c25-229e-5280-b44b-e5c2af3e374d"
+				}`,
+				// "bae-756c2bf0-4767-57fd-b12b-393915feae68",
+				`{
+					"name": "Andrew Lone",
+					"age": 30,
+					"verified": true,
+					"published_id": "bae-d3bc0f38-a2e1-5a26-9cc9-5b3fdb41c6db"
+				}`,
+			},
+		},
+		Results: []map[string]any{
+			{
+				"name": "Go Guide for Rust developers",
+				"author": map[string]any{
+					"name": "Andrew Lone",
+				},
+			},
+			{
+				"name": "Painted House",
+				"author": map[string]any{
+					"name": "John Grisham",
+				},
+			},
+		},
+	}
+
+	executeTestCase(t, test)
+}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #827

## Description

Resets scan node for each join. Scan node may have completed and will be in a finished state and will return nil for other items.

Specify the platform(s) on which this was tested:
- Debian Linux
