### PR TITLE
fix: Handling SIGTERM in CLI `start` command

### DIFF
--- a/cli/start.go
+++ b/cli/start.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"os/signal"
 	"strings"
+	"syscall"
 
 	badger "github.com/dgraph-io/badger/v3"
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
@@ -384,7 +385,7 @@ func start(ctx context.Context, cfg *config.Config) (*defraInstance, error) {
 func wait(ctx context.Context, di *defraInstance) error {
 	// setup signal handlers
 	signalCh := make(chan os.Signal, 1)
-	signal.Notify(signalCh, os.Interrupt)
+	signal.Notify(signalCh, os.Interrupt, syscall.SIGTERM)
 
 	select {
 	case <-ctx.Done():


### PR DESCRIPTION
## Relevant issue(s)

Resolves #1458

## Description

Simply adds SIGTERM to the list of handled signals.

I'm unsure how to test this. We can send send a signal, `syscall.Kill(syscall.Getpid(), syscall.SIGINT)` within an integration test but I'm worried it will end the test process which also is running the other tests.
It might require an 'external' integration test suite in which we can run the command and then send the signal to the process.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Manually