### PR TITLE
fix: Improve error message for NonNull GQL types

### DIFF
--- a/request/graphql/schema/collection.go
+++ b/request/graphql/schema/collection.go
@@ -228,6 +228,9 @@ func astTypeToKind(t ast.Type) (client.FieldKind, error) {
 			return client.FieldKind_FOREIGN_OBJECT, nil
 		}
 
+	case *ast.NonNull:
+		return 0, ErrNonNullNotSupported
+
 	default:
 		return 0, NewErrTypeNotFound(t.String())
 	}

--- a/request/graphql/schema/errors.go
+++ b/request/graphql/schema/errors.go
@@ -36,6 +36,9 @@ var (
 	ErrRelationMissingTypes      = errors.New("relation is missing its defined types and fields")
 	ErrRelationInvalidType       = errors.New("relation has an invalid type to be finalize")
 	ErrMultipleRelationPrimaries = errors.New("relation can only have a single field set as primary")
+	// NonNull is the literal name of the GQL type, so we have to disable the linter
+	//nolint:revive
+	ErrNonNullNotSupported = errors.New("NonNull fields are not currently supported")
 )
 
 func NewErrDuplicateField(objectName, fieldName string) error {

--- a/tests/integration/schema/simple_test.go
+++ b/tests/integration/schema/simple_test.go
@@ -222,7 +222,7 @@ func TestSchemaSimpleErrorsGivenNonNullField(t *testing.T) {
 						email: String!
 					}
 				`,
-				ExpectedError: "no type found for given name. Type: NonNull",
+				ExpectedError: "NonNull fields are not currently supported",
 			},
 		},
 	}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #1192

## Description

Improves the error message when attempting to declare a GQL schema with a NonNull field type.
