### PR TITLE
fix: Make return type for FieldKind_INT an int64

### DIFF
--- a/core/encoding.go
+++ b/core/encoding.go
@@ -109,9 +109,14 @@ func DecodeFieldValue(fieldDesc client.FieldDescription, val any) (any, error) {
 		case client.FieldKind_INT:
 			switch v := val.(type) {
 			case float64:
-				if v >= 0 {
-					return uint64(v), nil
-				}
+				return int64(v), nil
+			case int64:
+				return int64(v), nil
+			case int:
+				return int64(v), nil
+			case uint64:
+				return int64(v), nil
+			case uint:
 				return int64(v), nil
 			}
 		}

--- a/datastore/multi.go
+++ b/datastore/multi.go
@@ -41,10 +41,9 @@ var _ MultiStore = (*multistore)(nil)
 func MultiStoreFrom(rootstore ds.Datastore) MultiStore {
 	rootRW := AsDSReaderWriter(rootstore)
 	ms := &multistore{
-		root: rootRW,
-		data: prefix(rootRW, dataStoreKey),
-		head: prefix(rootRW, headStoreKey),
-		// the `peers` prefix is assigned by the libp2p peerstore
+		root:   rootRW,
+		data:   prefix(rootRW, dataStoreKey),
+		head:   prefix(rootRW, headStoreKey),
 		peer:   namespace.Wrap(rootstore, peerStoreKey),
 		system: prefix(rootRW, systemStoreKey),
 		dag:    NewDAGStore(prefix(rootRW, blockStoreKey)),

--- a/db/backup.go
+++ b/db/backup.go
@@ -250,9 +250,6 @@ func (db *db) basicExport(ctx context.Context, txn datastore.Txn, config *client
 									return err
 								}
 
-								// Temporary until https://github.com/sourcenetwork/defradb/issues/1681 is resolved.
-								ensureIntIsInt(foreignCol.Schema().Fields, oldForeignDoc)
-
 								delete(oldForeignDoc, "_key")
 								if foreignDoc.Key().String() == foreignDocKey.String() {
 									delete(oldForeignDoc, field.Name+request.RelatedObjectID)
@@ -288,9 +285,6 @@ func (db *db) basicExport(ctx context.Context, txn datastore.Txn, config *client
 			if err != nil {
 				return err
 			}
-
-			// Temporary until https://github.com/sourcenetwork/defradb/issues/1681 is resolved.
-			ensureIntIsInt(col.Schema().Fields, docM)
 
 			delete(docM, "_key")
 			if isSelfReference {
@@ -373,20 +367,4 @@ func writeString(f *os.File, normal, pretty string, isPretty bool) error {
 		return NewErrFailedToWriteString(err)
 	}
 	return nil
-}
-
-// Temporary until https://github.com/sourcenetwork/defradb/issues/1681 is resolved.
-func ensureIntIsInt(fields []client.FieldDescription, docMap map[string]any) {
-	for _, field := range fields {
-		if field.Kind == client.FieldKind_INT {
-			if val, ok := docMap[field.Name]; ok {
-				switch v := val.(type) {
-				case uint64:
-					docMap[field.Name] = int(v)
-				case int64:
-					docMap[field.Name] = int(v)
-				}
-			}
-		}
-	}
 }

--- a/db/errors.go
+++ b/db/errors.go
@@ -66,6 +66,7 @@ const (
 	errCanNotDropIndexWithPatch           string = "dropping indexes via patch is not supported"
 	errCanNotChangeIndexWithPatch         string = "changing indexes via patch is not supported"
 	errIndexWithNameDoesNotExists         string = "index with name doesn't exists"
+	errCorruptedIndex                     string = "corrupted index. Please delete and recreate the index"
 	errInvalidFieldValue                  string = "invalid field value"
 	errUnsupportedIndexFieldType          string = "unsupported index field type"
 	errIndexDescriptionHasNoFields        string = "index description has no fields"
@@ -147,6 +148,7 @@ var (
 	ErrIndexFieldMissingName              = errors.New(errIndexFieldMissingName)
 	ErrIndexFieldMissingDirection         = errors.New(errIndexFieldMissingDirection)
 	ErrIndexSingleFieldWrongDirection     = errors.New(errIndexSingleFieldWrongDirection)
+	ErrCorruptedIndex                     = errors.New(errCorruptedIndex)
 	ErrCanNotChangeIndexWithPatch         = errors.New(errCanNotChangeIndexWithPatch)
 	ErrFieldOrAliasToFieldNotExist        = errors.New(errFieldOrAliasToFieldNotExist)
 	ErrCreateFile                         = errors.New(errCreateFile)
@@ -474,6 +476,15 @@ func NewErrIndexWithNameAlreadyExists(indexName string) error {
 func NewErrIndexWithNameDoesNotExists(indexName string) error {
 	return errors.New(
 		errIndexWithNameDoesNotExists,
+		errors.NewKV("Name", indexName),
+	)
+}
+
+// NewErrCorruptedIndex returns a new error indicating that an index with the
+// given name has been corrupted.
+func NewErrCorruptedIndex(indexName string) error {
+	return errors.New(
+		errCorruptedIndex,
 		errors.NewKV("Name", indexName),
 	)
 }

--- a/db/index.go
+++ b/db/index.go
@@ -166,6 +166,13 @@ func (i *collectionSimpleIndex) Update(
 	if err != nil {
 		return err
 	}
+	exists, err := txn.Datastore().Has(ctx, key.ToDS())
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return NewErrCorruptedIndex(i.desc.Name)
+	}
 	err = txn.Datastore().Delete(ctx, key.ToDS())
 	if err != nil {
 		return err

--- a/db/indexed_docs_test.go
+++ b/db/indexed_docs_test.go
@@ -883,6 +883,7 @@ func TestNonUniqueUpdate_IfDatastoreFails_ReturnError(t *testing.T) {
 			Name: "Delete old value",
 			StubDataStore: func(ds *mocks.DSReaderWriter_Expecter) {
 				ds.Delete(mock.Anything, mock.Anything).Return(testErr)
+				ds.Has(mock.Anything, mock.Anything).Maybe().Return(true, nil)
 				ds.Get(mock.Anything, mock.Anything).Maybe().Return([]byte{}, nil)
 			},
 		},
@@ -891,6 +892,7 @@ func TestNonUniqueUpdate_IfDatastoreFails_ReturnError(t *testing.T) {
 			StubDataStore: func(ds *mocks.DSReaderWriter_Expecter) {
 				ds.Delete(mock.Anything, mock.Anything).Maybe().Return(nil)
 				ds.Get(mock.Anything, mock.Anything).Maybe().Return([]byte{}, nil)
+				ds.Has(mock.Anything, mock.Anything).Maybe().Return(true, nil)
 				ds.Put(mock.Anything, mock.Anything, mock.Anything).Maybe().Return(testErr)
 			},
 		},

--- a/db/indexed_docs_test.go
+++ b/db/indexed_docs_test.go
@@ -828,19 +828,14 @@ func TestNonUniqueUpdate_IfFailsToUpdateIndex_ReturnError(t *testing.T) {
 	f.commitTxn()
 
 	validKey := newIndexKeyBuilder(f).Col(usersColName).Field(usersAgeFieldName).Doc(doc).Build()
-	invalidKey := newIndexKeyBuilder(f).Col(usersColName).Field(usersAgeFieldName).Doc(doc).
-		Values([]byte("invalid")).Build()
-
 	err := f.txn.Datastore().Delete(f.ctx, validKey.ToDS())
-	require.NoError(f.t, err)
-	err = f.txn.Datastore().Put(f.ctx, invalidKey.ToDS(), []byte{})
 	require.NoError(f.t, err)
 	f.commitTxn()
 
 	err = doc.Set(usersAgeFieldName, 23)
 	require.NoError(t, err)
 	err = f.users.Update(f.ctx, doc)
-	require.Error(t, err)
+	require.ErrorIs(t, err, ErrCorruptedIndex)
 }
 
 func TestNonUniqueUpdate_ShouldPassToFetcherOnlyRelevantFields(t *testing.T) {

--- a/tests/integration/backup/one_to_many/import_test.go
+++ b/tests/integration/backup/one_to_many/import_test.go
@@ -43,15 +43,15 @@ func TestBackupImport_WithMultipleNoKeyAndMultipleCollections_NoError(t *testing
 				Results: []map[string]any{
 					{
 						"name": "Smith",
-						"age":  uint64(31),
+						"age":  int64(31),
 					},
 					{
 						"name": "Bob",
-						"age":  uint64(32),
+						"age":  int64(32),
 					},
 					{
 						"name": "John",
-						"age":  uint64(30),
+						"age":  int64(30),
 					},
 				},
 			},
@@ -123,11 +123,11 @@ func TestBackupImport_WithMultipleNoKeyAndMultipleCollectionsAndUpdatedDocs_NoEr
 				Results: []map[string]any{
 					{
 						"name": "Bob",
-						"age":  uint64(31),
+						"age":  int64(31),
 					},
 					{
 						"name": "John",
-						"age":  uint64(31),
+						"age":  int64(31),
 					},
 				},
 			},

--- a/tests/integration/backup/one_to_one/import_test.go
+++ b/tests/integration/backup/one_to_one/import_test.go
@@ -43,15 +43,15 @@ func TestBackupImport_WithMultipleNoKeyAndMultipleCollections_NoError(t *testing
 				Results: []map[string]any{
 					{
 						"name": "Smith",
-						"age":  uint64(31),
+						"age":  int64(31),
 					},
 					{
 						"name": "Bob",
-						"age":  uint64(32),
+						"age":  int64(32),
 					},
 					{
 						"name": "John",
-						"age":  uint64(30),
+						"age":  int64(30),
 					},
 				},
 			},
@@ -117,11 +117,11 @@ func TestBackupImport_WithMultipleNoKeyAndMultipleCollectionsAndUpdatedDocs_NoEr
 				Results: []map[string]any{
 					{
 						"name": "Bob",
-						"age":  uint64(31),
+						"age":  int64(31),
 					},
 					{
 						"name": "John",
-						"age":  uint64(31),
+						"age":  int64(31),
 					},
 				},
 			},

--- a/tests/integration/backup/simple/import_test.go
+++ b/tests/integration/backup/simple/import_test.go
@@ -33,7 +33,7 @@ func TestBackupImport_Simple_NoError(t *testing.T) {
 				Results: []map[string]any{
 					{
 						"name": "John",
-						"age":  uint64(30),
+						"age":  int64(30),
 					},
 				},
 			},
@@ -103,7 +103,7 @@ func TestBackupImport_WithNoKeys_NoError(t *testing.T) {
 				Results: []map[string]any{
 					{
 						"name": "John",
-						"age":  uint64(30),
+						"age":  int64(30),
 					},
 				},
 			},
@@ -134,15 +134,15 @@ func TestBackupImport_WithMultipleNoKeys_NoError(t *testing.T) {
 				Results: []map[string]any{
 					{
 						"name": "Smith",
-						"age":  uint64(31),
+						"age":  int64(31),
 					},
 					{
 						"name": "Bob",
-						"age":  uint64(32),
+						"age":  int64(32),
 					},
 					{
 						"name": "John",
-						"age":  uint64(30),
+						"age":  int64(30),
 					},
 				},
 			},

--- a/tests/integration/collection/update/simple/with_keys_test.go
+++ b/tests/integration/collection/update/simple/with_keys_test.go
@@ -160,7 +160,7 @@ func TestUpdateWithKeys(t *testing.T) {
 							return err
 						}
 
-						assert.Equal(t, uint64(40), name)
+						assert.Equal(t, int64(40), name)
 
 						d2, err := c.Get(ctx, doc2.Key(), false)
 						if err != nil {
@@ -172,7 +172,7 @@ func TestUpdateWithKeys(t *testing.T) {
 							return err
 						}
 
-						assert.Equal(t, uint64(40), name2)
+						assert.Equal(t, int64(40), name2)
 
 						return nil
 					},

--- a/tests/integration/index/create_drop_test.go
+++ b/tests/integration/index/create_drop_test.go
@@ -52,7 +52,7 @@ func TestIndexDrop_ShouldNotHinderQuerying(t *testing.T) {
 				Results: []map[string]any{
 					{
 						"Name": "John",
-						"Age":  uint64(21),
+						"Age":  int64(21),
 					},
 				},
 			},

--- a/tests/integration/index/create_test.go
+++ b/tests/integration/index/create_test.go
@@ -49,7 +49,7 @@ func TestIndexCreateWithCollection_ShouldNotHinderQuerying(t *testing.T) {
 				Results: []map[string]any{
 					{
 						"Name": "John",
-						"Age":  uint64(21),
+						"Age":  int64(21),
 					},
 				},
 			},
@@ -96,7 +96,7 @@ func TestIndexCreate_ShouldNotHinderQuerying(t *testing.T) {
 				Results: []map[string]any{
 					{
 						"Name": "John",
-						"Age":  uint64(21),
+						"Age":  int64(21),
 					},
 				},
 			},

--- a/tests/integration/index/drop_test.go
+++ b/tests/integration/index/drop_test.go
@@ -53,7 +53,7 @@ func TestIndexDrop_IfIndexDoesNotExist_ReturnError(t *testing.T) {
 				Results: []map[string]any{
 					{
 						"Name": "John",
-						"Age":  uint64(21),
+						"Age":  int64(21),
 					},
 				},
 			},

--- a/tests/integration/index/query_with_index_only_filter_test.go
+++ b/tests/integration/index/query_with_index_only_filter_test.go
@@ -36,7 +36,7 @@ func TestQueryWithIndex_WithNonIndexedFields_ShouldFetchAllOfThem(t *testing.T) 
 				Request: req,
 				Results: []map[string]any{{
 					"name": "Islam",
-					"age":  uint64(32),
+					"age":  int64(32),
 				}},
 			},
 			testUtils.Request{
@@ -104,8 +104,8 @@ func TestQueryWithIndex_IfSeveralDocsWithEqFilter_ShouldFetchAll(t *testing.T) {
 			testUtils.Request{
 				Request: req,
 				Results: []map[string]any{
-					{"age": uint64(32)},
-					{"age": uint64(18)},
+					{"age": int64(32)},
+					{"age": int64(18)},
 				},
 			},
 			testUtils.Request{
@@ -340,8 +340,8 @@ func TestQueryWithIndex_IfSeveralDocsWithInFilter_ShouldFetchAll(t *testing.T) {
 			testUtils.Request{
 				Request: req,
 				Results: []map[string]any{
-					{"age": uint64(32)},
-					{"age": uint64(18)},
+					{"age": int64(32)},
+					{"age": int64(18)},
 				},
 			},
 			testUtils.Request{

--- a/tests/integration/mutation/create/simple_test.go
+++ b/tests/integration/mutation/create/simple_test.go
@@ -85,7 +85,7 @@ func TestMutationCreate(t *testing.T) {
 					{
 						"_key": "bae-88b63198-7d38-5714-a9ff-21ba46374fd1",
 						"name": "John",
-						"age":  uint64(27),
+						"age":  int64(27),
 					},
 				},
 			},

--- a/tests/integration/mutation/delete/field_kinds/one_to_many/with_show_deleted_test.go
+++ b/tests/integration/mutation/delete/field_kinds/one_to_many/with_show_deleted_test.go
@@ -102,7 +102,7 @@ func TestDeletionOfADocumentUsingSingleKeyWithShowDeletedDocumentQuery(t *testin
 					{
 						"_deleted": false,
 						"name":     "John",
-						"age":      uint64(30),
+						"age":      int64(30),
 						"published": []map[string]any{
 							{
 								"_deleted": true,

--- a/tests/integration/mutation/delete/with_filter_test.go
+++ b/tests/integration/mutation/delete/with_filter_test.go
@@ -88,10 +88,10 @@ func TestMutationDeletion_WithFilterMatchingMultipleDocs(t *testing.T) {
 				}`,
 				Results: []map[string]any{
 					{
-						"age": uint64(2),
+						"age": int64(2),
 					},
 					{
-						"age": uint64(1),
+						"age": int64(1),
 					},
 				},
 			},

--- a/tests/integration/mutation/mix/with_txn_test.go
+++ b/tests/integration/mutation/mix/with_txn_test.go
@@ -109,7 +109,7 @@ func TestMutationWithTxnDoesNotDeletesUserGivenDifferentTransactions(t *testing.
 					{
 						"_key": "bae-88b63198-7d38-5714-a9ff-21ba46374fd1",
 						"name": "John",
-						"age":  uint64(27),
+						"age":  int64(27),
 					},
 				},
 			},
@@ -174,7 +174,7 @@ func TestMutationWithTxnDoesUpdateUserGivenSameTransactions(t *testing.T) {
 					{
 						"_key": "bae-88b63198-7d38-5714-a9ff-21ba46374fd1",
 						"name": "John",
-						"age":  uint64(28),
+						"age":  int64(28),
 					},
 				},
 			},
@@ -215,7 +215,7 @@ func TestMutationWithTxnDoesNotUpdateUserGivenDifferentTransactions(t *testing.T
 					{
 						"_key": "bae-88b63198-7d38-5714-a9ff-21ba46374fd1",
 						"name": "John",
-						"age":  uint64(28),
+						"age":  int64(28),
 					},
 				},
 			},
@@ -232,7 +232,7 @@ func TestMutationWithTxnDoesNotUpdateUserGivenDifferentTransactions(t *testing.T
 					{
 						"_key": "bae-88b63198-7d38-5714-a9ff-21ba46374fd1",
 						"name": "John",
-						"age":  uint64(27),
+						"age":  int64(27),
 					},
 				},
 			},
@@ -274,7 +274,7 @@ func TestMutationWithTxnDoesNotAllowUpdateInSecondTransactionUser(t *testing.T) 
 					{
 						"_key": "bae-88b63198-7d38-5714-a9ff-21ba46374fd1",
 						"name": "John",
-						"age":  uint64(28),
+						"age":  int64(28),
 					},
 				},
 			},
@@ -291,7 +291,7 @@ func TestMutationWithTxnDoesNotAllowUpdateInSecondTransactionUser(t *testing.T) 
 					{
 						"_key": "bae-88b63198-7d38-5714-a9ff-21ba46374fd1",
 						"name": "John",
-						"age":  uint64(29),
+						"age":  int64(29),
 					},
 				},
 			},
@@ -315,7 +315,7 @@ func TestMutationWithTxnDoesNotAllowUpdateInSecondTransactionUser(t *testing.T) 
 					{
 						"_key": "bae-88b63198-7d38-5714-a9ff-21ba46374fd1",
 						"name": "John",
-						"age":  uint64(28),
+						"age":  int64(28),
 					},
 				},
 			},

--- a/tests/integration/net/order/tcp_test.go
+++ b/tests/integration/net/order/tcp_test.go
@@ -56,12 +56,12 @@ func TestP2PWithSingleDocumentUpdatePerNode(t *testing.T) {
 		Results: map[int]map[int]map[string]any{
 			0: {
 				0: {
-					"Age": uint64(45),
+					"Age": int64(45),
 				},
 			},
 			1: {
 				0: {
-					"Age": uint64(60),
+					"Age": int64(60),
 				},
 			},
 		},
@@ -119,12 +119,12 @@ func TestP2PWithMultipleDocumentUpdatesPerNode(t *testing.T) {
 		Results: map[int]map[int]map[string]any{
 			0: {
 				0: {
-					"Age": uint64(47),
+					"Age": int64(47),
 				},
 			},
 			1: {
 				0: {
-					"Age": uint64(62),
+					"Age": int64(62),
 				},
 			},
 		},
@@ -157,7 +157,7 @@ func TestP2FullPReplicator(t *testing.T) {
 		ReplicatorResult: map[int]map[string]map[string]any{
 			1: {
 				doc.Key().String(): {
-					"Age": uint64(21),
+					"Age": int64(21),
 				},
 			},
 		},

--- a/tests/integration/net/state/simple/peer/with_create_test.go
+++ b/tests/integration/net/state/simple/peer/with_create_test.go
@@ -59,10 +59,10 @@ func TestP2PCreateDoesNotSync(t *testing.T) {
 				}`,
 				Results: []map[string]any{
 					{
-						"Age": uint64(21),
+						"Age": int64(21),
 					},
 					{
-						"Age": uint64(300),
+						"Age": int64(300),
 					},
 				},
 			},
@@ -75,7 +75,7 @@ func TestP2PCreateDoesNotSync(t *testing.T) {
 				}`,
 				Results: []map[string]any{
 					{
-						"Age": uint64(300),
+						"Age": int64(300),
 					},
 					// Peer sync should not sync new documents to nodes
 				},
@@ -147,13 +147,13 @@ func TestP2PCreateWithP2PCollection(t *testing.T) {
 				}`,
 				Results: []map[string]any{
 					{
-						"Age": uint64(21),
+						"Age": int64(21),
 					},
 					{
-						"Age": uint64(30),
+						"Age": int64(30),
 					},
 					{
-						"Age": uint64(28),
+						"Age": int64(28),
 					},
 					// Peer sync should not sync new documents to nodes that is not subscribed
 					// to the P2P collection.
@@ -168,16 +168,16 @@ func TestP2PCreateWithP2PCollection(t *testing.T) {
 				}`,
 				Results: []map[string]any{
 					{
-						"Age": uint64(21),
+						"Age": int64(21),
 					},
 					{
-						"Age": uint64(31),
+						"Age": int64(31),
 					},
 					{
-						"Age": uint64(30),
+						"Age": int64(30),
 					},
 					{
-						"Age": uint64(28),
+						"Age": int64(28),
 					},
 				},
 			},

--- a/tests/integration/net/state/simple/peer/with_delete_test.go
+++ b/tests/integration/net/state/simple/peer/with_delete_test.go
@@ -68,7 +68,7 @@ func TestP2PWithMultipleDocumentsSingleDelete(t *testing.T) {
 					{
 						"_deleted": false,
 						"Name":     "Andy",
-						"Age":      uint64(74),
+						"Age":      int64(74),
 					},
 				},
 			},
@@ -126,12 +126,12 @@ func TestP2PWithMultipleDocumentsSingleDeleteWithShowDeleted(t *testing.T) {
 					{
 						"_deleted": false,
 						"Name":     "Andy",
-						"Age":      uint64(74),
+						"Age":      int64(74),
 					},
 					{
 						"_deleted": true,
 						"Name":     "John",
-						"Age":      uint64(43),
+						"Age":      int64(43),
 					},
 				},
 			},
@@ -198,12 +198,12 @@ func TestP2PWithMultipleDocumentsWithSingleUpdateBeforeConnectSingleDeleteWithSh
 					{
 						"_deleted": false,
 						"Name":     "Andy",
-						"Age":      uint64(74),
+						"Age":      int64(74),
 					},
 					{
 						"_deleted": true,
 						"Name":     "John",
-						"Age":      uint64(60),
+						"Age":      int64(60),
 					},
 				},
 			},
@@ -279,12 +279,12 @@ func TestP2PWithMultipleDocumentsWithMultipleUpdatesBeforeConnectSingleDeleteWit
 					{
 						"_deleted": false,
 						"Name":     "Andy",
-						"Age":      uint64(74),
+						"Age":      int64(74),
 					},
 					{
 						"_deleted": true,
 						"Name":     "John",
-						"Age":      uint64(62),
+						"Age":      int64(62),
 					},
 				},
 			},
@@ -370,12 +370,12 @@ func TestP2PWithMultipleDocumentsWithUpdateAndDeleteBeforeConnectSingleDeleteWit
 					{
 						"_deleted": false,
 						"Name":     "Andy",
-						"Age":      uint64(74),
+						"Age":      int64(74),
 					},
 					{
 						"_deleted": true,
 						"Name":     "John",
-						"Age":      uint64(62),
+						"Age":      int64(62),
 					},
 				},
 			},
@@ -394,12 +394,12 @@ func TestP2PWithMultipleDocumentsWithUpdateAndDeleteBeforeConnectSingleDeleteWit
 					{
 						"_deleted": false,
 						"Name":     "Andy",
-						"Age":      uint64(74),
+						"Age":      int64(74),
 					},
 					{
 						"_deleted": false,
 						"Name":     "John",
-						"Age":      uint64(66),
+						"Age":      int64(66),
 					},
 				},
 			},

--- a/tests/integration/net/state/simple/peer/with_update_restart_test.go
+++ b/tests/integration/net/state/simple/peer/with_update_restart_test.go
@@ -59,7 +59,7 @@ func TestP2PWithSingleDocumentSingleUpdateFromChildAndRestart(t *testing.T) {
 				}`,
 				Results: []map[string]any{
 					{
-						"Age": uint64(60),
+						"Age": int64(60),
 					},
 				},
 			},

--- a/tests/integration/net/state/simple/peer/with_update_test.go
+++ b/tests/integration/net/state/simple/peer/with_update_test.go
@@ -60,7 +60,7 @@ func TestP2PWithSingleDocumentSingleUpdateFromChild(t *testing.T) {
 				}`,
 				Results: []map[string]any{
 					{
-						"Age": uint64(60),
+						"Age": int64(60),
 					},
 				},
 			},
@@ -112,7 +112,7 @@ func TestP2PWithSingleDocumentSingleUpdateFromParent(t *testing.T) {
 				}`,
 				Results: []map[string]any{
 					{
-						"Age": uint64(60),
+						"Age": int64(60),
 					},
 				},
 			},
@@ -170,7 +170,7 @@ func TestP2PWithSingleDocumentUpdatePerNode(t *testing.T) {
 				}`,
 				Results: []map[string]any{
 					{
-						"Age": testUtils.AnyOf{uint64(45), uint64(60)},
+						"Age": testUtils.AnyOf{int64(45), int64(60)},
 					},
 				},
 			},
@@ -223,7 +223,7 @@ func TestP2PWithSingleDocumentSingleUpdateDoesNotSyncToNonPeerNode(t *testing.T)
 				}`,
 				Results: []map[string]any{
 					{
-						"Age": uint64(60),
+						"Age": int64(60),
 					},
 				},
 			},
@@ -236,7 +236,7 @@ func TestP2PWithSingleDocumentSingleUpdateDoesNotSyncToNonPeerNode(t *testing.T)
 				}`,
 				Results: []map[string]any{
 					{
-						"Age": uint64(60),
+						"Age": int64(60),
 					},
 				},
 			},
@@ -250,7 +250,7 @@ func TestP2PWithSingleDocumentSingleUpdateDoesNotSyncToNonPeerNode(t *testing.T)
 				}`,
 				Results: []map[string]any{
 					{
-						"Age": uint64(21),
+						"Age": int64(21),
 					},
 				},
 			},
@@ -305,7 +305,7 @@ func TestP2PWithSingleDocumentSingleUpdateDoesNotSyncFromUnmappedNode(t *testing
 				}`,
 				Results: []map[string]any{
 					{
-						"Age": uint64(21),
+						"Age": int64(21),
 					},
 				},
 			},
@@ -319,7 +319,7 @@ func TestP2PWithSingleDocumentSingleUpdateDoesNotSyncFromUnmappedNode(t *testing
 				}`,
 				Results: []map[string]any{
 					{
-						"Age": uint64(21),
+						"Age": int64(21),
 					},
 				},
 			},
@@ -332,7 +332,7 @@ func TestP2PWithSingleDocumentSingleUpdateDoesNotSyncFromUnmappedNode(t *testing
 				}`,
 				Results: []map[string]any{
 					{
-						"Age": uint64(60),
+						"Age": int64(60),
 					},
 				},
 			},
@@ -412,7 +412,7 @@ func TestP2PWithMultipleDocumentUpdatesPerNode(t *testing.T) {
 				}`,
 				Results: []map[string]any{
 					{
-						"Age": testUtils.AnyOf{uint64(47), uint64(62)},
+						"Age": testUtils.AnyOf{int64(47), int64(62)},
 					},
 				},
 			},
@@ -475,10 +475,10 @@ func TestP2PWithSingleDocumentSingleUpdateFromChildWithP2PCollection(t *testing.
 				}`,
 				Results: []map[string]any{
 					{
-						"Age": uint64(21),
+						"Age": int64(21),
 					},
 					{
-						"Age": uint64(60),
+						"Age": int64(60),
 					},
 				},
 			},
@@ -591,10 +591,10 @@ func TestP2PWithMultipleDocumentUpdatesPerNodeWithP2PCollection(t *testing.T) {
 				}`,
 				Results: []map[string]any{
 					{
-						"Age": testUtils.AnyOf{uint64(47), uint64(62)},
+						"Age": testUtils.AnyOf{int64(47), int64(62)},
 					},
 					{
-						"Age": uint64(60),
+						"Age": int64(60),
 					},
 				},
 			},

--- a/tests/integration/net/state/simple/peer_replicator/with_create_test.go
+++ b/tests/integration/net/state/simple/peer_replicator/with_create_test.go
@@ -63,10 +63,10 @@ func TestP2PPeerReplicatorWithCreate(t *testing.T) {
 				}`,
 				Results: []map[string]any{
 					{
-						"Age": uint64(21),
+						"Age": int64(21),
 					},
 					{
-						"Age": uint64(3000),
+						"Age": int64(3000),
 					},
 				},
 			},
@@ -79,7 +79,7 @@ func TestP2PPeerReplicatorWithCreate(t *testing.T) {
 				}`,
 				Results: []map[string]any{
 					{
-						"Age": uint64(21),
+						"Age": int64(21),
 					},
 				},
 			},
@@ -92,10 +92,10 @@ func TestP2PPeerReplicatorWithCreate(t *testing.T) {
 				}`,
 				Results: []map[string]any{
 					{
-						"Age": uint64(21),
+						"Age": int64(21),
 					},
 					{
-						"Age": uint64(3000),
+						"Age": int64(3000),
 					},
 				},
 			},

--- a/tests/integration/net/state/simple/peer_replicator/with_delete_test.go
+++ b/tests/integration/net/state/simple/peer_replicator/with_delete_test.go
@@ -64,7 +64,7 @@ func TestP2PPeerReplicatorWithDeleteShowDeleted(t *testing.T) {
 					{
 						"_deleted": true,
 						"Name":     "John",
-						"Age":      uint64(21),
+						"Age":      int64(21),
 					},
 				},
 			},

--- a/tests/integration/net/state/simple/peer_replicator/with_update_restart_test.go
+++ b/tests/integration/net/state/simple/peer_replicator/with_update_restart_test.go
@@ -67,7 +67,7 @@ func TestP2PPeerReplicatorWithUpdateAndRestart(t *testing.T) {
 				}`,
 				Results: []map[string]any{
 					{
-						"Age": uint64(60),
+						"Age": int64(60),
 					},
 				},
 			},

--- a/tests/integration/net/state/simple/peer_replicator/with_update_test.go
+++ b/tests/integration/net/state/simple/peer_replicator/with_update_test.go
@@ -62,7 +62,7 @@ func TestP2PPeerReplicatorWithUpdate(t *testing.T) {
 				}`,
 				Results: []map[string]any{
 					{
-						"Age": uint64(60),
+						"Age": int64(60),
 					},
 				},
 			},

--- a/tests/integration/net/state/simple/replicator/with_create_restart_test.go
+++ b/tests/integration/net/state/simple/replicator/with_create_restart_test.go
@@ -53,7 +53,7 @@ func TestP2POneToOneReplicatorWithRestart(t *testing.T) {
 				}`,
 				Results: []map[string]any{
 					{
-						"Age": uint64(21),
+						"Age": int64(21),
 					},
 				},
 			},

--- a/tests/integration/net/state/simple/replicator/with_create_test.go
+++ b/tests/integration/net/state/simple/replicator/with_create_test.go
@@ -54,7 +54,7 @@ func TestP2POneToOneReplicator(t *testing.T) {
 				}`,
 				Results: []map[string]any{
 					{
-						"Age": uint64(21),
+						"Age": int64(21),
 					},
 				},
 			},
@@ -99,7 +99,7 @@ func TestP2POneToOneReplicatorDoesNotSyncExisting(t *testing.T) {
 				}`,
 				Results: []map[string]any{
 					{
-						"Age": uint64(21),
+						"Age": int64(21),
 					},
 				},
 			},
@@ -239,7 +239,7 @@ func TestP2POneToManyReplicator(t *testing.T) {
 				}`,
 				Results: []map[string]any{
 					{
-						"Age": uint64(21),
+						"Age": int64(21),
 					},
 				},
 			},
@@ -286,7 +286,7 @@ func TestP2POneToOneOfManyReplicator(t *testing.T) {
 				}`,
 				Results: []map[string]any{
 					{
-						"Age": uint64(21),
+						"Age": int64(21),
 					},
 				},
 			},
@@ -299,7 +299,7 @@ func TestP2POneToOneOfManyReplicator(t *testing.T) {
 				}`,
 				Results: []map[string]any{
 					{
-						"Age": uint64(21),
+						"Age": int64(21),
 					},
 				},
 			},
@@ -361,10 +361,10 @@ func TestP2POneToOneReplicatorManyDocs(t *testing.T) {
 				}`,
 				Results: []map[string]any{
 					{
-						"Age": uint64(21),
+						"Age": int64(21),
 					},
 					{
-						"Age": uint64(22),
+						"Age": int64(22),
 					},
 				},
 			},
