### PR TITLE
fix: Add reconnection to known peers

### DIFF
--- a/net/peer.go
+++ b/net/peer.go
@@ -139,14 +139,18 @@ func (p *Peer) Start() error {
 
 	// reconnect to known peers
 	for _, id := range p.host.Peerstore().PeersWithAddrs() {
+		if id == p.host.ID() {
+			continue
+		}
 		go func(id peer.ID) {
 			addr := p.host.Peerstore().PeerInfo(id)
 			err := p.host.Connect(p.ctx, addr)
 			if err != nil {
 				log.Info(
 					p.ctx,
-					"Failed to reconnect to peer`",
+					"Failure while reconnecting to a known peer",
 					logging.NewKV("peer", id),
+					logging.NewKV("error", err),
 				)
 			}
 		}(id)


### PR DESCRIPTION
## Relevant issue(s)

Resolves #1481 

## Description

Currently, we de not reconnect to known peers on restart unless the peer is defined in the config file or on the CLI command. This PR makes sure that we try to reconnect to known peers.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

make test shows now degradation and tested manually that peers reconnect on restart.

Specify the platform(s) on which this was tested:
- MacOS
