### PR TITLE
feat: Add field kind substitution for PatchSchema

### DIFF
--- a/client/db.go
+++ b/client/db.go
@@ -56,6 +56,9 @@ type Store interface {
 	// The collections (including the schema version ID) will only be updated if any changes have actually
 	// been made, if the net result of the patch matches the current persisted description then no changes
 	// will be applied.
+	//
+	// Field [FieldKind] values may be provided in either their raw integer form, or as string as per
+	// [FieldKindStringToEnumMapping].
 	PatchSchema(context.Context, string) error
 
 	CreateCollection(context.Context, CollectionDescription) (Collection, error)

--- a/client/descriptions.go
+++ b/client/descriptions.go
@@ -157,6 +157,30 @@ const (
 	FieldKind_NILLABLE_STRING_ARRAY FieldKind = 21
 )
 
+// FieldKindStringToEnumMapping maps string representations of [FieldKind] values to
+// their enum values.
+//
+// It is currently used to by [db.PatchSchema] to allow string representations of
+// [FieldKind] to be provided instead of their raw int values.  This useage may expand
+// in the future.  They currently roughly correspond to the GQL field types, but this
+// equality is not guarenteed.
+var FieldKindStringToEnumMapping = map[string]FieldKind{
+	"ID":         FieldKind_DocKey,
+	"Boolean":    FieldKind_BOOL,
+	"[Boolean]":  FieldKind_NILLABLE_BOOL_ARRAY,
+	"[Boolean!]": FieldKind_BOOL_ARRAY,
+	"Integer":    FieldKind_INT,
+	"[Integer]":  FieldKind_NILLABLE_INT_ARRAY,
+	"[Integer!]": FieldKind_INT_ARRAY,
+	"DateTime":   FieldKind_DATETIME,
+	"Float":      FieldKind_FLOAT,
+	"[Float]":    FieldKind_NILLABLE_FLOAT_ARRAY,
+	"[Float!]":   FieldKind_FLOAT_ARRAY,
+	"String":     FieldKind_STRING,
+	"[String]":   FieldKind_NILLABLE_STRING_ARRAY,
+	"[String!]":  FieldKind_STRING_ARRAY,
+}
+
 // RelationType describes the type of relation between two types.
 type RelationType uint8
 

--- a/db/errors.go
+++ b/db/errors.go
@@ -34,6 +34,7 @@ const (
 	errCannotMoveField               string = "moving fields is not currently supported"
 	errInvalidCRDTType               string = "only default or LWW (last writer wins) CRDT types are supported"
 	errCannotDeleteField             string = "deleting an existing field is not supported"
+	errFieldKindNotFound             string = "no type found for given name"
 )
 
 var (
@@ -79,6 +80,7 @@ var (
 	ErrCannotMoveField          = errors.New(errCannotMoveField)
 	ErrInvalidCRDTType          = errors.New(errInvalidCRDTType)
 	ErrCannotDeleteField        = errors.New(errCannotDeleteField)
+	ErrFieldKindNotFound        = errors.New(errFieldKindNotFound)
 )
 
 // NewErrFailedToGetHeads returns a new error indicating that the heads of a document
@@ -164,6 +166,13 @@ func NewErrCannotAddRelationalField(name string, kind client.FieldKind) error {
 	return errors.New(
 		errCannotAddRelationalField,
 		errors.NewKV("Field", name),
+		errors.NewKV("Kind", kind),
+	)
+}
+
+func NewErrFieldKindNotFound(kind string) error {
+	return errors.New(
+		errFieldKindNotFound,
 		errors.NewKV("Kind", kind),
 	)
 }

--- a/tests/integration/schema/updates/add/field/kind/bool_array_test.go
+++ b/tests/integration/schema/updates/add/field/kind/bool_array_test.go
@@ -91,3 +91,47 @@ func TestSchemaUpdatesAddFieldKindBoolArrayWithCreate(t *testing.T) {
 	}
 	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
 }
+
+func TestSchemaUpdatesAddFieldKindBoolArraySubstitutionWithCreate(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "Test schema update, add field with kind bool array substitution with create",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users {
+						Name: String
+					}
+				`,
+			},
+			testUtils.SchemaPatch{
+				Patch: `
+					[
+						{ "op": "add", "path": "/Users/Schema/Fields/-", "value": {"Name": "Foo", "Kind": "[Boolean!]"} }
+					]
+				`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `{
+					"Name": "John",
+					"Foo": [true, false, true]
+				}`,
+			},
+			testUtils.Request{
+				Request: `query {
+					Users {
+						Name
+						Foo
+					}
+				}`,
+				Results: []map[string]any{
+					{
+						"Name": "John",
+						"Foo":  []bool{true, false, true},
+					},
+				},
+			},
+		},
+	}
+	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+}

--- a/tests/integration/schema/updates/add/field/kind/bool_test.go
+++ b/tests/integration/schema/updates/add/field/kind/bool_test.go
@@ -91,3 +91,47 @@ func TestSchemaUpdatesAddFieldKindBoolWithCreate(t *testing.T) {
 	}
 	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
 }
+
+func TestSchemaUpdatesAddFieldKindBoolSubstitutionWithCreate(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "Test schema update, add field with kind bool substitution with create",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users {
+						Name: String
+					}
+				`,
+			},
+			testUtils.SchemaPatch{
+				Patch: `
+					[
+						{ "op": "add", "path": "/Users/Schema/Fields/-", "value": {"Name": "Foo", "Kind": "Boolean"} }
+					]
+				`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `{
+					"Name": "John",
+					"Foo": true
+				}`,
+			},
+			testUtils.Request{
+				Request: `query {
+					Users {
+						Name
+						Foo
+					}
+				}`,
+				Results: []map[string]any{
+					{
+						"Name": "John",
+						"Foo":  true,
+					},
+				},
+			},
+		},
+	}
+	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+}

