### PR TITLE
refactor: Remove generic param for error

### DIFF
--- a/client/document.go
+++ b/client/document.go
@@ -88,7 +88,7 @@ func NewDocFromMap(data map[string]any) (*Document, error) {
 		delete(data, "_key") // remove the key so it isn't parsed further
 		kstr, ok := k.(string)
 		if !ok {
-			return nil, NewErrUnexpectedType[string]("data[_key]", k)
+			return nil, NewErrUnexpectedType("data[_key]", "", k)
 		}
 		if doc.key, err = NewDocKeyFromString(kstr); err != nil {
 			return nil, err

--- a/client/errors.go
+++ b/client/errors.go
@@ -65,8 +65,7 @@ func NewErrSelectOfNonGroupField(name string) error {
 }
 
 // NewErrUnexpectedType returns an error indicating that the given value is of an unexpected type.
-func NewErrUnexpectedType[TExpected any](property string, actual any) error {
-	var expected TExpected
+func NewErrUnexpectedType(property string, expected any, actual any) error {
 	return errors.WithStack(
 		ErrUnexpectedType,
 		errors.NewKV("Property", property),

--- a/client/errors_test.go
+++ b/client/errors_test.go
@@ -19,6 +19,6 @@ import (
 func TestNewUnexpectedType(t *testing.T) {
 	someString := "defradb"
 	someLocation := "foo"
-	err := NewErrUnexpectedType[int](someLocation, someString)
+	err := NewErrUnexpectedType(someLocation, 0, someString)
 	assert.Equal(t, err.Error(), "unexpected type. Property: foo, Expected: int, Actual: string")
 }

--- a/core/crdt/composite.go
+++ b/core/crdt/composite.go
@@ -146,7 +146,7 @@ func (c CompositeDAG) DeltaDecode(node ipld.Node) (core.Delta, error) {
 	delta := &CompositeDAGDelta{}
 	pbNode, ok := node.(*dag.ProtoNode)
 	if !ok {
-		return nil, client.NewErrUnexpectedType[*dag.ProtoNode]("ipld.Node", node)
+		return nil, client.NewErrUnexpectedType("ipld.Node", (*dag.ProtoNode)(nil), node)
 	}
 	data := pbNode.Data()
 	h := &codec.CborHandle{}

--- a/core/crdt/lwwreg.go
+++ b/core/crdt/lwwreg.go
@@ -176,7 +176,7 @@ func (reg LWWRegister) DeltaDecode(node ipld.Node) (core.Delta, error) {
 	delta := &LWWRegDelta{}
 	pbNode, ok := node.(*dag.ProtoNode)
 	if !ok {
-		return nil, client.NewErrUnexpectedType[*dag.ProtoNode]("ipld.Node", node)
+		return nil, client.NewErrUnexpectedType("ipld.Node", (*dag.ProtoNode)(nil), node)
 	}
 	data := pbNode.Data()
 	h := &codec.CborHandle{}

--- a/db/fetcher/encoded_doc.go
+++ b/db/fetcher/encoded_doc.go
@@ -49,7 +49,7 @@ func (e encProperty) Decode() (client.CType, any, error) {
 			for i, untypedValue := range array {
 				boolArray[i], ok = untypedValue.(bool)
 				if !ok {
-					return ctype, nil, client.NewErrUnexpectedType[bool](e.Desc.Name, untypedValue)
+					return ctype, nil, client.NewErrUnexpectedType(e.Desc.Name, false, untypedValue)
 				}
 			}
 			val = boolArray
@@ -81,7 +81,8 @@ func (e encProperty) Decode() (client.CType, any, error) {
 			for i, untypedValue := range array {
 				floatArray[i], ok = untypedValue.(float64)
 				if !ok {
-					return ctype, nil, client.NewErrUnexpectedType[float64](e.Desc.Name, untypedValue)
+					var f float64
+					return ctype, nil, client.NewErrUnexpectedType(e.Desc.Name, f, untypedValue)
 				}
 			}
 			val = floatArray
@@ -97,7 +98,7 @@ func (e encProperty) Decode() (client.CType, any, error) {
 			for i, untypedValue := range array {
 				stringArray[i], ok = untypedValue.(string)
 				if !ok {
-					return ctype, nil, client.NewErrUnexpectedType[string](e.Desc.Name, untypedValue)
+					return ctype, nil, client.NewErrUnexpectedType(e.Desc.Name, "", untypedValue)
 				}
 			}
 			val = stringArray
@@ -136,7 +137,8 @@ func convertNillableArray[T any](propertyName string, items []any) ([]immutable.
 		}
 		value, ok := untypedValue.(T)
 		if !ok {
-			return nil, client.NewErrUnexpectedType[T](fmt.Sprintf("%s[%v]", propertyName, i), untypedValue)
+			var t T
+			return nil, client.NewErrUnexpectedType(fmt.Sprintf("%s[%v]", propertyName, i), t, untypedValue)
 		}
 		resultArray[i] = immutable.Some(value)
 	}
@@ -172,7 +174,7 @@ func convertToInt(propertyName string, untypedValue any) (int64, error) {
 	case float64:
 		return int64(value), nil
 	default:
-		return 0, client.NewErrUnexpectedType[string](propertyName, untypedValue)
+		return 0, client.NewErrUnexpectedType(propertyName, "", untypedValue)
 	}
 }
 

--- a/db/fetcher/versioned.go
+++ b/db/fetcher/versioned.go
@@ -225,7 +225,8 @@ func (vf *VersionedFetcher) seekTo(c cid.Cid) error {
 	for ccv := vf.queuedCids.Front(); ccv != nil; ccv = ccv.Next() {
 		cc, ok := ccv.Value.(cid.Cid)
 		if !ok {
-			return client.NewErrUnexpectedType[cid.Cid]("queueudCids", ccv.Value)
+			var c cid.Cid
+			return client.NewErrUnexpectedType("queueudCids", c, ccv.Value)
 		}
 		err := vf.merge(cc)
 		if err != nil {

--- a/db/subscriptions.go
+++ b/db/subscriptions.go
@@ -39,7 +39,7 @@ func (db *db) checkForClientSubsciptions(r *request.Request) (
 			return pub, subRequest, nil
 		}
 
-		return nil, nil, client.NewErrUnexpectedType[request.ObjectSubscription]("SubcriptionSelection", s)
+		return nil, nil, client.NewErrUnexpectedType("SubcriptionSelection", request.ObjectSubscription{}, s)
 	}
 	return nil, nil, nil
 }

--- a/planner/average.go
+++ b/planner/average.go
@@ -74,7 +74,8 @@ func (n *averageNode) Next() (bool, error) {
 	countProp := n.currentValue.Fields[n.countFieldIndex]
 	typedCount, isInt := countProp.(int)
 	if !isInt {
-		return false, client.NewErrUnexpectedType[int]("count", countProp)
+		var i int
+		return false, client.NewErrUnexpectedType("count", i, countProp)
 	}
 	count := typedCount
 

--- a/planner/multi.go
+++ b/planner/multi.go
@@ -435,7 +435,7 @@ func (s *selectNode) addSubPlan(fieldIndex int, plan planNode) error {
 		case mergeNode:
 			multiscan, sourceIsMultiscan := node.Source().(*multiScanNode)
 			if !sourceIsMultiscan {
-				return client.NewErrUnexpectedType[*multiScanNode]("mergeNode", node.Source())
+				return client.NewErrUnexpectedType("mergeNode", (*multiScanNode)(nil), node.Source())
 			}
 
 			// replace our new node internal scanNode with our existing multiscanner

--- a/query/graphql/parser/filter.go
+++ b/query/graphql/parser/filter.go
@@ -82,7 +82,7 @@ func ParseConditionsInOrder(stmt *ast.ObjectValue) ([]request.OrderCondition, er
 	if v, ok := cond.([]request.OrderCondition); ok {
 		return v, nil
 	}
-	return nil, client.NewErrUnexpectedType[[]request.OrderCondition]("condition", cond)
+	return nil, client.NewErrUnexpectedType("condition", []request.OrderCondition{}, cond)
 }
 
 func parseConditionsInOrder(stmt *ast.ObjectValue) (any, error) {
@@ -138,7 +138,7 @@ func ParseConditions(stmt *ast.ObjectValue, inputType gql.Input) (map[string]any
 	if v, ok := cond.(map[string]any); ok {
 		return v, nil
 	}
-	return nil, client.NewErrUnexpectedType[map[string]any]("condition", cond)
+	return nil, client.NewErrUnexpectedType("condition", map[string]any{}, cond)
 }
 
 func parseConditions(stmt *ast.ObjectValue, inputArg gql.Input) (any, error) {

--- a/query/graphql/parser/mutation.go
+++ b/query/graphql/parser/mutation.go
@@ -128,7 +128,7 @@ func parseMutation(schema gql.Schema, parent *gql.Object, field *ast.Field) (*re
 			for i, val := range raw.Values {
 				id, ok := val.(*ast.StringValue)
 				if !ok {
-					return nil, client.NewErrUnexpectedType[*ast.StringValue]("ids argument", val)
+					return nil, client.NewErrUnexpectedType("ids argument", (*ast.StringValue)(nil), val)
 				}
 				ids[i] = id.Value
 			}

--- a/query/graphql/parser/query.go
+++ b/query/graphql/parser/query.go
@@ -345,7 +345,7 @@ func parseAggregate(schema gql.Schema, parent *gql.Object, field *ast.Field, ind
 				}
 				argTypeObject, ok := argType.(*gql.InputObject)
 				if !ok {
-					return nil, client.NewErrUnexpectedType[*gql.InputObject]("arg type", argType)
+					return nil, client.NewErrUnexpectedType("arg type", (*gql.InputObject)(nil), argType)
 				}
 				filterType, ok := getArgumentTypeFromInput(argTypeObject, request.FilterClause)
 				if !ok {
@@ -353,7 +353,7 @@ func parseAggregate(schema gql.Schema, parent *gql.Object, field *ast.Field, ind
 				}
 				filterObjVal, ok := filterArg.Value.(*ast.ObjectValue)
 				if !ok {
-					return nil, client.NewErrUnexpectedType[*gql.InputObject]("filter arg", filterArg.Value)
+					return nil, client.NewErrUnexpectedType("filter arg", (*ast.ObjectValue)(nil), filterArg.Value)
 				}
 				filterValue, err := NewFilter(filterObjVal, filterType)
 				if err != nil {

--- a/query/graphql/schema/generate.go
+++ b/query/graphql/schema/generate.go
@@ -522,7 +522,7 @@ func getRelationshipName(
 				if argument.Name.Value == "name" {
 					name, isString := argument.Value.GetValue().(string)
 					if !isString {
-						return "", client.NewErrUnexpectedType[string]("Relationship name", argument.Value.GetValue())
+						return "", client.NewErrUnexpectedType("Relationship name", "", argument.Value.GetValue())
 					}
 					return name, nil
 				}
@@ -1187,7 +1187,7 @@ func (g *Generator) genLeafFilterArgInput(obj gql.Type) *gql.InputObject {
 		operatorObject, isInputObj := operatorType.(*gql.InputObject)
 		if !isInputObj {
 			// This should be impossible
-			return nil, client.NewErrUnexpectedType[*gql.InputObject]("operatorType", operatorType)
+			return nil, client.NewErrUnexpectedType("operatorType", (*gql.InputObject)(nil), operatorType)
 		}
 
 		for f, field := range operatorObject.Fields() {


### PR DESCRIPTION
## Relevant issue(s)

Resolves #1040

## Description

Removes the generic param for client.NewErrUnexpectedType as requested by the team.  I wish to re-emphasise that I really don't think that this is nicer.