### PR TITLE
feat: Track schema version history

### DIFF
--- a/core/key.go
+++ b/core/key.go
@@ -113,8 +113,8 @@ var _ Key = (*CollectionSchemaVersionKey)(nil)
 // If a SchemaHistoryKey does not exist for a given SchemaVersionID it means
 // that that SchemaVersionID is for the latest version.
 type SchemaHistoryKey struct {
-	SchemaID             string
-	PriorSchemaVersionId string
+	SchemaID                string
+	PreviousSchemaVersionId string
 }
 
 var _ Key = (*SchemaHistoryKey)(nil)
@@ -223,10 +223,10 @@ func NewCollectionSchemaVersionKey(schemaVersionId string) CollectionSchemaVersi
 	return CollectionSchemaVersionKey{SchemaVersionId: schemaVersionId}
 }
 
-func NewSchemaHistoryKey(schemaId string, priorSchemaVersionId string) SchemaHistoryKey {
+func NewSchemaHistoryKey(schemaId string, previousSchemaVersionId string) SchemaHistoryKey {
 	return SchemaHistoryKey{
-		SchemaID:             schemaId,
-		PriorSchemaVersionId: priorSchemaVersionId,
+		SchemaID:                schemaId,
+		PreviousSchemaVersionId: previousSchemaVersionId,
 	}
 }
 
@@ -428,8 +428,8 @@ func (k SchemaHistoryKey) ToString() string {
 		result = result + "/" + k.SchemaID
 	}
 
-	if k.PriorSchemaVersionId != "" {
-		result = result + "/" + k.PriorSchemaVersionId
+	if k.PreviousSchemaVersionId != "" {
+		result = result + "/" + k.PreviousSchemaVersionId
 	}
 
 	return result

--- a/core/key.go
+++ b/core/key.go
@@ -384,7 +384,7 @@ func (k CollectionSchemaKey) ToDS() ds.Key {
 }
 
 func (k CollectionSchemaVersionKey) ToString() string {
-	result := COLLECTION_SCHEMA_VERSION
+	result := COLLECTION_SCHEMA_VERSION + "/" + string(ValueKey)
 
 	if k.SchemaVersionId != "" {
 		result = result + "/" + k.SchemaVersionId

--- a/core/key.go
+++ b/core/key.go
@@ -41,13 +41,14 @@ const (
 )
 
 const (
-	COLLECTION                = "/collection/names"
-	COLLECTION_SCHEMA         = "/collection/schema"
-	COLLECTION_SCHEMA_VERSION = "/collection/version"
-	SEQ                       = "/seq"
-	PRIMARY_KEY               = "/pk"
-	REPLICATOR                = "/replicator/id"
-	P2P_COLLECTION            = "/p2p/collection"
+	COLLECTION                        = "/collection/names"
+	COLLECTION_SCHEMA                 = "/collection/schema"
+	COLLECTION_SCHEMA_VERSION         = "/collection/version/v"
+	COLLECTION_SCHEMA_VERSION_HISTORY = "/collection/version/h"
+	SEQ                               = "/seq"
+	PRIMARY_KEY                       = "/pk"
+	REPLICATOR                        = "/replicator/id"
+	P2P_COLLECTION                    = "/p2p/collection"
 )
 
 // Key is an interface that represents a key in the database.
@@ -404,7 +405,7 @@ func (k CollectionSchemaKey) ToDS() ds.Key {
 }
 
 func (k CollectionSchemaVersionKey) ToString() string {
-	result := COLLECTION_SCHEMA_VERSION + "/" + string(ValueKey)
+	result := COLLECTION_SCHEMA_VERSION
 
 	if k.SchemaVersionId != "" {
 		result = result + "/" + k.SchemaVersionId
@@ -422,7 +423,7 @@ func (k CollectionSchemaVersionKey) ToDS() ds.Key {
 }
 
 func (k SchemaHistoryKey) ToString() string {
-	result := COLLECTION_SCHEMA_VERSION + "/" + string(PriorityKey)
+	result := COLLECTION_SCHEMA_VERSION_HISTORY
 
 	if k.SchemaID != "" {
 		result = result + "/" + k.SchemaID

--- a/core/key.go
+++ b/core/key.go
@@ -106,6 +106,19 @@ type CollectionSchemaVersionKey struct {
 
 var _ Key = (*CollectionSchemaVersionKey)(nil)
 
+// SchemaHistoryKey holds the pathway through the schema version history for
+// any given schema.
+//
+// The keys point to the schema version id of the next version of the schema.
+// If a SchemaHistoryKey does not exist for a given SchemaVersionID it means
+// that that SchemaVersionID is for the latest version.
+type SchemaHistoryKey struct {
+	SchemaID             string
+	PriorSchemaVersionId string
+}
+
+var _ Key = (*SchemaHistoryKey)(nil)
+
 type P2PCollectionKey struct {
 	CollectionID string
 }
@@ -208,6 +221,13 @@ func NewCollectionSchemaKey(schemaId string) CollectionSchemaKey {
 
 func NewCollectionSchemaVersionKey(schemaVersionId string) CollectionSchemaVersionKey {
 	return CollectionSchemaVersionKey{SchemaVersionId: schemaVersionId}
+}
+
+func NewSchemaHistoryKey(schemaId string, priorSchemaVersionId string) SchemaHistoryKey {
+	return SchemaHistoryKey{
+		SchemaID:             schemaId,
+		PriorSchemaVersionId: priorSchemaVersionId,
+	}
 }
 
 func NewSequenceKey(name string) SequenceKey {
@@ -398,6 +418,28 @@ func (k CollectionSchemaVersionKey) Bytes() []byte {
 }
 
 func (k CollectionSchemaVersionKey) ToDS() ds.Key {
+	return ds.NewKey(k.ToString())
+}
+
+func (k SchemaHistoryKey) ToString() string {
+	result := COLLECTION_SCHEMA_VERSION + "/" + string(PriorityKey)
+
+	if k.SchemaID != "" {
+		result = result + "/" + k.SchemaID
+	}
+
+	if k.PriorSchemaVersionId != "" {
+		result = result + "/" + k.PriorSchemaVersionId
+	}
+
+	return result
+}
+
+func (k SchemaHistoryKey) Bytes() []byte {
+	return []byte(k.ToString())
+}
+
+func (k SchemaHistoryKey) ToDS() ds.Key {
 	return ds.NewKey(k.ToString())
 }
 

--- a/db/collection.go
+++ b/db/collection.go
@@ -236,6 +236,7 @@ func (db *db) updateCollection(
 	if err != nil {
 		return nil, err
 	}
+	priorSchemaVersionID := desc.Schema.VersionID
 	schemaVersionID := cid.String()
 	desc.Schema.VersionID = schemaVersionID
 
@@ -260,6 +261,12 @@ func (db *db) updateCollection(
 
 	collectionKey := core.NewCollectionKey(desc.Name)
 	err = txn.Systemstore().Put(ctx, collectionKey.ToDS(), []byte(schemaVersionID))
+	if err != nil {
+		return nil, err
+	}
+
+	schemaVersionHistoryKey := core.NewSchemaHistoryKey(desc.Schema.SchemaID, schemaVersionID)
+	err = txn.Systemstore().Put(ctx, schemaVersionHistoryKey.ToDS(), []byte(priorSchemaVersionID))
 	if err != nil {
 		return nil, err
 	}

--- a/db/collection.go
+++ b/db/collection.go
@@ -265,8 +265,8 @@ func (db *db) updateCollection(
 		return nil, err
 	}
 
-	schemaVersionHistoryKey := core.NewSchemaHistoryKey(desc.Schema.SchemaID, schemaVersionID)
-	err = txn.Systemstore().Put(ctx, schemaVersionHistoryKey.ToDS(), []byte(previousSchemaVersionID))
+	schemaVersionHistoryKey := core.NewSchemaHistoryKey(desc.Schema.SchemaID, previousSchemaVersionID)
+	err = txn.Systemstore().Put(ctx, schemaVersionHistoryKey.ToDS(), []byte(schemaVersionID))
 	if err != nil {
 		return nil, err
 	}

--- a/db/collection.go
+++ b/db/collection.go
@@ -236,7 +236,7 @@ func (db *db) updateCollection(
 	if err != nil {
 		return nil, err
 	}
-	priorSchemaVersionID := desc.Schema.VersionID
+	previousSchemaVersionID := desc.Schema.VersionID
 	schemaVersionID := cid.String()
 	desc.Schema.VersionID = schemaVersionID
 
@@ -266,7 +266,7 @@ func (db *db) updateCollection(
 	}
 
 	schemaVersionHistoryKey := core.NewSchemaHistoryKey(desc.Schema.SchemaID, schemaVersionID)
-	err = txn.Systemstore().Put(ctx, schemaVersionHistoryKey.ToDS(), []byte(priorSchemaVersionID))
+	err = txn.Systemstore().Put(ctx, schemaVersionHistoryKey.ToDS(), []byte(previousSchemaVersionID))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #1556

## Description

Tracks schema version history via dedicated index.

This is required by https://github.com/sourcenetwork/defradb/issues/1448 as the fetcher must know the path through the schema version history if migrating across multiple schema versions.  For example if a document is at schema version 1, and it needs to return it at schema version 3, it needs to know that it has to migrate to schema version 2 first.

The structure should allow for manual correction of divergent schemas, as the history can be overwritten with this change in a semi-destructive way.  Migrations will still work up from orphaned schema versions, but not down. This is an unlikely edge case, and I feel like this is a good compromise in the short-medium term, instead of over engineering to fully handle divergent schema migrations. 

~~I think I'm going to leave this as a draft for now, as I'd have to go out of my way (and add more features) in order to test this properly as it is internal only and the new keys are never read.  I would like feedback nowish though as the Defra-Len PR will be based off this work (and will properly test it).~~ I am now confident that this is required, and am looking to merge it. 

The change detector should hopefully fail, I wont fix (i.e. document) until shortly before merge. 