### PR TITLE
test(i): Extend mutation tests with col.Update and Create

### DIFF
--- a/.github/workflows/test-collection-named.yml
+++ b/.github/workflows/test-collection-named.yml
@@ -1,0 +1,61 @@
+# Copyright 2022 Democratized Data Foundation
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.txt.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0, included in the file
+# licenses/APL.txt.
+
+name: Run Collection.[Named] Mutations Tests Workflow
+
+# This workflow runs the test suite with any supporting mutation test actions
+# running their mutations via their corresponding named [Collection] call.
+#
+# For example, CreateDoc will call [Collection.Create], and
+# UpdateDoc will call [Collection.Update].
+
+on:
+  pull_request:
+    branches:
+      - master
+      - develop
+
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+    branches:
+      - master
+      - develop
+
+jobs:
+  test-gql-mutations:
+    name: Test Collection.[Named] Mutations job
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code into the directory
+        uses: actions/checkout@v3
+
+      - name: Setup Go environment explicitly
+        uses: actions/setup-go@v3
+        with:
+          go-version: "1.20"
+          check-latest: true
+
+      - name: Build dependencies
+        run: |
+          make deps:modules
+          make deps:test
+
+      - name: Run tests with Collection.[Named] mutations
+        run: make test:ci-col-named-mutations
+
+      ## Uncomment to enable ability to SSH into the runner.
+      #- name: Setup upterm ssh session for debugging
+      #  uses: lhotari/action-upterm@v1
+      #  with:
+      #    limit-access-to-actor: true
+      #    limit-access-to-users: shahzadlone

--- a/.github/workflows/test-collection-named.yml
+++ b/.github/workflows/test-collection-named.yml
@@ -52,10 +52,3 @@ jobs:
 
       - name: Run tests with Collection Named mutations
         run: make test:ci-col-named-mutations
-
-      ## Uncomment to enable ability to SSH into the runner.
-      #- name: Setup upterm ssh session for debugging
-      #  uses: lhotari/action-upterm@v1
-      #  with:
-      #    limit-access-to-actor: true
-      #    limit-access-to-users: shahzadlone

--- a/.github/workflows/test-collection-named.yml
+++ b/.github/workflows/test-collection-named.yml
@@ -8,7 +8,7 @@
 # by the Apache License, Version 2.0, included in the file
 # licenses/APL.txt.
 
-name: Run Collection.[Named] Mutations Tests Workflow
+name: Run Collection Named Mutations Tests Workflow
 
 # This workflow runs the test suite with any supporting mutation test actions
 # running their mutations via their corresponding named [Collection] call.
@@ -30,8 +30,8 @@ on:
       - develop
 
 jobs:
-  test-gql-mutations:
-    name: Test Collection.[Named] Mutations job
+  test-collection-named-mutations:
+    name: Test Collection Named Mutations job
 
     runs-on: ubuntu-latest
 
@@ -50,7 +50,7 @@ jobs:
           make deps:modules
           make deps:test
 
-      - name: Run tests with Collection.[Named] mutations
+      - name: Run tests with Collection Named mutations
         run: make test:ci-col-named-mutations
 
       ## Uncomment to enable ability to SSH into the runner.

--- a/.github/workflows/test-collection-named.yml
+++ b/.github/workflows/test-collection-named.yml
@@ -1,4 +1,4 @@
-# Copyright 2022 Democratized Data Foundation
+# Copyright 2023 Democratized Data Foundation
 #
 # Use of this software is governed by the Business Source License
 # included in the file licenses/BSL.txt.

--- a/.github/workflows/test-gql-mutations.yml
+++ b/.github/workflows/test-gql-mutations.yml
@@ -46,10 +46,3 @@ jobs:
 
       - name: Run tests with gql mutations
         run: make test:ci-gql-mutations
-
-      ## Uncomment to enable ability to SSH into the runner.
-      #- name: Setup upterm ssh session for debugging
-      #  uses: lhotari/action-upterm@v1
-      #  with:
-      #    limit-access-to-actor: true
-      #    limit-access-to-users: shahzadlone

--- a/Makefile
+++ b/Makefile
@@ -197,6 +197,19 @@ test\:ci-gql-mutations:
 test\:gql-mutations:
 	DEFRA_MUTATION_TYPE=gql DEFRA_BADGER_MEMORY=true gotestsum --format pkgname -- $(DEFAULT_TEST_DIRECTORIES)
 
+# This action and the test:col-named-mutations (below) runs the test suite with any supporting mutation test
+# actions running their mutations via their corresponding named [Collection] call.
+#
+# For example, CreateDoc will call [Collection.Create], and
+# UpdateDoc will call [Collection.Update].
+.PHONY: test\:ci-col-named-mutations
+test\:ci-col-named-mutations:
+	DEFRA_MUTATION_TYPE=collection-named DEFRA_BADGER_MEMORY=true $(MAKE) test:all
+
+.PHONY: test\:col-named-mutations
+test\:col-named-mutations:
+	DEFRA_MUTATION_TYPE=collection-named DEFRA_BADGER_MEMORY=true gotestsum --format pkgname -- $(DEFAULT_TEST_DIRECTORIES)
+
 .PHONY: test\:go
 test\:go:
 	go test $(DEFAULT_TEST_DIRECTORIES) $(TEST_FLAGS)


### PR DESCRIPTION
## Relevant issue(s)

Resolves #1832

## Description

Extends mutation tests with collection.Update and Create calls for the corresponding actions.  Adds another github workflow to run the tests.

I didn't really plan on adding this so soon, but I really want it for https://github.com/sourcenetwork/defradb/issues/935, which I want for https://github.com/sourcenetwork/defradb/issues/1331 - as well as just being nice to test these :)

Is based off https://github.com/sourcenetwork/defradb/pull/1837 - please don't review the first commit here.