### PR TITLE
feat: Add composite indexes

### DIFF
--- a/client/index.go
+++ b/client/index.go
@@ -58,3 +58,13 @@ func (d CollectionDescription) CollectIndexedFields(schema *SchemaDescription) [
 	}
 	return fields
 }
+
+func (d CollectionDescription) CollectIndexesOnField(fieldName string) []IndexDescription {
+	result := []IndexDescription{}
+	for _, index := range d.Indexes {
+		if index.Fields[0].Name == fieldName {
+			result = append(result, index)
+		}
+	}
+	return result
+}

--- a/client/index.go
+++ b/client/index.go
@@ -59,7 +59,9 @@ func (d CollectionDescription) CollectIndexedFields(schema *SchemaDescription) [
 	return fields
 }
 
-func (d CollectionDescription) CollectIndexesOnField(fieldName string) []IndexDescription {
+// GetIndexesOnField returns all indexes that are indexing the given field.
+// If the field is not the first field of a composite index, the index is not returned.
+func (d CollectionDescription) GetIndexesOnField(fieldName string) []IndexDescription {
 	result := []IndexDescription{}
 	for _, index := range d.Indexes {
 		if index.Fields[0].Name == fieldName {

--- a/client/index_test.go
+++ b/client/index_test.go
@@ -1,0 +1,119 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCollectIndexesOnField(t *testing.T) {
+	tests := []struct {
+		name     string
+		desc     CollectionDescription
+		field    string
+		expected []IndexDescription
+	}{
+		{
+			name: "no indexes",
+			desc: CollectionDescription{
+				Indexes: []IndexDescription{},
+			},
+			field:    "test",
+			expected: []IndexDescription{},
+		},
+		{
+			name: "single index on field",
+			desc: CollectionDescription{
+				Indexes: []IndexDescription{
+					{
+						Name: "index1",
+						Fields: []IndexedFieldDescription{
+							{Name: "test", Direction: Ascending},
+						},
+					},
+				},
+			},
+			field: "test",
+			expected: []IndexDescription{
+				{
+					Name: "index1",
+					Fields: []IndexedFieldDescription{
+						{Name: "test", Direction: Ascending},
+					},
+				},
+			},
+		},
+		{
+			name: "multiple indexes on field",
+			desc: CollectionDescription{
+				Indexes: []IndexDescription{
+					{
+						Name: "index1",
+						Fields: []IndexedFieldDescription{
+							{Name: "test", Direction: Ascending},
+						},
+					},
+					{
+						Name: "index2",
+						Fields: []IndexedFieldDescription{
+							{Name: "test", Direction: Descending},
+						},
+					},
+				},
+			},
+			field: "test",
+			expected: []IndexDescription{
+				{
+					Name: "index1",
+					Fields: []IndexedFieldDescription{
+						{Name: "test", Direction: Ascending},
+					},
+				},
+				{
+					Name: "index2",
+					Fields: []IndexedFieldDescription{
+						{Name: "test", Direction: Descending},
+					},
+				},
+			},
+		},
+		{
+			name: "no indexes on field",
+			desc: CollectionDescription{
+				Indexes: []IndexDescription{
+					{
+						Name: "index1",
+						Fields: []IndexedFieldDescription{
+							{Name: "other", Direction: Ascending},
+						},
+					},
+				},
+			},
+			field:    "test",
+			expected: []IndexDescription{},
+		},
+		{
+			name: "second field in composite index",
+			desc: CollectionDescription{
+				Indexes: []IndexDescription{
+					{
+						Name: "index1",
+						Fields: []IndexedFieldDescription{
+							{Name: "other", Direction: Ascending},
+							{Name: "test", Direction: Ascending},
+						},
+					},
+				},
+			},
+			field:    "test",
+			expected: []IndexDescription{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := tt.desc.CollectIndexesOnField(tt.field)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}

--- a/client/index_test.go
+++ b/client/index_test.go
@@ -1,3 +1,13 @@
+// Copyright 2024 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
 package client
 
 import (

--- a/client/index_test.go
+++ b/client/index_test.go
@@ -122,7 +122,7 @@ func TestCollectIndexesOnField(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			actual := tt.desc.CollectIndexesOnField(tt.field)
+			actual := tt.desc.GetIndexesOnField(tt.field)
 			assert.Equal(t, tt.expected, actual)
 		})
 	}

--- a/db/collection_index.go
+++ b/db/collection_index.go
@@ -232,7 +232,8 @@ func (c *collection) createIndex(
 	c.indexes = append(c.indexes, colIndex)
 	err = c.indexExistingDocs(ctx, txn, colIndex)
 	if err != nil {
-		return nil, err
+		removeErr := colIndex.RemoveAll(ctx, txn)
+		return nil, errors.Join(err, removeErr)
 	}
 	return colIndex, nil
 }

--- a/db/errors.go
+++ b/db/errors.go
@@ -87,6 +87,7 @@ const (
 	errOneOneAlreadyLinked                string = "target document is already linked to another document"
 	errIndexDoesNotMatchName              string = "the index used does not match the given name"
 	errCanNotIndexNonUniqueField          string = "can not index a doc's field that violates unique index"
+	errCanNotIndexNonUniqueCombination    string = "can not index a doc's fields that violate unique index"
 	errInvalidViewQuery                   string = "the query provided is not valid as a View"
 )
 
@@ -573,6 +574,14 @@ func NewErrCanNotIndexNonUniqueField(docID, fieldName string, value any) error {
 		errors.NewKV("Field name", fieldName),
 		errors.NewKV("Field value", value),
 	)
+}
+
+func NewErrCanNotIndexNonUniqueCombination(docID string, fieldValues ...errors.KV) error {
+	kvPairs := make([]errors.KV, 0, len(fieldValues)+1)
+	kvPairs = append(kvPairs, errors.NewKV("DocID", docID))
+	kvPairs = append(kvPairs, fieldValues...)
+
+	return errors.New(errCanNotIndexNonUniqueCombination, kvPairs...)
 }
 
 func NewErrInvalidViewQueryCastFailed(query string) error {

--- a/db/errors.go
+++ b/db/errors.go
@@ -69,7 +69,6 @@ const (
 	errInvalidFieldValue                  string = "invalid field value"
 	errUnsupportedIndexFieldType          string = "unsupported index field type"
 	errIndexDescriptionHasNoFields        string = "index description has no fields"
-	errIndexDescHasNonExistingField       string = "index description has non existing field"
 	errFieldOrAliasToFieldNotExist        string = "The given field or alias to field does not exist"
 	errCreateFile                         string = "failed to create file"
 	errRemoveFile                         string = "failed to remove file"
@@ -466,16 +465,6 @@ func NewErrIndexDescHasNoFields(desc client.IndexDescription) error {
 	return errors.New(
 		errIndexDescriptionHasNoFields,
 		errors.NewKV("Description", desc),
-	)
-}
-
-// NewErrIndexDescHasNonExistingField returns a new error indicating that the given index
-// description points to a field that does not exist.
-func NewErrIndexDescHasNonExistingField(desc client.IndexDescription, fieldName string) error {
-	return errors.New(
-		errIndexDescHasNonExistingField,
-		errors.NewKV("Description", desc),
-		errors.NewKV("Field name", fieldName),
 	)
 }
 

--- a/db/errors.go
+++ b/db/errors.go
@@ -86,8 +86,7 @@ const (
 	errExpectedJSONArray                  string = "expected JSON array"
 	errOneOneAlreadyLinked                string = "target document is already linked to another document"
 	errIndexDoesNotMatchName              string = "the index used does not match the given name"
-	errCanNotIndexNonUniqueField          string = "can not index a doc's field that violates unique index"
-	errCanNotIndexNonUniqueCombination    string = "can not index a doc's fields that violate unique index"
+	errCanNotIndexNonUniqueFields         string = "can not index a doc's field(s) that violates unique index"
 	errInvalidViewQuery                   string = "the query provided is not valid as a View"
 )
 
@@ -109,6 +108,7 @@ var (
 	ErrExpectedJSONObject             = errors.New(errExpectedJSONObject)
 	ErrExpectedJSONArray              = errors.New(errExpectedJSONArray)
 	ErrInvalidViewQuery               = errors.New(errInvalidViewQuery)
+	ErrCanNotIndexNonUniqueFields     = errors.New(errCanNotIndexNonUniqueFields)
 )
 
 // NewErrFailedToGetHeads returns a new error indicating that the heads of a document
@@ -567,21 +567,12 @@ func NewErrIndexDoesNotMatchName(index, name string) error {
 	)
 }
 
-func NewErrCanNotIndexNonUniqueField(docID, fieldName string, value any) error {
-	return errors.New(
-		errCanNotIndexNonUniqueField,
-		errors.NewKV("DocID", docID),
-		errors.NewKV("Field name", fieldName),
-		errors.NewKV("Field value", value),
-	)
-}
-
-func NewErrCanNotIndexNonUniqueCombination(docID string, fieldValues ...errors.KV) error {
+func NewErrCanNotIndexNonUniqueFields(docID string, fieldValues ...errors.KV) error {
 	kvPairs := make([]errors.KV, 0, len(fieldValues)+1)
 	kvPairs = append(kvPairs, errors.NewKV("DocID", docID))
 	kvPairs = append(kvPairs, fieldValues...)
 
-	return errors.New(errCanNotIndexNonUniqueCombination, kvPairs...)
+	return errors.New(errCanNotIndexNonUniqueFields, kvPairs...)
 }
 
 func NewErrInvalidViewQueryCastFailed(query string) error {

--- a/db/fetcher/errors.go
+++ b/db/fetcher/errors.go
@@ -26,6 +26,8 @@ const (
 	errVFetcherFailedToGetDagLink   string = "(version fetcher) failed to get node link from DAG"
 	errFailedToGetDagNode           string = "failed to get DAG Node"
 	errMissingMapper                string = "missing document mapper"
+	errInvalidInOperatorValue       string = "invalid _in/_nin value"
+	errInvalidIndexFilterCondition  string = "invalid index filter condition"
 )
 
 var (
@@ -41,6 +43,8 @@ var (
 	ErrFailedToGetDagNode           = errors.New(errFailedToGetDagNode)
 	ErrMissingMapper                = errors.New(errMissingMapper)
 	ErrSingleSpanOnly               = errors.New("spans must contain only a single entry")
+	ErrInvalidInOperatorValue       = errors.New(errInvalidInOperatorValue)
+	ErrInvalidIndexFilterCondition  = errors.New(errInvalidIndexFilterCondition)
 )
 
 // NewErrFieldIdNotFound returns an error indicating that the given FieldId was not found.

--- a/db/fetcher/indexer.go
+++ b/db/fetcher/indexer.go
@@ -77,7 +77,7 @@ func (f *IndexFetcher) Init(
 		}
 	}
 
-	f.docFields = make([]client.FieldDescription, 0, len(fields)-len(f.indexedFields))
+	f.docFields = make([]client.FieldDescription, 0, len(fields))
 outer:
 	for i := range fields {
 		for j := range f.indexedFields {

--- a/db/fetcher/indexer.go
+++ b/db/fetcher/indexer.go
@@ -88,7 +88,7 @@ outer:
 		f.docFields = append(f.docFields, fields[i])
 	}
 
-	iter, err := createIndexIterator(f.indexFilter, &f.execInfo, f.indexDesc, f.col.ID())
+	iter, err := f.createIndexIterator()
 	if err != nil {
 		return err
 	}

--- a/db/fetcher/indexer.go
+++ b/db/fetcher/indexer.go
@@ -23,19 +23,18 @@ import (
 // IndexFetcher is a fetcher that fetches documents by index.
 // It fetches only the indexed field and the rest of the fields are fetched by the internal fetcher.
 type IndexFetcher struct {
-	docFetcher        Fetcher
-	col               client.Collection
-	txn               datastore.Txn
-	indexFilter       *mapper.Filter
-	docFilter         *mapper.Filter
-	doc               *encodedDocument
-	mapping           *core.DocumentMapping
-	indexedFields     []client.FieldDescription
-	docFields         []client.FieldDescription
-	indexDesc         client.IndexDescription
-	indexIter         indexIterator
-	indexDataStoreKey core.IndexDataStoreKey
-	execInfo          ExecInfo
+	docFetcher    Fetcher
+	col           client.Collection
+	txn           datastore.Txn
+	indexFilter   *mapper.Filter
+	docFilter     *mapper.Filter
+	doc           *encodedDocument
+	mapping       *core.DocumentMapping
+	indexedFields []client.FieldDescription
+	docFields     []client.FieldDescription
+	indexDesc     client.IndexDescription
+	indexIter     indexIterator
+	execInfo      ExecInfo
 }
 
 var _ Fetcher = (*IndexFetcher)(nil)
@@ -69,9 +68,6 @@ func (f *IndexFetcher) Init(
 	f.mapping = docMapper
 	f.txn = txn
 
-	f.indexDataStoreKey.IndexID = f.indexDesc.ID
-	f.indexDataStoreKey.CollectionID = f.col.ID()
-
 	for _, indexedField := range f.indexDesc.Fields {
 		for _, field := range f.col.Schema().Fields {
 			if field.Name == indexedField.Name {
@@ -92,7 +88,7 @@ outer:
 		f.docFields = append(f.docFields, fields[i])
 	}
 
-	iter, err := createIndexIterator(f.indexDataStoreKey, f.indexFilter, &f.execInfo, f.indexDesc.Unique)
+	iter, err := createIndexIterator(f.indexFilter, &f.execInfo, f.indexDesc, f.col.ID())
 	if err != nil {
 		return err
 	}

--- a/db/fetcher/indexer_iterators.go
+++ b/db/fetcher/indexer_iterators.go
@@ -396,11 +396,12 @@ func (m *indexLikeMatcher) doesMatch(currentVal string) bool {
 }
 
 func createIndexIterator(
-	indexDataStoreKey core.IndexDataStoreKey,
 	indexFilterConditions *mapper.Filter,
 	execInfo *ExecInfo,
-	isUnique bool,
+	indexDesc client.IndexDescription,
+	colID uint32,
 ) (indexIterator, error) {
+	indexDataStoreKey := core.IndexDataStoreKey{CollectionID: colID, IndexID: indexDesc.ID}
 	var op string
 	var filterVal any
 	for _, indexFilterCond := range indexFilterConditions.Conditions {
@@ -425,7 +426,7 @@ func createIndexIterator(
 
 		switch op {
 		case opEq:
-			if isUnique {
+			if indexDesc.Unique {
 				return &eqSingleIndexIterator{
 					indexKey: indexDataStoreKey,
 					filterValueHolder: filterValueHolder{
@@ -503,7 +504,7 @@ func createIndexIterator(
 		}
 		if op == opIn {
 			var iter filterValueIndexIterator
-			if isUnique {
+			if indexDesc.Unique {
 				iter = &eqSingleIndexIterator{
 					indexKey: indexDataStoreKey,
 					execInfo: execInfo,

--- a/db/fetcher/indexer_iterators.go
+++ b/db/fetcher/indexer_iterators.go
@@ -39,7 +39,12 @@ const (
 	opNin   = "_nin"
 	opLike  = "_like"
 	opNlike = "_nlike"
-	opAny   = "_any"
+	// it's just there for composite indexes. We construct a slice of value matchers with
+	// every matcher being responsible for a corresponding field in the index to match.
+	// For some fields there might not be any criteria to match. For examples if you have
+	// composite index of /name/age/email/ and in the filter you specify only "name" and "email".
+	// Then the "_any" matcher will be used for "age".
+	opAny = "_any"
 )
 
 // indexIterator is an iterator over index keys.

--- a/db/fetcher/indexer_iterators.go
+++ b/db/fetcher/indexer_iterators.go
@@ -504,9 +504,9 @@ func (f *IndexFetcher) createIndexIterator() (indexIterator, error) {
 
 	switch fieldConditions[0].op {
 	case opEq:
-		writableValue := client.NewCBORValue(client.LWW_REGISTER, fieldConditions[0].val)
+		fieldVal := client.NewFieldValue(client.LWW_REGISTER, fieldConditions[0].val)
 
-		keyValueBytes, err := writableValue.Bytes()
+		keyValueBytes, err := fieldVal.Bytes()
 		if err != nil {
 			return nil, err
 		}
@@ -536,8 +536,8 @@ func (f *IndexFetcher) createIndexIterator() (indexIterator, error) {
 		}
 		keyFieldArr := make([][]byte, 0, len(inArr))
 		for _, v := range inArr {
-			writableValue := client.NewCBORValue(client.LWW_REGISTER, v)
-			keyFieldBytes, err := writableValue.Bytes()
+			fieldVal := client.NewFieldValue(client.LWW_REGISTER, v)
+			keyFieldBytes, err := fieldVal.Bytes()
 			if err != nil {
 				return nil, err
 			}

--- a/db/index.go
+++ b/db/index.go
@@ -96,7 +96,7 @@ func NewCollectionIndex(
 	for _, fieldDesc := range desc.Fields {
 		field, foundField := collection.Schema().GetField(fieldDesc.Name)
 		if !foundField {
-			return nil, NewErrIndexDescHasNonExistingField(desc, desc.Fields[0].Name)
+			return nil, client.NewErrFieldNotExist(desc.Fields[0].Name)
 		}
 		base.fieldsDescs = append(base.fieldsDescs, field)
 		validateFunc, err := getFieldValidateFunc(field.Kind)

--- a/db/index.go
+++ b/db/index.go
@@ -131,9 +131,8 @@ func (i *collectionBaseIndex) getDocFieldValue(doc *client.Document) ([][]byte, 
 				}
 				result = append(result, valBytes)
 				continue
-			} else {
-				return nil, err
 			}
+			return nil, err
 		}
 		if !i.validateFieldFuncs[iter](fieldVal.Value()) {
 			return nil, NewErrInvalidFieldValue(i.fieldsDescs[iter].Kind, fieldVal)

--- a/db/index.go
+++ b/db/index.go
@@ -90,16 +90,20 @@ func NewCollectionIndex(
 	if len(desc.Fields) == 0 {
 		return nil, NewErrIndexDescHasNoFields(desc)
 	}
-	field, foundField := collection.Schema().GetField(desc.Fields[0].Name)
-	if !foundField {
-		return nil, NewErrIndexDescHasNonExistingField(desc, desc.Fields[0].Name)
-	}
 	base := collectionBaseIndex{collection: collection, desc: desc}
-	base.fieldDesc = field
-	var err error
-	base.validateFieldFunc, err = getFieldValidateFunc(field.Kind)
-	if err != nil {
-		return nil, err
+	base.validateFieldFuncs = make([]func(any) bool, 0, len(desc.Fields))
+	base.fieldsDescs = make([]client.FieldDescription, 0, len(desc.Fields))
+	for _, fieldDesc := range desc.Fields {
+		field, foundField := collection.Schema().GetField(fieldDesc.Name)
+		if !foundField {
+			return nil, NewErrIndexDescHasNonExistingField(desc, desc.Fields[0].Name)
+		}
+		base.fieldsDescs = append(base.fieldsDescs, field)
+		validateFunc, err := getFieldValidateFunc(field.Kind)
+		if err != nil {
+			return nil, err
+		}
+		base.validateFieldFuncs = append(base.validateFieldFuncs, validateFunc)
 	}
 	if desc.Unique {
 		return &collectionUniqueIndex{collectionBaseIndex: base}, nil
@@ -109,34 +113,44 @@ func NewCollectionIndex(
 }
 
 type collectionBaseIndex struct {
-	collection        client.Collection
-	desc              client.IndexDescription
-	validateFieldFunc func(any) bool
-	fieldDesc         client.FieldDescription
+	collection         client.Collection
+	desc               client.IndexDescription
+	validateFieldFuncs []func(any) bool
+	fieldsDescs        []client.FieldDescription
 }
 
-func (i *collectionBaseIndex) getDocFieldValue(doc *client.Document) ([]byte, error) {
-	// collectionSimpleIndex only supports single field indexes, that's why we
-	// can safely access the first field
-	indexedFieldName := i.desc.Fields[0].Name
-	fieldVal, err := doc.GetValue(indexedFieldName)
-	if err != nil {
-		if errors.Is(err, client.ErrFieldNotExist) {
-			return client.NewFieldValue(client.LWW_REGISTER, nil).Bytes()
-		} else {
+func (i *collectionBaseIndex) getDocFieldValue(doc *client.Document) ([][]byte, error) {
+	result := make([][]byte, 0, len(i.fieldsDescs))
+	for iter := range i.fieldsDescs {
+		fieldVal, err := doc.GetValue(i.fieldsDescs[iter].Name)
+		if err != nil {
+			if errors.Is(err, client.ErrFieldNotExist) {
+				valBytes, err := client.NewFieldValue(client.LWW_REGISTER, nil).Bytes()
+				if err != nil {
+					return nil, err
+				}
+				result = append(result, valBytes)
+				continue
+			} else {
+				return nil, err
+			}
+		}
+		if !i.validateFieldFuncs[iter](fieldVal.Value()) {
+			return nil, NewErrInvalidFieldValue(i.fieldsDescs[iter].Kind, fieldVal)
+		}
+		valBytes, err := fieldVal.Bytes()
+		if err != nil {
 			return nil, err
 		}
+		result = append(result, valBytes)
 	}
-	if !i.validateFieldFunc(fieldVal.Value()) {
-		return nil, NewErrInvalidFieldValue(i.fieldDesc.Kind, fieldVal)
-	}
-	return fieldVal.Bytes()
+	return result, nil
 }
 
 func (i *collectionBaseIndex) getDocumentsIndexKey(
 	doc *client.Document,
 ) (core.IndexDataStoreKey, error) {
-	fieldValue, err := i.getDocFieldValue(doc)
+	fieldValues, err := i.getDocFieldValue(doc)
 	if err != nil {
 		return core.IndexDataStoreKey{}, err
 	}
@@ -144,7 +158,7 @@ func (i *collectionBaseIndex) getDocumentsIndexKey(
 	indexDataStoreKey := core.IndexDataStoreKey{}
 	indexDataStoreKey.CollectionID = i.collection.ID()
 	indexDataStoreKey.IndexID = i.desc.ID
-	indexDataStoreKey.FieldValues = [][]byte{fieldValue}
+	indexDataStoreKey.FieldValues = fieldValues
 	return indexDataStoreKey, nil
 }
 
@@ -289,7 +303,7 @@ func (i *collectionUniqueIndex) Save(
 func (i *collectionUniqueIndex) newUniqueIndexError(
 	doc *client.Document,
 ) error {
-	fieldVal, err := doc.GetValue(i.fieldDesc.Name)
+	fieldVal, err := doc.GetValue(i.fieldsDescs[0].Name)
 	var val any
 	if err != nil {
 		// If the error is ErrFieldNotExist, we leave `val` as is (e.g. nil)
@@ -301,7 +315,7 @@ func (i *collectionUniqueIndex) newUniqueIndexError(
 		val = fieldVal.Value()
 	}
 
-	return NewErrCanNotIndexNonUniqueField(doc.ID().String(), i.fieldDesc.Name, val)
+	return NewErrCanNotIndexNonUniqueField(doc.ID().String(), i.fieldsDescs[0].Name, val)
 }
 
 func (i *collectionUniqueIndex) Update(

--- a/db/index.go
+++ b/db/index.go
@@ -303,9 +303,9 @@ func (i *collectionUniqueIndex) newUniqueIndexError(
 	doc *client.Document,
 ) error {
 	kvs := make([]errors.KV, 0, len(i.fieldsDescs))
-	var val any
 	for iter := range i.fieldsDescs {
 		fieldVal, err := doc.GetValue(i.fieldsDescs[iter].Name)
+		var val any
 		if err != nil {
 			// If the error is ErrFieldNotExist, we leave `val` as is (e.g. nil)
 			// otherwise we return the error
@@ -318,10 +318,7 @@ func (i *collectionUniqueIndex) newUniqueIndexError(
 		kvs = append(kvs, errors.NewKV(i.fieldsDescs[iter].Name, val))
 	}
 
-	if len(kvs) == 1 {
-		return NewErrCanNotIndexNonUniqueField(doc.ID().String(), i.fieldsDescs[0].Name, val)
-	}
-	return NewErrCanNotIndexNonUniqueCombination(doc.ID().String(), kvs...)
+	return NewErrCanNotIndexNonUniqueFields(doc.ID().String(), kvs...)
 }
 
 func (i *collectionUniqueIndex) Update(

--- a/db/index_test.go
+++ b/db/index_test.go
@@ -209,7 +209,6 @@ func (f *indexTestFixture) createUserCollectionIndexOnNameAndAge() client.IndexD
 	indexDesc := addFieldToIndex(getUsersIndexDescOnName(), usersAgeFieldName)
 	newDesc, err := f.createCollectionIndexFor(f.users.Name(), indexDesc)
 	require.NoError(f.t, err)
-	f.commitTxn()
 	return newDesc
 }
 

--- a/db/index_test.go
+++ b/db/index_test.go
@@ -198,6 +198,21 @@ func (f *indexTestFixture) createUserCollectionUniqueIndexOnName() client.IndexD
 	return newDesc
 }
 
+func addFieldToIndex(indexDesc client.IndexDescription, fieldName string) client.IndexDescription {
+	indexDesc.Fields = append(indexDesc.Fields, client.IndexedFieldDescription{
+		Name: fieldName, Direction: client.Ascending,
+	})
+	return indexDesc
+}
+
+func (f *indexTestFixture) createUserCollectionIndexOnNameAndAge() client.IndexDescription {
+	indexDesc := addFieldToIndex(getUsersIndexDescOnName(), usersAgeFieldName)
+	newDesc, err := f.createCollectionIndexFor(f.users.Name(), indexDesc)
+	require.NoError(f.t, err)
+	f.commitTxn()
+	return newDesc
+}
+
 func (f *indexTestFixture) createUserCollectionIndexOnAge() client.IndexDescription {
 	newDesc, err := f.createCollectionIndexFor(f.users.Name().Value(), getUsersIndexDescOnAge())
 	require.NoError(f.t, err)

--- a/db/index_test.go
+++ b/db/index_test.go
@@ -198,19 +198,6 @@ func (f *indexTestFixture) createUserCollectionUniqueIndexOnName() client.IndexD
 	return newDesc
 }
 
-func makeUnique(indexDesc client.IndexDescription) client.IndexDescription {
-	indexDesc.Unique = true
-	return indexDesc
-}
-
-func (f *indexTestFixture) createUserCollectionUniqueIndexOnName() client.IndexDescription {
-	indexDesc := makeUnique(getUsersIndexDescOnName())
-	newDesc, err := f.createCollectionIndexFor(f.users.Name(), indexDesc)
-	require.NoError(f.t, err)
-	f.commitTxn()
-	return newDesc
-}
-
 func (f *indexTestFixture) createUserCollectionIndexOnAge() client.IndexDescription {
 	newDesc, err := f.createCollectionIndexFor(f.users.Name().Value(), getUsersIndexDescOnAge())
 	require.NoError(f.t, err)

--- a/db/index_test.go
+++ b/db/index_test.go
@@ -198,6 +198,19 @@ func (f *indexTestFixture) createUserCollectionUniqueIndexOnName() client.IndexD
 	return newDesc
 }
 
+func makeUnique(indexDesc client.IndexDescription) client.IndexDescription {
+	indexDesc.Unique = true
+	return indexDesc
+}
+
+func (f *indexTestFixture) createUserCollectionUniqueIndexOnName() client.IndexDescription {
+	indexDesc := makeUnique(getUsersIndexDescOnName())
+	newDesc, err := f.createCollectionIndexFor(f.users.Name(), indexDesc)
+	require.NoError(f.t, err)
+	f.commitTxn()
+	return newDesc
+}
+
 func (f *indexTestFixture) createUserCollectionIndexOnAge() client.IndexDescription {
 	newDesc, err := f.createCollectionIndexFor(f.users.Name().Value(), getUsersIndexDescOnAge())
 	require.NoError(f.t, err)

--- a/db/index_test.go
+++ b/db/index_test.go
@@ -207,7 +207,7 @@ func addFieldToIndex(indexDesc client.IndexDescription, fieldName string) client
 
 func (f *indexTestFixture) createUserCollectionIndexOnNameAndAge() client.IndexDescription {
 	indexDesc := addFieldToIndex(getUsersIndexDescOnName(), usersAgeFieldName)
-	newDesc, err := f.createCollectionIndexFor(f.users.Name(), indexDesc)
+	newDesc, err := f.createCollectionIndexFor(f.users.Name().Value(), indexDesc)
 	require.NoError(f.t, err)
 	return newDesc
 }

--- a/db/index_test.go
+++ b/db/index_test.go
@@ -1287,5 +1287,5 @@ func TestNewCollectionIndex_IfDescriptionHasNonExistingField_ReturnError(t *test
 	desc := getUsersIndexDescOnName()
 	desc.Fields[0].Name = "non_existing_field"
 	_, err := NewCollectionIndex(f.users, desc)
-	require.ErrorIs(t, err, NewErrIndexDescHasNonExistingField(desc, desc.Fields[0].Name))
+	require.ErrorIs(t, err, client.NewErrFieldNotExist(desc.Fields[0].Name))
 }

--- a/db/indexed_docs_test.go
+++ b/db/indexed_docs_test.go
@@ -169,7 +169,7 @@ indexLoop:
 			var fieldBytesVal []byte
 			var fieldValue *client.FieldValue
 			var err error
-			if len(b.values) == 0 {
+			if len(b.values) <= i {
 				fieldValue, err = b.doc.GetValue(fieldName)
 				require.NoError(b.f.t, err)
 			} else {
@@ -1136,9 +1136,9 @@ func TestCompositeCreate_ShouldIndexExistingDocs(t *testing.T) {
 	f := newIndexTestFixture(t)
 	defer f.db.Close()
 
-	doc1 := f.newUserDoc("John", 21)
+	doc1 := f.newUserDoc("John", 21, f.users)
 	f.saveDocToCollection(doc1, f.users)
-	doc2 := f.newUserDoc("Islam", 18)
+	doc2 := f.newUserDoc("Islam", 18, f.users)
 	f.saveDocToCollection(doc2, f.users)
 
 	f.createUserCollectionIndexOnNameAndAge()
@@ -1165,7 +1165,7 @@ func TestComposite_IfIndexedFieldIsNil_StoreItAsNil(t *testing.T) {
 	}{Age: 44})
 	require.NoError(f.t, err)
 
-	doc, err := client.NewDocFromJSON(docJSON)
+	doc, err := client.NewDocFromJSON(docJSON, f.users.Schema())
 	require.NoError(f.t, err)
 
 	f.saveDocToCollection(doc, f.users)
@@ -1187,8 +1187,8 @@ func TestCompositeDrop_ShouldDeleteStoredIndexedFields(t *testing.T) {
 	require.NoError(f.t, err)
 	f.commitTxn()
 
-	f.saveDocToCollection(f.newUserDoc("John", 21), users)
-	f.saveDocToCollection(f.newUserDoc("Islam", 23), users)
+	f.saveDocToCollection(f.newUserDoc("John", 21, users), users)
+	f.saveDocToCollection(f.newUserDoc("Islam", 23, users), users)
 
 	userNameAgeKey := newIndexKeyBuilder(f).Col(usersColName).Fields(usersNameFieldName, usersAgeFieldName).Build()
 	userAgeWeightKey := newIndexKeyBuilder(f).Col(usersColName).Fields(usersAgeFieldName, usersWeightFieldName).Build()
@@ -1245,7 +1245,7 @@ func TestCompositeUpdate_ShouldDeleteOldValueAndStoreNewOne(t *testing.T) {
 		},
 	}
 
-	doc := f.newUserDoc("John", 21)
+	doc := f.newUserDoc("John", 21, f.users)
 	f.saveDocToCollection(doc, f.users)
 
 	for _, tc := range cases {

--- a/db/indexed_docs_test.go
+++ b/db/indexed_docs_test.go
@@ -78,12 +78,12 @@ func (f *indexTestFixture) newProdDoc(id int, price float64, cat string, col cli
 // The format of the non-unique index key is: "/<collection_id>/<index_id>/<value>/<doc_id>"
 // Example: "/5/1/12/bae-61cd6879-63ca-5ca9-8731-470a3c1dac69"
 type indexKeyBuilder struct {
-	f         *indexTestFixture
-	colName   string
-	fieldName string
-	doc       *client.Document
-	values    [][]byte
-	isUnique  bool
+	f           *indexTestFixture
+	colName     string
+	fieldsNames []string
+	doc         *client.Document
+	values      [][]byte
+	isUnique    bool
 }
 
 func newIndexKeyBuilder(f *indexTestFixture) *indexKeyBuilder {
@@ -95,11 +95,11 @@ func (b *indexKeyBuilder) Col(colName string) *indexKeyBuilder {
 	return b
 }
 
-// Field sets the field name for the index key.
+// Fields sets the fields' names for the index key.
 // If the field name is not set, the index key will contain only collection id.
 // When building a key it will it will find the field id to use in the key.
-func (b *indexKeyBuilder) Field(fieldName string) *indexKeyBuilder {
-	b.fieldName = fieldName
+func (b *indexKeyBuilder) Fields(fieldsNames ...string) *indexKeyBuilder {
+	b.fieldsNames = fieldsNames
 	return b
 }
 
@@ -145,33 +145,41 @@ func (b *indexKeyBuilder) Build() core.IndexDataStoreKey {
 	}
 	key.CollectionID = collection.ID()
 
-	if b.fieldName == "" {
+	if len(b.fieldsNames) == 0 {
 		return key
 	}
 
 	indexes, err := collection.GetIndexes(b.f.ctx)
 	require.NoError(b.f.t, err)
+indexLoop:
 	for _, index := range indexes {
-		if index.Fields[0].Name == b.fieldName {
+		if len(index.Fields) == len(b.fieldsNames) {
+			for i := range index.Fields {
+				if index.Fields[i].Name != b.fieldsNames[i] {
+					continue indexLoop
+				}
+			}
 			key.IndexID = index.ID
-			break
+			break indexLoop
 		}
 	}
 
 	if b.doc != nil {
-		var fieldBytesVal []byte
-		var fieldValue *client.FieldValue
-		var err error
-		if len(b.values) == 0 {
-			fieldValue, err = b.doc.GetValue(b.fieldName)
+		for i, fieldName := range b.fieldsNames {
+			var fieldBytesVal []byte
+			var fieldValue *client.FieldValue
+			var err error
+			if len(b.values) == 0 {
+				fieldValue, err = b.doc.GetValue(fieldName)
+				require.NoError(b.f.t, err)
+			} else {
+				fieldValue = client.NewFieldValue(client.LWW_REGISTER, b.values[i])
+			}
+			fieldBytesVal, err = fieldValue.Bytes()
 			require.NoError(b.f.t, err)
-		} else {
-			fieldValue = client.NewFieldValue(client.LWW_REGISTER, b.values[0])
+			key.FieldValues = append(key.FieldValues, fieldBytesVal)
 		}
-		fieldBytesVal, err = fieldValue.Bytes()
-		require.NoError(b.f.t, err)
 
-		key.FieldValues = [][]byte{fieldBytesVal}
 		if !b.isUnique {
 			key.FieldValues = append(key.FieldValues, []byte(b.doc.ID().String()))
 		}
@@ -259,7 +267,7 @@ func TestNonUnique_IfDocIsAdded_ShouldBeIndexed(t *testing.T) {
 	doc := f.newUserDoc("John", 21, f.users)
 	f.saveDocToCollection(doc, f.users)
 
-	key := newIndexKeyBuilder(f).Col(usersColName).Field(usersNameFieldName).Doc(doc).Build()
+	key := newIndexKeyBuilder(f).Col(usersColName).Fields(usersNameFieldName).Doc(doc).Build()
 
 	data, err := f.txn.Datastore().Get(f.ctx, key.ToDS())
 	require.NoError(t, err)
@@ -272,7 +280,7 @@ func TestNonUnique_IfFailsToStoredIndexedDoc_Error(t *testing.T) {
 	f.createUserCollectionIndexOnName()
 
 	doc := f.newUserDoc("John", 21, f.users)
-	key := newIndexKeyBuilder(f).Col(usersColName).Field(usersNameFieldName).Doc(doc).Build()
+	key := newIndexKeyBuilder(f).Col(usersColName).Fields(usersNameFieldName).Doc(doc).Build()
 
 	mockTxn := f.mockTxn()
 
@@ -349,7 +357,7 @@ func TestNonUnique_IfIndexIntField_StoreIt(t *testing.T) {
 	doc := f.newUserDoc("John", 21, f.users)
 	f.saveDocToCollection(doc, f.users)
 
-	key := newIndexKeyBuilder(f).Col(usersColName).Field(usersAgeFieldName).Doc(doc).Build()
+	key := newIndexKeyBuilder(f).Col(usersColName).Fields(usersAgeFieldName).Doc(doc).Build()
 
 	data, err := f.txn.Datastore().Get(f.ctx, key.ToDS())
 	require.NoError(t, err)
@@ -376,8 +384,8 @@ func TestNonUnique_IfMultipleCollectionsWithIndexes_StoreIndexWithCollectionID(t
 	require.NoError(f.t, err)
 	f.commitTxn()
 
-	userDocID := newIndexKeyBuilder(f).Col(usersColName).Field(usersNameFieldName).Doc(userDoc).Build()
-	prodDocID := newIndexKeyBuilder(f).Col(productsColName).Field(productsCategoryFieldName).Doc(prodDoc).Build()
+	userDocID := newIndexKeyBuilder(f).Col(usersColName).Fields(usersNameFieldName).Doc(userDoc).Build()
+	prodDocID := newIndexKeyBuilder(f).Col(productsColName).Fields(productsCategoryFieldName).Doc(prodDoc).Build()
 
 	data, err := f.txn.Datastore().Get(f.ctx, userDocID.ToDS())
 	require.NoError(t, err)
@@ -396,8 +404,8 @@ func TestNonUnique_IfMultipleIndexes_StoreIndexWithIndexID(t *testing.T) {
 	doc := f.newUserDoc("John", 21, f.users)
 	f.saveDocToCollection(doc, f.users)
 
-	nameKey := newIndexKeyBuilder(f).Col(usersColName).Field(usersNameFieldName).Doc(doc).Build()
-	ageKey := newIndexKeyBuilder(f).Col(usersColName).Field(usersAgeFieldName).Doc(doc).Build()
+	nameKey := newIndexKeyBuilder(f).Col(usersColName).Fields(usersNameFieldName).Doc(doc).Build()
+	ageKey := newIndexKeyBuilder(f).Col(usersColName).Fields(usersAgeFieldName).Doc(doc).Build()
 
 	data, err := f.txn.Datastore().Get(f.ctx, nameKey.ToDS())
 	require.NoError(t, err)
@@ -509,7 +517,7 @@ func TestNonUnique_IfIndexedFieldIsNil_StoreItAsNil(t *testing.T) {
 
 	f.saveDocToCollection(doc, f.users)
 
-	key := newIndexKeyBuilder(f).Col(usersColName).Field(usersNameFieldName).Doc(doc).
+	key := newIndexKeyBuilder(f).Col(usersColName).Fields(usersNameFieldName).Doc(doc).
 		Values([]byte(nil)).Build()
 
 	data, err := f.txn.Datastore().Get(f.ctx, key.ToDS())
@@ -528,8 +536,8 @@ func TestNonUniqueCreate_ShouldIndexExistingDocs(t *testing.T) {
 
 	f.createUserCollectionIndexOnName()
 
-	key1 := newIndexKeyBuilder(f).Col(usersColName).Field(usersNameFieldName).Doc(doc1).Build()
-	key2 := newIndexKeyBuilder(f).Col(usersColName).Field(usersNameFieldName).Doc(doc2).Build()
+	key1 := newIndexKeyBuilder(f).Col(usersColName).Fields(usersNameFieldName).Doc(doc1).Build()
+	key2 := newIndexKeyBuilder(f).Col(usersColName).Fields(usersNameFieldName).Doc(doc2).Build()
 
 	data, err := f.txn.Datastore().Get(f.ctx, key1.ToDS())
 	require.NoError(t, err, key1.ToString())
@@ -600,7 +608,7 @@ func TestNonUniqueCreate_IfUponIndexingExistingDocsFetcherFails_ReturnError(t *t
 		f.saveDocToCollection(doc, f.users)
 
 		f.users.(*collection).fetcherFactory = tc.PrepareFetcher
-		key := newIndexKeyBuilder(f).Col(usersColName).Field(usersNameFieldName).Doc(doc).Build()
+		key := newIndexKeyBuilder(f).Col(usersColName).Fields(usersNameFieldName).Doc(doc).Build()
 
 		_, err := f.users.CreateIndex(f.ctx, getUsersIndexDescOnName())
 		require.ErrorIs(t, err, testError, tc.Name)
@@ -655,10 +663,10 @@ func TestNonUniqueDrop_ShouldDeleteStoredIndexedFields(t *testing.T) {
 
 	f.saveDocToCollection(f.newProdDoc(1, 55, "games", products), products)
 
-	userNameKey := newIndexKeyBuilder(f).Col(usersColName).Field(usersNameFieldName).Build()
-	userAgeKey := newIndexKeyBuilder(f).Col(usersColName).Field(usersAgeFieldName).Build()
-	userWeightKey := newIndexKeyBuilder(f).Col(usersColName).Field(usersWeightFieldName).Build()
-	prodCatKey := newIndexKeyBuilder(f).Col(productsColName).Field(productsCategoryFieldName).Build()
+	userNameKey := newIndexKeyBuilder(f).Col(usersColName).Fields(usersNameFieldName).Build()
+	userAgeKey := newIndexKeyBuilder(f).Col(usersColName).Fields(usersAgeFieldName).Build()
+	userWeightKey := newIndexKeyBuilder(f).Col(usersColName).Fields(usersWeightFieldName).Build()
+	prodCatKey := newIndexKeyBuilder(f).Col(productsColName).Fields(productsCategoryFieldName).Build()
 
 	err = f.dropIndex(usersColName, testUsersColIndexAge)
 	require.NoError(f.t, err)
@@ -699,7 +707,7 @@ func TestNonUniqueUpdate_ShouldDeleteOldValueAndStoreNewOne(t *testing.T) {
 	f.saveDocToCollection(doc, f.users)
 
 	for _, tc := range cases {
-		oldKey := newIndexKeyBuilder(f).Col(usersColName).Field(usersNameFieldName).Doc(doc).Build()
+		oldKey := newIndexKeyBuilder(f).Col(usersColName).Fields(usersNameFieldName).Doc(doc).Build()
 
 		err := doc.Set(usersNameFieldName, tc.NewValue)
 		require.NoError(t, err)
@@ -707,7 +715,7 @@ func TestNonUniqueUpdate_ShouldDeleteOldValueAndStoreNewOne(t *testing.T) {
 		require.NoError(t, err)
 		f.commitTxn()
 
-		newKey := newIndexKeyBuilder(f).Col(usersColName).Field(usersNameFieldName).Doc(doc).Build()
+		newKey := newIndexKeyBuilder(f).Col(usersColName).Fields(usersNameFieldName).Doc(doc).Build()
 
 		_, err = f.txn.Datastore().Get(f.ctx, oldKey.ToDS())
 		require.Error(t, err)
@@ -814,14 +822,14 @@ func TestNonUniqueUpdate_IfFetcherFails_ReturnError(t *testing.T) {
 		f.saveDocToCollection(doc, f.users)
 
 		f.users.(*collection).fetcherFactory = tc.PrepareFetcher
-		oldKey := newIndexKeyBuilder(f).Col(usersColName).Field(usersNameFieldName).Doc(doc).Build()
+		oldKey := newIndexKeyBuilder(f).Col(usersColName).Fields(usersNameFieldName).Doc(doc).Build()
 
 		err := doc.Set(usersNameFieldName, "Islam")
 		require.NoError(t, err, tc.Name)
 		err = f.users.Update(f.ctx, doc)
 		require.Error(t, err, tc.Name)
 
-		newKey := newIndexKeyBuilder(f).Col(usersColName).Field(usersNameFieldName).Doc(doc).Build()
+		newKey := newIndexKeyBuilder(f).Col(usersColName).Fields(usersNameFieldName).Doc(doc).Build()
 
 		_, err = f.txn.Datastore().Get(f.ctx, oldKey.ToDS())
 		require.NoError(t, err, tc.Name)
@@ -839,7 +847,7 @@ func TestNonUniqueUpdate_IfFailsToUpdateIndex_ReturnError(t *testing.T) {
 	f.saveDocToCollection(doc, f.users)
 	f.commitTxn()
 
-	validKey := newIndexKeyBuilder(f).Col(usersColName).Field(usersAgeFieldName).Doc(doc).Build()
+	validKey := newIndexKeyBuilder(f).Col(usersColName).Fields(usersAgeFieldName).Doc(doc).Build()
 	err := f.txn.Datastore().Delete(f.ctx, validKey.ToDS())
 	require.NoError(f.t, err)
 	f.commitTxn()
@@ -960,7 +968,7 @@ func TestNonUpdate_IfIndexedFieldWasNil_ShouldDeleteIt(t *testing.T) {
 
 	f.saveDocToCollection(doc, f.users)
 
-	oldKey := newIndexKeyBuilder(f).Col(usersColName).Field(usersNameFieldName).Doc(doc).
+	oldKey := newIndexKeyBuilder(f).Col(usersColName).Fields(usersNameFieldName).Doc(doc).
 		Values([]byte(nil)).Build()
 
 	err = doc.Set(usersNameFieldName, "John")
@@ -970,7 +978,7 @@ func TestNonUpdate_IfIndexedFieldWasNil_ShouldDeleteIt(t *testing.T) {
 	require.NoError(f.t, err)
 	f.commitTxn()
 
-	newKey := newIndexKeyBuilder(f).Col(usersColName).Field(usersNameFieldName).Doc(doc).Build()
+	newKey := newIndexKeyBuilder(f).Col(usersColName).Fields(usersNameFieldName).Doc(doc).Build()
 
 	_, err = f.txn.Datastore().Get(f.ctx, newKey.ToDS())
 	require.NoError(t, err)
@@ -1021,8 +1029,8 @@ func TestUniqueCreate_ShouldIndexExistingDocs(t *testing.T) {
 
 	f.createUserCollectionUniqueIndexOnName()
 
-	key1 := newIndexKeyBuilder(f).Col(usersColName).Field(usersNameFieldName).Unique().Doc(doc1).Build()
-	key2 := newIndexKeyBuilder(f).Col(usersColName).Field(usersNameFieldName).Unique().Doc(doc2).Build()
+	key1 := newIndexKeyBuilder(f).Col(usersColName).Fields(usersNameFieldName).Unique().Doc(doc1).Build()
+	key2 := newIndexKeyBuilder(f).Col(usersColName).Fields(usersNameFieldName).Unique().Doc(doc2).Build()
 
 	data, err := f.txn.Datastore().Get(f.ctx, key1.ToDS())
 	require.NoError(t, err, key1.ToString())
@@ -1047,7 +1055,7 @@ func TestUnique_IfIndexedFieldIsNil_StoreItAsNil(t *testing.T) {
 
 	f.saveDocToCollection(doc, f.users)
 
-	key := newIndexKeyBuilder(f).Col(usersColName).Field(usersNameFieldName).Unique().Doc(doc).
+	key := newIndexKeyBuilder(f).Col(usersColName).Fields(usersNameFieldName).Unique().Doc(doc).
 		Values([]byte(nil)).Build()
 
 	data, err := f.txn.Datastore().Get(f.ctx, key.ToDS())
@@ -1067,8 +1075,8 @@ func TestUniqueDrop_ShouldDeleteStoredIndexedFields(t *testing.T) {
 	f.saveDocToCollection(f.newUserDoc("John", 21, users), users)
 	f.saveDocToCollection(f.newUserDoc("Islam", 23, users), users)
 
-	userNameKey := newIndexKeyBuilder(f).Col(usersColName).Field(usersNameFieldName).Build()
-	userAgeKey := newIndexKeyBuilder(f).Col(usersColName).Field(usersAgeFieldName).Build()
+	userNameKey := newIndexKeyBuilder(f).Col(usersColName).Fields(usersNameFieldName).Build()
+	userAgeKey := newIndexKeyBuilder(f).Col(usersColName).Fields(usersAgeFieldName).Build()
 
 	err = f.dropIndex(usersColName, testUsersColIndexAge)
 	require.NoError(f.t, err)
@@ -1107,7 +1115,7 @@ func TestUniqueUpdate_ShouldDeleteOldValueAndStoreNewOne(t *testing.T) {
 	f.saveDocToCollection(doc, f.users)
 
 	for _, tc := range cases {
-		oldKey := newIndexKeyBuilder(f).Col(usersColName).Field(usersNameFieldName).Unique().Doc(doc).Build()
+		oldKey := newIndexKeyBuilder(f).Col(usersColName).Fields(usersNameFieldName).Unique().Doc(doc).Build()
 
 		err := doc.Set(usersNameFieldName, tc.NewValue)
 		require.NoError(t, err)
@@ -1115,7 +1123,7 @@ func TestUniqueUpdate_ShouldDeleteOldValueAndStoreNewOne(t *testing.T) {
 		require.NoError(t, err)
 		f.commitTxn()
 
-		newKey := newIndexKeyBuilder(f).Col(usersColName).Field(usersNameFieldName).Unique().Doc(doc).Build()
+		newKey := newIndexKeyBuilder(f).Col(usersColName).Fields(usersNameFieldName).Unique().Doc(doc).Build()
 
 		_, err = f.txn.Datastore().Get(f.ctx, oldKey.ToDS())
 		require.Error(t, err)

--- a/db/indexed_docs_test.go
+++ b/db/indexed_docs_test.go
@@ -1181,9 +1181,9 @@ func TestComposite_IfIndexedFieldIsNil_StoreItAsNil(t *testing.T) {
 func TestCompositeDrop_ShouldDeleteStoredIndexedFields(t *testing.T) {
 	f := newIndexTestFixtureBare(t)
 	users := f.addUsersCollection()
-	_, err := f.createCollectionIndexFor(users.Name(), addFieldToIndex(getUsersIndexDescOnName(), usersAgeFieldName))
+	_, err := f.createCollectionIndexFor(users.Name().Value(), addFieldToIndex(getUsersIndexDescOnName(), usersAgeFieldName))
 	require.NoError(f.t, err)
-	_, err = f.createCollectionIndexFor(users.Name(), addFieldToIndex(getUsersIndexDescOnAge(), usersWeightFieldName))
+	_, err = f.createCollectionIndexFor(users.Name().Value(), addFieldToIndex(getUsersIndexDescOnAge(), usersWeightFieldName))
 	require.NoError(f.t, err)
 	f.commitTxn()
 

--- a/db/indexed_docs_test.go
+++ b/db/indexed_docs_test.go
@@ -95,7 +95,7 @@ func (b *indexKeyBuilder) Col(colName string) *indexKeyBuilder {
 	return b
 }
 
-// Fields sets the fields' names for the index key.
+// Fields sets the fields names for the index key.
 // If the field name is not set, the index key will contain only collection id.
 // When building a key it will it will find the field id to use in the key.
 func (b *indexKeyBuilder) Fields(fieldsNames ...string) *indexKeyBuilder {

--- a/planner/filter/copy_field.go
+++ b/planner/filter/copy_field.go
@@ -15,7 +15,8 @@ import (
 )
 
 // CopyField copies the given field from the provided filter.
-// Multiple fields can be passed to copy related objects with a certain field.
+// Multiple fields can be passed to copy related objects with a certain field. 
+// In this case every subsequent field is a sub field of the previous one. Eg. bool.author.name
 // The result filter preserves the structure of the original filter.
 func CopyField(filter *mapper.Filter, fields ...mapper.Field) *mapper.Filter {
 	if filter == nil || len(fields) == 0 {

--- a/planner/filter/copy_field.go
+++ b/planner/filter/copy_field.go
@@ -15,7 +15,7 @@ import (
 )
 
 // CopyField copies the given field from the provided filter.
-// Multiple fields can be passed to copy related objects with a certain field. 
+// Multiple fields can be passed to copy related objects with a certain field.
 // In this case every subsequent field is a sub field of the previous one. Eg. bool.author.name
 // The result filter preserves the structure of the original filter.
 func CopyField(filter *mapper.Filter, fields ...mapper.Field) *mapper.Filter {

--- a/planner/filter/copy_field_test.go
+++ b/planner/filter/copy_field_test.go
@@ -120,16 +120,31 @@ func TestCopyField(t *testing.T) {
 	}
 }
 
-func TestCopyFieldOfNullFilter(t *testing.T) {
+func TestCopyField_IfFilterIsNil_NoOp(t *testing.T) {
 	actualFilter := CopyField(nil, mapper.Field{Index: 1})
 	assert.Nil(t, actualFilter)
 }
 
-func TestCopyFieldWithNoFieldGiven(t *testing.T) {
+func TestCopyField_IfNoFieldGiven_NoOp(t *testing.T) {
 	filter := mapper.NewFilter()
 	filter.Conditions = map[connor.FilterKey]any{
 		&mapper.PropertyIndex{Index: 0}: &mapper.Operator{Operation: "_eq"},
 	}
 	actualFilter := CopyField(filter)
+	assert.Nil(t, actualFilter)
+}
+
+func TestCopyField_IfSecondFieldIsNotSubField_NoOp(t *testing.T) {
+	mapping := getDocMapping()
+	inputFilter := mapper.ToFilter(request.Filter{Conditions: map[string]any{
+		"name": m("_eq", "John"),
+		"age":  m("_gt", 55),
+	}}, mapping)
+
+	var actualFilter *mapper.Filter
+	assert.NotPanics(t, func() {
+		actualFilter = CopyField(inputFilter, mapper.Field{Index: authorNameInd}, mapper.Field{Index: 666})
+	})
+
 	assert.Nil(t, actualFilter)
 }

--- a/planner/filter/normalize.go
+++ b/planner/filter/normalize.go
@@ -185,7 +185,12 @@ func normalizeProperties(parentKey connor.FilterKey, conditions []any) []any {
 	// if canMergeAnd is true, all _and groups will be merged
 	props := make(map[int][]any)
 	for _, c := range conditions {
-		for key, val := range c.(map[connor.FilterKey]any) {
+		cMap, ok := c.(map[connor.FilterKey]any)
+		if !ok {
+			result = append(result, c)
+			continue
+		}
+		for key, val := range cMap {
 			op, ok := key.(*mapper.Operator)
 			if canMergeAnd && ok && op.Operation == request.FilterOpAnd {
 				merge = append(merge, val.([]any)...)

--- a/planner/filter/split.go
+++ b/planner/filter/split.go
@@ -38,6 +38,9 @@ func SplitByFields(filter *mapper.Filter, fields ...mapper.Field) (*mapper.Filte
 
 	for _, field := range fields[1:] {
 		newSplitF := CopyField(filter, field)
+		if newSplitF == nil {
+			continue
+		}
 		splitF.Conditions = Merge(splitF.Conditions, newSplitF.Conditions)
 		RemoveField(filter, field)
 	}

--- a/planner/filter/split_test.go
+++ b/planner/filter/split_test.go
@@ -89,6 +89,22 @@ func TestSplitFilter(t *testing.T) {
 				"age":  m("_gt", 55),
 			},
 		},
+		{
+			name: "filter with two []any slices",
+			inputFilter: map[string]any{
+				"age":  m("_in", []any{10, 20, 30}),
+				"name": m("_in", []any{"John", "Bob"}),
+			},
+			inputFields: []mapper.Field{
+				{Index: authorNameInd},
+				{Index: authorAgeInd},
+			},
+			expectedFilter1: nil,
+			expectedFilter2: map[string]any{
+				"age":  m("_in", []any{10, 20, 30}),
+				"name": m("_in", []any{"John", "Bob"}),
+			},
+		},
 	}
 
 	mapping := getDocMapping()

--- a/planner/filter/split_test.go
+++ b/planner/filter/split_test.go
@@ -70,6 +70,25 @@ func TestSplitFilter(t *testing.T) {
 				"verified": m("_eq", false),
 			},
 		},
+		{
+			name: "split by fields that are not present",
+			inputFilter: map[string]any{
+				"name":     m("_eq", "John"),
+				"age":      m("_gt", 55),
+				"verified": m("_eq", false),
+			},
+			inputFields: []mapper.Field{
+				{Index: authorNameInd},
+				{Index: 100},
+				{Index: authorAgeInd},
+				{Index: 200},
+			},
+			expectedFilter1: m("verified", m("_eq", false)),
+			expectedFilter2: map[string]any{
+				"name": m("_eq", "John"),
+				"age":  m("_gt", 55),
+			},
+		},
 	}
 
 	mapping := getDocMapping()

--- a/planner/planner.go
+++ b/planner/planner.go
@@ -343,7 +343,7 @@ func (p *Planner) tryOptimizeJoinDirection(node *invertibleTypeJoin, parentPlan 
 	slct := node.subType.(*selectTopNode).selectNode
 	desc := slct.collection.Description()
 	for subFieldName, subFieldInd := range filteredSubFields {
-		indexes := desc.CollectIndexesOnField(subFieldName)
+		indexes := desc.GetIndexesOnField(subFieldName)
 		if len(indexes) > 0 {
 			subInd := node.documentMapping.FirstIndexOfName(node.subTypeName)
 			relatedField := mapper.Field{Name: node.subTypeName, Index: subInd}

--- a/planner/planner.go
+++ b/planner/planner.go
@@ -342,18 +342,17 @@ func (p *Planner) tryOptimizeJoinDirection(node *invertibleTypeJoin, parentPlan 
 	)
 	slct := node.subType.(*selectTopNode).selectNode
 	desc := slct.collection.Description()
-	schema := slct.collection.Schema()
-	indexedFields := desc.CollectIndexedFields(&schema)
-	for _, indField := range indexedFields {
-		if ind, ok := filteredSubFields[indField.Name]; ok {
+	for subFieldName, subFieldInd := range filteredSubFields {
+		indexes := desc.CollectIndexesOnField(subFieldName)
+		if len(indexes) > 0 {
 			subInd := node.documentMapping.FirstIndexOfName(node.subTypeName)
 			relatedField := mapper.Field{Name: node.subTypeName, Index: subInd}
 			fieldFilter := filter.UnwrapRelation(filter.CopyField(
 				parentPlan.selectNode.filter,
 				relatedField,
-				mapper.Field{Name: indField.Name, Index: ind},
+				mapper.Field{Name: subFieldName, Index: subFieldInd},
 			), relatedField)
-			err := node.invertJoinDirectionWithIndex(fieldFilter, indField)
+			err := node.invertJoinDirectionWithIndex(fieldFilter, indexes[0])
 			if err != nil {
 				return err
 			}

--- a/planner/scan.go
+++ b/planner/scan.go
@@ -138,7 +138,7 @@ func (n *scanNode) tryAddField(fieldName string) bool {
 
 func (scan *scanNode) initFetcher(
 	cid immutable.Option[string],
-	indexedField immutable.Option[client.FieldDescription],
+	index immutable.Option[client.IndexDescription],
 ) {
 	var f fetcher.Fetcher
 	if cid.HasValue() {
@@ -146,13 +146,14 @@ func (scan *scanNode) initFetcher(
 	} else {
 		f = new(fetcher.DocumentFetcher)
 
-		if indexedField.HasValue() {
-			typeIndex := scan.documentMapping.FirstIndexOfName(indexedField.Value().Name)
-			field := mapper.Field{Index: typeIndex, Name: indexedField.Value().Name}
+		if index.HasValue() {
+			fieldName := index.Value().Fields[0].Name
+			typeIndex := scan.documentMapping.FirstIndexOfName(fieldName)
+			field := mapper.Field{Index: typeIndex, Name: fieldName}
 			var indexFilter *mapper.Filter
 			scan.filter, indexFilter = filter.SplitByFields(scan.filter, field)
 			if indexFilter != nil {
-				fieldDesc, _ := scan.col.Schema().GetField(indexedField.Value().Name)
+				fieldDesc, _ := scan.col.Schema().GetField(fieldName)
 				f = fetcher.NewIndexFetcher(f, fieldDesc, indexFilter)
 			}
 		}

--- a/planner/scan.go
+++ b/planner/scan.go
@@ -147,11 +147,14 @@ func (scan *scanNode) initFetcher(
 		f = new(fetcher.DocumentFetcher)
 
 		if index.HasValue() {
-			fieldName := index.Value().Fields[0].Name
-			typeIndex := scan.documentMapping.FirstIndexOfName(fieldName)
-			field := mapper.Field{Index: typeIndex, Name: fieldName}
+			fields := make([]mapper.Field, 0, len(index.Value().Fields))
+			for _, field := range index.Value().Fields {
+				fieldName := field.Name
+				typeIndex := scan.documentMapping.FirstIndexOfName(fieldName)
+				fields = append(fields, mapper.Field{Index: typeIndex, Name: fieldName})
+			}
 			var indexFilter *mapper.Filter
-			scan.filter, indexFilter = filter.SplitByFields(scan.filter, field)
+			scan.filter, indexFilter = filter.SplitByFields(scan.filter, fields...)
 			if indexFilter != nil {
 				f = fetcher.NewIndexFetcher(f, index.Value(), indexFilter)
 			}

--- a/planner/scan.go
+++ b/planner/scan.go
@@ -153,8 +153,7 @@ func (scan *scanNode) initFetcher(
 			var indexFilter *mapper.Filter
 			scan.filter, indexFilter = filter.SplitByFields(scan.filter, field)
 			if indexFilter != nil {
-				fieldDesc, _ := scan.col.Schema().GetField(fieldName)
-				f = fetcher.NewIndexFetcher(f, fieldDesc, indexFilter)
+				f = fetcher.NewIndexFetcher(f, index.Value(), indexFilter)
 			}
 		}
 

--- a/planner/scan.go
+++ b/planner/scan.go
@@ -150,7 +150,7 @@ func (scan *scanNode) initFetcher(
 			typeIndex := scan.documentMapping.FirstIndexOfName(indexedField.Value().Name)
 			field := mapper.Field{Index: typeIndex, Name: indexedField.Value().Name}
 			var indexFilter *mapper.Filter
-			scan.filter, indexFilter = filter.SplitByField(scan.filter, field)
+			scan.filter, indexFilter = filter.SplitByFields(scan.filter, field)
 			if indexFilter != nil {
 				fieldDesc, _ := scan.col.Schema().GetField(indexedField.Value().Name)
 				f = fetcher.NewIndexFetcher(f, fieldDesc, indexFilter)

--- a/planner/select.go
+++ b/planner/select.go
@@ -290,27 +290,28 @@ func (n *selectNode) initSource() ([]aggregateNode, error) {
 	}
 
 	if isScanNode {
-		origScan.initFetcher(n.selectReq.Cid, findFilteredByIndexedField(origScan))
+		origScan.initFetcher(n.selectReq.Cid, findIndexByFilteringField(origScan))
 	}
 
 	return aggregates, nil
 }
 
-func findFilteredByIndexedField(scanNode *scanNode) immutable.Option[client.IndexDescription] {
-	if scanNode.filter != nil {
-		colDesc := scanNode.col.Description()
+func findIndexByFilteringField(scanNode *scanNode) immutable.Option[client.IndexDescription] {
+	if scanNode.filter == nil {
+		return immutable.None[client.IndexDescription]()
+	}
+	colDesc := scanNode.col.Description()
 
-		for _, field := range scanNode.col.Schema().Fields {
-			if _, isFiltered := scanNode.filter.ExternalConditions[field.Name]; !isFiltered {
-				continue
-			}
-			indexes := colDesc.GetIndexesOnField(field.Name)
-			if len(indexes) > 0 {
-				return immutable.Some(indexes[0])
-			}
+	for _, field := range scanNode.col.Schema().Fields {
+		if _, isFiltered := scanNode.filter.ExternalConditions[field.Name]; !isFiltered {
+			continue
+		}
+		indexes := colDesc.GetIndexesOnField(field.Name)
+		if len(indexes) > 0 {
+			// we return the first found index. We will optimize it later.
+			return immutable.Some(indexes[0])
 		}
 	}
-
 	return immutable.None[client.IndexDescription]()
 }
 

--- a/planner/select.go
+++ b/planner/select.go
@@ -304,7 +304,7 @@ func findFilteredByIndexedField(scanNode *scanNode) immutable.Option[client.Inde
 			if _, isFiltered := scanNode.filter.ExternalConditions[field.Name]; !isFiltered {
 				continue
 			}
-			indexes := colDesc.CollectIndexesOnField(field.Name)
+			indexes := colDesc.GetIndexesOnField(field.Name)
 			if len(indexes) > 0 {
 				return immutable.Some(indexes[0])
 			}

--- a/planner/type_join.go
+++ b/planner/type_join.go
@@ -606,12 +606,12 @@ func (join *invertibleTypeJoin) Next() (bool, error) {
 
 func (join *invertibleTypeJoin) invertJoinDirectionWithIndex(
 	fieldFilter *mapper.Filter,
-	field client.FieldDescription,
+	index client.IndexDescription,
 ) error {
 	subScan := getScanNode(join.subType)
 	subScan.tryAddField(join.rootName + request.RelatedObjectID)
 	subScan.filter = fieldFilter
-	subScan.initFetcher(immutable.Option[string]{}, immutable.Some(field))
+	subScan.initFetcher(immutable.Option[string]{}, immutable.Some(index))
 
 	join.invert()
 

--- a/planner/type_join.go
+++ b/planner/type_join.go
@@ -359,7 +359,7 @@ func prepareScanNodeFilterForTypeJoin(
 		filter.RemoveField(scan.filter, subType.Field)
 	} else {
 		var parentFilter *mapper.Filter
-		scan.filter, parentFilter = filter.SplitByField(scan.filter, subType.Field)
+		scan.filter, parentFilter = filter.SplitByFields(scan.filter, subType.Field)
 		if parentFilter != nil {
 			if parent.filter == nil {
 				parent.filter = parentFilter

--- a/tests/integration/explain_result_asserter.go
+++ b/tests/integration/explain_result_asserter.go
@@ -59,15 +59,15 @@ func (a *ExplainResultAsserter) Assert(t *testing.T, result []dataMap) {
 	require.Len(t, result, 1, "Expected len(result) = 1, got %d", len(result))
 	explainNode, ok := result[0]["explain"].(dataMap)
 	require.True(t, ok, "Expected explain none")
-	assert.Equal(t, explainNode["executionSuccess"], true, "Expected executionSuccess property")
+	assert.Equal(t, true, explainNode["executionSuccess"], "Expected executionSuccess property")
 	if a.sizeOfResults.HasValue() {
 		actual := explainNode["sizeOfResult"]
-		assert.Equal(t, actual, a.sizeOfResults.Value(),
+		assert.Equal(t, a.sizeOfResults.Value(), actual,
 			"Expected %d sizeOfResult, got %d", a.sizeOfResults.Value(), actual)
 	}
 	if a.planExecutions.HasValue() {
 		actual := explainNode["planExecutions"]
-		assert.Equal(t, actual, a.planExecutions.Value(),
+		assert.Equal(t, a.planExecutions.Value(), actual,
 			"Expected %d planExecutions, got %d", a.planExecutions.Value(), actual)
 	}
 	selectTopNode, ok := explainNode["selectTopNode"].(dataMap)
@@ -78,7 +78,7 @@ func (a *ExplainResultAsserter) Assert(t *testing.T, result []dataMap) {
 	if a.filterMatches.HasValue() {
 		filterMatches, hasFilterMatches := selectNode["filterMatches"]
 		require.True(t, hasFilterMatches, "Expected filterMatches property")
-		assert.Equal(t, filterMatches, uint64(a.filterMatches.Value()),
+		assert.Equal(t, uint64(a.filterMatches.Value()), filterMatches,
 			"Expected %d filterMatches, got %d", a.filterMatches, filterMatches)
 	}
 
@@ -102,22 +102,22 @@ func (a *ExplainResultAsserter) Assert(t *testing.T, result []dataMap) {
 
 	if a.iterations.HasValue() {
 		actual := getScanNodesProp(iterationsProp)
-		assert.Equal(t, actual, uint64(a.iterations.Value()),
+		assert.Equal(t, uint64(a.iterations.Value()), actual,
 			"Expected %d iterations, got %d", a.iterations.Value(), actual)
 	}
 	if a.docFetches.HasValue() {
 		actual := getScanNodesProp(docFetchesProp)
-		assert.Equal(t, actual, uint64(a.docFetches.Value()),
+		assert.Equal(t, uint64(a.docFetches.Value()), actual,
 			"Expected %d docFetches, got %d", a.docFetches.Value(), actual)
 	}
 	if a.fieldFetches.HasValue() {
 		actual := getScanNodesProp(fieldFetchesProp)
-		assert.Equal(t, actual, uint64(a.fieldFetches.Value()),
+		assert.Equal(t, uint64(a.fieldFetches.Value()), actual,
 			"Expected %d fieldFetches, got %d", a.fieldFetches.Value(), actual)
 	}
 	if a.indexFetches.HasValue() {
 		actual := getScanNodesProp(indexFetchesProp)
-		assert.Equal(t, actual, uint64(a.indexFetches.Value()),
+		assert.Equal(t, uint64(a.indexFetches.Value()), actual,
 			"Expected %d indexFetches, got %d", a.indexFetches.Value(), actual)
 	}
 }

--- a/tests/integration/index/create_composite_test.go
+++ b/tests/integration/index/create_composite_test.go
@@ -1,0 +1,76 @@
+// Copyright 2023 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package index
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/defradb/client"
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+func TestCompositeIndexCreate_WhenCreated_CanRetrieve(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "create composite index and retrieve it",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type User {
+						name: String 
+						age: Int 
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `
+					{
+						"name":	"John",
+						"age":	21
+					}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `
+					{
+						"name":	"Shahzad",
+						"age":	22
+					}`,
+			},
+			testUtils.CreateIndex{
+				CollectionID: 0,
+				IndexName:    "name_age_index",
+				FieldsNames:  []string{"name", "age"},
+			},
+			testUtils.GetIndexes{
+				CollectionID: 0,
+				ExpectedIndexes: []client.IndexDescription{
+					{
+						Name: "name_age_index",
+						ID:   1,
+						Fields: []client.IndexedFieldDescription{
+							{
+								Name:      "name",
+								Direction: client.Ascending,
+							},
+							{
+								Name:      "age",
+								Direction: client.Ascending,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/index/create_unique_composite_test.go
+++ b/tests/integration/index/create_unique_composite_test.go
@@ -54,7 +54,7 @@ func TestCreateUniqueCompositeIndex_IfFieldValuesAreNotUnique_ReturnError(t *tes
 				CollectionID: 0,
 				FieldsNames:  []string{"name", "age"},
 				Unique:       true,
-				ExpectedError: db.NewErrCanNotIndexNonUniqueCombination(
+				ExpectedError: db.NewErrCanNotIndexNonUniqueFields(
 					"bae-cae3deac-d371-5a1f-93b4-ede69042f79b",
 					errors.NewKV("name", "John"), errors.NewKV("age", 21),
 				).Error(),
@@ -99,7 +99,7 @@ func TestUniqueCompositeIndexCreate_UponAddingDocWithExistingFieldValue_ReturnEr
 						"age":	21,
 						"email": "another@gmail.com"
 					}`,
-				ExpectedError: db.NewErrCanNotIndexNonUniqueCombination(
+				ExpectedError: db.NewErrCanNotIndexNonUniqueFields(
 					"bae-13254430-7e9e-52e2-9861-9a7ec7a75c8d",
 					errors.NewKV("name", "John"), errors.NewKV("age", 21)).Error(),
 			},

--- a/tests/integration/index/create_unique_composite_test.go
+++ b/tests/integration/index/create_unique_composite_test.go
@@ -1,0 +1,182 @@
+// Copyright 2023 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package index
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/defradb/client"
+	"github.com/sourcenetwork/defradb/db"
+	"github.com/sourcenetwork/defradb/errors"
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+func TestCreateUniqueCompositeIndex_IfFieldValuesAreNotUnique_ReturnError(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "If combination of fields is not unique, creating of unique index fails",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type User {
+						name: String 
+						age: Int
+						email: String
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `
+					{
+						"name":	"John",
+						"age":	21,
+						"email": "email@gmail.com"
+					}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `
+					{
+						"name":	"John",
+						"age":	21,
+						"email": "another@gmail.com"
+					}`,
+			},
+			testUtils.CreateIndex{
+				CollectionID: 0,
+				FieldsNames:  []string{"name", "age"},
+				Unique:       true,
+				ExpectedError: db.NewErrCanNotIndexNonUniqueCombination(
+					"bae-cae3deac-d371-5a1f-93b4-ede69042f79b",
+					errors.NewKV("name", "John"), errors.NewKV("age", 21),
+				).Error(),
+			},
+			testUtils.GetIndexes{
+				CollectionID:    0,
+				ExpectedIndexes: []client.IndexDescription{},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestUniqueCompositeIndexCreate_UponAddingDocWithExistingFieldValue_ReturnError(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "adding a new doc with existing field combination for composite index should fail",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type User @index(unique: true, fields: ["name", "age"]) {
+						name: String 
+						age: Int 
+						email: String
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `
+					{
+						"name":	"John",
+						"age":	21,
+						"email": "email@gmail.com"
+					}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `
+					{
+						"name":	"John",
+						"age":	21,
+						"email": "another@gmail.com"
+					}`,
+				ExpectedError: db.NewErrCanNotIndexNonUniqueCombination(
+					"bae-13254430-7e9e-52e2-9861-9a7ec7a75c8d",
+					errors.NewKV("name", "John"), errors.NewKV("age", 21)).Error(),
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestUniqueCompositeIndexCreate_IfFieldValuesAreUnique_Succeed(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "create unique composite index if all docs have unique fields combinations",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type User {
+						name: String 
+						age: Int 
+						email: String
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `
+					{
+						"name":	"John",
+						"age":	21,
+						"email": "some@gmail.com"
+					}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `
+					{
+						"name":	"John",
+						"age":	35,
+						"email": "another@gmail.com"
+					}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `
+					{
+						"name":	"Andy",
+						"age":	35,
+						"email": "different@gmail.com"
+					}`,
+			},
+			testUtils.CreateIndex{
+				CollectionID: 0,
+				FieldsNames:  []string{"name", "age"},
+				IndexName:    "name_age_unique_index",
+				Unique:       true,
+			},
+			testUtils.GetIndexes{
+				CollectionID: 0,
+				ExpectedIndexes: []client.IndexDescription{
+					{
+						Name:   "name_age_unique_index",
+						ID:     1,
+						Unique: true,
+						Fields: []client.IndexedFieldDescription{
+							{
+								Name:      "name",
+								Direction: client.Ascending,
+							},
+							{
+								Name:      "age",
+								Direction: client.Ascending,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/index/create_unique_test.go
+++ b/tests/integration/index/create_unique_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/db"
+	"github.com/sourcenetwork/defradb/errors"
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
 )
 
@@ -57,10 +58,11 @@ func TestCreateUniqueIndex_IfFieldValuesAreNotUnique_ReturnError(t *testing.T) {
 					}`,
 			},
 			testUtils.CreateIndex{
-				CollectionID:  0,
-				FieldName:     "age",
-				Unique:        true,
-				ExpectedError: db.NewErrCanNotIndexNonUniqueField(johnDocID, "age", 21).Error(),
+				CollectionID: 0,
+				FieldName:    "age",
+				Unique:       true,
+				ExpectedError: db.NewErrCanNotIndexNonUniqueFields(
+					johnDocID, errors.NewKV("age", 21)).Error(),
 			},
 			testUtils.GetIndexes{
 				CollectionID:    0,
@@ -99,7 +101,8 @@ func TestUniqueIndexCreate_UponAddingDocWithExistingFieldValue_ReturnError(t *te
 						"name":	"John",
 						"age":	21
 					}`,
-				ExpectedError: db.NewErrCanNotIndexNonUniqueField(johnDocID, "age", 21).Error(),
+				ExpectedError: db.NewErrCanNotIndexNonUniqueFields(
+					johnDocID, errors.NewKV("age", 21)).Error(),
 			},
 			testUtils.Request{
 				Request: `query {
@@ -222,10 +225,11 @@ func TestUniqueIndexCreate_IfNilFieldsArePresent_ReturnError(t *testing.T) {
 					}`,
 			},
 			testUtils.CreateIndex{
-				CollectionID:  0,
-				FieldName:     "age",
-				Unique:        true,
-				ExpectedError: db.NewErrCanNotIndexNonUniqueField("bae-caba9876-89aa-5bcf-bc1c-387a52499b27", "age", nil).Error(),
+				CollectionID: 0,
+				FieldName:    "age",
+				Unique:       true,
+				ExpectedError: db.NewErrCanNotIndexNonUniqueFields(
+					"bae-caba9876-89aa-5bcf-bc1c-387a52499b27", errors.NewKV("age", nil)).Error(),
 			},
 		},
 	}
@@ -291,7 +295,8 @@ func TestUniqueIndexCreate_UponAddingDocWithExistingNilValue_ReturnError(t *test
 					{
 						"name":	"Andy"
 					}`,
-				ExpectedError: db.NewErrCanNotIndexNonUniqueField("bae-2159860f-3cd1-59de-9440-71331e77cbb8", "age", nil).Error(),
+				ExpectedError: db.NewErrCanNotIndexNonUniqueFields(
+					"bae-2159860f-3cd1-59de-9440-71331e77cbb8", errors.NewKV("age", nil)).Error(),
 			},
 		},
 	}

--- a/tests/integration/index/query_with_composite_index_only_filter_test.go
+++ b/tests/integration/index/query_with_composite_index_only_filter_test.go
@@ -620,7 +620,7 @@ func TestQueryWithCompositeIndex_IfFirstFieldIsNotInFilter_ShouldNotUseIndex(t *
 
 func TestQueryWithCompositeIndex_WithEqualFilterOnNilValueOnFirst_ShouldFetch(t *testing.T) {
 	test := testUtils.TestCase{
-		Description: "Test index filtering with _eq filter on nil value",
+		Description: "Test index filtering with _eq filter on nil value on first field",
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: schemaWithNameAgeIndex,
@@ -662,7 +662,7 @@ func TestQueryWithCompositeIndex_WithEqualFilterOnNilValueOnFirst_ShouldFetch(t 
 
 func TestQueryWithCompositeIndex_WithEqualFilterOnNilValueOnSecond_ShouldFetch(t *testing.T) {
 	test := testUtils.TestCase{
-		Description: "Test index filtering with _eq filter on nil value",
+		Description: "Test index filtering with _eq filter on nil value on second field",
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: schemaWithNameAgeIndex,
@@ -704,6 +704,64 @@ func TestQueryWithCompositeIndex_WithEqualFilterOnNilValueOnSecond_ShouldFetch(t
 					{
 						"name": "Alice",
 						"age":  nil,
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestQueryWithCompositeIndex_IfMiddleFieldIsNotIfFilter_ShouldIgnoreValue(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "Test composite index with filter without middle field",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type User @index(fields: ["name", "email", "age"]) {
+						name: String
+						email: String
+						age: Int
+					}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `
+					{
+						"name":	"Alice",
+						"email": "alice@gmail.com",
+						"age":	22
+					}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `
+					{
+						"name":	"Alan",
+						"email": "alan@gmail.com",
+						"age":	38
+					}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `
+					{
+						"name":	"Bob",
+						"email": "bob@gmail.com",
+						"age":	51
+					}`,
+			},
+			testUtils.Request{
+				Request: `
+					query {
+						User(filter: {name: {_like: "%l%"}, age: {_gt: 30}}) {
+							name
+						}
+					}`,
+				Results: []map[string]any{
+					{
+						"name": "Alan",
 					},
 				},
 			},

--- a/tests/integration/index/query_with_composite_index_only_filter_test.go
+++ b/tests/integration/index/query_with_composite_index_only_filter_test.go
@@ -16,20 +16,6 @@ import (
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
 )
 
-const schemaWithNameAgeIndex = `
-	type User @index(fields: ["name", "age"]) {
-		name: String
-		age: Int
-		email: String
-	}`
-
-const schemaWithAgeNameIndex = `
-	type User @index(fields: ["age", "name"]) {
-		name: String
-		age: Int
-		email: String
-	}`
-
 func TestQueryWithCompositeIndex_WithEqualFilter_ShouldFetch(t *testing.T) {
 	req1 := `query {
 		User(filter: {name: {_eq: "Islam"}}) {
@@ -53,7 +39,12 @@ func TestQueryWithCompositeIndex_WithEqualFilter_ShouldFetch(t *testing.T) {
 		Description: "Test filtering on composite index with _eq filter",
 		Actions: []any{
 			testUtils.SchemaUpdate{
-				Schema: schemaWithNameAgeIndex,
+				Schema: `
+					type User @index(fields: ["name", "age"]) {
+						name: String
+						age: Int
+						email: String
+					}`,
 			},
 			testUtils.CreatePredefinedDocs{
 				Docs: getUserDocs(),
@@ -98,7 +89,12 @@ func TestQueryWithCompositeIndex_WithGreaterThanFilterOnFirstField_ShouldFetch(t
 		Description: "Test index filtering with _gt filter",
 		Actions: []any{
 			testUtils.SchemaUpdate{
-				Schema: schemaWithAgeNameIndex,
+				Schema: `
+					type User @index(fields: ["age", "name"]) {
+						name: String
+						age: Int
+						email: String
+					}`,
 			},
 			testUtils.CreatePredefinedDocs{
 				Docs: getUserDocs(),
@@ -129,7 +125,12 @@ func TestQueryWithCompositeIndex_WithGreaterThanFilterOnSecondField_ShouldFetch(
 		Description: "Test index filtering with _gt filter",
 		Actions: []any{
 			testUtils.SchemaUpdate{
-				Schema: schemaWithNameAgeIndex,
+				Schema: `
+					type User @index(fields: ["name", "age"]) {
+						name: String
+						age: Int
+						email: String
+					}`,
 			},
 			testUtils.CreatePredefinedDocs{
 				Docs: getUserDocs(),
@@ -160,7 +161,12 @@ func TestQueryWithCompositeIndex_WithGreaterOrEqualFilterOnFirstField_ShouldFetc
 		Description: "Test index filtering with _ge filter",
 		Actions: []any{
 			testUtils.SchemaUpdate{
-				Schema: schemaWithAgeNameIndex,
+				Schema: `
+					type User @index(fields: ["age", "name"]) {
+						name: String
+						age: Int
+						email: String
+					}`,
 			},
 			testUtils.CreatePredefinedDocs{
 				Docs: getUserDocs(),
@@ -192,7 +198,12 @@ func TestQueryWithCompositeIndex_WithGreaterOrEqualFilterOnSecondField_ShouldFet
 		Description: "Test index filtering with _ge filter",
 		Actions: []any{
 			testUtils.SchemaUpdate{
-				Schema: schemaWithNameAgeIndex,
+				Schema: `
+					type User @index(fields: ["name", "age"]) {
+						name: String
+						age: Int
+						email: String
+					}`,
 			},
 			testUtils.CreatePredefinedDocs{
 				Docs: getUserDocs(),
@@ -224,7 +235,12 @@ func TestQueryWithCompositeIndex_WithLessThanFilterOnFirstField_ShouldFetch(t *t
 		Description: "Test index filtering with _lt filter",
 		Actions: []any{
 			testUtils.SchemaUpdate{
-				Schema: schemaWithAgeNameIndex,
+				Schema: `
+					type User @index(fields: ["age", "name"]) {
+						name: String
+						age: Int
+						email: String
+					}`,
 			},
 			testUtils.CreatePredefinedDocs{
 				Docs: getUserDocs(),
@@ -255,7 +271,12 @@ func TestQueryWithCompositeIndex_WithLessThanFilterOnSecondField_ShouldFetch(t *
 		Description: "Test index filtering with _lt filter",
 		Actions: []any{
 			testUtils.SchemaUpdate{
-				Schema: schemaWithNameAgeIndex,
+				Schema: `
+					type User @index(fields: ["name", "age"]) {
+						name: String
+						age: Int
+						email: String
+					}`,
 			},
 			testUtils.CreatePredefinedDocs{
 				Docs: getUserDocs(),
@@ -286,7 +307,12 @@ func TestQueryWithCompositeIndex_WithLessOrEqualFilterOnFirstField_ShouldFetch(t
 		Description: "Test index filtering with _le filter",
 		Actions: []any{
 			testUtils.SchemaUpdate{
-				Schema: schemaWithAgeNameIndex,
+				Schema: `
+					type User @index(fields: ["age", "name"]) {
+						name: String
+						age: Int
+						email: String
+					}`,
 			},
 			testUtils.CreatePredefinedDocs{
 				Docs: getUserDocs(),
@@ -318,7 +344,12 @@ func TestQueryWithCompositeIndex_WithLessOrEqualFilterOnSecondField_ShouldFetch(
 		Description: "Test index filtering with _le filter",
 		Actions: []any{
 			testUtils.SchemaUpdate{
-				Schema: schemaWithNameAgeIndex,
+				Schema: `
+					type User @index(fields: ["name", "age"]) {
+						name: String
+						age: Int
+						email: String
+					}`,
 			},
 			testUtils.CreatePredefinedDocs{
 				Docs: getUserDocs(),
@@ -350,7 +381,12 @@ func TestQueryWithCompositeIndex_WithNotEqualFilter_ShouldFetch(t *testing.T) {
 		Description: "Test index filtering with _ne filter",
 		Actions: []any{
 			testUtils.SchemaUpdate{
-				Schema: schemaWithNameAgeIndex,
+				Schema: `
+					type User @index(fields: ["name", "age"]) {
+						name: String
+						age: Int
+						email: String
+					}`,
 			},
 			testUtils.CreatePredefinedDocs{
 				Docs: getUserDocs(),
@@ -388,7 +424,12 @@ func TestQueryWithCompositeIndex_WithInFilter_ShouldFetch(t *testing.T) {
 		Description: "Test index filtering with _in filter",
 		Actions: []any{
 			testUtils.SchemaUpdate{
-				Schema: schemaWithNameAgeIndex,
+				Schema: `
+					type User @index(fields: ["name", "age"]) {
+						name: String
+						age: Int
+						email: String
+					}`,
 			},
 			testUtils.CreatePredefinedDocs{
 				Docs: getUserDocs(),
@@ -420,7 +461,12 @@ func TestQueryWithCompositeIndex_WithNotInFilter_ShouldFetch(t *testing.T) {
 		Description: "Test index filtering with _nin filter",
 		Actions: []any{
 			testUtils.SchemaUpdate{
-				Schema: schemaWithNameAgeIndex,
+				Schema: `
+					type User @index(fields: ["name", "age"]) {
+						name: String
+						age: Int
+						email: String
+					}`,
 			},
 			testUtils.CreatePredefinedDocs{
 				Docs: getUserDocs(),
@@ -599,7 +645,12 @@ func TestQueryWithCompositeIndex_IfFirstFieldIsNotInFilter_ShouldNotUseIndex(t *
 		Description: "Test if index is not used when first field is not in filter",
 		Actions: []any{
 			testUtils.SchemaUpdate{
-				Schema: schemaWithNameAgeIndex,
+				Schema: `
+					type User @index(fields: ["name", "age"]) {
+						name: String
+						age: Int
+						email: String
+					}`,
 			},
 			testUtils.CreatePredefinedDocs{
 				Docs: getUserDocs(),
@@ -623,7 +674,12 @@ func TestQueryWithCompositeIndex_WithEqualFilterOnNilValueOnFirst_ShouldFetch(t 
 		Description: "Test index filtering with _eq filter on nil value on first field",
 		Actions: []any{
 			testUtils.SchemaUpdate{
-				Schema: schemaWithNameAgeIndex,
+				Schema: `
+					type User @index(fields: ["name", "age"]) {
+						name: String
+						age: Int
+						email: String
+					}`,
 			},
 			testUtils.CreateDoc{
 				CollectionID: 0,
@@ -663,7 +719,12 @@ func TestQueryWithCompositeIndex_WithEqualFilterOnNilValueOnSecond_ShouldFetch(t
 		Description: "Test index filtering with _eq filter on nil value on second field",
 		Actions: []any{
 			testUtils.SchemaUpdate{
-				Schema: schemaWithNameAgeIndex,
+				Schema: `
+					type User @index(fields: ["name", "age"]) {
+						name: String
+						age: Int
+						email: String
+					}`,
 			},
 			testUtils.CreateDoc{
 				CollectionID: 0,

--- a/tests/integration/index/query_with_composite_index_only_filter_test.go
+++ b/tests/integration/index/query_with_composite_index_only_filter_test.go
@@ -617,3 +617,98 @@ func TestQueryWithCompositeIndex_IfFirstFieldIsNotInFilter_ShouldNotUseIndex(t *
 
 	testUtils.ExecuteTestCase(t, test)
 }
+
+func TestQueryWithCompositeIndex_WithEqualFilterOnNilValueOnFirst_ShouldFetch(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "Test index filtering with _eq filter on nil value",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: schemaWithNameAgeIndex,
+			},
+			testUtils.CreatePredefinedDocs{
+				Docs: getUserDocs(),
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `
+					{
+						"name":	"Alice",
+						"age":	22
+					}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `
+					{
+						"age":	32
+					}`,
+			},
+			testUtils.Request{
+				Request: `
+					query {
+						User(filter: {name: {_eq: null}}) {
+							age
+						}
+					}`,
+				Results: []map[string]any{
+					{"age": 32},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestQueryWithCompositeIndex_WithEqualFilterOnNilValueOnSecond_ShouldFetch(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "Test index filtering with _eq filter on nil value",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: schemaWithNameAgeIndex,
+			},
+			testUtils.CreatePredefinedDocs{
+				Docs: getUserDocs(),
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `
+					{
+						"name":	"Alice",
+						"age":	22
+					}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `
+					{
+						"name":	"Bob"
+					}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `
+					{
+						"name":	"Alice"
+					}`,
+			},
+			testUtils.Request{
+				Request: `
+					query {
+						User(filter: {name: {_eq: "Alice"}, age: {_eq: null}}) {
+							name
+							age
+						}
+					}`,
+				Results: []map[string]any{
+					{
+						"name": "Alice",
+						"age":  nil,
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/index/query_with_composite_index_only_filter_test.go
+++ b/tests/integration/index/query_with_composite_index_only_filter_test.go
@@ -1,0 +1,619 @@
+// Copyright 2024 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package index
+
+import (
+	"testing"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+const schemaWithNameAgeIndex = `
+	type User @index(fields: ["name", "age"]) {
+		name: String
+		age: Int
+		email: String
+	}`
+
+const schemaWithAgeNameIndex = `
+	type User @index(fields: ["age", "name"]) {
+		name: String
+		age: Int
+		email: String
+	}`
+
+func TestQueryWithCompositeIndex_WithEqualFilter_ShouldFetch(t *testing.T) {
+	req1 := `query {
+		User(filter: {name: {_eq: "Islam"}}) {
+			name
+			age
+		}
+	}`
+	req2 := `query {
+		User(filter: {name: {_eq: "Islam"}, age: {_eq: 32}}) {
+			name
+			age
+		}
+	}`
+	req3 := `query {
+		User(filter: {name: {_eq: "Islam"}, age: {_eq: 66}}) {
+			name
+			age
+		}
+	}`
+	test := testUtils.TestCase{
+		Description: "Test filtering on composite index with _eq filter",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: schemaWithNameAgeIndex,
+			},
+			testUtils.CreatePredefinedDocs{
+				Docs: getUserDocs(),
+			},
+			testUtils.Request{
+				Request: req1,
+				Results: []map[string]any{
+					{"name": "Islam", "age": 32},
+				},
+			},
+			testUtils.Request{
+				Request:  makeExplainQuery(req1),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(1).WithIndexFetches(1),
+			},
+			testUtils.Request{
+				Request: req2,
+				Results: []map[string]any{
+					{"name": "Islam", "age": 32},
+				},
+			},
+			testUtils.Request{
+				Request:  makeExplainQuery(req2),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(1).WithIndexFetches(1),
+			},
+			testUtils.Request{
+				Request: req3,
+				Results: []map[string]any{},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestQueryWithCompositeIndex_WithGreaterThanFilterOnFirstField_ShouldFetch(t *testing.T) {
+	req := `query {
+		User(filter: {name: {_ne: "Keenan"}, age: {_gt: 44}}) {
+			name
+		}
+	}`
+	test := testUtils.TestCase{
+		Description: "Test index filtering with _gt filter",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: schemaWithAgeNameIndex,
+			},
+			testUtils.CreatePredefinedDocs{
+				Docs: getUserDocs(),
+			},
+			testUtils.Request{
+				Request: req,
+				Results: []map[string]any{
+					{"name": "Chris"},
+				},
+			},
+			testUtils.Request{
+				Request:  makeExplainQuery(req),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(1).WithIndexFetches(10),
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestQueryWithCompositeIndex_WithGreaterThanFilterOnSecondField_ShouldFetch(t *testing.T) {
+	req := `query {
+		User(filter: {name: {_ne: "Keenan"}, age: {_gt: 44}}) {
+			name
+		}
+	}`
+	test := testUtils.TestCase{
+		Description: "Test index filtering with _gt filter",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: schemaWithNameAgeIndex,
+			},
+			testUtils.CreatePredefinedDocs{
+				Docs: getUserDocs(),
+			},
+			testUtils.Request{
+				Request: req,
+				Results: []map[string]any{
+					{"name": "Chris"},
+				},
+			},
+			testUtils.Request{
+				Request:  makeExplainQuery(req),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(1).WithIndexFetches(10),
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestQueryWithCompositeIndex_WithGreaterOrEqualFilterOnFirstField_ShouldFetch(t *testing.T) {
+	req := `query {
+		User(filter: {name: {_ne: "Keenan"}, age: {_ge: 44},}) {
+			name
+		}
+	}`
+	test := testUtils.TestCase{
+		Description: "Test index filtering with _ge filter",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: schemaWithAgeNameIndex,
+			},
+			testUtils.CreatePredefinedDocs{
+				Docs: getUserDocs(),
+			},
+			testUtils.Request{
+				Request: req,
+				Results: []map[string]any{
+					{"name": "Roy"},
+					{"name": "Chris"},
+				},
+			},
+			testUtils.Request{
+				Request:  makeExplainQuery(req),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(2).WithIndexFetches(10),
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestQueryWithCompositeIndex_WithGreaterOrEqualFilterOnSecondField_ShouldFetch(t *testing.T) {
+	req := `query {
+		User(filter: {age: {_ge: 44}, name: {_ne: "Keenan"}}) {
+			name
+		}
+	}`
+	test := testUtils.TestCase{
+		Description: "Test index filtering with _ge filter",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: schemaWithNameAgeIndex,
+			},
+			testUtils.CreatePredefinedDocs{
+				Docs: getUserDocs(),
+			},
+			testUtils.Request{
+				Request: req,
+				Results: []map[string]any{
+					{"name": "Roy"},
+					{"name": "Chris"},
+				},
+			},
+			testUtils.Request{
+				Request:  makeExplainQuery(req),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(2).WithIndexFetches(10),
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestQueryWithCompositeIndex_WithLessThanFilterOnFirstField_ShouldFetch(t *testing.T) {
+	req := `query {
+		User(filter: {age: {_lt: 24}, name: {_ne: "Shahzad"}}) {
+			name
+		}
+	}`
+	test := testUtils.TestCase{
+		Description: "Test index filtering with _lt filter",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: schemaWithAgeNameIndex,
+			},
+			testUtils.CreatePredefinedDocs{
+				Docs: getUserDocs(),
+			},
+			testUtils.Request{
+				Request: req,
+				Results: []map[string]any{
+					{"name": "Bruno"},
+				},
+			},
+			testUtils.Request{
+				Request:  makeExplainQuery(req),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(1).WithIndexFetches(10),
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestQueryWithCompositeIndex_WithLessThanFilterOnSecondField_ShouldFetch(t *testing.T) {
+	req := `query {
+		User(filter: {age: {_lt: 24}, name: {_ne: "Shahzad"}}) {
+			name
+		}
+	}`
+	test := testUtils.TestCase{
+		Description: "Test index filtering with _lt filter",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: schemaWithNameAgeIndex,
+			},
+			testUtils.CreatePredefinedDocs{
+				Docs: getUserDocs(),
+			},
+			testUtils.Request{
+				Request: req,
+				Results: []map[string]any{
+					{"name": "Bruno"},
+				},
+			},
+			testUtils.Request{
+				Request:  makeExplainQuery(req),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(1).WithIndexFetches(10),
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestQueryWithCompositeIndex_WithLessOrEqualFilterOnFirstField_ShouldFetch(t *testing.T) {
+	req := `query {
+		User(filter: {age: {_le: 28}, name: {_ne: "Bruno"}}) {
+			name
+		}
+	}`
+	test := testUtils.TestCase{
+		Description: "Test index filtering with _le filter",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: schemaWithAgeNameIndex,
+			},
+			testUtils.CreatePredefinedDocs{
+				Docs: getUserDocs(),
+			},
+			testUtils.Request{
+				Request: req,
+				Results: []map[string]any{
+					{"name": "Shahzad"},
+					{"name": "Fred"},
+				},
+			},
+			testUtils.Request{
+				Request:  makeExplainQuery(req),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(2).WithIndexFetches(10),
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestQueryWithCompositeIndex_WithLessOrEqualFilterOnSecondField_ShouldFetch(t *testing.T) {
+	req := `query {
+		User(filter: {age: {_le: 28}, name: {_ne: "Bruno"}}) {
+			name
+		}
+	}`
+	test := testUtils.TestCase{
+		Description: "Test index filtering with _le filter",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: schemaWithNameAgeIndex,
+			},
+			testUtils.CreatePredefinedDocs{
+				Docs: getUserDocs(),
+			},
+			testUtils.Request{
+				Request: req,
+				Results: []map[string]any{
+					{"name": "Fred"},
+					{"name": "Shahzad"},
+				},
+			},
+			testUtils.Request{
+				Request:  makeExplainQuery(req),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(2).WithIndexFetches(10),
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestQueryWithCompositeIndex_WithNotEqualFilter_ShouldFetch(t *testing.T) {
+	req := `query {
+		User(filter: {name: {_ne: "Islam"}, age: {_ne: 28}}) {
+			name
+		}
+	}`
+	test := testUtils.TestCase{
+		Description: "Test index filtering with _ne filter",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: schemaWithNameAgeIndex,
+			},
+			testUtils.CreatePredefinedDocs{
+				Docs: getUserDocs(),
+			},
+			testUtils.Request{
+				Request: req,
+				Results: []map[string]any{
+					{"name": "Roy"},
+					{"name": "Addo"},
+					{"name": "Andy"},
+					{"name": "John"},
+					{"name": "Bruno"},
+					{"name": "Chris"},
+					{"name": "Keenan"},
+					{"name": "Shahzad"},
+				},
+			},
+			testUtils.Request{
+				Request:  makeExplainQuery(req),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(8).WithIndexFetches(10),
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestQueryWithCompositeIndex_WithInFilter_ShouldFetch(t *testing.T) {
+	req := `query {
+		User(filter: {age: {_in: [20, 28, 33]}, name: {_in: ["Addo", "Andy", "Fred"]}}) {
+			name
+		}
+	}`
+	test := testUtils.TestCase{
+		Description: "Test index filtering with _in filter",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: schemaWithNameAgeIndex,
+			},
+			testUtils.CreatePredefinedDocs{
+				Docs: getUserDocs(),
+			},
+			testUtils.Request{
+				Request: req,
+				Results: []map[string]any{
+					{"name": "Andy"},
+					{"name": "Fred"},
+				},
+			},
+			testUtils.Request{
+				Request:  makeExplainQuery(req),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(2).WithIndexFetches(3),
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestQueryWithCompositeIndex_WithNotInFilter_ShouldFetch(t *testing.T) {
+	req := `query {
+		User(filter: {age: {_nin: [20, 23, 28, 42]}, name: {_nin: ["John", "Andy", "Chris"]}}) {
+			name
+		}
+	}`
+	test := testUtils.TestCase{
+		Description: "Test index filtering with _nin filter",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: schemaWithNameAgeIndex,
+			},
+			testUtils.CreatePredefinedDocs{
+				Docs: getUserDocs(),
+			},
+			testUtils.Request{
+				Request: req,
+				Results: []map[string]any{
+					{"name": "Roy"},
+					{"name": "Islam"},
+					{"name": "Keenan"},
+				},
+			},
+			testUtils.Request{
+				Request:  makeExplainQuery(req),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(3).WithIndexFetches(10),
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestQueryWithCompositeIndex_WithLikeFilter_ShouldFetch(t *testing.T) {
+	req1 := `query {
+			User(filter: {email: {_like: "a%"}, name: {_like: "%o"}}) {
+				name
+			}
+		}`
+	req2 := `query {
+			User(filter: {email: {_like: "%d@gmail.com"}, name: {_like: "F%"}}) {
+				name
+			}
+		}`
+	req3 := `query {
+			User(filter: {email: {_like: "%e%"}, name: {_like: "%n%"}}) {
+				name
+			}
+		}`
+	req4 := `query {
+		User(filter: {email: {_like: "fred@gmail.com"}, name: {_like: "Fred"}}) {
+			name
+		}
+	}`
+	req5 := `query {
+		User(filter: {email: {_like: "a%@gmail.com"}, name: {_like: "%dd%"}}) {
+			name
+		}
+	}`
+	req6 := `query {
+		User(filter: {email: {_like: "a%com%m"}}) {
+			name
+		}
+	}`
+	req7 := `query {
+		User(filter: {email: {_like: "s%"}, name: {_like: "s%h%d"}}) {
+			name
+		}
+	}`
+	test := testUtils.TestCase{
+		Description: "Test index filtering with _like filter",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type User @index(fields: ["name", "email"]) {
+						name: String 
+						email: String 
+					}`,
+			},
+			testUtils.CreatePredefinedDocs{
+				Docs: getUserDocs(),
+			},
+			testUtils.Request{
+				Request: req1,
+				Results: []map[string]any{
+					{"name": "Addo"},
+				},
+			},
+			testUtils.Request{
+				Request:  makeExplainQuery(req1),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(1).WithIndexFetches(10),
+			},
+			testUtils.Request{
+				Request: req2,
+				Results: []map[string]any{
+					{"name": "Fred"},
+				},
+			},
+			testUtils.Request{
+				Request:  makeExplainQuery(req2),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(1).WithIndexFetches(10),
+			},
+			testUtils.Request{
+				Request: req3,
+				Results: []map[string]any{
+					{"name": "Keenan"},
+				},
+			},
+			testUtils.Request{
+				Request:  makeExplainQuery(req3),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(1).WithIndexFetches(10),
+			},
+			testUtils.Request{
+				Request: req4,
+				Results: []map[string]any{
+					{"name": "Fred"},
+				},
+			},
+			testUtils.Request{
+				Request:  makeExplainQuery(req4),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(1).WithIndexFetches(10),
+			},
+			testUtils.Request{
+				Request: req5,
+				Results: []map[string]any{
+					{"name": "Addo"},
+				},
+			},
+			testUtils.Request{
+				Request:  makeExplainQuery(req5),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(1).WithIndexFetches(10),
+			},
+			testUtils.Request{
+				Request: req6,
+				Results: []map[string]any{},
+			},
+			testUtils.Request{
+				Request: req7,
+				Results: []map[string]any{},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestQueryWithCompositeIndex_WithNotLikeFilter_ShouldFetch(t *testing.T) {
+	req := `query {
+		User(filter: {name: {_nlike: "%h%"}, email: {_nlike: "%d%"}}) {
+			name
+		}
+	}`
+	test := testUtils.TestCase{
+		Description: "Test index filtering with _nlike filter",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type User @index(fields: ["name", "email"]) {
+						name: String 
+						email: String 
+					}`,
+			},
+			testUtils.CreatePredefinedDocs{
+				Docs: getUserDocs(),
+			},
+			testUtils.Request{
+				Request: req,
+				Results: []map[string]any{
+					{"name": "Roy"},
+					{"name": "Bruno"},
+					{"name": "Islam"},
+					{"name": "Keenan"},
+				},
+			},
+			testUtils.Request{
+				Request:  makeExplainQuery(req),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(4).WithIndexFetches(10),
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestQueryWithCompositeIndex_IfFirstFieldIsNotInFilter_ShouldNotUseIndex(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "Test if index is not used when first field is not in filter",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: schemaWithNameAgeIndex,
+			},
+			testUtils.CreatePredefinedDocs{
+				Docs: getUserDocs(),
+			},
+			testUtils.Request{
+				Request: `query @explain(type: execute) {
+					User(filter: {age: {_eq: 32}}) {
+							name
+						}
+					}`,
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(11).WithIndexFetches(0),
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/index/query_with_index_combined_filter_test.go
+++ b/tests/integration/index/query_with_index_combined_filter_test.go
@@ -46,7 +46,7 @@ func TestQueryWithIndex_IfIndexFilterWithRegular_ShouldFilter(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithDocFetches(3).WithFieldFetches(6).WithIndexFetches(3),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(6).WithIndexFetches(3),
 			},
 		},
 	}
@@ -86,7 +86,7 @@ func TestQueryWithIndex_IfMultipleIndexFiltersWithRegular_ShouldFilter(t *testin
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithDocFetches(6).WithFieldFetches(18),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(18),
 			},
 		},
 	}

--- a/tests/integration/index/query_with_index_only_filter_test.go
+++ b/tests/integration/index/query_with_index_only_filter_test.go
@@ -45,7 +45,7 @@ func TestQueryWithIndex_WithNonIndexedFields_ShouldFetchAllOfThem(t *testing.T) 
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithDocFetches(1).WithFieldFetches(2).WithIndexFetches(1),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(2).WithIndexFetches(1),
 			},
 		},
 	}
@@ -79,7 +79,7 @@ func TestQueryWithIndex_WithEqualFilter_ShouldFetch(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithDocFetches(1).WithFieldFetches(1).WithIndexFetches(1),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(1).WithIndexFetches(1),
 			},
 		},
 	}
@@ -122,7 +122,7 @@ func TestQueryWithIndex_IfSeveralDocsWithEqFilter_ShouldFetchAll(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithDocFetches(2).WithFieldFetches(4).WithIndexFetches(2),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(4).WithIndexFetches(2),
 			},
 		},
 	}
@@ -157,7 +157,7 @@ func TestQueryWithIndex_WithGreaterThanFilter_ShouldFetch(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithDocFetches(1).WithFieldFetches(2).WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(2).WithIndexFetches(10),
 			},
 		},
 	}
@@ -193,7 +193,7 @@ func TestQueryWithIndex_WithGreaterOrEqualFilter_ShouldFetch(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithDocFetches(2).WithFieldFetches(4).WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(4).WithIndexFetches(10),
 			},
 		},
 	}
@@ -228,7 +228,7 @@ func TestQueryWithIndex_WithLessThanFilter_ShouldFetch(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithDocFetches(1).WithFieldFetches(2).WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(2).WithIndexFetches(10),
 			},
 		},
 	}
@@ -264,7 +264,7 @@ func TestQueryWithIndex_WithLessOrEqualFilter_ShouldFetch(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithDocFetches(2).WithFieldFetches(4).WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(4).WithIndexFetches(10),
 			},
 		},
 	}
@@ -307,7 +307,7 @@ func TestQueryWithIndex_WithNotEqualFilter_ShouldFetch(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithDocFetches(9).WithFieldFetches(9).WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(9).WithIndexFetches(10),
 			},
 		},
 	}
@@ -343,7 +343,7 @@ func TestQueryWithIndex_WithInFilter_ShouldFetch(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithDocFetches(2).WithFieldFetches(4).WithIndexFetches(2),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(4).WithIndexFetches(2),
 			},
 		},
 	}
@@ -386,7 +386,7 @@ func TestQueryWithIndex_IfSeveralDocsWithInFilter_ShouldFetchAll(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithDocFetches(2).WithFieldFetches(4).WithIndexFetches(2),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(4).WithIndexFetches(2),
 			},
 		},
 	}
@@ -424,7 +424,7 @@ func TestQueryWithIndex_WithNotInFilter_ShouldFetch(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithDocFetches(4).WithFieldFetches(8).WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(8).WithIndexFetches(10),
 			},
 		},
 	}
@@ -485,7 +485,7 @@ func TestQueryWithIndex_WithLikeFilter_ShouldFetch(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req1),
-				Asserter: testUtils.NewExplainAsserter().WithDocFetches(2).WithFieldFetches(4).WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(4).WithIndexFetches(10),
 			},
 			testUtils.Request{
 				Request: req2,
@@ -496,7 +496,7 @@ func TestQueryWithIndex_WithLikeFilter_ShouldFetch(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req2),
-				Asserter: testUtils.NewExplainAsserter().WithDocFetches(2).WithFieldFetches(4).WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(4).WithIndexFetches(10),
 			},
 			testUtils.Request{
 				Request: req3,
@@ -507,7 +507,7 @@ func TestQueryWithIndex_WithLikeFilter_ShouldFetch(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req3),
-				Asserter: testUtils.NewExplainAsserter().WithDocFetches(2).WithFieldFetches(4).WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(4).WithIndexFetches(10),
 			},
 			testUtils.Request{
 				Request: req4,
@@ -517,7 +517,7 @@ func TestQueryWithIndex_WithLikeFilter_ShouldFetch(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req4),
-				Asserter: testUtils.NewExplainAsserter().WithDocFetches(1).WithFieldFetches(2).WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(2).WithIndexFetches(10),
 			},
 			testUtils.Request{
 				Request: req5,
@@ -528,7 +528,7 @@ func TestQueryWithIndex_WithLikeFilter_ShouldFetch(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req5),
-				Asserter: testUtils.NewExplainAsserter().WithDocFetches(2).WithFieldFetches(4).WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(4).WithIndexFetches(10),
 			},
 			testUtils.Request{
 				Request: req6,
@@ -536,7 +536,7 @@ func TestQueryWithIndex_WithLikeFilter_ShouldFetch(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req6),
-				Asserter: testUtils.NewExplainAsserter().WithDocFetches(0).WithFieldFetches(0).WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(0).WithIndexFetches(10),
 			},
 		},
 	}
@@ -577,7 +577,7 @@ func TestQueryWithIndex_WithNotLikeFilter_ShouldFetch(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithDocFetches(7).WithFieldFetches(7).WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(7).WithIndexFetches(10),
 			},
 		},
 	}

--- a/tests/integration/index/query_with_relation_filter_test.go
+++ b/tests/integration/index/query_with_relation_filter_test.go
@@ -60,7 +60,7 @@ func TestQueryWithIndexOnOneToManyRelation_IfFilterOnIndexedRelation_ShouldFilte
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req1),
-				Asserter: testUtils.NewExplainAsserter().WithDocFetches(6).WithFieldFetches(9).WithIndexFetches(3),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(9).WithIndexFetches(3),
 			},
 			testUtils.Request{
 				Request: req2,
@@ -70,7 +70,7 @@ func TestQueryWithIndexOnOneToManyRelation_IfFilterOnIndexedRelation_ShouldFilte
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req2),
-				Asserter: testUtils.NewExplainAsserter().WithDocFetches(2).WithFieldFetches(3).WithIndexFetches(1),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(3).WithIndexFetches(1),
 			},
 		},
 	}
@@ -122,7 +122,7 @@ func TestQueryWithIndexOnOneToManyRelation_IfFilterOnIndexedRelation_ShouldFilte
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req1),
-				Asserter: testUtils.NewExplainAsserter().WithDocFetches(6).WithFieldFetches(9).WithIndexFetches(3),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(9).WithIndexFetches(3),
 			},
 			testUtils.Request{
 				Request: req2,
@@ -132,7 +132,7 @@ func TestQueryWithIndexOnOneToManyRelation_IfFilterOnIndexedRelation_ShouldFilte
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req2),
-				Asserter: testUtils.NewExplainAsserter().WithDocFetches(2).WithFieldFetches(3).WithIndexFetches(1),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(3).WithIndexFetches(1),
 			},
 		},
 	}
@@ -182,7 +182,7 @@ func TestQueryWithIndexOnOneToOnesSecondaryRelation_IfFilterOnIndexedRelation_Sh
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req1),
-				Asserter: testUtils.NewExplainAsserter().WithDocFetches(2).WithFieldFetches(3).WithIndexFetches(1),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(3).WithIndexFetches(1),
 			},
 			testUtils.Request{
 				Request: req2,
@@ -194,7 +194,7 @@ func TestQueryWithIndexOnOneToOnesSecondaryRelation_IfFilterOnIndexedRelation_Sh
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req2),
-				Asserter: testUtils.NewExplainAsserter().WithDocFetches(6).WithFieldFetches(9).WithIndexFetches(3),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(9).WithIndexFetches(3),
 			},
 		},
 	}
@@ -245,7 +245,7 @@ func TestQueryWithIndexOnOneToOnePrimaryRelation_IfFilterOnIndexedFieldOfRelatio
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req1),
-				Asserter: testUtils.NewExplainAsserter().WithDocFetches(11).WithFieldFetches(12).WithIndexFetches(1),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(12).WithIndexFetches(1),
 			},
 			testUtils.Request{
 				Request: req2,
@@ -257,7 +257,7 @@ func TestQueryWithIndexOnOneToOnePrimaryRelation_IfFilterOnIndexedFieldOfRelatio
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req2),
-				Asserter: testUtils.NewExplainAsserter().WithDocFetches(15).WithFieldFetches(18).WithIndexFetches(3),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(18).WithIndexFetches(3),
 			},
 		},
 	}
@@ -301,7 +301,7 @@ func TestQueryWithIndexOnOneToOnePrimaryRelation_IfFilterOnIndexedRelationWhileI
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithDocFetches(11).WithFieldFetches(12).WithIndexFetches(1),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(12).WithIndexFetches(1),
 			},
 		},
 	}
@@ -368,7 +368,7 @@ func TestQueryWithIndexOnOneToTwoRelation_IfFilterOnIndexedRelation_ShouldFilter
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req1),
-				Asserter: testUtils.NewExplainAsserter().WithDocFetches(2).WithFieldFetches(3).WithIndexFetches(1),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(3).WithIndexFetches(1),
 			},
 			testUtils.Request{
 				Request: req2,
@@ -383,7 +383,7 @@ func TestQueryWithIndexOnOneToTwoRelation_IfFilterOnIndexedRelation_ShouldFilter
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req2),
-				Asserter: testUtils.NewExplainAsserter().WithDocFetches(2).WithFieldFetches(3).WithIndexFetches(1),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(3).WithIndexFetches(1),
 			},
 		},
 	}

--- a/tests/integration/index/query_with_unique_composite_index_filter_test.go
+++ b/tests/integration/index/query_with_unique_composite_index_filter_test.go
@@ -16,20 +16,6 @@ import (
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
 )
 
-const schemaWithNameAgeUniqueIndex = `
-	type User @index(unique: true, fields: ["name", "age"]) {
-		name: String
-		age: Int
-		email: String
-	}`
-
-const schemaWithAgeNameUniqueIndex = `
-	type User @index(unique: true, fields: ["age", "name"]) {
-		name: String
-		age: Int
-		email: String
-	}`
-
 func TestQueryWithUniqueCompositeIndex_WithEqualFilter_ShouldFetch(t *testing.T) {
 	req1 := `query {
 		User(filter: {name: {_eq: "Islam"}}) {
@@ -53,7 +39,12 @@ func TestQueryWithUniqueCompositeIndex_WithEqualFilter_ShouldFetch(t *testing.T)
 		Description: "Test filtering on composite index with _eq filter",
 		Actions: []any{
 			testUtils.SchemaUpdate{
-				Schema: schemaWithNameAgeUniqueIndex,
+				Schema: `
+					type User @index(unique: true, fields: ["name", "age"]) {
+						name: String
+						age: Int
+						email: String
+					}`,
 			},
 			testUtils.CreatePredefinedDocs{
 				Docs: getUserDocs(),
@@ -116,7 +107,12 @@ func TestQueryWithUniqueCompositeIndex_WithGreaterThanFilterOnFirstField_ShouldF
 		Description: "Test index filtering with _gt filter",
 		Actions: []any{
 			testUtils.SchemaUpdate{
-				Schema: schemaWithAgeNameUniqueIndex,
+				Schema: `
+					type User @index(unique: true, fields: ["age", "name"]) {
+						name: String
+						age: Int
+						email: String
+					}`,
 			},
 			testUtils.CreatePredefinedDocs{
 				Docs: getUserDocs(),
@@ -147,7 +143,12 @@ func TestQueryWithUniqueCompositeIndex_WithGreaterThanFilterOnSecondField_Should
 		Description: "Test index filtering with _gt filter",
 		Actions: []any{
 			testUtils.SchemaUpdate{
-				Schema: schemaWithNameAgeUniqueIndex,
+				Schema: `
+					type User @index(unique: true, fields: ["name", "age"]) {
+						name: String
+						age: Int
+						email: String
+					}`,
 			},
 			testUtils.CreatePredefinedDocs{
 				Docs: getUserDocs(),
@@ -178,7 +179,12 @@ func TestQueryWithUniqueCompositeIndex_WithGreaterOrEqualFilterOnFirstField_Shou
 		Description: "Test index filtering with _ge filter",
 		Actions: []any{
 			testUtils.SchemaUpdate{
-				Schema: schemaWithAgeNameUniqueIndex,
+				Schema: `
+					type User @index(unique: true, fields: ["age", "name"]) {
+						name: String
+						age: Int
+						email: String
+					}`,
 			},
 			testUtils.CreatePredefinedDocs{
 				Docs: getUserDocs(),
@@ -210,7 +216,12 @@ func TestQueryWithUniqueCompositeIndex_WithGreaterOrEqualFilterOnSecondField_Sho
 		Description: "Test index filtering with _ge filter",
 		Actions: []any{
 			testUtils.SchemaUpdate{
-				Schema: schemaWithNameAgeUniqueIndex,
+				Schema: `
+					type User @index(unique: true, fields: ["name", "age"]) {
+						name: String
+						age: Int
+						email: String
+					}`,
 			},
 			testUtils.CreatePredefinedDocs{
 				Docs: getUserDocs(),
@@ -242,7 +253,12 @@ func TestQueryWithUniqueCompositeIndex_WithLessThanFilterOnFirstField_ShouldFetc
 		Description: "Test index filtering with _lt filter",
 		Actions: []any{
 			testUtils.SchemaUpdate{
-				Schema: schemaWithAgeNameUniqueIndex,
+				Schema: `
+					type User @index(unique: true, fields: ["age", "name"]) {
+						name: String
+						age: Int
+						email: String
+					}`,
 			},
 			testUtils.CreatePredefinedDocs{
 				Docs: getUserDocs(),
@@ -273,7 +289,12 @@ func TestQueryWithUniqueCompositeIndex_WithLessThanFilterOnSecondField_ShouldFet
 		Description: "Test index filtering with _lt filter",
 		Actions: []any{
 			testUtils.SchemaUpdate{
-				Schema: schemaWithNameAgeUniqueIndex,
+				Schema: `
+					type User @index(unique: true, fields: ["name", "age"]) {
+						name: String
+						age: Int
+						email: String
+					}`,
 			},
 			testUtils.CreatePredefinedDocs{
 				Docs: getUserDocs(),
@@ -304,7 +325,12 @@ func TestQueryWithUniqueCompositeIndex_WithLessOrEqualFilterOnFirstField_ShouldF
 		Description: "Test index filtering with _le filter",
 		Actions: []any{
 			testUtils.SchemaUpdate{
-				Schema: schemaWithAgeNameUniqueIndex,
+				Schema: `
+					type User @index(unique: true, fields: ["age", "name"]) {
+						name: String
+						age: Int
+						email: String
+					}`,
 			},
 			testUtils.CreatePredefinedDocs{
 				Docs: getUserDocs(),
@@ -336,7 +362,12 @@ func TestQueryWithUniqueCompositeIndex_WithLessOrEqualFilterOnSecondField_Should
 		Description: "Test index filtering with _le filter",
 		Actions: []any{
 			testUtils.SchemaUpdate{
-				Schema: schemaWithNameAgeUniqueIndex,
+				Schema: `
+					type User @index(unique: true, fields: ["name", "age"]) {
+						name: String
+						age: Int
+						email: String
+					}`,
 			},
 			testUtils.CreatePredefinedDocs{
 				Docs: getUserDocs(),
@@ -368,7 +399,12 @@ func TestQueryWithUniqueCompositeIndex_WithNotEqualFilter_ShouldFetch(t *testing
 		Description: "Test index filtering with _ne filter",
 		Actions: []any{
 			testUtils.SchemaUpdate{
-				Schema: schemaWithNameAgeUniqueIndex,
+				Schema: `
+					type User @index(unique: true, fields: ["name", "age"]) {
+						name: String
+						age: Int
+						email: String
+					}`,
 			},
 			testUtils.CreatePredefinedDocs{
 				Docs: getUserDocs(),
@@ -407,7 +443,12 @@ func TestQueryWithUniqueCompositeIndex_WithInForFirstAndEqForRest_ShouldFetchEff
 		Description: "Test index filtering with _in filter",
 		Actions: []any{
 			testUtils.SchemaUpdate{
-				Schema: schemaWithNameAgeUniqueIndex,
+				Schema: `
+					type User @index(unique: true, fields: ["name", "age"]) {
+						name: String
+						age: Int
+						email: String
+					}`,
 			},
 			testUtils.CreateDoc{
 				CollectionID: 0,
@@ -476,7 +517,12 @@ func TestQueryWithUniqueCompositeIndex_WithInFilter_ShouldFetch(t *testing.T) {
 		Description: "Test index filtering with _in filter",
 		Actions: []any{
 			testUtils.SchemaUpdate{
-				Schema: schemaWithNameAgeUniqueIndex,
+				Schema: `
+					type User @index(unique: true, fields: ["name", "age"]) {
+						name: String
+						age: Int
+						email: String
+					}`,
 			},
 			testUtils.CreatePredefinedDocs{
 				Docs: getUserDocs(),
@@ -524,7 +570,12 @@ func TestQueryWithUniqueCompositeIndex_WithNotInFilter_ShouldFetch(t *testing.T)
 		Description: "Test index filtering with _nin filter",
 		Actions: []any{
 			testUtils.SchemaUpdate{
-				Schema: schemaWithNameAgeUniqueIndex,
+				Schema: `
+					type User @index(unique: true, fields: ["name", "age"]) {
+						name: String
+						age: Int
+						email: String
+					}`,
 			},
 			testUtils.CreatePredefinedDocs{
 				Docs: getUserDocs(),
@@ -703,7 +754,12 @@ func TestQueryWithUniqueCompositeIndex_IfFirstFieldIsNotInFilter_ShouldNotUseInd
 		Description: "Test if index is not used when first field is not in filter",
 		Actions: []any{
 			testUtils.SchemaUpdate{
-				Schema: schemaWithNameAgeUniqueIndex,
+				Schema: `
+					type User @index(unique: true, fields: ["name", "age"]) {
+						name: String
+						age: Int
+						email: String
+					}`,
 			},
 			testUtils.CreatePredefinedDocs{
 				Docs: getUserDocs(),
@@ -727,7 +783,12 @@ func TestQueryWithUniqueCompositeIndex_WithEqualFilterOnNilValueOnFirst_ShouldFe
 		Description: "Test index filtering with _eq filter on nil value on first field",
 		Actions: []any{
 			testUtils.SchemaUpdate{
-				Schema: schemaWithNameAgeUniqueIndex,
+				Schema: `
+					type User @index(unique: true, fields: ["name", "age"]) {
+						name: String
+						age: Int
+						email: String
+					}`,
 			},
 			testUtils.CreateDoc{
 				CollectionID: 0,
@@ -767,7 +828,12 @@ func TestQueryWithUniqueCompositeIndex_WithEqualFilterOnNilValueOnSecond_ShouldF
 		Description: "Test index filtering with _eq filter on nil value on second field",
 		Actions: []any{
 			testUtils.SchemaUpdate{
-				Schema: schemaWithNameAgeUniqueIndex,
+				Schema: `
+					type User @index(unique: true, fields: ["name", "age"]) {
+						name: String
+						age: Int
+						email: String
+					}`,
 			},
 			testUtils.CreateDoc{
 				CollectionID: 0,

--- a/tests/integration/index/query_with_unique_index_only_filter_test.go
+++ b/tests/integration/index/query_with_unique_index_only_filter_test.go
@@ -42,7 +42,7 @@ func TestQueryWithUniqueIndex_WithEqualFilter_ShouldFetch(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithDocFetches(1).WithFieldFetches(1).WithIndexFetches(1),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(1).WithIndexFetches(1),
 			},
 		},
 	}
@@ -77,7 +77,7 @@ func TestQueryWithUniqueIndex_WithGreaterThanFilter_ShouldFetch(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithDocFetches(1).WithFieldFetches(2).WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(2).WithIndexFetches(10),
 			},
 		},
 	}
@@ -113,7 +113,7 @@ func TestQueryWithUniqueIndex_WithGreaterOrEqualFilter_ShouldFetch(t *testing.T)
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithDocFetches(2).WithFieldFetches(4).WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(4).WithIndexFetches(10),
 			},
 		},
 	}
@@ -148,7 +148,7 @@ func TestQueryWithUniqueIndex_WithLessThanFilter_ShouldFetch(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithDocFetches(1).WithFieldFetches(2).WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(2).WithIndexFetches(10),
 			},
 		},
 	}
@@ -184,7 +184,7 @@ func TestQueryWithUniqueIndex_WithLessOrEqualFilter_ShouldFetch(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithDocFetches(2).WithFieldFetches(4).WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(4).WithIndexFetches(10),
 			},
 		},
 	}
@@ -227,7 +227,7 @@ func TestQueryWithUniqueIndex_WithNotEqualFilter_ShouldFetch(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithDocFetches(9).WithFieldFetches(9).WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(9).WithIndexFetches(10),
 			},
 		},
 	}
@@ -263,7 +263,7 @@ func TestQueryWithUniqueIndex_WithInFilter_ShouldFetch(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithDocFetches(2).WithFieldFetches(4).WithIndexFetches(2),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(4).WithIndexFetches(2),
 			},
 		},
 	}
@@ -301,7 +301,7 @@ func TestQueryWithUniqueIndex_WithNotInFilter_ShouldFetch(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithDocFetches(4).WithFieldFetches(8).WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(8).WithIndexFetches(10),
 			},
 		},
 	}
@@ -362,7 +362,7 @@ func TestQueryWithUniqueIndex_WithLikeFilter_ShouldFetch(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req1),
-				Asserter: testUtils.NewExplainAsserter().WithDocFetches(2).WithFieldFetches(4).WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(4).WithIndexFetches(10),
 			},
 			testUtils.Request{
 				Request: req2,
@@ -373,7 +373,7 @@ func TestQueryWithUniqueIndex_WithLikeFilter_ShouldFetch(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req2),
-				Asserter: testUtils.NewExplainAsserter().WithDocFetches(2).WithFieldFetches(4).WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(4).WithIndexFetches(10),
 			},
 			testUtils.Request{
 				Request: req3,
@@ -384,7 +384,7 @@ func TestQueryWithUniqueIndex_WithLikeFilter_ShouldFetch(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req3),
-				Asserter: testUtils.NewExplainAsserter().WithDocFetches(2).WithFieldFetches(4).WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(4).WithIndexFetches(10),
 			},
 			testUtils.Request{
 				Request: req4,
@@ -394,7 +394,7 @@ func TestQueryWithUniqueIndex_WithLikeFilter_ShouldFetch(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req4),
-				Asserter: testUtils.NewExplainAsserter().WithDocFetches(1).WithFieldFetches(2).WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(2).WithIndexFetches(10),
 			},
 			testUtils.Request{
 				Request: req5,
@@ -405,7 +405,7 @@ func TestQueryWithUniqueIndex_WithLikeFilter_ShouldFetch(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req5),
-				Asserter: testUtils.NewExplainAsserter().WithDocFetches(2).WithFieldFetches(4).WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(4).WithIndexFetches(10),
 			},
 			testUtils.Request{
 				Request: req6,
@@ -413,7 +413,7 @@ func TestQueryWithUniqueIndex_WithLikeFilter_ShouldFetch(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req6),
-				Asserter: testUtils.NewExplainAsserter().WithDocFetches(0).WithFieldFetches(0).WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(0).WithIndexFetches(10),
 			},
 		},
 	}
@@ -454,7 +454,7 @@ func TestQueryWithUniqueIndex_WithNotLikeFilter_ShouldFetch(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithDocFetches(7).WithFieldFetches(7).WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(7).WithIndexFetches(10),
 			},
 		},
 	}

--- a/tests/integration/test_case.go
+++ b/tests/integration/test_case.go
@@ -246,6 +246,7 @@ type CreateIndex struct {
 	// The names of the fields to index. Used only for composite indexes.
 	FieldsNames []string
 	// The directions of the 'FieldsNames' to index. Used only for composite indexes.
+	// If not provided all fields will be indexed in ascending order.
 	Directions []client.IndexDirection
 
 	// If Unique is true, the index will be created as a unique index.

--- a/tests/integration/utils2.go
+++ b/tests/integration/utils2.go
@@ -1339,9 +1339,13 @@ func createIndex(
 			}
 		} else if len(action.FieldsNames) > 0 {
 			for i := range action.FieldsNames {
+				dir := client.Ascending
+				if len(action.Directions) > i {
+					dir = action.Directions[i]
+				}
 				indexDesc.Fields = append(indexDesc.Fields, client.IndexedFieldDescription{
 					Name:      action.FieldsNames[i],
-					Direction: action.Directions[i],
+					Direction: dir,
 				})
 			}
 		}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #299 

## Description

This change introduces composite secondary indexes as well as unique-composite secondary indexes.
Note: different order direction for composite fields is not included in this change.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Unit and integration tests.

Specify the platform(s) on which this was tested:
- MacOS
