### PR TITLE
feat: Add PatchCollection

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -95,6 +95,7 @@ func NewDefraCommand() *cobra.Command {
 		MakeCollectionUpdateCommand(),
 		MakeCollectionCreateCommand(),
 		MakeCollectionDescribeCommand(),
+		MakeCollectionPatchCommand(),
 	)
 
 	client := MakeClientCommand()

--- a/cli/collection_patch.go
+++ b/cli/collection_patch.go
@@ -37,6 +37,7 @@ Example: patch from stdin:
   cat patch.json | defradb client collection patch -
 
 To learn more about the DefraDB GraphQL Schema Language, refer to https://docs.source.network.`,
+		Args: cobra.RangeArgs(0, 1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			store := mustGetContextStore(cmd)
 
@@ -54,7 +55,7 @@ To learn more about the DefraDB GraphQL Schema Language, refer to https://docs.s
 					return err
 				}
 				patch = string(data)
-			case len(args) >= 1:
+			case len(args) == 1:
 				patch = args[0]
 			default:
 				return fmt.Errorf("patch cannot be empty")

--- a/cli/collection_patch.go
+++ b/cli/collection_patch.go
@@ -31,7 +31,7 @@ Example: patch from an argument string:
   defradb client collection patch '[{ "op": "add", "path": "...", "value": {...} }]'
 
 Example: patch from file:
-  defradb client collection patch -f patch.json
+  defradb client collection patch -p patch.json
 
 Example: patch from stdin:
   cat patch.json | defradb client collection patch -

