### PR TITLE
test: Resume wait correctly following test node restart

### DIFF
--- a/tests/integration/p2p.go
+++ b/tests/integration/p2p.go
@@ -159,13 +159,14 @@ func connectPeers(
 	// allowed to complete before documentation begins or it will not even try and sync it. So for now, we
 	// sleep a little.
 	time.Sleep(100 * time.Millisecond)
-	return setupPeerWaitSync(ctx, t, testCase, cfg, sourceNode, targetNode)
+	return setupPeerWaitSync(ctx, t, testCase, 0, cfg, sourceNode, targetNode)
 }
 
 func setupPeerWaitSync(
 	ctx context.Context,
 	t *testing.T,
 	testCase TestCase,
+	startIndex int,
 	cfg ConnectPeers,
 	sourceNode *node.Node,
 	targetNode *node.Node,
@@ -174,8 +175,8 @@ func setupPeerWaitSync(
 	sourceToTargetEvents := []int{0}
 	targetToSourceEvents := []int{0}
 	waitIndex := 0
-	for _, a := range testCase.Actions {
-		switch action := a.(type) {
+	for i := startIndex; i < len(testCase.Actions); i++ {
+		switch action := testCase.Actions[i].(type) {
 		case SubscribeToCollection:
 			if action.ExpectedError != "" {
 				// If the subscription action is expected to error, then we should do nothing here.
@@ -314,13 +315,14 @@ func configureReplicator(
 
 	_, err = sourceNode.Peer.SetReplicator(ctx, addr)
 	require.NoError(t, err)
-	return setupRepicatorWaitSync(ctx, t, testCase, cfg, sourceNode, targetNode)
+	return setupRepicatorWaitSync(ctx, t, testCase, 0, cfg, sourceNode, targetNode)
 }
 
 func setupRepicatorWaitSync(
 	ctx context.Context,
 	t *testing.T,
 	testCase TestCase,
+	startIndex int,
 	cfg ConfigureReplicator,
 	sourceNode *node.Node,
 	targetNode *node.Node,
@@ -330,8 +332,8 @@ func setupRepicatorWaitSync(
 	docIDsSyncedToSource := map[int]struct{}{}
 	waitIndex := 0
 	currentdocID := 0
-	for _, a := range testCase.Actions {
-		switch action := a.(type) {
+	for i := startIndex; i < len(testCase.Actions); i++ {
+		switch action := testCase.Actions[i].(type) {
 		case CreateDoc:
 			if !action.NodeID.HasValue() || action.NodeID.Value() == cfg.SourceNodeID {
 				docIDsSyncedToSource[currentdocID] = struct{}{}

--- a/tests/integration/utils2.go
+++ b/tests/integration/utils2.go
@@ -341,7 +341,7 @@ func executeTestCase(
 			// gracefully as part of the node closure.
 			syncChans = append(
 				syncChans,
-				restartNodes(ctx, t, testCase, dbt, nodes, dbPaths, nodeAddresses, nodeConfigs)...,
+				restartNodes(ctx, t, testCase, dbt, i, nodes, dbPaths, nodeAddresses, nodeConfigs)...,
 			)
 
 			// If the db was restarted we need to refresh the collection definitions as the old instances
@@ -604,6 +604,7 @@ func restartNodes(
 	t *testing.T,
 	testCase TestCase,
 	dbt DatabaseType,
+	actionIndex int,
 	nodes []*node.Node,
 	dbPaths []string,
 	nodeAddresses []string,
@@ -654,6 +655,20 @@ func restartNodes(
 		nodes[i] = n
 	}
 
+	// The index of the action after the last wait action before the current restart action.
+	// We wish to resume the wait clock from this point onwards.
+	waitGroupStartIndex := 0
+actionLoop:
+	for i := actionIndex; i >= 0; i-- {
+		switch testCase.Actions[i].(type) {
+		case WaitForSync:
+			// +1 as we do not wish to resume from the wait itself, but the next action
+			// following it. This may be the current restart action.
+			waitGroupStartIndex = i + 1
+			break actionLoop
+		}
+	}
+
 	syncChans := []chan struct{}{}
 	for _, tc := range testCase.Actions {
 		switch action := tc.(type) {
@@ -661,13 +676,13 @@ func restartNodes(
 			// Give the nodes a chance to connect to each other and learn about each other's subscribed topics.
 			time.Sleep(100 * time.Millisecond)
 			syncChans = append(syncChans, setupPeerWaitSync(
-				ctx, t, testCase, action, nodes[action.SourceNodeID], nodes[action.TargetNodeID],
+				ctx, t, testCase, waitGroupStartIndex, action, nodes[action.SourceNodeID], nodes[action.TargetNodeID],
 			))
 		case ConfigureReplicator:
 			// Give the nodes a chance to connect to each other and learn about each other's subscribed topics.
 			time.Sleep(100 * time.Millisecond)
 			syncChans = append(syncChans, setupRepicatorWaitSync(
-				ctx, t, testCase, action, nodes[action.SourceNodeID], nodes[action.TargetNodeID],
+				ctx, t, testCase, waitGroupStartIndex, action, nodes[action.SourceNodeID], nodes[action.TargetNodeID],
 			))
 		}
 	}

--- a/tests/integration/utils2.go
+++ b/tests/integration/utils2.go
@@ -658,18 +658,19 @@ func restartNodes(
 	for _, tc := range testCase.Actions {
 		switch action := tc.(type) {
 		case ConnectPeers:
+			// Give the nodes a chance to connect to each other and learn about each other's subscribed topics.
+			time.Sleep(100 * time.Millisecond)
 			syncChans = append(syncChans, setupPeerWaitSync(
 				ctx, t, testCase, action, nodes[action.SourceNodeID], nodes[action.TargetNodeID],
 			))
 		case ConfigureReplicator:
+			// Give the nodes a chance to connect to each other and learn about each other's subscribed topics.
+			time.Sleep(100 * time.Millisecond)
 			syncChans = append(syncChans, setupRepicatorWaitSync(
 				ctx, t, testCase, action, nodes[action.SourceNodeID], nodes[action.TargetNodeID],
 			))
 		}
 	}
-
-	// Give the nodes a chance to connect to each other and learn about each other's subscrivbed topics.
-	time.Sleep(100 * time.Millisecond)
 
 	return syncChans
 }


### PR DESCRIPTION
## Relevant issue(s)

Resolves #1506

## Description

Previously the full wait-cycle would be calculated, meaning that if a Wait action was before the Restart action the Second wait action would progress once the expected number of events for the first Wait was received.  This changes it so that upon restart the wait calculation is started from just after the last wait action before the restart.

## How has this been tested?

Had a few hundred successful runs of the only affect test i(`TestP2PPeerReplicatorWithUpdateAndRestart`) n the CI.