### PR TITLE
ci: Add windows test runner

### DIFF
--- a/.github/workflows/test-and-upload-coverage.yml
+++ b/.github/workflows/test-and-upload-coverage.yml
@@ -28,6 +28,7 @@ jobs:
     name: Run tests matrix job
 
     strategy:
+      fail-fast: true
       matrix:
         os: [ubuntu-latest]
         client-type: [go, http, cli]

--- a/.github/workflows/test-and-upload-coverage.yml
+++ b/.github/workflows/test-and-upload-coverage.yml
@@ -46,8 +46,18 @@ jobs:
             database-type: badger-memory
             mutation-type: collection-save
             detect-changes: false
+          - os: windows-latest
+            client-type: go
+            database-type: badger-memory
+            mutation-type: collection-save
+            detect-changes: false
 
     runs-on: ${{ matrix.os }}
+
+    # We run all runners via the bash shell to provide us with a consistent set of env variables and commands
+    defaults:
+      run:
+        shell: bash
 
     env:
       CGO_ENABLED: 1

--- a/config/configfile_test.go
+++ b/config/configfile_test.go
@@ -14,6 +14,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"text/template"
 
@@ -61,6 +62,10 @@ func TestWritesConfigFileErroneousPath(t *testing.T) {
 }
 
 func TestReadConfigFileForLogger(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skipf("Test is not supported on windows as it leaks resources, see https://github.com/sourcenetwork/defradb/issues/2057")
+	}
+
 	cfg := DefaultConfig()
 	tmpdir := t.TempDir()
 	cfg.Rootdir = tmpdir

