### PR TITLE
fix: Serialize DB errors to json in http package

### DIFF
--- a/api/http/handlerfuncs.go
+++ b/api/http/handlerfuncs.go
@@ -151,7 +151,7 @@ func execGQLHandler(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	sendJSON(req.Context(), rw, result.GQL, http.StatusOK)
+	sendJSON(req.Context(), rw, newGQLResult(result.GQL), http.StatusOK)
 }
 
 func loadSchemaHandler(rw http.ResponseWriter, req *http.Request) {

--- a/api/http/handlerfuncs_test.go
+++ b/api/http/handlerfuncs_test.go
@@ -325,7 +325,7 @@ func TestExecGQLHandlerContentTypeJSON(t *testing.T) {
 		) {_key}
 	}"
 }`
-	// remote line returns and tabulation from formatted statement
+	// remove line returns and tabulation from formatted statement
 	stmt = strings.ReplaceAll(strings.ReplaceAll(stmt, "\t", ""), "\n", "")
 
 	buf := bytes.NewBuffer([]byte(stmt))
@@ -357,17 +357,18 @@ func TestExecGQLHandlerContentTypeJSONWithError(t *testing.T) {
 
 	// add document
 	stmt := `
-{
-	"query": "mutation {
-		create_user(
-			data: \"{
-				\\\"age\\\": 31,
-				\\\"notAField\\\": true
-			}\"
-		) {_key}
-	}"
-}`
-	// remote line returns and tabulation from formatted statement
+	{
+		"query": "mutation {
+			create_user(
+				data: \"{
+					\\\"age\\\": 31,
+					\\\"notAField\\\": true
+				}\"
+			) {_key}
+		}"
+	}`
+
+	// remove line returns and tabulation from formatted statement
 	stmt = strings.ReplaceAll(strings.ReplaceAll(stmt, "\t", ""), "\n", "")
 
 	buf := bytes.NewBuffer([]byte(stmt))

--- a/api/http/handlerfuncs_test.go
+++ b/api/http/handlerfuncs_test.go
@@ -371,9 +371,7 @@ func TestExecGQLHandlerContentTypeJSONWithError(t *testing.T) {
 	stmt = strings.ReplaceAll(strings.ReplaceAll(stmt, "\t", ""), "\n", "")
 
 	buf := bytes.NewBuffer([]byte(stmt))
-	resp := struct {
-		Errors []struct{}
-	}{}
+	resp := GQLResult{}
 	testRequest(testOptions{
 		Testing:        t,
 		DB:             defra,
@@ -385,7 +383,7 @@ func TestExecGQLHandlerContentTypeJSONWithError(t *testing.T) {
 		ResponseData:   &resp,
 	})
 
-	assert.Contains(t, resp.Errors, struct{}{})
+	assert.Contains(t, resp.Errors, "The given field does not exist. Name: notAField")
 	assert.Len(t, resp.Errors, 1)
 }
 

--- a/api/http/request_result.go
+++ b/api/http/request_result.go
@@ -1,0 +1,31 @@
+// Copyright 2022 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package http
+
+import "github.com/sourcenetwork/defradb/client"
+
+type GQLResult struct {
+	Errors []string `json:"errors,omitempty"`
+
+	Data any `json:"data"`
+}
+
+func newGQLResult(r client.GQLResult) *GQLResult {
+	errors := make([]string, len(r.Errors))
+	for i := range r.Errors {
+		errors[i] = r.Errors[i].Error()
+	}
+
+	return &GQLResult{
+		Errors: errors,
+		Data:   r.Data,
+	}
+}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #1383 

## Description

Serializes DB errors to json in http package. They were previously resolving to `"{}"`.

![image](https://user-images.githubusercontent.com/30875502/234074071-323bbe7d-c822-46d4-a0a4-f88aa8b8096f.png)

