### PR TITLE
ci: Allow CI to work from forked repo

### DIFF
--- a/.github/workflows/code-test-coverage.yml
+++ b/.github/workflows/code-test-coverage.yml
@@ -36,7 +36,6 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
           files: ./coverage.txt
           flags: defra-tests

--- a/.github/workflows/code-test-coverage.yml
+++ b/.github/workflows/code-test-coverage.yml
@@ -10,7 +10,11 @@
 
 name: Code Test Coverage Workflow
 
-on: [push]
+on:
+  pull_request:
+
+  push:
+
 
 jobs:
   code-test-coverage:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,7 +10,10 @@
 
 name: Run Tests Workflow
 
-on: [push]
+on:
+  pull_request:
+
+  push:
 
 jobs:
   run-tests:


### PR DESCRIPTION
## Relevant issue(s)

Resolves #1391

## Description

Removes code cov token from the code cov workflow, and changes the tests workflows to run on pull request.
