### PR TITLE
fix: Notify subscribers on close

### DIFF
--- a/events/events.go
+++ b/events/events.go
@@ -10,8 +10,6 @@
 
 package events
 
-type Subscription[T any] chan T
-
 // Channel represents a subscribable type that will expose inputted items to subscribers.
 type Channel[T any] interface {
 	// Subscribe subscribes to the Channel, returning a channel by which events can

--- a/events/simple_test.go
+++ b/events/simple_test.go
@@ -33,7 +33,7 @@ func TestSimpleSubscribersAreNotBlockedAfterClose(t *testing.T) {
 
 	s.Close()
 
-	<-ch
+	<-ch.Channel
 
 	// just assert that we reach this line, for the sake of having an assert
 	assert.True(t, true)
@@ -51,13 +51,13 @@ func TestSimpleEachSubscribersRecievesEachItem(t *testing.T) {
 
 	s.Publish(input1)
 
-	output1Ch1 := <-ch1
-	output1Ch2 := <-ch2
+	output1Ch1 := <-ch1.Channel
+	output1Ch2 := <-ch2.Channel
 
 	s.Publish(input2)
 
-	output2Ch1 := <-ch1
-	output2Ch2 := <-ch2
+	output2Ch1 := <-ch1.Channel
+	output2Ch2 := <-ch2.Channel
 
 	assert.Equal(t, input1, output1Ch1)
 	assert.Equal(t, input1, output1Ch2)
@@ -80,11 +80,11 @@ func TestSimpleEachSubscribersRecievesEachItemGivenBufferedEventChan(t *testing.
 	s.Publish(input1)
 	s.Publish(input2)
 
-	output1Ch1 := <-ch1
-	output1Ch2 := <-ch2
+	output1Ch1 := <-ch1.Channel
+	output1Ch2 := <-ch2.Channel
 
-	output2Ch1 := <-ch1
-	output2Ch2 := <-ch2
+	output2Ch1 := <-ch1.Channel
+	output2Ch2 := <-ch2.Channel
 
 	assert.Equal(t, input1, output1Ch1)
 	assert.Equal(t, input1, output1Ch2)
@@ -106,5 +106,5 @@ func TestSimpleSubscribersDontRecieveItemsAfterUnsubscribing(t *testing.T) {
 	time.Sleep(5 * time.Millisecond)
 
 	// closing the channel will result in reads yielding the default value
-	assert.Equal(t, 0, <-ch)
+	assert.Equal(t, 0, <-ch.Channel)
 }

--- a/events/subscription.go
+++ b/events/subscription.go
@@ -1,0 +1,28 @@
+// Copyright 2022 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package events
+
+type Subscription[T any] struct {
+	Channel chan T
+	Closing chan struct{}
+}
+
+func newSubscription[T any](eventBufferSize int) Subscription[T] {
+	return Subscription[T]{
+		Channel: make(chan T, eventBufferSize),
+		Closing: make(chan struct{}),
+	}
+}
+
+func (sub *Subscription[T]) close() {
+	close(sub.Closing)
+	close(sub.Channel)
+}

--- a/net/peer.go
+++ b/net/peer.go
@@ -33,6 +33,7 @@ import (
 	"github.com/sourcenetwork/defradb/core"
 	corenet "github.com/sourcenetwork/defradb/core/net"
 	"github.com/sourcenetwork/defradb/errors"
+	"github.com/sourcenetwork/defradb/events"
 	"github.com/sourcenetwork/defradb/logging"
 	"github.com/sourcenetwork/defradb/merkle/clock"
 	pb "github.com/sourcenetwork/defradb/net/pb"
@@ -48,7 +49,7 @@ type Peer struct {
 	//config??
 
 	db            client.DB
-	updateChannel chan client.UpdateEvent
+	updateChannel events.Subscription[client.UpdateEvent]
 
 	host host.Host
 	ps   *pubsub.PubSub
@@ -189,22 +190,26 @@ func (p *Peer) Close() error {
 func (p *Peer) handleBroadcastLoop() {
 	log.Debug(p.ctx, "Waiting for messages on internal broadcaster")
 	for {
-		log.Debug(p.ctx, "Handling internal broadcast bus message")
-		update := <-p.updateChannel
+		select {
+		case <-p.updateChannel.Closing:
+			return
+		case update := <-p.updateChannel.Channel:
+			log.Debug(p.ctx, "Handling internal broadcast bus message")
 
-		// check log priority, 1 is new doc log
-		// 2 is update log
-		var err error
-		if update.Priority == 1 {
-			err = p.handleDocCreateLog(update)
-		} else if update.Priority > 1 {
-			err = p.handleDocUpdateLog(update)
-		} else {
-			log.Info(p.ctx, "Skipping log with invalid priority of 0", logging.NewKV("CID", update.Cid))
-		}
+			// check log priority, 1 is new doc log
+			// 2 is update log
+			var err error
+			if update.Priority == 1 {
+				err = p.handleDocCreateLog(update)
+			} else if update.Priority > 1 {
+				err = p.handleDocUpdateLog(update)
+			} else {
+				log.Info(p.ctx, "Skipping log with invalid priority of 0", logging.NewKV("CID", update.Cid))
+			}
 
-		if err != nil {
-			log.ErrorE(p.ctx, "Error while handling broadcast log", err)
+			if err != nil {
+				log.ErrorE(p.ctx, "Error while handling broadcast log", err)
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Relevant issue(s)

Resolves #872

## Description

Notifies subscribers on close (and unsubscribe). Sorry about the bother.

## How was this tested

Checked logs no longer happen by defradb start and Ctrl+C (and confirmed behaviour against develop) 

Specify the platform(s) on which this was tested:
- Debian Linux
