### PR TITLE
test: Remove CLI tests from make test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,8 @@ endif
 TEST_FLAGS=-race -shuffle=on -timeout 70s
 
 LENS_TEST_DIRECTORY=tests/integration/schema/migrations
-DEFAULT_TEST_DIRECTORIES=$$(go list ./... | grep -v $(LENS_TEST_DIRECTORY))
+CLI_TEST_DIRECTORY=tests/integration/cli
+DEFAULT_TEST_DIRECTORIES=$$(go list ./... | grep -v -e $(LENS_TEST_DIRECTORY) -e $(CLI_TEST_DIRECTORY))
 
 default:
 	@go run $(BUILD_FLAGS) cmd/defradb/main.go
@@ -200,6 +201,7 @@ test\:names:
 test\:all:
 	@$(MAKE) test:names
 	@$(MAKE) test:lens
+	@$(MAKE) test:cli
 
 .PHONY: test\:verbose
 test\:verbose:
@@ -229,6 +231,10 @@ test\:scripts:
 test\:lens:
 	@$(MAKE) deps:lens
 	gotestsum --format testname -- ./$(LENS_TEST_DIRECTORY)/... $(TEST_FLAGS)
+
+.PHONY: test\:cli
+test\:cli:
+	gotestsum --format testname -- ./$(CLI_TEST_DIRECTORY)/... $(TEST_FLAGS)
 
 # Using go-acc to ensure integration tests are included.
 # Usage: `make test:coverage` or `make test:coverage path="{pathToPackage}"`


### PR DESCRIPTION
## Relevant issue(s)

Resolves #1642

## Description

Removes CLI tests from `make test` as they take ages to run and it is disruptive to dev-flow.

Also adds `make test:short` which is even leaner, skipping all the extras like the race detector.

Runtimes on my machine:
Old `make test`: 72s
New `make test`: 30s
New `make test:short`: 21s  