### PR TITLE
fix: Move field id off of schema

### DIFF
--- a/client/collection.go
+++ b/client/collection.go
@@ -18,14 +18,6 @@ import (
 	"github.com/sourcenetwork/defradb/datastore"
 )
 
-// CollectionDefinition contains the metadata defining what a Collection is.
-type CollectionDefinition struct {
-	// Description returns the CollectionDescription of this Collection.
-	Description CollectionDescription `json:"description"`
-	// Schema returns the SchemaDescription used to define this Collection.
-	Schema SchemaDescription `json:"schema"`
-}
-
 // Collection represents a defradb collection.
 //
 // A Collection is mostly analogous to a SQL table, however a collection is specific to its

--- a/client/definitions.go
+++ b/client/definitions.go
@@ -109,32 +109,7 @@ func NewFieldDefinition(local CollectionFieldDescription, global SchemaFieldDesc
 	}
 }
 
-// IsObject returns true if this field is an object type.
-func (f FieldDefinition) IsObject() bool {
-	return (f.Kind == FieldKind_FOREIGN_OBJECT) ||
-		(f.Kind == FieldKind_FOREIGN_OBJECT_ARRAY)
-}
-
-// IsObjectArray returns true if this field is an object array type.
-func (f FieldDefinition) IsObjectArray() bool {
-	return (f.Kind == FieldKind_FOREIGN_OBJECT_ARRAY)
-}
-
 // IsRelation returns true if this field is a relation.
 func (f FieldDefinition) IsRelation() bool {
 	return f.RelationName != ""
-}
-
-// IsArray returns true if this field is an array type which includes inline arrays as well
-// as relation arrays.
-func (f FieldDefinition) IsArray() bool {
-	return f.Kind == FieldKind_BOOL_ARRAY ||
-		f.Kind == FieldKind_INT_ARRAY ||
-		f.Kind == FieldKind_FLOAT_ARRAY ||
-		f.Kind == FieldKind_STRING_ARRAY ||
-		f.Kind == FieldKind_FOREIGN_OBJECT_ARRAY ||
-		f.Kind == FieldKind_NILLABLE_BOOL_ARRAY ||
-		f.Kind == FieldKind_NILLABLE_INT_ARRAY ||
-		f.Kind == FieldKind_NILLABLE_FLOAT_ARRAY ||
-		f.Kind == FieldKind_NILLABLE_STRING_ARRAY
 }

--- a/client/definitions.go
+++ b/client/definitions.go
@@ -1,0 +1,132 @@
+// Copyright 2024 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package client
+
+// CollectionDefinition contains the metadata defining what a Collection is.
+type CollectionDefinition struct {
+	// Description returns the CollectionDescription of this Collection.
+	Description CollectionDescription `json:"description"`
+	// Schema returns the SchemaDescription used to define this Collection.
+	Schema SchemaDescription `json:"schema"`
+}
+
+// GetFieldByName returns the field for the given field name. If such a field is found it
+// will return it and true, if it is not found it will return false.
+func (def CollectionDefinition) GetFieldByName(fieldName string) (FieldDefinition, bool) {
+	collectionField, ok := def.Description.GetFieldByName(fieldName)
+	if ok {
+		schemaField, ok := def.Schema.GetFieldByName(fieldName)
+		if ok {
+			return NewFieldDefinition(
+				collectionField,
+				schemaField,
+			), true
+		}
+	}
+	return FieldDefinition{}, false
+}
+
+// GetFields returns the combined local and global field elements on this [CollectionDefinition]
+// as a single set.
+func (def CollectionDefinition) GetFields() []FieldDefinition {
+	fields := []FieldDefinition{}
+	for _, localField := range def.Description.Fields {
+		globalField, ok := def.Schema.GetFieldByName(localField.Name)
+		if ok {
+			fields = append(
+				fields,
+				NewFieldDefinition(localField, globalField),
+			)
+		}
+	}
+	return fields
+}
+
+// FieldDefinition describes the combined local and global set of properties that constitutes
+// a field on a collection.
+//
+// It draws it's information from the [CollectionFieldDescription] on the [CollectionDescription],
+// and the [SchemaFieldDescription] on the [SchemaDescription].
+//
+// It is to [CollectionFieldDescription] and [SchemaFieldDescription] what [CollectionDefinition]
+// is to [CollectionDescription] and [SchemaDescription].
+type FieldDefinition struct {
+	// Name contains the name of this field.
+	Name string
+
+	// ID contains the local, internal ID of this field.
+	ID FieldID
+
+	// The data type that this field holds.
+	//
+	// Must contain a valid value. It is currently immutable.
+	Kind FieldKind
+
+	// Schema contains the schema name of the type this field contains if this field is
+	// a relation field.  Otherwise this will be empty.
+	Schema string
+
+	// RelationName the name of the relationship that this field represents if this field is
+	// a relation field.  Otherwise this will be empty.
+	RelationName string
+
+	// The CRDT Type of this field. If no type has been provided it will default to [LWW_REGISTER].
+	//
+	// It is currently immutable.
+	Typ CType
+
+	// If true, this is the primary half of a relation, otherwise is false.
+	IsPrimaryRelation bool
+}
+
+// NewFieldDefinition returns a new [FieldDefinition], combining the given local and global elements
+// into a single object.
+func NewFieldDefinition(local CollectionFieldDescription, global SchemaFieldDescription) FieldDefinition {
+	return FieldDefinition{
+		Name:              global.Name,
+		ID:                local.ID,
+		Kind:              global.Kind,
+		Schema:            global.Schema,
+		RelationName:      global.RelationName,
+		Typ:               global.Typ,
+		IsPrimaryRelation: global.IsPrimaryRelation,
+	}
+}
+
+// IsObject returns true if this field is an object type.
+func (f FieldDefinition) IsObject() bool {
+	return (f.Kind == FieldKind_FOREIGN_OBJECT) ||
+		(f.Kind == FieldKind_FOREIGN_OBJECT_ARRAY)
+}
+
+// IsObjectArray returns true if this field is an object array type.
+func (f FieldDefinition) IsObjectArray() bool {
+	return (f.Kind == FieldKind_FOREIGN_OBJECT_ARRAY)
+}
+
+// IsRelation returns true if this field is a relation.
+func (f FieldDefinition) IsRelation() bool {
+	return f.RelationName != ""
+}
+
+// IsArray returns true if this field is an array type which includes inline arrays as well
+// as relation arrays.
+func (f FieldDefinition) IsArray() bool {
+	return f.Kind == FieldKind_BOOL_ARRAY ||
+		f.Kind == FieldKind_INT_ARRAY ||
+		f.Kind == FieldKind_FLOAT_ARRAY ||
+		f.Kind == FieldKind_STRING_ARRAY ||
+		f.Kind == FieldKind_FOREIGN_OBJECT_ARRAY ||
+		f.Kind == FieldKind_NILLABLE_BOOL_ARRAY ||
+		f.Kind == FieldKind_NILLABLE_INT_ARRAY ||
+		f.Kind == FieldKind_NILLABLE_FLOAT_ARRAY ||
+		f.Kind == FieldKind_NILLABLE_STRING_ARRAY
+}

--- a/client/definitions.go
+++ b/client/definitions.go
@@ -11,6 +11,10 @@
 package client
 
 // CollectionDefinition contains the metadata defining what a Collection is.
