### PR TITLE
test(i): Assert all expected props are returned in tests

### DIFF
--- a/tests/integration/backup/one_to_one/import_test.go
+++ b/tests/integration/backup/one_to_one/import_test.go
@@ -237,7 +237,8 @@ func TestBackupImport_DoubleRelationshipWithUpdate_NoError(t *testing.T) {
 						},
 					},
 					{
-						"name": "Game of chains",
+						"name":   "Game of chains",
+						"author": nil,
 					},
 				},
 			},

--- a/tests/integration/net/state/simple/peer/with_create_add_field_test.go
+++ b/tests/integration/net/state/simple/peer/with_create_add_field_test.go
@@ -284,6 +284,7 @@ func TestP2PPeerCreateWithNewFieldDocSyncedBeforeReceivingNodeSchemaUpdatedDoesN
 					{
 						"Name": "John",
 						// The email should be returned but it is not
+						"Email": nil,
 					},
 				},
 			},

--- a/tests/integration/query/one_to_many/with_cid_doc_id_test.go
+++ b/tests/integration/query/one_to_many/with_cid_doc_id_test.go
@@ -255,6 +255,7 @@ func TestQueryOneToManyWithParentUpdateAndFirstCidAndDocID(t *testing.T) {
 						cid: "bafybeia3qbhebdwssoe5udinpbdj4pntb5wjr77ql7ptzq32howbaxz2cu",
 						docID: "bae-b9b83269-1f28-5c3b-ae75-3fb4c00d559d"
 					) {
+						name
 						rating
 						author {
 							name
@@ -327,6 +328,7 @@ func TestQueryOneToManyWithParentUpdateAndLastCidAndDocID(t *testing.T) {
 						cid: "bafybeibqkdnc63xh5k4frs3x3k7z7p6sw4usjrhxd4iusbjj2uhxfjfjcq",
 						docID: "bae-b9b83269-1f28-5c3b-ae75-3fb4c00d559d"
 					) {
+						name
 						rating
 						author {
 							name

--- a/tests/integration/query/one_to_many/with_group_related_id_alias_test.go
+++ b/tests/integration/query/one_to_many/with_group_related_id_alias_test.go
@@ -24,6 +24,7 @@ func TestQueryOneToManyWithParentGroupByOnRelatedTypeFromManySideUsingAlias(t *t
 
 		Request: `query {
 			Book(groupBy: [author]) {
+				author_id
 				_group {
 					name
 					rating

--- a/tests/integration/query/one_to_many/with_group_related_id_test.go
+++ b/tests/integration/query/one_to_many/with_group_related_id_test.go
@@ -22,6 +22,7 @@ func TestQueryOneToManyWithParentGroupByOnRelatedTypeIDFromManySide(t *testing.T
 		Description: "One-to-many query with groupBy on related id (from many side).",
 		Request: `query {
 				Book(groupBy: [author_id]) {
+					author_id
 					_group {
 						name
 						rating

--- a/tests/integration/query/simple/with_order_test.go
+++ b/tests/integration/query/simple/with_order_test.go
@@ -22,6 +22,7 @@ func TestQuerySimpleWithEmptyOrder(t *testing.T) {
 		Request: `query {
 					Users(order: {}) {
 						Name
+						Age
 					}
 				}`,
 		Docs: map[int][]string{

--- a/tests/integration/schema/migrations/query/with_p2p_schema_branch_test.go
+++ b/tests/integration/schema/migrations/query/with_p2p_schema_branch_test.go
@@ -117,6 +117,7 @@ func TestSchemaMigrationQueryWithP2PReplicatedDocOnOtherSchemaBranch(t *testing.
 						Users {
 							name
 							phone
+							verified
 						}
 					}
 				`,

--- a/tests/integration/utils2.go
+++ b/tests/integration/utils2.go
@@ -1811,6 +1811,18 @@ func assertRequestResults(
 
 	for docIndex, result := range resultantData {
 		expectedResult := expectedResults[docIndex]
+
+		require.Equal(
+			s.t,
+			len(expectedResult),
+			len(result),
+			fmt.Sprintf(
+				"%s \n(number of properties for item at index %v don't match)",
+				s.testCase.Description,
+				docIndex,
+			),
+		)
+
 		for field, actualValue := range result {
 			expectedValue := expectedResult[field]
 

--- a/tests/integration/view/simple/with_filter_test.go
+++ b/tests/integration/view/simple/with_filter_test.go
@@ -118,6 +118,7 @@ func TestView_SimpleWithFilterOnViewAndQuery(t *testing.T) {
 					query {
 						UserView(filter: {age: {_eq: 31}}) {
 							name
+							age
 						}
 					}
 				`,


### PR DESCRIPTION
## Relevant issue(s)

Resolves #2435

## Description

Asserts that all expected properties are returned in integration test queries.

Is quite bad that this was missed for so long, luckily none of the bad tests passing because of it failed when their queries were corrected :sweat_smile: 