### PR TITLE
fix: Limit the size of http request bodies that we handle

### DIFF
--- a/api/http/handlerfuncs.go
+++ b/api/http/handlerfuncs.go
@@ -11,11 +11,13 @@
 package http
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"mime"
 	"net/http"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	dshelp "github.com/ipfs/boxo/datastore/dshelp"
@@ -124,7 +126,7 @@ func execGQLHandler(rw http.ResponseWriter, req *http.Request) {
 				handleErr(req.Context(), rw, ErrBodyEmpty, http.StatusBadRequest)
 				return
 			}
-			body, err := io.ReadAll(req.Body)
+			body, err := readWithTimeout(req.Context(), req.Body, time.Second)
 			if err != nil {
 				handleErr(req.Context(), rw, errors.WithStack(err), http.StatusInternalServerError)
 				return
@@ -155,7 +157,7 @@ func execGQLHandler(rw http.ResponseWriter, req *http.Request) {
 }
 
 func loadSchemaHandler(rw http.ResponseWriter, req *http.Request) {
-	sdl, err := io.ReadAll(req.Body)
+	sdl, err := readWithTimeout(req.Context(), req.Body, time.Second)
 	if err != nil {
 		handleErr(req.Context(), rw, err, http.StatusInternalServerError)
 		return
@@ -182,7 +184,7 @@ func loadSchemaHandler(rw http.ResponseWriter, req *http.Request) {
 }
 
 func patchSchemaHandler(rw http.ResponseWriter, req *http.Request) {
-	patch, err := io.ReadAll(req.Body)
+	patch, err := readWithTimeout(req.Context(), req.Body, time.Second)
 	if err != nil {
 		handleErr(req.Context(), rw, err, http.StatusInternalServerError)
 		return
@@ -319,6 +321,35 @@ func subscriptionHandler(pub *events.Publisher[events.Update], rw http.ResponseW
 			}
 			fmt.Fprintf(rw, "data: %s\n\n", b)
 			flusher.Flush()
+		}
+	}
+}
+
+// readWithTimeout reads from the reader until either EoF or the given maxDuration has been reached.
+func readWithTimeout(ctx context.Context, reader io.Reader, maxDuration time.Duration) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(ctx, maxDuration)
+	defer cancel()
+
+	result := []byte{}
+	// This is arbitrary, and I like powers of two for this kind of stuff
+	const bufSize int = 2 ^ 8
+	buf := make([]byte, bufSize)
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+
+		default:
+			n, err := reader.Read(buf)
+			isEoF := errors.Is(err, io.EOF)
+			if !isEoF && err != nil {
+				return nil, err
+			}
+
+			result = append(result, buf[:n]...)
+			if isEoF {
+				return result, nil
+			}
 		}
 	}
 }

--- a/api/http/handlerfuncs.go
+++ b/api/http/handlerfuncs.go
@@ -11,6 +11,7 @@
 package http
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -329,5 +330,12 @@ const maxBytes int64 = 100 * (1 << (10 * 2)) // 100MB
 // readWithLimit reads from the reader until either EoF or the maximum number of bytes have been read.
 func readWithLimit(reader io.ReadCloser, rw http.ResponseWriter) ([]byte, error) {
 	reader = http.MaxBytesReader(rw, reader, maxBytes)
-	return io.ReadAll(reader)
+
+	var buf bytes.Buffer
+	_, err := io.Copy(&buf, reader)
+	if err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
 }

--- a/api/http/handlerfuncs.go
+++ b/api/http/handlerfuncs.go
@@ -324,7 +324,7 @@ func subscriptionHandler(pub *events.Publisher[events.Update], rw http.ResponseW
 }
 
 // maxBytes is an arbitrary limit to prevent unbounded message bodies being sent and read.
-const maxBytes int64 = 131072 //2 ^ 17
+const maxBytes int64 = 100 * (1 << (10 * 2)) // 100MB
 
 // readWithLimit reads from the reader until either EoF or the maximum number of bytes have been read.
 func readWithLimit(reader io.ReadCloser, rw http.ResponseWriter) ([]byte, error) {


### PR DESCRIPTION
## Relevant issue(s)

Resolves #1322

## Description

Limits the size of http request bodies that we handle to make things slightly harder for anyone to DoS a defra node.

Timeout time preferred by me over a byte limit as I find it much more descriptive, and will scale nicely with the system/hardware-context (more powerful machines can handle bigger req. bodies). Is undoubtably a runtime cost involved though compared to just using an int.

I set all the limits to 1 second, as that seems like plenty for now.  Should be added to the config at somepoint IMO though (not now).