### PR TITLE
refactor: Replace subscription events publisher

### DIFF
--- a/cli/request.go
+++ b/cli/request.go
@@ -77,12 +77,12 @@ To learn more about the DefraDB GraphQL Query Language, refer to https://docs.so
 			for _, err := range result.GQL.Errors {
 				errors = append(errors, err.Error())
 			}
-			if result.Pub == nil {
+			if result.Subscription == nil {
 				cmd.Print(REQ_RESULTS_HEADER)
 				return writeJSON(cmd, map[string]any{"data": result.GQL.Data, "errors": errors})
 			}
 			cmd.Print(SUB_RESULTS_HEADER)
-			for item := range result.Pub.Stream() {
+			for item := range result.Subscription {
 				writeJSON(cmd, item) //nolint:errcheck
 			}
 			return nil

--- a/client/db.go
+++ b/client/db.go
@@ -265,9 +265,9 @@ type RequestResult struct {
 	// GQL contains the immediate results of the GQL request.
 	GQL GQLResult
 
-	// Pub contains a pointer to an event stream which channels any subscription results
-	// if the request was a GQL subscription.
-	Pub *events.Publisher[events.Update]
+	// Subscription is an optional channel which returns results
+	// from a subscription request.
+	Subscription <-chan GQLResult
 }
 
 // CollectionFetchOptions represents a set of options used for fetching collections.

--- a/http/client.go
+++ b/http/client.go
@@ -393,10 +393,13 @@ func (c *Client) execRequestSubscription(r io.ReadCloser) chan client.GQLResult 
 	resCh := make(chan client.GQLResult)
 	go func() {
 		eventReader := sse.NewReadCloser(r)
-		// ignore close errors because the status
-		// and body of the request are already
-		// checked and it cannot be handled properly
-		defer eventReader.Close() //nolint:errcheck
+		defer func() {
+			// ignore close errors because the status
+			// and body of the request are already
+			// checked and it cannot be handled properly
+			eventReader.Close() //nolint:errcheck
+			close(resCh)
+		}()
 
 		for {
 			evt, err := eventReader.Next()

--- a/http/handler_ccip.go
+++ b/http/handler_ccip.go
@@ -61,7 +61,7 @@ func (c *ccipHandler) ExecCCIP(rw http.ResponseWriter, req *http.Request) {
 	}
 
 	result := store.ExecRequest(req.Context(), request.Query)
-	if result.Pub != nil {
+	if result.Subscription != nil {
 		responseJSON(rw, http.StatusBadRequest, errorResponse{ErrStreamingNotSupported})
 		return
 	}

--- a/http/handler_store.go
+++ b/http/handler_store.go
@@ -314,7 +314,7 @@ func (s *storeHandler) ExecRequest(rw http.ResponseWriter, req *http.Request) {
 
 	result := store.ExecRequest(req.Context(), request.Query)
 
-	if result.Pub == nil {
+	if result.Subscription == nil {
 		responseJSON(rw, http.StatusOK, GraphQLResponse{result.GQL.Data, result.GQL.Errors})
 		return
 	}
@@ -335,7 +335,7 @@ func (s *storeHandler) ExecRequest(rw http.ResponseWriter, req *http.Request) {
 		select {
 		case <-req.Context().Done():
 			return
-		case item, open := <-result.Pub.Stream():
+		case item, open := <-result.Subscription:
 			if !open {
 				return
 			}

--- a/tests/clients/cli/wrapper.go
+++ b/tests/clients/cli/wrapper.go
@@ -443,6 +443,7 @@ func (w *Wrapper) execRequestSubscription(r io.Reader) chan client.GQLResult {
 	resCh := make(chan client.GQLResult)
 	go func() {
 		dec := json.NewDecoder(r)
+		defer close(resCh)
 
 		for {
 			var response http.GraphQLResponse

--- a/tests/clients/cli/wrapper.go
+++ b/tests/clients/cli/wrapper.go
@@ -411,7 +411,7 @@ func (w *Wrapper) ExecRequest(
 		return result
 	}
 	if header == cli.SUB_RESULTS_HEADER {
-		result.Pub = w.execRequestSubscription(buffer)
+		result.Subscription = w.execRequestSubscription(buffer)
 		return result
 	}
 	data, err := io.ReadAll(buffer)
@@ -439,13 +439,8 @@ func (w *Wrapper) ExecRequest(
 	return result
 }
 
-func (w *Wrapper) execRequestSubscription(r io.Reader) *events.Publisher[events.Update] {
-	pubCh := events.New[events.Update](0, 0)
-	pub, err := events.NewPublisher[events.Update](pubCh, 0)
-	if err != nil {
-		return nil
-	}
-
+func (w *Wrapper) execRequestSubscription(r io.Reader) chan client.GQLResult {
+	resCh := make(chan client.GQLResult)
 	go func() {
 		dec := json.NewDecoder(r)
 
@@ -454,14 +449,13 @@ func (w *Wrapper) execRequestSubscription(r io.Reader) *events.Publisher[events.
 			if err := dec.Decode(&response); err != nil {
 				return
 			}
-			pub.Publish(client.GQLResult{
+			resCh <- client.GQLResult{
 				Errors: response.Errors,
 				Data:   response.Data,
-			})
+			}
 		}
 	}()
-
-	return pub
+	return resCh
 }
 
 func (w *Wrapper) NewTxn(ctx context.Context, readOnly bool) (datastore.Txn, error) {

--- a/tests/integration/utils2.go
+++ b/tests/integration/utils2.go
@@ -1679,13 +1679,11 @@ func executeSubscriptionRequest(
 
 			allActionsAreDone := false
 			expectedDataRecieved := len(action.Results) == 0
-			stream := result.Pub.Stream()
 			for {
 				select {
-				case s := <-stream:
-					sResult, _ := s.(client.GQLResult)
-					sData, _ := sResult.Data.([]map[string]any)
-					errs = append(errs, sResult.Errors...)
+				case s := <-result.Subscription:
+					sData, _ := s.Data.([]map[string]any)
+					errs = append(errs, s.Errors...)
 					data = append(data, sData...)
 
 					if len(data) >= len(action.Results) {


### PR DESCRIPTION
## Relevant issue(s)

Resolves #2685 

## Description

This PR replaces subscription event publishers with a simple go channel. This is a pre-requisite to a follow up events package refactor.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

`make test`

Specify the platform(s) on which this was tested:
- MacOS
