### PR TITLE
fix(i): Revert removal of root dir check in LoadWithRootDIr

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -130,6 +130,10 @@ func (cfg *Config) LoadWithRootdir(withRootdir bool) error {
 		return err
 	}
 
+	if err := cfg.LoadRootDirFromFlagOrDefault(); err != nil {
+		return err
+	}
+
 	if withRootdir {
 		if err := cfg.v.ReadInConfig(); err != nil {
 			return NewErrReadingConfigFile(err)


### PR DESCRIPTION
## Relevant issue(s)

Resolves #2268

## Description

Sorry guys, went one step too far on that last fix (I was the cause of the bug btw). removing the re-added lines cause the a config error on init.