### PR TITLE
test: Rework transaction test framework capabilities

### DIFF
--- a/docs/data_format_changes/i1602-no-change-tests-updated.md
+++ b/docs/data_format_changes/i1602-no-change-tests-updated.md
@@ -1,0 +1,3 @@
+# Rework transaction test framework capabilities
+
+This is not a breaking change, a test was split, which caused the change detector test-case to change.

--- a/tests/integration/mutation/relation/create/with_txn_test.go
+++ b/tests/integration/mutation/relation/create/with_txn_test.go
@@ -13,8 +13,9 @@ package relation_create
 import (
 	"testing"
 
-	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	"github.com/sourcenetwork/immutable"
 
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
 	relationTests "github.com/sourcenetwork/defradb/tests/integration/mutation/relation"
 )
 
@@ -39,8 +40,8 @@ func TestTransactionalCreationAndLinkingOfRelationalDocumentsForward(t *testing.
 				}`,
 			},
 			// Create books related to publishers, and ensure they are correctly linked (in and out of transactions).
-			testUtils.TransactionRequest2{
-				TransactionID: 0,
+			testUtils.Request{
+				TransactionID: immutable.Some(0),
 				Request: `mutation {
 					create_Book(data: "{\"name\": \"Book By Website\",\"rating\": 4.0, \"publisher_id\": \"bae-0e7c3bb5-4917-5d98-9fcf-b9db369ea6e4\"}") {
 						_key
@@ -52,8 +53,8 @@ func TestTransactionalCreationAndLinkingOfRelationalDocumentsForward(t *testing.
 					},
 				},
 			},
