### PR TITLE
fix: Improve P2P event handling

### DIFF
--- a/net/peer.go
+++ b/net/peer.go
@@ -125,10 +125,7 @@ func NewPeer(
 	if err != nil {
 		return nil, err
 	}
-	err = p.loadP2PCollections(p.ctx)
-	if err != nil {
-		return nil, err
-	}
+
 	p.setupBlockService()
 	p.setupDAGService()
 
@@ -258,7 +255,7 @@ func (p *Peer) RegisterNewDocument(
 	)
 
 	// register topic
-	if err := p.server.addPubSubTopic(dockey.String(), true); err != nil {
+	if err := p.server.addPubSubTopic(dockey.String(), !p.server.hasPubSubTopic(schemaID)); err != nil {
 		log.ErrorE(
 			p.ctx,
 			"Failed to create new pubsub topic",
@@ -607,20 +604,21 @@ func (p *Peer) loadReplicators(ctx context.Context) error {
 	return nil
 }
 
-func (p *Peer) loadP2PCollections(ctx context.Context) error {
+func (p *Peer) loadP2PCollections(ctx context.Context) (map[string]struct{}, error) {
 	collections, err := p.db.GetAllP2PCollections(ctx)
 	if err != nil && !errors.Is(err, ds.ErrNotFound) {
-		return err
+		return nil, err
 	}
-
+	colMap := make(map[string]struct{})
 	for _, col := range collections {
 		err := p.server.addPubSubTopic(col, true)
 		if err != nil {
-			return err
+			return nil, err
 		}
+		colMap[col] = struct{}{}
 	}
 
-	return nil
+	return colMap, nil
 }
 
 func (p *Peer) handleDocCreateLog(evt events.Update) error {
@@ -629,10 +627,16 @@ func (p *Peer) handleDocCreateLog(evt events.Update) error {
 		return errors.Wrap("failed to get DocKey from broadcast message", err)
 	}
 
+	// We need to register the document before pushing to the replicators if we want to
+	// ensure that we have subscribed to the topic.
+	err = p.RegisterNewDocument(p.ctx, dockey, evt.Cid, evt.Block, evt.SchemaID)
+	if err != nil {
+		return err
+	}
 	// push to each peer (replicator)
 	p.pushLogToReplicators(p.ctx, evt)
 
-	return p.RegisterNewDocument(p.ctx, dockey, evt.Cid, evt.Block, evt.SchemaID)
+	return nil
 }
 
 func (p *Peer) handleDocUpdateLog(evt events.Update) error {
@@ -804,6 +808,30 @@ func (p *Peer) AddP2PCollections(collections []string) error {
 		addedTopics = append(addedTopics, col)
 	}
 
+	// If adding the collection topics succeeds, we remove the collections' documents
+	// from the pubsub topics to avoid receiving duplicate events.
+	for _, col := range collections {
+		c, err := store.GetCollectionBySchemaID(p.ctx, col)
+		if err != nil {
+			return err
+		}
+		keyChan, err := c.GetAllDocKeys(p.ctx)
+		if err != nil {
+			return err
+		}
+		for key := range keyChan {
+			err := p.server.removePubSubTopic(key.Key.String())
+			if err != nil {
+				log.Info(
+					p.ctx,
+					"Failed to remove doc from pubsub topic",
+					logging.NewKV("DocKey", key.Key.String()),
+					logging.NewKV("Cause", err),
+				)
+			}
+		}
+	}
+
 	return txn.Commit(p.ctx)
 }
 
@@ -848,6 +876,30 @@ func (p *Peer) RemoveP2PCollections(collections []string) error {
 				}
 			}
 			return err
+		}
+	}
+
+	// If removing the collection topics succeeds, we add back the collections' documents
+	// to the pubsub topics.
+	for _, col := range collections {
+		c, err := store.GetCollectionBySchemaID(p.ctx, col)
+		if err != nil {
+			return err
+		}
+		keyChan, err := c.GetAllDocKeys(p.ctx)
+		if err != nil {
+			return err
+		}
+		for key := range keyChan {
+			err := p.server.addPubSubTopic(key.Key.String(), true)
+			if err != nil {
+				log.Info(
+					p.ctx,
+					"Failed to add doc to pubsub topic",
+					logging.NewKV("DocKey", key.Key.String()),
+					logging.NewKV("Cause", err),
+				)
+			}
 		}
 	}
 

--- a/net/peer.go
+++ b/net/peer.go
@@ -767,6 +767,8 @@ type EvtPubSub struct {
 //
 // It will error if any of the given collectionIDs are invalid, in such a case some of the
 // changes to the server may still be applied.
+//
+// WARNING: Calling this on collections with a large number of documents may take a long time to process.
 func (p *Peer) AddP2PCollections(collections []string) error {
 	txn, err := p.db.NewTxn(p.ctx, false)
 	if err != nil {
@@ -839,6 +841,8 @@ func (p *Peer) AddP2PCollections(collections []string) error {
 //
 // It will error if any of the given collectionIDs are invalid, in such a case some of the
 // changes to the server may still be applied.
+//
+// WARNING: Calling this on collections with a large number of documents may take a long time to process.
 func (p *Peer) RemoveP2PCollections(collections []string) error {
 	txn, err := p.db.NewTxn(p.ctx, false)
 	if err != nil {

--- a/tests/integration/p2p.go
+++ b/tests/integration/p2p.go
@@ -317,6 +317,8 @@ func configureReplicator(
 				docIDsSyncedToSource[currentdocID] = struct{}{}
 			}
 
+			// A document created on the source or one that is created on all nodes will be sent to the target even
+			// it already has it. It will create a `received push log` event on the target which we need to wait for.
 			if !action.NodeID.HasValue() || action.NodeID.Value() == cfg.SourceNodeID {
 				sourceToTargetEvents[waitIndex] += 1
 			}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #1334
Resolves #1335 
Resolves #1336
Resolves #1337
Resolves #1338
Resolves #1375

## Description

This PR seems to have fixed all known flakyness from the P2P integration tests. It does so at different levels:
1. We prevent pre peer connection and pre replicator configuration actions from having their events received by the wait function by adding a 100ms sleep call pre setup.
2. We ensure that the wait go routines are ready before continuing with the actions.
3. We add a docQueue to the PushLog function so that we don't handle multiple updates to the same document at once. This helps avoid unnecessary transaction conflicts. This would also sometimes cause the PushLog function to hang and the RPC call hitting a timeout.
4. We handle pubsub topic subscriptions a little better by subscribing only to the collection **OR** the documents. Subscribing to documents and the collection would cause double the event handling.


## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Integration test (a 6 hour run without errors)

Specify the platform(s) on which this was tested:
- Github CI
- MacOS
