### PR TITLE
fix(i): Correctly handle inverse lenses from multiple sources

### DIFF
--- a/lens/history.go
+++ b/lens/history.go
@@ -174,7 +174,7 @@ func getCollectionHistory(
 			srcSchemaVersion := schemaVersionsByColID[source.SourceCollectionID]
 			src := history[srcSchemaVersion]
 			historyItem.previous = append(
-				historyItem.next,
+				historyItem.previous,
 				src,
 			)
 

--- a/tests/integration/schema/migrations/query/with_inverse_test.go
+++ b/tests/integration/schema/migrations/query/with_inverse_test.go
@@ -1,0 +1,114 @@
+// Copyright 2024 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package query
+
+import (
+	"testing"
+
+	"github.com/lens-vm/lens/host-go/config/model"
+
+	"github.com/sourcenetwork/defradb/client"
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	"github.com/sourcenetwork/defradb/tests/lenses"
+)
+
+func TestSchemaMigrationQueryInversesAcrossMultipleVersions(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "Test schema migration, inverses across multiple migrated versions",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users {
+						name: String
+						age: Int
+						height: Int
+					}
+				`,
+			},
+			testUtils.SchemaPatch{
+				Patch: `
+					[
+						{ "op": "add", "path": "/Users/Fields/-", "value": {"Name": "verified", "Kind": "Boolean"} }
+					]
+				`,
+			},
+			testUtils.SchemaPatch{
+				Patch: `
+					[
+						{ "op": "add", "path": "/Users/Fields/-", "value": {"Name": "email", "Kind": "String"} }
+					]
+				`,
+			},
+			testUtils.ConfigureMigration{
+				LensConfig: client.LensConfig{
+					SourceSchemaVersionID:      "bafkreieabpdpv5ua4f6lc5lprud4vvbefmfinzqaewhx5gzuf7anwgrqmy",
+					DestinationSchemaVersionID: "bafkreid2g456hvlkedusgfp6argh76a74ymrlii2ag4yqqsn2sgt4pkslu",
+					Lens: model.Lens{
+						Lenses: []model.LensModule{
+							{
+								Path: lenses.SetDefaultModulePath,
+								Arguments: map[string]any{
+									"dst":   "age",
+									"value": 30,
+								},
+							},
+						},
+					},
+				},
+			},
+			testUtils.ConfigureMigration{
+				LensConfig: client.LensConfig{
+					SourceSchemaVersionID:      "bafkreid2g456hvlkedusgfp6argh76a74ymrlii2ag4yqqsn2sgt4pkslu",
+					DestinationSchemaVersionID: "bafkreibwswh2pxloduldc2l5h5jzm7b6fqt3s4vijq3nssmn3rr5gws2ki",
+					Lens: model.Lens{
+						Lenses: []model.LensModule{
+							{
+								Path: lenses.SetDefaultModulePath,
+								Arguments: map[string]any{
+									"dst":   "height",
+									"value": 190,
+								},
+							},
+						},
+					},
+				},
+			},
+			testUtils.CreateDoc{
+				Doc: `{
+					"name": "John",
+					"age": 33,
+					"height": 185
+				}`,
+			},
+			testUtils.SetActiveSchemaVersion{
+				SchemaVersionID: "bafkreieabpdpv5ua4f6lc5lprud4vvbefmfinzqaewhx5gzuf7anwgrqmy",
+			},
+			testUtils.Request{
+				Request: `query {
+					Users {
+						name
+						age
+						height
+					}
+				}`,
+				Results: []map[string]any{
+					{
+						"name":   "John",
+						"age":    nil,
+						"height": nil,
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #2433

## Description

Correctly handles inverse lenses from multiple sources.

PR includes a new test for verifying that inversing across multiple versions does work, it is not relevant to the bug fix, but I wrote it to make sure I want reading the code wrong (as I first did when creating the issue).

The bug is not testable atm, as this would only have become a problem when introducing multi-source collections (atm both `next` and `previous` slices are always empty before calling this line).  Was likely copy-paste code.