### PR TITLE
fix(i): For loop foot guns in tests

### DIFF
--- a/api/http/handler_test.go
+++ b/api/http/handler_test.go
@@ -247,7 +247,8 @@ func TestCORSRequest(t *testing.T) {
 
 	s := NewServer(nil, WithAllowedOrigins("https://source.network"))
 
-	for _, c := range cases {
+	for i := range cases {
+		c := cases[i]
 		t.Run(c.name, func(t *testing.T) {
 			req, err := http.NewRequest(c.method, PingPath, nil)
 			if err != nil {
@@ -289,7 +290,8 @@ func TestTLSRequestResponseHeader(t *testing.T) {
 
 	s := NewServer(nil, WithTLS(), WithAddress("example.com"), WithRootDir(dir))
 
-	for _, c := range cases {
+	for i := range cases {
+		c := cases[i]
 		t.Run(c.name, func(t *testing.T) {
 			req, err := http.NewRequest(c.method, PingPath, nil)
 			if err != nil {

--- a/planner/filter/complex_test.go
+++ b/planner/filter/complex_test.go
@@ -161,7 +161,8 @@ func TestIsComplex(t *testing.T) {
 	}
 
 	mapping := getDocMapping()
-	for _, test := range tests {
+	for i := range tests {
+		test := tests[i]
 		t.Run(test.name, func(t *testing.T) {
 			inputFilter := mapper.ToFilter(request.Filter{Conditions: test.inputFilter}, mapping)
 			actual := IsComplex(inputFilter)

--- a/planner/filter/copy_field_test.go
+++ b/planner/filter/copy_field_test.go
@@ -74,7 +74,8 @@ func TestCopyField(t *testing.T) {
 	}
 
 	mapping := getDocMapping()
-	for _, test := range tests {
+	for i := range tests {
+		test := tests[i]
 		t.Run(test.name, func(t *testing.T) {
 			inputFilter := mapper.ToFilter(request.Filter{Conditions: test.inputFilter}, mapping)
 			actualFilter := copyField(inputFilter, test.inputField)

--- a/planner/filter/copy_test.go
+++ b/planner/filter/copy_test.go
@@ -135,7 +135,8 @@ func TestCopyFilter(t *testing.T) {
 		},
 	}
 
-	for _, test := range tests {
+	for i := range tests {
+		test := tests[i]
 		t.Run(test.name, func(t *testing.T) {
 			f := getFilter()
 			test.act(t, f, Copy(f))

--- a/planner/filter/merge_test.go
+++ b/planner/filter/merge_test.go
@@ -55,7 +55,8 @@ func TestMergeFilterConditions(t *testing.T) {
 	}
 
 	mapping := getDocMapping()
-	for _, tt := range tests {
+	for i := range tests {
+		tt := tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			leftFilter := mapper.ToFilter(request.Filter{Conditions: tt.left}, mapping)
 			rightFilter := mapper.ToFilter(request.Filter{Conditions: tt.right}, mapping)

--- a/planner/filter/normalize_test.go
+++ b/planner/filter/normalize_test.go
@@ -291,7 +291,8 @@ func TestNormalizeConditions(t *testing.T) {
 	}
 
 	mapping := getDocMapping()
-	for _, tt := range tests {
+	for i := range tests {
+		tt := tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			inputFilter := mapper.ToFilter(request.Filter{Conditions: tt.input}, mapping)
 			actualFilter := normalize(inputFilter.Conditions)

--- a/planner/filter/remove_field_test.go
+++ b/planner/filter/remove_field_test.go
@@ -72,7 +72,8 @@ func TestRemoveFieldFromFilter(t *testing.T) {
 	}
 
 	mapping := getDocMapping()
-	for _, test := range tests {
+	for i := range tests {
+		test := tests[i]
 		t.Run(test.name, func(t *testing.T) {
 			inputFilter := mapper.ToFilter(request.Filter{Conditions: test.inputFilter}, mapping)
 			RemoveField(inputFilter, test.inputField)

--- a/planner/filter/split_test.go
+++ b/planner/filter/split_test.go
@@ -39,7 +39,8 @@ func TestSplitFilter(t *testing.T) {
 	}
 
 	mapping := getDocMapping()
-	for _, test := range tests {
+	for i := range tests {
+		test := tests[i]
 		t.Run(test.name, func(t *testing.T) {
 			inputFilter := mapper.ToFilter(request.Filter{Conditions: test.inputFilter}, mapping)
 			actualFilter1, actualFilter2 := SplitByField(inputFilter, test.inputField)

--- a/tests/change_detector/change_detector_test.go
+++ b/tests/change_detector/change_detector_test.go
@@ -59,7 +59,8 @@ func TestChanges(t *testing.T) {
 		sourceRepoPkgMap[pkg] = true
 	}
 
-	for _, pkg := range targetRepoPkgList {
+	for key := range targetRepoPkgList {
+		pkg := key
 		pkgName := strings.TrimPrefix(pkg, "github.com/sourcenetwork/defradb/")
 		t.Run(pkgName, func(t *testing.T) {
 			if pkg == "" || !sourceRepoPkgMap[pkg] {


### PR DESCRIPTION
## Relevant issue(s)

Resolves #1879

## Description

For loop variable assignment can cause race conditions when used with go routines such as `test.Run()`.

Read more about it here https://go.dev/blog/loopvar-preview

## Tasks

- [ ] I made sure the code is well commented, particularly hard-to-understand areas.
- [ ] I made sure the repository-held documentation is changed accordingly.
- [ ] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [ ] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

(*replace*) Describe the tests performed to verify the changes. Provide instructions to reproduce them.

Specify the platform(s) on which this was tested:
- *(modify the list accordingly*)
- Arch Linux
- Debian Linux
- MacOS
- Windows
