### PR TITLE
feat: Allow lens runtime selection via config

### DIFF
--- a/.github/workflows/test-and-upload-coverage.yml
+++ b/.github/workflows/test-and-upload-coverage.yml
@@ -34,6 +34,7 @@ jobs:
         client-type: [go, http, cli]
         database-type: [badger-file, badger-memory]
         mutation-type: [gql, collection-named, collection-save]
+        lens-type: [wasm-time]
         detect-changes: [false]
         database-encryption: [false]
         include:
@@ -63,6 +64,20 @@ jobs:
 ##          mutation-type: collection-save
 ##          detect-changes: false
 ##          database-encryption: false
+          - os: ubuntu-latest
+            client-type: go
+            database-type: badger-memory
+            mutation-type: collection-save
+            lens-type: wazero
+            detect-changes: false
+            database-encryption: false
+          - os: ubuntu-latest
+            client-type: go
+            database-type: badger-memory
+            mutation-type: collection-save
+            lens-type: wasmer
+            detect-changes: false
+            database-encryption: false
 
     runs-on: ${{ matrix.os }}
 
@@ -80,6 +95,7 @@ jobs:
       DEFRA_BADGER_FILE: ${{ matrix.database-type == 'badger-file' }}
       DEFRA_BADGER_ENCRYPTION: ${{ matrix.database-encryption }}
       DEFRA_MUTATION_TYPE: ${{ matrix.mutation-type }}
+      DEFRA_LENS_TYPE: ${{ matrix.lens-type }}
 
     steps:
       - name: Checkout code into the directory

--- a/.github/workflows/test-and-upload-coverage.yml
+++ b/.github/workflows/test-and-upload-coverage.yml
@@ -42,18 +42,21 @@ jobs:
             client-type: go
             database-type: badger-memory
             mutation-type: collection-save
+            lens-type: wasm-time
             detect-changes: true
             database-encryption: false
           - os: ubuntu-latest
             client-type: go
             database-type: badger-memory
             mutation-type: collection-save
+            lens-type: wasm-time
             detect-changes: false
             database-encryption: true
           - os: macos-latest
             client-type: go
             database-type: badger-memory
             mutation-type: collection-save
+            lens-type: wasm-time
             detect-changes: false
             database-encryption: false
 ## TODO: https://github.com/sourcenetwork/defradb/issues/2080

--- a/cli/server_dump.go
+++ b/cli/server_dump.go
@@ -37,7 +37,7 @@ func MakeServerDumpCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			db, err := db.NewDB(cmd.Context(), rootstore, acp.NoACP)
+			db, err := db.NewDB(cmd.Context(), rootstore, acp.NoACP, nil)
 			if err != nil {
 				return errors.Wrap("failed to initialize database", err)
 			}

