### PR TITLE
fix: Remove panics from document

### DIFF
--- a/client/document.go
+++ b/client/document.go
@@ -392,17 +392,18 @@ func (doc *Document) Bytes() ([]byte, error) {
 // cryptographic operations, such as signatures, or hashes
 // as it does not guarantee canonical representation or
 // ordering.
-func (doc *Document) String() string {
+func (doc *Document) String() (string, error) {
 	docMap, err := doc.toMap()
 	if err != nil {
-		panic(err) //should we return (string, error)?
+		return "", err
 	}
 
 	j, err := json.MarshalIndent(docMap, "", "\t")
 	if err != nil {
-		panic(err) // same as above
+		return "", err
 	}
-	return string(j)
+
+	return string(j), nil
 }
 
 // ToMap returns the document as a map[string]any


### PR DESCRIPTION
## Relevant issue(s)

Resolves #615

## Description

Removes panics from document. Got pushed out of 0.3.1 due to func signature change. I am assuming that there is no std-lib compatibility-type interface with `func String() string` that we want to implement here that will now break.

Specify the platform(s) on which this was tested:
- Debian Linux
