### PR TITLE
refactor: Reorganise collection description storage

### DIFF
--- a/core/key.go
+++ b/core/key.go
@@ -42,18 +42,18 @@ const (
 )
 
 const (
-	COLLECTION                        = "/collection/value"
-	COLLECTION_NAME                   = "/collection/name"
-	COLLECTION_SCHEMA_VERSION         = "/collection/version/v"
-	COLLECTION_SCHEMA_VERSION_HISTORY = "/collection/version/h"
-	COLLECTION_INDEX                  = "/collection/index"
-	SCHEMA_MIGRATION                  = "/schema/migration"
-	SCHEMA_VERSION                    = "/schema/version"
-	SEQ                               = "/seq"
-	PRIMARY_KEY                       = "/pk"
-	DATASTORE_DOC_VERSION_FIELD_ID    = "v"
-	REPLICATOR                        = "/replicator/id"
-	P2P_COLLECTION                    = "/p2p/collection"
+	COLLECTION                     = "/collection/value"
+	COLLECTION_NAME                = "/collection/name"
+	COLLECTION_SCHEMA_VERSION      = "/collection/version"
+	COLLECTION_INDEX               = "/collection/index"
+	SCHEMA_MIGRATION               = "/schema/migration"
+	SCHEMA_VERSION                 = "/schema/version/v"
+	SCHEMA_VERSION_HISTORY         = "/schema/version/h"
+	SEQ                            = "/seq"
+	PRIMARY_KEY                    = "/pk"
+	DATASTORE_DOC_VERSION_FIELD_ID = "v"
+	REPLICATOR                     = "/replicator/id"
+	P2P_COLLECTION                 = "/p2p/collection"
 )
 
 // Key is an interface that represents a key in the database.
