### PR TITLE
ci: Bump ssh-agent action to v0.7.0

### DIFF
--- a/.github/workflows/detect-change.yml
+++ b/.github/workflows/detect-change.yml
@@ -33,9 +33,10 @@ jobs:
 
       # We need SSH Authorization because change detection needs use `ls-remote` like:
       #  git ls-remote git@github.com:sourcenetwork/defradb.git refs/heads/develop
-      - uses: webfactory/ssh-agent@v0.5.4
+      - uses: webfactory/ssh-agent@v0.7.0
         with:
             ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+            log-public-key: false
 
       - name: Run detection for changes
         run: make test:changes


### PR DESCRIPTION
## Relevant issue(s)
Resolves #977 

## Description
Bumps the `ssh-agent` github action to version [v0.7.0](https://github.com/webfactory/ssh-agent/tree/v0.7.0) and uses some new configuration option(s).

## Tasks
- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?
CI

Specify the platform(s) on which this was tested:
- Manjaro
