### PR TITLE
test(i): Don't setup http and p2p by default in test suite

### DIFF
--- a/tests/integration/db.go
+++ b/tests/integration/db.go
@@ -109,7 +109,14 @@ func setupDatabase(s *state) (client.DB, string, error) {
 	}
 	storeOpts := []node.StoreOpt{}
 	acpOpts := []node.ACPOpt{}
-	opts := []node.NodeOpt{}
+	opts := []node.NodeOpt{
+		// The test framework sets this up elsewhere when required so that it may be wrapped
+		// into a [client.DB].
+		node.WithDisableAPI(true),
+		// The p2p is configured in the tests by [ConfigureNode] actions, we disable it here
+		// to keep the tests as lightweight as possible.
+		node.WithDisableP2P(true),
+	}
 
 	if badgerEncryption && encryptionKey == nil {
 		key, err := crypto.GenerateAES256()


### PR DESCRIPTION
## Relevant issue(s)

Resolves #2643

## Description

Don't setup http and p2p by default in test suite.

This is a regression I introduced in https://github.com/sourcenetwork/defradb/pull/2641 (sorry for the bother) - we set p2p and http up later.  As the new, unused, P2P and http servers werent cleaned up at the end of the test, this had quite a bad effect on test suite memory consumption.

Later, I think the surrounding code that sets up p2p and http could probably be changed later to make better use of `node.New`, but IMO this is good enough for now (we have other things to do).
