### PR TITLE
ci: Remove secret ssh key stuff from change detector wf

### DIFF
--- a/.github/workflows/detect-change.yml
+++ b/.github/workflows/detect-change.yml
@@ -41,13 +41,6 @@ jobs:
           make deps:modules
           make deps:test
 
-      # We need SSH Authorization because change detection needs use `ls-remote` like:
-      #  git ls-remote git@github.com:sourcenetwork/defradb.git refs/heads/develop
-      - uses: webfactory/ssh-agent@v0.7.0
-        with:
-            ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-            log-public-key: false
-
       - name: Run detection for changes
         run: make test:changes
 

--- a/tests/integration/utils2.go
+++ b/tests/integration/utils2.go
@@ -128,7 +128,7 @@ func init() {
 	SetupOnly = getBool(setupOnlyValue)
 
 	if !repositorySpecified {
-		repositoryValue = "git@github.com:sourcenetwork/defradb.git"
+		repositoryValue = "https://github.com/sourcenetwork/defradb.git"
 	}
 
 	if !targetBranchSpecified {


### PR DESCRIPTION
## Relevant issue(s)

Resolves #1437

## Description

Removes secret ssh key stuff from change detector workflow.