### PR TITLE
feat: Enable downgrading of documents via Lens inverses

### DIFF
--- a/lens/lens.go
+++ b/lens/lens.go
@@ -182,18 +182,14 @@ func (l *lens) Next() (bool, error) {
 
 				historyLocation = historyLocation.next.Value()
 			} else {
-				// The pipe head then becomes the schema version migration to the next version
-				// sourcing from any documents at schemaVersionID, or lower schema versions.
-				// This also ensures each document only passes through each migration once,
-				// in order, and through the same state container (in case migrations use state).
-				pipeHead, err = l.lensRegistry.MigrateDown(junctionPipe, historyLocation.schemaVersionID)
+				// Aquire a lens migration from the registery, using the junctionPipe as its source.
+				// The new pipeHead will then be connected as a source to the next migration-stage on
+				// the next loop.
+				pipeHead, err = l.lensRegistry.MigrateDown(junctionPipe, historyLocation.previous.Value().schemaVersionID)
 				if err != nil {
 					return false, err
 				}
 
-				// Aquire a lens migration from the registery, using the junctionPipe as its source.
-				// The new pipeHead will then be connected as a source to the next migration-stage on
-				// the next loop.
 				historyLocation = historyLocation.previous.Value()
 			}
 		}

--- a/lens/registry.go
+++ b/lens/registry.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/ipfs/go-datastore/query"
 	"github.com/lens-vm/lens/host-go/config"
+	"github.com/lens-vm/lens/host-go/config/model"
 	"github.com/lens-vm/lens/host-go/engine/module"
 	"github.com/lens-vm/lens/host-go/runtimes/wazero"
 	"github.com/sourcenetwork/immutable"
@@ -45,7 +46,8 @@ type lensRegistry struct {
 	modulesByPath map[string]module.Module
 	moduleLock    sync.Mutex
 
-	lensPoolsBySchemaVersionID map[string]*lensPool
+	lensPoolsBySchemaVersionID     map[string]*lensPool
+	reversedPoolsBySchemaVersionID map[string]*lensPool
 
 	// lens configurations by source schema version ID
 	configs map[string]client.LensConfig
@@ -68,11 +70,12 @@ func NewRegistry(lensPoolSize immutable.Option[int]) *lensRegistry {
 	}
 
 	return &lensRegistry{
-		poolSize:                   size,
-		runtime:                    wazero.New(),
-		modulesByPath:              map[string]module.Module{},
-		lensPoolsBySchemaVersionID: map[string]*lensPool{},
-		configs:                    map[string]client.LensConfig{},
+		poolSize:                       size,
+		runtime:                        wazero.New(),
+		modulesByPath:                  map[string]module.Module{},
+		lensPoolsBySchemaVersionID:     map[string]*lensPool{},
+		reversedPoolsBySchemaVersionID: map[string]*lensPool{},
+		configs:                        map[string]client.LensConfig{},
 	}
 }
 
