### PR TITLE
fix: TLS with only url

### DIFF
--- a/api/http/errors.go
+++ b/api/http/errors.go
@@ -35,6 +35,7 @@ var (
 	ErrMissingGQLQuery      = errors.New("missing GraphQL query")
 	ErrPeerIdUnavailable    = errors.New("no peer ID available. P2P might be disabled")
 	ErrStreamingUnsupported = errors.New("streaming unsupported")
+	ErrNoEmail              = errors.New("email address must be specified for tls with autocert")
 )
 
 // ErrorResponse is the GQL top level object holding error items for the response payload.

--- a/api/http/handler_test.go
+++ b/api/http/handler_test.go
@@ -287,7 +287,7 @@ func TestTLSRequestResponseHeader(t *testing.T) {
 	}
 	dir := t.TempDir()
 
-	s := NewServer(nil, WithAddress("example.com"), WithRootDir(dir))
+	s := NewServer(nil, WithTLS(), WithAddress("example.com"), WithRootDir(dir))
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/api/http/server_test.go
+++ b/api/http/server_test.go
@@ -57,12 +57,23 @@ func TestNewServerAndRunWithListenerAndValidPort(t *testing.T) {
 	<-serverDone
 }
 
+func TestNewServerAndRunWithAutocertWithoutEmail(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	s := NewServer(nil, WithAddress("example.com"), WithRootDir(dir), WithTLSPort(0))
+
+	err := s.Listen(ctx)
+	assert.ErrorIs(t, err, ErrNoEmail)
+
+	s.Shutdown(context.Background())
+}
+
 func TestNewServerAndRunWithAutocert(t *testing.T) {
 	ctx := context.Background()
 	serverRunning := make(chan struct{})
 	serverDone := make(chan struct{})
 	dir := t.TempDir()
-	s := NewServer(nil, WithAddress("example.com"), WithRootDir(dir), WithTLSPort(0))
+	s := NewServer(nil, WithAddress("example.com"), WithRootDir(dir), WithTLSPort(0), WithCAEmail("dev@defradb.net"))
 	go func() {
 		close(serverRunning)
 		err := s.Listen(ctx)
@@ -196,7 +207,7 @@ func TestNewServerWithAddress(t *testing.T) {
 
 func TestNewServerWithDomainAddress(t *testing.T) {
 	s := NewServer(nil, WithAddress("example.com"))
-	assert.Equal(t, "example.com", s.options.tls.Value().domain)
+	assert.Equal(t, "example.com", s.options.domain.Value())
 	assert.NotNil(t, s.options.tls)
 }
 

--- a/cli/start.go
+++ b/cli/start.go
@@ -318,6 +318,7 @@ func start(ctx context.Context) (*defraInstance, error) {
 	if cfg.API.TLS {
 		sOpt = append(
 			sOpt,
+			httpapi.WithTLS(),
 			httpapi.WithSelfSignedCert(cfg.API.PubKeyPath, cfg.API.PrivKeyPath),
 			httpapi.WithCAEmail(cfg.API.Email),
 		)

--- a/config/config.go
+++ b/config/config.go
@@ -310,6 +310,8 @@ type APIConfig struct {
 	Email       string
 }
 
+var DefaultAPIEmail = "example@example.com"
+
 func defaultAPIConfig() *APIConfig {
 	rootDir, err := DefaultRootDir()
 	if err != nil {
@@ -321,7 +323,7 @@ func defaultAPIConfig() *APIConfig {
 		TLS:         false,
 		PubKeyPath:  path.Join(rootDir, "certs/server.key"),
 		PrivKeyPath: path.Join(rootDir, "certs/server.crt"),
-		Email:       "example@example.com",
+		Email:       DefaultAPIEmail,
 	}
 }
 


### PR DESCRIPTION
## Relevant issue(s)

Resolves #1001
Resolves #962

## Description

This PR fixes the situation where defra was allowed to start when setting TLS with a domain and no email address. It also resolves the flaky test for the GraphQL subscription

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Unit test

Specify the platform(s) on which this was tested:
- MacOS
