### PR TITLE
design:  Collection and Schema naming

### DIFF
--- a/docs/design/I1025/README.md
+++ b/docs/design/I1025/README.md
@@ -1,0 +1,29 @@
+# Schema and Collection terminology cleanup
+
+Currently there is a fair amount of duplication and confusion of terminology in Defra regarding the words schema and collection. We discussed this over zoom and decided that the definition would be as below:
+
+> Schema: The global elements of a Collection description. A single Schema can be (in the future, currently unimplemented) used to define multiple Collections (both locally and globally).
+>
+> Collection: The local definition of a single complex database type set, analogous to a SQL table. The description of a collection includes the [global] Schema and any local-only elements such as indexes.
+
+Parts of the codebase do not adhere to this definition and this should be corrected.
+
+This document does not currently go into how they should be corrected, and only lists those that should.  How they should be corrected partly depends on the planned Schema Updates feature, and a work in progress design proposing a JSON based alternative to the current SDL format. Changes may also wish to bear in mind the planned allowance for multiple local Collections to be defined from a single Schema.
+
+## client.AddSchema
+
+`client.AddSchema` does not respect this definition. It accepts a `schemaString string` parameter, and uses it to define (local) Collections (the string can contain multiple type definitions). It then stores this local definition in the systemstore under the `/schema` prefix (discussed in [systemstore/schema](#systemstoreschema)).
+
+It is a public entry point and the needs of external users should be taken into consideration when changing it.
+
+## db.loadSchema
+
+`db.loadSchema` loads an (local) Collection SDL from [systemstore/schema](#systemstoreschema) on database restart.
+
+It is internal code called from one location and changing this should have little impact on anything.  That said, I believe it is currently quite poorly tested and particular care should be made with regards to testing any change here.
+
+## systemstore/schema
+
+A local Collection SDL is persisted in the systemstore under the `/schema` prefix. This is currently written to in [client.AddSchema](#clientaddschema) and read in [db.loadSchema](#dbloadschema) - called on database restart.
+
+It is internal, but a breaking change, and will likely impact code within `client.AddSchema` and `db.loadSchema` when made. Otherwise the impact should be minimal.


### PR DESCRIPTION
# Collection and Schema naming

Design of https://github.com/sourcenetwork/defradb/issues/1025

[Rendered](https://github.com/sourcenetwork/defradb/tree/sisley/design/I1025-collection-vs-schema/docs/design/I1025)

Documents the primary locations that differ from the agreed upon definitions of `Collection` and `Schema`.

## Meta-medium stuff

Additionally, this PR represents a play around with doing design/documentation in PR format within a repo.  Slightly amusingly, if we were to use this format this section should be in the contents of a PR (we can do that if preferred:))

It houses the design within a new `/docs/design/` directory, with a child directory named after its issue number for each design.  This allows multiple files per design (including images). The directory follows the pattern `I[issue#]`, the `I` prefix may want to be dropped, it is just the naming my own branches follow and doesn't really add much here.

Some benefits perceived of this vs the current Almanac setup: 
- I consider a directory pattern like this to be superior to the flatter structure currently used in Almanac as it groups the docs by issue (allowing multiple per issue), and follows a standardised pattern.  It could be used within Almanac if we want.
- I also think storing our design stuff in a repository is much much safer than housing them in Almanac.
- One less tool to use for day to day stuff.
- Clean linkage to issues, milestones and project boards.
- Code and design is in the same location. We can actually link to the design docs from prod code godocs I think. It also opens the possibility of including design docs in the same commit as prod-code changes if appropriate (e.g. for small stuff). 
- Can design offline.
- Public (a pure positive IMO, but business people might not want all discussion public).
- I do just prefer working within Gihub PRs, I just prefer the way it looks and feels, particularly regarding comments.
- I also prefer working with raw markdown files in an editor of my choosing.
- I also prefer using git for change tracking, pushing, etc. 

We'll want to change our CI slightly if we do use this, I think this will run the tests and benchmarks by default lol. We could probably add a new status 'In design' too. We'll also want to make sure these don't show up in the change log.

Happy to transfer this doc to Almanac, but I thought I'd have a play and let us test out a simple example.
   