### PR TITLE
test(i): Remap alias fields when refreshing test documents

### DIFF
--- a/tests/integration/utils2.go
+++ b/tests/integration/utils2.go
@@ -900,6 +900,11 @@ func refreshDocuments(
 			// Just use the collection from the first relevant node, as all will be the same for this
 			// purpose.
 			collection := getNodeCollections(action.NodeID, s.collections)[0][action.CollectionID]
+			if err := doc.RemapAliasFieldsAndDockey(collection.Schema().Fields); err != nil {
+				// If an err has been returned, ignore it - it may be expected and if not
+				// the test will fail later anyway
+				continue
+			}
 
 			// The document may have been mutated by other actions, so to be sure we have the latest
 			// version without having to worry about the individual update mechanics we fetch it.


### PR DESCRIPTION
## Relevant issue(s)

N/A

## Description

This PR fixes a bug that causes documents to not be correctly refreshed when they are created using alias fields.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

`make test:changes`

Specify the platform(s) on which this was tested:
- MacOS

