### PR TITLE
feat: Add offset support to allCommits

### DIFF
--- a/query/graphql/parser/commit.go
+++ b/query/graphql/parser/commit.go
@@ -110,6 +110,16 @@ func parseCommitSelect(field *ast.Field) (*CommitSelect, error) {
 				commit.Limit = &parserTypes.Limit{}
 			}
 			commit.Limit.Limit = limit
+		} else if prop == parserTypes.OffsetClause {
+			val := argument.Value.(*ast.IntValue)
+			offset, err := strconv.ParseInt(val.Value, 10, 64)
+			if err != nil {
+				return nil, err
+			}
+			if commit.Limit == nil {
+				commit.Limit = &parserTypes.Limit{}
+			}
+			commit.Limit.Offset = offset
 		}
 	}
 

--- a/query/graphql/schema/types/commits.go
+++ b/query/graphql/schema/types/commits.go
@@ -107,10 +107,11 @@ var (
 		Name: "allCommits",
 		Type: gql.NewList(CommitObject),
 		Args: gql.FieldConfigArgument{
-			"dockey":                NewArgConfig(gql.NewNonNull(gql.ID)),
-			"field":                 NewArgConfig(gql.String),
-			"order":                 NewArgConfig(AllCommitsOrderArg),
-			parserTypes.LimitClause: NewArgConfig(gql.Int),
+			"dockey":                 NewArgConfig(gql.NewNonNull(gql.ID)),
+			"field":                  NewArgConfig(gql.String),
+			"order":                  NewArgConfig(AllCommitsOrderArg),
+			parserTypes.LimitClause:  NewArgConfig(gql.Int),
+			parserTypes.OffsetClause: NewArgConfig(gql.Int),
 		},
 	}
 

--- a/tests/integration/query/all_commits/with_dockey_limit_offset_test.go
+++ b/tests/integration/query/all_commits/with_dockey_limit_offset_test.go
@@ -1,0 +1,61 @@
+// Copyright 2022 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package all_commits
+
+import (
+	"testing"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+func TestQueryAllCommitsWithDockeyAndLimitAndOffset(t *testing.T) {
+	test := testUtils.QueryTestCase{
+		Description: "Simple all commits query with dockey, limit and offset",
+		Query: `query {
+					allCommits(dockey: "bae-52b9170d-b77a-5887-b877-cbdbb99b009f", limit: 2, offset: 1) {
+						cid
+					}
+				}`,
+		Docs: map[int][]string{
+			0: {
+				`{
+					"Name": "John",
+					"Age": 21
+				}`,
+			},
+		},
+		Updates: map[int]map[int][]string{
+			0: {
+				0: {
+					`{
+						"Age": 22
+					}`,
+					`{
+						"Age": 23
+					}`,
+					`{
+						"Age": 24
+					}`,
+				},
+			},
+		},
+		Results: []map[string]any{
+			{
+				"cid": "bafybeid2tudsm4go5boq7yvz6pprtgaiddkazq2dip6c4fsqt3afhzexbq",
+			},
+			{
+				"cid": "bafybeibrbfg35mwggcj4vnskak4qn45hp7fy5a4zp2n34sbq5vt5utr6pq",
+			},
+		},
+	}
+
+	executeTestCase(t, test)
+}

--- a/tests/integration/query/all_commits/with_dockey_order_limit_offset_test.go
+++ b/tests/integration/query/all_commits/with_dockey_order_limit_offset_test.go
@@ -1,0 +1,64 @@
+// Copyright 2022 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package all_commits
+
+import (
+	"testing"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+func TestQueryAllCommitsWithDockeyAndOrderAndLimitAndOffset(t *testing.T) {
+	test := testUtils.QueryTestCase{
+		Description: "Simple all commits query with dockey, order, limit and offset",
+		Query: `query {
+					allCommits(dockey: "bae-52b9170d-b77a-5887-b877-cbdbb99b009f", order: {height: ASC}, limit: 2, offset: 1) {
+						cid
+						height
+					}
+				}`,
+		Docs: map[int][]string{
+			0: {
+				`{
+					"Name": "John",
+					"Age": 21
+				}`,
+			},
+		},
+		Updates: map[int]map[int][]string{
+			0: {
+				0: {
+					`{
+						"Age": 22
+					}`,
+					`{
+						"Age": 23
+					}`,
+					`{
+						"Age": 24
+					}`,
+				},
+			},
+		},
+		Results: []map[string]any{
+			{
+				"cid":    "bafybeibrbfg35mwggcj4vnskak4qn45hp7fy5a4zp2n34sbq5vt5utr6pq",
+				"height": int64(2),
+			},
+			{
+				"cid":    "bafybeid2tudsm4go5boq7yvz6pprtgaiddkazq2dip6c4fsqt3afhzexbq",
+				"height": int64(3),
+			},
+		},
+	}
+
+	executeTestCase(t, test)
+}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #855

## Description

Adds offset support to allCommits.  Not really required to perform the refactor, but it is an easy task/feature to do now.

Specify the platform(s) on which this was tested:
- Debian Linux
