### PR TITLE
fix: Add missing directive definitions

### DIFF
--- a/request/graphql/schema/collection.go
+++ b/request/graphql/schema/collection.go
@@ -15,14 +15,14 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/sourcenetwork/graphql-go/language/ast"
+	gqlp "github.com/sourcenetwork/graphql-go/language/parser"
+	"github.com/sourcenetwork/graphql-go/language/source"
 	"github.com/sourcenetwork/immutable"
 
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/request"
 	"github.com/sourcenetwork/defradb/request/graphql/schema/types"
-	"github.com/sourcenetwork/graphql-go/language/ast"
-	gqlp "github.com/sourcenetwork/graphql-go/language/parser"
-	"github.com/sourcenetwork/graphql-go/language/source"
 )
 
 // FromString parses a GQL SDL string into a set of collection descriptions.

--- a/request/graphql/schema/collection.go
+++ b/request/graphql/schema/collection.go
@@ -20,8 +20,6 @@ import (
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/request"
 	"github.com/sourcenetwork/defradb/request/graphql/schema/types"
-
-	schemaTypes "github.com/sourcenetwork/defradb/request/graphql/schema/types"
 	"github.com/sourcenetwork/graphql-go/language/ast"
 	gqlp "github.com/sourcenetwork/graphql-go/language/parser"
 	"github.com/sourcenetwork/graphql-go/language/source"
@@ -392,7 +390,7 @@ func setCRDTType(field *ast.FieldDefinition, kind client.FieldKind) (client.CTyp
 			switch arg.Name.Value {
 			case "type":
 				cTypeString := arg.Value.GetValue().(string)
-				cType, validCRDTEnum := schemaTypes.CRDTEnum.ParseValue(cTypeString).(client.CType)
+				cType, validCRDTEnum := types.CRDTEnum.ParseValue(cTypeString).(client.CType)
 				if !validCRDTEnum {
 					return 0, client.NewErrInvalidCRDTType(field.Name.Value, cTypeString)
 				}

--- a/request/graphql/schema/manager.go
+++ b/request/graphql/schema/manager.go
@@ -111,9 +111,12 @@ func defaultMutationType() *gql.Object {
 // default directives type.
 func defaultDirectivesType() []*gql.Directive {
 	return []*gql.Directive{
+		schemaTypes.CRDTFieldDirective,
 		schemaTypes.ExplainDirective,
 		schemaTypes.IndexDirective,
 		schemaTypes.IndexFieldDirective,
+		schemaTypes.PrimaryDirective,
+		schemaTypes.RelationDirective,
 	}
 }
 

--- a/request/graphql/schema/manager.go
+++ b/request/graphql/schema/manager.go
@@ -169,6 +169,7 @@ func defaultTypes() []gql.Type {
 		schemaTypes.CommitLinkObject,
 		schemaTypes.CommitObject,
 
+		schemaTypes.CRDTEnum,
 		schemaTypes.ExplainEnum,
 	}
 }

--- a/request/graphql/schema/types/descriptions.go
+++ b/request/graphql/schema/types/descriptions.go
@@ -218,6 +218,9 @@ Sort the results in ascending order, e.g. null,1,2,3,a,b,c.
 	descOrderDescription string = `
 Sort the results in descending order, e.g. c,b,a,3,2,1,null.
 `
+	crdtDirectiveDescription string = `
+Allows the explicit definition of a field's CRDT type. By default it is defined as LWWRegister.
+`
 	primaryDirectiveDescription string = `
 Indicate the primary side of a one-to-one relationship.
 `

--- a/request/graphql/schema/types/types.go
+++ b/request/graphql/schema/types/types.go
@@ -11,6 +11,7 @@
 package types
 
 import (
+	"github.com/sourcenetwork/defradb/client"
 	gql "github.com/sourcenetwork/graphql-go"
 )
 
@@ -130,13 +131,28 @@ var (
 		},
 	})
 
+	CRDTEnum = gql.NewEnum(gql.EnumConfig{
+		Name:        "CRDTType",
+		Description: "One of the possible CRDT Types.",
+		Values: gql.EnumValueConfigMap{
+			client.LWW_REGISTER.String(): &gql.EnumValueConfig{
+				Value:       client.LWW_REGISTER,
+				Description: "Last Write Wins register",
+			},
+			client.PN_COUNTER.String(): &gql.EnumValueConfig{
+				Value:       client.PN_COUNTER,
+				Description: "Positive-Negative Counter",
+			},
+		},
+	})
+
 	// CRDTFieldDirective @crdt is used to define the CRDT type of a field
 	CRDTFieldDirective *gql.Directive = gql.NewDirective(gql.DirectiveConfig{
 		Name:        CRDTDirectiveLabel,
 		Description: crdtDirectiveDescription,
 		Args: gql.FieldConfigArgument{
 			CRDTDirectivePropType: &gql.ArgumentConfig{
-				Type: gql.String,
+				Type: CRDTEnum,
 			},
 		},
 		Locations: []string{

--- a/request/graphql/schema/types/types.go
+++ b/request/graphql/schema/types/types.go
@@ -11,8 +11,9 @@
 package types
 
 import (
-	"github.com/sourcenetwork/defradb/client"
 	gql "github.com/sourcenetwork/graphql-go"
+
+	"github.com/sourcenetwork/defradb/client"
 )
 
 const (

--- a/request/graphql/schema/types/types.go
+++ b/request/graphql/schema/types/types.go
@@ -24,6 +24,9 @@ const (
 	ExplainArgExecute  string = "execute"
 	ExplainArgDebug    string = "debug"
 
+	CRDTDirectiveLabel    = "crdt"
+	CRDTDirectivePropType = "type"
+
 	IndexDirectiveLabel          = "index"
 	IndexDirectivePropName       = "name"
 	IndexDirectivePropUnique     = "unique"
@@ -120,6 +123,20 @@ var (
 			},
 			IndexDirectivePropDirection: &gql.ArgumentConfig{
 				Type: OrderingEnum,
+			},
+		},
+		Locations: []string{
+			gql.DirectiveLocationField,
+		},
+	})
+
+	// CRDTFieldDirective @crdt is used to define the CRDT type of a field
+	CRDTFieldDirective *gql.Directive = gql.NewDirective(gql.DirectiveConfig{
+		Name:        CRDTDirectiveLabel,
+		Description: crdtDirectiveDescription,
+		Args: gql.FieldConfigArgument{
+			CRDTDirectivePropType: &gql.ArgumentConfig{
+				Type: gql.String,
 			},
 		},
 		Locations: []string{


### PR DESCRIPTION
## Relevant issue(s)

Resolves #2312 

## Description

This PR adds the missing directive definitions (`@crdt`, `@primary`, `@relation`) to GraphQL

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

tested in GraphQL client

Specify the platform(s) on which this was tested:
- MacOS
