### PR TITLE
fix: Change the WriteSyncer to use lock when piping

### DIFF
--- a/logging/logger.go
+++ b/logging/logger.go
@@ -253,7 +253,7 @@ func buildZapLogger(name string, config Config) (*zap.Logger, error) {
 			cfg.EncodeLevel = defaultConfig.EncoderConfig.EncodeLevel
 			return zapcore.NewCore(
 				zapcore.NewJSONEncoder(cfg),
-				zapcore.AddSync(config.pipe),
+				zapcore.Lock(zapcore.AddSync(config.pipe)),
 				zap.NewAtomicLevelAt(zapcore.Level(config.Level.LogLevel)),
 			)
 		}))


### PR DESCRIPTION
## Relevant issue(s)

Resolves #1607

## Description

This PR wraps the pipe WriteSyncer with a Lock so that is can be used concurrently.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

make test

Specify the platform(s) on which this was tested:
- MacOS
