### PR TITLE
feat: Add Defra-Lens support for branching schema

### DIFF
--- a/lens/fetcher.go
+++ b/lens/fetcher.go
@@ -76,7 +76,7 @@ func (f *lensedFetcher) Init(
 		f.fieldDescriptionsByName[defFields[i].Name] = defFields[i]
 	}
 
-	history, err := getTargetedSchemaHistory(ctx, txn, f.col.Schema().Root, f.col.Schema().VersionID)
+	history, err := getTargetedCollectionHistory(ctx, txn, f.col.Schema().Root, f.col.Schema().VersionID)
 	if err != nil {
 		return err
 	}

--- a/lens/history.go
+++ b/lens/history.go
@@ -160,7 +160,10 @@ func getSchemaHistory(
 	schemaVersionsByColID := map[uint32]schemaVersionID{}
 
 	for _, c := range cols {
+		// Todo - this `col := c` can be removed with Go 1.22:
+		// https://github.com/sourcenetwork/defradb/issues/2431
 		col := c
+
 		// Convert the temporary types to the cleaner return type:
 		history[col.SchemaVersionID] = &schemaHistoryLink{
 			collection: &col,

--- a/lens/history.go
+++ b/lens/history.go
@@ -69,7 +69,7 @@ func getTargetedSchemaHistory(
 
 	targetHistoryItem, ok := history[targetSchemaVersionID]
 	if !ok {
-		// If the target schema version is unknown then there are possible no migrations
+		// If the target schema version is unknown then there are no possible migrations
 		// that we can do.
 		return nil, nil
 	}

--- a/lens/lens.go
+++ b/lens/lens.go
@@ -19,7 +19,6 @@ import (
 )
 
 type schemaVersionID = string
-type collectionID = uint32
 
 // LensDoc represents a document that will be sent to/from a Lens.
 type LensDoc = map[string]any
@@ -178,7 +177,7 @@ func (l *lens) Next() (bool, error) {
 				break
 			}
 
-			if historyLocation.targetVector > 0 {
+			if historyLocation.next.HasValue() {
 				// Aquire a lens migration from the registery, using the junctionPipe as its source.
 				// The new pipeHead will then be connected as a source to the next migration-stage on
 				// the next loop.
@@ -188,7 +187,7 @@ func (l *lens) Next() (bool, error) {
 				}
 
 				historyLocation = historyLocation.next.Value()
-			} else {
+			} else if historyLocation.previous.HasValue() {
 				// Aquire a lens migration from the registery, using the junctionPipe as its source.
 				// The new pipeHead will then be connected as a source to the next migration-stage on
 				// the next loop.

--- a/tests/integration/schema/migrations/query/with_p2p_schema_branch_test.go
+++ b/tests/integration/schema/migrations/query/with_p2p_schema_branch_test.go
@@ -95,8 +95,6 @@ func TestSchemaMigrationQueryWithP2PReplicatedDocOnOtherSchemaBranch(t *testing.
 			},
 			testUtils.WaitForSync{},
 			testUtils.Request{
-				// Node 0 should yield results as they were defined, as the newer schema version is
-				// unknown to this node.
 				NodeID: immutable.Some(0),
 				Request: `query {
 					Users {

--- a/tests/integration/schema/migrations/query/with_p2p_schema_branch_test.go
+++ b/tests/integration/schema/migrations/query/with_p2p_schema_branch_test.go
@@ -1,0 +1,138 @@
+// Copyright 2023 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package query
+
+import (
+	"testing"
+
+	"github.com/lens-vm/lens/host-go/config/model"
+	"github.com/sourcenetwork/immutable"
+
+	"github.com/sourcenetwork/defradb/client"
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	"github.com/sourcenetwork/defradb/tests/lenses"
+)
+
+func TestSchemaMigrationQueryWithP2PReplicatedDocOnOtherSchemaBranch(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.RandomNetworkingConfig(),
+			testUtils.RandomNetworkingConfig(),
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users {
+						name: String
+						verified: Boolean
+					}
+				`,
+			},
+			testUtils.SchemaPatch{
+				// Patch first node only
+				NodeID: immutable.Some(0),
+				Patch: `
+					[
+						{ "op": "add", "path": "/Users/Fields/-", "value": {"Name": "email", "Kind": "String"} }
+					]
+				`,
+			},
+			testUtils.ConfigureMigration{
+				// Register the migration on both nodes.
+				LensConfig: client.LensConfig{
+					SourceSchemaVersionID:      "bafkreihax57fohcdupqr2l4heoqxdsiggjfeaubr44tgrz4xqdgvnid4xy",
+					DestinationSchemaVersionID: "bafkreifer354qmdrwdtae5n3k7sbl2oauis3mz24fk46p3otub7ojznobq",
+					Lens: model.Lens{
+						Lenses: []model.LensModule{
+							{
+								Path: lenses.SetDefaultModulePath,
+								Arguments: map[string]any{
+									"dst":   "name",
+									"value": "Fred",
+								},
+							},
+						},
+					},
+				},
+			},
+			testUtils.SchemaPatch{
+				// Patch second node with different patch
+				NodeID: immutable.Some(1),
+				Patch: `
+					[
+						{ "op": "add", "path": "/Users/Fields/-", "value": {"Name": "phone", "Kind": 11} }
+					]
+				`,
+				Lens: immutable.Some(model.Lens{
+					Lenses: []model.LensModule{
+						{
+							Path: lenses.SetDefaultModulePath,
+							Arguments: map[string]any{
+								"dst":   "phone",
+								"value": "1234567890",
+							},
+						},
+					},
+				}),
+			},
+			testUtils.ConfigureReplicator{
+				SourceNodeID: 0,
+				TargetNodeID: 1,
+			},
+			testUtils.CreateDoc{
+				// Create John on the first (source) node only, and allow the value to sync
+				NodeID: immutable.Some(0),
+				Doc: `{
+					"name": "John",
+					"verified": true
+				}`,
+			},
+			testUtils.WaitForSync{},
+			testUtils.Request{
+				// Node 0 should yield results as they were defined, as the newer schema version is
+				// unknown to this node.
+				NodeID: immutable.Some(0),
+				Request: `query {
+					Users {
+						name
+					}
+				}`,
+				Results: []map[string]any{
+					{
+						"name":     "John",
+						"verified": true,
+					},
+				},
+			},
+			testUtils.Request{
+				// Node 1 should yield results migrated down to schema version 1, then up to schema version 3.
+				NodeID: immutable.Some(1),
+				Request: `
+					query {
+						Users {
+							name
+							phone
+						}
+					}
+				`,
+				Results: []map[string]any{
+					{
+						// name has been cleared by the inverse of the migration from version 1 to 2
+						"name": nil,
+						// phone has been set by the migration from version 1 to 3
+						"phone":    "1234567890",
+						"verified": true,
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/schema/migrations/query/with_p2p_schema_branch_test.go
+++ b/tests/integration/schema/migrations/query/with_p2p_schema_branch_test.go
@@ -99,6 +99,7 @@ func TestSchemaMigrationQueryWithP2PReplicatedDocOnOtherSchemaBranch(t *testing.
 				Request: `query {
 					Users {
 						name
+						verified
 					}
 				}`,
 				Results: []map[string]any{

--- a/tests/integration/schema/migrations/query/with_schema_branch_test.go
+++ b/tests/integration/schema/migrations/query/with_schema_branch_test.go
@@ -1,0 +1,107 @@
+// Copyright 2024 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package query
+
+import (
+	"testing"
+
+	"github.com/lens-vm/lens/host-go/config/model"
+	"github.com/sourcenetwork/immutable"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	"github.com/sourcenetwork/defradb/tests/lenses"
+)
+
+func TestSchemaMigrationQuery_WithBranchingSchema(t *testing.T) {
+	schemaVersion1ID := "bafkreiht46o4lakri2py2zw57ed3pdeib6ud6ojlsomgjlrgwh53wl3q4a"
+
+	test := testUtils.TestCase{
+		Description: "Test schema update, with branching schema migrations",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users {
+						name: String
+					}
+				`,
+			},
+			testUtils.SchemaPatch{
+				SetAsDefaultVersion: immutable.Some(true),
+				Patch: `
+					[
+						{ "op": "add", "path": "/Users/Fields/-", "value": {"Name": "email", "Kind": 11} }
+					]
+				`,
+				Lens: immutable.Some(model.Lens{
+					Lenses: []model.LensModule{
+						{
+							Path: lenses.SetDefaultModulePath,
+							Arguments: map[string]any{
+								"dst":   "name",
+								"value": "Fred",
+							},
+						},
+					},
+				}),
+			},
+			testUtils.CreateDoc{
+				// Create a document on the second schema version, with an email field value
+				Doc: `{
+					"name": "John",
+					"email": "john@source.hub"
+				}`,
+			},
+			testUtils.SetActiveSchemaVersion{
+				// Set the active schema version back to the first
+				SchemaVersionID: schemaVersion1ID,
+			},
+			testUtils.SchemaPatch{
+				// The third schema version will be set as the active version, going from version 1 to 3
+				SetAsDefaultVersion: immutable.Some(true),
+				Patch: `
+					[
+						{ "op": "add", "path": "/Users/Fields/-", "value": {"Name": "phone", "Kind": 11} }
+					]
+				`,
+				Lens: immutable.Some(model.Lens{
+					Lenses: []model.LensModule{
+						{
+							Path: lenses.SetDefaultModulePath,
+							Arguments: map[string]any{
+								"dst":   "phone",
+								"value": "1234567890",
+							},
+						},
+					},
+				}),
+			},
+			testUtils.Request{
+				Request: `
+					query {
+						Users {
+							name
+							phone
+						}
+					}
+				`,
+				Results: []map[string]any{
+					{
+						// name has been cleared by the inverse of the migration from version 1 to 2
+						"name": nil,
+						// phone has been set by the migration from version 1 to 3
+						"phone": "1234567890",
+					},
+				},
+			},
+		},
+	}
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/utils2.go
+++ b/tests/integration/utils2.go
@@ -746,7 +746,6 @@ func refreshCollections(
 			for _, collection := range allCollections {
 				if collection.Name().Value() == collectionName {
 					s.collections[nodeID][i] = collection
-					println(collection.Description().SchemaVersionID)
 					break
 				}
 			}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #2293

## Description

Adds Defra-Lens support for branching schema.

Defra will now be able to handle migrations for a branching schema version DAG.
