### PR TITLE
fix: Validation of API address with TLS

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -322,7 +322,7 @@ func (apicfg *APIConfig) validate() error {
 		return ErrInvalidDatabaseURL
 	}
 
-	if (host == "localhost" || host == "::1" || host == "0.0.0.0") && port == "" {
+	if (host == "localhost" || host == "::1" || host == "0.0.0.0") && port == "" { //nolint:goconst
 		return ErrMissingPortNumber
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -305,6 +305,11 @@ func defaultAPIConfig() *APIConfig {
 }
 
 func (apicfg *APIConfig) validate() error {
+	const (
+		zeroIP    = "0.0.0.0"
+		zeroIP6   = "::"
+		localhost = "localhost"
+	)
 	if apicfg.Address == "" {
 		return ErrInvalidDatabaseURL
 	}
@@ -312,7 +317,7 @@ func (apicfg *APIConfig) validate() error {
 	host, port, err := net.SplitHostPort(apicfg.Address)
 	if err != nil {
 		host = strings.TrimSpace(apicfg.Address)
-		if isValidDomainName(host) && host != "localhost" && host != "0.0.0.0" {
+		if isValidDomainName(host) && host != localhost && host != zeroIP && host != zeroIP6 {
 			return nil
 		}
 		return ErrMissingPortNumber
@@ -322,7 +327,7 @@ func (apicfg *APIConfig) validate() error {
 		return ErrInvalidDatabaseURL
 	}
 
-	if (host == "localhost" || host == "::1" || host == "0.0.0.0") && port == "" { //nolint:goconst
+	if (host == localhost || host == "::1" || host == zeroIP || host == zeroIP6) && port == "" {
 		return ErrMissingPortNumber
 	}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -514,18 +514,3 @@ func TestValidationAddress0000Valid(t *testing.T) {
 	err := cfg.validate()
 	assert.NoError(t, err)
 }
-
-func TestValidationAddressDomainWithSubdomainValidWithTLSCorrectPortIsInvalid(t *testing.T) {
-	cfg := DefaultConfig()
-	cfg.API.Address = "sub.example.com:443"
-	cfg.API.TLS = true
-	err := cfg.validate()
-	assert.ErrorIs(t, err, ErrNoPortWithDomain)
-}
-
-func TestValidationAddressDomainWithSubdomainWrongPortIsInvalid(t *testing.T) {
-	cfg := DefaultConfig()
-	cfg.API.Address = "sub.example.com:9876"
-	err := cfg.validate()
-	assert.ErrorIs(t, err, ErrNoPortWithDomain)
-}

--- a/config/errors.go
+++ b/config/errors.go
@@ -48,8 +48,9 @@ const (
 	errUnableToParseByteSize       string = "unable to parse byte size"
 	errInvalidDatastorePath        string = "invalid datastore path"
 	errMissingPortNumber           string = "missing port number"
-	errNoPortWithDomain            string = "cannot provide port with domain name"
 	errInvalidRootDir              string = "invalid root directory"
+	errInvalidPortForTLS           string = "invalid port for TLS"
+	errinvalidPort                 string = "invalid port"
 )
 
 var (
@@ -86,8 +87,9 @@ var (
 	ErrInvalidLoggerConfig         = errors.New(errInvalidLoggerConfig)
 	ErrorInvalidDatastorePath      = errors.New(errInvalidDatastorePath)
 	ErrMissingPortNumber           = errors.New(errMissingPortNumber)
-	ErrNoPortWithDomain            = errors.New(errNoPortWithDomain)
-	ErrorInvalidRootDir            = errors.New(errInvalidRootDir)
+	ErrInvalidRootDir              = errors.New(errInvalidRootDir)
+	ErrInvalidPortForTLS           = errors.New(errInvalidPortForTLS)
+	ErrInvalidPort                 = errors.New(errinvalidPort)
 )
 
 func NewErrFailedToWriteFile(inner error, path string) error {
@@ -216,4 +218,12 @@ func NewErrInvalidDatastorePath(path string) error {
 
 func NewErrInvalidRootDir(path string) error {
 	return errors.New(errInvalidRootDir, errors.NewKV("path", path))
+}
+
+func NewErrInvalidPortForTLS(port string) error {
+	return errors.New(errInvalidPortForTLS, errors.NewKV("port", port))
+}
+
+func NewErrInvalidPort(port string) error {
+	return errors.New(errinvalidPort, errors.NewKV("port", port))
 }

--- a/tests/integration/cli/client_ping_test.go
+++ b/tests/integration/cli/client_ping_test.go
@@ -46,7 +46,7 @@ func TestPingCommandToInvalidHost(t *testing.T) {
 	}
 	// for some line in stderr to contain the error message
 	for _, line := range stderr {
-		if strings.Contains(line, config.ErrFailedToValidateConfig.Error()) {
+		if strings.Contains(line, config.ErrFailedToValidateConfig.Error()) || strings.Contains(line, config.ErrInvalidPortForTLS.Error()) {
 			return
 		}
 	}

--- a/tests/integration/cli/start_test.go
+++ b/tests/integration/cli/start_test.go
@@ -13,6 +13,8 @@ package clitest
 import (
 	"fmt"
 	"testing"
+
+	"github.com/sourcenetwork/defradb/config"
 )
 
 func TestStartCommandBasic(t *testing.T) {
@@ -34,8 +36,8 @@ func TestStartCommandWithTLSIncomplete(t *testing.T) {
 		"--url", conf.APIURL,
 		"--tcpaddr", conf.GRPCAddr,
 	})
-	assertContainsSubstring(t, stderr, "Starting DefraDB service...")
 	assertContainsSubstring(t, stderr, "Error")
+	assertContainsSubstring(t, stderr, config.ErrInvalidPortForTLS.Error())
 }
 
 func TestStartCommandWithStoreMemory(t *testing.T) {

--- a/tests/integration/cli/utils.go
+++ b/tests/integration/cli/utils.go
@@ -108,9 +108,9 @@ func runDefraNode(t *testing.T, conf DefraNodeConfig) func() []string {
 func runDefraCommand(t *testing.T, conf DefraNodeConfig, args []string) (stdout, stderr []string) {
 	t.Helper()
 	cfg := config.DefaultConfig()
-	args = append([]string{
-		"--url", conf.APIURL,
-	}, args...)
+	if !contains(args, "--url") {
+		args = append(args, "--url", conf.APIURL)
+	}
 	if !contains(args, "--rootdir") {
 		args = append(args, "--rootdir", t.TempDir())
 	}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #1376 

## Description

Adds `start` command-specific validation for the TLS use case

Fixes related validation in `config`

Additionally fixes an issue with the "CLI integration test suite"

Opening as draft PR because it's late for me now.

## Tasks

- [ ] I made sure the code is well commented, particularly hard-to-understand areas.
- [ ] I made sure the repository-held documentation is changed accordingly.
- [ ] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [ ] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

CI
