### PR TITLE
test: Improve change detector performance

### DIFF
--- a/docs/data_format_changes/i1186-change-detctor-setup.md
+++ b/docs/data_format_changes/i1186-change-detctor-setup.md
@@ -1,0 +1,5 @@
+# Modify change detector setup flow
+
+This is not a breaking (production code) change.
+
+This does however change the way the change detector sets up the target branch in a way that is incompatible with the current develop, this file is required to allow the CI to pass (including comparing develop vs master).

--- a/tests/integration/change_detector.go
+++ b/tests/integration/change_detector.go
@@ -65,9 +65,10 @@ func detectDbChangesInit(repository string, targetBranch string) {
 	}
 
 	defraTempDir := path.Join(os.TempDir(), "defradb")
+	changeDetectorTempDir := path.Join(defraTempDir, "tests", "changeDetector")
 
 	latestTargetCommitHash := getLatestCommit(repository, targetBranch)
-	detectDbChangesCodeDir = path.Join(defraTempDir, latestTargetCommitHash, "code")
+	detectDbChangesCodeDir = path.Join(changeDetectorTempDir, latestTargetCommitHash, "code")
 
 	_, err := os.Stat(detectDbChangesCodeDir)
 	// Warning - there is a race condition here, where if running multiple packages in

--- a/tests/integration/change_detector.go
+++ b/tests/integration/change_detector.go
@@ -64,10 +64,10 @@ func detectDbChangesInit(repository string, targetBranch string) {
 		return
 	}
 
-	tempDir := os.TempDir()
+	defraTempDir := path.Join(os.TempDir(), "defra")
 
 	latestTargetCommitHash := getLatestCommit(repository, targetBranch)
-	detectDbChangesCodeDir = path.Join(tempDir, "defra", latestTargetCommitHash, "code")
+	detectDbChangesCodeDir = path.Join(defraTempDir, latestTargetCommitHash, "code")
 
 	_, err := os.Stat(detectDbChangesCodeDir)
 	// Warning - there is a race condition here, where if running multiple packages in

--- a/tests/integration/change_detector.go
+++ b/tests/integration/change_detector.go
@@ -118,15 +118,7 @@ func SetupDatabaseUsingTargetBranch(
 	t *testing.T,
 	collectionNames []string,
 ) client.DB {
-	currentTestPackage, err := os.Getwd()
-	if err != nil {
-		panic(err)
-	}
-
-	targetTestPackage := detectDbChangesCodeDir + "/tests/integration/" + strings.Split(
-		currentTestPackage,
-		"/tests/integration/",
-	)[1]
+	targetTestPackage := detectDbChangesCodeDir + "/tests/integration/" + getTestPackagePath()
 
 	// If we are checking for database changes, and we are not seting up the database,
 	// then we must be in the main test process, and need to create a new process
@@ -185,6 +177,20 @@ func SetupDatabaseUsingTargetBranch(
 		}
 	}
 	return refreshedDb
+}
+
+// getTestPackagePath returns the path to the package currently under test, relative
+// to `./tests/integration/`
+func getTestPackagePath() string {
+	currentTestPackage, err := os.Getwd()
+	if err != nil {
+		panic(err)
+	}
+
+	return strings.Split(
+		currentTestPackage,
+		"/tests/integration/",
+	)[1]
 }
 
 func checkIfDatabaseFormatChangesAreDocumented() bool {

--- a/tests/integration/change_detector.go
+++ b/tests/integration/change_detector.go
@@ -68,7 +68,7 @@ func detectDbChangesInit(repository string, targetBranch string) {
 	changeDetectorTempDir := path.Join(defraTempDir, "tests", "changeDetector")
 
 	latestTargetCommitHash := getLatestCommit(repository, targetBranch)
-	detectDbChangesCodeDir = path.Join(changeDetectorTempDir, latestTargetCommitHash, "code")
+	detectDbChangesCodeDir = path.Join(changeDetectorTempDir, "code", latestTargetCommitHash)
 
 	_, err := os.Stat(detectDbChangesCodeDir)
 	// Warning - there is a race condition here, where if running multiple packages in

--- a/tests/integration/change_detector.go
+++ b/tests/integration/change_detector.go
@@ -64,7 +64,7 @@ func detectDbChangesInit(repository string, targetBranch string) {
 		return
 	}
 
-	defraTempDir := path.Join(os.TempDir(), "defra")
+	defraTempDir := path.Join(os.TempDir(), "defradb")
 
 	latestTargetCommitHash := getLatestCommit(repository, targetBranch)
 	detectDbChangesCodeDir = path.Join(defraTempDir, latestTargetCommitHash, "code")

--- a/tests/integration/explain/utils.go
+++ b/tests/integration/explain/utils.go
@@ -154,37 +154,21 @@ func ExecuteExplainRequestTestCase(
 		log.Info(ctx, explainTest.Description, logging.NewKV("Database", dbi.name))
 
 		if testUtils.DetectDbChanges {
-			if testUtils.SetupOnly {
-				setupDatabase(
-					ctx,
-					t,
-					dbi,
-					schema,
-					collectionNames,
-					explainTest.Description,
-					explainTest.ExpectedError,
-					explainTest.Docs,
-					immutable.None[map[int]map[int][]string](),
-				)
-				dbi.db.Close(ctx)
-				return
-			}
-
-			dbi.db.Close(ctx)
-			db = testUtils.SetupDatabaseUsingTargetBranch(ctx, t, collectionNames)
-		} else {
-			setupDatabase(
-				ctx,
-				t,
-				dbi,
-				schema,
-				collectionNames,
-				explainTest.Description,
-				explainTest.ExpectedError,
-				explainTest.Docs,
-				immutable.None[map[int]map[int][]string](),
-			)
+			t.SkipNow()
+			return
 		}
+
+		setupDatabase(
+			ctx,
+			t,
+			dbi,
+			schema,
+			collectionNames,
+			explainTest.Description,
+			explainTest.ExpectedError,
+			explainTest.Docs,
+			immutable.None[map[int]map[int][]string](),
+		)
 
 		result := db.ExecRequest(ctx, explainTest.Request)
 		if assertExplainRequestResults(


### PR DESCRIPTION
## Relevant issue(s)

Resolves #1186
Partially resolves #1342

## Description

Improves the change detector performance. Decreases runtime from 17 minutes to 5 minutes on my local machine. It also cleans up the paths used by the change detector (part of https://github.com/sourcenetwork/defradb/issues/1342).

It does this by changing how the setup-stage is handled, instead of calling `go test` once per test, it now only calls it once per test package - setting up a bunch of test db instances for the entire package.

This does mean that they can no longer rely on the use of `test.TempDir`, and instead the database instances live within the temp directory. This PR does not provide a mechanic to clean those up, but it should be quite easy to do so later.  The total disk usage by a full test run is on 44MB (post run, during a run it is 2GB+44MB), so this is unlikely to be an issue.

I believe that more gains can be for not too much effort by allowing the change detector to run in parallel (package level, not each test). I believe this is currently this is only blocked by the git cloning of the latest target branch, and there are easy ways to remove that limitation (lower priority though): https://github.com/sourcenetwork/defradb/issues/1436.

Commits should be clean, most of the work is in the last commit `Do change-detector setup once per package`.

Todo immediately **after** merge:
- [ ] Enable change detector workflow in github (was disabled manually, no workflow files to change)