@@ -421,10 +421,10 @@ func TestP2POneToManyReplicatorManyDocs(t *testing.T) {
 				}`,
 				Results: []map[string]any{
 					{
-						"Age": uint64(21),
+						"Age": int64(21),
 					},
 					{
-						"Age": uint64(22),
+						"Age": int64(22),
 					},
 				},
 			},
@@ -488,7 +488,7 @@ func TestP2POneToOneReplicatorOrderIndependent(t *testing.T) {
 				Results: []map[string]any{
 					{
 						"_key": "bae-f54b9689-e06e-5e3a-89b3-f3aee8e64ca7",
-						"age":  uint64(21),
+						"age":  int64(21),
 						"name": "John",
 						"_version": []map[string]any{
 							{

--- a/tests/integration/net/state/simple/replicator/with_create_update_test.go
+++ b/tests/integration/net/state/simple/replicator/with_create_update_test.go
@@ -61,7 +61,7 @@ func TestP2POneToOneReplicatorWithCreateWithUpdate(t *testing.T) {
 				}`,
 				Results: []map[string]any{
 					{
-						"Age": uint64(60),
+						"Age": int64(60),
 					},
 				},
 			},
@@ -118,7 +118,7 @@ func TestP2POneToOneReplicatorWithCreateWithUpdateOnRecipientNode(t *testing.T) 
 				}`,
 				Results: []map[string]any{
 					{
-						"Age": uint64(60),
+						"Age": int64(60),
 					},
 				},
 			},

--- a/tests/integration/net/state/simple/replicator/with_delete_test.go
+++ b/tests/integration/net/state/simple/replicator/with_delete_test.go
@@ -62,7 +62,7 @@ func TestP2POneToOneReplicatorDeletesDocCreatedBeforeReplicatorConfig(t *testing
 					{
 						"_deleted": true,
 						"Name":     "John",
-						"Age":      uint64(21),
+						"Age":      int64(21),
 					},
 				},
 			},
@@ -116,7 +116,7 @@ func TestP2POneToOneReplicatorDeletesDocCreatedBeforeReplicatorConfigWithNodesIn
 					{
 						"_deleted": true,
 						"Name":     "John",
-						"Age":      uint64(21),
+						"Age":      int64(21),
 					},
 				},
 			},

--- a/tests/integration/net/state/simple/replicator/with_update_test.go
+++ b/tests/integration/net/state/simple/replicator/with_update_test.go
@@ -60,7 +60,7 @@ func TestP2POneToOneReplicatorUpdatesDocCreatedBeforeReplicatorConfig(t *testing
 				}`,
 				Results: []map[string]any{
 					{
-						"Age": uint64(60),
+						"Age": int64(60),
 					},
 				},
 			},
