### PR TITLE
fix: Add missing logs at startup

### DIFF
--- a/http/server_test.go
+++ b/http/server_test.go
@@ -65,11 +65,28 @@ var testHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) 
 	w.WriteHeader(http.StatusOK)
 })
 
+func TestServerServeWithNoListener(t *testing.T) {
+	srv, err := NewServer(testHandler)
+	require.NoError(t, err)
+
+	err = srv.Serve()
+	require.ErrorIs(t, err, ErrNoListener)
+}
+
+func TestServerServeWithTLSAndNoListener(t *testing.T) {
+	certPath, keyPath := writeTestCerts(t)
+	srv, err := NewServer(testHandler, WithTLSCertPath(certPath), WithTLSKeyPath(keyPath))
+	require.NoError(t, err)
+
+	err = srv.Serve()
+	require.ErrorIs(t, err, ErrNoListener)
+}
+
 func TestServerListenAndServeWithInvalidAddress(t *testing.T) {
 	srv, err := NewServer(testHandler, WithAddress("invalid"))
 	require.NoError(t, err)
 
-	err = srv.ListenAndServe()
+	err = srv.SetListener()
 	require.ErrorContains(t, err, "address invalid")
 }
 
@@ -78,15 +95,23 @@ func TestServerListenAndServeWithTLSAndInvalidAddress(t *testing.T) {
 	srv, err := NewServer(testHandler, WithAddress("invalid"), WithTLSCertPath(certPath), WithTLSKeyPath(keyPath))
 	require.NoError(t, err)
 
-	err = srv.ListenAndServe()
+	err = srv.SetListener()
 	require.ErrorContains(t, err, "address invalid")
 }
 
 func TestServerListenAndServeWithTLSAndInvalidCerts(t *testing.T) {
-	srv, err := NewServer(testHandler, WithAddress("invalid"), WithTLSCertPath("invalid.crt"), WithTLSKeyPath("invalid.key"))
+	srv, err := NewServer(
+		testHandler,
+		WithAddress("invalid"),
+		WithTLSCertPath("invalid.crt"),
+		WithTLSKeyPath("invalid.key"),
+		WithAddress("127.0.0.1:30001"),
+	)
 	require.NoError(t, err)
 
-	err = srv.ListenAndServe()
+	err = srv.SetListener()
+	require.NoError(t, err)
+	err = srv.Serve()
 	require.ErrorContains(t, err, "no such file or directory")
 }
 
@@ -95,7 +120,9 @@ func TestServerListenAndServeWithAddress(t *testing.T) {
 	require.NoError(t, err)
 
 	go func() {
-		err := srv.ListenAndServe()
+		err := srv.SetListener()
+		require.NoError(t, err)
+		err = srv.Serve()
 		require.ErrorIs(t, http.ErrServerClosed, err)
 	}()
 
@@ -118,7 +145,9 @@ func TestServerListenAndServeWithTLS(t *testing.T) {
 	require.NoError(t, err)
 
 	go func() {
-		err := srv.ListenAndServe()
+		err := srv.SetListener()
+		require.NoError(t, err)
+		err = srv.Serve()
 		require.ErrorIs(t, http.ErrServerClosed, err)
 	}()
 
@@ -140,7 +169,9 @@ func TestServerListenAndServeWithAllowedOrigins(t *testing.T) {
 	require.NoError(t, err)
 
 	go func() {
-		err := srv.ListenAndServe()
+		err := srv.SetListener()
+		require.NoError(t, err)
+		err = srv.Serve()
 		require.ErrorIs(t, http.ErrServerClosed, err)
 	}()
 

--- a/http/server_test.go
+++ b/http/server_test.go
@@ -113,6 +113,8 @@ func TestServerListenAndServeWithTLSAndInvalidCerts(t *testing.T) {
 	require.NoError(t, err)
 	err = srv.Serve()
 	require.ErrorContains(t, err, "no such file or directory")
+	err = srv.listener.Close()
+	require.NoError(t, err)
 }
 
 func TestServerListenAndServeWithAddress(t *testing.T) {

--- a/net/peer.go
+++ b/net/peer.go
@@ -177,6 +177,7 @@ func (p *Peer) Start() error {
 		go p.handleBroadcastLoop()
 	}
 
+	log.FeedbackInfo(p.ctx, "Starting P2P node", logging.NewKV("P2P addresses", p.host.Addrs()))
 	// register the P2P gRPC server
 	go func() {
 		pb.RegisterServiceServer(p.p2pRPC, p.server)

--- a/node/node.go
+++ b/node/node.go
@@ -12,6 +12,7 @@ package node
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	gohttp "net/http"
 
@@ -167,7 +168,7 @@ func (n *Node) Start(ctx context.Context) error {
 		}
 		log.FeedbackInfo(ctx, fmt.Sprintf("Providing HTTP API at %s.", n.Server.Address()))
 		go func() {
-			if err := n.Server.Serve(); err != nil && err != gohttp.ErrServerClosed {
+			if err := n.Server.Serve(); err != nil && !errors.Is(err, gohttp.ErrServerClosed) {
 				log.FeedbackErrorE(ctx, "HTTP server stopped", err)
 			}
 		}()

--- a/node/node.go
+++ b/node/node.go
@@ -12,6 +12,8 @@ package node
 
 import (
 	"context"
+	"fmt"
+	gohttp "net/http"
 
 	"github.com/libp2p/go-libp2p/core/peer"
 
@@ -159,8 +161,13 @@ func (n *Node) Start(ctx context.Context) error {
 		}
 	}
 	if n.Server != nil {
+		err := n.Server.SetListener()
+		if err != nil {
+			return err
+		}
+		log.FeedbackInfo(ctx, fmt.Sprintf("Providing HTTP API at %s.", n.Server.Address()))
 		go func() {
-			if err := n.Server.ListenAndServe(); err != nil {
+			if err := n.Server.Serve(); err != nil && err != gohttp.ErrServerClosed {
 				log.FeedbackErrorE(ctx, "HTTP server stopped", err)
 			}
 		}()


### PR DESCRIPTION
## Relevant issue(s)

Resolves #2308 
Resolves #2309

## Description

This PR re-adds startup logs showing the P2P addresses and HTTP endpoint of the node.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

manually tested in the CLI

Specify the platform(s) on which this was tested:
- MacOS
