### PR TITLE
feat: Add limit support to allCommits query

### DIFF
--- a/query/graphql/parser/commit.go
+++ b/query/graphql/parser/commit.go
@@ -11,6 +11,8 @@
 package parser
 
 import (
+	"strconv"
+
 	"github.com/graphql-go/graphql/language/ast"
 
 	"github.com/sourcenetwork/defradb/errors"
@@ -98,6 +100,16 @@ func parseCommitSelect(field *ast.Field) (*CommitSelect, error) {
 				Conditions: cond,
 				Statement:  obj,
 			}
+		} else if prop == parserTypes.LimitClause {
+			val := argument.Value.(*ast.IntValue)
+			limit, err := strconv.ParseInt(val.Value, 10, 64)
+			if err != nil {
+				return nil, err
+			}
+			if commit.Limit == nil {
+				commit.Limit = &parserTypes.Limit{}
+			}
+			commit.Limit.Limit = limit
 		}
 	}
 

--- a/query/graphql/schema/types/commits.go
+++ b/query/graphql/schema/types/commits.go
@@ -12,6 +12,8 @@ package types
 
 import (
 	gql "github.com/graphql-go/graphql"
+
+	parserTypes "github.com/sourcenetwork/defradb/query/graphql/parser/types"
 )
 
 var (
@@ -105,9 +107,10 @@ var (
 		Name: "allCommits",
 		Type: gql.NewList(CommitObject),
 		Args: gql.FieldConfigArgument{
-			"dockey": NewArgConfig(gql.NewNonNull(gql.ID)),
-			"field":  NewArgConfig(gql.String),
-			"order":  NewArgConfig(AllCommitsOrderArg),
+			"dockey":                NewArgConfig(gql.NewNonNull(gql.ID)),
+			"field":                 NewArgConfig(gql.String),
+			"order":                 NewArgConfig(AllCommitsOrderArg),
+			parserTypes.LimitClause: NewArgConfig(gql.Int),
 		},
 	}
 

--- a/tests/integration/query/all_commits/with_dockey_limit_test.go
+++ b/tests/integration/query/all_commits/with_dockey_limit_test.go
@@ -1,0 +1,58 @@
+// Copyright 2022 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package all_commits
+
+import (
+	"testing"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+func TestQueryAllCommitsWithDockeyAndLimit(t *testing.T) {
+	test := testUtils.QueryTestCase{
+		Description: "Simple all commits query with dockey and limit",
+		Query: `query {
+					allCommits(dockey: "bae-52b9170d-b77a-5887-b877-cbdbb99b009f", limit: 2) {
+						cid
+					}
+				}`,
+		Docs: map[int][]string{
+			0: {
+				`{
+					"Name": "John",
+					"Age": 21
+				}`,
+			},
+		},
+		Updates: map[int]map[int][]string{
+			0: {
+				0: {
+					`{
+						"Age": 22
+					}`,
+					`{
+						"Age": 23
+					}`,
+				},
+			},
+		},
+		Results: []map[string]any{
+			{
+				"cid": "bafybeid2tudsm4go5boq7yvz6pprtgaiddkazq2dip6c4fsqt3afhzexbq",
+			},
+			{
+				"cid": "bafybeibrbfg35mwggcj4vnskak4qn45hp7fy5a4zp2n34sbq5vt5utr6pq",
+			},
+		},
+	}
+
+	executeTestCase(t, test)
+}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #

## Description

Adds limit support to allCommits query.  Let me know if you dont want it in 0.3.1.

Specify the platform(s) on which this was tested:
- Debian Linux
