### PR TITLE
ci(i): Disable multiplexing in correct file

### DIFF
--- a/tests/lenses/.cargo/config.toml
+++ b/tests/lenses/.cargo/config.toml
@@ -1,0 +1,2 @@
+[http]
+multiplexing = false

--- a/tests/lenses/rust_wasm32_copy/Cargo.toml
+++ b/tests/lenses/rust_wasm32_copy/Cargo.toml
@@ -10,6 +10,3 @@ crate-type = ["cdylib"]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.87"
 lens_sdk = { version = "0.1.0", git = "https://github.com/lens-vm/lens.git" }
-
-[http]
-multiplexing = false

--- a/tests/lenses/rust_wasm32_remove/Cargo.toml
+++ b/tests/lenses/rust_wasm32_remove/Cargo.toml
@@ -10,6 +10,3 @@ crate-type = ["cdylib"]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.87"
 lens_sdk = { version = "0.1.0", git = "https://github.com/lens-vm/lens.git" }
-
-[http]
-multiplexing = false

--- a/tests/lenses/rust_wasm32_set_default/Cargo.toml
+++ b/tests/lenses/rust_wasm32_set_default/Cargo.toml
@@ -10,6 +10,3 @@ crate-type = ["cdylib"]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.87"
 lens_sdk = { version = "0.1.0", git = "https://github.com/lens-vm/lens.git" }
-
-[http]
-multiplexing = false


### PR DESCRIPTION
## Relevant issue(s)

Resolves #1835

## Description

Disable multiplexing in the correct file.

It does nothing in its current location, we get a warning logged saying that it is unused - this param belongs in the cargo config file as per this document: https://doc.rust-lang.org/cargo/reference/config.html.

Will hopefully fix the rust dependencies timeouts causing the build to fail every now and then.