### PR TITLE
test(i): Fix dataless compound relational index filter tests

### DIFF
--- a/tests/integration/index/query_with_compound_filter_relation_test.go
+++ b/tests/integration/index/query_with_compound_filter_relation_test.go
@@ -70,7 +70,7 @@ func TestIndex_QueryWithIndexOnOneToManyRelationOrFilter_NoData(t *testing.T) {
 				Request: `query {
 					Program(
 						filter: {
-							_and: [
+							_or: [
 								{ certificationBodyOrg: { name: { _eq: "Test" } } }
 							]
 						}
@@ -105,9 +105,9 @@ func TestIndex_QueryWithIndexOnOneToManyRelationNotFilter_NoData(t *testing.T) {
 				Request: `query {
 					Program(
 						filter: {
-							_and: [
-								{ certificationBodyOrg: { name: { _eq: "Test" } } }
-							]
+							_not: {
+								certificationBodyOrg: { name: { _eq: "Test" } }
+							}
 						}
 					) {
 						name


### PR DESCRIPTION
## Relevant issue(s)

Resolves #2580

## Description

Fix dataless compound relational index filter tests.

Spotted by @islamaliev here: https://github.com/sourcenetwork/defradb/pull/2575/files#r1587833621
