### PR TITLE
fix: Mark docs as deleted when querying in delete mut

### DIFF
--- a/planner/delete.go
+++ b/planner/delete.go
@@ -57,6 +57,10 @@ func (n *deleteNode) Next() (bool, error) {
 	if err != nil {
 		return false, err
 	}
+
+	n.currentValue.Status = client.Deleted
+	n.documentMapping.TrySetFirstOfName(&n.currentValue, request.DeletedFieldName, true)
+
 	return true, nil
 }
 

--- a/tests/integration/mutation/delete/with_deleted_field_test.go
+++ b/tests/integration/mutation/delete/with_deleted_field_test.go
@@ -16,8 +16,6 @@ import (
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
 )
 
-// This test documents a bug, see:
-// https://github.com/sourcenetwork/defradb/issues/1846
 func TestMutationDeletion_WithDeletedField(t *testing.T) {
 	test := testUtils.TestCase{
 		Actions: []any{
@@ -43,8 +41,7 @@ func TestMutationDeletion_WithDeletedField(t *testing.T) {
 					}`,
 				Results: []map[string]any{
 					{
-						// This should be true, as it has been deleted.
-						"_deleted": false,
+						"_deleted": true,
 						"_docID":   "bae-decf6467-4c7c-50d7-b09d-0a7097ef6bad",
 					},
 				},


### PR DESCRIPTION
## Relevant issue(s)

Resolves #1846

## Description

Marks docs as deleted when querying _deleted in delete mutation.

We could refetch them like we do in update queries, but that seems unnecessary for deletes (updates needs to watch out for impact on aggregates, relations, etc) 