--- a/tests/integration/schema/updates/add/field/kind/datetime_test.go
+++ b/tests/integration/schema/updates/add/field/kind/datetime_test.go
@@ -91,3 +91,47 @@ func TestSchemaUpdatesAddFieldKindDateTimeWithCreate(t *testing.T) {
 	}
 	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
 }
+
+func TestSchemaUpdatesAddFieldKindDateTimeSubstitutionWithCreate(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "Test schema update, add field with kind datetime substitution with create",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users {
+						Name: String
+					}
+				`,
+			},
+			testUtils.SchemaPatch{
+				Patch: `
+					[
+						{ "op": "add", "path": "/Users/Schema/Fields/-", "value": {"Name": "Foo", "Kind": "DateTime"} }
+					]
+				`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `{
+					"Name": "John",
+					"Foo": "2017-07-23T03:46:56.647Z"
+				}`,
+			},
+			testUtils.Request{
+				Request: `query {
+					Users {
+						Name
+						Foo
+					}
+				}`,
+				Results: []map[string]any{
+					{
+						"Name": "John",
+						"Foo":  "2017-07-23T03:46:56.647Z",
+					},
+				},
+			},
+		},
+	}
+	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+}

--- a/tests/integration/schema/updates/add/field/kind/dockey_test.go
+++ b/tests/integration/schema/updates/add/field/kind/dockey_test.go
@@ -91,3 +91,47 @@ func TestSchemaUpdatesAddFieldKindDocKeyWithCreate(t *testing.T) {
 	}
 	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
 }
+
+func TestSchemaUpdatesAddFieldKindDocKeySubstitutionWithCreate(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "Test schema update, add field with kind DocKey substitution and create",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users {
+						Name: String
+					}
+				`,
+			},
+			testUtils.SchemaPatch{
+				Patch: `
+					[
+						{ "op": "add", "path": "/Users/Schema/Fields/-", "value": {"Name": "Foo", "Kind": "ID"} }
+					]
+				`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `{
+					"Name": "John",
+					"Foo": "nhgfdsfd"
+				}`,
+			},
+			testUtils.Request{
+				Request: `query {
+					Users {
+						Name
+						Foo
+					}
+				}`,
+				Results: []map[string]any{
+					{
+						"Name": "John",
+						"Foo":  "nhgfdsfd",
+					},
+				},
+			},
+		},
+	}
+	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+}

