### PR TITLE
test: Add tests for foo_id field name clashes

### DIFF
--- a/tests/integration/query/one_to_many/with_id_field_test.go
+++ b/tests/integration/query/one_to_many/with_id_field_test.go
@@ -1,0 +1,88 @@
+// Copyright 2022 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package one_to_many
+
+import (
+	"testing"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+// This documents unwanted behaviour, see https://github.com/sourcenetwork/defradb/issues/1520
+func TestQueryOneToManyWithIdFieldOnPrimary(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "One-to-many relation primary direction, id field with name clash on primary side",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Book {
+						name: String
+						author_id: Int
+						author: Author
+					}
+
+					type Author {
+						name: String
+						published: [Book]
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				// bae-2edb7fdd-cad7-5ad4-9c7d-6920245a96ed
+				CollectionID: 1,
+				Doc: `{
+					"name": "John Grisham"
+				}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `{
+					"name": "Painted House",
+					"author_id": 123456
+				}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `{
+					"name": "A Time for Mercy",
+					"author_id": "bae-2edb7fdd-cad7-5ad4-9c7d-6920245a96ed"
+				}`,
+			},
+			testUtils.Request{
+				Request: `query {
+					Book {
+						name
+						author_id
+						author {
+							name
+						}
+					}
+				}`,
+				Results: []map[string]any{
+					{
+						"name":      "A Time for Mercy",
+						"author_id": "bae-2edb7fdd-cad7-5ad4-9c7d-6920245a96ed",
+						"author": map[string]any{
+							"name": "John Grisham",
+						},
+					},
+					{
+						"name":      "Painted House",
+						"author_id": uint64(123456),
+						"author":    nil,
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, []string{"Book", "Author"}, test)
+}

--- a/tests/integration/query/one_to_one/with_id_field_test.go
+++ b/tests/integration/query/one_to_one/with_id_field_test.go
@@ -1,0 +1,117 @@
+// Copyright 2022 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package one_to_one
+
+import (
+	"testing"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+func TestQueryOneToOneWithIdFieldOnSecondary(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "One-to-one relation secondary direction, id field with name clash on secondary side",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Book {
+						name: String
+						author_id: Int
+						author: Author
+					}
+
+					type Author {
+						name: String
+						published: Book @primary
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				// bae-d82dbe47-9df1-5e33-bd87-f92e9c378161
+				CollectionID: 0,
+				Doc: `{
+					"name": "Painted House",
+					"author_id": 123456
+				}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				Doc: `{
+					"name": "John Grisham",
+					"published_id": "bae-d82dbe47-9df1-5e33-bd87-f92e9c378161"
+				}`,
+			},
+			testUtils.Request{
+				Request: `query {
+					Book {
+						name
+						author_id
+						author {
+							name
+						}
+					}
+				}`,
+				Results: []map[string]any{
+					{
+						"name":      "Painted House",
+						"author_id": uint64(123456),
+						"author": map[string]any{
+							"name": "John Grisham",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, []string{"Book", "Author"}, test)
+}
+
+// This documents unwanted behaviour, see https://github.com/sourcenetwork/defradb/issues/1520
+func TestQueryOneToOneWithIdFieldOnPrimary(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "One-to-one relation primary direction, id field with name clash on primary side",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Book {
+						name: String
+						author_id: Int
+						author: Author @primary
+					}
+
+					type Author {
+						name: String
+						published: Book
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				// bae-d82dbe47-9df1-5e33-bd87-f92e9c378161
+				CollectionID: 0,
+				Doc: `{
+					"name": "Painted House",
+					"author_id": 123456
+				}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				Doc: `{
+					"name": "John Grisham",
+					"published_id": "bae-d82dbe47-9df1-5e33-bd87-f92e9c378161"
+				}`,
+				ExpectedError: "value doesn't contain number; it contains string",
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, []string{"Book", "Author"}, test)
+}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #1468 

## Description

Adds tests for foo_id field name clashes with relational id fields.

Fixing the issues is out of scope.