### PR TITLE
fix: Change `core.DocumentMapping` to pointer

### DIFF
--- a/planner/average.go
+++ b/planner/average.go
@@ -56,7 +56,7 @@ func (p *Planner) Average(
 		sumFieldIndex:     sumField.Index,
 		countFieldIndex:   countField.Index,
 		virtualFieldIndex: field.Index,
-		docMapper:         docMapper{&field.DocumentMapping},
+		docMapper:         docMapper{field.DocumentMapping},
 	}, nil
 }
 

--- a/planner/commit.go
+++ b/planner/commit.go
@@ -53,7 +53,7 @@ func (p *Planner) DAGScan(commitSelect *mapper.CommitSelect) *dagScanNode {
 		visitedNodes: make(map[string]bool),
 		queuedCids:   []*cid.Cid{},
 		commitSelect: commitSelect,
-		docMapper:    docMapper{&commitSelect.DocumentMapping},
+		docMapper:    docMapper{commitSelect.DocumentMapping},
 	}
 }
 

--- a/planner/count.go
+++ b/planner/count.go
@@ -48,7 +48,7 @@ func (p *Planner) Count(field *mapper.Aggregate, host *mapper.Select) (*countNod
 		p:                 p,
 		virtualFieldIndex: field.Index,
 		aggregateMapping:  field.AggregateTargets,
-		docMapper:         docMapper{&field.DocumentMapping},
+		docMapper:         docMapper{field.DocumentMapping},
 	}, nil
 }
 

--- a/planner/create.go
+++ b/planner/create.go
@@ -171,7 +171,7 @@ func (p *Planner) CreateDoc(parsed *mapper.Mutation) (planNode, error) {
 		p:         p,
 		newDocStr: parsed.Data,
 		results:   results,
-		docMapper: docMapper{&parsed.DocumentMapping},
+		docMapper: docMapper{parsed.DocumentMapping},
 	}
 
 	// get collection

--- a/planner/delete.go
+++ b/planner/delete.go
@@ -134,6 +134,6 @@ func (p *Planner) DeleteDocs(parsed *mapper.Mutation) (planNode, error) {
 		ids:        parsed.DocKeys.Value(),
 		collection: col.WithTxn(p.txn),
 		source:     slctNode,
-		docMapper:  docMapper{&parsed.DocumentMapping},
+		docMapper:  docMapper{parsed.DocumentMapping},
 	}, nil
 }

--- a/planner/group.go
+++ b/planner/group.go
@@ -91,7 +91,7 @@ func (p *Planner) GroupBy(n *mapper.GroupBy, parsed *mapper.Select, childSelects
 		childSelects:  childSelects,
 		groupByFields: n.Fields,
 		dataSources:   dataSources,
-		docMapper:     docMapper{&parsed.DocumentMapping},
+		docMapper:     docMapper{parsed.DocumentMapping},
 	}
 	return &groupNodeObj, nil
 }

--- a/planner/limit.go
+++ b/planner/limit.go
@@ -46,7 +46,7 @@ func (p *Planner) Limit(parsed *mapper.Select, n *mapper.Limit) (*limitNode, err
 		limit:     n.Limit,
 		offset:    n.Offset,
 		rowIndex:  0,
-		docMapper: docMapper{&parsed.DocumentMapping},
+		docMapper: docMapper{parsed.DocumentMapping},
 	}, nil
 }
 

