### PR TITLE
refactor(i): Unify collection.save and .applyMerge logic

### DIFF
--- a/client/document.go
+++ b/client/document.go
@@ -283,6 +283,12 @@ func (doc *Document) setAndParseType(field string, value any) error {
 		if err != nil {
 			return err
 		}
+	case uint64:
+		err := doc.setCBOR(LWW_REGISTER, field, int64(val))
+		if err != nil {
+			return err
+		}
+
 	case float64:
 		// case int64:
 
@@ -300,7 +306,7 @@ func (doc *Document) setAndParseType(field string, value any) error {
 		}
 
 	// string, bool, and more
-	case string, bool, []any:
+	case string, bool, int64, []any, []bool, []*bool, []int64, []*int64, []float64, []*float64, []string, []*string:
 		err := doc.setCBOR(LWW_REGISTER, field, val)
 		if err != nil {
 			return err

--- a/db/collection.go
+++ b/db/collection.go
@@ -1282,13 +1282,6 @@ func (c *collection) commitImplicitTxn(ctx context.Context, txn datastore.Txn) e
 	return nil
 }
 
-func (c *collection) getPrimaryKey(docKey string) core.PrimaryDataStoreKey {
-	return core.PrimaryDataStoreKey{
-		CollectionId: fmt.Sprint(c.colID),
-		DocKey:       docKey,
-	}
-}
-
 func (c *collection) getPrimaryKeyFromDocKey(docKey client.DocKey) core.PrimaryDataStoreKey {
 	return core.PrimaryDataStoreKey{
 		CollectionId: fmt.Sprint(c.colID),

--- a/db/collection_update.go
+++ b/db/collection_update.go
@@ -181,16 +181,17 @@ func (c *collection) updateWithKeys(
 		if err != nil {
 			return nil, err
 		}
-		v, err := doc.ToMap()
-		if err != nil {
-			return nil, err
-		}
 
 		if isPatch {
 			// todo
 		} else {
-			err = c.applyMerge(ctx, txn, v, parsedUpdater.GetObject())
+			err = c.applyMergeToDoc(doc, parsedUpdater.GetObject())
 		}
+		if err != nil {
+			return nil, err
+		}
+
+		_, err = c.save(ctx, txn, doc, false)
 		if err != nil {
 			return nil, err
 		}

--- a/db/collection_update.go
+++ b/db/collection_update.go
@@ -307,11 +307,7 @@ func (c *collection) applyMerge(
 
 		fd, isValidAliasField := c.desc.Schema.GetField(mfield + request.RelatedObjectID)
 		if isValidAliasField {
-			// Overwrite the key with aliased name to the internal related object name.
-			oldKey := mfield
 			mfield = mfield + request.RelatedObjectID
-			mergeMap[mfield] = mval
-			delete(mergeMap, oldKey)
 		} else {
 			var isValidField bool
 			fd, isValidField = c.desc.Schema.GetField(mfield)

--- a/db/collection_update.go
+++ b/db/collection_update.go
@@ -133,16 +133,17 @@ func (c *collection) updateWithKey(
 	if err != nil {
 		return nil, err
 	}
-	v, err := doc.ToMap()
-	if err != nil {
-		return nil, err
-	}
 
 	if isPatch {
 		// todo
 	} else {
-		err = c.applyMerge(ctx, txn, v, parsedUpdater.GetObject())
+		err = c.applyMergeToDoc(doc, parsedUpdater.GetObject())
 	}
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = c.save(ctx, txn, doc, false)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #1786

## Description

Unifies collection.save and collection.applyMerge field logic, leaving us with one function through which all document mutations take place.

Also fixes the slightly broken logic for determining whether a field was a foreign relation or not (relying on the field name ending in `_id` is not good enough).

Also expands the value types that `client.Document` can handle.  This is however not the goal of this PR, and they are undocumented (or poorly documented) and likely still incomplete.  Another work item can target this area at some other point in time. 