### PR TITLE
docs: Correct commits query example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ Obtain a specific commit by its content identifier (`cid`):
 ```gql
 defradb client query '
   query {
-    commit(cid: "bafybeidembipteezluioakc2zyke4h5fnj4rr3uaougfyxd35u3qzefzhm") {
+    commits(cid: "bafybeidembipteezluioakc2zyke4h5fnj4rr3uaougfyxd35u3qzefzhm") {
       cid
       delta
       height


### PR DESCRIPTION
## Relevant issue(s)

Resolves #1170

## Description

Corrects a commits query example in the readme. Spotted whilst looking it over for Pavneet.
