### PR TITLE
ci: Add mac test runner

### DIFF
--- a/.github/workflows/test-and-upload-coverage.yml
+++ b/.github/workflows/test-and-upload-coverage.yml
@@ -27,19 +27,26 @@ jobs:
   run-tests:
     name: Run tests matrix job
 
-    runs-on: ubuntu-latest
-
     strategy:
       matrix:
+        os: [ubuntu-latest]
         client-type: [go, http, cli]
         database-type: [badger-file, badger-memory]
         mutation-type: [gql, collection-named, collection-save]
         detect-changes: [false]
         include:
-          - client-type: go
+          - os: ubuntu-latest
+            client-type: go
             database-type: badger-memory
             mutation-type: collection-save
             detect-changes: true
+          - os: macos-latest
+            client-type: go
+            database-type: badger-memory
+            mutation-type: collection-save
+            detect-changes: false
+
+    runs-on: ${{ matrix.os }}
 
     env:
       DEFRA_CLIENT_GO: ${{ matrix.client-type == 'go' }}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #2034

## Description

Adds a mac (latest) test run to our test matrix.

This only use the lightest of configurations we have, I think this will catch any/99% issues that we would otherwise miss.

Windows has been broken out to a different ticket, as quite a lot of tests fail on windows and it will take more effort to get working: https://github.com/sourcenetwork/defradb/pull/2033