### PR TITLE
fix: Add `latest` image tag for ghcr

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -104,6 +104,7 @@ dockers:
     image_templates:
       - "{{ .Env.GITHUB_REPOSITORY }}:latest"
       - "{{ .Env.GITHUB_REPOSITORY }}:{{ .Version }}"
+      - "ghcr.io/{{ .Env.GITHUB_REPOSITORY }}:latest"
       - "ghcr.io/{{ .Env.GITHUB_REPOSITORY }}:{{ .Version }}"
     use: buildx
     build_flag_templates:


### PR DESCRIPTION
## Relevant issue(s)

Resolves #2332 

## Description

This PR adds the `latest` tag to the Github container registry release from GoReleaser.