-			testUtils.TransactionRequest2{
-				TransactionID: 1,
+			testUtils.Request{
+				TransactionID: immutable.Some(1),
 				Request: `mutation {
 					create_Book(data: "{\"name\": \"Book By Online\",\"rating\": 4.0, \"publisher_id\": \"bae-8a381044-9206-51e7-8bc8-dc683d5f2523\"}") {
 						_key
@@ -66,8 +67,8 @@ func TestTransactionalCreationAndLinkingOfRelationalDocumentsForward(t *testing.
 				},
 			},
 			// Assert publisher -> books direction within transaction 0.
-			testUtils.TransactionRequest2{
-				TransactionID: 0,
+			testUtils.Request{
+				TransactionID: immutable.Some(0),
 				Request: `query {
 					Publisher {
 						_key
@@ -96,8 +97,8 @@ func TestTransactionalCreationAndLinkingOfRelationalDocumentsForward(t *testing.
 				},
 			},
 			// Assert publisher -> books direction within transaction 1.
-			testUtils.TransactionRequest2{
-				TransactionID: 1,
+			testUtils.Request{
+				TransactionID: immutable.Some(1),
 				Request: `query {
 					Publisher {
 						_key
@@ -191,8 +192,8 @@ func TestTransactionalCreationAndLinkingOfRelationalDocumentsBackward(t *testing
 				}`,
 			},
 			// Create books related to publishers, and ensure they are correctly linked (in and out of transactions).
-			testUtils.TransactionRequest2{
-				TransactionID: 0,
+			testUtils.Request{
+				TransactionID: immutable.Some(0),
 				Request: `mutation {
 					create_Book(data: "{\"name\": \"Book By Website\",\"rating\": 4.0, \"publisher_id\": \"bae-0e7c3bb5-4917-5d98-9fcf-b9db369ea6e4\"}") {
 						_key
@@ -204,8 +205,8 @@ func TestTransactionalCreationAndLinkingOfRelationalDocumentsBackward(t *testing
 					},
 				},
 			},
-			testUtils.TransactionRequest2{
-				TransactionID: 1,
+			testUtils.Request{
+				TransactionID: immutable.Some(1),
 				Request: `mutation {
 					create_Book(data: "{\"name\": \"Book By Online\",\"rating\": 4.0, \"publisher_id\": \"bae-8a381044-9206-51e7-8bc8-dc683d5f2523\"}") {
 						_key
@@ -218,8 +219,8 @@ func TestTransactionalCreationAndLinkingOfRelationalDocumentsBackward(t *testing
 				},
 			},
 			// Assert publisher -> books direction within transaction 0.
-			testUtils.TransactionRequest2{
-				TransactionID: 0,
+			testUtils.Request{
+				TransactionID: immutable.Some(0),
 				Request: `query {
 					Book {
 						_key
@@ -242,8 +243,8 @@ func TestTransactionalCreationAndLinkingOfRelationalDocumentsBackward(t *testing
 				},
 			},
 			// Assert publisher -> books direction within transaction 1.
-			testUtils.TransactionRequest2{
-				TransactionID: 1,
+			testUtils.Request{
+				TransactionID: immutable.Some(1),
 				Request: `query {
 					Book {
 						_key

--- a/tests/integration/mutation/relation/delete/with_txn_test.go
+++ b/tests/integration/mutation/relation/delete/with_txn_test.go
@@ -13,8 +13,9 @@ package relation_delete
 import (
 	"testing"
 
-	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	"github.com/sourcenetwork/immutable"
 
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
 	relationTests "github.com/sourcenetwork/defradb/tests/integration/mutation/relation"
 )
 
@@ -41,9 +42,9 @@ func TestTxnDeletionOfRelatedDocFromPrimarySideForwardDirection(t *testing.T) {
 					"address": "Manning Publications"
 				}`,
 			},
-			testUtils.TransactionRequest2{
+			testUtils.Request{
 				// Delete a linked book that exists.
-				TransactionID: 0,
+				TransactionID: immutable.Some(0),
 				Request: `mutation {
 			        delete_Book(id: "bae-5b16ccd7-9cae-5145-a56c-03cfe7787722") {
 			            _key
@@ -107,9 +108,9 @@ func TestTxnDeletionOfRelatedDocFromPrimarySideBackwardDirection(t *testing.T) {
 					"address": "Manning Publications"
 				}`,
 			},
-			testUtils.TransactionRequest2{
+			testUtils.Request{
 				// Delete a linked book that exists.
-				TransactionID: 0,
+				TransactionID: immutable.Some(0),
 				Request: `mutation {
 			        delete_Book(id: "bae-5b16ccd7-9cae-5145-a56c-03cfe7787722") {
 			            _key
@@ -167,9 +168,9 @@ func TestATxnCanReadARecordThatIsDeletedInANonCommitedTxnForwardDirection(t *tes
 					"address": "Manning Publications"
 				}`,
 			},
-			testUtils.TransactionRequest2{
+			testUtils.Request{
 				// Delete a linked book that exists.
-				TransactionID: 0,
+				TransactionID: immutable.Some(0),
 				Request: `mutation {
 			        delete_Book(id: "bae-5b16ccd7-9cae-5145-a56c-03cfe7787722") {
 			            _key
@@ -181,9 +182,9 @@ func TestATxnCanReadARecordThatIsDeletedInANonCommitedTxnForwardDirection(t *tes
 					},
 				},
 			},
-			testUtils.TransactionRequest2{
+			testUtils.Request{
 				// Read the book (forward) that was deleted (in the non-commited transaction) in another transaction.
-				TransactionID: 1,
+				TransactionID: immutable.Some(1),
 				Request: `query {
 					Publisher {
 						_key
@@ -257,9 +258,9 @@ func TestATxnCanReadARecordThatIsDeletedInANonCommitedTxnBackwardDirection(t *te
 					"address": "Manning Publications"
 				}`,
 			},
-			testUtils.TransactionRequest2{
+			testUtils.Request{
 				// Delete a linked book that exists in transaction 0.
-				TransactionID: 0,
+				TransactionID: immutable.Some(0),
 				Request: `mutation {
 			        delete_Book(id: "bae-5b16ccd7-9cae-5145-a56c-03cfe7787722") {
 			            _key
@@ -271,9 +272,9 @@ func TestATxnCanReadARecordThatIsDeletedInANonCommitedTxnBackwardDirection(t *te
 					},
 				},
 			},
-			testUtils.TransactionRequest2{
+			testUtils.Request{
 				// Read the book (backwards) that was deleted (in the non-commited transaction) in another transaction.
-				TransactionID: 1,
+				TransactionID: immutable.Some(1),
 				Request: `query {
 					Book {
 						_key
@@ -341,10 +342,10 @@ func TestTxnDeletionOfRelatedDocFromNonPrimarySideForwardDirection(t *testing.T)
 					"address": "Manning Early Access Program (MEAP)"
 				}`,
 			},
-			testUtils.TransactionRequest2{
+			testUtils.Request{
 				// Delete a publisher and outside the transaction ensure it's linked
 				// book gets correctly unlinked too.
-				TransactionID: 0,
+				TransactionID: immutable.Some(0),
 				Request: `mutation {
 			        delete_Publisher(id: "bae-8a381044-9206-51e7-8bc8-dc683d5f2523") {
 			            _key
@@ -402,10 +403,10 @@ func TestTxnDeletionOfRelatedDocFromNonPrimarySideBackwardDirection(t *testing.T
 					"address": "Manning Early Access Program (MEAP)"
 				}`,
 			},
-			testUtils.TransactionRequest2{
+			testUtils.Request{
 				// Delete a publisher and outside the transaction ensure it's linked
 				// book gets correctly unlinked too.
-				TransactionID: 0,
+				TransactionID: immutable.Some(0),
 				Request: `mutation {
 			        delete_Publisher(id: "bae-8a381044-9206-51e7-8bc8-dc683d5f2523") {
 			            _key

--- a/tests/integration/mutation/simple/delete/multi_ids_test.go
+++ b/tests/integration/mutation/simple/delete/multi_ids_test.go
@@ -13,51 +13,64 @@ package delete
 import (
 	"testing"
 
+	"github.com/sourcenetwork/immutable"
+
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
 	simpleTests "github.com/sourcenetwork/defradb/tests/integration/mutation/simple"
 )
 
-func TestDeletionOfMultipleDocumentUsingMultipleKeys_Success(t *testing.T) {
-	tests := []testUtils.RequestTestCase{
-
-		{
-			Description: "Simple multi-key delete mutation with one key that exists.",
-			Docs: map[int][]string{
-				0: {
-					`{
-						"name": "Shahzad",
-						"age":  26,
-						"points": 48.48,
-						"verified": true
-					}`,
-				},
+func TestDeletionOfMultipleDocumentUsingMultipleKeysWhereOneExists(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "Simple multi-key delete mutation with one key that exists.",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type User {
+						name: String
+						age: Int
+						points: Float
+						verified: Boolean
+					}
+				`,
 			},
-			TransactionalRequests: []testUtils.TransactionRequest{
-				{
-					TransactionId: 0,
-					Request: `mutation {
-						delete_User(ids: ["bae-6a6482a8-24e1-5c73-a237-ca569e41507d"]) {
-							_key
-						}
-					}`,
-					Results: []map[string]any{
-						{
-							"_key": "bae-6a6482a8-24e1-5c73-a237-ca569e41507d",
-						},
+			testUtils.CreateDoc{
+				Doc: `{
+					"name": "Shahzad",
+					"age":  26,
+					"points": 48.48,
+					"verified": true
+				}`,
+			},
+			testUtils.Request{
+				TransactionID: immutable.Some(0),
+				Request: `mutation {
+					delete_User(ids: ["bae-6a6482a8-24e1-5c73-a237-ca569e41507d"]) {
+						_key
+					}
+				}`,
+				Results: []map[string]any{
+					{
+						"_key": "bae-6a6482a8-24e1-5c73-a237-ca569e41507d",
 					},
 				},
-				{
-					TransactionId: 0,
-					Request: `query {
-						User(dockeys: ["bae-6a6482a8-24e1-5c73-a237-ca569e41507d"]) {
-							_key
-						}
-					}`,
-					Results: []map[string]any{},
-				},
+			},
+			testUtils.Request{
+				TransactionID: immutable.Some(0),
+				Request: `query {
+					User(dockeys: ["bae-6a6482a8-24e1-5c73-a237-ca569e41507d"]) {
+						_key
+					}
+				}`,
+				Results: []map[string]any{},
 			},
 		},
+	}
 
+	testUtils.ExecuteTestCase(t, []string{"User"}, test)
+}
+
+func TestDeletionOfMultipleDocumentUsingMultipleKeys_Success(t *testing.T) {
+	tests := []testUtils.RequestTestCase{
 		{
 			Description: "Delete multiple documents that exist, when given multiple keys.",
 			Request: `mutation {

--- a/tests/integration/mutation/simple/delete/single_id_test.go
+++ b/tests/integration/mutation/simple/delete/single_id_test.go
@@ -13,53 +13,66 @@ package delete
 import (
 	"testing"
 
+	"github.com/sourcenetwork/immutable"
+
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
 	simpleTests "github.com/sourcenetwork/defradb/tests/integration/mutation/simple"
 )
 
-func TestDeletionOfADocumentUsingSingleKey_Success(t *testing.T) {
-	tests := []testUtils.RequestTestCase{
-
-		{
-			Description: "Simple delete mutation where one element exists.",
-			Docs: map[int][]string{
-				0: {
-					`{
-						"name": "Shahzad",
-						"age":  26,
-						"points": 48.5,
-						"verified": true
-					}`,
-				},
+func TestDeletionOfADocumentUsingSingleKeyWhereDocExists(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "Simple delete mutation where one element exists.",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type User {
+						name: String
+						age: Int
+						points: Float
+						verified: Boolean
+					}
+				`,
 			},
-			TransactionalRequests: []testUtils.TransactionRequest{
-				{
-					TransactionId: 0,
-					Request: `mutation {
-								delete_User(id: "bae-8ca944fd-260e-5a44-b88f-326d9faca810") {
-									_key
-								}
-							}`,
-					Results: []map[string]any{
-						{
-							"_key": "bae-8ca944fd-260e-5a44-b88f-326d9faca810",
-						},
+			testUtils.CreateDoc{
+				Doc: `{
+					"name": "Shahzad",
+					"age":  26,
+					"points": 48.5,
+					"verified": true
+				}`,
+			},
+			testUtils.Request{
+				TransactionID: immutable.Some(0),
+				Request: `mutation {
+							delete_User(id: "bae-8ca944fd-260e-5a44-b88f-326d9faca810") {
+								_key
+							}
+						}`,
+				Results: []map[string]any{
+					{
+						"_key": "bae-8ca944fd-260e-5a44-b88f-326d9faca810",
 					},
 				},
-				{
-					TransactionId: 0,
-					Request: `query {
-								User(dockey: "bae-8ca944fd-260e-5a44-b88f-326d9faca810") {
-									_key
-								}
-							}`,
+			},
+			testUtils.Request{
+				TransactionID: immutable.Some(0),
+				Request: `query {
+							User(dockey: "bae-8ca944fd-260e-5a44-b88f-326d9faca810") {
+								_key
+							}
+						}`,
 
-					// explicitly empty
-					Results: []map[string]any{},
-				},
+				// explicitly empty
+				Results: []map[string]any{},
 			},
 		},
+	}
 
+	testUtils.ExecuteTestCase(t, []string{"User"}, test)
+}
+
+func TestDeletionOfADocumentUsingSingleKey_Success(t *testing.T) {
+	tests := []testUtils.RequestTestCase{
 		{
 			Description: "Simple delete mutation with an aliased _key name.",
 			Docs: map[int][]string{

--- a/tests/integration/mutation/simple/mix/with_txn_test.go
+++ b/tests/integration/mutation/simple/mix/with_txn_test.go
@@ -13,17 +13,26 @@ package mix
 import (
 	"testing"
 
+	"github.com/sourcenetwork/immutable"
+
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
 	simpleTests "github.com/sourcenetwork/defradb/tests/integration/mutation/simple"
-	"github.com/sourcenetwork/immutable"
 )
 
 func TestMutationWithTxnDeletesUserGivenSameTransaction(t *testing.T) {
-	test := testUtils.RequestTestCase{
+	test := testUtils.TestCase{
 		Description: "Create followed by delete in same transaction",
-		TransactionalRequests: []testUtils.TransactionRequest{
-			{
-				TransactionId: 0,
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type User {
+						name: String
+						age: Int
+					}
+				`,
+			},
+			testUtils.Request{
+				TransactionID: immutable.Some(0),
 				Request: `mutation {
 					create_User(data: "{\"name\": \"John\",\"age\": 27}") {
 						_key
@@ -35,8 +44,8 @@ func TestMutationWithTxnDeletesUserGivenSameTransaction(t *testing.T) {
 					},
 				},
 			},
-			{
-				TransactionId: 0,
+			testUtils.Request{
+				TransactionID: immutable.Some(0),
 				Request: `mutation {
 					delete_User(id: "bae-88b63198-7d38-5714-a9ff-21ba46374fd1") {
 						_key
@@ -51,15 +60,23 @@ func TestMutationWithTxnDeletesUserGivenSameTransaction(t *testing.T) {
 		},
 	}
 
-	simpleTests.ExecuteTestCase(t, test)
+	testUtils.ExecuteTestCase(t, []string{"User"}, test)
 }
 
 func TestMutationWithTxnDoesNotDeletesUserGivenDifferentTransactions(t *testing.T) {
-	test := testUtils.RequestTestCase{
+	test := testUtils.TestCase{
 		Description: "Create followed by delete on 2nd transaction",
-		TransactionalRequests: []testUtils.TransactionRequest{
-			{
-				TransactionId: 0,
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type User {
+						name: String
+						age: Int
+					}
+				`,
+			},
+			testUtils.Request{
+				TransactionID: immutable.Some(0),
 				Request: `mutation {
 					create_User(data: "{\"name\": \"John\",\"age\": 27}") {
 						_key
@@ -71,8 +88,8 @@ func TestMutationWithTxnDoesNotDeletesUserGivenDifferentTransactions(t *testing.
 					},
 				},
 			},
-			{
-				TransactionId: 1,
+			testUtils.Request{
+				TransactionID: immutable.Some(1),
 				Request: `mutation {
 					delete_User(id: "bae-88b63198-7d38-5714-a9ff-21ba46374fd1") {
 						_key
@@ -80,8 +97,8 @@ func TestMutationWithTxnDoesNotDeletesUserGivenDifferentTransactions(t *testing.
 				}`,
 				Results: []map[string]any{},
 			},
-			{
-				TransactionId: 0,
+			testUtils.Request{
+				TransactionID: immutable.Some(0),
 				Request: `query {
 					User {
 						_key
@@ -97,8 +114,8 @@ func TestMutationWithTxnDoesNotDeletesUserGivenDifferentTransactions(t *testing.
 					},
 				},
 			},
-			{
-				TransactionId: 1,
+			testUtils.Request{
+				TransactionID: immutable.Some(1),
 				Request: `query {
 					User {
 						_key
@@ -111,23 +128,29 @@ func TestMutationWithTxnDoesNotDeletesUserGivenDifferentTransactions(t *testing.
 		},
 	}
 
-	simpleTests.ExecuteTestCase(t, test)
+	testUtils.ExecuteTestCase(t, []string{"User"}, test)
 }
 
 func TestMutationWithTxnDoesUpdateUserGivenSameTransactions(t *testing.T) {
-	test := testUtils.RequestTestCase{
+	test := testUtils.TestCase{
 		Description: "Update followed by read in same transaction",
-		Docs: map[int][]string{
-			0: {
-				`{
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type User {
+						name: String
+						age: Int
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
 					"name": "John",
 					"age": 27
 				}`,
 			},
-		},
-		TransactionalRequests: []testUtils.TransactionRequest{
-			{
-				TransactionId: 0,
+			testUtils.Request{
+				TransactionID: immutable.Some(0),
 				Request: `mutation {
 					update_User(data: "{\"age\": 28}") {
 						_key
@@ -139,8 +162,8 @@ func TestMutationWithTxnDoesUpdateUserGivenSameTransactions(t *testing.T) {
 					},
 				},
 			},
-			{
-				TransactionId: 0,
+			testUtils.Request{
+				TransactionID: immutable.Some(0),
 				Request: `query {
 					User {
 						_key
@@ -159,23 +182,29 @@ func TestMutationWithTxnDoesUpdateUserGivenSameTransactions(t *testing.T) {
 		},
 	}
 
-	simpleTests.ExecuteTestCase(t, test)
+	testUtils.ExecuteTestCase(t, []string{"User"}, test)
 }
 
 func TestMutationWithTxnDoesNotUpdateUserGivenDifferentTransactions(t *testing.T) {
-	test := testUtils.RequestTestCase{
+	test := testUtils.TestCase{
 		Description: "Update followed by read in different transaction",
-		Docs: map[int][]string{
-			0: {
-				`{
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type User {
+						name: String
+						age: Int
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
 					"name": "John",
 					"age": 27
 				}`,
 			},
-		},
-		TransactionalRequests: []testUtils.TransactionRequest{
-			{
-				TransactionId: 0,
+			testUtils.Request{
+				TransactionID: immutable.Some(0),
 				Request: `mutation {
 					update_User(data: "{\"age\": 28}") {
 						_key
@@ -191,8 +220,8 @@ func TestMutationWithTxnDoesNotUpdateUserGivenDifferentTransactions(t *testing.T
 					},
 				},
 			},
-			{
-				TransactionId: 1,
+			testUtils.Request{
+				TransactionID: immutable.Some(1),
 				Request: `query {
 					User {
 						_key
@@ -211,7 +240,7 @@ func TestMutationWithTxnDoesNotUpdateUserGivenDifferentTransactions(t *testing.T
 		},
 	}
 
-	simpleTests.ExecuteTestCase(t, test)
+	testUtils.ExecuteTestCase(t, []string{"User"}, test)
 }
 
 func TestMutationWithTxnDoesNotAllowUpdateInSecondTransactionUser(t *testing.T) {

--- a/tests/integration/mutation/simple/mix/with_txn_test.go
+++ b/tests/integration/mutation/simple/mix/with_txn_test.go
@@ -15,6 +15,7 @@ import (
 
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
 	simpleTests "github.com/sourcenetwork/defradb/tests/integration/mutation/simple"
+	"github.com/sourcenetwork/immutable"
 )
 
 func TestMutationWithTxnDeletesUserGivenSameTransaction(t *testing.T) {
@@ -224,8 +225,8 @@ func TestMutationWithTxnDoesNotAllowUpdateInSecondTransactionUser(t *testing.T) 
 					"age": 27
 				}`,
 			},
-			testUtils.TransactionRequest2{
-				TransactionID: 0,
+			testUtils.Request{
+				TransactionID: immutable.Some(0),
 				Request: `mutation {
 					update_User(data: "{\"age\": 28}") {
 						_key
@@ -241,8 +242,8 @@ func TestMutationWithTxnDoesNotAllowUpdateInSecondTransactionUser(t *testing.T) 
 					},
 				},
 			},
-			testUtils.TransactionRequest2{
-				TransactionID: 1,
+			testUtils.Request{
+				TransactionID: immutable.Some(1),
 				Request: `mutation {
 					update_User(data: "{\"age\": 29}") {
 						_key

--- a/tests/integration/test_case.go
+++ b/tests/integration/test_case.go
@@ -237,6 +237,9 @@ type Request struct {
 	// in which case the expected results must all match across all nodes.
 	NodeID immutable.Option[int]
 
+	// Used to identify the transaction for this to run against. Optional.
+	TransactionID immutable.Option[int]
+
 	// The request to execute.
 	Request string
 

--- a/tests/integration/test_case.go
+++ b/tests/integration/test_case.go
@@ -253,30 +253,6 @@ type Request struct {
 	ExpectedError string
 }
 
-// TransactionRequest2 represents a transactional request.
-//
-// A new transaction will be created for the first TransactionRequest2 of any given
-// TransactionId. TransactionRequest2s will be submitted to the database in the order
-// in which they are recieved (interleaving amongst other actions if provided), however
-// they will not be commited until a TransactionCommit of matching TransactionId is
-// provided.
-type TransactionRequest2 struct {
-	// Used to identify the transaction for this to run against.
-	TransactionID int
-
-	// The request to run against the transaction.
-	Request string
-
-	// The expected (data) results of the issued request.
-	Results []map[string]any
-
-	// Any error expected from the action. Optional.
-	//
-	// String can be a partial, and the test will pass if an error is returned that
-	// contains this string.
-	ExpectedError string
-}
-
 // TransactionCommit represents a commit request for a transaction of the given id.
 type TransactionCommit struct {
 	// Used to identify the transaction to commit.

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -14,26 +14,9 @@ import (
 	"testing"
 )
 
-// Represents a request assigned to a particular transaction.
-type TransactionRequest struct {
-	// Used to identify the transaction for this to run against (allows multiple
-	//  requtests to share a single transaction)
-	TransactionId int
-	// The request to run against the transaction
-	Request string
-	// The expected (data) results of the issued request
-	Results []map[string]any
-	// The expected error resulting from the issued request. Also checked against the txn commit.
-	ExpectedError string
-}
-
 type RequestTestCase struct {
 	Description string
 	Request     string
-
-	// A collection of requests that are tied to a specific transaction.
-	// These will be executed before `Request` (if specified), in the order that they are listed here.
-	TransactionalRequests []TransactionRequest
 
 	// docs is a map from Collection Index, to a list
 	// of docs in stringified JSON format
@@ -86,38 +69,6 @@ func ExecuteRequestTestCase(
 				)
 			}
 		}
-	}
-
-	for _, request := range test.TransactionalRequests {
-		actions = append(
-			actions,
-			TransactionRequest2{
-				TransactionID: request.TransactionId,
-				Request:       request.Request,
-				Results:       request.Results,
-				ExpectedError: request.ExpectedError,
-			},
-		)
-	}
-
-	// The old test framework commited all the transactions at the end
-	// so we can just lump these here, they must however be commited in
-	// the order in which they were first recieved.
-	txnIndexesCommited := map[int]struct{}{}
-	for _, request := range test.TransactionalRequests {
-		if _, alreadyCommited := txnIndexesCommited[request.TransactionId]; alreadyCommited {
-			// Only commit each transaction once.
-			continue
-		}
-
-		txnIndexesCommited[request.TransactionId] = struct{}{}
-		actions = append(
-			actions,
-			TransactionCommit{
-				TransactionID: request.TransactionId,
-				ExpectedError: request.ExpectedError,
-			},
-		)
 	}
 
 	if test.Request != "" {


### PR DESCRIPTION
## Relevant issue(s)

Resolves #1602

## Description

Instead of a dedicated txn action (like we currently have), we can instead follow a similar pattern to node ids where any action can specify a transaction id. I would like to use this on other actions, most immediately for Lens testing, although it will likely be very useful elsewhere too.
