### PR TITLE
fix: Unlock replicator lock before returning error

### DIFF
--- a/net/peer.go
+++ b/net/peer.go
@@ -370,6 +370,7 @@ func (p *Peer) setReplicator(
 	for _, col := range collections {
 		if reps, exists := p.replicators[col.SchemaID()]; exists {
 			if _, exists := reps[pid]; exists {
+				p.mu.Unlock()
 				return pid, errors.New(fmt.Sprintf(
 					"Replicator already exists for %s with ID %s",
 					col.Name(),


### PR DESCRIPTION
## Relevant issue(s)

Resolves #1367

## Description

Unlocks a lock that is held before returning an error.

Unlikely to be tripping up any of our tests, but is undesirable and should be fixed. 
