### PR TITLE
fix: Filtering on unique index if there is no match

### DIFF
--- a/db/fetcher/indexer_iterators.go
+++ b/db/fetcher/indexer_iterators.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 
 	"github.com/fxamacker/cbor/v2"
+	ds "github.com/ipfs/go-datastore"
 
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/connor"
@@ -141,6 +142,9 @@ func (i *eqSingleIndexIterator) Next() (indexIterResult, error) {
 	i.indexKey.FieldValues = [][]byte{i.value}
 	val, err := i.store.Get(i.ctx, i.indexKey.ToDS())
 	if err != nil {
+		if errors.Is(err, ds.ErrNotFound) {
+			return indexIterResult{key: i.indexKey}, nil
+		}
 		return indexIterResult{}, err
 	}
 	i.store = nil

--- a/tests/integration/index/query_with_unique_index_only_filter_test.go
+++ b/tests/integration/index/query_with_unique_index_only_filter_test.go
@@ -461,3 +461,36 @@ func TestQueryWithUniqueIndex_WithNotLikeFilter_ShouldFetch(t *testing.T) {
 
 	testUtils.ExecuteTestCase(t, test)
 }
+
+func TestQueryWithUniqueIndex_IfNoMatch_ReturnEmptyResult(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "If filter does not match any document, return empty result",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type User {
+						name: String 
+						age: Int @index(unique: true)
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: ` {
+						"name":	"Shahzad",
+						"age":	23
+					}`,
+			},
+			testUtils.Request{
+				Request: `query {
+					User(filter: {age: {_eq: 20}}) {
+						name
+					}
+				}`,
+				Results: []map[string]any{},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #2176

## Description

Make unique index distinguish between key-not-found and other errors.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Unit and integration tests

Specify the platform(s) on which this was tested:
- MacOS
