### PR TITLE
refactor: Improve parsing of DataStoreKey

### DIFF
--- a/core/key.go
+++ b/core/key.go
@@ -116,31 +116,26 @@ func NewDataStoreKey(key string) DataStoreKey {
 	numberOfElements := len(elements)
 
 	// With less than 4 elements, we know it's an invalid key
-	if numberOfElements < 4 {
+	if numberOfElements < 3 {
 		return dataStoreKey
 	}
 
-	// Exactly 4 elements happens only for unit tests.
-	if numberOfElements == 4 {
-		return DataStoreKey{
-			CollectionId: elements[0],
-			InstanceType: InstanceType(elements[1]),
-			DocKey:       elements[2],
-			FieldId:      elements[3],
+	// Once we find a valid prefix, we know that the following elements represent the DataStoreKey.
+	keyStart := -1
+	if numberOfElements > 4 {
+		for i := 0; i < numberOfElements; i++ {
+			if isValidPrefix(elements[i]) {
+				keyStart = i
+				break
+			}
 		}
 	}
 
-	// Once we find a valid prefix, we know that the following elements represent the DataStoreKey.
-	for i := 0; i < numberOfElements; i++ {
-		if isValidPrefix(elements[i]) {
-			dataStoreKey.CollectionId = elements[i+1]
-			dataStoreKey.InstanceType = InstanceType(elements[i+2])
-			dataStoreKey.DocKey = elements[i+3]
-			if i+4 < numberOfElements {
-				dataStoreKey.FieldId = elements[i+4]
-			}
-			break
-		}
+	dataStoreKey.CollectionId = elements[keyStart+1]
+	dataStoreKey.InstanceType = InstanceType(elements[keyStart+2])
+	dataStoreKey.DocKey = elements[keyStart+3]
+	if keyStart+4 < numberOfElements {
+		dataStoreKey.FieldId = elements[keyStart+4]
 	}
 
 	return dataStoreKey

--- a/core/key_test.go
+++ b/core/key_test.go
@@ -48,3 +48,74 @@ func TestNewDataStoreKey_ReturnsCollectionIdAndIndexIdAndDocKeyAndFieldIdAndInst
 		result)
 	assert.Equal(t, "/"+collectionId+"/"+instanceType+"/"+docKey+"/"+fieldId, resultString)
 }
+
+func TestNewDataStoreKey_ReturnsEmptyStruct_GivenAStringWithMissingElements(t *testing.T) {
+	inputString := "/0/v"
+
+	result := NewDataStoreKey(inputString)
+	resultString := result.ToString()
+
+	assert.Equal(t, DataStoreKey{}, result)
+	assert.Equal(t, "", resultString)
+}
+
+func TestNewDataStoreKey_GivenAShortObjectMarker(t *testing.T) {
+	instanceType := "anyType"
+	docKey := "docKey"
+	collectionId := "1"
+	inputString := collectionId + "/" + instanceType + "/" + docKey
+
+	result := NewDataStoreKey(inputString)
+	resultString := result.ToString()
+
+	assert.Equal(
+		t,
+		DataStoreKey{
+			CollectionId: collectionId,
+			DocKey:       docKey,
+			InstanceType: InstanceType(instanceType)},
+		result)
+	assert.Equal(t, "/"+collectionId+"/"+instanceType+"/"+docKey, resultString)
+}
+
+func TestNewDataStoreKey_GivenAStringWithExtraPrefixes(t *testing.T) {
+	instanceType := "anyType"
+	fieldId := "f1"
+	docKey := "docKey"
+	collectionId := "1"
+	inputString := "/db/my_database_name/data/" + collectionId + "/" + instanceType + "/" + docKey + "/" + fieldId
+
+	result := NewDataStoreKey(inputString)
+	resultString := result.ToString()
+
+	assert.Equal(
+		t,
+		DataStoreKey{
+			CollectionId: collectionId,
+			DocKey:       docKey,
+			FieldId:      fieldId,
+			InstanceType: InstanceType(instanceType)},
+		result)
+	assert.Equal(t, "/"+collectionId+"/"+instanceType+"/"+docKey+"/"+fieldId, resultString)
+}
+
+func TestNewDataStoreKey_GivenAStringWithExtraSuffix(t *testing.T) {
+	instanceType := "anyType"
+	fieldId := "f1"
+	docKey := "docKey"
+	collectionId := "1"
+	inputString := "/db/data/" + collectionId + "/" + instanceType + "/" + docKey + "/" + fieldId + "/version_number"
+
+	result := NewDataStoreKey(inputString)
+	resultString := result.ToString()
+
+	assert.Equal(
+		t,
+		DataStoreKey{
+			CollectionId: collectionId,
+			DocKey:       docKey,
+			FieldId:      fieldId,
+			InstanceType: InstanceType(instanceType)},
+		result)
+	assert.Equal(t, "/"+collectionId+"/"+instanceType+"/"+docKey+"/"+fieldId, resultString)
+}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #799 

## Description

This PR improves the parsing of DataStoreKey strings removing the dependency on having exactly the right number of elements. It no longer assumes exact position from left or right. 

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

make test

Specify the platform(s) on which this was tested:
- MacOS
