### PR TITLE
 feat: Design public schema mutation members

### DIFF
--- a/client/schema/example_tests.go
+++ b/client/schema/example_tests.go
@@ -1,0 +1,103 @@
+// Copyright 2023 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package schema
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sourcenetwork/defradb/client"
+)
+
+func TestTypedAddField(t *testing.T) {
+	var db client.DB
+	var ctx context.Context
+
+	collections, err := db.PatchSchema(
+		ctx,
+		AppendField("User", "Email", "String"),
+	)
+}
+
+func TestStringAddField(t *testing.T) {
+	var db client.DB
+	var ctx context.Context
+
+	collections, err := db.PatchSchemaS(
+		ctx,
+		// `-` is JSON patch syntax for appending at the end of a list
+		`{ "op": "add", "path": "/User/-", "value": "Email: String" }`,
+	)
+}
+
+func TestTypedRemoveField(t *testing.T) {
+	var db client.DB
+	var ctx context.Context
+
+	collections, err := db.PatchSchema(
+		ctx,
+		RemoveField("User", "LastName"),
+	)
+}
+
+func TestStringRemoveField(t *testing.T) {
+	var db client.DB
+	var ctx context.Context
+
+	collections, err := db.PatchSchemaS(
+		ctx,
+		`{ "op": "remove", "path": "/User/LastName" }`,
+	)
+}
+
+func TestTypedMultiple(t *testing.T) {
+	var db client.DB
+	var ctx context.Context
+
+	collections, err := db.PatchSchema(
+		ctx,
+		// If any of these operations fail, the whole set should be reverted/not-commited
+		AppendField("User", "LastName", "String"),
+		RemoveField("User", "Fax"),
+		AppendField("User", "PhoneNumber", "String"),
+		AppendSchema(
+			`type Dog {
+				Name: String
+				Owner: User
+			}`,
+		),
+		AppendField("User", "Dogs", "[Dog]"),
+	)
+}
+
+func TestStringMultiple(t *testing.T) {
+	var db client.DB
+	var ctx context.Context
+
+	collections, err := db.PatchSchemaS(
+		ctx,
+		// If any of these operations fail, the whole set should be reverted/not-commited
+		`[
+			{ "op": "add", "path": "/User/-", "value": "LastName: String" },
+			{ "op": "remove", "path": "/User/Fax" },
+			{ "op": "add", "path": "/User/-", "value": "PhoneNumber: String" },
+			{
+				"op": "add",
+				"path": "/-",
+				"value": "type Dog {
+					Name: String
+					Owner: User
+				}",
+			},
+			{ "op": "add", "path": "/User/-", "value": "Dog: [Dog]" },
+		]`,
+	)
+}

--- a/client/schema/mutation.go
+++ b/client/schema/mutation.go
@@ -1,0 +1,157 @@
+// Copyright 2023 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package schema
+
+import "fmt"
+
+// todo - confirm use of int - there may be some benefit to using string (direct use of json patch ops)
+// which might be more understandable to users.
+type PatchOp int
+
+const (
+	// IMO these names and the names of the types that implement `Patch` should very strictly stick to
+	// the names used in the JSON patch spec: https://jsonpatch.com/ - should save users a fair amount
+	// of head-scratching, and will provide natural consistency with any document level json-patch
+	// support that we might add later (e.g. for inline arrays).
+	PatchOpAdd    = 1
+	PatchOpMove   = 2
+	PatchOpRemove = 3
+)
+
+// interface helps minimize the failing surface area when compared to a struct
+// for example providing a value to a remove op, or failing to provide a dst path
+// to a move op.  See client/db.go for usage.
+//
+// Types implementing this interface might be converted to a single concrete type
+// internally (unimportant to decide that now IMO), similar to how Requests work.
+// Before doing all the generator/databasey stuff.
+type Patch interface {
+	Op() PatchOp
+	// question - I'm tempted to type this out instead of using raw []string, I think I prefer
+	// that but have no strong feelings - what are your thoughts?
+	Path() []string
+}
+
+var _ Patch = (*patchAdd)(nil)
+
+type patchAdd struct {
+	path []string
+	// any type is consistent with request-recult (document/map[string]any)
+	value any
+}
+
+func AppendSchema(schema string) Patch {
+	return &patchAdd{
+		path: []string{
+			"-",
+		},
+		value: schema,
+	}
+}
+
+func AppendField(schemaName string, fieldName string, fieldType string) Patch {
+	return &patchAdd{
+		path: []string{
+			schemaName,
+			"-",
+		},
+		value: fmt.Sprintf("%s: %s", fieldName, fieldType),
+	}
+}
+
+func AddFieldAfter(schemaName string, afterFieldName string, fieldName string, fieldType string) Patch {
+	return &patchAdd{
+		path: []string{
+			schemaName,
+			afterFieldName,
+		},
+		value: fmt.Sprintf("%s: %s", fieldName, fieldType),
+	}
+}
+
+func (p *patchAdd) Op() PatchOp {
+	return PatchOpAdd
+}
+
+func (p *patchAdd) Path() []string {
+	return p.path
+}
+
+var _ Patch = (*patchMove)(nil)
+
+// move is consistent with json patch naming, rename is not
+type patchMove struct {
+	from []string
+	path []string
+}
+
+func MoveField(schemaName string, src string, dst string) Patch {
+	return &patchMove{
+		from: []string{
+			schemaName,
+			src,
+		},
+		path: []string{
+			schemaName,
+			dst,
+		},
+	}
+}
+
+func MoveSchema(src string, dst string) Patch {
+	return &patchMove{
+		from: []string{
+			src,
+		},
+		path: []string{
+			dst,
+		},
+	}
+}
+
+func (p *patchMove) Op() PatchOp {
+	return PatchOpMove
+}
+
+func (p *patchMove) Path() []string {
+	return p.path
+}
+
+var _ Patch = (*patchRemove)(nil)
+
+type patchRemove struct {
+	path []string
+}
+
+func RemoveField(schemaName string, fieldName string) Patch {
+	return &patchRemove{
+		path: []string{
+			schemaName,
+			fieldName,
+		},
+	}
+}
+
+func RemoveSchema(schemaName string) Patch {
+	return &patchRemove{
+		path: []string{
+			schemaName,
+		},
+	}
+}
+
+func (p *patchRemove) Op() PatchOp {
+	return PatchOpRemove
+}
+
+func (p *patchRemove) Path() []string {
+	return p.path
+}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #https://github.com/sourcenetwork/defradb/issues/1013 https://github.com/sourcenetwork/defradb/issues/1014

