### PR TITLE
refactor: Remove unused Delete field from client.Document

### DIFF
--- a/client/value.go
+++ b/client/value.go
@@ -19,7 +19,6 @@ type FieldValue struct {
 	t       CType
 	value   any
 	isDirty bool
-	delete  bool
 }
 
 func NewFieldValue(t CType, val any) *FieldValue {
@@ -50,16 +49,6 @@ func (val FieldValue) IsDirty() bool {
 
 func (val *FieldValue) Clean() {
 	val.isDirty = false
-	val.delete = false
-}
-
-func (val *FieldValue) Delete() {
-	val.delete = true
-	val.isDirty = true
-}
-
-func (val FieldValue) IsDelete() bool {
-	return val.delete
 }
 
 func (val *FieldValue) SetType(t CType) {


### PR DESCRIPTION
## Relevant issue(s)

Resolves #2274 

## Description

Remove unused `Delete` method of `client.Document`

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Unit and integration tests.

Specify the platform(s) on which this was tested:
- MacOS