@@ -98,9 +101,53 @@ func (r *lensRegistry) SetMigration(ctx context.Context, txn datastore.Txn, cfg 
 }
 
 func (r *lensRegistry) cacheLens(txn datastore.Txn, cfg client.LensConfig) error {
-	locker, lockerAlreadyExists := r.lensPoolsBySchemaVersionID[cfg.SourceSchemaVersionID]
-	if !lockerAlreadyExists {
-		locker = r.newPool(r.poolSize, cfg)
+	inversedModuleCfgs := make([]model.LensModule, len(cfg.Lenses))
+	for i, moduleCfg := range cfg.Lenses {
+		// Reverse the order of the lenses for the inverse migration.
+		inversedModuleCfgs[len(cfg.Lenses)-i-1] = model.LensModule{
+			Path: moduleCfg.Path,
+			// Reverse the direction of the lens.
+			// This needs to be done on a clone of the original cfg or we may end up mutating
+			// the original.
+			Inverse:   !moduleCfg.Inverse,
+			Arguments: moduleCfg.Arguments,
+		}
+	}
+
+	reversedCfg := client.LensConfig{
+		SourceSchemaVersionID:      cfg.SourceSchemaVersionID,
+		DestinationSchemaVersionID: cfg.DestinationSchemaVersionID,
+		Lens: model.Lens{
+			Lenses: inversedModuleCfgs,
+		},
+	}
+
+	err := r.cachePool(txn, r.lensPoolsBySchemaVersionID, cfg)
+	if err != nil {
+		return err
+	}
+	err = r.cachePool(txn, r.reversedPoolsBySchemaVersionID, reversedCfg)
+	// For now, checking this error is the best way of determining if a migration has an inverse.
+	// Inverses are optional.
+	//nolint:revive
+	if err != nil && !errors.Is(errors.New("Export `inverse` does not exist"), err) {
+		return err
+	}
+
+	// todo - handling txns like this means that the migrations are not available within the current
+	// transaction if used for stuff (e.g. GQL requests) before commit.
+	// https://github.com/sourcenetwork/defradb/issues/1592
+	txn.OnSuccess(func() {
+		r.configs[cfg.SourceSchemaVersionID] = cfg
+	})
+
+	return nil
+}
+
+func (r *lensRegistry) cachePool(txn datastore.Txn, target map[string]*lensPool, cfg client.LensConfig) error {
+	pool, poolAlreadyExists := target[cfg.SourceSchemaVersionID]
+	if !poolAlreadyExists {
+		pool = r.newPool(r.poolSize, cfg)
 	}
 
 	newLensPipes := make([]*lensPipe, r.poolSize)
@@ -116,24 +163,22 @@ func (r *lensRegistry) cacheLens(txn datastore.Txn, cfg client.LensConfig) error
 	// transaction if used for stuff (e.g. GQL requests) before commit.
 	// https://github.com/sourcenetwork/defradb/issues/1592
 	txn.OnSuccess(func() {
-		if !lockerAlreadyExists {
-			r.lensPoolsBySchemaVersionID[cfg.SourceSchemaVersionID] = locker
+		if !poolAlreadyExists {
+			target[cfg.SourceSchemaVersionID] = pool
 		}
 
 	drainLoop:
 		for {
 			select {
-			case <-locker.pipes:
+			case <-pool.pipes:
 			default:
 				break drainLoop
 			}
 		}
 
 		for _, lensPipe := range newLensPipes {
-			locker.returnLens(lensPipe)
+			pool.returnLens(lensPipe)
 		}
-
-		r.configs[cfg.SourceSchemaVersionID] = cfg
 	})
 
 	return nil
@@ -203,7 +248,22 @@ func (r *lensRegistry) MigrateUp(
 	src enumerable.Enumerable[LensDoc],
 	schemaVersionID string,
 ) (enumerable.Enumerable[LensDoc], error) {
-	lensPool, ok := r.lensPoolsBySchemaVersionID[schemaVersionID]
+	return migrate(r.lensPoolsBySchemaVersionID, src, schemaVersionID)
+}
+
+func (r *lensRegistry) MigrateDown(
+	src enumerable.Enumerable[LensDoc],
+	schemaVersionID string,
+) (enumerable.Enumerable[LensDoc], error) {
+	return migrate(r.reversedPoolsBySchemaVersionID, src, schemaVersionID)
+}
+
+func migrate(
+	pools map[string]*lensPool,
+	src enumerable.Enumerable[LensDoc],
+	schemaVersionID string,
+) (enumerable.Enumerable[LensDoc], error) {
+	lensPool, ok := pools[schemaVersionID]
 	if !ok {
 		// If there are no migrations for this schema version, just return the given source.
 		return src, nil
@@ -217,14 +277,6 @@ func (r *lensRegistry) MigrateUp(
 	lens.SetSource(src)
 
 	return lens, nil
-}
-
-func (*lensRegistry) MigrateDown(
-	src enumerable.Enumerable[LensDoc],
-	schemaVersionID string,
-) (enumerable.Enumerable[LensDoc], error) {
-	// todo: https://github.com/sourcenetwork/defradb/issues/1719
-	return src, nil
 }
 
 func (r *lensRegistry) Config() []client.LensConfig {

--- a/tests/integration/schema/migrations/query/with_p2p_test.go
+++ b/tests/integration/schema/migrations/query/with_p2p_test.go
@@ -110,3 +110,176 @@ func TestSchemaMigrationQueryWithP2PReplicatedDocAtOlderSchemaVersion(t *testing
 
 	testUtils.ExecuteTestCase(t, test)
 }
+
+func TestSchemaMigrationQueryWithP2PReplicatedDocAtNewerSchemaVersion(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.RandomNetworkingConfig(),
+			testUtils.RandomNetworkingConfig(),
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users {
+						name: String
+						verified: Boolean
+					}
+				`,
+			},
+			testUtils.SchemaPatch{
+				// Patch node 0 only
+				NodeID: immutable.Some(0),
+				Patch: `
+					[
+						{ "op": "add", "path": "/Users/Schema/Fields/-", "value": {"Name": "email", "Kind": "String"} }
+					]
+				`,
+			},
+			testUtils.ConfigureMigration{
+				// Register the migration on both nodes.
+				LensConfig: client.LensConfig{
+					SourceSchemaVersionID:      "bafkreifmgqtwpvepenteuvj27u4ewix6nb7ypvyz6j555wsk5u2n7hrldm",
+					DestinationSchemaVersionID: "bafkreigfqdqnj5dunwgcsf2a6ht6q6m2yv3ys6byw5ifsmi5lfcpeh5t7e",
+					Lens: model.Lens{
+						Lenses: []model.LensModule{
+							{
+								Path: lenses.SetDefaultModulePath,
+								Arguments: map[string]any{
+									"dst":   "verified",
+									"value": true,
+								},
+							},
+						},
+					},
+				},
+			},
+			testUtils.ConfigureReplicator{
+				SourceNodeID: 0,
+				TargetNodeID: 1,
+			},
+			testUtils.CreateDoc{
+				// Create John on the first (source) node only, and allow the value to sync
+				NodeID: immutable.Some(0),
+				Doc: `{
+					"name": "John",
+					"verified": true
+				}`,
+			},
+			testUtils.WaitForSync{},
+			testUtils.Request{
+				// Node 0 should yield results as they were defined
+				NodeID: immutable.Some(0),
+				Request: `query {
+					Users {
+						name
+						verified
+					}
+				}`,
+				Results: []map[string]any{
+					{
+						"name":     "John",
+						"verified": true,
+					},
+				},
+			},
+			testUtils.Request{
+				// Node 1 should yield results migrated down to the old schema version.
+				NodeID: immutable.Some(1),
+				Request: `query {
+					Users {
+						name
+						verified
+					}
+				}`,
+				Results: []map[string]any{
+					{
+						"name": "John",
+						// John has been migrated down to the older schema version on node 1
+						// clearing the verified field
+						"verified": nil,
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestSchemaMigrationQueryWithP2PReplicatedDocAtMuchNewerSchemaVersionWithSchemaHistoryGap(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.RandomNetworkingConfig(),
+			testUtils.RandomNetworkingConfig(),
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users {
+						name: String
+					}
+				`,
+			},
+			testUtils.SchemaPatch{
+				// Patch node 0 only
+				NodeID: immutable.Some(0),
+				Patch: `
+					[
+						{ "op": "add", "path": "/Users/Schema/Fields/-", "value": {"Name": "verified", "Kind": "Boolean"} }
+					]
+				`,
+			},
+			testUtils.SchemaPatch{
+				// Patch node 0 only
+				NodeID: immutable.Some(0),
+				Patch: `
+					[
+						{ "op": "add", "path": "/Users/Schema/Fields/-", "value": {"Name": "email", "Kind": "String"} }
+					]
+				`,
+			},
+			testUtils.ConfigureMigration{
+				// Register a migration from version 2 to version 3 on both nodes.
+				// There is no migration from version 1 to 2, thus node 1 has no knowledge of schema version 2.
+				LensConfig: client.LensConfig{
+					SourceSchemaVersionID:      "bafkreia56p6i6o3l4jijayiqd5eiijsypjjokbldaxnmqgeav6fe576hcy",
+					DestinationSchemaVersionID: "bafkreiadb2rps7a2zykywfxwfpgkvet5vmzaig4nvzl5sgfqquzr3qrvsq",
+					Lens: model.Lens{
+						Lenses: []model.LensModule{
+							{
+								Path: lenses.SetDefaultModulePath,
+								Arguments: map[string]any{
+									"dst":   "verified",
+									"value": true,
+								},
+							},
+						},
+					},
+				},
+			},
+			testUtils.ConfigureReplicator{
+				SourceNodeID: 0,
+				TargetNodeID: 1,
+			},
+			testUtils.CreateDoc{
+				// Create John on the first (source) node only, and allow the value to sync
+				NodeID: immutable.Some(0),
+				Doc: `{
+					"name": "John"
+				}`,
+			},
+			testUtils.WaitForSync{},
+			testUtils.Request{
+				// Node 1 should also yield the synced doc, even though there was a gap in the schema version history
+				Request: `query {
+					Users {
+						name
+					}
+				}`,
+				Results: []map[string]any{
+					{
+						"name": "John",
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/lenses/rust_wasm32_set_default/src/lib.rs
+++ b/tests/lenses/rust_wasm32_set_default/src/lib.rs
@@ -78,3 +78,33 @@ fn try_transform(ptr: *mut u8) -> Result<Option<Vec<u8>>, Box<dyn Error>> {
     let result_json = serde_json::to_vec(&input.clone())?;
     Ok(Some(result_json))
 }
+
+#[no_mangle]
+pub extern fn inverse(ptr: *mut u8) -> *mut u8 {
+    match try_inverse(ptr) {
+        Ok(o) => match o {
+            Some(result_json) => lens_sdk::to_mem(lens_sdk::JSON_TYPE_ID, &result_json),
+            None => lens_sdk::nil_ptr(),
+        },
+        Err(e) => lens_sdk::to_mem(lens_sdk::ERROR_TYPE_ID, &e.to_string().as_bytes())
+    }
+}
+
+fn try_inverse(ptr: *mut u8) -> Result<Option<Vec<u8>>, Box<dyn Error>> {
+    let mut input = match lens_sdk::try_from_mem::<HashMap<String, serde_json::Value>>(ptr)? {
+        Some(v) => v,
+        // Implementations of `transform` are free to handle nil however they like. In this
+        // implementation we chose to return nil given a nil input.
+        None => return Ok(None),
+    };
+
+    let params = PARAMETERS.read()?
+        .clone()
+        .ok_or(ModuleError::ParametersNotSetError)?
+        .clone();
+
+    input.remove(&params.dst);
+
+    let result_json = serde_json::to_vec(&input.clone())?;
+    Ok(Some(result_json))
+}

--- a/tests/lenses/utils.go
+++ b/tests/lenses/utils.go
@@ -21,6 +21,8 @@ import (
 //   - `dst` is a string and is the name of the property you wish to set
 //   - `value` can be any valid json value and is the value that you wish the `dst` property
 //     of all documents being transformed by this module to have.
+//
+// This module has an inverse, which will clear any value in the `dst` field.
 var SetDefaultModulePath string = getPathRelativeToProjectRoot(
 	"/tests/lenses/rust_wasm32_set_default/target/wasm32-unknown-unknown/debug/rust_wasm32_set_default.wasm",
 )


### PR DESCRIPTION
## Relevant issue(s)

Resolves #1719

## Description

Enables downgrading of documents via Lens inverses.  Inverse migrations are optional.

This PR is based off of https://github.com/sourcenetwork/defradb/pull/1720 - please review only the last 2 commits here.

There are so far fewer tests than I thought there would be, but I am a bit tired atm, and I may add more whilst waiting on review.  Please suggest any where you think there may be gaps.

~~This IMO breaches the code freeze, but it could be very nice to get it in the release if everyone is happy.~~

Discussed in standup, this should not be merged before the release.