### PR TITLE
chore(i): Split build by OS for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,19 +23,16 @@ permissions:
   issues: write
 
 jobs:
-  goreleaser:
-    runs-on: ubuntu-latest
+  prepare:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code into the directory
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-
-      - name: Setup Go environment explicitly
-        uses: actions/setup-go@v3
-        with:
-          go-version: "1.20"
-          check-latest: true
 
       - name: Apply tag
         run: git tag ${{ github.event.inputs.tag }}
@@ -45,27 +42,135 @@ jobs:
       
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
+        if: matrix.os == 'ubuntu-latest'
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v2
+        if: matrix.os == 'ubuntu-latest'
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Log in to the Container registry
         uses: docker/login-action@v2
+        if: matrix.os == 'ubuntu-latest'
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Setup Go environment explicitly
+        uses: actions/setup-go@v3
+        with:
+          go-version: "1.20"
+          check-latest: true
+          cache: true
+
+      - shell: bash
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+      - uses: actions/cache@v4
+        if: matrix.os == 'ubuntu-latest'
+        with:
+          path: dist/linux_amd64
+          key: linux-${{ env.sha_short }}
+      - uses: actions/cache@v4
+        if: matrix.os == 'macos-latest'
+        with:
+          path: dist/darwin_amd64
+          key: darwin-${{ env.sha_short }}
+      - uses: actions/cache@v4
+        if: matrix.os == 'windows-latest'
+        with:
+          path: dist/windows_amd64
+          key: windows-${{ env.sha_short }}
+          enableCrossOsArchive: true
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v5
         with:
           distribution: goreleaser-pro
           version: latest
-          args: release --clean
+          args: release --clean --split ${{ env.flags }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+  
+  release:
+    runs-on: ubuntu-latest
+    needs: prepare
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Apply tag
+        run: git tag ${{ github.event.inputs.tag }}
+
+      - name: Setup Go environment explicitly
+        uses: actions/setup-go@v3
+        with:
+          go-version: "1.20"
+          check-latest: true
+          cache: true
+      
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      # copy the cashes from prepare
+      - shell: bash
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+      - uses: actions/cache@v4
+        with:
+          path: dist/linux_amd64
+          key: linux-${{ env.sha_short }}
+      - uses: actions/cache@v4
+        with:
+          path: dist/darwin_amd64
+          key: darwin-${{ env.sha_short }}
+      - uses: actions/cache@v4
+        with:
+          path: dist/windows_amd64
+          key: windows-${{ env.sha_short }}
+          enableCrossOsArchive: true
+
+
+      # release
+      - uses: goreleaser/goreleaser-action@v5
+        if: steps.cache.outputs.cache-hit != 'true' # do not run if cache hit
+        with:
+          distribution: goreleaser-pro
+          version: latest
+          args: continue --merge
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+  
+  pull-docker-image:
+    name: Pull docker image job
+    runs-on: ubuntu-latest
+    needs: prepare
+
+    strategy:
+      fail-fast: false
+      matrix:
+        image_tag:
+          - sourcenetwork/defradb:latest
+          - ghcr.io/sourcenetwork/defradb:latest
+
+    steps:
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          
+      - name: Pull Docker image
+        run: docker pull ${{ matrix.image_tag }}
+
+      - name: Test Docker image
+        run: docker run --rm ${{ matrix.image_tag }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,16 +1,9 @@
 version: 1
 
-dist: ./build
-
 before:
   hooks:
     - go mod tidy
     - make deps:playground
-
-after:
-  hooks:
-    - cmd: docker pull {{ .Env.GITHUB_REPOSITORY }}:latest
-    - cmd: docker run --rm {{ .Env.GITHUB_REPOSITORY }}:latest
 
 builds:
   - id: "defradb"
@@ -34,6 +27,9 @@ builds:
     goarch:
       - amd64
       - arm64
+  
+partial:
+  by: target
 
 archives:
   - id: defradb_playground


### PR DESCRIPTION
## Relevant issue(s)

Resolves #2227 

## Description

This PR modifies the release workflow to split the build on the 3 different OS. This is needed now that we use wasmtime and CGO is needed for compilation.
