### PR TITLE
test: Convert explain dagscan tests to new explain setup

### DIFF
--- a/tests/integration/explain/default/dagscan_test.go
+++ b/tests/integration/explain/default/dagscan_test.go
@@ -13,13 +13,23 @@ package test_explain_default
 import (
 	"testing"
 
-	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	explainUtils "github.com/sourcenetwork/defradb/tests/integration/explain"
 )
 
-func TestExplainCommitsDagScan(t *testing.T) {
-	test := testUtils.RequestTestCase{
+var dagScanPattern = dataMap{
+	"explain": dataMap{
+		"selectTopNode": dataMap{
+			"selectNode": dataMap{
+				"dagScanNode": dataMap{},
+			},
+		},
+	},
+}
 
-		Description: "Explain commits query.",
+func TestDefaultExplainCommitsDagScanQueryOp(t *testing.T) {
+	test := explainUtils.ExplainRequestTestCase{
+
+		Description: "Explain (default) commits query-op.",
 
 		Request: `query @explain {
 			commits (dockey: "bae-41598f0c-19bc-5da6-813b-e80f14a10df3", fieldId: "1") {
@@ -47,22 +57,19 @@ func TestExplainCommitsDagScan(t *testing.T) {
 			},
 		},
 
-		Results: []dataMap{
+		ExpectedPatterns: []dataMap{dagScanPattern},
+
+		ExpectedTargets: []explainUtils.PlanNodeTargetCase{
 			{
-				"explain": dataMap{
-					"selectTopNode": dataMap{
-						"selectNode": dataMap{
-							"filter": nil,
-							"dagScanNode": dataMap{
-								"cid":     nil,
-								"fieldId": "1",
-								"spans": []dataMap{
-									{
-										"start": "/bae-41598f0c-19bc-5da6-813b-e80f14a10df3/1",
-										"end":   "/bae-41598f0c-19bc-5da6-813b-e80f14a10df3/2",
-									},
-								},
-							},
+				TargetNodeName:    "dagScanNode",
+				IncludeChildNodes: true, // Shouldn't have any as this is the last node in the chain.
+				ExpectedAttributes: dataMap{
+					"cid":     nil,
+					"fieldId": "1",
+					"spans": []dataMap{
+						{
+							"start": "/bae-41598f0c-19bc-5da6-813b-e80f14a10df3/1",
+							"end":   "/bae-41598f0c-19bc-5da6-813b-e80f14a10df3/2",
 						},
 					},
 				},
@@ -70,13 +77,13 @@ func TestExplainCommitsDagScan(t *testing.T) {
 		},
 	}
 
-	executeTestCase(t, test)
+	runExplainTest(t, test)
 }
 
-func TestExplainCommitsDagScanWithoutField(t *testing.T) {
-	test := testUtils.RequestTestCase{
+func TestDefaultExplainCommitsDagScanQueryOpWithoutField(t *testing.T) {
+	test := explainUtils.ExplainRequestTestCase{
 
-		Description: "Explain commits query with only dockey (no field).",
+		Description: "Explain (default) commits query-op with only dockey (no field).",
 
 		Request: `query @explain {
 			commits (dockey: "bae-41598f0c-19bc-5da6-813b-e80f14a10df3") {
@@ -104,22 +111,19 @@ func TestExplainCommitsDagScanWithoutField(t *testing.T) {
 			},
 		},
 
-		Results: []dataMap{
+		ExpectedPatterns: []dataMap{dagScanPattern},
+
+		ExpectedTargets: []explainUtils.PlanNodeTargetCase{
 			{
-				"explain": dataMap{
-					"selectTopNode": dataMap{
-						"selectNode": dataMap{
-							"filter": nil,
-							"dagScanNode": dataMap{
-								"cid":     nil,
-								"fieldId": nil,
-								"spans": []dataMap{
-									{
-										"start": "/bae-41598f0c-19bc-5da6-813b-e80f14a10df3",
-										"end":   "/bae-41598f0c-19bc-5da6-813b-e80f14a10df4",
-									},
-								},
-							},
+				TargetNodeName:    "dagScanNode",
+				IncludeChildNodes: true, // Shouldn't have any as this is the last node in the chain.
+				ExpectedAttributes: dataMap{
+					"cid":     nil,
+					"fieldId": nil,
+					"spans": []dataMap{
+						{
+							"start": "/bae-41598f0c-19bc-5da6-813b-e80f14a10df3",
+							"end":   "/bae-41598f0c-19bc-5da6-813b-e80f14a10df4",
 						},
 					},
 				},
@@ -127,13 +131,13 @@ func TestExplainCommitsDagScanWithoutField(t *testing.T) {
 		},
 	}
 
-	executeTestCase(t, test)
+	runExplainTest(t, test)
 }
 
-func TestExplainLatestCommitsDagScan(t *testing.T) {
-	test := testUtils.RequestTestCase{
+func TestDefaultExplainLatestCommitsDagScanQueryOp(t *testing.T) {
+	test := explainUtils.ExplainRequestTestCase{
 
-		Description: "Explain latestCommits query.",
+		Description: "Explain (default) latestCommits query-op.",
 
 		Request: `query @explain {
 			latestCommits(dockey: "bae-41598f0c-19bc-5da6-813b-e80f14a10df3", fieldId: "1") {
@@ -162,22 +166,19 @@ func TestExplainLatestCommitsDagScan(t *testing.T) {
 			},
 		},
 
-		Results: []dataMap{
+		ExpectedPatterns: []dataMap{dagScanPattern},
+
+		ExpectedTargets: []explainUtils.PlanNodeTargetCase{
 			{
-				"explain": dataMap{
-					"selectTopNode": dataMap{
-						"selectNode": dataMap{
-							"filter": nil,
-							"dagScanNode": dataMap{
-								"cid":     nil,
-								"fieldId": "1",
-								"spans": []dataMap{
-									{
-										"start": "/bae-41598f0c-19bc-5da6-813b-e80f14a10df3/1",
-										"end":   "/bae-41598f0c-19bc-5da6-813b-e80f14a10df3/2",
-									},
-								},
-							},
+				TargetNodeName:    "dagScanNode",
+				IncludeChildNodes: true, // Shouldn't have any as this is the last node in the chain.
+				ExpectedAttributes: dataMap{
+					"cid":     nil,
+					"fieldId": "1",
+					"spans": []dataMap{
+						{
+							"start": "/bae-41598f0c-19bc-5da6-813b-e80f14a10df3/1",
+							"end":   "/bae-41598f0c-19bc-5da6-813b-e80f14a10df3/2",
 						},
 					},
 				},
@@ -185,13 +186,13 @@ func TestExplainLatestCommitsDagScan(t *testing.T) {
 		},
 	}
 
-	executeTestCase(t, test)
+	runExplainTest(t, test)
 }
 
-func TestExplainLatestCommitsDagScanWithoutField(t *testing.T) {
-	test := testUtils.RequestTestCase{
+func TestDefaultExplainLatestCommitsDagScanQueryOpWithoutField(t *testing.T) {
+	test := explainUtils.ExplainRequestTestCase{
 
-		Description: "Explain latestCommits query with only dockey (no field).",
+		Description: "Explain (default) latestCommits query-op with only dockey (no field).",
 
 		Request: `query @explain {
 			latestCommits(dockey: "bae-41598f0c-19bc-5da6-813b-e80f14a10df3") {
@@ -220,22 +221,19 @@ func TestExplainLatestCommitsDagScanWithoutField(t *testing.T) {
 			},
 		},
 
-		Results: []dataMap{
+		ExpectedPatterns: []dataMap{dagScanPattern},
+
+		ExpectedTargets: []explainUtils.PlanNodeTargetCase{
 			{
-				"explain": dataMap{
-					"selectTopNode": dataMap{
-						"selectNode": dataMap{
-							"filter": nil,
-							"dagScanNode": dataMap{
-								"cid":     nil,
-								"fieldId": "C",
-								"spans": []dataMap{
-									{
-										"start": "/bae-41598f0c-19bc-5da6-813b-e80f14a10df3/C",
-										"end":   "/bae-41598f0c-19bc-5da6-813b-e80f14a10df3/D",
-									},
-								},
-							},
+				TargetNodeName:    "dagScanNode",
+				IncludeChildNodes: true, // Shouldn't have any as this is the last node in the chain.
+				ExpectedAttributes: dataMap{
+					"cid":     nil,
+					"fieldId": "C",
+					"spans": []dataMap{
+						{
+							"start": "/bae-41598f0c-19bc-5da6-813b-e80f14a10df3/C",
+							"end":   "/bae-41598f0c-19bc-5da6-813b-e80f14a10df3/D",
 						},
 					},
 				},
@@ -243,13 +241,13 @@ func TestExplainLatestCommitsDagScanWithoutField(t *testing.T) {
 		},
 	}
 
-	executeTestCase(t, test)
+	runExplainTest(t, test)
 }
 
-func TestExplainLatestCommitsDagScanWithoutDocKey_Failure(t *testing.T) {
-	test := testUtils.RequestTestCase{
+func TestDefaultExplainLatestCommitsDagScanWithoutDocKey_Failure(t *testing.T) {
+	test := explainUtils.ExplainRequestTestCase{
 
-		Description: "Explain latestCommits query without DocKey.",
+		Description: "Explain (default) latestCommits query without DocKey.",
 
 		Request: `query @explain {
 			latestCommits(fieldId: "1") {
@@ -263,13 +261,13 @@ func TestExplainLatestCommitsDagScanWithoutDocKey_Failure(t *testing.T) {
 		ExpectedError: "Field \"latestCommits\" argument \"dockey\" of type \"ID!\" is required but not provided.",
 	}
 
-	executeTestCase(t, test)
+	runExplainTest(t, test)
 }
 
-func TestExplainLatestCommitsDagScanWithoutAnyArguments_Failure(t *testing.T) {
-	test := testUtils.RequestTestCase{
+func TestDefaultExplainLatestCommitsDagScanWithoutAnyArguments_Failure(t *testing.T) {
+	test := explainUtils.ExplainRequestTestCase{
 
-		Description: "Explain latestCommits query without any arguments.",
+		Description: "Explain (default) latestCommits query without any arguments.",
 
 		Request: `query @explain {
 			latestCommits {
@@ -283,5 +281,5 @@ func TestExplainLatestCommitsDagScanWithoutAnyArguments_Failure(t *testing.T) {
 		ExpectedError: "Field \"latestCommits\" argument \"dockey\" of type \"ID!\" is required but not provided.",
 	}
 
-	executeTestCase(t, test)
+	runExplainTest(t, test)
 }

--- a/tests/integration/explain/default/invalid_type_arg_test.go
+++ b/tests/integration/explain/default/invalid_type_arg_test.go
@@ -13,11 +13,11 @@ package test_explain_default
 import (
 	"testing"
 
-	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	explainUtils "github.com/sourcenetwork/defradb/tests/integration/explain"
 )
 
 func TestInvalidExplainRequestTypeReturnsError(t *testing.T) {
-	test := testUtils.RequestTestCase{
+	test := explainUtils.ExplainRequestTestCase{
 		Description: "Invalid type of explain request should error.",
 
 		Request: `query @explain(type: invalid) {
@@ -40,5 +40,5 @@ func TestInvalidExplainRequestTypeReturnsError(t *testing.T) {
 		ExpectedError: "Argument \"type\" has invalid value invalid.\nExpected type \"ExplainType\", found invalid.",
 	}
 
-	executeTestCase(t, test)
+	runExplainTest(t, test)
 }

--- a/tests/integration/explain/default/with_limit_count_test.go
+++ b/tests/integration/explain/default/with_limit_count_test.go
@@ -16,9 +16,10 @@ import (
 	explainUtils "github.com/sourcenetwork/defradb/tests/integration/explain"
 )
 
-func TestExplainQueryWithMultipleConflictingInnerLimits(t *testing.T) {
+func TestDefaultExplainRequestWithOnlyLimitOnRelatedChildWithCount(t *testing.T) {
 	test := explainUtils.ExplainRequestTestCase{
-		Description: "Explain Query With multiple conflicting inner limit nodes.",
+
+		Description: "Explain (default) request with limit on related child with count.",
 
 		Request: `query @explain {
 			Author {
@@ -128,34 +129,10 @@ func TestExplainQueryWithMultipleConflictingInnerLimits(t *testing.T) {
 							"selectNode": dataMap{
 								"parallelNode": []dataMap{
 									{
-										"typeIndexJoin": dataMap{
-											"root": dataMap{
-												"scanNode": dataMap{},
-											},
-											"subType": dataMap{
-												"selectTopNode": dataMap{
-													"limitNode": dataMap{
-														"selectNode": dataMap{
-															"scanNode": dataMap{},
-														},
-													},
-												},
-											},
-										},
+										"typeIndexJoin": limitTypeJoinPattern,
 									},
 									{
-										"typeIndexJoin": dataMap{
-											"root": dataMap{
-												"scanNode": dataMap{},
-											},
-											"subType": dataMap{
-												"selectTopNode": dataMap{
-													"selectNode": dataMap{
-														"scanNode": dataMap{},
-													},
-												},
-											},
-										},
+										"typeIndexJoin": normalTypeJoinPattern,
 									},
 								},
 							},
@@ -192,9 +169,10 @@ func TestExplainQueryWithMultipleConflictingInnerLimits(t *testing.T) {
 	runExplainTest(t, test)
 }
 
-func TestExplainQueryWithMultipleConflictingInnerLimitsAndOuterLimit(t *testing.T) {
+func TestDefaultExplainRequestWithLimitArgsOnParentAndRelatedChildWithCount(t *testing.T) {
 	test := explainUtils.ExplainRequestTestCase{
-		Description: "Explain Query With multiple conflicting inner limit nodes and an outer limit.",
+
+		Description: "Explain (default) request with limit args on parent and related child with count.",
 
 		Request: `query @explain {
 			Author(limit: 3, offset: 1) {
@@ -305,34 +283,10 @@ func TestExplainQueryWithMultipleConflictingInnerLimitsAndOuterLimit(t *testing.
 								"selectNode": dataMap{
 									"parallelNode": []dataMap{
 										{
-											"typeIndexJoin": dataMap{
-												"root": dataMap{
-													"scanNode": dataMap{},
-												},
-												"subType": dataMap{
-													"selectTopNode": dataMap{
-														"limitNode": dataMap{
-															"selectNode": dataMap{
-																"scanNode": dataMap{},
-															},
-														},
-													},
-												},
-											},
+											"typeIndexJoin": limitTypeJoinPattern,
 										},
 										{
-											"typeIndexJoin": dataMap{
-												"root": dataMap{
-													"scanNode": dataMap{},
-												},
-												"subType": dataMap{
-													"selectTopNode": dataMap{
-														"selectNode": dataMap{
-															"scanNode": dataMap{},
-														},
-													},
-												},
-											},
+											"typeIndexJoin": normalTypeJoinPattern,
 										},
 									},
 								},

--- a/tests/integration/explain/default/with_limit_join_test.go
+++ b/tests/integration/explain/default/with_limit_join_test.go
@@ -16,58 +16,38 @@ import (
 	explainUtils "github.com/sourcenetwork/defradb/tests/integration/explain"
 )
 
-var limitOnlyOnJoinPattern = dataMap{
-	"explain": dataMap{
+var normalTypeJoinPattern = dataMap{
+	"root": dataMap{
+		"scanNode": dataMap{},
+	},
+	"subType": dataMap{
 		"selectTopNode": dataMap{
 			"selectNode": dataMap{
-				"typeIndexJoin": dataMap{
-					"root": dataMap{
-						"scanNode": dataMap{},
-					},
-					"subType": dataMap{
-						"selectTopNode": dataMap{
-							"limitNode": dataMap{
-								"selectNode": dataMap{
-									"scanNode": dataMap{},
-								},
-							},
-						},
-					},
-				},
+				"scanNode": dataMap{},
 			},
 		},
 	},
 }
 
-var limitOnParentAndOnJoinPattern = dataMap{
-	"explain": dataMap{
+var limitTypeJoinPattern = dataMap{
+	"root": dataMap{
+		"scanNode": dataMap{},
+	},
+	"subType": dataMap{
 		"selectTopNode": dataMap{
 			"limitNode": dataMap{
 				"selectNode": dataMap{
-					"typeIndexJoin": dataMap{
-						"root": dataMap{
-							"scanNode": dataMap{},
-						},
-						"subType": dataMap{
-							"selectTopNode": dataMap{
-								"limitNode": dataMap{
-									"selectNode": dataMap{
-										"scanNode": dataMap{},
-									},
-								},
-							},
-						},
-					},
+					"scanNode": dataMap{},
 				},
 			},
 		},
 	},
 }
 
-func TestExplainQueryWithOnlyLimitOnChild(t *testing.T) {
+func TestDefaultExplainRequestWithOnlyLimitOnRelatedChild(t *testing.T) {
 	test := explainUtils.ExplainRequestTestCase{
 
-		Description: "change Explain Query With Only Limit On Child.",
+		Description: "Explain (default) request with only limit on related child.",
 
 		Request: `query @explain {
 			Author {
@@ -169,7 +149,17 @@ func TestExplainQueryWithOnlyLimitOnChild(t *testing.T) {
 			},
 		},
 
-		ExpectedPatterns: []dataMap{limitOnlyOnJoinPattern},
+		ExpectedPatterns: []dataMap{
+			{
+				"explain": dataMap{
+					"selectTopNode": dataMap{
+						"selectNode": dataMap{
+							"typeIndexJoin": limitTypeJoinPattern,
+						},
+					},
+				},
+			},
+		},
 
 		ExpectedTargets: []explainUtils.PlanNodeTargetCase{
 			{
@@ -186,10 +176,10 @@ func TestExplainQueryWithOnlyLimitOnChild(t *testing.T) {
 	runExplainTest(t, test)
 }
 
-func TestExplainQueryWithOnlyOffsetOnChild(t *testing.T) {
+func TestDefaultExplainRequestWithOnlyOffsetOnRelatedChild(t *testing.T) {
 	test := explainUtils.ExplainRequestTestCase{
 
-		Description: "Explain Query With Only Offset On Child.",
+		Description: "Explain (default) request with only offset on related child.",
 
 		Request: `query @explain {
 			Author {
@@ -291,7 +281,17 @@ func TestExplainQueryWithOnlyOffsetOnChild(t *testing.T) {
 			},
 		},
 
-		ExpectedPatterns: []dataMap{limitOnlyOnJoinPattern},
+		ExpectedPatterns: []dataMap{
+			{
+				"explain": dataMap{
+					"selectTopNode": dataMap{
+						"selectNode": dataMap{
+							"typeIndexJoin": limitTypeJoinPattern,
+						},
+					},
+				},
+			},
+		},
 
 		ExpectedTargets: []explainUtils.PlanNodeTargetCase{
 			{
@@ -308,10 +308,10 @@ func TestExplainQueryWithOnlyOffsetOnChild(t *testing.T) {
 	runExplainTest(t, test)
 }
 
-func TestExplainQueryWithBothLimitAndOffsetOnChild(t *testing.T) {
+func TestDefaultExplainRequestWithBothLimitAndOffsetOnRelatedChild(t *testing.T) {
 	test := explainUtils.ExplainRequestTestCase{
 
-		Description: "Explain Query With Both Limit And Offset On Child.",
+		Description: "Explain (default) request with both limit and offset on related child.",
 
 		Request: `query @explain {
 			Author {
@@ -413,7 +413,17 @@ func TestExplainQueryWithBothLimitAndOffsetOnChild(t *testing.T) {
 			},
 		},
 
-		ExpectedPatterns: []dataMap{limitOnlyOnJoinPattern},
+		ExpectedPatterns: []dataMap{
+			{
+				"explain": dataMap{
+					"selectTopNode": dataMap{
+						"selectNode": dataMap{
+							"typeIndexJoin": limitTypeJoinPattern,
+						},
+					},
+				},
+			},
+		},
 
 		ExpectedTargets: []explainUtils.PlanNodeTargetCase{
 			{
@@ -430,10 +440,10 @@ func TestExplainQueryWithBothLimitAndOffsetOnChild(t *testing.T) {
 	runExplainTest(t, test)
 }
 
-func TestExplainQueryWithLimitOnChildAndBothLimitAndOffsetOnParent(t *testing.T) {
+func TestDefaultExplainRequestWithLimitOnRelatedChildAndBothLimitAndOffsetOnParent(t *testing.T) {
 	test := explainUtils.ExplainRequestTestCase{
 
-		Description: "Explain Query With Limit On Child And Both Limit And Offset On Parent.",
+		Description: "Explain (default) request with limit on related child & both limit + offset on parent.",
 
 		Request: `query @explain {
 			Author(limit: 3, offset: 1) {
@@ -535,7 +545,19 @@ func TestExplainQueryWithLimitOnChildAndBothLimitAndOffsetOnParent(t *testing.T)
 			},
 		},
 
-		ExpectedPatterns: []dataMap{limitOnParentAndOnJoinPattern},
+		ExpectedPatterns: []dataMap{
+			{
+				"explain": dataMap{
+					"selectTopNode": dataMap{
+						"limitNode": dataMap{
+							"selectNode": dataMap{
+								"typeIndexJoin": limitTypeJoinPattern,
+							},
+						},
+					},
+				},
+			},
+		},
 
 		ExpectedTargets: []explainUtils.PlanNodeTargetCase{
 			{


### PR DESCRIPTION
## Relevant issue(s)
- Part of #953
- Resolves #1473

## Description
Continue converting explain tests to the new explain setup before we can integrate the entire setup to the new action based setup. #953 Has a lot more detail on the entire plan.

- Fixes test names and some fixtures for the limit test.
- This PR converts all the default dagscan explain tests to the new explain setup.
- Converts a wrong usage explain test case.

