### PR TITLE
fix(i): Move cache action after goreleaser action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,11 +71,17 @@ jobs:
         shell: bash
         run: echo "sha_short=$(git rev-parse --short HEAD)" >> ${GITHUB_ENV}
 
-      # Note: These saves don't actually happen right away, as if you notice there is
-      # no `dist` directory, when these are executed. The caching actually happens after
-      # the goreleaser is ran which populates the `dist` directory, which is then picked
-      # up in the job cleaning step that is ran end of this job. The step is a post-caching
-      # cleanup step which notices the target directory is now populated and caches it.
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v5
+        with:
+          distribution: goreleaser-pro
+          version: latest
+          args: release --clean --split ${{ env.flags }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+
       - name: Save cache on Linux
         if: matrix.os == 'ubuntu-latest'
         uses: actions/cache/save@v4
@@ -97,19 +103,6 @@ jobs:
           path: dist/windows_amd64
           key: windows-${{ env.sha_short }}
           enableCrossOsArchive: true
-
-      # This is the step that actually `populates` the `dist` directory.
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v5
-        with:
-          distribution: goreleaser-pro
-          version: latest
-          args: release --clean --split ${{ env.flags }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
-          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
-      # Cacheing actually happens, about here (once the above is ran).
 
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Relevant issue(s)

Resolves #2394 

## Description

This PR moves the cache action in the release workflow to be after the goreleaser action. After the last release, we changed the cache action to use `action/cache/save` instead of just `action/cache`. The difference is that `action/cache` acts like a defer function and  gets actioned at the end of a job. `action/cache/save` is meant to be more granular and tries to save when called. This caused a situation where it tried to save in the cache a path that didn't exist.

## How has this been tested?

tested the workflow on my personal fork
