### PR TITLE
test: Add more ACP integration tests

### DIFF
--- a/tests/integration/acp/query/avg_test.go
+++ b/tests/integration/acp/query/avg_test.go
@@ -32,20 +32,8 @@ func TestACP_QueryAverageWithoutIdentity(t *testing.T) {
 				`,
 				Results: []map[string]any{
 					{
+						// 2 public employees, 1 with salary 10k, 1 with salary 20k
 						"_avg": int(15000),
-					},
-				},
-			},
-
-			testUtils.Request{
-				Request: `
-					query {
-						_avg(Company: {field: capital})
-					}
-				`,
-				Results: []map[string]any{
-					{
-						"_avg": int(100000),
 					},
 				},
 			},
@@ -71,21 +59,8 @@ func TestACP_QueryAverageWithIdentity(t *testing.T) {
 				`,
 				Results: []map[string]any{
 					{
+						// 4 employees with salaries 10k, 20k, 30k, 40k
 						"_avg": int(25000),
-					},
-				},
-			},
-
-			testUtils.Request{
-				Identity: acpUtils.Actor1Identity,
-				Request: `
-					query {
-						_avg(Company: {field: capital})
-					}
-				`,
-				Results: []map[string]any{
-					{
-						"_avg": int(150000),
 					},
 				},
 			},
