### PR TITLE
refactor: Extract query parser errors to dedicated file

### DIFF
--- a/query/graphql/parser/errors.go
+++ b/query/graphql/parser/errors.go
@@ -1,0 +1,23 @@
+// Copyright 2022 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package parser
+
+import "github.com/sourcenetwork/defradb/errors"
+
+var (
+	ErrFilterMissingArgumentType      = errors.New("couldn't find filter argument type")
+	ErrInvalidOrderDirection          = errors.New("invalid order direction string")
+	ErrFailedToParseConditionsFromAST = errors.New("couldn't parse conditions value from AST")
+	ErrFailedToParseConditionValue    = errors.New("failed to parse condition value from query filter statement")
+	ErrEmptyDataPayload               = errors.New("given data payload is empty")
+	ErrUnknownMutationName            = errors.New("unknown mutation name")
+	ErrUnknownGQLOperation            = errors.New("unknown GraphQL operation type")
+)

--- a/query/graphql/parser/subscription.go
+++ b/query/graphql/parser/subscription.go
@@ -15,7 +15,6 @@ import (
 	"github.com/graphql-go/graphql/language/ast"
 
 	"github.com/sourcenetwork/defradb/client/request"
-	"github.com/sourcenetwork/defradb/errors"
 )
 
 // parseSubscriptionOperationDefinition parses the individual GraphQL
@@ -64,7 +63,7 @@ func parseSubscription(schema gql.Schema, field *ast.Field) (*request.ObjectSubs
 		if prop == request.FilterClause {
 			filterType, ok := getArgumentType(fieldDef, request.FilterClause)
 			if !ok {
-				return nil, errors.New("couldn't get argument type for subscription filter")
+				return nil, ErrFilterMissingArgumentType
 			}
 			obj := argument.Value.(*ast.ObjectValue)
 			filter, err := NewFilter(obj, filterType)


### PR DESCRIPTION
## Relevant issue(s)

Part of #257

## Description

Extracts query parser errors to dedicated files (includes mapper). Continuation of work done at the end of last year whilst waiting on other discussions to progress.