### PR TITLE
fix: Document change detector breaking change

### DIFF
--- a/docs/data_format_changes/i1530-change-detector-without-non-mutations.md
+++ b/docs/data_format_changes/i1530-change-detector-without-non-mutations.md
@@ -1,0 +1,3 @@
+# Change detector without non-mutations actions
+
+The previous fix caused a regression in the change detector and we need a documentation to break the cycle.

--- a/tests/integration/utils2.go
+++ b/tests/integration/utils2.go
@@ -549,8 +549,6 @@ ActionLoop:
 		} else if firstNonSetupIndex > -1 {
 			// -1 to exclude this index
 			endIndex = firstNonSetupIndex - 1
-		} else {
-			startIndex = endIndex
 		}
 	} else {
 		if setupCompleteIndex > -1 {
@@ -560,6 +558,7 @@ ActionLoop:
 			// We must not set this to -1 :)
 			startIndex = firstNonSetupIndex
 		} else {
+			// if we down't have any non-mutation actions, just use the last action
 			startIndex = endIndex
 		}
 	}

--- a/tests/integration/utils2.go
+++ b/tests/integration/utils2.go
@@ -558,7 +558,7 @@ ActionLoop:
 			// We must not set this to -1 :)
 			startIndex = firstNonSetupIndex
 		} else {
-			// if we down't have any non-mutation actions, just use the last action
+			// if we don't have any non-mutation actions, just use the last action
 			startIndex = endIndex
 		}
 	}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #1530 

## Description

This PR fixes the previous fix and adds a breaking change document to prevent the broken cycle in the change detector after the fix. Should have been part of the #1528 although the change detector was passing before merge.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

make test:changes

Specify the platform(s) on which this was tested:
- MacOS
