### PR TITLE
chore: Enshrine defra logger names

### DIFF
--- a/api/http/handler_test.go
+++ b/api/http/handler_test.go
@@ -86,7 +86,7 @@ func TestNewHandlerWithLogger(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	assert.Equal(t, "defra.http", kv["logger"])
+	assert.Equal(t, "http", kv["logger"])
 }
 
 func TestGetJSON(t *testing.T) {

--- a/api/http/http.go
+++ b/api/http/http.go
@@ -15,4 +15,4 @@ package http
 
 import "github.com/sourcenetwork/defradb/logging"
 
-var log = logging.MustNewLogger("defra.http")
+var log = logging.MustNewLogger("http")

--- a/api/http/logger_test.go
+++ b/api/http/logger_test.go
@@ -96,7 +96,7 @@ func TestLoggerKeyValueOutput(t *testing.T) {
 	// check that everything is as expected
 	assert.Equal(t, "{\"data\":{\"response\":\"pong\"}}", rec2.Body.String())
 	assert.Equal(t, "INFO", kv["level"])
-	assert.Equal(t, "defra.http", kv["logger"])
+	assert.Equal(t, "http", kv["logger"])
 	assert.Equal(t, "Request", kv["msg"])
 	assert.Equal(t, "GET", kv["Method"])
 	assert.Equal(t, "/ping", kv["Path"])

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -28,7 +28,7 @@ import (
 	"github.com/sourcenetwork/defradb/logging"
 )
 
-var log = logging.MustNewLogger("defra.cli")
+var log = logging.MustNewLogger("cli")
 
 const badgerDatastoreName = "badger"
 

--- a/cmd/genclidocs/genclidocs.go
+++ b/cmd/genclidocs/genclidocs.go
@@ -25,7 +25,7 @@ import (
 	"github.com/sourcenetwork/defradb/logging"
 )
 
-var log = logging.MustNewLogger("defra.genclidocs")
+var log = logging.MustNewLogger("genclidocs")
 
 func main() {
 	path := flag.String("o", "docs/cmd", "path to write the cmd docs to")

--- a/cmd/genmanpages/main.go
+++ b/cmd/genmanpages/main.go
@@ -28,7 +28,7 @@ import (
 
 const defaultPerm os.FileMode = 0o777
 
-var log = logging.MustNewLogger("defra.genmanpages")
+var log = logging.MustNewLogger("genmanpages")
 
 func main() {
 	dirFlag := flag.String("o", "build/man", "Directory in which to generate DefraDB man pages")

--- a/config/config.go
+++ b/config/config.go
@@ -64,7 +64,7 @@ import (
 	"github.com/sourcenetwork/defradb/node"
 )
 
-var log = logging.MustNewLogger("defra.config")
+var log = logging.MustNewLogger("config")
 
 const (
 	DefaultAPIEmail = "example@example.com"

--- a/datastore/store.go
+++ b/datastore/store.go
@@ -19,7 +19,7 @@ import (
 )
 
 var (
-	log = logging.MustNewLogger("defradb.store")
+	log = logging.MustNewLogger("store")
 )
 
 // RootStore wraps Batching and TxnDatastore requiring datastore to support both batching and transactions.

--- a/db/db.go
+++ b/db/db.go
@@ -34,7 +34,7 @@ import (
 )
 
 var (
-	log = logging.MustNewLogger("defra.db")
+	log = logging.MustNewLogger("db")
 )
 
 // make sure we match our client interface

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -14,7 +14,7 @@ import (
 	"context"
 )
 
-var log = MustNewLogger("defra.logging")
+var log = MustNewLogger("logging")
 
 // KV is a key-value pair used to pass structured data to loggers.
 type KV struct {

--- a/merkle/clock/clock.go
+++ b/merkle/clock/clock.go
@@ -26,7 +26,7 @@ import (
 )
 
 var (
-	log = logging.MustNewLogger("defra.merkleclock")
+	log = logging.MustNewLogger("merkleclock")
 )
 
 // MerkleClock is a MerkleCRDT clock that can be used to read/write events (deltas) to the clock.

--- a/merkle/crdt/merklecrdt.go
+++ b/merkle/crdt/merklecrdt.go
@@ -24,7 +24,7 @@ import (
 )
 
 var (
-	log = logging.MustNewLogger("defra.merklecrdt")
+	log = logging.MustNewLogger("merklecrdt")
 )
 
 // MerkleCRDT is the implementation of a Merkle Clock along with a

--- a/net/api/service.go
+++ b/net/api/service.go
@@ -26,7 +26,7 @@ import (
 )
 
 var (
-	log = logging.MustNewLogger("defra.netapi")
+	log = logging.MustNewLogger("netapi")
 )
 
 type Service struct {

--- a/net/net.go
+++ b/net/net.go
@@ -17,5 +17,5 @@ import (
 )
 
 var (
-	log = logging.MustNewLogger("defra.net")
+	log = logging.MustNewLogger("net")
 )

--- a/node/node.go
+++ b/node/node.go
@@ -50,7 +50,7 @@ import (
 )
 
 var (
-	log = logging.MustNewLogger("defra.node")
+	log = logging.MustNewLogger("node")
 )
 
 const evtWaitTimeout = 10 * time.Second

--- a/planner/planner.go
+++ b/planner/planner.go
@@ -22,7 +22,7 @@ import (
 )
 
 var (
-	log = logging.MustNewLogger("defra.planner")
+	log = logging.MustNewLogger("planner")
 )
 
 // planNode is an interface all nodes in the plan tree need to implement.

--- a/tests/bench/bench_util.go
+++ b/tests/bench/bench_util.go
@@ -37,7 +37,7 @@ const (
 
 var (
 	storage string = "memory"
-	log            = logging.MustNewLogger("defra.tests.bench")
+	log            = logging.MustNewLogger("tests.bench")
 )
 
 func init() {

--- a/tests/bench/query/simple/utils.go
+++ b/tests/bench/query/simple/utils.go
@@ -24,7 +24,7 @@ import (
 )
 
 var (
-// log = logging.MustNewLogger("defra.bench")
+// log = logging.MustNewLogger("bench")
 )
 
 func runQueryBenchGet(

--- a/tests/integration/cli/version_test.go
+++ b/tests/integration/cli/version_test.go
@@ -40,7 +40,6 @@ func TestExecVersionJSON(t *testing.T) {
 	assert.Contains(t, output, "go\":")
 	assert.Contains(t, output, "commit\":")
 	assert.Contains(t, output, "commitdate\":")
-
 	var data map[string]any
 	err := json.Unmarshal([]byte(output), &data)
 	assert.NoError(t, err)

--- a/tests/integration/explain/utils.go
+++ b/tests/integration/explain/utils.go
@@ -27,7 +27,7 @@ import (
 )
 
 var (
-	log = logging.MustNewLogger("defra.tests.integration.explain")
+	log = logging.MustNewLogger("tests.integration.explain")
 
 	allPlanNodeNames = map[string]struct{}{
 		// Not a planNode but need it here as this is root of the explain graph.

--- a/tests/integration/net/order/utils.go
+++ b/tests/integration/net/order/utils.go
@@ -31,7 +31,7 @@ import (
 )
 
 var (
-	log = logging.MustNewLogger("defra.test.net")
+	log = logging.MustNewLogger("test.net")
 )
 
 const (

--- a/tests/integration/utils2.go
+++ b/tests/integration/utils2.go
@@ -57,7 +57,7 @@ const (
 )
 
 var (
-	log            = logging.MustNewLogger("defra.tests.integration")
+	log            = logging.MustNewLogger("tests.integration")
 	badgerInMemory bool
 	badgerFile     bool
 	inMemoryStore  bool


### PR DESCRIPTION
## Relevant issue(s)

Resolves #1148

## Description

Simple approach: just rename the loggers.
Suggestion: non-defra loggers could have a prefix like e.g. `x.` 


## Tasks

- [ ] I made sure the code is well commented, particularly hard-to-understand areas.
- [ ] I made sure the repository-held documentation is changed accordingly.
- [ ] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [ ] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

CI