@@ -112,7 +112,7 @@ func TestP2POneToOneReplicatorUpdatesDocCreatedBeforeReplicatorConfigWithNodesIn
 				}`,
 				Results: []map[string]any{
 					{
-						"Age": uint64(60),
+						"Age": int64(60),
 					},
 				},
 			},

--- a/tests/integration/query/one_to_many/simple_test.go
+++ b/tests/integration/query/one_to_many/simple_test.go
@@ -54,7 +54,7 @@ func TestQueryOneToMany(t *testing.T) {
 					"rating": 4.9,
 					"author": map[string]any{
 						"name": "John Grisham",
-						"age":  uint64(65),
+						"age":  int64(65),
 					},
 				},
 			},
@@ -109,7 +109,7 @@ func TestQueryOneToMany(t *testing.T) {
 			Results: []map[string]any{
 				{
 					"name": "John Grisham",
-					"age":  uint64(65),
+					"age":  int64(65),
 					"published": []map[string]any{
 						{
 							"name":   "Painted House",
@@ -123,7 +123,7 @@ func TestQueryOneToMany(t *testing.T) {
 				},
 				{
 					"name": "Cornelia Funke",
-					"age":  uint64(62),
+					"age":  int64(62),
 					"published": []map[string]any{
 						{
 							"name":   "Theif Lord",

--- a/tests/integration/query/one_to_many/with_cid_dockey_test.go
+++ b/tests/integration/query/one_to_many/with_cid_dockey_test.go
@@ -159,7 +159,7 @@ func TestQueryOneToManyWithChildUpdateAndFirstCidAndDocKey(t *testing.T) {
 				"name": "Painted House",
 				"author": map[string]any{
 					"name": "John Grisham",
-					"age":  uint64(22),
+					"age":  int64(22),
 				},
 			},
 		},

--- a/tests/integration/query/one_to_many/with_filter_test.go
+++ b/tests/integration/query/one_to_many/with_filter_test.go
@@ -80,7 +80,7 @@ func TestQueryOneToManyWithNumericGreaterThanFilterOnParent(t *testing.T) {
 				Results: []map[string]any{
 					{
 						"name": "John Grisham",
-						"age":  uint64(65),
+						"age":  int64(65),
 						"published": []map[string]any{
 							{
 								"name":   "Painted House",
@@ -232,7 +232,7 @@ func TestQueryOneToManyWithNumericGreaterThanFilterOnParentAndChild(t *testing.T
 				Results: []map[string]any{
 					{
 						"name": "John Grisham",
-						"age":  uint64(65),
+						"age":  int64(65),
 						"published": []map[string]any{
 							{
 								"name":   "Painted House",
@@ -316,7 +316,7 @@ func TestQueryOneToManyWithMultipleAliasedFilteredChildren(t *testing.T) {
 				Results: []map[string]any{
 					{
 						"name": "John Grisham",
-						"age":  uint64(65),
+						"age":  int64(65),
 						"p1": []map[string]any{
 							{
 								"name":   "Painted House",
@@ -332,7 +332,7 @@ func TestQueryOneToManyWithMultipleAliasedFilteredChildren(t *testing.T) {
 					},
 					{
 						"name": "Cornelia Funke",
-						"age":  uint64(62),
+						"age":  int64(62),
 						"p1": []map[string]any{
 							{
 								"name":   "Theif Lord",

--- a/tests/integration/query/one_to_many/with_group_filter_test.go
+++ b/tests/integration/query/one_to_many/with_group_filter_test.go
@@ -90,7 +90,7 @@ func TestQueryOneToManyWithParentJoinGroupNumberAndNumberFilterOnJoin(t *testing
 			},
 			Results: []map[string]any{
 				{
-					"age": uint64(327),
+					"age": int64(327),
 					"_group": []map[string]any{
 						{
 							"name":      "Simon Pelloutier",
@@ -112,7 +112,7 @@ func TestQueryOneToManyWithParentJoinGroupNumberAndNumberFilterOnJoin(t *testing
 					},
 				},
 				{
-					"age": uint64(65),
+					"age": int64(65),
 					"_group": []map[string]any{
 						{
 							"name": "John Grisham",
@@ -208,7 +208,7 @@ func TestQueryOneToManyWithParentJoinGroupNumberAndNumberFilterOnGroup(t *testin
 			},
 			Results: []map[string]any{
 				{
-					"age": uint64(327),
+					"age": int64(327),
 					"_group": []map[string]any{
 						{
 							"name": "Voltaire",
@@ -226,7 +226,7 @@ func TestQueryOneToManyWithParentJoinGroupNumberAndNumberFilterOnGroup(t *testin
 					},
 				},
 				{
-					"age": uint64(65),
+					"age": int64(65),
 					"_group": []map[string]any{
 						{
 							"name": "John Grisham",
@@ -330,7 +330,7 @@ func TestQueryOneToManyWithParentJoinGroupNumberAndNumberFilterOnGroupAndOnGroup
 			},
 			Results: []map[string]any{
 				{
-					"age": uint64(327),
+					"age": int64(327),
 					"_group": []map[string]any{
 						{
 							"name":      "Simon Pelloutier",

--- a/tests/integration/query/one_to_many/with_group_related_id_alias_test.go
+++ b/tests/integration/query/one_to_many/with_group_related_id_alias_test.go
@@ -99,7 +99,7 @@ func TestQueryOneToManyWithParentGroupByOnRelatedTypeFromManySideUsingAlias(t *t
 						"name":   "Candide",
 						"rating": 4.95,
 						"author": map[string]any{
-							"age":  uint64(327),
+							"age":  int64(327),
 							"name": "Voltaire",
 						},
 					},
@@ -107,7 +107,7 @@ func TestQueryOneToManyWithParentGroupByOnRelatedTypeFromManySideUsingAlias(t *t
 						"name":   "Zadig",
 						"rating": 4.91,
 						"author": map[string]any{
-							"age":  uint64(327),
+							"age":  int64(327),
 							"name": "Voltaire",
 						},
 					},
@@ -120,7 +120,7 @@ func TestQueryOneToManyWithParentGroupByOnRelatedTypeFromManySideUsingAlias(t *t
 						"name":   "The Client",
 						"rating": 4.5,
 						"author": map[string]any{
-							"age":  uint64(65),
+							"age":  int64(65),
 							"name": "John Grisham",
 						},
 					},
@@ -128,7 +128,7 @@ func TestQueryOneToManyWithParentGroupByOnRelatedTypeFromManySideUsingAlias(t *t
 						"name":   "Painted House",
 						"rating": 4.9,
 						"author": map[string]any{
-							"age":  uint64(65),
+							"age":  int64(65),
 							"name": "John Grisham",
 						},
 					},
@@ -136,7 +136,7 @@ func TestQueryOneToManyWithParentGroupByOnRelatedTypeFromManySideUsingAlias(t *t
 						"name":   "A Time for Mercy",
 						"rating": 4.5,
 						"author": map[string]any{
-							"age":  uint64(65),
+							"age":  int64(65),
 							"name": "John Grisham",
 						},
 					},
@@ -149,7 +149,7 @@ func TestQueryOneToManyWithParentGroupByOnRelatedTypeFromManySideUsingAlias(t *t
 						"name":   "Histoiare des Celtes et particulierement des Gaulois et des Germains depuis les temps fabuleux jusqua la prise de Roze par les Gaulois",
 						"rating": 2.0,
 						"author": map[string]any{
-							"age":  uint64(327),
+							"age":  int64(327),
 							"name": "Simon Pelloutier",
 						},
 					},
@@ -251,7 +251,7 @@ func TestQueryOneToManyWithParentGroupByOnRelatedTypeFromManySideUsingAliasAndRe
 						"name":   "Candide",
 						"rating": 4.95,
 						"author": map[string]any{
-							"age":  uint64(327),
+							"age":  int64(327),
 							"name": "Voltaire",
 						},
 					},
@@ -259,7 +259,7 @@ func TestQueryOneToManyWithParentGroupByOnRelatedTypeFromManySideUsingAliasAndRe
 						"name":   "Zadig",
 						"rating": 4.91,
 						"author": map[string]any{
-							"age":  uint64(327),
+							"age":  int64(327),
 							"name": "Voltaire",
 						},
 					},
@@ -275,7 +275,7 @@ func TestQueryOneToManyWithParentGroupByOnRelatedTypeFromManySideUsingAliasAndRe
 						"name":   "The Client",
 						"rating": 4.5,
 						"author": map[string]any{
-							"age":  uint64(65),
+							"age":  int64(65),
 							"name": "John Grisham",
 						},
 					},
@@ -283,7 +283,7 @@ func TestQueryOneToManyWithParentGroupByOnRelatedTypeFromManySideUsingAliasAndRe
 						"name":   "Painted House",
 						"rating": 4.9,
 						"author": map[string]any{
-							"age":  uint64(65),
+							"age":  int64(65),
 							"name": "John Grisham",
 						},
 					},
@@ -291,7 +291,7 @@ func TestQueryOneToManyWithParentGroupByOnRelatedTypeFromManySideUsingAliasAndRe
 						"name":   "A Time for Mercy",
 						"rating": 4.5,
 						"author": map[string]any{
-							"age":  uint64(65),
+							"age":  int64(65),
 							"name": "John Grisham",
 						},
 					},
@@ -307,7 +307,7 @@ func TestQueryOneToManyWithParentGroupByOnRelatedTypeFromManySideUsingAliasAndRe
 						"name":   "Histoiare des Celtes et particulierement des Gaulois et des Germains depuis les temps fabuleux jusqua la prise de Roze par les Gaulois",
 						"rating": 2.0,
 						"author": map[string]any{
-							"age":  uint64(327),
+							"age":  int64(327),
 							"name": "Simon Pelloutier",
 						},
 					},
@@ -402,7 +402,7 @@ func TestQueryOneToManyWithParentGroupByOnRelatedTypeWithIDSelectionFromManySide
 						"name":   "Candide",
 						"rating": 4.95,
 						"author": map[string]any{
-							"age":  uint64(327),
+							"age":  int64(327),
 							"name": "Voltaire",
 						},
 					},
@@ -410,7 +410,7 @@ func TestQueryOneToManyWithParentGroupByOnRelatedTypeWithIDSelectionFromManySide
 						"name":   "Zadig",
 						"rating": 4.91,
 						"author": map[string]any{
-							"age":  uint64(327),
+							"age":  int64(327),
 							"name": "Voltaire",
 						},
 					},
@@ -423,7 +423,7 @@ func TestQueryOneToManyWithParentGroupByOnRelatedTypeWithIDSelectionFromManySide
 						"name":   "The Client",
 						"rating": 4.5,
 						"author": map[string]any{
-							"age":  uint64(65),
+							"age":  int64(65),
 							"name": "John Grisham",
 						},
 					},
@@ -431,7 +431,7 @@ func TestQueryOneToManyWithParentGroupByOnRelatedTypeWithIDSelectionFromManySide
 						"name":   "Painted House",
 						"rating": 4.9,
 						"author": map[string]any{
-							"age":  uint64(65),
+							"age":  int64(65),
 							"name": "John Grisham",
 						},
 					},
@@ -439,7 +439,7 @@ func TestQueryOneToManyWithParentGroupByOnRelatedTypeWithIDSelectionFromManySide
 						"name":   "A Time for Mercy",
 						"rating": 4.5,
 						"author": map[string]any{
-							"age":  uint64(65),
+							"age":  int64(65),
 							"name": "John Grisham",
 						},
 					},
@@ -452,7 +452,7 @@ func TestQueryOneToManyWithParentGroupByOnRelatedTypeWithIDSelectionFromManySide
 						"name":   "Histoiare des Celtes et particulierement des Gaulois et des Germains depuis les temps fabuleux jusqua la prise de Roze par les Gaulois",
 						"rating": 2.0,
 						"author": map[string]any{
-							"age":  uint64(327),
+							"age":  int64(327),
 							"name": "Simon Pelloutier",
 						},
 					},
@@ -555,7 +555,7 @@ func TestQueryOneToManyWithParentGroupByOnRelatedTypeWithIDSelectionFromManySide
 						"name":   "Candide",
 						"rating": 4.95,
 						"author": map[string]any{
-							"age":  uint64(327),
+							"age":  int64(327),
 							"name": "Voltaire",
 						},
 					},
@@ -563,7 +563,7 @@ func TestQueryOneToManyWithParentGroupByOnRelatedTypeWithIDSelectionFromManySide
 						"name":   "Zadig",
 						"rating": 4.91,
 						"author": map[string]any{
-							"age":  uint64(327),
+							"age":  int64(327),
 							"name": "Voltaire",
 						},
 					},
@@ -580,7 +580,7 @@ func TestQueryOneToManyWithParentGroupByOnRelatedTypeWithIDSelectionFromManySide
 						"name":   "The Client",
 						"rating": 4.5,
 						"author": map[string]any{
-							"age":  uint64(65),
+							"age":  int64(65),
 							"name": "John Grisham",
 						},
 					},
@@ -588,7 +588,7 @@ func TestQueryOneToManyWithParentGroupByOnRelatedTypeWithIDSelectionFromManySide
 						"name":   "Painted House",
 						"rating": 4.9,
 						"author": map[string]any{
-							"age":  uint64(65),
+							"age":  int64(65),
 							"name": "John Grisham",
 						},
 					},
@@ -596,7 +596,7 @@ func TestQueryOneToManyWithParentGroupByOnRelatedTypeWithIDSelectionFromManySide
 						"name":   "A Time for Mercy",
 						"rating": 4.5,
 						"author": map[string]any{
-							"age":  uint64(65),
+							"age":  int64(65),
 							"name": "John Grisham",
 						},
 					},
@@ -613,7 +613,7 @@ func TestQueryOneToManyWithParentGroupByOnRelatedTypeWithIDSelectionFromManySide
 						"name":   "Histoiare des Celtes et particulierement des Gaulois et des Germains depuis les temps fabuleux jusqua la prise de Roze par les Gaulois",
 						"rating": 2.0,
 						"author": map[string]any{
-							"age":  uint64(327),
+							"age":  int64(327),
 							"name": "Simon Pelloutier",
 						},
 					},

--- a/tests/integration/query/one_to_many/with_group_related_id_test.go
+++ b/tests/integration/query/one_to_many/with_group_related_id_test.go
@@ -96,7 +96,7 @@ func TestQueryOneToManyWithParentGroupByOnRelatedTypeIDFromManySide(t *testing.T
 						"name":   "Candide",
 						"rating": 4.95,
 						"author": map[string]any{
-							"age":  uint64(327),
+							"age":  int64(327),
 							"name": "Voltaire",
 						},
 					},
@@ -104,7 +104,7 @@ func TestQueryOneToManyWithParentGroupByOnRelatedTypeIDFromManySide(t *testing.T
 						"name":   "Zadig",
 						"rating": 4.91,
 						"author": map[string]any{
-							"age":  uint64(327),
+							"age":  int64(327),
 							"name": "Voltaire",
 						},
 					},
@@ -117,7 +117,7 @@ func TestQueryOneToManyWithParentGroupByOnRelatedTypeIDFromManySide(t *testing.T
 						"name":   "The Client",
 						"rating": 4.5,
 						"author": map[string]any{
-							"age":  uint64(65),
+							"age":  int64(65),
 							"name": "John Grisham",
 						},
 					},
@@ -125,7 +125,7 @@ func TestQueryOneToManyWithParentGroupByOnRelatedTypeIDFromManySide(t *testing.T
 						"name":   "Painted House",
 						"rating": 4.9,
 						"author": map[string]any{
-							"age":  uint64(65),
+							"age":  int64(65),
 							"name": "John Grisham",
 						},
 					},
@@ -133,7 +133,7 @@ func TestQueryOneToManyWithParentGroupByOnRelatedTypeIDFromManySide(t *testing.T
 						"name":   "A Time for Mercy",
 						"rating": 4.5,
 						"author": map[string]any{
-							"age":  uint64(65),
+							"age":  int64(65),
 							"name": "John Grisham",
 						},
 					},
@@ -146,7 +146,7 @@ func TestQueryOneToManyWithParentGroupByOnRelatedTypeIDFromManySide(t *testing.T
 						"name":   "Histoiare des Celtes et particulierement des Gaulois et des Germains depuis les temps fabuleux jusqua la prise de Roze par les Gaulois",
 						"rating": 2.0,
 						"author": map[string]any{
-							"age":  uint64(327),
+							"age":  int64(327),
 							"name": "Simon Pelloutier",
 						},
 					},
@@ -238,7 +238,7 @@ func TestQueryOneToManyWithParentGroupByOnRelatedTypeIDWithIDSelectionFromManySi
 						"name":   "Candide",
 						"rating": 4.95,
 						"author": map[string]any{
-							"age":  uint64(327),
+							"age":  int64(327),
 							"name": "Voltaire",
 						},
 					},
@@ -246,7 +246,7 @@ func TestQueryOneToManyWithParentGroupByOnRelatedTypeIDWithIDSelectionFromManySi
 						"name":   "Zadig",
 						"rating": 4.91,
 						"author": map[string]any{
-							"age":  uint64(327),
+							"age":  int64(327),
 							"name": "Voltaire",
 						},
 					},
@@ -259,7 +259,7 @@ func TestQueryOneToManyWithParentGroupByOnRelatedTypeIDWithIDSelectionFromManySi
 						"name":   "The Client",
 						"rating": 4.5,
 						"author": map[string]any{
-							"age":  uint64(65),
+							"age":  int64(65),
 							"name": "John Grisham",
 						},
 					},
@@ -267,7 +267,7 @@ func TestQueryOneToManyWithParentGroupByOnRelatedTypeIDWithIDSelectionFromManySi
 						"name":   "Painted House",
 						"rating": 4.9,
 						"author": map[string]any{
-							"age":  uint64(65),
+							"age":  int64(65),
 							"name": "John Grisham",
 						},
 					},
@@ -275,7 +275,7 @@ func TestQueryOneToManyWithParentGroupByOnRelatedTypeIDWithIDSelectionFromManySi
 						"name":   "A Time for Mercy",
 						"rating": 4.5,
 						"author": map[string]any{
-							"age":  uint64(65),
+							"age":  int64(65),
 							"name": "John Grisham",
 						},
 					},
@@ -288,7 +288,7 @@ func TestQueryOneToManyWithParentGroupByOnRelatedTypeIDWithIDSelectionFromManySi
 						"name":   "Histoiare des Celtes et particulierement des Gaulois et des Germains depuis les temps fabuleux jusqua la prise de Roze par les Gaulois",
 						"rating": 2.0,
 						"author": map[string]any{
-							"age":  uint64(327),
+							"age":  int64(327),
 							"name": "Simon Pelloutier",
 						},
 					},

--- a/tests/integration/query/one_to_many/with_group_test.go
+++ b/tests/integration/query/one_to_many/with_group_test.go
@@ -75,7 +75,7 @@ func TestQueryOneToManyWithInnerJoinGroupNumber(t *testing.T) {
 			Results: []map[string]any{
 				{
 					"name": "John Grisham",
-					"age":  uint64(65),
+					"age":  int64(65),
 					"published": []map[string]any{
 						{
 							"rating": 4.5,
@@ -100,7 +100,7 @@ func TestQueryOneToManyWithInnerJoinGroupNumber(t *testing.T) {
 				},
 				{
 					"name": "Cornelia Funke",
-					"age":  uint64(62),
+					"age":  int64(62),
 					"published": []map[string]any{
 						{
 							"rating": 4.8,
@@ -195,7 +195,7 @@ func TestQueryOneToManyWithParentJoinGroupNumber(t *testing.T) {
 			},
 			Results: []map[string]any{
 				{
-					"age": uint64(327),
+					"age": int64(327),
 					"_group": []map[string]any{
 						{
 							"name": "Simon Pelloutier",
@@ -222,7 +222,7 @@ func TestQueryOneToManyWithParentJoinGroupNumber(t *testing.T) {
 					},
 				},
 				{
-					"age": uint64(65),
+					"age": int64(65),
 					"_group": []map[string]any{
 						{
 							"name": "John Grisham",

--- a/tests/integration/query/one_to_many/with_id_field_test.go
+++ b/tests/integration/query/one_to_many/with_id_field_test.go
@@ -76,7 +76,7 @@ func TestQueryOneToManyWithIdFieldOnPrimary(t *testing.T) {
 					},
 					{
 						"name":      "Painted House",
-						"author_id": uint64(123456),
+						"author_id": int64(123456),
 						"author":    nil,
 					},
 				},

--- a/tests/integration/query/one_to_many/with_order_filter_limit_test.go
+++ b/tests/integration/query/one_to_many/with_order_filter_limit_test.go
@@ -69,7 +69,7 @@ func TestQueryOneToManyWithNumericGreaterThanFilterOnParentAndNumericSortAscendi
 		Results: []map[string]any{
 			{
 				"name": "John Grisham",
-				"age":  uint64(65),
+				"age":  int64(65),
 				"published": []map[string]any{
 					{
 						"name":   "A Time for Mercy",
@@ -136,7 +136,7 @@ func TestQueryOneToManyWithNumericGreaterThanFilterOnParentAndNumericSortDescend
 		Results: []map[string]any{
 			{
 				"name": "John Grisham",
-				"age":  uint64(65),
+				"age":  int64(65),
 				"published": []map[string]any{
 					{
 						"name":   "Painted House",

--- a/tests/integration/query/one_to_many/with_order_filter_test.go
+++ b/tests/integration/query/one_to_many/with_order_filter_test.go
@@ -69,7 +69,7 @@ func TestQueryOneToManyWithNumericGreaterThanFilterOnParentAndNumericSortAscendi
 		Results: []map[string]any{
 			{
 				"name": "John Grisham",
-				"age":  uint64(65),
+				"age":  int64(65),
 				"published": []map[string]any{
 					{
 						"name":   "A Time for Mercy",
@@ -138,7 +138,7 @@ func TestQueryOneToManyWithNumericGreaterThanFilterAndNumericSortDescendingOnChi
 		Results: []map[string]any{
 			{
 				"name": "John Grisham",
-				"age":  uint64(65),
+				"age":  int64(65),
 				"published": []map[string]any{
 					{
 						"name":   "Painted House",
@@ -152,7 +152,7 @@ func TestQueryOneToManyWithNumericGreaterThanFilterAndNumericSortDescendingOnChi
 			},
 			{
 				"name": "Cornelia Funke",
-				"age":  uint64(62),
+				"age":  int64(62),
 				"published": []map[string]any{
 					{
 						"name":   "Theif Lord",

--- a/tests/integration/query/one_to_many_to_one/with_filter_test.go
+++ b/tests/integration/query/one_to_many_to_one/with_filter_test.go
@@ -113,7 +113,7 @@ func TestQueryComplexWithDeepFilterOnRenderedChildren(t *testing.T) {
 						"book": []map[string]any{
 							{
 								"publisher": map[string]any{
-									"yearOpened": uint64(2022),
+									"yearOpened": int64(2022),
 								},
 							},
 						},
@@ -242,25 +242,25 @@ func TestOneToManyToOneWithTwoLevelDeepFilter(t *testing.T) {
 							{
 								"name": "Sooley",
 								"publisher": map[string]any{
-									"yearOpened": uint64(1999),
+									"yearOpened": int64(1999),
 								},
 							},
 							{
 								"name": "Theif Lord",
 								"publisher": map[string]any{
-									"yearOpened": uint64(2020),
+									"yearOpened": int64(2020),
 								},
 							},
 							{
 								"name": "Painted House",
 								"publisher": map[string]any{
-									"yearOpened": uint64(1995),
+									"yearOpened": int64(1995),
 								},
 							},
 							{
 								"name": "A Time for Mercy",
 								"publisher": map[string]any{
-									"yearOpened": uint64(2013),
+									"yearOpened": int64(2013),
 								},
 							},
 						},
@@ -271,7 +271,7 @@ func TestOneToManyToOneWithTwoLevelDeepFilter(t *testing.T) {
 							{
 								"name": "The Rooster Bar",
 								"publisher": map[string]any{
-									"yearOpened": uint64(2022),
+									"yearOpened": int64(2022),
 								},
 							},
 						},

--- a/tests/integration/query/one_to_many_to_one/with_order_test.go
+++ b/tests/integration/query/one_to_many_to_one/with_order_test.go
@@ -39,7 +39,7 @@ func TestMultipleOrderByWithDepthGreaterThanOne(t *testing.T) {
 						"rating": 3.2,
 						"publisher": map[string]any{
 							"name":       "Only Publisher of Sooley",
-							"yearOpened": uint64(1999),
+							"yearOpened": int64(1999),
 						},
 					},
 					{
@@ -47,7 +47,7 @@ func TestMultipleOrderByWithDepthGreaterThanOne(t *testing.T) {
 						"rating": 4.0,
 						"publisher": map[string]any{
 							"name":       "Only Publisher of The Rooster Bar",
-							"yearOpened": uint64(2022),
+							"yearOpened": int64(2022),
 						},
 					},
 					{
@@ -60,7 +60,7 @@ func TestMultipleOrderByWithDepthGreaterThanOne(t *testing.T) {
 						"rating": 4.5,
 						"publisher": map[string]any{
 							"name":       "Only Publisher of A Time for Mercy",
-							"yearOpened": uint64(2013),
+							"yearOpened": int64(2013),
 						},
 					},
 					{
@@ -68,7 +68,7 @@ func TestMultipleOrderByWithDepthGreaterThanOne(t *testing.T) {
 						"rating": 4.8,
 						"publisher": map[string]any{
 							"name":       "Only Publisher of Theif Lord",
-							"yearOpened": uint64(2020),
+							"yearOpened": int64(2020),
 						},
 					},
 					{
@@ -76,7 +76,7 @@ func TestMultipleOrderByWithDepthGreaterThanOne(t *testing.T) {
 						"rating": 4.9,
 						"publisher": map[string]any{
 							"name":       "Only Publisher of Painted House",
-							"yearOpened": uint64(1995),
+							"yearOpened": int64(1995),
 						},
 					},
 				},
@@ -110,7 +110,7 @@ func TestMultipleOrderByWithDepthGreaterThanOneOrderSwitched(t *testing.T) {
 						"rating": 4.0,
 						"publisher": map[string]any{
 							"name":       "Only Publisher of The Rooster Bar",
-							"yearOpened": uint64(2022),
+							"yearOpened": int64(2022),
 						},
 					},
 					{
@@ -118,7 +118,7 @@ func TestMultipleOrderByWithDepthGreaterThanOneOrderSwitched(t *testing.T) {
 						"rating": 4.8,
 						"publisher": map[string]any{
 							"name":       "Only Publisher of Theif Lord",
-							"yearOpened": uint64(2020),
+							"yearOpened": int64(2020),
 						},
 					},
 					{
@@ -126,7 +126,7 @@ func TestMultipleOrderByWithDepthGreaterThanOneOrderSwitched(t *testing.T) {
 						"rating": 4.5,
 						"publisher": map[string]any{
 							"name":       "Only Publisher of A Time for Mercy",
-							"yearOpened": uint64(2013),
+							"yearOpened": int64(2013),
 						},
 					},
 					{
@@ -134,7 +134,7 @@ func TestMultipleOrderByWithDepthGreaterThanOneOrderSwitched(t *testing.T) {
 						"rating": 3.2,
 						"publisher": map[string]any{
 							"name":       "Only Publisher of Sooley",
-							"yearOpened": uint64(1999),
+							"yearOpened": int64(1999),
 						},
 					},
 					{
@@ -142,7 +142,7 @@ func TestMultipleOrderByWithDepthGreaterThanOneOrderSwitched(t *testing.T) {
 						"rating": 4.9,
 						"publisher": map[string]any{
 							"name":       "Only Publisher of Painted House",
-							"yearOpened": uint64(1995),
+							"yearOpened": int64(1995),
 						},
 					},
 					{

--- a/tests/integration/query/one_to_one/simple_test.go
+++ b/tests/integration/query/one_to_one/simple_test.go
@@ -54,7 +54,7 @@ func TestQueryOneToOne(t *testing.T) {
 					"rating": 4.9,
 					"author": map[string]any{
 						"name": "John Grisham",
-						"age":  uint64(65),
+						"age":  int64(65),
 					},
 				},
 			},
@@ -92,7 +92,7 @@ func TestQueryOneToOne(t *testing.T) {
 			Results: []map[string]any{
 				{
 					"name": "John Grisham",
-					"age":  uint64(65),
+					"age":  int64(65),
 					"published": map[string]any{
 						"name":   "Painted House",
 						"rating": 4.9,

--- a/tests/integration/query/one_to_one/with_filter_test.go
+++ b/tests/integration/query/one_to_one/with_filter_test.go
@@ -58,7 +58,7 @@ func TestQueryOneToOneWithNumericFilterOnParent(t *testing.T) {
 						"rating": 4.9,
 						"author": map[string]any{
 							"name": "John Grisham",
-							"age":  uint64(65),
+							"age":  int64(65),
 						},
 					},
 				},
@@ -111,7 +111,7 @@ func TestQueryOneToOneWithStringFilterOnChild(t *testing.T) {
 						"rating": 4.9,
 						"author": map[string]any{
 							"name": "John Grisham",
-							"age":  uint64(65),
+							"age":  int64(65),
 						},
 					},
 				},
@@ -164,7 +164,7 @@ func TestQueryOneToOneWithBooleanFilterOnChild(t *testing.T) {
 						"rating": 4.9,
 						"author": map[string]any{
 							"name": "John Grisham",
-							"age":  uint64(65),
+							"age":  int64(65),
 						},
 					},
 				},
@@ -235,7 +235,7 @@ func TestQueryOneToOneWithFilterThroughChildBackToParent(t *testing.T) {
 						"rating": 4.9,
 						"author": map[string]any{
 							"name": "John Grisham",
-							"age":  uint64(65),
+							"age":  int64(65),
 						},
 					},
 				},

--- a/tests/integration/query/one_to_one/with_order_test.go
+++ b/tests/integration/query/one_to_one/with_order_test.go
@@ -67,7 +67,7 @@ func TestQueryOneToOneWithChildBooleanOrderDescending(t *testing.T) {
 				"rating": 4.9,
 				"author": map[string]any{
 					"name": "John Grisham",
-					"age":  uint64(65),
+					"age":  int64(65),
 				},
 			},
 			{
@@ -75,7 +75,7 @@ func TestQueryOneToOneWithChildBooleanOrderDescending(t *testing.T) {
 				"rating": 4.8,
 				"author": map[string]any{
 					"name": "Cornelia Funke",
-					"age":  uint64(62),
+					"age":  int64(62),
 				},
 			},
 		},
@@ -135,7 +135,7 @@ func TestQueryOneToOneWithChildBooleanOrderAscending(t *testing.T) {
 				"rating": 4.8,
 				"author": map[string]any{
 					"name": "Cornelia Funke",
-					"age":  uint64(62),
+					"age":  int64(62),
 				},
 			},
 			{
@@ -143,7 +143,7 @@ func TestQueryOneToOneWithChildBooleanOrderAscending(t *testing.T) {
 				"rating": 4.9,
 				"author": map[string]any{
 					"name": "John Grisham",
-					"age":  uint64(65),
+					"age":  int64(65),
 				},
 			},
 		},

--- a/tests/integration/query/one_to_two_many/simple_test.go
+++ b/tests/integration/query/one_to_two_many/simple_test.go
@@ -80,7 +80,7 @@ func TestQueryOneToTwoManyWithNilUnnamedRelationship(t *testing.T) {
 					},
 					"reviewedBy": map[string]any{
 						"name": "Cornelia Funke",
-						"age":  uint64(62),
+						"age":  int64(62),
 					},
 				},
 				{
@@ -91,7 +91,7 @@ func TestQueryOneToTwoManyWithNilUnnamedRelationship(t *testing.T) {
 					},
 					"reviewedBy": map[string]any{
 						"name": "John Grisham",
-						"age":  uint64(65),
+						"age":  int64(65),
 					},
 				},
 				{
@@ -102,7 +102,7 @@ func TestQueryOneToTwoManyWithNilUnnamedRelationship(t *testing.T) {
 					},
 					"reviewedBy": map[string]any{
 						"name": "Cornelia Funke",
-						"age":  uint64(62),
+						"age":  int64(62),
 					},
 				},
 			},
@@ -163,7 +163,7 @@ func TestQueryOneToTwoManyWithNilUnnamedRelationship(t *testing.T) {
 			Results: []map[string]any{
 				{
 					"name": "John Grisham",
-					"age":  uint64(65),
+					"age":  int64(65),
 					"reviewed": []map[string]any{
 						{
 							"name":   "Theif Lord",
@@ -181,7 +181,7 @@ func TestQueryOneToTwoManyWithNilUnnamedRelationship(t *testing.T) {
 				},
 				{
 					"name": "Cornelia Funke",
-					"age":  uint64(62),
+					"age":  int64(62),
 					"reviewed": []map[string]any{
 						{
 							"name":   "Painted House",
@@ -290,7 +290,7 @@ func TestQueryOneToTwoManyWithNamedAndUnnamedRelationships(t *testing.T) {
 					},
 					"reviewedBy": map[string]any{
 						"name": "John Grisham",
-						"age":  uint64(65),
+						"age":  int64(65),
 					},
 					"price": map[string]any{
 						"currency": "GBP",
@@ -305,7 +305,7 @@ func TestQueryOneToTwoManyWithNamedAndUnnamedRelationships(t *testing.T) {
 					},
 					"reviewedBy": map[string]any{
 						"name": "Cornelia Funke",
-						"age":  uint64(62),
+						"age":  int64(62),
 					},
 					"price": map[string]any{
 						"currency": "SEK",
@@ -320,7 +320,7 @@ func TestQueryOneToTwoManyWithNamedAndUnnamedRelationships(t *testing.T) {
 					},
 					"reviewedBy": map[string]any{
 						"name": "Cornelia Funke",
-						"age":  uint64(62),
+						"age":  int64(62),
 					},
 					"price": map[string]any{
 						"currency": "GBP",
@@ -403,7 +403,7 @@ func TestQueryOneToTwoManyWithNamedAndUnnamedRelationships(t *testing.T) {
 			Results: []map[string]any{
 				{
 					"name": "John Grisham",
-					"age":  uint64(65),
+					"age":  int64(65),
 					"reviewed": []map[string]any{
 						{
 							"name":   "Theif Lord",
@@ -427,7 +427,7 @@ func TestQueryOneToTwoManyWithNamedAndUnnamedRelationships(t *testing.T) {
 				},
 				{
 					"name": "Cornelia Funke",
-					"age":  uint64(62),
+					"age":  int64(62),
 					"reviewed": []map[string]any{
 						{
 							"name":   "A Time for Mercy",

--- a/tests/integration/query/simple/simple_test.go
+++ b/tests/integration/query/simple/simple_test.go
@@ -38,7 +38,7 @@ func TestQuerySimple(t *testing.T) {
 			{
 				"_key": "bae-52b9170d-b77a-5887-b877-cbdbb99b009f",
 				"Name": "John",
-				"Age":  uint64(21),
+				"Age":  int64(21),
 			},
 		},
 	}
@@ -66,7 +66,7 @@ func TestQuerySimpleWithAlias(t *testing.T) {
 		Results: []map[string]any{
 			{
 				"username": "John",
-				"age":      uint64(21),
+				"age":      int64(21),
 			},
 		},
 	}
@@ -98,11 +98,11 @@ func TestQuerySimpleWithMultipleRows(t *testing.T) {
 		Results: []map[string]any{
 			{
 				"Name": "Bob",
-				"Age":  uint64(27),
+				"Age":  int64(27),
 			},
 			{
 				"Name": "John",
-				"Age":  uint64(21),
+				"Age":  int64(21),
 			},
 		},
 	}

--- a/tests/integration/query/simple/with_cid_dockey_test.go
+++ b/tests/integration/query/simple/with_cid_dockey_test.go
@@ -130,7 +130,7 @@ func TestQuerySimpleWithUpdateAndFirstCidAndDocKey(t *testing.T) {
 		Results: []map[string]any{
 			{
 				"Name": "John",
-				"Age":  uint64(21),
+				"Age":  int64(21),
 			},
 		},
 	}
@@ -171,7 +171,7 @@ func TestQuerySimpleWithUpdateAndLastCidAndDocKey(t *testing.T) {
 		Results: []map[string]any{
 			{
 				"Name": "John",
-				"Age":  uint64(23),
+				"Age":  int64(23),
 			},
 		},
 	}
@@ -212,7 +212,7 @@ func TestQuerySimpleWithUpdateAndMiddleCidAndDocKey(t *testing.T) {
 		Results: []map[string]any{
 			{
 				"Name": "John",
-				"Age":  uint64(22),
+				"Age":  int64(22),
 			},
 		},
 	}
@@ -256,7 +256,7 @@ func TestQuerySimpleWithUpdateAndFirstCidAndDocKeyAndSchemaVersion(t *testing.T)
 		Results: []map[string]any{
 			{
 				"Name": "John",
-				"Age":  uint64(21),
+				"Age":  int64(21),
 				"_version": []map[string]any{
 					{
 						"schemaVersionId": "bafkreigrd4xdnprbzdh5bx3igtx2tayfbwp2f27pw3j3xjcbys7jekxfsm",

--- a/tests/integration/query/simple/with_dockey_test.go
+++ b/tests/integration/query/simple/with_dockey_test.go
@@ -37,7 +37,7 @@ func TestQuerySimpleWithDocKeyFilter(t *testing.T) {
 			Results: []map[string]any{
 				{
 					"Name": "John",
-					"Age":  uint64(21),
+					"Age":  int64(21),
 				},
 			},
 		},
@@ -82,7 +82,7 @@ func TestQuerySimpleWithDocKeyFilter(t *testing.T) {
 			Results: []map[string]any{
 				{
 					"Name": "John",
-					"Age":  uint64(21),
+					"Age":  int64(21),
 				},
 			},
 		},

--- a/tests/integration/query/simple/with_dockeys_test.go
+++ b/tests/integration/query/simple/with_dockeys_test.go
@@ -37,7 +37,7 @@ func TestQuerySimpleWithDocKeysFilter(t *testing.T) {
 			Results: []map[string]any{
 				{
 					"Name": "John",
-					"Age":  uint64(21),
+					"Age":  int64(21),
 				},
 			},
 		},
@@ -82,7 +82,7 @@ func TestQuerySimpleWithDocKeysFilter(t *testing.T) {
 			Results: []map[string]any{
 				{
 					"Name": "John",
-					"Age":  uint64(21),
+					"Age":  int64(21),
 				},
 			},
 		},
@@ -113,11 +113,11 @@ func TestQuerySimpleWithDocKeysFilter(t *testing.T) {
 			Results: []map[string]any{
 				{
 					"Name": "Jim",
-					"Age":  uint64(27),
+					"Age":  int64(27),
 				},
 				{
 					"Name": "John",
-					"Age":  uint64(21),
+					"Age":  int64(21),
 				},
 			},
 		},

--- a/tests/integration/query/simple/with_filter/with_and_test.go
+++ b/tests/integration/query/simple/with_filter/with_and_test.go
@@ -48,11 +48,11 @@ func TestQuerySimpleWithIntGreaterThanAndIntLessThanFilter(t *testing.T) {
 		Results: []map[string]any{
 			{
 				"Name": "Bob",
-				"Age":  uint64(32),
+				"Age":  int64(32),
 			},
 			{
 				"Name": "John",
-				"Age":  uint64(21),
+				"Age":  int64(21),
 			},
 		},
 	}

--- a/tests/integration/query/simple/with_filter/with_eq_datetime_test.go
+++ b/tests/integration/query/simple/with_filter/with_eq_datetime_test.go
@@ -43,7 +43,7 @@ func TestQuerySimpleWithDateTimeEqualsFilterBlock(t *testing.T) {
 		Results: []map[string]any{
 			{
 				"Name":      "John",
-				"Age":       uint64(21),
+				"Age":       int64(21),
 				"CreatedAt": "2017-07-23T03:46:56.647Z",
 			},
 		},
@@ -83,7 +83,7 @@ func TestQuerySimpleWithDateTimeEqualsNilFilterBlock(t *testing.T) {
 		Results: []map[string]any{
 			{
 				"Name":      "Fred",
-				"Age":       uint64(44),
+				"Age":       int64(44),
 				"CreatedAt": nil,
 			},
 		},

--- a/tests/integration/query/simple/with_filter/with_eq_int_test.go
+++ b/tests/integration/query/simple/with_filter/with_eq_int_test.go
@@ -40,7 +40,7 @@ func TestQuerySimpleWithIntEqualsFilterBlock(t *testing.T) {
 		Results: []map[string]any{
 			{
 				"Name": "John",
-				"Age":  uint64(21),
+				"Age":  int64(21),
 			},
 		},
 	}

--- a/tests/integration/query/simple/with_filter/with_eq_string_test.go
+++ b/tests/integration/query/simple/with_filter/with_eq_string_test.go
@@ -40,7 +40,7 @@ func TestQuerySimpleWithStringFilterBlock(t *testing.T) {
 		Results: []map[string]any{
 			{
 				"Name": "John",
-				"Age":  uint64(21),
+				"Age":  int64(21),
 			},
 		},
 	}
@@ -75,7 +75,7 @@ func TestQuerySimpleWithStringEqualsNilFilterBlock(t *testing.T) {
 		Results: []map[string]any{
 			{
 				"Name": nil,
-				"Age":  uint64(60),
+				"Age":  int64(60),
 			},
 		},
 	}
@@ -131,7 +131,7 @@ func TestQuerySimpleWithStringFilterBlockAndSelect(t *testing.T) {
 			},
 			Results: []map[string]any{
 				{
-					"Age": uint64(21),
+					"Age": int64(21),
 				},
 			},
 		},

--- a/tests/integration/query/simple/with_filter/with_gt_int_test.go
+++ b/tests/integration/query/simple/with_filter/with_gt_int_test.go
@@ -41,7 +41,7 @@ func TestQuerySimpleWithIntGreaterThanFilterBlock(t *testing.T) {
 			Results: []map[string]any{
 				{
 					"Name": "John",
-					"Age":  uint64(21),
+					"Age":  int64(21),
 				},
 			},
 		},
@@ -90,11 +90,11 @@ func TestQuerySimpleWithIntGreaterThanFilterBlock(t *testing.T) {
 			Results: []map[string]any{
 				{
 					"Name": "Bob",
-					"Age":  uint64(32),
+					"Age":  int64(32),
 				},
 				{
 					"Name": "John",
-					"Age":  uint64(21),
+					"Age":  int64(21),
 				},
 			},
 		},

--- a/tests/integration/query/simple/with_filter/with_in_test.go
+++ b/tests/integration/query/simple/with_filter/with_in_test.go
@@ -48,11 +48,11 @@ func TestQuerySimpleWithIntInFilter(t *testing.T) {
 		Results: []map[string]any{
 			{
 				"Name": "Alice",
-				"Age":  uint64(19),
+				"Age":  int64(19),
 			},
 			{
 				"Name": "Carlo",
-				"Age":  uint64(55),
+				"Age":  int64(55),
 			},
 		},
 	}
@@ -99,11 +99,11 @@ func TestQuerySimpleWithIntInFilterWithNullValue(t *testing.T) {
 			},
 			{
 				"Name": "Alice",
-				"Age":  uint64(19),
+				"Age":  int64(19),
 			},
 			{
 				"Name": "Carlo",
-				"Age":  uint64(55),
+				"Age":  int64(55),
 			},
 		},
 	}

--- a/tests/integration/query/simple/with_filter/with_ne_string_test.go
+++ b/tests/integration/query/simple/with_filter/with_ne_string_test.go
@@ -38,7 +38,7 @@ func TestQuerySimpleWithStringNotEqualsFilterBlock(t *testing.T) {
 		},
 		Results: []map[string]any{
 			{
-				"Age": uint64(32),
+				"Age": int64(32),
 			},
 		},
 	}
@@ -71,10 +71,10 @@ func TestQuerySimpleWithStringNotEqualsNilFilterBlock(t *testing.T) {
 		},
 		Results: []map[string]any{
 			{
-				"Age": uint64(32),
+				"Age": int64(32),
 			},
 			{
-				"Age": uint64(21),
+				"Age": int64(21),
 			},
 		},
 	}

--- a/tests/integration/query/simple/with_filter/with_not_test.go
+++ b/tests/integration/query/simple/with_filter/with_not_test.go
@@ -48,15 +48,15 @@ func TestQuerySimple_WithNotEqualToXFilter_NoError(t *testing.T) {
 		Results: []map[string]any{
 			{
 				"Name": "Bob",
-				"Age":  uint64(32),
+				"Age":  int64(32),
 			},
 			{
 				"Name": "Alice",
-				"Age":  uint64(19),
+				"Age":  int64(19),
 			},
 			{
 				"Name": "John",
-				"Age":  uint64(21),
+				"Age":  int64(21),
 			},
 		},
 	}
@@ -96,7 +96,7 @@ func TestQuerySimple_WithNotAndComparisonXFilter_NoError(t *testing.T) {
 		Results: []map[string]any{
 			{
 				"Name": "Alice",
-				"Age":  uint64(19),
+				"Age":  int64(19),
 			},
 		},
 	}
@@ -136,11 +136,11 @@ func TestQuerySimple_WithNotEqualToXorYFilter_NoError(t *testing.T) {
 		Results: []map[string]any{
 			{
 				"Name": "Bob",
-				"Age":  uint64(32),
+				"Age":  int64(32),
 			},
 			{
 				"Name": "John",
-				"Age":  uint64(21),
+				"Age":  int64(21),
 			},
 		},
 	}
@@ -219,19 +219,19 @@ func TestQuerySimple_WithNotEqualToXAndNotYFilter_NoError(t *testing.T) {
 		Results: []map[string]any{
 			{
 				"Name": "Bob",
-				"Age":  uint64(32),
+				"Age":  int64(32),
 			},
 			{
 				"Name": "Alice",
-				"Age":  uint64(19),
+				"Age":  int64(19),
 			},
 			{
 				"Name": "John",
-				"Age":  uint64(21),
+				"Age":  int64(21),
 			},
 			{
 				"Name": "Carlo",
-				"Age":  uint64(55),
+				"Age":  int64(55),
 			},
 		},
 	}

--- a/tests/integration/query/simple/with_filter/with_or_test.go
+++ b/tests/integration/query/simple/with_filter/with_or_test.go
@@ -48,11 +48,11 @@ func TestQuerySimpleWithIntEqualToXOrYFilter(t *testing.T) {
 		Results: []map[string]any{
 			{
 				"Name": "Alice",
-				"Age":  uint64(19),
+				"Age":  int64(19),
 			},
 			{
 				"Name": "Carlo",
-				"Age":  uint64(55),
+				"Age":  int64(55),
 			},
 		},
 	}

--- a/tests/integration/query/simple/with_group_average_filter_test.go
+++ b/tests/integration/query/simple/with_group_average_filter_test.go
@@ -90,7 +90,7 @@ func TestQuerySimpleWithGroupByStringWithRenderedGroupAndChildAverageWithFilter(
 				"_avg": float64(0),
 				"_group": []map[string]any{
 					{
-						"Age": uint64(19),
+						"Age": int64(19),
 					},
 				},
 			},
@@ -99,10 +99,10 @@ func TestQuerySimpleWithGroupByStringWithRenderedGroupAndChildAverageWithFilter(
 				"_avg": float64(33),
 				"_group": []map[string]any{
 					{
-						"Age": uint64(32),
+						"Age": int64(32),
 					},
 					{
-						"Age": uint64(34),
+						"Age": int64(34),
 					},
 				},
 			},
@@ -149,10 +149,10 @@ func TestQuerySimpleWithGroupByStringWithRenderedGroupAndChildAverageWithDateTim
 				"_avg": float64(33),
 				"_group": []map[string]any{
 					{
-						"Age": uint64(32),
+						"Age": int64(32),
 					},
 					{
-						"Age": uint64(34),
+						"Age": int64(34),
 					},
 				},
 			},
@@ -161,7 +161,7 @@ func TestQuerySimpleWithGroupByStringWithRenderedGroupAndChildAverageWithDateTim
 				"_avg": float64(0),
 				"_group": []map[string]any{
 					{
-						"Age": uint64(19),
+						"Age": int64(19),
 					},
 				},
 			},
@@ -210,7 +210,7 @@ func TestQuerySimpleWithGroupByStringWithRenderedGroupWithFilterAndChildAverageW
 				"_avg": float64(34),
 				"_group": []map[string]any{
 					{
-						"Age": uint64(34),
+						"Age": int64(34),
 					},
 				},
 			},
@@ -257,7 +257,7 @@ func TestQuerySimpleWithGroupByStringWithRenderedGroupWithFilterAndChildAverageW
 				"_avg": float64(34),
 				"_group": []map[string]any{
 					{
-						"Age": uint64(34),
+						"Age": int64(34),
 					},
 				},
 			},
@@ -306,7 +306,7 @@ func TestQuerySimpleWithGroupByStringWithRenderedGroupWithFilterAndChildAverageW
 				"_avg": float64(0),
 				"_group": []map[string]any{
 					{
-						"Age": uint64(19),
+						"Age": int64(19),
 					},
 				},
 			},
@@ -315,7 +315,7 @@ func TestQuerySimpleWithGroupByStringWithRenderedGroupWithFilterAndChildAverageW
 				"_avg": float64(34),
 				"_group": []map[string]any{
 					{
-						"Age": uint64(32),
+						"Age": int64(32),
 					},
 				},
 			},

--- a/tests/integration/query/simple/with_group_average_test.go
+++ b/tests/integration/query/simple/with_group_average_test.go
@@ -441,7 +441,7 @@ func TestQuerySimpleWithGroupByStringWithInnerGroupBooleanAndAverageOfAverageOfA
 						"_avg":     float64(2.22),
 						"_group": []map[string]any{
 							{
-								"Age":  uint64(34),
+								"Age":  int64(34),
 								"_avg": float64(2.22),
 							},
 						},
@@ -451,11 +451,11 @@ func TestQuerySimpleWithGroupByStringWithInnerGroupBooleanAndAverageOfAverageOfA
 						"_avg":     float64(1.715),
 						"_group": []map[string]any{
 							{
-								"Age":  uint64(32),
+								"Age":  int64(32),
 								"_avg": float64(1.61),
 							},
 							{
-								"Age":  uint64(25),
+								"Age":  int64(25),
 								"_avg": float64(1.82),
 							},
 						},
@@ -471,7 +471,7 @@ func TestQuerySimpleWithGroupByStringWithInnerGroupBooleanAndAverageOfAverageOfA
 						"_avg":     float64(2.04),
 						"_group": []map[string]any{
 							{
-								"Age":  uint64(19),
+								"Age":  int64(19),
 								"_avg": float64(2.04),
 							},
 						},
@@ -487,7 +487,7 @@ func TestQuerySimpleWithGroupByStringWithInnerGroupBooleanAndAverageOfAverageOfA
 						"_avg":     float64(1.74),
 						"_group": []map[string]any{
 							{
-								"Age":  uint64(55),
+								"Age":  int64(55),
 								"_avg": float64(1.74),
 							},
 						},

--- a/tests/integration/query/simple/with_group_count_filter_test.go
+++ b/tests/integration/query/simple/with_group_count_filter_test.go
@@ -43,11 +43,11 @@ func TestQuerySimpleWithGroupByNumberWithoutRenderedGroupAndChildCountWithFilter
 		},
 		Results: []map[string]any{
 			{
-				"Age":    uint64(32),
+				"Age":    int64(32),
 				"_count": 2,
 			},
 			{
-				"Age":    uint64(19),
+				"Age":    int64(19),
 				"_count": 0,
 			},
 		},
@@ -86,7 +86,7 @@ func TestQuerySimpleWithGroupByNumberWithRenderedGroupAndChildCountWithFilter(t 
 		},
 		Results: []map[string]any{
 			{
-				"Age":    uint64(32),
+				"Age":    int64(32),
 				"_count": 2,
 				"_group": []map[string]any{
 					{
@@ -98,7 +98,7 @@ func TestQuerySimpleWithGroupByNumberWithRenderedGroupAndChildCountWithFilter(t 
 				},
 			},
 			{
-				"Age":    uint64(19),
+				"Age":    int64(19),
 				"_count": 0,
 				"_group": []map[string]any{
 					{
@@ -142,7 +142,7 @@ func TestQuerySimpleWithGroupByNumberWithRenderedGroupWithFilterAndChildCountWit
 		},
 		Results: []map[string]any{
 			{
-				"Age":    uint64(32),
+				"Age":    int64(32),
 				"_count": 1,
 				"_group": []map[string]any{
 					{
@@ -151,7 +151,7 @@ func TestQuerySimpleWithGroupByNumberWithRenderedGroupWithFilterAndChildCountWit
 				},
 			},
 			{
-				"Age":    uint64(19),
+				"Age":    int64(19),
 				"_count": 0,
 				"_group": []map[string]any{},
 			},
@@ -191,7 +191,7 @@ func TestQuerySimpleWithGroupByNumberWithRenderedGroupWithFilterAndChildCountWit
 		},
 		Results: []map[string]any{
 			{
-				"Age":    uint64(32),
+				"Age":    int64(32),
 				"_count": 2,
 				"_group": []map[string]any{
 					{
@@ -200,7 +200,7 @@ func TestQuerySimpleWithGroupByNumberWithRenderedGroupWithFilterAndChildCountWit
 				},
 			},
 			{
-				"Age":    uint64(19),
+				"Age":    int64(19),
 				"_count": 0,
 				"_group": []map[string]any{},
 			},
@@ -238,12 +238,12 @@ func TestQuerySimpleWithGroupByNumberWithoutRenderedGroupAndChildCountsWithDiffe
 		},
 		Results: []map[string]any{
 			{
-				"Age": uint64(32),
+				"Age": int64(32),
 				"C1":  2,
 				"C2":  0,
 			},
 			{
-				"Age": uint64(19),
+				"Age": int64(19),
 				"C1":  0,
 				"C2":  1,
 			},

--- a/tests/integration/query/simple/with_group_count_limit_offset_test.go
+++ b/tests/integration/query/simple/with_group_count_limit_offset_test.go
@@ -43,11 +43,11 @@ func TestQuerySimpleWithGroupByNumberWithoutRenderedGroupAndChildCountWithLimitA
 		},
 		Results: []map[string]any{
 			{
-				"Age":    uint64(32),
+				"Age":    int64(32),
 				"_count": 1,
 			},
 			{
-				"Age":    uint64(19),
+				"Age":    int64(19),
 				"_count": 0,
 			},
 		},
@@ -90,7 +90,7 @@ func TestQuerySimpleWithGroupByNumberWithRenderedGroupWithLimitAndChildCountWith
 		},
 		Results: []map[string]any{
 			{
-				"Age":    uint64(32),
+				"Age":    int64(32),
 				"_count": 1,
 				"_group": []map[string]any{
 					{
@@ -102,7 +102,7 @@ func TestQuerySimpleWithGroupByNumberWithRenderedGroupWithLimitAndChildCountWith
 				},
 			},
 			{
-				"Age":    uint64(19),
+				"Age":    int64(19),
 				"_count": 0,
 				"_group": []map[string]any{
 					{

--- a/tests/integration/query/simple/with_group_count_limit_test.go
+++ b/tests/integration/query/simple/with_group_count_limit_test.go
@@ -43,11 +43,11 @@ func TestQuerySimpleWithGroupByNumberWithoutRenderedGroupAndChildCountWithLimit(
 		},
 		Results: []map[string]any{
 			{
-				"Age":    uint64(32),
+				"Age":    int64(32),
 				"_count": 1,
 			},
 			{
-				"Age":    uint64(19),
+				"Age":    int64(19),
 				"_count": 1,
 			},
 		},
@@ -90,7 +90,7 @@ func TestQuerySimpleWithGroupByNumberWithRenderedGroupWithLimitAndChildCountWith
 		},
 		Results: []map[string]any{
 			{
-				"Age":    uint64(32),
+				"Age":    int64(32),
 				"_count": 1,
 				"_group": []map[string]any{
 					{
@@ -102,7 +102,7 @@ func TestQuerySimpleWithGroupByNumberWithRenderedGroupWithLimitAndChildCountWith
 				},
 			},
 			{
-				"Age":    uint64(19),
+				"Age":    int64(19),
 				"_count": 1,
 				"_group": []map[string]any{
 					{

--- a/tests/integration/query/simple/with_group_count_test.go
+++ b/tests/integration/query/simple/with_group_count_test.go
@@ -92,11 +92,11 @@ func TestQuerySimpleWithGroupByNumberWithoutRenderedGroupAndChildCount(t *testin
 		},
 		Results: []map[string]any{
 			{
-				"Age":    uint64(32),
+				"Age":    int64(32),
 				"_count": 2,
 			},
 			{
-				"Age":    uint64(19),
+				"Age":    int64(19),
 				"_count": 1,
 			},
 		},
@@ -150,7 +150,7 @@ func TestQuerySimpleWithGroupByNumberWithRenderedGroupAndChildCount(t *testing.T
 		},
 		Results: []map[string]any{
 			{
-				"Age":    uint64(32),
+				"Age":    int64(32),
 				"_count": 2,
 				"_group": []map[string]any{
 					{
@@ -162,7 +162,7 @@ func TestQuerySimpleWithGroupByNumberWithRenderedGroupAndChildCount(t *testing.T
 				},
 			},
 			{
-				"Age":    uint64(19),
+				"Age":    int64(19),
 				"_count": 1,
 				"_group": []map[string]any{
 					{
@@ -234,11 +234,11 @@ func TestQuerySimpleWithGroupByNumberWithoutRenderedGroupAndAliasesChildCount(t 
 		},
 		Results: []map[string]any{
 			{
-				"Age":   uint64(32),
+				"Age":   int64(32),
 				"Count": 2,
 			},
 			{
-				"Age":   uint64(19),
+				"Age":   int64(19),
 				"Count": 1,
 			},
 		},
@@ -277,12 +277,12 @@ func TestQuerySimpleWithGroupByNumberWithoutRenderedGroupAndDuplicatedAliasedChi
 		},
 		Results: []map[string]any{
 			{
-				"Age":    uint64(32),
+				"Age":    int64(32),
 				"Count1": 2,
 				"Count2": 2,
 			},
 			{
-				"Age":    uint64(19),
+				"Age":    int64(19),
 				"Count1": 1,
 				"Count2": 1,
 			},

--- a/tests/integration/query/simple/with_group_dockey_test.go
+++ b/tests/integration/query/simple/with_group_dockey_test.go
@@ -46,11 +46,11 @@ func TestQuerySimpleWithGroupByWithGroupWithDocKey(t *testing.T) {
 		},
 		Results: []map[string]any{
 			{
-				"Age":    uint64(32),
+				"Age":    int64(32),
 				"_group": []map[string]any{},
 			},
 			{
-				"Age": uint64(21),
+				"Age": int64(21),
 				"_group": []map[string]any{
 					{
 						"Name": "John",

--- a/tests/integration/query/simple/with_group_dockeys_test.go
+++ b/tests/integration/query/simple/with_group_dockeys_test.go
@@ -51,11 +51,11 @@ func TestQuerySimpleWithGroupByWithGroupWithDocKeys(t *testing.T) {
 		},
 		Results: []map[string]any{
 			{
-				"Age":    uint64(32),
+				"Age":    int64(32),
 				"_group": []map[string]any{},
 			},
 			{
-				"Age": uint64(21),
+				"Age": int64(21),
 				"_group": []map[string]any{
 					{
 						"Name": "John",

--- a/tests/integration/query/simple/with_group_filter_test.go
+++ b/tests/integration/query/simple/with_group_filter_test.go
@@ -56,7 +56,7 @@ func TestQuerySimpleWithGroupByStringWithGroupNumberFilter(t *testing.T) {
 				"Name": "John",
 				"_group": []map[string]any{
 					{
-						"Age": uint64(32),
+						"Age": int64(32),
 					},
 				},
 			},
@@ -64,7 +64,7 @@ func TestQuerySimpleWithGroupByStringWithGroupNumberFilter(t *testing.T) {
 				"Name": "Carlo",
 				"_group": []map[string]any{
 					{
-						"Age": uint64(55),
+						"Age": int64(55),
 					},
 				},
 			},
@@ -110,7 +110,7 @@ func TestQuerySimpleWithGroupByStringWithGroupNumberWithParentFilter(t *testing.
 				"Name": "John",
 				"_group": []map[string]any{
 					{
-						"Age": uint64(32),
+						"Age": int64(32),
 					},
 				},
 			},
@@ -118,7 +118,7 @@ func TestQuerySimpleWithGroupByStringWithGroupNumberWithParentFilter(t *testing.
 				"Name": "Carlo",
 				"_group": []map[string]any{
 					{
-						"Age": uint64(55),
+						"Age": int64(55),
 					},
 				},
 			},
@@ -292,7 +292,7 @@ func TestQuerySimpleWithGroupByStringWithMultipleGroupNumberFilter(t *testing.T)
 				"G1":   []map[string]any{},
 				"G2": []map[string]any{
 					{
-						"Age": uint64(19),
+						"Age": int64(19),
 					},
 				},
 			},
@@ -300,12 +300,12 @@ func TestQuerySimpleWithGroupByStringWithMultipleGroupNumberFilter(t *testing.T)
 				"Name": "John",
 				"G1": []map[string]any{
 					{
-						"Age": uint64(32),
+						"Age": int64(32),
 					},
 				},
 				"G2": []map[string]any{
 					{
-						"Age": uint64(25),
+						"Age": int64(25),
 					},
 				},
 			},
@@ -313,7 +313,7 @@ func TestQuerySimpleWithGroupByStringWithMultipleGroupNumberFilter(t *testing.T)
 				"Name": "Carlo",
 				"G1": []map[string]any{
 					{
-						"Age": uint64(55),
+						"Age": int64(55),
 					},
 				},
 				"G2": []map[string]any{},

--- a/tests/integration/query/simple/with_group_limit_offset_test.go
+++ b/tests/integration/query/simple/with_group_limit_offset_test.go
@@ -45,7 +45,7 @@ func TestQuerySimpleWithGroupByNumberWithGroupLimitAndOffset(t *testing.T) {
 		},
 		Results: []map[string]any{
 			{
-				"Age": uint64(32),
+				"Age": int64(32),
 				"_group": []map[string]any{
 					{
 						"Name": "John",
@@ -53,7 +53,7 @@ func TestQuerySimpleWithGroupByNumberWithGroupLimitAndOffset(t *testing.T) {
 				},
 			},
 			{
-				"Age":    uint64(19),
+				"Age":    int64(19),
 				"_group": []map[string]any{},
 			},
 		},
@@ -91,7 +91,7 @@ func TestQuerySimpleWithGroupByNumberWithLimitAndOffsetAndWithGroupLimitAndOffse
 		},
 		Results: []map[string]any{
 			{
-				"Age":    uint64(19),
+				"Age":    int64(19),
 				"_group": []map[string]any{},
 			},
 		},

--- a/tests/integration/query/simple/with_group_limit_test.go
+++ b/tests/integration/query/simple/with_group_limit_test.go
@@ -45,7 +45,7 @@ func TestQuerySimpleWithGroupByNumberWithGroupLimit(t *testing.T) {
 		},
 		Results: []map[string]any{
 			{
-				"Age": uint64(32),
+				"Age": int64(32),
 				"_group": []map[string]any{
 					{
 						"Name": "Bob",
@@ -53,7 +53,7 @@ func TestQuerySimpleWithGroupByNumberWithGroupLimit(t *testing.T) {
 				},
 			},
 			{
-				"Age": uint64(19),
+				"Age": int64(19),
 				"_group": []map[string]any{
 					{
 						"Name": "Alice",
@@ -98,7 +98,7 @@ func TestQuerySimpleWithGroupByNumberWithMultipleGroupsWithDifferentLimits(t *te
 		},
 		Results: []map[string]any{
 			{
-				"Age": uint64(32),
+				"Age": int64(32),
 				"G1": []map[string]any{
 					{
 						"Name": "Bob",
@@ -114,7 +114,7 @@ func TestQuerySimpleWithGroupByNumberWithMultipleGroupsWithDifferentLimits(t *te
 				},
 			},
 			{
-				"Age": uint64(19),
+				"Age": int64(19),
 				"G1": []map[string]any{
 					{
 						"Name": "Alice",
@@ -161,7 +161,7 @@ func TestQuerySimpleWithGroupByNumberWithLimitAndGroupWithHigherLimit(t *testing
 		},
 		Results: []map[string]any{
 			{
-				"Age": uint64(32),
+				"Age": int64(32),
 				"_group": []map[string]any{
 					{
 						"Name": "Bob",
@@ -210,7 +210,7 @@ func TestQuerySimpleWithGroupByNumberWithLimitAndGroupWithLowerLimit(t *testing.
 		},
 		Results: []map[string]any{
 			{
-				"Age": uint64(32),
+				"Age": int64(32),
 				"_group": []map[string]any{
 					{
 						"Name": "Bob",
@@ -218,7 +218,7 @@ func TestQuerySimpleWithGroupByNumberWithLimitAndGroupWithLowerLimit(t *testing.
 				},
 			},
 			{
-				"Age": uint64(42),
+				"Age": int64(42),
 				"_group": []map[string]any{
 					{
 						"Name": "Alice",

--- a/tests/integration/query/simple/with_group_order_test.go
+++ b/tests/integration/query/simple/with_group_order_test.go
@@ -52,7 +52,7 @@ func TestQuerySimpleWithGroupByStringWithGroupNumberWithGroupOrder(t *testing.T)
 				"Name": "Alice",
 				"_group": []map[string]any{
 					{
-						"Age": uint64(19),
+						"Age": int64(19),
 					},
 				},
 			},
@@ -60,10 +60,10 @@ func TestQuerySimpleWithGroupByStringWithGroupNumberWithGroupOrder(t *testing.T)
 				"Name": "John",
 				"_group": []map[string]any{
 					{
-						"Age": uint64(25),
+						"Age": int64(25),
 					},
 					{
-						"Age": uint64(32),
+						"Age": int64(32),
 					},
 				},
 			},
@@ -71,7 +71,7 @@ func TestQuerySimpleWithGroupByStringWithGroupNumberWithGroupOrder(t *testing.T)
 				"Name": "Carlo",
 				"_group": []map[string]any{
 					{
-						"Age": uint64(55),
+						"Age": int64(55),
 					},
 				},
 			},
@@ -117,7 +117,7 @@ func TestQuerySimpleWithGroupByStringWithGroupNumberWithGroupOrderDescending(t *
 				"Name": "Alice",
 				"_group": []map[string]any{
 					{
-						"Age": uint64(19),
+						"Age": int64(19),
 					},
 				},
 			},
@@ -125,7 +125,7 @@ func TestQuerySimpleWithGroupByStringWithGroupNumberWithGroupOrderDescending(t *
 				"Name": "Carlo",
 				"_group": []map[string]any{
 					{
-						"Age": uint64(55),
+						"Age": int64(55),
 					},
 				},
 			},
@@ -133,10 +133,10 @@ func TestQuerySimpleWithGroupByStringWithGroupNumberWithGroupOrderDescending(t *
 				"Name": "John",
 				"_group": []map[string]any{
 					{
-						"Age": uint64(32),
+						"Age": int64(32),
 					},
 					{
-						"Age": uint64(25),
+						"Age": int64(25),
 					},
 				},
 			},
@@ -182,10 +182,10 @@ func TestQuerySimpleWithGroupByStringAndOrderDescendingWithGroupNumberWithGroupO
 				"Name": "John",
 				"_group": []map[string]any{
 					{
-						"Age": uint64(25),
+						"Age": int64(25),
 					},
 					{
-						"Age": uint64(32),
+						"Age": int64(32),
 					},
 				},
 			},
@@ -193,7 +193,7 @@ func TestQuerySimpleWithGroupByStringAndOrderDescendingWithGroupNumberWithGroupO
 				"Name": "Carlo",
 				"_group": []map[string]any{
 					{
-						"Age": uint64(55),
+						"Age": int64(55),
 					},
 				},
 			},
@@ -201,7 +201,7 @@ func TestQuerySimpleWithGroupByStringAndOrderDescendingWithGroupNumberWithGroupO
 				"Name": "Alice",
 				"_group": []map[string]any{
 					{
-						"Age": uint64(19),
+						"Age": int64(19),
 					},
 				},
 			},
@@ -262,10 +262,10 @@ func TestQuerySimpleWithGroupByStringWithInnerGroupBooleanThenInnerOrderDescendi
 						"Verified": true,
 						"_group": []map[string]any{
 							{
-								"Age": uint64(32),
+								"Age": int64(32),
 							},
 							{
-								"Age": uint64(25),
+								"Age": int64(25),
 							},
 						},
 					},
@@ -273,7 +273,7 @@ func TestQuerySimpleWithGroupByStringWithInnerGroupBooleanThenInnerOrderDescendi
 						"Verified": false,
 						"_group": []map[string]any{
 							{
-								"Age": uint64(34),
+								"Age": int64(34),
 							},
 						},
 					},
@@ -286,7 +286,7 @@ func TestQuerySimpleWithGroupByStringWithInnerGroupBooleanThenInnerOrderDescendi
 						"Verified": true,
 						"_group": []map[string]any{
 							{
-								"Age": uint64(55),
+								"Age": int64(55),
 							},
 						},
 					},
@@ -299,7 +299,7 @@ func TestQuerySimpleWithGroupByStringWithInnerGroupBooleanThenInnerOrderDescendi
 						"Verified": false,
 						"_group": []map[string]any{
 							{
-								"Age": uint64(19),
+								"Age": int64(19),
 							},
 						},
 					},
@@ -364,10 +364,10 @@ func TestQuerySimpleWithGroupByStringWithInnerGroupBooleanAndOrderAscendingThenI
 						"Verified": false,
 						"_group": []map[string]any{
 							{
-								"Age": uint64(34),
+								"Age": int64(34),
 							},
 							{
-								"Age": uint64(25),
+								"Age": int64(25),
 							},
 						},
 					},
@@ -375,7 +375,7 @@ func TestQuerySimpleWithGroupByStringWithInnerGroupBooleanAndOrderAscendingThenI
 						"Verified": true,
 						"_group": []map[string]any{
 							{
-								"Age": uint64(32),
+								"Age": int64(32),
 							},
 						},
 					},
@@ -388,7 +388,7 @@ func TestQuerySimpleWithGroupByStringWithInnerGroupBooleanAndOrderAscendingThenI
 						"Verified": false,
 						"_group": []map[string]any{
 							{
-								"Age": uint64(19),
+								"Age": int64(19),
 							},
 						},
 					},
@@ -401,7 +401,7 @@ func TestQuerySimpleWithGroupByStringWithInnerGroupBooleanAndOrderAscendingThenI
 						"Verified": true,
 						"_group": []map[string]any{
 							{
-								"Age": uint64(55),
+								"Age": int64(55),
 							},
 						},
 					},

--- a/tests/integration/query/simple/with_group_sum_filter_test.go
+++ b/tests/integration/query/simple/with_group_sum_filter_test.go
@@ -43,11 +43,11 @@ func TestQuerySimpleWithGroupByNumberWithoutRenderedGroupAndChildSumWithFilter(t
 		},
 		Results: []map[string]any{
 			{
-				"Age":  uint64(32),
+				"Age":  int64(32),
 				"_sum": int64(64),
 			},
 			{
-				"Age":  uint64(19),
+				"Age":  int64(19),
 				"_sum": int64(0),
 			},
 		},
@@ -86,7 +86,7 @@ func TestQuerySimpleWithGroupByNumberWithRenderedGroupAndChildSumWithFilter(t *t
 		},
 		Results: []map[string]any{
 			{
-				"Age":  uint64(32),
+				"Age":  int64(32),
 				"_sum": int64(64),
 				"_group": []map[string]any{
 					{
@@ -98,7 +98,7 @@ func TestQuerySimpleWithGroupByNumberWithRenderedGroupAndChildSumWithFilter(t *t
 				},
 			},
 			{
-				"Age":  uint64(19),
+				"Age":  int64(19),
 				"_sum": int64(0),
 				"_group": []map[string]any{
 					{
@@ -142,7 +142,7 @@ func TestQuerySimpleWithGroupByNumberWithRenderedGroupWithFilterAndChildSumWithM
 		},
 		Results: []map[string]any{
 			{
-				"Age":  uint64(32),
+				"Age":  int64(32),
 				"_sum": int64(32),
 				"_group": []map[string]any{
 					{
@@ -151,7 +151,7 @@ func TestQuerySimpleWithGroupByNumberWithRenderedGroupWithFilterAndChildSumWithM
 				},
 			},
 			{
-				"Age":    uint64(19),
+				"Age":    int64(19),
 				"_sum":   int64(0),
 				"_group": []map[string]any{},
 			},
@@ -191,7 +191,7 @@ func TestQuerySimpleWithGroupByNumberWithRenderedGroupWithFilterAndChildSumWithD
 		},
 		Results: []map[string]any{
 			{
-				"Age":  uint64(32),
+				"Age":  int64(32),
 				"_sum": int64(64),
 				"_group": []map[string]any{
 					{
@@ -200,7 +200,7 @@ func TestQuerySimpleWithGroupByNumberWithRenderedGroupWithFilterAndChildSumWithD
 				},
 			},
 			{
-				"Age":    uint64(19),
+				"Age":    int64(19),
 				"_sum":   int64(0),
 				"_group": []map[string]any{},
 			},
@@ -238,12 +238,12 @@ func TestQuerySimpleWithGroupByNumberWithoutRenderedGroupAndChildSumsWithDiffere
 		},
 		Results: []map[string]any{
 			{
-				"Age": uint64(32),
+				"Age": int64(32),
 				"S1":  int64(64),
 				"S2":  int64(0),
 			},
 			{
-				"Age": uint64(19),
+				"Age": int64(19),
 				"S1":  int64(0),
 				"S2":  int64(19),
 			},

--- a/tests/integration/query/simple/with_group_sum_test.go
+++ b/tests/integration/query/simple/with_group_sum_test.go
@@ -441,7 +441,7 @@ func TestQuerySimpleWithGroupByStringWithInnerGroupBooleanAndSumOfSumOfSumOfFloa
 						"_sum":     float64(2.22),
 						"_group": []map[string]any{
 							{
-								"Age":  uint64(34),
+								"Age":  int64(34),
 								"_sum": float64(2.22),
 							},
 						},
@@ -451,11 +451,11 @@ func TestQuerySimpleWithGroupByStringWithInnerGroupBooleanAndSumOfSumOfSumOfFloa
 						"_sum":     float64(3.43),
 						"_group": []map[string]any{
 							{
-								"Age":  uint64(32),
+								"Age":  int64(32),
 								"_sum": float64(1.61),
 							},
 							{
-								"Age":  uint64(25),
+								"Age":  int64(25),
 								"_sum": float64(1.82),
 							},
 						},
@@ -471,7 +471,7 @@ func TestQuerySimpleWithGroupByStringWithInnerGroupBooleanAndSumOfSumOfSumOfFloa
 						"_sum":     float64(2.04),
 						"_group": []map[string]any{
 							{
-								"Age":  uint64(19),
+								"Age":  int64(19),
 								"_sum": float64(2.04),
 							},
 						},
@@ -487,7 +487,7 @@ func TestQuerySimpleWithGroupByStringWithInnerGroupBooleanAndSumOfSumOfSumOfFloa
 						"_sum":     float64(1.74),
 						"_group": []map[string]any{
 							{
-								"Age":  uint64(55),
+								"Age":  int64(55),
 								"_sum": float64(1.74),
 							},
 						},

--- a/tests/integration/query/simple/with_group_test.go
+++ b/tests/integration/query/simple/with_group_test.go
@@ -85,13 +85,13 @@ func TestQuerySimpleWithGroupByNumber(t *testing.T) {
 		},
 		Results: []map[string]any{
 			{
-				"Age": uint64(32),
+				"Age": int64(32),
 			},
 			{
-				"Age": uint64(19),
+				"Age": int64(19),
 			},
 			{
-				"Age": uint64(55),
+				"Age": int64(55),
 			},
 		},
 	}
@@ -176,7 +176,7 @@ func TestQuerySimpleWithGroupByNumberWithGroupString(t *testing.T) {
 		},
 		Results: []map[string]any{
 			{
-				"Age": uint64(32),
+				"Age": int64(32),
 				"_group": []map[string]any{
 					{
 						"Name": "Bob",
@@ -187,7 +187,7 @@ func TestQuerySimpleWithGroupByNumberWithGroupString(t *testing.T) {
 				},
 			},
 			{
-				"Age": uint64(19),
+				"Age": int64(19),
 				"_group": []map[string]any{
 					{
 						"Name": "Alice",
@@ -195,7 +195,7 @@ func TestQuerySimpleWithGroupByNumberWithGroupString(t *testing.T) {
 				},
 			},
 			{
-				"Age": uint64(55),
+				"Age": int64(55),
 				"_group": []map[string]any{
 					{
 						"Name": "Carlo",
@@ -244,7 +244,7 @@ func TestQuerySimpleWithGroupByWithoutGroupedFieldSelectedWithInnerGroup(t *test
 				"Name": "Alice",
 				"_group": []map[string]any{
 					{
-						"Age": uint64(19),
+						"Age": int64(19),
 					},
 				},
 			},
@@ -252,10 +252,10 @@ func TestQuerySimpleWithGroupByWithoutGroupedFieldSelectedWithInnerGroup(t *test
 				"Name": "John",
 				"_group": []map[string]any{
 					{
-						"Age": uint64(32),
+						"Age": int64(32),
 					},
 					{
-						"Age": uint64(25),
+						"Age": int64(25),
 					},
 				},
 			},
@@ -263,7 +263,7 @@ func TestQuerySimpleWithGroupByWithoutGroupedFieldSelectedWithInnerGroup(t *test
 				"Name": "Carlo",
 				"_group": []map[string]any{
 					{
-						"Age": uint64(55),
+						"Age": int64(55),
 					},
 				},
 			},
@@ -309,7 +309,7 @@ func TestQuerySimpleWithGroupByString(t *testing.T) {
 				"Name": "Alice",
 				"_group": []map[string]any{
 					{
-						"Age": uint64(19),
+						"Age": int64(19),
 					},
 				},
 			},
@@ -317,10 +317,10 @@ func TestQuerySimpleWithGroupByString(t *testing.T) {
 				"Name": "John",
 				"_group": []map[string]any{
 					{
-						"Age": uint64(32),
+						"Age": int64(32),
 					},
 					{
-						"Age": uint64(25),
+						"Age": int64(25),
 					},
 				},
 			},
@@ -328,7 +328,7 @@ func TestQuerySimpleWithGroupByString(t *testing.T) {
 				"Name": "Carlo",
 				"_group": []map[string]any{
 					{
-						"Age": uint64(55),
+						"Age": int64(55),
 					},
 				},
 			},
@@ -389,10 +389,10 @@ func TestQuerySimpleWithGroupByStringWithInnerGroupBoolean(t *testing.T) {
 						"Verified": true,
 						"_group": []map[string]any{
 							{
-								"Age": uint64(25),
+								"Age": int64(25),
 							},
 							{
-								"Age": uint64(32),
+								"Age": int64(32),
 							},
 						},
 					},
@@ -400,7 +400,7 @@ func TestQuerySimpleWithGroupByStringWithInnerGroupBoolean(t *testing.T) {
 						"Verified": false,
 						"_group": []map[string]any{
 							{
-								"Age": uint64(34),
+								"Age": int64(34),
 							},
 						},
 					},
@@ -413,7 +413,7 @@ func TestQuerySimpleWithGroupByStringWithInnerGroupBoolean(t *testing.T) {
 						"Verified": false,
 						"_group": []map[string]any{
 							{
-								"Age": uint64(19),
+								"Age": int64(19),
 							},
 						},
 					},
@@ -426,7 +426,7 @@ func TestQuerySimpleWithGroupByStringWithInnerGroupBoolean(t *testing.T) {
 						"Verified": true,
 						"_group": []map[string]any{
 							{
-								"Age": uint64(55),
+								"Age": int64(55),
 							},
 						},
 					},
@@ -485,10 +485,10 @@ func TestQuerySimpleWithGroupByStringThenBoolean(t *testing.T) {
 				"Verified": true,
 				"_group": []map[string]any{
 					{
-						"Age": uint64(25),
+						"Age": int64(25),
 					},
 					{
-						"Age": uint64(32),
+						"Age": int64(32),
 					},
 				},
 			},
@@ -497,7 +497,7 @@ func TestQuerySimpleWithGroupByStringThenBoolean(t *testing.T) {
 				"Verified": false,
 				"_group": []map[string]any{
 					{
-						"Age": uint64(34),
+						"Age": int64(34),
 					},
 				},
 			},
@@ -506,7 +506,7 @@ func TestQuerySimpleWithGroupByStringThenBoolean(t *testing.T) {
 				"Verified": false,
 				"_group": []map[string]any{
 					{
-						"Age": uint64(19),
+						"Age": int64(19),
 					},
 				},
 			},
@@ -515,7 +515,7 @@ func TestQuerySimpleWithGroupByStringThenBoolean(t *testing.T) {
 				"Verified": true,
 				"_group": []map[string]any{
 					{
-						"Age": uint64(55),
+						"Age": int64(55),
 					},
 				},
 			},
@@ -572,10 +572,10 @@ func TestQuerySimpleWithGroupByBooleanThenNumber(t *testing.T) {
 				"Verified": true,
 				"_group": []map[string]any{
 					{
-						"Age": uint64(25),
+						"Age": int64(25),
 					},
 					{
-						"Age": uint64(32),
+						"Age": int64(32),
 					},
 				},
 			},
@@ -584,7 +584,7 @@ func TestQuerySimpleWithGroupByBooleanThenNumber(t *testing.T) {
 				"Verified": false,
 				"_group": []map[string]any{
 					{
-						"Age": uint64(34),
+						"Age": int64(34),
 					},
 				},
 			},
@@ -593,7 +593,7 @@ func TestQuerySimpleWithGroupByBooleanThenNumber(t *testing.T) {
 				"Verified": false,
 				"_group": []map[string]any{
 					{
-						"Age": uint64(19),
+						"Age": int64(19),
 					},
 				},
 			},
@@ -602,7 +602,7 @@ func TestQuerySimpleWithGroupByBooleanThenNumber(t *testing.T) {
 				"Verified": true,
 				"_group": []map[string]any{
 					{
-						"Age": uint64(55),
+						"Age": int64(55),
 					},
 				},
 			},
@@ -639,7 +639,7 @@ func TestQuerySimpleWithGroupByNumberOnUndefined(t *testing.T) {
 				"Age": nil,
 			},
 			{
-				"Age": uint64(32),
+				"Age": int64(32),
 			},
 		},
 	}
@@ -685,7 +685,7 @@ func TestQuerySimpleWithGroupByNumberOnUndefinedWithChildren(t *testing.T) {
 				},
 			},
 			{
-				"Age": uint64(32),
+				"Age": int64(32),
 				"_group": []map[string]any{
 					{
 						"Name": "John",

--- a/tests/integration/query/simple/with_key_test.go
+++ b/tests/integration/query/simple/with_key_test.go
@@ -40,7 +40,7 @@ func TestQuerySimpleWithKeyFilterBlock(t *testing.T) {
 		Results: []map[string]any{
 			{
 				"Name": "John",
-				"Age":  uint64(21),
+				"Age":  int64(21),
 			},
 		},
 	}

--- a/tests/integration/query/simple/with_limit_offset_test.go
+++ b/tests/integration/query/simple/with_limit_offset_test.go
@@ -74,7 +74,7 @@ func TestQuerySimpleWithLimit(t *testing.T) {
 			Results: []map[string]any{
 				{
 					"Name": "Bob",
-					"Age":  uint64(32),
+					"Age":  int64(32),
 				},
 			},
 		},
@@ -109,11 +109,11 @@ func TestQuerySimpleWithLimit(t *testing.T) {
 			Results: []map[string]any{
 				{
 					"Name": "Bob",
-					"Age":  uint64(32),
+					"Age":  int64(32),
 				},
 				{
 					"Name": "Alice",
-					"Age":  uint64(19),
+					"Age":  int64(19),
 				},
 			},
 		},
@@ -149,7 +149,7 @@ func TestQuerySimpleWithLimitAndOffset(t *testing.T) {
 			Results: []map[string]any{
 				{
 					"Name": "John",
-					"Age":  uint64(21),
+					"Age":  int64(21),
 				},
 			},
 		},
@@ -184,11 +184,11 @@ func TestQuerySimpleWithLimitAndOffset(t *testing.T) {
 			Results: []map[string]any{
 				{
 					"Name": "John",
-					"Age":  uint64(21),
+					"Age":  int64(21),
 				},
 				{
 					"Name": "Carlo",
-					"Age":  uint64(55),
+					"Age":  int64(55),
 				},
 			},
 		},
@@ -224,7 +224,7 @@ func TestQuerySimpleWithOffset(t *testing.T) {
 			Results: []map[string]any{
 				{
 					"Name": "John",
-					"Age":  uint64(21),
+					"Age":  int64(21),
 				},
 			},
 		},
@@ -263,15 +263,15 @@ func TestQuerySimpleWithOffset(t *testing.T) {
 			Results: []map[string]any{
 				{
 					"Name": "Alice",
-					"Age":  uint64(19),
+					"Age":  int64(19),
 				},
 				{
 					"Name": "John",
-					"Age":  uint64(21),
+					"Age":  int64(21),
 				},
 				{
 					"Name": "Carlo",
-					"Age":  uint64(55),
+					"Age":  int64(55),
 				},
 			},
 		},

--- a/tests/integration/query/simple/with_order_filter_test.go
+++ b/tests/integration/query/simple/with_order_filter_test.go
@@ -48,11 +48,11 @@ func TestQuerySimpleWithNumericGreaterThanFilterAndNumericOrderDescending(t *tes
 		Results: []map[string]any{
 			{
 				"Name": "Carlo",
-				"Age":  uint64(55),
+				"Age":  int64(55),
 			},
 			{
 				"Name": "Bob",
-				"Age":  uint64(32),
+				"Age":  int64(32),
 			},
 		},
 	}

--- a/tests/integration/query/simple/with_order_test.go
+++ b/tests/integration/query/simple/with_order_test.go
@@ -43,15 +43,15 @@ func TestQuerySimpleWithEmptyOrder(t *testing.T) {
 		Results: []map[string]any{
 			{
 				"Name": "Bob",
-				"Age":  uint64(32),
+				"Age":  int64(32),
 			},
 			{
 				"Name": "John",
-				"Age":  uint64(21),
+				"Age":  int64(21),
 			},
 			{
 				"Name": "Carlo",
-				"Age":  uint64(55),
+				"Age":  int64(55),
 			},
 		},
 	}
@@ -91,19 +91,19 @@ func TestQuerySimpleWithNumericOrderAscending(t *testing.T) {
 		Results: []map[string]any{
 			{
 				"Name": "Alice",
-				"Age":  uint64(19),
+				"Age":  int64(19),
 			},
 			{
 				"Name": "John",
-				"Age":  uint64(21),
+				"Age":  int64(21),
 			},
 			{
 				"Name": "Bob",
-				"Age":  uint64(32),
+				"Age":  int64(32),
 			},
 			{
 				"Name": "Carlo",
-				"Age":  uint64(55),
+				"Age":  int64(55),
 			},
 		},
 	}
@@ -147,19 +147,19 @@ func TestQuerySimpleWithDateTimeOrderAscending(t *testing.T) {
 		Results: []map[string]any{
 			{
 				"Name": "Alice",
-				"Age":  uint64(19),
+				"Age":  int64(19),
 			},
 			{
 				"Name": "John",
-				"Age":  uint64(21),
+				"Age":  int64(21),
 			},
 			{
 				"Name": "Bob",
-				"Age":  uint64(32),
+				"Age":  int64(32),
 			},
 			{
 				"Name": "Carlo",
-				"Age":  uint64(55),
+				"Age":  int64(55),
 			},
 		},
 	}
@@ -199,19 +199,19 @@ func TestQuerySimpleWithNumericOrderDescending(t *testing.T) {
 		Results: []map[string]any{
 			{
 				"Name": "Carlo",
-				"Age":  uint64(55),
+				"Age":  int64(55),
 			},
 			{
 				"Name": "Bob",
-				"Age":  uint64(32),
+				"Age":  int64(32),
 			},
 			{
 				"Name": "John",
-				"Age":  uint64(21),
+				"Age":  int64(21),
 			},
 			{
 				"Name": "Alice",
-				"Age":  uint64(19),
+				"Age":  int64(19),
 			},
 		},
 	}
@@ -255,19 +255,19 @@ func TestQuerySimpleWithDateTimeOrderDescending(t *testing.T) {
 		Results: []map[string]any{
 			{
 				"Name": "Carlo",
-				"Age":  uint64(55),
+				"Age":  int64(55),
 			},
 			{
 				"Name": "Bob",
-				"Age":  uint64(32),
+				"Age":  int64(32),
 			},
 			{
 				"Name": "John",
-				"Age":  uint64(21),
+				"Age":  int64(21),
 			},
 			{
 				"Name": "Alice",
-				"Age":  uint64(19),
+				"Age":  int64(19),
 			},
 		},
 	}
@@ -312,22 +312,22 @@ func TestQuerySimpleWithNumericOrderDescendingAndBooleanOrderAscending(t *testin
 		Results: []map[string]any{
 			{
 				"Name":     "Carlo",
-				"Age":      uint64(55),
+				"Age":      int64(55),
 				"Verified": true,
 			},
 			{
 				"Name":     "Bob",
-				"Age":      uint64(21),
+				"Age":      int64(21),
 				"Verified": false,
 			},
 			{
 				"Name":     "John",
-				"Age":      uint64(21),
+				"Age":      int64(21),
 				"Verified": true,
 			},
 			{
 				"Name":     "Alice",
-				"Age":      uint64(19),
+				"Age":      int64(19),
 				"Verified": false,
 			},
 		},

--- a/tests/integration/query/simple/with_restart_test.go
+++ b/tests/integration/query/simple/with_restart_test.go
@@ -46,7 +46,7 @@ func TestQuerySimpleWithRestart(t *testing.T) {
 				Results: []map[string]any{
 					{
 						"name": "Shahzad",
-						"age":  uint64(30),
+						"age":  int64(30),
 					},
 				},
 			},

--- a/tests/integration/query/simple/with_version_test.go
+++ b/tests/integration/query/simple/with_version_test.go
@@ -43,7 +43,7 @@ func TestQuerySimpleWithEmbeddedLatestCommit(t *testing.T) {
 		Results: []map[string]any{
 			{
 				"Name": "John",
-				"Age":  uint64(21),
+				"Age":  int64(21),
 				"_version": []map[string]any{
 					{
 						"cid": "bafybeigyyj2jvd4265aalvq6wctzz7jz36rluxrevlnx2hewvowlq672na",
@@ -168,7 +168,7 @@ func TestQuerySimpleWithMultipleAliasedEmbeddedLatestCommit(t *testing.T) {
 		Results: []map[string]any{
 			{
 				"Name": "John",
-				"Age":  uint64(21),
+				"Age":  int64(21),
 				"_version": []map[string]any{
 					{
 						"cid": "bafybeigyyj2jvd4265aalvq6wctzz7jz36rluxrevlnx2hewvowlq672na",

--- a/tests/integration/schema/migrations/query/simple_test.go
+++ b/tests/integration/schema/migrations/query/simple_test.go
@@ -761,7 +761,7 @@ func TestSchemaMigrationQueryMigrationPreservesExistingFieldWhenFieldNotRequeste
 				Results: []map[string]any{
 					{
 						"name": "Fred",
-						"age":  uint64(40),
+						"age":  int64(40),
 					},
 				},
 			},
@@ -823,7 +823,7 @@ func TestSchemaMigrationQueryMigrationCopiesExistingFieldWhenSrcFieldNotRequeste
 				Results: []map[string]any{
 					{
 						"name":       "John",
-						"yearsLived": uint64(40),
+						"yearsLived": int64(40),
 					},
 				},
 			},
@@ -898,8 +898,8 @@ func TestSchemaMigrationQueryMigrationCopiesExistingFieldWhenSrcAndDstFieldNotRe
 				Results: []map[string]any{
 					{
 						"name":       "John",
-						"age":        uint64(40),
-						"yearsLived": uint64(40),
+						"age":        int64(40),
+						"yearsLived": int64(40),
 					},
 				},
 			},

--- a/tests/integration/schema/updates/add/field/kind/int_test.go
+++ b/tests/integration/schema/updates/add/field/kind/int_test.go
@@ -83,7 +83,7 @@ func TestSchemaUpdatesAddFieldKindIntWithCreate(t *testing.T) {
 				Results: []map[string]any{
 					{
 						"name": "John",
-						"foo":  uint64(3),
+						"foo":  int64(3),
 					},
 				},
 			},
@@ -127,7 +127,7 @@ func TestSchemaUpdatesAddFieldKindIntSubstitutionWithCreate(t *testing.T) {
 				Results: []map[string]any{
 					{
 						"name": "John",
-						"foo":  uint64(3),
+						"foo":  int64(3),
 					},
 				},
 			},

--- a/tests/integration/schema/updates/copy/field/simple_test.go
+++ b/tests/integration/schema/updates/copy/field/simple_test.go
@@ -130,7 +130,7 @@ func TestSchemaUpdatesCopyFieldWithRemoveIDAndReplaceNameAndKindSubstitution(t *
 					{
 						"name": "John",
 						// It is important to test this with data, to ensure the type has been substituted correctly
-						"age": uint64(3),
+						"age": int64(3),
 					},
 				},
 			},

--- a/tests/integration/subscription/subscription_test.go
+++ b/tests/integration/subscription/subscription_test.go
@@ -31,12 +31,12 @@ func TestSubscriptionWithCreateMutations(t *testing.T) {
 				Results: []map[string]any{
 					{
 						"_key": "bae-0a24cf29-b2c2-5861-9d00-abd6250c475d",
-						"age":  uint64(27),
+						"age":  int64(27),
 						"name": "John",
 					},
 					{
 						"_key": "bae-18def051-7f0f-5dc9-8a69-2a5e423f6b55",
-						"age":  uint64(31),
+						"age":  int64(31),
 						"name": "Addo",
 					},
 				},
@@ -86,7 +86,7 @@ func TestSubscriptionWithFilterAndOneCreateMutation(t *testing.T) {
 				Results: []map[string]any{
 					{
 						"_key": "bae-0a24cf29-b2c2-5861-9d00-abd6250c475d",
-						"age":  uint64(27),
+						"age":  int64(27),
 						"name": "John",
 					},
 				},
@@ -156,7 +156,7 @@ func TestSubscriptionWithFilterAndCreateMutations(t *testing.T) {
 				Results: []map[string]any{
 					{
 						"_key": "bae-0a24cf29-b2c2-5861-9d00-abd6250c475d",
-						"age":  uint64(27),
+						"age":  int64(27),
 						"name": "John",
 					},
 				},
@@ -225,7 +225,7 @@ func TestSubscriptionWithUpdateMutations(t *testing.T) {
 				Results: []map[string]any{
 					{
 						"_key":   "bae-0a24cf29-b2c2-5861-9d00-abd6250c475d",
-						"age":    uint64(27),
+						"age":    int64(27),
 						"name":   "John",
 						"points": float64(45),
 					},
@@ -283,13 +283,13 @@ func TestSubscriptionWithUpdateAllMutations(t *testing.T) {
 				Results: []map[string]any{
 					{
 						"_key":   "bae-0a24cf29-b2c2-5861-9d00-abd6250c475d",
-						"age":    uint64(27),
+						"age":    int64(27),
 						"name":   "John",
 						"points": float64(55),
 					},
 					{
 						"_key":   "bae-cf723876-5c6a-5dcf-a877-ab288eb30d57",
-						"age":    uint64(31),
+						"age":    int64(31),
 						"name":   "Addo",
 						"points": float64(55),
 					},


### PR DESCRIPTION
## Relevant issue(s)

Resolves #1681 
Resolves #1981 

## Description

The PR ensures the return type for `FieldKind_INT` is always of the same go type `int64`.

Fixing this also surface a small bug in the indexes where a broken index should have returned an error but was returning an error for a different reason. That reason being that the expected return type was `int64` but the actual returned type was `uint64`.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

(*replace*) Describe the tests performed to verify the changes. Provide instructions to reproduce them.

Specify the platform(s) on which this was tested:
- MacOS
