### PR TITLE
test: Bundle test state into single var

### DIFF
--- a/tests/integration/explain.go
+++ b/tests/integration/explain.go
@@ -16,12 +16,12 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/sourcenetwork/immutable"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/logging"
-	"github.com/sourcenetwork/immutable"
 )
 
 var (

--- a/tests/integration/explain.go
+++ b/tests/integration/explain.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/logging"
-	"github.com/sourcenetwork/defradb/net"
 	"github.com/sourcenetwork/immutable"
 )
 
@@ -103,7 +102,6 @@ type ExplainRequest struct {
 
 func executeExplainRequest(
 	s *state,
-	nodes []*net.Node,
 	action ExplainRequest,
 ) {
 	// Must have a non-empty request.
@@ -127,7 +125,7 @@ func executeExplainRequest(
 		require.Fail(s.t, "Expected error should not have other expected results with it.", s.testCase.Description)
 	}
 
-	for _, node := range getNodes(action.NodeID, nodes) {
+	for _, node := range getNodes(action.NodeID, s.nodes) {
 		result := node.DB.ExecRequest(s.ctx, action.Request)
 		assertExplainRequestResults(
 			s.ctx,

--- a/tests/integration/explain.go
+++ b/tests/integration/explain.go
@@ -97,15 +97,13 @@ type ExplainRequest struct {
 }
 
 func executeExplainRequest(
-	ctx context.Context,
-	t *testing.T,
-	description string,
+	s *state,
 	db client.DB,
 	action ExplainRequest,
 ) {
 	// Must have a non-empty request.
 	if action.Request == "" {
-		require.Fail(t, "Explain test must have a non-empty request.", description)
+		require.Fail(s.t, "Explain test must have a non-empty request.", s.testCase.Description)
 	}
 
 	// If no expected results are provided, then it's invalid use of this explain testing setup.
@@ -113,7 +111,7 @@ func executeExplainRequest(
 		action.ExpectedPatterns == nil &&
 		action.ExpectedTargets == nil &&
 		action.ExpectedFullGraph == nil {
-		require.Fail(t, "Atleast one expected explain parameter must be provided.", description)
+		require.Fail(s.t, "Atleast one expected explain parameter must be provided.", s.testCase.Description)
 	}
 
 	// If we expect an error, then all other expected results should be empty (they shouldn't be provided).
@@ -121,14 +119,14 @@ func executeExplainRequest(
 		(action.ExpectedFullGraph != nil ||
 			action.ExpectedPatterns != nil ||
 			action.ExpectedTargets != nil) {
-		require.Fail(t, "Expected error should not have other expected results with it.", description)
+		require.Fail(s.t, "Expected error should not have other expected results with it.", s.testCase.Description)
 	}
 
-	result := db.ExecRequest(ctx, action.Request)
+	result := db.ExecRequest(s.ctx, action.Request)
 	assertExplainRequestResults(
-		ctx,
-		t,
-		description,
+		s.ctx,
+		s.t,
+		s.testCase.Description,
 		&result.GQL,
 		action,
 	)

--- a/tests/integration/lens.go
+++ b/tests/integration/lens.go
@@ -15,7 +15,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/sourcenetwork/defradb/client"
-	"github.com/sourcenetwork/defradb/net"
 )
 
 // ConfigureMigration is a test action which will configure a Lens migration using the
@@ -54,10 +53,9 @@ type GetMigrations struct {
 
 func configureMigration(
 	s *state,
-	nodes []*net.Node,
 	action ConfigureMigration,
 ) {
-	for _, node := range getNodes(action.NodeID, nodes) {
+	for _, node := range getNodes(action.NodeID, s.nodes) {
 		db := getStore(s, node.DB, action.TransactionID, action.ExpectedError)
 
 		err := db.SetMigration(s.ctx, action.LensConfig)
@@ -69,10 +67,9 @@ func configureMigration(
 
 func getMigrations(
 	s *state,
-	nodes []*net.Node,
 	action GetMigrations,
 ) {
-	for _, node := range getNodes(action.NodeID, nodes) {
+	for _, node := range getNodes(action.NodeID, s.nodes) {
 		db := getStore(s, node.DB, action.TransactionID, "")
 
 		configs := db.LensRegistry().Config()

--- a/tests/integration/lens.go
+++ b/tests/integration/lens.go
@@ -11,9 +11,6 @@
 package tests
 
 import (
-	"context"
-	"testing"
-
 	"github.com/sourcenetwork/immutable"
 	"github.com/stretchr/testify/assert"
 
@@ -57,38 +54,34 @@ type GetMigrations struct {
 }
 
 func configureMigration(
-	ctx context.Context,
-	t *testing.T,
+	s *state,
 	nodes []*net.Node,
 	txnsPointer *[]datastore.Txn,
-	testCase TestCase,
 	action ConfigureMigration,
 ) {
 	for _, node := range getNodes(action.NodeID, nodes) {
-		db := getStore(ctx, t, testCase.Description, node.DB, txnsPointer, action.TransactionID, action.ExpectedError)
+		db := getStore(s, node.DB, txnsPointer, action.TransactionID, action.ExpectedError)
 
-		err := db.SetMigration(ctx, action.LensConfig)
-		expectedErrorRaised := AssertError(t, testCase.Description, err, action.ExpectedError)
+		err := db.SetMigration(s.ctx, action.LensConfig)
+		expectedErrorRaised := AssertError(s.t, s.testCase.Description, err, action.ExpectedError)
 
-		assertExpectedErrorRaised(t, testCase.Description, action.ExpectedError, expectedErrorRaised)
+		assertExpectedErrorRaised(s.t, s.testCase.Description, action.ExpectedError, expectedErrorRaised)
 	}
 }
 
 func getMigrations(
-	ctx context.Context,
-	t *testing.T,
+	s *state,
 	nodes []*net.Node,
 	txnsPointer *[]datastore.Txn,
-	testCase TestCase,
 	action GetMigrations,
 ) {
 	for _, node := range getNodes(action.NodeID, nodes) {
-		db := getStore(ctx, t, testCase.Description, node.DB, txnsPointer, action.TransactionID, "")
+		db := getStore(s, node.DB, txnsPointer, action.TransactionID, "")
 
 		configs := db.LensRegistry().Config()
 
 		// The order of the results is not deterministic, so do not assert on the element
 		// locations.
-		assert.ElementsMatch(t, configs, action.ExpectedResults)
+		assert.ElementsMatch(s.t, configs, action.ExpectedResults)
 	}
 }

--- a/tests/integration/lens.go
+++ b/tests/integration/lens.go
@@ -15,7 +15,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/sourcenetwork/defradb/client"
-	"github.com/sourcenetwork/defradb/datastore"
 	"github.com/sourcenetwork/defradb/net"
 )
 
@@ -56,11 +55,10 @@ type GetMigrations struct {
 func configureMigration(
 	s *state,
 	nodes []*net.Node,
-	txnsPointer *[]datastore.Txn,
 	action ConfigureMigration,
 ) {
 	for _, node := range getNodes(action.NodeID, nodes) {
-		db := getStore(s, node.DB, txnsPointer, action.TransactionID, action.ExpectedError)
+		db := getStore(s, node.DB, action.TransactionID, action.ExpectedError)
 
 		err := db.SetMigration(s.ctx, action.LensConfig)
 		expectedErrorRaised := AssertError(s.t, s.testCase.Description, err, action.ExpectedError)
@@ -72,11 +70,10 @@ func configureMigration(
 func getMigrations(
 	s *state,
 	nodes []*net.Node,
-	txnsPointer *[]datastore.Txn,
 	action GetMigrations,
 ) {
 	for _, node := range getNodes(action.NodeID, nodes) {
-		db := getStore(s, node.DB, txnsPointer, action.TransactionID, "")
+		db := getStore(s, node.DB, action.TransactionID, "")
 
 		configs := db.LensRegistry().Config()
 

--- a/tests/integration/p2p.go
+++ b/tests/integration/p2p.go
@@ -14,7 +14,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/config"
 	"github.com/sourcenetwork/defradb/logging"
 	"github.com/sourcenetwork/defradb/net"
@@ -394,7 +393,6 @@ func setupReplicatorWaitSync(
 func subscribeToCollection(
 	s *state,
 	action SubscribeToCollection,
-	collections [][]client.Collection,
 ) {
 	n := s.nodes[action.NodeID]
 
@@ -405,7 +403,7 @@ func subscribeToCollection(
 			continue
 		}
 
-		col := collections[action.NodeID][collectionIndex]
+		col := s.collections[action.NodeID][collectionIndex]
 		schemaIDs = append(schemaIDs, col.SchemaID())
 	}
 
@@ -430,7 +428,6 @@ func subscribeToCollection(
 func unsubscribeToCollection(
 	s *state,
 	action UnsubscribeToCollection,
-	collections [][]client.Collection,
 ) {
 	n := s.nodes[action.NodeID]
 
@@ -441,7 +438,7 @@ func unsubscribeToCollection(
 			continue
 		}
 
-		col := collections[action.NodeID][collectionIndex]
+		col := s.collections[action.NodeID][collectionIndex]
 		schemaIDs = append(schemaIDs, col.SchemaID())
 	}
 
@@ -467,11 +464,10 @@ func unsubscribeToCollection(
 func getAllP2PCollections(
 	s *state,
 	action GetAllP2PCollections,
-	collections [][]client.Collection,
 ) {
 	expectedCollections := []*pb.GetAllP2PCollectionsReply_Collection{}
 	for _, collectionIndex := range action.ExpectedCollectionIDs {
-		col := collections[action.NodeID][collectionIndex]
+		col := s.collections[action.NodeID][collectionIndex]
 		expectedCollections = append(
 			expectedCollections,
 			&pb.GetAllP2PCollectionsReply_Collection{

--- a/tests/integration/p2p.go
+++ b/tests/integration/p2p.go
@@ -134,13 +134,12 @@ type AnyOf []any
 func connectPeers(
 	s *state,
 	cfg ConnectPeers,
-	nodes []*net.Node,
 ) {
 	// If we have some database actions prior to connecting the peers, we want to ensure that they had time to
 	// complete before we connect. Otherwise we might wrongly catch them in our wait function.
 	time.Sleep(100 * time.Millisecond)
-	sourceNode := nodes[cfg.SourceNodeID]
-	targetNode := nodes[cfg.TargetNodeID]
+	sourceNode := s.nodes[cfg.SourceNodeID]
+	targetNode := s.nodes[cfg.TargetNodeID]
 	targetAddress := s.nodeAddresses[cfg.TargetNodeID]
 
 	log.Info(s.ctx, "Parsing bootstrap peers", logging.NewKV("Peers", targetAddress))
@@ -292,13 +291,12 @@ func collectionSubscribedTo(
 func configureReplicator(
 	s *state,
 	cfg ConfigureReplicator,
-	nodes []*net.Node,
 ) {
 	// If we have some database actions prior to configuring the replicator, we want to ensure that they had time to
 	// complete before the configuration. Otherwise we might wrongly catch them in our wait function.
 	time.Sleep(100 * time.Millisecond)
-	sourceNode := nodes[cfg.SourceNodeID]
-	targetNode := nodes[cfg.TargetNodeID]
+	sourceNode := s.nodes[cfg.SourceNodeID]
+	targetNode := s.nodes[cfg.TargetNodeID]
 	targetAddress := s.nodeAddresses[cfg.TargetNodeID]
 
 	addr, err := ma.NewMultiaddr(targetAddress)
@@ -396,10 +394,9 @@ func setupReplicatorWaitSync(
 func subscribeToCollection(
 	s *state,
 	action SubscribeToCollection,
-	nodes []*net.Node,
 	collections [][]client.Collection,
 ) {
-	n := nodes[action.NodeID]
+	n := s.nodes[action.NodeID]
 
 	schemaIDs := []string{}
 	for _, collectionIndex := range action.CollectionIDs {
@@ -433,10 +430,9 @@ func subscribeToCollection(
 func unsubscribeToCollection(
 	s *state,
 	action UnsubscribeToCollection,
-	nodes []*net.Node,
 	collections [][]client.Collection,
 ) {
-	n := nodes[action.NodeID]
+	n := s.nodes[action.NodeID]
 
 	schemaIDs := []string{}
 	for _, collectionIndex := range action.CollectionIDs {
@@ -471,7 +467,6 @@ func unsubscribeToCollection(
 func getAllP2PCollections(
 	s *state,
 	action GetAllP2PCollections,
-	nodes []*net.Node,
 	collections [][]client.Collection,
 ) {
 	expectedCollections := []*pb.GetAllP2PCollectionsReply_Collection{}
@@ -486,7 +481,7 @@ func getAllP2PCollections(
 		)
 	}
 
-	n := nodes[action.NodeID]
+	n := s.nodes[action.NodeID]
 	cols, err := n.Peer.GetAllP2PCollections(
 		s.ctx,
 		&pb.GetAllP2PCollectionsRequest{},

--- a/tests/integration/p2p.go
+++ b/tests/integration/p2p.go
@@ -135,14 +135,13 @@ func connectPeers(
 	s *state,
 	cfg ConnectPeers,
 	nodes []*net.Node,
-	addresses []string,
 ) {
 	// If we have some database actions prior to connecting the peers, we want to ensure that they had time to
 	// complete before we connect. Otherwise we might wrongly catch them in our wait function.
 	time.Sleep(100 * time.Millisecond)
 	sourceNode := nodes[cfg.SourceNodeID]
 	targetNode := nodes[cfg.TargetNodeID]
-	targetAddress := addresses[cfg.TargetNodeID]
+	targetAddress := s.nodeAddresses[cfg.TargetNodeID]
 
 	log.Info(s.ctx, "Parsing bootstrap peers", logging.NewKV("Peers", targetAddress))
 	addrs, err := netutils.ParsePeers([]string{targetAddress})
@@ -294,14 +293,13 @@ func configureReplicator(
 	s *state,
 	cfg ConfigureReplicator,
 	nodes []*net.Node,
-	addresses []string,
 ) {
 	// If we have some database actions prior to configuring the replicator, we want to ensure that they had time to
 	// complete before the configuration. Otherwise we might wrongly catch them in our wait function.
 	time.Sleep(100 * time.Millisecond)
 	sourceNode := nodes[cfg.SourceNodeID]
 	targetNode := nodes[cfg.TargetNodeID]
-	targetAddress := addresses[cfg.TargetNodeID]
+	targetAddress := s.nodeAddresses[cfg.TargetNodeID]
 
 	addr, err := ma.NewMultiaddr(targetAddress)
 	require.NoError(s.t, err)

--- a/tests/integration/state.go
+++ b/tests/integration/state.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/config"
 	"github.com/sourcenetwork/defradb/datastore"
 	"github.com/sourcenetwork/defradb/net"
@@ -57,6 +58,9 @@ type state struct {
 
 	// The paths to any file-based databases active in this test.
 	dbPaths []string
+
+	// Collections by index, by nodeID present in the test.
+	collections [][]client.Collection
 }
 
 // newState returns a new fresh state for the given testCase.
@@ -79,5 +83,6 @@ func newState(
 		nodeConfigs:              []config.Config{},
 		nodes:                    []*net.Node{},
 		dbPaths:                  []string{},
+		collections:              [][]client.Collection{},
 	}
 }

--- a/tests/integration/state.go
+++ b/tests/integration/state.go
@@ -66,6 +66,12 @@ type state struct {
 	// The names of the collections active in this test.
 	// Indexes matches that of collections.
 	collectionNames []string
+
+	// Documents by index, by collection index.
+	//
+	// Each index is assumed to be global, and may be expected across multiple
+	// nodes.
+	documents [][]*client.Document
 }
 
 // newState returns a new fresh state for the given testCase.
@@ -91,5 +97,6 @@ func newState(
 		dbPaths:                  []string{},
 		collections:              [][]client.Collection{},
 		collectionNames:          collectionNames,
+		documents:                [][]*client.Document{},
 	}
 }

--- a/tests/integration/state.go
+++ b/tests/integration/state.go
@@ -37,6 +37,9 @@ type state struct {
 
 	// Will recieve an item once all actions have finished processing.
 	allActionsDone chan struct{}
+
+	// These channels will recieve a function which asserts results of any subscription requests.
+	subscriptionResultsChans []chan func()
 }
 
 // newState returns a new fresh state for the given testCase.
@@ -47,11 +50,12 @@ func newState(
 	dbt DatabaseType,
 ) *state {
 	return &state{
-		ctx:            ctx,
-		t:              t,
-		testCase:       testCase,
-		dbt:            dbt,
-		txns:           []datastore.Txn{},
-		allActionsDone: make(chan struct{}),
+		ctx:                      ctx,
+		t:                        t,
+		testCase:                 testCase,
+		dbt:                      dbt,
+		txns:                     []datastore.Txn{},
+		allActionsDone:           make(chan struct{}),
+		subscriptionResultsChans: []chan func(){},
 	}
 }

--- a/tests/integration/state.go
+++ b/tests/integration/state.go
@@ -1,0 +1,45 @@
+// Copyright 2023 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package tests
+
+import (
+	"context"
+	"testing"
+)
+
+type state struct {
+	// The test context.
+	ctx context.Context
+
+	// The Go Test test state
+	t *testing.T
+
+	// The TestCase currently being executed.
+	testCase TestCase
+
+	// The type of database currently being tested.
+	dbt DatabaseType
+}
+
+// newState returns a new fresh state for the given testCase.
+func newState(
+	ctx context.Context,
+	t *testing.T,
+	testCase TestCase,
+	dbt DatabaseType,
+) *state {
+	return &state{
+		ctx:      ctx,
+		t:        t,
+		testCase: testCase,
+		dbt:      dbt,
+	}
+}

--- a/tests/integration/state.go
+++ b/tests/integration/state.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/sourcenetwork/defradb/config"
 	"github.com/sourcenetwork/defradb/datastore"
+	"github.com/sourcenetwork/defradb/net"
 )
 
 type state struct {
@@ -50,6 +51,12 @@ type state struct {
 
 	// The configurations for any nodes
 	nodeConfigs []config.Config
+
+	// The nodes active in this test.
+	nodes []*net.Node
+
+	// The paths to any file-based databases active in this test.
+	dbPaths []string
 }
 
 // newState returns a new fresh state for the given testCase.
@@ -70,5 +77,7 @@ func newState(
 		syncChans:                []chan struct{}{},
 		nodeAddresses:            []string{},
 		nodeConfigs:              []config.Config{},
+		nodes:                    []*net.Node{},
+		dbPaths:                  []string{},
 	}
 }

--- a/tests/integration/state.go
+++ b/tests/integration/state.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/sourcenetwork/defradb/config"
 	"github.com/sourcenetwork/defradb/datastore"
 )
 
@@ -43,6 +44,12 @@ type state struct {
 
 	// These synchronisation channels allow async actions to track their completion.
 	syncChans []chan struct{}
+
+	// The addresses of any nodes configured.
+	nodeAddresses []string
+
+	// The configurations for any nodes
+	nodeConfigs []config.Config
 }
 
 // newState returns a new fresh state for the given testCase.
@@ -61,5 +68,7 @@ func newState(
 		allActionsDone:           make(chan struct{}),
 		subscriptionResultsChans: []chan func(){},
 		syncChans:                []chan struct{}{},
+		nodeAddresses:            []string{},
+		nodeConfigs:              []config.Config{},
 	}
 }

--- a/tests/integration/state.go
+++ b/tests/integration/state.go
@@ -40,6 +40,9 @@ type state struct {
 
 	// These channels will recieve a function which asserts results of any subscription requests.
 	subscriptionResultsChans []chan func()
+
+	// These synchronisation channels allow async actions to track their completion.
+	syncChans []chan struct{}
 }
 
 // newState returns a new fresh state for the given testCase.
@@ -57,5 +60,6 @@ func newState(
 		txns:                     []datastore.Txn{},
 		allActionsDone:           make(chan struct{}),
 		subscriptionResultsChans: []chan func(){},
+		syncChans:                []chan struct{}{},
 	}
 }

--- a/tests/integration/state.go
+++ b/tests/integration/state.go
@@ -13,6 +13,8 @@ package tests
 import (
 	"context"
 	"testing"
+
+	"github.com/sourcenetwork/defradb/datastore"
 )
 
 type state struct {
@@ -27,6 +29,11 @@ type state struct {
 
 	// The type of database currently being tested.
 	dbt DatabaseType
+
+	// Any explicit transactions active in this test.
+	//
+	// This is order dependent and the property is accessed by index.
+	txns []datastore.Txn
 }
 
 // newState returns a new fresh state for the given testCase.
@@ -41,5 +48,6 @@ func newState(
 		t:        t,
 		testCase: testCase,
 		dbt:      dbt,
+		txns:     []datastore.Txn{},
 	}
 }

--- a/tests/integration/state.go
+++ b/tests/integration/state.go
@@ -72,6 +72,9 @@ type state struct {
 	// Each index is assumed to be global, and may be expected across multiple
 	// nodes.
 	documents [][]*client.Document
+
+	// Indexes, by index, by collection index, by node index.
+	indexes [][][]client.IndexDescription
 }
 
 // newState returns a new fresh state for the given testCase.
@@ -98,5 +101,6 @@ func newState(
 		collections:              [][]client.Collection{},
 		collectionNames:          collectionNames,
 		documents:                [][]*client.Document{},
+		indexes:                  [][][]client.IndexDescription{},
 	}
 }

--- a/tests/integration/state.go
+++ b/tests/integration/state.go
@@ -60,7 +60,12 @@ type state struct {
 	dbPaths []string
 
 	// Collections by index, by nodeID present in the test.
+	// Indexes matches that of collectionNames.
 	collections [][]client.Collection
+
+	// The names of the collections active in this test.
+	// Indexes matches that of collections.
+	collectionNames []string
 }
 
 // newState returns a new fresh state for the given testCase.
@@ -69,6 +74,7 @@ func newState(
 	t *testing.T,
 	testCase TestCase,
 	dbt DatabaseType,
+	collectionNames []string,
 ) *state {
 	return &state{
 		ctx:                      ctx,
@@ -84,5 +90,6 @@ func newState(
 		nodes:                    []*net.Node{},
 		dbPaths:                  []string{},
 		collections:              [][]client.Collection{},
+		collectionNames:          collectionNames,
 	}
 }

--- a/tests/integration/state.go
+++ b/tests/integration/state.go
@@ -34,6 +34,9 @@ type state struct {
 	//
 	// This is order dependent and the property is accessed by index.
 	txns []datastore.Txn
+
+	// Will recieve an item once all actions have finished processing.
+	allActionsDone chan struct{}
 }
 
 // newState returns a new fresh state for the given testCase.
@@ -44,10 +47,11 @@ func newState(
 	dbt DatabaseType,
 ) *state {
 	return &state{
-		ctx:      ctx,
-		t:        t,
-		testCase: testCase,
-		dbt:      dbt,
-		txns:     []datastore.Txn{},
+		ctx:            ctx,
+		t:              t,
+		testCase:       testCase,
+		dbt:            dbt,
+		txns:           []datastore.Txn{},
+		allActionsDone: make(chan struct{}),
 	}
 }

--- a/tests/integration/test_case.go
+++ b/tests/integration/test_case.go
@@ -270,6 +270,9 @@ type TransactionCommit struct {
 // The subscription will remain active until shortly after all actions have been processed.
 // The results of the subscription will then be asserted upon.
 type SubscriptionRequest struct {
+	// NodeID is the node ID (index) of the node in which to subscribe to.
+	NodeID immutable.Option[int]
+
 	// The subscription request to submit.
 	Request string
 
@@ -284,6 +287,9 @@ type SubscriptionRequest struct {
 }
 
 type IntrospectionRequest struct {
+	// NodeID is the node ID (index) of the node in which to introspect.
+	NodeID immutable.Option[int]
+
 	// The introspection request to use when fetching schema state.
 	//
 	// Available properties can be found in the GQL spec:
@@ -314,6 +320,9 @@ type IntrospectionRequest struct {
 // The GraphQL clients usually use this to fetch the schema state with a default introspection
 // query they provide.
 type ClientIntrospectionRequest struct {
+	// NodeID is the node ID (index) of the node in which to introspect.
+	NodeID immutable.Option[int]
+
 	// The introspection request to use when fetching schema state.
 	Request string
 

--- a/tests/integration/utils2.go
+++ b/tests/integration/utils2.go
@@ -316,11 +316,6 @@ func executeTestCase(
 	for i := startActionIndex; i <= endActionIndex; i++ {
 		switch action := testCase.Actions[i].(type) {
 		case ConfigureNode:
-			if DetectDbChanges {
-				// We do not yet support the change detector for tests running across multiple nodes.
-				t.SkipNow()
-				return
-			}
 			configureNode(s, action)
 
 		case Restart:
@@ -700,6 +695,12 @@ func configureNode(
 	s *state,
 	action ConfigureNode,
 ) {
+	if DetectDbChanges {
+		// We do not yet support the change detector for tests running across multiple nodes.
+		s.t.SkipNow()
+		return
+	}
+
 	cfg := action()
 	// WARNING: This is a horrible hack both deduplicates/randomizes peer IDs
 	// And affects where libp2p(?) stores some values on the file system, even when using

--- a/tests/integration/utils2.go
+++ b/tests/integration/utils2.go
@@ -321,11 +321,6 @@ func executeTestCase(
 		case Restart:
 			restartNodes(s, i)
 
-			// If the db was restarted we need to refresh the collection definitions as the old instances
-			// will reference the old (closed) database instances.
-			refreshCollections(s)
-			refreshIndexes(s)
-
 		case ConnectPeers:
 			connectPeers(s, action)
 
@@ -343,15 +338,9 @@ func executeTestCase(
 
 		case SchemaUpdate:
 			updateSchema(s, action)
-			// If the schema was updated we need to refresh the collection definitions.
-			refreshCollections(s)
-			refreshIndexes(s)
 
 		case SchemaPatch:
 			patchSchema(s, action)
-			// If the schema was updated we need to refresh the collection definitions.
-			refreshCollections(s)
-			refreshIndexes(s)
 
 		case ConfigureMigration:
 			configureMigration(s, action)
@@ -660,6 +649,11 @@ actionLoop:
 			)
 		}
 	}
+
+	// If the db was restarted we need to refresh the collection definitions as the old instances
+	// will reference the old (closed) database instances.
+	refreshCollections(s)
+	refreshIndexes(s)
 }
 
 // refreshCollections refreshes all the collections of the given names, preserving order.
@@ -918,6 +912,10 @@ func updateSchema(
 
 		assertExpectedErrorRaised(s.t, s.testCase.Description, action.ExpectedError, expectedErrorRaised)
 	}
+
+	// If the schema was updated we need to refresh the collection definitions.
+	refreshCollections(s)
+	refreshIndexes(s)
 }
 
 func patchSchema(
@@ -930,6 +928,10 @@ func patchSchema(
 
 		assertExpectedErrorRaised(s.t, s.testCase.Description, action.ExpectedError, expectedErrorRaised)
 	}
+
+	// If the schema was updated we need to refresh the collection definitions.
+	refreshCollections(s)
+	refreshIndexes(s)
 }
 
 // createDoc creates a document using the collection api and caches it in the


### PR DESCRIPTION
## Relevant issue(s)

Resolves #1644

## Description

Bundles all test state into single var.  Stuff was starting to get too messy as the action system expanded.  This makes all the stuff consistent, in name and location and removes the need to pass the individual items around as and when needed. All props have been documented.

It also simplifies refreshing state, as return values are no longer needed.  It opens the way to making the action system interface-based, which we can look at in the future if we want but not here in this PR. 
