### PR TITLE
feat: Allow relation alias on create and update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,6 +175,10 @@ endif
 test:
 	gotestsum --format pkgname -- $(DEFAULT_TEST_DIRECTORIES) $(TEST_FLAGS)
 
+.PHONY: test\:quick
+test\:quick:
+	gotestsum --format pkgname -- $(DEFAULT_TEST_DIRECTORIES)
+
 # Only build the tests (don't execute them).
 .PHONY: test\:build
 test\:build:

--- a/client/document.go
+++ b/client/document.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/fxamacker/cbor/v2"
 	"github.com/ipfs/go-cid"
+
 	"github.com/sourcenetwork/defradb/client/request"
 	ccid "github.com/sourcenetwork/defradb/core/cid"
 )
@@ -109,7 +110,10 @@ func NewDocFromMap(data map[string]any) (*Document, error) {
 
 	// if no key was specified, then we assume it doesn't exist and we generate, and set it.
 	if !hasKey {
-		doc.generateAndSetDocKey()
+		err = doc.generateAndSetDocKey()
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return doc, nil

--- a/client/document.go
+++ b/client/document.go
@@ -18,6 +18,7 @@ import (
 	"github.com/fxamacker/cbor/v2"
 	"github.com/ipfs/go-cid"
 	mh "github.com/multiformats/go-multihash"
+	"github.com/sourcenetwork/defradb/client/request"
 )
 
 // This is the main implementation starting point for accessing the internal Document API
@@ -502,7 +503,7 @@ func (doc *Document) remapAliasFields(fieldDescriptions []FieldDescription) (boo
 	foundAlias := false
 	for docField, docFieldValue := range doc.fields {
 		for _, fieldDescription := range fieldDescriptions {
-			maybeAliasField := docField + "_id"
+			maybeAliasField := docField + request.RelatedObjectID
 			if fieldDescription.Name == maybeAliasField {
 				foundAlias = true
 				doc.fields[maybeAliasField] = docFieldValue

--- a/client/document_test.go
+++ b/client/document_test.go
@@ -13,8 +13,7 @@ package client
 import (
 	"testing"
 
-	"github.com/ipfs/go-cid"
-	mh "github.com/multiformats/go-multihash"
+	ccid "github.com/sourcenetwork/defradb/core/cid"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -28,12 +27,7 @@ var (
 		}
 	}`)
 
-	pref = cid.Prefix{
-		Version:  1,
-		Codec:    cid.Raw,
-		MhType:   mh.SHA2_256,
-		MhLength: -1, // default length
-	}
+	pref = ccid.NewDefaultSHA256PrefixV1()
 )
 
 func TestNewFromJSON(t *testing.T) {

--- a/client/document_test.go
+++ b/client/document_test.go
@@ -13,8 +13,9 @@ package client
 import (
 	"testing"
 
-	ccid "github.com/sourcenetwork/defradb/core/cid"
 	"github.com/stretchr/testify/assert"
+
+	ccid "github.com/sourcenetwork/defradb/core/cid"
 )
 
 var (

--- a/client/errors.go
+++ b/client/errors.go
@@ -17,12 +17,11 @@ import (
 )
 
 const (
-	errFieldNotExist         string = "The given field does not exist"
-	errSelectOfNonGroupField string = "cannot select a non-group-by field at group-level"
-	errUnexpectedType        string = "unexpected type"
-	errParsingFailed         string = "failed to parse argument"
-	errUninitializeProperty  string = "invalid state, required property is uninitialized"
-	errMaxTxnRetries         string = "reached maximum transaction reties"
+	errFieldNotExist        string = "The given field does not exist"
+	errUnexpectedType       string = "unexpected type"
+	errParsingFailed        string = "failed to parse argument"
+	errUninitializeProperty string = "invalid state, required property is uninitialized"
+	errMaxTxnRetries        string = "reached maximum transaction reties"
 )
 
 // Errors returnable from this package.
@@ -30,21 +29,20 @@ const (
 // This list is incomplete and undefined errors may also be returned.
 // Errors returned from this package may be tested against these errors with errors.Is.
 var (
-	ErrFieldNotExist         = errors.New(errFieldNotExist)
-	ErrSelectOfNonGroupField = errors.New(errSelectOfNonGroupField)
-	ErrUnexpectedType        = errors.New(errUnexpectedType)
-	ErrParsingFailed         = errors.New(errParsingFailed)
-	ErrUninitializeProperty  = errors.New(errUninitializeProperty)
-	ErrFieldNotObject        = errors.New("trying to access field on a non object type")
-	ErrValueTypeMismatch     = errors.New("value does not match indicated type")
-	ErrIndexNotFound         = errors.New("no index found for given ID")
-	ErrDocumentNotFound      = errors.New("no document for the given key exists")
-	ErrInvalidUpdateTarget   = errors.New("the target document to update is of invalid type")
-	ErrInvalidUpdater        = errors.New("the updater of a document is of invalid type")
-	ErrInvalidDeleteTarget   = errors.New("the target document to delete is of invalid type")
-	ErrMalformedDocKey       = errors.New("malformed DocKey, missing either version or cid")
-	ErrInvalidDocKeyVersion  = errors.New("invalid DocKey version")
-	ErrMaxTxnRetries         = errors.New(errMaxTxnRetries)
+	ErrFieldNotExist        = errors.New(errFieldNotExist)
+	ErrUnexpectedType       = errors.New(errUnexpectedType)
+	ErrParsingFailed        = errors.New(errParsingFailed)
+	ErrUninitializeProperty = errors.New(errUninitializeProperty)
+	ErrFieldNotObject       = errors.New("trying to access field on a non object type")
+	ErrValueTypeMismatch    = errors.New("value does not match indicated type")
+	ErrIndexNotFound        = errors.New("no index found for given ID")
+	ErrDocumentNotFound     = errors.New("no document for the given key exists")
+	ErrInvalidUpdateTarget  = errors.New("the target document to update is of invalid type")
+	ErrInvalidUpdater       = errors.New("the updater of a document is of invalid type")
+	ErrInvalidDeleteTarget  = errors.New("the target document to delete is of invalid type")
+	ErrMalformedDocKey      = errors.New("malformed DocKey, missing either version or cid")
+	ErrInvalidDocKeyVersion = errors.New("invalid DocKey version")
+	ErrMaxTxnRetries        = errors.New(errMaxTxnRetries)
 )
 
 // NewErrFieldNotExist returns an error indicating that the given field does not exist.
@@ -56,12 +54,6 @@ func NewErrFieldNotExist(name string) error {
 // given location.
 func NewErrFieldIndexNotExist(index int) error {
 	return errors.New(errFieldNotExist, errors.NewKV("Index", index))
-}
-
-// NewErrSelectOfNonGroupField returns an error indicating that a non-group-by field
-// was selected at group-level.
-func NewErrSelectOfNonGroupField(name string) error {
-	return errors.New(errSelectOfNonGroupField, errors.NewKV("Field", name))
 }
 
 // NewErrUnexpectedType returns an error indicating that the given value is of an unexpected type.

--- a/client/request/errors.go
+++ b/client/request/errors.go
@@ -1,0 +1,33 @@
+// Copyright 2023 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package request
+
+import (
+	"github.com/sourcenetwork/defradb/errors"
+)
+
+const (
+	errSelectOfNonGroupField string = "cannot select a non-group-by field at group-level"
+)
+
+// Errors returnable from this package.
+//
+// This list is incomplete and undefined errors may also be returned.
+// Errors returned from this package may be tested against these errors with errors.Is.
+var (
+	ErrSelectOfNonGroupField = errors.New(errSelectOfNonGroupField)
+)
+
+// NewErrSelectOfNonGroupField returns an error indicating that a non-group-by field
+// was selected at group-level.
+func NewErrSelectOfNonGroupField(name string) error {
+	return errors.New(errSelectOfNonGroupField, errors.NewKV("Field", name))
+}

--- a/client/request/select.go
+++ b/client/request/select.go
@@ -12,8 +12,6 @@ package request
 
 import (
 	"github.com/sourcenetwork/immutable"
-
-	"github.com/sourcenetwork/defradb/client"
 )
 
 // SelectionType is the type of selection.
@@ -100,7 +98,7 @@ func (s *Select) validateGroupBy() []error {
 				}
 			}
 			if !fieldExistsInGroupBy && !isAliasFieldInGroupBy {
-				result = append(result, client.NewErrSelectOfNonGroupField(typedChildSelection.Name))
+				result = append(result, NewErrSelectOfNonGroupField(typedChildSelection.Name))
 			}
 		default:
 			// Do nothing

--- a/core/cid/cid.go
+++ b/core/cid/cid.go
@@ -8,22 +8,24 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-package core
+package cid
 
 import (
 	"github.com/ipfs/go-cid"
 	mh "github.com/multiformats/go-multihash"
 )
 
-// NewSHA256CidV1 returns a new CIDv1 with the SHA256 multihash.
-func NewSHA256CidV1(data []byte) (cid.Cid, error) {
-	pref := cid.Prefix{
+func NewDefaultSHA256PrefixV1() cid.Prefix {
+	return cid.Prefix{
 		Version:  1,
 		Codec:    cid.Raw,
 		MhType:   mh.SHA2_256,
 		MhLength: -1, // default length
 	}
+}
 
+// NewSHA256CidV1 returns a new CIDv1 with the SHA256 multihash.
+func NewSHA256CidV1(data []byte) (cid.Cid, error) {
 	// And then feed it some data
-	return pref.Sum(data)
+	return NewDefaultSHA256PrefixV1().Sum(data)
 }

--- a/datastore/blockstore_test.go
+++ b/datastore/blockstore_test.go
@@ -17,8 +17,9 @@ import (
 	blocks "github.com/ipfs/go-block-format"
 	"github.com/ipfs/go-cid"
 	ipld "github.com/ipfs/go-ipld-format"
-	ccid "github.com/sourcenetwork/defradb/core/cid"
 	"github.com/stretchr/testify/require"
+
+	ccid "github.com/sourcenetwork/defradb/core/cid"
 
 	"github.com/sourcenetwork/defradb/datastore/memory"
 )

--- a/datastore/blockstore_test.go
+++ b/datastore/blockstore_test.go
@@ -17,7 +17,7 @@ import (
 	blocks "github.com/ipfs/go-block-format"
 	"github.com/ipfs/go-cid"
 	ipld "github.com/ipfs/go-ipld-format"
-	mh "github.com/multiformats/go-multihash"
+	ccid "github.com/sourcenetwork/defradb/core/cid"
 	"github.com/stretchr/testify/require"
 
 	"github.com/sourcenetwork/defradb/datastore/memory"
@@ -28,20 +28,6 @@ var (
 	data2 = []byte("SourceHub")
 )
 
-// Adding this here to avoid circular dependency datastore->core->datastore.
-// The culprit is `core.Parser`.
-func newSHA256CidV1(data []byte) (cid.Cid, error) {
-	pref := cid.Prefix{
-		Version:  1,
-		Codec:    cid.Raw,
-		MhType:   mh.SHA2_256,
-		MhLength: -1, // default length
-	}
-
-	// And then feed it some data
-	return pref.Sum(data)
-}
-
 func TestBStoreGet(t *testing.T) {
 	ctx := context.Background()
 	rootstore := memory.NewDatastore(ctx)
@@ -51,7 +37,7 @@ func TestBStoreGet(t *testing.T) {
 		store: dsRW,
 	}
 
-	cID, err := newSHA256CidV1(data)
+	cID, err := ccid.NewSHA256CidV1(data)
 	require.NoError(t, err)
 	b, err := blocks.NewBlockWithCid(data, cID)
 	require.NoError(t, err)
@@ -73,7 +59,7 @@ func TestBStoreGetWithUndefinedCID(t *testing.T) {
 		store: dsRW,
 	}
 
-	cID, err := newSHA256CidV1(data)
+	cID, err := ccid.NewSHA256CidV1(data)
 	require.NoError(t, err)
 	b, err := blocks.NewBlockWithCid(data, cID)
 	require.NoError(t, err)
@@ -93,7 +79,7 @@ func TestBStoreGetWithStoreClosed(t *testing.T) {
 		store: dsRW,
 	}
 
-	cID, err := newSHA256CidV1(data)
+	cID, err := ccid.NewSHA256CidV1(data)
 	require.NoError(t, err)
 	b, err := blocks.NewBlockWithCid(data, cID)
 	require.NoError(t, err)
@@ -118,7 +104,7 @@ func TestBStoreGetWithReHash(t *testing.T) {
 
 	bs.HashOnRead(true)
 
-	cID, err := newSHA256CidV1(data)
+	cID, err := ccid.NewSHA256CidV1(data)
 	require.NoError(t, err)
 	b, err := blocks.NewBlockWithCid(data, cID)
 	require.NoError(t, err)
@@ -140,12 +126,12 @@ func TestPutMany(t *testing.T) {
 		store: dsRW,
 	}
 
-	cID, err := newSHA256CidV1(data)
+	cID, err := ccid.NewSHA256CidV1(data)
 	require.NoError(t, err)
 	b, err := blocks.NewBlockWithCid(data, cID)
 	require.NoError(t, err)
 
-	cID2, err := newSHA256CidV1(data2)
+	cID2, err := ccid.NewSHA256CidV1(data)
 	require.NoError(t, err)
 	b2, err := blocks.NewBlockWithCid(data2, cID2)
 	require.NoError(t, err)
@@ -163,7 +149,7 @@ func TestPutManyWithExists(t *testing.T) {
 		store: dsRW,
 	}
 
-	cID, err := newSHA256CidV1(data)
+	cID, err := ccid.NewSHA256CidV1(data)
 	require.NoError(t, err)
 	b, err := blocks.NewBlockWithCid(data, cID)
 	require.NoError(t, err)
@@ -171,7 +157,7 @@ func TestPutManyWithExists(t *testing.T) {
 	err = bs.Put(ctx, b)
 	require.NoError(t, err)
 
-	cID2, err := newSHA256CidV1(data2)
+	cID2, err := ccid.NewSHA256CidV1(data)
 	require.NoError(t, err)
 	b2, err := blocks.NewBlockWithCid(data2, cID2)
 	require.NoError(t, err)
@@ -189,12 +175,12 @@ func TestPutManyWithStoreClosed(t *testing.T) {
 		store: dsRW,
 	}
 
-	cID, err := newSHA256CidV1(data)
+	cID, err := ccid.NewSHA256CidV1(data)
 	require.NoError(t, err)
 	b, err := blocks.NewBlockWithCid(data, cID)
 	require.NoError(t, err)
 
-	cID2, err := newSHA256CidV1(data2)
+	cID2, err := ccid.NewSHA256CidV1(data2)
 	require.NoError(t, err)
 	b2, err := blocks.NewBlockWithCid(data2, cID2)
 	require.NoError(t, err)

--- a/db/collection.go
+++ b/db/collection.go
@@ -731,6 +731,11 @@ func (c *collection) getKeysFromDoc(
 }
 
 func (c *collection) create(ctx context.Context, txn datastore.Txn, doc *client.Document) error {
+	// This has to be done before dockey verification happens in the next step.
+	if err := doc.RemapAliasFieldsAndDockey(c.desc.Schema.Fields); err != nil {
+		return err
+	}
+
 	dockey, primaryKey, err := c.getKeysFromDoc(doc)
 	if err != nil {
 		return err
@@ -874,14 +879,7 @@ func (c *collection) save(
 		}
 
 		if val.IsDirty() {
-			fieldKey, isAliasKey, fieldExists := c.tryGetFieldKey(primaryKey, k)
-			// Overwrite the aliased key with the internal related object name.
-			if isAliasKey {
-				oldKey := k
-				k = oldKey + request.RelatedObjectID
-				doc.Fields()[k] = v
-				delete(doc.Fields(), oldKey)
-			}
+			fieldKey, fieldExists := c.tryGetFieldKey(primaryKey, k)
 
 			if !fieldExists {
 				return cid.Undef, client.NewErrFieldNotExist(k)
@@ -1191,40 +1189,32 @@ func (c *collection) getDSKeyFromDockey(docKey client.DocKey) core.DataStoreKey 
 	}
 }
 
-func (c *collection) tryGetFieldKey(key core.PrimaryDataStoreKey, fieldName string) (core.DataStoreKey, bool, bool) {
-	fieldId, isAliasKey, hasField := c.tryGetSchemaFieldID(fieldName)
+func (c *collection) tryGetFieldKey(key core.PrimaryDataStoreKey, fieldName string) (core.DataStoreKey, bool) {
+	fieldId, hasField := c.tryGetSchemaFieldID(fieldName)
 	if !hasField {
-		return core.DataStoreKey{}, false, false
+		return core.DataStoreKey{}, false
 	}
 
 	return core.DataStoreKey{
 		CollectionID: key.CollectionId,
 		DocKey:       key.DocKey,
 		FieldId:      strconv.FormatUint(uint64(fieldId), 10),
-	}, isAliasKey, true
+	}, true
 }
 
 // tryGetSchemaFieldID returns the FieldID of the given fieldName.
 // Will return false if the field is not found.
-func (c *collection) tryGetSchemaFieldID(fieldName string) (uint32, bool, bool) {
-	// Before comparing the name exactly, check if it is an alias, if it is then return the FieldID
-	// of the found alias field.
-	for _, field := range c.desc.Schema.Fields {
-		if field.Name == (fieldName + request.RelatedObjectID) {
-			return uint32(field.ID), true, true
-		}
-	}
-
+func (c *collection) tryGetSchemaFieldID(fieldName string) (uint32, bool) {
 	for _, field := range c.desc.Schema.Fields {
 		if field.Name == fieldName {
 			if field.IsObject() || field.IsObjectArray() {
 				// We do not wish to match navigational properties, only
 				// fields directly on the collection.
-				return uint32(0), false, false
+				return uint32(0), false
 			}
-			return uint32(field.ID), false, true
+			return uint32(field.ID), true
 		}
 	}
 
-	return uint32(0), false, false
+	return uint32(0), false
 }

--- a/db/collection.go
+++ b/db/collection.go
@@ -22,12 +22,12 @@ import (
 	ds "github.com/ipfs/go-datastore"
 	"github.com/ipfs/go-datastore/query"
 	ipld "github.com/ipfs/go-ipld-format"
-	mh "github.com/multiformats/go-multihash"
 	"github.com/sourcenetwork/immutable"
 
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/request"
 	"github.com/sourcenetwork/defradb/core"
+	ccid "github.com/sourcenetwork/defradb/core/cid"
 	"github.com/sourcenetwork/defradb/datastore"
 	"github.com/sourcenetwork/defradb/db/base"
 	"github.com/sourcenetwork/defradb/db/fetcher"
@@ -166,7 +166,7 @@ func (db *db) createCollection(
 	}
 
 	// add a reference to this DB by desc hash
-	cid, err := core.NewSHA256CidV1(globalSchemaBuf)
+	cid, err := ccid.NewSHA256CidV1(globalSchemaBuf)
 	if err != nil {
 		return nil, err
 	}
@@ -262,7 +262,7 @@ func (db *db) updateCollection(
 		return nil, err
 	}
 
-	cid, err := core.NewSHA256CidV1(globalSchemaBuf)
+	cid, err := ccid.NewSHA256CidV1(globalSchemaBuf)
 	if err != nil {
 		return nil, err
 	}
@@ -703,31 +703,17 @@ func (c *collection) CreateMany(ctx context.Context, docs []*client.Document) er
 func (c *collection) getKeysFromDoc(
 	doc *client.Document,
 ) (client.DocKey, core.PrimaryDataStoreKey, error) {
-	// DocKey verification
-	buf, err := doc.Bytes()
-	if err != nil {
-		return client.DocKey{}, core.PrimaryDataStoreKey{}, err
-	}
-	// @todo:  grab the cid Prefix from the DocKey internal CID if available
-	pref := cid.Prefix{
-		Version:  1,
-		Codec:    cid.Raw,
-		MhType:   mh.SHA2_256,
-		MhLength: -1, // default length
-	}
-	// And then feed it some data
-	doccid, err := pref.Sum(buf)
+	docKey, err := doc.GenerateDocKey()
 	if err != nil {
 		return client.DocKey{}, core.PrimaryDataStoreKey{}, err
 	}
 
-	dockey := client.NewDocKeyV0(doccid)
-	primaryKey := c.getPrimaryKeyFromDocKey(dockey)
+	primaryKey := c.getPrimaryKeyFromDocKey(docKey)
 	if primaryKey.DocKey != doc.Key().String() {
 		return client.DocKey{}, core.PrimaryDataStoreKey{},
 			NewErrDocVerification(doc.Key().String(), primaryKey.DocKey)
 	}
-	return dockey, primaryKey, nil
+	return docKey, primaryKey, nil
 }
 
 func (c *collection) create(ctx context.Context, txn datastore.Txn, doc *client.Document) error {

--- a/db/collection_update.go
+++ b/db/collection_update.go
@@ -305,9 +305,20 @@ func (c *collection) applyMerge(
 			return ErrInvalidMergeValueType
 		}
 
-		fd, valid := c.desc.Schema.GetField(mfield)
-		if !valid {
-			return client.NewErrFieldNotExist(mfield)
+		fd, isValidAliasField := c.desc.Schema.GetField(mfield + request.RelatedObjectID)
+		if isValidAliasField {
+			// Overwrite the key with aliased name to the internal related object name.
+			oldKey := mfield
+			mfield = mfield + request.RelatedObjectID
+			mergeMap[mfield] = mval
+			delete(mergeMap, oldKey)
+		} else {
+			var isValidField bool
+			fd, isValidField = c.desc.Schema.GetField(mfield)
+			if !isValidField {
+				return client.NewErrFieldNotExist(mfield)
+
+			}
 		}
 
 		relationFieldDescription, isSecondaryRelationID := c.isSecondaryIDField(fd)
@@ -493,7 +504,7 @@ func validateFieldSchema(val *fastjson.Value, field client.FieldDescription) (an
 		return getNillableArray(val, getInt64)
 
 	case client.FieldKind_FOREIGN_OBJECT, client.FieldKind_FOREIGN_OBJECT_ARRAY:
-		return nil, ErrMergeSubTypeNotSupported
+		return nil, NewErrFieldOrAliasToFieldNotExist(field.Name)
 	}
 
 	return nil, client.NewErrUnhandledType("FieldKind", field.Kind)

--- a/db/collection_update.go
+++ b/db/collection_update.go
@@ -334,7 +334,7 @@ func (c *collection) applyMerge(
 		mergeCBOR[mfield] = cborVal
 
 		val := client.NewCBORValue(fd.Typ, cborVal)
-		fieldKey, fieldExists := c.tryGetFieldKey(key, mfield)
+		fieldKey, _, fieldExists := c.tryGetFieldKey(key, mfield)
 		if !fieldExists {
 			return client.NewErrFieldNotExist(mfield)
 		}

--- a/db/collection_update.go
+++ b/db/collection_update.go
@@ -317,7 +317,6 @@ func (c *collection) applyMerge(
 			fd, isValidField = c.desc.Schema.GetField(mfield)
 			if !isValidField {
 				return client.NewErrFieldNotExist(mfield)
-
 			}
 		}
 

--- a/db/collection_update.go
+++ b/db/collection_update.go
@@ -334,7 +334,7 @@ func (c *collection) applyMerge(
 		mergeCBOR[mfield] = cborVal
 
 		val := client.NewCBORValue(fd.Typ, cborVal)
-		fieldKey, _, fieldExists := c.tryGetFieldKey(key, mfield)
+		fieldKey, fieldExists := c.tryGetFieldKey(key, mfield)
 		if !fieldExists {
 			return client.NewErrFieldNotExist(mfield)
 		}

--- a/db/errors.go
+++ b/db/errors.go
@@ -58,6 +58,7 @@ const (
 	errUnsupportedIndexFieldType      string = "unsupported index field type"
 	errIndexDescriptionHasNoFields    string = "index description has no fields"
 	errIndexDescHasNonExistingField   string = "index description has non existing field"
+	errFieldOrAliasToFieldNotExist    string = "The given field or alias to field does not exist"
 )
 
 var (
@@ -77,7 +78,6 @@ var (
 	)
 	ErrMissingDocFieldToUpdate        = errors.New("missing document field to update")
 	ErrDocMissingKey                  = errors.New("document is missing key")
-	ErrMergeSubTypeNotSupported       = errors.New("merge doesn't support sub types yet")
 	ErrInvalidFilter                  = errors.New("invalid filter")
 	ErrInvalidOpPath                  = errors.New("invalid patch op path")
 	ErrDocumentAlreadyExists          = errors.New(errDocumentAlreadyExists)
@@ -110,7 +110,13 @@ var (
 	ErrIndexFieldMissingDirection     = errors.New(errIndexFieldMissingDirection)
 	ErrIndexSingleFieldWrongDirection = errors.New(errIndexSingleFieldWrongDirection)
 	ErrCanNotChangeIndexWithPatch     = errors.New(errCanNotChangeIndexWithPatch)
+	ErrFieldOrAliasToFieldNotExist    = errors.New(errFieldOrAliasToFieldNotExist)
 )
+
+// NewErrFieldOrAliasToFieldNotExist returns an error indicating that the given field or an alias field does not exist.
+func NewErrFieldOrAliasToFieldNotExist(name string) error {
+	return errors.New(errFieldOrAliasToFieldNotExist, errors.NewKV("Name", name))
+}
 
 // NewErrFailedToGetHeads returns a new error indicating that the heads of a document
 // could not be obtained.

--- a/merkle/clock/clock_test.go
+++ b/merkle/clock/clock_test.go
@@ -16,9 +16,9 @@ import (
 
 	cid "github.com/ipfs/go-cid"
 	ds "github.com/ipfs/go-datastore"
-	mh "github.com/multiformats/go-multihash"
 
 	"github.com/sourcenetwork/defradb/core"
+	ccid "github.com/sourcenetwork/defradb/core/cid"
 	"github.com/sourcenetwork/defradb/core/crdt"
 	"github.com/sourcenetwork/defradb/datastore"
 )
@@ -79,15 +79,7 @@ func TestMerkleClockPutBlockWithHeads(t *testing.T) {
 	delta := &crdt.LWWRegDelta{
 		Data: []byte("test"),
 	}
-	pref := cid.Prefix{
-		Version:  1,
-		Codec:    cid.Raw,
-		MhType:   mh.SHA2_256,
-		MhLength: -1, // default length
-	}
-
-	// And then feed it some data
-	c, err := pref.Sum([]byte("Hello World!"))
+	c, err := ccid.NewSHA256CidV1([]byte("Hello World!"))
 	if err != nil {
 		t.Error("Failed to create new head CID:", err)
 		return

--- a/merkle/clock/heads_test.go
+++ b/merkle/clock/heads_test.go
@@ -20,26 +20,19 @@ import (
 	"testing"
 
 	"github.com/ipfs/go-cid"
-	mh "github.com/multiformats/go-multihash"
 
 	"github.com/sourcenetwork/defradb/core"
+	ccid "github.com/sourcenetwork/defradb/core/cid"
 	"github.com/sourcenetwork/defradb/datastore"
 )
 
 func newRandomCID() cid.Cid {
-	pref := cid.Prefix{
-		Version:  1,
-		Codec:    cid.Raw,
-		MhType:   mh.SHA2_256,
-		MhLength: -1, // default length
-	}
-
 	// And then feed it some data
 	bs := make([]byte, 4)
 	i := rand.Uint32()
 	binary.LittleEndian.PutUint32(bs, i)
 
-	c, err := pref.Sum(bs)
+	c, err := ccid.NewSHA256CidV1(bs)
 	if err != nil {
 		return cid.Undef
 	}

--- a/tests/integration/collection/create/one_to_many/simple_test.go
+++ b/tests/integration/collection/create/one_to_many/simple_test.go
@@ -20,7 +20,7 @@ import (
 	testUtils "github.com/sourcenetwork/defradb/tests/integration/collection"
 )
 
-func TestCreateSaveErrorsGivenValueInRelationField(t *testing.T) {
+func TestCreateSaveGivenAliasValueInRelationField(t *testing.T) {
 	doc, err := client.NewDocFromJSON(
 		[]byte(
 			`{
@@ -41,7 +41,6 @@ func TestCreateSaveErrorsGivenValueInRelationField(t *testing.T) {
 				},
 			},
 		},
-		ExpectedError: "The given field does not exist",
 	}
 
 	executeTestCase(t, test)

--- a/tests/integration/mutation/one_to_many/create/with_alias_test.go
+++ b/tests/integration/mutation/one_to_many/create/with_alias_test.go
@@ -1,0 +1,188 @@
+// Copyright 2023 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package create
+
+import (
+	"fmt"
+	"testing"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	fixture "github.com/sourcenetwork/defradb/tests/integration/mutation/one_to_many"
+)
+
+func TestMutationCreateOneToMany_AliasedRelationNameWithInvalidField_Error(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "One to many create mutation, with an invalid field, with alias.",
+		Actions: []any{
+			testUtils.Request{
+				Request: `mutation {
+					create_Book(data: "{\"notName\": \"Painted House\",\"author\": \"bae-fd541c25-229e-5280-b44b-e5c2af3e374d\"}") {
+						name
+					}
+				}`,
+				ExpectedError: "The given field does not exist. Name: notName",
+			},
+		},
+	}
+	fixture.ExecuteTestCase(t, test)
+}
+
+func TestMutationCreateOneToMany_AliasedRelationNameNonExistingRelationSingleSide_NoIDFieldError(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "One to many create mutation, non-existing id, from the single side, no id relation field, with alias.",
+		Actions: []any{
+			testUtils.Request{
+				Request: `mutation {
+					create_Author(data: "{\"name\": \"John Grisham\",\"published\": \"bae--b44b-e5c2af3e374d\"}") {
+						name
+					}
+				}`,
+				ExpectedError: "The given field does not exist. Name: published",
+			},
+		},
+	}
+	fixture.ExecuteTestCase(t, test)
+}
+
+// Note: This test should probably not pass, as it contains a
+// reference to a document that doesnt exist.
+func TestMutationCreateOneToMany_AliasedRelationNameNonExistingRelationManySide_CreatedDoc(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "One to many create mutation, non-existing id, from the many side, with alias",
+		Actions: []any{
+			testUtils.Request{
+				Request: `mutation {
+					create_Book(data: "{\"name\": \"Painted House\",\"author\": \"bae-fd541c25-229e-5280-b44b-e5c2af3e374d\"}") {
+						name
+					}
+				}`,
+				Results: []map[string]any{
+					{
+						"name": "Painted House",
+					},
+				},
+			},
+		},
+	}
+	fixture.ExecuteTestCase(t, test)
+}
+
+func TestMutationCreateOneToMany_AliasedRelationNamToLinkFromSingleSide_NoIDFieldError(t *testing.T) {
+	bookKey := "bae-3d236f89-6a31-5add-a36a-27971a2eac76"
+
+	test := testUtils.TestCase{
+		Description: "One to many create mutation with relation id from single side, with alias.",
+		Actions: []any{
+			testUtils.Request{
+				Request: `mutation {
+					create_Book(data: "{\"name\": \"Painted House\"}") {
+						_key
+					}
+				}`,
+				Results: []map[string]any{
+					{
+						"_key": bookKey,
+					},
+				},
+			},
+			testUtils.Request{
+				Request: fmt.Sprintf(
+					`mutation {
+						create_Author(data: "{\"name\": \"John Grisham\",\"published\": \"%s\"}") {
+							name
+						}
+					}`,
+					bookKey,
+				),
+				ExpectedError: "The given field does not exist. Name: published",
+			},
+		},
+	}
+
+	fixture.ExecuteTestCase(t, test)
+}
+
+func TestMutationCreateOneToMany_AliasedRelationNameToLinkFromManySide(t *testing.T) {
+	authorKey := "bae-2edb7fdd-cad7-5ad4-9c7d-6920245a96ed"
+
+	test := testUtils.TestCase{
+		Description: "One to many create mutation using relation id from many side, with alias.",
+		Actions: []any{
+			testUtils.Request{
+				Request: `mutation {
+					create_Author(data: "{\"name\": \"John Grisham\"}") {
+						_key
+					}
+				}`,
+				Results: []map[string]any{
+					{
+						"_key": authorKey,
+					},
+				},
+			},
+			testUtils.Request{
+				Request: fmt.Sprintf(
+					`mutation {
+						create_Book(data: "{\"name\": \"Painted House\",\"author\": \"%s\"}") {
+							name
+						}
+					}`,
+					authorKey,
+				),
+				Results: []map[string]any{
+					{
+						"name": "Painted House",
+					},
+				},
+			},
+			testUtils.Request{
+				Request: `query {
+					Author {
+						name
+						published {
+							name
+						}
+					}
+				}`,
+				Results: []map[string]any{
+					{
+						"name": "John Grisham",
+						"published": []map[string]any{
+							{
+								"name": "Painted House",
+							},
+						},
+					},
+				},
+			},
+			testUtils.Request{
+				Request: `query {
+					Book {
+						name
+						author {
+							name
+						}
+					}
+				}`,
+				Results: []map[string]any{
+					{
+						"name": "Painted House",
+						"author": map[string]any{
+							"name": "John Grisham",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	fixture.ExecuteTestCase(t, test)
+}

--- a/tests/integration/mutation/one_to_many/create/with_simple_test.go
+++ b/tests/integration/mutation/one_to_many/create/with_simple_test.go
@@ -1,0 +1,188 @@
+// Copyright 2022 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package create
+
+import (
+	"fmt"
+	"testing"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	fixture "github.com/sourcenetwork/defradb/tests/integration/mutation/one_to_many"
+)
+
+func TestMutationCreateOneToMany_WithInvalidField_Error(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "One to many create mutation, with an invalid field.",
+		Actions: []any{
+			testUtils.Request{
+				Request: `mutation {
+					create_Book(data: "{\"notName\": \"Painted House\",\"author_id\": \"bae-fd541c25-229e-5280-b44b-e5c2af3e374d\"}") {
+						name
+					}
+				}`,
+				ExpectedError: "The given field does not exist. Name: notName",
+			},
+		},
+	}
+	fixture.ExecuteTestCase(t, test)
+}
+
+func TestMutationCreateOneToMany_NonExistingRelationSingleSide_NoIDFieldError(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "One to many create mutation, non-existing id, from the single side, no id relation field.",
+		Actions: []any{
+			testUtils.Request{
+				Request: `mutation {
+					create_Author(data: "{\"name\": \"John Grisham\",\"published_id\": \"bae--b44b-e5c2af3e374d\"}") {
+						name
+					}
+				}`,
+				ExpectedError: "The given field does not exist. Name: published_id",
+			},
+		},
+	}
+	fixture.ExecuteTestCase(t, test)
+}
+
+// Note: This test should probably not pass, as it contains a
+// reference to a document that doesnt exist.
+func TestMutationCreateOneToMany_NonExistingRelationManySide_CreatedDoc(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "One to many create mutation, non-existing id, from the many side",
+		Actions: []any{
+			testUtils.Request{
+				Request: `mutation {
+					create_Book(data: "{\"name\": \"Painted House\",\"author_id\": \"bae-fd541c25-229e-5280-b44b-e5c2af3e374d\"}") {
+						name
+					}
+				}`,
+				Results: []map[string]any{
+					{
+						"name": "Painted House",
+					},
+				},
+			},
+		},
+	}
+	fixture.ExecuteTestCase(t, test)
+}
+
+func TestMutationCreateOneToMany_RelationIDToLinkFromSingleSide_NoIDFieldError(t *testing.T) {
+	bookKey := "bae-3d236f89-6a31-5add-a36a-27971a2eac76"
+
+	test := testUtils.TestCase{
+		Description: "One to many create mutation with relation id from single side.",
+		Actions: []any{
+			testUtils.Request{
+				Request: `mutation {
+					create_Book(data: "{\"name\": \"Painted House\"}") {
+						_key
+					}
+				}`,
+				Results: []map[string]any{
+					{
+						"_key": bookKey,
+					},
+				},
+			},
+			testUtils.Request{
+				Request: fmt.Sprintf(
+					`mutation {
+						create_Author(data: "{\"name\": \"John Grisham\",\"published_id\": \"%s\"}") {
+							name
+						}
+					}`,
+					bookKey,
+				),
+				ExpectedError: "The given field does not exist. Name: published_id",
+			},
+		},
+	}
+
+	fixture.ExecuteTestCase(t, test)
+}
+
+func TestMutationCreateOneToMany_RelationIDToLinkFromManySide(t *testing.T) {
+	authorKey := "bae-2edb7fdd-cad7-5ad4-9c7d-6920245a96ed"
+
+	test := testUtils.TestCase{
+		Description: "One to many create mutation using relation id from many side",
+		Actions: []any{
+			testUtils.Request{
+				Request: `mutation {
+					create_Author(data: "{\"name\": \"John Grisham\"}") {
+						_key
+					}
+				}`,
+				Results: []map[string]any{
+					{
+						"_key": authorKey,
+					},
+				},
+			},
+			testUtils.Request{
+				Request: fmt.Sprintf(
+					`mutation {
+						create_Book(data: "{\"name\": \"Painted House\",\"author_id\": \"%s\"}") {
+							name
+						}
+					}`,
+					authorKey,
+				),
+				Results: []map[string]any{
+					{
+						"name": "Painted House",
+					},
+				},
+			},
+			testUtils.Request{
+				Request: `query {
+					Author {
+						name
+						published {
+							name
+						}
+					}
+				}`,
+				Results: []map[string]any{
+					{
+						"name": "John Grisham",
+						"published": []map[string]any{
+							{
+								"name": "Painted House",
+							},
+						},
+					},
+				},
+			},
+			testUtils.Request{
+				Request: `query {
+					Book {
+						name
+						author {
+							name
+						}
+					}
+				}`,
+				Results: []map[string]any{
+					{
+						"name": "Painted House",
+						"author": map[string]any{
+							"name": "John Grisham",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	fixture.ExecuteTestCase(t, test)
+}

--- a/tests/integration/mutation/one_to_many/delete/with_show_deleted_test.go
+++ b/tests/integration/mutation/one_to_many/delete/with_show_deleted_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/sourcenetwork/defradb/client"
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	fixture "github.com/sourcenetwork/defradb/tests/integration/mutation/one_to_many"
 )
 
 func TestDeletionOfADocumentUsingSingleKeyWithShowDeletedDocumentQuery(t *testing.T) {
@@ -45,22 +46,8 @@ func TestDeletionOfADocumentUsingSingleKeyWithShowDeletedDocumentQuery(t *testin
 	// require.NoError(t, err)
 
 	test := testUtils.TestCase{
+		Description: "One to many delete document using single key show deleted.",
 		Actions: []any{
-			testUtils.SchemaUpdate{
-				Schema: `
-				type Book {
-					name: String
-					rating: Float
-					author: Author
-				}
-
-				type Author {
-					name: String
-					age: Int
-					published: [Book]
-				}
-				`,
-			},
 			testUtils.CreateDoc{
 				CollectionID: 1,
 				Doc:          jsonString1,
@@ -121,5 +108,6 @@ func TestDeletionOfADocumentUsingSingleKeyWithShowDeletedDocumentQuery(t *testin
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Book", "Author"}, test)
+	fixture.ExecuteTestCase(t, test)
+
 }

--- a/tests/integration/mutation/one_to_many/delete/with_show_deleted_test.go
+++ b/tests/integration/mutation/one_to_many/delete/with_show_deleted_test.go
@@ -109,5 +109,4 @@ func TestDeletionOfADocumentUsingSingleKeyWithShowDeletedDocumentQuery(t *testin
 	}
 
 	fixture.ExecuteTestCase(t, test)
-
 }

--- a/tests/integration/mutation/one_to_many/update/related_object_link_test.go
+++ b/tests/integration/mutation/one_to_many/update/related_object_link_test.go
@@ -1,0 +1,359 @@
+// Copyright 2023 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package update
+
+import (
+	"fmt"
+	"testing"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	fixture "github.com/sourcenetwork/defradb/tests/integration/mutation/one_to_many"
+)
+
+func TestMutationUpdateOneToMany_RelationIDToLinkFromSingleSide_Error(t *testing.T) {
+	author1Key := "bae-2edb7fdd-cad7-5ad4-9c7d-6920245a96ed"
+	author2Key := "bae-35953caf-4898-518d-9e6b-9ce6cd86ebe5"
+	bookKey := "bae-22e0a1c2-d12b-5bfd-b039-0cf72f963991"
+
+	test := testUtils.TestCase{
+		Description: "One to many update mutation using relation id from single side (wrong)",
+		Actions: []any{
+			testUtils.Request{
+				Request: `mutation {
+ 					create_Author(data: "{\"name\": \"John Grisham\"}") {
+ 						_key
+ 					}
+ 				}`,
+				Results: []map[string]any{
+					{
+						"_key": author1Key,
+					},
+				},
+			},
+			testUtils.Request{
+				Request: `mutation {
+ 					create_Author(data: "{\"name\": \"New Shahzad\"}") {
+ 						_key
+ 					}
+ 				}`,
+				Results: []map[string]any{
+					{
+						"_key": author2Key,
+					},
+				},
+			},
+			testUtils.Request{
+				Request: fmt.Sprintf(
+					`mutation {
+ 						create_Book(data: "{\"name\": \"Painted House\",\"author_id\": \"%s\"}") {
+ 							_key
+ 							name
+ 						}
+ 					}`,
+					author1Key,
+				),
+				Results: []map[string]any{
+					{
+						"_key": bookKey,
+						"name": "Painted House",
+					},
+				},
+			},
+			testUtils.Request{ // NOTE: There is no `published_id` on book.
+				Request: fmt.Sprintf(
+					`mutation {
+ 						update_Author(id: "%s", data: "{\"published_id\": \"%s\"}") {
+ 							name
+ 						}
+ 					}`,
+					author2Key,
+					bookKey,
+				),
+				ExpectedError: "The given field does not exist. Name: published_id",
+			},
+		},
+	}
+
+	fixture.ExecuteTestCase(t, test)
+}
+
+// Note: This test should probably not pass, as it contains a
+// reference to a document that doesnt exist.
+func TestMutationUpdateOneToMany_InvalidRelationIDToLinkFromManySide(t *testing.T) {
+	author1Key := "bae-2edb7fdd-cad7-5ad4-9c7d-6920245a96ed"
+	invalidAuthorKey := "bae-35953ca-518d-9e6b-9ce6cd00eff5"
+	bookKey := "bae-22e0a1c2-d12b-5bfd-b039-0cf72f963991"
+
+	test := testUtils.TestCase{
+		Description: "One to many update mutation using relation id from many side",
+		Actions: []any{
+			testUtils.Request{
+				Request: `mutation {
+ 					create_Author(data: "{\"name\": \"John Grisham\"}") {
+ 						_key
+ 					}
+ 				}`,
+				Results: []map[string]any{
+					{
+						"_key": author1Key,
+					},
+				},
+			},
+			testUtils.Request{
+				Request: fmt.Sprintf(
+					`mutation {
+ 						create_Book(data: "{\"name\": \"Painted House\",\"author_id\": \"%s\"}") {
+ 							_key
+ 							name
+ 						}
+ 					}`,
+					author1Key,
+				),
+				Results: []map[string]any{
+					{
+						"_key": bookKey,
+						"name": "Painted House",
+					},
+				},
+			},
+			testUtils.Request{
+				Request: fmt.Sprintf(
+					`mutation {
+ 						update_Book(id: "%s", data: "{\"author_id\": \"%s\"}") {
+ 							name
+ 						}
+ 					}`,
+					bookKey,
+					invalidAuthorKey,
+				),
+				Results: []map[string]any{
+					{
+						"name": "Painted House",
+					},
+				},
+			},
+			testUtils.Request{
+				Request: `query {
+ 					Author {
+ 						name
+ 						published {
+ 							name
+ 						}
+ 					}
+ 				}`,
+				Results: []map[string]any{
+					{
+						"name":      "John Grisham",
+						"published": []map[string]any{},
+					},
+				},
+			},
+			testUtils.Request{
+				Request: `query {
+					Book {
+						name
+						author {
+							name
+						}
+					}
+				}`,
+				Results: []map[string]any{
+					{
+						"name":   "Painted House",
+						"author": nil, // Linked to incorrect id
+					},
+				},
+			},
+		},
+	}
+
+	fixture.ExecuteTestCase(t, test)
+}
+
+func TestMutationUpdateOneToMany_RelationIDToLinkFromManySideWithWrongField_Error(t *testing.T) {
+	author1Key := "bae-2edb7fdd-cad7-5ad4-9c7d-6920245a96ed"
+	author2Key := "bae-35953caf-4898-518d-9e6b-9ce6cd86ebe5"
+	bookKey := "bae-22e0a1c2-d12b-5bfd-b039-0cf72f963991"
+
+	test := testUtils.TestCase{
+		Description: "One to many update mutation using relation id from many side, with a wrong field.",
+		Actions: []any{
+			testUtils.Request{
+				Request: `mutation {
+ 					create_Author(data: "{\"name\": \"John Grisham\"}") {
+ 						_key
+ 					}
+ 				}`,
+				Results: []map[string]any{
+					{
+						"_key": author1Key,
+					},
+				},
+			},
+			testUtils.Request{
+				Request: `mutation {
+ 					create_Author(data: "{\"name\": \"New Shahzad\"}") {
+ 						_key
+ 					}
+ 				}`,
+				Results: []map[string]any{
+					{
+						"_key": author2Key,
+					},
+				},
+			},
+			testUtils.Request{
+				Request: fmt.Sprintf(
+					`mutation {
+ 						create_Book(data: "{\"name\": \"Painted House\",\"author_id\": \"%s\"}") {
+ 							_key
+ 							name
+ 						}
+ 					}`,
+					author1Key,
+				),
+				Results: []map[string]any{
+					{
+						"_key": bookKey,
+						"name": "Painted House",
+					},
+				},
+			},
+			testUtils.Request{
+				Request: fmt.Sprintf(
+					`mutation {
+ 						update_Book(id: "%s", data: "{\"notName\": \"Unpainted Condo\",\"author_id\": \"%s\"}") {
+ 							name
+ 						}
+ 					}`,
+					bookKey,
+					author2Key,
+				),
+				ExpectedError: "The given field does not exist. Name: notName",
+			},
+		},
+	}
+
+	fixture.ExecuteTestCase(t, test)
+}
+
+func TestMutationUpdateOneToMany_RelationIDToLinkFromManySide(t *testing.T) {
+	author1Key := "bae-2edb7fdd-cad7-5ad4-9c7d-6920245a96ed"
+	author2Key := "bae-35953caf-4898-518d-9e6b-9ce6cd86ebe5"
+	bookKey := "bae-22e0a1c2-d12b-5bfd-b039-0cf72f963991"
+
+	test := testUtils.TestCase{
+		Description: "One to many update mutation using relation id from many side",
+		Actions: []any{
+			testUtils.Request{
+				Request: `mutation {
+ 					create_Author(data: "{\"name\": \"John Grisham\"}") {
+ 						_key
+ 					}
+ 				}`,
+				Results: []map[string]any{
+					{
+						"_key": author1Key,
+					},
+				},
+			},
+			testUtils.Request{
+				Request: `mutation {
+ 					create_Author(data: "{\"name\": \"New Shahzad\"}") {
+ 						_key
+ 					}
+ 				}`,
+				Results: []map[string]any{
+					{
+						"_key": author2Key,
+					},
+				},
+			},
+			testUtils.Request{
+				Request: fmt.Sprintf(
+					`mutation {
+ 						create_Book(data: "{\"name\": \"Painted House\",\"author_id\": \"%s\"}") {
+ 							_key
+ 							name
+ 						}
+ 					}`,
+					author1Key,
+				),
+				Results: []map[string]any{
+					{
+						"_key": bookKey,
+						"name": "Painted House",
+					},
+				},
+			},
+			testUtils.Request{
+				Request: fmt.Sprintf(
+					`mutation {
+ 						update_Book(id: "%s", data: "{\"author_id\": \"%s\"}") {
+ 							name
+ 						}
+ 					}`,
+					bookKey,
+					author2Key,
+				),
+				Results: []map[string]any{
+					{
+						"name": "Painted House",
+					},
+				},
+			},
+			testUtils.Request{
+				Request: `query {
+ 					Author {
+ 						name
+ 						published {
+ 							name
+ 						}
+ 					}
+ 				}`,
+				Results: []map[string]any{
+					{
+						"name":      "John Grisham",
+						"published": []map[string]any{},
+					},
+					{
+						"name": "New Shahzad",
+						"published": []map[string]any{
+							{
+								"name": "Painted House",
+							},
+						},
+					},
+				},
+			},
+			testUtils.Request{
+				Request: `query {
+					Book {
+						name
+						author {
+							name
+						}
+					}
+				}`,
+				Results: []map[string]any{
+					{
+						"name": "Painted House",
+						"author": map[string]any{
+							"name": "New Shahzad",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	fixture.ExecuteTestCase(t, test)
+}

--- a/tests/integration/mutation/one_to_many/update/related_object_link_with_alias_test.go
+++ b/tests/integration/mutation/one_to_many/update/related_object_link_with_alias_test.go
@@ -1,0 +1,359 @@
+// Copyright 2023 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package update
+
+import (
+	"fmt"
+	"testing"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	fixture "github.com/sourcenetwork/defradb/tests/integration/mutation/one_to_many"
+)
+
+func TestMutationUpdateOneToMany_AliasRelationNameToLinkFromSingleSide_Error(t *testing.T) {
+	author1Key := "bae-2edb7fdd-cad7-5ad4-9c7d-6920245a96ed"
+	author2Key := "bae-35953caf-4898-518d-9e6b-9ce6cd86ebe5"
+	bookKey := "bae-22e0a1c2-d12b-5bfd-b039-0cf72f963991"
+
+	test := testUtils.TestCase{
+		Description: "One to many update mutation using relation alias name from single side (wrong)",
+		Actions: []any{
+			testUtils.Request{
+				Request: `mutation {
+ 					create_Author(data: "{\"name\": \"John Grisham\"}") {
+ 						_key
+ 					}
+ 				}`,
+				Results: []map[string]any{
+					{
+						"_key": author1Key,
+					},
+				},
+			},
+			testUtils.Request{
+				Request: `mutation {
+ 					create_Author(data: "{\"name\": \"New Shahzad\"}") {
+ 						_key
+ 					}
+ 				}`,
+				Results: []map[string]any{
+					{
+						"_key": author2Key,
+					},
+				},
+			},
+			testUtils.Request{
+				Request: fmt.Sprintf(
+					`mutation {
+ 						create_Book(data: "{\"name\": \"Painted House\",\"author\": \"%s\"}") {
+ 							_key
+ 							name
+ 						}
+ 					}`,
+					author1Key,
+				),
+				Results: []map[string]any{
+					{
+						"_key": bookKey,
+						"name": "Painted House",
+					},
+				},
+			},
+			testUtils.Request{ // NOTE: There is no `published_id` and so `published` alias is invalid use on book.
+				Request: fmt.Sprintf(
+					`mutation {
+ 						update_Author(id: "%s", data: "{\"published\": \"%s\"}") {
+ 							name
+ 						}
+ 					}`,
+					author2Key,
+					bookKey,
+				),
+				ExpectedError: "The given field or alias to field does not exist. Name: published",
+			},
+		},
+	}
+
+	fixture.ExecuteTestCase(t, test)
+}
+
+// Note: This test should probably not pass, as it contains a
+// reference to a document that doesnt exist.
+func TestMutationUpdateOneToMany_InvalidAliasRelationNameToLinkFromManySide(t *testing.T) {
+	author1Key := "bae-2edb7fdd-cad7-5ad4-9c7d-6920245a96ed"
+	invalidAuthorKey := "bae-35953ca-518d-9e6b-9ce6cd00eff5"
+	bookKey := "bae-22e0a1c2-d12b-5bfd-b039-0cf72f963991"
+
+	test := testUtils.TestCase{
+		Description: "One to many update mutation using relation alias name from many side",
+		Actions: []any{
+			testUtils.Request{
+				Request: `mutation {
+ 					create_Author(data: "{\"name\": \"John Grisham\"}") {
+ 						_key
+ 					}
+ 				}`,
+				Results: []map[string]any{
+					{
+						"_key": author1Key,
+					},
+				},
+			},
+			testUtils.Request{
+				Request: fmt.Sprintf(
+					`mutation {
+ 						create_Book(data: "{\"name\": \"Painted House\",\"author\": \"%s\"}") {
+ 							_key
+ 							name
+ 						}
+ 					}`,
+					author1Key,
+				),
+				Results: []map[string]any{
+					{
+						"_key": bookKey,
+						"name": "Painted House",
+					},
+				},
+			},
+			testUtils.Request{
+				Request: fmt.Sprintf(
+					`mutation {
+ 						update_Book(id: "%s", data: "{\"author\": \"%s\"}") {
+ 							name
+ 						}
+ 					}`,
+					bookKey,
+					invalidAuthorKey,
+				),
+				Results: []map[string]any{
+					{
+						"name": "Painted House",
+					},
+				},
+			},
+			testUtils.Request{
+				Request: `query {
+ 					Author {
+ 						name
+ 						published {
+ 							name
+ 						}
+ 					}
+ 				}`,
+				Results: []map[string]any{
+					{
+						"name":      "John Grisham",
+						"published": []map[string]any{},
+					},
+				},
+			},
+			testUtils.Request{
+				Request: `query {
+					Book {
+						name
+						author {
+							name
+						}
+					}
+				}`,
+				Results: []map[string]any{
+					{
+						"name":   "Painted House",
+						"author": nil, // Linked to incorrect id
+					},
+				},
+			},
+		},
+	}
+
+	fixture.ExecuteTestCase(t, test)
+}
+
+func TestMutationUpdateOneToMany_AliasRelationNameToLinkFromManySideWithWrongField_Error(t *testing.T) {
+	author1Key := "bae-2edb7fdd-cad7-5ad4-9c7d-6920245a96ed"
+	author2Key := "bae-35953caf-4898-518d-9e6b-9ce6cd86ebe5"
+	bookKey := "bae-22e0a1c2-d12b-5bfd-b039-0cf72f963991"
+
+	test := testUtils.TestCase{
+		Description: "One to many update mutation using relation alias name from many side, with a wrong field.",
+		Actions: []any{
+			testUtils.Request{
+				Request: `mutation {
+ 					create_Author(data: "{\"name\": \"John Grisham\"}") {
+ 						_key
+ 					}
+ 				}`,
+				Results: []map[string]any{
+					{
+						"_key": author1Key,
+					},
+				},
+			},
+			testUtils.Request{
+				Request: `mutation {
+ 					create_Author(data: "{\"name\": \"New Shahzad\"}") {
+ 						_key
+ 					}
+ 				}`,
+				Results: []map[string]any{
+					{
+						"_key": author2Key,
+					},
+				},
+			},
+			testUtils.Request{
+				Request: fmt.Sprintf(
+					`mutation {
+ 						create_Book(data: "{\"name\": \"Painted House\",\"author\": \"%s\"}") {
+ 							_key
+ 							name
+ 						}
+ 					}`,
+					author1Key,
+				),
+				Results: []map[string]any{
+					{
+						"_key": bookKey,
+						"name": "Painted House",
+					},
+				},
+			},
+			testUtils.Request{
+				Request: fmt.Sprintf(
+					`mutation {
+ 						update_Book(id: "%s", data: "{\"notName\": \"Unpainted Condo\",\"author\": \"%s\"}") {
+ 							name
+ 						}
+ 					}`,
+					bookKey,
+					author2Key,
+				),
+				ExpectedError: "The given field does not exist. Name: notName",
+			},
+		},
+	}
+
+	fixture.ExecuteTestCase(t, test)
+}
+
+func TestMutationUpdateOneToMany_AliasRelationNameToLinkFromManySide(t *testing.T) {
+	author1Key := "bae-2edb7fdd-cad7-5ad4-9c7d-6920245a96ed"
+	author2Key := "bae-35953caf-4898-518d-9e6b-9ce6cd86ebe5"
+	bookKey := "bae-22e0a1c2-d12b-5bfd-b039-0cf72f963991"
+
+	test := testUtils.TestCase{
+		Description: "One to many update mutation using relation alias name from many side",
+		Actions: []any{
+			testUtils.Request{
+				Request: `mutation {
+ 					create_Author(data: "{\"name\": \"John Grisham\"}") {
+ 						_key
+ 					}
+ 				}`,
+				Results: []map[string]any{
+					{
+						"_key": author1Key,
+					},
+				},
+			},
+			testUtils.Request{
+				Request: `mutation {
+ 					create_Author(data: "{\"name\": \"New Shahzad\"}") {
+ 						_key
+ 					}
+ 				}`,
+				Results: []map[string]any{
+					{
+						"_key": author2Key,
+					},
+				},
+			},
+			testUtils.Request{
+				Request: fmt.Sprintf(
+					`mutation {
+ 						create_Book(data: "{\"name\": \"Painted House\",\"author\": \"%s\"}") {
+ 							_key
+ 							name
+ 						}
+ 					}`,
+					author1Key,
+				),
+				Results: []map[string]any{
+					{
+						"_key": bookKey,
+						"name": "Painted House",
+					},
+				},
+			},
+			testUtils.Request{
+				Request: fmt.Sprintf(
+					`mutation {
+ 						update_Book(id: "%s", data: "{\"author\": \"%s\"}") {
+ 							name
+ 						}
+ 					}`,
+					bookKey,
+					author2Key,
+				),
+				Results: []map[string]any{
+					{
+						"name": "Painted House",
+					},
+				},
+			},
+			testUtils.Request{
+				Request: `query {
+ 					Author {
+ 						name
+ 						published {
+ 							name
+ 						}
+ 					}
+ 				}`,
+				Results: []map[string]any{
+					{
+						"name":      "John Grisham",
+						"published": []map[string]any{},
+					},
+					{
+						"name": "New Shahzad",
+						"published": []map[string]any{
+							{
+								"name": "Painted House",
+							},
+						},
+					},
+				},
+			},
+			testUtils.Request{
+				Request: `query {
+					Book {
+						name
+						author {
+							name
+						}
+					}
+				}`,
+				Results: []map[string]any{
+					{
+						"name": "Painted House",
+						"author": map[string]any{
+							"name": "New Shahzad",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	fixture.ExecuteTestCase(t, test)
+}

--- a/tests/integration/mutation/one_to_many/utils.go
+++ b/tests/integration/mutation/one_to_many/utils.go
@@ -1,0 +1,47 @@
+// Copyright 2023 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package one_to_many
+
+import (
+	"testing"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+func ExecuteTestCase(t *testing.T, test testUtils.TestCase) {
+	testUtils.ExecuteTestCase(
+		t,
+		[]string{"Book", "Author"},
+		testUtils.TestCase{
+			Description: test.Description,
+			Actions: append(
+				[]any{
+					testUtils.SchemaUpdate{
+						Schema: `
+							type Book {
+								name: String
+								rating: Float
+								author: Author
+							}
+
+							type Author {
+								name: String
+								age: Int
+								published: [Book]
+							}
+						`,
+					},
+				},
+				test.Actions...,
+			),
+		},
+	)
+}

--- a/tests/integration/mutation/one_to_one/create/with_alias_test.go
+++ b/tests/integration/mutation/one_to_one/create/with_alias_test.go
@@ -1,0 +1,226 @@
+// Copyright 2023 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package create
+
+import (
+	"fmt"
+	"testing"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	simpleTests "github.com/sourcenetwork/defradb/tests/integration/mutation/one_to_one"
+)
+
+func TestMutationCreateOneToOne_UseAliasWithInvalidField_Error(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "One to one create mutation, alias relation, with an invalid field.",
+		Actions: []any{
+			testUtils.Request{
+				Request: `mutation {
+					create_Author(data: "{\"notName\": \"John Grisham\",\"published\": \"bae-fd541c25-229e-5280-b44b-e5c2af3e374d\"}") {
+					name
+				}
+			}`,
+				ExpectedError: "The given field does not exist. Name: notName",
+			},
+		},
+	}
+	simpleTests.ExecuteTestCase(t, test)
+}
+
+// Note: This test should probably not pass, as it contains a
+// reference to a document that doesnt exist.
+func TestMutationCreateOneToOne_UseAliasWithNonExistingRelationPrimarySide_CreatedDoc(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "One to one create mutation, alias relation, from the wrong side",
+		Actions: []any{
+			testUtils.Request{
+				Request: `mutation {
+					create_Author(data: "{\"name\": \"John Grisham\",\"published\": \"bae-fd541c25-229e-5280-b44b-e5c2af3e374d\"}") {
+					name
+				}
+			}`,
+				Results: []map[string]any{
+					{
+						"name": "John Grisham",
+					},
+				},
+			},
+		},
+	}
+	simpleTests.ExecuteTestCase(t, test)
+}
+
+func TestMutationCreateOneToOne_UseAliasWithNonExistingRelationSecondarySide_Error(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "One to one create mutation, alias relation, from the secondary side",
+		Actions: []any{
+			testUtils.Request{
+				Request: `mutation {
+					create_Book(data: "{\"name\": \"Painted House\",\"author\": \"bae-fd541c25-229e-5280-b44b-e5c2af3e374d\"}") {
+						name
+					}
+				}`,
+				ExpectedError: "no document for the given key exists",
+			},
+		},
+	}
+	simpleTests.ExecuteTestCase(t, test)
+}
+
+func TestMutationCreateOneToOne_UseAliasedRelationNameToLink_QueryFromPrimarySide(t *testing.T) {
+	bookKey := "bae-3d236f89-6a31-5add-a36a-27971a2eac76"
+
+	test := testUtils.TestCase{
+		Description: "One to one create mutation with an alias relation.",
+		Actions: []any{
+			testUtils.Request{
+				Request: `mutation {
+					create_Book(data: "{\"name\": \"Painted House\"}") {
+						_key
+					}
+				}`,
+				Results: []map[string]any{
+					{
+						"_key": bookKey,
+					},
+				},
+			},
+			testUtils.Request{
+				Request: fmt.Sprintf(
+					`mutation {
+						create_Author(data: "{\"name\": \"John Grisham\",\"published\": \"%s\"}") {
+							name
+						}
+					}`,
+					bookKey,
+				),
+				Results: []map[string]any{
+					{
+						"name": "John Grisham",
+					},
+				},
+			},
+			testUtils.Request{
+				Request: `query {
+					Book {
+						name
+						author {
+							name
+						}
+					}
+				}`,
+				Results: []map[string]any{
+					{
+						"name": "Painted House",
+						"author": map[string]any{
+							"name": "John Grisham",
+						},
+					},
+				},
+			},
+			testUtils.Request{
+				Request: `query {
+					Author {
+						name
+						published {
+							name
+						}
+					}
+				}`,
+				Results: []map[string]any{
+					{
+						"name": "John Grisham",
+						"published": map[string]any{
+							"name": "Painted House",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	simpleTests.ExecuteTestCase(t, test)
+}
+
+func TestMutationCreateOneToOne_UseAliasedRelationNameToLink_QueryFromSecondarySide(t *testing.T) {
+	authorKey := "bae-2edb7fdd-cad7-5ad4-9c7d-6920245a96ed"
+
+	test := testUtils.TestCase{
+		Description: "One to one create mutation from secondary side with alias relation.",
+		Actions: []any{
+			testUtils.Request{
+				Request: `mutation {
+					create_Author(data: "{\"name\": \"John Grisham\"}") {
+						_key
+					}
+				}`,
+				Results: []map[string]any{
+					{
+						"_key": authorKey,
+					},
+				},
+			},
+			testUtils.Request{
+				Request: fmt.Sprintf(
+					`mutation {
+						create_Book(data: "{\"name\": \"Painted House\",\"author\": \"%s\"}") {
+							name
+						}
+					}`,
+					authorKey,
+				),
+				Results: []map[string]any{
+					{
+						"name": "Painted House",
+					},
+				},
+			},
+			testUtils.Request{
+				Request: `query {
+					Author {
+						name
+						published {
+							name
+						}
+					}
+				}`,
+				Results: []map[string]any{
+					{
+						"name": "John Grisham",
+						"published": map[string]any{
+							"name": "Painted House",
+						},
+					},
+				},
+			},
+			testUtils.Request{
+				Request: `query {
+					Book {
+						name
+						author {
+							name
+						}
+					}
+				}`,
+				Results: []map[string]any{
+					{
+						"name": "Painted House",
+						"author": map[string]any{
+							"name": "John Grisham",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	simpleTests.ExecuteTestCase(t, test)
+}

--- a/tests/integration/mutation/one_to_one/create/with_simple_test.go
+++ b/tests/integration/mutation/one_to_one/create/with_simple_test.go
@@ -18,6 +18,23 @@ import (
 	simpleTests "github.com/sourcenetwork/defradb/tests/integration/mutation/one_to_one"
 )
 
+func TestMutationCreateOneToOne_WithInvalidField_Error(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "One to one create mutation, with an invalid field.",
+		Actions: []any{
+			testUtils.Request{
+				Request: `mutation {
+					create_Author(data: "{\"notName\": \"John Grisham\",\"published_id\": \"bae-fd541c25-229e-5280-b44b-e5c2af3e374d\"}") {
+					name
+				}
+			}`,
+				ExpectedError: "The given field does not exist. Name: notName",
+			},
+		},
+	}
+	simpleTests.ExecuteTestCase(t, test)
+}
+
 // Note: This test should probably not pass, as it contains a
 // reference to a document that doesnt exist.
 func TestMutationCreateOneToOneNoChild(t *testing.T) {
@@ -35,6 +52,23 @@ func TestMutationCreateOneToOneNoChild(t *testing.T) {
 						"name": "John Grisham",
 					},
 				},
+			},
+		},
+	}
+	simpleTests.ExecuteTestCase(t, test)
+}
+
+func TestMutationCreateOneToOne_NonExistingRelationSecondarySide_Error(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "One to one create mutation, from the secondary side",
+		Actions: []any{
+			testUtils.Request{
+				Request: `mutation {
+					create_Book(data: "{\"name\": \"Painted House\",\"author_id\": \"bae-fd541c25-229e-5280-b44b-e5c2af3e374d\"}") {
+						name
+					}
+				}`,
+				ExpectedError: "no document for the given key exists",
 			},
 		},
 	}

--- a/tests/integration/mutation/one_to_one/update/related_object_link_test.go
+++ b/tests/integration/mutation/one_to_one/update/related_object_link_test.go
@@ -1,0 +1,437 @@
+// Copyright 2023 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// Copyright 2023 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package update
+
+import (
+	"fmt"
+	"testing"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	fixture "github.com/sourcenetwork/defradb/tests/integration/mutation/one_to_one"
+)
+
+// Note: This test should probably not pass, as even after updating a link to a new document
+// from one side the previous link still remains on the other side of the link.
+func TestMutationUpdateOneToOne_RelationIDToLinkFromPrimarySide(t *testing.T) {
+	author1Key := "bae-2edb7fdd-cad7-5ad4-9c7d-6920245a96ed"
+	author2Key := "bae-35953caf-4898-518d-9e6b-9ce6cd86ebe5"
+	bookKey := "bae-22e0a1c2-d12b-5bfd-b039-0cf72f963991"
+
+	test := testUtils.TestCase{
+		Description: "One to one update mutation using relation id from single side (wrong)",
+		Actions: []any{
+			testUtils.Request{
+				Request: `mutation {
+ 					create_Author(data: "{\"name\": \"John Grisham\"}") {
+ 						_key
+ 					}
+ 				}`,
+				Results: []map[string]any{
+					{
+						"_key": author1Key,
+					},
+				},
+			},
+			testUtils.Request{
+				Request: `mutation {
+ 					create_Author(data: "{\"name\": \"New Shahzad\"}") {
+ 						_key
+ 					}
+ 				}`,
+				Results: []map[string]any{
+					{
+						"_key": author2Key,
+					},
+				},
+			},
+			testUtils.Request{
+				Request: fmt.Sprintf(
+					`mutation {
+ 						create_Book(data: "{\"name\": \"Painted House\",\"author_id\": \"%s\"}") {
+ 							_key
+ 							name
+ 						}
+ 					}`,
+					author1Key,
+				),
+				Results: []map[string]any{
+					{
+						"_key": bookKey,
+						"name": "Painted House",
+					},
+				},
+			},
+			testUtils.Request{
+				Request: fmt.Sprintf(
+					`mutation {
+ 						update_Author(id: "%s", data: "{\"published_id\": \"%s\"}") {
+ 							name
+ 						}
+ 					}`,
+					author2Key,
+					bookKey,
+				),
+				Results: []map[string]any{
+					{
+						"name": "New Shahzad",
+					},
+				},
+			},
+			testUtils.Request{
+				Request: `query {
+ 					Author {
+ 						name
+ 						published {
+ 							name
+ 						}
+ 					}
+ 				}`,
+				Results: []map[string]any{
+					{
+						"name": "John Grisham",
+						"published": map[string]any{
+							"name": "Painted House",
+						},
+					},
+					{
+						"name": "New Shahzad",
+						"published": map[string]any{
+							"name": "Painted House",
+						},
+					},
+				},
+			},
+			testUtils.Request{
+				Request: `query {
+					Book {
+						name
+						author {
+							name
+						}
+					}
+				}`,
+				Results: []map[string]any{
+					{
+						"name": "Painted House",
+						"author": map[string]any{
+							"name": "John Grisham",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	fixture.ExecuteTestCase(t, test)
+}
+
+// Note: This test should probably not pass, as even after updating a link to a new document
+// from one side the previous link still remains on the other side of the link.
+func TestMutationUpdateOneToOne_RelationIDToLinkFromSecondarySide(t *testing.T) {
+	author1Key := "bae-2edb7fdd-cad7-5ad4-9c7d-6920245a96ed"
+	author2Key := "bae-35953caf-4898-518d-9e6b-9ce6cd86ebe5"
+	bookKey := "bae-22e0a1c2-d12b-5bfd-b039-0cf72f963991"
+
+	test := testUtils.TestCase{
+		Description: "One to one update mutation using relation id from secondary side",
+		Actions: []any{
+			testUtils.Request{
+				Request: `mutation {
+ 					create_Author(data: "{\"name\": \"John Grisham\"}") {
+ 						_key
+ 					}
+ 				}`,
+				Results: []map[string]any{
+					{
+						"_key": author1Key,
+					},
+				},
+			},
+			testUtils.Request{
+				Request: `mutation {
+ 					create_Author(data: "{\"name\": \"New Shahzad\"}") {
+ 						_key
+ 					}
+ 				}`,
+				Results: []map[string]any{
+					{
+						"_key": author2Key,
+					},
+				},
+			},
+			testUtils.Request{
+				Request: fmt.Sprintf(
+					`mutation {
+ 						create_Book(data: "{\"name\": \"Painted House\",\"author_id\": \"%s\"}") {
+ 							_key
+ 							name
+ 						}
+ 					}`,
+					author1Key,
+				),
+				Results: []map[string]any{
+					{
+						"_key": bookKey,
+						"name": "Painted House",
+					},
+				},
+			},
+			testUtils.Request{
+				Request: fmt.Sprintf(
+					`mutation {
+ 						update_Book(id: "%s", data: "{\"author_id\": \"%s\"}") {
+ 							name
+ 						}
+ 					}`,
+					bookKey,
+					author2Key,
+				),
+				Results: []map[string]any{
+					{
+						"name": "Painted House",
+					},
+				},
+			},
+			testUtils.Request{
+				Request: `query {
+ 					Author {
+ 						name
+ 						published {
+ 							name
+ 						}
+ 					}
+ 				}`,
+				Results: []map[string]any{
+					{
+						"name": "John Grisham",
+						"published": map[string]any{
+							"name": "Painted House",
+						},
+					},
+					{
+						"name": "New Shahzad",
+						"published": map[string]any{
+							"name": "Painted House",
+						},
+					},
+				},
+			},
+			testUtils.Request{
+				Request: `query {
+					Book {
+						name
+						author {
+							name
+						}
+					}
+				}`,
+				Results: []map[string]any{
+					{
+						"name": "Painted House",
+						"author": map[string]any{
+							"name": "John Grisham",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	fixture.ExecuteTestCase(t, test)
+}
+
+func TestMutationUpdateOneToOne_InvalidLengthRelationIDToLink_Error(t *testing.T) {
+	author1Key := "bae-2edb7fdd-cad7-5ad4-9c7d-6920245a96ed"
+	invalidLenSubKey := "35953ca-518d-9e6b-9ce6cd00eff5"
+	invalidAuthorKey := "bae-" + invalidLenSubKey
+	bookKey := "bae-22e0a1c2-d12b-5bfd-b039-0cf72f963991"
+
+	test := testUtils.TestCase{
+		Description: "One to one update mutation using invalid relation id",
+		Actions: []any{
+			testUtils.Request{
+				Request: `mutation {
+ 					create_Author(data: "{\"name\": \"John Grisham\"}") {
+ 						_key
+ 					}
+ 				}`,
+				Results: []map[string]any{
+					{
+						"_key": author1Key,
+					},
+				},
+			},
+			testUtils.Request{
+				Request: fmt.Sprintf(
+					`mutation {
+ 						create_Book(data: "{\"name\": \"Painted House\",\"author_id\": \"%s\"}") {
+ 							_key
+ 							name
+ 						}
+ 					}`,
+					author1Key,
+				),
+				Results: []map[string]any{
+					{
+						"_key": bookKey,
+						"name": "Painted House",
+					},
+				},
+			},
+			testUtils.Request{
+				Request: fmt.Sprintf(
+					`mutation {
+						update_Book(id: "%s", data: "{\"author_id\": \"%s\"}") {
+							name
+						}
+					}`,
+					bookKey,
+					invalidAuthorKey,
+				),
+				ExpectedError: "uuid: incorrect UUID length 30 in string \"" + invalidLenSubKey + "\"",
+			},
+		},
+	}
+
+	fixture.ExecuteTestCase(t, test)
+}
+
+func TestMutationUpdateOneToOne_InvalidRelationIDToLinkFromSecondarySide_Error(t *testing.T) {
+	author1Key := "bae-2edb7fdd-cad7-5ad4-9c7d-6920245a96ed"
+	invalidAuthorKey := "bae-2edb7fdd-cad7-5ad4-9c7d-6920245a96ee"
+	bookKey := "bae-22e0a1c2-d12b-5bfd-b039-0cf72f963991"
+
+	test := testUtils.TestCase{
+		Description: "One to one update mutation using relation id from secondary side",
+		Actions: []any{
+			testUtils.Request{
+				Request: `mutation {
+ 					create_Author(data: "{\"name\": \"John Grisham\"}") {
+ 						_key
+ 					}
+ 				}`,
+				Results: []map[string]any{
+					{
+						"_key": author1Key,
+					},
+				},
+			},
+			testUtils.Request{
+				Request: fmt.Sprintf(
+					`mutation {
+ 						create_Book(data: "{\"name\": \"Painted House\",\"author_id\": \"%s\"}") {
+ 							_key
+ 							name
+ 						}
+ 					}`,
+					author1Key,
+				),
+				Results: []map[string]any{
+					{
+						"_key": bookKey,
+						"name": "Painted House",
+					},
+				},
+			},
+			testUtils.Request{
+				Request: fmt.Sprintf(
+					`mutation {
+						update_Book(id: "%s", data: "{\"author_id\": \"%s\"}") {
+							name
+						}
+					}`,
+					bookKey,
+					invalidAuthorKey,
+				),
+				ExpectedError: "no document for the given key exists",
+			},
+		},
+	}
+
+	fixture.ExecuteTestCase(t, test)
+}
+
+func TestMutationUpdateOneToOne_RelationIDToLinkFromSecondarySideWithWrongField_Error(t *testing.T) {
+	author1Key := "bae-2edb7fdd-cad7-5ad4-9c7d-6920245a96ed"
+	author2Key := "bae-35953caf-4898-518d-9e6b-9ce6cd86ebe5"
+	bookKey := "bae-22e0a1c2-d12b-5bfd-b039-0cf72f963991"
+
+	test := testUtils.TestCase{
+		Description: "One to one update mutation using relation id from secondary side, with a wrong field.",
+		Actions: []any{
+			testUtils.Request{
+				Request: `mutation {
+ 					create_Author(data: "{\"name\": \"John Grisham\"}") {
+ 						_key
+ 					}
+ 				}`,
+				Results: []map[string]any{
+					{
+						"_key": author1Key,
+					},
+				},
+			},
+			testUtils.Request{
+				Request: `mutation {
+ 					create_Author(data: "{\"name\": \"New Shahzad\"}") {
+ 						_key
+ 					}
+ 				}`,
+				Results: []map[string]any{
+					{
+						"_key": author2Key,
+					},
+				},
+			},
+			testUtils.Request{
+				Request: fmt.Sprintf(
+					`mutation {
+ 						create_Book(data: "{\"name\": \"Painted House\",\"author_id\": \"%s\"}") {
+ 							_key
+ 							name
+ 						}
+ 					}`,
+					author1Key,
+				),
+				Results: []map[string]any{
+					{
+						"_key": bookKey,
+						"name": "Painted House",
+					},
+				},
+			},
+			testUtils.Request{
+				Request: fmt.Sprintf(
+					`mutation {
+ 						update_Book(id: "%s", data: "{\"notName\": \"Unpainted Condo\",\"author_id\": \"%s\"}") {
+ 							name
+ 						}
+ 					}`,
+					bookKey,
+					author2Key,
+				),
+				ExpectedError: "The given field does not exist. Name: notName",
+			},
+		},
+	}
+
+	fixture.ExecuteTestCase(t, test)
+}

--- a/tests/integration/mutation/one_to_one/update/related_object_link_with_alias_test.go
+++ b/tests/integration/mutation/one_to_one/update/related_object_link_with_alias_test.go
@@ -1,0 +1,427 @@
+// Copyright 2023 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package update
+
+import (
+	"fmt"
+	"testing"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	fixture "github.com/sourcenetwork/defradb/tests/integration/mutation/one_to_one"
+)
+
+// Note: This test should probably not pass, as even after updating a link to a new document
+// from one side the previous link still remains on the other side of the link.
+func TestMutationUpdateOneToOne_AliasRelationNameToLinkFromPrimarySide(t *testing.T) {
+	author1Key := "bae-2edb7fdd-cad7-5ad4-9c7d-6920245a96ed"
+	author2Key := "bae-35953caf-4898-518d-9e6b-9ce6cd86ebe5"
+	bookKey := "bae-22e0a1c2-d12b-5bfd-b039-0cf72f963991"
+
+	test := testUtils.TestCase{
+		Description: "One to one update mutation using alias relation id from single side",
+		Actions: []any{
+			testUtils.Request{
+				Request: `mutation {
+ 					create_Author(data: "{\"name\": \"John Grisham\"}") {
+ 						_key
+ 					}
+ 				}`,
+				Results: []map[string]any{
+					{
+						"_key": author1Key,
+					},
+				},
+			},
+			testUtils.Request{
+				Request: `mutation {
+ 					create_Author(data: "{\"name\": \"New Shahzad\"}") {
+ 						_key
+ 					}
+ 				}`,
+				Results: []map[string]any{
+					{
+						"_key": author2Key,
+					},
+				},
+			},
+			testUtils.Request{
+				Request: fmt.Sprintf(
+					`mutation {
+ 						create_Book(data: "{\"name\": \"Painted House\",\"author\": \"%s\"}") {
+ 							_key
+ 							name
+ 						}
+ 					}`,
+					author1Key,
+				),
+				Results: []map[string]any{
+					{
+						"_key": bookKey,
+						"name": "Painted House",
+					},
+				},
+			},
+			testUtils.Request{
+				Request: fmt.Sprintf(
+					`mutation {
+ 						update_Author(id: "%s", data: "{\"published\": \"%s\"}") {
+ 							name
+ 						}
+ 					}`,
+					author2Key,
+					bookKey,
+				),
+				Results: []map[string]any{
+					{
+						"name": "New Shahzad",
+					},
+				},
+			},
+			testUtils.Request{
+				Request: `query {
+ 					Author {
+ 						name
+ 						published {
+ 							name
+ 						}
+ 					}
+ 				}`,
+				Results: []map[string]any{
+					{
+						"name": "John Grisham",
+						"published": map[string]any{
+							"name": "Painted House",
+						},
+					},
+					{
+						"name": "New Shahzad",
+						"published": map[string]any{
+							"name": "Painted House",
+						},
+					},
+				},
+			},
+			testUtils.Request{
+				Request: `query {
+					Book {
+						name
+						author {
+							name
+						}
+					}
+				}`,
+				Results: []map[string]any{
+					{
+						"name": "Painted House",
+						"author": map[string]any{
+							"name": "John Grisham",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	fixture.ExecuteTestCase(t, test)
+}
+
+// Note: This test should probably not pass, as even after updating a link to a new document
+// from one side the previous link still remains on the other side of the link.
+func TestMutationUpdateOneToOne_AliasRelationNameToLinkFromSecondarySide(t *testing.T) {
+	author1Key := "bae-2edb7fdd-cad7-5ad4-9c7d-6920245a96ed"
+	author2Key := "bae-35953caf-4898-518d-9e6b-9ce6cd86ebe5"
+	bookKey := "bae-22e0a1c2-d12b-5bfd-b039-0cf72f963991"
+
+	test := testUtils.TestCase{
+		Description: "One to one update mutation using alias relation id from secondary side",
+		Actions: []any{
+			testUtils.Request{
+				Request: `mutation {
+ 					create_Author(data: "{\"name\": \"John Grisham\"}") {
+ 						_key
+ 					}
+ 				}`,
+				Results: []map[string]any{
+					{
+						"_key": author1Key,
+					},
+				},
+			},
+			testUtils.Request{
+				Request: `mutation {
+ 					create_Author(data: "{\"name\": \"New Shahzad\"}") {
+ 						_key
+ 					}
+ 				}`,
+				Results: []map[string]any{
+					{
+						"_key": author2Key,
+					},
+				},
+			},
+			testUtils.Request{
+				Request: fmt.Sprintf(
+					`mutation {
+ 						create_Book(data: "{\"name\": \"Painted House\",\"author\": \"%s\"}") {
+ 							_key
+ 							name
+ 						}
+ 					}`,
+					author1Key,
+				),
+				Results: []map[string]any{
+					{
+						"_key": bookKey,
+						"name": "Painted House",
+					},
+				},
+			},
+			testUtils.Request{
+				Request: fmt.Sprintf(
+					`mutation {
+ 						update_Book(id: "%s", data: "{\"author\": \"%s\"}") {
+ 							name
+ 						}
+ 					}`,
+					bookKey,
+					author2Key,
+				),
+				Results: []map[string]any{
+					{
+						"name": "Painted House",
+					},
+				},
+			},
+			testUtils.Request{
+				Request: `query {
+ 					Author {
+ 						name
+ 						published {
+ 							name
+ 						}
+ 					}
+ 				}`,
+				Results: []map[string]any{
+					{
+						"name": "John Grisham",
+						"published": map[string]any{
+							"name": "Painted House",
+						},
+					},
+					{
+						"name": "New Shahzad",
+						"published": map[string]any{
+							"name": "Painted House",
+						},
+					},
+				},
+			},
+			testUtils.Request{
+				Request: `query {
+					Book {
+						name
+						author {
+							name
+						}
+					}
+				}`,
+				Results: []map[string]any{
+					{
+						"name": "Painted House",
+						"author": map[string]any{
+							"name": "John Grisham",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	fixture.ExecuteTestCase(t, test)
+}
+
+func TestMutationUpdateOneToOne_AliasWithInvalidLengthRelationIDToLink_Error(t *testing.T) {
+	author1Key := "bae-2edb7fdd-cad7-5ad4-9c7d-6920245a96ed"
+	invalidLenSubKey := "35953ca-518d-9e6b-9ce6cd00eff5"
+	invalidAuthorKey := "bae-" + invalidLenSubKey
+	bookKey := "bae-22e0a1c2-d12b-5bfd-b039-0cf72f963991"
+
+	test := testUtils.TestCase{
+		Description: "One to one update mutation using invalid alias relation id",
+		Actions: []any{
+			testUtils.Request{
+				Request: `mutation {
+ 					create_Author(data: "{\"name\": \"John Grisham\"}") {
+ 						_key
+ 					}
+ 				}`,
+				Results: []map[string]any{
+					{
+						"_key": author1Key,
+					},
+				},
+			},
+			testUtils.Request{
+				Request: fmt.Sprintf(
+					`mutation {
+ 						create_Book(data: "{\"name\": \"Painted House\",\"author\": \"%s\"}") {
+ 							_key
+ 							name
+ 						}
+ 					}`,
+					author1Key,
+				),
+				Results: []map[string]any{
+					{
+						"_key": bookKey,
+						"name": "Painted House",
+					},
+				},
+			},
+			testUtils.Request{
+				Request: fmt.Sprintf(
+					`mutation {
+						update_Book(id: "%s", data: "{\"author\": \"%s\"}") {
+							name
+						}
+					}`,
+					bookKey,
+					invalidAuthorKey,
+				),
+				ExpectedError: "uuid: incorrect UUID length 30 in string \"" + invalidLenSubKey + "\"",
+			},
+		},
+	}
+
+	fixture.ExecuteTestCase(t, test)
+}
+
+func TestMutationUpdateOneToOne_InvalidAliasRelationNameToLinkFromSecondarySide_Error(t *testing.T) {
+	author1Key := "bae-2edb7fdd-cad7-5ad4-9c7d-6920245a96ed"
+	invalidAuthorKey := "bae-2edb7fdd-cad7-5ad4-9c7d-6920245a96ee"
+	bookKey := "bae-22e0a1c2-d12b-5bfd-b039-0cf72f963991"
+
+	test := testUtils.TestCase{
+		Description: "One to one update mutation using alias relation id from secondary side",
+		Actions: []any{
+			testUtils.Request{
+				Request: `mutation {
+ 					create_Author(data: "{\"name\": \"John Grisham\"}") {
+ 						_key
+ 					}
+ 				}`,
+				Results: []map[string]any{
+					{
+						"_key": author1Key,
+					},
+				},
+			},
+			testUtils.Request{
+				Request: fmt.Sprintf(
+					`mutation {
+ 						create_Book(data: "{\"name\": \"Painted House\",\"author\": \"%s\"}") {
+ 							_key
+ 							name
+ 						}
+ 					}`,
+					author1Key,
+				),
+				Results: []map[string]any{
+					{
+						"_key": bookKey,
+						"name": "Painted House",
+					},
+				},
+			},
+			testUtils.Request{
+				Request: fmt.Sprintf(
+					`mutation {
+						update_Book(id: "%s", data: "{\"author\": \"%s\"}") {
+							name
+						}
+					}`,
+					bookKey,
+					invalidAuthorKey,
+				),
+				ExpectedError: "no document for the given key exists",
+			},
+		},
+	}
+
+	fixture.ExecuteTestCase(t, test)
+}
+
+func TestMutationUpdateOneToOne_AliasRelationNameToLinkFromSecondarySideWithWrongField_Error(t *testing.T) {
+	author1Key := "bae-2edb7fdd-cad7-5ad4-9c7d-6920245a96ed"
+	author2Key := "bae-35953caf-4898-518d-9e6b-9ce6cd86ebe5"
+	bookKey := "bae-22e0a1c2-d12b-5bfd-b039-0cf72f963991"
+
+	test := testUtils.TestCase{
+		Description: "One to one update mutation using relation alias name from secondary side, with a wrong field.",
+		Actions: []any{
+			testUtils.Request{
+				Request: `mutation {
+ 					create_Author(data: "{\"name\": \"John Grisham\"}") {
+ 						_key
+ 					}
+ 				}`,
+				Results: []map[string]any{
+					{
+						"_key": author1Key,
+					},
+				},
+			},
+			testUtils.Request{
+				Request: `mutation {
+ 					create_Author(data: "{\"name\": \"New Shahzad\"}") {
+ 						_key
+ 					}
+ 				}`,
+				Results: []map[string]any{
+					{
+						"_key": author2Key,
+					},
+				},
+			},
+			testUtils.Request{
+				Request: fmt.Sprintf(
+					`mutation {
+ 						create_Book(data: "{\"name\": \"Painted House\",\"author\": \"%s\"}") {
+ 							_key
+ 							name
+ 						}
+ 					}`,
+					author1Key,
+				),
+				Results: []map[string]any{
+					{
+						"_key": bookKey,
+						"name": "Painted House",
+					},
+				},
+			},
+			testUtils.Request{
+				Request: fmt.Sprintf(
+					`mutation {
+ 						update_Book(id: "%s", data: "{\"notName\": \"Unpainted Condo\",\"author\": \"%s\"}") {
+ 							name
+ 						}
+ 					}`,
+					bookKey,
+					author2Key,
+				),
+				ExpectedError: "The given field does not exist. Name: notName",
+			},
+		},
+	}
+
+	fixture.ExecuteTestCase(t, test)
+}

--- a/tests/integration/query/one_to_many/with_filter_related_id_test.go
+++ b/tests/integration/query/one_to_many/with_filter_related_id_test.go
@@ -1,0 +1,404 @@
+// Copyright 2023 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package one_to_many
+
+import (
+	"testing"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+func TestQueryFromManySideWithEqFilterOnRelatedType(t *testing.T) {
+	test := testUtils.RequestTestCase{
+
+		Description: "One-to-many query from many side with _eq filter on related field type.",
+
+		Request: `query {
+			Book(filter: {author: {_key: {_eq: "bae-41598f0c-19bc-5da6-813b-e80f14a10df3"}}}) {
+				name
+			}
+		}`,
+
+		Docs: map[int][]string{
+			//books
+			0: { // bae-fd541c25-229e-5280-b44b-e5c2af3e374d
+				`{
+					"name": "Painted House",
+					"rating": 4.9,
+					"author_id": "bae-41598f0c-19bc-5da6-813b-e80f14a10df3"
+				}`,
+				`{
+					"name": "A Time for Mercy",
+					"rating": 4.5,
+					"author_id": "bae-41598f0c-19bc-5da6-813b-e80f14a10df3"
+				}`,
+				`{
+					"name": "The Client",
+					"rating": 4.5,
+					"author_id": "bae-41598f0c-19bc-5da6-813b-e80f14a10df3"
+				}`,
+				`{
+					"name": "Candide",
+					"rating": 4.95,
+					"author_id": "bae-7accaba8-ea9d-54b1-92f4-4a7ac5de88b3"
+				}`,
+				`{
+					"name": "Zadig",
+					"rating": 4.91,
+					"author_id": "bae-7accaba8-ea9d-54b1-92f4-4a7ac5de88b3"
+				}`,
+				`{
+					"name": "Histoiare des Celtes et particulierement des Gaulois et des Germains depuis les temps fabuleux jusqua la prise de Roze par les Gaulois",
+					"rating": 2,
+					"author_id": "bae-09d33399-197a-5b98-b135-4398f2b6de4c"
+				}`,
+			},
+			//authors
+			1: {
+				// bae-41598f0c-19bc-5da6-813b-e80f14a10df3
+				`{
+					"name": "John Grisham",
+					"age": 65,
+					"verified": true
+				}`,
+				// bae-7accaba8-ea9d-54b1-92f4-4a7ac5de88b3
+				`{
+					"name": "Voltaire",
+					"age": 327,
+					"verified": true
+				}`,
+				// bae-09d33399-197a-5b98-b135-4398f2b6de4c
+				`{
+					"name": "Simon Pelloutier",
+					"age": 327,
+					"verified": true
+				}`,
+			},
+		},
+		Results: []map[string]any{
+			{"name": "The Client"},
+			{"name": "Painted House"},
+			{"name": "A Time for Mercy"},
+		},
+	}
+
+	executeTestCase(t, test)
+}
+
+func TestQueryFromManySideWithFilterOnRelatedObjectID(t *testing.T) {
+	test := testUtils.RequestTestCase{
+
+		Description: "One-to-many query from many side with filter on related field.",
+
+		Request: `query {
+			Book(filter: {author_id: {_eq: "bae-41598f0c-19bc-5da6-813b-e80f14a10df3"}}) {
+				name
+			}
+		}`,
+
+		Docs: map[int][]string{
+			//books
+			0: { // bae-fd541c25-229e-5280-b44b-e5c2af3e374d
+				`{
+					"name": "Painted House",
+					"rating": 4.9,
+					"author_id": "bae-41598f0c-19bc-5da6-813b-e80f14a10df3"
+				}`,
+				`{
+					"name": "A Time for Mercy",
+					"rating": 4.5,
+					"author_id": "bae-41598f0c-19bc-5da6-813b-e80f14a10df3"
+				}`,
+				`{
+					"name": "The Client",
+					"rating": 4.5,
+					"author_id": "bae-41598f0c-19bc-5da6-813b-e80f14a10df3"
+				}`,
+				`{
+					"name": "Candide",
+					"rating": 4.95,
+					"author_id": "bae-7accaba8-ea9d-54b1-92f4-4a7ac5de88b3"
+				}`,
+				`{
+					"name": "Zadig",
+					"rating": 4.91,
+					"author_id": "bae-7accaba8-ea9d-54b1-92f4-4a7ac5de88b3"
+				}`,
+				`{
+					"name": "Histoiare des Celtes et particulierement des Gaulois et des Germains depuis les temps fabuleux jusqua la prise de Roze par les Gaulois",
+					"rating": 2,
+					"author_id": "bae-09d33399-197a-5b98-b135-4398f2b6de4c"
+				}`,
+			},
+			//authors
+			1: {
+				// bae-41598f0c-19bc-5da6-813b-e80f14a10df3
+				`{
+					"name": "John Grisham",
+					"age": 65,
+					"verified": true
+				}`,
+				// bae-7accaba8-ea9d-54b1-92f4-4a7ac5de88b3
+				`{
+					"name": "Voltaire",
+					"age": 327,
+					"verified": true
+				}`,
+				// bae-09d33399-197a-5b98-b135-4398f2b6de4c
+				`{
+					"name": "Simon Pelloutier",
+					"age": 327,
+					"verified": true
+				}`,
+			},
+		},
+		Results: []map[string]any{
+			{"name": "The Client"},
+			{"name": "Painted House"},
+			{"name": "A Time for Mercy"},
+		},
+	}
+
+	executeTestCase(t, test)
+}
+
+func TestQueryFromManySideWithSameFiltersInDifferentWayOnRelatedType(t *testing.T) {
+	test := testUtils.RequestTestCase{
+
+		Description: "One-to-many query from many side with same filters in different way on related type.",
+
+		Request: `query {
+			Book(
+				filter: {
+					author: {_key: {_eq: "bae-41598f0c-19bc-5da6-813b-e80f14a10df3"}},
+					author_id: {_eq: "bae-41598f0c-19bc-5da6-813b-e80f14a10df3"}
+				}
+			) {
+				name
+			}
+		}`,
+
+		Docs: map[int][]string{
+			//books
+			0: { // bae-fd541c25-229e-5280-b44b-e5c2af3e374d
+				`{
+					"name": "Painted House",
+					"rating": 4.9,
+					"author_id": "bae-41598f0c-19bc-5da6-813b-e80f14a10df3"
+				}`,
+				`{
+					"name": "A Time for Mercy",
+					"rating": 4.5,
+					"author_id": "bae-41598f0c-19bc-5da6-813b-e80f14a10df3"
+				}`,
+				`{
+					"name": "The Client",
+					"rating": 4.5,
+					"author_id": "bae-41598f0c-19bc-5da6-813b-e80f14a10df3"
+				}`,
+				`{
+					"name": "Candide",
+					"rating": 4.95,
+					"author_id": "bae-7accaba8-ea9d-54b1-92f4-4a7ac5de88b3"
+				}`,
+				`{
+					"name": "Zadig",
+					"rating": 4.91,
+					"author_id": "bae-7accaba8-ea9d-54b1-92f4-4a7ac5de88b3"
+				}`,
+				`{
+					"name": "Histoiare des Celtes et particulierement des Gaulois et des Germains depuis les temps fabuleux jusqua la prise de Roze par les Gaulois",
+					"rating": 2,
+					"author_id": "bae-09d33399-197a-5b98-b135-4398f2b6de4c"
+				}`,
+			},
+			//authors
+			1: {
+				// bae-41598f0c-19bc-5da6-813b-e80f14a10df3
+				`{
+					"name": "John Grisham",
+					"age": 65,
+					"verified": true
+				}`,
+				// bae-7accaba8-ea9d-54b1-92f4-4a7ac5de88b3
+				`{
+					"name": "Voltaire",
+					"age": 327,
+					"verified": true
+				}`,
+				// bae-09d33399-197a-5b98-b135-4398f2b6de4c
+				`{
+					"name": "Simon Pelloutier",
+					"age": 327,
+					"verified": true
+				}`,
+			},
+		},
+		Results: []map[string]any{
+			{"name": "The Client"},
+			{"name": "Painted House"},
+			{"name": "A Time for Mercy"},
+		},
+	}
+
+	executeTestCase(t, test)
+}
+
+func TestQueryFromSingleSideWithEqFilterOnRelatedType(t *testing.T) {
+	test := testUtils.RequestTestCase{
+
+		Description: "One-to-many query from single side with _eq filter on related field type.",
+
+		Request: `query {
+			Author(filter: {published: {_key: {_eq: "bae-b9b83269-1f28-5c3b-ae75-3fb4c00d559d"}}}) {
+				name
+			}
+		}`,
+
+		Docs: map[int][]string{
+			//books
+			0: { // bae-fd541c25-229e-5280-b44b-e5c2af3e374d
+				`{
+					"name": "Painted House",
+					"rating": 4.9,
+					"author_id": "bae-41598f0c-19bc-5da6-813b-e80f14a10df3"
+				}`,
+				`{
+					"name": "A Time for Mercy",
+					"rating": 4.5,
+					"author_id": "bae-41598f0c-19bc-5da6-813b-e80f14a10df3"
+				}`,
+				`{
+					"name": "The Client",
+					"rating": 4.5,
+					"author_id": "bae-41598f0c-19bc-5da6-813b-e80f14a10df3"
+				}`,
+				`{
+					"name": "Candide",
+					"rating": 4.95,
+					"author_id": "bae-7accaba8-ea9d-54b1-92f4-4a7ac5de88b3"
+				}`,
+				`{
+					"name": "Zadig",
+					"rating": 4.91,
+					"author_id": "bae-7accaba8-ea9d-54b1-92f4-4a7ac5de88b3"
+				}`,
+				`{
+					"name": "Histoiare des Celtes et particulierement des Gaulois et des Germains depuis les temps fabuleux jusqua la prise de Roze par les Gaulois",
+					"rating": 2,
+					"author_id": "bae-09d33399-197a-5b98-b135-4398f2b6de4c"
+				}`,
+			},
+			//authors
+			1: {
+				// bae-41598f0c-19bc-5da6-813b-e80f14a10df3
+				`{
+					"name": "John Grisham",
+					"age": 65,
+					"verified": true
+				}`,
+				// bae-7accaba8-ea9d-54b1-92f4-4a7ac5de88b3
+				`{
+					"name": "Voltaire",
+					"age": 327,
+					"verified": true
+				}`,
+				// bae-09d33399-197a-5b98-b135-4398f2b6de4c
+				`{
+					"name": "Simon Pelloutier",
+					"age": 327,
+					"verified": true
+				}`,
+			},
+		},
+		Results: []map[string]any{
+			{
+				"name": "John Grisham",
+			},
+		},
+	}
+
+	executeTestCase(t, test)
+}
+
+func TestQueryFromSingleSideWithFilterOnRelatedObjectID_Error(t *testing.T) {
+	test := testUtils.RequestTestCase{
+
+		Description: "One-to-many query from single side with filter on related field.",
+
+		Request: `query {
+			Author(filter: {published_id: {_eq: "bae-b9b83269-1f28-5c3b-ae75-3fb4c00d559d"}}) {
+				name
+			}
+		}`,
+
+		Docs: map[int][]string{
+			//books
+			0: { // bae-fd541c25-229e-5280-b44b-e5c2af3e374d
+				`{
+					"name": "Painted House",
+					"rating": 4.9,
+					"author_id": "bae-41598f0c-19bc-5da6-813b-e80f14a10df3"
+				}`,
+				`{
+					"name": "A Time for Mercy",
+					"rating": 4.5,
+					"author_id": "bae-41598f0c-19bc-5da6-813b-e80f14a10df3"
+				}`,
+				`{
+					"name": "The Client",
+					"rating": 4.5,
+					"author_id": "bae-41598f0c-19bc-5da6-813b-e80f14a10df3"
+				}`,
+				`{
+					"name": "Candide",
+					"rating": 4.95,
+					"author_id": "bae-7accaba8-ea9d-54b1-92f4-4a7ac5de88b3"
+				}`,
+				`{
+					"name": "Zadig",
+					"rating": 4.91,
+					"author_id": "bae-7accaba8-ea9d-54b1-92f4-4a7ac5de88b3"
+				}`,
+				`{
+					"name": "Histoiare des Celtes et particulierement des Gaulois et des Germains depuis les temps fabuleux jusqua la prise de Roze par les Gaulois",
+					"rating": 2,
+					"author_id": "bae-09d33399-197a-5b98-b135-4398f2b6de4c"
+				}`,
+			},
+			//authors
+			1: {
+				// bae-41598f0c-19bc-5da6-813b-e80f14a10df3
+				`{
+					"name": "John Grisham",
+					"age": 65,
+					"verified": true
+				}`,
+				// bae-7accaba8-ea9d-54b1-92f4-4a7ac5de88b3
+				`{
+					"name": "Voltaire",
+					"age": 327,
+					"verified": true
+				}`,
+				// bae-09d33399-197a-5b98-b135-4398f2b6de4c
+				`{
+					"name": "Simon Pelloutier",
+					"age": 327,
+					"verified": true
+				}`,
+			},
+		},
+
+		ExpectedError: "Argument \"filter\" has invalid value {published_id: {_eq: \"bae-b9b83269-1f28-5c3b-ae75-3fb4c00d559d\"}}.\nIn field \"published_id\": Unknown field.",
+	}
+
+	executeTestCase(t, test)
+}


### PR DESCRIPTION
## Relevant issue(s)
Resolves #1279 

## Description
Here are the main tasks that were done in this PR:
- [x] Add some tests that are might not be directly related
- [x] Before implementation add more tests for non-alias behavior while creating document.
- [x] Add implementation for aliasing on related object link while creating document.
- [x] Add 1-1 tests for aliasing on related object while creating document.
- [x] Add 1-M tests for aliasing on related object while creating document.
- [x] Before implementation add tests for non-alias behavior while updating document.
- [x] Add implementation for aliasing on related object link while updating document.
- [x] Add 1-1 tests for aliasing on related object while updating document.
- [x] Add 1-M tests for aliasing on related object while updating document.

In addition, I had to resolve a circular dependency but making the `core/cid.go` stuff it's own modular package. Refactored manual uses of `cid.Prefix` and dockey generation so that it's consistent.

## For Reviewers
- This commit `PR(FIX): Squash the dockey verification + diff bug` undoes some work in the commit `PR(CORE): Implement the alias logic for create` to fix a bug. Other than that should be "cleanish" history.


## How has this been tested?
- Integration tests.
