### PR TITLE
fix: Change time format for HTTP API log

### DIFF
--- a/api/http/logger.go
+++ b/api/http/logger.go
@@ -76,8 +76,8 @@ func loggerMiddleware(next http.Handler) http.Handler {
 				lrw.contentLength,
 			),
 			logging.NewKV(
-				"ElapsedSeconds",
-				elapsed,
+				"ElapsedTime",
+				elapsed.String(),
 			),
 		)
 	})


### PR DESCRIPTION
## Relevant issue(s)

Resolves #899 

## Description

This PR changes the formatting of the elapsed time in the logs from requests to the HTTP API.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

manually tested and visually confirmed

Specify the platform(s) on which this was tested:
- MacOS