--- a/tests/integration/schema/updates/add/field/kind/float_array_test.go
+++ b/tests/integration/schema/updates/add/field/kind/float_array_test.go
@@ -91,3 +91,47 @@ func TestSchemaUpdatesAddFieldKindFloatArrayWithCreate(t *testing.T) {
 	}
 	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
 }
+
+func TestSchemaUpdatesAddFieldKindFloatArraySubstitutionWithCreate(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "Test schema update, add field with kind float array substitution with create",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users {
+						Name: String
+					}
+				`,
+			},
+			testUtils.SchemaPatch{
+				Patch: `
+					[
+						{ "op": "add", "path": "/Users/Schema/Fields/-", "value": {"Name": "Foo", "Kind": "[Float!]"} }
+					]
+				`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `{
+					"Name": "John",
+					"Foo": [3.1, -8.1, 0]
+				}`,
+			},
+			testUtils.Request{
+				Request: `query {
+					Users {
+						Name
+						Foo
+					}
+				}`,
+				Results: []map[string]any{
+					{
+						"Name": "John",
+						"Foo":  []float64{3.1, -8.1, 0},
+					},
+				},
+			},
+		},
+	}
+	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+}

--- a/tests/integration/schema/updates/add/field/kind/float_test.go
+++ b/tests/integration/schema/updates/add/field/kind/float_test.go
@@ -91,3 +91,47 @@ func TestSchemaUpdatesAddFieldKindFloatWithCreate(t *testing.T) {
 	}
 	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
 }
+
+func TestSchemaUpdatesAddFieldKindFloatSubstitutionWithCreate(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "Test schema update, add field with kind float substitution with create",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users {
+						Name: String
+					}
+				`,
+			},
+			testUtils.SchemaPatch{
+				Patch: `
+					[
+						{ "op": "add", "path": "/Users/Schema/Fields/-", "value": {"Name": "Foo", "Kind": "Float"} }
+					]
+				`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `{
+					"Name": "John",
+					"Foo": 3
+				}`,
+			},
+			testUtils.Request{
+				Request: `query {
+					Users {
+						Name
+						Foo
+					}
+				}`,
+				Results: []map[string]any{
+					{
+						"Name": "John",
+						"Foo":  float64(3),
+					},
+				},
+			},
+		},
+	}
+	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+}

--- a/tests/integration/schema/updates/add/field/kind/int_array_test.go
+++ b/tests/integration/schema/updates/add/field/kind/int_array_test.go
@@ -91,3 +91,47 @@ func TestSchemaUpdatesAddFieldKindIntArrayWithCreate(t *testing.T) {
 	}
 	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
 }
+
+func TestSchemaUpdatesAddFieldKindIntArraySubstitutionWithCreate(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "Test schema update, add field with kind int array substitution with create",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users {
+						Name: String
+					}
+				`,
+			},
+			testUtils.SchemaPatch{
+				Patch: `
+					[
+						{ "op": "add", "path": "/Users/Schema/Fields/-", "value": {"Name": "Foo", "Kind": "[Integer!]"} }
+					]
+				`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `{
+					"Name": "John",
+					"Foo": [3, 5, 8]
+				}`,
+			},
+			testUtils.Request{
+				Request: `query {
+					Users {
+						Name
+						Foo
+					}
+				}`,
+				Results: []map[string]any{
+					{
+						"Name": "John",
+						"Foo":  []int64{3, 5, 8},
+					},
+				},
+			},
+		},
+	}
+	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+}

--- a/tests/integration/schema/updates/add/field/kind/int_test.go
+++ b/tests/integration/schema/updates/add/field/kind/int_test.go
@@ -91,3 +91,47 @@ func TestSchemaUpdatesAddFieldKindIntWithCreate(t *testing.T) {
 	}
 	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
 }
+
+func TestSchemaUpdatesAddFieldKindIntSubstitutionWithCreate(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "Test schema update, add field with kind int substitution with create",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users {
+						Name: String
+					}
+				`,
+			},
+			testUtils.SchemaPatch{
+				Patch: `
+					[
+						{ "op": "add", "path": "/Users/Schema/Fields/-", "value": {"Name": "Foo", "Kind": "Integer"} }
+					]
+				`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `{
+					"Name": "John",
+					"Foo": 3
+				}`,
+			},
+			testUtils.Request{
+				Request: `query {
+					Users {
+						Name
+						Foo
+					}
+				}`,
+				Results: []map[string]any{
+					{
+						"Name": "John",
+						"Foo":  uint64(3),
+					},
+				},
+			},
+		},
+	}
+	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+}

