### PR TITLE
fix: Only update updated fields via update requests

### DIFF
--- a/db/fetcher/encoded_doc.go
+++ b/db/fetcher/encoded_doc.go
@@ -123,6 +123,11 @@ func Decode(encdoc EncodedDocument) (*client.Document, error) {
 
 	doc.SchemaVersionID = encdoc.SchemaVersionID()
 
+	// client.Document tracks which fields have been set ('dirtied'), here we
+	// are simply decoding a clean document and the dirty flag is an artifact
+	// of the current client.Document interface.
+	doc.Clean()
+
 	return doc, nil
 }
 


### PR DESCRIPTION
## Relevant issue(s)

Resolves #1811

## Description

Only updates updated fields via update requests by returning a clean document from Decode.

## How has this been tested?

I have tested this via https://github.com/sourcenetwork/defradb/issues/1816 (https://github.com/sourcenetwork/defradb/compare/develop...AndrewSisley:1816-mutation-equivilency?expand=1) however this is a very simple and quite important fix deserving of its own commit/change-log entry in develop, and the test changes are complex and may bog down the merging of the fix. 