### PR TITLE
fix: Only check for events queue on subscription request

### DIFF
--- a/db/subscriptions.go
+++ b/db/subscriptions.go
@@ -24,24 +24,26 @@ func (db *db) checkForClientSubscriptions(r *request.Request) (
 	*request.ObjectSubscription,
 	error,
 ) {
-	if len(r.Subscription) > 0 && len(r.Subscription[0].Selections) > 0 {
-		if !db.events.Updates.HasValue() {
-			return nil, nil, ErrSubscriptionsNotAllowed
-		}
-
-		s := r.Subscription[0].Selections[0]
-		if subRequest, ok := s.(*request.ObjectSubscription); ok {
-			pub, err := events.NewPublisher(db.events.Updates.Value(), 5)
-			if err != nil {
-				return nil, nil, err
-			}
-
-			return pub, subRequest, nil
-		}
-
-		return nil, nil, client.NewErrUnexpectedType[request.ObjectSubscription]("SubscriptionSelection", s)
+	if len(r.Subscription) == 0 || len(r.Subscription[0].Selections) == 0 {
+		// This is not a subscription request and we have nothing to do here
+		return nil, nil, nil
 	}
-	return nil, nil, nil
+
+	if !db.events.Updates.HasValue() {
+		return nil, nil, ErrSubscriptionsNotAllowed
+	}
+
+	s := r.Subscription[0].Selections[0]
+	if subRequest, ok := s.(*request.ObjectSubscription); ok {
+		pub, err := events.NewPublisher(db.events.Updates.Value(), 5)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		return pub, subRequest, nil
+	}
+
+	return nil, nil, client.NewErrUnexpectedType[request.ObjectSubscription]("SubscriptionSelection", s)
 }
 
 func (db *db) handleSubscription(


### PR DESCRIPTION
## Relevant issue(s)

Resolves #1189

## Description

Only checks for the events queue on subscription request.  This makes the optional `WithUpdateEvents` database (constructor) option optional again (it would error without it for any kind of non-introspection request).

Tested by running a few of the integration tests having hacked away the WithUpdateEvents db option in utils2.go, also checked that without the fix the hacks would result in an error.

As the integration test framework does not allow for db configuration atm, and we are planning on releasing today I am skimping on adding proper automated tests for this right now.