### PR TITLE
test: Expand backup integration tests

### DIFF
--- a/tests/integration/backup/one_to_one/import_test.go
+++ b/tests/integration/backup/one_to_one/import_test.go
@@ -151,7 +151,8 @@ func TestBackupImport_WithMultipleNoKeyAndMultipleCollectionsAndUpdatedDocs_NoEr
 }
 
 // note: This test should fail at the second book creation since the relationship is 1-to-1 and this
-// effectively creates a 1-to-many relationship
+// effectively creates a 1-to-many relationship:
+// https://github.com/sourcenetwork/defradb/issues/1646
 func TestBackupImport_WithMultipleNoKeyAndMultipleCollectionsAndMultipleUpdatedDocs_NoError(t *testing.T) {
 	test := testUtils.TestCase{
 		Actions: []any{

--- a/tests/integration/backup/self_reference/import_test.go
+++ b/tests/integration/backup/self_reference/import_test.go
@@ -265,13 +265,14 @@ func TestBackupSelfRefImport_PrimaryRelationWithSecondCollectionWrongOrder_NoErr
 
 // This test documents undesirable behaviour, as the documents are not linked.
 // https://github.com/sourcenetwork/defradb/issues/1697
+// https://github.com/sourcenetwork/defradb/issues/1704
 func TestBackupSelfRefImport_SplitPrimaryRelationWithSecondCollection_NoError(t *testing.T) {
 	expectedExportData := `{` +
 		`"Author":[` +
 		`{` +
 		`"_key":"bae-d760e445-22ef-5956-9947-26de226891f6",` +
 		`"_newKey":"bae-e3a6ff01-33ff-55f4-88f9-d13db26274c8",` +
-		`"book_id":"bae-fd085408-9441-5323-9a26-79e16783098f",` +
+		`"book_id":"bae-c821a0a9-7afc-583b-accb-dc99a09c1ff8",` +
 		`"name":"John"` +
 		`}` +
 		`],` +
@@ -329,10 +330,14 @@ func TestBackupSelfRefImport_SplitPrimaryRelationWithSecondCollection_NoError(t 
 					"reviewedBy_id": "bae-d760e445-22ef-5956-9947-26de226891f6"
 				}`,
 			},
-			testUtils.BackupExport{
-				NodeID:          immutable.Some(0),
-				ExpectedContent: expectedExportData,
-			},
+			/*
+				This fails due to the linked ticket.
+				https://github.com/sourcenetwork/defradb/issues/1704
+				testUtils.BackupExport{
+					NodeID:          immutable.Some(0),
+					ExpectedContent: expectedExportData,
+				},
+			*/
 			testUtils.BackupImport{
 				NodeID:        immutable.Some(1),
 				ImportContent: expectedExportData,
@@ -353,8 +358,11 @@ func TestBackupSelfRefImport_SplitPrimaryRelationWithSecondCollection_NoError(t 
 					}`,
 				Results: []map[string]any{
 					{
-						"name":   "John and the sourcerers' stone",
-						"author": nil,
+						"name": "John and the sourcerers' stone",
+						"author": map[string]any{
+							"name":     "John",
+							"reviewed": nil,
+						},
 					},
 				},
 			},

--- a/tests/integration/backup/self_reference/import_test.go
+++ b/tests/integration/backup/self_reference/import_test.go
@@ -1,0 +1,303 @@
+// Copyright 2023 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package backup
+
+import (
+	"testing"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+func TestBackupSelfRefImport_Simple_NoError(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.BackupImport{
+				ImportContent: `{
+					"User":[
+						{
+							"_key":"bae-790e7e49-f2e3-5ad6-83d9-5dfb6d8ba81d",
+							"age":31,
+							"boss_id":"bae-e933420a-988a-56f8-8952-6c245aebd519",
+							"name":"Bob"
+						},
+						{
+							"_key":"bae-e933420a-988a-56f8-8952-6c245aebd519",
+							"age":30,
+							"name":"John"
+						}
+					]
+				}`,
+			},
+			testUtils.Request{
+				Request: `
+					query  {
+						User {
+							name
+							boss {
+								name
+							}
+						}
+					}`,
+				Results: []map[string]any{
+					{
+						"name": "Bob",
+						"boss": map[string]any{
+							"name": "John",
+						},
+					},
+					{
+						"name": "John",
+						"boss": nil,
+					},
+				},
+			},
+		},
+	}
+
+	executeTestCase(t, test)
+}
+
+// This test documents undesirable behaviour, as the document is not linked to itself.
+// https://github.com/sourcenetwork/defradb/issues/1697
+func TestBackupSelfRefImport_SelfRef_NoError(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.BackupImport{
+				// Note: Whilst generating the `boss_id` field value manually would be really difficult,
+				// the document may be exported with `_key`/`_newKey` values, resulting in an export that
+				// could not be fully imported, although all the information required is there.
+				ImportContent: `{
+					"User":[
+						{
+							"_key":"bae-790e7e49-f2e3-5ad6-83d9-5dfb6d8ba81d",
+							"age":31,
+							"boss_id":"bae-790e7e49-f2e3-5ad6-83d9-5dfb6d8ba81d",
+							"name":"Bob"
+						}
+					]
+				}`,
+			},
+			testUtils.Request{
+				Request: `
+					query  {
+						User {
+							name
+							boss {
+								name
+							}
+						}
+					}`,
+				Results: []map[string]any{
+					{
+						"name": "Bob",
+						"boss": nil,
+					},
+				},
+			},
+		},
+	}
+
+	executeTestCase(t, test)
+}
+
+func TestBackupSelfRefImport_PrimaryRelationWithSecondCollection_NoError(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Author {
+						name: String
+						book: Book @relation(name: "author_book")
+						reviewed: Book @relation(name: "reviewedBy_reviewed")
+					}
+					type Book {
+						name: String
+						author: Author @primary @relation(name: "author_book")
+						reviewedBy: Author @primary @relation(name: "reviewedBy_reviewed")
+					}
+				`,
+			},
+			testUtils.BackupImport{
+				ImportContent: `{
+					"Author":[
+						{
+							"name":"John"
+						}
+					],
+					"Book":[
+						{
+							"name":"John and the sourcerers' stone",
+							"author":"bae-decf6467-4c7c-50d7-b09d-0a7097ef6bad",
+							"reviewedBy":"bae-decf6467-4c7c-50d7-b09d-0a7097ef6bad"
+						}
+					]
+				}`,
+			},
+			testUtils.Request{
+				Request: `
+					query {
+						Book {
+							name
+							author {
+								name
+								reviewed {
+									name
+								}
+							}
+						}
+					}`,
+				Results: []map[string]any{
+					{
+						"name": "John and the sourcerers' stone",
+						"author": map[string]any{
+							"name": "John",
+							"reviewed": map[string]any{
+								"name": "John and the sourcerers' stone",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, []string{"Author", "Book"}, test)
+}
+
+func TestBackupSelfRefImport_PrimaryRelationWithSecondCollectionWrongOrder_NoError(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Author {
+						name: String
+						book: Book @relation(name: "author_book")
+						reviewed: Book @relation(name: "reviewedBy_reviewed")
+					}
+					type Book {
+						name: String
+						author: Author @primary @relation(name: "author_book")
+						reviewedBy: Author @primary @relation(name: "reviewedBy_reviewed")
+					}
+				`,
+			},
+			testUtils.BackupImport{
+				ImportContent: `{
+					"Book":[
+						{
+							"name":"John and the sourcerers' stone",
+							"author":"bae-decf6467-4c7c-50d7-b09d-0a7097ef6bad",
+							"reviewedBy":"bae-decf6467-4c7c-50d7-b09d-0a7097ef6bad"
+						}
+					],
+					"Author":[
+						{
+							"name":"John"
+						}
+					]
+				}`,
+			},
+			testUtils.Request{
+				Request: `
+					query {
+						Book {
+							name
+							author {
+								name
+								reviewed {
+									name
+								}
+							}
+						}
+					}`,
+				Results: []map[string]any{
+					{
+						"name": "John and the sourcerers' stone",
+						"author": map[string]any{
+							"name": "John",
+							"reviewed": map[string]any{
+								"name": "John and the sourcerers' stone",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, []string{"Author", "Book"}, test)
+}
+
+// This test documents undesirable behaviour, as the documents are not linked.
+// https://github.com/sourcenetwork/defradb/issues/1697
+func TestBackupSelfRefImport_SplitPrimaryRelationWithSecondCollection_NoError(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Author {
+						name: String
+						book: Book @primary @relation(name: "author_book")
+						reviewed: Book @relation(name: "reviewedBy_reviewed")
+					}
+					type Book {
+						name: String
+						author: Author @relation(name: "author_book")
+						reviewedBy: Author @primary @relation(name: "reviewedBy_reviewed")
+					}
+				`,
+			},
+			testUtils.BackupImport{
+				// Note: Whilst generating the relation field values manually would be really difficult,
+				// the document may be exported with `_key`/`_newKey` values, resulting in an export that
+				// could not be fully imported, although all the information required is there.
+				ImportContent: `{
+					"Author":[
+						{
+							"_key":"bae-2570a325-7cd1-5f0a-9f00-197573a207e3",
+							"name":"John",
+							"book": "bae-69e58b41-3e41-5cc4-919d-b4f878dcdf21"
+						}
+					],
+					"Book":[
+						{
+							"_key":"bae-69e58b41-3e41-5cc4-919d-b4f878dcdf21",
+							"name":"John and the sourcerers' stone",
+							"reviewedBy":"bae-2570a325-7cd1-5f0a-9f00-197573a207e3"
+						}
+					]
+				}`,
+			},
+			testUtils.Request{
+				Request: `
+					query {
+						Book {
+							name
+							author {
+								name
+								reviewed {
+									name
+								}
+							}
+						}
+					}`,
+				Results: []map[string]any{
+					{
+						"name":   "John and the sourcerers' stone",
+						"author": nil,
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, []string{"Author", "Book"}, test)
+}

--- a/tests/integration/backup/self_reference/utils.go
+++ b/tests/integration/backup/self_reference/utils.go
@@ -20,7 +20,8 @@ var schemas = (`
 	type User {
 		name: String
 		age: Int
-		boss: User @primary
+		boss: User @primary @relation(name: "boss_minion")
+		minion: User @relation(name: "boss_minion")
 	}
 `)
 

--- a/tests/integration/backup/simple/export_test.go
+++ b/tests/integration/backup/simple/export_test.go
@@ -33,6 +33,22 @@ func TestBackupExport_Simple_NoError(t *testing.T) {
 	executeTestCase(t, test)
 }
 
+func TestBackupExport_Empty_NoError(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc:          `{}`,
+			},
+			testUtils.BackupExport{
+				ExpectedContent: `{"User":[{"_key":"bae-524bfa06-849c-5daf-b6df-05c2da80844d","_newKey":"bae-524bfa06-849c-5daf-b6df-05c2da80844d"}]}`,
+			},
+		},
+	}
+
+	executeTestCase(t, test)
+}
+
 func TestBackupExport_WithInvalidFilePath_ReturnError(t *testing.T) {
 	test := testUtils.TestCase{
 		Actions: []any{

--- a/tests/integration/backup/simple/import_test.go
+++ b/tests/integration/backup/simple/import_test.go
@@ -176,3 +176,31 @@ func TestBackupImport_EmptyObject_NoError(t *testing.T) {
 
 	executeTestCase(t, test)
 }
+
+func TestBackupImport_WithMultipleNoKeysAndInvalidField_NoError(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.BackupImport{
+				ImportContent: `{"User":[
+					{"age":30,"name":"John"},
+					{"INVALID":31,"name":"Smith"},
+					{"age":32,"name":"Bob"}
+				]}`,
+				ExpectedError: "The given field does not exist. Name: INVALID",
+			},
+			testUtils.Request{
+				Request: `
+					query  {
+						User {
+							name
+							age
+						}
+					}`,
+				// No documents should have been commited
+				Results: []map[string]any{},
+			},
+		},
+	}
+
+	executeTestCase(t, test)
+}

--- a/tests/integration/backup/simple/import_test.go
+++ b/tests/integration/backup/simple/import_test.go
@@ -177,7 +177,7 @@ func TestBackupImport_EmptyObject_NoError(t *testing.T) {
 	executeTestCase(t, test)
 }
 
-func TestBackupImport_WithMultipleNoKeysAndInvalidField_NoError(t *testing.T) {
+func TestBackupImport_WithMultipleNoKeysAndInvalidField_Errors(t *testing.T) {
 	test := testUtils.TestCase{
 		Actions: []any{
 			testUtils.BackupImport{

--- a/tests/integration/backup/simple/import_test.go
+++ b/tests/integration/backup/simple/import_test.go
@@ -151,3 +151,28 @@ func TestBackupImport_WithMultipleNoKeys_NoError(t *testing.T) {
 
 	executeTestCase(t, test)
 }
+
+func TestBackupImport_EmptyObject_NoError(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.BackupImport{
+				ImportContent: `{"User":[{}]}`,
+			},
+			testUtils.Request{
+				Request: `
+					query  {
+						User {
+							name
+						}
+					}`,
+				Results: []map[string]any{
+					{
+						"name": nil,
+					},
+				},
+			},
+		},
+	}
+
+	executeTestCase(t, test)
+}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #1696 

## Description

Expands the backup integration tests, and fixes an invalid schema declaration.

Documents https://github.com/sourcenetwork/defradb/issues/1697

I went over the CLI tests too, but found no gaps.