### PR TITLE
ci: Fix the SSH security issue from AMI scan report

### DIFF
--- a/.github/workflows/build-ami-with-packer.yml
+++ b/.github/workflows/build-ami-with-packer.yml
@@ -52,8 +52,8 @@ jobs:
 
       - name: Run `packer validate`
         id: validate
-        run: "packer validate -var \"github_pat=${{ secrets.ONLY_DEFRADB_REPO_CI_PAT }}\" -var \"commit=${{ env.RELEASE_VERSION }}\" ./tools/cloud/aws/packer/build_aws_ami.pkr.hcl"
+        run: "packer validate -var \"commit=${{ env.RELEASE_VERSION }}\" ./tools/cloud/aws/packer/build_aws_ami.pkr.hcl"
 
       - name: Run `packer build`
         id: build
-        run: "packer build -var \"github_pat=${{ secrets.ONLY_DEFRADB_REPO_CI_PAT }}\" -var \"commit=${{ env.RELEASE_VERSION }}\" ./tools/cloud/aws/packer/build_aws_ami.pkr.hcl"
+        run: "packer build -var \"commit=${{ env.RELEASE_VERSION }}\" ./tools/cloud/aws/packer/build_aws_ami.pkr.hcl"

--- a/tools/cloud/aws/packer/build_aws_ami.pkr.hcl
+++ b/tools/cloud/aws/packer/build_aws_ami.pkr.hcl
@@ -58,7 +58,7 @@ build {
   sources = [
     "source.amazon-ebs.ubuntu-lts"
   ]
-  
+
   provisioner "shell" {
     environment_vars = ["COMMIT_TO_DEPLOY=${var.commit}", "DEFRADB_GIT_REPO=github.com/sourcenetwork/defradb.git"]
     pause_before = "10s"
@@ -79,11 +79,14 @@ build {
       "export GOBIN=\"$GOPATH/bin\"",
       "export PATH=\"$GOBIN:$GOROOT/bin:$PATH\"",
       "defradb version || { printf \"\\\ndefradb installed but not working properly.\\\n\" && exit 6; }",
-      "printf \"\\\ndefradb successfully installed.\\\n\"",
-      "sudo /usr/sbin/sshd -o \"PasswordAuthentication no\" -o \"PermitRootLogin without-password\" ",
-      "sudo shred -u /etc/ssh/*_key /etc/ssh/*_key.pub",
+      "printf \"\\\nDefraDB successfully installed.\\\n\"",
       "cd ..",
-      "sudo rm -rf ./defradb"
+      "sudo rm -rf ./defradb",
+      "sudo /usr/sbin/sshd -o \"PasswordAuthentication no\" -o \"PermitRootLogin without-password\" ",
+      "sudo shred --zero --force --verbose --remove --iterations=5 /etc/ssh/*_key* /etc/ssh/*.pub || true",
+      "sudo shred --zero --force --verbose --remove --iterations=5 /home/*/.ssh/*_key* /home/*/.ssh/*.pub || true",
+      "sudo shred --zero --force --verbose --remove --iterations=5 /root/.ssh/authorized_keys",
+      "printf \"\\\nPacker build succeeded!.\\\n\""
       ]
   }
 

--- a/tools/cloud/aws/packer/build_aws_ami.pkr.hcl
+++ b/tools/cloud/aws/packer/build_aws_ami.pkr.hcl
@@ -13,10 +13,6 @@ variable "ami_prefix" {
   default = "source-defradb"
 }
 
-variable "github_pat" {
-  default = env("ONLY_DEFRADB_REPO_CI_PAT")
-}
-
 variable "commit" {
   default = env("COMMIT_TO_DEPLOY")
 }
@@ -64,7 +60,7 @@ build {
   ]
   
   provisioner "shell" {
-    environment_vars = ["COMMIT_TO_DEPLOY=${var.commit}", "DEFRADB_GIT_REPO=github.com/sourcenetwork/defradb.git", "ONLY_DEFRADB_REPO_CI_PAT=${var.github_pat}"]
+    environment_vars = ["COMMIT_TO_DEPLOY=${var.commit}", "DEFRADB_GIT_REPO=github.com/sourcenetwork/defradb.git"]
     pause_before = "10s"
     remote_folder = "/home/ubuntu"
     inline = [
@@ -73,7 +69,7 @@ build {
       "curl -OL https://golang.org/dl/go1.19.8.linux-amd64.tar.gz",
       "rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.19.8.linux-amd64.tar.gz",
       "export PATH=$PATH:/usr/local/go/bin",
-      "git clone \"https://git:$ONLY_DEFRADB_REPO_CI_PAT@$DEFRADB_GIT_REPO\"",
+      "git clone \"https://git@$DEFRADB_GIT_REPO\"",
       "cd ./defradb || { printf \"\\\ncd into defradb failed.\\\n\" && exit 2; }",
       "git checkout $COMMIT_TO_DEPLOY || { printf \"\\\nchecking out commit failed.\\\n\" && exit 3; }",
       "make deps:modules",


### PR DESCRIPTION
## Relevant issue(s)
Resolves #1425

## Description
- Shreds the keys in all locations noted in the issue.
- Generated the AMI of name: `source-defradb-v0.5.0-20230501085514` , with ID: `ami-0814ed8a30589825b`

## How has this been tested?
- Manually tested the commands after sshing into the image, to ensure the work, and manually generated a run.
- The run that generated the AMI successfully can be found here: https://github.com/sourcenetwork/defradb/actions/runs/4849906529/jobs/8642330562?pr=1426


