### PR TITLE
ci(i): Disable windows build

### DIFF
--- a/.github/workflows/test-and-upload-coverage.yml
+++ b/.github/workflows/test-and-upload-coverage.yml
@@ -46,11 +46,13 @@ jobs:
             database-type: badger-memory
             mutation-type: collection-save
             detect-changes: false
-          - os: windows-latest
-            client-type: go
-            database-type: badger-memory
-            mutation-type: collection-save
-            detect-changes: false
+## TODO: https://github.com/sourcenetwork/defradb/issues/2080
+## Uncomment the lines below to Re-enable the windows build once this todo is resolved.
+##        - os: windows-latest
+##          client-type: go
+##          database-type: badger-memory
+##          mutation-type: collection-save
+##          detect-changes: false
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
## Relevant issue(s)
Resolves #2449 

## Description
- Disable windows build until wasmtime-go is fixed
- To enable back just uncomment the lines in: `.github/workflows/test-and-upload-coverage.yml`

