### PR TITLE
ci: Bump all gh-action versions to support node16

### DIFF
--- a/.github/workflows/code-test-coverage.yml
+++ b/.github/workflows/code-test-coverage.yml
@@ -24,7 +24,7 @@ jobs:
         run: make test:coverage
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true


### PR DESCRIPTION
## Relevant issue(s)
Resolves #979 

## Description
This PR ensures all old versions of GitHub actions that will soon be deprecated are bumped up.

Note: When I made the issue I thought there might be many actions that would be need to be updated after #978. Turns out only the code coverage action needed an update to fix the warnings.

## Tasks
- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?
CI

Specify the platform(s) on which this was tested:
- WSL2 Manjaro
