### PR TITLE
fix: Missing port and server name on tls

### DIFF
--- a/api/http/server.go
+++ b/api/http/server.go
@@ -213,11 +213,15 @@ func (s *Server) listenWithTLS(ctx context.Context) error {
 			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
 			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
 		},
+		ServerName: "DefraDB",
 	}
 	addr := s.Addr
 
 	if s.options.tls.Value().domain != "" {
 		addr = s.options.tls.Value().port
+		if addr == "" {
+			addr = ":443"
+		}
 
 		certCache := path.Join(s.options.rootDir, "autocerts")
 


### PR DESCRIPTION
## Relevant issue(s)

Resolves #996

## Description

This PR fixes a missing port number and server name when using TLS with a domain name.

## How has this been tested?

manually on a remote server

Specify the platform(s) on which this was tested:
- Amazon Linux
