### PR TITLE
ci: Bump go version within packer for AWS AMI

### DIFF
--- a/.github/workflows/build-ami-with-packer.yml
+++ b/.github/workflows/build-ami-with-packer.yml
@@ -16,7 +16,7 @@ on:
 
 env:
   PACKER_LOG: 1
-  # RELEASE_VERSION: v0.4.0
+  # RELEASE_VERSION: v0.5.0
 
 jobs:
   build-ami-with-packer:

--- a/tools/cloud/aws/packer/build_aws_ami.pkr.hcl
+++ b/tools/cloud/aws/packer/build_aws_ami.pkr.hcl
@@ -70,8 +70,8 @@ build {
     inline = [
       "/usr/bin/cloud-init status --wait",
       "sudo apt-get update && sudo apt-get install make build-essential -y",
-      "curl -OL https://golang.org/dl/go1.18.5.linux-amd64.tar.gz",
-      "rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.18.5.linux-amd64.tar.gz",
+      "curl -OL https://golang.org/dl/go1.19.8.linux-amd64.tar.gz",
+      "rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.19.8.linux-amd64.tar.gz",
       "export PATH=$PATH:/usr/local/go/bin",
       "git clone \"https://git:$ONLY_DEFRADB_REPO_CI_PAT@$DEFRADB_GIT_REPO\"",
       "cd ./defradb || { printf \"\\\ncd into defradb failed.\\\n\" && exit 2; }",


### PR DESCRIPTION
## Relevant issue(s)
Resolves #1343

## Description
Fixes the issue by bumping Golang dependency it will build to `v1.19.8`.

## How has this been tested?
Manually on `v0.5.0`, here is the passing action: https://github.com/sourcenetwork/defradb/actions/runs/4684981654/jobs/8301658218

Specify the platform(s) on which this was tested:
- WSL2 (Manjaro)
