### PR TITLE
fix: Do not assume parent record exists when joining

### DIFF
--- a/planner/type_join.go
+++ b/planner/type_join.go
@@ -364,8 +364,6 @@ func (n *typeJoinOne) valuesPrimary(doc core.Doc) core.Doc {
 		return doc
 	}
 
-	doc.Fields[n.subSelect.Index] = n.subSelect.DocumentMapping.NewDoc()
-
 	// create the collection key for the sub doc
 	slct := n.subType.(*selectTopNode).selectnode
 	desc := slct.sourceInfo.collectionDescription

--- a/tests/integration/mutation/relation/delete/with_txn_test.go
+++ b/tests/integration/mutation/relation/delete/with_txn_test.go
@@ -464,12 +464,9 @@ func TestTxnDeletionOfRelatedDocFromNonPrimarySideBackwardDirection(t *testing.T
 
 		Results: []map[string]any{
 			{
-				"_key": "bae-edf7f0fc-f0fd-57e2-b695-569d87e1b251",
-				"name": "Book By Online",
-				"publisher": map[string]any{ // TODO(#874): This should be properly unlinked.
-					"_key": nil,
-					"name": nil,
-				},
+				"_key":      "bae-edf7f0fc-f0fd-57e2-b695-569d87e1b251",
+				"name":      "Book By Online",
+				"publisher": nil,
 			},
 		},
 

--- a/tests/integration/query/one_to_many/simple_test.go
+++ b/tests/integration/query/one_to_many/simple_test.go
@@ -139,3 +139,38 @@ func TestQueryOneToMany(t *testing.T) {
 		executeTestCase(t, test)
 	}
 }
+
+func TestQueryOneToManyWithNonExistantParent(t *testing.T) {
+	test := testUtils.QueryTestCase{
+		Description: "One-to-many relation query from one side with non-existant parent",
+		Query: `query {
+						book {
+							name
+							rating
+							author {
+								name
+								age
+							}
+						}
+					}`,
+		Docs: map[int][]string{
+			//books
+			0: {
+				`{
+					"name": "Painted House",
+					"rating": 4.9,
+					"author_id": "bae-41598f0c-19bc-5da6-813b-e80f14a10df3"
+				}`,
+			},
+		},
+		Results: []map[string]any{
+			{
+				"name":   "Painted House",
+				"rating": 4.9,
+				"author": nil,
+			},
+		},
+	}
+
+	executeTestCase(t, test)
+}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #874

## Description

Removes a line that pre-populates a parent relation before it is known that the parent exists.  My guess is that this was accidentally left here during a refactoring.

One-one joins were unaffected, and already had tests (`TestQueryOneToOneWithNilChild` and `TestQueryOneToOneWithNilParent`).
