### PR TITLE
refactor: Add peerstore to multistore

### DIFF
--- a/client/db.go
+++ b/client/db.go
@@ -51,6 +51,11 @@ type DB interface {
 	// It sits within the rootstore returned by [Root].
 	Blockstore() blockstore.Blockstore
 
+	// Peerstore returns the peerstore where known host information is stored.
+	//
+	// It sits within the rootstore returned by [Root].
+	Peerstore() datastore.DSBatching
+
 	// Close closes the database instance and releases any resources held.
 	//
 	// The behaviour of other functions in this package after this function has been called is undefined

--- a/client/mocks/collection.go
+++ b/client/mocks/collection.go
@@ -164,6 +164,47 @@ func (_c *Collection_CreateMany_Call) RunAndReturn(run func(context.Context, []*
 	return _c
 }
 
+// Definition provides a mock function with given fields:
+func (_m *Collection) Definition() client.CollectionDefinition {
+	ret := _m.Called()
+
+	var r0 client.CollectionDefinition
+	if rf, ok := ret.Get(0).(func() client.CollectionDefinition); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(client.CollectionDefinition)
+	}
+
+	return r0
+}
+
+// Collection_Definition_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Definition'
+type Collection_Definition_Call struct {
+	*mock.Call
+}
+
+// Definition is a helper method to define mock.On call
+func (_e *Collection_Expecter) Definition() *Collection_Definition_Call {
+	return &Collection_Definition_Call{Call: _e.mock.On("Definition")}
+}
+
+func (_c *Collection_Definition_Call) Run(run func()) *Collection_Definition_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *Collection_Definition_Call) Return(_a0 client.CollectionDefinition) *Collection_Definition_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Collection_Definition_Call) RunAndReturn(run func() client.CollectionDefinition) *Collection_Definition_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Delete provides a mock function with given fields: _a0, _a1
 func (_m *Collection) Delete(_a0 context.Context, _a1 client.DocKey) (bool, error) {
 	ret := _m.Called(_a0, _a1)

--- a/client/mocks/db.go
+++ b/client/mocks/db.go
@@ -28,49 +28,6 @@ func (_m *DB) EXPECT() *DB_Expecter {
 	return &DB_Expecter{mock: &_m.Mock}
 }
 
-// AddP2PCollection provides a mock function with given fields: ctx, collectionID
-func (_m *DB) AddP2PCollection(ctx context.Context, collectionID string) error {
-	ret := _m.Called(ctx, collectionID)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
-		r0 = rf(ctx, collectionID)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// DB_AddP2PCollection_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AddP2PCollection'
-type DB_AddP2PCollection_Call struct {
-	*mock.Call
-}
-
-// AddP2PCollection is a helper method to define mock.On call
-//   - ctx context.Context
-//   - collectionID string
-func (_e *DB_Expecter) AddP2PCollection(ctx interface{}, collectionID interface{}) *DB_AddP2PCollection_Call {
-	return &DB_AddP2PCollection_Call{Call: _e.mock.On("AddP2PCollection", ctx, collectionID)}
-}
-
-func (_c *DB_AddP2PCollection_Call) Run(run func(ctx context.Context, collectionID string)) *DB_AddP2PCollection_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string))
-	})
-	return _c
-}
-
-func (_c *DB_AddP2PCollection_Call) Return(_a0 error) *DB_AddP2PCollection_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *DB_AddP2PCollection_Call) RunAndReturn(run func(context.Context, string) error) *DB_AddP2PCollection_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // AddSchema provides a mock function with given fields: _a0, _a1
 func (_m *DB) AddSchema(_a0 context.Context, _a1 string) ([]client.CollectionDescription, error) {
 	ret := _m.Called(_a0, _a1)
@@ -255,9 +212,9 @@ func (_c *DB_Blockstore_Call) RunAndReturn(run func() blockstore.Blockstore) *DB
 	return _c
 }
 