@@ -111,21 +86,8 @@ func TestACP_QueryAverageWithWrongIdentity(t *testing.T) {
 				`,
 				Results: []map[string]any{
 					{
+						// 2 public employees, 1 with salary 10k, 1 with salary 20k
 						"_avg": int(15000),
-					},
-				},
-			},
-
-			testUtils.Request{
-				Identity: acpUtils.Actor2Identity,
-				Request: `
-					query {
-						_avg(Company: {field: capital})
-					}
-				`,
-				Results: []map[string]any{
-					{
-						"_avg": int(100000),
 					},
 				},
 			},

--- a/tests/integration/acp/query/avg_test.go
+++ b/tests/integration/acp/query/avg_test.go
@@ -1,0 +1,136 @@
+// Copyright 2024 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package test_acp
+
+import (
+	"testing"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	acpUtils "github.com/sourcenetwork/defradb/tests/integration/acp"
+)
+
+func TestACP_QueryAverageWithoutIdentity(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "Test acp, query average without identity",
+
+		Actions: []any{
+			getSetupEmployeeCompanyActions(),
+
+			testUtils.Request{
+				Request: `
+					query {
+						_avg(Employee: {field: salary})
+					}
+				`,
+				Results: []map[string]any{
+					{
+						"_avg": int(15000),
+					},
+				},
+			},
+
+			testUtils.Request{
+				Request: `
+					query {
+						_avg(Company: {field: capital})
+					}
+				`,
+				Results: []map[string]any{
+					{
+						"_avg": int(100000),
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestACP_QueryAverageWithIdentity(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "Test acp, query average with identity",
+
+		Actions: []any{
+			getSetupEmployeeCompanyActions(),
+
+			testUtils.Request{
+				Identity: acpUtils.Actor1Identity,
+				Request: `
+					query {
+						_avg(Employee: {field: salary})
+					}
+				`,
+				Results: []map[string]any{
+					{
+						"_avg": int(25000),
+					},
+				},
+			},
+
+			testUtils.Request{
+				Identity: acpUtils.Actor1Identity,
+				Request: `
+					query {
+						_avg(Company: {field: capital})
+					}
+				`,
+				Results: []map[string]any{
+					{
+						"_avg": int(150000),
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestACP_QueryAverageWithWrongIdentity(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "Test acp, query average without identity",
+
+		Actions: []any{
+			getSetupEmployeeCompanyActions(),
+
+			testUtils.Request{
+				Identity: acpUtils.Actor2Identity,
+				Request: `
+					query {
+						_avg(Employee: {field: salary})
+					}
+				`,
+				Results: []map[string]any{
+					{
+						"_avg": int(15000),
+					},
+				},
+			},
+
+			testUtils.Request{
+				Identity: acpUtils.Actor2Identity,
+				Request: `
+					query {
+						_avg(Company: {field: capital})
+					}
+				`,
+				Results: []map[string]any{
+					{
+						"_avg": int(100000),
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/acp/query/count_test.go
+++ b/tests/integration/acp/query/count_test.go
@@ -1,0 +1,186 @@
+// Copyright 2024 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package test_acp
+
+import (
+	"testing"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	acpUtils "github.com/sourcenetwork/defradb/tests/integration/acp"
+)
+
+func TestACP_QueryCountWithoutIdentity(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "Test acp, query count without identity",
+
+		Actions: []any{
+			getSetupEmployeeCompanyActions(),
+
+			testUtils.Request{
+				Request: `
+					query {
+						_count(Employee: {})
+					}
+				`,
+				Results: []map[string]any{
+					{
+						"_count": int(2),
+					},
+				},
+			},
+
+			testUtils.Request{
+				Request: `
+					query {
+						_count(Company: {})
+					}
+				`,
+				Results: []map[string]any{
+					{
+						"_count": int(1),
+					},
+				},
+			},
+
+			testUtils.Request{
+				Request: `
+					query {
+						Company {
+							_count(employees: {})
+						}
+					}
+				`,
+				Results: []map[string]any{
+					{
+						"_count": int(1),
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestACP_QueryCountWithIdentity(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "Test acp, query count with identity",
+
+		Actions: []any{
+			getSetupEmployeeCompanyActions(),
+
+			testUtils.Request{
+				Identity: acpUtils.Actor1Identity,
+				Request: `
+					query {
+						_count(Employee: {})
+					}
+				`,
+				Results: []map[string]any{
+					{
+						"_count": int(4),
+					},
+				},
+			},
+
+			testUtils.Request{
+				Identity: acpUtils.Actor1Identity,
+				Request: `
+					query {
+						_count(Company: {})
+					}
+				`,
+				Results: []map[string]any{
+					{
+						"_count": int(2),
+					},
+				},
+			},
+
+			testUtils.Request{
+				Identity: acpUtils.Actor1Identity,
+				Request: `
+					query {
+						Company {
+							_count(employees: {})
+						}
+					}
+				`,
+				Results: []map[string]any{
+					{
+						"_count": int(2),
+					},
+					{
+						"_count": int(2),
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestACP_QueryCountWithWrongIdentity(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "Test acp, query count without identity",
+
+		Actions: []any{
+			getSetupEmployeeCompanyActions(),
+
+			testUtils.Request{
+				Identity: acpUtils.Actor2Identity,
+				Request: `
+					query {
+						_count(Employee: {})
+					}
+				`,
+				Results: []map[string]any{
+					{
+						"_count": int(2),
+					},
+				},
+			},
+
+			testUtils.Request{
+				Identity: acpUtils.Actor2Identity,
+				Request: `
+					query {
+						_count(Company: {})
+					}
+				`,
+				Results: []map[string]any{
+					{
+						"_count": int(1),
+					},
+				},
+			},
+
+			testUtils.Request{
+				Identity: acpUtils.Actor2Identity,
+				Request: `
+					query {
+						Company {
+							_count(employees: {})
+						}
+					}
+				`,
+				Results: []map[string]any{
+					{
+						"_count": int(1),
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/acp/query/count_test.go
+++ b/tests/integration/acp/query/count_test.go
@@ -17,9 +17,9 @@ import (
 	acpUtils "github.com/sourcenetwork/defradb/tests/integration/acp"
 )
 
-func TestACP_QueryCountWithoutIdentity(t *testing.T) {
+func TestACP_QueryCountDocumentsWithoutIdentity(t *testing.T) {
 	test := testUtils.TestCase{
-		Description: "Test acp, query count without identity",
+		Description: "Test acp, query documents' count without identity",
 
 		Actions: []any{
 			getSetupEmployeeCompanyActions(),
@@ -36,19 +36,18 @@ func TestACP_QueryCountWithoutIdentity(t *testing.T) {
 					},
 				},
 			},
+		},
+	}
 
-			testUtils.Request{
-				Request: `
-					query {
-						_count(Company: {})
-					}
-				`,
-				Results: []map[string]any{
-					{
-						"_count": int(1),
-					},
-				},
-			},
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestACP_QueryCountRelatedObjectsWithoutIdentity(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "Test acp, query count of related objects without identity",
+
+		Actions: []any{
+			getSetupEmployeeCompanyActions(),
 
 			testUtils.Request{
 				Request: `
@@ -60,6 +59,7 @@ func TestACP_QueryCountWithoutIdentity(t *testing.T) {
 				`,
 				Results: []map[string]any{
 					{
+						// 1 of 2 companies is public and has 1 public employee out of 2
 						"_count": int(1),
 					},
 				},
@@ -70,9 +70,9 @@ func TestACP_QueryCountWithoutIdentity(t *testing.T) {
 	testUtils.ExecuteTestCase(t, test)
 }
 
-func TestACP_QueryCountWithIdentity(t *testing.T) {
+func TestACP_QueryCountDocumentsWithIdentity(t *testing.T) {
 	test := testUtils.TestCase{
-		Description: "Test acp, query count with identity",
+		Description: "Test acp, query documents' count with identity",
 
 		Actions: []any{
 			getSetupEmployeeCompanyActions(),
@@ -90,20 +90,18 @@ func TestACP_QueryCountWithIdentity(t *testing.T) {
 					},
 				},
 			},
+		},
+	}
 
-			testUtils.Request{
-				Identity: acpUtils.Actor1Identity,
-				Request: `
-					query {
-						_count(Company: {})
-					}
-				`,
-				Results: []map[string]any{
-					{
-						"_count": int(2),
-					},
-				},
-			},
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestACP_QueryCountRelatedObjectsWithIdentity(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "Test acp, query count of related objects with identity",
+
+		Actions: []any{
+			getSetupEmployeeCompanyActions(),
 
 			testUtils.Request{
 				Identity: acpUtils.Actor1Identity,
@@ -129,9 +127,9 @@ func TestACP_QueryCountWithIdentity(t *testing.T) {
 	testUtils.ExecuteTestCase(t, test)
 }
 
-func TestACP_QueryCountWithWrongIdentity(t *testing.T) {
+func TestACP_QueryCountDocumentsWithWrongIdentity(t *testing.T) {
 	test := testUtils.TestCase{
-		Description: "Test acp, query count without identity",
+		Description: "Test acp, query documents' count without identity",
 
 		Actions: []any{
 			getSetupEmployeeCompanyActions(),
@@ -149,20 +147,18 @@ func TestACP_QueryCountWithWrongIdentity(t *testing.T) {
 					},
 				},
 			},
+		},
+	}
 
-			testUtils.Request{
-				Identity: acpUtils.Actor2Identity,
-				Request: `
-					query {
-						_count(Company: {})
-					}
-				`,
-				Results: []map[string]any{
-					{
-						"_count": int(1),
-					},
-				},
-			},
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestACP_QueryCountRelatedObjectsWithWrongIdentity(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "Test acp, query count of related objects without identity",
+
+		Actions: []any{
+			getSetupEmployeeCompanyActions(),
 
 			testUtils.Request{
 				Identity: acpUtils.Actor2Identity,
@@ -175,6 +171,7 @@ func TestACP_QueryCountWithWrongIdentity(t *testing.T) {
 				`,
 				Results: []map[string]any{
 					{
+						// 1 of 2 companies is public and has 1 public employee out of 2
 						"_count": int(1),
 					},
 				},

--- a/tests/integration/acp/query/fixture.go
+++ b/tests/integration/acp/query/fixture.go
@@ -108,7 +108,7 @@ func getSetupEmployeeCompanyActions() []any {
 					{
 						"name": "PubEmp in PubCompany",
 						"salary": 10000,
-						"company": "bae-f4beaae4-ca13-5349-bccf-74a47bf1309e"
+						"company": "bae-1ab7ac86-3c68-5abb-b526-803858c9dccf"
 					}
 				`,
 		},
@@ -118,7 +118,7 @@ func getSetupEmployeeCompanyActions() []any {
 					{
 						"name": "PubEmp in PrivateCompany",
 						"salary": 20000,
-						"company": "bae-74d9f5d4-fad7-5b87-8e8b-4d1e8cfbf83c"
+						"company": "bae-4aef4bd6-e2ee-5075-85a5-4d64bbf80bca"
 					}
 				`,
 		},
@@ -129,7 +129,7 @@ func getSetupEmployeeCompanyActions() []any {
 					{
 						"name": "PrivateEmp in PubCompany",
 						"salary": 30000,
-						"company": "bae-f4beaae4-ca13-5349-bccf-74a47bf1309e"
+						"company": "bae-1ab7ac86-3c68-5abb-b526-803858c9dccf"
 					}
 				`,
 		},
@@ -140,7 +140,7 @@ func getSetupEmployeeCompanyActions() []any {
 					{
 						"name": "PrivateEmp in PrivateCompany",
 						"salary": 40000,
-						"company": "bae-74d9f5d4-fad7-5b87-8e8b-4d1e8cfbf83c"
+						"company": "bae-4aef4bd6-e2ee-5075-85a5-4d64bbf80bca"
 					}
 				`,
 		},

--- a/tests/integration/acp/query/fixture.go
+++ b/tests/integration/acp/query/fixture.go
@@ -1,0 +1,148 @@
+// Copyright 2024 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package test_acp
+
+import (
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	acpUtils "github.com/sourcenetwork/defradb/tests/integration/acp"
+)
+
+const employeeCompanyPolicy = `
+description: A Valid DefraDB Policy Interface (DPI)
+
+actor:
+  name: actor
+
+resources:
+  employees:
+    permissions:
+      read:
+        expr: owner + reader
+      write:
+        expr: owner
+
+    relations:
+      owner:
+        types:
+          - actor
+      reader:
+        types:
+          - actor
+
+  companies:
+    permissions:
+      read:
+        expr: owner + reader
+      write:
+        expr: owner
+
+    relations:
+      owner:
+        types:
+          - actor
+      reader:
+        types:
+          - actor
+`
+
+func getSetupEmployeeCompanyActions() []any {
+	return []any{
+		testUtils.AddPolicy{
+			Identity:         acpUtils.Actor1Identity,
+			Policy:           employeeCompanyPolicy,
+			ExpectedPolicyID: "67607eb2a2a873f4a69eb6876323cee7601d8a4d4fedcc18154aaee65cf38e7f",
+		},
+
+		testUtils.SchemaUpdate{
+			Schema: `
+					type Employee @policy(
+						id: "67607eb2a2a873f4a69eb6876323cee7601d8a4d4fedcc18154aaee65cf38e7f",
+						resource: "employees"
+					) {
+						name: String
+						salary: Int
+						company: Company
+					}
+
+					type Company @policy(
+						id: "67607eb2a2a873f4a69eb6876323cee7601d8a4d4fedcc18154aaee65cf38e7f",
+						resource: "companies"
+					) {
+						name: String
+						capital: Int
+						employees: [Employee]
+					}
+				`,
+		},
+
+		testUtils.CreateDoc{
+			CollectionID: 1,
+			Doc: `
+					{
+						"name": "Public Company",
+						"capital": 100000
+					}
+				`,
+		},
+		testUtils.CreateDoc{
+			CollectionID: 1,
+			Identity:     acpUtils.Actor1Identity,
+			Doc: `
+					{
+						"name": "Private Company",
+						"capital": 200000
+					}
+				`,
+		},
+		testUtils.CreateDoc{
+			CollectionID: 0,
+			Doc: `
+					{
+						"name": "PubEmp in PubCompany",
+						"salary": 10000,
+						"company": "bae-f4beaae4-ca13-5349-bccf-74a47bf1309e"
+					}
+				`,
+		},
+		testUtils.CreateDoc{
+			CollectionID: 0,
+			Doc: `
+					{
+						"name": "PubEmp in PrivateCompany",
+						"salary": 20000,
+						"company": "bae-74d9f5d4-fad7-5b87-8e8b-4d1e8cfbf83c"
+					}
+				`,
+		},
+		testUtils.CreateDoc{
+			CollectionID: 0,
+			Identity:     acpUtils.Actor1Identity,
+			Doc: `
+					{
+						"name": "PrivateEmp in PubCompany",
+						"salary": 30000,
+						"company": "bae-f4beaae4-ca13-5349-bccf-74a47bf1309e"
+					}
+				`,
+		},
+		testUtils.CreateDoc{
+			CollectionID: 0,
+			Identity:     acpUtils.Actor1Identity,
+			Doc: `
+					{
+						"name": "PrivateEmp in PrivateCompany",
+						"salary": 40000,
+						"company": "bae-74d9f5d4-fad7-5b87-8e8b-4d1e8cfbf83c"
+					}
+				`,
+		},
+	}
+}

--- a/tests/integration/acp/query/relation_objects_test.go
+++ b/tests/integration/acp/query/relation_objects_test.go
@@ -17,9 +17,9 @@ import (
 	acpUtils "github.com/sourcenetwork/defradb/tests/integration/acp"
 )
 
-func TestACP_QueryRelationObjectsWithoutIdentity(t *testing.T) {
+func TestACP_QueryManyToOneRelationObjectsWithoutIdentity(t *testing.T) {
 	test := testUtils.TestCase{
-		Description: "Test acp, query employees and companies without identity",
+		Description: "Test acp, query employees with their companies without identity",
 
 		Actions: []any{
 			getSetupEmployeeCompanyActions(),
@@ -46,6 +46,18 @@ func TestACP_QueryRelationObjectsWithoutIdentity(t *testing.T) {
 					},
 				},
 			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestACP_QueryOneToManyRelationObjectsWithoutIdentity(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "Test acp, query companies with their employees without identity",
+
+		Actions: []any{
+			getSetupEmployeeCompanyActions(),
 
 			testUtils.Request{
 				Request: `
@@ -73,9 +85,9 @@ func TestACP_QueryRelationObjectsWithoutIdentity(t *testing.T) {
 	testUtils.ExecuteTestCase(t, test)
 }
 
-func TestACP_QueryRelationObjectsWithIdentity(t *testing.T) {
+func TestACP_QueryManyToOneRelationObjectsWithIdentity(t *testing.T) {
 	test := testUtils.TestCase{
-		Description: "Test acp, query employees and companies with identity",
+		Description: "Test acp, query employees with their companies with identity",
 
 		Actions: []any{
 			getSetupEmployeeCompanyActions(),
@@ -111,6 +123,18 @@ func TestACP_QueryRelationObjectsWithIdentity(t *testing.T) {
 					},
 				},
 			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestACP_QueryOneToManyRelationObjectsWithIdentity(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "Test acp, query companies with their employees with identity",
+
+		Actions: []any{
+			getSetupEmployeeCompanyActions(),
 
 			testUtils.Request{
 				Identity: acpUtils.Actor1Identity,
@@ -147,9 +171,9 @@ func TestACP_QueryRelationObjectsWithIdentity(t *testing.T) {
 	testUtils.ExecuteTestCase(t, test)
 }
 
-func TestACP_QueryRelationObjectsWithWrongIdentity(t *testing.T) {
+func TestACP_QueryManyToOneRelationObjectsWithWrongIdentity(t *testing.T) {
 	test := testUtils.TestCase{
-		Description: "Test acp, query employees and companies with wrong identity",
+		Description: "Test acp, query employees with their companies with wrong identity",
 
 		Actions: []any{
 			getSetupEmployeeCompanyActions(),
@@ -177,6 +201,18 @@ func TestACP_QueryRelationObjectsWithWrongIdentity(t *testing.T) {
 					},
 				},
 			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestACP_QueryOneToManyRelationObjectsWithWrongIdentity(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "Test acp, query companies with their employees with wrong identity",
+
+		Actions: []any{
+			getSetupEmployeeCompanyActions(),
 
 			testUtils.Request{
 				Identity: acpUtils.Actor2Identity,

--- a/tests/integration/acp/query/relation_objects_test.go
+++ b/tests/integration/acp/query/relation_objects_test.go
@@ -1,0 +1,206 @@
+// Copyright 2024 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package test_acp
+
+import (
+	"testing"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	acpUtils "github.com/sourcenetwork/defradb/tests/integration/acp"
+)
+
+func TestACP_QueryRelationObjectsWithoutIdentity(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "Test acp, query employees and companies without identity",
+
+		Actions: []any{
+			getSetupEmployeeCompanyActions(),
+
+			testUtils.Request{
+				Request: `
+					query {
+						Employee {
+							name
+							company {
+								name
+							}
+						}
+					}
+				`,
+				Results: []map[string]any{
+					{
+						"name":    "PubEmp in PubCompany",
+						"company": map[string]any{"name": "Public Company"},
+					},
+					{
+						"name":    "PubEmp in PrivateCompany",
+						"company": nil,
+					},
+				},
+			},
+
+			testUtils.Request{
+				Request: `
+					query {
+						Company {
+							name
+							employees {
+								name
+							}
+						}
+					}
+				`,
+				Results: []map[string]any{
+					{
+						"name": "Public Company",
+						"employees": []map[string]any{
+							{"name": "PubEmp in PubCompany"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestACP_QueryRelationObjectsWithIdentity(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "Test acp, query employees and companies with identity",
+
+		Actions: []any{
+			getSetupEmployeeCompanyActions(),
+
+			testUtils.Request{
+				Identity: acpUtils.Actor1Identity,
+				Request: `
+					query {
+						Employee {
+							name
+							company {
+								name
+							}
+						}
+					}
+				`,
+				Results: []map[string]any{
+					{
+						"name":    "PubEmp in PubCompany",
+						"company": map[string]any{"name": "Public Company"},
+					},
+					{
+						"name":    "PrivateEmp in PubCompany",
+						"company": map[string]any{"name": "Public Company"},
+					},
+					{
+						"name":    "PrivateEmp in PrivateCompany",
+						"company": map[string]any{"name": "Private Company"},
+					},
+					{
+						"name":    "PubEmp in PrivateCompany",
+						"company": map[string]any{"name": "Private Company"},
+					},
+				},
+			},
+
+			testUtils.Request{
+				Identity: acpUtils.Actor1Identity,
+				Request: `
+					query {
+						Company {
+							name
+							employees {
+								name
+							}
+						}
+					}
+				`,
+				Results: []map[string]any{
+					{
+						"name": "Private Company",
+						"employees": []map[string]any{
+							{"name": "PrivateEmp in PrivateCompany"},
+							{"name": "PubEmp in PrivateCompany"},
+						},
+					},
+					{
+						"name": "Public Company",
+						"employees": []map[string]any{
+							{"name": "PubEmp in PubCompany"},
+							{"name": "PrivateEmp in PubCompany"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestACP_QueryRelationObjectsWithWrongIdentity(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "Test acp, query employees and companies with wrong identity",
+
+		Actions: []any{
+			getSetupEmployeeCompanyActions(),
+
+			testUtils.Request{
+				Identity: acpUtils.Actor2Identity,
+				Request: `
+					query {
+						Employee {
+							name
+							company {
+								name
+							}
+						}
+					}
+				`,
+				Results: []map[string]any{
+					{
+						"name":    "PubEmp in PubCompany",
+						"company": map[string]any{"name": "Public Company"},
+					},
+					{
+						"name":    "PubEmp in PrivateCompany",
+						"company": nil,
+					},
+				},
+			},
+
+			testUtils.Request{
+				Identity: acpUtils.Actor2Identity,
+				Request: `
+					query {
+						Company {
+							name
+							employees {
+								name
+							}
+						}
+					}
+				`,
+				Results: []map[string]any{
+					{
+						"name": "Public Company",
+						"employees": []map[string]any{
+							{"name": "PubEmp in PubCompany"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/acp/query/relation_objects_test.go
+++ b/tests/integration/acp/query/relation_objects_test.go
@@ -37,12 +37,12 @@ func TestACP_QueryRelationObjectsWithoutIdentity(t *testing.T) {
 				`,
 				Results: []map[string]any{
 					{
-						"name":    "PubEmp in PubCompany",
-						"company": map[string]any{"name": "Public Company"},
-					},
-					{
 						"name":    "PubEmp in PrivateCompany",
 						"company": nil,
+					},
+					{
+						"name":    "PubEmp in PubCompany",
+						"company": map[string]any{"name": "Public Company"},
 					},
 				},
 			},
@@ -94,10 +94,6 @@ func TestACP_QueryRelationObjectsWithIdentity(t *testing.T) {
 				`,
 				Results: []map[string]any{
 					{
-						"name":    "PubEmp in PubCompany",
-						"company": map[string]any{"name": "Public Company"},
-					},
-					{
 						"name":    "PrivateEmp in PubCompany",
 						"company": map[string]any{"name": "Public Company"},
 					},
@@ -108,6 +104,10 @@ func TestACP_QueryRelationObjectsWithIdentity(t *testing.T) {
 					{
 						"name":    "PubEmp in PrivateCompany",
 						"company": map[string]any{"name": "Private Company"},
+					},
+					{
+						"name":    "PubEmp in PubCompany",
+						"company": map[string]any{"name": "Public Company"},
 					},
 				},
 			},
@@ -126,17 +126,17 @@ func TestACP_QueryRelationObjectsWithIdentity(t *testing.T) {
 				`,
 				Results: []map[string]any{
 					{
+						"name": "Public Company",
+						"employees": []map[string]any{
+							{"name": "PrivateEmp in PubCompany"},
+							{"name": "PubEmp in PubCompany"},
+						},
+					},
+					{
 						"name": "Private Company",
 						"employees": []map[string]any{
 							{"name": "PrivateEmp in PrivateCompany"},
 							{"name": "PubEmp in PrivateCompany"},
-						},
-					},
-					{
-						"name": "Public Company",
-						"employees": []map[string]any{
-							{"name": "PubEmp in PubCompany"},
-							{"name": "PrivateEmp in PubCompany"},
 						},
 					},
 				},
@@ -168,12 +168,12 @@ func TestACP_QueryRelationObjectsWithWrongIdentity(t *testing.T) {
 				`,
 				Results: []map[string]any{
 					{
-						"name":    "PubEmp in PubCompany",
-						"company": map[string]any{"name": "Public Company"},
-					},
-					{
 						"name":    "PubEmp in PrivateCompany",
 						"company": nil,
+					},
+					{
+						"name":    "PubEmp in PubCompany",
+						"company": map[string]any{"name": "Public Company"},
 					},
 				},
 			},


### PR DESCRIPTION
Resolves #2474 and #2475

Add integration tests for ACP on relation objects and `_avg` and `_count` methods.