### PR TITLE
fix: Ensure field does not exist error consistent

### DIFF
--- a/tests/integration/mutation/update/field_kinds/one_to_many/with_alias_test.go
+++ b/tests/integration/mutation/update/field_kinds/one_to_many/with_alias_test.go
@@ -25,13 +25,6 @@ func TestMutationUpdateOneToMany_AliasRelationNameToLinkFromSingleSide_Collectio
 
 	test := testUtils.TestCase{
 		Description: "One to many update mutation using relation alias name from single side (wrong)",
-		// This restiction is temporary due to an inconsitent error message, see
-		// TestMutationUpdateOneToMany_AliasRelationNameToLinkFromSingleSide_GQL
-		// and https://github.com/sourcenetwork/defradb/issues/1854 for more info.
-		SupportedMutationTypes: immutable.Some([]testUtils.MutationType{
-			testUtils.CollectionNamedMutationType,
-			testUtils.CollectionSaveMutationType,
-		}),
 		Actions: []any{
 			testUtils.CreateDoc{
 				CollectionID: 1,
@@ -79,12 +72,6 @@ func TestMutationUpdateOneToMany_AliasRelationNameToLinkFromSingleSide_GQL(t *te
 
 	test := testUtils.TestCase{
 		Description: "One to many update mutation using relation alias name from single side (wrong)",
-		// This restiction is temporary due to an inconsitent error message, see
-		// TestMutationUpdateOneToMany_AliasRelationNameToLinkFromSingleSide_Collection
-		// and https://github.com/sourcenetwork/defradb/issues/1854 for more info.
-		SupportedMutationTypes: immutable.Some([]testUtils.MutationType{
-			testUtils.GQLRequestMutationType,
-		}),
 		Actions: []any{
 			testUtils.CreateDoc{
 				CollectionID: 1,
@@ -118,7 +105,7 @@ func TestMutationUpdateOneToMany_AliasRelationNameToLinkFromSingleSide_GQL(t *te
 					}`,
 					bookKey,
 				),
-				ExpectedError: "The given field or alias to field does not exist. Name: published",
+				ExpectedError: "The given field does not exist. Name: published",
 			},
 		},
 	}


### PR DESCRIPTION
## Relevant issue(s)

Resolves https://github.com/sourcenetwork/defradb/issues/1854
TestMutationUpdateOneToMany_AliasRelationNameToLinkFromSingleSide_Collection
TestMutationUpdateOneToMany_AliasRelationNameToLinkFromSingleSide_GQL

Ensure the errors are consistent in these 2 tests.

## Description

Checked the tests are passing and removed comment.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?


Specify the platform(s) on which this was tested:
- MacOS
