### PR TITLE
test(i): Test top level agg. wt compound relational filter

### DIFF
--- a/tests/integration/query/one_to_many/with_cid_dockey_test.go
+++ b/tests/integration/query/one_to_many/with_cid_dockey_test.go
@@ -60,7 +60,7 @@ import (
 // 		},
 // 	}
 
-// 	testUtils.AssertPanicAndSkipChangeDetection(t, func() { executeTestCase(t, test) })
+// 	testUtils.AssertPanic(t, func() { executeTestCase(t, test) })
 // }
 
 func TestQueryOneToManyWithCidAndDocKey(t *testing.T) {

--- a/tests/integration/query/one_to_one/with_count_filter_test.go
+++ b/tests/integration/query/one_to_one/with_count_filter_test.go
@@ -1,0 +1,119 @@
+// Copyright 2023 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package one_to_one
+
+import (
+	"testing"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+// This test documents a bug and should be altered with:
+// https://github.com/sourcenetwork/defradb/issues/1869
+func TestQueryOneToOneWithCountWithCompoundOrFilterThatIncludesRelation(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "One-to-one relation with count with _or filter that includes relation",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: bookAuthorGQLSchema,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				// bae-fd541c25-229e-5280-b44b-e5c2af3e374d
+				Doc: `{
+					"name": "Painted House",
+					"rating": 4.9
+				}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				// bae-f60d6af6-92f7-5f11-9182-1d7273a5a9e8
+				Doc: `{
+					"name": "Some Book",
+					"rating": 4.0
+				}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				// bae-1c890922-ddf9-5820-a888-c7f977848934
+				Doc: `{
+					"name": "Some Other Book",
+					"rating": 3.5
+				}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				// bae-e8642720-08cb-5f5b-a8d6-7187c444a78d
+				Doc: `{
+					"name": "Yet Another Book",
+					"rating": 3.0
+				}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				// bae-41598f0c-19bc-5da6-813b-e80f14a10df3
+				Doc: `{
+					"name": "John Grisham",
+					"age": 65,
+					"verified": true,
+					"published_id": "bae-fd541c25-229e-5280-b44b-e5c2af3e374d"
+				}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				Doc: `{
+					"name": "Some Writer",
+					"age": 45,
+					"verified": false,
+					"published_id": "bae-f60d6af6-92f7-5f11-9182-1d7273a5a9e8"
+				}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				Doc: `{
+					"name": "Some Other Writer",
+					"age": 35,
+					"verified": false,
+					"published_id": "bae-1c890922-ddf9-5820-a888-c7f977848934"
+				}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				Doc: `{
+					"name": "Yet Another Writer",
+					"age": 30,
+					"verified": false,
+					"published_id": "bae-e8642720-08cb-5f5b-a8d6-7187c444a78d"
+				}`,
+			},
+			testUtils.Request{
+				Request: `query {
+					_count(Book: {filter: {_or: [
+						{_not: {author: {age: {_lt: 65}}} },
+						{_not: {author: {age: {_gt: 30}}} }
+					]}})
+				}`,
+				Results: []map[string]any{
+					{
+						"_count": "2",
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.AssertPanicAndSkipChangeDetection(
+		t,
+		func() {
+			testUtils.ExecuteTestCase(t, test)
+		},
+	)
+}

--- a/tests/integration/query/one_to_one/with_count_filter_test.go
+++ b/tests/integration/query/one_to_one/with_count_filter_test.go
@@ -110,7 +110,7 @@ func TestQueryOneToOneWithCountWithCompoundOrFilterThatIncludesRelation(t *testi
 		},
 	}
 
-	testUtils.AssertPanicAndSkipChangeDetection(
+	testUtils.AssertPanic(
 		t,
 		func() {
 			testUtils.ExecuteTestCase(t, test)

--- a/tests/integration/utils2.go
+++ b/tests/integration/utils2.go
@@ -196,17 +196,24 @@ func init() {
 	}
 }
 
-// AssertPanicAndSkipChangeDetection asserts that the code of function actually panics,
+// AssertPanic asserts that the code inside the specified PanicTestFunc panics.
 //
-//	also ensures the change detection is skipped so no false fails happen.
+// This function is not supported by either the change detector, or the http-client.
+// Calling this within either of them will result in the test being skipped.
 //
-//	Usage: AssertPanicAndSkipChangeDetection(t, func() { executeTestCase(t, test) })
-func AssertPanicAndSkipChangeDetection(t *testing.T, f assert.PanicTestFunc) bool {
+// Usage: AssertPanic(t, func() { executeTestCase(t, test) })
+func AssertPanic(t *testing.T, f assert.PanicTestFunc) bool {
 	if IsDetectingDbChanges() {
 		// The `assert.Panics` call will falsely fail if this test is executed during
-		// a detect changes test run
-		t.Skip()
+		// a detect changes test run.
+		t.Skip("Assert panic with the change detector is not currently supported.")
 	}
+
+	if httpClient {
+		// The http-client will return an error instead of panicing at the moment.
+		t.Skip("Assert panic with the http client is not currently supported.")
+	}
+
 	return assert.Panics(t, f, "expected a panic, but none found.")
 }
 


### PR DESCRIPTION
## Relevant issue(s)

Resolves #1868

## Description

Adds a test for aggregates with a compound relational filter.

Documents https://github.com/sourcenetwork/defradb/issues/1869

I believe this predates the release, and may be a fiddly fix with lots more testing required, so I'm documenting it now and moving on - maybe it will be fixed before the release goes out, but will see. 