--- a/tests/integration/schema/updates/add/field/kind/invalid_test.go
+++ b/tests/integration/schema/updates/add/field/kind/invalid_test.go
@@ -187,3 +187,27 @@ func TestSchemaUpdatesAddFieldKind198(t *testing.T) {
 	}
 	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
 }
+
+func TestSchemaUpdatesAddFieldKindInvalidSubstitution(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "Test schema update, add field with kind unsupported (198)",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users {
+						Name: String
+					}
+				`,
+			},
+			testUtils.SchemaPatch{
+				Patch: `
+					[
+						{ "op": "add", "path": "/Users/Schema/Fields/-", "value": {"Name": "Foo", "Kind": "InvalidKind"} }
+					]
+				`,
+				ExpectedError: "no type found for given name. Kind: InvalidKind",
+			},
+		},
+	}
+	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+}

--- a/tests/integration/schema/updates/add/field/kind/string_nil_array_test.go
+++ b/tests/integration/schema/updates/add/field/kind/string_nil_array_test.go
@@ -97,3 +97,51 @@ func TestSchemaUpdatesAddFieldKindNillableStringArrayWithCreate(t *testing.T) {
 	}
 	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
 }
+
+func TestSchemaUpdatesAddFieldKindNillableStringArraySubstitutionWithCreate(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "Test schema update, add field with kind nillable string array substitution with create",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users {
+						Name: String
+					}
+				`,
+			},
+			testUtils.SchemaPatch{
+				Patch: `
+					[
+						{ "op": "add", "path": "/Users/Schema/Fields/-", "value": {"Name": "Foo", "Kind": "[String]"} }
+					]
+				`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `{
+					"Name": "John",
+					"Foo": ["hello", "پدر سگ", null]
+				}`,
+			},
+			testUtils.Request{
+				Request: `query {
+					Users {
+						Name
+						Foo
+					}
+				}`,
+				Results: []map[string]any{
+					{
+						"Name": "John",
+						"Foo": []immutable.Option[string]{
+							immutable.Some("hello"),
+							immutable.Some("پدر سگ"),
+							immutable.None[string](),
+						},
+					},
+				},
+			},
+		},
+	}
+	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+}

--- a/tests/integration/schema/updates/add/field/kind/string_test.go
+++ b/tests/integration/schema/updates/add/field/kind/string_test.go
@@ -91,3 +91,47 @@ func TestSchemaUpdatesAddFieldKindStringWithCreate(t *testing.T) {
 	}
 	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
 }
+
+func TestSchemaUpdatesAddFieldKindStringSubstitutionWithCreate(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "Test schema update, add field with kind string substitution with create",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users {
+						Name: String
+					}
+				`,
+			},
+			testUtils.SchemaPatch{
+				Patch: `
+					[
+						{ "op": "add", "path": "/Users/Schema/Fields/-", "value": {"Name": "Foo", "Kind": "String"} }
+					]
+				`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `{
+					"Name": "John",
+					"Foo": "bar"
+				}`,
+			},
+			testUtils.Request{
+				Request: `query {
+					Users {
+						Name
+						Foo
+					}
+				}`,
+				Results: []map[string]any{
+					{
+						"Name": "John",
+						"Foo":  "bar",
+					},
+				},
+			},
+		},
+	}
+	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #1220

## Description

Adds field kind substitution for PatchSchema.

It does not block users from using the raw values if they want to.  I think this is important for two reasons, firstly - it would break the JSON patch spec IMO as they are blocked from patching a mutable property with valid values, secondly - I don't think we should stop them from doing so if they want to do that.

The code in `substituteSchemaPatch` is a bit unsightly, and contains a bit of duplication, however due to minor but annoying differences between the two refactoring it out did not result in nicer code at the moment.  When we add similar behaviour for other elements (field indexes, CRDTType) this should be revisited (we'll probs want to break up that func anyway to provide clean distinctions between the different elements being substituted, something I also dont think is nice or worth it now). 