-// Close provides a mock function with given fields: _a0
-func (_m *DB) Close(_a0 context.Context) {
-	_m.Called(_a0)
+// Close provides a mock function with given fields:
+func (_m *DB) Close() {
+	_m.Called()
 }
 
 // DB_Close_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Close'
@@ -266,14 +223,13 @@ type DB_Close_Call struct {
 }
 
 // Close is a helper method to define mock.On call
-//   - _a0 context.Context
-func (_e *DB_Expecter) Close(_a0 interface{}) *DB_Close_Call {
-	return &DB_Close_Call{Call: _e.mock.On("Close", _a0)}
+func (_e *DB_Expecter) Close() *DB_Close_Call {
+	return &DB_Close_Call{Call: _e.mock.On("Close")}
 }
 
-func (_c *DB_Close_Call) Run(run func(_a0 context.Context)) *DB_Close_Call {
+func (_c *DB_Close_Call) Run(run func()) *DB_Close_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context))
+		run()
 	})
 	return _c
 }
@@ -283,50 +239,7 @@ func (_c *DB_Close_Call) Return() *DB_Close_Call {
 	return _c
 }
 
-func (_c *DB_Close_Call) RunAndReturn(run func(context.Context)) *DB_Close_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// DeleteReplicator provides a mock function with given fields: ctx, rep
-func (_m *DB) DeleteReplicator(ctx context.Context, rep client.Replicator) error {
-	ret := _m.Called(ctx, rep)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, client.Replicator) error); ok {
-		r0 = rf(ctx, rep)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// DB_DeleteReplicator_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteReplicator'
-type DB_DeleteReplicator_Call struct {
-	*mock.Call
-}
-
-// DeleteReplicator is a helper method to define mock.On call
-//   - ctx context.Context
-//   - rep client.Replicator
-func (_e *DB_Expecter) DeleteReplicator(ctx interface{}, rep interface{}) *DB_DeleteReplicator_Call {
-	return &DB_DeleteReplicator_Call{Call: _e.mock.On("DeleteReplicator", ctx, rep)}
-}
-
-func (_c *DB_DeleteReplicator_Call) Run(run func(ctx context.Context, rep client.Replicator)) *DB_DeleteReplicator_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(client.Replicator))
-	})
-	return _c
-}
-
-func (_c *DB_DeleteReplicator_Call) Return(_a0 error) *DB_DeleteReplicator_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *DB_DeleteReplicator_Call) RunAndReturn(run func(context.Context, client.Replicator) error) *DB_DeleteReplicator_Call {
+func (_c *DB_Close_Call) RunAndReturn(run func()) *DB_Close_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -521,114 +434,6 @@ func (_c *DB_GetAllIndexes_Call) Return(_a0 map[string][]client.IndexDescription
 }
 
 func (_c *DB_GetAllIndexes_Call) RunAndReturn(run func(context.Context) (map[string][]client.IndexDescription, error)) *DB_GetAllIndexes_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// GetAllP2PCollections provides a mock function with given fields: ctx
-func (_m *DB) GetAllP2PCollections(ctx context.Context) ([]string, error) {
-	ret := _m.Called(ctx)
-
-	var r0 []string
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context) ([]string, error)); ok {
-		return rf(ctx)
-	}
-	if rf, ok := ret.Get(0).(func(context.Context) []string); ok {
-		r0 = rf(ctx)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]string)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
-		r1 = rf(ctx)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// DB_GetAllP2PCollections_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAllP2PCollections'
-type DB_GetAllP2PCollections_Call struct {
-	*mock.Call
-}
-
-// GetAllP2PCollections is a helper method to define mock.On call
-//   - ctx context.Context
-func (_e *DB_Expecter) GetAllP2PCollections(ctx interface{}) *DB_GetAllP2PCollections_Call {
-	return &DB_GetAllP2PCollections_Call{Call: _e.mock.On("GetAllP2PCollections", ctx)}
-}
-
-func (_c *DB_GetAllP2PCollections_Call) Run(run func(ctx context.Context)) *DB_GetAllP2PCollections_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context))
-	})
-	return _c
-}
-
-func (_c *DB_GetAllP2PCollections_Call) Return(_a0 []string, _a1 error) *DB_GetAllP2PCollections_Call {
-	_c.Call.Return(_a0, _a1)
-	return _c
-}
-
-func (_c *DB_GetAllP2PCollections_Call) RunAndReturn(run func(context.Context) ([]string, error)) *DB_GetAllP2PCollections_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// GetAllReplicators provides a mock function with given fields: ctx
-func (_m *DB) GetAllReplicators(ctx context.Context) ([]client.Replicator, error) {
-	ret := _m.Called(ctx)
-
-	var r0 []client.Replicator
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context) ([]client.Replicator, error)); ok {
-		return rf(ctx)
-	}
-	if rf, ok := ret.Get(0).(func(context.Context) []client.Replicator); ok {
-		r0 = rf(ctx)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]client.Replicator)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
-		r1 = rf(ctx)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// DB_GetAllReplicators_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAllReplicators'
-type DB_GetAllReplicators_Call struct {
-	*mock.Call
-}
-
-// GetAllReplicators is a helper method to define mock.On call
-//   - ctx context.Context
-func (_e *DB_Expecter) GetAllReplicators(ctx interface{}) *DB_GetAllReplicators_Call {
-	return &DB_GetAllReplicators_Call{Call: _e.mock.On("GetAllReplicators", ctx)}
-}
-
-func (_c *DB_GetAllReplicators_Call) Run(run func(ctx context.Context)) *DB_GetAllReplicators_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context))
-	})
-	return _c
-}
-
-func (_c *DB_GetAllReplicators_Call) Return(_a0 []client.Replicator, _a1 error) *DB_GetAllReplicators_Call {
-	_c.Call.Return(_a0, _a1)
-	return _c
-}
-
-func (_c *DB_GetAllReplicators_Call) RunAndReturn(run func(context.Context) ([]client.Replicator, error)) *DB_GetAllReplicators_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -1036,6 +841,49 @@ func (_c *DB_PatchSchema_Call) RunAndReturn(run func(context.Context, string, bo
 	return _c
 }
 
+// Peerstore provides a mock function with given fields:
+func (_m *DB) Peerstore() datastore.DSBatching {
+	ret := _m.Called()
+
+	var r0 datastore.DSBatching
+	if rf, ok := ret.Get(0).(func() datastore.DSBatching); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(datastore.DSBatching)
+		}
+	}
+
+	return r0
+}
+
+// DB_Peerstore_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Peerstore'
+type DB_Peerstore_Call struct {
+	*mock.Call
+}
+
+// Peerstore is a helper method to define mock.On call
+func (_e *DB_Expecter) Peerstore() *DB_Peerstore_Call {
+	return &DB_Peerstore_Call{Call: _e.mock.On("Peerstore")}
+}
+
+func (_c *DB_Peerstore_Call) Run(run func()) *DB_Peerstore_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *DB_Peerstore_Call) Return(_a0 datastore.DSBatching) *DB_Peerstore_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *DB_Peerstore_Call) RunAndReturn(run func() datastore.DSBatching) *DB_Peerstore_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // PrintDump provides a mock function with given fields: ctx
 func (_m *DB) PrintDump(ctx context.Context) error {
 	ret := _m.Called(ctx)
@@ -1074,49 +922,6 @@ func (_c *DB_PrintDump_Call) Return(_a0 error) *DB_PrintDump_Call {
 }
 
 func (_c *DB_PrintDump_Call) RunAndReturn(run func(context.Context) error) *DB_PrintDump_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// RemoveP2PCollection provides a mock function with given fields: ctx, collectionID
-func (_m *DB) RemoveP2PCollection(ctx context.Context, collectionID string) error {
-	ret := _m.Called(ctx, collectionID)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
-		r0 = rf(ctx, collectionID)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// DB_RemoveP2PCollection_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RemoveP2PCollection'
-type DB_RemoveP2PCollection_Call struct {
-	*mock.Call
-}
-
-// RemoveP2PCollection is a helper method to define mock.On call
-//   - ctx context.Context
-//   - collectionID string
-func (_e *DB_Expecter) RemoveP2PCollection(ctx interface{}, collectionID interface{}) *DB_RemoveP2PCollection_Call {
-	return &DB_RemoveP2PCollection_Call{Call: _e.mock.On("RemoveP2PCollection", ctx, collectionID)}
-}
-
-func (_c *DB_RemoveP2PCollection_Call) Run(run func(ctx context.Context, collectionID string)) *DB_RemoveP2PCollection_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string))
-	})
-	return _c
-}
-
-func (_c *DB_RemoveP2PCollection_Call) Return(_a0 error) *DB_RemoveP2PCollection_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *DB_RemoveP2PCollection_Call) RunAndReturn(run func(context.Context, string) error) *DB_RemoveP2PCollection_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -1246,49 +1051,6 @@ func (_c *DB_SetMigration_Call) Return(_a0 error) *DB_SetMigration_Call {
 }
 
 func (_c *DB_SetMigration_Call) RunAndReturn(run func(context.Context, client.LensConfig) error) *DB_SetMigration_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// SetReplicator provides a mock function with given fields: ctx, rep
