### PR TITLE
fix: Handle the querying of secondary relation id fields

### DIFF
--- a/planner/mapper/mapper.go
+++ b/planner/mapper/mapper.go
@@ -809,12 +809,12 @@ sourceLoop:
 		propertyMapped := len(mapping.IndexesByName[key]) != 0
 
 		if !propertyMapped {
-			dummyJoin, err := constructDummyJoin(descriptionsRepo, parentCollectionName, mapping, key)
+			join, err := constructEmptyJoin(descriptionsRepo, parentCollectionName, mapping, key)
 			if err != nil {
 				return nil, err
 			}
 
-			newFields = append(newFields, dummyJoin)
+			newFields = append(newFields, join)
 		}
 
 		keyIndex := mapping.FirstIndexOfName(key)
@@ -906,8 +906,8 @@ sourceLoop:
 	return newFields, nil
 }
 
-// constructDummyJoin constructs a valid empty join with no requested fields.
-func constructDummyJoin(
+// constructEmptyJoin constructs a valid empty join with no requested fields.
+func constructEmptyJoin(
 	descriptionsRepo *DescriptionsRepo,
 	parentCollectionName string,
 	parentMapping *core.DocumentMapping,
@@ -1014,7 +1014,7 @@ func resolveSecondaryRelationIDs(
 			objectFieldName := strings.TrimSuffix(existingField.Name, request.RelatedObjectID)
 
 			// We only require the dockey of the related object, so an empty join is all we need.
-			dummyJoin, err := constructDummyJoin(
+			join, err := constructEmptyJoin(
 				descriptionsRepo,
 				desc.Name,
 				mapping,
@@ -1024,7 +1024,7 @@ func resolveSecondaryRelationIDs(
 				return nil, err
 			}
 
-			fields = append(fields, dummyJoin)
+			fields = append(fields, join)
 		}
 	}
 

--- a/planner/type_join.go
+++ b/planner/type_join.go
@@ -293,7 +293,7 @@ func (p *Planner) makeTypeJoinOne(
 
 	// determine relation direction (primary or secondary?)
 	// check if the field we're querying is the primary side of the relation
-	isPrimary := subTypeFieldDesc.RelationType&client.Relation_Type_Primary > 0
+	isPrimary := subTypeFieldDesc.RelationType.IsSet(client.Relation_Type_Primary)
 
 	subTypeCollectionDesc, err := p.getCollectionDesc(subType.CollectionName)
 	if err != nil {

--- a/planner/type_join.go
+++ b/planner/type_join.go
@@ -11,6 +11,8 @@
 package planner
 
 import (
+	"github.com/sourcenetwork/immutable"
+
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/request"
 	"github.com/sourcenetwork/defradb/connor"
@@ -255,7 +257,8 @@ type typeJoinOne struct {
 	subTypeName      string
 	subTypeFieldName string
 
-	primary bool
+	primary             bool
+	secondaryFieldIndex immutable.Option[int]
 
 	spans     core.Spans
 	subSelect *mapper.Select
@@ -305,15 +308,24 @@ func (p *Planner) makeTypeJoinOne(
 		return nil, client.NewErrFieldNotExist(subTypeFieldDesc.RelationName)
 	}
 
+	var secondaryFieldIndex immutable.Option[int]
+	if !isPrimary {
+		idFieldName := subTypeFieldDesc.Name + request.RelatedObjectID
+		secondaryFieldIndex = immutable.Some(
+			parent.documentMapping.FirstIndexOfName(idFieldName),
+		)
+	}
+
 	return &typeJoinOne{
-		p:                p,
-		root:             source,
-		subSelect:        subType,
-		subTypeName:      subType.Name,
-		subTypeFieldName: subTypeField.Name,
-		subType:          selectPlan,
-		primary:          isPrimary,
-		docMapper:        docMapper{parent.documentMapping},
+		p:                   p,
+		root:                source,
+		subSelect:           subType,
+		subTypeName:         subType.Name,
+		subTypeFieldName:    subTypeField.Name,
+		subType:             selectPlan,
+		primary:             isPrimary,
+		secondaryFieldIndex: secondaryFieldIndex,
+		docMapper:           docMapper{parent.documentMapping},
 	}, nil
 }
 
@@ -387,6 +399,11 @@ func (n *typeJoinOne) valuesSecondary(doc core.Doc) (core.Doc, error) {
 
 	subdoc := n.subType.Value()
 	doc.Fields[n.subSelect.Index] = subdoc
+
+	if n.secondaryFieldIndex.HasValue() {
+		doc.Fields[n.secondaryFieldIndex.Value()] = subdoc.GetKey()
+	}
+
 	return doc, nil
 }
 

--- a/tests/integration/query/one_to_one/simple_test.go
+++ b/tests/integration/query/one_to_one/simple_test.go
@@ -374,9 +374,8 @@ func TestQueryOneToOne_WithRelationIDFromSecondarySide(t *testing.T) {
 				}`,
 				Results: []map[string]any{
 					{
-						"name": "Painted House",
-						// This is undesirable and needs to change within this PR
-						"author_id": nil,
+						"name":      "Painted House",
+						"author_id": "bae-6b624301-3d0a-5336-bd2c-ca00bca3de85",
 					},
 				},
 			},

--- a/tests/integration/query/one_to_one/simple_test.go
+++ b/tests/integration/query/one_to_one/simple_test.go
@@ -282,3 +282,106 @@ func TestQueryOneToOneWithNilParent(t *testing.T) {
 
 	executeTestCase(t, test)
 }
+
+func TestQueryOneToOne_WithRelationIDFromPrimarySide(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "One-to-one relation primary direction, relation ID field",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Book {
+						name: String
+						author: Author
+					}
+
+					type Author {
+						name: String
+						published: Book @primary
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				// bae-3d236f89-6a31-5add-a36a-27971a2eac76
+				CollectionID: 0,
+				Doc: `{
+					"name": "Painted House"
+				}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				Doc: `{
+					"name": "John Grisham",
+					"published_id": "bae-3d236f89-6a31-5add-a36a-27971a2eac76"
+				}`,
+			},
+			testUtils.Request{
+				Request: `query {
+					Author {
+						name
+						published_id
+					}
+				}`,
+				Results: []map[string]any{
+					{
+						"name":         "John Grisham",
+						"published_id": "bae-3d236f89-6a31-5add-a36a-27971a2eac76",
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestQueryOneToOne_WithRelationIDFromSecondarySide(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "One-to-one relation secondary direction, relation ID field",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Book {
+						name: String
+						author: Author
+					}
+
+					type Author {
+						name: String
+						published: Book @primary
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				// bae-3d236f89-6a31-5add-a36a-27971a2eac76
+				CollectionID: 0,
+				Doc: `{
+					"name": "Painted House"
+				}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				Doc: `{
+					"name": "John Grisham",
+					"published_id": "bae-3d236f89-6a31-5add-a36a-27971a2eac76"
+				}`,
+			},
+			testUtils.Request{
+				Request: `query {
+					Book {
+						name
+						author_id
+					}
+				}`,
+				Results: []map[string]any{
+					{
+						"name": "Painted House",
+						// This is undesirable and needs to change within this PR
+						"author_id": nil,
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/query/one_to_one/with_clashing_id_field_test.go
+++ b/tests/integration/query/one_to_one/with_clashing_id_field_test.go
@@ -16,6 +16,7 @@ import (
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
 )
 
+// This documents unwanted behaviour, see https://github.com/sourcenetwork/defradb/issues/1520
 func TestQueryOneToOneWithClashingIdFieldOnSecondary(t *testing.T) {
 	test := testUtils.TestCase{
 		Description: "One-to-one relation secondary direction, id field with name clash on secondary side",
@@ -62,7 +63,7 @@ func TestQueryOneToOneWithClashingIdFieldOnSecondary(t *testing.T) {
 				Results: []map[string]any{
 					{
 						"name":      "Painted House",
-						"author_id": uint64(123456),
+						"author_id": "bae-9d67a886-64e3-520b-8cd5-1ca7b098fabe",
 						"author": map[string]any{
 							"name": "John Grisham",
 						},

--- a/tests/integration/query/one_to_one/with_clashing_id_field_test.go
+++ b/tests/integration/query/one_to_one/with_clashing_id_field_test.go
@@ -16,7 +16,7 @@ import (
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
 )
 
-func TestQueryOneToOneWithIdFieldOnSecondary(t *testing.T) {
+func TestQueryOneToOneWithClashingIdFieldOnSecondary(t *testing.T) {
 	test := testUtils.TestCase{
 		Description: "One-to-one relation secondary direction, id field with name clash on secondary side",
 		Actions: []any{
@@ -76,7 +76,7 @@ func TestQueryOneToOneWithIdFieldOnSecondary(t *testing.T) {
 }
 
 // This documents unwanted behaviour, see https://github.com/sourcenetwork/defradb/issues/1520
-func TestQueryOneToOneWithIdFieldOnPrimary(t *testing.T) {
+func TestQueryOneToOneWithClashingIdFieldOnPrimary(t *testing.T) {
 	test := testUtils.TestCase{
 		Description: "One-to-one relation primary direction, id field with name clash on primary side",
 		Actions: []any{

--- a/tests/integration/query/one_to_one/with_group_related_id_alias_test.go
+++ b/tests/integration/query/one_to_one/with_group_related_id_alias_test.go
@@ -26,7 +26,7 @@ func TestQueryOneToOneWithGroupRelatedIDAlias(t *testing.T) {
 						name: String
 						author: Author @primary
 					}
-				
+
 					type Author {
 						name: String
 						published: Book
@@ -106,9 +106,233 @@ func TestQueryOneToOneWithGroupRelatedIDAlias(t *testing.T) {
 	testUtils.ExecuteTestCase(t, test)
 }
 
-// This test documents unwanted behaviour, see:
-// https://github.com/sourcenetwork/defradb/issues/1654
-func TestQueryOneToOneWithGroupRelatedIDAliasFromSecondary(t *testing.T) {
+func TestQueryOneToOneWithGroupRelatedIDAliasFromSecondaryWithoutInnerGroup(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "One-to-one relation query with group by related id alias (secondary side)",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Book {
+						name: String
+						author: Author
+					}
+
+					type Author {
+						name: String
+						published: Book @primary
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				// bae-3d236f89-6a31-5add-a36a-27971a2eac76
+				Doc: `{
+					"name": "Painted House"
+				}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				// bae-d6627fea-8bf7-511c-bcf9-bac4212bddd6
+				Doc: `{
+					"name": "Go Guide for Rust developers"
+				}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				// bae-6b624301-3d0a-5336-bd2c-ca00bca3de85
+				Doc: `{
+					"name": "John Grisham",
+					"published_id": "bae-3d236f89-6a31-5add-a36a-27971a2eac76"
+				}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				// bae-92fa9dcb-c1ee-5b84-b2f6-e9437c7f261c
+				Doc: `{
+					"name": "Andrew Lone",
+					"published_id": "bae-d6627fea-8bf7-511c-bcf9-bac4212bddd6"
+				}`,
+			},
+			testUtils.Request{
+				Request: `query {
+					Book(groupBy: [author]) {
+						author_id
+					}
+				}`,
+				Results: []map[string]any{
+					{
+						"author_id": "bae-6b624301-3d0a-5336-bd2c-ca00bca3de85",
+					},
+					{
+						"author_id": "bae-92fa9dcb-c1ee-5b84-b2f6-e9437c7f261c",
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestQueryOneToOneWithGroupRelatedIDAliasFromSecondaryWithoutInnerGroupWithJoin(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "One-to-one relation query with group by related id alias (secondary side)",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Book {
+						name: String
+						author: Author
+					}
+
+					type Author {
+						name: String
+						published: Book @primary
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				// bae-3d236f89-6a31-5add-a36a-27971a2eac76
+				Doc: `{
+					"name": "Painted House"
+				}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				// bae-d6627fea-8bf7-511c-bcf9-bac4212bddd6
+				Doc: `{
+					"name": "Go Guide for Rust developers"
+				}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				// bae-6b624301-3d0a-5336-bd2c-ca00bca3de85
+				Doc: `{
+					"name": "John Grisham",
+					"published_id": "bae-3d236f89-6a31-5add-a36a-27971a2eac76"
+				}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				// bae-92fa9dcb-c1ee-5b84-b2f6-e9437c7f261c
+				Doc: `{
+					"name": "Andrew Lone",
+					"published_id": "bae-d6627fea-8bf7-511c-bcf9-bac4212bddd6"
+				}`,
+			},
+			testUtils.Request{
+				Request: `query {
+					Book(groupBy: [author]) {
+						author_id
+						author {
+							name
+						}
+					}
+				}`,
+				Results: []map[string]any{
+					{
+						"author_id": "bae-6b624301-3d0a-5336-bd2c-ca00bca3de85",
+						"author": map[string]any{
+							"name": "John Grisham",
+						},
+					},
+					{
+						"author_id": "bae-92fa9dcb-c1ee-5b84-b2f6-e9437c7f261c",
+						"author": map[string]any{
+							"name": "Andrew Lone",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestQueryOneToOneWithGroupRelatedIDAliasFromSecondaryWithInnerGroup(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "One-to-one relation query with group by related id alias (secondary side)",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Book {
+						name: String
+						author: Author
+					}
+				
+					type Author {
+						name: String
+						published: Book @primary
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				// bae-3d236f89-6a31-5add-a36a-27971a2eac76
+				Doc: `{
+					"name": "Painted House"
+				}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				// bae-d6627fea-8bf7-511c-bcf9-bac4212bddd6
+				Doc: `{
+					"name": "Go Guide for Rust developers"
+				}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				// bae-6b624301-3d0a-5336-bd2c-ca00bca3de85
+				Doc: `{
+					"name": "John Grisham",
+					"published_id": "bae-3d236f89-6a31-5add-a36a-27971a2eac76"
+				}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				// bae-92fa9dcb-c1ee-5b84-b2f6-e9437c7f261c
+				Doc: `{
+					"name": "Andrew Lone",
+					"published_id": "bae-d6627fea-8bf7-511c-bcf9-bac4212bddd6"
+				}`,
+			},
+			testUtils.Request{
+				Request: `query {
+					Book(groupBy: [author]) {
+						author_id
+						_group {
+							name
+						}
+					}
+				}`,
+				Results: []map[string]any{
+					{
+						"author_id": "bae-6b624301-3d0a-5336-bd2c-ca00bca3de85",
+						"_group": []map[string]any{
+							{
+								"name": "Painted House",
+							},
+						},
+					},
+					{
+						"author_id": "bae-92fa9dcb-c1ee-5b84-b2f6-e9437c7f261c",
+						"_group": []map[string]any{
+							{
+								"name": "Go Guide for Rust developers",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestQueryOneToOneWithGroupRelatedIDAliasFromSecondaryWithInnerGroupWithJoin(t *testing.T) {
 	test := testUtils.TestCase{
 		Description: "One-to-one relation query with group by related id alias (secondary side)",
 		Actions: []any{
@@ -169,14 +393,22 @@ func TestQueryOneToOneWithGroupRelatedIDAliasFromSecondary(t *testing.T) {
 				}`,
 				Results: []map[string]any{
 					{
-						"author_id": nil,
+						"author_id": "bae-6b624301-3d0a-5336-bd2c-ca00bca3de85",
 						"author": map[string]any{
-							"name": "Andrew Lone",
+							"name": "John Grisham",
 						},
 						"_group": []map[string]any{
 							{
 								"name": "Painted House",
 							},
+						},
+					},
+					{
+						"author_id": "bae-92fa9dcb-c1ee-5b84-b2f6-e9437c7f261c",
+						"author": map[string]any{
+							"name": "Andrew Lone",
+						},
+						"_group": []map[string]any{
 							{
 								"name": "Go Guide for Rust developers",
 							},


### PR DESCRIPTION
## Relevant issue(s)

Resolves #1654

## Description

Handles the querying of secondary relation id fields.

It does this by joining the related object and copying the dockey value into the secondary related id field.

- ~~Is currently blocked by https://github.com/sourcenetwork/defradb/issues/1769 but can still be reviewed now~~ ~~PR is now based off the fix for that issue (do not review the first commit here).  Will rebase off develop branch before merge.~~ Fix merged to develop, this branch has been rebased onto it. 