### PR TITLE
refactor: Rework client interfaces to wrap transactions

### DIFF
--- a/client/db.go
+++ b/client/db.go
@@ -20,6 +20,23 @@ import (
 )
 
 type DB interface {
+	CreateCollection(context.Context, CollectionDescription) (Collection, error)
+
+	GetCollectionByName(context.Context, string) (Collection, error)
+	GetCollectionBySchemaID(context.Context, string) (Collection, error)
+	GetAllCollections(context.Context) ([]Collection, error)
+
+	ExecRequest(context.Context, string) *RequestResult
+}
+
+type DBImmediate interface { //name??
+	DB
+	// P2PImmediate holds the P2P related methods that must be implemented by the database.
+	P2PImmediate
+
+	WithTxn(context.Context, bool) (DBTxn, error)
+	WithConcurrentTxn(context.Context, bool) (DBTxn, error)
+
 	AddSchema(context.Context, string) error
 
 	// PatchSchema takes the given JSON patch string and applies it to the set of CollectionDescriptions
@@ -35,10 +52,27 @@ type DB interface {
 	// will be applied.
 	PatchSchema(context.Context, string) error
 
-	CreateCollection(context.Context, CollectionDescription) (Collection, error)
-	CreateCollectionTxn(context.Context, datastore.Txn, CollectionDescription) (Collection, error)
+	Root() datastore.RootStore
+	Blockstore() blockstore.Blockstore
+	Events() events.Events
+	MaxTxnRetries() int
 
-	// UpdateCollectionTxn updates the persisted collection description matching the name of the given
+	PrintDump(ctx context.Context) error
+
+	Close(context.Context)
+}
+
+type DefraTxn interface {
+	Commit(context.Context) error
+	Discard(context.Context)
+}
+
+type DBTxn interface {
+	DB
+	P2PTxn
+	DefraTxn
+
+	// UpdateCollection updates the persisted collection description matching the name of the given
 	// description, to the values in the given description.
 	//
 	// It will validate the given description using [ValidateUpdateCollectionTxn] before updating it.
@@ -46,38 +80,13 @@ type DB interface {
 	// The collection (including the schema version ID) will only be updated if any changes have actually
 	// been made, if the given description matches the current persisted description then no changes will be
 	// applied.
-	UpdateCollectionTxn(context.Context, datastore.Txn, CollectionDescription) (Collection, error)
+	UpdateCollection(context.Context, CollectionDescription) (Collection, error)
 
-	// ValidateUpdateCollectionTxn validates that the given collection description is a valid update.
+	// ValidateUpdateCollection validates that the given collection description is a valid update.
 	//
 	// Will return true if the given desctiption differs from the current persisted state of the
 	// collection. Will return an error if it fails validation.
-	ValidateUpdateCollectionTxn(context.Context, datastore.Txn, CollectionDescription) (bool, error)
-
-	GetCollectionByName(context.Context, string) (Collection, error)
-	GetCollectionByNameTxn(context.Context, datastore.Txn, string) (Collection, error)
-	GetCollectionBySchemaID(context.Context, string) (Collection, error)
-	GetCollectionBySchemaIDTxn(context.Context, datastore.Txn, string) (Collection, error)
-	GetAllCollections(context.Context) ([]Collection, error)
-	GetAllCollectionsTxn(context.Context, datastore.Txn) ([]Collection, error)
-
-	Root() datastore.RootStore
-	Blockstore() blockstore.Blockstore
-
-	NewTxn(context.Context, bool) (datastore.Txn, error)
-	NewConcurrentTxn(context.Context, bool) (datastore.Txn, error)
-	ExecRequest(context.Context, string) *RequestResult
-	ExecTransactionalRequest(context.Context, string, datastore.Txn) *RequestResult
-	Close(context.Context)
-
-	Events() events.Events
-
-	MaxTxnRetries() int
-
-	PrintDump(ctx context.Context) error
-
-	// P2P holds the P2P related methods that must be implemented by the database.
-	P2P
+	ValidateUpdateCollection(context.Context, CollectionDescription) (bool, error)
 }
 
 type GQLResult struct {

--- a/client/p2p.go
+++ b/client/p2p.go
@@ -12,11 +12,23 @@ package client
 
 import (
 	"context"
-
-	"github.com/sourcenetwork/defradb/datastore"
 )
 
 type P2P interface {
+	// AddP2PCollection adds the given collection ID that the P2P system
+	// subscribes to to the the persisted list. It will error if the provided
+	// collection ID is invalid.
+	AddP2PCollection(ctx context.Context, collectionID string) error
+
+	// RemoveP2PCollection removes the given collection ID that the P2P system
+	// subscribes to from the the persisted list. It will error if the provided
+	// collection ID is invalid.
+	RemoveP2PCollection(ctx context.Context, collectionID string) error
+}
+
+type P2PImmediate interface { //name??
+	P2P
+
 	// SetReplicator adds a replicator to the persisted list or adds
 	// schemas if the replicator already exists.
 	SetReplicator(ctx context.Context, rep Replicator) error
@@ -27,25 +39,12 @@ type P2P interface {
 	// subscribed schemas.
 	GetAllReplicators(ctx context.Context) ([]Replicator, error)
 
-	// AddP2PCollection adds the given collection ID that the P2P system
-	// subscribes to to the the persisted list. It will error if the provided
-	// collection ID is invalid.
-	AddP2PCollection(ctx context.Context, collectionID string) error
-	// AddP2PCollectionTxn adds the given collection ID that the P2P system
-	// subscribes to to the the persisted list. It will error if the provided
-	// collection ID is invalid.
-	AddP2PCollectionTxn(ctx context.Context, txn datastore.Txn, collectionID string) error
-
-	// RemoveP2PCollection removes the given collection ID that the P2P system
-	// subscribes to from the the persisted list. It will error if the provided
-	// collection ID is invalid.
-	RemoveP2PCollection(ctx context.Context, collectionID string) error
-	// RemoveP2PCollectionTxn removes the given collection ID that the P2P system
-	// subscribes to from the the persisted list. It will error if the provided
-	// collection ID is invalid.
-	RemoveP2PCollectionTxn(ctx context.Context, txn datastore.Txn, collectionID string) error
-
 	// GetAllP2PCollections returns the list of persisted collection IDs that
 	// the P2P system subscribes to.
 	GetAllP2PCollections(ctx context.Context) ([]string, error)
+}
+
+type P2PTxn interface {
+	P2P
+	DefraTxn
 }


### PR DESCRIPTION
## Relevant issue(s)

Resolves #1161

## Description

Reworks the client interfaces to wrap transactions in a user friendly non-bloated way.

Opening this as a draft PR now, as it will probably take a fair bit of effort to make the necessary changes to the implementing classes to make this compile/work and we can review the hard/controversial/important bits before that effort is completed.

I have just declared the interfaces as I like.  Adding new functions to close the gap between transaction/immediate interfaces is out of scope but should be done at a later date. It preserves the existing split with P2P.  There is a ticket to split it further/in-a-nicer-way along similar, non-transactional lines, but that is out of scope.

Documentation is as detailed as it is in develop.  Adding documentation to existing functions is out of scope, however documentation the new transaction related stuff (types, funcs) is in scope and will be done before full-PR status.  Current names are horrible, I just need to call them something for now.  I hope however that the important stuff remains reviewable in the short term, as I do not wish to spend days on getting this full-PR ready only to be asked to make a whole bunch of painful changes that could be requested now.

It splits the P2P and DB interfaces into 3 each:
1. Shared (i.e. DB, P2P) - this contains functions available on both txnal/non-txnal variants, and will be useful for places that dont care about whether it is acting on a transaction or not.  It should grow (out of scope) to include pretty much all functions IMO.
2. Txn - this contains functions only available on the transactional variant - long term this should contain pretty much nothing minus Commit, Discard and  Shared functions, however closing that gap now is out of scope.
3. Immediate - this contains functions not available on the transactional variant, such as WithTxn.

Additionally both P2PTxn and DbTxn inherit from DefraTxn, this is so that P2PTxn and DbTxn remain complete, and can be used as-is for all txn related changes - e.g. it would be annoying if you had to cast or use another reference to commit/discard if just working with the P2PTxn interface.

Also, NewTxn and NewConcurrentTxn have been renamed to WithTxn and WithConcurrentTxn respectively and their return types tweaked.  Their purpose has not changed although the implementation will do so slightly (to wrap the DbTxn implementation instead of raw ipfs Txn).

I'll keep any implementation work out of the `BREAKING - Rework client interfaces to wrap transactions` commit, but I'll rewrite the git history without warning up until this enters full-PR state - please ignore any other commits until that point.