### PR TITLE
fix: Discard index and subscription implicit transactions

### DIFF
--- a/db/collection_index.go
+++ b/db/collection_index.go
@@ -403,6 +403,8 @@ func (c *collection) GetIndexes(ctx context.Context) ([]client.IndexDescription,
 	if err != nil {
 		return nil, err
 	}
+	defer c.discardImplicitTxn(ctx, txn)
+
 	err = c.loadIndexes(ctx, txn)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Relevant issue(s)

Resolves #1714

## Description

Discard index and subscription implicit transactions.

I'm not sure if this was causing any problems, but they should be discarded. 