### PR TITLE
fix: Fix deadlock on memory-datastore Close

### DIFF
--- a/datastore/memory/txn_test.go
+++ b/datastore/memory/txn_test.go
@@ -707,9 +707,9 @@ func TestTxnWithConflict(t *testing.T) {
 		require.NoError(t, err)
 	}()
 
-	tx := s.newTransaction(false)
+	tx := s.newTransaction(false, false)
 
-	tx2 := s.newTransaction(false)
+	tx2 := s.newTransaction(false, false)
 
 	err := tx.Put(ctx, testKey3, testValue3)
 	require.NoError(t, err)
@@ -732,9 +732,9 @@ func TestTxnWithConflictAfterDelete(t *testing.T) {
 		require.NoError(t, err)
 	}()
 
-	tx := s.newTransaction(false)
+	tx := s.newTransaction(false, false)
 
-	tx2 := s.newTransaction(false)
+	tx2 := s.newTransaction(false, false)
 
 	err := tx.Put(ctx, testKey2, testValue3)
 	require.NoError(t, err)
@@ -757,9 +757,9 @@ func TestTxnWithConflictAfterGet(t *testing.T) {
 		require.NoError(t, err)
 	}()
 
-	tx := s.newTransaction(false)
+	tx := s.newTransaction(false, false)
 
-	tx2 := s.newTransaction(false)
+	tx2 := s.newTransaction(false, false)
 
 	_, err := tx.Get(ctx, testKey2)
 	require.NoError(t, err)


### PR DESCRIPTION
## Relevant issue(s)

Resolves #1154

## Description

Removes the datastore ability to double lock on `ds.closeLk`.

This was resulting in deadlock if an attempt was made to acquire the (write) lock after the first read lock was held, but before the second was held:

1. routine 1 - RLock held (e.g. in `datastore.Put`)
2. routine 2 - tries to acquire Lock (in `datastore.Close`)
3. routine 1 - tries to re-acquire RLock (e.g. in `txn.Put`), but routine 2 has reserved its acquisition, routine 1 is now blocked, and as it is blocked, it can never unlock the lock it holds (acquired in step 1), so routine 2 can never progress either.  

This deadlock scenario is explicitly warned against in the RWMutex documentation:

> If a goroutine holds a RWMutex for reading and another goroutine might
// call Lock, no goroutine should expect to be able to acquire a read lock
// until the initial read lock is released. In particular, this prohibits
// recursive read locking. This is to ensure that the lock eventually becomes
// available; a blocked Lock call excludes new readers from acquiring the
// lock.

This deadlock was almost certainly responsible for at least one of the flaky test failures, I do not know if there are other causes ofc, and we can reopen the linked ticket again if need be.

An alternative solution is to remove the sharing lock completely, I prefer this: https://github.com/sourcenetwork/defradb/pull/1273
Another channel based approach is this: https://github.com/sourcenetwork/defradb/pull/1274