### PR TITLE
fix(i): Dont build mutation input types for embedded schema

### DIFF
--- a/request/graphql/schema/generate.go
+++ b/request/graphql/schema/generate.go
@@ -528,6 +528,13 @@ func (g *Generator) buildTypes(
 // for collection create and update mutation operations.
 func (g *Generator) buildMutationInputTypes(collections []client.CollectionDefinition) error {
 	for _, c := range collections {
+		if c.Description.Name == "" {
+			// If the definition's collection is empty, this must be a collectionless
+			// schema, in which case users cannot mutate documents through it and we
+			// have no need to build mutation input types for it.
+			continue
+		}
+
 		// Copy the loop variable before usage within the loop or it
 		// will be reassigned before the thunk is run
 		// TODO remove when Go 1.22

--- a/tests/integration/view/one_to_many/simple_test.go
+++ b/tests/integration/view/one_to_many/simple_test.go
@@ -303,3 +303,63 @@ func TestView_OneToManyWithRelationInQueryButNotInSDL(t *testing.T) {
 
 	testUtils.ExecuteTestCase(t, test)
 }
+
+func TestView_OneToManyMultipleViewsWithEmbeddedSchema(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "Multiple one to many views with embedded schemas",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Author {
+						name: String
+						books: [Book]
+					}
+					type Book {
+						name: String
+						author: Author
+					}
+				`,
+			},
+			testUtils.CreateView{
+				Query: `
+					Book {
+						name
+						author {
+							name
+						}
+					}
+				`,
+				SDL: `
+					type BookView {
+						name: String
+						author: AuthorView
+					}
+					interface AuthorView {
+						name: String
+					}
+				`,
+			},
+			testUtils.CreateView{
+				Query: `
+					Book {
+						name
+						author {
+							name
+						}
+					}
+				`,
+				SDL: `
+					type BookView2 {
+						name: String
+						author: AuthorView2
+					}
+					interface AuthorView2 {
+						name: String
+					}
+				`,
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #2191

## Description

Don't generate mutation input types for embedded schema.