### PR TITLE
refactor: Schema list output to include schemaVersionID

### DIFF
--- a/api/http/handlerfuncs.go
+++ b/api/http/handlerfuncs.go
@@ -244,8 +244,9 @@ func loadSchemaHandler(rw http.ResponseWriter, req *http.Request) {
 			return
 		}
 		colResp[i] = collectionResponse{
-			Name: col.Name(),
-			ID:   col.SchemaID(),
+			Name:      col.Name(),
+			ID:        col.SchemaID(),
+			VersionID: col.Schema().VersionID,
 		}
 	}
 

--- a/api/http/handlerfuncs.go
+++ b/api/http/handlerfuncs.go
@@ -164,9 +164,10 @@ type fieldResponse struct {
 }
 
 type collectionResponse struct {
-	Name   string          `json:"name"`
-	ID     string          `json:"id"`
-	Fields []fieldResponse `json:"fields,omitempty"`
+	Name      string          `json:"name"`
+	ID        string          `json:"id"`
+	VersionID string          `json:"version_id"`
+	Fields    []fieldResponse `json:"fields,omitempty"`
 }
 
 func listSchemaHandler(rw http.ResponseWriter, req *http.Request) {
@@ -201,9 +202,10 @@ func listSchemaHandler(rw http.ResponseWriter, req *http.Request) {
 			fields = append(fields, fieldRes)
 		}
 		colResp[i] = collectionResponse{
-			Name:   col.Name(),
-			ID:     col.SchemaID(),
-			Fields: fields,
+			Name:      col.Name(),
+			ID:        col.SchemaID(),
+			VersionID: col.Schema().VersionID,
+			Fields:    fields,
 		}
 	}
 

--- a/api/http/handlerfuncs_test.go
+++ b/api/http/handlerfuncs_test.go
@@ -651,8 +651,9 @@ type group {
 		assert.Equal(t, map[string]any{
 			"collections": []any{
 				map[string]any{
-					"name": "group",
-					"id":   "bafkreieunyhcyupkdppyo2g4zcqtdxvj5xi4f422gp2jwene6ohndvcobe",
+					"name":       "group",
+					"id":         "bafkreieunyhcyupkdppyo2g4zcqtdxvj5xi4f422gp2jwene6ohndvcobe",
+					"version_id": "bafkreieunyhcyupkdppyo2g4zcqtdxvj5xi4f422gp2jwene6ohndvcobe",
 					"fields": []any{
 						map[string]any{
 							"id":       "0",
@@ -681,8 +682,9 @@ type group {
 					},
 				},
 				map[string]any{
-					"name": "user",
-					"id":   "bafkreigrucdl7x3lsa4xwgz2bn7lbqmiwkifnspgx7hlkpaal3o55325bq",
+					"name":       "user",
+					"id":         "bafkreigrucdl7x3lsa4xwgz2bn7lbqmiwkifnspgx7hlkpaal3o55325bq",
+					"version_id": "bafkreigrucdl7x3lsa4xwgz2bn7lbqmiwkifnspgx7hlkpaal3o55325bq",
 					"fields": []any{
 						map[string]any{
 							"id":       "0",
@@ -849,8 +851,9 @@ type User {
 			"result": "success",
 			"collections": []any{
 				map[string]any{
-					"name": "User",
-					"id":   "bafkreibpnvkvjqvg4skzlijka5xe63zeu74ivcjwd76q7yi65jdhwqhske",
+					"name":       "User",
+					"id":         "bafkreibpnvkvjqvg4skzlijka5xe63zeu74ivcjwd76q7yi65jdhwqhske",
+					"version_id": "bafkreibpnvkvjqvg4skzlijka5xe63zeu74ivcjwd76q7yi65jdhwqhske",
 				},
 			},
 		}, v)

--- a/cli/schema_list.go
+++ b/cli/schema_list.go
@@ -25,9 +25,10 @@ import (
 type schemaListResponse struct {
 	Data struct {
 		Collections []struct {
-			Name   string `json:"name"`
-			ID     string `json:"id"`
-			Fields []struct {
+			Name      string `json:"name"`
+			ID        string `json:"id"`
+			VersionID string `json:"version_id"`
+			Fields    []struct {
 				ID       string `json:"id"`
 				Name     string `json:"name"`
 				Kind     string `json:"kind"`
@@ -70,13 +71,15 @@ func MakeSchemaListCommand(cfg *config.Config) *cobra.Command {
 			}
 
 			for _, c := range r.Data.Collections {
+				cmd.Printf("# Schema ID: %s\n", c.ID)
+				cmd.Printf("# Version ID: %s\n", c.VersionID)
 				cmd.Printf("type %s {\n", c.Name)
 				for _, f := range c.Fields {
 					if !f.Internal {
 						cmd.Printf("\t%s: %s\n", f.Name, f.Kind)
 					}
 				}
-				cmd.Printf("}\n")
+				cmd.Printf("}\n\n")
 			}
 
 			return nil

--- a/tests/integration/cli/client_schema_add_test.go
+++ b/tests/integration/cli/client_schema_add_test.go
@@ -30,7 +30,7 @@ func TestAddSchemaFromFile(t *testing.T) {
 
 	nodeLog := stopDefra()
 
-	jsonReponse := `{"data":{"collections":[{"name":"User","id":"bafkreib5hb7mr7ecbdufd7mvv6va6mpxukjai7hpnqkhxonnw7lzwfqlja"}],"result":"success"}}`
+	jsonReponse := `{"data":{"collections":[{"name":"User","id":"bafkreib5hb7mr7ecbdufd7mvv6va6mpxukjai7hpnqkhxonnw7lzwfqlja","version_id":"bafkreib5hb7mr7ecbdufd7mvv6va6mpxukjai7hpnqkhxonnw7lzwfqlja"}],"result":"success"}}`
 	assert.Contains(t, stdout, jsonReponse)
 	assertNotContainsSubstring(t, nodeLog, "ERROR")
 }
@@ -47,7 +47,7 @@ func TestAddSchemaWithDuplicateType(t *testing.T) {
 
 	_ = stopDefra()
 
-	jsonReponse := `{"data":{"collections":[{"name":"Post","id":"bafkreicgpbla5wlogpinnm32arcqzptusdc5tzdznipqrf6nkroav6b25a"}],"result":"success"}}`
+	jsonReponse := `{"data":{"collections":[{"name":"Post","id":"bafkreicgpbla5wlogpinnm32arcqzptusdc5tzdznipqrf6nkroav6b25a","version_id":"bafkreicgpbla5wlogpinnm32arcqzptusdc5tzdznipqrf6nkroav6b25a"}],"result":"success"}}`
 	assertContainsSubstring(t, stdout1, jsonReponse)
 	assertContainsSubstring(t, stdout2, `schema type already exists. Name: Post`)
 }


### PR DESCRIPTION
## Relevant issue(s)

Resolves #1705 

## Description

Adds some additional `schemaID` and `schemaVersionID` fields to the `schema list` API, both HTTP and CLI

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).

## How has this been tested?
- Manually
- Updated integration tests

Specify the platform(s) on which this was tested:
- Ubuntu WSL
