### PR TITLE
test: Skip change detection for tests that assert panic

### DIFF
--- a/tests/integration/query/one_to_many/with_cid_dockey_test.go
+++ b/tests/integration/query/one_to_many/with_cid_dockey_test.go
@@ -13,8 +13,6 @@ package one_to_many
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
 )
 
@@ -62,15 +60,7 @@ func TestQueryOneToManyWithUnknownCidAndDocKey(t *testing.T) {
 		},
 	}
 
-	if testUtils.IsDetectingDbChanges() {
-		// The `assert.Panics` call will falsely fail if this test is executed during
-		// a detect changes test run
-		t.Skip()
-	}
-
-	assert.Panics(t, func() {
-		executeTestCase(t, test)
-	})
+	testUtils.AssertPanicAndSkipChangeDetection(t, func() { executeTestCase(t, test) })
 }
 
 func TestQueryOneToManyWithCidAndDocKey(t *testing.T) {

--- a/tests/integration/query/one_to_many_to_one/with_order_limit_test.go
+++ b/tests/integration/query/one_to_many_to_one/with_order_limit_test.go
@@ -13,8 +13,6 @@ package one_to_many_to_one
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
 )
 
@@ -134,9 +132,5 @@ func TestOneToManyToOneDeepOrderBySubTypeOfBothDescAndAsc(t *testing.T) {
 		Results: []map[string]any{},
 	}
 
-	assert.Panics(
-		t,
-		func() { executeTestCase(t, test) },
-		"expected a panic, but none found.",
-	)
+	testUtils.AssertPanicAndSkipChangeDetection(t, func() { executeTestCase(t, test) })
 }

--- a/tests/integration/query/one_to_many_to_one/with_sum_order_limit_test.go
+++ b/tests/integration/query/one_to_many_to_one/with_sum_order_limit_test.go
@@ -13,8 +13,6 @@ package one_to_many_to_one
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
 )
 
@@ -302,11 +300,7 @@ func TestOneToManyToOneWithSumOfDeepOrderBySubTypeAndDeepOrderBySubtypeAscDirect
 		},
 	}
 
-	assert.Panics(
-		t,
-		func() { executeTestCase(t, test) },
-		"expected a panic, but none found.",
-	)
+	testUtils.AssertPanicAndSkipChangeDetection(t, func() { executeTestCase(t, test) })
 }
 
 // TODO: Fix this panic in #833.
@@ -421,11 +415,7 @@ func TestOneToManyToOneWithSumOfDeepOrderBySubTypeOfBothDescAndAsc(t *testing.T)
 		Results: []map[string]any{},
 	}
 
-	assert.Panics(
-		t,
-		func() { executeTestCase(t, test) },
-		"expected a panic, but none found.",
-	)
+	testUtils.AssertPanicAndSkipChangeDetection(t, func() { executeTestCase(t, test) })
 }
 
 // TODO: Fix this panic in #833.
@@ -542,9 +532,5 @@ func TestOneToManyToOneWithSumOfDeepOrderBySubTypeAndDeepOrderBySubtypeOppositeD
 		Results: []map[string]any{},
 	}
 
-	assert.Panics(
-		t,
-		func() { executeTestCase(t, test) },
-		"expected a panic, but none found.",
-	)
+	testUtils.AssertPanicAndSkipChangeDetection(t, func() { executeTestCase(t, test) })
 }

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -181,6 +181,19 @@ func IsDetectingDbChanges() bool {
 	return detectDbChanges
 }
 
+// AssertPanicAndSkipChangeDetection asserts that the code of function actually panics,
+//  also ensures the change detection is skipped so no false fails happen.
+//
+//  Usage: AssertPanicAndSkipChangeDetection(t, func() { executeTestCase(t, test) })
+func AssertPanicAndSkipChangeDetection(t *testing.T, f assert.PanicTestFunc) bool {
+	if IsDetectingDbChanges() {
+		// The `assert.Panics` call will falsely fail if this test is executed during
+		// a detect changes test run
+		t.Skip()
+	}
+	return assert.Panics(t, f, "expected a panic, but none found.")
+}
+
 func NewBadgerMemoryDB(ctx context.Context, dbopts ...db.Option) (databaseInfo, error) {
 	opts := badgerds.Options{Options: badger.DefaultOptions("").WithInMemory(true)}
 	rootstore, err := badgerds.NewDatastore("", &opts)


### PR DESCRIPTION
## Relevant issue(s)
Resolves #882 

## Description
- Skip change detector for tests that assert for panics.
- Clean up assertion of panic and skipping of change detector into a utility function.

## Tasks
- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?
CI & Locally

Specify the platform(s) on which this was tested:
- Manjaro Wsl2
