### PR TITLE
refactor: Change counters to support encryption

### DIFF
--- a/docs/data_format_changes/i2696-support-encryption-for-counters.md
+++ b/docs/data_format_changes/i2696-support-encryption-for-counters.md
@@ -1,0 +1,2 @@
+# Support encryption for counters
+We changed the data format of counters from int64 and float64 to bytes to support encryption. This changes the generated CIDs for counters.

--- a/internal/core/block/block.go
+++ b/internal/core/block/block.go
@@ -40,7 +40,7 @@ func init() {
 		&crdt.CRDT{},
 		&crdt.LWWRegDelta{},
 		&crdt.CompositeDAGDelta{},
-		&crdt.CounterDelta[int64]{}, // Only need to call one of the CounterDelta types.
+		&crdt.CounterDelta{},
 	)
 }
 
@@ -149,10 +149,8 @@ func New(delta core.Delta, links []DAGLink, heads ...cid.Cid) *Block {
 		crdtDelta = crdt.CRDT{LWWRegDelta: delta}
 	case *crdt.CompositeDAGDelta:
 		crdtDelta = crdt.CRDT{CompositeDAGDelta: delta}
-	case *crdt.CounterDelta[int64]:
-		crdtDelta = crdt.CRDT{CounterDeltaInt: delta}
-	case *crdt.CounterDelta[float64]:
-		crdtDelta = crdt.CRDT{CounterDeltaFloat: delta}
+	case *crdt.CounterDelta:
+		crdtDelta = crdt.CRDT{CounterDelta: delta}
 	}
 
 	return &Block{

--- a/internal/core/crdt/counter.go
+++ b/internal/core/crdt/counter.go
@@ -33,7 +33,7 @@ type Incrementable interface {
 }
 
 // CounterDelta is a single delta operation for a Counter
-type CounterDelta[T Incrementable] struct {
+type CounterDelta struct {
 	DocID     []byte
 	FieldName string
 	Priority  uint64
@@ -44,69 +44,60 @@ type CounterDelta[T Incrementable] struct {
 	//
 	// It can be used to identify the collection datastructure state at the time of commit.
 	SchemaVersionID string
-	Data            T
+	Data            []byte
 }
 
-var _ core.Delta = (*CounterDelta[float64])(nil)
-var _ core.Delta = (*CounterDelta[int64])(nil)
+var _ core.Delta = (*CounterDelta)(nil)
 
 // IPLDSchemaBytes returns the IPLD schema representation for the type.
 //
-// This needs to match the [CounterDelta[T]] struct or [coreblock.mustSetSchema] will panic on init.
-func (delta *CounterDelta[T]) IPLDSchemaBytes() []byte {
+// This needs to match the [CounterDelta] struct or [coreblock.mustSetSchema] will panic on init.
+func (delta *CounterDelta) IPLDSchemaBytes() []byte {
 	return []byte(`
-	type CounterDeltaFloat struct {
+	type CounterDelta struct {
 		docID     		Bytes
 		fieldName 		String
 		priority  		Int
 		nonce 			Int
 		schemaVersionID String
-		data            Float
-	}
-	
-	type CounterDeltaInt struct {
-		docID     		Bytes
-		fieldName 		String
-		priority  		Int
-		nonce 			Int
-		schemaVersionID String
-		data            Int
+		data            Bytes
 	}`)
 }
 
 // GetPriority gets the current priority for this delta.
-func (delta *CounterDelta[T]) GetPriority() uint64 {
+func (delta *CounterDelta) GetPriority() uint64 {
 	return delta.Priority
 }
 
 // SetPriority will set the priority for this delta.
-func (delta *CounterDelta[T]) SetPriority(prio uint64) {
+func (delta *CounterDelta) SetPriority(prio uint64) {
 	delta.Priority = prio
 }
 
 // Counter, is a simple CRDT type that allows increment/decrement
 // of an Int and Float data types that ensures convergence.
-type Counter[T Incrementable] struct {
+type Counter struct {
 	baseCRDT
 	AllowDecrement bool
+	Kind           client.ScalarKind
 }
 
-var _ core.ReplicatedData = (*Counter[float64])(nil)
-var _ core.ReplicatedData = (*Counter[int64])(nil)
+var _ core.ReplicatedData = (*Counter)(nil)
 
 // NewCounter returns a new instance of the Counter with the given ID.
-func NewCounter[T Incrementable](
+func NewCounter(
 	store datastore.DSReaderWriter,
 	schemaVersionKey core.CollectionSchemaVersionKey,
 	key core.DataStoreKey,
 	fieldName string,
 	allowDecrement bool,
-) Counter[T] {
-	return Counter[T]{newBaseCRDT(store, key, schemaVersionKey, fieldName), allowDecrement}
+	kind client.ScalarKind,
+) Counter {
+	return Counter{newBaseCRDT(store, key, schemaVersionKey, fieldName), allowDecrement, kind}
 }
 
 // Value gets the current counter value
-func (c Counter[T]) Value(ctx context.Context) ([]byte, error) {
+func (c Counter) Value(ctx context.Context) ([]byte, error) {
 	valueK := c.key.WithValueFlag()
 	buf, err := c.store.Get(ctx, valueK.ToDS())
 	if err != nil {
@@ -120,7 +111,7 @@ func (c Counter[T]) Value(ctx context.Context) ([]byte, error) {
 // WARNING: Incrementing an integer and causing it to overflow the int64 max value
 // will cause the value to roll over to the int64 min value. Incremeting a float and
 // causing it to overflow the float64 max value will act like a no-op.
-func (c Counter[T]) Increment(ctx context.Context, value T) (*CounterDelta[T], error) {
+func (c Counter) Increment(ctx context.Context, value []byte) (*CounterDelta, error) {
 	// To ensure that the dag block is unique, we add a random number to the delta.
 	// This is done only on update (if the doc doesn't already exist) to ensure that the
 	// initial dag block of a document can be reproducible.
@@ -137,7 +128,7 @@ func (c Counter[T]) Increment(ctx context.Context, value T) (*CounterDelta[T], e
 		nonce = r.Int64()
 	}
 
-	return &CounterDelta[T]{
+	return &CounterDelta{
 		DocID:           []byte(c.key.DocID),
 		FieldName:       c.fieldName,
 		Data:            value,
@@ -148,8 +139,8 @@ func (c Counter[T]) Increment(ctx context.Context, value T) (*CounterDelta[T], e
 
 // Merge implements ReplicatedData interface.
 // It merges two CounterRegisty by adding the values together.
-func (c Counter[T]) Merge(ctx context.Context, delta core.Delta) error {
-	d, ok := delta.(*CounterDelta[T])
+func (c Counter) Merge(ctx context.Context, delta core.Delta) error {
+	d, ok := delta.(*CounterDelta)
 	if !ok {
 		return ErrMismatchedMergeType
 	}
@@ -157,10 +148,11 @@ func (c Counter[T]) Merge(ctx context.Context, delta core.Delta) error {
 	return c.incrementValue(ctx, d.Data, d.GetPriority())
 }
 
-func (c Counter[T]) incrementValue(ctx context.Context, value T, priority uint64) error {
-	if !c.AllowDecrement && value < 0 {
-		return NewErrNegativeValue(value)
-	}
+func (c Counter) incrementValue(
+	ctx context.Context,
+	valueAsBytes []byte,
+	priority uint64,
+) error {
 	key := c.key.WithValueFlag()
 	marker, err := c.store.Get(ctx, c.key.ToPrimaryDataStoreKey().ToDS())
 	if err != nil && !errors.Is(err, ds.ErrNotFound) {
@@ -170,18 +162,24 @@ func (c Counter[T]) incrementValue(ctx context.Context, value T, priority uint64
 		key = key.WithDeletedFlag()
 	}
 
-	curValue, err := c.getCurrentValue(ctx, key)
-	if err != nil {
-		return err
+	var resultAsBytes []byte
+
+	switch c.Kind {
+	case client.FieldKind_NILLABLE_INT:
+		resultAsBytes, err = validateAndIncrement[int64](ctx, c.store, key, valueAsBytes, c.AllowDecrement)
+		if err != nil {
+			return err
+		}
+	case client.FieldKind_NILLABLE_FLOAT:
+		resultAsBytes, err = validateAndIncrement[float64](ctx, c.store, key, valueAsBytes, c.AllowDecrement)
+		if err != nil {
+			return err
+		}
+	default:
+		return NewErrUnsupportedCounterType(c.Kind)
 	}
 
-	newValue := curValue + value
-	b, err := cbor.Marshal(newValue)
-	if err != nil {
-		return err
-	}
-
-	err = c.store.Put(ctx, key.ToDS(), b)
+	err = c.store.Put(ctx, key.ToDS(), resultAsBytes)
 	if err != nil {
 		return NewErrFailedToStoreValue(err)
 	}
@@ -189,8 +187,44 @@ func (c Counter[T]) incrementValue(ctx context.Context, value T, priority uint64
 	return c.setPriority(ctx, c.key, priority)
 }
 
-func (c Counter[T]) getCurrentValue(ctx context.Context, key core.DataStoreKey) (T, error) {
-	curValue, err := c.store.Get(ctx, key.ToDS())
+func validateAndIncrement[T Incrementable](
+	ctx context.Context,
+	store datastore.DSReaderWriter,
+	key core.DataStoreKey,
+	valueAsBytes []byte,
+	allowDecrement bool,
+) ([]byte, error) {
+	value, err := getNumericFromBytes[T](valueAsBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	if !allowDecrement && value < 0 {
+		return nil, NewErrNegativeValue(value)
+	}
+
+	curValue, err := getCurrentValue[T](ctx, store, key)
+	if err != nil {
+		return nil, err
+	}
+
+	newValue := curValue + value
+	return cbor.Marshal(newValue)
+}
+
+func (c Counter) CType() client.CType {
+	if c.AllowDecrement {
+		return client.PN_COUNTER
+	}
+	return client.P_COUNTER
+}
+
+func getCurrentValue[T Incrementable](
+	ctx context.Context,
+	store datastore.DSReaderWriter,
+	key core.DataStoreKey,
+) (T, error) {
+	curValue, err := store.Get(ctx, key.ToDS())
 	if err != nil {
 		if errors.Is(err, ds.ErrNotFound) {
 			return 0, nil
@@ -199,13 +233,6 @@ func (c Counter[T]) getCurrentValue(ctx context.Context, key core.DataStoreKey) 
 	}
 
 	return getNumericFromBytes[T](curValue)
-}
-
-func (c Counter[T]) CType() client.CType {
-	if c.AllowDecrement {
-		return client.PN_COUNTER
-	}
-	return client.P_COUNTER
 }
 
 func getNumericFromBytes[T Incrementable](b []byte) (T, error) {

--- a/internal/core/crdt/counter.go
+++ b/internal/core/crdt/counter.go
@@ -187,6 +187,13 @@ func (c Counter) incrementValue(
 	return c.setPriority(ctx, c.key, priority)
 }
 
+func (c Counter) CType() client.CType {
+	if c.AllowDecrement {
+		return client.PN_COUNTER
+	}
+	return client.P_COUNTER
+}
+
 func validateAndIncrement[T Incrementable](
 	ctx context.Context,
 	store datastore.DSReaderWriter,
@@ -210,13 +217,6 @@ func validateAndIncrement[T Incrementable](
 
 	newValue := curValue + value
 	return cbor.Marshal(newValue)
-}
-
-func (c Counter) CType() client.CType {
-	if c.AllowDecrement {
-		return client.PN_COUNTER
-	}
-	return client.P_COUNTER
 }
 
 func getCurrentValue[T Incrementable](

--- a/internal/core/crdt/errors.go
+++ b/internal/core/crdt/errors.go
@@ -11,13 +11,15 @@
 package crdt
 
 import (
+	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/errors"
 )
 
 const (
-	errFailedToGetPriority string = "failed to get priority"
-	errFailedToStoreValue  string = "failed to store value"
-	errNegativeValue       string = "value cannot be negative"
+	errFailedToGetPriority    string = "failed to get priority"
+	errFailedToStoreValue     string = "failed to store value"
+	errNegativeValue          string = "value cannot be negative"
+	errUnsupportedCounterType string = "unsupported counter type. Valid types are int64 and float64"
 )
 
 // Errors returnable from this package.
@@ -31,7 +33,8 @@ var (
 	ErrEncodingPriority    = errors.New("error encoding priority")
 	ErrDecodingPriority    = errors.New("error decoding priority")
 	// ErrMismatchedMergeType - Tying to merge two ReplicatedData of different types
-	ErrMismatchedMergeType = errors.New("given type to merge does not match source")
+	ErrMismatchedMergeType    = errors.New("given type to merge does not match source")
+	ErrUnsupportedCounterType = errors.New(errUnsupportedCounterType)
 )
 
 // NewErrFailedToGetPriority returns an error indicating that the priority could not be retrieved.
@@ -46,4 +49,8 @@ func NewErrFailedToStoreValue(inner error) error {
 
 func NewErrNegativeValue[T Incrementable](value T) error {
 	return errors.New(errNegativeValue, errors.NewKV("Value", value))
+}
+
+func NewErrUnsupportedCounterType(valueType client.ScalarKind) error {
+	return errors.New(errUnsupportedCounterType, errors.NewKV("Type", valueType))
 }

--- a/internal/core/crdt/ipld_union.go
+++ b/internal/core/crdt/ipld_union.go
@@ -16,8 +16,7 @@ import "github.com/sourcenetwork/defradb/internal/core"
 type CRDT struct {
 	LWWRegDelta       *LWWRegDelta
 	CompositeDAGDelta *CompositeDAGDelta
-	CounterDeltaInt   *CounterDelta[int64]
-	CounterDeltaFloat *CounterDelta[float64]
+	CounterDelta      *CounterDelta
 }
 
 // IPLDSchemaBytes returns the IPLD schema representation for the CRDT.
@@ -28,8 +27,7 @@ func (c CRDT) IPLDSchemaBytes() []byte {
 	type CRDT union {
 		| LWWRegDelta "lww"
 		| CompositeDAGDelta "composite"
-		| CounterDeltaInt "counterInt"
-		| CounterDeltaFloat "counterFloat"
+		| CounterDelta "counter"
 	} representation keyed`)
 }
 
@@ -40,10 +38,8 @@ func (c CRDT) GetDelta() core.Delta {
 		return c.LWWRegDelta
 	case c.CompositeDAGDelta != nil:
 		return c.CompositeDAGDelta
-	case c.CounterDeltaFloat != nil:
-		return c.CounterDeltaFloat
-	case c.CounterDeltaInt != nil:
-		return c.CounterDeltaInt
+	case c.CounterDelta != nil:
+		return c.CounterDelta
 	}
 	return nil
 }
@@ -55,10 +51,8 @@ func (c CRDT) GetPriority() uint64 {
 		return c.LWWRegDelta.GetPriority()
 	case c.CompositeDAGDelta != nil:
 		return c.CompositeDAGDelta.GetPriority()
-	case c.CounterDeltaFloat != nil:
-		return c.CounterDeltaFloat.GetPriority()
-	case c.CounterDeltaInt != nil:
-		return c.CounterDeltaInt.GetPriority()
+	case c.CounterDelta != nil:
+		return c.CounterDelta.GetPriority()
 	}
 	return 0
 }
@@ -70,10 +64,8 @@ func (c CRDT) GetFieldName() string {
 		return c.LWWRegDelta.FieldName
 	case c.CompositeDAGDelta != nil:
 		return c.CompositeDAGDelta.FieldName
-	case c.CounterDeltaFloat != nil:
-		return c.CounterDeltaFloat.FieldName
-	case c.CounterDeltaInt != nil:
-		return c.CounterDeltaInt.FieldName
+	case c.CounterDelta != nil:
+		return c.CounterDelta.FieldName
 	}
 	return ""
 }
@@ -85,10 +77,8 @@ func (c CRDT) GetDocID() []byte {
 		return c.LWWRegDelta.DocID
 	case c.CompositeDAGDelta != nil:
 		return c.CompositeDAGDelta.DocID
-	case c.CounterDeltaFloat != nil:
-		return c.CounterDeltaFloat.DocID
-	case c.CounterDeltaInt != nil:
-		return c.CounterDeltaInt.DocID
+	case c.CounterDelta != nil:
+		return c.CounterDelta.DocID
 	}
 	return nil
 }
@@ -100,10 +90,8 @@ func (c CRDT) GetSchemaVersionID() string {
 		return c.LWWRegDelta.SchemaVersionID
 	case c.CompositeDAGDelta != nil:
 		return c.CompositeDAGDelta.SchemaVersionID
-	case c.CounterDeltaFloat != nil:
-		return c.CounterDeltaFloat.SchemaVersionID
-	case c.CounterDeltaInt != nil:
-		return c.CounterDeltaInt.SchemaVersionID
+	case c.CounterDelta != nil:
+		return c.CounterDelta.SchemaVersionID
 	}
 	return ""
 }

--- a/internal/merkle/crdt/merklecrdt.go
+++ b/internal/merkle/crdt/merklecrdt.go
@@ -88,24 +88,14 @@ func InstanceWithStore(
 			fieldName,
 		), nil
 	case client.PN_COUNTER, client.P_COUNTER:
-		switch kind {
-		case client.FieldKind_NILLABLE_INT:
-			return NewMerkleCounter[int64](
-				store,
-				schemaVersionKey,
-				key,
-				fieldName,
-				cType == client.PN_COUNTER,
-			), nil
-		case client.FieldKind_NILLABLE_FLOAT:
-			return NewMerkleCounter[float64](
-				store,
-				schemaVersionKey,
-				key,
-				fieldName,
-				cType == client.PN_COUNTER,
-			), nil
-		}
+		return NewMerkleCounter(
+			store,
+			schemaVersionKey,
+			key,
+			fieldName,
+			cType == client.PN_COUNTER,
+			kind.(client.ScalarKind),
+		), nil
 	case client.COMPOSITE:
 		return NewMerkleCompositeDAG(
 			store,

--- a/tests/integration/query/simple/with_cid_doc_id_test.go
+++ b/tests/integration/query/simple/with_cid_doc_id_test.go
@@ -324,7 +324,7 @@ func TestCidAndDocIDQuery_ContainsPNCounterWithIntKind_NoError(t *testing.T) {
 			testUtils.Request{
 				Request: `query {
 					Users (
-						cid: "bafyreicsx7flfz4b6iwfmwgrnrnd2klxrbg6yojuffh4ia3lrrqcph5q7a",
+						cid: "bafyreienkinjn7cvsonvhs4tslqvmmcnezuu4aif57jn75cyp6i3vdvkpm",
 						docID: "bae-d8cb53d4-ac5a-5c55-8306-64df633d400d"
 					) {
 						name
@@ -376,7 +376,7 @@ func TestCidAndDocIDQuery_ContainsPNCounterWithFloatKind_NoError(t *testing.T) {
 			testUtils.Request{
 				Request: `query {
 					Users (
-						cid: "bafyreidwtowbnmdfshq3dptfdggzswtdftyh5374ohfcmqki4ad2wd4m64",
+						cid: "bafyreiceodj32fyhq3v7ryk6mmcjanwx3zr7ajl2k47w4setngmyx7nc3e",
 						docID: "bae-d420ebcd-023a-5800-ae2e-8ea89442318e"
 					) {
 						name
@@ -423,7 +423,7 @@ func TestCidAndDocIDQuery_ContainsPCounterWithIntKind_NoError(t *testing.T) {
 			testUtils.Request{
 				Request: `query {
 					Users (
-						cid: "bafyreifngcu76fxe3dtjee556hwymfjgsm3sqhxned4cykit5lcsyy3ope",
+						cid: "bafyreieypgt2mq43g4ute2hkzombdqw5v6wctleyxyy6vdkzitrfje636i",
 						docID: "bae-d8cb53d4-ac5a-5c55-8306-64df633d400d"
 					) {
 						name
@@ -470,7 +470,7 @@ func TestCidAndDocIDQuery_ContainsPCounterWithFloatKind_NoError(t *testing.T) {
 			testUtils.Request{
 				Request: `query {
 					Users (
-						cid: "bafyreigih3wl4ycq5lktczydbecvcvlmdsy5jzarx2l6hcqdcrqkoranny",
+						cid: "bafyreigb3ujvnxie7kwl53w4chiq6cjcyuhranchseo5gmx5i6vfje67da",
 						docID: "bae-d420ebcd-023a-5800-ae2e-8ea89442318e"
 					) {
 						name


### PR DESCRIPTION
## Relevant issue(s)

Resolves #2696 

## Description
This PR changes the counter CRDTs to make them support the document encryption feature. They previously stored their values as concrete types (int64 and float64) instead of bytes. Storing them as bytes allow them to be stored plainly or encrypted.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

make test

Specify the platform(s) on which this was tested:
- MacOS
