### PR TITLE
chore: Bump to GoLang v1.20

### DIFF
--- a/.github/workflows/build-dependencies.yml
+++ b/.github/workflows/build-dependencies.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Setup Go environment explicitly
         uses: actions/setup-go@v3
         with:
-          go-version: "1.19"
+          go-version: "1.20"
           check-latest: true
 
       - name: Build all dependencies

--- a/.github/workflows/check-vulnerabilities.yml
+++ b/.github/workflows/check-vulnerabilities.yml
@@ -1,0 +1,39 @@
+# Copyright 2023 Democratized Data Foundation
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.txt.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0, included in the file
+# licenses/APL.txt.
+
+name: Check Vulnerabilities Workflow
+
+on:
+  pull_request:
+    branches:
+      - master
+      - develop
+
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+    branches:
+      - master
+      - develop
+
+jobs:
+  check-vulnerabilities:
+    name: Check vulnerabilities job
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Run govulncheck
+        uses: golang/govulncheck-action@v1
+        with:
+          go-version-input: "1.19.5"
+          go-package: ./...
+          check-latest: true
+          cache: true

--- a/.github/workflows/check-vulnerabilities.yml
+++ b/.github/workflows/check-vulnerabilities.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Run govulncheck
         uses: golang/govulncheck-action@v1
         with:
-          go-version-input: "1.19.5"
+          go-version-input: "1.20"
           go-package: ./...
           check-latest: true
           cache: true

--- a/.github/workflows/code-test-coverage.yml
+++ b/.github/workflows/code-test-coverage.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Go environment explicitly
         uses: actions/setup-go@v3
         with:
-          go-version: "1.19"
+          go-version: "1.20"
           check-latest: true
 
       - name: Generate full test coverage report using go-acc

--- a/.github/workflows/detect-change.yml
+++ b/.github/workflows/detect-change.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Go environment explicitly
         uses: actions/setup-go@v3
         with:
-          go-version: "1.19"
+          go-version: "1.20"
           check-latest: true
 
       - name: Build dependencies

--- a/.github/workflows/lint-then-benchmark.yml
+++ b/.github/workflows/lint-then-benchmark.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Setup Go environment explicitly
         uses: actions/setup-go@v3
         with:
-          go-version: "1.19"
+          go-version: "1.20"
           check-latest: true
 
       - name: Run the golangci-lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -46,7 +46,7 @@ jobs:
           # Required: the version of golangci-lint is required.
           # Note: The version should not pick the patch version as the latest patch
           #  version is what will always be used.
-          version: v1.51
+          version: v1.53
 
           # Optional: working directory, useful for monorepos or if we wanted to run this
           #  on a non-root directory.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Go environment explicitly
         uses: actions/setup-go@v3
         with:
-          go-version: "1.19"
+          go-version: "1.20"
           check-latest: true
 
       - name: Check linting through golangci-lint

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Go environment explicitly
         uses: actions/setup-go@v3
         with:
-          go-version: "1.19"
+          go-version: "1.20"
           check-latest: true
 
       - name: Build dependencies

--- a/.github/workflows/start-binary.yml
+++ b/.github/workflows/start-binary.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Setup Go environment explicitly
         uses: actions/setup-go@v3
         with:
-          go-version: "1.19"
+          go-version: "1.20"
           check-latest: true
 
       - name: Build modules

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ client\:add-schema:
 
 .PHONY: deps\:lint
 deps\:lint:
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.53
 
 .PHONY: deps\:test
 deps\:test:

--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,7 @@ verify:
 
 .PHONY: tidy
 tidy:
-	go mod tidy -go=1.19
+	go mod tidy -go=1.20
 
 .PHONY: clean
 clean:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sourcenetwork/defradb
 
