### PR TITLE
feat: Add allowed origins config

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,19 @@ Note: `sudo` is needed above for the redirection server (to bind port 80).
 
 A valid email address is necessary for the creation of the certificate, and is important to get notifications from the Certificate Authority - in case the certificate is about to expire, etc.
 
+## Supporting CORS
+
+When accessing DefraDB through a frontend interface, you may be confronted with a CORS error. That is because, by default, DefraDB will not have any allowed origins set. To specify which origins should be allowed to access your DefraDB endpoint, you can specify them when starting the database:
+```shell
+defradb start --allowedorigins=https://yourdomain.com
+```
+
+If running a frontend app locally on localhost, allowed origins must be set with the port of the app:
+```shell
+defradb start --allowedorigins=http://localhost:3000
+```
+
+The catch-all `*` is also a valid origin. 
 
 ## Community
 

--- a/README.md
+++ b/README.md
@@ -379,12 +379,12 @@ A valid email address is necessary for the creation of the certificate, and is i
 
 When accessing DefraDB through a frontend interface, you may be confronted with a CORS error. That is because, by default, DefraDB will not have any allowed origins set. To specify which origins should be allowed to access your DefraDB endpoint, you can specify them when starting the database:
 ```shell
-defradb start --allowedorigins=https://yourdomain.com
+defradb start --allowe-dorigins=https://yourdomain.com
 ```
 
 If running a frontend app locally on localhost, allowed origins must be set with the port of the app:
 ```shell
-defradb start --allowedorigins=http://localhost:3000
+defradb start --allowed-origins=http://localhost:3000
 ```
 
 The catch-all `*` is also a valid origin. 

--- a/cli/start.go
+++ b/cli/start.go
@@ -155,12 +155,12 @@ func MakeStartCommand(cfg *config.Config) *cobra.Command {
 	}
 
 	cmd.Flags().StringArray(
-		"allowedorigins", cfg.API.AllowedOrigins,
+		"allowed-origins", cfg.API.AllowedOrigins,
 		"List of origins to allow for CORS requests",
 	)
