### PR TITLE
feat: Add `_not` operator

### DIFF
--- a/connor/connor.go
+++ b/connor/connor.go
@@ -40,6 +40,8 @@ func matchWith(op string, conditions, data any) (bool, error) {
 		return like(conditions, data)
 	case "_nlike":
 		return nlike(conditions, data)
+	case "_not":
+		return not(conditions, data)
 	default:
 		return false, NewErrUnknownOperator(op)
 	}

--- a/connor/not.go
+++ b/connor/not.go
@@ -3,11 +3,9 @@ package connor
 // not is an operator which performs object equality test
 // and returns the inverse of the result.
 func not(condition, data any) (bool, error) {
-	if m, err := eq(condition, data); err != nil {
+	m, err := eq(condition, data)
+	if err != nil {
 		return false, err
-	} else if m {
-		return false, nil
 	}
-
-	return true, nil
+	return !m, nil
 }

--- a/connor/not.go
+++ b/connor/not.go
@@ -1,7 +1,7 @@
 package connor
 
-// like is an operator which performs string equality
-// tests.
+// not is an operator which performs object equality test
+// and returns the inverse of the result.
 func not(condition, data any) (bool, error) {
 	if m, err := eq(condition, data); err != nil {
 		return false, err

--- a/connor/not.go
+++ b/connor/not.go
@@ -1,0 +1,13 @@
+package connor
+
+// like is an operator which performs string equality
+// tests.
+func not(condition, data any) (bool, error) {
+	if m, err := eq(condition, data); err != nil {
+		return false, err
+	} else if m {
+		return false, nil
+	}
+
+	return true, nil
+}

--- a/connor/not_test.go
+++ b/connor/not_test.go
@@ -28,7 +28,7 @@ func TestNot_WithEmptyCondition_ReturnError(t *testing.T) {
 }
 
 type operator struct {
-	// The filter operation string that this Operator represents.
+	// The filter operation string that this `operator`` represents.
 	//
 	// E.g. "_eq", or "_and".
 	Operation string

--- a/connor/not_test.go
+++ b/connor/not_test.go
@@ -1,0 +1,50 @@
+package connor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNot_WithNotAndNotNot_NoError(t *testing.T) {
+	const testString = "Source is the glue of web3"
+
+	// not equal
+	result, err := not(testString, testString)
+	require.NoError(t, err)
+	require.False(t, result)
+
+	// not not equal
+	result, err = not("Source is the glue", testString)
+	require.NoError(t, err)
+	require.True(t, result)
+}
+
+func TestNot_WithEmptyCondition_ReturnError(t *testing.T) {
+	const testString = "Source is the glue of web3"
+
+	_, err := not(map[FilterKey]any{&operator{"_some"}: "test"}, testString)
+	require.ErrorIs(t, err, ErrUnknownOperator)
+}
+
+type operator struct {
+	// The filter operation string that this Operator represents.
+	//
+	// E.g. "_eq", or "_and".
+	Operation string
+}
+
+func (k *operator) GetProp(data any) any {
+	return data
+}
+
+func (k *operator) GetOperatorOrDefault(defaultOp string) string {
+	return k.Operation
+}
+
+func (k *operator) Equal(other FilterKey) bool {
+	if otherKey, isOk := other.(*operator); isOk && *k == *otherKey {
+		return true
+	}
+	return false
+}

--- a/planner/mapper/mapper.go
+++ b/planner/mapper/mapper.go
@@ -1039,6 +1039,13 @@ func toFilterMap(
 				returnClauses = append(returnClauses, returnClause)
 			}
 			return key, returnClauses
+		case map[string]any:
+			innerMapClause := map[connor.FilterKey]any{}
+			for innerSourceKey, innerSourceValue := range typedClause {
+				rKey, rValue := toFilterMap(innerSourceKey, innerSourceValue, mapping)
+				innerMapClause[rKey] = rValue
+			}
+			return key, innerMapClause
 		default:
 			return key, typedClause
 		}

--- a/planner/mapper/targetable.go
+++ b/planner/mapper/targetable.go
@@ -117,6 +117,9 @@ func filterObjectToMap(mapping *core.DocumentMapping, obj map[connor.FilterKey]a
 					logicMapEntries[i] = filterObjectToMap(mapping, itemMap)
 				}
 				outmap[keyType.Operation] = logicMapEntries
+			case "_not":
+				itemMap := v.(map[connor.FilterKey]any)
+				outmap[keyType.Operation] = filterObjectToMap(mapping, itemMap)
 			default:
 				outmap[keyType.Operation] = v
 			}

--- a/tests/integration/query/simple/with_filter/with_not_test.go
+++ b/tests/integration/query/simple/with_filter/with_not_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Democratized Data Foundation
+// Copyright 2023 Democratized Data Foundation
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt.

--- a/tests/integration/query/simple/with_filter/with_not_test.go
+++ b/tests/integration/query/simple/with_filter/with_not_test.go
@@ -1,0 +1,109 @@
+// Copyright 2022 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package simple
+
+import (
+	"testing"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+func TestQuerySimpleWithIntNotEqualToXFilter(t *testing.T) {
+	test := testUtils.RequestTestCase{
+		Description: "Simple query with logical compound filter (not)",
+		Request: `query {
+					Users(filter: {_not: {Age: {_eq: 55}}}) {
+						Name
+						Age
+					}
+				}`,
+		Docs: map[int][]string{
+			0: {
+				`{
+					"Name": "John",
+					"Age": 21
+				}`,
+				`{
+					"Name": "Bob",
+					"Age": 32
+				}`,
+				`{
+					"Name": "Carlo",
+					"Age": 55
+				}`,
+				`{
+					"Name": "Alice",
+					"Age": 19
+				}`,
+			},
+		},
+		Results: []map[string]any{
+			{
+				"Name": "Bob",
+				"Age":  uint64(32),
+			},
+			{
+				"Name": "Alice",
+				"Age":  uint64(19),
+			},
+			{
+				"Name": "John",
+				"Age":  uint64(21),
+			},
+		},
+	}
+
+	executeTestCase(t, test)
+}
+
+func TestQuerySimpleWithIntNotEqualToXorYFilter(t *testing.T) {
+	test := testUtils.RequestTestCase{
+		Description: "Simple query with logical compound filter (not)",
+		Request: `query {
+					Users(filter: {_not: {_or: [{Age: {_eq: 55}}, {Name: {_eq: "Alice"}}]}}) {
+						Name
+						Age
+					}
+				}`,
+		Docs: map[int][]string{
+			0: {
+				`{
+					"Name": "John",
+					"Age": 21
+				}`,
+				`{
+					"Name": "Bob",
+					"Age": 32
+				}`,
+				`{
+					"Name": "Carlo",
+					"Age": 55
+				}`,
+				`{
+					"Name": "Alice",
+					"Age": 19
+				}`,
+			},
+		},
+		Results: []map[string]any{
+			{
+				"Name": "Bob",
+				"Age":  uint64(32),
+			},
+			{
+				"Name": "John",
+				"Age":  uint64(21),
+			},
+		},
+	}
+
+	executeTestCase(t, test)
+}

--- a/tests/integration/query/simple/with_filter/with_not_test.go
+++ b/tests/integration/query/simple/with_filter/with_not_test.go
@@ -16,7 +16,7 @@ import (
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
 )
 
-func TestQuerySimpleWithIntNotEqualToXFilter(t *testing.T) {
+func TestQuerySimple_WithNotEqualToXFilter_NoError(t *testing.T) {
 	test := testUtils.RequestTestCase{
 		Description: "Simple query with logical compound filter (not)",
 		Request: `query {
@@ -64,7 +64,7 @@ func TestQuerySimpleWithIntNotEqualToXFilter(t *testing.T) {
 	executeTestCase(t, test)
 }
 
-func TestQuerySimpleWithIntNotEqualToXorYFilter(t *testing.T) {
+func TestQuerySimple_WithNotEqualToXorYFilter_NoError(t *testing.T) {
 	test := testUtils.RequestTestCase{
 		Description: "Simple query with logical compound filter (not)",
 		Request: `query {
@@ -101,6 +101,97 @@ func TestQuerySimpleWithIntNotEqualToXorYFilter(t *testing.T) {
 			{
 				"Name": "John",
 				"Age":  uint64(21),
+			},
+		},
+	}
+
+	executeTestCase(t, test)
+}
+
+func TestQuerySimple_WithEmptyNotFilter_ReturnError(t *testing.T) {
+	test := testUtils.RequestTestCase{
+		Description: "Simple query with empty logical compound filter (not) returns empty result set",
+		Request: `query {
+					Users(filter: {_not: {}}) {
+						Name
+						Age
+					}
+				}`,
+		Docs: map[int][]string{
+			0: {
+				`{
+					"Name": "John",
+					"Age": 21
+				}`,
+				`{
+					"Name": "Bob",
+					"Age": 32
+				}`,
+				`{
+					"Name": "Carlo",
+					"Age": 55
+				}`,
+				`{
+					"Name": "Alice",
+					"Age": 19
+				}`,
+			},
+		},
+		Results: []map[string]any{},
+	}
+
+	executeTestCase(t, test)
+}
+
+func TestQuerySimple_WithNotEqualToXAndNotYFilter_NoError(t *testing.T) {
+	test := testUtils.RequestTestCase{
+		Description: "Simple query with logical compound filter (not)",
+		Request: `query {
+					Users(filter: {_not: {Age: {_eq: 55}, _not: {Name: {_eq: "Carlo"}}}}) {
+						Name
+						Age
+					}
+				}`,
+		Docs: map[int][]string{
+			0: {
+				`{
+					"Name": "John",
+					"Age": 21
+				}`,
+				`{
+					"Name": "Bob",
+					"Age": 32
+				}`,
+				`{
+					"Name": "Carlo",
+					"Age": 55
+				}`,
+				`{
+					"Name": "Alice",
+					"Age": 19
+				}`,
+				`{
+					"Name": "Frank",
+					"Age": 55
+				}`,
+			},
+		},
+		Results: []map[string]any{
+			{
+				"Name": "Bob",
+				"Age":  uint64(32),
+			},
+			{
+				"Name": "Alice",
+				"Age":  uint64(19),
+			},
+			{
+				"Name": "John",
+				"Age":  uint64(21),
+			},
+			{
+				"Name": "Carlo",
+				"Age":  uint64(55),
 			},
 		},
 	}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #1542 

## Description

This PR add the `_not` operator as an option for filters in graphql queries.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

make test

Specify the platform(s) on which this was tested:
- MacOS
