### PR TITLE
refactor: [Proof of concept] Add strict ordering of serialized fieldIDs

### DIFF
--- a/client/descriptions.go
+++ b/client/descriptions.go
@@ -50,10 +50,10 @@ func (col CollectionDescription) GetField(name string) (FieldDescription, bool) 
 
 // GetFieldByID searches for a field with the given ID. If such a field is found it
 // will return it and true, if it is not found it will return false.
-func (col CollectionDescription) GetFieldByID(id string) (FieldDescription, bool) {
+func (col CollectionDescription) GetFieldByID(id uint16) (FieldDescription, bool) {
 	if !col.Schema.IsEmpty() {
 		for _, field := range col.Schema.Fields {
-			if field.ID.String() == id {
+			if uint16(field.ID) == id {
 				return field, true
 			}
 		}
@@ -106,13 +106,13 @@ func (sd SchemaDescription) IsEmpty() bool {
 }
 
 // GetFieldKey returns the field ID for the given field name.
-func (sd SchemaDescription) GetFieldKey(fieldName string) uint32 {
+func (sd SchemaDescription) GetFieldKey(fieldName string) uint16 {
 	for _, field := range sd.Fields {
 		if field.Name == fieldName {
-			return uint32(field.ID)
+			return uint16(field.ID)
 		}
 	}
-	return uint32(0)
+	return 0
 }
 
 // FieldKind describes the type of a field.
@@ -189,7 +189,7 @@ const (
 )
 
 // FieldID is a unique identifier for a field in a schema.
-type FieldID uint32
+type FieldID uint16
 
 func (f FieldID) String() string {
 	return fmt.Sprint(uint32(f))

--- a/client/request/commit.go
+++ b/client/request/commit.go
@@ -20,7 +20,7 @@ type CommitSelect struct {
 	Field
 
 	DocKey  immutable.Option[string]
-	FieldID immutable.Option[string]
+	FieldID immutable.Option[uint16]
 	Cid     immutable.Option[string]
 	Depth   immutable.Option[uint64]
 

--- a/core/crdt/composite.go
+++ b/core/crdt/composite.go
@@ -151,7 +151,7 @@ func (c CompositeDAG) Merge(ctx context.Context, delta core.Delta, id string) er
 		if err != nil {
 			return err
 		}
-		return c.deleteWithPrefix(ctx, c.key.WithValueFlag().WithFieldId(""))
+		return c.deleteWithPrefix(ctx, c.key.WithValueFlag().WithFieldId(0))
 	}
 
 	// ensure object marker exists

--- a/core/key_test.go
+++ b/core/key_test.go
@@ -32,10 +32,11 @@ func TestNewDataStoreKey_ReturnsCollectionIdAndIndexIdAndDocKeyAndFieldIdAndInst
 	t *testing.T,
 ) {
 	instanceType := "anyType"
-	fieldId := "f1"
+	fieldId := uint16(1)
+	fieldIdStr := "001"
 	docKey := "docKey"
 	collectionId := "1"
-	inputString := collectionId + "/" + instanceType + "/" + docKey + "/" + fieldId
+	inputString := collectionId + "/" + instanceType + "/" + docKey + "/" + fieldIdStr
 
 	result, err := NewDataStoreKey(inputString)
 	if err != nil {
@@ -51,7 +52,7 @@ func TestNewDataStoreKey_ReturnsCollectionIdAndIndexIdAndDocKeyAndFieldIdAndInst
 			FieldId:      fieldId,
 			InstanceType: InstanceType(instanceType)},
 		result)
-	assert.Equal(t, "/"+collectionId+"/"+instanceType+"/"+docKey+"/"+fieldId, resultString)
+	assert.Equal(t, "/"+collectionId+"/"+instanceType+"/"+docKey+"/"+fieldIdStr, resultString)
 }
 
 func TestNewDataStoreKey_ReturnsEmptyStruct_GivenAStringWithMissingElements(t *testing.T) {

--- a/core/type.go
+++ b/core/type.go
@@ -11,6 +11,7 @@
 package core
 
 const (
-	COMPOSITE_NAMESPACE = "C"
-	HEAD                = "_head"
+	COMPOSITE_NAMESPACE_ID = compositeFieldID
+	COMPOSITE_NAMESPACE    = "C"
+	HEAD                   = "_head"
 )

--- a/db/base/collection_keys.go
+++ b/db/base/collection_keys.go
@@ -11,8 +11,6 @@
 package base
 
 import (
-	"fmt"
-
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/core"
 )
@@ -40,7 +38,7 @@ func MakePrimaryIndexKeyForCRDT(
 ) (core.DataStoreKey, error) {
 	switch ctype {
 	case client.COMPOSITE:
-		return MakeCollectionKey(c).WithInstanceInfo(key).WithFieldId(core.COMPOSITE_NAMESPACE), nil
+		return MakeCollectionKey(c).WithInstanceInfo(key).WithFieldId(core.COMPOSITE_NAMESPACE_ID), nil
 	case client.LWW_REGISTER:
 		fieldKey := getFieldKey(c, key, fieldName)
 		return MakeCollectionKey(c).WithInstanceInfo(fieldKey), nil
@@ -53,8 +51,5 @@ func getFieldKey(
 	key core.DataStoreKey,
 	fieldName string,
 ) core.DataStoreKey {
-	if !c.Schema.IsEmpty() {
-		return key.WithFieldId(fmt.Sprint(c.Schema.GetFieldKey(fieldName)))
-	}
-	return key.WithFieldId(fieldName)
+	return key.WithFieldId(c.Schema.GetFieldKey(fieldName))
 }

--- a/db/collection.go
+++ b/db/collection.go
@@ -15,7 +15,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strconv"
 
 	"github.com/fxamacker/cbor/v2"
 	"github.com/ipfs/go-cid"
@@ -993,7 +992,7 @@ func (c *collection) saveValueToMerkleCRDT(
 		lwwreg := merkleCRDT.(*crdt.MerkleLWWRegister)
 		return lwwreg.Set(ctx, bytes)
 	case client.COMPOSITE:
-		key = key.WithFieldId(core.COMPOSITE_NAMESPACE)
+		key = key.WithFieldId(core.COMPOSITE_NAMESPACE_ID)
 		merkleCRDT, err := c.db.crdtFactory.InstanceWithStores(
 			txn,
 			core.NewCollectionSchemaVersionKey(c.Schema().VersionID),
@@ -1093,22 +1092,22 @@ func (c *collection) tryGetFieldKey(key core.PrimaryDataStoreKey, fieldName stri
 	return core.DataStoreKey{
 		CollectionID: key.CollectionId,
 		DocKey:       key.DocKey,
-		FieldId:      strconv.FormatUint(uint64(fieldId), 10),
+		FieldId:      fieldId,
 	}, true
 }
 
 // tryGetSchemaFieldID returns the FieldID of the given fieldName.
 // Will return false if the field is not found.
-func (c *collection) tryGetSchemaFieldID(fieldName string) (uint32, bool) {
+func (c *collection) tryGetSchemaFieldID(fieldName string) (uint16, bool) {
 	for _, field := range c.desc.Schema.Fields {
 		if field.Name == fieldName {
 			if field.IsObject() || field.IsObjectArray() {
 				// We do not wish to match navigational properties, only
 				// fields directly on the collection.
-				return uint32(0), false
+				return 0, false
 			}
-			return uint32(field.ID), true
+			return uint16(field.ID), true
 		}
 	}
-	return uint32(0), false
+	return uint16(0), false
 }

--- a/db/collection_delete.go
+++ b/db/collection_delete.go
@@ -246,7 +246,7 @@ func (c *collection) applyDelete(
 
 	headset := clock.NewHeadSet(
 		txn.Headstore(),
-		dsKey.WithFieldId(core.COMPOSITE_NAMESPACE).ToHeadStoreKey(),
+		dsKey.WithFieldId(core.COMPOSITE_NAMESPACE_ID).ToHeadStoreKey(),
 	)
 	cids, _, err := headset.List(ctx)
 	if err != nil {

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -17,6 +17,7 @@ import (
 	badger "github.com/dgraph-io/badger/v3"
 	dag "github.com/ipfs/boxo/ipld/merkledag"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/core"
@@ -320,13 +321,16 @@ func TestDocumentMerkleDAG(t *testing.T) {
 	err = col.Save(ctx, doc)
 	assert.NoError(t, err)
 
+	fd, ok := col.Description().GetField("Name")
+	require.True(t, ok)
+
 	clk := clock.NewMerkleClock(
 		db.multistore.Headstore(),
 		nil,
 		core.HeadStoreKey{}.WithDocKey(
 			"bae-09cd7539-9b86-5661-90f6-14fbf6c1a14d",
 		).WithFieldId(
-			"Name",
+			uint16(fd.ID),
 		),
 		nil,
 	)

--- a/db/fetcher/dag.go
+++ b/db/fetcher/dag.go
@@ -26,7 +26,7 @@ import (
 // HeadFetcher is a utility to incrementally fetch all the MerkleCRDT heads of a given doc/field.
 type HeadFetcher struct {
 	spans   core.Spans
-	fieldId immutable.Option[string]
+	fieldId immutable.Option[uint16]
 
 	kvIter dsq.Results
 }
@@ -35,7 +35,7 @@ func (hf *HeadFetcher) Start(
 	ctx context.Context,
 	txn datastore.Txn,
 	spans core.Spans,
-	fieldId immutable.Option[string],
+	fieldId immutable.Option[uint16],
 ) error {
 	if len(spans.Value) == 0 {
 		spans = core.NewSpans(

--- a/db/fetcher/errors.go
+++ b/db/fetcher/errors.go
@@ -25,6 +25,7 @@ const (
 	errVFetcherFailedToDecodeNode   string = "(version fetcher) failed to decode protobuf"
 	errVFetcherFailedToGetDagLink   string = "(version fetcher) failed to get node link from DAG"
 	errFailedToGetDagNode           string = "failed to get DAG Node"
+	// errSeekTargetBeforeCurrentState string = "cannot seek to target that is behind the current state"
 )
 
 var (
@@ -42,7 +43,7 @@ var (
 )
 
 // NewErrFieldIdNotFound returns an error indicating that the given FieldId was not found.
-func NewErrFieldIdNotFound(fieldId uint32) error {
+func NewErrFieldIdNotFound(fieldId uint16) error {
 	return errors.New(errFieldIdNotFound, errors.NewKV("FieldId", fieldId))
 }
 

--- a/db/fetcher/fetcher.go
+++ b/db/fetcher/fetcher.go
@@ -48,7 +48,7 @@ type DocumentFetcher struct {
 	order        []dsq.Order
 	curSpanIndex int
 
-	schemaFields map[uint32]client.FieldDescription
+	schemaFields map[uint16]client.FieldDescription
 	fields       []*client.FieldDescription
 
 	doc         *encodedDocument
@@ -118,9 +118,9 @@ func (df *DocumentFetcher) init(
 	}
 	df.kvIter = nil
 
-	df.schemaFields = make(map[uint32]client.FieldDescription)
+	df.schemaFields = make(map[uint16]client.FieldDescription)
 	for _, field := range col.Schema.Fields {
-		df.schemaFields[uint32(field.ID)] = field
+		df.schemaFields[uint16(field.ID)] = field
 	}
 	return nil
 }
@@ -325,13 +325,9 @@ func (df *DocumentFetcher) processKV(kv *core.KeyValue) error {
 	}
 
 	// extract the FieldID and update the encoded doc properties map
-	fieldID, err := kv.Key.FieldID()
-	if err != nil {
-		return err
-	}
-	fieldDesc, exists := df.schemaFields[fieldID]
+	fieldDesc, exists := df.schemaFields[kv.Key.FieldId]
 	if !exists {
-		return NewErrFieldIdNotFound(fieldID)
+		return NewErrFieldIdNotFound(kv.Key.FieldId)
 	}
 
 	// @todo: Secondary Index might not have encoded FieldIDs

--- a/db/fetcher/versioned.go
+++ b/db/fetcher/versioned.go
@@ -93,7 +93,7 @@ type VersionedFetcher struct {
 
 	col *client.CollectionDescription
 	// @todo index  *client.IndexDescription
-	mCRDTs map[uint32]crdt.MerkleCRDT
+	mCRDTs map[uint16]crdt.MerkleCRDT
 }
 
 // Init initializes the VersionedFetcher.
@@ -105,7 +105,7 @@ func (vf *VersionedFetcher) Init(
 ) error {
 	vf.col = col
 	vf.queuedCids = list.New()
-	vf.mCRDTs = make(map[uint32]crdt.MerkleCRDT)
+	vf.mCRDTs = make(map[uint16]crdt.MerkleCRDT)
 
 	// run the DF init, VersionedFetchers only supports the Primary (0) index
 	vf.DocumentFetcher = new(DocumentFetcher)
@@ -350,7 +350,7 @@ func (vf *VersionedFetcher) merge(c cid.Cid) error {
 		}
 
 		fieldID := vf.col.Schema.GetFieldKey(l.Name)
-		if fieldID == uint32(0) {
+		if fieldID == 0 {
 			return client.NewErrFieldNotExist(l.Name)
 		}
 		// @todo: Right now we ONLY handle LWW_REGISTER, need to swith on this and
@@ -364,7 +364,7 @@ func (vf *VersionedFetcher) merge(c cid.Cid) error {
 }
 
 func (vf *VersionedFetcher) processNode(
-	crdtIndex uint32,
+	crdtIndex uint16,
 	nd format.Node,
 	ctype client.CType,
 	fieldName string,

--- a/merkle/clock/clock_test.go
+++ b/merkle/clock/clock_test.go
@@ -33,7 +33,7 @@ func newTestMerkleClock() *MerkleClock {
 	rw := datastore.AsDSReaderWriter(s)
 	multistore := datastore.MultiStoreFrom(rw)
 	reg := crdt.NewLWWRegister(rw, core.CollectionSchemaVersionKey{}, core.DataStoreKey{}, "")
-	return NewMerkleClock(multistore.Headstore(), multistore.DAGstore(), core.HeadStoreKey{DocKey: "dockey", FieldId: "1"}, reg).(*MerkleClock)
+	return NewMerkleClock(multistore.Headstore(), multistore.DAGstore(), core.HeadStoreKey{DocKey: "dockey", FieldId: 1}, reg).(*MerkleClock)
 }
 
 func TestNewMerkleClock(t *testing.T) {

--- a/merkle/clock/heads_test.go
+++ b/merkle/clock/heads_test.go
@@ -52,7 +52,7 @@ func newHeadSet() *heads {
 
 	return NewHeadSet(
 		datastore.AsDSReaderWriter(s),
-		core.HeadStoreKey{}.WithDocKey("mydockey").WithFieldId("1"),
+		core.HeadStoreKey{}.WithDocKey("mydockey").WithFieldId(1),
 	)
 }
 

--- a/net/peer.go
+++ b/net/peer.go
@@ -433,7 +433,7 @@ func (p *Peer) pushToReplicator(
 		dockey := core.DataStoreKeyFromDocKey(key.Key)
 		headset := clock.NewHeadSet(
 			txn.Headstore(),
-			dockey.WithFieldId(core.COMPOSITE_NAMESPACE).ToHeadStoreKey(),
+			dockey.WithFieldId(core.COMPOSITE_NAMESPACE_ID).ToHeadStoreKey(),
 		)
 		cids, priority, err := headset.List(ctx)
 		if err != nil {

--- a/net/process.go
+++ b/net/process.go
@@ -99,15 +99,15 @@ func initCRDTForType(
 		).WithInstanceInfo(
 			docKey,
 		).WithFieldId(
-			core.COMPOSITE_NAMESPACE,
+			core.COMPOSITE_NAMESPACE_ID,
 		)
 	} else {
 		fd, ok := description.GetField(field)
 		if !ok {
-			return nil, errors.New(fmt.Sprintf("Couldn't find field %s for doc %s", field, docKey))
+			return nil, errors.New(fmt.Sprintf("Couldn't find field %s for doc %s", field, docKey.DocKey))
 		}
 		ctype = fd.Typ
-		fieldID := fd.ID.String()
+		fieldID := uint16(fd.ID)
 		key = base.MakeCollectionKey(description).WithInstanceInfo(docKey).WithFieldId(fieldID)
 	}
 	log.Debug(ctx, "Got CRDT Type", logging.NewKV("CType", ctype), logging.NewKV("Field", field))

--- a/planner/commit.go
+++ b/planner/commit.go
@@ -104,11 +104,11 @@ func (n *dagScanNode) Spans(spans core.Spans) {
 	}
 	copy(headSetSpans.Value, spans.Value)
 
-	var fieldId string
+	var fieldId uint16
 	if n.commitSelect.FieldID.HasValue() {
 		fieldId = n.commitSelect.FieldID.Value()
 	} else {
-		fieldId = core.COMPOSITE_NAMESPACE
+		fieldId = core.COMPOSITE_NAMESPACE_ID
 	}
 
 	for i, span := range headSetSpans.Value {

--- a/planner/mapper/commitSelect.go
+++ b/planner/mapper/commitSelect.go
@@ -23,7 +23,7 @@ type CommitSelect struct {
 	DocKey immutable.Option[string]
 
 	// The field for which commits have been requested.
-	FieldID immutable.Option[string]
+	FieldID immutable.Option[uint16]
 
 	// The maximum depth to yield results for.
 	Depth immutable.Option[uint64]

--- a/request/graphql/parser/commit.go
+++ b/request/graphql/parser/commit.go
@@ -39,7 +39,15 @@ func parseCommitSelect(schema gql.Schema, parent *gql.Object, field *ast.Field) 
 			commit.Cid = immutable.Some(raw.Value)
 		} else if prop == request.FieldIDName {
 			raw := argument.Value.(*ast.StringValue)
-			commit.FieldID = immutable.Some(raw.Value)
+			if raw.Value == core.COMPOSITE_NAMESPACE {
+				commit.FieldID = immutable.Some(core.COMPOSITE_NAMESPACE_ID)
+			} else {
+				fid, err := strconv.ParseUint(raw.Value, 10, 16)
+				if err != nil {
+					return nil, err
+				}
+				commit.FieldID = immutable.Some(uint16(fid))
+			}
 		} else if prop == request.OrderClause {
 			obj := argument.Value.(*ast.ObjectValue)
 			cond, err := ParseConditionsInOrder(obj)
@@ -96,7 +104,7 @@ func parseCommitSelect(schema gql.Schema, parent *gql.Object, field *ast.Field) 
 
 		if !commit.FieldID.HasValue() {
 			// latest commits defaults to composite commits only at the moment
-			commit.FieldID = immutable.Some(core.COMPOSITE_NAMESPACE)
+			commit.FieldID = immutable.Some(core.COMPOSITE_NAMESPACE_ID)
 		}
 	}
 

--- a/tests/integration/query/commits/with_dockey_field_test.go
+++ b/tests/integration/query/commits/with_dockey_field_test.go
@@ -34,7 +34,7 @@ func TestQueryCommitsWithDockeyAndUnknownField(t *testing.T) {
 							cid
 						}
 					}`,
-				Results: []map[string]any{},
+				ExpectedError: "strconv.ParseUint: parsing \"not a field\"", // @todo: replace with typed error
 			},
 		},
 	}
@@ -56,7 +56,7 @@ func TestQueryCommitsWithDockeyAndUnknownFieldId(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: `query {
-						commits(dockey: "bae-f54b9689-e06e-5e3a-89b3-f3aee8e64ca7", fieldId: "999999") {
+						commits(dockey: "bae-f54b9689-e06e-5e3a-89b3-f3aee8e64ca7", fieldId: "998") {
 							cid
 						}
 					}`,
@@ -88,7 +88,7 @@ func TestQueryCommitsWithDockeyAndField(t *testing.T) {
 							cid
 						}
 					}`,
-				Results: []map[string]any{},
+				ExpectedError: "strconv.ParseUint: parsing \"Age\"", // @todo: replace with typed error
 			},
 		},
 	}


### PR DESCRIPTION
*note this is potentially necessary for #490, as I need to implement a `Seek` method. Its not 100% as I can order keys on the fetcher using the same (broken) ordering, and the seek would work correctly, but since I was already in this area, and the question came up recently regarding strict ordering of keys, I thought I would explore this*

Uses an alternative approach then what was previously discussed regarding binary encoding of fieldIDs when serializing data store keys.

Implements a "string based" strict ordering, instead of a "binary" based approach. By applying a padding of zeros, and limiting the stringified fieldID to 3 characters will gurantee ordering.

Basically, "001" < "002" < "011", where as before
"1" < "11" < "2".

This has the effect that we can only have 999 fields per document.

(*replace*) Include a summary of the changes. List the issue(s) it solves in the section above, and
create one if none exists.  Include relevant motivation and context. Detail new dependencies required for this change.
