### PR TITLE
feat: Auto-create relation id fields via PatchSchema

### DIFF
--- a/db/collection.go
+++ b/db/collection.go
@@ -244,6 +244,20 @@ func (db *db) updateCollection(
 		return db.getCollectionByName(ctx, txn, desc.Name)
 	}
 
+	for _, field := range desc.Schema.Fields {
+		if field.RelationType.IsSet(client.Relation_Type_ONE) {
+			idFieldName := field.Name + "_id"
+			if _, ok := desc.Schema.GetField(idFieldName); !ok {
+				desc.Schema.Fields = append(desc.Schema.Fields, client.FieldDescription{
+					Name:         idFieldName,
+					Kind:         client.FieldKind_DocKey,
+					RelationType: client.Relation_Type_INTERNAL_ID,
+					RelationName: field.RelationName,
+				})
+			}
+		}
+	}
+
 	for i, field := range desc.Schema.Fields {
 		if field.ID == client.FieldID(0) {
 			// This is not wonderful and will probably break when we add the ability
@@ -443,24 +457,22 @@ func validateUpdateCollectionFields(
 			if proposedField.Kind == client.FieldKind_FOREIGN_OBJECT {
 				idFieldName := proposedField.Name + "_id"
 				idField, idFieldFound := proposedDesc.Schema.GetField(idFieldName)
-				if !idFieldFound {
-					return false, NewErrRelationalFieldMissingIDField(proposedField.Name, idFieldName)
-				}
+				if idFieldFound {
+					if idField.Kind != client.FieldKind_DocKey {
+						return false, NewErrRelationalFieldIDInvalidType(idField.Name, client.FieldKind_DocKey, idField.Kind)
+					}
 
-				if idField.Kind != client.FieldKind_DocKey {
-					return false, NewErrRelationalFieldIDInvalidType(idField.Name, client.FieldKind_DocKey, idField.Kind)
-				}
+					if idField.RelationType != client.Relation_Type_INTERNAL_ID {
+						return false, NewErrRelationalFieldInvalidRelationType(
+							idField.Name,
+							client.Relation_Type_INTERNAL_ID,
+							idField.RelationType,
+						)
+					}
 
-				if idField.RelationType != client.Relation_Type_INTERNAL_ID {
-					return false, NewErrRelationalFieldInvalidRelationType(
-						idField.Name,
-						client.Relation_Type_INTERNAL_ID,
-						idField.RelationType,
-					)
-				}
-
-				if idField.RelationName == "" {
-					return false, NewErrRelationalFieldMissingRelationName(idField.Name)
+					if idField.RelationName == "" {
+						return false, NewErrRelationalFieldMissingRelationName(idField.Name)
+					}
 				}
 			}
 

--- a/db/schema.go
+++ b/db/schema.go
@@ -134,10 +134,12 @@ func (db *db) patchSchema(ctx context.Context, txn datastore.Txn, patchString st
 		newDescriptions = append(newDescriptions, desc)
 	}
 
-	for _, desc := range newDescriptions {
-		if _, err := db.updateCollection(ctx, txn, collectionsByName, newDescriptionsByName, desc); err != nil {
+	for i, desc := range newDescriptions {
+		col, err := db.updateCollection(ctx, txn, collectionsByName, newDescriptionsByName, desc)
+		if err != nil {
 			return err
 		}
+		newDescriptions[i] = col.Description()
 	}
 
 	return db.parser.SetSchema(ctx, txn, newDescriptions)

--- a/tests/integration/schema/updates/add/field/kind/foreign_object_array_test.go
+++ b/tests/integration/schema/updates/add/field/kind/foreign_object_array_test.go
@@ -115,32 +115,6 @@ func TestSchemaUpdatesAddFieldKindForeignObjectArray_MissingRelationName(t *test
 	testUtils.ExecuteTestCase(t, test)
 }
 
-func TestSchemaUpdatesAddFieldKindForeignObjectArray_MissingIDField(t *testing.T) {
-	test := testUtils.TestCase{
-		Description: "Test schema update, add field with kind foreign object array (17), missing id field",
-		Actions: []any{
-			testUtils.SchemaUpdate{
-				Schema: `
-					type Users {
-						name: String
-					}
-				`,
-			},
-			testUtils.SchemaPatch{
-				Patch: `
-					[
-						{ "op": "add", "path": "/Users/Schema/Fields/-", "value": {
-							"Name": "foo", "Kind": 16, "RelationType": 137, "Schema": "Users", "RelationName": "foo"
-						}}
-					]
-				`,
-				ExpectedError: "missing id field for relation object field. Field: foo, ExpectedIDFieldName: foo_id",
-			},
-		},
-	}
-	testUtils.ExecuteTestCase(t, test)
-}
-
 func TestSchemaUpdatesAddFieldKindForeignObjectArray_IDFieldMissingKind(t *testing.T) {
 	test := testUtils.TestCase{
 		Description: "Test schema update, add field with kind foreign object array (17), id field missing kind",
@@ -949,6 +923,82 @@ func TestSchemaUpdatesAddFieldKindForeignObjectArray_SecondaryObjectKindAndSchem
 					]
 				`,
 				ExpectedError: "field Kind does not match field Schema. Kind: [Users], Schema: Dog",
+			},
+		},
+	}
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestSchemaUpdatesAddFieldKindForeignObjectArray_MissingPrimaryIDField(t *testing.T) {
+	key1 := "bae-decf6467-4c7c-50d7-b09d-0a7097ef6bad"
+
+	test := testUtils.TestCase{
+		Description: "Test schema update, add field with kind foreign object array (17), with auto id field generation",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users {
+						name: String
+					}
+				`,
+			},
+			testUtils.SchemaPatch{
+				Patch: `
+					[
+						{ "op": "add", "path": "/Users/Schema/Fields/-", "value": {
+							"Name": "foo", "Kind": "Users", "RelationType": 137, "RelationName": "foo"
+						}},
+						{ "op": "add", "path": "/Users/Schema/Fields/-", "value": {
+							"Name": "foobar", "Kind": "[Users]", "RelationType": 10, "RelationName": "foo"
+						}}
+					]
+				`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `{
+					"name": "John"
+				}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: fmt.Sprintf(`{
+						"name": "Keenan",
+						"foo": "%s"
+					}`,
+					key1,
+				),
+			},
+			testUtils.Request{
+				Request: `query {
+					Users {
+						name
+						foo {
+							name
+						}
+						foobar {
+							name
+						}
+					}
+				}`,
+				Results: []map[string]any{
+					{
+						"name": "Keenan",
+						"foo": map[string]any{
+							"name": "John",
+						},
+						"foobar": []map[string]any{},
+					},
+					{
+						"name": "John",
+						"foo":  nil,
+						"foobar": []map[string]any{
+							{
+								"name": "Keenan",
+							},
+						},
+					},
+				},
 			},
 		},
 	}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #1773

## Description

Auto-creates relation id fields via PatchSchema if not explicitly defined by the user.