--- a/datastore/badger/v4/datastore_test.go
+++ b/datastore/badger/v4/datastore_test.go
@@ -60,6 +60,10 @@ func TestNewDatastoreWithOptions(t *testing.T) {
 
 	s, err := NewDatastore(dir, &opt)
 	require.NoError(t, err)
+	defer func() {
+		err := s.Close()
+		require.NoError(t, err)
+	}()
 
 	s.Put(ctx, testKey1, testValue1)
 	s.Put(ctx, testKey2, testValue2)
@@ -68,6 +72,10 @@ func TestNewDatastoreWithOptions(t *testing.T) {
 func TestNewBatch(t *testing.T) {
 	ctx := context.Background()
 	s := newLoadedDatastore(ctx, t)
+	defer func() {
+		err := s.Close()
+		require.NoError(t, err)
+	}()
 
 	b, err := s.Batch(ctx)
 	require.NoError(t, err)
@@ -77,6 +85,10 @@ func TestNewBatch(t *testing.T) {
 func TestBatchOperations(t *testing.T) {
 	ctx := context.Background()
 	s := newLoadedDatastore(ctx, t)
+	defer func() {
+		err := s.Close()
+		require.NoError(t, err)
+	}()
 
 	b, err := s.Batch(ctx)
 	require.NoError(t, err)
@@ -154,6 +166,10 @@ func TestBatchCommitWithStoreClosed(t *testing.T) {
 func TestBatchConsecutiveCommit(t *testing.T) {
 	ctx := context.Background()
 	s := newLoadedDatastore(ctx, t)
+	defer func() {
+		err := s.Close()
+		require.NoError(t, err)
+	}()
 
 	b, err := s.Batch(ctx)
 	require.NoError(t, err)
@@ -168,6 +184,10 @@ func TestBatchConsecutiveCommit(t *testing.T) {
 func TestCollectGarbage(t *testing.T) {
 	ctx := context.Background()
 	s := newLoadedDatastore(ctx, t)
+	defer func() {
+		err := s.Close()
+		require.NoError(t, err)
+	}()
 
 	err := s.CollectGarbage(ctx)
 	require.NoError(t, err)
@@ -206,6 +226,10 @@ func TestConsecutiveClose(t *testing.T) {
 func TestGetOperation(t *testing.T) {
 	ctx := context.Background()
 	s := newLoadedDatastore(ctx, t)
+	defer func() {
+		err := s.Close()
+		require.NoError(t, err)
+	}()
 
 	resp, err := s.Get(ctx, testKey1)
 	require.NoError(t, err)
@@ -225,6 +249,10 @@ func TestGetOperationWithStoreClosed(t *testing.T) {
 func TestGetOperationNotFound(t *testing.T) {
 	ctx := context.Background()
 	s := newLoadedDatastore(ctx, t)
+	defer func() {
+		err := s.Close()
+		require.NoError(t, err)
+	}()
 
 	_, err := s.Get(ctx, testKey3)
 	require.ErrorIs(t, err, ds.ErrNotFound)
@@ -233,6 +261,10 @@ func TestGetOperationNotFound(t *testing.T) {
 func TestDeleteOperation(t *testing.T) {
 	ctx := context.Background()
 	s := newLoadedDatastore(ctx, t)
+	defer func() {
+		err := s.Close()
+		require.NoError(t, err)
+	}()
 
 	err := s.Delete(ctx, testKey1)
 	require.NoError(t, err)
@@ -244,6 +276,10 @@ func TestDeleteOperation(t *testing.T) {
 func TestDeleteOperation2(t *testing.T) {
 	ctx := context.Background()
 	s := newLoadedDatastore(ctx, t)
+	defer func() {
+		err := s.Close()
+		require.NoError(t, err)
+	}()
 
 	err := s.Put(ctx, testKey1, testValue1)
 	require.NoError(t, err)
@@ -269,6 +305,10 @@ func TestDeleteOperationWithStoreClosed(t *testing.T) {
 func TestGetSizeOperation(t *testing.T) {
 	ctx := context.Background()
 	s := newLoadedDatastore(ctx, t)
+	defer func() {
+		err := s.Close()
+		require.NoError(t, err)
+	}()
 
 	resp, err := s.GetSize(ctx, testKey1)
 	require.NoError(t, err)
@@ -278,6 +318,10 @@ func TestGetSizeOperation(t *testing.T) {
 func TestGetSizeOperationNotFound(t *testing.T) {
 	ctx := context.Background()
 	s := newLoadedDatastore(ctx, t)
+	defer func() {
+		err := s.Close()
+		require.NoError(t, err)
+	}()
 
 	_, err := s.GetSize(ctx, testKey3)
 	require.ErrorIs(t, err, ds.ErrNotFound)
@@ -297,6 +341,10 @@ func TestGetSizeOperationWithStoreClosed(t *testing.T) {
 func TestHasOperation(t *testing.T) {
 	ctx := context.Background()
 	s := newLoadedDatastore(ctx, t)
+	defer func() {
+		err := s.Close()
+		require.NoError(t, err)
+	}()
 
 	resp, err := s.Has(ctx, testKey1)
 	require.NoError(t, err)
@@ -306,6 +354,10 @@ func TestHasOperation(t *testing.T) {
 func TestHasOperationNotFound(t *testing.T) {
 	ctx := context.Background()
 	s := newLoadedDatastore(ctx, t)
+	defer func() {
+		err := s.Close()
+		require.NoError(t, err)
+	}()
 
 	resp, err := s.Has(ctx, testKey3)
 	require.NoError(t, err)
@@ -326,6 +378,10 @@ func TestHasOperationWithStoreClosed(t *testing.T) {
 func TestPutOperation(t *testing.T) {
 	ctx := context.Background()
 	s := newLoadedDatastore(ctx, t)
+	defer func() {
+		err := s.Close()
+		require.NoError(t, err)
+	}()
 
 	err := s.Put(ctx, testKey3, testValue3)
 	require.NoError(t, err)
@@ -349,6 +405,10 @@ func TestPutOperationWithStoreClosed(t *testing.T) {
 func TestQueryOperation(t *testing.T) {
 	ctx := context.Background()
 	s := newLoadedDatastore(ctx, t)
+	defer func() {
+		err := s.Close()
+		require.NoError(t, err)
+	}()
 
 	results, err := s.Query(ctx, dsq.Query{
 		Limit:  1,
@@ -379,6 +439,10 @@ func TestQueryOperationWithStoreClosed(t *testing.T) {
 func TestDiskUsage(t *testing.T) {
 	ctx := context.Background()
 	s := newLoadedDatastore(ctx, t)
+	defer func() {
+		err := s.Close()
+		require.NoError(t, err)
+	}()
 
 	size, err := s.DiskUsage(ctx)
 	require.NoError(t, err)
@@ -399,6 +463,10 @@ func TestDiskUsageWithStoreClosed(t *testing.T) {
 func TestSync(t *testing.T) {
 	ctx := context.Background()
 	s := newLoadedDatastore(ctx, t)
+	defer func() {
+		err := s.Close()
+		require.NoError(t, err)
+	}()
 	err := s.Sync(ctx, testKey1)
 	require.NoError(t, err)
 }

--- a/datastore/memory/memory_test.go
+++ b/datastore/memory/memory_test.go
@@ -475,7 +475,9 @@ func TestClearOldFlightTransactions(t *testing.T) {
 	s.inFlightTxn.Set(dsTxn{
 		dsVersion:  s.getVersion(),
 		txnVersion: s.getVersion() + 1,
-		expiresAt:  time.Now(),
+		// Ensure expiresAt is before the value returned from the later call in `clearOldInFlightTxn`,
+		// in windows in particular it seems that the two `time.Now` calls can return the same value
+		expiresAt: time.Now().Add(-1 * time.Minute),
 	})
 
 	require.Equal(t, 1, s.inFlightTxn.Len())

--- a/db/index_test.go
+++ b/db/index_test.go
@@ -239,6 +239,7 @@ func (f *indexTestFixture) getCollectionIndexes(colName string) ([]client.IndexD
 
 func TestCreateIndex_IfFieldsIsEmpty_ReturnError(t *testing.T) {
 	f := newIndexTestFixture(t)
+	defer f.db.Close()
 
 	_, err := f.createCollectionIndex(client.IndexDescription{
 		Name: "some_index_name",
@@ -248,6 +249,7 @@ func TestCreateIndex_IfFieldsIsEmpty_ReturnError(t *testing.T) {
 
 func TestCreateIndex_IfIndexDescriptionIDIsNotZero_ReturnError(t *testing.T) {
 	f := newIndexTestFixture(t)
+	defer f.db.Close()
 
 	for _, id := range []uint32{1, 20, 999} {
 		desc := client.IndexDescription{
@@ -264,6 +266,7 @@ func TestCreateIndex_IfIndexDescriptionIDIsNotZero_ReturnError(t *testing.T) {
 
 func TestCreateIndex_IfValidInput_CreateIndex(t *testing.T) {
 	f := newIndexTestFixture(t)
+	defer f.db.Close()
 
 	desc := client.IndexDescription{
 		Name: "some_index_name",
@@ -279,6 +282,7 @@ func TestCreateIndex_IfValidInput_CreateIndex(t *testing.T) {
 
 func TestCreateIndex_IfFieldNameIsEmpty_ReturnError(t *testing.T) {
 	f := newIndexTestFixture(t)
+	defer f.db.Close()
 
 	desc := client.IndexDescription{
 		Name: "some_index_name",
@@ -292,6 +296,7 @@ func TestCreateIndex_IfFieldNameIsEmpty_ReturnError(t *testing.T) {
 
 func TestCreateIndex_IfFieldHasNoDirection_DefaultToAsc(t *testing.T) {
 	f := newIndexTestFixture(t)
+	defer f.db.Close()
 
 	desc := client.IndexDescription{
 		Name:   "some_index_name",
@@ -304,6 +309,7 @@ func TestCreateIndex_IfFieldHasNoDirection_DefaultToAsc(t *testing.T) {
 
 func TestCreateIndex_IfSingleFieldInDescOrder_ReturnError(t *testing.T) {
 	f := newIndexTestFixture(t)
+	defer f.db.Close()
 
 	desc := client.IndexDescription{
 		Fields: []client.IndexedFieldDescription{
@@ -316,6 +322,7 @@ func TestCreateIndex_IfSingleFieldInDescOrder_ReturnError(t *testing.T) {
 
 func TestCreateIndex_IfIndexWithNameAlreadyExists_ReturnError(t *testing.T) {
 	f := newIndexTestFixture(t)
+	defer f.db.Close()
 
 	name := "some_index_name"
 	desc1 := client.IndexDescription{
@@ -334,6 +341,7 @@ func TestCreateIndex_IfIndexWithNameAlreadyExists_ReturnError(t *testing.T) {
 
 func TestCreateIndex_IfGeneratedNameMatchesExisting_AddIncrement(t *testing.T) {
 	f := newIndexTestFixture(t)
+	defer f.db.Close()
 
 	name := usersColName + "_" + usersAgeFieldName + "_ASC"
 	desc1 := client.IndexDescription{
@@ -359,6 +367,7 @@ func TestCreateIndex_IfGeneratedNameMatchesExisting_AddIncrement(t *testing.T) {
 
 func TestCreateIndex_ShouldSaveToSystemStorage(t *testing.T) {
 	f := newIndexTestFixture(t)
+	defer f.db.Close()
 
 	name := "users_age_ASC"
 	desc := client.IndexDescription{
@@ -380,6 +389,7 @@ func TestCreateIndex_ShouldSaveToSystemStorage(t *testing.T) {
 
 func TestCreateIndex_IfCollectionDoesntExist_ReturnError(t *testing.T) {
 	f := newIndexTestFixture(t)
+	defer f.db.Close()
 
 	desc := client.IndexDescription{
 		Fields: []client.IndexedFieldDescription{{Name: productsPriceFieldName}},
@@ -391,6 +401,7 @@ func TestCreateIndex_IfCollectionDoesntExist_ReturnError(t *testing.T) {
 
 func TestCreateIndex_IfPropertyDoesntExist_ReturnError(t *testing.T) {
 	f := newIndexTestFixture(t)
+	defer f.db.Close()
 
 	const field = "non_existing_field"
 	desc := client.IndexDescription{
@@ -433,10 +444,13 @@ func TestCreateIndex_WithMultipleCollectionsAndIndexes_AssignIncrementedIDPerCol
 
 func TestCreateIndex_IfFailsToCreateTxn_ReturnError(t *testing.T) {
 	f := newIndexTestFixture(t)
+	defer f.db.Close()
 
 	testErr := errors.New("test error")
 
 	mockedRootStore := mocks.NewRootStore(t)
+	mockedRootStore.On("Close").Return(nil)
+
 	mockedRootStore.EXPECT().NewTransaction(mock.Anything, mock.Anything).Return(nil, testErr)
 	f.db.rootstore = mockedRootStore
 
@@ -446,6 +460,7 @@ func TestCreateIndex_IfFailsToCreateTxn_ReturnError(t *testing.T) {
 
 func TestCreateIndex_IfProvideInvalidIndexName_ReturnError(t *testing.T) {
 	f := newIndexTestFixture(t)
+	defer f.db.Close()
 
 	indexDesc := getUsersIndexDescOnName()
 	indexDesc.Name = "!"
@@ -455,6 +470,7 @@ func TestCreateIndex_IfProvideInvalidIndexName_ReturnError(t *testing.T) {
 
 func TestCreateIndex_ShouldUpdateCollectionsDescription(t *testing.T) {
 	f := newIndexTestFixture(t)
+	defer f.db.Close()
 
 	indOnName, err := f.users.CreateIndex(f.ctx, getUsersIndexDescOnName())
 	require.NoError(t, err)
@@ -500,6 +516,7 @@ func TestCreateIndex_IfAttemptToIndexOnUnsupportedType_ReturnError(t *testing.T)
 
 func TestGetIndexes_ShouldReturnListOfAllExistingIndexes(t *testing.T) {
 	f := newIndexTestFixture(t)
+	defer f.db.Close()
 
 	usersIndexDesc := client.IndexDescription{
 		Name:   "users_name_index",
@@ -531,6 +548,7 @@ func TestGetIndexes_ShouldReturnListOfAllExistingIndexes(t *testing.T) {
 
 func TestGetIndexes_IfInvalidIndexIsStored_ReturnError(t *testing.T) {
 	f := newIndexTestFixture(t)
+	defer f.db.Close()
 
 	indexKey := core.NewCollectionIndexKey(usersColName, "users_name_index")
 	err := f.txn.Systemstore().Put(f.ctx, indexKey.ToDS(), []byte("invalid"))
@@ -542,6 +560,7 @@ func TestGetIndexes_IfInvalidIndexIsStored_ReturnError(t *testing.T) {
 
 func TestGetIndexes_IfInvalidIndexKeyIsStored_ReturnError(t *testing.T) {
 	f := newIndexTestFixture(t)
+	defer f.db.Close()
 
 	indexKey := core.NewCollectionIndexKey(usersColName, "users_name_index")
 	key := ds.NewKey(indexKey.ToString() + "/invalid")
@@ -561,6 +580,7 @@ func TestGetIndexes_IfInvalidIndexKeyIsStored_ReturnError(t *testing.T) {
 
 func TestGetIndexes_IfSystemStoreFails_ReturnError(t *testing.T) {
 	f := newIndexTestFixture(t)
+	defer f.db.Close()
 
 	testErr := errors.New("test error")
 
@@ -575,6 +595,7 @@ func TestGetIndexes_IfSystemStoreFails_ReturnError(t *testing.T) {
 
 func TestGetIndexes_IfSystemStoreFails_ShouldCloseIterator(t *testing.T) {
 	f := newIndexTestFixture(t)
+	defer f.db.Close()
 
 	mockedTxn := f.mockTxn()
 	mockedTxn.MockSystemstore.EXPECT().Query(mock.Anything, mock.Anything).Unset()
@@ -587,6 +608,7 @@ func TestGetIndexes_IfSystemStoreFails_ShouldCloseIterator(t *testing.T) {
 
 func TestGetIndexes_IfSystemStoreQueryIteratorFails_ReturnError(t *testing.T) {
 	f := newIndexTestFixture(t)
+	defer f.db.Close()
 
 	testErr := errors.New("test error")
 
@@ -604,6 +626,7 @@ func TestGetIndexes_IfSystemStoreQueryIteratorFails_ReturnError(t *testing.T) {
 
 func TestGetIndexes_IfSystemStoreHasInvalidData_ReturnError(t *testing.T) {
 	f := newIndexTestFixture(t)
+	defer f.db.Close()
 
 	mockedTxn := f.mockTxn()
 
@@ -619,6 +642,7 @@ func TestGetIndexes_IfSystemStoreHasInvalidData_ReturnError(t *testing.T) {
 
 func TestGetCollectionIndexes_ShouldReturnListOfCollectionIndexes(t *testing.T) {
 	f := newIndexTestFixture(t)
+	defer f.db.Close()
 
 	usersIndexDesc := client.IndexDescription{
 		Name:   "users_name_index",
@@ -656,6 +680,7 @@ func TestGetCollectionIndexes_ShouldReturnListOfCollectionIndexes(t *testing.T) 
 
 func TestGetCollectionIndexes_IfSystemStoreFails_ReturnError(t *testing.T) {
 	f := newIndexTestFixture(t)
+	defer f.db.Close()
 
 	testErr := errors.New("test error")
 
@@ -671,6 +696,7 @@ func TestGetCollectionIndexes_IfSystemStoreFails_ReturnError(t *testing.T) {
 
 func TestGetCollectionIndexes_IfSystemStoreFails_ShouldCloseIterator(t *testing.T) {
 	f := newIndexTestFixture(t)
+	defer f.db.Close()
 
 	mockedTxn := f.mockTxn()
 	mockedTxn.MockSystemstore = mocks.NewDSReaderWriter(t)
@@ -685,6 +711,7 @@ func TestGetCollectionIndexes_IfSystemStoreFails_ShouldCloseIterator(t *testing.
 
 func TestGetCollectionIndexes_IfSystemStoreQueryIteratorFails_ReturnError(t *testing.T) {
 	f := newIndexTestFixture(t)
+	defer f.db.Close()
 
 	testErr := errors.New("test error")
 
@@ -701,6 +728,7 @@ func TestGetCollectionIndexes_IfSystemStoreQueryIteratorFails_ReturnError(t *tes
 
 func TestGetCollectionIndexes_IfInvalidIndexIsStored_ReturnError(t *testing.T) {
 	f := newIndexTestFixture(t)
+	defer f.db.Close()
 
 	indexKey := core.NewCollectionIndexKey(usersColName, "users_name_index")
 	err := f.txn.Systemstore().Put(f.ctx, indexKey.ToDS(), []byte("invalid"))
@@ -712,6 +740,7 @@ func TestGetCollectionIndexes_IfInvalidIndexIsStored_ReturnError(t *testing.T) {
 
 func TestCollectionGetIndexes_ShouldReturnIndexes(t *testing.T) {
 	f := newIndexTestFixture(t)
+	defer f.db.Close()
 
 	f.createUserCollectionIndexOnName()
 
@@ -724,6 +753,7 @@ func TestCollectionGetIndexes_ShouldReturnIndexes(t *testing.T) {
 
 func TestCollectionGetIndexes_ShouldCloseQueryIterator(t *testing.T) {
 	f := newIndexTestFixture(t)
+	defer f.db.Close()
 
 	f.createUserCollectionIndexOnName()
 
@@ -784,6 +814,7 @@ func TestCollectionGetIndexes_IfSystemStoreFails_ReturnError(t *testing.T) {
 
 	for _, testCase := range testCases {
 		f := newIndexTestFixture(t)
+		defer f.db.Close()
 
 		f.createUserCollectionIndexOnName()
 
@@ -800,6 +831,7 @@ func TestCollectionGetIndexes_IfSystemStoreFails_ReturnError(t *testing.T) {
 
 func TestCollectionGetIndexes_IfFailsToCreateTxn_ShouldNotCache(t *testing.T) {
 	f := newIndexTestFixture(t)
+	defer f.db.Close()
 
 	f.createUserCollectionIndexOnName()
 
@@ -861,6 +893,7 @@ func TestCollectionGetIndexes_IfStoredIndexWithUnsupportedType_ReturnError(t *te
 
 func TestCollectionGetIndexes_IfInvalidIndexIsStored_ReturnError(t *testing.T) {
 	f := newIndexTestFixture(t)
+	defer f.db.Close()
 
 	f.createUserCollectionIndexOnName()
 	f.createUserCollectionIndexOnAge()
@@ -877,6 +910,7 @@ func TestCollectionGetIndexes_IfInvalidIndexIsStored_ReturnError(t *testing.T) {
 
 func TestCollectionGetIndexes_IfIndexIsCreated_ReturnUpdateIndexes(t *testing.T) {
 	f := newIndexTestFixture(t)
+	defer f.db.Close()
 
 	f.createUserCollectionIndexOnName()
 
@@ -894,6 +928,7 @@ func TestCollectionGetIndexes_IfIndexIsCreated_ReturnUpdateIndexes(t *testing.T)
 
 func TestCollectionGetIndexes_IfIndexIsDropped_ReturnUpdateIndexes(t *testing.T) {
 	f := newIndexTestFixture(t)
+	defer f.db.Close()
 
 	f.createUserCollectionIndexOnName()
 	f.createUserCollectionIndexOnAge()
@@ -982,6 +1017,7 @@ func TestCollectionGetIndexes_ShouldReturnIndexesInOrderedByName(t *testing.T) {
 
 func TestDropIndex_ShouldDeleteIndex(t *testing.T) {
 	f := newIndexTestFixture(t)
+	defer f.db.Close()
 	desc := f.createUserCollectionIndexOnName()
 
 	err := f.dropIndex(usersColName, desc.Name)
@@ -994,6 +1030,7 @@ func TestDropIndex_ShouldDeleteIndex(t *testing.T) {
 
 func TestDropIndex_IfStorageFails_ReturnError(t *testing.T) {
 	f := newIndexTestFixture(t)
+	defer f.db.Close()
 	desc := f.createUserCollectionIndexOnName()
 	f.db.Close()
 
@@ -1003,6 +1040,7 @@ func TestDropIndex_IfStorageFails_ReturnError(t *testing.T) {
 
 func TestDropIndex_IfCollectionDoesntExist_ReturnError(t *testing.T) {
 	f := newIndexTestFixture(t)
+	defer f.db.Close()
 
 	err := f.dropIndex(productsColName, "any_name")
 	assert.ErrorIs(t, err, NewErrCanNotReadCollection(usersColName, nil))
@@ -1010,12 +1048,15 @@ func TestDropIndex_IfCollectionDoesntExist_ReturnError(t *testing.T) {
 
 func TestDropIndex_IfFailsToCreateTxn_ReturnError(t *testing.T) {
 	f := newIndexTestFixture(t)
+	defer f.db.Close()
 
 	f.createUserCollectionIndexOnName()
 
 	testErr := errors.New("test error")
 
 	mockedRootStore := mocks.NewRootStore(t)
+	mockedRootStore.On("Close").Return(nil)
+
 	mockedRootStore.EXPECT().NewTransaction(mock.Anything, mock.Anything).Return(nil, testErr)
 	f.db.rootstore = mockedRootStore
 
@@ -1025,6 +1066,7 @@ func TestDropIndex_IfFailsToCreateTxn_ReturnError(t *testing.T) {
 
 func TestDropIndex_IfFailsToDeleteFromStorage_ReturnError(t *testing.T) {
 	f := newIndexTestFixture(t)
+	defer f.db.Close()
 
 	f.createUserCollectionIndexOnName()
 
@@ -1043,6 +1085,7 @@ func TestDropIndex_IfFailsToDeleteFromStorage_ReturnError(t *testing.T) {
 
 func TestDropIndex_ShouldUpdateCollectionsDescription(t *testing.T) {
 	f := newIndexTestFixture(t)
+	defer f.db.Close()
 	col := f.users.WithTxn(f.txn)
 	_, err := col.CreateIndex(f.ctx, getUsersIndexDescOnName())
 	require.NoError(t, err)
@@ -1064,6 +1107,7 @@ func TestDropIndex_ShouldUpdateCollectionsDescription(t *testing.T) {
 
 func TestDropIndex_IfIndexWithNameDoesNotExist_ReturnError(t *testing.T) {
 	f := newIndexTestFixture(t)
+	defer f.db.Close()
 
 	const name = "not_existing_index"
 	err := f.users.DropIndex(f.ctx, name)
@@ -1074,6 +1118,7 @@ func TestDropIndex_IfSystemStoreFails_ReturnError(t *testing.T) {
 	testErr := errors.New("test error")
 
 	f := newIndexTestFixture(t)
+	defer f.db.Close()
 
 	f.createUserCollectionIndexOnName()
 
@@ -1091,6 +1136,7 @@ func TestDropIndex_IfSystemStoreFails_ReturnError(t *testing.T) {
 
 func TestDropAllIndexes_ShouldDeleteAllIndexes(t *testing.T) {
 	f := newIndexTestFixture(t)
+	defer f.db.Close()
 	_, err := f.createCollectionIndexFor(usersColName, client.IndexDescription{
 		Fields: []client.IndexedFieldDescription{
 			{Name: usersNameFieldName, Direction: client.Ascending},
@@ -1115,6 +1161,7 @@ func TestDropAllIndexes_ShouldDeleteAllIndexes(t *testing.T) {
 
 func TestDropAllIndexes_IfStorageFails_ReturnError(t *testing.T) {
 	f := newIndexTestFixture(t)
+	defer f.db.Close()
 	f.createUserCollectionIndexOnName()
 	f.db.Close()
 
@@ -1165,6 +1212,7 @@ func TestDropAllIndexes_IfSystemStorageFails_ReturnError(t *testing.T) {
 
 	for _, testCase := range testCases {
 		f := newIndexTestFixture(t)
+		defer f.db.Close()
 		f.createUserCollectionIndexOnName()
 
 		mockedTxn := f.mockTxn()
@@ -1180,6 +1228,7 @@ func TestDropAllIndexes_IfSystemStorageFails_ReturnError(t *testing.T) {
 
 func TestDropAllIndexes_ShouldCloseQueryIterator(t *testing.T) {
 	f := newIndexTestFixture(t)
+	defer f.db.Close()
 	f.createUserCollectionIndexOnName()
 
 	mockedTxn := f.mockTxn()
@@ -1198,6 +1247,7 @@ func TestDropAllIndexes_ShouldCloseQueryIterator(t *testing.T) {
 
 func TestNewCollectionIndex_IfDescriptionHasNoFields_ReturnError(t *testing.T) {
 	f := newIndexTestFixture(t)
+	defer f.db.Close()
 	desc := getUsersIndexDescOnName()
 	desc.Fields = nil
 	_, err := NewCollectionIndex(f.users, desc)
@@ -1206,6 +1256,7 @@ func TestNewCollectionIndex_IfDescriptionHasNoFields_ReturnError(t *testing.T) {
 
 func TestNewCollectionIndex_IfDescriptionHasNonExistingField_ReturnError(t *testing.T) {
 	f := newIndexTestFixture(t)
+	defer f.db.Close()
 	desc := getUsersIndexDescOnName()
 	desc.Fields[0].Name = "non_existing_field"
 	_, err := NewCollectionIndex(f.users, desc)

--- a/db/indexed_docs_test.go
+++ b/db/indexed_docs_test.go
@@ -249,6 +249,7 @@ func (f *indexTestFixture) stubSystemStore(systemStoreOn *mocks.DSReaderWriter_E
 
 func TestNonUnique_IfDocIsAdded_ShouldBeIndexed(t *testing.T) {
 	f := newIndexTestFixture(t)
+	defer f.db.Close()
 	f.createUserCollectionIndexOnName()
 
 	doc := f.newUserDoc("John", 21)
@@ -263,6 +264,7 @@ func TestNonUnique_IfDocIsAdded_ShouldBeIndexed(t *testing.T) {
 
 func TestNonUnique_IfFailsToStoredIndexedDoc_Error(t *testing.T) {
 	f := newIndexTestFixture(t)
+	defer f.db.Close()
 	f.createUserCollectionIndexOnName()
 
 	doc := f.newUserDoc("John", 21)
@@ -281,6 +283,7 @@ func TestNonUnique_IfFailsToStoredIndexedDoc_Error(t *testing.T) {
 
 func TestNonUnique_IfDocDoesNotHaveIndexedField_SkipIndex(t *testing.T) {
 	f := newIndexTestFixture(t)
+	defer f.db.Close()
 	f.createUserCollectionIndexOnName()
 
 	data, err := json.Marshal(struct {
@@ -302,6 +305,7 @@ func TestNonUnique_IfDocDoesNotHaveIndexedField_SkipIndex(t *testing.T) {
 
 func TestNonUnique_IfSystemStorageHasInvalidIndexDescription_Error(t *testing.T) {
 	f := newIndexTestFixture(t)
+	defer f.db.Close()
 	f.createUserCollectionIndexOnName()
 
 	doc := f.newUserDoc("John", 21)
@@ -317,6 +321,7 @@ func TestNonUnique_IfSystemStorageHasInvalidIndexDescription_Error(t *testing.T)
 
 func TestNonUnique_IfSystemStorageFailsToReadIndexDesc_Error(t *testing.T) {
 	f := newIndexTestFixture(t)
+	defer f.db.Close()
 	f.createUserCollectionIndexOnName()
 
 	doc := f.newUserDoc("John", 21)
@@ -334,6 +339,7 @@ func TestNonUnique_IfSystemStorageFailsToReadIndexDesc_Error(t *testing.T) {
 
 func TestNonUnique_IfIndexIntField_StoreIt(t *testing.T) {
 	f := newIndexTestFixture(t)
+	defer f.db.Close()
 	f.createUserCollectionIndexOnAge()
 
 	doc := f.newUserDoc("John", 21)
@@ -379,6 +385,7 @@ func TestNonUnique_IfMultipleCollectionsWithIndexes_StoreIndexWithCollectionID(t
 
 func TestNonUnique_IfMultipleIndexes_StoreIndexWithIndexID(t *testing.T) {
 	f := newIndexTestFixture(t)
+	defer f.db.Close()
 	f.createUserCollectionIndexOnName()
 	f.createUserCollectionIndexOnAge()
 
@@ -482,6 +489,7 @@ func TestNonUnique_StoringIndexedFieldValueOfDifferentTypes(t *testing.T) {
 
 func TestNonUnique_IfIndexedFieldIsNil_StoreItAsNil(t *testing.T) {
 	f := newIndexTestFixture(t)
+	defer f.db.Close()
 	f.createUserCollectionIndexOnName()
 
 	docJSON, err := json.Marshal(struct {
@@ -504,6 +512,7 @@ func TestNonUnique_IfIndexedFieldIsNil_StoreItAsNil(t *testing.T) {
 
 func TestNonUniqueCreate_ShouldIndexExistingDocs(t *testing.T) {
 	f := newIndexTestFixture(t)
+	defer f.db.Close()
 
 	doc1 := f.newUserDoc("John", 21)
 	f.saveDocToCollection(doc1, f.users)
@@ -578,6 +587,7 @@ func TestNonUniqueCreate_IfUponIndexingExistingDocsFetcherFails_ReturnError(t *t
 
 	for _, tc := range cases {
 		f := newIndexTestFixture(t)
+		defer f.db.Close()
 
 		doc := f.newUserDoc("John", 21)
 		f.saveDocToCollection(doc, f.users)
@@ -595,6 +605,7 @@ func TestNonUniqueCreate_IfUponIndexingExistingDocsFetcherFails_ReturnError(t *t
 
 func TestNonUniqueCreate_IfDatastoreFailsToStoreIndex_ReturnError(t *testing.T) {
 	f := newIndexTestFixture(t)
+	defer f.db.Close()
 
 	doc := f.newUserDoc("John", 21)
 	f.saveDocToCollection(doc, f.users)
@@ -652,6 +663,7 @@ func TestNonUniqueDrop_ShouldDeleteStoredIndexedFields(t *testing.T) {
 
 func TestNonUniqueUpdate_ShouldDeleteOldValueAndStoreNewOne(t *testing.T) {
 	f := newIndexTestFixture(t)
+	defer f.db.Close()
 	f.createUserCollectionIndexOnName()
 
 	cases := []struct {
@@ -698,6 +710,7 @@ func TestNonUniqueUpdate_ShouldDeleteOldValueAndStoreNewOne(t *testing.T) {
 
 func TestNonUniqueUpdate_IfFailsToReadIndexDescription_ReturnError(t *testing.T) {
 	f := newIndexTestFixture(t)
+	defer f.db.Close()
 	f.createUserCollectionIndexOnName()
 
 	doc := f.newUserDoc("John", 21)
@@ -786,6 +799,7 @@ func TestNonUniqueUpdate_IfFetcherFails_ReturnError(t *testing.T) {
 		t.Log(tc.Name)
 
 		f := newIndexTestFixture(t)
+		defer f.db.Close()
 		f.createUserCollectionIndexOnName()
 
 		doc := f.newUserDoc("John", 21)
@@ -810,6 +824,7 @@ func TestNonUniqueUpdate_IfFetcherFails_ReturnError(t *testing.T) {
 
 func TestNonUniqueUpdate_IfFailsToUpdateIndex_ReturnError(t *testing.T) {
 	f := newIndexTestFixture(t)
+	defer f.db.Close()
 	f.createUserCollectionIndexOnAge()
 
 	doc := f.newUserDoc("John", 21)
@@ -829,6 +844,7 @@ func TestNonUniqueUpdate_IfFailsToUpdateIndex_ReturnError(t *testing.T) {
 
 func TestNonUniqueUpdate_ShouldPassToFetcherOnlyRelevantFields(t *testing.T) {
 	f := newIndexTestFixture(t)
+	defer f.db.Close()
 	f.createUserCollectionIndexOnName()
 	f.createUserCollectionIndexOnAge()
 
@@ -891,6 +907,7 @@ func TestNonUniqueUpdate_IfDatastoreFails_ReturnError(t *testing.T) {
 		t.Log(tc.Name)
 
 		f := newIndexTestFixture(t)
+		defer f.db.Close()
 		f.createUserCollectionIndexOnName()
 
 		doc := f.newUserDoc("John", 21)
@@ -922,6 +939,7 @@ func TestNonUniqueUpdate_IfDatastoreFails_ReturnError(t *testing.T) {
 
 func TestNonUpdate_IfIndexedFieldWasNil_ShouldDeleteIt(t *testing.T) {
 	f := newIndexTestFixture(t)
+	defer f.db.Close()
 	f.createUserCollectionIndexOnName()
 
 	docJSON, err := json.Marshal(struct {

--- a/http/errors.go
+++ b/http/errors.go
@@ -12,7 +12,8 @@ package http
 
 import (
 	"encoding/json"
-	"errors"
+
+	"github.com/sourcenetwork/defradb/errors"
 )
 
 // Errors returnable from this package.

--- a/http/errors.go
+++ b/http/errors.go
@@ -16,6 +16,10 @@ import (
 	"github.com/sourcenetwork/defradb/errors"
 )
 
+const (
+	errFailedToLoadKeys string = "failed to load given keys"
+)
+
 // Errors returnable from this package.
 //
 // This list is incomplete. Undefined errors may also be returned.
@@ -56,4 +60,13 @@ func (e *errorResponse) UnmarshalJSON(data []byte) error {
 	}
 	e.Error = parseError(out["error"])
 	return nil
+}
+
+func NewErrFailedToLoadKeys(inner error, publicKeyPath, privateKeyPath string) error {
+	return errors.Wrap(
+		errFailedToLoadKeys,
+		inner,
+		errors.NewKV("PublicKeyPath", publicKeyPath),
+		errors.NewKV("PrivateKeyPath", privateKeyPath),
+	)
 }

--- a/http/server.go
+++ b/http/server.go
@@ -272,7 +272,7 @@ func (s *Server) listenWithTLS(ctx context.Context) error {
 			s.options.TLS.Value().PublicKey,
 		)
 		if err != nil {
-			return errors.WithStack(err)
+			return NewErrFailedToLoadKeys(err, s.options.TLS.Value().PublicKey, s.options.TLS.Value().PrivateKey)
 		}
 
 		cfg.Certificates = []tls.Certificate{cert}

--- a/http/server_test.go
+++ b/http/server_test.go
@@ -105,7 +105,7 @@ func TestNewServerAndRunWithSelfSignedCertAndNoKeyFiles(t *testing.T) {
 	go func() {
 		close(serverRunning)
 		err := s.Listen(ctx)
-		assert.Contains(t, err.Error(), "no such file or directory")
+		assert.Contains(t, err.Error(), "failed to load given keys")
 		defer close(serverDone)
 	}()
 

--- a/logging/logging_test.go
+++ b/logging/logging_test.go
@@ -8,6 +8,12 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+// todo: The logger(s) appear to leak resources and do not close down promptly on windows,
+// the log files have open readers when the Golang test runner attempts to delete them.
+// See https://github.com/sourcenetwork/defradb/issues/2057 for more info.
+
+//go:build !windows
+
 package logging
 
 import (

--- a/net/client_test.go
+++ b/net/client_test.go
@@ -25,6 +25,7 @@ import (
 func TestPushlogWithDialFailure(t *testing.T) {
 	ctx := context.Background()
 	_, n := newTestNode(ctx, t)
+	defer n.Close()
 
 	doc, err := client.NewDocFromJSON([]byte(`{"test": "test"}`))
 	require.NoError(t, err)
@@ -51,6 +52,7 @@ func TestPushlogWithDialFailure(t *testing.T) {
 func TestPushlogWithInvalidPeerID(t *testing.T) {
 	ctx := context.Background()
 	_, n := newTestNode(ctx, t)
+	defer n.Close()
 
 	doc, err := client.NewDocFromJSON([]byte(`{"test": "test"}`))
 	require.NoError(t, err)
@@ -71,8 +73,10 @@ func TestPushlogWithInvalidPeerID(t *testing.T) {
 func TestPushlogW_WithValidPeerID_NoError(t *testing.T) {
 	ctx := context.Background()
 	_, n1 := newTestNode(ctx, t)
+	defer n1.Close()
 	n1.Start()
 	_, n2 := newTestNode(ctx, t)
+	defer n2.Close()
 	n2.Start()
 
 	err := n1.host.Connect(ctx, n2.PeerInfo())

--- a/net/dialer_test.go
+++ b/net/dialer_test.go
@@ -21,20 +21,23 @@ import (
 )
 
 func TestDial_WithConnectedPeer_NoError(t *testing.T) {
-	db := FixtureNewMemoryDBWithBroadcaster(t)
+	db1 := FixtureNewMemoryDBWithBroadcaster(t)
+	db2 := FixtureNewMemoryDBWithBroadcaster(t)
 	ctx := context.Background()
 	n1, err := NewNode(
 		ctx,
-		db,
+		db1,
 		WithListenP2PAddrStrings("/ip4/0.0.0.0/tcp/0"),
 	)
 	assert.NoError(t, err)
+	defer n1.Close()
 	n2, err := NewNode(
 		ctx,
-		db,
+		db2,
 		WithListenP2PAddrStrings("/ip4/0.0.0.0/tcp/0"),
 	)
 	assert.NoError(t, err)
+	defer n2.Close()
 	addrs, err := netutils.ParsePeers([]string{n1.host.Addrs()[0].String() + "/p2p/" + n1.PeerID().String()})
 	if err != nil {
 		t.Fatal(err)
@@ -45,20 +48,23 @@ func TestDial_WithConnectedPeer_NoError(t *testing.T) {
 }
 
 func TestDial_WithConnectedPeerAndSecondConnection_NoError(t *testing.T) {
-	db := FixtureNewMemoryDBWithBroadcaster(t)
+	db1 := FixtureNewMemoryDBWithBroadcaster(t)
+	db2 := FixtureNewMemoryDBWithBroadcaster(t)
 	ctx := context.Background()
 	n1, err := NewNode(
 		ctx,
-		db,
+		db1,
 		WithListenP2PAddrStrings("/ip4/0.0.0.0/tcp/0"),
 	)
 	assert.NoError(t, err)
+	defer n1.Close()
 	n2, err := NewNode(
 		ctx,
-		db,
+		db2,
 		WithListenP2PAddrStrings("/ip4/0.0.0.0/tcp/0"),
 	)
 	assert.NoError(t, err)
+	defer n2.Close()
 	addrs, err := netutils.ParsePeers([]string{n1.host.Addrs()[0].String() + "/p2p/" + n1.PeerID().String()})
 	if err != nil {
 		t.Fatal(err)
@@ -72,20 +78,23 @@ func TestDial_WithConnectedPeerAndSecondConnection_NoError(t *testing.T) {
 }
 
 func TestDial_WithConnectedPeerAndSecondConnectionWithConnectionShutdown_ClosingConnectionError(t *testing.T) {
-	db := FixtureNewMemoryDBWithBroadcaster(t)
+	db1 := FixtureNewMemoryDBWithBroadcaster(t)
+	db2 := FixtureNewMemoryDBWithBroadcaster(t)
 	ctx := context.Background()
 	n1, err := NewNode(
 		ctx,
-		db,
+		db1,
 		WithListenP2PAddrStrings("/ip4/0.0.0.0/tcp/0"),
 	)
 	assert.NoError(t, err)
+	defer n1.Close()
 	n2, err := NewNode(
 		ctx,
-		db,
+		db2,
 		WithListenP2PAddrStrings("/ip4/0.0.0.0/tcp/0"),
 	)
 	assert.NoError(t, err)
+	defer n2.Close()
 	addrs, err := netutils.ParsePeers([]string{n1.host.Addrs()[0].String() + "/p2p/" + n1.PeerID().String()})
 	if err != nil {
 		t.Fatal(err)

--- a/net/peer_test.go
+++ b/net/peer_test.go
@@ -197,6 +197,7 @@ func TestNewPeer_WithExistingTopic_TopicAlreadyExistsError(t *testing.T) {
 func TestStartAndClose_NoError(t *testing.T) {
 	ctx := context.Background()
 	db, n := newTestNode(ctx, t)
+	defer n.Close()
 
 	err := n.Start()
 	require.NoError(t, err)
@@ -323,6 +324,7 @@ func TestStart_WitClosedUpdateChannel_ClosedChannelError(t *testing.T) {
 func TestRegisterNewDocument_NoError(t *testing.T) {
 	ctx := context.Background()
 	db, n := newTestNode(ctx, t)
+	defer n.Close()
 
 	_, err := db.AddSchema(ctx, `type User {
 		name: String
@@ -346,6 +348,7 @@ func TestRegisterNewDocument_NoError(t *testing.T) {
 func TestRegisterNewDocument_RPCTopicAlreadyRegisteredError(t *testing.T) {
 	ctx := context.Background()
 	db, n := newTestNode(ctx, t)
+	defer n.Close()
 
 	_, err := db.AddSchema(ctx, `type User {
 		name: String
@@ -372,6 +375,7 @@ func TestRegisterNewDocument_RPCTopicAlreadyRegisteredError(t *testing.T) {
 func TestSetReplicator_NoError(t *testing.T) {
 	ctx := context.Background()
 	db, n := newTestNode(ctx, t)
+	defer n.Close()
 
 	_, err := db.AddSchema(ctx, `type User {
 		name: String
@@ -392,6 +396,7 @@ func TestSetReplicator_NoError(t *testing.T) {
 func TestSetReplicator_WithInvalidAddress_EmptyPeerIDError(t *testing.T) {
 	ctx := context.Background()
 	db, n := newTestNode(ctx, t)
+	defer n.Close()
 
 	_, err := db.AddSchema(ctx, `type User {
 		name: String
@@ -409,6 +414,7 @@ func TestSetReplicator_WithInvalidAddress_EmptyPeerIDError(t *testing.T) {
 func TestSetReplicator_WithDBClosed_DatastoreClosedError(t *testing.T) {
 	ctx := context.Background()
 	db, n := newTestNode(ctx, t)
+	defer n.Close()
 
 	db.Close()
 
@@ -425,6 +431,7 @@ func TestSetReplicator_WithDBClosed_DatastoreClosedError(t *testing.T) {
 func TestSetReplicator_WithUndefinedCollection_KeyNotFoundError(t *testing.T) {
 	ctx := context.Background()
 	_, n := newTestNode(ctx, t)
+	defer n.Close()
 
 	info, err := peer.AddrInfoFromString("/ip4/0.0.0.0/tcp/0/p2p/QmYyQSo1c1Ym7orWxLYvCrM2EmxFTANf8wXmmE7DWjhx5N")
 	require.NoError(t, err)
@@ -439,6 +446,7 @@ func TestSetReplicator_WithUndefinedCollection_KeyNotFoundError(t *testing.T) {
 func TestSetReplicator_ForAllCollections_NoError(t *testing.T) {
 	ctx := context.Background()
 	db, n := newTestNode(ctx, t)
+	defer n.Close()
 
 	_, err := db.AddSchema(ctx, `type User {
 		name: String
@@ -458,6 +466,7 @@ func TestSetReplicator_ForAllCollections_NoError(t *testing.T) {
 func TestPushToReplicator_SingleDocumentNoPeer_FailedToReplicateLogError(t *testing.T) {
 	ctx := context.Background()
 	db, n := newTestNode(ctx, t)
+	defer n.Close()
 	_, err := db.AddSchema(ctx, `type User {
 		name: String
 		age: Int
@@ -485,6 +494,7 @@ func TestPushToReplicator_SingleDocumentNoPeer_FailedToReplicateLogError(t *test
 func TestDeleteReplicator_WithDBClosed_DataStoreClosedError(t *testing.T) {
 	ctx := context.Background()
 	db, n := newTestNode(ctx, t)
+	defer n.Close()
 
 	info := peer.AddrInfo{
 		ID:    n.PeerID(),
@@ -503,6 +513,7 @@ func TestDeleteReplicator_WithDBClosed_DataStoreClosedError(t *testing.T) {
 func TestDeleteReplicator_WithTargetSelf_SelfTargetForReplicatorError(t *testing.T) {
 	ctx := context.Background()
 	_, n := newTestNode(ctx, t)
+	defer n.Close()
 
 	err := n.Peer.DeleteReplicator(ctx, client.Replicator{
 		Info:    n.PeerInfo(),
@@ -514,8 +525,10 @@ func TestDeleteReplicator_WithTargetSelf_SelfTargetForReplicatorError(t *testing
 func TestDeleteReplicator_WithInvalidCollection_KeyNotFoundError(t *testing.T) {
 	ctx := context.Background()
 	_, n := newTestNode(ctx, t)
+	defer n.Close()
 
 	_, n2 := newTestNode(ctx, t)
+	defer n2.Close()
 
 	err := n.Peer.DeleteReplicator(ctx, client.Replicator{
 		Info:    n2.PeerInfo(),
@@ -527,6 +540,7 @@ func TestDeleteReplicator_WithInvalidCollection_KeyNotFoundError(t *testing.T) {
 func TestDeleteReplicator_WithCollectionAndPreviouslySetReplicator_NoError(t *testing.T) {
 	ctx := context.Background()
 	db, n := newTestNode(ctx, t)
+	defer n.Close()
 
 	_, err := db.AddSchema(ctx, `type User {
 		name: String
@@ -535,6 +549,7 @@ func TestDeleteReplicator_WithCollectionAndPreviouslySetReplicator_NoError(t *te
 	require.NoError(t, err)
 
 	_, n2 := newTestNode(ctx, t)
+	defer n2.Close()
 
 	err = n.Peer.SetReplicator(ctx, client.Replicator{
 		Info: n2.PeerInfo(),
@@ -550,8 +565,10 @@ func TestDeleteReplicator_WithCollectionAndPreviouslySetReplicator_NoError(t *te
 func TestDeleteReplicator_WithNoCollection_NoError(t *testing.T) {
 	ctx := context.Background()
 	_, n := newTestNode(ctx, t)
+	defer n.Close()
 
 	_, n2 := newTestNode(ctx, t)
+	defer n2.Close()
 
 	err := n.Peer.DeleteReplicator(ctx, client.Replicator{
 		Info: n2.PeerInfo(),
@@ -562,6 +579,7 @@ func TestDeleteReplicator_WithNoCollection_NoError(t *testing.T) {
 func TestDeleteReplicator_WithNotSetReplicator_KeyNotFoundError(t *testing.T) {
 	ctx := context.Background()
 	db, n := newTestNode(ctx, t)
+	defer n.Close()
 
 	_, err := db.AddSchema(ctx, `type User {
 		name: String
@@ -570,6 +588,7 @@ func TestDeleteReplicator_WithNotSetReplicator_KeyNotFoundError(t *testing.T) {
 	require.NoError(t, err)
 
 	_, n2 := newTestNode(ctx, t)
+	defer n2.Close()
 
 	err = n.Peer.DeleteReplicator(ctx, client.Replicator{
 		Info:    n2.PeerInfo(),
@@ -581,6 +600,7 @@ func TestDeleteReplicator_WithNotSetReplicator_KeyNotFoundError(t *testing.T) {
 func TestGetAllReplicator_WithReplicator_NoError(t *testing.T) {
 	ctx := context.Background()
 	db, n := newTestNode(ctx, t)
+	defer n.Close()
 
 	_, err := db.AddSchema(ctx, `type User {
 		name: String
@@ -589,6 +609,7 @@ func TestGetAllReplicator_WithReplicator_NoError(t *testing.T) {
 	require.NoError(t, err)
 
 	_, n2 := newTestNode(ctx, t)
+	defer n2.Close()
 
 	err = n.Peer.SetReplicator(ctx, client.Replicator{
 		Info: n2.PeerInfo(),
@@ -605,6 +626,7 @@ func TestGetAllReplicator_WithReplicator_NoError(t *testing.T) {
 func TestGetAllReplicator_WithDBClosed_DatastoreClosedError(t *testing.T) {
 	ctx := context.Background()
 	db, n := newTestNode(ctx, t)
+	defer n.Close()
 
 	db.Close()
 
@@ -615,6 +637,7 @@ func TestGetAllReplicator_WithDBClosed_DatastoreClosedError(t *testing.T) {
 func TestLoadReplicators_WithDBClosed_DatastoreClosedError(t *testing.T) {
 	ctx := context.Background()
 	db, n := newTestNode(ctx, t)
+	defer n.Close()
 
 	db.Close()
 
@@ -625,6 +648,7 @@ func TestLoadReplicators_WithDBClosed_DatastoreClosedError(t *testing.T) {
 func TestLoadReplicator_WithReplicator_NoError(t *testing.T) {
 	ctx := context.Background()
 	db, n := newTestNode(ctx, t)
+	defer n.Close()
 
 	_, err := db.AddSchema(ctx, `type User {
 		name: String
@@ -633,6 +657,7 @@ func TestLoadReplicator_WithReplicator_NoError(t *testing.T) {
 	require.NoError(t, err)
 
 	_, n2 := newTestNode(ctx, t)
+	defer n2.Close()
 
 	err = n.Peer.SetReplicator(ctx, client.Replicator{
 		Info: n2.PeerInfo(),
@@ -646,6 +671,7 @@ func TestLoadReplicator_WithReplicator_NoError(t *testing.T) {
 func TestLoadReplicator_WithReplicatorAndEmptyReplicatorMap_NoError(t *testing.T) {
 	ctx := context.Background()
 	db, n := newTestNode(ctx, t)
+	defer n.Close()
 
 	_, err := db.AddSchema(ctx, `type User {
 		name: String
@@ -654,6 +680,7 @@ func TestLoadReplicator_WithReplicatorAndEmptyReplicatorMap_NoError(t *testing.T
 	require.NoError(t, err)
 
 	_, n2 := newTestNode(ctx, t)
+	defer n2.Close()
 
 	err = n.Peer.SetReplicator(ctx, client.Replicator{
 		Info: n2.PeerInfo(),
@@ -669,6 +696,7 @@ func TestLoadReplicator_WithReplicatorAndEmptyReplicatorMap_NoError(t *testing.T
 func TestAddP2PCollections_WithInvalidCollectionID_NotFoundError(t *testing.T) {
 	ctx := context.Background()
 	_, n := newTestNode(ctx, t)
+	defer n.Close()
 
 	err := n.Peer.AddP2PCollections(ctx, []string{"invalid_collection"})
 	require.Error(t, err, ds.ErrNotFound)
@@ -677,6 +705,7 @@ func TestAddP2PCollections_WithInvalidCollectionID_NotFoundError(t *testing.T) {
 func TestAddP2PCollections_NoError(t *testing.T) {
 	ctx := context.Background()
 	db, n := newTestNode(ctx, t)
+	defer n.Close()
 
 	_, err := db.AddSchema(ctx, `type User {
 		name: String
@@ -694,6 +723,7 @@ func TestAddP2PCollections_NoError(t *testing.T) {
 func TestRemoveP2PCollectionsWithInvalidCollectionID(t *testing.T) {
 	ctx := context.Background()
 	_, n := newTestNode(ctx, t)
+	defer n.Close()
 
 	err := n.Peer.RemoveP2PCollections(ctx, []string{"invalid_collection"})
 	require.Error(t, err, ds.ErrNotFound)
@@ -702,6 +732,7 @@ func TestRemoveP2PCollectionsWithInvalidCollectionID(t *testing.T) {
 func TestRemoveP2PCollections(t *testing.T) {
 	ctx := context.Background()
 	db, n := newTestNode(ctx, t)
+	defer n.Close()
 
 	_, err := db.AddSchema(ctx, `type User {
 		name: String
@@ -719,6 +750,7 @@ func TestRemoveP2PCollections(t *testing.T) {
 func TestGetAllP2PCollectionsWithNoCollections(t *testing.T) {
 	ctx := context.Background()
 	_, n := newTestNode(ctx, t)
+	defer n.Close()
 
 	cols, err := n.Peer.GetAllP2PCollections(ctx)
 	require.NoError(t, err)
@@ -728,6 +760,7 @@ func TestGetAllP2PCollectionsWithNoCollections(t *testing.T) {
 func TestGetAllP2PCollections(t *testing.T) {
 	ctx := context.Background()
 	db, n := newTestNode(ctx, t)
+	defer n.Close()
 
 	_, err := db.AddSchema(ctx, `type User {
 		name: String
@@ -749,6 +782,7 @@ func TestGetAllP2PCollections(t *testing.T) {
 func TestHandleDocCreateLog_NoError(t *testing.T) {
 	ctx := context.Background()
 	db, n := newTestNode(ctx, t)
+	defer n.Close()
 
 	_, err := db.AddSchema(ctx, `type User {
 		name: String
@@ -790,6 +824,7 @@ func TestHandleDocCreateLog_NoError(t *testing.T) {
 func TestHandleDocCreateLog_WithInvalidDockey_NoError(t *testing.T) {
 	ctx := context.Background()
 	_, n := newTestNode(ctx, t)
+	defer n.Close()
 
 	err := n.handleDocCreateLog(events.Update{
 		DocKey: "some-invalid-key",
@@ -800,6 +835,7 @@ func TestHandleDocCreateLog_WithInvalidDockey_NoError(t *testing.T) {
 func TestHandleDocCreateLog_WithExistingTopic_TopicExistsError(t *testing.T) {
 	ctx := context.Background()
 	db, n := newTestNode(ctx, t)
+	defer n.Close()
 
 	_, err := db.AddSchema(ctx, `type User {
 		name: String
@@ -829,6 +865,7 @@ func TestHandleDocCreateLog_WithExistingTopic_TopicExistsError(t *testing.T) {
 func TestHandleDocUpdateLog_NoError(t *testing.T) {
 	ctx := context.Background()
 	db, n := newTestNode(ctx, t)
+	defer n.Close()
 
 	_, err := db.AddSchema(ctx, `type User {
 		name: String
@@ -870,6 +907,7 @@ func TestHandleDocUpdateLog_NoError(t *testing.T) {
 func TestHandleDoUpdateLog_WithInvalidDockey_NoError(t *testing.T) {
 	ctx := context.Background()
 	_, n := newTestNode(ctx, t)
+	defer n.Close()
 
 	err := n.handleDocUpdateLog(events.Update{
 		DocKey: "some-invalid-key",
@@ -880,6 +918,7 @@ func TestHandleDoUpdateLog_WithInvalidDockey_NoError(t *testing.T) {
 func TestHandleDocUpdateLog_WithExistingDockeyTopic_TopicExistsError(t *testing.T) {
 	ctx := context.Background()
 	db, n := newTestNode(ctx, t)
+	defer n.Close()
 
 	_, err := db.AddSchema(ctx, `type User {
 		name: String
@@ -923,6 +962,7 @@ func TestHandleDocUpdateLog_WithExistingDockeyTopic_TopicExistsError(t *testing.
 func TestHandleDocUpdateLog_WithExistingSchemaTopic_TopicExistsError(t *testing.T) {
 	ctx := context.Background()
 	db, n := newTestNode(ctx, t)
+	defer n.Close()
 
 	_, err := db.AddSchema(ctx, `type User {
 		name: String
@@ -966,6 +1006,7 @@ func TestHandleDocUpdateLog_WithExistingSchemaTopic_TopicExistsError(t *testing.
 func TestPushLogToReplicator_WithReplicator_FailedPushingLogError(t *testing.T) {
 	ctx := context.Background()
 	db, n := newTestNode(ctx, t)
+	defer n.Close()
 
 	_, err := db.AddSchema(ctx, `type User {
 		name: String
@@ -1012,6 +1053,7 @@ func TestPushLogToReplicator_WithReplicator_FailedPushingLogError(t *testing.T) 
 func TestSession_NoError(t *testing.T) {
 	ctx := context.Background()
 	_, n := newTestNode(ctx, t)
+	defer n.Close()
 	ng := n.Session(ctx)
 	require.Implements(t, (*ipld.NodeGetter)(nil), ng)
 }

--- a/tests/integration/backup/simple/export_test.go
+++ b/tests/integration/backup/simple/export_test.go
@@ -60,7 +60,7 @@ func TestBackupExport_WithInvalidFilePath_ReturnError(t *testing.T) {
 				Config: client.BackupConfig{
 					Filepath: t.TempDir() + "/some/test.json",
 				},
-				ExpectedError: "no such file or directory",
+				ExpectedError: "failed to create file",
 			},
 		},
 	}

--- a/tests/integration/backup/simple/import_test.go
+++ b/tests/integration/backup/simple/import_test.go
@@ -48,7 +48,7 @@ func TestBackupImport_WithInvalidFilePath_ReturnError(t *testing.T) {
 		Actions: []any{
 			testUtils.BackupImport{
 				Filepath:      t.TempDir() + "/some/test.json",
-				ExpectedError: "no such file or directory",
+				ExpectedError: "failed to open file",
 			},
 		},
 	}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #2032 

## Description

Adds a windows test run to our test matrix.

Strongly suggest reviewing commit by commit - I've tried to explain why a bunch of stuff I had to change has been changed in the commit bodies.

## Notes

- The windows run is consistently slower than the mac/ubuntu ones, worsening our ci wait times
- The below failure appears to happen occasionally:
> error generating coverage report: writing D:\a\defradb\defradb\coverage\covmeta.776b203c66aeebb53e5712fcea6cd9a0: rename from D:\a\defradb\defradb\coverage\tmp.covmeta.776b203c66aeebb53e5712fcea6cd9a01700087389181284400 failed: rename D:\a\defradb\defradb\coverage\tmp.covmeta.776b203c66aeebb53e5712fcea6cd9a01700087389181284400 D:\a\defradb\defradb\coverage\covmeta.776b203c66aeebb53e5712fcea6cd9a0: Access is denied.

I can't spot anything obvious searching for this, and I've only seen it maybe twice/thrice out 30-40 runs, so at the moment I'm in favour of merging as-is, and then we can disable the cod-cov for windows runs whilst we fix/shelve it - but do let me know.