### PR TITLE
fix: Correctly handles nil one-one joins

### DIFF
--- a/query/graphql/planner/type_join.go
+++ b/query/graphql/planner/type_join.go
@@ -344,7 +344,6 @@ func (n *typeJoinOne) valuesSecondary(doc core.Doc) core.Doc {
 		return core.Doc{}
 	}
 
-	doc.Fields[n.subSelect.Index] = n.subSelect.DocumentMapping.NewDoc()
 	next, err := n.subType.Next()
 	if !next || err != nil {
 		return doc

--- a/tests/integration/query/one_to_one/simple_test.go
+++ b/tests/integration/query/one_to_one/simple_test.go
@@ -168,3 +168,63 @@ func TestQueryOneToOneWithMultipleRecords(t *testing.T) {
 
 	executeTestCase(t, test)
 }
+
+func TestQueryOneToOneWithNilChild(t *testing.T) {
+	test := testUtils.QueryTestCase{
+		Description: "One-to-one relation primary direction, nil child",
+		Query: `query {
+			author {
+				name
+				published {
+					name
+				}
+			}
+		}`,
+		Docs: map[int][]string{
+			//authors
+			1: {
+				`{
+					"name": "John Grisham"
+				}`,
+			},
+		},
+		Results: []map[string]any{
+			{
+				"name":      "John Grisham",
+				"published": nil,
+			},
+		},
+	}
+
+	executeTestCase(t, test)
+}
+
+func TestQueryOneToOneWithNilParent(t *testing.T) {
+	test := testUtils.QueryTestCase{
+		Description: "One-to-one relation primary direction, nil parent",
+		Query: `query {
+			book {
+				name
+				author {
+					name
+				}
+			}
+		}`,
+		Docs: map[int][]string{
+			//books
+			0: {
+				`{
+					"name": "Painted House"
+				}`,
+			},
+		},
+		Results: []map[string]any{
+			{
+				"name":   "Painted House",
+				"author": nil,
+			},
+		},
+	}
+
+	executeTestCase(t, test)
+}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #829

## Description

Correctly handles nil one-one joins.  Credit goes to John for spotting the fix a few days ago.  Can go in 0.3.1 if reviewed quickly.

Specify the platform(s) on which this was tested:
- Debian Linux
