### PR TITLE
refactor: Extract query schema errors to dedicated file

### DIFF
--- a/query/graphql/schema/descriptions.go
+++ b/query/graphql/schema/descriptions.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/request"
-	"github.com/sourcenetwork/defradb/errors"
 )
 
 var (
@@ -167,7 +166,7 @@ func (g *Generator) CreateDescriptions(
 				// let's make sure its an _id field, otherwise
 				// we might have an error here
 				if !strings.HasSuffix(fname, "_id") {
-					return nil, errors.New(fmt.Sprintf("Error: found a duplicate field '%s' for type %s", fname, t.Name()))
+					return nil, NewErrDuplicateField(fname, t.Name())
 				}
 				continue
 			}
@@ -186,18 +185,13 @@ func (g *Generator) CreateDescriptions(
 				rel := g.manager.Relations.getRelationByDescription(
 					fname, schemaName, t.Name())
 				if rel == nil {
-					return nil, errors.New(fmt.Sprintf(
-						"Field missing associated relation. FieldName: %s, SchemaType: %s, ObjectType: %s",
-						fname,
-						field.Type.Name(),
-						t.Name(),
-					))
+					return nil, NewErrFieldMissingRelation(field.Type.Name(), fname, t.Name())
 				}
 				fd.RelationName = rel.name
 
 				_, fieldRelationType, ok := rel.GetField(schemaName, fname)
 				if !ok {
-					return nil, errors.New("relation is missing field")
+					return nil, NewErrRelationMissingField(field.Type.Name(), fname)
 				}
 
 				fd.RelationType = rel.Kind() | fieldRelationType

--- a/query/graphql/schema/errors.go
+++ b/query/graphql/schema/errors.go
@@ -1,0 +1,100 @@
+// Copyright 2022 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package schema
+
+import "github.com/sourcenetwork/defradb/errors"
+
+const (
+	errDuplicateField            string = "duplicate field"
+	errFieldMissingRelation      string = "field missing associated relation"
+	errRelationMissingField      string = "relation missing field"
+	errAggregateTargetNotFound   string = "aggregate target not found"
+	errSchemaTypeAlreadyExist    string = "schema type already exists"
+	errObjectNotFoundDuringThunk string = "object not found whilst executing fields thunk"
+	errTypeNotFound              string = "no type found for given name"
+	errRelationNotFound          string = "no relation found"
+)
+
+var (
+	ErrDuplicateField            = errors.New(errDuplicateField)
+	ErrFieldMissingRelation      = errors.New(errFieldMissingRelation)
+	ErrRelationMissingField      = errors.New(errRelationMissingField)
+	ErrAggregateTargetNotFound   = errors.New(errAggregateTargetNotFound)
+	ErrSchemaTypeAlreadyExist    = errors.New(errSchemaTypeAlreadyExist)
+	ErrObjectNotFoundDuringThunk = errors.New(errObjectNotFoundDuringThunk)
+	ErrTypeNotFound              = errors.New(errTypeNotFound)
+	ErrRelationNotFound          = errors.New(errRelationNotFound)
+	ErrRelationMutlipleTypes     = errors.New("relation type can only be either One or Many, not both")
+	ErrRelationMissingTypes      = errors.New("relation is missing its defined types and fields")
+	ErrRelationInvalidType       = errors.New("relation has an invalid type to be finalize")
+	ErrMultipleRelationPrimaries = errors.New("relation can only have a single field set as primary")
+)
+
+func NewErrDuplicateField(objectName, fieldName string) error {
+	return errors.New(
+		errDuplicateField,
+		errors.NewKV("Object", objectName),
+		errors.NewKV("Field", fieldName),
+	)
+}
+
+func NewErrFieldMissingRelation(objectName, fieldName string, objectType string) error {
+	return errors.New(
+		errFieldMissingRelation,
+		errors.NewKV("Object", objectName),
+		errors.NewKV("Field", fieldName),
+		errors.NewKV("ObjectType", objectType),
+	)
+}
+
+func NewErrRelationMissingField(objectName, fieldName string) error {
+	return errors.New(
+		errRelationMissingField,
+		errors.NewKV("Object", objectName),
+		errors.NewKV("Field", fieldName),
+	)
+}
+
+func NewErrAggregateTargetNotFound(objectName, target string) error {
+	return errors.New(
+		errAggregateTargetNotFound,
+		errors.NewKV("Object", objectName),
+		errors.NewKV("Target", target),
+	)
+}
+
+func NewErrSchemaTypeAlreadyExist(name string) error {
+	return errors.New(
+		errSchemaTypeAlreadyExist,
+		errors.NewKV("Name", name),
+	)
+}
+
+func NewErrObjectNotFoundDuringThunk(object string) error {
+	return errors.New(
+		errObjectNotFoundDuringThunk,
+		errors.NewKV("Object", object),
+	)
+}
+
+func NewErrTypeNotFound(typeName string) error {
+	return errors.New(
+		errTypeNotFound,
+		errors.NewKV("Type", typeName),
+	)
+}
+
+func NewErrRelationNotFound(relationName string) error {
+	return errors.New(
+		errRelationNotFound,
+		errors.NewKV("RelationName", relationName),
+	)
+}

--- a/tests/integration/schema/simple_test.go
+++ b/tests/integration/schema/simple_test.go
@@ -55,7 +55,7 @@ func TestSchemaSimpleErrorsGivenDuplicateSchema(t *testing.T) {
 				}
 			}
 		`,
-		ExpectedError: "Schema type already exists",
+		ExpectedError: "schema type already exists",
 	}
 
 	ExecuteQueryTestCase(t, test)
@@ -136,7 +136,7 @@ func TestSchemaSimpleErrorsGivenTypeWithInvalidFieldType(t *testing.T) {
 				}
 			}
 		`,
-		ExpectedError: "No type found for given name",
+		ExpectedError: "no type found for given name",
 	}
 
 	ExecuteQueryTestCase(t, test)


### PR DESCRIPTION
## Relevant issue(s)

Part of #257

## Description

Extracts query schema errors to dedicated files (includes mapper). Continuation of work done at the end of last year whilst waiting on other discussions to progress.