-	err = cfg.BindFlag("api.allowedorigins", cmd.Flags().Lookup("allowedorigins"))
+	err = cfg.BindFlag("api.allowed-origins", cmd.Flags().Lookup("allowed-origins"))
 	if err != nil {
-		log.FeedbackFatalE(context.Background(), "Could not bind api.allowedorigins", err)
+		log.FeedbackFatalE(context.Background(), "Could not bind api.allowed-origins", err)
 	}
 
 	cmd.Flags().String(

--- a/cli/start.go
+++ b/cli/start.go
@@ -154,6 +154,15 @@ func MakeStartCommand(cfg *config.Config) *cobra.Command {
 		log.FeedbackFatalE(context.Background(), "Could not bind api.tls", err)
 	}
 
+	cmd.Flags().StringArray(
+		"allowedorigins", cfg.API.AllowedOrigins,
+		"List of origins to allow for CORS requests",
+	)
+	err = cfg.BindFlag("api.allowedorigins", cmd.Flags().Lookup("allowedorigins"))
+	if err != nil {
+		log.FeedbackFatalE(context.Background(), "Could not bind api.allowedorigins", err)
+	}
+
 	cmd.Flags().String(
 		"pubkeypath", cfg.API.PubKeyPath,
 		"Path to the public key for tls",
@@ -319,6 +328,7 @@ func start(ctx context.Context, cfg *config.Config) (*defraInstance, error) {
 	sOpt := []func(*httpapi.Server){
 		httpapi.WithAddress(cfg.API.Address),
 		httpapi.WithRootDir(cfg.Rootdir),
+		httpapi.WithAllowedOrigins(cfg.API.AllowedOrigins...),
 	}
 
 	if n != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -289,7 +289,7 @@ func (dbcfg DatastoreConfig) validate() error {
 type APIConfig struct {
 	Address        string
 	TLS            bool
-	AllowedOrigins []string
+	AllowedOrigins []string `mapstructure:"allowed-origins"`
 	PubKeyPath     string
 	PrivKeyPath    string
 	Email          string

--- a/config/config.go
+++ b/config/config.go
@@ -299,7 +299,7 @@ func defaultAPIConfig() *APIConfig {
 	return &APIConfig{
 		Address:        "localhost:9181",
 		TLS:            false,
-		AllowedOrigins: []string{"*"},
+		AllowedOrigins: []string{},
 		PubKeyPath:     "certs/server.key",
 		PrivKeyPath:    "certs/server.crt",
 		Email:          DefaultAPIEmail,

--- a/config/config.go
+++ b/config/config.go
@@ -287,20 +287,22 @@ func (dbcfg DatastoreConfig) validate() error {
 
 // APIConfig configures the API endpoints.
 type APIConfig struct {
-	Address     string
-	TLS         bool
-	PubKeyPath  string
-	PrivKeyPath string
-	Email       string
+	Address        string
+	TLS            bool
+	AllowedOrigins []string
+	PubKeyPath     string
+	PrivKeyPath    string
+	Email          string
 }
 
 func defaultAPIConfig() *APIConfig {
 	return &APIConfig{
-		Address:     "localhost:9181",
-		TLS:         false,
-		PubKeyPath:  "certs/server.key",
-		PrivKeyPath: "certs/server.crt",
-		Email:       DefaultAPIEmail,
+		Address:        "localhost:9181",
+		TLS:            false,
+		AllowedOrigins: []string{"*"},
+		PubKeyPath:     "certs/server.key",
+		PrivKeyPath:    "certs/server.crt",
+		Email:          DefaultAPIEmail,
 	}
 }
 

--- a/config/configfile_yaml.gotmpl
+++ b/config/configfile_yaml.gotmpl
@@ -24,7 +24,7 @@ api:
     # Whether the API server should listen over HTTPS
     tls: {{ .API.TLS }}
     # The list of origins a cross-domain request can be executed from.
-    # allowedorigins: {{ .API.AllowedOrigins }}
+    # allowed-origins: {{ .API.AllowedOrigins }}
     # The path to the public key file. Ignored if domains is set.
     pubkeypath: {{ .API.PubKeyPath }}
     # The path to the private key file. Ignored if domains is set.

--- a/config/configfile_yaml.gotmpl
+++ b/config/configfile_yaml.gotmpl
@@ -23,6 +23,7 @@ api:
     address: {{ .API.Address }}
     # Whether the API server should listen over HTTPS
     tls: {{ .API.TLS }}
+    allowedorigins: {{ .API.AllowedOrigins }}
     # The path to the public key file. Ignored if domains is set.
     pubkeypath: {{ .API.PubKeyPath }}
     # The path to the private key file. Ignored if domains is set.

--- a/config/configfile_yaml.gotmpl
+++ b/config/configfile_yaml.gotmpl
@@ -23,7 +23,8 @@ api:
     address: {{ .API.Address }}
     # Whether the API server should listen over HTTPS
     tls: {{ .API.TLS }}
-    allowedorigins: {{ .API.AllowedOrigins }}
+    # The list of origins a cross-domain request can be executed from.
+    # allowedorigins: {{ .API.AllowedOrigins }}
     # The path to the public key file. Ignored if domains is set.
     pubkeypath: {{ .API.PubKeyPath }}
     # The path to the private key file. Ignored if domains is set.


### PR DESCRIPTION
## Relevant issue(s)

Resolves #1355 

## Description

This PR adds the option to set allowed origins for the HTTP API using the config file or a CLI flag.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Unit tests and curl with allowedOrigins set to http://test.com
```shell
# this will result in an unsuccessful Preflight request
curl -i http://localhost:9181/api/v1/ping -H "Origin: http://no.com" -H "Access-Control-Request-Method: GET" -X OPTIONS

# this will result in an successful Preflight request
curl -i http://localhost:9181/api/v1/ping -H "Origin: http://test.com" -H "Access-Control-Request-Method: GET" -X OPTIONS
```

Specify the platform(s) on which this was tested:
- MacOS
