### PR TITLE
refactor(i): DB identity context

### DIFF
--- a/acp/identity/identity.go
+++ b/acp/identity/identity.go
@@ -18,17 +18,17 @@ package identity
 type Identity string
 
 var (
-	// NoIdentity is an empty identity.
-	NoIdentity = Identity("")
+	// None is an empty identity.
+	None = Identity("")
 )
 
-// New makes a new identity if the input is not empty otherwise, returns an empty Option.
+// New makes a new identity if the input is not empty otherwise, returns None.
 func New(identity string) Identity {
 	// TODO-ACP: There will be more validation once sourcehub gets some utilities.
 	// Then a validation function would do the validation, will likely do outside this function.
 	// https://github.com/sourcenetwork/defradb/issues/2358
 	if identity == "" {
-		return NoIdentity
+		return None
 	}
 	return Identity(identity)
 }

--- a/acp/identity/identity.go
+++ b/acp/identity/identity.go
@@ -18,18 +18,21 @@ import (
 	"github.com/sourcenetwork/immutable"
 )
 
+// Identity is the unique identifier for an actor.
+type Identity immutable.Option[string]
+
 var (
 	// NoIdentity is an empty identity.
-	NoIdentity = immutable.None[string]()
+	NoIdentity = Identity(immutable.None[string]())
 )
 
 // NewIdentity makes a new identity if the input is not empty otherwise, returns an empty Option.
-func NewIdentity(identity string) immutable.Option[string] {
+func NewIdentity(identity string) Identity {
 	// TODO-ACP: There will be more validation once sourcehub gets some utilities.
 	// Then a validation function would do the validation, will likely do outside this function.
 	// https://github.com/sourcenetwork/defradb/issues/2358
 	if identity == "" {
 		return NoIdentity
 	}
-	return immutable.Some[string](identity)
+	return Identity(immutable.Some[string](identity))
 }

--- a/acp/identity/identity.go
+++ b/acp/identity/identity.go
@@ -36,3 +36,13 @@ func NewIdentity(identity string) Identity {
 	}
 	return Identity(immutable.Some[string](identity))
 }
+
+// HasValue returns true if the identity is not empty.
+func (i Identity) HasValue() bool {
+	return immutable.Option[string](i).HasValue()
+}
+
+// Value returns the identity value.
+func (i Identity) Value() string {
+	return immutable.Option[string](i).Value()
+}

--- a/acp/identity/identity.go
+++ b/acp/identity/identity.go
@@ -14,23 +14,25 @@ Package identity provides defradb identity.
 
 package identity
 
+import "github.com/sourcenetwork/immutable"
+
 // Identity is the unique identifier for an actor.
 type Identity string
 
 var (
 	// None is an empty identity.
-	None = Identity("")
+	None = immutable.None[Identity]()
 )
 
 // New makes a new identity if the input is not empty otherwise, returns None.
-func New(identity string) Identity {
+func New(identity string) immutable.Option[Identity] {
 	// TODO-ACP: There will be more validation once sourcehub gets some utilities.
 	// Then a validation function would do the validation, will likely do outside this function.
 	// https://github.com/sourcenetwork/defradb/issues/2358
 	if identity == "" {
 		return None
 	}
-	return Identity(identity)
+	return immutable.Some(Identity(identity))
 }
 
 // String returns the string representation of the identity.

--- a/acp/identity/identity.go
+++ b/acp/identity/identity.go
@@ -14,35 +14,26 @@ Package identity provides defradb identity.
 
 package identity
 
-import (
-	"github.com/sourcenetwork/immutable"
-)
-
 // Identity is the unique identifier for an actor.
-type Identity immutable.Option[string]
+type Identity string
 
 var (
 	// NoIdentity is an empty identity.
-	NoIdentity = Identity(immutable.None[string]())
+	NoIdentity = Identity("")
 )
 
-// NewIdentity makes a new identity if the input is not empty otherwise, returns an empty Option.
-func NewIdentity(identity string) Identity {
+// New makes a new identity if the input is not empty otherwise, returns an empty Option.
+func New(identity string) Identity {
 	// TODO-ACP: There will be more validation once sourcehub gets some utilities.
 	// Then a validation function would do the validation, will likely do outside this function.
 	// https://github.com/sourcenetwork/defradb/issues/2358
 	if identity == "" {
 		return NoIdentity
 	}
-	return Identity(immutable.Some[string](identity))
+	return Identity(identity)
 }
 
-// HasValue returns true if the identity is not empty.
-func (i Identity) HasValue() bool {
-	return immutable.Option[string](i).HasValue()
-}
-
-// Value returns the identity value.
-func (i Identity) Value() string {
-	return immutable.Option[string](i).Value()
+// String returns the string representation of the identity.
+func (i Identity) String() string {
+	return string(i)
 }

--- a/cli/acp_policy_add.go
+++ b/cli/acp_policy_add.go
@@ -15,18 +15,12 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-
-	"github.com/sourcenetwork/defradb/acp"
 )
 
 func MakeACPPolicyAddCommand() *cobra.Command {
-	const identityFlagLongRequired string = "identity"
-	const identityFlagShortRequired string = "i"
-
 	const fileFlagLong string = "file"
 	const fileFlagShort string = "f"
 
-	var identityValue string
 	var policyFile string
 
 	var cmd = &cobra.Command{
@@ -77,10 +71,6 @@ Example: add from stdin:
 
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if identityValue == "" {
-				return acp.ErrPolicyCreatorMustNotBeEmpty
-			}
-
 			// TODO-ACP: Ensure here (before going through acp system) if the required identity argument
 			// is valid, if it is valid then keep proceeding further, otherwise return this error:
 			// `NewErrRequiredFlagInvalid(identityFlagLongRequired, identityFlagShortRequired)`
@@ -114,7 +104,6 @@ Example: add from stdin:
 			db := mustGetContextDB(cmd)
 			policyResult, err := db.AddPolicy(
 				cmd.Context(),
-				identityValue,
 				policy,
 			)
 
@@ -126,14 +115,5 @@ Example: add from stdin:
 		},
 	}
 	cmd.Flags().StringVarP(&policyFile, fileFlagLong, fileFlagShort, "", "File to load a policy from")
-	cmd.Flags().StringVarP(
-		&identityValue,
-		identityFlagLongRequired,
-		identityFlagShortRequired,
-		"",
-		"[Required] Identity of the creator",
-	)
-	_ = cmd.MarkFlagRequired(identityFlagLongRequired)
-
 	return cmd
 }

--- a/cli/client.go
+++ b/cli/client.go
@@ -16,6 +16,7 @@ import (
 
 func MakeClientCommand() *cobra.Command {
 	var txID uint64
+	var identity string
 	var cmd = &cobra.Command{
 		Use:   "client",
 		Short: "Interact with a DefraDB node",
@@ -28,12 +29,16 @@ Execute queries, add schema types, obtain node info, etc.`,
 			if err := setContextConfig(cmd); err != nil {
 				return err
 			}
+			if err := setContextIdentity(cmd, identity); err != nil {
+				return err
+			}
 			if err := setContextTransaction(cmd, txID); err != nil {
 				return err
 			}
 			return setContextDB(cmd)
 		},
 	}
+	cmd.PersistentFlags().StringVarP(&identity, "identity", "i", "", "ACP Identity")
 	cmd.PersistentFlags().Uint64Var(&txID, "tx", 0, "Transaction ID")
 	return cmd
 }

--- a/cli/collection.go
+++ b/cli/collection.go
@@ -21,6 +21,7 @@ import (
 
 func MakeCollectionCommand() *cobra.Command {
 	var txID uint64
+	var identity string
 	var name string
 	var schemaRoot string
 	var versionID string
@@ -35,6 +36,9 @@ func MakeCollectionCommand() *cobra.Command {
 				return err
 			}
 			if err := setContextConfig(cmd); err != nil {
+				return err
+			}
+			if err := setContextIdentity(cmd, identity); err != nil {
 				return err
 			}
 			if err := setContextTransaction(cmd, txID); err != nil {
@@ -76,6 +80,7 @@ func MakeCollectionCommand() *cobra.Command {
 		},
 	}
 	cmd.PersistentFlags().Uint64Var(&txID, "tx", 0, "Transaction ID")
+	cmd.PersistentFlags().StringVarP(&identity, "identity", "i", "", "ACP Identity")
 	cmd.PersistentFlags().StringVar(&name, "name", "", "Collection name")
 	cmd.PersistentFlags().StringVar(&schemaRoot, "schema", "", "Collection schema Root")
 	cmd.PersistentFlags().StringVar(&versionID, "version", "", "Collection version ID")

--- a/cli/collection_create.go
+++ b/cli/collection_create.go
@@ -16,17 +16,11 @@ import (
 
 	"github.com/spf13/cobra"
 
-	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 )
 
 func MakeCollectionCreateCommand() *cobra.Command {
-	const identityFlagLongRequired string = "identity"
-	const identityFlagShortRequired string = "i"
-
-	var identityValue string
 	var file string
-
 	var cmd = &cobra.Command{
 		Use:   "create [-i --identity] <document>",
 		Short: "Create a new document.",
@@ -49,9 +43,6 @@ Example: create from stdin:
 		`,
 		Args: cobra.RangeArgs(0, 1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// TODO-ACP: `https://github.com/sourcenetwork/defradb/issues/2358` do the validation here.
-			identity := acpIdentity.NewIdentity(identityValue)
-
 			var docData []byte
 			switch {
 			case file != "":
@@ -82,23 +73,16 @@ Example: create from stdin:
 				if err != nil {
 					return err
 				}
-				return col.CreateMany(cmd.Context(), identity, docs)
+				return col.CreateMany(cmd.Context(), docs)
 			}
 
 			doc, err := client.NewDocFromJSON(docData, col.Schema())
 			if err != nil {
 				return err
 			}
-			return col.Create(cmd.Context(), identity, doc)
+			return col.Create(cmd.Context(), doc)
 		},
 	}
 	cmd.Flags().StringVarP(&file, "file", "f", "", "File containing document(s)")
-	cmd.Flags().StringVarP(
-		&identityValue,
-		identityFlagLongRequired,
-		identityFlagShortRequired,
-		"",
-		"Identity of the actor",
-	)
 	return cmd
 }

--- a/cli/collection_delete.go
+++ b/cli/collection_delete.go
@@ -13,15 +13,10 @@ package cli
 import (
 	"github.com/spf13/cobra"
 
-	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 )
 
 func MakeCollectionDeleteCommand() *cobra.Command {
-	const identityFlagLongRequired string = "identity"
-	const identityFlagShortRequired string = "i"
-
-	var identityValue string
 	var argDocIDs []string
 	var filter string
 	var cmd = &cobra.Command{
@@ -39,9 +34,6 @@ Example: delete by filter:
   defradb client collection delete --name User --filter '{ "_gte": { "points": 100 } }'
 		`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// TODO-ACP: `https://github.com/sourcenetwork/defradb/issues/2358` do the validation here.
-			identity := acpIdentity.NewIdentity(identityValue)
-
 			col, ok := tryGetContextCollection(cmd)
 			if !ok {
 				return cmd.Usage()
@@ -53,7 +45,7 @@ Example: delete by filter:
 				if err != nil {
 					return err
 				}
-				res, err := col.DeleteWithDocID(cmd.Context(), identity, docID)
+				res, err := col.DeleteWithDocID(cmd.Context(), docID)
 				if err != nil {
 					return err
 				}
@@ -67,13 +59,13 @@ Example: delete by filter:
 					}
 					docIDs[i] = docID
 				}
-				res, err := col.DeleteWithDocIDs(cmd.Context(), identity, docIDs)
+				res, err := col.DeleteWithDocIDs(cmd.Context(), docIDs)
 				if err != nil {
 					return err
 				}
 				return writeJSON(cmd, res)
 			case filter != "":
-				res, err := col.DeleteWithFilter(cmd.Context(), identity, filter)
+				res, err := col.DeleteWithFilter(cmd.Context(), filter)
 				if err != nil {
 					return err
 				}
@@ -85,12 +77,5 @@ Example: delete by filter:
 	}
 	cmd.Flags().StringSliceVar(&argDocIDs, "docID", nil, "Document ID")
 	cmd.Flags().StringVar(&filter, "filter", "", "Document filter")
-	cmd.Flags().StringVarP(
-		&identityValue,
-		identityFlagLongRequired,
-		identityFlagShortRequired,
-		"",
-		"Identity of the actor",
-	)
 	return cmd
 }

--- a/cli/collection_get.go
+++ b/cli/collection_get.go
@@ -13,15 +13,10 @@ package cli
 import (
 	"github.com/spf13/cobra"
 
-	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 )
 
 func MakeCollectionGetCommand() *cobra.Command {
-	const identityFlagLongRequired string = "identity"
-	const identityFlagShortRequired string = "i"
-
-	var identityValue string
 	var showDeleted bool
 	var cmd = &cobra.Command{
 		Use:   "get [-i --identity] [--show-deleted] <docID> ",
@@ -36,9 +31,6 @@ Example to get a private document we must use an identity:
 		`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// TODO-ACP: `https://github.com/sourcenetwork/defradb/issues/2358` do the validation here.
-			identity := acpIdentity.NewIdentity(identityValue)
-
 			col, ok := tryGetContextCollection(cmd)
 			if !ok {
 				return cmd.Usage()
@@ -48,7 +40,7 @@ Example to get a private document we must use an identity:
 			if err != nil {
 				return err
 			}
-			doc, err := col.Get(cmd.Context(), identity, docID, showDeleted)
+			doc, err := col.Get(cmd.Context(), docID, showDeleted)
 			if err != nil {
 				return err
 			}
@@ -60,12 +52,5 @@ Example to get a private document we must use an identity:
 		},
 	}
 	cmd.Flags().BoolVar(&showDeleted, "show-deleted", false, "Show deleted documents")
-	cmd.Flags().StringVarP(
-		&identityValue,
-		identityFlagLongRequired,
-		identityFlagShortRequired,
-		"",
-		"Identity of the actor",
-	)
 	return cmd
 }

--- a/cli/collection_list_doc_ids.go
+++ b/cli/collection_list_doc_ids.go
@@ -13,16 +13,10 @@ package cli
 import (
 	"github.com/spf13/cobra"
 
-	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/http"
 )
 
 func MakeCollectionListDocIDsCommand() *cobra.Command {
-	const identityFlagLongRequired string = "identity"
-	const identityFlagShortRequired string = "i"
-
-	var identityValue string
-
 	var cmd = &cobra.Command{
 		Use:   "docIDs [-i --identity]",
 		Short: "List all document IDs (docIDs).",
@@ -35,15 +29,12 @@ Example: list all docID(s), with an identity:
   defradb client collection docIDs -i cosmos1f2djr7dl9vhrk3twt3xwqp09nhtzec9mdkf70j --name User 
 		`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// TODO-ACP: `https://github.com/sourcenetwork/defradb/issues/2358` do the validation here.
-			identity := acpIdentity.NewIdentity(identityValue)
-
 			col, ok := tryGetContextCollection(cmd)
 			if !ok {
 				return cmd.Usage()
 			}
 
-			docCh, err := col.GetAllDocIDs(cmd.Context(), identity)
+			docCh, err := col.GetAllDocIDs(cmd.Context())
 			if err != nil {
 				return err
 			}
@@ -61,12 +52,5 @@ Example: list all docID(s), with an identity:
 			return nil
 		},
 	}
-	cmd.Flags().StringVarP(
-		&identityValue,
-		identityFlagLongRequired,
-		identityFlagShortRequired,
-		"",
-		"Identity of the actor",
-	)
 	return cmd
 }

--- a/cli/collection_update.go
+++ b/cli/collection_update.go
@@ -13,15 +13,10 @@ package cli
 import (
 	"github.com/spf13/cobra"
 
-	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 )
 
 func MakeCollectionUpdateCommand() *cobra.Command {
-	const identityFlagLongRequired string = "identity"
-	const identityFlagShortRequired string = "i"
-
-	var identityValue string
 	var argDocIDs []string
 	var filter string
 	var updater string
@@ -47,9 +42,6 @@ Example: update private docIDs, with identity:
 		`,
 		Args: cobra.RangeArgs(0, 1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// TODO-ACP: `https://github.com/sourcenetwork/defradb/issues/2358` do the validation here.
-			identity := acpIdentity.NewIdentity(identityValue)
-
 			col, ok := tryGetContextCollection(cmd)
 			if !ok {
 				return cmd.Usage()
@@ -61,7 +53,7 @@ Example: update private docIDs, with identity:
 				if err != nil {
 					return err
 				}
-				res, err := col.UpdateWithDocID(cmd.Context(), identity, docID, updater)
+				res, err := col.UpdateWithDocID(cmd.Context(), docID, updater)
 				if err != nil {
 					return err
 				}
@@ -75,13 +67,13 @@ Example: update private docIDs, with identity:
 					}
 					docIDs[i] = docID
 				}
-				res, err := col.UpdateWithDocIDs(cmd.Context(), identity, docIDs, updater)
+				res, err := col.UpdateWithDocIDs(cmd.Context(), docIDs, updater)
 				if err != nil {
 					return err
 				}
 				return writeJSON(cmd, res)
 			case filter != "" && updater != "":
-				res, err := col.UpdateWithFilter(cmd.Context(), identity, filter, updater)
+				res, err := col.UpdateWithFilter(cmd.Context(), filter, updater)
 				if err != nil {
 					return err
 				}
@@ -91,14 +83,14 @@ Example: update private docIDs, with identity:
 				if err != nil {
 					return err
 				}
-				doc, err := col.Get(cmd.Context(), identity, docID, true)
+				doc, err := col.Get(cmd.Context(), docID, true)
 				if err != nil {
 					return err
 				}
 				if err := doc.SetWithJSON([]byte(args[0])); err != nil {
 					return err
 				}
-				return col.Update(cmd.Context(), identity, doc)
+				return col.Update(cmd.Context(), doc)
 			default:
 				return ErrNoDocIDOrFilter
 			}
@@ -107,12 +99,5 @@ Example: update private docIDs, with identity:
 	cmd.Flags().StringSliceVar(&argDocIDs, "docID", nil, "Document ID")
 	cmd.Flags().StringVar(&filter, "filter", "", "Document filter")
 	cmd.Flags().StringVar(&updater, "updater", "", "Document updater")
-	cmd.Flags().StringVarP(
-		&identityValue,
-		identityFlagLongRequired,
-		identityFlagShortRequired,
-		"",
-		"Identity of the actor",
-	)
 	return cmd
 }

--- a/cli/request.go
+++ b/cli/request.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/errors"
 )
 
@@ -26,10 +25,6 @@ const (
 )
 
 func MakeRequestCommand() *cobra.Command {
-	const identityFlagLongRequired string = "identity"
-	const identityFlagShortRequired string = "i"
-
-	var identityValue string
 	var filePath string
 	var cmd = &cobra.Command{
 		Use:   "query [-i --identity] [request]",
@@ -53,9 +48,6 @@ with the database more conveniently.
 
 To learn more about the DefraDB GraphQL Query Language, refer to https://docs.source.network.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// TODO-ACP: `https://github.com/sourcenetwork/defradb/issues/2358` do the validation here.
-			identity := acpIdentity.NewIdentity(identityValue)
-
 			var request string
 			switch {
 			case filePath != "":
@@ -79,7 +71,7 @@ To learn more about the DefraDB GraphQL Query Language, refer to https://docs.so
 			}
 
 			store := mustGetContextStore(cmd)
-			result := store.ExecRequest(cmd.Context(), identity, request)
+			result := store.ExecRequest(cmd.Context(), request)
 
 			var errors []string
 			for _, err := range result.GQL.Errors {
@@ -98,12 +90,5 @@ To learn more about the DefraDB GraphQL Query Language, refer to https://docs.so
 	}
 
 	cmd.Flags().StringVarP(&filePath, "file", "f", "", "File containing the query request")
-	cmd.Flags().StringVarP(
-		&identityValue,
-		identityFlagLongRequired,
-		identityFlagShortRequired,
-		"",
-		"Identity of the actor",
-	)
 	return cmd
 }

--- a/cli/utils.go
+++ b/cli/utils.go
@@ -130,7 +130,7 @@ func setContextIdentity(cmd *cobra.Command, id string) error {
 	if id == "" {
 		return nil
 	}
-	ctx := db.SetContextIdentity(cmd.Context(), identity.NewIdentity(id))
+	ctx := db.SetContextIdentity(cmd.Context(), identity.New(id))
 	cmd.SetContext(ctx)
 	return nil
 }

--- a/cli/utils.go
+++ b/cli/utils.go
@@ -20,7 +20,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
+	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/db"
 	"github.com/sourcenetwork/defradb/http"
@@ -125,12 +125,12 @@ func setContextTransaction(cmd *cobra.Command, txId uint64) error {
 }
 
 // setContextIdentity sets the identity for the current command context.
-func setContextIdentity(cmd *cobra.Command, identity string) error {
+func setContextIdentity(cmd *cobra.Command, id string) error {
 	// TODO-ACP: `https://github.com/sourcenetwork/defradb/issues/2358` do the validation here.
-	if identity == "" {
+	if id == "" {
 		return nil
 	}
-	ctx := db.SetContextIdentity(cmd.Context(), acpIdentity.NewIdentity(identity))
+	ctx := db.SetContextIdentity(cmd.Context(), identity.NewIdentity(id))
 	cmd.SetContext(ctx)
 	return nil
 }

--- a/cli/utils.go
+++ b/cli/utils.go
@@ -20,6 +20,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
+	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/db"
 	"github.com/sourcenetwork/defradb/http"
@@ -119,6 +120,17 @@ func setContextTransaction(cmd *cobra.Command, txId uint64) error {
 		return err
 	}
 	ctx := db.SetContextTxn(cmd.Context(), tx)
+	cmd.SetContext(ctx)
+	return nil
+}
+
+// setContextIdentity sets the identity for the current command context.
+func setContextIdentity(cmd *cobra.Command, identity string) error {
+	// TODO-ACP: `https://github.com/sourcenetwork/defradb/issues/2358` do the validation here.
+	if identity == "" {
+		return nil
+	}
+	ctx := db.SetContextIdentity(cmd.Context(), acpIdentity.NewIdentity(identity))
 	cmd.SetContext(ctx)
 	return nil
 }

--- a/cli/utils.go
+++ b/cli/utils.go
@@ -20,7 +20,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	"github.com/sourcenetwork/defradb/acp/identity"
+	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/db"
 	"github.com/sourcenetwork/defradb/http"
@@ -125,12 +125,12 @@ func setContextTransaction(cmd *cobra.Command, txId uint64) error {
 }
 
 // setContextIdentity sets the identity for the current command context.
-func setContextIdentity(cmd *cobra.Command, id string) error {
+func setContextIdentity(cmd *cobra.Command, identity string) error {
 	// TODO-ACP: `https://github.com/sourcenetwork/defradb/issues/2358` do the validation here.
-	if id == "" {
+	if identity == "" {
 		return nil
 	}
-	ctx := db.SetContextIdentity(cmd.Context(), identity.New(id))
+	ctx := db.SetContextIdentity(cmd.Context(), acpIdentity.New(identity))
 	cmd.SetContext(ctx)
 	return nil
 }

--- a/client/collection.go
+++ b/client/collection.go
@@ -44,12 +44,12 @@ type Collection interface {
 	// Create a new document.
 	//
 	// Will verify the DocID/CID to ensure that the new document is correctly formatted.
-	Create(ctx context.Context, identity immutable.Option[string], doc *Document) error
+	Create(ctx context.Context, doc *Document) error
 
 	// CreateMany new documents.
 	//
 	// Will verify the DocIDs/CIDs to ensure that the new documents are correctly formatted.
-	CreateMany(ctx context.Context, identity immutable.Option[string], docs []*Document) error
+	CreateMany(ctx context.Context, docs []*Document) error
 
 	// Update an existing document with the new values.
 	//
@@ -57,13 +57,13 @@ type Collection interface {
 	// Any field that is nil/empty that hasn't called Clear will be ignored.
 	//
 	// Will return a ErrDocumentNotFound error if the given document is not found.
-	Update(ctx context.Context, identity immutable.Option[string], docs *Document) error
+	Update(ctx context.Context, docs *Document) error
 
 	// Save the given document in the database.
 	//
 	// If a document exists with the given DocID it will update it. Otherwise a new document
 	// will be created.
-	Save(ctx context.Context, identity immutable.Option[string], doc *Document) error
+	Save(ctx context.Context, doc *Document) error
 
 	// Delete will attempt to delete a document by DocID.
 	//
@@ -71,12 +71,12 @@ type Collection interface {
 	// if it cannot. If the document doesn't exist, then it will return false and a ErrDocumentNotFound error.
 	// This operation will hard-delete all state relating to the given DocID.
 	// This includes data, block, and head storage.
-	Delete(ctx context.Context, identity immutable.Option[string], docID DocID) (bool, error)
+	Delete(ctx context.Context, docID DocID) (bool, error)
 
 	// Exists checks if a given document exists with supplied DocID.
 	//
 	// Will return true if a matching document exists, otherwise will return false.
-	Exists(ctx context.Context, identity immutable.Option[string], docID DocID) (bool, error)
+	Exists(ctx context.Context, docID DocID) (bool, error)
 
 	// UpdateWith updates a target document using the given updater type.
 	//
@@ -89,7 +89,6 @@ type Collection interface {
 	// Returns an ErrInvalidUpdater error if the updater type is not supported.
 	UpdateWith(
 		ctx context.Context,
-		identity immutable.Option[string],
 		target any,
 		updater string,
 	) (*UpdateResult, error)
@@ -100,7 +99,6 @@ type Collection interface {
 	// else an ErrInvalidUpdater will be returned.
 	UpdateWithFilter(
 		ctx context.Context,
-		identity immutable.Option[string],
 		filter any,
 		updater string,
 	) (*UpdateResult, error)
@@ -113,7 +111,6 @@ type Collection interface {
 	// Returns an ErrDocumentNotFound if a document matching the given DocID is not found.
 	UpdateWithDocID(
 		ctx context.Context,
-		identity immutable.Option[string],
 		docID DocID,
 		updater string,
 	) (*UpdateResult, error)
@@ -126,7 +123,6 @@ type Collection interface {
 	// Returns an ErrDocumentNotFound if a document is not found for any given DocID.
 	UpdateWithDocIDs(
 		ctx context.Context,
-		identity immutable.Option[string],
 		docIDs []DocID,
 		updater string,
 	) (*UpdateResult, error)
@@ -142,7 +138,6 @@ type Collection interface {
 	// Returns an ErrInvalidDeleteTarget if the target type is not supported.
 	DeleteWith(
 		ctx context.Context,
-		identity immutable.Option[string],
 		target any,
 	) (*DeleteResult, error)
 
@@ -152,7 +147,6 @@ type Collection interface {
 	// with a status of `Deleted`.
 	DeleteWithFilter(
 		ctx context.Context,
-		identity immutable.Option[string],
 		filter any,
 	) (*DeleteResult, error)
 
@@ -164,7 +158,6 @@ type Collection interface {
 	// Returns an ErrDocumentNotFound if a document matching the given DocID is not found.
 	DeleteWithDocID(
 		ctx context.Context,
-		identity immutable.Option[string],
 		docID DocID,
 	) (*DeleteResult, error)
 
@@ -176,7 +169,6 @@ type Collection interface {
 	// Returns an ErrDocumentNotFound if a document is not found for any given DocID.
 	DeleteWithDocIDs(
 		ctx context.Context,
-		identity immutable.Option[string],
 		docIDs []DocID,
 	) (*DeleteResult, error)
 
@@ -185,13 +177,12 @@ type Collection interface {
 	// Returns an ErrDocumentNotFound if a document matching the given DocID is not found.
 	Get(
 		ctx context.Context,
-		identity immutable.Option[string],
 		docID DocID,
 		showDeleted bool,
 	) (*Document, error)
 
 	// GetAllDocIDs returns all the document IDs that exist in the collection.
-	GetAllDocIDs(ctx context.Context, identity immutable.Option[string]) (<-chan DocIDResult, error)
+	GetAllDocIDs(ctx context.Context) (<-chan DocIDResult, error)
 
 	// CreateIndex creates a new index on the collection.
 	// `IndexDescription` contains the description of the index to be created.

--- a/client/db.go
+++ b/client/db.go
@@ -235,12 +235,8 @@ type Store interface {
 	// GetAllIndexes returns all the indexes that currently exist within this [Store].
 	GetAllIndexes(context.Context) (map[CollectionName][]IndexDescription, error)
 
-	// ExecRequest executes the given GQL request against the [Store], with the given identity.
-	ExecRequest(
-		ctx context.Context,
-		identity immutable.Option[string],
-		request string,
-	) *RequestResult
+	// ExecRequest executes the given GQL request against the [Store].
+	ExecRequest(ctx context.Context, request string) *RequestResult
 }
 
 // GQLResult represents the immediate results of a GQL request.

--- a/client/db.go
+++ b/client/db.go
@@ -93,7 +93,7 @@ type DB interface {
 	// validation fails.
 	//
 	// Note: A policy can not be added without the creatorID (identity).
-	AddPolicy(ctx context.Context, creatorID string, policy string) (AddPolicyResult, error)
+	AddPolicy(ctx context.Context, policy string) (AddPolicyResult, error)
 }
 
 // Store contains the core DefraDB read-write operations.

--- a/client/mocks/collection.go
+++ b/client/mocks/collection.go
@@ -7,8 +7,6 @@ import (
 
 	client "github.com/sourcenetwork/defradb/client"
 
-	datastore "github.com/sourcenetwork/defradb/datastore"
-
 	immutable "github.com/sourcenetwork/immutable"
 
 	mock "github.com/stretchr/testify/mock"
@@ -27,13 +25,13 @@ func (_m *Collection) EXPECT() *Collection_Expecter {
 	return &Collection_Expecter{mock: &_m.Mock}
 }
 
-// Create provides a mock function with given fields: ctx, identity, doc
-func (_m *Collection) Create(ctx context.Context, identity immutable.Option[string], doc *client.Document) error {
-	ret := _m.Called(ctx, identity, doc)
+// Create provides a mock function with given fields: ctx, doc
+func (_m *Collection) Create(ctx context.Context, doc *client.Document) error {
+	ret := _m.Called(ctx, doc)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, immutable.Option[string], *client.Document) error); ok {
-		r0 = rf(ctx, identity, doc)
+	if rf, ok := ret.Get(0).(func(context.Context, *client.Document) error); ok {
+		r0 = rf(ctx, doc)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -48,15 +46,14 @@ type Collection_Create_Call struct {
 
 // Create is a helper method to define mock.On call
 //   - ctx context.Context
-//   - identity immutable.Option[string]
 //   - doc *client.Document
-func (_e *Collection_Expecter) Create(ctx interface{}, identity interface{}, doc interface{}) *Collection_Create_Call {
-	return &Collection_Create_Call{Call: _e.mock.On("Create", ctx, identity, doc)}
+func (_e *Collection_Expecter) Create(ctx interface{}, doc interface{}) *Collection_Create_Call {
+	return &Collection_Create_Call{Call: _e.mock.On("Create", ctx, doc)}
 }
 
-func (_c *Collection_Create_Call) Run(run func(ctx context.Context, identity immutable.Option[string], doc *client.Document)) *Collection_Create_Call {
+func (_c *Collection_Create_Call) Run(run func(ctx context.Context, doc *client.Document)) *Collection_Create_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(immutable.Option[string]), args[2].(*client.Document))
+		run(args[0].(context.Context), args[1].(*client.Document))
 	})
 	return _c
 }
@@ -66,7 +63,7 @@ func (_c *Collection_Create_Call) Return(_a0 error) *Collection_Create_Call {
 	return _c
 }
 
-func (_c *Collection_Create_Call) RunAndReturn(run func(context.Context, immutable.Option[string], *client.Document) error) *Collection_Create_Call {
+func (_c *Collection_Create_Call) RunAndReturn(run func(context.Context, *client.Document) error) *Collection_Create_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -167,13 +164,13 @@ func (_c *Collection_CreateIndex_Call) RunAndReturn(run func(context.Context, cl
 	return _c
 }
 
-// CreateMany provides a mock function with given fields: ctx, identity, docs
-func (_m *Collection) CreateMany(ctx context.Context, identity immutable.Option[string], docs []*client.Document) error {
-	ret := _m.Called(ctx, identity, docs)
+// CreateMany provides a mock function with given fields: ctx, docs
+func (_m *Collection) CreateMany(ctx context.Context, docs []*client.Document) error {
+	ret := _m.Called(ctx, docs)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, immutable.Option[string], []*client.Document) error); ok {
-		r0 = rf(ctx, identity, docs)
+	if rf, ok := ret.Get(0).(func(context.Context, []*client.Document) error); ok {
+		r0 = rf(ctx, docs)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -188,15 +185,14 @@ type Collection_CreateMany_Call struct {
 
 // CreateMany is a helper method to define mock.On call
 //   - ctx context.Context
-//   - identity immutable.Option[string]
 //   - docs []*client.Document
-func (_e *Collection_Expecter) CreateMany(ctx interface{}, identity interface{}, docs interface{}) *Collection_CreateMany_Call {
-	return &Collection_CreateMany_Call{Call: _e.mock.On("CreateMany", ctx, identity, docs)}
+func (_e *Collection_Expecter) CreateMany(ctx interface{}, docs interface{}) *Collection_CreateMany_Call {
+	return &Collection_CreateMany_Call{Call: _e.mock.On("CreateMany", ctx, docs)}
 }
 
-func (_c *Collection_CreateMany_Call) Run(run func(ctx context.Context, identity immutable.Option[string], docs []*client.Document)) *Collection_CreateMany_Call {
+func (_c *Collection_CreateMany_Call) Run(run func(ctx context.Context, docs []*client.Document)) *Collection_CreateMany_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(immutable.Option[string]), args[2].([]*client.Document))
+		run(args[0].(context.Context), args[1].([]*client.Document))
 	})
 	return _c
 }
@@ -206,7 +202,7 @@ func (_c *Collection_CreateMany_Call) Return(_a0 error) *Collection_CreateMany_C
 	return _c
 }
 
-func (_c *Collection_CreateMany_Call) RunAndReturn(run func(context.Context, immutable.Option[string], []*client.Document) error) *Collection_CreateMany_Call {
+func (_c *Collection_CreateMany_Call) RunAndReturn(run func(context.Context, []*client.Document) error) *Collection_CreateMany_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -252,23 +248,23 @@ func (_c *Collection_Definition_Call) RunAndReturn(run func() client.CollectionD
 	return _c
 }
 
-// Delete provides a mock function with given fields: ctx, identity, docID
-func (_m *Collection) Delete(ctx context.Context, identity immutable.Option[string], docID client.DocID) (bool, error) {
-	ret := _m.Called(ctx, identity, docID)
+// Delete provides a mock function with given fields: ctx, docID
+func (_m *Collection) Delete(ctx context.Context, docID client.DocID) (bool, error) {
+	ret := _m.Called(ctx, docID)
 
 	var r0 bool
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, immutable.Option[string], client.DocID) (bool, error)); ok {
-		return rf(ctx, identity, docID)
+	if rf, ok := ret.Get(0).(func(context.Context, client.DocID) (bool, error)); ok {
+		return rf(ctx, docID)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, immutable.Option[string], client.DocID) bool); ok {
-		r0 = rf(ctx, identity, docID)
+	if rf, ok := ret.Get(0).(func(context.Context, client.DocID) bool); ok {
+		r0 = rf(ctx, docID)
 	} else {
 		r0 = ret.Get(0).(bool)
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, immutable.Option[string], client.DocID) error); ok {
-		r1 = rf(ctx, identity, docID)
+	if rf, ok := ret.Get(1).(func(context.Context, client.DocID) error); ok {
+		r1 = rf(ctx, docID)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -283,15 +279,14 @@ type Collection_Delete_Call struct {
 
 // Delete is a helper method to define mock.On call
 //   - ctx context.Context
-//   - identity immutable.Option[string]
 //   - docID client.DocID
-func (_e *Collection_Expecter) Delete(ctx interface{}, identity interface{}, docID interface{}) *Collection_Delete_Call {
-	return &Collection_Delete_Call{Call: _e.mock.On("Delete", ctx, identity, docID)}
+func (_e *Collection_Expecter) Delete(ctx interface{}, docID interface{}) *Collection_Delete_Call {
+	return &Collection_Delete_Call{Call: _e.mock.On("Delete", ctx, docID)}
 }
 
-func (_c *Collection_Delete_Call) Run(run func(ctx context.Context, identity immutable.Option[string], docID client.DocID)) *Collection_Delete_Call {
+func (_c *Collection_Delete_Call) Run(run func(ctx context.Context, docID client.DocID)) *Collection_Delete_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(immutable.Option[string]), args[2].(client.DocID))
+		run(args[0].(context.Context), args[1].(client.DocID))
 	})
 	return _c
 }
@@ -301,7 +296,7 @@ func (_c *Collection_Delete_Call) Return(_a0 bool, _a1 error) *Collection_Delete
 	return _c
 }
 
-func (_c *Collection_Delete_Call) RunAndReturn(run func(context.Context, immutable.Option[string], client.DocID) (bool, error)) *Collection_Delete_Call {
+func (_c *Collection_Delete_Call) RunAndReturn(run func(context.Context, client.DocID) (bool, error)) *Collection_Delete_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -349,25 +344,25 @@ func (_c *Collection_DeleteDocIndex_Call) RunAndReturn(run func(context.Context,
 	return _c
 }
 
-// DeleteWith provides a mock function with given fields: ctx, identity, target
-func (_m *Collection) DeleteWith(ctx context.Context, identity immutable.Option[string], target interface{}) (*client.DeleteResult, error) {
-	ret := _m.Called(ctx, identity, target)
+// DeleteWith provides a mock function with given fields: ctx, target
+func (_m *Collection) DeleteWith(ctx context.Context, target interface{}) (*client.DeleteResult, error) {
+	ret := _m.Called(ctx, target)
 
 	var r0 *client.DeleteResult
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, immutable.Option[string], interface{}) (*client.DeleteResult, error)); ok {
-		return rf(ctx, identity, target)
+	if rf, ok := ret.Get(0).(func(context.Context, interface{}) (*client.DeleteResult, error)); ok {
+		return rf(ctx, target)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, immutable.Option[string], interface{}) *client.DeleteResult); ok {
-		r0 = rf(ctx, identity, target)
+	if rf, ok := ret.Get(0).(func(context.Context, interface{}) *client.DeleteResult); ok {
+		r0 = rf(ctx, target)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*client.DeleteResult)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, immutable.Option[string], interface{}) error); ok {
-		r1 = rf(ctx, identity, target)
+	if rf, ok := ret.Get(1).(func(context.Context, interface{}) error); ok {
+		r1 = rf(ctx, target)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -382,15 +377,14 @@ type Collection_DeleteWith_Call struct {
 
 // DeleteWith is a helper method to define mock.On call
 //   - ctx context.Context
-//   - identity immutable.Option[string]
 //   - target interface{}
-func (_e *Collection_Expecter) DeleteWith(ctx interface{}, identity interface{}, target interface{}) *Collection_DeleteWith_Call {
-	return &Collection_DeleteWith_Call{Call: _e.mock.On("DeleteWith", ctx, identity, target)}
+func (_e *Collection_Expecter) DeleteWith(ctx interface{}, target interface{}) *Collection_DeleteWith_Call {
+	return &Collection_DeleteWith_Call{Call: _e.mock.On("DeleteWith", ctx, target)}
 }
 
-func (_c *Collection_DeleteWith_Call) Run(run func(ctx context.Context, identity immutable.Option[string], target interface{})) *Collection_DeleteWith_Call {
+func (_c *Collection_DeleteWith_Call) Run(run func(ctx context.Context, target interface{})) *Collection_DeleteWith_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(immutable.Option[string]), args[2].(interface{}))
+		run(args[0].(context.Context), args[1].(interface{}))
 	})
 	return _c
 }
@@ -400,30 +394,30 @@ func (_c *Collection_DeleteWith_Call) Return(_a0 *client.DeleteResult, _a1 error
 	return _c
 }
 
-func (_c *Collection_DeleteWith_Call) RunAndReturn(run func(context.Context, immutable.Option[string], interface{}) (*client.DeleteResult, error)) *Collection_DeleteWith_Call {
+func (_c *Collection_DeleteWith_Call) RunAndReturn(run func(context.Context, interface{}) (*client.DeleteResult, error)) *Collection_DeleteWith_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// DeleteWithDocID provides a mock function with given fields: ctx, identity, docID
-func (_m *Collection) DeleteWithDocID(ctx context.Context, identity immutable.Option[string], docID client.DocID) (*client.DeleteResult, error) {
-	ret := _m.Called(ctx, identity, docID)
+// DeleteWithDocID provides a mock function with given fields: ctx, docID
+func (_m *Collection) DeleteWithDocID(ctx context.Context, docID client.DocID) (*client.DeleteResult, error) {
+	ret := _m.Called(ctx, docID)
 
 	var r0 *client.DeleteResult
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, immutable.Option[string], client.DocID) (*client.DeleteResult, error)); ok {
-		return rf(ctx, identity, docID)
+	if rf, ok := ret.Get(0).(func(context.Context, client.DocID) (*client.DeleteResult, error)); ok {
+		return rf(ctx, docID)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, immutable.Option[string], client.DocID) *client.DeleteResult); ok {
-		r0 = rf(ctx, identity, docID)
+	if rf, ok := ret.Get(0).(func(context.Context, client.DocID) *client.DeleteResult); ok {
+		r0 = rf(ctx, docID)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*client.DeleteResult)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, immutable.Option[string], client.DocID) error); ok {
-		r1 = rf(ctx, identity, docID)
+	if rf, ok := ret.Get(1).(func(context.Context, client.DocID) error); ok {
+		r1 = rf(ctx, docID)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -438,15 +432,14 @@ type Collection_DeleteWithDocID_Call struct {
 
 // DeleteWithDocID is a helper method to define mock.On call
 //   - ctx context.Context
-//   - identity immutable.Option[string]
 //   - docID client.DocID
-func (_e *Collection_Expecter) DeleteWithDocID(ctx interface{}, identity interface{}, docID interface{}) *Collection_DeleteWithDocID_Call {
-	return &Collection_DeleteWithDocID_Call{Call: _e.mock.On("DeleteWithDocID", ctx, identity, docID)}
+func (_e *Collection_Expecter) DeleteWithDocID(ctx interface{}, docID interface{}) *Collection_DeleteWithDocID_Call {
+	return &Collection_DeleteWithDocID_Call{Call: _e.mock.On("DeleteWithDocID", ctx, docID)}
 }
 
-func (_c *Collection_DeleteWithDocID_Call) Run(run func(ctx context.Context, identity immutable.Option[string], docID client.DocID)) *Collection_DeleteWithDocID_Call {
+func (_c *Collection_DeleteWithDocID_Call) Run(run func(ctx context.Context, docID client.DocID)) *Collection_DeleteWithDocID_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(immutable.Option[string]), args[2].(client.DocID))
+		run(args[0].(context.Context), args[1].(client.DocID))
 	})
 	return _c
 }
@@ -456,30 +449,30 @@ func (_c *Collection_DeleteWithDocID_Call) Return(_a0 *client.DeleteResult, _a1 
 	return _c
 }
 
-func (_c *Collection_DeleteWithDocID_Call) RunAndReturn(run func(context.Context, immutable.Option[string], client.DocID) (*client.DeleteResult, error)) *Collection_DeleteWithDocID_Call {
+func (_c *Collection_DeleteWithDocID_Call) RunAndReturn(run func(context.Context, client.DocID) (*client.DeleteResult, error)) *Collection_DeleteWithDocID_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// DeleteWithDocIDs provides a mock function with given fields: ctx, identity, docIDs
-func (_m *Collection) DeleteWithDocIDs(ctx context.Context, identity immutable.Option[string], docIDs []client.DocID) (*client.DeleteResult, error) {
-	ret := _m.Called(ctx, identity, docIDs)
+// DeleteWithDocIDs provides a mock function with given fields: ctx, docIDs
+func (_m *Collection) DeleteWithDocIDs(ctx context.Context, docIDs []client.DocID) (*client.DeleteResult, error) {
+	ret := _m.Called(ctx, docIDs)
 
 	var r0 *client.DeleteResult
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, immutable.Option[string], []client.DocID) (*client.DeleteResult, error)); ok {
-		return rf(ctx, identity, docIDs)
+	if rf, ok := ret.Get(0).(func(context.Context, []client.DocID) (*client.DeleteResult, error)); ok {
+		return rf(ctx, docIDs)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, immutable.Option[string], []client.DocID) *client.DeleteResult); ok {
-		r0 = rf(ctx, identity, docIDs)
+	if rf, ok := ret.Get(0).(func(context.Context, []client.DocID) *client.DeleteResult); ok {
+		r0 = rf(ctx, docIDs)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*client.DeleteResult)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, immutable.Option[string], []client.DocID) error); ok {
-		r1 = rf(ctx, identity, docIDs)
+	if rf, ok := ret.Get(1).(func(context.Context, []client.DocID) error); ok {
+		r1 = rf(ctx, docIDs)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -494,15 +487,14 @@ type Collection_DeleteWithDocIDs_Call struct {
 
 // DeleteWithDocIDs is a helper method to define mock.On call
 //   - ctx context.Context
-//   - identity immutable.Option[string]
 //   - docIDs []client.DocID
-func (_e *Collection_Expecter) DeleteWithDocIDs(ctx interface{}, identity interface{}, docIDs interface{}) *Collection_DeleteWithDocIDs_Call {
-	return &Collection_DeleteWithDocIDs_Call{Call: _e.mock.On("DeleteWithDocIDs", ctx, identity, docIDs)}
+func (_e *Collection_Expecter) DeleteWithDocIDs(ctx interface{}, docIDs interface{}) *Collection_DeleteWithDocIDs_Call {
+	return &Collection_DeleteWithDocIDs_Call{Call: _e.mock.On("DeleteWithDocIDs", ctx, docIDs)}
 }
 
-func (_c *Collection_DeleteWithDocIDs_Call) Run(run func(ctx context.Context, identity immutable.Option[string], docIDs []client.DocID)) *Collection_DeleteWithDocIDs_Call {
+func (_c *Collection_DeleteWithDocIDs_Call) Run(run func(ctx context.Context, docIDs []client.DocID)) *Collection_DeleteWithDocIDs_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(immutable.Option[string]), args[2].([]client.DocID))
+		run(args[0].(context.Context), args[1].([]client.DocID))
 	})
 	return _c
 }
@@ -512,30 +504,30 @@ func (_c *Collection_DeleteWithDocIDs_Call) Return(_a0 *client.DeleteResult, _a1
 	return _c
 }
 
-func (_c *Collection_DeleteWithDocIDs_Call) RunAndReturn(run func(context.Context, immutable.Option[string], []client.DocID) (*client.DeleteResult, error)) *Collection_DeleteWithDocIDs_Call {
+func (_c *Collection_DeleteWithDocIDs_Call) RunAndReturn(run func(context.Context, []client.DocID) (*client.DeleteResult, error)) *Collection_DeleteWithDocIDs_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// DeleteWithFilter provides a mock function with given fields: ctx, identity, filter
-func (_m *Collection) DeleteWithFilter(ctx context.Context, identity immutable.Option[string], filter interface{}) (*client.DeleteResult, error) {
-	ret := _m.Called(ctx, identity, filter)
+// DeleteWithFilter provides a mock function with given fields: ctx, filter
+func (_m *Collection) DeleteWithFilter(ctx context.Context, filter interface{}) (*client.DeleteResult, error) {
+	ret := _m.Called(ctx, filter)
 
 	var r0 *client.DeleteResult
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, immutable.Option[string], interface{}) (*client.DeleteResult, error)); ok {
-		return rf(ctx, identity, filter)
+	if rf, ok := ret.Get(0).(func(context.Context, interface{}) (*client.DeleteResult, error)); ok {
+		return rf(ctx, filter)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, immutable.Option[string], interface{}) *client.DeleteResult); ok {
-		r0 = rf(ctx, identity, filter)
+	if rf, ok := ret.Get(0).(func(context.Context, interface{}) *client.DeleteResult); ok {
+		r0 = rf(ctx, filter)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*client.DeleteResult)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, immutable.Option[string], interface{}) error); ok {
-		r1 = rf(ctx, identity, filter)
+	if rf, ok := ret.Get(1).(func(context.Context, interface{}) error); ok {
+		r1 = rf(ctx, filter)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -550,15 +542,14 @@ type Collection_DeleteWithFilter_Call struct {
 
 // DeleteWithFilter is a helper method to define mock.On call
 //   - ctx context.Context
-//   - identity immutable.Option[string]
 //   - filter interface{}
-func (_e *Collection_Expecter) DeleteWithFilter(ctx interface{}, identity interface{}, filter interface{}) *Collection_DeleteWithFilter_Call {
-	return &Collection_DeleteWithFilter_Call{Call: _e.mock.On("DeleteWithFilter", ctx, identity, filter)}
+func (_e *Collection_Expecter) DeleteWithFilter(ctx interface{}, filter interface{}) *Collection_DeleteWithFilter_Call {
+	return &Collection_DeleteWithFilter_Call{Call: _e.mock.On("DeleteWithFilter", ctx, filter)}
 }
 
-func (_c *Collection_DeleteWithFilter_Call) Run(run func(ctx context.Context, identity immutable.Option[string], filter interface{})) *Collection_DeleteWithFilter_Call {
+func (_c *Collection_DeleteWithFilter_Call) Run(run func(ctx context.Context, filter interface{})) *Collection_DeleteWithFilter_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(immutable.Option[string]), args[2].(interface{}))
+		run(args[0].(context.Context), args[1].(interface{}))
 	})
 	return _c
 }
@@ -568,7 +559,7 @@ func (_c *Collection_DeleteWithFilter_Call) Return(_a0 *client.DeleteResult, _a1
 	return _c
 }
 
-func (_c *Collection_DeleteWithFilter_Call) RunAndReturn(run func(context.Context, immutable.Option[string], interface{}) (*client.DeleteResult, error)) *Collection_DeleteWithFilter_Call {
+func (_c *Collection_DeleteWithFilter_Call) RunAndReturn(run func(context.Context, interface{}) (*client.DeleteResult, error)) *Collection_DeleteWithFilter_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -657,23 +648,23 @@ func (_c *Collection_DropIndex_Call) RunAndReturn(run func(context.Context, stri
 	return _c
 }
 
-// Exists provides a mock function with given fields: ctx, identity, docID
-func (_m *Collection) Exists(ctx context.Context, identity immutable.Option[string], docID client.DocID) (bool, error) {
-	ret := _m.Called(ctx, identity, docID)
+// Exists provides a mock function with given fields: ctx, docID
+func (_m *Collection) Exists(ctx context.Context, docID client.DocID) (bool, error) {
+	ret := _m.Called(ctx, docID)
 
 	var r0 bool
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, immutable.Option[string], client.DocID) (bool, error)); ok {
-		return rf(ctx, identity, docID)
+	if rf, ok := ret.Get(0).(func(context.Context, client.DocID) (bool, error)); ok {
+		return rf(ctx, docID)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, immutable.Option[string], client.DocID) bool); ok {
-		r0 = rf(ctx, identity, docID)
+	if rf, ok := ret.Get(0).(func(context.Context, client.DocID) bool); ok {
+		r0 = rf(ctx, docID)
 	} else {
 		r0 = ret.Get(0).(bool)
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, immutable.Option[string], client.DocID) error); ok {
-		r1 = rf(ctx, identity, docID)
+	if rf, ok := ret.Get(1).(func(context.Context, client.DocID) error); ok {
+		r1 = rf(ctx, docID)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -688,15 +679,14 @@ type Collection_Exists_Call struct {
 
 // Exists is a helper method to define mock.On call
 //   - ctx context.Context
-//   - identity immutable.Option[string]
 //   - docID client.DocID
-func (_e *Collection_Expecter) Exists(ctx interface{}, identity interface{}, docID interface{}) *Collection_Exists_Call {
-	return &Collection_Exists_Call{Call: _e.mock.On("Exists", ctx, identity, docID)}
+func (_e *Collection_Expecter) Exists(ctx interface{}, docID interface{}) *Collection_Exists_Call {
+	return &Collection_Exists_Call{Call: _e.mock.On("Exists", ctx, docID)}
 }
 
-func (_c *Collection_Exists_Call) Run(run func(ctx context.Context, identity immutable.Option[string], docID client.DocID)) *Collection_Exists_Call {
+func (_c *Collection_Exists_Call) Run(run func(ctx context.Context, docID client.DocID)) *Collection_Exists_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(immutable.Option[string]), args[2].(client.DocID))
+		run(args[0].(context.Context), args[1].(client.DocID))
 	})
 	return _c
 }
@@ -706,30 +696,30 @@ func (_c *Collection_Exists_Call) Return(_a0 bool, _a1 error) *Collection_Exists
 	return _c
 }
 
-func (_c *Collection_Exists_Call) RunAndReturn(run func(context.Context, immutable.Option[string], client.DocID) (bool, error)) *Collection_Exists_Call {
+func (_c *Collection_Exists_Call) RunAndReturn(run func(context.Context, client.DocID) (bool, error)) *Collection_Exists_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// Get provides a mock function with given fields: ctx, identity, docID, showDeleted
-func (_m *Collection) Get(ctx context.Context, identity immutable.Option[string], docID client.DocID, showDeleted bool) (*client.Document, error) {
-	ret := _m.Called(ctx, identity, docID, showDeleted)
+// Get provides a mock function with given fields: ctx, docID, showDeleted
+func (_m *Collection) Get(ctx context.Context, docID client.DocID, showDeleted bool) (*client.Document, error) {
+	ret := _m.Called(ctx, docID, showDeleted)
 
 	var r0 *client.Document
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, immutable.Option[string], client.DocID, bool) (*client.Document, error)); ok {
-		return rf(ctx, identity, docID, showDeleted)
+	if rf, ok := ret.Get(0).(func(context.Context, client.DocID, bool) (*client.Document, error)); ok {
+		return rf(ctx, docID, showDeleted)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, immutable.Option[string], client.DocID, bool) *client.Document); ok {
-		r0 = rf(ctx, identity, docID, showDeleted)
+	if rf, ok := ret.Get(0).(func(context.Context, client.DocID, bool) *client.Document); ok {
+		r0 = rf(ctx, docID, showDeleted)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*client.Document)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, immutable.Option[string], client.DocID, bool) error); ok {
-		r1 = rf(ctx, identity, docID, showDeleted)
+	if rf, ok := ret.Get(1).(func(context.Context, client.DocID, bool) error); ok {
+		r1 = rf(ctx, docID, showDeleted)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -744,16 +734,15 @@ type Collection_Get_Call struct {
 
 // Get is a helper method to define mock.On call
 //   - ctx context.Context
-//   - identity immutable.Option[string]
 //   - docID client.DocID
 //   - showDeleted bool
-func (_e *Collection_Expecter) Get(ctx interface{}, identity interface{}, docID interface{}, showDeleted interface{}) *Collection_Get_Call {
-	return &Collection_Get_Call{Call: _e.mock.On("Get", ctx, identity, docID, showDeleted)}
+func (_e *Collection_Expecter) Get(ctx interface{}, docID interface{}, showDeleted interface{}) *Collection_Get_Call {
+	return &Collection_Get_Call{Call: _e.mock.On("Get", ctx, docID, showDeleted)}
 }
 
-func (_c *Collection_Get_Call) Run(run func(ctx context.Context, identity immutable.Option[string], docID client.DocID, showDeleted bool)) *Collection_Get_Call {
+func (_c *Collection_Get_Call) Run(run func(ctx context.Context, docID client.DocID, showDeleted bool)) *Collection_Get_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(immutable.Option[string]), args[2].(client.DocID), args[3].(bool))
+		run(args[0].(context.Context), args[1].(client.DocID), args[2].(bool))
 	})
 	return _c
 }
@@ -763,30 +752,30 @@ func (_c *Collection_Get_Call) Return(_a0 *client.Document, _a1 error) *Collecti
 	return _c
 }
 
-func (_c *Collection_Get_Call) RunAndReturn(run func(context.Context, immutable.Option[string], client.DocID, bool) (*client.Document, error)) *Collection_Get_Call {
+func (_c *Collection_Get_Call) RunAndReturn(run func(context.Context, client.DocID, bool) (*client.Document, error)) *Collection_Get_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// GetAllDocIDs provides a mock function with given fields: ctx, identity
-func (_m *Collection) GetAllDocIDs(ctx context.Context, identity immutable.Option[string]) (<-chan client.DocIDResult, error) {
-	ret := _m.Called(ctx, identity)
+// GetAllDocIDs provides a mock function with given fields: ctx
+func (_m *Collection) GetAllDocIDs(ctx context.Context) (<-chan client.DocIDResult, error) {
+	ret := _m.Called(ctx)
 
 	var r0 <-chan client.DocIDResult
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, immutable.Option[string]) (<-chan client.DocIDResult, error)); ok {
-		return rf(ctx, identity)
+	if rf, ok := ret.Get(0).(func(context.Context) (<-chan client.DocIDResult, error)); ok {
+		return rf(ctx)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, immutable.Option[string]) <-chan client.DocIDResult); ok {
-		r0 = rf(ctx, identity)
+	if rf, ok := ret.Get(0).(func(context.Context) <-chan client.DocIDResult); ok {
+		r0 = rf(ctx)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(<-chan client.DocIDResult)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, immutable.Option[string]) error); ok {
-		r1 = rf(ctx, identity)
+	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = rf(ctx)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -801,14 +790,13 @@ type Collection_GetAllDocIDs_Call struct {
 
 // GetAllDocIDs is a helper method to define mock.On call
 //   - ctx context.Context
-//   - identity immutable.Option[string]
-func (_e *Collection_Expecter) GetAllDocIDs(ctx interface{}, identity interface{}) *Collection_GetAllDocIDs_Call {
-	return &Collection_GetAllDocIDs_Call{Call: _e.mock.On("GetAllDocIDs", ctx, identity)}
+func (_e *Collection_Expecter) GetAllDocIDs(ctx interface{}) *Collection_GetAllDocIDs_Call {
+	return &Collection_GetAllDocIDs_Call{Call: _e.mock.On("GetAllDocIDs", ctx)}
 }
 
-func (_c *Collection_GetAllDocIDs_Call) Run(run func(ctx context.Context, identity immutable.Option[string])) *Collection_GetAllDocIDs_Call {
+func (_c *Collection_GetAllDocIDs_Call) Run(run func(ctx context.Context)) *Collection_GetAllDocIDs_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(immutable.Option[string]))
+		run(args[0].(context.Context))
 	})
 	return _c
 }
@@ -818,7 +806,7 @@ func (_c *Collection_GetAllDocIDs_Call) Return(_a0 <-chan client.DocIDResult, _a
 	return _c
 }
 
-func (_c *Collection_GetAllDocIDs_Call) RunAndReturn(run func(context.Context, immutable.Option[string]) (<-chan client.DocIDResult, error)) *Collection_GetAllDocIDs_Call {
+func (_c *Collection_GetAllDocIDs_Call) RunAndReturn(run func(context.Context) (<-chan client.DocIDResult, error)) *Collection_GetAllDocIDs_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -959,13 +947,13 @@ func (_c *Collection_Name_Call) RunAndReturn(run func() immutable.Option[string]
 	return _c
 }
 
-// Save provides a mock function with given fields: ctx, identity, doc
-func (_m *Collection) Save(ctx context.Context, identity immutable.Option[string], doc *client.Document) error {
-	ret := _m.Called(ctx, identity, doc)
+// Save provides a mock function with given fields: ctx, doc
+func (_m *Collection) Save(ctx context.Context, doc *client.Document) error {
+	ret := _m.Called(ctx, doc)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, immutable.Option[string], *client.Document) error); ok {
-		r0 = rf(ctx, identity, doc)
+	if rf, ok := ret.Get(0).(func(context.Context, *client.Document) error); ok {
+		r0 = rf(ctx, doc)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -980,15 +968,14 @@ type Collection_Save_Call struct {
 
 // Save is a helper method to define mock.On call
 //   - ctx context.Context
-//   - identity immutable.Option[string]
 //   - doc *client.Document
-func (_e *Collection_Expecter) Save(ctx interface{}, identity interface{}, doc interface{}) *Collection_Save_Call {
-	return &Collection_Save_Call{Call: _e.mock.On("Save", ctx, identity, doc)}
+func (_e *Collection_Expecter) Save(ctx interface{}, doc interface{}) *Collection_Save_Call {
+	return &Collection_Save_Call{Call: _e.mock.On("Save", ctx, doc)}
 }
 
-func (_c *Collection_Save_Call) Run(run func(ctx context.Context, identity immutable.Option[string], doc *client.Document)) *Collection_Save_Call {
+func (_c *Collection_Save_Call) Run(run func(ctx context.Context, doc *client.Document)) *Collection_Save_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(immutable.Option[string]), args[2].(*client.Document))
+		run(args[0].(context.Context), args[1].(*client.Document))
 	})
 	return _c
 }
@@ -998,7 +985,7 @@ func (_c *Collection_Save_Call) Return(_a0 error) *Collection_Save_Call {
 	return _c
 }
 
-func (_c *Collection_Save_Call) RunAndReturn(run func(context.Context, immutable.Option[string], *client.Document) error) *Collection_Save_Call {
+func (_c *Collection_Save_Call) RunAndReturn(run func(context.Context, *client.Document) error) *Collection_Save_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -1085,13 +1072,13 @@ func (_c *Collection_SchemaRoot_Call) RunAndReturn(run func() string) *Collectio
 	return _c
 }
 
-// Update provides a mock function with given fields: ctx, identity, docs
-func (_m *Collection) Update(ctx context.Context, identity immutable.Option[string], docs *client.Document) error {
-	ret := _m.Called(ctx, identity, docs)
+// Update provides a mock function with given fields: ctx, docs
+func (_m *Collection) Update(ctx context.Context, docs *client.Document) error {
+	ret := _m.Called(ctx, docs)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, immutable.Option[string], *client.Document) error); ok {
-		r0 = rf(ctx, identity, docs)
+	if rf, ok := ret.Get(0).(func(context.Context, *client.Document) error); ok {
+		r0 = rf(ctx, docs)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -1106,15 +1093,14 @@ type Collection_Update_Call struct {
 
 // Update is a helper method to define mock.On call
 //   - ctx context.Context
-//   - identity immutable.Option[string]
 //   - docs *client.Document
-func (_e *Collection_Expecter) Update(ctx interface{}, identity interface{}, docs interface{}) *Collection_Update_Call {
-	return &Collection_Update_Call{Call: _e.mock.On("Update", ctx, identity, docs)}
+func (_e *Collection_Expecter) Update(ctx interface{}, docs interface{}) *Collection_Update_Call {
+	return &Collection_Update_Call{Call: _e.mock.On("Update", ctx, docs)}
 }
 
-func (_c *Collection_Update_Call) Run(run func(ctx context.Context, identity immutable.Option[string], docs *client.Document)) *Collection_Update_Call {
+func (_c *Collection_Update_Call) Run(run func(ctx context.Context, docs *client.Document)) *Collection_Update_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(immutable.Option[string]), args[2].(*client.Document))
+		run(args[0].(context.Context), args[1].(*client.Document))
 	})
 	return _c
 }
@@ -1124,7 +1110,7 @@ func (_c *Collection_Update_Call) Return(_a0 error) *Collection_Update_Call {
 	return _c
 }
 
-func (_c *Collection_Update_Call) RunAndReturn(run func(context.Context, immutable.Option[string], *client.Document) error) *Collection_Update_Call {
+func (_c *Collection_Update_Call) RunAndReturn(run func(context.Context, *client.Document) error) *Collection_Update_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -1173,25 +1159,25 @@ func (_c *Collection_UpdateDocIndex_Call) RunAndReturn(run func(context.Context,
 	return _c
 }
 
-// UpdateWith provides a mock function with given fields: ctx, identity, target, updater
-func (_m *Collection) UpdateWith(ctx context.Context, identity immutable.Option[string], target interface{}, updater string) (*client.UpdateResult, error) {
-	ret := _m.Called(ctx, identity, target, updater)
+// UpdateWith provides a mock function with given fields: ctx, target, updater
+func (_m *Collection) UpdateWith(ctx context.Context, target interface{}, updater string) (*client.UpdateResult, error) {
+	ret := _m.Called(ctx, target, updater)
 
 	var r0 *client.UpdateResult
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, immutable.Option[string], interface{}, string) (*client.UpdateResult, error)); ok {
-		return rf(ctx, identity, target, updater)
+	if rf, ok := ret.Get(0).(func(context.Context, interface{}, string) (*client.UpdateResult, error)); ok {
+		return rf(ctx, target, updater)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, immutable.Option[string], interface{}, string) *client.UpdateResult); ok {
-		r0 = rf(ctx, identity, target, updater)
+	if rf, ok := ret.Get(0).(func(context.Context, interface{}, string) *client.UpdateResult); ok {
+		r0 = rf(ctx, target, updater)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*client.UpdateResult)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, immutable.Option[string], interface{}, string) error); ok {
-		r1 = rf(ctx, identity, target, updater)
+	if rf, ok := ret.Get(1).(func(context.Context, interface{}, string) error); ok {
+		r1 = rf(ctx, target, updater)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1206,16 +1192,15 @@ type Collection_UpdateWith_Call struct {
 
 // UpdateWith is a helper method to define mock.On call
 //   - ctx context.Context
-//   - identity immutable.Option[string]
 //   - target interface{}
 //   - updater string
-func (_e *Collection_Expecter) UpdateWith(ctx interface{}, identity interface{}, target interface{}, updater interface{}) *Collection_UpdateWith_Call {
-	return &Collection_UpdateWith_Call{Call: _e.mock.On("UpdateWith", ctx, identity, target, updater)}
+func (_e *Collection_Expecter) UpdateWith(ctx interface{}, target interface{}, updater interface{}) *Collection_UpdateWith_Call {
+	return &Collection_UpdateWith_Call{Call: _e.mock.On("UpdateWith", ctx, target, updater)}
 }
 
-func (_c *Collection_UpdateWith_Call) Run(run func(ctx context.Context, identity immutable.Option[string], target interface{}, updater string)) *Collection_UpdateWith_Call {
+func (_c *Collection_UpdateWith_Call) Run(run func(ctx context.Context, target interface{}, updater string)) *Collection_UpdateWith_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(immutable.Option[string]), args[2].(interface{}), args[3].(string))
+		run(args[0].(context.Context), args[1].(interface{}), args[2].(string))
 	})
 	return _c
 }
@@ -1225,30 +1210,30 @@ func (_c *Collection_UpdateWith_Call) Return(_a0 *client.UpdateResult, _a1 error
 	return _c
 }
 
-func (_c *Collection_UpdateWith_Call) RunAndReturn(run func(context.Context, immutable.Option[string], interface{}, string) (*client.UpdateResult, error)) *Collection_UpdateWith_Call {
+func (_c *Collection_UpdateWith_Call) RunAndReturn(run func(context.Context, interface{}, string) (*client.UpdateResult, error)) *Collection_UpdateWith_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// UpdateWithDocID provides a mock function with given fields: ctx, identity, docID, updater
-func (_m *Collection) UpdateWithDocID(ctx context.Context, identity immutable.Option[string], docID client.DocID, updater string) (*client.UpdateResult, error) {
-	ret := _m.Called(ctx, identity, docID, updater)
+// UpdateWithDocID provides a mock function with given fields: ctx, docID, updater
+func (_m *Collection) UpdateWithDocID(ctx context.Context, docID client.DocID, updater string) (*client.UpdateResult, error) {
+	ret := _m.Called(ctx, docID, updater)
 
 	var r0 *client.UpdateResult
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, immutable.Option[string], client.DocID, string) (*client.UpdateResult, error)); ok {
-		return rf(ctx, identity, docID, updater)
+	if rf, ok := ret.Get(0).(func(context.Context, client.DocID, string) (*client.UpdateResult, error)); ok {
+		return rf(ctx, docID, updater)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, immutable.Option[string], client.DocID, string) *client.UpdateResult); ok {
-		r0 = rf(ctx, identity, docID, updater)
+	if rf, ok := ret.Get(0).(func(context.Context, client.DocID, string) *client.UpdateResult); ok {
+		r0 = rf(ctx, docID, updater)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*client.UpdateResult)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, immutable.Option[string], client.DocID, string) error); ok {
-		r1 = rf(ctx, identity, docID, updater)
+	if rf, ok := ret.Get(1).(func(context.Context, client.DocID, string) error); ok {
+		r1 = rf(ctx, docID, updater)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1263,16 +1248,15 @@ type Collection_UpdateWithDocID_Call struct {
 
 // UpdateWithDocID is a helper method to define mock.On call
 //   - ctx context.Context
-//   - identity immutable.Option[string]
 //   - docID client.DocID
 //   - updater string
-func (_e *Collection_Expecter) UpdateWithDocID(ctx interface{}, identity interface{}, docID interface{}, updater interface{}) *Collection_UpdateWithDocID_Call {
-	return &Collection_UpdateWithDocID_Call{Call: _e.mock.On("UpdateWithDocID", ctx, identity, docID, updater)}
+func (_e *Collection_Expecter) UpdateWithDocID(ctx interface{}, docID interface{}, updater interface{}) *Collection_UpdateWithDocID_Call {
+	return &Collection_UpdateWithDocID_Call{Call: _e.mock.On("UpdateWithDocID", ctx, docID, updater)}
 }
 
-func (_c *Collection_UpdateWithDocID_Call) Run(run func(ctx context.Context, identity immutable.Option[string], docID client.DocID, updater string)) *Collection_UpdateWithDocID_Call {
+func (_c *Collection_UpdateWithDocID_Call) Run(run func(ctx context.Context, docID client.DocID, updater string)) *Collection_UpdateWithDocID_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(immutable.Option[string]), args[2].(client.DocID), args[3].(string))
+		run(args[0].(context.Context), args[1].(client.DocID), args[2].(string))
 	})
 	return _c
 }
@@ -1282,30 +1266,30 @@ func (_c *Collection_UpdateWithDocID_Call) Return(_a0 *client.UpdateResult, _a1 
 	return _c
 }
 
-func (_c *Collection_UpdateWithDocID_Call) RunAndReturn(run func(context.Context, immutable.Option[string], client.DocID, string) (*client.UpdateResult, error)) *Collection_UpdateWithDocID_Call {
+func (_c *Collection_UpdateWithDocID_Call) RunAndReturn(run func(context.Context, client.DocID, string) (*client.UpdateResult, error)) *Collection_UpdateWithDocID_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// UpdateWithDocIDs provides a mock function with given fields: ctx, identity, docIDs, updater
-func (_m *Collection) UpdateWithDocIDs(ctx context.Context, identity immutable.Option[string], docIDs []client.DocID, updater string) (*client.UpdateResult, error) {
-	ret := _m.Called(ctx, identity, docIDs, updater)
+// UpdateWithDocIDs provides a mock function with given fields: ctx, docIDs, updater
+func (_m *Collection) UpdateWithDocIDs(ctx context.Context, docIDs []client.DocID, updater string) (*client.UpdateResult, error) {
+	ret := _m.Called(ctx, docIDs, updater)
 
 	var r0 *client.UpdateResult
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, immutable.Option[string], []client.DocID, string) (*client.UpdateResult, error)); ok {
-		return rf(ctx, identity, docIDs, updater)
+	if rf, ok := ret.Get(0).(func(context.Context, []client.DocID, string) (*client.UpdateResult, error)); ok {
+		return rf(ctx, docIDs, updater)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, immutable.Option[string], []client.DocID, string) *client.UpdateResult); ok {
-		r0 = rf(ctx, identity, docIDs, updater)
+	if rf, ok := ret.Get(0).(func(context.Context, []client.DocID, string) *client.UpdateResult); ok {
+		r0 = rf(ctx, docIDs, updater)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*client.UpdateResult)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, immutable.Option[string], []client.DocID, string) error); ok {
-		r1 = rf(ctx, identity, docIDs, updater)
+	if rf, ok := ret.Get(1).(func(context.Context, []client.DocID, string) error); ok {
+		r1 = rf(ctx, docIDs, updater)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1320,16 +1304,15 @@ type Collection_UpdateWithDocIDs_Call struct {
 
 // UpdateWithDocIDs is a helper method to define mock.On call
 //   - ctx context.Context
-//   - identity immutable.Option[string]
 //   - docIDs []client.DocID
 //   - updater string
-func (_e *Collection_Expecter) UpdateWithDocIDs(ctx interface{}, identity interface{}, docIDs interface{}, updater interface{}) *Collection_UpdateWithDocIDs_Call {
-	return &Collection_UpdateWithDocIDs_Call{Call: _e.mock.On("UpdateWithDocIDs", ctx, identity, docIDs, updater)}
+func (_e *Collection_Expecter) UpdateWithDocIDs(ctx interface{}, docIDs interface{}, updater interface{}) *Collection_UpdateWithDocIDs_Call {
+	return &Collection_UpdateWithDocIDs_Call{Call: _e.mock.On("UpdateWithDocIDs", ctx, docIDs, updater)}
 }
 
-func (_c *Collection_UpdateWithDocIDs_Call) Run(run func(ctx context.Context, identity immutable.Option[string], docIDs []client.DocID, updater string)) *Collection_UpdateWithDocIDs_Call {
+func (_c *Collection_UpdateWithDocIDs_Call) Run(run func(ctx context.Context, docIDs []client.DocID, updater string)) *Collection_UpdateWithDocIDs_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(immutable.Option[string]), args[2].([]client.DocID), args[3].(string))
+		run(args[0].(context.Context), args[1].([]client.DocID), args[2].(string))
 	})
 	return _c
 }
@@ -1339,30 +1322,30 @@ func (_c *Collection_UpdateWithDocIDs_Call) Return(_a0 *client.UpdateResult, _a1
 	return _c
 }
 
-func (_c *Collection_UpdateWithDocIDs_Call) RunAndReturn(run func(context.Context, immutable.Option[string], []client.DocID, string) (*client.UpdateResult, error)) *Collection_UpdateWithDocIDs_Call {
+func (_c *Collection_UpdateWithDocIDs_Call) RunAndReturn(run func(context.Context, []client.DocID, string) (*client.UpdateResult, error)) *Collection_UpdateWithDocIDs_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// UpdateWithFilter provides a mock function with given fields: ctx, identity, filter, updater
-func (_m *Collection) UpdateWithFilter(ctx context.Context, identity immutable.Option[string], filter interface{}, updater string) (*client.UpdateResult, error) {
-	ret := _m.Called(ctx, identity, filter, updater)
+// UpdateWithFilter provides a mock function with given fields: ctx, filter, updater
+func (_m *Collection) UpdateWithFilter(ctx context.Context, filter interface{}, updater string) (*client.UpdateResult, error) {
+	ret := _m.Called(ctx, filter, updater)
 
 	var r0 *client.UpdateResult
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, immutable.Option[string], interface{}, string) (*client.UpdateResult, error)); ok {
-		return rf(ctx, identity, filter, updater)
+	if rf, ok := ret.Get(0).(func(context.Context, interface{}, string) (*client.UpdateResult, error)); ok {
+		return rf(ctx, filter, updater)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, immutable.Option[string], interface{}, string) *client.UpdateResult); ok {
-		r0 = rf(ctx, identity, filter, updater)
+	if rf, ok := ret.Get(0).(func(context.Context, interface{}, string) *client.UpdateResult); ok {
+		r0 = rf(ctx, filter, updater)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*client.UpdateResult)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, immutable.Option[string], interface{}, string) error); ok {
-		r1 = rf(ctx, identity, filter, updater)
+	if rf, ok := ret.Get(1).(func(context.Context, interface{}, string) error); ok {
+		r1 = rf(ctx, filter, updater)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1377,16 +1360,15 @@ type Collection_UpdateWithFilter_Call struct {
 
 // UpdateWithFilter is a helper method to define mock.On call
 //   - ctx context.Context
-//   - identity immutable.Option[string]
 //   - filter interface{}
 //   - updater string
-func (_e *Collection_Expecter) UpdateWithFilter(ctx interface{}, identity interface{}, filter interface{}, updater interface{}) *Collection_UpdateWithFilter_Call {
-	return &Collection_UpdateWithFilter_Call{Call: _e.mock.On("UpdateWithFilter", ctx, identity, filter, updater)}
+func (_e *Collection_Expecter) UpdateWithFilter(ctx interface{}, filter interface{}, updater interface{}) *Collection_UpdateWithFilter_Call {
+	return &Collection_UpdateWithFilter_Call{Call: _e.mock.On("UpdateWithFilter", ctx, filter, updater)}
 }
 
-func (_c *Collection_UpdateWithFilter_Call) Run(run func(ctx context.Context, identity immutable.Option[string], filter interface{}, updater string)) *Collection_UpdateWithFilter_Call {
+func (_c *Collection_UpdateWithFilter_Call) Run(run func(ctx context.Context, filter interface{}, updater string)) *Collection_UpdateWithFilter_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(immutable.Option[string]), args[2].(interface{}), args[3].(string))
+		run(args[0].(context.Context), args[1].(interface{}), args[2].(string))
 	})
 	return _c
 }
@@ -1396,51 +1378,7 @@ func (_c *Collection_UpdateWithFilter_Call) Return(_a0 *client.UpdateResult, _a1
 	return _c
 }
 
-func (_c *Collection_UpdateWithFilter_Call) RunAndReturn(run func(context.Context, immutable.Option[string], interface{}, string) (*client.UpdateResult, error)) *Collection_UpdateWithFilter_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// WithTxn provides a mock function with given fields: _a0
-func (_m *Collection) WithTxn(_a0 datastore.Txn) client.Collection {
-	ret := _m.Called(_a0)
-
-	var r0 client.Collection
-	if rf, ok := ret.Get(0).(func(datastore.Txn) client.Collection); ok {
-		r0 = rf(_a0)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(client.Collection)
-		}
-	}
-
-	return r0
-}
-
-// Collection_WithTxn_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'WithTxn'
-type Collection_WithTxn_Call struct {
-	*mock.Call
-}
-
-// WithTxn is a helper method to define mock.On call
-//   - _a0 datastore.Txn
-func (_e *Collection_Expecter) WithTxn(_a0 interface{}) *Collection_WithTxn_Call {
-	return &Collection_WithTxn_Call{Call: _e.mock.On("WithTxn", _a0)}
-}
-
-func (_c *Collection_WithTxn_Call) Run(run func(_a0 datastore.Txn)) *Collection_WithTxn_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(datastore.Txn))
-	})
-	return _c
-}
-
-func (_c *Collection_WithTxn_Call) Return(_a0 client.Collection) *Collection_WithTxn_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *Collection_WithTxn_Call) RunAndReturn(run func(datastore.Txn) client.Collection) *Collection_WithTxn_Call {
+func (_c *Collection_UpdateWithFilter_Call) RunAndReturn(run func(context.Context, interface{}, string) (*client.UpdateResult, error)) *Collection_UpdateWithFilter_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/client/mocks/db.go
+++ b/client/mocks/db.go
@@ -400,13 +400,13 @@ func (_c *DB_Events_Call) RunAndReturn(run func() events.Events) *DB_Events_Call
 	return _c
 }
 
-// ExecRequest provides a mock function with given fields: ctx, identity, request
-func (_m *DB) ExecRequest(ctx context.Context, identity immutable.Option[string], request string) *client.RequestResult {
-	ret := _m.Called(ctx, identity, request)
+// ExecRequest provides a mock function with given fields: ctx, request
+func (_m *DB) ExecRequest(ctx context.Context, request string) *client.RequestResult {
+	ret := _m.Called(ctx, request)
 
 	var r0 *client.RequestResult
-	if rf, ok := ret.Get(0).(func(context.Context, immutable.Option[string], string) *client.RequestResult); ok {
-		r0 = rf(ctx, identity, request)
+	if rf, ok := ret.Get(0).(func(context.Context, string) *client.RequestResult); ok {
+		r0 = rf(ctx, request)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*client.RequestResult)
@@ -423,15 +423,14 @@ type DB_ExecRequest_Call struct {
 
 // ExecRequest is a helper method to define mock.On call
 //   - ctx context.Context
-//   - identity immutable.Option[string]
 //   - request string
-func (_e *DB_Expecter) ExecRequest(ctx interface{}, identity interface{}, request interface{}) *DB_ExecRequest_Call {
-	return &DB_ExecRequest_Call{Call: _e.mock.On("ExecRequest", ctx, identity, request)}
+func (_e *DB_Expecter) ExecRequest(ctx interface{}, request interface{}) *DB_ExecRequest_Call {
+	return &DB_ExecRequest_Call{Call: _e.mock.On("ExecRequest", ctx, request)}
 }
 
-func (_c *DB_ExecRequest_Call) Run(run func(ctx context.Context, identity immutable.Option[string], request string)) *DB_ExecRequest_Call {
+func (_c *DB_ExecRequest_Call) Run(run func(ctx context.Context, request string)) *DB_ExecRequest_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(immutable.Option[string]), args[2].(string))
+		run(args[0].(context.Context), args[1].(string))
 	})
 	return _c
 }
@@ -441,7 +440,7 @@ func (_c *DB_ExecRequest_Call) Return(_a0 *client.RequestResult) *DB_ExecRequest
 	return _c
 }
 
-func (_c *DB_ExecRequest_Call) RunAndReturn(run func(context.Context, immutable.Option[string], string) *client.RequestResult) *DB_ExecRequest_Call {
+func (_c *DB_ExecRequest_Call) RunAndReturn(run func(context.Context, string) *client.RequestResult) *DB_ExecRequest_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -1210,50 +1209,6 @@ func (_c *DB_SetMigration_Call) Return(_a0 error) *DB_SetMigration_Call {
 }
 
 func (_c *DB_SetMigration_Call) RunAndReturn(run func(context.Context, client.LensConfig) error) *DB_SetMigration_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// WithTxn provides a mock function with given fields: _a0
-func (_m *DB) WithTxn(_a0 datastore.Txn) client.Store {
-	ret := _m.Called(_a0)
-
-	var r0 client.Store
-	if rf, ok := ret.Get(0).(func(datastore.Txn) client.Store); ok {
-		r0 = rf(_a0)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(client.Store)
-		}
-	}
-
-	return r0
-}
-
-// DB_WithTxn_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'WithTxn'
-type DB_WithTxn_Call struct {
-	*mock.Call
-}
-
-// WithTxn is a helper method to define mock.On call
-//   - _a0 datastore.Txn
-func (_e *DB_Expecter) WithTxn(_a0 interface{}) *DB_WithTxn_Call {
-	return &DB_WithTxn_Call{Call: _e.mock.On("WithTxn", _a0)}
-}
-
-func (_c *DB_WithTxn_Call) Run(run func(_a0 datastore.Txn)) *DB_WithTxn_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(datastore.Txn))
-	})
-	return _c
-}
-
-func (_c *DB_WithTxn_Call) Return(_a0 client.Store) *DB_WithTxn_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *DB_WithTxn_Call) RunAndReturn(run func(datastore.Txn) client.Store) *DB_WithTxn_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/db/backup.go
+++ b/db/backup.go
@@ -89,7 +89,6 @@ func (db *db) basicImport(ctx context.Context, filepath string) (err error) {
 				return NewErrDocFromMap(err)
 			}
 
-			// TODO-ACP: https://github.com/sourcenetwork/defradb/issues/2430 - Add identity ability to backup
 			err = col.Create(ctx, doc)
 			if err != nil {
 				return NewErrDocCreate(err)
@@ -101,7 +100,6 @@ func (db *db) basicImport(ctx context.Context, filepath string) (err error) {
 				if err != nil {
 					return NewErrDocUpdate(err)
 				}
-				// TODO-ACP: https://github.com/sourcenetwork/defradb/issues/2430 - Add identity ability to backup
 				err = col.Update(ctx, doc)
 				if err != nil {
 					return NewErrDocUpdate(err)
@@ -189,7 +187,6 @@ func (db *db) basicExport(ctx context.Context, config *client.BackupConfig) (err
 		if err != nil {
 			return err
 		}
-		// TODO-ACP: https://github.com/sourcenetwork/defradb/issues/2430 - Add identity ability to export
 		docIDsCh, err := col.GetAllDocIDs(ctx)
 		if err != nil {
 			return err
@@ -206,7 +203,6 @@ func (db *db) basicExport(ctx context.Context, config *client.BackupConfig) (err
 					return err
 				}
 			}
-			// TODO-ACP: https://github.com/sourcenetwork/defradb/issues/2430 - Add identity ability to export
 			doc, err := col.Get(ctx, docResultWithID.ID, false)
 			if err != nil {
 				return err
@@ -239,7 +235,6 @@ func (db *db) basicExport(ctx context.Context, config *client.BackupConfig) (err
 							if err != nil {
 								return err
 							}
-							// TODO-ACP: https://github.com/sourcenetwork/defradb/issues/2430
 							foreignDoc, err := foreignCol.Get(ctx, foreignDocID, false)
 							if err != nil {
 								err := doc.Set(field.Name+request.RelatedObjectID, nil)

--- a/db/backup.go
+++ b/db/backup.go
@@ -17,7 +17,6 @@ import (
 	"fmt"
 	"os"
 
-	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/request"
 )
@@ -91,7 +90,7 @@ func (db *db) basicImport(ctx context.Context, filepath string) (err error) {
 			}
 
 			// TODO-ACP: https://github.com/sourcenetwork/defradb/issues/2430 - Add identity ability to backup
-			err = col.Create(ctx, acpIdentity.NoIdentity, doc)
+			err = col.Create(ctx, doc)
 			if err != nil {
 				return NewErrDocCreate(err)
 			}
@@ -103,7 +102,7 @@ func (db *db) basicImport(ctx context.Context, filepath string) (err error) {
 					return NewErrDocUpdate(err)
 				}
 				// TODO-ACP: https://github.com/sourcenetwork/defradb/issues/2430 - Add identity ability to backup
-				err = col.Update(ctx, acpIdentity.NoIdentity, doc)
+				err = col.Update(ctx, doc)
 				if err != nil {
 					return NewErrDocUpdate(err)
 				}
@@ -191,7 +190,7 @@ func (db *db) basicExport(ctx context.Context, config *client.BackupConfig) (err
 			return err
 		}
 		// TODO-ACP: https://github.com/sourcenetwork/defradb/issues/2430 - Add identity ability to export
-		docIDsCh, err := col.GetAllDocIDs(ctx, acpIdentity.NoIdentity)
+		docIDsCh, err := col.GetAllDocIDs(ctx)
 		if err != nil {
 			return err
 		}
@@ -208,7 +207,7 @@ func (db *db) basicExport(ctx context.Context, config *client.BackupConfig) (err
 				}
 			}
 			// TODO-ACP: https://github.com/sourcenetwork/defradb/issues/2430 - Add identity ability to export
-			doc, err := col.Get(ctx, acpIdentity.NoIdentity, docResultWithID.ID, false)
+			doc, err := col.Get(ctx, docResultWithID.ID, false)
 			if err != nil {
 				return err
 			}
@@ -241,7 +240,7 @@ func (db *db) basicExport(ctx context.Context, config *client.BackupConfig) (err
 								return err
 							}
 							// TODO-ACP: https://github.com/sourcenetwork/defradb/issues/2430
-							foreignDoc, err := foreignCol.Get(ctx, acpIdentity.NoIdentity, foreignDocID, false)
+							foreignDoc, err := foreignCol.Get(ctx, foreignDocID, false)
 							if err != nil {
 								err := doc.Set(field.Name+request.RelatedObjectID, nil)
 								if err != nil {

--- a/db/backup_test.go
+++ b/db/backup_test.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/sourcenetwork/defradb/acp/identity"
+	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 )
 
@@ -66,7 +66,7 @@ func TestBasicExport_WithNormalFormatting_NoError(t *testing.T) {
 	require.NoError(t, err)
 	defer txn.Discard(ctx)
 
-	ctx = SetContextIdentity(ctx, identity.None)
+	ctx = SetContextIdentity(ctx, acpIdentity.None)
 	ctx = SetContextTxn(ctx, txn)
 
 	filepath := t.TempDir() + "/test.json"
@@ -131,7 +131,7 @@ func TestBasicExport_WithPrettyFormatting_NoError(t *testing.T) {
 	require.NoError(t, err)
 	defer txn.Discard(ctx)
 
-	ctx = SetContextIdentity(ctx, identity.None)
+	ctx = SetContextIdentity(ctx, acpIdentity.None)
 	ctx = SetContextTxn(ctx, txn)
 
 	filepath := t.TempDir() + "/test.json"
@@ -196,7 +196,7 @@ func TestBasicExport_WithSingleCollection_NoError(t *testing.T) {
 	require.NoError(t, err)
 	defer txn.Discard(ctx)
 
-	ctx = SetContextIdentity(ctx, identity.None)
+	ctx = SetContextIdentity(ctx, acpIdentity.None)
 	ctx = SetContextTxn(ctx, txn)
 
 	filepath := t.TempDir() + "/test.json"
@@ -273,7 +273,7 @@ func TestBasicExport_WithMultipleCollectionsAndUpdate_NoError(t *testing.T) {
 	require.NoError(t, err)
 	defer txn.Discard(ctx)
 
-	ctx = SetContextIdentity(ctx, identity.None)
+	ctx = SetContextIdentity(ctx, acpIdentity.None)
 	ctx = SetContextTxn(ctx, txn)
 
 	filepath := t.TempDir() + "/test.json"
@@ -338,7 +338,7 @@ func TestBasicExport_EnsureFileOverwrite_NoError(t *testing.T) {
 	require.NoError(t, err)
 	defer txn.Discard(ctx)
 
-	ctx = SetContextIdentity(ctx, identity.None)
+	ctx = SetContextIdentity(ctx, acpIdentity.None)
 	ctx = SetContextTxn(ctx, txn)
 
 	filepath := t.TempDir() + "/test.json"
@@ -386,7 +386,7 @@ func TestBasicImport_WithMultipleCollectionsAndObjects_NoError(t *testing.T) {
 	txn, err := db.NewTxn(ctx, false)
 	require.NoError(t, err)
 
-	ctx = SetContextIdentity(ctx, identity.None)
+	ctx = SetContextIdentity(ctx, acpIdentity.None)
 	ctx = SetContextTxn(ctx, txn)
 
 	filepath := t.TempDir() + "/test.json"
@@ -406,7 +406,7 @@ func TestBasicImport_WithMultipleCollectionsAndObjects_NoError(t *testing.T) {
 	txn, err = db.NewTxn(ctx, true)
 	require.NoError(t, err)
 
-	ctx = SetContextIdentity(ctx, identity.None)
+	ctx = SetContextIdentity(ctx, acpIdentity.None)
 	ctx = SetContextTxn(ctx, txn)
 
 	col1, err := db.getCollectionByName(ctx, "Address")

--- a/db/backup_test.go
+++ b/db/backup_test.go
@@ -47,10 +47,10 @@ func TestBasicExport_WithNormalFormatting_NoError(t *testing.T) {
 	doc2, err := client.NewDocFromJSON([]byte(`{"name": "Bob", "age": 40}`), col1.Schema())
 	require.NoError(t, err)
 
-	err = col1.Create(ctx, acpIdentity.NoIdentity, doc1)
+	err = col1.Create(ctx, doc1)
 	require.NoError(t, err)
 
-	err = col1.Create(ctx, acpIdentity.NoIdentity, doc2)
+	err = col1.Create(ctx, doc2)
 	require.NoError(t, err)
 
 	col2, err := db.GetCollectionByName(ctx, "Address")
@@ -59,14 +59,15 @@ func TestBasicExport_WithNormalFormatting_NoError(t *testing.T) {
 	doc3, err := client.NewDocFromJSON([]byte(`{"street": "101 Maple St", "city": "Toronto"}`), col2.Schema())
 	require.NoError(t, err)
 
-	err = col2.Create(ctx, acpIdentity.NoIdentity, doc3)
+	err = col2.Create(ctx, doc3)
 	require.NoError(t, err)
 
 	txn, err := db.NewTxn(ctx, true)
 	require.NoError(t, err)
-
-	ctx = SetContextTxn(ctx, txn)
 	defer txn.Discard(ctx)
+
+	ctx = SetContextIdentity(ctx, acpIdentity.NoIdentity)
+	ctx = SetContextTxn(ctx, txn)
 
 	filepath := t.TempDir() + "/test.json"
 	err = db.basicExport(ctx, &client.BackupConfig{Filepath: filepath})
@@ -111,10 +112,10 @@ func TestBasicExport_WithPrettyFormatting_NoError(t *testing.T) {
 	doc2, err := client.NewDocFromJSON([]byte(`{"name": "Bob", "age": 40}`), col1.Schema())
 	require.NoError(t, err)
 
-	err = col1.Create(ctx, acpIdentity.NoIdentity, doc1)
+	err = col1.Create(ctx, doc1)
 	require.NoError(t, err)
 
-	err = col1.Create(ctx, acpIdentity.NoIdentity, doc2)
+	err = col1.Create(ctx, doc2)
 	require.NoError(t, err)
 
 	col2, err := db.GetCollectionByName(ctx, "Address")
@@ -123,14 +124,15 @@ func TestBasicExport_WithPrettyFormatting_NoError(t *testing.T) {
 	doc3, err := client.NewDocFromJSON([]byte(`{"street": "101 Maple St", "city": "Toronto"}`), col2.Schema())
 	require.NoError(t, err)
 
-	err = col2.Create(ctx, acpIdentity.NoIdentity, doc3)
+	err = col2.Create(ctx, doc3)
 	require.NoError(t, err)
 
 	txn, err := db.NewTxn(ctx, true)
 	require.NoError(t, err)
-
-	ctx = SetContextTxn(ctx, txn)
 	defer txn.Discard(ctx)
+
+	ctx = SetContextIdentity(ctx, acpIdentity.NoIdentity)
+	ctx = SetContextTxn(ctx, txn)
 
 	filepath := t.TempDir() + "/test.json"
 	err = db.basicExport(ctx, &client.BackupConfig{Filepath: filepath, Pretty: true})
@@ -175,10 +177,10 @@ func TestBasicExport_WithSingleCollection_NoError(t *testing.T) {
 	doc2, err := client.NewDocFromJSON([]byte(`{"name": "Bob", "age": 40}`), col1.Schema())
 	require.NoError(t, err)
 
-	err = col1.Create(ctx, acpIdentity.NoIdentity, doc1)
+	err = col1.Create(ctx, doc1)
 	require.NoError(t, err)
 
-	err = col1.Create(ctx, acpIdentity.NoIdentity, doc2)
+	err = col1.Create(ctx, doc2)
 	require.NoError(t, err)
 
 	col2, err := db.GetCollectionByName(ctx, "Address")
@@ -187,14 +189,15 @@ func TestBasicExport_WithSingleCollection_NoError(t *testing.T) {
 	doc3, err := client.NewDocFromJSON([]byte(`{"street": "101 Maple St", "city": "Toronto"}`), col2.Schema())
 	require.NoError(t, err)
 
-	err = col2.Create(ctx, acpIdentity.NoIdentity, doc3)
+	err = col2.Create(ctx, doc3)
 	require.NoError(t, err)
 
 	txn, err := db.NewTxn(ctx, true)
 	require.NoError(t, err)
-
-	ctx = SetContextTxn(ctx, txn)
 	defer txn.Discard(ctx)
+
+	ctx = SetContextIdentity(ctx, acpIdentity.NoIdentity)
+	ctx = SetContextTxn(ctx, txn)
 
 	filepath := t.TempDir() + "/test.json"
 	err = db.basicExport(ctx, &client.BackupConfig{Filepath: filepath, Collections: []string{"Address"}})
@@ -240,10 +243,10 @@ func TestBasicExport_WithMultipleCollectionsAndUpdate_NoError(t *testing.T) {
 	doc2, err := client.NewDocFromJSON([]byte(`{"name": "Bob", "age": 31}`), col1.Schema())
 	require.NoError(t, err)
 
-	err = col1.Create(ctx, acpIdentity.NoIdentity, doc1)
+	err = col1.Create(ctx, doc1)
 	require.NoError(t, err)
 
-	err = col1.Create(ctx, acpIdentity.NoIdentity, doc2)
+	err = col1.Create(ctx, doc2)
 	require.NoError(t, err)
 
 	col2, err := db.GetCollectionByName(ctx, "Book")
@@ -255,22 +258,23 @@ func TestBasicExport_WithMultipleCollectionsAndUpdate_NoError(t *testing.T) {
 	doc4, err := client.NewDocFromJSON([]byte(`{"name": "Game of chains", "author": "bae-e933420a-988a-56f8-8952-6c245aebd519"}`), col2.Schema())
 	require.NoError(t, err)
 
-	err = col2.Create(ctx, acpIdentity.NoIdentity, doc3)
+	err = col2.Create(ctx, doc3)
 	require.NoError(t, err)
-	err = col2.Create(ctx, acpIdentity.NoIdentity, doc4)
+	err = col2.Create(ctx, doc4)
 	require.NoError(t, err)
 
 	err = doc1.Set("age", 31)
 	require.NoError(t, err)
 
-	err = col1.Update(ctx, acpIdentity.NoIdentity, doc1)
+	err = col1.Update(ctx, doc1)
 	require.NoError(t, err)
 
 	txn, err := db.NewTxn(ctx, true)
 	require.NoError(t, err)
-
-	ctx = SetContextTxn(ctx, txn)
 	defer txn.Discard(ctx)
+
+	ctx = SetContextIdentity(ctx, acpIdentity.NoIdentity)
+	ctx = SetContextTxn(ctx, txn)
 
 	filepath := t.TempDir() + "/test.json"
 	err = db.basicExport(ctx, &client.BackupConfig{Filepath: filepath})
@@ -315,10 +319,10 @@ func TestBasicExport_EnsureFileOverwrite_NoError(t *testing.T) {
 	doc2, err := client.NewDocFromJSON([]byte(`{"name": "Bob", "age": 40}`), col1.Schema())
 	require.NoError(t, err)
 
-	err = col1.Create(ctx, acpIdentity.NoIdentity, doc1)
+	err = col1.Create(ctx, doc1)
 	require.NoError(t, err)
 
-	err = col1.Create(ctx, acpIdentity.NoIdentity, doc2)
+	err = col1.Create(ctx, doc2)
 	require.NoError(t, err)
 
 	col2, err := db.GetCollectionByName(ctx, "Address")
@@ -327,14 +331,15 @@ func TestBasicExport_EnsureFileOverwrite_NoError(t *testing.T) {
 	doc3, err := client.NewDocFromJSON([]byte(`{"street": "101 Maple St", "city": "Toronto"}`), col2.Schema())
 	require.NoError(t, err)
 
-	err = col2.Create(ctx, acpIdentity.NoIdentity, doc3)
+	err = col2.Create(ctx, doc3)
 	require.NoError(t, err)
 
 	txn, err := db.NewTxn(ctx, true)
 	require.NoError(t, err)
-
-	ctx = SetContextTxn(ctx, txn)
 	defer txn.Discard(ctx)
+
+	ctx = SetContextIdentity(ctx, acpIdentity.NoIdentity)
+	ctx = SetContextTxn(ctx, txn)
 
 	filepath := t.TempDir() + "/test.json"
 
@@ -380,6 +385,8 @@ func TestBasicImport_WithMultipleCollectionsAndObjects_NoError(t *testing.T) {
 
 	txn, err := db.NewTxn(ctx, false)
 	require.NoError(t, err)
+
+	ctx = SetContextIdentity(ctx, acpIdentity.NoIdentity)
 	ctx = SetContextTxn(ctx, txn)
 
 	filepath := t.TempDir() + "/test.json"
@@ -398,6 +405,8 @@ func TestBasicImport_WithMultipleCollectionsAndObjects_NoError(t *testing.T) {
 
 	txn, err = db.NewTxn(ctx, true)
 	require.NoError(t, err)
+
+	ctx = SetContextIdentity(ctx, acpIdentity.NoIdentity)
 	ctx = SetContextTxn(ctx, txn)
 
 	col1, err := db.getCollectionByName(ctx, "Address")
@@ -405,7 +414,7 @@ func TestBasicImport_WithMultipleCollectionsAndObjects_NoError(t *testing.T) {
 
 	key1, err := client.NewDocIDFromString("bae-8096f2c1-ea4c-5226-8ba5-17fc4b68ac1f")
 	require.NoError(t, err)
-	_, err = col1.Get(ctx, acpIdentity.NoIdentity, key1, false)
+	_, err = col1.Get(ctx, key1, false)
 	require.NoError(t, err)
 
 	col2, err := db.getCollectionByName(ctx, "User")
@@ -413,12 +422,12 @@ func TestBasicImport_WithMultipleCollectionsAndObjects_NoError(t *testing.T) {
 
 	key2, err := client.NewDocIDFromString("bae-b94880d1-e6d2-542f-b9e0-5a369fafd0df")
 	require.NoError(t, err)
-	_, err = col2.Get(ctx, acpIdentity.NoIdentity, key2, false)
+	_, err = col2.Get(ctx, key2, false)
 	require.NoError(t, err)
 
 	key3, err := client.NewDocIDFromString("bae-e933420a-988a-56f8-8952-6c245aebd519")
 	require.NoError(t, err)
-	_, err = col2.Get(ctx, acpIdentity.NoIdentity, key3, false)
+	_, err = col2.Get(ctx, key3, false)
 	require.NoError(t, err)
 }
 

--- a/db/backup_test.go
+++ b/db/backup_test.go
@@ -66,7 +66,7 @@ func TestBasicExport_WithNormalFormatting_NoError(t *testing.T) {
 	require.NoError(t, err)
 	defer txn.Discard(ctx)
 
-	ctx = SetContextIdentity(ctx, identity.NoIdentity)
+	ctx = SetContextIdentity(ctx, identity.None)
 	ctx = SetContextTxn(ctx, txn)
 
 	filepath := t.TempDir() + "/test.json"
@@ -131,7 +131,7 @@ func TestBasicExport_WithPrettyFormatting_NoError(t *testing.T) {
 	require.NoError(t, err)
 	defer txn.Discard(ctx)
 
-	ctx = SetContextIdentity(ctx, identity.NoIdentity)
+	ctx = SetContextIdentity(ctx, identity.None)
 	ctx = SetContextTxn(ctx, txn)
 
 	filepath := t.TempDir() + "/test.json"
@@ -196,7 +196,7 @@ func TestBasicExport_WithSingleCollection_NoError(t *testing.T) {
 	require.NoError(t, err)
 	defer txn.Discard(ctx)
 
-	ctx = SetContextIdentity(ctx, identity.NoIdentity)
+	ctx = SetContextIdentity(ctx, identity.None)
 	ctx = SetContextTxn(ctx, txn)
 
 	filepath := t.TempDir() + "/test.json"
@@ -273,7 +273,7 @@ func TestBasicExport_WithMultipleCollectionsAndUpdate_NoError(t *testing.T) {
 	require.NoError(t, err)
 	defer txn.Discard(ctx)
 
-	ctx = SetContextIdentity(ctx, identity.NoIdentity)
+	ctx = SetContextIdentity(ctx, identity.None)
 	ctx = SetContextTxn(ctx, txn)
 
 	filepath := t.TempDir() + "/test.json"
@@ -338,7 +338,7 @@ func TestBasicExport_EnsureFileOverwrite_NoError(t *testing.T) {
 	require.NoError(t, err)
 	defer txn.Discard(ctx)
 
-	ctx = SetContextIdentity(ctx, identity.NoIdentity)
+	ctx = SetContextIdentity(ctx, identity.None)
 	ctx = SetContextTxn(ctx, txn)
 
 	filepath := t.TempDir() + "/test.json"
@@ -386,7 +386,7 @@ func TestBasicImport_WithMultipleCollectionsAndObjects_NoError(t *testing.T) {
 	txn, err := db.NewTxn(ctx, false)
 	require.NoError(t, err)
 
-	ctx = SetContextIdentity(ctx, identity.NoIdentity)
+	ctx = SetContextIdentity(ctx, identity.None)
 	ctx = SetContextTxn(ctx, txn)
 
 	filepath := t.TempDir() + "/test.json"
@@ -406,7 +406,7 @@ func TestBasicImport_WithMultipleCollectionsAndObjects_NoError(t *testing.T) {
 	txn, err = db.NewTxn(ctx, true)
 	require.NoError(t, err)
 
-	ctx = SetContextIdentity(ctx, identity.NoIdentity)
+	ctx = SetContextIdentity(ctx, identity.None)
 	ctx = SetContextTxn(ctx, txn)
 
 	col1, err := db.getCollectionByName(ctx, "Address")

--- a/db/backup_test.go
+++ b/db/backup_test.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
+	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 )
 
@@ -66,7 +66,7 @@ func TestBasicExport_WithNormalFormatting_NoError(t *testing.T) {
 	require.NoError(t, err)
 	defer txn.Discard(ctx)
 
-	ctx = SetContextIdentity(ctx, acpIdentity.NoIdentity)
+	ctx = SetContextIdentity(ctx, identity.NoIdentity)
 	ctx = SetContextTxn(ctx, txn)
 
 	filepath := t.TempDir() + "/test.json"
@@ -131,7 +131,7 @@ func TestBasicExport_WithPrettyFormatting_NoError(t *testing.T) {
 	require.NoError(t, err)
 	defer txn.Discard(ctx)
 
-	ctx = SetContextIdentity(ctx, acpIdentity.NoIdentity)
+	ctx = SetContextIdentity(ctx, identity.NoIdentity)
 	ctx = SetContextTxn(ctx, txn)
 
 	filepath := t.TempDir() + "/test.json"
@@ -196,7 +196,7 @@ func TestBasicExport_WithSingleCollection_NoError(t *testing.T) {
 	require.NoError(t, err)
 	defer txn.Discard(ctx)
 
-	ctx = SetContextIdentity(ctx, acpIdentity.NoIdentity)
+	ctx = SetContextIdentity(ctx, identity.NoIdentity)
 	ctx = SetContextTxn(ctx, txn)
 
 	filepath := t.TempDir() + "/test.json"
@@ -273,7 +273,7 @@ func TestBasicExport_WithMultipleCollectionsAndUpdate_NoError(t *testing.T) {
 	require.NoError(t, err)
 	defer txn.Discard(ctx)
 
-	ctx = SetContextIdentity(ctx, acpIdentity.NoIdentity)
+	ctx = SetContextIdentity(ctx, identity.NoIdentity)
 	ctx = SetContextTxn(ctx, txn)
 
 	filepath := t.TempDir() + "/test.json"
@@ -338,7 +338,7 @@ func TestBasicExport_EnsureFileOverwrite_NoError(t *testing.T) {
 	require.NoError(t, err)
 	defer txn.Discard(ctx)
 
-	ctx = SetContextIdentity(ctx, acpIdentity.NoIdentity)
+	ctx = SetContextIdentity(ctx, identity.NoIdentity)
 	ctx = SetContextTxn(ctx, txn)
 
 	filepath := t.TempDir() + "/test.json"
@@ -386,7 +386,7 @@ func TestBasicImport_WithMultipleCollectionsAndObjects_NoError(t *testing.T) {
 	txn, err := db.NewTxn(ctx, false)
 	require.NoError(t, err)
 
-	ctx = SetContextIdentity(ctx, acpIdentity.NoIdentity)
+	ctx = SetContextIdentity(ctx, identity.NoIdentity)
 	ctx = SetContextTxn(ctx, txn)
 
 	filepath := t.TempDir() + "/test.json"
@@ -406,7 +406,7 @@ func TestBasicImport_WithMultipleCollectionsAndObjects_NoError(t *testing.T) {
 	txn, err = db.NewTxn(ctx, true)
 	require.NoError(t, err)
 
-	ctx = SetContextIdentity(ctx, acpIdentity.NoIdentity)
+	ctx = SetContextIdentity(ctx, identity.NoIdentity)
 	ctx = SetContextTxn(ctx, txn)
 
 	col1, err := db.getCollectionByName(ctx, "Address")

--- a/db/collection.go
+++ b/db/collection.go
@@ -1228,7 +1228,7 @@ func (db *db) getAllActiveDefinitions(ctx context.Context) ([]client.CollectionD
 func (c *collection) GetAllDocIDs(
 	ctx context.Context,
 ) (<-chan client.DocIDResult, error) {
-	ctx, _, err := ensureContextValues(ctx, c.db, true)
+	ctx, _, err := ensureContextTxn(ctx, c.db, true)
 	if err != nil {
 		return nil, err
 	}
@@ -1342,7 +1342,7 @@ func (c *collection) Create(
 	ctx context.Context,
 	doc *client.Document,
 ) error {
-	ctx, txn, err := ensureContextValues(ctx, c.db, false)
+	ctx, txn, err := ensureContextTxn(ctx, c.db, false)
 	if err != nil {
 		return err
 	}
@@ -1362,7 +1362,7 @@ func (c *collection) CreateMany(
 	ctx context.Context,
 	docs []*client.Document,
 ) error {
-	ctx, txn, err := ensureContextValues(ctx, c.db, false)
+	ctx, txn, err := ensureContextTxn(ctx, c.db, false)
 	if err != nil {
 		return err
 	}
@@ -1445,7 +1445,7 @@ func (c *collection) Update(
 	ctx context.Context,
 	doc *client.Document,
 ) error {
-	ctx, txn, err := ensureContextValues(ctx, c.db, false)
+	ctx, txn, err := ensureContextTxn(ctx, c.db, false)
 	if err != nil {
 		return err
 	}
@@ -1506,7 +1506,7 @@ func (c *collection) Save(
 	ctx context.Context,
 	doc *client.Document,
 ) error {
-	ctx, txn, err := ensureContextValues(ctx, c.db, false)
+	ctx, txn, err := ensureContextTxn(ctx, c.db, false)
 	if err != nil {
 		return err
 	}
@@ -1780,7 +1780,7 @@ func (c *collection) Delete(
 	ctx context.Context,
 	docID client.DocID,
 ) (bool, error) {
-	ctx, txn, err := ensureContextValues(ctx, c.db, false)
+	ctx, txn, err := ensureContextTxn(ctx, c.db, false)
 	if err != nil {
 		return false, err
 	}
@@ -1800,7 +1800,7 @@ func (c *collection) Exists(
 	ctx context.Context,
 	docID client.DocID,
 ) (bool, error) {
-	ctx, txn, err := ensureContextValues(ctx, c.db, false)
+	ctx, txn, err := ensureContextTxn(ctx, c.db, false)
 	if err != nil {
 		return false, err
 	}

--- a/db/collection.go
+++ b/db/collection.go
@@ -1229,7 +1229,7 @@ func (c *collection) GetAllDocIDs(
 	ctx context.Context,
 	identity immutable.Option[string],
 ) (<-chan client.DocIDResult, error) {
-	ctx, _, err := ensureContextTxn(ctx, c.db, true)
+	ctx, _, err := ensureContextValues(ctx, c.db, true)
 	if err != nil {
 		return nil, err
 	}
@@ -1346,7 +1346,7 @@ func (c *collection) Create(
 	identity immutable.Option[string],
 	doc *client.Document,
 ) error {
-	ctx, txn, err := ensureContextTxn(ctx, c.db, false)
+	ctx, txn, err := ensureContextValues(ctx, c.db, false)
 	if err != nil {
 		return err
 	}
@@ -1367,7 +1367,7 @@ func (c *collection) CreateMany(
 	identity immutable.Option[string],
 	docs []*client.Document,
 ) error {
-	ctx, txn, err := ensureContextTxn(ctx, c.db, false)
+	ctx, txn, err := ensureContextValues(ctx, c.db, false)
 	if err != nil {
 		return err
 	}
@@ -1452,7 +1452,7 @@ func (c *collection) Update(
 	identity immutable.Option[string],
 	doc *client.Document,
 ) error {
-	ctx, txn, err := ensureContextTxn(ctx, c.db, false)
+	ctx, txn, err := ensureContextValues(ctx, c.db, false)
 	if err != nil {
 		return err
 	}
@@ -1516,7 +1516,7 @@ func (c *collection) Save(
 	identity immutable.Option[string],
 	doc *client.Document,
 ) error {
-	ctx, txn, err := ensureContextTxn(ctx, c.db, false)
+	ctx, txn, err := ensureContextValues(ctx, c.db, false)
 	if err != nil {
 		return err
 	}
@@ -1795,7 +1795,7 @@ func (c *collection) Delete(
 	identity immutable.Option[string],
 	docID client.DocID,
 ) (bool, error) {
-	ctx, txn, err := ensureContextTxn(ctx, c.db, false)
+	ctx, txn, err := ensureContextValues(ctx, c.db, false)
 	if err != nil {
 		return false, err
 	}
@@ -1816,7 +1816,7 @@ func (c *collection) Exists(
 	identity immutable.Option[string],
 	docID client.DocID,
 ) (bool, error) {
-	ctx, txn, err := ensureContextTxn(ctx, c.db, false)
+	ctx, txn, err := ensureContextValues(ctx, c.db, false)
 	if err != nil {
 		return false, err
 	}

--- a/db/collection.go
+++ b/db/collection.go
@@ -1227,18 +1227,16 @@ func (db *db) getAllActiveDefinitions(ctx context.Context) ([]client.CollectionD
 // it hits every key and will cause Tx conflicts for concurrent Txs
 func (c *collection) GetAllDocIDs(
 	ctx context.Context,
-	identity immutable.Option[string],
 ) (<-chan client.DocIDResult, error) {
 	ctx, _, err := ensureContextValues(ctx, c.db, true)
 	if err != nil {
 		return nil, err
 	}
-	return c.getAllDocIDsChan(ctx, identity)
+	return c.getAllDocIDsChan(ctx)
 }
 
 func (c *collection) getAllDocIDsChan(
 	ctx context.Context,
-	identity immutable.Option[string],
 ) (<-chan client.DocIDResult, error) {
 	txn := mustGetContextTxn(ctx)
 	prefix := core.PrimaryDataStoreKey{ // empty path for all keys prefix
@@ -1288,7 +1286,6 @@ func (c *collection) getAllDocIDsChan(
 
 			canRead, err := c.checkAccessOfDocWithACP(
 				ctx,
-				identity,
 				acp.ReadPermission,
 				docID.String(),
 			)
@@ -1343,7 +1340,6 @@ func (c *collection) Definition() client.CollectionDefinition {
 // Will verify the DocID/CID to ensure that the new document is correctly formatted.
 func (c *collection) Create(
 	ctx context.Context,
-	identity immutable.Option[string],
 	doc *client.Document,
 ) error {
 	ctx, txn, err := ensureContextValues(ctx, c.db, false)
@@ -1352,7 +1348,7 @@ func (c *collection) Create(
 	}
 	defer txn.Discard(ctx)
 
-	err = c.create(ctx, identity, doc)
+	err = c.create(ctx, doc)
 	if err != nil {
 		return err
 	}
@@ -1364,7 +1360,6 @@ func (c *collection) Create(
 // Will verify the DocID/CID to ensure that the new documents are correctly formatted.
 func (c *collection) CreateMany(
 	ctx context.Context,
-	identity immutable.Option[string],
 	docs []*client.Document,
 ) error {
 	ctx, txn, err := ensureContextValues(ctx, c.db, false)
@@ -1374,7 +1369,7 @@ func (c *collection) CreateMany(
 	defer txn.Discard(ctx)
 
 	for _, doc := range docs {
-		err = c.create(ctx, identity, doc)
+		err = c.create(ctx, doc)
 		if err != nil {
 			return err
 		}
@@ -1400,7 +1395,6 @@ func (c *collection) getDocIDAndPrimaryKeyFromDoc(
 
 func (c *collection) create(
 	ctx context.Context,
-	identity immutable.Option[string],
 	doc *client.Document,
 ) error {
 	docID, primaryKey, err := c.getDocIDAndPrimaryKeyFromDoc(doc)
@@ -1409,7 +1403,7 @@ func (c *collection) create(
 	}
 
 	// check if doc already exists
-	exists, isDeleted, err := c.exists(ctx, identity, primaryKey)
+	exists, isDeleted, err := c.exists(ctx, primaryKey)
 	if err != nil {
 		return err
 	}
@@ -1431,7 +1425,7 @@ func (c *collection) create(
 	}
 
 	// write data to DB via MerkleClock/CRDT
-	_, err = c.save(ctx, identity, doc, true)
+	_, err = c.save(ctx, doc, true)
 	if err != nil {
 		return err
 	}
@@ -1441,7 +1435,7 @@ func (c *collection) create(
 		return err
 	}
 
-	return c.registerDocWithACP(ctx, identity, doc.ID().String())
+	return c.registerDocWithACP(ctx, doc.ID().String())
 }
 
 // Update an existing document with the new values.
@@ -1449,7 +1443,6 @@ func (c *collection) create(
 // Any field that is nil/empty that hasn't called Clear will be ignored.
 func (c *collection) Update(
 	ctx context.Context,
-	identity immutable.Option[string],
 	doc *client.Document,
 ) error {
 	ctx, txn, err := ensureContextValues(ctx, c.db, false)
@@ -1459,7 +1452,7 @@ func (c *collection) Update(
 	defer txn.Discard(ctx)
 
 	primaryKey := c.getPrimaryKeyFromDocID(doc.ID())
-	exists, isDeleted, err := c.exists(ctx, identity, primaryKey)
+	exists, isDeleted, err := c.exists(ctx, primaryKey)
 	if err != nil {
 		return err
 	}
@@ -1470,7 +1463,7 @@ func (c *collection) Update(
 		return NewErrDocumentDeleted(primaryKey.DocID)
 	}
 
-	err = c.update(ctx, identity, doc)
+	err = c.update(ctx, doc)
 	if err != nil {
 		return err
 	}
@@ -1485,13 +1478,11 @@ func (c *collection) Update(
 // add to the bloat.
 func (c *collection) update(
 	ctx context.Context,
-	identity immutable.Option[string],
 	doc *client.Document,
 ) error {
 	// Stop the update if the correct permissions aren't there.
 	canUpdate, err := c.checkAccessOfDocWithACP(
 		ctx,
-		identity,
 		acp.WritePermission,
 		doc.ID().String(),
 	)
@@ -1502,7 +1493,7 @@ func (c *collection) update(
 		return client.ErrDocumentNotFoundOrNotAuthorized
 	}
 
-	_, err = c.save(ctx, identity, doc, false)
+	_, err = c.save(ctx, doc, false)
 	if err != nil {
 		return err
 	}
@@ -1513,7 +1504,6 @@ func (c *collection) update(
 // Either by creating a new document or by updating an existing one
 func (c *collection) Save(
 	ctx context.Context,
-	identity immutable.Option[string],
 	doc *client.Document,
 ) error {
 	ctx, txn, err := ensureContextValues(ctx, c.db, false)
@@ -1524,7 +1514,7 @@ func (c *collection) Save(
 
 	// Check if document already exists with primary DS key.
 	primaryKey := c.getPrimaryKeyFromDocID(doc.ID())
-	exists, isDeleted, err := c.exists(ctx, identity, primaryKey)
+	exists, isDeleted, err := c.exists(ctx, primaryKey)
 	if err != nil {
 		return err
 	}
@@ -1534,9 +1524,9 @@ func (c *collection) Save(
 	}
 
 	if exists {
-		err = c.update(ctx, identity, doc)
+		err = c.update(ctx, doc)
 	} else {
-		err = c.create(ctx, identity, doc)
+		err = c.create(ctx, doc)
 	}
 	if err != nil {
 		return err
@@ -1550,7 +1540,6 @@ func (c *collection) Save(
 // save elsewhere could cause the omission of acp checks.
 func (c *collection) save(
 	ctx context.Context,
-	identity immutable.Option[string],
 	doc *client.Document,
 	isCreate bool,
 ) (cid.Cid, error) {
@@ -1606,7 +1595,6 @@ func (c *collection) save(
 
 				err = c.patchPrimaryDoc(
 					ctx,
-					identity,
 					c.Name().Value(),
 					relationFieldDescription,
 					primaryKey.DocID,
@@ -1623,7 +1611,6 @@ func (c *collection) save(
 
 			err = c.validateOneToOneLinkDoesntAlreadyExist(
 				ctx,
-				identity,
 				doc.ID().String(),
 				fieldDescription,
 				val.Value(),
@@ -1692,7 +1679,6 @@ func (c *collection) save(
 
 func (c *collection) validateOneToOneLinkDoesntAlreadyExist(
 	ctx context.Context,
-	identity immutable.Option[string],
 	docID string,
 	fieldDescription client.FieldDefinition,
 	value any,
@@ -1738,7 +1724,7 @@ func (c *collection) validateOneToOneLinkDoesntAlreadyExist(
 		fieldDescription.Name,
 		value,
 	)
-	selectionPlan, err := c.makeSelectionPlan(ctx, identity, filter)
+	selectionPlan, err := c.makeSelectionPlan(ctx, filter)
 	if err != nil {
 		return err
 	}
@@ -1792,7 +1778,6 @@ func (c *collection) validateOneToOneLinkDoesntAlreadyExist(
 // This operation will all state relating to the given DocID. This includes data, block, and head storage.
 func (c *collection) Delete(
 	ctx context.Context,
-	identity immutable.Option[string],
 	docID client.DocID,
 ) (bool, error) {
 	ctx, txn, err := ensureContextValues(ctx, c.db, false)
@@ -1803,7 +1788,7 @@ func (c *collection) Delete(
 
 	primaryKey := c.getPrimaryKeyFromDocID(docID)
 
-	err = c.applyDelete(ctx, identity, primaryKey)
+	err = c.applyDelete(ctx, primaryKey)
 	if err != nil {
 		return false, err
 	}
@@ -1813,7 +1798,6 @@ func (c *collection) Delete(
 // Exists checks if a given document exists with supplied DocID.
 func (c *collection) Exists(
 	ctx context.Context,
-	identity immutable.Option[string],
 	docID client.DocID,
 ) (bool, error) {
 	ctx, txn, err := ensureContextValues(ctx, c.db, false)
@@ -1823,7 +1807,7 @@ func (c *collection) Exists(
 	defer txn.Discard(ctx)
 
 	primaryKey := c.getPrimaryKeyFromDocID(docID)
-	exists, isDeleted, err := c.exists(ctx, identity, primaryKey)
+	exists, isDeleted, err := c.exists(ctx, primaryKey)
 	if err != nil && !errors.Is(err, ds.ErrNotFound) {
 		return false, err
 	}
@@ -1833,12 +1817,10 @@ func (c *collection) Exists(
 // check if a document exists with the given primary key
 func (c *collection) exists(
 	ctx context.Context,
-	identity immutable.Option[string],
 	primaryKey core.PrimaryDataStoreKey,
 ) (exists bool, isDeleted bool, err error) {
 	canRead, err := c.checkAccessOfDocWithACP(
 		ctx,
-		identity,
 		acp.ReadPermission,
 		primaryKey.DocID,
 	)

--- a/db/collection_acp.go
+++ b/db/collection_acp.go
@@ -13,8 +13,6 @@ package db
 import (
 	"context"
 
-	"github.com/sourcenetwork/immutable"
-
 	"github.com/sourcenetwork/defradb/acp"
 	"github.com/sourcenetwork/defradb/db/permission"
 )
@@ -32,14 +30,13 @@ import (
 // Otherwise, nothing is registered with the acp system.
 func (c *collection) registerDocWithACP(
 	ctx context.Context,
-	identity immutable.Option[string],
 	docID string,
 ) error {
 	// If acp is not available, then no document is registered.
 	if !c.db.acp.HasValue() {
 		return nil
 	}
-
+	identity := mustGetContextIdentity(ctx)
 	return permission.RegisterDocOnCollectionWithACP(
 		ctx,
 		identity,
@@ -51,7 +48,6 @@ func (c *collection) registerDocWithACP(
 
 func (c *collection) checkAccessOfDocWithACP(
 	ctx context.Context,
-	identity immutable.Option[string],
 	dpiPermission acp.DPIPermission,
 	docID string,
 ) (bool, error) {
@@ -59,7 +55,7 @@ func (c *collection) checkAccessOfDocWithACP(
 	if !c.db.acp.HasValue() {
 		return true, nil
 	}
-
+	identity := mustGetContextIdentity(ctx)
 	return permission.CheckAccessOfDocOnCollectionWithACP(
 		ctx,
 		identity,

--- a/db/collection_acp.go
+++ b/db/collection_acp.go
@@ -36,7 +36,7 @@ func (c *collection) registerDocWithACP(
 	if !c.db.acp.HasValue() {
 		return nil
 	}
-	identity := mustGetContextIdentity(ctx)
+	identity := GetContextIdentity(ctx)
 	return permission.RegisterDocOnCollectionWithACP(
 		ctx,
 		identity,
@@ -55,7 +55,7 @@ func (c *collection) checkAccessOfDocWithACP(
 	if !c.db.acp.HasValue() {
 		return true, nil
 	}
-	identity := mustGetContextIdentity(ctx)
+	identity := GetContextIdentity(ctx)
 	return permission.CheckAccessOfDocOnCollectionWithACP(
 		ctx,
 		identity,

--- a/db/collection_delete.go
+++ b/db/collection_delete.go
@@ -53,7 +53,7 @@ func (c *collection) DeleteWithDocID(
 	identity immutable.Option[string],
 	docID client.DocID,
 ) (*client.DeleteResult, error) {
-	ctx, txn, err := ensureContextTxn(ctx, c.db, false)
+	ctx, txn, err := ensureContextValues(ctx, c.db, false)
 	if err != nil {
 		return nil, err
 	}
@@ -74,7 +74,7 @@ func (c *collection) DeleteWithDocIDs(
 	identity immutable.Option[string],
 	docIDs []client.DocID,
 ) (*client.DeleteResult, error) {
-	ctx, txn, err := ensureContextTxn(ctx, c.db, false)
+	ctx, txn, err := ensureContextValues(ctx, c.db, false)
 	if err != nil {
 		return nil, err
 	}
@@ -94,7 +94,7 @@ func (c *collection) DeleteWithFilter(
 	identity immutable.Option[string],
 	filter any,
 ) (*client.DeleteResult, error) {
-	ctx, txn, err := ensureContextTxn(ctx, c.db, false)
+	ctx, txn, err := ensureContextValues(ctx, c.db, false)
 	if err != nil {
 		return nil, err
 	}

--- a/db/collection_delete.go
+++ b/db/collection_delete.go
@@ -49,7 +49,7 @@ func (c *collection) DeleteWithDocID(
 	ctx context.Context,
 	docID client.DocID,
 ) (*client.DeleteResult, error) {
-	ctx, txn, err := ensureContextValues(ctx, c.db, false)
+	ctx, txn, err := ensureContextTxn(ctx, c.db, false)
 	if err != nil {
 		return nil, err
 	}
@@ -69,7 +69,7 @@ func (c *collection) DeleteWithDocIDs(
 	ctx context.Context,
 	docIDs []client.DocID,
 ) (*client.DeleteResult, error) {
-	ctx, txn, err := ensureContextValues(ctx, c.db, false)
+	ctx, txn, err := ensureContextTxn(ctx, c.db, false)
 	if err != nil {
 		return nil, err
 	}
@@ -88,7 +88,7 @@ func (c *collection) DeleteWithFilter(
 	ctx context.Context,
 	filter any,
 ) (*client.DeleteResult, error) {
-	ctx, txn, err := ensureContextValues(ctx, c.db, false)
+	ctx, txn, err := ensureContextTxn(ctx, c.db, false)
 	if err != nil {
 		return nil, err
 	}

--- a/db/collection_get.go
+++ b/db/collection_get.go
@@ -28,7 +28,7 @@ func (c *collection) Get(
 	showDeleted bool,
 ) (*client.Document, error) {
 	// create txn
-	ctx, txn, err := ensureContextTxn(ctx, c.db, true)
+	ctx, txn, err := ensureContextValues(ctx, c.db, true)
 	if err != nil {
 		return nil, err
 	}

--- a/db/collection_get.go
+++ b/db/collection_get.go
@@ -25,7 +25,7 @@ func (c *collection) Get(
 	showDeleted bool,
 ) (*client.Document, error) {
 	// create txn
-	ctx, txn, err := ensureContextValues(ctx, c.db, true)
+	ctx, txn, err := ensureContextTxn(ctx, c.db, true)
 	if err != nil {
 		return nil, err
 	}
@@ -59,7 +59,7 @@ func (c *collection) get(
 	showDeleted bool,
 ) (*client.Document, error) {
 	txn := mustGetContextTxn(ctx)
-	identity := mustGetContextIdentity(ctx)
+	identity := GetContextIdentity(ctx)
 	// create a new document fetcher
 	df := c.newFetcher()
 	// initialize it with the primary index

--- a/db/collection_index.go
+++ b/db/collection_index.go
@@ -110,7 +110,7 @@ func (db *db) fetchCollectionIndexDescriptions(
 }
 
 func (c *collection) CreateDocIndex(ctx context.Context, doc *client.Document) error {
-	ctx, txn, err := ensureContextTxn(ctx, c.db, false)
+	ctx, txn, err := ensureContextValues(ctx, c.db, false)
 	if err != nil {
 		return err
 	}
@@ -125,7 +125,7 @@ func (c *collection) CreateDocIndex(ctx context.Context, doc *client.Document) e
 }
 
 func (c *collection) UpdateDocIndex(ctx context.Context, oldDoc, newDoc *client.Document) error {
-	ctx, txn, err := ensureContextTxn(ctx, c.db, false)
+	ctx, txn, err := ensureContextValues(ctx, c.db, false)
 	if err != nil {
 		return err
 	}
@@ -144,7 +144,7 @@ func (c *collection) UpdateDocIndex(ctx context.Context, oldDoc, newDoc *client.
 }
 
 func (c *collection) DeleteDocIndex(ctx context.Context, doc *client.Document) error {
-	ctx, txn, err := ensureContextTxn(ctx, c.db, false)
+	ctx, txn, err := ensureContextValues(ctx, c.db, false)
 	if err != nil {
 		return err
 	}
@@ -241,7 +241,7 @@ func (c *collection) CreateIndex(
 	ctx context.Context,
 	desc client.IndexDescription,
 ) (client.IndexDescription, error) {
-	ctx, txn, err := ensureContextTxn(ctx, c.db, false)
+	ctx, txn, err := ensureContextValues(ctx, c.db, false)
 	if err != nil {
 		return client.IndexDescription{}, err
 	}
@@ -395,7 +395,7 @@ func (c *collection) indexExistingDocs(
 //
 // All index artifacts for existing documents related the index will be removed.
 func (c *collection) DropIndex(ctx context.Context, indexName string) error {
-	ctx, txn, err := ensureContextTxn(ctx, c.db, false)
+	ctx, txn, err := ensureContextValues(ctx, c.db, false)
 	if err != nil {
 		return err
 	}
@@ -486,7 +486,7 @@ func (c *collection) loadIndexes(ctx context.Context) error {
 
 // GetIndexes returns all indexes for the collection.
 func (c *collection) GetIndexes(ctx context.Context) ([]client.IndexDescription, error) {
-	ctx, txn, err := ensureContextTxn(ctx, c.db, false)
+	ctx, txn, err := ensureContextValues(ctx, c.db, false)
 	if err != nil {
 		return nil, err
 	}

--- a/db/collection_index.go
+++ b/db/collection_index.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/sourcenetwork/immutable"
 
-	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
+	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/core"
 	"github.com/sourcenetwork/defradb/datastore"
@@ -110,7 +110,7 @@ func (db *db) fetchCollectionIndexDescriptions(
 }
 
 func (c *collection) CreateDocIndex(ctx context.Context, doc *client.Document) error {
-	ctx, txn, err := ensureContextValues(ctx, c.db, false)
+	ctx, txn, err := ensureContextTxn(ctx, c.db, false)
 	if err != nil {
 		return err
 	}
@@ -125,7 +125,7 @@ func (c *collection) CreateDocIndex(ctx context.Context, doc *client.Document) e
 }
 
 func (c *collection) UpdateDocIndex(ctx context.Context, oldDoc, newDoc *client.Document) error {
-	ctx, txn, err := ensureContextValues(ctx, c.db, false)
+	ctx, txn, err := ensureContextTxn(ctx, c.db, false)
 	if err != nil {
 		return err
 	}
@@ -144,7 +144,7 @@ func (c *collection) UpdateDocIndex(ctx context.Context, oldDoc, newDoc *client.
 }
 
 func (c *collection) DeleteDocIndex(ctx context.Context, doc *client.Document) error {
-	ctx, txn, err := ensureContextValues(ctx, c.db, false)
+	ctx, txn, err := ensureContextTxn(ctx, c.db, false)
 	if err != nil {
 		return err
 	}
@@ -240,7 +240,7 @@ func (c *collection) CreateIndex(
 	ctx context.Context,
 	desc client.IndexDescription,
 ) (client.IndexDescription, error) {
-	ctx, txn, err := ensureContextValues(ctx, c.db, false)
+	ctx, txn, err := ensureContextTxn(ctx, c.db, false)
 	if err != nil {
 		return client.IndexDescription{}, err
 	}
@@ -327,7 +327,7 @@ func (c *collection) iterateAllDocs(
 	df := c.newFetcher()
 	err := df.Init(
 		ctx,
-		acpIdentity.NoIdentity, // TODO-ACP: https://github.com/sourcenetwork/defradb/issues/2365 - ACP <> Indexing
+		identity.NoIdentity, // TODO-ACP: https://github.com/sourcenetwork/defradb/issues/2365 - ACP <> Indexing
 		txn,
 		c.db.acp,
 		c,
@@ -394,7 +394,7 @@ func (c *collection) indexExistingDocs(
 //
 // All index artifacts for existing documents related the index will be removed.
 func (c *collection) DropIndex(ctx context.Context, indexName string) error {
-	ctx, txn, err := ensureContextValues(ctx, c.db, false)
+	ctx, txn, err := ensureContextTxn(ctx, c.db, false)
 	if err != nil {
 		return err
 	}
@@ -485,7 +485,7 @@ func (c *collection) loadIndexes(ctx context.Context) error {
 
 // GetIndexes returns all indexes for the collection.
 func (c *collection) GetIndexes(ctx context.Context) ([]client.IndexDescription, error) {
-	ctx, txn, err := ensureContextValues(ctx, c.db, false)
+	ctx, txn, err := ensureContextTxn(ctx, c.db, false)
 	if err != nil {
 		return nil, err
 	}

--- a/db/collection_index.go
+++ b/db/collection_index.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/sourcenetwork/immutable"
 
-	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/core"
 	"github.com/sourcenetwork/defradb/datastore"
@@ -324,10 +323,12 @@ func (c *collection) iterateAllDocs(
 	exec func(doc *client.Document) error,
 ) error {
 	txn := mustGetContextTxn(ctx)
+	identity := GetContextIdentity(ctx)
+
 	df := c.newFetcher()
 	err := df.Init(
 		ctx,
-		identity.NoIdentity, // TODO-ACP: https://github.com/sourcenetwork/defradb/issues/2365 - ACP <> Indexing
+		identity,
 		txn,
 		c.db.acp,
 		c,

--- a/db/collection_index.go
+++ b/db/collection_index.go
@@ -186,7 +186,6 @@ func (c *collection) updateIndexedDoc(
 	// and handle the case of when oldDoc == nil (will be nil if inaccessible document).
 	oldDoc, err := c.get(
 		ctx,
-		acpIdentity.NoIdentity,
 		c.getPrimaryKeyFromDocID(doc.ID()),
 		c.Definition().CollectIndexedFields(),
 		false,

--- a/db/collection_update.go
+++ b/db/collection_update.go
@@ -54,7 +54,7 @@ func (c *collection) UpdateWithFilter(
 	filter any,
 	updater string,
 ) (*client.UpdateResult, error) {
-	ctx, txn, err := ensureContextValues(ctx, c.db, false)
+	ctx, txn, err := ensureContextTxn(ctx, c.db, false)
 	if err != nil {
 		return nil, err
 	}
@@ -75,7 +75,7 @@ func (c *collection) UpdateWithDocID(
 	docID client.DocID,
 	updater string,
 ) (*client.UpdateResult, error) {
-	ctx, txn, err := ensureContextValues(ctx, c.db, false)
+	ctx, txn, err := ensureContextTxn(ctx, c.db, false)
 	if err != nil {
 		return nil, err
 	}
@@ -97,7 +97,7 @@ func (c *collection) UpdateWithDocIDs(
 	docIDs []client.DocID,
 	updater string,
 ) (*client.UpdateResult, error) {
-	ctx, txn, err := ensureContextValues(ctx, c.db, false)
+	ctx, txn, err := ensureContextTxn(ctx, c.db, false)
 	if err != nil {
 		return nil, err
 	}
@@ -420,7 +420,7 @@ func (c *collection) makeSelectionPlan(
 	}
 
 	txn := mustGetContextTxn(ctx)
-	identity := mustGetContextIdentity(ctx)
+	identity := GetContextIdentity(ctx)
 	planner := planner.New(
 		ctx,
 		identity,

--- a/db/collection_update.go
+++ b/db/collection_update.go
@@ -56,7 +56,7 @@ func (c *collection) UpdateWithFilter(
 	filter any,
 	updater string,
 ) (*client.UpdateResult, error) {
-	ctx, txn, err := ensureContextTxn(ctx, c.db, false)
+	ctx, txn, err := ensureContextValues(ctx, c.db, false)
 	if err != nil {
 		return nil, err
 	}
@@ -78,7 +78,7 @@ func (c *collection) UpdateWithDocID(
 	docID client.DocID,
 	updater string,
 ) (*client.UpdateResult, error) {
-	ctx, txn, err := ensureContextTxn(ctx, c.db, false)
+	ctx, txn, err := ensureContextValues(ctx, c.db, false)
 	if err != nil {
 		return nil, err
 	}
@@ -101,7 +101,7 @@ func (c *collection) UpdateWithDocIDs(
 	docIDs []client.DocID,
 	updater string,
 ) (*client.UpdateResult, error) {
-	ctx, txn, err := ensureContextTxn(ctx, c.db, false)
+	ctx, txn, err := ensureContextValues(ctx, c.db, false)
 	if err != nil {
 		return nil, err
 	}

--- a/db/context.go
+++ b/db/context.go
@@ -96,7 +96,7 @@ func GetContextIdentity(ctx context.Context) identity.Identity {
 	if ok {
 		return id
 	}
-	return identity.NoIdentity
+	return identity.None
 }
 
 // SetContextTxn returns a new context with the identity value set.

--- a/db/context.go
+++ b/db/context.go
@@ -13,6 +13,8 @@ package db
 import (
 	"context"
 
+	"github.com/sourcenetwork/immutable"
+
 	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/datastore"
 )
@@ -91,10 +93,10 @@ func SetContextTxn(ctx context.Context, txn datastore.Txn) context.Context {
 // GetContextIdentity returns the identity from the given context.
 //
 // If an identity does not exist `NoIdentity` is returned.
-func GetContextIdentity(ctx context.Context) identity.Identity {
+func GetContextIdentity(ctx context.Context) immutable.Option[identity.Identity] {
 	id, ok := ctx.Value(identityContextKey{}).(identity.Identity)
 	if ok {
-		return id
+		return immutable.Some(id)
 	}
 	return identity.None
 }
@@ -102,6 +104,9 @@ func GetContextIdentity(ctx context.Context) identity.Identity {
 // SetContextTxn returns a new context with the identity value set.
 //
 // This will overwrite any previously set identity value.
-func SetContextIdentity(ctx context.Context, id identity.Identity) context.Context {
-	return context.WithValue(ctx, identityContextKey{}, id)
+func SetContextIdentity(ctx context.Context, id immutable.Option[identity.Identity]) context.Context {
+	if id.HasValue() {
+		return context.WithValue(ctx, identityContextKey{}, id.Value())
+	}
+	return context.WithValue(ctx, identityContextKey{}, nil)
 }

--- a/db/context.go
+++ b/db/context.go
@@ -13,11 +13,15 @@ package db
 import (
 	"context"
 
+	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/datastore"
 )
 
 // txnContextKey is the key type for transaction context values.
 type txnContextKey struct{}
+
+// identityContextKey is the key type for ACP identity context values.
+type identityContextKey struct{}
 
 // explicitTxn is a transaction that is managed outside of a db operation.
 type explicitTxn struct {
@@ -37,18 +41,26 @@ type transactionDB interface {
 	NewTxn(context.Context, bool) (datastore.Txn, error)
 }
 
-// ensureContextTxn ensures that the returned context has a transaction.
+// ensureContextValues ensures that the returned context has a transaction
+// and an identity.
 //
 // If a transactions exists on the context it will be made explicit,
 // otherwise a new implicit transaction will be created.
 //
-// The returned context will contain the transaction
+// The returned context will contain the transaction and identity
 // along with the copied values from the input context.
-func ensureContextTxn(ctx context.Context, db transactionDB, readOnly bool) (context.Context, datastore.Txn, error) {
+func ensureContextValues(ctx context.Context, db transactionDB, readOnly bool) (context.Context, datastore.Txn, error) {
+	// default identity
+	_, ok := TryGetContextIdentity(ctx)
+	if !ok {
+		ctx = SetContextIdentity(ctx, identity.NoIdentity)
+	}
+	// explicit transaction
 	txn, ok := TryGetContextTxn(ctx)
 	if ok {
 		return SetContextTxn(ctx, &explicitTxn{txn}), &explicitTxn{txn}, nil
 	}
+	// implicit transaction
 	txn, err := db.NewTxn(ctx, readOnly)
 	if err != nil {
 		return nil, txn, err
@@ -64,6 +76,14 @@ func mustGetContextTxn(ctx context.Context) datastore.Txn {
 	return ctx.Value(txnContextKey{}).(datastore.Txn)
 }
 
+// mustGetContextIdentity returns the identity from the context or panics.
+//
+// This should only be called from private functions within the db package
+// where we ensure an identity always exists.
+func mustGetContextIdentity(ctx context.Context) identity.Identity {
+	return ctx.Value(identityContextKey{}).(identity.Identity)
+}
+
 // TryGetContextTxn returns a transaction and a bool indicating if the
 // txn was retrieved from the given context.
 func TryGetContextTxn(ctx context.Context) (datastore.Txn, bool) {
@@ -76,4 +96,18 @@ func TryGetContextTxn(ctx context.Context) (datastore.Txn, bool) {
 // This will overwrite any previously set transaction value.
 func SetContextTxn(ctx context.Context, txn datastore.Txn) context.Context {
 	return context.WithValue(ctx, txnContextKey{}, txn)
+}
+
+// TryGetContextTxn returns an identity and a bool indicating if the
+// identity was retrieved from the given context.
+func TryGetContextIdentity(ctx context.Context) (identity.Identity, bool) {
+	id, ok := ctx.Value(identityContextKey{}).(identity.Identity)
+	return id, ok
+}
+
+// SetContextTxn returns a new context with the identity value set.
+//
+// This will overwrite any previously set identity value.
+func SetContextIdentity(ctx context.Context, id identity.Identity) context.Context {
+	return context.WithValue(ctx, identityContextKey{}, id)
 }

--- a/db/context.go
+++ b/db/context.go
@@ -13,7 +13,7 @@ package db
 import (
 	"context"
 
-	"github.com/sourcenetwork/defradb/acp/identity"
+	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/datastore"
 )
 
@@ -53,7 +53,7 @@ func ensureContextValues(ctx context.Context, db transactionDB, readOnly bool) (
 	// default identity
 	_, ok := TryGetContextIdentity(ctx)
 	if !ok {
-		ctx = SetContextIdentity(ctx, identity.NoIdentity)
+		ctx = SetContextIdentity(ctx, acpIdentity.NoIdentity)
 	}
 	// explicit transaction
 	txn, ok := TryGetContextTxn(ctx)
@@ -80,8 +80,8 @@ func mustGetContextTxn(ctx context.Context) datastore.Txn {
 //
 // This should only be called from private functions within the db package
 // where we ensure an identity always exists.
-func mustGetContextIdentity(ctx context.Context) identity.Identity {
-	return ctx.Value(identityContextKey{}).(identity.Identity)
+func mustGetContextIdentity(ctx context.Context) acpIdentity.Identity {
+	return ctx.Value(identityContextKey{}).(acpIdentity.Identity)
 }
 
 // TryGetContextTxn returns a transaction and a bool indicating if the
@@ -100,14 +100,14 @@ func SetContextTxn(ctx context.Context, txn datastore.Txn) context.Context {
 
 // TryGetContextTxn returns an identity and a bool indicating if the
 // identity was retrieved from the given context.
-func TryGetContextIdentity(ctx context.Context) (identity.Identity, bool) {
-	id, ok := ctx.Value(identityContextKey{}).(identity.Identity)
+func TryGetContextIdentity(ctx context.Context) (acpIdentity.Identity, bool) {
+	id, ok := ctx.Value(identityContextKey{}).(acpIdentity.Identity)
 	return id, ok
 }
 
 // SetContextTxn returns a new context with the identity value set.
 //
 // This will overwrite any previously set identity value.
-func SetContextIdentity(ctx context.Context, id identity.Identity) context.Context {
+func SetContextIdentity(ctx context.Context, id acpIdentity.Identity) context.Context {
 	return context.WithValue(ctx, identityContextKey{}, id)
 }

--- a/db/context.go
+++ b/db/context.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/sourcenetwork/immutable"
 
-	"github.com/sourcenetwork/defradb/acp/identity"
+	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/datastore"
 )
 
@@ -93,20 +93,20 @@ func SetContextTxn(ctx context.Context, txn datastore.Txn) context.Context {
 // GetContextIdentity returns the identity from the given context.
 //
 // If an identity does not exist `NoIdentity` is returned.
-func GetContextIdentity(ctx context.Context) immutable.Option[identity.Identity] {
-	id, ok := ctx.Value(identityContextKey{}).(identity.Identity)
+func GetContextIdentity(ctx context.Context) immutable.Option[acpIdentity.Identity] {
+	identity, ok := ctx.Value(identityContextKey{}).(acpIdentity.Identity)
 	if ok {
-		return immutable.Some(id)
+		return immutable.Some(identity)
 	}
-	return identity.None
+	return acpIdentity.None
 }
 
 // SetContextTxn returns a new context with the identity value set.
 //
 // This will overwrite any previously set identity value.
-func SetContextIdentity(ctx context.Context, id immutable.Option[identity.Identity]) context.Context {
-	if id.HasValue() {
-		return context.WithValue(ctx, identityContextKey{}, id.Value())
+func SetContextIdentity(ctx context.Context, identity immutable.Option[acpIdentity.Identity]) context.Context {
+	if identity.HasValue() {
+		return context.WithValue(ctx, identityContextKey{}, identity.Value())
 	}
 	return context.WithValue(ctx, identityContextKey{}, nil)
 }

--- a/db/context_test.go
+++ b/db/context_test.go
@@ -30,7 +30,7 @@ func TestEnsureContextTxnExplicit(t *testing.T) {
 	// set an explicit transaction
 	ctx = SetContextTxn(ctx, txn)
 
-	ctx, txn, err = ensureContextValues(ctx, db, true)
+	ctx, txn, err = ensureContextTxn(ctx, db, true)
 	require.NoError(t, err)
 
 	_, ok := txn.(*explicitTxn)
@@ -46,7 +46,7 @@ func TestEnsureContextTxnImplicit(t *testing.T) {
 	db, err := newMemoryDB(ctx)
 	require.NoError(t, err)
 
-	ctx, txn, err := ensureContextValues(ctx, db, true)
+	ctx, txn, err := ensureContextTxn(ctx, db, true)
 	require.NoError(t, err)
 
 	_, ok := txn.(*explicitTxn)

--- a/db/context_test.go
+++ b/db/context_test.go
@@ -30,7 +30,7 @@ func TestEnsureContextTxnExplicit(t *testing.T) {
 	// set an explicit transaction
 	ctx = SetContextTxn(ctx, txn)
 
-	ctx, txn, err = ensureContextTxn(ctx, db, true)
+	ctx, txn, err = ensureContextValues(ctx, db, true)
 	require.NoError(t, err)
 
 	_, ok := txn.(*explicitTxn)
@@ -46,7 +46,7 @@ func TestEnsureContextTxnImplicit(t *testing.T) {
 	db, err := newMemoryDB(ctx)
 	require.NoError(t, err)
 
-	ctx, txn, err := ensureContextTxn(ctx, db, true)
+	ctx, txn, err := ensureContextValues(ctx, db, true)
 	require.NoError(t, err)
 
 	_, ok := txn.(*explicitTxn)

--- a/db/db.go
+++ b/db/db.go
@@ -181,7 +181,7 @@ func (db *db) initialize(ctx context.Context) error {
 	db.glock.Lock()
 	defer db.glock.Unlock()
 
-	ctx, txn, err := ensureContextValues(ctx, db, false)
+	ctx, txn, err := ensureContextTxn(ctx, db, false)
 	if err != nil {
 		return err
 	}

--- a/db/db.go
+++ b/db/db.go
@@ -155,16 +155,15 @@ func (db *db) LensRegistry() client.LensRegistry {
 
 func (db *db) AddPolicy(
 	ctx context.Context,
-	creator string,
 	policy string,
 ) (client.AddPolicyResult, error) {
 	if !db.acp.HasValue() {
 		return client.AddPolicyResult{}, client.ErrPolicyAddFailureNoACP
 	}
-
+	identity := GetContextIdentity(ctx)
 	policyID, err := db.acp.Value().AddPolicy(
 		ctx,
-		creator,
+		identity.Value().String(),
 		policy,
 	)
 

--- a/db/db.go
+++ b/db/db.go
@@ -181,7 +181,7 @@ func (db *db) initialize(ctx context.Context) error {
 	db.glock.Lock()
 	defer db.glock.Unlock()
 
-	ctx, txn, err := ensureContextTxn(ctx, db, false)
+	ctx, txn, err := ensureContextValues(ctx, db, false)
 	if err != nil {
 		return err
 	}

--- a/db/fetcher/fetcher.go
+++ b/db/fetcher/fetcher.go
@@ -21,7 +21,7 @@ import (
 	"github.com/sourcenetwork/immutable"
 
 	"github.com/sourcenetwork/defradb/acp"
-	"github.com/sourcenetwork/defradb/acp/identity"
+	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/core"
 	"github.com/sourcenetwork/defradb/datastore"
@@ -61,7 +61,7 @@ func (s *ExecInfo) Reset() {
 type Fetcher interface {
 	Init(
 		ctx context.Context,
-		id immutable.Option[identity.Identity],
+		identity immutable.Option[acpIdentity.Identity],
 		txn datastore.Txn,
 		acp immutable.Option[acp.ACP],
 		col client.Collection,
@@ -88,7 +88,7 @@ var (
 
 // DocumentFetcher is a utility to incrementally fetch all the documents.
 type DocumentFetcher struct {
-	id                    immutable.Option[identity.Identity]
+	identity              immutable.Option[acpIdentity.Identity]
 	acp                   immutable.Option[acp.ACP]
 	passedPermissionCheck bool // have valid permission to access
 
@@ -147,7 +147,7 @@ type DocumentFetcher struct {
 // Init implements DocumentFetcher.
 func (df *DocumentFetcher) Init(
 	ctx context.Context,
-	id immutable.Option[identity.Identity],
+	identity immutable.Option[acpIdentity.Identity],
 	txn datastore.Txn,
 	acp immutable.Option[acp.ACP],
 	col client.Collection,
@@ -159,7 +159,7 @@ func (df *DocumentFetcher) Init(
 ) error {
 	df.txn = txn
 
-	err := df.init(id, acp, col, fields, filter, docmapper, reverse)
+	err := df.init(identity, acp, col, fields, filter, docmapper, reverse)
 	if err != nil {
 		return err
 	}
@@ -169,14 +169,14 @@ func (df *DocumentFetcher) Init(
 			df.deletedDocFetcher = new(DocumentFetcher)
 			df.deletedDocFetcher.txn = txn
 		}
-		return df.deletedDocFetcher.init(id, acp, col, fields, filter, docmapper, reverse)
+		return df.deletedDocFetcher.init(identity, acp, col, fields, filter, docmapper, reverse)
 	}
 
 	return nil
 }
 
 func (df *DocumentFetcher) init(
-	id immutable.Option[identity.Identity],
+	identity immutable.Option[acpIdentity.Identity],
 	acp immutable.Option[acp.ACP],
 	col client.Collection,
 	fields []client.FieldDefinition,
@@ -184,7 +184,7 @@ func (df *DocumentFetcher) init(
 	docMapper *core.DocumentMapping,
 	reverse bool,
 ) error {
-	df.id = id
+	df.identity = identity
 	df.acp = acp
 	df.col = col
 	df.reverse = reverse
@@ -630,7 +630,7 @@ func (df *DocumentFetcher) fetchNext(ctx context.Context) (EncodedDocument, Exec
 			} else {
 				hasPermission, err := permission.CheckAccessOfDocOnCollectionWithACP(
 					ctx,
-					df.id,
+					df.identity,
 					df.acp.Value(),
 					df.col,
 					acp.ReadPermission,

--- a/db/fetcher/fetcher.go
+++ b/db/fetcher/fetcher.go
@@ -21,6 +21,7 @@ import (
 	"github.com/sourcenetwork/immutable"
 
 	"github.com/sourcenetwork/defradb/acp"
+	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/core"
 	"github.com/sourcenetwork/defradb/datastore"
@@ -60,7 +61,7 @@ func (s *ExecInfo) Reset() {
 type Fetcher interface {
 	Init(
 		ctx context.Context,
-		identity immutable.Option[string],
+		identity acpIdentity.Identity,
 		txn datastore.Txn,
 		acp immutable.Option[acp.ACP],
 		col client.Collection,
@@ -87,7 +88,7 @@ var (
 
 // DocumentFetcher is a utility to incrementally fetch all the documents.
 type DocumentFetcher struct {
-	identity              immutable.Option[string]
+	identity              acpIdentity.Identity
 	acp                   immutable.Option[acp.ACP]
 	passedPermissionCheck bool // have valid permission to access
 
@@ -146,7 +147,7 @@ type DocumentFetcher struct {
 // Init implements DocumentFetcher.
 func (df *DocumentFetcher) Init(
 	ctx context.Context,
-	identity immutable.Option[string],
+	identity acpIdentity.Identity,
 	txn datastore.Txn,
 	acp immutable.Option[acp.ACP],
 	col client.Collection,
@@ -175,7 +176,7 @@ func (df *DocumentFetcher) Init(
 }
 
 func (df *DocumentFetcher) init(
-	identity immutable.Option[string],
+	identity acpIdentity.Identity,
 	acp immutable.Option[acp.ACP],
 	col client.Collection,
 	fields []client.FieldDefinition,

--- a/db/fetcher/fetcher.go
+++ b/db/fetcher/fetcher.go
@@ -21,7 +21,7 @@ import (
 	"github.com/sourcenetwork/immutable"
 
 	"github.com/sourcenetwork/defradb/acp"
-	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
+	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/core"
 	"github.com/sourcenetwork/defradb/datastore"
@@ -61,7 +61,7 @@ func (s *ExecInfo) Reset() {
 type Fetcher interface {
 	Init(
 		ctx context.Context,
-		identity acpIdentity.Identity,
+		identity identity.Identity,
 		txn datastore.Txn,
 		acp immutable.Option[acp.ACP],
 		col client.Collection,
@@ -88,7 +88,7 @@ var (
 
 // DocumentFetcher is a utility to incrementally fetch all the documents.
 type DocumentFetcher struct {
-	identity              acpIdentity.Identity
+	identity              identity.Identity
 	acp                   immutable.Option[acp.ACP]
 	passedPermissionCheck bool // have valid permission to access
 
@@ -147,7 +147,7 @@ type DocumentFetcher struct {
 // Init implements DocumentFetcher.
 func (df *DocumentFetcher) Init(
 	ctx context.Context,
-	identity acpIdentity.Identity,
+	identity identity.Identity,
 	txn datastore.Txn,
 	acp immutable.Option[acp.ACP],
 	col client.Collection,
@@ -176,7 +176,7 @@ func (df *DocumentFetcher) Init(
 }
 
 func (df *DocumentFetcher) init(
-	identity acpIdentity.Identity,
+	identity identity.Identity,
 	acp immutable.Option[acp.ACP],
 	col client.Collection,
 	fields []client.FieldDefinition,

--- a/db/fetcher/indexer.go
+++ b/db/fetcher/indexer.go
@@ -16,7 +16,7 @@ import (
 	"github.com/sourcenetwork/immutable"
 
 	"github.com/sourcenetwork/defradb/acp"
-	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
+	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/core"
 	"github.com/sourcenetwork/defradb/datastore"
@@ -58,7 +58,7 @@ func NewIndexFetcher(
 
 func (f *IndexFetcher) Init(
 	ctx context.Context,
-	identity acpIdentity.Identity,
+	identity identity.Identity,
 	txn datastore.Txn,
 	acp immutable.Option[acp.ACP],
 	col client.Collection,

--- a/db/fetcher/indexer.go
+++ b/db/fetcher/indexer.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sourcenetwork/immutable"
 
 	"github.com/sourcenetwork/defradb/acp"
+	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/core"
 	"github.com/sourcenetwork/defradb/datastore"
@@ -57,7 +58,7 @@ func NewIndexFetcher(
 
 func (f *IndexFetcher) Init(
 	ctx context.Context,
-	identity immutable.Option[string],
+	identity acpIdentity.Identity,
 	txn datastore.Txn,
 	acp immutable.Option[acp.ACP],
 	col client.Collection,

--- a/db/fetcher/indexer.go
+++ b/db/fetcher/indexer.go
@@ -16,7 +16,7 @@ import (
 	"github.com/sourcenetwork/immutable"
 
 	"github.com/sourcenetwork/defradb/acp"
-	"github.com/sourcenetwork/defradb/acp/identity"
+	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/core"
 	"github.com/sourcenetwork/defradb/datastore"
@@ -58,7 +58,7 @@ func NewIndexFetcher(
 
 func (f *IndexFetcher) Init(
 	ctx context.Context,
-	id immutable.Option[identity.Identity],
+	identity immutable.Option[acpIdentity.Identity],
 	txn datastore.Txn,
 	acp immutable.Option[acp.ACP],
 	col client.Collection,
@@ -101,7 +101,7 @@ outer:
 	if f.docFetcher != nil && len(f.docFields) > 0 {
 		err = f.docFetcher.Init(
 			ctx,
-			id,
+			identity,
 			f.txn,
 			acp,
 			f.col,

--- a/db/fetcher/indexer.go
+++ b/db/fetcher/indexer.go
@@ -58,7 +58,7 @@ func NewIndexFetcher(
 
 func (f *IndexFetcher) Init(
 	ctx context.Context,
-	identity identity.Identity,
+	id immutable.Option[identity.Identity],
 	txn datastore.Txn,
 	acp immutable.Option[acp.ACP],
 	col client.Collection,
@@ -101,7 +101,7 @@ outer:
 	if f.docFetcher != nil && len(f.docFields) > 0 {
 		err = f.docFetcher.Init(
 			ctx,
-			identity,
+			id,
 			f.txn,
 			acp,
 			f.col,

--- a/db/fetcher/mocks/fetcher.go
+++ b/db/fetcher/mocks/fetcher.go
@@ -138,13 +138,13 @@ func (_c *Fetcher_FetchNext_Call) RunAndReturn(run func(context.Context) (fetche
 	return _c
 }
 
-// Init provides a mock function with given fields: ctx, _a1, txn, _a3, col, fields, filter, docmapper, reverse, showDeleted
-func (_m *Fetcher) Init(ctx context.Context, _a1 identity.Identity, txn datastore.Txn, _a3 immutable.Option[acp.ACP], col client.Collection, fields []client.FieldDefinition, filter *mapper.Filter, docmapper *core.DocumentMapping, reverse bool, showDeleted bool) error {
-	ret := _m.Called(ctx, _a1, txn, _a3, col, fields, filter, docmapper, reverse, showDeleted)
+// Init provides a mock function with given fields: ctx, id, txn, _a3, col, fields, filter, docmapper, reverse, showDeleted
+func (_m *Fetcher) Init(ctx context.Context, id immutable.Option[identity.Identity], txn datastore.Txn, _a3 immutable.Option[acp.ACP], col client.Collection, fields []client.FieldDefinition, filter *mapper.Filter, docmapper *core.DocumentMapping, reverse bool, showDeleted bool) error {
+	ret := _m.Called(ctx, id, txn, _a3, col, fields, filter, docmapper, reverse, showDeleted)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, identity.Identity, datastore.Txn, immutable.Option[acp.ACP], client.Collection, []client.FieldDefinition, *mapper.Filter, *core.DocumentMapping, bool, bool) error); ok {
-		r0 = rf(ctx, _a1, txn, _a3, col, fields, filter, docmapper, reverse, showDeleted)
+	if rf, ok := ret.Get(0).(func(context.Context, immutable.Option[identity.Identity], datastore.Txn, immutable.Option[acp.ACP], client.Collection, []client.FieldDefinition, *mapper.Filter, *core.DocumentMapping, bool, bool) error); ok {
+		r0 = rf(ctx, id, txn, _a3, col, fields, filter, docmapper, reverse, showDeleted)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -159,7 +159,7 @@ type Fetcher_Init_Call struct {
 
 // Init is a helper method to define mock.On call
 //   - ctx context.Context
-//   - _a1 identity.Identity
+//   - id immutable.Option[identity.Identity]
 //   - txn datastore.Txn
 //   - _a3 immutable.Option[acp.ACP]
 //   - col client.Collection
@@ -168,13 +168,13 @@ type Fetcher_Init_Call struct {
 //   - docmapper *core.DocumentMapping
 //   - reverse bool
 //   - showDeleted bool
-func (_e *Fetcher_Expecter) Init(ctx interface{}, _a1 interface{}, txn interface{}, _a3 interface{}, col interface{}, fields interface{}, filter interface{}, docmapper interface{}, reverse interface{}, showDeleted interface{}) *Fetcher_Init_Call {
-	return &Fetcher_Init_Call{Call: _e.mock.On("Init", ctx, _a1, txn, _a3, col, fields, filter, docmapper, reverse, showDeleted)}
+func (_e *Fetcher_Expecter) Init(ctx interface{}, id interface{}, txn interface{}, _a3 interface{}, col interface{}, fields interface{}, filter interface{}, docmapper interface{}, reverse interface{}, showDeleted interface{}) *Fetcher_Init_Call {
+	return &Fetcher_Init_Call{Call: _e.mock.On("Init", ctx, id, txn, _a3, col, fields, filter, docmapper, reverse, showDeleted)}
 }
 
-func (_c *Fetcher_Init_Call) Run(run func(ctx context.Context, _a1 identity.Identity, txn datastore.Txn, _a3 immutable.Option[acp.ACP], col client.Collection, fields []client.FieldDefinition, filter *mapper.Filter, docmapper *core.DocumentMapping, reverse bool, showDeleted bool)) *Fetcher_Init_Call {
+func (_c *Fetcher_Init_Call) Run(run func(ctx context.Context, id immutable.Option[identity.Identity], txn datastore.Txn, _a3 immutable.Option[acp.ACP], col client.Collection, fields []client.FieldDefinition, filter *mapper.Filter, docmapper *core.DocumentMapping, reverse bool, showDeleted bool)) *Fetcher_Init_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(identity.Identity), args[2].(datastore.Txn), args[3].(immutable.Option[acp.ACP]), args[4].(client.Collection), args[5].([]client.FieldDefinition), args[6].(*mapper.Filter), args[7].(*core.DocumentMapping), args[8].(bool), args[9].(bool))
+		run(args[0].(context.Context), args[1].(immutable.Option[identity.Identity]), args[2].(datastore.Txn), args[3].(immutable.Option[acp.ACP]), args[4].(client.Collection), args[5].([]client.FieldDefinition), args[6].(*mapper.Filter), args[7].(*core.DocumentMapping), args[8].(bool), args[9].(bool))
 	})
 	return _c
 }
@@ -184,7 +184,7 @@ func (_c *Fetcher_Init_Call) Return(_a0 error) *Fetcher_Init_Call {
 	return _c
 }
 
-func (_c *Fetcher_Init_Call) RunAndReturn(run func(context.Context, identity.Identity, datastore.Txn, immutable.Option[acp.ACP], client.Collection, []client.FieldDefinition, *mapper.Filter, *core.DocumentMapping, bool, bool) error) *Fetcher_Init_Call {
+func (_c *Fetcher_Init_Call) RunAndReturn(run func(context.Context, immutable.Option[identity.Identity], datastore.Txn, immutable.Option[acp.ACP], client.Collection, []client.FieldDefinition, *mapper.Filter, *core.DocumentMapping, bool, bool) error) *Fetcher_Init_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/db/fetcher/mocks/fetcher.go
+++ b/db/fetcher/mocks/fetcher.go
@@ -14,6 +14,8 @@ import (
 
 	fetcher "github.com/sourcenetwork/defradb/db/fetcher"
 
+	identity "github.com/sourcenetwork/defradb/acp/identity"
+
 	immutable "github.com/sourcenetwork/immutable"
 
 	mapper "github.com/sourcenetwork/defradb/planner/mapper"
@@ -136,13 +138,13 @@ func (_c *Fetcher_FetchNext_Call) RunAndReturn(run func(context.Context) (fetche
 	return _c
 }
 
-// Init provides a mock function with given fields: ctx, identity, txn, _a3, col, fields, filter, docmapper, reverse, showDeleted
-func (_m *Fetcher) Init(ctx context.Context, identity immutable.Option[string], txn datastore.Txn, _a3 immutable.Option[acp.ACP], col client.Collection, fields []client.FieldDefinition, filter *mapper.Filter, docmapper *core.DocumentMapping, reverse bool, showDeleted bool) error {
-	ret := _m.Called(ctx, identity, txn, _a3, col, fields, filter, docmapper, reverse, showDeleted)
+// Init provides a mock function with given fields: ctx, _a1, txn, _a3, col, fields, filter, docmapper, reverse, showDeleted
+func (_m *Fetcher) Init(ctx context.Context, _a1 identity.Identity, txn datastore.Txn, _a3 immutable.Option[acp.ACP], col client.Collection, fields []client.FieldDefinition, filter *mapper.Filter, docmapper *core.DocumentMapping, reverse bool, showDeleted bool) error {
+	ret := _m.Called(ctx, _a1, txn, _a3, col, fields, filter, docmapper, reverse, showDeleted)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, immutable.Option[string], datastore.Txn, immutable.Option[acp.ACP], client.Collection, []client.FieldDefinition, *mapper.Filter, *core.DocumentMapping, bool, bool) error); ok {
-		r0 = rf(ctx, identity, txn, _a3, col, fields, filter, docmapper, reverse, showDeleted)
+	if rf, ok := ret.Get(0).(func(context.Context, identity.Identity, datastore.Txn, immutable.Option[acp.ACP], client.Collection, []client.FieldDefinition, *mapper.Filter, *core.DocumentMapping, bool, bool) error); ok {
+		r0 = rf(ctx, _a1, txn, _a3, col, fields, filter, docmapper, reverse, showDeleted)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -157,7 +159,7 @@ type Fetcher_Init_Call struct {
 
 // Init is a helper method to define mock.On call
 //   - ctx context.Context
-//   - identity immutable.Option[string]
+//   - _a1 identity.Identity
 //   - txn datastore.Txn
 //   - _a3 immutable.Option[acp.ACP]
 //   - col client.Collection
@@ -166,13 +168,13 @@ type Fetcher_Init_Call struct {
 //   - docmapper *core.DocumentMapping
 //   - reverse bool
 //   - showDeleted bool
-func (_e *Fetcher_Expecter) Init(ctx interface{}, identity interface{}, txn interface{}, _a3 interface{}, col interface{}, fields interface{}, filter interface{}, docmapper interface{}, reverse interface{}, showDeleted interface{}) *Fetcher_Init_Call {
-	return &Fetcher_Init_Call{Call: _e.mock.On("Init", ctx, identity, txn, _a3, col, fields, filter, docmapper, reverse, showDeleted)}
+func (_e *Fetcher_Expecter) Init(ctx interface{}, _a1 interface{}, txn interface{}, _a3 interface{}, col interface{}, fields interface{}, filter interface{}, docmapper interface{}, reverse interface{}, showDeleted interface{}) *Fetcher_Init_Call {
+	return &Fetcher_Init_Call{Call: _e.mock.On("Init", ctx, _a1, txn, _a3, col, fields, filter, docmapper, reverse, showDeleted)}
 }
 
-func (_c *Fetcher_Init_Call) Run(run func(ctx context.Context, identity immutable.Option[string], txn datastore.Txn, _a3 immutable.Option[acp.ACP], col client.Collection, fields []client.FieldDefinition, filter *mapper.Filter, docmapper *core.DocumentMapping, reverse bool, showDeleted bool)) *Fetcher_Init_Call {
+func (_c *Fetcher_Init_Call) Run(run func(ctx context.Context, _a1 identity.Identity, txn datastore.Txn, _a3 immutable.Option[acp.ACP], col client.Collection, fields []client.FieldDefinition, filter *mapper.Filter, docmapper *core.DocumentMapping, reverse bool, showDeleted bool)) *Fetcher_Init_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(immutable.Option[string]), args[2].(datastore.Txn), args[3].(immutable.Option[acp.ACP]), args[4].(client.Collection), args[5].([]client.FieldDefinition), args[6].(*mapper.Filter), args[7].(*core.DocumentMapping), args[8].(bool), args[9].(bool))
+		run(args[0].(context.Context), args[1].(identity.Identity), args[2].(datastore.Txn), args[3].(immutable.Option[acp.ACP]), args[4].(client.Collection), args[5].([]client.FieldDefinition), args[6].(*mapper.Filter), args[7].(*core.DocumentMapping), args[8].(bool), args[9].(bool))
 	})
 	return _c
 }
@@ -182,7 +184,7 @@ func (_c *Fetcher_Init_Call) Return(_a0 error) *Fetcher_Init_Call {
 	return _c
 }
 
-func (_c *Fetcher_Init_Call) RunAndReturn(run func(context.Context, immutable.Option[string], datastore.Txn, immutable.Option[acp.ACP], client.Collection, []client.FieldDefinition, *mapper.Filter, *core.DocumentMapping, bool, bool) error) *Fetcher_Init_Call {
+func (_c *Fetcher_Init_Call) RunAndReturn(run func(context.Context, identity.Identity, datastore.Txn, immutable.Option[acp.ACP], client.Collection, []client.FieldDefinition, *mapper.Filter, *core.DocumentMapping, bool, bool) error) *Fetcher_Init_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/db/fetcher/versioned.go
+++ b/db/fetcher/versioned.go
@@ -22,6 +22,7 @@ import (
 	"github.com/sourcenetwork/immutable"
 
 	"github.com/sourcenetwork/defradb/acp"
+	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/core"
 	"github.com/sourcenetwork/defradb/datastore"
@@ -104,7 +105,7 @@ type VersionedFetcher struct {
 // Init initializes the VersionedFetcher.
 func (vf *VersionedFetcher) Init(
 	ctx context.Context,
-	identity immutable.Option[string],
+	identity acpIdentity.Identity,
 	txn datastore.Txn,
 	acp immutable.Option[acp.ACP],
 	col client.Collection,

--- a/db/fetcher/versioned.go
+++ b/db/fetcher/versioned.go
@@ -105,7 +105,7 @@ type VersionedFetcher struct {
 // Init initializes the VersionedFetcher.
 func (vf *VersionedFetcher) Init(
 	ctx context.Context,
-	identity identity.Identity,
+	id immutable.Option[identity.Identity],
 	txn datastore.Txn,
 	acp immutable.Option[acp.ACP],
 	col client.Collection,
@@ -141,7 +141,7 @@ func (vf *VersionedFetcher) Init(
 	vf.DocumentFetcher = new(DocumentFetcher)
 	return vf.DocumentFetcher.Init(
 		ctx,
-		identity,
+		id,
 		vf.store,
 		acp,
 		col,

--- a/db/fetcher/versioned.go
+++ b/db/fetcher/versioned.go
@@ -22,7 +22,7 @@ import (
 	"github.com/sourcenetwork/immutable"
 
 	"github.com/sourcenetwork/defradb/acp"
-	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
+	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/core"
 	"github.com/sourcenetwork/defradb/datastore"
@@ -105,7 +105,7 @@ type VersionedFetcher struct {
 // Init initializes the VersionedFetcher.
 func (vf *VersionedFetcher) Init(
 	ctx context.Context,
-	identity acpIdentity.Identity,
+	identity identity.Identity,
 	txn datastore.Txn,
 	acp immutable.Option[acp.ACP],
 	col client.Collection,

--- a/db/fetcher/versioned.go
+++ b/db/fetcher/versioned.go
@@ -22,7 +22,7 @@ import (
 	"github.com/sourcenetwork/immutable"
 
 	"github.com/sourcenetwork/defradb/acp"
-	"github.com/sourcenetwork/defradb/acp/identity"
+	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/core"
 	"github.com/sourcenetwork/defradb/datastore"
@@ -105,7 +105,7 @@ type VersionedFetcher struct {
 // Init initializes the VersionedFetcher.
 func (vf *VersionedFetcher) Init(
 	ctx context.Context,
-	id immutable.Option[identity.Identity],
+	identity immutable.Option[acpIdentity.Identity],
 	txn datastore.Txn,
 	acp immutable.Option[acp.ACP],
 	col client.Collection,
@@ -141,7 +141,7 @@ func (vf *VersionedFetcher) Init(
 	vf.DocumentFetcher = new(DocumentFetcher)
 	return vf.DocumentFetcher.Init(
 		ctx,
-		id,
+		identity,
 		vf.store,
 		acp,
 		col,

--- a/db/indexed_docs_test.go
+++ b/db/indexed_docs_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/sourcenetwork/defradb/acp"
-	"github.com/sourcenetwork/defradb/acp/identity"
+	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/core"
 	"github.com/sourcenetwork/defradb/datastore"
@@ -974,7 +974,7 @@ func TestNonUniqueUpdate_ShouldPassToFetcherOnlyRelevantFields(t *testing.T) {
 		).
 			RunAndReturn(func(
 				ctx context.Context,
-				id immutable.Option[identity.Identity],
+				identity immutable.Option[acpIdentity.Identity],
 				txn datastore.Txn,
 				acp immutable.Option[acp.ACP],
 				col client.Collection,

--- a/db/indexed_docs_test.go
+++ b/db/indexed_docs_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/sourcenetwork/defradb/acp"
-	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
+	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/core"
 	"github.com/sourcenetwork/defradb/datastore"
@@ -974,7 +974,7 @@ func TestNonUniqueUpdate_ShouldPassToFetcherOnlyRelevantFields(t *testing.T) {
 		).
 			RunAndReturn(func(
 				ctx context.Context,
-				identity acpIdentity.Identity,
+				identity identity.Identity,
 				txn datastore.Txn,
 				acp immutable.Option[acp.ACP],
 				col client.Collection,

--- a/db/indexed_docs_test.go
+++ b/db/indexed_docs_test.go
@@ -974,7 +974,7 @@ func TestNonUniqueUpdate_ShouldPassToFetcherOnlyRelevantFields(t *testing.T) {
 		).
 			RunAndReturn(func(
 				ctx context.Context,
-				identity identity.Identity,
+				id immutable.Option[identity.Identity],
 				txn datastore.Txn,
 				acp immutable.Option[acp.ACP],
 				col client.Collection,

--- a/db/indexed_docs_test.go
+++ b/db/indexed_docs_test.go
@@ -48,7 +48,7 @@ type productDoc struct {
 }
 
 func (f *indexTestFixture) saveDocToCollection(doc *client.Document, col client.Collection) {
-	err := col.Create(f.ctx, acpIdentity.NoIdentity, doc)
+	err := col.Create(f.ctx, doc)
 	require.NoError(f.t, err)
 	f.commitTxn()
 	f.txn, err = f.db.NewTxn(f.ctx, false)
@@ -324,7 +324,7 @@ func TestNonUnique_IfFailsToStoredIndexedDoc_Error(t *testing.T) {
 	dataStoreOn.Put(mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
 	ctx := SetContextTxn(f.ctx, mockTxn)
-	err := f.users.Create(ctx, acpIdentity.NoIdentity, doc)
+	err := f.users.Create(ctx, doc)
 	require.ErrorIs(f.t, err, NewErrFailedToStoreIndexedField("name", nil))
 }
 
@@ -342,7 +342,7 @@ func TestNonUnique_IfDocDoesNotHaveIndexedField_SkipIndex(t *testing.T) {
 	doc, err := client.NewDocFromJSON(data, f.users.Schema())
 	require.NoError(f.t, err)
 
-	err = f.users.Create(f.ctx, acpIdentity.NoIdentity, doc)
+	err = f.users.Create(f.ctx, doc)
 	require.NoError(f.t, err)
 
 	key := newIndexKeyBuilder(f).Col(usersColName).Build()
@@ -363,7 +363,7 @@ func TestNonUnique_IfSystemStorageHasInvalidIndexDescription_Error(t *testing.T)
 		Return(mocks.NewQueryResultsWithValues(t, []byte("invalid")), nil)
 
 	ctx := SetContextTxn(f.ctx, mockTxn)
-	err := f.users.Create(ctx, acpIdentity.NoIdentity, doc)
+	err := f.users.Create(ctx, doc)
 	assert.ErrorIs(t, err, datastore.NewErrInvalidStoredValue(nil))
 }
 
@@ -382,7 +382,7 @@ func TestNonUnique_IfSystemStorageFailsToReadIndexDesc_Error(t *testing.T) {
 		Return(nil, testErr)
 
 	ctx := SetContextTxn(f.ctx, mockTxn)
-	err := f.users.Create(ctx, acpIdentity.NoIdentity, doc)
+	err := f.users.Create(ctx, doc)
 	require.ErrorIs(t, err, testErr)
 }
 
@@ -415,9 +415,9 @@ func TestNonUnique_IfMultipleCollectionsWithIndexes_StoreIndexWithCollectionID(t
 	userDoc := f.newUserDoc("John", 21, users)
 	prodDoc := f.newProdDoc(1, 3, "games", products)
 
-	err = users.Create(f.ctx, acpIdentity.NoIdentity, userDoc)
+	err = users.Create(f.ctx, userDoc)
 	require.NoError(f.t, err)
-	err = products.Create(f.ctx, acpIdentity.NoIdentity, prodDoc)
+	err = products.Create(f.ctx, prodDoc)
 	require.NoError(f.t, err)
 	f.commitTxn()
 
@@ -749,14 +749,14 @@ func TestNonUniqueUpdate_ShouldDeleteOldValueAndStoreNewOne(t *testing.T) {
 			Name:     "update",
 			NewValue: "Islam",
 			Exec: func(doc *client.Document) error {
-				return f.users.Update(f.ctx, acpIdentity.NoIdentity, doc)
+				return f.users.Update(f.ctx, doc)
 			},
 		},
 		{
 			Name:     "save",
 			NewValue: "Andy",
 			Exec: func(doc *client.Document) error {
-				return f.users.Save(f.ctx, acpIdentity.NoIdentity, doc)
+				return f.users.Save(f.ctx, doc)
 			},
 		},
 	}
@@ -812,7 +812,7 @@ func TestNonUniqueUpdate_IfFailsToReadIndexDescription_ReturnError(t *testing.T)
 		return fetcherMocks.NewStubbedFetcher(t)
 	}
 	ctx = SetContextTxn(f.ctx, mockedTxn)
-	err = usersCol.Update(ctx, acpIdentity.NoIdentity, doc)
+	err = usersCol.Update(ctx, doc)
 	require.ErrorIs(t, err, testErr)
 }
 
@@ -908,7 +908,7 @@ func TestNonUniqueUpdate_IfFetcherFails_ReturnError(t *testing.T) {
 
 		err := doc.Set(usersNameFieldName, "Islam")
 		require.NoError(t, err, tc.Name)
-		err = f.users.Update(f.ctx, acpIdentity.NoIdentity, doc)
+		err = f.users.Update(f.ctx, doc)
 		require.Error(t, err, tc.Name)
 
 		newKey := newIndexKeyBuilder(f).Col(usersColName).Fields(usersNameFieldName).Doc(doc).Build()
@@ -936,7 +936,7 @@ func TestNonUniqueUpdate_IfFailsToUpdateIndex_ReturnError(t *testing.T) {
 
 	err = doc.Set(usersAgeFieldName, 23)
 	require.NoError(t, err)
-	err = f.users.Update(f.ctx, acpIdentity.NoIdentity, doc)
+	err = f.users.Update(f.ctx, doc)
 	require.ErrorIs(t, err, ErrCorruptedIndex)
 }
 
@@ -974,7 +974,7 @@ func TestNonUniqueUpdate_ShouldPassToFetcherOnlyRelevantFields(t *testing.T) {
 		).
 			RunAndReturn(func(
 				ctx context.Context,
-				identity immutable.Option[string],
+				identity acpIdentity.Identity,
 				txn datastore.Txn,
 				acp immutable.Option[acp.ACP],
 				col client.Collection,
@@ -996,7 +996,7 @@ func TestNonUniqueUpdate_ShouldPassToFetcherOnlyRelevantFields(t *testing.T) {
 
 	err := doc.Set(usersNameFieldName, "Islam")
 	require.NoError(t, err)
-	_ = f.users.Update(f.ctx, acpIdentity.NoIdentity, doc)
+	_ = f.users.Update(f.ctx, doc)
 }
 
 func TestNonUniqueUpdate_IfDatastoreFails_ReturnError(t *testing.T) {
@@ -1055,7 +1055,7 @@ func TestNonUniqueUpdate_IfDatastoreFails_ReturnError(t *testing.T) {
 		mockedTxn.EXPECT().Datastore().Return(mockedTxn.MockDatastore).Maybe()
 
 		ctx := SetContextTxn(f.ctx, mockedTxn)
-		err = f.users.Update(ctx, acpIdentity.NoIdentity, doc)
+		err = f.users.Update(ctx, doc)
 		require.ErrorIs(t, err, testErr)
 	}
 }
@@ -1080,7 +1080,7 @@ func TestNonUpdate_IfIndexedFieldWasNil_ShouldDeleteIt(t *testing.T) {
 	err = doc.Set(usersNameFieldName, "John")
 	require.NoError(f.t, err)
 
-	err = f.users.Update(f.ctx, acpIdentity.NoIdentity, doc)
+	err = f.users.Update(f.ctx, doc)
 	require.NoError(f.t, err)
 	f.commitTxn()
 
@@ -1204,14 +1204,14 @@ func TestUniqueUpdate_ShouldDeleteOldValueAndStoreNewOne(t *testing.T) {
 			Name:     "update",
 			NewValue: "Islam",
 			Exec: func(doc *client.Document) error {
-				return f.users.Update(f.ctx, acpIdentity.NoIdentity, doc)
+				return f.users.Update(f.ctx, doc)
 			},
 		},
 		{
 			Name:     "save",
 			NewValue: "Andy",
 			Exec: func(doc *client.Document) error {
-				return f.users.Save(f.ctx, acpIdentity.NoIdentity, doc)
+				return f.users.Save(f.ctx, doc)
 			},
 		},
 	}
@@ -1347,7 +1347,7 @@ func TestUniqueComposite_IfNilUpdateToValue_ShouldUpdateIndexStored(t *testing.T
 			newKey := newIndexKeyBuilder(f).Col(usersColName).Fields(usersNameFieldName, usersAgeFieldName).
 				Doc(doc).Unique().Build()
 
-			require.NoError(t, f.users.Update(f.ctx, acpIdentity.NoIdentity, doc), tc.Name)
+			require.NoError(t, f.users.Update(f.ctx, doc), tc.Name)
 			f.commitTxn()
 
 			_, err = f.txn.Datastore().Get(f.ctx, oldKey.ToDS())
@@ -1396,7 +1396,7 @@ func TestCompositeUpdate_ShouldDeleteOldValueAndStoreNewOne(t *testing.T) {
 			NewValue: "Islam",
 			Field:    usersNameFieldName,
 			Exec: func(doc *client.Document) error {
-				return f.users.Update(f.ctx, acpIdentity.NoIdentity, doc)
+				return f.users.Update(f.ctx, doc)
 			},
 		},
 		{
@@ -1404,7 +1404,7 @@ func TestCompositeUpdate_ShouldDeleteOldValueAndStoreNewOne(t *testing.T) {
 			NewValue: "Andy",
 			Field:    usersNameFieldName,
 			Exec: func(doc *client.Document) error {
-				return f.users.Save(f.ctx, acpIdentity.NoIdentity, doc)
+				return f.users.Save(f.ctx, doc)
 			},
 		},
 		{
@@ -1412,7 +1412,7 @@ func TestCompositeUpdate_ShouldDeleteOldValueAndStoreNewOne(t *testing.T) {
 			NewValue: 33,
 			Field:    usersAgeFieldName,
 			Exec: func(doc *client.Document) error {
-				return f.users.Update(f.ctx, acpIdentity.NoIdentity, doc)
+				return f.users.Update(f.ctx, doc)
 			},
 		},
 		{
@@ -1420,7 +1420,7 @@ func TestCompositeUpdate_ShouldDeleteOldValueAndStoreNewOne(t *testing.T) {
 			NewValue: 36,
 			Field:    usersAgeFieldName,
 			Exec: func(doc *client.Document) error {
-				return f.users.Save(f.ctx, acpIdentity.NoIdentity, doc)
+				return f.users.Save(f.ctx, doc)
 			},
 		},
 	}

--- a/db/permission/check.go
+++ b/db/permission/check.go
@@ -33,7 +33,7 @@ import (
 // - Document is public (unregistered), whether signatured request or not doesn't matter.
 func CheckAccessOfDocOnCollectionWithACP(
 	ctx context.Context,
-	identityOptional identity.Identity,
+	id identity.Identity,
 	acpSystem acp.ACP,
 	collection client.Collection,
 	permission acp.DPIPermission,
@@ -68,7 +68,7 @@ func CheckAccessOfDocOnCollectionWithACP(
 	// At this point if the request is not signatured, then it has no access, because:
 	// the collection has a policy on it, and the acp is enabled/available,
 	// and the document is not public (is regestered with acp).
-	if !identityOptional.HasValue() {
+	if id == identity.NoIdentity {
 		return false, nil
 	}
 
@@ -76,7 +76,7 @@ func CheckAccessOfDocOnCollectionWithACP(
 	hasAccess, err := acpSystem.CheckDocAccess(
 		ctx,
 		permission,
-		identityOptional.Value(),
+		id.String(),
 		policyID,
 		resourceName,
 		docID,

--- a/db/permission/check.go
+++ b/db/permission/check.go
@@ -13,9 +13,8 @@ package permission
 import (
 	"context"
 
-	"github.com/sourcenetwork/immutable"
-
 	"github.com/sourcenetwork/defradb/acp"
+	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 )
 
@@ -34,7 +33,7 @@ import (
 // - Document is public (unregistered), whether signatured request or not doesn't matter.
 func CheckAccessOfDocOnCollectionWithACP(
 	ctx context.Context,
-	identityOptional immutable.Option[string],
+	identityOptional acpIdentity.Identity,
 	acpSystem acp.ACP,
 	collection client.Collection,
 	permission acp.DPIPermission,

--- a/db/permission/check.go
+++ b/db/permission/check.go
@@ -13,6 +13,8 @@ package permission
 import (
 	"context"
 
+	"github.com/sourcenetwork/immutable"
+
 	"github.com/sourcenetwork/defradb/acp"
 	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
@@ -33,7 +35,7 @@ import (
 // - Document is public (unregistered), whether signatured request or not doesn't matter.
 func CheckAccessOfDocOnCollectionWithACP(
 	ctx context.Context,
-	id identity.Identity,
+	id immutable.Option[identity.Identity],
 	acpSystem acp.ACP,
 	collection client.Collection,
 	permission acp.DPIPermission,
@@ -68,7 +70,7 @@ func CheckAccessOfDocOnCollectionWithACP(
 	// At this point if the request is not signatured, then it has no access, because:
 	// the collection has a policy on it, and the acp is enabled/available,
 	// and the document is not public (is regestered with acp).
-	if id == identity.None {
+	if !id.HasValue() {
 		return false, nil
 	}
 
@@ -76,7 +78,7 @@ func CheckAccessOfDocOnCollectionWithACP(
 	hasAccess, err := acpSystem.CheckDocAccess(
 		ctx,
 		permission,
-		id.String(),
+		id.Value().String(),
 		policyID,
 		resourceName,
 		docID,

--- a/db/permission/check.go
+++ b/db/permission/check.go
@@ -68,7 +68,7 @@ func CheckAccessOfDocOnCollectionWithACP(
 	// At this point if the request is not signatured, then it has no access, because:
 	// the collection has a policy on it, and the acp is enabled/available,
 	// and the document is not public (is regestered with acp).
-	if id == identity.NoIdentity {
+	if id == identity.None {
 		return false, nil
 	}
 

--- a/db/permission/check.go
+++ b/db/permission/check.go
@@ -16,7 +16,7 @@ import (
 	"github.com/sourcenetwork/immutable"
 
 	"github.com/sourcenetwork/defradb/acp"
-	"github.com/sourcenetwork/defradb/acp/identity"
+	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 )
 
@@ -35,7 +35,7 @@ import (
 // - Document is public (unregistered), whether signatured request or not doesn't matter.
 func CheckAccessOfDocOnCollectionWithACP(
 	ctx context.Context,
-	id immutable.Option[identity.Identity],
+	identity immutable.Option[acpIdentity.Identity],
 	acpSystem acp.ACP,
 	collection client.Collection,
 	permission acp.DPIPermission,
@@ -70,7 +70,7 @@ func CheckAccessOfDocOnCollectionWithACP(
 	// At this point if the request is not signatured, then it has no access, because:
 	// the collection has a policy on it, and the acp is enabled/available,
 	// and the document is not public (is regestered with acp).
-	if !id.HasValue() {
+	if !identity.HasValue() {
 		return false, nil
 	}
 
@@ -78,7 +78,7 @@ func CheckAccessOfDocOnCollectionWithACP(
 	hasAccess, err := acpSystem.CheckDocAccess(
 		ctx,
 		permission,
-		id.Value().String(),
+		identity.Value().String(),
 		policyID,
 		resourceName,
 		docID,

--- a/db/permission/check.go
+++ b/db/permission/check.go
@@ -14,7 +14,7 @@ import (
 	"context"
 
 	"github.com/sourcenetwork/defradb/acp"
-	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
+	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 )
 
@@ -33,7 +33,7 @@ import (
 // - Document is public (unregistered), whether signatured request or not doesn't matter.
 func CheckAccessOfDocOnCollectionWithACP(
 	ctx context.Context,
-	identityOptional acpIdentity.Identity,
+	identityOptional identity.Identity,
 	acpSystem acp.ACP,
 	collection client.Collection,
 	permission acp.DPIPermission,

--- a/db/permission/register.go
+++ b/db/permission/register.go
@@ -14,7 +14,7 @@ import (
 	"context"
 
 	"github.com/sourcenetwork/defradb/acp"
-	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
+	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 )
 
@@ -29,7 +29,7 @@ import (
 // Otherwise, nothing is registered with acp.
 func RegisterDocOnCollectionWithACP(
 	ctx context.Context,
-	identity acpIdentity.Identity,
+	identity identity.Identity,
 	acpSystem acp.ACP,
 	collection client.Collection,
 	docID string,

--- a/db/permission/register.go
+++ b/db/permission/register.go
@@ -29,16 +29,16 @@ import (
 // Otherwise, nothing is registered with acp.
 func RegisterDocOnCollectionWithACP(
 	ctx context.Context,
-	identity identity.Identity,
+	id identity.Identity,
 	acpSystem acp.ACP,
 	collection client.Collection,
 	docID string,
 ) error {
 	// An identity exists and the collection has a policy.
-	if policyID, resourceName, hasPolicy := isPermissioned(collection); hasPolicy && identity.HasValue() {
+	if policyID, resourceName, hasPolicy := isPermissioned(collection); hasPolicy && id != identity.NoIdentity {
 		return acpSystem.RegisterDocObject(
 			ctx,
-			identity.Value(),
+			id.String(),
 			policyID,
 			resourceName,
 			docID,

--- a/db/permission/register.go
+++ b/db/permission/register.go
@@ -35,7 +35,7 @@ func RegisterDocOnCollectionWithACP(
 	docID string,
 ) error {
 	// An identity exists and the collection has a policy.
-	if policyID, resourceName, hasPolicy := isPermissioned(collection); hasPolicy && id != identity.NoIdentity {
+	if policyID, resourceName, hasPolicy := isPermissioned(collection); hasPolicy && id != identity.None {
 		return acpSystem.RegisterDocObject(
 			ctx,
 			id.String(),

--- a/db/permission/register.go
+++ b/db/permission/register.go
@@ -13,9 +13,8 @@ package permission
 import (
 	"context"
 
-	"github.com/sourcenetwork/immutable"
-
 	"github.com/sourcenetwork/defradb/acp"
+	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 )
 
@@ -30,7 +29,7 @@ import (
 // Otherwise, nothing is registered with acp.
 func RegisterDocOnCollectionWithACP(
 	ctx context.Context,
-	identity immutable.Option[string],
+	identity acpIdentity.Identity,
 	acpSystem acp.ACP,
 	collection client.Collection,
 	docID string,

--- a/db/permission/register.go
+++ b/db/permission/register.go
@@ -16,7 +16,7 @@ import (
 	"github.com/sourcenetwork/immutable"
 
 	"github.com/sourcenetwork/defradb/acp"
-	"github.com/sourcenetwork/defradb/acp/identity"
+	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 )
 
@@ -31,16 +31,16 @@ import (
 // Otherwise, nothing is registered with acp.
 func RegisterDocOnCollectionWithACP(
 	ctx context.Context,
-	id immutable.Option[identity.Identity],
+	identity immutable.Option[acpIdentity.Identity],
 	acpSystem acp.ACP,
 	collection client.Collection,
 	docID string,
 ) error {
 	// An identity exists and the collection has a policy.
-	if policyID, resourceName, hasPolicy := isPermissioned(collection); hasPolicy && id.HasValue() {
+	if policyID, resourceName, hasPolicy := isPermissioned(collection); hasPolicy && identity.HasValue() {
 		return acpSystem.RegisterDocObject(
 			ctx,
-			id.Value().String(),
+			identity.Value().String(),
 			policyID,
 			resourceName,
 			docID,

--- a/db/permission/register.go
+++ b/db/permission/register.go
@@ -13,6 +13,8 @@ package permission
 import (
 	"context"
 
+	"github.com/sourcenetwork/immutable"
+
 	"github.com/sourcenetwork/defradb/acp"
 	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
@@ -29,16 +31,16 @@ import (
 // Otherwise, nothing is registered with acp.
 func RegisterDocOnCollectionWithACP(
 	ctx context.Context,
-	id identity.Identity,
+	id immutable.Option[identity.Identity],
 	acpSystem acp.ACP,
 	collection client.Collection,
 	docID string,
 ) error {
 	// An identity exists and the collection has a policy.
-	if policyID, resourceName, hasPolicy := isPermissioned(collection); hasPolicy && id != identity.None {
+	if policyID, resourceName, hasPolicy := isPermissioned(collection); hasPolicy && id.HasValue() {
 		return acpSystem.RegisterDocObject(
 			ctx,
-			id.String(),
+			id.Value().String(),
 			policyID,
 			resourceName,
 			docID,

--- a/db/request.go
+++ b/db/request.go
@@ -13,18 +13,12 @@ package db
 import (
 	"context"
 
-	"github.com/sourcenetwork/immutable"
-
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/planner"
 )
 
 // execRequest executes a request against the database.
-func (db *db) execRequest(
-	ctx context.Context,
-	identity immutable.Option[string],
-	request string,
-) *client.RequestResult {
+func (db *db) execRequest(ctx context.Context, request string) *client.RequestResult {
 	res := &client.RequestResult{}
 	ast, err := db.parser.BuildRequestAST(request)
 	if err != nil {
@@ -49,11 +43,12 @@ func (db *db) execRequest(
 
 	if pub != nil {
 		res.Pub = pub
-		go db.handleSubscription(ctx, identity, pub, subRequest)
+		go db.handleSubscription(ctx, pub, subRequest)
 		return res
 	}
 
 	txn := mustGetContextTxn(ctx)
+	identity := mustGetContextIdentity(ctx)
 	planner := planner.New(
 		ctx,
 		identity,

--- a/db/request.go
+++ b/db/request.go
@@ -48,7 +48,7 @@ func (db *db) execRequest(ctx context.Context, request string) *client.RequestRe
 	}
 
 	txn := mustGetContextTxn(ctx)
-	identity := mustGetContextIdentity(ctx)
+	identity := GetContextIdentity(ctx)
 	planner := planner.New(
 		ctx,
 		identity,

--- a/db/store.go
+++ b/db/store.go
@@ -26,7 +26,7 @@ func (db *db) ExecRequest(
 	identity immutable.Option[string],
 	request string,
 ) *client.RequestResult {
-	ctx, txn, err := ensureContextTxn(ctx, db, false)
+	ctx, txn, err := ensureContextValues(ctx, db, false)
 	if err != nil {
 		res := &client.RequestResult{}
 		res.GQL.Errors = []error{err}
@@ -49,7 +49,7 @@ func (db *db) ExecRequest(
 
 // GetCollectionByName returns an existing collection within the database.
 func (db *db) GetCollectionByName(ctx context.Context, name string) (client.Collection, error) {
-	ctx, txn, err := ensureContextTxn(ctx, db, true)
+	ctx, txn, err := ensureContextValues(ctx, db, true)
 	if err != nil {
 		return nil, err
 	}
@@ -63,7 +63,7 @@ func (db *db) GetCollections(
 	ctx context.Context,
 	options client.CollectionFetchOptions,
 ) ([]client.Collection, error) {
-	ctx, txn, err := ensureContextTxn(ctx, db, true)
+	ctx, txn, err := ensureContextValues(ctx, db, true)
 	if err != nil {
 		return nil, err
 	}
@@ -77,7 +77,7 @@ func (db *db) GetCollections(
 //
 // Will return an error if it is not found.
 func (db *db) GetSchemaByVersionID(ctx context.Context, versionID string) (client.SchemaDescription, error) {
-	ctx, txn, err := ensureContextTxn(ctx, db, true)
+	ctx, txn, err := ensureContextValues(ctx, db, true)
 	if err != nil {
 		return client.SchemaDescription{}, err
 	}
@@ -92,7 +92,7 @@ func (db *db) GetSchemas(
 	ctx context.Context,
 	options client.SchemaFetchOptions,
 ) ([]client.SchemaDescription, error) {
-	ctx, txn, err := ensureContextTxn(ctx, db, true)
+	ctx, txn, err := ensureContextValues(ctx, db, true)
 	if err != nil {
 		return nil, err
 	}
@@ -105,7 +105,7 @@ func (db *db) GetSchemas(
 func (db *db) GetAllIndexes(
 	ctx context.Context,
 ) (map[client.CollectionName][]client.IndexDescription, error) {
-	ctx, txn, err := ensureContextTxn(ctx, db, true)
+	ctx, txn, err := ensureContextValues(ctx, db, true)
 	if err != nil {
 		return nil, err
 	}
@@ -120,7 +120,7 @@ func (db *db) GetAllIndexes(
 // All schema types provided must not exist prior to calling this, and they may not reference existing
 // types previously defined.
 func (db *db) AddSchema(ctx context.Context, schemaString string) ([]client.CollectionDescription, error) {
-	ctx, txn, err := ensureContextTxn(ctx, db, false)
+	ctx, txn, err := ensureContextValues(ctx, db, false)
 	if err != nil {
 		return nil, err
 	}
@@ -154,7 +154,7 @@ func (db *db) PatchSchema(
 	migration immutable.Option[model.Lens],
 	setAsDefaultVersion bool,
 ) error {
-	ctx, txn, err := ensureContextTxn(ctx, db, false)
+	ctx, txn, err := ensureContextValues(ctx, db, false)
 	if err != nil {
 		return err
 	}
@@ -172,7 +172,7 @@ func (db *db) PatchCollection(
 	ctx context.Context,
 	patchString string,
 ) error {
-	ctx, txn, err := ensureContextTxn(ctx, db, false)
+	ctx, txn, err := ensureContextValues(ctx, db, false)
 	if err != nil {
 		return err
 	}
@@ -187,7 +187,7 @@ func (db *db) PatchCollection(
 }
 
 func (db *db) SetActiveSchemaVersion(ctx context.Context, schemaVersionID string) error {
-	ctx, txn, err := ensureContextTxn(ctx, db, false)
+	ctx, txn, err := ensureContextValues(ctx, db, false)
 	if err != nil {
 		return err
 	}
@@ -202,7 +202,7 @@ func (db *db) SetActiveSchemaVersion(ctx context.Context, schemaVersionID string
 }
 
 func (db *db) SetMigration(ctx context.Context, cfg client.LensConfig) error {
-	ctx, txn, err := ensureContextTxn(ctx, db, false)
+	ctx, txn, err := ensureContextValues(ctx, db, false)
 	if err != nil {
 		return err
 	}
@@ -222,7 +222,7 @@ func (db *db) AddView(
 	sdl string,
 	transform immutable.Option[model.Lens],
 ) ([]client.CollectionDefinition, error) {
-	ctx, txn, err := ensureContextTxn(ctx, db, false)
+	ctx, txn, err := ensureContextValues(ctx, db, false)
 	if err != nil {
 		return nil, err
 	}
@@ -244,7 +244,7 @@ func (db *db) AddView(
 // BasicImport imports a json dataset.
 // filepath must be accessible to the node.
 func (db *db) BasicImport(ctx context.Context, filepath string) error {
-	ctx, txn, err := ensureContextTxn(ctx, db, false)
+	ctx, txn, err := ensureContextValues(ctx, db, false)
 	if err != nil {
 		return err
 	}
@@ -260,7 +260,7 @@ func (db *db) BasicImport(ctx context.Context, filepath string) error {
 
 // BasicExport exports the current data or subset of data to file in json format.
 func (db *db) BasicExport(ctx context.Context, config *client.BackupConfig) error {
-	ctx, txn, err := ensureContextTxn(ctx, db, true)
+	ctx, txn, err := ensureContextValues(ctx, db, true)
 	if err != nil {
 		return err
 	}

--- a/db/store.go
+++ b/db/store.go
@@ -21,11 +21,7 @@ import (
 )
 
 // ExecRequest executes a request against the database.
-func (db *db) ExecRequest(
-	ctx context.Context,
-	identity immutable.Option[string],
-	request string,
-) *client.RequestResult {
+func (db *db) ExecRequest(ctx context.Context, request string) *client.RequestResult {
 	ctx, txn, err := ensureContextValues(ctx, db, false)
 	if err != nil {
 		res := &client.RequestResult{}
@@ -34,7 +30,7 @@ func (db *db) ExecRequest(
 	}
 	defer txn.Discard(ctx)
 
-	res := db.execRequest(ctx, identity, request)
+	res := db.execRequest(ctx, request)
 	if len(res.GQL.Errors) > 0 {
 		return res
 	}

--- a/db/store.go
+++ b/db/store.go
@@ -22,7 +22,7 @@ import (
 
 // ExecRequest executes a request against the database.
 func (db *db) ExecRequest(ctx context.Context, request string) *client.RequestResult {
-	ctx, txn, err := ensureContextValues(ctx, db, false)
+	ctx, txn, err := ensureContextTxn(ctx, db, false)
 	if err != nil {
 		res := &client.RequestResult{}
 		res.GQL.Errors = []error{err}
@@ -45,7 +45,7 @@ func (db *db) ExecRequest(ctx context.Context, request string) *client.RequestRe
 
 // GetCollectionByName returns an existing collection within the database.
 func (db *db) GetCollectionByName(ctx context.Context, name string) (client.Collection, error) {
-	ctx, txn, err := ensureContextValues(ctx, db, true)
+	ctx, txn, err := ensureContextTxn(ctx, db, true)
 	if err != nil {
 		return nil, err
 	}
@@ -59,7 +59,7 @@ func (db *db) GetCollections(
 	ctx context.Context,
 	options client.CollectionFetchOptions,
 ) ([]client.Collection, error) {
-	ctx, txn, err := ensureContextValues(ctx, db, true)
+	ctx, txn, err := ensureContextTxn(ctx, db, true)
 	if err != nil {
 		return nil, err
 	}
@@ -73,7 +73,7 @@ func (db *db) GetCollections(
 //
 // Will return an error if it is not found.
 func (db *db) GetSchemaByVersionID(ctx context.Context, versionID string) (client.SchemaDescription, error) {
-	ctx, txn, err := ensureContextValues(ctx, db, true)
+	ctx, txn, err := ensureContextTxn(ctx, db, true)
 	if err != nil {
 		return client.SchemaDescription{}, err
 	}
@@ -88,7 +88,7 @@ func (db *db) GetSchemas(
 	ctx context.Context,
 	options client.SchemaFetchOptions,
 ) ([]client.SchemaDescription, error) {
-	ctx, txn, err := ensureContextValues(ctx, db, true)
+	ctx, txn, err := ensureContextTxn(ctx, db, true)
 	if err != nil {
 		return nil, err
 	}
@@ -101,7 +101,7 @@ func (db *db) GetSchemas(
 func (db *db) GetAllIndexes(
 	ctx context.Context,
 ) (map[client.CollectionName][]client.IndexDescription, error) {
-	ctx, txn, err := ensureContextValues(ctx, db, true)
+	ctx, txn, err := ensureContextTxn(ctx, db, true)
 	if err != nil {
 		return nil, err
 	}
@@ -116,7 +116,7 @@ func (db *db) GetAllIndexes(
 // All schema types provided must not exist prior to calling this, and they may not reference existing
 // types previously defined.
 func (db *db) AddSchema(ctx context.Context, schemaString string) ([]client.CollectionDescription, error) {
-	ctx, txn, err := ensureContextValues(ctx, db, false)
+	ctx, txn, err := ensureContextTxn(ctx, db, false)
 	if err != nil {
 		return nil, err
 	}
@@ -150,7 +150,7 @@ func (db *db) PatchSchema(
 	migration immutable.Option[model.Lens],
 	setAsDefaultVersion bool,
 ) error {
-	ctx, txn, err := ensureContextValues(ctx, db, false)
+	ctx, txn, err := ensureContextTxn(ctx, db, false)
 	if err != nil {
 		return err
 	}
@@ -168,7 +168,7 @@ func (db *db) PatchCollection(
 	ctx context.Context,
 	patchString string,
 ) error {
-	ctx, txn, err := ensureContextValues(ctx, db, false)
+	ctx, txn, err := ensureContextTxn(ctx, db, false)
 	if err != nil {
 		return err
 	}
@@ -183,7 +183,7 @@ func (db *db) PatchCollection(
 }
 
 func (db *db) SetActiveSchemaVersion(ctx context.Context, schemaVersionID string) error {
-	ctx, txn, err := ensureContextValues(ctx, db, false)
+	ctx, txn, err := ensureContextTxn(ctx, db, false)
 	if err != nil {
 		return err
 	}
@@ -198,7 +198,7 @@ func (db *db) SetActiveSchemaVersion(ctx context.Context, schemaVersionID string
 }
 
 func (db *db) SetMigration(ctx context.Context, cfg client.LensConfig) error {
-	ctx, txn, err := ensureContextValues(ctx, db, false)
+	ctx, txn, err := ensureContextTxn(ctx, db, false)
 	if err != nil {
 		return err
 	}
@@ -218,7 +218,7 @@ func (db *db) AddView(
 	sdl string,
 	transform immutable.Option[model.Lens],
 ) ([]client.CollectionDefinition, error) {
-	ctx, txn, err := ensureContextValues(ctx, db, false)
+	ctx, txn, err := ensureContextTxn(ctx, db, false)
 	if err != nil {
 		return nil, err
 	}
@@ -240,7 +240,7 @@ func (db *db) AddView(
 // BasicImport imports a json dataset.
 // filepath must be accessible to the node.
 func (db *db) BasicImport(ctx context.Context, filepath string) error {
-	ctx, txn, err := ensureContextValues(ctx, db, false)
+	ctx, txn, err := ensureContextTxn(ctx, db, false)
 	if err != nil {
 		return err
 	}
@@ -256,7 +256,7 @@ func (db *db) BasicImport(ctx context.Context, filepath string) error {
 
 // BasicExport exports the current data or subset of data to file in json format.
 func (db *db) BasicExport(ctx context.Context, config *client.BackupConfig) error {
-	ctx, txn, err := ensureContextValues(ctx, db, true)
+	ctx, txn, err := ensureContextTxn(ctx, db, true)
 	if err != nil {
 		return err
 	}

--- a/db/subscriptions.go
+++ b/db/subscriptions.go
@@ -71,7 +71,7 @@ func (db *db) handleEvent(
 	r *request.ObjectSubscription,
 ) {
 	txn := mustGetContextTxn(ctx)
-	identity := mustGetContextIdentity(ctx)
+	identity := GetContextIdentity(ctx)
 	p := planner.New(
 		ctx,
 		identity,

--- a/db/subscriptions.go
+++ b/db/subscriptions.go
@@ -13,8 +13,6 @@ package db
 import (
 	"context"
 
-	"github.com/sourcenetwork/immutable"
-
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/request"
 	"github.com/sourcenetwork/defradb/events"
@@ -50,7 +48,6 @@ func (db *db) checkForClientSubscriptions(r *request.Request) (
 
 func (db *db) handleSubscription(
 	ctx context.Context,
-	identity immutable.Option[string],
 	pub *events.Publisher[events.Update],
 	r *request.ObjectSubscription,
 ) {
@@ -62,19 +59,19 @@ func (db *db) handleSubscription(
 		}
 
 		ctx := SetContextTxn(ctx, txn)
-		db.handleEvent(ctx, identity, pub, evt, r)
+		db.handleEvent(ctx, pub, evt, r)
 		txn.Discard(ctx)
 	}
 }
 
 func (db *db) handleEvent(
 	ctx context.Context,
-	identity immutable.Option[string],
 	pub *events.Publisher[events.Update],
 	evt events.Update,
 	r *request.ObjectSubscription,
 ) {
 	txn := mustGetContextTxn(ctx)
+	identity := mustGetContextIdentity(ctx)
 	p := planner.New(
 		ctx,
 		identity,

--- a/docs/cli/defradb_client.md
+++ b/docs/cli/defradb_client.md
@@ -10,8 +10,9 @@ Execute queries, add schema types, obtain node info, etc.
 ### Options
 
 ```
-  -h, --help      help for client
-      --tx uint   Transaction ID
+  -h, --help              help for client
+  -i, --identity string   ACP Identity
+      --tx uint           Transaction ID
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli/defradb_client_acp.md
+++ b/docs/cli/defradb_client_acp.md
@@ -20,6 +20,7 @@ Learn more about [ACP](/acp/README.md)
 
 ```
       --allowed-origins stringArray   List of origins to allow for CORS requests
+  -i, --identity string               ACP Identity
       --log-format string             Log format to use. Options are text or json (default "text")
       --log-level string              Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string             Log output path. Options are stderr or stdout. (default "stderr")

--- a/docs/cli/defradb_client_acp_policy.md
+++ b/docs/cli/defradb_client_acp_policy.md
@@ -16,6 +16,7 @@ Interact with the acp policy features of DefraDB instance
 
 ```
       --allowed-origins stringArray   List of origins to allow for CORS requests
+  -i, --identity string               ACP Identity
       --log-format string             Log format to use. Options are text or json (default "text")
       --log-level string              Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string             Log output path. Options are stderr or stdout. (default "stderr")

--- a/docs/cli/defradb_client_acp_policy_add.md
+++ b/docs/cli/defradb_client_acp_policy_add.md
@@ -56,15 +56,15 @@ defradb client acp policy add [-i --identity] [policy] [flags]
 ### Options
 
 ```
-  -f, --file string       File to load a policy from
-  -h, --help              help for add
-  -i, --identity string   [Required] Identity of the creator
+  -f, --file string   File to load a policy from
+  -h, --help          help for add
 ```
 
 ### Options inherited from parent commands
 
 ```
       --allowed-origins stringArray   List of origins to allow for CORS requests
+  -i, --identity string               ACP Identity
       --log-format string             Log format to use. Options are text or json (default "text")
       --log-level string              Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string             Log output path. Options are stderr or stdout. (default "stderr")

--- a/docs/cli/defradb_client_backup.md
+++ b/docs/cli/defradb_client_backup.md
@@ -17,6 +17,7 @@ Currently only supports JSON format.
 
 ```
       --allowed-origins stringArray   List of origins to allow for CORS requests
+  -i, --identity string               ACP Identity
       --log-format string             Log format to use. Options are text or json (default "text")
       --log-level string              Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string             Log output path. Options are stderr or stdout. (default "stderr")

--- a/docs/cli/defradb_client_backup_export.md
+++ b/docs/cli/defradb_client_backup_export.md
@@ -31,6 +31,7 @@ defradb client backup export  [-c --collections | -p --pretty | -f --format] <ou
 
 ```
       --allowed-origins stringArray   List of origins to allow for CORS requests
+  -i, --identity string               ACP Identity
       --log-format string             Log format to use. Options are text or json (default "text")
       --log-level string              Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string             Log output path. Options are stderr or stdout. (default "stderr")

--- a/docs/cli/defradb_client_backup_import.md
+++ b/docs/cli/defradb_client_backup_import.md
@@ -23,6 +23,7 @@ defradb client backup import <input_path> [flags]
 
 ```
       --allowed-origins stringArray   List of origins to allow for CORS requests
+  -i, --identity string               ACP Identity
       --log-format string             Log format to use. Options are text or json (default "text")
       --log-level string              Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string             Log output path. Options are stderr or stdout. (default "stderr")

--- a/docs/cli/defradb_client_collection.md
+++ b/docs/cli/defradb_client_collection.md
@@ -9,12 +9,13 @@ Create, read, update, and delete documents within a collection.
 ### Options
 
 ```
-      --get-inactive     Get inactive collections as well as active
-  -h, --help             help for collection
-      --name string      Collection name
-      --schema string    Collection schema Root
-      --tx uint          Transaction ID
-      --version string   Collection version ID
+      --get-inactive      Get inactive collections as well as active
+  -h, --help              help for collection
+  -i, --identity string   ACP Identity
+      --name string       Collection name
+      --schema string     Collection schema Root
+      --tx uint           Transaction ID
+      --version string    Collection version ID
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli/defradb_client_collection_create.md
+++ b/docs/cli/defradb_client_collection_create.md
@@ -29,9 +29,8 @@ defradb client collection create [-i --identity] <document> [flags]
 ### Options
 
 ```
-  -f, --file string       File containing document(s)
-  -h, --help              help for create
-  -i, --identity string   Identity of the actor
+  -f, --file string   File containing document(s)
+  -h, --help          help for create
 ```
 
 ### Options inherited from parent commands
@@ -39,6 +38,7 @@ defradb client collection create [-i --identity] <document> [flags]
 ```
       --allowed-origins stringArray   List of origins to allow for CORS requests
       --get-inactive                  Get inactive collections as well as active
+  -i, --identity string               ACP Identity
       --log-format string             Log format to use. Options are text or json (default "text")
       --log-level string              Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string             Log output path. Options are stderr or stdout. (default "stderr")

--- a/docs/cli/defradb_client_collection_delete.md
+++ b/docs/cli/defradb_client_collection_delete.md
@@ -23,10 +23,9 @@ defradb client collection delete [-i --identity] [--filter <filter> --docID <doc
 ### Options
 
 ```
-      --docID strings     Document ID
-      --filter string     Document filter
-  -h, --help              help for delete
-  -i, --identity string   Identity of the actor
+      --docID strings   Document ID
+      --filter string   Document filter
+  -h, --help            help for delete
 ```
 
 ### Options inherited from parent commands
@@ -34,6 +33,7 @@ defradb client collection delete [-i --identity] [--filter <filter> --docID <doc
 ```
       --allowed-origins stringArray   List of origins to allow for CORS requests
       --get-inactive                  Get inactive collections as well as active
+  -i, --identity string               ACP Identity
       --log-format string             Log format to use. Options are text or json (default "text")
       --log-level string              Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string             Log output path. Options are stderr or stdout. (default "stderr")

--- a/docs/cli/defradb_client_collection_describe.md
+++ b/docs/cli/defradb_client_collection_describe.md
@@ -37,6 +37,7 @@ defradb client collection describe [flags]
 
 ```
       --allowed-origins stringArray   List of origins to allow for CORS requests
+  -i, --identity string               ACP Identity
       --log-format string             Log format to use. Options are text or json (default "text")
       --log-level string              Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string             Log output path. Options are stderr or stdout. (default "stderr")

--- a/docs/cli/defradb_client_collection_docIDs.md
+++ b/docs/cli/defradb_client_collection_docIDs.md
@@ -20,8 +20,7 @@ defradb client collection docIDs [-i --identity] [flags]
 ### Options
 
 ```
-  -h, --help              help for docIDs
-  -i, --identity string   Identity of the actor
+  -h, --help   help for docIDs
 ```
 
 ### Options inherited from parent commands
@@ -29,6 +28,7 @@ defradb client collection docIDs [-i --identity] [flags]
 ```
       --allowed-origins stringArray   List of origins to allow for CORS requests
       --get-inactive                  Get inactive collections as well as active
+  -i, --identity string               ACP Identity
       --log-format string             Log format to use. Options are text or json (default "text")
       --log-level string              Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string             Log output path. Options are stderr or stdout. (default "stderr")

--- a/docs/cli/defradb_client_collection_get.md
+++ b/docs/cli/defradb_client_collection_get.md
@@ -20,9 +20,8 @@ defradb client collection get [-i --identity] [--show-deleted] <docID>  [flags]
 ### Options
 
 ```
-  -h, --help              help for get
-  -i, --identity string   Identity of the actor
-      --show-deleted      Show deleted documents
+  -h, --help           help for get
+      --show-deleted   Show deleted documents
 ```
 
 ### Options inherited from parent commands
@@ -30,6 +29,7 @@ defradb client collection get [-i --identity] [--show-deleted] <docID>  [flags]
 ```
       --allowed-origins stringArray   List of origins to allow for CORS requests
       --get-inactive                  Get inactive collections as well as active
+  -i, --identity string               ACP Identity
       --log-format string             Log format to use. Options are text or json (default "text")
       --log-level string              Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string             Log output path. Options are stderr or stdout. (default "stderr")

--- a/docs/cli/defradb_client_collection_patch.md
+++ b/docs/cli/defradb_client_collection_patch.md
@@ -35,6 +35,7 @@ defradb client collection patch [patch] [flags]
 ```
       --allowed-origins stringArray   List of origins to allow for CORS requests
       --get-inactive                  Get inactive collections as well as active
+  -i, --identity string               ACP Identity
       --log-format string             Log format to use. Options are text or json (default "text")
       --log-level string              Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string             Log output path. Options are stderr or stdout. (default "stderr")

--- a/docs/cli/defradb_client_collection_update.md
+++ b/docs/cli/defradb_client_collection_update.md
@@ -29,11 +29,10 @@ defradb client collection update [-i --identity] [--filter <filter> --docID <doc
 ### Options
 
 ```
-      --docID strings     Document ID
-      --filter string     Document filter
-  -h, --help              help for update
-  -i, --identity string   Identity of the actor
-      --updater string    Document updater
+      --docID strings    Document ID
+      --filter string    Document filter
+  -h, --help             help for update
+      --updater string   Document updater
 ```
 
 ### Options inherited from parent commands
@@ -41,6 +40,7 @@ defradb client collection update [-i --identity] [--filter <filter> --docID <doc
 ```
       --allowed-origins stringArray   List of origins to allow for CORS requests
       --get-inactive                  Get inactive collections as well as active
+  -i, --identity string               ACP Identity
       --log-format string             Log format to use. Options are text or json (default "text")
       --log-level string              Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string             Log output path. Options are stderr or stdout. (default "stderr")

--- a/docs/cli/defradb_client_dump.md
+++ b/docs/cli/defradb_client_dump.md
@@ -16,6 +16,7 @@ defradb client dump [flags]
 
 ```
       --allowed-origins stringArray   List of origins to allow for CORS requests
+  -i, --identity string               ACP Identity
       --log-format string             Log format to use. Options are text or json (default "text")
       --log-level string              Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string             Log output path. Options are stderr or stdout. (default "stderr")

--- a/docs/cli/defradb_client_index.md
+++ b/docs/cli/defradb_client_index.md
@@ -16,6 +16,7 @@ Manage (create, drop, or list) collection indexes on a DefraDB node.
 
 ```
       --allowed-origins stringArray   List of origins to allow for CORS requests
+  -i, --identity string               ACP Identity
       --log-format string             Log format to use. Options are text or json (default "text")
       --log-level string              Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string             Log output path. Options are stderr or stdout. (default "stderr")

--- a/docs/cli/defradb_client_index_create.md
+++ b/docs/cli/defradb_client_index_create.md
@@ -33,6 +33,7 @@ defradb client index create -c --collection <collection> --fields <fields> [-n -
 
 ```
       --allowed-origins stringArray   List of origins to allow for CORS requests
+  -i, --identity string               ACP Identity
       --log-format string             Log format to use. Options are text or json (default "text")
       --log-level string              Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string             Log output path. Options are stderr or stdout. (default "stderr")

--- a/docs/cli/defradb_client_index_drop.md
+++ b/docs/cli/defradb_client_index_drop.md
@@ -25,6 +25,7 @@ defradb client index drop -c --collection <collection> -n --name <name> [flags]
 
 ```
       --allowed-origins stringArray   List of origins to allow for CORS requests
+  -i, --identity string               ACP Identity
       --log-format string             Log format to use. Options are text or json (default "text")
       --log-level string              Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string             Log output path. Options are stderr or stdout. (default "stderr")

--- a/docs/cli/defradb_client_index_list.md
+++ b/docs/cli/defradb_client_index_list.md
@@ -27,6 +27,7 @@ defradb client index list [-c --collection <collection>] [flags]
 
 ```
       --allowed-origins stringArray   List of origins to allow for CORS requests
+  -i, --identity string               ACP Identity
       --log-format string             Log format to use. Options are text or json (default "text")
       --log-level string              Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string             Log output path. Options are stderr or stdout. (default "stderr")

--- a/docs/cli/defradb_client_p2p.md
+++ b/docs/cli/defradb_client_p2p.md
@@ -16,6 +16,7 @@ Interact with the DefraDB P2P system
 
 ```
       --allowed-origins stringArray   List of origins to allow for CORS requests
+  -i, --identity string               ACP Identity
       --log-format string             Log format to use. Options are text or json (default "text")
       --log-level string              Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string             Log output path. Options are stderr or stdout. (default "stderr")

--- a/docs/cli/defradb_client_p2p_collection.md
+++ b/docs/cli/defradb_client_p2p_collection.md
@@ -17,6 +17,7 @@ The selected collections synchronize their events on the pubsub network.
 
 ```
       --allowed-origins stringArray   List of origins to allow for CORS requests
+  -i, --identity string               ACP Identity
       --log-format string             Log format to use. Options are text or json (default "text")
       --log-level string              Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string             Log output path. Options are stderr or stdout. (default "stderr")

--- a/docs/cli/defradb_client_p2p_collection_add.md
+++ b/docs/cli/defradb_client_p2p_collection_add.md
@@ -28,6 +28,7 @@ defradb client p2p collection add [collectionIDs] [flags]
 
 ```
       --allowed-origins stringArray   List of origins to allow for CORS requests
+  -i, --identity string               ACP Identity
       --log-format string             Log format to use. Options are text or json (default "text")
       --log-level string              Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string             Log output path. Options are stderr or stdout. (default "stderr")

--- a/docs/cli/defradb_client_p2p_collection_getall.md
+++ b/docs/cli/defradb_client_p2p_collection_getall.md
@@ -21,6 +21,7 @@ defradb client p2p collection getall [flags]
 
 ```
       --allowed-origins stringArray   List of origins to allow for CORS requests
+  -i, --identity string               ACP Identity
       --log-format string             Log format to use. Options are text or json (default "text")
       --log-level string              Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string             Log output path. Options are stderr or stdout. (default "stderr")

--- a/docs/cli/defradb_client_p2p_collection_remove.md
+++ b/docs/cli/defradb_client_p2p_collection_remove.md
@@ -28,6 +28,7 @@ defradb client p2p collection remove [collectionIDs] [flags]
 
 ```
       --allowed-origins stringArray   List of origins to allow for CORS requests
+  -i, --identity string               ACP Identity
       --log-format string             Log format to use. Options are text or json (default "text")
       --log-level string              Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string             Log output path. Options are stderr or stdout. (default "stderr")

--- a/docs/cli/defradb_client_p2p_info.md
+++ b/docs/cli/defradb_client_p2p_info.md
@@ -20,6 +20,7 @@ defradb client p2p info [flags]
 
 ```
       --allowed-origins stringArray   List of origins to allow for CORS requests
+  -i, --identity string               ACP Identity
       --log-format string             Log format to use. Options are text or json (default "text")
       --log-level string              Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string             Log output path. Options are stderr or stdout. (default "stderr")

--- a/docs/cli/defradb_client_p2p_replicator.md
+++ b/docs/cli/defradb_client_p2p_replicator.md
@@ -17,6 +17,7 @@ A replicator replicates one or all collection(s) from one node to another.
 
 ```
       --allowed-origins stringArray   List of origins to allow for CORS requests
+  -i, --identity string               ACP Identity
       --log-format string             Log format to use. Options are text or json (default "text")
       --log-level string              Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string             Log output path. Options are stderr or stdout. (default "stderr")

--- a/docs/cli/defradb_client_p2p_replicator_delete.md
+++ b/docs/cli/defradb_client_p2p_replicator_delete.md
@@ -26,6 +26,7 @@ defradb client p2p replicator delete [-c, --collection] <peer> [flags]
 
 ```
       --allowed-origins stringArray   List of origins to allow for CORS requests
+  -i, --identity string               ACP Identity
       --log-format string             Log format to use. Options are text or json (default "text")
       --log-level string              Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string             Log output path. Options are stderr or stdout. (default "stderr")

--- a/docs/cli/defradb_client_p2p_replicator_getall.md
+++ b/docs/cli/defradb_client_p2p_replicator_getall.md
@@ -25,6 +25,7 @@ defradb client p2p replicator getall [flags]
 
 ```
       --allowed-origins stringArray   List of origins to allow for CORS requests
+  -i, --identity string               ACP Identity
       --log-format string             Log format to use. Options are text or json (default "text")
       --log-level string              Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string             Log output path. Options are stderr or stdout. (default "stderr")

--- a/docs/cli/defradb_client_p2p_replicator_set.md
+++ b/docs/cli/defradb_client_p2p_replicator_set.md
@@ -26,6 +26,7 @@ defradb client p2p replicator set [-c, --collection] <peer> [flags]
 
 ```
       --allowed-origins stringArray   List of origins to allow for CORS requests
+  -i, --identity string               ACP Identity
       --log-format string             Log format to use. Options are text or json (default "text")
       --log-level string              Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string             Log output path. Options are stderr or stdout. (default "stderr")

--- a/docs/cli/defradb_client_query.md
+++ b/docs/cli/defradb_client_query.md
@@ -30,15 +30,15 @@ defradb client query [-i --identity] [request] [flags]
 ### Options
 
 ```
-  -f, --file string       File containing the query request
-  -h, --help              help for query
-  -i, --identity string   Identity of the actor
+  -f, --file string   File containing the query request
+  -h, --help          help for query
 ```
 
 ### Options inherited from parent commands
 
 ```
       --allowed-origins stringArray   List of origins to allow for CORS requests
+  -i, --identity string               ACP Identity
       --log-format string             Log format to use. Options are text or json (default "text")
       --log-level string              Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string             Log output path. Options are stderr or stdout. (default "stderr")

--- a/docs/cli/defradb_client_schema.md
+++ b/docs/cli/defradb_client_schema.md
@@ -16,6 +16,7 @@ Make changes, updates, or look for existing schema types.
 
 ```
       --allowed-origins stringArray   List of origins to allow for CORS requests
+  -i, --identity string               ACP Identity
       --log-format string             Log format to use. Options are text or json (default "text")
       --log-level string              Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string             Log output path. Options are stderr or stdout. (default "stderr")

--- a/docs/cli/defradb_client_schema_add.md
+++ b/docs/cli/defradb_client_schema_add.md
@@ -37,6 +37,7 @@ defradb client schema add [schema] [flags]
 
 ```
       --allowed-origins stringArray   List of origins to allow for CORS requests
+  -i, --identity string               ACP Identity
       --log-format string             Log format to use. Options are text or json (default "text")
       --log-level string              Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string             Log output path. Options are stderr or stdout. (default "stderr")

--- a/docs/cli/defradb_client_schema_describe.md
+++ b/docs/cli/defradb_client_schema_describe.md
@@ -36,6 +36,7 @@ defradb client schema describe [flags]
 
 ```
       --allowed-origins stringArray   List of origins to allow for CORS requests
+  -i, --identity string               ACP Identity
       --log-format string             Log format to use. Options are text or json (default "text")
       --log-level string              Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string             Log output path. Options are stderr or stdout. (default "stderr")

--- a/docs/cli/defradb_client_schema_migration.md
+++ b/docs/cli/defradb_client_schema_migration.md
@@ -16,6 +16,7 @@ Make set or look for existing schema migrations on a DefraDB node.
 
 ```
       --allowed-origins stringArray   List of origins to allow for CORS requests
+  -i, --identity string               ACP Identity
       --log-format string             Log format to use. Options are text or json (default "text")
       --log-level string              Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string             Log output path. Options are stderr or stdout. (default "stderr")

--- a/docs/cli/defradb_client_schema_migration_down.md
+++ b/docs/cli/defradb_client_schema_migration_down.md
@@ -33,6 +33,7 @@ defradb client schema migration down --collection <collectionID> <documents> [fl
 
 ```
       --allowed-origins stringArray   List of origins to allow for CORS requests
+  -i, --identity string               ACP Identity
       --log-format string             Log format to use. Options are text or json (default "text")
       --log-level string              Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string             Log output path. Options are stderr or stdout. (default "stderr")

--- a/docs/cli/defradb_client_schema_migration_reload.md
+++ b/docs/cli/defradb_client_schema_migration_reload.md
@@ -20,6 +20,7 @@ defradb client schema migration reload [flags]
 
 ```
       --allowed-origins stringArray   List of origins to allow for CORS requests
+  -i, --identity string               ACP Identity
       --log-format string             Log format to use. Options are text or json (default "text")
       --log-level string              Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string             Log output path. Options are stderr or stdout. (default "stderr")

--- a/docs/cli/defradb_client_schema_migration_set-registry.md
+++ b/docs/cli/defradb_client_schema_migration_set-registry.md
@@ -26,6 +26,7 @@ defradb client schema migration set-registry [collectionID] [cfg] [flags]
 
 ```
       --allowed-origins stringArray   List of origins to allow for CORS requests
+  -i, --identity string               ACP Identity
       --log-format string             Log format to use. Options are text or json (default "text")
       --log-level string              Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string             Log output path. Options are stderr or stdout. (default "stderr")

--- a/docs/cli/defradb_client_schema_migration_set.md
+++ b/docs/cli/defradb_client_schema_migration_set.md
@@ -33,6 +33,7 @@ defradb client schema migration set [src] [dst] [cfg] [flags]
 
 ```
       --allowed-origins stringArray   List of origins to allow for CORS requests
+  -i, --identity string               ACP Identity
       --log-format string             Log format to use. Options are text or json (default "text")
       --log-level string              Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string             Log output path. Options are stderr or stdout. (default "stderr")

--- a/docs/cli/defradb_client_schema_migration_up.md
+++ b/docs/cli/defradb_client_schema_migration_up.md
@@ -33,6 +33,7 @@ defradb client schema migration up --collection <collectionID> <documents> [flag
 
 ```
       --allowed-origins stringArray   List of origins to allow for CORS requests
+  -i, --identity string               ACP Identity
       --log-format string             Log format to use. Options are text or json (default "text")
       --log-level string              Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string             Log output path. Options are stderr or stdout. (default "stderr")

--- a/docs/cli/defradb_client_schema_patch.md
+++ b/docs/cli/defradb_client_schema_patch.md
@@ -36,6 +36,7 @@ defradb client schema patch [schema] [migration] [flags]
 
 ```
       --allowed-origins stringArray   List of origins to allow for CORS requests
+  -i, --identity string               ACP Identity
       --log-format string             Log format to use. Options are text or json (default "text")
       --log-level string              Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string             Log output path. Options are stderr or stdout. (default "stderr")

--- a/docs/cli/defradb_client_schema_set-active.md
+++ b/docs/cli/defradb_client_schema_set-active.md
@@ -21,6 +21,7 @@ defradb client schema set-active [versionID] [flags]
 
 ```
       --allowed-origins stringArray   List of origins to allow for CORS requests
+  -i, --identity string               ACP Identity
       --log-format string             Log format to use. Options are text or json (default "text")
       --log-level string              Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string             Log output path. Options are stderr or stdout. (default "stderr")

--- a/docs/cli/defradb_client_tx.md
+++ b/docs/cli/defradb_client_tx.md
@@ -16,6 +16,7 @@ Create, commit, and discard DefraDB transactions
 
 ```
       --allowed-origins stringArray   List of origins to allow for CORS requests
+  -i, --identity string               ACP Identity
       --log-format string             Log format to use. Options are text or json (default "text")
       --log-level string              Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string             Log output path. Options are stderr or stdout. (default "stderr")

--- a/docs/cli/defradb_client_tx_commit.md
+++ b/docs/cli/defradb_client_tx_commit.md
@@ -20,6 +20,7 @@ defradb client tx commit [id] [flags]
 
 ```
       --allowed-origins stringArray   List of origins to allow for CORS requests
+  -i, --identity string               ACP Identity
       --log-format string             Log format to use. Options are text or json (default "text")
       --log-level string              Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string             Log output path. Options are stderr or stdout. (default "stderr")

--- a/docs/cli/defradb_client_tx_create.md
+++ b/docs/cli/defradb_client_tx_create.md
@@ -22,6 +22,7 @@ defradb client tx create [flags]
 
 ```
       --allowed-origins stringArray   List of origins to allow for CORS requests
+  -i, --identity string               ACP Identity
       --log-format string             Log format to use. Options are text or json (default "text")
       --log-level string              Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string             Log output path. Options are stderr or stdout. (default "stderr")

--- a/docs/cli/defradb_client_tx_discard.md
+++ b/docs/cli/defradb_client_tx_discard.md
@@ -20,6 +20,7 @@ defradb client tx discard [id] [flags]
 
 ```
       --allowed-origins stringArray   List of origins to allow for CORS requests
+  -i, --identity string               ACP Identity
       --log-format string             Log format to use. Options are text or json (default "text")
       --log-level string              Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string             Log output path. Options are stderr or stdout. (default "stderr")

--- a/docs/cli/defradb_client_view.md
+++ b/docs/cli/defradb_client_view.md
@@ -16,6 +16,7 @@ Manage (add) views withing a running DefraDB instance
 
 ```
       --allowed-origins stringArray   List of origins to allow for CORS requests
+  -i, --identity string               ACP Identity
       --log-format string             Log format to use. Options are text or json (default "text")
       --log-level string              Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string             Log output path. Options are stderr or stdout. (default "stderr")

--- a/docs/cli/defradb_client_view_add.md
+++ b/docs/cli/defradb_client_view_add.md
@@ -26,6 +26,7 @@ defradb client view add [query] [sdl] [transform] [flags]
 
 ```
       --allowed-origins stringArray   List of origins to allow for CORS requests
+  -i, --identity string               ACP Identity
       --log-format string             Log format to use. Options are text or json (default "text")
       --log-level string              Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string             Log output path. Options are stderr or stdout. (default "stderr")

--- a/http/client.go
+++ b/http/client.go
@@ -339,7 +339,6 @@ func (c *Client) GetAllIndexes(ctx context.Context) (map[client.CollectionName][
 
 func (c *Client) ExecRequest(
 	ctx context.Context,
-	identity immutable.Option[string],
 	query string,
 ) *client.RequestResult {
 	methodURL := c.http.baseURL.JoinPath("graphql")
@@ -356,7 +355,6 @@ func (c *Client) ExecRequest(
 		return result
 	}
 	c.http.setDefaultHeaders(req)
-	addIdentityToAuthHeaderIfExists(req, identity)
 
 	res, err := c.http.client.Do(req)
 	if err != nil {

--- a/http/client_acp.go
+++ b/http/client_acp.go
@@ -11,44 +11,24 @@
 package http
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"net/http"
+	"strings"
 
 	"github.com/sourcenetwork/defradb/client"
 )
 
-// AddPolicyResult wraps the result of successfully adding/registering a Policy.
-type AddPolicyRequest struct {
-	// Policy body in JSON or YAML format.
-	Policy string `json:"policy"`
-	// CreatorID is the acp identity of the policy creator.
-	CreatorID string `json:"creator_id"`
-}
-
 func (c *Client) AddPolicy(
 	ctx context.Context,
-	creator string,
 	policy string,
 ) (client.AddPolicyResult, error) {
 	methodURL := c.http.baseURL.JoinPath("acp", "policy")
-
-	addPolicyRequest := AddPolicyRequest{
-		Policy:    policy,
-		CreatorID: creator,
-	}
-
-	addPolicyBody, err := json.Marshal(addPolicyRequest)
-	if err != nil {
-		return client.AddPolicyResult{}, err
-	}
 
 	req, err := http.NewRequestWithContext(
 		ctx,
 		http.MethodPost,
 		methodURL.String(),
-		bytes.NewBuffer(addPolicyBody),
+		strings.NewReader(policy),
 	)
 
 	if err != nil {

--- a/http/client_acp.go
+++ b/http/client_acp.go
@@ -23,6 +23,8 @@ import (
 type AddPolicyRequest struct {
 	// Policy body in JSON or YAML format.
 	Policy string `json:"policy"`
+	// CreateID is the acp identity of the policy creator.
+	CreateID string `json:"creator_id"`
 }
 
 func (c *Client) AddPolicy(
@@ -33,7 +35,8 @@ func (c *Client) AddPolicy(
 	methodURL := c.http.baseURL.JoinPath("acp", "policy")
 
 	addPolicyRequest := AddPolicyRequest{
-		Policy: policy,
+		Policy:   policy,
+		CreateID: creator,
 	}
 
 	addPolicyBody, err := json.Marshal(addPolicyRequest)

--- a/http/client_acp.go
+++ b/http/client_acp.go
@@ -48,8 +48,6 @@ func (c *Client) AddPolicy(
 		bytes.NewBuffer(addPolicyBody),
 	)
 
-	addIdentityToAuthHeader(req, creator)
-
 	if err != nil {
 		return client.AddPolicyResult{}, err
 	}

--- a/http/client_acp.go
+++ b/http/client_acp.go
@@ -23,8 +23,8 @@ import (
 type AddPolicyRequest struct {
 	// Policy body in JSON or YAML format.
 	Policy string `json:"policy"`
-	// CreateID is the acp identity of the policy creator.
-	CreateID string `json:"creator_id"`
+	// CreatorID is the acp identity of the policy creator.
+	CreatorID string `json:"creator_id"`
 }
 
 func (c *Client) AddPolicy(
@@ -35,8 +35,8 @@ func (c *Client) AddPolicy(
 	methodURL := c.http.baseURL.JoinPath("acp", "policy")
 
 	addPolicyRequest := AddPolicyRequest{
-		Policy:   policy,
-		CreateID: creator,
+		Policy:    policy,
+		CreatorID: creator,
 	}
 
 	addPolicyBody, err := json.Marshal(addPolicyRequest)

--- a/http/handler.go
+++ b/http/handler.go
@@ -81,6 +81,7 @@ func NewHandler(db client.DB) (*Handler, error) {
 		r.Use(
 			ApiMiddleware(db, txs),
 			TransactionMiddleware,
+			IdentityMiddleware,
 		)
 		r.Handle("/*", router)
 	})

--- a/http/handler_acp.go
+++ b/http/handler_acp.go
@@ -15,15 +15,13 @@ import (
 
 	"github.com/getkin/kin-openapi/openapi3"
 
-	"github.com/sourcenetwork/defradb/acp"
 	"github.com/sourcenetwork/defradb/client"
-	"github.com/sourcenetwork/defradb/db"
 )
 
 type acpHandler struct{}
 
 func (s *acpHandler) AddPolicy(rw http.ResponseWriter, req *http.Request) {
-	d, ok := req.Context().Value(dbContextKey).(client.DB)
+	db, ok := req.Context().Value(dbContextKey).(client.DB)
 	if !ok {
 		responseJSON(rw, http.StatusBadRequest, errorResponse{NewErrFailedToGetContext("db")})
 		return
@@ -35,15 +33,9 @@ func (s *acpHandler) AddPolicy(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	identity, ok := db.TryGetContextIdentity(req.Context())
-	if !ok || !identity.HasValue() {
-		responseJSON(rw, http.StatusBadRequest, errorResponse{acp.ErrPolicyCreatorMustNotBeEmpty})
-		return
-	}
-
-	addPolicyResult, err := d.AddPolicy(
+	addPolicyResult, err := db.AddPolicy(
 		req.Context(),
-		identity.Value(),
+		addPolicyRequest.CreateID,
 		addPolicyRequest.Policy,
 	)
 	if err != nil {

--- a/http/handler_acp.go
+++ b/http/handler_acp.go
@@ -35,7 +35,7 @@ func (s *acpHandler) AddPolicy(rw http.ResponseWriter, req *http.Request) {
 
 	addPolicyResult, err := db.AddPolicy(
 		req.Context(),
-		addPolicyRequest.CreateID,
+		addPolicyRequest.CreatorID,
 		addPolicyRequest.Policy,
 	)
 	if err != nil {

--- a/http/handler_acp.go
+++ b/http/handler_acp.go
@@ -11,6 +11,7 @@
 package http
 
 import (
+	"io"
 	"net/http"
 
 	"github.com/getkin/kin-openapi/openapi3"
@@ -27,16 +28,15 @@ func (s *acpHandler) AddPolicy(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	var addPolicyRequest AddPolicyRequest
-	if err := requestJSON(req, &addPolicyRequest); err != nil {
+	policyBytes, err := io.ReadAll(req.Body)
+	if err != nil {
 		responseJSON(rw, http.StatusBadRequest, errorResponse{err})
 		return
 	}
 
 	addPolicyResult, err := db.AddPolicy(
 		req.Context(),
-		addPolicyRequest.CreatorID,
-		addPolicyRequest.Policy,
+		string(policyBytes),
 	)
 	if err != nil {
 		responseJSON(rw, http.StatusBadRequest, errorResponse{err})
@@ -53,13 +53,10 @@ func (h *acpHandler) bindRoutes(router *Router) {
 	errorResponse := &openapi3.ResponseRef{
 		Ref: "#/components/responses/error",
 	}
-	acpAddPolicySchema := &openapi3.SchemaRef{
-		Ref: "#/components/schemas/add_policy_request",
-	}
 
 	acpAddPolicyRequest := openapi3.NewRequestBody().
 		WithRequired(true).
-		WithJSONSchemaRef(acpAddPolicySchema)
+		WithContent(openapi3.NewContentWithSchema(openapi3.NewStringSchema(), []string{"text/plain"}))
 
 	acpAddPolicy := openapi3.NewOperation()
 	acpAddPolicy.OperationID = "add policy"

--- a/http/handler_ccip.go
+++ b/http/handler_ccip.go
@@ -60,8 +60,7 @@ func (c *ccipHandler) ExecCCIP(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	identity := getIdentityFromAuthHeader(req)
-	result := store.ExecRequest(req.Context(), identity, request.Query)
+	result := store.ExecRequest(req.Context(), request.Query)
 	if result.Pub != nil {
 		responseJSON(rw, http.StatusBadRequest, errorResponse{ErrStreamingNotSupported})
 		return

--- a/http/handler_ccip_test.go
+++ b/http/handler_ccip_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/datastore/memory"
 	"github.com/sourcenetwork/defradb/db"
@@ -207,7 +206,7 @@ func setupDatabase(t *testing.T) client.DB {
 	doc, err := client.NewDocFromJSON([]byte(`{"name": "bob"}`), col.Schema())
 	require.NoError(t, err)
 
-	err = col.Create(ctx, acpIdentity.NoIdentity, doc)
+	err = col.Create(ctx, doc)
 	require.NoError(t, err)
 
 	return cdb

--- a/http/handler_collection.go
+++ b/http/handler_collection.go
@@ -47,8 +47,6 @@ func (s *collectionHandler) Create(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	identity := getIdentityFromAuthHeader(req)
-
 	switch {
 	case client.IsJSONArray(data):
 		docList, err := client.NewDocsFromJSON(data, col.Schema())
@@ -57,7 +55,7 @@ func (s *collectionHandler) Create(rw http.ResponseWriter, req *http.Request) {
 			return
 		}
 
-		if err := col.CreateMany(req.Context(), identity, docList); err != nil {
+		if err := col.CreateMany(req.Context(), docList); err != nil {
 			responseJSON(rw, http.StatusBadRequest, errorResponse{err})
 			return
 		}
@@ -68,7 +66,7 @@ func (s *collectionHandler) Create(rw http.ResponseWriter, req *http.Request) {
 			responseJSON(rw, http.StatusBadRequest, errorResponse{err})
 			return
 		}
-		if err := col.Create(req.Context(), identity, doc); err != nil {
+		if err := col.Create(req.Context(), doc); err != nil {
 			responseJSON(rw, http.StatusBadRequest, errorResponse{err})
 			return
 		}
@@ -85,11 +83,9 @@ func (s *collectionHandler) DeleteWith(rw http.ResponseWriter, req *http.Request
 		return
 	}
 
-	identity := getIdentityFromAuthHeader(req)
-
 	switch {
 	case request.Filter != nil:
-		result, err := col.DeleteWith(req.Context(), identity, request.Filter)
+		result, err := col.DeleteWith(req.Context(), request.Filter)
 		if err != nil {
 			responseJSON(rw, http.StatusBadRequest, errorResponse{err})
 			return
@@ -101,7 +97,7 @@ func (s *collectionHandler) DeleteWith(rw http.ResponseWriter, req *http.Request
 			responseJSON(rw, http.StatusBadRequest, errorResponse{err})
 			return
 		}
-		result, err := col.DeleteWith(req.Context(), identity, docID)
+		result, err := col.DeleteWith(req.Context(), docID)
 		if err != nil {
 			responseJSON(rw, http.StatusBadRequest, errorResponse{err})
 			return
@@ -117,7 +113,7 @@ func (s *collectionHandler) DeleteWith(rw http.ResponseWriter, req *http.Request
 			}
 			docIDs = append(docIDs, docID)
 		}
-		result, err := col.DeleteWith(req.Context(), identity, docIDs)
+		result, err := col.DeleteWith(req.Context(), docIDs)
 		if err != nil {
 			responseJSON(rw, http.StatusBadRequest, errorResponse{err})
 			return
@@ -137,11 +133,9 @@ func (s *collectionHandler) UpdateWith(rw http.ResponseWriter, req *http.Request
 		return
 	}
 
-	identity := getIdentityFromAuthHeader(req)
-
 	switch {
 	case request.Filter != nil:
-		result, err := col.UpdateWith(req.Context(), identity, request.Filter, request.Updater)
+		result, err := col.UpdateWith(req.Context(), request.Filter, request.Updater)
 		if err != nil {
 			responseJSON(rw, http.StatusBadRequest, errorResponse{err})
 			return
@@ -153,7 +147,7 @@ func (s *collectionHandler) UpdateWith(rw http.ResponseWriter, req *http.Request
 			responseJSON(rw, http.StatusBadRequest, errorResponse{err})
 			return
 		}
-		result, err := col.UpdateWith(req.Context(), identity, docID, request.Updater)
+		result, err := col.UpdateWith(req.Context(), docID, request.Updater)
 		if err != nil {
 			responseJSON(rw, http.StatusBadRequest, errorResponse{err})
 			return
@@ -169,7 +163,7 @@ func (s *collectionHandler) UpdateWith(rw http.ResponseWriter, req *http.Request
 			}
 			docIDs = append(docIDs, docID)
 		}
-		result, err := col.UpdateWith(req.Context(), identity, docIDs, request.Updater)
+		result, err := col.UpdateWith(req.Context(), docIDs, request.Updater)
 		if err != nil {
 			responseJSON(rw, http.StatusBadRequest, errorResponse{err})
 			return
@@ -189,9 +183,7 @@ func (s *collectionHandler) Update(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	identity := getIdentityFromAuthHeader(req)
-
-	doc, err := col.Get(req.Context(), identity, docID, true)
+	doc, err := col.Get(req.Context(), docID, true)
 	if err != nil {
 		responseJSON(rw, http.StatusBadRequest, errorResponse{err})
 		return
@@ -211,7 +203,7 @@ func (s *collectionHandler) Update(rw http.ResponseWriter, req *http.Request) {
 		responseJSON(rw, http.StatusBadRequest, errorResponse{err})
 		return
 	}
-	err = col.Update(req.Context(), identity, doc)
+	err = col.Update(req.Context(), doc)
 	if err != nil {
 		responseJSON(rw, http.StatusBadRequest, errorResponse{err})
 		return
@@ -228,9 +220,7 @@ func (s *collectionHandler) Delete(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	identity := getIdentityFromAuthHeader(req)
-
-	_, err = col.Delete(req.Context(), identity, docID)
+	_, err = col.Delete(req.Context(), docID)
 	if err != nil {
 		responseJSON(rw, http.StatusBadRequest, errorResponse{err})
 		return
@@ -248,9 +238,7 @@ func (s *collectionHandler) Get(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	identity := getIdentityFromAuthHeader(req)
-
-	doc, err := col.Get(req.Context(), identity, docID, showDeleted)
+	doc, err := col.Get(req.Context(), docID, showDeleted)
 	if err != nil {
 		responseJSON(rw, http.StatusBadRequest, errorResponse{err})
 		return
@@ -283,9 +271,7 @@ func (s *collectionHandler) GetAllDocIDs(rw http.ResponseWriter, req *http.Reque
 		return
 	}
 
-	identity := getIdentityFromAuthHeader(req)
-
-	docIDsResult, err := col.GetAllDocIDs(req.Context(), identity)
+	docIDsResult, err := col.GetAllDocIDs(req.Context())
 	if err != nil {
 		responseJSON(rw, http.StatusBadRequest, errorResponse{err})
 		return

--- a/http/handler_store.go
+++ b/http/handler_store.go
@@ -312,8 +312,7 @@ func (s *storeHandler) ExecRequest(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	identity := getIdentityFromAuthHeader(req)
-	result := store.ExecRequest(req.Context(), identity, request.Query)
+	result := store.ExecRequest(req.Context(), request.Query)
 
 	if result.Pub == nil {
 		responseJSON(rw, http.StatusOK, GraphQLResponse{result.GQL.Data, result.GQL.Errors})

--- a/http/http_client.go
+++ b/http/http_client.go
@@ -18,7 +18,6 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/db"
 )
 
@@ -51,8 +50,8 @@ func (c *httpClient) setDefaultHeaders(req *http.Request) {
 		req.Header.Set(txHeaderName, fmt.Sprintf("%d", txn.ID()))
 	}
 	id := db.GetContextIdentity(req.Context())
-	if id != identity.None {
-		req.Header.Add(authHeaderName, authSchemaPrefix+id.String())
+	if id.HasValue() {
+		req.Header.Add(authHeaderName, authSchemaPrefix+id.Value().String())
 	}
 }
 

--- a/http/http_client.go
+++ b/http/http_client.go
@@ -47,7 +47,11 @@ func (c *httpClient) setDefaultHeaders(req *http.Request) {
 
 	txn, ok := db.TryGetContextTxn(req.Context())
 	if ok {
-		req.Header.Set(TX_HEADER_NAME, fmt.Sprintf("%d", txn.ID()))
+		req.Header.Set(txHeaderName, fmt.Sprintf("%d", txn.ID()))
+	}
+	id, ok := db.TryGetContextIdentity(req.Context())
+	if ok && id.HasValue() {
+		req.Header.Add(authHeaderName, authSchemaPrefix+id.Value())
 	}
 }
 

--- a/http/http_client.go
+++ b/http/http_client.go
@@ -49,8 +49,8 @@ func (c *httpClient) setDefaultHeaders(req *http.Request) {
 	if ok {
 		req.Header.Set(txHeaderName, fmt.Sprintf("%d", txn.ID()))
 	}
-	id, ok := db.TryGetContextIdentity(req.Context())
-	if ok && id.HasValue() {
+	id := db.GetContextIdentity(req.Context())
+	if id.HasValue() {
 		req.Header.Add(authHeaderName, authSchemaPrefix+id.Value())
 	}
 }

--- a/http/http_client.go
+++ b/http/http_client.go
@@ -18,6 +18,7 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/db"
 )
 
@@ -50,8 +51,8 @@ func (c *httpClient) setDefaultHeaders(req *http.Request) {
 		req.Header.Set(txHeaderName, fmt.Sprintf("%d", txn.ID()))
 	}
 	id := db.GetContextIdentity(req.Context())
-	if id.HasValue() {
-		req.Header.Add(authHeaderName, authSchemaPrefix+id.Value())
+	if id != identity.NoIdentity {
+		req.Header.Add(authHeaderName, authSchemaPrefix+id.String())
 	}
 }
 

--- a/http/http_client.go
+++ b/http/http_client.go
@@ -51,7 +51,7 @@ func (c *httpClient) setDefaultHeaders(req *http.Request) {
 		req.Header.Set(txHeaderName, fmt.Sprintf("%d", txn.ID()))
 	}
 	id := db.GetContextIdentity(req.Context())
-	if id != identity.NoIdentity {
+	if id != identity.None {
 		req.Header.Add(authHeaderName, authSchemaPrefix+id.String())
 	}
 }

--- a/http/middleware.go
+++ b/http/middleware.go
@@ -21,7 +21,7 @@ import (
 	"github.com/go-chi/cors"
 	"golang.org/x/exp/slices"
 
-	"github.com/sourcenetwork/defradb/acp/identity"
+	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/datastore"
 	"github.com/sourcenetwork/defradb/db"
@@ -132,14 +132,14 @@ func IdentityMiddleware(next http.Handler) http.Handler {
 			return
 		}
 
-		id := strings.TrimPrefix(authHeader, authSchemaPrefix)
+		identity := strings.TrimPrefix(authHeader, authSchemaPrefix)
 		// If expected schema prefix was not found, or empty, then assume no identity.
-		if id == authHeader || id == "" {
+		if identity == authHeader || identity == "" {
 			next.ServeHTTP(rw, req)
 			return
 		}
 
-		ctx := db.SetContextIdentity(req.Context(), identity.New(id))
+		ctx := db.SetContextIdentity(req.Context(), acpIdentity.New(identity))
 		next.ServeHTTP(rw, req.WithContext(ctx))
 	})
 }

--- a/http/middleware.go
+++ b/http/middleware.go
@@ -139,7 +139,7 @@ func IdentityMiddleware(next http.Handler) http.Handler {
 			return
 		}
 
-		ctx := db.SetContextIdentity(req.Context(), identity.NewIdentity(id))
+		ctx := db.SetContextIdentity(req.Context(), identity.New(id))
 		next.ServeHTTP(rw, req.WithContext(ctx))
 	})
 }

--- a/http/middleware.go
+++ b/http/middleware.go
@@ -21,7 +21,7 @@ import (
 	"github.com/go-chi/cors"
 	"golang.org/x/exp/slices"
 
-	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
+	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/datastore"
 	"github.com/sourcenetwork/defradb/db"
@@ -132,14 +132,14 @@ func IdentityMiddleware(next http.Handler) http.Handler {
 			return
 		}
 
-		identity := strings.TrimPrefix(authHeader, authSchemaPrefix)
+		id := strings.TrimPrefix(authHeader, authSchemaPrefix)
 		// If expected schema prefix was not found, or empty, then assume no identity.
-		if identity == authHeader || identity == "" {
+		if id == authHeader || id == "" {
 			next.ServeHTTP(rw, req)
 			return
 		}
 
-		ctx := db.SetContextIdentity(req.Context(), acpIdentity.NewIdentity(identity))
+		ctx := db.SetContextIdentity(req.Context(), identity.NewIdentity(id))
 		next.ServeHTTP(rw, req.WithContext(ctx))
 	})
 }

--- a/http/middleware.go
+++ b/http/middleware.go
@@ -21,12 +21,23 @@ import (
 	"github.com/go-chi/cors"
 	"golang.org/x/exp/slices"
 
+	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/datastore"
 	"github.com/sourcenetwork/defradb/db"
 )
 
-const TX_HEADER_NAME = "x-defradb-tx"
+const (
+	// txHeaderName is the name of the transaction header.
+	// This header should contain a valid transaction id.
+	txHeaderName = "x-defradb-tx"
+	// authHeaderName is the name of the authorization header.
+	// This header should contain an ACP identity.
+	authHeaderName = "Authorization"
+	// Using Basic right now, but this will soon change to 'Bearer' as acp authentication
+	// gets implemented: https://github.com/sourcenetwork/defradb/issues/2017
+	authSchemaPrefix = "Basic "
+)
 
 type contextKey string
 
@@ -74,7 +85,7 @@ func TransactionMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		txs := req.Context().Value(txsContextKey).(*sync.Map)
 
-		txValue := req.Header.Get(TX_HEADER_NAME)
+		txValue := req.Header.Get(txHeaderName)
 		if txValue == "" {
 			next.ServeHTTP(rw, req)
 			return
@@ -109,6 +120,26 @@ func CollectionMiddleware(next http.Handler) http.Handler {
 		}
 
 		ctx := context.WithValue(req.Context(), colContextKey, col)
+		next.ServeHTTP(rw, req.WithContext(ctx))
+	})
+}
+
+func IdentityMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		authHeader := req.Header.Get(authHeaderName)
+		if authHeader == "" {
+			next.ServeHTTP(rw, req)
+			return
+		}
+
+		identity := strings.TrimPrefix(authHeader, authSchemaPrefix)
+		// If expected schema prefix was not found, or empty, then assume no identity.
+		if identity == authHeader || identity == "" {
+			next.ServeHTTP(rw, req)
+			return
+		}
+
+		ctx := db.SetContextIdentity(req.Context(), acpIdentity.NewIdentity(identity))
 		next.ServeHTTP(rw, req.WithContext(ctx))
 	})
 }

--- a/http/openapi.go
+++ b/http/openapi.go
@@ -40,7 +40,6 @@ var openApiSchemas = map[string]any{
 	"ccip_response":         &CCIPResponse{},
 	"patch_schema_request":  &patchSchemaRequest{},
 	"add_view_request":      &addViewRequest{},
-	"add_policy_request":    &AddPolicyRequest{},
 	"migrate_request":       &migrateRequest{},
 	"set_migration_request": &setMigrationRequest{},
 }

--- a/http/utils.go
+++ b/http/utils.go
@@ -15,21 +15,10 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 
-	"github.com/sourcenetwork/immutable"
-
-	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/datastore/badger/v4"
 )
-
-// Using Basic right now, but this will soon change to 'Bearer' as acp authentication
-// gets implemented: https://github.com/sourcenetwork/defradb/issues/2017
-const authSchemaPrefix = "Basic "
-
-// Name of authorization header
-const authHeaderName = "Authorization"
 
 func requestJSON(req *http.Request, out any) error {
 	data, err := io.ReadAll(req.Body)
@@ -54,39 +43,4 @@ func parseError(msg any) error {
 	default:
 		return fmt.Errorf("%s", msg)
 	}
-}
-
-// addIdentityToAuthHeader adds the identity to auth header as it must always exist.
-func addIdentityToAuthHeader(req *http.Request, identity string) {
-	// Create a bearer that will get added to authorization header.
-	bearerWithIdentity := authSchemaPrefix + identity
-
-	// Add the authorization header with the bearer containing identity.
-	req.Header.Add(authHeaderName, bearerWithIdentity)
-}
-
-// addIdentityToAuthHeaderIfExists adds the identity to auth header if it exsits, otherwise does nothing.
-func addIdentityToAuthHeaderIfExists(req *http.Request, identity immutable.Option[string]) {
-	// Do nothing if there is no identity to add.
-	if !identity.HasValue() {
-		return
-	}
-	addIdentityToAuthHeader(req, identity.Value())
-}
-
-// getIdentityFromAuthHeader tries to get the identity from the auth header, if it is found
-// with the expecte auth schema then it is returned, otherwise no identity is returned.
-func getIdentityFromAuthHeader(req *http.Request) immutable.Option[string] {
-	authHeader := req.Header.Get(authHeaderName)
-	if authHeader == "" {
-		return acpIdentity.NoIdentity
-	}
-
-	identity := strings.TrimPrefix(authHeader, authSchemaPrefix)
-	// If expected schema prefix was not found, or empty, then assume no identity.
-	if identity == authHeader || identity == "" {
-		return acpIdentity.NoIdentity
-	}
-
-	return acpIdentity.NewIdentity(identity)
 }

--- a/lens/fetcher.go
+++ b/lens/fetcher.go
@@ -19,7 +19,7 @@ import (
 	"github.com/sourcenetwork/immutable"
 
 	"github.com/sourcenetwork/defradb/acp"
-	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
+	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/request"
 	"github.com/sourcenetwork/defradb/core"
@@ -62,7 +62,7 @@ func NewFetcher(source fetcher.Fetcher, registry client.LensRegistry) fetcher.Fe
 
 func (f *lensedFetcher) Init(
 	ctx context.Context,
-	identity acpIdentity.Identity,
+	identity identity.Identity,
 	txn datastore.Txn,
 	acp immutable.Option[acp.ACP],
 	col client.Collection,

--- a/lens/fetcher.go
+++ b/lens/fetcher.go
@@ -19,6 +19,7 @@ import (
 	"github.com/sourcenetwork/immutable"
 
 	"github.com/sourcenetwork/defradb/acp"
+	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/request"
 	"github.com/sourcenetwork/defradb/core"
@@ -61,7 +62,7 @@ func NewFetcher(source fetcher.Fetcher, registry client.LensRegistry) fetcher.Fe
 
 func (f *lensedFetcher) Init(
 	ctx context.Context,
-	identity immutable.Option[string],
+	identity acpIdentity.Identity,
 	txn datastore.Txn,
 	acp immutable.Option[acp.ACP],
 	col client.Collection,

--- a/lens/fetcher.go
+++ b/lens/fetcher.go
@@ -19,7 +19,7 @@ import (
 	"github.com/sourcenetwork/immutable"
 
 	"github.com/sourcenetwork/defradb/acp"
-	"github.com/sourcenetwork/defradb/acp/identity"
+	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/request"
 	"github.com/sourcenetwork/defradb/core"
@@ -62,7 +62,7 @@ func NewFetcher(source fetcher.Fetcher, registry client.LensRegistry) fetcher.Fe
 
 func (f *lensedFetcher) Init(
 	ctx context.Context,
-	id immutable.Option[identity.Identity],
+	identity immutable.Option[acpIdentity.Identity],
 	txn datastore.Txn,
 	acp immutable.Option[acp.ACP],
 	col client.Collection,
@@ -114,7 +114,7 @@ historyLoop:
 	}
 	return f.source.Init(
 		ctx,
-		id,
+		identity,
 		txn,
 		acp,
 		col,

--- a/lens/fetcher.go
+++ b/lens/fetcher.go
@@ -62,7 +62,7 @@ func NewFetcher(source fetcher.Fetcher, registry client.LensRegistry) fetcher.Fe
 
 func (f *lensedFetcher) Init(
 	ctx context.Context,
-	identity identity.Identity,
+	id immutable.Option[identity.Identity],
 	txn datastore.Txn,
 	acp immutable.Option[acp.ACP],
 	col client.Collection,
@@ -114,7 +114,7 @@ historyLoop:
 	}
 	return f.source.Init(
 		ctx,
-		identity,
+		id,
 		txn,
 		acp,
 		col,

--- a/net/client_test.go
+++ b/net/client_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 
-	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/events"
 )
@@ -114,12 +113,12 @@ func TestPushlogW_WithValidPeerID_NoError(t *testing.T) {
 	doc, err := client.NewDocFromJSON([]byte(`{"name": "test"}`), col.Schema())
 	require.NoError(t, err)
 
-	err = col.Save(ctx, acpIdentity.NoIdentity, doc)
+	err = col.Save(ctx, doc)
 	require.NoError(t, err)
 
 	col, err = n2.db.GetCollectionByName(ctx, "User")
 	require.NoError(t, err)
-	err = col.Save(ctx, acpIdentity.NoIdentity, doc)
+	err = col.Save(ctx, doc)
 	require.NoError(t, err)
 
 	cid, err := createCID(doc)

--- a/net/dag_test.go
+++ b/net/dag_test.go
@@ -22,7 +22,6 @@ import (
 	mh "github.com/multiformats/go-multihash"
 	"github.com/stretchr/testify/require"
 
-	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/core"
 	"github.com/sourcenetwork/defradb/merkle/clock"
@@ -173,7 +172,7 @@ func TestSendJobWorker_WithPeer_NoError(t *testing.T) {
 	require.NoError(t, err)
 	dsKey := core.DataStoreKeyFromDocID(doc.ID())
 
-	err = col.Create(ctx, acpIdentity.NoIdentity, doc)
+	err = col.Create(ctx, doc)
 	require.NoError(t, err)
 
 	txn1, _ := db1.NewTxn(ctx, false)

--- a/net/peer_collection.go
+++ b/net/peer_collection.go
@@ -16,7 +16,6 @@ import (
 	dsq "github.com/ipfs/go-datastore/query"
 	"github.com/sourcenetwork/immutable"
 
-	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/core"
 	"github.com/sourcenetwork/defradb/db"
@@ -83,7 +82,7 @@ func (p *Peer) AddP2PCollections(ctx context.Context, collectionIDs []string) er
 	removedTopics := []string{}
 	for _, col := range storeCollections {
 		// TODO-ACP: Support ACP <> P2P - https://github.com/sourcenetwork/defradb/issues/2366
-		keyChan, err := col.GetAllDocIDs(p.ctx, acpIdentity.NoIdentity)
+		keyChan, err := col.GetAllDocIDs(p.ctx)
 		if err != nil {
 			return err
 		}
@@ -155,7 +154,7 @@ func (p *Peer) RemoveP2PCollections(ctx context.Context, collectionIDs []string)
 	addedTopics := []string{}
 	for _, col := range storeCollections {
 		// TODO-ACP: Support ACP <> P2P - https://github.com/sourcenetwork/defradb/issues/2366
-		keyChan, err := col.GetAllDocIDs(p.ctx, acpIdentity.NoIdentity)
+		keyChan, err := col.GetAllDocIDs(p.ctx)
 		if err != nil {
 			return err
 		}

--- a/net/peer_replicator.go
+++ b/net/peer_replicator.go
@@ -18,7 +18,6 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/peerstore"
 
-	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/core"
 	"github.com/sourcenetwork/defradb/db"
@@ -113,7 +112,7 @@ func (p *Peer) SetReplicator(ctx context.Context, rep client.Replicator) error {
 	// push all collection documents to the replicator peer
 	for _, col := range added {
 		// TODO-ACP: Support ACP <> P2P - https://github.com/sourcenetwork/defradb/issues/2366
-		keysCh, err := col.GetAllDocIDs(ctx, acpIdentity.NoIdentity)
+		keysCh, err := col.GetAllDocIDs(ctx)
 		if err != nil {
 			return NewErrReplicatorDocID(err, col.Name().Value(), rep.Info.ID)
 		}

--- a/net/peer_replicator.go
+++ b/net/peer_replicator.go
@@ -40,7 +40,8 @@ func (p *Peer) SetReplicator(ctx context.Context, rep client.Replicator) error {
 		return err
 	}
 
-	// set transaction for all operations
+	// TODO-ACP: Support ACP <> P2P - https://github.com/sourcenetwork/defradb/issues/2366
+	// ctx = db.SetContextIdentity(ctx, identity)
 	ctx = db.SetContextTxn(ctx, txn)
 
 	var collections []client.Collection
@@ -111,7 +112,6 @@ func (p *Peer) SetReplicator(ctx context.Context, rep client.Replicator) error {
 
 	// push all collection documents to the replicator peer
 	for _, col := range added {
-		// TODO-ACP: Support ACP <> P2P - https://github.com/sourcenetwork/defradb/issues/2366
 		keysCh, err := col.GetAllDocIDs(ctx)
 		if err != nil {
 			return NewErrReplicatorDocID(err, col.Name().Value(), rep.Info.ID)

--- a/net/peer_test.go
+++ b/net/peer_test.go
@@ -26,7 +26,6 @@ import (
 	rpc "github.com/sourcenetwork/go-libp2p-pubsub-rpc"
 	"github.com/stretchr/testify/require"
 
-	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/core/crdt"
 	"github.com/sourcenetwork/defradb/datastore/memory"
@@ -171,7 +170,7 @@ func TestNewPeer_WithExistingTopic_TopicAlreadyExistsError(t *testing.T) {
 	doc, err := client.NewDocFromJSON([]byte(`{"name": "John", "age": 30}`), col.Schema())
 	require.NoError(t, err)
 
-	err = col.Create(ctx, acpIdentity.NoIdentity, doc)
+	err = col.Create(ctx, doc)
 	require.NoError(t, err)
 
 	h, err := libp2p.New()
@@ -576,10 +575,10 @@ func TestPushToReplicator_SingleDocumentNoPeer_FailedToReplicateLogError(t *test
 	doc, err := client.NewDocFromJSON([]byte(`{"name": "John", "age": 30}`), col.Schema())
 	require.NoError(t, err)
 
-	err = col.Create(ctx, acpIdentity.NoIdentity, doc)
+	err = col.Create(ctx, doc)
 	require.NoError(t, err)
 
-	keysCh, err := col.GetAllDocIDs(ctx, acpIdentity.NoIdentity)
+	keysCh, err := col.GetAllDocIDs(ctx)
 	require.NoError(t, err)
 
 	txn, err := db.NewTxn(ctx, true)
@@ -940,7 +939,7 @@ func TestHandleDocCreateLog_NoError(t *testing.T) {
 	doc, err := client.NewDocFromJSON([]byte(`{"name": "John", "age": 30}`), col.Schema())
 	require.NoError(t, err)
 
-	err = col.Create(ctx, acpIdentity.NoIdentity, doc)
+	err = col.Create(ctx, doc)
 	require.NoError(t, err)
 
 	docCid, err := createCID(doc)
@@ -993,7 +992,7 @@ func TestHandleDocCreateLog_WithExistingTopic_TopicExistsError(t *testing.T) {
 	doc, err := client.NewDocFromJSON([]byte(`{"name": "John", "age": 30}`), col.Schema())
 	require.NoError(t, err)
 
-	err = col.Create(ctx, acpIdentity.NoIdentity, doc)
+	err = col.Create(ctx, doc)
 	require.NoError(t, err)
 
 	_, err = rpc.NewTopic(ctx, n.ps, n.host.ID(), doc.ID().String(), true)
@@ -1023,7 +1022,7 @@ func TestHandleDocUpdateLog_NoError(t *testing.T) {
 	doc, err := client.NewDocFromJSON([]byte(`{"name": "John", "age": 30}`), col.Schema())
 	require.NoError(t, err)
 
-	err = col.Create(ctx, acpIdentity.NoIdentity, doc)
+	err = col.Create(ctx, doc)
 	require.NoError(t, err)
 
 	docCid, err := createCID(doc)
@@ -1076,7 +1075,7 @@ func TestHandleDocUpdateLog_WithExistingDocIDTopic_TopicExistsError(t *testing.T
 	doc, err := client.NewDocFromJSON([]byte(`{"name": "John", "age": 30}`), col.Schema())
 	require.NoError(t, err)
 
-	err = col.Create(ctx, acpIdentity.NoIdentity, doc)
+	err = col.Create(ctx, doc)
 	require.NoError(t, err)
 
 	docCid, err := createCID(doc)
@@ -1120,7 +1119,7 @@ func TestHandleDocUpdateLog_WithExistingSchemaTopic_TopicExistsError(t *testing.
 	doc, err := client.NewDocFromJSON([]byte(`{"name": "John", "age": 30}`), col.Schema())
 	require.NoError(t, err)
 
-	err = col.Create(ctx, acpIdentity.NoIdentity, doc)
+	err = col.Create(ctx, doc)
 	require.NoError(t, err)
 
 	docCid, err := createCID(doc)

--- a/net/peer_test.go
+++ b/net/peer_test.go
@@ -26,6 +26,7 @@ import (
 	rpc "github.com/sourcenetwork/go-libp2p-pubsub-rpc"
 	"github.com/stretchr/testify/require"
 
+	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/core/crdt"
 	"github.com/sourcenetwork/defradb/datastore/memory"
@@ -395,7 +396,7 @@ func TestSetReplicator_NoError(t *testing.T) {
 // TODO-ACP: ACP <> P2P https://github.com/sourcenetwork/defradb/issues/2366
 func TestSetReplicatorWithACollectionSpecifiedThatHasPolicy_ReturnError(t *testing.T) {
 	ctx := context.Background()
-	db, n := newTestNode(ctx, t)
+	d, n := newTestNode(ctx, t)
 	defer n.Close()
 
 	policy := `
@@ -414,7 +415,8 @@ func TestSetReplicatorWithACollectionSpecifiedThatHasPolicy_ReturnError(t *testi
                 types:
                   - actor
     `
-	policyResult, err := db.AddPolicy(ctx, "cosmos1zzg43wdrhmmk89z3pmejwete2kkd4a3vn7w969", policy)
+	ctx = db.SetContextIdentity(ctx, identity.New("cosmos1zzg43wdrhmmk89z3pmejwete2kkd4a3vn7w969"))
+	policyResult, err := d.AddPolicy(ctx, policy)
 	policyID := policyResult.PolicyID
 	require.NoError(t, err)
 	require.Equal(t, "fc3a0a39c73949c70a79e02b8d928028e9cbcc772ba801463a6acdcf2f256cd4", policyID)
@@ -426,7 +428,7 @@ func TestSetReplicatorWithACollectionSpecifiedThatHasPolicy_ReturnError(t *testi
 		}
 	`, policyID,
 	)
-	_, err = db.AddSchema(ctx, schema)
+	_, err = d.AddSchema(ctx, schema)
 	require.NoError(t, err)
 
 	info, err := peer.AddrInfoFromString("/ip4/0.0.0.0/tcp/0/p2p/QmYyQSo1c1Ym7orWxLYvCrM2EmxFTANf8wXmmE7DWjhx5N")
@@ -445,7 +447,7 @@ func TestSetReplicatorWithACollectionSpecifiedThatHasPolicy_ReturnError(t *testi
 // TODO-ACP: ACP <> P2P https://github.com/sourcenetwork/defradb/issues/2366
 func TestSetReplicatorWithSomeCollectionThatHasPolicyUsingAllCollectionsByDefault_ReturnError(t *testing.T) {
 	ctx := context.Background()
-	db, n := newTestNode(ctx, t)
+	d, n := newTestNode(ctx, t)
 	defer n.Close()
 
 	policy := `
@@ -464,7 +466,8 @@ func TestSetReplicatorWithSomeCollectionThatHasPolicyUsingAllCollectionsByDefaul
                 types:
                   - actor
     `
-	policyResult, err := db.AddPolicy(ctx, "cosmos1zzg43wdrhmmk89z3pmejwete2kkd4a3vn7w969", policy)
+	ctx = db.SetContextIdentity(ctx, identity.New("cosmos1zzg43wdrhmmk89z3pmejwete2kkd4a3vn7w969"))
+	policyResult, err := d.AddPolicy(ctx, policy)
 	policyID := policyResult.PolicyID
 	require.NoError(t, err)
 	require.Equal(t, "fc3a0a39c73949c70a79e02b8d928028e9cbcc772ba801463a6acdcf2f256cd4", policyID)
@@ -476,7 +479,7 @@ func TestSetReplicatorWithSomeCollectionThatHasPolicyUsingAllCollectionsByDefaul
 		}
 	`, policyID,
 	)
-	_, err = db.AddSchema(ctx, schema)
+	_, err = d.AddSchema(ctx, schema)
 	require.NoError(t, err)
 
 	info, err := peer.AddrInfoFromString("/ip4/0.0.0.0/tcp/0/p2p/QmYyQSo1c1Ym7orWxLYvCrM2EmxFTANf8wXmmE7DWjhx5N")
@@ -803,7 +806,7 @@ func TestAddP2PCollections_WithInvalidCollectionID_NotFoundError(t *testing.T) {
 // TODO-ACP: ACP <> P2P https://github.com/sourcenetwork/defradb/issues/2366
 func TestAddP2PCollectionsWithPermissionedCollection_Error(t *testing.T) {
 	ctx := context.Background()
-	db, n := newTestNode(ctx, t)
+	d, n := newTestNode(ctx, t)
 	defer n.Close()
 
 	policy := `
@@ -822,7 +825,8 @@ func TestAddP2PCollectionsWithPermissionedCollection_Error(t *testing.T) {
                 types:
                   - actor
     `
-	policyResult, err := db.AddPolicy(ctx, "cosmos1zzg43wdrhmmk89z3pmejwete2kkd4a3vn7w969", policy)
+	ctx = db.SetContextIdentity(ctx, identity.New("cosmos1zzg43wdrhmmk89z3pmejwete2kkd4a3vn7w969"))
+	policyResult, err := d.AddPolicy(ctx, policy)
 	policyID := policyResult.PolicyID
 	require.NoError(t, err)
 	require.Equal(t, "fc3a0a39c73949c70a79e02b8d928028e9cbcc772ba801463a6acdcf2f256cd4", policyID)
@@ -834,10 +838,10 @@ func TestAddP2PCollectionsWithPermissionedCollection_Error(t *testing.T) {
 		}
 	`, policyID,
 	)
-	_, err = db.AddSchema(ctx, schema)
+	_, err = d.AddSchema(ctx, schema)
 	require.NoError(t, err)
 
-	col, err := db.GetCollectionByName(ctx, "User")
+	col, err := d.GetCollectionByName(ctx, "User")
 	require.NoError(t, err)
 
 	err = n.Peer.AddP2PCollections(ctx, []string{col.SchemaRoot()})

--- a/net/peer_test.go
+++ b/net/peer_test.go
@@ -26,7 +26,7 @@ import (
 	rpc "github.com/sourcenetwork/go-libp2p-pubsub-rpc"
 	"github.com/stretchr/testify/require"
 
-	"github.com/sourcenetwork/defradb/acp/identity"
+	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/core/crdt"
 	"github.com/sourcenetwork/defradb/datastore/memory"
@@ -415,7 +415,7 @@ func TestSetReplicatorWithACollectionSpecifiedThatHasPolicy_ReturnError(t *testi
                 types:
                   - actor
     `
-	ctx = db.SetContextIdentity(ctx, identity.New("cosmos1zzg43wdrhmmk89z3pmejwete2kkd4a3vn7w969"))
+	ctx = db.SetContextIdentity(ctx, acpIdentity.New("cosmos1zzg43wdrhmmk89z3pmejwete2kkd4a3vn7w969"))
 	policyResult, err := d.AddPolicy(ctx, policy)
 	policyID := policyResult.PolicyID
 	require.NoError(t, err)
@@ -466,7 +466,7 @@ func TestSetReplicatorWithSomeCollectionThatHasPolicyUsingAllCollectionsByDefaul
                 types:
                   - actor
     `
-	ctx = db.SetContextIdentity(ctx, identity.New("cosmos1zzg43wdrhmmk89z3pmejwete2kkd4a3vn7w969"))
+	ctx = db.SetContextIdentity(ctx, acpIdentity.New("cosmos1zzg43wdrhmmk89z3pmejwete2kkd4a3vn7w969"))
 	policyResult, err := d.AddPolicy(ctx, policy)
 	policyID := policyResult.PolicyID
 	require.NoError(t, err)
@@ -825,7 +825,7 @@ func TestAddP2PCollectionsWithPermissionedCollection_Error(t *testing.T) {
                 types:
                   - actor
     `
-	ctx = db.SetContextIdentity(ctx, identity.New("cosmos1zzg43wdrhmmk89z3pmejwete2kkd4a3vn7w969"))
+	ctx = db.SetContextIdentity(ctx, acpIdentity.New("cosmos1zzg43wdrhmmk89z3pmejwete2kkd4a3vn7w969"))
 	policyResult, err := d.AddPolicy(ctx, policy)
 	policyID := policyResult.PolicyID
 	require.NoError(t, err)

--- a/net/server.go
+++ b/net/server.go
@@ -29,7 +29,6 @@ import (
 	grpcpeer "google.golang.org/grpc/peer"
 	"google.golang.org/protobuf/proto"
 
-	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/core"
 	"github.com/sourcenetwork/defradb/datastore/badger/v4"
@@ -110,7 +109,7 @@ func newServer(p *Peer, db client.DB, opts ...grpc.DialOption) (*server, error) 
 				continue
 			}
 			// TODO-ACP: Support ACP <> P2P - https://github.com/sourcenetwork/defradb/issues/2366
-			docIDChan, err := col.GetAllDocIDs(p.ctx, acpIdentity.NoIdentity)
+			docIDChan, err := col.GetAllDocIDs(p.ctx)
 			if err != nil {
 				return nil, err
 			}
@@ -358,7 +357,7 @@ func (s *server) syncIndexedDocs(
 
 	//TODO-ACP: https://github.com/sourcenetwork/defradb/issues/2365
 	// Resolve while handling acp <> secondary indexes.
-	oldDoc, err := col.Get(oldCtx, acpIdentity.NoIdentity, docID, false)
+	oldDoc, err := col.Get(oldCtx, docID, false)
 	isNewDoc := errors.Is(err, client.ErrDocumentNotFoundOrNotAuthorized)
 	if !isNewDoc && err != nil {
 		return err
@@ -366,7 +365,7 @@ func (s *server) syncIndexedDocs(
 
 	//TODO-ACP: https://github.com/sourcenetwork/defradb/issues/2365
 	// Resolve while handling acp <> secondary indexes.
-	doc, err := col.Get(ctx, acpIdentity.NoIdentity, docID, false)
+	doc, err := col.Get(ctx, docID, false)
 	isDeletedDoc := errors.Is(err, client.ErrDocumentNotFoundOrNotAuthorized)
 	if !isDeletedDoc && err != nil {
 		return err

--- a/net/server_test.go
+++ b/net/server_test.go
@@ -18,11 +18,9 @@ import (
 	"github.com/libp2p/go-libp2p/core/event"
 	"github.com/libp2p/go-libp2p/core/host"
 	rpc "github.com/sourcenetwork/go-libp2p-pubsub-rpc"
-	"github.com/sourcenetwork/immutable"
 	"github.com/stretchr/testify/require"
 	grpcpeer "google.golang.org/grpc/peer"
 
-	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/datastore/memory"
 	"github.com/sourcenetwork/defradb/errors"
@@ -102,8 +100,6 @@ func (mCol *mockCollection) SchemaRoot() string {
 }
 func (mCol *mockCollection) GetAllDocIDs(
 	ctx context.Context,
-	identity immutable.Option[string],
-
 ) (<-chan client.DocIDResult, error) {
 	return nil, mockError
 }
@@ -140,7 +136,7 @@ func TestNewServerWithAddTopicError(t *testing.T) {
 	doc, err := client.NewDocFromJSON([]byte(`{"name": "John", "age": 30}`), col.Schema())
 	require.NoError(t, err)
 
-	err = col.Create(ctx, acpIdentity.NoIdentity, doc)
+	err = col.Create(ctx, doc)
 	require.NoError(t, err)
 
 	_, err = rpc.NewTopic(ctx, n.Peer.ps, n.Peer.host.ID(), doc.ID().String(), true)
@@ -186,7 +182,7 @@ func TestNewServerWithEmitterError(t *testing.T) {
 	doc, err := client.NewDocFromJSON([]byte(`{"name": "John", "age": 30}`), col.Schema())
 	require.NoError(t, err)
 
-	err = col.Create(ctx, acpIdentity.NoIdentity, doc)
+	err = col.Create(ctx, doc)
 	require.NoError(t, err)
 
 	n.Peer.host = &mockHost{n.Peer.host}

--- a/planner/create.go
+++ b/planner/create.go
@@ -80,7 +80,6 @@ func (n *createNode) Next() (bool, error) {
 
 	if err := n.collection.Create(
 		n.p.ctx,
-		n.p.identity,
 		n.doc,
 	); err != nil {
 		return false, err

--- a/planner/delete.go
+++ b/planner/delete.go
@@ -55,7 +55,6 @@ func (n *deleteNode) Next() (bool, error) {
 	}
 	_, err = n.collection.DeleteWithDocID(
 		n.p.ctx,
-		n.p.identity,
 		docID,
 	)
 	if err != nil {

--- a/planner/planner.go
+++ b/planner/planner.go
@@ -86,27 +86,27 @@ type PlanContext struct {
 // Planner combines session state and database state to
 // produce a request plan, which is run by the execution context.
 type Planner struct {
-	txn      datastore.Txn
-	identity identity.Identity
-	acp      immutable.Option[acp.ACP]
-	db       client.Store
+	txn datastore.Txn
+	id  immutable.Option[identity.Identity]
+	acp immutable.Option[acp.ACP]
+	db  client.Store
 
 	ctx context.Context
 }
 
 func New(
 	ctx context.Context,
-	identity identity.Identity,
+	id immutable.Option[identity.Identity],
 	acp immutable.Option[acp.ACP],
 	db client.Store,
 	txn datastore.Txn,
 ) *Planner {
 	return &Planner{
-		txn:      txn,
-		identity: identity,
-		acp:      acp,
-		db:       db,
-		ctx:      ctx,
+		txn: txn,
+		id:  id,
+		acp: acp,
+		db:  db,
+		ctx: ctx,
 	}
 }
 

--- a/planner/planner.go
+++ b/planner/planner.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sourcenetwork/immutable"
 
 	"github.com/sourcenetwork/defradb/acp"
+	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/request"
 	"github.com/sourcenetwork/defradb/connor"
@@ -86,7 +87,7 @@ type PlanContext struct {
 // produce a request plan, which is run by the execution context.
 type Planner struct {
 	txn      datastore.Txn
-	identity immutable.Option[string]
+	identity identity.Identity
 	acp      immutable.Option[acp.ACP]
 	db       client.Store
 
@@ -95,7 +96,7 @@ type Planner struct {
 
 func New(
 	ctx context.Context,
-	identity immutable.Option[string],
+	identity identity.Identity,
 	acp immutable.Option[acp.ACP],
 	db client.Store,
 	txn datastore.Txn,

--- a/planner/planner.go
+++ b/planner/planner.go
@@ -16,7 +16,7 @@ import (
 	"github.com/sourcenetwork/immutable"
 
 	"github.com/sourcenetwork/defradb/acp"
-	"github.com/sourcenetwork/defradb/acp/identity"
+	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/request"
 	"github.com/sourcenetwork/defradb/connor"
@@ -86,27 +86,27 @@ type PlanContext struct {
 // Planner combines session state and database state to
 // produce a request plan, which is run by the execution context.
 type Planner struct {
-	txn datastore.Txn
-	id  immutable.Option[identity.Identity]
-	acp immutable.Option[acp.ACP]
-	db  client.Store
+	txn      datastore.Txn
+	identity immutable.Option[acpIdentity.Identity]
+	acp      immutable.Option[acp.ACP]
+	db       client.Store
 
 	ctx context.Context
 }
 
 func New(
 	ctx context.Context,
-	id immutable.Option[identity.Identity],
+	identity immutable.Option[acpIdentity.Identity],
 	acp immutable.Option[acp.ACP],
 	db client.Store,
 	txn datastore.Txn,
 ) *Planner {
 	return &Planner{
-		txn: txn,
-		id:  id,
-		acp: acp,
-		db:  db,
-		ctx: ctx,
+		txn:      txn,
+		identity: identity,
+		acp:      acp,
+		db:       db,
+		ctx:      ctx,
 	}
 }
 

--- a/planner/scan.go
+++ b/planner/scan.go
@@ -64,7 +64,7 @@ func (n *scanNode) Init() error {
 	// init the fetcher
 	if err := n.fetcher.Init(
 		n.p.ctx,
-		n.p.id,
+		n.p.identity,
 		n.p.txn,
 		n.p.acp,
 		n.col,

--- a/planner/scan.go
+++ b/planner/scan.go
@@ -64,7 +64,7 @@ func (n *scanNode) Init() error {
 	// init the fetcher
 	if err := n.fetcher.Init(
 		n.p.ctx,
-		n.p.identity,
+		n.p.id,
 		n.p.txn,
 		n.p.acp,
 		n.col,

--- a/planner/update.go
+++ b/planner/update.go
@@ -72,7 +72,7 @@ func (n *updateNode) Next() (bool, error) {
 			if err != nil {
 				return false, err
 			}
-			_, err = n.collection.UpdateWithDocID(n.p.ctx, n.p.identity, docID, string(patch))
+			_, err = n.collection.UpdateWithDocID(n.p.ctx, docID, string(patch))
 			if err != nil {
 				return false, err
 			}

--- a/tests/bench/bench_util.go
+++ b/tests/bench/bench_util.go
@@ -22,7 +22,6 @@ import (
 	"github.com/sourcenetwork/badger/v4"
 	"github.com/sourcenetwork/corelog"
 
-	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/errors"
 	"github.com/sourcenetwork/defradb/tests/bench/fixtures"
@@ -171,7 +170,7 @@ func BackfillBenchmarkDB(
 						// in place. The error check could prob use a wrap system
 						// but its fine :).
 						for {
-							if err := cols[j].Create(ctx, acpIdentity.NoIdentity, doc); err != nil &&
+							if err := cols[j].Create(ctx, doc); err != nil &&
 								err.Error() == badger.ErrConflict.Error() {
 								log.InfoContext(
 									ctx,

--- a/tests/bench/collection/utils.go
+++ b/tests/bench/collection/utils.go
@@ -17,7 +17,6 @@ import (
 	"sync"
 	"testing"
 
-	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/errors"
 	benchutils "github.com/sourcenetwork/defradb/tests/bench"
@@ -75,7 +74,6 @@ func runCollectionBenchGetSync(b *testing.B,
 			for k := 0; k < numTypes; k++ { // apply op to all the related types
 				collections[k].Get( //nolint:errcheck
 					ctx,
-					acpIdentity.NoIdentity,
 					listOfDocIDs[j][k],
 					false,
 				)
@@ -106,7 +104,6 @@ func runCollectionBenchGetAsync(b *testing.B,
 				go func(ctx context.Context, col client.Collection, docID client.DocID) {
 					col.Get( //nolint:errcheck
 						ctx,
-						acpIdentity.NoIdentity,
 						docID,
 						false,
 					)
@@ -184,7 +181,7 @@ func runCollectionBenchCreateMany(
 			docs[j], _ = client.NewDocFromJSON([]byte(d[0]), collections[0].Schema())
 		}
 
-		collections[0].CreateMany(ctx, acpIdentity.NoIdentity, docs) //nolint:errcheck
+		collections[0].CreateMany(ctx, docs) //nolint:errcheck
 	}
 	b.StopTimer()
 
@@ -205,7 +202,7 @@ func runCollectionBenchCreateSync(b *testing.B,
 			docs, _ := fixture.GenerateDocs()
 			for k := 0; k < numTypes; k++ {
 				doc, _ := client.NewDocFromJSON([]byte(docs[k]), collections[k].Schema())
-				collections[k].Create(ctx, acpIdentity.NoIdentity, doc) //nolint:errcheck
+				collections[k].Create(ctx, doc) //nolint:errcheck
 			}
 		}
 	}
@@ -244,7 +241,7 @@ func runCollectionBenchCreateAsync(b *testing.B,
 					// create the documents
 					for j := 0; j < numTypes; j++ {
 						doc, _ := client.NewDocFromJSON([]byte(docs[j]), collections[j].Schema())
-						collections[j].Create(ctx, acpIdentity.NoIdentity, doc) //nolint:errcheck
+						collections[j].Create(ctx, doc) //nolint:errcheck
 					}
 
 					wg.Done()

--- a/tests/bench/query/planner/utils.go
+++ b/tests/bench/query/planner/utils.go
@@ -16,7 +16,7 @@ import (
 	"testing"
 
 	"github.com/sourcenetwork/defradb/acp"
-	"github.com/sourcenetwork/defradb/acp/identity"
+	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/core"
 	"github.com/sourcenetwork/defradb/datastore"
 	"github.com/sourcenetwork/defradb/errors"
@@ -82,7 +82,7 @@ func runMakePlanBench(
 	for i := 0; i < b.N; i++ {
 		planner := planner.New(
 			ctx,
-			identity.None,
+			acpIdentity.None,
 			acp.NoACP,
 			d,
 			txn,

--- a/tests/bench/query/planner/utils.go
+++ b/tests/bench/query/planner/utils.go
@@ -16,7 +16,7 @@ import (
 	"testing"
 
 	"github.com/sourcenetwork/defradb/acp"
-	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
+	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/core"
 	"github.com/sourcenetwork/defradb/datastore"
 	"github.com/sourcenetwork/defradb/errors"
@@ -82,7 +82,7 @@ func runMakePlanBench(
 	for i := 0; i < b.N; i++ {
 		planner := planner.New(
 			ctx,
-			acpIdentity.NoIdentity,
+			identity.NoIdentity,
 			acp.NoACP,
 			d,
 			txn,

--- a/tests/bench/query/planner/utils.go
+++ b/tests/bench/query/planner/utils.go
@@ -82,7 +82,7 @@ func runMakePlanBench(
 	for i := 0; i < b.N; i++ {
 		planner := planner.New(
 			ctx,
-			identity.NoIdentity,
+			identity.None,
 			acp.NoACP,
 			d,
 			txn,

--- a/tests/bench/query/simple/utils.go
+++ b/tests/bench/query/simple/utils.go
@@ -17,7 +17,6 @@ import (
 	"strings"
 	"testing"
 
-	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/errors"
 	benchutils "github.com/sourcenetwork/defradb/tests/bench"
@@ -71,7 +70,7 @@ func runQueryBenchGetSync(
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		res := db.ExecRequest(ctx, acpIdentity.NoIdentity, query)
+		res := db.ExecRequest(ctx, query)
 		if len(res.GQL.Errors) > 0 {
 			return errors.New(fmt.Sprintf("Query error: %v", res.GQL.Errors))
 		}

--- a/tests/clients/cli/wrapper.go
+++ b/tests/clients/cli/wrapper.go
@@ -394,15 +394,10 @@ func (w *Wrapper) GetAllIndexes(ctx context.Context) (map[client.CollectionName]
 
 func (w *Wrapper) ExecRequest(
 	ctx context.Context,
-	identity immutable.Option[string],
 	query string,
 ) *client.RequestResult {
 	args := []string{"client", "query"}
 	args = append(args, query)
-
-	if identity.HasValue() {
-		args = append(args, "--identity", identity.Value())
-	}
 
 	result := &client.RequestResult{}
 

--- a/tests/clients/cli/wrapper.go
+++ b/tests/clients/cli/wrapper.go
@@ -174,11 +174,9 @@ func (w *Wrapper) BasicExport(ctx context.Context, config *client.BackupConfig) 
 
 func (w *Wrapper) AddPolicy(
 	ctx context.Context,
-	creator string,
 	policy string,
 ) (client.AddPolicyResult, error) {
 	args := []string{"client", "acp", "policy", "add"}
-	args = append(args, "--identity", creator)
 	args = append(args, policy)
 
 	data, err := w.cmd.execute(ctx, args)

--- a/tests/clients/cli/wrapper_cli.go
+++ b/tests/clients/cli/wrapper_cli.go
@@ -16,6 +16,7 @@ import (
 	"io"
 	"strings"
 
+	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/cli"
 	"github.com/sourcenetwork/defradb/db"
 )
@@ -57,9 +58,9 @@ func (w *cliWrapper) executeStream(ctx context.Context, args []string) (io.ReadC
 	if ok {
 		args = append(args, "--tx", fmt.Sprintf("%d", tx.ID()))
 	}
-	identity := db.GetContextIdentity(ctx)
-	if identity.HasValue() {
-		args = append(args, "--identity", identity.Value())
+	id := db.GetContextIdentity(ctx)
+	if id != identity.NoIdentity {
+		args = append(args, "--identity", id.String())
 	}
 	args = append(args, "--url", w.address)
 

--- a/tests/clients/cli/wrapper_cli.go
+++ b/tests/clients/cli/wrapper_cli.go
@@ -57,8 +57,8 @@ func (w *cliWrapper) executeStream(ctx context.Context, args []string) (io.ReadC
 	if ok {
 		args = append(args, "--tx", fmt.Sprintf("%d", tx.ID()))
 	}
-	identity, ok := db.TryGetContextIdentity(ctx)
-	if ok && identity.HasValue() {
+	identity := db.GetContextIdentity(ctx)
+	if identity.HasValue() {
 		args = append(args, "--identity", identity.Value())
 	}
 	args = append(args, "--url", w.address)

--- a/tests/clients/cli/wrapper_cli.go
+++ b/tests/clients/cli/wrapper_cli.go
@@ -57,6 +57,10 @@ func (w *cliWrapper) executeStream(ctx context.Context, args []string) (io.ReadC
 	if ok {
 		args = append(args, "--tx", fmt.Sprintf("%d", tx.ID()))
 	}
+	identity, ok := db.TryGetContextIdentity(ctx)
+	if ok && identity.HasValue() {
+		args = append(args, "--identity", identity.Value())
+	}
 	args = append(args, "--url", w.address)
 
 	cmd := cli.NewDefraCommand()

--- a/tests/clients/cli/wrapper_cli.go
+++ b/tests/clients/cli/wrapper_cli.go
@@ -59,7 +59,7 @@ func (w *cliWrapper) executeStream(ctx context.Context, args []string) (io.ReadC
 		args = append(args, "--tx", fmt.Sprintf("%d", tx.ID()))
 	}
 	id := db.GetContextIdentity(ctx)
-	if id != identity.NoIdentity {
+	if id != identity.None {
 		args = append(args, "--identity", id.String())
 	}
 	args = append(args, "--url", w.address)

--- a/tests/clients/cli/wrapper_cli.go
+++ b/tests/clients/cli/wrapper_cli.go
@@ -16,7 +16,6 @@ import (
 	"io"
 	"strings"
 
-	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/cli"
 	"github.com/sourcenetwork/defradb/db"
 )
@@ -59,8 +58,8 @@ func (w *cliWrapper) executeStream(ctx context.Context, args []string) (io.ReadC
 		args = append(args, "--tx", fmt.Sprintf("%d", tx.ID()))
 	}
 	id := db.GetContextIdentity(ctx)
-	if id != identity.None {
-		args = append(args, "--identity", id.String())
+	if id.HasValue() {
+		args = append(args, "--identity", id.Value().String())
 	}
 	args = append(args, "--url", w.address)
 

--- a/tests/clients/http/wrapper.go
+++ b/tests/clients/http/wrapper.go
@@ -100,10 +100,9 @@ func (w *Wrapper) AddSchema(ctx context.Context, schema string) ([]client.Collec
 
 func (w *Wrapper) AddPolicy(
 	ctx context.Context,
-	creator string,
 	policy string,
 ) (client.AddPolicyResult, error) {
-	return w.client.AddPolicy(ctx, creator, policy)
+	return w.client.AddPolicy(ctx, policy)
 }
 
 func (w *Wrapper) PatchSchema(

--- a/tests/clients/http/wrapper.go
+++ b/tests/clients/http/wrapper.go
@@ -171,10 +171,9 @@ func (w *Wrapper) GetAllIndexes(ctx context.Context) (map[client.CollectionName]
 
 func (w *Wrapper) ExecRequest(
 	ctx context.Context,
-	identity immutable.Option[string],
 	query string,
 ) *client.RequestResult {
-	return w.client.ExecRequest(ctx, identity, query)
+	return w.client.ExecRequest(ctx, query)
 }
 
 func (w *Wrapper) NewTxn(ctx context.Context, readOnly bool) (datastore.Txn, error) {

--- a/tests/gen/cli/gendocs.go
+++ b/tests/gen/cli/gendocs.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/http"
 	"github.com/sourcenetwork/defradb/tests/gen"
@@ -122,7 +121,7 @@ func saveBatchToCollections(
 	for colName, colDocs := range colDocsMap {
 		for _, col := range collections {
 			if col.Description().Name.Value() == colName {
-				err := col.CreateMany(ctx, acpIdentity.NoIdentity, colDocs)
+				err := col.CreateMany(ctx, colDocs)
 				if err != nil {
 					return err
 				}

--- a/tests/integration/acp.go
+++ b/tests/integration/acp.go
@@ -13,6 +13,9 @@ package tests
 import (
 	"github.com/sourcenetwork/immutable"
 	"github.com/stretchr/testify/require"
+
+	"github.com/sourcenetwork/defradb/acp/identity"
+	"github.com/sourcenetwork/defradb/db"
 )
 
 // AddPolicy will attempt to add the given policy using DefraDB's ACP system.
@@ -25,8 +28,8 @@ type AddPolicy struct {
 	// The raw policy string.
 	Policy string
 
-	// The policy creator, i.e. actor creating the policy.
-	Creator string
+	// The policy creator identity, i.e. actor creating the policy.
+	Identity string
 
 	// The expected policyID generated based on the Policy loaded in to the ACP system.
 	ExpectedPolicyID string
@@ -49,11 +52,8 @@ func addPolicyACP(
 	}
 
 	for _, node := range getNodes(action.NodeID, s.nodes) {
-		policyResult, err := node.AddPolicy(
-			s.ctx,
-			action.Creator,
-			action.Policy,
-		)
+		ctx := db.SetContextIdentity(s.ctx, identity.New(action.Identity))
+		policyResult, err := node.AddPolicy(ctx, action.Policy)
 
 		if err == nil {
 			require.Equal(s.t, action.ExpectedError, "")

--- a/tests/integration/acp.go
+++ b/tests/integration/acp.go
@@ -14,7 +14,7 @@ import (
 	"github.com/sourcenetwork/immutable"
 	"github.com/stretchr/testify/require"
 
-	"github.com/sourcenetwork/defradb/acp/identity"
+	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/db"
 )
 
@@ -52,7 +52,7 @@ func addPolicyACP(
 	}
 
 	for _, node := range getNodes(action.NodeID, s.nodes) {
-		ctx := db.SetContextIdentity(s.ctx, identity.New(action.Identity))
+		ctx := db.SetContextIdentity(s.ctx, acpIdentity.New(action.Identity))
 		policyResult, err := node.AddPolicy(ctx, action.Policy)
 
 		if err == nil {

--- a/tests/integration/acp/add_policy/basic_test.go
+++ b/tests/integration/acp/add_policy/basic_test.go
@@ -23,7 +23,7 @@ func TestACP_AddPolicy_BasicYAML_ValidPolicyID(t *testing.T) {
 
 		Actions: []any{
 			testUtils.AddPolicy{
-				Creator: actor1Identity,
+				Identity: actor1Identity,
 
 				Policy: `
                     description: a basic policy that satisfies minimum DPI requirements
@@ -61,7 +61,7 @@ func TestACP_AddPolicy_BasicJSON_ValidPolicyID(t *testing.T) {
 
 		Actions: []any{
 			testUtils.AddPolicy{
-				Creator: actor1Identity,
+				Identity: actor1Identity,
 
 				Policy: `
 					{

--- a/tests/integration/acp/add_policy/basic_test.go
+++ b/tests/integration/acp/add_policy/basic_test.go
@@ -23,7 +23,7 @@ func TestACP_AddPolicy_BasicYAML_ValidPolicyID(t *testing.T) {
 
 		Actions: []any{
 			testUtils.AddPolicy{
-				Creator: actor1Signature,
+				Creator: actor1Identity,
 
 				Policy: `
                     description: a basic policy that satisfies minimum DPI requirements
@@ -61,7 +61,7 @@ func TestACP_AddPolicy_BasicJSON_ValidPolicyID(t *testing.T) {
 
 		Actions: []any{
 			testUtils.AddPolicy{
-				Creator: actor1Signature,
+				Creator: actor1Identity,
 
 				Policy: `
 					{

--- a/tests/integration/acp/add_policy/fixture.go
+++ b/tests/integration/acp/add_policy/fixture.go
@@ -14,5 +14,5 @@ import (
 	acpUtils "github.com/sourcenetwork/defradb/tests/integration/acp"
 )
 
-var actor1Signature = acpUtils.Actor1Signature
-var actor2Signature = acpUtils.Actor2Signature
+var actor1Identity = acpUtils.Actor1Identity
+var actor2Identity = acpUtils.Actor2Identity

--- a/tests/integration/acp/add_policy/with_empty_args_test.go
+++ b/tests/integration/acp/add_policy/with_empty_args_test.go
@@ -23,7 +23,7 @@ func TestACP_AddPolicy_EmptyPolicyData_Error(t *testing.T) {
 
 		Actions: []any{
 			testUtils.AddPolicy{
-				Creator: actor1Signature,
+				Creator: actor1Identity,
 
 				Policy: "",
 

--- a/tests/integration/acp/add_policy/with_empty_args_test.go
+++ b/tests/integration/acp/add_policy/with_empty_args_test.go
@@ -23,7 +23,7 @@ func TestACP_AddPolicy_EmptyPolicyData_Error(t *testing.T) {
 
 		Actions: []any{
 			testUtils.AddPolicy{
-				Creator: actor1Identity,
+				Identity: actor1Identity,
 
 				Policy: "",
 
@@ -42,7 +42,7 @@ func TestACP_AddPolicy_EmptyPolicyCreator_Error(t *testing.T) {
 
 		Actions: []any{
 			testUtils.AddPolicy{
-				Creator: "",
+				Identity: "",
 
 				Policy: `
                     description: a basic policy that satisfies minimum DPI requirements
@@ -80,7 +80,7 @@ func TestACP_AddPolicy_EmptyCreatorAndPolicyArgs_Error(t *testing.T) {
 
 		Actions: []any{
 			testUtils.AddPolicy{
-				Creator: "",
+				Identity: "",
 
 				Policy: "",
 

--- a/tests/integration/acp/add_policy/with_extra_perms_and_relations_test.go
+++ b/tests/integration/acp/add_policy/with_extra_perms_and_relations_test.go
@@ -23,7 +23,7 @@ func TestACP_AddPolicy_ExtraPermissionsAndExtraRelations_ValidPolicyID(t *testin
 
 		Actions: []any{
 			testUtils.AddPolicy{
-				Creator: actor1Identity,
+				Identity: actor1Identity,
 
 				Policy: `
                     description: a policy

--- a/tests/integration/acp/add_policy/with_extra_perms_and_relations_test.go
+++ b/tests/integration/acp/add_policy/with_extra_perms_and_relations_test.go
@@ -23,7 +23,7 @@ func TestACP_AddPolicy_ExtraPermissionsAndExtraRelations_ValidPolicyID(t *testin
 
 		Actions: []any{
 			testUtils.AddPolicy{
-				Creator: actor1Signature,
+				Creator: actor1Identity,
 
 				Policy: `
                     description: a policy

--- a/tests/integration/acp/add_policy/with_extra_perms_test.go
+++ b/tests/integration/acp/add_policy/with_extra_perms_test.go
@@ -23,7 +23,7 @@ func TestACP_AddPolicy_ExtraPermissions_ValidPolicyID(t *testing.T) {
 
 		Actions: []any{
 			testUtils.AddPolicy{
-				Creator: actor1Identity,
+				Identity: actor1Identity,
 
 				Policy: `
                     description: a policy
@@ -62,7 +62,7 @@ func TestACP_AddPolicy_ExtraDuplicatePermissions_Error(t *testing.T) {
 
 		Actions: []any{
 			testUtils.AddPolicy{
-				Creator: actor1Identity,
+				Identity: actor1Identity,
 
 				Policy: `
                     description: a policy

--- a/tests/integration/acp/add_policy/with_extra_perms_test.go
+++ b/tests/integration/acp/add_policy/with_extra_perms_test.go
@@ -23,7 +23,7 @@ func TestACP_AddPolicy_ExtraPermissions_ValidPolicyID(t *testing.T) {
 
 		Actions: []any{
 			testUtils.AddPolicy{
-				Creator: actor1Signature,
+				Creator: actor1Identity,
 
 				Policy: `
                     description: a policy
@@ -62,7 +62,7 @@ func TestACP_AddPolicy_ExtraDuplicatePermissions_Error(t *testing.T) {
 
 		Actions: []any{
 			testUtils.AddPolicy{
-				Creator: actor1Signature,
+				Creator: actor1Identity,
 
 				Policy: `
                     description: a policy

--- a/tests/integration/acp/add_policy/with_extra_relations_test.go
+++ b/tests/integration/acp/add_policy/with_extra_relations_test.go
@@ -23,7 +23,7 @@ func TestACP_AddPolicy_ExtraRelations_ValidPolicyID(t *testing.T) {
 
 		Actions: []any{
 			testUtils.AddPolicy{
-				Creator: actor1Signature,
+				Creator: actor1Identity,
 
 				Policy: `
                     description: a policy
@@ -66,7 +66,7 @@ func TestACP_AddPolicy_ExtraDuplicateRelations_Error(t *testing.T) {
 
 		Actions: []any{
 			testUtils.AddPolicy{
-				Creator: actor1Signature,
+				Creator: actor1Identity,
 
 				Policy: `
                     description: a policy

--- a/tests/integration/acp/add_policy/with_extra_relations_test.go
+++ b/tests/integration/acp/add_policy/with_extra_relations_test.go
@@ -23,7 +23,7 @@ func TestACP_AddPolicy_ExtraRelations_ValidPolicyID(t *testing.T) {
 
 		Actions: []any{
 			testUtils.AddPolicy{
-				Creator: actor1Identity,
+				Identity: actor1Identity,
 
 				Policy: `
                     description: a policy
@@ -66,7 +66,7 @@ func TestACP_AddPolicy_ExtraDuplicateRelations_Error(t *testing.T) {
 
 		Actions: []any{
 			testUtils.AddPolicy{
-				Creator: actor1Identity,
+				Identity: actor1Identity,
 
 				Policy: `
                     description: a policy

--- a/tests/integration/acp/add_policy/with_invalid_creator_arg_test.go
+++ b/tests/integration/acp/add_policy/with_invalid_creator_arg_test.go
@@ -23,7 +23,7 @@ func TestACP_AddPolicy_InvalidCreatorIdentityWithValidPolicy_Error(t *testing.T)
 
 		Actions: []any{
 			testUtils.AddPolicy{
-				Creator: "invalid",
+				Identity: "invalid",
 
 				Policy: `
                     description: a basic policy that satisfies minimum DPI requirements
@@ -62,7 +62,7 @@ func TestACP_AddPolicy_InvalidCreatorIdentityWithEmptyPolicy_Error(t *testing.T)
 
 		Actions: []any{
 			testUtils.AddPolicy{
-				Creator: "invalid",
+				Identity: "invalid",
 
 				Policy: "",
 

--- a/tests/integration/acp/add_policy/with_invalid_relations_test.go
+++ b/tests/integration/acp/add_policy/with_invalid_relations_test.go
@@ -23,7 +23,7 @@ func TestACP_AddPolicy_NoRelations_Error(t *testing.T) {
 
 		Actions: []any{
 			testUtils.AddPolicy{
-				Creator: actor1Signature,
+				Creator: actor1Identity,
 
 				Policy: `
                     description: a policy
@@ -57,7 +57,7 @@ func TestACP_AddPolicy_NoRelationsLabel_Error(t *testing.T) {
 
 		Actions: []any{
 			testUtils.AddPolicy{
-				Creator: actor1Signature,
+				Creator: actor1Identity,
 
 				Policy: `
                     description: a policy

--- a/tests/integration/acp/add_policy/with_invalid_relations_test.go
+++ b/tests/integration/acp/add_policy/with_invalid_relations_test.go
@@ -23,7 +23,7 @@ func TestACP_AddPolicy_NoRelations_Error(t *testing.T) {
 
 		Actions: []any{
 			testUtils.AddPolicy{
-				Creator: actor1Identity,
+				Identity: actor1Identity,
 
 				Policy: `
                     description: a policy
@@ -57,7 +57,7 @@ func TestACP_AddPolicy_NoRelationsLabel_Error(t *testing.T) {
 
 		Actions: []any{
 			testUtils.AddPolicy{
-				Creator: actor1Identity,
+				Identity: actor1Identity,
 
 				Policy: `
                     description: a policy

--- a/tests/integration/acp/add_policy/with_invalid_required_relation_test.go
+++ b/tests/integration/acp/add_policy/with_invalid_required_relation_test.go
@@ -23,7 +23,7 @@ func TestACP_AddPolicy_MissingRequiredOwnerRelation_Error(t *testing.T) {
 
 		Actions: []any{
 			testUtils.AddPolicy{
-				Creator: actor1Signature,
+				Creator: actor1Identity,
 
 				Policy: `
                     description: a policy
@@ -60,7 +60,7 @@ func TestACP_AddPolicy_DuplicateOwnerRelation_Error(t *testing.T) {
 
 		Actions: []any{
 			testUtils.AddPolicy{
-				Creator: actor1Signature,
+				Creator: actor1Identity,
 
 				Policy: `
                     description: a policy

--- a/tests/integration/acp/add_policy/with_invalid_required_relation_test.go
+++ b/tests/integration/acp/add_policy/with_invalid_required_relation_test.go
@@ -23,7 +23,7 @@ func TestACP_AddPolicy_MissingRequiredOwnerRelation_Error(t *testing.T) {
 
 		Actions: []any{
 			testUtils.AddPolicy{
-				Creator: actor1Identity,
+				Identity: actor1Identity,
 
 				Policy: `
                     description: a policy
@@ -60,7 +60,7 @@ func TestACP_AddPolicy_DuplicateOwnerRelation_Error(t *testing.T) {
 
 		Actions: []any{
 			testUtils.AddPolicy{
-				Creator: actor1Identity,
+				Identity: actor1Identity,
 
 				Policy: `
                     description: a policy

--- a/tests/integration/acp/add_policy/with_invalid_resource_test.go
+++ b/tests/integration/acp/add_policy/with_invalid_resource_test.go
@@ -23,7 +23,7 @@ func TestACP_AddPolicy_OneResourceThatIsEmpty_Error(t *testing.T) {
 
 		Actions: []any{
 			testUtils.AddPolicy{
-				Creator: actor1Identity,
+				Identity: actor1Identity,
 
 				Policy: `
                     description: a policy

--- a/tests/integration/acp/add_policy/with_invalid_resource_test.go
+++ b/tests/integration/acp/add_policy/with_invalid_resource_test.go
@@ -23,7 +23,7 @@ func TestACP_AddPolicy_OneResourceThatIsEmpty_Error(t *testing.T) {
 
 		Actions: []any{
 			testUtils.AddPolicy{
-				Creator: actor1Signature,
+				Creator: actor1Identity,
 
 				Policy: `
                     description: a policy

--- a/tests/integration/acp/add_policy/with_managed_relation_test.go
+++ b/tests/integration/acp/add_policy/with_managed_relation_test.go
@@ -22,7 +22,7 @@ func TestACP_AddPolicy_WithRelationManagingOtherRelation_ValidPolicyID(t *testin
 		Description: "Test acp, where a relation is managing another relation, valid policy id",
 		Actions: []any{
 			testUtils.AddPolicy{
-				Creator: actor1Identity,
+				Identity: actor1Identity,
 
 				Policy: `
                     description: a policy with admin relation managing reader relation

--- a/tests/integration/acp/add_policy/with_managed_relation_test.go
+++ b/tests/integration/acp/add_policy/with_managed_relation_test.go
@@ -22,7 +22,7 @@ func TestACP_AddPolicy_WithRelationManagingOtherRelation_ValidPolicyID(t *testin
 		Description: "Test acp, where a relation is managing another relation, valid policy id",
 		Actions: []any{
 			testUtils.AddPolicy{
-				Creator: actor1Signature,
+				Creator: actor1Identity,
 
 				Policy: `
                     description: a policy with admin relation managing reader relation

--- a/tests/integration/acp/add_policy/with_multi_policies_test.go
+++ b/tests/integration/acp/add_policy/with_multi_policies_test.go
@@ -23,7 +23,7 @@ func TestACP_AddPolicy_AddMultipleDifferentPolicies_ValidPolicyIDs(t *testing.T)
 
 		Actions: []any{
 			testUtils.AddPolicy{
-				Creator: actor1Identity,
+				Identity: actor1Identity,
 
 				Policy: `
                     description: a policy
@@ -50,7 +50,7 @@ func TestACP_AddPolicy_AddMultipleDifferentPolicies_ValidPolicyIDs(t *testing.T)
 			},
 
 			testUtils.AddPolicy{
-				Creator: actor1Identity,
+				Identity: actor1Identity,
 
 				Policy: `
                     description: another policy
@@ -95,7 +95,7 @@ func TestACP_AddPolicy_AddMultipleDifferentPoliciesInDifferentFmts_ValidPolicyID
 
 		Actions: []any{
 			testUtils.AddPolicy{
-				Creator: actor1Identity,
+				Identity: actor1Identity,
 
 				Policy: `
                     {
@@ -129,7 +129,7 @@ func TestACP_AddPolicy_AddMultipleDifferentPoliciesInDifferentFmts_ValidPolicyID
 			},
 
 			testUtils.AddPolicy{
-				Creator: actor1Identity,
+				Identity: actor1Identity,
 
 				Policy: `
                     description: another policy
@@ -194,7 +194,7 @@ func TestACP_AddPolicy_AddDuplicatePolicyByOtherCreator_ValidPolicyIDs(t *testin
 
 		Actions: []any{
 			testUtils.AddPolicy{
-				Creator: actor1Identity,
+				Identity: actor1Identity,
 
 				Policy: policyUsedByBoth,
 
@@ -202,7 +202,7 @@ func TestACP_AddPolicy_AddDuplicatePolicyByOtherCreator_ValidPolicyIDs(t *testin
 			},
 
 			testUtils.AddPolicy{
-				Creator: actor2Identity,
+				Identity: actor2Identity,
 
 				Policy: policyUsedByBoth,
 
@@ -221,7 +221,7 @@ func TestACP_AddPolicy_AddMultipleDuplicatePolicies_Error(t *testing.T) {
 
 		Actions: []any{
 			testUtils.AddPolicy{
-				Creator: actor1Identity,
+				Identity: actor1Identity,
 
 				Policy: `
                     description: a policy
@@ -248,7 +248,7 @@ func TestACP_AddPolicy_AddMultipleDuplicatePolicies_Error(t *testing.T) {
 			},
 
 			testUtils.AddPolicy{
-				Creator: actor1Identity,
+				Identity: actor1Identity,
 
 				Policy: `
                     description: a policy
@@ -286,7 +286,7 @@ func TestACP_AddPolicy_AddMultipleDuplicatePoliciesDifferentFmts_Error(t *testin
 
 		Actions: []any{
 			testUtils.AddPolicy{
-				Creator: actor1Identity,
+				Identity: actor1Identity,
 
 				Policy: `
                     description: a policy
@@ -312,7 +312,7 @@ func TestACP_AddPolicy_AddMultipleDuplicatePoliciesDifferentFmts_Error(t *testin
 			},
 
 			testUtils.AddPolicy{
-				Creator: actor1Identity,
+				Identity: actor1Identity,
 
 				Policy: `
                    {

--- a/tests/integration/acp/add_policy/with_multi_policies_test.go
+++ b/tests/integration/acp/add_policy/with_multi_policies_test.go
@@ -23,7 +23,7 @@ func TestACP_AddPolicy_AddMultipleDifferentPolicies_ValidPolicyIDs(t *testing.T)
 
 		Actions: []any{
 			testUtils.AddPolicy{
-				Creator: actor1Signature,
+				Creator: actor1Identity,
 
 				Policy: `
                     description: a policy
@@ -50,7 +50,7 @@ func TestACP_AddPolicy_AddMultipleDifferentPolicies_ValidPolicyIDs(t *testing.T)
 			},
 
 			testUtils.AddPolicy{
-				Creator: actor1Signature,
+				Creator: actor1Identity,
 
 				Policy: `
                     description: another policy
@@ -95,7 +95,7 @@ func TestACP_AddPolicy_AddMultipleDifferentPoliciesInDifferentFmts_ValidPolicyID
 
 		Actions: []any{
 			testUtils.AddPolicy{
-				Creator: actor1Signature,
+				Creator: actor1Identity,
 
 				Policy: `
                     {
@@ -129,7 +129,7 @@ func TestACP_AddPolicy_AddMultipleDifferentPoliciesInDifferentFmts_ValidPolicyID
 			},
 
 			testUtils.AddPolicy{
-				Creator: actor1Signature,
+				Creator: actor1Identity,
 
 				Policy: `
                     description: another policy
@@ -194,7 +194,7 @@ func TestACP_AddPolicy_AddDuplicatePolicyByOtherCreator_ValidPolicyIDs(t *testin
 
 		Actions: []any{
 			testUtils.AddPolicy{
-				Creator: actor1Signature,
+				Creator: actor1Identity,
 
 				Policy: policyUsedByBoth,
 
@@ -202,7 +202,7 @@ func TestACP_AddPolicy_AddDuplicatePolicyByOtherCreator_ValidPolicyIDs(t *testin
 			},
 
 			testUtils.AddPolicy{
-				Creator: actor2Signature,
+				Creator: actor2Identity,
 
 				Policy: policyUsedByBoth,
 
@@ -221,7 +221,7 @@ func TestACP_AddPolicy_AddMultipleDuplicatePolicies_Error(t *testing.T) {
 
 		Actions: []any{
 			testUtils.AddPolicy{
-				Creator: actor1Signature,
+				Creator: actor1Identity,
 
 				Policy: `
                     description: a policy
@@ -248,7 +248,7 @@ func TestACP_AddPolicy_AddMultipleDuplicatePolicies_Error(t *testing.T) {
 			},
 
 			testUtils.AddPolicy{
-				Creator: actor1Signature,
+				Creator: actor1Identity,
 
 				Policy: `
                     description: a policy
@@ -286,7 +286,7 @@ func TestACP_AddPolicy_AddMultipleDuplicatePoliciesDifferentFmts_Error(t *testin
 
 		Actions: []any{
 			testUtils.AddPolicy{
-				Creator: actor1Signature,
+				Creator: actor1Identity,
 
 				Policy: `
                     description: a policy
@@ -312,7 +312,7 @@ func TestACP_AddPolicy_AddMultipleDuplicatePoliciesDifferentFmts_Error(t *testin
 			},
 
 			testUtils.AddPolicy{
-				Creator: actor1Signature,
+				Creator: actor1Identity,
 
 				Policy: `
                    {

--- a/tests/integration/acp/add_policy/with_multiple_resources_test.go
+++ b/tests/integration/acp/add_policy/with_multiple_resources_test.go
@@ -23,7 +23,7 @@ func TestACP_AddPolicy_MultipleResources_ValidID(t *testing.T) {
 
 		Actions: []any{
 			testUtils.AddPolicy{
-				Creator: actor1Identity,
+				Identity: actor1Identity,
 
 				Policy: `
                     description: a policy
@@ -77,7 +77,7 @@ func TestACP_AddPolicy_MultipleResourcesUsingRelationDefinedInOther_Error(t *tes
 
 		Actions: []any{
 			testUtils.AddPolicy{
-				Creator: actor1Identity,
+				Identity: actor1Identity,
 
 				Policy: `
                     description: a policy
@@ -128,7 +128,7 @@ func TestACP_AddPolicy_SecondResourcesMissingRequiredOwner_Error(t *testing.T) {
 
 		Actions: []any{
 			testUtils.AddPolicy{
-				Creator: actor1Identity,
+				Identity: actor1Identity,
 
 				Policy: `
                     description: a policy

--- a/tests/integration/acp/add_policy/with_multiple_resources_test.go
+++ b/tests/integration/acp/add_policy/with_multiple_resources_test.go
@@ -23,7 +23,7 @@ func TestACP_AddPolicy_MultipleResources_ValidID(t *testing.T) {
 
 		Actions: []any{
 			testUtils.AddPolicy{
-				Creator: actor1Signature,
+				Creator: actor1Identity,
 
 				Policy: `
                     description: a policy
@@ -77,7 +77,7 @@ func TestACP_AddPolicy_MultipleResourcesUsingRelationDefinedInOther_Error(t *tes
 
 		Actions: []any{
 			testUtils.AddPolicy{
-				Creator: actor1Signature,
+				Creator: actor1Identity,
 
 				Policy: `
                     description: a policy
@@ -128,7 +128,7 @@ func TestACP_AddPolicy_SecondResourcesMissingRequiredOwner_Error(t *testing.T) {
 
 		Actions: []any{
 			testUtils.AddPolicy{
-				Creator: actor1Signature,
+				Creator: actor1Identity,
 
 				Policy: `
                     description: a policy

--- a/tests/integration/acp/add_policy/with_no_perms_test.go
+++ b/tests/integration/acp/add_policy/with_no_perms_test.go
@@ -31,7 +31,7 @@ func TestACP_AddPolicy_NoPermissionsOnlyOwner_ValidID(t *testing.T) {
 
 		Actions: []any{
 			testUtils.AddPolicy{
-				Creator: actor1Identity,
+				Identity: actor1Identity,
 
 				Policy: `
                     description: a policy
@@ -65,7 +65,7 @@ func TestACP_AddPolicy_NoPermissionsMultiRelations_ValidID(t *testing.T) {
 
 		Actions: []any{
 			testUtils.AddPolicy{
-				Creator: actor1Identity,
+				Identity: actor1Identity,
 
 				Policy: `
                     description: a policy
@@ -102,7 +102,7 @@ func TestACP_AddPolicy_NoPermissionsLabelOnlyOwner_ValidID(t *testing.T) {
 
 		Actions: []any{
 			testUtils.AddPolicy{
-				Creator: actor1Identity,
+				Identity: actor1Identity,
 
 				Policy: `
                     description: a policy
@@ -134,7 +134,7 @@ func TestACP_AddPolicy_NoPermissionsLabelMultiRelations_ValidID(t *testing.T) {
 
 		Actions: []any{
 			testUtils.AddPolicy{
-				Creator: actor1Identity,
+				Identity: actor1Identity,
 
 				Policy: `
                     description: a policy

--- a/tests/integration/acp/add_policy/with_no_perms_test.go
+++ b/tests/integration/acp/add_policy/with_no_perms_test.go
@@ -31,7 +31,7 @@ func TestACP_AddPolicy_NoPermissionsOnlyOwner_ValidID(t *testing.T) {
 
 		Actions: []any{
 			testUtils.AddPolicy{
-				Creator: actor1Signature,
+				Creator: actor1Identity,
 
 				Policy: `
                     description: a policy
@@ -65,7 +65,7 @@ func TestACP_AddPolicy_NoPermissionsMultiRelations_ValidID(t *testing.T) {
 
 		Actions: []any{
 			testUtils.AddPolicy{
-				Creator: actor1Signature,
+				Creator: actor1Identity,
 
 				Policy: `
                     description: a policy
@@ -102,7 +102,7 @@ func TestACP_AddPolicy_NoPermissionsLabelOnlyOwner_ValidID(t *testing.T) {
 
 		Actions: []any{
 			testUtils.AddPolicy{
-				Creator: actor1Signature,
+				Creator: actor1Identity,
 
 				Policy: `
                     description: a policy
@@ -134,7 +134,7 @@ func TestACP_AddPolicy_NoPermissionsLabelMultiRelations_ValidID(t *testing.T) {
 
 		Actions: []any{
 			testUtils.AddPolicy{
-				Creator: actor1Signature,
+				Creator: actor1Identity,
 
 				Policy: `
                     description: a policy

--- a/tests/integration/acp/add_policy/with_no_resources_test.go
+++ b/tests/integration/acp/add_policy/with_no_resources_test.go
@@ -25,7 +25,7 @@ func TestACP_AddPolicy_NoResource_ValidID(t *testing.T) {
 
 		Actions: []any{
 			testUtils.AddPolicy{
-				Creator: actor1Signature,
+				Creator: actor1Identity,
 
 				Policy: `
                     description: a policy
@@ -53,7 +53,7 @@ func TestACP_AddPolicy_NoResourceLabel_ValidID(t *testing.T) {
 
 		Actions: []any{
 			testUtils.AddPolicy{
-				Creator: actor1Signature,
+				Creator: actor1Identity,
 
 				Policy: `
                     description: a policy
@@ -79,7 +79,7 @@ func TestACP_AddPolicy_PolicyWithOnlySpace_ValidID(t *testing.T) {
 
 		Actions: []any{
 			testUtils.AddPolicy{
-				Creator: actor1Signature,
+				Creator: actor1Identity,
 
 				Policy: " ",
 

--- a/tests/integration/acp/add_policy/with_no_resources_test.go
+++ b/tests/integration/acp/add_policy/with_no_resources_test.go
@@ -25,7 +25,7 @@ func TestACP_AddPolicy_NoResource_ValidID(t *testing.T) {
 
 		Actions: []any{
 			testUtils.AddPolicy{
-				Creator: actor1Identity,
+				Identity: actor1Identity,
 
 				Policy: `
                     description: a policy
@@ -53,7 +53,7 @@ func TestACP_AddPolicy_NoResourceLabel_ValidID(t *testing.T) {
 
 		Actions: []any{
 			testUtils.AddPolicy{
-				Creator: actor1Identity,
+				Identity: actor1Identity,
 
 				Policy: `
                     description: a policy
@@ -79,7 +79,7 @@ func TestACP_AddPolicy_PolicyWithOnlySpace_ValidID(t *testing.T) {
 
 		Actions: []any{
 			testUtils.AddPolicy{
-				Creator: actor1Identity,
+				Identity: actor1Identity,
 
 				Policy: " ",
 

--- a/tests/integration/acp/add_policy/with_perm_expr_test.go
+++ b/tests/integration/acp/add_policy/with_perm_expr_test.go
@@ -23,7 +23,7 @@ func TestACP_AddPolicy_PermissionExprWithOwnerInTheEndWithMinus_ValidID(t *testi
 
 		Actions: []any{
 			testUtils.AddPolicy{
-				Creator: actor1Identity,
+				Identity: actor1Identity,
 
 				Policy: `
                     description: a policy
@@ -64,7 +64,7 @@ func TestACP_AddPolicy_PermissionExprWithOwnerInTheEndWithMinusNoSpace_ValidID(t
 
 		Actions: []any{
 			testUtils.AddPolicy{
-				Creator: actor1Identity,
+				Identity: actor1Identity,
 
 				Policy: `
                     description: a policy

--- a/tests/integration/acp/add_policy/with_perm_expr_test.go
+++ b/tests/integration/acp/add_policy/with_perm_expr_test.go
@@ -23,7 +23,7 @@ func TestACP_AddPolicy_PermissionExprWithOwnerInTheEndWithMinus_ValidID(t *testi
 
 		Actions: []any{
 			testUtils.AddPolicy{
-				Creator: actor1Signature,
+				Creator: actor1Identity,
 
 				Policy: `
                     description: a policy
@@ -64,7 +64,7 @@ func TestACP_AddPolicy_PermissionExprWithOwnerInTheEndWithMinusNoSpace_ValidID(t
 
 		Actions: []any{
 			testUtils.AddPolicy{
-				Creator: actor1Signature,
+				Creator: actor1Identity,
 
 				Policy: `
                     description: a policy

--- a/tests/integration/acp/add_policy/with_perm_invalid_expr_test.go
+++ b/tests/integration/acp/add_policy/with_perm_invalid_expr_test.go
@@ -23,7 +23,7 @@ func TestACP_AddPolicy_EmptyExpressionInPermission_Error(t *testing.T) {
 
 		Actions: []any{
 			testUtils.AddPolicy{
-				Creator: actor1Signature,
+				Creator: actor1Identity,
 
 				Policy: `
                     description: a policy
@@ -63,7 +63,7 @@ func TestACP_AddPolicy_PermissionExprWithOwnerInTheEndWithInocorrectSymbol_Error
 
 		Actions: []any{
 			testUtils.AddPolicy{
-				Creator: actor1Signature,
+				Creator: actor1Identity,
 
 				Policy: `
                     description: a policy
@@ -103,7 +103,7 @@ func TestACP_AddPolicy_PermissionExprWithOwnerInTheEndWithInocorrectSymbolNoSpac
 
 		Actions: []any{
 			testUtils.AddPolicy{
-				Creator: actor1Signature,
+				Creator: actor1Identity,
 
 				Policy: `
                     description: a policy

--- a/tests/integration/acp/add_policy/with_perm_invalid_expr_test.go
+++ b/tests/integration/acp/add_policy/with_perm_invalid_expr_test.go
@@ -23,7 +23,7 @@ func TestACP_AddPolicy_EmptyExpressionInPermission_Error(t *testing.T) {
 
 		Actions: []any{
 			testUtils.AddPolicy{
-				Creator: actor1Identity,
+				Identity: actor1Identity,
 
 				Policy: `
                     description: a policy
@@ -63,7 +63,7 @@ func TestACP_AddPolicy_PermissionExprWithOwnerInTheEndWithInocorrectSymbol_Error
 
 		Actions: []any{
 			testUtils.AddPolicy{
-				Creator: actor1Identity,
+				Identity: actor1Identity,
 
 				Policy: `
                     description: a policy
@@ -103,7 +103,7 @@ func TestACP_AddPolicy_PermissionExprWithOwnerInTheEndWithInocorrectSymbolNoSpac
 
 		Actions: []any{
 			testUtils.AddPolicy{
-				Creator: actor1Identity,
+				Identity: actor1Identity,
 
 				Policy: `
                     description: a policy

--- a/tests/integration/acp/add_policy/with_permissionless_owner_test.go
+++ b/tests/integration/acp/add_policy/with_permissionless_owner_test.go
@@ -30,7 +30,7 @@ func TestACP_AddPolicy_PermissionlessOwnerWrite_ValidID(t *testing.T) {
 
 		Actions: []any{
 			testUtils.AddPolicy{
-				Creator: actor1Identity,
+				Identity: actor1Identity,
 
 				Policy: `
                     description: a policy
@@ -70,7 +70,7 @@ func TestACP_AddPolicy_PermissionlessOwnerRead_ValidID(t *testing.T) {
 
 		Actions: []any{
 			testUtils.AddPolicy{
-				Creator: actor1Identity,
+				Identity: actor1Identity,
 
 				Policy: `
                     description: a policy
@@ -110,7 +110,7 @@ func TestACP_AddPolicy_PermissionlessOwnerReadWrite_ValidID(t *testing.T) {
 
 		Actions: []any{
 			testUtils.AddPolicy{
-				Creator: actor1Identity,
+				Identity: actor1Identity,
 
 				Policy: `
                     description: a policy

--- a/tests/integration/acp/add_policy/with_permissionless_owner_test.go
+++ b/tests/integration/acp/add_policy/with_permissionless_owner_test.go
@@ -30,7 +30,7 @@ func TestACP_AddPolicy_PermissionlessOwnerWrite_ValidID(t *testing.T) {
 
 		Actions: []any{
 			testUtils.AddPolicy{
-				Creator: actor1Signature,
+				Creator: actor1Identity,
 
 				Policy: `
                     description: a policy
@@ -70,7 +70,7 @@ func TestACP_AddPolicy_PermissionlessOwnerRead_ValidID(t *testing.T) {
 
 		Actions: []any{
 			testUtils.AddPolicy{
-				Creator: actor1Signature,
+				Creator: actor1Identity,
 
 				Policy: `
                     description: a policy
@@ -110,7 +110,7 @@ func TestACP_AddPolicy_PermissionlessOwnerReadWrite_ValidID(t *testing.T) {
 
 		Actions: []any{
 			testUtils.AddPolicy{
-				Creator: actor1Signature,
+				Creator: actor1Identity,
 
 				Policy: `
                     description: a policy

--- a/tests/integration/acp/add_policy/with_unused_relations_test.go
+++ b/tests/integration/acp/add_policy/with_unused_relations_test.go
@@ -23,7 +23,7 @@ func TestACP_AddPolicy_UnusedRelation_ValidID(t *testing.T) {
 
 		Actions: []any{
 			testUtils.AddPolicy{
-				Creator: actor1Identity,
+				Identity: actor1Identity,
 
 				Policy: `
                     description: a policy

--- a/tests/integration/acp/add_policy/with_unused_relations_test.go
+++ b/tests/integration/acp/add_policy/with_unused_relations_test.go
@@ -23,7 +23,7 @@ func TestACP_AddPolicy_UnusedRelation_ValidID(t *testing.T) {
 
 		Actions: []any{
 			testUtils.AddPolicy{
-				Creator: actor1Signature,
+				Creator: actor1Identity,
 
 				Policy: `
                     description: a policy

--- a/tests/integration/acp/fixture.go
+++ b/tests/integration/acp/fixture.go
@@ -11,6 +11,6 @@
 package test_acp
 
 var (
-	Actor1Signature = "cosmos1zzg43wdrhmmk89z3pmejwete2kkd4a3vn7w969"
-	Actor2Signature = "cosmos1x25hhksxhu86r45hqwk28dd70qzux3262hdrll"
+	Actor1Identity = "cosmos1zzg43wdrhmmk89z3pmejwete2kkd4a3vn7w969"
+	Actor2Identity = "cosmos1x25hhksxhu86r45hqwk28dd70qzux3262hdrll"
 )

--- a/tests/integration/acp/fixture.go
+++ b/tests/integration/acp/fixture.go
@@ -10,5 +10,13 @@
 
 package test_acp
 
-var Actor1Signature = "cosmos1zzg43wdrhmmk89z3pmejwete2kkd4a3vn7w969"
-var Actor2Signature = "cosmos1x25hhksxhu86r45hqwk28dd70qzux3262hdrll"
+import (
+	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
+)
+
+var (
+	Actor1Signature = "cosmos1zzg43wdrhmmk89z3pmejwete2kkd4a3vn7w969"
+	Actor2Signature = "cosmos1x25hhksxhu86r45hqwk28dd70qzux3262hdrll"
+	Actor1Identity  = acpIdentity.NewIdentity(Actor1Signature)
+	Actor2Identity  = acpIdentity.NewIdentity(Actor2Signature)
+)

--- a/tests/integration/acp/fixture.go
+++ b/tests/integration/acp/fixture.go
@@ -11,12 +11,12 @@
 package test_acp
 
 import (
-	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
+	"github.com/sourcenetwork/defradb/acp/identity"
 )
 
 var (
 	Actor1Signature = "cosmos1zzg43wdrhmmk89z3pmejwete2kkd4a3vn7w969"
 	Actor2Signature = "cosmos1x25hhksxhu86r45hqwk28dd70qzux3262hdrll"
-	Actor1Identity  = acpIdentity.NewIdentity(Actor1Signature)
-	Actor2Identity  = acpIdentity.NewIdentity(Actor2Signature)
+	Actor1Identity  = identity.NewIdentity(Actor1Signature)
+	Actor2Identity  = identity.NewIdentity(Actor2Signature)
 )

--- a/tests/integration/acp/fixture.go
+++ b/tests/integration/acp/fixture.go
@@ -10,13 +10,7 @@
 
 package test_acp
 
-import (
-	"github.com/sourcenetwork/defradb/acp/identity"
-)
-
 var (
 	Actor1Signature = "cosmos1zzg43wdrhmmk89z3pmejwete2kkd4a3vn7w969"
 	Actor2Signature = "cosmos1x25hhksxhu86r45hqwk28dd70qzux3262hdrll"
-	Actor1Identity  = identity.NewIdentity(Actor1Signature)
-	Actor2Identity  = identity.NewIdentity(Actor2Signature)
 )

--- a/tests/integration/acp/index/create_test.go
+++ b/tests/integration/acp/index/create_test.go
@@ -27,7 +27,7 @@ func TestACP_IndexCreateWithSeparateRequest_OnCollectionWithPolicy_ReturnError(t
 
 			testUtils.AddPolicy{
 
-				Creator: acpUtils.Actor1Identity,
+				Identity: acpUtils.Actor1Identity,
 
 				Policy: `
                     description: a test policy which marks a collection in a database as a resource
@@ -109,7 +109,7 @@ func TestACP_IndexCreateWithDirective_OnCollectionWithPolicy_ReturnError(t *test
 
 			testUtils.AddPolicy{
 
-				Creator: acpUtils.Actor1Identity,
+				Identity: acpUtils.Actor1Identity,
 
 				Policy: `
                     description: a test policy which marks a collection in a database as a resource

--- a/tests/integration/acp/index/create_test.go
+++ b/tests/integration/acp/index/create_test.go
@@ -27,7 +27,7 @@ func TestACP_IndexCreateWithSeparateRequest_OnCollectionWithPolicy_ReturnError(t
 
 			testUtils.AddPolicy{
 
-				Creator: acpUtils.Actor1Signature,
+				Creator: acpUtils.Actor1Identity,
 
 				Policy: `
                     description: a test policy which marks a collection in a database as a resource
@@ -109,7 +109,7 @@ func TestACP_IndexCreateWithDirective_OnCollectionWithPolicy_ReturnError(t *test
 
 			testUtils.AddPolicy{
 
-				Creator: acpUtils.Actor1Signature,
+				Creator: acpUtils.Actor1Identity,
 
 				Policy: `
                     description: a test policy which marks a collection in a database as a resource

--- a/tests/integration/acp/p2p/replicator_test.go
+++ b/tests/integration/acp/p2p/replicator_test.go
@@ -32,7 +32,7 @@ func TestACP_P2POneToOneReplicatorWithPermissionedCollection_Error(t *testing.T)
 
 			testUtils.AddPolicy{
 
-				Creator: acpUtils.Actor1Identity,
+				Identity: acpUtils.Actor1Identity,
 
 				Policy: `
                     description: a test policy which marks a collection in a database as a resource

--- a/tests/integration/acp/p2p/replicator_test.go
+++ b/tests/integration/acp/p2p/replicator_test.go
@@ -32,7 +32,7 @@ func TestACP_P2POneToOneReplicatorWithPermissionedCollection_Error(t *testing.T)
 
 			testUtils.AddPolicy{
 
-				Creator: acpUtils.Actor1Signature,
+				Creator: acpUtils.Actor1Identity,
 
 				Policy: `
                     description: a test policy which marks a collection in a database as a resource

--- a/tests/integration/acp/p2p/subscribe_test.go
+++ b/tests/integration/acp/p2p/subscribe_test.go
@@ -32,7 +32,7 @@ func TestACP_P2PSubscribeAddGetSingleWithPermissionedCollection_Error(t *testing
 
 			testUtils.AddPolicy{
 
-				Creator: acpUtils.Actor1Identity,
+				Identity: acpUtils.Actor1Identity,
 
 				Policy: `
                     description: a test policy which marks a collection in a database as a resource

--- a/tests/integration/acp/p2p/subscribe_test.go
+++ b/tests/integration/acp/p2p/subscribe_test.go
@@ -32,7 +32,7 @@ func TestACP_P2PSubscribeAddGetSingleWithPermissionedCollection_Error(t *testing
 
 			testUtils.AddPolicy{
 
-				Creator: acpUtils.Actor1Signature,
+				Creator: acpUtils.Actor1Identity,
 
 				Policy: `
                     description: a test policy which marks a collection in a database as a resource

--- a/tests/integration/acp/register_and_delete_test.go
+++ b/tests/integration/acp/register_and_delete_test.go
@@ -180,7 +180,7 @@ func TestACP_CreateWithoutIdentityAndDeleteWithIdentity_CanDelete(t *testing.T) 
 			testUtils.DeleteDoc{
 				CollectionID: 0,
 
-				Identity: Actor1Identity,
+				Identity: Actor1Signature,
 
 				DocID: 0,
 			},
@@ -206,8 +206,7 @@ func TestACP_CreateWithoutIdentityAndDeleteWithIdentity_CanDelete(t *testing.T) 
 func TestACP_CreateWithIdentityAndDeleteWithIdentity_CanDelete(t *testing.T) {
 	// OwnerIdentity should be the same identity that is used to do the registering/creation,
 	// and the final read check to see the state of that registered document.
-	OwnerIdentity := Actor1Identity
-	OwnerSignature := Actor1Signature
+	OwnerIdentity := Actor1Signature
 
 	test := testUtils.TestCase{
 
@@ -216,7 +215,7 @@ func TestACP_CreateWithIdentityAndDeleteWithIdentity_CanDelete(t *testing.T) {
 		Actions: []any{
 			testUtils.AddPolicy{
 
-				Creator: OwnerSignature,
+				Creator: OwnerIdentity,
 
 				Policy: `
                     description: a test policy which marks a collection in a database as a resource
@@ -305,7 +304,7 @@ func TestACP_CreateWithIdentityAndDeleteWithIdentity_CanDelete(t *testing.T) {
 func TestACP_CreateWithIdentityAndDeleteWithoutIdentity_CanNotDelete(t *testing.T) {
 	// OwnerIdentity should be the same identity that is used to do the registering/creation,
 	// and the final read check to see the state of that registered document.
-	OwnerIdentity := Actor1Identity
+	OwnerIdentity := Actor1Signature
 	OwnerSignature := Actor1Signature
 
 	test := testUtils.TestCase{
@@ -410,10 +409,9 @@ func TestACP_CreateWithIdentityAndDeleteWithoutIdentity_CanNotDelete(t *testing.
 func TestACP_CreateWithIdentityAndDeleteWithWrongIdentity_CanNotDelete(t *testing.T) {
 	// OwnerIdentity should be the same identity that is used to do the registering/creation,
 	// and the final read check to see the state of that registered document.
-	OwnerIdentity := Actor1Identity
-	OwnerSignature := Actor1Signature
+	OwnerIdentity := Actor1Signature
 
-	WrongIdentity := Actor2Identity
+	WrongIdentity := Actor2Signature
 
 	test := testUtils.TestCase{
 
@@ -422,7 +420,7 @@ func TestACP_CreateWithIdentityAndDeleteWithWrongIdentity_CanNotDelete(t *testin
 		Actions: []any{
 			testUtils.AddPolicy{
 
-				Creator: OwnerSignature,
+				Creator: OwnerIdentity,
 
 				Policy: `
                     description: a test policy which marks a collection in a database as a resource

--- a/tests/integration/acp/register_and_delete_test.go
+++ b/tests/integration/acp/register_and_delete_test.go
@@ -180,7 +180,7 @@ func TestACP_CreateWithoutIdentityAndDeleteWithIdentity_CanDelete(t *testing.T) 
 			testUtils.DeleteDoc{
 				CollectionID: 0,
 
-				Identity: Actor1Signature,
+				Identity: Actor1Identity,
 
 				DocID: 0,
 			},
@@ -206,7 +206,8 @@ func TestACP_CreateWithoutIdentityAndDeleteWithIdentity_CanDelete(t *testing.T) 
 func TestACP_CreateWithIdentityAndDeleteWithIdentity_CanDelete(t *testing.T) {
 	// OwnerIdentity should be the same identity that is used to do the registering/creation,
 	// and the final read check to see the state of that registered document.
-	OwnerIdentity := Actor1Signature
+	OwnerIdentity := Actor1Identity
+	OwnerSignature := Actor1Signature
 
 	test := testUtils.TestCase{
 
@@ -215,7 +216,7 @@ func TestACP_CreateWithIdentityAndDeleteWithIdentity_CanDelete(t *testing.T) {
 		Actions: []any{
 			testUtils.AddPolicy{
 
-				Creator: OwnerIdentity,
+				Creator: OwnerSignature,
 
 				Policy: `
                     description: a test policy which marks a collection in a database as a resource
@@ -304,7 +305,8 @@ func TestACP_CreateWithIdentityAndDeleteWithIdentity_CanDelete(t *testing.T) {
 func TestACP_CreateWithIdentityAndDeleteWithoutIdentity_CanNotDelete(t *testing.T) {
 	// OwnerIdentity should be the same identity that is used to do the registering/creation,
 	// and the final read check to see the state of that registered document.
-	OwnerIdentity := Actor1Signature
+	OwnerIdentity := Actor1Identity
+	OwnerSignature := Actor1Signature
 
 	test := testUtils.TestCase{
 
@@ -313,7 +315,7 @@ func TestACP_CreateWithIdentityAndDeleteWithoutIdentity_CanNotDelete(t *testing.
 		Actions: []any{
 			testUtils.AddPolicy{
 
-				Creator: OwnerIdentity,
+				Creator: OwnerSignature,
 
 				Policy: `
                     description: a test policy which marks a collection in a database as a resource
@@ -408,9 +410,10 @@ func TestACP_CreateWithIdentityAndDeleteWithoutIdentity_CanNotDelete(t *testing.
 func TestACP_CreateWithIdentityAndDeleteWithWrongIdentity_CanNotDelete(t *testing.T) {
 	// OwnerIdentity should be the same identity that is used to do the registering/creation,
 	// and the final read check to see the state of that registered document.
-	OwnerIdentity := Actor1Signature
+	OwnerIdentity := Actor1Identity
+	OwnerSignature := Actor1Signature
 
-	WrongIdentity := Actor2Signature
+	WrongIdentity := Actor2Identity
 
 	test := testUtils.TestCase{
 
@@ -419,7 +422,7 @@ func TestACP_CreateWithIdentityAndDeleteWithWrongIdentity_CanNotDelete(t *testin
 		Actions: []any{
 			testUtils.AddPolicy{
 
-				Creator: OwnerIdentity,
+				Creator: OwnerSignature,
 
 				Policy: `
                     description: a test policy which marks a collection in a database as a resource

--- a/tests/integration/acp/register_and_delete_test.go
+++ b/tests/integration/acp/register_and_delete_test.go
@@ -305,7 +305,6 @@ func TestACP_CreateWithIdentityAndDeleteWithoutIdentity_CanNotDelete(t *testing.
 	// OwnerIdentity should be the same identity that is used to do the registering/creation,
 	// and the final read check to see the state of that registered document.
 	OwnerIdentity := Actor1Signature
-	OwnerSignature := Actor1Signature
 
 	test := testUtils.TestCase{
 
@@ -314,7 +313,7 @@ func TestACP_CreateWithIdentityAndDeleteWithoutIdentity_CanNotDelete(t *testing.
 		Actions: []any{
 			testUtils.AddPolicy{
 
-				Creator: OwnerSignature,
+				Creator: OwnerIdentity,
 
 				Policy: `
                     description: a test policy which marks a collection in a database as a resource

--- a/tests/integration/acp/register_and_delete_test.go
+++ b/tests/integration/acp/register_and_delete_test.go
@@ -28,7 +28,7 @@ func TestACP_CreateWithoutIdentityAndDeleteWithoutIdentity_CanDelete(t *testing.
 		Actions: []any{
 			testUtils.AddPolicy{
 
-				Creator: Actor1Signature,
+				Creator: Actor1Identity,
 
 				Policy: `
                     description: a test policy which marks a collection in a database as a resource
@@ -121,7 +121,7 @@ func TestACP_CreateWithoutIdentityAndDeleteWithIdentity_CanDelete(t *testing.T) 
 		Actions: []any{
 			testUtils.AddPolicy{
 
-				Creator: Actor1Signature,
+				Creator: Actor1Identity,
 
 				Policy: `
                     description: a test policy which marks a collection in a database as a resource
@@ -180,7 +180,7 @@ func TestACP_CreateWithoutIdentityAndDeleteWithIdentity_CanDelete(t *testing.T) 
 			testUtils.DeleteDoc{
 				CollectionID: 0,
 
-				Identity: Actor1Signature,
+				Identity: Actor1Identity,
 
 				DocID: 0,
 			},
@@ -206,7 +206,7 @@ func TestACP_CreateWithoutIdentityAndDeleteWithIdentity_CanDelete(t *testing.T) 
 func TestACP_CreateWithIdentityAndDeleteWithIdentity_CanDelete(t *testing.T) {
 	// OwnerIdentity should be the same identity that is used to do the registering/creation,
 	// and the final read check to see the state of that registered document.
-	OwnerIdentity := Actor1Signature
+	OwnerIdentity := Actor1Identity
 
 	test := testUtils.TestCase{
 
@@ -304,7 +304,7 @@ func TestACP_CreateWithIdentityAndDeleteWithIdentity_CanDelete(t *testing.T) {
 func TestACP_CreateWithIdentityAndDeleteWithoutIdentity_CanNotDelete(t *testing.T) {
 	// OwnerIdentity should be the same identity that is used to do the registering/creation,
 	// and the final read check to see the state of that registered document.
-	OwnerIdentity := Actor1Signature
+	OwnerIdentity := Actor1Identity
 
 	test := testUtils.TestCase{
 
@@ -408,9 +408,9 @@ func TestACP_CreateWithIdentityAndDeleteWithoutIdentity_CanNotDelete(t *testing.
 func TestACP_CreateWithIdentityAndDeleteWithWrongIdentity_CanNotDelete(t *testing.T) {
 	// OwnerIdentity should be the same identity that is used to do the registering/creation,
 	// and the final read check to see the state of that registered document.
-	OwnerIdentity := Actor1Signature
+	OwnerIdentity := Actor1Identity
 
-	WrongIdentity := Actor2Signature
+	WrongIdentity := Actor2Identity
 
 	test := testUtils.TestCase{
 

--- a/tests/integration/acp/register_and_delete_test.go
+++ b/tests/integration/acp/register_and_delete_test.go
@@ -28,7 +28,7 @@ func TestACP_CreateWithoutIdentityAndDeleteWithoutIdentity_CanDelete(t *testing.
 		Actions: []any{
 			testUtils.AddPolicy{
 
-				Creator: Actor1Identity,
+				Identity: Actor1Identity,
 
 				Policy: `
                     description: a test policy which marks a collection in a database as a resource
@@ -121,7 +121,7 @@ func TestACP_CreateWithoutIdentityAndDeleteWithIdentity_CanDelete(t *testing.T) 
 		Actions: []any{
 			testUtils.AddPolicy{
 
-				Creator: Actor1Identity,
+				Identity: Actor1Identity,
 
 				Policy: `
                     description: a test policy which marks a collection in a database as a resource
@@ -215,7 +215,7 @@ func TestACP_CreateWithIdentityAndDeleteWithIdentity_CanDelete(t *testing.T) {
 		Actions: []any{
 			testUtils.AddPolicy{
 
-				Creator: OwnerIdentity,
+				Identity: OwnerIdentity,
 
 				Policy: `
                     description: a test policy which marks a collection in a database as a resource
@@ -313,7 +313,7 @@ func TestACP_CreateWithIdentityAndDeleteWithoutIdentity_CanNotDelete(t *testing.
 		Actions: []any{
 			testUtils.AddPolicy{
 
-				Creator: OwnerIdentity,
+				Identity: OwnerIdentity,
 
 				Policy: `
                     description: a test policy which marks a collection in a database as a resource
@@ -419,7 +419,7 @@ func TestACP_CreateWithIdentityAndDeleteWithWrongIdentity_CanNotDelete(t *testin
 		Actions: []any{
 			testUtils.AddPolicy{
 
-				Creator: OwnerIdentity,
+				Identity: OwnerIdentity,
 
 				Policy: `
                     description: a test policy which marks a collection in a database as a resource

--- a/tests/integration/acp/register_and_read_test.go
+++ b/tests/integration/acp/register_and_read_test.go
@@ -169,7 +169,7 @@ func TestACP_CreateWithoutIdentityAndReadWithIdentity_CanRead(t *testing.T) {
 			},
 
 			testUtils.Request{
-				Identity: Actor1Identity,
+				Identity: Actor1Signature,
 
 				Request: `
 					query {
@@ -250,7 +250,7 @@ func TestACP_CreateWithIdentityAndReadWithIdentity_CanRead(t *testing.T) {
 			testUtils.CreateDoc{
 				CollectionID: 0,
 
-				Identity: Actor1Identity,
+				Identity: Actor1Signature,
 
 				Doc: `
 					{
@@ -261,7 +261,7 @@ func TestACP_CreateWithIdentityAndReadWithIdentity_CanRead(t *testing.T) {
 			},
 
 			testUtils.Request{
-				Identity: Actor1Identity,
+				Identity: Actor1Signature,
 
 				Request: `
 					query {
@@ -342,7 +342,7 @@ func TestACP_CreateWithIdentityAndReadWithoutIdentity_CanNotRead(t *testing.T) {
 			testUtils.CreateDoc{
 				CollectionID: 0,
 
-				Identity: Actor1Identity,
+				Identity: Actor1Signature,
 
 				Doc: `
 					{
@@ -426,7 +426,7 @@ func TestACP_CreateWithIdentityAndReadWithWrongIdentity_CanNotRead(t *testing.T)
 			testUtils.CreateDoc{
 				CollectionID: 0,
 
-				Identity: Actor1Identity,
+				Identity: Actor1Signature,
 
 				Doc: `
  					{
@@ -437,7 +437,7 @@ func TestACP_CreateWithIdentityAndReadWithWrongIdentity_CanNotRead(t *testing.T)
 			},
 
 			testUtils.Request{
-				Identity: Actor2Identity,
+				Identity: Actor2Signature,
 
 				Request: `
  					query {

--- a/tests/integration/acp/register_and_read_test.go
+++ b/tests/integration/acp/register_and_read_test.go
@@ -24,7 +24,7 @@ func TestACP_CreateWithoutIdentityAndReadWithoutIdentity_CanRead(t *testing.T) {
 		Actions: []any{
 			testUtils.AddPolicy{
 
-				Creator: Actor1Identity,
+				Identity: Actor1Identity,
 
 				Policy: `
                     description: a test policy which marks a collection in a database as a resource
@@ -112,7 +112,7 @@ func TestACP_CreateWithoutIdentityAndReadWithIdentity_CanRead(t *testing.T) {
 		Actions: []any{
 			testUtils.AddPolicy{
 
-				Creator: Actor1Identity,
+				Identity: Actor1Identity,
 
 				Policy: `
                     description: a test policy which marks a collection in a database as a resource
@@ -202,7 +202,7 @@ func TestACP_CreateWithIdentityAndReadWithIdentity_CanRead(t *testing.T) {
 		Actions: []any{
 			testUtils.AddPolicy{
 
-				Creator: Actor1Identity,
+				Identity: Actor1Identity,
 
 				Policy: `
                     description: a test policy which marks a collection in a database as a resource
@@ -294,7 +294,7 @@ func TestACP_CreateWithIdentityAndReadWithoutIdentity_CanNotRead(t *testing.T) {
 		Actions: []any{
 			testUtils.AddPolicy{
 
-				Creator: Actor1Identity,
+				Identity: Actor1Identity,
 
 				Policy: `
                     description: a test policy which marks a collection in a database as a resource
@@ -378,7 +378,7 @@ func TestACP_CreateWithIdentityAndReadWithWrongIdentity_CanNotRead(t *testing.T)
 		Actions: []any{
 			testUtils.AddPolicy{
 
-				Creator: Actor1Identity,
+				Identity: Actor1Identity,
 
 				Policy: `
                      description: a test policy which marks a collection in a database as a resource

--- a/tests/integration/acp/register_and_read_test.go
+++ b/tests/integration/acp/register_and_read_test.go
@@ -169,7 +169,7 @@ func TestACP_CreateWithoutIdentityAndReadWithIdentity_CanRead(t *testing.T) {
 			},
 
 			testUtils.Request{
-				Identity: Actor1Signature,
+				Identity: Actor1Identity,
 
 				Request: `
 					query {
@@ -250,7 +250,7 @@ func TestACP_CreateWithIdentityAndReadWithIdentity_CanRead(t *testing.T) {
 			testUtils.CreateDoc{
 				CollectionID: 0,
 
-				Identity: Actor1Signature,
+				Identity: Actor1Identity,
 
 				Doc: `
 					{
@@ -261,7 +261,7 @@ func TestACP_CreateWithIdentityAndReadWithIdentity_CanRead(t *testing.T) {
 			},
 
 			testUtils.Request{
-				Identity: Actor1Signature,
+				Identity: Actor1Identity,
 
 				Request: `
 					query {
@@ -342,7 +342,7 @@ func TestACP_CreateWithIdentityAndReadWithoutIdentity_CanNotRead(t *testing.T) {
 			testUtils.CreateDoc{
 				CollectionID: 0,
 
-				Identity: Actor1Signature,
+				Identity: Actor1Identity,
 
 				Doc: `
 					{
@@ -426,7 +426,7 @@ func TestACP_CreateWithIdentityAndReadWithWrongIdentity_CanNotRead(t *testing.T)
 			testUtils.CreateDoc{
 				CollectionID: 0,
 
-				Identity: Actor1Signature,
+				Identity: Actor1Identity,
 
 				Doc: `
  					{
@@ -437,7 +437,7 @@ func TestACP_CreateWithIdentityAndReadWithWrongIdentity_CanNotRead(t *testing.T)
 			},
 
 			testUtils.Request{
-				Identity: Actor2Signature,
+				Identity: Actor2Identity,
 
 				Request: `
  					query {

--- a/tests/integration/acp/register_and_read_test.go
+++ b/tests/integration/acp/register_and_read_test.go
@@ -24,7 +24,7 @@ func TestACP_CreateWithoutIdentityAndReadWithoutIdentity_CanRead(t *testing.T) {
 		Actions: []any{
 			testUtils.AddPolicy{
 
-				Creator: Actor1Signature,
+				Creator: Actor1Identity,
 
 				Policy: `
                     description: a test policy which marks a collection in a database as a resource
@@ -112,7 +112,7 @@ func TestACP_CreateWithoutIdentityAndReadWithIdentity_CanRead(t *testing.T) {
 		Actions: []any{
 			testUtils.AddPolicy{
 
-				Creator: Actor1Signature,
+				Creator: Actor1Identity,
 
 				Policy: `
                     description: a test policy which marks a collection in a database as a resource
@@ -169,7 +169,7 @@ func TestACP_CreateWithoutIdentityAndReadWithIdentity_CanRead(t *testing.T) {
 			},
 
 			testUtils.Request{
-				Identity: Actor1Signature,
+				Identity: Actor1Identity,
 
 				Request: `
 					query {
@@ -202,7 +202,7 @@ func TestACP_CreateWithIdentityAndReadWithIdentity_CanRead(t *testing.T) {
 		Actions: []any{
 			testUtils.AddPolicy{
 
-				Creator: Actor1Signature,
+				Creator: Actor1Identity,
 
 				Policy: `
                     description: a test policy which marks a collection in a database as a resource
@@ -250,7 +250,7 @@ func TestACP_CreateWithIdentityAndReadWithIdentity_CanRead(t *testing.T) {
 			testUtils.CreateDoc{
 				CollectionID: 0,
 
-				Identity: Actor1Signature,
+				Identity: Actor1Identity,
 
 				Doc: `
 					{
@@ -261,7 +261,7 @@ func TestACP_CreateWithIdentityAndReadWithIdentity_CanRead(t *testing.T) {
 			},
 
 			testUtils.Request{
-				Identity: Actor1Signature,
+				Identity: Actor1Identity,
 
 				Request: `
 					query {
@@ -294,7 +294,7 @@ func TestACP_CreateWithIdentityAndReadWithoutIdentity_CanNotRead(t *testing.T) {
 		Actions: []any{
 			testUtils.AddPolicy{
 
-				Creator: Actor1Signature,
+				Creator: Actor1Identity,
 
 				Policy: `
                     description: a test policy which marks a collection in a database as a resource
@@ -342,7 +342,7 @@ func TestACP_CreateWithIdentityAndReadWithoutIdentity_CanNotRead(t *testing.T) {
 			testUtils.CreateDoc{
 				CollectionID: 0,
 
-				Identity: Actor1Signature,
+				Identity: Actor1Identity,
 
 				Doc: `
 					{
@@ -378,7 +378,7 @@ func TestACP_CreateWithIdentityAndReadWithWrongIdentity_CanNotRead(t *testing.T)
 		Actions: []any{
 			testUtils.AddPolicy{
 
-				Creator: Actor1Signature,
+				Creator: Actor1Identity,
 
 				Policy: `
                      description: a test policy which marks a collection in a database as a resource
@@ -426,7 +426,7 @@ func TestACP_CreateWithIdentityAndReadWithWrongIdentity_CanNotRead(t *testing.T)
 			testUtils.CreateDoc{
 				CollectionID: 0,
 
-				Identity: Actor1Signature,
+				Identity: Actor1Identity,
 
 				Doc: `
  					{
@@ -437,7 +437,7 @@ func TestACP_CreateWithIdentityAndReadWithWrongIdentity_CanNotRead(t *testing.T)
 			},
 
 			testUtils.Request{
-				Identity: Actor2Signature,
+				Identity: Actor2Identity,
 
 				Request: `
  					query {

--- a/tests/integration/acp/register_and_update_test.go
+++ b/tests/integration/acp/register_and_update_test.go
@@ -233,7 +233,6 @@ func TestACP_CreateWithIdentityAndUpdateWithIdentity_CanUpdate(t *testing.T) {
 	// OwnerIdentity should be the same identity that is used to do the registering/creation,
 	// and the final read check to see the state of that registered document.
 	OwnerIdentity := Actor1Signature
-	OwnerSignature := Actor1Signature
 
 	test := testUtils.TestCase{
 
@@ -242,7 +241,7 @@ func TestACP_CreateWithIdentityAndUpdateWithIdentity_CanUpdate(t *testing.T) {
 		Actions: []any{
 			testUtils.AddPolicy{
 
-				Creator: OwnerSignature,
+				Creator: OwnerIdentity,
 
 				Policy: `
                     description: a test policy which marks a collection in a database as a resource
@@ -583,7 +582,6 @@ func TestACP_CreateWithIdentityAndUpdateWithoutIdentityGQL_CanNotUpdate(t *testi
 	// OwnerIdentity should be the same identity that is used to do the registering/creation,
 	// and the final read check to see the state of that registered document.
 	OwnerIdentity := Actor1Signature
-	OwnerSignature := Actor1Signature
 
 	test := testUtils.TestCase{
 
@@ -597,7 +595,7 @@ func TestACP_CreateWithIdentityAndUpdateWithoutIdentityGQL_CanNotUpdate(t *testi
 		Actions: []any{
 			testUtils.AddPolicy{
 
-				Creator: OwnerSignature,
+				Creator: OwnerIdentity,
 
 				Policy: `
                     description: a test policy which marks a collection in a database as a resource

--- a/tests/integration/acp/register_and_update_test.go
+++ b/tests/integration/acp/register_and_update_test.go
@@ -30,7 +30,7 @@ func TestACP_CreateWithoutIdentityAndUpdateWithoutIdentity_CanUpdate(t *testing.
 		Actions: []any{
 			testUtils.AddPolicy{
 
-				Creator: Actor1Signature,
+				Creator: Actor1Identity,
 
 				Policy: `
                     description: a test policy which marks a collection in a database as a resource
@@ -135,7 +135,7 @@ func TestACP_CreateWithoutIdentityAndUpdateWithIdentity_CanUpdate(t *testing.T) 
 		Actions: []any{
 			testUtils.AddPolicy{
 
-				Creator: Actor1Signature,
+				Creator: Actor1Identity,
 
 				Policy: `
                     description: a test policy which marks a collection in a database as a resource
@@ -194,7 +194,7 @@ func TestACP_CreateWithoutIdentityAndUpdateWithIdentity_CanUpdate(t *testing.T) 
 			testUtils.UpdateDoc{
 				CollectionID: 0,
 
-				Identity: Actor1Signature,
+				Identity: Actor1Identity,
 
 				DocID: 0,
 
@@ -232,7 +232,7 @@ func TestACP_CreateWithoutIdentityAndUpdateWithIdentity_CanUpdate(t *testing.T) 
 func TestACP_CreateWithIdentityAndUpdateWithIdentity_CanUpdate(t *testing.T) {
 	// OwnerIdentity should be the same identity that is used to do the registering/creation,
 	// and the final read check to see the state of that registered document.
-	OwnerIdentity := Actor1Signature
+	OwnerIdentity := Actor1Identity
 
 	test := testUtils.TestCase{
 
@@ -342,8 +342,7 @@ func TestACP_CreateWithIdentityAndUpdateWithIdentity_CanUpdate(t *testing.T) {
 func TestACP_CreateWithIdentityAndUpdateWithoutIdentity_CanNotUpdate(t *testing.T) {
 	// OwnerIdentity should be the same identity that is used to do the registering/creation,
 	// and the final read check to see the state of that registered document.
-	OwnerSignature := Actor1Signature
-	OwnerIdentity := Actor1Signature
+	OwnerIdentity := Actor1Identity
 
 	test := testUtils.TestCase{
 
@@ -358,7 +357,7 @@ func TestACP_CreateWithIdentityAndUpdateWithoutIdentity_CanNotUpdate(t *testing.
 		Actions: []any{
 			testUtils.AddPolicy{
 
-				Creator: OwnerSignature,
+				Creator: OwnerIdentity,
 
 				Policy: `
                     description: a test policy which marks a collection in a database as a resource
@@ -459,9 +458,9 @@ func TestACP_CreateWithIdentityAndUpdateWithoutIdentity_CanNotUpdate(t *testing.
 func TestACP_CreateWithIdentityAndUpdateWithWrongIdentity_CanNotUpdate(t *testing.T) {
 	// OwnerIdentity should be the same identity that is used to do the registering/creation,
 	// and the final read check to see the state of that registered document.
-	OwnerIdentity := Actor1Signature
+	OwnerIdentity := Actor1Identity
 
-	WrongIdentity := Actor2Signature
+	WrongIdentity := Actor2Identity
 
 	test := testUtils.TestCase{
 
@@ -581,7 +580,7 @@ func TestACP_CreateWithIdentityAndUpdateWithWrongIdentity_CanNotUpdate(t *testin
 func TestACP_CreateWithIdentityAndUpdateWithoutIdentityGQL_CanNotUpdate(t *testing.T) {
 	// OwnerIdentity should be the same identity that is used to do the registering/creation,
 	// and the final read check to see the state of that registered document.
-	OwnerIdentity := Actor1Signature
+	OwnerIdentity := Actor1Identity
 
 	test := testUtils.TestCase{
 
@@ -696,9 +695,9 @@ func TestACP_CreateWithIdentityAndUpdateWithoutIdentityGQL_CanNotUpdate(t *testi
 func TestACP_CreateWithIdentityAndUpdateWithWrongIdentityGQL_CanNotUpdate(t *testing.T) {
 	// OwnerIdentity should be the same identity that is used to do the registering/creation,
 	// and the final read check to see the state of that registered document.
-	OwnerIdentity := Actor1Signature
+	OwnerIdentity := Actor1Identity
 
-	WrongIdentity := Actor2Signature
+	WrongIdentity := Actor2Identity
 
 	test := testUtils.TestCase{
 

--- a/tests/integration/acp/register_and_update_test.go
+++ b/tests/integration/acp/register_and_update_test.go
@@ -194,7 +194,7 @@ func TestACP_CreateWithoutIdentityAndUpdateWithIdentity_CanUpdate(t *testing.T) 
 			testUtils.UpdateDoc{
 				CollectionID: 0,
 
-				Identity: Actor1Signature,
+				Identity: Actor1Identity,
 
 				DocID: 0,
 
@@ -232,7 +232,8 @@ func TestACP_CreateWithoutIdentityAndUpdateWithIdentity_CanUpdate(t *testing.T) 
 func TestACP_CreateWithIdentityAndUpdateWithIdentity_CanUpdate(t *testing.T) {
 	// OwnerIdentity should be the same identity that is used to do the registering/creation,
 	// and the final read check to see the state of that registered document.
-	OwnerIdentity := Actor1Signature
+	OwnerIdentity := Actor1Identity
+	OwnerSignature := Actor1Signature
 
 	test := testUtils.TestCase{
 
@@ -241,7 +242,7 @@ func TestACP_CreateWithIdentityAndUpdateWithIdentity_CanUpdate(t *testing.T) {
 		Actions: []any{
 			testUtils.AddPolicy{
 
-				Creator: OwnerIdentity,
+				Creator: OwnerSignature,
 
 				Policy: `
                     description: a test policy which marks a collection in a database as a resource
@@ -342,7 +343,8 @@ func TestACP_CreateWithIdentityAndUpdateWithIdentity_CanUpdate(t *testing.T) {
 func TestACP_CreateWithIdentityAndUpdateWithoutIdentity_CanNotUpdate(t *testing.T) {
 	// OwnerIdentity should be the same identity that is used to do the registering/creation,
 	// and the final read check to see the state of that registered document.
-	OwnerIdentity := Actor1Signature
+	OwnerSignature := Actor1Signature
+	OwnerIdentity := Actor1Identity
 
 	test := testUtils.TestCase{
 
@@ -357,7 +359,7 @@ func TestACP_CreateWithIdentityAndUpdateWithoutIdentity_CanNotUpdate(t *testing.
 		Actions: []any{
 			testUtils.AddPolicy{
 
-				Creator: OwnerIdentity,
+				Creator: OwnerSignature,
 
 				Policy: `
                     description: a test policy which marks a collection in a database as a resource
@@ -458,9 +460,10 @@ func TestACP_CreateWithIdentityAndUpdateWithoutIdentity_CanNotUpdate(t *testing.
 func TestACP_CreateWithIdentityAndUpdateWithWrongIdentity_CanNotUpdate(t *testing.T) {
 	// OwnerIdentity should be the same identity that is used to do the registering/creation,
 	// and the final read check to see the state of that registered document.
-	OwnerIdentity := Actor1Signature
+	OwnerIdentity := Actor1Identity
+	OwnerSignature := Actor1Signature
 
-	WrongIdentity := Actor2Signature
+	WrongIdentity := Actor2Identity
 
 	test := testUtils.TestCase{
 
@@ -475,7 +478,7 @@ func TestACP_CreateWithIdentityAndUpdateWithWrongIdentity_CanNotUpdate(t *testin
 		Actions: []any{
 			testUtils.AddPolicy{
 
-				Creator: OwnerIdentity,
+				Creator: OwnerSignature,
 
 				Policy: `
                     description: a test policy which marks a collection in a database as a resource
@@ -580,7 +583,8 @@ func TestACP_CreateWithIdentityAndUpdateWithWrongIdentity_CanNotUpdate(t *testin
 func TestACP_CreateWithIdentityAndUpdateWithoutIdentityGQL_CanNotUpdate(t *testing.T) {
 	// OwnerIdentity should be the same identity that is used to do the registering/creation,
 	// and the final read check to see the state of that registered document.
-	OwnerIdentity := Actor1Signature
+	OwnerIdentity := Actor1Identity
+	OwnerSignature := Actor1Signature
 
 	test := testUtils.TestCase{
 
@@ -594,7 +598,7 @@ func TestACP_CreateWithIdentityAndUpdateWithoutIdentityGQL_CanNotUpdate(t *testi
 		Actions: []any{
 			testUtils.AddPolicy{
 
-				Creator: OwnerIdentity,
+				Creator: OwnerSignature,
 
 				Policy: `
                     description: a test policy which marks a collection in a database as a resource
@@ -695,9 +699,10 @@ func TestACP_CreateWithIdentityAndUpdateWithoutIdentityGQL_CanNotUpdate(t *testi
 func TestACP_CreateWithIdentityAndUpdateWithWrongIdentityGQL_CanNotUpdate(t *testing.T) {
 	// OwnerIdentity should be the same identity that is used to do the registering/creation,
 	// and the final read check to see the state of that registered document.
-	OwnerIdentity := Actor1Signature
+	OwnerIdentity := Actor1Identity
+	OwnerSignature := Actor1Signature
 
-	WrongIdentity := Actor2Signature
+	WrongIdentity := Actor2Identity
 
 	test := testUtils.TestCase{
 
@@ -711,7 +716,7 @@ func TestACP_CreateWithIdentityAndUpdateWithWrongIdentityGQL_CanNotUpdate(t *tes
 		Actions: []any{
 			testUtils.AddPolicy{
 
-				Creator: OwnerIdentity,
+				Creator: OwnerSignature,
 
 				Policy: `
                     description: a test policy which marks a collection in a database as a resource

--- a/tests/integration/acp/register_and_update_test.go
+++ b/tests/integration/acp/register_and_update_test.go
@@ -194,7 +194,7 @@ func TestACP_CreateWithoutIdentityAndUpdateWithIdentity_CanUpdate(t *testing.T) 
 			testUtils.UpdateDoc{
 				CollectionID: 0,
 
-				Identity: Actor1Identity,
+				Identity: Actor1Signature,
 
 				DocID: 0,
 
@@ -232,7 +232,7 @@ func TestACP_CreateWithoutIdentityAndUpdateWithIdentity_CanUpdate(t *testing.T) 
 func TestACP_CreateWithIdentityAndUpdateWithIdentity_CanUpdate(t *testing.T) {
 	// OwnerIdentity should be the same identity that is used to do the registering/creation,
 	// and the final read check to see the state of that registered document.
-	OwnerIdentity := Actor1Identity
+	OwnerIdentity := Actor1Signature
 	OwnerSignature := Actor1Signature
 
 	test := testUtils.TestCase{
@@ -344,7 +344,7 @@ func TestACP_CreateWithIdentityAndUpdateWithoutIdentity_CanNotUpdate(t *testing.
 	// OwnerIdentity should be the same identity that is used to do the registering/creation,
 	// and the final read check to see the state of that registered document.
 	OwnerSignature := Actor1Signature
-	OwnerIdentity := Actor1Identity
+	OwnerIdentity := Actor1Signature
 
 	test := testUtils.TestCase{
 
@@ -460,10 +460,9 @@ func TestACP_CreateWithIdentityAndUpdateWithoutIdentity_CanNotUpdate(t *testing.
 func TestACP_CreateWithIdentityAndUpdateWithWrongIdentity_CanNotUpdate(t *testing.T) {
 	// OwnerIdentity should be the same identity that is used to do the registering/creation,
 	// and the final read check to see the state of that registered document.
-	OwnerIdentity := Actor1Identity
-	OwnerSignature := Actor1Signature
+	OwnerIdentity := Actor1Signature
 
-	WrongIdentity := Actor2Identity
+	WrongIdentity := Actor2Signature
 
 	test := testUtils.TestCase{
 
@@ -478,7 +477,7 @@ func TestACP_CreateWithIdentityAndUpdateWithWrongIdentity_CanNotUpdate(t *testin
 		Actions: []any{
 			testUtils.AddPolicy{
 
-				Creator: OwnerSignature,
+				Creator: OwnerIdentity,
 
 				Policy: `
                     description: a test policy which marks a collection in a database as a resource
@@ -583,7 +582,7 @@ func TestACP_CreateWithIdentityAndUpdateWithWrongIdentity_CanNotUpdate(t *testin
 func TestACP_CreateWithIdentityAndUpdateWithoutIdentityGQL_CanNotUpdate(t *testing.T) {
 	// OwnerIdentity should be the same identity that is used to do the registering/creation,
 	// and the final read check to see the state of that registered document.
-	OwnerIdentity := Actor1Identity
+	OwnerIdentity := Actor1Signature
 	OwnerSignature := Actor1Signature
 
 	test := testUtils.TestCase{
@@ -699,10 +698,9 @@ func TestACP_CreateWithIdentityAndUpdateWithoutIdentityGQL_CanNotUpdate(t *testi
 func TestACP_CreateWithIdentityAndUpdateWithWrongIdentityGQL_CanNotUpdate(t *testing.T) {
 	// OwnerIdentity should be the same identity that is used to do the registering/creation,
 	// and the final read check to see the state of that registered document.
-	OwnerIdentity := Actor1Identity
-	OwnerSignature := Actor1Signature
+	OwnerIdentity := Actor1Signature
 
-	WrongIdentity := Actor2Identity
+	WrongIdentity := Actor2Signature
 
 	test := testUtils.TestCase{
 
@@ -716,7 +714,7 @@ func TestACP_CreateWithIdentityAndUpdateWithWrongIdentityGQL_CanNotUpdate(t *tes
 		Actions: []any{
 			testUtils.AddPolicy{
 
-				Creator: OwnerSignature,
+				Creator: OwnerIdentity,
 
 				Policy: `
                     description: a test policy which marks a collection in a database as a resource

--- a/tests/integration/acp/register_and_update_test.go
+++ b/tests/integration/acp/register_and_update_test.go
@@ -30,7 +30,7 @@ func TestACP_CreateWithoutIdentityAndUpdateWithoutIdentity_CanUpdate(t *testing.
 		Actions: []any{
 			testUtils.AddPolicy{
 
-				Creator: Actor1Identity,
+				Identity: Actor1Identity,
 
 				Policy: `
                     description: a test policy which marks a collection in a database as a resource
@@ -135,7 +135,7 @@ func TestACP_CreateWithoutIdentityAndUpdateWithIdentity_CanUpdate(t *testing.T) 
 		Actions: []any{
 			testUtils.AddPolicy{
 
-				Creator: Actor1Identity,
+				Identity: Actor1Identity,
 
 				Policy: `
                     description: a test policy which marks a collection in a database as a resource
@@ -241,7 +241,7 @@ func TestACP_CreateWithIdentityAndUpdateWithIdentity_CanUpdate(t *testing.T) {
 		Actions: []any{
 			testUtils.AddPolicy{
 
-				Creator: OwnerIdentity,
+				Identity: OwnerIdentity,
 
 				Policy: `
                     description: a test policy which marks a collection in a database as a resource
@@ -357,7 +357,7 @@ func TestACP_CreateWithIdentityAndUpdateWithoutIdentity_CanNotUpdate(t *testing.
 		Actions: []any{
 			testUtils.AddPolicy{
 
-				Creator: OwnerIdentity,
+				Identity: OwnerIdentity,
 
 				Policy: `
                     description: a test policy which marks a collection in a database as a resource
@@ -475,7 +475,7 @@ func TestACP_CreateWithIdentityAndUpdateWithWrongIdentity_CanNotUpdate(t *testin
 		Actions: []any{
 			testUtils.AddPolicy{
 
-				Creator: OwnerIdentity,
+				Identity: OwnerIdentity,
 
 				Policy: `
                     description: a test policy which marks a collection in a database as a resource
@@ -594,7 +594,7 @@ func TestACP_CreateWithIdentityAndUpdateWithoutIdentityGQL_CanNotUpdate(t *testi
 		Actions: []any{
 			testUtils.AddPolicy{
 
-				Creator: OwnerIdentity,
+				Identity: OwnerIdentity,
 
 				Policy: `
                     description: a test policy which marks a collection in a database as a resource
@@ -711,7 +711,7 @@ func TestACP_CreateWithIdentityAndUpdateWithWrongIdentityGQL_CanNotUpdate(t *tes
 		Actions: []any{
 			testUtils.AddPolicy{
 
-				Creator: OwnerIdentity,
+				Identity: OwnerIdentity,
 
 				Policy: `
                     description: a test policy which marks a collection in a database as a resource

--- a/tests/integration/acp/schema/add_dpi/accept_basic_dpi_fmts_test.go
+++ b/tests/integration/acp/schema/add_dpi/accept_basic_dpi_fmts_test.go
@@ -28,7 +28,7 @@ func TestACP_AddDPISchema_BasicYAML_SchemaAccepted(t *testing.T) {
 		Actions: []any{
 			testUtils.AddPolicy{
 
-				Creator: actor1Signature,
+				Creator: actor1Identity,
 
 				Policy: `
                     description: a basic policy that satisfies minimum DPI requirements
@@ -122,7 +122,7 @@ func TestACP_AddDPISchema_BasicJSON_SchemaAccepted(t *testing.T) {
 		Actions: []any{
 			testUtils.AddPolicy{
 
-				Creator: actor1Signature,
+				Creator: actor1Identity,
 
 				Policy: `
 					{

--- a/tests/integration/acp/schema/add_dpi/accept_basic_dpi_fmts_test.go
+++ b/tests/integration/acp/schema/add_dpi/accept_basic_dpi_fmts_test.go
@@ -28,7 +28,7 @@ func TestACP_AddDPISchema_BasicYAML_SchemaAccepted(t *testing.T) {
 		Actions: []any{
 			testUtils.AddPolicy{
 
-				Creator: actor1Identity,
+				Identity: actor1Identity,
 
 				Policy: `
                     description: a basic policy that satisfies minimum DPI requirements
@@ -122,7 +122,7 @@ func TestACP_AddDPISchema_BasicJSON_SchemaAccepted(t *testing.T) {
 		Actions: []any{
 			testUtils.AddPolicy{
 
-				Creator: actor1Identity,
+				Identity: actor1Identity,
 
 				Policy: `
 					{

--- a/tests/integration/acp/schema/add_dpi/accept_extra_permissions_on_dpi_test.go
+++ b/tests/integration/acp/schema/add_dpi/accept_extra_permissions_on_dpi_test.go
@@ -29,7 +29,7 @@ func TestACP_AddDPISchema_WithExtraPermsHavingRequiredRelation_AcceptSchema(t *t
 
 			testUtils.AddPolicy{
 
-				Creator: actor1Identity,
+				Identity: actor1Identity,
 
 				Policy: `
                     description: A Valid Defra Policy Interface (DPI)
@@ -128,7 +128,7 @@ func TestACP_AddDPISchema_WithExtraPermsHavingRequiredRelationInTheEnd_AcceptSch
 
 			testUtils.AddPolicy{
 
-				Creator: actor1Identity,
+				Identity: actor1Identity,
 
 				Policy: `
                     description: A Valid Defra Policy Interface (DPI)
@@ -227,7 +227,7 @@ func TestACP_AddDPISchema_WithExtraPermsHavingNoRequiredRelation_AcceptSchema(t 
 
 			testUtils.AddPolicy{
 
-				Creator: actor1Identity,
+				Identity: actor1Identity,
 
 				Policy: `
                     description: A Valid Defra Policy Interface (DPI)

--- a/tests/integration/acp/schema/add_dpi/accept_extra_permissions_on_dpi_test.go
+++ b/tests/integration/acp/schema/add_dpi/accept_extra_permissions_on_dpi_test.go
@@ -29,7 +29,7 @@ func TestACP_AddDPISchema_WithExtraPermsHavingRequiredRelation_AcceptSchema(t *t
 
 			testUtils.AddPolicy{
 
-				Creator: actor1Signature,
+				Creator: actor1Identity,
 
 				Policy: `
                     description: A Valid Defra Policy Interface (DPI)
@@ -128,7 +128,7 @@ func TestACP_AddDPISchema_WithExtraPermsHavingRequiredRelationInTheEnd_AcceptSch
 
 			testUtils.AddPolicy{
 
-				Creator: actor1Signature,
+				Creator: actor1Identity,
 
 				Policy: `
                     description: A Valid Defra Policy Interface (DPI)
@@ -227,7 +227,7 @@ func TestACP_AddDPISchema_WithExtraPermsHavingNoRequiredRelation_AcceptSchema(t 
 
 			testUtils.AddPolicy{
 
-				Creator: actor1Signature,
+				Creator: actor1Identity,
 
 				Policy: `
                     description: A Valid Defra Policy Interface (DPI)

--- a/tests/integration/acp/schema/add_dpi/accept_managed_relation_on_dpi_test.go
+++ b/tests/integration/acp/schema/add_dpi/accept_managed_relation_on_dpi_test.go
@@ -29,7 +29,7 @@ func TestACP_AddDPISchema_WithManagedRelation_AcceptSchemas(t *testing.T) {
 
 			testUtils.AddPolicy{
 
-				Creator: actor1Signature,
+				Creator: actor1Identity,
 
 				Policy: `
                     description: A Valid Defra Policy Interface (DPI)

--- a/tests/integration/acp/schema/add_dpi/accept_managed_relation_on_dpi_test.go
+++ b/tests/integration/acp/schema/add_dpi/accept_managed_relation_on_dpi_test.go
@@ -29,7 +29,7 @@ func TestACP_AddDPISchema_WithManagedRelation_AcceptSchemas(t *testing.T) {
 
 			testUtils.AddPolicy{
 
-				Creator: actor1Identity,
+				Identity: actor1Identity,
 
 				Policy: `
                     description: A Valid Defra Policy Interface (DPI)

--- a/tests/integration/acp/schema/add_dpi/accept_mixed_resources_on_partial_dpi_test.go
+++ b/tests/integration/acp/schema/add_dpi/accept_mixed_resources_on_partial_dpi_test.go
@@ -29,7 +29,7 @@ func TestACP_AddDPISchema_PartialValidDPIButUseOnlyValidDPIResource_AcceptSchema
 
 			testUtils.AddPolicy{
 
-				Creator: actor1Identity,
+				Identity: actor1Identity,
 
 				Policy: `
                     description: A Partially Valid Defra Policy Interface (DPI)

--- a/tests/integration/acp/schema/add_dpi/accept_mixed_resources_on_partial_dpi_test.go
+++ b/tests/integration/acp/schema/add_dpi/accept_mixed_resources_on_partial_dpi_test.go
@@ -29,7 +29,7 @@ func TestACP_AddDPISchema_PartialValidDPIButUseOnlyValidDPIResource_AcceptSchema
 
 			testUtils.AddPolicy{
 
-				Creator: actor1Signature,
+				Creator: actor1Identity,
 
 				Policy: `
                     description: A Partially Valid Defra Policy Interface (DPI)

--- a/tests/integration/acp/schema/add_dpi/accept_multi_dpis_test.go
+++ b/tests/integration/acp/schema/add_dpi/accept_multi_dpis_test.go
@@ -53,7 +53,7 @@ func TestACP_AddDPISchema_AddDuplicateDPIsByOtherCreatorsUseBoth_AcceptSchema(t 
 		Actions: []any{
 			testUtils.AddPolicy{
 
-				Creator: actor1Identity,
+				Identity: actor1Identity,
 
 				Policy: validDPIUsedByBoth,
 
@@ -62,7 +62,7 @@ func TestACP_AddDPISchema_AddDuplicateDPIsByOtherCreatorsUseBoth_AcceptSchema(t 
 
 			testUtils.AddPolicy{
 
-				Creator: actor2Identity,
+				Identity: actor2Identity,
 
 				Policy: validDPIUsedByBoth,
 

--- a/tests/integration/acp/schema/add_dpi/accept_multi_dpis_test.go
+++ b/tests/integration/acp/schema/add_dpi/accept_multi_dpis_test.go
@@ -53,7 +53,7 @@ func TestACP_AddDPISchema_AddDuplicateDPIsByOtherCreatorsUseBoth_AcceptSchema(t 
 		Actions: []any{
 			testUtils.AddPolicy{
 
-				Creator: actor1Signature,
+				Creator: actor1Identity,
 
 				Policy: validDPIUsedByBoth,
 
@@ -62,7 +62,7 @@ func TestACP_AddDPISchema_AddDuplicateDPIsByOtherCreatorsUseBoth_AcceptSchema(t 
 
 			testUtils.AddPolicy{
 
-				Creator: actor2Signature,
+				Creator: actor2Identity,
 
 				Policy: validDPIUsedByBoth,
 

--- a/tests/integration/acp/schema/add_dpi/accept_multi_resources_on_dpi_test.go
+++ b/tests/integration/acp/schema/add_dpi/accept_multi_resources_on_dpi_test.go
@@ -29,7 +29,7 @@ func TestACP_AddDPISchema_WithMultipleResources_AcceptSchema(t *testing.T) {
 
 			testUtils.AddPolicy{
 
-				Creator: actor1Identity,
+				Identity: actor1Identity,
 
 				Policy: `
                     description: A Valid Defra Policy Interface (DPI)
@@ -138,7 +138,7 @@ func TestACP_AddDPISchema_WithMultipleResourcesBothBeingUsed_AcceptSchema(t *tes
 
 			testUtils.AddPolicy{
 
-				Creator: actor1Identity,
+				Identity: actor1Identity,
 
 				Policy: `
                     description: A Valid Defra Policy Interface (DPI)

--- a/tests/integration/acp/schema/add_dpi/accept_multi_resources_on_dpi_test.go
+++ b/tests/integration/acp/schema/add_dpi/accept_multi_resources_on_dpi_test.go
@@ -29,7 +29,7 @@ func TestACP_AddDPISchema_WithMultipleResources_AcceptSchema(t *testing.T) {
 
 			testUtils.AddPolicy{
 
-				Creator: actor1Signature,
+				Creator: actor1Identity,
 
 				Policy: `
                     description: A Valid Defra Policy Interface (DPI)
@@ -138,7 +138,7 @@ func TestACP_AddDPISchema_WithMultipleResourcesBothBeingUsed_AcceptSchema(t *tes
 
 			testUtils.AddPolicy{
 
-				Creator: actor1Signature,
+				Creator: actor1Identity,
 
 				Policy: `
                     description: A Valid Defra Policy Interface (DPI)

--- a/tests/integration/acp/schema/add_dpi/accept_same_resource_on_diff_schemas_test.go
+++ b/tests/integration/acp/schema/add_dpi/accept_same_resource_on_diff_schemas_test.go
@@ -30,7 +30,7 @@ func TestACP_AddDPISchema_UseSameResourceOnDifferentSchemas_AcceptSchemas(t *tes
 
 			testUtils.AddPolicy{
 
-				Creator: actor1Identity,
+				Identity: actor1Identity,
 
 				Policy: `
                     description: A Valid Defra Policy Interface (DPI)

--- a/tests/integration/acp/schema/add_dpi/accept_same_resource_on_diff_schemas_test.go
+++ b/tests/integration/acp/schema/add_dpi/accept_same_resource_on_diff_schemas_test.go
@@ -30,7 +30,7 @@ func TestACP_AddDPISchema_UseSameResourceOnDifferentSchemas_AcceptSchemas(t *tes
 
 			testUtils.AddPolicy{
 
-				Creator: actor1Signature,
+				Creator: actor1Identity,
 
 				Policy: `
                     description: A Valid Defra Policy Interface (DPI)

--- a/tests/integration/acp/schema/add_dpi/fixture.go
+++ b/tests/integration/acp/schema/add_dpi/fixture.go
@@ -14,5 +14,5 @@ import (
 	acpUtils "github.com/sourcenetwork/defradb/tests/integration/acp"
 )
 
-var actor1Signature = acpUtils.Actor1Signature
-var actor2Signature = acpUtils.Actor2Signature
+var actor1Identity = acpUtils.Actor1Identity
+var actor2Identity = acpUtils.Actor2Identity

--- a/tests/integration/acp/schema/add_dpi/reject_empty_arg_on_schema_test.go
+++ b/tests/integration/acp/schema/add_dpi/reject_empty_arg_on_schema_test.go
@@ -27,7 +27,7 @@ func TestACP_AddDPISchema_NoArgWasSpecifiedOnSchema_SchemaRejected(t *testing.T)
 
 			testUtils.AddPolicy{
 
-				Creator: actor1Identity,
+				Identity: actor1Identity,
 
 				Policy: `
                     description: A Valid Defra Policy Interface (DPI)
@@ -101,7 +101,7 @@ func TestACP_AddDPISchema_SpecifiedArgsAreEmptyOnSchema_SchemaRejected(t *testin
 
 			testUtils.AddPolicy{
 
-				Creator: actor1Identity,
+				Identity: actor1Identity,
 
 				Policy: `
                     description: A Valid Defra Policy Interface (DPI)

--- a/tests/integration/acp/schema/add_dpi/reject_empty_arg_on_schema_test.go
+++ b/tests/integration/acp/schema/add_dpi/reject_empty_arg_on_schema_test.go
@@ -27,7 +27,7 @@ func TestACP_AddDPISchema_NoArgWasSpecifiedOnSchema_SchemaRejected(t *testing.T)
 
 			testUtils.AddPolicy{
 
-				Creator: actor1Signature,
+				Creator: actor1Identity,
 
 				Policy: `
                     description: A Valid Defra Policy Interface (DPI)
@@ -101,7 +101,7 @@ func TestACP_AddDPISchema_SpecifiedArgsAreEmptyOnSchema_SchemaRejected(t *testin
 
 			testUtils.AddPolicy{
 
-				Creator: actor1Signature,
+				Creator: actor1Identity,
 
 				Policy: `
                     description: A Valid Defra Policy Interface (DPI)

--- a/tests/integration/acp/schema/add_dpi/reject_invalid_arg_type_on_schema_test.go
+++ b/tests/integration/acp/schema/add_dpi/reject_invalid_arg_type_on_schema_test.go
@@ -28,7 +28,7 @@ func TestACP_AddDPISchema_InvalidPolicyIDArgTypeWasSpecifiedOnSchema_SchemaRejec
 
 			testUtils.AddPolicy{
 
-				Creator: actor1Signature,
+				Creator: actor1Identity,
 
 				Policy: `
                     description: A Valid Defra Policy Interface (DPI)
@@ -102,7 +102,7 @@ func TestACP_AddDPISchema_InvalidResourceArgTypeWasSpecifiedOnSchema_SchemaRejec
 
 			testUtils.AddPolicy{
 
-				Creator: actor1Signature,
+				Creator: actor1Identity,
 
 				Policy: `
                     description: A Valid Defra Policy Interface (DPI)

--- a/tests/integration/acp/schema/add_dpi/reject_invalid_arg_type_on_schema_test.go
+++ b/tests/integration/acp/schema/add_dpi/reject_invalid_arg_type_on_schema_test.go
@@ -28,7 +28,7 @@ func TestACP_AddDPISchema_InvalidPolicyIDArgTypeWasSpecifiedOnSchema_SchemaRejec
 
 			testUtils.AddPolicy{
 
-				Creator: actor1Identity,
+				Identity: actor1Identity,
 
 				Policy: `
                     description: A Valid Defra Policy Interface (DPI)
@@ -102,7 +102,7 @@ func TestACP_AddDPISchema_InvalidResourceArgTypeWasSpecifiedOnSchema_SchemaRejec
 
 			testUtils.AddPolicy{
 
-				Creator: actor1Identity,
+				Identity: actor1Identity,
 
 				Policy: `
                     description: A Valid Defra Policy Interface (DPI)

--- a/tests/integration/acp/schema/add_dpi/reject_invalid_owner_read_perm_on_dpi_test.go
+++ b/tests/integration/acp/schema/add_dpi/reject_invalid_owner_read_perm_on_dpi_test.go
@@ -28,7 +28,7 @@ func TestACP_AddDPISchema_OwnerMissingRequiredReadPermissionOnDPI_SchemaRejected
 
 			testUtils.AddPolicy{
 
-				Creator: actor1Identity,
+				Identity: actor1Identity,
 
 				Policy: `
                     description: a policy
@@ -112,7 +112,7 @@ func TestACP_AddDPISchema_OwnerMissingRequiredReadPermissionLabelOnDPI_SchemaRej
 
 			testUtils.AddPolicy{
 
-				Creator: actor1Identity,
+				Identity: actor1Identity,
 
 				Policy: `
                     description: a policy
@@ -195,7 +195,7 @@ func TestACP_AddDPISchema_OwnerSpecifiedIncorrectlyOnReadPermissionExprOnDPI_Sch
 
 			testUtils.AddPolicy{
 
-				Creator: actor1Identity,
+				Identity: actor1Identity,
 
 				Policy: `
                     description: a policy
@@ -279,7 +279,7 @@ func TestACP_AddDPISchema_OwnerSpecifiedIncorrectlyOnReadPermissionNoSpaceExprOn
 
 			testUtils.AddPolicy{
 
-				Creator: actor1Identity,
+				Identity: actor1Identity,
 
 				Policy: `
                     description: a policy
@@ -363,7 +363,7 @@ func TestACP_AddDPISchema_MaliciousOwnerSpecifiedOnReadPermissionExprOnDPI_Schem
 
 			testUtils.AddPolicy{
 
-				Creator: actor1Identity,
+				Identity: actor1Identity,
 
 				Policy: `
                     description: a policy

--- a/tests/integration/acp/schema/add_dpi/reject_invalid_owner_read_perm_on_dpi_test.go
+++ b/tests/integration/acp/schema/add_dpi/reject_invalid_owner_read_perm_on_dpi_test.go
@@ -28,7 +28,7 @@ func TestACP_AddDPISchema_OwnerMissingRequiredReadPermissionOnDPI_SchemaRejected
 
 			testUtils.AddPolicy{
 
-				Creator: actor1Signature,
+				Creator: actor1Identity,
 
 				Policy: `
                     description: a policy
@@ -112,7 +112,7 @@ func TestACP_AddDPISchema_OwnerMissingRequiredReadPermissionLabelOnDPI_SchemaRej
 
 			testUtils.AddPolicy{
 
-				Creator: actor1Signature,
+				Creator: actor1Identity,
 
 				Policy: `
                     description: a policy
@@ -195,7 +195,7 @@ func TestACP_AddDPISchema_OwnerSpecifiedIncorrectlyOnReadPermissionExprOnDPI_Sch
 
 			testUtils.AddPolicy{
 
-				Creator: actor1Signature,
+				Creator: actor1Identity,
 
 				Policy: `
                     description: a policy
@@ -279,7 +279,7 @@ func TestACP_AddDPISchema_OwnerSpecifiedIncorrectlyOnReadPermissionNoSpaceExprOn
 
 			testUtils.AddPolicy{
 
-				Creator: actor1Signature,
+				Creator: actor1Identity,
 
 				Policy: `
                     description: a policy
@@ -363,7 +363,7 @@ func TestACP_AddDPISchema_MaliciousOwnerSpecifiedOnReadPermissionExprOnDPI_Schem
 
 			testUtils.AddPolicy{
 
-				Creator: actor1Signature,
+				Creator: actor1Identity,
 
 				Policy: `
                     description: a policy

--- a/tests/integration/acp/schema/add_dpi/reject_invalid_owner_read_perm_symbol_on_dpi_test.go
+++ b/tests/integration/acp/schema/add_dpi/reject_invalid_owner_read_perm_symbol_on_dpi_test.go
@@ -28,7 +28,7 @@ func TestACP_AddDPISchema_OwnerRelationWithDifferenceSetOpOnReadPermissionExprOn
 
 			testUtils.AddPolicy{
 
-				Creator: actor1Identity,
+				Identity: actor1Identity,
 
 				Policy: `
                     description: a policy
@@ -113,7 +113,7 @@ func TestACP_AddDPISchema_OwnerRelationWithIntersectionSetOpOnReadPermissionExpr
 
 			testUtils.AddPolicy{
 
-				Creator: actor1Identity,
+				Identity: actor1Identity,
 
 				Policy: `
                     description: a policy
@@ -198,7 +198,7 @@ func TestACP_AddDPISchema_OwnerRelationWithInvalidSetOpOnReadPermissionExprOnDPI
 
 			testUtils.AddPolicy{
 
-				Creator: actor1Identity,
+				Identity: actor1Identity,
 
 				Policy: `
                     description: a policy

--- a/tests/integration/acp/schema/add_dpi/reject_invalid_owner_read_perm_symbol_on_dpi_test.go
+++ b/tests/integration/acp/schema/add_dpi/reject_invalid_owner_read_perm_symbol_on_dpi_test.go
@@ -28,7 +28,7 @@ func TestACP_AddDPISchema_OwnerRelationWithDifferenceSetOpOnReadPermissionExprOn
 
 			testUtils.AddPolicy{
 
-				Creator: actor1Signature,
+				Creator: actor1Identity,
 
 				Policy: `
                     description: a policy
@@ -113,7 +113,7 @@ func TestACP_AddDPISchema_OwnerRelationWithIntersectionSetOpOnReadPermissionExpr
 
 			testUtils.AddPolicy{
 
-				Creator: actor1Signature,
+				Creator: actor1Identity,
 
 				Policy: `
                     description: a policy
@@ -198,7 +198,7 @@ func TestACP_AddDPISchema_OwnerRelationWithInvalidSetOpOnReadPermissionExprOnDPI
 
 			testUtils.AddPolicy{
 
-				Creator: actor1Signature,
+				Creator: actor1Identity,
 
 				Policy: `
                     description: a policy

--- a/tests/integration/acp/schema/add_dpi/reject_invalid_owner_write_perm_on_dpi_test.go
+++ b/tests/integration/acp/schema/add_dpi/reject_invalid_owner_write_perm_on_dpi_test.go
@@ -28,7 +28,7 @@ func TestACP_AddDPISchema_OwnerMissingRequiredWritePermissionOnDPI_SchemaRejecte
 
 			testUtils.AddPolicy{
 
-				Creator: actor1Signature,
+				Creator: actor1Identity,
 
 				Policy: `
                     description: a policy
@@ -112,7 +112,7 @@ func TestACP_AddDPISchema_OwnerMissingRequiredWritePermissionLabelOnDPI_SchemaRe
 
 			testUtils.AddPolicy{
 
-				Creator: actor1Signature,
+				Creator: actor1Identity,
 
 				Policy: `
                      description: a policy
@@ -195,7 +195,7 @@ func TestACP_AddDPISchema_OwnerSpecifiedIncorrectlyOnWritePermissionExprOnDPI_Sc
 
 			testUtils.AddPolicy{
 
-				Creator: actor1Signature,
+				Creator: actor1Identity,
 
 				Policy: `
                      description: a policy
@@ -279,7 +279,7 @@ func TestACP_AddDPISchema_OwnerSpecifiedIncorrectlyOnWritePermissionNoSpaceExprO
 
 			testUtils.AddPolicy{
 
-				Creator: actor1Signature,
+				Creator: actor1Identity,
 
 				Policy: `
                      description: a policy
@@ -363,7 +363,7 @@ func TestACP_AddDPISchema_MaliciousOwnerSpecifiedOnWritePermissionExprOnDPI_Sche
 
 			testUtils.AddPolicy{
 
-				Creator: actor1Signature,
+				Creator: actor1Identity,
 
 				Policy: `
                      description: a policy

--- a/tests/integration/acp/schema/add_dpi/reject_invalid_owner_write_perm_on_dpi_test.go
+++ b/tests/integration/acp/schema/add_dpi/reject_invalid_owner_write_perm_on_dpi_test.go
@@ -28,7 +28,7 @@ func TestACP_AddDPISchema_OwnerMissingRequiredWritePermissionOnDPI_SchemaRejecte
 
 			testUtils.AddPolicy{
 
-				Creator: actor1Identity,
+				Identity: actor1Identity,
 
 				Policy: `
                     description: a policy
@@ -112,7 +112,7 @@ func TestACP_AddDPISchema_OwnerMissingRequiredWritePermissionLabelOnDPI_SchemaRe
 
 			testUtils.AddPolicy{
 
-				Creator: actor1Identity,
+				Identity: actor1Identity,
 
 				Policy: `
                      description: a policy
@@ -195,7 +195,7 @@ func TestACP_AddDPISchema_OwnerSpecifiedIncorrectlyOnWritePermissionExprOnDPI_Sc
 
 			testUtils.AddPolicy{
 
-				Creator: actor1Identity,
+				Identity: actor1Identity,
 
 				Policy: `
                      description: a policy
@@ -279,7 +279,7 @@ func TestACP_AddDPISchema_OwnerSpecifiedIncorrectlyOnWritePermissionNoSpaceExprO
 
 			testUtils.AddPolicy{
 
-				Creator: actor1Identity,
+				Identity: actor1Identity,
 
 				Policy: `
                      description: a policy
@@ -363,7 +363,7 @@ func TestACP_AddDPISchema_MaliciousOwnerSpecifiedOnWritePermissionExprOnDPI_Sche
 
 			testUtils.AddPolicy{
 
-				Creator: actor1Identity,
+				Identity: actor1Identity,
 
 				Policy: `
                      description: a policy

--- a/tests/integration/acp/schema/add_dpi/reject_invalid_owner_write_perm_symbol_on_dpi_test.go
+++ b/tests/integration/acp/schema/add_dpi/reject_invalid_owner_write_perm_symbol_on_dpi_test.go
@@ -28,7 +28,7 @@ func TestACP_AddDPISchema_OwnerRelationWithDifferenceSetOpOnWritePermissionExprO
 
 			testUtils.AddPolicy{
 
-				Creator: actor1Signature,
+				Creator: actor1Identity,
 
 				Policy: `
                     description: a policy
@@ -113,7 +113,7 @@ func TestACP_AddDPISchema_OwnerRelationWithIntersectionSetOpOnWritePermissionExp
 
 			testUtils.AddPolicy{
 
-				Creator: actor1Signature,
+				Creator: actor1Identity,
 
 				Policy: `
                     description: a policy
@@ -198,7 +198,7 @@ func TestACP_AddDPISchema_OwnerRelationWithInvalidSetOpOnWritePermissionExprOnDP
 
 			testUtils.AddPolicy{
 
-				Creator: actor1Signature,
+				Creator: actor1Identity,
 
 				Policy: `
                     description: a policy

--- a/tests/integration/acp/schema/add_dpi/reject_invalid_owner_write_perm_symbol_on_dpi_test.go
+++ b/tests/integration/acp/schema/add_dpi/reject_invalid_owner_write_perm_symbol_on_dpi_test.go
@@ -28,7 +28,7 @@ func TestACP_AddDPISchema_OwnerRelationWithDifferenceSetOpOnWritePermissionExprO
 
 			testUtils.AddPolicy{
 
-				Creator: actor1Identity,
+				Identity: actor1Identity,
 
 				Policy: `
                     description: a policy
@@ -113,7 +113,7 @@ func TestACP_AddDPISchema_OwnerRelationWithIntersectionSetOpOnWritePermissionExp
 
 			testUtils.AddPolicy{
 
-				Creator: actor1Identity,
+				Identity: actor1Identity,
 
 				Policy: `
                     description: a policy
@@ -198,7 +198,7 @@ func TestACP_AddDPISchema_OwnerRelationWithInvalidSetOpOnWritePermissionExprOnDP
 
 			testUtils.AddPolicy{
 
-				Creator: actor1Identity,
+				Identity: actor1Identity,
 
 				Policy: `
                     description: a policy

--- a/tests/integration/acp/schema/add_dpi/reject_missing_dpi_test.go
+++ b/tests/integration/acp/schema/add_dpi/reject_missing_dpi_test.go
@@ -79,7 +79,7 @@ func TestACP_AddDPISchema_WhereAPolicyWasAddedButLinkedPolicyWasNotAdded_SchemaR
 
 			testUtils.AddPolicy{
 
-				Creator: actor1Signature,
+				Creator: actor1Identity,
 
 				Policy: `
                     description: A Valid Defra Policy Interface (DPI)

--- a/tests/integration/acp/schema/add_dpi/reject_missing_dpi_test.go
+++ b/tests/integration/acp/schema/add_dpi/reject_missing_dpi_test.go
@@ -79,7 +79,7 @@ func TestACP_AddDPISchema_WhereAPolicyWasAddedButLinkedPolicyWasNotAdded_SchemaR
 
 			testUtils.AddPolicy{
 
-				Creator: actor1Identity,
+				Identity: actor1Identity,
 
 				Policy: `
                     description: A Valid Defra Policy Interface (DPI)

--- a/tests/integration/acp/schema/add_dpi/reject_missing_id_arg_on_schema_test.go
+++ b/tests/integration/acp/schema/add_dpi/reject_missing_id_arg_on_schema_test.go
@@ -27,7 +27,7 @@ func TestACP_AddDPISchema_NoPolicyIDWasSpecifiedOnSchema_SchemaRejected(t *testi
 
 			testUtils.AddPolicy{
 
-				Creator: actor1Signature,
+				Creator: actor1Identity,
 
 				Policy: `
                     description: A Valid Defra Policy Interface (DPI)
@@ -101,7 +101,7 @@ func TestACP_AddDPISchema_SpecifiedPolicyIDArgIsEmptyOnSchema_SchemaRejected(t *
 
 			testUtils.AddPolicy{
 
-				Creator: actor1Signature,
+				Creator: actor1Identity,
 
 				Policy: `
                     description: A Valid Defra Policy Interface (DPI)

--- a/tests/integration/acp/schema/add_dpi/reject_missing_id_arg_on_schema_test.go
+++ b/tests/integration/acp/schema/add_dpi/reject_missing_id_arg_on_schema_test.go
@@ -27,7 +27,7 @@ func TestACP_AddDPISchema_NoPolicyIDWasSpecifiedOnSchema_SchemaRejected(t *testi
 
 			testUtils.AddPolicy{
 
-				Creator: actor1Identity,
+				Identity: actor1Identity,
 
 				Policy: `
                     description: A Valid Defra Policy Interface (DPI)
@@ -101,7 +101,7 @@ func TestACP_AddDPISchema_SpecifiedPolicyIDArgIsEmptyOnSchema_SchemaRejected(t *
 
 			testUtils.AddPolicy{
 
-				Creator: actor1Identity,
+				Identity: actor1Identity,
 
 				Policy: `
                     description: A Valid Defra Policy Interface (DPI)

--- a/tests/integration/acp/schema/add_dpi/reject_missing_perms_on_dpi_test.go
+++ b/tests/integration/acp/schema/add_dpi/reject_missing_perms_on_dpi_test.go
@@ -28,7 +28,7 @@ func TestACP_AddDPISchema_MissingRequiredReadPermissionOnDPI_SchemaRejected(t *t
 
 			testUtils.AddPolicy{
 
-				Creator: actor1Signature,
+				Creator: actor1Identity,
 
 				Policy: `
                     description: A policy

--- a/tests/integration/acp/schema/add_dpi/reject_missing_perms_on_dpi_test.go
+++ b/tests/integration/acp/schema/add_dpi/reject_missing_perms_on_dpi_test.go
@@ -28,7 +28,7 @@ func TestACP_AddDPISchema_MissingRequiredReadPermissionOnDPI_SchemaRejected(t *t
 
 			testUtils.AddPolicy{
 
-				Creator: actor1Identity,
+				Identity: actor1Identity,
 
 				Policy: `
                     description: A policy

--- a/tests/integration/acp/schema/add_dpi/reject_missing_resource_arg_on_schema_test.go
+++ b/tests/integration/acp/schema/add_dpi/reject_missing_resource_arg_on_schema_test.go
@@ -28,7 +28,7 @@ func TestACP_AddDPISchema_NoResourceWasSpecifiedOnSchema_SchemaRejected(t *testi
 
 			testUtils.AddPolicy{
 
-				Creator: actor1Identity,
+				Identity: actor1Identity,
 
 				Policy: `
                     description: A Valid Defra Policy Interface (DPI)
@@ -104,7 +104,7 @@ func TestACP_AddDPISchema_SpecifiedResourceArgIsEmptyOnSchema_SchemaRejected(t *
 
 			testUtils.AddPolicy{
 
-				Creator: actor1Identity,
+				Identity: actor1Identity,
 
 				Policy: `
                     description: A Valid Defra Policy Interface (DPI)

--- a/tests/integration/acp/schema/add_dpi/reject_missing_resource_arg_on_schema_test.go
+++ b/tests/integration/acp/schema/add_dpi/reject_missing_resource_arg_on_schema_test.go
@@ -28,7 +28,7 @@ func TestACP_AddDPISchema_NoResourceWasSpecifiedOnSchema_SchemaRejected(t *testi
 
 			testUtils.AddPolicy{
 
-				Creator: actor1Signature,
+				Creator: actor1Identity,
 
 				Policy: `
                     description: A Valid Defra Policy Interface (DPI)
@@ -104,7 +104,7 @@ func TestACP_AddDPISchema_SpecifiedResourceArgIsEmptyOnSchema_SchemaRejected(t *
 
 			testUtils.AddPolicy{
 
-				Creator: actor1Signature,
+				Creator: actor1Identity,
 
 				Policy: `
                     description: A Valid Defra Policy Interface (DPI)

--- a/tests/integration/acp/schema/add_dpi/reject_missing_resource_on_dpi_test.go
+++ b/tests/integration/acp/schema/add_dpi/reject_missing_resource_on_dpi_test.go
@@ -28,7 +28,7 @@ func TestACP_AddDPISchema_SpecifiedResourceDoesNotExistOnDPI_SchemaRejected(t *t
 
 			testUtils.AddPolicy{
 
-				Creator: actor1Identity,
+				Identity: actor1Identity,
 
 				Policy: `
                     description: A Valid Defra Policy Interface (DPI)

--- a/tests/integration/acp/schema/add_dpi/reject_missing_resource_on_dpi_test.go
+++ b/tests/integration/acp/schema/add_dpi/reject_missing_resource_on_dpi_test.go
@@ -28,7 +28,7 @@ func TestACP_AddDPISchema_SpecifiedResourceDoesNotExistOnDPI_SchemaRejected(t *t
 
 			testUtils.AddPolicy{
 
-				Creator: actor1Signature,
+				Creator: actor1Identity,
 
 				Policy: `
                     description: A Valid Defra Policy Interface (DPI)

--- a/tests/integration/acp/schema/add_dpi/reject_mixed_resources_on_partial_dpi_test.go
+++ b/tests/integration/acp/schema/add_dpi/reject_mixed_resources_on_partial_dpi_test.go
@@ -28,7 +28,7 @@ func TestACP_AddDPISchema_PartialValidDPIButUseInValidDPIResource_RejectSchema(t
 
 			testUtils.AddPolicy{
 
-				Creator: actor1Identity,
+				Identity: actor1Identity,
 
 				Policy: `
                     description: A Partially Valid Defra Policy Interface (DPI)

--- a/tests/integration/acp/schema/add_dpi/reject_mixed_resources_on_partial_dpi_test.go
+++ b/tests/integration/acp/schema/add_dpi/reject_mixed_resources_on_partial_dpi_test.go
@@ -28,7 +28,7 @@ func TestACP_AddDPISchema_PartialValidDPIButUseInValidDPIResource_RejectSchema(t
 
 			testUtils.AddPolicy{
 
-				Creator: actor1Signature,
+				Creator: actor1Identity,
 
 				Policy: `
                     description: A Partially Valid Defra Policy Interface (DPI)

--- a/tests/integration/collection/update/simple/with_doc_id_test.go
+++ b/tests/integration/collection/update/simple/with_doc_id_test.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	testUtils "github.com/sourcenetwork/defradb/tests/integration/collection"
 )
@@ -44,7 +43,6 @@ func TestUpdateWithDocID(t *testing.T) {
 						ctx := context.Background()
 						_, err := c.UpdateWithDocID(
 							ctx,
-							acpIdentity.NoIdentity,
 							doc.ID(),
 							`{name: "Eric"}`,
 						)
@@ -62,7 +60,7 @@ func TestUpdateWithDocID(t *testing.T) {
 				"Users": []func(c client.Collection) error{
 					func(c client.Collection) error {
 						ctx := context.Background()
-						_, err := c.UpdateWithDocID(ctx, acpIdentity.NoIdentity, doc.ID(), `"name: Eric"`)
+						_, err := c.UpdateWithDocID(ctx, doc.ID(), `"name: Eric"`)
 						return err
 					},
 				},
@@ -79,7 +77,7 @@ func TestUpdateWithDocID(t *testing.T) {
 						ctx := context.Background()
 						_, err := c.UpdateWithDocID(
 							ctx,
-							acpIdentity.NoIdentity,
+
 							doc.ID(),
 							`[
 								{
@@ -93,7 +91,7 @@ func TestUpdateWithDocID(t *testing.T) {
 							return err
 						}
 
-						d, err := c.Get(ctx, acpIdentity.NoIdentity, doc.ID(), false)
+						d, err := c.Get(ctx, doc.ID(), false)
 						if err != nil {
 							return err
 						}
@@ -120,7 +118,7 @@ func TestUpdateWithDocID(t *testing.T) {
 						ctx := context.Background()
 						_, err := c.UpdateWithDocID(
 							ctx,
-							acpIdentity.NoIdentity,
+
 							doc.ID(),
 							`{"name": "Eric"}`,
 						)
@@ -128,7 +126,7 @@ func TestUpdateWithDocID(t *testing.T) {
 							return err
 						}
 
-						d, err := c.Get(ctx, acpIdentity.NoIdentity, doc.ID(), false)
+						d, err := c.Get(ctx, doc.ID(), false)
 						if err != nil {
 							return err
 						}

--- a/tests/integration/collection/update/simple/with_doc_ids_test.go
+++ b/tests/integration/collection/update/simple/with_doc_ids_test.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	testUtils "github.com/sourcenetwork/defradb/tests/integration/collection"
 )
@@ -57,7 +56,6 @@ func TestUpdateWithDocIDs(t *testing.T) {
 						ctx := context.Background()
 						_, err := c.UpdateWithDocIDs(
 							ctx,
-							acpIdentity.NoIdentity,
 							[]client.DocID{doc1.ID(), doc2.ID()},
 							`{name: "Eric"}`,
 						)
@@ -80,7 +78,6 @@ func TestUpdateWithDocIDs(t *testing.T) {
 						ctx := context.Background()
 						_, err := c.UpdateWithDocIDs(
 							ctx,
-							acpIdentity.NoIdentity,
 							[]client.DocID{doc1.ID(), doc2.ID()},
 							`"name: Eric"`,
 						)
@@ -103,7 +100,6 @@ func TestUpdateWithDocIDs(t *testing.T) {
 						ctx := context.Background()
 						_, err := c.UpdateWithDocIDs(
 							ctx,
-							acpIdentity.NoIdentity,
 							[]client.DocID{doc1.ID(), doc2.ID()},
 							`[
 								{
@@ -117,7 +113,7 @@ func TestUpdateWithDocIDs(t *testing.T) {
 							return err
 						}
 
-						d, err := c.Get(ctx, acpIdentity.NoIdentity, doc1.ID(), false)
+						d, err := c.Get(ctx, doc1.ID(), false)
 						if err != nil {
 							return err
 						}
@@ -129,7 +125,7 @@ func TestUpdateWithDocIDs(t *testing.T) {
 
 						assert.Equal(t, "John", name)
 
-						d2, err := c.Get(ctx, acpIdentity.NoIdentity, doc2.ID(), false)
+						d2, err := c.Get(ctx, doc2.ID(), false)
 						if err != nil {
 							return err
 						}
@@ -159,7 +155,7 @@ func TestUpdateWithDocIDs(t *testing.T) {
 						ctx := context.Background()
 						_, err := c.UpdateWithDocIDs(
 							ctx,
-							acpIdentity.NoIdentity,
+
 							[]client.DocID{doc1.ID(), doc2.ID()},
 							`{"age": 40}`,
 						)
@@ -167,7 +163,7 @@ func TestUpdateWithDocIDs(t *testing.T) {
 							return err
 						}
 
-						d, err := c.Get(ctx, acpIdentity.NoIdentity, doc1.ID(), false)
+						d, err := c.Get(ctx, doc1.ID(), false)
 						if err != nil {
 							return err
 						}
@@ -179,7 +175,7 @@ func TestUpdateWithDocIDs(t *testing.T) {
 
 						assert.Equal(t, int64(40), name)
 
-						d2, err := c.Get(ctx, acpIdentity.NoIdentity, doc2.ID(), false)
+						d2, err := c.Get(ctx, doc2.ID(), false)
 						if err != nil {
 							return err
 						}

--- a/tests/integration/collection/update/simple/with_filter_test.go
+++ b/tests/integration/collection/update/simple/with_filter_test.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	testUtils "github.com/sourcenetwork/defradb/tests/integration/collection"
 )
@@ -32,7 +31,6 @@ func TestUpdateWithInvalidFilterType(t *testing.T) {
 					// test with an invalid filter type
 					_, err := c.UpdateWithFilter(
 						ctx,
-						acpIdentity.NoIdentity,
 						t,
 						`{"name": "Eric"}`,
 					)
@@ -57,7 +55,6 @@ func TestUpdateWithEmptyFilter(t *testing.T) {
 					// test with an empty filter
 					_, err := c.UpdateWithFilter(
 						ctx,
-						acpIdentity.NoIdentity,
 						"",
 						`{"name": "Eric"}`,
 					)
@@ -96,7 +93,6 @@ func TestUpdateWithFilter(t *testing.T) {
 						ctx := context.Background()
 						_, err := c.UpdateWithFilter(
 							ctx,
-							acpIdentity.NoIdentity,
 							filter,
 							`{name: "Eric"}`,
 						)
@@ -116,7 +112,6 @@ func TestUpdateWithFilter(t *testing.T) {
 						ctx := context.Background()
 						_, err := c.UpdateWithFilter(
 							ctx,
-							acpIdentity.NoIdentity,
 							filter,
 							`"name: Eric"`,
 						)
@@ -136,7 +131,6 @@ func TestUpdateWithFilter(t *testing.T) {
 						ctx := context.Background()
 						_, err := c.UpdateWithFilter(
 							ctx,
-							acpIdentity.NoIdentity,
 							filter,
 							`[
 								{
@@ -150,7 +144,7 @@ func TestUpdateWithFilter(t *testing.T) {
 							return err
 						}
 
-						d, err := c.Get(ctx, acpIdentity.NoIdentity, doc.ID(), false)
+						d, err := c.Get(ctx, doc.ID(), false)
 						if err != nil {
 							return err
 						}
@@ -177,7 +171,6 @@ func TestUpdateWithFilter(t *testing.T) {
 						ctx := context.Background()
 						_, err := c.UpdateWithFilter(
 							ctx,
-							acpIdentity.NoIdentity,
 							filter,
 							`{"name": "Eric"}`,
 						)
@@ -185,7 +178,7 @@ func TestUpdateWithFilter(t *testing.T) {
 							return err
 						}
 
-						d, err := c.Get(ctx, acpIdentity.NoIdentity, doc.ID(), false)
+						d, err := c.Get(ctx, doc.ID(), false)
 						if err != nil {
 							return err
 						}

--- a/tests/integration/collection/utils.go
+++ b/tests/integration/collection/utils.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/errors"
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
@@ -91,7 +90,7 @@ func setupDatabase(
 			if assertError(t, testCase.Description, err, testCase.ExpectedError) {
 				return
 			}
-			err = col.Save(ctx, acpIdentity.NoIdentity, doc)
+			err = col.Save(ctx, doc)
 			if assertError(t, testCase.Description, err, testCase.ExpectedError) {
 				return
 			}

--- a/tests/integration/collection_description/updates/remove/policy_test.go
+++ b/tests/integration/collection_description/updates/remove/policy_test.go
@@ -22,7 +22,7 @@ func TestColDescrUpdateRemovePolicy_Errors(t *testing.T) {
 		Actions: []any{
 			testUtils.AddPolicy{
 
-				Creator: acpUtils.Actor1Identity,
+				Identity: acpUtils.Actor1Identity,
 
 				Policy: `
                     description: a test policy which marks a collection in a database as a resource

--- a/tests/integration/collection_description/updates/remove/policy_test.go
+++ b/tests/integration/collection_description/updates/remove/policy_test.go
@@ -22,7 +22,7 @@ func TestColDescrUpdateRemovePolicy_Errors(t *testing.T) {
 		Actions: []any{
 			testUtils.AddPolicy{
 
-				Creator: acpUtils.Actor1Signature,
+				Creator: acpUtils.Actor1Identity,
 
 				Policy: `
                     description: a test policy which marks a collection in a database as a resource

--- a/tests/integration/events/simple/with_create_test.go
+++ b/tests/integration/events/simple/with_create_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/sourcenetwork/immutable"
 	"github.com/stretchr/testify/assert"
 
-	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	testUtils "github.com/sourcenetwork/defradb/tests/integration/events"
 )
@@ -49,11 +48,11 @@ func TestEventsSimpleWithCreate(t *testing.T) {
 		CollectionCalls: map[string][]func(client.Collection){
 			"Users": []func(c client.Collection){
 				func(c client.Collection) {
-					err = c.Save(context.Background(), acpIdentity.NoIdentity, doc1)
+					err = c.Save(context.Background(), doc1)
 					assert.Nil(t, err)
 				},
 				func(c client.Collection) {
-					err = c.Save(context.Background(), acpIdentity.NoIdentity, doc2)
+					err = c.Save(context.Background(), doc2)
 					assert.Nil(t, err)
 				},
 			},

--- a/tests/integration/events/simple/with_create_txn_test.go
+++ b/tests/integration/events/simple/with_create_txn_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/sourcenetwork/immutable"
 	"github.com/stretchr/testify/assert"
 
-	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/db"
 	testUtils "github.com/sourcenetwork/defradb/tests/integration/events"
@@ -29,7 +28,6 @@ func TestEventsSimpleWithCreateWithTxnDiscarded(t *testing.T) {
 			func(ctx context.Context, d client.DB) {
 				r := d.ExecRequest(
 					ctx,
-					acpIdentity.NoIdentity,
 					`mutation {
 						create_Users(input: {name: "John"}) {
 							_docID
@@ -47,7 +45,6 @@ func TestEventsSimpleWithCreateWithTxnDiscarded(t *testing.T) {
 				ctx = db.SetContextTxn(ctx, txn)
 				r := d.ExecRequest(
 					ctx,
-					acpIdentity.NoIdentity,
 					`mutation {
 						create_Users(input: {name: "Shahzad"}) {
 							_docID

--- a/tests/integration/events/simple/with_delete_test.go
+++ b/tests/integration/events/simple/with_delete_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/sourcenetwork/immutable"
 	"github.com/stretchr/testify/assert"
 
-	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	testUtils "github.com/sourcenetwork/defradb/tests/integration/events"
 )
@@ -38,11 +37,11 @@ func TestEventsSimpleWithDelete(t *testing.T) {
 		CollectionCalls: map[string][]func(client.Collection){
 			"Users": []func(c client.Collection){
 				func(c client.Collection) {
-					err = c.Save(context.Background(), acpIdentity.NoIdentity, doc1)
+					err = c.Save(context.Background(), doc1)
 					assert.Nil(t, err)
 				},
 				func(c client.Collection) {
-					wasDeleted, err := c.Delete(context.Background(), acpIdentity.NoIdentity, doc1.ID())
+					wasDeleted, err := c.Delete(context.Background(), doc1.ID())
 					assert.Nil(t, err)
 					assert.True(t, wasDeleted)
 				},

--- a/tests/integration/events/simple/with_update_test.go
+++ b/tests/integration/events/simple/with_update_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/sourcenetwork/immutable"
 	"github.com/stretchr/testify/assert"
 
-	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	testUtils "github.com/sourcenetwork/defradb/tests/integration/events"
 )
@@ -49,17 +48,17 @@ func TestEventsSimpleWithUpdate(t *testing.T) {
 		CollectionCalls: map[string][]func(client.Collection){
 			"Users": []func(c client.Collection){
 				func(c client.Collection) {
-					err = c.Save(context.Background(), acpIdentity.NoIdentity, doc1)
+					err = c.Save(context.Background(), doc1)
 					assert.Nil(t, err)
 				},
 				func(c client.Collection) {
-					err = c.Save(context.Background(), acpIdentity.NoIdentity, doc2)
+					err = c.Save(context.Background(), doc2)
 					assert.Nil(t, err)
 				},
 				func(c client.Collection) {
 					// Update John
 					doc1.Set("name", "Johnnnnn")
-					err = c.Save(context.Background(), acpIdentity.NoIdentity, doc1)
+					err = c.Save(context.Background(), doc1)
 					assert.Nil(t, err)
 				},
 			},

--- a/tests/integration/events/utils.go
+++ b/tests/integration/events/utils.go
@@ -19,7 +19,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/db"
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
@@ -153,7 +152,7 @@ func setupDatabase(
 			doc, err := client.NewDocFromJSON([]byte(docStr), col.Schema())
 			require.NoError(t, err)
 
-			err = col.Save(ctx, acpIdentity.NoIdentity, doc)
+			err = col.Save(ctx, doc)
 			require.NoError(t, err)
 		}
 	}

--- a/tests/integration/explain.go
+++ b/tests/integration/explain.go
@@ -20,7 +20,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 )
 
@@ -133,7 +132,6 @@ func executeExplainRequest(
 	for _, node := range getNodes(action.NodeID, s.nodes) {
 		result := node.ExecRequest(
 			s.ctx,
-			acpIdentity.NewIdentity(action.Identity),
 			action.Request,
 		)
 		assertExplainRequestResults(s, &result.GQL, action)

--- a/tests/integration/net/order/utils.go
+++ b/tests/integration/net/order/utils.go
@@ -19,9 +19,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/sourcenetwork/immutable"
-
-	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	coreDB "github.com/sourcenetwork/defradb/db"
 	"github.com/sourcenetwork/defradb/errors"
@@ -77,7 +74,6 @@ type P2PTestCase struct {
 
 func setupDefraNode(
 	t *testing.T,
-	identity immutable.Option[string],
 	opts []net.NodeOpt,
 	peers []string,
 	seeds []string,
@@ -97,7 +93,7 @@ func setupDefraNode(
 	// seed the database with a set of documents
 	docIDs := []client.DocID{}
 	for _, document := range seeds {
-		docID, err := seedDocument(ctx, identity, db, document)
+		docID, err := seedDocument(ctx, db, document)
 		require.NoError(t, err)
 		docIDs = append(docIDs, docID)
 	}
@@ -136,7 +132,6 @@ func seedSchema(ctx context.Context, db client.DB) error {
 
 func seedDocument(
 	ctx context.Context,
-	identity immutable.Option[string],
 	db client.DB,
 	document string,
 ) (client.DocID, error) {
@@ -150,7 +145,7 @@ func seedDocument(
 		return client.DocID{}, err
 	}
 
-	err = col.Save(ctx, identity, doc)
+	err = col.Save(ctx, doc)
 	if err != nil {
 		return client.DocID{}, err
 	}
@@ -160,7 +155,6 @@ func seedDocument(
 
 func saveDocument(
 	ctx context.Context,
-	identity immutable.Option[string],
 	db client.DB,
 	document *client.Document,
 ) error {
@@ -169,12 +163,11 @@ func saveDocument(
 		return err
 	}
 
-	return col.Save(ctx, identity, document)
+	return col.Save(ctx, document)
 }
 
 func updateDocument(
 	ctx context.Context,
-	identity immutable.Option[string],
 	db client.DB,
 	docID client.DocID,
 	update string,
@@ -184,7 +177,7 @@ func updateDocument(
 		return err
 	}
 
-	doc, err := getDocument(ctx, identity, db, docID)
+	doc, err := getDocument(ctx, db, docID)
 	if err != nil {
 		return err
 	}
@@ -193,12 +186,11 @@ func updateDocument(
 		return err
 	}
 
-	return col.Save(ctx, identity, doc)
+	return col.Save(ctx, doc)
 }
 
 func getDocument(
 	ctx context.Context,
-	identity immutable.Option[string],
 	db client.DB,
 	docID client.DocID,
 ) (*client.Document, error) {
@@ -207,7 +199,7 @@ func getDocument(
 		return nil, err
 	}
 
-	doc, err := col.Get(ctx, identity, docID, false)
+	doc, err := col.Get(ctx, docID, false)
 	if err != nil {
 		return nil, err
 	}
@@ -238,7 +230,6 @@ func executeTestCase(t *testing.T, test P2PTestCase) {
 		}
 		n, d, err := setupDefraNode(
 			t,
-			acpIdentity.NewIdentity(test.Identity),
 			cfg,
 			peerAddresses,
 			test.SeedDocuments,
@@ -270,8 +261,6 @@ func executeTestCase(t *testing.T, test P2PTestCase) {
 		}
 	}
 
-	identity := acpIdentity.NewIdentity(test.Identity)
-
 	// update and sync peers
 	for n, updateMap := range test.Updates {
 		if n >= len(nodes) {
@@ -284,7 +273,6 @@ func executeTestCase(t *testing.T, test P2PTestCase) {
 				log.InfoContext(ctx, fmt.Sprintf("Updating node %d with update %d", n, d))
 				err := updateDocument(
 					ctx,
-					identity,
 					nodes[n].DB,
 					docIDs[d],
 					update,
@@ -318,7 +306,6 @@ func executeTestCase(t *testing.T, test P2PTestCase) {
 				for field, result := range results {
 					doc, err := getDocument(
 						ctx,
-						identity,
 						nodes[n2].DB,
 						docIDs[d],
 					)
@@ -355,7 +342,6 @@ func executeTestCase(t *testing.T, test P2PTestCase) {
 			for _, doc := range test.DocumentsToReplicate {
 				err := saveDocument(
 					ctx,
-					identity,
 					nodes[n].DB,
 					doc,
 				)
@@ -374,7 +360,6 @@ func executeTestCase(t *testing.T, test P2PTestCase) {
 
 						doc, err := getDocument(
 							ctx,
-							identity,
 							nodes[rep].DB,
 							d,
 						)

--- a/tests/integration/test_case.go
+++ b/tests/integration/test_case.go
@@ -16,7 +16,7 @@ import (
 	"github.com/lens-vm/lens/host-go/config/model"
 	"github.com/sourcenetwork/immutable"
 
-	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
+	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/net"
 	"github.com/sourcenetwork/defradb/tests/gen"
@@ -212,7 +212,7 @@ type CreateDoc struct {
 	//
 	// If an Identity is provided and the collection has a policy, then the
 	// created document(s) will be owned by this Identity.
-	Identity acpIdentity.Identity
+	Identity identity.Identity
 
 	// The collection in which this document should be created.
 	CollectionID int
@@ -241,7 +241,7 @@ type DeleteDoc struct {
 	//
 	// If an Identity is provided and the collection has a policy, then
 	// can also delete private document(s) that are owned by this Identity.
-	Identity acpIdentity.Identity
+	Identity identity.Identity
 
 	// The collection in which this document should be deleted.
 	CollectionID int
@@ -274,7 +274,7 @@ type UpdateDoc struct {
 	//
 	// If an Identity is provided and the collection has a policy, then
 	// can also update private document(s) that are owned by this Identity.
-	Identity acpIdentity.Identity
+	Identity identity.Identity
 
 	// The collection in which this document exists.
 	CollectionID int
@@ -428,7 +428,7 @@ type Request struct {
 	//
 	// If an Identity is provided and the collection has a policy, then can
 	// operate over private document(s) that are owned by this Identity.
-	Identity acpIdentity.Identity
+	Identity identity.Identity
 
 	// Used to identify the transaction for this to run against. Optional.
 	TransactionID immutable.Option[int]

--- a/tests/integration/test_case.go
+++ b/tests/integration/test_case.go
@@ -16,6 +16,7 @@ import (
 	"github.com/lens-vm/lens/host-go/config/model"
 	"github.com/sourcenetwork/immutable"
 
+	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/net"
 	"github.com/sourcenetwork/defradb/tests/gen"
@@ -211,7 +212,7 @@ type CreateDoc struct {
 	//
 	// If an Identity is provided and the collection has a policy, then the
 	// created document(s) will be owned by this Identity.
-	Identity string
+	Identity acpIdentity.Identity
 
 	// The collection in which this document should be created.
 	CollectionID int
@@ -240,7 +241,7 @@ type DeleteDoc struct {
 	//
 	// If an Identity is provided and the collection has a policy, then
 	// can also delete private document(s) that are owned by this Identity.
-	Identity string
+	Identity acpIdentity.Identity
 
 	// The collection in which this document should be deleted.
 	CollectionID int
@@ -273,7 +274,7 @@ type UpdateDoc struct {
 	//
 	// If an Identity is provided and the collection has a policy, then
 	// can also update private document(s) that are owned by this Identity.
-	Identity string
+	Identity acpIdentity.Identity
 
 	// The collection in which this document exists.
 	CollectionID int
@@ -427,7 +428,7 @@ type Request struct {
 	//
 	// If an Identity is provided and the collection has a policy, then can
 	// operate over private document(s) that are owned by this Identity.
-	Identity string
+	Identity acpIdentity.Identity
 
 	// Used to identify the transaction for this to run against. Optional.
 	TransactionID immutable.Option[int]

--- a/tests/integration/test_case.go
+++ b/tests/integration/test_case.go
@@ -16,7 +16,6 @@ import (
 	"github.com/lens-vm/lens/host-go/config/model"
 	"github.com/sourcenetwork/immutable"
 
-	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/net"
 	"github.com/sourcenetwork/defradb/tests/gen"
@@ -212,7 +211,7 @@ type CreateDoc struct {
 	//
 	// If an Identity is provided and the collection has a policy, then the
 	// created document(s) will be owned by this Identity.
-	Identity identity.Identity
+	Identity string
 
 	// The collection in which this document should be created.
 	CollectionID int
@@ -241,7 +240,7 @@ type DeleteDoc struct {
 	//
 	// If an Identity is provided and the collection has a policy, then
 	// can also delete private document(s) that are owned by this Identity.
-	Identity identity.Identity
+	Identity string
 
 	// The collection in which this document should be deleted.
 	CollectionID int
@@ -274,7 +273,7 @@ type UpdateDoc struct {
 	//
 	// If an Identity is provided and the collection has a policy, then
 	// can also update private document(s) that are owned by this Identity.
-	Identity identity.Identity
+	Identity string
 
 	// The collection in which this document exists.
 	CollectionID int
@@ -428,7 +427,7 @@ type Request struct {
 	//
 	// If an Identity is provided and the collection has a policy, then can
 	// operate over private document(s) that are owned by this Identity.
-	Identity identity.Identity
+	Identity string
 
 	// Used to identify the transaction for this to run against. Optional.
 	TransactionID immutable.Option[int]

--- a/tests/integration/utils2.go
+++ b/tests/integration/utils2.go
@@ -28,6 +28,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/datastore"
 	badgerds "github.com/sourcenetwork/defradb/datastore/badger/v4"
@@ -847,7 +848,7 @@ func refreshDocuments(
 				continue
 			}
 
-			ctx := db.SetContextIdentity(s.ctx, action.Identity)
+			ctx := db.SetContextIdentity(s.ctx, identity.New(action.Identity))
 			// The document may have been mutated by other actions, so to be sure we have the latest
 			// version without having to worry about the individual update mechanics we fetch it.
 			doc, err = collection.Get(ctx, doc.ID(), false)
@@ -1202,7 +1203,7 @@ func createDocViaColSave(
 	txn := getTransaction(s, node, immutable.None[int](), action.ExpectedError)
 
 	ctx := db.SetContextTxn(s.ctx, txn)
-	ctx = db.SetContextIdentity(ctx, action.Identity)
+	ctx = db.SetContextIdentity(ctx, identity.New(action.Identity))
 
 	return doc, collections[action.CollectionID].Save(ctx, doc)
 }
@@ -1222,7 +1223,7 @@ func createDocViaColCreate(
 	txn := getTransaction(s, node, immutable.None[int](), action.ExpectedError)
 
 	ctx := db.SetContextTxn(s.ctx, txn)
-	ctx = db.SetContextIdentity(ctx, action.Identity)
+	ctx = db.SetContextIdentity(ctx, identity.New(action.Identity))
 
 	return doc, collections[action.CollectionID].Create(ctx, doc)
 }
@@ -1251,7 +1252,7 @@ func createDocViaGQL(
 	txn := getTransaction(s, node, immutable.None[int](), action.ExpectedError)
 
 	ctx := db.SetContextTxn(s.ctx, txn)
-	ctx = db.SetContextIdentity(ctx, action.Identity)
+	ctx = db.SetContextIdentity(ctx, identity.New(action.Identity))
 
 	result := node.ExecRequest(
 		ctx,
@@ -1283,7 +1284,7 @@ func deleteDoc(
 	action DeleteDoc,
 ) {
 	doc := s.documents[action.CollectionID][action.DocID]
-	ctx := db.SetContextIdentity(s.ctx, action.Identity)
+	ctx := db.SetContextIdentity(s.ctx, identity.New(action.Identity))
 
 	var expectedErrorRaised bool
 	actionNodes := getNodes(action.NodeID, s.nodes)
@@ -1341,7 +1342,7 @@ func updateDocViaColSave(
 	collections []client.Collection,
 ) error {
 	cachedDoc := s.documents[action.CollectionID][action.DocID]
-	ctx := db.SetContextIdentity(s.ctx, action.Identity)
+	ctx := db.SetContextIdentity(s.ctx, identity.New(action.Identity))
 
 	doc, err := collections[action.CollectionID].Get(ctx, cachedDoc.ID(), true)
 	if err != nil {
@@ -1368,7 +1369,7 @@ func updateDocViaColUpdate(
 	collections []client.Collection,
 ) error {
 	cachedDoc := s.documents[action.CollectionID][action.DocID]
-	ctx := db.SetContextIdentity(s.ctx, action.Identity)
+	ctx := db.SetContextIdentity(s.ctx, identity.New(action.Identity))
 
 	doc, err := collections[action.CollectionID].Get(ctx, cachedDoc.ID(), true)
 	if err != nil {
@@ -1411,7 +1412,7 @@ func updateDocViaGQL(
 	txn := getTransaction(s, node, immutable.None[int](), action.ExpectedError)
 
 	ctx := db.SetContextTxn(s.ctx, txn)
-	ctx = db.SetContextIdentity(ctx, action.Identity)
+	ctx = db.SetContextIdentity(ctx, identity.New(action.Identity))
 
 	result := node.ExecRequest(ctx, request)
 	if len(result.GQL.Errors) > 0 {
@@ -1631,7 +1632,7 @@ func executeRequest(
 		txn := getTransaction(s, node, action.TransactionID, action.ExpectedError)
 
 		ctx := db.SetContextTxn(s.ctx, txn)
-		ctx = db.SetContextIdentity(ctx, action.Identity)
+		ctx = db.SetContextIdentity(ctx, identity.New(action.Identity))
 
 		result := node.ExecRequest(ctx, action.Request)
 

--- a/tests/integration/utils2.go
+++ b/tests/integration/utils2.go
@@ -28,7 +28,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/sourcenetwork/defradb/acp/identity"
+	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/datastore"
 	badgerds "github.com/sourcenetwork/defradb/datastore/badger/v4"
@@ -848,7 +848,7 @@ func refreshDocuments(
 				continue
 			}
 
-			ctx := db.SetContextIdentity(s.ctx, identity.New(action.Identity))
+			ctx := db.SetContextIdentity(s.ctx, acpIdentity.New(action.Identity))
 			// The document may have been mutated by other actions, so to be sure we have the latest
 			// version without having to worry about the individual update mechanics we fetch it.
 			doc, err = collection.Get(ctx, doc.ID(), false)
@@ -1203,7 +1203,7 @@ func createDocViaColSave(
 	txn := getTransaction(s, node, immutable.None[int](), action.ExpectedError)
 
 	ctx := db.SetContextTxn(s.ctx, txn)
-	ctx = db.SetContextIdentity(ctx, identity.New(action.Identity))
+	ctx = db.SetContextIdentity(ctx, acpIdentity.New(action.Identity))
 
 	return doc, collections[action.CollectionID].Save(ctx, doc)
 }
@@ -1223,7 +1223,7 @@ func createDocViaColCreate(
 	txn := getTransaction(s, node, immutable.None[int](), action.ExpectedError)
 
 	ctx := db.SetContextTxn(s.ctx, txn)
-	ctx = db.SetContextIdentity(ctx, identity.New(action.Identity))
+	ctx = db.SetContextIdentity(ctx, acpIdentity.New(action.Identity))
 
 	return doc, collections[action.CollectionID].Create(ctx, doc)
 }
@@ -1252,7 +1252,7 @@ func createDocViaGQL(
 	txn := getTransaction(s, node, immutable.None[int](), action.ExpectedError)
 
 	ctx := db.SetContextTxn(s.ctx, txn)
-	ctx = db.SetContextIdentity(ctx, identity.New(action.Identity))
+	ctx = db.SetContextIdentity(ctx, acpIdentity.New(action.Identity))
 
 	result := node.ExecRequest(
 		ctx,
@@ -1284,7 +1284,7 @@ func deleteDoc(
 	action DeleteDoc,
 ) {
 	doc := s.documents[action.CollectionID][action.DocID]
-	ctx := db.SetContextIdentity(s.ctx, identity.New(action.Identity))
+	ctx := db.SetContextIdentity(s.ctx, acpIdentity.New(action.Identity))
 
 	var expectedErrorRaised bool
 	actionNodes := getNodes(action.NodeID, s.nodes)
@@ -1342,7 +1342,7 @@ func updateDocViaColSave(
 	collections []client.Collection,
 ) error {
 	cachedDoc := s.documents[action.CollectionID][action.DocID]
-	ctx := db.SetContextIdentity(s.ctx, identity.New(action.Identity))
+	ctx := db.SetContextIdentity(s.ctx, acpIdentity.New(action.Identity))
 
 	doc, err := collections[action.CollectionID].Get(ctx, cachedDoc.ID(), true)
 	if err != nil {
@@ -1369,7 +1369,7 @@ func updateDocViaColUpdate(
 	collections []client.Collection,
 ) error {
 	cachedDoc := s.documents[action.CollectionID][action.DocID]
-	ctx := db.SetContextIdentity(s.ctx, identity.New(action.Identity))
+	ctx := db.SetContextIdentity(s.ctx, acpIdentity.New(action.Identity))
 
 	doc, err := collections[action.CollectionID].Get(ctx, cachedDoc.ID(), true)
 	if err != nil {
@@ -1412,7 +1412,7 @@ func updateDocViaGQL(
 	txn := getTransaction(s, node, immutable.None[int](), action.ExpectedError)
 
 	ctx := db.SetContextTxn(s.ctx, txn)
-	ctx = db.SetContextIdentity(ctx, identity.New(action.Identity))
+	ctx = db.SetContextIdentity(ctx, acpIdentity.New(action.Identity))
 
 	result := node.ExecRequest(ctx, request)
 	if len(result.GQL.Errors) > 0 {
@@ -1632,7 +1632,7 @@ func executeRequest(
 		txn := getTransaction(s, node, action.TransactionID, action.ExpectedError)
 
 		ctx := db.SetContextTxn(s.ctx, txn)
-		ctx = db.SetContextIdentity(ctx, identity.New(action.Identity))
+		ctx = db.SetContextIdentity(ctx, acpIdentity.New(action.Identity))
 
 		result := node.ExecRequest(ctx, action.Request)
 


### PR DESCRIPTION
## Relevant issue(s)

Resolves #2439

## Description

This PR moves the identity param from the `client.DB` and `client.Collection` interfaces to the context.

Notable changes:
- `acp/identity.go` added `Identity` type alias to make future updates simpler

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

`make test`

Specify the platform(s) on which this was tested:
- MacOS

