### PR TITLE
test(i): Increase the package-levl test timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ ifdef BUILD_TAGS
 BUILD_FLAGS+=-tags $(BUILD_TAGS)
 endif
 
-TEST_FLAGS=-race -shuffle=on -timeout 150s
+TEST_FLAGS=-race -shuffle=on -timeout 210s
 
 PLAYGROUND_DIRECTORY=playground
 LENS_TEST_DIRECTORY=tests/integration/schema/migrations


### PR DESCRIPTION
## Relevant issue(s)

Resolves #1794

## Description

Increases the package-levl test timeout.

150s has been breached a couple of times recently, costing dev time.
