### PR TITLE
feat: Add PN Counter CRDT type

### DIFF
--- a/cli/utils.go
+++ b/cli/utils.go
@@ -99,9 +99,6 @@ func setStoreContext(cmd *cobra.Command, cfg *config.Config) error {
 // loadConfig loads the rootDir containing the configuration file,
 // otherwise warn about it and load a default configuration.
 func loadConfig(cfg *config.Config) error {
-	if err := cfg.LoadRootDirFromFlagOrDefault(); err != nil {
-		return err
-	}
 	return cfg.LoadWithRootdir(cfg.ConfigFileExists())
 }
 

--- a/client/ctype.go
+++ b/client/ctype.go
@@ -22,4 +22,46 @@ const (
 	LWW_REGISTER
 	OBJECT
 	COMPOSITE
+	PN_COUNTER_REGISTER
 )
+
+// IsSupportedFieldCType returns true if the type is supported as a document field type.
+func (t CType) IsSupportedFieldCType() bool {
+	switch t {
+	case NONE_CRDT, LWW_REGISTER, PN_COUNTER_REGISTER:
+		return true
+	default:
+		return false
+	}
+}
+
+// IsCompatibleWith returns true if the CRDT is compatible with the field kind
+func (t CType) IsCompatibleWith(kind FieldKind) bool {
+	switch t {
+	case PN_COUNTER_REGISTER:
+		if kind == FieldKind_INT {
+			return true
+		}
+		return false
+	default:
+		return true
+	}
+}
+
+// String returns the string representation of the CRDT.
+func (t CType) String() string {
+	switch t {
+	case NONE_CRDT:
+		return "none"
+	case LWW_REGISTER:
+		return "lww"
+	case OBJECT:
+		return "object"
+	case COMPOSITE:
+		return "composite"
+	case PN_COUNTER_REGISTER:
+		return "pncounter"
+	default:
+		return "unknown"
+	}
+}

--- a/client/ctype.go
+++ b/client/ctype.go
@@ -22,13 +22,13 @@ const (
 	LWW_REGISTER
 	OBJECT
 	COMPOSITE
-	PN_COUNTER_REGISTER
+	PN_COUNTER
 )
 
 // IsSupportedFieldCType returns true if the type is supported as a document field type.
 func (t CType) IsSupportedFieldCType() bool {
 	switch t {
-	case NONE_CRDT, LWW_REGISTER, PN_COUNTER_REGISTER:
+	case NONE_CRDT, LWW_REGISTER, PN_COUNTER:
 		return true
 	default:
 		return false
@@ -38,8 +38,8 @@ func (t CType) IsSupportedFieldCType() bool {
 // IsCompatibleWith returns true if the CRDT is compatible with the field kind
 func (t CType) IsCompatibleWith(kind FieldKind) bool {
 	switch t {
-	case PN_COUNTER_REGISTER:
-		if kind == FieldKind_INT {
+	case PN_COUNTER:
+		if kind == FieldKind_INT || kind == FieldKind_FLOAT {
 			return true
 		}
 		return false
@@ -59,7 +59,7 @@ func (t CType) String() string {
 		return "object"
 	case COMPOSITE:
 		return "composite"
-	case PN_COUNTER_REGISTER:
+	case PN_COUNTER:
 		return "pncounter"
 	default:
 		return "unknown"

--- a/client/document.go
+++ b/client/document.go
@@ -151,7 +151,7 @@ func NewDocsFromJSON(obj []byte, sd SchemaDescription) ([]*Document, error) {
 	}
 
 	docs := make([]*Document, len(a))
-	for _, v := range a {
+	for i, v := range a {
 		o, err := v.Object()
 		if err != nil {
 			return nil, err
@@ -165,7 +165,7 @@ func NewDocsFromJSON(obj []byte, sd SchemaDescription) ([]*Document, error) {
 		if err != nil {
 			return nil, err
 		}
-		docs = append(docs, doc)
+		docs[i] = doc
 	}
 
 	return docs, nil

--- a/client/errors.go
+++ b/client/errors.go
@@ -24,8 +24,10 @@ const (
 	errMaxTxnRetries               string = "reached maximum transaction reties"
 	errRelationOneSided            string = "relation must be defined on both schemas"
 	errCollectionNotFound          string = "collection not found"
-	errUnknownCRDT                 string = "unknown crdt"
 	errFieldOrAliasToFieldNotExist string = "The given field or alias to field does not exist"
+	errUnknownCRDT                 string = "unknown crdt"
+	errCRDTKindMismatch            string = "CRDT type %s can't be assigned to field kind %s"
+	errInvalidCRDTType             string = "CRDT type not supported"
 )
 
 // Errors returnable from this package.
@@ -130,4 +132,16 @@ func NewErrUnknownCRDT(cType CType) error {
 // NewErrFieldOrAliasToFieldNotExist returns an error indicating that the given field or an alias field does not exist.
 func NewErrFieldOrAliasToFieldNotExist(name string) error {
 	return errors.New(errFieldOrAliasToFieldNotExist, errors.NewKV("Name", name))
+}
+
+func NewErrInvalidCRDTType(name, crdtType string) error {
+	return errors.New(
+		errInvalidCRDTType,
+		errors.NewKV("Name", name),
+		errors.NewKV("CRDTType", crdtType),
+	)
+}
+
+func NewErrCRDTKindMismatch(cType, kind string) error {
+	return errors.New(fmt.Sprintf(errCRDTKindMismatch, cType, kind))
 }

--- a/client/value.go
+++ b/client/value.go
@@ -15,119 +15,78 @@ import (
 	"github.com/sourcenetwork/immutable"
 )
 
-// Value is an interface that points to a concrete Value implementation.
-// (TODO May collapse this down without an interface)
-type Value interface {
-	Value() any
-	IsDocument() bool
-	Type() CType
-	IsDirty() bool
-	Clean()
-	IsDelete() bool //todo: Update IsDelete naming
-	Delete()
-}
-
-// WriteableValue defines a simple interface with a Bytes() method
-// which is used to indicate if a Value is writeable type versus
-// a composite type like a Sub-Document.
-// Writeable types include simple Strings/Ints/Floats/Binary
-// that can be loaded into a CRDT Register, Set, Counter, etc.
-type WriteableValue interface {
-	Value
-
-	Bytes() ([]byte, error)
-}
-
-type ReadableValue interface {
-	Value
-
-	Read() (any, error)
-}
-
-type simpleValue struct {
+type FieldValue struct {
 	t       CType
 	value   any
 	isDirty bool
 	delete  bool
 }
 
-func newValue(t CType, val any) simpleValue {
-	return simpleValue{
+func NewFieldValue(t CType, val any) *FieldValue {
+	return &FieldValue{
 		t:       t,
 		value:   val,
 		isDirty: true,
 	}
 }
 
-// func (val simpleValue) Set(val any)
-
-func (val simpleValue) Value() any {
+func (val FieldValue) Value() any {
 	return val.value
 }
 
-func (val simpleValue) Type() CType {
+func (val FieldValue) Type() CType {
 	return val.t
 }
 
-func (val simpleValue) IsDocument() bool {
+func (val FieldValue) IsDocument() bool {
 	_, ok := val.value.(*Document)
 	return ok
 }
 
 // IsDirty returns if the value is marked as dirty (unsaved/changed)
-func (val simpleValue) IsDirty() bool {
+func (val FieldValue) IsDirty() bool {
 	return val.isDirty
 }
 
-func (val *simpleValue) Clean() {
+func (val *FieldValue) Clean() {
 	val.isDirty = false
 	val.delete = false
 }
 
-func (val *simpleValue) Delete() {
+func (val *FieldValue) Delete() {
 	val.delete = true
 	val.isDirty = true
 }
 
-func (val simpleValue) IsDelete() bool {
+func (val FieldValue) IsDelete() bool {
 	return val.delete
 }
 
-type cborValue struct {
-	*simpleValue
+func (val *FieldValue) SetType(t CType) {
+	val.t = t
 }
 
-// NewCBORValue creates a new CBOR value from a CRDT type and a value.
-func NewCBORValue(t CType, val any) WriteableValue {
-	return newCBORValue(t, val)
-}
-
-func newCBORValue(t CType, val any) WriteableValue {
-	v := newValue(t, val)
-	return cborValue{&v}
-}
-
-func (v cborValue) Bytes() ([]byte, error) {
+func (val FieldValue) Bytes() ([]byte, error) {
 	em, err := cbor.EncOptions{Time: cbor.TimeRFC3339}.EncMode()
 	if err != nil {
 		return nil, err
 	}
 
-	var val any
-	switch tempVal := v.value.(type) {
+	var value any
+	switch tempVal := val.value.(type) {
 	case []immutable.Option[string]:
-		val = convertImmutable(tempVal)
+		value = convertImmutable(tempVal)
 	case []immutable.Option[int64]:
-		val = convertImmutable(tempVal)
+		value = convertImmutable(tempVal)
 	case []immutable.Option[float64]:
-		val = convertImmutable(tempVal)
+		value = convertImmutable(tempVal)
 	case []immutable.Option[bool]:
-		val = convertImmutable(tempVal)
+		value = convertImmutable(tempVal)
 	default:
-		val = v.value
+		value = val.value
 	}
 
-	return em.Marshal(val)
+	return em.Marshal(value)
 }
 
 func convertImmutable[T any](vals []immutable.Option[T]) []any {

--- a/config/config.go
+++ b/config/config.go
@@ -101,22 +101,13 @@ func DefaultConfig() *Config {
 	cfg.v.SetConfigName(DefaultConfigFileName)
 	cfg.v.SetConfigType(configType)
 
-	// Load default values in viper.
-	b, err := cfg.toBytes()
-	if err != nil {
-		panic(err)
-	}
-	if err = cfg.v.ReadConfig(bytes.NewReader(b)); err != nil {
-		panic(NewErrReadingConfigFile(err))
-	}
+	cfg.Persist()
 
 	return cfg
 }
 
-// WithCustomValues allows changing values of config and persists them in the viper config.
-func (cfg *Config) WithCustomValues(f func(cfg *Config)) {
-	f(cfg)
-
+// Persist persists manually set config parameters to the viper config.
+func (cfg *Config) Persist() {
 	// Load new values in viper.
 	b, err := cfg.toBytes()
 	if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -113,6 +113,20 @@ func DefaultConfig() *Config {
 	return cfg
 }
 
+// WithCustomValues allows changing values of config and persists them in the viper config.
+func (cfg *Config) WithCustomValues(f func(cfg *Config)) {
+	f(cfg)
+
+	// Load new values in viper.
+	b, err := cfg.toBytes()
+	if err != nil {
+		panic(err)
+	}
+	if err = cfg.v.ReadConfig(bytes.NewReader(b)); err != nil {
+		panic(NewErrReadingConfigFile(err))
+	}
+}
+
 // LoadWithRootdir loads a Config with parameters from defaults, config file, environment variables, and CLI flags.
 // It loads from config file when `fromFile` is true, otherwise it loads directly from a default configuration.
 // Use on a Config struct already loaded with default values from DefaultConfig().

--- a/core/crdt/composite.go
+++ b/core/crdt/composite.go
@@ -31,19 +31,17 @@ import (
 
 // CompositeDAGDelta represents a delta-state update made of sub-MerkleCRDTs.
 type CompositeDAGDelta struct {
+	DocID     []byte
+	FieldName string
+	Priority  uint64
 	// SchemaVersionID is the schema version datastore key at the time of commit.
 	//
-	// It can be used to identify the collection datastructure state at time of commit.
+	// It can be used to identify the collection datastructure state at the time of commit.
 	SchemaVersionID string
-	Priority        uint64
-	Data            []byte
-	DocID           []byte
-	SubDAGs         []core.DAGLink
 	// Status represents the status of the document. By default it is `Active`.
 	// Alternatively, if can be set to `Deleted`.
-	Status client.DocumentStatus
-
-	FieldName string
+	Status  client.DocumentStatus
+	SubDAGs []core.DAGLink `json:"-"` // should not be marshalled
 }
 
 var _ core.CompositeDelta = (*CompositeDAGDelta)(nil)
@@ -63,23 +61,11 @@ func (delta *CompositeDAGDelta) Marshal() ([]byte, error) {
 	h := &codec.CborHandle{}
 	buf := bytes.NewBuffer(nil)
 	enc := codec.NewEncoder(buf, h)
-	err := enc.Encode(struct {
-		SchemaVersionID string
-		Priority        uint64
-		Data            []byte
-		DocID           []byte
-		Status          uint8
-		FieldName       string
-	}{delta.SchemaVersionID, delta.Priority, delta.Data, delta.DocID, delta.Status.UInt8(), delta.FieldName})
+	err := enc.Encode(delta)
 	if err != nil {
 		return nil, err
 	}
 	return buf.Bytes(), nil
-}
-
-// Value returns the value of this delta.
-func (delta *CompositeDAGDelta) Value() any {
-	return delta.Data
 }
 
 // Links returns the links for this delta.
@@ -109,17 +95,16 @@ func (c CompositeDAG) Value(ctx context.Context) ([]byte, error) {
 }
 
 // Set applies a delta to the composite DAG CRDT. TBD
-func (c CompositeDAG) Set(patch []byte, links []core.DAGLink) *CompositeDAGDelta {
+func (c CompositeDAG) Set(links []core.DAGLink) *CompositeDAGDelta {
 	// make sure the links are sorted lexicographically by CID
 	sort.Slice(links, func(i, j int) bool {
 		return strings.Compare(links[i].Cid.String(), links[j].Cid.String()) < 0
 	})
 	return &CompositeDAGDelta{
-		Data:            patch,
 		DocID:           []byte(c.key.DocID),
-		SubDAGs:         links,
-		SchemaVersionID: c.schemaVersionKey.SchemaVersionId,
 		FieldName:       c.fieldName,
+		SchemaVersionID: c.schemaVersionKey.SchemaVersionId,
+		SubDAGs:         links,
 	}
 }
 

--- a/core/crdt/lwwreg.go
+++ b/core/crdt/lwwreg.go
@@ -29,7 +29,7 @@ import (
 // LWWRegDelta is a single delta operation for an LWWRegister
 // @todo: Expand delta metadata (investigate if needed)
 type LWWRegDelta struct {
-	DocKey    []byte
+	DocID     []byte
 	FieldName string
 	Priority  uint64
 	// SchemaVersionID is the schema version datastore key at the time of commit.
@@ -105,6 +105,7 @@ func (reg LWWRegister) Value(ctx context.Context) ([]byte, error) {
 func (reg LWWRegister) Set(value []byte) *LWWRegDelta {
 	return &LWWRegDelta{
 		Data:            value,
+		DocID:           []byte(reg.key.DocID),
 		FieldName:       reg.fieldName,
 		SchemaVersionID: reg.schemaVersionKey.SchemaVersionId,
 	}

--- a/core/crdt/pncounter.go
+++ b/core/crdt/pncounter.go
@@ -1,0 +1,213 @@
+// Copyright 2022 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package crdt
+
+import (
+	"bytes"
+	"context"
+
+	"github.com/fxamacker/cbor/v2"
+	dag "github.com/ipfs/boxo/ipld/merkledag"
+	ds "github.com/ipfs/go-datastore"
+	ipld "github.com/ipfs/go-ipld-format"
+	"github.com/ugorji/go/codec"
+
+	"github.com/sourcenetwork/defradb/client"
+	"github.com/sourcenetwork/defradb/core"
+	"github.com/sourcenetwork/defradb/datastore"
+	"github.com/sourcenetwork/defradb/db/base"
+	"github.com/sourcenetwork/defradb/errors"
+)
+
+var (
+	// ensure types implements core interfaces
+	_ core.ReplicatedData = (*PNCounterRegister)(nil)
+	_ core.Delta          = (*PNCounterDelta)(nil)
+)
+
+// PNCounterDelta is a single delta operation for an PNCounterRegister
+type PNCounterDelta struct {
+	DocKey    []byte
+	FieldName string
+	Priority  uint64
+	// SchemaVersionID is the schema version datastore key at the time of commit.
+	//
+	// It can be used to identify the collection datastructure state at the time of commit.
+	SchemaVersionID string
+	Data            []byte
+	FieldValue      client.FieldValue `json:"-"` // should not be marshalled
+}
+
+// GetPriority gets the current priority for this delta.
+func (delta *PNCounterDelta) GetPriority() uint64 {
+	return delta.Priority
+}
+
+// SetPriority will set the priority for this delta.
+func (delta *PNCounterDelta) SetPriority(prio uint64) {
+	delta.Priority = prio
+}
+
+// Marshal encodes the delta using CBOR.
+func (delta *PNCounterDelta) Marshal() ([]byte, error) {
+	b, err := delta.FieldValue.Bytes()
+	if err != nil {
+		return nil, err
+	}
+	delta.Data = b
+
+	h := &codec.CborHandle{}
+	buf := bytes.NewBuffer(nil)
+	enc := codec.NewEncoder(buf, h)
+	err = enc.Encode(delta)
+	if err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// PNCounterRegister, Last-Writer-Wins Register, is a simple CRDT type that allows set/get
+// of an arbitrary data type that ensures convergence.
+type PNCounterRegister struct {
+	baseCRDT
+}
+
+// NewPNCounterRegister returns a new instance of the PNCounter with the given ID.
+func NewPNCounterRegister(
+	store datastore.DSReaderWriter,
+	schemaVersionKey core.CollectionSchemaVersionKey,
+	key core.DataStoreKey,
+	fieldName string,
+) PNCounterRegister {
+	return PNCounterRegister{newBaseCRDT(store, key, schemaVersionKey, fieldName)}
+}
+
+// Value gets the current register value
+func (reg PNCounterRegister) Value(ctx context.Context) ([]byte, error) {
+	valueK := reg.key.WithValueFlag()
+	buf, err := reg.store.Get(ctx, valueK.ToDS())
+	if err != nil {
+		return nil, err
+	}
+	return buf, nil
+}
+
+// Set generates a new delta with the supplied value
+func (reg PNCounterRegister) Set(value client.FieldValue) *PNCounterDelta {
+	return &PNCounterDelta{
+		DocKey:          []byte(reg.key.DocKey),
+		FieldName:       reg.fieldName,
+		FieldValue:      value,
+		SchemaVersionID: reg.schemaVersionKey.SchemaVersionId,
+	}
+}
+
+// Merge implements ReplicatedData interface.
+// It merges two PNCounterRegisty by adding the values together.
+func (reg PNCounterRegister) Merge(ctx context.Context, delta core.Delta) error {
+	d, ok := delta.(*PNCounterDelta)
+	if !ok {
+		return ErrMismatchedMergeType
+	}
+
+	return reg.addValue(ctx, d.FieldValue, d.GetPriority())
+}
+
+func (reg PNCounterRegister) addValue(ctx context.Context, value client.FieldValue, priority uint64) error {
+	var number int64
+	switch v := value.Value().(type) {
+	case int64:
+		number = int64(v)
+	case uint64:
+		number = int64(v)
+	default:
+		return errors.New("invalid value type. Must be compatible with int64")
+	}
+
+	key := reg.key.WithValueFlag()
+	marker, err := reg.store.Get(ctx, reg.key.ToPrimaryDataStoreKey().ToDS())
+	if err != nil && !errors.Is(err, ds.ErrNotFound) {
+		return err
+	}
+	if bytes.Equal(marker, []byte{base.DeletedObjectMarker}) {
+		key = key.WithDeletedFlag()
+	}
+
+	curValue, err := reg.getCurrentValue(ctx, key)
+	if err != nil {
+		return err
+	}
+
+	b, err := cbor.Marshal(curValue + number)
+	if err != nil {
+		return err
+	}
+
+	err = reg.store.Put(ctx, key.ToDS(), b)
+	if err != nil {
+		return NewErrFailedToStoreValue(err)
+	}
+
+	return reg.setPriority(ctx, reg.key, priority)
+}
+
+func (reg PNCounterRegister) getCurrentValue(ctx context.Context, key core.DataStoreKey) (int64, error) {
+	curValue, err := reg.store.Get(ctx, key.ToDS())
+	if err != nil {
+		if errors.Is(err, ds.ErrNotFound) {
+			return 0, nil
+		}
+		return 0, err
+	}
+
+	return getInt64FromBytes(curValue)
+}
+
+// DeltaDecode is a typed helper to extract a PNCounterDelta from a ipld.Node
+func (reg PNCounterRegister) DeltaDecode(node ipld.Node) (core.Delta, error) {
+	delta := &PNCounterDelta{}
+	pbNode, ok := node.(*dag.ProtoNode)
+	if !ok {
+		return nil, client.NewErrUnexpectedType[*dag.ProtoNode]("ipld.Node", node)
+	}
+	data := pbNode.Data()
+	h := &codec.CborHandle{}
+	dec := codec.NewDecoderBytes(data, h)
+	err := dec.Decode(delta)
+	if err != nil {
+		return nil, err
+	}
+
+	val, err := getInt64FromBytes(delta.Data)
+	if err != nil {
+		return nil, err
+	}
+	delta.FieldValue = *(client.NewFieldValue(client.PN_COUNTER_REGISTER, val))
+
+	return delta, nil
+}
+
+func getInt64FromBytes(b []byte) (int64, error) {
+	var val any
+	err := cbor.Unmarshal(b, &val)
+	if err != nil {
+		return 0, err
+	}
+
+	switch v := val.(type) {
+	case int64:
+		return int64(v), nil
+	case uint64:
+		return int64(v), nil
+	default:
+		return 0, errors.New("invalid value type. Must be int64 or uint64")
+	}
+}

--- a/core/crdt/pncounter.go
+++ b/core/crdt/pncounter.go
@@ -42,7 +42,7 @@ type Incrementable interface {
 
 // PNCounterDelta is a single delta operation for an PNCounter
 type PNCounterDelta[T Incrementable] struct {
-	DocKey    []byte
+	DocID     []byte
 	FieldName string
 	Priority  uint64
 	// SchemaVersionID is the schema version datastore key at the time of commit.
@@ -110,7 +110,7 @@ func (reg PNCounter[T]) Value(ctx context.Context) ([]byte, error) {
 // Set generates a new delta with the supplied value
 func (reg PNCounter[T]) Increment(value T) *PNCounterDelta[T] {
 	return &PNCounterDelta[T]{
-		DocKey:          []byte(reg.key.DocKey),
+		DocID:           []byte(reg.key.DocID),
 		FieldName:       reg.fieldName,
 		Data:            value,
 		SchemaVersionID: reg.schemaVersionKey.SchemaVersionId,

--- a/core/crdt/pncounter.go
+++ b/core/crdt/pncounter.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Democratized Data Foundation
+// Copyright 2023 Democratized Data Foundation
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt.

--- a/core/delta.go
+++ b/core/delta.go
@@ -20,6 +20,7 @@ type Delta interface {
 	GetPriority() uint64
 	SetPriority(uint64)
 	Marshal() ([]byte, error)
+	Unmarshal(b []byte) error
 }
 
 // CompositeDelta represents a delta-state update to a composite CRDT.

--- a/core/delta.go
+++ b/core/delta.go
@@ -20,7 +20,6 @@ type Delta interface {
 	GetPriority() uint64
 	SetPriority(uint64)
 	Marshal() ([]byte, error)
-	Value() any
 }
 
 // CompositeDelta represents a delta-state update to a composite CRDT.

--- a/db/base/collection_keys.go
+++ b/db/base/collection_keys.go
@@ -45,7 +45,7 @@ func MakePrimaryIndexKeyForCRDT(
 	switch ctype {
 	case client.COMPOSITE:
 		return MakeDataStoreKeyWithCollectionDescription(c).WithInstanceInfo(key).WithFieldId(core.COMPOSITE_NAMESPACE), nil
-	case client.LWW_REGISTER, client.PN_COUNTER_REGISTER:
+	case client.LWW_REGISTER, client.PN_COUNTER:
 		field, ok := c.GetFieldByName(fieldName, &schema)
 		if !ok {
 			return core.DataStoreKey{}, client.NewErrFieldNotExist(fieldName)

--- a/db/base/collection_keys.go
+++ b/db/base/collection_keys.go
@@ -45,7 +45,7 @@ func MakePrimaryIndexKeyForCRDT(
 	switch ctype {
 	case client.COMPOSITE:
 		return MakeDataStoreKeyWithCollectionDescription(c).WithInstanceInfo(key).WithFieldId(core.COMPOSITE_NAMESPACE), nil
-	case client.LWW_REGISTER:
+	case client.LWW_REGISTER, client.PN_COUNTER_REGISTER:
 		field, ok := c.GetFieldByName(fieldName, &schema)
 		if !ok {
 			return core.DataStoreKey{}, client.NewErrFieldNotExist(fieldName)

--- a/db/collection_delete.go
+++ b/db/collection_delete.go
@@ -265,7 +265,6 @@ func (c *collection) applyDelete(
 		ctx,
 		txn,
 		dsKey,
-		[]byte{},
 		dagLinks,
 		client.Deleted,
 	)

--- a/db/errors.go
+++ b/db/errors.go
@@ -42,7 +42,6 @@ const (
 	errDuplicateField                     string = "duplicate field"
 	errCannotMutateField                  string = "mutating an existing field is not supported"
 	errCannotMoveField                    string = "moving fields is not currently supported"
-	errInvalidCRDTType                    string = "only default or LWW (last writer wins) CRDT types are supported"
 	errCannotDeleteField                  string = "deleting an existing field is not supported"
 	errFieldKindNotFound                  string = "no type found for given name"
 	errFieldKindDoesNotMatchFieldSchema   string = "field Kind does not match field Schema"
@@ -371,14 +370,6 @@ func NewErrCannotMoveField(name string, proposedIndex, existingIndex int) error 
 		errors.NewKV("Name", name),
 		errors.NewKV("ProposedIndex", proposedIndex),
 		errors.NewKV("ExistingIndex", existingIndex),
-	)
-}
-
-func NewErrInvalidCRDTType(name string, crdtType client.CType) error {
-	return errors.New(
-		errInvalidCRDTType,
-		errors.NewKV("Name", name),
-		errors.NewKV("CRDTType", crdtType),
 	)
 }
 

--- a/db/fetcher/indexer_iterators.go
+++ b/db/fetcher/indexer_iterators.go
@@ -412,9 +412,9 @@ func createIndexIterator(
 
 	switch op {
 	case opEq, opGt, opGe, opLt, opLe, opNe:
-		writableValue := client.NewCBORValue(client.LWW_REGISTER, filterVal)
+		fieldValue := client.NewFieldValue(client.LWW_REGISTER, filterVal)
 
-		valueBytes, err := writableValue.Bytes()
+		valueBytes, err := fieldValue.Bytes()
 		if err != nil {
 			return nil, err
 		}
@@ -490,8 +490,8 @@ func createIndexIterator(
 		}
 		valArr := make([][]byte, 0, len(inArr))
 		for _, v := range inArr {
-			writableValue := client.NewCBORValue(client.LWW_REGISTER, v)
-			valueBytes, err := writableValue.Bytes()
+			fieldValue := client.NewFieldValue(client.LWW_REGISTER, v)
+			valueBytes, err := fieldValue.Bytes()
 			if err != nil {
 				return nil, err
 			}

--- a/db/fetcher/versioned.go
+++ b/db/fetcher/versioned.go
@@ -339,7 +339,7 @@ func (vf *VersionedFetcher) merge(c cid.Cid) error {
 	}
 
 	// first arg 0 is the index for the composite DAG in the mCRDTs cache
-	if err := vf.processNode(0, nd, client.COMPOSITE, ""); err != nil {
+	if err := vf.processNode(0, nd, client.COMPOSITE, client.FieldKind_None, ""); err != nil {
 		return err
 	}
 
@@ -361,7 +361,7 @@ func (vf *VersionedFetcher) merge(c cid.Cid) error {
 		if !ok {
 			return client.NewErrFieldNotExist(l.Name)
 		}
-		if err := vf.processNode(uint32(field.ID), subNd, field.Typ, l.Name); err != nil {
+		if err := vf.processNode(uint32(field.ID), subNd, field.Typ, field.Kind, l.Name); err != nil {
 			return err
 		}
 	}
@@ -373,6 +373,7 @@ func (vf *VersionedFetcher) processNode(
 	crdtIndex uint32,
 	nd format.Node,
 	ctype client.CType,
+	kind client.FieldKind,
 	fieldName string,
 ) (err error) {
 	// handle CompositeDAG
@@ -386,6 +387,7 @@ func (vf *VersionedFetcher) processNode(
 			vf.store,
 			core.CollectionSchemaVersionKey{},
 			ctype,
+			kind,
 			dsKey,
 			fieldName,
 		)

--- a/db/fetcher/versioned.go
+++ b/db/fetcher/versioned.go
@@ -361,9 +361,7 @@ func (vf *VersionedFetcher) merge(c cid.Cid) error {
 		if !ok {
 			return client.NewErrFieldNotExist(l.Name)
 		}
-		// @todo: Right now we ONLY handle LWW_REGISTER, need to swith on this and
-		//        get CType from descriptions
-		if err := vf.processNode(uint32(field.ID), subNd, client.LWW_REGISTER, l.Name); err != nil {
+		if err := vf.processNode(uint32(field.ID), subNd, field.Typ, l.Name); err != nil {
 			return err
 		}
 	}

--- a/db/index.go
+++ b/db/index.go
@@ -122,16 +122,15 @@ func (i *collectionBaseIndex) getDocFieldValue(doc *client.Document) ([]byte, er
 	fieldVal, err := doc.GetValue(indexedFieldName)
 	if err != nil {
 		if errors.Is(err, client.ErrFieldNotExist) {
-			return client.NewCBORValue(client.LWW_REGISTER, nil).Bytes()
+			return client.NewFieldValue(client.LWW_REGISTER, nil).Bytes()
 		} else {
 			return nil, err
 		}
 	}
-	writeableVal, ok := fieldVal.(client.WriteableValue)
-	if !ok || !i.validateFieldFunc(fieldVal.Value()) {
-		return nil, NewErrInvalidFieldValue(i.fieldDesc.Kind, writeableVal)
+	if !i.validateFieldFunc(fieldVal.Value()) {
+		return nil, NewErrInvalidFieldValue(i.fieldDesc.Kind, fieldVal)
 	}
-	return writeableVal.Bytes()
+	return fieldVal.Bytes()
 }
 
 func (i *collectionBaseIndex) getDocumentsIndexKey(

--- a/db/indexed_docs_test.go
+++ b/db/indexed_docs_test.go
@@ -159,17 +159,15 @@ func (b *indexKeyBuilder) Build() core.IndexDataStoreKey {
 
 	if b.doc != nil {
 		var fieldBytesVal []byte
-		var writeableVal client.WriteableValue
+		var fieldValue *client.FieldValue
+		var err error
 		if len(b.values) == 0 {
-			fieldVal, err := b.doc.GetValue(b.fieldName)
+			fieldValue, err = b.doc.GetValue(b.fieldName)
 			require.NoError(b.f.t, err)
-			var ok bool
-			writeableVal, ok = fieldVal.(client.WriteableValue)
-			require.True(b.f.t, ok)
 		} else {
-			writeableVal = client.NewCBORValue(client.LWW_REGISTER, b.values[0])
+			fieldValue = client.NewFieldValue(client.LWW_REGISTER, b.values[0])
 		}
-		fieldBytesVal, err = writeableVal.Bytes()
+		fieldBytesVal, err = fieldValue.Bytes()
 		require.NoError(b.f.t, err)
 
 		key.FieldValues = [][]byte{fieldBytesVal}

--- a/docs/data_format_changes/i2115-add-pn-counter-crdt.md
+++ b/docs/data_format_changes/i2115-add-pn-counter-crdt.md
@@ -1,0 +1,3 @@
+# Change CRDT encoded data struct fields
+
+The composite CRDT delta struct no longer hosts the changed properties of the document. The removes the leakage of field level values for when we implement field level access control.

--- a/examples/schema/user.graphql
+++ b/examples/schema/user.graphql
@@ -2,5 +2,5 @@ type User {
     name: String
     age: Int
     verified: Boolean
-    points: Float
+    points: Int @crdt(type: "pncounter")
 }

--- a/merkle/clock/clock_test.go
+++ b/merkle/clock/clock_test.go
@@ -59,9 +59,8 @@ func TestNewMerkleClock(t *testing.T) {
 func TestMerkleClockPutBlock(t *testing.T) {
 	ctx := context.Background()
 	clk := newTestMerkleClock()
-	delta := &crdt.LWWRegDelta{
-		Data: []byte("test"),
-	}
+	reg := crdt.LWWRegister{}
+	delta := reg.Set([]byte("test"))
 	node, err := clk.putBlock(ctx, nil, delta)
 	if err != nil {
 		t.Errorf("Failed to putBlock, err: %v", err)
@@ -80,9 +79,8 @@ func TestMerkleClockPutBlock(t *testing.T) {
 func TestMerkleClockPutBlockWithHeads(t *testing.T) {
 	ctx := context.Background()
 	clk := newTestMerkleClock()
-	delta := &crdt.LWWRegDelta{
-		Data: []byte("test"),
-	}
+	reg := crdt.LWWRegister{}
+	delta := reg.Set([]byte("test"))
 	c, err := ccid.NewSHA256CidV1([]byte("Hello World!"))
 	if err != nil {
 		t.Error("Failed to create new head CID:", err)
@@ -103,9 +101,8 @@ func TestMerkleClockPutBlockWithHeads(t *testing.T) {
 func TestMerkleClockAddDAGNode(t *testing.T) {
 	ctx := context.Background()
 	clk := newTestMerkleClock()
-	delta := &crdt.LWWRegDelta{
-		Data: []byte("test"),
-	}
+	reg := crdt.LWWRegister{}
+	delta := reg.Set([]byte("test"))
 
 	_, err := clk.AddDAGNode(ctx, delta)
 	if err != nil {
@@ -117,9 +114,8 @@ func TestMerkleClockAddDAGNode(t *testing.T) {
 func TestMerkleClockAddDAGNodeWithHeads(t *testing.T) {
 	ctx := context.Background()
 	clk := newTestMerkleClock()
-	delta := &crdt.LWWRegDelta{
-		Data: []byte("test1"),
-	}
+	reg := crdt.LWWRegister{}
+	delta := reg.Set([]byte("test"))
 
 	_, err := clk.AddDAGNode(ctx, delta)
 	if err != nil {
@@ -127,9 +123,8 @@ func TestMerkleClockAddDAGNodeWithHeads(t *testing.T) {
 		return
 	}
 
-	delta2 := &crdt.LWWRegDelta{
-		Data: []byte("test2"),
-	}
+	reg2 := crdt.LWWRegister{}
+	delta2 := reg2.Set([]byte("test2"))
 
 	_, err = clk.AddDAGNode(ctx, delta2)
 	if err != nil {

--- a/merkle/crdt/composite.go
+++ b/merkle/crdt/composite.go
@@ -60,7 +60,7 @@ func (m *MerkleCompositeDAG) Delete(
 	// Set() call on underlying CompositeDAG CRDT
 	// persist/publish delta
 	log.Debug(ctx, "Applying delta-mutator 'Delete' on CompositeDAG")
-	delta := m.reg.Set([]byte{}, links)
+	delta := m.reg.Set(links)
 	delta.Status = client.Deleted
 	nd, err := m.clock.AddDAGNode(ctx, delta)
 	if err != nil {
@@ -73,13 +73,12 @@ func (m *MerkleCompositeDAG) Delete(
 // Set sets the values of CompositeDAG. The value is always the object from the mutation operations.
 func (m *MerkleCompositeDAG) Set(
 	ctx context.Context,
-	patch []byte,
 	links []core.DAGLink,
 ) (ipld.Node, uint64, error) {
 	// Set() call on underlying CompositeDAG CRDT
 	// persist/publish delta
 	log.Debug(ctx, "Applying delta-mutator 'Set' on CompositeDAG")
-	delta := m.reg.Set(patch, links)
+	delta := m.reg.Set(links)
 	nd, err := m.clock.AddDAGNode(ctx, delta)
 	if err != nil {
 		return nil, 0, err

--- a/merkle/crdt/composite.go
+++ b/merkle/crdt/composite.go
@@ -71,14 +71,11 @@ func (m *MerkleCompositeDAG) Delete(
 }
 
 // Set sets the values of CompositeDAG. The value is always the object from the mutation operations.
-func (m *MerkleCompositeDAG) Set(
-	ctx context.Context,
-	links []core.DAGLink,
-) (ipld.Node, uint64, error) {
+func (m *MerkleCompositeDAG) Save(ctx context.Context, data any) (ipld.Node, uint64, error) {
 	// Set() call on underlying CompositeDAG CRDT
 	// persist/publish delta
 	log.Debug(ctx, "Applying delta-mutator 'Set' on CompositeDAG")
-	delta := m.reg.Set(links)
+	delta := m.reg.Set(data.([]core.DAGLink))
 	nd, err := m.clock.AddDAGNode(ctx, delta)
 	if err != nil {
 		return nil, 0, err

--- a/merkle/crdt/composite.go
+++ b/merkle/crdt/composite.go
@@ -70,12 +70,16 @@ func (m *MerkleCompositeDAG) Delete(
 	return nd, delta.GetPriority(), nil
 }
 
-// Set sets the values of CompositeDAG. The value is always the object from the mutation operations.
+// Save the value of the composite CRDT to DAG.
 func (m *MerkleCompositeDAG) Save(ctx context.Context, data any) (ipld.Node, uint64, error) {
+	value, ok := data.([]core.DAGLink)
+	if !ok {
+		return nil, 0, NewErrUnexpectedValueType(client.COMPOSITE, []core.DAGLink{}, data)
+	}
 	// Set() call on underlying CompositeDAG CRDT
 	// persist/publish delta
 	log.Debug(ctx, "Applying delta-mutator 'Set' on CompositeDAG")
-	delta := m.reg.Set(data.([]core.DAGLink))
+	delta := m.reg.Set(value)
 	nd, err := m.clock.AddDAGNode(ctx, delta)
 	if err != nil {
 		return nil, 0, err

--- a/merkle/crdt/errors.go
+++ b/merkle/crdt/errors.go
@@ -1,0 +1,35 @@
+// Copyright 2023 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package merklecrdt
+
+import (
+	"fmt"
+
+	"github.com/sourcenetwork/defradb/client"
+	"github.com/sourcenetwork/defradb/errors"
+)
+
+const (
+	errUnexpectedValueType = "unexpected value type for merkle CRDT"
+)
+
+var (
+	ErrUnexpectedValueType = errors.New(errUnexpectedValueType)
+)
+
+func NewErrUnexpectedValueType(cType client.CType, expected, actual any) error {
+	return errors.New(
+		errUnexpectedValueType,
+		errors.NewKV("CRDT", cType.String()),
+		errors.NewKV("expected", fmt.Sprintf("%T", expected)),
+		errors.NewKV("actual", fmt.Sprintf("%T", actual)),
+	)
+}

--- a/merkle/crdt/lwwreg.go
+++ b/merkle/crdt/lwwreg.go
@@ -15,8 +15,10 @@ import (
 
 	ipld "github.com/ipfs/go-ipld-format"
 
+	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/core"
 	corecrdt "github.com/sourcenetwork/defradb/core/crdt"
+	"github.com/sourcenetwork/defradb/errors"
 	"github.com/sourcenetwork/defradb/merkle/clock"
 )
 
@@ -45,10 +47,18 @@ func NewMerkleLWWRegister(
 }
 
 // Set the value of the register.
-func (mlwwreg *MerkleLWWRegister) Set(ctx context.Context, value []byte) (ipld.Node, uint64, error) {
+func (mlwwreg *MerkleLWWRegister) Save(ctx context.Context, data any) (ipld.Node, uint64, error) {
+	value, ok := data.(*client.FieldValue)
+	if !ok {
+		return nil, 0, errors.New("invalid type")
+	}
+	bytes, err := value.Bytes()
+	if err != nil {
+		return nil, 0, err
+	}
 	// Set() call on underlying LWWRegister CRDT
 	// persist/publish delta
-	delta := mlwwreg.reg.Set(value)
+	delta := mlwwreg.reg.Set(bytes)
 	nd, err := mlwwreg.clock.AddDAGNode(ctx, delta)
 	return nd, delta.GetPriority(), err
 }

--- a/merkle/crdt/lwwreg.go
+++ b/merkle/crdt/lwwreg.go
@@ -18,7 +18,6 @@ import (
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/core"
 	corecrdt "github.com/sourcenetwork/defradb/core/crdt"
-	"github.com/sourcenetwork/defradb/errors"
 	"github.com/sourcenetwork/defradb/merkle/clock"
 )
 
@@ -46,11 +45,11 @@ func NewMerkleLWWRegister(
 	}
 }
 
-// Set the value of the register.
+// Save the value of the register to the DAG.
 func (mlwwreg *MerkleLWWRegister) Save(ctx context.Context, data any) (ipld.Node, uint64, error) {
 	value, ok := data.(*client.FieldValue)
 	if !ok {
-		return nil, 0, errors.New("invalid type")
+		return nil, 0, NewErrUnexpectedValueType(client.LWW_REGISTER, &client.FieldValue{}, data)
 	}
 	bytes, err := value.Bytes()
 	if err != nil {

--- a/merkle/crdt/merklecrdt.go
+++ b/merkle/crdt/merklecrdt.go
@@ -71,6 +71,7 @@ func InstanceWithStore(
 	store Stores,
 	schemaVersionKey core.CollectionSchemaVersionKey,
 	ctype client.CType,
+	kind client.FieldKind,
 	key core.DataStoreKey,
 	fieldName string,
 ) (MerkleCRDT, error) {
@@ -82,13 +83,23 @@ func InstanceWithStore(
 			key,
 			fieldName,
 		), nil
-	case client.PN_COUNTER_REGISTER:
-		return NewMerklePNCounterRegister(
-			store,
-			schemaVersionKey,
-			key,
-			fieldName,
-		), nil
+	case client.PN_COUNTER:
+		switch kind {
+		case client.FieldKind_INT:
+			return NewMerklePNCounter[int64](
+				store,
+				schemaVersionKey,
+				key,
+				fieldName,
+			), nil
+		case client.FieldKind_FLOAT:
+			return NewMerklePNCounter[float64](
+				store,
+				schemaVersionKey,
+				key,
+				fieldName,
+			), nil
+		}
 	case client.COMPOSITE:
 		return NewMerkleCompositeDAG(
 			store,

--- a/merkle/crdt/merklecrdt.go
+++ b/merkle/crdt/merklecrdt.go
@@ -42,14 +42,14 @@ type MerkleCRDT interface {
 	Clock() core.MerkleClock
 }
 
-var _ core.ReplicatedData = (*baseMerkleCRDT)(nil)
-
 // baseMerkleCRDT handles the MerkleCRDT overhead functions that aren't CRDT specific like the mutations and state
 // retrieval functions. It handles creating and publishing the CRDT DAG with the help of the MerkleClock.
 type baseMerkleCRDT struct {
 	clock core.MerkleClock
 	crdt  core.ReplicatedData
 }
+
+var _ core.ReplicatedData = (*baseMerkleCRDT)(nil)
 
 func (base *baseMerkleCRDT) Clock() core.MerkleClock {
 	return base.clock
@@ -77,6 +77,13 @@ func InstanceWithStore(
 	switch ctype {
 	case client.LWW_REGISTER:
 		return NewMerkleLWWRegister(
+			store,
+			schemaVersionKey,
+			key,
+			fieldName,
+		), nil
+	case client.PN_COUNTER_REGISTER:
+		return NewMerklePNCounterRegister(
 			store,
 			schemaVersionKey,
 			key,

--- a/merkle/crdt/merklecrdt.go
+++ b/merkle/crdt/merklecrdt.go
@@ -40,6 +40,7 @@ type Stores interface {
 type MerkleCRDT interface {
 	core.ReplicatedData
 	Clock() core.MerkleClock
+	Save(ctx context.Context, data any) (ipld.Node, uint64, error)
 }
 
 // baseMerkleCRDT handles the MerkleCRDT overhead functions that aren't CRDT specific like the mutations and state

--- a/merkle/crdt/merklecrdt_test.go
+++ b/merkle/crdt/merklecrdt_test.go
@@ -16,12 +16,10 @@ import (
 
 	"github.com/ipfs/go-cid"
 	ds "github.com/ipfs/go-datastore"
-	"github.com/ipfs/go-datastore/query"
 
 	"github.com/sourcenetwork/defradb/core"
-	corecrdt "github.com/sourcenetwork/defradb/core/crdt"
+	crdt "github.com/sourcenetwork/defradb/core/crdt"
 	"github.com/sourcenetwork/defradb/datastore"
-	"github.com/sourcenetwork/defradb/logging"
 	"github.com/sourcenetwork/defradb/merkle/clock"
 )
 
@@ -33,17 +31,16 @@ func newTestBaseMerkleCRDT() (*baseMerkleCRDT, datastore.DSReaderWriter) {
 	s := newDS()
 	multistore := datastore.MultiStoreFrom(s)
 
-	reg := corecrdt.NewLWWRegister(multistore.Datastore(), core.CollectionSchemaVersionKey{}, core.DataStoreKey{}, "")
+	reg := crdt.NewLWWRegister(multistore.Datastore(), core.CollectionSchemaVersionKey{}, core.DataStoreKey{}, "")
 	clk := clock.NewMerkleClock(multistore.Headstore(), multistore.DAGstore(), core.HeadStoreKey{}, reg)
 	return &baseMerkleCRDT{clock: clk, crdt: reg}, multistore.Rootstore()
 }
 
 func TestMerkleCRDTPublish(t *testing.T) {
 	ctx := context.Background()
-	bCRDT, store := newTestBaseMerkleCRDT()
-	delta := &corecrdt.LWWRegDelta{
-		Data: []byte("test"),
-	}
+	bCRDT, _ := newTestBaseMerkleCRDT()
+	reg := crdt.LWWRegister{}
+	delta := reg.Set([]byte("test"))
 
 	nd, err := bCRDT.clock.AddDAGNode(ctx, delta)
 	if err != nil {
@@ -54,26 +51,5 @@ func TestMerkleCRDTPublish(t *testing.T) {
 	if nd.Cid() == cid.Undef {
 		t.Error("Published returned invalid CID Undef:", nd.Cid())
 		return
-	}
-
-	printStore(ctx, store)
-}
-
-func printStore(ctx context.Context, store datastore.DSReaderWriter) {
-	q := query.Query{
-		Prefix:   "",
-		KeysOnly: false,
-	}
-
-	results, err := store.Query(ctx, q)
-
-	if err != nil {
-		panic(err)
-	}
-
-	defer results.Close()
-
-	for r := range results.Next() {
-		log.Info(ctx, "", logging.NewKV(r.Key, r.Value))
 	}
 }

--- a/merkle/crdt/pncounter.go
+++ b/merkle/crdt/pncounter.go
@@ -18,7 +18,6 @@ import (
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/core"
 	"github.com/sourcenetwork/defradb/core/crdt"
-	"github.com/sourcenetwork/defradb/errors"
 	"github.com/sourcenetwork/defradb/merkle/clock"
 )
 
@@ -46,11 +45,11 @@ func NewMerklePNCounter[T crdt.Incrementable](
 	}
 }
 
-// Increment the value of the register.
+// Save the value of the PN Counter to the DAG.
 func (mPNC *MerklePNCounter[T]) Save(ctx context.Context, data any) (ipld.Node, uint64, error) {
 	value, ok := data.(*client.FieldValue)
 	if !ok {
-		return nil, 0, errors.New("invalid type")
+		return nil, 0, NewErrUnexpectedValueType(client.PN_COUNTER, &client.FieldValue{}, data)
 	}
 	delta := mPNC.reg.Increment(value.Value().(T))
 	nd, err := mPNC.clock.AddDAGNode(ctx, delta)

--- a/merkle/crdt/pncounter.go
+++ b/merkle/crdt/pncounter.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Democratized Data Foundation
+// Copyright 2023 Democratized Data Foundation
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt.

--- a/merkle/crdt/pncounter.go
+++ b/merkle/crdt/pncounter.go
@@ -1,0 +1,53 @@
+// Copyright 2022 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package merklecrdt
+
+import (
+	"context"
+
+	ipld "github.com/ipfs/go-ipld-format"
+
+	"github.com/sourcenetwork/defradb/client"
+	"github.com/sourcenetwork/defradb/core"
+	corecrdt "github.com/sourcenetwork/defradb/core/crdt"
+	"github.com/sourcenetwork/defradb/merkle/clock"
+)
+
+// MerklePNCounterRegister is a MerkleCRDT implementation of the PNCounterRegister using MerkleClocks.
+type MerklePNCounterRegister struct {
+	*baseMerkleCRDT
+
+	reg corecrdt.PNCounterRegister
+}
+
+// NewMerklePNCounterRegister creates a new instance (or loaded from DB) of a MerkleCRDT
+// backed by a PNCounterRegister CRDT.
+func NewMerklePNCounterRegister(
+	store Stores,
+	schemaVersionKey core.CollectionSchemaVersionKey,
+	key core.DataStoreKey,
+	fieldName string,
+) *MerklePNCounterRegister {
+	register := corecrdt.NewPNCounterRegister(store.Datastore(), schemaVersionKey, key, fieldName)
+	clk := clock.NewMerkleClock(store.Headstore(), store.DAGstore(), key.ToHeadStoreKey(), register)
+	base := &baseMerkleCRDT{clock: clk, crdt: register}
+	return &MerklePNCounterRegister{
+		baseMerkleCRDT: base,
+		reg:            register,
+	}
+}
+
+// Add the value of the register.
+func (mPNC *MerklePNCounterRegister) Add(ctx context.Context, value client.FieldValue) (ipld.Node, uint64, error) {
+	delta := mPNC.reg.Set(value)
+	nd, err := mPNC.clock.AddDAGNode(ctx, delta)
+	return nd, delta.GetPriority(), err
+}

--- a/merkle/crdt/pncounter.go
+++ b/merkle/crdt/pncounter.go
@@ -15,39 +15,38 @@ import (
 
 	ipld "github.com/ipfs/go-ipld-format"
 
-	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/core"
-	corecrdt "github.com/sourcenetwork/defradb/core/crdt"
+	"github.com/sourcenetwork/defradb/core/crdt"
 	"github.com/sourcenetwork/defradb/merkle/clock"
 )
 
-// MerklePNCounterRegister is a MerkleCRDT implementation of the PNCounterRegister using MerkleClocks.
-type MerklePNCounterRegister struct {
+// MerklePNCounter is a MerkleCRDT implementation of the PNCounter using MerkleClocks.
+type MerklePNCounter[T crdt.Incrementable] struct {
 	*baseMerkleCRDT
 
-	reg corecrdt.PNCounterRegister
+	reg crdt.PNCounter[T]
 }
 
-// NewMerklePNCounterRegister creates a new instance (or loaded from DB) of a MerkleCRDT
-// backed by a PNCounterRegister CRDT.
-func NewMerklePNCounterRegister(
+// NewMerklePNCounter creates a new instance (or loaded from DB) of a MerkleCRDT
+// backed by a PNCounter CRDT.
+func NewMerklePNCounter[T crdt.Incrementable](
 	store Stores,
 	schemaVersionKey core.CollectionSchemaVersionKey,
 	key core.DataStoreKey,
 	fieldName string,
-) *MerklePNCounterRegister {
-	register := corecrdt.NewPNCounterRegister(store.Datastore(), schemaVersionKey, key, fieldName)
+) *MerklePNCounter[T] {
+	register := crdt.NewPNCounter[T](store.Datastore(), schemaVersionKey, key, fieldName)
 	clk := clock.NewMerkleClock(store.Headstore(), store.DAGstore(), key.ToHeadStoreKey(), register)
 	base := &baseMerkleCRDT{clock: clk, crdt: register}
-	return &MerklePNCounterRegister{
+	return &MerklePNCounter[T]{
 		baseMerkleCRDT: base,
 		reg:            register,
 	}
 }
 
-// Add the value of the register.
-func (mPNC *MerklePNCounterRegister) Add(ctx context.Context, value client.FieldValue) (ipld.Node, uint64, error) {
-	delta := mPNC.reg.Set(value)
+// Increment the value of the register.
+func (mPNC *MerklePNCounter[T]) Increment(ctx context.Context, value T) (ipld.Node, uint64, error) {
+	delta := mPNC.reg.Increment(value)
 	nd, err := mPNC.clock.AddDAGNode(ctx, delta)
 	return nd, delta.GetPriority(), err
 }

--- a/net/process.go
+++ b/net/process.go
@@ -158,12 +158,13 @@ func initCRDTForType(
 	key = base.MakeDataStoreKeyWithCollectionDescription(description).WithInstanceInfo(dsKey).WithFieldId(fieldID)
 
 	log.Debug(ctx, "Got CRDT Type", logging.NewKV("CType", ctype), logging.NewKV("Field", field))
-	return merklecrdt.NewMerkleLWWRegister(
+	return merklecrdt.InstanceWithStore(
 		txn,
 		core.NewCollectionSchemaVersionKey(col.Schema().VersionID, col.ID()),
+		ctype,
 		key,
 		field,
-	), nil
+	)
 }
 
 func decodeBlockBuffer(buf []byte, cid cid.Cid) (ipld.Node, error) {

--- a/net/process.go
+++ b/net/process.go
@@ -162,6 +162,7 @@ func initCRDTForType(
 		txn,
 		core.NewCollectionSchemaVersionKey(col.Schema().VersionID, col.ID()),
 		ctype,
+		fd.Kind,
 		key,
 		field,
 	)

--- a/request/graphql/schema/collection.go
+++ b/request/graphql/schema/collection.go
@@ -388,11 +388,11 @@ func setCRDTType(field *ast.FieldDefinition, kind client.FieldKind) (client.CTyp
 			case "type":
 				cType := arg.Value.GetValue().(string)
 				switch cType {
-				case client.PN_COUNTER_REGISTER.String():
-					if !client.PN_COUNTER_REGISTER.IsCompatibleWith(kind) {
+				case client.PN_COUNTER.String():
+					if !client.PN_COUNTER.IsCompatibleWith(kind) {
 						return 0, client.NewErrCRDTKindMismatch(cType, kind.String())
 					}
-					return client.PN_COUNTER_REGISTER, nil
+					return client.PN_COUNTER, nil
 				case client.LWW_REGISTER.String():
 					return client.LWW_REGISTER, nil
 				default:

--- a/tests/gen/cli/util_test.go
+++ b/tests/gen/cli/util_test.go
@@ -71,9 +71,8 @@ func start(ctx context.Context, cfg *config.Config) (*defraInstance, error) {
 		return nil, errors.Wrap(fmt.Sprintf("failed to listen on TCP address %v", server.Addr), err)
 	}
 	// save the address on the config in case the port number was set to random
-	cfg.WithCustomValues(func(cfg *config.Config) {
-		cfg.API.Address = server.AssignedAddr()
-	})
+	cfg.API.Address = server.AssignedAddr()
+	cfg.Persist()
 
 	// run the server in a separate goroutine
 	go func(apiAddress string) {
@@ -93,13 +92,12 @@ func start(ctx context.Context, cfg *config.Config) (*defraInstance, error) {
 
 func getTestConfig(t *testing.T) *config.Config {
 	cfg := config.DefaultConfig()
-	cfg.WithCustomValues(func(cfg *config.Config) {
-		cfg.Datastore.Store = "memory"
-		cfg.Net.P2PDisabled = true
-		cfg.Rootdir = t.TempDir()
-		cfg.Net.P2PAddress = "/ip4/127.0.0.1/tcp/0"
-		cfg.API.Address = "127.0.0.1:0"
-	})
+	cfg.Datastore.Store = "memory"
+	cfg.Net.P2PDisabled = true
+	cfg.Rootdir = t.TempDir()
+	cfg.Net.P2PAddress = "/ip4/127.0.0.1/tcp/0"
+	cfg.API.Address = "127.0.0.1:0"
+	cfg.Persist()
 	return cfg
 }
 

--- a/tests/integration/events/simple/with_update_test.go
+++ b/tests/integration/events/simple/with_update_test.go
@@ -66,14 +66,14 @@ func TestEventsSimpleWithUpdate(t *testing.T) {
 		ExpectedUpdates: []testUtils.ExpectedUpdate{
 			{
 				DocID: immutable.Some(docID1),
-				Cid:   immutable.Some("bafybeicbv34oa4hfcnqbka3jqnby4g75ttlj4wfvc7zhvat5xca45ggq2u"),
+				Cid:   immutable.Some("bafybeiayfnxksqr5fbqdjgbnhykoazjggtkvi3sajxn4d2ewsnbhe64czi"),
 			},
 			{
 				DocID: immutable.Some(docID2),
 			},
 			{
 				DocID: immutable.Some(docID1),
-				Cid:   immutable.Some("bafybeiep6f7sls7z325oqd5oddigxq3fkxwpp5b7um47yz5erxfybjd6ra"),
+				Cid:   immutable.Some("bafybeic4gotxyhj2fi3pwnsacxa7qfoy2glvjflicmes35qnr4ehn66rni"),
 			},
 		},
 	}

--- a/tests/integration/events/simple/with_update_test.go
+++ b/tests/integration/events/simple/with_update_test.go
@@ -66,14 +66,14 @@ func TestEventsSimpleWithUpdate(t *testing.T) {
 		ExpectedUpdates: []testUtils.ExpectedUpdate{
 			{
 				DocID: immutable.Some(docID1),
-				Cid:   immutable.Some("bafybeiayfnxksqr5fbqdjgbnhykoazjggtkvi3sajxn4d2ewsnbhe64czi"),
+				Cid:   immutable.Some("bafybeif5l2a5f2lcsmuml2cji6unq4qk2ta4f3uow4wccdjebsu7jcjrj4"),
 			},
 			{
 				DocID: immutable.Some(docID2),
 			},
 			{
 				DocID: immutable.Some(docID1),
-				Cid:   immutable.Some("bafybeic4gotxyhj2fi3pwnsacxa7qfoy2glvjflicmes35qnr4ehn66rni"),
+				Cid:   immutable.Some("bafybeihchzitl7e7pyhci5bs563dn3seykcleqk56r7vjtslvi3rv3wsne"),
 			},
 		},
 	}

--- a/tests/integration/mutation/create/crdt/pncounter_test.go
+++ b/tests/integration/mutation/create/crdt/pncounter_test.go
@@ -16,9 +16,9 @@ import (
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
 )
 
-func TestMutationCreate_PNCounter_NoError(t *testing.T) {
+func TestPNCounterCreate_IntKindWithPositiveValue_NoError(t *testing.T) {
 	test := testUtils.TestCase{
-		Description: "Simple create mutation of a PN Counter",
+		Description: "Document creation with PN Counter",
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `

--- a/tests/integration/mutation/create/crdt/pncounter_test.go
+++ b/tests/integration/mutation/create/crdt/pncounter_test.go
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-package update
+package create
 
 import (
 	"testing"

--- a/tests/integration/mutation/create/with_version_test.go
+++ b/tests/integration/mutation/create/with_version_test.go
@@ -39,7 +39,7 @@ func TestMutationCreate_ReturnsVersionCID(t *testing.T) {
 					{
 						"_version": []map[string]any{
 							{
-								"cid": "bafybeiayfnxksqr5fbqdjgbnhykoazjggtkvi3sajxn4d2ewsnbhe64czi",
+								"cid": "bafybeif5l2a5f2lcsmuml2cji6unq4qk2ta4f3uow4wccdjebsu7jcjrj4",
 							},
 						},
 					},

--- a/tests/integration/mutation/create/with_version_test.go
+++ b/tests/integration/mutation/create/with_version_test.go
@@ -39,7 +39,7 @@ func TestMutationCreate_ReturnsVersionCID(t *testing.T) {
 					{
 						"_version": []map[string]any{
 							{
-								"cid": "bafybeicbv34oa4hfcnqbka3jqnby4g75ttlj4wfvc7zhvat5xca45ggq2u",
+								"cid": "bafybeiayfnxksqr5fbqdjgbnhykoazjggtkvi3sajxn4d2ewsnbhe64czi",
 							},
 						},
 					},

--- a/tests/integration/mutation/update/crdt/pncounter_test.go
+++ b/tests/integration/mutation/update/crdt/pncounter_test.go
@@ -69,9 +69,6 @@ func TestPNCounterUpdate_IntKindWithPositiveIncrement_ShouldIncrement(t *testing
 }
 
 // This test documents what happens when an overflow occurs in a PN Counter with Int type.
-// Note: This documents a sub optimal behaviour of the system due to json unmarshalling
-// MaxInt64 into a float which loses precision and converting it back to int64 sets it as a negative
-// value.
 func TestPNCounterUpdate_IntKindWithPositiveIncrementOverflow_RollsOverToMinInt64(t *testing.T) {
 	test := testUtils.TestCase{
 		Description: "Positive increments of a PN Counter with Int type causing overflow behaviour",

--- a/tests/integration/mutation/update/crdt/pncounter_test.go
+++ b/tests/integration/mutation/update/crdt/pncounter_test.go
@@ -1,0 +1,69 @@
+// Copyright 2023 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package update
+
+import (
+	"testing"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+func TestMutationUpdate_PNCounter_NoError(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "Simple update mutation of a PN Counter",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users {
+						name: String
+						points: Int @crdt(type: "pncounter")
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
+					"name": "John",
+					"points": 0
+				}`,
+			},
+			testUtils.Request{
+				Request: `mutation {
+					update_Users(id: "bae-7d3bc1c9-b467-5ad0-979c-2ecfa06f2184", data: "{\"points\": 10}") {
+						name
+						points
+					}
+				}`,
+				Results: []map[string]any{
+					{
+						"name":   "John",
+						"points": int64(10),
+					},
+				},
+			},
+			testUtils.Request{
+				Request: `mutation {
+					update_Users(id: "bae-7d3bc1c9-b467-5ad0-979c-2ecfa06f2184", data: "{\"points\": 10}") {
+						name
+						points
+					}
+				}`,
+				Results: []map[string]any{
+					{
+						"name":   "John",
+						"points": int64(20),
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/net/state/simple/peer/crdt/pncounter_test.go
+++ b/tests/integration/net/state/simple/peer/crdt/pncounter_test.go
@@ -1,0 +1,69 @@
+// Copyright 2023 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package peer_test
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/immutable"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+func TestP2PUpdate_WithPNCounter_NoError(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.RandomNetworkingConfig(),
+			testUtils.RandomNetworkingConfig(),
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users {
+						name: String
+						points: Int @crdt(type: "pncounter")
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				// Create Shahzad on all nodes
+				Doc: `{
+					"name": "Shahzad",
+					"points": 10
+				}`,
+			},
+			testUtils.ConnectPeers{
+				SourceNodeID: 1,
+				TargetNodeID: 0,
+			},
+			testUtils.UpdateDoc{
+				NodeID: immutable.Some(0),
+				DocID:  0,
+				Doc: `{
+					"points": 10
+				}`,
+			},
+			testUtils.WaitForSync{},
+			testUtils.Request{
+				Request: `query {
+					Users {
+						points
+					}
+				}`,
+				Results: []map[string]any{
+					{
+						"points": int64(20),
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/net/state/simple/peer_replicator/crdt/pncounter_test.go
+++ b/tests/integration/net/state/simple/peer_replicator/crdt/pncounter_test.go
@@ -1,0 +1,160 @@
+// Copyright 2023 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package peer_replicator_test
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/immutable"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+func TestP2PPeerReplicatorWithCreate_PNCounter_NoError(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.RandomNetworkingConfig(),
+			testUtils.RandomNetworkingConfig(),
+			testUtils.RandomNetworkingConfig(),
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users {
+						name: String
+						points: Int @crdt(type: "pncounter")
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
+					"name": "John",
+					"points": 0
+				}`,
+			},
+			testUtils.ConfigureReplicator{
+				SourceNodeID: 0,
+				TargetNodeID: 2,
+			},
+			testUtils.ConnectPeers{
+				SourceNodeID: 0,
+				TargetNodeID: 1,
+			},
+			testUtils.CreateDoc{
+				NodeID: immutable.Some(0),
+				Doc: `{
+					"name": "Shahzad",
+					"points": 3000
+				}`,
+			},
+			testUtils.WaitForSync{},
+			testUtils.Request{
+				NodeID: immutable.Some(0),
+				Request: `query {
+					Users {
+						points
+					}
+				}`,
+				Results: []map[string]any{
+					{
+						"points": int64(0),
+					},
+					{
+						"points": int64(3000),
+					},
+				},
+			},
+			testUtils.Request{
+				NodeID: immutable.Some(1),
+				Request: `query {
+					Users {
+						points
+					}
+				}`,
+				Results: []map[string]any{
+					{
+						"points": int64(0),
+					},
+				},
+			},
+			testUtils.Request{
+				NodeID: immutable.Some(2),
+				Request: `query {
+					Users {
+						points
+					}
+				}`,
+				Results: []map[string]any{
+					{
+						"points": int64(0),
+					},
+					{
+						"points": int64(3000),
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestP2PPeerReplicatorWithUpdate_PNCounter_NoError(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.RandomNetworkingConfig(),
+			testUtils.RandomNetworkingConfig(),
+			testUtils.RandomNetworkingConfig(),
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users {
+						name: String
+						points: Int @crdt(type: "pncounter")
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
+					"name": "John",
+					"points": 10
+				}`,
+			},
+			testUtils.ConnectPeers{
+				SourceNodeID: 1,
+				TargetNodeID: 0,
+			},
+			testUtils.ConfigureReplicator{
+				SourceNodeID: 0,
+				TargetNodeID: 2,
+			},
+			testUtils.UpdateDoc{
+				// Update John's points on the first node only, and allow the value to sync
+				NodeID: immutable.Some(0),
+				Doc: `{
+					"points": 10
+				}`,
+			},
+			testUtils.WaitForSync{},
+			testUtils.Request{
+				Request: `query {
+					Users {
+						points
+					}
+				}`,
+				Results: []map[string]any{
+					{
+						"points": int64(20),
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/net/state/simple/replicator/crdt/pncounter_test.go
+++ b/tests/integration/net/state/simple/replicator/crdt/pncounter_test.go
@@ -1,0 +1,71 @@
+// Copyright 2023 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package replicator
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/immutable"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+func TestP2POneToOneReplicatorUpdate_PNCounter_NoError(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.RandomNetworkingConfig(),
+			testUtils.RandomNetworkingConfig(),
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users {
+						name: String
+						points: Int @crdt(type: "pncounter")
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				// This document is created in first node before the replicator is set up.
+				// Updates should be synced across nodes.
+				NodeID: immutable.Some(0),
+				Doc: `{
+					"name": "John",
+					"points": 10
+				}`,
+			},
+			testUtils.ConfigureReplicator{
+				SourceNodeID: 0,
+				TargetNodeID: 1,
+			},
+			testUtils.UpdateDoc{
+				// Update John's points on the first node only, and allow the value to sync
+				NodeID: immutable.Some(0),
+				Doc: `{
+					"points": 10
+				}`,
+			},
+			testUtils.WaitForSync{},
+			testUtils.Request{
+				Request: `query {
+					Users {
+						points
+					}
+				}`,
+				Results: []map[string]any{
+					{
+						"points": int64(20),
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/query/commits/simple_test.go
+++ b/tests/integration/query/commits/simple_test.go
@@ -36,13 +36,13 @@ func TestQueryCommits(t *testing.T) {
 					}`,
 				Results: []map[string]any{
 					{
-						"cid": "bafybeiagew5ervkxkyz6sezgkrcrhv6towawpbirg6ziouah7lj5eg7lwy",
+						"cid": "bafybeihfw5lufgs7ygv45to5rqvt3xkecjgikoccjyx6y2i7lnaclmrcjm",
 					},
 					{
-						"cid": "bafybeibsfjpv57libozcmiihs2ixgsoseu752ni6nkeqqv2nhgxgpe7l5m",
+						"cid": "bafybeigmez6gtszsqx6aevzlanvpazhhezw5va4wizhqtqz5k4s2dqjb24",
 					},
 					{
-						"cid": "bafybeiaitgizimh6ttm3stfabpwqvg5tvty3j46p6hqbat4w7ippcbw4ky",
+						"cid": "bafybeiedu23doqe2nagdbmkvfyuouajnfxo7ezy57vbv34dqewhwbfg45u",
 					},
 				},
 			},
@@ -79,22 +79,22 @@ func TestQueryCommitsMultipleDocs(t *testing.T) {
 					}`,
 				Results: []map[string]any{
 					{
-						"cid": "bafybeieskldux7w2loaoy4zvz6aroixgsh6e5tbf6hjjn2kjgugyqamhka",
+						"cid": "bafybeigdcaas33fnrv7jbigm5a5phxtxl76weuf74kqcrb5udjgttqssju",
 					},
 					{
-						"cid": "bafybeidt3dgghrg2dnacwue67d2xbulcq2i76yephc4lptelii6rlc6kbe",
+						"cid": "bafybeiahfq2ji7uneqfqddeqsvz5t3rdkgo7wpnpswo2jon23kxpgvqdsa",
 					},
 					{
-						"cid": "bafybeicjkwd55fow2yivucptomtypfcb2x6luwqb27pg7kfdx6nbtxqsty",
+						"cid": "bafybeihhadjgfxsyrlg5gftmi4ikppuhecyeqznjru47l3tup4c6sbzhga",
 					},
 					{
-						"cid": "bafybeiagew5ervkxkyz6sezgkrcrhv6towawpbirg6ziouah7lj5eg7lwy",
+						"cid": "bafybeihfw5lufgs7ygv45to5rqvt3xkecjgikoccjyx6y2i7lnaclmrcjm",
 					},
 					{
-						"cid": "bafybeibsfjpv57libozcmiihs2ixgsoseu752ni6nkeqqv2nhgxgpe7l5m",
+						"cid": "bafybeigmez6gtszsqx6aevzlanvpazhhezw5va4wizhqtqz5k4s2dqjb24",
 					},
 					{
-						"cid": "bafybeiaitgizimh6ttm3stfabpwqvg5tvty3j46p6hqbat4w7ippcbw4ky",
+						"cid": "bafybeiedu23doqe2nagdbmkvfyuouajnfxo7ezy57vbv34dqewhwbfg45u",
 					},
 				},
 			},
@@ -125,16 +125,16 @@ func TestQueryCommitsWithSchemaVersionIdField(t *testing.T) {
 					}`,
 				Results: []map[string]any{
 					{
-						"cid":             "bafybeiagew5ervkxkyz6sezgkrcrhv6towawpbirg6ziouah7lj5eg7lwy",
-						"schemaVersionId": "bafkreictcre4pylafzzoh5lpgbetdodunz4r6pz3ormdzzpsz2lqtp4v34",
+						"cid":             "bafybeihfw5lufgs7ygv45to5rqvt3xkecjgikoccjyx6y2i7lnaclmrcjm",
+						"schemaVersionId": "bafkreiayhdsgzhmrz6t5d3x2cgqqbdjt7aqgldtlkmxn5eibg542j3n6ea",
 					},
 					{
-						"cid":             "bafybeibsfjpv57libozcmiihs2ixgsoseu752ni6nkeqqv2nhgxgpe7l5m",
-						"schemaVersionId": "bafkreictcre4pylafzzoh5lpgbetdodunz4r6pz3ormdzzpsz2lqtp4v34",
+						"cid":             "bafybeigmez6gtszsqx6aevzlanvpazhhezw5va4wizhqtqz5k4s2dqjb24",
+						"schemaVersionId": "bafkreiayhdsgzhmrz6t5d3x2cgqqbdjt7aqgldtlkmxn5eibg542j3n6ea",
 					},
 					{
-						"cid":             "bafybeiaitgizimh6ttm3stfabpwqvg5tvty3j46p6hqbat4w7ippcbw4ky",
-						"schemaVersionId": "bafkreictcre4pylafzzoh5lpgbetdodunz4r6pz3ormdzzpsz2lqtp4v34",
+						"cid":             "bafybeiedu23doqe2nagdbmkvfyuouajnfxo7ezy57vbv34dqewhwbfg45u",
+						"schemaVersionId": "bafkreiayhdsgzhmrz6t5d3x2cgqqbdjt7aqgldtlkmxn5eibg542j3n6ea",
 					},
 				},
 			},

--- a/tests/integration/query/commits/simple_test.go
+++ b/tests/integration/query/commits/simple_test.go
@@ -36,13 +36,13 @@ func TestQueryCommits(t *testing.T) {
 					}`,
 				Results: []map[string]any{
 					{
-						"cid": "bafybeibcr5lkdvcvtr67rpsnvn57hgrhlg36cnmmf7kywjekjodwxytpi4",
+						"cid": "bafybeiagew5ervkxkyz6sezgkrcrhv6towawpbirg6ziouah7lj5eg7lwy",
 					},
 					{
-						"cid": "bafybeifw7cu7uweruypv44on2zupjzolyqvyh4ookoeybkztzys67m4hwi",
+						"cid": "bafybeibsfjpv57libozcmiihs2ixgsoseu752ni6nkeqqv2nhgxgpe7l5m",
 					},
 					{
-						"cid": "bafybeige7qoom3bgjitfisxvhbifou6n4tgguan3ihwbkz5mvbumndeiaa",
+						"cid": "bafybeiaitgizimh6ttm3stfabpwqvg5tvty3j46p6hqbat4w7ippcbw4ky",
 					},
 				},
 			},
@@ -79,22 +79,22 @@ func TestQueryCommitsMultipleDocs(t *testing.T) {
 					}`,
 				Results: []map[string]any{
 					{
-						"cid": "bafybeifnoeodhrvpimwnuwcxmz2fxci6cwrw5ck5vo5n6rkkdt47hepyhm",
+						"cid": "bafybeieskldux7w2loaoy4zvz6aroixgsh6e5tbf6hjjn2kjgugyqamhka",
 					},
 					{
-						"cid": "bafybeihx6t43wc23xzak7raultfzpvnetrsi7vhzglray3r7k4gdksbuk4",
+						"cid": "bafybeidt3dgghrg2dnacwue67d2xbulcq2i76yephc4lptelii6rlc6kbe",
 					},
 					{
-						"cid": "bafybeicvpe4oyfrgcuhf2eqqgp2iwuifgl73d6jo4pdlg3x3vqmnusgxv4",
+						"cid": "bafybeicjkwd55fow2yivucptomtypfcb2x6luwqb27pg7kfdx6nbtxqsty",
 					},
 					{
-						"cid": "bafybeibcr5lkdvcvtr67rpsnvn57hgrhlg36cnmmf7kywjekjodwxytpi4",
+						"cid": "bafybeiagew5ervkxkyz6sezgkrcrhv6towawpbirg6ziouah7lj5eg7lwy",
 					},
 					{
-						"cid": "bafybeifw7cu7uweruypv44on2zupjzolyqvyh4ookoeybkztzys67m4hwi",
+						"cid": "bafybeibsfjpv57libozcmiihs2ixgsoseu752ni6nkeqqv2nhgxgpe7l5m",
 					},
 					{
-						"cid": "bafybeige7qoom3bgjitfisxvhbifou6n4tgguan3ihwbkz5mvbumndeiaa",
+						"cid": "bafybeiaitgizimh6ttm3stfabpwqvg5tvty3j46p6hqbat4w7ippcbw4ky",
 					},
 				},
 			},
@@ -125,16 +125,16 @@ func TestQueryCommitsWithSchemaVersionIdField(t *testing.T) {
 					}`,
 				Results: []map[string]any{
 					{
-						"cid":             "bafybeibcr5lkdvcvtr67rpsnvn57hgrhlg36cnmmf7kywjekjodwxytpi4",
-						"schemaVersionId": "bafkreiayhdsgzhmrz6t5d3x2cgqqbdjt7aqgldtlkmxn5eibg542j3n6ea",
+						"cid":             "bafybeiagew5ervkxkyz6sezgkrcrhv6towawpbirg6ziouah7lj5eg7lwy",
+						"schemaVersionId": "bafkreictcre4pylafzzoh5lpgbetdodunz4r6pz3ormdzzpsz2lqtp4v34",
 					},
 					{
-						"cid":             "bafybeifw7cu7uweruypv44on2zupjzolyqvyh4ookoeybkztzys67m4hwi",
-						"schemaVersionId": "bafkreiayhdsgzhmrz6t5d3x2cgqqbdjt7aqgldtlkmxn5eibg542j3n6ea",
+						"cid":             "bafybeibsfjpv57libozcmiihs2ixgsoseu752ni6nkeqqv2nhgxgpe7l5m",
+						"schemaVersionId": "bafkreictcre4pylafzzoh5lpgbetdodunz4r6pz3ormdzzpsz2lqtp4v34",
 					},
 					{
-						"cid":             "bafybeige7qoom3bgjitfisxvhbifou6n4tgguan3ihwbkz5mvbumndeiaa",
-						"schemaVersionId": "bafkreiayhdsgzhmrz6t5d3x2cgqqbdjt7aqgldtlkmxn5eibg542j3n6ea",
+						"cid":             "bafybeiaitgizimh6ttm3stfabpwqvg5tvty3j46p6hqbat4w7ippcbw4ky",
+						"schemaVersionId": "bafkreictcre4pylafzzoh5lpgbetdodunz4r6pz3ormdzzpsz2lqtp4v34",
 					},
 				},
 			},

--- a/tests/integration/query/commits/with_cid_test.go
+++ b/tests/integration/query/commits/with_cid_test.go
@@ -38,14 +38,14 @@ func TestQueryCommitsWithCid(t *testing.T) {
 			testUtils.Request{
 				Request: `query {
 						commits(
-							cid: "bafybeiaitgizimh6ttm3stfabpwqvg5tvty3j46p6hqbat4w7ippcbw4ky"
+							cid: "bafybeiedu23doqe2nagdbmkvfyuouajnfxo7ezy57vbv34dqewhwbfg45u"
 						) {
 							cid
 						}
 					}`,
 				Results: []map[string]any{
 					{
-						"cid": "bafybeiaitgizimh6ttm3stfabpwqvg5tvty3j46p6hqbat4w7ippcbw4ky",
+						"cid": "bafybeiedu23doqe2nagdbmkvfyuouajnfxo7ezy57vbv34dqewhwbfg45u",
 					},
 				},
 			},
@@ -71,14 +71,14 @@ func TestQueryCommitsWithCidForFieldCommit(t *testing.T) {
 			testUtils.Request{
 				Request: `query {
 						commits(
-							cid: "bafybeiaitgizimh6ttm3stfabpwqvg5tvty3j46p6hqbat4w7ippcbw4ky"
+							cid: "bafybeiedu23doqe2nagdbmkvfyuouajnfxo7ezy57vbv34dqewhwbfg45u"
 						) {
 							cid
 						}
 					}`,
 				Results: []map[string]any{
 					{
-						"cid": "bafybeiaitgizimh6ttm3stfabpwqvg5tvty3j46p6hqbat4w7ippcbw4ky",
+						"cid": "bafybeiedu23doqe2nagdbmkvfyuouajnfxo7ezy57vbv34dqewhwbfg45u",
 					},
 				},
 			},

--- a/tests/integration/query/commits/with_cid_test.go
+++ b/tests/integration/query/commits/with_cid_test.go
@@ -38,14 +38,14 @@ func TestQueryCommitsWithCid(t *testing.T) {
 			testUtils.Request{
 				Request: `query {
 						commits(
-							cid: "bafybeifw7cu7uweruypv44on2zupjzolyqvyh4ookoeybkztzys67m4hwi"
+							cid: "bafybeiaitgizimh6ttm3stfabpwqvg5tvty3j46p6hqbat4w7ippcbw4ky"
 						) {
 							cid
 						}
 					}`,
 				Results: []map[string]any{
 					{
-						"cid": "bafybeifw7cu7uweruypv44on2zupjzolyqvyh4ookoeybkztzys67m4hwi",
+						"cid": "bafybeiaitgizimh6ttm3stfabpwqvg5tvty3j46p6hqbat4w7ippcbw4ky",
 					},
 				},
 			},
@@ -71,14 +71,14 @@ func TestQueryCommitsWithCidForFieldCommit(t *testing.T) {
 			testUtils.Request{
 				Request: `query {
 						commits(
-							cid: "bafybeifw7cu7uweruypv44on2zupjzolyqvyh4ookoeybkztzys67m4hwi"
+							cid: "bafybeiaitgizimh6ttm3stfabpwqvg5tvty3j46p6hqbat4w7ippcbw4ky"
 						) {
 							cid
 						}
 					}`,
 				Results: []map[string]any{
 					{
-						"cid": "bafybeifw7cu7uweruypv44on2zupjzolyqvyh4ookoeybkztzys67m4hwi",
+						"cid": "bafybeiaitgizimh6ttm3stfabpwqvg5tvty3j46p6hqbat4w7ippcbw4ky",
 					},
 				},
 			},

--- a/tests/integration/query/commits/with_depth_test.go
+++ b/tests/integration/query/commits/with_depth_test.go
@@ -36,13 +36,13 @@ func TestQueryCommitsWithDepth1(t *testing.T) {
 					}`,
 				Results: []map[string]any{
 					{
-						"cid": "bafybeiagew5ervkxkyz6sezgkrcrhv6towawpbirg6ziouah7lj5eg7lwy",
+						"cid": "bafybeihfw5lufgs7ygv45to5rqvt3xkecjgikoccjyx6y2i7lnaclmrcjm",
 					},
 					{
-						"cid": "bafybeibsfjpv57libozcmiihs2ixgsoseu752ni6nkeqqv2nhgxgpe7l5m",
+						"cid": "bafybeigmez6gtszsqx6aevzlanvpazhhezw5va4wizhqtqz5k4s2dqjb24",
 					},
 					{
-						"cid": "bafybeiaitgizimh6ttm3stfabpwqvg5tvty3j46p6hqbat4w7ippcbw4ky",
+						"cid": "bafybeiedu23doqe2nagdbmkvfyuouajnfxo7ezy57vbv34dqewhwbfg45u",
 					},
 				},
 			},
@@ -81,16 +81,16 @@ func TestQueryCommitsWithDepth1WithUpdate(t *testing.T) {
 				Results: []map[string]any{
 					{
 						// "Age" field head
-						"cid":    "bafybeiblr52xw3xplsat66bwwyfg4pgbh3gei7njmdvomodf2qygt627r4",
+						"cid":    "bafybeihqgrwnhc4w7e5cbhycxvqrpzgi2ei4xrcsre2plceclptgn4tc3i",
 						"height": int64(2),
 					},
 					{
 						// "Name" field head (unchanged from create)
-						"cid":    "bafybeibsfjpv57libozcmiihs2ixgsoseu752ni6nkeqqv2nhgxgpe7l5m",
+						"cid":    "bafybeigmez6gtszsqx6aevzlanvpazhhezw5va4wizhqtqz5k4s2dqjb24",
 						"height": int64(1),
 					},
 					{
-						"cid":    "bafybeihu5onq2trqv25zieyejrnj6kyh2533i3rchvq64kahbjz7uzrquu",
+						"cid":    "bafybeibfwqf5szatmlyl3alru4nq3gnxaiyyb3ggqung2jwb4qnm6mejyu",
 						"height": int64(2),
 					},
 				},
@@ -137,27 +137,27 @@ func TestQueryCommitsWithDepth2WithUpdate(t *testing.T) {
 				Results: []map[string]any{
 					{
 						// Composite head
-						"cid":    "bafybeigzqhl3ckoduvhl7slck4mlgqo6lif5w2nedjlwz7rq3pacodc6t4",
+						"cid":    "bafybeihvhr7ke7bjgjixce262544tlo7mdlyuswtgl66zsrxcfc5targjy",
 						"height": int64(3),
 					},
 					{
 						// Composite head -1
-						"cid":    "bafybeiblr52xw3xplsat66bwwyfg4pgbh3gei7njmdvomodf2qygt627r4",
+						"cid":    "bafybeihqgrwnhc4w7e5cbhycxvqrpzgi2ei4xrcsre2plceclptgn4tc3i",
 						"height": int64(2),
 					},
 					{
 						// "Name" field head (unchanged from create)
-						"cid":    "bafybeibsfjpv57libozcmiihs2ixgsoseu752ni6nkeqqv2nhgxgpe7l5m",
+						"cid":    "bafybeigmez6gtszsqx6aevzlanvpazhhezw5va4wizhqtqz5k4s2dqjb24",
 						"height": int64(1),
 					},
 					{
 						// "Age" field head
-						"cid":    "bafybeibbigbsvqdf2smkd33c34psvcljxfkexvbpismeumiy7r3mkuhtai",
+						"cid":    "bafybeicacrvck5qf37pk3pdsiavvxy2jk67dbdpww5pvoun2k52lw2ftqi",
 						"height": int64(3),
 					},
 					{
 						// "Age" field head -1
-						"cid":    "bafybeihu5onq2trqv25zieyejrnj6kyh2533i3rchvq64kahbjz7uzrquu",
+						"cid":    "bafybeibfwqf5szatmlyl3alru4nq3gnxaiyyb3ggqung2jwb4qnm6mejyu",
 						"height": int64(2),
 					},
 				},
@@ -195,22 +195,22 @@ func TestQueryCommitsWithDepth1AndMultipleDocs(t *testing.T) {
 					}`,
 				Results: []map[string]any{
 					{
-						"cid": "bafybeihzfcx7als6w6qxy76lcxdxs6yepdxt7fmhcqmkgm3s2vjjokcdaq",
+						"cid": "bafybeigvcksw7ck2o7rqfyxncn2h5u6bbwj5ejjfvsihsjibxvrqrxbtui",
 					},
 					{
-						"cid": "bafybeiffaln23wx47mcfhvzgiuuyqfjto2r32hjjrd2kq5hzce72vwdixy",
+						"cid": "bafybeibcdmghhshx4v3xamoktw3n6blv7courh6x2d5cttwuzlodml74ny",
 					},
 					{
-						"cid": "bafybeie3y57zvbpw4pnw7okbj55uneh42ihspp4vjqsqxvr6if4xgwffqq",
+						"cid": "bafybeig6rwkq6hlf5rcjq64jodl3gtfv5svnmsjlkwrnmbcjui7t3vy3qi",
 					},
 					{
-						"cid": "bafybeiagew5ervkxkyz6sezgkrcrhv6towawpbirg6ziouah7lj5eg7lwy",
+						"cid": "bafybeihfw5lufgs7ygv45to5rqvt3xkecjgikoccjyx6y2i7lnaclmrcjm",
 					},
 					{
-						"cid": "bafybeibsfjpv57libozcmiihs2ixgsoseu752ni6nkeqqv2nhgxgpe7l5m",
+						"cid": "bafybeigmez6gtszsqx6aevzlanvpazhhezw5va4wizhqtqz5k4s2dqjb24",
 					},
 					{
-						"cid": "bafybeiaitgizimh6ttm3stfabpwqvg5tvty3j46p6hqbat4w7ippcbw4ky",
+						"cid": "bafybeiedu23doqe2nagdbmkvfyuouajnfxo7ezy57vbv34dqewhwbfg45u",
 					},
 				},
 			},

--- a/tests/integration/query/commits/with_depth_test.go
+++ b/tests/integration/query/commits/with_depth_test.go
@@ -36,13 +36,13 @@ func TestQueryCommitsWithDepth1(t *testing.T) {
 					}`,
 				Results: []map[string]any{
 					{
-						"cid": "bafybeibcr5lkdvcvtr67rpsnvn57hgrhlg36cnmmf7kywjekjodwxytpi4",
+						"cid": "bafybeiagew5ervkxkyz6sezgkrcrhv6towawpbirg6ziouah7lj5eg7lwy",
 					},
 					{
-						"cid": "bafybeifw7cu7uweruypv44on2zupjzolyqvyh4ookoeybkztzys67m4hwi",
+						"cid": "bafybeibsfjpv57libozcmiihs2ixgsoseu752ni6nkeqqv2nhgxgpe7l5m",
 					},
 					{
-						"cid": "bafybeige7qoom3bgjitfisxvhbifou6n4tgguan3ihwbkz5mvbumndeiaa",
+						"cid": "bafybeiaitgizimh6ttm3stfabpwqvg5tvty3j46p6hqbat4w7ippcbw4ky",
 					},
 				},
 			},
@@ -81,16 +81,16 @@ func TestQueryCommitsWithDepth1WithUpdate(t *testing.T) {
 				Results: []map[string]any{
 					{
 						// "Age" field head
-						"cid":    "bafybeibybndrw4dida2m2mlwfl42i56pwoxna6ztansrvya4ikejd63kju",
+						"cid":    "bafybeiblr52xw3xplsat66bwwyfg4pgbh3gei7njmdvomodf2qygt627r4",
 						"height": int64(2),
 					},
 					{
 						// "Name" field head (unchanged from create)
-						"cid":    "bafybeifw7cu7uweruypv44on2zupjzolyqvyh4ookoeybkztzys67m4hwi",
+						"cid":    "bafybeibsfjpv57libozcmiihs2ixgsoseu752ni6nkeqqv2nhgxgpe7l5m",
 						"height": int64(1),
 					},
 					{
-						"cid":    "bafybeieufqlniob4m5abilofa7iewl3mheykvordbhuhi5g4ewszmxnfvi",
+						"cid":    "bafybeihu5onq2trqv25zieyejrnj6kyh2533i3rchvq64kahbjz7uzrquu",
 						"height": int64(2),
 					},
 				},
@@ -137,27 +137,27 @@ func TestQueryCommitsWithDepth2WithUpdate(t *testing.T) {
 				Results: []map[string]any{
 					{
 						// Composite head
-						"cid":    "bafybeifj3dw2wehaabwmrkcmebj3xyyujlp32sycydd3wfjszx3bfxglfu",
+						"cid":    "bafybeigzqhl3ckoduvhl7slck4mlgqo6lif5w2nedjlwz7rq3pacodc6t4",
 						"height": int64(3),
 					},
 					{
 						// Composite head -1
-						"cid":    "bafybeibybndrw4dida2m2mlwfl42i56pwoxna6ztansrvya4ikejd63kju",
+						"cid":    "bafybeiblr52xw3xplsat66bwwyfg4pgbh3gei7njmdvomodf2qygt627r4",
 						"height": int64(2),
 					},
 					{
 						// "Name" field head (unchanged from create)
-						"cid":    "bafybeifw7cu7uweruypv44on2zupjzolyqvyh4ookoeybkztzys67m4hwi",
+						"cid":    "bafybeibsfjpv57libozcmiihs2ixgsoseu752ni6nkeqqv2nhgxgpe7l5m",
 						"height": int64(1),
 					},
 					{
 						// "Age" field head
-						"cid":    "bafybeieirgdstog2griwuuxgb4c3frgka55yoodjwdznraoieqcxfdijw4",
+						"cid":    "bafybeibbigbsvqdf2smkd33c34psvcljxfkexvbpismeumiy7r3mkuhtai",
 						"height": int64(3),
 					},
 					{
 						// "Age" field head -1
-						"cid":    "bafybeieufqlniob4m5abilofa7iewl3mheykvordbhuhi5g4ewszmxnfvi",
+						"cid":    "bafybeihu5onq2trqv25zieyejrnj6kyh2533i3rchvq64kahbjz7uzrquu",
 						"height": int64(2),
 					},
 				},
@@ -195,22 +195,22 @@ func TestQueryCommitsWithDepth1AndMultipleDocs(t *testing.T) {
 					}`,
 				Results: []map[string]any{
 					{
-						"cid": "bafybeiasu5mdp6652oux4avwugv6gbd6ciqqsuj2zjv4ypksmiwndgwkeq",
+						"cid": "bafybeihzfcx7als6w6qxy76lcxdxs6yepdxt7fmhcqmkgm3s2vjjokcdaq",
 					},
 					{
-						"cid": "bafybeia7shc4tpafpzblxqjyxmb7fayegsvaol3p2ucujaawig3wtopibu",
+						"cid": "bafybeiffaln23wx47mcfhvzgiuuyqfjto2r32hjjrd2kq5hzce72vwdixy",
 					},
 					{
-						"cid": "bafybeifwn57hy5m5rddplfxdomes34ykck775yvinc522nowspkvawqr6q",
+						"cid": "bafybeie3y57zvbpw4pnw7okbj55uneh42ihspp4vjqsqxvr6if4xgwffqq",
 					},
 					{
-						"cid": "bafybeibcr5lkdvcvtr67rpsnvn57hgrhlg36cnmmf7kywjekjodwxytpi4",
+						"cid": "bafybeiagew5ervkxkyz6sezgkrcrhv6towawpbirg6ziouah7lj5eg7lwy",
 					},
 					{
-						"cid": "bafybeifw7cu7uweruypv44on2zupjzolyqvyh4ookoeybkztzys67m4hwi",
+						"cid": "bafybeibsfjpv57libozcmiihs2ixgsoseu752ni6nkeqqv2nhgxgpe7l5m",
 					},
 					{
-						"cid": "bafybeige7qoom3bgjitfisxvhbifou6n4tgguan3ihwbkz5mvbumndeiaa",
+						"cid": "bafybeiaitgizimh6ttm3stfabpwqvg5tvty3j46p6hqbat4w7ippcbw4ky",
 					},
 				},
 			},

--- a/tests/integration/query/commits/with_doc_id_cid_test.go
+++ b/tests/integration/query/commits/with_doc_id_cid_test.go
@@ -103,15 +103,15 @@ func TestQueryCommitsWithDocIDAndCidWithUpdate(t *testing.T) {
 			testUtils.Request{
 				Request: ` {
 						commits(
-							dockey: "bae-f54b9689-e06e-5e3a-89b3-f3aee8e64ca7",
-							cid: "bafybeiagew5ervkxkyz6sezgkrcrhv6towawpbirg6ziouah7lj5eg7lwy"
+							docID: "bae-f54b9689-e06e-5e3a-89b3-f3aee8e64ca7",
+							cid: "bafybeibfwqf5szatmlyl3alru4nq3gnxaiyyb3ggqung2jwb4qnm6mejyu"
 						) {
 							cid
 						}
 					}`,
 				Results: []map[string]any{
 					{
-						"cid": "bafybeiagew5ervkxkyz6sezgkrcrhv6towawpbirg6ziouah7lj5eg7lwy",
+						"cid": "bafybeibfwqf5szatmlyl3alru4nq3gnxaiyyb3ggqung2jwb4qnm6mejyu",
 					},
 				},
 			},

--- a/tests/integration/query/commits/with_doc_id_cid_test.go
+++ b/tests/integration/query/commits/with_doc_id_cid_test.go
@@ -103,15 +103,15 @@ func TestQueryCommitsWithDocIDAndCidWithUpdate(t *testing.T) {
 			testUtils.Request{
 				Request: ` {
 						commits(
-							docID: "bae-f54b9689-e06e-5e3a-89b3-f3aee8e64ca7",
-							cid: "bafybeibybndrw4dida2m2mlwfl42i56pwoxna6ztansrvya4ikejd63kju"
+							dockey: "bae-f54b9689-e06e-5e3a-89b3-f3aee8e64ca7",
+							cid: "bafybeiagew5ervkxkyz6sezgkrcrhv6towawpbirg6ziouah7lj5eg7lwy"
 						) {
 							cid
 						}
 					}`,
 				Results: []map[string]any{
 					{
-						"cid": "bafybeibybndrw4dida2m2mlwfl42i56pwoxna6ztansrvya4ikejd63kju",
+						"cid": "bafybeiagew5ervkxkyz6sezgkrcrhv6towawpbirg6ziouah7lj5eg7lwy",
 					},
 				},
 			},

--- a/tests/integration/query/commits/with_doc_id_count_test.go
+++ b/tests/integration/query/commits/with_doc_id_count_test.go
@@ -37,15 +37,15 @@ func TestQueryCommitsWithDocIDAndLinkCount(t *testing.T) {
 					}`,
 				Results: []map[string]any{
 					{
-						"cid":    "bafybeiagew5ervkxkyz6sezgkrcrhv6towawpbirg6ziouah7lj5eg7lwy",
+						"cid":    "bafybeihfw5lufgs7ygv45to5rqvt3xkecjgikoccjyx6y2i7lnaclmrcjm",
 						"_count": 0,
 					},
 					{
-						"cid":    "bafybeibsfjpv57libozcmiihs2ixgsoseu752ni6nkeqqv2nhgxgpe7l5m",
+						"cid":    "bafybeigmez6gtszsqx6aevzlanvpazhhezw5va4wizhqtqz5k4s2dqjb24",
 						"_count": 0,
 					},
 					{
-						"cid":    "bafybeiaitgizimh6ttm3stfabpwqvg5tvty3j46p6hqbat4w7ippcbw4ky",
+						"cid":    "bafybeiedu23doqe2nagdbmkvfyuouajnfxo7ezy57vbv34dqewhwbfg45u",
 						"_count": 2,
 					},
 				},

--- a/tests/integration/query/commits/with_doc_id_count_test.go
+++ b/tests/integration/query/commits/with_doc_id_count_test.go
@@ -37,15 +37,15 @@ func TestQueryCommitsWithDocIDAndLinkCount(t *testing.T) {
 					}`,
 				Results: []map[string]any{
 					{
-						"cid":    "bafybeibcr5lkdvcvtr67rpsnvn57hgrhlg36cnmmf7kywjekjodwxytpi4",
+						"cid":    "bafybeiagew5ervkxkyz6sezgkrcrhv6towawpbirg6ziouah7lj5eg7lwy",
 						"_count": 0,
 					},
 					{
-						"cid":    "bafybeifw7cu7uweruypv44on2zupjzolyqvyh4ookoeybkztzys67m4hwi",
+						"cid":    "bafybeibsfjpv57libozcmiihs2ixgsoseu752ni6nkeqqv2nhgxgpe7l5m",
 						"_count": 0,
 					},
 					{
-						"cid":    "bafybeige7qoom3bgjitfisxvhbifou6n4tgguan3ihwbkz5mvbumndeiaa",
+						"cid":    "bafybeiaitgizimh6ttm3stfabpwqvg5tvty3j46p6hqbat4w7ippcbw4ky",
 						"_count": 2,
 					},
 				},

--- a/tests/integration/query/commits/with_doc_id_field_test.go
+++ b/tests/integration/query/commits/with_doc_id_field_test.go
@@ -118,7 +118,7 @@ func TestQueryCommitsWithDocIDAndFieldId(t *testing.T) {
 					}`,
 				Results: []map[string]any{
 					{
-						"cid": "bafybeibcr5lkdvcvtr67rpsnvn57hgrhlg36cnmmf7kywjekjodwxytpi4",
+						"cid": "bafybeiagew5ervkxkyz6sezgkrcrhv6towawpbirg6ziouah7lj5eg7lwy",
 					},
 				},
 			},
@@ -150,7 +150,7 @@ func TestQueryCommitsWithDocIDAndCompositeFieldId(t *testing.T) {
 					}`,
 				Results: []map[string]any{
 					{
-						"cid": "bafybeige7qoom3bgjitfisxvhbifou6n4tgguan3ihwbkz5mvbumndeiaa",
+						"cid": "bafybeiaitgizimh6ttm3stfabpwqvg5tvty3j46p6hqbat4w7ippcbw4ky",
 					},
 				},
 			},

--- a/tests/integration/query/commits/with_doc_id_field_test.go
+++ b/tests/integration/query/commits/with_doc_id_field_test.go
@@ -118,7 +118,7 @@ func TestQueryCommitsWithDocIDAndFieldId(t *testing.T) {
 					}`,
 				Results: []map[string]any{
 					{
-						"cid": "bafybeiagew5ervkxkyz6sezgkrcrhv6towawpbirg6ziouah7lj5eg7lwy",
+						"cid": "bafybeihfw5lufgs7ygv45to5rqvt3xkecjgikoccjyx6y2i7lnaclmrcjm",
 					},
 				},
 			},
@@ -150,7 +150,7 @@ func TestQueryCommitsWithDocIDAndCompositeFieldId(t *testing.T) {
 					}`,
 				Results: []map[string]any{
 					{
-						"cid": "bafybeiaitgizimh6ttm3stfabpwqvg5tvty3j46p6hqbat4w7ippcbw4ky",
+						"cid": "bafybeiedu23doqe2nagdbmkvfyuouajnfxo7ezy57vbv34dqewhwbfg45u",
 					},
 				},
 			},

--- a/tests/integration/query/commits/with_doc_id_limit_offset_test.go
+++ b/tests/integration/query/commits/with_doc_id_limit_offset_test.go
@@ -57,10 +57,10 @@ func TestQueryCommitsWithDocIDAndLimitAndOffset(t *testing.T) {
 					}`,
 				Results: []map[string]any{
 					{
-						"cid": "bafybeigzqhl3ckoduvhl7slck4mlgqo6lif5w2nedjlwz7rq3pacodc6t4",
+						"cid": "bafybeihvhr7ke7bjgjixce262544tlo7mdlyuswtgl66zsrxcfc5targjy",
 					},
 					{
-						"cid": "bafybeiblr52xw3xplsat66bwwyfg4pgbh3gei7njmdvomodf2qygt627r4",
+						"cid": "bafybeihqgrwnhc4w7e5cbhycxvqrpzgi2ei4xrcsre2plceclptgn4tc3i",
 					},
 				},
 			},

--- a/tests/integration/query/commits/with_doc_id_limit_offset_test.go
+++ b/tests/integration/query/commits/with_doc_id_limit_offset_test.go
@@ -57,10 +57,10 @@ func TestQueryCommitsWithDocIDAndLimitAndOffset(t *testing.T) {
 					}`,
 				Results: []map[string]any{
 					{
-						"cid": "bafybeifj3dw2wehaabwmrkcmebj3xyyujlp32sycydd3wfjszx3bfxglfu",
+						"cid": "bafybeigzqhl3ckoduvhl7slck4mlgqo6lif5w2nedjlwz7rq3pacodc6t4",
 					},
 					{
-						"cid": "bafybeibybndrw4dida2m2mlwfl42i56pwoxna6ztansrvya4ikejd63kju",
+						"cid": "bafybeiblr52xw3xplsat66bwwyfg4pgbh3gei7njmdvomodf2qygt627r4",
 					},
 				},
 			},

--- a/tests/integration/query/commits/with_doc_id_limit_test.go
+++ b/tests/integration/query/commits/with_doc_id_limit_test.go
@@ -50,10 +50,10 @@ func TestQueryCommitsWithDocIDAndLimit(t *testing.T) {
 					}`,
 				Results: []map[string]any{
 					{
-						"cid": "bafybeifj3dw2wehaabwmrkcmebj3xyyujlp32sycydd3wfjszx3bfxglfu",
+						"cid": "bafybeigzqhl3ckoduvhl7slck4mlgqo6lif5w2nedjlwz7rq3pacodc6t4",
 					},
 					{
-						"cid": "bafybeibybndrw4dida2m2mlwfl42i56pwoxna6ztansrvya4ikejd63kju",
+						"cid": "bafybeiblr52xw3xplsat66bwwyfg4pgbh3gei7njmdvomodf2qygt627r4",
 					},
 				},
 			},

--- a/tests/integration/query/commits/with_doc_id_limit_test.go
+++ b/tests/integration/query/commits/with_doc_id_limit_test.go
@@ -50,10 +50,10 @@ func TestQueryCommitsWithDocIDAndLimit(t *testing.T) {
 					}`,
 				Results: []map[string]any{
 					{
-						"cid": "bafybeigzqhl3ckoduvhl7slck4mlgqo6lif5w2nedjlwz7rq3pacodc6t4",
+						"cid": "bafybeihvhr7ke7bjgjixce262544tlo7mdlyuswtgl66zsrxcfc5targjy",
 					},
 					{
-						"cid": "bafybeiblr52xw3xplsat66bwwyfg4pgbh3gei7njmdvomodf2qygt627r4",
+						"cid": "bafybeihqgrwnhc4w7e5cbhycxvqrpzgi2ei4xrcsre2plceclptgn4tc3i",
 					},
 				},
 			},

--- a/tests/integration/query/commits/with_doc_id_order_limit_offset_test.go
+++ b/tests/integration/query/commits/with_doc_id_order_limit_offset_test.go
@@ -58,11 +58,11 @@ func TestQueryCommitsWithDocIDAndOrderAndLimitAndOffset(t *testing.T) {
 					}`,
 				Results: []map[string]any{
 					{
-						"cid":    "bafybeieufqlniob4m5abilofa7iewl3mheykvordbhuhi5g4ewszmxnfvi",
+						"cid":    "bafybeihu5onq2trqv25zieyejrnj6kyh2533i3rchvq64kahbjz7uzrquu",
 						"height": int64(2),
 					},
 					{
-						"cid":    "bafybeifj3dw2wehaabwmrkcmebj3xyyujlp32sycydd3wfjszx3bfxglfu",
+						"cid":    "bafybeigzqhl3ckoduvhl7slck4mlgqo6lif5w2nedjlwz7rq3pacodc6t4",
 						"height": int64(3),
 					},
 				},

--- a/tests/integration/query/commits/with_doc_id_order_limit_offset_test.go
+++ b/tests/integration/query/commits/with_doc_id_order_limit_offset_test.go
@@ -58,11 +58,11 @@ func TestQueryCommitsWithDocIDAndOrderAndLimitAndOffset(t *testing.T) {
 					}`,
 				Results: []map[string]any{
 					{
-						"cid":    "bafybeihu5onq2trqv25zieyejrnj6kyh2533i3rchvq64kahbjz7uzrquu",
+						"cid":    "bafybeibfwqf5szatmlyl3alru4nq3gnxaiyyb3ggqung2jwb4qnm6mejyu",
 						"height": int64(2),
 					},
 					{
-						"cid":    "bafybeigzqhl3ckoduvhl7slck4mlgqo6lif5w2nedjlwz7rq3pacodc6t4",
+						"cid":    "bafybeihvhr7ke7bjgjixce262544tlo7mdlyuswtgl66zsrxcfc5targjy",
 						"height": int64(3),
 					},
 				},

--- a/tests/integration/query/commits/with_doc_id_order_test.go
+++ b/tests/integration/query/commits/with_doc_id_order_test.go
@@ -44,23 +44,23 @@ func TestQueryCommitsWithDocIDAndOrderHeightDesc(t *testing.T) {
 					}`,
 				Results: []map[string]any{
 					{
-						"cid":    "bafybeiblr52xw3xplsat66bwwyfg4pgbh3gei7njmdvomodf2qygt627r4",
+						"cid":    "bafybeihqgrwnhc4w7e5cbhycxvqrpzgi2ei4xrcsre2plceclptgn4tc3i",
 						"height": int64(2),
 					},
 					{
-						"cid":    "bafybeihu5onq2trqv25zieyejrnj6kyh2533i3rchvq64kahbjz7uzrquu",
+						"cid":    "bafybeibfwqf5szatmlyl3alru4nq3gnxaiyyb3ggqung2jwb4qnm6mejyu",
 						"height": int64(2),
 					},
 					{
-						"cid":    "bafybeiagew5ervkxkyz6sezgkrcrhv6towawpbirg6ziouah7lj5eg7lwy",
+						"cid":    "bafybeihfw5lufgs7ygv45to5rqvt3xkecjgikoccjyx6y2i7lnaclmrcjm",
 						"height": int64(1),
 					},
 					{
-						"cid":    "bafybeibsfjpv57libozcmiihs2ixgsoseu752ni6nkeqqv2nhgxgpe7l5m",
+						"cid":    "bafybeigmez6gtszsqx6aevzlanvpazhhezw5va4wizhqtqz5k4s2dqjb24",
 						"height": int64(1),
 					},
 					{
-						"cid":    "bafybeiaitgizimh6ttm3stfabpwqvg5tvty3j46p6hqbat4w7ippcbw4ky",
+						"cid":    "bafybeiedu23doqe2nagdbmkvfyuouajnfxo7ezy57vbv34dqewhwbfg45u",
 						"height": int64(1),
 					},
 				},
@@ -99,23 +99,23 @@ func TestQueryCommitsWithDocIDAndOrderHeightAsc(t *testing.T) {
 					}`,
 				Results: []map[string]any{
 					{
-						"cid":    "bafybeiagew5ervkxkyz6sezgkrcrhv6towawpbirg6ziouah7lj5eg7lwy",
+						"cid":    "bafybeihfw5lufgs7ygv45to5rqvt3xkecjgikoccjyx6y2i7lnaclmrcjm",
 						"height": int64(1),
 					},
 					{
-						"cid":    "bafybeibsfjpv57libozcmiihs2ixgsoseu752ni6nkeqqv2nhgxgpe7l5m",
+						"cid":    "bafybeigmez6gtszsqx6aevzlanvpazhhezw5va4wizhqtqz5k4s2dqjb24",
 						"height": int64(1),
 					},
 					{
-						"cid":    "bafybeiaitgizimh6ttm3stfabpwqvg5tvty3j46p6hqbat4w7ippcbw4ky",
+						"cid":    "bafybeiedu23doqe2nagdbmkvfyuouajnfxo7ezy57vbv34dqewhwbfg45u",
 						"height": int64(1),
 					},
 					{
-						"cid":    "bafybeiblr52xw3xplsat66bwwyfg4pgbh3gei7njmdvomodf2qygt627r4",
+						"cid":    "bafybeihqgrwnhc4w7e5cbhycxvqrpzgi2ei4xrcsre2plceclptgn4tc3i",
 						"height": int64(2),
 					},
 					{
-						"cid":    "bafybeihu5onq2trqv25zieyejrnj6kyh2533i3rchvq64kahbjz7uzrquu",
+						"cid":    "bafybeibfwqf5szatmlyl3alru4nq3gnxaiyyb3ggqung2jwb4qnm6mejyu",
 						"height": int64(2),
 					},
 				},
@@ -154,24 +154,24 @@ func TestQueryCommitsWithDocIDAndOrderCidDesc(t *testing.T) {
 					}`,
 				Results: []map[string]any{
 					{
-						"cid":    "bafybeihu5onq2trqv25zieyejrnj6kyh2533i3rchvq64kahbjz7uzrquu",
+						"cid":    "bafybeihqgrwnhc4w7e5cbhycxvqrpzgi2ei4xrcsre2plceclptgn4tc3i",
 						"height": int64(2),
 					},
 					{
-						"cid":    "bafybeibsfjpv57libozcmiihs2ixgsoseu752ni6nkeqqv2nhgxgpe7l5m",
+						"cid":    "bafybeihfw5lufgs7ygv45to5rqvt3xkecjgikoccjyx6y2i7lnaclmrcjm",
 						"height": int64(1),
 					},
 					{
-						"cid":    "bafybeiblr52xw3xplsat66bwwyfg4pgbh3gei7njmdvomodf2qygt627r4",
+						"cid":    "bafybeigmez6gtszsqx6aevzlanvpazhhezw5va4wizhqtqz5k4s2dqjb24",
+						"height": int64(1),
+					},
+					{
+						"cid":    "bafybeiedu23doqe2nagdbmkvfyuouajnfxo7ezy57vbv34dqewhwbfg45u",
+						"height": int64(1),
+					},
+					{
+						"cid":    "bafybeibfwqf5szatmlyl3alru4nq3gnxaiyyb3ggqung2jwb4qnm6mejyu",
 						"height": int64(2),
-					},
-					{
-						"cid":    "bafybeiaitgizimh6ttm3stfabpwqvg5tvty3j46p6hqbat4w7ippcbw4ky",
-						"height": int64(1),
-					},
-					{
-						"cid":    "bafybeiagew5ervkxkyz6sezgkrcrhv6towawpbirg6ziouah7lj5eg7lwy",
-						"height": int64(1),
 					},
 				},
 			},
@@ -209,23 +209,23 @@ func TestQueryCommitsWithDocIDAndOrderCidAsc(t *testing.T) {
 					}`,
 				Results: []map[string]any{
 					{
-						"cid":    "bafybeiagew5ervkxkyz6sezgkrcrhv6towawpbirg6ziouah7lj5eg7lwy",
-						"height": int64(1),
-					},
-					{
-						"cid":    "bafybeiaitgizimh6ttm3stfabpwqvg5tvty3j46p6hqbat4w7ippcbw4ky",
-						"height": int64(1),
-					},
-					{
-						"cid":    "bafybeiblr52xw3xplsat66bwwyfg4pgbh3gei7njmdvomodf2qygt627r4",
+						"cid":    "bafybeibfwqf5szatmlyl3alru4nq3gnxaiyyb3ggqung2jwb4qnm6mejyu",
 						"height": int64(2),
 					},
 					{
-						"cid":    "bafybeibsfjpv57libozcmiihs2ixgsoseu752ni6nkeqqv2nhgxgpe7l5m",
+						"cid":    "bafybeiedu23doqe2nagdbmkvfyuouajnfxo7ezy57vbv34dqewhwbfg45u",
 						"height": int64(1),
 					},
 					{
-						"cid":    "bafybeihu5onq2trqv25zieyejrnj6kyh2533i3rchvq64kahbjz7uzrquu",
+						"cid":    "bafybeigmez6gtszsqx6aevzlanvpazhhezw5va4wizhqtqz5k4s2dqjb24",
+						"height": int64(1),
+					},
+					{
+						"cid":    "bafybeihfw5lufgs7ygv45to5rqvt3xkecjgikoccjyx6y2i7lnaclmrcjm",
+						"height": int64(1),
+					},
+					{
+						"cid":    "bafybeihqgrwnhc4w7e5cbhycxvqrpzgi2ei4xrcsre2plceclptgn4tc3i",
 						"height": int64(2),
 					},
 				},
@@ -278,39 +278,39 @@ func TestQueryCommitsWithDocIDAndOrderAndMultiUpdatesCidAsc(t *testing.T) {
 					 }`,
 				Results: []map[string]any{
 					{
-						"cid":    "bafybeiagew5ervkxkyz6sezgkrcrhv6towawpbirg6ziouah7lj5eg7lwy",
+						"cid":    "bafybeihfw5lufgs7ygv45to5rqvt3xkecjgikoccjyx6y2i7lnaclmrcjm",
 						"height": int64(1),
 					},
 					{
-						"cid":    "bafybeibsfjpv57libozcmiihs2ixgsoseu752ni6nkeqqv2nhgxgpe7l5m",
+						"cid":    "bafybeigmez6gtszsqx6aevzlanvpazhhezw5va4wizhqtqz5k4s2dqjb24",
 						"height": int64(1),
 					},
 					{
-						"cid":    "bafybeiaitgizimh6ttm3stfabpwqvg5tvty3j46p6hqbat4w7ippcbw4ky",
+						"cid":    "bafybeiedu23doqe2nagdbmkvfyuouajnfxo7ezy57vbv34dqewhwbfg45u",
 						"height": int64(1),
 					},
 					{
-						"cid":    "bafybeiblr52xw3xplsat66bwwyfg4pgbh3gei7njmdvomodf2qygt627r4",
+						"cid":    "bafybeihqgrwnhc4w7e5cbhycxvqrpzgi2ei4xrcsre2plceclptgn4tc3i",
 						"height": int64(2),
 					},
 					{
-						"cid":    "bafybeihu5onq2trqv25zieyejrnj6kyh2533i3rchvq64kahbjz7uzrquu",
+						"cid":    "bafybeibfwqf5szatmlyl3alru4nq3gnxaiyyb3ggqung2jwb4qnm6mejyu",
 						"height": int64(2),
 					},
 					{
-						"cid":    "bafybeigzqhl3ckoduvhl7slck4mlgqo6lif5w2nedjlwz7rq3pacodc6t4",
+						"cid":    "bafybeihvhr7ke7bjgjixce262544tlo7mdlyuswtgl66zsrxcfc5targjy",
 						"height": int64(3),
 					},
 					{
-						"cid":    "bafybeibbigbsvqdf2smkd33c34psvcljxfkexvbpismeumiy7r3mkuhtai",
+						"cid":    "bafybeicacrvck5qf37pk3pdsiavvxy2jk67dbdpww5pvoun2k52lw2ftqi",
 						"height": int64(3),
 					},
 					{
-						"cid":    "bafybeifxmvyhbhn5r7bndk3ihddi3f57c5ud46lhdsdiiampczkp63wrt4",
+						"cid":    "bafybeicv72yzbkdmp5r32eesxcna7rqyuhwoovg66kkivclzji3onbwm3a",
 						"height": int64(4),
 					},
 					{
-						"cid":    "bafybeigraptlxmhowk7we2mx552baukqlyijlovj6oqqczf5jb473vjbla",
+						"cid":    "bafybeicf36fznyghq3spknjabxrp72kf66khrzscco3rnyat3ezaufhon4",
 						"height": int64(4),
 					},
 				},

--- a/tests/integration/query/commits/with_doc_id_order_test.go
+++ b/tests/integration/query/commits/with_doc_id_order_test.go
@@ -44,23 +44,23 @@ func TestQueryCommitsWithDocIDAndOrderHeightDesc(t *testing.T) {
 					}`,
 				Results: []map[string]any{
 					{
-						"cid":    "bafybeibybndrw4dida2m2mlwfl42i56pwoxna6ztansrvya4ikejd63kju",
+						"cid":    "bafybeiblr52xw3xplsat66bwwyfg4pgbh3gei7njmdvomodf2qygt627r4",
 						"height": int64(2),
 					},
 					{
-						"cid":    "bafybeieufqlniob4m5abilofa7iewl3mheykvordbhuhi5g4ewszmxnfvi",
+						"cid":    "bafybeihu5onq2trqv25zieyejrnj6kyh2533i3rchvq64kahbjz7uzrquu",
 						"height": int64(2),
 					},
 					{
-						"cid":    "bafybeibcr5lkdvcvtr67rpsnvn57hgrhlg36cnmmf7kywjekjodwxytpi4",
+						"cid":    "bafybeiagew5ervkxkyz6sezgkrcrhv6towawpbirg6ziouah7lj5eg7lwy",
 						"height": int64(1),
 					},
 					{
-						"cid":    "bafybeifw7cu7uweruypv44on2zupjzolyqvyh4ookoeybkztzys67m4hwi",
+						"cid":    "bafybeibsfjpv57libozcmiihs2ixgsoseu752ni6nkeqqv2nhgxgpe7l5m",
 						"height": int64(1),
 					},
 					{
-						"cid":    "bafybeige7qoom3bgjitfisxvhbifou6n4tgguan3ihwbkz5mvbumndeiaa",
+						"cid":    "bafybeiaitgizimh6ttm3stfabpwqvg5tvty3j46p6hqbat4w7ippcbw4ky",
 						"height": int64(1),
 					},
 				},
@@ -99,23 +99,23 @@ func TestQueryCommitsWithDocIDAndOrderHeightAsc(t *testing.T) {
 					}`,
 				Results: []map[string]any{
 					{
-						"cid":    "bafybeibcr5lkdvcvtr67rpsnvn57hgrhlg36cnmmf7kywjekjodwxytpi4",
+						"cid":    "bafybeiagew5ervkxkyz6sezgkrcrhv6towawpbirg6ziouah7lj5eg7lwy",
 						"height": int64(1),
 					},
 					{
-						"cid":    "bafybeifw7cu7uweruypv44on2zupjzolyqvyh4ookoeybkztzys67m4hwi",
+						"cid":    "bafybeibsfjpv57libozcmiihs2ixgsoseu752ni6nkeqqv2nhgxgpe7l5m",
 						"height": int64(1),
 					},
 					{
-						"cid":    "bafybeige7qoom3bgjitfisxvhbifou6n4tgguan3ihwbkz5mvbumndeiaa",
+						"cid":    "bafybeiaitgizimh6ttm3stfabpwqvg5tvty3j46p6hqbat4w7ippcbw4ky",
 						"height": int64(1),
 					},
 					{
-						"cid":    "bafybeibybndrw4dida2m2mlwfl42i56pwoxna6ztansrvya4ikejd63kju",
+						"cid":    "bafybeiblr52xw3xplsat66bwwyfg4pgbh3gei7njmdvomodf2qygt627r4",
 						"height": int64(2),
 					},
 					{
-						"cid":    "bafybeieufqlniob4m5abilofa7iewl3mheykvordbhuhi5g4ewszmxnfvi",
+						"cid":    "bafybeihu5onq2trqv25zieyejrnj6kyh2533i3rchvq64kahbjz7uzrquu",
 						"height": int64(2),
 					},
 				},
@@ -154,23 +154,23 @@ func TestQueryCommitsWithDocIDAndOrderCidDesc(t *testing.T) {
 					}`,
 				Results: []map[string]any{
 					{
-						"cid":    "bafybeige7qoom3bgjitfisxvhbifou6n4tgguan3ihwbkz5mvbumndeiaa",
-						"height": int64(1),
-					},
-					{
-						"cid":    "bafybeifw7cu7uweruypv44on2zupjzolyqvyh4ookoeybkztzys67m4hwi",
-						"height": int64(1),
-					},
-					{
-						"cid":    "bafybeieufqlniob4m5abilofa7iewl3mheykvordbhuhi5g4ewszmxnfvi",
+						"cid":    "bafybeihu5onq2trqv25zieyejrnj6kyh2533i3rchvq64kahbjz7uzrquu",
 						"height": int64(2),
 					},
 					{
-						"cid":    "bafybeibybndrw4dida2m2mlwfl42i56pwoxna6ztansrvya4ikejd63kju",
+						"cid":    "bafybeibsfjpv57libozcmiihs2ixgsoseu752ni6nkeqqv2nhgxgpe7l5m",
+						"height": int64(1),
+					},
+					{
+						"cid":    "bafybeiblr52xw3xplsat66bwwyfg4pgbh3gei7njmdvomodf2qygt627r4",
 						"height": int64(2),
 					},
 					{
-						"cid":    "bafybeibcr5lkdvcvtr67rpsnvn57hgrhlg36cnmmf7kywjekjodwxytpi4",
+						"cid":    "bafybeiaitgizimh6ttm3stfabpwqvg5tvty3j46p6hqbat4w7ippcbw4ky",
+						"height": int64(1),
+					},
+					{
+						"cid":    "bafybeiagew5ervkxkyz6sezgkrcrhv6towawpbirg6ziouah7lj5eg7lwy",
 						"height": int64(1),
 					},
 				},
@@ -209,24 +209,24 @@ func TestQueryCommitsWithDocIDAndOrderCidAsc(t *testing.T) {
 					}`,
 				Results: []map[string]any{
 					{
-						"cid":    "bafybeibcr5lkdvcvtr67rpsnvn57hgrhlg36cnmmf7kywjekjodwxytpi4",
+						"cid":    "bafybeiagew5ervkxkyz6sezgkrcrhv6towawpbirg6ziouah7lj5eg7lwy",
 						"height": int64(1),
 					},
 					{
-						"cid":    "bafybeibybndrw4dida2m2mlwfl42i56pwoxna6ztansrvya4ikejd63kju",
+						"cid":    "bafybeiaitgizimh6ttm3stfabpwqvg5tvty3j46p6hqbat4w7ippcbw4ky",
+						"height": int64(1),
+					},
+					{
+						"cid":    "bafybeiblr52xw3xplsat66bwwyfg4pgbh3gei7njmdvomodf2qygt627r4",
 						"height": int64(2),
 					},
 					{
-						"cid":    "bafybeieufqlniob4m5abilofa7iewl3mheykvordbhuhi5g4ewszmxnfvi",
+						"cid":    "bafybeibsfjpv57libozcmiihs2ixgsoseu752ni6nkeqqv2nhgxgpe7l5m",
+						"height": int64(1),
+					},
+					{
+						"cid":    "bafybeihu5onq2trqv25zieyejrnj6kyh2533i3rchvq64kahbjz7uzrquu",
 						"height": int64(2),
-					},
-					{
-						"cid":    "bafybeifw7cu7uweruypv44on2zupjzolyqvyh4ookoeybkztzys67m4hwi",
-						"height": int64(1),
-					},
-					{
-						"cid":    "bafybeige7qoom3bgjitfisxvhbifou6n4tgguan3ihwbkz5mvbumndeiaa",
-						"height": int64(1),
 					},
 				},
 			},
@@ -278,39 +278,39 @@ func TestQueryCommitsWithDocIDAndOrderAndMultiUpdatesCidAsc(t *testing.T) {
 					 }`,
 				Results: []map[string]any{
 					{
-						"cid":    "bafybeibcr5lkdvcvtr67rpsnvn57hgrhlg36cnmmf7kywjekjodwxytpi4",
+						"cid":    "bafybeiagew5ervkxkyz6sezgkrcrhv6towawpbirg6ziouah7lj5eg7lwy",
 						"height": int64(1),
 					},
 					{
-						"cid":    "bafybeifw7cu7uweruypv44on2zupjzolyqvyh4ookoeybkztzys67m4hwi",
+						"cid":    "bafybeibsfjpv57libozcmiihs2ixgsoseu752ni6nkeqqv2nhgxgpe7l5m",
 						"height": int64(1),
 					},
 					{
-						"cid":    "bafybeige7qoom3bgjitfisxvhbifou6n4tgguan3ihwbkz5mvbumndeiaa",
+						"cid":    "bafybeiaitgizimh6ttm3stfabpwqvg5tvty3j46p6hqbat4w7ippcbw4ky",
 						"height": int64(1),
 					},
 					{
-						"cid":    "bafybeibybndrw4dida2m2mlwfl42i56pwoxna6ztansrvya4ikejd63kju",
+						"cid":    "bafybeiblr52xw3xplsat66bwwyfg4pgbh3gei7njmdvomodf2qygt627r4",
 						"height": int64(2),
 					},
 					{
-						"cid":    "bafybeieufqlniob4m5abilofa7iewl3mheykvordbhuhi5g4ewszmxnfvi",
+						"cid":    "bafybeihu5onq2trqv25zieyejrnj6kyh2533i3rchvq64kahbjz7uzrquu",
 						"height": int64(2),
 					},
 					{
-						"cid":    "bafybeifj3dw2wehaabwmrkcmebj3xyyujlp32sycydd3wfjszx3bfxglfu",
+						"cid":    "bafybeigzqhl3ckoduvhl7slck4mlgqo6lif5w2nedjlwz7rq3pacodc6t4",
 						"height": int64(3),
 					},
 					{
-						"cid":    "bafybeieirgdstog2griwuuxgb4c3frgka55yoodjwdznraoieqcxfdijw4",
+						"cid":    "bafybeibbigbsvqdf2smkd33c34psvcljxfkexvbpismeumiy7r3mkuhtai",
 						"height": int64(3),
 					},
 					{
-						"cid":    "bafybeidoph22zh2c4kh2tx5qbg62nbrulvald6w5hgvp5x5rjurdbz3ibi",
+						"cid":    "bafybeifxmvyhbhn5r7bndk3ihddi3f57c5ud46lhdsdiiampczkp63wrt4",
 						"height": int64(4),
 					},
 					{
-						"cid":    "bafybeiacs2yvfbjgk3xfz5zgt43gswo4jhreieenwkb4whpstjas5cpbdy",
+						"cid":    "bafybeigraptlxmhowk7we2mx552baukqlyijlovj6oqqczf5jb473vjbla",
 						"height": int64(4),
 					},
 				},

--- a/tests/integration/query/commits/with_doc_id_test.go
+++ b/tests/integration/query/commits/with_doc_id_test.go
@@ -62,13 +62,13 @@ func TestQueryCommitsWithDocID(t *testing.T) {
 					}`,
 				Results: []map[string]any{
 					{
-						"cid": "bafybeibcr5lkdvcvtr67rpsnvn57hgrhlg36cnmmf7kywjekjodwxytpi4",
+						"cid": "bafybeiagew5ervkxkyz6sezgkrcrhv6towawpbirg6ziouah7lj5eg7lwy",
 					},
 					{
-						"cid": "bafybeifw7cu7uweruypv44on2zupjzolyqvyh4ookoeybkztzys67m4hwi",
+						"cid": "bafybeibsfjpv57libozcmiihs2ixgsoseu752ni6nkeqqv2nhgxgpe7l5m",
 					},
 					{
-						"cid": "bafybeige7qoom3bgjitfisxvhbifou6n4tgguan3ihwbkz5mvbumndeiaa",
+						"cid": "bafybeiaitgizimh6ttm3stfabpwqvg5tvty3j46p6hqbat4w7ippcbw4ky",
 					},
 				},
 			},
@@ -102,22 +102,22 @@ func TestQueryCommitsWithDocIDAndLinks(t *testing.T) {
 					}`,
 				Results: []map[string]any{
 					{
-						"cid":   "bafybeibcr5lkdvcvtr67rpsnvn57hgrhlg36cnmmf7kywjekjodwxytpi4",
+						"cid":   "bafybeiagew5ervkxkyz6sezgkrcrhv6towawpbirg6ziouah7lj5eg7lwy",
 						"links": []map[string]any{},
 					},
 					{
-						"cid":   "bafybeifw7cu7uweruypv44on2zupjzolyqvyh4ookoeybkztzys67m4hwi",
+						"cid":   "bafybeibsfjpv57libozcmiihs2ixgsoseu752ni6nkeqqv2nhgxgpe7l5m",
 						"links": []map[string]any{},
 					},
 					{
-						"cid": "bafybeige7qoom3bgjitfisxvhbifou6n4tgguan3ihwbkz5mvbumndeiaa",
+						"cid": "bafybeiaitgizimh6ttm3stfabpwqvg5tvty3j46p6hqbat4w7ippcbw4ky",
 						"links": []map[string]any{
 							{
-								"cid":  "bafybeibcr5lkdvcvtr67rpsnvn57hgrhlg36cnmmf7kywjekjodwxytpi4",
+								"cid":  "bafybeiagew5ervkxkyz6sezgkrcrhv6towawpbirg6ziouah7lj5eg7lwy",
 								"name": "age",
 							},
 							{
-								"cid":  "bafybeifw7cu7uweruypv44on2zupjzolyqvyh4ookoeybkztzys67m4hwi",
+								"cid":  "bafybeibsfjpv57libozcmiihs2ixgsoseu752ni6nkeqqv2nhgxgpe7l5m",
 								"name": "name",
 							},
 						},
@@ -158,23 +158,23 @@ func TestQueryCommitsWithDocIDAndUpdate(t *testing.T) {
 					}`,
 				Results: []map[string]any{
 					{
-						"cid":    "bafybeibybndrw4dida2m2mlwfl42i56pwoxna6ztansrvya4ikejd63kju",
+						"cid":    "bafybeiblr52xw3xplsat66bwwyfg4pgbh3gei7njmdvomodf2qygt627r4",
 						"height": int64(2),
 					},
 					{
-						"cid":    "bafybeibcr5lkdvcvtr67rpsnvn57hgrhlg36cnmmf7kywjekjodwxytpi4",
+						"cid":    "bafybeiagew5ervkxkyz6sezgkrcrhv6towawpbirg6ziouah7lj5eg7lwy",
 						"height": int64(1),
 					},
 					{
-						"cid":    "bafybeifw7cu7uweruypv44on2zupjzolyqvyh4ookoeybkztzys67m4hwi",
+						"cid":    "bafybeibsfjpv57libozcmiihs2ixgsoseu752ni6nkeqqv2nhgxgpe7l5m",
 						"height": int64(1),
 					},
 					{
-						"cid":    "bafybeieufqlniob4m5abilofa7iewl3mheykvordbhuhi5g4ewszmxnfvi",
+						"cid":    "bafybeihu5onq2trqv25zieyejrnj6kyh2533i3rchvq64kahbjz7uzrquu",
 						"height": int64(2),
 					},
 					{
-						"cid":    "bafybeige7qoom3bgjitfisxvhbifou6n4tgguan3ihwbkz5mvbumndeiaa",
+						"cid":    "bafybeiaitgizimh6ttm3stfabpwqvg5tvty3j46p6hqbat4w7ippcbw4ky",
 						"height": int64(1),
 					},
 				},
@@ -219,44 +219,44 @@ func TestQueryCommitsWithDocIDAndUpdateAndLinks(t *testing.T) {
 					}`,
 				Results: []map[string]any{
 					{
-						"cid": "bafybeibybndrw4dida2m2mlwfl42i56pwoxna6ztansrvya4ikejd63kju",
+						"cid": "bafybeiblr52xw3xplsat66bwwyfg4pgbh3gei7njmdvomodf2qygt627r4",
 						"links": []map[string]any{
 							{
-								"cid":  "bafybeibcr5lkdvcvtr67rpsnvn57hgrhlg36cnmmf7kywjekjodwxytpi4",
+								"cid":  "bafybeiagew5ervkxkyz6sezgkrcrhv6towawpbirg6ziouah7lj5eg7lwy",
 								"name": "_head",
 							},
 						},
 					},
 					{
-						"cid":   "bafybeibcr5lkdvcvtr67rpsnvn57hgrhlg36cnmmf7kywjekjodwxytpi4",
+						"cid":   "bafybeiagew5ervkxkyz6sezgkrcrhv6towawpbirg6ziouah7lj5eg7lwy",
 						"links": []map[string]any{},
 					},
 					{
-						"cid":   "bafybeifw7cu7uweruypv44on2zupjzolyqvyh4ookoeybkztzys67m4hwi",
+						"cid":   "bafybeibsfjpv57libozcmiihs2ixgsoseu752ni6nkeqqv2nhgxgpe7l5m",
 						"links": []map[string]any{},
 					},
 					{
-						"cid": "bafybeieufqlniob4m5abilofa7iewl3mheykvordbhuhi5g4ewszmxnfvi",
+						"cid": "bafybeihu5onq2trqv25zieyejrnj6kyh2533i3rchvq64kahbjz7uzrquu",
 						"links": []map[string]any{
 							{
-								"cid":  "bafybeige7qoom3bgjitfisxvhbifou6n4tgguan3ihwbkz5mvbumndeiaa",
+								"cid":  "bafybeiaitgizimh6ttm3stfabpwqvg5tvty3j46p6hqbat4w7ippcbw4ky",
 								"name": "_head",
 							},
 							{
-								"cid":  "bafybeibybndrw4dida2m2mlwfl42i56pwoxna6ztansrvya4ikejd63kju",
+								"cid":  "bafybeiblr52xw3xplsat66bwwyfg4pgbh3gei7njmdvomodf2qygt627r4",
 								"name": "age",
 							},
 						},
 					},
 					{
-						"cid": "bafybeige7qoom3bgjitfisxvhbifou6n4tgguan3ihwbkz5mvbumndeiaa",
+						"cid": "bafybeiaitgizimh6ttm3stfabpwqvg5tvty3j46p6hqbat4w7ippcbw4ky",
 						"links": []map[string]any{
 							{
-								"cid":  "bafybeibcr5lkdvcvtr67rpsnvn57hgrhlg36cnmmf7kywjekjodwxytpi4",
+								"cid":  "bafybeiagew5ervkxkyz6sezgkrcrhv6towawpbirg6ziouah7lj5eg7lwy",
 								"name": "age",
 							},
 							{
-								"cid":  "bafybeifw7cu7uweruypv44on2zupjzolyqvyh4ookoeybkztzys67m4hwi",
+								"cid":  "bafybeibsfjpv57libozcmiihs2ixgsoseu752ni6nkeqqv2nhgxgpe7l5m",
 								"name": "name",
 							},
 						},

--- a/tests/integration/query/commits/with_doc_id_test.go
+++ b/tests/integration/query/commits/with_doc_id_test.go
@@ -62,13 +62,13 @@ func TestQueryCommitsWithDocID(t *testing.T) {
 					}`,
 				Results: []map[string]any{
 					{
-						"cid": "bafybeiagew5ervkxkyz6sezgkrcrhv6towawpbirg6ziouah7lj5eg7lwy",
+						"cid": "bafybeihfw5lufgs7ygv45to5rqvt3xkecjgikoccjyx6y2i7lnaclmrcjm",
 					},
 					{
-						"cid": "bafybeibsfjpv57libozcmiihs2ixgsoseu752ni6nkeqqv2nhgxgpe7l5m",
+						"cid": "bafybeigmez6gtszsqx6aevzlanvpazhhezw5va4wizhqtqz5k4s2dqjb24",
 					},
 					{
-						"cid": "bafybeiaitgizimh6ttm3stfabpwqvg5tvty3j46p6hqbat4w7ippcbw4ky",
+						"cid": "bafybeiedu23doqe2nagdbmkvfyuouajnfxo7ezy57vbv34dqewhwbfg45u",
 					},
 				},
 			},
@@ -102,22 +102,22 @@ func TestQueryCommitsWithDocIDAndLinks(t *testing.T) {
 					}`,
 				Results: []map[string]any{
 					{
-						"cid":   "bafybeiagew5ervkxkyz6sezgkrcrhv6towawpbirg6ziouah7lj5eg7lwy",
+						"cid":   "bafybeihfw5lufgs7ygv45to5rqvt3xkecjgikoccjyx6y2i7lnaclmrcjm",
 						"links": []map[string]any{},
 					},
 					{
-						"cid":   "bafybeibsfjpv57libozcmiihs2ixgsoseu752ni6nkeqqv2nhgxgpe7l5m",
+						"cid":   "bafybeigmez6gtszsqx6aevzlanvpazhhezw5va4wizhqtqz5k4s2dqjb24",
 						"links": []map[string]any{},
 					},
 					{
-						"cid": "bafybeiaitgizimh6ttm3stfabpwqvg5tvty3j46p6hqbat4w7ippcbw4ky",
+						"cid": "bafybeiedu23doqe2nagdbmkvfyuouajnfxo7ezy57vbv34dqewhwbfg45u",
 						"links": []map[string]any{
 							{
-								"cid":  "bafybeiagew5ervkxkyz6sezgkrcrhv6towawpbirg6ziouah7lj5eg7lwy",
+								"cid":  "bafybeihfw5lufgs7ygv45to5rqvt3xkecjgikoccjyx6y2i7lnaclmrcjm",
 								"name": "age",
 							},
 							{
-								"cid":  "bafybeibsfjpv57libozcmiihs2ixgsoseu752ni6nkeqqv2nhgxgpe7l5m",
+								"cid":  "bafybeigmez6gtszsqx6aevzlanvpazhhezw5va4wizhqtqz5k4s2dqjb24",
 								"name": "name",
 							},
 						},
@@ -158,23 +158,23 @@ func TestQueryCommitsWithDocIDAndUpdate(t *testing.T) {
 					}`,
 				Results: []map[string]any{
 					{
-						"cid":    "bafybeiblr52xw3xplsat66bwwyfg4pgbh3gei7njmdvomodf2qygt627r4",
+						"cid":    "bafybeihqgrwnhc4w7e5cbhycxvqrpzgi2ei4xrcsre2plceclptgn4tc3i",
 						"height": int64(2),
 					},
 					{
-						"cid":    "bafybeiagew5ervkxkyz6sezgkrcrhv6towawpbirg6ziouah7lj5eg7lwy",
+						"cid":    "bafybeihfw5lufgs7ygv45to5rqvt3xkecjgikoccjyx6y2i7lnaclmrcjm",
 						"height": int64(1),
 					},
 					{
-						"cid":    "bafybeibsfjpv57libozcmiihs2ixgsoseu752ni6nkeqqv2nhgxgpe7l5m",
+						"cid":    "bafybeigmez6gtszsqx6aevzlanvpazhhezw5va4wizhqtqz5k4s2dqjb24",
 						"height": int64(1),
 					},
 					{
-						"cid":    "bafybeihu5onq2trqv25zieyejrnj6kyh2533i3rchvq64kahbjz7uzrquu",
+						"cid":    "bafybeibfwqf5szatmlyl3alru4nq3gnxaiyyb3ggqung2jwb4qnm6mejyu",
 						"height": int64(2),
 					},
 					{
-						"cid":    "bafybeiaitgizimh6ttm3stfabpwqvg5tvty3j46p6hqbat4w7ippcbw4ky",
+						"cid":    "bafybeiedu23doqe2nagdbmkvfyuouajnfxo7ezy57vbv34dqewhwbfg45u",
 						"height": int64(1),
 					},
 				},
@@ -219,44 +219,44 @@ func TestQueryCommitsWithDocIDAndUpdateAndLinks(t *testing.T) {
 					}`,
 				Results: []map[string]any{
 					{
-						"cid": "bafybeiblr52xw3xplsat66bwwyfg4pgbh3gei7njmdvomodf2qygt627r4",
+						"cid": "bafybeihqgrwnhc4w7e5cbhycxvqrpzgi2ei4xrcsre2plceclptgn4tc3i",
 						"links": []map[string]any{
 							{
-								"cid":  "bafybeiagew5ervkxkyz6sezgkrcrhv6towawpbirg6ziouah7lj5eg7lwy",
+								"cid":  "bafybeihfw5lufgs7ygv45to5rqvt3xkecjgikoccjyx6y2i7lnaclmrcjm",
 								"name": "_head",
 							},
 						},
 					},
 					{
-						"cid":   "bafybeiagew5ervkxkyz6sezgkrcrhv6towawpbirg6ziouah7lj5eg7lwy",
+						"cid":   "bafybeihfw5lufgs7ygv45to5rqvt3xkecjgikoccjyx6y2i7lnaclmrcjm",
 						"links": []map[string]any{},
 					},
 					{
-						"cid":   "bafybeibsfjpv57libozcmiihs2ixgsoseu752ni6nkeqqv2nhgxgpe7l5m",
+						"cid":   "bafybeigmez6gtszsqx6aevzlanvpazhhezw5va4wizhqtqz5k4s2dqjb24",
 						"links": []map[string]any{},
 					},
 					{
-						"cid": "bafybeihu5onq2trqv25zieyejrnj6kyh2533i3rchvq64kahbjz7uzrquu",
+						"cid": "bafybeibfwqf5szatmlyl3alru4nq3gnxaiyyb3ggqung2jwb4qnm6mejyu",
 						"links": []map[string]any{
 							{
-								"cid":  "bafybeiaitgizimh6ttm3stfabpwqvg5tvty3j46p6hqbat4w7ippcbw4ky",
+								"cid":  "bafybeiedu23doqe2nagdbmkvfyuouajnfxo7ezy57vbv34dqewhwbfg45u",
 								"name": "_head",
 							},
 							{
-								"cid":  "bafybeiblr52xw3xplsat66bwwyfg4pgbh3gei7njmdvomodf2qygt627r4",
+								"cid":  "bafybeihqgrwnhc4w7e5cbhycxvqrpzgi2ei4xrcsre2plceclptgn4tc3i",
 								"name": "age",
 							},
 						},
 					},
 					{
-						"cid": "bafybeiaitgizimh6ttm3stfabpwqvg5tvty3j46p6hqbat4w7ippcbw4ky",
+						"cid": "bafybeiedu23doqe2nagdbmkvfyuouajnfxo7ezy57vbv34dqewhwbfg45u",
 						"links": []map[string]any{
 							{
-								"cid":  "bafybeiagew5ervkxkyz6sezgkrcrhv6towawpbirg6ziouah7lj5eg7lwy",
+								"cid":  "bafybeihfw5lufgs7ygv45to5rqvt3xkecjgikoccjyx6y2i7lnaclmrcjm",
 								"name": "age",
 							},
 							{
-								"cid":  "bafybeibsfjpv57libozcmiihs2ixgsoseu752ni6nkeqqv2nhgxgpe7l5m",
+								"cid":  "bafybeigmez6gtszsqx6aevzlanvpazhhezw5va4wizhqtqz5k4s2dqjb24",
 								"name": "name",
 							},
 						},

--- a/tests/integration/query/commits/with_doc_id_typename_test.go
+++ b/tests/integration/query/commits/with_doc_id_typename_test.go
@@ -37,15 +37,15 @@ func TestQueryCommitsWithDocIDWithTypeName(t *testing.T) {
 					}`,
 				Results: []map[string]any{
 					{
-						"cid":        "bafybeibcr5lkdvcvtr67rpsnvn57hgrhlg36cnmmf7kywjekjodwxytpi4",
+						"cid":        "bafybeiagew5ervkxkyz6sezgkrcrhv6towawpbirg6ziouah7lj5eg7lwy",
 						"__typename": "Commit",
 					},
 					{
-						"cid":        "bafybeifw7cu7uweruypv44on2zupjzolyqvyh4ookoeybkztzys67m4hwi",
+						"cid":        "bafybeibsfjpv57libozcmiihs2ixgsoseu752ni6nkeqqv2nhgxgpe7l5m",
 						"__typename": "Commit",
 					},
 					{
-						"cid":        "bafybeige7qoom3bgjitfisxvhbifou6n4tgguan3ihwbkz5mvbumndeiaa",
+						"cid":        "bafybeiaitgizimh6ttm3stfabpwqvg5tvty3j46p6hqbat4w7ippcbw4ky",
 						"__typename": "Commit",
 					},
 				},

--- a/tests/integration/query/commits/with_doc_id_typename_test.go
+++ b/tests/integration/query/commits/with_doc_id_typename_test.go
@@ -37,15 +37,15 @@ func TestQueryCommitsWithDocIDWithTypeName(t *testing.T) {
 					}`,
 				Results: []map[string]any{
 					{
-						"cid":        "bafybeiagew5ervkxkyz6sezgkrcrhv6towawpbirg6ziouah7lj5eg7lwy",
+						"cid":        "bafybeihfw5lufgs7ygv45to5rqvt3xkecjgikoccjyx6y2i7lnaclmrcjm",
 						"__typename": "Commit",
 					},
 					{
-						"cid":        "bafybeibsfjpv57libozcmiihs2ixgsoseu752ni6nkeqqv2nhgxgpe7l5m",
+						"cid":        "bafybeigmez6gtszsqx6aevzlanvpazhhezw5va4wizhqtqz5k4s2dqjb24",
 						"__typename": "Commit",
 					},
 					{
-						"cid":        "bafybeiaitgizimh6ttm3stfabpwqvg5tvty3j46p6hqbat4w7ippcbw4ky",
+						"cid":        "bafybeiedu23doqe2nagdbmkvfyuouajnfxo7ezy57vbv34dqewhwbfg45u",
 						"__typename": "Commit",
 					},
 				},

--- a/tests/integration/query/commits/with_field_test.go
+++ b/tests/integration/query/commits/with_field_test.go
@@ -66,7 +66,7 @@ func TestQueryCommitsWithFieldId(t *testing.T) {
 					}`,
 				Results: []map[string]any{
 					{
-						"cid": "bafybeibcr5lkdvcvtr67rpsnvn57hgrhlg36cnmmf7kywjekjodwxytpi4",
+						"cid": "bafybeiagew5ervkxkyz6sezgkrcrhv6towawpbirg6ziouah7lj5eg7lwy",
 					},
 				},
 			},
@@ -98,7 +98,7 @@ func TestQueryCommitsWithCompositeFieldId(t *testing.T) {
 					}`,
 				Results: []map[string]any{
 					{
-						"cid": "bafybeige7qoom3bgjitfisxvhbifou6n4tgguan3ihwbkz5mvbumndeiaa",
+						"cid": "bafybeiaitgizimh6ttm3stfabpwqvg5tvty3j46p6hqbat4w7ippcbw4ky",
 					},
 				},
 			},
@@ -131,8 +131,8 @@ func TestQueryCommitsWithCompositeFieldIdWithReturnedSchemaVersionId(t *testing.
 					}`,
 				Results: []map[string]any{
 					{
-						"cid":             "bafybeige7qoom3bgjitfisxvhbifou6n4tgguan3ihwbkz5mvbumndeiaa",
-						"schemaVersionId": "bafkreiayhdsgzhmrz6t5d3x2cgqqbdjt7aqgldtlkmxn5eibg542j3n6ea",
+						"cid":             "bafybeiaitgizimh6ttm3stfabpwqvg5tvty3j46p6hqbat4w7ippcbw4ky",
+						"schemaVersionId": "bafkreictcre4pylafzzoh5lpgbetdodunz4r6pz3ormdzzpsz2lqtp4v34",
 					},
 				},
 			},

--- a/tests/integration/query/commits/with_field_test.go
+++ b/tests/integration/query/commits/with_field_test.go
@@ -66,7 +66,7 @@ func TestQueryCommitsWithFieldId(t *testing.T) {
 					}`,
 				Results: []map[string]any{
 					{
-						"cid": "bafybeiagew5ervkxkyz6sezgkrcrhv6towawpbirg6ziouah7lj5eg7lwy",
+						"cid": "bafybeihfw5lufgs7ygv45to5rqvt3xkecjgikoccjyx6y2i7lnaclmrcjm",
 					},
 				},
 			},
@@ -98,7 +98,7 @@ func TestQueryCommitsWithCompositeFieldId(t *testing.T) {
 					}`,
 				Results: []map[string]any{
 					{
-						"cid": "bafybeiaitgizimh6ttm3stfabpwqvg5tvty3j46p6hqbat4w7ippcbw4ky",
+						"cid": "bafybeiedu23doqe2nagdbmkvfyuouajnfxo7ezy57vbv34dqewhwbfg45u",
 					},
 				},
 			},
@@ -131,8 +131,8 @@ func TestQueryCommitsWithCompositeFieldIdWithReturnedSchemaVersionId(t *testing.
 					}`,
 				Results: []map[string]any{
 					{
-						"cid":             "bafybeiaitgizimh6ttm3stfabpwqvg5tvty3j46p6hqbat4w7ippcbw4ky",
-						"schemaVersionId": "bafkreictcre4pylafzzoh5lpgbetdodunz4r6pz3ormdzzpsz2lqtp4v34",
+						"cid":             "bafybeiedu23doqe2nagdbmkvfyuouajnfxo7ezy57vbv34dqewhwbfg45u",
+						"schemaVersionId": "bafkreiayhdsgzhmrz6t5d3x2cgqqbdjt7aqgldtlkmxn5eibg542j3n6ea",
 					},
 				},
 			},

--- a/tests/integration/query/commits/with_group_test.go
+++ b/tests/integration/query/commits/with_group_test.go
@@ -89,10 +89,10 @@ func TestQueryCommitsWithGroupByHeightWithChild(t *testing.T) {
 						"height": int64(2),
 						"_group": []map[string]any{
 							{
-								"cid": "bafybeibybndrw4dida2m2mlwfl42i56pwoxna6ztansrvya4ikejd63kju",
+								"cid": "bafybeiblr52xw3xplsat66bwwyfg4pgbh3gei7njmdvomodf2qygt627r4",
 							},
 							{
-								"cid": "bafybeieufqlniob4m5abilofa7iewl3mheykvordbhuhi5g4ewszmxnfvi",
+								"cid": "bafybeihu5onq2trqv25zieyejrnj6kyh2533i3rchvq64kahbjz7uzrquu",
 							},
 						},
 					},
@@ -100,13 +100,13 @@ func TestQueryCommitsWithGroupByHeightWithChild(t *testing.T) {
 						"height": int64(1),
 						"_group": []map[string]any{
 							{
-								"cid": "bafybeibcr5lkdvcvtr67rpsnvn57hgrhlg36cnmmf7kywjekjodwxytpi4",
+								"cid": "bafybeiagew5ervkxkyz6sezgkrcrhv6towawpbirg6ziouah7lj5eg7lwy",
 							},
 							{
-								"cid": "bafybeifw7cu7uweruypv44on2zupjzolyqvyh4ookoeybkztzys67m4hwi",
+								"cid": "bafybeibsfjpv57libozcmiihs2ixgsoseu752ni6nkeqqv2nhgxgpe7l5m",
 							},
 							{
-								"cid": "bafybeige7qoom3bgjitfisxvhbifou6n4tgguan3ihwbkz5mvbumndeiaa",
+								"cid": "bafybeiaitgizimh6ttm3stfabpwqvg5tvty3j46p6hqbat4w7ippcbw4ky",
 							},
 						},
 					},
@@ -142,7 +142,7 @@ func TestQueryCommitsWithGroupByCidWithChild(t *testing.T) {
 					}`,
 				Results: []map[string]any{
 					{
-						"cid": "bafybeibcr5lkdvcvtr67rpsnvn57hgrhlg36cnmmf7kywjekjodwxytpi4",
+						"cid": "bafybeiagew5ervkxkyz6sezgkrcrhv6towawpbirg6ziouah7lj5eg7lwy",
 						"_group": []map[string]any{
 							{
 								"height": int64(1),
@@ -150,7 +150,7 @@ func TestQueryCommitsWithGroupByCidWithChild(t *testing.T) {
 						},
 					},
 					{
-						"cid": "bafybeifw7cu7uweruypv44on2zupjzolyqvyh4ookoeybkztzys67m4hwi",
+						"cid": "bafybeibsfjpv57libozcmiihs2ixgsoseu752ni6nkeqqv2nhgxgpe7l5m",
 						"_group": []map[string]any{
 							{
 								"height": int64(1),
@@ -158,7 +158,7 @@ func TestQueryCommitsWithGroupByCidWithChild(t *testing.T) {
 						},
 					},
 					{
-						"cid": "bafybeige7qoom3bgjitfisxvhbifou6n4tgguan3ihwbkz5mvbumndeiaa",
+						"cid": "bafybeiaitgizimh6ttm3stfabpwqvg5tvty3j46p6hqbat4w7ippcbw4ky",
 						"_group": []map[string]any{
 							{
 								"height": int64(1),

--- a/tests/integration/query/commits/with_group_test.go
+++ b/tests/integration/query/commits/with_group_test.go
@@ -89,10 +89,10 @@ func TestQueryCommitsWithGroupByHeightWithChild(t *testing.T) {
 						"height": int64(2),
 						"_group": []map[string]any{
 							{
-								"cid": "bafybeiblr52xw3xplsat66bwwyfg4pgbh3gei7njmdvomodf2qygt627r4",
+								"cid": "bafybeihqgrwnhc4w7e5cbhycxvqrpzgi2ei4xrcsre2plceclptgn4tc3i",
 							},
 							{
-								"cid": "bafybeihu5onq2trqv25zieyejrnj6kyh2533i3rchvq64kahbjz7uzrquu",
+								"cid": "bafybeibfwqf5szatmlyl3alru4nq3gnxaiyyb3ggqung2jwb4qnm6mejyu",
 							},
 						},
 					},
@@ -100,13 +100,13 @@ func TestQueryCommitsWithGroupByHeightWithChild(t *testing.T) {
 						"height": int64(1),
 						"_group": []map[string]any{
 							{
-								"cid": "bafybeiagew5ervkxkyz6sezgkrcrhv6towawpbirg6ziouah7lj5eg7lwy",
+								"cid": "bafybeihfw5lufgs7ygv45to5rqvt3xkecjgikoccjyx6y2i7lnaclmrcjm",
 							},
 							{
-								"cid": "bafybeibsfjpv57libozcmiihs2ixgsoseu752ni6nkeqqv2nhgxgpe7l5m",
+								"cid": "bafybeigmez6gtszsqx6aevzlanvpazhhezw5va4wizhqtqz5k4s2dqjb24",
 							},
 							{
-								"cid": "bafybeiaitgizimh6ttm3stfabpwqvg5tvty3j46p6hqbat4w7ippcbw4ky",
+								"cid": "bafybeiedu23doqe2nagdbmkvfyuouajnfxo7ezy57vbv34dqewhwbfg45u",
 							},
 						},
 					},
@@ -142,7 +142,7 @@ func TestQueryCommitsWithGroupByCidWithChild(t *testing.T) {
 					}`,
 				Results: []map[string]any{
 					{
-						"cid": "bafybeiagew5ervkxkyz6sezgkrcrhv6towawpbirg6ziouah7lj5eg7lwy",
+						"cid": "bafybeihfw5lufgs7ygv45to5rqvt3xkecjgikoccjyx6y2i7lnaclmrcjm",
 						"_group": []map[string]any{
 							{
 								"height": int64(1),
@@ -150,7 +150,7 @@ func TestQueryCommitsWithGroupByCidWithChild(t *testing.T) {
 						},
 					},
 					{
-						"cid": "bafybeibsfjpv57libozcmiihs2ixgsoseu752ni6nkeqqv2nhgxgpe7l5m",
+						"cid": "bafybeigmez6gtszsqx6aevzlanvpazhhezw5va4wizhqtqz5k4s2dqjb24",
 						"_group": []map[string]any{
 							{
 								"height": int64(1),
@@ -158,7 +158,7 @@ func TestQueryCommitsWithGroupByCidWithChild(t *testing.T) {
 						},
 					},
 					{
-						"cid": "bafybeiaitgizimh6ttm3stfabpwqvg5tvty3j46p6hqbat4w7ippcbw4ky",
+						"cid": "bafybeiedu23doqe2nagdbmkvfyuouajnfxo7ezy57vbv34dqewhwbfg45u",
 						"_group": []map[string]any{
 							{
 								"height": int64(1),

--- a/tests/integration/query/latest_commits/with_doc_id_field_test.go
+++ b/tests/integration/query/latest_commits/with_doc_id_field_test.go
@@ -68,7 +68,7 @@ func TestQueryLatestCommitsWithDocIDAndFieldId(t *testing.T) {
 		},
 		Results: []map[string]any{
 			{
-				"cid":   "bafybeibcr5lkdvcvtr67rpsnvn57hgrhlg36cnmmf7kywjekjodwxytpi4",
+				"cid":   "bafybeiagew5ervkxkyz6sezgkrcrhv6towawpbirg6ziouah7lj5eg7lwy",
 				"links": []map[string]any{},
 			},
 		},
@@ -101,14 +101,14 @@ func TestQueryLatestCommitsWithDocIDAndCompositeFieldId(t *testing.T) {
 		},
 		Results: []map[string]any{
 			{
-				"cid": "bafybeige7qoom3bgjitfisxvhbifou6n4tgguan3ihwbkz5mvbumndeiaa",
+				"cid": "bafybeiaitgizimh6ttm3stfabpwqvg5tvty3j46p6hqbat4w7ippcbw4ky",
 				"links": []map[string]any{
 					{
-						"cid":  "bafybeibcr5lkdvcvtr67rpsnvn57hgrhlg36cnmmf7kywjekjodwxytpi4",
+						"cid":  "bafybeiagew5ervkxkyz6sezgkrcrhv6towawpbirg6ziouah7lj5eg7lwy",
 						"name": "age",
 					},
 					{
-						"cid":  "bafybeifw7cu7uweruypv44on2zupjzolyqvyh4ookoeybkztzys67m4hwi",
+						"cid":  "bafybeibsfjpv57libozcmiihs2ixgsoseu752ni6nkeqqv2nhgxgpe7l5m",
 						"name": "name",
 					},
 				},

--- a/tests/integration/query/latest_commits/with_doc_id_field_test.go
+++ b/tests/integration/query/latest_commits/with_doc_id_field_test.go
@@ -68,7 +68,7 @@ func TestQueryLatestCommitsWithDocIDAndFieldId(t *testing.T) {
 		},
 		Results: []map[string]any{
 			{
-				"cid":   "bafybeiagew5ervkxkyz6sezgkrcrhv6towawpbirg6ziouah7lj5eg7lwy",
+				"cid":   "bafybeihfw5lufgs7ygv45to5rqvt3xkecjgikoccjyx6y2i7lnaclmrcjm",
 				"links": []map[string]any{},
 			},
 		},
@@ -101,14 +101,14 @@ func TestQueryLatestCommitsWithDocIDAndCompositeFieldId(t *testing.T) {
 		},
 		Results: []map[string]any{
 			{
-				"cid": "bafybeiaitgizimh6ttm3stfabpwqvg5tvty3j46p6hqbat4w7ippcbw4ky",
+				"cid": "bafybeiedu23doqe2nagdbmkvfyuouajnfxo7ezy57vbv34dqewhwbfg45u",
 				"links": []map[string]any{
 					{
-						"cid":  "bafybeiagew5ervkxkyz6sezgkrcrhv6towawpbirg6ziouah7lj5eg7lwy",
+						"cid":  "bafybeihfw5lufgs7ygv45to5rqvt3xkecjgikoccjyx6y2i7lnaclmrcjm",
 						"name": "age",
 					},
 					{
-						"cid":  "bafybeibsfjpv57libozcmiihs2ixgsoseu752ni6nkeqqv2nhgxgpe7l5m",
+						"cid":  "bafybeigmez6gtszsqx6aevzlanvpazhhezw5va4wizhqtqz5k4s2dqjb24",
 						"name": "name",
 					},
 				},

--- a/tests/integration/query/latest_commits/with_doc_id_test.go
+++ b/tests/integration/query/latest_commits/with_doc_id_test.go
@@ -38,14 +38,14 @@ func TestQueryLatestCommitsWithDocID(t *testing.T) {
 		},
 		Results: []map[string]any{
 			{
-				"cid": "bafybeiaitgizimh6ttm3stfabpwqvg5tvty3j46p6hqbat4w7ippcbw4ky",
+				"cid": "bafybeiedu23doqe2nagdbmkvfyuouajnfxo7ezy57vbv34dqewhwbfg45u",
 				"links": []map[string]any{
 					{
-						"cid":  "bafybeiagew5ervkxkyz6sezgkrcrhv6towawpbirg6ziouah7lj5eg7lwy",
+						"cid":  "bafybeihfw5lufgs7ygv45to5rqvt3xkecjgikoccjyx6y2i7lnaclmrcjm",
 						"name": "age",
 					},
 					{
-						"cid":  "bafybeibsfjpv57libozcmiihs2ixgsoseu752ni6nkeqqv2nhgxgpe7l5m",
+						"cid":  "bafybeigmez6gtszsqx6aevzlanvpazhhezw5va4wizhqtqz5k4s2dqjb24",
 						"name": "name",
 					},
 				},
@@ -75,8 +75,8 @@ func TestQueryLatestCommitsWithDocIDWithSchemaVersionIdField(t *testing.T) {
 		},
 		Results: []map[string]any{
 			{
-				"cid":             "bafybeiaitgizimh6ttm3stfabpwqvg5tvty3j46p6hqbat4w7ippcbw4ky",
-				"schemaVersionId": "bafkreictcre4pylafzzoh5lpgbetdodunz4r6pz3ormdzzpsz2lqtp4v34",
+				"cid":             "bafybeiedu23doqe2nagdbmkvfyuouajnfxo7ezy57vbv34dqewhwbfg45u",
+				"schemaVersionId": "bafkreiayhdsgzhmrz6t5d3x2cgqqbdjt7aqgldtlkmxn5eibg542j3n6ea",
 			},
 		},
 	}

--- a/tests/integration/query/latest_commits/with_doc_id_test.go
+++ b/tests/integration/query/latest_commits/with_doc_id_test.go
@@ -38,14 +38,14 @@ func TestQueryLatestCommitsWithDocID(t *testing.T) {
 		},
 		Results: []map[string]any{
 			{
-				"cid": "bafybeige7qoom3bgjitfisxvhbifou6n4tgguan3ihwbkz5mvbumndeiaa",
+				"cid": "bafybeiaitgizimh6ttm3stfabpwqvg5tvty3j46p6hqbat4w7ippcbw4ky",
 				"links": []map[string]any{
 					{
-						"cid":  "bafybeibcr5lkdvcvtr67rpsnvn57hgrhlg36cnmmf7kywjekjodwxytpi4",
+						"cid":  "bafybeiagew5ervkxkyz6sezgkrcrhv6towawpbirg6ziouah7lj5eg7lwy",
 						"name": "age",
 					},
 					{
-						"cid":  "bafybeifw7cu7uweruypv44on2zupjzolyqvyh4ookoeybkztzys67m4hwi",
+						"cid":  "bafybeibsfjpv57libozcmiihs2ixgsoseu752ni6nkeqqv2nhgxgpe7l5m",
 						"name": "name",
 					},
 				},
@@ -75,8 +75,8 @@ func TestQueryLatestCommitsWithDocIDWithSchemaVersionIdField(t *testing.T) {
 		},
 		Results: []map[string]any{
 			{
-				"cid":             "bafybeige7qoom3bgjitfisxvhbifou6n4tgguan3ihwbkz5mvbumndeiaa",
-				"schemaVersionId": "bafkreiayhdsgzhmrz6t5d3x2cgqqbdjt7aqgldtlkmxn5eibg542j3n6ea",
+				"cid":             "bafybeiaitgizimh6ttm3stfabpwqvg5tvty3j46p6hqbat4w7ippcbw4ky",
+				"schemaVersionId": "bafkreictcre4pylafzzoh5lpgbetdodunz4r6pz3ormdzzpsz2lqtp4v34",
 			},
 		},
 	}

--- a/tests/integration/query/one_to_many/with_cid_doc_id_test.go
+++ b/tests/integration/query/one_to_many/with_cid_doc_id_test.go
@@ -68,7 +68,7 @@ func TestQueryOneToManyWithCidAndDocID(t *testing.T) {
 		Description: "One-to-many relation query from one side with  cid and docID",
 		Request: `query {
 					Book (
-							cid: "bafybeiddywe5odj47ljhyslzey3kbmw3yqdzsstqqjh3ge6cliy2unty64"
+							cid: "bafybeidli5zshe4xpipe26hrgrxjgi2x24bquerqmrpqvu7net3sldjsru"
 							docID: "bae-b9b83269-1f28-5c3b-ae75-3fb4c00d559d"
 						) {
 						name
@@ -117,7 +117,7 @@ func TestQueryOneToManyWithChildUpdateAndFirstCidAndDocID(t *testing.T) {
 		Description: "One-to-many relation query from one side with child update and parent cid and docID",
 		Request: `query {
 					Book (
-							cid: "bafybeiddywe5odj47ljhyslzey3kbmw3yqdzsstqqjh3ge6cliy2unty64",
+							cid: "bafybeidli5zshe4xpipe26hrgrxjgi2x24bquerqmrpqvu7net3sldjsru",
 							docID: "bae-b9b83269-1f28-5c3b-ae75-3fb4c00d559d"
 						) {
 						name
@@ -173,7 +173,7 @@ func TestQueryOneToManyWithParentUpdateAndFirstCidAndDocID(t *testing.T) {
 		Description: "One-to-many relation query from one side with parent update and parent cid and docID",
 		Request: `query {
 					Book (
-							cid: "bafybeie2okvnf3w3767gspsnln5d6n54hvnmu65wjkadxciopwoi6gxqha",
+							cid: "bafybeidli5zshe4xpipe26hrgrxjgi2x24bquerqmrpqvu7net3sldjsru",
 							docID: "bae-b9b83269-1f28-5c3b-ae75-3fb4c00d559d"
 						) {
 						name
@@ -225,7 +225,7 @@ func TestQueryOneToManyWithParentUpdateAndLastCidAndDocID(t *testing.T) {
 		Description: "One-to-many relation query from one side with parent update and parent cid and docID",
 		Request: `query {
 					Book (
-							cid: "bafybeie2okvnf3w3767gspsnln5d6n54hvnmu65wjkadxciopwoi6gxqha",
+							cid: "bafybeic3b4g6gmrnslwe6iyiaue3r5jtipzey76ulah3qenfkme6zq2msm",
 							docID: "bae-b9b83269-1f28-5c3b-ae75-3fb4c00d559d"
 						) {
 						name

--- a/tests/integration/query/one_to_many/with_cid_doc_id_test.go
+++ b/tests/integration/query/one_to_many/with_cid_doc_id_test.go
@@ -65,10 +65,10 @@ import (
 
 func TestQueryOneToManyWithCidAndDocID(t *testing.T) {
 	test := testUtils.RequestTestCase{
-		Description: "One-to-many relation query from one side with  cid and docID",
+		Description: "One-to-many relation query from one side with cid and docID",
 		Request: `query {
 					Book (
-							cid: "bafybeidli5zshe4xpipe26hrgrxjgi2x24bquerqmrpqvu7net3sldjsru"
+							cid: "bafybeielrctlwgqx3o5cu3m2636fnfqcizayinyyuemaqhgdgy7ykfhyvi"
 							docID: "bae-b9b83269-1f28-5c3b-ae75-3fb4c00d559d"
 						) {
 						name
@@ -117,7 +117,7 @@ func TestQueryOneToManyWithChildUpdateAndFirstCidAndDocID(t *testing.T) {
 		Description: "One-to-many relation query from one side with child update and parent cid and docID",
 		Request: `query {
 					Book (
-							cid: "bafybeidli5zshe4xpipe26hrgrxjgi2x24bquerqmrpqvu7net3sldjsru",
+							cid: "bafybeielrctlwgqx3o5cu3m2636fnfqcizayinyyuemaqhgdgy7ykfhyvi",
 							docID: "bae-b9b83269-1f28-5c3b-ae75-3fb4c00d559d"
 						) {
 						name
@@ -129,7 +129,7 @@ func TestQueryOneToManyWithChildUpdateAndFirstCidAndDocID(t *testing.T) {
 				}`,
 		Docs: map[int][]string{
 			//books
-			0: { // bae-fd541c25-229e-5280-b44b-e5c2af3e374d
+			0: { // bae-b9b83269-1f28-5c3b-ae75-3fb4c00d559d
 				`{
 					"name": "Painted House",
 					"rating": 4.9,
@@ -173,7 +173,7 @@ func TestQueryOneToManyWithParentUpdateAndFirstCidAndDocID(t *testing.T) {
 		Description: "One-to-many relation query from one side with parent update and parent cid and docID",
 		Request: `query {
 					Book (
-							cid: "bafybeidli5zshe4xpipe26hrgrxjgi2x24bquerqmrpqvu7net3sldjsru",
+							cid: "bafybeiao32zf3tqrtutibbivxhk4fjjhsryb5q4mqyp3gecqp3s5tgegfy",
 							docID: "bae-b9b83269-1f28-5c3b-ae75-3fb4c00d559d"
 						) {
 						name
@@ -225,7 +225,7 @@ func TestQueryOneToManyWithParentUpdateAndLastCidAndDocID(t *testing.T) {
 		Description: "One-to-many relation query from one side with parent update and parent cid and docID",
 		Request: `query {
 					Book (
-							cid: "bafybeic3b4g6gmrnslwe6iyiaue3r5jtipzey76ulah3qenfkme6zq2msm",
+							cid: "bafybeiao32zf3tqrtutibbivxhk4fjjhsryb5q4mqyp3gecqp3s5tgegfy",
 							docID: "bae-b9b83269-1f28-5c3b-ae75-3fb4c00d559d"
 						) {
 						name

--- a/tests/integration/query/simple/with_cid_doc_id_test.go
+++ b/tests/integration/query/simple/with_cid_doc_id_test.go
@@ -73,7 +73,7 @@ func TestQuerySimpleWithCidAndDocID(t *testing.T) {
 		Description: "Simple query with cid and docID",
 		Request: `query {
 					Users (
-							cid: "bafybeiebx4gp6ghqksxq56imktbyefze6bezrd42tco2vqcv2hrx2jstam",
+							cid: "bafybeigwxfw2nfcwelqxzgjsmm5okrt7dctzvzml4tm7i7q7fsdit3ihz4",
 							docID: "bae-52b9170d-b77a-5887-b877-cbdbb99b009f"
 						) {
 						Name
@@ -102,7 +102,7 @@ func TestQuerySimpleWithUpdateAndFirstCidAndDocID(t *testing.T) {
 		Description: "Simple query with (first) cid and docID",
 		Request: `query {
 					Users (
-							cid: "bafybeiebx4gp6ghqksxq56imktbyefze6bezrd42tco2vqcv2hrx2jstam",
+							cid: "bafybeigwxfw2nfcwelqxzgjsmm5okrt7dctzvzml4tm7i7q7fsdit3ihz4",
 							docID: "bae-52b9170d-b77a-5887-b877-cbdbb99b009f"
 						) {
 						Name
@@ -143,7 +143,7 @@ func TestQuerySimpleWithUpdateAndLastCidAndDocID(t *testing.T) {
 		Description: "Simple query with (last) cid and docID",
 		Request: `query {
 					Users (
-							cid: "bafybeiawyt67laj4wzigasmbwvglrdlpkba5xiagsseealuacrixitizoa"
+							cid: "bafybeigotwnjltl5y5ou5yqxujdayoqet4axspaclbvzustjhinzqx77ym"
 							docID: "bae-52b9170d-b77a-5887-b877-cbdbb99b009f"
 						) {
 						Name
@@ -184,7 +184,7 @@ func TestQuerySimpleWithUpdateAndMiddleCidAndDocID(t *testing.T) {
 		Description: "Simple query with (middle) cid and docID",
 		Request: `query {
 					Users (
-							cid: "bafybeibg345u3ea7fq7hupjtz34w5tq3ffb4j6owygv6j33hfmgnj4tx64",
+							cid: "bafybeib4cdjv4dxmayzgf242hx2r3v5tq5ib5z6oyyrzk3dtddt3wsyyhi",
 							docID: "bae-52b9170d-b77a-5887-b877-cbdbb99b009f"
 						) {
 						Name
@@ -224,8 +224,8 @@ func TestQuerySimpleWithUpdateAndFirstCidAndDocIDAndSchemaVersion(t *testing.T) 
 	test := testUtils.RequestTestCase{
 		Description: "Simple query with (first) cid and docID and yielded schema version",
 		Request: `query {
-					Users (
-							cid: "bafybeiebx4gp6ghqksxq56imktbyefze6bezrd42tco2vqcv2hrx2jstam",
+					Users (					
+							cid: "bafybeigwxfw2nfcwelqxzgjsmm5okrt7dctzvzml4tm7i7q7fsdit3ihz4",
 							docID: "bae-52b9170d-b77a-5887-b877-cbdbb99b009f"
 						) {
 						Name
@@ -269,9 +269,9 @@ func TestQuerySimpleWithUpdateAndFirstCidAndDocIDAndSchemaVersion(t *testing.T) 
 	executeTestCase(t, test)
 }
 
-func TestCidAndDocKeyQuery_ContainsPNCounterWithIntKind_NoError(t *testing.T) {
+func TestCidAndDocIDQuery_ContainsPNCounterWithIntKind_NoError(t *testing.T) {
 	test := testUtils.TestCase{
-		Description: "Simple query with second last cid and dockey with pncounter int type",
+		Description: "Simple query with second last cid and docID with pncounter int type",
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
@@ -300,8 +300,8 @@ func TestCidAndDocKeyQuery_ContainsPNCounterWithIntKind_NoError(t *testing.T) {
 			testUtils.Request{
 				Request: `query {
 					Users (
-						cid: "bafybeiemzwrx7jotpqjzajfmu2gi2o7h35yptgehihbdyoxkmzox4coetm",
-						dockey: "bae-a688789e-d8a6-57a7-be09-22e005ab79e0"
+						cid: "bafybeiabh6mqnysyrv5phhjikjyl5zgxnpxzxogpip7s7knyujkh7fx3qu",
+						docID: "bae-a688789e-d8a6-57a7-be09-22e005ab79e0"
 					) {
 						name
 						points
@@ -320,9 +320,9 @@ func TestCidAndDocKeyQuery_ContainsPNCounterWithIntKind_NoError(t *testing.T) {
 	testUtils.ExecuteTestCase(t, test)
 }
 
-func TestCidAndDocKeyQuery_ContainsPNCounterWithFloatKind_NoError(t *testing.T) {
+func TestCidAndDocIDQuery_ContainsPNCounterWithFloatKind_NoError(t *testing.T) {
 	test := testUtils.TestCase{
-		Description: "Simple query with second last cid and dockey with pncounter and float type",
+		Description: "Simple query with second last cid and docID with pncounter and float type",
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
@@ -351,8 +351,8 @@ func TestCidAndDocKeyQuery_ContainsPNCounterWithFloatKind_NoError(t *testing.T) 
 			testUtils.Request{
 				Request: `query {
 					Users (
-						cid: "bafybeidanfj4emzh4izmij5bwocgnecpvolx2b77il4mtwyrucvmgueyp4",
-						dockey: "bae-fa6a97e9-e0e9-5826-8a8c-57775d35e07c"
+						cid: "bafybeiaqw6oxeshkvd3ilzzagjy3c6h776l3hqvmz5loq4sokr7tlxkm5m",
+						docID: "bae-fa6a97e9-e0e9-5826-8a8c-57775d35e07c"
 					) {
 						name
 						points

--- a/tests/integration/query/simple/with_cid_doc_id_test.go
+++ b/tests/integration/query/simple/with_cid_doc_id_test.go
@@ -269,9 +269,9 @@ func TestQuerySimpleWithUpdateAndFirstCidAndDocIDAndSchemaVersion(t *testing.T) 
 	executeTestCase(t, test)
 }
 
-func TestQuerySimple_WithUpdateAndCidAndDocKeyWithPNCounter_NoError(t *testing.T) {
+func TestQuerySimple_WithUpdateAndCidAndDocKeyWithPNCounterInt_NoError(t *testing.T) {
 	test := testUtils.TestCase{
-		Description: "Simple query with second last cid and dockey with pncounter",
+		Description: "Simple query with second last cid and dockey with pncounter int type",
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
@@ -289,7 +289,7 @@ func TestQuerySimple_WithUpdateAndCidAndDocKeyWithPNCounter_NoError(t *testing.T
 			},
 			testUtils.UpdateDoc{
 				Doc: `{
-					"points": 5
+					"points": -5
 				}`,
 			},
 			testUtils.UpdateDoc{
@@ -300,7 +300,7 @@ func TestQuerySimple_WithUpdateAndCidAndDocKeyWithPNCounter_NoError(t *testing.T
 			testUtils.Request{
 				Request: `query {
 					Users (
-						cid: "bafybeib3acmixgdwe5wkx7mb2japn2adg3vlsw4q2o34l4e7baqkqcwmqq",
+						cid: "bafybeiemzwrx7jotpqjzajfmu2gi2o7h35yptgehihbdyoxkmzox4coetm",
 						dockey: "bae-a688789e-d8a6-57a7-be09-22e005ab79e0"
 					) {
 						name
@@ -310,7 +310,59 @@ func TestQuerySimple_WithUpdateAndCidAndDocKeyWithPNCounter_NoError(t *testing.T
 				Results: []map[string]any{
 					{
 						"name":   "John",
-						"points": int64(15),
+						"points": int64(5),
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestQuerySimple_WithUpdateAndCidAndDocKeyWithPNCounterFloat_NoError(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "Simple query with second last cid and dockey with pncounter and float type",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users {
+						name: String
+						points: Float @crdt(type: "pncounter")
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
+					"name": "John",
+					"points": 10.2
+				}`,
+			},
+			testUtils.UpdateDoc{
+				Doc: `{
+					"points": -5.3
+				}`,
+			},
+			testUtils.UpdateDoc{
+				Doc: `{
+					"points": 20.6
+				}`,
+			},
+			testUtils.Request{
+				Request: `query {
+					Users (
+						cid: "bafybeidanfj4emzh4izmij5bwocgnecpvolx2b77il4mtwyrucvmgueyp4",
+						dockey: "bae-fa6a97e9-e0e9-5826-8a8c-57775d35e07c"
+					) {
+						name
+						points
+					}
+				}`,
+				Results: []map[string]any{
+					{
+						"name": "John",
+						// Note the lack of precision of float types.
+						"points": 4.8999999999999995,
 					},
 				},
 			},

--- a/tests/integration/query/simple/with_cid_doc_id_test.go
+++ b/tests/integration/query/simple/with_cid_doc_id_test.go
@@ -73,7 +73,7 @@ func TestQuerySimpleWithCidAndDocID(t *testing.T) {
 		Description: "Simple query with cid and docID",
 		Request: `query {
 					Users (
-		 					cid: "bafybeiealfslrqsbiwotlducidmesjaemiq2hb7y2bxkcwc7bppuceujui",
+							cid: "bafybeiebx4gp6ghqksxq56imktbyefze6bezrd42tco2vqcv2hrx2jstam",
 							docID: "bae-52b9170d-b77a-5887-b877-cbdbb99b009f"
 						) {
 						Name
@@ -102,7 +102,7 @@ func TestQuerySimpleWithUpdateAndFirstCidAndDocID(t *testing.T) {
 		Description: "Simple query with (first) cid and docID",
 		Request: `query {
 					Users (
-		 					cid: "bafybeiealfslrqsbiwotlducidmesjaemiq2hb7y2bxkcwc7bppuceujui",
+							cid: "bafybeiebx4gp6ghqksxq56imktbyefze6bezrd42tco2vqcv2hrx2jstam",
 							docID: "bae-52b9170d-b77a-5887-b877-cbdbb99b009f"
 						) {
 						Name
@@ -143,7 +143,7 @@ func TestQuerySimpleWithUpdateAndLastCidAndDocID(t *testing.T) {
 		Description: "Simple query with (last) cid and docID",
 		Request: `query {
 					Users (
-							cid: "bafybeibnj6yitgmynodaxnvtl22rhzclhsrc5asmocwyccsbsamobibpsy",
+							cid: "bafybeiawyt67laj4wzigasmbwvglrdlpkba5xiagsseealuacrixitizoa"
 							docID: "bae-52b9170d-b77a-5887-b877-cbdbb99b009f"
 						) {
 						Name
@@ -184,7 +184,7 @@ func TestQuerySimpleWithUpdateAndMiddleCidAndDocID(t *testing.T) {
 		Description: "Simple query with (middle) cid and docID",
 		Request: `query {
 					Users (
-							cid: "bafybeify36bauenmsov4rijdmency367boy234mjezpvg4dj6r47ay3jwq",
+							cid: "bafybeibg345u3ea7fq7hupjtz34w5tq3ffb4j6owygv6j33hfmgnj4tx64",
 							docID: "bae-52b9170d-b77a-5887-b877-cbdbb99b009f"
 						) {
 						Name
@@ -224,18 +224,17 @@ func TestQuerySimpleWithUpdateAndFirstCidAndDocIDAndSchemaVersion(t *testing.T) 
 	test := testUtils.RequestTestCase{
 		Description: "Simple query with (first) cid and docID and yielded schema version",
 		Request: `query {
-		 			Users (
-		 					cid: "bafybeiealfslrqsbiwotlducidmesjaemiq2hb7y2bxkcwc7bppuceujui",
-		 					docID: "bae-52b9170d-b77a-5887-b877-cbdbb99b009f"
-		 				) {
-		 				Name
-		 				Age
-		 				_version {
-		 					schemaVersionId
-		 				}
-		 			}
-		 		}`,
-
+					Users (
+							cid: "bafybeiebx4gp6ghqksxq56imktbyefze6bezrd42tco2vqcv2hrx2jstam",
+							docID: "bae-52b9170d-b77a-5887-b877-cbdbb99b009f"
+						) {
+						Name
+						Age
+						_version {
+							schemaVersionId
+						}
+					}
+				}`,
 		Docs: map[int][]string{
 			0: {
 				`{
@@ -301,7 +300,7 @@ func TestQuerySimple_WithUpdateAndCidAndDocKeyWithPNCounter_NoError(t *testing.T
 			testUtils.Request{
 				Request: `query {
 					Users (
-						cid: "bafybeig2hd5p7gmkcpzf45udup63h2mgmaq5kouhdqpfkguyrfnnswexle",
+						cid: "bafybeib3acmixgdwe5wkx7mb2japn2adg3vlsw4q2o34l4e7baqkqcwmqq",
 						dockey: "bae-a688789e-d8a6-57a7-be09-22e005ab79e0"
 					) {
 						name

--- a/tests/integration/query/simple/with_cid_doc_id_test.go
+++ b/tests/integration/query/simple/with_cid_doc_id_test.go
@@ -269,3 +269,54 @@ func TestQuerySimpleWithUpdateAndFirstCidAndDocIDAndSchemaVersion(t *testing.T) 
 
 	executeTestCase(t, test)
 }
+
+func TestQuerySimple_WithUpdateAndCidAndDocKeyWithPNCounter_NoError(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "Simple query with second last cid and dockey with pncounter",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users {
+						name: String
+						points: Int @crdt(type: "pncounter")
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
+					"name": "John",
+					"points": 10
+				}`,
+			},
+			testUtils.UpdateDoc{
+				Doc: `{
+					"points": 5
+				}`,
+			},
+			testUtils.UpdateDoc{
+				Doc: `{
+					"points": 20
+				}`,
+			},
+			testUtils.Request{
+				Request: `query {
+					Users (
+						cid: "bafybeig2hd5p7gmkcpzf45udup63h2mgmaq5kouhdqpfkguyrfnnswexle",
+						dockey: "bae-a688789e-d8a6-57a7-be09-22e005ab79e0"
+					) {
+						name
+						points
+					}
+				}`,
+				Results: []map[string]any{
+					{
+						"name":   "John",
+						"points": int64(15),
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/query/simple/with_cid_doc_id_test.go
+++ b/tests/integration/query/simple/with_cid_doc_id_test.go
@@ -269,7 +269,7 @@ func TestQuerySimpleWithUpdateAndFirstCidAndDocIDAndSchemaVersion(t *testing.T) 
 	executeTestCase(t, test)
 }
 
-func TestQuerySimple_WithUpdateAndCidAndDocKeyWithPNCounterInt_NoError(t *testing.T) {
+func TestCidAndDocKeyQuery_ContainsPNCounterWithIntKind_NoError(t *testing.T) {
 	test := testUtils.TestCase{
 		Description: "Simple query with second last cid and dockey with pncounter int type",
 		Actions: []any{
@@ -320,7 +320,7 @@ func TestQuerySimple_WithUpdateAndCidAndDocKeyWithPNCounterInt_NoError(t *testin
 	testUtils.ExecuteTestCase(t, test)
 }
 
-func TestQuerySimple_WithUpdateAndCidAndDocKeyWithPNCounterFloat_NoError(t *testing.T) {
+func TestCidAndDocKeyQuery_ContainsPNCounterWithFloatKind_NoError(t *testing.T) {
 	test := testUtils.TestCase{
 		Description: "Simple query with second last cid and dockey with pncounter and float type",
 		Actions: []any{

--- a/tests/integration/query/simple/with_version_test.go
+++ b/tests/integration/query/simple/with_version_test.go
@@ -46,14 +46,14 @@ func TestQuerySimpleWithEmbeddedLatestCommit(t *testing.T) {
 				"Age":  int64(21),
 				"_version": []map[string]any{
 					{
-						"cid": "bafybeiealfslrqsbiwotlducidmesjaemiq2hb7y2bxkcwc7bppuceujui",
+						"cid": "bafybeiebx4gp6ghqksxq56imktbyefze6bezrd42tco2vqcv2hrx2jstam",
 						"links": []map[string]any{
 							{
-								"cid":  "bafybeigpazmunkmlf5p5jw6fl4supfslupgp2kksvqr7quvhfhsddfa44e",
+								"cid":  "bafybeigocy6cfqxtdkalprk4lqor5cb4nf2myjecirnmlgqc2gzn6zkn6m",
 								"name": "Age",
 							},
 							{
-								"cid":  "bafybeibxsjz4krbv3jcbobpdm2igdcvunitu332o6ebsxup53wglkyn6ee",
+								"cid":  "bafybeib7tcbqp32cc2supgfw2ky3ufeyy7z474tsecpsy6zxohdvsjmadi",
 								"name": "Name",
 							},
 						},
@@ -171,14 +171,14 @@ func TestQuerySimpleWithMultipleAliasedEmbeddedLatestCommit(t *testing.T) {
 				"Age":  int64(21),
 				"_version": []map[string]any{
 					{
-						"cid": "bafybeiealfslrqsbiwotlducidmesjaemiq2hb7y2bxkcwc7bppuceujui",
+						"cid": "bafybeiebx4gp6ghqksxq56imktbyefze6bezrd42tco2vqcv2hrx2jstam",
 						"L1": []map[string]any{
 							{
-								"cid":  "bafybeigpazmunkmlf5p5jw6fl4supfslupgp2kksvqr7quvhfhsddfa44e",
+								"cid":  "bafybeigocy6cfqxtdkalprk4lqor5cb4nf2myjecirnmlgqc2gzn6zkn6m",
 								"name": "Age",
 							},
 							{
-								"cid":  "bafybeibxsjz4krbv3jcbobpdm2igdcvunitu332o6ebsxup53wglkyn6ee",
+								"cid":  "bafybeib7tcbqp32cc2supgfw2ky3ufeyy7z474tsecpsy6zxohdvsjmadi",
 								"name": "Name",
 							},
 						},

--- a/tests/integration/query/simple/with_version_test.go
+++ b/tests/integration/query/simple/with_version_test.go
@@ -46,14 +46,14 @@ func TestQuerySimpleWithEmbeddedLatestCommit(t *testing.T) {
 				"Age":  int64(21),
 				"_version": []map[string]any{
 					{
-						"cid": "bafybeiebx4gp6ghqksxq56imktbyefze6bezrd42tco2vqcv2hrx2jstam",
+						"cid": "bafybeigwxfw2nfcwelqxzgjsmm5okrt7dctzvzml4tm7i7q7fsdit3ihz4",
 						"links": []map[string]any{
 							{
-								"cid":  "bafybeigocy6cfqxtdkalprk4lqor5cb4nf2myjecirnmlgqc2gzn6zkn6m",
+								"cid":  "bafybeigcmjyt2ux4mzfckbsz5snkoqrr42vfkesgk7rdw6xzblrowrzfg4",
 								"name": "Age",
 							},
 							{
-								"cid":  "bafybeib7tcbqp32cc2supgfw2ky3ufeyy7z474tsecpsy6zxohdvsjmadi",
+								"cid":  "bafybeihkekm4kfn2ttx3wb33l2ps7aductuzd7hrmu6n7zloaicrj5n75u",
 								"name": "Name",
 							},
 						},
@@ -171,14 +171,14 @@ func TestQuerySimpleWithMultipleAliasedEmbeddedLatestCommit(t *testing.T) {
 				"Age":  int64(21),
 				"_version": []map[string]any{
 					{
-						"cid": "bafybeiebx4gp6ghqksxq56imktbyefze6bezrd42tco2vqcv2hrx2jstam",
+						"cid": "bafybeigwxfw2nfcwelqxzgjsmm5okrt7dctzvzml4tm7i7q7fsdit3ihz4",
 						"L1": []map[string]any{
 							{
-								"cid":  "bafybeigocy6cfqxtdkalprk4lqor5cb4nf2myjecirnmlgqc2gzn6zkn6m",
+								"cid":  "bafybeigcmjyt2ux4mzfckbsz5snkoqrr42vfkesgk7rdw6xzblrowrzfg4",
 								"name": "Age",
 							},
 							{
-								"cid":  "bafybeib7tcbqp32cc2supgfw2ky3ufeyy7z474tsecpsy6zxohdvsjmadi",
+								"cid":  "bafybeihkekm4kfn2ttx3wb33l2ps7aductuzd7hrmu6n7zloaicrj5n75u",
 								"name": "Name",
 							},
 						},

--- a/tests/integration/schema/crdt_type_test.go
+++ b/tests/integration/schema/crdt_type_test.go
@@ -19,7 +19,7 @@ import (
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
 )
 
-func TestSchemaCreate_PNCounterType_NoError(t *testing.T) {
+func TestSchemaCreate_PNCounterTypeWithInt_NoError(t *testing.T) {
 	schemaVersionID := "bafkreia444xgvvpyyvxn2m56mgsyovhtrbbx6zpmn4ocnkqbbjnytlfvrm"
 
 	test := testUtils.TestCase{
@@ -47,7 +47,47 @@ func TestSchemaCreate_PNCounterType_NoError(t *testing.T) {
 								Name: "points",
 								ID:   1,
 								Kind: client.FieldKind_INT,
-								Typ:  client.PN_COUNTER_REGISTER,
+								Typ:  client.PN_COUNTER,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestSchemaCreate_PNCounterTypeWithFloat_NoError(t *testing.T) {
+	schemaVersionID := "bafkreiexc2p3oc6vhywrhmyqqxntlgryjjlywtzz42r2ebyzq7mqu5ow2m"
+
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users {
+						points: Float @crdt(type: "pncounter")
+					}
+				`,
+			},
+			testUtils.GetSchema{
+				VersionID: immutable.Some(schemaVersionID),
+				ExpectedResults: []client.SchemaDescription{
+					{
+						Name:      "Users",
+						VersionID: schemaVersionID,
+						Root:      schemaVersionID,
+						Fields: []client.FieldDescription{
+							{
+								Name: "_key",
+								Kind: client.FieldKind_DocKey,
+							},
+							{
+								Name: "points",
+								ID:   1,
+								Kind: client.FieldKind_FLOAT,
+								Typ:  client.PN_COUNTER,
 							},
 						},
 					},
@@ -82,10 +122,10 @@ func TestSchemaCreate_InvalidType_Error(t *testing.T) {
 			testUtils.SchemaUpdate{
 				Schema: `
 					type Users {
-						points: Int @crdt(type: "pn_counter")
+						points: Int @crdt(type: "invalid")
 					}
 				`,
-				ExpectedError: "CRDT type not supported. Name: points, CRDTType: pn_counter",
+				ExpectedError: "CRDT type not supported. Name: points, CRDTType: invalid",
 			},
 		},
 	}

--- a/tests/integration/schema/crdt_type_test.go
+++ b/tests/integration/schema/crdt_type_test.go
@@ -19,7 +19,7 @@ import (
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
 )
 
-func TestSchemaCreate_PNCounterTypeWithInt_NoError(t *testing.T) {
+func TestSchemaCreate_ContainsPNCounterTypeWithIntKind_NoError(t *testing.T) {
 	schemaVersionID := "bafkreia444xgvvpyyvxn2m56mgsyovhtrbbx6zpmn4ocnkqbbjnytlfvrm"
 
 	test := testUtils.TestCase{
@@ -59,7 +59,7 @@ func TestSchemaCreate_PNCounterTypeWithInt_NoError(t *testing.T) {
 	testUtils.ExecuteTestCase(t, test)
 }
 
-func TestSchemaCreate_PNCounterTypeWithFloat_NoError(t *testing.T) {
+func TestSchemaCreate_ContainsPNCounterTypeWithFloatKind_NoError(t *testing.T) {
 	schemaVersionID := "bafkreiexc2p3oc6vhywrhmyqqxntlgryjjlywtzz42r2ebyzq7mqu5ow2m"
 
 	test := testUtils.TestCase{
@@ -99,7 +99,7 @@ func TestSchemaCreate_PNCounterTypeWithFloat_NoError(t *testing.T) {
 	testUtils.ExecuteTestCase(t, test)
 }
 
-func TestSchemaCreate_PNCounterTypeWithWrongKind_Error(t *testing.T) {
+func TestSchemaCreate_ContainsPNCounterTypeWithWrongKind_Error(t *testing.T) {
 	test := testUtils.TestCase{
 		Actions: []any{
 			testUtils.SchemaUpdate{
@@ -116,7 +116,7 @@ func TestSchemaCreate_PNCounterTypeWithWrongKind_Error(t *testing.T) {
 	testUtils.ExecuteTestCase(t, test)
 }
 
-func TestSchemaCreate_InvalidType_Error(t *testing.T) {
+func TestSchemaCreate_ContainsPNCounterWithInvalidType_Error(t *testing.T) {
 	test := testUtils.TestCase{
 		Actions: []any{
 			testUtils.SchemaUpdate{

--- a/tests/integration/schema/crdt_type_test.go
+++ b/tests/integration/schema/crdt_type_test.go
@@ -1,0 +1,94 @@
+// Copyright 2022 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package schema
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/immutable"
+
+	"github.com/sourcenetwork/defradb/client"
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+func TestSchemaCreate_PNCounterType_NoError(t *testing.T) {
+	schemaVersionID := "bafkreia444xgvvpyyvxn2m56mgsyovhtrbbx6zpmn4ocnkqbbjnytlfvrm"
+
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users {
+						points: Int @crdt(type: "pncounter")
+					}
+				`,
+			},
+			testUtils.GetSchema{
+				VersionID: immutable.Some(schemaVersionID),
+				ExpectedResults: []client.SchemaDescription{
+					{
+						Name:      "Users",
+						VersionID: schemaVersionID,
+						Root:      schemaVersionID,
+						Fields: []client.FieldDescription{
+							{
+								Name: "_key",
+								Kind: client.FieldKind_DocKey,
+							},
+							{
+								Name: "points",
+								ID:   1,
+								Kind: client.FieldKind_INT,
+								Typ:  client.PN_COUNTER_REGISTER,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestSchemaCreate_PNCounterTypeWithWrongKind_Error(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users {
+						points: String @crdt(type: "pncounter")
+					}
+				`,
+				ExpectedError: "CRDT type pncounter can't be assigned to field kind String",
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestSchemaCreate_InvalidType_Error(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users {
+						points: Int @crdt(type: "pn_counter")
+					}
+				`,
+				ExpectedError: "CRDT type not supported. Name: points, CRDTType: pn_counter",
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/schema/crdt_type_test.go
+++ b/tests/integration/schema/crdt_type_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func TestSchemaCreate_ContainsPNCounterTypeWithIntKind_NoError(t *testing.T) {
-	schemaVersionID := "bafkreia444xgvvpyyvxn2m56mgsyovhtrbbx6zpmn4ocnkqbbjnytlfvrm"
+	schemaVersionID := "bafkreig54q5pw7elljueepsyux4qgdspm3ozct5dqocr5b2kufpjwb2mae"
 
 	test := testUtils.TestCase{
 		Actions: []any{
@@ -40,8 +40,8 @@ func TestSchemaCreate_ContainsPNCounterTypeWithIntKind_NoError(t *testing.T) {
 						Root:      schemaVersionID,
 						Fields: []client.FieldDescription{
 							{
-								Name: "_key",
-								Kind: client.FieldKind_DocKey,
+								Name: "_docID",
+								Kind: client.FieldKind_DocID,
 							},
 							{
 								Name: "points",
@@ -60,7 +60,7 @@ func TestSchemaCreate_ContainsPNCounterTypeWithIntKind_NoError(t *testing.T) {
 }
 
 func TestSchemaCreate_ContainsPNCounterTypeWithFloatKind_NoError(t *testing.T) {
-	schemaVersionID := "bafkreiexc2p3oc6vhywrhmyqqxntlgryjjlywtzz42r2ebyzq7mqu5ow2m"
+	schemaVersionID := "bafkreibaeypr2i2eg3kozq3mlfsibgtolqlrcozo5ufqfb725dfq3hx43e"
 
 	test := testUtils.TestCase{
 		Actions: []any{
@@ -80,8 +80,8 @@ func TestSchemaCreate_ContainsPNCounterTypeWithFloatKind_NoError(t *testing.T) {
 						Root:      schemaVersionID,
 						Fields: []client.FieldDescription{
 							{
-								Name: "_key",
-								Kind: client.FieldKind_DocKey,
+								Name: "_docID",
+								Kind: client.FieldKind_DocID,
 							},
 							{
 								Name: "points",

--- a/tests/integration/schema/updates/add/field/crdt/composite_test.go
+++ b/tests/integration/schema/updates/add/field/crdt/composite_test.go
@@ -33,7 +33,7 @@ func TestSchemaUpdatesAddFieldCRDTCompositeErrors(t *testing.T) {
 						{ "op": "add", "path": "/Users/Fields/-", "value": {"Name": "foo", "Kind": 2, "Typ":3} }
 					]
 				`,
-				ExpectedError: "only default or LWW (last writer wins) CRDT types are supported. Name: foo, CRDTType: 3",
+				ExpectedError: "CRDT type not supported. Name: foo, CRDTType: composite",
 			},
 		},
 	}

--- a/tests/integration/schema/updates/add/field/crdt/invalid_test.go
+++ b/tests/integration/schema/updates/add/field/crdt/invalid_test.go
@@ -33,7 +33,7 @@ func TestSchemaUpdatesAddFieldCRDTInvalidErrors(t *testing.T) {
 						{ "op": "add", "path": "/Users/Fields/-", "value": {"Name": "foo", "Kind": 2, "Typ":99} }
 					]
 				`,
-				ExpectedError: "only default or LWW (last writer wins) CRDT types are supported. Name: foo, CRDTType: 99",
+				ExpectedError: "CRDT type not supported. Name: foo, CRDTType: unknown",
 			},
 		},
 	}

--- a/tests/integration/schema/updates/add/field/crdt/pncounter_test.go
+++ b/tests/integration/schema/updates/add/field/crdt/pncounter_test.go
@@ -1,0 +1,73 @@
+// Copyright 2023 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package crdt
+
+import (
+	"testing"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+func TestSchemaUpdates_AddFieldCRDTPNCounter_NoError(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "Test schema update, add field with crdt PN Counter (4)",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users {
+						name: String
+					}
+				`,
+			},
+			testUtils.SchemaPatch{
+				Patch: `
+					[
+						{ "op": "add", "path": "/Users/Fields/-", "value": {"Name": "foo", "Kind": 4, "Typ": 4} }
+					]
+				`,
+			},
+			testUtils.Request{
+				Request: `query {
+					Users {
+						name
+						foo
+					}
+				}`,
+				Results: []map[string]any{},
+			},
+		},
+	}
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestSchemaUpdates_AddFieldCRDTPNCounterWithMismatchKind_Error(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "Test schema update, add field with crdt PN Counter (4)",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users {
+						name: String
+					}
+				`,
+			},
+			testUtils.SchemaPatch{
+				Patch: `
+					[
+						{ "op": "add", "path": "/Users/Fields/-", "value": {"Name": "foo", "Kind": 2, "Typ": 4} }
+					]
+				`,
+				ExpectedError: "CRDT type pncounter can't be assigned to field kind Boolean",
+			},
+		},
+	}
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/view/one_to_many/with_introspection_test.go
+++ b/tests/integration/view/one_to_many/with_introspection_test.go
@@ -108,7 +108,7 @@ func TestView_OneToMany_GQLIntrospectionTest(t *testing.T) {
 				ExpectedData: map[string]any{
 					"__type": map[string]any{
 						"name": "BookView",
-						// Note: `_key`, `_version`, `_deleted`, etc should not be present,
+						// Note: `_docID`, `_version`, `_deleted`, etc should not be present,
 						// although aggregates and `_group` should be.
 						// There should also be no `Author` field - the relationship field
 						// should only exist on the parent.


### PR DESCRIPTION
## Relevant issue(s)

Resolves #2115

## Description

This PR adds the PN Counter CRDT type. This type enforces changes that are incrementing or decrementing the value. A value cannot be set directly.

The PR also simplifies the CRDT flow a bit further. For example, the `Data` field on the composite CRDT has been removed since the type links to the changed fields. This change will removes the data leak that would be present once we implement field level access control.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

make test with added integrations tests

Specify the platform(s) on which this was tested:
- MacOS