-func (_m *DB) SetReplicator(ctx context.Context, rep client.Replicator) error {
-	ret := _m.Called(ctx, rep)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, client.Replicator) error); ok {
-		r0 = rf(ctx, rep)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// DB_SetReplicator_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetReplicator'
-type DB_SetReplicator_Call struct {
-	*mock.Call
-}
-
-// SetReplicator is a helper method to define mock.On call
-//   - ctx context.Context
-//   - rep client.Replicator
-func (_e *DB_Expecter) SetReplicator(ctx interface{}, rep interface{}) *DB_SetReplicator_Call {
-	return &DB_SetReplicator_Call{Call: _e.mock.On("SetReplicator", ctx, rep)}
-}
-
-func (_c *DB_SetReplicator_Call) Run(run func(ctx context.Context, rep client.Replicator)) *DB_SetReplicator_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(client.Replicator))
-	})
-	return _c
-}
-
-func (_c *DB_SetReplicator_Call) Return(_a0 error) *DB_SetReplicator_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *DB_SetReplicator_Call) RunAndReturn(run func(context.Context, client.Replicator) error) *DB_SetReplicator_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/datastore/concurrent_txn.go
+++ b/datastore/concurrent_txn.go
@@ -49,8 +49,7 @@ func NewConcurrentTxnFrom(ctx context.Context, rootstore ds.TxnDatastore, id uin
 	}
 
 	rootConcurentTxn := &concurrentTxn{Txn: rootTxn}
