### PR TITLE
feat: Add case insensitive `like` operator

### DIFF
--- a/connor/connor.go
+++ b/connor/connor.go
@@ -40,6 +40,10 @@ func matchWith(op string, conditions, data any) (bool, error) {
 		return like(conditions, data)
 	case "_nlike":
 		return nlike(conditions, data)
+	case "_ilike":
+		return ilike(conditions, data)
+	case "_nilike":
+		return nilike(conditions, data)
 	case "_not":
 		return not(conditions, data)
 	default:

--- a/connor/ilike.go
+++ b/connor/ilike.go
@@ -1,0 +1,30 @@
+package connor
+
+import (
+	"strings"
+
+	"github.com/sourcenetwork/immutable"
+
+	"github.com/sourcenetwork/defradb/client"
+)
+
+// ilike is an operator which performs case insensitive string equality tests.
+func ilike(condition, data any) (bool, error) {
+	switch d := data.(type) {
+	case immutable.Option[string]:
+		if !d.HasValue() {
+			return condition == nil, nil
+		}
+		data = d.Value()
+	}
+
+	switch cn := condition.(type) {
+	case string:
+		if d, ok := data.(string); ok {
+			return like(strings.ToLower(cn), strings.ToLower(d))
+		}
+		return false, nil
+	default:
+		return false, client.NewErrUnhandledType("condition", cn)
+	}
+}

--- a/connor/ilike_test.go
+++ b/connor/ilike_test.go
@@ -1,0 +1,41 @@
+package connor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestILike(t *testing.T) {
+	const testString = "Source Is The Glue of Web3"
+
+	// case insensitive exact match
+	result, err := ilike("source is the glue of web3", testString)
+	require.NoError(t, err)
+	require.True(t, result)
+
+	// case insensitive no match
+	result, err = ilike("source is the glue", testString)
+	require.NoError(t, err)
+	require.False(t, result)
+
+	// case insensitive match prefix
+	result, err = ilike("source%", testString)
+	require.NoError(t, err)
+	require.True(t, result)
+
+	// case insensitive match suffix
+	result, err = ilike("%web3", testString)
+	require.NoError(t, err)
+	require.True(t, result)
+
+	// case insensitive match contains
+	result, err = ilike("%glue%", testString)
+	require.NoError(t, err)
+	require.True(t, result)
+
+	// case insensitive match start and end with
+	result, err = ilike("source%web3", testString)
+	require.NoError(t, err)
+	require.True(t, result)
+}

--- a/connor/like.go
+++ b/connor/like.go
@@ -11,12 +11,12 @@ import (
 // like is an operator which performs string equality
 // tests.
 func like(condition, data any) (bool, error) {
-	switch arr := data.(type) {
+	switch d := data.(type) {
 	case immutable.Option[string]:
-		if !arr.HasValue() {
+		if !d.HasValue() {
 			return condition == nil, nil
 		}
-		data = arr.Value()
+		data = d.Value()
 	}
 
 	switch cn := condition.(type) {

--- a/connor/nilike.go
+++ b/connor/nilike.go
@@ -1,0 +1,12 @@
+package connor
+
+// nilike performs case insensitive string inequality comparisons by inverting
+// the result of the Like operator for non-error cases.
+func nilike(conditions, data any) (bool, error) {
+	m, err := ilike(conditions, data)
+	if err != nil {
+		return false, err
+	}
+
+	return !m, err
+}

--- a/connor/nilike_test.go
+++ b/connor/nilike_test.go
@@ -1,0 +1,41 @@
+package connor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNILike(t *testing.T) {
+	const testString = "Source Is The Glue of Web3"
+
+	// case insensitive exact match
+	result, err := nilike("source is the glue of web3", testString)
+	require.NoError(t, err)
+	require.False(t, result)
+
+	// case insensitive no match
+	result, err = nilike("source is the glue", testString)
+	require.NoError(t, err)
+	require.True(t, result)
+
+	// case insensitive match prefix
+	result, err = nilike("source%", testString)
+	require.NoError(t, err)
+	require.False(t, result)
+
+	// case insensitive match suffix
+	result, err = nilike("%web3", testString)
+	require.NoError(t, err)
+	require.False(t, result)
+
+	// case insensitive match contains
+	result, err = nilike("%glue%", testString)
+	require.NoError(t, err)
+	require.False(t, result)
+
+	// case insensitive match start and end with
+	result, err = nilike("source%web3", testString)
+	require.NoError(t, err)
+	require.False(t, result)
+}

--- a/connor/nlike_test.go
+++ b/connor/nlike_test.go
@@ -1,0 +1,41 @@
+package connor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNLike(t *testing.T) {
+	const testString = "Source is the glue of web3"
+
+	// exact match
+	result, err := nlike(testString, testString)
+	require.NoError(t, err)
+	require.False(t, result)
+
+	// exact match error
+	result, err = nlike("Source is the glue", testString)
+	require.NoError(t, err)
+	require.True(t, result)
+
+	// match prefix
+	result, err = nlike("Source%", testString)
+	require.NoError(t, err)
+	require.False(t, result)
+
+	// match suffix
+	result, err = nlike("%web3", testString)
+	require.NoError(t, err)
+	require.False(t, result)
+
+	// match contains
+	result, err = nlike("%glue%", testString)
+	require.NoError(t, err)
+	require.False(t, result)
+
+	// match start and end with
+	result, err = nlike("Source%web3", testString)
+	require.NoError(t, err)
+	require.False(t, result)
+}

--- a/request/graphql/schema/types/base.go
+++ b/request/graphql/schema/types/base.go
@@ -291,6 +291,14 @@ var StringOperatorBlock = gql.NewInputObject(gql.InputObjectConfig{
 			Description: nlikeStringOperatorDescription,
 			Type:        gql.String,
 		},
+		"_ilike": &gql.InputObjectFieldConfig{
+			Description: ilikeStringOperatorDescription,
+			Type:        gql.String,
+		},
+		"_nilike": &gql.InputObjectFieldConfig{
+			Description: nilikeStringOperatorDescription,
+			Type:        gql.String,
+		},
 	},
 })
 
@@ -321,6 +329,14 @@ var NotNullstringOperatorBlock = gql.NewInputObject(gql.InputObjectConfig{
 		},
 		"_nlike": &gql.InputObjectFieldConfig{
 			Description: nlikeStringOperatorDescription,
+			Type:        gql.String,
+		},
+		"_ilike": &gql.InputObjectFieldConfig{
+			Description: ilikeStringOperatorDescription,
+			Type:        gql.String,
+		},
+		"_nilike": &gql.InputObjectFieldConfig{
+			Description: nilikeStringOperatorDescription,
 			Type:        gql.String,
 		},
 	},

--- a/request/graphql/schema/types/descriptions.go
+++ b/request/graphql/schema/types/descriptions.go
@@ -203,6 +203,16 @@ The not-like operator - if the target value does not contain the given sub-strin
  pass. '%' characters may be used as wildcards, for example '_nlike: "%Ritchie"' would match on
  the string 'Quentin Tarantino'.
 `
+	ilikeStringOperatorDescription string = `
+The case insensitive like operator - if the target value contains the given case insensitive sub-string the check
+ will pass. '%' characters may be used as wildcards, for example '_like: "%ritchie"' would match on strings
+ ending in 'Ritchie'.
+`
+	nilikeStringOperatorDescription string = `
+The case insensitive not-like operator - if the target value does not contain the given case insensitive sub-string
+ the check will pass. '%' characters may be used as wildcards, for example '_nlike: "%ritchie"' would match on
+ the string 'Quentin Tarantino'.
+`
 	AndOperatorDescription string = `
 The and operator - all checks within this clause must pass in order for this check to pass.
 `

--- a/tests/integration/index/query_with_composite_index_field_order_test.go
+++ b/tests/integration/index/query_with_composite_index_field_order_test.go
@@ -92,6 +92,82 @@ func TestQueryWithCompositeIndex_WithDefaultOrder_ShouldFetchInDefaultOrder(t *t
 	testUtils.ExecuteTestCase(t, test)
 }
 
+func TestQueryWithCompositeIndex_WithDefaultOrderCaseInsensitive_ShouldFetchInDefaultOrder(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "Test composite index in default order and case insensitive operator",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type User @index(fields: ["name",  "age"]) {
+						name: String
+						age: Int
+					}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `
+					{
+						"name":	"Alice",
+						"age":	22
+					}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `
+					{
+						"name":	"Alan",
+						"age":	29
+					}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `
+					{
+						"name":	"Alice",
+						"age":	38
+					}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `
+					{
+						"name":	"Alice",
+						"age":	24
+					}`,
+			},
+			testUtils.Request{
+				Request: `
+					query {
+						User(filter: {name: {_ilike: "al%"}}) {
+							name
+							age
+						}
+					}`,
+				Results: []map[string]any{
+					{
+						"name": "Alan",
+						"age":  29,
+					},
+					{
+						"name": "Alice",
+						"age":  22,
+					},
+					{
+						"name": "Alice",
+						"age":  24,
+					},
+					{
+						"name": "Alice",
+						"age":  38,
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
 func TestQueryWithCompositeIndex_WithRevertedOrderOnFirstField_ShouldFetchInRevertedOrder(t *testing.T) {
 	test := testUtils.TestCase{
 		Description: "Test composite index with reverted order on first field",
@@ -180,6 +256,94 @@ func TestQueryWithCompositeIndex_WithRevertedOrderOnFirstField_ShouldFetchInReve
 	testUtils.ExecuteTestCase(t, test)
 }
 
+func TestQueryWithCompositeIndex_WithRevertedOrderOnFirstFieldCaseInsensitive_ShouldFetchInRevertedOrder(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "Test composite index with reverted order on first field and case insensitive operator",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type User @index(fields: ["name",  "age"], directions: [DESC, ASC]) {
+						name: String
+						age: Int
+					}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `
+					{
+						"name":	"Alice",
+						"age":	22
+					}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `
+					{
+						"name":	"Alan",
+						"age":	29
+					}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `
+					{
+						"name":	"Alice",
+						"age":	38
+					}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `
+					{
+						"name":	"Andy",
+						"age":	24
+					}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `
+					{
+						"name":	"Alice",
+						"age":	24
+					}`,
+			},
+			testUtils.Request{
+				Request: `
+					query {
+						User(filter: {name: {_ilike: "a%"}}) {
+							name
+							age
+						}
+					}`,
+				Results: []map[string]any{
+					{
+						"name": "Andy",
+						"age":  24,
+					},
+					{
+						"name": "Alice",
+						"age":  22,
+					},
+					{
+						"name": "Alice",
+						"age":  24,
+					},
+					{
+						"name": "Alice",
+						"age":  38,
+					},
+					{
+						"name": "Alan",
+						"age":  29,
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
 func TestQueryWithCompositeIndex_WithRevertedOrderOnSecondField_ShouldFetchInRevertedOrder(t *testing.T) {
 	test := testUtils.TestCase{
 		Description: "Test composite index with reverted order on second field",
@@ -227,6 +391,84 @@ func TestQueryWithCompositeIndex_WithRevertedOrderOnSecondField_ShouldFetchInRev
 				Request: `
 					query {
 						User(filter: {name: {_like: "Al%"}}) {
+							name
+							age
+						}
+					}`,
+				Results: []map[string]any{
+					{
+						"name": "Alan",
+						"age":  29,
+					},
+					{
+						"name": "Alice",
+						"age":  38,
+					},
+					{
+						"name": "Alice",
+						"age":  24,
+					},
+					{
+						"name": "Alice",
+						"age":  22,
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestQueryWithCompositeIndex_WithRevertedOrderOnSecondFieldCaseInsensitive_ShouldFetchInRevertedOrder(
+	t *testing.T,
+) {
+	test := testUtils.TestCase{
+		Description: "Test composite index with reverted order on second field and case insensitive operator",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type User @index(fields: ["name",  "age"], directions: [ASC, DESC]) {
+						name: String
+						age: Int
+					}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `
+					{
+						"name":	"Alice",
+						"age":	22
+					}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `
+					{
+						"name":	"Alan",
+						"age":	29
+					}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `
+					{
+						"name":	"Alice",
+						"age":	38
+					}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `
+					{
+						"name":	"Alice",
+						"age":	24
+					}`,
+			},
+			testUtils.Request{
+				Request: `
+					query {
+						User(filter: {name: {_ilike: "al%"}}) {
 							name
 							age
 						}

--- a/tests/integration/query/one_to_many/with_filter_test.go
+++ b/tests/integration/query/one_to_many/with_filter_test.go
@@ -456,3 +456,98 @@ func TestQueryOneToManyWithCompoundOperatorInFilterAndRelation(t *testing.T) {
 	}
 	testUtils.ExecuteTestCase(t, test)
 }
+
+func TestQueryOneToMany_WithCompoundOperatorInFilterAndRelationAndCaseInsensitiveLike_NoError(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "One-to-many relation query filter with compound operator and relation",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: bookAuthorGQLSchema,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `{
+					"name": "Painted House",
+					"rating": 4.9,
+					"author_id": "bae-41598f0c-19bc-5da6-813b-e80f14a10df3"
+				}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `{
+					"name": "A Time for Mercy",
+					"rating": 4.5,
+					"author_id": "bae-41598f0c-19bc-5da6-813b-e80f14a10df3"
+					}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `{
+					"name": "Theif Lord",
+					"rating": 4.8,
+					"author_id": "bae-b769708d-f552-5c3d-a402-ccfd7ac7fb04"
+				}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `{
+					"name": "The Lord of the Rings",
+					"rating": 5.0,
+					"author_id": "bae-61d279c1-eab9-56ec-8654-dce0324ebfda"
+				}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				// bae-41598f0c-19bc-5da6-813b-e80f14a10df3
+				Doc: `{
+					"name": "John Grisham",
+					"age": 65,
+					"verified": true
+				}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				// bae-b769708d-f552-5c3d-a402-ccfd7ac7fb04
+				Doc: `{
+					"name": "Cornelia Funke",
+					"age": 62,
+					"verified": false
+				}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				// bae-61d279c1-eab9-56ec-8654-dce0324ebfda
+				Doc: `{
+					"name": "John Tolkien",
+					"age": 70,
+					"verified": true
+				}`,
+			},
+			testUtils.Request{
+				Request: `query {
+					Author(filter: {_or: [
+						{_and: [
+							{published: {rating: {_lt: 5.0}}},
+							{published: {rating: {_gt: 4.8}}}
+						]},
+						{_and: [
+							{age: {_le: 65}},
+							{published: {name: {_ilike: "%lord%"}}}
+						]},
+					]}) {
+						name
+					}
+				}`,
+				Results: []map[string]any{
+					{
+						"name": "John Grisham",
+					},
+					{
+						"name": "Cornelia Funke",
+					},
+				},
+			},
+		},
+	}
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/query/simple/with_filter/with_like_string_test.go
+++ b/tests/integration/query/simple/with_filter/with_like_string_test.go
@@ -46,11 +46,71 @@ func TestQuerySimpleWithLikeStringContainsFilterBlockContainsString(t *testing.T
 	executeTestCase(t, test)
 }
 
+func TestQuerySimple_WithCaseInsensitiveLike_ShouldMatchString(t *testing.T) {
+	test := testUtils.RequestTestCase{
+		Description: "Simple query with basic case insensitive like-string filter contains string",
+		Request: `query {
+					Users(filter: {Name: {_ilike: "%stormborn%"}}) {
+						Name
+					}
+				}`,
+		Docs: map[int][]string{
+			0: {
+				`{
+					"Name": "Daenerys Stormborn of House Targaryen, the First of Her Name",
+					"HeightM": 1.65
+				}`,
+				`{
+					"Name": "Viserys I Targaryen, King of the Andals",
+					"HeightM": 1.82
+				}`,
+			},
+		},
+		Results: []map[string]any{
+			{
+				"Name": "Daenerys Stormborn of House Targaryen, the First of Her Name",
+			},
+		},
+	}
+
+	executeTestCase(t, test)
+}
+
 func TestQuerySimpleWithLikeStringContainsFilterBlockAsPrefixString(t *testing.T) {
 	test := testUtils.RequestTestCase{
 		Description: "Simple query with basic like-string filter with string as prefix",
 		Request: `query {
 					Users(filter: {Name: {_like: "Viserys%"}}) {
+						Name
+					}
+				}`,
+		Docs: map[int][]string{
+			0: {
+				`{
+					"Name": "Daenerys Stormborn of House Targaryen, the First of Her Name",
+					"HeightM": 1.65
+				}`,
+				`{
+					"Name": "Viserys I Targaryen, King of the Andals",
+					"HeightM": 1.82
+				}`,
+			},
+		},
+		Results: []map[string]any{
+			{
+				"Name": "Viserys I Targaryen, King of the Andals",
+			},
+		},
+	}
+
+	executeTestCase(t, test)
+}
+
+func TestQuerySimple_WithCaseInsensitiveLikeString_ShouldMatchPrefixString(t *testing.T) {
+	test := testUtils.RequestTestCase{
+		Description: "Simple query with basic case insensitive like-string filter with string as prefix",
+		Request: `query {
+					Users(filter: {Name: {_ilike: "viserys%"}}) {
 						Name
 					}
 				}`,
@@ -106,11 +166,71 @@ func TestQuerySimpleWithLikeStringContainsFilterBlockAsSuffixString(t *testing.T
 	executeTestCase(t, test)
 }
 
+func TestQuerySimple_WithCaseInsensitiveLikeString_ShouldMatchSuffixString(t *testing.T) {
+	test := testUtils.RequestTestCase{
+		Description: "Simple query with basic case insensitive like-string filter with string as suffix",
+		Request: `query {
+					Users(filter: {Name: {_ilike: "%andals"}}) {
+						Name
+					}
+				}`,
+		Docs: map[int][]string{
+			0: {
+				`{
+					"Name": "Daenerys Stormborn of House Targaryen, the First of Her Name",
+					"HeightM": 1.65
+				}`,
+				`{
+					"Name": "Viserys I Targaryen, King of the Andals",
+					"HeightM": 1.82
+				}`,
+			},
+		},
+		Results: []map[string]any{
+			{
+				"Name": "Viserys I Targaryen, King of the Andals",
+			},
+		},
+	}
+
+	executeTestCase(t, test)
+}
+
 func TestQuerySimpleWithLikeStringContainsFilterBlockExactString(t *testing.T) {
 	test := testUtils.RequestTestCase{
 		Description: "Simple query with basic like-string filter with string as suffix",
 		Request: `query {
 					Users(filter: {Name: {_like: "Daenerys Stormborn of House Targaryen, the First of Her Name"}}) {
+						Name
+					}
+				}`,
+		Docs: map[int][]string{
+			0: {
+				`{
+					"Name": "Daenerys Stormborn of House Targaryen, the First of Her Name",
+					"HeightM": 1.65
+				}`,
+				`{
+					"Name": "Viserys I Targaryen, King of the Andals",
+					"HeightM": 1.82
+				}`,
+			},
+		},
+		Results: []map[string]any{
+			{
+				"Name": "Daenerys Stormborn of House Targaryen, the First of Her Name",
+			},
+		},
+	}
+
+	executeTestCase(t, test)
+}
+
+func TestQuerySimple_WithCaseInsensitiveLikeString_ShouldMatchExactString(t *testing.T) {
+	test := testUtils.RequestTestCase{
+		Description: "Simple query with basic like-string filter with string as suffix",
+		Request: `query {
+					Users(filter: {Name: {_ilike: "daenerys stormborn of house targaryen, the first of her name"}}) {
 						Name
 					}
 				}`,

--- a/tests/integration/query/simple/with_filter/with_nlike_string_test.go
+++ b/tests/integration/query/simple/with_filter/with_nlike_string_test.go
@@ -46,11 +46,71 @@ func TestQuerySimpleWithNotLikeStringContainsFilterBlockContainsString(t *testin
 	executeTestCase(t, test)
 }
 
+func TestQuerySimple_WithNotCaseInsensitiveLikeString_ShouldMatchString(t *testing.T) {
+	test := testUtils.RequestTestCase{
+		Description: "Simple query with basic not case insensitive like-string filter contains string",
+		Request: `query {
+					Users(filter: {Name: {_nilike: "%stormborn%"}}) {
+						Name
+					}
+				}`,
+		Docs: map[int][]string{
+			0: {
+				`{
+					"Name": "Daenerys Stormborn of House Targaryen, the First of Her Name",
+					"HeightM": 1.65
+				}`,
+				`{
+					"Name": "Viserys I Targaryen, King of the Andals",
+					"HeightM": 1.82
+				}`,
+			},
+		},
+		Results: []map[string]any{
+			{
+				"Name": "Viserys I Targaryen, King of the Andals",
+			},
+		},
+	}
+
+	executeTestCase(t, test)
+}
+
 func TestQuerySimpleWithNotLikeStringContainsFilterBlockAsPrefixString(t *testing.T) {
 	test := testUtils.RequestTestCase{
 		Description: "Simple query with basic not like-string filter with string as prefix",
 		Request: `query {
 					Users(filter: {Name: {_nlike: "Viserys%"}}) {
+						Name
+					}
+				}`,
+		Docs: map[int][]string{
+			0: {
+				`{
+					"Name": "Daenerys Stormborn of House Targaryen, the First of Her Name",
+					"HeightM": 1.65
+				}`,
+				`{
+					"Name": "Viserys I Targaryen, King of the Andals",
+					"HeightM": 1.82
+				}`,
+			},
+		},
+		Results: []map[string]any{
+			{
+				"Name": "Daenerys Stormborn of House Targaryen, the First of Her Name",
+			},
+		},
+	}
+
+	executeTestCase(t, test)
+}
+
+func TestQuerySimple_WithNotCaseInsensitiveLikeString_ShouldMatchPrefixString(t *testing.T) {
+	test := testUtils.RequestTestCase{
+		Description: "Simple query with basic not case insensitive like-string filter with string as prefix",
+		Request: `query {
+					Users(filter: {Name: {_nilike: "viserys%"}}) {
 						Name
 					}
 				}`,
@@ -106,11 +166,71 @@ func TestQuerySimpleWithNotLikeStringContainsFilterBlockAsSuffixString(t *testin
 	executeTestCase(t, test)
 }
 
+func TestQuerySimple_WithNotCaseInsensitiveLikeString_ShouldMatchSuffixString(t *testing.T) {
+	test := testUtils.RequestTestCase{
+		Description: "Simple query with basic not like-string filter with string as suffix",
+		Request: `query {
+					Users(filter: {Name: {_nilike: "%andals"}}) {
+						Name
+					}
+				}`,
+		Docs: map[int][]string{
+			0: {
+				`{
+					"Name": "Daenerys Stormborn of House Targaryen, the First of Her Name",
+					"HeightM": 1.65
+				}`,
+				`{
+					"Name": "Viserys I Targaryen, King of the Andals",
+					"HeightM": 1.82
+				}`,
+			},
+		},
+		Results: []map[string]any{
+			{
+				"Name": "Daenerys Stormborn of House Targaryen, the First of Her Name",
+			},
+		},
+	}
+
+	executeTestCase(t, test)
+}
+
 func TestQuerySimpleWithNotLikeStringContainsFilterBlockExactString(t *testing.T) {
 	test := testUtils.RequestTestCase{
 		Description: "Simple query with basic not like-string filter with string as suffix",
 		Request: `query {
 					Users(filter: {Name: {_nlike: "Daenerys Stormborn of House Targaryen, the First of Her Name"}}) {
+						Name
+					}
+				}`,
+		Docs: map[int][]string{
+			0: {
+				`{
+					"Name": "Daenerys Stormborn of House Targaryen, the First of Her Name",
+					"HeightM": 1.65
+				}`,
+				`{
+					"Name": "Viserys I Targaryen, King of the Andals",
+					"HeightM": 1.82
+				}`,
+			},
+		},
+		Results: []map[string]any{
+			{
+				"Name": "Viserys I Targaryen, King of the Andals",
+			},
+		},
+	}
+
+	executeTestCase(t, test)
+}
+
+func TestQuerySimple_WithNotCaseInsensitiveLikeString_MatchExactString(t *testing.T) {
+	test := testUtils.RequestTestCase{
+		Description: "Simple query with basic not case insensitive like-string filter with string as suffix",
+		Request: `query {
+					Users(filter: {Name: {_nilike: "daenerys stormborn of house targaryen, the first of her name"}}) {
 						Name
 					}
 				}`,

--- a/tests/integration/schema/aggregates/inline_array_test.go
+++ b/tests/integration/schema/aggregates/inline_array_test.go
@@ -1387,6 +1387,12 @@ func TestSchemaAggregateInlineArrayCreatesUsersNillableStringCountFilter(t *test
 																},
 															},
 															map[string]any{
+																"name": "_ilike",
+																"type": map[string]any{
+																	"name": "String",
+																},
+															},
+															map[string]any{
 																"name": "_in",
 																"type": map[string]any{
 																	"name": nil,
@@ -1400,6 +1406,12 @@ func TestSchemaAggregateInlineArrayCreatesUsersNillableStringCountFilter(t *test
 															},
 															map[string]any{
 																"name": "_ne",
+																"type": map[string]any{
+																	"name": "String",
+																},
+															},
+															map[string]any{
+																"name": "_nilike",
 																"type": map[string]any{
 																	"name": "String",
 																},
@@ -1525,6 +1537,12 @@ func TestSchemaAggregateInlineArrayCreatesUsersStringCountFilter(t *testing.T) {
 																},
 															},
 															map[string]any{
+																"name": "_ilike",
+																"type": map[string]any{
+																	"name": "String",
+																},
+															},
+															map[string]any{
 																"name": "_in",
 																"type": map[string]any{
 																	"name": nil,
@@ -1538,6 +1556,12 @@ func TestSchemaAggregateInlineArrayCreatesUsersStringCountFilter(t *testing.T) {
 															},
 															map[string]any{
 																"name": "_ne",
+																"type": map[string]any{
+																	"name": "String",
+																},
+															},
+															map[string]any{
+																"name": "_nilike",
 																"type": map[string]any{
 																	"name": "String",
 																},


### PR DESCRIPTION
## Relevant issue(s)

Resolves #2367 

## Description

This PR adds support for case insensitive like and not-like operators. This was requested by a partner.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

make test

Specify the platform(s) on which this was tested:
- MacOS
