### PR TITLE
fix: Load root dir before loading config

### DIFF
--- a/cli/utils.go
+++ b/cli/utils.go
@@ -99,6 +99,9 @@ func setStoreContext(cmd *cobra.Command, cfg *config.Config) error {
 // loadConfig loads the rootDir containing the configuration file,
 // otherwise warn about it and load a default configuration.
 func loadConfig(cfg *config.Config) error {
+	if err := cfg.LoadRootDirFromFlagOrDefault(); err != nil {
+		return err
+	}
 	return cfg.LoadWithRootdir(cfg.ConfigFileExists())
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -130,10 +130,6 @@ func (cfg *Config) LoadWithRootdir(withRootdir bool) error {
 		return err
 	}
 
-	if err := cfg.LoadRootDirFromFlagOrDefault(); err != nil {
-		return err
-	}
-
 	if withRootdir {
 		if err := cfg.v.ReadInConfig(); err != nil {
 			return NewErrReadingConfigFile(err)


### PR DESCRIPTION
## Relevant issue(s)

Resolves #2264 

## Description

This PR ensures that the root dir path gets defined prior to looking for a config file. It fixes an issue where the config file wasn't being loaded on node start.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

manually tested that a change in the config file would be reflected in the node behaviour.

Specify the platform(s) on which this was tested:
- MacOS
