### PR TITLE
test: Convert explain join tests to new explain setup

### DIFF
--- a/tests/integration/explain/default/type_join_many_test.go
+++ b/tests/integration/explain/default/type_join_many_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Democratized Data Foundation
+// Copyright 2023 Democratized Data Foundation
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt.

--- a/tests/integration/explain/default/type_join_many_test.go
+++ b/tests/integration/explain/default/type_join_many_test.go
@@ -1,0 +1,186 @@
+// Copyright 2022 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package test_explain_default
+
+import (
+	"testing"
+
+	explainUtils "github.com/sourcenetwork/defradb/tests/integration/explain"
+)
+
+func TestDefaultExplainRequestWithAOneToManyJoin(t *testing.T) {
+	test := explainUtils.ExplainRequestTestCase{
+
+		Description: "Explain (default) request with a 1-to-M join.",
+
+		Request: `query @explain {
+			Author {
+				articles {
+					name
+				}
+			}
+		}`,
+
+		Docs: map[int][]string{
+			// articles
+			0: {
+				`{
+					"name": "After Guantánamo, Another Injustice",
+					"author_id": "bae-41598f0c-19bc-5da6-813b-e80f14a10df3"
+				}`,
+				`{
+					"name": "To my dear readers",
+					"author_id": "bae-b769708d-f552-5c3d-a402-ccfd7ac7fb04"
+					}`,
+				`{
+					"name": "Twinklestar's Favourite Xmas Cookie",
+					"author_id": "bae-b769708d-f552-5c3d-a402-ccfd7ac7fb04"
+				}`,
+			},
+			// books
+			1: {
+				`{
+					"name": "Painted House",
+					"author_id": "bae-41598f0c-19bc-5da6-813b-e80f14a10df3"
+				}`,
+				`{
+					"name": "A Time for Mercy",
+					"author_id": "bae-41598f0c-19bc-5da6-813b-e80f14a10df3"
+					}`,
+				`{
+					"name": "Theif Lord",
+					"author_id": "bae-b769708d-f552-5c3d-a402-ccfd7ac7fb04"
+				}`,
+			},
+			// authors
+			2: {
+				// _key: bae-41598f0c-19bc-5da6-813b-e80f14a10df3
+				`{
+					"name": "John Grisham",
+					"age": 65,
+					"verified": true,
+					"contact_id": "bae-1fe427b8-ab8d-56c3-9df2-826a6ce86fed"
+				}`,
+				// _key: bae-b769708d-f552-5c3d-a402-ccfd7ac7fb04
+				`{
+					"name": "Cornelia Funke",
+					"age": 62,
+					"verified": false,
+					"contact_id": "bae-c0960a29-b704-5c37-9c2e-59e1249e4559"
+				}`,
+			},
+			// contact
+			3: {
+				// _key: bae-1fe427b8-ab8d-56c3-9df2-826a6ce86fed
+				// "author_id": "bae-41598f0c-19bc-5da6-813b-e80f14a10df3"
+				`{
+					"cell": "5197212301",
+					"email": "john_grisham@example.com",
+					"address_id": "bae-c8448e47-6cd1-571f-90bd-364acb80da7b"
+				}`,
+
+				// _key: bae-c0960a29-b704-5c37-9c2e-59e1249e4559
+				// "author_id": "bae-b769708d-f552-5c3d-a402-ccfd7ac7fb04"
+				`{
+					"cell": "5197212302",
+					"email": "cornelia_funke@example.com",
+					"address_id": "bae-c0960a29-b704-5c37-9c2e-59e1249e4559"
+				}`,
+			},
+
+			// address
+			4: {
+				// _key: bae-c8448e47-6cd1-571f-90bd-364acb80da7b
+				// "contact_id": "bae-1fe427b8-ab8d-56c3-9df2-826a6ce86fed"
+				`{
+					"city": "Waterloo",
+					"country": "Canada"
+				}`,
+
+				// _key: bae-f01bf83f-1507-5fb5-a6a3-09ecffa3c692
+				// "contact_id": "bae-c0960a29-b704-5c37-9c2e-59e1249e4559"
+				`{
+					"city": "Brampton",
+					"country": "Canada"
+				}`,
+			},
+		},
+
+		ExpectedPatterns: []dataMap{
+			{
+				"explain": dataMap{
+					"selectTopNode": dataMap{
+						"selectNode": dataMap{
+							"typeIndexJoin": normalTypeJoinPattern,
+						},
+					},
+				},
+			},
+		},
+
+		ExpectedTargets: []explainUtils.PlanNodeTargetCase{
+			{
+				TargetNodeName:    "typeIndexJoin",
+				IncludeChildNodes: false,
+				ExpectedAttributes: dataMap{
+					"joinType":    "typeJoinMany",
+					"rootName":    "author",
+					"subTypeName": "articles",
+				},
+			},
+			{
+				// Note: `root` is not a node but is a special case because for typeIndexJoin we
+				//       restructure to show both `root` and `subType` at the same level.
+				TargetNodeName:    "root",
+				IncludeChildNodes: true, // We care about checking children nodes.
+				ExpectedAttributes: dataMap{
+					"scanNode": dataMap{
+						"filter":         nil,
+						"collectionID":   "3",
+						"collectionName": "Author",
+						"spans": []dataMap{
+							{
+								"start": "/3",
+								"end":   "/4",
+							},
+						},
+					},
+				},
+			},
+			{
+				// Note: `subType` is not a node but is a special case because for typeIndexJoin we
+				//       restructure to show both `root` and `subType` at the same level.
+				TargetNodeName:    "subType",
+				IncludeChildNodes: true, // We care about checking children nodes.
+				ExpectedAttributes: dataMap{
+					"selectTopNode": dataMap{
+						"selectNode": dataMap{
+							"filter": nil,
+							"scanNode": dataMap{
+								"filter":         nil,
+								"collectionID":   "1",
+								"collectionName": "Article",
+								"spans": []dataMap{
+									{
+										"start": "/1",
+										"end":   "/2",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	runExplainTest(t, test)
+}

--- a/tests/integration/explain/default/type_join_one_test.go
+++ b/tests/integration/explain/default/type_join_one_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Democratized Data Foundation
+// Copyright 2023 Democratized Data Foundation
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt.

--- a/tests/integration/explain/default/type_join_one_test.go
+++ b/tests/integration/explain/default/type_join_one_test.go
@@ -1,0 +1,404 @@
+// Copyright 2022 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package test_explain_default
+
+import (
+	"testing"
+
+	explainUtils "github.com/sourcenetwork/defradb/tests/integration/explain"
+)
+
+func TestDefaultExplainRequestWithAOneToOneJoin(t *testing.T) {
+	test := explainUtils.ExplainRequestTestCase{
+
+		Description: "Explain (default) request with a 1-to-1 join.",
+
+		Request: `query @explain {
+			Author {
+				OnlyEmail: contact {
+					email
+				}
+			}
+		}`,
+
+		Docs: map[int][]string{
+			// articles
+			0: {
+				`{
+					"name": "After Guantánamo, Another Injustice",
+					"author_id": "bae-41598f0c-19bc-5da6-813b-e80f14a10df3"
+				}`,
+				`{
+					"name": "To my dear readers",
+					"author_id": "bae-b769708d-f552-5c3d-a402-ccfd7ac7fb04"
+					}`,
+				`{
+					"name": "Twinklestar's Favourite Xmas Cookie",
+					"author_id": "bae-b769708d-f552-5c3d-a402-ccfd7ac7fb04"
+				}`,
+			},
+			// books
+			1: {
+				`{
+					"name": "Painted House",
+					"author_id": "bae-41598f0c-19bc-5da6-813b-e80f14a10df3"
+				}`,
+				`{
+					"name": "A Time for Mercy",
+					"author_id": "bae-41598f0c-19bc-5da6-813b-e80f14a10df3"
+					}`,
+				`{
+					"name": "Theif Lord",
+					"author_id": "bae-b769708d-f552-5c3d-a402-ccfd7ac7fb04"
+				}`,
+			},
+			// authors
+			2: {
+				// _key: bae-41598f0c-19bc-5da6-813b-e80f14a10df3
+				`{
+					"name": "John Grisham",
+					"age": 65,
+					"verified": true,
+					"contact_id": "bae-1fe427b8-ab8d-56c3-9df2-826a6ce86fed"
+				}`,
+				// _key: bae-b769708d-f552-5c3d-a402-ccfd7ac7fb04
+				`{
+					"name": "Cornelia Funke",
+					"age": 62,
+					"verified": false,
+					"contact_id": "bae-c0960a29-b704-5c37-9c2e-59e1249e4559"
+				}`,
+			},
+			// contact
+			3: {
+				// _key: bae-1fe427b8-ab8d-56c3-9df2-826a6ce86fed
+				// "author_id": "bae-41598f0c-19bc-5da6-813b-e80f14a10df3"
+				`{
+					"cell": "5197212301",
+					"email": "john_grisham@example.com",
+					"address_id": "bae-c8448e47-6cd1-571f-90bd-364acb80da7b"
+				}`,
+
+				// _key: bae-c0960a29-b704-5c37-9c2e-59e1249e4559
+				// "author_id": "bae-b769708d-f552-5c3d-a402-ccfd7ac7fb04"
+				`{
+					"cell": "5197212302",
+					"email": "cornelia_funke@example.com",
+					"address_id": "bae-c0960a29-b704-5c37-9c2e-59e1249e4559"
+				}`,
+			},
+
+			// address
+			4: {
+				// _key: bae-c8448e47-6cd1-571f-90bd-364acb80da7b
+				// "contact_id": "bae-1fe427b8-ab8d-56c3-9df2-826a6ce86fed"
+				`{
+					"city": "Waterloo",
+					"country": "Canada"
+				}`,
+
+				// _key: bae-f01bf83f-1507-5fb5-a6a3-09ecffa3c692
+				// "contact_id": "bae-c0960a29-b704-5c37-9c2e-59e1249e4559"
+				`{
+					"city": "Brampton",
+					"country": "Canada"
+				}`,
+			},
+		},
+
+		ExpectedPatterns: []dataMap{
+			{
+				"explain": dataMap{
+					"selectTopNode": dataMap{
+						"selectNode": dataMap{
+							"typeIndexJoin": normalTypeJoinPattern,
+						},
+					},
+				},
+			},
+		},
+
+		ExpectedTargets: []explainUtils.PlanNodeTargetCase{
+			{
+				TargetNodeName:    "typeIndexJoin",
+				IncludeChildNodes: false,
+				ExpectedAttributes: dataMap{
+					"direction":   "primary",
+					"joinType":    "typeJoinOne",
+					"rootName":    "author",
+					"subTypeName": "contact",
+				},
+			},
+			{
+				// Note: `root` is not a node but is a special case because for typeIndexJoin we
+				//       restructure to show both `root` and `subType` at the same level.
+				TargetNodeName:    "root",
+				IncludeChildNodes: true, // We care about checking children nodes.
+				ExpectedAttributes: dataMap{
+					"scanNode": dataMap{
+						"filter":         nil,
+						"collectionID":   "3",
+						"collectionName": "Author",
+						"spans": []dataMap{
+							{
+								"start": "/3",
+								"end":   "/4",
+							},
+						},
+					},
+				},
+			},
+			{
+				// Note: `subType` is not a node but is a special case because for typeIndexJoin we
+				//       restructure to show both `root` and `subType` at the same level.
+				TargetNodeName:    "subType",
+				IncludeChildNodes: true, // We care about checking children nodes.
+				ExpectedAttributes: dataMap{
+					"selectTopNode": dataMap{
+						"selectNode": dataMap{
+							"filter": nil,
+							"scanNode": dataMap{
+								"filter":         nil,
+								"collectionID":   "4",
+								"collectionName": "AuthorContact",
+								"spans": []dataMap{
+									{
+										"start": "/4",
+										"end":   "/5",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	runExplainTest(t, test)
+}
+
+func TestDefaultExplainRequestWithTwoLevelDeepNestedJoins(t *testing.T) {
+	test := explainUtils.ExplainRequestTestCase{
+
+		Description: "Explain (default) request with two level deep nested joins.",
+
+		Request: `query @explain {
+			Author {
+				name
+				contact {
+					email
+					address {
+						city
+					}
+				}
+			}
+		}`,
+
+		Docs: map[int][]string{
+			// articles
+			0: {
+				`{
+					"name": "After Guantánamo, Another Injustice",
+					"author_id": "bae-41598f0c-19bc-5da6-813b-e80f14a10df3"
+				}`,
+				`{
+					"name": "To my dear readers",
+					"author_id": "bae-b769708d-f552-5c3d-a402-ccfd7ac7fb04"
+					}`,
+				`{
+					"name": "Twinklestar's Favourite Xmas Cookie",
+					"author_id": "bae-b769708d-f552-5c3d-a402-ccfd7ac7fb04"
+				}`,
+			},
+			// books
+			1: {
+				`{
+					"name": "Painted House",
+					"author_id": "bae-41598f0c-19bc-5da6-813b-e80f14a10df3"
+				}`,
+				`{
+					"name": "A Time for Mercy",
+					"author_id": "bae-41598f0c-19bc-5da6-813b-e80f14a10df3"
+					}`,
+				`{
+					"name": "Theif Lord",
+					"author_id": "bae-b769708d-f552-5c3d-a402-ccfd7ac7fb04"
+				}`,
+			},
+			// authors
+			2: {
+				// _key: bae-41598f0c-19bc-5da6-813b-e80f14a10df3
+				`{
+					"name": "John Grisham",
+					"age": 65,
+					"verified": true,
+					"contact_id": "bae-1fe427b8-ab8d-56c3-9df2-826a6ce86fed"
+				}`,
+				// _key: bae-b769708d-f552-5c3d-a402-ccfd7ac7fb04
+				`{
+					"name": "Cornelia Funke",
+					"age": 62,
+					"verified": false,
+					"contact_id": "bae-c0960a29-b704-5c37-9c2e-59e1249e4559"
+				}`,
+			},
+			// contact
+			3: {
+				// _key: bae-1fe427b8-ab8d-56c3-9df2-826a6ce86fed
+				// "author_id": "bae-41598f0c-19bc-5da6-813b-e80f14a10df3"
+				`{
+					"cell": "5197212301",
+					"email": "john_grisham@example.com",
+					"address_id": "bae-c8448e47-6cd1-571f-90bd-364acb80da7b"
+				}`,
+
+				// _key: bae-c0960a29-b704-5c37-9c2e-59e1249e4559
+				// "author_id": "bae-b769708d-f552-5c3d-a402-ccfd7ac7fb04"
+				`{
+					"cell": "5197212302",
+					"email": "cornelia_funke@example.com",
+					"address_id": "bae-c0960a29-b704-5c37-9c2e-59e1249e4559"
+				}`,
+			},
+
+			// address
+			4: {
+				// _key: bae-c8448e47-6cd1-571f-90bd-364acb80da7b
+				// "contact_id": "bae-1fe427b8-ab8d-56c3-9df2-826a6ce86fed"
+				`{
+					"city": "Waterloo",
+					"country": "Canada"
+				}`,
+
+				// _key: bae-f01bf83f-1507-5fb5-a6a3-09ecffa3c692
+				// "contact_id": "bae-c0960a29-b704-5c37-9c2e-59e1249e4559"
+				`{
+					"city": "Brampton",
+					"country": "Canada"
+				}`,
+			},
+		},
+
+		ExpectedPatterns: []dataMap{
+			{
+				"explain": dataMap{
+					"selectTopNode": dataMap{
+						"selectNode": dataMap{
+							"typeIndexJoin": dataMap{
+								"root": dataMap{
+									"scanNode": dataMap{},
+								},
+								"subType": dataMap{
+									"selectTopNode": dataMap{
+										"selectNode": dataMap{
+											"typeIndexJoin": normalTypeJoinPattern,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+
+		ExpectedTargets: []explainUtils.PlanNodeTargetCase{
+			{
+				TargetNodeName:    "typeIndexJoin",
+				OccurancesToSkip:  0,
+				IncludeChildNodes: false,
+				ExpectedAttributes: dataMap{
+					"direction":   "primary",
+					"joinType":    "typeJoinOne",
+					"rootName":    "author",
+					"subTypeName": "contact",
+				},
+			},
+			{
+				TargetNodeName:    "root",
+				OccurancesToSkip:  0,
+				IncludeChildNodes: true, // We care about checking children nodes.
+				ExpectedAttributes: dataMap{
+					"scanNode": dataMap{
+						"filter":         nil,
+						"collectionID":   "3",
+						"collectionName": "Author",
+						"spans": []dataMap{
+							{
+								"start": "/3",
+								"end":   "/4",
+							},
+						},
+					},
+				},
+			},
+
+			// Note: the 1st `subType` will contain the entire rest of the graph so we target
+			//       and select only the nodes we care about inside it and not `subType` itself.
+
+			{
+				TargetNodeName:    "typeIndexJoin",
+				OccurancesToSkip:  1,
+				IncludeChildNodes: false,
+				ExpectedAttributes: dataMap{
+					"direction":   "primary",
+					"joinType":    "typeJoinOne",
+					"rootName":    "contact",
+					"subTypeName": "address",
+				},
+			},
+			{
+				TargetNodeName:    "root",
+				OccurancesToSkip:  1,
+				IncludeChildNodes: true,
+				ExpectedAttributes: dataMap{
+					"scanNode": dataMap{
+						"filter":         nil,
+						"collectionID":   "4",
+						"collectionName": "AuthorContact",
+						"spans": []dataMap{
+							{
+								"start": "/4",
+								"end":   "/5",
+							},
+						},
+					},
+				},
+			},
+			{
+				TargetNodeName:    "subType", // The last subType (assert everything under it).
+				OccurancesToSkip:  1,
+				IncludeChildNodes: true,
+				ExpectedAttributes: dataMap{
+					"selectTopNode": dataMap{
+						"selectNode": dataMap{
+							"filter": nil,
+							"scanNode": dataMap{
+								"filter":         nil,
+								"collectionID":   "5",
+								"collectionName": "ContactAddress",
+								"spans": []dataMap{
+									{
+										"start": "/5",
+										"end":   "/6",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	runExplainTest(t, test)
+}

--- a/tests/integration/explain/default/type_join_test.go
+++ b/tests/integration/explain/default/type_join_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Democratized Data Foundation
+// Copyright 2023 Democratized Data Foundation
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt.

--- a/tests/integration/explain/default/type_join_test.go
+++ b/tests/integration/explain/default/type_join_test.go
@@ -13,13 +13,13 @@ package test_explain_default
 import (
 	"testing"
 
-	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	explainUtils "github.com/sourcenetwork/defradb/tests/integration/explain"
 )
 
-func TestExplainQueryWithAOneToOneJoin(t *testing.T) {
-	test := testUtils.RequestTestCase{
+func TestDefaultExplainRequestWithAOneToOneJoin(t *testing.T) {
+	test := explainUtils.ExplainRequestTestCase{
 
-		Description: "Explain a one-to-one join relation query, with alias.",
+		Description: "Explain (default) request with a 1-to-1 join.",
 
 		Request: `query @explain {
 			Author {
@@ -114,7 +114,7 @@ func TestExplainQueryWithAOneToOneJoin(t *testing.T) {
 			},
 		},
 
-		Results: []dataMap{
+		ExpectedFullGraph: []dataMap{
 			{
 				"explain": dataMap{
 					"selectTopNode": dataMap{
@@ -164,13 +164,13 @@ func TestExplainQueryWithAOneToOneJoin(t *testing.T) {
 		},
 	}
 
-	executeTestCase(t, test)
+	runExplainTest(t, test)
 }
 
-func TestExplainQueryWithMultipleOneToOneJoins(t *testing.T) {
-	test := testUtils.RequestTestCase{
+func TestDefaultExplainRequestWithMultipleOneToOneJoins(t *testing.T) {
+	test := explainUtils.ExplainRequestTestCase{
 
-		Description: "Explain two one-to-one join relation query.",
+		Description: "Explain (default) request with multiple (two) 1-to-1 joins.",
 
 		Request: `query @explain {
 			Author {
@@ -269,7 +269,7 @@ func TestExplainQueryWithMultipleOneToOneJoins(t *testing.T) {
 			},
 		},
 
-		Results: []dataMap{
+		ExpectedFullGraph: []dataMap{
 			{
 				"explain": dataMap{
 					"selectTopNode": dataMap{
@@ -362,13 +362,13 @@ func TestExplainQueryWithMultipleOneToOneJoins(t *testing.T) {
 		},
 	}
 
-	executeTestCase(t, test)
+	runExplainTest(t, test)
 }
 
-func TestExplainQueryWithTwoLeveLDeepNestedJoins(t *testing.T) {
-	test := testUtils.RequestTestCase{
+func TestDefaultExplainRequestWithTwoLevelDeepNestedJoins(t *testing.T) {
+	test := explainUtils.ExplainRequestTestCase{
 
-		Description: "Explain query with two nested level deep one to one join.",
+		Description: "Explain (default) request with two level deep nested joins.",
 
 		Request: `query @explain {
 			Author {
@@ -468,7 +468,7 @@ func TestExplainQueryWithTwoLeveLDeepNestedJoins(t *testing.T) {
 			},
 		},
 
-		Results: []dataMap{
+		ExpectedFullGraph: []dataMap{
 			{
 				"explain": dataMap{
 					"selectTopNode": dataMap{
@@ -544,5 +544,5 @@ func TestExplainQueryWithTwoLeveLDeepNestedJoins(t *testing.T) {
 		},
 	}
 
-	executeTestCase(t, test)
+	runExplainTest(t, test)
 }

--- a/tests/integration/explain/default/type_join_test.go
+++ b/tests/integration/explain/default/type_join_test.go
@@ -16,166 +16,31 @@ import (
 	explainUtils "github.com/sourcenetwork/defradb/tests/integration/explain"
 )
 
-func TestDefaultExplainRequestWithAOneToOneJoin(t *testing.T) {
+var normalTypeJoinPattern = dataMap{
+	"root": dataMap{
+		"scanNode": dataMap{},
+	},
+	"subType": dataMap{
+		"selectTopNode": dataMap{
+			"selectNode": dataMap{
+				"scanNode": dataMap{},
+			},
+		},
+	},
+}
+
+func TestDefaultExplainRequestWith2SingleJoinsAnd1ManyJoin(t *testing.T) {
 	test := explainUtils.ExplainRequestTestCase{
 
-		Description: "Explain (default) request with a 1-to-1 join.",
+		Description: "Explain (default) request with 2 single joins and 1 many join.",
 
 		Request: `query @explain {
 			Author {
 				OnlyEmail: contact {
 					email
 				}
-			}
-		}`,
-
-		Docs: map[int][]string{
-			// articles
-			0: {
-				`{
-					"name": "After Guantánamo, Another Injustice",
-					"author_id": "bae-41598f0c-19bc-5da6-813b-e80f14a10df3"
-				}`,
-				`{
-					"name": "To my dear readers",
-					"author_id": "bae-b769708d-f552-5c3d-a402-ccfd7ac7fb04"
-					}`,
-				`{
-					"name": "Twinklestar's Favourite Xmas Cookie",
-					"author_id": "bae-b769708d-f552-5c3d-a402-ccfd7ac7fb04"
-				}`,
-			},
-			// books
-			1: {
-				`{
-					"name": "Painted House",
-					"author_id": "bae-41598f0c-19bc-5da6-813b-e80f14a10df3"
-				}`,
-				`{
-					"name": "A Time for Mercy",
-					"author_id": "bae-41598f0c-19bc-5da6-813b-e80f14a10df3"
-					}`,
-				`{
-					"name": "Theif Lord",
-					"author_id": "bae-b769708d-f552-5c3d-a402-ccfd7ac7fb04"
-				}`,
-			},
-			// authors
-			2: {
-				// _key: bae-41598f0c-19bc-5da6-813b-e80f14a10df3
-				`{
-					"name": "John Grisham",
-					"age": 65,
-					"verified": true,
-					"contact_id": "bae-1fe427b8-ab8d-56c3-9df2-826a6ce86fed"
-				}`,
-				// _key: bae-b769708d-f552-5c3d-a402-ccfd7ac7fb04
-				`{
-					"name": "Cornelia Funke",
-					"age": 62,
-					"verified": false,
-					"contact_id": "bae-c0960a29-b704-5c37-9c2e-59e1249e4559"
-				}`,
-			},
-			// contact
-			3: {
-				// _key: bae-1fe427b8-ab8d-56c3-9df2-826a6ce86fed
-				// "author_id": "bae-41598f0c-19bc-5da6-813b-e80f14a10df3"
-				`{
-					"cell": "5197212301",
-					"email": "john_grisham@example.com",
-					"address_id": "bae-c8448e47-6cd1-571f-90bd-364acb80da7b"
-				}`,
-
-				// _key: bae-c0960a29-b704-5c37-9c2e-59e1249e4559
-				// "author_id": "bae-b769708d-f552-5c3d-a402-ccfd7ac7fb04"
-				`{
-					"cell": "5197212302",
-					"email": "cornelia_funke@example.com",
-					"address_id": "bae-c0960a29-b704-5c37-9c2e-59e1249e4559"
-				}`,
-			},
-
-			// address
-			4: {
-				// _key: bae-c8448e47-6cd1-571f-90bd-364acb80da7b
-				// "contact_id": "bae-1fe427b8-ab8d-56c3-9df2-826a6ce86fed"
-				`{
-					"city": "Waterloo",
-					"country": "Canada"
-				}`,
-
-				// _key: bae-f01bf83f-1507-5fb5-a6a3-09ecffa3c692
-				// "contact_id": "bae-c0960a29-b704-5c37-9c2e-59e1249e4559"
-				`{
-					"city": "Brampton",
-					"country": "Canada"
-				}`,
-			},
-		},
-
-		ExpectedFullGraph: []dataMap{
-			{
-				"explain": dataMap{
-					"selectTopNode": dataMap{
-						"selectNode": dataMap{
-							"filter": nil,
-							"typeIndexJoin": dataMap{
-								"direction": "primary",
-								"joinType":  "typeJoinOne",
-								"rootName":  "author",
-								"root": dataMap{
-									"scanNode": dataMap{
-										"filter":         nil,
-										"collectionID":   "3",
-										"collectionName": "Author",
-										"spans": []dataMap{
-											{
-												"start": "/3",
-												"end":   "/4",
-											},
-										},
-									},
-								},
-								"subTypeName": "contact",
-								"subType": dataMap{
-									"selectTopNode": dataMap{
-										"selectNode": dataMap{
-											"filter": nil,
-											"scanNode": dataMap{
-												"filter":         nil,
-												"collectionID":   "4",
-												"collectionName": "AuthorContact",
-												"spans": []dataMap{
-													{
-														"start": "/4",
-														"end":   "/5",
-													},
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-
-	runExplainTest(t, test)
-}
-
-func TestDefaultExplainRequestWithMultipleOneToOneJoins(t *testing.T) {
-	test := explainUtils.ExplainRequestTestCase{
-
-		Description: "Explain (default) request with multiple (two) 1-to-1 joins.",
-
-		Request: `query @explain {
-			Author {
-				OnlyEmail: contact {
-					email
+				articles {
+					name
 				}
 				contact {
 					cell
@@ -269,90 +134,20 @@ func TestDefaultExplainRequestWithMultipleOneToOneJoins(t *testing.T) {
 			},
 		},
 
-		ExpectedFullGraph: []dataMap{
+		ExpectedPatterns: []dataMap{
 			{
 				"explain": dataMap{
 					"selectTopNode": dataMap{
 						"selectNode": dataMap{
-							"filter": nil,
 							"parallelNode": []dataMap{
 								{
-									"typeIndexJoin": dataMap{
-										"joinType":  "typeJoinOne",
-										"direction": "primary",
-										"rootName":  "author",
-										"root": dataMap{
-											"scanNode": dataMap{
-												"filter":         nil,
-												"collectionID":   "3",
-												"collectionName": "Author",
-												"spans": []dataMap{
-													{
-														"start": "/3",
-														"end":   "/4",
-													},
-												},
-											},
-										},
-										"subTypeName": "contact",
-										"subType": dataMap{
-											"selectTopNode": dataMap{
-												"selectNode": dataMap{
-													"filter": nil,
-													"scanNode": dataMap{
-														"filter":         nil,
-														"collectionID":   "4",
-														"collectionName": "AuthorContact",
-														"spans": []dataMap{
-															{
-																"start": "/4",
-																"end":   "/5",
-															},
-														},
-													},
-												},
-											},
-										},
-									},
+									"typeIndexJoin": normalTypeJoinPattern,
 								},
 								{
-									"typeIndexJoin": dataMap{
-										"joinType":  "typeJoinOne",
-										"direction": "primary",
-										"rootName":  "author",
-										"root": dataMap{
-											"scanNode": dataMap{
-												"filter":         nil,
-												"collectionID":   "3",
-												"collectionName": "Author",
-												"spans": []dataMap{
-													{
-														"start": "/3",
-														"end":   "/4",
-													},
-												},
-											},
-										},
-										"subTypeName": "contact",
-										"subType": dataMap{
-											"selectTopNode": dataMap{
-												"selectNode": dataMap{
-													"filter": nil,
-													"scanNode": dataMap{
-														"filter":         nil,
-														"collectionID":   "4",
-														"collectionName": "AuthorContact",
-														"spans": []dataMap{
-															{
-																"start": "/4",
-																"end":   "/5",
-															},
-														},
-													},
-												},
-											},
-										},
-									},
+									"typeIndexJoin": normalTypeJoinPattern,
+								},
+								{
+									"typeIndexJoin": normalTypeJoinPattern,
 								},
 							},
 						},
@@ -360,183 +155,168 @@ func TestDefaultExplainRequestWithMultipleOneToOneJoins(t *testing.T) {
 				},
 			},
 		},
-	}
 
-	runExplainTest(t, test)
-}
-
-func TestDefaultExplainRequestWithTwoLevelDeepNestedJoins(t *testing.T) {
-	test := explainUtils.ExplainRequestTestCase{
-
-		Description: "Explain (default) request with two level deep nested joins.",
-
-		Request: `query @explain {
-			Author {
-				_key
-				name
-				contact {
-					email
-					address {
-						city
-					}
-				}
-			}
-		}`,
-
-		Docs: map[int][]string{
-			// articles
-			0: {
-				`{
-					"name": "After Guantánamo, Another Injustice",
-					"author_id": "bae-41598f0c-19bc-5da6-813b-e80f14a10df3"
-				}`,
-				`{
-					"name": "To my dear readers",
-					"author_id": "bae-b769708d-f552-5c3d-a402-ccfd7ac7fb04"
-					}`,
-				`{
-					"name": "Twinklestar's Favourite Xmas Cookie",
-					"author_id": "bae-b769708d-f552-5c3d-a402-ccfd7ac7fb04"
-				}`,
-			},
-			// books
-			1: {
-				`{
-					"name": "Painted House",
-					"author_id": "bae-41598f0c-19bc-5da6-813b-e80f14a10df3"
-				}`,
-				`{
-					"name": "A Time for Mercy",
-					"author_id": "bae-41598f0c-19bc-5da6-813b-e80f14a10df3"
-					}`,
-				`{
-					"name": "Theif Lord",
-					"author_id": "bae-b769708d-f552-5c3d-a402-ccfd7ac7fb04"
-				}`,
-			},
-			// authors
-			2: {
-				// _key: bae-41598f0c-19bc-5da6-813b-e80f14a10df3
-				`{
-					"name": "John Grisham",
-					"age": 65,
-					"verified": true,
-					"contact_id": "bae-1fe427b8-ab8d-56c3-9df2-826a6ce86fed"
-				}`,
-				// _key: bae-b769708d-f552-5c3d-a402-ccfd7ac7fb04
-				`{
-					"name": "Cornelia Funke",
-					"age": 62,
-					"verified": false,
-					"contact_id": "bae-c0960a29-b704-5c37-9c2e-59e1249e4559"
-				}`,
-			},
-			// contact
-			3: {
-				// _key: bae-1fe427b8-ab8d-56c3-9df2-826a6ce86fed
-				// "author_id": "bae-41598f0c-19bc-5da6-813b-e80f14a10df3"
-				`{
-					"cell": "5197212301",
-					"email": "john_grisham@example.com",
-					"address_id": "bae-c8448e47-6cd1-571f-90bd-364acb80da7b"
-				}`,
-
-				// _key: bae-c0960a29-b704-5c37-9c2e-59e1249e4559
-				// "author_id": "bae-b769708d-f552-5c3d-a402-ccfd7ac7fb04"
-				`{
-					"cell": "5197212302",
-					"email": "cornelia_funke@example.com",
-					"address_id": "bae-c0960a29-b704-5c37-9c2e-59e1249e4559"
-				}`,
-			},
-
-			// address
-			4: {
-				// _key: bae-c8448e47-6cd1-571f-90bd-364acb80da7b
-				// "contact_id": "bae-1fe427b8-ab8d-56c3-9df2-826a6ce86fed"
-				`{
-					"city": "Waterloo",
-					"country": "Canada"
-				}`,
-
-				// _key: bae-f01bf83f-1507-5fb5-a6a3-09ecffa3c692
-				// "contact_id": "bae-c0960a29-b704-5c37-9c2e-59e1249e4559"
-				`{
-					"city": "Brampton",
-					"country": "Canada"
-				}`,
-			},
-		},
-
-		ExpectedFullGraph: []dataMap{
+		ExpectedTargets: []explainUtils.PlanNodeTargetCase{
+			// 1st join's assertions.
 			{
-				"explain": dataMap{
+				TargetNodeName:    "typeIndexJoin",
+				OccurancesToSkip:  0,
+				IncludeChildNodes: false,
+				ExpectedAttributes: dataMap{
+					"direction":   "primary",
+					"joinType":    "typeJoinOne",
+					"rootName":    "author",
+					"subTypeName": "contact",
+				},
+			},
+			{
+				// Note: `root` is not a node but is a special case because for typeIndexJoin we
+				//       restructure to show both `root` and `subType` at the same level.
+				TargetNodeName:    "root",
+				OccurancesToSkip:  0,
+				IncludeChildNodes: true, // We care about checking children nodes.
+				ExpectedAttributes: dataMap{
+					"scanNode": dataMap{
+						"filter":         nil,
+						"collectionID":   "3",
+						"collectionName": "Author",
+						"spans": []dataMap{
+							{
+								"start": "/3",
+								"end":   "/4",
+							},
+						},
+					},
+				},
+			},
+			{
+				// Note: `subType` is not a node but is a special case because for typeIndexJoin we
+				//       restructure to show both `root` and `subType` at the same level.
+				TargetNodeName:    "subType",
+				OccurancesToSkip:  0,
+				IncludeChildNodes: true, // We care about checking children nodes.
+				ExpectedAttributes: dataMap{
 					"selectTopNode": dataMap{
 						"selectNode": dataMap{
 							"filter": nil,
-							"typeIndexJoin": dataMap{
-								"joinType":  "typeJoinOne",
-								"direction": "primary",
-								"rootName":  "author",
-								"root": dataMap{
-									"scanNode": dataMap{
-										"filter":         nil,
-										"collectionID":   "3",
-										"collectionName": "Author",
-										"spans": []dataMap{
-											{
-												"start": "/3",
-												"end":   "/4",
-											},
-										},
-									},
-								},
-								"subTypeName": "contact",
-								"subType": dataMap{
-									"selectTopNode": dataMap{
-										"selectNode": dataMap{
-											"filter": nil,
-											"typeIndexJoin": dataMap{
-												"joinType":  "typeJoinOne",
-												"direction": "primary",
-												"rootName":  "contact",
-												"root": dataMap{
-													"scanNode": dataMap{
-														"filter":         nil,
-														"collectionID":   "4",
-														"collectionName": "AuthorContact",
-														"spans": []dataMap{
-															{
-																"start": "/4",
-																"end":   "/5",
-															},
-														},
-													},
-												},
-												"subTypeName": "address",
-												"subType": dataMap{
-													"selectTopNode": dataMap{
-														"selectNode": dataMap{
-															"filter": nil,
-															"scanNode": dataMap{
-																"filter":         nil,
-																"collectionID":   "5",
-																"collectionName": "ContactAddress",
-																"spans": []dataMap{
-																	{
-																		"start": "/5",
-																		"end":   "/6",
-																	},
-																},
-															},
-														},
-													},
-												},
-											},
-										},
+							"scanNode": dataMap{
+								"filter":         nil,
+								"collectionID":   "4",
+								"collectionName": "AuthorContact",
+								"spans": []dataMap{
+									{
+										"start": "/4",
+										"end":   "/5",
 									},
 								},
 							},
+						},
+					},
+				},
+			},
+
+			// 2nd join's assertions (the one to many join).
+			{
+				TargetNodeName:    "typeIndexJoin",
+				OccurancesToSkip:  1,
+				IncludeChildNodes: false,
+				ExpectedAttributes: dataMap{
+					"joinType":    "typeJoinMany",
+					"rootName":    "author",
+					"subTypeName": "articles",
+				},
+			},
+			{
+				// Note: `root` is not a node but is a special case because for typeIndexJoin we
+				//       restructure to show both `root` and `subType` at the same level.
+				TargetNodeName:    "root",
+				OccurancesToSkip:  1,
+				IncludeChildNodes: true, // We care about checking children nodes.
+				ExpectedAttributes: dataMap{
+					"scanNode": dataMap{
+						"filter":         nil,
+						"collectionID":   "3",
+						"collectionName": "Author",
+						"spans": []dataMap{
+							{
+								"start": "/3",
+								"end":   "/4",
+							},
+						},
+					},
+				},
+			},
+			{
+				// Note: `subType` is not a node but is a special case because for typeIndexJoin we
+				//       restructure to show both `root` and `subType` at the same level.
+				TargetNodeName:    "subType",
+				OccurancesToSkip:  1,
+				IncludeChildNodes: true, // We care about checking children nodes.
+				ExpectedAttributes: dataMap{
+					"selectTopNode": dataMap{
+						"selectNode": dataMap{
+							"filter": nil,
+							"scanNode": dataMap{
+								"filter":         nil,
+								"collectionID":   "1",
+								"collectionName": "Article",
+								"spans": []dataMap{
+									{
+										"start": "/1",
+										"end":   "/2",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+
+			// 3rd join's assertions (should be same as 1st one, so after `typeIndexJoin` lets just
+			// assert that the `scanNode`s are valid only.
+			{
+				TargetNodeName:    "typeIndexJoin",
+				OccurancesToSkip:  2,
+				IncludeChildNodes: false,
+				ExpectedAttributes: dataMap{
+					"direction":   "primary",
+					"joinType":    "typeJoinOne",
+					"rootName":    "author",
+					"subTypeName": "contact",
+				},
+			},
+			{
+				// Note: `root` is not a node but is a special case because for typeIndexJoin we
+				//       restructure to show both `root` and `subType` at the same level.
+				TargetNodeName:    "scanNode",
+				OccurancesToSkip:  4,    // As we encountered 2 `scanNode`s per join.
+				IncludeChildNodes: true, // Shouldn't have any.
+				ExpectedAttributes: dataMap{
+					"filter":         nil,
+					"collectionID":   "3",
+					"collectionName": "Author",
+					"spans": []dataMap{
+						{
+							"start": "/3",
+							"end":   "/4",
+						},
+					},
+				},
+			},
+			{
+				// Note: `subType` is not a node but is a special case because for typeIndexJoin we
+				//       restructure to show both `root` and `subType` at the same level.
+				TargetNodeName:    "scanNode",
+				OccurancesToSkip:  5,    // As we encountered 2 `scanNode`s per join + 1 in the `root` above.
+				IncludeChildNodes: true, // Shouldn't have any.
+				ExpectedAttributes: dataMap{
+					"filter":         nil,
+					"collectionID":   "4",
+					"collectionName": "AuthorContact",
+					"spans": []dataMap{
+						{
+							"start": "/4",
+							"end":   "/5",
 						},
 					},
 				},

--- a/tests/integration/explain/default/with_limit_join_test.go
+++ b/tests/integration/explain/default/with_limit_join_test.go
@@ -16,19 +16,6 @@ import (
 	explainUtils "github.com/sourcenetwork/defradb/tests/integration/explain"
 )
 
-var normalTypeJoinPattern = dataMap{
-	"root": dataMap{
-		"scanNode": dataMap{},
-	},
-	"subType": dataMap{
-		"selectTopNode": dataMap{
-			"selectNode": dataMap{
-				"scanNode": dataMap{},
-			},
-		},
-	},
-}
-
 var limitTypeJoinPattern = dataMap{
 	"root": dataMap{
 		"scanNode": dataMap{},


### PR DESCRIPTION
## Relevant issue(s)
- Part of #953
- Resolves #1475

## Description
Continue converting explain tests to the new explain setup before we can integrate the entire setup to the new action based testing setup. #953 Has a lot more detail on the entire plan.

- Splits type join one tests into a separate file.
- Added some type join many tests into a separate file.
- This PR converts all the default typeJoin explain tests to the new explain setup.
- Keeps the mixed test that use both type of joins in the original file.

