### PR TITLE
test: Convert explain group tests to new explain setup

### DIFF
--- a/tests/integration/explain/default/group_test.go
+++ b/tests/integration/explain/default/group_test.go
@@ -16,6 +16,18 @@ import (
 	explainUtils "github.com/sourcenetwork/defradb/tests/integration/explain"
 )
 
+var groupPattern = dataMap{
+	"explain": dataMap{
+		"selectTopNode": dataMap{
+			"groupNode": dataMap{
+				"selectNode": dataMap{
+					"scanNode": dataMap{},
+				},
+			},
+		},
+	},
+}
+
 func TestDefaultExplainRequestWithGroupByOnParent(t *testing.T) {
 	test := explainUtils.ExplainRequestTestCase{
 
@@ -50,37 +62,16 @@ func TestDefaultExplainRequestWithGroupByOnParent(t *testing.T) {
 			},
 		},
 
-		ExpectedFullGraph: []dataMap{
+		ExpectedPatterns: []dataMap{groupPattern},
+
+		ExpectedTargets: []explainUtils.PlanNodeTargetCase{
 			{
-				"explain": dataMap{
-					"selectTopNode": dataMap{
-						"groupNode": dataMap{
-							"groupByFields": []string{"age"},
-							"childSelects": []dataMap{
-								{
-									"collectionName": "Author",
-									"docKeys":        nil,
-									"groupBy":        nil,
-									"limit":          nil,
-									"orderBy":        nil,
-									"filter":         nil,
-								},
-							},
-							"selectNode": dataMap{
-								"filter": nil,
-								"scanNode": dataMap{
-									"collectionID":   "3",
-									"collectionName": "Author",
-									"filter":         nil,
-									"spans": []dataMap{
-										{
-											"start": "/3",
-											"end":   "/4",
-										},
-									},
-								},
-							},
-						},
+				TargetNodeName:    "groupNode",
+				IncludeChildNodes: false,
+				ExpectedAttributes: dataMap{
+					"groupByFields": []string{"age"},
+					"childSelects": []dataMap{
+						emptyChildSelectsAttributeForAuthor,
 					},
 				},
 			},
@@ -124,37 +115,16 @@ func TestDefaultExplainRequestWithGroupByTwoFieldsOnParent(t *testing.T) {
 			},
 		},
 
-		ExpectedFullGraph: []dataMap{
+		ExpectedPatterns: []dataMap{groupPattern},
+
+		ExpectedTargets: []explainUtils.PlanNodeTargetCase{
 			{
-				"explain": dataMap{
-					"selectTopNode": dataMap{
-						"groupNode": dataMap{
-							"groupByFields": []string{"age", "name"},
-							"childSelects": []dataMap{
-								{
-									"collectionName": "Author",
-									"docKeys":        nil,
-									"groupBy":        nil,
-									"limit":          nil,
-									"orderBy":        nil,
-									"filter":         nil,
-								},
-							},
-							"selectNode": dataMap{
-								"filter": nil,
-								"scanNode": dataMap{
-									"collectionID":   "3",
-									"collectionName": "Author",
-									"filter":         nil,
-									"spans": []dataMap{
-										{
-											"start": "/3",
-											"end":   "/4",
-										},
-									},
-								},
-							},
-						},
+				TargetNodeName:    "groupNode",
+				IncludeChildNodes: false,
+				ExpectedAttributes: dataMap{
+					"groupByFields": []string{"age", "name"},
+					"childSelects": []dataMap{
+						emptyChildSelectsAttributeForAuthor,
 					},
 				},
 			},

--- a/tests/integration/explain/default/group_test.go
+++ b/tests/integration/explain/default/group_test.go
@@ -13,12 +13,13 @@ package test_explain_default
 import (
 	"testing"
 
-	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	explainUtils "github.com/sourcenetwork/defradb/tests/integration/explain"
 )
 
-func TestExplainSimpleGroupByOnParent(t *testing.T) {
-	test := testUtils.RequestTestCase{
-		Description: "Explain a grouping on parent.",
+func TestDefaultExplainRequestWithGroupByOnParent(t *testing.T) {
+	test := explainUtils.ExplainRequestTestCase{
+
+		Description: "Explain (default) request with group-by on parent.",
 
 		Request: `query @explain {
 			Author (groupBy: [age]) {
@@ -49,7 +50,7 @@ func TestExplainSimpleGroupByOnParent(t *testing.T) {
 			},
 		},
 
-		Results: []dataMap{
+		ExpectedFullGraph: []dataMap{
 			{
 				"explain": dataMap{
 					"selectTopNode": dataMap{
@@ -86,12 +87,13 @@ func TestExplainSimpleGroupByOnParent(t *testing.T) {
 		},
 	}
 
-	executeTestCase(t, test)
+	runExplainTest(t, test)
 }
 
-func TestExplainGroupByTwoFieldsOnParent(t *testing.T) {
-	test := testUtils.RequestTestCase{
-		Description: "Explain a grouping by two fields.",
+func TestDefaultExplainRequestWithGroupByTwoFieldsOnParent(t *testing.T) {
+	test := explainUtils.ExplainRequestTestCase{
+
+		Description: "Explain (default) request with group-by two fields on parent.",
 
 		Request: `query @explain {
 			Author (groupBy: [age, name]) {
@@ -122,7 +124,7 @@ func TestExplainGroupByTwoFieldsOnParent(t *testing.T) {
 			},
 		},
 
-		Results: []dataMap{
+		ExpectedFullGraph: []dataMap{
 			{
 				"explain": dataMap{
 					"selectTopNode": dataMap{
@@ -159,5 +161,5 @@ func TestExplainGroupByTwoFieldsOnParent(t *testing.T) {
 		},
 	}
 
-	executeTestCase(t, test)
+	runExplainTest(t, test)
 }

--- a/tests/integration/explain/default/group_with_average_test.go
+++ b/tests/integration/explain/default/group_with_average_test.go
@@ -13,12 +13,13 @@ package test_explain_default
 import (
 	"testing"
 
-	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	explainUtils "github.com/sourcenetwork/defradb/tests/integration/explain"
 )
 
-func TestExplainGroupByWithAverageOnAnInnerField(t *testing.T) {
-	test := testUtils.RequestTestCase{
-		Description: "Explain a groupBy with average on an field.",
+func TestDefaultExplainRequestWithGroupByWithAverageOnAnInnerField(t *testing.T) {
+	test := explainUtils.ExplainRequestTestCase{
+
+		Description: "Explain (default) request with group-by with average on inner field.",
 
 		Request: `query @explain {
 			Author (groupBy: [name]) {
@@ -63,7 +64,7 @@ func TestExplainGroupByWithAverageOnAnInnerField(t *testing.T) {
 			},
 		},
 
-		Results: []dataMap{
+		ExpectedFullGraph: []dataMap{
 			{
 				"explain": dataMap{
 					"selectTopNode": dataMap{
@@ -131,12 +132,13 @@ func TestExplainGroupByWithAverageOnAnInnerField(t *testing.T) {
 		},
 	}
 
-	executeTestCase(t, test)
+	runExplainTest(t, test)
 }
 
-func TestExplainGroupByWithAnAverageInsideTheInnerGroupOnAField(t *testing.T) {
-	test := testUtils.RequestTestCase{
-		Description: "Explain a groupBy with average of inside the inner group (on a field).",
+func TestDefaultExplainRequestWithAverageInsideTheInnerGroupOnAField(t *testing.T) {
+	test := explainUtils.ExplainRequestTestCase{
+
+		Description: "Explain (default) request with group-by with average of the inner group on a field.",
 
 		Request: `query @explain {
 			Author (groupBy: [name]) {
@@ -185,7 +187,7 @@ func TestExplainGroupByWithAnAverageInsideTheInnerGroupOnAField(t *testing.T) {
 			},
 		},
 
-		Results: []dataMap{
+		ExpectedFullGraph: []dataMap{
 			{
 				"explain": dataMap{
 					"selectTopNode": dataMap{
@@ -241,12 +243,13 @@ func TestExplainGroupByWithAnAverageInsideTheInnerGroupOnAField(t *testing.T) {
 		},
 	}
 
-	executeTestCase(t, test)
+	runExplainTest(t, test)
 }
 
-func TestExplainGroupByWithAnAverageInsideTheInnerGroupAndNestedGroupBy(t *testing.T) {
-	test := testUtils.RequestTestCase{
-		Description: "Explain a groupBy with average of inside the inner group with nested groupBy.",
+func TestDefaultExplainRequestWithAverageInsideTheInnerGroupOnAFieldAndNestedGroupBy(t *testing.T) {
+	test := explainUtils.ExplainRequestTestCase{
+
+		Description: "Explain (default) request with group-by with average of the inner group on a field and nested group-by.",
 
 		Request: `query @explain {
 			Author (groupBy: [name]) {
@@ -298,7 +301,7 @@ func TestExplainGroupByWithAnAverageInsideTheInnerGroupAndNestedGroupBy(t *testi
 			},
 		},
 
-		Results: []dataMap{
+		ExpectedFullGraph: []dataMap{
 			{
 				"explain": dataMap{
 					"selectTopNode": dataMap{
@@ -354,12 +357,13 @@ func TestExplainGroupByWithAnAverageInsideTheInnerGroupAndNestedGroupBy(t *testi
 		},
 	}
 
-	executeTestCase(t, test)
+	runExplainTest(t, test)
 }
 
-func TestExplainGroupByWihAnAverageInsideTheInnerGroupAndNestedGroupByWithAnAverage(t *testing.T) {
-	test := testUtils.RequestTestCase{
-		Description: "Explain a groupBy with average of inside the inner group with nested groupBy with and average.",
+func TestDefaultExplainRequestWithAverageInsideTheInnerGroupAndNestedGroupByWithAverage(t *testing.T) {
+	test := explainUtils.ExplainRequestTestCase{
+
+		Description: "Explain (default) request with average inside the inner _group and nested groupBy with average.",
 
 		Request: `query @explain {
 			Author (groupBy: [name]) {
@@ -412,7 +416,7 @@ func TestExplainGroupByWihAnAverageInsideTheInnerGroupAndNestedGroupByWithAnAver
 			},
 		},
 
-		Results: []dataMap{
+		ExpectedFullGraph: []dataMap{
 			{
 				"explain": dataMap{
 					"selectTopNode": dataMap{
@@ -468,5 +472,5 @@ func TestExplainGroupByWihAnAverageInsideTheInnerGroupAndNestedGroupByWithAnAver
 		},
 	}
 
-	executeTestCase(t, test)
+	runExplainTest(t, test)
 }

--- a/tests/integration/explain/default/group_with_dockey_child_test.go
+++ b/tests/integration/explain/default/group_with_dockey_child_test.go
@@ -1,0 +1,97 @@
+// Copyright 2023 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package test_explain_default
+
+import (
+	"testing"
+
+	explainUtils "github.com/sourcenetwork/defradb/tests/integration/explain"
+)
+
+func TestDefaultExplainRequestWithDockeysOnInnerGroupSelection(t *testing.T) {
+	test := explainUtils.ExplainRequestTestCase{
+
+		Description: "Explain (default) request with dockeys on inner _group.",
+
+		Request: `query @explain {
+			Author(
+				groupBy: [age]
+			) {
+				age
+				_group(dockeys: ["bae-6a4c5bc5-b044-5a03-a868-8260af6f2254"]) {
+					name
+				}
+			}
+		}`,
+
+		Docs: map[int][]string{
+			//authors
+			2: {
+				// dockey: "bae-21a6ad4a-1cd8-5613-807c-a90c7c12f880"
+				`{
+					"name": "John Grisham",
+					"age": 12
+				}`,
+
+				// dockey: "bae-6a4c5bc5-b044-5a03-a868-8260af6f2254"
+				`{
+					"name": "Cornelia Funke",
+					"age": 20
+				}`,
+
+				// dockey: "bae-4ea9d148-13f3-5a48-a0ef-9ffd344caeed"
+				`{
+					"name": "John's Twin",
+					"age": 65
+				}`,
+			},
+		},
+
+		ExpectedPatterns: []dataMap{groupPattern},
+
+		ExpectedTargets: []explainUtils.PlanNodeTargetCase{
+			{
+				TargetNodeName:    "groupNode",
+				IncludeChildNodes: false,
+				ExpectedAttributes: dataMap{
+					"groupByFields": []string{"age"},
+					"childSelects": []dataMap{
+						{
+							"collectionName": "Author",
+							"docKeys":        []string{"bae-6a4c5bc5-b044-5a03-a868-8260af6f2254"},
+							"filter":         nil,
+							"groupBy":        nil,
+							"limit":          nil,
+							"orderBy":        nil,
+						},
+					},
+				},
+			},
+			{
+				TargetNodeName:    "scanNode",
+				IncludeChildNodes: true, // should be leaf of it's branch, so will have no child nodes.
+				ExpectedAttributes: dataMap{
+					"collectionID":   "3",
+					"collectionName": "Author",
+					"filter":         nil,
+					"spans": []dataMap{
+						{
+							"start": "/3",
+							"end":   "/4",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	runExplainTest(t, test)
+}

--- a/tests/integration/explain/default/group_with_dockey_test.go
+++ b/tests/integration/explain/default/group_with_dockey_test.go
@@ -13,12 +13,13 @@ package test_explain_default
 import (
 	"testing"
 
-	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	explainUtils "github.com/sourcenetwork/defradb/tests/integration/explain"
 )
 
-func TestExplainQueryWithDockeysFilterOnInnerGroupBy(t *testing.T) {
-	test := testUtils.RequestTestCase{
-		Description: "Explain query with a dockeys filter on inner _group.",
+func TestDefaultExplainRequestWithDockeysOnInnerGroupSelection(t *testing.T) {
+	test := explainUtils.ExplainRequestTestCase{
+
+		Description: "Explain (default) request with dockeys on inner _group.",
 
 		Request: `query @explain {
 			Author(
@@ -54,7 +55,7 @@ func TestExplainQueryWithDockeysFilterOnInnerGroupBy(t *testing.T) {
 			},
 		},
 
-		Results: []dataMap{
+		ExpectedFullGraph: []dataMap{
 			{
 				"explain": dataMap{
 					"selectTopNode": dataMap{
@@ -91,12 +92,13 @@ func TestExplainQueryWithDockeysFilterOnInnerGroupBy(t *testing.T) {
 		},
 	}
 
-	executeTestCase(t, test)
+	runExplainTest(t, test)
 }
 
-func TestExplainQueryWithDockeyOnParentGroupBy(t *testing.T) {
-	test := testUtils.RequestTestCase{
-		Description: "Explain query with a dockey on parent groupBy.",
+func TestDefaultExplainRequestWithDockeyOnParentGroupBy(t *testing.T) {
+	test := explainUtils.ExplainRequestTestCase{
+
+		Description: "Explain (default) request with a dockey on parent groupBy.",
 
 		Request: `query @explain {
 			Author(
@@ -133,7 +135,7 @@ func TestExplainQueryWithDockeyOnParentGroupBy(t *testing.T) {
 			},
 		},
 
-		Results: []dataMap{
+		ExpectedFullGraph: []dataMap{
 			{
 				"explain": dataMap{
 					"selectTopNode": dataMap{
@@ -170,12 +172,13 @@ func TestExplainQueryWithDockeyOnParentGroupBy(t *testing.T) {
 		},
 	}
 
-	executeTestCase(t, test)
+	runExplainTest(t, test)
 }
 
-func TestExplainQuerySimpleWithDockeysAndFilter(t *testing.T) {
-	test := testUtils.RequestTestCase{
-		Description: "Explain query with a dockeys and filter on parent groupBy.",
+func TestDefaultExplainRequestWithDockeysAndFilterOnParentGroupBy(t *testing.T) {
+	test := explainUtils.ExplainRequestTestCase{
+
+		Description: "Explain (default) request with dockeys and filter on parent groupBy.",
 
 		Request: `query @explain {
 			Author(
@@ -216,7 +219,7 @@ func TestExplainQuerySimpleWithDockeysAndFilter(t *testing.T) {
 			},
 		},
 
-		Results: []dataMap{
+		ExpectedFullGraph: []dataMap{
 			{
 				"explain": dataMap{
 					"selectTopNode": dataMap{
@@ -261,5 +264,5 @@ func TestExplainQuerySimpleWithDockeysAndFilter(t *testing.T) {
 		},
 	}
 
-	executeTestCase(t, test)
+	runExplainTest(t, test)
 }

--- a/tests/integration/explain/default/group_with_dockey_test.go
+++ b/tests/integration/explain/default/group_with_dockey_test.go
@@ -16,85 +16,6 @@ import (
 	explainUtils "github.com/sourcenetwork/defradb/tests/integration/explain"
 )
 
-func TestDefaultExplainRequestWithDockeysOnInnerGroupSelection(t *testing.T) {
-	test := explainUtils.ExplainRequestTestCase{
-
-		Description: "Explain (default) request with dockeys on inner _group.",
-
-		Request: `query @explain {
-			Author(
-				groupBy: [age]
-			) {
-				age
-				_group(dockeys: ["bae-6a4c5bc5-b044-5a03-a868-8260af6f2254"]) {
-					name
-				}
-			}
-		}`,
-
-		Docs: map[int][]string{
-			//authors
-			2: {
-				// dockey: "bae-21a6ad4a-1cd8-5613-807c-a90c7c12f880"
-				`{
-					"name": "John Grisham",
-					"age": 12
-				}`,
-
-				// dockey: "bae-6a4c5bc5-b044-5a03-a868-8260af6f2254"
-				`{
-					"name": "Cornelia Funke",
-					"age": 20
-				}`,
-
-				// dockey: "bae-4ea9d148-13f3-5a48-a0ef-9ffd344caeed"
-				`{
-					"name": "John's Twin",
-					"age": 65
-				}`,
-			},
-		},
-
-		ExpectedFullGraph: []dataMap{
-			{
-				"explain": dataMap{
-					"selectTopNode": dataMap{
-						"groupNode": dataMap{
-							"childSelects": []dataMap{
-								{
-									"collectionName": "Author",
-									"docKeys":        []string{"bae-6a4c5bc5-b044-5a03-a868-8260af6f2254"},
-									"filter":         nil,
-									"groupBy":        nil,
-									"limit":          nil,
-									"orderBy":        nil,
-								},
-							},
-							"groupByFields": []string{"age"},
-							"selectNode": dataMap{
-								"filter": nil,
-								"scanNode": dataMap{
-									"collectionID":   "3",
-									"collectionName": "Author",
-									"filter":         nil,
-									"spans": []dataMap{
-										{
-											"start": "/3",
-											"end":   "/4",
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-
-	runExplainTest(t, test)
-}
-
 func TestDefaultExplainRequestWithDockeyOnParentGroupBy(t *testing.T) {
 	test := explainUtils.ExplainRequestTestCase{
 
@@ -135,36 +56,30 @@ func TestDefaultExplainRequestWithDockeyOnParentGroupBy(t *testing.T) {
 			},
 		},
 
-		ExpectedFullGraph: []dataMap{
+		ExpectedPatterns: []dataMap{groupPattern},
+
+		ExpectedTargets: []explainUtils.PlanNodeTargetCase{
 			{
-				"explain": dataMap{
-					"selectTopNode": dataMap{
-						"groupNode": dataMap{
-							"childSelects": []dataMap{
-								{
-									"collectionName": "Author",
-									"docKeys":        nil,
-									"filter":         nil,
-									"groupBy":        nil,
-									"limit":          nil,
-									"orderBy":        nil,
-								},
-							},
-							"groupByFields": []string{"age"},
-							"selectNode": dataMap{
-								"filter": nil,
-								"scanNode": dataMap{
-									"collectionID":   "3",
-									"collectionName": "Author",
-									"filter":         nil,
-									"spans": []dataMap{
-										{
-											"start": "/3/bae-6a4c5bc5-b044-5a03-a868-8260af6f2254",
-											"end":   "/3/bae-6a4c5bc5-b044-5a03-a868-8260af6f2255",
-										},
-									},
-								},
-							},
+				TargetNodeName:    "groupNode",
+				IncludeChildNodes: false,
+				ExpectedAttributes: dataMap{
+					"groupByFields": []string{"age"},
+					"childSelects": []dataMap{
+						emptyChildSelectsAttributeForAuthor,
+					},
+				},
+			},
+			{
+				TargetNodeName:    "scanNode",
+				IncludeChildNodes: true, // should be leaf of it's branch, so will have no child nodes.
+				ExpectedAttributes: dataMap{
+					"collectionID":   "3",
+					"collectionName": "Author",
+					"filter":         nil,
+					"spans": []dataMap{
+						{
+							"start": "/3/bae-6a4c5bc5-b044-5a03-a868-8260af6f2254",
+							"end":   "/3/bae-6a4c5bc5-b044-5a03-a868-8260af6f2255",
 						},
 					},
 				},
@@ -219,44 +134,38 @@ func TestDefaultExplainRequestWithDockeysAndFilterOnParentGroupBy(t *testing.T) 
 			},
 		},
 
-		ExpectedFullGraph: []dataMap{
+		ExpectedPatterns: []dataMap{groupPattern},
+
+		ExpectedTargets: []explainUtils.PlanNodeTargetCase{
 			{
-				"explain": dataMap{
-					"selectTopNode": dataMap{
-						"groupNode": dataMap{
-							"childSelects": []dataMap{
-								{
-									"collectionName": "Author",
-									"docKeys":        nil,
-									"groupBy":        nil,
-									"limit":          nil,
-									"orderBy":        nil,
-									"filter":         nil,
-								},
-							},
-							"groupByFields": []string{"age"},
-							"selectNode": dataMap{
-								"filter": nil,
-								"scanNode": dataMap{
-									"collectionID":   "3",
-									"collectionName": "Author",
-									"filter": dataMap{
-										"age": dataMap{
-											"_eq": int32(20),
-										},
-									},
-									"spans": []dataMap{
-										{
-											"start": "/3/bae-6a4c5bc5-b044-5a03-a868-8260af6f2254",
-											"end":   "/3/bae-6a4c5bc5-b044-5a03-a868-8260af6f2255",
-										},
-										{
-											"start": "/3/bae-4ea9d148-13f3-5a48-a0ef-9ffd344caeed",
-											"end":   "/3/bae-4ea9d148-13f3-5a48-a0ef-9ffd344caeee",
-										},
-									},
-								},
-							},
+				TargetNodeName:    "groupNode",
+				IncludeChildNodes: false,
+				ExpectedAttributes: dataMap{
+					"groupByFields": []string{"age"},
+					"childSelects": []dataMap{
+						emptyChildSelectsAttributeForAuthor,
+					},
+				},
+			},
+			{
+				TargetNodeName:    "scanNode",
+				IncludeChildNodes: true, // should be leaf of it's branch, so will have no child nodes.
+				ExpectedAttributes: dataMap{
+					"collectionID":   "3",
+					"collectionName": "Author",
+					"filter": dataMap{
+						"age": dataMap{
+							"_eq": int32(20),
+						},
+					},
+					"spans": []dataMap{
+						{
+							"start": "/3/bae-6a4c5bc5-b044-5a03-a868-8260af6f2254",
+							"end":   "/3/bae-6a4c5bc5-b044-5a03-a868-8260af6f2255",
+						},
+						{
+							"start": "/3/bae-4ea9d148-13f3-5a48-a0ef-9ffd344caeed",
+							"end":   "/3/bae-4ea9d148-13f3-5a48-a0ef-9ffd344caeee",
 						},
 					},
 				},

--- a/tests/integration/explain/default/group_with_filter_child_test.go
+++ b/tests/integration/explain/default/group_with_filter_child_test.go
@@ -1,0 +1,182 @@
+// Copyright 2023 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package test_explain_default
+
+import (
+	"testing"
+
+	explainUtils "github.com/sourcenetwork/defradb/tests/integration/explain"
+)
+
+func TestDefaultExplainRequestWithFilterOnInnerGroupSelection(t *testing.T) {
+	test := explainUtils.ExplainRequestTestCase{
+
+		Description: "Explain (default) request with filter on the inner _group selection.",
+
+		Request: `query @explain {
+			Author (groupBy: [age]) {
+				age
+				_group(filter: {age: {_gt: 63}}) {
+					name
+				}
+			}
+		}`,
+
+		Docs: map[int][]string{
+			//authors
+			2: {
+				`{
+                     "name": "John Grisham",
+                     "age": 65
+                 }`,
+
+				`{
+                     "name": "Cornelia Funke",
+                     "age": 62
+                 }`,
+
+				`{
+                     "name": "John's Twin",
+                     "age": 65
+                 }`,
+			},
+		},
+
+		ExpectedPatterns: []dataMap{groupPattern},
+
+		ExpectedTargets: []explainUtils.PlanNodeTargetCase{
+			{
+				TargetNodeName:    "groupNode",
+				IncludeChildNodes: false,
+				ExpectedAttributes: dataMap{
+					"groupByFields": []string{"age"},
+					"childSelects": []dataMap{
+						{
+							"collectionName": "Author",
+							"docKeys":        nil,
+							"filter": dataMap{
+								"age": dataMap{
+									"_gt": int32(63),
+								},
+							},
+							"groupBy": nil,
+							"limit":   nil,
+							"orderBy": nil,
+						},
+					},
+				},
+			},
+			{
+				TargetNodeName:    "scanNode",
+				IncludeChildNodes: true, // should be leaf of it's branch, so will have no child nodes.
+				ExpectedAttributes: dataMap{
+					"filter":         nil,
+					"collectionID":   "3",
+					"collectionName": "Author",
+					"spans": []dataMap{
+						{
+							"start": "/3",
+							"end":   "/4",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	runExplainTest(t, test)
+}
+
+func TestDefaultExplainRequestWithFilterOnParentGroupByAndInnerGroupSelection(t *testing.T) {
+	test := explainUtils.ExplainRequestTestCase{
+
+		Description: "Explain (default) request with filter on parent groupBy and on the inner _group selection.",
+
+		Request: `query @explain {
+			Author (
+				groupBy: [age],
+				filter: {age: {_gt: 62}}
+			) {
+				age
+				_group(filter: {age: {_gt: 63}}) {
+					name
+				}
+			}
+		}`,
+
+		Docs: map[int][]string{
+			//authors
+			2: {
+				`{
+                     "name": "John Grisham",
+                     "age": 65
+                 }`,
+
+				`{
+                     "name": "Cornelia Funke",
+                     "age": 62
+                 }`,
+
+				`{
+                     "name": "John's Twin",
+                     "age": 65
+                 }`,
+			},
+		},
+
+		ExpectedPatterns: []dataMap{groupPattern},
+
+		ExpectedTargets: []explainUtils.PlanNodeTargetCase{
+			{
+				TargetNodeName:    "groupNode",
+				IncludeChildNodes: false,
+				ExpectedAttributes: dataMap{
+					"groupByFields": []string{"age"},
+					"childSelects": []dataMap{
+						{
+							"collectionName": "Author",
+							"docKeys":        nil,
+							"filter": dataMap{
+								"age": dataMap{
+									"_gt": int32(63),
+								},
+							},
+							"groupBy": nil,
+							"limit":   nil,
+							"orderBy": nil,
+						},
+					},
+				},
+			},
+			{
+				TargetNodeName:    "scanNode",
+				IncludeChildNodes: true, // should be leaf of it's branch, so will have no child nodes.
+				ExpectedAttributes: dataMap{
+					"filter": dataMap{
+						"age": dataMap{
+							"_gt": int32(62),
+						},
+					},
+					"collectionID":   "3",
+					"collectionName": "Author",
+					"spans": []dataMap{
+						{
+							"start": "/3",
+							"end":   "/4",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	runExplainTest(t, test)
+}

--- a/tests/integration/explain/default/group_with_filter_test.go
+++ b/tests/integration/explain/default/group_with_filter_test.go
@@ -13,12 +13,13 @@ package test_explain_default
 import (
 	"testing"
 
-	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	explainUtils "github.com/sourcenetwork/defradb/tests/integration/explain"
 )
 
-func TestExplainGroupByWithFilterOnParent(t *testing.T) {
-	test := testUtils.RequestTestCase{
-		Description: "Explain a grouping with filter on parent.",
+func TestDefaultExplainRequestWithFilterOnGroupByParent(t *testing.T) {
+	test := explainUtils.ExplainRequestTestCase{
+
+		Description: "Explain (default) request with filter on parent groupBy.",
 
 		Request: `query @explain {
 			Author (
@@ -52,7 +53,7 @@ func TestExplainGroupByWithFilterOnParent(t *testing.T) {
 			},
 		},
 
-		Results: []dataMap{
+		ExpectedFullGraph: []dataMap{
 			{
 				"explain": dataMap{
 					"selectTopNode": dataMap{
@@ -93,12 +94,13 @@ func TestExplainGroupByWithFilterOnParent(t *testing.T) {
 		},
 	}
 
-	executeTestCase(t, test)
+	runExplainTest(t, test)
 }
 
-func TestExplainGroupByWithFilterOnInnerGroupSelection(t *testing.T) {
-	test := testUtils.RequestTestCase{
-		Description: "Explain a grouping with filter on the inner group selection.",
+func TestDefaultExplainRequestWithFilterOnInnerGroupSelection(t *testing.T) {
+	test := explainUtils.ExplainRequestTestCase{
+
+		Description: "Explain (default) request with filter on the inner _group selection.",
 
 		Request: `query @explain {
 			Author (groupBy: [age]) {
@@ -129,7 +131,7 @@ func TestExplainGroupByWithFilterOnInnerGroupSelection(t *testing.T) {
 			},
 		},
 
-		Results: []dataMap{
+		ExpectedFullGraph: []dataMap{
 			{
 				"explain": dataMap{
 					"selectTopNode": dataMap{
@@ -170,5 +172,5 @@ func TestExplainGroupByWithFilterOnInnerGroupSelection(t *testing.T) {
 		},
 	}
 
-	executeTestCase(t, test)
+	runExplainTest(t, test)
 }

--- a/tests/integration/explain/default/group_with_filter_test.go
+++ b/tests/integration/explain/default/group_with_filter_test.go
@@ -53,118 +53,34 @@ func TestDefaultExplainRequestWithFilterOnGroupByParent(t *testing.T) {
 			},
 		},
 
-		ExpectedFullGraph: []dataMap{
+		ExpectedPatterns: []dataMap{groupPattern},
+
+		ExpectedTargets: []explainUtils.PlanNodeTargetCase{
 			{
-				"explain": dataMap{
-					"selectTopNode": dataMap{
-						"groupNode": dataMap{
-							"groupByFields": []string{"age"},
-							"childSelects": []dataMap{
-								{
-									"collectionName": "Author",
-									"docKeys":        nil,
-									"groupBy":        nil,
-									"limit":          nil,
-									"orderBy":        nil,
-									"filter":         nil,
-								},
-							},
-							"selectNode": dataMap{
-								"filter": nil,
-								"scanNode": dataMap{
-									"collectionID":   "3",
-									"collectionName": "Author",
-									"filter": dataMap{
-										"age": dataMap{
-											"_gt": int32(63),
-										},
-									},
-									"spans": []dataMap{
-										{
-											"start": "/3",
-											"end":   "/4",
-										},
-									},
-								},
-							},
-						},
+				TargetNodeName:    "groupNode",
+				IncludeChildNodes: false,
+				ExpectedAttributes: dataMap{
+					"groupByFields": []string{"age"},
+					"childSelects": []dataMap{
+						emptyChildSelectsAttributeForAuthor,
 					},
 				},
 			},
-		},
-	}
-
-	runExplainTest(t, test)
-}
-
-func TestDefaultExplainRequestWithFilterOnInnerGroupSelection(t *testing.T) {
-	test := explainUtils.ExplainRequestTestCase{
-
-		Description: "Explain (default) request with filter on the inner _group selection.",
-
-		Request: `query @explain {
-			Author (groupBy: [age]) {
-				age
-				_group(filter: {age: {_gt: 63}}) {
-					name
-				}
-			}
-		}`,
-
-		Docs: map[int][]string{
-			//authors
-			2: {
-				`{
-                     "name": "John Grisham",
-                     "age": 65
-                 }`,
-
-				`{
-                     "name": "Cornelia Funke",
-                     "age": 62
-                 }`,
-
-				`{
-                     "name": "John's Twin",
-                     "age": 65
-                 }`,
-			},
-		},
-
-		ExpectedFullGraph: []dataMap{
 			{
-				"explain": dataMap{
-					"selectTopNode": dataMap{
-						"groupNode": dataMap{
-							"groupByFields": []string{"age"},
-							"childSelects": []dataMap{
-								{
-									"collectionName": "Author",
-									"docKeys":        nil,
-									"groupBy":        nil,
-									"limit":          nil,
-									"orderBy":        nil,
-									"filter": dataMap{
-										"age": dataMap{
-											"_gt": int32(63),
-										},
-									},
-								},
-							},
-							"selectNode": dataMap{
-								"filter": nil,
-								"scanNode": dataMap{
-									"filter":         nil,
-									"collectionID":   "3",
-									"collectionName": "Author",
-									"spans": []dataMap{
-										{
-											"start": "/3",
-											"end":   "/4",
-										},
-									},
-								},
-							},
+				TargetNodeName:    "scanNode",
+				IncludeChildNodes: true, // should be leaf of it's branch, so will have no child nodes.
+				ExpectedAttributes: dataMap{
+					"collectionID":   "3",
+					"collectionName": "Author",
+					"filter": dataMap{
+						"age": dataMap{
+							"_gt": int32(63),
+						},
+					},
+					"spans": []dataMap{
+						{
+							"start": "/3",
+							"end":   "/4",
 						},
 					},
 				},

--- a/tests/integration/explain/default/group_with_limit_child_test.go
+++ b/tests/integration/explain/default/group_with_limit_child_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Democratized Data Foundation
+// Copyright 2023 Democratized Data Foundation
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt.
@@ -16,33 +16,15 @@ import (
 	explainUtils "github.com/sourcenetwork/defradb/tests/integration/explain"
 )
 
-var groupLimitPattern = dataMap{
-	"explain": dataMap{
-		"selectTopNode": dataMap{
-			"limitNode": dataMap{
-				"groupNode": dataMap{
-					"selectNode": dataMap{
-						"scanNode": dataMap{},
-					},
-				},
-			},
-		},
-	},
-}
-
-func TestDefaultExplainRequestWithLimitAndOffsetOnParentGroupBy(t *testing.T) {
+func TestDefaultExplainRequestWithLimitAndOffsetOnInnerGroupSelection(t *testing.T) {
 	test := explainUtils.ExplainRequestTestCase{
 
-		Description: "Explain (default) request with limit and offset on parent groupBy.",
+		Description: "Explain (default) request with limit and offset on inner _group selection.",
 
 		Request: `query @explain {
-			Author(
-				groupBy: [name],
-				limit: 1,
-				offset: 1
-			) {
+			Author(groupBy: [name]) {
 				name
-				_group {
+				_group(limit: 2, offset: 1) {
 					age
 				}
 			}
@@ -84,87 +66,7 @@ func TestDefaultExplainRequestWithLimitAndOffsetOnParentGroupBy(t *testing.T) {
 			},
 		},
 
-		ExpectedPatterns: []dataMap{groupLimitPattern},
-
-		ExpectedTargets: []explainUtils.PlanNodeTargetCase{
-			{
-				TargetNodeName:    "groupNode",
-				IncludeChildNodes: false,
-				ExpectedAttributes: dataMap{
-					"groupByFields": []string{"name"},
-					"childSelects": []dataMap{
-						emptyChildSelectsAttributeForAuthor,
-					},
-				},
-			},
-			{
-				TargetNodeName:    "limitNode",
-				IncludeChildNodes: false,
-				ExpectedAttributes: dataMap{
-					"limit":  uint64(1),
-					"offset": uint64(1),
-				},
-			},
-		},
-	}
-
-	runExplainTest(t, test)
-}
-
-func TestDefaultExplainRequestWithLimitOnParentGroupByAndInnerGroupSelection(t *testing.T) {
-	test := explainUtils.ExplainRequestTestCase{
-
-		Description: "Explain (default) request with limit and offset on parent groupBy and inner _group selection.",
-
-		Request: `query @explain {
-			Author(
-				groupBy: [name],
-				limit: 1
-			) {
-				name
-				_group(limit: 2) {
-					age
-				}
-			}
-		}`,
-
-		Docs: map[int][]string{
-			//authors
-			2: {
-				`{
-					"name": "John Grisham",
-					"verified": true,
-					"age": 65
-				}`,
-				`{
-					"name": "John Grisham",
- 					"verified": false,
- 					"age": 2
-				}`,
-				`{
-					"name": "John Grisham",
-					"verified": true,
-					"age": 50
-				}`,
-				`{
-					"name": "Cornelia Funke",
-					"verified": true,
-					"age": 62
-				}`,
-				`{
-					"name": "Twin",
-					"verified": true,
-					"age": 63
-				}`,
-				`{
-					"name": "Twin",
-					"verified": true,
-					"age": 63
-				}`,
-			},
-		},
-
-		ExpectedPatterns: []dataMap{groupLimitPattern},
+		ExpectedPatterns: []dataMap{groupPattern},
 
 		ExpectedTargets: []explainUtils.PlanNodeTargetCase{
 			{
@@ -177,22 +79,107 @@ func TestDefaultExplainRequestWithLimitOnParentGroupByAndInnerGroupSelection(t *
 							"collectionName": "Author",
 							"limit": dataMap{
 								"limit":  uint64(2),
-								"offset": uint64(0),
+								"offset": uint64(1),
 							},
-							"orderBy": nil,
 							"docKeys": nil,
-							"groupBy": nil,
 							"filter":  nil,
+							"groupBy": nil,
+							"orderBy": nil,
 						},
 					},
 				},
 			},
+		},
+	}
+
+	runExplainTest(t, test)
+}
+
+func TestDefaultExplainRequestWithLimitAndOffsetOnMultipleInnerGroupSelections(t *testing.T) {
+	test := explainUtils.ExplainRequestTestCase{
+
+		Description: "Explain (default) request with limit and offset on multiple inner _group selections.",
+
+		Request: `query @explain {
+			Author(groupBy: [name]) {
+				name
+				innerFirstGroup: _group(limit: 1, offset: 2) {
+					age
+				}
+				innerSecondGroup: _group(limit: 2) {
+					age
+				}
+			}
+		}`,
+
+		Docs: map[int][]string{
+			//authors
+			2: {
+				`{
+					"name": "John Grisham",
+					"verified": true,
+					"age": 65
+				}`,
+				`{
+					"name": "John Grisham",
+ 					"verified": false,
+ 					"age": 2
+				}`,
+				`{
+					"name": "John Grisham",
+					"verified": true,
+					"age": 50
+				}`,
+				`{
+					"name": "Cornelia Funke",
+					"verified": true,
+					"age": 62
+				}`,
+				`{
+					"name": "Twin",
+					"verified": true,
+					"age": 63
+				}`,
+				`{
+					"name": "Twin",
+					"verified": true,
+					"age": 63
+				}`,
+			},
+		},
+
+		ExpectedPatterns: []dataMap{groupPattern},
+
+		ExpectedTargets: []explainUtils.PlanNodeTargetCase{
 			{
-				TargetNodeName:    "limitNode",
+				TargetNodeName:    "groupNode",
 				IncludeChildNodes: false,
 				ExpectedAttributes: dataMap{
-					"limit":  uint64(1),
-					"offset": uint64(0),
+					"groupByFields": []string{"name"},
+					"childSelects": []dataMap{
+						{
+							"collectionName": "Author",
+							"limit": dataMap{
+								"limit":  uint64(1),
+								"offset": uint64(2),
+							},
+							"docKeys": nil,
+							"filter":  nil,
+							"groupBy": nil,
+							"orderBy": nil,
+						},
+						{
+							"collectionName": "Author",
+							"limit": dataMap{
+								"limit":  uint64(2),
+								"offset": uint64(0),
+							},
+							"docKeys": nil,
+							"filter":  nil,
+							"groupBy": nil,
+							"orderBy": nil,
+						},
+					},
 				},
 			},
 		},

--- a/tests/integration/explain/default/group_with_limit_test.go
+++ b/tests/integration/explain/default/group_with_limit_test.go
@@ -13,13 +13,13 @@ package test_explain_default
 import (
 	"testing"
 
-	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	explainUtils "github.com/sourcenetwork/defradb/tests/integration/explain"
 )
 
-func TestExplainGroupByWithGroupLimitAndOffsetOnParentGroupBy(t *testing.T) {
-	test := testUtils.RequestTestCase{
+func TestDefaultExplainRequestWithLimitAndOffsetOnParentGroupBy(t *testing.T) {
+	test := explainUtils.ExplainRequestTestCase{
 
-		Description: "Explain query with limit and offset on parent groupBy.",
+		Description: "Explain (default) request with limit and offset on parent groupBy.",
 
 		Request: `query @explain {
 			Author(
@@ -70,7 +70,7 @@ func TestExplainGroupByWithGroupLimitAndOffsetOnParentGroupBy(t *testing.T) {
 			},
 		},
 
-		Results: []dataMap{
+		ExpectedFullGraph: []dataMap{
 			{
 				"explain": dataMap{
 					"selectTopNode": dataMap{
@@ -111,13 +111,13 @@ func TestExplainGroupByWithGroupLimitAndOffsetOnParentGroupBy(t *testing.T) {
 		},
 	}
 
-	executeTestCase(t, test)
+	runExplainTest(t, test)
 }
 
-func TestExplainGroupByWithGroupLimitAndOffsetOnChild(t *testing.T) {
-	test := testUtils.RequestTestCase{
+func TestDefaultExplainRequestWithLimitAndOffsetOnInnerGroupSelection(t *testing.T) {
+	test := explainUtils.ExplainRequestTestCase{
 
-		Description: "Explain query with limit and offset on child groupBy.",
+		Description: "Explain (default) request with limit and offset on inner _group selection.",
 
 		Request: `query @explain {
 			Author(groupBy: [name]) {
@@ -164,7 +164,7 @@ func TestExplainGroupByWithGroupLimitAndOffsetOnChild(t *testing.T) {
 			},
 		},
 
-		Results: []dataMap{
+		ExpectedFullGraph: []dataMap{
 			{
 				"explain": dataMap{
 					"selectTopNode": dataMap{
@@ -204,12 +204,13 @@ func TestExplainGroupByWithGroupLimitAndOffsetOnChild(t *testing.T) {
 		},
 	}
 
-	executeTestCase(t, test)
+	runExplainTest(t, test)
 }
 
-func TestExplainGroupByWithGroupLimitOnChildMultipleRendered(t *testing.T) {
-	test := testUtils.RequestTestCase{
-		Description: "Explain query with limit on child groupBy (multiple rendered).",
+func TestDefaultExplainRequestWithLimitAndOffsetOnMultipleInnerGroupSelections(t *testing.T) {
+	test := explainUtils.ExplainRequestTestCase{
+
+		Description: "Explain (default) request with limit and offset on multiple inner _group selections.",
 
 		Request: `query @explain {
 			Author(groupBy: [name]) {
@@ -259,7 +260,7 @@ func TestExplainGroupByWithGroupLimitOnChildMultipleRendered(t *testing.T) {
 			},
 		},
 
-		Results: []dataMap{
+		ExpectedFullGraph: []dataMap{
 			{
 				"explain": dataMap{
 					"selectTopNode": dataMap{
@@ -310,12 +311,13 @@ func TestExplainGroupByWithGroupLimitOnChildMultipleRendered(t *testing.T) {
 		},
 	}
 
-	executeTestCase(t, test)
+	runExplainTest(t, test)
 }
 
-func TestExplainGroupByWithGroupLimitOnParentAndChild(t *testing.T) {
-	test := testUtils.RequestTestCase{
-		Description: "Explain query with limit on parent and child groupBy.",
+func TestDefaultExplainRequestWithLimitOnParentGroupByAndInnerGroupSelection(t *testing.T) {
+	test := explainUtils.ExplainRequestTestCase{
+
+		Description: "Explain (default) request with limit and offset on parent groupBy and inner _group selection.",
 
 		Request: `query @explain {
 			Author(
@@ -365,7 +367,7 @@ func TestExplainGroupByWithGroupLimitOnParentAndChild(t *testing.T) {
 			},
 		},
 
-		Results: []dataMap{
+		ExpectedFullGraph: []dataMap{
 			{
 				"explain": dataMap{
 					"selectTopNode": dataMap{
@@ -409,5 +411,5 @@ func TestExplainGroupByWithGroupLimitOnParentAndChild(t *testing.T) {
 		},
 	}
 
-	executeTestCase(t, test)
+	runExplainTest(t, test)
 }

--- a/tests/integration/explain/default/group_with_order_test.go
+++ b/tests/integration/explain/default/group_with_order_test.go
@@ -114,6 +114,199 @@ func TestDefaultExplainRequestWithDescendingOrderOnParentGroupBy(t *testing.T) {
 	runExplainTest(t, test)
 }
 
+func TestDefaultExplainRequestWithAscendingOrderOnParentGroupBy(t *testing.T) {
+	test := explainUtils.ExplainRequestTestCase{
+
+		Description: "Explain (default) request with order (ascending) on parent groupBy.",
+
+		Request: `query @explain {
+			Author(groupBy: [name], order: {name: ASC}) {
+				name
+				_group {
+					age
+				}
+			}
+		}`,
+
+		Docs: map[int][]string{
+			//authors
+			2: {
+				`{
+					"name": "John Grisham",
+					"verified": true,
+					"age": 65
+				}`,
+				`{
+					"name": "John Grisham",
+					"verified": false,
+					"age": 2
+				}`,
+				`{
+					"name": "John Grisham",
+					"verified": true,
+					"age": 50
+				}`,
+				`{
+					"name": "Cornelia Funke",
+					"verified": true,
+					"age": 62
+				}`,
+				`{
+					"name": "Twin",
+					"verified": true,
+					"age": 63
+				}`,
+				`{
+					"name": "Twin",
+					"verified": true,
+					"age": 63
+				}`,
+			},
+		},
+
+		ExpectedFullGraph: []dataMap{
+			{
+				"explain": dataMap{
+					"selectTopNode": dataMap{
+						"orderNode": dataMap{
+							"orderings": []dataMap{
+								{
+									"direction": "ASC",
+									"fields":    []string{"name"},
+								},
+							},
+							"groupNode": dataMap{
+								"groupByFields": []string{"name"},
+								"childSelects": []dataMap{
+									{
+										"collectionName": "Author",
+										"docKeys":        nil,
+										"orderBy":        nil,
+										"groupBy":        nil,
+										"limit":          nil,
+										"filter":         nil,
+									},
+								},
+								"selectNode": dataMap{
+									"filter": nil,
+									"scanNode": dataMap{
+										"collectionID":   "3",
+										"collectionName": "Author",
+										"filter":         nil,
+										"spans": []dataMap{
+											{
+												"start": "/3",
+												"end":   "/4",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	runExplainTest(t, test)
+}
+
+func TestDefaultExplainRequestWithDescendingOrderOnInnerGroupSelection(t *testing.T) {
+	test := explainUtils.ExplainRequestTestCase{
+
+		Description: "Explain (default) request with order (descending) on inner _group selection.",
+
+		Request: `query @explain {
+			Author(groupBy: [name]) {
+				name
+				_group (order: {age: DESC}){
+					age
+				}
+			}
+		}`,
+
+		Docs: map[int][]string{
+			//authors
+			2: {
+				`{
+					"name": "John Grisham",
+					"verified": true,
+					"age": 65
+				}`,
+				`{
+					"name": "John Grisham",
+					"verified": false,
+					"age": 2
+				}`,
+				`{
+					"name": "John Grisham",
+					"verified": true,
+					"age": 50
+				}`,
+				`{
+					"name": "Cornelia Funke",
+					"verified": true,
+					"age": 62
+				}`,
+				`{
+					"name": "Twin",
+					"verified": true,
+					"age": 63
+				}`,
+				`{
+					"name": "Twin",
+					"verified": true,
+					"age": 63
+				}`,
+			},
+		},
+
+		ExpectedFullGraph: []dataMap{
+			{
+				"explain": dataMap{
+					"selectTopNode": dataMap{
+						"groupNode": dataMap{
+							"groupByFields": []string{"name"},
+							"childSelects": []dataMap{
+								{
+									"collectionName": "Author",
+									"orderBy": []dataMap{
+										{
+											"direction": "DESC",
+											"fields":    []string{"age"},
+										},
+									},
+									"docKeys": nil,
+									"groupBy": nil,
+									"limit":   nil,
+									"filter":  nil,
+								},
+							},
+							"selectNode": dataMap{
+								"filter": nil,
+								"scanNode": dataMap{
+									"collectionID":   "3",
+									"collectionName": "Author",
+									"filter":         nil,
+									"spans": []dataMap{
+										{
+											"start": "/3",
+											"end":   "/4",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	runExplainTest(t, test)
+}
+
 func TestDefaultExplainRequestWithAscendingOrderOnInnerGroupSelection(t *testing.T) {
 	test := explainUtils.ExplainRequestTestCase{
 

--- a/tests/integration/explain/default/group_with_order_test.go
+++ b/tests/integration/explain/default/group_with_order_test.go
@@ -13,12 +13,13 @@ package test_explain_default
 import (
 	"testing"
 
-	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	explainUtils "github.com/sourcenetwork/defradb/tests/integration/explain"
 )
 
-func TestExplainGroupByWithOrderOnParentGroup(t *testing.T) {
-	test := testUtils.RequestTestCase{
-		Description: "Explain query with ordered parent groupBy.",
+func TestDefaultExplainRequestWithDescendingOrderOnParentGroupBy(t *testing.T) {
+	test := explainUtils.ExplainRequestTestCase{
+
+		Description: "Explain (default) request with order (descending) on parent groupBy.",
 
 		Request: `query @explain {
 			Author(groupBy: [name], order: {name: DESC}) {
@@ -65,7 +66,7 @@ func TestExplainGroupByWithOrderOnParentGroup(t *testing.T) {
 			},
 		},
 
-		Results: []dataMap{
+		ExpectedFullGraph: []dataMap{
 			{
 				"explain": dataMap{
 					"selectTopNode": dataMap{
@@ -110,12 +111,13 @@ func TestExplainGroupByWithOrderOnParentGroup(t *testing.T) {
 		},
 	}
 
-	executeTestCase(t, test)
+	runExplainTest(t, test)
 }
 
-func TestExplainGroupByWithOrderOnTheChildGroup(t *testing.T) {
-	test := testUtils.RequestTestCase{
-		Description: "Explain query with groupBy string, and child order ascending.",
+func TestDefaultExplainRequestWithAscendingOrderOnInnerGroupSelection(t *testing.T) {
+	test := explainUtils.ExplainRequestTestCase{
+
+		Description: "Explain (default) request with order (ascending) on inner _group selection.",
 
 		Request: `query @explain {
 			Author(groupBy: [name]) {
@@ -162,7 +164,7 @@ func TestExplainGroupByWithOrderOnTheChildGroup(t *testing.T) {
 			},
 		},
 
-		Results: []dataMap{
+		ExpectedFullGraph: []dataMap{
 			{
 				"explain": dataMap{
 					"selectTopNode": dataMap{
@@ -204,12 +206,13 @@ func TestExplainGroupByWithOrderOnTheChildGroup(t *testing.T) {
 		},
 	}
 
-	executeTestCase(t, test)
+	runExplainTest(t, test)
 }
 
-func TestExplainGroupByWithOrderOnTheChildGroupAndOnParentGroup(t *testing.T) {
-	test := testUtils.RequestTestCase{
-		Description: "Explain query with parent groupBy order, and child order.",
+func TestDefaultExplainRequestWithOrderOnParentGroupByAndOnInnerGroupSelection(t *testing.T) {
+	test := explainUtils.ExplainRequestTestCase{
+
+		Description: "Explain (default) request with order on parent groupBy and inner _group selection.",
 
 		Request: `query @explain {
 			Author(groupBy: [name], order: {name: DESC}) {
@@ -256,7 +259,7 @@ func TestExplainGroupByWithOrderOnTheChildGroupAndOnParentGroup(t *testing.T) {
 			},
 		},
 
-		Results: []dataMap{
+		ExpectedFullGraph: []dataMap{
 			{
 				"explain": dataMap{
 					"selectTopNode": dataMap{
@@ -306,12 +309,13 @@ func TestExplainGroupByWithOrderOnTheChildGroupAndOnParentGroup(t *testing.T) {
 		},
 	}
 
-	executeTestCase(t, test)
+	runExplainTest(t, test)
 }
 
-func TestExplainGroupByWithOrderOnTheNestedChildOfChildGroup(t *testing.T) {
-	test := testUtils.RequestTestCase{
-		Description: "Explain query with parent groupBy order, and child order.",
+func TestDefaultExplainRequestWithOrderOnNestedParentGroupByAndOnNestedParentsInnerGroupSelection(t *testing.T) {
+	test := explainUtils.ExplainRequestTestCase{
+
+		Description: "Explain (default) request with order on nested parent groupBy and on nested parent's inner _group.",
 
 		Request: `query @explain {
 			Author(groupBy: [name]) {
@@ -364,7 +368,7 @@ func TestExplainGroupByWithOrderOnTheNestedChildOfChildGroup(t *testing.T) {
 			},
 		},
 
-		Results: []dataMap{
+		ExpectedFullGraph: []dataMap{
 			{
 				"explain": dataMap{
 					"selectTopNode": dataMap{
@@ -406,5 +410,5 @@ func TestExplainGroupByWithOrderOnTheNestedChildOfChildGroup(t *testing.T) {
 		},
 	}
 
-	executeTestCase(t, test)
+	runExplainTest(t, test)
 }

--- a/tests/integration/explain/default/utils.go
+++ b/tests/integration/explain/default/utils.go
@@ -13,7 +13,6 @@ package test_explain_default
 import (
 	"testing"
 
-	testUtils "github.com/sourcenetwork/defradb/tests/integration"
 	explainUtils "github.com/sourcenetwork/defradb/tests/integration/explain"
 )
 
@@ -57,16 +56,6 @@ var bookAuthorGQLSchema = (`
 
 `)
 
-// TODO: This should be resolved in ISSUE#953 (github.com/sourcenetwork/defradb).
-func executeTestCase(t *testing.T, test testUtils.RequestTestCase) {
-	testUtils.ExecuteRequestTestCase(
-		t,
-		bookAuthorGQLSchema,
-		[]string{"Article", "Book", "Author", "AuthorContact", "ContactAddress"},
-		test,
-	)
-}
-
 func runExplainTest(t *testing.T, test explainUtils.ExplainRequestTestCase) {
 	explainUtils.ExecuteExplainRequestTestCase(
 		t,
@@ -84,4 +73,13 @@ var basicPattern = dataMap{
 			},
 		},
 	},
+}
+
+var emptyChildSelectsAttributeForAuthor = dataMap{
+	"collectionName": "Author",
+	"docKeys":        nil,
+	"filter":         nil,
+	"groupBy":        nil,
+	"limit":          nil,
+	"orderBy":        nil,
 }


### PR DESCRIPTION
## Relevant issue(s)
- Part of #953
- Resolves #1536 

## Description
This PR is the last PR for default explain test conversions, this PR converts the remaining group tests.

- This PR converts all the default explain group tests.
- Separates some tests into their group child select cases.
- Added a few tests where there was a test gap.

Note: One more PR after this to convert the simple tests and then the integration to the new testing framework with the new explain testing setup can be done.