### PR TITLE
feat: Multiple docs with nil value on unique-indexed field

### DIFF
--- a/client/document.go
+++ b/client/document.go
@@ -12,6 +12,7 @@ package client
 
 import (
 	"encoding/json"
+	"errors"
 	"regexp"
 	"strings"
 	"sync"
@@ -466,6 +467,16 @@ func (doc *Document) GetValue(field string) (*FieldValue, error) {
 	} else {
 		return val.Value().(*Document).GetValue(subPaths)
 	}
+}
+
+// TryGetValue returns the value for a given field, if it exists.
+// If the field does not exist then return nil and an error.
+func (doc *Document) TryGetValue(field string) (*FieldValue, error) {
+	val, err := doc.GetValue(field)
+	if err != nil && errors.Is(err, ErrFieldNotExist) {
+		return nil, nil
+	}
+	return val, err
 }
 
 // GetValueWithField gets the Value type from a given Field type

--- a/db/fetcher/errors.go
+++ b/db/fetcher/errors.go
@@ -27,7 +27,7 @@ const (
 	errFailedToGetDagNode           string = "failed to get DAG Node"
 	errMissingMapper                string = "missing document mapper"
 	errInvalidInOperatorValue       string = "invalid _in/_nin value"
-	errInvalidIndexFilterCondition  string = "invalid index filter condition"
+	errInvalidFilterOperator        string = "invalid filter operator is provided"
 )
 
 var (
@@ -44,7 +44,7 @@ var (
 	ErrMissingMapper                = errors.New(errMissingMapper)
 	ErrSingleSpanOnly               = errors.New("spans must contain only a single entry")
 	ErrInvalidInOperatorValue       = errors.New(errInvalidInOperatorValue)
-	ErrInvalidIndexFilterCondition  = errors.New(errInvalidIndexFilterCondition)
+	ErrInvalidFilterOperator        = errors.New(errInvalidFilterOperator)
 )
 
 // NewErrFieldIdNotFound returns an error indicating that the given FieldId was not found.
@@ -96,4 +96,9 @@ func NewErrVFetcherFailedToGetDagLink(inner error) error {
 // NewErrFailedToGetDagNode returns an error indicating that the given DAG node could not be retrieved.
 func NewErrFailedToGetDagNode(inner error) error {
 	return errors.Wrap(errFailedToGetDagNode, inner)
+}
+
+// NewErrInvalidFilterOperator returns an error indicating that the given filter operator is invalid.
+func NewErrInvalidFilterOperator(operator string) error {
+	return errors.New(errInvalidFilterOperator, errors.NewKV("Operator", operator))
 }

--- a/docs/data_format_changes/i2161-document-strong-typing.md
+++ b/docs/data_format_changes/i2161-document-strong-typing.md
@@ -1,3 +1,3 @@
 # Add strong typing to document creation
 
-Since we now inforce type safety in the document creation, some of the fields in our tests now marshal to a different types and this is causing CIDs and docIDs to change.
+Since we now enforce type safety in the document creation, some of the fields in our tests now marshal to a different types and this is causing CIDs and docIDs to change.

--- a/docs/data_format_changes/i2276-multiple-nil-for-unique-index-change.md
+++ b/docs/data_format_changes/i2276-multiple-nil-for-unique-index-change.md
@@ -1,0 +1,3 @@
+# Multiple nil values for unique index change
+
+Added ability to have multiple docs with nil values on unique-indexed field. This slightly change datastore.

--- a/tests/integration/index/create_unique_test.go
+++ b/tests/integration/index/create_unique_test.go
@@ -190,7 +190,7 @@ func TestUniqueIndexCreate_IfFieldValuesAreUnique_Succeed(t *testing.T) {
 	testUtils.ExecuteTestCase(t, test)
 }
 
-func TestUniqueIndexCreate_IfNilFieldsArePresent_ReturnError(t *testing.T) {
+func TestUniqueIndexCreate_WithMultipleNilFields_ShouldSucceed(t *testing.T) {
 	test := testUtils.TestCase{
 		Description: "If filter does not match any document, return empty result",
 		Actions: []any{
@@ -228,8 +228,6 @@ func TestUniqueIndexCreate_IfNilFieldsArePresent_ReturnError(t *testing.T) {
 				CollectionID: 0,
 				FieldName:    "age",
 				Unique:       true,
-				ExpectedError: db.NewErrCanNotIndexNonUniqueFields(
-					"bae-caba9876-89aa-5bcf-bc1c-387a52499b27", errors.NewKV("age", nil)).Error(),
 			},
 		},
 	}
@@ -262,7 +260,7 @@ func TestUniqueIndexCreate_AddingDocWithNilValue_ShouldSucceed(t *testing.T) {
 	testUtils.ExecuteTestCase(t, test)
 }
 
-func TestUniqueIndexCreate_UponAddingDocWithExistingNilValue_ReturnError(t *testing.T) {
+func TestUniqueIndexCreate_UponAddingDocWithExistingNilValue_ShouldSucceed(t *testing.T) {
 	test := testUtils.TestCase{
 		Description: "If filter does not match any document, return empty result",
 		Actions: []any{
@@ -295,8 +293,6 @@ func TestUniqueIndexCreate_UponAddingDocWithExistingNilValue_ReturnError(t *test
 					{
 						"name":	"Andy"
 					}`,
-				ExpectedError: db.NewErrCanNotIndexNonUniqueFields(
-					"bae-2159860f-3cd1-59de-9440-71331e77cbb8", errors.NewKV("age", nil)).Error(),
 			},
 		},
 	}

--- a/tests/integration/index/create_unique_test.go
+++ b/tests/integration/index/create_unique_test.go
@@ -226,8 +226,25 @@ func TestUniqueIndexCreate_WithMultipleNilFields_ShouldSucceed(t *testing.T) {
 			},
 			testUtils.CreateIndex{
 				CollectionID: 0,
+				IndexName:    "age_unique_index",
 				FieldName:    "age",
 				Unique:       true,
+			},
+			testUtils.GetIndexes{
+				CollectionID: 0,
+				ExpectedIndexes: []client.IndexDescription{
+					{
+						Name:   "age_unique_index",
+						ID:     1,
+						Unique: true,
+						Fields: []client.IndexedFieldDescription{
+							{
+								Name:      "age",
+								Direction: client.Ascending,
+							},
+						},
+					},
+				},
 			},
 		},
 	}

--- a/tests/integration/index/query_with_composite_index_only_filter_test.go
+++ b/tests/integration/index/query_with_composite_index_only_filter_test.go
@@ -57,7 +57,7 @@ func TestQueryWithCompositeIndex_WithEqualFilter_ShouldFetch(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req1),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(1).WithIndexFetches(1),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(0).WithIndexFetches(1),
 			},
 			testUtils.Request{
 				Request: req2,
@@ -67,7 +67,7 @@ func TestQueryWithCompositeIndex_WithEqualFilter_ShouldFetch(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req2),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(1).WithIndexFetches(1),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(0).WithIndexFetches(1),
 			},
 			testUtils.Request{
 				Request: req3,
@@ -107,7 +107,7 @@ func TestQueryWithCompositeIndex_WithGreaterThanFilterOnFirstField_ShouldFetch(t
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(1).WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(0).WithIndexFetches(10),
 			},
 		},
 	}
@@ -143,7 +143,7 @@ func TestQueryWithCompositeIndex_WithGreaterThanFilterOnSecondField_ShouldFetch(
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(1).WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(0).WithIndexFetches(10),
 			},
 		},
 	}
@@ -180,7 +180,7 @@ func TestQueryWithCompositeIndex_WithGreaterOrEqualFilterOnFirstField_ShouldFetc
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(2).WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(0).WithIndexFetches(10),
 			},
 		},
 	}
@@ -217,7 +217,7 @@ func TestQueryWithCompositeIndex_WithGreaterOrEqualFilterOnSecondField_ShouldFet
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(2).WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(0).WithIndexFetches(10),
 			},
 		},
 	}
@@ -253,7 +253,7 @@ func TestQueryWithCompositeIndex_WithLessThanFilterOnFirstField_ShouldFetch(t *t
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(1).WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(0).WithIndexFetches(10),
 			},
 		},
 	}
@@ -289,7 +289,7 @@ func TestQueryWithCompositeIndex_WithLessThanFilterOnSecondField_ShouldFetch(t *
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(1).WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(0).WithIndexFetches(10),
 			},
 		},
 	}
@@ -326,7 +326,7 @@ func TestQueryWithCompositeIndex_WithLessOrEqualFilterOnFirstField_ShouldFetch(t
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(2).WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(0).WithIndexFetches(10),
 			},
 		},
 	}
@@ -363,7 +363,7 @@ func TestQueryWithCompositeIndex_WithLessOrEqualFilterOnSecondField_ShouldFetch(
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(2).WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(0).WithIndexFetches(10),
 			},
 		},
 	}
@@ -406,7 +406,7 @@ func TestQueryWithCompositeIndex_WithNotEqualFilter_ShouldFetch(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(8).WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(0).WithIndexFetches(10),
 			},
 		},
 	}
@@ -443,7 +443,7 @@ func TestQueryWithCompositeIndex_WithInFilter_ShouldFetch(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(2).WithIndexFetches(3),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(0).WithIndexFetches(3),
 			},
 		},
 	}
@@ -481,7 +481,7 @@ func TestQueryWithCompositeIndex_WithNotInFilter_ShouldFetch(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(3).WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(0).WithIndexFetches(10),
 			},
 		},
 	}
@@ -546,7 +546,7 @@ func TestQueryWithCompositeIndex_WithLikeFilter_ShouldFetch(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req1),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(1).WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(0).WithIndexFetches(10),
 			},
 			testUtils.Request{
 				Request: req2,
@@ -556,7 +556,7 @@ func TestQueryWithCompositeIndex_WithLikeFilter_ShouldFetch(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req2),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(1).WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(0).WithIndexFetches(10),
 			},
 			testUtils.Request{
 				Request: req3,
@@ -566,7 +566,7 @@ func TestQueryWithCompositeIndex_WithLikeFilter_ShouldFetch(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req3),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(1).WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(0).WithIndexFetches(10),
 			},
 			testUtils.Request{
 				Request: req4,
@@ -576,7 +576,7 @@ func TestQueryWithCompositeIndex_WithLikeFilter_ShouldFetch(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req4),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(1).WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(0).WithIndexFetches(10),
 			},
 			testUtils.Request{
 				Request: req5,
@@ -586,7 +586,7 @@ func TestQueryWithCompositeIndex_WithLikeFilter_ShouldFetch(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req5),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(1).WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(0).WithIndexFetches(10),
 			},
 			testUtils.Request{
 				Request: req6,
@@ -632,7 +632,7 @@ func TestQueryWithCompositeIndex_WithNotLikeFilter_ShouldFetch(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(4).WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(0).WithIndexFetches(10),
 			},
 		},
 	}
@@ -820,6 +820,126 @@ func TestQueryWithCompositeIndex_IfMiddleFieldIsNotInFilter_ShouldIgnoreValue(t 
 						"name": "Alan",
 					},
 				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestQueryWithCompositeIndex_IfConsecutiveEqOps_ShouldUseAllToOptimizeQuery(t *testing.T) {
+	reqWithName := `query {
+			User(filter: {name: {_eq: "Bob"}}) {
+				about
+			}
+		}`
+	reqWithNameAge := `query {
+			User(filter: {name: {_eq: "Bob"}, age: {_eq: 22}}) {
+				about
+			}
+		}`
+	reqWithNameAgeNumChildren := `query {
+			User(filter: {name: {_eq: "Bob"}, age: {_eq: 22}, numChildren: {_eq: 2}}) {
+				about
+			}
+		}`
+	test := testUtils.TestCase{
+		Description: "Test index filtering with _eq filter on nil value on second field",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type User @index(fields: ["name", "age", "numChildren"]) {
+						name: String
+						age: Int
+						numChildren: Int
+						about: String
+					}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `
+					{
+						"name":	"Bob",
+						"age":	22,
+						"numChildren": 2,
+						"about": "bob1"
+					}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `
+					{
+						"name":	"Bob",
+						"age":	22,
+						"numChildren": 2,
+						"about": "bob2"
+					}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `
+					{
+						"name":	"Bob",
+						"age":	22,
+						"numChildren": 0,
+						"about": "bob3"
+					}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `
+					{
+						"name":	"Bob",
+						"age":	44,
+						"numChildren": 2,
+						"about": "bob4"
+					}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `
+					{
+						"name":	"Alice",
+						"age":	22,
+						"numChildren": 2,
+						"about": "alice"
+					}`,
+			},
+			testUtils.Request{
+				Request: reqWithName,
+				Results: []map[string]any{
+					{"about": "bob3"},
+					{"about": "bob1"},
+					{"about": "bob2"},
+					{"about": "bob4"},
+				},
+			},
+			testUtils.Request{
+				Request:  makeExplainQuery(reqWithName),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(4).WithIndexFetches(4),
+			},
+			testUtils.Request{
+				Request: reqWithNameAge,
+				Results: []map[string]any{
+					{"about": "bob3"},
+					{"about": "bob1"},
+					{"about": "bob2"},
+				},
+			},
+			testUtils.Request{
+				Request:  makeExplainQuery(reqWithNameAge),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(3).WithIndexFetches(3),
+			},
+			testUtils.Request{
+				Request: reqWithNameAgeNumChildren,
+				Results: []map[string]any{
+					{"about": "bob1"},
+					{"about": "bob2"},
+				},
+			},
+			testUtils.Request{
+				Request:  makeExplainQuery(reqWithNameAgeNumChildren),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(2).WithIndexFetches(2),
 			},
 		},
 	}

--- a/tests/integration/index/query_with_index_combined_filter_test.go
+++ b/tests/integration/index/query_with_index_combined_filter_test.go
@@ -46,7 +46,7 @@ func TestQueryWithIndex_IfIndexFilterWithRegular_ShouldFilter(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(6).WithIndexFetches(3),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(3).WithIndexFetches(3),
 			},
 		},
 	}
@@ -86,7 +86,7 @@ func TestQueryWithIndex_IfMultipleIndexFiltersWithRegular_ShouldFilter(t *testin
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(18),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(12),
 			},
 		},
 	}

--- a/tests/integration/index/query_with_index_only_filter_test.go
+++ b/tests/integration/index/query_with_index_only_filter_test.go
@@ -45,7 +45,7 @@ func TestQueryWithIndex_WithNonIndexedFields_ShouldFetchAllOfThem(t *testing.T) 
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(2).WithIndexFetches(1),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(1).WithIndexFetches(1),
 			},
 		},
 	}
@@ -79,7 +79,7 @@ func TestQueryWithIndex_WithEqualFilter_ShouldFetch(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(1).WithIndexFetches(1),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(0).WithIndexFetches(1),
 			},
 		},
 	}
@@ -122,7 +122,7 @@ func TestQueryWithIndex_IfSeveralDocsWithEqFilter_ShouldFetchAll(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(4).WithIndexFetches(2),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(2).WithIndexFetches(2),
 			},
 		},
 	}
@@ -157,7 +157,7 @@ func TestQueryWithIndex_WithGreaterThanFilter_ShouldFetch(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(2).WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(1).WithIndexFetches(10),
 			},
 		},
 	}
@@ -193,7 +193,7 @@ func TestQueryWithIndex_WithGreaterOrEqualFilter_ShouldFetch(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(4).WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(2).WithIndexFetches(10),
 			},
 		},
 	}
@@ -228,7 +228,7 @@ func TestQueryWithIndex_WithLessThanFilter_ShouldFetch(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(2).WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(1).WithIndexFetches(10),
 			},
 		},
 	}
@@ -264,7 +264,7 @@ func TestQueryWithIndex_WithLessOrEqualFilter_ShouldFetch(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(4).WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(2).WithIndexFetches(10),
 			},
 		},
 	}
@@ -307,7 +307,7 @@ func TestQueryWithIndex_WithNotEqualFilter_ShouldFetch(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(9).WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(0).WithIndexFetches(10),
 			},
 		},
 	}
@@ -343,7 +343,7 @@ func TestQueryWithIndex_WithInFilter_ShouldFetch(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(4).WithIndexFetches(2),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(2).WithIndexFetches(2),
 			},
 		},
 	}
@@ -386,7 +386,7 @@ func TestQueryWithIndex_IfSeveralDocsWithInFilter_ShouldFetchAll(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(4).WithIndexFetches(2),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(2).WithIndexFetches(2),
 			},
 		},
 	}
@@ -424,7 +424,7 @@ func TestQueryWithIndex_WithNotInFilter_ShouldFetch(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(8).WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(4).WithIndexFetches(10),
 			},
 		},
 	}
@@ -485,7 +485,7 @@ func TestQueryWithIndex_WithLikeFilter_ShouldFetch(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req1),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(4).WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(2).WithIndexFetches(10),
 			},
 			testUtils.Request{
 				Request: req2,
@@ -496,7 +496,7 @@ func TestQueryWithIndex_WithLikeFilter_ShouldFetch(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req2),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(4).WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(2).WithIndexFetches(10),
 			},
 			testUtils.Request{
 				Request: req3,
@@ -507,7 +507,7 @@ func TestQueryWithIndex_WithLikeFilter_ShouldFetch(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req3),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(4).WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(2).WithIndexFetches(10),
 			},
 			testUtils.Request{
 				Request: req4,
@@ -517,7 +517,7 @@ func TestQueryWithIndex_WithLikeFilter_ShouldFetch(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req4),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(2).WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(1).WithIndexFetches(10),
 			},
 			testUtils.Request{
 				Request: req5,
@@ -528,7 +528,7 @@ func TestQueryWithIndex_WithLikeFilter_ShouldFetch(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req5),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(4).WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(2).WithIndexFetches(10),
 			},
 			testUtils.Request{
 				Request: req6,
@@ -577,7 +577,7 @@ func TestQueryWithIndex_WithNotLikeFilter_ShouldFetch(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(7).WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(0).WithIndexFetches(10),
 			},
 		},
 	}

--- a/tests/integration/index/query_with_relation_filter_test.go
+++ b/tests/integration/index/query_with_relation_filter_test.go
@@ -60,7 +60,7 @@ func TestQueryWithIndexOnOneToManyRelation_IfFilterOnIndexedRelation_ShouldFilte
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req1),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(9).WithIndexFetches(3),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(6).WithIndexFetches(3),
 			},
 			testUtils.Request{
 				Request: req2,
@@ -70,7 +70,7 @@ func TestQueryWithIndexOnOneToManyRelation_IfFilterOnIndexedRelation_ShouldFilte
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req2),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(3).WithIndexFetches(1),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(2).WithIndexFetches(1),
 			},
 		},
 	}
@@ -122,7 +122,7 @@ func TestQueryWithIndexOnOneToManyRelation_IfFilterOnIndexedRelation_ShouldFilte
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req1),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(9).WithIndexFetches(3),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(6).WithIndexFetches(3),
 			},
 			testUtils.Request{
 				Request: req2,
@@ -132,7 +132,7 @@ func TestQueryWithIndexOnOneToManyRelation_IfFilterOnIndexedRelation_ShouldFilte
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req2),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(3).WithIndexFetches(1),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(2).WithIndexFetches(1),
 			},
 		},
 	}
@@ -182,7 +182,7 @@ func TestQueryWithIndexOnOneToOnesSecondaryRelation_IfFilterOnIndexedRelation_Sh
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req1),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(3).WithIndexFetches(1),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(2).WithIndexFetches(1),
 			},
 			testUtils.Request{
 				Request: req2,
@@ -194,7 +194,7 @@ func TestQueryWithIndexOnOneToOnesSecondaryRelation_IfFilterOnIndexedRelation_Sh
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req2),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(9).WithIndexFetches(3),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(6).WithIndexFetches(3),
 			},
 		},
 	}
@@ -245,7 +245,7 @@ func TestQueryWithIndexOnOneToOnePrimaryRelation_IfFilterOnIndexedFieldOfRelatio
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req1),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(12).WithIndexFetches(1),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(11).WithIndexFetches(1),
 			},
 			testUtils.Request{
 				Request: req2,
@@ -257,7 +257,7 @@ func TestQueryWithIndexOnOneToOnePrimaryRelation_IfFilterOnIndexedFieldOfRelatio
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req2),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(18).WithIndexFetches(3),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(15).WithIndexFetches(3),
 			},
 		},
 	}
@@ -301,7 +301,7 @@ func TestQueryWithIndexOnOneToOnePrimaryRelation_IfFilterOnIndexedRelationWhileI
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(12).WithIndexFetches(1),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(11).WithIndexFetches(1),
 			},
 		},
 	}
@@ -368,7 +368,7 @@ func TestQueryWithIndexOnOneToTwoRelation_IfFilterOnIndexedRelation_ShouldFilter
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req1),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(3).WithIndexFetches(1),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(2).WithIndexFetches(1),
 			},
 			testUtils.Request{
 				Request: req2,
@@ -383,7 +383,7 @@ func TestQueryWithIndexOnOneToTwoRelation_IfFilterOnIndexedRelation_ShouldFilter
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req2),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(3).WithIndexFetches(1),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(2).WithIndexFetches(1),
 			},
 		},
 	}

--- a/tests/integration/index/query_with_unique_composite_index_filter_test.go
+++ b/tests/integration/index/query_with_unique_composite_index_filter_test.go
@@ -75,7 +75,7 @@ func TestQueryWithUniqueCompositeIndex_WithEqualFilter_ShouldFetch(t *testing.T)
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req1),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(3).WithIndexFetches(3),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(0).WithIndexFetches(3),
 			},
 			testUtils.Request{
 				Request: req2,
@@ -85,7 +85,7 @@ func TestQueryWithUniqueCompositeIndex_WithEqualFilter_ShouldFetch(t *testing.T)
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req2),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(1).WithIndexFetches(1),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(0).WithIndexFetches(1),
 			},
 			testUtils.Request{
 				Request: req3,
@@ -125,7 +125,7 @@ func TestQueryWithUniqueCompositeIndex_WithGreaterThanFilterOnFirstField_ShouldF
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(1).WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(0).WithIndexFetches(10),
 			},
 		},
 	}
@@ -161,7 +161,7 @@ func TestQueryWithUniqueCompositeIndex_WithGreaterThanFilterOnSecondField_Should
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(1).WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(0).WithIndexFetches(10),
 			},
 		},
 	}
@@ -198,7 +198,7 @@ func TestQueryWithUniqueCompositeIndex_WithGreaterOrEqualFilterOnFirstField_Shou
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(2).WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(0).WithIndexFetches(10),
 			},
 		},
 	}
@@ -235,7 +235,7 @@ func TestQueryWithUniqueCompositeIndex_WithGreaterOrEqualFilterOnSecondField_Sho
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(2).WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(0).WithIndexFetches(10),
 			},
 		},
 	}
@@ -271,7 +271,7 @@ func TestQueryWithUniqueCompositeIndex_WithLessThanFilterOnFirstField_ShouldFetc
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(1).WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(0).WithIndexFetches(10),
 			},
 		},
 	}
@@ -307,7 +307,7 @@ func TestQueryWithUniqueCompositeIndex_WithLessThanFilterOnSecondField_ShouldFet
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(1).WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(0).WithIndexFetches(10),
 			},
 		},
 	}
@@ -344,7 +344,7 @@ func TestQueryWithUniqueCompositeIndex_WithLessOrEqualFilterOnFirstField_ShouldF
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(2).WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(0).WithIndexFetches(10),
 			},
 		},
 	}
@@ -381,7 +381,7 @@ func TestQueryWithUniqueCompositeIndex_WithLessOrEqualFilterOnSecondField_Should
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(2).WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(0).WithIndexFetches(10),
 			},
 		},
 	}
@@ -424,7 +424,7 @@ func TestQueryWithUniqueCompositeIndex_WithNotEqualFilter_ShouldFetch(t *testing
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(8).WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(0).WithIndexFetches(10),
 			},
 		},
 	}
@@ -499,7 +499,7 @@ func TestQueryWithUniqueCompositeIndex_WithInForFirstAndEqForRest_ShouldFetchEff
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(2).WithIndexFetches(2),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(0).WithIndexFetches(2),
 			},
 		},
 	}
@@ -552,7 +552,7 @@ func TestQueryWithUniqueCompositeIndex_WithInFilter_ShouldFetch(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(2).WithIndexFetches(5),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(0).WithIndexFetches(5),
 			},
 		},
 	}
@@ -590,7 +590,7 @@ func TestQueryWithUniqueCompositeIndex_WithNotInFilter_ShouldFetch(t *testing.T)
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(3).WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(0).WithIndexFetches(10),
 			},
 		},
 	}
@@ -655,7 +655,7 @@ func TestQueryWithUniqueCompositeIndex_WithLikeFilter_ShouldFetch(t *testing.T) 
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req1),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(1).WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(0).WithIndexFetches(10),
 			},
 			testUtils.Request{
 				Request: req2,
@@ -665,7 +665,7 @@ func TestQueryWithUniqueCompositeIndex_WithLikeFilter_ShouldFetch(t *testing.T) 
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req2),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(1).WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(0).WithIndexFetches(10),
 			},
 			testUtils.Request{
 				Request: req3,
@@ -675,7 +675,7 @@ func TestQueryWithUniqueCompositeIndex_WithLikeFilter_ShouldFetch(t *testing.T) 
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req3),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(1).WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(0).WithIndexFetches(10),
 			},
 			testUtils.Request{
 				Request: req4,
@@ -685,7 +685,7 @@ func TestQueryWithUniqueCompositeIndex_WithLikeFilter_ShouldFetch(t *testing.T) 
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req4),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(1).WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(0).WithIndexFetches(10),
 			},
 			testUtils.Request{
 				Request: req5,
@@ -695,7 +695,7 @@ func TestQueryWithUniqueCompositeIndex_WithLikeFilter_ShouldFetch(t *testing.T) 
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req5),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(1).WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(0).WithIndexFetches(10),
 			},
 			testUtils.Request{
 				Request: req6,
@@ -741,7 +741,7 @@ func TestQueryWithUniqueCompositeIndex_WithNotLikeFilter_ShouldFetch(t *testing.
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(4).WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(0).WithIndexFetches(10),
 			},
 		},
 	}
@@ -823,6 +823,67 @@ func TestQueryWithUniqueCompositeIndex_WithEqualFilterOnNilValueOnFirst_ShouldFe
 	testUtils.ExecuteTestCase(t, test)
 }
 
+func TestQueryWithUniqueCompositeIndex_WithMultipleNilOnFirstFieldAndNilFilter_ShouldFetchAll(t *testing.T) {
+	req := `query {
+			User(filter: {name: {_eq: null}}) {
+				name
+				age
+				email
+			}
+		}`
+	test := testUtils.TestCase{
+		Description: "Test index filtering with _eq filter on nil value on first field with multiple matches",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type User @index(unique: true, fields: ["name", "age"]) {
+						name: String
+						age: Int
+						email: String
+					}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `
+					{
+						"name":	"Alice",
+						"age":	22,
+						"email": "alice@gmail.com"
+					}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `
+					{
+						"age":	32,
+						"email": "bob@gmail.com"
+					}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `
+					{
+						"age":	32,
+						"email": "cate@gmail.com"
+					}`,
+			},
+			testUtils.Request{
+				Request: req,
+				Results: []map[string]any{
+					{"name": nil, "age": 32, "email": "bob@gmail.com"},
+					{"name": nil, "age": 32, "email": "cate@gmail.com"},
+				},
+			},
+			testUtils.Request{
+				Request:  makeExplainQuery(req),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(2).WithIndexFetches(2),
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
 func TestQueryWithUniqueCompositeIndex_WithEqualFilterOnNilValueOnSecond_ShouldFetch(t *testing.T) {
 	test := testUtils.TestCase{
 		Description: "Test index filtering with _eq filter on nil value on second field",
@@ -870,6 +931,171 @@ func TestQueryWithUniqueCompositeIndex_WithEqualFilterOnNilValueOnSecond_ShouldF
 						"name": "Alice",
 						"age":  nil,
 					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestQueryWithUniqueCompositeIndex_WithMultipleNilOnSecondFieldsAndNilFilter_ShouldFetchAll(t *testing.T) {
+	req := `query {
+			User(filter: {name: {_eq: "Bob"}, age: {_eq: null}}) {
+				name
+				age
+				email
+			}
+		}`
+	test := testUtils.TestCase{
+		Description: "Test index filtering with _eq filter on nil value on second field",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type User @index(unique: true, fields: ["name", "age"]) {
+						name: String
+						age: Int
+						email: String
+					}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `
+					{
+						"name":	"Bob",
+						"age":	22,
+						"email": "bob_age_22@gmail.com"
+					}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `
+					{
+						"name":	"Bob",
+						"age":	44,
+						"email": "bob_age_44@gmail.com"
+					}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `
+					{
+						"name":	"Bob",
+						"email": "bob1@gmail.com"
+					}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `
+					{
+						"name":	"Bob",
+						"email": "bob2@gmail.com"
+					}`,
+			},
+			testUtils.Request{
+				Request: req,
+				Results: []map[string]any{
+					{"name": "Bob", "age": nil, "email": "bob2@gmail.com"},
+					{"name": "Bob", "age": nil, "email": "bob1@gmail.com"},
+				},
+			},
+			testUtils.Request{
+				Request:  makeExplainQuery(req),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(2).WithIndexFetches(2),
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestQueryWithUniqueCompositeIndex_WithMultipleNilOnBothFieldsAndNilFilter_ShouldFetchAll(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "Test index filtering with _eq filter on nil value on second field",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type User @index(unique: true, fields: ["name", "age"]) {
+						name: String
+						age: Int
+						about: String
+					}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `
+					{
+						"name":	"Bob",
+						"age":	22,
+						"about": "bob_22"
+					}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `
+					{
+						"name":	"Bob",
+						"about": "bob_nil"
+					}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `
+					{
+						"age":	22,
+						"about": "nil_22"
+					}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `
+					{
+						"about": "nil_nil_1"
+					}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `
+					{
+						"about": "nil_nil_2"
+					}`,
+			},
+			testUtils.Request{
+				Request: `
+					query {
+						User(filter: {name: {_eq: null}, age: {_eq: null}}) {
+							about
+						}
+					}`,
+				Results: []map[string]any{
+					{"about": "nil_nil_2"},
+					{"about": "nil_nil_1"},
+				},
+			},
+			testUtils.Request{
+				Request: `
+					query {
+						User(filter: {name: {_eq: null}}) {
+							about
+						}
+					}`,
+				Results: []map[string]any{
+					{"about": "nil_22"},
+					{"about": "nil_nil_2"},
+					{"about": "nil_nil_1"},
+				},
+			},
+			testUtils.Request{
+				Request: `
+					query {
+						User(filter: {age: {_eq: null}}) {
+							about
+						}
+					}`,
+				Results: []map[string]any{
+					{"about": "nil_nil_2"},
+					{"about": "bob_nil"},
+					{"about": "nil_nil_1"},
 				},
 			},
 		},

--- a/tests/integration/index/query_with_unique_composite_index_filter_test.go
+++ b/tests/integration/index/query_with_unique_composite_index_filter_test.go
@@ -893,7 +893,7 @@ func TestQueryWithUniqueCompositeIndex_WithEqualFilterOnNilValueOnSecond_ShouldF
 					type User @index(unique: true, fields: ["name", "age"]) {
 						name: String
 						age: Int
-						email: String
+						about: String
 					}`,
 			},
 			testUtils.CreateDoc{
@@ -901,35 +901,38 @@ func TestQueryWithUniqueCompositeIndex_WithEqualFilterOnNilValueOnSecond_ShouldF
 				Doc: `
 					{
 						"name":	"Alice",
-						"age":	22
+						"age":	22,
+						"about": "alice_22"
 					}`,
 			},
 			testUtils.CreateDoc{
 				CollectionID: 0,
 				Doc: `
 					{
-						"name":	"Bob"
+						"name":	"Bob",
+						"about": "bob_nil"
 					}`,
 			},
 			testUtils.CreateDoc{
 				CollectionID: 0,
 				Doc: `
 					{
-						"name":	"Alice"
+						"name":	"Alice",
+						"about": "alice_nil"
 					}`,
 			},
 			testUtils.Request{
 				Request: `
 					query {
 						User(filter: {name: {_eq: "Alice"}, age: {_eq: null}}) {
-							name
 							age
+							about
 						}
 					}`,
 				Results: []map[string]any{
 					{
-						"name": "Alice",
-						"age":  nil,
+						"age":   nil,
+						"about": "alice_nil",
 					},
 				},
 			},

--- a/tests/integration/index/query_with_unique_index_only_filter_test.go
+++ b/tests/integration/index/query_with_unique_index_only_filter_test.go
@@ -42,7 +42,7 @@ func TestQueryWithUniqueIndex_WithEqualFilter_ShouldFetch(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(1).WithIndexFetches(1),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(0).WithIndexFetches(1),
 			},
 		},
 	}
@@ -77,7 +77,7 @@ func TestQueryWithUniqueIndex_WithGreaterThanFilter_ShouldFetch(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(2).WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(1).WithIndexFetches(10),
 			},
 		},
 	}
@@ -113,7 +113,7 @@ func TestQueryWithUniqueIndex_WithGreaterOrEqualFilter_ShouldFetch(t *testing.T)
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(4).WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(2).WithIndexFetches(10),
 			},
 		},
 	}
@@ -148,7 +148,7 @@ func TestQueryWithUniqueIndex_WithLessThanFilter_ShouldFetch(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(2).WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(1).WithIndexFetches(10),
 			},
 		},
 	}
@@ -184,7 +184,7 @@ func TestQueryWithUniqueIndex_WithLessOrEqualFilter_ShouldFetch(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(4).WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(2).WithIndexFetches(10),
 			},
 		},
 	}
@@ -227,7 +227,7 @@ func TestQueryWithUniqueIndex_WithNotEqualFilter_ShouldFetch(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(9).WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(0).WithIndexFetches(10),
 			},
 		},
 	}
@@ -263,7 +263,7 @@ func TestQueryWithUniqueIndex_WithInFilter_ShouldFetch(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(4).WithIndexFetches(2),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(2).WithIndexFetches(2),
 			},
 		},
 	}
@@ -301,7 +301,7 @@ func TestQueryWithUniqueIndex_WithNotInFilter_ShouldFetch(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(8).WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(4).WithIndexFetches(10),
 			},
 		},
 	}
@@ -362,7 +362,7 @@ func TestQueryWithUniqueIndex_WithLikeFilter_ShouldFetch(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req1),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(4).WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(2).WithIndexFetches(10),
 			},
 			testUtils.Request{
 				Request: req2,
@@ -373,7 +373,7 @@ func TestQueryWithUniqueIndex_WithLikeFilter_ShouldFetch(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req2),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(4).WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(2).WithIndexFetches(10),
 			},
 			testUtils.Request{
 				Request: req3,
@@ -384,7 +384,7 @@ func TestQueryWithUniqueIndex_WithLikeFilter_ShouldFetch(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req3),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(4).WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(2).WithIndexFetches(10),
 			},
 			testUtils.Request{
 				Request: req4,
@@ -394,7 +394,7 @@ func TestQueryWithUniqueIndex_WithLikeFilter_ShouldFetch(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req4),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(2).WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(1).WithIndexFetches(10),
 			},
 			testUtils.Request{
 				Request: req5,
@@ -405,7 +405,7 @@ func TestQueryWithUniqueIndex_WithLikeFilter_ShouldFetch(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req5),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(4).WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(2).WithIndexFetches(10),
 			},
 			testUtils.Request{
 				Request: req6,
@@ -454,7 +454,7 @@ func TestQueryWithUniqueIndex_WithNotLikeFilter_ShouldFetch(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(7).WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(0).WithIndexFetches(10),
 			},
 		},
 	}
@@ -524,6 +524,57 @@ func TestQueryWithUniqueIndex_WithEqualFilterOnNilValue_ShouldFetch(t *testing.T
 						}
 					}`,
 				Results: []map[string]any{
+					{"name": "Alice"},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestQueryWithUniqueIndex_WithMultipleNilValuesAndEqualFilter_ShouldFetch(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "Test index filtering with _eq filter on nil value",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type User {
+						name: String 
+						age: Int @index(unique: true)
+					}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `
+					{
+						"name":	"John",
+						"age":	44
+					}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `
+					{
+						"name":	"Alice"
+					}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `
+					{
+						"name":	"Bob"
+					}`,
+			},
+			testUtils.Request{
+				Request: `
+					query {
+						User(filter: {age: {_eq: null}}) {
+							name
+						}
+					}`,
+				Results: []map[string]any{
+					{"name": "Bob"},
 					{"name": "Alice"},
 				},
 			},


### PR DESCRIPTION
## Relevant issue(s)

Resolves #2180

## Description

Allow multiple docs with nil value on unique-indexed field.
This change also included few minor query optimizations that involve secondary indexes.

Explain request is slightly adjusted not to increase field fetches count upon fetching indexes.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Unit and integration tests.

Specify the platform(s) on which this was tested:
- MacOS