+//
+// The definition types ([CollectionDefinition], [FieldDefinition]) are read-only types returned
+// from various functions as a convienient means to access the computated convergence of schema
+// and collection descriptions.
 type CollectionDefinition struct {
 	// Description returns the CollectionDescription of this Collection.
 	Description CollectionDescription `json:"description"`
@@ -58,6 +62,10 @@ func (def CollectionDefinition) GetFields() []FieldDefinition {
 //
 // It is to [CollectionFieldDescription] and [SchemaFieldDescription] what [CollectionDefinition]
 // is to [CollectionDescription] and [SchemaDescription].
+//
+// The definition types ([CollectionDefinition], [FieldDefinition]) are read-only types returned
+// from various functions as a convienient means to access the computated convergence of schema
+// and collection descriptions.
 type FieldDefinition struct {
 	// Name contains the name of this field.
 	Name string

--- a/client/descriptions.go
+++ b/client/descriptions.go
@@ -240,13 +240,13 @@ func (f FieldKind) String() string {
 
 // IsObject returns true if this FieldKind is an object type.
 func (f FieldKind) IsObject() bool {
-	return (f == FieldKind_FOREIGN_OBJECT) ||
-		(f == FieldKind_FOREIGN_OBJECT_ARRAY)
+	return f == FieldKind_FOREIGN_OBJECT ||
+		f == FieldKind_FOREIGN_OBJECT_ARRAY
 }
 
 // IsObjectArray returns true if this FieldKind is an object array type.
 func (f FieldKind) IsObjectArray() bool {
-	return (f == FieldKind_FOREIGN_OBJECT_ARRAY)
+	return f == FieldKind_FOREIGN_OBJECT_ARRAY
 }
 
 // IsArray returns true if this FieldKind is an array type which includes inline arrays as well

--- a/client/descriptions.go
+++ b/client/descriptions.go
@@ -74,22 +74,6 @@ func (col CollectionDescription) IDString() string {
 
 // GetFieldByName returns the field for the given field name. If such a field is found it
 // will return it and true, if it is not found it will return false.
-func (def CollectionDefinition) GetFieldByName(fieldName string) (FieldDefinition, bool) {
-	collectionField, ok := def.Description.GetFieldByName(fieldName)
-	if ok {
-		schemaField, ok := def.Schema.GetFieldByName(fieldName)
-		if ok {
-			return NewFieldDefinition(
-				collectionField,
-				schemaField,
-			), true
-		}
-	}
-	return FieldDefinition{}, false
-}
-
-// GetFieldByName returns the field for the given field name. If such a field is found it
-// will return it and true, if it is not found it will return false.
 func (col CollectionDescription) GetFieldByName(fieldName string) (CollectionFieldDescription, bool) {
 	for _, field := range col.Fields {
 		if field.Name == fieldName {
@@ -108,22 +92,6 @@ func (s SchemaDescription) GetFieldByName(fieldName string) (SchemaFieldDescript
 		}
 	}
 	return SchemaFieldDescription{}, false
-}
-
-// GetFields returns the combined local and global field elements on this [CollectionDefinition]
-// as a single set.
-func (def CollectionDefinition) GetFields() []FieldDefinition {
-	fields := []FieldDefinition{}
-	for _, localField := range def.Description.Fields {
-		globalField, ok := def.Schema.GetFieldByName(localField.Name)
-		if ok {
-			fields = append(
-				fields,
-				NewFieldDefinition(localField, globalField),
-			)
-		}
-	}
-	return fields
 }
 
 // GetFieldByRelation returns the field that supports the relation of the given name.
@@ -373,87 +341,6 @@ type CollectionFieldDescription struct {
 
 	// ID contains the local, internal ID of this field.
 	ID FieldID
-}
-
-// FieldDefinition describes the combined local and global set of properties that constitutes
-// a field on a collection.
-//
-// It draws it's information from the [CollectionFieldDescription] on the [CollectionDescription],
-// and the [SchemaFieldDescription] on the [SchemaDescription].
-//
-// It is to [CollectionFieldDescription] and [SchemaFieldDescription] what [CollectionDefinition]
-// is to [CollectionDescription] and [SchemaDescription].
-type FieldDefinition struct {
-	// Name contains the name of this field.
-	Name string
-
-	// ID contains the local, internal ID of this field.
-	ID FieldID
-
-	// The data type that this field holds.
-	//
-	// Must contain a valid value. It is currently immutable.
-	Kind FieldKind
-
-	// Schema contains the schema name of the type this field contains if this field is
-	// a relation field.  Otherwise this will be empty.
-	Schema string
-
-	// RelationName the name of the relationship that this field represents if this field is
-	// a relation field.  Otherwise this will be empty.
-	RelationName string
-
-	// The CRDT Type of this field. If no type has been provided it will default to [LWW_REGISTER].
-	//
-	// It is currently immutable.
-	Typ CType
-
-	// If true, this is the primary half of a relation, otherwise is false.
-	IsPrimaryRelation bool
-}
-
-// NewFieldDefinition returns a new [FieldDefinition], combining the given local and global elements
-// into a single object.
-func NewFieldDefinition(local CollectionFieldDescription, global SchemaFieldDescription) FieldDefinition {
-	return FieldDefinition{
-		Name:              global.Name,
-		ID:                local.ID,
-		Kind:              global.Kind,
-		Schema:            global.Schema,
-		RelationName:      global.RelationName,
-		Typ:               global.Typ,
-		IsPrimaryRelation: global.IsPrimaryRelation,
-	}
-}
-
-// IsObject returns true if this field is an object type.
-func (f FieldDefinition) IsObject() bool {
-	return (f.Kind == FieldKind_FOREIGN_OBJECT) ||
-		(f.Kind == FieldKind_FOREIGN_OBJECT_ARRAY)
-}
-
-// IsObjectArray returns true if this field is an object array type.
-func (f FieldDefinition) IsObjectArray() bool {
-	return (f.Kind == FieldKind_FOREIGN_OBJECT_ARRAY)
-}
-
-// IsRelation returns true if this field is a relation.
-func (f FieldDefinition) IsRelation() bool {
-	return f.RelationName != ""
-}
-
-// IsArray returns true if this field is an array type which includes inline arrays as well
-// as relation arrays.
-func (f FieldDefinition) IsArray() bool {
-	return f.Kind == FieldKind_BOOL_ARRAY ||
-		f.Kind == FieldKind_INT_ARRAY ||
-		f.Kind == FieldKind_FLOAT_ARRAY ||
-		f.Kind == FieldKind_STRING_ARRAY ||
-		f.Kind == FieldKind_FOREIGN_OBJECT_ARRAY ||
-		f.Kind == FieldKind_NILLABLE_BOOL_ARRAY ||
-		f.Kind == FieldKind_NILLABLE_INT_ARRAY ||
-		f.Kind == FieldKind_NILLABLE_FLOAT_ARRAY ||
-		f.Kind == FieldKind_NILLABLE_STRING_ARRAY
 }
 
 // IsObject returns true if this field is an object type.

--- a/client/descriptions.go
+++ b/client/descriptions.go
@@ -238,6 +238,31 @@ func (f FieldKind) String() string {
 	}
 }
 
+// IsObject returns true if this FieldKind is an object type.
+func (f FieldKind) IsObject() bool {
+	return (f == FieldKind_FOREIGN_OBJECT) ||
+		(f == FieldKind_FOREIGN_OBJECT_ARRAY)
+}
+
+// IsObjectArray returns true if this FieldKind is an object array type.
+func (f FieldKind) IsObjectArray() bool {
+	return (f == FieldKind_FOREIGN_OBJECT_ARRAY)
+}
+
+// IsArray returns true if this FieldKind is an array type which includes inline arrays as well
+// as relation arrays.
+func (f FieldKind) IsArray() bool {
+	return f == FieldKind_BOOL_ARRAY ||
+		f == FieldKind_INT_ARRAY ||
+		f == FieldKind_FLOAT_ARRAY ||
+		f == FieldKind_STRING_ARRAY ||
+		f == FieldKind_FOREIGN_OBJECT_ARRAY ||
+		f == FieldKind_NILLABLE_BOOL_ARRAY ||
+		f == FieldKind_NILLABLE_INT_ARRAY ||
+		f == FieldKind_NILLABLE_FLOAT_ARRAY ||
+		f == FieldKind_NILLABLE_STRING_ARRAY
+}
+
 // Note: These values are serialized and persisted in the database, avoid modifying existing values.
 const (
 	FieldKind_None              FieldKind = 0
@@ -343,34 +368,9 @@ type CollectionFieldDescription struct {
 	ID FieldID
 }
 
-// IsObject returns true if this field is an object type.
-func (f SchemaFieldDescription) IsObject() bool {
-	return (f.Kind == FieldKind_FOREIGN_OBJECT) ||
-		(f.Kind == FieldKind_FOREIGN_OBJECT_ARRAY)
-}
-
-// IsObjectArray returns true if this field is an object array type.
-func (f SchemaFieldDescription) IsObjectArray() bool {
-	return (f.Kind == FieldKind_FOREIGN_OBJECT_ARRAY)
-}
-
 // IsRelation returns true if this field is a relation.
 func (f SchemaFieldDescription) IsRelation() bool {
 	return f.RelationName != ""
-}
-
-// IsArray returns true if this field is an array type which includes inline arrays as well
-// as relation arrays.
-func (f SchemaFieldDescription) IsArray() bool {
-	return f.Kind == FieldKind_BOOL_ARRAY ||
-		f.Kind == FieldKind_INT_ARRAY ||
-		f.Kind == FieldKind_FLOAT_ARRAY ||
-		f.Kind == FieldKind_STRING_ARRAY ||
-		f.Kind == FieldKind_FOREIGN_OBJECT_ARRAY ||
-		f.Kind == FieldKind_NILLABLE_BOOL_ARRAY ||
-		f.Kind == FieldKind_NILLABLE_INT_ARRAY ||
-		f.Kind == FieldKind_NILLABLE_FLOAT_ARRAY ||
-		f.Kind == FieldKind_NILLABLE_STRING_ARRAY
 }
 
 // IsSet returns true if the target relation type is set.

--- a/client/descriptions.go
+++ b/client/descriptions.go
@@ -69,17 +69,6 @@ func (col CollectionDescription) IDString() string {
 	return fmt.Sprint(col.ID)
 }
 
-// GetFieldByID searches for a field with the given ID. If such a field is found it
-// will return it and true, if it is not found it will return false.
-func (col CollectionDescription) GetFieldByID(id FieldID, schema *SchemaDescription) (FieldDescription, bool) {
-	for _, field := range schema.Fields {
-		if field.ID == id {
-			return field, true
-		}
-	}
-	return FieldDescription{}, false
-}
-
 // GetFieldByName returns the field for the given field name. If such a field is found it
 // will return it and true, if it is not found it will return false.
 func (col CollectionDescription) GetFieldByName(fieldName string, schema *SchemaDescription) (FieldDescription, bool) {

--- a/client/document.go
+++ b/client/document.go
@@ -526,7 +526,7 @@ func (doc *Document) Set(field string, value any) error {
 	if !exists {
 		return NewErrFieldNotExist(field)
 	}
-	if fd.IsRelation() && !fd.IsObjectArray() {
+	if fd.IsRelation() && !fd.Kind.IsObjectArray() {
 		if !strings.HasSuffix(field, request.RelatedObjectID) {
 			field = field + request.RelatedObjectID
 		}

--- a/client/document.go
+++ b/client/document.go
@@ -187,7 +187,7 @@ func isNillableKind(kind FieldKind) bool {
 // and ensures it matches the supplied field description.
 // It will do any minor parsing, like dates, and return
 // the typed value again as an interface.
-func validateFieldSchema(val any, field FieldDescription) (any, error) {
+func validateFieldSchema(val any, field SchemaFieldDescription) (any, error) {
 	if isNillableKind(field.Kind) {
 		if val == nil {
 			return nil, nil
@@ -522,7 +522,7 @@ func (doc *Document) setWithFastJSONObject(obj *fastjson.Object) error {
 
 // Set the value of a field.
 func (doc *Document) Set(field string, value any) error {
-	fd, exists := doc.schemaDescription.GetField(field)
+	fd, exists := doc.schemaDescription.GetFieldByName(field)
 	if !exists {
 		return NewErrFieldNotExist(field)
 	}
@@ -530,7 +530,7 @@ func (doc *Document) Set(field string, value any) error {
 		if !strings.HasSuffix(field, request.RelatedObjectID) {
 			field = field + request.RelatedObjectID
 		}
-		fd, exists = doc.schemaDescription.GetField(field)
+		fd, exists = doc.schemaDescription.GetFieldByName(field)
 		if !exists {
 			return NewErrFieldNotExist(field)
 		}

--- a/client/document_test.go
+++ b/client/document_test.go
@@ -30,7 +30,7 @@ var (
 	schemaDescriptions = []SchemaDescription{
 		{
 			Name: "User",
-			Fields: []FieldDescription{
+			Fields: []SchemaFieldDescription{
 				{
 					Name: "Name",
 					Typ:  LWW_REGISTER,

--- a/client/index.go
+++ b/client/index.go
@@ -46,13 +46,14 @@ func (d CollectionDescription) CollectIndexedFields(schema *SchemaDescription) [
 	fields := make([]FieldDescription, 0, len(d.Indexes))
 	for _, index := range d.Indexes {
 		for _, field := range index.Fields {
-			for i := range schema.Fields {
-				colField := schema.Fields[i]
-				if field.Name == colField.Name && !fieldsMap[field.Name] {
-					fieldsMap[field.Name] = true
-					fields = append(fields, colField)
-					break
-				}
+			if fieldsMap[field.Name] {
+				// If the FieldDescription has already been added to the result do not add it a second time
+				// this can happen if a field if referenced by multiple indexes
+				continue
+			}
+			colField, ok := d.GetFieldByName(field.Name, schema)
+			if ok {
+				fields = append(fields, colField)
 			}
 		}
 	}

--- a/client/index.go
+++ b/client/index.go
@@ -41,17 +41,17 @@ type IndexDescription struct {
 }
 
 // CollectIndexedFields returns all fields that are indexed by all collection indexes.
-func (d CollectionDescription) CollectIndexedFields(schema *SchemaDescription) []FieldDescription {
+func (d CollectionDefinition) CollectIndexedFields() []FieldDefinition {
 	fieldsMap := make(map[string]bool)
-	fields := make([]FieldDescription, 0, len(d.Indexes))
-	for _, index := range d.Indexes {
+	fields := make([]FieldDefinition, 0, len(d.Description.Indexes))
+	for _, index := range d.Description.Indexes {
 		for _, field := range index.Fields {
 			if fieldsMap[field.Name] {
 				// If the FieldDescription has already been added to the result do not add it a second time
 				// this can happen if a field if referenced by multiple indexes
 				continue
 			}
-			colField, ok := d.GetFieldByName(field.Name, schema)
+			colField, ok := d.GetFieldByName(field.Name)
 			if ok {
 				fields = append(fields, colField)
 			}

--- a/client/index.go
+++ b/client/index.go
@@ -48,7 +48,7 @@ func (d CollectionDefinition) CollectIndexedFields() []FieldDefinition {
 		for _, field := range index.Fields {
 			if fieldsMap[field.Name] {
 				// If the FieldDescription has already been added to the result do not add it a second time
-				// this can happen if a field if referenced by multiple indexes
+				// this can happen if a field is referenced by multiple indexes
 				continue
 			}
 			colField, ok := d.GetFieldByName(field.Name)

--- a/core/encoding.go
+++ b/core/encoding.go
@@ -21,7 +21,7 @@ import (
 
 // DecodeFieldValue takes a field value and description and converts it to the
 // standardized Defra Go type.
-func DecodeFieldValue(fieldDesc client.FieldDescription, val any) (any, error) {
+func DecodeFieldValue(fieldDesc client.FieldDefinition, val any) (any, error) {
 	if val == nil {
 		return nil, nil
 	}

--- a/db/base/collection_keys.go
+++ b/db/base/collection_keys.go
@@ -36,22 +36,27 @@ func MakeDataStoreKeyWithCollectionAndDocID(
 }
 
 func MakePrimaryIndexKeyForCRDT(
-	c client.CollectionDescription,
-	schema client.SchemaDescription,
+	c client.CollectionDefinition,
 	ctype client.CType,
 	key core.DataStoreKey,
 	fieldName string,
 ) (core.DataStoreKey, error) {
 	switch ctype {
 	case client.COMPOSITE:
-		return MakeDataStoreKeyWithCollectionDescription(c).WithInstanceInfo(key).WithFieldId(core.COMPOSITE_NAMESPACE), nil
+		return MakeDataStoreKeyWithCollectionDescription(c.Description).
+				WithInstanceInfo(key).
+				WithFieldId(core.COMPOSITE_NAMESPACE),
+			nil
 	case client.LWW_REGISTER, client.PN_COUNTER:
-		field, ok := c.GetFieldByName(fieldName, &schema)
+		field, ok := c.GetFieldByName(fieldName)
 		if !ok {
 			return core.DataStoreKey{}, client.NewErrFieldNotExist(fieldName)
 		}
 
-		return MakeDataStoreKeyWithCollectionDescription(c).WithInstanceInfo(key).WithFieldId(fmt.Sprint(field.ID)), nil
+		return MakeDataStoreKeyWithCollectionDescription(c.Description).
+				WithInstanceInfo(key).
+				WithFieldId(fmt.Sprint(field.ID)),
+			nil
 	}
 	return core.DataStoreKey{}, ErrInvalidCrdtType
 }

--- a/db/collection.go
+++ b/db/collection.go
@@ -1205,7 +1205,7 @@ func (c *collection) validateOneToOneLinkDoesntAlreadyExist(
 	ctx context.Context,
 	txn datastore.Txn,
 	docID string,
-	fieldDescription client.FieldDescription,
+	fieldDescription client.FieldDefinition,
 	value any,
 ) error {
 	if fieldDescription.Kind != client.FieldKind_DocID {

--- a/db/collection.go
+++ b/db/collection.go
@@ -1446,7 +1446,7 @@ func (c *collection) tryGetFieldKey(primaryKey core.PrimaryDataStoreKey, fieldNa
 func (c *collection) tryGetSchemaFieldID(fieldName string) (uint32, bool) {
 	for _, field := range c.Definition().GetFields() {
 		if field.Name == fieldName {
-			if field.IsObject() || field.IsObjectArray() {
+			if field.Kind.IsObject() || field.Kind.IsObjectArray() {
 				// We do not wish to match navigational properties, only
 				// fields directly on the collection.
 				return uint32(0), false

--- a/db/collection_get.go
+++ b/db/collection_get.go
@@ -48,7 +48,7 @@ func (c *collection) get(
 	ctx context.Context,
 	txn datastore.Txn,
 	primaryKey core.PrimaryDataStoreKey,
-	fields []client.FieldDescription,
+	fields []client.FieldDefinition,
 	showDeleted bool,
 ) (*client.Document, error) {
 	// create a new document fetcher

--- a/db/collection_index.go
+++ b/db/collection_index.go
@@ -130,12 +130,10 @@ func (c *collection) updateIndexedDoc(
 	if err != nil {
 		return err
 	}
-	desc := c.Description()
-	schema := c.Schema()
 	oldDoc, err := c.get(
 		ctx,
 		txn,
-		c.getPrimaryKeyFromDocID(doc.ID()), desc.CollectIndexedFields(&schema),
+		c.getPrimaryKeyFromDocID(doc.ID()), c.Definition().CollectIndexedFields(),
 		false,
 	)
 	if err != nil {
@@ -241,7 +239,7 @@ func (c *collection) createIndex(
 func (c *collection) iterateAllDocs(
 	ctx context.Context,
 	txn datastore.Txn,
-	fields []client.FieldDescription,
+	fields []client.FieldDefinition,
 	exec func(doc *client.Document) error,
 ) error {
 	df := c.newFetcher()
@@ -285,7 +283,7 @@ func (c *collection) indexExistingDocs(
 	txn datastore.Txn,
 	index CollectionIndex,
 ) error {
-	fields := make([]client.FieldDescription, 0, 1)
+	fields := make([]client.FieldDefinition, 0, 1)
 	for _, field := range index.Description().Fields {
 		colField, ok := c.Definition().GetFieldByName(field.Name)
 		if ok {

--- a/db/collection_index.go
+++ b/db/collection_index.go
@@ -287,12 +287,9 @@ func (c *collection) indexExistingDocs(
 ) error {
 	fields := make([]client.FieldDescription, 0, 1)
 	for _, field := range index.Description().Fields {
-		for i := range c.Schema().Fields {
-			colField := c.Schema().Fields[i]
-			if field.Name == colField.Name {
-				fields = append(fields, colField)
-				break
-			}
+		colField, ok := c.Definition().GetFieldByName(field.Name)
+		if ok {
+			fields = append(fields, colField)
 		}
 	}
 

--- a/db/collection_update.go
+++ b/db/collection_update.go
@@ -439,7 +439,7 @@ func (c *collection) makeSelectLocal(filter immutable.Option[request.Filter]) (*
 	}
 
 	for _, fd := range c.Schema().Fields {
-		if fd.IsObject() {
+		if fd.Kind.IsObject() {
 			continue
 		}
 		slct.Fields = append(slct.Fields, &request.Field{

--- a/db/collection_update.go
+++ b/db/collection_update.go
@@ -291,9 +291,9 @@ func (c *collection) updateWithFilter(
 }
 
 // isSecondaryIDField returns true if the given field description represents a secondary relation field ID.
-func (c *collection) isSecondaryIDField(fieldDesc client.FieldDescription) (client.FieldDescription, bool) {
+func (c *collection) isSecondaryIDField(fieldDesc client.FieldDefinition) (client.FieldDefinition, bool) {
 	if fieldDesc.RelationName == "" || fieldDesc.Kind != client.FieldKind_DocID {
-		return client.FieldDescription{}, false
+		return client.FieldDefinition{}, false
 	}
 
 	relationFieldDescription, valid := c.Definition().GetFieldByName(
@@ -312,7 +312,7 @@ func (c *collection) patchPrimaryDoc(
 	ctx context.Context,
 	txn datastore.Txn,
 	secondaryCollectionName string,
-	relationFieldDescription client.FieldDescription,
+	relationFieldDescription client.FieldDefinition,
 	docID string,
 	fieldValue string,
 ) error {

--- a/db/collection_update.go
+++ b/db/collection_update.go
@@ -296,7 +296,7 @@ func (c *collection) isSecondaryIDField(fieldDesc client.FieldDescription) (clie
 		return client.FieldDescription{}, false
 	}
 
-	relationFieldDescription, valid := c.Schema().GetField(
+	relationFieldDescription, valid := c.Definition().GetFieldByName(
 		strings.TrimSuffix(fieldDesc.Name, request.RelatedObjectID),
 	)
 	return relationFieldDescription, valid && !relationFieldDescription.IsPrimaryRelation
@@ -338,7 +338,7 @@ func (c *collection) patchPrimaryDoc(
 		return client.NewErrFieldNotExist(relationFieldDescription.RelationName)
 	}
 
-	primaryIDField, ok := primaryCol.Schema().GetField(primaryField.Name + request.RelatedObjectID)
+	primaryIDField, ok := primaryCol.Definition().GetFieldByName(primaryField.Name + request.RelatedObjectID)
 	if !ok {
 		return client.NewErrFieldNotExist(primaryField.Name + request.RelatedObjectID)
 	}

--- a/db/description/schema.go
+++ b/db/description/schema.go
@@ -30,13 +30,6 @@ func CreateSchemaVersion(
 	txn datastore.Txn,
 	desc client.SchemaDescription,
 ) (client.SchemaDescription, error) {
-	for i := range desc.Fields {
-		// This is not wonderful and will probably break when we add the ability
-		// to delete fields, however it is good enough for now and matches the
-		// create behaviour.
-		desc.Fields[i].ID = client.FieldID(i)
-	}
-
 	buf, err := json.Marshal(desc)
 	if err != nil {
 		return client.SchemaDescription{}, err

--- a/db/errors.go
+++ b/db/errors.go
@@ -28,7 +28,6 @@ const (
 	errSchemaRootDoesntMatch              string = "SchemaRoot does not match existing"
 	errCannotModifySchemaName             string = "modifying the schema name is not supported"
 	errCannotSetVersionID                 string = "setting the VersionID is not supported. It is updated automatically"
-	errCannotSetFieldID                   string = "explicitly setting a field ID value is not supported"
 	errRelationalFieldMissingSchema       string = "a `Schema` [name] must be provided when adding a new relation field"
 	errRelationalFieldInvalidRelationType string = "invalid RelationType"
 	errRelationalFieldMissingIDField      string = "missing id field for relation object field"
@@ -237,14 +236,6 @@ func NewErrCannotModifySchemaName(existingName, proposedName string) error {
 	)
 }
 
-func NewErrCannotSetFieldID(name string, id client.FieldID) error {
-	return errors.New(
-		errCannotSetFieldID,
-		errors.NewKV("Field", name),
-		errors.NewKV("ID", id),
-	)
-}
-
 func NewErrRelationalFieldMissingSchema(name string, kind client.FieldKind) error {
 	return errors.New(
 		errRelationalFieldMissingSchema,
@@ -334,10 +325,9 @@ func NewErrDuplicateField(name string) error {
 	return errors.New(errDuplicateField, errors.NewKV("Name", name))
 }
 
-func NewErrCannotMutateField(id client.FieldID, name string) error {
+func NewErrCannotMutateField(name string) error {
 	return errors.New(
 		errCannotMutateField,
-		errors.NewKV("ID", id),
 		errors.NewKV("ProposedName", name),
 	)
 }
@@ -351,11 +341,10 @@ func NewErrCannotMoveField(name string, proposedIndex, existingIndex int) error 
 	)
 }
 
-func NewErrCannotDeleteField(name string, id client.FieldID) error {
+func NewErrCannotDeleteField(name string) error {
 	return errors.New(
 		errCannotDeleteField,
 		errors.NewKV("Name", name),
-		errors.NewKV("ID", id),
 	)
 }
 

--- a/db/fetcher/encoded_doc.go
+++ b/db/fetcher/encoded_doc.go
@@ -31,7 +31,7 @@ type EncodedDocument interface {
 
 	// Properties returns a copy of the decoded property values mapped by their field
 	// description.
-	Properties(onlyFilterProps bool) (map[client.FieldDescription]any, error)
+	Properties(onlyFilterProps bool) (map[client.FieldDefinition]any, error)
 
 	// Reset re-initializes the EncodedDocument object.
 	Reset()
@@ -41,7 +41,7 @@ type EPTuple []encProperty
 
 // EncProperty is an encoded property of a EncodedDocument
 type encProperty struct {
-	Desc client.FieldDescription
+	Desc client.FieldDefinition
 	Raw  []byte
 
 	// Filter flag to determine if this flag
@@ -68,8 +68,8 @@ type encodedDocument struct {
 	id                   []byte
 	schemaVersionID      string
 	status               client.DocumentStatus
-	properties           map[client.FieldDescription]*encProperty
-	decodedPropertyCache map[client.FieldDescription]any
+	properties           map[client.FieldDefinition]*encProperty
+	decodedPropertyCache map[client.FieldDefinition]any
 
 	// tracking bitsets
 	// A value of 1 indicates a required field
@@ -96,7 +96,7 @@ func (encdoc *encodedDocument) Status() client.DocumentStatus {
 
 // Reset re-initializes the EncodedDocument object.
 func (encdoc *encodedDocument) Reset() {
-	encdoc.properties = make(map[client.FieldDescription]*encProperty, 0)
+	encdoc.properties = make(map[client.FieldDefinition]*encProperty, 0)
 	encdoc.id = nil
 	encdoc.filterSet = nil
 	encdoc.selectSet = nil
@@ -172,10 +172,10 @@ func DecodeToDoc(encdoc EncodedDocument, mapping *core.DocumentMapping, filter b
 	return doc, nil
 }
 
-func (encdoc *encodedDocument) Properties(onlyFilterProps bool) (map[client.FieldDescription]any, error) {
-	result := map[client.FieldDescription]any{}
+func (encdoc *encodedDocument) Properties(onlyFilterProps bool) (map[client.FieldDefinition]any, error) {
+	result := map[client.FieldDefinition]any{}
 	if encdoc.decodedPropertyCache == nil {
-		encdoc.decodedPropertyCache = map[client.FieldDescription]any{}
+		encdoc.decodedPropertyCache = map[client.FieldDefinition]any{}
 	}
 
 	for _, prop := range encdoc.properties {

--- a/db/fetcher/errors.go
+++ b/db/fetcher/errors.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	errFieldIdNotFound              string = "unable to find FieldDescription for given FieldId"
+	errFieldIdNotFound              string = "unable to find SchemaFieldDescription for given FieldId"
 	errFailedToDecodeCIDForVFetcher string = "failed to decode CID for VersionedFetcher"
 	errFailedToSeek                 string = "seek failed"
 	errFailedToMergeState           string = "failed merging state"

--- a/db/fetcher/fetcher.go
+++ b/db/fetcher/fetcher.go
@@ -58,7 +58,7 @@ type Fetcher interface {
 		ctx context.Context,
 		txn datastore.Txn,
 		col client.Collection,
-		fields []client.FieldDescription,
+		fields []client.FieldDefinition,
 		filter *mapper.Filter,
 		docmapper *core.DocumentMapping,
 		reverse bool,
@@ -94,8 +94,8 @@ type DocumentFetcher struct {
 	ranFilter    bool // did we run the filter
 	passedFilter bool // did we pass the filter
 
-	filterFields map[uint32]client.FieldDescription
-	selectFields map[uint32]client.FieldDescription
+	filterFields map[uint32]client.FieldDefinition
+	selectFields map[uint32]client.FieldDefinition
 
 	// static bitset to which stores the IDs of fields
 	// needed for filtering.
@@ -138,7 +138,7 @@ func (df *DocumentFetcher) Init(
 	ctx context.Context,
 	txn datastore.Txn,
 	col client.Collection,
-	fields []client.FieldDescription,
+	fields []client.FieldDefinition,
 	filter *mapper.Filter,
 	docmapper *core.DocumentMapping,
 	reverse bool,
@@ -164,7 +164,7 @@ func (df *DocumentFetcher) Init(
 
 func (df *DocumentFetcher) init(
 	col client.Collection,
-	fields []client.FieldDescription,
+	fields []client.FieldDefinition,
 	filter *mapper.Filter,
 	docMapper *core.DocumentMapping,
 	reverse bool,
@@ -194,10 +194,10 @@ func (df *DocumentFetcher) init(
 	}
 	df.kvIter = nil
 
-	df.selectFields = make(map[uint32]client.FieldDescription, len(fields))
+	df.selectFields = make(map[uint32]client.FieldDefinition, len(fields))
 	// if we haven't been told to get specific fields
 	// get them all
-	var targetFields []client.FieldDescription
+	var targetFields []client.FieldDefinition
 	if len(fields) == 0 {
 		targetFields = df.col.Definition().GetFields()
 	} else {
@@ -214,7 +214,7 @@ func (df *DocumentFetcher) init(
 		if err != nil {
 			return err
 		}
-		df.filterFields = make(map[uint32]client.FieldDescription, len(parsedfilterFields))
+		df.filterFields = make(map[uint32]client.FieldDefinition, len(parsedfilterFields))
 		df.filterSet = bitset.New(uint(len(col.Schema().Fields)))
 		for _, field := range parsedfilterFields {
 			df.filterFields[uint32(field.ID)] = field

--- a/db/fetcher/fetcher.go
+++ b/db/fetcher/fetcher.go
@@ -199,7 +199,7 @@ func (df *DocumentFetcher) init(
 	// get them all
 	var targetFields []client.FieldDescription
 	if len(fields) == 0 {
-		targetFields = df.col.Schema().Fields
+		targetFields = df.col.Definition().GetFields()
 	} else {
 		targetFields = fields
 	}
@@ -210,7 +210,7 @@ func (df *DocumentFetcher) init(
 
 	if df.filter != nil {
 		conditions := df.filter.ToMap(df.mapping)
-		parsedfilterFields, err := parser.ParseFilterFieldsForDescription(conditions, df.col.Schema())
+		parsedfilterFields, err := parser.ParseFilterFieldsForDescription(conditions, df.col.Definition())
 		if err != nil {
 			return err
 		}

--- a/db/fetcher/indexer.go
+++ b/db/fetcher/indexer.go
@@ -69,11 +69,9 @@ func (f *IndexFetcher) Init(
 	f.txn = txn
 
 	for _, indexedField := range f.indexDesc.Fields {
-		for _, field := range f.col.Schema().Fields {
-			if field.Name == indexedField.Name {
-				f.indexedFields = append(f.indexedFields, field)
-				break
-			}
+		field, ok := f.col.Definition().GetFieldByName(indexedField.Name)
+		if ok {
+			f.indexedFields = append(f.indexedFields, field)
 		}
 	}
 

--- a/db/fetcher/indexer.go
+++ b/db/fetcher/indexer.go
@@ -30,8 +30,8 @@ type IndexFetcher struct {
 	docFilter     *mapper.Filter
 	doc           *encodedDocument
 	mapping       *core.DocumentMapping
-	indexedFields []client.FieldDescription
-	docFields     []client.FieldDescription
+	indexedFields []client.FieldDefinition
+	docFields     []client.FieldDefinition
 	indexDesc     client.IndexDescription
 	indexIter     indexIterator
 	execInfo      ExecInfo
@@ -56,7 +56,7 @@ func (f *IndexFetcher) Init(
 	ctx context.Context,
 	txn datastore.Txn,
 	col client.Collection,
-	fields []client.FieldDescription,
+	fields []client.FieldDefinition,
 	filter *mapper.Filter,
 	docMapper *core.DocumentMapping,
 	reverse bool,
@@ -75,7 +75,7 @@ func (f *IndexFetcher) Init(
 		}
 	}
 
-	f.docFields = make([]client.FieldDescription, 0, len(fields))
+	f.docFields = make([]client.FieldDefinition, 0, len(fields))
 outer:
 	for i := range fields {
 		for j := range f.indexedFields {

--- a/db/fetcher/mocks/encoded_document.go
+++ b/db/fetcher/mocks/encoded_document.go
@@ -65,19 +65,19 @@ func (_c *EncodedDocument_ID_Call) RunAndReturn(run func() []byte) *EncodedDocum
 }
 
 // Properties provides a mock function with given fields: onlyFilterProps
-func (_m *EncodedDocument) Properties(onlyFilterProps bool) (map[client.FieldDescription]interface{}, error) {
+func (_m *EncodedDocument) Properties(onlyFilterProps bool) (map[client.FieldDefinition]interface{}, error) {
 	ret := _m.Called(onlyFilterProps)
 
-	var r0 map[client.FieldDescription]interface{}
+	var r0 map[client.FieldDefinition]interface{}
 	var r1 error
-	if rf, ok := ret.Get(0).(func(bool) (map[client.FieldDescription]interface{}, error)); ok {
+	if rf, ok := ret.Get(0).(func(bool) (map[client.FieldDefinition]interface{}, error)); ok {
 		return rf(onlyFilterProps)
 	}
-	if rf, ok := ret.Get(0).(func(bool) map[client.FieldDescription]interface{}); ok {
+	if rf, ok := ret.Get(0).(func(bool) map[client.FieldDefinition]interface{}); ok {
 		r0 = rf(onlyFilterProps)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(map[client.FieldDescription]interface{})
+			r0 = ret.Get(0).(map[client.FieldDefinition]interface{})
 		}
 	}
 
@@ -108,12 +108,12 @@ func (_c *EncodedDocument_Properties_Call) Run(run func(onlyFilterProps bool)) *
 	return _c
 }
 
-func (_c *EncodedDocument_Properties_Call) Return(_a0 map[client.FieldDescription]interface{}, _a1 error) *EncodedDocument_Properties_Call {
+func (_c *EncodedDocument_Properties_Call) Return(_a0 map[client.FieldDefinition]interface{}, _a1 error) *EncodedDocument_Properties_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *EncodedDocument_Properties_Call) RunAndReturn(run func(bool) (map[client.FieldDescription]interface{}, error)) *EncodedDocument_Properties_Call {
+func (_c *EncodedDocument_Properties_Call) RunAndReturn(run func(bool) (map[client.FieldDefinition]interface{}, error)) *EncodedDocument_Properties_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/db/fetcher/mocks/fetcher.go
+++ b/db/fetcher/mocks/fetcher.go
@@ -134,11 +134,11 @@ func (_c *Fetcher_FetchNext_Call) RunAndReturn(run func(context.Context) (fetche
 }
 
 // Init provides a mock function with given fields: ctx, txn, col, fields, filter, docmapper, reverse, showDeleted
-func (_m *Fetcher) Init(ctx context.Context, txn datastore.Txn, col client.Collection, fields []client.FieldDescription, filter *mapper.Filter, docmapper *core.DocumentMapping, reverse bool, showDeleted bool) error {
+func (_m *Fetcher) Init(ctx context.Context, txn datastore.Txn, col client.Collection, fields []client.FieldDefinition, filter *mapper.Filter, docmapper *core.DocumentMapping, reverse bool, showDeleted bool) error {
 	ret := _m.Called(ctx, txn, col, fields, filter, docmapper, reverse, showDeleted)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, datastore.Txn, client.Collection, []client.FieldDescription, *mapper.Filter, *core.DocumentMapping, bool, bool) error); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, datastore.Txn, client.Collection, []client.FieldDefinition, *mapper.Filter, *core.DocumentMapping, bool, bool) error); ok {
 		r0 = rf(ctx, txn, col, fields, filter, docmapper, reverse, showDeleted)
 	} else {
 		r0 = ret.Error(0)
@@ -156,7 +156,7 @@ type Fetcher_Init_Call struct {
 //   - ctx context.Context
 //   - txn datastore.Txn
 //   - col client.Collection
-//   - fields []client.FieldDescription
+//   - fields []client.FieldDefinition
 //   - filter *mapper.Filter
 //   - docmapper *core.DocumentMapping
 //   - reverse bool
@@ -165,9 +165,9 @@ func (_e *Fetcher_Expecter) Init(ctx interface{}, txn interface{}, col interface
 	return &Fetcher_Init_Call{Call: _e.mock.On("Init", ctx, txn, col, fields, filter, docmapper, reverse, showDeleted)}
 }
 
-func (_c *Fetcher_Init_Call) Run(run func(ctx context.Context, txn datastore.Txn, col client.Collection, fields []client.FieldDescription, filter *mapper.Filter, docmapper *core.DocumentMapping, reverse bool, showDeleted bool)) *Fetcher_Init_Call {
+func (_c *Fetcher_Init_Call) Run(run func(ctx context.Context, txn datastore.Txn, col client.Collection, fields []client.FieldDefinition, filter *mapper.Filter, docmapper *core.DocumentMapping, reverse bool, showDeleted bool)) *Fetcher_Init_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(datastore.Txn), args[2].(client.Collection), args[3].([]client.FieldDescription), args[4].(*mapper.Filter), args[5].(*core.DocumentMapping), args[6].(bool), args[7].(bool))
+		run(args[0].(context.Context), args[1].(datastore.Txn), args[2].(client.Collection), args[3].([]client.FieldDefinition), args[4].(*mapper.Filter), args[5].(*core.DocumentMapping), args[6].(bool), args[7].(bool))
 	})
 	return _c
 }
@@ -177,7 +177,7 @@ func (_c *Fetcher_Init_Call) Return(_a0 error) *Fetcher_Init_Call {
 	return _c
 }
 
-func (_c *Fetcher_Init_Call) RunAndReturn(run func(context.Context, datastore.Txn, client.Collection, []client.FieldDescription, *mapper.Filter, *core.DocumentMapping, bool, bool) error) *Fetcher_Init_Call {
+func (_c *Fetcher_Init_Call) RunAndReturn(run func(context.Context, datastore.Txn, client.Collection, []client.FieldDefinition, *mapper.Filter, *core.DocumentMapping, bool, bool) error) *Fetcher_Init_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/db/fetcher/versioned.go
+++ b/db/fetcher/versioned.go
@@ -101,7 +101,7 @@ func (vf *VersionedFetcher) Init(
 	ctx context.Context,
 	txn datastore.Txn,
 	col client.Collection,
-	fields []client.FieldDescription,
+	fields []client.FieldDefinition,
 	filter *mapper.Filter,
 	docmapper *core.DocumentMapping,
 	reverse bool,
@@ -356,8 +356,7 @@ func (vf *VersionedFetcher) merge(c cid.Cid) error {
 			return err
 		}
 
-		schema := vf.col.Schema()
-		field, ok := vf.col.Description().GetFieldByName(l.Name, &schema)
+		field, ok := vf.col.Definition().GetFieldByName(l.Name)
 		if !ok {
 			return client.NewErrFieldNotExist(l.Name)
 		}
@@ -379,7 +378,7 @@ func (vf *VersionedFetcher) processNode(
 	// handle CompositeDAG
 	mcrdt, exists := vf.mCRDTs[crdtIndex]
 	if !exists {
-		dsKey, err := base.MakePrimaryIndexKeyForCRDT(vf.col.Description(), vf.col.Schema(), ctype, vf.dsKey, fieldName)
+		dsKey, err := base.MakePrimaryIndexKeyForCRDT(vf.col.Definition(), ctype, vf.dsKey, fieldName)
 		if err != nil {
 			return err
 		}

--- a/db/index.go
+++ b/db/index.go
@@ -92,9 +92,9 @@ func NewCollectionIndex(
 	}
 	base := collectionBaseIndex{collection: collection, desc: desc}
 	base.validateFieldFuncs = make([]func(any) bool, 0, len(desc.Fields))
-	base.fieldsDescs = make([]client.FieldDescription, 0, len(desc.Fields))
+	base.fieldsDescs = make([]client.SchemaFieldDescription, 0, len(desc.Fields))
 	for _, fieldDesc := range desc.Fields {
-		field, foundField := collection.Schema().GetField(fieldDesc.Name)
+		field, foundField := collection.Schema().GetFieldByName(fieldDesc.Name)
 		if !foundField {
 			return nil, client.NewErrFieldNotExist(desc.Fields[0].Name)
 		}
@@ -116,7 +116,7 @@ type collectionBaseIndex struct {
 	collection         client.Collection
 	desc               client.IndexDescription
 	validateFieldFuncs []func(any) bool
-	fieldsDescs        []client.FieldDescription
+	fieldsDescs        []client.SchemaFieldDescription
 }
 
 func (i *collectionBaseIndex) getDocFieldValue(doc *client.Document) ([][]byte, error) {

--- a/db/indexed_docs_test.go
+++ b/db/indexed_docs_test.go
@@ -887,7 +887,7 @@ func TestNonUniqueUpdate_ShouldPassToFetcherOnlyRelevantFields(t *testing.T) {
 				ctx context.Context,
 				txn datastore.Txn,
 				col client.Collection,
-				fields []client.FieldDescription,
+				fields []client.FieldDefinition,
 				filter *mapper.Filter,
 				mapping *core.DocumentMapping,
 				reverse, showDeleted bool,
@@ -1005,7 +1005,7 @@ type shimEncodedDocument struct {
 	key             []byte
 	schemaVersionID string
 	status          client.DocumentStatus
-	properties      map[client.FieldDescription]any
+	properties      map[client.FieldDefinition]any
 }
 
 var _ fetcher.EncodedDocument = (*shimEncodedDocument)(nil)
@@ -1022,7 +1022,7 @@ func (encdoc *shimEncodedDocument) Status() client.DocumentStatus {
 	return encdoc.status
 }
 
-func (encdoc *shimEncodedDocument) Properties(onlyFilterProps bool) (map[client.FieldDescription]any, error) {
+func (encdoc *shimEncodedDocument) Properties(onlyFilterProps bool) (map[client.FieldDefinition]any, error) {
 	return encdoc.properties, nil
 }
 
@@ -1030,7 +1030,7 @@ func (encdoc *shimEncodedDocument) Reset() {
 	encdoc.key = nil
 	encdoc.schemaVersionID = ""
 	encdoc.status = 0
-	encdoc.properties = map[client.FieldDescription]any{}
+	encdoc.properties = map[client.FieldDefinition]any{}
 }
 
 func TestUniqueCreate_ShouldIndexExistingDocs(t *testing.T) {

--- a/db/schema.go
+++ b/db/schema.go
@@ -361,18 +361,18 @@ func getSubstituteFieldKind(
 	}
 }
 
-// isFieldOrInner returns true if the given path points to a FieldDescription or a property within it.
+// isFieldOrInner returns true if the given path points to a SchemaFieldDescription or a property within it.
 func isFieldOrInner(path []string) bool {
 	//nolint:goconst
 	return len(path) >= 3 && path[fieldsPathIndex] == "Fields"
 }
 
-// isField returns true if the given path points to a FieldDescription.
+// isField returns true if the given path points to a SchemaFieldDescription.
 func isField(path []string) bool {
 	return len(path) == 3 && path[fieldsPathIndex] == "Fields"
 }
 
-// isField returns true if the given path points to a FieldDescription.Kind property.
+// isField returns true if the given path points to a SchemaFieldDescription.Kind property.
 func isFieldKind(path []string) bool {
 	return len(path) == 4 &&
 		path[fieldIndexPathIndex+1] == "Kind" &&

--- a/docs/data_format_changes/i2334-field-id-is-local.md
+++ b/docs/data_format_changes/i2334-field-id-is-local.md
@@ -1,0 +1,3 @@
+# Move field id off of schema
+
+Field ID has been made local, and moved off of the schema and onto collection.  As a result schema root and schema version id are no longer dependent on it.

--- a/lens/fetcher.go
+++ b/lens/fetcher.go
@@ -71,9 +71,9 @@ func (f *lensedFetcher) Init(
 	// Add cache the field descriptions in reverse, allowing smaller-index fields to overwrite any later
 	// ones.  This should never really happen here, but it ensures the result is consistent with col.GetField
 	// which returns the first one it finds with a matching name.
-	for i := len(col.Schema().Fields) - 1; i >= 0; i-- {
-		field := col.Schema().Fields[i]
-		f.fieldDescriptionsByName[field.Name] = field
+	defFields := col.Definition().GetFields()
+	for i := len(defFields) - 1; i >= 0; i-- {
+		f.fieldDescriptionsByName[defFields[i].Name] = defFields[i]
 	}
 
 	history, err := getTargetedSchemaHistory(ctx, txn, f.col.Schema().Root, f.col.Schema().VersionID)

--- a/lens/fetcher.go
+++ b/lens/fetcher.go
@@ -36,7 +36,7 @@ type lensedFetcher struct {
 
 	col client.Collection
 	// Cache the fieldDescriptions mapped by name to allow for cheaper access within the fetcher loop
-	fieldDescriptionsByName map[string]client.FieldDescription
+	fieldDescriptionsByName map[string]client.FieldDefinition
 
 	targetVersionID string
 
@@ -59,7 +59,7 @@ func (f *lensedFetcher) Init(
 	ctx context.Context,
 	txn datastore.Txn,
 	col client.Collection,
-	fields []client.FieldDescription,
+	fields []client.FieldDefinition,
 	filter *mapper.Filter,
 	docmapper *core.DocumentMapping,
 	reverse bool,
@@ -67,7 +67,7 @@ func (f *lensedFetcher) Init(
 ) error {
 	f.col = col
 
-	f.fieldDescriptionsByName = make(map[string]client.FieldDescription, len(col.Schema().Fields))
+	f.fieldDescriptionsByName = make(map[string]client.FieldDefinition, len(col.Schema().Fields))
 	// Add cache the field descriptions in reverse, allowing smaller-index fields to overwrite any later
 	// ones.  This should never really happen here, but it ensures the result is consistent with col.GetField
 	// which returns the first one it finds with a matching name.
@@ -96,7 +96,7 @@ historyLoop:
 
 	f.targetVersionID = col.Schema().VersionID
 
-	var innerFetcherFields []client.FieldDescription
+	var innerFetcherFields []client.FieldDefinition
 	if f.hasMigrations {
 		// If there are migrations present, they may require fields that are not otherwise
 		// requested.  At the moment this means we need to pass in nil so that the underlying
@@ -198,7 +198,7 @@ func encodedDocToLensDoc(doc fetcher.EncodedDocument) (LensDoc, error) {
 func (f *lensedFetcher) lensDocToEncodedDoc(docAsMap LensDoc) (fetcher.EncodedDocument, error) {
 	var key string
 	status := client.Active
-	properties := map[client.FieldDescription]any{}
+	properties := map[client.FieldDefinition]any{}
 
 	for fieldName, fieldByteValue := range docAsMap {
 		if fieldName == request.DocIDFieldName {
@@ -315,7 +315,7 @@ type lensEncodedDocument struct {
 	key             []byte
 	schemaVersionID string
 	status          client.DocumentStatus
-	properties      map[client.FieldDescription]any
+	properties      map[client.FieldDefinition]any
 }
 
 var _ fetcher.EncodedDocument = (*lensEncodedDocument)(nil)
@@ -332,7 +332,7 @@ func (encdoc *lensEncodedDocument) Status() client.DocumentStatus {
 	return encdoc.status
 }
 
-func (encdoc *lensEncodedDocument) Properties(onlyFilterProps bool) (map[client.FieldDescription]any, error) {
+func (encdoc *lensEncodedDocument) Properties(onlyFilterProps bool) (map[client.FieldDefinition]any, error) {
 	return encdoc.properties, nil
 }
 
@@ -340,5 +340,5 @@ func (encdoc *lensEncodedDocument) Reset() {
 	encdoc.key = nil
 	encdoc.schemaVersionID = ""
 	encdoc.status = 0
-	encdoc.properties = map[client.FieldDescription]any{}
+	encdoc.properties = map[client.FieldDefinition]any{}
 }

--- a/net/client_test.go
+++ b/net/client_test.go
@@ -24,7 +24,7 @@ import (
 
 var sd = client.SchemaDescription{
 	Name: "test",
-	Fields: []client.FieldDescription{
+	Fields: []client.SchemaFieldDescription{
 		{
 			Name: "test",
 			Kind: client.FieldKind_NILLABLE_STRING,

--- a/net/process.go
+++ b/net/process.go
@@ -149,7 +149,7 @@ func initCRDTForType(
 		), nil
 	}
 
-	fd, ok := col.Schema().GetField(field)
+	fd, ok := col.Definition().GetFieldByName(field)
 	if !ok {
 		return nil, errors.New(fmt.Sprintf("Couldn't find field %s for doc %s", field, dsKey.ToString()))
 	}

--- a/planner/commit.go
+++ b/planner/commit.go
@@ -345,7 +345,7 @@ func (n *dagScanNode) dagBlockToNodeDoc(block blocks.Block) (core.Doc, []*ipld.L
 
 		// Because we only care about the schema, we can safely take the first - the schema is the same
 		// for all in the set.
-		field, ok := cols[0].Schema().GetField(fieldName.(string))
+		field, ok := cols[0].Definition().GetFieldByName(fieldName.(string))
 		if !ok {
 			return core.Doc{}, nil, client.NewErrFieldNotExist(fieldName.(string))
 		}

--- a/planner/mapper/mapper.go
+++ b/planner/mapper/mapper.go
@@ -267,7 +267,7 @@ func resolveAggregates(
 	inputFields []Requestable,
 	mapping *core.DocumentMapping,
 	collectionName string,
-	schema client.CollectionDefinition,
+	def client.CollectionDefinition,
 	store client.Store,
 ) ([]Requestable, error) {
 	fields := inputFields
@@ -287,7 +287,7 @@ func resolveAggregates(
 			var hasHost bool
 			var convertedFilter *Filter
 			if childIsMapped {
-				fieldDesc, isField := schema.GetFieldByName(target.hostExternalName)
+				fieldDesc, isField := def.GetFieldByName(target.hostExternalName)
 
 				if isField && !fieldDesc.IsObject() {
 					var order *OrderBy

--- a/planner/mapper/mapper.go
+++ b/planner/mapper/mapper.go
@@ -58,7 +58,7 @@ func toSelect(
 		return nil, err
 	}
 
-	mapping, schema, err := getTopLevelInfo(ctx, store, selectRequest, collectionName)
+	mapping, definition, err := getTopLevelInfo(ctx, store, selectRequest, collectionName)
 	if err != nil {
 		return nil, err
 	}
@@ -91,7 +91,7 @@ func toSelect(
 		fields,
 		mapping,
 		collectionName,
-		schema,
+		definition,
 		store,
 	)
 
@@ -99,8 +99,8 @@ func toSelect(
 		return nil, err
 	}
 
-	if len(schema.Fields) != 0 {
-		fields, err = resolveSecondaryRelationIDs(ctx, store, collectionName, schema, mapping, fields)
+	if len(definition.Schema.Fields) != 0 {
+		fields, err = resolveSecondaryRelationIDs(ctx, store, collectionName, definition.Schema, mapping, fields)
 		if err != nil {
 			return nil, err
 		}
@@ -111,7 +111,7 @@ func toSelect(
 		groupByFields := selectRequest.GroupBy.Value().Fields
 		// Remap all alias field names to use their internal field name mappings.
 		for index, groupByField := range groupByFields {
-			fieldDesc, ok := schema.GetField(groupByField)
+			fieldDesc, ok := definition.GetFieldByName(groupByField)
 			if ok && fieldDesc.IsObject() && !fieldDesc.IsObjectArray() {
 				groupByFields[index] = groupByField + request.RelatedObjectID
 			} else if ok && fieldDesc.IsObjectArray() {
@@ -267,7 +267,7 @@ func resolveAggregates(
 	inputFields []Requestable,
 	mapping *core.DocumentMapping,
 	collectionName string,
-	schema client.SchemaDescription,
+	schema client.CollectionDefinition,
 	store client.Store,
 ) ([]Requestable, error) {
 	fields := inputFields
@@ -287,7 +287,7 @@ func resolveAggregates(
 			var hasHost bool
 			var convertedFilter *Filter
 			if childIsMapped {
-				fieldDesc, isField := schema.GetField(target.hostExternalName)
+				fieldDesc, isField := schema.GetFieldByName(target.hostExternalName)
 
 				if isField && !fieldDesc.IsObject() {
 					var order *OrderBy
@@ -729,7 +729,7 @@ func getCollectionName(
 			return "", err
 		}
 
-		hostFieldDesc, parentHasField := parentCollection.Schema().GetField(selectRequest.Name)
+		hostFieldDesc, parentHasField := parentCollection.Definition().GetFieldByName(selectRequest.Name)
 		if parentHasField && hostFieldDesc.RelationName != "" {
 			// If this field exists on the parent, and it is a child object
 			// then this collection name is the collection name of the child.
@@ -746,17 +746,17 @@ func getTopLevelInfo(
 	store client.Store,
 	selectRequest *request.Select,
 	collectionName string,
-) (*core.DocumentMapping, client.SchemaDescription, error) {
+) (*core.DocumentMapping, client.CollectionDefinition, error) {
 	mapping := core.NewDocumentMapping()
 
 	if _, isAggregate := request.Aggregates[selectRequest.Name]; isAggregate {
 		// If this is a (top-level) aggregate, then it will have no collection
 		// description, and no top-level fields, so we return an empty mapping only
-		return mapping, client.SchemaDescription{}, nil
+		return mapping, client.CollectionDefinition{}, nil
 	}
 
 	if selectRequest.Root == request.ObjectSelection {
-		var schema client.SchemaDescription
+		var definition client.CollectionDefinition
 		collection, err := store.GetCollectionByName(ctx, collectionName)
 		if err != nil {
 			// If the collection is not found, check to see if a schema of that name exists,
@@ -771,27 +771,34 @@ func getTopLevelInfo(
 				},
 			)
 			if err != nil {
-				return nil, client.SchemaDescription{}, err
+				return nil, client.CollectionDefinition{}, err
 			}
 			if len(schemas) == 0 {
-				return nil, client.SchemaDescription{}, NewErrTypeNotFound(collectionName)
+				return nil, client.CollectionDefinition{}, NewErrTypeNotFound(collectionName)
 			}
-			// `schemas` will contain all versions of that name, as views cannot be updated atm this should
-			// be fine for now
-			schema = schemas[0]
+
+			for i, f := range schemas[0].Fields {
+				// As embedded objects do not have collections/field-ids, we just take the index
+				mapping.Add(int(i), f.Name)
+			}
+
+			definition = client.CollectionDefinition{
+				// `schemas` will contain all versions of that name, as views cannot be updated atm this should
+				// be fine for now
+				Schema: schemas[0],
+			}
 		} else {
 			mapping.Add(core.DocIDFieldIndex, request.DocIDFieldName)
-			schema = collection.Schema()
-		}
-
-		// Map all fields from schema into the map as they are fetched automatically
-		for _, f := range schema.Fields {
-			if f.IsObject() {
-				// Objects are skipped, as they are not fetched by default and
-				// have to be requested via selects.
-				continue
+			definition = collection.Definition()
+			// Map all fields from schema into the map as they are fetched automatically
+			for _, f := range definition.GetFields() {
+				if f.IsObject() {
+					// Objects are skipped, as they are not fetched by default and
+					// have to be requested via selects.
+					continue
+				}
+				mapping.Add(int(f.ID), f.Name)
 			}
-			mapping.Add(int(f.ID), f.Name)
 		}
 
 		// Setting the type name must be done after adding the fields, as
@@ -800,7 +807,7 @@ func getTopLevelInfo(
 
 		mapping.Add(mapping.GetNextIndex(), request.DeletedFieldName)
 
-		return mapping, schema, nil
+		return mapping, definition, nil
 	}
 
 	if selectRequest.Name == request.LinksFieldName {
@@ -821,7 +828,7 @@ func getTopLevelInfo(
 		mapping.SetTypeName(request.CommitTypeName)
 	}
 
-	return mapping, client.SchemaDescription{}, nil
+	return mapping, client.CollectionDefinition{}, nil
 }
 
 func resolveFilterDependencies(
@@ -1031,7 +1038,7 @@ func resolveSecondaryRelationIDs(
 			continue
 		}
 
-		fieldDesc, descFound := schema.GetField(existingField.Name)
+		fieldDesc, descFound := schema.GetFieldByName(existingField.Name)
 		if !descFound {
 			continue
 		}

--- a/planner/mapper/mapper.go
+++ b/planner/mapper/mapper.go
@@ -112,9 +112,9 @@ func toSelect(
 		// Remap all alias field names to use their internal field name mappings.
 		for index, groupByField := range groupByFields {
 			fieldDesc, ok := definition.GetFieldByName(groupByField)
-			if ok && fieldDesc.IsObject() && !fieldDesc.IsObjectArray() {
+			if ok && fieldDesc.Kind.IsObject() && !fieldDesc.Kind.IsObjectArray() {
 				groupByFields[index] = groupByField + request.RelatedObjectID
-			} else if ok && fieldDesc.IsObjectArray() {
+			} else if ok && fieldDesc.Kind.IsObjectArray() {
 				return nil, NewErrInvalidFieldToGroupBy(groupByField)
 			}
 		}
@@ -289,7 +289,7 @@ func resolveAggregates(
 			if childIsMapped {
 				fieldDesc, isField := def.GetFieldByName(target.hostExternalName)
 
-				if isField && !fieldDesc.IsObject() {
+				if isField && !fieldDesc.Kind.IsObject() {
 					var order *OrderBy
 					if target.order.HasValue() && len(target.order.Value().Conditions) > 0 {
 						// For inline arrays the order element will consist of just a direction
@@ -792,7 +792,7 @@ func getTopLevelInfo(
 			definition = collection.Definition()
 			// Map all fields from schema into the map as they are fetched automatically
 			for _, f := range definition.GetFields() {
-				if f.IsObject() {
+				if f.Kind.IsObject() {
 					// Objects are skipped, as they are not fetched by default and
 					// have to be requested via selects.
 					continue

--- a/planner/scan.go
+++ b/planner/scan.go
@@ -104,7 +104,7 @@ func (n *scanNode) initFields(fields []mapper.Requestable) error {
 				if target.Filter != nil {
 					fieldDescs, err := parser.ParseFilterFieldsForDescription(
 						target.Filter.ExternalConditions,
-						n.col.Schema(),
+						n.col.Definition(),
 					)
 					if err != nil {
 						return err
@@ -125,7 +125,7 @@ func (n *scanNode) initFields(fields []mapper.Requestable) error {
 }
 
 func (n *scanNode) tryAddField(fieldName string) bool {
-	fd, ok := n.col.Schema().GetField(fieldName)
+	fd, ok := n.col.Definition().GetFieldByName(fieldName)
 	if !ok {
 		// skip fields that are not part of the
 		// schema description. The scanner (and fetcher)

--- a/planner/scan.go
+++ b/planner/scan.go
@@ -41,7 +41,7 @@ type scanNode struct {
 	p   *Planner
 	col client.Collection
 
-	fields []client.FieldDescription
+	fields []client.FieldDefinition
 
 	showDeleted bool
 

--- a/planner/sum.go
+++ b/planner/sum.go
@@ -82,7 +82,7 @@ func (p *Planner) isValueFloat(
 			return false, err
 		}
 
-		fieldDescription, fieldDescriptionFound := parentCol.Schema().GetField(source.Name)
+		fieldDescription, fieldDescriptionFound := parentCol.Schema().GetFieldByName(source.Name)
 		if !fieldDescriptionFound {
 			return false, client.NewErrFieldNotExist(source.Name)
 		}
@@ -130,7 +130,7 @@ func (p *Planner) isValueFloat(
 		return false, err
 	}
 
-	fieldDescription, fieldDescriptionFound := childCol.Schema().GetField(source.ChildTarget.Name)
+	fieldDescription, fieldDescriptionFound := childCol.Schema().GetFieldByName(source.ChildTarget.Name)
 	if !fieldDescriptionFound {
 		return false, client.NewErrFieldNotExist(source.ChildTarget.Name)
 	}

--- a/planner/type_join.go
+++ b/planner/type_join.go
@@ -80,7 +80,7 @@ func (p *Planner) makeTypeIndexJoin(
 	var joinPlan planNode
 	var err error
 
-	typeFieldDesc, ok := parent.collection.Schema().GetField(subType.Name)
+	typeFieldDesc, ok := parent.collection.Schema().GetFieldByName(subType.Name)
 	if !ok {
 		return nil, client.NewErrFieldNotExist(subType.Name)
 	}
@@ -239,7 +239,7 @@ func (p *Planner) makeTypeJoinOne(
 	}
 
 	// get the correct sub field schema type (collection)
-	subTypeFieldDesc, ok := parent.collection.Schema().GetField(subType.Name)
+	subTypeFieldDesc, ok := parent.collection.Schema().GetFieldByName(subType.Name)
 	if !ok {
 		return nil, client.NewErrFieldNotExist(subType.Name)
 	}
@@ -374,7 +374,7 @@ func (p *Planner) makeTypeJoinMany(
 		return nil, err
 	}
 
-	subTypeFieldDesc, ok := parent.collection.Schema().GetField(subType.Name)
+	subTypeFieldDesc, ok := parent.collection.Schema().GetFieldByName(subType.Name)
 	if !ok {
 		return nil, client.NewErrFieldNotExist(subType.Name)
 	}

--- a/request/graphql/parser/filter.go
+++ b/request/graphql/parser/filter.go
@@ -195,15 +195,15 @@ func parseVal(val ast.Value, recurseFn parseFn) (any, error) {
 func ParseFilterFieldsForDescription(
 	conditions map[string]any,
 	col client.CollectionDefinition,
-) ([]client.FieldDescription, error) {
+) ([]client.FieldDefinition, error) {
 	return parseFilterFieldsForDescriptionMap(conditions, col)
 }
 
 func parseFilterFieldsForDescriptionMap(
 	conditions map[string]any,
 	col client.CollectionDefinition,
-) ([]client.FieldDescription, error) {
-	fields := make([]client.FieldDescription, 0)
+) ([]client.FieldDefinition, error) {
+	fields := make([]client.FieldDefinition, 0)
 	for k, v := range conditions {
 		switch k {
 		case "_or", "_and":
@@ -234,8 +234,8 @@ func parseFilterFieldsForDescriptionMap(
 func parseFilterFieldsForDescriptionSlice(
 	conditions []any,
 	schema client.CollectionDefinition,
-) ([]client.FieldDescription, error) {
-	fields := make([]client.FieldDescription, 0)
+) ([]client.FieldDefinition, error) {
+	fields := make([]client.FieldDefinition, 0)
 	for _, v := range conditions {
 		switch cond := v.(type) {
 		case map[string]any:

--- a/request/graphql/parser/filter.go
+++ b/request/graphql/parser/filter.go
@@ -222,7 +222,7 @@ func parseFilterFieldsForDescriptionMap(
 			fields = append(fields, parsedFileds...)
 		default:
 			f, found := col.GetFieldByName(k)
-			if !found || f.IsObject() {
+			if !found || f.Kind.IsObject() {
 				continue
 			}
 			fields = append(fields, f)

--- a/request/graphql/parser/filter.go
+++ b/request/graphql/parser/filter.go
@@ -194,34 +194,34 @@ func parseVal(val ast.Value, recurseFn parseFn) (any, error) {
 // from the filter conditions“
 func ParseFilterFieldsForDescription(
 	conditions map[string]any,
-	schema client.SchemaDescription,
+	col client.CollectionDefinition,
 ) ([]client.FieldDescription, error) {
-	return parseFilterFieldsForDescriptionMap(conditions, schema)
+	return parseFilterFieldsForDescriptionMap(conditions, col)
 }
 
 func parseFilterFieldsForDescriptionMap(
 	conditions map[string]any,
-	schema client.SchemaDescription,
+	col client.CollectionDefinition,
 ) ([]client.FieldDescription, error) {
 	fields := make([]client.FieldDescription, 0)
 	for k, v := range conditions {
 		switch k {
 		case "_or", "_and":
 			conds := v.([]any)
-			parsedFileds, err := parseFilterFieldsForDescriptionSlice(conds, schema)
+			parsedFileds, err := parseFilterFieldsForDescriptionSlice(conds, col)
 			if err != nil {
 				return nil, err
 			}
 			fields = append(fields, parsedFileds...)
 		case "_not":
 			conds := v.(map[string]any)
-			parsedFileds, err := parseFilterFieldsForDescriptionMap(conds, schema)
+			parsedFileds, err := parseFilterFieldsForDescriptionMap(conds, col)
 			if err != nil {
 				return nil, err
 			}
 			fields = append(fields, parsedFileds...)
 		default:
-			f, found := schema.GetField(k)
+			f, found := col.GetFieldByName(k)
 			if !found || f.IsObject() {
 				continue
 			}
@@ -233,7 +233,7 @@ func parseFilterFieldsForDescriptionMap(
 
 func parseFilterFieldsForDescriptionSlice(
 	conditions []any,
-	schema client.SchemaDescription,
+	schema client.CollectionDefinition,
 ) ([]client.FieldDescription, error) {
 	fields := make([]client.FieldDescription, 0)
 	for _, v := range conditions {

--- a/request/graphql/parser/filter.go
+++ b/request/graphql/parser/filter.go
@@ -250,21 +250,3 @@ func parseFilterFieldsForDescriptionSlice(
 	}
 	return fields, nil
 }
-
-/*
-userCollection := db.getCollection("users")
-doc := userCollection.NewFromJSON("{
-	"title": "Painted House",
-	"description": "...",
-	"genres": ["bae-123", "bae-def", "bae-456"]
-	"author_id": "bae-999",
-}")
-doc.Save()
-
-doc := document.New(schema).FromJSON
-
-------------------------------------
-
-
-
-*/

--- a/request/graphql/schema/collection.go
+++ b/request/graphql/schema/collection.go
@@ -102,7 +102,7 @@ func collectionFromAstDefinition(
 	relationManager *RelationManager,
 	def *ast.ObjectDefinition,
 ) (client.CollectionDefinition, error) {
-	fieldDescriptions := []client.FieldDescription{
+	fieldDescriptions := []client.SchemaFieldDescription{
 		{
 			Name: request.DocIDFieldName,
 			Kind: client.FieldKind_DocID,
@@ -168,7 +168,7 @@ func schemaFromAstDefinition(
 	relationManager *RelationManager,
 	def *ast.InterfaceDefinition,
 ) (client.SchemaDescription, error) {
-	fieldDescriptions := []client.FieldDescription{}
+	fieldDescriptions := []client.SchemaFieldDescription{}
 
 	for _, field := range def.Fields {
 		tmpFieldsDescriptions, err := fieldsFromAST(field, relationManager, def.Name.Value)
@@ -315,7 +315,7 @@ func indexFromAST(directive *ast.Directive) (client.IndexDescription, error) {
 func fieldsFromAST(field *ast.FieldDefinition,
 	relationManager *RelationManager,
 	hostObjectName string,
-) ([]client.FieldDescription, error) {
+) ([]client.SchemaFieldDescription, error) {
 	kind, err := astTypeToKind(field.Type)
 	if err != nil {
 		return nil, err
@@ -325,7 +325,7 @@ func fieldsFromAST(field *ast.FieldDefinition,
 	relationName := ""
 	relationType := relationType(0)
 
-	fieldDescriptions := []client.FieldDescription{}
+	fieldDescriptions := []client.SchemaFieldDescription{}
 
 	if kind == client.FieldKind_FOREIGN_OBJECT || kind == client.FieldKind_FOREIGN_OBJECT_ARRAY {
 		if kind == client.FieldKind_FOREIGN_OBJECT {
@@ -346,7 +346,7 @@ func fieldsFromAST(field *ast.FieldDefinition,
 
 		if kind == client.FieldKind_FOREIGN_OBJECT {
 			// An _id field is added for every 1-N relationship from this object.
-			fieldDescriptions = append(fieldDescriptions, client.FieldDescription{
+			fieldDescriptions = append(fieldDescriptions, client.SchemaFieldDescription{
 				Name:         fmt.Sprintf("%s_id", field.Name.Value),
 				Kind:         client.FieldKind_DocID,
 				Typ:          defaultCRDTForFieldKind[client.FieldKind_DocID],
@@ -372,7 +372,7 @@ func fieldsFromAST(field *ast.FieldDefinition,
 		return nil, err
 	}
 
-	fieldDescription := client.FieldDescription{
+	fieldDescription := client.SchemaFieldDescription{
 		Name:         field.Name.Value,
 		Kind:         kind,
 		Typ:          cType,

--- a/request/graphql/schema/descriptions_test.go
+++ b/request/graphql/schema/descriptions_test.go
@@ -39,7 +39,7 @@ func TestSingleSimpleType(t *testing.T) {
 					},
 					Schema: client.SchemaDescription{
 						Name: "User",
-						Fields: []client.FieldDescription{
+						Fields: []client.SchemaFieldDescription{
 							{
 								Name: "_docID",
 								Kind: client.FieldKind_DocID,
@@ -88,7 +88,7 @@ func TestSingleSimpleType(t *testing.T) {
 					},
 					Schema: client.SchemaDescription{
 						Name: "User",
-						Fields: []client.FieldDescription{
+						Fields: []client.SchemaFieldDescription{
 							{
 								Name: "_docID",
 								Kind: client.FieldKind_DocID,
@@ -119,7 +119,7 @@ func TestSingleSimpleType(t *testing.T) {
 					},
 					Schema: client.SchemaDescription{
 						Name: "Author",
-						Fields: []client.FieldDescription{
+						Fields: []client.SchemaFieldDescription{
 							{
 								Name: "_docID",
 								Kind: client.FieldKind_DocID,
@@ -168,7 +168,7 @@ func TestSingleSimpleType(t *testing.T) {
 					},
 					Schema: client.SchemaDescription{
 						Name: "Book",
-						Fields: []client.FieldDescription{
+						Fields: []client.SchemaFieldDescription{
 							{
 								Name: "_docID",
 								Kind: client.FieldKind_DocID,
@@ -206,7 +206,7 @@ func TestSingleSimpleType(t *testing.T) {
 					},
 					Schema: client.SchemaDescription{
 						Name: "Author",
-						Fields: []client.FieldDescription{
+						Fields: []client.SchemaFieldDescription{
 							{
 								Name: "_docID",
 								Kind: client.FieldKind_DocID,
@@ -263,7 +263,7 @@ func TestSingleSimpleType(t *testing.T) {
 					},
 					Schema: client.SchemaDescription{
 						Name: "User",
-						Fields: []client.FieldDescription{
+						Fields: []client.SchemaFieldDescription{
 							{
 								Name: "_docID",
 								Kind: client.FieldKind_DocID,
@@ -294,7 +294,7 @@ func TestSingleSimpleType(t *testing.T) {
 					},
 					Schema: client.SchemaDescription{
 						Name: "Author",
-						Fields: []client.FieldDescription{
+						Fields: []client.SchemaFieldDescription{
 							{
 								Name: "_docID",
 								Kind: client.FieldKind_DocID,
@@ -343,7 +343,7 @@ func TestSingleSimpleType(t *testing.T) {
 					},
 					Schema: client.SchemaDescription{
 						Name: "Book",
-						Fields: []client.FieldDescription{
+						Fields: []client.SchemaFieldDescription{
 							{
 								Name: "_docID",
 								Kind: client.FieldKind_DocID,
@@ -381,7 +381,7 @@ func TestSingleSimpleType(t *testing.T) {
 					},
 					Schema: client.SchemaDescription{
 						Name: "Author",
-						Fields: []client.FieldDescription{
+						Fields: []client.SchemaFieldDescription{
 							{
 								Name: "_docID",
 								Kind: client.FieldKind_DocID,
@@ -438,7 +438,7 @@ func TestSingleSimpleType(t *testing.T) {
 					},
 					Schema: client.SchemaDescription{
 						Name: "Book",
-						Fields: []client.FieldDescription{
+						Fields: []client.SchemaFieldDescription{
 							{
 								Name: "_docID",
 								Kind: client.FieldKind_DocID,
@@ -477,7 +477,7 @@ func TestSingleSimpleType(t *testing.T) {
 					},
 					Schema: client.SchemaDescription{
 						Name: "Author",
-						Fields: []client.FieldDescription{
+						Fields: []client.SchemaFieldDescription{
 							{
 								Name: "_docID",
 								Kind: client.FieldKind_DocID,
@@ -533,7 +533,7 @@ func TestSingleSimpleType(t *testing.T) {
 					},
 					Schema: client.SchemaDescription{
 						Name: "Book",
-						Fields: []client.FieldDescription{
+						Fields: []client.SchemaFieldDescription{
 							{
 								Name: "_docID",
 								Kind: client.FieldKind_DocID,
@@ -572,7 +572,7 @@ func TestSingleSimpleType(t *testing.T) {
 					},
 					Schema: client.SchemaDescription{
 						Name: "Author",
-						Fields: []client.FieldDescription{
+						Fields: []client.SchemaFieldDescription{
 							{
 								Name: "_docID",
 								Kind: client.FieldKind_DocID,

--- a/tests/gen/gen_auto.go
+++ b/tests/gen/gen_auto.go
@@ -119,7 +119,7 @@ func (g *randomDocGenerator) getMaxTotalDemand() int {
 }
 
 // getNextPrimaryDocID returns the docID of the next primary document to be used as a relation.
-func (g *randomDocGenerator) getNextPrimaryDocID(secondaryType string, field *client.FieldDescription) string {
+func (g *randomDocGenerator) getNextPrimaryDocID(secondaryType string, field *client.SchemaFieldDescription) string {
 	ind := g.configurator.usageCounter.getNextTypeIndForField(secondaryType, field)
 	return g.generatedDocs[field.Schema][ind].docID
 }

--- a/tests/gen/gen_auto.go
+++ b/tests/gen/gen_auto.go
@@ -225,7 +225,7 @@ func validateDefinitions(definitions []client.CollectionDefinition) error {
 			if field.Name == "" {
 				return NewErrIncompleteColDefinition("field name is empty")
 			}
-			if field.IsObject() {
+			if field.Kind.IsObject() {
 				if field.Schema == "" {
 					return NewErrIncompleteColDefinition("field schema is empty")
 				}

--- a/tests/gen/gen_auto_config.go
+++ b/tests/gen/gen_auto_config.go
@@ -58,7 +58,7 @@ func validateConfig(types map[string]client.CollectionDefinition, configsMap con
 			return newNotDefinedTypeErr(typeName)
 		}
 		for fieldName, fieldConfig := range typeConfigs {
-			fieldDef, hasField := typeDef.Description.GetFieldByName(fieldName, &typeDef.Schema)
+			fieldDef, hasField := typeDef.Schema.GetFieldByName(fieldName)
 			if !hasField {
 				return NewErrInvalidConfiguration("field " + fieldName +
 					" is not defined in the schema for type " + typeName)
@@ -82,7 +82,7 @@ func validateConfig(types map[string]client.CollectionDefinition, configsMap con
 	return nil
 }
 
-func checkAndValidateMinMax(field *client.FieldDescription, conf *genConfig) error {
+func checkAndValidateMinMax(field *client.SchemaFieldDescription, conf *genConfig) error {
 	_, hasMin := conf.props["min"]
 	if hasMin {
 		var err error
@@ -100,7 +100,7 @@ func checkAndValidateMinMax(field *client.FieldDescription, conf *genConfig) err
 	return nil
 }
 
-func checkAndValidateLen(field *client.FieldDescription, conf *genConfig) error {
+func checkAndValidateLen(field *client.SchemaFieldDescription, conf *genConfig) error {
 	lenConf, hasLen := conf.props["len"]
 	if hasLen {
 		if field.Kind != client.FieldKind_NILLABLE_STRING {
@@ -117,7 +117,7 @@ func checkAndValidateLen(field *client.FieldDescription, conf *genConfig) error 
 	return nil
 }
 
-func checkAndValidateRatio(field *client.FieldDescription, conf *genConfig) error {
+func checkAndValidateRatio(field *client.SchemaFieldDescription, conf *genConfig) error {
 	ratioConf, hasRatio := conf.props["ratio"]
 	if hasRatio {
 		if field.Kind != client.FieldKind_NILLABLE_BOOL {

--- a/tests/gen/gen_auto_config.go
+++ b/tests/gen/gen_auto_config.go
@@ -86,8 +86,8 @@ func checkAndValidateMinMax(field *client.SchemaFieldDescription, conf *genConfi
 	_, hasMin := conf.props["min"]
 	if hasMin {
 		var err error
-		if field.IsArray() || field.Kind == client.FieldKind_NILLABLE_INT {
-			err = validateMinConfig[int](conf, field.IsArray())
+		if field.Kind.IsArray() || field.Kind == client.FieldKind_NILLABLE_INT {
+			err = validateMinConfig[int](conf, field.Kind.IsArray())
 		} else {
 			err = validateMinConfig[float64](conf, false)
 		}

--- a/tests/gen/gen_auto_configurator.go
+++ b/tests/gen/gen_auto_configurator.go
@@ -273,11 +273,11 @@ func (g *docsGenConfigurator) getDemandForPrimaryType(
 ) (typeDemand, error) {
 	primaryTypeDef := g.types[primaryType]
 	for _, field := range primaryTypeDef.Schema.Fields {
-		if field.IsObject() && field.Schema == secondaryType {
+		if field.Kind.IsObject() && field.Schema == secondaryType {
 			primaryDemand := typeDemand{min: secondaryDemand.min, max: secondaryDemand.max}
 			minPerDoc, maxPerDoc := 1, 1
 
-			if field.IsArray() {
+			if field.Kind.IsArray() {
 				fieldConf := g.config.ForField(primaryType, field.Name)
 				minPerDoc, maxPerDoc = getMinMaxOrDefault(fieldConf, 0, secondaryDemand.max)
 				// if we request min 100 of secondary docs and there can be max 5 per primary doc,
@@ -339,14 +339,14 @@ func (g *docsGenConfigurator) calculateDemandForSecondaryTypes(
 ) error {
 	typeDef := g.types[typeName]
 	for _, field := range typeDef.Schema.Fields {
-		if field.IsObject() && !field.IsPrimaryRelation {
+		if field.Kind.IsObject() && !field.IsPrimaryRelation {
 			primaryDocDemand := g.docsDemand[typeName]
 			newSecDemand := typeDemand{min: primaryDocDemand.min, max: primaryDocDemand.max}
 			minPerDoc, maxPerDoc := 1, 1
 
 			curSecDemand, hasSecDemand := g.docsDemand[field.Schema]
 
-			if field.IsArray() {
+			if field.Kind.IsArray() {
 				fieldConf := g.config.ForField(typeName, field.Name)
 				if prop, ok := fieldConf.props["min"]; ok {
 					minPerDoc = prop.(int)
@@ -418,7 +418,7 @@ func getRelationGraph(types map[string]client.CollectionDefinition) map[string][
 
 	for typeName, typeDef := range types {
 		for _, field := range typeDef.Schema.Fields {
-			if field.IsObject() {
+			if field.Kind.IsObject() {
 				if field.IsPrimaryRelation {
 					primaryGraph[typeName] = appendUnique(primaryGraph[typeName], field.Schema)
 				} else {

--- a/tests/gen/gen_auto_configurator.go
+++ b/tests/gen/gen_auto_configurator.go
@@ -65,7 +65,7 @@ func newTypeUsageCounter(random *rand.Rand) typeUsageCounters {
 // addRelationUsage adds a relation usage tracker for a foreign field.
 func (c *typeUsageCounters) addRelationUsage(
 	secondaryType string,
-	field client.FieldDescription,
+	field client.SchemaFieldDescription,
 	minPerDoc, maxPerDoc, numDocs int,
 ) {
 	primaryType := field.Schema
@@ -81,7 +81,7 @@ func (c *typeUsageCounters) addRelationUsage(
 }
 
 // getNextTypeIndForField returns the next index to be used for a foreign field.
-func (c *typeUsageCounters) getNextTypeIndForField(secondaryType string, field *client.FieldDescription) int {
+func (c *typeUsageCounters) getNextTypeIndForField(secondaryType string, field *client.SchemaFieldDescription) int {
 	current := c.m[field.Schema][secondaryType][field.Name]
 	return current.useNextDocIDIndex()
 }

--- a/tests/gen/gen_auto_test.go
+++ b/tests/gen/gen_auto_test.go
@@ -1206,7 +1206,7 @@ func TestAutoGenerate_IfCollectionDefinitionIsIncomplete_ReturnError(t *testing.
 				},
 				Schema: client.SchemaDescription{
 					Name: "User",
-					Fields: []client.FieldDescription{
+					Fields: []client.SchemaFieldDescription{
 						{
 							Name: "name",
 							Kind: client.FieldKind_NILLABLE_INT,
@@ -1226,7 +1226,7 @@ func TestAutoGenerate_IfCollectionDefinitionIsIncomplete_ReturnError(t *testing.
 				},
 				Schema: client.SchemaDescription{
 					Name: "Device",
-					Fields: []client.FieldDescription{
+					Fields: []client.SchemaFieldDescription{
 						{
 							Name: "model",
 							Kind: client.FieldKind_NILLABLE_STRING,
@@ -1321,7 +1321,7 @@ func TestAutoGenerate_IfColDefinitionsAreValid_ShouldGenerate(t *testing.T) {
 			},
 			Schema: client.SchemaDescription{
 				Name: "User",
-				Fields: []client.FieldDescription{
+				Fields: []client.SchemaFieldDescription{
 					{
 						Name: "name",
 						Kind: client.FieldKind_NILLABLE_STRING,
@@ -1350,7 +1350,7 @@ func TestAutoGenerate_IfColDefinitionsAreValid_ShouldGenerate(t *testing.T) {
 			},
 			Schema: client.SchemaDescription{
 				Name: "Device",
-				Fields: []client.FieldDescription{
+				Fields: []client.SchemaFieldDescription{
 					{
 						Name: "model",
 						Kind: client.FieldKind_NILLABLE_STRING,

--- a/tests/integration/events/simple/with_update_test.go
+++ b/tests/integration/events/simple/with_update_test.go
@@ -66,14 +66,14 @@ func TestEventsSimpleWithUpdate(t *testing.T) {
 		ExpectedUpdates: []testUtils.ExpectedUpdate{
 			{
 				DocID: immutable.Some(docID1),
-				Cid:   immutable.Some("bafybeiffwlvaz742mg2ejv7v2qd62couktzrejfkzzedzw3djmxpvt5lvi"),
+				Cid:   immutable.Some("bafybeidzstxabh7qktq7pkmmxvpjbnwklxz3h5l6d425ldvjy65xvvuxu4"),
 			},
 			{
 				DocID: immutable.Some(docID2),
 			},
 			{
 				DocID: immutable.Some(docID1),
-				Cid:   immutable.Some("bafybeidzdbok2dutsjobk62jxgoqttk2omwazvh4ycvrz27ffg7dp4joo4"),
+				Cid:   immutable.Some("bafybeiah75qvtqxflw3urgejxetaugpcddx5h2ocj7pid34zjyy7tpp6wi"),
 			},
 		},
 	}

--- a/tests/integration/mutation/create/with_version_test.go
+++ b/tests/integration/mutation/create/with_version_test.go
@@ -39,7 +39,7 @@ func TestMutationCreate_ReturnsVersionCID(t *testing.T) {
 					{
 						"_version": []map[string]any{
 							{
-								"cid": "bafybeiffwlvaz742mg2ejv7v2qd62couktzrejfkzzedzw3djmxpvt5lvi",
+								"cid": "bafybeidzstxabh7qktq7pkmmxvpjbnwklxz3h5l6d425ldvjy65xvvuxu4",
 							},
 						},
 					},

--- a/tests/integration/net/state/simple/peer/subscribe/with_add_get_test.go
+++ b/tests/integration/net/state/simple/peer/subscribe/with_add_get_test.go
@@ -76,7 +76,7 @@ func TestP2PSubscribeAddGetMultiple(t *testing.T) {
 			},
 			testUtils.GetAllP2PCollections{
 				NodeID:                1,
-				ExpectedCollectionIDs: []int{2, 0},
+				ExpectedCollectionIDs: []int{0, 2},
 			},
 		},
 	}

--- a/tests/integration/net/state/simple/replicator/with_create_test.go
+++ b/tests/integration/net/state/simple/replicator/with_create_test.go
@@ -492,7 +492,7 @@ func TestP2POneToOneReplicatorOrderIndependent(t *testing.T) {
 						"name":   "John",
 						"_version": []map[string]any{
 							{
-								"schemaVersionId": "bafkreihh4zkyuqk4ibwb5utyayvbw75hdfkueg3scm7taysk3rbh2jhaee",
+								"schemaVersionId": "bafkreiewca6o66mgkpbai2vtrupolvtf66wllbvouvtwo6fkc6alrybzfa",
 							},
 						},
 					},
@@ -552,7 +552,7 @@ func TestP2POneToOneReplicatorOrderIndependentDirectCreate(t *testing.T) {
 						"_docID": "bae-f54b9689-e06e-5e3a-89b3-f3aee8e64ca7",
 						"_version": []map[string]any{
 							{
-								"schemaVersionId": "bafkreihh4zkyuqk4ibwb5utyayvbw75hdfkueg3scm7taysk3rbh2jhaee",
+								"schemaVersionId": "bafkreiewca6o66mgkpbai2vtrupolvtf66wllbvouvtwo6fkc6alrybzfa",
 							},
 						},
 					},

--- a/tests/integration/query/commits/simple_test.go
+++ b/tests/integration/query/commits/simple_test.go
@@ -36,13 +36,13 @@ func TestQueryCommits(t *testing.T) {
 					}`,
 				Results: []map[string]any{
 					{
-						"cid": "bafybeieikx6l2xead2dzsa5wwy5irxced2eddyq23jkp4csf5igoob7diq",
+						"cid": "bafybeicvpgfinf2m2jufbbcy5mhv6jca6in5k4fzx5op7xvvcmbp7sceaa",
 					},
 					{
-						"cid": "bafybeiehcr3diremeja2ndk2osux647v5fc7s353h7pbvrnsagw4paugku",
+						"cid": "bafybeib2espk2hq366wjnmazg45uvoswqbvf4plx7fgzayagxdn737onci",
 					},
 					{
-						"cid": "bafybeiggrv6gyhld2dbkspaxsenjejfhnk52pm4mlpyz2q6x4dlnaff2mu",
+						"cid": "bafybeigvpf62j7j2wbpid5iavzxielbhbsbbirmgzqkw3wpptdvysuztwi",
 					},
 				},
 			},
@@ -79,22 +79,22 @@ func TestQueryCommitsMultipleDocs(t *testing.T) {
 					}`,
 				Results: []map[string]any{
 					{
-						"cid": "bafybeifxmoq5yeukxrizqgncteztxao53d26ch6gqlyciakbrvlxwyob6a",
+						"cid": "bafybeibhain2764v7eltfiam6dgwivfj56mvbme34nbdsdbndrsjkc2cje",
 					},
 					{
-						"cid": "bafybeigkpb7jwgrsq3dq2nt2cnsarp3nq2ilefsuyz7jwcxfecot3qxwia",
+						"cid": "bafybeickrd5xayjhedyypf3yus55bkhpwd5dqlkdhivrcceexkpsgnic24",
 					},
 					{
-						"cid": "bafybeidacwdvdzz7y5r6lqsjgs3kom2zjnlarw6r3rgxlj3iw4kck4mer4",
+						"cid": "bafybeieqyyprwrkbgyn7x4jkzmlnupnzpdymvbulef37brkzn7blqbe6l4",
 					},
 					{
-						"cid": "bafybeieikx6l2xead2dzsa5wwy5irxced2eddyq23jkp4csf5igoob7diq",
+						"cid": "bafybeicvpgfinf2m2jufbbcy5mhv6jca6in5k4fzx5op7xvvcmbp7sceaa",
 					},
 					{
-						"cid": "bafybeiehcr3diremeja2ndk2osux647v5fc7s353h7pbvrnsagw4paugku",
+						"cid": "bafybeib2espk2hq366wjnmazg45uvoswqbvf4plx7fgzayagxdn737onci",
 					},
 					{
-						"cid": "bafybeiggrv6gyhld2dbkspaxsenjejfhnk52pm4mlpyz2q6x4dlnaff2mu",
+						"cid": "bafybeigvpf62j7j2wbpid5iavzxielbhbsbbirmgzqkw3wpptdvysuztwi",
 					},
 				},
 			},
@@ -125,16 +125,16 @@ func TestQueryCommitsWithSchemaVersionIdField(t *testing.T) {
 					}`,
 				Results: []map[string]any{
 					{
-						"cid":             "bafybeieikx6l2xead2dzsa5wwy5irxced2eddyq23jkp4csf5igoob7diq",
-						"schemaVersionId": "bafkreidjvyxputjthx4wzyxtk33fce3shqguif3yhifykilybpn6canony",
+						"cid":             "bafybeicvpgfinf2m2jufbbcy5mhv6jca6in5k4fzx5op7xvvcmbp7sceaa",
+						"schemaVersionId": "bafkreidqkjb23ngp34eebeaxiogrlogkpfz62vjb3clnnyvhlbgdaywkg4",
 					},
 					{
-						"cid":             "bafybeiehcr3diremeja2ndk2osux647v5fc7s353h7pbvrnsagw4paugku",
-						"schemaVersionId": "bafkreidjvyxputjthx4wzyxtk33fce3shqguif3yhifykilybpn6canony",
+						"cid":             "bafybeib2espk2hq366wjnmazg45uvoswqbvf4plx7fgzayagxdn737onci",
+						"schemaVersionId": "bafkreidqkjb23ngp34eebeaxiogrlogkpfz62vjb3clnnyvhlbgdaywkg4",
 					},
 					{
-						"cid":             "bafybeiggrv6gyhld2dbkspaxsenjejfhnk52pm4mlpyz2q6x4dlnaff2mu",
-						"schemaVersionId": "bafkreidjvyxputjthx4wzyxtk33fce3shqguif3yhifykilybpn6canony",
+						"cid":             "bafybeigvpf62j7j2wbpid5iavzxielbhbsbbirmgzqkw3wpptdvysuztwi",
+						"schemaVersionId": "bafkreidqkjb23ngp34eebeaxiogrlogkpfz62vjb3clnnyvhlbgdaywkg4",
 					},
 				},
 			},
@@ -349,7 +349,7 @@ func TestQuery_CommitsWithAllFieldsWithUpdate_NoError(t *testing.T) {
 				`,
 				Results: []map[string]any{
 					{
-						"cid":          "bafybeiddpjl27ulw2yo4ohup6gr2wob3pwagqw2rbeaxxodv4ljelnu7ve",
+						"cid":          "bafybeicwg56ddi7smy3j2kkv5y4yghvdrj3twqqafzdwtinbkw5mlpxwz4",
 						"collectionID": int64(1),
 						"delta":        testUtils.CBORValue(22),
 						"docID":        "bae-f54b9689-e06e-5e3a-89b3-f3aee8e64ca7",
@@ -358,13 +358,13 @@ func TestQuery_CommitsWithAllFieldsWithUpdate_NoError(t *testing.T) {
 						"height":       int64(2),
 						"links": []map[string]any{
 							{
-								"cid":  "bafybeieikx6l2xead2dzsa5wwy5irxced2eddyq23jkp4csf5igoob7diq",
+								"cid":  "bafybeicvpgfinf2m2jufbbcy5mhv6jca6in5k4fzx5op7xvvcmbp7sceaa",
 								"name": "_head",
 							},
 						},
 					},
 					{
-						"cid":          "bafybeieikx6l2xead2dzsa5wwy5irxced2eddyq23jkp4csf5igoob7diq",
+						"cid":          "bafybeicvpgfinf2m2jufbbcy5mhv6jca6in5k4fzx5op7xvvcmbp7sceaa",
 						"collectionID": int64(1),
 						"delta":        testUtils.CBORValue(21),
 						"docID":        "bae-f54b9689-e06e-5e3a-89b3-f3aee8e64ca7",
@@ -374,7 +374,7 @@ func TestQuery_CommitsWithAllFieldsWithUpdate_NoError(t *testing.T) {
 						"links":        []map[string]any{},
 					},
 					{
-						"cid":          "bafybeiehcr3diremeja2ndk2osux647v5fc7s353h7pbvrnsagw4paugku",
+						"cid":          "bafybeib2espk2hq366wjnmazg45uvoswqbvf4plx7fgzayagxdn737onci",
 						"collectionID": int64(1),
 						"delta":        testUtils.CBORValue("John"),
 						"docID":        "bae-f54b9689-e06e-5e3a-89b3-f3aee8e64ca7",
@@ -384,7 +384,7 @@ func TestQuery_CommitsWithAllFieldsWithUpdate_NoError(t *testing.T) {
 						"links":        []map[string]any{},
 					},
 					{
-						"cid":          "bafybeiekajrgheumrgamrc4mprmm66ulp2qr75sviowfcriuviggokydbm",
+						"cid":          "bafybeidxnkwhuzmkdw5wuippru3tp74vcmz5jvcziambpjadxeathdh26a",
 						"collectionID": int64(1),
 						"delta":        nil,
 						"docID":        "bae-f54b9689-e06e-5e3a-89b3-f3aee8e64ca7",
@@ -393,17 +393,17 @@ func TestQuery_CommitsWithAllFieldsWithUpdate_NoError(t *testing.T) {
 						"height":       int64(2),
 						"links": []map[string]any{
 							{
-								"cid":  "bafybeiggrv6gyhld2dbkspaxsenjejfhnk52pm4mlpyz2q6x4dlnaff2mu",
+								"cid":  "bafybeigvpf62j7j2wbpid5iavzxielbhbsbbirmgzqkw3wpptdvysuztwi",
 								"name": "_head",
 							},
 							{
-								"cid":  "bafybeiddpjl27ulw2yo4ohup6gr2wob3pwagqw2rbeaxxodv4ljelnu7ve",
+								"cid":  "bafybeicwg56ddi7smy3j2kkv5y4yghvdrj3twqqafzdwtinbkw5mlpxwz4",
 								"name": "age",
 							},
 						},
 					},
 					{
-						"cid":          "bafybeiggrv6gyhld2dbkspaxsenjejfhnk52pm4mlpyz2q6x4dlnaff2mu",
+						"cid":          "bafybeigvpf62j7j2wbpid5iavzxielbhbsbbirmgzqkw3wpptdvysuztwi",
 						"collectionID": int64(1),
 						"delta":        nil,
 						"docID":        "bae-f54b9689-e06e-5e3a-89b3-f3aee8e64ca7",
@@ -412,11 +412,11 @@ func TestQuery_CommitsWithAllFieldsWithUpdate_NoError(t *testing.T) {
 						"height":       int64(1),
 						"links": []map[string]any{
 							{
-								"cid":  "bafybeieikx6l2xead2dzsa5wwy5irxced2eddyq23jkp4csf5igoob7diq",
+								"cid":  "bafybeicvpgfinf2m2jufbbcy5mhv6jca6in5k4fzx5op7xvvcmbp7sceaa",
 								"name": "age",
 							},
 							{
-								"cid":  "bafybeiehcr3diremeja2ndk2osux647v5fc7s353h7pbvrnsagw4paugku",
+								"cid":  "bafybeib2espk2hq366wjnmazg45uvoswqbvf4plx7fgzayagxdn737onci",
 								"name": "name",
 							},
 						},

--- a/tests/integration/query/commits/with_cid_test.go
+++ b/tests/integration/query/commits/with_cid_test.go
@@ -38,14 +38,14 @@ func TestQueryCommitsWithCid(t *testing.T) {
 			testUtils.Request{
 				Request: `query {
 						commits(
-							cid: "bafybeiggrv6gyhld2dbkspaxsenjejfhnk52pm4mlpyz2q6x4dlnaff2mu"
+							cid: "bafybeigvpf62j7j2wbpid5iavzxielbhbsbbirmgzqkw3wpptdvysuztwi"
 						) {
 							cid
 						}
 					}`,
 				Results: []map[string]any{
 					{
-						"cid": "bafybeiggrv6gyhld2dbkspaxsenjejfhnk52pm4mlpyz2q6x4dlnaff2mu",
+						"cid": "bafybeigvpf62j7j2wbpid5iavzxielbhbsbbirmgzqkw3wpptdvysuztwi",
 					},
 				},
 			},
@@ -71,14 +71,14 @@ func TestQueryCommitsWithCidForFieldCommit(t *testing.T) {
 			testUtils.Request{
 				Request: `query {
 						commits(
-							cid: "bafybeiggrv6gyhld2dbkspaxsenjejfhnk52pm4mlpyz2q6x4dlnaff2mu"
+							cid: "bafybeigvpf62j7j2wbpid5iavzxielbhbsbbirmgzqkw3wpptdvysuztwi"
 						) {
 							cid
 						}
 					}`,
 				Results: []map[string]any{
 					{
-						"cid": "bafybeiggrv6gyhld2dbkspaxsenjejfhnk52pm4mlpyz2q6x4dlnaff2mu",
+						"cid": "bafybeigvpf62j7j2wbpid5iavzxielbhbsbbirmgzqkw3wpptdvysuztwi",
 					},
 				},
 			},

--- a/tests/integration/query/commits/with_depth_test.go
+++ b/tests/integration/query/commits/with_depth_test.go
@@ -36,13 +36,13 @@ func TestQueryCommitsWithDepth1(t *testing.T) {
 					}`,
 				Results: []map[string]any{
 					{
-						"cid": "bafybeieikx6l2xead2dzsa5wwy5irxced2eddyq23jkp4csf5igoob7diq",
+						"cid": "bafybeicvpgfinf2m2jufbbcy5mhv6jca6in5k4fzx5op7xvvcmbp7sceaa",
 					},
 					{
-						"cid": "bafybeiehcr3diremeja2ndk2osux647v5fc7s353h7pbvrnsagw4paugku",
+						"cid": "bafybeib2espk2hq366wjnmazg45uvoswqbvf4plx7fgzayagxdn737onci",
 					},
 					{
-						"cid": "bafybeiggrv6gyhld2dbkspaxsenjejfhnk52pm4mlpyz2q6x4dlnaff2mu",
+						"cid": "bafybeigvpf62j7j2wbpid5iavzxielbhbsbbirmgzqkw3wpptdvysuztwi",
 					},
 				},
 			},
@@ -81,16 +81,16 @@ func TestQueryCommitsWithDepth1WithUpdate(t *testing.T) {
 				Results: []map[string]any{
 					{
 						// "Age" field head
-						"cid":    "bafybeiddpjl27ulw2yo4ohup6gr2wob3pwagqw2rbeaxxodv4ljelnu7ve",
+						"cid":    "bafybeicwg56ddi7smy3j2kkv5y4yghvdrj3twqqafzdwtinbkw5mlpxwz4",
 						"height": int64(2),
 					},
 					{
 						// "Name" field head (unchanged from create)
-						"cid":    "bafybeiehcr3diremeja2ndk2osux647v5fc7s353h7pbvrnsagw4paugku",
+						"cid":    "bafybeib2espk2hq366wjnmazg45uvoswqbvf4plx7fgzayagxdn737onci",
 						"height": int64(1),
 					},
 					{
-						"cid":    "bafybeiekajrgheumrgamrc4mprmm66ulp2qr75sviowfcriuviggokydbm",
+						"cid":    "bafybeidxnkwhuzmkdw5wuippru3tp74vcmz5jvcziambpjadxeathdh26a",
 						"height": int64(2),
 					},
 				},
@@ -137,27 +137,27 @@ func TestQueryCommitsWithDepth2WithUpdate(t *testing.T) {
 				Results: []map[string]any{
 					{
 						// Composite head
-						"cid":    "bafybeibfip3j6fr755tjjhlmuqxqywlmgxbalgbnhggq3xj3xvtwe6f6jy",
+						"cid":    "bafybeic45wkhxtpn3vgd2dmmohq76vw56qz3cpu3oorha3hf2w6qu7bpoa",
 						"height": int64(3),
 					},
 					{
 						// Composite head -1
-						"cid":    "bafybeiddpjl27ulw2yo4ohup6gr2wob3pwagqw2rbeaxxodv4ljelnu7ve",
+						"cid":    "bafybeicwg56ddi7smy3j2kkv5y4yghvdrj3twqqafzdwtinbkw5mlpxwz4",
 						"height": int64(2),
 					},
 					{
 						// "Name" field head (unchanged from create)
-						"cid":    "bafybeiehcr3diremeja2ndk2osux647v5fc7s353h7pbvrnsagw4paugku",
+						"cid":    "bafybeib2espk2hq366wjnmazg45uvoswqbvf4plx7fgzayagxdn737onci",
 						"height": int64(1),
 					},
 					{
 						// "Age" field head
-						"cid":    "bafybeigomkxadtuj4vfkb7ix55d2qhnzh24wnxv4gqvbo2s5hdtyf2y7im",
+						"cid":    "bafybeid4y4vqmvec2mvm3su77rrmj6tzsx5zdlt6ias4hzqxbevmosydc4",
 						"height": int64(3),
 					},
 					{
 						// "Age" field head -1
-						"cid":    "bafybeiekajrgheumrgamrc4mprmm66ulp2qr75sviowfcriuviggokydbm",
+						"cid":    "bafybeidxnkwhuzmkdw5wuippru3tp74vcmz5jvcziambpjadxeathdh26a",
 						"height": int64(2),
 					},
 				},
@@ -195,22 +195,22 @@ func TestQueryCommitsWithDepth1AndMultipleDocs(t *testing.T) {
 					}`,
 				Results: []map[string]any{
 					{
-						"cid": "bafybeihf2bo3amfoojd3ihliafgtka4jxava5i6rmujktvzon2x4iuzzna",
+						"cid": "bafybeifysgo74dhzl2t74j5qh32t5uufar7otua6ggvsapjbxpzimcbnoi",
 					},
 					{
-						"cid": "bafybeic4lebzixuxdsgzqs4nvy6ont7sheognehdbmpr27ha2cvror6v4m",
+						"cid": "bafybeibqvujxi4tjtrwg5igvg6zdvjaxvkmb5h2msjbtta3lmytgs7hft4",
 					},
 					{
-						"cid": "bafybeietgsruk6dlepqsre27fripbsjnwawpmygnwdxsmpt5vb6q4mkdxi",
+						"cid": "bafybeib7zmofgbtvxcb3gy3bfbwp3btqrmoacmxl4duqhwlvwu6pihzbeu",
 					},
 					{
-						"cid": "bafybeieikx6l2xead2dzsa5wwy5irxced2eddyq23jkp4csf5igoob7diq",
+						"cid": "bafybeicvpgfinf2m2jufbbcy5mhv6jca6in5k4fzx5op7xvvcmbp7sceaa",
 					},
 					{
-						"cid": "bafybeiehcr3diremeja2ndk2osux647v5fc7s353h7pbvrnsagw4paugku",
+						"cid": "bafybeib2espk2hq366wjnmazg45uvoswqbvf4plx7fgzayagxdn737onci",
 					},
 					{
-						"cid": "bafybeiggrv6gyhld2dbkspaxsenjejfhnk52pm4mlpyz2q6x4dlnaff2mu",
+						"cid": "bafybeigvpf62j7j2wbpid5iavzxielbhbsbbirmgzqkw3wpptdvysuztwi",
 					},
 				},
 			},

--- a/tests/integration/query/commits/with_doc_id_cid_test.go
+++ b/tests/integration/query/commits/with_doc_id_cid_test.go
@@ -104,14 +104,14 @@ func TestQueryCommitsWithDocIDAndCidWithUpdate(t *testing.T) {
 				Request: ` {
 						commits(
 							docID: "bae-f54b9689-e06e-5e3a-89b3-f3aee8e64ca7",
-							cid: "bafybeiekajrgheumrgamrc4mprmm66ulp2qr75sviowfcriuviggokydbm"
+							cid: "bafybeidxnkwhuzmkdw5wuippru3tp74vcmz5jvcziambpjadxeathdh26a"
 						) {
 							cid
 						}
 					}`,
 				Results: []map[string]any{
 					{
-						"cid": "bafybeiekajrgheumrgamrc4mprmm66ulp2qr75sviowfcriuviggokydbm",
+						"cid": "bafybeidxnkwhuzmkdw5wuippru3tp74vcmz5jvcziambpjadxeathdh26a",
 					},
 				},
 			},

--- a/tests/integration/query/commits/with_doc_id_count_test.go
+++ b/tests/integration/query/commits/with_doc_id_count_test.go
@@ -37,15 +37,15 @@ func TestQueryCommitsWithDocIDAndLinkCount(t *testing.T) {
 					}`,
 				Results: []map[string]any{
 					{
-						"cid":    "bafybeieikx6l2xead2dzsa5wwy5irxced2eddyq23jkp4csf5igoob7diq",
+						"cid":    "bafybeicvpgfinf2m2jufbbcy5mhv6jca6in5k4fzx5op7xvvcmbp7sceaa",
 						"_count": 0,
 					},
 					{
-						"cid":    "bafybeiehcr3diremeja2ndk2osux647v5fc7s353h7pbvrnsagw4paugku",
+						"cid":    "bafybeib2espk2hq366wjnmazg45uvoswqbvf4plx7fgzayagxdn737onci",
 						"_count": 0,
 					},
 					{
-						"cid":    "bafybeiggrv6gyhld2dbkspaxsenjejfhnk52pm4mlpyz2q6x4dlnaff2mu",
+						"cid":    "bafybeigvpf62j7j2wbpid5iavzxielbhbsbbirmgzqkw3wpptdvysuztwi",
 						"_count": 2,
 					},
 				},

--- a/tests/integration/query/commits/with_doc_id_field_test.go
+++ b/tests/integration/query/commits/with_doc_id_field_test.go
@@ -118,7 +118,7 @@ func TestQueryCommitsWithDocIDAndFieldId(t *testing.T) {
 					}`,
 				Results: []map[string]any{
 					{
-						"cid": "bafybeieikx6l2xead2dzsa5wwy5irxced2eddyq23jkp4csf5igoob7diq",
+						"cid": "bafybeicvpgfinf2m2jufbbcy5mhv6jca6in5k4fzx5op7xvvcmbp7sceaa",
 					},
 				},
 			},
@@ -150,7 +150,7 @@ func TestQueryCommitsWithDocIDAndCompositeFieldId(t *testing.T) {
 					}`,
 				Results: []map[string]any{
 					{
-						"cid": "bafybeiggrv6gyhld2dbkspaxsenjejfhnk52pm4mlpyz2q6x4dlnaff2mu",
+						"cid": "bafybeigvpf62j7j2wbpid5iavzxielbhbsbbirmgzqkw3wpptdvysuztwi",
 					},
 				},
 			},

--- a/tests/integration/query/commits/with_doc_id_limit_offset_test.go
+++ b/tests/integration/query/commits/with_doc_id_limit_offset_test.go
@@ -57,10 +57,10 @@ func TestQueryCommitsWithDocIDAndLimitAndOffset(t *testing.T) {
 					}`,
 				Results: []map[string]any{
 					{
-						"cid": "bafybeibfip3j6fr755tjjhlmuqxqywlmgxbalgbnhggq3xj3xvtwe6f6jy",
+						"cid": "bafybeic45wkhxtpn3vgd2dmmohq76vw56qz3cpu3oorha3hf2w6qu7bpoa",
 					},
 					{
-						"cid": "bafybeiddpjl27ulw2yo4ohup6gr2wob3pwagqw2rbeaxxodv4ljelnu7ve",
+						"cid": "bafybeicwg56ddi7smy3j2kkv5y4yghvdrj3twqqafzdwtinbkw5mlpxwz4",
 					},
 				},
 			},

--- a/tests/integration/query/commits/with_doc_id_limit_test.go
+++ b/tests/integration/query/commits/with_doc_id_limit_test.go
@@ -50,10 +50,10 @@ func TestQueryCommitsWithDocIDAndLimit(t *testing.T) {
 					}`,
 				Results: []map[string]any{
 					{
-						"cid": "bafybeibfip3j6fr755tjjhlmuqxqywlmgxbalgbnhggq3xj3xvtwe6f6jy",
+						"cid": "bafybeic45wkhxtpn3vgd2dmmohq76vw56qz3cpu3oorha3hf2w6qu7bpoa",
 					},
 					{
-						"cid": "bafybeiddpjl27ulw2yo4ohup6gr2wob3pwagqw2rbeaxxodv4ljelnu7ve",
+						"cid": "bafybeicwg56ddi7smy3j2kkv5y4yghvdrj3twqqafzdwtinbkw5mlpxwz4",
 					},
 				},
 			},

--- a/tests/integration/query/commits/with_doc_id_order_limit_offset_test.go
+++ b/tests/integration/query/commits/with_doc_id_order_limit_offset_test.go
@@ -58,11 +58,11 @@ func TestQueryCommitsWithDocIDAndOrderAndLimitAndOffset(t *testing.T) {
 					}`,
 				Results: []map[string]any{
 					{
-						"cid":    "bafybeiekajrgheumrgamrc4mprmm66ulp2qr75sviowfcriuviggokydbm",
+						"cid":    "bafybeidxnkwhuzmkdw5wuippru3tp74vcmz5jvcziambpjadxeathdh26a",
 						"height": int64(2),
 					},
 					{
-						"cid":    "bafybeibfip3j6fr755tjjhlmuqxqywlmgxbalgbnhggq3xj3xvtwe6f6jy",
+						"cid":    "bafybeic45wkhxtpn3vgd2dmmohq76vw56qz3cpu3oorha3hf2w6qu7bpoa",
 						"height": int64(3),
 					},
 				},

--- a/tests/integration/query/commits/with_doc_id_order_test.go
+++ b/tests/integration/query/commits/with_doc_id_order_test.go
@@ -44,23 +44,23 @@ func TestQueryCommitsWithDocIDAndOrderHeightDesc(t *testing.T) {
 					}`,
 				Results: []map[string]any{
 					{
-						"cid":    "bafybeiddpjl27ulw2yo4ohup6gr2wob3pwagqw2rbeaxxodv4ljelnu7ve",
+						"cid":    "bafybeicwg56ddi7smy3j2kkv5y4yghvdrj3twqqafzdwtinbkw5mlpxwz4",
 						"height": int64(2),
 					},
 					{
-						"cid":    "bafybeiekajrgheumrgamrc4mprmm66ulp2qr75sviowfcriuviggokydbm",
+						"cid":    "bafybeidxnkwhuzmkdw5wuippru3tp74vcmz5jvcziambpjadxeathdh26a",
 						"height": int64(2),
 					},
 					{
-						"cid":    "bafybeieikx6l2xead2dzsa5wwy5irxced2eddyq23jkp4csf5igoob7diq",
+						"cid":    "bafybeicvpgfinf2m2jufbbcy5mhv6jca6in5k4fzx5op7xvvcmbp7sceaa",
 						"height": int64(1),
 					},
 					{
-						"cid":    "bafybeiehcr3diremeja2ndk2osux647v5fc7s353h7pbvrnsagw4paugku",
+						"cid":    "bafybeib2espk2hq366wjnmazg45uvoswqbvf4plx7fgzayagxdn737onci",
 						"height": int64(1),
 					},
 					{
-						"cid":    "bafybeiggrv6gyhld2dbkspaxsenjejfhnk52pm4mlpyz2q6x4dlnaff2mu",
+						"cid":    "bafybeigvpf62j7j2wbpid5iavzxielbhbsbbirmgzqkw3wpptdvysuztwi",
 						"height": int64(1),
 					},
 				},
@@ -99,23 +99,23 @@ func TestQueryCommitsWithDocIDAndOrderHeightAsc(t *testing.T) {
 					}`,
 				Results: []map[string]any{
 					{
-						"cid":    "bafybeieikx6l2xead2dzsa5wwy5irxced2eddyq23jkp4csf5igoob7diq",
+						"cid":    "bafybeicvpgfinf2m2jufbbcy5mhv6jca6in5k4fzx5op7xvvcmbp7sceaa",
 						"height": int64(1),
 					},
 					{
-						"cid":    "bafybeiehcr3diremeja2ndk2osux647v5fc7s353h7pbvrnsagw4paugku",
+						"cid":    "bafybeib2espk2hq366wjnmazg45uvoswqbvf4plx7fgzayagxdn737onci",
 						"height": int64(1),
 					},
 					{
-						"cid":    "bafybeiggrv6gyhld2dbkspaxsenjejfhnk52pm4mlpyz2q6x4dlnaff2mu",
+						"cid":    "bafybeigvpf62j7j2wbpid5iavzxielbhbsbbirmgzqkw3wpptdvysuztwi",
 						"height": int64(1),
 					},
 					{
-						"cid":    "bafybeiddpjl27ulw2yo4ohup6gr2wob3pwagqw2rbeaxxodv4ljelnu7ve",
+						"cid":    "bafybeicwg56ddi7smy3j2kkv5y4yghvdrj3twqqafzdwtinbkw5mlpxwz4",
 						"height": int64(2),
 					},
 					{
-						"cid":    "bafybeiekajrgheumrgamrc4mprmm66ulp2qr75sviowfcriuviggokydbm",
+						"cid":    "bafybeidxnkwhuzmkdw5wuippru3tp74vcmz5jvcziambpjadxeathdh26a",
 						"height": int64(2),
 					},
 				},
@@ -154,24 +154,24 @@ func TestQueryCommitsWithDocIDAndOrderCidDesc(t *testing.T) {
 					}`,
 				Results: []map[string]any{
 					{
-						"cid":    "bafybeiggrv6gyhld2dbkspaxsenjejfhnk52pm4mlpyz2q6x4dlnaff2mu",
+						"cid":    "bafybeigvpf62j7j2wbpid5iavzxielbhbsbbirmgzqkw3wpptdvysuztwi",
 						"height": int64(1),
 					},
 					{
-						"cid":    "bafybeiekajrgheumrgamrc4mprmm66ulp2qr75sviowfcriuviggokydbm",
+						"cid":    "bafybeidxnkwhuzmkdw5wuippru3tp74vcmz5jvcziambpjadxeathdh26a",
 						"height": int64(2),
 					},
 					{
-						"cid":    "bafybeieikx6l2xead2dzsa5wwy5irxced2eddyq23jkp4csf5igoob7diq",
-						"height": int64(1),
-					},
-					{
-						"cid":    "bafybeiehcr3diremeja2ndk2osux647v5fc7s353h7pbvrnsagw4paugku",
-						"height": int64(1),
-					},
-					{
-						"cid":    "bafybeiddpjl27ulw2yo4ohup6gr2wob3pwagqw2rbeaxxodv4ljelnu7ve",
+						"cid":    "bafybeicwg56ddi7smy3j2kkv5y4yghvdrj3twqqafzdwtinbkw5mlpxwz4",
 						"height": int64(2),
+					},
+					{
+						"cid":    "bafybeicvpgfinf2m2jufbbcy5mhv6jca6in5k4fzx5op7xvvcmbp7sceaa",
+						"height": int64(1),
+					},
+					{
+						"cid":    "bafybeib2espk2hq366wjnmazg45uvoswqbvf4plx7fgzayagxdn737onci",
+						"height": int64(1),
 					},
 				},
 			},
@@ -209,23 +209,23 @@ func TestQueryCommitsWithDocIDAndOrderCidAsc(t *testing.T) {
 					}`,
 				Results: []map[string]any{
 					{
-						"cid":    "bafybeiddpjl27ulw2yo4ohup6gr2wob3pwagqw2rbeaxxodv4ljelnu7ve",
-						"height": int64(2),
-					},
-					{
-						"cid":    "bafybeiehcr3diremeja2ndk2osux647v5fc7s353h7pbvrnsagw4paugku",
+						"cid":    "bafybeib2espk2hq366wjnmazg45uvoswqbvf4plx7fgzayagxdn737onci",
 						"height": int64(1),
 					},
 					{
-						"cid":    "bafybeieikx6l2xead2dzsa5wwy5irxced2eddyq23jkp4csf5igoob7diq",
+						"cid":    "bafybeicvpgfinf2m2jufbbcy5mhv6jca6in5k4fzx5op7xvvcmbp7sceaa",
 						"height": int64(1),
 					},
 					{
-						"cid":    "bafybeiekajrgheumrgamrc4mprmm66ulp2qr75sviowfcriuviggokydbm",
+						"cid":    "bafybeicwg56ddi7smy3j2kkv5y4yghvdrj3twqqafzdwtinbkw5mlpxwz4",
 						"height": int64(2),
 					},
 					{
-						"cid":    "bafybeiggrv6gyhld2dbkspaxsenjejfhnk52pm4mlpyz2q6x4dlnaff2mu",
+						"cid":    "bafybeidxnkwhuzmkdw5wuippru3tp74vcmz5jvcziambpjadxeathdh26a",
+						"height": int64(2),
+					},
+					{
+						"cid":    "bafybeigvpf62j7j2wbpid5iavzxielbhbsbbirmgzqkw3wpptdvysuztwi",
 						"height": int64(1),
 					},
 				},
@@ -278,39 +278,39 @@ func TestQueryCommitsWithDocIDAndOrderAndMultiUpdatesCidAsc(t *testing.T) {
 					 }`,
 				Results: []map[string]any{
 					{
-						"cid":    "bafybeieikx6l2xead2dzsa5wwy5irxced2eddyq23jkp4csf5igoob7diq",
+						"cid":    "bafybeicvpgfinf2m2jufbbcy5mhv6jca6in5k4fzx5op7xvvcmbp7sceaa",
 						"height": int64(1),
 					},
 					{
-						"cid":    "bafybeiehcr3diremeja2ndk2osux647v5fc7s353h7pbvrnsagw4paugku",
+						"cid":    "bafybeib2espk2hq366wjnmazg45uvoswqbvf4plx7fgzayagxdn737onci",
 						"height": int64(1),
 					},
 					{
-						"cid":    "bafybeiggrv6gyhld2dbkspaxsenjejfhnk52pm4mlpyz2q6x4dlnaff2mu",
+						"cid":    "bafybeigvpf62j7j2wbpid5iavzxielbhbsbbirmgzqkw3wpptdvysuztwi",
 						"height": int64(1),
 					},
 					{
-						"cid":    "bafybeiddpjl27ulw2yo4ohup6gr2wob3pwagqw2rbeaxxodv4ljelnu7ve",
+						"cid":    "bafybeicwg56ddi7smy3j2kkv5y4yghvdrj3twqqafzdwtinbkw5mlpxwz4",
 						"height": int64(2),
 					},
 					{
-						"cid":    "bafybeiekajrgheumrgamrc4mprmm66ulp2qr75sviowfcriuviggokydbm",
+						"cid":    "bafybeidxnkwhuzmkdw5wuippru3tp74vcmz5jvcziambpjadxeathdh26a",
 						"height": int64(2),
 					},
 					{
-						"cid":    "bafybeibfip3j6fr755tjjhlmuqxqywlmgxbalgbnhggq3xj3xvtwe6f6jy",
+						"cid":    "bafybeic45wkhxtpn3vgd2dmmohq76vw56qz3cpu3oorha3hf2w6qu7bpoa",
 						"height": int64(3),
 					},
 					{
-						"cid":    "bafybeigomkxadtuj4vfkb7ix55d2qhnzh24wnxv4gqvbo2s5hdtyf2y7im",
+						"cid":    "bafybeid4y4vqmvec2mvm3su77rrmj6tzsx5zdlt6ias4hzqxbevmosydc4",
 						"height": int64(3),
 					},
 					{
-						"cid":    "bafybeigrdrat2xyrfzryclfequ5isakqorz6oedvq2vl6cjektcpmmt7fm",
+						"cid":    "bafybeiatfviresatclvedt6zhk4ys7p6cdts5udqsl33nu5d2hxtw4l6la",
 						"height": int64(4),
 					},
 					{
-						"cid":    "bafybeibvbwkak42qyfgwg6rnlfelhovriqucsuq2kz77d6z7h7m46k4sdi",
+						"cid":    "bafybeiaydxxf7bmeh5ou47z6exa73heg6vjjzznbvrxqbemmu55sdhvuom",
 						"height": int64(4),
 					},
 				},

--- a/tests/integration/query/commits/with_doc_id_test.go
+++ b/tests/integration/query/commits/with_doc_id_test.go
@@ -62,13 +62,13 @@ func TestQueryCommitsWithDocID(t *testing.T) {
 					}`,
 				Results: []map[string]any{
 					{
-						"cid": "bafybeieikx6l2xead2dzsa5wwy5irxced2eddyq23jkp4csf5igoob7diq",
+						"cid": "bafybeicvpgfinf2m2jufbbcy5mhv6jca6in5k4fzx5op7xvvcmbp7sceaa",
 					},
 					{
-						"cid": "bafybeiehcr3diremeja2ndk2osux647v5fc7s353h7pbvrnsagw4paugku",
+						"cid": "bafybeib2espk2hq366wjnmazg45uvoswqbvf4plx7fgzayagxdn737onci",
 					},
 					{
-						"cid": "bafybeiggrv6gyhld2dbkspaxsenjejfhnk52pm4mlpyz2q6x4dlnaff2mu",
+						"cid": "bafybeigvpf62j7j2wbpid5iavzxielbhbsbbirmgzqkw3wpptdvysuztwi",
 					},
 				},
 			},
@@ -102,22 +102,22 @@ func TestQueryCommitsWithDocIDAndLinks(t *testing.T) {
 					}`,
 				Results: []map[string]any{
 					{
-						"cid":   "bafybeieikx6l2xead2dzsa5wwy5irxced2eddyq23jkp4csf5igoob7diq",
+						"cid":   "bafybeicvpgfinf2m2jufbbcy5mhv6jca6in5k4fzx5op7xvvcmbp7sceaa",
 						"links": []map[string]any{},
 					},
 					{
-						"cid":   "bafybeiehcr3diremeja2ndk2osux647v5fc7s353h7pbvrnsagw4paugku",
+						"cid":   "bafybeib2espk2hq366wjnmazg45uvoswqbvf4plx7fgzayagxdn737onci",
 						"links": []map[string]any{},
 					},
 					{
-						"cid": "bafybeiggrv6gyhld2dbkspaxsenjejfhnk52pm4mlpyz2q6x4dlnaff2mu",
+						"cid": "bafybeigvpf62j7j2wbpid5iavzxielbhbsbbirmgzqkw3wpptdvysuztwi",
 						"links": []map[string]any{
 							{
-								"cid":  "bafybeieikx6l2xead2dzsa5wwy5irxced2eddyq23jkp4csf5igoob7diq",
+								"cid":  "bafybeicvpgfinf2m2jufbbcy5mhv6jca6in5k4fzx5op7xvvcmbp7sceaa",
 								"name": "age",
 							},
 							{
-								"cid":  "bafybeiehcr3diremeja2ndk2osux647v5fc7s353h7pbvrnsagw4paugku",
+								"cid":  "bafybeib2espk2hq366wjnmazg45uvoswqbvf4plx7fgzayagxdn737onci",
 								"name": "name",
 							},
 						},
@@ -158,23 +158,23 @@ func TestQueryCommitsWithDocIDAndUpdate(t *testing.T) {
 					}`,
 				Results: []map[string]any{
 					{
-						"cid":    "bafybeiddpjl27ulw2yo4ohup6gr2wob3pwagqw2rbeaxxodv4ljelnu7ve",
+						"cid":    "bafybeicwg56ddi7smy3j2kkv5y4yghvdrj3twqqafzdwtinbkw5mlpxwz4",
 						"height": int64(2),
 					},
 					{
-						"cid":    "bafybeieikx6l2xead2dzsa5wwy5irxced2eddyq23jkp4csf5igoob7diq",
+						"cid":    "bafybeicvpgfinf2m2jufbbcy5mhv6jca6in5k4fzx5op7xvvcmbp7sceaa",
 						"height": int64(1),
 					},
 					{
-						"cid":    "bafybeiehcr3diremeja2ndk2osux647v5fc7s353h7pbvrnsagw4paugku",
+						"cid":    "bafybeib2espk2hq366wjnmazg45uvoswqbvf4plx7fgzayagxdn737onci",
 						"height": int64(1),
 					},
 					{
-						"cid":    "bafybeiekajrgheumrgamrc4mprmm66ulp2qr75sviowfcriuviggokydbm",
+						"cid":    "bafybeidxnkwhuzmkdw5wuippru3tp74vcmz5jvcziambpjadxeathdh26a",
 						"height": int64(2),
 					},
 					{
-						"cid":    "bafybeiggrv6gyhld2dbkspaxsenjejfhnk52pm4mlpyz2q6x4dlnaff2mu",
+						"cid":    "bafybeigvpf62j7j2wbpid5iavzxielbhbsbbirmgzqkw3wpptdvysuztwi",
 						"height": int64(1),
 					},
 				},
@@ -219,44 +219,44 @@ func TestQueryCommitsWithDocIDAndUpdateAndLinks(t *testing.T) {
 					}`,
 				Results: []map[string]any{
 					{
-						"cid": "bafybeiddpjl27ulw2yo4ohup6gr2wob3pwagqw2rbeaxxodv4ljelnu7ve",
+						"cid": "bafybeicwg56ddi7smy3j2kkv5y4yghvdrj3twqqafzdwtinbkw5mlpxwz4",
 						"links": []map[string]any{
 							{
-								"cid":  "bafybeieikx6l2xead2dzsa5wwy5irxced2eddyq23jkp4csf5igoob7diq",
+								"cid":  "bafybeicvpgfinf2m2jufbbcy5mhv6jca6in5k4fzx5op7xvvcmbp7sceaa",
 								"name": "_head",
 							},
 						},
 					},
 					{
-						"cid":   "bafybeieikx6l2xead2dzsa5wwy5irxced2eddyq23jkp4csf5igoob7diq",
+						"cid":   "bafybeicvpgfinf2m2jufbbcy5mhv6jca6in5k4fzx5op7xvvcmbp7sceaa",
 						"links": []map[string]any{},
 					},
 					{
-						"cid":   "bafybeiehcr3diremeja2ndk2osux647v5fc7s353h7pbvrnsagw4paugku",
+						"cid":   "bafybeib2espk2hq366wjnmazg45uvoswqbvf4plx7fgzayagxdn737onci",
 						"links": []map[string]any{},
 					},
 					{
-						"cid": "bafybeiekajrgheumrgamrc4mprmm66ulp2qr75sviowfcriuviggokydbm",
+						"cid": "bafybeidxnkwhuzmkdw5wuippru3tp74vcmz5jvcziambpjadxeathdh26a",
 						"links": []map[string]any{
 							{
-								"cid":  "bafybeiggrv6gyhld2dbkspaxsenjejfhnk52pm4mlpyz2q6x4dlnaff2mu",
+								"cid":  "bafybeigvpf62j7j2wbpid5iavzxielbhbsbbirmgzqkw3wpptdvysuztwi",
 								"name": "_head",
 							},
 							{
-								"cid":  "bafybeiddpjl27ulw2yo4ohup6gr2wob3pwagqw2rbeaxxodv4ljelnu7ve",
+								"cid":  "bafybeicwg56ddi7smy3j2kkv5y4yghvdrj3twqqafzdwtinbkw5mlpxwz4",
 								"name": "age",
 							},
 						},
 					},
 					{
-						"cid": "bafybeiggrv6gyhld2dbkspaxsenjejfhnk52pm4mlpyz2q6x4dlnaff2mu",
+						"cid": "bafybeigvpf62j7j2wbpid5iavzxielbhbsbbirmgzqkw3wpptdvysuztwi",
 						"links": []map[string]any{
 							{
-								"cid":  "bafybeieikx6l2xead2dzsa5wwy5irxced2eddyq23jkp4csf5igoob7diq",
+								"cid":  "bafybeicvpgfinf2m2jufbbcy5mhv6jca6in5k4fzx5op7xvvcmbp7sceaa",
 								"name": "age",
 							},
 							{
-								"cid":  "bafybeiehcr3diremeja2ndk2osux647v5fc7s353h7pbvrnsagw4paugku",
+								"cid":  "bafybeib2espk2hq366wjnmazg45uvoswqbvf4plx7fgzayagxdn737onci",
 								"name": "name",
 							},
 						},

--- a/tests/integration/query/commits/with_doc_id_typename_test.go
+++ b/tests/integration/query/commits/with_doc_id_typename_test.go
@@ -37,15 +37,15 @@ func TestQueryCommitsWithDocIDWithTypeName(t *testing.T) {
 					}`,
 				Results: []map[string]any{
 					{
-						"cid":        "bafybeieikx6l2xead2dzsa5wwy5irxced2eddyq23jkp4csf5igoob7diq",
+						"cid":        "bafybeicvpgfinf2m2jufbbcy5mhv6jca6in5k4fzx5op7xvvcmbp7sceaa",
 						"__typename": "Commit",
 					},
 					{
-						"cid":        "bafybeiehcr3diremeja2ndk2osux647v5fc7s353h7pbvrnsagw4paugku",
+						"cid":        "bafybeib2espk2hq366wjnmazg45uvoswqbvf4plx7fgzayagxdn737onci",
 						"__typename": "Commit",
 					},
 					{
-						"cid":        "bafybeiggrv6gyhld2dbkspaxsenjejfhnk52pm4mlpyz2q6x4dlnaff2mu",
+						"cid":        "bafybeigvpf62j7j2wbpid5iavzxielbhbsbbirmgzqkw3wpptdvysuztwi",
 						"__typename": "Commit",
 					},
 				},

--- a/tests/integration/query/commits/with_field_test.go
+++ b/tests/integration/query/commits/with_field_test.go
@@ -66,7 +66,7 @@ func TestQueryCommitsWithFieldId(t *testing.T) {
 					}`,
 				Results: []map[string]any{
 					{
-						"cid": "bafybeieikx6l2xead2dzsa5wwy5irxced2eddyq23jkp4csf5igoob7diq",
+						"cid": "bafybeicvpgfinf2m2jufbbcy5mhv6jca6in5k4fzx5op7xvvcmbp7sceaa",
 					},
 				},
 			},
@@ -98,7 +98,7 @@ func TestQueryCommitsWithCompositeFieldId(t *testing.T) {
 					}`,
 				Results: []map[string]any{
 					{
-						"cid": "bafybeiggrv6gyhld2dbkspaxsenjejfhnk52pm4mlpyz2q6x4dlnaff2mu",
+						"cid": "bafybeigvpf62j7j2wbpid5iavzxielbhbsbbirmgzqkw3wpptdvysuztwi",
 					},
 				},
 			},
@@ -131,8 +131,8 @@ func TestQueryCommitsWithCompositeFieldIdWithReturnedSchemaVersionId(t *testing.
 					}`,
 				Results: []map[string]any{
 					{
-						"cid":             "bafybeiggrv6gyhld2dbkspaxsenjejfhnk52pm4mlpyz2q6x4dlnaff2mu",
-						"schemaVersionId": "bafkreidjvyxputjthx4wzyxtk33fce3shqguif3yhifykilybpn6canony",
+						"cid":             "bafybeigvpf62j7j2wbpid5iavzxielbhbsbbirmgzqkw3wpptdvysuztwi",
+						"schemaVersionId": "bafkreidqkjb23ngp34eebeaxiogrlogkpfz62vjb3clnnyvhlbgdaywkg4",
 					},
 				},
 			},

--- a/tests/integration/query/commits/with_group_test.go
+++ b/tests/integration/query/commits/with_group_test.go
@@ -89,10 +89,10 @@ func TestQueryCommitsWithGroupByHeightWithChild(t *testing.T) {
 						"height": int64(2),
 						"_group": []map[string]any{
 							{
-								"cid": "bafybeiddpjl27ulw2yo4ohup6gr2wob3pwagqw2rbeaxxodv4ljelnu7ve",
+								"cid": "bafybeicwg56ddi7smy3j2kkv5y4yghvdrj3twqqafzdwtinbkw5mlpxwz4",
 							},
 							{
-								"cid": "bafybeiekajrgheumrgamrc4mprmm66ulp2qr75sviowfcriuviggokydbm",
+								"cid": "bafybeidxnkwhuzmkdw5wuippru3tp74vcmz5jvcziambpjadxeathdh26a",
 							},
 						},
 					},
@@ -100,13 +100,13 @@ func TestQueryCommitsWithGroupByHeightWithChild(t *testing.T) {
 						"height": int64(1),
 						"_group": []map[string]any{
 							{
-								"cid": "bafybeieikx6l2xead2dzsa5wwy5irxced2eddyq23jkp4csf5igoob7diq",
+								"cid": "bafybeicvpgfinf2m2jufbbcy5mhv6jca6in5k4fzx5op7xvvcmbp7sceaa",
 							},
 							{
-								"cid": "bafybeiehcr3diremeja2ndk2osux647v5fc7s353h7pbvrnsagw4paugku",
+								"cid": "bafybeib2espk2hq366wjnmazg45uvoswqbvf4plx7fgzayagxdn737onci",
 							},
 							{
-								"cid": "bafybeiggrv6gyhld2dbkspaxsenjejfhnk52pm4mlpyz2q6x4dlnaff2mu",
+								"cid": "bafybeigvpf62j7j2wbpid5iavzxielbhbsbbirmgzqkw3wpptdvysuztwi",
 							},
 						},
 					},
@@ -142,7 +142,7 @@ func TestQueryCommitsWithGroupByCidWithChild(t *testing.T) {
 					}`,
 				Results: []map[string]any{
 					{
-						"cid": "bafybeieikx6l2xead2dzsa5wwy5irxced2eddyq23jkp4csf5igoob7diq",
+						"cid": "bafybeicvpgfinf2m2jufbbcy5mhv6jca6in5k4fzx5op7xvvcmbp7sceaa",
 						"_group": []map[string]any{
 							{
 								"height": int64(1),
@@ -150,7 +150,7 @@ func TestQueryCommitsWithGroupByCidWithChild(t *testing.T) {
 						},
 					},
 					{
-						"cid": "bafybeiehcr3diremeja2ndk2osux647v5fc7s353h7pbvrnsagw4paugku",
+						"cid": "bafybeib2espk2hq366wjnmazg45uvoswqbvf4plx7fgzayagxdn737onci",
 						"_group": []map[string]any{
 							{
 								"height": int64(1),
@@ -158,7 +158,7 @@ func TestQueryCommitsWithGroupByCidWithChild(t *testing.T) {
 						},
 					},
 					{
-						"cid": "bafybeiggrv6gyhld2dbkspaxsenjejfhnk52pm4mlpyz2q6x4dlnaff2mu",
+						"cid": "bafybeigvpf62j7j2wbpid5iavzxielbhbsbbirmgzqkw3wpptdvysuztwi",
 						"_group": []map[string]any{
 							{
 								"height": int64(1),

--- a/tests/integration/query/latest_commits/with_doc_id_field_test.go
+++ b/tests/integration/query/latest_commits/with_doc_id_field_test.go
@@ -68,7 +68,7 @@ func TestQueryLatestCommitsWithDocIDAndFieldId(t *testing.T) {
 		},
 		Results: []map[string]any{
 			{
-				"cid":   "bafybeieikx6l2xead2dzsa5wwy5irxced2eddyq23jkp4csf5igoob7diq",
+				"cid":   "bafybeicvpgfinf2m2jufbbcy5mhv6jca6in5k4fzx5op7xvvcmbp7sceaa",
 				"links": []map[string]any{},
 			},
 		},
@@ -101,14 +101,14 @@ func TestQueryLatestCommitsWithDocIDAndCompositeFieldId(t *testing.T) {
 		},
 		Results: []map[string]any{
 			{
-				"cid": "bafybeiggrv6gyhld2dbkspaxsenjejfhnk52pm4mlpyz2q6x4dlnaff2mu",
+				"cid": "bafybeigvpf62j7j2wbpid5iavzxielbhbsbbirmgzqkw3wpptdvysuztwi",
 				"links": []map[string]any{
 					{
-						"cid":  "bafybeieikx6l2xead2dzsa5wwy5irxced2eddyq23jkp4csf5igoob7diq",
+						"cid":  "bafybeicvpgfinf2m2jufbbcy5mhv6jca6in5k4fzx5op7xvvcmbp7sceaa",
 						"name": "age",
 					},
 					{
-						"cid":  "bafybeiehcr3diremeja2ndk2osux647v5fc7s353h7pbvrnsagw4paugku",
+						"cid":  "bafybeib2espk2hq366wjnmazg45uvoswqbvf4plx7fgzayagxdn737onci",
 						"name": "name",
 					},
 				},

--- a/tests/integration/query/latest_commits/with_doc_id_test.go
+++ b/tests/integration/query/latest_commits/with_doc_id_test.go
@@ -38,14 +38,14 @@ func TestQueryLatestCommitsWithDocID(t *testing.T) {
 		},
 		Results: []map[string]any{
 			{
-				"cid": "bafybeiggrv6gyhld2dbkspaxsenjejfhnk52pm4mlpyz2q6x4dlnaff2mu",
+				"cid": "bafybeigvpf62j7j2wbpid5iavzxielbhbsbbirmgzqkw3wpptdvysuztwi",
 				"links": []map[string]any{
 					{
-						"cid":  "bafybeieikx6l2xead2dzsa5wwy5irxced2eddyq23jkp4csf5igoob7diq",
+						"cid":  "bafybeicvpgfinf2m2jufbbcy5mhv6jca6in5k4fzx5op7xvvcmbp7sceaa",
 						"name": "age",
 					},
 					{
-						"cid":  "bafybeiehcr3diremeja2ndk2osux647v5fc7s353h7pbvrnsagw4paugku",
+						"cid":  "bafybeib2espk2hq366wjnmazg45uvoswqbvf4plx7fgzayagxdn737onci",
 						"name": "name",
 					},
 				},
@@ -75,8 +75,8 @@ func TestQueryLatestCommitsWithDocIDWithSchemaVersionIdField(t *testing.T) {
 		},
 		Results: []map[string]any{
 			{
-				"cid":             "bafybeiggrv6gyhld2dbkspaxsenjejfhnk52pm4mlpyz2q6x4dlnaff2mu",
-				"schemaVersionId": "bafkreidjvyxputjthx4wzyxtk33fce3shqguif3yhifykilybpn6canony",
+				"cid":             "bafybeigvpf62j7j2wbpid5iavzxielbhbsbbirmgzqkw3wpptdvysuztwi",
+				"schemaVersionId": "bafkreidqkjb23ngp34eebeaxiogrlogkpfz62vjb3clnnyvhlbgdaywkg4",
 			},
 		},
 	}

--- a/tests/integration/query/one_to_many/with_cid_doc_id_test.go
+++ b/tests/integration/query/one_to_many/with_cid_doc_id_test.go
@@ -68,7 +68,7 @@ func TestQueryOneToManyWithCidAndDocID(t *testing.T) {
 		Description: "One-to-many relation query from one side with cid and docID",
 		Request: `query {
 					Book (
-							cid: "bafybeic2p6yvejdoprdkjtg5yy3lgs7t2hk5gfw4zzdl76f63befyh3imi"
+							cid: "bafybeidshqlc7z2psrtfhmrarsxwxwwis6baxjrzs2x6mdmzsop6b7hnii"
 							docID: "bae-b9b83269-1f28-5c3b-ae75-3fb4c00d559d"
 						) {
 						name
@@ -117,7 +117,7 @@ func TestQueryOneToManyWithChildUpdateAndFirstCidAndDocID(t *testing.T) {
 		Description: "One-to-many relation query from one side with child update and parent cid and docID",
 		Request: `query {
 					Book (
-							cid: "bafybeic2p6yvejdoprdkjtg5yy3lgs7t2hk5gfw4zzdl76f63befyh3imi",
+							cid: "bafybeidshqlc7z2psrtfhmrarsxwxwwis6baxjrzs2x6mdmzsop6b7hnii",
 							docID: "bae-b9b83269-1f28-5c3b-ae75-3fb4c00d559d"
 						) {
 						name
@@ -173,7 +173,7 @@ func TestQueryOneToManyWithParentUpdateAndFirstCidAndDocID(t *testing.T) {
 		Description: "One-to-many relation query from one side with parent update and parent cid and docID",
 		Request: `query {
 					Book (
-							cid: "bafybeic2p6yvejdoprdkjtg5yy3lgs7t2hk5gfw4zzdl76f63befyh3imi",
+							cid: "bafybeidshqlc7z2psrtfhmrarsxwxwwis6baxjrzs2x6mdmzsop6b7hnii",
 							docID: "bae-b9b83269-1f28-5c3b-ae75-3fb4c00d559d"
 						) {
 						name
@@ -225,7 +225,7 @@ func TestQueryOneToManyWithParentUpdateAndLastCidAndDocID(t *testing.T) {
 		Description: "One-to-many relation query from one side with parent update and parent cid and docID",
 		Request: `query {
 					Book (
-							cid: "bafybeieie7sfx727alq2njnhvvxg33aw2mn3fdj7eu4372lqoc45efwiaq",
+							cid: "bafybeiefqhex3axofwy2gwdynhs6rijwrpkdpwy5fnqnzbk3e7iwcgvrqa",
 							docID: "bae-b9b83269-1f28-5c3b-ae75-3fb4c00d559d"
 						) {
 						name

--- a/tests/integration/query/simple/with_cid_doc_id_test.go
+++ b/tests/integration/query/simple/with_cid_doc_id_test.go
@@ -73,7 +73,7 @@ func TestQuerySimpleWithCidAndDocID(t *testing.T) {
 		Description: "Simple query with cid and docID",
 		Request: `query {
 					Users (
-							cid: "bafybeib26cyuzbnf7uq3js5mykfveplsn4imo2fmf2jnnib6rrtnllv4pe",
+							cid: "bafybeicojqe66grk564b2hns3zi6rhquqvugxj6wi4s6xk4e2gg65dzx5e",
 							docID: "bae-52b9170d-b77a-5887-b877-cbdbb99b009f"
 						) {
 						Name
@@ -102,7 +102,7 @@ func TestQuerySimpleWithUpdateAndFirstCidAndDocID(t *testing.T) {
 		Description: "Simple query with (first) cid and docID",
 		Request: `query {
 					Users (
-							cid: "bafybeib26cyuzbnf7uq3js5mykfveplsn4imo2fmf2jnnib6rrtnllv4pe",
+							cid: "bafybeicojqe66grk564b2hns3zi6rhquqvugxj6wi4s6xk4e2gg65dzx5e",
 							docID: "bae-52b9170d-b77a-5887-b877-cbdbb99b009f"
 						) {
 						Name
@@ -143,7 +143,7 @@ func TestQuerySimpleWithUpdateAndLastCidAndDocID(t *testing.T) {
 		Description: "Simple query with (last) cid and docID",
 		Request: `query {
 					Users (
-							cid: "bafybeicehye3yrct3yaumy64sucndh2ab7i6ymj72klfm2gphigjx6yw5u"
+							cid: "bafybeifxz2k3qudz2fau37xu3unw5l4ihenha66tlb37gctq5mtdriq3ly"
 							docID: "bae-52b9170d-b77a-5887-b877-cbdbb99b009f"
 						) {
 						Name
@@ -184,7 +184,7 @@ func TestQuerySimpleWithUpdateAndMiddleCidAndDocID(t *testing.T) {
 		Description: "Simple query with (middle) cid and docID",
 		Request: `query {
 					Users (
-							cid: "bafybeie23a5xsx4qyoffa3riij3kei5to54bb6gq7m4lftfjujaohkabwu",
+							cid: "bafybeigcjabzlkuj4j35boczgcl4jmars7gz5a7dfvpq3m344bzth7ebqq",
 							docID: "bae-52b9170d-b77a-5887-b877-cbdbb99b009f"
 						) {
 						Name
@@ -225,7 +225,7 @@ func TestQuerySimpleWithUpdateAndFirstCidAndDocIDAndSchemaVersion(t *testing.T) 
 		Description: "Simple query with (first) cid and docID and yielded schema version",
 		Request: `query {
 					Users (					
-							cid: "bafybeib26cyuzbnf7uq3js5mykfveplsn4imo2fmf2jnnib6rrtnllv4pe",
+							cid: "bafybeicojqe66grk564b2hns3zi6rhquqvugxj6wi4s6xk4e2gg65dzx5e",
 							docID: "bae-52b9170d-b77a-5887-b877-cbdbb99b009f"
 						) {
 						Name
@@ -259,7 +259,7 @@ func TestQuerySimpleWithUpdateAndFirstCidAndDocIDAndSchemaVersion(t *testing.T) 
 				"Age":  int64(21),
 				"_version": []map[string]any{
 					{
-						"schemaVersionId": "bafkreihuvcb7e7vy6ua3yrwbwnul3djqrtbhyuv3c4dqe4y3i2ssudzveu",
+						"schemaVersionId": "bafkreiekkppcdl573ru624wh3kwkmy2nhqzjsvqpu6jv5dgq2kidpnon4u",
 					},
 				},
 			},
@@ -301,7 +301,7 @@ func TestCidAndDocIDQuery_ContainsPNCounterWithIntKind_NoError(t *testing.T) {
 			testUtils.Request{
 				Request: `query {
 					Users (
-						cid: "bafybeia4u3g4r3uolc7slho4thvhqfma5fkfrtho3lgapopatud2fl63lu",
+						cid: "bafybeiebqzqml6nn3laarr7yekakrsdnkn4nbgrl4xc5rshljp3in6au2m",
 						docID: "bae-a688789e-d8a6-57a7-be09-22e005ab79e0"
 					) {
 						name
@@ -353,7 +353,7 @@ func TestCidAndDocIDQuery_ContainsPNCounterWithFloatKind_NoError(t *testing.T) {
 			testUtils.Request{
 				Request: `query {
 					Users (
-						cid: "bafybeicldbqzhmhu2hgowp6jazm4xpwh7tdurvc2xynuc54k4j7edn3vem",
+						cid: "bafybeifzuh74aq47vjngkwipjne4r2gi3v2clewgsruspqirihnps4vcmu",
 						docID: "bae-fa6a97e9-e0e9-5826-8a8c-57775d35e07c"
 					) {
 						name

--- a/tests/integration/query/simple/with_version_test.go
+++ b/tests/integration/query/simple/with_version_test.go
@@ -46,14 +46,14 @@ func TestQuerySimpleWithEmbeddedLatestCommit(t *testing.T) {
 				"Age":  int64(21),
 				"_version": []map[string]any{
 					{
-						"cid": "bafybeib26cyuzbnf7uq3js5mykfveplsn4imo2fmf2jnnib6rrtnllv4pe",
+						"cid": "bafybeicojqe66grk564b2hns3zi6rhquqvugxj6wi4s6xk4e2gg65dzx5e",
 						"links": []map[string]any{
 							{
-								"cid":  "bafybeihkhgtdogxwqe2lkjqord5bzthfwwthyo3gu6iljfm5l7n7fkhpsq",
+								"cid":  "bafybeic45t5rj54wx47fhaqm6dubwt2cf5fkqzwm2nea7ypam3f6s2zbk4",
 								"name": "Age",
 							},
 							{
-								"cid":  "bafybeico2g2tdkpo4i64ph6b5vgngn5zbxus4jxwav3bi2joieqicplfxi",
+								"cid":  "bafybeifkcrogypyaq5iw7krgi5jd26s7jlfsy5u232e7e7y7dqe3wm2hcu",
 								"name": "Name",
 							},
 						},
@@ -90,7 +90,7 @@ func TestQuerySimpleWithEmbeddedLatestCommitWithSchemaVersionId(t *testing.T) {
 				"Name": "John",
 				"_version": []map[string]any{
 					{
-						"schemaVersionId": "bafkreihuvcb7e7vy6ua3yrwbwnul3djqrtbhyuv3c4dqe4y3i2ssudzveu",
+						"schemaVersionId": "bafkreiekkppcdl573ru624wh3kwkmy2nhqzjsvqpu6jv5dgq2kidpnon4u",
 					},
 				},
 			},
@@ -171,14 +171,14 @@ func TestQuerySimpleWithMultipleAliasedEmbeddedLatestCommit(t *testing.T) {
 				"Age":  int64(21),
 				"_version": []map[string]any{
 					{
-						"cid": "bafybeib26cyuzbnf7uq3js5mykfveplsn4imo2fmf2jnnib6rrtnllv4pe",
+						"cid": "bafybeicojqe66grk564b2hns3zi6rhquqvugxj6wi4s6xk4e2gg65dzx5e",
 						"L1": []map[string]any{
 							{
-								"cid":  "bafybeihkhgtdogxwqe2lkjqord5bzthfwwthyo3gu6iljfm5l7n7fkhpsq",
+								"cid":  "bafybeic45t5rj54wx47fhaqm6dubwt2cf5fkqzwm2nea7ypam3f6s2zbk4",
 								"name": "Age",
 							},
 							{
-								"cid":  "bafybeico2g2tdkpo4i64ph6b5vgngn5zbxus4jxwav3bi2joieqicplfxi",
+								"cid":  "bafybeifkcrogypyaq5iw7krgi5jd26s7jlfsy5u232e7e7y7dqe3wm2hcu",
 								"name": "Name",
 							},
 						},
@@ -242,7 +242,7 @@ func TestQuery_WithAllCommitFields_NoError(t *testing.T) {
 						"_docID": docID,
 						"_version": []map[string]any{
 							{
-								"cid":          "bafybeib26cyuzbnf7uq3js5mykfveplsn4imo2fmf2jnnib6rrtnllv4pe",
+								"cid":          "bafybeicojqe66grk564b2hns3zi6rhquqvugxj6wi4s6xk4e2gg65dzx5e",
 								"collectionID": int64(1),
 								"delta":        nil,
 								"docID":        "bae-52b9170d-b77a-5887-b877-cbdbb99b009f",
@@ -251,15 +251,15 @@ func TestQuery_WithAllCommitFields_NoError(t *testing.T) {
 								"height":       int64(1),
 								"links": []map[string]any{
 									{
-										"cid":  "bafybeihkhgtdogxwqe2lkjqord5bzthfwwthyo3gu6iljfm5l7n7fkhpsq",
+										"cid":  "bafybeic45t5rj54wx47fhaqm6dubwt2cf5fkqzwm2nea7ypam3f6s2zbk4",
 										"name": "Age",
 									},
 									{
-										"cid":  "bafybeico2g2tdkpo4i64ph6b5vgngn5zbxus4jxwav3bi2joieqicplfxi",
+										"cid":  "bafybeifkcrogypyaq5iw7krgi5jd26s7jlfsy5u232e7e7y7dqe3wm2hcu",
 										"name": "Name",
 									},
 								},
-								"schemaVersionId": "bafkreihuvcb7e7vy6ua3yrwbwnul3djqrtbhyuv3c4dqe4y3i2ssudzveu",
+								"schemaVersionId": "bafkreiekkppcdl573ru624wh3kwkmy2nhqzjsvqpu6jv5dgq2kidpnon4u",
 							},
 						},
 					},
@@ -321,7 +321,7 @@ func TestQuery_WithAllCommitFieldsWithUpdate_NoError(t *testing.T) {
 						"_docID": docID,
 						"_version": []map[string]any{
 							{
-								"cid":          "bafybeie23a5xsx4qyoffa3riij3kei5to54bb6gq7m4lftfjujaohkabwu",
+								"cid":          "bafybeigcjabzlkuj4j35boczgcl4jmars7gz5a7dfvpq3m344bzth7ebqq",
 								"collectionID": int64(1),
 								"delta":        nil,
 								"docID":        "bae-52b9170d-b77a-5887-b877-cbdbb99b009f",
@@ -330,18 +330,18 @@ func TestQuery_WithAllCommitFieldsWithUpdate_NoError(t *testing.T) {
 								"height":       int64(2),
 								"links": []map[string]any{
 									{
-										"cid":  "bafybeicixwhd4prbj2jfnkkc3a7wr2f5twppyhivg3kajoe7jal5cvrdza",
+										"cid":  "bafybeihzra5nmcai4omdv2hkplrpexjsau62eaa2ndrf2b7ksxvl7hx3qm",
 										"name": "Age",
 									},
 									{
-										"cid":  "bafybeib26cyuzbnf7uq3js5mykfveplsn4imo2fmf2jnnib6rrtnllv4pe",
+										"cid":  "bafybeicojqe66grk564b2hns3zi6rhquqvugxj6wi4s6xk4e2gg65dzx5e",
 										"name": "_head",
 									},
 								},
-								"schemaVersionId": "bafkreihuvcb7e7vy6ua3yrwbwnul3djqrtbhyuv3c4dqe4y3i2ssudzveu",
+								"schemaVersionId": "bafkreiekkppcdl573ru624wh3kwkmy2nhqzjsvqpu6jv5dgq2kidpnon4u",
 							},
 							{
-								"cid":          "bafybeib26cyuzbnf7uq3js5mykfveplsn4imo2fmf2jnnib6rrtnllv4pe",
+								"cid":          "bafybeicojqe66grk564b2hns3zi6rhquqvugxj6wi4s6xk4e2gg65dzx5e",
 								"collectionID": int64(1),
 								"delta":        nil,
 								"docID":        "bae-52b9170d-b77a-5887-b877-cbdbb99b009f",
@@ -350,15 +350,15 @@ func TestQuery_WithAllCommitFieldsWithUpdate_NoError(t *testing.T) {
 								"height":       int64(1),
 								"links": []map[string]any{
 									{
-										"cid":  "bafybeihkhgtdogxwqe2lkjqord5bzthfwwthyo3gu6iljfm5l7n7fkhpsq",
+										"cid":  "bafybeic45t5rj54wx47fhaqm6dubwt2cf5fkqzwm2nea7ypam3f6s2zbk4",
 										"name": "Age",
 									},
 									{
-										"cid":  "bafybeico2g2tdkpo4i64ph6b5vgngn5zbxus4jxwav3bi2joieqicplfxi",
+										"cid":  "bafybeifkcrogypyaq5iw7krgi5jd26s7jlfsy5u232e7e7y7dqe3wm2hcu",
 										"name": "Name",
 									},
 								},
-								"schemaVersionId": "bafkreihuvcb7e7vy6ua3yrwbwnul3djqrtbhyuv3c4dqe4y3i2ssudzveu",
+								"schemaVersionId": "bafkreiekkppcdl573ru624wh3kwkmy2nhqzjsvqpu6jv5dgq2kidpnon4u",
 							},
 						},
 					},

--- a/tests/integration/schema/crdt_type_test.go
+++ b/tests/integration/schema/crdt_type_test.go
@@ -38,14 +38,13 @@ func TestSchemaCreate_ContainsPNCounterTypeWithIntKind_NoError(t *testing.T) {
 						Name:      "Users",
 						VersionID: schemaVersionID,
 						Root:      schemaVersionID,
-						Fields: []client.FieldDescription{
+						Fields: []client.SchemaFieldDescription{
 							{
 								Name: "_docID",
 								Kind: client.FieldKind_DocID,
 							},
 							{
 								Name: "points",
-								ID:   1,
 								Kind: client.FieldKind_NILLABLE_INT,
 								Typ:  client.PN_COUNTER,
 							},
@@ -78,14 +77,13 @@ func TestSchemaCreate_ContainsPNCounterTypeWithFloatKind_NoError(t *testing.T) {
 						Name:      "Users",
 						VersionID: schemaVersionID,
 						Root:      schemaVersionID,
-						Fields: []client.FieldDescription{
+						Fields: []client.SchemaFieldDescription{
 							{
 								Name: "_docID",
 								Kind: client.FieldKind_DocID,
 							},
 							{
 								Name: "points",
-								ID:   1,
 								Kind: client.FieldKind_NILLABLE_FLOAT,
 								Typ:  client.PN_COUNTER,
 							},

--- a/tests/integration/schema/crdt_type_test.go
+++ b/tests/integration/schema/crdt_type_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func TestSchemaCreate_ContainsPNCounterTypeWithIntKind_NoError(t *testing.T) {
-	schemaVersionID := "bafkreicawqdqtzuw5dvhb7jg2u4yheu7yhigciocode4kyvfyrq57mtxty"
+	schemaVersionID := "bafkreib2rcnzkjrwabw6kx7qnncfuylugukoosilmb2dct5qylmgec7fdu"
 
 	test := testUtils.TestCase{
 		Actions: []any{
@@ -59,7 +59,7 @@ func TestSchemaCreate_ContainsPNCounterTypeWithIntKind_NoError(t *testing.T) {
 }
 
 func TestSchemaCreate_ContainsPNCounterTypeWithFloatKind_NoError(t *testing.T) {
-	schemaVersionID := "bafkreica5ubot4w4bwpei5afvhf3obfveob5jotjyqzrcc47spargaznae"
+	schemaVersionID := "bafkreiddz4h2oqi3qzfeqfbjt3wpwrvtm62r4l6uche2nxyullmlmezrsq"
 
 	test := testUtils.TestCase{
 		Actions: []any{

--- a/tests/integration/schema/get_schema_test.go
+++ b/tests/integration/schema/get_schema_test.go
@@ -71,9 +71,9 @@ func TestGetSchema_GivenNoSchemaGivenUnknownName(t *testing.T) {
 }
 
 func TestGetSchema_ReturnsAllSchema(t *testing.T) {
-	usersSchemaVersion1ID := "bafkreiagl4ml2ll45ex6g62bunpfs6o4mr2zstfuegwtxktm52stq6abxi"
-	usersSchemaVersion2ID := "bafkreib7rfcyxx5anpl3ikvi5g63jv6gtgwywtt6usrng2pdg4j5jwjlsa"
-	booksSchemaVersion1ID := "bafkreic3guyvlavrp7pq23s2uftvk5tx2gq2hs5ikbadtaghbafpkfox34"
+	usersSchemaVersion1ID := "bafkreiegrxzoqa3mdgjsfz2vuatbpjbnqxub6yi23dvdumjpt4g3nhiwzq"
+	usersSchemaVersion2ID := "bafkreidic23paxtc5sannovwkpp6kmpg7xufufz4dgxjsiq2exk2wieh4a"
+	booksSchemaVersion1ID := "bafkreiakx6sdz3govsorfppdv2pru4fgjzt2qljgjhpkxnkyr7kl4vhdme"
 
 	test := testUtils.TestCase{
 		Actions: []any{
@@ -98,9 +98,9 @@ func TestGetSchema_ReturnsAllSchema(t *testing.T) {
 			testUtils.GetSchema{
 				ExpectedResults: []client.SchemaDescription{
 					{
-						Name:      "Users",
-						Root:      usersSchemaVersion1ID,
-						VersionID: usersSchemaVersion1ID,
+						Name:      "Books",
+						Root:      booksSchemaVersion1ID,
+						VersionID: booksSchemaVersion1ID,
 						Fields: []client.SchemaFieldDescription{
 							{
 								Name: "_docID",
@@ -126,9 +126,9 @@ func TestGetSchema_ReturnsAllSchema(t *testing.T) {
 						},
 					},
 					{
-						Name:      "Books",
-						Root:      booksSchemaVersion1ID,
-						VersionID: booksSchemaVersion1ID,
+						Name:      "Users",
+						Root:      usersSchemaVersion1ID,
+						VersionID: usersSchemaVersion1ID,
 						Fields: []client.SchemaFieldDescription{
 							{
 								Name: "_docID",
@@ -145,8 +145,8 @@ func TestGetSchema_ReturnsAllSchema(t *testing.T) {
 }
 
 func TestGetSchema_ReturnsSchemaForGivenRoot(t *testing.T) {
-	usersSchemaVersion1ID := "bafkreiagl4ml2ll45ex6g62bunpfs6o4mr2zstfuegwtxktm52stq6abxi"
-	usersSchemaVersion2ID := "bafkreib7rfcyxx5anpl3ikvi5g63jv6gtgwywtt6usrng2pdg4j5jwjlsa"
+	usersSchemaVersion1ID := "bafkreiegrxzoqa3mdgjsfz2vuatbpjbnqxub6yi23dvdumjpt4g3nhiwzq"
+	usersSchemaVersion2ID := "bafkreidic23paxtc5sannovwkpp6kmpg7xufufz4dgxjsiq2exk2wieh4a"
 
 	test := testUtils.TestCase{
 		Actions: []any{
@@ -174,17 +174,6 @@ func TestGetSchema_ReturnsSchemaForGivenRoot(t *testing.T) {
 					{
 						Name:      "Users",
 						Root:      usersSchemaVersion1ID,
-						VersionID: usersSchemaVersion1ID,
-						Fields: []client.SchemaFieldDescription{
-							{
-								Name: "_docID",
-								Kind: client.FieldKind_DocID,
-							},
-						},
-					},
-					{
-						Name:      "Users",
-						Root:      usersSchemaVersion1ID,
 						VersionID: usersSchemaVersion2ID,
 						Fields: []client.SchemaFieldDescription{
 							{
@@ -199,6 +188,17 @@ func TestGetSchema_ReturnsSchemaForGivenRoot(t *testing.T) {
 							},
 						},
 					},
+					{
+						Name:      "Users",
+						Root:      usersSchemaVersion1ID,
+						VersionID: usersSchemaVersion1ID,
+						Fields: []client.SchemaFieldDescription{
+							{
+								Name: "_docID",
+								Kind: client.FieldKind_DocID,
+							},
+						},
+					},
 				},
 			},
 		},
@@ -208,8 +208,8 @@ func TestGetSchema_ReturnsSchemaForGivenRoot(t *testing.T) {
 }
 
 func TestGetSchema_ReturnsSchemaForGivenName(t *testing.T) {
-	usersSchemaVersion1ID := "bafkreiagl4ml2ll45ex6g62bunpfs6o4mr2zstfuegwtxktm52stq6abxi"
-	usersSchemaVersion2ID := "bafkreib7rfcyxx5anpl3ikvi5g63jv6gtgwywtt6usrng2pdg4j5jwjlsa"
+	usersSchemaVersion1ID := "bafkreiegrxzoqa3mdgjsfz2vuatbpjbnqxub6yi23dvdumjpt4g3nhiwzq"
+	usersSchemaVersion2ID := "bafkreidic23paxtc5sannovwkpp6kmpg7xufufz4dgxjsiq2exk2wieh4a"
 
 	test := testUtils.TestCase{
 		Actions: []any{
@@ -237,17 +237,6 @@ func TestGetSchema_ReturnsSchemaForGivenName(t *testing.T) {
 					{
 						Name:      "Users",
 						Root:      usersSchemaVersion1ID,
-						VersionID: usersSchemaVersion1ID,
-						Fields: []client.SchemaFieldDescription{
-							{
-								Name: "_docID",
-								Kind: client.FieldKind_DocID,
-							},
-						},
-					},
-					{
-						Name:      "Users",
-						Root:      usersSchemaVersion1ID,
 						VersionID: usersSchemaVersion2ID,
 						Fields: []client.SchemaFieldDescription{
 							{
@@ -259,6 +248,17 @@ func TestGetSchema_ReturnsSchemaForGivenName(t *testing.T) {
 								Name: "name",
 								Kind: client.FieldKind_NILLABLE_STRING,
 								Typ:  client.LWW_REGISTER,
+							},
+						},
+					},
+					{
+						Name:      "Users",
+						Root:      usersSchemaVersion1ID,
+						VersionID: usersSchemaVersion1ID,
+						Fields: []client.SchemaFieldDescription{
+							{
+								Name: "_docID",
+								Kind: client.FieldKind_DocID,
 							},
 						},
 					},

--- a/tests/integration/schema/get_schema_test.go
+++ b/tests/integration/schema/get_schema_test.go
@@ -101,7 +101,7 @@ func TestGetSchema_ReturnsAllSchema(t *testing.T) {
 						Name:      "Users",
 						Root:      usersSchemaVersion1ID,
 						VersionID: usersSchemaVersion1ID,
-						Fields: []client.FieldDescription{
+						Fields: []client.SchemaFieldDescription{
 							{
 								Name: "_docID",
 								Kind: client.FieldKind_DocID,
@@ -112,7 +112,7 @@ func TestGetSchema_ReturnsAllSchema(t *testing.T) {
 						Name:      "Users",
 						Root:      usersSchemaVersion1ID,
 						VersionID: usersSchemaVersion2ID,
-						Fields: []client.FieldDescription{
+						Fields: []client.SchemaFieldDescription{
 							{
 								Name: "_docID",
 								Kind: client.FieldKind_DocID,
@@ -120,7 +120,6 @@ func TestGetSchema_ReturnsAllSchema(t *testing.T) {
 							},
 							{
 								Name: "name",
-								ID:   1,
 								Kind: client.FieldKind_NILLABLE_STRING,
 								Typ:  client.LWW_REGISTER,
 							},
@@ -130,7 +129,7 @@ func TestGetSchema_ReturnsAllSchema(t *testing.T) {
 						Name:      "Books",
 						Root:      booksSchemaVersion1ID,
 						VersionID: booksSchemaVersion1ID,
-						Fields: []client.FieldDescription{
+						Fields: []client.SchemaFieldDescription{
 							{
 								Name: "_docID",
 								Kind: client.FieldKind_DocID,
@@ -176,7 +175,7 @@ func TestGetSchema_ReturnsSchemaForGivenRoot(t *testing.T) {
 						Name:      "Users",
 						Root:      usersSchemaVersion1ID,
 						VersionID: usersSchemaVersion1ID,
-						Fields: []client.FieldDescription{
+						Fields: []client.SchemaFieldDescription{
 							{
 								Name: "_docID",
 								Kind: client.FieldKind_DocID,
@@ -187,7 +186,7 @@ func TestGetSchema_ReturnsSchemaForGivenRoot(t *testing.T) {
 						Name:      "Users",
 						Root:      usersSchemaVersion1ID,
 						VersionID: usersSchemaVersion2ID,
-						Fields: []client.FieldDescription{
+						Fields: []client.SchemaFieldDescription{
 							{
 								Name: "_docID",
 								Kind: client.FieldKind_DocID,
@@ -195,7 +194,6 @@ func TestGetSchema_ReturnsSchemaForGivenRoot(t *testing.T) {
 							},
 							{
 								Name: "name",
-								ID:   1,
 								Kind: client.FieldKind_NILLABLE_STRING,
 								Typ:  client.LWW_REGISTER,
 							},
@@ -240,7 +238,7 @@ func TestGetSchema_ReturnsSchemaForGivenName(t *testing.T) {
 						Name:      "Users",
 						Root:      usersSchemaVersion1ID,
 						VersionID: usersSchemaVersion1ID,
-						Fields: []client.FieldDescription{
+						Fields: []client.SchemaFieldDescription{
 							{
 								Name: "_docID",
 								Kind: client.FieldKind_DocID,
@@ -251,7 +249,7 @@ func TestGetSchema_ReturnsSchemaForGivenName(t *testing.T) {
 						Name:      "Users",
 						Root:      usersSchemaVersion1ID,
 						VersionID: usersSchemaVersion2ID,
-						Fields: []client.FieldDescription{
+						Fields: []client.SchemaFieldDescription{
 							{
 								Name: "_docID",
 								Kind: client.FieldKind_DocID,
@@ -259,7 +257,6 @@ func TestGetSchema_ReturnsSchemaForGivenName(t *testing.T) {
 							},
 							{
 								Name: "name",
-								ID:   1,
 								Kind: client.FieldKind_NILLABLE_STRING,
 								Typ:  client.LWW_REGISTER,
 							},

--- a/tests/integration/schema/migrations/query/simple_test.go
+++ b/tests/integration/schema/migrations/query/simple_test.go
@@ -45,8 +45,8 @@ func TestSchemaMigrationQuery(t *testing.T) {
 			},
 			testUtils.ConfigureMigration{
 				LensConfig: client.LensConfig{
-					SourceSchemaVersionID:      "bafkreibjb4h5nudsei7cq2kkontjinmjpbqls2tmowqp5nxougu4tuus4i",
-					DestinationSchemaVersionID: "bafkreih6o2jyurelxtpbg66gk23pio2tq6o3aed334z6w2u3qwve3at7ku",
+					SourceSchemaVersionID:      "bafkreiebcgze3rs6j3g7gu65dwskdg5fn3qby5c6nqffhbdkcy2l5bbvp4",
+					DestinationSchemaVersionID: "bafkreiexwzcpjuz3eaghcanr3fnmyc6el5w6i5ovhop5zfrqctucwlraba",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{
@@ -115,8 +115,8 @@ func TestSchemaMigrationQueryMultipleDocs(t *testing.T) {
 			},
 			testUtils.ConfigureMigration{
 				LensConfig: client.LensConfig{
-					SourceSchemaVersionID:      "bafkreibjb4h5nudsei7cq2kkontjinmjpbqls2tmowqp5nxougu4tuus4i",
-					DestinationSchemaVersionID: "bafkreih6o2jyurelxtpbg66gk23pio2tq6o3aed334z6w2u3qwve3at7ku",
+					SourceSchemaVersionID:      "bafkreiebcgze3rs6j3g7gu65dwskdg5fn3qby5c6nqffhbdkcy2l5bbvp4",
+					DestinationSchemaVersionID: "bafkreiexwzcpjuz3eaghcanr3fnmyc6el5w6i5ovhop5zfrqctucwlraba",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{
@@ -178,8 +178,8 @@ func TestSchemaMigrationQueryWithMigrationRegisteredBeforeSchemaPatch(t *testing
 			},
 			testUtils.ConfigureMigration{
 				LensConfig: client.LensConfig{
-					SourceSchemaVersionID:      "bafkreibjb4h5nudsei7cq2kkontjinmjpbqls2tmowqp5nxougu4tuus4i",
-					DestinationSchemaVersionID: "bafkreih6o2jyurelxtpbg66gk23pio2tq6o3aed334z6w2u3qwve3at7ku",
+					SourceSchemaVersionID:      "bafkreiebcgze3rs6j3g7gu65dwskdg5fn3qby5c6nqffhbdkcy2l5bbvp4",
+					DestinationSchemaVersionID: "bafkreiexwzcpjuz3eaghcanr3fnmyc6el5w6i5ovhop5zfrqctucwlraba",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{
@@ -254,8 +254,8 @@ func TestSchemaMigrationQueryMigratesToIntermediaryVersion(t *testing.T) {
 				// Register a migration from schema version 1 to schema version 2 **only** -
 				// there should be no migration from version 2 to version 3.
 				LensConfig: client.LensConfig{
-					SourceSchemaVersionID:      "bafkreibjb4h5nudsei7cq2kkontjinmjpbqls2tmowqp5nxougu4tuus4i",
-					DestinationSchemaVersionID: "bafkreih6o2jyurelxtpbg66gk23pio2tq6o3aed334z6w2u3qwve3at7ku",
+					SourceSchemaVersionID:      "bafkreiebcgze3rs6j3g7gu65dwskdg5fn3qby5c6nqffhbdkcy2l5bbvp4",
+					DestinationSchemaVersionID: "bafkreiexwzcpjuz3eaghcanr3fnmyc6el5w6i5ovhop5zfrqctucwlraba",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{
@@ -325,8 +325,8 @@ func TestSchemaMigrationQueryMigratesFromIntermediaryVersion(t *testing.T) {
 				// Register a migration from schema version 2 to schema version 3 **only** -
 				// there should be no migration from version 1 to version 2.
 				LensConfig: client.LensConfig{
-					SourceSchemaVersionID:      "bafkreih6o2jyurelxtpbg66gk23pio2tq6o3aed334z6w2u3qwve3at7ku",
-					DestinationSchemaVersionID: "bafkreihv4ktjwzyhhkmas5iz4q7cawet4aeurqci33i66wr225l5pet4qu",
+					SourceSchemaVersionID:      "bafkreiexwzcpjuz3eaghcanr3fnmyc6el5w6i5ovhop5zfrqctucwlraba",
+					DestinationSchemaVersionID: "bafkreicyyn7ourjvr2o6bqa57z2bl5wz5u2ykdlmd5v7n53cw7l6xsdplm",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{
@@ -394,8 +394,8 @@ func TestSchemaMigrationQueryMigratesAcrossMultipleVersions(t *testing.T) {
 			},
 			testUtils.ConfigureMigration{
 				LensConfig: client.LensConfig{
-					SourceSchemaVersionID:      "bafkreibjb4h5nudsei7cq2kkontjinmjpbqls2tmowqp5nxougu4tuus4i",
-					DestinationSchemaVersionID: "bafkreih6o2jyurelxtpbg66gk23pio2tq6o3aed334z6w2u3qwve3at7ku",
+					SourceSchemaVersionID:      "bafkreiebcgze3rs6j3g7gu65dwskdg5fn3qby5c6nqffhbdkcy2l5bbvp4",
+					DestinationSchemaVersionID: "bafkreiexwzcpjuz3eaghcanr3fnmyc6el5w6i5ovhop5zfrqctucwlraba",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{
@@ -411,8 +411,8 @@ func TestSchemaMigrationQueryMigratesAcrossMultipleVersions(t *testing.T) {
 			},
 			testUtils.ConfigureMigration{
 				LensConfig: client.LensConfig{
-					SourceSchemaVersionID:      "bafkreih6o2jyurelxtpbg66gk23pio2tq6o3aed334z6w2u3qwve3at7ku",
-					DestinationSchemaVersionID: "bafkreihv4ktjwzyhhkmas5iz4q7cawet4aeurqci33i66wr225l5pet4qu",
+					SourceSchemaVersionID:      "bafkreiexwzcpjuz3eaghcanr3fnmyc6el5w6i5ovhop5zfrqctucwlraba",
+					DestinationSchemaVersionID: "bafkreicyyn7ourjvr2o6bqa57z2bl5wz5u2ykdlmd5v7n53cw7l6xsdplm",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{
@@ -466,8 +466,8 @@ func TestSchemaMigrationQueryMigratesAcrossMultipleVersionsBeforePatches(t *test
 			},
 			testUtils.ConfigureMigration{
 				LensConfig: client.LensConfig{
-					SourceSchemaVersionID:      "bafkreibjb4h5nudsei7cq2kkontjinmjpbqls2tmowqp5nxougu4tuus4i",
-					DestinationSchemaVersionID: "bafkreih6o2jyurelxtpbg66gk23pio2tq6o3aed334z6w2u3qwve3at7ku",
+					SourceSchemaVersionID:      "bafkreiebcgze3rs6j3g7gu65dwskdg5fn3qby5c6nqffhbdkcy2l5bbvp4",
+					DestinationSchemaVersionID: "bafkreiexwzcpjuz3eaghcanr3fnmyc6el5w6i5ovhop5zfrqctucwlraba",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{
@@ -483,8 +483,8 @@ func TestSchemaMigrationQueryMigratesAcrossMultipleVersionsBeforePatches(t *test
 			},
 			testUtils.ConfigureMigration{
 				LensConfig: client.LensConfig{
-					SourceSchemaVersionID:      "bafkreih6o2jyurelxtpbg66gk23pio2tq6o3aed334z6w2u3qwve3at7ku",
-					DestinationSchemaVersionID: "bafkreihv4ktjwzyhhkmas5iz4q7cawet4aeurqci33i66wr225l5pet4qu",
+					SourceSchemaVersionID:      "bafkreiexwzcpjuz3eaghcanr3fnmyc6el5w6i5ovhop5zfrqctucwlraba",
+					DestinationSchemaVersionID: "bafkreicyyn7ourjvr2o6bqa57z2bl5wz5u2ykdlmd5v7n53cw7l6xsdplm",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{
@@ -553,8 +553,8 @@ func TestSchemaMigrationQueryMigratesAcrossMultipleVersionsBeforePatchesWrongOrd
 			testUtils.ConfigureMigration{
 				// Declare the migration from v2=>v3 before declaring the migration from v1=>v2
 				LensConfig: client.LensConfig{
-					SourceSchemaVersionID:      "bafkreih6o2jyurelxtpbg66gk23pio2tq6o3aed334z6w2u3qwve3at7ku",
-					DestinationSchemaVersionID: "bafkreihv4ktjwzyhhkmas5iz4q7cawet4aeurqci33i66wr225l5pet4qu",
+					SourceSchemaVersionID:      "bafkreiexwzcpjuz3eaghcanr3fnmyc6el5w6i5ovhop5zfrqctucwlraba",
+					DestinationSchemaVersionID: "bafkreicyyn7ourjvr2o6bqa57z2bl5wz5u2ykdlmd5v7n53cw7l6xsdplm",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{
@@ -570,8 +570,8 @@ func TestSchemaMigrationQueryMigratesAcrossMultipleVersionsBeforePatchesWrongOrd
 			},
 			testUtils.ConfigureMigration{
 				LensConfig: client.LensConfig{
-					SourceSchemaVersionID:      "bafkreibjb4h5nudsei7cq2kkontjinmjpbqls2tmowqp5nxougu4tuus4i",
-					DestinationSchemaVersionID: "bafkreih6o2jyurelxtpbg66gk23pio2tq6o3aed334z6w2u3qwve3at7ku",
+					SourceSchemaVersionID:      "bafkreiebcgze3rs6j3g7gu65dwskdg5fn3qby5c6nqffhbdkcy2l5bbvp4",
+					DestinationSchemaVersionID: "bafkreiexwzcpjuz3eaghcanr3fnmyc6el5w6i5ovhop5zfrqctucwlraba",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{
@@ -712,8 +712,8 @@ func TestSchemaMigrationQueryMigrationMutatesExistingScalarField(t *testing.T) {
 			},
 			testUtils.ConfigureMigration{
 				LensConfig: client.LensConfig{
-					SourceSchemaVersionID:      "bafkreibjb4h5nudsei7cq2kkontjinmjpbqls2tmowqp5nxougu4tuus4i",
-					DestinationSchemaVersionID: "bafkreih6o2jyurelxtpbg66gk23pio2tq6o3aed334z6w2u3qwve3at7ku",
+					SourceSchemaVersionID:      "bafkreiebcgze3rs6j3g7gu65dwskdg5fn3qby5c6nqffhbdkcy2l5bbvp4",
+					DestinationSchemaVersionID: "bafkreiexwzcpjuz3eaghcanr3fnmyc6el5w6i5ovhop5zfrqctucwlraba",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{
@@ -773,8 +773,8 @@ func TestSchemaMigrationQueryMigrationMutatesExistingInlineArrayField(t *testing
 			},
 			testUtils.ConfigureMigration{
 				LensConfig: client.LensConfig{
-					SourceSchemaVersionID:      "bafkreic2fcxa2e7o2acur6yh6iv7vyso4ecgfcqbbp6l55twpgdumdctui",
-					DestinationSchemaVersionID: "bafkreidz6fo522l4vzsdbe4b5mhm3c7tc5xmve7i2egsk4s53zg6emkbyy",
+					SourceSchemaVersionID:      "bafkreiasjk4ypvsmdiebxadvhdnpvq4eun6wielebzlcnipyqr357bz7ou",
+					DestinationSchemaVersionID: "bafkreie7zotytkhmsp7ro5dqyf75fwrafos4xowgatalicbcb3lu5lfade",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{
@@ -836,8 +836,8 @@ func TestSchemaMigrationQueryMigrationRemovesExistingField(t *testing.T) {
 			},
 			testUtils.ConfigureMigration{
 				LensConfig: client.LensConfig{
-					SourceSchemaVersionID:      "bafkreihh4zkyuqk4ibwb5utyayvbw75hdfkueg3scm7taysk3rbh2jhaee",
-					DestinationSchemaVersionID: "bafkreifzcnwsq2os36utxnqpmq74wjt7o2czkcjo6exzv4fhm3ni2ounxe",
+					SourceSchemaVersionID:      "bafkreiewca6o66mgkpbai2vtrupolvtf66wllbvouvtwo6fkc6alrybzfa",
+					DestinationSchemaVersionID: "bafkreibqzsrn3acwn7hkakm2ko5i4t5pdarmylvodi5tnpxunfcwmut2ua",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{
@@ -897,8 +897,8 @@ func TestSchemaMigrationQueryMigrationPreservesExistingFieldWhenFieldNotRequeste
 			},
 			testUtils.ConfigureMigration{
 				LensConfig: client.LensConfig{
-					SourceSchemaVersionID:      "bafkreihh4zkyuqk4ibwb5utyayvbw75hdfkueg3scm7taysk3rbh2jhaee",
-					DestinationSchemaVersionID: "bafkreifzcnwsq2os36utxnqpmq74wjt7o2czkcjo6exzv4fhm3ni2ounxe",
+					SourceSchemaVersionID:      "bafkreiewca6o66mgkpbai2vtrupolvtf66wllbvouvtwo6fkc6alrybzfa",
+					DestinationSchemaVersionID: "bafkreibqzsrn3acwn7hkakm2ko5i4t5pdarmylvodi5tnpxunfcwmut2ua",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{
@@ -971,8 +971,8 @@ func TestSchemaMigrationQueryMigrationCopiesExistingFieldWhenSrcFieldNotRequeste
 			},
 			testUtils.ConfigureMigration{
 				LensConfig: client.LensConfig{
-					SourceSchemaVersionID:      "bafkreihh4zkyuqk4ibwb5utyayvbw75hdfkueg3scm7taysk3rbh2jhaee",
-					DestinationSchemaVersionID: "bafkreica72aah4lm4sry67eqxqufsr24to6abgocomra4qeokwa7oaazwi",
+					SourceSchemaVersionID:      "bafkreiewca6o66mgkpbai2vtrupolvtf66wllbvouvtwo6fkc6alrybzfa",
+					DestinationSchemaVersionID: "bafkreicf3nvrorgv2v6czh2lkakibv4me2il5xxytqxfyof7jlmkkdkle4",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{
@@ -1033,8 +1033,8 @@ func TestSchemaMigrationQueryMigrationCopiesExistingFieldWhenSrcAndDstFieldNotRe
 			},
 			testUtils.ConfigureMigration{
 				LensConfig: client.LensConfig{
-					SourceSchemaVersionID:      "bafkreihh4zkyuqk4ibwb5utyayvbw75hdfkueg3scm7taysk3rbh2jhaee",
-					DestinationSchemaVersionID: "bafkreica72aah4lm4sry67eqxqufsr24to6abgocomra4qeokwa7oaazwi",
+					SourceSchemaVersionID:      "bafkreiewca6o66mgkpbai2vtrupolvtf66wllbvouvtwo6fkc6alrybzfa",
+					DestinationSchemaVersionID: "bafkreicf3nvrorgv2v6czh2lkakibv4me2il5xxytqxfyof7jlmkkdkle4",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{

--- a/tests/integration/schema/migrations/query/with_doc_id_test.go
+++ b/tests/integration/schema/migrations/query/with_doc_id_test.go
@@ -52,8 +52,8 @@ func TestSchemaMigrationQueryByDocID(t *testing.T) {
 			},
 			testUtils.ConfigureMigration{
 				LensConfig: client.LensConfig{
-					SourceSchemaVersionID:      "bafkreibjb4h5nudsei7cq2kkontjinmjpbqls2tmowqp5nxougu4tuus4i",
-					DestinationSchemaVersionID: "bafkreih6o2jyurelxtpbg66gk23pio2tq6o3aed334z6w2u3qwve3at7ku",
+					SourceSchemaVersionID:      "bafkreiebcgze3rs6j3g7gu65dwskdg5fn3qby5c6nqffhbdkcy2l5bbvp4",
+					DestinationSchemaVersionID: "bafkreiexwzcpjuz3eaghcanr3fnmyc6el5w6i5ovhop5zfrqctucwlraba",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{
@@ -158,8 +158,8 @@ func TestSchemaMigrationQueryMultipleQueriesByDocID(t *testing.T) {
 			},
 			testUtils.ConfigureMigration{
 				LensConfig: client.LensConfig{
-					SourceSchemaVersionID:      "bafkreibjb4h5nudsei7cq2kkontjinmjpbqls2tmowqp5nxougu4tuus4i",
-					DestinationSchemaVersionID: "bafkreih6o2jyurelxtpbg66gk23pio2tq6o3aed334z6w2u3qwve3at7ku",
+					SourceSchemaVersionID:      "bafkreiebcgze3rs6j3g7gu65dwskdg5fn3qby5c6nqffhbdkcy2l5bbvp4",
+					DestinationSchemaVersionID: "bafkreiexwzcpjuz3eaghcanr3fnmyc6el5w6i5ovhop5zfrqctucwlraba",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{

--- a/tests/integration/schema/migrations/query/with_p2p_test.go
+++ b/tests/integration/schema/migrations/query/with_p2p_test.go
@@ -46,8 +46,8 @@ func TestSchemaMigrationQueryWithP2PReplicatedDocAtOlderSchemaVersion(t *testing
 			testUtils.ConfigureMigration{
 				// Register the migration on both nodes.
 				LensConfig: client.LensConfig{
-					SourceSchemaVersionID:      "bafkreiadnck34zzbwayjw3aeubw7eg4jmgtwoibu35tkxbjpar5rzxkdpu",
-					DestinationSchemaVersionID: "bafkreibzqyjmyjs7vyo2q4h2tv5rbdbe4lv7tjbl5esilmobhgclia2juy",
+					SourceSchemaVersionID:      "bafkreiaqs2jvnjgddkkhxzhhfmrr6o4yohhqymbi55b7ltynxo4tmge4wu",
+					DestinationSchemaVersionID: "bafkreigc5whyvnmgqvdr6yk366ct4dddgmwnwrnbgbmu4f3edm3sfwerha",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{
@@ -145,8 +145,8 @@ func TestSchemaMigrationQueryWithP2PReplicatedDocAtMuchOlderSchemaVersion(t *tes
 			testUtils.ConfigureMigration{
 				// Register the migration on both nodes.
 				LensConfig: client.LensConfig{
-					SourceSchemaVersionID:      "bafkreiadnck34zzbwayjw3aeubw7eg4jmgtwoibu35tkxbjpar5rzxkdpu",
-					DestinationSchemaVersionID: "bafkreibzqyjmyjs7vyo2q4h2tv5rbdbe4lv7tjbl5esilmobhgclia2juy",
+					SourceSchemaVersionID:      "bafkreiaqs2jvnjgddkkhxzhhfmrr6o4yohhqymbi55b7ltynxo4tmge4wu",
+					DestinationSchemaVersionID: "bafkreigc5whyvnmgqvdr6yk366ct4dddgmwnwrnbgbmu4f3edm3sfwerha",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{
@@ -163,8 +163,8 @@ func TestSchemaMigrationQueryWithP2PReplicatedDocAtMuchOlderSchemaVersion(t *tes
 			testUtils.ConfigureMigration{
 				// Register the migration on both nodes.
 				LensConfig: client.LensConfig{
-					SourceSchemaVersionID:      "bafkreibzqyjmyjs7vyo2q4h2tv5rbdbe4lv7tjbl5esilmobhgclia2juy",
-					DestinationSchemaVersionID: "bafkreicvjzscbtmuff7m7swfmmunnclp66ky4sxhfixacq2yuvion5s5ti",
+					SourceSchemaVersionID:      "bafkreigc5whyvnmgqvdr6yk366ct4dddgmwnwrnbgbmu4f3edm3sfwerha",
+					DestinationSchemaVersionID: "bafkreidtw4d7bv57wmwwwxkejburwuktc2kiakkmzgiacyy5vl7gj2ih5i",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{
@@ -253,8 +253,8 @@ func TestSchemaMigrationQueryWithP2PReplicatedDocAtNewerSchemaVersion(t *testing
 			testUtils.ConfigureMigration{
 				// Register the migration on both nodes.
 				LensConfig: client.LensConfig{
-					SourceSchemaVersionID:      "bafkreiadnck34zzbwayjw3aeubw7eg4jmgtwoibu35tkxbjpar5rzxkdpu",
-					DestinationSchemaVersionID: "bafkreibzqyjmyjs7vyo2q4h2tv5rbdbe4lv7tjbl5esilmobhgclia2juy",
+					SourceSchemaVersionID:      "bafkreiaqs2jvnjgddkkhxzhhfmrr6o4yohhqymbi55b7ltynxo4tmge4wu",
+					DestinationSchemaVersionID: "bafkreigc5whyvnmgqvdr6yk366ct4dddgmwnwrnbgbmu4f3edm3sfwerha",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{
@@ -355,8 +355,8 @@ func TestSchemaMigrationQueryWithP2PReplicatedDocAtMuchNewerSchemaVersionWithSch
 				// Register a migration from version 2 to version 3 on both nodes.
 				// There is no migration from version 1 to 2, thus node 1 has no knowledge of schema version 2.
 				LensConfig: client.LensConfig{
-					SourceSchemaVersionID:      "bafkreih6o2jyurelxtpbg66gk23pio2tq6o3aed334z6w2u3qwve3at7ku",
-					DestinationSchemaVersionID: "bafkreihv4ktjwzyhhkmas5iz4q7cawet4aeurqci33i66wr225l5pet4qu",
+					SourceSchemaVersionID:      "bafkreiexwzcpjuz3eaghcanr3fnmyc6el5w6i5ovhop5zfrqctucwlraba",
+					DestinationSchemaVersionID: "bafkreicyyn7ourjvr2o6bqa57z2bl5wz5u2ykdlmd5v7n53cw7l6xsdplm",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{

--- a/tests/integration/schema/migrations/query/with_restart_test.go
+++ b/tests/integration/schema/migrations/query/with_restart_test.go
@@ -45,8 +45,8 @@ func TestSchemaMigrationQueryWithRestart(t *testing.T) {
 			},
 			testUtils.ConfigureMigration{
 				LensConfig: client.LensConfig{
-					SourceSchemaVersionID:      "bafkreibjb4h5nudsei7cq2kkontjinmjpbqls2tmowqp5nxougu4tuus4i",
-					DestinationSchemaVersionID: "bafkreih6o2jyurelxtpbg66gk23pio2tq6o3aed334z6w2u3qwve3at7ku",
+					SourceSchemaVersionID:      "bafkreiebcgze3rs6j3g7gu65dwskdg5fn3qby5c6nqffhbdkcy2l5bbvp4",
+					DestinationSchemaVersionID: "bafkreiexwzcpjuz3eaghcanr3fnmyc6el5w6i5ovhop5zfrqctucwlraba",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{
@@ -99,8 +99,8 @@ func TestSchemaMigrationQueryWithRestartAndMigrationBeforeSchemaPatch(t *testing
 			},
 			testUtils.ConfigureMigration{
 				LensConfig: client.LensConfig{
-					SourceSchemaVersionID:      "bafkreibjb4h5nudsei7cq2kkontjinmjpbqls2tmowqp5nxougu4tuus4i",
-					DestinationSchemaVersionID: "bafkreih6o2jyurelxtpbg66gk23pio2tq6o3aed334z6w2u3qwve3at7ku",
+					SourceSchemaVersionID:      "bafkreiebcgze3rs6j3g7gu65dwskdg5fn3qby5c6nqffhbdkcy2l5bbvp4",
+					DestinationSchemaVersionID: "bafkreiexwzcpjuz3eaghcanr3fnmyc6el5w6i5ovhop5zfrqctucwlraba",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{

--- a/tests/integration/schema/migrations/query/with_set_default_test.go
+++ b/tests/integration/schema/migrations/query/with_set_default_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestSchemaMigrationQuery_WithSetDefaultToLatest_AppliesForwardMigration(t *testing.T) {
-	schemaVersionID2 := "bafkreibzqyjmyjs7vyo2q4h2tv5rbdbe4lv7tjbl5esilmobhgclia2juy"
+	schemaVersionID2 := "bafkreigc5whyvnmgqvdr6yk366ct4dddgmwnwrnbgbmu4f3edm3sfwerha"
 
 	test := testUtils.TestCase{
 		Description: "Test schema migration",
@@ -83,8 +83,8 @@ func TestSchemaMigrationQuery_WithSetDefaultToLatest_AppliesForwardMigration(t *
 }
 
 func TestSchemaMigrationQuery_WithSetDefaultToOriginal_AppliesInverseMigration(t *testing.T) {
-	schemaVersionID1 := "bafkreiadnck34zzbwayjw3aeubw7eg4jmgtwoibu35tkxbjpar5rzxkdpu"
-	schemaVersionID2 := "bafkreibzqyjmyjs7vyo2q4h2tv5rbdbe4lv7tjbl5esilmobhgclia2juy"
+	schemaVersionID1 := "bafkreiaqs2jvnjgddkkhxzhhfmrr6o4yohhqymbi55b7ltynxo4tmge4wu"
+	schemaVersionID2 := "bafkreigc5whyvnmgqvdr6yk366ct4dddgmwnwrnbgbmu4f3edm3sfwerha"
 
 	test := testUtils.TestCase{
 		Description: "Test schema migration",
@@ -158,8 +158,8 @@ func TestSchemaMigrationQuery_WithSetDefaultToOriginal_AppliesInverseMigration(t
 }
 
 func TestSchemaMigrationQuery_WithSetDefaultToOriginalVersionThatDocWasCreatedAt_ClearsMigrations(t *testing.T) {
-	schemaVersionID1 := "bafkreiadnck34zzbwayjw3aeubw7eg4jmgtwoibu35tkxbjpar5rzxkdpu"
-	schemaVersionID2 := "bafkreibzqyjmyjs7vyo2q4h2tv5rbdbe4lv7tjbl5esilmobhgclia2juy"
+	schemaVersionID1 := "bafkreiaqs2jvnjgddkkhxzhhfmrr6o4yohhqymbi55b7ltynxo4tmge4wu"
+	schemaVersionID2 := "bafkreigc5whyvnmgqvdr6yk366ct4dddgmwnwrnbgbmu4f3edm3sfwerha"
 
 	test := testUtils.TestCase{
 		Description: "Test schema migration",

--- a/tests/integration/schema/migrations/query/with_txn_test.go
+++ b/tests/integration/schema/migrations/query/with_txn_test.go
@@ -47,8 +47,8 @@ func TestSchemaMigrationQueryWithTxn(t *testing.T) {
 			testUtils.ConfigureMigration{
 				TransactionID: immutable.Some(0),
 				LensConfig: client.LensConfig{
-					SourceSchemaVersionID:      "bafkreibjb4h5nudsei7cq2kkontjinmjpbqls2tmowqp5nxougu4tuus4i",
-					DestinationSchemaVersionID: "bafkreih6o2jyurelxtpbg66gk23pio2tq6o3aed334z6w2u3qwve3at7ku",
+					SourceSchemaVersionID:      "bafkreiebcgze3rs6j3g7gu65dwskdg5fn3qby5c6nqffhbdkcy2l5bbvp4",
+					DestinationSchemaVersionID: "bafkreiexwzcpjuz3eaghcanr3fnmyc6el5w6i5ovhop5zfrqctucwlraba",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{
@@ -109,8 +109,8 @@ func TestSchemaMigrationQueryWithTxnAndCommit(t *testing.T) {
 			testUtils.ConfigureMigration{
 				TransactionID: immutable.Some(0),
 				LensConfig: client.LensConfig{
-					SourceSchemaVersionID:      "bafkreibjb4h5nudsei7cq2kkontjinmjpbqls2tmowqp5nxougu4tuus4i",
-					DestinationSchemaVersionID: "bafkreih6o2jyurelxtpbg66gk23pio2tq6o3aed334z6w2u3qwve3at7ku",
+					SourceSchemaVersionID:      "bafkreiebcgze3rs6j3g7gu65dwskdg5fn3qby5c6nqffhbdkcy2l5bbvp4",
+					DestinationSchemaVersionID: "bafkreiexwzcpjuz3eaghcanr3fnmyc6el5w6i5ovhop5zfrqctucwlraba",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{

--- a/tests/integration/schema/migrations/query/with_update_test.go
+++ b/tests/integration/schema/migrations/query/with_update_test.go
@@ -45,8 +45,8 @@ func TestSchemaMigrationQueryWithUpdateRequest(t *testing.T) {
 			},
 			testUtils.ConfigureMigration{
 				LensConfig: client.LensConfig{
-					SourceSchemaVersionID:      "bafkreibjb4h5nudsei7cq2kkontjinmjpbqls2tmowqp5nxougu4tuus4i",
-					DestinationSchemaVersionID: "bafkreih6o2jyurelxtpbg66gk23pio2tq6o3aed334z6w2u3qwve3at7ku",
+					SourceSchemaVersionID:      "bafkreiebcgze3rs6j3g7gu65dwskdg5fn3qby5c6nqffhbdkcy2l5bbvp4",
+					DestinationSchemaVersionID: "bafkreiexwzcpjuz3eaghcanr3fnmyc6el5w6i5ovhop5zfrqctucwlraba",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{
@@ -129,8 +129,8 @@ func TestSchemaMigrationQueryWithMigrationRegisteredAfterUpdate(t *testing.T) {
 			},
 			testUtils.ConfigureMigration{
 				LensConfig: client.LensConfig{
-					SourceSchemaVersionID:      "bafkreibjb4h5nudsei7cq2kkontjinmjpbqls2tmowqp5nxougu4tuus4i",
-					DestinationSchemaVersionID: "bafkreih6o2jyurelxtpbg66gk23pio2tq6o3aed334z6w2u3qwve3at7ku",
+					SourceSchemaVersionID:      "bafkreiebcgze3rs6j3g7gu65dwskdg5fn3qby5c6nqffhbdkcy2l5bbvp4",
+					DestinationSchemaVersionID: "bafkreiexwzcpjuz3eaghcanr3fnmyc6el5w6i5ovhop5zfrqctucwlraba",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{

--- a/tests/integration/schema/migrations/simple_test.go
+++ b/tests/integration/schema/migrations/simple_test.go
@@ -106,8 +106,8 @@ func TestSchemaMigrationGetMigrationsReturnsMultiple(t *testing.T) {
 			},
 			testUtils.ConfigureMigration{
 				LensConfig: client.LensConfig{
-					SourceSchemaVersionID:      "bafkreibjb4h5nudsei7cq2kkontjinmjpbqls2tmowqp5nxougu4tuus4i",
-					DestinationSchemaVersionID: "bafkreih6o2jyurelxtpbg66gk23pio2tq6o3aed334z6w2u3qwve3at7ku",
+					SourceSchemaVersionID:      "bafkreiebcgze3rs6j3g7gu65dwskdg5fn3qby5c6nqffhbdkcy2l5bbvp4",
+					DestinationSchemaVersionID: "bafkreiexwzcpjuz3eaghcanr3fnmyc6el5w6i5ovhop5zfrqctucwlraba",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{
@@ -154,11 +154,11 @@ func TestSchemaMigrationGetMigrationsReturnsMultiple(t *testing.T) {
 					},
 					{
 						ID:              3,
-						SchemaVersionID: "bafkreibjb4h5nudsei7cq2kkontjinmjpbqls2tmowqp5nxougu4tuus4i",
+						SchemaVersionID: "bafkreiebcgze3rs6j3g7gu65dwskdg5fn3qby5c6nqffhbdkcy2l5bbvp4",
 					},
 					{
 						ID:              4,
-						SchemaVersionID: "bafkreih6o2jyurelxtpbg66gk23pio2tq6o3aed334z6w2u3qwve3at7ku",
+						SchemaVersionID: "bafkreiexwzcpjuz3eaghcanr3fnmyc6el5w6i5ovhop5zfrqctucwlraba",
 						Sources: []any{
 							&client.CollectionSource{
 								SourceCollectionID: 3,

--- a/tests/integration/schema/simple_test.go
+++ b/tests/integration/schema/simple_test.go
@@ -50,7 +50,7 @@ func TestSchemaSimpleCreatesSchemaGivenEmptyType(t *testing.T) {
 						Name:      "Users",
 						VersionID: schemaVersionID,
 						Root:      schemaVersionID,
-						Fields: []client.FieldDescription{
+						Fields: []client.SchemaFieldDescription{
 							{
 								Name: "_docID",
 								Kind: client.FieldKind_DocID,

--- a/tests/integration/schema/simple_test.go
+++ b/tests/integration/schema/simple_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func TestSchemaSimpleCreatesSchemaGivenEmptyType(t *testing.T) {
-	schemaVersionID := "bafkreiagl4ml2ll45ex6g62bunpfs6o4mr2zstfuegwtxktm52stq6abxi"
+	schemaVersionID := "bafkreiegrxzoqa3mdgjsfz2vuatbpjbnqxub6yi23dvdumjpt4g3nhiwzq"
 
 	test := testUtils.TestCase{
 		Actions: []any{

--- a/tests/integration/schema/updates/add/field/create_update_test.go
+++ b/tests/integration/schema/updates/add/field/create_update_test.go
@@ -17,8 +17,8 @@ import (
 )
 
 func TestSchemaUpdatesAddFieldWithCreateWithUpdateAfterSchemaUpdateAndVersionJoin(t *testing.T) {
-	initialSchemaVersionId := "bafkreibjb4h5nudsei7cq2kkontjinmjpbqls2tmowqp5nxougu4tuus4i"
-	updatedSchemaVersionId := "bafkreibzozorw6lqjn5bjogsqxeqcswoqedcatdvphhts4frd7mb4jn7x4"
+	initialSchemaVersionId := "bafkreiebcgze3rs6j3g7gu65dwskdg5fn3qby5c6nqffhbdkcy2l5bbvp4"
+	updatedSchemaVersionId := "bafkreidn4f3i52756wevi3sfpbqzijgy6v24zh565pmvtmpqr4ou52v2q4"
 
 	test := testUtils.TestCase{
 		Description: "Test schema update, add field with update after schema update, version join",
@@ -105,8 +105,8 @@ func TestSchemaUpdatesAddFieldWithCreateWithUpdateAfterSchemaUpdateAndVersionJoi
 }
 
 func TestSchemaUpdatesAddFieldWithCreateWithUpdateAfterSchemaUpdateAndCommitQuery(t *testing.T) {
-	initialSchemaVersionId := "bafkreibjb4h5nudsei7cq2kkontjinmjpbqls2tmowqp5nxougu4tuus4i"
-	updatedSchemaVersionId := "bafkreibzozorw6lqjn5bjogsqxeqcswoqedcatdvphhts4frd7mb4jn7x4"
+	initialSchemaVersionId := "bafkreiebcgze3rs6j3g7gu65dwskdg5fn3qby5c6nqffhbdkcy2l5bbvp4"
+	updatedSchemaVersionId := "bafkreidn4f3i52756wevi3sfpbqzijgy6v24zh565pmvtmpqr4ou52v2q4"
 
 	test := testUtils.TestCase{
 		Description: "Test schema update, add field with update after schema update, commits query",

--- a/tests/integration/schema/updates/add/field/kind/foreign_object_array_test.go
+++ b/tests/integration/schema/updates/add/field/kind/foreign_object_array_test.go
@@ -58,7 +58,7 @@ func TestSchemaUpdatesAddFieldKindForeignObjectArray_InvalidSchemaJson(t *testin
 						{ "op": "add", "path": "/Users/Fields/-", "value": {"Name": "foo", "Kind": 17, "Schema": 123} }
 					]
 				`,
-				ExpectedError: "json: cannot unmarshal number into Go struct field FieldDescription.Fields.Schema of type string",
+				ExpectedError: "json: cannot unmarshal number into Go struct field SchemaFieldDescription.Fields.Schema of type string",
 			},
 		},
 	}

--- a/tests/integration/schema/updates/add/field/kind/foreign_object_test.go
+++ b/tests/integration/schema/updates/add/field/kind/foreign_object_test.go
@@ -58,7 +58,7 @@ func TestSchemaUpdatesAddFieldKindForeignObject_InvalidSchemaJson(t *testing.T) 
 						{ "op": "add", "path": "/Users/Fields/-", "value": {"Name": "foo", "Kind": 16, "Schema": 123} }
 					]
 				`,
-				ExpectedError: "json: cannot unmarshal number into Go struct field FieldDescription.Fields.Schema of type string",
+				ExpectedError: "json: cannot unmarshal number into Go struct field SchemaFieldDescription.Fields.Schema of type string",
 			},
 		},
 	}

--- a/tests/integration/schema/updates/add/field/simple_test.go
+++ b/tests/integration/schema/updates/add/field/simple_test.go
@@ -20,8 +20,8 @@ import (
 )
 
 func TestSchemaUpdatesAddFieldSimple(t *testing.T) {
-	schemaVersion1ID := "bafkreibjb4h5nudsei7cq2kkontjinmjpbqls2tmowqp5nxougu4tuus4i"
-	schemaVersion2ID := "bafkreibzozorw6lqjn5bjogsqxeqcswoqedcatdvphhts4frd7mb4jn7x4"
+	schemaVersion1ID := "bafkreiebcgze3rs6j3g7gu65dwskdg5fn3qby5c6nqffhbdkcy2l5bbvp4"
+	schemaVersion2ID := "bafkreidn4f3i52756wevi3sfpbqzijgy6v24zh565pmvtmpqr4ou52v2q4"
 
 	test := testUtils.TestCase{
 		Description: "Test schema update, add field",
@@ -115,8 +115,8 @@ func TestSchemaUpdates_AddFieldSimpleDoNotSetDefault_Errors(t *testing.T) {
 }
 
 func TestSchemaUpdates_AddFieldSimpleDoNotSetDefault_VersionIsQueryable(t *testing.T) {
-	schemaVersion1ID := "bafkreibjb4h5nudsei7cq2kkontjinmjpbqls2tmowqp5nxougu4tuus4i"
-	schemaVersion2ID := "bafkreibzozorw6lqjn5bjogsqxeqcswoqedcatdvphhts4frd7mb4jn7x4"
+	schemaVersion1ID := "bafkreiebcgze3rs6j3g7gu65dwskdg5fn3qby5c6nqffhbdkcy2l5bbvp4"
+	schemaVersion2ID := "bafkreidn4f3i52756wevi3sfpbqzijgy6v24zh565pmvtmpqr4ou52v2q4"
 
 	test := testUtils.TestCase{
 		Description: "Test schema update, add field",

--- a/tests/integration/schema/updates/add/field/simple_test.go
+++ b/tests/integration/schema/updates/add/field/simple_test.go
@@ -56,7 +56,7 @@ func TestSchemaUpdatesAddFieldSimple(t *testing.T) {
 						Name:      "Users",
 						VersionID: schemaVersion2ID,
 						Root:      schemaVersion1ID,
-						Fields: []client.FieldDescription{
+						Fields: []client.SchemaFieldDescription{
 							{
 								Name: "_docID",
 								Kind: client.FieldKind_DocID,
@@ -64,13 +64,11 @@ func TestSchemaUpdatesAddFieldSimple(t *testing.T) {
 							},
 							{
 								Name: "name",
-								ID:   1,
 								Kind: client.FieldKind_NILLABLE_STRING,
 								Typ:  client.LWW_REGISTER,
 							},
 							{
 								Name: "email",
-								ID:   2,
 								Kind: client.FieldKind_NILLABLE_STRING,
 								Typ:  client.LWW_REGISTER,
 							},
@@ -147,7 +145,7 @@ func TestSchemaUpdates_AddFieldSimpleDoNotSetDefault_VersionIsQueryable(t *testi
 						// fetch it.
 						VersionID: schemaVersion2ID,
 						Root:      schemaVersion1ID,
-						Fields: []client.FieldDescription{
+						Fields: []client.SchemaFieldDescription{
 							{
 								Name: "_docID",
 								Kind: client.FieldKind_DocID,
@@ -155,13 +153,11 @@ func TestSchemaUpdates_AddFieldSimpleDoNotSetDefault_VersionIsQueryable(t *testi
 							},
 							{
 								Name: "name",
-								ID:   1,
 								Kind: client.FieldKind_NILLABLE_STRING,
 								Typ:  client.LWW_REGISTER,
 							},
 							{
 								Name: "email",
-								ID:   2,
 								Kind: client.FieldKind_NILLABLE_STRING,
 								Typ:  client.LWW_REGISTER,
 							},
@@ -392,30 +388,6 @@ func TestSchemaUpdatesAddFieldSimpleDuplicateField(t *testing.T) {
 					]
 				`,
 				ExpectedError: "duplicate field. Name: email",
-			},
-		},
-	}
-	testUtils.ExecuteTestCase(t, test)
-}
-
-func TestSchemaUpdatesAddFieldWithExplicitIDErrors(t *testing.T) {
-	test := testUtils.TestCase{
-		Description: "Test schema update, add field that already exists",
-		Actions: []any{
-			testUtils.SchemaUpdate{
-				Schema: `
-					type Users {
-						name: String
-					}
-				`,
-			},
-			testUtils.SchemaPatch{
-				Patch: `
-					[
-						{ "op": "add", "path": "/Users/Fields/-", "value": {"ID": 2, "Name": "email", "Kind": 11} }
-					]
-				`,
-				ExpectedError: "explicitly setting a field ID value is not supported. Field: email, ID: 2",
 			},
 		},
 	}

--- a/tests/integration/schema/updates/copy/field/simple_test.go
+++ b/tests/integration/schema/updates/copy/field/simple_test.go
@@ -50,9 +50,9 @@ func TestSchemaUpdatesCopyFieldErrors(t *testing.T) {
 	testUtils.ExecuteTestCase(t, test)
 }
 
-func TestSchemaUpdatesCopyFieldWithRemoveIDAndReplaceName(t *testing.T) {
+func TestSchemaUpdatesCopyFieldWithAndReplaceName(t *testing.T) {
 	test := testUtils.TestCase{
-		Description: "Test schema update, copy field, rename and remove IDs",
+		Description: "Test schema update, copy field and rename",
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
@@ -63,12 +63,11 @@ func TestSchemaUpdatesCopyFieldWithRemoveIDAndReplaceName(t *testing.T) {
 				`,
 			},
 			testUtils.SchemaPatch{
-				// Here we esentially use Email as a template, copying it, clearing the ID, and renaming the
+				// Here we esentially use Email as a template, copying it and renaming the
 				// clone.
 				Patch: `
 					[
 						{ "op": "copy", "from": "/Users/Fields/1", "path": "/Users/Fields/3" },
-						{ "op": "remove", "path": "/Users/Fields/3/ID" },
 						{ "op": "replace", "path": "/Users/Fields/3/Name", "value": "fax" }
 					]
 				`,
@@ -89,9 +88,9 @@ func TestSchemaUpdatesCopyFieldWithRemoveIDAndReplaceName(t *testing.T) {
 }
 
 // This is an odd test, but still a possibility and we should still cover it.
-func TestSchemaUpdatesCopyFieldWithRemoveIDAndReplaceNameAndKindSubstitution(t *testing.T) {
+func TestSchemaUpdatesCopyFieldWithReplaceNameAndKindSubstitution(t *testing.T) {
 	test := testUtils.TestCase{
-		Description: "Test schema update, copy field, rename, re-type, and remove IDs",
+		Description: "Test schema update, copy field, rename, re-type",
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
@@ -101,12 +100,11 @@ func TestSchemaUpdatesCopyFieldWithRemoveIDAndReplaceNameAndKindSubstitution(t *
 				`,
 			},
 			testUtils.SchemaPatch{
-				// Here we esentially use Name as a template, copying it, clearing the ID, and renaming and
+				// Here we esentially use Name as a template, copying it, and renaming and
 				// re-typing the clone.
 				Patch: `
 					[
 						{ "op": "copy", "from": "/Users/Fields/1", "path": "/Users/Fields/2" },
-						{ "op": "remove", "path": "/Users/Fields/2/ID" },
 						{ "op": "replace", "path": "/Users/Fields/2/Name", "value": "age" },
 						{ "op": "replace", "path": "/Users/Fields/2/Kind", "value": "Int" }
 					]
@@ -140,9 +138,9 @@ func TestSchemaUpdatesCopyFieldWithRemoveIDAndReplaceNameAndKindSubstitution(t *
 }
 
 // This is an odd test, but still a possibility and we should still cover it.
-func TestSchemaUpdatesCopyFieldWithRemoveIDAndReplaceNameAndInvalidKindSubstitution(t *testing.T) {
+func TestSchemaUpdatesCopyFieldAndReplaceNameAndInvalidKindSubstitution(t *testing.T) {
 	test := testUtils.TestCase{
-		Description: "Test schema update, copy field, rename, re-type to invalid, and remove ID",
+		Description: "Test schema update, copy field, rename, re-type to invalid",
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
@@ -152,12 +150,11 @@ func TestSchemaUpdatesCopyFieldWithRemoveIDAndReplaceNameAndInvalidKindSubstitut
 				`,
 			},
 			testUtils.SchemaPatch{
-				// Here we esentially use Name as a template, copying it, clearing the ID, and renaming and
+				// Here we esentially use Name as a template, copying it and renaming and
 				// re-typing the clone.
 				Patch: `
 					[
 						{ "op": "copy", "from": "/Users/Schema/Fields/1", "path": "/Users/Fields/2" },
-						{ "op": "remove", "path": "/Users/Fields/2/ID" },
 						{ "op": "replace", "path": "/Users/Fields/2/Name", "value": "Age" },
 						{ "op": "replace", "path": "/Users/Fields/2/Kind", "value": "NotAValidKind" }
 					]

--- a/tests/integration/schema/updates/copy/field/with_introspection_test.go
+++ b/tests/integration/schema/updates/copy/field/with_introspection_test.go
@@ -32,7 +32,6 @@ func TestSchemaUpdatesCopyFieldIntrospectionWithRemoveIDAndReplaceName(t *testin
 				Patch: `
 					[
 						{ "op": "copy", "from": "/Users/Fields/1", "path": "/Users/Fields/2" },
-						{ "op": "remove", "path": "/Users/Fields/2/ID" },
 						{ "op": "replace", "path": "/Users/Fields/2/Name", "value": "fax" }
 					]
 				`,

--- a/tests/integration/schema/updates/copy/simple_test.go
+++ b/tests/integration/schema/updates/copy/simple_test.go
@@ -28,14 +28,13 @@ func TestSchemaUpdatesCopyCollectionWithRemoveIDAndReplaceName(t *testing.T) {
 				`,
 			},
 			testUtils.SchemaPatch{
-				// Here we esentially use Users as a template, copying it, clearing the IDs, and renaming the
+				// Here we esentially use Users as a template, copying it and renaming the
 				// clone. It is deliberately blocked for now, but should function at somepoint.
 				Patch: `
 					[
 						{ "op": "copy", "from": "/Users", "path": "/Book" },
 						{ "op": "remove", "path": "/Book/Root" },
 						{ "op": "remove", "path": "/Book/VersionID" },
-						{ "op": "remove", "path": "/Book/Fields/1/ID" },
 						{ "op": "replace", "path": "/Book/Name", "value": "Book" }
 					]
 				`,

--- a/tests/integration/schema/updates/move/simple_test.go
+++ b/tests/integration/schema/updates/move/simple_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestSchemaUpdatesMoveCollectionDoesNothing(t *testing.T) {
-	schemaVersionID := "bafkreibjb4h5nudsei7cq2kkontjinmjpbqls2tmowqp5nxougu4tuus4i"
+	schemaVersionID := "bafkreiebcgze3rs6j3g7gu65dwskdg5fn3qby5c6nqffhbdkcy2l5bbvp4"
 
 	test := testUtils.TestCase{
 		Description: "Test schema update, move collection",

--- a/tests/integration/schema/updates/remove/fields/simple_test.go
+++ b/tests/integration/schema/updates/remove/fields/simple_test.go
@@ -91,31 +91,6 @@ func TestSchemaUpdatesRemoveFieldNameErrors(t *testing.T) {
 	testUtils.ExecuteTestCase(t, test)
 }
 
-func TestSchemaUpdatesRemoveFieldIDErrors(t *testing.T) {
-	test := testUtils.TestCase{
-		Description: "Test schema update, remove field id",
-		Actions: []any{
-			testUtils.SchemaUpdate{
-				Schema: `
-					type Users {
-						name: String
-						email: String
-					}
-				`,
-			},
-			testUtils.SchemaPatch{
-				Patch: `
-					[
-						{ "op": "remove", "path": "/Users/Fields/2/ID" }
-					]
-				`,
-				ExpectedError: "mutating an existing field is not supported. ProposedName: name",
-			},
-		},
-	}
-	testUtils.ExecuteTestCase(t, test)
-}
-
 func TestSchemaUpdatesRemoveFieldKindErrors(t *testing.T) {
 	test := testUtils.TestCase{
 		Description: "Test schema update, remove field kind",

--- a/tests/integration/schema/updates/remove/fields/simple_test.go
+++ b/tests/integration/schema/updates/remove/fields/simple_test.go
@@ -84,7 +84,7 @@ func TestSchemaUpdatesRemoveFieldNameErrors(t *testing.T) {
 						{ "op": "remove", "path": "/Users/Fields/2/Name" }
 					]
 				`,
-				ExpectedError: "mutating an existing field is not supported. ID: 2, ProposedName: ",
+				ExpectedError: "deleting an existing field is not supported. Name: name",
 			},
 		},
 	}
@@ -109,7 +109,7 @@ func TestSchemaUpdatesRemoveFieldIDErrors(t *testing.T) {
 						{ "op": "remove", "path": "/Users/Fields/2/ID" }
 					]
 				`,
-				ExpectedError: "deleting an existing field is not supported. Name: name, ID: 2",
+				ExpectedError: "mutating an existing field is not supported. ProposedName: name",
 			},
 		},
 	}
@@ -134,7 +134,7 @@ func TestSchemaUpdatesRemoveFieldKindErrors(t *testing.T) {
 						{ "op": "remove", "path": "/Users/Fields/2/Kind" }
 					]
 				`,
-				ExpectedError: "mutating an existing field is not supported. ID: 2, ProposedName: ",
+				ExpectedError: "mutating an existing field is not supported. ProposedName: ",
 			},
 		},
 	}
@@ -159,7 +159,7 @@ func TestSchemaUpdatesRemoveFieldTypErrors(t *testing.T) {
 						{ "op": "remove", "path": "/Users/Fields/2/Typ" }
 					]
 				`,
-				ExpectedError: "mutating an existing field is not supported. ID: 2, ProposedName: ",
+				ExpectedError: "mutating an existing field is not supported. ProposedName: name",
 			},
 		},
 	}
@@ -188,7 +188,7 @@ func TestSchemaUpdatesRemoveFieldSchemaErrors(t *testing.T) {
 						{ "op": "remove", "path": "/Author/Fields/1/Schema" }
 					]
 				`,
-				ExpectedError: "mutating an existing field is not supported. ID: 1, ProposedName: book",
+				ExpectedError: "mutating an existing field is not supported. ProposedName: book",
 			},
 		},
 	}
@@ -217,7 +217,7 @@ func TestSchemaUpdatesRemoveFieldRelationNameErrors(t *testing.T) {
 						{ "op": "remove", "path": "/Author/Fields/1/RelationName" }
 					]
 				`,
-				ExpectedError: "mutating an existing field is not supported. ID: 1, ProposedName: book",
+				ExpectedError: "mutating an existing field is not supported. ProposedName: book",
 			},
 		},
 	}

--- a/tests/integration/schema/updates/replace/field/simple_test.go
+++ b/tests/integration/schema/updates/replace/field/simple_test.go
@@ -56,7 +56,7 @@ func TestSchemaUpdatesReplaceFieldWithIDErrors(t *testing.T) {
 			testUtils.SchemaPatch{
 				Patch: `
 					[
-						{ "op": "replace", "path": "/Users/Fields/2", "value": {"ID":2, "Name": "fax", "Kind": 11} }
+						{ "op": "replace", "path": "/Users/Fields/2", "value": {"Name": "fax", "Kind": 11} }
 					]
 				`,
 				ExpectedError: "deleting an existing field is not supported. Name: name",

--- a/tests/integration/schema/updates/replace/field/simple_test.go
+++ b/tests/integration/schema/updates/replace/field/simple_test.go
@@ -34,7 +34,7 @@ func TestSchemaUpdatesReplaceFieldErrors(t *testing.T) {
 						{ "op": "replace", "path": "/Users/Fields/2", "value": {"Name": "Fax", "Kind": 11} }
 					]
 				`,
-				ExpectedError: "deleting an existing field is not supported. Name: name, ID: 2",
+				ExpectedError: "deleting an existing field is not supported. Name: name",
 			},
 		},
 	}
@@ -59,7 +59,7 @@ func TestSchemaUpdatesReplaceFieldWithIDErrors(t *testing.T) {
 						{ "op": "replace", "path": "/Users/Fields/2", "value": {"ID":2, "Name": "fax", "Kind": 11} }
 					]
 				`,
-				ExpectedError: "mutating an existing field is not supported. ID: 2, ProposedName: fax",
+				ExpectedError: "deleting an existing field is not supported. Name: name",
 			},
 		},
 	}

--- a/tests/integration/schema/updates/test/field/simple_test.go
+++ b/tests/integration/schema/updates/test/field/simple_test.go
@@ -102,7 +102,7 @@ func TestSchemaUpdatesTestFieldPasses(t *testing.T) {
 				Patch: `
 					[
 						{ "op": "test", "path": "/Users/Fields/1", "value": {
-							"ID":1, "Name": "name", "Kind": 11, "Schema":"", "IsPrimaryRelation":false, "RelationName":"", "Typ":1
+							"Name": "name", "Kind": 11, "Schema":"", "IsPrimaryRelation":false, "RelationName":"", "Typ":1
 						} }
 					]
 				`,
@@ -127,7 +127,7 @@ func TestSchemaUpdatesTestFieldPasses_UsingFieldNameAsIndex(t *testing.T) {
 				Patch: `
 					[
 						{ "op": "test", "path": "/Users/Fields/name", "value": {
-							"ID":1, "Kind": 11, "Schema":"", "IsPrimaryRelation":false, "RelationName":"", "Typ":1
+							"Kind": 11, "Schema":"", "IsPrimaryRelation":false, "RelationName":"", "Typ":1
 						} }
 					]
 				`,

--- a/tests/integration/schema/updates/with_schema_branch_test.go
+++ b/tests/integration/schema/updates/with_schema_branch_test.go
@@ -70,7 +70,7 @@ func TestSchemaUpdates_WithBranchingSchema(t *testing.T) {
 						Name:      "Users",
 						VersionID: schemaVersion2ID,
 						Root:      schemaVersion1ID,
-						Fields: []client.FieldDescription{
+						Fields: []client.SchemaFieldDescription{
 							{
 								Name: "_docID",
 								Kind: client.FieldKind_DocID,
@@ -78,13 +78,11 @@ func TestSchemaUpdates_WithBranchingSchema(t *testing.T) {
 							},
 							{
 								Name: "name",
-								ID:   1,
 								Kind: client.FieldKind_NILLABLE_STRING,
 								Typ:  client.LWW_REGISTER,
 							},
 							{
 								Name: "email",
-								ID:   2,
 								Kind: client.FieldKind_NILLABLE_STRING,
 								Typ:  client.LWW_REGISTER,
 							},
@@ -110,7 +108,7 @@ func TestSchemaUpdates_WithBranchingSchema(t *testing.T) {
 						Name:      "Users",
 						VersionID: schemaVersion3ID,
 						Root:      schemaVersion1ID,
-						Fields: []client.FieldDescription{
+						Fields: []client.SchemaFieldDescription{
 							{
 								Name: "_docID",
 								Kind: client.FieldKind_DocID,
@@ -118,13 +116,11 @@ func TestSchemaUpdates_WithBranchingSchema(t *testing.T) {
 							},
 							{
 								Name: "name",
-								ID:   1,
 								Kind: client.FieldKind_NILLABLE_STRING,
 								Typ:  client.LWW_REGISTER,
 							},
 							{
 								Name: "phone",
-								ID:   2,
 								Kind: client.FieldKind_NILLABLE_STRING,
 								Typ:  client.LWW_REGISTER,
 							},
@@ -234,7 +230,7 @@ func TestSchemaUpdates_WithPatchOnBranchedSchema(t *testing.T) {
 						Name:      "Users",
 						VersionID: schemaVersion4ID,
 						Root:      schemaVersion1ID,
-						Fields: []client.FieldDescription{
+						Fields: []client.SchemaFieldDescription{
 							{
 								Name: "_docID",
 								Kind: client.FieldKind_DocID,
@@ -242,19 +238,16 @@ func TestSchemaUpdates_WithPatchOnBranchedSchema(t *testing.T) {
 							},
 							{
 								Name: "name",
-								ID:   1,
 								Kind: client.FieldKind_NILLABLE_STRING,
 								Typ:  client.LWW_REGISTER,
 							},
 							{
 								Name: "phone",
-								ID:   2,
 								Kind: client.FieldKind_NILLABLE_STRING,
 								Typ:  client.LWW_REGISTER,
 							},
 							{
 								Name: "discordName",
-								ID:   3,
 								Kind: client.FieldKind_NILLABLE_STRING,
 								Typ:  client.LWW_REGISTER,
 							},
@@ -475,7 +468,7 @@ func TestSchemaUpdates_WithBranchingSchemaAndSetActiveSchemaToOtherBranchThenPat
 						Name:      "Users",
 						VersionID: schemaVersion4ID,
 						Root:      schemaVersion1ID,
-						Fields: []client.FieldDescription{
+						Fields: []client.SchemaFieldDescription{
 							{
 								Name: "_docID",
 								Kind: client.FieldKind_DocID,
@@ -483,19 +476,16 @@ func TestSchemaUpdates_WithBranchingSchemaAndSetActiveSchemaToOtherBranchThenPat
 							},
 							{
 								Name: "name",
-								ID:   1,
 								Kind: client.FieldKind_NILLABLE_STRING,
 								Typ:  client.LWW_REGISTER,
 							},
 							{
 								Name: "email",
-								ID:   2,
 								Kind: client.FieldKind_NILLABLE_STRING,
 								Typ:  client.LWW_REGISTER,
 							},
 							{
 								Name: "discordName",
-								ID:   3,
 								Kind: client.FieldKind_NILLABLE_STRING,
 								Typ:  client.LWW_REGISTER,
 							},

--- a/tests/integration/schema/updates/with_schema_branch_test.go
+++ b/tests/integration/schema/updates/with_schema_branch_test.go
@@ -20,9 +20,9 @@ import (
 )
 
 func TestSchemaUpdates_WithBranchingSchema(t *testing.T) {
-	schemaVersion1ID := "bafkreibjb4h5nudsei7cq2kkontjinmjpbqls2tmowqp5nxougu4tuus4i"
-	schemaVersion2ID := "bafkreibzozorw6lqjn5bjogsqxeqcswoqedcatdvphhts4frd7mb4jn7x4"
-	schemaVersion3ID := "bafkreiahizg44dgnuniim3y75ztjtj67kkezkit7w445lfpirx6iq6ixg4"
+	schemaVersion1ID := "bafkreiebcgze3rs6j3g7gu65dwskdg5fn3qby5c6nqffhbdkcy2l5bbvp4"
+	schemaVersion2ID := "bafkreidn4f3i52756wevi3sfpbqzijgy6v24zh565pmvtmpqr4ou52v2q4"
+	schemaVersion3ID := "bafkreieilqyv4bydakul5tbikpysmzwhzvxdau4twcny5n46zvxhkv7oli"
 
 	test := testUtils.TestCase{
 		Description: "Test schema update, with branching schema",
@@ -169,10 +169,10 @@ func TestSchemaUpdates_WithBranchingSchema(t *testing.T) {
 }
 
 func TestSchemaUpdates_WithPatchOnBranchedSchema(t *testing.T) {
-	schemaVersion1ID := "bafkreibjb4h5nudsei7cq2kkontjinmjpbqls2tmowqp5nxougu4tuus4i"
-	schemaVersion2ID := "bafkreibzozorw6lqjn5bjogsqxeqcswoqedcatdvphhts4frd7mb4jn7x4"
-	schemaVersion3ID := "bafkreiahizg44dgnuniim3y75ztjtj67kkezkit7w445lfpirx6iq6ixg4"
-	schemaVersion4ID := "bafkreig2b545qyt3luwmt37uyofbka2flmbc3kkhoifsh7mv2rgqy7fgty"
+	schemaVersion1ID := "bafkreiebcgze3rs6j3g7gu65dwskdg5fn3qby5c6nqffhbdkcy2l5bbvp4"
+	schemaVersion2ID := "bafkreidn4f3i52756wevi3sfpbqzijgy6v24zh565pmvtmpqr4ou52v2q4"
+	schemaVersion3ID := "bafkreieilqyv4bydakul5tbikpysmzwhzvxdau4twcny5n46zvxhkv7oli"
+	schemaVersion4ID := "bafkreicy4llechrh44zwviafs2ptjnr7sloiajjvpp7buaknhwspfevnt4"
 
 	test := testUtils.TestCase{
 		Description: "Test schema update, with patch on branching schema",
@@ -307,9 +307,9 @@ func TestSchemaUpdates_WithPatchOnBranchedSchema(t *testing.T) {
 }
 
 func TestSchemaUpdates_WithBranchingSchemaAndSetActiveSchemaToOtherBranch(t *testing.T) {
-	schemaVersion1ID := "bafkreibjb4h5nudsei7cq2kkontjinmjpbqls2tmowqp5nxougu4tuus4i"
-	schemaVersion2ID := "bafkreibzozorw6lqjn5bjogsqxeqcswoqedcatdvphhts4frd7mb4jn7x4"
-	schemaVersion3ID := "bafkreiahizg44dgnuniim3y75ztjtj67kkezkit7w445lfpirx6iq6ixg4"
+	schemaVersion1ID := "bafkreiebcgze3rs6j3g7gu65dwskdg5fn3qby5c6nqffhbdkcy2l5bbvp4"
+	schemaVersion2ID := "bafkreidn4f3i52756wevi3sfpbqzijgy6v24zh565pmvtmpqr4ou52v2q4"
+	schemaVersion3ID := "bafkreieilqyv4bydakul5tbikpysmzwhzvxdau4twcny5n46zvxhkv7oli"
 
 	test := testUtils.TestCase{
 		Description: "Test schema update, with branching schema toggling between branches",
@@ -403,10 +403,10 @@ func TestSchemaUpdates_WithBranchingSchemaAndSetActiveSchemaToOtherBranch(t *tes
 }
 
 func TestSchemaUpdates_WithBranchingSchemaAndSetActiveSchemaToOtherBranchThenPatch(t *testing.T) {
-	schemaVersion1ID := "bafkreibjb4h5nudsei7cq2kkontjinmjpbqls2tmowqp5nxougu4tuus4i"
-	schemaVersion2ID := "bafkreibzozorw6lqjn5bjogsqxeqcswoqedcatdvphhts4frd7mb4jn7x4"
-	schemaVersion3ID := "bafkreiahizg44dgnuniim3y75ztjtj67kkezkit7w445lfpirx6iq6ixg4"
-	schemaVersion4ID := "bafkreigtg424aidykeyhty44b7b6arhsaewxcg6kfcw37jxigfwskxgf2e"
+	schemaVersion1ID := "bafkreiebcgze3rs6j3g7gu65dwskdg5fn3qby5c6nqffhbdkcy2l5bbvp4"
+	schemaVersion2ID := "bafkreidn4f3i52756wevi3sfpbqzijgy6v24zh565pmvtmpqr4ou52v2q4"
+	schemaVersion3ID := "bafkreieilqyv4bydakul5tbikpysmzwhzvxdau4twcny5n46zvxhkv7oli"
+	schemaVersion4ID := "bafkreict4nqhcurfkjskxlek3djpep2acwlfkztughoum4dsvuwigkfqzi"
 
 	test := testUtils.TestCase{
 		Description: "Test schema update, with branching schema toggling between branches then patch",

--- a/tests/integration/schema/with_update_set_default_test.go
+++ b/tests/integration/schema/with_update_set_default_test.go
@@ -92,7 +92,7 @@ func TestSchema_WithUpdateAndSetDefaultVersionToOriginal_NewFieldIsNotQueriable(
 				SetAsDefaultVersion: immutable.Some(false),
 			},
 			testUtils.SetActiveSchemaVersion{
-				SchemaVersionID: "bafkreibjb4h5nudsei7cq2kkontjinmjpbqls2tmowqp5nxougu4tuus4i",
+				SchemaVersionID: "bafkreiebcgze3rs6j3g7gu65dwskdg5fn3qby5c6nqffhbdkcy2l5bbvp4",
 			},
 			testUtils.Request{
 				Request: `query {
@@ -129,7 +129,7 @@ func TestSchema_WithUpdateAndSetDefaultVersionToNew_AllowsQueryingOfNewField(t *
 				SetAsDefaultVersion: immutable.Some(false),
 			},
 			testUtils.SetActiveSchemaVersion{
-				SchemaVersionID: "bafkreibzozorw6lqjn5bjogsqxeqcswoqedcatdvphhts4frd7mb4jn7x4",
+				SchemaVersionID: "bafkreidn4f3i52756wevi3sfpbqzijgy6v24zh565pmvtmpqr4ou52v2q4",
 			},
 			testUtils.Request{
 				Request: `query {

--- a/tests/predefined/gen_predefined.go
+++ b/tests/predefined/gen_predefined.go
@@ -218,7 +218,7 @@ func (this *docGenerator) generateSecondaryDocs(
 func (this *docGenerator) generateSecondaryDocsForField(
 	primaryDoc map[string]any,
 	primaryTypeName string,
-	relField *client.FieldDescription,
+	relField *client.SchemaFieldDescription,
 	primaryDocID string,
 ) ([]gen.GeneratedDoc, error) {
 	result := []gen.GeneratedDoc{}

--- a/tests/predefined/gen_predefined_test.go
+++ b/tests/predefined/gen_predefined_test.go
@@ -508,7 +508,7 @@ func TestGeneratePredefinedFromSchema_TwoPrimaryToOneRoot(t *testing.T) {
 // 			},
 // 			Schema: client.SchemaDescription{
 // 				Name: "User",
-// 				Fields: []client.FieldDescription{
+// 				Fields: []client.SchemaFieldDescription{
 // 					{
 // 						Name: "name",
 // 						Kind: client.FieldKind_STRING,
@@ -528,7 +528,7 @@ func TestGeneratePredefinedFromSchema_TwoPrimaryToOneRoot(t *testing.T) {
 // 			},
 // 			Schema: client.SchemaDescription{
 // 				Name: "Device",
-// 				Fields: []client.FieldDescription{
+// 				Fields: []client.SchemaFieldDescription{
 // 					{
 // 						Name: "model",
 // 						Kind: client.FieldKind_STRING,


### PR DESCRIPTION
## Relevant issue(s)

Resolves #2334

## Description

Moves field id off of schema and onto collection.

It is now a local property and does not need to be the same across multiple nodes.  The new `Fields` property on `CollectionDescription` will be where other local field stuff is move too from the schema (relation_name, descriptions, secondary relation fields).

This change is a prerequisite of allowing fields to be deleted and schema branching (see https://github.com/sourcenetwork/defradb/issues/2333 for more info on that if currious)  