### PR TITLE
fix: Avoid duplicated requestable fields

### DIFF
--- a/planner/mapper/mapper.go
+++ b/planner/mapper/mapper.go
@@ -795,6 +795,7 @@ func resolveInnerFilterDependencies(
 ) ([]Requestable, error) {
 	newFields := []Requestable{}
 
+sourceLoop:
 	for key := range source {
 		if strings.HasPrefix(key, "_") && key != request.KeyFieldName {
 			continue
@@ -844,15 +845,10 @@ func resolveInnerFilterDependencies(
 			// If the key index is outside the bounds of the child mapping array, then
 			// this is not a relation/join and we can add it to the fields and
 			// continue (no child props to process)
-			isDuplicate := false
 			for _, field := range existingFields {
 				if field.GetIndex() == keyIndex {
-					isDuplicate = true
-					break
+					continue sourceLoop
 				}
-			}
-			if isDuplicate {
-				continue
 			}
 			newFields = append(existingFields, &Field{
 				Index: keyIndex,

--- a/planner/mapper/mapper.go
+++ b/planner/mapper/mapper.go
@@ -844,6 +844,16 @@ func resolveInnerFilterDependencies(
 			// If the key index is outside the bounds of the child mapping array, then
 			// this is not a relation/join and we can add it to the fields and
 			// continue (no child props to process)
+			isDuplicate := false
+			for _, field := range existingFields {
+				if field.GetIndex() == keyIndex {
+					isDuplicate = true
+					break
+				}
+			}
+			if isDuplicate {
+				continue
+			}
 			newFields = append(existingFields, &Field{
 				Index: keyIndex,
 				Name:  key,


### PR DESCRIPTION
## Relevant issue(s)

Resolves #1615

## Description

Makes sure the requestable fields aren't duplicated 

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Intergration tests

Specify the platform(s) on which this was tested:
- MacOS
