### PR TITLE
fix(i): Retain embedded schema within gql types on reload

### DIFF
--- a/db/view.go
+++ b/db/view.go
@@ -60,21 +60,6 @@ func (db *db) addView(
 		newDefinitions[i].Description.BaseQuery = baseQuery
 	}
 
-	existingCollections, err := db.getAllCollections(ctx, txn)
-	if err != nil {
-		return nil, err
-	}
-
-	existingDefinitions := make([]client.CollectionDefinition, len(existingCollections))
-	for i := range existingCollections {
-		existingDefinitions[i] = existingCollections[i].Definition()
-	}
-
-	err = db.parser.SetSchema(ctx, txn, append(existingDefinitions, newDefinitions...))
-	if err != nil {
-		return nil, err
-	}
-
 	returnDescriptions := make([]client.CollectionDefinition, len(newDefinitions))
 	for i, definition := range newDefinitions {
 		if definition.Description.Name == "" {
@@ -93,6 +78,11 @@ func (db *db) addView(
 			}
 			returnDescriptions[i] = col.Definition()
 		}
+	}
+
+	err = db.loadSchema(ctx, txn)
+	if err != nil {
+		return nil, err
 	}
 
 	return returnDescriptions, nil

--- a/tests/integration/schema/simple_test.go
+++ b/tests/integration/schema/simple_test.go
@@ -78,7 +78,7 @@ func TestSchemaSimpleErrorsGivenDuplicateSchema(t *testing.T) {
 				Schema: `
 					type Users {}
 				`,
-				ExpectedError: "schema type already exists",
+				ExpectedError: "collection already exists",
 			},
 		},
 	}
@@ -94,7 +94,7 @@ func TestSchemaSimpleErrorsGivenDuplicateSchemaInSameSDL(t *testing.T) {
 					type Users {}
 					type Users {}
 				`,
-				ExpectedError: "schema type already exists",
+				ExpectedError: "collection already exists",
 			},
 		},
 	}

--- a/tests/integration/view/one_to_one/identical_schema_test.go
+++ b/tests/integration/view/one_to_one/identical_schema_test.go
@@ -92,3 +92,55 @@ func TestView_OneToOneSameSchema(t *testing.T) {
 
 	testUtils.ExecuteTestCase(t, test)
 }
+
+func TestView_OneToOneEmbeddedSchemaIsNotLostOnNextUpdate(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "One to one view followed by GQL type update",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Author {
+						name: String
+						books: [Book]
+					}
+					type Book {
+						name: String
+						author: Author
+					}
+				`,
+			},
+			testUtils.CreateView{
+				Query: `
+					Author {
+						name
+						books {
+							name
+						}
+					}
+				`,
+				SDL: `
+					type AuthorView {
+						name: String
+						books: [BookView]
+					}
+					interface BookView {
+						name: String
+					}
+				`,
+			},
+			// After creating the view, update the system's types again and ensure
+			// that `BookView` is not forgotten.  A GQL error would appear if this
+			// was broken as `AuthorView.books` would reference a type that does
+			// not exist.
+			testUtils.SchemaUpdate{
+				Schema: `
+					type User {
+						name: String
+					}
+				`,
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/view/one_to_one/identical_schema_test.go
+++ b/tests/integration/view/one_to_one/identical_schema_test.go
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-package one_to_many
+package one_to_one
 
 import (
 	"testing"

--- a/tests/integration/view/one_to_one/simple_test_test.go
+++ b/tests/integration/view/one_to_one/simple_test_test.go
@@ -1,0 +1,94 @@
+// Copyright 2024 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package one_to_one
+
+import (
+	"testing"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+func TestView_OneToOneDuplicateEmbeddedSchema_Errors(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "One to one view and duplicate embedded schema",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Author {
+						name: String
+						books: [Book]
+					}
+					type Book {
+						name: String
+						author: Author
+					}
+				`,
+			},
+			testUtils.CreateView{
+				Query: `
+					Author {
+						name
+						books {
+							name
+						}
+					}
+				`,
+				SDL: `
+					type AuthorView {
+						name: String
+						books: [BookView]
+					}
+					interface BookView {
+						name: String
+					}
+				`,
+			},
+			// Try and create a second view that creates a new `BookView`, this
+			// should error as `BookView` has already been created by the first view.
+			testUtils.CreateView{
+				Query: `
+					Author {
+						authorName: name
+						books {
+							bookName: name
+						}
+					}
+				`,
+				SDL: `
+					type AuthorAliasView {
+						authorName: String
+						books: [BookView]
+					}
+					interface BookView {
+						bookName: String
+					}
+				`,
+				ExpectedError: "schema type already exists. Name: BookView",
+			},
+			testUtils.IntrospectionRequest{
+				Request: `
+					query {
+						__type (name: "BookView") {
+							name
+						}
+					}
+				`,
+				ExpectedData: map[string]any{
+					"__type": map[string]any{
+						"name": "BookView",
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/view/one_to_one/with_restart_test.go
+++ b/tests/integration/view/one_to_one/with_restart_test.go
@@ -1,0 +1,88 @@
+// Copyright 2024 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package one_to_one
+
+import (
+	"testing"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+func TestView_OneToOneEmbeddedSchemaIsNotLostORestart(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "One to one view and restart",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Author {
+						name: String
+						books: [Book]
+					}
+					type Book {
+						name: String
+						author: Author
+					}
+				`,
+			},
+			testUtils.CreateView{
+				Query: `
+					Author {
+						name
+						books {
+							name
+						}
+					}
+				`,
+				SDL: `
+					type AuthorView {
+						name: String
+						books: [BookView]
+					}
+					interface BookView {
+						name: String
+					}
+				`,
+			},
+			// After creating the view, restart and ensure that `BookView` is not forgotten.
+			testUtils.Restart{},
+			testUtils.IntrospectionRequest{
+				Request: `
+					query {
+						__type (name: "AuthorView") {
+							name
+						}
+					}
+				`,
+				ExpectedData: map[string]any{
+					"__type": map[string]any{
+						"name": "AuthorView",
+					},
+				},
+			},
+			testUtils.IntrospectionRequest{
+				Request: `
+					query {
+						__type (name: "BookView") {
+							name
+						}
+					}
+				`,
+				ExpectedData: map[string]any{
+					"__type": map[string]any{
+						"name": "BookView",
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #2184 #2182

## Description

Retain embedded schema within gql types on reload and further GQL modification.

Also refactors the code a little to make it harder to re-introduce (calling `loadSchema` instead of sometimes relying on function vars).

Appears to accidentally solve #2182
Todo: 
- [x] Add proper tests for #2182
