### PR TITLE
fix: Fix invalid (badger) datastore state

### DIFF
--- a/db/fetcher/encoded_doc.go
+++ b/db/fetcher/encoded_doc.go
@@ -95,6 +95,7 @@ func (encdoc *encodedDocument) Reset() {
 	}
 	encdoc.filterSet = nil
 	encdoc.selectSet = nil
+	encdoc.schemaVersionID = ""
 }
 
 // Decode returns a properly decoded document object

--- a/db/fetcher/fetcher.go
+++ b/db/fetcher/fetcher.go
@@ -332,6 +332,10 @@ func (df *DocumentFetcher) nextKey(ctx context.Context, seekNext bool) (spanDone
 
 	df.kvEnd = spanDone
 	if df.kvEnd {
+		err = df.kvResultsIter.Close()
+		if err != nil {
+			return false, false, err
+		}
 		moreSpans, err := df.startNextSpan(ctx)
 		if err != nil {
 			return false, false, err

--- a/db/fetcher/fetcher.go
+++ b/db/fetcher/fetcher.go
@@ -656,22 +656,18 @@ func (df *DocumentFetcher) FetchNextDoc(
 
 // Close closes the DocumentFetcher.
 func (df *DocumentFetcher) Close() error {
-	if df.kvIter == nil {
-		return nil
+	if df.kvIter != nil {
+		err := df.kvIter.Close()
+		if err != nil {
+			return err
+		}
 	}
 
-	err := df.kvIter.Close()
-	if err != nil {
-		return err
-	}
-
-	if df.kvResultsIter == nil {
-		return nil
-	}
-
-	err = df.kvResultsIter.Close()
-	if err != nil {
-		return err
+	if df.kvResultsIter != nil {
+		err := df.kvResultsIter.Close()
+		if err != nil {
+			return err
+		}
 	}
 
 	if df.deletedDocFetcher != nil {

--- a/planner/scan.go
+++ b/planner/scan.go
@@ -48,8 +48,6 @@ type scanNode struct {
 	filter *mapper.Filter
 	slct   *mapper.Select
 
-	scanInitialized bool
-
 	fetcher fetcher.Fetcher
 
 	execInfo scanExecInfo
@@ -152,7 +150,6 @@ func (n *scanNode) initScan() error {
 		return err
 	}
 
-	n.scanInitialized = true
 	return nil
 }
 

--- a/tests/integration/query/one_to_one/with_group_related_id_test.go
+++ b/tests/integration/query/one_to_one/with_group_related_id_test.go
@@ -97,9 +97,6 @@ func TestQueryOneToOneWithGroupRelatedID(t *testing.T) {
 	testUtils.ExecuteTestCase(t, []string{"Book", "Author"}, test)
 }
 
-/* This test is temporarily disabled due to:
-https://github.com/sourcenetwork/defradb/issues/1672
-
 // This test documents unwanted behaviour, see:
 // https://github.com/sourcenetwork/defradb/issues/1654
 func TestQueryOneToOneWithGroupRelatedIDFromSecondary(t *testing.T) {
@@ -177,4 +174,3 @@ func TestQueryOneToOneWithGroupRelatedIDFromSecondary(t *testing.T) {
 
 	testUtils.ExecuteTestCase(t, []string{"Book", "Author"}, test)
 }
-*/


### PR DESCRIPTION
## Relevant issue(s)

Resolves #1672

## Description

Fixes invalid datastore state where somehow the iterator is not closed properly, even though Close is called.  I am guessing that something is getting GC'd before it can be closed, as closing it immediately after use appears to remove the issue.

Bug discovered testing with badger-file, but I cannot be sure where the GC'd object is, and so it could be within the ipfs code, which could mean other datastore implementations were exposed to this.

Fix is commit `Close iterator on spanDone` *only*, the others are small improvements to the codebase I found along the way.
