### PR TITLE
refactor: CRDT merge direction

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -256,7 +256,11 @@ test\:coverage:
 	@$(MAKE) deps:lens
 	@$(MAKE) clean:coverage
 	mkdir $(COVERAGE_DIRECTORY)
+ifeq ($(path),)
 	gotestsum --format testname -- ./... $(TEST_FLAGS) $(COVERAGE_FLAGS)
+else
+	gotestsum --format testname -- $(path) $(TEST_FLAGS) $(COVERAGE_FLAGS)
+endif
 	go tool covdata textfmt -i=$(COVERAGE_DIRECTORY) -o $(COVERAGE_FILE)
 
 .PHONY: test\:coverage-func
@@ -266,8 +270,9 @@ test\:coverage-func:
 
 .PHONY: test\:coverage-html
 test\:coverage-html:
-	@$(MAKE) test:coverage
+	@$(MAKE) test:coverage path=$(path)
 	go tool cover -html=$(COVERAGE_FILE)
+	rm -rf ./coverage
 
 .PHONY: test\:changes
 test\:changes:

--- a/Makefile
+++ b/Makefile
@@ -272,7 +272,8 @@ test\:coverage-func:
 test\:coverage-html:
 	@$(MAKE) test:coverage path=$(path)
 	go tool cover -html=$(COVERAGE_FILE)
-	rm -rf ./coverage
+	@$(MAKE) clean:coverage
+	
 
 .PHONY: test\:changes
 test\:changes:

--- a/core/clock.go
+++ b/core/clock.go
@@ -13,7 +13,6 @@ package core
 import (
 	"context"
 
-	cid "github.com/ipfs/go-cid"
 	ipld "github.com/ipfs/go-ipld-format"
 )
 
@@ -24,5 +23,5 @@ type MerkleClock interface {
 		ctx context.Context,
 		delta Delta,
 	) (ipld.Node, error) // possibly change to AddDeltaNode?
-	ProcessNode(context.Context, NodeGetter, Delta, ipld.Node) ([]cid.Cid, error)
+	ProcessNode(context.Context, Delta, ipld.Node) error
 }

--- a/core/crdt/composite.go
+++ b/core/crdt/composite.go
@@ -196,20 +196,6 @@ func (c CompositeDAG) Merge(ctx context.Context, delta core.Delta) error {
 }
 
 func (c CompositeDAG) deleteWithPrefix(ctx context.Context, key core.DataStoreKey) error {
-	val, err := c.store.Get(ctx, key.ToDS())
-	if err != nil && !errors.Is(err, ds.ErrNotFound) {
-		return err
-	}
-	if !errors.Is(err, ds.ErrNotFound) {
-		err = c.store.Put(ctx, c.key.WithDeletedFlag().ToDS(), val)
-		if err != nil {
-			return err
-		}
-		err = c.store.Delete(ctx, key.ToDS())
-		if err != nil {
-			return err
-		}
-	}
 	q := query.Query{
 		Prefix: key.ToString(),
 	}

--- a/db/fetcher/versioned.go
+++ b/db/fetcher/versioned.go
@@ -405,7 +405,7 @@ func (vf *VersionedFetcher) processNode(
 		return err
 	}
 
-	_, err = mcrdt.Clock().ProcessNode(vf.ctx, nil, delta, nd)
+	err = mcrdt.Clock().ProcessNode(vf.ctx, delta, nd)
 	return err
 }
 

--- a/net/dag_test.go
+++ b/net/dag_test.go
@@ -18,14 +18,13 @@ import (
 
 	dag "github.com/ipfs/boxo/ipld/merkledag"
 	"github.com/ipfs/go-cid"
-	format "github.com/ipfs/go-ipld-format"
 	ipld "github.com/ipfs/go-ipld-format"
 	mh "github.com/multiformats/go-multihash"
 	"github.com/stretchr/testify/require"
 
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/core"
-	"github.com/sourcenetwork/defradb/core/crdt"
+	"github.com/sourcenetwork/defradb/merkle/clock"
 	netutils "github.com/sourcenetwork/defradb/net/utils"
 )
 
