### PR TITLE
fix: Handle multiple nil values on unique indexed fields

### DIFF
--- a/db/errors.go
+++ b/db/errors.go
@@ -86,7 +86,8 @@ const (
 	errExpectedJSONArray                  string = "expected JSON array"
 	errOneOneAlreadyLinked                string = "target document is already linked to another document"
 	errIndexDoesNotMatchName              string = "the index used does not match the given name"
-	errCanNotIndexNonUniqueField          string = "can not create doc that violates unique index"
+	errCanNotIndexNonUniqueField          string = "can not index a doc's field that violates unique index"
+	errCanNotIndexNilField                string = "can not index a doc's field with nil value"
 	errInvalidViewQuery                   string = "the query provided is not valid as a View"
 )
 
@@ -572,6 +573,14 @@ func NewErrCanNotIndexNonUniqueField(docID, fieldName string, value any) error {
 		errors.NewKV("DocID", docID),
 		errors.NewKV("Field name", fieldName),
 		errors.NewKV("Field value", value),
+	)
+}
+
+func NewErrCanNotIndexNilField(docID, fieldName string) error {
+	return errors.New(
+		errCanNotIndexNilField,
+		errors.NewKV("DocID", docID),
+		errors.NewKV("Field name", fieldName),
 	)
 }
 

--- a/db/errors.go
+++ b/db/errors.go
@@ -87,7 +87,6 @@ const (
 	errOneOneAlreadyLinked                string = "target document is already linked to another document"
 	errIndexDoesNotMatchName              string = "the index used does not match the given name"
 	errCanNotIndexNonUniqueField          string = "can not index a doc's field that violates unique index"
-	errCanNotIndexNilField                string = "can not index a doc's field with nil value"
 	errInvalidViewQuery                   string = "the query provided is not valid as a View"
 )
 
@@ -576,19 +575,11 @@ func NewErrCanNotIndexNonUniqueField(docID, fieldName string, value any) error {
 	)
 }
 
-func NewErrCanNotIndexNilField(docID, fieldName string) error {
-	return errors.New(
-		errCanNotIndexNilField,
-		errors.NewKV("DocID", docID),
-		errors.NewKV("Field name", fieldName),
-	)
-}
-
 func NewErrInvalidViewQueryCastFailed(query string) error {
 	return errors.New(
 		errInvalidViewQuery,
 		errors.NewKV("Query", query),
-		errors.NewKV("Reason", "Internal errror, cast failed"),
+		errors.NewKV("Reason", "Internal error, cast failed"),
 	)
 }
 

