### PR TITLE
feat: Enable playground in Docker build

### DIFF
--- a/tools/defradb.containerfile
+++ b/tools/defradb.containerfile
@@ -2,7 +2,7 @@
 
 # An image to run defradb.
 
-# Stage: PLAYGROUND
+# Stage: PLAYGROUND_BUILD
 FROM docker.io/node:20 AS PLAYGROUND_BUILD
 WORKDIR /repo/
 COPY playground/ ./

--- a/tools/defradb.containerfile
+++ b/tools/defradb.containerfile
@@ -2,6 +2,13 @@
 
 # An image to run defradb.
 
+# Stage: PLAYGROUND
+FROM docker.io/node:20 AS PLAYGROUND_BUILD
+WORKDIR /repo/
+COPY playground/ ./
+RUN npm install
+RUN npm run build
+
 # Stage: BUILD
 # Several steps are involved to enable caching and because of the behavior of COPY regarding directories.
 FROM docker.io/golang:1.20 AS BUILD
@@ -9,6 +16,7 @@ WORKDIR /repo/
 COPY go.mod go.sum Makefile ./
 RUN make deps:modules
 COPY . .
+COPY --from=PLAYGROUND_BUILD /repo/dist /repo/playground/dist/
 ENV BUILD_TAGS=playground
 RUN make build
 

--- a/tools/defradb.containerfile
+++ b/tools/defradb.containerfile
@@ -9,6 +9,7 @@ WORKDIR /repo/
 COPY go.mod go.sum Makefile ./
 RUN make deps:modules
 COPY . .
+ENV BUILD_TAGS=playground
 RUN make build
 
 # Stage: RUN


### PR DESCRIPTION
## Relevant issue(s)

Resolves #1983

## Description

This PR enables the embedded playground in the DefraDB Docker builds.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Built and pushed image to `docker.io/sourcenetwork/defradb:develop`

Specify the platform(s) on which this was tested:
- MacOS