--- a/cli/collection_patch.go
+++ b/cli/collection_patch.go
@@ -1,0 +1,68 @@
+// Copyright 2023 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package cli
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+func MakeCollectionPatchCommand() *cobra.Command {
+	var patchFile string
+	var cmd = &cobra.Command{
+		Use:   "patch [patch]",
+		Short: "Patch existing collection descriptions",
+		Long: `Patch existing collection descriptions.
+
+Uses JSON Patch to modify collection descriptions.
+
+Example: patch from an argument string:
+  defradb client collection patch '[{ "op": "add", "path": "...", "value": {...} }]'
+
+Example: patch from file:
+  defradb client collection patch -f patch.json
+
+Example: patch from stdin:
+  cat patch.json | defradb client collection patch -
+
+To learn more about the DefraDB GraphQL Schema Language, refer to https://docs.source.network.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			store := mustGetContextStore(cmd)
+
+			var patch string
+			switch {
+			case patchFile != "":
+				data, err := os.ReadFile(patchFile)
+				if err != nil {
+					return err
+				}
+				patch = string(data)
+			case len(args) > 0 && args[0] == "-":
+				data, err := io.ReadAll(cmd.InOrStdin())
+				if err != nil {
+					return err
+				}
+				patch = string(data)
+			case len(args) >= 1:
+				patch = args[0]
+			default:
+				return fmt.Errorf("patch cannot be empty")
+			}
+
+			return store.PatchCollection(cmd.Context(), patch)
+		},
+	}
+	cmd.Flags().StringVarP(&patchFile, "patch-file", "p", "", "File to load a patch from")
+	return cmd
+}

--- a/cli/collection_patch.go
+++ b/cli/collection_patch.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Democratized Data Foundation
+// Copyright 2024 Democratized Data Foundation
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt.

--- a/cli/schema_patch.go
+++ b/cli/schema_patch.go
@@ -37,7 +37,7 @@ Example: patch from an argument string:
   defradb client schema patch '[{ "op": "add", "path": "...", "value": {...} }]' '{"lenses": [...'
 
 Example: patch from file:
-  defradb client schema patch -f patch.json
+  defradb client schema patch -p patch.json
 
 Example: patch from stdin:
   cat patch.json | defradb client schema patch -

--- a/client/db.go
+++ b/client/db.go
@@ -120,6 +120,17 @@ type Store interface {
 	// A lens configuration may also be provided, it will be added to all collections using the schema.
 	PatchSchema(context.Context, string, immutable.Option[model.Lens], bool) error
 
+	// PatchCollection takes the given JSON patch string and applies it to the set of CollectionDescriptions
+	// present in the database.
+	//
+	// It will also update the GQL types used by the query system. It will error and not apply any of the
+	// requested, valid updates should the net result of the patch result in an invalid state.  The
+	// individual operations defined in the patch do not need to result in a valid state, only the net result
+	// of the full patch.
+	//
+	// Currently only the collection name can be modified.
+	PatchCollection(context.Context, string) error
+
 	// SetActiveSchemaVersion activates all collection versions with the given schema version, and deactivates all
 	// those without it (if they share the same schema root).
 	//

--- a/client/mocks/db.go
+++ b/client/mocks/db.go
@@ -857,6 +857,49 @@ func (_c *DB_NewTxn_Call) RunAndReturn(run func(context.Context, bool) (datastor
 	return _c
 }
 
+// PatchCollection provides a mock function with given fields: _a0, _a1
+func (_m *DB) PatchCollection(_a0 context.Context, _a1 string) error {
+	ret := _m.Called(_a0, _a1)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// DB_PatchCollection_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'PatchCollection'
+type DB_PatchCollection_Call struct {
+	*mock.Call
+}
+
+// PatchCollection is a helper method to define mock.On call
+//   - _a0 context.Context
+//   - _a1 string
+func (_e *DB_Expecter) PatchCollection(_a0 interface{}, _a1 interface{}) *DB_PatchCollection_Call {
+	return &DB_PatchCollection_Call{Call: _e.mock.On("PatchCollection", _a0, _a1)}
+}
+
+func (_c *DB_PatchCollection_Call) Run(run func(_a0 context.Context, _a1 string)) *DB_PatchCollection_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string))
+	})
+	return _c
+}
+
+func (_c *DB_PatchCollection_Call) Return(_a0 error) *DB_PatchCollection_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *DB_PatchCollection_Call) RunAndReturn(run func(context.Context, string) error) *DB_PatchCollection_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // PatchSchema provides a mock function with given fields: _a0, _a1, _a2, _a3
 func (_m *DB) PatchSchema(_a0 context.Context, _a1 string, _a2 immutable.Option[model.Lens], _a3 bool) error {
 	ret := _m.Called(_a0, _a1, _a2, _a3)

--- a/db/collection.go
+++ b/db/collection.go
@@ -794,7 +794,7 @@ oldLoop:
 	for _, oldCol := range oldColsByID {
 		for _, newCol := range newColsByID {
 			// It is not enough to just match by the map index, in case the index does not pair
-			// up with the ID (this can happen if a user moves it)
+			// up with the ID (this can happen if a user moves the collection within the map)
 			if newCol.ID == oldCol.ID {
 				continue oldLoop
 			}

--- a/db/description/collection.go
+++ b/db/description/collection.go
@@ -13,8 +13,10 @@ package description
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"sort"
 
+	ds "github.com/ipfs/go-datastore"
 	"github.com/ipfs/go-datastore/query"
 
 	"github.com/sourcenetwork/defradb/client"
@@ -29,6 +31,11 @@ func SaveCollection(
 	txn datastore.Txn,
 	desc client.CollectionDescription,
 ) (client.CollectionDescription, error) {
+	existing, err := GetCollectionByID(ctx, txn, desc.ID)
+	if err != nil && !errors.Is(err, ds.ErrNotFound) {
+		return client.CollectionDescription{}, err
+	}
+
 	buf, err := json.Marshal(desc)
 	if err != nil {
 		return client.CollectionDescription{}, err
@@ -38,6 +45,35 @@ func SaveCollection(
 	err = txn.Systemstore().Put(ctx, key.ToDS(), buf)
 	if err != nil {
 		return client.CollectionDescription{}, err
+	}
+
+	if existing.Name.HasValue() && existing.Name != desc.Name {
+		nameKey := core.NewCollectionNameKey(existing.Name.Value())
+		idBuf, err := txn.Systemstore().Get(ctx, nameKey.ToDS())
+		nameIndexExsts := true
+		if err != nil {
+			if errors.Is(err, ds.ErrNotFound) {
+				nameIndexExsts = false
+			} else {
+				return client.CollectionDescription{}, err
+			}
+		}
+		if nameIndexExsts {
+			var keyID uint32
+			err = json.Unmarshal(idBuf, &keyID)
+			if err != nil {
+				return client.CollectionDescription{}, err
+			}
+
+			if keyID == desc.ID {
+				// The name index may have already been overwritten, pointing at another collection
+				// we should only remove the existing index if it still points at this collection
+				err := txn.Systemstore().Delete(ctx, nameKey.ToDS())
+				if err != nil {
+					return client.CollectionDescription{}, err
+				}
+			}
+		}
 	}
 
 	if desc.Name.HasValue() {

--- a/db/errors.go
+++ b/db/errors.go
@@ -16,95 +16,112 @@ import (
 )
 
 const (
-	errFailedToGetHeads                   string = "failed to get document heads"
-	errFailedToCreateCollectionQuery      string = "failed to create collection prefix query"
-	errFailedToGetCollection              string = "failed to get collection"
-	errFailedToGetAllCollections          string = "failed to get all collections"
-	errDocVerification                    string = "the document verification failed"
-	errAddingP2PCollection                string = "cannot add collection ID"
-	errRemovingP2PCollection              string = "cannot remove collection ID"
-	errAddCollectionWithPatch             string = "unknown collection, adding collections via patch is not supported"
-	errCollectionIDDoesntMatch            string = "CollectionID does not match existing"
-	errSchemaRootDoesntMatch              string = "SchemaRoot does not match existing"
-	errCannotModifySchemaName             string = "modifying the schema name is not supported"
-	errCannotSetVersionID                 string = "setting the VersionID is not supported. It is updated automatically"
-	errRelationalFieldMissingSchema       string = "a `Schema` [name] must be provided when adding a new relation field"
-	errRelationalFieldInvalidRelationType string = "invalid RelationType"
-	errRelationalFieldMissingIDField      string = "missing id field for relation object field"
-	errRelationalFieldMissingRelationName string = "missing relation name"
-	errPrimarySideNotDefined              string = "primary side of relation not defined"
-	errPrimarySideOnMany                  string = "cannot set the many side of a relation as primary"
-	errBothSidesPrimary                   string = "both sides of a relation cannot be primary"
-	errRelatedFieldKindMismatch           string = "invalid Kind of the related field"
-	errRelatedFieldRelationTypeMismatch   string = "invalid RelationType of the related field"
-	errRelationalFieldIDInvalidType       string = "relational id field of invalid kind"
-	errDuplicateField                     string = "duplicate field"
-	errCannotMutateField                  string = "mutating an existing field is not supported"
-	errCannotMoveField                    string = "moving fields is not currently supported"
-	errCannotDeleteField                  string = "deleting an existing field is not supported"
-	errFieldKindNotFound                  string = "no type found for given name"
-	errFieldKindDoesNotMatchFieldSchema   string = "field Kind does not match field Schema"
-	errSchemaNotFound                     string = "no schema found for given name"
-	errDocumentAlreadyExists              string = "a document with the given ID already exists"
-	errDocumentDeleted                    string = "a document with the given ID has been deleted"
-	errIndexMissingFields                 string = "index missing fields"
-	errNonZeroIndexIDProvided             string = "non-zero index ID provided"
-	errIndexFieldMissingName              string = "index field missing name"
-	errIndexFieldMissingDirection         string = "index field missing direction"
-	errIndexWithNameAlreadyExists         string = "index with name already exists"
-	errInvalidStoredIndex                 string = "invalid stored index"
-	errInvalidStoredIndexKey              string = "invalid stored index key"
-	errNonExistingFieldForIndex           string = "creating an index on a non-existing property"
-	errCollectionDoesntExisting           string = "collection with given name doesn't exist"
-	errFailedToStoreIndexedField          string = "failed to store indexed field"
-	errFailedToReadStoredIndexDesc        string = "failed to read stored index description"
-	errCanNotDeleteIndexedField           string = "can not delete indexed field"
-	errCanNotAddIndexWithPatch            string = "adding indexes via patch is not supported"
-	errCanNotDropIndexWithPatch           string = "dropping indexes via patch is not supported"
-	errCanNotChangeIndexWithPatch         string = "changing indexes via patch is not supported"
-	errIndexWithNameDoesNotExists         string = "index with name doesn't exists"
-	errCorruptedIndex                     string = "corrupted index. Please delete and recreate the index"
-	errInvalidFieldValue                  string = "invalid field value"
-	errUnsupportedIndexFieldType          string = "unsupported index field type"
-	errIndexDescriptionHasNoFields        string = "index description has no fields"
-	errFieldOrAliasToFieldNotExist        string = "The given field or alias to field does not exist"
-	errCreateFile                         string = "failed to create file"
-	errRemoveFile                         string = "failed to remove file"
-	errOpenFile                           string = "failed to open file"
-	errCloseFile                          string = "failed to close file"
-	errFailedtoCloseQueryReqAllIDs        string = "failed to close query requesting all docIDs"
-	errFailedToReadByte                   string = "failed to read byte"
-	errFailedToWriteString                string = "failed to write string"
-	errJSONDecode                         string = "failed to decode JSON"
-	errDocFromMap                         string = "failed to create a new doc from map"
-	errDocCreate                          string = "failed to save a new doc to collection"
-	errDocUpdate                          string = "failed to update doc to collection"
-	errExpectedJSONObject                 string = "expected JSON object"
-	errExpectedJSONArray                  string = "expected JSON array"
-	errOneOneAlreadyLinked                string = "target document is already linked to another document"
-	errIndexDoesNotMatchName              string = "the index used does not match the given name"
-	errCanNotIndexNonUniqueFields         string = "can not index a doc's field(s) that violates unique index"
-	errInvalidViewQuery                   string = "the query provided is not valid as a View"
+	errFailedToGetHeads                         string = "failed to get document heads"
+	errFailedToCreateCollectionQuery            string = "failed to create collection prefix query"
+	errFailedToGetCollection                    string = "failed to get collection"
+	errFailedToGetAllCollections                string = "failed to get all collections"
+	errDocVerification                          string = "the document verification failed"
+	errAddingP2PCollection                      string = "cannot add collection ID"
+	errRemovingP2PCollection                    string = "cannot remove collection ID"
+	errAddCollectionWithPatch                   string = "adding collections via patch is not supported"
+	errCollectionIDDoesntMatch                  string = "CollectionID does not match existing"
+	errSchemaRootDoesntMatch                    string = "SchemaRoot does not match existing"
+	errCannotModifySchemaName                   string = "modifying the schema name is not supported"
+	errCannotSetVersionID                       string = "setting the VersionID is not supported"
+	errRelationalFieldMissingSchema             string = "a schema name must be provided when adding a new relation field"
+	errRelationalFieldInvalidRelationType       string = "invalid RelationType"
+	errRelationalFieldMissingIDField            string = "missing id field for relation object field"
+	errRelationalFieldMissingRelationName       string = "missing relation name"
+	errPrimarySideNotDefined                    string = "primary side of relation not defined"
+	errPrimarySideOnMany                        string = "cannot set the many side of a relation as primary"
+	errBothSidesPrimary                         string = "both sides of a relation cannot be primary"
+	errRelatedFieldKindMismatch                 string = "invalid Kind of the related field"
+	errRelatedFieldRelationTypeMismatch         string = "invalid RelationType of the related field"
+	errRelationalFieldIDInvalidType             string = "relational id field of invalid kind"
+	errDuplicateField                           string = "duplicate field"
+	errCannotMutateField                        string = "mutating an existing field is not supported"
+	errCannotMoveField                          string = "moving fields is not currently supported"
+	errCannotDeleteField                        string = "deleting an existing field is not supported"
+	errFieldKindNotFound                        string = "no type found for given name"
+	errFieldKindDoesNotMatchFieldSchema         string = "field Kind does not match field Schema"
+	errSchemaNotFound                           string = "no schema found for given name"
+	errDocumentAlreadyExists                    string = "a document with the given ID already exists"
+	errDocumentDeleted                          string = "a document with the given ID has been deleted"
+	errIndexMissingFields                       string = "index missing fields"
+	errNonZeroIndexIDProvided                   string = "non-zero index ID provided"
+	errIndexFieldMissingName                    string = "index field missing name"
+	errIndexFieldMissingDirection               string = "index field missing direction"
+	errIndexWithNameAlreadyExists               string = "index with name already exists"
+	errInvalidStoredIndex                       string = "invalid stored index"
+	errInvalidStoredIndexKey                    string = "invalid stored index key"
+	errNonExistingFieldForIndex                 string = "creating an index on a non-existing property"
+	errCollectionDoesntExisting                 string = "collection with given name doesn't exist"
+	errFailedToStoreIndexedField                string = "failed to store indexed field"
+	errFailedToReadStoredIndexDesc              string = "failed to read stored index description"
+	errCanNotDeleteIndexedField                 string = "can not delete indexed field"
+	errCanNotAddIndexWithPatch                  string = "adding indexes via patch is not supported"
+	errCanNotDropIndexWithPatch                 string = "dropping indexes via patch is not supported"
+	errCanNotChangeIndexWithPatch               string = "changing indexes via patch is not supported"
+	errIndexWithNameDoesNotExists               string = "index with name doesn't exists"
+	errCorruptedIndex                           string = "corrupted index. Please delete and recreate the index"
+	errInvalidFieldValue                        string = "invalid field value"
+	errUnsupportedIndexFieldType                string = "unsupported index field type"
+	errIndexDescriptionHasNoFields              string = "index description has no fields"
+	errFieldOrAliasToFieldNotExist              string = "The given field or alias to field does not exist"
+	errCreateFile                               string = "failed to create file"
+	errRemoveFile                               string = "failed to remove file"
+	errOpenFile                                 string = "failed to open file"
+	errCloseFile                                string = "failed to close file"
+	errFailedtoCloseQueryReqAllIDs              string = "failed to close query requesting all docIDs"
+	errFailedToReadByte                         string = "failed to read byte"
+	errFailedToWriteString                      string = "failed to write string"
+	errJSONDecode                               string = "failed to decode JSON"
+	errDocFromMap                               string = "failed to create a new doc from map"
+	errDocCreate                                string = "failed to save a new doc to collection"
+	errDocUpdate                                string = "failed to update doc to collection"
+	errExpectedJSONObject                       string = "expected JSON object"
+	errExpectedJSONArray                        string = "expected JSON array"
+	errOneOneAlreadyLinked                      string = "target document is already linked to another document"
+	errIndexDoesNotMatchName                    string = "the index used does not match the given name"
+	errCanNotIndexNonUniqueFields               string = "can not index a doc's field(s) that violates unique index"
+	errInvalidViewQuery                         string = "the query provided is not valid as a View"
+	errCollectionAlreadyExists                  string = "collection already exists"
+	errMultipleActiveCollectionVersions         string = "multiple versions of same collection cannot be active"
+	errCollectionSourcesCannotBeMutated         string = "collection sources cannot be mutated"
+	errCollectionIndexesCannotBeMutated         string = "collection indexes cannot be mutated"
+	errCollectionFieldsCannotBeMutated          string = "collection fields cannot be mutated"
+	errCollectionRootIDCannotBeMutated          string = "collection root ID cannot be mutated"
+	errCollectionSchemaVersionIDCannotBeMutated string = "collection schema version ID cannot be mutated"
+	errCollectionIDCannotBeZero                 string = "collection ID cannot be zero"
+	errCollectionsCannotBeDeleted               string = "collections cannot be deleted"
 )
 
 var (
-	ErrFailedToGetCollection      = errors.New(errFailedToGetCollection)
-	ErrSubscriptionsNotAllowed    = errors.New("server does not accept subscriptions")
-	ErrInvalidFilter              = errors.New("invalid filter")
-	ErrCollectionAlreadyExists    = errors.New("collection already exists")
-	ErrCollectionNameEmpty        = errors.New("collection name can't be empty")
-	ErrSchemaNameEmpty            = errors.New("schema name can't be empty")
-	ErrSchemaRootEmpty            = errors.New("schema root can't be empty")
-	ErrSchemaVersionIDEmpty       = errors.New("schema version ID can't be empty")
-	ErrKeyEmpty                   = errors.New("key cannot be empty")
-	ErrCannotSetVersionID         = errors.New(errCannotSetVersionID)
-	ErrIndexMissingFields         = errors.New(errIndexMissingFields)
-	ErrIndexFieldMissingName      = errors.New(errIndexFieldMissingName)
-	ErrCorruptedIndex             = errors.New(errCorruptedIndex)
-	ErrExpectedJSONObject         = errors.New(errExpectedJSONObject)
-	ErrExpectedJSONArray          = errors.New(errExpectedJSONArray)
-	ErrInvalidViewQuery           = errors.New(errInvalidViewQuery)
-	ErrCanNotIndexNonUniqueFields = errors.New(errCanNotIndexNonUniqueFields)
+	ErrFailedToGetCollection                    = errors.New(errFailedToGetCollection)
+	ErrSubscriptionsNotAllowed                  = errors.New("server does not accept subscriptions")
+	ErrInvalidFilter                            = errors.New("invalid filter")
+	ErrCollectionAlreadyExists                  = errors.New(errCollectionAlreadyExists)
+	ErrCollectionNameEmpty                      = errors.New("collection name can't be empty")
+	ErrSchemaNameEmpty                          = errors.New("schema name can't be empty")
+	ErrSchemaRootEmpty                          = errors.New("schema root can't be empty")
+	ErrSchemaVersionIDEmpty                     = errors.New("schema version ID can't be empty")
+	ErrKeyEmpty                                 = errors.New("key cannot be empty")
+	ErrCannotSetVersionID                       = errors.New(errCannotSetVersionID)
+	ErrIndexMissingFields                       = errors.New(errIndexMissingFields)
+	ErrIndexFieldMissingName                    = errors.New(errIndexFieldMissingName)
+	ErrCorruptedIndex                           = errors.New(errCorruptedIndex)
+	ErrExpectedJSONObject                       = errors.New(errExpectedJSONObject)
+	ErrExpectedJSONArray                        = errors.New(errExpectedJSONArray)
+	ErrInvalidViewQuery                         = errors.New(errInvalidViewQuery)
+	ErrCanNotIndexNonUniqueFields               = errors.New(errCanNotIndexNonUniqueFields)
+	ErrMultipleActiveCollectionVersions         = errors.New(errMultipleActiveCollectionVersions)
+	ErrCollectionSourcesCannotBeMutated         = errors.New(errCollectionSourcesCannotBeMutated)
+	ErrCollectionIndexesCannotBeMutated         = errors.New(errCollectionIndexesCannotBeMutated)
+	ErrCollectionFieldsCannotBeMutated          = errors.New(errCollectionFieldsCannotBeMutated)
+	ErrCollectionRootIDCannotBeMutated          = errors.New(errCollectionRootIDCannotBeMutated)
+	ErrCollectionSchemaVersionIDCannotBeMutated = errors.New(errCollectionSchemaVersionIDCannotBeMutated)
+	ErrCollectionIDCannotBeZero                 = errors.New(errCollectionIDCannotBeZero)
+	ErrCollectionsCannotBeDeleted               = errors.New(errCollectionsCannotBeDeleted)
 )
 
 // NewErrFailedToGetHeads returns a new error indicating that the heads of a document
@@ -205,6 +222,13 @@ func NewErrAddCollectionWithPatch(name string) error {
 	return errors.New(
 		errAddCollectionWithPatch,
 		errors.NewKV("Name", name),
+	)
+}
+
+func NewErrAddCollectionIDWithPatch(id uint32) error {
+	return errors.New(
+		errAddCollectionWithPatch,
+		errors.NewKV("ID", id),
 	)
 }
 
@@ -541,5 +565,69 @@ func NewErrInvalidViewQueryMissingQuery() error {
 	return errors.New(
 		errInvalidViewQuery,
 		errors.NewKV("Reason", "No query provided"),
+	)
+}
+
+func NewErrCollectionAlreadyExists(name string) error {
+	return errors.New(
+		errCollectionAlreadyExists,
+		errors.NewKV("Name", name),
+	)
+}
+
+func NewErrCollectionIDAlreadyExists(id uint32) error {
+	return errors.New(
+		errCollectionAlreadyExists,
+		errors.NewKV("ID", id),
+	)
+}
+
+func NewErrMultipleActiveCollectionVersions(name string, root uint32) error {
+	return errors.New(
+		errMultipleActiveCollectionVersions,
+		errors.NewKV("Name", name),
+		errors.NewKV("Root", root),
+	)
+}
+
+func NewErrCollectionSourcesCannotBeMutated(colID uint32) error {
+	return errors.New(
+		errCollectionSourcesCannotBeMutated,
+		errors.NewKV("CollectionID", colID),
+	)
+}
+
+func NewErrCollectionIndexesCannotBeMutated(colID uint32) error {
+	return errors.New(
+		errCollectionIndexesCannotBeMutated,
+		errors.NewKV("CollectionID", colID),
+	)
+}
+
+func NewErrCollectionFieldsCannotBeMutated(colID uint32) error {
+	return errors.New(
+		errCollectionFieldsCannotBeMutated,
+		errors.NewKV("CollectionID", colID),
+	)
+}
+
+func NewErrCollectionRootIDCannotBeMutated(colID uint32) error {
+	return errors.New(
+		errCollectionRootIDCannotBeMutated,
+		errors.NewKV("CollectionID", colID),
+	)
+}
+
+func NewErrCollectionSchemaVersionIDCannotBeMutated(colID uint32) error {
+	return errors.New(
+		errCollectionSchemaVersionIDCannotBeMutated,
+		errors.NewKV("CollectionID", colID),
+	)
+}
+
+func NewErrCollectionsCannotBeDeleted(colID uint32) error {
+	return errors.New(
+		errCollectionsCannotBeDeleted,
+		errors.NewKV("CollectionID", colID),
 	)
 }

--- a/db/txn_db.go
+++ b/db/txn_db.go
@@ -267,6 +267,31 @@ func (db *explicitTxnDB) PatchSchema(
 	return db.patchSchema(ctx, db.txn, patchString, migration, setAsDefaultVersion)
 }
 
+func (db *implicitTxnDB) PatchCollection(
+	ctx context.Context,
+	patchString string,
+) error {
+	txn, err := db.NewTxn(ctx, false)
+	if err != nil {
+		return err
+	}
+	defer txn.Discard(ctx)
+
+	err = db.patchCollection(ctx, txn, patchString)
+	if err != nil {
+		return err
+	}
+
+	return txn.Commit(ctx)
+}
+
+func (db *explicitTxnDB) PatchCollection(
+	ctx context.Context,
+	patchString string,
+) error {
+	return db.patchCollection(ctx, db.txn, patchString)
+}
+
 func (db *implicitTxnDB) SetActiveSchemaVersion(ctx context.Context, schemaVersionID string) error {
 	txn, err := db.NewTxn(ctx, false)
 	if err != nil {

--- a/http/client.go
+++ b/http/client.go
@@ -161,6 +161,25 @@ func (c *Client) PatchSchema(
 	return err
 }
 
+func (c *Client) PatchCollection(
+	ctx context.Context,
+	patch string,
+) error {
+	methodURL := c.http.baseURL.JoinPath("collections")
+
+	body, err := json.Marshal(patch)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPatch, methodURL.String(), bytes.NewBuffer(body))
+	if err != nil {
+		return err
+	}
+	_, err = c.http.request(req)
+	return err
+}
+
 func (c *Client) SetActiveSchemaVersion(ctx context.Context, schemaVersionID string) error {
 	methodURL := c.http.baseURL.JoinPath("schema", "default")
 

--- a/tests/clients/cli/wrapper.go
+++ b/tests/clients/cli/wrapper.go
@@ -210,6 +210,16 @@ func (w *Wrapper) PatchSchema(
 	return err
 }
 
+func (w *Wrapper) PatchCollection(
+	ctx context.Context,
+	patch string,
+) error {
+	args := []string{"client", "collection", "patch"}
+	args = append(args, patch)
+	_, err := w.cmd.execute(ctx, args)
+	return err
+}
+
 func (w *Wrapper) SetActiveSchemaVersion(ctx context.Context, schemaVersionID string) error {
 	args := []string{"client", "schema", "set-active"}
 	args = append(args, schemaVersionID)

--- a/tests/clients/http/wrapper.go
+++ b/tests/clients/http/wrapper.go
@@ -106,6 +106,13 @@ func (w *Wrapper) PatchSchema(
 	return w.client.PatchSchema(ctx, patch, migration, setAsDefaultVersion)
 }
 
+func (w *Wrapper) PatchCollection(
+	ctx context.Context,
+	patch string,
+) error {
+	return w.client.PatchCollection(ctx, patch)
+}
+
 func (w *Wrapper) SetActiveSchemaVersion(ctx context.Context, schemaVersionID string) error {
 	return w.client.SetActiveSchemaVersion(ctx, schemaVersionID)
 }

--- a/tests/integration/collection_description/simple_test.go
+++ b/tests/integration/collection_description/simple_test.go
@@ -1,0 +1,42 @@
+// Copyright 2024 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package collection_description
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/immutable"
+
+	"github.com/sourcenetwork/defradb/client"
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+func TestColDescrSimpleCreatesColGivenEmptyType(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users {}
+				`,
+			},
+			testUtils.GetCollections{
+				ExpectedResults: []client.CollectionDescription{
+					{
+						ID:   1,
+						Name: immutable.Some("Users"),
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/collection_description/updates/add/collections_test.go
+++ b/tests/integration/collection_description/updates/add/collections_test.go
@@ -1,0 +1,85 @@
+// Copyright 2024 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package add
+
+import (
+	"testing"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+func TestColDescrUpdateAddCollections_WithUndefinedID_Errors(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users {}
+				`,
+			},
+			testUtils.PatchCollection{
+				Patch: `
+					[
+						{ "op": "add", "path": "/2", "value": {"Name": "Dogs"} }
+					]
+				`,
+				ExpectedError: "collection ID cannot be zero",
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestColDescrUpdateAddCollections_Errors(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users {}
+				`,
+			},
+			testUtils.PatchCollection{
+				Patch: `
+					[
+						{ "op": "add", "path": "/2", "value": {"ID": 2, "Name": "Dogs"} }
+					]
+				`,
+				ExpectedError: "adding collections via patch is not supported. ID: 2",
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestColDescrUpdateAddCollections_WithNoIndex_Errors(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users {}
+				`,
+			},
+			testUtils.PatchCollection{
+				Patch: `
+					[
+						{ "op": "add", "path": "/-", "value": {"Name": "Dogs"} }
+					]
+				`,
+				// We get this error because we are marshalling into a map[uint32]CollectionDescription,
+				// we will need to handle `-` when we allow adding collections via patches.
+				ExpectedError: "json: cannot unmarshal number - into Go value of type uint32",
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/collection_description/updates/add/collections_test.go
+++ b/tests/integration/collection_description/updates/add/collections_test.go
@@ -38,6 +38,28 @@ func TestColDescrUpdateAddCollections_WithUndefinedID_Errors(t *testing.T) {
 	testUtils.ExecuteTestCase(t, test)
 }
 
+func TestColDescrUpdateAddCollections_WithZeroedID_Errors(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users {}
+				`,
+			},
+			testUtils.PatchCollection{
+				Patch: `
+					[
+						{ "op": "add", "path": "/2", "value": {"ID": 0, "Name": "Dogs"} }
+					]
+				`,
+				ExpectedError: "collection ID cannot be zero",
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
 func TestColDescrUpdateAddCollections_Errors(t *testing.T) {
 	test := testUtils.TestCase{
 		Actions: []any{

--- a/tests/integration/collection_description/updates/add/sources_test.go
+++ b/tests/integration/collection_description/updates/add/sources_test.go
@@ -1,0 +1,39 @@
+// Copyright 2024 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package add
+
+import (
+	"testing"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+func TestColDescrUpdateAddSources_Errors(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users {}
+				`,
+			},
+			testUtils.PatchCollection{
+				Patch: `
+					[
+						{ "op": "add", "path": "/1/Sources/-", "value": {"SourceCollectionID": 1} }
+					]
+				`,
+				ExpectedError: "collection sources cannot be mutated. CollectionID: 1",
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/collection_description/updates/copy/name_test.go
+++ b/tests/integration/collection_description/updates/copy/name_test.go
@@ -18,6 +18,36 @@ import (
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
 )
 
+func TestColDescrUpdateCopyName_Errors(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users {}
+				`,
+			},
+			testUtils.SchemaPatch{
+				Patch: `
+					[
+						{ "op": "add", "path": "/Users/Fields/-", "value": {"Name": "name", "Kind": "String"} }
+					]
+				`,
+				SetAsDefaultVersion: immutable.Some(false),
+			},
+			testUtils.PatchCollection{
+				Patch: `
+					[
+						{ "op": "copy", "from": "/1/Name", "path": "/2/Name" }
+					]
+				`,
+				ExpectedError: "collection already exists. Name: Users",
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
 func TestColDescrUpdateCopyName(t *testing.T) {
 	test := testUtils.TestCase{
 		Actions: []any{

--- a/tests/integration/collection_description/updates/copy/name_test.go
+++ b/tests/integration/collection_description/updates/copy/name_test.go
@@ -1,0 +1,68 @@
+// Copyright 2024 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package copy
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/immutable"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+func TestColDescrUpdateCopyName(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users {}
+				`,
+			},
+			testUtils.SchemaPatch{
+				Patch: `
+					[
+						{ "op": "add", "path": "/Users/Fields/-", "value": {"Name": "name", "Kind": "String"} }
+					]
+				`,
+				SetAsDefaultVersion: immutable.Some(false),
+			},
+			testUtils.PatchCollection{
+				// Activate the second collection by setting its name to that of the first,
+				// then decativate the original collection version by removing the name
+				Patch: `
+					[
+						{ "op": "copy", "from": "/1/Name", "path": "/2/Name" },
+						{ "op": "remove", "path": "/1/Name" }
+					]
+				`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
+					"name": "John"
+				}`,
+			},
+			testUtils.Request{
+				Request: `query {
+					Users {
+						name
+					}
+				}`,
+				Results: []map[string]any{
+					{
+						"name": "John",
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/collection_description/updates/move/name_test.go
+++ b/tests/integration/collection_description/updates/move/name_test.go
@@ -1,0 +1,66 @@
+// Copyright 2024 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package move
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/immutable"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+func TestColDescrUpdateMoveName(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users {}
+				`,
+			},
+			testUtils.SchemaPatch{
+				Patch: `
+					[
+						{ "op": "add", "path": "/Users/Fields/-", "value": {"Name": "name", "Kind": "String"} }
+					]
+				`,
+				SetAsDefaultVersion: immutable.Some(false),
+			},
+			testUtils.PatchCollection{
+				// Make the second collection the active one by moving its name from the first to the second
+				Patch: `
+					[
+						{ "op": "move", "from": "/1/Name", "path": "/2/Name" }
+					]
+				`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
+					"name": "John"
+				}`,
+			},
+			testUtils.Request{
+				Request: `query {
+					Users {
+						name
+					}
+				}`,
+				Results: []map[string]any{
+					{
+						"name": "John",
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/collection_description/updates/remove/collections_test.go
+++ b/tests/integration/collection_description/updates/remove/collections_test.go
@@ -1,0 +1,41 @@
+// Copyright 2024 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package remove
+
+import (
+	"testing"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+func TestColDescrUpdateRemoveCollections(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users {
+						name: String
+					}
+				`,
+			},
+			testUtils.PatchCollection{
+				Patch: `
+					[
+						{ "op": "remove", "path": "/1" }
+					]
+				`,
+				ExpectedError: `collections cannot be deleted. CollectionID: 1`,
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/collection_description/updates/remove/name_test.go
+++ b/tests/integration/collection_description/updates/remove/name_test.go
@@ -1,0 +1,49 @@
+// Copyright 2024 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package remove
+
+import (
+	"testing"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+func TestColDescrUpdateRemoveName(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users {
+						name: String
+					}
+				`,
+			},
+			testUtils.PatchCollection{
+				Patch: `
+					[
+						{ "op": "remove", "path": "/1/Name" }
+					]
+				`,
+			},
+			testUtils.Request{
+				Request: `query {
+					Users {
+						name
+					}
+				}`,
+				// The Users collection has been deactivated and is no longer accessible
+				ExpectedError: `Cannot query field "Users" on type "Query".`,
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/collection_description/updates/replace/fields_test.go
+++ b/tests/integration/collection_description/updates/replace/fields_test.go
@@ -1,0 +1,39 @@
+// Copyright 2024 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package replace
+
+import (
+	"testing"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+func TestColDescrUpdateReplaceFields_Errors(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users {}
+				`,
+			},
+			testUtils.PatchCollection{
+				Patch: `
+					[
+						{ "op": "replace", "path": "/1/Fields", "value": [{}] }
+					]
+				`,
+				ExpectedError: "collection fields cannot be mutated. CollectionID: 1",
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/collection_description/updates/replace/id_test.go
+++ b/tests/integration/collection_description/updates/replace/id_test.go
@@ -1,0 +1,146 @@
+// Copyright 2024 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package replace
+
+import (
+	"testing"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+func TestColDescrUpdateReplaceID_WithZero_Errors(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users {}
+				`,
+			},
+			testUtils.PatchCollection{
+				Patch: `
+					[
+						{ "op": "replace", "path": "/1/ID", "value": 0 }
+					]
+				`,
+				ExpectedError: "collection ID cannot be zero",
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestColDescrUpdateReplaceID_WithExisting_Errors(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users {}
+				`,
+			},
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Books {}
+				`,
+			},
+			testUtils.PatchCollection{
+				Patch: `
+					[
+						{ "op": "replace", "path": "/1/ID", "value": 2 }
+					]
+				`,
+				ExpectedError: "collection already exists. ID: 2",
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestColDescrUpdateReplaceID_WithExistingSameRoot_Errors(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users {}
+				`,
+			},
+			testUtils.SchemaPatch{
+				Patch: `
+					[
+						{ "op": "add", "path": "/Users/Fields/-", "value": {"Name": "name", "Kind": "String"} }
+					]
+				`,
+			},
+			testUtils.PatchCollection{
+				Patch: `
+					[
+						{ "op": "replace", "path": "/1/ID", "value": 2 },
+						{ "op": "replace", "path": "/2/ID", "value": 1 }
+					]
+				`,
+				ExpectedError: "collection sources cannot be mutated.",
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestColDescrUpdateReplaceID_WithExistingDifferentRoot_Errors(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users {}
+				`,
+			},
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Dogs {}
+				`,
+			},
+			testUtils.PatchCollection{
+				Patch: `
+					[
+						{ "op": "replace", "path": "/1/ID", "value": 2 },
+						{ "op": "replace", "path": "/2/ID", "value": 1 }
+					]
+				`,
+				ExpectedError: "collection root ID cannot be mutated.",
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestColDescrUpdateReplaceID_WithNew_Errors(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users {}
+				`,
+			},
+			testUtils.PatchCollection{
+				Patch: `
+					[
+						{ "op": "replace", "path": "/1/ID", "value": 2 }
+					]
+				`,
+				ExpectedError: "adding collections via patch is not supported. ID: 2",
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/collection_description/updates/replace/indexes_test.go
+++ b/tests/integration/collection_description/updates/replace/indexes_test.go
@@ -1,0 +1,39 @@
+// Copyright 2024 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package replace
+
+import (
+	"testing"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+func TestColDescrUpdateReplaceIndexes_Errors(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users {}
+				`,
+			},
+			testUtils.PatchCollection{
+				Patch: `
+					[
+						{ "op": "replace", "path": "/1/Indexes", "value": [{}] }
+					]
+				`,
+				ExpectedError: "collection indexes cannot be mutated. CollectionID: 1",
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/collection_description/updates/replace/name_test.go
+++ b/tests/integration/collection_description/updates/replace/name_test.go
@@ -1,0 +1,210 @@
+// Copyright 2024 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package replace
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/immutable"
+
+	"github.com/sourcenetwork/defradb/client"
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+func TestColDescrUpdateReplaceName_GivenExistingName(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users {
+						name: String
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
+					"name": "John"
+				}`,
+			},
+			testUtils.PatchCollection{
+				Patch: `
+					[
+						{ "op": "replace", "path": "/1/Name", "value": "Actors" }
+					]
+				`,
+			},
+			testUtils.GetCollections{
+				ExpectedResults: []client.CollectionDescription{
+					{
+						ID:   1,
+						Name: immutable.Some("Actors"),
+					},
+				},
+			},
+			testUtils.Request{
+				Request: `query {
+					Users {
+						name
+					}
+				}`,
+				ExpectedError: `Cannot query field "Users" on type "Query".`,
+			},
+			testUtils.Request{
+				Request: `query {
+					Actors {
+						name
+					}
+				}`,
+				Results: []map[string]any{
+					{
+						"name": "John",
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestColDescrUpdateReplaceName_GivenInactiveCollectionWithSameName_Errors(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users {
+						name: String
+					}
+				`,
+			},
+			testUtils.SchemaPatch{
+				Patch: `
+					[
+						{ "op": "add", "path": "/Users/Fields/-", "value": {"Name": "foo", "Kind": "String"} }
+					]
+				`,
+				SetAsDefaultVersion: immutable.Some(false),
+			},
+			testUtils.PatchCollection{
+				Patch: `
+					[
+						{ "op": "replace", "path": "/2/Name", "value": "Users" }
+					]
+				`,
+				ExpectedError: "collection already exists. Name: Users",
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestColDescrUpdateReplaceName_GivenInactiveCollection_Errors(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users {
+						name: String
+					}
+				`,
+			},
+			testUtils.SchemaPatch{
+				Patch: `
+					[
+						{ "op": "add", "path": "/Users/Fields/-", "value": {"Name": "foo", "Kind": "String"} }
+					]
+				`,
+				SetAsDefaultVersion: immutable.Some(false),
+			},
+			testUtils.PatchCollection{
+				Patch: `
+					[
+						{ "op": "replace", "path": "/2/Name", "value": "Actors" }
+					]
+				`,
+				// The params at the end of the error message is dependant on the order Go decides to iterate through
+				// a map and so is not included in the test.
+				ExpectedError: "multiple versions of same collection cannot be active",
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestColDescrUpdateReplaceName_RemoveExistingName(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users {
+						name: String
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
+					"name": "John"
+				}`,
+			},
+			testUtils.SchemaPatch{
+				Patch: `
+					[
+						{ "op": "add", "path": "/Users/Fields/-", "value": {"Name": "foo", "Kind": "String"} }
+					]
+				`,
+				SetAsDefaultVersion: immutable.Some(false),
+			},
+			testUtils.PatchCollection{
+				Patch: `
+					[
+						{ "op": "remove", "path": "/1/Name" },
+						{ "op": "replace", "path": "/2/Name", "value": "Actors" }
+					]
+				`,
+			},
+			testUtils.GetCollections{
+				FilterOptions: client.CollectionFetchOptions{
+					IncludeInactive: immutable.Some(true),
+				},
+				ExpectedResults: []client.CollectionDescription{
+					{
+						ID: 1,
+					},
+					{
+						ID:   2,
+						Name: immutable.Some("Actors"),
+						Sources: []any{
+							&client.CollectionSource{
+								SourceCollectionID: 1,
+							},
+						},
+					},
+				},
+			},
+			testUtils.Request{
+				Request: `query {
+					Actors {
+						name
+					}
+				}`,
+				Results: []map[string]any{
+					{
+						"name": "John",
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/collection_description/updates/replace/root_id_test.go
+++ b/tests/integration/collection_description/updates/replace/root_id_test.go
@@ -1,0 +1,39 @@
+// Copyright 2024 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package replace
+
+import (
+	"testing"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+func TestColDescrUpdateReplaceRootID_Errors(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users {}
+				`,
+			},
+			testUtils.PatchCollection{
+				Patch: `
+					[
+						{ "op": "replace", "path": "/1/RootID", "value": 2 }
+					]
+				`,
+				ExpectedError: "collection root ID cannot be mutated. CollectionID: 1",
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/collection_description/updates/replace/schema_version_id_test.go
+++ b/tests/integration/collection_description/updates/replace/schema_version_id_test.go
@@ -1,0 +1,39 @@
+// Copyright 2024 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package replace
+
+import (
+	"testing"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+func TestColDescrUpdateReplaceSchemaVersionID_Errors(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users {}
+				`,
+			},
+			testUtils.PatchCollection{
+				Patch: `
+					[
+						{ "op": "replace", "path": "/1/SchemaVersionID", "value": "ghfdsas" }
+					]
+				`,
+				ExpectedError: "collection schema version ID cannot be mutated. CollectionID: 1",
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/collection_description/updates/replace/sources_test.go
+++ b/tests/integration/collection_description/updates/replace/sources_test.go
@@ -1,0 +1,39 @@
+// Copyright 2024 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package replace
+
+import (
+	"testing"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+func TestColDescrUpdateReplaceSources_Errors(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users {}
+				`,
+			},
+			testUtils.PatchCollection{
+				Patch: `
+					[
+						{ "op": "replace", "path": "/1/Sources", "value": [{"SourceCollectionID": 1}] }
+					]
+				`,
+				ExpectedError: "collection sources cannot be mutated. CollectionID: 1",
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/collection_description/updates/test/name_test.go
+++ b/tests/integration/collection_description/updates/test/name_test.go
@@ -1,0 +1,60 @@
+// Copyright 2024 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package test
+
+import (
+	"testing"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+func TestColDescrUpdateTestName(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users {}
+				`,
+			},
+			testUtils.PatchCollection{
+				Patch: `
+					[
+						{ "op": "test", "path": "/1/Name", "value": "Users" }
+					]
+				`,
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestColDescrUpdateTestName_Fails(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users {}
+				`,
+			},
+			testUtils.PatchCollection{
+				Patch: `
+					[
+						{ "op": "test", "path": "/1/Name", "value": "Dogs" }
+					]
+				`,
+				ExpectedError: "testing value /1/Name failed: test failed",
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/schema/updates/add/field/kind/foreign_object_array_test.go
+++ b/tests/integration/schema/updates/add/field/kind/foreign_object_array_test.go
@@ -34,7 +34,7 @@ func TestSchemaUpdatesAddFieldKindForeignObjectArray(t *testing.T) {
 						{ "op": "add", "path": "/Users/Fields/-", "value": {"Name": "foo", "Kind": 17} }
 					]
 				`,
-				ExpectedError: "a `Schema` [name] must be provided when adding a new relation field. Field: foo, Kind: 17",
+				ExpectedError: "a schema name must be provided when adding a new relation field. Field: foo, Kind: 17",
 			},
 		},
 	}

--- a/tests/integration/schema/updates/add/field/kind/foreign_object_test.go
+++ b/tests/integration/schema/updates/add/field/kind/foreign_object_test.go
@@ -34,7 +34,7 @@ func TestSchemaUpdatesAddFieldKindForeignObject(t *testing.T) {
 						{ "op": "add", "path": "/Users/Fields/-", "value": {"Name": "foo", "Kind": 16} }
 					]
 				`,
-				ExpectedError: "a `Schema` [name] must be provided when adding a new relation field. Field: foo, Kind: 16",
+				ExpectedError: "a schema name must be provided when adding a new relation field. Field: foo, Kind: 16",
 			},
 		},
 	}

--- a/tests/integration/schema/updates/add/field/with_index_test.go
+++ b/tests/integration/schema/updates/add/field/with_index_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Democratized Data Foundation
+// Copyright 2024 Democratized Data Foundation
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt.
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-package index
+package field
 
 import (
 	"testing"
@@ -16,7 +16,7 @@ import (
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
 )
 
-func TestPatching_ForCollectionWithIndex_StillWorks(t *testing.T) {
+func TestSchemaUpdatesAddFieldSimple_WithExistingIndex(t *testing.T) {
 	test := testUtils.TestCase{
 		Description: "Test patching schema for collection with index still works",
 		Actions: []any{

--- a/tests/integration/schema/updates/add/simple_test.go
+++ b/tests/integration/schema/updates/add/simple_test.go
@@ -33,7 +33,7 @@ func TestSchemaUpdatesAddSimpleErrorsAddingSchema(t *testing.T) {
 						{ "op": "add", "path": "/-", "value": {"Name": "books"} }
 					]
 				`,
-				ExpectedError: "unknown collection, adding collections via patch is not supported. Name: books",
+				ExpectedError: "adding collections via patch is not supported. Name: books",
 			},
 			testUtils.Request{
 				Request: `query {

--- a/tests/integration/schema/updates/copy/simple_test.go
+++ b/tests/integration/schema/updates/copy/simple_test.go
@@ -38,7 +38,7 @@ func TestSchemaUpdatesCopyCollectionWithRemoveIDAndReplaceName(t *testing.T) {
 						{ "op": "replace", "path": "/Book/Name", "value": "Book" }
 					]
 				`,
-				ExpectedError: "unknown collection, adding collections via patch is not supported. Name: Book",
+				ExpectedError: "adding collections via patch is not supported. Name: Book",
 			},
 		},
 	}

--- a/tests/integration/schema/updates/replace/simple_test.go
+++ b/tests/integration/schema/updates/replace/simple_test.go
@@ -44,7 +44,7 @@ func TestSchemaUpdatesReplaceCollectionErrors(t *testing.T) {
 				// WARNING: An error is still expected if/when we allow the adding of collections, as this also
 				// implies that the "Users" collection is to be deleted.  Only once we support the adding *and*
 				// removal of collections should this not error.
-				ExpectedError: "unknown collection, adding collections via patch is not supported. Name: Book",
+				ExpectedError: "adding collections via patch is not supported. Name: Book",
 			},
 		},
 	}

--- a/tests/integration/test_case.go
+++ b/tests/integration/test_case.go
@@ -103,6 +103,7 @@ type PatchCollection struct {
 	// If a value is not provided the patch will be applied to all nodes.
 	NodeID immutable.Option[int]
 
+	// The Patch to apply to the collection description.
 	Patch string
 
 	ExpectedError string

--- a/tests/integration/test_case.go
+++ b/tests/integration/test_case.go
@@ -97,6 +97,17 @@ type SchemaPatch struct {
 	ExpectedError string
 }
 
+type PatchCollection struct {
+	// NodeID may hold the ID (index) of a node to apply this patch to.
+	//
+	// If a value is not provided the patch will be applied to all nodes.
+	NodeID immutable.Option[int]
+
+	Patch string
+
+	ExpectedError string
+}
+
 // GetSchema is an action that fetches schema using the provided options.
 type GetSchema struct {
 	// NodeID may hold the ID (index) of a node to apply this patch to.

--- a/tests/integration/utils2.go
+++ b/tests/integration/utils2.go
@@ -260,6 +260,9 @@ func performAction(
 	case SchemaPatch:
 		patchSchema(s, action)
 
+	case PatchCollection:
+		patchCollection(s, action)
+
 	case GetSchema:
 		getSchema(s, action)
 
@@ -995,6 +998,22 @@ func patchSchema(
 		}
 
 		err := node.PatchSchema(s.ctx, action.Patch, action.Lens, setAsDefaultVersion)
+		expectedErrorRaised := AssertError(s.t, s.testCase.Description, err, action.ExpectedError)
+
+		assertExpectedErrorRaised(s.t, s.testCase.Description, action.ExpectedError, expectedErrorRaised)
+	}
+
+	// If the schema was updated we need to refresh the collection definitions.
+	refreshCollections(s)
+	refreshIndexes(s)
+}
+
+func patchCollection(
+	s *state,
+	action PatchCollection,
+) {
+	for _, node := range getNodes(action.NodeID, s.nodes) {
+		err := node.PatchCollection(s.ctx, action.Patch)
 		expectedErrorRaised := AssertError(s.t, s.testCase.Description, err, action.ExpectedError)
 
 		assertExpectedErrorRaised(s.t, s.testCase.Description, action.ExpectedError, expectedErrorRaised)


### PR DESCRIPTION
## Relevant issue(s)

Resolves #2389

## Description

Adds the PatchCollection command.

Mutating anything but the collection name is currently disabled, we can expand this as we see fit, but for now I'd prefer to keep the initial PR small.

This change means that the Collection Name is no longer always going to be the same as the Schema Name.

I've manually tested the OpenApi stuff via playground.