### PR TITLE
feat: Sec. indexes on relations

### DIFF
--- a/client/normal_nil.go
+++ b/client/normal_nil.go
@@ -30,7 +30,7 @@ func NewNormalNil(kind FieldKind) (NormalValue, error) {
 		return NewNormalNillableFloat(immutable.None[float64]()), nil
 	case FieldKind_NILLABLE_DATETIME:
 		return NewNormalNillableTime(immutable.None[time.Time]()), nil
-	case FieldKind_NILLABLE_STRING, FieldKind_NILLABLE_JSON:
+	case FieldKind_NILLABLE_STRING, FieldKind_NILLABLE_JSON, FieldKind_DocID:
 		return NewNormalNillableString(immutable.None[string]()), nil
 	case FieldKind_NILLABLE_BLOB:
 		return NewNormalNillableBytes(immutable.None[[]byte]()), nil

--- a/client/normal_value_test.go
+++ b/client/normal_value_test.go
@@ -1404,7 +1404,7 @@ func TestNormalValue_NewNormalNil(t *testing.T) {
 			assert.True(t, v.IsNil())
 		} else {
 			_, err := NewNormalNil(kind)
-			require.Error(t, err, "field kind: " + kind.String())
+			require.Error(t, err, "field kind: "+kind.String())
 		}
 	}
 }

--- a/client/normal_value_test.go
+++ b/client/normal_value_test.go
@@ -1404,7 +1404,7 @@ func TestNormalValue_NewNormalNil(t *testing.T) {
 			assert.True(t, v.IsNil())
 		} else {
 			_, err := NewNormalNil(kind)
-			require.Error(t, err)
+			require.Error(t, err, "field kind: " + kind.String())
 		}
 	}
 }

