### PR TITLE
fix: Do not commit if errors have been returned

### DIFF
--- a/db/txn_db.go
+++ b/db/txn_db.go
@@ -42,6 +42,9 @@ func (db *implicitTxnDB) ExecRequest(ctx context.Context, request string) *clien
 	defer txn.Discard(ctx)
 
 	res := db.execRequest(ctx, request, txn)
+	if len(res.GQL.Errors) > 0 {
+		return res
+	}
 
 	if err := txn.Commit(ctx); err != nil {
 		res.GQL.Errors = []error{err}

--- a/tests/integration/mutation/simple/create/simple_test.go
+++ b/tests/integration/mutation/simple/create/simple_test.go
@@ -37,6 +37,7 @@ func TestMutationCreateSimpleErrorsGivenNonExistantField(t *testing.T) {
 				ExpectedError: "The given field does not exist. Name: fieldDoesNotExist",
 			},
 			testUtils.Request{
+				// Ensure that no documents have been written.
 				Request: `
 					query {
 						Users {
@@ -44,11 +45,7 @@ func TestMutationCreateSimpleErrorsGivenNonExistantField(t *testing.T) {
 						}
 					}
 				`,
-				Results: []map[string]any{
-					{
-						"name": "John",
-					},
-				},
+				Results: []map[string]any{},
 			},
 		},
 	}

--- a/tests/integration/mutation/simple/create/simple_test.go
+++ b/tests/integration/mutation/simple/create/simple_test.go
@@ -17,6 +17,45 @@ import (
 	simpleTests "github.com/sourcenetwork/defradb/tests/integration/mutation/simple"
 )
 
+func TestMutationCreateSimpleErrorsGivenNonExistantField(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "Simple create mutation with non existant field",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users {
+						name: String
+					}
+				`,
+			},
+			testUtils.Request{
+				Request: `mutation {
+							create_Users(data: "{\"name\": \"John\",\"fieldDoesNotExist\": 27}") {
+								_key
+							}
+						}`,
+				ExpectedError: "The given field does not exist. Name: fieldDoesNotExist",
+			},
+			testUtils.Request{
+				Request: `
+					query {
+						Users {
+							name
+						}
+					}
+				`,
+				Results: []map[string]any{
+					{
+						"name": "John",
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+}
+
 func TestMutationCreateSimple(t *testing.T) {
 	test := testUtils.RequestTestCase{
 		Description: "Simple create mutation",


### PR DESCRIPTION
## Relevant issue(s)

Resolves #1382

## Description

Does not commit if errors have been returned.  This allowed changes to be persisted on error.

Note: First commit documents the error, second commit fixes it.