### PR TITLE
test: Convert explain order tests to new explain setup

### DIFF
--- a/tests/integration/explain/default/with_order_join_test.go
+++ b/tests/integration/explain/default/with_order_join_test.go
@@ -16,20 +16,6 @@ import (
 	explainUtils "github.com/sourcenetwork/defradb/tests/integration/explain"
 )
 
-// Note: This fixture would end up in type_join_test.go (as this used for order, limit, etc.).
-var normalTypeJoinPattern = dataMap{
-	"root": dataMap{
-		"scanNode": dataMap{},
-	},
-	"subType": dataMap{
-		"selectTopNode": dataMap{
-			"selectNode": dataMap{
-				"scanNode": dataMap{},
-			},
-		},
-	},
-}
-
 var orderTypeJoinPattern = dataMap{
 	"root": dataMap{
 		"scanNode": dataMap{},

--- a/tests/integration/explain/default/with_order_join_test.go
+++ b/tests/integration/explain/default/with_order_join_test.go
@@ -1,0 +1,361 @@
+// Copyright 2023 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package test_explain_default
+
+import (
+	"testing"
+
+	explainUtils "github.com/sourcenetwork/defradb/tests/integration/explain"
+)
+
+func TestDefaultExplainRequestWithOrderFieldOnRelatedChild(t *testing.T) {
+	test := explainUtils.ExplainRequestTestCase{
+
+		Description: "Explain (default) request with order field on a related child.",
+
+		Request: `query @explain {
+			Author {
+				name
+				articles(order: {name: DESC}) {
+					name
+				}
+			}
+		}`,
+
+		Docs: map[int][]string{
+			// articles
+			0: {
+				`{
+					"name": "After Guantánamo, Another Injustice",
+					"author_id": "bae-41598f0c-19bc-5da6-813b-e80f14a10df3"
+				}`,
+				`{
+					"name": "To my dear readers",
+					"author_id": "bae-b769708d-f552-5c3d-a402-ccfd7ac7fb04"
+				}`,
+				`{
+					"name": "Twinklestar's Favourite Xmas Cookie",
+					"author_id": "bae-b769708d-f552-5c3d-a402-ccfd7ac7fb04"
+				}`,
+			},
+
+			// authors
+			2: {
+				// _key: bae-41598f0c-19bc-5da6-813b-e80f14a10df3
+				`{
+					"name": "John Grisham",
+					"age": 65,
+					"verified": true
+				}`,
+				// _key: bae-b769708d-f552-5c3d-a402-ccfd7ac7fb04
+				`{
+					"name": "Cornelia Funke",
+					"age": 62,
+					"verified": false
+				}`,
+			},
+		},
+
+		ExpectedFullGraph: []dataMap{
+			{
+				"explain": dataMap{
+					"selectTopNode": dataMap{
+						"selectNode": dataMap{
+							"filter": nil,
+							"typeIndexJoin": dataMap{
+								"joinType": "typeJoinMany",
+								"rootName": "author",
+								"root": dataMap{
+									"scanNode": dataMap{
+										"collectionID":   "3",
+										"collectionName": "Author",
+										"filter":         nil,
+										"spans": []dataMap{
+											{
+												"start": "/3",
+												"end":   "/4",
+											},
+										},
+									},
+								},
+								"subTypeName": "articles",
+								"subType": dataMap{
+									"selectTopNode": dataMap{
+										"orderNode": dataMap{
+											"orderings": []dataMap{
+												{
+													"direction": "DESC",
+													"fields": []string{
+														"name",
+													},
+												},
+											},
+											"selectNode": dataMap{
+												"filter": nil,
+												"scanNode": dataMap{
+													"collectionID":   "1",
+													"collectionName": "Article",
+													"filter":         nil,
+													"spans": []dataMap{
+														{
+															"start": "/1",
+															"end":   "/2",
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	runExplainTest(t, test)
+}
+
+func TestDefaultExplainRequestWithOrderFieldOnParentAndRelatedChild(t *testing.T) {
+	test := explainUtils.ExplainRequestTestCase{
+
+		Description: "Explain (default) request with order field on parent and related child.",
+
+		Request: `query @explain {
+			Author(order: {name: ASC}) {
+				name
+				articles(order: {name: DESC}) {
+					name
+				}
+			}
+		}`,
+
+		Docs: map[int][]string{
+			// articles
+			0: {
+				`{
+					"name": "After Guantánamo, Another Injustice",
+					"author_id": "bae-41598f0c-19bc-5da6-813b-e80f14a10df3"
+				}`,
+				`{
+					"name": "To my dear readers",
+					"author_id": "bae-b769708d-f552-5c3d-a402-ccfd7ac7fb04"
+				}`,
+				`{
+					"name": "Twinklestar's Favourite Xmas Cookie",
+					"author_id": "bae-b769708d-f552-5c3d-a402-ccfd7ac7fb04"
+				}`,
+			},
+
+			// authors
+			2: {
+				// _key: bae-41598f0c-19bc-5da6-813b-e80f14a10df3
+				`{
+					"name": "John Grisham",
+					"age": 65,
+					"verified": true
+				}`,
+				// _key: bae-b769708d-f552-5c3d-a402-ccfd7ac7fb04
+				`{
+					"name": "Cornelia Funke",
+					"age": 62,
+					"verified": false
+				}`,
+			},
+		},
+
+		ExpectedFullGraph: []dataMap{
+			{
+				"explain": dataMap{
+					"selectTopNode": dataMap{
+						"orderNode": dataMap{
+							"orderings": []dataMap{
+								{
+									"direction": "ASC",
+									"fields": []string{
+										"name",
+									},
+								},
+							},
+							"selectNode": dataMap{
+								"filter": nil,
+								"typeIndexJoin": dataMap{
+									"joinType": "typeJoinMany",
+									"rootName": "author",
+									"root": dataMap{
+										"scanNode": dataMap{
+											"collectionID":   "3",
+											"collectionName": "Author",
+											"filter":         nil,
+											"spans": []dataMap{
+												{
+													"start": "/3",
+													"end":   "/4",
+												},
+											},
+										},
+									},
+									"subTypeName": "articles",
+									"subType": dataMap{
+										"selectTopNode": dataMap{
+											"orderNode": dataMap{
+												"orderings": []dataMap{
+													{
+														"direction": "DESC",
+														"fields": []string{
+															"name",
+														},
+													},
+												},
+												"selectNode": dataMap{
+													"filter": nil,
+													"scanNode": dataMap{
+														"collectionID":   "1",
+														"collectionName": "Article",
+														"filter":         nil,
+														"spans": []dataMap{
+															{
+																"start": "/1",
+																"end":   "/2",
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	runExplainTest(t, test)
+}
+
+func TestDefaultExplainRequestWhereParentIsOrderedByItsRelatedChild(t *testing.T) {
+	test := explainUtils.ExplainRequestTestCase{
+
+		Description: "Explain (default) request where parent is ordered by it's related child.",
+
+		Request: `query @explain {
+			Author(
+				order: {
+					articles: {name: ASC}
+				}
+			) {
+				articles {
+				    name
+				}
+			}
+		}`,
+
+		Docs: map[int][]string{
+			// articles
+			0: {
+				`{
+					"name": "After Guantánamo, Another Injustice",
+					"author_id": "bae-41598f0c-19bc-5da6-813b-e80f14a10df3"
+				}`,
+				`{
+					"name": "To my dear readers",
+					"author_id": "bae-b769708d-f552-5c3d-a402-ccfd7ac7fb04"
+				}`,
+				`{
+					"name": "Twinklestar's Favourite Xmas Cookie",
+					"author_id": "bae-b769708d-f552-5c3d-a402-ccfd7ac7fb04"
+				}`,
+			},
+
+			// authors
+			2: {
+				// _key: bae-41598f0c-19bc-5da6-813b-e80f14a10df3
+				`{
+					"name": "John Grisham",
+					"age": 65,
+					"verified": true
+				}`,
+				// _key: bae-b769708d-f552-5c3d-a402-ccfd7ac7fb04
+				`{
+					"name": "Cornelia Funke",
+					"age": 62,
+					"verified": false
+				}`,
+			},
+		},
+
+		ExpectedFullGraph: []dataMap{
+			{
+				"explain": dataMap{
+					"selectTopNode": dataMap{
+						"orderNode": dataMap{
+							"orderings": []dataMap{
+								{
+									"direction": "ASC",
+									"fields": []string{
+										"articles",
+										"name",
+									},
+								},
+							},
+							"selectNode": dataMap{
+								"filter": nil,
+								"typeIndexJoin": dataMap{
+									"joinType": "typeJoinMany",
+									"rootName": "author",
+									"root": dataMap{
+										"scanNode": dataMap{
+											"collectionID":   "3",
+											"collectionName": "Author",
+											"filter":         nil,
+											"spans": []dataMap{
+												{
+													"start": "/3",
+													"end":   "/4",
+												},
+											},
+										},
+									},
+									"subTypeName": "articles",
+									"subType": dataMap{
+										"selectTopNode": dataMap{
+											"selectNode": dataMap{
+												"filter": nil,
+												"scanNode": dataMap{
+													"collectionID":   "1",
+													"collectionName": "Article",
+													"filter":         nil,
+													"spans": []dataMap{
+														{
+															"start": "/1",
+															"end":   "/2",
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	runExplainTest(t, test)
+}


### PR DESCRIPTION
## Relevant issue(s)
- Part of #953
- Resolves #1477

## Description
Continue converting explain tests to the new explain setup before we can integrate the entire setup to the new action based setup. #953 Has a lot more detail on the entire plan.

- This PR converts all the default order explain tests to the new explain setup.
- Splits the order join tests into a separate file.
