### PR TITLE
test: Explicitly state change detector split for test

### DIFF
--- a/tests/integration/schema/simple_test.go
+++ b/tests/integration/schema/simple_test.go
@@ -52,6 +52,7 @@ func TestSchemaSimpleErrorsGivenDuplicateSchema(t *testing.T) {
 					type users {}
 				`,
 			},
+			testUtils.SetupComplete{},
 			testUtils.SchemaUpdate{
 				Schema: `
 					type users {}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #1227

## Description

Explicitly states the change detector split for `TestSchemaSimpleErrorsGivenDuplicateSchema`. This test caused the change detector to auto-split between setup and run incorrectly causing a test failure. Here we explicitly tell it to split between the two schema changes.