### PR TITLE
fix: Add entropy to counter CRDT type updates

### DIFF
--- a/core/crdt/pncounter.go
+++ b/core/crdt/pncounter.go
@@ -13,6 +13,9 @@ package crdt
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
+	"math"
+	"math/big"
 
 	"github.com/fxamacker/cbor/v2"
 	dag "github.com/ipfs/boxo/ipld/merkledag"
@@ -45,6 +48,9 @@ type PNCounterDelta[T Incrementable] struct {
 	DocID     []byte
 	FieldName string
 	Priority  uint64
+	// Entropy is an added randomly generated number that ensures
+	// that each increment operation is unique.
+	Entropy int64
 	// SchemaVersionID is the schema version datastore key at the time of commit.
 	//
 	// It can be used to identify the collection datastructure state at the time of commit.
@@ -108,13 +114,30 @@ func (reg PNCounter[T]) Value(ctx context.Context) ([]byte, error) {
 }
 
 // Set generates a new delta with the supplied value
-func (reg PNCounter[T]) Increment(value T) *PNCounterDelta[T] {
+func (reg PNCounter[T]) Increment(ctx context.Context, value T) (*PNCounterDelta[T], error) {
+	// To ensure that the dag block is unique, we add a random number to the delta.
+	// This is done only on update (if the doc doesn't already exist) to ensure that the
+	// initial dag block of a document can be reproducible.
+	exists, err := reg.store.Has(ctx, reg.key.ToPrimaryDataStoreKey().ToDS())
+	if err != nil {
+		return nil, err
+	}
+	var entropy int64
+	if exists {
+		r, err := rand.Int(rand.Reader, big.NewInt(math.MaxInt64))
+		if err != nil {
+			return nil, err
+		}
+		entropy = r.Int64()
+	}
+
 	return &PNCounterDelta[T]{
 		DocID:           []byte(reg.key.DocID),
 		FieldName:       reg.fieldName,
 		Data:            value,
 		SchemaVersionID: reg.schemaVersionKey.SchemaVersionId,
-	}
+		Entropy:         entropy,
+	}, nil
 }
 
 // Merge implements ReplicatedData interface.

--- a/core/crdt/pncounter.go
+++ b/core/crdt/pncounter.go
@@ -48,9 +48,9 @@ type PNCounterDelta[T Incrementable] struct {
 	DocID     []byte
 	FieldName string
 	Priority  uint64
-	// Entropy is an added randomly generated number that ensures
+	// Nonce is an added randomly generated number that ensures
 	// that each increment operation is unique.
-	Entropy int64
+	Nonce int64
 	// SchemaVersionID is the schema version datastore key at the time of commit.
 	//
 	// It can be used to identify the collection datastructure state at the time of commit.
@@ -122,13 +122,13 @@ func (reg PNCounter[T]) Increment(ctx context.Context, value T) (*PNCounterDelta
 	if err != nil {
 		return nil, err
 	}
-	var entropy int64
+	var nonce int64
 	if exists {
 		r, err := rand.Int(rand.Reader, big.NewInt(math.MaxInt64))
 		if err != nil {
 			return nil, err
 		}
-		entropy = r.Int64()
+		nonce = r.Int64()
 	}
 
 	return &PNCounterDelta[T]{
@@ -136,7 +136,7 @@ func (reg PNCounter[T]) Increment(ctx context.Context, value T) (*PNCounterDelta
 		FieldName:       reg.fieldName,
 		Data:            value,
 		SchemaVersionID: reg.schemaVersionKey.SchemaVersionId,
-		Entropy:         entropy,
+		Nonce:           nonce,
 	}, nil
 }
 

--- a/docs/data_format_changes/i2186-adding-entropy-to-pn-counter.md
+++ b/docs/data_format_changes/i2186-adding-entropy-to-pn-counter.md
@@ -1,0 +1,3 @@
+# Adding entropy to pn counter delta
+
+We've added entropy to the pn counter delta by introducing a nonce field. This is causing some of the pn counter tests to have a different CID on updates.

--- a/merkle/crdt/pncounter.go
+++ b/merkle/crdt/pncounter.go
@@ -51,7 +51,10 @@ func (mPNC *MerklePNCounter[T]) Save(ctx context.Context, data any) (ipld.Node, 
 	if !ok {
 		return nil, 0, NewErrUnexpectedValueType(client.PN_COUNTER, &client.FieldValue{}, data)
 	}
-	delta := mPNC.reg.Increment(value.Value().(T))
+	delta, err := mPNC.reg.Increment(ctx, value.Value().(T))
+	if err != nil {
+		return nil, 0, err
+	}
 	nd, err := mPNC.clock.AddDAGNode(ctx, delta)
 	return nd, delta.GetPriority(), err
 }

--- a/tests/integration/mutation/create/crdt/pncounter_test.go
+++ b/tests/integration/mutation/create/crdt/pncounter_test.go
@@ -37,12 +37,14 @@ func TestPNCounterCreate_IntKindWithPositiveValue_NoError(t *testing.T) {
 			testUtils.Request{
 				Request: `query {
 					Users {
+						_docID
 						name
 						points
 					}
 				}`,
 				Results: []map[string]any{
 					{
+						"_docID": "bae-a688789e-d8a6-57a7-be09-22e005ab79e0",
 						"name":   "John",
 						"points": int64(10),
 					},

--- a/tests/integration/query/simple/with_cid_doc_id_test.go
+++ b/tests/integration/query/simple/with_cid_doc_id_test.go
@@ -269,9 +269,10 @@ func TestQuerySimpleWithUpdateAndFirstCidAndDocIDAndSchemaVersion(t *testing.T) 
 	executeTestCase(t, test)
 }
 
+// Note: Only the first CID is reproducible given the added entropy to the Counter CRDT type.
 func TestCidAndDocIDQuery_ContainsPNCounterWithIntKind_NoError(t *testing.T) {
 	test := testUtils.TestCase{
-		Description: "Simple query with second last cid and docID with pncounter int type",
+		Description: "Simple query with first cid and docID with pncounter int type",
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
@@ -300,7 +301,7 @@ func TestCidAndDocIDQuery_ContainsPNCounterWithIntKind_NoError(t *testing.T) {
 			testUtils.Request{
 				Request: `query {
 					Users (
-						cid: "bafybeiabh6mqnysyrv5phhjikjyl5zgxnpxzxogpip7s7knyujkh7fx3qu",
+						cid: "bafybeickgiyku2f22hie7ikr46nsskmccdqufvbaoqjytptmpxb6vk3kfi",
 						docID: "bae-a688789e-d8a6-57a7-be09-22e005ab79e0"
 					) {
 						name
@@ -310,7 +311,7 @@ func TestCidAndDocIDQuery_ContainsPNCounterWithIntKind_NoError(t *testing.T) {
 				Results: []map[string]any{
 					{
 						"name":   "John",
-						"points": int64(5),
+						"points": int64(10),
 					},
 				},
 			},
@@ -320,9 +321,10 @@ func TestCidAndDocIDQuery_ContainsPNCounterWithIntKind_NoError(t *testing.T) {
 	testUtils.ExecuteTestCase(t, test)
 }
 
+// Note: Only the first CID is reproducible given the added entropy to the Counter CRDT type.
 func TestCidAndDocIDQuery_ContainsPNCounterWithFloatKind_NoError(t *testing.T) {
 	test := testUtils.TestCase{
-		Description: "Simple query with second last cid and docID with pncounter and float type",
+		Description: "Simple query with first cid and docID with pncounter and float type",
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
@@ -351,7 +353,7 @@ func TestCidAndDocIDQuery_ContainsPNCounterWithFloatKind_NoError(t *testing.T) {
 			testUtils.Request{
 				Request: `query {
 					Users (
-						cid: "bafybeiaqw6oxeshkvd3ilzzagjy3c6h776l3hqvmz5loq4sokr7tlxkm5m",
+						cid: "bafybeigm7fohco7l2hvg3zpslu2wu6dtz4azb7ikxczdtw5dvpyix26fr4",
 						docID: "bae-fa6a97e9-e0e9-5826-8a8c-57775d35e07c"
 					) {
 						name
@@ -360,9 +362,8 @@ func TestCidAndDocIDQuery_ContainsPNCounterWithFloatKind_NoError(t *testing.T) {
 				}`,
 				Results: []map[string]any{
 					{
-						"name": "John",
-						// Note the lack of precision of float types.
-						"points": 4.8999999999999995,
+						"name":   "John",
+						"points": 10.2,
 					},
 				},
 			},

--- a/tests/integration/query/simple/with_cid_doc_id_test.go
+++ b/tests/integration/query/simple/with_cid_doc_id_test.go
@@ -301,7 +301,7 @@ func TestCidAndDocIDQuery_ContainsPNCounterWithIntKind_NoError(t *testing.T) {
 			testUtils.Request{
 				Request: `query {
 					Users (
-						cid: "bafybeickgiyku2f22hie7ikr46nsskmccdqufvbaoqjytptmpxb6vk3kfi",
+						cid: "bafybeiepi2gpoyshdj2ekdsydhw5itxqmipsh7f6pd6iyoiu6sqsdlj2se",
 						docID: "bae-a688789e-d8a6-57a7-be09-22e005ab79e0"
 					) {
 						name
@@ -353,7 +353,7 @@ func TestCidAndDocIDQuery_ContainsPNCounterWithFloatKind_NoError(t *testing.T) {
 			testUtils.Request{
 				Request: `query {
 					Users (
-						cid: "bafybeigm7fohco7l2hvg3zpslu2wu6dtz4azb7ikxczdtw5dvpyix26fr4",
+						cid: "bafybeihjdntxsc75hpnyakog4nnaxakljer7zf7pjybpgntcsg45qmisau",
 						docID: "bae-fa6a97e9-e0e9-5826-8a8c-57775d35e07c"
 					) {
 						name


### PR DESCRIPTION
## Relevant issue(s)

Resolves #2179 

## Description

Counters need to be incrementable independently from different nodes. Initially, if two nodes incremented by the same amount from the same synced state, then the update CID would be the same and thus taken as a the same operation when syncing. So starting from 10 if both node A and B increment by 5 simultaneously, because they would generate the same CID for the update, the end result would be 15. We want it to be 20.

This PR adds entropy to the PN Counter delta so that a situation like described above would result in 20.

Note that the entropy is only added on update so that a document can be instantiated on multiple nodes with exactly the same CID.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

make test

Specify the platform(s) on which this was tested:
- MacOS
