### PR TITLE
ci: Skip benchmarks for dependabot

### DIFF
--- a/.github/workflows/lint-then-benchmark.yml
+++ b/.github/workflows/lint-then-benchmark.yml
@@ -117,7 +117,8 @@ jobs:
         if: |
           github.event_name == 'pull_request' &&
           github.base_ref != 'develop' ||
-          contains(github.event.pull_request.labels.*.name, 'action/no-benchmark')
+          contains(github.event.pull_request.labels.*.name, 'action/no-benchmark') ||
+          github.actor == 'dependabot[bot]'
         run: echo "DEFAULT_BENCHMARK_TYPE=NONE" >> ${GITHUB_ENV}
 
       - name: Run full benchmarks if merged PR (push event) on develop


### PR DESCRIPTION
## Relevant issue(s)
Resolves #1143

## Description
We have to replicate all github secrets for dependabot, a quick get around I want to try is to see if we can just skip the benchmark workflow for dependabot. Can turn benchmarking back on if we decide we need that once benchmarking has been fixed/improved. Other than the benchmark secrets we have a token for code cov and a ssh deploy key for defradb, both of which have been replicated in dependabot secrets.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?
Will need to have a dependabot PR open to test if this actually works or not.

Specify the platform(s) on which this was tested:
- WSL - Manjaro
