### PR TITLE
fix: Add check to filter result for logical ops

### DIFF
--- a/db/fetcher/fetcher.go
+++ b/db/fetcher/fetcher.go
@@ -585,6 +585,45 @@ func (df *DocumentFetcher) FetchNext(ctx context.Context) (EncodedDocument, Exec
 	return encdoc, resultExecInfo, err
 }
 
+// shouldCheckExternalCondition checks if the external condition should be evaluated. To check
+// the external condition, we make the filter pass the check.
+//
+// This usually happens when we have an _and or _or operator in the filter and we are filtering
+// on some foreign object field value.
+func shouldCheckExternalCondition(passed bool, f *mapper.Filter) bool {
+	for k, v := range f.Conditions {
+		op := k.GetOperatorOrDefault("")
+		if op == "" {
+			// If we have a condition without an operator, it means that it's a property index
+			// and we can skip to the next condition.
+			continue
+		}
+		switch op {
+		case "_and":
+			// If we have an _and operator and we already failed the filter, we can return false
+			if !passed {
+				return false
+			}
+		case "_or":
+			// If we have an _or operator and we already passed the filter, we can return true
+			if passed {
+				return true
+			}
+		default:
+			// For now we only care about _and and _or.
+			return passed
+		}
+		filterSet, ok := f.ExternalConditions[op]
+		if !ok {
+			return false
+		}
+		if len(filterSet.([]any)) != len(v.([]any)) {
+			return true
+		}
+	}
+	return passed
+}
+
 func (df *DocumentFetcher) fetchNext(ctx context.Context) (EncodedDocument, ExecInfo, error) {
 	if df.kvEnd {
 		return nil, ExecInfo{}, nil
@@ -619,6 +658,7 @@ func (df *DocumentFetcher) fetchNext(ctx context.Context) (EncodedDocument, Exec
 				if err != nil {
 					return nil, ExecInfo{}, err
 				}
+				df.passedFilter = shouldCheckExternalCondition(df.passedFilter, df.filter)
 			}
 		}
 

--- a/planner/filter/complex.go
+++ b/planner/filter/complex.go
@@ -17,7 +17,7 @@ import (
 
 // IsComplex returns true if the provided filter is complex.
 // A filter is considered complex if it contains a relation
-// object withing an _or or _not operator not necessarily being
+// object withing an _or, _and or _not operator not necessarily being
 // its direct  child.
 func IsComplex(filter *mapper.Filter) bool {
 	if filter == nil {
@@ -32,6 +32,7 @@ func isComplex(conditions any, seekRelation bool) bool {
 		for k, v := range typedCond {
 			if op, ok := k.(*mapper.Operator); ok {
 				if (op.Operation == request.FilterOpOr && len(v.([]any)) > 1) ||
+					(op.Operation == request.FilterOpAnd && len(v.([]any)) > 1) ||
 					op.Operation == request.FilterOpNot {
 					if isComplex(v, true) {
 						return true

--- a/planner/filter/complex.go
+++ b/planner/filter/complex.go
@@ -31,9 +31,11 @@ func isComplex(conditions any, seekRelation bool) bool {
 	case map[connor.FilterKey]any:
 		for k, v := range typedCond {
 			if op, ok := k.(*mapper.Operator); ok {
-				if (op.Operation == request.FilterOpOr && len(v.([]any)) > 1) ||
-					(op.Operation == request.FilterOpAnd && len(v.([]any)) > 1) ||
-					op.Operation == request.FilterOpNot {
+				switch op.Operation {
+				case request.FilterOpOr, request.FilterOpAnd, request.FilterOpNot:
+					if v, ok := v.([]any); ok && len(v) == 1 {
+						continue
+					}
 					if isComplex(v, true) {
 						return true
 					}

--- a/planner/filter/complex_test.go
+++ b/planner/filter/complex_test.go
@@ -109,7 +109,7 @@ func TestIsComplex(t *testing.T) {
 					m("published", m("rating", m("_gt", 4.0))),
 				),
 			),
-			isComplex: false,
+			isComplex: true,
 		},
 		{
 			name: "relation inside _and and _or",

--- a/planner/type_join.go
+++ b/planner/type_join.go
@@ -345,7 +345,7 @@ func prepareScanNodeFilterForTypeJoin(
 			parent.filter.Conditions = filter.Merge(
 				parent.filter.Conditions, scan.filter.Conditions)
 		}
-		filter.RemoveField(scan.filter, subType.Field)
+		scan.filter = nil
 	} else {
 		var parentFilter *mapper.Filter
 		scan.filter, parentFilter = filter.SplitByFields(scan.filter, subType.Field)


### PR DESCRIPTION
## Relevant issue(s)

Resolves #2571

## Description

This PR adds a check post doc filtering in the fetcher to see if we need to rely on the external conditions instead to ensure a valid filtering operation. This is specially important when filtering with logical operators `_and` and `_or`.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

make test

Specify the platform(s) on which this was tested:
- MacOS
