### PR TITLE
fix: Fix os.Exit(1) on badger close

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -273,7 +273,7 @@ test\:coverage-html:
 .PHONY: test\:changes
 test\:changes:
 	@$(MAKE) deps:lens
-	env DEFRA_DETECT_DATABASE_CHANGES=true gotestsum -- ./tests/integration/query/one_to_many_to_one --run TestQueryOneToOneRelations -shuffle=on -p 1
+	env DEFRA_DETECT_DATABASE_CHANGES=true DEFRA_TARGET_BRANCH=1702-flaky-close-issue gotestsum -- ./tests/integration/query/one_to_many_to_one --run TestQueryOneToOneRelations -shuffle=on -p 1
 
 .PHONY: validate\:codecov
 validate\:codecov:

--- a/Makefile
+++ b/Makefile
@@ -273,7 +273,7 @@ test\:coverage-html:
 .PHONY: test\:changes
 test\:changes:
 	@$(MAKE) deps:lens
-	env DEFRA_DETECT_DATABASE_CHANGES=true gotestsum -- ./... -shuffle=on -p 1
+	env DEFRA_DETECT_DATABASE_CHANGES=true gotestsum -- ./tests/integration/query/one_to_many_to_one --run TestQueryOneToOneRelations -shuffle=on -p 1
 
 .PHONY: validate\:codecov
 validate\:codecov:


### PR DESCRIPTION
## Relevant issue(s)

Resolves #1702

## Description

Fixes os.Exit(1) on badger close by manually triggering the badger GC before closing.  Seems to solve the problem.

Todo:
- [ ] Drop the temp commits once happy is consistently passing in the CI
