### PR TITLE
fix: Fix test module relying on closed memory leak

### DIFF
--- a/tests/lenses/rust_wasm32_copy/src/lib.rs
+++ b/tests/lenses/rust_wasm32_copy/src/lib.rs
@@ -84,8 +84,9 @@ fn try_transform(ptr: *mut u8) -> Result<Option<Vec<u8>>, Box<dyn Error>> {
         .ok_or(ModuleError::PropertyNotFoundError{requested: params.src.clone()})?
         .clone();
 
-    input.insert(params.dst, value);
+    let mut result = input.clone();
+    result.insert(params.dst, value);
 
-    let result_json = serde_json::to_vec(&input)?;
+    let result_json = serde_json::to_vec(&result)?;
     Ok(Some(result_json))
 }


### PR DESCRIPTION
## Relevant issue(s)

Resolves #2036

## Description

Fix module relying on closed memory leak.

It only half fixes this, it will be solved properly in lens-vm/lens#62