--- a/client/schema_field_description.go
+++ b/client/schema_field_description.go
@@ -104,7 +104,7 @@ func (k ScalarKind) Underlying() string {
 }
 
 func (k ScalarKind) IsNillable() bool {
-	return k != FieldKind_DocID
+	return true
 }
 
 func (k ScalarKind) IsObject() bool {

--- a/docs/data_format_changes/i2670-sec-index-on-relations.md
+++ b/docs/data_format_changes/i2670-sec-index-on-relations.md
@@ -1,0 +1,3 @@
+# Enable secondary index on relations
+
+This naturally caused some explain metrics to change and change detector complain about it.

--- a/internal/db/collection_index.go
+++ b/internal/db/collection_index.go
@@ -496,7 +496,7 @@ func (c *collection) GetIndexes(ctx context.Context) ([]client.IndexDescription,
 
 // checkExistingFieldsAndAdjustRelFieldNames checks if the fields in the index description
 // exist in the collection schema.
-// If a field is a relation, it will be adjusted to relation id field name, a.k.a. `field_name + _id`. 
+// If a field is a relation, it will be adjusted to relation id field name, a.k.a. `field_name + _id`.
 func (c *collection) checkExistingFieldsAndAdjustRelFieldNames(
 	fields []client.IndexedFieldDescription,
 ) error {

--- a/internal/db/collection_index.go
+++ b/internal/db/collection_index.go
@@ -21,6 +21,7 @@ import (
 	"github.com/sourcenetwork/immutable"
 
 	"github.com/sourcenetwork/defradb/client"
+	"github.com/sourcenetwork/defradb/client/request"
 	"github.com/sourcenetwork/defradb/datastore"
 	"github.com/sourcenetwork/defradb/internal/core"
 	"github.com/sourcenetwork/defradb/internal/db/base"
@@ -264,7 +265,7 @@ func (c *collection) createIndex(
 		return nil, err
 	}
 
-	err = c.checkExistingFields(desc.Fields)
+	err = c.checkExistingFieldsAndAdjustRelFieldNames(desc.Fields)
 	if err != nil {
 		return nil, err
 	}
@@ -493,20 +494,19 @@ func (c *collection) GetIndexes(ctx context.Context) ([]client.IndexDescription,
 	return c.Description().Indexes, nil
 }
 
-func (c *collection) checkExistingFields(
+// checkExistingFieldsAndAdjustRelFieldNames checks if the fields in the index description
+// exist in the collection schema.
+// If a field is a relation, it will be adjusted to relation id field name, a.k.a. `field_name + _id`. 
+func (c *collection) checkExistingFieldsAndAdjustRelFieldNames(
 	fields []client.IndexedFieldDescription,
 ) error {
-	collectionFields := c.Schema().Fields
-	for _, field := range fields {
-		found := false
-		for _, colField := range collectionFields {
-			if field.Name == colField.Name {
-				found = true
-				break
-			}
-		}
+	for i := range fields {
+		field, found := c.Schema().GetFieldByName(fields[i].Name)
 		if !found {
-			return NewErrNonExistingFieldForIndex(field.Name)
+			return NewErrNonExistingFieldForIndex(fields[i].Name)
+		}
+		if field.Kind.IsObject() {
+			fields[i].Name = fields[i].Name + request.RelatedObjectID
 		}
 	}
 	return nil

--- a/internal/db/index.go
+++ b/internal/db/index.go
@@ -41,7 +41,7 @@ func getValidateIndexFieldFunc(kind client.FieldKind) func(any) bool {
 	}
 
 	switch kind {
-	case client.FieldKind_NILLABLE_STRING:
+	case client.FieldKind_NILLABLE_STRING, client.FieldKind_DocID:
 		return canConvertIndexFieldValue[string]
 	case client.FieldKind_NILLABLE_INT:
 		return canConvertIndexFieldValue[int64]

--- a/internal/planner/explain.go
+++ b/internal/planner/explain.go
@@ -92,8 +92,8 @@ func buildDebugExplainGraph(source planNode) (map[string]any, error) {
 		var explainGraphBuilder = map[string]any{}
 
 		// If root is not the last child then keep walking and explaining the root graph.
-		if node.root != nil {
-			indexJoinRootExplainGraph, err := buildDebugExplainGraph(node.root)
+		if node.parentPlan != nil {
+			indexJoinRootExplainGraph, err := buildDebugExplainGraph(node.parentPlan)
 			if err != nil {
 				return nil, err
 			}
@@ -101,8 +101,8 @@ func buildDebugExplainGraph(source planNode) (map[string]any, error) {
 			explainGraphBuilder[joinRootLabel] = indexJoinRootExplainGraph
 		}
 
-		if node.subType != nil {
-			indexJoinSubTypeExplainGraph, err := buildDebugExplainGraph(node.subType)
+		if node.childPlan != nil {
+			indexJoinSubTypeExplainGraph, err := buildDebugExplainGraph(node.childPlan)
 			if err != nil {
 				return nil, err
 			}
@@ -117,8 +117,8 @@ func buildDebugExplainGraph(source planNode) (map[string]any, error) {
 		var explainGraphBuilder = map[string]any{}
 
 		// If root is not the last child then keep walking and explaining the root graph.
-		if node.root != nil {
-			indexJoinRootExplainGraph, err := buildDebugExplainGraph(node.root)
+		if node.parentPlan != nil {
+			indexJoinRootExplainGraph, err := buildDebugExplainGraph(node.parentPlan)
 			if err != nil {
 				return nil, err
 			}
@@ -128,8 +128,8 @@ func buildDebugExplainGraph(source planNode) (map[string]any, error) {
 			explainGraphBuilder[joinRootLabel] = nil
 		}
 
-		if node.subType != nil {
-			indexJoinSubTypeExplainGraph, err := buildDebugExplainGraph(node.subType)
+		if node.childPlan != nil {
+			indexJoinSubTypeExplainGraph, err := buildDebugExplainGraph(node.childPlan)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/planner/explain.go
+++ b/internal/planner/explain.go
@@ -92,8 +92,8 @@ func buildDebugExplainGraph(source planNode) (map[string]any, error) {
 		var explainGraphBuilder = map[string]any{}
 
 		// If root is not the last child then keep walking and explaining the root graph.
-		if node.parentPlan != nil {
-			indexJoinRootExplainGraph, err := buildDebugExplainGraph(node.parentPlan)
+		if node.parentSide.plan != nil {
+			indexJoinRootExplainGraph, err := buildDebugExplainGraph(node.parentSide.plan)
 			if err != nil {
 				return nil, err
 			}
@@ -101,8 +101,8 @@ func buildDebugExplainGraph(source planNode) (map[string]any, error) {
 			explainGraphBuilder[joinRootLabel] = indexJoinRootExplainGraph
 		}
 
-		if node.childPlan != nil {
-			indexJoinSubTypeExplainGraph, err := buildDebugExplainGraph(node.childPlan)
+		if node.childSide.plan != nil {
+			indexJoinSubTypeExplainGraph, err := buildDebugExplainGraph(node.childSide.plan)
 			if err != nil {
 				return nil, err
 			}
@@ -117,8 +117,8 @@ func buildDebugExplainGraph(source planNode) (map[string]any, error) {
 		var explainGraphBuilder = map[string]any{}
 
 		// If root is not the last child then keep walking and explaining the root graph.
-		if node.parentPlan != nil {
-			indexJoinRootExplainGraph, err := buildDebugExplainGraph(node.parentPlan)
+		if node.parentSide.plan != nil {
+			indexJoinRootExplainGraph, err := buildDebugExplainGraph(node.parentSide.plan)
 			if err != nil {
 				return nil, err
 			}
@@ -128,8 +128,8 @@ func buildDebugExplainGraph(source planNode) (map[string]any, error) {
 			explainGraphBuilder[joinRootLabel] = nil
 		}
 
-		if node.childPlan != nil {
-			indexJoinSubTypeExplainGraph, err := buildDebugExplainGraph(node.childPlan)
+		if node.childSide.plan != nil {
+			indexJoinSubTypeExplainGraph, err := buildDebugExplainGraph(node.childSide.plan)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/planner/mapper/mapper.go
+++ b/internal/planner/mapper/mapper.go
@@ -987,6 +987,7 @@ func resolveInnerFilterDependencies(
 				return nil, err
 			}
 
+			childSelect.SkipResolve = true
 			newFields = append(newFields, childSelect)
 		}
 

--- a/internal/planner/mapper/mapper.go
+++ b/internal/planner/mapper/mapper.go
@@ -413,25 +413,23 @@ func resolveAggregates(
 				childMapping = childMapping.CloneWithoutRender()
 				mapping.SetChildAt(index, childMapping)
 
-				if !childIsMapped {
-					filterDependencies, err := resolveFilterDependencies(
-						ctx,
-						store,
-						rootSelectType,
-						childCollectionName,
-						target.filter,
-						mapping.ChildMappings[index],
-						childFields,
-					)
-					if err != nil {
-						return nil, err
-					}
-					childFields = append(childFields, filterDependencies...)
-
-					// If the child was not mapped, the filter will not have been converted yet
-					// so we must do that now.
-					convertedFilter = ToFilter(target.filter.Value(), mapping.ChildMappings[index])
+				filterDependencies, err := resolveFilterDependencies(
+					ctx,
+					store,
+					rootSelectType,
+					childCollectionName,
+					target.filter,
+					mapping.ChildMappings[index],
+					childFields,
+				)
+				if err != nil {
+					return nil, err
 				}
+				childFields = append(childFields, filterDependencies...)
+
+				// If the child was not mapped, the filter will not have been converted yet
+				// so we must do that now.
+				convertedFilter = ToFilter(target.filter.Value(), mapping.ChildMappings[index])
 
 				dummyJoin := &Select{
 					Targetable: Targetable{

--- a/internal/planner/mapper/select.go
+++ b/internal/planner/mapper/select.go
@@ -38,6 +38,10 @@ type Select struct {
 	// These can include stuff such as version information, aggregates, and other
 	// Selects.
 	Fields []Requestable
+
+	// SkipResolve is a flag that indicates that the fields in this select should not be resolved.
+	// It is used avoid resolving related objects if they are used in a filter and not requested in a response.
+	SkipResolve bool
 }
 
 func (s *Select) AsTargetable() (*Targetable, bool) {

--- a/internal/planner/mapper/select.go
+++ b/internal/planner/mapper/select.go
@@ -39,7 +39,8 @@ type Select struct {
 	// Selects.
 	Fields []Requestable
 
-	// SkipResolve is a flag that indicates that the fields in this Select don't need to be resolved.
+	// SkipResolve is a flag that indicates that the fields in this Select don't need to be resolved, 
+	// i.e. it's value doesn't need to be fetched and provided to the user.
 	// It is used to avoid resolving related objects if they are used only in a filter and not requested in a response.
 	SkipResolve bool
 }

--- a/internal/planner/mapper/select.go
+++ b/internal/planner/mapper/select.go
@@ -39,7 +39,7 @@ type Select struct {
 	// Selects.
 	Fields []Requestable
 
-	// SkipResolve is a flag that indicates that the fields in this Select don't need to be resolved, 
+	// SkipResolve is a flag that indicates that the fields in this Select don't need to be resolved,
 	// i.e. it's value doesn't need to be fetched and provided to the user.
 	// It is used to avoid resolving related objects if they are used only in a filter and not requested in a response.
 	SkipResolve bool

--- a/internal/planner/mapper/select.go
+++ b/internal/planner/mapper/select.go
@@ -39,8 +39,8 @@ type Select struct {
 	// Selects.
 	Fields []Requestable
 
-	// SkipResolve is a flag that indicates that the fields in this select should not be resolved.
-	// It is used avoid resolving related objects if they are used in a filter and not requested in a response.
+	// SkipResolve is a flag that indicates that the fields in this Select don't need to be resolved.
+	// It is used to avoid resolving related objects if they are used only in a filter and not requested in a response.
 	SkipResolve bool
 }
 

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -362,8 +362,8 @@ func (p *Planner) tryOptimizeJoinDirection(node *invertibleTypeJoin, parentPlan 
 	for subFieldName, subFieldInd := range filteredSubFields {
 		indexes := desc.GetIndexesOnField(subFieldName)
 		if len(indexes) > 0 && !filter.IsComplex(parentPlan.selectNode.filter) {
-			subInd := node.documentMapping.FirstIndexOfName(node.subTypeName)
-			relatedField := mapper.Field{Name: node.subTypeName, Index: subInd}
+			subInd := node.documentMapping.FirstIndexOfName(node.getSubTypeName())
+			relatedField := mapper.Field{Name: node.getSubTypeName(), Index: subInd}
 			fieldFilter := filter.UnwrapRelation(filter.CopyField(
 				parentPlan.selectNode.filter,
 				relatedField,

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -357,7 +357,7 @@ func (p *Planner) tryOptimizeJoinDirection(node *invertibleTypeJoin, parentPlan 
 		parentPlan.selectNode.filter.Conditions,
 		node.documentMapping,
 	)
-	slct := node.childPlan.(*selectTopNode).selectNode
+	slct := node.childSide.plan.(*selectTopNode).selectNode
 	desc := slct.collection.Description()
 	for subFieldName, subFieldInd := range filteredSubFields {
 		indexes := desc.GetIndexesOnField(subFieldName)
@@ -383,7 +383,7 @@ func (p *Planner) tryOptimizeJoinDirection(node *invertibleTypeJoin, parentPlan 
 // expandTypeJoin does a plan graph expansion and other optimizations on invertibleTypeJoin.
 func (p *Planner) expandTypeJoin(node *invertibleTypeJoin, parentPlan *selectTopNode) error {
 	if parentPlan.selectNode.filter == nil {
-		return p.expandPlan(node.childPlan, parentPlan)
+		return p.expandPlan(node.childSide.plan, parentPlan)
 	}
 
 	err := p.tryOptimizeJoinDirection(node, parentPlan)
@@ -391,7 +391,7 @@ func (p *Planner) expandTypeJoin(node *invertibleTypeJoin, parentPlan *selectTop
 		return err
 	}
 
-	return p.expandPlan(node.childPlan, parentPlan)
+	return p.expandPlan(node.childSide.plan, parentPlan)
 }
 
 func (p *Planner) expandGroupNodePlan(topNodeSelect *selectTopNode) error {

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -369,6 +369,8 @@ func (p *Planner) tryOptimizeJoinDirection(node *invertibleTypeJoin, parentPlan 
 				relatedField,
 				mapper.Field{Name: subFieldName, Index: subFieldInd},
 			), relatedField)
+			// At the moment we just take the first index, but later we want to run some kind of analysis to
+			// determine which index is best to use. https://github.com/sourcenetwork/defradb/issues/2680
 			err := node.invertJoinDirectionWithIndex(fieldFilter, indexes[0])
 			if err != nil {
 				return err

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -357,7 +357,7 @@ func (p *Planner) tryOptimizeJoinDirection(node *invertibleTypeJoin, parentPlan 
 		parentPlan.selectNode.filter.Conditions,
 		node.documentMapping,
 	)
-	slct := node.subType.(*selectTopNode).selectNode
+	slct := node.childPlan.(*selectTopNode).selectNode
 	desc := slct.collection.Description()
 	for subFieldName, subFieldInd := range filteredSubFields {
 		indexes := desc.GetIndexesOnField(subFieldName)
@@ -383,7 +383,7 @@ func (p *Planner) tryOptimizeJoinDirection(node *invertibleTypeJoin, parentPlan 
 // expandTypeJoin does a plan graph expansion and other optimizations on invertibleTypeJoin.
 func (p *Planner) expandTypeJoin(node *invertibleTypeJoin, parentPlan *selectTopNode) error {
 	if parentPlan.selectNode.filter == nil {
-		return p.expandPlan(node.subType, parentPlan)
+		return p.expandPlan(node.childPlan, parentPlan)
 	}
 
 	err := p.tryOptimizeJoinDirection(node, parentPlan)
@@ -391,7 +391,7 @@ func (p *Planner) expandTypeJoin(node *invertibleTypeJoin, parentPlan *selectTop
 		return err
 	}
 
-	return p.expandPlan(node.subType, parentPlan)
+	return p.expandPlan(node.childPlan, parentPlan)
 }
 
 func (p *Planner) expandGroupNodePlan(topNodeSelect *selectTopNode) error {

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -362,8 +362,8 @@ func (p *Planner) tryOptimizeJoinDirection(node *invertibleTypeJoin, parentPlan 
 	for subFieldName, subFieldInd := range filteredSubFields {
 		indexes := desc.GetIndexesOnField(subFieldName)
 		if len(indexes) > 0 && !filter.IsComplex(parentPlan.selectNode.filter) {
-			subInd := node.documentMapping.FirstIndexOfName(node.getSubTypeName())
-			relatedField := mapper.Field{Name: node.getSubTypeName(), Index: subInd}
+			subInd := node.documentMapping.FirstIndexOfName(node.parentSide.relFieldDef.Name)
+			relatedField := mapper.Field{Name: node.parentSide.relFieldDef.Name, Index: subInd}
 			fieldFilter := filter.UnwrapRelation(filter.CopyField(
 				parentPlan.selectNode.filter,
 				relatedField,

--- a/internal/planner/select.go
+++ b/internal/planner/select.go
@@ -315,6 +315,19 @@ func findIndexByFilteringField(scanNode *scanNode) immutable.Option[client.Index
 	return immutable.None[client.IndexDescription]()
 }
 
+func findIndexByFieldName(col client.Collection, fieldName string) immutable.Option[client.IndexDescription] {
+	for _, field := range col.Schema().Fields {
+		if field.Name != fieldName {
+			continue
+		}
+		indexes := col.Description().GetIndexesOnField(field.Name)
+		if len(indexes) > 0 {
+			return immutable.Some(indexes[0])
+		}
+	}
+	return immutable.None[client.IndexDescription]()
+}
+
 func (n *selectNode) initFields(selectReq *mapper.Select) ([]aggregateNode, error) {
 	aggregates := []aggregateNode{}
 	// loop over the sub type

--- a/internal/planner/select.go
+++ b/internal/planner/select.go
@@ -322,6 +322,8 @@ func findIndexByFieldName(col client.Collection, fieldName string) immutable.Opt
 		}
 		indexes := col.Description().GetIndexesOnField(field.Name)
 		if len(indexes) > 0 {
+			// At the moment we just take the first index, but later we want to run some kind of analysis to
+			// determine which index is best to use. https://github.com/sourcenetwork/defradb/issues/2680
 			return immutable.Some(indexes[0])
 		}
 	}

--- a/internal/planner/type_join.go
+++ b/internal/planner/type_join.go
@@ -695,7 +695,6 @@ func (join *invertibleTypeJoin) nextJoinedSecondaryDoc() (bool, error) {
 	secondSide := join.getSecondSide()
 
 	secondaryDocID := getForeignKey(firstSide.plan, firstSide.relFieldDef.Name)
-	// TODO: add some tests with filter on nil relation
 	if secondaryDocID == "" {
 		if firstSide.isParent {
 			join.docsToYield = append(join.docsToYield, firstSide.plan.Value())
@@ -718,8 +717,6 @@ func (join *invertibleTypeJoin) nextJoinedSecondaryDoc() (bool, error) {
 		return false, err
 	}
 
-	// TODO: add some tests that either return error if the doc is not found or return
-	// the related doc (without this one) and let it be filtered.
 	if !hasDoc {
 		if firstSide.isParent {
 			join.docsToYield = append(join.docsToYield, firstSide.plan.Value())

--- a/internal/planner/type_join.go
+++ b/internal/planner/type_join.go
@@ -167,9 +167,9 @@ func (n *typeIndexJoin) simpleExplain() (map[string]any, error) {
 	case *typeJoinOne:
 		// Add the direction attribute.
 		if joinType.parentSide.isPrimary() {
-			simpleExplainMap[joinDirectionLabel] = joinDirectionSecondaryLabel
-		} else {
 			simpleExplainMap[joinDirectionLabel] = joinDirectionPrimaryLabel
+		} else {
+			simpleExplainMap[joinDirectionLabel] = joinDirectionSecondaryLabel
 		}
 
 		err = addExplainData(&joinType.invertibleTypeJoin)

--- a/internal/planner/type_join.go
+++ b/internal/planner/type_join.go
@@ -592,14 +592,16 @@ func (j *primaryObjectsFetcher) fetchPrimaryDocs() ([]core.Doc, error) {
 	j.primaryScan.initFetcher(immutable.None[string](), indexOnRelation)
 
 	docs, err := j.collectDocs(0)
-
-	j.primaryScan.fetcher.Close()
-
-	j.primaryScan.fetcher = oldFetcher
-
 	if err != nil {
 		return nil, err
 	}
+
+	err = j.primaryScan.fetcher.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	j.primaryScan.fetcher = oldFetcher
 
 	return docs, nil
 }

--- a/internal/planner/type_join.go
+++ b/internal/planner/type_join.go
@@ -259,15 +259,6 @@ func (p *Planner) makeTypeJoinOne(
 		return nil, client.NewErrFieldNotExist(subSelect.Name)
 	}
 
-	// TODO: remove this block?
-	var secondaryFieldIndex immutable.Option[int]
-	if !parentsRelFieldDef.IsPrimaryRelation {
-		idFieldName := parentsRelFieldDef.Name
-		secondaryFieldIndex = immutable.Some(
-			parent.documentMapping.FirstIndexOfName(idFieldName + request.RelatedObjectID),
-		)
-	}
-
 	parentSide := joinSide{
 		plan:             sourcePlan,
 		relFieldDef:      parentsRelFieldDef,
@@ -303,7 +294,6 @@ func (p *Planner) makeTypeJoinOne(
 			parentSide:          parentSide,
 			childSide:           childSide,
 			childSelect:         subSelect,
-			secondaryFieldIndex: secondaryFieldIndex,
 			secondaryFetchLimit: 1,
 		},
 	}, nil
@@ -535,7 +525,6 @@ type invertibleTypeJoin struct {
 	parentSide joinSide
 	childSide  joinSide
 
-	secondaryFieldIndex immutable.Option[int]
 	secondaryFetchLimit uint
 
 	// docsToYield contains documents read and ready to be yielded by this node.

--- a/tests/integration/explain/execute/with_count_test.go
+++ b/tests/integration/explain/execute/with_count_test.go
@@ -62,7 +62,7 @@ func TestExecuteExplainRequestWithCountOnOneToManyRelation(t *testing.T) {
 											"subTypeScanNode": dataMap{
 												"iterations":   uint64(5),
 												"docFetches":   uint64(6),
-												"fieldFetches": uint64(14),
+												"fieldFetches": uint64(6),
 												"indexFetches": uint64(0),
 											},
 										},

--- a/tests/integration/index/query_with_relation_filter_test.go
+++ b/tests/integration/index/query_with_relation_filter_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 func TestQueryWithIndexOnOneToManyRelation_IfFilterOnIndexedRelation_ShouldFilter2(t *testing.T) {
+	// 3 users have a MacBook Pro: Islam, Shahzad, Keenan
 	req1 := `query {
 		User(filter: {
 			devices: {model: {_eq: "MacBook Pro"}}
@@ -24,6 +25,7 @@ func TestQueryWithIndexOnOneToManyRelation_IfFilterOnIndexedRelation_ShouldFilte
 			name
 		}
 	}`
+	// 1 user has an iPhone 10: Addo
 	req2 := `query {
 		User(filter: {
 			devices: {model: {_eq: "iPhone 10"}}
@@ -53,16 +55,14 @@ func TestQueryWithIndexOnOneToManyRelation_IfFilterOnIndexedRelation_ShouldFilte
 			testUtils.Request{
 				Request: req1,
 				Results: []map[string]any{
-					{"name": "Keenan"},
 					{"name": "Islam"},
 					{"name": "Shahzad"},
+					{"name": "Keenan"},
 				},
 			},
 			testUtils.Request{
-				Request: makeExplainQuery(req1),
-				// The invertable join does not support inverting one-many relations, so the index is
-				// not used.
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(450).WithIndexFetches(0),
+				Request:  makeExplainQuery(req1),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(6).WithIndexFetches(3),
 			},
 			testUtils.Request{
 				Request: req2,
@@ -71,10 +71,8 @@ func TestQueryWithIndexOnOneToManyRelation_IfFilterOnIndexedRelation_ShouldFilte
 				},
 			},
 			testUtils.Request{
-				Request: makeExplainQuery(req2),
-				// The invertable join does not support inverting one-many relations, so the index is
-				// not used.
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(450).WithIndexFetches(0),
+				Request:  makeExplainQuery(req2),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(2).WithIndexFetches(1),
 			},
 		},
 	}
@@ -83,6 +81,7 @@ func TestQueryWithIndexOnOneToManyRelation_IfFilterOnIndexedRelation_ShouldFilte
 }
 
 func TestQueryWithIndexOnOneToManyRelation_IfFilterOnIndexedRelation_ShouldFilter(t *testing.T) {
+	// 3 users have a MacBook Pro: Islam, Shahzad, Keenan
 	req1 := `query {
 		User(filter: {
 			devices: {model: {_eq: "MacBook Pro"}}
@@ -90,6 +89,7 @@ func TestQueryWithIndexOnOneToManyRelation_IfFilterOnIndexedRelation_ShouldFilte
 			name
 		}
 	}`
+	// 1 user has an iPhone 10: Addo
 	req2 := `query {
 		User(filter: {
 			devices: {model: {_eq: "iPhone 10"}}
@@ -119,16 +119,14 @@ func TestQueryWithIndexOnOneToManyRelation_IfFilterOnIndexedRelation_ShouldFilte
 			testUtils.Request{
 				Request: req1,
 				Results: []map[string]any{
-					{"name": "Keenan"},
 					{"name": "Islam"},
 					{"name": "Shahzad"},
+					{"name": "Keenan"},
 				},
 			},
 			testUtils.Request{
-				Request: makeExplainQuery(req1),
-				// The invertable join does not support inverting one-many relations, so the index is
-				// not used.
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(450).WithIndexFetches(0),
+				Request:  makeExplainQuery(req1),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(6).WithIndexFetches(3),
 			},
 			testUtils.Request{
 				Request: req2,
@@ -137,10 +135,8 @@ func TestQueryWithIndexOnOneToManyRelation_IfFilterOnIndexedRelation_ShouldFilte
 				},
 			},
 			testUtils.Request{
-				Request: makeExplainQuery(req2),
-				// The invertable join does not support inverting one-many relations, so the index is
-				// not used.
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(450).WithIndexFetches(0),
+				Request:  makeExplainQuery(req2),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(2).WithIndexFetches(1),
 			},
 		},
 	}
@@ -149,6 +145,7 @@ func TestQueryWithIndexOnOneToManyRelation_IfFilterOnIndexedRelation_ShouldFilte
 }
 
 func TestQueryWithIndexOnOneToOnesSecondaryRelation_IfFilterOnIndexedRelation_ShouldFilter(t *testing.T) {
+	// 1 user lives in Munich: Islam
 	req1 := `query {
 		User(filter: {
 			address: {city: {_eq: "Munich"}}
@@ -156,6 +153,7 @@ func TestQueryWithIndexOnOneToOnesSecondaryRelation_IfFilterOnIndexedRelation_Sh
 			name
 		}
 	}`
+	// 3 users live in Montreal: Shahzad, Fred, John
 	req2 := `query {
 		User(filter: {
 			address: {city: {_eq: "Montreal"}}
@@ -176,7 +174,7 @@ func TestQueryWithIndexOnOneToOnesSecondaryRelation_IfFilterOnIndexedRelation_Sh
 
 					type Address {
 						user: User @primary
-						city: String @index
+						city: String @index 
 					}`,
 			},
 			testUtils.CreatePredefinedDocs{
@@ -210,7 +208,8 @@ func TestQueryWithIndexOnOneToOnesSecondaryRelation_IfFilterOnIndexedRelation_Sh
 	testUtils.ExecuteTestCase(t, test)
 }
 
-func TestQueryWithIndexOnOneToOnePrimaryRelation_IfFilterOnIndexedFieldOfRelation_ShouldFilter(t *testing.T) {
+func TestQueryWithIndexOnOneToOnePrimaryRelation_IfFilterOnIndexedFieldOfRelationAndRelation_ShouldFilter(t *testing.T) {
+	// 1 user lives in London: Andy
 	req1 := `query {
 		User(filter: {
 			address: {city: {_eq: "London"}}
@@ -218,6 +217,78 @@ func TestQueryWithIndexOnOneToOnePrimaryRelation_IfFilterOnIndexedFieldOfRelatio
 			name
 		}
 	}`
+	// 3 users live in Montreal: Shahzad, Fred, John
+	req2 := `query {
+		User(filter: {
+			address: {city: {_eq: "Montreal"}}
+		}) {
+			name
+		}
+	}`
+	test := testUtils.TestCase{
+		Description: "Filter on indexed field of primary relation in 1-1 relation",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type User {
+						name: String 
+						age: Int
+						address: Address @primary @index
+					} 
+
+					type Address {
+						user: User
+						city: String @index
+						street: String 
+					}`,
+			},
+			testUtils.CreatePredefinedDocs{
+				Docs: getUserDocs(),
+			},
+			testUtils.Request{
+				Request: req1,
+				Results: []map[string]any{
+					{"name": "Andy"},
+				},
+			},
+			testUtils.Request{
+				Request: makeExplainQuery(req1),
+				// we make 2 index fetches: 1. to get the only address with city == "London"
+				// and 2. to get the corresponding user
+				// then 1 field fetch to get the name of the user
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(1).WithIndexFetches(2),
+			},
+			testUtils.Request{
+				Request: req2,
+				Results: []map[string]any{
+					{"name": "John"},
+					{"name": "Fred"},
+					{"name": "Shahzad"},
+				},
+			},
+			testUtils.Request{
+				Request: makeExplainQuery(req2),
+				// we make 3 index fetches to get the 3 address with city == "Montreal"
+				// and 3 more index fetches to get the corresponding users
+				// then 3 field fetches to get the name of each user
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(3).WithIndexFetches(6),
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestQueryWithIndexOnOneToOnePrimaryRelation_IfFilterOnIndexedFieldOfRelation_ShouldFilter(t *testing.T) {
+	// 1 user lives in London: Andy
+	req1 := `query {
+		User(filter: {
+			address: {city: {_eq: "London"}}
+		}) {
+			name
+		}
+	}`
+	// 3 users live in Montreal: Shahzad, Fred, John
 	req2 := `query {
 		User(filter: {
 			address: {city: {_eq: "Montreal"}}
@@ -256,7 +327,6 @@ func TestQueryWithIndexOnOneToOnePrimaryRelation_IfFilterOnIndexedFieldOfRelatio
 				// we make 1 index fetch to get the only address with city == "London"
 				// then we scan all 10 users to find one with matching "address_id"
 				// after this we fetch the name of the user
-				// it should be optimized after this is done https://github.com/sourcenetwork/defradb/issues/2601
 				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(11).WithIndexFetches(1),
 			},
 			testUtils.Request{
@@ -272,7 +342,6 @@ func TestQueryWithIndexOnOneToOnePrimaryRelation_IfFilterOnIndexedFieldOfRelatio
 				// we make 3 index fetch to get the 3 address with city == "Montreal"
 				// then we scan all 10 users to find one with matching "address_id" for each address
 				// after this we fetch the name of each user
-				// it should be optimized after this is done https://github.com/sourcenetwork/defradb/issues/2601
 				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(33).WithIndexFetches(3),
 			},
 		},
@@ -282,6 +351,7 @@ func TestQueryWithIndexOnOneToOnePrimaryRelation_IfFilterOnIndexedFieldOfRelatio
 }
 
 func TestQueryWithIndexOnOneToOnePrimaryRelation_IfFilterOnIndexedRelationWhileIndexedForeignField_ShouldFilter(t *testing.T) {
+	// 1 user lives in London: Andy
 	req := `query {
 		User(filter: {
 			address: {city: {_eq: "London"}}
@@ -317,7 +387,7 @@ func TestQueryWithIndexOnOneToOnePrimaryRelation_IfFilterOnIndexedRelationWhileI
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(11).WithIndexFetches(1),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(1).WithIndexFetches(2),
 			},
 		},
 	}
@@ -500,10 +570,8 @@ func TestQueryWithIndexOnOneToMany_IfFilterOnIndexedRelation_ShouldFilterWithExp
 				},
 			},
 			testUtils.Request{
-				Request: makeExplainQuery(req),
-				// The invertable join does not support inverting one-many relations, so the index is
-				// not used.
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(10).WithIndexFetches(0),
+				Request:  makeExplainQuery(req),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(14).WithIndexFetches(2),
 			},
 		},
 	}
@@ -512,6 +580,7 @@ func TestQueryWithIndexOnOneToMany_IfFilterOnIndexedRelation_ShouldFilterWithExp
 }
 
 func TestQueryWithIndexOnOneToOne_IfFilterOnIndexedRelation_ShouldFilter(t *testing.T) {
+	// 1 user lives in Munich: Islam
 	req := `query {
 		User(filter: {
 			address: {city: {_eq: "Munich"}}
@@ -563,8 +632,8 @@ func TestQueryWithIndexOnOneToOne_IfFilterOnIndexedRelation_ShouldFilter(t *test
 }
 
 func TestQueryWithIndexOnManyToOne_IfFilterOnIndexedField_ShouldFilterWithExplain(t *testing.T) {
-	// This query will fetch first a matching device which is secondary doc and therefore
-	// has a reference to the primary User doc.
+	// This query will fetch first a matching device which is primary doc and therefore
+	// has a reference to the secondary User doc.
 	req := `query {
 		Device(filter: {
 			year: {_eq: 2021}
@@ -633,7 +702,6 @@ func TestQueryWithIndexOnManyToOne_IfFilterOnIndexedField_ShouldFilterWithExplai
 func TestQueryWithIndexOnManyToOne_IfFilterOnIndexedRelation_ShouldFilterWithExplain(t *testing.T) {
 	// This query will fetch first a matching user (owner) which is primary doc and therefore
 	// has no direct reference to secondary Device docs.
-	// At the moment the db has to make a full scan of the Device docs to find the matching ones.
 	// Keenan has 3 devices.
 	req := `query {
 		Device(filter: {
@@ -650,11 +718,11 @@ func TestQueryWithIndexOnManyToOne_IfFilterOnIndexedRelation_ShouldFilterWithExp
 					type User {
 						name: String @index
 						devices: [Device]
-					} 
+					}
 
 					type Device {
-						model: String 
-						owner: User
+						model: String
+						owner: User @index
 					}
 				`,
 			},
@@ -671,10 +739,10 @@ func TestQueryWithIndexOnManyToOne_IfFilterOnIndexedRelation_ShouldFilterWithExp
 			},
 			testUtils.Request{
 				Request: makeExplainQuery(req),
-				// we make only 1 index fetch to get the owner by it's name
-				// and 44 field fetches to get 2 fields for all 22 devices in the db.
-				// it should be optimized after this is done https://github.com/sourcenetwork/defradb/issues/2601
-				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(44).WithIndexFetches(1),
+				// we make 1 index fetch to get the owner by it's name
+				// and 3 index fetches to get all 3 devices of the owner
+				// and 3 field fetches to get 1 'model' field for every fetched device.
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(3).WithIndexFetches(4),
 			},
 		},
 	}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #2601 #2578 #2577

## Description

Enables fetching related objects via secondary indexes.

It also fixes a bug with queries that contain multiple aggregates on the same collection.

Note: I will add some more tests