### PR TITLE
test(i): Fix PnCounter overflow tests

### DIFF
--- a/tests/integration/issues/2566_test.go
+++ b/tests/integration/issues/2566_test.go
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-package peer_test
+package issues
 
 import (
 	"fmt"

--- a/tests/integration/issues/2566_test.go
+++ b/tests/integration/issues/2566_test.go
@@ -23,6 +23,13 @@ import (
 // This test documents https://github.com/sourcenetwork/defradb/issues/2566
 func TestP2PUpdate_WithPNCounterSimultaneousOverflowIncrement_DoesNotReachConsitency(t *testing.T) {
 	test := testUtils.TestCase{
+		SupportedClientTypes: immutable.Some(
+			[]testUtils.ClientType{
+				// This test only supports the Go client at the moment due to
+				// https://github.com/sourcenetwork/defradb/issues/2569
+				testUtils.GoClientType,
+			},
+		),
 		Actions: []any{
 			testUtils.RandomNetworkingConfig(),
 			testUtils.RandomNetworkingConfig(),
@@ -108,6 +115,13 @@ func TestP2PUpdate_WithPNCounterSimultaneousOverflowIncrement_DoesNotReachConsit
 // This test documents https://github.com/sourcenetwork/defradb/issues/2566
 func TestP2PUpdate_WithPNCounterSimultaneousOverflowDecrement_DoesNotReachConsitency(t *testing.T) {
 	test := testUtils.TestCase{
+		SupportedClientTypes: immutable.Some(
+			[]testUtils.ClientType{
+				// This test only supports the Go client at the moment due to
+				// https://github.com/sourcenetwork/defradb/issues/2569
+				testUtils.GoClientType,
+			},
+		),
 		Actions: []any{
 			testUtils.RandomNetworkingConfig(),
 			testUtils.RandomNetworkingConfig(),

--- a/tests/integration/issues/2566_test.go
+++ b/tests/integration/issues/2566_test.go
@@ -41,10 +41,6 @@ func TestP2PUpdate_WithPNCounterSimultaneousOverflowIncrement_DoesNotReachConsit
 					"Age": %g
 				}`, math.MaxFloat64/10),
 			},
-			testUtils.ConnectPeers{
-				SourceNodeID: 0,
-				TargetNodeID: 1,
-			},
 			testUtils.UpdateDoc{
 				NodeID: immutable.Some(0),
 				Doc: fmt.Sprintf(`{
@@ -56,6 +52,21 @@ func TestP2PUpdate_WithPNCounterSimultaneousOverflowIncrement_DoesNotReachConsit
 				Doc: fmt.Sprintf(`{
 					"Age": %g
 				}`, -math.MaxFloat64),
+			},
+			testUtils.ConnectPeers{
+				// Configure the peer connection after the document has been created and updated independently
+				// on each node.  This allows us to be sure which update was applied on each node.
+				// If the connection was configured before the updates there would be a race condition resulting
+				// in a variable resultant state.
+				SourceNodeID: 0,
+				TargetNodeID: 1,
+			},
+			testUtils.UpdateDoc{
+				// This is an arbitrary update on both nodes to force the sync of the document created
+				// before the peer connection was configured.
+				Doc: `{
+					"Name": "Fred"
+				}`,
 			},
 			testUtils.WaitForSync{},
 			testUtils.Request{
@@ -115,10 +126,6 @@ func TestP2PUpdate_WithPNCounterSimultaneousOverflowDecrement_DoesNotReachConsit
 					"Age": %g
 				}`, -math.MaxFloat64/10),
 			},
-			testUtils.ConnectPeers{
-				SourceNodeID: 0,
-				TargetNodeID: 1,
-			},
 			testUtils.UpdateDoc{
 				NodeID: immutable.Some(1),
 				Doc: fmt.Sprintf(`{
@@ -130,6 +137,21 @@ func TestP2PUpdate_WithPNCounterSimultaneousOverflowDecrement_DoesNotReachConsit
 				Doc: fmt.Sprintf(`{
 					"Age": %g
 				}`, -math.MaxFloat64),
+			},
+			testUtils.ConnectPeers{
+				// Configure the peer connection after the document has been created and updated independently
+				// on each node.  This allows us to be sure which update was applied on each node.
+				// If the connection was configured before the updates there would be a race condition resulting
+				// in a variable resultant state.
+				SourceNodeID: 0,
+				TargetNodeID: 1,
+			},
+			testUtils.UpdateDoc{
+				// This is an arbitrary update on both nodes to force the sync of the document created
+				// before the peer connection was configured.
+				Doc: `{
+					"Name": "Fred"
+				}`,
 			},
 			testUtils.WaitForSync{},
 			testUtils.Request{

--- a/tests/integration/issues/2566_test.go
+++ b/tests/integration/issues/2566_test.go
@@ -1,0 +1,169 @@
+// Copyright 2024 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package peer_test
+
+import (
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/sourcenetwork/immutable"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+// This test documents https://github.com/sourcenetwork/defradb/issues/2566
+func TestP2PUpdate_WithPNCounterSimultaneousOverflowIncrement_DoesNotReachConsitency(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.RandomNetworkingConfig(),
+			testUtils.RandomNetworkingConfig(),
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users {
+						Name: String
+						Age: Float @crdt(type: "pncounter")
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				// Create John on all nodes
+				Doc: fmt.Sprintf(`{
+					"Name": "John",
+					"Age": %g
+				}`, math.MaxFloat64/10),
+			},
+			testUtils.ConnectPeers{
+				SourceNodeID: 0,
+				TargetNodeID: 1,
+			},
+			testUtils.UpdateDoc{
+				NodeID: immutable.Some(0),
+				Doc: fmt.Sprintf(`{
+					"Age": %g
+				}`, math.MaxFloat64),
+			},
+			testUtils.UpdateDoc{
+				NodeID: immutable.Some(1),
+				Doc: fmt.Sprintf(`{
+					"Age": %g
+				}`, -math.MaxFloat64),
+			},
+			testUtils.WaitForSync{},
+			testUtils.Request{
+				NodeID: immutable.Some(0),
+				Request: `query {
+					Users {
+						Age
+					}
+				}`,
+				Results: []map[string]any{
+					{
+						// Node 0 overflows before subtraction, and because subtracting from infinity
+						// results in infinity the value remains infinate
+						"Age": math.Inf(1),
+					},
+				},
+			},
+			testUtils.Request{
+				NodeID: immutable.Some(1),
+				Request: `query {
+					Users {
+						Age
+					}
+				}`,
+				Results: []map[string]any{
+					{
+						// Node 1 subtracts before adding, meaning no overflow is achieved and the value
+						// remains finate
+						"Age": float64(1.7976931348623155e+307),
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+// This test documents https://github.com/sourcenetwork/defradb/issues/2566
+func TestP2PUpdate_WithPNCounterSimultaneousOverflowDecrement_DoesNotReachConsitency(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.RandomNetworkingConfig(),
+			testUtils.RandomNetworkingConfig(),
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users {
+						Name: String
+						Age: Float @crdt(type: "pncounter")
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				// Create John on all nodes
+				Doc: fmt.Sprintf(`{
+					"Name": "John",
+					"Age": %g
+				}`, -math.MaxFloat64/10),
+			},
+			testUtils.ConnectPeers{
+				SourceNodeID: 0,
+				TargetNodeID: 1,
+			},
+			testUtils.UpdateDoc{
+				NodeID: immutable.Some(1),
+				Doc: fmt.Sprintf(`{
+					"Age": %g
+				}`, math.MaxFloat64),
+			},
+			testUtils.UpdateDoc{
+				NodeID: immutable.Some(0),
+				Doc: fmt.Sprintf(`{
+					"Age": %g
+				}`, -math.MaxFloat64),
+			},
+			testUtils.WaitForSync{},
+			testUtils.Request{
+				NodeID: immutable.Some(0),
+				Request: `query {
+					Users {
+						Age
+					}
+				}`,
+				Results: []map[string]any{
+					{
+						// Node 0 overflows before addition, and because adding to infinity
+						// results in infinity the value remains infinate
+						"Age": math.Inf(-1),
+					},
+				},
+			},
+			testUtils.Request{
+				NodeID: immutable.Some(1),
+				Request: `query {
+					Users {
+						Age
+					}
+				}`,
+				Results: []map[string]any{
+					{
+						// Node 1 adds before subtracting, meaning no overflow is achieved and the value
+						// remains finate
+						"Age": float64(-1.7976931348623155e+307),
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/issues/2569_test.go
+++ b/tests/integration/issues/2569_test.go
@@ -1,0 +1,167 @@
+// Copyright 2024 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package issues
+
+import (
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/sourcenetwork/immutable"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+// These tests document https://github.com/sourcenetwork/defradb/issues/2569
+
+func TestP2PUpdate_WithPNCounterFloatOverflowIncrement_PreventsQuerying(t *testing.T) {
+	test := testUtils.TestCase{
+		SupportedClientTypes: immutable.Some(
+			[]testUtils.ClientType{
+				// This issue only affects the http and the cli clients
+				testUtils.HTTPClientType,
+				testUtils.CLIClientType,
+			},
+		),
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users {
+						name: String
+						points: Float @crdt(type: "pncounter")
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				Doc: fmt.Sprintf(`{
+					"name": "John",
+					"points": %g
+				}`, math.MaxFloat64),
+			},
+			testUtils.UpdateDoc{
+				// Overflow the points field, this results in a value of `math.Inf(1)`
+				Doc: fmt.Sprintf(`{
+					"points": %g
+				}`, math.MaxFloat64/10),
+			},
+			testUtils.Request{
+				Request: `query {
+					Users {
+						name
+						points
+					}
+				}`,
+				ExpectedError: "unexpected end of JSON input",
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestP2PUpdate_WithPNCounterFloatOverflowDecrement_PreventsQuerying(t *testing.T) {
+	test := testUtils.TestCase{
+		SupportedClientTypes: immutable.Some(
+			[]testUtils.ClientType{
+				// This issue only affects the http and the cli clients
+				testUtils.HTTPClientType,
+				testUtils.CLIClientType,
+			},
+		),
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users {
+						name: String
+						points: Float @crdt(type: "pncounter")
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				Doc: fmt.Sprintf(`{
+					"name": "John",
+					"points": %g
+				}`, -math.MaxFloat64),
+			},
+			testUtils.UpdateDoc{
+				// Overflow the points field, this results in a value of `math.Inf(-1)`
+				Doc: fmt.Sprintf(`{
+					"points": %g
+				}`, -math.MaxFloat64/10),
+			},
+			testUtils.Request{
+				Request: `query {
+					Users {
+						name
+						points
+					}
+				}`,
+				ExpectedError: "unexpected end of JSON input",
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestP2PUpdate_WithPNCounterFloatOverflow_PreventsCollectionGet(t *testing.T) {
+	test := testUtils.TestCase{
+		SupportedClientTypes: immutable.Some(
+			[]testUtils.ClientType{
+				// This issue only affects the http and the cli clients
+				testUtils.HTTPClientType,
+				testUtils.CLIClientType,
+			},
+		),
+		SupportedMutationTypes: immutable.Some(
+			[]testUtils.MutationType{
+				// We limit the test to Collection mutation calls, as the test framework
+				// will make a `Get` call before submitting the document, which is where the error
+				// will surface (not the update itelf)
+				testUtils.CollectionSaveMutationType,
+				testUtils.CollectionNamedMutationType,
+			},
+		),
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users {
+						name: String
+						points: Float @crdt(type: "pncounter")
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				Doc: fmt.Sprintf(`{
+					"name": "John",
+					"points": %g
+				}`, math.MaxFloat64),
+			},
+			testUtils.UpdateDoc{
+				// Overflow the points field, this results in a value of `math.Inf(1)`
+				Doc: fmt.Sprintf(`{
+					"points": %g
+				}`, math.MaxFloat64/10),
+			},
+			testUtils.UpdateDoc{
+				// Try and update the document again, the value used does not matter.
+				Doc: `{
+					"points": 1
+				}`,
+				// WARNING: This error is just an artifact of our test harness, what actually happens
+				// is the test harness calls `collection.Get`, which returns an empty string and no error.
+				ExpectedError: "cannot parse JSON: cannot parse empty string",
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/issues/README.md
+++ b/tests/integration/issues/README.md
@@ -1,0 +1,5 @@
+# Issues
+
+This directory hosts tests documenting known issues.  Test files are named after their corresponding GitHub issue ("\[IssueNumber\]_test.go").
+
+Ideally the only file in this directory would be this readme.

--- a/tests/integration/mutation/update/crdt/pncounter_test.go
+++ b/tests/integration/mutation/update/crdt/pncounter_test.go
@@ -174,10 +174,9 @@ func TestPNCounterUpdate_FloatKindWithPositiveIncrement_ShouldIncrement(t *testi
 }
 
 // This test documents what happens when an overflow occurs in a PN Counter with Float type.
-// In this case it is the same as a no-op.
-func TestPNCounterUpdate_FloatKindWithPositiveIncrementOverflow_NoOp(t *testing.T) {
+func TestPNCounterUpdate_FloatKindWithPositiveIncrementOverflow_PositiveInf(t *testing.T) {
 	test := testUtils.TestCase{
-		Description: "Positive increments of a PN Counter with Float type and overflow causing a no-op",
+		Description: "Positive increments of a PN Counter with Float type and overflow",
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
@@ -195,9 +194,9 @@ func TestPNCounterUpdate_FloatKindWithPositiveIncrementOverflow_NoOp(t *testing.
 			},
 			testUtils.UpdateDoc{
 				DocID: 0,
-				Doc: `{
-					"points": 1000
-				}`,
+				Doc: fmt.Sprintf(`{
+					"points": %g
+				}`, math.MaxFloat64/10),
 			},
 			testUtils.Request{
 				Request: `query {
@@ -209,7 +208,7 @@ func TestPNCounterUpdate_FloatKindWithPositiveIncrementOverflow_NoOp(t *testing.
 				Results: []map[string]any{
 					{
 						"name":   "John",
-						"points": math.MaxFloat64,
+						"points": math.Inf(1),
 					},
 				},
 			},

--- a/tests/integration/mutation/update/crdt/pncounter_test.go
+++ b/tests/integration/mutation/update/crdt/pncounter_test.go
@@ -177,6 +177,13 @@ func TestPNCounterUpdate_FloatKindWithPositiveIncrement_ShouldIncrement(t *testi
 func TestPNCounterUpdate_FloatKindWithPositiveIncrementOverflow_PositiveInf(t *testing.T) {
 	test := testUtils.TestCase{
 		Description: "Positive increments of a PN Counter with Float type and overflow",
+		SupportedClientTypes: immutable.Some(
+			[]testUtils.ClientType{
+				// This test only supports the Go client at the moment due to
+				// https://github.com/sourcenetwork/defradb/issues/2569
+				testUtils.GoClientType,
+			},
+		),
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
@@ -222,6 +229,13 @@ func TestPNCounterUpdate_FloatKindWithPositiveIncrementOverflow_PositiveInf(t *t
 func TestPNCounterUpdate_FloatKindWithDecrementOverflow_NegativeInf(t *testing.T) {
 	test := testUtils.TestCase{
 		Description: "Positive increments of a PN Counter with Float type and overflow",
+		SupportedClientTypes: immutable.Some(
+			[]testUtils.ClientType{
+				// This test only supports the Go client at the moment due to
+				// https://github.com/sourcenetwork/defradb/issues/2569
+				testUtils.GoClientType,
+			},
+		),
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `

--- a/tests/integration/test_case.go
+++ b/tests/integration/test_case.go
@@ -38,6 +38,13 @@ type TestCase struct {
 	// This is to only be used in the very rare cases where we really do want behavioural
 	// differences between mutation types, or we need to temporarily document a bug.
 	SupportedMutationTypes immutable.Option[[]MutationType]
+
+	// If provided a value, SupportedClientTypes will limit the client types under test to those
+	// within this set.  If no active clients pass this filter the test will be skipped.
+	//
+	// This is to only be used in the very rare cases where we really do want behavioural
+	// differences between client types, or we need to temporarily document a bug.
+	SupportedClientTypes immutable.Option[[]ClientType]
 }
 
 // SetupComplete is a flag to explicitly notify the change detector at which point


### PR DESCRIPTION
## Relevant issue(s)

Resolves #2565

## Description

Fixes a faulty PnCounter overflow test which was doing a no-op whilst pretending to increment.

Adds a test for negative float64 overflows, and two tests documenting the newly found https://github.com/sourcenetwork/defradb/issues/2566 in a new `issues` directory.

I don't think I see #2566 as a release blocker, but no strong feelings there yet.

There is more info in the commit messages RE each change.

## Todo

- [x] Tests are flaky in the CI
- [x] http client does not like the update mutations 
