### PR TITLE
test: Add flag to skip network tests

### DIFF
--- a/tests/integration/test_case.go
+++ b/tests/integration/test_case.go
@@ -593,3 +593,35 @@ type BackupImport struct {
 	// contains this string.
 	ExpectedError string
 }
+
+// IsNetworkAction returns true if the given action involves the network subsystem.
+func IsNetworkAction(act any) bool {
+	switch act.(type) {
+	case ConfigureNode:
+		return true
+
+	case ConnectPeers:
+		return true
+
+	case ConfigureReplicator:
+		return true
+
+	case DeleteReplicator:
+		return true
+
+	case SubscribeToCollection:
+		return true
+
+	case UnsubscribeToCollection:
+		return true
+
+	case GetAllP2PCollections:
+		return true
+
+	case WaitForSync:
+		return true
+
+	default:
+		return false
+	}
+}

--- a/tests/integration/test_case.go
+++ b/tests/integration/test_case.go
@@ -593,35 +593,3 @@ type BackupImport struct {
 	// contains this string.
 	ExpectedError string
 }
-
-// IsNetworkAction returns true if the given action involves the network subsystem.
-func IsNetworkAction(act any) bool {
-	switch act.(type) {
-	case ConfigureNode:
-		return true
-
-	case ConnectPeers:
-		return true
-
-	case ConfigureReplicator:
-		return true
-
-	case DeleteReplicator:
-		return true
-
-	case SubscribeToCollection:
-		return true
-
-	case UnsubscribeToCollection:
-		return true
-
-	case GetAllP2PCollections:
-		return true
-
-	case WaitForSync:
-		return true
-
-	default:
-		return false
-	}
-}

--- a/tests/integration/utils2.go
+++ b/tests/integration/utils2.go
@@ -2017,7 +2017,10 @@ func skipIfMutationTypeUnsupported(t *testing.T, supportedMutationTypes immutabl
 func skipIfNetworkTest(t *testing.T, actions []any) {
 	hasNetworkAction := false
 	for _, act := range actions {
-		hasNetworkAction = hasNetworkAction || IsNetworkAction(act)
+		switch act.(type) {
+		case ConfigureNode:
+			hasNetworkAction = true
+		}
 	}
 	if skipNetworkTests && hasNetworkAction {
 		t.Skip("test involves network actions")

--- a/tests/integration/utils2.go
+++ b/tests/integration/utils2.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -40,7 +41,10 @@ import (
 	"github.com/sourcenetwork/defradb/tests/predefined"
 )
 
-const mutationTypeEnvName = "DEFRA_MUTATION_TYPE"
+const (
+	mutationTypeEnvName     = "DEFRA_MUTATION_TYPE"
+	skipNetworkTestsEnvName = "DEFRA_SKIP_NETWORK_TESTS"
+)
 
 // The MutationType that tests will run using.
 //
@@ -72,6 +76,8 @@ const (
 var (
 	log          = corelog.NewLogger("tests.integration")
 	mutationType MutationType
+	// skipNetworkTests will skip any tests that involve network actions
+	skipNetworkTests = false
 )
 
 const (
@@ -94,6 +100,9 @@ func init() {
 		// faster. We assume this is desirable when not explicitly testing any particular
 		// mutation type.
 		mutationType = CollectionSaveMutationType
+	}
+	if value, ok := os.LookupEnv(skipNetworkTestsEnvName); ok {
+		skipNetworkTests, _ = strconv.ParseBool(value)
 	}
 }
 
@@ -131,6 +140,7 @@ func ExecuteTestCase(
 	collectionNames := getCollectionNames(testCase)
 	changeDetector.PreTestChecks(t, collectionNames)
 	skipIfMutationTypeUnsupported(t, testCase.SupportedMutationTypes)
+	skipIfNetworkTest(t, testCase.Actions)
 
 	var clients []ClientType
 	if httpClient {
@@ -182,6 +192,7 @@ func executeTestCase(
 		corelog.Any("client", clientType),
 		corelog.Any("mutationType", mutationType),
 		corelog.String("databaseDir", databaseDir),
+		corelog.Bool("skipNetworkTests", skipNetworkTests),
 		corelog.Bool("changeDetector.Enabled", changeDetector.Enabled),
 		corelog.Bool("changeDetector.SetupOnly", changeDetector.SetupOnly),
 		corelog.String("changeDetector.SourceBranch", changeDetector.SourceBranch),
@@ -1998,6 +2009,18 @@ func skipIfMutationTypeUnsupported(t *testing.T, supportedMutationTypes immutabl
 		if !isTypeSupported {
 			t.Skipf("test does not support given mutation type. Type: %s", mutationType)
 		}
+	}
+}
+
+// skipIfNetworkTest skips the current test if the given actions
+// contain network actions and skipNetworkTests is true.
+func skipIfNetworkTest(t *testing.T, actions []any) {
+	hasNetworkAction := false
+	for _, act := range actions {
+		hasNetworkAction = hasNetworkAction || IsNetworkAction(act)
+	}
+	if skipNetworkTests && hasNetworkAction {
+		t.Skip("test involves network actions")
 	}
 }
 


### PR DESCRIPTION
## Relevant issue(s)

Resolves #2494 

## Description

This PR adds a test flag set via an environment variable to skip any tests that involve network actions.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

`make test`

Specify the platform(s) on which this was tested:
- MacOS