--- a/db/index.go
+++ b/db/index.go
@@ -292,6 +292,8 @@ func (i *collectionUniqueIndex) newUniqueIndexError(
 	fieldVal, err := doc.GetValue(i.fieldDesc.Name)
 	var val any
 	if err != nil {
+		// If the error is ErrFieldNotExist, we leave `val` as is (e.g. nil)
+		// otherwise we return the error
 		if !errors.Is(err, client.ErrFieldNotExist) {
 			return err
 		}

--- a/db/indexed_docs_test.go
+++ b/db/indexed_docs_test.go
@@ -1028,29 +1028,6 @@ func TestUniqueCreate_ShouldIndexExistingDocs(t *testing.T) {
 	assert.Equal(t, data, []byte(doc2.ID().String()))
 }
 
-func TestUnique_IfIndexedFieldIsNil_StoreItAsNil(t *testing.T) {
-	f := newIndexTestFixture(t)
-	defer f.db.Close()
-	f.createUserCollectionUniqueIndexOnName()
-
-	docJSON, err := json.Marshal(struct {
-		Age int `json:"age"`
-	}{Age: 44})
-	require.NoError(f.t, err)
-
-	doc, err := client.NewDocFromJSON(docJSON, f.users.Schema())
-	require.NoError(f.t, err)
-
-	f.saveDocToCollection(doc, f.users)
-
-	key := newIndexKeyBuilder(f).Col(usersColName).Field(usersNameFieldName).Unique().Doc(doc).
-		Values([]byte(nil)).Build()
-
-	data, err := f.txn.Datastore().Get(f.ctx, key.ToDS())
-	require.NoError(t, err)
-	assert.Equal(t, data, []byte(doc.ID().String()))
-}
-
 func TestUniqueDrop_ShouldDeleteStoredIndexedFields(t *testing.T) {
 	f := newIndexTestFixtureBare(t)
 	users := f.addUsersCollection()

--- a/tests/integration/index/create_unique_test.go
+++ b/tests/integration/index/create_unique_test.go
@@ -187,7 +187,7 @@ func TestUniqueIndexCreate_IfFieldValuesAreUnique_Succeed(t *testing.T) {
 	testUtils.ExecuteTestCase(t, test)
 }
 
-func TestUniqueIndexCreate_IfFieldIsNil_ReturnError(t *testing.T) {
+func TestUniqueIndexCreate_IfNilFieldsArePresent_ReturnError(t *testing.T) {
 	test := testUtils.TestCase{
 		Description: "If filter does not match any document, return empty result",
 		Actions: []any{
@@ -214,11 +214,18 @@ func TestUniqueIndexCreate_IfFieldIsNil_ReturnError(t *testing.T) {
 						"name":	"Andy"
 					}`,
 			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `
+					{
+						"name":	"Keenan"
+					}`,
+			},
 			testUtils.CreateIndex{
 				CollectionID:  0,
 				FieldName:     "age",
 				Unique:        true,
-				ExpectedError: db.NewErrCanNotIndexNilField("bae-2159860f-3cd1-59de-9440-71331e77cbb8", "age").Error(),
+				ExpectedError: db.NewErrCanNotIndexNonUniqueField("bae-caba9876-89aa-5bcf-bc1c-387a52499b27", "age", nil).Error(),
 			},
 		},
 	}
@@ -226,7 +233,7 @@ func TestUniqueIndexCreate_IfFieldIsNil_ReturnError(t *testing.T) {
 	testUtils.ExecuteTestCase(t, test)
 }
 
-func TestUniqueIndexCreate_UponAddingDocWithNilValue_ReturnError(t *testing.T) {
+func TestUniqueIndexCreate_UponAddingDocWithExistingNilValue_ReturnError(t *testing.T) {
 	test := testUtils.TestCase{
 		Description: "If filter does not match any document, return empty result",
 		Actions: []any{
@@ -242,9 +249,24 @@ func TestUniqueIndexCreate_UponAddingDocWithNilValue_ReturnError(t *testing.T) {
 				CollectionID: 0,
 				Doc: `
 					{
+						"name":	"John",
+						"age":	21
+					}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `
+					{
+						"name":	"Keenan"
+					}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `
+					{
 						"name":	"Andy"
 					}`,
-				ExpectedError: db.NewErrCanNotIndexNilField("bae-2159860f-3cd1-59de-9440-71331e77cbb8", "age").Error(),
+				ExpectedError: db.NewErrCanNotIndexNonUniqueField("bae-2159860f-3cd1-59de-9440-71331e77cbb8", "age", nil).Error(),
 			},
 		},
 	}

--- a/tests/integration/index/create_unique_test.go
+++ b/tests/integration/index/create_unique_test.go
@@ -233,6 +233,31 @@ func TestUniqueIndexCreate_IfNilFieldsArePresent_ReturnError(t *testing.T) {
 	testUtils.ExecuteTestCase(t, test)
 }
 
+func TestUniqueIndexCreate_AddingDocWithNilValue_ShouldSucceed(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "Test adding a doc with nil value for indexed field should succeed",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type User {
+						name: String 
+						age: Int @index(unique: true)
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `
+					{
+						"name":	"John"
+					}`,
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
 func TestUniqueIndexCreate_UponAddingDocWithExistingNilValue_ReturnError(t *testing.T) {
 	test := testUtils.TestCase{
 		Description: "If filter does not match any document, return empty result",

--- a/tests/integration/index/create_unique_test.go
+++ b/tests/integration/index/create_unique_test.go
@@ -186,3 +186,68 @@ func TestUniqueIndexCreate_IfFieldValuesAreUnique_Succeed(t *testing.T) {
 
 	testUtils.ExecuteTestCase(t, test)
 }
+
+func TestUniqueIndexCreate_IfFieldIsNil_ReturnError(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "If filter does not match any document, return empty result",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type User {
+						name: String 
+						age: Int
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `
+					{
+						"name":	"John",
+						"age":	21
+					}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `
+					{
+						"name":	"Andy"
+					}`,
+			},
+			testUtils.CreateIndex{
+				CollectionID:  0,
+				FieldName:     "age",
+				Unique:        true,
+				ExpectedError: db.NewErrCanNotIndexNilField("bae-2159860f-3cd1-59de-9440-71331e77cbb8", "age").Error(),
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestUniqueIndexCreate_UponAddingDocWithNilValue_ReturnError(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "If filter does not match any document, return empty result",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type User {
+						name: String 
+						age: Int @index(unique: true)
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `
+					{
+						"name":	"Andy"
+					}`,
+				ExpectedError: db.NewErrCanNotIndexNilField("bae-2159860f-3cd1-59de-9440-71331e77cbb8", "age").Error(),
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/index/query_with_unique_index_only_filter_test.go
+++ b/tests/integration/index/query_with_unique_index_only_filter_test.go
@@ -494,3 +494,41 @@ func TestQueryWithUniqueIndex_IfNoMatch_ReturnEmptyResult(t *testing.T) {
 
 	testUtils.ExecuteTestCase(t, test)
 }
+
+func TestQueryWithUniqueIndex_WithEqualFilterOnNilValue_ShouldFetch(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "Test index filtering with _eq filter on nil value",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type User {
+						name: String 
+						age: Int @index(unique: true)
+					}`,
+			},
+			testUtils.CreatePredefinedDocs{
+				Docs: getUserDocs(),
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `
+					{
+						"name":	"Alice"
+					}`,
+			},
+			testUtils.Request{
+				Request: `
+					query {
+						User(filter: {age: {_eq: null}}) {
+							name
+						}
+					}`,
+				Results: []map[string]any{
+					{"name": "Alice"},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #2174 #2175

## Description

Forbid `nil` values for fields that are unique-indexed.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Integration and unit tests

Specify the platform(s) on which this was tested:
- MacOS
