### PR TITLE
fix: Handle SIGHUP signal in start command

### DIFF
--- a/cli/start.go
+++ b/cli/start.go
@@ -385,7 +385,7 @@ func start(ctx context.Context, cfg *config.Config) (*defraInstance, error) {
 func wait(ctx context.Context, di *defraInstance) error {
 	// setup signal handlers
 	signalCh := make(chan os.Signal, 1)
-	signal.Notify(signalCh, os.Interrupt, syscall.SIGTERM)
+	signal.Notify(signalCh, os.Interrupt, syscall.SIGTERM, syscall.SIGHUP)
 
 	select {
 	case <-ctx.Done():


### PR DESCRIPTION
## Relevant issue(s)

Resolves #1517

## Description

Add the handling of SIGHUP signal. SIGHUP (Signal Hang Up) is a signal sent to a process by the operating system when the controlling terminal or session of the process is disconnected or closed.

I'm not sure about this PR. SIGHUP is sometimes used for "reload of configuration".

## How has this been tested?

Manual
