### PR TITLE
test: Add DB/Node Restart tests

### DIFF
--- a/net/peer.go
+++ b/net/peer.go
@@ -231,6 +231,10 @@ func (p *Peer) Close() error {
 		log.ErrorE(p.ctx, "Error closing block service", err)
 	}
 
+	if err := p.host.Close(); err != nil {
+		log.ErrorE(p.ctx, "Error closing host", err)
+	}
+
 	p.cancel()
 	return nil
 }

--- a/tests/bench/bench_util.go
+++ b/tests/bench/bench_util.go
@@ -245,7 +245,7 @@ func newBenchStoreInfo(ctx context.Context, t testing.TB) (client.DB, error) {
 	case "memory":
 		db, err = testutils.NewBadgerMemoryDB(ctx)
 	case "badger":
-		db, err = testutils.NewBadgerFileDB(ctx, t)
+		db, _, err = testutils.NewBadgerFileDB(ctx, t)
 	default:
 		return nil, errors.New(fmt.Sprintf("invalid storage engine backend: %s", storage))
 	}

--- a/tests/integration/change_detector.go
+++ b/tests/integration/change_detector.go
@@ -22,6 +22,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 var skip bool
@@ -56,6 +58,18 @@ func DetectDbChangesPreTestChecks(
 		// If the test doesn't specify any collections, then we can't use it to check
 		//  the database format, so we skip it
 		t.SkipNow()
+	}
+
+	if !SetupOnly {
+		dbDirectory := path.Join(rootDatabaseDir, t.Name())
+		_, err := os.Stat(dbDirectory)
+		if os.IsNotExist(err) {
+			// This is a new test that does not exist in the target branch, we should
+			// skip it.
+			t.SkipNow()
+		} else {
+			require.NoError(t, err)
+		}
 	}
 
 	return false

