### PR TITLE
test: Test node pkg constructor via integration test suite

### DIFF
--- a/cli/server_dump.go
+++ b/cli/server_dump.go
@@ -33,7 +33,7 @@ func MakeServerDumpCmd() *cobra.Command {
 			storeOpts := []node.StoreOpt{
 				node.WithPath(cfg.GetString("datastore.badger.path")),
 			}
-			rootstore, err := node.NewStore(storeOpts...)
+			rootstore, err := node.NewStore(cmd.Context(), storeOpts...)
 			if err != nil {
 				return err
 			}

--- a/node/node.go
+++ b/node/node.go
@@ -116,7 +116,8 @@ func NewNode(ctx context.Context, opts ...NodeOpt) (*Node, error) {
 	for _, opt := range opts {
 		opt(options)
 	}
-	rootstore, err := NewStore(options.storeOpts...)
+
+	rootstore, err := NewStore(ctx, options.storeOpts...)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/bench/bench_util.go
+++ b/tests/bench/bench_util.go
@@ -227,7 +227,7 @@ func newBenchStoreInfo(ctx context.Context, t testing.TB) (client.DB, error) {
 	case "memory":
 		db, err = testutils.NewBadgerMemoryDB(ctx)
 	case "badger":
-		db, _, err = testutils.NewBadgerFileDB(ctx, t)
+		db, err = testutils.NewBadgerFileDB(ctx, t)
 	default:
 		return nil, errors.New(fmt.Sprintf("invalid storage engine backend: %s", storage))
 	}

--- a/tests/integration/db.go
+++ b/tests/integration/db.go
@@ -157,7 +157,7 @@ func NewBadgerFileDB(ctx context.Context, t testing.TB, dbopts ...db.Option) (cl
 // testing state. The database type on the test state is used to
 // select the datastore implementation to use.
 func setupDatabase(s *state) (impl client.DB, path string, err error) {
-	dbopts := []db.Option{
+	dbOpts := []db.Option{
 		db.WithUpdateEvents(),
 		db.WithLensPoolSize(lensPoolSize),
 	}
@@ -172,13 +172,13 @@ func setupDatabase(s *state) (impl client.DB, path string, err error) {
 
 	switch s.dbt {
 	case badgerIMType:
-		impl, err = NewBadgerMemoryDB(s.ctx, dbopts...)
+		impl, err = NewBadgerMemoryDB(s.ctx, dbOpts...)
 
 	case badgerFileType:
-		impl, path, err = NewBadgerFileDB(s.ctx, s.t, dbopts...)
+		impl, path, err = NewBadgerFileDB(s.ctx, s.t, dbOpts...)
 
 	case defraIMType:
-		impl, err = NewInMemoryDB(s.ctx, dbopts...)
+		impl, err = NewInMemoryDB(s.ctx, dbOpts...)
 
 	default:
 		err = fmt.Errorf("invalid database type: %v", s.dbt)

--- a/tests/integration/events/utils.go
+++ b/tests/integration/events/utils.go
@@ -20,7 +20,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/sourcenetwork/defradb/client"
-	"github.com/sourcenetwork/defradb/internal/db"
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
 )
 
@@ -70,7 +69,7 @@ func ExecuteRequestTestCase(
 ) {
 	ctx := context.Background()
 
-	db, err := testUtils.NewBadgerMemoryDB(ctx, db.WithUpdateEvents())
+	db, err := testUtils.NewBadgerMemoryDB(ctx)
 	require.NoError(t, err)
 
 	_, err = db.AddSchema(ctx, schema)

--- a/tests/integration/net/order/utils.go
+++ b/tests/integration/net/order/utils.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/errors"
-	coreDB "github.com/sourcenetwork/defradb/internal/db"
 	"github.com/sourcenetwork/defradb/net"
 	netutils "github.com/sourcenetwork/defradb/net/utils"
 	testutils "github.com/sourcenetwork/defradb/tests/integration"
@@ -81,7 +80,7 @@ func setupDefraNode(
 	ctx := context.Background()
 
 	log.InfoContext(ctx, "Building new memory store")
-	db, err := testutils.NewBadgerMemoryDB(ctx, coreDB.WithUpdateEvents())
+	db, err := testutils.NewBadgerMemoryDB(ctx)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #2634

## Description

Tests node pkg constructor via integration test suite instead of bypassing it and directly creating `db` instances via the `db` package.

