### PR TITLE
fix: Improve the way migrations handle transactions

### DIFF
--- a/api/http/handlerfuncs.go
+++ b/api/http/handlerfuncs.go
@@ -298,12 +298,6 @@ func setMigrationHandler(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	txn, err := db.NewTxn(req.Context(), false)
-	if err != nil {
-		handleErr(req.Context(), rw, err, http.StatusInternalServerError)
-		return
-	}
-
 	var cfg client.LensConfig
 	err = json.Unmarshal(cfgStr, &cfg)
 	if err != nil {
@@ -312,12 +306,6 @@ func setMigrationHandler(rw http.ResponseWriter, req *http.Request) {
 	}
 
 	err = db.LensRegistry().SetMigration(req.Context(), cfg)
-	if err != nil {
-		handleErr(req.Context(), rw, err, http.StatusInternalServerError)
-		return
-	}
-
-	err = txn.Commit(req.Context())
 	if err != nil {
 		handleErr(req.Context(), rw, err, http.StatusInternalServerError)
 		return

--- a/api/http/handlerfuncs.go
+++ b/api/http/handlerfuncs.go
@@ -311,7 +311,7 @@ func setMigrationHandler(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	err = db.LensRegistry().SetMigration(req.Context(), txn, cfg)
+	err = db.LensRegistry().SetMigration(req.Context(), cfg)
 	if err != nil {
 		handleErr(req.Context(), rw, err, http.StatusInternalServerError)
 		return
@@ -338,7 +338,7 @@ func getMigrationHandler(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	cfgs := db.LensRegistry().Config()
+	cfgs, err := db.LensRegistry().Config(req.Context())
 	if err != nil {
 		handleErr(req.Context(), rw, err, http.StatusInternalServerError)
 		return

--- a/client/lens.go
+++ b/client/lens.go
@@ -43,6 +43,12 @@ type LensConfig struct {
 // LensRegistry exposes several useful thread-safe migration related functions which may
 // be used to manage migrations.
 type LensRegistry interface {
+	// WithTxn returns a new LensRegistry scoped to the given transaction.
+	//
+	// WARNING: Currently this does not provide snapshot isolation, if other transactions are commited
+	// after this has been created, the results of those commits will be visible within this scope.
+	WithTxn(datastore.Txn) LensRegistry
+
 	// SetMigration sets the migration for the given source-destination schema version IDs. Is equivilent to
 	// calling `Store.SetMigration(ctx, cfg)`.
 	//
@@ -55,29 +61,37 @@ type LensRegistry interface {
 	//
 	// Migrations will only run if there is a complete path from the document schema version to the latest local
 	// schema version.
-	SetMigration(context.Context, datastore.Txn, LensConfig) error
+	SetMigration(context.Context, LensConfig) error
 
 	// ReloadLenses clears any cached migrations, loads their configurations from the database and re-initializes
 	// them.  It is run on database start if the database already existed.
-	ReloadLenses(ctx context.Context, txn datastore.Txn) error
+	ReloadLenses(context.Context) error
 
 	// MigrateUp returns an enumerable that feeds the given source through the Lens migration for the given
 	// schema version id if one is found, if there is no matching migration the given source will be returned.
-	MigrateUp(enumerable.Enumerable[map[string]any], string) (enumerable.Enumerable[map[string]any], error)
+	MigrateUp(
+		context.Context,
+		enumerable.Enumerable[map[string]any],
+		string,
+	) (enumerable.Enumerable[map[string]any], error)
 
 	// MigrateDown returns an enumerable that feeds the given source through the Lens migration for the schema
 	// version that precedes the given schema version id in reverse, if one is found, if there is no matching
 	// migration the given source will be returned.
 	//
 	// This downgrades any documents in the source enumerable if/when enumerated.
-	MigrateDown(enumerable.Enumerable[map[string]any], string) (enumerable.Enumerable[map[string]any], error)
+	MigrateDown(
+		context.Context,
+		enumerable.Enumerable[map[string]any],
+		string,
+	) (enumerable.Enumerable[map[string]any], error)
 
 	// Config returns a slice of the configurations of the currently loaded migrations.
 	//
 	// Modifying the slice does not affect the loaded configurations.
-	Config() []LensConfig
+	Config(context.Context) ([]LensConfig, error)
 
 	// HasMigration returns true if there is a migration registered for the given schema version id, otherwise
 	// will return false.
-	HasMigration(string) bool
+	HasMigration(context.Context, string) (bool, error)
 }

--- a/datastore/concurrent_txn.go
+++ b/datastore/concurrent_txn.go
@@ -31,7 +31,7 @@ type concurrentTxn struct {
 }
 
 // NewConcurrentTxnFrom creates a new Txn from rootstore that supports concurrent API calls
-func NewConcurrentTxnFrom(ctx context.Context, rootstore ds.TxnDatastore, readonly bool) (Txn, error) {
+func NewConcurrentTxnFrom(ctx context.Context, rootstore ds.TxnDatastore, id uint64, readonly bool) (Txn, error) {
 	var rootTxn ds.Txn
 	var err error
 
@@ -54,6 +54,7 @@ func NewConcurrentTxnFrom(ctx context.Context, rootstore ds.TxnDatastore, readon
 	return &txn{
 		rootConcurentTxn,
 		multistore,
+		id,
 		[]func(){},
 		[]func(){},
 	}, nil

--- a/datastore/concurrent_txn.go
+++ b/datastore/concurrent_txn.go
@@ -57,6 +57,7 @@ func NewConcurrentTxnFrom(ctx context.Context, rootstore ds.TxnDatastore, id uin
 		id,
 		[]func(){},
 		[]func(){},
+		[]func(){},
 	}, nil
 }
 

--- a/datastore/concurrent_txt_test.go
+++ b/datastore/concurrent_txt_test.go
@@ -28,7 +28,7 @@ func TestNewConcurrentTxnFrom(t *testing.T) {
 	rootstore, err := badgerds.NewDatastore("", &opts)
 	require.NoError(t, err)
 
-	txn, err := NewConcurrentTxnFrom(ctx, rootstore, false)
+	txn, err := NewConcurrentTxnFrom(ctx, rootstore, 0, false)
 	require.NoError(t, err)
 
 	err = txn.Commit(ctx)
@@ -44,7 +44,7 @@ func TestNewConcurrentTxnFromWithStoreClosed(t *testing.T) {
 	err = rootstore.Close()
 	require.NoError(t, err)
 
-	_, err = NewConcurrentTxnFrom(ctx, rootstore, false)
+	_, err = NewConcurrentTxnFrom(ctx, rootstore, 0, false)
 	require.ErrorIs(t, err, badgerds.ErrClosed)
 }
 
@@ -52,7 +52,7 @@ func TestNewConcurrentTxnFromNonIterable(t *testing.T) {
 	ctx := context.Background()
 	rootstore := memory.NewDatastore(ctx)
 
-	txn, err := NewConcurrentTxnFrom(ctx, rootstore, false)
+	txn, err := NewConcurrentTxnFrom(ctx, rootstore, 0, false)
 	require.NoError(t, err)
 
 	err = txn.Commit(ctx)
@@ -66,7 +66,7 @@ func TestNewConcurrentTxnFromNonIterableWithStoreClosed(t *testing.T) {
 	err := rootstore.Close()
 	require.NoError(t, err)
 
-	_, err = NewConcurrentTxnFrom(ctx, rootstore, false)
+	_, err = NewConcurrentTxnFrom(ctx, rootstore, 0, false)
 	require.ErrorIs(t, err, badgerds.ErrClosed)
 }
 

--- a/datastore/mocks/txn.go
+++ b/datastore/mocks/txn.go
@@ -267,6 +267,39 @@ func (_c *Txn_ID_Call) RunAndReturn(run func() uint64) *Txn_ID_Call {
 	return _c
 }
 
+// OnDiscard provides a mock function with given fields: fn
+func (_m *Txn) OnDiscard(fn func()) {
+	_m.Called(fn)
+}
+
+// Txn_OnDiscard_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'OnDiscard'
+type Txn_OnDiscard_Call struct {
+	*mock.Call
+}
+
+// OnDiscard is a helper method to define mock.On call
+//   - fn func()
+func (_e *Txn_Expecter) OnDiscard(fn interface{}) *Txn_OnDiscard_Call {
+	return &Txn_OnDiscard_Call{Call: _e.mock.On("OnDiscard", fn)}
+}
+
+func (_c *Txn_OnDiscard_Call) Run(run func(fn func())) *Txn_OnDiscard_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(func()))
+	})
+	return _c
+}
+
+func (_c *Txn_OnDiscard_Call) Return() *Txn_OnDiscard_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *Txn_OnDiscard_Call) RunAndReturn(run func(func())) *Txn_OnDiscard_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // OnError provides a mock function with given fields: fn
 func (_m *Txn) OnError(fn func()) {
 	_m.Called(fn)

--- a/datastore/mocks/txn.go
+++ b/datastore/mocks/txn.go
@@ -226,6 +226,47 @@ func (_c *Txn_Headstore_Call) RunAndReturn(run func() datastore.DSReaderWriter) 
 	return _c
 }
 
+// ID provides a mock function with given fields:
+func (_m *Txn) ID() uint64 {
+	ret := _m.Called()
+
+	var r0 uint64
+	if rf, ok := ret.Get(0).(func() uint64); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(uint64)
+	}
+
+	return r0
+}
+
+// Txn_ID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ID'
+type Txn_ID_Call struct {
+	*mock.Call
+}
+
+// ID is a helper method to define mock.On call
+func (_e *Txn_Expecter) ID() *Txn_ID_Call {
+	return &Txn_ID_Call{Call: _e.mock.On("ID")}
+}
+
+func (_c *Txn_ID_Call) Run(run func()) *Txn_ID_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *Txn_ID_Call) Return(_a0 uint64) *Txn_ID_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Txn_ID_Call) RunAndReturn(run func() uint64) *Txn_ID_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // OnError provides a mock function with given fields: fn
 func (_m *Txn) OnError(fn func()) {
 	_m.Called(fn)

--- a/datastore/txn_test.go
+++ b/datastore/txn_test.go
@@ -27,7 +27,7 @@ func TestNewTxnFrom(t *testing.T) {
 	rootstore, err := badgerds.NewDatastore("", &opts)
 	require.NoError(t, err)
 
-	txn, err := NewTxnFrom(ctx, rootstore, false)
+	txn, err := NewTxnFrom(ctx, rootstore, 0, false)
 	require.NoError(t, err)
 
 	err = txn.Commit(ctx)
@@ -43,7 +43,7 @@ func TestNewTxnFromWithStoreClosed(t *testing.T) {
 	err = rootstore.Close()
 	require.NoError(t, err)
 
-	_, err = NewTxnFrom(ctx, rootstore, false)
+	_, err = NewTxnFrom(ctx, rootstore, 0, false)
 	require.ErrorIs(t, err, badgerds.ErrClosed)
 }
 
@@ -53,7 +53,7 @@ func TestOnSuccess(t *testing.T) {
 	rootstore, err := badgerds.NewDatastore("", &opts)
 	require.NoError(t, err)
 
-	txn, err := NewTxnFrom(ctx, rootstore, false)
+	txn, err := NewTxnFrom(ctx, rootstore, 0, false)
 	require.NoError(t, err)
 
 	txn.OnSuccess(nil)
@@ -74,7 +74,7 @@ func TestOnError(t *testing.T) {
 	rootstore, err := badgerds.NewDatastore("", &opts)
 	require.NoError(t, err)
 
-	txn, err := NewTxnFrom(ctx, rootstore, false)
+	txn, err := NewTxnFrom(ctx, rootstore, 0, false)
 	require.NoError(t, err)
 
 	txn.OnError(nil)

--- a/db/db.go
+++ b/db/db.go
@@ -17,6 +17,7 @@ package db
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 
 	blockstore "github.com/ipfs/boxo/blockstore"
 	ds "github.com/ipfs/go-datastore"
@@ -50,6 +51,13 @@ const (
 // DB is the main interface for interacting with the
 // DefraDB storage system.
 type db struct {
+	// The ID of the last transaction created.
+	//
+	// Warning: we currently rely on this prop being 64-bit aligned in memory
+	// relative to the start of the `db` struct (for atomic.Add calls).  The
+	// easiest way to ensure this alignment is to declare it at the top.
+	previousTxnID uint64
+
 	glock sync.RWMutex
 
 	rootstore  datastore.RootStore
@@ -150,12 +158,15 @@ func newDB(ctx context.Context, rootstore datastore.RootStore, options ...Option
 
 // NewTxn creates a new transaction.
 func (db *db) NewTxn(ctx context.Context, readonly bool) (datastore.Txn, error) {
-	return datastore.NewTxnFrom(ctx, db.rootstore, readonly)
+	txnId := atomic.AddUint64(&db.previousTxnID, 1)
+
+	return datastore.NewTxnFrom(ctx, db.rootstore, txnId, readonly)
 }
 
 // NewConcurrentTxn creates a new transaction that supports concurrent API calls.
 func (db *db) NewConcurrentTxn(ctx context.Context, readonly bool) (datastore.Txn, error) {
-	return datastore.NewConcurrentTxnFrom(ctx, db.rootstore, readonly)
+	txnId := atomic.AddUint64(&db.previousTxnID, 1)
+	return datastore.NewConcurrentTxnFrom(ctx, db.rootstore, txnId, readonly)
 }
 
 // WithTxn returns a new [client.Store] that respects the given transaction.

--- a/db/db.go
+++ b/db/db.go
@@ -155,7 +155,6 @@ func newDB(ctx context.Context, rootstore datastore.RootStore, options ...Option
 // NewTxn creates a new transaction.
 func (db *db) NewTxn(ctx context.Context, readonly bool) (datastore.Txn, error) {
 	txnId := db.previousTxnID.Add(1)
-
 	return datastore.NewTxnFrom(ctx, db.rootstore, txnId, readonly)
 }
 

--- a/db/fetcher/versioned.go
+++ b/db/fetcher/versioned.go
@@ -121,6 +121,8 @@ func (vf *VersionedFetcher) Init(
 	vf.store, err = datastore.NewTxnFrom(
 		ctx,
 		vf.root,
+		// We can take the parent txn id here
+		txn.ID(),
 		false,
 	) // were going to discard and nuke this later
 	if err != nil {

--- a/db/txn_db.go
+++ b/db/txn_db.go
@@ -28,7 +28,8 @@ type implicitTxnDB struct {
 
 type explicitTxnDB struct {
 	*db
-	txn datastore.Txn
+	txn          datastore.Txn
+	lensRegistry client.LensRegistry
 }
 
 // ExecRequest executes a request against the database.
@@ -286,7 +287,7 @@ func (db *implicitTxnDB) SetMigration(ctx context.Context, cfg client.LensConfig
 	}
 	defer txn.Discard(ctx)
 
-	err = db.lensRegistry.SetMigration(ctx, txn, cfg)
+	err = db.lensRegistry.SetMigration(ctx, cfg)
 	if err != nil {
 		return err
 	}
@@ -295,7 +296,7 @@ func (db *implicitTxnDB) SetMigration(ctx context.Context, cfg client.LensConfig
 }
 
 func (db *explicitTxnDB) SetMigration(ctx context.Context, cfg client.LensConfig) error {
-	return db.lensRegistry.SetMigration(ctx, db.txn, cfg)
+	return db.lensRegistry.SetMigration(ctx, cfg)
 }
 
 // SetReplicator adds a new replicator to the database.
@@ -416,4 +417,11 @@ func (db *implicitTxnDB) BasicExport(ctx context.Context, config *client.BackupC
 // BasicExport exports the current data or subset of data to file in json format.
 func (db *explicitTxnDB) BasicExport(ctx context.Context, config *client.BackupConfig) error {
 	return db.basicExport(ctx, db.txn, config)
+}
+
+// LensRegistry returns the LensRegistry in use by this database instance.
+//
+// It exposes several useful thread-safe migration related functions.
+func (db *explicitTxnDB) LensRegistry() client.LensRegistry {
+	return db.lensRegistry
 }

--- a/lens/registry.go
+++ b/lens/registry.go
@@ -48,12 +48,43 @@ type lensRegistry struct {
 
 	lensPoolsBySchemaVersionID     map[string]*lensPool
 	reversedPoolsBySchemaVersionID map[string]*lensPool
+	poolLock                       sync.RWMutex
 
 	// lens configurations by source schema version ID
-	configs map[string]client.LensConfig
+	configs    map[string]client.LensConfig
+	configLock sync.RWMutex
+
+	// Writable transaction contexts by transaction ID.
+	//
+	// Read-only transaction contexts are not tracked.
+	txnCtxs map[uint64]*txnContext
+	txnLock sync.RWMutex
 }
 
-var _ client.LensRegistry = (*lensRegistry)(nil)
+// txnContext contains uncommitted transaction state tracked by the registry,
+// stuff within here should be accessible from within this transaction but not
+// from outside.
+type txnContext struct {
+	txn                            datastore.Txn
+	lensPoolsBySchemaVersionID     map[string]*lensPool
+	reversedPoolsBySchemaVersionID map[string]*lensPool
+	configs                        map[string]client.LensConfig
+}
+
+func newTxnCtx(txn datastore.Txn) *txnContext {
+	return &txnContext{
+		txn:                            txn,
+		lensPoolsBySchemaVersionID:     map[string]*lensPool{},
+		reversedPoolsBySchemaVersionID: map[string]*lensPool{},
+		configs:                        map[string]client.LensConfig{},
+	}
+}
+
+// TxnSource represents an object capable of constructing the transactions that
+// implicit-transaction registries need internally.
+type TxnSource interface {
+	NewTxn(context.Context, bool) (datastore.Txn, error)
+}
 
 // DefaultPoolSize is the default size of the lens pool for each schema version.
 const DefaultPoolSize int = 5
@@ -61,7 +92,7 @@ const DefaultPoolSize int = 5
 // NewRegistry instantiates a new registery.
 //
 // It will be of size 5 (per schema version) if a size is not provided.
-func NewRegistry(lensPoolSize immutable.Option[int]) *lensRegistry {
+func NewRegistry(lensPoolSize immutable.Option[int], db TxnSource) client.LensRegistry {
 	var size int
 	if lensPoolSize.HasValue() {
 		size = lensPoolSize.Value()
@@ -69,17 +100,76 @@ func NewRegistry(lensPoolSize immutable.Option[int]) *lensRegistry {
 		size = DefaultPoolSize
 	}
 
-	return &lensRegistry{
-		poolSize:                       size,
-		runtime:                        wazero.New(),
-		modulesByPath:                  map[string]module.Module{},
-		lensPoolsBySchemaVersionID:     map[string]*lensPool{},
-		reversedPoolsBySchemaVersionID: map[string]*lensPool{},
-		configs:                        map[string]client.LensConfig{},
+	return &implicitTxnLensRegistry{
+		db: db,
+		registry: &lensRegistry{
+			poolSize:                       size,
+			runtime:                        wazero.New(),
+			modulesByPath:                  map[string]module.Module{},
+			lensPoolsBySchemaVersionID:     map[string]*lensPool{},
+			reversedPoolsBySchemaVersionID: map[string]*lensPool{},
+			configs:                        map[string]client.LensConfig{},
+			txnCtxs:                        map[uint64]*txnContext{},
+		},
 	}
 }
 
-func (r *lensRegistry) SetMigration(ctx context.Context, txn datastore.Txn, cfg client.LensConfig) error {
+func (r *lensRegistry) getCtx(txn datastore.Txn, readonly bool) *txnContext {
+	r.txnLock.RLock()
+	if txnCtx, ok := r.txnCtxs[txn.ID()]; ok {
+		r.txnLock.RUnlock()
+		return txnCtx
+	}
+	r.txnLock.RUnlock()
+
+	txnCtx := newTxnCtx(txn)
+	if readonly {
+		return txnCtx
+	}
+
+	r.txnLock.Lock()
+	r.txnCtxs[txn.ID()] = txnCtx
+	r.txnLock.Unlock()
+
+	txnCtx.txn.OnSuccess(func() {
+		r.poolLock.Lock()
+		for schemaVersionID, locker := range txnCtx.lensPoolsBySchemaVersionID {
+			r.lensPoolsBySchemaVersionID[schemaVersionID] = locker
+		}
+		for schemaVersionID, locker := range txnCtx.reversedPoolsBySchemaVersionID {
+			r.reversedPoolsBySchemaVersionID[schemaVersionID] = locker
+		}
+		r.poolLock.Unlock()
+
+		r.configLock.Lock()
+		for schemaVersionID, cfg := range txnCtx.configs {
+			r.configs[schemaVersionID] = cfg
+		}
+		r.configLock.Unlock()
+
+		r.txnLock.Lock()
+		delete(r.txnCtxs, txn.ID())
+		r.txnLock.Unlock()
+	})
+
+	txn.OnError(func() {
+		r.txnLock.Lock()
+		delete(r.txnCtxs, txn.ID())
+		r.txnLock.Unlock()
+	})
+
+	txn.OnDiscard(func() {
+		// Delete it to help reduce the build up of memory, the txnCtx will be re-contructed if the
+		// txn is reused after discard.
+		r.txnLock.Lock()
+		delete(r.txnCtxs, txn.ID())
+		r.txnLock.Unlock()
+	})
+
+	return txnCtx
+}
+
+func (r *lensRegistry) setMigration(ctx context.Context, txnCtx *txnContext, cfg client.LensConfig) error {
 	key := core.NewSchemaVersionMigrationKey(cfg.SourceSchemaVersionID)
 
 	json, err := json.Marshal(cfg)
@@ -87,12 +177,12 @@ func (r *lensRegistry) SetMigration(ctx context.Context, txn datastore.Txn, cfg 
 		return err
 	}
 
-	err = txn.Systemstore().Put(ctx, key.ToDS(), json)
+	err = txnCtx.txn.Systemstore().Put(ctx, key.ToDS(), json)
 	if err != nil {
 		return err
 	}
 
-	err = r.cacheLens(txn, cfg)
+	err = r.cacheLens(txnCtx, cfg)
 	if err != nil {
 		return err
 	}
@@ -100,7 +190,7 @@ func (r *lensRegistry) SetMigration(ctx context.Context, txn datastore.Txn, cfg 
 	return nil
 }
 
-func (r *lensRegistry) cacheLens(txn datastore.Txn, cfg client.LensConfig) error {
+func (r *lensRegistry) cacheLens(txnCtx *txnContext, cfg client.LensConfig) error {
 	inversedModuleCfgs := make([]model.LensModule, len(cfg.Lenses))
 	for i, moduleCfg := range cfg.Lenses {
 		// Reverse the order of the lenses for the inverse migration.
@@ -122,11 +212,11 @@ func (r *lensRegistry) cacheLens(txn datastore.Txn, cfg client.LensConfig) error
 		},
 	}
 
-	err := r.cachePool(txn, r.lensPoolsBySchemaVersionID, cfg)
+	err := r.cachePool(txnCtx.txn, txnCtx.lensPoolsBySchemaVersionID, cfg)
 	if err != nil {
 		return err
 	}
-	err = r.cachePool(txn, r.reversedPoolsBySchemaVersionID, reversedCfg)
+	err = r.cachePool(txnCtx.txn, txnCtx.reversedPoolsBySchemaVersionID, reversedCfg)
 	// For now, checking this error is the best way of determining if a migration has an inverse.
 	// Inverses are optional.
 	//nolint:revive
@@ -134,59 +224,30 @@ func (r *lensRegistry) cacheLens(txn datastore.Txn, cfg client.LensConfig) error
 		return err
 	}
 
-	// todo - handling txns like this means that the migrations are not available within the current
-	// transaction if used for stuff (e.g. GQL requests) before commit.
-	// https://github.com/sourcenetwork/defradb/issues/1592
-	txn.OnSuccess(func() {
-		r.configs[cfg.SourceSchemaVersionID] = cfg
-	})
+	txnCtx.configs[cfg.SourceSchemaVersionID] = cfg
 
 	return nil
 }
 
 func (r *lensRegistry) cachePool(txn datastore.Txn, target map[string]*lensPool, cfg client.LensConfig) error {
-	pool, poolAlreadyExists := target[cfg.SourceSchemaVersionID]
-	if !poolAlreadyExists {
-		pool = r.newPool(r.poolSize, cfg)
-	}
+	pool := r.newPool(r.poolSize, cfg)
 
-	newLensPipes := make([]*lensPipe, r.poolSize)
 	for i := 0; i < r.poolSize; i++ {
-		var err error
-		newLensPipes[i], err = r.newLensPipe(cfg)
+		lensPipe, err := r.newLensPipe(cfg)
 		if err != nil {
 			return err
 		}
+		pool.returnLens(lensPipe)
 	}
 
-	// todo - handling txns like this means that the migrations are not available within the current
-	// transaction if used for stuff (e.g. GQL requests) before commit.
-	// https://github.com/sourcenetwork/defradb/issues/1592
-	txn.OnSuccess(func() {
-		if !poolAlreadyExists {
-			target[cfg.SourceSchemaVersionID] = pool
-		}
-
-	drainLoop:
-		for {
-			select {
-			case <-pool.pipes:
-			default:
-				break drainLoop
-			}
-		}
-
-		for _, lensPipe := range newLensPipes {
-			pool.returnLens(lensPipe)
-		}
-	})
+	target[cfg.SourceSchemaVersionID] = pool
 
 	return nil
 }
 
-func (r *lensRegistry) ReloadLenses(ctx context.Context, txn datastore.Txn) error {
+func (r *lensRegistry) reloadLenses(ctx context.Context, txnCtx *txnContext) error {
 	prefix := core.NewSchemaVersionMigrationKey("")
-	q, err := txn.Systemstore().Query(ctx, query.Query{
+	q, err := txnCtx.txn.Systemstore().Query(ctx, query.Query{
 		Prefix: prefix.ToString(),
 	})
 	if err != nil {
@@ -226,7 +287,7 @@ func (r *lensRegistry) ReloadLenses(ctx context.Context, txn datastore.Txn) erro
 			return err
 		}
 
-		err = r.cacheLens(txn, cfg)
+		err = r.cacheLens(txnCtx, cfg)
 		if err != nil {
 			err = q.Close()
 			if err != nil {
@@ -244,26 +305,29 @@ func (r *lensRegistry) ReloadLenses(ctx context.Context, txn datastore.Txn) erro
 	return nil
 }
 
-func (r *lensRegistry) MigrateUp(
+func (r *lensRegistry) migrateUp(
+	txnCtx *txnContext,
 	src enumerable.Enumerable[LensDoc],
 	schemaVersionID string,
 ) (enumerable.Enumerable[LensDoc], error) {
-	return migrate(r.lensPoolsBySchemaVersionID, src, schemaVersionID)
+	return r.migrate(r.lensPoolsBySchemaVersionID, txnCtx.lensPoolsBySchemaVersionID, src, schemaVersionID)
 }
 
-func (r *lensRegistry) MigrateDown(
+func (r *lensRegistry) migrateDown(
+	txnCtx *txnContext,
 	src enumerable.Enumerable[LensDoc],
 	schemaVersionID string,
 ) (enumerable.Enumerable[LensDoc], error) {
-	return migrate(r.reversedPoolsBySchemaVersionID, src, schemaVersionID)
+	return r.migrate(r.reversedPoolsBySchemaVersionID, txnCtx.reversedPoolsBySchemaVersionID, src, schemaVersionID)
 }
 
-func migrate(
+func (r *lensRegistry) migrate(
 	pools map[string]*lensPool,
+	txnPools map[string]*lensPool,
 	src enumerable.Enumerable[LensDoc],
 	schemaVersionID string,
 ) (enumerable.Enumerable[LensDoc], error) {
-	lensPool, ok := pools[schemaVersionID]
+	lensPool, ok := r.getPool(pools, txnPools, schemaVersionID)
 	if !ok {
 		// If there are no migrations for this schema version, just return the given source.
 		return src, nil
@@ -279,17 +343,46 @@ func migrate(
 	return lens, nil
 }
 
-func (r *lensRegistry) Config() []client.LensConfig {
+func (r *lensRegistry) config(txnCtx *txnContext) []client.LensConfig {
+	configs := map[string]client.LensConfig{}
+	r.configLock.RLock()
+	for schemaVersionID, cfg := range r.configs {
+		configs[schemaVersionID] = cfg
+	}
+	r.configLock.RUnlock()
+
+	// If within a txn actively writing to this registry overwrite
+	// values from the (commited) registry.
+	// Note: Config cannot be removed, only replaced at the moment.
+	for schemaVersionID, cfg := range txnCtx.configs {
+		configs[schemaVersionID] = cfg
+	}
+
 	result := []client.LensConfig{}
-	for _, cfg := range r.configs {
+	for _, cfg := range configs {
 		result = append(result, cfg)
 	}
 	return result
 }
 
-func (r *lensRegistry) HasMigration(schemaVersionID string) bool {
-	_, hasMigration := r.lensPoolsBySchemaVersionID[schemaVersionID]
+func (r *lensRegistry) hasMigration(txnCtx *txnContext, schemaVersionID string) bool {
+	_, hasMigration := r.getPool(r.lensPoolsBySchemaVersionID, txnCtx.lensPoolsBySchemaVersionID, schemaVersionID)
 	return hasMigration
+}
+
+func (r *lensRegistry) getPool(
+	pools map[string]*lensPool,
+	txnPools map[string]*lensPool,
+	schemaVersionID string,
+) (*lensPool, bool) {
+	if pool, ok := txnPools[schemaVersionID]; ok {
+		return pool, true
+	}
+
+	r.poolLock.RLock()
+	pool, ok := pools[schemaVersionID]
+	r.poolLock.RUnlock()
+	return pool, ok
 }
 
 // lensPool provides a pool-like mechanic for caching a limited number of wasm lens modules in

--- a/lens/txn_registry.go
+++ b/lens/txn_registry.go
@@ -1,0 +1,163 @@
+// Copyright 2023 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package lens
+
+import (
+	"context"
+
+	"github.com/sourcenetwork/immutable/enumerable"
+
+	"github.com/sourcenetwork/defradb/client"
+	"github.com/sourcenetwork/defradb/datastore"
+)
+
+type implicitTxnLensRegistry struct {
+	registry *lensRegistry
+	db       TxnSource
+}
+
+type explicitTxnLensRegistry struct {
+	registry *lensRegistry
+	txn      datastore.Txn
+}
+
+var _ client.LensRegistry = (*implicitTxnLensRegistry)(nil)
+var _ client.LensRegistry = (*explicitTxnLensRegistry)(nil)
+
+func (r *implicitTxnLensRegistry) WithTxn(txn datastore.Txn) client.LensRegistry {
+	return &explicitTxnLensRegistry{
+		registry: r.registry,
+		txn:      txn,
+	}
+}
+
+func (r *explicitTxnLensRegistry) WithTxn(txn datastore.Txn) client.LensRegistry {
+	return &explicitTxnLensRegistry{
+		registry: r.registry,
+		txn:      txn,
+	}
+}
+
+func (r *implicitTxnLensRegistry) SetMigration(ctx context.Context, cfg client.LensConfig) error {
+	txn, err := r.db.NewTxn(ctx, false)
+	if err != nil {
+		return err
+	}
+	defer txn.Discard(ctx)
+	txnCtx := r.registry.getCtx(txn, false)
+
+	err = r.registry.setMigration(ctx, txnCtx, cfg)
+	if err != nil {
+		return err
+	}
+
+	return txn.Commit(ctx)
+}
+
+func (r *explicitTxnLensRegistry) SetMigration(ctx context.Context, cfg client.LensConfig) error {
+	return r.registry.setMigration(ctx, r.registry.getCtx(r.txn, false), cfg)
+}
+
+func (r *implicitTxnLensRegistry) ReloadLenses(ctx context.Context) error {
+	txn, err := r.db.NewTxn(ctx, true)
+	if err != nil {
+		return err
+	}
+	defer txn.Discard(ctx)
+	txnCtx := r.registry.getCtx(txn, false)
+
+	err = r.registry.reloadLenses(ctx, txnCtx)
+	if err != nil {
+		return err
+	}
+
+	return txn.Commit(ctx)
+}
+
+func (r *explicitTxnLensRegistry) ReloadLenses(ctx context.Context) error {
+	return r.registry.reloadLenses(ctx, r.registry.getCtx(r.txn, true))
+}
+
+func (r *implicitTxnLensRegistry) MigrateUp(
+	ctx context.Context,
+	src enumerable.Enumerable[LensDoc],
+	schemaVersionID string,
+) (enumerable.Enumerable[map[string]any], error) {
+	txn, err := r.db.NewTxn(ctx, true)
+	if err != nil {
+		return nil, err
+	}
+	defer txn.Discard(ctx)
+	txnCtx := newTxnCtx(txn)
+
+	return r.registry.migrateUp(txnCtx, src, schemaVersionID)
+}
+
+func (r *explicitTxnLensRegistry) MigrateUp(
+	ctx context.Context,
+	src enumerable.Enumerable[LensDoc],
+	schemaVersionID string,
+) (enumerable.Enumerable[map[string]any], error) {
+	return r.registry.migrateUp(r.registry.getCtx(r.txn, true), src, schemaVersionID)
+}
+
+func (r *implicitTxnLensRegistry) MigrateDown(
+	ctx context.Context,
+	src enumerable.Enumerable[LensDoc],
+	schemaVersionID string,
+) (enumerable.Enumerable[map[string]any], error) {
+	txn, err := r.db.NewTxn(ctx, true)
+	if err != nil {
+		return nil, err
+	}
+	defer txn.Discard(ctx)
+	txnCtx := newTxnCtx(txn)
+
+	return r.registry.migrateDown(txnCtx, src, schemaVersionID)
+}
+
+func (r *explicitTxnLensRegistry) MigrateDown(
+	ctx context.Context,
+	src enumerable.Enumerable[LensDoc],
+	schemaVersionID string,
+) (enumerable.Enumerable[map[string]any], error) {
+	return r.registry.migrateDown(r.registry.getCtx(r.txn, true), src, schemaVersionID)
+}
+
+func (r *implicitTxnLensRegistry) Config(ctx context.Context) ([]client.LensConfig, error) {
+	txn, err := r.db.NewTxn(ctx, true)
+	if err != nil {
+		return nil, err
+	}
+	defer txn.Discard(ctx)
+	txnCtx := newTxnCtx(txn)
+
+	return r.registry.config(txnCtx), nil
+}
+
+func (r *explicitTxnLensRegistry) Config(ctx context.Context) ([]client.LensConfig, error) {
+	return r.registry.config(r.registry.getCtx(r.txn, true)), nil
+}
+
+func (r *implicitTxnLensRegistry) HasMigration(ctx context.Context, schemaVersionID string) (bool, error) {
+	txn, err := r.db.NewTxn(ctx, true)
+	if err != nil {
+		return false, err
+	}
+	defer txn.Discard(ctx)
+	txnCtx := newTxnCtx(txn)
+
+	return r.registry.hasMigration(txnCtx, schemaVersionID), nil
+}
+
+func (r *explicitTxnLensRegistry) HasMigration(ctx context.Context, schemaVersionID string) (bool, error) {
+	return r.registry.hasMigration(r.registry.getCtx(r.txn, true), schemaVersionID), nil
+}

--- a/tests/bench/query/planner/utils.go
+++ b/tests/bench/query/planner/utils.go
@@ -133,3 +133,4 @@ func (*dummyTxn) Commit(ctx context.Context) error      { return nil }
 func (*dummyTxn) Discard(ctx context.Context)           {}
 func (*dummyTxn) OnSuccess(fn func())                   {}
 func (*dummyTxn) OnError(fn func())                     {}
+func (*dummyTxn) ID() uint64                            { return 0 }

--- a/tests/bench/query/planner/utils.go
+++ b/tests/bench/query/planner/utils.go
@@ -133,4 +133,5 @@ func (*dummyTxn) Commit(ctx context.Context) error      { return nil }
 func (*dummyTxn) Discard(ctx context.Context)           {}
 func (*dummyTxn) OnSuccess(fn func())                   {}
 func (*dummyTxn) OnError(fn func())                     {}
+func (*dummyTxn) OnDiscard(fn func())                   {}
 func (*dummyTxn) ID() uint64                            { return 0 }

--- a/tests/integration/lens.go
+++ b/tests/integration/lens.go
@@ -13,6 +13,7 @@ package tests
 import (
 	"github.com/sourcenetwork/immutable"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/sourcenetwork/defradb/client"
 )
@@ -72,7 +73,8 @@ func getMigrations(
 	for _, node := range getNodes(action.NodeID, s.nodes) {
 		db := getStore(s, node.DB, action.TransactionID, "")
 
-		configs := db.LensRegistry().Config()
+		configs, err := db.LensRegistry().Config(s.ctx)
+		require.NoError(s.t, err)
 
 		// The order of the results is not deterministic, so do not assert on the element
 		// locations.

--- a/tests/integration/schema/migrations/query/with_txn_test.go
+++ b/tests/integration/schema/migrations/query/with_txn_test.go
@@ -21,8 +21,6 @@ import (
 	"github.com/sourcenetwork/defradb/tests/lenses"
 )
 
-// todo: This test documents unwanted behaviour and should be fixed with
-// https://github.com/sourcenetwork/defradb/issues/1592
 func TestSchemaMigrationQueryWithTxn(t *testing.T) {
 	test := testUtils.TestCase{
 		Description: "Test schema migration, with transaction",
@@ -74,10 +72,8 @@ func TestSchemaMigrationQueryWithTxn(t *testing.T) {
 				}`,
 				Results: []map[string]any{
 					{
-						"name": "John",
-						// This is the bug - although the request and migration are on the same transaction
-						// the migration is not picked up during the request.
-						"verified": nil,
+						"name":     "John",
+						"verified": true,
 					},
 				},
 			},

--- a/tests/integration/schema/migrations/with_txn_test.go
+++ b/tests/integration/schema/migrations/with_txn_test.go
@@ -21,8 +21,6 @@ import (
 	"github.com/sourcenetwork/defradb/tests/lenses"
 )
 
-// todo: This test documents unwanted behaviour and should be fixed with
-// https://github.com/sourcenetwork/defradb/issues/1592
 func TestSchemaMigrationGetMigrationsWithTxn(t *testing.T) {
 	test := testUtils.TestCase{
 		Description: "Test schema migration, with txn",
@@ -49,7 +47,23 @@ func TestSchemaMigrationGetMigrationsWithTxn(t *testing.T) {
 				TransactionID: immutable.Some(0),
 				// This is the bug - although the GetMigrations call and migration are on the same transaction
 				// the migration is not returned in the results.
-				ExpectedResults: []client.LensConfig{},
+				ExpectedResults: []client.LensConfig{
+					{
+						SourceSchemaVersionID:      "does not exist",
+						DestinationSchemaVersionID: "also does not exist",
+						Lens: model.Lens{
+							Lenses: []model.LensModule{
+								{
+									Path: lenses.SetDefaultModulePath,
+									Arguments: map[string]any{
+										"dst":   "verified",
+										"value": false,
+									},
+								},
+							},
+						},
+					},
+				},
 			},
 		},
 	}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #1649 #1592

## Description

Improves the way migrations handle transactions, as well as fixing a couple of concurrency issues:

- Adds locks around the various registry properties, these maps can be accessed concurrently and need to be protected.
- Removes the transaction continuity issue in the client.LenRegistry interface, where db.LensRegistry() returns an object that does not respect the transactionality of the parent store, and takes `txn`s as input parameters to some of its functions. It does this by following the same pattern as `db.db`. (#1649)
- Fixes the bugs in the lens package where migrations set were not visible/accessible until after commit.  They are now visible within the transaction scope. (#1592)

It still does not provide transaction snapshot isolation, I see that issue as relatively high effort low reward at the moment.
