### PR TITLE
chore: Handle GH actions deprecated command

### DIFF
--- a/.github/workflows/lint-then-benchmark.yml
+++ b/.github/workflows/lint-then-benchmark.yml
@@ -128,7 +128,7 @@ jobs:
 
       - name: Set the output to be the benchmark type
         id: set-benchmark-type
-        run: echo "::set-output name=type::${DEFAULT_BENCHMARK_TYPE}"
+        run: echo "type=${DEFAULT_BENCHMARK_TYPE}" >> $GITHUB_OUTPUT
 
   # ================== Step-3: Start the runner and get it registered as a github runner.
   start-runner:


### PR DESCRIPTION
## Relevant issue(s)

Resolves #1133

## Description

One-liner to handle the deprecation

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

## Tasks

- [ ] I made sure the code is well commented, particularly hard-to-understand areas.
- [ ] I made sure the repository-held documentation is changed accordingly.
- [ ] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [ ] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

TBD