--- a/tests/integration/explain/utils.go
+++ b/tests/integration/explain/utils.go
@@ -475,7 +475,7 @@ func getDatabases(ctx context.Context, t *testing.T) ([]databaseInfo, error) {
 	databases := []databaseInfo{}
 
 	for _, dbt := range testUtils.GetDatabaseTypes() {
-		db, err := testUtils.GetDatabase(ctx, t, dbt)
+		db, _, err := testUtils.GetDatabase(ctx, t, dbt)
 		if err != nil {
 			return nil, err
 		}

--- a/tests/integration/net/order/utils.go
+++ b/tests/integration/net/order/utils.go
@@ -342,10 +342,10 @@ func executeTestCase(t *testing.T, test P2PTestCase) {
 
 	// clean up
 	for _, n := range nodes {
-		n.DB.Close(ctx)
 		if err := n.Close(); err != nil {
 			log.Info(ctx, "node not closing as expected", logging.NewKV("Error", err.Error()))
 		}
+		n.DB.Close(ctx)
 	}
 }
 

--- a/tests/integration/net/state/simple/peer/with_update_restart_test.go
+++ b/tests/integration/net/state/simple/peer/with_update_restart_test.go
@@ -1,0 +1,70 @@
+// Copyright 2022 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package peer_test
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/immutable"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+func TestP2PWithSingleDocumentSingleUpdateFromChildAndRestart(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.RandomNetworkingConfig(),
+			testUtils.RandomNetworkingConfig(),
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users {
+						Name: String
+						Age: Int
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				// Create John on all nodes
+				Doc: `{
+					"Name": "John",
+					"Age": 21
+				}`,
+			},
+			testUtils.ConnectPeers{
+				SourceNodeID: 0,
+				TargetNodeID: 1,
+			},
+			testUtils.Restart{},
+			testUtils.UpdateDoc{
+				// Update John's Age on the first node only, and allow the value to sync
+				NodeID: immutable.Some(0),
+				Doc: `{
+					"Age": 60
+				}`,
+			},
+			testUtils.WaitForSync{},
+			testUtils.Request{
+				Request: `query {
+					Users {
+						Age
+					}
+				}`,
+				Results: []map[string]any{
+					{
+						"Age": uint64(60),
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+}

--- a/tests/integration/net/state/simple/peer_replicator/with_update_restart_test.go
+++ b/tests/integration/net/state/simple/peer_replicator/with_update_restart_test.go
@@ -1,0 +1,78 @@
+// Copyright 2022 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package peer_replicator_test
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/immutable"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+func TestP2PPeerReplicatorWithUpdateAndRestart(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.RandomNetworkingConfig(),
+			testUtils.RandomNetworkingConfig(),
+			testUtils.RandomNetworkingConfig(),
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users {
+						Name: String
+						Age: Int
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
+					"Name": "John",
+					"Age": 21
+				}`,
+			},
+			testUtils.ConnectPeers{
+				SourceNodeID: 1,
+				TargetNodeID: 0,
+			},
+			testUtils.ConfigureReplicator{
+				SourceNodeID: 0,
+				TargetNodeID: 2,
+			},
+			// We need to wait and ensure that the create events are handled before
+			// restarting the nodes as otherwise there is no gaurentee which side of
+			// the restart that the create events are handled, resulting in flaky tests
+			testUtils.WaitForSync{},
+			testUtils.Restart{},
+			testUtils.UpdateDoc{
+				// Update John's Age on the first node only, and allow the value to sync
+				NodeID: immutable.Some(0),
+				Doc: `{
+					"Age": 60
+				}`,
+			},
+			testUtils.WaitForSync{},
+			testUtils.Request{
+				Request: `query {
+					Users {
+						Age
+					}
+				}`,
+				Results: []map[string]any{
+					{
+						"Age": uint64(60),
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+}

--- a/tests/integration/net/state/simple/replicator/with_create_restart_test.go
+++ b/tests/integration/net/state/simple/replicator/with_create_restart_test.go
@@ -1,0 +1,64 @@
+// Copyright 2022 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package replicator
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/immutable"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+func TestP2POneToOneReplicatorWithRestart(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.RandomNetworkingConfig(),
+			testUtils.RandomNetworkingConfig(),
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users {
+						Name: String
+						Age: Int
+					}
+				`,
+			},
+			testUtils.ConfigureReplicator{
+				SourceNodeID: 0,
+				TargetNodeID: 1,
+			},
+			testUtils.Restart{},
+			testUtils.CreateDoc{
+				// Create John on the first (source) node only, and allow the value to sync
+				NodeID: immutable.Some(0),
+				Doc: `{
+					"Name": "John",
+					"Age": 21
+				}`,
+			},
+			testUtils.WaitForSync{},
+			testUtils.Request{
+				Request: `query {
+					Users {
+						Age
+					}
+				}`,
+				Results: []map[string]any{
+					{
+						"Age": uint64(21),
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+}

--- a/tests/integration/p2p.go
+++ b/tests/integration/p2p.go
@@ -139,12 +139,13 @@ func connectPeers(
 	cfg ConnectPeers,
 	nodes []*node.Node,
 	addresses []string,
+	restartChan chan struct{},
 ) chan struct{} {
 	// If we have some database actions prior to connecting the peers, we want to ensure that they had time to
 	// complete before we connect. Otherwise we might wrongly catch them in our wait function.
 	time.Sleep(100 * time.Millisecond)
-	sourceNode := nodes[cfg.SourceNodeID]
-	targetNode := nodes[cfg.TargetNodeID]
+	sourceNode := func() *node.Node { return nodes[cfg.SourceNodeID] }
+	targetNode := func() *node.Node { return nodes[cfg.TargetNodeID] }
 	targetAddress := addresses[cfg.TargetNodeID]
 
 	log.Info(ctx, "Parsing bootstrap peers", logging.NewKV("Peers", targetAddress))
@@ -153,7 +154,7 @@ func connectPeers(
 		t.Fatal(fmt.Sprintf("failed to parse bootstrap peers %v", targetAddress), err)
 	}
 	log.Info(ctx, "Bootstrapping with peers", logging.NewKV("Addresses", addrs))
-	sourceNode.Boostrap(addrs)
+	sourceNode().Boostrap(addrs)
 
 	// Boostrap triggers a bunch of async stuff for which we have no good way of waiting on.  It must be
 	// allowed to complete before documentation begins or it will not even try and sync it. So for now, we
@@ -161,11 +162,15 @@ func connectPeers(
 	time.Sleep(100 * time.Millisecond)
 
 	nodeCollections := map[int][]int{}
+	restartEvents := []int{0}
 	sourceToTargetEvents := []int{0}
 	targetToSourceEvents := []int{0}
 	waitIndex := 0
 	for _, a := range testCase.Actions {
 		switch action := a.(type) {
+		case Restart:
+			restartEvents[waitIndex] += 1
+
 		case SubscribeToCollection:
 			if action.ExpectedError != "" {
 				// If the subscription action is expected to error, then we should do nothing here.
@@ -238,6 +243,7 @@ func connectPeers(
 			waitIndex += 1
 			targetToSourceEvents = append(targetToSourceEvents, 0)
 			sourceToTargetEvents = append(sourceToTargetEvents, 0)
+			restartEvents = append(restartEvents, 0)
 		}
 	}
 
@@ -246,12 +252,16 @@ func connectPeers(
 	go func(ready chan struct{}) {
 		ready <- struct{}{}
 		for waitIndex := 0; waitIndex < len(sourceToTargetEvents); waitIndex++ {
+			for i := 0; i < restartEvents[waitIndex]; i++ {
+				// this wont work for complex config - need events simple chan stuff...
+				<-restartChan
+			}
 			for i := 0; i < targetToSourceEvents[waitIndex]; i++ {
-				err := sourceNode.WaitForPushLogByPeerEvent(targetNode.PeerID())
+				err := sourceNode().WaitForPushLogByPeerEvent(targetNode().PeerID())
 				require.NoError(t, err)
 			}
 			for i := 0; i < sourceToTargetEvents[waitIndex]; i++ {
-				err := targetNode.WaitForPushLogByPeerEvent(sourceNode.PeerID())
+				err := targetNode().WaitForPushLogByPeerEvent(sourceNode().PeerID())
 				require.NoError(t, err)
 			}
 			nodeSynced <- struct{}{}
@@ -291,20 +301,22 @@ func configureReplicator(
 	cfg ConfigureReplicator,
 	nodes []*node.Node,
 	addresses []string,
+	restartChan chan struct{},
 ) chan struct{} {
 	// If we have some database actions prior to configuring the replicator, we want to ensure that they had time to
 	// complete before the configuration. Otherwise we might wrongly catch them in our wait function.
 	time.Sleep(100 * time.Millisecond)
-	sourceNode := nodes[cfg.SourceNodeID]
-	targetNode := nodes[cfg.TargetNodeID]
+	sourceNode := func() *node.Node { return nodes[cfg.SourceNodeID] }
+	targetNode := func() *node.Node { return nodes[cfg.TargetNodeID] }
 	targetAddress := addresses[cfg.TargetNodeID]
 
 	addr, err := ma.NewMultiaddr(targetAddress)
 	require.NoError(t, err)
 
-	_, err = sourceNode.Peer.SetReplicator(ctx, addr)
+	_, err = sourceNode().Peer.SetReplicator(ctx, addr)
 	require.NoError(t, err)
 
+	restartEvents := []int{0}
 	sourceToTargetEvents := []int{0}
 	targetToSourceEvents := []int{0}
 	docIDsSyncedToSource := map[int]struct{}{}
@@ -312,6 +324,9 @@ func configureReplicator(
 	currentdocID := 0
 	for _, a := range testCase.Actions {
 		switch action := a.(type) {
+		case Restart:
+			restartEvents[waitIndex] += 1
+
 		case CreateDoc:
 			if !action.NodeID.HasValue() || action.NodeID.Value() == cfg.SourceNodeID {
 				docIDsSyncedToSource[currentdocID] = struct{}{}
@@ -349,20 +364,26 @@ func configureReplicator(
 			waitIndex += 1
 			targetToSourceEvents = append(targetToSourceEvents, 0)
 			sourceToTargetEvents = append(sourceToTargetEvents, 0)
+			restartEvents = append(restartEvents, 0)
 		}
 	}
 
 	nodeSynced := make(chan struct{})
 	ready := make(chan struct{})
 	go func(ready chan struct{}) {
-		ready <- struct{}{}
+		ready <- struct{}{} //need to wait for restart or old node instances will be waited on
 		for waitIndex := 0; waitIndex < len(sourceToTargetEvents); waitIndex++ {
+			for i := 0; i < restartEvents[waitIndex]; i++ {
+				// this wont work for complex config - need events simple chan stuff...
+				<-restartChan
+			}
+
 			for i := 0; i < targetToSourceEvents[waitIndex]; i++ {
-				err := sourceNode.WaitForPushLogByPeerEvent(targetNode.PeerID())
+				err := sourceNode().WaitForPushLogByPeerEvent(targetNode().PeerID())
 				require.NoError(t, err)
 			}
 			for i := 0; i < sourceToTargetEvents[waitIndex]; i++ {
-				err := targetNode.WaitForPushLogByPeerEvent(sourceNode.PeerID())
+				err := targetNode().WaitForPushLogByPeerEvent(sourceNode().PeerID())
 				require.NoError(t, err)
 			}
 			nodeSynced <- struct{}{}

--- a/tests/integration/p2p.go
+++ b/tests/integration/p2p.go
@@ -522,12 +522,11 @@ func waitForSync(
 const randomMultiaddr = "/ip4/0.0.0.0/tcp/0"
 
 func RandomNetworkingConfig() ConfigureNode {
-	cfg := config.DefaultConfig()
-	cfg.Net.P2PAddress = randomMultiaddr
-	cfg.Net.RPCAddress = "0.0.0.0:0"
-	cfg.Net.TCPAddress = randomMultiaddr
-
-	return ConfigureNode{
-		Config: *cfg,
+	return func() config.Config {
+		cfg := config.DefaultConfig()
+		cfg.Net.P2PAddress = randomMultiaddr
+		cfg.Net.RPCAddress = "0.0.0.0:0"
+		cfg.Net.TCPAddress = randomMultiaddr
+		return *cfg
 	}
 }

--- a/tests/integration/query/simple/with_restart_test.go
+++ b/tests/integration/query/simple/with_restart_test.go
@@ -1,0 +1,57 @@
+// Copyright 2022 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package simple
+
+import (
+	"testing"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+func TestQuerySimpleWithRestart(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "Simple query with no filter",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users {
+						name: String
+						age: Int
+					}
+				`,
+			},
+			testUtils.Restart{},
+			testUtils.CreateDoc{
+				Doc: `{
+					"name": "Shahzad",
+					"age": 30
+				}`,
+			},
+			testUtils.Restart{},
+			testUtils.Request{
+				Request: ` query {
+					Users {
+						name
+						age
+					}
+				}`,
+				Results: []map[string]any{
+					{
+						"name": "Shahzad",
+						"age":  uint64(30),
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+}

--- a/tests/integration/test_case.go
+++ b/tests/integration/test_case.go
@@ -44,15 +44,8 @@ type SetupComplete struct{}
 // effected on all nodes.
 type ConfigureNode func() config.Config
 
-// Restart is an action that will close and then start node(s).
-//
-// If no nodes are explicitly configured, all configured nodes will be restarted.
-type Restart struct {
-	// NodeID may hold the ID (index) of a node to apply this update to.
-	//
-	// If a value is not provided the update will be applied to all nodes.
-	NodeID immutable.Option[int]
-}
+// Restart is an action that will close and then start all nodes.
+type Restart struct{}
 
 // SchemaUpdate is an action that will update the database schema.
 type SchemaUpdate struct {

--- a/tests/integration/test_case.go
+++ b/tests/integration/test_case.go
@@ -42,9 +42,7 @@ type SetupComplete struct{}
 // Nodes may be explicitly referenced by index by other actions using `NodeID` properties.
 // If the action has a `NodeID` property and it is not specified, the action will be
 // effected on all nodes.
-type ConfigureNode struct {
-	config.Config
-}
+type ConfigureNode func() config.Config
 
 // Restart is an action that will close and then start node(s).
 //

--- a/tests/integration/test_case.go
+++ b/tests/integration/test_case.go
@@ -46,6 +46,16 @@ type ConfigureNode struct {
 	config.Config
 }
 
+// Restart is an action that will close and then start node(s).
+//
+// If no nodes are explicitly configured, all configured nodes will be restarted.
+type Restart struct {
+	// NodeID may hold the ID (index) of a node to apply this update to.
+	//
+	// If a value is not provided the update will be applied to all nodes.
+	NodeID immutable.Option[int]
+}
+
 // SchemaUpdate is an action that will update the database schema.
 type SchemaUpdate struct {
 	// NodeID may hold the ID (index) of a node to apply this update to.


### PR DESCRIPTION
## Relevant issue(s)

Resolves #1082 

## Description

Adds DB/Node Restart tests.  This will be required by Lens (e.g. to make sure migrations are not lost on restart). IIRC I think this also found https://github.com/sourcenetwork/defradb/pull/1482 (also fixed by Fred).

Fred was a massive help here and fixed the difficult bits when I flaked out on Friday :) Any commit that lists him as an author are his, I am only tagged in them having rebased them.

Commits are messy as anything as I wanted to preserve the level of credit due to Fred, and I'd suggest reviewing this PR at PR level as cleanup has not been squashed into commits introducing broken/messy code.

I will merge this when approved, whether that is 0.5.1 or 0.6 - it introduces no breaking (or risky) changes to the production code.
