### PR TITLE
ci: Fix go-header linter rule to be any year

### DIFF
--- a/tools/configs/golangci.yaml
+++ b/tools/configs/golangci.yaml
@@ -119,7 +119,7 @@ linters:
     - forbidigo
     - goconst
     - gofmt
-    # - goheader
+    - goheader
     - goimports
     - gosimple
     - govet
@@ -247,11 +247,10 @@ linters-settings:
         APL: "Apache License, Version 2.0"
 
       regexp:
-        # define here regexp type values, for example
-        # AUTHOR: .*@mycompany\.com
+        ANY-YEAR: (20\d\d)
 
     template: |-
-      Copyright {{ YEAR }} Democratized Data Foundation
+      Copyright {{ ANY-YEAR }} Democratized Data Foundation
 
       Use of this software is governed by the {{ BSL }}
       included in the file licenses/BSL.txt.


### PR DESCRIPTION
## Relevant issue(s)

Resolves #1020

## Description
Make the go-header linter placeholder in the template be any year, instead of the current year (default).

## Tasks
- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?
CI and Local

Specify the platform(s) on which this was tested:
-Manjaro WSL2