### PR TITLE
fix(i): Remove default collection fields from gql view types

### DIFF
--- a/request/graphql/schema/generate.go
+++ b/request/graphql/schema/generate.go
@@ -417,6 +417,7 @@ func (g *Generator) buildTypes(
 		collection := c
 		fieldDescriptions := collection.Schema.Fields
 		isEmbeddedObject := collection.Description.Name == ""
+		isViewObject := isEmbeddedObject || collection.Description.BaseQuery != nil
 
 		var objectName string
 		if isEmbeddedObject {
@@ -441,7 +442,7 @@ func (g *Generator) buildTypes(
 		fieldsThunk := (gql.FieldsThunk)(func() (gql.Fields, error) {
 			fields := gql.Fields{}
 
-			if !isEmbeddedObject {
+			if !isViewObject {
 				// automatically add the _docID: ID field to the type
 				fields[request.DocIDFieldName] = &gql.Field{
 					Description: docIDFieldDescription,
@@ -495,7 +496,7 @@ func (g *Generator) buildTypes(
 				Type:        gql.NewList(gqlType),
 			}
 
-			if !isEmbeddedObject {
+			if !isViewObject {
 				// add _version field
 				fields[request.VersionFieldName] = &gql.Field{
 					Description: versionFieldDescription,

--- a/tests/integration/schema/default_fields.go
+++ b/tests/integration/schema/default_fields.go
@@ -70,9 +70,9 @@ var DefaultFields = concat(
 	aggregateFields,
 )
 
-// DefaultEmbeddedObjFields contains the list of fields every
-// defra embedded-object should have.
-var DefaultEmbeddedObjFields = concat(
+// DefaultViewObjFields contains the list of fields every
+// defra view-object should have.
+var DefaultViewObjFields = concat(
 	fields{
 		groupField,
 	},

--- a/tests/integration/view/one_to_many/with_introspection_test.go
+++ b/tests/integration/view/one_to_many/with_introspection_test.go
@@ -112,7 +112,7 @@ func TestView_OneToMany_GQLIntrospectionTest(t *testing.T) {
 						// although aggregates and `_group` should be.
 						// There should also be no `Author` field - the relationship field
 						// should only exist on the parent.
-						"fields": schema.DefaultEmbeddedObjFields.Append(
+						"fields": schema.DefaultViewObjFields.Append(
 							schema.Field{
 								"name": "name",
 								"type": map[string]any{

--- a/tests/integration/view/one_to_many/with_introspection_test.go
+++ b/tests/integration/view/one_to_many/with_introspection_test.go
@@ -70,7 +70,7 @@ func TestView_OneToMany_GQLIntrospectionTest(t *testing.T) {
 				ExpectedData: map[string]any{
 					"__type": map[string]any{
 						"name": "AuthorView",
-						"fields": schema.DefaultFields.Append(
+						"fields": schema.DefaultViewObjFields.Append(
 							schema.Field{
 								"name": "name",
 								"type": map[string]any{

--- a/tests/integration/view/simple/with_introspection_test.go
+++ b/tests/integration/view/simple/with_introspection_test.go
@@ -58,7 +58,7 @@ func TestView_Simple_GQLIntrospectionTest(t *testing.T) {
 				ExpectedData: map[string]any{
 					"__type": map[string]any{
 						"name": "UserView",
-						"fields": schema.DefaultFields.Append(
+						"fields": schema.DefaultViewObjFields.Append(
 							schema.Field{
 								"name": "name",
 								"type": map[string]any{


### PR DESCRIPTION
## Relevant issue(s)

Resolves #2199

## Description

Removes default collection fields from gql view types.

Views should not automatically have these fields.  It will also be impossible to guarantee that they exist once we allow Views to have Lens transforms.