### PR TITLE
ci(i): Add workflow to ensure cli docs are in sync

### DIFF
--- a/.github/workflows/check-cli-documentation.yml
+++ b/.github/workflows/check-cli-documentation.yml
@@ -1,0 +1,61 @@
+# Copyright 2024 Democratized Data Foundation
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.txt.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0, included in the file
+# licenses/APL.txt.
+
+# This workflow checks that all CLI documentation is up to date.
+# If the documentation is not up to date then this action will fail.
+name: Check CLI Documentation Workflow
+
+on:
+  pull_request:
+    branches:
+      - master
+      - develop
+
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+    branches:
+      - master
+      - develop
+
+jobs:
+  check-cli-documentation:
+    name: Check cli documentation job
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code into the directory
+        uses: actions/checkout@v3
+
+      # This check is there as a safety to ensure we start clean (without any changes).
+      # If there are ever changes here, the rest of the job will output false result.
+      - name: Check no changes exist initially
+        uses: tj-actions/verify-changed-files@v20
+        with:
+          fail-if-changed: true
+          files: |
+             docs/website/references/cli
+
+      - name: Setup Go environment explicitly
+        uses: actions/setup-go@v3
+        with:
+          go-version: "1.21"
+          check-latest: true
+
+      - name: Try generating cli documentation
+        run: make docs:cli
+
+      - name: Check no new changes exist
+        uses: tj-actions/verify-changed-files@v20
+        with:
+          fail-if-changed: true
+          files: |
+             docs/website/references/cli


### PR DESCRIPTION
## Relevant issue(s)
Resolves #2165

## Description
- Detects if cli documents need updating.
- If Documentation is up to date the action passes, else fails.
- Run `make docs` or `make docs:cli` to generate the documentation.
- Introducing as a non-required check, but would argue it should be required.

## Tasks
- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?
- Manually testing through action run and by using `act` utility.
- Failed action: https://github.com/sourcenetwork/defradb/actions/runs/9214068142/job/25349425467?pr=2647

Specify the platform(s) on which this was tested:
- WSL2