--- a/planner/mapper/aggregate.go
+++ b/planner/mapper/aggregate.go
@@ -45,7 +45,7 @@ type AggregateTarget struct {
 type Aggregate struct {
 	Field
 	// The mapping of this aggregate's parent/host.
-	core.DocumentMapping
+	*core.DocumentMapping
 
 	// The collection of targets that this aggregate will aggregate.
 	AggregateTargets []AggregateTarget

--- a/planner/mapper/mapper.go
+++ b/planner/mapper/mapper.go
@@ -97,7 +97,7 @@ func toSelect(
 
 	return &Select{
 		Targetable:      toTargetable(thisIndex, selectRequest, mapping),
-		DocumentMapping: *mapping,
+		DocumentMapping: mapping,
 		Cid:             selectRequest.CID,
 		CollectionName:  collectionName,
 		Fields:          fields,
@@ -142,7 +142,7 @@ func resolveOrderDependencies(
 				return err
 			}
 			*existingFields = append(*existingFields, innerSelect)
-			mapping.SetChildAt(index, &innerSelect.DocumentMapping)
+			mapping.SetChildAt(index, innerSelect.DocumentMapping)
 		}
 	}
 
@@ -271,7 +271,7 @@ func resolveAggregates(
 						OrderBy: toOrderBy(target.order, childMapping),
 					},
 					CollectionName:  childCollectionName,
-					DocumentMapping: *childMapping,
+					DocumentMapping: childMapping,
 					Fields:          childFields,
 				}
 
@@ -326,7 +326,7 @@ func resolveAggregates(
 
 		newAggregate := Aggregate{
 			Field:            aggregate.field,
-			DocumentMapping:  *mapping,
+			DocumentMapping:  mapping,
 			AggregateTargets: aggregateTargets,
 		}
 		fields = append(fields, &newAggregate)
@@ -514,7 +514,7 @@ func getRequestables(
 				return nil, nil, err
 			}
 			fields = append(fields, innerSelect)
-			mapping.SetChildAt(index, &innerSelect.DocumentMapping)
+			mapping.SetChildAt(index, innerSelect.DocumentMapping)
 
 			mapping.RenderKeys = append(mapping.RenderKeys, core.RenderKey{
 				Index: index,
@@ -732,7 +732,7 @@ func resolveInnerFilterDependencies(
 					},
 				},
 				CollectionName:  childCollectionName,
-				DocumentMapping: *childMapping,
+				DocumentMapping: childMapping,
 			}
 
 			newFields = append(newFields, dummyJoin)

--- a/planner/mapper/select.go
+++ b/planner/mapper/select.go
@@ -25,7 +25,7 @@ type Select struct {
 
 	// The document mapping for this select, describing how items yielded
 	// for this select can be accessed and rendered.
-	core.DocumentMapping
+	*core.DocumentMapping
 
 	// A commit identifier that can be specified to request data at a given time.
 	Cid immutable.Option[string]

--- a/planner/order.go
+++ b/planner/order.go
@@ -82,7 +82,7 @@ func (p *Planner) OrderBy(parsed *mapper.Select, n *mapper.OrderBy) (*orderNode,
 		p:         p,
 		ordering:  n.Conditions,
 		needSort:  true,
-		docMapper: docMapper{&parsed.DocumentMapping},
+		docMapper: docMapper{parsed.DocumentMapping},
 	}, nil
 }
 

--- a/planner/scan.go
+++ b/planner/scan.go
@@ -212,7 +212,7 @@ func (p *Planner) Scan(parsed *mapper.Select) *scanNode {
 	return &scanNode{
 		p:         p,
 		fetcher:   f,
-		docMapper: docMapper{&parsed.DocumentMapping},
+		docMapper: docMapper{parsed.DocumentMapping},
 	}
 }
 

--- a/planner/select.go
+++ b/planner/select.go
@@ -405,7 +405,7 @@ func (p *Planner) SelectFromSource(
 		source:     source,
 		origSource: source,
 		selectReq:  selectReq,
-		docMapper:  docMapper{&selectReq.DocumentMapping},
+		docMapper:  docMapper{selectReq.DocumentMapping},
 		filter:     selectReq.Filter,
 		docKeys:    selectReq.DocKeys,
 	}
@@ -452,7 +452,7 @@ func (p *Planner) SelectFromSource(
 		order:      orderPlan,
 		group:      groupPlan,
 		aggregates: aggregates,
-		docMapper:  docMapper{&selectReq.DocumentMapping},
+		docMapper:  docMapper{selectReq.DocumentMapping},
 	}
 	return top, nil
 }
@@ -464,7 +464,7 @@ func (p *Planner) Select(selectReq *mapper.Select) (planNode, error) {
 		filter:    selectReq.Filter,
 		docKeys:   selectReq.DocKeys,
 		selectReq: selectReq,
-		docMapper: docMapper{&selectReq.DocumentMapping},
+		docMapper: docMapper{selectReq.DocumentMapping},
 	}
 	limit := selectReq.Limit
 	orderBy := selectReq.OrderBy
@@ -496,7 +496,7 @@ func (p *Planner) Select(selectReq *mapper.Select) (planNode, error) {
 		order:      orderPlan,
 		group:      groupPlan,
 		aggregates: aggregates,
-		docMapper:  docMapper{&selectReq.DocumentMapping},
+		docMapper:  docMapper{selectReq.DocumentMapping},
 	}
 	return top, nil
 }

--- a/planner/sum.go
+++ b/planner/sum.go
@@ -61,7 +61,7 @@ func (p *Planner) Sum(
 		isFloat:           isFloat,
 		aggregateMapping:  field.AggregateTargets,
 		virtualFieldIndex: field.Index,
-		docMapper:         docMapper{&field.DocumentMapping},
+		docMapper:         docMapper{field.DocumentMapping},
 	}, nil
 }
 

