### PR TITLE
ci(i): Cleanup codecov config & enable annotations

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,40 +1,64 @@
 # Source Network's codecov configuration file.
 
+
 github_checks:
-  annotations: true
+  annotations: true # This won't work if patch is `false` or has flags.
+
 
 codecov:
-  require_ci_to_pass: yes
+  require_ci_to_pass: false
+  allow_pseudo_compare: true
+  allow_coverage_offsets: true
+
 
 coverage:
   precision: 2
-  round: down
-  range: 65...100
+  round: "nearest"
+  range: 60...90
 
   status:
-    # Learn more at https://docs.codecov.io/docs/commit-status
+
     project:
       default:
-        target: 50%
-        threshold: 0.05 # allow this much decrease on project
-        flags:
-          - unit
+        only_pulls: true        # Only post the status if the commits are on a pull request.
+        informational: true     # Don't fail codcov action because of project's coverage.
+        if_ci_failed: "error"   # Give an error if CI fails (eg. upload to codecov failed).
+        if_not_found: "failure" # Fail if no report for HEAD found.
 
-    # Disable patch as it is not correct and buggy.
-    # Folks over at amazon's aws and mozilla's firefox tv also did the same LOL:
-    #   - https://github.com/aws/amazon-vpc-cni-k8s/pull/1226/files
-    #   - https://github.com/mozilla-mobile/firefox-tv/pull/779/files
+    # Note: Patch is needed for github annotations.
     patch:
       default:
-        enabled: no
-        if_not_found: success
+        informational: true     # Don't fail codcov action because of patch's coverage.
+        if_ci_failed: "error"   # Give an error if CI fails (eg. upload to codecov failed).
+        if_not_found: "failure" # Fail if no report for HEAD found.
 
-    changes: false
+    # Detect indirect coverage changes.
+    changes:
+      default:
+        informational: true     # Don't fail codcov action because of indirect coverage changes.
+        if_ci_failed: "error"   # Give an error if CI fails (eg. upload to codecov failed).
+        if_not_found: "failure" # Fail if no report for HEAD found.
+
+
+parsers:
+  go:
+    partials_as_hits: false     # Don't treat partials as hits.
+
 
 comment:
-  layout: "reach, diff, files"
-  behavior: default # update if exists else create new
-  require_changes: true
+  # First the reach graph, then the diff, then the file changes.
+  layout: "newheader, reach, diff, flags, files, footer"
+
+  # Change old comment with new results.
+  behavior: "default"
+
+  # Post comment even if there were no changes.
+  require_changes: false
+
+  # Post comment even if no head or base found.
+  require_head: false
+  require_base: false
+
 
 ignore:
   - "tests"

--- a/.github/workflows/code-test-coverage.yml
+++ b/.github/workflows/code-test-coverage.yml
@@ -52,10 +52,11 @@ jobs:
           attempt_delay: 10000
           action: codecov/codecov-action@v3
           with: |
-            fail_ci_if_error: true
+            name: defradb-codecov
             files: ./coverage.txt
-            flags: defra-tests
-            name: codecov-umbrella
+            flags: all-tests
+            os: 'linux'
+            fail_ci_if_error: true
             verbose: true
 
       - name: Upload coverage to Codecov with token
@@ -65,10 +66,11 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           token: ${{ env.codecov_secret }}
-          fail_ci_if_error: true
+          name: defradb-codecov
           files: ./coverage.txt
-          flags: defra-tests
-          name: codecov-umbrella
+          flags: all-tests
+          os: 'linux'
+          fail_ci_if_error: true
           verbose: true
           # path_to_write_report: ./coverage/codecov_report.txt
           # directory: ./coverage/reports/

--- a/Makefile
+++ b/Makefile
@@ -195,10 +195,10 @@ test\:scripts:
 test\:coverage:
 	@$(MAKE) deps:coverage
 ifeq ($(path),)
-	go-acc ./... --output=coverage.txt --covermode=atomic -- -coverpkg=./...
+	go-acc ./... --output=coverage.txt --covermode=atomic -- -failfast -coverpkg=./...
 	@echo "Show coverage information for each function in ./..."
 else
-	go-acc $(path) --output=coverage.txt --covermode=atomic -- -coverpkg=$(path)
+	go-acc $(path) --output=coverage.txt --covermode=atomic -- -failfast -coverpkg=$(path)
 	@echo "Show coverage information for each function in" path=$(path)
 endif
 	go tool cover -func coverage.txt | grep total | awk '{print $$3}'


### PR DESCRIPTION
## Relevant issue(s)
Resolves #1548

## Description
- Clean up config file and use the newer style.
- Try out patch and github annotations (seems like they fixed the bugs).