### PR TITLE
test: Convert explain sum tests to new explain setup

### DIFF
--- a/tests/integration/explain/default/with_sum_join_test.go
+++ b/tests/integration/explain/default/with_sum_join_test.go
@@ -1,0 +1,481 @@
+// Copyright 2023 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package test_explain_default
+
+import (
+	"testing"
+
+	explainUtils "github.com/sourcenetwork/defradb/tests/integration/explain"
+)
+
+var sumTypeIndexJoinPattern = dataMap{
+	"explain": dataMap{
+		"selectTopNode": dataMap{
+			"sumNode": dataMap{
+				"selectNode": dataMap{
+					"typeIndexJoin": normalTypeJoinPattern,
+				},
+			},
+		},
+	},
+}
+
+func TestDefaultExplainRequestWithSumOnOneToManyJoinedField(t *testing.T) {
+	test := explainUtils.ExplainRequestTestCase{
+
+		Description: "Explain (default) request with sum on a one-to-many joined field.",
+
+		Request: `query @explain {
+			Author {
+				name
+				_key
+				TotalPages: _sum(
+					books: {field: pages}
+				)
+			}
+		}`,
+
+		Docs: map[int][]string{
+			// books
+			1: {
+				`{
+					"name": "Painted House",
+					"author_id": "bae-25fafcc7-f251-58c1-9495-ead73e676fb8",
+					"pages": 22
+				}`,
+				`{
+					"name": "A Time for Mercy",
+					"author_id": "bae-25fafcc7-f251-58c1-9495-ead73e676fb8",
+					"pages": 101
+				}`,
+				`{
+					"name": "Theif Lord",
+					"author_id": "bae-3dddb519-3612-5e43-86e5-49d6295d4f84",
+					"pages": 321
+				}`,
+			},
+
+			// authors
+			2: {
+				// _key: "bae-25fafcc7-f251-58c1-9495-ead73e676fb8"
+				`{
+					"name": "John Grisham",
+					"age": 65,
+					"verified": true,
+					"contact_id": "bae-1fe427b8-ab8d-56c3-9df2-826a6ce86fed"
+				}`,
+				// _key: "bae-3dddb519-3612-5e43-86e5-49d6295d4f84"
+				`{
+					"name": "Cornelia Funke",
+					"age": 62,
+					"verified": false,
+					"contact_id": "bae-c0960a29-b704-5c37-9c2e-59e1249e4559"
+				}`,
+			},
+		},
+
+		ExpectedPatterns: []dataMap{sumTypeIndexJoinPattern},
+
+		ExpectedTargets: []explainUtils.PlanNodeTargetCase{
+			{
+				TargetNodeName:    "sumNode",
+				IncludeChildNodes: false,
+				ExpectedAttributes: dataMap{
+					"sources": []dataMap{
+						{
+							"fieldName":      "books",
+							"childFieldName": "pages",
+							"filter":         nil,
+						},
+					},
+				},
+			},
+			{
+				TargetNodeName:    "typeIndexJoin",
+				IncludeChildNodes: false,
+				ExpectedAttributes: dataMap{
+					"joinType":    "typeJoinMany",
+					"rootName":    "author",
+					"subTypeName": "books",
+				},
+			},
+			{
+				TargetNodeName:    "scanNode", // inside of root
+				OccurancesToSkip:  0,
+				IncludeChildNodes: true, // should be leaf of it's branch, so will have no child nodes.
+				ExpectedAttributes: dataMap{
+					"collectionID":   "3",
+					"collectionName": "Author",
+					"filter":         nil,
+					"spans": []dataMap{
+						{
+							"start": "/3",
+							"end":   "/4",
+						},
+					},
+				},
+			},
+			{
+				TargetNodeName:    "scanNode", // inside of subType (related type)
+				OccurancesToSkip:  1,
+				IncludeChildNodes: true, // should be leaf of it's branch, so will have no child nodes.
+				ExpectedAttributes: dataMap{
+					"collectionID":   "2",
+					"collectionName": "Book",
+					"filter":         nil,
+					"spans": []dataMap{
+						{
+							"start": "/2",
+							"end":   "/3",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	runExplainTest(t, test)
+}
+
+func TestDefaultExplainRequestWithSumOnOneToManyJoinedFieldWithFilter(t *testing.T) {
+	test := explainUtils.ExplainRequestTestCase{
+
+		Description: "Explain (default) request with sum on a one-to-many joined field, with filter.",
+
+		Request: `query @explain {
+			Author {
+				name
+				TotalPages: _sum(
+					articles: {
+						field: pages,
+						filter: {
+							name: {
+								_eq: "To my dear readers"
+							}
+						}
+					}
+				)
+			}
+		}`,
+
+		Docs: map[int][]string{
+			// articles
+			0: {
+				`{
+					"name": "After Guantánamo, Another Injustice",
+					"author_id": "bae-25fafcc7-f251-58c1-9495-ead73e676fb8",
+					"pages": 2
+				}`,
+				`{
+					"name": "To my dear readers",
+					"author_id": "bae-3dddb519-3612-5e43-86e5-49d6295d4f84",
+					"pages": 11
+				}`,
+				`{
+					"name": "Twinklestar's Favourite Xmas Cookie",
+					"author_id": "bae-3dddb519-3612-5e43-86e5-49d6295d4f84",
+					"pages": 31
+				}`,
+			},
+
+			// authors
+			2: {
+				// _key: "bae-25fafcc7-f251-58c1-9495-ead73e676fb8"
+				`{
+					"name": "John Grisham",
+					"age": 65,
+					"verified": true,
+					"contact_id": "bae-1fe427b8-ab8d-56c3-9df2-826a6ce86fed"
+				}`,
+				// _key: "bae-3dddb519-3612-5e43-86e5-49d6295d4f84"
+				`{
+					"name": "Cornelia Funke",
+					"age": 62,
+					"verified": false,
+					"contact_id": "bae-c0960a29-b704-5c37-9c2e-59e1249e4559"
+				}`,
+			},
+		},
+
+		ExpectedPatterns: []dataMap{sumTypeIndexJoinPattern},
+
+		ExpectedTargets: []explainUtils.PlanNodeTargetCase{
+			{
+				TargetNodeName:    "sumNode",
+				IncludeChildNodes: false,
+				ExpectedAttributes: dataMap{
+					"sources": []dataMap{
+						{
+							"fieldName":      "articles",
+							"childFieldName": "pages",
+							"filter": dataMap{
+								"name": dataMap{
+									"_eq": "To my dear readers",
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				TargetNodeName:    "typeIndexJoin",
+				IncludeChildNodes: false,
+				ExpectedAttributes: dataMap{
+					"joinType":    "typeJoinMany",
+					"rootName":    "author",
+					"subTypeName": "articles",
+				},
+			},
+			{
+				TargetNodeName:    "scanNode", // inside of root
+				OccurancesToSkip:  0,
+				IncludeChildNodes: true, // should be leaf of it's branch, so will have no child nodes.
+				ExpectedAttributes: dataMap{
+					"collectionID":   "3",
+					"collectionName": "Author",
+					"filter":         nil,
+					"spans": []dataMap{
+						{
+							"start": "/3",
+							"end":   "/4",
+						},
+					},
+				},
+			},
+			{
+				TargetNodeName:    "scanNode", // inside of subType (related type)
+				OccurancesToSkip:  1,
+				IncludeChildNodes: true, // should be leaf of it's branch, so will have no child nodes.
+				ExpectedAttributes: dataMap{
+					"collectionID":   "1",
+					"collectionName": "Article",
+					"filter": dataMap{
+						"name": dataMap{
+							"_eq": "To my dear readers",
+						},
+					},
+					"spans": []dataMap{
+						{
+							"start": "/1",
+							"end":   "/2",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	runExplainTest(t, test)
+}
+
+func TestDefaultExplainRequestWithSumOnOneToManyJoinedFieldWithManySources(t *testing.T) {
+	test := explainUtils.ExplainRequestTestCase{
+
+		Description: "Explain (default) request with sum on a one-to-many joined field with many sources.",
+
+		Request: `query @explain {
+			Author {
+				name
+				TotalPages: _sum(
+					books: {field: pages},
+					articles: {field: pages}
+				)
+			}
+		}`,
+
+		Docs: map[int][]string{
+			// articles
+			0: {
+				`{
+					"name": "After Guantánamo, Another Injustice",
+					"author_id": "bae-25fafcc7-f251-58c1-9495-ead73e676fb8",
+					"pages": 2
+				}`,
+				`{
+					"name": "To my dear readers",
+					"author_id": "bae-3dddb519-3612-5e43-86e5-49d6295d4f84",
+					"pages": 11
+				}`,
+				`{
+					"name": "Twinklestar's Favourite Xmas Cookie",
+					"author_id": "bae-3dddb519-3612-5e43-86e5-49d6295d4f84",
+					"pages": 31
+				}`,
+			},
+
+			// books
+			1: {
+				`{
+					"name": "Painted House",
+					"author_id": "bae-25fafcc7-f251-58c1-9495-ead73e676fb8",
+					"pages": 22
+				}`,
+				`{
+					"name": "A Time for Mercy",
+					"author_id": "bae-25fafcc7-f251-58c1-9495-ead73e676fb8",
+					"pages": 101
+				}`,
+				`{
+					"name": "Theif Lord",
+					"author_id": "bae-3dddb519-3612-5e43-86e5-49d6295d4f84",
+					"pages": 321
+				}`,
+			},
+
+			// authors
+			2: {
+				// _key: "bae-25fafcc7-f251-58c1-9495-ead73e676fb8"
+				`{
+					"name": "John Grisham",
+					"age": 65,
+					"verified": true,
+					"contact_id": "bae-1fe427b8-ab8d-56c3-9df2-826a6ce86fed"
+				}`,
+				// _key: "bae-3dddb519-3612-5e43-86e5-49d6295d4f84"
+				`{
+					"name": "Cornelia Funke",
+					"age": 62,
+					"verified": false,
+					"contact_id": "bae-c0960a29-b704-5c37-9c2e-59e1249e4559"
+				}`,
+			},
+		},
+
+		ExpectedPatterns: []dataMap{
+			{
+				"explain": dataMap{
+					"selectTopNode": dataMap{
+						"sumNode": dataMap{
+							"selectNode": dataMap{
+								"parallelNode": []dataMap{
+									{
+										"typeIndexJoin": normalTypeJoinPattern,
+									},
+									{
+										"typeIndexJoin": normalTypeJoinPattern,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+
+		ExpectedTargets: []explainUtils.PlanNodeTargetCase{
+			{
+				TargetNodeName:    "sumNode",
+				IncludeChildNodes: false,
+				ExpectedAttributes: dataMap{
+					"sources": []dataMap{
+						{
+							"childFieldName": "pages",
+							"fieldName":      "books",
+							"filter":         nil,
+						},
+
+						{
+							"childFieldName": "pages",
+							"fieldName":      "articles",
+							"filter":         nil,
+						},
+					},
+				},
+			},
+			{
+				TargetNodeName:    "typeIndexJoin",
+				OccurancesToSkip:  0,
+				IncludeChildNodes: false,
+				ExpectedAttributes: dataMap{
+					"joinType":    "typeJoinMany",
+					"rootName":    "author",
+					"subTypeName": "books",
+				},
+			},
+			{
+				TargetNodeName:    "scanNode", // inside of 1st root type
+				OccurancesToSkip:  0,
+				IncludeChildNodes: true, // should be leaf of it's branch, so will have no child nodes.
+				ExpectedAttributes: dataMap{
+					"collectionID":   "3",
+					"collectionName": "Author",
+					"filter":         nil,
+					"spans": []dataMap{
+						{
+							"start": "/3",
+							"end":   "/4",
+						},
+					},
+				},
+			},
+			{
+				TargetNodeName:    "scanNode", // inside of 1st subType (related type)
+				OccurancesToSkip:  1,
+				IncludeChildNodes: true, // should be leaf of it's branch, so will have no child nodes.
+				ExpectedAttributes: dataMap{
+					"collectionID":   "2",
+					"collectionName": "Book",
+					"filter":         nil,
+					"spans": []dataMap{
+						{
+							"start": "/2",
+							"end":   "/3",
+						},
+					},
+				},
+			},
+			{
+				TargetNodeName:    "typeIndexJoin",
+				OccurancesToSkip:  1,
+				IncludeChildNodes: false,
+				ExpectedAttributes: dataMap{
+					"joinType":    "typeJoinMany",
+					"rootName":    "author",
+					"subTypeName": "articles",
+				},
+			},
+			{
+				TargetNodeName:    "scanNode", // inside of 2nd root type (AKA: subType's root)
+				OccurancesToSkip:  2,
+				IncludeChildNodes: true, // should be leaf of it's branch, so will have no child nodes.
+				ExpectedAttributes: dataMap{
+					"collectionID":   "3",
+					"collectionName": "Author",
+					"filter":         nil,
+					"spans": []dataMap{
+						{
+							"start": "/3",
+							"end":   "/4",
+						},
+					},
+				},
+			},
+			{
+				TargetNodeName:    "scanNode", // inside of 2nd subType (AKA: subType's subtype)
+				OccurancesToSkip:  3,
+				IncludeChildNodes: true, // should be leaf of it's branch, so will have no child nodes.
+				ExpectedAttributes: dataMap{
+					"collectionID":   "1",
+					"collectionName": "Article",
+					"filter":         nil,
+					"spans": []dataMap{
+						{
+							"start": "/1",
+							"end":   "/2",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	runExplainTest(t, test)
+}

--- a/tests/integration/explain/default/with_sum_test.go
+++ b/tests/integration/explain/default/with_sum_test.go
@@ -16,430 +16,16 @@ import (
 	explainUtils "github.com/sourcenetwork/defradb/tests/integration/explain"
 )
 
-func TestDefaultExplainRequestWithSumOnOneToManyJoinedField(t *testing.T) {
-	test := explainUtils.ExplainRequestTestCase{
-
-		Description: "Explain (default) request with sum on a one-to-many joined field.",
-
-		Request: `query @explain {
-			Author {
-				name
-				_key
-				TotalPages: _sum(
-					books: {field: pages}
-				)
-			}
-		}`,
-
-		Docs: map[int][]string{
-			// books
-			1: {
-				`{
-					"name": "Painted House",
-					"author_id": "bae-25fafcc7-f251-58c1-9495-ead73e676fb8",
-					"pages": 22
-				}`,
-				`{
-					"name": "A Time for Mercy",
-					"author_id": "bae-25fafcc7-f251-58c1-9495-ead73e676fb8",
-					"pages": 101
-				}`,
-				`{
-					"name": "Theif Lord",
-					"author_id": "bae-3dddb519-3612-5e43-86e5-49d6295d4f84",
-					"pages": 321
-				}`,
-			},
-
-			// authors
-			2: {
-				// _key: "bae-25fafcc7-f251-58c1-9495-ead73e676fb8"
-				`{
-					"name": "John Grisham",
-					"age": 65,
-					"verified": true,
-					"contact_id": "bae-1fe427b8-ab8d-56c3-9df2-826a6ce86fed"
-				}`,
-				// _key: "bae-3dddb519-3612-5e43-86e5-49d6295d4f84"
-				`{
-					"name": "Cornelia Funke",
-					"age": 62,
-					"verified": false,
-					"contact_id": "bae-c0960a29-b704-5c37-9c2e-59e1249e4559"
-				}`,
-			},
-		},
-
-		ExpectedFullGraph: []dataMap{
-			{
-				"explain": dataMap{
-					"selectTopNode": dataMap{
-						"sumNode": dataMap{
-							"sources": []dataMap{
-								{
-									"fieldName":      "books",
-									"childFieldName": "pages",
-									"filter":         nil,
-								},
-							},
-							"selectNode": dataMap{
-								"filter": nil,
-								"typeIndexJoin": dataMap{
-									"joinType": "typeJoinMany",
-									"rootName": "author",
-									"root": dataMap{
-										"scanNode": dataMap{
-											"collectionID":   "3",
-											"collectionName": "Author",
-											"filter":         nil,
-											"spans": []dataMap{
-												{
-													"start": "/3",
-													"end":   "/4",
-												},
-											},
-										},
-									},
-									"subTypeName": "books",
-									"subType": dataMap{
-										"selectTopNode": dataMap{
-											"selectNode": dataMap{
-												"filter": nil,
-												"scanNode": dataMap{
-													"collectionID":   "2",
-													"collectionName": "Book",
-													"filter":         nil,
-													"spans": []dataMap{
-														{
-															"start": "/2",
-															"end":   "/3",
-														},
-													},
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-					},
+var sumPattern = dataMap{
+	"explain": dataMap{
+		"selectTopNode": dataMap{
+			"sumNode": dataMap{
+				"selectNode": dataMap{
+					"scanNode": dataMap{},
 				},
 			},
 		},
-	}
-
-	runExplainTest(t, test)
-}
-
-func TestDefaultExplainRequestWithSumOnOneToManyJoinedFieldWithFilter(t *testing.T) {
-	test := explainUtils.ExplainRequestTestCase{
-
-		Description: "Explain (default) request with sum on a one-to-many joined field, with filter.",
-
-		Request: `query @explain {
-			Author {
-				name
-				TotalPages: _sum(
-					articles: {
-						field: pages,
-						filter: {
-							name: {
-								_eq: "To my dear readers"
-							}
-						}
-					}
-				)
-			}
-		}`,
-
-		Docs: map[int][]string{
-			// articles
-			0: {
-				`{
-					"name": "After Guantánamo, Another Injustice",
-					"author_id": "bae-25fafcc7-f251-58c1-9495-ead73e676fb8",
-					"pages": 2
-				}`,
-				`{
-					"name": "To my dear readers",
-					"author_id": "bae-3dddb519-3612-5e43-86e5-49d6295d4f84",
-					"pages": 11
-				}`,
-				`{
-					"name": "Twinklestar's Favourite Xmas Cookie",
-					"author_id": "bae-3dddb519-3612-5e43-86e5-49d6295d4f84",
-					"pages": 31
-				}`,
-			},
-
-			// authors
-			2: {
-				// _key: "bae-25fafcc7-f251-58c1-9495-ead73e676fb8"
-				`{
-					"name": "John Grisham",
-					"age": 65,
-					"verified": true,
-					"contact_id": "bae-1fe427b8-ab8d-56c3-9df2-826a6ce86fed"
-				}`,
-				// _key: "bae-3dddb519-3612-5e43-86e5-49d6295d4f84"
-				`{
-					"name": "Cornelia Funke",
-					"age": 62,
-					"verified": false,
-					"contact_id": "bae-c0960a29-b704-5c37-9c2e-59e1249e4559"
-				}`,
-			},
-		},
-
-		ExpectedFullGraph: []dataMap{
-			{
-				"explain": dataMap{
-					"selectTopNode": dataMap{
-						"sumNode": dataMap{
-							"sources": []dataMap{
-								{
-									"fieldName":      "articles",
-									"childFieldName": "pages",
-									"filter": dataMap{
-										"name": dataMap{
-											"_eq": "To my dear readers",
-										},
-									},
-								},
-							},
-							"selectNode": dataMap{
-								"filter": nil,
-								"typeIndexJoin": dataMap{
-									"joinType": "typeJoinMany",
-									"rootName": "author",
-									"root": dataMap{
-										"scanNode": dataMap{
-											"collectionID":   "3",
-											"collectionName": "Author",
-											"filter":         nil,
-											"spans": []dataMap{
-												{
-													"start": "/3",
-													"end":   "/4",
-												},
-											},
-										},
-									},
-									"subTypeName": "articles",
-									"subType": dataMap{
-										"selectTopNode": dataMap{
-											"selectNode": dataMap{
-												"filter": nil,
-												"scanNode": dataMap{
-													"collectionID":   "1",
-													"collectionName": "Article",
-													"filter": dataMap{
-														"name": dataMap{
-															"_eq": "To my dear readers",
-														},
-													},
-													"spans": []dataMap{
-														{
-															"start": "/1",
-															"end":   "/2",
-														},
-													},
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-
-	runExplainTest(t, test)
-}
-
-func TestDefaultExplainRequestWithSumOnOneToManyJoinedFieldWithManySources(t *testing.T) {
-	test := explainUtils.ExplainRequestTestCase{
-
-		Description: "Explain (default) request with sum on a one-to-many joined field with many sources.",
-
-		Request: `query @explain {
-			Author {
-				name
-				TotalPages: _sum(
-					books: {field: pages},
-					articles: {field: pages}
-				)
-			}
-		}`,
-
-		Docs: map[int][]string{
-			// articles
-			0: {
-				`{
-					"name": "After Guantánamo, Another Injustice",
-					"author_id": "bae-25fafcc7-f251-58c1-9495-ead73e676fb8",
-					"pages": 2
-				}`,
-				`{
-					"name": "To my dear readers",
-					"author_id": "bae-3dddb519-3612-5e43-86e5-49d6295d4f84",
-					"pages": 11
-				}`,
-				`{
-					"name": "Twinklestar's Favourite Xmas Cookie",
-					"author_id": "bae-3dddb519-3612-5e43-86e5-49d6295d4f84",
-					"pages": 31
-				}`,
-			},
-
-			// books
-			1: {
-				`{
-					"name": "Painted House",
-					"author_id": "bae-25fafcc7-f251-58c1-9495-ead73e676fb8",
-					"pages": 22
-				}`,
-				`{
-					"name": "A Time for Mercy",
-					"author_id": "bae-25fafcc7-f251-58c1-9495-ead73e676fb8",
-					"pages": 101
-				}`,
-				`{
-					"name": "Theif Lord",
-					"author_id": "bae-3dddb519-3612-5e43-86e5-49d6295d4f84",
-					"pages": 321
-				}`,
-			},
-
-			// authors
-			2: {
-				// _key: "bae-25fafcc7-f251-58c1-9495-ead73e676fb8"
-				`{
-					"name": "John Grisham",
-					"age": 65,
-					"verified": true,
-					"contact_id": "bae-1fe427b8-ab8d-56c3-9df2-826a6ce86fed"
-				}`,
-				// _key: "bae-3dddb519-3612-5e43-86e5-49d6295d4f84"
-				`{
-					"name": "Cornelia Funke",
-					"age": 62,
-					"verified": false,
-					"contact_id": "bae-c0960a29-b704-5c37-9c2e-59e1249e4559"
-				}`,
-			},
-		},
-
-		ExpectedFullGraph: []dataMap{
-			{
-				"explain": dataMap{
-					"selectTopNode": dataMap{
-						"sumNode": dataMap{
-							"sources": []dataMap{
-								{
-									"childFieldName": "pages",
-									"fieldName":      "books",
-									"filter":         nil,
-								},
-
-								{
-									"childFieldName": "pages",
-									"fieldName":      "articles",
-									"filter":         nil,
-								},
-							},
-							"selectNode": dataMap{
-								"filter": nil,
-								"parallelNode": []dataMap{
-									{
-										"typeIndexJoin": dataMap{
-											"joinType": "typeJoinMany",
-											"rootName": "author",
-											"root": dataMap{
-												"scanNode": dataMap{
-													"collectionID":   "3",
-													"collectionName": "Author",
-													"filter":         nil,
-													"spans": []dataMap{
-														{
-															"start": "/3",
-															"end":   "/4",
-														},
-													},
-												},
-											},
-											"subTypeName": "books",
-											"subType": dataMap{
-												"selectTopNode": dataMap{
-													"selectNode": dataMap{
-														"filter": nil,
-														"scanNode": dataMap{
-															"collectionID":   "2",
-															"collectionName": "Book",
-															"filter":         nil,
-															"spans": []dataMap{
-																{
-																	"start": "/2",
-																	"end":   "/3",
-																},
-															},
-														},
-													},
-												},
-											},
-										},
-									},
-									{
-										"typeIndexJoin": dataMap{
-											"joinType": "typeJoinMany",
-											"rootName": "author",
-											"root": dataMap{
-												"scanNode": dataMap{
-													"collectionID":   "3",
-													"collectionName": "Author",
-													"filter":         nil,
-													"spans": []dataMap{
-														{
-															"start": "/3",
-															"end":   "/4",
-														},
-													},
-												},
-											},
-											"subTypeName": "articles",
-											"subType": dataMap{
-												"selectTopNode": dataMap{
-													"selectNode": dataMap{
-														"filter": nil,
-														"scanNode": dataMap{
-															"collectionID":   "1",
-															"collectionName": "Article",
-															"filter":         nil,
-															"spans": []dataMap{
-																{
-																	"start": "/1",
-																	"end":   "/2",
-																},
-															},
-														},
-													},
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-
-	runExplainTest(t, test)
+	},
 }
 
 func TestDefaultExplainRequestWithSumOnInlineArrayField_ChildFieldWillBeEmpty(t *testing.T) {
@@ -480,32 +66,33 @@ func TestDefaultExplainRequestWithSumOnInlineArrayField_ChildFieldWillBeEmpty(t 
 			},
 		},
 
-		ExpectedFullGraph: []dataMap{
+		ExpectedPatterns: []dataMap{sumPattern},
+
+		ExpectedTargets: []explainUtils.PlanNodeTargetCase{
 			{
-				"explain": dataMap{
-					"selectTopNode": dataMap{
-						"sumNode": dataMap{
-							"sources": []dataMap{
-								{
-									"fieldName":      "chapterPages",
-									"childFieldName": nil,
-									"filter":         nil,
-								},
-							},
-							"selectNode": dataMap{
-								"filter": nil,
-								"scanNode": dataMap{
-									"collectionID":   "2",
-									"collectionName": "Book",
-									"filter":         nil,
-									"spans": []dataMap{
-										{
-											"start": "/2",
-											"end":   "/3",
-										},
-									},
-								},
-							},
+				TargetNodeName:    "sumNode",
+				IncludeChildNodes: false,
+				ExpectedAttributes: dataMap{
+					"sources": []dataMap{
+						{
+							"fieldName":      "chapterPages",
+							"childFieldName": nil,
+							"filter":         nil,
+						},
+					},
+				},
+			},
+			{
+				TargetNodeName:    "scanNode",
+				IncludeChildNodes: true, // should be leaf of it's branch, so will have no child nodes.
+				ExpectedAttributes: dataMap{
+					"collectionID":   "2",
+					"collectionName": "Book",
+					"filter":         nil,
+					"spans": []dataMap{
+						{
+							"start": "/2",
+							"end":   "/3",
 						},
 					},
 				},

--- a/tests/integration/explain/default/with_sum_test.go
+++ b/tests/integration/explain/default/with_sum_test.go
@@ -13,12 +13,13 @@ package test_explain_default
 import (
 	"testing"
 
-	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	explainUtils "github.com/sourcenetwork/defradb/tests/integration/explain"
 )
 
-func TestExplainQuerySumOfRelatedOneToManyField(t *testing.T) {
-	test := testUtils.RequestTestCase{
-		Description: "Explain a simple sum query of a One-to-Many realted sub-type.",
+func TestDefaultExplainRequestWithSumOnOneToManyJoinedField(t *testing.T) {
+	test := explainUtils.ExplainRequestTestCase{
+
+		Description: "Explain (default) request with sum on a one-to-many joined field.",
 
 		Request: `query @explain {
 			Author {
@@ -69,7 +70,7 @@ func TestExplainQuerySumOfRelatedOneToManyField(t *testing.T) {
 			},
 		},
 
-		Results: []dataMap{
+		ExpectedFullGraph: []dataMap{
 			{
 				"explain": dataMap{
 					"selectTopNode": dataMap{
@@ -127,12 +128,13 @@ func TestExplainQuerySumOfRelatedOneToManyField(t *testing.T) {
 		},
 	}
 
-	executeTestCase(t, test)
+	runExplainTest(t, test)
 }
 
-func TestExplainQuerySumOfRelatedOneToManyFieldWithFilter(t *testing.T) {
-	test := testUtils.RequestTestCase{
-		Description: "Explain a simple sum query of a One-to-Many realted sub-type with a filter.",
+func TestDefaultExplainRequestWithSumOnOneToManyJoinedFieldWithFilter(t *testing.T) {
+	test := explainUtils.ExplainRequestTestCase{
+
+		Description: "Explain (default) request with sum on a one-to-many joined field, with filter.",
 
 		Request: `query @explain {
 			Author {
@@ -189,7 +191,7 @@ func TestExplainQuerySumOfRelatedOneToManyFieldWithFilter(t *testing.T) {
 			},
 		},
 
-		Results: []dataMap{
+		ExpectedFullGraph: []dataMap{
 			{
 				"explain": dataMap{
 					"selectTopNode": dataMap{
@@ -255,85 +257,13 @@ func TestExplainQuerySumOfRelatedOneToManyFieldWithFilter(t *testing.T) {
 		},
 	}
 
-	executeTestCase(t, test)
+	runExplainTest(t, test)
 }
 
-func TestExplainQuerySumOfInlineArrayField_ShouldHaveEmptyChildField(t *testing.T) {
-	test := testUtils.RequestTestCase{
-		Description: "Explain a simple sum query on an  inline array field (childFieldName is nil).",
+func TestDefaultExplainRequestWithSumOnOneToManyJoinedFieldWithManySources(t *testing.T) {
+	test := explainUtils.ExplainRequestTestCase{
 
-		Request: `query @explain {
-			Book {
-				name
-				NotSureWhySomeoneWouldSumTheChapterPagesButHereItIs: _sum(chapterPages: {})
-			}
-		}`,
-
-		Docs: map[int][]string{
-			// books
-			1: {
-				`{
-					"name": "Painted House",
-					"author_id": "bae-25fafcc7-f251-58c1-9495-ead73e676fb8",
-					"pages": 77,
-					"chapterPages": [1, 22, 33, 44, 55, 66]
-				}`, // sum of chapterPages == 221
-
-				`{
-					"name": "A Time for Mercy",
-					"author_id": "bae-25fafcc7-f251-58c1-9495-ead73e676fb8",
-					"pages": 55,
-					"chapterPages": [1, 22]
-				}`, // sum of chapterPages == 23
-
-				`{
-					"name": "Theif Lord",
-					"author_id": "bae-3dddb519-3612-5e43-86e5-49d6295d4f84",
-					"pages": 321,
-					"chapterPages": [10, 50, 100, 200, 300]
-				}`, // sum of chapterPages == 660
-			},
-		},
-
-		Results: []dataMap{
-			{
-				"explain": dataMap{
-					"selectTopNode": dataMap{
-						"sumNode": dataMap{
-							"sources": []dataMap{
-								{
-									"fieldName":      "chapterPages",
-									"childFieldName": nil,
-									"filter":         nil,
-								},
-							},
-							"selectNode": dataMap{
-								"filter": nil,
-								"scanNode": dataMap{
-									"collectionID":   "2",
-									"collectionName": "Book",
-									"filter":         nil,
-									"spans": []dataMap{
-										{
-											"start": "/2",
-											"end":   "/3",
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-
-	executeTestCase(t, test)
-}
-
-func TestExplainQuerySumOfRelatedOneToManyFieldWithManySources(t *testing.T) {
-	test := testUtils.RequestTestCase{
-		Description: "Explain a simple sum query of a One-to-Many realted sub-type with many sources.",
+		Description: "Explain (default) request with sum on a one-to-many joined field with many sources.",
 
 		Request: `query @explain {
 			Author {
@@ -403,7 +333,7 @@ func TestExplainQuerySumOfRelatedOneToManyFieldWithManySources(t *testing.T) {
 			},
 		},
 
-		Results: []dataMap{
+		ExpectedFullGraph: []dataMap{
 			{
 				"explain": dataMap{
 					"selectTopNode": dataMap{
@@ -509,5 +439,79 @@ func TestExplainQuerySumOfRelatedOneToManyFieldWithManySources(t *testing.T) {
 		},
 	}
 
-	executeTestCase(t, test)
+	runExplainTest(t, test)
+}
+
+func TestDefaultExplainRequestWithSumOnInlineArrayField_ChildFieldWillBeEmpty(t *testing.T) {
+	test := explainUtils.ExplainRequestTestCase{
+
+		Description: "Explain (default) request with sum on an inline array field.",
+
+		Request: `query @explain {
+			Book {
+				name
+				NotSureWhySomeoneWouldSumTheChapterPagesButHereItIs: _sum(chapterPages: {})
+			}
+		}`,
+
+		Docs: map[int][]string{
+			// books
+			1: {
+				`{
+					"name": "Painted House",
+					"author_id": "bae-25fafcc7-f251-58c1-9495-ead73e676fb8",
+					"pages": 77,
+					"chapterPages": [1, 22, 33, 44, 55, 66]
+				}`, // sum of chapterPages == 221
+
+				`{
+					"name": "A Time for Mercy",
+					"author_id": "bae-25fafcc7-f251-58c1-9495-ead73e676fb8",
+					"pages": 55,
+					"chapterPages": [1, 22]
+				}`, // sum of chapterPages == 23
+
+				`{
+					"name": "Theif Lord",
+					"author_id": "bae-3dddb519-3612-5e43-86e5-49d6295d4f84",
+					"pages": 321,
+					"chapterPages": [10, 50, 100, 200, 300]
+				}`, // sum of chapterPages == 660
+			},
+		},
+
+		ExpectedFullGraph: []dataMap{
+			{
+				"explain": dataMap{
+					"selectTopNode": dataMap{
+						"sumNode": dataMap{
+							"sources": []dataMap{
+								{
+									"fieldName":      "chapterPages",
+									"childFieldName": nil,
+									"filter":         nil,
+								},
+							},
+							"selectNode": dataMap{
+								"filter": nil,
+								"scanNode": dataMap{
+									"collectionID":   "2",
+									"collectionName": "Book",
+									"filter":         nil,
+									"spans": []dataMap{
+										{
+											"start": "/2",
+											"end":   "/3",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	runExplainTest(t, test)
 }


### PR DESCRIPTION
## Relevant issue(s)
- Part of #953
- Resolves #1485

## Description
Continue converting explain tests to the new explain setup before we can integrate the entire setup to the new action-based setup. #953 Has a lot more detail on the entire plan.

- This PR converts all the default explain sum tests.
- Splits sum join tests in a separate PR.