--- a/planner/top.go
+++ b/planner/top.go
@@ -186,7 +186,7 @@ func (n *topLevelNode) Next() (bool, error) {
 // Top creates a new topLevelNode using the given Select.
 func (p *Planner) Top(m *mapper.Select) (*topLevelNode, error) {
 	node := topLevelNode{
-		docMapper: docMapper{&m.DocumentMapping},
+		docMapper: docMapper{m.DocumentMapping},
 	}
 
 	aggregateChildren := []planNode{}

--- a/planner/update.go
+++ b/planner/update.go
@@ -160,7 +160,7 @@ func (p *Planner) UpdateDocs(parsed *mapper.Mutation) (planNode, error) {
 		ids:        parsed.DocKeys.Value(),
 		isUpdating: true,
 		patch:      parsed.Data,
-		docMapper:  docMapper{&parsed.DocumentMapping},
+		docMapper:  docMapper{parsed.DocumentMapping},
 	}
 
 	// get collection

--- a/tests/integration/query/one_to_many_to_one/with_filter_test.go
+++ b/tests/integration/query/one_to_many_to_one/with_filter_test.go
@@ -213,3 +213,74 @@ func TestOneToManyToOneWithSumOfDeepFilterSubTypeAndDeepOrderBySubtypeOppositeDi
 
 	testUtils.ExecuteTestCase(t, []string{"Author", "Book", "Publisher"}, test)
 }
+
+func TestOneToManyToOneWithTwoLevelDeepFilter(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "1-N-1 two level deep filter",
+		Actions: []any{
+			gqlSchemaOneToManyToOne(),
+			createDocsWith6BooksAnd5Publishers(),
+			testUtils.Request{
+				Request: `query {
+					Author (filter: {book: {publisher: {yearOpened: { _ge: 2020}}}}){
+						name
+						book {
+							name
+							publisher {
+								yearOpened
+							}
+						}
+					}
+				}`,
+				Results: []map[string]any{
+					{
+						"book": []map[string]any{
+							{
+								"name":      "The Associate",
+								"publisher": nil,
+							},
+							{
+								"name": "Sooley",
+								"publisher": map[string]any{
+									"yearOpened": uint64(1999),
+								},
+							},
+							{
+								"name": "Theif Lord",
+								"publisher": map[string]any{
+									"yearOpened": uint64(2020),
+								},
+							},
+							{
+								"name": "Painted House",
+								"publisher": map[string]any{
+									"yearOpened": uint64(1995),
+								},
+							},
+							{
+								"name": "A Time for Mercy",
+								"publisher": map[string]any{
+									"yearOpened": uint64(2013),
+								},
+							},
+						},
+						"name": "John Grisham",
+					},
+					{
+						"book": []map[string]any{
+							{
+								"name": "The Rooster Bar",
+								"publisher": map[string]any{
+									"yearOpened": uint64(2022),
+								},
+							},
+						},
+						"name": "Cornelia Funke",
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, []string{"Author", "Book", "Publisher"}, test)
+}

--- a/tests/integration/utils2.go
+++ b/tests/integration/utils2.go
@@ -303,7 +303,7 @@ func executeTestCase(
 	nodeAddresses := []string{}
 	// The actions responsible for configuring the node
 	nodeConfigs := []config.Config{}
-	nodes, dbPaths := getStartingNodes(ctx, t, dbt, collectionNames, testCase)
+	nodes, dbPaths := getStartingNodes(ctx, t, dbt, testCase)
 	// It is very important that the databases are always closed, otherwise resources will leak
 	// as tests run.  This is particularly important for file based datastores.
 	defer closeNodes(ctx, t, nodes)
@@ -549,6 +549,8 @@ ActionLoop:
 		} else if firstNonSetupIndex > -1 {
 			// -1 to exclude this index
 			endIndex = firstNonSetupIndex - 1
+		} else {
+			startIndex = endIndex
 		}
 	} else {
 		if setupCompleteIndex > -1 {
@@ -557,6 +559,8 @@ ActionLoop:
 		} else if firstNonSetupIndex > -1 {
 			// We must not set this to -1 :)
 			startIndex = firstNonSetupIndex
+		} else {
+			startIndex = endIndex
 		}
 	}
 
@@ -571,7 +575,6 @@ func getStartingNodes(
 	ctx context.Context,
 	t *testing.T,
 	dbt DatabaseType,
-	collectionNames []string,
 	testCase TestCase,
 ) ([]*node.Node, []string) {
 	hasExplicitNode := false


### PR DESCRIPTION
## Relevant issue(s)

Resolves #1526 

## Description

This PR converts `core.DocumentMapping` in `mapper.Select` and `mapper.Aggregate` to a pointer. It also adds an integration test for the two level deep filter.

It also includes a fix of the change detector for when there are no other actions after SchemaUpdate, CreateDoc and UpdateDoc.

*Note: The pointer fix was found by @jsimnz.*

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

make test

Specify the platform(s) on which this was tested:
- MacOS
