### PR TITLE
refactor: Extract Defra specific logic from ACPLocal type

### DIFF
--- a/acp/acp_local.go
+++ b/acp/acp_local.go
@@ -25,7 +25,7 @@ type ACPLocal struct {
 	localACP    *embedded.LocalACP
 }
 
-var _ sourcehubClient = (*ACPLocal)(nil)
+var _ sourceHubClient = (*ACPLocal)(nil)
 
 func (l *ACPLocal) Init(ctx context.Context, path string) {
 	if path == "" {

--- a/acp/acp_local.go
+++ b/acp/acp_local.go
@@ -14,17 +14,9 @@ import (
 	"context"
 
 	protoTypes "github.com/cosmos/gogoproto/types"
-	"github.com/sourcenetwork/corelog"
 	"github.com/sourcenetwork/immutable"
 	"github.com/sourcenetwork/sourcehub/x/acp/embedded"
 	"github.com/sourcenetwork/sourcehub/x/acp/types"
-	"github.com/valyala/fastjson"
-
-	"github.com/sourcenetwork/defradb/errors"
-)
-
-var (
-	_ ACP = (*ACPLocal)(nil)
 )
 
 // ACPLocal represents a local acp implementation that makes no remote calls.
@@ -32,6 +24,8 @@ type ACPLocal struct {
 	pathToStore immutable.Option[string]
 	localACP    *embedded.LocalACP
 }
+
+var _ sourcehubClient = (*ACPLocal)(nil)
 
 func (l *ACPLocal) Init(ctx context.Context, path string) {
 	if path == "" {
@@ -75,22 +69,9 @@ func (l *ACPLocal) AddPolicy(
 	ctx context.Context,
 	creatorID string,
 	policy string,
+	policyMarshalType types.PolicyMarshalingType,
+	creationTime *protoTypes.Timestamp,
 ) (string, error) {
-	// Having a creator identity is a MUST requirement for adding a policy.
-	if creatorID == "" {
-		return "", ErrPolicyCreatorMustNotBeEmpty
-	}
-
-	if policy == "" {
-		return "", ErrPolicyDataMustNotBeEmpty
-	}
-
-	// Assume policy is in YAML format by default.
-	policyMarshalType := types.PolicyMarshalingType_SHORT_YAML
-	if isJSON := fastjson.Validate(policy) == nil; isJSON { // Detect JSON format.
-		policyMarshalType = types.PolicyMarshalingType_SHORT_JSON
-	}
-
 	createPolicy := types.MsgCreatePolicy{
 		Creator:      creatorID,
 		Policy:       policy,
@@ -102,160 +83,68 @@ func (l *ACPLocal) AddPolicy(
 		l.localACP.GetCtx(),
 		&createPolicy,
 	)
-
 	if err != nil {
-		return "", NewErrFailedToAddPolicyWithACP(err, "Local", creatorID)
+		return "", err
 	}
 
-	policyID := createPolicyResponse.Policy.Id
-	log.InfoContext(ctx, "Created Policy", corelog.Any("PolicyID", policyID))
-
-	return policyID, nil
+	return createPolicyResponse.Policy.Id, nil
 }
 
-func (l *ACPLocal) ValidateResourceExistsOnValidDPI(
+func (l *ACPLocal) Policy(
 	ctx context.Context,
 	policyID string,
-	resourceName string,
-) error {
-	if policyID == "" && resourceName == "" {
-		return ErrNoPolicyArgs
-	}
-
-	if policyID == "" {
-		return ErrPolicyIDMustNotBeEmpty
-	}
-
-	if resourceName == "" {
-		return ErrResourceNameMustNotBeEmpty
-	}
-
-	queryPolicyRequest := types.QueryPolicyRequest{Id: policyID}
+) (*types.Policy, error) {
 	queryPolicyResponse, err := l.localACP.GetQueryService().Policy(
 		l.localACP.GetCtx(),
-		&queryPolicyRequest,
+		&types.QueryPolicyRequest{Id: policyID},
 	)
-
 	if err != nil {
-		if errors.Is(err, types.ErrPolicyNotFound) {
-			return newErrPolicyDoesNotExistWithACP(err, policyID)
-		} else {
-			return newErrPolicyValidationFailedWithACP(err, policyID)
-		}
+		return nil, err
 	}
 
-	// So far we validated that the policy exists, now lets validate that resource exists.
-	resourceResponse := queryPolicyResponse.Policy.GetResourceByName(resourceName)
-	if resourceResponse == nil {
-		return newErrResourceDoesNotExistOnTargetPolicy(resourceName, policyID)
-	}
-
-	// Now that we have validated that policyID exists and it contains a corresponding
-	// resource with the matching name, validate that all required permissions
-	// for DPI actually exist on the target resource.
-	for _, requiredPermission := range dpiRequiredPermissions {
-		permissionResponse := resourceResponse.GetPermissionByName(requiredPermission)
-		if permissionResponse == nil {
-			return newErrResourceIsMissingRequiredPermission(
-				resourceName,
-				requiredPermission,
-				policyID,
-			)
-		}
-
-		// Now we need to ensure that the "owner" relation has access to all the required
-		// permissions for DPI. This is important because even if the policy has the required
-		// permissions under the resource, it's possible that those permissions are not granted
-		// to the "owner" relation, this will help users not shoot themseleves in the foot.
-		// TODO-ACP: Better validation, once sourcehub implements meta-policies.
-		// Issue: https://github.com/sourcenetwork/defradb/issues/2359
-		if err := validateDPIExpressionOfRequiredPermission(
-			permissionResponse.Expression,
-			requiredPermission,
-		); err != nil {
-			return err
-		}
-	}
-
-	return nil
+	return queryPolicyResponse.Policy, nil
 }
 
-func (l *ACPLocal) RegisterDocObject(
+func (l *ACPLocal) RegisterObject(
 	ctx context.Context,
 	actorID string,
 	policyID string,
 	resourceName string,
-	docID string,
-) error {
-	registerDoc := types.MsgRegisterObject{
-		Creator:      actorID,
-		PolicyId:     policyID,
-		Object:       types.NewObject(resourceName, docID),
-		CreationTime: protoTypes.TimestampNow(),
-	}
-
+	objectID string,
+	creationTime *protoTypes.Timestamp,
+) (types.RegistrationResult, error) {
 	registerDocResponse, err := l.localACP.GetMsgService().RegisterObject(
 		l.localACP.GetCtx(),
-		&registerDoc,
+		&types.MsgRegisterObject{
+			Creator:      actorID,
+			PolicyId:     policyID,
+			Object:       types.NewObject(resourceName, objectID),
+			CreationTime: creationTime,
+		},
 	)
-
 	if err != nil {
-		return NewErrFailedToRegisterDocWithACP(err, "Local", policyID, actorID, resourceName, docID)
+		return types.RegistrationResult(0), err
 	}
 
-	switch registerDocResponse.Result {
-	case types.RegistrationResult_NoOp:
-		return ErrObjectDidNotRegister
-
-	case types.RegistrationResult_Registered:
-		log.InfoContext(
-			ctx,
-			"Document registered with local acp",
-			corelog.Any("PolicyID", policyID),
-			corelog.Any("Creator", actorID),
-			corelog.Any("Resource", resourceName),
-			corelog.Any("DocID", docID),
-		)
-		return nil
-
-	case types.RegistrationResult_Unarchived:
-		log.InfoContext(
-			ctx,
-			"Document re-registered (unarchived object) with local acp",
-			corelog.Any("PolicyID", policyID),
-			corelog.Any("Creator", actorID),
-			corelog.Any("Resource", resourceName),
-			corelog.Any("DocID", docID),
-		)
-		return nil
-	}
-
-	return ErrObjectDidNotRegister
+	return registerDocResponse.Result, nil
 }
 
-func (l *ACPLocal) IsDocRegistered(
+func (l *ACPLocal) ObjectOwner(
 	ctx context.Context,
 	policyID string,
 	resourceName string,
-	docID string,
-) (bool, error) {
-	queryObjectOwner := types.QueryObjectOwnerRequest{
-		PolicyId: policyID,
-		Object:   types.NewObject(resourceName, docID),
-	}
-
-	queryObjectOwnerResponse, err := l.localACP.GetQueryService().ObjectOwner(
+	objectID string,
+) (*types.QueryObjectOwnerResponse, error) {
+	return l.localACP.GetQueryService().ObjectOwner(
 		l.localACP.GetCtx(),
-		&queryObjectOwner,
+		&types.QueryObjectOwnerRequest{
+			PolicyId: policyID,
+			Object:   types.NewObject(resourceName, objectID),
+		},
 	)
-	if err != nil {
-		return false, NewErrFailedToCheckIfDocIsRegisteredWithACP(err, "Local", policyID, resourceName, docID)
-	}
-
-	return queryObjectOwnerResponse.IsRegistered, nil
 }
 
-func (l *ACPLocal) CheckDocAccess(
+func (l *ACPLocal) VerifyAccessRequest(
 	ctx context.Context,
 	permission DPIPermission,
 	actorID string,
@@ -263,48 +152,26 @@ func (l *ACPLocal) CheckDocAccess(
 	resourceName string,
 	docID string,
 ) (bool, error) {
-	checkDoc := types.QueryVerifyAccessRequestRequest{
-		PolicyId: policyID,
-		AccessRequest: &types.AccessRequest{
-			Operations: []*types.Operation{
-				{
-					Object:     types.NewObject(resourceName, docID),
-					Permission: permission.String(),
-				},
-			},
-			Actor: &types.Actor{
-				Id: actorID,
-			},
-		},
-	}
-
 	checkDocResponse, err := l.localACP.GetQueryService().VerifyAccessRequest(
 		l.localACP.GetCtx(),
-		&checkDoc,
+		&types.QueryVerifyAccessRequestRequest{
+			PolicyId: policyID,
+			AccessRequest: &types.AccessRequest{
+				Operations: []*types.Operation{
+					{
+						Object:     types.NewObject(resourceName, docID),
+						Permission: permission.String(),
+					},
+				},
+				Actor: &types.Actor{
+					Id: actorID,
+				},
+			},
+		},
 	)
 	if err != nil {
-		return false, NewErrFailedToVerifyDocAccessWithACP(err, "Local", policyID, actorID, resourceName, docID)
+		return false, err
 	}
 
-	if checkDocResponse.Valid {
-		log.InfoContext(
-			ctx,
-			"Document accessible",
-			corelog.Any("PolicyID", policyID),
-			corelog.Any("ActorID", actorID),
-			corelog.Any("Resource", resourceName),
-			corelog.Any("DocID", docID),
-		)
-		return true, nil
-	} else {
-		log.InfoContext(
-			ctx,
-			"Document inaccessible",
-			corelog.Any("PolicyID", policyID),
-			corelog.Any("ActorID", actorID),
-			corelog.Any("Resource", resourceName),
-			corelog.Any("DocID", docID),
-		)
-		return false, nil
-	}
+	return checkDocResponse.Valid, nil
 }

--- a/acp/acp_local_test.go
+++ b/acp/acp_local_test.go
@@ -46,7 +46,7 @@ resources:
 
 func Test_LocalACP_InMemory_StartAndClose_NoError(t *testing.T) {
 	ctx := context.Background()
-	var localACP ACPLocal
+	localACP := NewLocalACP()
 
 	localACP.Init(ctx, "")
 	err := localACP.Start(ctx)
@@ -62,7 +62,7 @@ func Test_LocalACP_PersistentMemory_StartAndClose_NoError(t *testing.T) {
 	require.NotEqual(t, "", acpPath)
 
 	ctx := context.Background()
-	var localACP ACPLocal
+	localACP := NewLocalACP()
 
 	localACP.Init(ctx, acpPath)
 	err := localACP.Start(ctx)
@@ -74,7 +74,7 @@ func Test_LocalACP_PersistentMemory_StartAndClose_NoError(t *testing.T) {
 
 func Test_LocalACP_InMemory_AddPolicy_CanCreateTwice(t *testing.T) {
 	ctx := context.Background()
-	var localACP ACPLocal
+	localACP := NewLocalACP()
 
 	localACP.Init(ctx, "")
 	errStart := localACP.Start(ctx)
@@ -123,7 +123,7 @@ func Test_LocalACP_PersistentMemory_AddPolicy_CanNotCreateTwice(t *testing.T) {
 	require.NotEqual(t, "", acpPath)
 
 	ctx := context.Background()
-	var localACP ACPLocal
+	localACP := NewLocalACP()
 
 	localACP.Init(ctx, acpPath)
 	errStart := localACP.Start(ctx)
@@ -165,7 +165,7 @@ func Test_LocalACP_PersistentMemory_AddPolicy_CanNotCreateTwice(t *testing.T) {
 
 func Test_LocalACP_InMemory_ValidateResourseExistsOrNot_ErrIfDoesntExist(t *testing.T) {
 	ctx := context.Background()
-	var localACP ACPLocal
+	localACP := NewLocalACP()
 
 	localACP.Init(ctx, "")
 	errStart := localACP.Start(ctx)
@@ -215,7 +215,7 @@ func Test_LocalACP_PersistentMemory_ValidateResourseExistsOrNot_ErrIfDoesntExist
 	require.NotEqual(t, "", acpPath)
 
 	ctx := context.Background()
-	var localACP ACPLocal
+	localACP := NewLocalACP()
 
 	localACP.Init(ctx, acpPath)
 	errStart := localACP.Start(ctx)
@@ -278,7 +278,7 @@ func Test_LocalACP_PersistentMemory_ValidateResourseExistsOrNot_ErrIfDoesntExist
 
 func Test_LocalACP_InMemory_IsDocRegistered_TrueIfRegisteredFalseIfNotAndErrorOtherwise(t *testing.T) {
 	ctx := context.Background()
-	var localACP ACPLocal
+	localACP := NewLocalACP()
 
 	localACP.Init(ctx, "")
 	errStart := localACP.Start(ctx)
@@ -358,7 +358,7 @@ func Test_LocalACP_PersistentMemory_IsDocRegistered_TrueIfRegisteredFalseIfNotAn
 	require.NotEqual(t, "", acpPath)
 
 	ctx := context.Background()
-	var localACP ACPLocal
+	localACP := NewLocalACP()
 
 	localACP.Init(ctx, acpPath)
 	errStart := localACP.Start(ctx)
@@ -454,7 +454,7 @@ func Test_LocalACP_PersistentMemory_IsDocRegistered_TrueIfRegisteredFalseIfNotAn
 
 func Test_LocalACP_InMemory_CheckDocAccess_TrueIfHaveAccessFalseIfNotErrorOtherwise(t *testing.T) {
 	ctx := context.Background()
-	var localACP ACPLocal
+	localACP := NewLocalACP()
 
 	localACP.Init(ctx, "")
 	errStart := localACP.Start(ctx)
@@ -540,7 +540,7 @@ func Test_LocalACP_PersistentMemory_CheckDocAccess_TrueIfHaveAccessFalseIfNotErr
 	require.NotEqual(t, "", acpPath)
 
 	ctx := context.Background()
-	var localACP ACPLocal
+	localACP := NewLocalACP()
 
 	localACP.Init(ctx, acpPath)
 	errStart := localACP.Start(ctx)

--- a/acp/source_hub_client.go
+++ b/acp/source_hub_client.go
@@ -21,10 +21,10 @@ import (
 	"github.com/sourcenetwork/defradb/errors"
 )
 
-// sourcehubClient is a private abstraction to allow multiple ACP implementations
+// sourceHubClient is a private abstraction to allow multiple ACP implementations
 // based off of the SourceHub libraries to share the same Defra-specific logic via the
 // sourceHubBridge.
-type sourcehubClient interface {
+type sourceHubClient interface {
 	// Init initializes the acp, with an absolute path. The provided path indicates where the
 	// persistent data will be stored for acp.
 	//
@@ -88,10 +88,10 @@ type sourcehubClient interface {
 	Close() error
 }
 
-// sourceHubBridge wraps a sourcehubClient, hosting the Defra-specific logic away from client-specific
+// sourceHubBridge wraps a sourceHubClient, hosting the Defra-specific logic away from client-specific
 // code.
 type sourceHubBridge struct {
-	client sourcehubClient
+	client sourceHubClient
 }
 
 var _ ACP = (*sourceHubBridge)(nil)

--- a/acp/source_hub_client.go
+++ b/acp/source_hub_client.go
@@ -1,0 +1,323 @@
+// Copyright 2024 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package acp
+
+import (
+	"context"
+
+	protoTypes "github.com/cosmos/gogoproto/types"
+	"github.com/sourcenetwork/corelog"
+	"github.com/sourcenetwork/sourcehub/x/acp/types"
+	"github.com/valyala/fastjson"
+
+	"github.com/sourcenetwork/defradb/errors"
+)
+
+// sourcehubClient is a private abstraction to allow multiple ACP implementations
+// based off of the SourceHub libraries to share the same Defra-specific logic via the
+// sourceHubBridge.
+type sourcehubClient interface {
+	// Init initializes the acp, with an absolute path. The provided path indicates where the
+	// persistent data will be stored for acp.
+	//
+	// If the path is empty then acp will run in memory.
+	Init(ctx context.Context, path string)
+
+	// Start starts the acp, using the initialized path. Will recover acp state
+	// from a previous run if under the same path.
+	//
+	// If the path is empty then acp will run in memory.
+	Start(ctx context.Context) error
+
+	// AddPolicy attempts to add the given policy. Upon success a policyID is returned,
+	// otherwise returns error.
+	AddPolicy(
+		ctx context.Context,
+		creatorID string,
+		policy string,
+		policyMarshalingType types.PolicyMarshalingType,
+		creationTime *protoTypes.Timestamp,
+	) (string, error)
+
+	// Policy returns a policy of the given policyID if one is found.
+	Policy(
+		ctx context.Context,
+		policyID string,
+	) (*types.Policy, error)
+
+	// RegisterObject registers the object to have access control.
+	// No error is returned upon successful registering of an object.
+	RegisterObject(
+		ctx context.Context,
+		actorID string,
+		policyID string,
+		resourceName string,
+		objectID string,
+		creationTime *protoTypes.Timestamp,
+	) (types.RegistrationResult, error)
+
+	// ObjectOwner returns the owner of the object of the given objectID.
+	ObjectOwner(
+		ctx context.Context,
+		policyID string,
+		resourceName string,
+		objectID string,
+	) (*types.QueryObjectOwnerResponse, error)
+
+	// VerifyAccessRequest returns true if the check was successfull and the request has access to the object. If
+	// the check was successful but the request does not have access to the object, then returns false.
+	// Otherwise if check failed then an error is returned (and the boolean result should not be used).
+	VerifyAccessRequest(
+		ctx context.Context,
+		permission DPIPermission,
+		actorID string,
+		policyID string,
+		resourceName string,
+		docID string,
+	) (bool, error)
+
+	// Close closes any resources in use by acp.
+	Close() error
+}
+
+// sourceHubBridge wraps a sourcehubClient, hosting the Defra-specific logic away from client-specific
+// code.
+type sourceHubBridge struct {
+	client sourcehubClient
+}
+
+var _ ACP = (*sourceHubBridge)(nil)
+
+func NewLocalACP() ACP {
+	return &sourceHubBridge{
+		client: &ACPLocal{},
+	}
+}
+
+func (a *sourceHubBridge) Init(ctx context.Context, path string) {
+	a.client.Init(ctx, path)
+}
+
+func (a *sourceHubBridge) Start(ctx context.Context) error {
+	return a.client.Start(ctx)
+}
+
+func (a *sourceHubBridge) AddPolicy(ctx context.Context, creatorID string, policy string) (string, error) {
+	// Having a creator identity is a MUST requirement for adding a policy.
+	if creatorID == "" {
+		return "", ErrPolicyCreatorMustNotBeEmpty
+	}
+
+	if policy == "" {
+		return "", ErrPolicyDataMustNotBeEmpty
+	}
+
+	// Assume policy is in YAML format by default.
+	policyMarshalType := types.PolicyMarshalingType_SHORT_YAML
+	if isJSON := fastjson.Validate(policy) == nil; isJSON { // Detect JSON format.
+		policyMarshalType = types.PolicyMarshalingType_SHORT_JSON
+	}
+
+	policyID, err := a.client.AddPolicy(
+		ctx,
+		creatorID,
+		policy,
+		policyMarshalType,
+		protoTypes.TimestampNow(),
+	)
+
+	if err != nil {
+		return "", NewErrFailedToAddPolicyWithACP(err, "Local", creatorID)
+	}
+
+	log.InfoContext(ctx, "Created Policy", corelog.Any("PolicyID", policyID))
+
+	return policyID, nil
+}
+
+func (a *sourceHubBridge) ValidateResourceExistsOnValidDPI(
+	ctx context.Context,
+	policyID string,
+	resourceName string,
+) error {
+	if policyID == "" && resourceName == "" {
+		return ErrNoPolicyArgs
+	}
+
+	if policyID == "" {
+		return ErrPolicyIDMustNotBeEmpty
+	}
+
+	if resourceName == "" {
+		return ErrResourceNameMustNotBeEmpty
+	}
+
+	policy, err := a.client.Policy(ctx, policyID)
+
+	if err != nil {
+		if errors.Is(err, types.ErrPolicyNotFound) {
+			return newErrPolicyDoesNotExistWithACP(err, policyID)
+		} else {
+			return newErrPolicyValidationFailedWithACP(err, policyID)
+		}
+	}
+
+	// So far we validated that the policy exists, now lets validate that resource exists.
+	resourceResponse := policy.GetResourceByName(resourceName)
+	if resourceResponse == nil {
+		return newErrResourceDoesNotExistOnTargetPolicy(resourceName, policyID)
+	}
+
+	// Now that we have validated that policyID exists and it contains a corresponding
+	// resource with the matching name, validate that all required permissions
+	// for DPI actually exist on the target resource.
+	for _, requiredPermission := range dpiRequiredPermissions {
+		permissionResponse := resourceResponse.GetPermissionByName(requiredPermission)
+		if permissionResponse == nil {
+			return newErrResourceIsMissingRequiredPermission(
+				resourceName,
+				requiredPermission,
+				policyID,
+			)
+		}
+
+		// Now we need to ensure that the "owner" relation has access to all the required
+		// permissions for DPI. This is important because even if the policy has the required
+		// permissions under the resource, it's possible that those permissions are not granted
+		// to the "owner" relation, this will help users not shoot themseleves in the foot.
+		// TODO-ACP: Better validation, once sourcehub implements meta-policies.
+		// Issue: https://github.com/sourcenetwork/defradb/issues/2359
+		if err := validateDPIExpressionOfRequiredPermission(
+			permissionResponse.Expression,
+			requiredPermission,
+		); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (a *sourceHubBridge) RegisterDocObject(
+	ctx context.Context,
+	actorID string,
+	policyID string,
+	resourceName string,
+	docID string,
+) error {
+	registerDocResult, err := a.client.RegisterObject(
+		ctx,
+		actorID,
+		policyID,
+		resourceName,
+		docID,
+		protoTypes.TimestampNow(),
+	)
+
+	if err != nil {
+		return NewErrFailedToRegisterDocWithACP(err, "Local", policyID, actorID, resourceName, docID)
+	}
+
+	switch registerDocResult {
+	case types.RegistrationResult_NoOp:
+		return ErrObjectDidNotRegister
+
+	case types.RegistrationResult_Registered:
+		log.InfoContext(
+			ctx,
+			"Document registered with local acp",
+			corelog.Any("PolicyID", policyID),
+			corelog.Any("Creator", actorID),
+			corelog.Any("Resource", resourceName),
+			corelog.Any("DocID", docID),
+		)
+		return nil
+
+	case types.RegistrationResult_Unarchived:
+		log.InfoContext(
+			ctx,
+			"Document re-registered (unarchived object) with local acp",
+			corelog.Any("PolicyID", policyID),
+			corelog.Any("Creator", actorID),
+			corelog.Any("Resource", resourceName),
+			corelog.Any("DocID", docID),
+		)
+		return nil
+	}
+
+	return ErrObjectDidNotRegister
+}
+
+func (a *sourceHubBridge) IsDocRegistered(
+	ctx context.Context,
+	policyID string,
+	resourceName string,
+	docID string,
+) (bool, error) {
+	queryObjectOwnerResponse, err := a.client.ObjectOwner(
+		ctx,
+		policyID,
+		resourceName,
+		docID,
+	)
+	if err != nil {
+		return false, NewErrFailedToCheckIfDocIsRegisteredWithACP(err, "Local", policyID, resourceName, docID)
+	}
+
+	return queryObjectOwnerResponse.IsRegistered, nil
+}
+
+func (a *sourceHubBridge) CheckDocAccess(
+	ctx context.Context,
+	permission DPIPermission,
+	actorID string,
+	policyID string,
+	resourceName string,
+	docID string,
+) (bool, error) {
+	isValid, err := a.client.VerifyAccessRequest(
+		ctx,
+		permission,
+		actorID,
+		policyID,
+		resourceName,
+		docID,
+	)
+	if err != nil {
+		return false, NewErrFailedToVerifyDocAccessWithACP(err, "Local", policyID, actorID, resourceName, docID)
+	}
+
+	if isValid {
+		log.InfoContext(
+			ctx,
+			"Document accessible",
+			corelog.Any("PolicyID", policyID),
+			corelog.Any("ActorID", actorID),
+			corelog.Any("Resource", resourceName),
+			corelog.Any("DocID", docID),
+		)
+		return true, nil
+	} else {
+		log.InfoContext(
+			ctx,
+			"Document inaccessible",
+			corelog.Any("PolicyID", policyID),
+			corelog.Any("ActorID", actorID),
+			corelog.Any("Resource", resourceName),
+			corelog.Any("DocID", docID),
+		)
+		return false, nil
+	}
+}
+
+func (a *sourceHubBridge) Close() error {
+	return a.client.Close()
+}

--- a/net/peer_test.go
+++ b/net/peer_test.go
@@ -71,9 +71,9 @@ const randomMultiaddr = "/ip4/127.0.0.1/tcp/0"
 
 func newTestNode(ctx context.Context, t *testing.T) (client.DB, *Node) {
 	store := memory.NewDatastore(ctx)
-	var acpLocal acp.ACPLocal
+	acpLocal := acp.NewLocalACP()
 	acpLocal.Init(context.Background(), "")
-	db, err := db.NewDB(ctx, store, immutable.Some[acp.ACP](&acpLocal), db.WithUpdateEvents())
+	db, err := db.NewDB(ctx, store, immutable.Some[acp.ACP](acpLocal), db.WithUpdateEvents())
 	require.NoError(t, err)
 
 	n, err := NewNode(

--- a/node/acp.go
+++ b/node/acp.go
@@ -71,13 +71,13 @@ func NewACP(ctx context.Context, opts ...ACPOpt) (immutable.Option[acp.ACP], err
 		return acp.NoACP, nil
 
 	case LocalACPType:
-		var acpLocal acp.ACPLocal
+		acpLocal := acp.NewLocalACP()
 		acpLocal.Init(ctx, options.path)
-		return immutable.Some[acp.ACP](&acpLocal), nil
+		return immutable.Some[acp.ACP](acpLocal), nil
 
 	default:
-		var acpLocal acp.ACPLocal
+		acpLocal := acp.NewLocalACP()
 		acpLocal.Init(ctx, options.path)
-		return immutable.Some[acp.ACP](&acpLocal), nil
+		return immutable.Some[acp.ACP](acpLocal), nil
 	}
 }


### PR DESCRIPTION
## Relevant issue(s)

Resolves #2655

## Description

Extracts Defra specific logic from the ACPLocal type so that it may be re-used for SourceHub ACP.

None of the code has changed, it's just moved around.

I'm opening a PR now, as a lot of us (including Bruno) are working in this space, and merging refactors like this asap tends to minimise conflicts.

The (WIP) source hub implementation can be found here: https://github.com/sourcenetwork/defradb/pull/2657