### PR TITLE
refactor: Use `int32` for proper gql scalar Int parsing

### DIFF
--- a/connor/eq.go
+++ b/connor/eq.go
@@ -61,7 +61,7 @@ func eq(condition, data any) (bool, error) {
 		return false, nil
 	case int64:
 		return numbers.Equal(cn, data), nil
-	case int:
+	case int32:
 		return numbers.Equal(cn, data), nil
 	case float64:
 		return numbers.Equal(cn, data), nil

--- a/go.mod
+++ b/go.mod
@@ -198,6 +198,6 @@ require (
 
 // SourceNetwork fork og graphql-go
 replace (
-	github.com/graphql-go/graphql => github.com/sourcenetwork/graphql-go v0.7.10-0.20230427183824-8343db738835
+	github.com/graphql-go/graphql => github.com/sourcenetwork/graphql-go v0.7.10-0.20230511091704-fe7085512c23
 	github.com/textileio/go-libp2p-pubsub-rpc => github.com/sourcenetwork/go-libp2p-pubsub-rpc v0.0.0-20230209220544-e16d5e34c4fc
 )

--- a/go.sum
+++ b/go.sum
@@ -1214,8 +1214,8 @@ github.com/sourcegraph/annotate v0.0.0-20160123013949-f4cad6c6324d/go.mod h1:Udh
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
 github.com/sourcenetwork/go-libp2p-pubsub-rpc v0.0.0-20230209220544-e16d5e34c4fc h1:ZrkklfmN27eENGFmzblEcs35PJ02hmlNgMHE8XJqFAo=
 github.com/sourcenetwork/go-libp2p-pubsub-rpc v0.0.0-20230209220544-e16d5e34c4fc/go.mod h1:3rOV6TxePSwADKpnwXBKpTjAA4QyjZBus13xc6VCtSw=
-github.com/sourcenetwork/graphql-go v0.7.10-0.20230427183824-8343db738835 h1:P/FCdfRdvRWhNR6DPLlMVZBkOUaG7aVxr0e9CNeukW4=
-github.com/sourcenetwork/graphql-go v0.7.10-0.20230427183824-8343db738835/go.mod h1:3Ty9EMes+aoxl8xS0CsuCGQZ4JEsOlC5yqQDLOKoBRw=
+github.com/sourcenetwork/graphql-go v0.7.10-0.20230511091704-fe7085512c23 h1:QcSWSYlE1alUC0uOO/trppYMLpR8OuFIL8IqR+PR5sA=
+github.com/sourcenetwork/graphql-go v0.7.10-0.20230511091704-fe7085512c23/go.mod h1:3Ty9EMes+aoxl8xS0CsuCGQZ4JEsOlC5yqQDLOKoBRw=
 github.com/sourcenetwork/immutable v0.2.2 h1:Qjz1cCWhgjS6YkUTWb53R22wSYMEZhzBghhEzWaFi8c=
 github.com/sourcenetwork/immutable v0.2.2/go.mod h1:4jpxObkIQw8pvlIRm4ndZqf3pH9ZjYEw/UYI6GZDJww=
 github.com/spacemonkeygo/openssl v0.0.0-20181017203307-c2dcc5cca94a/go.mod h1:7AyxJNCJ7SBZ1MfVQCWD6Uqo2oubI2Eq2y2eqf+A5r0=

--- a/tests/integration/explain/default/delete_test.go
+++ b/tests/integration/explain/default/delete_test.go
@@ -382,7 +382,7 @@ func TestDefaultExplainMutationRequestWithDeleteUsingFilterAndIds(t *testing.T) 
 						"_and": []any{
 							dataMap{
 								"age": dataMap{
-									"_lt": int(26),
+									"_lt": int32(26),
 								},
 							},
 							dataMap{
@@ -409,7 +409,7 @@ func TestDefaultExplainMutationRequestWithDeleteUsingFilterAndIds(t *testing.T) 
 						"_and": []any{
 							dataMap{
 								"age": dataMap{
-									"_lt": int(26),
+									"_lt": int32(26),
 								},
 							},
 							dataMap{

--- a/tests/integration/explain/default/group_with_dockey_test.go
+++ b/tests/integration/explain/default/group_with_dockey_test.go
@@ -239,7 +239,7 @@ func TestExplainQuerySimpleWithDockeysAndFilter(t *testing.T) {
 									"collectionName": "Author",
 									"filter": dataMap{
 										"age": dataMap{
-											"_eq": int(20),
+											"_eq": int32(20),
 										},
 									},
 									"spans": []dataMap{

--- a/tests/integration/explain/default/group_with_filter_test.go
+++ b/tests/integration/explain/default/group_with_filter_test.go
@@ -75,7 +75,7 @@ func TestExplainGroupByWithFilterOnParent(t *testing.T) {
 									"collectionName": "Author",
 									"filter": dataMap{
 										"age": dataMap{
-											"_gt": int(63),
+											"_gt": int32(63),
 										},
 									},
 									"spans": []dataMap{
@@ -144,7 +144,7 @@ func TestExplainGroupByWithFilterOnInnerGroupSelection(t *testing.T) {
 									"orderBy":        nil,
 									"filter": dataMap{
 										"age": dataMap{
-											"_gt": int(63),
+											"_gt": int32(63),
 										},
 									},
 								},

--- a/tests/integration/explain/default/top_with_average_test.go
+++ b/tests/integration/explain/default/top_with_average_test.go
@@ -184,7 +184,7 @@ func TestDefaultExplainTopLevelAverageRequestWithFilter(t *testing.T) {
 					"collectionName": "Author",
 					"filter": dataMap{
 						"age": dataMap{
-							"_gt": int(26),
+							"_gt": int32(26),
 							"_ne": nil,
 						},
 					},
@@ -206,7 +206,7 @@ func TestDefaultExplainTopLevelAverageRequestWithFilter(t *testing.T) {
 							"fieldName":      "Author",
 							"filter": dataMap{
 								"age": dataMap{
-									"_gt": int(26),
+									"_gt": int32(26),
 									"_ne": nil,
 								},
 							},
@@ -223,7 +223,7 @@ func TestDefaultExplainTopLevelAverageRequestWithFilter(t *testing.T) {
 							"fieldName": "Author",
 							"filter": dataMap{
 								"age": dataMap{
-									"_gt": int(26),
+									"_gt": int32(26),
 									"_ne": nil,
 								},
 							},

--- a/tests/integration/explain/default/top_with_count_test.go
+++ b/tests/integration/explain/default/top_with_count_test.go
@@ -143,7 +143,7 @@ func TestDefaultExplainTopLevelCountRequestWithFilter(t *testing.T) {
 					"collectionName": "Author",
 					"filter": dataMap{
 						"age": dataMap{
-							"_gt": int(26),
+							"_gt": int32(26),
 						},
 					},
 					"spans": []dataMap{
@@ -163,7 +163,7 @@ func TestDefaultExplainTopLevelCountRequestWithFilter(t *testing.T) {
 							"fieldName": "Author",
 							"filter": dataMap{
 								"age": dataMap{
-									"_gt": int(26),
+									"_gt": int32(26),
 								},
 							},
 						},

--- a/tests/integration/explain/default/top_with_sum_test.go
+++ b/tests/integration/explain/default/top_with_sum_test.go
@@ -149,7 +149,7 @@ func TestDefaultExplainTopLevelSumRequestWithFilter(t *testing.T) {
 					"collectionName": "Author",
 					"filter": dataMap{
 						"age": dataMap{
-							"_gt": int(26),
+							"_gt": int32(26),
 						},
 					},
 					"spans": []dataMap{
@@ -170,7 +170,7 @@ func TestDefaultExplainTopLevelSumRequestWithFilter(t *testing.T) {
 							"childFieldName": "age",
 							"filter": dataMap{
 								"age": dataMap{
-									"_gt": int(26),
+									"_gt": int32(26),
 								},
 							},
 						},

--- a/tests/integration/explain/default/with_average_join_test.go
+++ b/tests/integration/explain/default/with_average_join_test.go
@@ -310,7 +310,7 @@ func TestDefaultExplainRequestWithAverageOnMultipleJoinedFieldsWithFilter(t *tes
 							"fieldName": "articles",
 							"filter": dataMap{
 								"pages": dataMap{
-									"_gt": int(3),
+									"_gt": int32(3),
 									"_ne": nil,
 								},
 							},
@@ -337,7 +337,7 @@ func TestDefaultExplainRequestWithAverageOnMultipleJoinedFieldsWithFilter(t *tes
 							"fieldName":      "articles",
 							"filter": dataMap{
 								"pages": dataMap{
-									"_gt": int(3),
+									"_gt": int32(3),
 									"_ne": nil,
 								},
 							},
@@ -426,7 +426,7 @@ func TestDefaultExplainRequestWithAverageOnMultipleJoinedFieldsWithFilter(t *tes
 					"collectionName": "Article",
 					"filter": dataMap{
 						"pages": dataMap{
-							"_gt": int(3),
+							"_gt": int32(3),
 							"_ne": nil,
 						},
 					},

--- a/tests/integration/explain/default/with_filter_test.go
+++ b/tests/integration/explain/default/with_filter_test.go
@@ -113,7 +113,7 @@ func TestDefaultExplainRequestWithIntegerEqualFilter(t *testing.T) {
 					"collectionName": "Author",
 					"filter": dataMap{
 						"age": dataMap{
-							"_eq": int(26),
+							"_eq": int32(26),
 						},
 					},
 					"spans": []dataMap{
@@ -170,7 +170,7 @@ func TestDefaultExplainRequestWithGreaterThanFilter(t *testing.T) {
 					"collectionName": "Author",
 					"filter": dataMap{
 						"age": dataMap{
-							"_gt": int(20),
+							"_gt": int32(20),
 						},
 					},
 					"spans": []dataMap{
@@ -233,12 +233,12 @@ func TestDefaultExplainRequestWithLogicalCompoundAndFilter(t *testing.T) {
 						"_and": []any{
 							dataMap{
 								"age": dataMap{
-									"_gt": int(20),
+									"_gt": int32(20),
 								},
 							},
 							dataMap{
 								"age": dataMap{
-									"_lt": int(50),
+									"_lt": int32(50),
 								},
 							},
 						},
@@ -303,12 +303,12 @@ func TestDefaultExplainRequestWithLogicalCompoundOrFilter(t *testing.T) {
 						"_or": []any{
 							dataMap{
 								"age": dataMap{
-									"_eq": int(55),
+									"_eq": int32(55),
 								},
 							},
 							dataMap{
 								"age": dataMap{
-									"_eq": int(19),
+									"_eq": int32(19),
 								},
 							},
 						},
@@ -372,9 +372,9 @@ func TestDefaultExplainRequestWithMatchInsideList(t *testing.T) {
 					"filter": dataMap{
 						"age": dataMap{
 							"_in": []any{
-								int(19),
-								int(40),
-								int(55),
+								int32(19),
+								int32(40),
+								int32(55),
 							},
 						},
 					},


### PR DESCRIPTION
## Relevant issue(s)

Resolves #938 

## Description

Updates the graphql-go lib to [this](https://github.com/sourcenetwork/graphql-go/commit/fe7085512c230f9daec4afa8231bd10b9225852b) update, which applies proper scalar Int parsing and coercing to return `int32` instead of `int`.

This has *minor* downstream changes as you can see in this PR. Also had to update the explain tests @shahzadlone since it was using the filter types directly in the explain output which has now changed to `int32`

## Tasks

- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Manually + CI

Specify the platform(s) on which this was tested:
- Ubuntu (WSL2)
