### PR TITLE
fix: Allow update when updating non-indexed field

### DIFF
--- a/db/index.go
+++ b/db/index.go
@@ -11,7 +11,6 @@
 package db
 
 import (
-	"bytes"
 	"context"
 	"time"
 
@@ -363,15 +362,6 @@ func (index *collectionUniqueIndex) prepareIndexRecordToStore(
 			return core.IndexDataStoreKey{}, nil, err
 		}
 		if exists {
-			if oldDoc != nil {
-				oldKey, oldVal, err := index.getDocumentsIndexRecord(oldDoc)
-				if err != nil {
-					return core.IndexDataStoreKey{}, nil, err
-				}
-				if oldKey.ToString() == key.ToString() && bytes.Equal(oldVal, val) {
-					return core.IndexDataStoreKey{}, nil, nil
-				}
-			}
 			return core.IndexDataStoreKey{}, nil, index.newUniqueIndexError(doc)
 		}
 	}
@@ -395,11 +385,6 @@ func (index *collectionUniqueIndex) Update(
 	newKey, newVal, err := index.prepareIndexRecordToStore(ctx, txn, newDoc, oldDoc)
 	if err != nil {
 		return err
-	}
-	if newKey.ToString() == "" {
-		// This will happen when the updated doc results in the same key-value pair.
-		// The outcome is a no-op.
-		return nil
 	}
 	err = index.deleteDocIndex(ctx, txn, oldDoc)
 	if err != nil {

--- a/db/index.go
+++ b/db/index.go
@@ -303,7 +303,7 @@ func (index *collectionUniqueIndex) Save(
 	txn datastore.Txn,
 	doc *client.Document,
 ) error {
-	key, val, err := index.prepareIndexRecordToStore(ctx, txn, doc, nil)
+	key, val, err := index.prepareIndexRecordToStore(ctx, txn, doc)
 	if err != nil {
 		return err
 	}
@@ -349,7 +349,6 @@ func (index *collectionUniqueIndex) prepareIndexRecordToStore(
 	ctx context.Context,
 	txn datastore.Txn,
 	doc *client.Document,
-	oldDoc *client.Document,
 ) (core.IndexDataStoreKey, []byte, error) {
 	key, val, err := index.getDocumentsIndexRecord(doc)
 	if err != nil {
@@ -382,7 +381,7 @@ func (index *collectionUniqueIndex) Update(
 	oldDoc *client.Document,
 	newDoc *client.Document,
 ) error {
-	newKey, newVal, err := index.prepareIndexRecordToStore(ctx, txn, newDoc, oldDoc)
+	newKey, newVal, err := index.prepareIndexRecordToStore(ctx, txn, newDoc)
 	if err != nil {
 		return err
 	}

--- a/tests/integration/index/update_unique_composite_test.go
+++ b/tests/integration/index/update_unique_composite_test.go
@@ -45,7 +45,6 @@ func TestUniqueCompositeIndexUpdate_UponUpdatingDocWithExistingFieldValue_Should
 					{
 						"email": "another@gmail.com"
 					}`,
-				ExpectedError: "can not index a doc's field(s) that violates unique index",
 			},
 		},
 	}

--- a/tests/integration/index/update_unique_composite_test.go
+++ b/tests/integration/index/update_unique_composite_test.go
@@ -1,0 +1,54 @@
+// Copyright 2024 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package index
+
+import (
+	"testing"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+func TestUniqueCompositeIndexUpdate_UponUpdatingDocWithExistingFieldValue_ShouldSucceed(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "updating non-indexed fields on a doc with existing field combination for composite index should succeed",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type User @index(unique: true, fields: ["name", "age"]) {
+						name: String 
+						age: Int 
+						email: String
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `
+					{
+						"name":	"John",
+						"age":	21,
+						"email": "email@gmail.com"
+					}`,
+			},
+			testUtils.UpdateDoc{
+				CollectionID: 0,
+				DocID:        0,
+				Doc: `
+					{
+						"email": "another@gmail.com"
+					}`,
+				ExpectedError: "can not index a doc's field(s) that violates unique index",
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/index/update_unique_test.go
+++ b/tests/integration/index/update_unique_test.go
@@ -1,0 +1,52 @@
+// Copyright 2024 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package index
+
+import (
+	"testing"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+func TestUniqueIndexUpdate_UponUpdatingDocNonIndexedField_ShouldSucceed(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "updating non-indexed fields on a doc with a unique index should succeed",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type User {
+						name: String @index(unique: true)
+						age: Int
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `
+					{
+						"name":	"Fred",
+						"age":	36
+					}`,
+			},
+			testUtils.UpdateDoc{
+				CollectionID: 0,
+				DocID:        0,
+				Doc: `
+					{
+						"age":	37
+					}`,
+				ExpectedError: "can not index a doc's field(s) that violates unique index",
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/index/update_unique_test.go
+++ b/tests/integration/index/update_unique_test.go
@@ -43,7 +43,6 @@ func TestUniqueIndexUpdate_UponUpdatingDocNonIndexedField_ShouldSucceed(t *testi
 					{
 						"age":	37
 					}`,
-				ExpectedError: "can not index a doc's field(s) that violates unique index",
 			},
 		},
 	}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #2510 

## Description

This PR adds a check to the index validation step where if the resulting KV pair is the same on update as the previous KV pair, the outcome will be an no-op instead of an index existing error.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

make test

Specify the platform(s) on which this was tested:
- MacOS