@@ -39,49 +38,6 @@ func TestSendJobWorker_ExitOnContextClose_NoError(t *testing.T) {
 		n.sendJobWorker()
 		close(done)
 	}()
-	n.Close()
-	select {
-	case <-done:
-	case <-time.After(timeout):
-		t.Error("failed to close sendJobWorker")
-	}
-}
-
-func TestSendJobWorker_WithNewJobWithClosePriorToProcessing_NoError(t *testing.T) {
-	ctx := context.Background()
-	db, n := newTestNode(ctx, t)
-	done := make(chan struct{})
-	go func() {
-		n.sendJobWorker()
-		close(done)
-	}()
-	_, err := db.AddSchema(ctx, `type User {
-		name: String
-		age: Int
-	}`)
-	require.NoError(t, err)
-
-	col, err := db.GetCollectionByName(ctx, "User")
-	require.NoError(t, err)
-
-	doc, err := client.NewDocFromJSON([]byte(`{"name": "John", "age": 30}`))
-	require.NoError(t, err)
-	dsKey := core.DataStoreKeyFromDocKey(doc.Key())
-
-	txn, err := db.NewTxn(ctx, false)
-	require.NoError(t, err)
-
-	wg := sync.WaitGroup{}
-	wg.Add(1)
-
-	n.sendJobs <- &dagJob{
-		session:    &wg,
-		node:       &EmptyNode{},
-		collection: col,
-		dsKey:      dsKey,
-		txn:        txn,
-	}
-
 	n.Close()
 	select {
 	case <-done:
@@ -104,9 +60,6 @@ func TestSendJobWorker_WithNewJob_NoError(t *testing.T) {
 	}`)
 	require.NoError(t, err)
 
-	col, err := db.GetCollectionByName(ctx, "User")
-	require.NoError(t, err)
-
 	doc, err := client.NewDocFromJSON([]byte(`{"name": "John", "age": 30}`))
 	require.NoError(t, err)
 	dsKey := core.DataStoreKeyFromDocKey(doc.Key())
@@ -118,11 +71,9 @@ func TestSendJobWorker_WithNewJob_NoError(t *testing.T) {
 	wg.Add(1)
 
 	n.sendJobs <- &dagJob{
-		session:    &wg,
-		node:       &EmptyNode{},
-		collection: col,
-		dsKey:      dsKey,
-		txn:        txn,
+		session: &wg,
+		dsKey:   dsKey,
+		txn:     txn,
 	}
 	// Give the jobworker time to process the job.
 	time.Sleep(100 * time.Microsecond)
@@ -148,9 +99,6 @@ func TestSendJobWorker_WithCloseJob_NoError(t *testing.T) {
 	}`)
 	require.NoError(t, err)
 
-	col, err := db.GetCollectionByName(ctx, "User")
-	require.NoError(t, err)
-
 	doc, err := client.NewDocFromJSON([]byte(`{"name": "John", "age": 30}`))
 	require.NoError(t, err)
 	dsKey := core.DataStoreKeyFromDocKey(doc.Key())
@@ -162,11 +110,9 @@ func TestSendJobWorker_WithCloseJob_NoError(t *testing.T) {
 	wg.Add(1)
 
 	n.sendJobs <- &dagJob{
-		session:    &wg,
-		node:       &EmptyNode{},
-		collection: col,
-		dsKey:      dsKey,
-		txn:        txn,
+		session: &wg,
+		dsKey:   dsKey,
+		txn:     txn,
 	}
 
 	n.closeJob <- dsKey.DocKey
@@ -179,7 +125,7 @@ func TestSendJobWorker_WithCloseJob_NoError(t *testing.T) {
 	}
 }
 
-func TestSendJobWorker_WithPeerAndNoChildren_NoError(t *testing.T) {
+func TestSendJobWorker_WithPeer_NoError(t *testing.T) {
 	ctx := context.Background()
 	db1, n1 := newTestNode(ctx, t)
 	db2, n2 := newTestNode(ctx, t)
@@ -188,6 +134,10 @@ func TestSendJobWorker_WithPeerAndNoChildren_NoError(t *testing.T) {
 	require.NoError(t, err)
 	n2.Bootstrap(addrs)
 
+	err = n1.WaitForPeerConnectionEvent(n2.PeerID())
+	require.NoError(t, err)
+	err = n2.WaitForPeerConnectionEvent(n1.PeerID())
+	require.NoError(t, err)
 	done := make(chan struct{})
 	go func() {
 		n2.sendJobWorker()
@@ -215,132 +165,48 @@ func TestSendJobWorker_WithPeerAndNoChildren_NoError(t *testing.T) {
 	err = col.Create(ctx, doc)
 	require.NoError(t, err)
 
-	txn, err := db2.NewTxn(ctx, false)
+	txn1, _ := db1.NewTxn(ctx, false)
+	heads, _, err := clock.NewHeadSet(txn1.Headstore(), dsKey.ToHeadStoreKey().WithFieldId(core.COMPOSITE_NAMESPACE)).List(ctx)
+	require.NoError(t, err)
+	txn1.Discard(ctx)
+
+	txn2, err := db2.NewTxn(ctx, false)
 	require.NoError(t, err)
 
 	wg := sync.WaitGroup{}
 	wg.Add(1)
 
-	delta := &crdt.CompositeDAGDelta{
-		SchemaVersionID: col.Schema().VersionID,
-		Priority:        1,
-		DocKey:          doc.Key().Bytes(),
-	}
-
-	node, err := makeNode(delta, []cid.Cid{})
-	require.NoError(t, err)
-
-	var getter format.NodeGetter = n2.Peer.newDAGSyncerTxn(txn)
+	var getter ipld.NodeGetter = n2.Peer.newDAGSyncerTxn(txn2)
 	if sessionMaker, ok := getter.(SessionDAGSyncer); ok {
 		log.Debug(ctx, "Upgrading DAGSyncer with a session")
 		getter = sessionMaker.Session(ctx)
 	}
 
 	n2.sendJobs <- &dagJob{
-		session:    &wg,
-		nodeGetter: getter,
-		node:       node,
-		collection: col,
-		dsKey:      dsKey,
-		txn:        txn,
+		bp:          newBlockProcessor(n2.Peer),
+		session:     &wg,
+		nodeGetter:  getter,
+		dsKey:       dsKey,
+		txn:         txn2,
+		cid:         heads[0],
+		isComposite: true,
 	}
-	// Give the jobworker time to process the job.
-	time.Sleep(100 * time.Microsecond)
-	n1.Close()
-	n2.Close()
-	select {
-	case <-done:
-	case <-time.After(timeout):
-		t.Error("failed to close sendJobWorker")
-	}
-}
+	wg.Wait()
 
-func TestSendJobWorker_WithPeerAndChildren_NoError(t *testing.T) {
-	ctx := context.Background()
-	db1, n1 := newTestNode(ctx, t)
-	db2, n2 := newTestNode(ctx, t)
-
-	addrs, err := netutils.ParsePeers([]string{n1.host.Addrs()[0].String() + "/p2p/" + n1.PeerID().String()})
-	require.NoError(t, err)
-	n2.Bootstrap(addrs)
-
-	done := make(chan struct{})
-	go func() {
-		n2.sendJobWorker()
-		close(done)
-	}()
-
-	_, err = db1.AddSchema(ctx, `type User {
-		name: String
-		age: Int
-	}`)
-	require.NoError(t, err)
-	_, err = db2.AddSchema(ctx, `type User {
-		name: String
-		age: Int
-	}`)
+	err = txn2.Commit(ctx)
 	require.NoError(t, err)
 
-	col, err := db1.GetCollectionByName(ctx, "User")
+	block, err := n1.db.Blockstore().Get(ctx, heads[0])
+	require.NoError(t, err)
+	nd, err := dag.DecodeProtobufBlock(block)
 	require.NoError(t, err)
 
-	doc, err := client.NewDocFromJSON([]byte(`{"name": "John", "age": 30}`))
-	require.NoError(t, err)
-	dsKey := core.DataStoreKeyFromDocKey(doc.Key())
-
-	err = col.Create(ctx, doc)
-	require.NoError(t, err)
-
-	txn, err := db2.NewTxn(ctx, false)
-	require.NoError(t, err)
-
-	wg := sync.WaitGroup{}
-	wg.Add(1)
-
-	links := []core.DAGLink{}
-	for k := range doc.Fields() {
-		delta := &crdt.LWWRegDelta{
-			SchemaVersionID: col.Schema().VersionID,
-			Priority:        1,
-			DocKey:          doc.Key().Bytes(),
-			FieldName:       k,
-		}
-
-		node, err := makeNode(delta, []cid.Cid{})
+	for _, link := range nd.Links() {
+		exists, err := n2.db.Blockstore().Has(ctx, link.Cid)
 		require.NoError(t, err)
-
-		links = append(links, core.DAGLink{
-			Name: k,
-			Cid:  node.Cid(),
-		})
+		require.True(t, exists)
 	}
 
-	delta := &crdt.CompositeDAGDelta{
-		SchemaVersionID: col.Schema().VersionID,
-		Priority:        1,
-		DocKey:          doc.Key().Bytes(),
-		SubDAGs:         links,
-	}
-
-	node, err := makeNode(delta, []cid.Cid{})
-	require.NoError(t, err)
-
-	var getter format.NodeGetter = n2.Peer.newDAGSyncerTxn(txn)
-	if sessionMaker, ok := getter.(SessionDAGSyncer); ok {
-		log.Debug(ctx, "Upgrading DAGSyncer with a session")
-		getter = sessionMaker.Session(ctx)
-	}
-
-	n2.sendJobs <- &dagJob{
-		session:    &wg,
-		nodeGetter: getter,
-		node:       node,
-		collection: col,
-		dsKey:      dsKey,
-		txn:        txn,
-	}
-	// Give the jobworker time to process the job.
-	time.Sleep(100 * time.Microsecond)
 	n1.Close()
 	n2.Close()
 	select {

--- a/net/dag_test.go
+++ b/net/dag_test.go
@@ -72,8 +72,10 @@ func TestSendJobWorker_WithNewJob_NoError(t *testing.T) {
 
 	n.sendJobs <- &dagJob{
 		session: &wg,
-		dsKey:   dsKey,
-		txn:     txn,
+		bp: &blockProcessor{
+			dsKey: dsKey,
+			txn:   txn,
+		},
 	}
 	// Give the jobworker time to process the job.
 	time.Sleep(100 * time.Microsecond)
@@ -111,8 +113,10 @@ func TestSendJobWorker_WithCloseJob_NoError(t *testing.T) {
 
 	n.sendJobs <- &dagJob{
 		session: &wg,
-		dsKey:   dsKey,
-		txn:     txn,
+		bp: &blockProcessor{
+			dsKey: dsKey,
+			txn:   txn,
+		},
 	}
 
 	n.closeJob <- dsKey.DocKey
@@ -183,11 +187,8 @@ func TestSendJobWorker_WithPeer_NoError(t *testing.T) {
 	}
 
 	n2.sendJobs <- &dagJob{
-		bp:          newBlockProcessor(n2.Peer),
+		bp:          newBlockProcessor(n2.Peer, txn2, col, dsKey, getter),
 		session:     &wg,
-		nodeGetter:  getter,
-		dsKey:       dsKey,
-		txn:         txn2,
 		cid:         heads[0],
 		isComposite: true,
 	}

--- a/net/server.go
+++ b/net/server.go
@@ -247,7 +247,7 @@ func (s *server) PushLog(ctx context.Context, req *pb.PushLogRequest) (*pb.PushL
 	}
 
 	schemaRoot := string(req.Body.SchemaRoot)
-	docKey := core.DataStoreKeyFromDocKey(dockey)
+	dsKey := core.DataStoreKeyFromDocKey(dockey)
 
 	var txnErr error
 	for retry := 0; retry < s.peer.db.MaxTxnRetries(); retry++ {
@@ -284,33 +284,37 @@ func (s *server) PushLog(ctx context.Context, req *pb.PushLogRequest) (*pb.PushL
 			return nil, errors.Wrap("failed to decode block to ipld.Node", err)
 		}
 
-		cids, err := s.peer.processLog(ctx, txn, col, docKey, "", nd, getter, false)
+		var session sync.WaitGroup
+		bp := newBlockProcessor(s.peer)
+		err = bp.processRemoteBlock(ctx, &session, txn, dsKey, nd, getter, true)
 		if err != nil {
 			log.ErrorE(
 				ctx,
-				"Failed to process PushLog node",
+				"Failed to process remote block",
 				err,
-				logging.NewKV("DocKey", docKey),
+				logging.NewKV("DocKey", dsKey.DocKey),
 				logging.NewKV("CID", cid),
 			)
 		}
+		session.Wait()
+		for e := bp.composites.Front(); e != nil; e = e.Next() {
+			nd := e.Value.(format.Node)
+			err := s.peer.processBlock(ctx, txn, col, dsKey, nd, "")
+			if err != nil {
+				log.ErrorE(
+					ctx,
+					"Failed to process block",
+					err,
+					logging.NewKV("DocKey", dsKey.DocKey),
+					logging.NewKV("CID", nd.Cid()),
+				)
+			}
+		}
 
-		// handleChildren
-		if len(cids) > 0 { // we have child nodes to get
-			log.Debug(
-				ctx,
-				"Handling children for log",
-				logging.NewKV("NChildren", len(cids)),
-				logging.NewKV("CID", cid),
-			)
-			var session sync.WaitGroup
-			s.peer.handleChildBlocks(&session, txn, col, docKey, "", nd, cids, getter)
-			session.Wait()
-			// dagWorkers specific to the dockey will have been spawned within handleChildBlocks.
-			// Once we are done with the dag syncing process, we can get rid of those workers.
-			s.peer.closeJob <- docKey.DocKey
-		} else {
-			log.Debug(ctx, "No more children to process for log", logging.NewKV("CID", cid))
+		// dagWorkers specific to the dockey will have been spawned within handleChildBlocks.
+		// Once we are done with the dag syncing process, we can get rid of those workers.
+		if s.peer.closeJob != nil {
+			s.peer.closeJob <- dsKey.DocKey
 		}
 
 		if txnErr = txn.Commit(ctx); txnErr != nil {
@@ -323,7 +327,7 @@ func (s *server) PushLog(ctx context.Context, req *pb.PushLogRequest) (*pb.PushL
 		// Once processed, subscribe to the dockey topic on the pubsub network unless we already
 		// suscribe to the collection.
 		if !s.hasPubSubTopic(col.SchemaRoot()) {
-			err = s.addPubSubTopic(docKey.DocKey, true)
+			err = s.addPubSubTopic(dsKey.DocKey, true)
 			if err != nil {
 				return nil, err
 			}

--- a/net/server_test.go
+++ b/net/server_test.go
@@ -248,8 +248,10 @@ func TestDocQueue(t *testing.T) {
 func TestPushLog(t *testing.T) {
 	ctx := context.Background()
 	db, n := newTestNode(ctx, t)
+	err := n.Start()
+	require.NoError(t, err)
 
-	_, err := db.AddSchema(ctx, `type User {
+	_, err = db.AddSchema(ctx, `type User {
 		name: String
 		age: Int
 	}`)


### PR DESCRIPTION
## Relevant issue(s)

Resolves #1066 

## Description

This PR change the CRDT merge direction. Originally, when an update arrived over the P2P network, each block was added to the DAG store and merged into the datastore in the order that they were received (newest to oldest block).

With this update, we start my receiving all blocks up to the version that we currently have (or until we reach the root) and then we apply the merge from oldest to newest block. This will enable more CRDT types to be added.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

make test

Specify the platform(s) on which this was tested:
- MacOS