-	root := AsDSReaderWriter(rootConcurentTxn)
-	multistore := MultiStoreFrom(root)
+	multistore := MultiStoreFrom(rootConcurentTxn)
 	return &txn{
 		rootConcurentTxn,
 		multistore,

--- a/datastore/mocks/txn.go
+++ b/datastore/mocks/txn.go
@@ -366,6 +366,49 @@ func (_c *Txn_OnSuccess_Call) RunAndReturn(run func(func())) *Txn_OnSuccess_Call
 	return _c
 }
 
+// Peerstore provides a mock function with given fields:
+func (_m *Txn) Peerstore() datastore.DSBatching {
+	ret := _m.Called()
+
+	var r0 datastore.DSBatching
+	if rf, ok := ret.Get(0).(func() datastore.DSBatching); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(datastore.DSBatching)
+		}
+	}
+
+	return r0
+}
+
+// Txn_Peerstore_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Peerstore'
+type Txn_Peerstore_Call struct {
+	*mock.Call
+}
+
+// Peerstore is a helper method to define mock.On call
+func (_e *Txn_Expecter) Peerstore() *Txn_Peerstore_Call {
+	return &Txn_Peerstore_Call{Call: _e.mock.On("Peerstore")}
+}
+
+func (_c *Txn_Peerstore_Call) Run(run func()) *Txn_Peerstore_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *Txn_Peerstore_Call) Return(_a0 datastore.DSBatching) *Txn_Peerstore_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Txn_Peerstore_Call) RunAndReturn(run func() datastore.DSBatching) *Txn_Peerstore_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Rootstore provides a mock function with given fields:
 func (_m *Txn) Rootstore() datastore.DSReaderWriter {
 	ret := _m.Called()

--- a/datastore/multi.go
+++ b/datastore/multi.go
@@ -22,6 +22,7 @@ var (
 	dataStoreKey   = rootStoreKey.ChildString("data")
 	headStoreKey   = rootStoreKey.ChildString("heads")
 	blockStoreKey  = rootStoreKey.ChildString("blocks")
+	peerStoreKey   = rootStoreKey.ChildString("ps")
 )
 
 type multistore struct {
@@ -44,7 +45,7 @@ func MultiStoreFrom(rootstore ds.Datastore) MultiStore {
 		data: prefix(rootRW, dataStoreKey),
 		head: prefix(rootRW, headStoreKey),
 		// the `peers` prefix is assigned by the libp2p peerstore
-		peer:   namespace.Wrap(rootstore, rootStoreKey),
+		peer:   namespace.Wrap(rootstore, peerStoreKey),
 		system: prefix(rootRW, systemStoreKey),
 		dag:    NewDAGStore(prefix(rootRW, blockStoreKey)),
 	}

--- a/datastore/multi.go
+++ b/datastore/multi.go
@@ -12,21 +12,23 @@ package datastore
 
 import (
 	ds "github.com/ipfs/go-datastore"
+	"github.com/ipfs/go-datastore/namespace"
 )
 
 var (
 	// Individual Store Keys
-	rootStoreKey   = ds.NewKey("/db")
-	systemStoreKey = rootStoreKey.ChildString("/system")
-	dataStoreKey   = rootStoreKey.ChildString("/data")
-	headStoreKey   = rootStoreKey.ChildString("/heads")
-	blockStoreKey  = rootStoreKey.ChildString("/blocks")
+	rootStoreKey   = ds.NewKey("db")
+	systemStoreKey = rootStoreKey.ChildString("system")
+	dataStoreKey   = rootStoreKey.ChildString("data")
+	headStoreKey   = rootStoreKey.ChildString("heads")
+	blockStoreKey  = rootStoreKey.ChildString("blocks")
 )
 
 type multistore struct {
 	root   DSReaderWriter
 	data   DSReaderWriter
 	head   DSReaderWriter
+	peer   DSBatching
 	system DSReaderWriter
 	// block DSReaderWriter
 	dag DAGStore
@@ -35,14 +37,16 @@ type multistore struct {
 var _ MultiStore = (*multistore)(nil)
 
 // MultiStoreFrom creates a MultiStore from a root datastore.
-func MultiStoreFrom(rootstore DSReaderWriter) MultiStore {
-	block := prefix(rootstore, blockStoreKey)
+func MultiStoreFrom(rootstore ds.Datastore) MultiStore {
+	rootRW := AsDSReaderWriter(rootstore)
 	ms := &multistore{
-		root:   rootstore,
-		data:   prefix(rootstore, dataStoreKey),
-		head:   prefix(rootstore, headStoreKey),
-		system: prefix(rootstore, systemStoreKey),
-		dag:    NewDAGStore(block),
+		root: rootRW,
+		data: prefix(rootRW, dataStoreKey),
+		head: prefix(rootRW, headStoreKey),
+		// the `peers` prefix is assigned by the libp2p peerstore
+		peer:   namespace.Wrap(rootstore, rootStoreKey),
+		system: prefix(rootRW, systemStoreKey),
+		dag:    NewDAGStore(prefix(rootRW, blockStoreKey)),
 	}
 
 	return ms
@@ -56,6 +60,11 @@ func (ms multistore) Datastore() DSReaderWriter {
 // Headstore implements MultiStore.
 func (ms multistore) Headstore() DSReaderWriter {
 	return ms.head
+}
+
+// Peerstore implements MultiStore.
+func (ms multistore) Peerstore() DSBatching {
+	return ms.peer
 }
 
 // DAGstore implements MultiStore.

--- a/datastore/store.go
+++ b/datastore/store.go
@@ -40,6 +40,11 @@ type MultiStore interface {
 	// under the /head namespace
 	Headstore() DSReaderWriter
 
+	// Peerstore is a wrapped root DSReaderWriter
+	// as a ds.Batching, embedded into a DSBatching
+	// under the /peers namespace
+	Peerstore() DSBatching
+
 	// DAGstore is a wrapped root DSReaderWriter
 	// as a Blockstore, embedded into a DAGStore
 	// under the /blocks namespace
@@ -66,4 +71,9 @@ type DSReaderWriter interface {
 // DAGStore proxies the ipld.DAGService under the /core namespace for future-proofing
 type DAGStore interface {
 	blockstore.Blockstore
+}
+
+// DSBatching wraps the Batching interface from go-datastore
+type DSBatching interface {
+	ds.Batching
 }

--- a/datastore/txn.go
+++ b/datastore/txn.go
@@ -66,7 +66,7 @@ func NewTxnFrom(ctx context.Context, rootstore ds.TxnDatastore, id uint64, reado
 		if err != nil {
 			return nil, err
 		}
-		multistore := MultiStoreFrom(rootTxn)
+		multistore := MultiStoreFrom(ShimTxnStore{rootTxn})
 		return &txn{
 			rootTxn,
 			multistore,
@@ -82,8 +82,7 @@ func NewTxnFrom(ctx context.Context, rootstore ds.TxnDatastore, id uint64, reado
 		return nil, err
 	}
 
-	root := AsDSReaderWriter(ShimTxnStore{rootTxn})
-	multistore := MultiStoreFrom(root)
+	multistore := MultiStoreFrom(ShimTxnStore{rootTxn})
 	return &txn{
 		rootTxn,
 		multistore,

--- a/db/db.go
+++ b/db/db.go
@@ -113,8 +113,7 @@ func NewDB(ctx context.Context, rootstore datastore.RootStore, options ...Option
 
 func newDB(ctx context.Context, rootstore datastore.RootStore, options ...Option) (*implicitTxnDB, error) {
 	log.Debug(ctx, "Loading: internal datastores")
-	root := datastore.AsDSReaderWriter(rootstore)
-	multistore := datastore.MultiStoreFrom(root)
+	multistore := datastore.MultiStoreFrom(rootstore)
 	crdtFactory := crdt.DefaultFactory.WithStores(multistore)
 
 	parser, err := graphql.NewParser()
@@ -181,6 +180,11 @@ func (db *db) Root() datastore.RootStore {
 // Blockstore returns the internal DAG store which contains IPLD blocks.
 func (db *db) Blockstore() blockstore.Blockstore {
 	return db.multistore.DAGstore()
+}
+
+// Peerstore returns the internal DAG store which contains IPLD blocks.
+func (db *db) Peerstore() datastore.DSBatching {
+	return db.multistore.Peerstore()
 }
 
 func (db *db) LensRegistry() client.LensRegistry {

--- a/http/client.go
+++ b/http/client.go
@@ -349,6 +349,10 @@ func (c *Client) Blockstore() blockstore.Blockstore {
 	panic("client side database")
 }
 
+func (c *Client) Peerstore() datastore.DSBatching {
+	panic("client side database")
+}
+
 func (c *Client) Events() events.Events {
 	panic("client side database")
 }

--- a/http/client_tx.go
+++ b/http/client_tx.go
@@ -83,6 +83,10 @@ func (c *Transaction) Headstore() datastore.DSReaderWriter {
 	panic("client side transaction")
 }
 
+func (c *Transaction) Peerstore() datastore.DSBatching {
+	panic("client side transaction")
+}
+
 func (c *Transaction) DAGstore() datastore.DAGStore {
 	panic("client side transaction")
 }

--- a/merkle/clock/clock_test.go
+++ b/merkle/clock/clock_test.go
@@ -30,17 +30,15 @@ func newDS() ds.Datastore {
 func newTestMerkleClock() *MerkleClock {
 	s := newDS()
 
-	rw := datastore.AsDSReaderWriter(s)
-	multistore := datastore.MultiStoreFrom(rw)
-	reg := crdt.NewLWWRegister(rw, core.CollectionSchemaVersionKey{}, core.DataStoreKey{}, "")
+	multistore := datastore.MultiStoreFrom(s)
+	reg := crdt.NewLWWRegister(multistore.Rootstore(), core.CollectionSchemaVersionKey{}, core.DataStoreKey{}, "")
 	return NewMerkleClock(multistore.Headstore(), multistore.DAGstore(), core.HeadStoreKey{DocKey: "dockey", FieldId: "1"}, reg).(*MerkleClock)
 }
 
 func TestNewMerkleClock(t *testing.T) {
 	s := newDS()
-	rw := datastore.AsDSReaderWriter(s)
-	multistore := datastore.MultiStoreFrom(rw)
-	reg := crdt.NewLWWRegister(rw, core.CollectionSchemaVersionKey{}, core.DataStoreKey{}, "")
+	multistore := datastore.MultiStoreFrom(s)
+	reg := crdt.NewLWWRegister(multistore.Rootstore(), core.CollectionSchemaVersionKey{}, core.DataStoreKey{}, "")
 	clk := NewMerkleClock(multistore.Headstore(), multistore.DAGstore(), core.HeadStoreKey{}, reg).(*MerkleClock)
 
 	if clk.headstore != multistore.Headstore() {

--- a/merkle/crdt/factory.go
+++ b/merkle/crdt/factory.go
@@ -137,6 +137,14 @@ func (factory Factory) Headstore() datastore.DSReaderWriter {
 	return factory.multistore.Headstore()
 }
 
+// Peerstore implements datastore.MultiStore and returns the current Peerstore.
+func (factory Factory) Peerstore() datastore.DSBatching {
+	if factory.multistore == nil {
+		return nil
+	}
+	return factory.multistore.Peerstore()
+}
+
 // Head implements datastore.MultiStore and returns the current Headstore.
 func (factory Factory) Systemstore() datastore.DSReaderWriter {
 	if factory.multistore == nil {

--- a/merkle/crdt/factory_test.go
+++ b/merkle/crdt/factory_test.go
@@ -25,8 +25,7 @@ import (
 
 func newStores() datastore.MultiStore {
 	root := ds.NewMapDatastore()
-	rw := datastore.AsDSReaderWriter(root)
-	return datastore.MultiStoreFrom(rw)
+	return datastore.MultiStoreFrom(root)
 }
 
 func TestNewBlankFactory(t *testing.T) {

--- a/merkle/crdt/merklecrdt_test.go
+++ b/merkle/crdt/merklecrdt_test.go
@@ -31,12 +31,11 @@ func newDS() ds.Datastore {
 
 func newTestBaseMerkleCRDT() (*baseMerkleCRDT, datastore.DSReaderWriter) {
 	s := newDS()
-	rw := datastore.AsDSReaderWriter(s)
-	multistore := datastore.MultiStoreFrom(rw)
+	multistore := datastore.MultiStoreFrom(s)
 
 	reg := corecrdt.NewLWWRegister(multistore.Datastore(), core.CollectionSchemaVersionKey{}, core.DataStoreKey{}, "")
 	clk := clock.NewMerkleClock(multistore.Headstore(), multistore.DAGstore(), core.HeadStoreKey{}, reg)
-	return &baseMerkleCRDT{clock: clk, crdt: reg}, rw
+	return &baseMerkleCRDT{clock: clk, crdt: reg}, multistore.Rootstore()
 }
 
 func TestMerkleCRDTPublish(t *testing.T) {

--- a/net/node.go
+++ b/net/node.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/ipfs/boxo/ipns"
 	ds "github.com/ipfs/go-datastore"
-	"github.com/ipfs/go-datastore/namespace"
 	libp2p "github.com/libp2p/go-libp2p"
 	dht "github.com/libp2p/go-libp2p-kad-dht"
 	dualdht "github.com/libp2p/go-libp2p-kad-dht/dual"
@@ -86,11 +85,7 @@ func NewNode(
 
 	fin := finalizer.NewFinalizer()
 
-	// create our peerstore from the underlying defra rootstore
-	// prefixed with "p2p"
-	rootstore := db.Root()
-	pstore := namespace.Wrap(rootstore, ds.NewKey("/db"))
-	peerstore, err := pstoreds.NewPeerstore(ctx, pstore, pstoreds.DefaultOpts())
+	peerstore, err := pstoreds.NewPeerstore(ctx, db.Peerstore(), pstoreds.DefaultOpts())
 	if err != nil {
 		return nil, fin.Cleanup(err)
 	}
@@ -121,7 +116,7 @@ func NewNode(
 			// if dsb, isBatching := rootstore.(ds.Batching); isBatching {
 			// 	store = dsb
 			// }
-			store := rootstore // Delete this line once we remove batchable datastore support.
+			store := db.Root() // Delete this line once we remove batchable datastore support.
 			ddht, err = newDHT(ctx, h, store)
 			return ddht, err
 		}),

--- a/tests/bench/query/planner/utils.go
+++ b/tests/bench/query/planner/utils.go
@@ -127,6 +127,7 @@ type dummyTxn struct{}
 func (*dummyTxn) Rootstore() datastore.DSReaderWriter   { return nil }
 func (*dummyTxn) Datastore() datastore.DSReaderWriter   { return nil }
 func (*dummyTxn) Headstore() datastore.DSReaderWriter   { return nil }
+func (*dummyTxn) Peerstore() datastore.DSBatching       { return nil }
 func (*dummyTxn) DAGstore() datastore.DAGStore          { return nil }
 func (*dummyTxn) Systemstore() datastore.DSReaderWriter { return nil }
 func (*dummyTxn) Commit(ctx context.Context) error      { return nil }

--- a/tests/clients/cli/wrapper.go
+++ b/tests/clients/cli/wrapper.go
@@ -417,6 +417,10 @@ func (w *Wrapper) Blockstore() blockstore.Blockstore {
 	return w.node.Blockstore()
 }
 
+func (w *Wrapper) Peerstore() datastore.DSBatching {
+	return w.node.Peerstore()
+}
+
 func (w *Wrapper) Close() {
 	w.httpServer.CloseClientConnections()
 	w.httpServer.Close()

--- a/tests/clients/cli/wrapper_tx.go
+++ b/tests/clients/cli/wrapper_tx.go
@@ -67,6 +67,10 @@ func (w *Transaction) Headstore() datastore.DSReaderWriter {
 	return w.tx.Headstore()
 }
 
+func (w *Transaction) Peerstore() datastore.DSBatching {
+	return w.tx.Peerstore()
+}
+
 func (w *Transaction) DAGstore() datastore.DAGStore {
 	return w.tx.DAGstore()
 }

--- a/tests/clients/http/wrapper.go
+++ b/tests/clients/http/wrapper.go
@@ -171,6 +171,10 @@ func (w *Wrapper) Blockstore() blockstore.Blockstore {
 	return w.node.Blockstore()
 }
 
+func (w *Wrapper) Peerstore() datastore.DSBatching {
+	return w.node.Peerstore()
+}
+
 func (w *Wrapper) Close() {
 	w.httpServer.CloseClientConnections()
 	w.httpServer.Close()

--- a/tests/clients/http/wrapper_tx.go
+++ b/tests/clients/http/wrapper_tx.go
@@ -61,6 +61,10 @@ func (w *TxWrapper) Headstore() datastore.DSReaderWriter {
 	return w.server.Headstore()
 }
 
+func (w *TxWrapper) Peerstore() datastore.DSBatching {
+	return w.server.Peerstore()
+}
+
 func (w *TxWrapper) DAGstore() datastore.DAGStore {
 	return w.server.DAGstore()
 }


### PR DESCRIPTION
## Relevant issue(s)

Resolves #1680

## Description

This small refactor adds the `peerstore` to the `multistore`. In doing so, we broaden the types of stores that can be part of the `multistore` by starting from a `ds.Datastore` instead of the more restrictive `DSReaderWriter`

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

make test showed no change in behaviour.

Specify the platform(s) on which this was tested:
- MacOS
