### PR TITLE
fix: Update GetCollections behaviour

### DIFF
--- a/cli/collection_describe.go
+++ b/cli/collection_describe.go
@@ -33,10 +33,10 @@ Example: view all collections
 Example: view collection by name
   defradb client collection describe --name User
 		
-Example: view collection by schema id
+Example: view collection by schema root id
   defradb client collection describe --schema bae123
 		
-Example: view collection by version id
+Example: view collection by version id. This will also return inactive collections
   defradb client collection describe --version bae123
 		`,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/client/db.go
+++ b/client/db.go
@@ -191,6 +191,9 @@ type Store interface {
 
 	// GetCollections returns all collections and their descriptions matching the given options
 	// that currently exist within this [Store].
+	//
+	// Inactive collections are not returned by default unless a specific schema version ID
+	// is provided.
 	GetCollections(context.Context, CollectionFetchOptions) ([]Collection, error)
 
 	// GetSchemaByVersionID returns the schema description for the schema version of the

--- a/db/collection.go
+++ b/db/collection.go
@@ -709,8 +709,11 @@ func (db *db) getCollectionByName(ctx context.Context, txn datastore.Txn, name s
 	return cols[0], nil
 }
 
-// GetCollections returns all collections and their descriptions matching the given options
+// getCollections returns all collections and their descriptions matching the given options
 // that currently exist within this [Store].
+//
+// Inactive collections are not returned by default unless a specific schema version ID
+// is provided.
 func (db *db) getCollections(
 	ctx context.Context,
 	txn datastore.Txn,

--- a/db/collection.go
+++ b/db/collection.go
@@ -763,7 +763,8 @@ func (db *db) getCollections(
 				continue
 			}
 		}
-		if !options.IncludeInactive.Value() && !col.Name.HasValue() {
+		// By default, we don't return inactive collections unless a specific version is requested.
+		if !options.IncludeInactive.Value() && !col.Name.HasValue() && !options.SchemaVersionID.HasValue() {
 			continue
 		}
 

--- a/tests/integration/schema/updates/with_schema_branch_test.go
+++ b/tests/integration/schema/updates/with_schema_branch_test.go
@@ -545,8 +545,7 @@ func TestSchemaUpdates_WithBranchingSchemaAndSetActiveSchemaToOtherBranchThenPat
 }
 
 func TestSchemaUpdates_WithBranchingSchemaAndGetCollectionAtVersion(t *testing.T) {
-	schemaVersion2ID := "bafkreidn4f3i52756wevi3sfpbqzijgy6v24zh565pmvtmpqr4ou52v2q4"
-	schemaVersion3ID := "bafkreieilqyv4bydakul5tbikpysmzwhzvxdau4twcny5n46zvxhkv7oli"
+	schemaVersion1ID := "bafkreiebcgze3rs6j3g7gu65dwskdg5fn3qby5c6nqffhbdkcy2l5bbvp4"
 
 	test := testUtils.TestCase{
 		Description: `Test schema update, with branching schema toggling between branches and gets the 
@@ -561,41 +560,22 @@ collection at a specific version`,
 			},
 			testUtils.SchemaPatch{
 				// The second schema version will not be set as the active version, leaving the initial version active
-				SetAsDefaultVersion: immutable.Some(false),
+				SetAsDefaultVersion: immutable.Some(true),
 				Patch: `
 					[
 						{ "op": "add", "path": "/Users/Fields/-", "value": {"Name": "email", "Kind": 11} }
 					]
 				`,
 			},
-			testUtils.SchemaPatch{
-				// The third schema version will be set as the active version, going from version 1 to 3
-				SetAsDefaultVersion: immutable.Some(true),
-				Patch: `
-					[
-						{ "op": "add", "path": "/Users/Fields/-", "value": {"Name": "phone", "Kind": 11} }
-					]
-				`,
-			},
-			testUtils.SetActiveSchemaVersion{
-				// Set the second schema version to be active
-				SchemaVersionID: schemaVersion2ID,
-			},
 			testUtils.GetCollections{
 				FilterOptions: client.CollectionFetchOptions{
-					SchemaVersionID: immutable.Some(schemaVersion3ID),
+					SchemaVersionID: immutable.Some(schemaVersion1ID),
 				},
 				ExpectedResults: []client.CollectionDescription{
 					{
-						// The collection version for schema version 3 is present and is inactive, it also has the first collection
-						// as source.
-						ID:              3,
-						SchemaVersionID: schemaVersion3ID,
-						Sources: []any{
-							&client.CollectionSource{
-								SourceCollectionID: 1,
-							},
-						},
+						// The original collection version is present, it has no source and is inactive (has no name).
+						ID:              1,
+						SchemaVersionID: schemaVersion1ID,
 					},
 				},
 			},


### PR DESCRIPTION
## Relevant issue(s)

Resolves #2371 

## Description

This PR updates the behaviour of `getCollections` to return inactive collections if a specific version is requested even if the `--get-inactive` flag hasn't been set.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

make test

Specify the platform(s) on which this was tested:
- MacOS
