### PR TITLE
fix: Make node options composable

### DIFF
--- a/node/node_test.go
+++ b/node/node_test.go
@@ -11,50 +11,12 @@
 package node
 
 import (
-	"context"
 	"testing"
-	"time"
 
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/sourcenetwork/defradb/http"
-	"github.com/sourcenetwork/defradb/internal/db"
-	"github.com/sourcenetwork/defradb/net"
 )
-
-func TestWithStoreOpts(t *testing.T) {
-	storeOpts := []StoreOpt{WithPath("test")}
-
-	options := &Options{}
-	WithStoreOpts(storeOpts...)(options)
-	assert.Equal(t, storeOpts, options.storeOpts)
-}
-
-func TestWithDatabaseOpts(t *testing.T) {
-	dbOpts := []db.Option{db.WithMaxRetries(10)}
-
-	options := &Options{}
-	WithDatabaseOpts(dbOpts...)(options)
-	assert.Equal(t, dbOpts, options.dbOpts)
-}
-
-func TestWithNetOpts(t *testing.T) {
-	netOpts := []net.NodeOpt{net.WithEnablePubSub(true)}
-
-	options := &Options{}
-	WithNetOpts(netOpts...)(options)
-	assert.Equal(t, netOpts, options.netOpts)
-}
-
-func TestWithServerOpts(t *testing.T) {
-	serverOpts := []http.ServerOpt{http.WithAddress("127.0.0.1:8080")}
-
-	options := &Options{}
-	WithServerOpts(serverOpts...)(options)
-	assert.Equal(t, serverOpts, options.serverOpts)
-}
 
 func TestWithDisableP2P(t *testing.T) {
 	options := &Options{}
@@ -77,25 +39,4 @@ func TestWithPeers(t *testing.T) {
 
 	require.Len(t, options.peers, 1)
 	assert.Equal(t, *peer, options.peers[0])
-}
-
-func TestNodeStart(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	opts := []NodeOpt{
-		WithStoreOpts(WithPath(t.TempDir())),
-		WithDatabaseOpts(db.WithUpdateEvents()),
-	}
-
-	node, err := NewNode(ctx, opts...)
-	require.NoError(t, err)
-
-	err = node.Start(ctx)
-	require.NoError(t, err)
-
-	<-time.After(5 * time.Second)
-
-	err = node.Close(ctx)
-	require.NoError(t, err)
 }


### PR DESCRIPTION
## Relevant issue(s)

Resolves #2642 

## Description

This PR fixes an issue where node subsystem options were not composable.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

`make test`

Specify the platform(s) on which this was tested:
- MacOS

