### PR TITLE
docs: Document client Description types

### DIFF
--- a/client/descriptions.go
+++ b/client/descriptions.go
@@ -18,7 +18,7 @@ import (
 type CollectionDescription struct {
 	// Name contains the name of the collection.
 	//
-	// It is conceptually local to node hosting the DefraDB instance, but currently there
+	// It is conceptually local to the node hosting the DefraDB instance, but currently there
 	// is no means to update the local value so that it differs from the (global) schema name.
 	Name string
 


### PR DESCRIPTION
## Relevant issue(s)

Resolves #1306

## Description

Documents the client Description types and removes some dead code.

Following this PR the only real other totally undocumented stuff in client is the Document related stuff, and that is quite dirty and in need of a rework I think soon anyway, I also see it as less important at the moment, so I wont go over it for 0.5.
