### PR TITLE
feat: Add collection response information on creation

### DIFF
--- a/api/http/handlerfuncs_test.go
+++ b/api/http/handlerfuncs_test.go
@@ -713,7 +713,15 @@ type user {
 
 	switch v := resp.Data.(type) {
 	case map[string]any:
-		assert.Equal(t, "success", v["result"])
+		assert.Equal(t, map[string]any{
+			"result": "success",
+			"collections": []any{
+				map[string]any{
+					"name": "user",
+					"id":   "bafkreigrucdl7x3lsa4xwgz2bn7lbqmiwkifnspgx7hlkpaal3o55325bq",
+				},
+			},
+		}, v)
 
 	default:
 		t.Fatalf("data should be of type map[string]any but got %T\n%v", resp.Data, v)
@@ -1024,7 +1032,7 @@ type user {
 	verified: Boolean 
 	points: Float
 }`
-	err := db.AddSchema(ctx, stmt)
+	_, err := db.AddSchema(ctx, stmt)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cli/schema_add.go
+++ b/cli/schema_add.go
@@ -23,6 +23,7 @@ import (
 	httpapi "github.com/sourcenetwork/defradb/api/http"
 	"github.com/sourcenetwork/defradb/config"
 	"github.com/sourcenetwork/defradb/errors"
+	"github.com/sourcenetwork/defradb/logging"
 )
 
 func MakeSchemaAddCommand(cfg *config.Config) *cobra.Command {
@@ -134,13 +135,20 @@ Learn more about the DefraDB GraphQL Schema Language on https://docs.source.netw
 				} else {
 					type schemaResponse struct {
 						Data struct {
-							Result string `json:"result"`
+							Result      string `json:"result"`
+							Collections []struct {
+								Name string `json:"name"`
+								ID   string `json:"id"`
+							} `json:"collections"`
 						} `json:"data"`
 					}
 					r := schemaResponse{}
 					err = json.Unmarshal(response, &r)
 					if err != nil {
 						return errors.Wrap("failed to unmarshal response", err)
+					}
+					if r.Data.Result == "success" {
+						log.FeedbackInfo(cmd.Context(), "Successfully added schema.", logging.NewKV("Collections", r.Data.Collections))
 					}
 					log.FeedbackInfo(cmd.Context(), r.Data.Result)
 				}

--- a/client/db.go
+++ b/client/db.go
@@ -88,7 +88,7 @@ type Store interface {
 	//
 	// All schema types provided must not exist prior to calling this, and they may not reference existing
 	// types previously defined.
-	AddSchema(context.Context, string) error
+	AddSchema(context.Context, string) ([]CollectionDescription, error)
 
 	// PatchSchema takes the given JSON patch string and applies it to the set of CollectionDescriptions
 	// present in the database.

--- a/db/schema.go
+++ b/db/schema.go
@@ -23,29 +23,32 @@ import (
 
 // addSchema takes the provided schema in SDL format, and applies it to the database,
 // and creates the necessary collections, request types, etc.
-func (db *db) addSchema(ctx context.Context, txn datastore.Txn, schemaString string) error {
+func (db *db) addSchema(ctx context.Context, txn datastore.Txn, schemaString string) ([]client.CollectionDescription, error) {
 	existingDescriptions, err := db.getCollectionDescriptions(ctx, txn)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	newDescriptions, err := db.parser.ParseSDL(ctx, schemaString)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	err = db.parser.SetSchema(ctx, txn, append(existingDescriptions, newDescriptions...))
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	for _, desc := range newDescriptions {
-		if _, err := db.createCollection(ctx, txn, desc); err != nil {
-			return err
+	returnDescriptions := make([]client.CollectionDescription, len(newDescriptions))
+	for i, desc := range newDescriptions {
+		col, err := db.createCollection(ctx, txn, desc)
+		if err != nil {
+			return nil, err
 		}
+		returnDescriptions[i] = col.Description()
 	}
 
-	return nil
+	return returnDescriptions, nil
 }
 
 func (db *db) loadSchema(ctx context.Context, txn datastore.Txn) error {

--- a/db/schema.go
+++ b/db/schema.go
@@ -23,7 +23,11 @@ import (
 
 // addSchema takes the provided schema in SDL format, and applies it to the database,
 // and creates the necessary collections, request types, etc.
-func (db *db) addSchema(ctx context.Context, txn datastore.Txn, schemaString string) ([]client.CollectionDescription, error) {
+func (db *db) addSchema(
+	ctx context.Context,
+	txn datastore.Txn,
+	schemaString string,
+) ([]client.CollectionDescription, error) {
 	existingDescriptions, err := db.getCollectionDescriptions(ctx, txn)
 	if err != nil {
 		return nil, err

--- a/db/txn_db.go
+++ b/db/txn_db.go
@@ -191,19 +191,22 @@ func (db *explicitTxnDB) GetAllCollections(ctx context.Context) ([]client.Collec
 //
 // All schema types provided must not exist prior to calling this, and they may not reference existing
 // types previously defined.
-func (db *implicitTxnDB) AddSchema(ctx context.Context, schemaString string) error {
+func (db *implicitTxnDB) AddSchema(ctx context.Context, schemaString string) ([]client.CollectionDescription, error) {
 	txn, err := db.NewTxn(ctx, false)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer txn.Discard(ctx)
 
-	err = db.addSchema(ctx, txn, schemaString)
+	cols, err := db.addSchema(ctx, txn, schemaString)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	return txn.Commit(ctx)
+	if err := txn.Commit(ctx); err != nil {
+		return nil, err
+	}
+	return cols, nil
 }
 
 // AddSchema takes the provided GQL schema in SDL format, and applies it to the database,
@@ -211,7 +214,7 @@ func (db *implicitTxnDB) AddSchema(ctx context.Context, schemaString string) err
 //
 // All schema types provided must not exist prior to calling this, and they may not reference existing
 // types previously defined.
-func (db *explicitTxnDB) AddSchema(ctx context.Context, schemaString string) error {
+func (db *explicitTxnDB) AddSchema(ctx context.Context, schemaString string) ([]client.CollectionDescription, error) {
 	return db.addSchema(ctx, db.txn, schemaString)
 }
 

--- a/tests/bench/bench_util.go
+++ b/tests/bench/bench_util.go
@@ -78,7 +78,7 @@ func SetupCollections(
 
 	// b.Logf("Loading schema: \n%s", schema)
 
-	if err := db.AddSchema(ctx, schema); err != nil {
+	if _, err := db.AddSchema(ctx, schema); err != nil {
 		return nil, errors.Wrap("couldn't load schema", err)
 	}
 

--- a/tests/integration/cli/client_schema_add_test.go
+++ b/tests/integration/cli/client_schema_add_test.go
@@ -46,6 +46,7 @@ func TestAddSchemaWithDuplicateType(t *testing.T) {
 
 	_ = stopDefra()
 
-	assertContainsSubstring(t, stdout1, `{"data":{"result":"success"}}`)
+	jsonReponse := `{"data":{"collections":[{"name":"Post","id":"bafkreicgpbla5wlogpinnm32arcqzptusdc5tzdznipqrf6nkroav6b25a"}],"result":"success"}}`
+	assertContainsSubstring(t, stdout1, jsonReponse)
 	assertContainsSubstring(t, stdout2, `schema type already exists. Name: Post`)
 }

--- a/tests/integration/cli/client_schema_add_test.go
+++ b/tests/integration/cli/client_schema_add_test.go
@@ -30,7 +30,8 @@ func TestAddSchemaFromFile(t *testing.T) {
 
 	nodeLog := stopDefra()
 
-	assert.Contains(t, stdout, `{"data":{"result":"success"}}`)
+	jsonReponse := `{"data":{"collections":[{"name":"User","id":"bafkreib5hb7mr7ecbdufd7mvv6va6mpxukjai7hpnqkhxonnw7lzwfqlja"}],"result":"success"}}`
+	assert.Contains(t, stdout, jsonReponse)
 	assertNotContainsSubstring(t, nodeLog, "ERROR")
 }
 

--- a/tests/integration/collection/utils.go
+++ b/tests/integration/collection/utils.go
@@ -47,7 +47,7 @@ func ExecuteRequestTestCase(
 		t.Fatal(err)
 	}
 
-	err = db.AddSchema(ctx, schema)
+	_, err = db.AddSchema(ctx, schema)
 	if assertError(t, testCase.Description, err, testCase.ExpectedError) {
 		return
 	}

--- a/tests/integration/events/utils.go
+++ b/tests/integration/events/utils.go
@@ -73,7 +73,7 @@ func ExecuteRequestTestCase(
 	db, err := testUtils.NewBadgerMemoryDB(ctx, db.WithUpdateEvents())
 	require.NoError(t, err)
 
-	err = db.AddSchema(ctx, schema)
+	_, err = db.AddSchema(ctx, schema)
 	require.NoError(t, err)
 
 	setupDatabase(ctx, t, db, testCase)

--- a/tests/integration/explain/utils.go
+++ b/tests/integration/explain/utils.go
@@ -506,7 +506,7 @@ func setupDatabase(
 	updates immutable.Option[map[int]map[int][]string],
 ) {
 	db := dbi.db
-	err := db.AddSchema(ctx, schema)
+	_, err := db.AddSchema(ctx, schema)
 	if testUtils.AssertError(t, description, err, expectedError) {
 		return
 	}

--- a/tests/integration/net/order/utils.go
+++ b/tests/integration/net/order/utils.go
@@ -128,7 +128,8 @@ func setupDefraNode(t *testing.T, cfg *config.Config, seeds []string) (*node.Nod
 }
 
 func seedSchema(ctx context.Context, db client.DB) error {
-	return db.AddSchema(ctx, userCollectionGQLSchema)
+	_, err := db.AddSchema(ctx, userCollectionGQLSchema)
+	return err
 }
 
 func seedDocument(ctx context.Context, db client.DB, document string) (client.DocKey, error) {

--- a/tests/integration/utils2.go
+++ b/tests/integration/utils2.go
@@ -709,7 +709,7 @@ func updateSchema(
 	action SchemaUpdate,
 ) {
 	for _, node := range getNodes(action.NodeID, nodes) {
-		err := node.DB.AddSchema(ctx, action.Schema)
+		_, err := node.DB.AddSchema(ctx, action.Schema)
 		expectedErrorRaised := AssertError(t, testCase.Description, err, action.ExpectedError)
 
 		assertExpectedErrorRaised(t, testCase.Description, action.ExpectedError, expectedErrorRaised)


### PR DESCRIPTION
## Relevant issue(s)

Resolves #1498

## Description

Updates the response of the CLI, HTTP, and client APIs to include collection information on schema add/creation.

Internally this is to just return the newly made collection descriptions. Externally this updates the HTTP API to include a `collections` key with an array of objects that include `name` and `id` values.

Coorresponding CLI changes to read new HTTP response state was also made.

I don't know if we want this to land for 0.5.1 as in my opinion its technically a feature, more than a refactor, and we're aiming to not have features in the 0.X.1 releases. I'm happy either way.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [ ] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Manually via the CLI and HTTP, CI

Specify the platform(s) on which this was tested:
- Ubuntu (WSL2)
