### PR TITLE
fix: Handle compound filters on related indexed fields

### DIFF
--- a/planner/filter/complex.go
+++ b/planner/filter/complex.go
@@ -33,9 +33,6 @@ func isComplex(conditions any, seekRelation bool) bool {
 			if op, ok := k.(*mapper.Operator); ok {
 				switch op.Operation {
 				case request.FilterOpOr, request.FilterOpAnd, request.FilterOpNot:
-					if v, ok := v.([]any); ok && len(v) == 0 {
-						continue
-					}
 					if isComplex(v, true) {
 						return true
 					}

--- a/planner/filter/complex.go
+++ b/planner/filter/complex.go
@@ -33,7 +33,7 @@ func isComplex(conditions any, seekRelation bool) bool {
 			if op, ok := k.(*mapper.Operator); ok {
 				switch op.Operation {
 				case request.FilterOpOr, request.FilterOpAnd, request.FilterOpNot:
-					if v, ok := v.([]any); ok && len(v) == 1 {
+					if v, ok := v.([]any); ok && len(v) == 0 {
 						continue
 					}
 					if isComplex(v, true) {

--- a/planner/filter/complex_test.go
+++ b/planner/filter/complex_test.go
@@ -80,7 +80,7 @@ func TestIsComplex(t *testing.T) {
 			inputFilter: r("_or",
 				m("published", m("rating", m("_gt", 4.0))),
 			),
-			isComplex: false,
+			isComplex: true,
 		},
 		{
 			name: "relation inside _or",

--- a/planner/planner.go
+++ b/planner/planner.go
@@ -361,7 +361,7 @@ func (p *Planner) tryOptimizeJoinDirection(node *invertibleTypeJoin, parentPlan 
 	desc := slct.collection.Description()
 	for subFieldName, subFieldInd := range filteredSubFields {
 		indexes := desc.GetIndexesOnField(subFieldName)
-		if len(indexes) > 0 {
+		if len(indexes) > 0 && !filter.IsComplex(parentPlan.selectNode.filter) {
 			subInd := node.documentMapping.FirstIndexOfName(node.subTypeName)
 			relatedField := mapper.Field{Name: node.subTypeName, Index: subInd}
 			fieldFilter := filter.UnwrapRelation(filter.CopyField(

--- a/planner/type_join.go
+++ b/planner/type_join.go
@@ -486,7 +486,7 @@ type invertibleTypeJoin struct {
 	secondaryFieldIndex immutable.Option[int]
 	secondaryFetchLimit uint
 
-	// docsToYield contains cocuments read and ready to be yielded by this node.
+	// docsToYield contains documents read and ready to be yielded by this node.
 	docsToYield []core.Doc
 
 	dir joinDirection

--- a/planner/type_join.go
+++ b/planner/type_join.go
@@ -473,7 +473,6 @@ func (dir *joinDirection) invert() {
 }
 
 type invertibleTypeJoin struct {
-	documentIterator
 	docMapper
 
 	root        planNode
@@ -486,6 +485,9 @@ type invertibleTypeJoin struct {
 	isSecondary         bool
 	secondaryFieldIndex immutable.Option[int]
 	secondaryFetchLimit uint
+
+	// docsToYield contains cocuments read and ready to be yielded by this node.
+	docsToYield []core.Doc
 
 	dir joinDirection
 }
@@ -556,6 +558,17 @@ func (join *invertibleTypeJoin) processSecondResult(secondDocs []core.Doc) (any,
 }
 
 func (join *invertibleTypeJoin) Next() (bool, error) {
+	if len(join.docsToYield) > 0 {
+		// If there is one or more documents in the queue, drop the first one -
+		// it will have been yielded by the last `Next()` call.
+		join.docsToYield = join.docsToYield[1:]
+		if len(join.docsToYield) > 0 {
+			// If there are still documents in the queue, return true yielding the next
+			// one in the queue.
+			return true, nil
+		}
+	}
+
 	hasFirstValue, err := join.dir.firstNode.Next()
 
 	if err != nil || !hasFirstValue {
@@ -577,7 +590,14 @@ func (join *invertibleTypeJoin) Next() (bool, error) {
 			return false, err
 		}
 		if join.dir.secondNode == join.root {
-			join.root.Value().Fields[join.subSelect.Index] = join.subType.Value()
+			if len(secondDocs) == 0 {
+				return false, nil
+			}
+			for i := range secondDocs {
+				secondDocs[i].Fields[join.subSelect.Index] = join.subType.Value()
+			}
+			join.docsToYield = append(join.docsToYield, secondDocs...)
+			return true, nil
 		} else {
 			secondResult, secondIDResult := join.processSecondResult(secondDocs)
 			join.dir.firstNode.Value().Fields[join.subSelect.Index] = secondResult
@@ -596,9 +616,16 @@ func (join *invertibleTypeJoin) Next() (bool, error) {
 		}
 	}
 
-	join.currentValue = join.root.Value()
+	join.docsToYield = append(join.docsToYield, join.root.Value())
 
 	return true, nil
+}
+
+func (join *invertibleTypeJoin) Value() core.Doc {
+	if len(join.docsToYield) == 0 {
+		return core.Doc{}
+	}
+	return join.docsToYield[0]
 }
 
 func (join *invertibleTypeJoin) invertJoinDirectionWithIndex(

--- a/tests/integration/index/query_with_compound_filter_relation_test.go
+++ b/tests/integration/index/query_with_compound_filter_relation_test.go
@@ -43,7 +43,7 @@ func TestIndex_QueryWithIndexOnOneToManyRelationAndFilter_NoData(t *testing.T) {
 						name
 					}
 				}`,
-				ExpectedError: "invalid filter operator is provided. Operator: _any",
+				Results: []map[string]any{},
 			},
 		},
 	}
@@ -78,7 +78,7 @@ func TestIndex_QueryWithIndexOnOneToManyRelationOrFilter_NoData(t *testing.T) {
 						name
 					}
 				}`,
-				ExpectedError: "invalid filter operator is provided. Operator: _any",
+				Results: []map[string]any{},
 			},
 		},
 	}
@@ -187,7 +187,14 @@ func TestIndex_QueryWithIndexOnOneToManyRelationAndFilter_Data(t *testing.T) {
 						name
 					}
 				}`,
-				ExpectedError: "invalid filter operator is provided. Operator: _any",
+				Results: []map[string]any{
+					{
+						"name": "DefraDB",
+					},
+					{
+						"name": "LensVM",
+					},
+				},
 			},
 		},
 	}
@@ -262,7 +269,17 @@ func TestIndex_QueryWithIndexOnOneToManyRelationOrFilter_Data(t *testing.T) {
 						name
 					}
 				}`,
-				ExpectedError: "invalid filter operator is provided. Operator: _any",
+				Results: []map[string]any{
+					{
+						"name": "Zanzi",
+					},
+					{
+						"name": "DefraDB",
+					},
+					{
+						"name": "LensVM",
+					},
+				},
 			},
 		},
 	}
@@ -331,7 +348,10 @@ func TestIndex_QueryWithIndexOnOneToManyRelationNotFilter_Data(t *testing.T) {
 				}`,
 				Results: []map[string]any{
 					{
-						"name": "DefraDB",
+						"name": "Horizon",
+					},
+					{
+						"name": "Zanzi",
 					},
 				},
 			},

--- a/tests/integration/index/query_with_compound_filter_relation_test.go
+++ b/tests/integration/index/query_with_compound_filter_relation_test.go
@@ -1,0 +1,342 @@
+// Copyright 2024 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package index
+
+import (
+	"testing"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+func TestIndex_QueryWithIndexOnOneToManyRelationAndFilter_NoData(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+				  type Program {
+					name: String
+					certificationBodyOrg: Organization
+				  }
+
+				  type Organization {
+					name: String @index
+					programs: [Program]
+				  }`,
+			},
+			testUtils.Request{
+				Request: `query {
+					Program(
+						filter: {
+							_and: [
+								{ certificationBodyOrg: { name: { _eq: "Test" } } }
+							]
+						}
+					) {
+						name
+					}
+				}`,
+				ExpectedError: "invalid filter operator is provided. Operator: _any",
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestIndex_QueryWithIndexOnOneToManyRelationOrFilter_NoData(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+				  type Program {
+					name: String
+					certificationBodyOrg: Organization
+				  }
+
+				  type Organization {
+					name: String @index
+					programs: [Program]
+				  }`,
+			},
+			testUtils.Request{
+				Request: `query {
+					Program(
+						filter: {
+							_and: [
+								{ certificationBodyOrg: { name: { _eq: "Test" } } }
+							]
+						}
+					) {
+						name
+					}
+				}`,
+				ExpectedError: "invalid filter operator is provided. Operator: _any",
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestIndex_QueryWithIndexOnOneToManyRelationNotFilter_NoData(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+				  type Program {
+					name: String
+					certificationBodyOrg: Organization
+				  }
+
+				  type Organization {
+					name: String @index
+					programs: [Program]
+				  }`,
+			},
+			testUtils.Request{
+				Request: `query {
+					Program(
+						filter: {
+							_and: [
+								{ certificationBodyOrg: { name: { _eq: "Test" } } }
+							]
+						}
+					) {
+						name
+					}
+				}`,
+				Results: []map[string]any{},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestIndex_QueryWithIndexOnOneToManyRelationAndFilter_Data(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+				  type Program {
+					name: String
+					certificationBodyOrg: Organization
+				  }
+
+				  type Organization {
+					name: String @index
+					programs: [Program]
+				  }`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				Doc: `{
+					"name": "Source Inc."
+				}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `{
+					"certificationBodyOrg": "bae-2b020aba-0681-5896-91d6-e3224938c32e",
+					"name": "DefraDB"
+				}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `{
+					"certificationBodyOrg": "bae-2b020aba-0681-5896-91d6-e3224938c32e",
+					"name": "LensVM"
+				}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				Doc: `{
+                    "name": "ESA"
+                }`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `{
+                    "certificationBodyOrg": "bae-5e7a0a2c-40a0-572c-93b6-79930cab3317",
+                    "name": "Horizon"
+                }`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `{
+					"name": "Zanzi"
+				}`,
+			},
+			testUtils.Request{
+				Request: `query {
+					Program(
+						filter: {
+							_and: [
+								{ certificationBodyOrg: { name: { _eq: "Source Inc." } } }
+							]
+						}
+					) {
+						name
+					}
+				}`,
+				ExpectedError: "invalid filter operator is provided. Operator: _any",
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestIndex_QueryWithIndexOnOneToManyRelationOrFilter_Data(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+				  type Program {
+					name: String
+					certificationBodyOrg: Organization
+				  }
+
+				  type Organization {
+					name: String @index
+					programs: [Program]
+				  }`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				Doc: `{
+                    "name": "Source Inc."
+                }`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `{
+                    "certificationBodyOrg": "bae-2b020aba-0681-5896-91d6-e3224938c32e",
+                    "name": "DefraDB"
+                }`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `{
+                    "certificationBodyOrg": "bae-2b020aba-0681-5896-91d6-e3224938c32e",
+                    "name": "LensVM"
+                }`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				Doc: `{
+                    "name": "ESA"
+                }`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `{
+                    "certificationBodyOrg": "bae-5e7a0a2c-40a0-572c-93b6-79930cab3317",
+                    "name": "Horizon"
+                }`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `{
+                    "name": "Zanzi"
+                }`,
+			},
+			testUtils.Request{
+				Request: `query {
+					Program(
+						filter: {
+							_or: [
+								{ certificationBodyOrg: { name: { _eq: "Source Inc." } } },
+								{ name: { _eq: "Zanzi" } }
+							]
+						}
+					) {
+						name
+					}
+				}`,
+				ExpectedError: "invalid filter operator is provided. Operator: _any",
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestIndex_QueryWithIndexOnOneToManyRelationNotFilter_Data(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+				  type Program {
+					name: String
+					certificationBodyOrg: Organization
+				  }
+
+				  type Organization {
+					name: String @index
+					programs: [Program]
+				  }`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				Doc: `{
+                    "name": "Source Inc."
+                }`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `{
+                    "certificationBodyOrg": "bae-2b020aba-0681-5896-91d6-e3224938c32e",
+                    "name": "DefraDB"
+                }`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				Doc: `{
+                    "name": "ESA"
+                }`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `{
+                    "certificationBodyOrg": "bae-5e7a0a2c-40a0-572c-93b6-79930cab3317",
+                    "name": "Horizon"
+                }`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `{
+                    "name": "Zanzi"
+                }`,
+			},
+			testUtils.Request{
+				Request: `query {
+					Program(
+						filter: {
+							_not: {
+								certificationBodyOrg: { name: { _eq: "Source Inc." } }
+							}
+						}
+					) {
+						name
+					}
+				}`,
+				Results: []map[string]any{
+					{
+						"name": "DefraDB",
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #2572

## Description

Handles compound filters targeting related indexed fields, and one-many joins from the many side.

The invertableJoin issue may be affecting non indexed joins.

First commit documents the existing behaviour, second commit fixes it.

There is another issue in this space not solved by this PR: https://github.com/sourcenetwork/defradb/issues/2574