### PR TITLE
chore: Include version metadata in cross-building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,9 +32,16 @@ default:
 install:
 	@go install $(BUILD_FLAGS) ./cmd/defradb
 
+# Usage:
+# 	- make build
+# 	- make build path="path/to/defradb-binary"
 .PHONY: build
 build:
+ifeq ($(path),)
 	@go build $(BUILD_FLAGS) -o build/defradb cmd/defradb/main.go
+else
+	@go build $(BUILD_FLAGS) -o $(path) cmd/defradb/main.go
+endif
 
 # Usage: make cross-build platforms="{platforms}"
 # platforms is specified as a comma-separated list with no whitespace, e.g. "linux/amd64,linux/arm,linux/arm64"

--- a/tools/scripts/cross-build.sh
+++ b/tools/scripts/cross-build.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
-DEFRADB_MAIN="cmd/defradb/main.go"
+# Cross-compilation script for DefraDB.
+# We assume we run this from a position where DefraDB's build toolchain (go, make, ...) is available.
+
 BUILD_DIR="build/"
 
 platforms=$1
@@ -31,7 +33,7 @@ do
     if [ "$GOOS" = "windows" ]; then
         output_name+='.exe'
     fi
-    if ! env GOOS="$GOOS" GOARCH="$GOARCH" go build -o $output_name $DEFRADB_MAIN; then
+    if ! env GOOS="$GOOS" GOARCH="$GOARCH" make build path="$output_name"; then
         echo 'An error has occurred! Aborting the script execution...'
         exit 1
     fi


### PR DESCRIPTION
## Relevant issue(s)

Resolves #929

## Description

Leverage Makefile in cross-building script for that is what adds metadata to build process.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Tested only one binary, by cross-building on arm64 MacOS, and running a resulting binary on amd64 Linux.