### PR TITLE
fix(i): Prevent double-sided relations in views

### DIFF
--- a/request/graphql/schema/collection.go
+++ b/request/graphql/schema/collection.go
@@ -536,7 +536,12 @@ func finalizeRelations(relationManager *RelationManager, definitions []client.Co
 
 			// if not finalized then we are missing one side of the relationship
 			// unless this is an embedded object, which only have single-sided relations
-			if _, ok := embeddedObjNames[field.Schema]; !ok && !rel.finalized {
+			_, shouldBeOneSidedRelation := embeddedObjNames[field.Schema]
+			if shouldBeOneSidedRelation && rel.finalized {
+				return NewErrViewRelationMustBeOneSided(field.Name, field.Schema)
+			}
+
+			if !shouldBeOneSidedRelation && !rel.finalized {
 				return client.NewErrRelationOneSided(field.Name, field.Schema)
 			}
 

--- a/request/graphql/schema/errors.go
+++ b/request/graphql/schema/errors.go
@@ -27,6 +27,7 @@ const (
 	errIndexUnknownArgument          string = "index with unknown argument"
 	errIndexInvalidArgument          string = "index with invalid argument"
 	errIndexInvalidName              string = "index with invalid name"
+	errViewRelationMustBeOneSided    string = "relations in views must only be defined on one schema"
 )
 
 var (
@@ -46,10 +47,11 @@ var (
 	ErrMultipleRelationPrimaries     = errors.New("relation can only have a single field set as primary")
 	// NonNull is the literal name of the GQL type, so we have to disable the linter
 	//nolint:revive
-	ErrNonNullNotSupported = errors.New("NonNull fields are not currently supported")
-	ErrIndexMissingFields  = errors.New(errIndexMissingFields)
-	ErrIndexWithUnknownArg = errors.New(errIndexUnknownArgument)
-	ErrIndexWithInvalidArg = errors.New(errIndexInvalidArgument)
+	ErrNonNullNotSupported        = errors.New("NonNull fields are not currently supported")
+	ErrIndexMissingFields         = errors.New(errIndexMissingFields)
+	ErrIndexWithUnknownArg        = errors.New(errIndexUnknownArgument)
+	ErrIndexWithInvalidArg        = errors.New(errIndexInvalidArgument)
+	ErrViewRelationMustBeOneSided = errors.New(errViewRelationMustBeOneSided)
 )
 
 func NewErrDuplicateField(objectName, fieldName string) error {
@@ -128,5 +130,13 @@ func NewErrRelationNotFound(relationName string) error {
 	return errors.New(
 		errRelationNotFound,
 		errors.NewKV("RelationName", relationName),
+	)
+}
+
+func NewErrViewRelationMustBeOneSided(fieldName string, typeName string) error {
+	return errors.New(
+		errViewRelationMustBeOneSided,
+		errors.NewKV("Field", fieldName),
+		errors.NewKV("Type", typeName),
 	)
 }

--- a/tests/integration/view/one_to_many/simple_test.go
+++ b/tests/integration/view/one_to_many/simple_test.go
@@ -363,3 +363,46 @@ func TestView_OneToManyMultipleViewsWithEmbeddedSchema(t *testing.T) {
 
 	testUtils.ExecuteTestCase(t, test)
 }
+
+func TestView_OneToManyWithDoubleSidedRelation_Errors(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "One to many view",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Author {
+						name: String
+						books: [Book]
+					}
+					type Book {
+						name: String
+						author: Author
+					}
+				`,
+			},
+			testUtils.CreateView{
+				Query: `
+					Author {
+						name
+						books {
+							name
+						}
+					}
+				`,
+				SDL: `
+					type AuthorView {
+						name: String
+						books: [BookView]
+					}
+					interface BookView {
+						name: String
+						author: AuthorView
+					}
+				`,
+				ExpectedError: "relations in views must only be defined on one schema",
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #2221

## Description

Prevents users from defining double-sided relations in views.

I'm pretty sure this was discussed during the development of views, and accepted as a means of simplifying initial development (lots of stuff gets really complicated if we allow this).  Is just that I only permitted one sided relations, I never blocked off double sided relations.