### PR TITLE
feat: Add Big Int and Big Float scalars

### DIFF
--- a/client/descriptions.go
+++ b/client/descriptions.go
@@ -150,6 +150,8 @@ func (f FieldKind) String() string {
 		return "Blob"
 	case FieldKind_BIG_INT:
 		return "BigInt"
+	case FieldKind_BIG_FLOAT:
+		return "BigFloat"
 	default:
 		return fmt.Sprint(uint8(f))
 	}
@@ -166,7 +168,7 @@ const (
 	FieldKind_FLOAT        FieldKind = 6
 	FieldKind_FLOAT_ARRAY  FieldKind = 7
 	FieldKind_BIG_INT      FieldKind = 8
-	_                      FieldKind = 9 // safe to repurpose (previously old field)
+	FieldKind_BIG_FLOAT    FieldKind = 9
 	FieldKind_DATETIME     FieldKind = 10
 	FieldKind_STRING       FieldKind = 11
 	FieldKind_STRING_ARRAY FieldKind = 12
@@ -209,6 +211,8 @@ var FieldKindStringToEnumMapping = map[string]FieldKind{
 	"[String]":   FieldKind_NILLABLE_STRING_ARRAY,
 	"[String!]":  FieldKind_STRING_ARRAY,
 	"Blob":       FieldKind_BLOB,
+	"BigInt":     FieldKind_BIG_INT,
+	"BigFloat":   FieldKind_BIG_FLOAT,
 }
 
 // RelationType describes the type of relation between two types.

--- a/client/descriptions.go
+++ b/client/descriptions.go
@@ -148,6 +148,8 @@ func (f FieldKind) String() string {
 		return "[String!]"
 	case FieldKind_BLOB:
 		return "Blob"
+	case FieldKind_BIG_INT:
+		return "BigInt"
 	default:
 		return fmt.Sprint(uint8(f))
 	}
@@ -163,7 +165,7 @@ const (
 	FieldKind_INT_ARRAY    FieldKind = 5
 	FieldKind_FLOAT        FieldKind = 6
 	FieldKind_FLOAT_ARRAY  FieldKind = 7
-	_                      FieldKind = 8 // safe to repurpose (was never used)
+	FieldKind_BIG_INT      FieldKind = 8
 	_                      FieldKind = 9 // safe to repurpose (previously old field)
 	FieldKind_DATETIME     FieldKind = 10
 	FieldKind_STRING       FieldKind = 11

--- a/request/graphql/schema/collection.go
+++ b/request/graphql/schema/collection.go
@@ -333,6 +333,7 @@ func astTypeToKind(t ast.Type) (client.FieldKind, error) {
 		typeString   string = "String"
 		typeBlob     string = "Blob"
 		typeBigInt   string = "BigInt"
+		typeBigFloat string = "BigFloat"
 	)
 
 	switch astTypeVal := t.(type) {
@@ -385,6 +386,8 @@ func astTypeToKind(t ast.Type) (client.FieldKind, error) {
 			return client.FieldKind_BLOB, nil
 		case typeBigInt:
 			return client.FieldKind_BIG_INT, nil
+		case typeBigFloat:
+			return client.FieldKind_BIG_FLOAT, nil
 		default:
 			return client.FieldKind_FOREIGN_OBJECT, nil
 		}

--- a/request/graphql/schema/collection.go
+++ b/request/graphql/schema/collection.go
@@ -332,6 +332,7 @@ func astTypeToKind(t ast.Type) (client.FieldKind, error) {
 		typeDateTime string = "DateTime"
 		typeString   string = "String"
 		typeBlob     string = "Blob"
+		typeBigInt   string = "BigInt"
 	)
 
 	switch astTypeVal := t.(type) {
@@ -382,6 +383,8 @@ func astTypeToKind(t ast.Type) (client.FieldKind, error) {
 			return client.FieldKind_STRING, nil
 		case typeBlob:
 			return client.FieldKind_BLOB, nil
+		case typeBigInt:
+			return client.FieldKind_BIG_INT, nil
 		default:
 			return client.FieldKind_FOREIGN_OBJECT, nil
 		}

--- a/request/graphql/schema/descriptions.go
+++ b/request/graphql/schema/descriptions.go
@@ -33,8 +33,9 @@ var (
 		&gql.Object{}: client.FieldKind_FOREIGN_OBJECT,
 		&gql.List{}:   client.FieldKind_FOREIGN_OBJECT_ARRAY,
 		// Custom scalars
-		schemaTypes.BlobScalarType:   client.FieldKind_BLOB,
-		schemaTypes.BigIntScalarType: client.FieldKind_BIG_INT,
+		schemaTypes.BlobScalarType:     client.FieldKind_BLOB,
+		schemaTypes.BigIntScalarType:   client.FieldKind_BIG_INT,
+		schemaTypes.BigFloatScalarType: client.FieldKind_BIG_FLOAT,
 		// More custom ones to come
 		// - JSON
 		// - Counters
@@ -56,8 +57,9 @@ var (
 		client.FieldKind_STRING_ARRAY:          gql.NewList(gql.NewNonNull(gql.String)),
 		client.FieldKind_NILLABLE_STRING_ARRAY: gql.NewList(gql.String),
 		// custom scalar types
-		client.FieldKind_BLOB:    schemaTypes.BlobScalarType,
-		client.FieldKind_BIG_INT: schemaTypes.BigIntScalarType,
+		client.FieldKind_BLOB:      schemaTypes.BlobScalarType,
+		client.FieldKind_BIG_INT:   schemaTypes.BigIntScalarType,
+		client.FieldKind_BIG_FLOAT: schemaTypes.BigFloatScalarType,
 	}
 
 	// This map is fine to use
@@ -78,6 +80,7 @@ var (
 		client.FieldKind_NILLABLE_STRING_ARRAY: client.LWW_REGISTER,
 		client.FieldKind_BLOB:                  client.LWW_REGISTER,
 		client.FieldKind_BIG_INT:               client.LWW_REGISTER,
+		client.FieldKind_BIG_FLOAT:             client.LWW_REGISTER,
 		client.FieldKind_FOREIGN_OBJECT:        client.NONE_CRDT,
 		client.FieldKind_FOREIGN_OBJECT_ARRAY:  client.NONE_CRDT,
 	}

--- a/request/graphql/schema/descriptions.go
+++ b/request/graphql/schema/descriptions.go
@@ -33,7 +33,8 @@ var (
 		&gql.Object{}: client.FieldKind_FOREIGN_OBJECT,
 		&gql.List{}:   client.FieldKind_FOREIGN_OBJECT_ARRAY,
 		// Custom scalars
-		schemaTypes.BlobScalarType: client.FieldKind_BLOB,
+		schemaTypes.BlobScalarType:   client.FieldKind_BLOB,
+		schemaTypes.BigIntScalarType: client.FieldKind_BIG_INT,
 		// More custom ones to come
 		// - JSON
 		// - Counters
@@ -54,7 +55,9 @@ var (
 		client.FieldKind_STRING:                gql.String,
 		client.FieldKind_STRING_ARRAY:          gql.NewList(gql.NewNonNull(gql.String)),
 		client.FieldKind_NILLABLE_STRING_ARRAY: gql.NewList(gql.String),
-		client.FieldKind_BLOB:                  schemaTypes.BlobScalarType,
+		// custom scalar types
+		client.FieldKind_BLOB:    schemaTypes.BlobScalarType,
+		client.FieldKind_BIG_INT: schemaTypes.BigIntScalarType,
 	}
 
 	// This map is fine to use
@@ -74,6 +77,7 @@ var (
 		client.FieldKind_STRING_ARRAY:          client.LWW_REGISTER,
 		client.FieldKind_NILLABLE_STRING_ARRAY: client.LWW_REGISTER,
 		client.FieldKind_BLOB:                  client.LWW_REGISTER,
+		client.FieldKind_BIG_INT:               client.LWW_REGISTER,
 		client.FieldKind_FOREIGN_OBJECT:        client.NONE_CRDT,
 		client.FieldKind_FOREIGN_OBJECT_ARRAY:  client.NONE_CRDT,
 	}

--- a/request/graphql/schema/types/scalars.go
+++ b/request/graphql/schema/types/scalars.go
@@ -12,6 +12,7 @@ package types
 
 import (
 	"encoding/hex"
+	"math/big"
 	"regexp"
 
 	"github.com/sourcenetwork/graphql-go"
@@ -63,3 +64,106 @@ var BlobScalarType = graphql.NewScalar(graphql.ScalarConfig{
 		}
 	},
 })
+
+var BigIntPattern = regexp.MustCompile("^[0-9]+$")
+
+var BigIntScalarType = graphql.NewScalar(graphql.ScalarConfig{
+	Name:        "BigInt",
+	Description: "The `BigInt` scalar type represents an arbitrary precision integer.",
+	// Serialize converts the value to a string
+	Serialize: coerceBigInt,
+	// ParseValue converts the value to a string
+	ParseValue: coerceBigInt,
+	// ParseLiteral converts the ast value to a string
+	ParseLiteral: func(valueAST ast.Value) any {
+		switch valueAST := valueAST.(type) {
+		case *ast.IntValue:
+			return coerceBigInt(valueAST.Value)
+		case *ast.FloatValue:
+			return coerceBigInt(valueAST.Value)
+		case *ast.StringValue:
+			return coerceBigInt(valueAST.Value)
+		default:
+			// return nil if the value cannot be parsed
+			return nil
+		}
+	},
+})
+
+// coerceBigInt converts the given value into a valid BigInt.
+// If the value cannot be converted nil is returned.
+func coerceBigInt(value any) any {
+	switch value := value.(type) {
+	case float32:
+		return big.NewInt(int64(value)).String()
+
+	case *float32:
+		return coerceBigInt(*value)
+
+	case float64:
+		return big.NewInt(int64(value)).String()
+
+	case *float64:
+		return coerceBigInt(*value)
+
+	case int:
+		return big.NewInt(int64(value)).String()
+
+	case *int:
+		return coerceBigInt(*value)
+
+	case int16:
+		return big.NewInt(int64(value)).String()
+
+	case *int16:
+		return coerceBigInt(*value)
+
+	case int32:
+		return big.NewInt(int64(value)).String()
+
+	case *int32:
+		return coerceBigInt(*value)
+
+	case int64:
+		return big.NewInt(int64(value)).String()
+
+	case *int64:
+		return coerceBigInt(*value)
+
+	case uint:
+		return big.NewInt(int64(value)).String()
+
+	case *uint:
+		return coerceBigInt(*value)
+
+	case uint16:
+		return big.NewInt(int64(value)).String()
+
+	case *uint16:
+		return coerceBigInt(*value)
+
+	case uint32:
+		return big.NewInt(int64(value)).String()
+
+	case *uint32:
+		return coerceBigInt(*value)
+
+	case uint64:
+		return big.NewInt(int64(value)).String()
+
+	case *uint64:
+		return coerceBigInt(*value)
+
+	case string:
+		if !BigIntPattern.MatchString(value) {
+			return nil
+		}
+		return value
+
+	case *string:
+		return coerceBlob(*value)
+
+	default:
+		return nil
+	}
+}

--- a/request/graphql/schema/types/scalars.go
+++ b/request/graphql/schema/types/scalars.go
@@ -65,6 +65,7 @@ var BlobScalarType = graphql.NewScalar(graphql.ScalarConfig{
 	},
 })
 
+// BigIntPattern is a regex for validating big int strings
 var BigIntPattern = regexp.MustCompile("^[0-9]+$")
 
 var BigIntScalarType = graphql.NewScalar(graphql.ScalarConfig{
@@ -161,7 +162,111 @@ func coerceBigInt(value any) any {
 		return value
 
 	case *string:
-		return coerceBlob(*value)
+		return coerceBigInt(*value)
+
+	default:
+		return nil
+	}
+}
+
+// BigFloatPattern is a regex for validating big float strings
+var BigFloatPattern = regexp.MustCompile("^[0-9]+(.[0-9]+)?$")
+
+var BigFloatScalarType = graphql.NewScalar(graphql.ScalarConfig{
+	Name:        "BigFloat",
+	Description: "The `BigFloat` scalar type represents an arbitrary precision float.",
+	// Serialize converts the value to a string
+	Serialize: coerceBigFloat,
+	// ParseValue converts the value to a string
+	ParseValue: coerceBigFloat,
+	// ParseLiteral converts the ast value to a string
+	ParseLiteral: func(valueAST ast.Value) any {
+		switch valueAST := valueAST.(type) {
+		case *ast.IntValue:
+			return coerceBigFloat(valueAST.Value)
+		case *ast.FloatValue:
+			return coerceBigFloat(valueAST.Value)
+		case *ast.StringValue:
+			return coerceBigFloat(valueAST.Value)
+		default:
+			// return nil if the value cannot be parsed
+			return nil
+		}
+	},
+})
+
+// coerceBigFloat converts the given value into a valid BigFloat.
+// If the value cannot be converted nil is returned.
+func coerceBigFloat(value any) any {
+	switch value := value.(type) {
+	case float32:
+		return big.NewFloat(float64(value)).String()
+
+	case *float32:
+		return coerceBigFloat(*value)
+
+	case float64:
+		return big.NewFloat(float64(value)).String()
+
+	case *float64:
+		return coerceBigFloat(*value)
+
+	case int:
+		return big.NewFloat(float64(value)).String()
+
+	case *int:
+		return coerceBigFloat(*value)
+
+	case int16:
+		return big.NewFloat(float64(value)).String()
+
+	case *int16:
+		return coerceBigFloat(*value)
+
+	case int32:
+		return big.NewFloat(float64(value)).String()
+
+	case *int32:
+		return coerceBigFloat(*value)
+
+	case int64:
+		return big.NewFloat(float64(value)).String()
+
+	case *int64:
+		return coerceBigFloat(*value)
+
+	case uint:
+		return big.NewFloat(float64(value)).String()
+
+	case *uint:
+		return coerceBigFloat(*value)
+
+	case uint16:
+		return big.NewFloat(float64(value)).String()
+
+	case *uint16:
+		return coerceBigFloat(*value)
+
+	case uint32:
+		return big.NewFloat(float64(value)).String()
+
+	case *uint32:
+		return coerceBigFloat(*value)
+
+	case uint64:
+		return big.NewFloat(float64(value)).String()
+
+	case *uint64:
+		return coerceBigFloat(*value)
+
+	case string:
+		if !BigFloatPattern.MatchString(value) {
+			return nil
+		}
+		return value
+
+	case *string:
+		return coerceBigFloat(*value)
 
 	default:
 		return nil

--- a/request/graphql/schema/types/scalars.go
+++ b/request/graphql/schema/types/scalars.go
@@ -170,7 +170,7 @@ func coerceBigInt(value any) any {
 }
 
 // BigFloatPattern is a regex for validating big float strings
-var BigFloatPattern = regexp.MustCompile("^[0-9]+(.[0-9]+)?$")
+var BigFloatPattern = regexp.MustCompile(`^\d+(.\d+(e±\d\d)?)?$`)
 
 var BigFloatScalarType = graphql.NewScalar(graphql.ScalarConfig{
 	Name:        "BigFloat",

--- a/request/graphql/schema/types/scalars_test.go
+++ b/request/graphql/schema/types/scalars_test.go
@@ -17,28 +17,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestBlobScalarTypeSerialize(t *testing.T) {
-	stringInput := "00ff"
-	bytesInput := []byte{0, 255}
-
-	cases := []struct {
-		input  any
-		expect any
-	}{
-		{stringInput, "00ff"},
-		{&stringInput, "00ff"},
-		{bytesInput, "00ff"},
-		{&bytesInput, "00ff"},
-		{nil, nil},
-		{0, nil},
-		{false, nil},
-	}
-	for _, c := range cases {
-		result := BlobScalarType.Serialize(c.input)
-		assert.Equal(t, c.expect, result)
-	}
-}
-
 func TestBlobScalarTypeParseValue(t *testing.T) {
 	stringInput := "00ff"
 	bytesInput := []byte{0, 255}
@@ -83,6 +61,80 @@ func TestBlobScalarTypeParseLiteral(t *testing.T) {
 	}
 	for _, c := range cases {
 		result := BlobScalarType.ParseLiteral(c.input)
+		assert.Equal(t, c.expect, result)
+	}
+}
+
+func TestBigIntScalarTypeParseValue(t *testing.T) {
+	stringInput := "123456"
+	intInput := int(123456)
+	int16Input := int16(12345)
+	int32Input := int32(123456)
+	int64Input := int64(123456)
+	uintInput := uint(123456)
+	uint16Input := uint16(12345)
+	uint32Input := uint32(123456)
+	uint64Input := uint64(123456)
+	float32Input := float32(123456)
+	float64Input := float64(123456)
+	// invalid string containing non-number characters
+	invalidString := "!@#$%^&*"
+
+	cases := []struct {
+		input  any
+		expect any
+	}{
+		{stringInput, "123456"},
+		{&stringInput, "123456"},
+		{intInput, "123456"},
+		{&intInput, "123456"},
+		{int16Input, "12345"},
+		{&int16Input, "12345"},
+		{int32Input, "123456"},
+		{&int32Input, "123456"},
+		{int64Input, "123456"},
+		{&int64Input, "123456"},
+		{uintInput, "123456"},
+		{&uintInput, "123456"},
+		{uint16Input, "12345"},
+		{&uint16Input, "12345"},
+		{uint32Input, "123456"},
+		{&uint32Input, "123456"},
+		{uint64Input, "123456"},
+		{&uint64Input, "123456"},
+		{float32Input, "123456"},
+		{&float32Input, "123456"},
+		{float64Input, "123456"},
+		{&float64Input, "123456"},
+		{invalidString, nil},
+		{&invalidString, nil},
+		{nil, nil},
+		{false, nil},
+	}
+	for _, c := range cases {
+		result := BigIntScalarType.ParseValue(c.input)
+		assert.Equal(t, c.expect, result)
+	}
+}
+
+func TestBigIntScalarTypeParseLiteral(t *testing.T) {
+	cases := []struct {
+		input  ast.Value
+		expect any
+	}{
+		{&ast.StringValue{Value: "123456"}, "123456"},
+		{&ast.StringValue{Value: "00!@#$%^&*"}, nil},
+		{&ast.StringValue{Value: "!@#$%^&*00"}, nil},
+		{&ast.IntValue{Value: "123456"}, "123456"},
+		{&ast.BooleanValue{}, nil},
+		{&ast.NullValue{}, nil},
+		{&ast.EnumValue{}, nil},
+		{&ast.FloatValue{Value: "123456"}, "123456"},
+		{&ast.ListValue{}, nil},
+		{&ast.ObjectValue{}, nil},
+	}
+	for _, c := range cases {
+		result := BigIntScalarType.ParseLiteral(c.input)
 		assert.Equal(t, c.expect, result)
 	}
 }

--- a/request/graphql/schema/types/scalars_test.go
+++ b/request/graphql/schema/types/scalars_test.go
@@ -141,6 +141,7 @@ func TestBigIntScalarTypeParseLiteral(t *testing.T) {
 
 func TestBigFloatScalarTypeParseValue(t *testing.T) {
 	stringInput := "123456.123456"
+	exponentInput := "123456.123456e±12"
 	intInput := int(123456)
 	int16Input := int16(12345)
 	int32Input := int32(123456)
@@ -160,6 +161,8 @@ func TestBigFloatScalarTypeParseValue(t *testing.T) {
 	}{
 		{stringInput, "123456.123456"},
 		{&stringInput, "123456.123456"},
+		{exponentInput, "123456.123456e±12"},
+		{&exponentInput, "123456.123456e±12"},
 		{intInput, "123456"},
 		{&intInput, "123456"},
 		{int16Input, "12345"},
@@ -197,6 +200,7 @@ func TestBigFloatScalarTypeParseLiteral(t *testing.T) {
 		expect any
 	}{
 		{&ast.StringValue{Value: "123456.123456"}, "123456.123456"},
+		{&ast.StringValue{Value: "123456.123456e±12"}, "123456.123456e±12"},
 		{&ast.StringValue{Value: "00!@#$%^&*"}, nil},
 		{&ast.StringValue{Value: "!@#$%^&*00"}, nil},
 		{&ast.IntValue{Value: "123456"}, "123456"},

--- a/request/graphql/schema/types/scalars_test.go
+++ b/request/graphql/schema/types/scalars_test.go
@@ -138,3 +138,77 @@ func TestBigIntScalarTypeParseLiteral(t *testing.T) {
 		assert.Equal(t, c.expect, result)
 	}
 }
+
+func TestBigFloatScalarTypeParseValue(t *testing.T) {
+	stringInput := "123456.123456"
+	intInput := int(123456)
+	int16Input := int16(12345)
+	int32Input := int32(123456)
+	int64Input := int64(123456)
+	uintInput := uint(123456)
+	uint16Input := uint16(12345)
+	uint32Input := uint32(123456)
+	uint64Input := uint64(123456)
+	float32Input := float32(123456.123456)
+	float64Input := float64(123456.123456)
+	// invalid string containing non-number characters
+	invalidString := "!@#$%^&*"
+
+	cases := []struct {
+		input  any
+		expect any
+	}{
+		{stringInput, "123456.123456"},
+		{&stringInput, "123456.123456"},
+		{intInput, "123456"},
+		{&intInput, "123456"},
+		{int16Input, "12345"},
+		{&int16Input, "12345"},
+		{int32Input, "123456"},
+		{&int32Input, "123456"},
+		{int64Input, "123456"},
+		{&int64Input, "123456"},
+		{uintInput, "123456"},
+		{&uintInput, "123456"},
+		{uint16Input, "12345"},
+		{&uint16Input, "12345"},
+		{uint32Input, "123456"},
+		{&uint32Input, "123456"},
+		{uint64Input, "123456"},
+		{&uint64Input, "123456"},
+		{float32Input, "123456.125"},
+		{&float32Input, "123456.125"},
+		{float64Input, "123456.1235"},
+		{&float64Input, "123456.1235"},
+		{invalidString, nil},
+		{&invalidString, nil},
+		{nil, nil},
+		{false, nil},
+	}
+	for _, c := range cases {
+		result := BigFloatScalarType.ParseValue(c.input)
+		assert.Equal(t, c.expect, result)
+	}
+}
+
+func TestBigFloatScalarTypeParseLiteral(t *testing.T) {
+	cases := []struct {
+		input  ast.Value
+		expect any
+	}{
+		{&ast.StringValue{Value: "123456.123456"}, "123456.123456"},
+		{&ast.StringValue{Value: "00!@#$%^&*"}, nil},
+		{&ast.StringValue{Value: "!@#$%^&*00"}, nil},
+		{&ast.IntValue{Value: "123456"}, "123456"},
+		{&ast.BooleanValue{}, nil},
+		{&ast.NullValue{}, nil},
+		{&ast.EnumValue{}, nil},
+		{&ast.FloatValue{Value: "123456.123456"}, "123456.123456"},
+		{&ast.ListValue{}, nil},
+		{&ast.ObjectValue{}, nil},
+	}
+	for _, c := range cases {
+		result := BigFloatScalarType.ParseLiteral(c.input)
+		assert.Equal(t, c.expect, result)
+	}
+}

--- a/tests/integration/schema/updates/add/field/kind/big_float_test.go
+++ b/tests/integration/schema/updates/add/field/kind/big_float_test.go
@@ -16,9 +16,9 @@ import (
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
 )
 
-func TestSchemaUpdatesAddFieldKindBigInt(t *testing.T) {
+func TestSchemaUpdatesAddFieldKindBigFloat(t *testing.T) {
 	test := testUtils.TestCase{
-		Description: "Test schema update, add field with kind big int (8)",
+		Description: "Test schema update, add field with kind big float (9)",
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
@@ -30,7 +30,7 @@ func TestSchemaUpdatesAddFieldKindBigInt(t *testing.T) {
 			testUtils.SchemaPatch{
 				Patch: `
 					[
-						{ "op": "add", "path": "/Users/Fields/-", "value": {"Name": "foo", "Kind": 8} }
+						{ "op": "add", "path": "/Users/Fields/-", "value": {"Name": "foo", "Kind": 9} }
 					]
 				`,
 			},
@@ -48,9 +48,9 @@ func TestSchemaUpdatesAddFieldKindBigInt(t *testing.T) {
 	testUtils.ExecuteTestCase(t, test)
 }
 
-func TestSchemaUpdatesAddFieldKindBigIntWithCreate(t *testing.T) {
+func TestSchemaUpdatesAddFieldKindBigFloatWithCreate(t *testing.T) {
 	test := testUtils.TestCase{
-		Description: "Test schema update, add field with kind big int (8) with create",
+		Description: "Test schema update, add field with kind big float (9) with create",
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
@@ -62,7 +62,7 @@ func TestSchemaUpdatesAddFieldKindBigIntWithCreate(t *testing.T) {
 			testUtils.SchemaPatch{
 				Patch: `
 					[
-						{ "op": "add", "path": "/Users/Fields/-", "value": {"Name": "foo", "Kind": 8} }
+						{ "op": "add", "path": "/Users/Fields/-", "value": {"Name": "foo", "Kind": 9} }
 					]
 				`,
 			},
@@ -70,7 +70,7 @@ func TestSchemaUpdatesAddFieldKindBigIntWithCreate(t *testing.T) {
 				CollectionID: 0,
 				Doc: `{
 					"name": "John",
-					"foo": "123456"
+					"foo": "123456.123456"
 				}`,
 			},
 			testUtils.Request{
@@ -83,7 +83,7 @@ func TestSchemaUpdatesAddFieldKindBigIntWithCreate(t *testing.T) {
 				Results: []map[string]any{
 					{
 						"name": "John",
-						"foo":  "123456",
+						"foo":  "123456.123456",
 					},
 				},
 			},
@@ -92,9 +92,9 @@ func TestSchemaUpdatesAddFieldKindBigIntWithCreate(t *testing.T) {
 	testUtils.ExecuteTestCase(t, test)
 }
 
-func TestSchemaUpdatesAddFieldKindBigIntSubstitutionWithCreate(t *testing.T) {
+func TestSchemaUpdatesAddFieldKindBigFloatSubstitutionWithCreate(t *testing.T) {
 	test := testUtils.TestCase{
-		Description: "Test schema update, add field with kind big int substitution with create",
+		Description: "Test schema update, add field with kind big float substitution with create",
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
@@ -106,7 +106,7 @@ func TestSchemaUpdatesAddFieldKindBigIntSubstitutionWithCreate(t *testing.T) {
 			testUtils.SchemaPatch{
 				Patch: `
 					[
-						{ "op": "add", "path": "/Users/Fields/-", "value": {"Name": "foo", "Kind": "BigInt"} }
+						{ "op": "add", "path": "/Users/Fields/-", "value": {"Name": "foo", "Kind": "BigFloat"} }
 					]
 				`,
 			},
@@ -114,7 +114,7 @@ func TestSchemaUpdatesAddFieldKindBigIntSubstitutionWithCreate(t *testing.T) {
 				CollectionID: 0,
 				Doc: `{
 					"name": "John",
-					"foo": "123456"
+					"foo": "123456.123456"
 				}`,
 			},
 			testUtils.Request{
@@ -127,7 +127,7 @@ func TestSchemaUpdatesAddFieldKindBigIntSubstitutionWithCreate(t *testing.T) {
 				Results: []map[string]any{
 					{
 						"name": "John",
-						"foo":  "123456",
+						"foo":  "123456.123456",
 					},
 				},
 			},

--- a/tests/integration/schema/updates/add/field/kind/big_int_test.go
+++ b/tests/integration/schema/updates/add/field/kind/big_int_test.go
@@ -1,0 +1,137 @@
+// Copyright 2023 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package kind
+
+import (
+	"testing"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+func TestSchemaUpdatesAddFieldKindBigInt(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "Test schema update, add field with kind big int (8)",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users {
+						name: String
+					}
+				`,
+			},
+			testUtils.SchemaPatch{
+				Patch: `
+					[
+						{ "op": "add", "path": "/Users/Fields/-", "value": {"Name": "foo", "Kind": 8} }
+					]
+				`,
+			},
+			testUtils.Request{
+				Request: `query {
+					Users {
+						name
+						foo
+					}
+				}`,
+				Results: []map[string]any{},
+			},
+		},
+	}
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestSchemaUpdatesAddFieldKindBigIntWithCreate(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "Test schema update, add field with kind big int (8) with create",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users {
+						name: String
+					}
+				`,
+			},
+			testUtils.SchemaPatch{
+				Patch: `
+					[
+						{ "op": "add", "path": "/Users/Fields/-", "value": {"Name": "foo", "Kind": 8} }
+					]
+				`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `{
+					"name": "John",
+					"foo": "123456"
+				}`,
+			},
+			testUtils.Request{
+				Request: `query {
+					Users {
+						name
+						foo
+					}
+				}`,
+				Results: []map[string]any{
+					{
+						"name": "John",
+						"foo":  "123456",
+					},
+				},
+			},
+		},
+	}
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestSchemaUpdatesAddFieldKindBigIntSubstitutionWithCreate(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "Test schema update, add field with kind big int substitution with create",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users {
+						name: String
+					}
+				`,
+			},
+			testUtils.SchemaPatch{
+				Patch: `
+					[
+						{ "op": "add", "path": "/Users/Fields/-", "value": {"Name": "foo", "Kind": "Blob"} }
+					]
+				`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `{
+					"name": "John",
+					"foo": "123456"
+				}`,
+			},
+			testUtils.Request{
+				Request: `query {
+					Users {
+						name
+						foo
+					}
+				}`,
+				Results: []map[string]any{
+					{
+						"name": "John",
+						"foo":  "123456",
+					},
+				},
+			},
+		},
+	}
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/schema/updates/add/field/kind/invalid_test.go
+++ b/tests/integration/schema/updates/add/field/kind/invalid_test.go
@@ -16,30 +16,6 @@ import (
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
 )
 
-func TestSchemaUpdatesAddFieldKind8(t *testing.T) {
-	test := testUtils.TestCase{
-		Description: "Test schema update, add field with kind deprecated (8)",
-		Actions: []any{
-			testUtils.SchemaUpdate{
-				Schema: `
-					type Users {
-						name: String
-					}
-				`,
-			},
-			testUtils.SchemaPatch{
-				Patch: `
-					[
-						{ "op": "add", "path": "/Users/Fields/-", "value": {"Name": "foo", "Kind": 8} }
-					]
-				`,
-				ExpectedError: "no type found for given name. Type: 8",
-			},
-		},
-	}
-	testUtils.ExecuteTestCase(t, test)
-}
-
 func TestSchemaUpdatesAddFieldKind9(t *testing.T) {
 	test := testUtils.TestCase{
 		Description: "Test schema update, add field with kind deprecated (9)",

--- a/tests/integration/schema/updates/add/field/kind/invalid_test.go
+++ b/tests/integration/schema/updates/add/field/kind/invalid_test.go
@@ -16,30 +16,6 @@ import (
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
 )
 
-func TestSchemaUpdatesAddFieldKind9(t *testing.T) {
-	test := testUtils.TestCase{
-		Description: "Test schema update, add field with kind deprecated (9)",
-		Actions: []any{
-			testUtils.SchemaUpdate{
-				Schema: `
-					type Users {
-						name: String
-					}
-				`,
-			},
-			testUtils.SchemaPatch{
-				Patch: `
-					[
-						{ "op": "add", "path": "/Users/Fields/-", "value": {"Name": "foo", "Kind": 9} }
-					]
-				`,
-				ExpectedError: "no type found for given name. Type: 9",
-			},
-		},
-	}
-	testUtils.ExecuteTestCase(t, test)
-}
-
 func TestSchemaUpdatesAddFieldKind14(t *testing.T) {
 	test := testUtils.TestCase{
 		Description: "Test schema update, add field with kind deprecated (14)",


### PR DESCRIPTION
## Relevant issue(s)

Resolves #2129 

## Description

This PR adds two new scalar types: `BigInt` and `BigFloat`.

Aggregate support was intentionally left out so we can figure it out in a future PR.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Added tests

Specify the platform(s) on which this was tested:
- MacOS