@@ -356,7 +356,7 @@ func NewSchemaVersionMigrationKey(schemaVersionID string) SchemaVersionMigration
 }
 
 func NewSchemaHistoryKeyFromString(keyString string) (SchemaHistoryKey, error) {
-	keyString = strings.TrimPrefix(keyString, COLLECTION_SCHEMA_VERSION_HISTORY+"/")
+	keyString = strings.TrimPrefix(keyString, SCHEMA_VERSION_HISTORY+"/")
 	elements := strings.Split(keyString, "/")
 	if len(elements) != 2 {
 		return SchemaHistoryKey{}, ErrInvalidKey
@@ -673,7 +673,7 @@ func (k SchemaVersionKey) ToDS() ds.Key {
 }
 
 func (k SchemaHistoryKey) ToString() string {
-	result := COLLECTION_SCHEMA_VERSION_HISTORY
+	result := SCHEMA_VERSION_HISTORY
 
 	if k.SchemaID != "" {
 		result = result + "/" + k.SchemaID

--- a/core/key.go
+++ b/core/key.go
@@ -11,6 +11,7 @@
 package core
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -41,8 +42,8 @@ const (
 )
 
 const (
-	COLLECTION                        = "/collection/names"
-	COLLECTION_SCHEMA                 = "/collection/schema"
+	COLLECTION                        = "/collection/value"
+	COLLECTION_NAME                   = "/collection/name"
 	COLLECTION_SCHEMA_VERSION         = "/collection/version/v"
 	COLLECTION_SCHEMA_VERSION_HISTORY = "/collection/version/h"
 	COLLECTION_INDEX                  = "/collection/index"
@@ -99,26 +100,32 @@ type HeadStoreKey struct {
 
 var _ Key = (*HeadStoreKey)(nil)
 
-// CollectionKey points to the current/'head' SchemaVersionId for
-// the collection of the given name.
+// CollectionKey points to the json serialized description of the
+// the collection of the given ID.
 type CollectionKey struct {
-	CollectionName string
+	CollectionID uint32
 }
 
 var _ Key = (*CollectionKey)(nil)
 
-// CollectionSchemaKey points to the current/'head' SchemaVersionId for
-// the collection of the given schema id.
-type CollectionSchemaKey struct {
-	SchemaId string
+// CollectionNameKey points to the ID of the collection of the given
+// name.
+type CollectionNameKey struct {
+	Name string
 }
 
-var _ Key = (*CollectionSchemaKey)(nil)
+var _ Key = (*CollectionNameKey)(nil)
 
-// CollectionSchemaVersionKey points to schema of a collection at a given
-// version.
+// CollectionSchemaVersionKey points to nil, but the keys/prefix can be used
+// to get collections that are using, or have used a given schema version.
+//
+// If a collection is updated to a different schema version, the old entry(s)
+// of this key will be preserved.
+//
+// This key should be removed in https://github.com/sourcenetwork/defradb/issues/1085
 type CollectionSchemaVersionKey struct {
 	SchemaVersionId string
+	CollectionID    uint32
 }
 
 var _ Key = (*CollectionSchemaVersionKey)(nil)
@@ -255,21 +262,32 @@ func NewHeadStoreKey(key string) (HeadStoreKey, error) {
 
 // Returns a formatted collection key for the system data store.
 // It assumes the name of the collection is non-empty.
-func NewCollectionKey(name string) CollectionKey {
-	return CollectionKey{CollectionName: name}
+func NewCollectionKey(id uint32) CollectionKey {
+	return CollectionKey{CollectionID: id}
 }
 
-func NewCollectionSchemaKey(schemaId string) CollectionSchemaKey {
-	return CollectionSchemaKey{SchemaId: schemaId}
+func NewCollectionNameKey(name string) CollectionNameKey {
+	return CollectionNameKey{Name: name}
 }
 
-func NewCollectionSchemaVersionKey(schemaVersionId string) CollectionSchemaVersionKey {
-	return CollectionSchemaVersionKey{SchemaVersionId: schemaVersionId}
+func NewCollectionSchemaVersionKey(schemaVersionId string, collectionID uint32) CollectionSchemaVersionKey {
+	return CollectionSchemaVersionKey{
+		SchemaVersionId: schemaVersionId,
+		CollectionID:    collectionID,
+	}
 }
 
-func NewCollectionSchemaVersionKeyFromString(key string) CollectionSchemaVersionKey {
+func NewCollectionSchemaVersionKeyFromString(key string) (CollectionSchemaVersionKey, error) {
 	elements := strings.Split(key, "/")
-	return CollectionSchemaVersionKey{SchemaVersionId: elements[len(elements)-1]}
+	colID, err := strconv.Atoi(elements[len(elements)-1])
+	if err != nil {
+		return CollectionSchemaVersionKey{}, err
+	}
+
+	return CollectionSchemaVersionKey{
+		SchemaVersionId: elements[len(elements)-2],
+		CollectionID:    uint32(colID),
+	}, nil
 }
 
 // NewCollectionIndexKey creates a new CollectionIndexKey from a collection name and index name.
@@ -591,13 +609,7 @@ func (k PrimaryDataStoreKey) ToString() string {
 }
 
 func (k CollectionKey) ToString() string {
-	result := COLLECTION
-
-	if k.CollectionName != "" {
-		result = result + "/" + k.CollectionName
-	}
-
-	return result
+	return fmt.Sprintf("%s/%s", COLLECTION, strconv.Itoa(int(k.CollectionID)))
 }
 
 func (k CollectionKey) Bytes() []byte {
@@ -608,21 +620,15 @@ func (k CollectionKey) ToDS() ds.Key {
 	return ds.NewKey(k.ToString())
 }
 
-func (k CollectionSchemaKey) ToString() string {
-	result := COLLECTION_SCHEMA
-
-	if k.SchemaId != "" {
-		result = result + "/" + k.SchemaId
-	}
-
-	return result
+func (k CollectionNameKey) ToString() string {
+	return fmt.Sprintf("%s/%s", COLLECTION_NAME, k.Name)
 }
 
-func (k CollectionSchemaKey) Bytes() []byte {
+func (k CollectionNameKey) Bytes() []byte {
 	return []byte(k.ToString())
 }
 
-func (k CollectionSchemaKey) ToDS() ds.Key {
+func (k CollectionNameKey) ToDS() ds.Key {
 	return ds.NewKey(k.ToString())
 }
 
@@ -631,6 +637,10 @@ func (k CollectionSchemaVersionKey) ToString() string {
 
 	if k.SchemaVersionId != "" {
 		result = result + "/" + k.SchemaVersionId
+	}
+
+	if k.CollectionID != 0 {
+		result = fmt.Sprintf("%s/%s", result, strconv.Itoa(int(k.CollectionID)))
 	}
 
 	return result

--- a/core/key.go
+++ b/core/key.go
@@ -42,7 +42,7 @@ const (
 )
 
 const (
-	COLLECTION                     = "/collection/value"
+	COLLECTION                     = "/collection/id"
 	COLLECTION_NAME                = "/collection/name"
 	COLLECTION_SCHEMA_VERSION      = "/collection/version"
 	COLLECTION_INDEX               = "/collection/index"

--- a/core/parser.go
+++ b/core/parser.go
@@ -54,5 +54,7 @@ type Parser interface {
 	ParseSDL(ctx context.Context, schemaString string) ([]client.CollectionDefinition, error)
 
 	// Adds the given schema to this parser's model.
+	//
+	// All collections should be provided, not just new/updated ones.
 	SetSchema(ctx context.Context, txn datastore.Txn, collections []client.CollectionDefinition) error
 }

--- a/db/description/collection.go
+++ b/db/description/collection.go
@@ -1,0 +1,214 @@
+// Copyright 2023 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package description
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/ipfs/go-datastore/query"
+
+	"github.com/sourcenetwork/defradb/client"
+	"github.com/sourcenetwork/defradb/core"
+	"github.com/sourcenetwork/defradb/datastore"
+)
+
+func SaveCollection(
+	ctx context.Context,
+	txn datastore.Txn,
+	desc client.CollectionDescription,
+) (client.CollectionDescription, error) {
+	buf, err := json.Marshal(desc)
+	if err != nil {
+		return client.CollectionDescription{}, err
+	}
+
+	key := core.NewCollectionKey(desc.ID)
+	err = txn.Systemstore().Put(ctx, key.ToDS(), buf)
+	if err != nil {
+		return client.CollectionDescription{}, err
+	}
+
+	idBuf, err := json.Marshal(desc.ID)
+	if err != nil {
+		return client.CollectionDescription{}, err
+	}
+
+	nameKey := core.NewCollectionNameKey(desc.Name)
+	err = txn.Systemstore().Put(ctx, nameKey.ToDS(), idBuf)
+	if err != nil {
+		return client.CollectionDescription{}, err
+	}
+
+	// The need for this key is temporary, we should replace it with the global collection ID
+	// https://github.com/sourcenetwork/defradb/issues/1085
+	schemaVersionKey := core.NewCollectionSchemaVersionKey(desc.SchemaVersionID, desc.ID)
+	err = txn.Systemstore().Put(ctx, schemaVersionKey.ToDS(), []byte{})
+	if err != nil {
+		return client.CollectionDescription{}, err
+	}
+
+	return desc, nil
+}
+
+func GetCollectionByName(
+	ctx context.Context,
+	txn datastore.Txn,
+	name string,
+) (client.CollectionDescription, error) {
+	nameKey := core.NewCollectionNameKey(name)
+	idBuf, err := txn.Systemstore().Get(ctx, nameKey.ToDS())
+	if err != nil {
+		return client.CollectionDescription{}, err
+	}
+
+	var id uint32
+	err = json.Unmarshal(idBuf, &id)
+	if err != nil {
+		return client.CollectionDescription{}, err
+	}
+
+	key := core.NewCollectionKey(id)
+	buf, err := txn.Systemstore().Get(ctx, key.ToDS())
+	if err != nil {
+		return client.CollectionDescription{}, err
+	}
+
+	var col client.CollectionDescription
+	err = json.Unmarshal(buf, &col)
+	if err != nil {
+		return client.CollectionDescription{}, err
+	}
+
+	return col, nil
+}
+
+func GetCollectionsBySchemaVersionID(
+	ctx context.Context,
+	txn datastore.Txn,
+	schemaVersionID string,
+) ([]client.CollectionDescription, error) {
+	schemaVersionKey := core.NewCollectionSchemaVersionKey(schemaVersionID, 0)
+
+	schemaVersionQuery, err := txn.Systemstore().Query(ctx, query.Query{
+		Prefix:   schemaVersionKey.ToString(),
+		KeysOnly: true,
+	})
+	if err != nil {
+		return nil, NewErrFailedToCreateCollectionQuery(err)
+	}
+
+	colIDs := make([]uint32, 0)
+	for res := range schemaVersionQuery.Next() {
+		if res.Error != nil {
+			if err := schemaVersionQuery.Close(); err != nil {
+				return nil, NewErrFailedToCloseSchemaQuery(err)
+			}
+			return nil, err
+		}
+
+		colSchemaVersionKey, err := core.NewCollectionSchemaVersionKeyFromString(string(res.Key))
+		if err != nil {
+			if err := schemaVersionQuery.Close(); err != nil {
+				return nil, NewErrFailedToCloseSchemaQuery(err)
+			}
+			return nil, err
+		}
+
+		colIDs = append(colIDs, colSchemaVersionKey.CollectionID)
+	}
+
+	cols := make([]client.CollectionDescription, 0)
+	for _, colID := range colIDs {
+		key := core.NewCollectionKey(colID)
+		buf, err := txn.Systemstore().Get(ctx, key.ToDS())
+		if err != nil {
+			return nil, err
+		}
+
+		var col client.CollectionDescription
+		err = json.Unmarshal(buf, &col)
+		if err != nil {
+			return nil, err
+		}
+
+		cols = append(cols, col)
+	}
+
+	return cols, nil
+}
+
+func GetCollectionsBySchemaID(
+	ctx context.Context,
+	txn datastore.Txn,
+	schemaID string,
+) ([]client.CollectionDescription, error) {
+	schemaVersionIDs, err := GetSchemaVersionIDs(ctx, txn, schemaID)
+	if err != nil {
+		return nil, err
+	}
+
+	cols := []client.CollectionDescription{}
+	for _, schemaVersionID := range schemaVersionIDs {
+		versionCols, err := GetCollectionsBySchemaVersionID(ctx, txn, schemaVersionID)
+		if err != nil {
+			return nil, err
+		}
+
+		cols = append(cols, versionCols...)
+	}
+
+	return cols, nil
+}
+
+func GetCollections(
+	ctx context.Context,
+	txn datastore.Txn,
+) ([]client.CollectionDescription, error) {
+	q, err := txn.Systemstore().Query(ctx, query.Query{
+		Prefix: core.COLLECTION,
+	})
+	if err != nil {
+		return nil, NewErrFailedToCreateCollectionQuery(err)
+	}
+
+	cols := make([]client.CollectionDescription, 0)
+	for res := range q.Next() {
+		if res.Error != nil {
+			if err := q.Close(); err != nil {
+				return nil, NewErrFailedToCloseCollectionQuery(err)
+			}
+			return nil, err
+		}
+
+		var col client.CollectionDescription
+		err = json.Unmarshal(res.Value, &col)
+		if err != nil {
+			if err := q.Close(); err != nil {
+				return nil, NewErrFailedToCloseCollectionQuery(err)
+			}
+			return nil, err
+		}
+
+		cols = append(cols, col)
+	}
+
+	return cols, nil
+}
+
+func HasCollectionByName(
+	ctx context.Context,
+	txn datastore.Txn,
+	name string,
+) (bool, error) {
+	nameKey := core.NewCollectionNameKey(name)
+	return txn.Systemstore().Has(ctx, nameKey.ToDS())
+}

--- a/db/description/collection.go
+++ b/db/description/collection.go
@@ -135,8 +135,8 @@ func GetCollectionsBySchemaVersionID(
 		colIDs = append(colIDs, colSchemaVersionKey.CollectionID)
 	}
 
-	cols := make([]client.CollectionDescription, 0)
-	for _, colID := range colIDs {
+	cols := make([]client.CollectionDescription, len(colIDs))
+	for i, colID := range colIDs {
 		key := core.NewCollectionKey(colID)
 		buf, err := txn.Systemstore().Get(ctx, key.ToDS())
 		if err != nil {
@@ -149,7 +149,7 @@ func GetCollectionsBySchemaVersionID(
 			return nil, err
 		}
 
-		cols = append(cols, col)
+		cols[i] = col
 	}
 
 	return cols, nil

--- a/db/description/collection.go
+++ b/db/description/collection.go
@@ -21,6 +21,8 @@ import (
 	"github.com/sourcenetwork/defradb/datastore"
 )
 
+// SaveCollection saves the given collection to the system store overwriting any
+// pre-existing values.
 func SaveCollection(
 	ctx context.Context,
 	txn datastore.Txn,
@@ -59,6 +61,9 @@ func SaveCollection(
 	return desc, nil
 }
 
+// GetCollectionByName returns the collection with the given name.
+//
+// If no collection of that name is found, it will return an error.
 func GetCollectionByName(
 	ctx context.Context,
 	txn datastore.Txn,
@@ -91,6 +96,10 @@ func GetCollectionByName(
 	return col, nil
 }
 
+// GetCollectionsBySchemaVersionID returns all collections that use the given
+// schemaVersionID.
+//
+// If no collections are found an empty set will be returned.
 func GetCollectionsBySchemaVersionID(
 	ctx context.Context,
 	txn datastore.Txn,
@@ -146,6 +155,10 @@ func GetCollectionsBySchemaVersionID(
 	return cols, nil
 }
 
+// GetCollectionsBySchemaID returns all collections that use the given
+// schemaID.
+//
+// If no collections are found an empty set will be returned.
 func GetCollectionsBySchemaID(
 	ctx context.Context,
 	txn datastore.Txn,
@@ -169,6 +182,7 @@ func GetCollectionsBySchemaID(
 	return cols, nil
 }
 
+// GetCollections returns all collections in the system.
 func GetCollections(
 	ctx context.Context,
 	txn datastore.Txn,
@@ -204,6 +218,8 @@ func GetCollections(
 	return cols, nil
 }
 
+// HasCollectionByName returns true if there is a collection of the given name,
+// else returns false.
 func HasCollectionByName(
 	ctx context.Context,
 	txn datastore.Txn,

--- a/db/description/errors.go
+++ b/db/description/errors.go
@@ -13,8 +13,10 @@ package description
 import "github.com/sourcenetwork/defradb/errors"
 
 const (
-	errFailedToCreateSchemaQuery string = "failed to create schema prefix query"
-	errFailedToCloseSchemaQuery  string = "failed to close schema prefix query"
+	errFailedToCreateSchemaQuery     string = "failed to create schema prefix query"
+	errFailedToCloseSchemaQuery      string = "failed to close schema prefix query"
+	errFailedToCreateCollectionQuery string = "failed to create collection prefix query"
+	errFailedToCloseCollectionQuery  string = "failed to close collection prefix query"
 )
 
 // NewErrFailedToCreateSchemaQuery returns a new error indicating that the query
@@ -27,4 +29,16 @@ func NewErrFailedToCreateSchemaQuery(inner error) error {
 // to create a schema failed to close.
 func NewErrFailedToCloseSchemaQuery(inner error) error {
 	return errors.Wrap(errFailedToCloseSchemaQuery, inner)
+}
+
+// NewErrFailedToCreateCollectionQuery returns a new error indicating that the query
+// to create a collection failed.
+func NewErrFailedToCreateCollectionQuery(inner error) error {
+	return errors.Wrap(errFailedToCreateCollectionQuery, inner)
+}
+
+// NewErrFailedToCreateCollectionQuery returns a new error indicating that the query
+// to create a collection failed to close.
+func NewErrFailedToCloseCollectionQuery(inner error) error {
+	return errors.Wrap(errFailedToCloseCollectionQuery, inner)
 }

--- a/db/index_test.go
+++ b/db/index_test.go
@@ -48,8 +48,6 @@ const (
 	testUsersColIndexName   = "user_name"
 	testUsersColIndexAge    = "user_age"
 	testUsersColIndexWeight = "user_weight"
-
-	userColVersionID = "bafkreiefzlx2xsfaxixs24hcqwwqpa3nuqbutkapasymk3d5v4fxa4rlhy"
 )
 
 type indexTestFixture struct {

--- a/db/index_test.go
+++ b/db/index_test.go
@@ -470,27 +470,6 @@ func TestCreateIndex_ShouldUpdateCollectionsDescription(t *testing.T) {
 		f.users.Description().Indexes)
 }
 
-func TestCreateIndex_NewCollectionDescription_ShouldIncludeIndexDescription(t *testing.T) {
-	f := newIndexTestFixture(t)
-
-	_, err := f.createCollectionIndex(getUsersIndexDescOnName())
-	require.NoError(t, err)
-
-	desc := getUsersIndexDescOnAge()
-	desc.Name = ""
-	_, err = f.createCollectionIndex(desc)
-	require.NoError(t, err)
-
-	cols, err := f.db.getAllCollections(f.ctx, f.txn)
-	require.NoError(t, err)
-
-	require.Equal(t, 1, len(cols))
-	col := cols[0]
-	require.Equal(t, 2, len(col.Description().Indexes))
-	require.NotEmpty(t, col.Description().Indexes[0].Name)
-	require.NotEmpty(t, col.Description().Indexes[1].Name)
-}
-
 func TestCreateIndex_IfAttemptToIndexOnUnsupportedType_ReturnError(t *testing.T) {
 	f := newIndexTestFixtureBare(t)
 
@@ -519,36 +498,6 @@ func TestCreateIndex_IfAttemptToIndexOnUnsupportedType_ReturnError(t *testing.T)
 	_, err = f.createCollectionIndexFor(collection.Name(), indexDesc)
 	require.ErrorIs(f.t, err, NewErrUnsupportedIndexFieldType(unsupportedKind))
 	f.commitTxn()
-}
-
-func TestCreateIndex_IfFailedToReadIndexUponRetrievingCollectionDesc_ReturnError(t *testing.T) {
-	f := newIndexTestFixture(t)
-
-	testErr := errors.New("test error")
-
-	mockedTxn := f.mockTxn().ClearSystemStore()
-	onSystemStore := mockedTxn.MockSystemstore.EXPECT()
-
-	colIndexKey := core.NewCollectionIndexKey(f.users.Description().Name, "")
-	matchPrefixFunc := func(q query.Query) bool {
-		res := q.Prefix == colIndexKey.ToDS().String()
-		return res
-	}
-
-	onSystemStore.Query(mock.Anything, mock.MatchedBy(matchPrefixFunc)).Return(nil, testErr)
-
-	descData, err := json.Marshal(f.users.Description())
-	require.NoError(t, err)
-
-	onSystemStore.Query(mock.Anything, mock.Anything).
-		Return(mocks.NewQueryResultsWithValues(t, []byte("schemaID")), nil)
-	onSystemStore.Get(mock.Anything, mock.Anything).Unset()
-	onSystemStore.Get(mock.Anything, mock.Anything).Return(descData, nil)
-
-	f.stubSystemStore(onSystemStore)
-
-	_, err = f.db.getAllCollections(f.ctx, f.txn)
-	require.ErrorIs(t, err, testErr)
 }
 
 func TestGetIndexes_ShouldReturnListOfAllExistingIndexes(t *testing.T) {

--- a/db/indexed_docs_test.go
+++ b/db/indexed_docs_test.go
@@ -230,17 +230,6 @@ func (f *indexTestFixture) stubSystemStore(systemStoreOn *mocks.DSReaderWriter_E
 	systemStoreOn.Query(mock.Anything, mock.Anything).Maybe().
 		Return(mocks.NewQueryResultsWithValues(f.t), nil)
 
-	colKey := core.NewCollectionKey(usersColName)
-	systemStoreOn.Get(mock.Anything, colKey.ToDS()).Maybe().Return([]byte(userColVersionID), nil)
-
-	colVersionIDKey := core.NewCollectionSchemaVersionKey(userColVersionID)
-	usersCol, err := f.db.GetCollectionByName(f.ctx, usersColName)
-	require.NoError(f.t, err)
-	colDesc := usersCol.Description()
-	colDescBytes, err := json.Marshal(colDesc)
-	require.NoError(f.t, err)
-	systemStoreOn.Get(mock.Anything, colVersionIDKey.ToDS()).Maybe().Return(colDescBytes, nil)
-
 	colIndexOnNameKey := core.NewCollectionIndexKey(usersColName, testUsersColIndexName)
 	systemStoreOn.Get(mock.Anything, colIndexOnNameKey.ToDS()).Maybe().Return(indexOnNameDescData, nil)
 

--- a/db/schema.go
+++ b/db/schema.go
@@ -137,7 +137,7 @@ func (db *db) patchSchema(ctx context.Context, txn datastore.Txn, patchString st
 	}
 
 	for _, schema := range newSchemaByName {
-		_, err := db.updateSchema(
+		err := db.updateSchema(
 			ctx,
 			txn,
 			existingSchemaByName,

--- a/db/schema.go
+++ b/db/schema.go
@@ -136,9 +136,8 @@ func (db *db) patchSchema(ctx context.Context, txn datastore.Txn, patchString st
 		return err
 	}
 
-	newCollections := []client.CollectionDefinition{}
 	for _, schema := range newSchemaByName {
-		col, err := db.updateSchema(
+		_, err := db.updateSchema(
 			ctx,
 			txn,
 			existingSchemaByName,
@@ -149,11 +148,19 @@ func (db *db) patchSchema(ctx context.Context, txn datastore.Txn, patchString st
 		if err != nil {
 			return err
 		}
-
-		newCollections = append(newCollections, col.Definition())
 	}
 
-	return db.parser.SetSchema(ctx, txn, newCollections)
+	newCollections, err := db.getAllCollections(ctx, txn)
+	if err != nil {
+		return err
+	}
+
+	definitions := make([]client.CollectionDefinition, len(newCollections))
+	for i, col := range newCollections {
+		definitions[i] = col.Definition()
+	}
+
+	return db.parser.SetSchema(ctx, txn, definitions)
 }
 
 // substituteSchemaPatch handles any substitution of values that may be required before

--- a/docs/data_format_changes/i1964-reorg-col-desc-storage.md
+++ b/docs/data_format_changes/i1964-reorg-col-desc-storage.md
@@ -1,0 +1,3 @@
+# Reorganise collection description storage
+
+The way collection descriptions are stored and index in Defra has changed, please refer to https://github.com/sourcenetwork/defradb/pull/1988 and https://github.com/sourcenetwork/defradb/issues/1964 for more info.

--- a/net/peer_collection.go
+++ b/net/peer_collection.go
@@ -35,6 +35,9 @@ func (p *Peer) AddP2PCollections(ctx context.Context, collectionIDs []string) er
 		if err != nil {
 			return err
 		}
+		if len(storeCol) == 0 {
+			return client.NewErrCollectionNotFoundForSchema(col)
+		}
 		storeCollections = append(storeCollections, storeCol...)
 	}
 
@@ -96,6 +99,9 @@ func (p *Peer) RemoveP2PCollections(ctx context.Context, collectionIDs []string)
 		storeCol, err := p.db.WithTxn(txn).GetCollectionsBySchemaID(p.ctx, col)
 		if err != nil {
 			return err
+		}
+		if len(storeCol) == 0 {
+			return client.NewErrCollectionNotFoundForSchema(col)
 		}
 		storeCollections = append(storeCollections, storeCol...)
 	}

--- a/net/process.go
+++ b/net/process.go
@@ -113,7 +113,7 @@ func initCRDTForType(
 	log.Debug(ctx, "Got CRDT Type", logging.NewKV("CType", ctype), logging.NewKV("Field", field))
 	return crdt.DefaultFactory.InstanceWithStores(
 		txn,
-		core.NewCollectionSchemaVersionKey(col.Schema().VersionID),
+		core.NewCollectionSchemaVersionKey(col.Schema().VersionID, col.ID()),
 		events.EmptyUpdateChannel,
 		ctype,
 		key,

--- a/tests/integration/backup/one_to_many/export_test.go
+++ b/tests/integration/backup/one_to_many/export_test.go
@@ -57,7 +57,7 @@ func TestBackupExport_AllCollectionsMultipleDocsAndDocUpdate_NoError(t *testing.
 				Doc:          `{"age": 31}`,
 			},
 			testUtils.BackupExport{
-				ExpectedContent: `{"Book":[{"_key":"bae-5cf2fec3-d8ed-50d5-8286-39109853d2da","_newKey":"bae-edeade01-2d21-5d6d-aadf-efc5a5279de5","author_id":"bae-807ea028-6c13-5f86-a72b-46e8b715a162","name":"John and the sourcerers' stone"}],"User":[{"_key":"bae-0648f44e-74e8-593b-a662-3310ec278927","_newKey":"bae-0648f44e-74e8-593b-a662-3310ec278927","age":31,"name":"Bob"},{"_key":"bae-e933420a-988a-56f8-8952-6c245aebd519","_newKey":"bae-807ea028-6c13-5f86-a72b-46e8b715a162","age":31,"name":"John"}]}`,
+				ExpectedContent: `{"User":[{"_key":"bae-0648f44e-74e8-593b-a662-3310ec278927","_newKey":"bae-0648f44e-74e8-593b-a662-3310ec278927","age":31,"name":"Bob"},{"_key":"bae-e933420a-988a-56f8-8952-6c245aebd519","_newKey":"bae-807ea028-6c13-5f86-a72b-46e8b715a162","age":31,"name":"John"}],"Book":[{"_key":"bae-5cf2fec3-d8ed-50d5-8286-39109853d2da","_newKey":"bae-edeade01-2d21-5d6d-aadf-efc5a5279de5","author_id":"bae-807ea028-6c13-5f86-a72b-46e8b715a162","name":"John and the sourcerers' stone"}]}`,
 			},
 		},
 	}
@@ -90,7 +90,7 @@ func TestBackupExport_AllCollectionsMultipleDocsAndMultipleDocUpdate_NoError(t *
 				Doc:          `{"age": 31}`,
 			},
 			testUtils.BackupExport{
-				ExpectedContent: `{"Book":[{"_key":"bae-4399f189-138d-5d49-9e25-82e78463677b","_newKey":"bae-78a40f28-a4b8-5dca-be44-392b0f96d0ff","author_id":"bae-807ea028-6c13-5f86-a72b-46e8b715a162","name":"Game of chains"},{"_key":"bae-5cf2fec3-d8ed-50d5-8286-39109853d2da","_newKey":"bae-edeade01-2d21-5d6d-aadf-efc5a5279de5","author_id":"bae-807ea028-6c13-5f86-a72b-46e8b715a162","name":"John and the sourcerers' stone"}],"User":[{"_key":"bae-0648f44e-74e8-593b-a662-3310ec278927","_newKey":"bae-0648f44e-74e8-593b-a662-3310ec278927","age":31,"name":"Bob"},{"_key":"bae-e933420a-988a-56f8-8952-6c245aebd519","_newKey":"bae-807ea028-6c13-5f86-a72b-46e8b715a162","age":31,"name":"John"}]}`,
+				ExpectedContent: `{"User":[{"_key":"bae-0648f44e-74e8-593b-a662-3310ec278927","_newKey":"bae-0648f44e-74e8-593b-a662-3310ec278927","age":31,"name":"Bob"},{"_key":"bae-e933420a-988a-56f8-8952-6c245aebd519","_newKey":"bae-807ea028-6c13-5f86-a72b-46e8b715a162","age":31,"name":"John"}],"Book":[{"_key":"bae-4399f189-138d-5d49-9e25-82e78463677b","_newKey":"bae-78a40f28-a4b8-5dca-be44-392b0f96d0ff","author_id":"bae-807ea028-6c13-5f86-a72b-46e8b715a162","name":"Game of chains"},{"_key":"bae-5cf2fec3-d8ed-50d5-8286-39109853d2da","_newKey":"bae-edeade01-2d21-5d6d-aadf-efc5a5279de5","author_id":"bae-807ea028-6c13-5f86-a72b-46e8b715a162","name":"John and the sourcerers' stone"}]}`,
 			},
 		},
 	}

--- a/tests/integration/backup/one_to_one/export_test.go
+++ b/tests/integration/backup/one_to_one/export_test.go
@@ -57,7 +57,7 @@ func TestBackupExport_AllCollectionsMultipleDocsAndDocUpdate_NoError(t *testing.
 				Doc:          `{"age": 31}`,
 			},
 			testUtils.BackupExport{
-				ExpectedContent: `{"Book":[{"_key":"bae-5cf2fec3-d8ed-50d5-8286-39109853d2da","_newKey":"bae-edeade01-2d21-5d6d-aadf-efc5a5279de5","author_id":"bae-807ea028-6c13-5f86-a72b-46e8b715a162","name":"John and the sourcerers' stone"}],"User":[{"_key":"bae-0648f44e-74e8-593b-a662-3310ec278927","_newKey":"bae-0648f44e-74e8-593b-a662-3310ec278927","age":31,"name":"Bob"},{"_key":"bae-e933420a-988a-56f8-8952-6c245aebd519","_newKey":"bae-807ea028-6c13-5f86-a72b-46e8b715a162","age":31,"name":"John"}]}`,
+				ExpectedContent: `{"User":[{"_key":"bae-0648f44e-74e8-593b-a662-3310ec278927","_newKey":"bae-0648f44e-74e8-593b-a662-3310ec278927","age":31,"name":"Bob"},{"_key":"bae-e933420a-988a-56f8-8952-6c245aebd519","_newKey":"bae-807ea028-6c13-5f86-a72b-46e8b715a162","age":31,"name":"John"}],"Book":[{"_key":"bae-5cf2fec3-d8ed-50d5-8286-39109853d2da","_newKey":"bae-edeade01-2d21-5d6d-aadf-efc5a5279de5","author_id":"bae-807ea028-6c13-5f86-a72b-46e8b715a162","name":"John and the sourcerers' stone"}]}`,
 			},
 		},
 	}
@@ -101,7 +101,7 @@ func TestBackupExport_DoubleReletionship_NoError(t *testing.T) {
 				Doc:          `{"age": 31}`,
 			},
 			testUtils.BackupExport{
-				ExpectedContent: `{"Book":[{"_key":"bae-45b1def4-4e63-5a93-a1b8-f7b08e682164","_newKey":"bae-add2ccfe-84a1-519c-ab7d-c54b43909532","author_id":"bae-807ea028-6c13-5f86-a72b-46e8b715a162","favourite_id":"bae-0648f44e-74e8-593b-a662-3310ec278927","name":"John and the sourcerers' stone"}],"User":[{"_key":"bae-0648f44e-74e8-593b-a662-3310ec278927","_newKey":"bae-0648f44e-74e8-593b-a662-3310ec278927","age":31,"name":"Bob"},{"_key":"bae-e933420a-988a-56f8-8952-6c245aebd519","_newKey":"bae-807ea028-6c13-5f86-a72b-46e8b715a162","age":31,"name":"John"}]}`,
+				ExpectedContent: `{"User":[{"_key":"bae-0648f44e-74e8-593b-a662-3310ec278927","_newKey":"bae-0648f44e-74e8-593b-a662-3310ec278927","age":31,"name":"Bob"},{"_key":"bae-e933420a-988a-56f8-8952-6c245aebd519","_newKey":"bae-807ea028-6c13-5f86-a72b-46e8b715a162","age":31,"name":"John"}],"Book":[{"_key":"bae-45b1def4-4e63-5a93-a1b8-f7b08e682164","_newKey":"bae-add2ccfe-84a1-519c-ab7d-c54b43909532","author_id":"bae-807ea028-6c13-5f86-a72b-46e8b715a162","favourite_id":"bae-0648f44e-74e8-593b-a662-3310ec278927","name":"John and the sourcerers' stone"}]}`,
 			},
 		},
 	}
@@ -149,7 +149,7 @@ func TestBackupExport_DoubleReletionshipWithUpdate_NoError(t *testing.T) {
 				Doc:          `{"age": 31}`,
 			},
 			testUtils.BackupExport{
-				ExpectedContent: `{"Book":[{"_key":"bae-45b1def4-4e63-5a93-a1b8-f7b08e682164","_newKey":"bae-add2ccfe-84a1-519c-ab7d-c54b43909532","author_id":"bae-807ea028-6c13-5f86-a72b-46e8b715a162","favourite_id":"bae-0648f44e-74e8-593b-a662-3310ec278927","name":"John and the sourcerers' stone"},{"_key":"bae-da7f2d88-05c4-528a-846a-0d18ab26603b","_newKey":"bae-da7f2d88-05c4-528a-846a-0d18ab26603b","name":"Game of chains"}],"User":[{"_key":"bae-0648f44e-74e8-593b-a662-3310ec278927","_newKey":"bae-0648f44e-74e8-593b-a662-3310ec278927","age":31,"name":"Bob"},{"_key":"bae-e933420a-988a-56f8-8952-6c245aebd519","_newKey":"bae-807ea028-6c13-5f86-a72b-46e8b715a162","age":31,"name":"John"}]}`,
+				ExpectedContent: `{"User":[{"_key":"bae-0648f44e-74e8-593b-a662-3310ec278927","_newKey":"bae-0648f44e-74e8-593b-a662-3310ec278927","age":31,"name":"Bob"},{"_key":"bae-e933420a-988a-56f8-8952-6c245aebd519","_newKey":"bae-807ea028-6c13-5f86-a72b-46e8b715a162","age":31,"name":"John"}],"Book":[{"_key":"bae-45b1def4-4e63-5a93-a1b8-f7b08e682164","_newKey":"bae-add2ccfe-84a1-519c-ab7d-c54b43909532","author_id":"bae-807ea028-6c13-5f86-a72b-46e8b715a162","favourite_id":"bae-0648f44e-74e8-593b-a662-3310ec278927","name":"John and the sourcerers' stone"},{"_key":"bae-da7f2d88-05c4-528a-846a-0d18ab26603b","_newKey":"bae-da7f2d88-05c4-528a-846a-0d18ab26603b","name":"Game of chains"}]}`,
 			},
 		},
 	}

--- a/tests/integration/net/state/simple/peer/subscribe/with_add_remove_test.go
+++ b/tests/integration/net/state/simple/peer/subscribe/with_add_remove_test.go
@@ -170,7 +170,7 @@ func TestP2PSubscribeAddSingleAndRemoveErroneous(t *testing.T) {
 			testUtils.UnsubscribeToCollection{
 				NodeID:        1,
 				CollectionIDs: []int{0, testUtils.NonExistentCollectionID},
-				ExpectedError: "datastore: key not found",
+				ExpectedError: "collection not found",
 			},
 			testUtils.CreateDoc{
 				NodeID: immutable.Some(0),

--- a/tests/integration/net/state/simple/peer/subscribe/with_add_test.go
+++ b/tests/integration/net/state/simple/peer/subscribe/with_add_test.go
@@ -199,7 +199,7 @@ func TestP2PSubscribeAddSingleErroneousCollectionID(t *testing.T) {
 			testUtils.SubscribeToCollection{
 				NodeID:        1,
 				CollectionIDs: []int{testUtils.NonExistentCollectionID},
-				ExpectedError: "datastore: key not found",
+				ExpectedError: "collection not found",
 			},
 			testUtils.CreateDoc{
 				NodeID: immutable.Some(0),
@@ -243,7 +243,7 @@ func TestP2PSubscribeAddValidAndErroneousCollectionID(t *testing.T) {
 			testUtils.SubscribeToCollection{
 				NodeID:        1,
 				CollectionIDs: []int{0, testUtils.NonExistentCollectionID},
-				ExpectedError: "datastore: key not found",
+				ExpectedError: "collection not found",
 			},
 			testUtils.CreateDoc{
 				NodeID: immutable.Some(0),
@@ -292,7 +292,7 @@ func TestP2PSubscribeAddValidThenErroneousCollectionID(t *testing.T) {
 			testUtils.SubscribeToCollection{
 				NodeID:        1,
 				CollectionIDs: []int{testUtils.NonExistentCollectionID},
-				ExpectedError: "datastore: key not found",
+				ExpectedError: "collection not found",
 			},
 			testUtils.CreateDoc{
 				NodeID: immutable.Some(0),


### PR DESCRIPTION
## Relevant issue(s)

Resolves #1964 #1913 

## Description

Reorganises collection description storage so that it actually makes sense.

The existing key/value setup has been replaced with the following keys:
```
[Collection.ID] => json // Json should be stored against an immutable index, i.e. not against `Name`
[Collection.Name] => [Collection.ID]  // This means collection names must be unique
```
We also need the following for the short-term, before Collection.GlobalID gets added, as otherwise if a collection is updated to a new schema version, we lose track of what collection it could be.  The locations that use this have been linked to https://github.com/sourcenetwork/defradb/issues/1085
```
[Collection.SchemaVersionId]/[Collection.ID] => nil
```

With this change the storage setup should fully support multiple collections from a single schema, however this is blocked off by `setDefaultSchemaVersion` (it doesn't allow users to explicitly specify a collection, so atm there is no way to try and do this). Later when we introduce `patchCollection` we will need to be mindful of this and block off user's ability to do this (if done before #1085).

Strongly recommend reviewing commit by commit, I've tried to add a fair bit of context in each commit message.