### PR TITLE
fix: CLI to display specific command usage help

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -49,12 +49,12 @@ func Execute() {
 	rootCmd.SilenceUsage = true
 	rootCmd.SilenceErrors = true
 	rootCmd.SetOut(os.Stdout)
-	err := rootCmd.ExecuteContext(ctx)
+	cmd, err := rootCmd.ExecuteContextC(ctx)
 	if err != nil {
 		for _, cobraError := range usageErrors {
 			if strings.HasPrefix(err.Error(), cobraError) {
 				log.FeedbackErrorE(ctx, "Usage error", err)
-				if usageErr := rootCmd.Usage(); usageErr != nil {
+				if usageErr := cmd.Usage(); usageErr != nil {
 					log.FeedbackFatalE(ctx, "error displaying usage help", usageErr)
 				}
 				os.Exit(1)


### PR DESCRIPTION
## Relevant issue(s)

Resolves #1313

## Description

Print the specific command's usage text instead of always printing root command's usage text, on user error.

## Tasks

- [ ] I made sure the code is well commented, particularly hard-to-understand areas.
- [ ] I made sure the repository-held documentation is changed accordingly.
- [ ] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [ ] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

manually