### PR TITLE
test: Convert explain top-level tests to new explain setup

### DIFF
--- a/tests/integration/explain/default/top_with_average_test.go
+++ b/tests/integration/explain/default/top_with_average_test.go
@@ -13,12 +13,36 @@ package test_explain_default
 import (
 	"testing"
 
-	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	explainUtils "github.com/sourcenetwork/defradb/tests/integration/explain"
 )
 
-func TestExplainTopLevelAverageQuery(t *testing.T) {
-	test := testUtils.RequestTestCase{
-		Description: "Explain top-level average query.",
+var topLevelAveragePattern = dataMap{
+	"explain": dataMap{
+		"topLevelNode": []dataMap{
+			{
+				"selectTopNode": dataMap{
+					"selectNode": dataMap{
+						"scanNode": dataMap{},
+					},
+				},
+			},
+			{
+				"sumNode": dataMap{},
+			},
+			{
+				"countNode": dataMap{},
+			},
+			{
+				"averageNode": dataMap{},
+			},
+		},
+	},
+}
+
+func TestDefaultExplainTopLevelAverageRequest(t *testing.T) {
+	test := explainUtils.ExplainRequestTestCase{
+
+		Description: "Explain (default) top-level average request with filter.",
 
 		Request: `query @explain {
 			_avg(
@@ -44,76 +68,76 @@ func TestExplainTopLevelAverageQuery(t *testing.T) {
 			},
 		},
 
-		Results: []dataMap{
+		ExpectedPatterns: []dataMap{topLevelAveragePattern},
+
+		ExpectedTargets: []explainUtils.PlanNodeTargetCase{
 			{
-				"explain": dataMap{
-					"topLevelNode": []dataMap{
-						{
-							"selectTopNode": dataMap{
-								"selectNode": dataMap{
-									"filter": nil,
-									"scanNode": dataMap{
-										"collectionID":   "3",
-										"collectionName": "Author",
-										"filter": dataMap{
-											"age": dataMap{
-												"_ne": nil,
-											},
-										},
-										"spans": []dataMap{
-											{
-												"end":   "/4",
-												"start": "/3",
-											},
-										},
-									},
-								},
-							},
+				TargetNodeName:    "scanNode",
+				IncludeChildNodes: true, // should be leaf of it's branch, so will have no child nodes.
+				ExpectedAttributes: dataMap{
+					"collectionID":   "3",
+					"collectionName": "Author",
+					"filter": dataMap{
+						"age": dataMap{
+							"_ne": nil,
 						},
+					},
+					"spans": []dataMap{
 						{
-							"sumNode": dataMap{
-								"sources": []dataMap{
-									{
-										"childFieldName": "age",
-										"fieldName":      "Author",
-										"filter": dataMap{
-											"age": dataMap{
-												"_ne": nil,
-											},
-										},
-									},
-								},
-							},
-						},
-						{
-							"countNode": dataMap{
-								"sources": []dataMap{
-									{
-										"fieldName": "Author",
-										"filter": dataMap{
-											"age": dataMap{
-												"_ne": nil,
-											},
-										},
-									},
-								},
-							},
-						},
-						{
-							"averageNode": dataMap{},
+							"end":   "/4",
+							"start": "/3",
 						},
 					},
 				},
 			},
+			{
+				TargetNodeName:    "sumNode",
+				IncludeChildNodes: true, // should be leaf of it's branch, so will have no child nodes.
+				ExpectedAttributes: dataMap{
+					"sources": []dataMap{
+						{
+							"childFieldName": "age",
+							"fieldName":      "Author",
+							"filter": dataMap{
+								"age": dataMap{
+									"_ne": nil,
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				TargetNodeName:    "countNode",
+				IncludeChildNodes: true, // should be leaf of it's branch, so will have no child nodes.
+				ExpectedAttributes: dataMap{
+					"sources": []dataMap{
+						{
+							"fieldName": "Author",
+							"filter": dataMap{
+								"age": dataMap{
+									"_ne": nil,
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				TargetNodeName:     "averageNode",
+				IncludeChildNodes:  true,      // should be leaf of it's branch, so will have no child nodes.
+				ExpectedAttributes: dataMap{}, // no attributes
+			},
 		},
 	}
 
-	executeTestCase(t, test)
+	runExplainTest(t, test)
 }
 
-func TestExplainTopLevelAverageQueryWithFilter(t *testing.T) {
-	test := testUtils.RequestTestCase{
-		Description: "Explain top-level average query with filter.",
+func TestDefaultExplainTopLevelAverageRequestWithFilter(t *testing.T) {
+	test := explainUtils.ExplainRequestTestCase{
+
+		Description: "Explain (default) top-level average request with filter.",
 
 		Request: `query @explain {
 			_avg(
@@ -149,72 +173,71 @@ func TestExplainTopLevelAverageQueryWithFilter(t *testing.T) {
 			},
 		},
 
-		Results: []dataMap{
+		ExpectedPatterns: []dataMap{topLevelAveragePattern},
+
+		ExpectedTargets: []explainUtils.PlanNodeTargetCase{
 			{
-				"explain": dataMap{
-					"topLevelNode": []dataMap{
-						{
-							"selectTopNode": dataMap{
-								"selectNode": dataMap{
-									"filter": nil,
-									"scanNode": dataMap{
-										"collectionID":   "3",
-										"collectionName": "Author",
-										"filter": dataMap{
-											"age": dataMap{
-												"_ne": nil,
-												"_gt": int(26),
-											},
-										},
-										"spans": []dataMap{
-											{
-												"end":   "/4",
-												"start": "/3",
-											},
-										},
-									},
-								},
-							},
+				TargetNodeName:    "scanNode",
+				IncludeChildNodes: true, // should be leaf of it's branch, so will have no child nodes.
+				ExpectedAttributes: dataMap{
+					"collectionID":   "3",
+					"collectionName": "Author",
+					"filter": dataMap{
+						"age": dataMap{
+							"_gt": int(26),
+							"_ne": nil,
 						},
+					},
+					"spans": []dataMap{
 						{
-							"sumNode": dataMap{
-								"sources": []dataMap{
-									{
-										"childFieldName": "age",
-										"fieldName":      "Author",
-										"filter": dataMap{
-											"age": dataMap{
-												"_gt": int(26),
-												"_ne": nil,
-											},
-										},
-									},
-								},
-							},
-						},
-						{
-							"countNode": dataMap{
-								"sources": []dataMap{
-									{
-										"fieldName": "Author",
-										"filter": dataMap{
-											"age": dataMap{
-												"_gt": int(26),
-												"_ne": nil,
-											},
-										},
-									},
-								},
-							},
-						},
-						{
-							"averageNode": dataMap{},
+							"end":   "/4",
+							"start": "/3",
 						},
 					},
 				},
 			},
+			{
+				TargetNodeName:    "sumNode",
+				IncludeChildNodes: true, // should be leaf of it's branch, so will have no child nodes.
+				ExpectedAttributes: dataMap{
+					"sources": []dataMap{
+						{
+							"childFieldName": "age",
+							"fieldName":      "Author",
+							"filter": dataMap{
+								"age": dataMap{
+									"_gt": int(26),
+									"_ne": nil,
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				TargetNodeName:    "countNode",
+				IncludeChildNodes: true, // should be leaf of it's branch, so will have no child nodes.
+				ExpectedAttributes: dataMap{
+					"sources": []dataMap{
+						{
+							"fieldName": "Author",
+							"filter": dataMap{
+								"age": dataMap{
+									"_gt": int(26),
+									"_ne": nil,
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				TargetNodeName:     "averageNode",
+				IncludeChildNodes:  true,      // should be leaf of it's branch, so will have no child nodes.
+				ExpectedAttributes: dataMap{}, // no attributes
+			},
 		},
 	}
 
-	executeTestCase(t, test)
+	runExplainTest(t, test)
 }

--- a/tests/integration/explain/default/top_with_count_test.go
+++ b/tests/integration/explain/default/top_with_count_test.go
@@ -13,12 +13,30 @@ package test_explain_default
 import (
 	"testing"
 
-	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	explainUtils "github.com/sourcenetwork/defradb/tests/integration/explain"
 )
 
-func TestExplainTopLevelCountQuery(t *testing.T) {
-	test := testUtils.RequestTestCase{
-		Description: "Explain top-level count query.",
+var topLevelCountPattern = dataMap{
+	"explain": dataMap{
+		"topLevelNode": []dataMap{
+			{
+				"selectTopNode": dataMap{
+					"selectNode": dataMap{
+						"scanNode": dataMap{},
+					},
+				},
+			},
+			{
+				"countNode": dataMap{},
+			},
+		},
+	},
+}
+
+func TestDefaultExplainTopLevelCountRequest(t *testing.T) {
+	test := explainUtils.ExplainRequestTestCase{
+
+		Description: "Explain (default) top-level count request.",
 
 		Request: `query @explain {
 			_count(Author: {})
@@ -40,37 +58,32 @@ func TestExplainTopLevelCountQuery(t *testing.T) {
 			},
 		},
 
-		Results: []dataMap{
+		ExpectedPatterns: []dataMap{topLevelCountPattern},
+
+		ExpectedTargets: []explainUtils.PlanNodeTargetCase{
 			{
-				"explain": dataMap{
-					"topLevelNode": []dataMap{
+				TargetNodeName:    "scanNode",
+				IncludeChildNodes: true, // should be leaf of it's branch, so will have no child nodes.
+				ExpectedAttributes: dataMap{
+					"collectionID":   "3",
+					"collectionName": "Author",
+					"filter":         nil,
+					"spans": []dataMap{
 						{
-							"selectTopNode": dataMap{
-								"selectNode": dataMap{
-									"filter": nil,
-									"scanNode": dataMap{
-										"collectionID":   "3",
-										"collectionName": "Author",
-										"filter":         nil,
-										"spans": []dataMap{
-											{
-												"start": "/3",
-												"end":   "/4",
-											},
-										},
-									},
-								},
-							},
+							"start": "/3",
+							"end":   "/4",
 						},
+					},
+				},
+			},
+			{
+				TargetNodeName:    "countNode",
+				IncludeChildNodes: true, // should be leaf of it's branch, so will have no child nodes.
+				ExpectedAttributes: dataMap{
+					"sources": []dataMap{
 						{
-							"countNode": dataMap{
-								"sources": []dataMap{
-									{
-										"fieldName": "Author",
-										"filter":    nil,
-									},
-								},
-							},
+							"fieldName": "Author",
+							"filter":    nil,
 						},
 					},
 				},
@@ -78,12 +91,13 @@ func TestExplainTopLevelCountQuery(t *testing.T) {
 		},
 	}
 
-	executeTestCase(t, test)
+	runExplainTest(t, test)
 }
 
-func TestExplainTopLevelCountQueryWithFilter(t *testing.T) {
-	test := testUtils.RequestTestCase{
-		Description: "Explain top-level count query with filter.",
+func TestDefaultExplainTopLevelCountRequestWithFilter(t *testing.T) {
+	test := explainUtils.ExplainRequestTestCase{
+
+		Description: "Explain (default) top-level count request with filter.",
 
 		Request: `query @explain {
 			_count(
@@ -118,43 +132,38 @@ func TestExplainTopLevelCountQueryWithFilter(t *testing.T) {
 			},
 		},
 
-		Results: []dataMap{
+		ExpectedPatterns: []dataMap{topLevelCountPattern},
+
+		ExpectedTargets: []explainUtils.PlanNodeTargetCase{
 			{
-				"explain": dataMap{
-					"topLevelNode": []dataMap{
-						{
-							"selectTopNode": dataMap{
-								"selectNode": dataMap{
-									"filter": nil,
-									"scanNode": dataMap{
-										"collectionID":   "3",
-										"collectionName": "Author",
-										"filter": dataMap{
-											"age": dataMap{
-												"_gt": int(26),
-											},
-										},
-										"spans": []dataMap{
-											{
-												"start": "/3",
-												"end":   "/4",
-											},
-										},
-									},
-								},
-							},
+				TargetNodeName:    "scanNode",
+				IncludeChildNodes: true, // should be leaf of it's branch, so will have no child nodes.
+				ExpectedAttributes: dataMap{
+					"collectionID":   "3",
+					"collectionName": "Author",
+					"filter": dataMap{
+						"age": dataMap{
+							"_gt": int(26),
 						},
+					},
+					"spans": []dataMap{
 						{
-							"countNode": dataMap{
-								"sources": []dataMap{
-									{
-										"fieldName": "Author",
-										"filter": dataMap{
-											"age": dataMap{
-												"_gt": int(26),
-											},
-										},
-									},
+							"start": "/3",
+							"end":   "/4",
+						},
+					},
+				},
+			},
+			{
+				TargetNodeName:    "countNode",
+				IncludeChildNodes: true, // should be leaf of it's branch, so will have no child nodes.
+				ExpectedAttributes: dataMap{
+					"sources": []dataMap{
+						{
+							"fieldName": "Author",
+							"filter": dataMap{
+								"age": dataMap{
+									"_gt": int(26),
 								},
 							},
 						},
@@ -164,5 +173,5 @@ func TestExplainTopLevelCountQueryWithFilter(t *testing.T) {
 		},
 	}
 
-	executeTestCase(t, test)
+	runExplainTest(t, test)
 }


### PR DESCRIPTION
## Relevant issue(s)
- Part of #953
- Resolves #1479

## Description
Continue converting explain tests to the new explain setup before we can integrate the entire setup to the new action-based setup. #953 Has a lot more detail on the entire plan.

- This PR converts all the default top-level explain tests.