## Description

Proposes a set of public members to allow for **local-only** schema updates using JSON patch syntax https://jsonpatch.com/.  Two entry points will be added - one with typed commands, similar to `request.Request`, and a string based version.

Users may wish to update their schemas for a wide variety of reasons, for example as business requires change they may wish to store additional data in their database.  They may also wish to refactor the data structure, or even remove parts of it.

Using a JSON patch based syntax is not a given, and discussing the merits of it is a large part of why this PR exists. 

Anything migration-wise (i.e. Lens), or remote related (i.e. P2P/Lens) is out of scope at the moment and will be introduced later outside of this PR.

This PR does not compile and does not implement the feature. It is for discussion only.  It will not morph into an implementation in this PR.  It is not suggesting that all of the examples are to be implemented in one go, or even all for v0.5. This includes all documented functions in `db.go` (including the two existing), only one of either `PatchSchema` or `PatchSchemaS` is actually required to expose all required functionality to the user. 

The types implemented in mutation.go are not exhaustive, we'll probably end up with one per operation, and they probably wont all live in the same file.

There are a handful of implementation details that will still need to be discussed before I start implementing (such as persistance/change-tracking), but I would much rather discuss that elsewhere and keep this PR focused on the external interfaces.

Please have a read and let me know your thoughts! It might be easiest to start by either reading the tests or db.go.  There are a couple of unresolved questions in the code-comments and it would be especially good to get feedback there :)

### Update (description only)

As discussed elsewhere, my preference was to not pollute the initial reactions of reviewers with my own thoughts on why I like JSON-patch.  It however seems to have contributed to confusion on this topic and so please find my thoughts below:

- The `patch` part of JSON patch very nicely reduces the risk that providing `full` schemas introduces.  If two `full` but differing schemas are provided (e.g. at roughly the same time, by two actors) the last one to be processed will replace the changes requested by the first - e.g. if actor A seeks to add `email` and actor B wants to add `phone` and they submit their changes without knowledge and coordination between the two then only one field will remain in the system (as the second `full` schema will not include the other new field).
- The `patch` system could play really nicely with Lens, as many operations are well defined, it may allow us to automatically configure basic Lens migrations in some cases (e.g. a field rename).
- JSON-patch is a well defined standard and will be familiar to many users unfamiliar to Defra. This reduces the unexpected, and the amount of learning required. It has also (presumably :)) been thought out and reviewed by a larger number of people (including users) than we can afford to dedicate to an initial DDL design.
- JSON-patch is planned for a couple of other Defra elements (e.g. inline array patching). Using it here is consistent and cuts down on user surprises and learning.
- JSON 'stuff' appears to be the norm within the GQL world when it comes to mutations.  This includes our mutation request syntax - again, less learning and surprises for our users.
- Obvious and concise means to describe transactionality. This includes the `test` operation in the JSON-patch spec, which I really like the idea of using here but is currently out of scope for 0.5. 