### PR TITLE
feat: CLI client request from file

### DIFF
--- a/examples/request/user_creation.graphql
+++ b/examples/request/user_creation.graphql
@@ -1,0 +1,5 @@
+mutation {
+    create_User(data: "{\"age\": 31, \"verified\": true, \"points\": 90, \"name\": \"Bob\"}") {
+        _key
+    }
+}

--- a/examples/request/user_query.graphql
+++ b/examples/request/user_query.graphql
@@ -1,0 +1,9 @@
+query {
+    User {
+        name
+        age
+        verified
+        points
+        _key
+    }
+}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #1258 

## Description

Adds support to read from a file to the `client query` CLI command, via `-f` flag, and a simple test for it, and two related examples in the `/examples` directory.