--- a/cli/start.go
+++ b/cli/start.go
@@ -126,6 +126,7 @@ func MakeStartCommand() *cobra.Command {
 				http.WithAllowedOrigins(cfg.GetStringSlice("api.allowed-origins")...),
 				http.WithTLSCertPath(cfg.GetString("api.pubKeyPath")),
 				http.WithTLSKeyPath(cfg.GetString("api.privKeyPath")),
+				node.WithLensRuntime(node.LensRuntimeType(cfg.GetString("lens.runtime"))),
 			}
 
 			if cfg.GetString("datastore.store") != configStoreMemory {

--- a/client/lens.go
+++ b/client/lens.go
@@ -15,6 +15,8 @@ import (
 
 	"github.com/lens-vm/lens/host-go/config/model"
 	"github.com/sourcenetwork/immutable/enumerable"
+
+	"github.com/sourcenetwork/defradb/datastore"
 )
 
 // LensConfig represents the configuration of a Lens migration in Defra.
@@ -38,9 +40,18 @@ type LensConfig struct {
 	model.Lens
 }
 
+// TxnSource represents an object capable of constructing the transactions that
+// implicit-transaction registries need internally.
+type TxnSource interface {
+	NewTxn(context.Context, bool) (datastore.Txn, error)
+}
+
 // LensRegistry exposes several useful thread-safe migration related functions which may
 // be used to manage migrations.
 type LensRegistry interface {
+	// Init initializes the registry with the provided transaction source.
+	Init(TxnSource)
+
 	// SetMigration caches the migration for the given collection ID. It does not persist the migration in long
 	// term storage, for that one should call [Store.SetMigration(ctx, cfg)].
 	//

--- a/docs/config.md
+++ b/docs/config.md
@@ -111,3 +111,12 @@ Keyring backend to use. Defaults to `file`.
 
 - `file` Stores keys in encrypted files
 - `system` Stores keys in the OS managed keyring
+
+## `lens.runtime`
+
+The LensVM wasm runtime to run lens modules in.
+
+Possible values:
+- `wasm-time` (default): https://github.com/bytecodealliance/wasmtime-go
+- `wasmer` (windows not supported): https://github.com/wasmerio/wasmer-go
+- `wazero`: https://github.com/tetratelabs/wazero

--- a/go.mod
+++ b/go.mod
@@ -282,8 +282,10 @@ require (
 	github.com/tendermint/go-amino v0.16.0 // indirect
 	github.com/tendermint/tm-db v0.6.7 // indirect
 	github.com/teserakt-io/golang-ed25519 v0.0.0-20210104091850-3888c087a4c8 // indirect
+	github.com/tetratelabs/wazero v1.5.0 // indirect
 	github.com/textileio/go-log/v2 v2.1.3-gke-2 // indirect
 	github.com/ugorji/go/codec v1.2.12 // indirect
+	github.com/wasmerio/wasmer-go v1.0.4 // indirect
 	github.com/whyrusleeping/go-keyspace v0.0.0-20160322163242-5b898ac5add1 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect

--- a/go.sum
+++ b/go.sum
@@ -1139,6 +1139,8 @@ github.com/tendermint/tm-db v0.6.7 h1:fE00Cbl0jayAoqlExN6oyQJ7fR/ZtoVOmvPJ//+shu
 github.com/tendermint/tm-db v0.6.7/go.mod h1:byQDzFkZV1syXr/ReXS808NxA2xvyuuVgXOJ/088L6I=
 github.com/teserakt-io/golang-ed25519 v0.0.0-20210104091850-3888c087a4c8 h1:RBkacARv7qY5laaXGlF4wFB/tk5rnthhPb8oIBGoagY=
 github.com/teserakt-io/golang-ed25519 v0.0.0-20210104091850-3888c087a4c8/go.mod h1:9PdLyPiZIiW3UopXyRnPYyjUXSpiQNHRLu8fOsR3o8M=
+github.com/tetratelabs/wazero v1.5.0 h1:Yz3fZHivfDiZFUXnWMPUoiW7s8tC1sjdBtlJn08qYa0=
+github.com/tetratelabs/wazero v1.5.0/go.mod h1:0U0G41+ochRKoPKCJlh0jMg1CHkyfK8kDqiirMmKY8A=
 github.com/textileio/go-datastore-extensions v1.0.1 h1:qIJGqJaigQ1wD4TdwS/hf73u0HChhXvvUSJuxBEKS+c=
 github.com/textileio/go-datastore-extensions v1.0.1/go.mod h1:Pzj9FDRkb55910dr/FX8M7WywvnS26gBgEDez1ZBuLE=
 github.com/textileio/go-ds-badger3 v0.1.0 h1:q0kBuBmAcRUR3ClMSYlyw0224XeuzjjGinU53Qz1uXI=
@@ -1168,6 +1170,8 @@ github.com/warpfork/go-testmark v0.12.1 h1:rMgCpJfwy1sJ50x0M0NgyphxYYPMOODIJHhsX
 github.com/warpfork/go-testmark v0.12.1/go.mod h1:kHwy7wfvGSPh1rQJYKayD4AbtNaeyZdcGi9tNJTaa5Y=
 github.com/warpfork/go-wish v0.0.0-20220906213052-39a1cc7a02d0 h1:GDDkbFiaK8jsSDJfjId/PEGEShv6ugrt4kYsC5UIDaQ=
 github.com/warpfork/go-wish v0.0.0-20220906213052-39a1cc7a02d0/go.mod h1:x6AKhvSSexNrVSrViXSHUEbICjmGXhtgABaHIySUSGw=
+github.com/wasmerio/wasmer-go v1.0.4 h1:MnqHoOGfiQ8MMq2RF6wyCeebKOe84G88h5yv+vmxJgs=
+github.com/wasmerio/wasmer-go v1.0.4/go.mod h1:0gzVdSfg6pysA6QVp6iVRPTagC6Wq9pOE8J86WKb2Fk=
 github.com/whyrusleeping/base32 v0.0.0-20170828182744-c30ac30633cc h1:BCPnHtcboadS0DvysUuJXZ4lWVv5Bh5i7+tbIyi+ck4=
 github.com/whyrusleeping/base32 v0.0.0-20170828182744-c30ac30633cc/go.mod h1:r45hJU7yEoA81k6MWNhpMj/kms0n14dkzkxYHoB96UM=
 github.com/whyrusleeping/chunker v0.0.0-20181014151217-fe64bd25879f h1:jQa4QT2UP9WYv2nzyawpKMOCl+Z/jW7djv2/J50lj9E=

--- a/http/client_lens.go
+++ b/http/client_lens.go
@@ -35,6 +35,8 @@ type setMigrationRequest struct {
 	Config       model.Lens
 }
 
+func (w *LensRegistry) Init(txnSource client.TxnSource) {}
+
 func (c *LensRegistry) SetMigration(ctx context.Context, collectionID uint32, config model.Lens) error {
 	methodURL := c.http.baseURL.JoinPath("lens", "registry")
 

--- a/http/handler_ccip_test.go
+++ b/http/handler_ccip_test.go
@@ -193,7 +193,7 @@ func TestCCIPPost_WithInvalidBody(t *testing.T) {
 func setupDatabase(t *testing.T) client.DB {
 	ctx := context.Background()
 
-	cdb, err := db.NewDB(ctx, memory.NewDatastore(ctx), acp.NoACP, db.WithUpdateEvents())
+	cdb, err := db.NewDB(ctx, memory.NewDatastore(ctx), acp.NoACP, nil, db.WithUpdateEvents())
 	require.NoError(t, err)
 
 	_, err = cdb.AddSchema(ctx, `type User {

--- a/internal/db/config.go
+++ b/internal/db/config.go
@@ -11,7 +11,6 @@
 package db
 
 import (
-	"github.com/lens-vm/lens/host-go/engine/module"
 	"github.com/sourcenetwork/immutable"
 
 	"github.com/sourcenetwork/defradb/events"
@@ -38,21 +37,5 @@ func WithUpdateEvents() Option {
 func WithMaxRetries(num int) Option {
 	return func(db *db) {
 		db.maxTxnRetries = immutable.Some(num)
-	}
-}
-
-// WithLensPoolSize sets the maximum number of cached migrations instances to preserve per schema version.
-//
-// Will default to `5` if not set.
-func WithLensPoolSize(size int) Option {
-	return func(db *db) {
-		db.lensPoolSize = immutable.Some(size)
-	}
-}
-
-// WithLensRuntime returns an option that sets the lens registry runtime.
-func WithLensRuntime(runtime module.Runtime) Option {
-	return func(db *db) {
-		db.lensRuntime = immutable.Some(runtime)
 	}
 }

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -26,7 +26,7 @@ func newMemoryDB(ctx context.Context) (*db, error) {
 	if err != nil {
 		return nil, err
 	}
-	return newDB(ctx, rootstore, acp.NoACP)
+	return newDB(ctx, rootstore, acp.NoACP, nil)
 }
 
 func TestNewDB(t *testing.T) {
@@ -38,7 +38,7 @@ func TestNewDB(t *testing.T) {
 		return
 	}
 
-	_, err = NewDB(ctx, rootstore, acp.NoACP)
+	_, err = NewDB(ctx, rootstore, acp.NoACP, nil)
 	if err != nil {
 		t.Error(err)
 	}

--- a/internal/lens/txn_registry.go
+++ b/internal/lens/txn_registry.go
@@ -22,7 +22,7 @@ import (
 
 type implicitTxnLensRegistry struct {
 	registry *lensRegistry
-	db       TxnSource
+	db       client.TxnSource
 }
 
 type explicitTxnLensRegistry struct {
@@ -33,12 +33,11 @@ type explicitTxnLensRegistry struct {
 var _ client.LensRegistry = (*implicitTxnLensRegistry)(nil)
 var _ client.LensRegistry = (*explicitTxnLensRegistry)(nil)
 
-func (r *implicitTxnLensRegistry) WithTxn(txn datastore.Txn) client.LensRegistry {
-	return &explicitTxnLensRegistry{
-		registry: r.registry,
-		txn:      txn,
-	}
+func (r *implicitTxnLensRegistry) Init(txnSource client.TxnSource) {
+	r.db = txnSource
 }
+
+func (r *explicitTxnLensRegistry) Init(txnSource client.TxnSource) {}
 
 func (r *explicitTxnLensRegistry) WithTxn(txn datastore.Txn) client.LensRegistry {
 	return &explicitTxnLensRegistry{

--- a/net/node_test.go
+++ b/net/node_test.go
@@ -36,7 +36,7 @@ func FixtureNewMemoryDBWithBroadcaster(t *testing.T) client.DB {
 	opts := badgerds.Options{Options: badger.DefaultOptions("").WithInMemory(true)}
 	rootstore, err := badgerds.NewDatastore("", &opts)
 	require.NoError(t, err)
-	database, err = db.NewDB(ctx, rootstore, acp.NoACP, db.WithUpdateEvents())
+	database, err = db.NewDB(ctx, rootstore, acp.NoACP, nil, db.WithUpdateEvents())
 	require.NoError(t, err)
 	return database
 }
@@ -44,7 +44,7 @@ func FixtureNewMemoryDBWithBroadcaster(t *testing.T) client.DB {
 func TestNewNode_WithEnableRelay_NoError(t *testing.T) {
 	ctx := context.Background()
 	store := memory.NewDatastore(ctx)
-	db, err := db.NewDB(ctx, store, acp.NoACP, db.WithUpdateEvents())
+	db, err := db.NewDB(ctx, store, acp.NoACP, nil, db.WithUpdateEvents())
 	require.NoError(t, err)
 	n, err := NewNode(
 		context.Background(),
@@ -59,7 +59,7 @@ func TestNewNode_WithDBClosed_NoError(t *testing.T) {
 	ctx := context.Background()
 	store := memory.NewDatastore(ctx)
 
-	db, err := db.NewDB(ctx, store, acp.NoACP, db.WithUpdateEvents())
+	db, err := db.NewDB(ctx, store, acp.NoACP, nil, db.WithUpdateEvents())
 	require.NoError(t, err)
 	db.Close()
 
@@ -73,7 +73,7 @@ func TestNewNode_WithDBClosed_NoError(t *testing.T) {
 func TestNewNode_NoPubSub_NoError(t *testing.T) {
 	ctx := context.Background()
 	store := memory.NewDatastore(ctx)
-	db, err := db.NewDB(ctx, store, acp.NoACP, db.WithUpdateEvents())
+	db, err := db.NewDB(ctx, store, acp.NoACP, nil, db.WithUpdateEvents())
 	require.NoError(t, err)
 	n, err := NewNode(
 		context.Background(),
@@ -88,7 +88,7 @@ func TestNewNode_NoPubSub_NoError(t *testing.T) {
 func TestNewNode_WithEnablePubSub_NoError(t *testing.T) {
 	ctx := context.Background()
 	store := memory.NewDatastore(ctx)
-	db, err := db.NewDB(ctx, store, acp.NoACP, db.WithUpdateEvents())
+	db, err := db.NewDB(ctx, store, acp.NoACP, nil, db.WithUpdateEvents())
 	require.NoError(t, err)
 
 	n, err := NewNode(
@@ -106,7 +106,7 @@ func TestNewNode_WithEnablePubSub_NoError(t *testing.T) {
 func TestNodeClose_NoError(t *testing.T) {
 	ctx := context.Background()
 	store := memory.NewDatastore(ctx)
-	db, err := db.NewDB(ctx, store, acp.NoACP, db.WithUpdateEvents())
+	db, err := db.NewDB(ctx, store, acp.NoACP, nil, db.WithUpdateEvents())
 	require.NoError(t, err)
 	n, err := NewNode(
 		context.Background(),
@@ -119,7 +119,7 @@ func TestNodeClose_NoError(t *testing.T) {
 func TestNewNode_BootstrapWithNoPeer_NoError(t *testing.T) {
 	ctx := context.Background()
 	store := memory.NewDatastore(ctx)
-	db, err := db.NewDB(ctx, store, acp.NoACP, db.WithUpdateEvents())
+	db, err := db.NewDB(ctx, store, acp.NoACP, nil, db.WithUpdateEvents())
 	require.NoError(t, err)
 
 	n1, err := NewNode(
@@ -135,7 +135,7 @@ func TestNewNode_BootstrapWithNoPeer_NoError(t *testing.T) {
 func TestNewNode_BootstrapWithOnePeer_NoError(t *testing.T) {
 	ctx := context.Background()
 	store := memory.NewDatastore(ctx)
-	db, err := db.NewDB(ctx, store, acp.NoACP, db.WithUpdateEvents())
+	db, err := db.NewDB(ctx, store, acp.NoACP, nil, db.WithUpdateEvents())
 	require.NoError(t, err)
 
 	n1, err := NewNode(
@@ -162,7 +162,7 @@ func TestNewNode_BootstrapWithOnePeer_NoError(t *testing.T) {
 func TestNewNode_BootstrapWithOneValidPeerAndManyInvalidPeers_NoError(t *testing.T) {
 	ctx := context.Background()
 	store := memory.NewDatastore(ctx)
-	db, err := db.NewDB(ctx, store, acp.NoACP, db.WithUpdateEvents())
+	db, err := db.NewDB(ctx, store, acp.NoACP, nil, db.WithUpdateEvents())
 	require.NoError(t, err)
 
 	n1, err := NewNode(
@@ -192,7 +192,7 @@ func TestNewNode_BootstrapWithOneValidPeerAndManyInvalidPeers_NoError(t *testing
 func TestListenAddrs_WithListenAddresses_NoError(t *testing.T) {
 	ctx := context.Background()
 	store := memory.NewDatastore(ctx)
-	db, err := db.NewDB(ctx, store, acp.NoACP, db.WithUpdateEvents())
+	db, err := db.NewDB(ctx, store, acp.NoACP, nil, db.WithUpdateEvents())
 	require.NoError(t, err)
 	n, err := NewNode(
 		context.Background(),

--- a/net/peer_test.go
+++ b/net/peer_test.go
@@ -75,7 +75,7 @@ func newTestNode(ctx context.Context, t *testing.T) (client.DB, *Node) {
 	store := memory.NewDatastore(ctx)
 	acpLocal := acp.NewLocalACP()
 	acpLocal.Init(context.Background(), "")
-	db, err := db.NewDB(ctx, store, immutable.Some[acp.ACP](acpLocal), db.WithUpdateEvents())
+	db, err := db.NewDB(ctx, store, immutable.Some[acp.ACP](acpLocal), nil, db.WithUpdateEvents())
 	require.NoError(t, err)
 
 	n, err := NewNode(
@@ -91,7 +91,7 @@ func newTestNode(ctx context.Context, t *testing.T) (client.DB, *Node) {
 func TestNewPeer_NoError(t *testing.T) {
 	ctx := context.Background()
 	store := memory.NewDatastore(ctx)
-	db, err := db.NewDB(ctx, store, acp.NoACP, db.WithUpdateEvents())
+	db, err := db.NewDB(ctx, store, acp.NoACP, nil, db.WithUpdateEvents())
 	require.NoError(t, err)
 
 	h, err := libp2p.New()
@@ -114,7 +114,7 @@ func TestNewPeer_NoDB_NilDBError(t *testing.T) {
 func TestNewPeer_WithExistingTopic_TopicAlreadyExistsError(t *testing.T) {
 	ctx := context.Background()
 	store := memory.NewDatastore(ctx)
-	db, err := db.NewDB(ctx, store, acp.NoACP, db.WithUpdateEvents())
+	db, err := db.NewDB(ctx, store, acp.NoACP, nil, db.WithUpdateEvents())
 	require.NoError(t, err)
 
 	_, err = db.AddSchema(ctx, `type User {
@@ -164,11 +164,11 @@ func TestStartAndClose_NoError(t *testing.T) {
 func TestStart_WithKnownPeer_NoError(t *testing.T) {
 	ctx := context.Background()
 	store := memory.NewDatastore(ctx)
-	db1, err := db.NewDB(ctx, store, acp.NoACP, db.WithUpdateEvents())
+	db1, err := db.NewDB(ctx, store, acp.NoACP, nil, db.WithUpdateEvents())
 	require.NoError(t, err)
 
 	store2 := memory.NewDatastore(ctx)
-	db2, err := db.NewDB(ctx, store2, acp.NoACP, db.WithUpdateEvents())
+	db2, err := db.NewDB(ctx, store2, acp.NoACP, nil, db.WithUpdateEvents())
 	require.NoError(t, err)
 
 	n1, err := NewNode(
@@ -200,11 +200,11 @@ func TestStart_WithKnownPeer_NoError(t *testing.T) {
 func TestStart_WithOfflineKnownPeer_NoError(t *testing.T) {
 	ctx := context.Background()
 	store := memory.NewDatastore(ctx)
-	db1, err := db.NewDB(ctx, store, acp.NoACP, db.WithUpdateEvents())
+	db1, err := db.NewDB(ctx, store, acp.NoACP, nil, db.WithUpdateEvents())
 	require.NoError(t, err)
 
 	store2 := memory.NewDatastore(ctx)
-	db2, err := db.NewDB(ctx, store2, acp.NoACP, db.WithUpdateEvents())
+	db2, err := db.NewDB(ctx, store2, acp.NoACP, nil, db.WithUpdateEvents())
 	require.NoError(t, err)
 
 	n1, err := NewNode(
@@ -240,7 +240,7 @@ func TestStart_WithOfflineKnownPeer_NoError(t *testing.T) {
 func TestStart_WithNoUpdateChannel_NilUpdateChannelError(t *testing.T) {
 	ctx := context.Background()
 	store := memory.NewDatastore(ctx)
-	db, err := db.NewDB(ctx, store, acp.NoACP)
+	db, err := db.NewDB(ctx, store, acp.NoACP, nil)
 	require.NoError(t, err)
 
 	n, err := NewNode(
@@ -259,7 +259,7 @@ func TestStart_WithNoUpdateChannel_NilUpdateChannelError(t *testing.T) {
 func TestStart_WitClosedUpdateChannel_ClosedChannelError(t *testing.T) {
 	ctx := context.Background()
 	store := memory.NewDatastore(ctx)
-	db, err := db.NewDB(ctx, store, acp.NoACP, db.WithUpdateEvents())
+	db, err := db.NewDB(ctx, store, acp.NoACP, nil, db.WithUpdateEvents())
 	require.NoError(t, err)
 
 	n, err := NewNode(

--- a/node/errors.go
+++ b/node/errors.go
@@ -8,23 +8,18 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-package db
+package node
 
 import (
-	"testing"
-
-	"github.com/stretchr/testify/assert"
+	"github.com/sourcenetwork/defradb/errors"
 )
 
-func TestWithUpdateEvents(t *testing.T) {
-	d := &db{}
-	WithUpdateEvents()(d)
-	assert.NotNil(t, d.events)
-}
+const (
+	errLensRuntimeNotSupported string = "the selected lens runtime is not supported by this build"
+)
 
-func TestWithMaxRetries(t *testing.T) {
-	d := &db{}
-	WithMaxRetries(10)(d)
-	assert.True(t, d.maxTxnRetries.HasValue())
-	assert.Equal(t, 10, d.maxTxnRetries.Value())
+var ErrLensRuntimeNotSupported = errors.New(errLensRuntimeNotSupported)
+
+func NewErrLensRuntimeNotSupported(lens LensRuntimeType) error {
+	return errors.New(errLensRuntimeNotSupported, errors.NewKV("Lens", lens))
 }

--- a/node/lens.go
+++ b/node/lens.go
@@ -22,9 +22,16 @@ import (
 type LensRuntimeType string
 
 const (
+	// The Go-enum default LensRuntimeType.
+	//
+	// The actual runtime type that this resolves to depends on the build target.
 	DefaultLens LensRuntimeType = ""
 )
 
+// runtimeConstructors is a map of [LensRuntimeType]s to lens runtimes.
+//
+// Is is populated by the `init` functions in the runtime-specific files - this
+// allows it's population to be managed by build flags.
 var runtimeConstructors = map[LensRuntimeType]func() module.Runtime{}
 
 // LensOptions contains Lens configuration values.

--- a/node/lens.go
+++ b/node/lens.go
@@ -1,0 +1,83 @@
+// Copyright 2024 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package node
+
+import (
+	"context"
+
+	"github.com/lens-vm/lens/host-go/engine/module"
+
+	"github.com/sourcenetwork/defradb/client"
+	"github.com/sourcenetwork/defradb/internal/lens"
+)
+
+type LensRuntimeType string
+
+const (
+	DefaultLens LensRuntimeType = ""
+)
+
+var runtimeConstructors = map[LensRuntimeType]func() module.Runtime{}
+
+// LensOptions contains Lens configuration values.
+type LensOptions struct {
+	lensRuntime LensRuntimeType
+
+	// The maximum number of cached migrations instances to preserve per schema version.
+	lensPoolSize int
+}
+
+// DefaultACPOptions returns new options with default values.
+func DefaultLensOptions() *LensOptions {
+	return &LensOptions{
+		lensPoolSize: lens.DefaultPoolSize,
+	}
+}
+
+type LenOpt func(*LensOptions)
+
+// WithLensRuntime returns an option that sets the lens registry runtime.
+func WithLensRuntime(runtime LensRuntimeType) Option {
+	return func(o *LensOptions) {
+		o.lensRuntime = runtime
+	}
+}
+
+// WithLensPoolSize sets the maximum number of cached migrations instances to preserve per schema version.
+//
+// Will default to `5` if not set.
+func WithLensPoolSize(size int) Option {
+	return func(o *LensOptions) {
+		o.lensPoolSize = size
+	}
+}
+
+func NewLens(
+	ctx context.Context,
+	opts ...LenOpt,
+) (client.LensRegistry, error) {
+	options := DefaultLensOptions()
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	var runtime module.Runtime
+	if runtimeConstructor, ok := runtimeConstructors[options.lensRuntime]; ok {
+		runtime = runtimeConstructor()
+	} else {
+		return nil, NewErrLensRuntimeNotSupported(options.lensRuntime)
+	}
+
+	return lens.NewRegistry(
+		options.lensPoolSize,
+		runtime,
+	), nil
+}

--- a/node/lens_wasmer.go
+++ b/node/lens_wasmer.go
@@ -8,23 +8,17 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-package db
+//go:build !windows && !js
+
+package node
 
 import (
-	"testing"
-
-	"github.com/stretchr/testify/assert"
+	"github.com/lens-vm/lens/host-go/engine/module"
+	"github.com/lens-vm/lens/host-go/runtimes/wasmer"
 )
 
-func TestWithUpdateEvents(t *testing.T) {
-	d := &db{}
-	WithUpdateEvents()(d)
-	assert.NotNil(t, d.events)
-}
+const Wasmer LensRuntimeType = "wasmer"
 
-func TestWithMaxRetries(t *testing.T) {
-	d := &db{}
-	WithMaxRetries(10)(d)
-	assert.True(t, d.maxTxnRetries.HasValue())
-	assert.Equal(t, 10, d.maxTxnRetries.Value())
+func init() {
+	runtimeConstructors[Wasmer] = func() module.Runtime { return wasmer.New() }
 }

--- a/node/lens_wasmtime.go
+++ b/node/lens_wasmtime.go
@@ -8,23 +8,18 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-package db
+//go:build !js
+
+package node
 
 import (
-	"testing"
-
-	"github.com/stretchr/testify/assert"
+	"github.com/lens-vm/lens/host-go/engine/module"
+	"github.com/lens-vm/lens/host-go/runtimes/wasmtime"
 )
 
-func TestWithUpdateEvents(t *testing.T) {
-	d := &db{}
-	WithUpdateEvents()(d)
-	assert.NotNil(t, d.events)
-}
+const WasmTime LensRuntimeType = "wasm-time"
 
-func TestWithMaxRetries(t *testing.T) {
-	d := &db{}
-	WithMaxRetries(10)(d)
-	assert.True(t, d.maxTxnRetries.HasValue())
-	assert.Equal(t, 10, d.maxTxnRetries.Value())
+func init() {
+	runtimeConstructors[DefaultLens] = func() module.Runtime { return wasmtime.New() }
+	runtimeConstructors[WasmTime] = func() module.Runtime { return wasmtime.New() }
 }

--- a/node/lens_wazero.go
+++ b/node/lens_wazero.go
@@ -8,23 +8,17 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-package db
+//go:build !js
+
+package node
 
 import (
-	"testing"
-
-	"github.com/stretchr/testify/assert"
+	"github.com/lens-vm/lens/host-go/engine/module"
+	"github.com/lens-vm/lens/host-go/runtimes/wazero"
 )
 
-func TestWithUpdateEvents(t *testing.T) {
-	d := &db{}
-	WithUpdateEvents()(d)
-	assert.NotNil(t, d.events)
-}
+const Wazero LensRuntimeType = "wazero"
 
-func TestWithMaxRetries(t *testing.T) {
-	d := &db{}
-	WithMaxRetries(10)(d)
-	assert.True(t, d.maxTxnRetries.HasValue())
-	assert.Equal(t, 10, d.maxTxnRetries.Value())
+func init() {
+	runtimeConstructors[Wazero] = func() module.Runtime { return wazero.New() }
 }

--- a/node/node.go
+++ b/node/node.go
@@ -89,6 +89,7 @@ func NewNode(ctx context.Context, opts ...Option) (*Node, error) {
 		netOpts    []net.NodeOpt
 		storeOpts  []StoreOpt
 		serverOpts []http.ServerOpt
+		lensOpts   []LenOpt
 	)
 
 	options := DefaultOptions()
@@ -111,6 +112,9 @@ func NewNode(ctx context.Context, opts ...Option) (*Node, error) {
 
 		case net.NodeOpt:
 			netOpts = append(netOpts, t)
+
+		case LenOpt:
+			lensOpts = append(lensOpts, t)
 		}
 	}
 
@@ -124,7 +128,12 @@ func NewNode(ctx context.Context, opts ...Option) (*Node, error) {
 		return nil, err
 	}
 
-	db, err := db.NewDB(ctx, rootstore, acp, dbOpts...)
+	lens, err := NewLens(ctx, lensOpts...)
+	if err != nil {
+		return nil, err
+	}
+
+	db, err := db.NewDB(ctx, rootstore, acp, lens, dbOpts...)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/clients/cli/wrapper_lens.go
+++ b/tests/clients/cli/wrapper_lens.go
@@ -28,6 +28,8 @@ type LensRegistry struct {
 	cmd *cliWrapper
 }
 
+func (w *LensRegistry) Init(txnSource client.TxnSource) {}
+
 func (w *LensRegistry) SetMigration(ctx context.Context, collectionID uint32, config model.Lens) error {
 	args := []string{"client", "schema", "migration", "set-registry"}
 

--- a/tests/gen/cli/util_test.go
+++ b/tests/gen/cli/util_test.go
@@ -50,7 +50,7 @@ func start(ctx context.Context) (*defraInstance, error) {
 		return nil, errors.Wrap("failed to open datastore", err)
 	}
 
-	db, err := db.NewDB(ctx, rootstore, acp.NoACP)
+	db, err := db.NewDB(ctx, rootstore, acp.NoACP, nil)
 	if err != nil {
 		return nil, errors.Wrap("failed to create a database", err)
 	}

--- a/tests/integration/db.go
+++ b/tests/integration/db.go
@@ -105,13 +105,14 @@ func NewBadgerFileDB(ctx context.Context, t testing.TB) (client.DB, error) {
 func setupDatabase(s *state) (client.DB, string, error) {
 	opts := []node.Option{
 		db.WithUpdateEvents(),
-		db.WithLensPoolSize(lensPoolSize),
+		node.WithLensPoolSize(lensPoolSize),
 		// The test framework sets this up elsewhere when required so that it may be wrapped
 		// into a [client.DB].
 		node.WithDisableAPI(true),
 		// The p2p is configured in the tests by [ConfigureNode] actions, we disable it here
 		// to keep the tests as lightweight as possible.
 		node.WithDisableP2P(true),
+		node.WithLensRuntime(lensType),
 	}
 
 	if badgerEncryption && encryptionKey == nil {

--- a/tests/integration/lens.go
+++ b/tests/integration/lens.go
@@ -11,11 +11,26 @@
 package tests
 
 import (
+	"os"
+
 	"github.com/sourcenetwork/immutable"
 
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/internal/db"
+	"github.com/sourcenetwork/defradb/node"
 )
+
+const (
+	lensTypeEnvName = "DEFRA_LENS_TYPE"
+)
+
+var (
+	lensType node.LensRuntimeType
+)
+
+func init() {
+	lensType = node.LensRuntimeType(os.Getenv(lensTypeEnvName))
+}
 
 // ConfigureMigration is a test action which will configure a Lens migration using the
 // provided configuration.

--- a/tools/defradb.containerfile
+++ b/tools/defradb.containerfile
@@ -18,11 +18,16 @@ RUN make deps:modules
 COPY . .
 COPY --from=PLAYGROUND_BUILD /repo/dist /repo/playground/dist/
 ENV BUILD_TAGS=playground
+# manually copy libwasmer.so to fix linking issue https://github.com/wasmerio/wasmer-go/issues/281
+RUN export WASMER_ARCH=$(go env GOHOSTARCH | sed "s/arm64/aarch64/") && \
+    export WASMER_PATH=$(go env GOMODCACHE)/github.com/wasmerio/wasmer-go@v1.0.4/wasmer/packaged/lib/linux-$WASMER_ARCH/libwasmer.so && \
+    cp $WASMER_PATH /lib/libwasmer.so
 RUN make build
 
 # Stage: RUN
 FROM debian:bookworm-slim
 COPY --from=BUILD /repo/build/defradb /defradb
+COPY --from=BUILD /lib/libwasmer.so /lib/libwasmer.so
 
 # Documents which ports are normally used.
 # To publish the ports: `docker run -p 9181:9181` ...


### PR DESCRIPTION
## Relevant issue(s)

Resolves #2683

## Description

Allows lens runtime selection via config/cli param.

Also adds CI jobs to the matrix to test wasmer and wazero.  I was hoping it would solve the windows build issue, but still no joy there :(