### PR TITLE
docs: Add codcov and go report card badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+![Tests Workflow](https://github.com/sourcenetwork/defradb/actions/workflows/run-tests.yml/badge.svg)
+[![Go Report Card](https://goreportcard.com/badge/github.com/sourcenetwork/defradb)](https://goreportcard.com/report/github.com/sourcenetwork/defradb)
+[![codecov](https://codecov.io/gh/sourcenetwork/defradb/branch/develop/graph/badge.svg?token=RHAORX13PA)](https://codecov.io/gh/sourcenetwork/defradb)
+[![Discord](https://img.shields.io/discord/427944769851752448.svg?color=768AD4&label=discord&logo=https%3A%2F%2Fdiscordapp.com%2Fassets%2F8c9701b98ad4372b58f13fd9f65f966e.svg)](https://discord.source.network/)
+[![Twitter Follow](https://img.shields.io/twitter/follow/sourcenetwrk.svg?label=&style=social)](https://twitter.com/sourcenetwrk)
+
 <p align="center">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="docs/DefraDB_White.svg">


### PR DESCRIPTION
## Relevant issue(s)
Resolves #1353

## Description
- Add go report card badge
- Add code coverage badge
- Add test action status badge
- Add twitter badge
- Add discord badge


Can check how it looks here: https://github.com/sourcenetwork/defradb/tree/lone/docs/badges
