### PR TITLE
fix: Return correct results from one-many indexed filter

### DIFF
--- a/tests/integration/index/query_with_relation_filter_test.go
+++ b/tests/integration/index/query_with_relation_filter_test.go
@@ -53,14 +53,16 @@ func TestQueryWithIndexOnOneToManyRelation_IfFilterOnIndexedRelation_ShouldFilte
 			testUtils.Request{
 				Request: req1,
 				Results: []map[string]any{
+					{"name": "Keenan"},
 					{"name": "Islam"},
 					{"name": "Shahzad"},
-					{"name": "Keenan"},
 				},
 			},
 			testUtils.Request{
-				Request:  makeExplainQuery(req1),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(6).WithIndexFetches(3),
+				Request: makeExplainQuery(req1),
+				// The invertable join does not support inverting one-many relations, so the index is
+				// not used.
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(450).WithIndexFetches(0),
 			},
 			testUtils.Request{
 				Request: req2,
@@ -69,8 +71,10 @@ func TestQueryWithIndexOnOneToManyRelation_IfFilterOnIndexedRelation_ShouldFilte
 				},
 			},
 			testUtils.Request{
-				Request:  makeExplainQuery(req2),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(2).WithIndexFetches(1),
+				Request: makeExplainQuery(req2),
+				// The invertable join does not support inverting one-many relations, so the index is
+				// not used.
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(450).WithIndexFetches(0),
 			},
 		},
 	}
@@ -115,14 +119,16 @@ func TestQueryWithIndexOnOneToManyRelation_IfFilterOnIndexedRelation_ShouldFilte
 			testUtils.Request{
 				Request: req1,
 				Results: []map[string]any{
+					{"name": "Keenan"},
 					{"name": "Islam"},
 					{"name": "Shahzad"},
-					{"name": "Keenan"},
 				},
 			},
 			testUtils.Request{
-				Request:  makeExplainQuery(req1),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(6).WithIndexFetches(3),
+				Request: makeExplainQuery(req1),
+				// The invertable join does not support inverting one-many relations, so the index is
+				// not used.
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(450).WithIndexFetches(0),
 			},
 			testUtils.Request{
 				Request: req2,
@@ -131,8 +137,10 @@ func TestQueryWithIndexOnOneToManyRelation_IfFilterOnIndexedRelation_ShouldFilte
 				},
 			},
 			testUtils.Request{
-				Request:  makeExplainQuery(req2),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(2).WithIndexFetches(1),
+				Request: makeExplainQuery(req2),
+				// The invertable join does not support inverting one-many relations, so the index is
+				// not used.
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(450).WithIndexFetches(0),
 			},
 		},
 	}
@@ -334,6 +342,12 @@ func TestQueryWithIndexOnOneToMany_IfFilterOnIndexedRelation_ShouldFilter(t *tes
 				}`,
 			},
 			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `{
+					"name":	"Addo"
+				}`,
+			},
+			testUtils.CreateDoc{
 				CollectionID: 1,
 				Doc: `{
 					"model":	"Walkman",
@@ -372,16 +386,20 @@ func TestQueryWithIndexOnOneToMany_IfFilterOnIndexedRelation_ShouldFilter(t *tes
 				Results: []map[string]any{
 					{
 						"name": "Chris",
-						"devices": map[string]any{
-							"model":        "Walkman",
-							"manufacturer": "Sony",
-						},
-					},
-					{
-						"name": "Chris",
-						"devices": map[string]any{
-							"model":        "Walkman",
-							"manufacturer": "The Proclaimers",
+						"devices": []map[string]any{
+							{
+								"model":        "Walkman",
+								"manufacturer": "Sony",
+							},
+							{
+								"model":        "Walkman",
+								"manufacturer": "The Proclaimers",
+							},
+							// The filter is on User, so all devices belonging to it will be returned
+							{
+								"model":        "Running Man",
+								"manufacturer": "Braveworld Productions",
+							},
 						},
 					},
 				},
@@ -456,23 +474,28 @@ func TestQueryWithIndexOnOneToMany_IfFilterOnIndexedRelation_ShouldFilterWithExp
 				Results: []map[string]any{
 					{
 						"name": "Chris",
-						"devices": map[string]any{
-							"model":        "Walkman",
-							"manufacturer": "Sony",
-						},
-					},
-					{
-						"name": "Chris",
-						"devices": map[string]any{
-							"model":        "Walkman",
-							"manufacturer": "The Proclaimers",
+						"devices": []map[string]any{
+							{
+								"model":        "Walkman",
+								"manufacturer": "Sony",
+							},
+							{
+								"model":        "Walkman",
+								"manufacturer": "The Proclaimers",
+							},
+							{
+								"model":        "Running Man",
+								"manufacturer": "Braveworld Productions",
+							},
 						},
 					},
 				},
 			},
 			testUtils.Request{
-				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(6).WithIndexFetches(2),
+				Request: makeExplainQuery(req),
+				// The invertable join does not support inverting one-many relations, so the index is
+				// not used.
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(10).WithIndexFetches(0),
 			},
 		},
 	}

--- a/tests/integration/index/query_with_relation_filter_test.go
+++ b/tests/integration/index/query_with_relation_filter_test.go
@@ -317,6 +317,7 @@ func TestQueryWithIndexOnOneToMany_IfFilterOnIndexedRelation_ShouldFilter(t *tes
 			name
 			devices {
 				model
+				manufacturer
 			}
 		}
 	}`
@@ -332,12 +333,40 @@ func TestQueryWithIndexOnOneToMany_IfFilterOnIndexedRelation_ShouldFilter(t *tes
 
 					type Device {
 						model: String @index
+						manufacturer: String
 						owner: User
 					}
 				`,
 			},
-			testUtils.CreatePredefinedDocs{
-				Docs: getUserDocs(),
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `{
+					"name":	"Chris"
+				}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				Doc: `{
+					"model":	"Walkman",
+					"manufacturer": "Sony",
+					"owner": "bae-403d7337-f73e-5c81-8719-e853938c8985"
+				}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				Doc: `{
+					"model":	"Walkman",
+					"manufacturer": "The Proclaimers",
+					"owner": "bae-403d7337-f73e-5c81-8719-e853938c8985"
+				}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				Doc: `{
+					"model":	"Running Man",
+					"manufacturer": "Braveworld Productions",
+					"owner": "bae-403d7337-f73e-5c81-8719-e853938c8985"
+				}`,
 			},
 			testUtils.Request{
 				Request: req,
@@ -345,14 +374,22 @@ func TestQueryWithIndexOnOneToMany_IfFilterOnIndexedRelation_ShouldFilter(t *tes
 					{
 						"name": "Chris",
 						"devices": map[string]any{
-							"model": "Walkman",
+							"model":        "Walkman",
+							"manufacturer": "Sony",
+						},
+					},
+					{
+						"name": "Chris",
+						"devices": map[string]any{
+							"model":        "Walkman",
+							"manufacturer": "The Proclaimers",
 						},
 					},
 				},
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(2).WithIndexFetches(1),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(6).WithIndexFetches(2),
 			},
 		},
 	}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #2574

## Description

Return correct results from one-many joins filtered on an indexed field on the many side.

The invertibleTypeJoin doesn't support the inversion of one-many joins and was converting them into one-one joins.

This means that the index is no longer used if targeting the many side: https://github.com/sourcenetwork/defradb/issues/2578 (this support can be added after the release).