### PR TITLE
fix: Fix fetcher close

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -272,7 +272,7 @@ test\:coverage-html:
 .PHONY: test\:changes
 test\:changes:
 	@$(MAKE) deps:lens
-	env DEFRA_DETECT_DATABASE_CHANGES=true gotestsum -- ./... -shuffle=on -p 1
+	env DEFRA_DETECT_DATABASE_CHANGES=true DEFRA_TARGET_BRANCH=1672-assert-true-chd-db-close gotestsum -- ./... -shuffle=on -p 1
 
 .PHONY: validate\:codecov
 validate\:codecov:

--- a/db/fetcher/fetcher.go
+++ b/db/fetcher/fetcher.go
@@ -656,22 +656,18 @@ func (df *DocumentFetcher) FetchNextDoc(
 
 // Close closes the DocumentFetcher.
 func (df *DocumentFetcher) Close() error {
-	if df.kvIter == nil {
-		return nil
+	if df.kvIter != nil {
+		err := df.kvIter.Close()
+		if err != nil {
+			return err
+		}
 	}
 
-	err := df.kvIter.Close()
-	if err != nil {
-		return err
-	}
-
-	if df.kvResultsIter == nil {
-		return nil
-	}
-
-	err = df.kvResultsIter.Close()
-	if err != nil {
-		return err
+	if df.kvResultsIter != nil {
+		err := df.kvResultsIter.Close()
+		if err != nil {
+			return err
+		}
 	}
 
 	if df.deletedDocFetcher != nil {


### PR DESCRIPTION
## Relevant issue(s)

Resolves #1672

## Description

Fixes the fetcher close logic, removing the too-early exits.

Lucky guess, but it seems to have fixed the change detector issue.

- [ ] Don't forget to remove the temp commit :) Will also need to add a breaking change doc to allow merge.