### PR TITLE
fix: Remove client Create/UpdateCollection

### DIFF
--- a/client/db.go
+++ b/client/db.go
@@ -106,12 +106,6 @@ type Store interface {
 	// [FieldKindStringToEnumMapping].
 	PatchSchema(context.Context, string) error
 
-	// CreateCollection creates a new collection using the given description.
-	//
-	// WARNING: It does not currently update the GQL types, and as such a database restart is required after
-	// calling this if use of the new collection via GQL is desired (for example via [ExecRequest]).
-	CreateCollection(context.Context, CollectionDescription) (Collection, error)
-
 	// GetCollectionByName attempts to retrieve a collection matching the given name.
 	//
 	// If no matching collection is found an error will be returned.

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -49,31 +49,11 @@ func TestNewDB(t *testing.T) {
 	}
 }
 
-func TestNewDBWithCollection_Errors_GivenNoSchema(t *testing.T) {
-	ctx := context.Background()
-	opts := badgerds.Options{Options: badger.DefaultOptions("").WithInMemory(true)}
-	rootstore, err := badgerds.NewDatastore("", &opts)
-	if err != nil {
-		t.Error(err)
-	}
-
-	db, err := NewDB(ctx, rootstore)
-	if err != nil {
-		t.Error(err)
-	}
-
-	_, err = db.CreateCollection(ctx, client.CollectionDescription{
-		Name: "test",
-	})
-
-	assert.Error(t, err)
-}
-
 func TestDBSaveSimpleDocument(t *testing.T) {
 	ctx := context.Background()
 	db, err := newMemoryDB(ctx)
 	assert.NoError(t, err)
-	col, err := newTestCollectionWithSchema(ctx, db)
+	col, err := newTestCollectionWithSchema(t, ctx, db)
 	assert.NoError(t, err)
 
 	testJSONObj := []byte(`{
@@ -115,7 +95,7 @@ func TestDBUpdateDocument(t *testing.T) {
 	ctx := context.Background()
 	db, err := newMemoryDB(ctx)
 	assert.NoError(t, err)
-	col, err := newTestCollectionWithSchema(ctx, db)
+	col, err := newTestCollectionWithSchema(t, ctx, db)
 	assert.NoError(t, err)
 
 	testJSONObj := []byte(`{
@@ -165,7 +145,7 @@ func TestDBUpdateNonExistingDocument(t *testing.T) {
 	ctx := context.Background()
 	db, err := newMemoryDB(ctx)
 	assert.NoError(t, err)
-	col, err := newTestCollectionWithSchema(ctx, db)
+	col, err := newTestCollectionWithSchema(t, ctx, db)
 	assert.NoError(t, err)
 
 	testJSONObj := []byte(`{
@@ -188,7 +168,7 @@ func TestDBUpdateExistingDocument(t *testing.T) {
 	ctx := context.Background()
 	db, err := newMemoryDB(ctx)
 	assert.NoError(t, err)
-	col, err := newTestCollectionWithSchema(ctx, db)
+	col, err := newTestCollectionWithSchema(t, ctx, db)
 	assert.NoError(t, err)
 
 	testJSONObj := []byte(`{
@@ -231,7 +211,7 @@ func TestDBGetDocument(t *testing.T) {
 	ctx := context.Background()
 	db, err := newMemoryDB(ctx)
 	assert.NoError(t, err)
-	col, err := newTestCollectionWithSchema(ctx, db)
+	col, err := newTestCollectionWithSchema(t, ctx, db)
 	assert.NoError(t, err)
 
 	testJSONObj := []byte(`{
@@ -272,7 +252,7 @@ func TestDBGetNotFoundDocument(t *testing.T) {
 	ctx := context.Background()
 	db, err := newMemoryDB(ctx)
 	assert.NoError(t, err)
-	col, err := newTestCollectionWithSchema(ctx, db)
+	col, err := newTestCollectionWithSchema(t, ctx, db)
 	assert.NoError(t, err)
 
 	key, err := client.NewDocKeyFromString("bae-09cd7539-9b86-5661-90f6-14fbf6c1a14d")
@@ -285,7 +265,7 @@ func TestDBDeleteDocument(t *testing.T) {
 	ctx := context.Background()
 	db, err := newMemoryDB(ctx)
 	assert.NoError(t, err)
-	col, err := newTestCollectionWithSchema(ctx, db)
+	col, err := newTestCollectionWithSchema(t, ctx, db)
 	assert.NoError(t, err)
 
 	testJSONObj := []byte(`{
@@ -311,7 +291,7 @@ func TestDBDeleteNotFoundDocument(t *testing.T) {
 	ctx := context.Background()
 	db, err := newMemoryDB(ctx)
 	assert.NoError(t, err)
-	col, err := newTestCollectionWithSchema(ctx, db)
+	col, err := newTestCollectionWithSchema(t, ctx, db)
 	assert.NoError(t, err)
 
 	key, err := client.NewDocKeyFromString("bae-09cd7539-9b86-5661-90f6-14fbf6c1a14d")
@@ -325,7 +305,7 @@ func TestDocumentMerkleDAG(t *testing.T) {
 	ctx := context.Background()
 	db, err := newMemoryDB(ctx)
 	assert.NoError(t, err)
-	col, err := newTestCollectionWithSchema(ctx, db)
+	col, err := newTestCollectionWithSchema(t, ctx, db)
 	assert.NoError(t, err)
 
 	testJSONObj := []byte(`{
@@ -405,7 +385,7 @@ func TestDBSchemaSaveSimpleDocument(t *testing.T) {
 	ctx := context.Background()
 	db, err := newMemoryDB(ctx)
 	assert.NoError(t, err)
-	col, err := newTestCollectionWithSchema(ctx, db)
+	col, err := newTestCollectionWithSchema(t, ctx, db)
 	assert.NoError(t, err)
 
 	testJSONObj := []byte(`{

--- a/db/fetcher_test.go
+++ b/db/fetcher_test.go
@@ -112,7 +112,7 @@ func TestFetcherGetAllPrimaryIndexEncodedDocSingle(t *testing.T) {
 	db, err := newMemoryDB(ctx)
 	assert.NoError(t, err)
 
-	col, err := newTestCollectionWithSchema(ctx, db)
+	col, err := newTestCollectionWithSchema(t, ctx, db)
 	assert.NoError(t, err)
 
 	doc, err := client.NewDocFromJSON([]byte(`{
@@ -149,7 +149,7 @@ func TestFetcherGetAllPrimaryIndexEncodedDocMultiple(t *testing.T) {
 	db, err := newMemoryDB(ctx)
 	assert.NoError(t, err)
 
-	col, err := newTestCollectionWithSchema(ctx, db)
+	col, err := newTestCollectionWithSchema(t, ctx, db)
 	assert.NoError(t, err)
 
 	doc, err := client.NewDocFromJSON([]byte(`{
@@ -197,7 +197,7 @@ func TestFetcherGetAllPrimaryIndexDecodedSingle(t *testing.T) {
 	db, err := newMemoryDB(ctx)
 	assert.NoError(t, err)
 
-	col, err := newTestCollectionWithSchema(ctx, db)
+	col, err := newTestCollectionWithSchema(t, ctx, db)
 	assert.NoError(t, err)
 
 	doc, err := client.NewDocFromJSON([]byte(`{
@@ -241,7 +241,7 @@ func TestFetcherGetAllPrimaryIndexDecodedMultiple(t *testing.T) {
 	db, err := newMemoryDB(ctx)
 	assert.NoError(t, err)
 
-	col, err := newTestCollectionWithSchema(ctx, db)
+	col, err := newTestCollectionWithSchema(t, ctx, db)
 	assert.NoError(t, err)
 
 	doc, err := client.NewDocFromJSON([]byte(`{
@@ -306,7 +306,7 @@ func TestFetcherGetOnePrimaryIndexDecoded(t *testing.T) {
 	db, err := newMemoryDB(ctx)
 	assert.NoError(t, err)
 
-	col, err := newTestCollectionWithSchema(ctx, db)
+	col, err := newTestCollectionWithSchema(t, ctx, db)
 	assert.NoError(t, err)
 
 	doc, err := client.NewDocFromJSON([]byte(`{

--- a/db/p2p_collection_test.go
+++ b/db/p2p_collection_test.go
@@ -19,7 +19,12 @@ import (
 	"github.com/sourcenetwork/defradb/client"
 )
 
-func newTestCollection(ctx context.Context, db client.DB, name string) (client.Collection, error) {
+func newTestCollection(
+	t *testing.T,
+	ctx context.Context,
+	db *implicitTxnDB,
+	name string,
+) client.Collection {
 	desc := client.CollectionDescription{
 		Name: name,
 		Schema: client.SchemaDescription{
@@ -37,7 +42,16 @@ func newTestCollection(ctx context.Context, db client.DB, name string) (client.C
 		},
 	}
 
-	return db.CreateCollection(ctx, desc)
+	txn, err := db.db.NewTxn(ctx, false)
+	require.NoError(t, err)
+
+	col, err := db.db.createCollection(ctx, txn, desc)
+	require.NoError(t, err)
+
+	err = txn.Commit(ctx)
+	require.NoError(t, err)
+
+	return col
 }
 
 func TestAddP2PCollection(t *testing.T) {
@@ -46,8 +60,7 @@ func TestAddP2PCollection(t *testing.T) {
 	require.NoError(t, err)
 	defer db.Close(ctx)
 
-	col, err := newTestCollection(ctx, db, "test")
-	require.NoError(t, err)
+	col := newTestCollection(t, ctx, db, "test")
 
 	err = db.AddP2PCollection(ctx, col.SchemaID())
 	require.NoError(t, err)
@@ -59,18 +72,15 @@ func TestGetAllP2PCollection(t *testing.T) {
 	require.NoError(t, err)
 	defer db.Close(ctx)
 
-	col1, err := newTestCollection(ctx, db, "test1")
-	require.NoError(t, err)
+	col1 := newTestCollection(t, ctx, db, "test1")
 	err = db.AddP2PCollection(ctx, col1.SchemaID())
 	require.NoError(t, err)
 
-	col2, err := newTestCollection(ctx, db, "test2")
-	require.NoError(t, err)
+	col2 := newTestCollection(t, ctx, db, "test2")
 	err = db.AddP2PCollection(ctx, col2.SchemaID())
 	require.NoError(t, err)
 
-	col3, err := newTestCollection(ctx, db, "test3")
-	require.NoError(t, err)
+	col3 := newTestCollection(t, ctx, db, "test3")
 	err = db.AddP2PCollection(ctx, col3.SchemaID())
 	require.NoError(t, err)
 
@@ -85,18 +95,15 @@ func TestRemoveP2PCollection(t *testing.T) {
 	require.NoError(t, err)
 	defer db.Close(ctx)
 
-	col1, err := newTestCollection(ctx, db, "test1")
-	require.NoError(t, err)
+	col1 := newTestCollection(t, ctx, db, "test1")
 	err = db.AddP2PCollection(ctx, col1.SchemaID())
 	require.NoError(t, err)
 
-	col2, err := newTestCollection(ctx, db, "test2")
-	require.NoError(t, err)
+	col2 := newTestCollection(t, ctx, db, "test2")
 	err = db.AddP2PCollection(ctx, col2.SchemaID())
 	require.NoError(t, err)
 
-	col3, err := newTestCollection(ctx, db, "test3")
-	require.NoError(t, err)
+	col3 := newTestCollection(t, ctx, db, "test3")
 	err = db.AddP2PCollection(ctx, col3.SchemaID())
 	require.NoError(t, err)
 

--- a/db/txn_db.go
+++ b/db/txn_db.go
@@ -31,32 +31,6 @@ type explicitTxnDB struct {
 	txn datastore.Txn
 }
 
-func (db *implicitTxnDB) CreateCollection(
-	ctx context.Context,
-	desc client.CollectionDescription,
-) (client.Collection, error) {
-	txn, err := db.NewTxn(ctx, false)
-	if err != nil {
-		return nil, err
-	}
-	defer txn.Discard(ctx)
-
-	col, err := db.createCollection(ctx, txn, desc)
-	if err != nil {
-		return nil, err
-	}
-
-	err = txn.Commit(ctx)
-	return col, err
-}
-
-func (db *explicitTxnDB) CreateCollection(
-	ctx context.Context,
-	desc client.CollectionDescription,
-) (client.Collection, error) {
-	return db.createCollection(ctx, db.txn, desc)
-}
-
 // ExecRequest executes a request against the database.
 func (db *implicitTxnDB) ExecRequest(ctx context.Context, request string) *client.RequestResult {
 	txn, err := db.NewTxn(ctx, false)


### PR DESCRIPTION
## Relevant issue(s)

Resolves #1308

## Description

Removes the client CreateCollection, UpdateCollection, ValidateUpdateCollection functions as Create and Update only partially updateed the database (did not handle GQL types), and ValidateUpdateCollection makes no sense to stay public without UpdateCollection.

A bunch of tests in the db package referenced CreateCollection and had to be updated to use the internal function.

Part of the DefraDB project, but there is stupid arbitrary limit on the number of items our overlords at Microsoft/Github allow us to have in any one project so I cant add it properly.