### PR TITLE
refactor: Add prefix to pubsub topics

### DIFF
--- a/net/api/service.go
+++ b/net/api/service.go
@@ -139,7 +139,7 @@ func (s *Service) GetAllP2PCollections(
 	req *pb.GetAllP2PCollectionsRequest,
 ) (*pb.GetAllP2PCollectionsReply, error) {
 	log.Debug(ctx, "Received GetAllP2PCollections request")
-	collections, err := s.peer.GetAllP2PCollections()
+	collections, err := s.peer.GetAllP2PCollectionsFromStore()
 	if err != nil {
 		return nil, err
 	}

--- a/net/peer.go
+++ b/net/peer.go
@@ -893,6 +893,7 @@ func (p *Peer) RemoveP2PCollections(collections []string) error {
 		if err != nil {
 			return p.rollbackRemovePubSubTopics(removedTopics, err)
 		}
+		removedTopics = append(removedTopics, col)
 	}
 
 	if err = txn.Commit(p.ctx); err != nil {

--- a/net/peer.go
+++ b/net/peer.go
@@ -763,6 +763,26 @@ type EvtPubSub struct {
 	Peer peer.ID
 }
 
+// rollbackAddPubSubTopics removes the given topics from the pubsub system.
+func (p *Peer) rollbackAddPubSubTopics(topics []string, cause error) error {
+	for _, topic := range topics {
+		if err := p.server.removePubSubTopic(topic); err != nil {
+			return errors.WithStack(err, errors.NewKV("Cause", cause))
+		}
+	}
+	return cause
+}
+
+// rollbackRemovePubSubTopics adds back the given topics from the pubsub system.
+func (p *Peer) rollbackRemovePubSubTopics(topics []string, cause error) error {
+	for _, topic := range topics {
+		if err := p.server.addPubSubTopic(topic, true); err != nil {
+			return errors.WithStack(err, errors.NewKV("Cause", cause))
+		}
+	}
+	return cause
+}
+
 // AddP2PCollections adds the given collectionIDs to the pubsup topics.
 //
 // It will error if any of the given collectionIDs are invalid, in such a case some of the
@@ -778,11 +798,13 @@ func (p *Peer) AddP2PCollections(collections []string) error {
 	store := p.db.WithTxn(txn)
 
 	// first let's make sure the collections actually exists
+	storeCollections := []client.Collection{}
 	for _, col := range collections {
-		_, err := store.GetCollectionBySchemaID(p.ctx, col)
+		storeCol, err := store.GetCollectionBySchemaID(p.ctx, col)
 		if err != nil {
 			return err
 		}
+		storeCollections = append(storeCollections, storeCol)
 	}
 
 	// Ensure we can add all the collections to the store on the transaction
@@ -799,25 +821,19 @@ func (p *Peer) AddP2PCollections(collections []string) error {
 	for _, col := range collections {
 		err = p.server.addPubSubTopic(col, true)
 		if err != nil {
-			for _, topic := range addedTopics {
-				e := p.server.removePubSubTopic(topic)
-				if e != nil {
-					return errors.WithStack(e, errors.NewKV("Cause", err))
-				}
-			}
-			return err
+			return p.rollbackAddPubSubTopics(addedTopics, err)
 		}
 		addedTopics = append(addedTopics, col)
 	}
 
+	if err = txn.Commit(p.ctx); err != nil {
+		return p.rollbackAddPubSubTopics(addedTopics, err)
+	}
+
 	// If adding the collection topics succeeds, we remove the collections' documents
 	// from the pubsub topics to avoid receiving duplicate events.
-	for _, col := range collections {
-		c, err := store.GetCollectionBySchemaID(p.ctx, col)
-		if err != nil {
-			return err
-		}
-		keyChan, err := c.GetAllDocKeys(p.ctx)
+	for _, col := range storeCollections {
+		keyChan, err := col.GetAllDocKeys(p.ctx)
 		if err != nil {
 			return err
 		}
@@ -834,7 +850,7 @@ func (p *Peer) AddP2PCollections(collections []string) error {
 		}
 	}
 
-	return txn.Commit(p.ctx)
+	return nil
 }
 
 // RemoveP2PCollections removes the given collectionIDs from the pubsup topics.
@@ -852,11 +868,13 @@ func (p *Peer) RemoveP2PCollections(collections []string) error {
 	store := p.db.WithTxn(txn)
 
 	// first let's make sure the collections actually exists
+	storeCollections := []client.Collection{}
 	for _, col := range collections {
-		_, err := store.GetCollectionBySchemaID(p.ctx, col)
+		storeCol, err := store.GetCollectionBySchemaID(p.ctx, col)
 		if err != nil {
 			return err
 		}
+		storeCollections = append(storeCollections, storeCol)
 	}
 
 	// Ensure we can remove all the collections to the store on the transaction
@@ -873,24 +891,18 @@ func (p *Peer) RemoveP2PCollections(collections []string) error {
 	for _, col := range collections {
 		err = p.server.removePubSubTopic(col)
 		if err != nil {
-			for _, topic := range removedTopics {
-				e := p.server.addPubSubTopic(topic, true)
-				if e != nil {
-					return errors.WithStack(e, errors.NewKV("Cause", err))
-				}
-			}
-			return err
+			return p.rollbackRemovePubSubTopics(removedTopics, err)
 		}
+	}
+
+	if err = txn.Commit(p.ctx); err != nil {
+		return p.rollbackRemovePubSubTopics(removedTopics, err)
 	}
 
 	// If removing the collection topics succeeds, we add back the collections' documents
 	// to the pubsub topics.
-	for _, col := range collections {
-		c, err := store.GetCollectionBySchemaID(p.ctx, col)
-		if err != nil {
-			return err
-		}
-		keyChan, err := c.GetAllDocKeys(p.ctx)
+	for _, col := range storeCollections {
+		keyChan, err := col.GetAllDocKeys(p.ctx)
 		if err != nil {
 			return err
 		}
@@ -907,20 +919,21 @@ func (p *Peer) RemoveP2PCollections(collections []string) error {
 		}
 	}
 
-	return txn.Commit(p.ctx)
+	return nil
 }
 
-// GetAllP2PCollections gets all the collectionIDs from the pubsup topics
+// GetAllP2PCollections gets all the collectionIDs that have been added to the
+// pubsub topics from the system store.
 func (p *Peer) GetAllP2PCollections() ([]client.P2PCollection, error) {
 	txn, err := p.db.NewTxn(p.ctx, false)
 	if err != nil {
 		return nil, err
 	}
+	defer txn.Discard(p.ctx)
 	store := p.db.WithTxn(txn)
 
 	collections, err := p.db.GetAllP2PCollections(p.ctx)
 	if err != nil {
-		txn.Discard(p.ctx)
 		return nil, err
 	}
 
@@ -928,7 +941,6 @@ func (p *Peer) GetAllP2PCollections() ([]client.P2PCollection, error) {
 	for _, colID := range collections {
 		col, err := store.GetCollectionBySchemaID(p.ctx, colID)
 		if err != nil {
-			txn.Discard(p.ctx)
 			return nil, err
 		}
 		p2pCols = append(p2pCols, client.P2PCollection{

--- a/net/peer.go
+++ b/net/peer.go
@@ -258,7 +258,7 @@ func (p *Peer) RegisterNewDocument(
 	// register topic
 	if err := p.server.addPubSubTopic(
 		newTopic(dockeyPrefix, dockey.String()),
-		!p.server.hasPubSubTopic(schemaID),
+		!p.server.hasPubSubTopic(newTopic(collectionPrefix, schemaID)),
 	); err != nil {
 		log.ErrorE(
 			p.ctx,

--- a/net/server.go
+++ b/net/server.go
@@ -15,8 +15,6 @@ package net
 import (
 	"context"
 	"fmt"
-	"sort"
-	"strings"
 	"sync"
 
 	"github.com/gogo/protobuf/proto"
@@ -361,21 +359,6 @@ func (s *server) addPubSubTopic(topic string, subscribe bool) error {
 		subscribed: subscribe,
 	}
 	return nil
-}
-
-// getAllPubSubTopic returns all the topics we are subscribed to in lexicographic order. If a prefix is provided,
-// it returns all the topics that start with the prefix.
-func (s *server) getAllPubSubTopics(prefix string) []string {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	topics := []string{}
-	for topic := range s.topics {
-		if strings.HasPrefix(topic, prefix) {
-			topics = append(topics, topic)
-		}
-	}
-	sort.Strings(topics)
-	return topics
 }
 
 // hasPubSubTopic checks if we are subscribed to a topic.

--- a/net/server.go
+++ b/net/server.go
@@ -309,7 +309,7 @@ func (s *server) PushLog(ctx context.Context, req *pb.PushLogRequest) (*pb.PushL
 
 		// Once processed, subscribe to the dockey topic on the pubsub network unless we already
 		// suscribe to the collection.
-		if !s.hasPubSubTopic(col.SchemaID()) {
+		if !s.hasPubSubTopic(newTopic(collectionPrefix, col.SchemaID())) {
 			err = s.addPubSubTopic(newTopic(dockeyPrefix, docKey.DocKey), true)
 			if err != nil {
 				return nil, err

--- a/net/server.go
+++ b/net/server.go
@@ -15,6 +15,7 @@ package net
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 
@@ -362,17 +363,18 @@ func (s *server) addPubSubTopic(topic string, subscribe bool) error {
 	return nil
 }
 
-// getAllPubSubTopic returns all the topics we are subscribed to. If a prefix is provided,
+// getAllPubSubTopic returns all the topics we are subscribed to in lexicographic order. If a prefix is provided,
 // it returns all the topics that start with the prefix.
 func (s *server) getAllPubSubTopics(prefix string) []string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	topics := []string{}
-	for topic, _ := range s.topics {
+	for topic := range s.topics {
 		if strings.HasPrefix(topic, prefix) {
 			topics = append(topics, topic)
 		}
 	}
+	sort.Strings(topics)
 	return topics
 }
 

--- a/tests/integration/p2p.go
+++ b/tests/integration/p2p.go
@@ -466,7 +466,7 @@ func getAllP2PCollections(
 	}
 
 	n := nodes[action.NodeID]
-	cols, err := n.Peer.GetAllP2PCollections()
+	cols, err := n.Peer.GetAllP2PCollectionsFromServer()
 	require.NoError(t, err)
 
 	assert.Equal(t, expectedCollections, cols)


### PR DESCRIPTION
## Relevant issue(s)

Resolves #1283

## Description

This PR adds prefixes to pubsub topics which allows filtering by topic type. It enables returning the list of P2P collections based on the topics the server is registered to instead of those that are stored in the system store. 

Note 1: This PR builds on #1461.

Note 2: Maybe this PR should just be a draft as it's intended purpose is to generate a discussion around the approach.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

make test

Specify the platform(s) on which this was tested:
- MacOS
