### PR TITLE
test(i): Remove collection names param from ExecuteTestCase

### DIFF
--- a/tests/integration/backup/one_to_many/utils.go
+++ b/tests/integration/backup/one_to_many/utils.go
@@ -30,7 +30,7 @@ var schemas = (`
 `)
 
 func executeTestCase(t *testing.T, test testUtils.TestCase) {
-	testUtils.ExecuteTEMP(
+	testUtils.ExecuteTestCase(
 		t,
 		testUtils.TestCase{
 			Description: test.Description,

--- a/tests/integration/backup/one_to_many/utils.go
+++ b/tests/integration/backup/one_to_many/utils.go
@@ -30,9 +30,8 @@ var schemas = (`
 `)
 
 func executeTestCase(t *testing.T, test testUtils.TestCase) {
-	testUtils.ExecuteTestCase(
+	testUtils.ExecuteTEMP(
 		t,
-		[]string{"User", "Book"},
 		testUtils.TestCase{
 			Description: test.Description,
 			Actions: append(

--- a/tests/integration/backup/one_to_one/export_test.go
+++ b/tests/integration/backup/one_to_one/export_test.go
@@ -141,7 +141,7 @@ func TestBackupExport_DoubleReletionship_NoError(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestBackupExport_DoubleReletionshipWithUpdate_NoError(t *testing.T) {
@@ -189,7 +189,7 @@ func TestBackupExport_DoubleReletionshipWithUpdate_NoError(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 // note: This test should fail at the second book creation since the relationship is 1-to-1 and this
@@ -239,5 +239,5 @@ func TestBackupExport_DoubleReletionshipWithUpdateAndDoublylinked_NoError(t *tes
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/backup/one_to_one/export_test.go
+++ b/tests/integration/backup/one_to_one/export_test.go
@@ -141,7 +141,7 @@ func TestBackupExport_DoubleReletionship_NoError(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"User", "Book"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestBackupExport_DoubleReletionshipWithUpdate_NoError(t *testing.T) {
@@ -189,7 +189,7 @@ func TestBackupExport_DoubleReletionshipWithUpdate_NoError(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"User", "Book"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 // note: This test should fail at the second book creation since the relationship is 1-to-1 and this
@@ -239,5 +239,5 @@ func TestBackupExport_DoubleReletionshipWithUpdateAndDoublylinked_NoError(t *tes
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"User", "Book"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/backup/one_to_one/import_test.go
+++ b/tests/integration/backup/one_to_one/import_test.go
@@ -290,5 +290,5 @@ func TestBackupImport_DoubleRelationshipWithUpdate_NoError(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/backup/one_to_one/import_test.go
+++ b/tests/integration/backup/one_to_one/import_test.go
@@ -290,5 +290,5 @@ func TestBackupImport_DoubleRelationshipWithUpdate_NoError(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"User", "Book"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/backup/one_to_one/utils.go
+++ b/tests/integration/backup/one_to_one/utils.go
@@ -30,7 +30,7 @@ var schemas = (`
 `)
 
 func executeTestCase(t *testing.T, test testUtils.TestCase) {
-	testUtils.ExecuteTEMP(
+	testUtils.ExecuteTestCase(
 		t,
 		testUtils.TestCase{
 			Description: test.Description,

--- a/tests/integration/backup/one_to_one/utils.go
+++ b/tests/integration/backup/one_to_one/utils.go
@@ -30,9 +30,8 @@ var schemas = (`
 `)
 
 func executeTestCase(t *testing.T, test testUtils.TestCase) {
-	testUtils.ExecuteTestCase(
+	testUtils.ExecuteTEMP(
 		t,
-		[]string{"User", "Book"},
 		testUtils.TestCase{
 			Description: test.Description,
 			Actions: append(

--- a/tests/integration/backup/self_reference/import_test.go
+++ b/tests/integration/backup/self_reference/import_test.go
@@ -132,7 +132,7 @@ func TestBackupSelfRefImport_SelfRef_NoError(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestBackupSelfRefImport_PrimaryRelationWithSecondCollection_NoError(t *testing.T) {
@@ -196,7 +196,7 @@ func TestBackupSelfRefImport_PrimaryRelationWithSecondCollection_NoError(t *test
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestBackupSelfRefImport_PrimaryRelationWithSecondCollectionWrongOrder_NoError(t *testing.T) {
@@ -260,7 +260,7 @@ func TestBackupSelfRefImport_PrimaryRelationWithSecondCollectionWrongOrder_NoErr
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 // This test documents undesirable behaviour, as the documents are not linked.
@@ -368,5 +368,5 @@ func TestBackupSelfRefImport_SplitPrimaryRelationWithSecondCollection_NoError(t 
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/backup/self_reference/import_test.go
+++ b/tests/integration/backup/self_reference/import_test.go
@@ -132,7 +132,7 @@ func TestBackupSelfRefImport_SelfRef_NoError(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"User"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestBackupSelfRefImport_PrimaryRelationWithSecondCollection_NoError(t *testing.T) {
@@ -196,7 +196,7 @@ func TestBackupSelfRefImport_PrimaryRelationWithSecondCollection_NoError(t *test
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Author", "Book"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestBackupSelfRefImport_PrimaryRelationWithSecondCollectionWrongOrder_NoError(t *testing.T) {
@@ -260,7 +260,7 @@ func TestBackupSelfRefImport_PrimaryRelationWithSecondCollectionWrongOrder_NoErr
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Author", "Book"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 // This test documents undesirable behaviour, as the documents are not linked.
@@ -368,5 +368,5 @@ func TestBackupSelfRefImport_SplitPrimaryRelationWithSecondCollection_NoError(t 
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Author", "Book"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/backup/self_reference/utils.go
+++ b/tests/integration/backup/self_reference/utils.go
@@ -26,7 +26,7 @@ var schemas = (`
 `)
 
 func executeTestCase(t *testing.T, test testUtils.TestCase) {
-	testUtils.ExecuteTEMP(
+	testUtils.ExecuteTestCase(
 		t,
 		testUtils.TestCase{
 			Description: test.Description,

--- a/tests/integration/backup/self_reference/utils.go
+++ b/tests/integration/backup/self_reference/utils.go
@@ -26,9 +26,8 @@ var schemas = (`
 `)
 
 func executeTestCase(t *testing.T, test testUtils.TestCase) {
-	testUtils.ExecuteTestCase(
+	testUtils.ExecuteTEMP(
 		t,
-		[]string{"User"},
 		testUtils.TestCase{
 			Description: test.Description,
 			Actions: append(

--- a/tests/integration/backup/simple/utils.go
+++ b/tests/integration/backup/simple/utils.go
@@ -24,9 +24,8 @@ var schemas = (`
 `)
 
 func executeTestCase(t *testing.T, test testUtils.TestCase) {
-	testUtils.ExecuteTestCase(
+	testUtils.ExecuteTEMP(
 		t,
-		[]string{"User"},
 		testUtils.TestCase{
 			Description: test.Description,
 			Actions: append(

--- a/tests/integration/backup/simple/utils.go
+++ b/tests/integration/backup/simple/utils.go
@@ -24,7 +24,7 @@ var schemas = (`
 `)
 
 func executeTestCase(t *testing.T, test testUtils.TestCase) {
-	testUtils.ExecuteTEMP(
+	testUtils.ExecuteTestCase(
 		t,
 		testUtils.TestCase{
 			Description: test.Description,

--- a/tests/integration/explain/fixture.go
+++ b/tests/integration/explain/fixture.go
@@ -56,9 +56,8 @@ var SchemaForExplainTests = testUtils.SchemaUpdate{
 }
 
 func ExecuteTestCase(t *testing.T, test testUtils.TestCase) {
-	testUtils.ExecuteTestCase(
+	testUtils.ExecuteTEMP(
 		t,
-		[]string{"Article", "Book", "Author", "AuthorContact", "ContactAddress"},
 		test,
 	)
 }

--- a/tests/integration/explain/fixture.go
+++ b/tests/integration/explain/fixture.go
@@ -56,7 +56,7 @@ var SchemaForExplainTests = testUtils.SchemaUpdate{
 }
 
 func ExecuteTestCase(t *testing.T, test testUtils.TestCase) {
-	testUtils.ExecuteTEMP(
+	testUtils.ExecuteTestCase(
 		t,
 		test,
 	)

--- a/tests/integration/index/create_drop_test.go
+++ b/tests/integration/index/create_drop_test.go
@@ -59,5 +59,5 @@ func TestIndexDrop_ShouldNotHinderQuerying(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/index/create_drop_test.go
+++ b/tests/integration/index/create_drop_test.go
@@ -59,5 +59,5 @@ func TestIndexDrop_ShouldNotHinderQuerying(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/index/create_get_test.go
+++ b/tests/integration/index/create_get_test.go
@@ -57,5 +57,5 @@ func TestIndexGet_ShouldReturnListOfExistingIndexes(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/index/create_get_test.go
+++ b/tests/integration/index/create_get_test.go
@@ -57,5 +57,5 @@ func TestIndexGet_ShouldReturnListOfExistingIndexes(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/index/create_test.go
+++ b/tests/integration/index/create_test.go
@@ -56,7 +56,7 @@ func TestIndexCreateWithCollection_ShouldNotHinderQuerying(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestIndexCreate_ShouldNotHinderQuerying(t *testing.T) {
@@ -103,7 +103,7 @@ func TestIndexCreate_ShouldNotHinderQuerying(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestIndexCreate_IfInvalidIndexName_ReturnError(t *testing.T) {
@@ -127,5 +127,5 @@ func TestIndexCreate_IfInvalidIndexName_ReturnError(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/index/create_test.go
+++ b/tests/integration/index/create_test.go
@@ -56,7 +56,7 @@ func TestIndexCreateWithCollection_ShouldNotHinderQuerying(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestIndexCreate_ShouldNotHinderQuerying(t *testing.T) {
@@ -103,7 +103,7 @@ func TestIndexCreate_ShouldNotHinderQuerying(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestIndexCreate_IfInvalidIndexName_ReturnError(t *testing.T) {
@@ -127,5 +127,5 @@ func TestIndexCreate_IfInvalidIndexName_ReturnError(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/index/drop_test.go
+++ b/tests/integration/index/drop_test.go
@@ -60,5 +60,5 @@ func TestIndexDrop_IfIndexDoesNotExist_ReturnError(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/index/drop_test.go
+++ b/tests/integration/index/drop_test.go
@@ -60,5 +60,5 @@ func TestIndexDrop_IfIndexDoesNotExist_ReturnError(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/index/get_test.go
+++ b/tests/integration/index/get_test.go
@@ -36,5 +36,5 @@ func TestIndexGet_IfThereAreNoIndexes_ReturnEmptyList(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/index/get_test.go
+++ b/tests/integration/index/get_test.go
@@ -36,5 +36,5 @@ func TestIndexGet_IfThereAreNoIndexes_ReturnEmptyList(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/mutation/one_to_many/utils.go
+++ b/tests/integration/mutation/one_to_many/utils.go
@@ -17,9 +17,8 @@ import (
 )
 
 func ExecuteTestCase(t *testing.T, test testUtils.TestCase) {
-	testUtils.ExecuteTestCase(
+	testUtils.ExecuteTEMP(
 		t,
-		[]string{"Book", "Author"},
 		testUtils.TestCase{
 			Description: test.Description,
 			Actions: append(

--- a/tests/integration/mutation/one_to_many/utils.go
+++ b/tests/integration/mutation/one_to_many/utils.go
@@ -17,7 +17,7 @@ import (
 )
 
 func ExecuteTestCase(t *testing.T, test testUtils.TestCase) {
-	testUtils.ExecuteTEMP(
+	testUtils.ExecuteTestCase(
 		t,
 		testUtils.TestCase{
 			Description: test.Description,

--- a/tests/integration/mutation/one_to_one/utils.go
+++ b/tests/integration/mutation/one_to_one/utils.go
@@ -17,9 +17,8 @@ import (
 )
 
 func ExecuteTestCase(t *testing.T, test testUtils.TestCase) {
-	testUtils.ExecuteTestCase(
+	testUtils.ExecuteTEMP(
 		t,
-		[]string{"Book", "Author"},
 		testUtils.TestCase{
 			Description: test.Description,
 			Actions: append(

--- a/tests/integration/mutation/one_to_one/utils.go
+++ b/tests/integration/mutation/one_to_one/utils.go
@@ -17,7 +17,7 @@ import (
 )
 
 func ExecuteTestCase(t *testing.T, test testUtils.TestCase) {
-	testUtils.ExecuteTEMP(
+	testUtils.ExecuteTestCase(
 		t,
 		testUtils.TestCase{
 			Description: test.Description,

--- a/tests/integration/mutation/relation/utils.go
+++ b/tests/integration/mutation/relation/utils.go
@@ -17,9 +17,8 @@ import (
 )
 
 func Execute(t *testing.T, test testUtils.TestCase) {
-	testUtils.ExecuteTestCase(
+	testUtils.ExecuteTEMP(
 		t,
-		[]string{"Book", "Author", "Publisher"},
 		testUtils.TestCase{
 			Description: test.Description,
 			Actions: append(

--- a/tests/integration/mutation/relation/utils.go
+++ b/tests/integration/mutation/relation/utils.go
@@ -17,7 +17,7 @@ import (
 )
 
 func Execute(t *testing.T, test testUtils.TestCase) {
-	testUtils.ExecuteTEMP(
+	testUtils.ExecuteTestCase(
 		t,
 		testUtils.TestCase{
 			Description: test.Description,

--- a/tests/integration/mutation/simple/create/simple_test.go
+++ b/tests/integration/mutation/simple/create/simple_test.go
@@ -50,7 +50,7 @@ func TestMutationCreateSimpleErrorsGivenNonExistantField(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestMutationCreateSimple(t *testing.T) {

--- a/tests/integration/mutation/simple/create/simple_test.go
+++ b/tests/integration/mutation/simple/create/simple_test.go
@@ -50,7 +50,7 @@ func TestMutationCreateSimpleErrorsGivenNonExistantField(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestMutationCreateSimple(t *testing.T) {

--- a/tests/integration/mutation/simple/delete/multi_ids_test.go
+++ b/tests/integration/mutation/simple/delete/multi_ids_test.go
@@ -66,7 +66,7 @@ func TestDeletionOfMultipleDocumentUsingMultipleKeysWhereOneExists(t *testing.T)
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"User"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestDeletionOfMultipleDocumentUsingMultipleKeys_Success(t *testing.T) {
@@ -416,7 +416,7 @@ func TestDeletionOfMultipleDocumentsUsingSingleKeyWithShowDeletedDocumentQuery_S
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"User"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestDeletionOfMultipleDocumentsUsingEmptySet(t *testing.T) {
@@ -474,5 +474,5 @@ func TestDeletionOfMultipleDocumentsUsingEmptySet(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"User"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/mutation/simple/delete/multi_ids_test.go
+++ b/tests/integration/mutation/simple/delete/multi_ids_test.go
@@ -66,7 +66,7 @@ func TestDeletionOfMultipleDocumentUsingMultipleKeysWhereOneExists(t *testing.T)
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestDeletionOfMultipleDocumentUsingMultipleKeys_Success(t *testing.T) {
@@ -416,7 +416,7 @@ func TestDeletionOfMultipleDocumentsUsingSingleKeyWithShowDeletedDocumentQuery_S
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestDeletionOfMultipleDocumentsUsingEmptySet(t *testing.T) {
@@ -474,5 +474,5 @@ func TestDeletionOfMultipleDocumentsUsingEmptySet(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/mutation/simple/delete/single_id_test.go
+++ b/tests/integration/mutation/simple/delete/single_id_test.go
@@ -68,7 +68,7 @@ func TestDeletionOfADocumentUsingSingleKeyWhereDocExists(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestDeletionOfADocumentUsingSingleKey_Success(t *testing.T) {
@@ -278,5 +278,5 @@ func TestDeletionOfADocumentUsingSingleKeyWithShowDeletedDocumentQuery_Success(t
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/mutation/simple/delete/single_id_test.go
+++ b/tests/integration/mutation/simple/delete/single_id_test.go
@@ -68,7 +68,7 @@ func TestDeletionOfADocumentUsingSingleKeyWhereDocExists(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"User"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestDeletionOfADocumentUsingSingleKey_Success(t *testing.T) {
@@ -278,5 +278,5 @@ func TestDeletionOfADocumentUsingSingleKeyWithShowDeletedDocumentQuery_Success(t
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"User"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/mutation/simple/delete/with_filter_test.go
+++ b/tests/integration/mutation/simple/delete/with_filter_test.go
@@ -414,5 +414,5 @@ func TestDeletionOfDocumentsWithFilterWithShowDeletedDocumentQuery_Success(t *te
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"User"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/mutation/simple/delete/with_filter_test.go
+++ b/tests/integration/mutation/simple/delete/with_filter_test.go
@@ -414,5 +414,5 @@ func TestDeletionOfDocumentsWithFilterWithShowDeletedDocumentQuery_Success(t *te
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/mutation/simple/mix/with_txn_test.go
+++ b/tests/integration/mutation/simple/mix/with_txn_test.go
@@ -60,7 +60,7 @@ func TestMutationWithTxnDeletesUserGivenSameTransaction(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestMutationWithTxnDoesNotDeletesUserGivenDifferentTransactions(t *testing.T) {
@@ -128,7 +128,7 @@ func TestMutationWithTxnDoesNotDeletesUserGivenDifferentTransactions(t *testing.
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestMutationWithTxnDoesUpdateUserGivenSameTransactions(t *testing.T) {
@@ -182,7 +182,7 @@ func TestMutationWithTxnDoesUpdateUserGivenSameTransactions(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestMutationWithTxnDoesNotUpdateUserGivenDifferentTransactions(t *testing.T) {
@@ -240,7 +240,7 @@ func TestMutationWithTxnDoesNotUpdateUserGivenDifferentTransactions(t *testing.T
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestMutationWithTxnDoesNotAllowUpdateInSecondTransactionUser(t *testing.T) {

--- a/tests/integration/mutation/simple/mix/with_txn_test.go
+++ b/tests/integration/mutation/simple/mix/with_txn_test.go
@@ -60,7 +60,7 @@ func TestMutationWithTxnDeletesUserGivenSameTransaction(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"User"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestMutationWithTxnDoesNotDeletesUserGivenDifferentTransactions(t *testing.T) {
@@ -128,7 +128,7 @@ func TestMutationWithTxnDoesNotDeletesUserGivenDifferentTransactions(t *testing.
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"User"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestMutationWithTxnDoesUpdateUserGivenSameTransactions(t *testing.T) {
@@ -182,7 +182,7 @@ func TestMutationWithTxnDoesUpdateUserGivenSameTransactions(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"User"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestMutationWithTxnDoesNotUpdateUserGivenDifferentTransactions(t *testing.T) {
@@ -240,7 +240,7 @@ func TestMutationWithTxnDoesNotUpdateUserGivenDifferentTransactions(t *testing.T
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"User"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestMutationWithTxnDoesNotAllowUpdateInSecondTransactionUser(t *testing.T) {

--- a/tests/integration/mutation/simple/utils.go
+++ b/tests/integration/mutation/simple/utils.go
@@ -30,9 +30,8 @@ func ExecuteTestCase(t *testing.T, test testUtils.RequestTestCase) {
 }
 
 func Execute(t *testing.T, test testUtils.TestCase) {
-	testUtils.ExecuteTestCase(
+	testUtils.ExecuteTEMP(
 		t,
-		[]string{"User"},
 		testUtils.TestCase{
 			Description: test.Description,
 			Actions: append(

--- a/tests/integration/mutation/simple/utils.go
+++ b/tests/integration/mutation/simple/utils.go
@@ -30,7 +30,7 @@ func ExecuteTestCase(t *testing.T, test testUtils.RequestTestCase) {
 }
 
 func Execute(t *testing.T, test testUtils.TestCase) {
-	testUtils.ExecuteTEMP(
+	testUtils.ExecuteTestCase(
 		t,
 		testUtils.TestCase{
 			Description: test.Description,

--- a/tests/integration/net/state/one_to_many/peer/with_create_update_test.go
+++ b/tests/integration/net/state/one_to_many/peer/with_create_update_test.go
@@ -113,5 +113,5 @@ func TestP2POneToManyPeerWithCreateUpdateLinkingSyncedDocToUnsyncedDoc(t *testin
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Author", "Book"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/net/state/one_to_many/peer/with_create_update_test.go
+++ b/tests/integration/net/state/one_to_many/peer/with_create_update_test.go
@@ -113,5 +113,5 @@ func TestP2POneToManyPeerWithCreateUpdateLinkingSyncedDocToUnsyncedDoc(t *testin
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/net/state/one_to_many/replicator/with_create_test.go
+++ b/tests/integration/net/state/one_to_many/replicator/with_create_test.go
@@ -80,5 +80,5 @@ func TestP2POneToManyReplicator(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Author", "Book"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/net/state/one_to_many/replicator/with_create_test.go
+++ b/tests/integration/net/state/one_to_many/replicator/with_create_test.go
@@ -80,5 +80,5 @@ func TestP2POneToManyReplicator(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/net/state/simple/peer/subscribe/with_add_get_remove_test.go
+++ b/tests/integration/net/state/simple/peer/subscribe/with_add_get_remove_test.go
@@ -47,7 +47,7 @@ func TestP2PSubscribeAddRemoveGetSingle(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestP2PSubscribeAddRemoveGetMultiple(t *testing.T) {
@@ -85,5 +85,5 @@ func TestP2PSubscribeAddRemoveGetMultiple(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/net/state/simple/peer/subscribe/with_add_get_remove_test.go
+++ b/tests/integration/net/state/simple/peer/subscribe/with_add_get_remove_test.go
@@ -47,7 +47,7 @@ func TestP2PSubscribeAddRemoveGetSingle(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestP2PSubscribeAddRemoveGetMultiple(t *testing.T) {
@@ -85,5 +85,5 @@ func TestP2PSubscribeAddRemoveGetMultiple(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users", "Giraffes"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/net/state/simple/peer/subscribe/with_add_get_test.go
+++ b/tests/integration/net/state/simple/peer/subscribe/with_add_get_test.go
@@ -43,7 +43,7 @@ func TestP2PSubscribeAddGetSingle(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestP2PSubscribeAddGetMultiple(t *testing.T) {
@@ -79,5 +79,5 @@ func TestP2PSubscribeAddGetMultiple(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users", "Giraffes", "Bears"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/net/state/simple/peer/subscribe/with_add_get_test.go
+++ b/tests/integration/net/state/simple/peer/subscribe/with_add_get_test.go
@@ -43,7 +43,7 @@ func TestP2PSubscribeAddGetSingle(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestP2PSubscribeAddGetMultiple(t *testing.T) {
@@ -79,5 +79,5 @@ func TestP2PSubscribeAddGetMultiple(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/net/state/simple/peer/subscribe/with_add_remove_test.go
+++ b/tests/integration/net/state/simple/peer/subscribe/with_add_remove_test.go
@@ -72,7 +72,7 @@ func TestP2PSubscribeAddAndRemoveSingle(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestP2PSubscribeAddAndRemoveMultiple(t *testing.T) {
@@ -144,7 +144,7 @@ func TestP2PSubscribeAddAndRemoveMultiple(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestP2PSubscribeAddSingleAndRemoveErroneous(t *testing.T) {
@@ -196,7 +196,7 @@ func TestP2PSubscribeAddSingleAndRemoveErroneous(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestP2PSubscribeAddSingleAndRemoveNone(t *testing.T) {
@@ -246,5 +246,5 @@ func TestP2PSubscribeAddSingleAndRemoveNone(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/net/state/simple/peer/subscribe/with_add_remove_test.go
+++ b/tests/integration/net/state/simple/peer/subscribe/with_add_remove_test.go
@@ -72,7 +72,7 @@ func TestP2PSubscribeAddAndRemoveSingle(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestP2PSubscribeAddAndRemoveMultiple(t *testing.T) {
@@ -144,7 +144,7 @@ func TestP2PSubscribeAddAndRemoveMultiple(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users", "Giraffes"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestP2PSubscribeAddSingleAndRemoveErroneous(t *testing.T) {
@@ -196,7 +196,7 @@ func TestP2PSubscribeAddSingleAndRemoveErroneous(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestP2PSubscribeAddSingleAndRemoveNone(t *testing.T) {
@@ -246,5 +246,5 @@ func TestP2PSubscribeAddSingleAndRemoveNone(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/net/state/simple/peer/subscribe/with_add_test.go
+++ b/tests/integration/net/state/simple/peer/subscribe/with_add_test.go
@@ -87,7 +87,7 @@ func TestP2PSubscribeAddSingle(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestP2PSubscribeAddMultiple(t *testing.T) {
@@ -177,7 +177,7 @@ func TestP2PSubscribeAddMultiple(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestP2PSubscribeAddSingleErroneousCollectionID(t *testing.T) {
@@ -221,7 +221,7 @@ func TestP2PSubscribeAddSingleErroneousCollectionID(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestP2PSubscribeAddValidAndErroneousCollectionID(t *testing.T) {
@@ -266,7 +266,7 @@ func TestP2PSubscribeAddValidAndErroneousCollectionID(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestP2PSubscribeAddValidThenErroneousCollectionID(t *testing.T) {
@@ -318,7 +318,7 @@ func TestP2PSubscribeAddValidThenErroneousCollectionID(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestP2PSubscribeAddNone(t *testing.T) {
@@ -360,5 +360,5 @@ func TestP2PSubscribeAddNone(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/net/state/simple/peer/subscribe/with_add_test.go
+++ b/tests/integration/net/state/simple/peer/subscribe/with_add_test.go
@@ -87,7 +87,7 @@ func TestP2PSubscribeAddSingle(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestP2PSubscribeAddMultiple(t *testing.T) {
@@ -177,7 +177,7 @@ func TestP2PSubscribeAddMultiple(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users", "Giraffes", "Bears"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestP2PSubscribeAddSingleErroneousCollectionID(t *testing.T) {
@@ -221,7 +221,7 @@ func TestP2PSubscribeAddSingleErroneousCollectionID(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestP2PSubscribeAddValidAndErroneousCollectionID(t *testing.T) {
@@ -266,7 +266,7 @@ func TestP2PSubscribeAddValidAndErroneousCollectionID(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestP2PSubscribeAddValidThenErroneousCollectionID(t *testing.T) {
@@ -318,7 +318,7 @@ func TestP2PSubscribeAddValidThenErroneousCollectionID(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestP2PSubscribeAddNone(t *testing.T) {
@@ -360,5 +360,5 @@ func TestP2PSubscribeAddNone(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/net/state/simple/peer/subscribe/with_get_test.go
+++ b/tests/integration/net/state/simple/peer/subscribe/with_get_test.go
@@ -36,5 +36,5 @@ func TestP2PSubscribeGetAll(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/net/state/simple/peer/subscribe/with_get_test.go
+++ b/tests/integration/net/state/simple/peer/subscribe/with_get_test.go
@@ -36,5 +36,5 @@ func TestP2PSubscribeGetAll(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/net/state/simple/peer/with_create_add_field_test.go
+++ b/tests/integration/net/state/simple/peer/with_create_add_field_test.go
@@ -88,7 +88,7 @@ func TestP2PPeerCreateWithNewFieldSyncsDocsToOlderSchemaVersion(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestP2PPeerCreateWithNewFieldSyncsDocsToNewerSchemaVersion(t *testing.T) {
@@ -145,7 +145,7 @@ func TestP2PPeerCreateWithNewFieldSyncsDocsToNewerSchemaVersion(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestP2PPeerCreateWithNewFieldSyncsDocsToUpdatedSchemaVersion(t *testing.T) {
@@ -201,5 +201,5 @@ func TestP2PPeerCreateWithNewFieldSyncsDocsToUpdatedSchemaVersion(t *testing.T) 
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/net/state/simple/peer/with_create_add_field_test.go
+++ b/tests/integration/net/state/simple/peer/with_create_add_field_test.go
@@ -88,7 +88,7 @@ func TestP2PPeerCreateWithNewFieldSyncsDocsToOlderSchemaVersion(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestP2PPeerCreateWithNewFieldSyncsDocsToNewerSchemaVersion(t *testing.T) {
@@ -145,7 +145,7 @@ func TestP2PPeerCreateWithNewFieldSyncsDocsToNewerSchemaVersion(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestP2PPeerCreateWithNewFieldSyncsDocsToUpdatedSchemaVersion(t *testing.T) {
@@ -201,5 +201,5 @@ func TestP2PPeerCreateWithNewFieldSyncsDocsToUpdatedSchemaVersion(t *testing.T) 
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/net/state/simple/peer/with_create_test.go
+++ b/tests/integration/net/state/simple/peer/with_create_test.go
@@ -83,7 +83,7 @@ func TestP2PCreateDoesNotSync(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 // TestP2PCreateWithP2PCollection ensures that created documents reach the node that subscribes
@@ -184,5 +184,5 @@ func TestP2PCreateWithP2PCollection(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/net/state/simple/peer/with_create_test.go
+++ b/tests/integration/net/state/simple/peer/with_create_test.go
@@ -83,7 +83,7 @@ func TestP2PCreateDoesNotSync(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 // TestP2PCreateWithP2PCollection ensures that created documents reach the node that subscribes
@@ -184,5 +184,5 @@ func TestP2PCreateWithP2PCollection(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/net/state/simple/peer/with_delete_test.go
+++ b/tests/integration/net/state/simple/peer/with_delete_test.go
@@ -75,7 +75,7 @@ func TestP2PWithMultipleDocumentsSingleDelete(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestP2PWithMultipleDocumentsSingleDeleteWithShowDeleted(t *testing.T) {
@@ -138,7 +138,7 @@ func TestP2PWithMultipleDocumentsSingleDeleteWithShowDeleted(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestP2PWithMultipleDocumentsWithSingleUpdateBeforeConnectSingleDeleteWithShowDeleted(t *testing.T) {
@@ -210,7 +210,7 @@ func TestP2PWithMultipleDocumentsWithSingleUpdateBeforeConnectSingleDeleteWithSh
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestP2PWithMultipleDocumentsWithMultipleUpdatesBeforeConnectSingleDeleteWithShowDeleted(t *testing.T) {
@@ -291,7 +291,7 @@ func TestP2PWithMultipleDocumentsWithMultipleUpdatesBeforeConnectSingleDeleteWit
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestP2PWithMultipleDocumentsWithUpdateAndDeleteBeforeConnectSingleDeleteWithShowDeleted(t *testing.T) {
@@ -406,5 +406,5 @@ func TestP2PWithMultipleDocumentsWithUpdateAndDeleteBeforeConnectSingleDeleteWit
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/net/state/simple/peer/with_delete_test.go
+++ b/tests/integration/net/state/simple/peer/with_delete_test.go
@@ -75,7 +75,7 @@ func TestP2PWithMultipleDocumentsSingleDelete(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestP2PWithMultipleDocumentsSingleDeleteWithShowDeleted(t *testing.T) {
@@ -138,7 +138,7 @@ func TestP2PWithMultipleDocumentsSingleDeleteWithShowDeleted(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestP2PWithMultipleDocumentsWithSingleUpdateBeforeConnectSingleDeleteWithShowDeleted(t *testing.T) {
@@ -210,7 +210,7 @@ func TestP2PWithMultipleDocumentsWithSingleUpdateBeforeConnectSingleDeleteWithSh
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestP2PWithMultipleDocumentsWithMultipleUpdatesBeforeConnectSingleDeleteWithShowDeleted(t *testing.T) {
@@ -291,7 +291,7 @@ func TestP2PWithMultipleDocumentsWithMultipleUpdatesBeforeConnectSingleDeleteWit
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestP2PWithMultipleDocumentsWithUpdateAndDeleteBeforeConnectSingleDeleteWithShowDeleted(t *testing.T) {
@@ -406,5 +406,5 @@ func TestP2PWithMultipleDocumentsWithUpdateAndDeleteBeforeConnectSingleDeleteWit
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/net/state/simple/peer/with_update_add_field_test.go
+++ b/tests/integration/net/state/simple/peer/with_update_add_field_test.go
@@ -100,7 +100,7 @@ func TestP2PPeerUpdateWithNewFieldSyncsDocsToOlderSchemaVersionMultistep(t *test
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestP2PPeerUpdateWithNewFieldSyncsDocsToOlderSchemaVersion(t *testing.T) {
@@ -177,5 +177,5 @@ func TestP2PPeerUpdateWithNewFieldSyncsDocsToOlderSchemaVersion(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/net/state/simple/peer/with_update_add_field_test.go
+++ b/tests/integration/net/state/simple/peer/with_update_add_field_test.go
@@ -100,7 +100,7 @@ func TestP2PPeerUpdateWithNewFieldSyncsDocsToOlderSchemaVersionMultistep(t *test
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestP2PPeerUpdateWithNewFieldSyncsDocsToOlderSchemaVersion(t *testing.T) {
@@ -177,5 +177,5 @@ func TestP2PPeerUpdateWithNewFieldSyncsDocsToOlderSchemaVersion(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/net/state/simple/peer/with_update_restart_test.go
+++ b/tests/integration/net/state/simple/peer/with_update_restart_test.go
@@ -66,5 +66,5 @@ func TestP2PWithSingleDocumentSingleUpdateFromChildAndRestart(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/net/state/simple/peer/with_update_restart_test.go
+++ b/tests/integration/net/state/simple/peer/with_update_restart_test.go
@@ -66,5 +66,5 @@ func TestP2PWithSingleDocumentSingleUpdateFromChildAndRestart(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/net/state/simple/peer/with_update_test.go
+++ b/tests/integration/net/state/simple/peer/with_update_test.go
@@ -67,7 +67,7 @@ func TestP2PWithSingleDocumentSingleUpdateFromChild(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 // The parent-child distinction in these tests is as much documentation and test
@@ -119,7 +119,7 @@ func TestP2PWithSingleDocumentSingleUpdateFromParent(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 // TestP2PWithSingleDocumentUpdatePerNode tests document syncing between two nodes with a single update per node
@@ -177,7 +177,7 @@ func TestP2PWithSingleDocumentUpdatePerNode(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestP2PWithSingleDocumentSingleUpdateDoesNotSyncToNonPeerNode(t *testing.T) {
@@ -257,7 +257,7 @@ func TestP2PWithSingleDocumentSingleUpdateDoesNotSyncToNonPeerNode(t *testing.T)
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestP2PWithSingleDocumentSingleUpdateDoesNotSyncFromUnmappedNode(t *testing.T) {
@@ -339,7 +339,7 @@ func TestP2PWithSingleDocumentSingleUpdateDoesNotSyncFromUnmappedNode(t *testing
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 // TestP2PWithMultipleDocumentUpdatesPerNode tests document syncing between two nodes with multiple updates per node.
@@ -419,7 +419,7 @@ func TestP2PWithMultipleDocumentUpdatesPerNode(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 // TestP2PWithSingleDocumentSingleUpdateFromChildWithP2PCollection tests document syncing between two nodes by
@@ -485,7 +485,7 @@ func TestP2PWithSingleDocumentSingleUpdateFromChildWithP2PCollection(t *testing.
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 // TestP2PWithMultipleDocumentUpdatesPerNodeWithP2PCollection tests document syncing between two nodes with multiple
@@ -601,5 +601,5 @@ func TestP2PWithMultipleDocumentUpdatesPerNodeWithP2PCollection(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/net/state/simple/peer/with_update_test.go
+++ b/tests/integration/net/state/simple/peer/with_update_test.go
@@ -67,7 +67,7 @@ func TestP2PWithSingleDocumentSingleUpdateFromChild(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 // The parent-child distinction in these tests is as much documentation and test
@@ -119,7 +119,7 @@ func TestP2PWithSingleDocumentSingleUpdateFromParent(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 // TestP2PWithSingleDocumentUpdatePerNode tests document syncing between two nodes with a single update per node
@@ -177,7 +177,7 @@ func TestP2PWithSingleDocumentUpdatePerNode(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestP2PWithSingleDocumentSingleUpdateDoesNotSyncToNonPeerNode(t *testing.T) {
@@ -257,7 +257,7 @@ func TestP2PWithSingleDocumentSingleUpdateDoesNotSyncToNonPeerNode(t *testing.T)
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestP2PWithSingleDocumentSingleUpdateDoesNotSyncFromUnmappedNode(t *testing.T) {
@@ -339,7 +339,7 @@ func TestP2PWithSingleDocumentSingleUpdateDoesNotSyncFromUnmappedNode(t *testing
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 // TestP2PWithMultipleDocumentUpdatesPerNode tests document syncing between two nodes with multiple updates per node.
@@ -419,7 +419,7 @@ func TestP2PWithMultipleDocumentUpdatesPerNode(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 // TestP2PWithSingleDocumentSingleUpdateFromChildWithP2PCollection tests document syncing between two nodes by
@@ -485,7 +485,7 @@ func TestP2PWithSingleDocumentSingleUpdateFromChildWithP2PCollection(t *testing.
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 // TestP2PWithMultipleDocumentUpdatesPerNodeWithP2PCollection tests document syncing between two nodes with multiple
@@ -601,5 +601,5 @@ func TestP2PWithMultipleDocumentUpdatesPerNodeWithP2PCollection(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/net/state/simple/peer_replicator/with_create_test.go
+++ b/tests/integration/net/state/simple/peer_replicator/with_create_test.go
@@ -102,5 +102,5 @@ func TestP2PPeerReplicatorWithCreate(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/net/state/simple/peer_replicator/with_create_test.go
+++ b/tests/integration/net/state/simple/peer_replicator/with_create_test.go
@@ -102,5 +102,5 @@ func TestP2PPeerReplicatorWithCreate(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/net/state/simple/peer_replicator/with_delete_test.go
+++ b/tests/integration/net/state/simple/peer_replicator/with_delete_test.go
@@ -71,5 +71,5 @@ func TestP2PPeerReplicatorWithDeleteShowDeleted(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/net/state/simple/peer_replicator/with_delete_test.go
+++ b/tests/integration/net/state/simple/peer_replicator/with_delete_test.go
@@ -71,5 +71,5 @@ func TestP2PPeerReplicatorWithDeleteShowDeleted(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/net/state/simple/peer_replicator/with_update_restart_test.go
+++ b/tests/integration/net/state/simple/peer_replicator/with_update_restart_test.go
@@ -74,5 +74,5 @@ func TestP2PPeerReplicatorWithUpdateAndRestart(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/net/state/simple/peer_replicator/with_update_restart_test.go
+++ b/tests/integration/net/state/simple/peer_replicator/with_update_restart_test.go
@@ -74,5 +74,5 @@ func TestP2PPeerReplicatorWithUpdateAndRestart(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/net/state/simple/peer_replicator/with_update_test.go
+++ b/tests/integration/net/state/simple/peer_replicator/with_update_test.go
@@ -69,5 +69,5 @@ func TestP2PPeerReplicatorWithUpdate(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/net/state/simple/peer_replicator/with_update_test.go
+++ b/tests/integration/net/state/simple/peer_replicator/with_update_test.go
@@ -69,5 +69,5 @@ func TestP2PPeerReplicatorWithUpdate(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/net/state/simple/replicator/with_create_add_field_test.go
+++ b/tests/integration/net/state/simple/replicator/with_create_add_field_test.go
@@ -67,7 +67,7 @@ func TestP2POneToOneReplicatorCreateWithNewFieldSyncsDocsToOlderSchemaVersion(t 
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestP2POneToOneReplicatorCreateWithNewFieldSyncsDocsToNewerSchemaVersion(t *testing.T) {
@@ -118,7 +118,7 @@ func TestP2POneToOneReplicatorCreateWithNewFieldSyncsDocsToNewerSchemaVersion(t 
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestP2POneToOneReplicatorCreateWithNewFieldSyncsDocsToUpdatedSchemaVersion(t *testing.T) {
@@ -171,5 +171,5 @@ func TestP2POneToOneReplicatorCreateWithNewFieldSyncsDocsToUpdatedSchemaVersion(
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/net/state/simple/replicator/with_create_add_field_test.go
+++ b/tests/integration/net/state/simple/replicator/with_create_add_field_test.go
@@ -67,7 +67,7 @@ func TestP2POneToOneReplicatorCreateWithNewFieldSyncsDocsToOlderSchemaVersion(t 
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestP2POneToOneReplicatorCreateWithNewFieldSyncsDocsToNewerSchemaVersion(t *testing.T) {
@@ -118,7 +118,7 @@ func TestP2POneToOneReplicatorCreateWithNewFieldSyncsDocsToNewerSchemaVersion(t 
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestP2POneToOneReplicatorCreateWithNewFieldSyncsDocsToUpdatedSchemaVersion(t *testing.T) {
@@ -171,5 +171,5 @@ func TestP2POneToOneReplicatorCreateWithNewFieldSyncsDocsToUpdatedSchemaVersion(
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/net/state/simple/replicator/with_create_restart_test.go
+++ b/tests/integration/net/state/simple/replicator/with_create_restart_test.go
@@ -60,5 +60,5 @@ func TestP2POneToOneReplicatorWithRestart(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/net/state/simple/replicator/with_create_restart_test.go
+++ b/tests/integration/net/state/simple/replicator/with_create_restart_test.go
@@ -60,5 +60,5 @@ func TestP2POneToOneReplicatorWithRestart(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/net/state/simple/replicator/with_create_test.go
+++ b/tests/integration/net/state/simple/replicator/with_create_test.go
@@ -60,7 +60,7 @@ func TestP2POneToOneReplicator(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestP2POneToOneReplicatorDoesNotSyncExisting(t *testing.T) {
@@ -105,7 +105,7 @@ func TestP2POneToOneReplicatorDoesNotSyncExisting(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestP2POneToOneReplicatorDoesNotSyncFromTargetToSource(t *testing.T) {
@@ -147,7 +147,7 @@ func TestP2POneToOneReplicatorDoesNotSyncFromTargetToSource(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestP2POneToManyReplicator(t *testing.T) {
@@ -196,7 +196,7 @@ func TestP2POneToManyReplicator(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestP2POneToOneOfManyReplicator(t *testing.T) {
@@ -266,7 +266,7 @@ func TestP2POneToOneOfManyReplicator(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestP2POneToOneReplicatorManyDocs(t *testing.T) {
@@ -321,7 +321,7 @@ func TestP2POneToOneReplicatorManyDocs(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestP2POneToManyReplicatorManyDocs(t *testing.T) {
@@ -381,7 +381,7 @@ func TestP2POneToManyReplicatorManyDocs(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestP2POneToOneReplicatorOrderIndependent(t *testing.T) {
@@ -451,7 +451,7 @@ func TestP2POneToOneReplicatorOrderIndependent(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestP2POneToOneReplicatorOrderIndependentDirectCreate(t *testing.T) {
@@ -511,5 +511,5 @@ func TestP2POneToOneReplicatorOrderIndependentDirectCreate(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/net/state/simple/replicator/with_create_test.go
+++ b/tests/integration/net/state/simple/replicator/with_create_test.go
@@ -60,7 +60,7 @@ func TestP2POneToOneReplicator(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestP2POneToOneReplicatorDoesNotSyncExisting(t *testing.T) {
@@ -105,7 +105,7 @@ func TestP2POneToOneReplicatorDoesNotSyncExisting(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestP2POneToOneReplicatorDoesNotSyncFromTargetToSource(t *testing.T) {
@@ -147,7 +147,7 @@ func TestP2POneToOneReplicatorDoesNotSyncFromTargetToSource(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestP2POneToManyReplicator(t *testing.T) {
@@ -196,7 +196,7 @@ func TestP2POneToManyReplicator(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestP2POneToOneOfManyReplicator(t *testing.T) {
@@ -266,7 +266,7 @@ func TestP2POneToOneOfManyReplicator(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestP2POneToOneReplicatorManyDocs(t *testing.T) {
@@ -321,7 +321,7 @@ func TestP2POneToOneReplicatorManyDocs(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestP2POneToManyReplicatorManyDocs(t *testing.T) {
@@ -381,7 +381,7 @@ func TestP2POneToManyReplicatorManyDocs(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestP2POneToOneReplicatorOrderIndependent(t *testing.T) {
@@ -451,7 +451,7 @@ func TestP2POneToOneReplicatorOrderIndependent(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestP2POneToOneReplicatorOrderIndependentDirectCreate(t *testing.T) {
@@ -511,5 +511,5 @@ func TestP2POneToOneReplicatorOrderIndependentDirectCreate(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/net/state/simple/replicator/with_create_update_test.go
+++ b/tests/integration/net/state/simple/replicator/with_create_update_test.go
@@ -68,7 +68,7 @@ func TestP2POneToOneReplicatorWithCreateWithUpdate(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestP2POneToOneReplicatorWithCreateWithUpdateOnRecipientNode(t *testing.T) {
@@ -125,7 +125,7 @@ func TestP2POneToOneReplicatorWithCreateWithUpdateOnRecipientNode(t *testing.T) 
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestP2POneToOneReplicatorDoesNotUpdateDocExistingOnlyOnTarget(t *testing.T) {
@@ -186,5 +186,5 @@ func TestP2POneToOneReplicatorDoesNotUpdateDocExistingOnlyOnTarget(t *testing.T)
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/net/state/simple/replicator/with_create_update_test.go
+++ b/tests/integration/net/state/simple/replicator/with_create_update_test.go
@@ -68,7 +68,7 @@ func TestP2POneToOneReplicatorWithCreateWithUpdate(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestP2POneToOneReplicatorWithCreateWithUpdateOnRecipientNode(t *testing.T) {
@@ -125,7 +125,7 @@ func TestP2POneToOneReplicatorWithCreateWithUpdateOnRecipientNode(t *testing.T) 
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestP2POneToOneReplicatorDoesNotUpdateDocExistingOnlyOnTarget(t *testing.T) {
@@ -186,5 +186,5 @@ func TestP2POneToOneReplicatorDoesNotUpdateDocExistingOnlyOnTarget(t *testing.T)
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/net/state/simple/replicator/with_delete_test.go
+++ b/tests/integration/net/state/simple/replicator/with_delete_test.go
@@ -69,7 +69,7 @@ func TestP2POneToOneReplicatorDeletesDocCreatedBeforeReplicatorConfig(t *testing
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestP2POneToOneReplicatorDeletesDocCreatedBeforeReplicatorConfigWithNodesInversed(t *testing.T) {
@@ -123,5 +123,5 @@ func TestP2POneToOneReplicatorDeletesDocCreatedBeforeReplicatorConfigWithNodesIn
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/net/state/simple/replicator/with_delete_test.go
+++ b/tests/integration/net/state/simple/replicator/with_delete_test.go
@@ -69,7 +69,7 @@ func TestP2POneToOneReplicatorDeletesDocCreatedBeforeReplicatorConfig(t *testing
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestP2POneToOneReplicatorDeletesDocCreatedBeforeReplicatorConfigWithNodesInversed(t *testing.T) {
@@ -123,5 +123,5 @@ func TestP2POneToOneReplicatorDeletesDocCreatedBeforeReplicatorConfigWithNodesIn
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/net/state/simple/replicator/with_update_add_field_test.go
+++ b/tests/integration/net/state/simple/replicator/with_update_add_field_test.go
@@ -96,7 +96,7 @@ func TestP2PReplicatorUpdateWithNewFieldSyncsDocsToOlderSchemaVersionMultistep(t
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestP2PReplicatorUpdateWithNewFieldSyncsDocsToOlderSchemaVersion(t *testing.T) {
@@ -169,5 +169,5 @@ func TestP2PReplicatorUpdateWithNewFieldSyncsDocsToOlderSchemaVersion(t *testing
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/net/state/simple/replicator/with_update_add_field_test.go
+++ b/tests/integration/net/state/simple/replicator/with_update_add_field_test.go
@@ -96,7 +96,7 @@ func TestP2PReplicatorUpdateWithNewFieldSyncsDocsToOlderSchemaVersionMultistep(t
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestP2PReplicatorUpdateWithNewFieldSyncsDocsToOlderSchemaVersion(t *testing.T) {
@@ -169,5 +169,5 @@ func TestP2PReplicatorUpdateWithNewFieldSyncsDocsToOlderSchemaVersion(t *testing
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/net/state/simple/replicator/with_update_test.go
+++ b/tests/integration/net/state/simple/replicator/with_update_test.go
@@ -67,7 +67,7 @@ func TestP2POneToOneReplicatorUpdatesDocCreatedBeforeReplicatorConfig(t *testing
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestP2POneToOneReplicatorUpdatesDocCreatedBeforeReplicatorConfigWithNodesInversed(t *testing.T) {
@@ -119,5 +119,5 @@ func TestP2POneToOneReplicatorUpdatesDocCreatedBeforeReplicatorConfigWithNodesIn
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/net/state/simple/replicator/with_update_test.go
+++ b/tests/integration/net/state/simple/replicator/with_update_test.go
@@ -67,7 +67,7 @@ func TestP2POneToOneReplicatorUpdatesDocCreatedBeforeReplicatorConfig(t *testing
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestP2POneToOneReplicatorUpdatesDocCreatedBeforeReplicatorConfigWithNodesInversed(t *testing.T) {
@@ -119,5 +119,5 @@ func TestP2POneToOneReplicatorUpdatesDocCreatedBeforeReplicatorConfigWithNodesIn
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/query/commits/simple_test.go
+++ b/tests/integration/query/commits/simple_test.go
@@ -49,7 +49,7 @@ func TestQueryCommits(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestQueryCommitsMultipleDocs(t *testing.T) {
@@ -101,7 +101,7 @@ func TestQueryCommitsMultipleDocs(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestQueryCommitsWithSchemaVersionIdField(t *testing.T) {
@@ -141,7 +141,7 @@ func TestQueryCommitsWithSchemaVersionIdField(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestQueryCommitsWithFieldNameField(t *testing.T) {
@@ -178,7 +178,7 @@ func TestQueryCommitsWithFieldNameField(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestQueryCommitsWithFieldNameFieldAndUpdate(t *testing.T) {
@@ -226,7 +226,7 @@ func TestQueryCommitsWithFieldNameFieldAndUpdate(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestQueryCommitsWithFieldIDField(t *testing.T) {
@@ -263,7 +263,7 @@ func TestQueryCommitsWithFieldIDField(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestQueryCommitsWithFieldIDFieldWithUpdate(t *testing.T) {
@@ -311,5 +311,5 @@ func TestQueryCommitsWithFieldIDFieldWithUpdate(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/query/commits/simple_test.go
+++ b/tests/integration/query/commits/simple_test.go
@@ -49,7 +49,7 @@ func TestQueryCommits(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestQueryCommitsMultipleDocs(t *testing.T) {
@@ -101,7 +101,7 @@ func TestQueryCommitsMultipleDocs(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestQueryCommitsWithSchemaVersionIdField(t *testing.T) {
@@ -141,7 +141,7 @@ func TestQueryCommitsWithSchemaVersionIdField(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestQueryCommitsWithFieldNameField(t *testing.T) {
@@ -178,7 +178,7 @@ func TestQueryCommitsWithFieldNameField(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestQueryCommitsWithFieldNameFieldAndUpdate(t *testing.T) {
@@ -226,7 +226,7 @@ func TestQueryCommitsWithFieldNameFieldAndUpdate(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestQueryCommitsWithFieldIDField(t *testing.T) {
@@ -263,7 +263,7 @@ func TestQueryCommitsWithFieldIDField(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestQueryCommitsWithFieldIDFieldWithUpdate(t *testing.T) {
@@ -311,5 +311,5 @@ func TestQueryCommitsWithFieldIDFieldWithUpdate(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/query/commits/with_cid_test.go
+++ b/tests/integration/query/commits/with_cid_test.go
@@ -52,7 +52,7 @@ func TestQueryCommitsWithCid(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestQueryCommitsWithCidForFieldCommit(t *testing.T) {
@@ -85,7 +85,7 @@ func TestQueryCommitsWithCidForFieldCommit(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestQueryCommitsWithInvalidCid(t *testing.T) {
@@ -113,7 +113,7 @@ func TestQueryCommitsWithInvalidCid(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestQueryCommitsWithInvalidShortCid(t *testing.T) {
@@ -141,7 +141,7 @@ func TestQueryCommitsWithInvalidShortCid(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestQueryCommitsWithUnknownCid(t *testing.T) {
@@ -169,5 +169,5 @@ func TestQueryCommitsWithUnknownCid(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/query/commits/with_cid_test.go
+++ b/tests/integration/query/commits/with_cid_test.go
@@ -52,7 +52,7 @@ func TestQueryCommitsWithCid(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestQueryCommitsWithCidForFieldCommit(t *testing.T) {
@@ -85,7 +85,7 @@ func TestQueryCommitsWithCidForFieldCommit(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestQueryCommitsWithInvalidCid(t *testing.T) {
@@ -113,7 +113,7 @@ func TestQueryCommitsWithInvalidCid(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestQueryCommitsWithInvalidShortCid(t *testing.T) {
@@ -141,7 +141,7 @@ func TestQueryCommitsWithInvalidShortCid(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestQueryCommitsWithUnknownCid(t *testing.T) {
@@ -169,5 +169,5 @@ func TestQueryCommitsWithUnknownCid(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/query/commits/with_collectionid_group_order_test.go
+++ b/tests/integration/query/commits/with_collectionid_group_order_test.go
@@ -53,7 +53,7 @@ func TestQueryCommitsWithCollectionIDGroupedAndOrderedDesc(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestQueryCommitsWithCollectionIDGroupedAndOrderedAs(t *testing.T) {
@@ -93,5 +93,5 @@ func TestQueryCommitsWithCollectionIDGroupedAndOrderedAs(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/query/commits/with_collectionid_group_order_test.go
+++ b/tests/integration/query/commits/with_collectionid_group_order_test.go
@@ -53,7 +53,7 @@ func TestQueryCommitsWithCollectionIDGroupedAndOrderedDesc(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users", "Companies"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestQueryCommitsWithCollectionIDGroupedAndOrderedAs(t *testing.T) {
@@ -93,5 +93,5 @@ func TestQueryCommitsWithCollectionIDGroupedAndOrderedAs(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users", "Companies"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/query/commits/with_collectionid_prop_test.go
+++ b/tests/integration/query/commits/with_collectionid_prop_test.go
@@ -62,5 +62,5 @@ func TestQueryCommitsWithCollectionID(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/query/commits/with_collectionid_prop_test.go
+++ b/tests/integration/query/commits/with_collectionid_prop_test.go
@@ -62,5 +62,5 @@ func TestQueryCommitsWithCollectionID(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users", "Companies"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/query/commits/with_depth_test.go
+++ b/tests/integration/query/commits/with_depth_test.go
@@ -49,7 +49,7 @@ func TestQueryCommitsWithDepth1(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestQueryCommitsWithDepth1WithUpdate(t *testing.T) {
@@ -98,7 +98,7 @@ func TestQueryCommitsWithDepth1WithUpdate(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestQueryCommitsWithDepth2WithUpdate(t *testing.T) {
@@ -165,7 +165,7 @@ func TestQueryCommitsWithDepth2WithUpdate(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestQueryCommitsWithDepth1AndMultipleDocs(t *testing.T) {
@@ -217,5 +217,5 @@ func TestQueryCommitsWithDepth1AndMultipleDocs(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/query/commits/with_depth_test.go
+++ b/tests/integration/query/commits/with_depth_test.go
@@ -49,7 +49,7 @@ func TestQueryCommitsWithDepth1(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestQueryCommitsWithDepth1WithUpdate(t *testing.T) {
@@ -98,7 +98,7 @@ func TestQueryCommitsWithDepth1WithUpdate(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestQueryCommitsWithDepth2WithUpdate(t *testing.T) {
@@ -165,7 +165,7 @@ func TestQueryCommitsWithDepth2WithUpdate(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestQueryCommitsWithDepth1AndMultipleDocs(t *testing.T) {
@@ -217,5 +217,5 @@ func TestQueryCommitsWithDepth1AndMultipleDocs(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/query/commits/with_dockey_cid_test.go
+++ b/tests/integration/query/commits/with_dockey_cid_test.go
@@ -42,7 +42,7 @@ func TestQueryCommitsWithDockeyAndCidForDifferentDoc(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestQueryCommitsWithDockeyAndCidForDifferentDocWithUpdate(t *testing.T) {
@@ -78,7 +78,7 @@ func TestQueryCommitsWithDockeyAndCidForDifferentDocWithUpdate(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestQueryCommitsWithDockeyAndCid(t *testing.T) {
@@ -118,5 +118,5 @@ func TestQueryCommitsWithDockeyAndCid(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/query/commits/with_dockey_cid_test.go
+++ b/tests/integration/query/commits/with_dockey_cid_test.go
@@ -42,7 +42,7 @@ func TestQueryCommitsWithDockeyAndCidForDifferentDoc(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestQueryCommitsWithDockeyAndCidForDifferentDocWithUpdate(t *testing.T) {
@@ -78,7 +78,7 @@ func TestQueryCommitsWithDockeyAndCidForDifferentDocWithUpdate(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestQueryCommitsWithDockeyAndCid(t *testing.T) {
@@ -118,5 +118,5 @@ func TestQueryCommitsWithDockeyAndCid(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/query/commits/with_dockey_count_test.go
+++ b/tests/integration/query/commits/with_dockey_count_test.go
@@ -53,5 +53,5 @@ func TestQueryCommitsWithDockeyAndLinkCount(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/query/commits/with_dockey_count_test.go
+++ b/tests/integration/query/commits/with_dockey_count_test.go
@@ -53,5 +53,5 @@ func TestQueryCommitsWithDockeyAndLinkCount(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/query/commits/with_dockey_field_test.go
+++ b/tests/integration/query/commits/with_dockey_field_test.go
@@ -39,7 +39,7 @@ func TestQueryCommitsWithDockeyAndUnknownField(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestQueryCommitsWithDockeyAndUnknownFieldId(t *testing.T) {
@@ -65,7 +65,7 @@ func TestQueryCommitsWithDockeyAndUnknownFieldId(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 // This test is for documentation reasons only. This is not
@@ -93,7 +93,7 @@ func TestQueryCommitsWithDockeyAndField(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 // This test is for documentation reasons only. This is not
@@ -125,7 +125,7 @@ func TestQueryCommitsWithDockeyAndFieldId(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 // This test is for documentation reasons only. This is not
@@ -157,5 +157,5 @@ func TestQueryCommitsWithDockeyAndCompositeFieldId(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/query/commits/with_dockey_field_test.go
+++ b/tests/integration/query/commits/with_dockey_field_test.go
@@ -39,7 +39,7 @@ func TestQueryCommitsWithDockeyAndUnknownField(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestQueryCommitsWithDockeyAndUnknownFieldId(t *testing.T) {
@@ -65,7 +65,7 @@ func TestQueryCommitsWithDockeyAndUnknownFieldId(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 // This test is for documentation reasons only. This is not
@@ -93,7 +93,7 @@ func TestQueryCommitsWithDockeyAndField(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 // This test is for documentation reasons only. This is not
@@ -125,7 +125,7 @@ func TestQueryCommitsWithDockeyAndFieldId(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 // This test is for documentation reasons only. This is not
@@ -157,5 +157,5 @@ func TestQueryCommitsWithDockeyAndCompositeFieldId(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/query/commits/with_dockey_group_order_test.go
+++ b/tests/integration/query/commits/with_dockey_group_order_test.go
@@ -53,5 +53,5 @@ func TestQueryCommitsOrderedAndGroupedByDocKey(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/query/commits/with_dockey_group_order_test.go
+++ b/tests/integration/query/commits/with_dockey_group_order_test.go
@@ -53,5 +53,5 @@ func TestQueryCommitsOrderedAndGroupedByDocKey(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/query/commits/with_dockey_limit_offset_test.go
+++ b/tests/integration/query/commits/with_dockey_limit_offset_test.go
@@ -67,5 +67,5 @@ func TestQueryCommitsWithDockeyAndLimitAndOffset(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/query/commits/with_dockey_limit_offset_test.go
+++ b/tests/integration/query/commits/with_dockey_limit_offset_test.go
@@ -67,5 +67,5 @@ func TestQueryCommitsWithDockeyAndLimitAndOffset(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/query/commits/with_dockey_limit_test.go
+++ b/tests/integration/query/commits/with_dockey_limit_test.go
@@ -60,5 +60,5 @@ func TestQueryCommitsWithDockeyAndLimit(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/query/commits/with_dockey_limit_test.go
+++ b/tests/integration/query/commits/with_dockey_limit_test.go
@@ -60,5 +60,5 @@ func TestQueryCommitsWithDockeyAndLimit(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/query/commits/with_dockey_order_limit_offset_test.go
+++ b/tests/integration/query/commits/with_dockey_order_limit_offset_test.go
@@ -70,5 +70,5 @@ func TestQueryCommitsWithDockeyAndOrderAndLimitAndOffset(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/query/commits/with_dockey_order_limit_offset_test.go
+++ b/tests/integration/query/commits/with_dockey_order_limit_offset_test.go
@@ -70,5 +70,5 @@ func TestQueryCommitsWithDockeyAndOrderAndLimitAndOffset(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/query/commits/with_dockey_order_test.go
+++ b/tests/integration/query/commits/with_dockey_order_test.go
@@ -68,7 +68,7 @@ func TestQueryCommitsWithDockeyAndOrderHeightDesc(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestQueryCommitsWithDockeyAndOrderHeightAsc(t *testing.T) {
@@ -123,7 +123,7 @@ func TestQueryCommitsWithDockeyAndOrderHeightAsc(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestQueryCommitsWithDockeyAndOrderCidDesc(t *testing.T) {
@@ -178,7 +178,7 @@ func TestQueryCommitsWithDockeyAndOrderCidDesc(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestQueryCommitsWithDockeyAndOrderCidAsc(t *testing.T) {
@@ -233,7 +233,7 @@ func TestQueryCommitsWithDockeyAndOrderCidAsc(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestQueryCommitsWithDockeyAndOrderAndMultiUpdatesCidAsc(t *testing.T) {
@@ -318,5 +318,5 @@ func TestQueryCommitsWithDockeyAndOrderAndMultiUpdatesCidAsc(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/query/commits/with_dockey_order_test.go
+++ b/tests/integration/query/commits/with_dockey_order_test.go
@@ -68,7 +68,7 @@ func TestQueryCommitsWithDockeyAndOrderHeightDesc(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestQueryCommitsWithDockeyAndOrderHeightAsc(t *testing.T) {
@@ -123,7 +123,7 @@ func TestQueryCommitsWithDockeyAndOrderHeightAsc(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestQueryCommitsWithDockeyAndOrderCidDesc(t *testing.T) {
@@ -178,7 +178,7 @@ func TestQueryCommitsWithDockeyAndOrderCidDesc(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestQueryCommitsWithDockeyAndOrderCidAsc(t *testing.T) {
@@ -233,7 +233,7 @@ func TestQueryCommitsWithDockeyAndOrderCidAsc(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestQueryCommitsWithDockeyAndOrderAndMultiUpdatesCidAsc(t *testing.T) {
@@ -318,5 +318,5 @@ func TestQueryCommitsWithDockeyAndOrderAndMultiUpdatesCidAsc(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/query/commits/with_dockey_prop_test.go
+++ b/tests/integration/query/commits/with_dockey_prop_test.go
@@ -49,5 +49,5 @@ func TestQueryCommitsWithDockeyProperty(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/query/commits/with_dockey_prop_test.go
+++ b/tests/integration/query/commits/with_dockey_prop_test.go
@@ -49,5 +49,5 @@ func TestQueryCommitsWithDockeyProperty(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/query/commits/with_dockey_test.go
+++ b/tests/integration/query/commits/with_dockey_test.go
@@ -39,7 +39,7 @@ func TestQueryCommitsWithUnknownDockey(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestQueryCommitsWithDockey(t *testing.T) {
@@ -75,7 +75,7 @@ func TestQueryCommitsWithDockey(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestQueryCommitsWithDockeyAndLinks(t *testing.T) {
@@ -127,7 +127,7 @@ func TestQueryCommitsWithDockeyAndLinks(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestQueryCommitsWithDockeyAndUpdate(t *testing.T) {
@@ -182,7 +182,7 @@ func TestQueryCommitsWithDockeyAndUpdate(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 // This test is for documentation reasons only. This is not
@@ -266,5 +266,5 @@ func TestQueryCommitsWithDockeyAndUpdateAndLinks(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/query/commits/with_dockey_test.go
+++ b/tests/integration/query/commits/with_dockey_test.go
@@ -39,7 +39,7 @@ func TestQueryCommitsWithUnknownDockey(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestQueryCommitsWithDockey(t *testing.T) {
@@ -75,7 +75,7 @@ func TestQueryCommitsWithDockey(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestQueryCommitsWithDockeyAndLinks(t *testing.T) {
@@ -127,7 +127,7 @@ func TestQueryCommitsWithDockeyAndLinks(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestQueryCommitsWithDockeyAndUpdate(t *testing.T) {
@@ -182,7 +182,7 @@ func TestQueryCommitsWithDockeyAndUpdate(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 // This test is for documentation reasons only. This is not
@@ -266,5 +266,5 @@ func TestQueryCommitsWithDockeyAndUpdateAndLinks(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/query/commits/with_dockey_typename_test.go
+++ b/tests/integration/query/commits/with_dockey_typename_test.go
@@ -53,5 +53,5 @@ func TestQueryCommitsWithDockeyWithTypeName(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/query/commits/with_dockey_typename_test.go
+++ b/tests/integration/query/commits/with_dockey_typename_test.go
@@ -53,5 +53,5 @@ func TestQueryCommitsWithDockeyWithTypeName(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/query/commits/with_field_test.go
+++ b/tests/integration/query/commits/with_field_test.go
@@ -41,7 +41,7 @@ func TestQueryCommitsWithField(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 // This test is for documentation reasons only. This is not
@@ -73,7 +73,7 @@ func TestQueryCommitsWithFieldId(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 // This test is for documentation reasons only. This is not
@@ -105,7 +105,7 @@ func TestQueryCommitsWithCompositeFieldId(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 // This test is for documentation reasons only. This is not
@@ -139,5 +139,5 @@ func TestQueryCommitsWithCompositeFieldIdWithReturnedSchemaVersionId(t *testing.
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/query/commits/with_field_test.go
+++ b/tests/integration/query/commits/with_field_test.go
@@ -41,7 +41,7 @@ func TestQueryCommitsWithField(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 // This test is for documentation reasons only. This is not
@@ -73,7 +73,7 @@ func TestQueryCommitsWithFieldId(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 // This test is for documentation reasons only. This is not
@@ -105,7 +105,7 @@ func TestQueryCommitsWithCompositeFieldId(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 // This test is for documentation reasons only. This is not
@@ -139,5 +139,5 @@ func TestQueryCommitsWithCompositeFieldIdWithReturnedSchemaVersionId(t *testing.
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/query/commits/with_group_test.go
+++ b/tests/integration/query/commits/with_group_test.go
@@ -53,7 +53,7 @@ func TestQueryCommitsWithGroupBy(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestQueryCommitsWithGroupByHeightWithChild(t *testing.T) {
@@ -115,7 +115,7 @@ func TestQueryCommitsWithGroupByHeightWithChild(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 // This is an odd test, but we need to make sure it works
@@ -170,7 +170,7 @@ func TestQueryCommitsWithGroupByCidWithChild(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestQueryCommitsWithGroupByDocKey(t *testing.T) {
@@ -224,7 +224,7 @@ func TestQueryCommitsWithGroupByDocKey(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestQueryCommitsWithGroupByFieldName(t *testing.T) {
@@ -267,7 +267,7 @@ func TestQueryCommitsWithGroupByFieldName(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestQueryCommitsWithGroupByFieldNameWithChild(t *testing.T) {
@@ -334,7 +334,7 @@ func TestQueryCommitsWithGroupByFieldNameWithChild(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestQueryCommitsWithGroupByFieldID(t *testing.T) {
@@ -377,7 +377,7 @@ func TestQueryCommitsWithGroupByFieldID(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestQueryCommitsWithGroupByFieldIDWithChild(t *testing.T) {
@@ -444,5 +444,5 @@ func TestQueryCommitsWithGroupByFieldIDWithChild(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/query/commits/with_group_test.go
+++ b/tests/integration/query/commits/with_group_test.go
@@ -53,7 +53,7 @@ func TestQueryCommitsWithGroupBy(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestQueryCommitsWithGroupByHeightWithChild(t *testing.T) {
@@ -115,7 +115,7 @@ func TestQueryCommitsWithGroupByHeightWithChild(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 // This is an odd test, but we need to make sure it works
@@ -170,7 +170,7 @@ func TestQueryCommitsWithGroupByCidWithChild(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestQueryCommitsWithGroupByDocKey(t *testing.T) {
@@ -224,7 +224,7 @@ func TestQueryCommitsWithGroupByDocKey(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestQueryCommitsWithGroupByFieldName(t *testing.T) {
@@ -267,7 +267,7 @@ func TestQueryCommitsWithGroupByFieldName(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestQueryCommitsWithGroupByFieldNameWithChild(t *testing.T) {
@@ -334,7 +334,7 @@ func TestQueryCommitsWithGroupByFieldNameWithChild(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestQueryCommitsWithGroupByFieldID(t *testing.T) {
@@ -377,7 +377,7 @@ func TestQueryCommitsWithGroupByFieldID(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestQueryCommitsWithGroupByFieldIDWithChild(t *testing.T) {
@@ -444,5 +444,5 @@ func TestQueryCommitsWithGroupByFieldIDWithChild(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/query/latest_commits/with_collectionid_prop_test.go
+++ b/tests/integration/query/latest_commits/with_collectionid_prop_test.go
@@ -62,5 +62,5 @@ func TestQueryLastCommitsWithCollectionIdProperty(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users", "Companies"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/query/latest_commits/with_collectionid_prop_test.go
+++ b/tests/integration/query/latest_commits/with_collectionid_prop_test.go
@@ -62,5 +62,5 @@ func TestQueryLastCommitsWithCollectionIdProperty(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/query/latest_commits/with_dockey_prop_test.go
+++ b/tests/integration/query/latest_commits/with_dockey_prop_test.go
@@ -43,5 +43,5 @@ func TestQueryLastCommitsWithDockeyProperty(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/query/latest_commits/with_dockey_prop_test.go
+++ b/tests/integration/query/latest_commits/with_dockey_prop_test.go
@@ -43,5 +43,5 @@ func TestQueryLastCommitsWithDockeyProperty(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/query/one_to_many/with_id_field_test.go
+++ b/tests/integration/query/one_to_many/with_id_field_test.go
@@ -84,5 +84,5 @@ func TestQueryOneToManyWithIdFieldOnPrimary(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Book", "Author"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/query/one_to_many/with_id_field_test.go
+++ b/tests/integration/query/one_to_many/with_id_field_test.go
@@ -84,5 +84,5 @@ func TestQueryOneToManyWithIdFieldOnPrimary(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/query/one_to_many_to_one/joins_test.go
+++ b/tests/integration/query/one_to_many_to_one/joins_test.go
@@ -233,5 +233,5 @@ func TestOneToManyToOneJoinsAreLinkedProperly(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Author", "Book", "Publisher"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/query/one_to_many_to_one/joins_test.go
+++ b/tests/integration/query/one_to_many_to_one/joins_test.go
@@ -233,5 +233,5 @@ func TestOneToManyToOneJoinsAreLinkedProperly(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/query/one_to_many_to_one/simple_test.go
+++ b/tests/integration/query/one_to_many_to_one/simple_test.go
@@ -140,5 +140,5 @@ func TestQueryOneToOneRelations(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Author", "Book", "Publisher"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/query/one_to_many_to_one/simple_test.go
+++ b/tests/integration/query/one_to_many_to_one/simple_test.go
@@ -140,5 +140,5 @@ func TestQueryOneToOneRelations(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/query/one_to_many_to_one/with_filter_test.go
+++ b/tests/integration/query/one_to_many_to_one/with_filter_test.go
@@ -123,7 +123,7 @@ func TestQueryComplexWithDeepFilterOnRenderedChildren(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Author", "Book", "Publisher"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestOneToManyToOneWithSumOfDeepFilterSubTypeOfBothDescAndAsc(t *testing.T) {
@@ -163,7 +163,7 @@ func TestOneToManyToOneWithSumOfDeepFilterSubTypeOfBothDescAndAsc(t *testing.T) 
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Author", "Book", "Publisher"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestOneToManyToOneWithSumOfDeepFilterSubTypeAndDeepOrderBySubtypeOppositeDirections(t *testing.T) {
@@ -211,7 +211,7 @@ func TestOneToManyToOneWithSumOfDeepFilterSubTypeAndDeepOrderBySubtypeOppositeDi
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Author", "Book", "Publisher"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestOneToManyToOneWithTwoLevelDeepFilter(t *testing.T) {
@@ -282,5 +282,5 @@ func TestOneToManyToOneWithTwoLevelDeepFilter(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Author", "Book", "Publisher"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/query/one_to_many_to_one/with_filter_test.go
+++ b/tests/integration/query/one_to_many_to_one/with_filter_test.go
@@ -123,7 +123,7 @@ func TestQueryComplexWithDeepFilterOnRenderedChildren(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestOneToManyToOneWithSumOfDeepFilterSubTypeOfBothDescAndAsc(t *testing.T) {
@@ -163,7 +163,7 @@ func TestOneToManyToOneWithSumOfDeepFilterSubTypeOfBothDescAndAsc(t *testing.T) 
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestOneToManyToOneWithSumOfDeepFilterSubTypeAndDeepOrderBySubtypeOppositeDirections(t *testing.T) {
@@ -211,7 +211,7 @@ func TestOneToManyToOneWithSumOfDeepFilterSubTypeAndDeepOrderBySubtypeOppositeDi
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestOneToManyToOneWithTwoLevelDeepFilter(t *testing.T) {
@@ -282,5 +282,5 @@ func TestOneToManyToOneWithTwoLevelDeepFilter(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/query/one_to_many_to_one/with_order_limit_test.go
+++ b/tests/integration/query/one_to_many_to_one/with_order_limit_test.go
@@ -71,5 +71,5 @@ func TestOneToManyToOneDeepOrderBySubTypeOfBothDescAndAsc(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/query/one_to_many_to_one/with_order_limit_test.go
+++ b/tests/integration/query/one_to_many_to_one/with_order_limit_test.go
@@ -71,5 +71,5 @@ func TestOneToManyToOneDeepOrderBySubTypeOfBothDescAndAsc(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Author", "Book", "Publisher"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/query/one_to_many_to_one/with_order_test.go
+++ b/tests/integration/query/one_to_many_to_one/with_order_test.go
@@ -84,7 +84,7 @@ func TestMultipleOrderByWithDepthGreaterThanOne(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestMultipleOrderByWithDepthGreaterThanOneOrderSwitched(t *testing.T) {
@@ -155,5 +155,5 @@ func TestMultipleOrderByWithDepthGreaterThanOneOrderSwitched(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/query/one_to_many_to_one/with_order_test.go
+++ b/tests/integration/query/one_to_many_to_one/with_order_test.go
@@ -84,7 +84,7 @@ func TestMultipleOrderByWithDepthGreaterThanOne(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Author", "Book", "Publisher"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestMultipleOrderByWithDepthGreaterThanOneOrderSwitched(t *testing.T) {
@@ -155,5 +155,5 @@ func TestMultipleOrderByWithDepthGreaterThanOneOrderSwitched(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Author", "Book", "Publisher"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/query/one_to_many_to_one/with_sum_order_limit_test.go
+++ b/tests/integration/query/one_to_many_to_one/with_sum_order_limit_test.go
@@ -63,7 +63,7 @@ func TestOneToManyToOneWithSumOfDeepOrderBySubTypeAndDeepOrderBySubtypeDescDirec
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestOneToManyToOneWithSumOfDeepOrderBySubTypeAndDeepOrderBySubtypeAscDirections(t *testing.T) {
@@ -116,7 +116,7 @@ func TestOneToManyToOneWithSumOfDeepOrderBySubTypeAndDeepOrderBySubtypeAscDirect
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestOneToManyToOneWithSumOfDeepOrderBySubTypeOfBothDescAndAsc(t *testing.T) {
@@ -156,7 +156,7 @@ func TestOneToManyToOneWithSumOfDeepOrderBySubTypeOfBothDescAndAsc(t *testing.T)
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestOneToManyToOneWithSumOfDeepOrderBySubTypeAndDeepOrderBySubtypeOppositeDirections(t *testing.T) {
@@ -208,5 +208,5 @@ func TestOneToManyToOneWithSumOfDeepOrderBySubTypeAndDeepOrderBySubtypeOppositeD
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/query/one_to_many_to_one/with_sum_order_limit_test.go
+++ b/tests/integration/query/one_to_many_to_one/with_sum_order_limit_test.go
@@ -63,7 +63,7 @@ func TestOneToManyToOneWithSumOfDeepOrderBySubTypeAndDeepOrderBySubtypeDescDirec
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Author", "Book", "Publisher"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestOneToManyToOneWithSumOfDeepOrderBySubTypeAndDeepOrderBySubtypeAscDirections(t *testing.T) {
@@ -116,7 +116,7 @@ func TestOneToManyToOneWithSumOfDeepOrderBySubTypeAndDeepOrderBySubtypeAscDirect
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Author", "Book", "Publisher"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestOneToManyToOneWithSumOfDeepOrderBySubTypeOfBothDescAndAsc(t *testing.T) {
@@ -156,7 +156,7 @@ func TestOneToManyToOneWithSumOfDeepOrderBySubTypeOfBothDescAndAsc(t *testing.T)
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Author", "Book", "Publisher"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestOneToManyToOneWithSumOfDeepOrderBySubTypeAndDeepOrderBySubtypeOppositeDirections(t *testing.T) {
@@ -208,5 +208,5 @@ func TestOneToManyToOneWithSumOfDeepOrderBySubTypeAndDeepOrderBySubtypeOppositeD
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Author", "Book", "Publisher"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/query/one_to_many_to_one/with_sum_test.go
+++ b/tests/integration/query/one_to_many_to_one/with_sum_test.go
@@ -112,5 +112,5 @@ func TestQueryWithSumOnInlineAndSumOnOneToManyField(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Author", "Book", "Publisher"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/query/one_to_many_to_one/with_sum_test.go
+++ b/tests/integration/query/one_to_many_to_one/with_sum_test.go
@@ -112,5 +112,5 @@ func TestQueryWithSumOnInlineAndSumOnOneToManyField(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/query/one_to_one/with_group_related_id_alias_test.go
+++ b/tests/integration/query/one_to_one/with_group_related_id_alias_test.go
@@ -103,7 +103,7 @@ func TestQueryOneToOneWithGroupRelatedIDAlias(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 // This test documents unwanted behaviour, see:
@@ -187,5 +187,5 @@ func TestQueryOneToOneWithGroupRelatedIDAliasFromSecondary(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/query/one_to_one/with_group_related_id_alias_test.go
+++ b/tests/integration/query/one_to_one/with_group_related_id_alias_test.go
@@ -103,7 +103,7 @@ func TestQueryOneToOneWithGroupRelatedIDAlias(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Book", "Author"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 // This test documents unwanted behaviour, see:
@@ -187,5 +187,5 @@ func TestQueryOneToOneWithGroupRelatedIDAliasFromSecondary(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Book", "Author"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/query/one_to_one/with_group_related_id_test.go
+++ b/tests/integration/query/one_to_one/with_group_related_id_test.go
@@ -94,7 +94,7 @@ func TestQueryOneToOneWithGroupRelatedID(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Book", "Author"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 // This test documents unwanted behaviour, see:
@@ -172,5 +172,5 @@ func TestQueryOneToOneWithGroupRelatedIDFromSecondary(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Book", "Author"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/query/one_to_one/with_group_related_id_test.go
+++ b/tests/integration/query/one_to_one/with_group_related_id_test.go
@@ -94,7 +94,7 @@ func TestQueryOneToOneWithGroupRelatedID(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 // This test documents unwanted behaviour, see:
@@ -172,5 +172,5 @@ func TestQueryOneToOneWithGroupRelatedIDFromSecondary(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/query/one_to_one/with_id_field_test.go
+++ b/tests/integration/query/one_to_one/with_id_field_test.go
@@ -72,7 +72,7 @@ func TestQueryOneToOneWithIdFieldOnSecondary(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Book", "Author"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 // This documents unwanted behaviour, see https://github.com/sourcenetwork/defradb/issues/1520
@@ -113,5 +113,5 @@ func TestQueryOneToOneWithIdFieldOnPrimary(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Book", "Author"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/query/one_to_one/with_id_field_test.go
+++ b/tests/integration/query/one_to_one/with_id_field_test.go
@@ -72,7 +72,7 @@ func TestQueryOneToOneWithIdFieldOnSecondary(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 // This documents unwanted behaviour, see https://github.com/sourcenetwork/defradb/issues/1520
@@ -113,5 +113,5 @@ func TestQueryOneToOneWithIdFieldOnPrimary(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/query/one_to_one_to_many/simple_test.go
+++ b/tests/integration/query/one_to_one_to_many/simple_test.go
@@ -88,7 +88,7 @@ func TestQueryOneToOneToMany(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestQueryOneToOneToManyFromSecondaryOnOneToMany(t *testing.T) {
@@ -165,7 +165,7 @@ func TestQueryOneToOneToManyFromSecondaryOnOneToMany(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestQueryOneToOneToManyFromSecondaryOnOneToOne(t *testing.T) {
@@ -240,7 +240,7 @@ func TestQueryOneToOneToManyFromSecondaryOnOneToOne(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestQueryOneToOneToManyFromSecondary(t *testing.T) {
@@ -317,5 +317,5 @@ func TestQueryOneToOneToManyFromSecondary(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/query/one_to_one_to_many/simple_test.go
+++ b/tests/integration/query/one_to_one_to_many/simple_test.go
@@ -88,7 +88,7 @@ func TestQueryOneToOneToMany(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Indicator", "Observable", "Observation"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestQueryOneToOneToManyFromSecondaryOnOneToMany(t *testing.T) {
@@ -165,7 +165,7 @@ func TestQueryOneToOneToManyFromSecondaryOnOneToMany(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Indicator", "Observable", "Observation"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestQueryOneToOneToManyFromSecondaryOnOneToOne(t *testing.T) {
@@ -240,7 +240,7 @@ func TestQueryOneToOneToManyFromSecondaryOnOneToOne(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Indicator", "Observable", "Observation"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestQueryOneToOneToManyFromSecondary(t *testing.T) {
@@ -317,5 +317,5 @@ func TestQueryOneToOneToManyFromSecondary(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Indicator", "Observable", "Observation"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/query/one_to_one_to_one/simple_test.go
+++ b/tests/integration/query/one_to_one_to_one/simple_test.go
@@ -119,7 +119,7 @@ func TestQueryOneToOneToOne(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestQueryOneToOneToOneSecondaryThenPrimary(t *testing.T) {
@@ -225,7 +225,7 @@ func TestQueryOneToOneToOneSecondaryThenPrimary(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestQueryOneToOneToOnePrimaryThenSecondary(t *testing.T) {
@@ -331,7 +331,7 @@ func TestQueryOneToOneToOnePrimaryThenSecondary(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestQueryOneToOneToOneSecondary(t *testing.T) {
@@ -437,5 +437,5 @@ func TestQueryOneToOneToOneSecondary(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/query/one_to_one_to_one/simple_test.go
+++ b/tests/integration/query/one_to_one_to_one/simple_test.go
@@ -119,7 +119,7 @@ func TestQueryOneToOneToOne(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Publisher", "Book", "Author"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestQueryOneToOneToOneSecondaryThenPrimary(t *testing.T) {
@@ -225,7 +225,7 @@ func TestQueryOneToOneToOneSecondaryThenPrimary(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Publisher", "Book", "Author"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestQueryOneToOneToOnePrimaryThenSecondary(t *testing.T) {
@@ -331,7 +331,7 @@ func TestQueryOneToOneToOnePrimaryThenSecondary(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Publisher", "Book", "Author"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestQueryOneToOneToOneSecondary(t *testing.T) {
@@ -437,5 +437,5 @@ func TestQueryOneToOneToOneSecondary(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Publisher", "Book", "Author"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/query/one_to_one_to_one/with_order_test.go
+++ b/tests/integration/query/one_to_one_to_one/with_order_test.go
@@ -119,5 +119,5 @@ func TestQueryOneToOneToOneWithNestedOrder(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Publisher", "Book", "Author"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/query/one_to_one_to_one/with_order_test.go
+++ b/tests/integration/query/one_to_one_to_one/with_order_test.go
@@ -119,5 +119,5 @@ func TestQueryOneToOneToOneWithNestedOrder(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/query/simple/with_restart_test.go
+++ b/tests/integration/query/simple/with_restart_test.go
@@ -53,5 +53,5 @@ func TestQuerySimpleWithRestart(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/query/simple/with_restart_test.go
+++ b/tests/integration/query/simple/with_restart_test.go
@@ -53,5 +53,5 @@ func TestQuerySimpleWithRestart(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/schema/aggregates/inline_array_test.go
+++ b/tests/integration/schema/aggregates/inline_array_test.go
@@ -138,7 +138,7 @@ func TestSchemaAggregateInlineArrayCreatesUsersCount(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 */
 
@@ -261,7 +261,7 @@ func TestSchemaAggregateInlineArrayCreatesUsersSum(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 /* WIP
@@ -384,7 +384,7 @@ func TestSchemaAggregateInlineArrayCreatesUsersAverage(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 */
 
@@ -589,7 +589,7 @@ func TestSchemaAggregateInlineArrayCreatesUsersNillableBooleanCountFilter(t *tes
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaAggregateInlineArrayCreatesUsersBooleanCountFilter(t *testing.T) {
@@ -715,7 +715,7 @@ func TestSchemaAggregateInlineArrayCreatesUsersBooleanCountFilter(t *testing.T) 
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaAggregateInlineArrayCreatesUsersNillableIntegerCountFilter(t *testing.T) {
@@ -865,7 +865,7 @@ func TestSchemaAggregateInlineArrayCreatesUsersNillableIntegerCountFilter(t *tes
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaAggregateInlineArrayCreatesUsersIntegerCountFilter(t *testing.T) {
@@ -1015,7 +1015,7 @@ func TestSchemaAggregateInlineArrayCreatesUsersIntegerCountFilter(t *testing.T) 
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaAggregateInlineArrayCreatesUsersNillableFloatCountFilter(t *testing.T) {
@@ -1165,7 +1165,7 @@ func TestSchemaAggregateInlineArrayCreatesUsersNillableFloatCountFilter(t *testi
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaAggregateInlineArrayCreatesUsersFloatCountFilter(t *testing.T) {
@@ -1315,7 +1315,7 @@ func TestSchemaAggregateInlineArrayCreatesUsersFloatCountFilter(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaAggregateInlineArrayCreatesUsersNillableStringCountFilter(t *testing.T) {
@@ -1453,7 +1453,7 @@ func TestSchemaAggregateInlineArrayCreatesUsersNillableStringCountFilter(t *test
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaAggregateInlineArrayCreatesUsersStringCountFilter(t *testing.T) {
@@ -1591,5 +1591,5 @@ func TestSchemaAggregateInlineArrayCreatesUsersStringCountFilter(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/schema/aggregates/inline_array_test.go
+++ b/tests/integration/schema/aggregates/inline_array_test.go
@@ -138,7 +138,7 @@ func TestSchemaAggregateInlineArrayCreatesUsersCount(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 */
 
@@ -261,7 +261,7 @@ func TestSchemaAggregateInlineArrayCreatesUsersSum(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 /* WIP
@@ -384,7 +384,7 @@ func TestSchemaAggregateInlineArrayCreatesUsersAverage(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 */
 
@@ -589,7 +589,7 @@ func TestSchemaAggregateInlineArrayCreatesUsersNillableBooleanCountFilter(t *tes
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaAggregateInlineArrayCreatesUsersBooleanCountFilter(t *testing.T) {
@@ -715,7 +715,7 @@ func TestSchemaAggregateInlineArrayCreatesUsersBooleanCountFilter(t *testing.T) 
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaAggregateInlineArrayCreatesUsersNillableIntegerCountFilter(t *testing.T) {
@@ -865,7 +865,7 @@ func TestSchemaAggregateInlineArrayCreatesUsersNillableIntegerCountFilter(t *tes
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaAggregateInlineArrayCreatesUsersIntegerCountFilter(t *testing.T) {
@@ -1015,7 +1015,7 @@ func TestSchemaAggregateInlineArrayCreatesUsersIntegerCountFilter(t *testing.T) 
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaAggregateInlineArrayCreatesUsersNillableFloatCountFilter(t *testing.T) {
@@ -1165,7 +1165,7 @@ func TestSchemaAggregateInlineArrayCreatesUsersNillableFloatCountFilter(t *testi
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaAggregateInlineArrayCreatesUsersFloatCountFilter(t *testing.T) {
@@ -1315,7 +1315,7 @@ func TestSchemaAggregateInlineArrayCreatesUsersFloatCountFilter(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaAggregateInlineArrayCreatesUsersNillableStringCountFilter(t *testing.T) {
@@ -1453,7 +1453,7 @@ func TestSchemaAggregateInlineArrayCreatesUsersNillableStringCountFilter(t *test
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaAggregateInlineArrayCreatesUsersStringCountFilter(t *testing.T) {
@@ -1591,5 +1591,5 @@ func TestSchemaAggregateInlineArrayCreatesUsersStringCountFilter(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/schema/aggregates/simple_test.go
+++ b/tests/integration/schema/aggregates/simple_test.go
@@ -109,7 +109,7 @@ func TestSchemaAggregateSimpleCreatesUsersCount(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaAggregateSimpleCreatesUsersSum(t *testing.T) {
@@ -213,7 +213,7 @@ func TestSchemaAggregateSimpleCreatesUsersSum(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaAggregateSimpleCreatesUsersAverage(t *testing.T) {
@@ -317,5 +317,5 @@ func TestSchemaAggregateSimpleCreatesUsersAverage(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/schema/aggregates/simple_test.go
+++ b/tests/integration/schema/aggregates/simple_test.go
@@ -109,7 +109,7 @@ func TestSchemaAggregateSimpleCreatesUsersCount(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaAggregateSimpleCreatesUsersSum(t *testing.T) {
@@ -213,7 +213,7 @@ func TestSchemaAggregateSimpleCreatesUsersSum(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaAggregateSimpleCreatesUsersAverage(t *testing.T) {
@@ -317,5 +317,5 @@ func TestSchemaAggregateSimpleCreatesUsersAverage(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/schema/aggregates/top_level_test.go
+++ b/tests/integration/schema/aggregates/top_level_test.go
@@ -91,7 +91,7 @@ func TestSchemaAggregateTopLevelCreatesCountGivenSchema(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaAggregateTopLevelCreatesSumGivenSchema(t *testing.T) {
@@ -197,7 +197,7 @@ func TestSchemaAggregateTopLevelCreatesSumGivenSchema(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaAggregateTopLevelCreatesAverageGivenSchema(t *testing.T) {
@@ -303,5 +303,5 @@ func TestSchemaAggregateTopLevelCreatesAverageGivenSchema(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/schema/aggregates/top_level_test.go
+++ b/tests/integration/schema/aggregates/top_level_test.go
@@ -91,7 +91,7 @@ func TestSchemaAggregateTopLevelCreatesCountGivenSchema(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaAggregateTopLevelCreatesSumGivenSchema(t *testing.T) {
@@ -197,7 +197,7 @@ func TestSchemaAggregateTopLevelCreatesSumGivenSchema(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaAggregateTopLevelCreatesAverageGivenSchema(t *testing.T) {
@@ -303,5 +303,5 @@ func TestSchemaAggregateTopLevelCreatesAverageGivenSchema(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/schema/client_introspection/one_many_test.go
+++ b/tests/integration/schema/client_introspection/one_many_test.go
@@ -43,5 +43,5 @@ func TestClientIntrospectionWithOneToManySchema(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Book", "Author"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/schema/client_introspection/one_many_test.go
+++ b/tests/integration/schema/client_introspection/one_many_test.go
@@ -43,5 +43,5 @@ func TestClientIntrospectionWithOneToManySchema(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/schema/client_introspection/simple_test.go
+++ b/tests/integration/schema/client_introspection/simple_test.go
@@ -28,5 +28,5 @@ func TestClientIntrospectionBasic(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/schema/client_introspection/simple_test.go
+++ b/tests/integration/schema/client_introspection/simple_test.go
@@ -28,5 +28,5 @@ func TestClientIntrospectionBasic(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/schema/client_test.go
+++ b/tests/integration/schema/client_test.go
@@ -49,5 +49,5 @@ func TestIntrospectionExplainTypeDefined(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/schema/client_test.go
+++ b/tests/integration/schema/client_test.go
@@ -49,5 +49,5 @@ func TestIntrospectionExplainTypeDefined(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/schema/filter_test.go
+++ b/tests/integration/schema/filter_test.go
@@ -118,7 +118,7 @@ func TestFilterForSimpleSchema(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 var testFilterForSimpleSchemaArgProps = map[string]any{
@@ -270,7 +270,7 @@ func TestFilterForOneToOneSchema(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 var testFilterForOneToOneSchemaArgProps = map[string]any{

--- a/tests/integration/schema/filter_test.go
+++ b/tests/integration/schema/filter_test.go
@@ -118,7 +118,7 @@ func TestFilterForSimpleSchema(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 var testFilterForSimpleSchemaArgProps = map[string]any{
@@ -270,7 +270,7 @@ func TestFilterForOneToOneSchema(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Book", "Author"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 var testFilterForOneToOneSchemaArgProps = map[string]any{

--- a/tests/integration/schema/group_test.go
+++ b/tests/integration/schema/group_test.go
@@ -75,7 +75,7 @@ func TestGroupByFieldForTheManySideInSchema(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestGroupByFieldForTheSingleSideInSchema(t *testing.T) {
@@ -138,5 +138,5 @@ func TestGroupByFieldForTheSingleSideInSchema(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/schema/group_test.go
+++ b/tests/integration/schema/group_test.go
@@ -75,7 +75,7 @@ func TestGroupByFieldForTheManySideInSchema(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Book, Author"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestGroupByFieldForTheSingleSideInSchema(t *testing.T) {
@@ -138,5 +138,5 @@ func TestGroupByFieldForTheSingleSideInSchema(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Book, Author"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/schema/input_type_test.go
+++ b/tests/integration/schema/input_type_test.go
@@ -116,7 +116,7 @@ func TestInputTypeOfOrderFieldWhereSchemaHasManyRelationType(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestInputTypeOfOrderFieldWhereSchemaHasRelationType(t *testing.T) {
@@ -241,7 +241,7 @@ func TestInputTypeOfOrderFieldWhereSchemaHasRelationType(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 var testInputTypeOfOrderFieldWhereSchemaHasRelationTypeArgProps = map[string]any{

--- a/tests/integration/schema/input_type_test.go
+++ b/tests/integration/schema/input_type_test.go
@@ -116,7 +116,7 @@ func TestInputTypeOfOrderFieldWhereSchemaHasManyRelationType(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"user", "group"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestInputTypeOfOrderFieldWhereSchemaHasRelationType(t *testing.T) {
@@ -241,7 +241,7 @@ func TestInputTypeOfOrderFieldWhereSchemaHasRelationType(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"book", "author"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 var testInputTypeOfOrderFieldWhereSchemaHasRelationTypeArgProps = map[string]any{

--- a/tests/integration/schema/migrations/query/simple_test.go
+++ b/tests/integration/schema/migrations/query/simple_test.go
@@ -77,7 +77,7 @@ func TestSchemaMigrationQuery(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaMigrationQueryMultipleDocs(t *testing.T) {
@@ -155,7 +155,7 @@ func TestSchemaMigrationQueryMultipleDocs(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 // Users may want to register migrations before the schema is locally updated. This may be particularly useful
@@ -217,7 +217,7 @@ func TestSchemaMigrationQueryWithMigrationRegisteredBeforeSchemaPatch(t *testing
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaMigrationQueryMigratesToIntermediaryVersion(t *testing.T) {
@@ -288,7 +288,7 @@ func TestSchemaMigrationQueryMigratesToIntermediaryVersion(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaMigrationQueryMigratesFromIntermediaryVersion(t *testing.T) {
@@ -359,7 +359,7 @@ func TestSchemaMigrationQueryMigratesFromIntermediaryVersion(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaMigrationQueryMigratesAcrossMultipleVersions(t *testing.T) {
@@ -445,7 +445,7 @@ func TestSchemaMigrationQueryMigratesAcrossMultipleVersions(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 // This test is important as it tests that orphan migrations do not block the fetcher(s)
@@ -511,7 +511,7 @@ func TestSchemaMigrationQueryWithUnknownSchemaMigration(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaMigrationQueryMigrationMutatesExistingScalarField(t *testing.T) {
@@ -572,7 +572,7 @@ func TestSchemaMigrationQueryMigrationMutatesExistingScalarField(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaMigrationQueryMigrationMutatesExistingInlineArrayField(t *testing.T) {
@@ -633,7 +633,7 @@ func TestSchemaMigrationQueryMigrationMutatesExistingInlineArrayField(t *testing
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaMigrationQueryMigrationRemovesExistingField(t *testing.T) {
@@ -694,7 +694,7 @@ func TestSchemaMigrationQueryMigrationRemovesExistingField(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaMigrationQueryMigrationPreservesExistingFieldWhenFieldNotRequested(t *testing.T) {
@@ -768,7 +768,7 @@ func TestSchemaMigrationQueryMigrationPreservesExistingFieldWhenFieldNotRequeste
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaMigrationQueryMigrationCopiesExistingFieldWhenSrcFieldNotRequested(t *testing.T) {
@@ -830,7 +830,7 @@ func TestSchemaMigrationQueryMigrationCopiesExistingFieldWhenSrcFieldNotRequeste
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaMigrationQueryMigrationCopiesExistingFieldWhenSrcAndDstFieldNotRequested(t *testing.T) {
@@ -906,5 +906,5 @@ func TestSchemaMigrationQueryMigrationCopiesExistingFieldWhenSrcAndDstFieldNotRe
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/schema/migrations/query/simple_test.go
+++ b/tests/integration/schema/migrations/query/simple_test.go
@@ -77,7 +77,7 @@ func TestSchemaMigrationQuery(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaMigrationQueryMultipleDocs(t *testing.T) {
@@ -155,7 +155,7 @@ func TestSchemaMigrationQueryMultipleDocs(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 // Users may want to register migrations before the schema is locally updated. This may be particularly useful
@@ -217,7 +217,7 @@ func TestSchemaMigrationQueryWithMigrationRegisteredBeforeSchemaPatch(t *testing
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaMigrationQueryMigratesToIntermediaryVersion(t *testing.T) {
@@ -288,7 +288,7 @@ func TestSchemaMigrationQueryMigratesToIntermediaryVersion(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaMigrationQueryMigratesFromIntermediaryVersion(t *testing.T) {
@@ -359,7 +359,7 @@ func TestSchemaMigrationQueryMigratesFromIntermediaryVersion(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaMigrationQueryMigratesAcrossMultipleVersions(t *testing.T) {
@@ -445,7 +445,7 @@ func TestSchemaMigrationQueryMigratesAcrossMultipleVersions(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 // This test is important as it tests that orphan migrations do not block the fetcher(s)
@@ -511,7 +511,7 @@ func TestSchemaMigrationQueryWithUnknownSchemaMigration(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaMigrationQueryMigrationMutatesExistingScalarField(t *testing.T) {
@@ -572,7 +572,7 @@ func TestSchemaMigrationQueryMigrationMutatesExistingScalarField(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaMigrationQueryMigrationMutatesExistingInlineArrayField(t *testing.T) {
@@ -633,7 +633,7 @@ func TestSchemaMigrationQueryMigrationMutatesExistingInlineArrayField(t *testing
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaMigrationQueryMigrationRemovesExistingField(t *testing.T) {
@@ -694,7 +694,7 @@ func TestSchemaMigrationQueryMigrationRemovesExistingField(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaMigrationQueryMigrationPreservesExistingFieldWhenFieldNotRequested(t *testing.T) {
@@ -768,7 +768,7 @@ func TestSchemaMigrationQueryMigrationPreservesExistingFieldWhenFieldNotRequeste
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaMigrationQueryMigrationCopiesExistingFieldWhenSrcFieldNotRequested(t *testing.T) {
@@ -830,7 +830,7 @@ func TestSchemaMigrationQueryMigrationCopiesExistingFieldWhenSrcFieldNotRequeste
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaMigrationQueryMigrationCopiesExistingFieldWhenSrcAndDstFieldNotRequested(t *testing.T) {
@@ -906,5 +906,5 @@ func TestSchemaMigrationQueryMigrationCopiesExistingFieldWhenSrcAndDstFieldNotRe
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/schema/migrations/query/with_dockey_test.go
+++ b/tests/integration/schema/migrations/query/with_dockey_test.go
@@ -84,7 +84,7 @@ func TestSchemaMigrationQueryByDocKey(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 // This test asserts that lenses are being correctly returned to the pool for reuse after
@@ -260,5 +260,5 @@ func TestSchemaMigrationQueryMultipleQueriesByDocKey(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/schema/migrations/query/with_dockey_test.go
+++ b/tests/integration/schema/migrations/query/with_dockey_test.go
@@ -84,7 +84,7 @@ func TestSchemaMigrationQueryByDocKey(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 // This test asserts that lenses are being correctly returned to the pool for reuse after
@@ -260,5 +260,5 @@ func TestSchemaMigrationQueryMultipleQueriesByDocKey(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/schema/migrations/query/with_p2p_test.go
+++ b/tests/integration/schema/migrations/query/with_p2p_test.go
@@ -107,5 +107,5 @@ func TestSchemaMigrationQueryWithP2PReplicatedDocAtOlderSchemaVersion(t *testing
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/schema/migrations/query/with_p2p_test.go
+++ b/tests/integration/schema/migrations/query/with_p2p_test.go
@@ -107,5 +107,5 @@ func TestSchemaMigrationQueryWithP2PReplicatedDocAtOlderSchemaVersion(t *testing
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/schema/migrations/query/with_restart_test.go
+++ b/tests/integration/schema/migrations/query/with_restart_test.go
@@ -78,5 +78,5 @@ func TestSchemaMigrationQueryWithRestart(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/schema/migrations/query/with_restart_test.go
+++ b/tests/integration/schema/migrations/query/with_restart_test.go
@@ -78,5 +78,5 @@ func TestSchemaMigrationQueryWithRestart(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/schema/migrations/query/with_txn_test.go
+++ b/tests/integration/schema/migrations/query/with_txn_test.go
@@ -84,7 +84,7 @@ func TestSchemaMigrationQueryWithTxn(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaMigrationQueryWithTxnAndCommit(t *testing.T) {
@@ -149,5 +149,5 @@ func TestSchemaMigrationQueryWithTxnAndCommit(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/schema/migrations/query/with_txn_test.go
+++ b/tests/integration/schema/migrations/query/with_txn_test.go
@@ -84,7 +84,7 @@ func TestSchemaMigrationQueryWithTxn(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaMigrationQueryWithTxnAndCommit(t *testing.T) {
@@ -149,5 +149,5 @@ func TestSchemaMigrationQueryWithTxnAndCommit(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/schema/migrations/query/with_update_test.go
+++ b/tests/integration/schema/migrations/query/with_update_test.go
@@ -95,7 +95,7 @@ func TestSchemaMigrationQueryWithUpdateRequest(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaMigrationQueryWithMigrationRegisteredAfterUpdate(t *testing.T) {
@@ -163,5 +163,5 @@ func TestSchemaMigrationQueryWithMigrationRegisteredAfterUpdate(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/schema/migrations/query/with_update_test.go
+++ b/tests/integration/schema/migrations/query/with_update_test.go
@@ -95,7 +95,7 @@ func TestSchemaMigrationQueryWithUpdateRequest(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaMigrationQueryWithMigrationRegisteredAfterUpdate(t *testing.T) {
@@ -163,5 +163,5 @@ func TestSchemaMigrationQueryWithMigrationRegisteredAfterUpdate(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/schema/migrations/simple_test.go
+++ b/tests/integration/schema/migrations/simple_test.go
@@ -65,7 +65,7 @@ func TestSchemaMigrationDoesNotErrorGivenUnknownSchemaIDs(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaMigrationGetMigrationsReturnsMultiple(t *testing.T) {
@@ -143,7 +143,7 @@ func TestSchemaMigrationGetMigrationsReturnsMultiple(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaMigrationReplacesExistingMigationBasedOnSourceID(t *testing.T) {
@@ -207,5 +207,5 @@ func TestSchemaMigrationReplacesExistingMigationBasedOnSourceID(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/schema/migrations/simple_test.go
+++ b/tests/integration/schema/migrations/simple_test.go
@@ -65,7 +65,7 @@ func TestSchemaMigrationDoesNotErrorGivenUnknownSchemaIDs(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaMigrationGetMigrationsReturnsMultiple(t *testing.T) {
@@ -143,7 +143,7 @@ func TestSchemaMigrationGetMigrationsReturnsMultiple(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaMigrationReplacesExistingMigationBasedOnSourceID(t *testing.T) {
@@ -207,5 +207,5 @@ func TestSchemaMigrationReplacesExistingMigationBasedOnSourceID(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/schema/migrations/with_txn_test.go
+++ b/tests/integration/schema/migrations/with_txn_test.go
@@ -54,5 +54,5 @@ func TestSchemaMigrationGetMigrationsWithTxn(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/schema/migrations/with_txn_test.go
+++ b/tests/integration/schema/migrations/with_txn_test.go
@@ -54,5 +54,5 @@ func TestSchemaMigrationGetMigrationsWithTxn(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/schema/relations_test.go
+++ b/tests/integration/schema/relations_test.go
@@ -70,7 +70,7 @@ func TestSchemaRelationOneToOne(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaRelationManyToOne(t *testing.T) {
@@ -120,7 +120,7 @@ func TestSchemaRelationManyToOne(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaRelationErrorsGivenOneSidedManyRelationField(t *testing.T) {
@@ -140,7 +140,7 @@ func TestSchemaRelationErrorsGivenOneSidedManyRelationField(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaRelationErrorsGivenOneSidedRelationField(t *testing.T) {
@@ -160,7 +160,7 @@ func TestSchemaRelationErrorsGivenOneSidedRelationField(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaRelation_GivenSelfReferemceRelationField_ReturnError(t *testing.T) {
@@ -178,5 +178,5 @@ func TestSchemaRelation_GivenSelfReferemceRelationField_ReturnError(t *testing.T
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/schema/relations_test.go
+++ b/tests/integration/schema/relations_test.go
@@ -70,7 +70,7 @@ func TestSchemaRelationOneToOne(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Dog", "User"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaRelationManyToOne(t *testing.T) {
@@ -120,7 +120,7 @@ func TestSchemaRelationManyToOne(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Dog", "User"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaRelationErrorsGivenOneSidedManyRelationField(t *testing.T) {
@@ -140,7 +140,7 @@ func TestSchemaRelationErrorsGivenOneSidedManyRelationField(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Dog", "User"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaRelationErrorsGivenOneSidedRelationField(t *testing.T) {
@@ -160,7 +160,7 @@ func TestSchemaRelationErrorsGivenOneSidedRelationField(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Dog", "User"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaRelation_GivenSelfReferemceRelationField_ReturnError(t *testing.T) {
@@ -178,5 +178,5 @@ func TestSchemaRelation_GivenSelfReferemceRelationField_ReturnError(t *testing.T
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Dog", "User"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/schema/simple_test.go
+++ b/tests/integration/schema/simple_test.go
@@ -41,7 +41,7 @@ func TestSchemaSimpleCreatesSchemaGivenEmptyType(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaSimpleErrorsGivenDuplicateSchema(t *testing.T) {
@@ -62,7 +62,7 @@ func TestSchemaSimpleErrorsGivenDuplicateSchema(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaSimpleErrorsGivenDuplicateSchemaInSameSDL(t *testing.T) {
@@ -78,7 +78,7 @@ func TestSchemaSimpleErrorsGivenDuplicateSchemaInSameSDL(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaSimpleCreatesSchemaGivenNewTypes(t *testing.T) {
@@ -111,7 +111,7 @@ func TestSchemaSimpleCreatesSchemaGivenNewTypes(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users", "Books"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaSimpleCreatesSchemaWithDefaultFieldsGivenEmptyType(t *testing.T) {
@@ -147,7 +147,7 @@ func TestSchemaSimpleCreatesSchemaWithDefaultFieldsGivenEmptyType(t *testing.T) 
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaSimpleErrorsGivenTypeWithInvalidFieldType(t *testing.T) {
@@ -164,7 +164,7 @@ func TestSchemaSimpleErrorsGivenTypeWithInvalidFieldType(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaSimpleCreatesSchemaGivenTypeWithStringField(t *testing.T) {
@@ -210,7 +210,7 @@ func TestSchemaSimpleCreatesSchemaGivenTypeWithStringField(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaSimpleErrorsGivenNonNullField(t *testing.T) {
@@ -227,7 +227,7 @@ func TestSchemaSimpleErrorsGivenNonNullField(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaSimpleErrorsGivenNonNullManyRelationField(t *testing.T) {
@@ -248,5 +248,5 @@ func TestSchemaSimpleErrorsGivenNonNullManyRelationField(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Dogs", "Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/schema/simple_test.go
+++ b/tests/integration/schema/simple_test.go
@@ -41,7 +41,7 @@ func TestSchemaSimpleCreatesSchemaGivenEmptyType(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaSimpleErrorsGivenDuplicateSchema(t *testing.T) {
@@ -62,7 +62,7 @@ func TestSchemaSimpleErrorsGivenDuplicateSchema(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaSimpleErrorsGivenDuplicateSchemaInSameSDL(t *testing.T) {
@@ -78,7 +78,7 @@ func TestSchemaSimpleErrorsGivenDuplicateSchemaInSameSDL(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaSimpleCreatesSchemaGivenNewTypes(t *testing.T) {
@@ -111,7 +111,7 @@ func TestSchemaSimpleCreatesSchemaGivenNewTypes(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaSimpleCreatesSchemaWithDefaultFieldsGivenEmptyType(t *testing.T) {
@@ -147,7 +147,7 @@ func TestSchemaSimpleCreatesSchemaWithDefaultFieldsGivenEmptyType(t *testing.T) 
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaSimpleErrorsGivenTypeWithInvalidFieldType(t *testing.T) {
@@ -164,7 +164,7 @@ func TestSchemaSimpleErrorsGivenTypeWithInvalidFieldType(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaSimpleCreatesSchemaGivenTypeWithStringField(t *testing.T) {
@@ -210,7 +210,7 @@ func TestSchemaSimpleCreatesSchemaGivenTypeWithStringField(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaSimpleErrorsGivenNonNullField(t *testing.T) {
@@ -227,7 +227,7 @@ func TestSchemaSimpleErrorsGivenNonNullField(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaSimpleErrorsGivenNonNullManyRelationField(t *testing.T) {
@@ -248,5 +248,5 @@ func TestSchemaSimpleErrorsGivenNonNullManyRelationField(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/schema/updates/add/field/crdt/composite_test.go
+++ b/tests/integration/schema/updates/add/field/crdt/composite_test.go
@@ -37,5 +37,5 @@ func TestSchemaUpdatesAddFieldCRDTCompositeErrors(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/schema/updates/add/field/crdt/composite_test.go
+++ b/tests/integration/schema/updates/add/field/crdt/composite_test.go
@@ -37,5 +37,5 @@ func TestSchemaUpdatesAddFieldCRDTCompositeErrors(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/schema/updates/add/field/crdt/invalid_test.go
+++ b/tests/integration/schema/updates/add/field/crdt/invalid_test.go
@@ -37,5 +37,5 @@ func TestSchemaUpdatesAddFieldCRDTInvalidErrors(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/schema/updates/add/field/crdt/invalid_test.go
+++ b/tests/integration/schema/updates/add/field/crdt/invalid_test.go
@@ -37,5 +37,5 @@ func TestSchemaUpdatesAddFieldCRDTInvalidErrors(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/schema/updates/add/field/crdt/lww_test.go
+++ b/tests/integration/schema/updates/add/field/crdt/lww_test.go
@@ -45,5 +45,5 @@ func TestSchemaUpdatesAddFieldCRDTLWW(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/schema/updates/add/field/crdt/lww_test.go
+++ b/tests/integration/schema/updates/add/field/crdt/lww_test.go
@@ -45,5 +45,5 @@ func TestSchemaUpdatesAddFieldCRDTLWW(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/schema/updates/add/field/crdt/none_test.go
+++ b/tests/integration/schema/updates/add/field/crdt/none_test.go
@@ -45,7 +45,7 @@ func TestSchemaUpdatesAddFieldCRDTDefault(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaUpdatesAddFieldCRDTNone(t *testing.T) {
@@ -77,5 +77,5 @@ func TestSchemaUpdatesAddFieldCRDTNone(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/schema/updates/add/field/crdt/none_test.go
+++ b/tests/integration/schema/updates/add/field/crdt/none_test.go
@@ -45,7 +45,7 @@ func TestSchemaUpdatesAddFieldCRDTDefault(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaUpdatesAddFieldCRDTNone(t *testing.T) {
@@ -77,5 +77,5 @@ func TestSchemaUpdatesAddFieldCRDTNone(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/schema/updates/add/field/crdt/object_bool_test.go
+++ b/tests/integration/schema/updates/add/field/crdt/object_bool_test.go
@@ -37,5 +37,5 @@ func TestSchemaUpdatesAddFieldCRDTObjectWithBoolFieldErrors(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/schema/updates/add/field/crdt/object_bool_test.go
+++ b/tests/integration/schema/updates/add/field/crdt/object_bool_test.go
@@ -37,5 +37,5 @@ func TestSchemaUpdatesAddFieldCRDTObjectWithBoolFieldErrors(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/schema/updates/add/field/create_test.go
+++ b/tests/integration/schema/updates/add/field/create_test.go
@@ -58,7 +58,7 @@ func TestSchemaUpdatesAddFieldWithCreate(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaUpdatesAddFieldWithCreateAfterSchemaUpdate(t *testing.T) {
@@ -118,5 +118,5 @@ func TestSchemaUpdatesAddFieldWithCreateAfterSchemaUpdate(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/schema/updates/add/field/create_test.go
+++ b/tests/integration/schema/updates/add/field/create_test.go
@@ -58,7 +58,7 @@ func TestSchemaUpdatesAddFieldWithCreate(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaUpdatesAddFieldWithCreateAfterSchemaUpdate(t *testing.T) {
@@ -118,5 +118,5 @@ func TestSchemaUpdatesAddFieldWithCreateAfterSchemaUpdate(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/schema/updates/add/field/create_update_test.go
+++ b/tests/integration/schema/updates/add/field/create_update_test.go
@@ -101,7 +101,7 @@ func TestSchemaUpdatesAddFieldWithCreateWithUpdateAfterSchemaUpdateAndVersionJoi
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaUpdatesAddFieldWithCreateWithUpdateAfterSchemaUpdateAndCommitQuery(t *testing.T) {
@@ -157,5 +157,5 @@ func TestSchemaUpdatesAddFieldWithCreateWithUpdateAfterSchemaUpdateAndCommitQuer
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/schema/updates/add/field/create_update_test.go
+++ b/tests/integration/schema/updates/add/field/create_update_test.go
@@ -101,7 +101,7 @@ func TestSchemaUpdatesAddFieldWithCreateWithUpdateAfterSchemaUpdateAndVersionJoi
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaUpdatesAddFieldWithCreateWithUpdateAfterSchemaUpdateAndCommitQuery(t *testing.T) {
@@ -157,5 +157,5 @@ func TestSchemaUpdatesAddFieldWithCreateWithUpdateAfterSchemaUpdateAndCommitQuer
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/schema/updates/add/field/kind/bool_array_test.go
+++ b/tests/integration/schema/updates/add/field/kind/bool_array_test.go
@@ -45,7 +45,7 @@ func TestSchemaUpdatesAddFieldKindBoolArray(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaUpdatesAddFieldKindBoolArrayWithCreate(t *testing.T) {
@@ -89,7 +89,7 @@ func TestSchemaUpdatesAddFieldKindBoolArrayWithCreate(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaUpdatesAddFieldKindBoolArraySubstitutionWithCreate(t *testing.T) {
@@ -133,5 +133,5 @@ func TestSchemaUpdatesAddFieldKindBoolArraySubstitutionWithCreate(t *testing.T) 
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/schema/updates/add/field/kind/bool_array_test.go
+++ b/tests/integration/schema/updates/add/field/kind/bool_array_test.go
@@ -45,7 +45,7 @@ func TestSchemaUpdatesAddFieldKindBoolArray(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaUpdatesAddFieldKindBoolArrayWithCreate(t *testing.T) {
@@ -89,7 +89,7 @@ func TestSchemaUpdatesAddFieldKindBoolArrayWithCreate(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaUpdatesAddFieldKindBoolArraySubstitutionWithCreate(t *testing.T) {
@@ -133,5 +133,5 @@ func TestSchemaUpdatesAddFieldKindBoolArraySubstitutionWithCreate(t *testing.T) 
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/schema/updates/add/field/kind/bool_nil_array_test.go
+++ b/tests/integration/schema/updates/add/field/kind/bool_nil_array_test.go
@@ -47,7 +47,7 @@ func TestSchemaUpdatesAddFieldKindNillableBoolArray(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaUpdatesAddFieldKindNillableBoolArrayWithCreate(t *testing.T) {
@@ -91,7 +91,7 @@ func TestSchemaUpdatesAddFieldKindNillableBoolArrayWithCreate(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaUpdatesAddFieldKindNillableBoolArraySubstitutionWithCreate(t *testing.T) {
@@ -135,5 +135,5 @@ func TestSchemaUpdatesAddFieldKindNillableBoolArraySubstitutionWithCreate(t *tes
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/schema/updates/add/field/kind/bool_nil_array_test.go
+++ b/tests/integration/schema/updates/add/field/kind/bool_nil_array_test.go
@@ -47,7 +47,7 @@ func TestSchemaUpdatesAddFieldKindNillableBoolArray(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaUpdatesAddFieldKindNillableBoolArrayWithCreate(t *testing.T) {
@@ -91,7 +91,7 @@ func TestSchemaUpdatesAddFieldKindNillableBoolArrayWithCreate(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaUpdatesAddFieldKindNillableBoolArraySubstitutionWithCreate(t *testing.T) {
@@ -135,5 +135,5 @@ func TestSchemaUpdatesAddFieldKindNillableBoolArraySubstitutionWithCreate(t *tes
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/schema/updates/add/field/kind/bool_test.go
+++ b/tests/integration/schema/updates/add/field/kind/bool_test.go
@@ -45,7 +45,7 @@ func TestSchemaUpdatesAddFieldKindBool(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaUpdatesAddFieldKindBoolWithCreate(t *testing.T) {
@@ -89,7 +89,7 @@ func TestSchemaUpdatesAddFieldKindBoolWithCreate(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaUpdatesAddFieldKindBoolSubstitutionWithCreate(t *testing.T) {
@@ -133,5 +133,5 @@ func TestSchemaUpdatesAddFieldKindBoolSubstitutionWithCreate(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/schema/updates/add/field/kind/bool_test.go
+++ b/tests/integration/schema/updates/add/field/kind/bool_test.go
@@ -45,7 +45,7 @@ func TestSchemaUpdatesAddFieldKindBool(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaUpdatesAddFieldKindBoolWithCreate(t *testing.T) {
@@ -89,7 +89,7 @@ func TestSchemaUpdatesAddFieldKindBoolWithCreate(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaUpdatesAddFieldKindBoolSubstitutionWithCreate(t *testing.T) {
@@ -133,5 +133,5 @@ func TestSchemaUpdatesAddFieldKindBoolSubstitutionWithCreate(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/schema/updates/add/field/kind/datetime_test.go
+++ b/tests/integration/schema/updates/add/field/kind/datetime_test.go
@@ -45,7 +45,7 @@ func TestSchemaUpdatesAddFieldKindDateTime(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaUpdatesAddFieldKindDateTimeWithCreate(t *testing.T) {
@@ -89,7 +89,7 @@ func TestSchemaUpdatesAddFieldKindDateTimeWithCreate(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaUpdatesAddFieldKindDateTimeSubstitutionWithCreate(t *testing.T) {
@@ -133,5 +133,5 @@ func TestSchemaUpdatesAddFieldKindDateTimeSubstitutionWithCreate(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/schema/updates/add/field/kind/datetime_test.go
+++ b/tests/integration/schema/updates/add/field/kind/datetime_test.go
@@ -45,7 +45,7 @@ func TestSchemaUpdatesAddFieldKindDateTime(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaUpdatesAddFieldKindDateTimeWithCreate(t *testing.T) {
@@ -89,7 +89,7 @@ func TestSchemaUpdatesAddFieldKindDateTimeWithCreate(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaUpdatesAddFieldKindDateTimeSubstitutionWithCreate(t *testing.T) {
@@ -133,5 +133,5 @@ func TestSchemaUpdatesAddFieldKindDateTimeSubstitutionWithCreate(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/schema/updates/add/field/kind/dockey_test.go
+++ b/tests/integration/schema/updates/add/field/kind/dockey_test.go
@@ -45,7 +45,7 @@ func TestSchemaUpdatesAddFieldKindDocKey(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaUpdatesAddFieldKindDocKeyWithCreate(t *testing.T) {
@@ -89,7 +89,7 @@ func TestSchemaUpdatesAddFieldKindDocKeyWithCreate(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaUpdatesAddFieldKindDocKeySubstitutionWithCreate(t *testing.T) {
@@ -133,5 +133,5 @@ func TestSchemaUpdatesAddFieldKindDocKeySubstitutionWithCreate(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/schema/updates/add/field/kind/dockey_test.go
+++ b/tests/integration/schema/updates/add/field/kind/dockey_test.go
@@ -45,7 +45,7 @@ func TestSchemaUpdatesAddFieldKindDocKey(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaUpdatesAddFieldKindDocKeyWithCreate(t *testing.T) {
@@ -89,7 +89,7 @@ func TestSchemaUpdatesAddFieldKindDocKeyWithCreate(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaUpdatesAddFieldKindDocKeySubstitutionWithCreate(t *testing.T) {
@@ -133,5 +133,5 @@ func TestSchemaUpdatesAddFieldKindDocKeySubstitutionWithCreate(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/schema/updates/add/field/kind/float_array_test.go
+++ b/tests/integration/schema/updates/add/field/kind/float_array_test.go
@@ -45,7 +45,7 @@ func TestSchemaUpdatesAddFieldKindFloatArray(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaUpdatesAddFieldKindFloatArrayWithCreate(t *testing.T) {
@@ -89,7 +89,7 @@ func TestSchemaUpdatesAddFieldKindFloatArrayWithCreate(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaUpdatesAddFieldKindFloatArraySubstitutionWithCreate(t *testing.T) {
@@ -133,5 +133,5 @@ func TestSchemaUpdatesAddFieldKindFloatArraySubstitutionWithCreate(t *testing.T)
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/schema/updates/add/field/kind/float_array_test.go
+++ b/tests/integration/schema/updates/add/field/kind/float_array_test.go
@@ -45,7 +45,7 @@ func TestSchemaUpdatesAddFieldKindFloatArray(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaUpdatesAddFieldKindFloatArrayWithCreate(t *testing.T) {
@@ -89,7 +89,7 @@ func TestSchemaUpdatesAddFieldKindFloatArrayWithCreate(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaUpdatesAddFieldKindFloatArraySubstitutionWithCreate(t *testing.T) {
@@ -133,5 +133,5 @@ func TestSchemaUpdatesAddFieldKindFloatArraySubstitutionWithCreate(t *testing.T)
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/schema/updates/add/field/kind/float_nil_array_test.go
+++ b/tests/integration/schema/updates/add/field/kind/float_nil_array_test.go
@@ -47,7 +47,7 @@ func TestSchemaUpdatesAddFieldKindNillableFloatArray(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaUpdatesAddFieldKindNillableFloatArrayWithCreate(t *testing.T) {
@@ -95,7 +95,7 @@ func TestSchemaUpdatesAddFieldKindNillableFloatArrayWithCreate(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaUpdatesAddFieldKindNillableFloatArraySubstitutionWithCreate(t *testing.T) {
@@ -143,5 +143,5 @@ func TestSchemaUpdatesAddFieldKindNillableFloatArraySubstitutionWithCreate(t *te
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/schema/updates/add/field/kind/float_nil_array_test.go
+++ b/tests/integration/schema/updates/add/field/kind/float_nil_array_test.go
@@ -47,7 +47,7 @@ func TestSchemaUpdatesAddFieldKindNillableFloatArray(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaUpdatesAddFieldKindNillableFloatArrayWithCreate(t *testing.T) {
@@ -95,7 +95,7 @@ func TestSchemaUpdatesAddFieldKindNillableFloatArrayWithCreate(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaUpdatesAddFieldKindNillableFloatArraySubstitutionWithCreate(t *testing.T) {
@@ -143,5 +143,5 @@ func TestSchemaUpdatesAddFieldKindNillableFloatArraySubstitutionWithCreate(t *te
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/schema/updates/add/field/kind/float_test.go
+++ b/tests/integration/schema/updates/add/field/kind/float_test.go
@@ -45,7 +45,7 @@ func TestSchemaUpdatesAddFieldKindFloat(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaUpdatesAddFieldKindFloatWithCreate(t *testing.T) {
@@ -89,7 +89,7 @@ func TestSchemaUpdatesAddFieldKindFloatWithCreate(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaUpdatesAddFieldKindFloatSubstitutionWithCreate(t *testing.T) {
@@ -133,5 +133,5 @@ func TestSchemaUpdatesAddFieldKindFloatSubstitutionWithCreate(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/schema/updates/add/field/kind/float_test.go
+++ b/tests/integration/schema/updates/add/field/kind/float_test.go
@@ -45,7 +45,7 @@ func TestSchemaUpdatesAddFieldKindFloat(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaUpdatesAddFieldKindFloatWithCreate(t *testing.T) {
@@ -89,7 +89,7 @@ func TestSchemaUpdatesAddFieldKindFloatWithCreate(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaUpdatesAddFieldKindFloatSubstitutionWithCreate(t *testing.T) {
@@ -133,5 +133,5 @@ func TestSchemaUpdatesAddFieldKindFloatSubstitutionWithCreate(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/schema/updates/add/field/kind/foreign_object_array_test.go
+++ b/tests/integration/schema/updates/add/field/kind/foreign_object_array_test.go
@@ -37,5 +37,5 @@ func TestSchemaUpdatesAddFieldKindForeignObjectArray(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/schema/updates/add/field/kind/foreign_object_array_test.go
+++ b/tests/integration/schema/updates/add/field/kind/foreign_object_array_test.go
@@ -37,5 +37,5 @@ func TestSchemaUpdatesAddFieldKindForeignObjectArray(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/schema/updates/add/field/kind/foreign_object_test.go
+++ b/tests/integration/schema/updates/add/field/kind/foreign_object_test.go
@@ -37,5 +37,5 @@ func TestSchemaUpdatesAddFieldKindForeignObject(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/schema/updates/add/field/kind/foreign_object_test.go
+++ b/tests/integration/schema/updates/add/field/kind/foreign_object_test.go
@@ -37,5 +37,5 @@ func TestSchemaUpdatesAddFieldKindForeignObject(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/schema/updates/add/field/kind/int_array_test.go
+++ b/tests/integration/schema/updates/add/field/kind/int_array_test.go
@@ -45,7 +45,7 @@ func TestSchemaUpdatesAddFieldKindIntArray(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaUpdatesAddFieldKindIntArrayWithCreate(t *testing.T) {
@@ -89,7 +89,7 @@ func TestSchemaUpdatesAddFieldKindIntArrayWithCreate(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaUpdatesAddFieldKindIntArraySubstitutionWithCreate(t *testing.T) {
@@ -133,5 +133,5 @@ func TestSchemaUpdatesAddFieldKindIntArraySubstitutionWithCreate(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/schema/updates/add/field/kind/int_array_test.go
+++ b/tests/integration/schema/updates/add/field/kind/int_array_test.go
@@ -45,7 +45,7 @@ func TestSchemaUpdatesAddFieldKindIntArray(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaUpdatesAddFieldKindIntArrayWithCreate(t *testing.T) {
@@ -89,7 +89,7 @@ func TestSchemaUpdatesAddFieldKindIntArrayWithCreate(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaUpdatesAddFieldKindIntArraySubstitutionWithCreate(t *testing.T) {
@@ -133,5 +133,5 @@ func TestSchemaUpdatesAddFieldKindIntArraySubstitutionWithCreate(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/schema/updates/add/field/kind/int_nil_array_test.go
+++ b/tests/integration/schema/updates/add/field/kind/int_nil_array_test.go
@@ -47,7 +47,7 @@ func TestSchemaUpdatesAddFieldKindNillableIntArray(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaUpdatesAddFieldKindNillableIntArrayWithCreate(t *testing.T) {
@@ -95,7 +95,7 @@ func TestSchemaUpdatesAddFieldKindNillableIntArrayWithCreate(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaUpdatesAddFieldKindNillableIntArraySubstitutionWithCreate(t *testing.T) {
@@ -143,5 +143,5 @@ func TestSchemaUpdatesAddFieldKindNillableIntArraySubstitutionWithCreate(t *test
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/schema/updates/add/field/kind/int_nil_array_test.go
+++ b/tests/integration/schema/updates/add/field/kind/int_nil_array_test.go
@@ -47,7 +47,7 @@ func TestSchemaUpdatesAddFieldKindNillableIntArray(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaUpdatesAddFieldKindNillableIntArrayWithCreate(t *testing.T) {
@@ -95,7 +95,7 @@ func TestSchemaUpdatesAddFieldKindNillableIntArrayWithCreate(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaUpdatesAddFieldKindNillableIntArraySubstitutionWithCreate(t *testing.T) {
@@ -143,5 +143,5 @@ func TestSchemaUpdatesAddFieldKindNillableIntArraySubstitutionWithCreate(t *test
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/schema/updates/add/field/kind/int_test.go
+++ b/tests/integration/schema/updates/add/field/kind/int_test.go
@@ -45,7 +45,7 @@ func TestSchemaUpdatesAddFieldKindInt(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaUpdatesAddFieldKindIntWithCreate(t *testing.T) {
@@ -89,7 +89,7 @@ func TestSchemaUpdatesAddFieldKindIntWithCreate(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaUpdatesAddFieldKindIntSubstitutionWithCreate(t *testing.T) {
@@ -133,5 +133,5 @@ func TestSchemaUpdatesAddFieldKindIntSubstitutionWithCreate(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/schema/updates/add/field/kind/int_test.go
+++ b/tests/integration/schema/updates/add/field/kind/int_test.go
@@ -45,7 +45,7 @@ func TestSchemaUpdatesAddFieldKindInt(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaUpdatesAddFieldKindIntWithCreate(t *testing.T) {
@@ -89,7 +89,7 @@ func TestSchemaUpdatesAddFieldKindIntWithCreate(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaUpdatesAddFieldKindIntSubstitutionWithCreate(t *testing.T) {
@@ -133,5 +133,5 @@ func TestSchemaUpdatesAddFieldKindIntSubstitutionWithCreate(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/schema/updates/add/field/kind/invalid_test.go
+++ b/tests/integration/schema/updates/add/field/kind/invalid_test.go
@@ -37,7 +37,7 @@ func TestSchemaUpdatesAddFieldKind8(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaUpdatesAddFieldKind9(t *testing.T) {
@@ -61,7 +61,7 @@ func TestSchemaUpdatesAddFieldKind9(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaUpdatesAddFieldKind13(t *testing.T) {
@@ -85,7 +85,7 @@ func TestSchemaUpdatesAddFieldKind13(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaUpdatesAddFieldKind14(t *testing.T) {
@@ -109,7 +109,7 @@ func TestSchemaUpdatesAddFieldKind14(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaUpdatesAddFieldKind15(t *testing.T) {
@@ -133,7 +133,7 @@ func TestSchemaUpdatesAddFieldKind15(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 // This test is currently the first unsupported value, if it becomes supported
@@ -159,7 +159,7 @@ func TestSchemaUpdatesAddFieldKind22(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 // Tests a semi-random but hardcoded unsupported kind to try and protect against anything odd permitting
@@ -185,7 +185,7 @@ func TestSchemaUpdatesAddFieldKind198(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaUpdatesAddFieldKindInvalidSubstitution(t *testing.T) {
@@ -209,5 +209,5 @@ func TestSchemaUpdatesAddFieldKindInvalidSubstitution(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/schema/updates/add/field/kind/invalid_test.go
+++ b/tests/integration/schema/updates/add/field/kind/invalid_test.go
@@ -37,7 +37,7 @@ func TestSchemaUpdatesAddFieldKind8(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaUpdatesAddFieldKind9(t *testing.T) {
@@ -61,7 +61,7 @@ func TestSchemaUpdatesAddFieldKind9(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaUpdatesAddFieldKind13(t *testing.T) {
@@ -85,7 +85,7 @@ func TestSchemaUpdatesAddFieldKind13(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaUpdatesAddFieldKind14(t *testing.T) {
@@ -109,7 +109,7 @@ func TestSchemaUpdatesAddFieldKind14(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaUpdatesAddFieldKind15(t *testing.T) {
@@ -133,7 +133,7 @@ func TestSchemaUpdatesAddFieldKind15(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 // This test is currently the first unsupported value, if it becomes supported
@@ -159,7 +159,7 @@ func TestSchemaUpdatesAddFieldKind22(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 // Tests a semi-random but hardcoded unsupported kind to try and protect against anything odd permitting
@@ -185,7 +185,7 @@ func TestSchemaUpdatesAddFieldKind198(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaUpdatesAddFieldKindInvalidSubstitution(t *testing.T) {
@@ -209,5 +209,5 @@ func TestSchemaUpdatesAddFieldKindInvalidSubstitution(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/schema/updates/add/field/kind/none_test.go
+++ b/tests/integration/schema/updates/add/field/kind/none_test.go
@@ -37,5 +37,5 @@ func TestSchemaUpdatesAddFieldKindNone(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/schema/updates/add/field/kind/none_test.go
+++ b/tests/integration/schema/updates/add/field/kind/none_test.go
@@ -37,5 +37,5 @@ func TestSchemaUpdatesAddFieldKindNone(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/schema/updates/add/field/kind/string_array_test.go
+++ b/tests/integration/schema/updates/add/field/kind/string_array_test.go
@@ -45,7 +45,7 @@ func TestSchemaUpdatesAddFieldKindStringArray(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaUpdatesAddFieldKindStringArrayWithCreate(t *testing.T) {
@@ -89,7 +89,7 @@ func TestSchemaUpdatesAddFieldKindStringArrayWithCreate(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaUpdatesAddFieldKindStringArraySubstitutionWithCreate(t *testing.T) {
@@ -133,5 +133,5 @@ func TestSchemaUpdatesAddFieldKindStringArraySubstitutionWithCreate(t *testing.T
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/schema/updates/add/field/kind/string_array_test.go
+++ b/tests/integration/schema/updates/add/field/kind/string_array_test.go
@@ -45,7 +45,7 @@ func TestSchemaUpdatesAddFieldKindStringArray(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaUpdatesAddFieldKindStringArrayWithCreate(t *testing.T) {
@@ -89,7 +89,7 @@ func TestSchemaUpdatesAddFieldKindStringArrayWithCreate(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaUpdatesAddFieldKindStringArraySubstitutionWithCreate(t *testing.T) {
@@ -133,5 +133,5 @@ func TestSchemaUpdatesAddFieldKindStringArraySubstitutionWithCreate(t *testing.T
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/schema/updates/add/field/kind/string_nil_array_test.go
+++ b/tests/integration/schema/updates/add/field/kind/string_nil_array_test.go
@@ -47,7 +47,7 @@ func TestSchemaUpdatesAddFieldKindNillableStringArray(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaUpdatesAddFieldKindNillableStringArrayWithCreate(t *testing.T) {
@@ -95,7 +95,7 @@ func TestSchemaUpdatesAddFieldKindNillableStringArrayWithCreate(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaUpdatesAddFieldKindNillableStringArraySubstitutionWithCreate(t *testing.T) {
@@ -143,5 +143,5 @@ func TestSchemaUpdatesAddFieldKindNillableStringArraySubstitutionWithCreate(t *t
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/schema/updates/add/field/kind/string_nil_array_test.go
+++ b/tests/integration/schema/updates/add/field/kind/string_nil_array_test.go
@@ -47,7 +47,7 @@ func TestSchemaUpdatesAddFieldKindNillableStringArray(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaUpdatesAddFieldKindNillableStringArrayWithCreate(t *testing.T) {
@@ -95,7 +95,7 @@ func TestSchemaUpdatesAddFieldKindNillableStringArrayWithCreate(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaUpdatesAddFieldKindNillableStringArraySubstitutionWithCreate(t *testing.T) {
@@ -143,5 +143,5 @@ func TestSchemaUpdatesAddFieldKindNillableStringArraySubstitutionWithCreate(t *t
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/schema/updates/add/field/kind/string_test.go
+++ b/tests/integration/schema/updates/add/field/kind/string_test.go
@@ -45,7 +45,7 @@ func TestSchemaUpdatesAddFieldKindString(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaUpdatesAddFieldKindStringWithCreate(t *testing.T) {
@@ -89,7 +89,7 @@ func TestSchemaUpdatesAddFieldKindStringWithCreate(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaUpdatesAddFieldKindStringSubstitutionWithCreate(t *testing.T) {
@@ -133,5 +133,5 @@ func TestSchemaUpdatesAddFieldKindStringSubstitutionWithCreate(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/schema/updates/add/field/kind/string_test.go
+++ b/tests/integration/schema/updates/add/field/kind/string_test.go
@@ -45,7 +45,7 @@ func TestSchemaUpdatesAddFieldKindString(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaUpdatesAddFieldKindStringWithCreate(t *testing.T) {
@@ -89,7 +89,7 @@ func TestSchemaUpdatesAddFieldKindStringWithCreate(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaUpdatesAddFieldKindStringSubstitutionWithCreate(t *testing.T) {
@@ -133,5 +133,5 @@ func TestSchemaUpdatesAddFieldKindStringSubstitutionWithCreate(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/schema/updates/add/field/simple_test.go
+++ b/tests/integration/schema/updates/add/field/simple_test.go
@@ -45,7 +45,7 @@ func TestSchemaUpdatesAddFieldSimple(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaUpdatesAddFieldSimpleErrorsAddingToUnknownCollection(t *testing.T) {
@@ -77,7 +77,7 @@ func TestSchemaUpdatesAddFieldSimpleErrorsAddingToUnknownCollection(t *testing.T
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaUpdatesAddFieldMultipleInPatch(t *testing.T) {
@@ -111,7 +111,7 @@ func TestSchemaUpdatesAddFieldMultipleInPatch(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaUpdatesAddFieldMultiplePatches(t *testing.T) {
@@ -151,7 +151,7 @@ func TestSchemaUpdatesAddFieldMultiplePatches(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaUpdatesAddFieldSimpleWithoutName(t *testing.T) {
@@ -175,7 +175,7 @@ func TestSchemaUpdatesAddFieldSimpleWithoutName(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaUpdatesAddFieldMultipleInPatchPartialSuccess(t *testing.T) {
@@ -220,7 +220,7 @@ func TestSchemaUpdatesAddFieldMultipleInPatchPartialSuccess(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaUpdatesAddFieldSimpleDuplicateOfExistingField(t *testing.T) {
@@ -244,7 +244,7 @@ func TestSchemaUpdatesAddFieldSimpleDuplicateOfExistingField(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaUpdatesAddFieldSimpleDuplicateField(t *testing.T) {
@@ -269,7 +269,7 @@ func TestSchemaUpdatesAddFieldSimpleDuplicateField(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaUpdatesAddFieldWithExplicitIDErrors(t *testing.T) {
@@ -293,5 +293,5 @@ func TestSchemaUpdatesAddFieldWithExplicitIDErrors(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/schema/updates/add/field/simple_test.go
+++ b/tests/integration/schema/updates/add/field/simple_test.go
@@ -45,7 +45,7 @@ func TestSchemaUpdatesAddFieldSimple(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaUpdatesAddFieldSimpleErrorsAddingToUnknownCollection(t *testing.T) {
@@ -77,7 +77,7 @@ func TestSchemaUpdatesAddFieldSimpleErrorsAddingToUnknownCollection(t *testing.T
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaUpdatesAddFieldMultipleInPatch(t *testing.T) {
@@ -111,7 +111,7 @@ func TestSchemaUpdatesAddFieldMultipleInPatch(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaUpdatesAddFieldMultiplePatches(t *testing.T) {
@@ -151,7 +151,7 @@ func TestSchemaUpdatesAddFieldMultiplePatches(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaUpdatesAddFieldSimpleWithoutName(t *testing.T) {
@@ -175,7 +175,7 @@ func TestSchemaUpdatesAddFieldSimpleWithoutName(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaUpdatesAddFieldMultipleInPatchPartialSuccess(t *testing.T) {
@@ -220,7 +220,7 @@ func TestSchemaUpdatesAddFieldMultipleInPatchPartialSuccess(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaUpdatesAddFieldSimpleDuplicateOfExistingField(t *testing.T) {
@@ -244,7 +244,7 @@ func TestSchemaUpdatesAddFieldSimpleDuplicateOfExistingField(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaUpdatesAddFieldSimpleDuplicateField(t *testing.T) {
@@ -269,7 +269,7 @@ func TestSchemaUpdatesAddFieldSimpleDuplicateField(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaUpdatesAddFieldWithExplicitIDErrors(t *testing.T) {
@@ -293,5 +293,5 @@ func TestSchemaUpdatesAddFieldWithExplicitIDErrors(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/schema/updates/add/field/with_filter_test.go
+++ b/tests/integration/schema/updates/add/field/with_filter_test.go
@@ -44,7 +44,7 @@ func TestSchemaUpdatesAddFieldSimpleWithFilter(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaUpdatesAddFieldSimpleWithFilterOnPopulatedDatabase(t *testing.T) {
@@ -88,5 +88,5 @@ func TestSchemaUpdatesAddFieldSimpleWithFilterOnPopulatedDatabase(t *testing.T) 
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/schema/updates/add/field/with_filter_test.go
+++ b/tests/integration/schema/updates/add/field/with_filter_test.go
@@ -44,7 +44,7 @@ func TestSchemaUpdatesAddFieldSimpleWithFilter(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaUpdatesAddFieldSimpleWithFilterOnPopulatedDatabase(t *testing.T) {
@@ -88,5 +88,5 @@ func TestSchemaUpdatesAddFieldSimpleWithFilterOnPopulatedDatabase(t *testing.T) 
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/schema/updates/add/field/with_introspection_test.go
+++ b/tests/integration/schema/updates/add/field/with_introspection_test.go
@@ -65,7 +65,7 @@ func TestSchemaUpdatesAddFieldIntrospection(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaUpdatesAddFieldIntrospectionDoesNotAmendGQLTypesGivenBadPatch(t *testing.T) {
@@ -113,5 +113,5 @@ func TestSchemaUpdatesAddFieldIntrospectionDoesNotAmendGQLTypesGivenBadPatch(t *
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/schema/updates/add/field/with_introspection_test.go
+++ b/tests/integration/schema/updates/add/field/with_introspection_test.go
@@ -65,7 +65,7 @@ func TestSchemaUpdatesAddFieldIntrospection(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaUpdatesAddFieldIntrospectionDoesNotAmendGQLTypesGivenBadPatch(t *testing.T) {
@@ -113,5 +113,5 @@ func TestSchemaUpdatesAddFieldIntrospectionDoesNotAmendGQLTypesGivenBadPatch(t *
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/schema/updates/add/simple_test.go
+++ b/tests/integration/schema/updates/add/simple_test.go
@@ -45,7 +45,7 @@ func TestSchemaUpdatesAddSimpleErrorsAddingSchema(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaUpdatesAddSimpleErrorsAddingCollectionProp(t *testing.T) {
@@ -69,7 +69,7 @@ func TestSchemaUpdatesAddSimpleErrorsAddingCollectionProp(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaUpdatesAddSimpleErrorsAddingSchemaProp(t *testing.T) {
@@ -93,7 +93,7 @@ func TestSchemaUpdatesAddSimpleErrorsAddingSchemaProp(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaUpdatesAddSimpleErrorsAddingUnsupportedCollectionProp(t *testing.T) {
@@ -125,7 +125,7 @@ func TestSchemaUpdatesAddSimpleErrorsAddingUnsupportedCollectionProp(t *testing.
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaUpdatesAddSimpleErrorsAddingUnsupportedSchemaProp(t *testing.T) {
@@ -157,5 +157,5 @@ func TestSchemaUpdatesAddSimpleErrorsAddingUnsupportedSchemaProp(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/schema/updates/add/simple_test.go
+++ b/tests/integration/schema/updates/add/simple_test.go
@@ -45,7 +45,7 @@ func TestSchemaUpdatesAddSimpleErrorsAddingSchema(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaUpdatesAddSimpleErrorsAddingCollectionProp(t *testing.T) {
@@ -69,7 +69,7 @@ func TestSchemaUpdatesAddSimpleErrorsAddingCollectionProp(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaUpdatesAddSimpleErrorsAddingSchemaProp(t *testing.T) {
@@ -93,7 +93,7 @@ func TestSchemaUpdatesAddSimpleErrorsAddingSchemaProp(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaUpdatesAddSimpleErrorsAddingUnsupportedCollectionProp(t *testing.T) {
@@ -125,7 +125,7 @@ func TestSchemaUpdatesAddSimpleErrorsAddingUnsupportedCollectionProp(t *testing.
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaUpdatesAddSimpleErrorsAddingUnsupportedSchemaProp(t *testing.T) {
@@ -157,5 +157,5 @@ func TestSchemaUpdatesAddSimpleErrorsAddingUnsupportedSchemaProp(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/schema/updates/copy/field/simple_test.go
+++ b/tests/integration/schema/updates/copy/field/simple_test.go
@@ -47,7 +47,7 @@ func TestSchemaUpdatesCopyFieldErrors(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaUpdatesCopyFieldWithRemoveIDAndReplaceName(t *testing.T) {
@@ -85,7 +85,7 @@ func TestSchemaUpdatesCopyFieldWithRemoveIDAndReplaceName(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 // This is an odd test, but still a possibility and we should still cover it.
@@ -136,7 +136,7 @@ func TestSchemaUpdatesCopyFieldWithRemoveIDAndReplaceNameAndKindSubstitution(t *
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 // This is an odd test, but still a possibility and we should still cover it.
@@ -166,5 +166,5 @@ func TestSchemaUpdatesCopyFieldWithRemoveIDAndReplaceNameAndInvalidKindSubstitut
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/schema/updates/copy/field/simple_test.go
+++ b/tests/integration/schema/updates/copy/field/simple_test.go
@@ -47,7 +47,7 @@ func TestSchemaUpdatesCopyFieldErrors(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaUpdatesCopyFieldWithRemoveIDAndReplaceName(t *testing.T) {
@@ -85,7 +85,7 @@ func TestSchemaUpdatesCopyFieldWithRemoveIDAndReplaceName(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 // This is an odd test, but still a possibility and we should still cover it.
@@ -136,7 +136,7 @@ func TestSchemaUpdatesCopyFieldWithRemoveIDAndReplaceNameAndKindSubstitution(t *
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 // This is an odd test, but still a possibility and we should still cover it.
@@ -166,5 +166,5 @@ func TestSchemaUpdatesCopyFieldWithRemoveIDAndReplaceNameAndInvalidKindSubstitut
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/schema/updates/copy/field/with_introspection_test.go
+++ b/tests/integration/schema/updates/copy/field/with_introspection_test.go
@@ -77,5 +77,5 @@ func TestSchemaUpdatesCopyFieldIntrospectionWithRemoveIDAndReplaceName(t *testin
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/schema/updates/copy/field/with_introspection_test.go
+++ b/tests/integration/schema/updates/copy/field/with_introspection_test.go
@@ -77,5 +77,5 @@ func TestSchemaUpdatesCopyFieldIntrospectionWithRemoveIDAndReplaceName(t *testin
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/schema/updates/copy/simple_test.go
+++ b/tests/integration/schema/updates/copy/simple_test.go
@@ -45,5 +45,5 @@ func TestSchemaUpdatesCopyCollectionWithRemoveIDAndReplaceName(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/schema/updates/copy/simple_test.go
+++ b/tests/integration/schema/updates/copy/simple_test.go
@@ -45,5 +45,5 @@ func TestSchemaUpdatesCopyCollectionWithRemoveIDAndReplaceName(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/schema/updates/index/simple_test.go
+++ b/tests/integration/schema/updates/index/simple_test.go
@@ -47,7 +47,7 @@ func TestPatching_ForCollectionWithIndex_StillWorks(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestPatching_IfAttemptToAddIndex_ReturnError(t *testing.T) {
@@ -90,7 +90,7 @@ func TestPatching_IfAttemptToAddIndex_ReturnError(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestPatching_IfAttemptToDropIndex_ReturnError(t *testing.T) {
@@ -123,7 +123,7 @@ func TestPatching_IfAttemptToDropIndex_ReturnError(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestPatching_IfAttemptToChangeIndexName_ReturnError(t *testing.T) {
@@ -156,7 +156,7 @@ func TestPatching_IfAttemptToChangeIndexName_ReturnError(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestPatching_IfAttemptToChangeIndexField_ReturnError(t *testing.T) {
@@ -228,6 +228,6 @@ func TestPatching_IfAttemptToChangeIndexField_ReturnError(t *testing.T) {
 				},
 			},
 		}
-		testUtils.ExecuteTEMP(t, test)
+		testUtils.ExecuteTestCase(t, test)
 	}
 }

--- a/tests/integration/schema/updates/index/simple_test.go
+++ b/tests/integration/schema/updates/index/simple_test.go
@@ -47,7 +47,7 @@ func TestPatching_ForCollectionWithIndex_StillWorks(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestPatching_IfAttemptToAddIndex_ReturnError(t *testing.T) {
@@ -90,7 +90,7 @@ func TestPatching_IfAttemptToAddIndex_ReturnError(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestPatching_IfAttemptToDropIndex_ReturnError(t *testing.T) {
@@ -123,7 +123,7 @@ func TestPatching_IfAttemptToDropIndex_ReturnError(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestPatching_IfAttemptToChangeIndexName_ReturnError(t *testing.T) {
@@ -156,7 +156,7 @@ func TestPatching_IfAttemptToChangeIndexName_ReturnError(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestPatching_IfAttemptToChangeIndexField_ReturnError(t *testing.T) {
@@ -228,6 +228,6 @@ func TestPatching_IfAttemptToChangeIndexField_ReturnError(t *testing.T) {
 				},
 			},
 		}
-		testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+		testUtils.ExecuteTEMP(t, test)
 	}
 }

--- a/tests/integration/schema/updates/move/field/simple_test.go
+++ b/tests/integration/schema/updates/move/field/simple_test.go
@@ -38,5 +38,5 @@ func TestSchemaUpdatesMoveFieldErrors(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/schema/updates/move/field/simple_test.go
+++ b/tests/integration/schema/updates/move/field/simple_test.go
@@ -38,5 +38,5 @@ func TestSchemaUpdatesMoveFieldErrors(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/schema/updates/move/simple_test.go
+++ b/tests/integration/schema/updates/move/simple_test.go
@@ -84,5 +84,5 @@ func TestSchemaUpdatesMoveCollectionDoesNothing(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/schema/updates/move/simple_test.go
+++ b/tests/integration/schema/updates/move/simple_test.go
@@ -84,5 +84,5 @@ func TestSchemaUpdatesMoveCollectionDoesNothing(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/schema/updates/remove/fields/simple_test.go
+++ b/tests/integration/schema/updates/remove/fields/simple_test.go
@@ -38,7 +38,7 @@ func TestSchemaUpdatesRemoveFieldErrors(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaUpdatesRemoveAllFieldsErrors(t *testing.T) {
@@ -63,7 +63,7 @@ func TestSchemaUpdatesRemoveAllFieldsErrors(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaUpdatesRemoveFieldNameErrors(t *testing.T) {
@@ -88,7 +88,7 @@ func TestSchemaUpdatesRemoveFieldNameErrors(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaUpdatesRemoveFieldIDErrors(t *testing.T) {
@@ -113,7 +113,7 @@ func TestSchemaUpdatesRemoveFieldIDErrors(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaUpdatesRemoveFieldKindErrors(t *testing.T) {
@@ -138,7 +138,7 @@ func TestSchemaUpdatesRemoveFieldKindErrors(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaUpdatesRemoveFieldTypErrors(t *testing.T) {
@@ -163,7 +163,7 @@ func TestSchemaUpdatesRemoveFieldTypErrors(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaUpdatesRemoveFieldSchemaErrors(t *testing.T) {
@@ -192,7 +192,7 @@ func TestSchemaUpdatesRemoveFieldSchemaErrors(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Author", "Book"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaUpdatesRemoveFieldRelationNameErrors(t *testing.T) {
@@ -221,7 +221,7 @@ func TestSchemaUpdatesRemoveFieldRelationNameErrors(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Author", "Book"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaUpdatesRemoveFieldRelationTypeErrors(t *testing.T) {
@@ -250,5 +250,5 @@ func TestSchemaUpdatesRemoveFieldRelationTypeErrors(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Author", "Book"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/schema/updates/remove/fields/simple_test.go
+++ b/tests/integration/schema/updates/remove/fields/simple_test.go
@@ -38,7 +38,7 @@ func TestSchemaUpdatesRemoveFieldErrors(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaUpdatesRemoveAllFieldsErrors(t *testing.T) {
@@ -63,7 +63,7 @@ func TestSchemaUpdatesRemoveAllFieldsErrors(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaUpdatesRemoveFieldNameErrors(t *testing.T) {
@@ -88,7 +88,7 @@ func TestSchemaUpdatesRemoveFieldNameErrors(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaUpdatesRemoveFieldIDErrors(t *testing.T) {
@@ -113,7 +113,7 @@ func TestSchemaUpdatesRemoveFieldIDErrors(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaUpdatesRemoveFieldKindErrors(t *testing.T) {
@@ -138,7 +138,7 @@ func TestSchemaUpdatesRemoveFieldKindErrors(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaUpdatesRemoveFieldTypErrors(t *testing.T) {
@@ -163,7 +163,7 @@ func TestSchemaUpdatesRemoveFieldTypErrors(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaUpdatesRemoveFieldSchemaErrors(t *testing.T) {
@@ -192,7 +192,7 @@ func TestSchemaUpdatesRemoveFieldSchemaErrors(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaUpdatesRemoveFieldRelationNameErrors(t *testing.T) {
@@ -221,7 +221,7 @@ func TestSchemaUpdatesRemoveFieldRelationNameErrors(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaUpdatesRemoveFieldRelationTypeErrors(t *testing.T) {
@@ -250,5 +250,5 @@ func TestSchemaUpdatesRemoveFieldRelationTypeErrors(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/schema/updates/remove/simple_test.go
+++ b/tests/integration/schema/updates/remove/simple_test.go
@@ -38,7 +38,7 @@ func TestSchemaUpdatesRemoveCollectionNameErrors(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaUpdatesRemoveCollectionIDErrors(t *testing.T) {
@@ -63,7 +63,7 @@ func TestSchemaUpdatesRemoveCollectionIDErrors(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaUpdatesRemoveSchemaIDErrors(t *testing.T) {
@@ -88,7 +88,7 @@ func TestSchemaUpdatesRemoveSchemaIDErrors(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaUpdatesRemoveSchemaVersionIDErrors(t *testing.T) {
@@ -122,7 +122,7 @@ func TestSchemaUpdatesRemoveSchemaVersionIDErrors(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaUpdatesRemoveSchemaNameErrors(t *testing.T) {
@@ -147,5 +147,5 @@ func TestSchemaUpdatesRemoveSchemaNameErrors(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/schema/updates/remove/simple_test.go
+++ b/tests/integration/schema/updates/remove/simple_test.go
@@ -38,7 +38,7 @@ func TestSchemaUpdatesRemoveCollectionNameErrors(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaUpdatesRemoveCollectionIDErrors(t *testing.T) {
@@ -63,7 +63,7 @@ func TestSchemaUpdatesRemoveCollectionIDErrors(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaUpdatesRemoveSchemaIDErrors(t *testing.T) {
@@ -88,7 +88,7 @@ func TestSchemaUpdatesRemoveSchemaIDErrors(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaUpdatesRemoveSchemaVersionIDErrors(t *testing.T) {
@@ -122,7 +122,7 @@ func TestSchemaUpdatesRemoveSchemaVersionIDErrors(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaUpdatesRemoveSchemaNameErrors(t *testing.T) {
@@ -147,5 +147,5 @@ func TestSchemaUpdatesRemoveSchemaNameErrors(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/schema/updates/replace/field/simple_test.go
+++ b/tests/integration/schema/updates/replace/field/simple_test.go
@@ -38,7 +38,7 @@ func TestSchemaUpdatesReplaceFieldErrors(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaUpdatesReplaceFieldWithIDErrors(t *testing.T) {
@@ -63,5 +63,5 @@ func TestSchemaUpdatesReplaceFieldWithIDErrors(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/schema/updates/replace/field/simple_test.go
+++ b/tests/integration/schema/updates/replace/field/simple_test.go
@@ -38,7 +38,7 @@ func TestSchemaUpdatesReplaceFieldErrors(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaUpdatesReplaceFieldWithIDErrors(t *testing.T) {
@@ -63,5 +63,5 @@ func TestSchemaUpdatesReplaceFieldWithIDErrors(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/schema/updates/replace/simple_test.go
+++ b/tests/integration/schema/updates/replace/simple_test.go
@@ -51,7 +51,7 @@ func TestSchemaUpdatesReplaceCollectionErrors(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 /* WIP
@@ -108,6 +108,6 @@ func TestSchemaUpdatesReplaceCollectionNameWithExistingDoesNotChangeVersionID(t 
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 */

--- a/tests/integration/schema/updates/replace/simple_test.go
+++ b/tests/integration/schema/updates/replace/simple_test.go
@@ -51,7 +51,7 @@ func TestSchemaUpdatesReplaceCollectionErrors(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 /* WIP
@@ -108,6 +108,6 @@ func TestSchemaUpdatesReplaceCollectionNameWithExistingDoesNotChangeVersionID(t 
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 */

--- a/tests/integration/schema/updates/test/add_field_test.go
+++ b/tests/integration/schema/updates/test/add_field_test.go
@@ -46,7 +46,7 @@ func TestSchemaUpdatesTestAddField(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaUpdatesTestAddFieldBlockedByTest(t *testing.T) {
@@ -80,5 +80,5 @@ func TestSchemaUpdatesTestAddFieldBlockedByTest(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/schema/updates/test/add_field_test.go
+++ b/tests/integration/schema/updates/test/add_field_test.go
@@ -46,7 +46,7 @@ func TestSchemaUpdatesTestAddField(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaUpdatesTestAddFieldBlockedByTest(t *testing.T) {
@@ -80,5 +80,5 @@ func TestSchemaUpdatesTestAddFieldBlockedByTest(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/schema/updates/test/field/simple_test.go
+++ b/tests/integration/schema/updates/test/field/simple_test.go
@@ -37,7 +37,7 @@ func TestSchemaUpdatesTestFieldNameErrors(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaUpdatesTestFieldNamePasses(t *testing.T) {
@@ -60,7 +60,7 @@ func TestSchemaUpdatesTestFieldNamePasses(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaUpdatesTestFieldErrors(t *testing.T) {
@@ -84,7 +84,7 @@ func TestSchemaUpdatesTestFieldErrors(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaUpdatesTestFieldPasses(t *testing.T) {
@@ -108,5 +108,5 @@ func TestSchemaUpdatesTestFieldPasses(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/schema/updates/test/field/simple_test.go
+++ b/tests/integration/schema/updates/test/field/simple_test.go
@@ -37,7 +37,7 @@ func TestSchemaUpdatesTestFieldNameErrors(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaUpdatesTestFieldNamePasses(t *testing.T) {
@@ -60,7 +60,7 @@ func TestSchemaUpdatesTestFieldNamePasses(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaUpdatesTestFieldErrors(t *testing.T) {
@@ -84,7 +84,7 @@ func TestSchemaUpdatesTestFieldErrors(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaUpdatesTestFieldPasses(t *testing.T) {
@@ -108,5 +108,5 @@ func TestSchemaUpdatesTestFieldPasses(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/schema/updates/test/simple_test.go
+++ b/tests/integration/schema/updates/test/simple_test.go
@@ -37,7 +37,7 @@ func TestSchemaUpdatesTestCollectionNameErrors(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaUpdatesTestCollectionNamePasses(t *testing.T) {
@@ -60,7 +60,7 @@ func TestSchemaUpdatesTestCollectionNamePasses(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 /* WIP
@@ -116,6 +116,6 @@ func TestSchemaUpdatesTestCollectionNameDoesNotChangeVersionID(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 */

--- a/tests/integration/schema/updates/test/simple_test.go
+++ b/tests/integration/schema/updates/test/simple_test.go
@@ -37,7 +37,7 @@ func TestSchemaUpdatesTestCollectionNameErrors(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaUpdatesTestCollectionNamePasses(t *testing.T) {
@@ -60,7 +60,7 @@ func TestSchemaUpdatesTestCollectionNamePasses(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 /* WIP
@@ -116,6 +116,6 @@ func TestSchemaUpdatesTestCollectionNameDoesNotChangeVersionID(t *testing.T) {
 			},
 		},
 	}
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 */

--- a/tests/integration/schema/with_inline_array_test.go
+++ b/tests/integration/schema/with_inline_array_test.go
@@ -43,7 +43,7 @@ func TestSchemaInlineArrayCreatesSchemaGivenSingleType(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }
 
 func TestSchemaInlineArrayCreatesSchemaGivenSecondType(t *testing.T) {
@@ -80,5 +80,5 @@ func TestSchemaInlineArrayCreatesSchemaGivenSecondType(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTestCase(t, []string{"Users", "Books"}, test)
+	testUtils.ExecuteTEMP(t, test)
 }

--- a/tests/integration/schema/with_inline_array_test.go
+++ b/tests/integration/schema/with_inline_array_test.go
@@ -43,7 +43,7 @@ func TestSchemaInlineArrayCreatesSchemaGivenSingleType(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }
 
 func TestSchemaInlineArrayCreatesSchemaGivenSecondType(t *testing.T) {
@@ -80,5 +80,5 @@ func TestSchemaInlineArrayCreatesSchemaGivenSecondType(t *testing.T) {
 		},
 	}
 
-	testUtils.ExecuteTEMP(t, test)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/subscription/utils.go
+++ b/tests/integration/subscription/utils.go
@@ -17,7 +17,7 @@ import (
 )
 
 func execute(t *testing.T, test testUtils.TestCase) {
-	testUtils.ExecuteTEMP(
+	testUtils.ExecuteTestCase(
 		t,
 		testUtils.TestCase{
 			Description: test.Description,

--- a/tests/integration/subscription/utils.go
+++ b/tests/integration/subscription/utils.go
@@ -17,9 +17,8 @@ import (
 )
 
 func execute(t *testing.T, test testUtils.TestCase) {
-	testUtils.ExecuteTestCase(
+	testUtils.ExecuteTEMP(
 		t,
-		[]string{"User"},
 		testUtils.TestCase{
 			Description: test.Description,
 			Actions: append(

--- a/tests/integration/test_case.go
+++ b/tests/integration/test_case.go
@@ -49,6 +49,9 @@ type ConfigureNode func() config.Config
 type Restart struct{}
 
 // SchemaUpdate is an action that will update the database schema.
+//
+// WARNING: getCollectionNames will not work with schemas ending in `type`, e.g. `user_type`
+// and should be updated if such a name is desired.
 type SchemaUpdate struct {
 	// NodeID may hold the ID (index) of a node to apply this update to.
 	//

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -82,9 +82,8 @@ func ExecuteRequestTestCase(
 		)
 	}
 
-	ExecuteTestCase(
+	ExecuteTEMP(
 		t,
-		collectionNames,
 		TestCase{
 			Description: test.Description,
 			Actions:     actions,

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -82,7 +82,7 @@ func ExecuteRequestTestCase(
 		)
 	}
 
-	ExecuteTEMP(
+	ExecuteTestCase(
 		t,
 		TestCase{
 			Description: test.Description,

--- a/tests/integration/utils2.go
+++ b/tests/integration/utils2.go
@@ -267,25 +267,12 @@ func GetDatabase(ctx context.Context, t *testing.T, dbt DatabaseType) (client.DB
 //
 // Will also attempt to detect incompatible changes in the persisted data if
 // configured to do so (the CI will do so, but disabled by default as it is slow).
-func ExecuteTEMP(
+func ExecuteTestCase(
 	t *testing.T,
 	testCase TestCase,
 ) {
 	collectionNames := getCollectionNames(testCase)
 
-	ExecuteTestCase(t, collectionNames, testCase)
-}
-
-// ExecuteTestCase executes the given TestCase against the configured database
-// instances.
-//
-// Will also attempt to detect incompatible changes in the persisted data if
-// configured to do so (the CI will do so, but disabled by default as it is slow).
-func ExecuteTestCase(
-	t *testing.T,
-	collectionNames []string,
-	testCase TestCase,
-) {
 	if DetectDbChanges && DetectDbChangesPreTestChecks(t, collectionNames) {
 		return
 	}

--- a/tests/integration/utils2.go
+++ b/tests/integration/utils2.go
@@ -426,6 +426,8 @@ func executeTestCase(
 // the new node will respect the index originally assigned.  This allows collections to be
 // referenced across multiple nodes by a consistent, predictable index - allowing a single
 // action to target the same collection across multiple nodes.
+//
+// WARNING: This will not work with schemas ending in `type`, e.g. `user_type`
 func getCollectionNames(testCase TestCase) []string {
 	nextIndex := 0
 	collectionIndexByName := map[string]int{}
@@ -438,6 +440,7 @@ func getCollectionNames(testCase TestCase) []string {
 				continue
 			}
 
+			// WARNING: This will not work with schemas ending in `type`, e.g. `user_type`
 			splitByType := strings.Split(action.Schema, "type ")
 			// Skip the first, as that preceeds `type ` if `type ` is present,
 			// else there are no types.


### PR DESCRIPTION
## Relevant issue(s)

Resolves #1717

## Description

Removes collection names param from testUtils.ExecuteTestCase and instead figures stuff out from the test actions.

It has irked me for a while that we had to declare this, and it is only going to keep getting harder and harder to remove it as we add more tests.

I have a preference to use simple string stuff instead of any ast magic for this, as we'd be using the production code under test to test itself, and it is a bit heavy going for now.  If the basic string stuff becomes a hassle we can switch over to ast stuff or similar without too much trouble at a later date.

~~This is opened as a draft PR as I have 375 references to update and I'd prefer to get feedback on this before updating all of them~~

~~`ExecuteTEMP` is temporary, allowing me to keep testing as I update all the refs, instead of doing all 365 before realising I have messed something up.  Once all the refs have been updated `ExecuteTestCase` will lose it's collectionsNames param, and I will find+replace all references to `ExecuteTEMP` back to `ExecuteTestCase` and then delete `ExecuteTEMP` before converting this draft to a full PR.~~

Todo:
- [x] Remove `ExecuteTEMP`