### PR TITLE
fix: Remove duplicated `peers` in peerstore prefix

### DIFF
--- a/net/node.go
+++ b/net/node.go
@@ -85,7 +85,7 @@ func NewNode(
 	// create our peerstore from the underlying defra rootstore
 	// prefixed with "p2p"
 	rootstore := db.Root()
-	pstore := namespace.Wrap(rootstore, ds.NewKey("peers"))
+	pstore := namespace.Wrap(rootstore, ds.NewKey("/db"))
 	peerstore, err := pstoreds.NewPeerstore(ctx, pstore, pstoreds.DefaultOpts())
 	if err != nil {
 		return nil, fin.Cleanup(err)


### PR DESCRIPTION
## Relevant issue(s)

Resolves #1260 

## Description

This PR changes the peerstore prefix from `/peers/peers` to `/db/peers`

## How has this been tested?

manual `defradb client dump`

Specify the platform(s) on which this was tested:
- MacOS
