### PR TITLE
test: Exclude auto-generated protobuf files from codecov

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -39,5 +39,4 @@ comment:
 ignore:
   - "tests"
   - "**/*_test.go"
-  - "net/pb/net.pb.go"
-  - "net/api/pb/api.pb.go"
+  - "**/*.pb.go"


### PR DESCRIPTION
## Relevant issue(s)

Resolves #1045

## Description

Excludes auto-generated protobuf files from codecov.  They accounted for about 3200 line misses (our code base is about 19 000 lines)
