### PR TITLE
tools: Changelog to only accept specific categories

### DIFF
--- a/tools/configs/chglog/config.yml
+++ b/tools/configs/chglog/config.yml
@@ -5,12 +5,17 @@ info:
   repository_url: https://github.com/sourcenetwork/defradb
 options:
   commits:
-  filters:
-    Type:
-      - feat
-      - fix
-      - perf
-      - refactor
+    filters:
+      Type:
+        - feat
+        - fix
+        - tools
+        - docs
+        - perf
+        - refactor
+        - test
+        - ci
+        - chore
   commit_groups:
     title_maps:
       feat: Features


### PR DESCRIPTION
## Relevant issue(s)

Resolves #1167

## Description

Have the changelog generation script to ignore all categories that are not in our specific list.

Question: How to relate to commits done by `dependabot`?
They can be categorized as `deps` or `chore(TBD)` or etc.
Then, either include them or ignore.

Note the `options.filters` was previously not used, as `filters` is actually only a subcategory of `options.commits`.


## Tasks

- [ ] I made sure the code is well commented, particularly hard-to-understand areas.
- [ ] I made sure the repository-held documentation is changed accordingly.
- [ ] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [ ] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Manual run locally.