### PR TITLE
fix: Guarantee event processing order

### DIFF
--- a/events/events.go
+++ b/events/events.go
@@ -41,8 +41,8 @@ var _ Channel[int] = (*simpleChannel[int])(nil)
 //
 // At the moment this will always return a new simpleChannel, however that may change in
 // the future as this feature gets fleshed out.
-func New[T any](subscriberBufferSize int, eventBufferSize int) Channel[T] {
-	return NewSimpleChannel[T](subscriberBufferSize, eventBufferSize)
+func New[T any](commandBufferSize int, eventBufferSize int) Channel[T] {
+	return NewSimpleChannel[T](commandBufferSize, eventBufferSize)
 }
 
 // Events hold the supported event types

--- a/events/simple.go
+++ b/events/simple.go
@@ -16,6 +16,9 @@ type simpleChannel[T any] struct {
 	//
 	// It is important that all stuff gets sent through this single channel to ensure
 	// that the order of operations is preserved.
+	//
+	// WARNING: This does mean that non-event commands can block the database if the buffer
+	// size is breached (e.g. if many subscribe commands occupy the buffer).
 	commandChannel  chan any
 	eventBufferSize int
 	hasClosedChan   chan struct{}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #1351 #1349
May also resolve much of the current test flakiness, but there may be other underlying issues so I'll leave those open for a bit. It does not resolve all of the flakiness and I have seen one P2P local failure on this branch (logged in https://github.com/sourcenetwork/defradb/issues/1338 )

## Description

Modifies the simpleChannel to guarantee the processing order of stuff. 

The previous solution did not do this, and allowed new subscriptions to pick up database events that had previously occurred but had not yet been processed by `handleChannel`.

A common scenario for how this can result in a test failure is documented in #1351

Also includes a fix for https://github.com/sourcenetwork/defradb/issues/1349 as I believe it occurs in the same part of the codebase, for similar reasons, and there is no point putting up a second, dependant review for it.