-go 1.19
+go 1.20
 
 require (
 	github.com/bits-and-blooms/bitset v1.8.0

--- a/tests/bench/bench_util.go
+++ b/tests/bench/bench_util.go
@@ -13,9 +13,7 @@ package bench
 import (
 	"context"
 	"fmt"
-	"hash/fnv"
 	"math"
-	"math/rand"
 	"os"
 	"sync"
 	"testing"
@@ -43,24 +41,10 @@ var (
 func init() {
 	logging.SetConfig(logging.Config{Level: logging.NewLogLevelOption(logging.Error)})
 
-	// create a consistent seed value for the random package
-	// so we don't have random fluctuations between runs
-	// (specifically thinking about the fixture generation stuff)
-	seed := hashToInt64("https://xkcd.com/221/")
-	rand.Seed(seed)
-
 	// assign if not empty
 	if s := os.Getenv(storageEnvName); s != "" {
 		storage = s
 	}
-}
-
-// hashToInt64 uses the FNV-1 hash to int
-// algorithm
-func hashToInt64(s string) int64 {
-	h := fnv.New64a()
-	h.Write([]byte(s))
-	return int64(h.Sum64())
 }
 
 func SetupCollections(

--- a/tests/bench/storage/utils.go
+++ b/tests/bench/storage/utils.go
@@ -12,7 +12,8 @@ package storage
 
 import (
 	"context"
-	"math/rand"
+	"crypto/rand"
+	mathRand "math/rand"
 	"sort"
 	"testing"
 
@@ -327,5 +328,5 @@ func getSampledIndex(populationSize int, sampleSize int, i int) int {
 	}
 
 	pointsPerInterval := populationSize / sampleSize
-	return (i * pointsPerInterval) + rand.Intn(pointsPerInterval)
+	return (i * pointsPerInterval) + mathRand.Intn(pointsPerInterval)
 }

--- a/tests/integration/change_detector.go
+++ b/tests/integration/change_detector.go
@@ -89,8 +89,8 @@ func detectDbChangesInit(repository string, targetBranch string) {
 
 	latestTargetCommitHash := getLatestCommit(repository, targetBranch)
 	detectDbChangesCodeDir = path.Join(changeDetectorTempDir, "code", latestTargetCommitHash)
-	rand.Seed(time.Now().Unix())
-	randNumber := rand.Int()
+	r := rand.New(rand.NewSource(time.Now().Unix()))
+	randNumber := r.Int()
 	dbsDir := path.Join(changeDetectorTempDir, "dbs", fmt.Sprint(randNumber))
 
 	testPackagePath, isIntegrationTest := getTestPackagePath()

--- a/tools/cloud/aws/packer/build_aws_ami.pkr.hcl
+++ b/tools/cloud/aws/packer/build_aws_ami.pkr.hcl
@@ -66,8 +66,8 @@ build {
     inline = [
       "/usr/bin/cloud-init status --wait",
       "sudo apt-get update && sudo apt-get install make build-essential -y",
-      "curl -OL https://golang.org/dl/go1.19.8.linux-amd64.tar.gz",
-      "rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.19.8.linux-amd64.tar.gz",
+      "curl -OL https://golang.org/dl/go1.20.6.linux-amd64.tar.gz",
+      "rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.20.6.linux-amd64.tar.gz",
       "export PATH=$PATH:/usr/local/go/bin",
       "git clone \"https://git@$DEFRADB_GIT_REPO\"",
       "cd ./defradb || { printf \"\\\ncd into defradb failed.\\\n\" && exit 2; }",

--- a/tools/configs/golangci.yaml
+++ b/tools/configs/golangci.yaml
@@ -57,7 +57,7 @@ run:
 
   # Define the Go version limit.
   # Default: use Go version from the go.mod file, fallback on the env var `GOVERSION`.
-  go: "1.19"
+  go: "1.20"
 
 #=====================================================================================[ Output Configuration Options ]
 output:
@@ -263,7 +263,7 @@ linters-settings:
 
   gosimple:
     # Select the Go version to target.
-    go: "1.19"
+    go: "1.20"
     # https://staticcheck.io/docs/options#checks
     checks: ["all", "-S1038"]
     # Turn on all except (these are disabled):
@@ -355,13 +355,13 @@ linters-settings:
 
   staticcheck:
     # Select the Go version to target.
-    go: "1.19"
+    go: "1.20"
     # https://staticcheck.io/docs/options#checks
     checks: ["all"]
 
   unused:
     # Select the Go version to target.
-    go: "1.19"
+    go: "1.20"
 
   whitespace:
     # Enforces newlines (or comments) after every multi-line if statement.

--- a/tools/defradb-builder.containerfile
+++ b/tools/defradb-builder.containerfile
@@ -2,7 +2,7 @@
 
 # An image with defradb's code and go tooling available, to assemble in a larger container.
 
-FROM docker.io/golang:1.19 AS BUILD
+FROM docker.io/golang:1.20 AS BUILD
 
 WORKDIR /lib/defradb/
 

--- a/tools/defradb.containerfile
+++ b/tools/defradb.containerfile
@@ -4,7 +4,7 @@
 
 # Stage: BUILD
 # Several steps are involved to enable caching and because of the behavior of COPY regarding directories.
-FROM docker.io/golang:1.19 AS BUILD
+FROM docker.io/golang:1.20 AS BUILD
 WORKDIR /repo/
 COPY go.mod go.sum Makefile ./
 RUN make deps:modules


### PR DESCRIPTION
## Relevant issue(s)
- Resolves #522
- Resolves #1687 

## Description
- This is a routine version bump of GoLang, the previous bump was done in (https://github.com/sourcenetwork/defradb/pull/818)
- This PR also introduces a new workflow action (not-mandatory to pass in order to merge) that was showing some vulnerabilities pre-version-bump, all of the vulnerabilities were resolved once the golang version was bumped. In future this trigger will be used to bump golang versions.
- Also updates the golang version for AWS AMI generation.

Note:
- Before the bump we had 13 vulnerabilities: https://github.com/sourcenetwork/defradb/actions/runs/5629964770/job/15255493129?pr=1688
- After the bump: passing with no vulnerabilities.


## How has this been tested?
- Added action that failed with vulnerabilities.
- Bumped version.
- Vulnerabilities were resolved and action passed.

Specify the platform(s) on which this was tested:
- Arch Linux