### PR TITLE
refactor: Rework definition validation

### DIFF
--- a/internal/db/collection_define.go
+++ b/internal/db/collection_define.go
@@ -36,9 +36,9 @@ func (db *db) createCollections(
 		return nil, err
 	}
 
-	for i, def := range newDefinitions {
-		txn := mustGetContextTxn(ctx)
+	txn := mustGetContextTxn(ctx)
 
+	for i, def := range newDefinitions {
 		schemaByName := map[string]client.SchemaDescription{}
 		for _, existingDefinition := range existingDefinitions {
 			schemaByName[existingDefinition.Schema.Name] = existingDefinition.Schema
@@ -57,7 +57,6 @@ func (db *db) createCollections(
 
 	for _, def := range newDefinitions {
 		desc := def.Description
-		txn := mustGetContextTxn(ctx)
 
 		if desc.Name.HasValue() {
 			exists, err := description.HasCollectionByName(ctx, txn, desc.Name.Value())

--- a/internal/db/collection_define.go
+++ b/internal/db/collection_define.go
@@ -25,113 +25,136 @@ import (
 	"github.com/sourcenetwork/defradb/internal/db/description"
 )
 
-func (db *db) createCollection(
+func (db *db) createCollections(
 	ctx context.Context,
-	def client.CollectionDefinition,
 	newDefinitions []client.CollectionDefinition,
-) (client.Collection, error) {
-	schema := def.Schema
-	desc := def.Description
-	txn := mustGetContextTxn(ctx)
-
-	if desc.Name.HasValue() {
-		exists, err := description.HasCollectionByName(ctx, txn, desc.Name.Value())
-		if err != nil {
-			return nil, err
-		}
-		if exists {
-			return nil, ErrCollectionAlreadyExists
-		}
-	}
+) ([]client.CollectionDefinition, error) {
+	returnDescriptions := make([]client.CollectionDefinition, len(newDefinitions))
 
 	existingDefinitions, err := db.getAllActiveDefinitions(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	schemaByName := map[string]client.SchemaDescription{}
-	for _, existingDefinition := range existingDefinitions {
-		schemaByName[existingDefinition.Schema.Name] = existingDefinition.Schema
-	}
-	for _, newDefinition := range newDefinitions {
-		schemaByName[newDefinition.Schema.Name] = newDefinition.Schema
+	for i, def := range newDefinitions {
+		schema := def.Schema
+		txn := mustGetContextTxn(ctx)
+
+		schemaByName := map[string]client.SchemaDescription{}
+		for _, existingDefinition := range existingDefinitions {
+			schemaByName[existingDefinition.Schema.Name] = existingDefinition.Schema
+		}
+		for _, newDefinition := range newDefinitions {
+			schemaByName[newDefinition.Schema.Name] = newDefinition.Schema
+		}
+
+		_, err = validateUpdateSchemaFields(schemaByName, client.SchemaDescription{}, schema)
+		if err != nil {
+			return nil, err
+		}
+
+		schema, err = description.CreateSchemaVersion(ctx, txn, schema)
+		if err != nil {
+			return nil, err
+		}
+		newDefinitions[i].Description.SchemaVersionID = schema.VersionID
+		newDefinitions[i].Schema = schema
 	}
 
-	_, err = validateUpdateSchemaFields(schemaByName, client.SchemaDescription{}, schema)
-	if err != nil {
-		return nil, err
-	}
+	for _, def := range newDefinitions {
+		// Only accept the schema if policy description is valid, otherwise reject the schema.
+		err := db.validateCollectionDefinitionPolicyDesc(ctx, def.Description.Policy)
+		if err != nil {
+			return nil, err
+		}
 
-	definitionsByName := map[string]client.CollectionDefinition{}
-	for _, existingDefinition := range existingDefinitions {
-		definitionsByName[existingDefinition.GetName()] = existingDefinition
-	}
-	for _, newDefinition := range newDefinitions {
-		definitionsByName[newDefinition.GetName()] = newDefinition
-	}
-	err = db.validateNewCollection(def, definitionsByName)
-	if err != nil {
-		return nil, err
-	}
+		schema := def.Schema
+		desc := def.Description
+		txn := mustGetContextTxn(ctx)
 
-	colSeq, err := db.getSequence(ctx, core.CollectionIDSequenceKey{})
-	if err != nil {
-		return nil, err
-	}
-	colID, err := colSeq.next(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	fieldSeq, err := db.getSequence(ctx, core.NewFieldIDSequenceKey(uint32(colID)))
-	if err != nil {
-		return nil, err
-	}
-
-	desc.ID = uint32(colID)
-	desc.RootID = desc.ID
-
-	schema, err = description.CreateSchemaVersion(ctx, txn, schema)
-	if err != nil {
-		return nil, err
-	}
-	desc.SchemaVersionID = schema.VersionID
-	for _, localField := range desc.Fields {
-		var fieldID uint64
-		if localField.Name == request.DocIDFieldName {
-			// There is no hard technical requirement for this, we just think it looks nicer
-			// if the doc id is at the zero index.  It makes it look a little nicer in commit
-			// queries too.
-			fieldID = 0
-		} else {
-			fieldID, err = fieldSeq.next(ctx)
+		if desc.Name.HasValue() {
+			exists, err := description.HasCollectionByName(ctx, txn, desc.Name.Value())
 			if err != nil {
+				return nil, err
+			}
+			if exists {
+				return nil, ErrCollectionAlreadyExists
+			}
+		}
+
+		definitionsByName := map[string]client.CollectionDefinition{}
+		for _, existingDefinition := range existingDefinitions {
+			definitionsByName[existingDefinition.GetName()] = existingDefinition
+		}
+		for _, newDefinition := range newDefinitions {
+			definitionsByName[newDefinition.GetName()] = newDefinition
+		}
+		err = db.validateNewCollection(def, definitionsByName)
+		if err != nil {
+			return nil, err
+		}
+
+		colSeq, err := db.getSequence(ctx, core.CollectionIDSequenceKey{})
+		if err != nil {
+			return nil, err
+		}
+		colID, err := colSeq.next(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		fieldSeq, err := db.getSequence(ctx, core.NewFieldIDSequenceKey(uint32(colID)))
+		if err != nil {
+			return nil, err
+		}
+
+		desc.ID = uint32(colID)
+		desc.RootID = desc.ID
+
+		for _, localField := range desc.Fields {
+			var fieldID uint64
+			if localField.Name == request.DocIDFieldName {
+				// There is no hard technical requirement for this, we just think it looks nicer
+				// if the doc id is at the zero index.  It makes it look a little nicer in commit
+				// queries too.
+				fieldID = 0
+			} else {
+				fieldID, err = fieldSeq.next(ctx)
+				if err != nil {
+					return nil, err
+				}
+			}
+
+			for i := range desc.Fields {
+				if desc.Fields[i].Name == localField.Name {
+					desc.Fields[i].ID = client.FieldID(fieldID)
+					break
+				}
+			}
+		}
+
+		desc, err = description.SaveCollection(ctx, txn, desc)
+		if err != nil {
+			return nil, err
+		}
+
+		col := db.newCollection(desc, schema)
+
+		for _, index := range desc.Indexes {
+			if _, err := col.createIndex(ctx, index); err != nil {
 				return nil, err
 			}
 		}
 
-		for i := range desc.Fields {
-			if desc.Fields[i].Name == localField.Name {
-				desc.Fields[i].ID = client.FieldID(fieldID)
-				break
-			}
-		}
-	}
-
-	desc, err = description.SaveCollection(ctx, txn, desc)
-	if err != nil {
-		return nil, err
-	}
-
-	col := db.newCollection(desc, schema)
-
-	for _, index := range desc.Indexes {
-		if _, err := col.createIndex(ctx, index); err != nil {
+		result, err := db.getCollectionByID(ctx, desc.ID)
+		if err != nil {
 			return nil, err
 		}
+
+		returnDescriptions = append(returnDescriptions, result.Definition())
 	}
 
-	return db.getCollectionByID(ctx, desc.ID)
+	return returnDescriptions, nil
 }
 
 func (db *db) patchCollection(

--- a/internal/db/collection_define.go
+++ b/internal/db/collection_define.go
@@ -129,7 +129,7 @@ func (db *db) createCollections(
 			}
 		}
 
-		err = db.validateNewCollection(def, definitionsByName)
+		err = db.validateNewCollection(ctx, definitionsByName)
 		if err != nil {
 			return nil, err
 		}
@@ -195,7 +195,7 @@ func (db *db) patchCollection(
 		return err
 	}
 
-	err = db.validateCollectionChanges(existingColsByID, newColsByID)
+	err = db.validateCollectionChanges(ctx, cols, newColsByID)
 	if err != nil {
 		return err
 	}

--- a/internal/db/collection_define.go
+++ b/internal/db/collection_define.go
@@ -48,11 +48,6 @@ func (db *db) createCollections(
 			schemaByName[newDefinition.Schema.Name] = newDefinition.Schema
 		}
 
-		_, err = validateUpdateSchemaFields(schemaByName, client.SchemaDescription{}, schema)
-		if err != nil {
-			return nil, err
-		}
-
 		schema, err = description.CreateSchemaVersion(ctx, txn, schema)
 		if err != nil {
 			return nil, err

--- a/internal/db/collection_define.go
+++ b/internal/db/collection_define.go
@@ -89,10 +89,6 @@ func (db *db) createCollections(
 		for _, newDefinition := range newDefinitions {
 			definitionsByName[newDefinition.GetName()] = newDefinition
 		}
-		err = db.validateNewCollection(def, definitionsByName)
-		if err != nil {
-			return nil, err
-		}
 
 		colSeq, err := db.getSequence(ctx, core.CollectionIDSequenceKey{})
 		if err != nil {
@@ -131,6 +127,11 @@ func (db *db) createCollections(
 					break
 				}
 			}
+		}
+
+		err = db.validateNewCollection(def, definitionsByName)
+		if err != nil {
+			return nil, err
 		}
 
 		desc, err = description.SaveCollection(ctx, txn, desc)

--- a/internal/db/collection_define.go
+++ b/internal/db/collection_define.go
@@ -62,12 +62,6 @@ func (db *db) createCollections(
 	}
 
 	for _, def := range newDefinitions {
-		// Only accept the schema if policy description is valid, otherwise reject the schema.
-		err := db.validateCollectionDefinitionPolicyDesc(ctx, def.Description.Policy)
-		if err != nil {
-			return nil, err
-		}
-
 		schema := def.Schema
 		desc := def.Description
 		txn := mustGetContextTxn(ctx)

--- a/internal/db/collection_define.go
+++ b/internal/db/collection_define.go
@@ -37,7 +37,6 @@ func (db *db) createCollections(
 	}
 
 	for i, def := range newDefinitions {
-		schema := def.Schema
 		txn := mustGetContextTxn(ctx)
 
 		schemaByName := map[string]client.SchemaDescription{}
@@ -48,7 +47,7 @@ func (db *db) createCollections(
 			schemaByName[newDefinition.Schema.Name] = newDefinition.Schema
 		}
 
-		schema, err = description.CreateSchemaVersion(ctx, txn, schema)
+		schema, err := description.CreateSchemaVersion(ctx, txn, def.Schema)
 		if err != nil {
 			return nil, err
 		}
@@ -57,7 +56,6 @@ func (db *db) createCollections(
 	}
 
 	for _, def := range newDefinitions {
-		schema := def.Schema
 		desc := def.Description
 		txn := mustGetContextTxn(ctx)
 
@@ -128,7 +126,7 @@ func (db *db) createCollections(
 			return nil, err
 		}
 
-		col := db.newCollection(desc, schema)
+		col := db.newCollection(desc, def.Schema)
 
 		for _, index := range desc.Indexes {
 			if _, err := col.createIndex(ctx, index); err != nil {

--- a/internal/db/definition_validation.go
+++ b/internal/db/definition_validation.go
@@ -237,6 +237,20 @@ func validateRelationPointsToValidKind(
 		}
 	}
 
+	for _, schema := range newState.schemaByName {
+		for _, field := range schema.Fields {
+			if !field.Kind.IsObject() {
+				continue
+			}
+
+			underlying := field.Kind.Underlying()
+			_, ok := newState.definitionsByName[underlying]
+			if !ok {
+				return NewErrFieldKindNotFound(field.Name, underlying)
+			}
+		}
+	}
+
 	return nil
 }
 
@@ -728,14 +742,6 @@ func validateUpdateSchemaFields(
 
 		// If the field is new, then the collection has changed
 		hasChanged = hasChanged || !fieldAlreadyExists
-
-		if !fieldAlreadyExists && proposedField.Kind.IsObject() {
-			_, relatedDescFound := descriptionsByName[proposedField.Kind.Underlying()]
-
-			if !relatedDescFound {
-				return false, NewErrFieldKindNotFound(proposedField.Name, proposedField.Kind.Underlying())
-			}
-		}
 
 		newFieldNames[proposedField.Name] = struct{}{}
 	}

--- a/internal/db/definition_validation.go
+++ b/internal/db/definition_validation.go
@@ -592,6 +592,17 @@ func validateRootIDNotMutated(
 		}
 	}
 
+	for _, newSchema := range newState.schemaByName {
+		oldSchema := oldState.schemaByName[newSchema.Name]
+		if newSchema.Root != oldSchema.Root {
+			return NewErrSchemaRootDoesntMatch(
+				newSchema.Name,
+				oldSchema.Root,
+				newSchema.Root,
+			)
+		}
+	}
+
 	return nil
 }
 
@@ -702,14 +713,6 @@ func (db *db) validateUpdateSchema(
 	existingDesc, collectionExists := existingDescriptionsByName[proposedDesc.Name]
 	if !collectionExists {
 		return false, NewErrAddCollectionWithPatch(proposedDesc.Name)
-	}
-
-	if proposedDesc.Root != existingDesc.Root {
-		return false, NewErrSchemaRootDoesntMatch(
-			proposedDesc.Name,
-			existingDesc.Root,
-			proposedDesc.Root,
-		)
 	}
 
 	hasChangedFields, err := validateUpdateSchemaFields(proposedDescriptionsByName, existingDesc, proposedDesc)

--- a/internal/db/definition_validation.go
+++ b/internal/db/definition_validation.go
@@ -699,51 +699,6 @@ func validateCollectionDefinitionPolicyDesc(
 	return nil
 }
 
-// validateUpdateSchema validates that the given schema description is a valid update.
-//
-// Will return true if the given description differs from the current persisted state of the
-// schema. Will return an error if it fails validation.
-func (db *db) validateUpdateSchema(
-	existingDescriptionsByName map[string]client.SchemaDescription,
-	proposedDescriptionsByName map[string]client.SchemaDescription,
-	proposedDesc client.SchemaDescription,
-) (bool, error) {
-	existingDesc := existingDescriptionsByName[proposedDesc.Name]
-
-	hasChangedFields, err := validateUpdateSchemaFields(proposedDescriptionsByName, existingDesc, proposedDesc)
-	if err != nil {
-		return hasChangedFields, err
-	}
-
-	return hasChangedFields, err
-}
-
-func validateUpdateSchemaFields(
-	descriptionsByName map[string]client.SchemaDescription,
-	existingDesc client.SchemaDescription,
-	proposedDesc client.SchemaDescription,
-) (bool, error) {
-	hasChanged := false
-	existingFieldsByName := map[string]client.SchemaFieldDescription{}
-	existingFieldIndexesByName := map[string]int{}
-	for i, field := range existingDesc.Fields {
-		existingFieldIndexesByName[field.Name] = i
-		existingFieldsByName[field.Name] = field
-	}
-
-	newFieldNames := map[string]struct{}{}
-	for _, proposedField := range proposedDesc.Fields {
-		_, fieldAlreadyExists := existingFieldsByName[proposedField.Name]
-
-		// If the field is new, then the collection has changed
-		hasChanged = hasChanged || !fieldAlreadyExists
-
-		newFieldNames[proposedField.Name] = struct{}{}
-	}
-
-	return hasChanged, nil
-}
-
 func validateSchemaFieldNotDeleted(
 	ctx context.Context,
 	db *db,

--- a/internal/db/definition_validation.go
+++ b/internal/db/definition_validation.go
@@ -704,12 +704,6 @@ func (db *db) validateUpdateSchema(
 		)
 	}
 
-	if proposedDesc.Name != existingDesc.Name {
-		// There is actually little reason to not support this atm besides controlling the surface area
-		// of the new feature.  Changing this should not break anything, but it should be tested first.
-		return false, NewErrCannotModifySchemaName(existingDesc.Name, proposedDesc.Name)
-	}
-
 	if proposedDesc.VersionID != "" && proposedDesc.VersionID != existingDesc.VersionID {
 		// If users specify this it will be overwritten, an error is preferred to quietly ignoring it.
 		return false, ErrCannotSetVersionID

--- a/internal/db/definition_validation.go
+++ b/internal/db/definition_validation.go
@@ -119,6 +119,7 @@ var globalValidators = []definitionValidator{
 	validateSecondaryFieldsPairUp,
 	validateSingleSidePrimary,
 	validateCollectionDefinitionPolicyDesc,
+	validateSecondaryNotOnSchema,
 	validateTypeSupported,
 	validateTypeAndKindCompatible,
 	validateFieldNotDuplicated,
@@ -745,10 +746,6 @@ func validateUpdateSchemaFields(
 			}
 		}
 
-		if proposedField.Kind.IsObjectArray() {
-			return false, NewErrSecondaryFieldOnSchema(proposedField.Name)
-		}
-
 		newFieldNames[proposedField.Name] = struct{}{}
 	}
 
@@ -879,6 +876,23 @@ func validateFieldNotDuplicated(
 				return NewErrDuplicateField(field.Name)
 			}
 			fieldNames[field.Name] = struct{}{}
+		}
+	}
+
+	return nil
+}
+
+func validateSecondaryNotOnSchema(
+	ctx context.Context,
+	db *db,
+	newState *definitionState,
+	oldState *definitionState,
+) error {
+	for _, newSchema := range newState.schemaByName {
+		for _, newField := range newSchema.Fields {
+			if newField.Kind.IsObjectArray() {
+				return NewErrSecondaryFieldOnSchema(newField.Name)
+			}
 		}
 	}
 

--- a/internal/db/definition_validation.go
+++ b/internal/db/definition_validation.go
@@ -51,8 +51,8 @@ func (db *db) validateCollectionChanges(
 	oldColsByID map[uint32]client.CollectionDescription,
 	newColsByID map[uint32]client.CollectionDescription,
 ) error {
-	for _, validators := range patchCollectionValidators {
-		err := validators(oldColsByID, newColsByID)
+	for _, validator := range patchCollectionValidators {
+		err := validator(oldColsByID, newColsByID)
 		if err != nil {
 			return err
 		}
@@ -65,8 +65,8 @@ func (db *db) validateNewCollection(
 	def client.CollectionDefinition,
 	defsByName map[string]client.CollectionDefinition,
 ) error {
-	for _, validators := range newCollectionValidators {
-		err := validators(def, defsByName)
+	for _, validator := range newCollectionValidators {
+		err := validator(def, defsByName)
 		if err != nil {
 			return err
 		}

--- a/internal/db/definition_validation.go
+++ b/internal/db/definition_validation.go
@@ -612,6 +612,14 @@ func validateSchemaVersionIDNotMutated(
 		}
 	}
 
+	for _, newSchema := range newState.schemaByName {
+		oldSchema := oldState.schemaByName[newSchema.Name]
+		if newSchema.VersionID != "" && newSchema.VersionID != oldSchema.VersionID {
+			// If users specify this it will be overwritten, an error is preferred to quietly ignoring it.
+			return ErrCannotSetVersionID
+		}
+	}
+
 	return nil
 }
 
@@ -702,11 +710,6 @@ func (db *db) validateUpdateSchema(
 			existingDesc.Root,
 			proposedDesc.Root,
 		)
-	}
-
-	if proposedDesc.VersionID != "" && proposedDesc.VersionID != existingDesc.VersionID {
-		// If users specify this it will be overwritten, an error is preferred to quietly ignoring it.
-		return false, ErrCannotSetVersionID
 	}
 
 	hasChangedFields, err := validateUpdateSchemaFields(proposedDescriptionsByName, existingDesc, proposedDesc)

--- a/internal/db/definition_validation.go
+++ b/internal/db/definition_validation.go
@@ -120,6 +120,7 @@ var globalValidators = []definitionValidator{
 	validateSecondaryFieldsPairUp,
 	validateSingleSidePrimary,
 	validateCollectionDefinitionPolicyDesc,
+	validateSchemaNameNotEmpty,
 	validateRelationalFieldIDType,
 	validateSecondaryNotOnSchema,
 	validateTypeSupported,
@@ -707,10 +708,6 @@ func (db *db) validateUpdateSchema(
 	proposedDescriptionsByName map[string]client.SchemaDescription,
 	proposedDesc client.SchemaDescription,
 ) (bool, error) {
-	if proposedDesc.Name == "" {
-		return false, ErrSchemaNameEmpty
-	}
-
 	existingDesc := existingDescriptionsByName[proposedDesc.Name]
 
 	hasChangedFields, err := validateUpdateSchemaFields(proposedDescriptionsByName, existingDesc, proposedDesc)
@@ -932,6 +929,21 @@ func validateSchemaNotAdded(
 	for _, newSchema := range newState.schemaByName {
 		if _, exists := oldState.schemaByName[newSchema.Name]; !exists {
 			return NewErrAddSchemaWithPatch(newSchema.Name)
+		}
+	}
+
+	return nil
+}
+
+func validateSchemaNameNotEmpty(
+	ctx context.Context,
+	db *db,
+	newState *definitionState,
+	oldState *definitionState,
+) error {
+	for _, schema := range newState.schemaByName {
+		if schema.Name == "" {
+			return ErrSchemaNameEmpty
 		}
 	}
 

--- a/internal/db/errors.go
+++ b/internal/db/errors.go
@@ -26,7 +26,6 @@ const (
 	errAddCollectionWithPatch                   string = "adding collections via patch is not supported"
 	errCollectionIDDoesntMatch                  string = "CollectionID does not match existing"
 	errSchemaRootDoesntMatch                    string = "SchemaRoot does not match existing"
-	errCannotModifySchemaName                   string = "modifying the schema name is not supported"
 	errCannotSetVersionID                       string = "setting the VersionID is not supported"
 	errRelationalFieldInvalidRelationType       string = "invalid RelationType"
 	errRelationalFieldMissingIDField            string = "missing id field for relation object field"
@@ -253,14 +252,6 @@ func NewErrSchemaRootDoesntMatch(name, existingRoot, proposedRoot string) error 
 		errors.NewKV("Name", name),
 		errors.NewKV("ExistingRoot", existingRoot),
 		errors.NewKV("ProposedRoot", proposedRoot),
-	)
-}
-
-func NewErrCannotModifySchemaName(existingName, proposedName string) error {
-	return errors.New(
-		errCannotModifySchemaName,
-		errors.NewKV("ExistingName", existingName),
-		errors.NewKV("ProposedName", proposedName),
 	)
 }
 

--- a/internal/db/errors.go
+++ b/internal/db/errors.go
@@ -24,6 +24,7 @@ const (
 	errAddingP2PCollection                      string = "cannot add collection ID"
 	errRemovingP2PCollection                    string = "cannot remove collection ID"
 	errAddCollectionWithPatch                   string = "adding collections via patch is not supported"
+	errAddSchemaWithPatch                       string = "adding schema via patch is not supported"
 	errCollectionIDDoesntMatch                  string = "CollectionID does not match existing"
 	errSchemaRootDoesntMatch                    string = "SchemaRoot does not match existing"
 	errCannotSetVersionID                       string = "setting the VersionID is not supported"
@@ -223,9 +224,9 @@ func NewErrRemovingP2PCollection(inner error) error {
 	return errors.Wrap(errRemovingP2PCollection, inner)
 }
 
-func NewErrAddCollectionWithPatch(name string) error {
+func NewErrAddSchemaWithPatch(name string) error {
 	return errors.New(
-		errAddCollectionWithPatch,
+		errAddSchemaWithPatch,
 		errors.NewKV("Name", name),
 	)
 }

--- a/internal/db/schema.go
+++ b/internal/db/schema.go
@@ -336,21 +336,16 @@ func (db *db) updateSchema(
 	migration immutable.Option[model.Lens],
 	setAsActiveVersion bool,
 ) error {
-	hasChanged, err := db.validateUpdateSchema(
-		existingSchemaByName,
-		proposedDescriptionsByName,
-		schema,
-	)
-	if err != nil {
-		return err
-	}
-	err = db.validateSchemaUpdate(ctx, proposedDescriptionsByName, existingSchemaByName)
-	if err != nil {
-		return err
+	previousSchema := existingSchemaByName[schema.Name]
+
+	areEqual := areSchemasEqual(schema, previousSchema)
+	if areEqual {
+		return nil
 	}
 
-	if !hasChanged {
-		return nil
+	err := db.validateSchemaUpdate(ctx, proposedDescriptionsByName, existingSchemaByName)
+	if err != nil {
+		return err
 	}
 
 	for _, field := range schema.Fields {
@@ -365,7 +360,6 @@ func (db *db) updateSchema(
 		}
 	}
 
-	previousSchema := existingSchemaByName[schema.Name]
 	previousFieldNames := make(map[string]struct{}, len(previousSchema.Fields))
 	for _, field := range previousSchema.Fields {
 		previousFieldNames[field.Name] = struct{}{}
@@ -528,4 +522,20 @@ func (db *db) updateSchema(
 	}
 
 	return nil
+}
+
+func areSchemasEqual(this client.SchemaDescription, that client.SchemaDescription) bool {
+	if len(this.Fields) != len(that.Fields) {
+		return false
+	}
+
+	for i, thisField := range this.Fields {
+		if thisField != that.Fields[i] {
+			return false
+		}
+	}
+
+	return this.Name == that.Name &&
+		this.Root == that.Root &&
+		this.VersionID == that.VersionID
 }

--- a/internal/db/schema.go
+++ b/internal/db/schema.go
@@ -366,8 +366,14 @@ func (db *db) updateSchema(
 		}
 	}
 
+	previousSchema := existingSchemaByName[schema.Name]
+	previousFieldNames := make(map[string]struct{}, len(previousSchema.Fields))
+	for _, field := range previousSchema.Fields {
+		previousFieldNames[field.Name] = struct{}{}
+	}
+
 	for i, field := range schema.Fields {
-		if field.Typ == client.NONE_CRDT {
+		if _, existed := previousFieldNames[field.Name]; !existed && field.Typ == client.NONE_CRDT {
 			// If no CRDT Type has been provided, default to LWW_REGISTER.
 			field.Typ = client.LWW_REGISTER
 			schema.Fields[i] = field

--- a/internal/db/schema.go
+++ b/internal/db/schema.go
@@ -344,6 +344,10 @@ func (db *db) updateSchema(
 	if err != nil {
 		return err
 	}
+	err = db.validateSchemaUpdate(ctx, proposedDescriptionsByName, existingSchemaByName)
+	if err != nil {
+		return err
+	}
 
 	if !hasChanged {
 		return nil

--- a/internal/db/schema.go
+++ b/internal/db/schema.go
@@ -44,19 +44,14 @@ func (db *db) addSchema(
 		return nil, err
 	}
 
-	returnDescriptions := make([]client.CollectionDescription, len(newDefinitions))
-	for i, definition := range newDefinitions {
-		// Only accept the schema if policy description is valid, otherwise reject the schema.
-		err := db.validateCollectionDefinitionPolicyDesc(ctx, definition.Description.Policy)
-		if err != nil {
-			return nil, err
-		}
+	returnDefinitions, err := db.createCollections(ctx, newDefinitions)
+	if err != nil {
+		return nil, err
+	}
 
-		col, err := db.createCollection(ctx, definition, newDefinitions)
-		if err != nil {
-			return nil, err
-		}
-		returnDescriptions[i] = col.Description()
+	returnDescriptions := make([]client.CollectionDescription, len(returnDefinitions))
+	for i, def := range returnDefinitions {
+		returnDescriptions[i] = def.Description
 	}
 
 	err = db.loadSchema(ctx)

--- a/tests/integration/collection_description/updates/copy/name_test.go
+++ b/tests/integration/collection_description/updates/copy/name_test.go
@@ -40,7 +40,7 @@ func TestColDescrUpdateCopyName_Errors(t *testing.T) {
 						{ "op": "copy", "from": "/1/Name", "path": "/2/Name" }
 					]
 				`,
-				ExpectedError: "collection already exists. Name: Users",
+				ExpectedError: "multiple versions of same collection cannot be active. Name: Users, Root: 1",
 			},
 		},
 	}

--- a/tests/integration/collection_description/updates/replace/name_test.go
+++ b/tests/integration/collection_description/updates/replace/name_test.go
@@ -99,7 +99,7 @@ func TestColDescrUpdateReplaceName_GivenInactiveCollectionWithSameName_Errors(t 
 						{ "op": "replace", "path": "/2/Name", "value": "Users" }
 					]
 				`,
-				ExpectedError: "collection already exists. Name: Users",
+				ExpectedError: "multiple versions of same collection cannot be active. Name: Users, Root: 1",
 			},
 		},
 	}

--- a/tests/integration/schema/get_schema_test.go
+++ b/tests/integration/schema/get_schema_test.go
@@ -72,7 +72,7 @@ func TestGetSchema_GivenNoSchemaGivenUnknownName(t *testing.T) {
 
 func TestGetSchema_ReturnsAllSchema(t *testing.T) {
 	usersSchemaVersion1ID := "bafkreia2jn5ecrhtvy4fravk6pm3wqiny46m7mqymvjkgat7xiqupgqoai"
-	usersSchemaVersion2ID := "bafkreibbsqjeladin2keszmja5kektzgi4eowb6m3oimxssiqge7mmvhva"
+	usersSchemaVersion2ID := "bafkreialnju2rez4t3quvpobf3463eai3lo64vdrdhdmunz7yy7sv3f5ce"
 	booksSchemaVersion1ID := "bafkreibiu34zrehpq346pwp5z24qkderm7ibhnpcqalhkivhnf5e2afqoy"
 
 	test := testUtils.TestCase{
@@ -116,7 +116,7 @@ func TestGetSchema_ReturnsAllSchema(t *testing.T) {
 							{
 								Name: "_docID",
 								Kind: client.FieldKind_DocID,
-								Typ:  client.LWW_REGISTER,
+								Typ:  client.NONE_CRDT,
 							},
 							{
 								Name: "name",
@@ -146,7 +146,7 @@ func TestGetSchema_ReturnsAllSchema(t *testing.T) {
 
 func TestGetSchema_ReturnsSchemaForGivenRoot(t *testing.T) {
 	usersSchemaVersion1ID := "bafkreia2jn5ecrhtvy4fravk6pm3wqiny46m7mqymvjkgat7xiqupgqoai"
-	usersSchemaVersion2ID := "bafkreibbsqjeladin2keszmja5kektzgi4eowb6m3oimxssiqge7mmvhva"
+	usersSchemaVersion2ID := "bafkreialnju2rez4t3quvpobf3463eai3lo64vdrdhdmunz7yy7sv3f5ce"
 
 	test := testUtils.TestCase{
 		Actions: []any{
@@ -190,7 +190,7 @@ func TestGetSchema_ReturnsSchemaForGivenRoot(t *testing.T) {
 							{
 								Name: "_docID",
 								Kind: client.FieldKind_DocID,
-								Typ:  client.LWW_REGISTER,
+								Typ:  client.NONE_CRDT,
 							},
 							{
 								Name: "name",
@@ -209,7 +209,7 @@ func TestGetSchema_ReturnsSchemaForGivenRoot(t *testing.T) {
 
 func TestGetSchema_ReturnsSchemaForGivenName(t *testing.T) {
 	usersSchemaVersion1ID := "bafkreia2jn5ecrhtvy4fravk6pm3wqiny46m7mqymvjkgat7xiqupgqoai"
-	usersSchemaVersion2ID := "bafkreibbsqjeladin2keszmja5kektzgi4eowb6m3oimxssiqge7mmvhva"
+	usersSchemaVersion2ID := "bafkreialnju2rez4t3quvpobf3463eai3lo64vdrdhdmunz7yy7sv3f5ce"
 
 	test := testUtils.TestCase{
 		Actions: []any{
@@ -253,7 +253,7 @@ func TestGetSchema_ReturnsSchemaForGivenName(t *testing.T) {
 							{
 								Name: "_docID",
 								Kind: client.FieldKind_DocID,
-								Typ:  client.LWW_REGISTER,
+								Typ:  client.NONE_CRDT,
 							},
 							{
 								Name: "name",

--- a/tests/integration/schema/migrations/query/simple_test.go
+++ b/tests/integration/schema/migrations/query/simple_test.go
@@ -46,7 +46,7 @@ func TestSchemaMigrationQuery(t *testing.T) {
 			testUtils.ConfigureMigration{
 				LensConfig: client.LensConfig{
 					SourceSchemaVersionID:      "bafkreia3o3cetvcnnxyu5spucimoos77ifungfmacxdkva4zah2is3aooe",
-					DestinationSchemaVersionID: "bafkreib5jaawobqqiu6frzacerlj55pxxxuql3igqj4ldmg2pgilke4bty",
+					DestinationSchemaVersionID: "bafkreiahhaeagyfsxaxmv3d665qvnbtyn3ts6jshhghy5bijwztbe7efpq",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{
@@ -116,7 +116,7 @@ func TestSchemaMigrationQueryMultipleDocs(t *testing.T) {
 			testUtils.ConfigureMigration{
 				LensConfig: client.LensConfig{
 					SourceSchemaVersionID:      "bafkreia3o3cetvcnnxyu5spucimoos77ifungfmacxdkva4zah2is3aooe",
-					DestinationSchemaVersionID: "bafkreib5jaawobqqiu6frzacerlj55pxxxuql3igqj4ldmg2pgilke4bty",
+					DestinationSchemaVersionID: "bafkreiahhaeagyfsxaxmv3d665qvnbtyn3ts6jshhghy5bijwztbe7efpq",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{
@@ -179,7 +179,7 @@ func TestSchemaMigrationQueryWithMigrationRegisteredBeforeSchemaPatch(t *testing
 			testUtils.ConfigureMigration{
 				LensConfig: client.LensConfig{
 					SourceSchemaVersionID:      "bafkreia3o3cetvcnnxyu5spucimoos77ifungfmacxdkva4zah2is3aooe",
-					DestinationSchemaVersionID: "bafkreib5jaawobqqiu6frzacerlj55pxxxuql3igqj4ldmg2pgilke4bty",
+					DestinationSchemaVersionID: "bafkreiahhaeagyfsxaxmv3d665qvnbtyn3ts6jshhghy5bijwztbe7efpq",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{
@@ -255,7 +255,7 @@ func TestSchemaMigrationQueryMigratesToIntermediaryVersion(t *testing.T) {
 				// there should be no migration from version 2 to version 3.
 				LensConfig: client.LensConfig{
 					SourceSchemaVersionID:      "bafkreia3o3cetvcnnxyu5spucimoos77ifungfmacxdkva4zah2is3aooe",
-					DestinationSchemaVersionID: "bafkreib5jaawobqqiu6frzacerlj55pxxxuql3igqj4ldmg2pgilke4bty",
+					DestinationSchemaVersionID: "bafkreiahhaeagyfsxaxmv3d665qvnbtyn3ts6jshhghy5bijwztbe7efpq",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{
@@ -325,8 +325,8 @@ func TestSchemaMigrationQueryMigratesFromIntermediaryVersion(t *testing.T) {
 				// Register a migration from schema version 2 to schema version 3 **only** -
 				// there should be no migration from version 1 to version 2.
 				LensConfig: client.LensConfig{
-					SourceSchemaVersionID:      "bafkreib5jaawobqqiu6frzacerlj55pxxxuql3igqj4ldmg2pgilke4bty",
-					DestinationSchemaVersionID: "bafkreib65lld2tdyvlilbumlcccftqwvflpgutugghf5afrnlhdg7dgyv4",
+					SourceSchemaVersionID:      "bafkreiahhaeagyfsxaxmv3d665qvnbtyn3ts6jshhghy5bijwztbe7efpq",
+					DestinationSchemaVersionID: "bafkreicpdtq27uclgcyeqivvyjvojtk57a573y3upfhi3lvteytktyhlva",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{
@@ -395,7 +395,7 @@ func TestSchemaMigrationQueryMigratesAcrossMultipleVersions(t *testing.T) {
 			testUtils.ConfigureMigration{
 				LensConfig: client.LensConfig{
 					SourceSchemaVersionID:      "bafkreia3o3cetvcnnxyu5spucimoos77ifungfmacxdkva4zah2is3aooe",
-					DestinationSchemaVersionID: "bafkreib5jaawobqqiu6frzacerlj55pxxxuql3igqj4ldmg2pgilke4bty",
+					DestinationSchemaVersionID: "bafkreiahhaeagyfsxaxmv3d665qvnbtyn3ts6jshhghy5bijwztbe7efpq",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{
@@ -411,8 +411,8 @@ func TestSchemaMigrationQueryMigratesAcrossMultipleVersions(t *testing.T) {
 			},
 			testUtils.ConfigureMigration{
 				LensConfig: client.LensConfig{
-					SourceSchemaVersionID:      "bafkreib5jaawobqqiu6frzacerlj55pxxxuql3igqj4ldmg2pgilke4bty",
-					DestinationSchemaVersionID: "bafkreib65lld2tdyvlilbumlcccftqwvflpgutugghf5afrnlhdg7dgyv4",
+					SourceSchemaVersionID:      "bafkreiahhaeagyfsxaxmv3d665qvnbtyn3ts6jshhghy5bijwztbe7efpq",
+					DestinationSchemaVersionID: "bafkreicpdtq27uclgcyeqivvyjvojtk57a573y3upfhi3lvteytktyhlva",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{
@@ -467,7 +467,7 @@ func TestSchemaMigrationQueryMigratesAcrossMultipleVersionsBeforePatches(t *test
 			testUtils.ConfigureMigration{
 				LensConfig: client.LensConfig{
 					SourceSchemaVersionID:      "bafkreia3o3cetvcnnxyu5spucimoos77ifungfmacxdkva4zah2is3aooe",
-					DestinationSchemaVersionID: "bafkreib5jaawobqqiu6frzacerlj55pxxxuql3igqj4ldmg2pgilke4bty",
+					DestinationSchemaVersionID: "bafkreiahhaeagyfsxaxmv3d665qvnbtyn3ts6jshhghy5bijwztbe7efpq",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{
@@ -483,8 +483,8 @@ func TestSchemaMigrationQueryMigratesAcrossMultipleVersionsBeforePatches(t *test
 			},
 			testUtils.ConfigureMigration{
 				LensConfig: client.LensConfig{
-					SourceSchemaVersionID:      "bafkreib5jaawobqqiu6frzacerlj55pxxxuql3igqj4ldmg2pgilke4bty",
-					DestinationSchemaVersionID: "bafkreib65lld2tdyvlilbumlcccftqwvflpgutugghf5afrnlhdg7dgyv4",
+					SourceSchemaVersionID:      "bafkreiahhaeagyfsxaxmv3d665qvnbtyn3ts6jshhghy5bijwztbe7efpq",
+					DestinationSchemaVersionID: "bafkreicpdtq27uclgcyeqivvyjvojtk57a573y3upfhi3lvteytktyhlva",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{
@@ -553,8 +553,8 @@ func TestSchemaMigrationQueryMigratesAcrossMultipleVersionsBeforePatchesWrongOrd
 			testUtils.ConfigureMigration{
 				// Declare the migration from v2=>v3 before declaring the migration from v1=>v2
 				LensConfig: client.LensConfig{
-					SourceSchemaVersionID:      "bafkreib5jaawobqqiu6frzacerlj55pxxxuql3igqj4ldmg2pgilke4bty",
-					DestinationSchemaVersionID: "bafkreib65lld2tdyvlilbumlcccftqwvflpgutugghf5afrnlhdg7dgyv4",
+					SourceSchemaVersionID:      "bafkreiahhaeagyfsxaxmv3d665qvnbtyn3ts6jshhghy5bijwztbe7efpq",
+					DestinationSchemaVersionID: "bafkreicpdtq27uclgcyeqivvyjvojtk57a573y3upfhi3lvteytktyhlva",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{
@@ -571,7 +571,7 @@ func TestSchemaMigrationQueryMigratesAcrossMultipleVersionsBeforePatchesWrongOrd
 			testUtils.ConfigureMigration{
 				LensConfig: client.LensConfig{
 					SourceSchemaVersionID:      "bafkreia3o3cetvcnnxyu5spucimoos77ifungfmacxdkva4zah2is3aooe",
-					DestinationSchemaVersionID: "bafkreib5jaawobqqiu6frzacerlj55pxxxuql3igqj4ldmg2pgilke4bty",
+					DestinationSchemaVersionID: "bafkreiahhaeagyfsxaxmv3d665qvnbtyn3ts6jshhghy5bijwztbe7efpq",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{
@@ -713,7 +713,7 @@ func TestSchemaMigrationQueryMigrationMutatesExistingScalarField(t *testing.T) {
 			testUtils.ConfigureMigration{
 				LensConfig: client.LensConfig{
 					SourceSchemaVersionID:      "bafkreia3o3cetvcnnxyu5spucimoos77ifungfmacxdkva4zah2is3aooe",
-					DestinationSchemaVersionID: "bafkreib5jaawobqqiu6frzacerlj55pxxxuql3igqj4ldmg2pgilke4bty",
+					DestinationSchemaVersionID: "bafkreiahhaeagyfsxaxmv3d665qvnbtyn3ts6jshhghy5bijwztbe7efpq",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{
@@ -774,7 +774,7 @@ func TestSchemaMigrationQueryMigrationMutatesExistingInlineArrayField(t *testing
 			testUtils.ConfigureMigration{
 				LensConfig: client.LensConfig{
 					SourceSchemaVersionID:      "bafkreicn6ltdovb6y7g3ecoptqkvx2y5y5yntrb5uydmg3jiakskqva2ta",
-					DestinationSchemaVersionID: "bafkreifv4vhz3dw7upc5u3omsqi6klz3h3e54ogfskp72gtut62fuxqrcu",
+					DestinationSchemaVersionID: "bafkreigb473jarbms7de62ykdu5necvxukmb6zbzolp4szdjcwzjvomuiq",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{
@@ -837,7 +837,7 @@ func TestSchemaMigrationQueryMigrationRemovesExistingField(t *testing.T) {
 			testUtils.ConfigureMigration{
 				LensConfig: client.LensConfig{
 					SourceSchemaVersionID:      "bafkreihhd6bqrjhl5zidwztgxzeseveplv3cj3fwtn3unjkdx7j2vr2vrq",
-					DestinationSchemaVersionID: "bafkreiegvk3fkcjxoqqpp7npxqjdjwijiwthvynzmsvtzajpjevgu2krku",
+					DestinationSchemaVersionID: "bafkreibbnm7nrtnvwo7hmjjxacx7nxlqkp6bfr24vtlbv5vhwttlhrbr4q",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{
@@ -898,7 +898,7 @@ func TestSchemaMigrationQueryMigrationPreservesExistingFieldWhenFieldNotRequeste
 			testUtils.ConfigureMigration{
 				LensConfig: client.LensConfig{
 					SourceSchemaVersionID:      "bafkreihhd6bqrjhl5zidwztgxzeseveplv3cj3fwtn3unjkdx7j2vr2vrq",
-					DestinationSchemaVersionID: "bafkreiegvk3fkcjxoqqpp7npxqjdjwijiwthvynzmsvtzajpjevgu2krku",
+					DestinationSchemaVersionID: "bafkreibbnm7nrtnvwo7hmjjxacx7nxlqkp6bfr24vtlbv5vhwttlhrbr4q",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{
@@ -972,7 +972,7 @@ func TestSchemaMigrationQueryMigrationCopiesExistingFieldWhenSrcFieldNotRequeste
 			testUtils.ConfigureMigration{
 				LensConfig: client.LensConfig{
 					SourceSchemaVersionID:      "bafkreihhd6bqrjhl5zidwztgxzeseveplv3cj3fwtn3unjkdx7j2vr2vrq",
-					DestinationSchemaVersionID: "bafkreidgnuvanzqur3pkp4mmrd77ojwvov2rlczraaks4435e6wsgxpwoq",
+					DestinationSchemaVersionID: "bafkreifhm3admsxmv3xsbxehfkmtfnxqaq5wchrx47e7zc6vaxr352b3om",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{
@@ -1034,7 +1034,7 @@ func TestSchemaMigrationQueryMigrationCopiesExistingFieldWhenSrcAndDstFieldNotRe
 			testUtils.ConfigureMigration{
 				LensConfig: client.LensConfig{
 					SourceSchemaVersionID:      "bafkreihhd6bqrjhl5zidwztgxzeseveplv3cj3fwtn3unjkdx7j2vr2vrq",
-					DestinationSchemaVersionID: "bafkreidgnuvanzqur3pkp4mmrd77ojwvov2rlczraaks4435e6wsgxpwoq",
+					DestinationSchemaVersionID: "bafkreifhm3admsxmv3xsbxehfkmtfnxqaq5wchrx47e7zc6vaxr352b3om",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{

--- a/tests/integration/schema/migrations/query/with_doc_id_test.go
+++ b/tests/integration/schema/migrations/query/with_doc_id_test.go
@@ -53,7 +53,7 @@ func TestSchemaMigrationQueryByDocID(t *testing.T) {
 			testUtils.ConfigureMigration{
 				LensConfig: client.LensConfig{
 					SourceSchemaVersionID:      "bafkreia3o3cetvcnnxyu5spucimoos77ifungfmacxdkva4zah2is3aooe",
-					DestinationSchemaVersionID: "bafkreib5jaawobqqiu6frzacerlj55pxxxuql3igqj4ldmg2pgilke4bty",
+					DestinationSchemaVersionID: "bafkreiahhaeagyfsxaxmv3d665qvnbtyn3ts6jshhghy5bijwztbe7efpq",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{
@@ -159,7 +159,7 @@ func TestSchemaMigrationQueryMultipleQueriesByDocID(t *testing.T) {
 			testUtils.ConfigureMigration{
 				LensConfig: client.LensConfig{
 					SourceSchemaVersionID:      "bafkreia3o3cetvcnnxyu5spucimoos77ifungfmacxdkva4zah2is3aooe",
-					DestinationSchemaVersionID: "bafkreib5jaawobqqiu6frzacerlj55pxxxuql3igqj4ldmg2pgilke4bty",
+					DestinationSchemaVersionID: "bafkreiahhaeagyfsxaxmv3d665qvnbtyn3ts6jshhghy5bijwztbe7efpq",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{

--- a/tests/integration/schema/migrations/query/with_inverse_test.go
+++ b/tests/integration/schema/migrations/query/with_inverse_test.go
@@ -50,7 +50,7 @@ func TestSchemaMigrationQueryInversesAcrossMultipleVersions(t *testing.T) {
 			testUtils.ConfigureMigration{
 				LensConfig: client.LensConfig{
 					SourceSchemaVersionID:      "bafkreicdkt3m6mgwuoix7qyijvwxwtj3dlre4a4c6mdnqbucbndwuxjsvi",
-					DestinationSchemaVersionID: "bafkreibpaw4dxy6bvmuoyegm7bwxyi24nubozmukemwiour4v62kz5ffuu",
+					DestinationSchemaVersionID: "bafkreigijxrkfpadmnkpagokjdy6zpwtryad32m6nkgsqrd452kjlfp46e",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{
@@ -66,8 +66,8 @@ func TestSchemaMigrationQueryInversesAcrossMultipleVersions(t *testing.T) {
 			},
 			testUtils.ConfigureMigration{
 				LensConfig: client.LensConfig{
-					SourceSchemaVersionID:      "bafkreibpaw4dxy6bvmuoyegm7bwxyi24nubozmukemwiour4v62kz5ffuu",
-					DestinationSchemaVersionID: "bafkreickm4zodm2muw5qcctmssht63g57u7kxujqyoax4zb5c42zs4pdh4",
+					SourceSchemaVersionID:      "bafkreigijxrkfpadmnkpagokjdy6zpwtryad32m6nkgsqrd452kjlfp46e",
+					DestinationSchemaVersionID: "bafkreibtmdbc3nbdt74xdwvfrez53fxwyz6nh4b6ppwsrxiqpj5zpwgole",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{

--- a/tests/integration/schema/migrations/query/with_p2p_schema_branch_test.go
+++ b/tests/integration/schema/migrations/query/with_p2p_schema_branch_test.go
@@ -47,7 +47,7 @@ func TestSchemaMigrationQueryWithP2PReplicatedDocOnOtherSchemaBranch(t *testing.
 				// Register the migration on both nodes.
 				LensConfig: client.LensConfig{
 					SourceSchemaVersionID:      "bafkreibpai5hfnalhtn5mgamzkgml4gwftow7pklmjcn6i4sqey6a5u5ce",
-					DestinationSchemaVersionID: "bafkreidrbhf54zckhmchzw2ngbobfqtkt7sm6ihbliu2wtxesehz5g4xwm",
+					DestinationSchemaVersionID: "bafkreif7z5sj2ehtmjenverki7c2hqfjgvbajqdlch6yk4kkbx7qvm2yba",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{

--- a/tests/integration/schema/migrations/query/with_p2p_test.go
+++ b/tests/integration/schema/migrations/query/with_p2p_test.go
@@ -47,7 +47,7 @@ func TestSchemaMigrationQueryWithP2PReplicatedDocAtOlderSchemaVersion(t *testing
 				// Register the migration on both nodes.
 				LensConfig: client.LensConfig{
 					SourceSchemaVersionID:      "bafkreibpai5hfnalhtn5mgamzkgml4gwftow7pklmjcn6i4sqey6a5u5ce",
-					DestinationSchemaVersionID: "bafkreidrbhf54zckhmchzw2ngbobfqtkt7sm6ihbliu2wtxesehz5g4xwm",
+					DestinationSchemaVersionID: "bafkreif7z5sj2ehtmjenverki7c2hqfjgvbajqdlch6yk4kkbx7qvm2yba",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{
@@ -146,7 +146,7 @@ func TestSchemaMigrationQueryWithP2PReplicatedDocAtMuchOlderSchemaVersion(t *tes
 				// Register the migration on both nodes.
 				LensConfig: client.LensConfig{
 					SourceSchemaVersionID:      "bafkreibpai5hfnalhtn5mgamzkgml4gwftow7pklmjcn6i4sqey6a5u5ce",
-					DestinationSchemaVersionID: "bafkreidrbhf54zckhmchzw2ngbobfqtkt7sm6ihbliu2wtxesehz5g4xwm",
+					DestinationSchemaVersionID: "bafkreif7z5sj2ehtmjenverki7c2hqfjgvbajqdlch6yk4kkbx7qvm2yba",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{
@@ -163,8 +163,8 @@ func TestSchemaMigrationQueryWithP2PReplicatedDocAtMuchOlderSchemaVersion(t *tes
 			testUtils.ConfigureMigration{
 				// Register the migration on both nodes.
 				LensConfig: client.LensConfig{
-					SourceSchemaVersionID:      "bafkreidrbhf54zckhmchzw2ngbobfqtkt7sm6ihbliu2wtxesehz5g4xwm",
-					DestinationSchemaVersionID: "bafkreidiohu3klvu4f2fdqcywtpqild4v7spsn7ivsjtg6sea6ome2oc4i",
+					SourceSchemaVersionID:      "bafkreif7z5sj2ehtmjenverki7c2hqfjgvbajqdlch6yk4kkbx7qvm2yba",
+					DestinationSchemaVersionID: "bafkreiglqiiz6j7d5dokcle6juoz26uixxggc5zawqkgwcivmenvhob5jy",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{
@@ -254,7 +254,7 @@ func TestSchemaMigrationQueryWithP2PReplicatedDocAtNewerSchemaVersion(t *testing
 				// Register the migration on both nodes.
 				LensConfig: client.LensConfig{
 					SourceSchemaVersionID:      "bafkreibpai5hfnalhtn5mgamzkgml4gwftow7pklmjcn6i4sqey6a5u5ce",
-					DestinationSchemaVersionID: "bafkreidrbhf54zckhmchzw2ngbobfqtkt7sm6ihbliu2wtxesehz5g4xwm",
+					DestinationSchemaVersionID: "bafkreif7z5sj2ehtmjenverki7c2hqfjgvbajqdlch6yk4kkbx7qvm2yba",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{
@@ -355,8 +355,8 @@ func TestSchemaMigrationQueryWithP2PReplicatedDocAtMuchNewerSchemaVersionWithSch
 				// Register a migration from version 2 to version 3 on both nodes.
 				// There is no migration from version 1 to 2, thus node 1 has no knowledge of schema version 2.
 				LensConfig: client.LensConfig{
-					SourceSchemaVersionID:      "bafkreib5jaawobqqiu6frzacerlj55pxxxuql3igqj4ldmg2pgilke4bty",
-					DestinationSchemaVersionID: "bafkreib65lld2tdyvlilbumlcccftqwvflpgutugghf5afrnlhdg7dgyv4",
+					SourceSchemaVersionID:      "bafkreiahhaeagyfsxaxmv3d665qvnbtyn3ts6jshhghy5bijwztbe7efpq",
+					DestinationSchemaVersionID: "bafkreicpdtq27uclgcyeqivvyjvojtk57a573y3upfhi3lvteytktyhlva",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{

--- a/tests/integration/schema/migrations/query/with_restart_test.go
+++ b/tests/integration/schema/migrations/query/with_restart_test.go
@@ -46,7 +46,7 @@ func TestSchemaMigrationQueryWithRestart(t *testing.T) {
 			testUtils.ConfigureMigration{
 				LensConfig: client.LensConfig{
 					SourceSchemaVersionID:      "bafkreia3o3cetvcnnxyu5spucimoos77ifungfmacxdkva4zah2is3aooe",
-					DestinationSchemaVersionID: "bafkreib5jaawobqqiu6frzacerlj55pxxxuql3igqj4ldmg2pgilke4bty",
+					DestinationSchemaVersionID: "bafkreiahhaeagyfsxaxmv3d665qvnbtyn3ts6jshhghy5bijwztbe7efpq",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{
@@ -100,7 +100,7 @@ func TestSchemaMigrationQueryWithRestartAndMigrationBeforeSchemaPatch(t *testing
 			testUtils.ConfigureMigration{
 				LensConfig: client.LensConfig{
 					SourceSchemaVersionID:      "bafkreia3o3cetvcnnxyu5spucimoos77ifungfmacxdkva4zah2is3aooe",
-					DestinationSchemaVersionID: "bafkreib5jaawobqqiu6frzacerlj55pxxxuql3igqj4ldmg2pgilke4bty",
+					DestinationSchemaVersionID: "bafkreiahhaeagyfsxaxmv3d665qvnbtyn3ts6jshhghy5bijwztbe7efpq",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{

--- a/tests/integration/schema/migrations/query/with_set_default_test.go
+++ b/tests/integration/schema/migrations/query/with_set_default_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestSchemaMigrationQuery_WithSetDefaultToLatest_AppliesForwardMigration(t *testing.T) {
-	schemaVersionID2 := "bafkreidrbhf54zckhmchzw2ngbobfqtkt7sm6ihbliu2wtxesehz5g4xwm"
+	schemaVersionID2 := "bafkreif7z5sj2ehtmjenverki7c2hqfjgvbajqdlch6yk4kkbx7qvm2yba"
 
 	test := testUtils.TestCase{
 		Description: "Test schema migration",
@@ -84,7 +84,7 @@ func TestSchemaMigrationQuery_WithSetDefaultToLatest_AppliesForwardMigration(t *
 
 func TestSchemaMigrationQuery_WithSetDefaultToOriginal_AppliesInverseMigration(t *testing.T) {
 	schemaVersionID1 := "bafkreibpai5hfnalhtn5mgamzkgml4gwftow7pklmjcn6i4sqey6a5u5ce"
-	schemaVersionID2 := "bafkreidrbhf54zckhmchzw2ngbobfqtkt7sm6ihbliu2wtxesehz5g4xwm"
+	schemaVersionID2 := "bafkreif7z5sj2ehtmjenverki7c2hqfjgvbajqdlch6yk4kkbx7qvm2yba"
 
 	test := testUtils.TestCase{
 		Description: "Test schema migration",
@@ -159,7 +159,7 @@ func TestSchemaMigrationQuery_WithSetDefaultToOriginal_AppliesInverseMigration(t
 
 func TestSchemaMigrationQuery_WithSetDefaultToOriginalVersionThatDocWasCreatedAt_ClearsMigrations(t *testing.T) {
 	schemaVersionID1 := "bafkreibpai5hfnalhtn5mgamzkgml4gwftow7pklmjcn6i4sqey6a5u5ce"
-	schemaVersionID2 := "bafkreidrbhf54zckhmchzw2ngbobfqtkt7sm6ihbliu2wtxesehz5g4xwm"
+	schemaVersionID2 := "bafkreif7z5sj2ehtmjenverki7c2hqfjgvbajqdlch6yk4kkbx7qvm2yba"
 
 	test := testUtils.TestCase{
 		Description: "Test schema migration",

--- a/tests/integration/schema/migrations/query/with_txn_test.go
+++ b/tests/integration/schema/migrations/query/with_txn_test.go
@@ -48,7 +48,7 @@ func TestSchemaMigrationQueryWithTxn(t *testing.T) {
 				TransactionID: immutable.Some(0),
 				LensConfig: client.LensConfig{
 					SourceSchemaVersionID:      "bafkreia3o3cetvcnnxyu5spucimoos77ifungfmacxdkva4zah2is3aooe",
-					DestinationSchemaVersionID: "bafkreib5jaawobqqiu6frzacerlj55pxxxuql3igqj4ldmg2pgilke4bty",
+					DestinationSchemaVersionID: "bafkreiahhaeagyfsxaxmv3d665qvnbtyn3ts6jshhghy5bijwztbe7efpq",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{
@@ -110,7 +110,7 @@ func TestSchemaMigrationQueryWithTxnAndCommit(t *testing.T) {
 				TransactionID: immutable.Some(0),
 				LensConfig: client.LensConfig{
 					SourceSchemaVersionID:      "bafkreia3o3cetvcnnxyu5spucimoos77ifungfmacxdkva4zah2is3aooe",
-					DestinationSchemaVersionID: "bafkreib5jaawobqqiu6frzacerlj55pxxxuql3igqj4ldmg2pgilke4bty",
+					DestinationSchemaVersionID: "bafkreiahhaeagyfsxaxmv3d665qvnbtyn3ts6jshhghy5bijwztbe7efpq",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{

--- a/tests/integration/schema/migrations/query/with_update_test.go
+++ b/tests/integration/schema/migrations/query/with_update_test.go
@@ -46,7 +46,7 @@ func TestSchemaMigrationQueryWithUpdateRequest(t *testing.T) {
 			testUtils.ConfigureMigration{
 				LensConfig: client.LensConfig{
 					SourceSchemaVersionID:      "bafkreia3o3cetvcnnxyu5spucimoos77ifungfmacxdkva4zah2is3aooe",
-					DestinationSchemaVersionID: "bafkreib5jaawobqqiu6frzacerlj55pxxxuql3igqj4ldmg2pgilke4bty",
+					DestinationSchemaVersionID: "bafkreiahhaeagyfsxaxmv3d665qvnbtyn3ts6jshhghy5bijwztbe7efpq",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{
@@ -130,7 +130,7 @@ func TestSchemaMigrationQueryWithMigrationRegisteredAfterUpdate(t *testing.T) {
 			testUtils.ConfigureMigration{
 				LensConfig: client.LensConfig{
 					SourceSchemaVersionID:      "bafkreia3o3cetvcnnxyu5spucimoos77ifungfmacxdkva4zah2is3aooe",
-					DestinationSchemaVersionID: "bafkreib5jaawobqqiu6frzacerlj55pxxxuql3igqj4ldmg2pgilke4bty",
+					DestinationSchemaVersionID: "bafkreiahhaeagyfsxaxmv3d665qvnbtyn3ts6jshhghy5bijwztbe7efpq",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{

--- a/tests/integration/schema/migrations/simple_test.go
+++ b/tests/integration/schema/migrations/simple_test.go
@@ -107,7 +107,7 @@ func TestSchemaMigrationGetMigrationsReturnsMultiple(t *testing.T) {
 			testUtils.ConfigureMigration{
 				LensConfig: client.LensConfig{
 					SourceSchemaVersionID:      "bafkreia3o3cetvcnnxyu5spucimoos77ifungfmacxdkva4zah2is3aooe",
-					DestinationSchemaVersionID: "bafkreib5jaawobqqiu6frzacerlj55pxxxuql3igqj4ldmg2pgilke4bty",
+					DestinationSchemaVersionID: "bafkreiahhaeagyfsxaxmv3d665qvnbtyn3ts6jshhghy5bijwztbe7efpq",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{
@@ -158,7 +158,7 @@ func TestSchemaMigrationGetMigrationsReturnsMultiple(t *testing.T) {
 					},
 					{
 						ID:              4,
-						SchemaVersionID: "bafkreib5jaawobqqiu6frzacerlj55pxxxuql3igqj4ldmg2pgilke4bty",
+						SchemaVersionID: "bafkreiahhaeagyfsxaxmv3d665qvnbtyn3ts6jshhghy5bijwztbe7efpq",
 						Sources: []any{
 							&client.CollectionSource{
 								SourceCollectionID: 3,

--- a/tests/integration/schema/one_one_test.go
+++ b/tests/integration/schema/one_one_test.go
@@ -30,7 +30,9 @@ func TestSchemaOneOne_NoPrimary_Errors(t *testing.T) {
 						owner: User
 					}
 				`,
-				ExpectedError: "relation missing field. Object: Dog, RelationName: dog_user",
+				// This error is dependent upon the order in which definitions are validated, so
+				// we only assert that the error is the correct type, and do not check the key-values
+				ExpectedError: "relation missing field",
 			},
 		},
 	}

--- a/tests/integration/schema/updates/add/field/create_update_test.go
+++ b/tests/integration/schema/updates/add/field/create_update_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestSchemaUpdatesAddFieldWithCreateWithUpdateAfterSchemaUpdateAndVersionJoin(t *testing.T) {
 	initialSchemaVersionID := "bafkreia3o3cetvcnnxyu5spucimoos77ifungfmacxdkva4zah2is3aooe"
-	updatedSchemaVersionID := "bafkreibz4g6rkxanzn6ro74ezmbwoe5hvcguwvi34judrk2kfuqqtk5ak4"
+	updatedSchemaVersionID := "bafkreidt4i22v4bzga3aezlcxsrfbvuhzcbqo5bnfe2x2dgkpz3eds2afe"
 
 	test := testUtils.TestCase{
 		Description: "Test schema update, add field with update after schema update, version join",
@@ -106,7 +106,7 @@ func TestSchemaUpdatesAddFieldWithCreateWithUpdateAfterSchemaUpdateAndVersionJoi
 
 func TestSchemaUpdatesAddFieldWithCreateWithUpdateAfterSchemaUpdateAndCommitQuery(t *testing.T) {
 	initialSchemaVersionID := "bafkreia3o3cetvcnnxyu5spucimoos77ifungfmacxdkva4zah2is3aooe"
-	updatedSchemaVersionID := "bafkreibz4g6rkxanzn6ro74ezmbwoe5hvcguwvi34judrk2kfuqqtk5ak4"
+	updatedSchemaVersionID := "bafkreidt4i22v4bzga3aezlcxsrfbvuhzcbqo5bnfe2x2dgkpz3eds2afe"
 
 	test := testUtils.TestCase{
 		Description: "Test schema update, add field with update after schema update, commits query",

--- a/tests/integration/schema/updates/add/field/simple_test.go
+++ b/tests/integration/schema/updates/add/field/simple_test.go
@@ -21,7 +21,7 @@ import (
 
 func TestSchemaUpdatesAddFieldSimple(t *testing.T) {
 	schemaVersion1ID := "bafkreia3o3cetvcnnxyu5spucimoos77ifungfmacxdkva4zah2is3aooe"
-	schemaVersion2ID := "bafkreibz4g6rkxanzn6ro74ezmbwoe5hvcguwvi34judrk2kfuqqtk5ak4"
+	schemaVersion2ID := "bafkreidt4i22v4bzga3aezlcxsrfbvuhzcbqo5bnfe2x2dgkpz3eds2afe"
 
 	test := testUtils.TestCase{
 		Description: "Test schema update, add field",
@@ -60,7 +60,7 @@ func TestSchemaUpdatesAddFieldSimple(t *testing.T) {
 							{
 								Name: "_docID",
 								Kind: client.FieldKind_DocID,
-								Typ:  client.LWW_REGISTER,
+								Typ:  client.NONE_CRDT,
 							},
 							{
 								Name: "name",
@@ -116,7 +116,7 @@ func TestSchemaUpdates_AddFieldSimpleDoNotSetDefault_Errors(t *testing.T) {
 
 func TestSchemaUpdates_AddFieldSimpleDoNotSetDefault_VersionIsQueryable(t *testing.T) {
 	schemaVersion1ID := "bafkreia3o3cetvcnnxyu5spucimoos77ifungfmacxdkva4zah2is3aooe"
-	schemaVersion2ID := "bafkreibz4g6rkxanzn6ro74ezmbwoe5hvcguwvi34judrk2kfuqqtk5ak4"
+	schemaVersion2ID := "bafkreidt4i22v4bzga3aezlcxsrfbvuhzcbqo5bnfe2x2dgkpz3eds2afe"
 
 	test := testUtils.TestCase{
 		Description: "Test schema update, add field",
@@ -149,7 +149,7 @@ func TestSchemaUpdates_AddFieldSimpleDoNotSetDefault_VersionIsQueryable(t *testi
 							{
 								Name: "_docID",
 								Kind: client.FieldKind_DocID,
-								Typ:  client.LWW_REGISTER,
+								Typ:  client.NONE_CRDT,
 							},
 							{
 								Name: "name",

--- a/tests/integration/schema/updates/add/field/simple_test.go
+++ b/tests/integration/schema/updates/add/field/simple_test.go
@@ -362,7 +362,7 @@ func TestSchemaUpdatesAddFieldSimpleDuplicateOfExistingField(t *testing.T) {
 						{ "op": "add", "path": "/Users/Fields/-", "value": {"Name": "name", "Kind": 11} }
 					]
 				`,
-				ExpectedError: "duplicate field. Name: name",
+				ExpectedError: "mutating an existing field is not supported. ProposedName: name",
 			},
 		},
 	}

--- a/tests/integration/schema/updates/add/simple_test.go
+++ b/tests/integration/schema/updates/add/simple_test.go
@@ -33,7 +33,7 @@ func TestSchemaUpdatesAddSimpleErrorsAddingSchema(t *testing.T) {
 						{ "op": "add", "path": "/-", "value": {"Name": "books"} }
 					]
 				`,
-				ExpectedError: "adding collections via patch is not supported. Name: books",
+				ExpectedError: "adding schema via patch is not supported. Name: books",
 			},
 			testUtils.Request{
 				Request: `query {

--- a/tests/integration/schema/updates/copy/field/simple_test.go
+++ b/tests/integration/schema/updates/copy/field/simple_test.go
@@ -34,7 +34,7 @@ func TestSchemaUpdatesCopyFieldErrors(t *testing.T) {
 						{ "op": "copy", "from": "/Users/Fields/1", "path": "/Users/Fields/2" }
 					]
 				`,
-				ExpectedError: "duplicate field. Name: email",
+				ExpectedError: "moving fields is not currently supported. Name: email",
 			},
 			testUtils.Request{
 				Request: `query {

--- a/tests/integration/schema/updates/copy/simple_test.go
+++ b/tests/integration/schema/updates/copy/simple_test.go
@@ -38,7 +38,7 @@ func TestSchemaUpdatesCopyCollectionWithRemoveIDAndReplaceName(t *testing.T) {
 						{ "op": "replace", "path": "/Book/Name", "value": "Book" }
 					]
 				`,
-				ExpectedError: "adding collections via patch is not supported. Name: Book",
+				ExpectedError: "adding schema via patch is not supported. Name: Book",
 			},
 		},
 	}

--- a/tests/integration/schema/updates/remove/simple_test.go
+++ b/tests/integration/schema/updates/remove/simple_test.go
@@ -34,7 +34,7 @@ func TestSchemaUpdatesRemoveCollectionNameErrors(t *testing.T) {
 						{ "op": "remove", "path": "/Users/Name" }
 					]
 				`,
-				ExpectedError: "schema name can't be empty",
+				ExpectedError: "SchemaRoot does not match existing. Name: ",
 			},
 		},
 	}
@@ -118,7 +118,7 @@ func TestSchemaUpdatesRemoveSchemaNameErrors(t *testing.T) {
 						{ "op": "remove", "path": "/Users/Name" }
 					]
 				`,
-				ExpectedError: "schema name can't be empty",
+				ExpectedError: "SchemaRoot does not match existing. Name: ",
 			},
 		},
 	}

--- a/tests/integration/schema/updates/replace/simple_test.go
+++ b/tests/integration/schema/updates/replace/simple_test.go
@@ -44,7 +44,7 @@ func TestSchemaUpdatesReplaceCollectionErrors(t *testing.T) {
 				// WARNING: An error is still expected if/when we allow the adding of collections, as this also
 				// implies that the "Users" collection is to be deleted.  Only once we support the adding *and*
 				// removal of collections should this not error.
-				ExpectedError: "adding collections via patch is not supported. Name: Book",
+				ExpectedError: "adding schema via patch is not supported. Name: Book",
 			},
 		},
 	}

--- a/tests/integration/schema/updates/with_schema_branch_test.go
+++ b/tests/integration/schema/updates/with_schema_branch_test.go
@@ -21,8 +21,8 @@ import (
 
 func TestSchemaUpdates_WithBranchingSchema(t *testing.T) {
 	schemaVersion1ID := "bafkreia3o3cetvcnnxyu5spucimoos77ifungfmacxdkva4zah2is3aooe"
-	schemaVersion2ID := "bafkreibz4g6rkxanzn6ro74ezmbwoe5hvcguwvi34judrk2kfuqqtk5ak4"
-	schemaVersion3ID := "bafkreifswbi23wxvq2zpqnoldolsxk2fhtj5t6rs3pidil3j6tybc62q3m"
+	schemaVersion2ID := "bafkreidt4i22v4bzga3aezlcxsrfbvuhzcbqo5bnfe2x2dgkpz3eds2afe"
+	schemaVersion3ID := "bafkreifc46y7pk2xfwc3nc442r7iqf6cjixxerxrrnrsouky544gmz4zve"
 
 	test := testUtils.TestCase{
 		Description: "Test schema update, with branching schema",
@@ -74,7 +74,7 @@ func TestSchemaUpdates_WithBranchingSchema(t *testing.T) {
 							{
 								Name: "_docID",
 								Kind: client.FieldKind_DocID,
-								Typ:  client.LWW_REGISTER,
+								Typ:  client.NONE_CRDT,
 							},
 							{
 								Name: "name",
@@ -112,7 +112,7 @@ func TestSchemaUpdates_WithBranchingSchema(t *testing.T) {
 							{
 								Name: "_docID",
 								Kind: client.FieldKind_DocID,
-								Typ:  client.LWW_REGISTER,
+								Typ:  client.NONE_CRDT,
 							},
 							{
 								Name: "name",
@@ -170,9 +170,9 @@ func TestSchemaUpdates_WithBranchingSchema(t *testing.T) {
 
 func TestSchemaUpdates_WithPatchOnBranchedSchema(t *testing.T) {
 	schemaVersion1ID := "bafkreia3o3cetvcnnxyu5spucimoos77ifungfmacxdkva4zah2is3aooe"
-	schemaVersion2ID := "bafkreibz4g6rkxanzn6ro74ezmbwoe5hvcguwvi34judrk2kfuqqtk5ak4"
-	schemaVersion3ID := "bafkreifswbi23wxvq2zpqnoldolsxk2fhtj5t6rs3pidil3j6tybc62q3m"
-	schemaVersion4ID := "bafkreid4ulxeclzgpzhznge7zdin6docxvklugvr6gt4jxfyanz5i2r2hu"
+	schemaVersion2ID := "bafkreidt4i22v4bzga3aezlcxsrfbvuhzcbqo5bnfe2x2dgkpz3eds2afe"
+	schemaVersion3ID := "bafkreifc46y7pk2xfwc3nc442r7iqf6cjixxerxrrnrsouky544gmz4zve"
+	schemaVersion4ID := "bafkreic2heai3vgufxcxs6bfvil2oyz27w3bzkwoqehjevlnkewq3ffp4e"
 
 	test := testUtils.TestCase{
 		Description: "Test schema update, with patch on branching schema",
@@ -234,7 +234,7 @@ func TestSchemaUpdates_WithPatchOnBranchedSchema(t *testing.T) {
 							{
 								Name: "_docID",
 								Kind: client.FieldKind_DocID,
-								Typ:  client.LWW_REGISTER,
+								Typ:  client.NONE_CRDT,
 							},
 							{
 								Name: "name",
@@ -308,8 +308,8 @@ func TestSchemaUpdates_WithPatchOnBranchedSchema(t *testing.T) {
 
 func TestSchemaUpdates_WithBranchingSchemaAndSetActiveSchemaToOtherBranch(t *testing.T) {
 	schemaVersion1ID := "bafkreia3o3cetvcnnxyu5spucimoos77ifungfmacxdkva4zah2is3aooe"
-	schemaVersion2ID := "bafkreibz4g6rkxanzn6ro74ezmbwoe5hvcguwvi34judrk2kfuqqtk5ak4"
-	schemaVersion3ID := "bafkreifswbi23wxvq2zpqnoldolsxk2fhtj5t6rs3pidil3j6tybc62q3m"
+	schemaVersion2ID := "bafkreidt4i22v4bzga3aezlcxsrfbvuhzcbqo5bnfe2x2dgkpz3eds2afe"
+	schemaVersion3ID := "bafkreifc46y7pk2xfwc3nc442r7iqf6cjixxerxrrnrsouky544gmz4zve"
 
 	test := testUtils.TestCase{
 		Description: "Test schema update, with branching schema toggling between branches",
@@ -404,9 +404,9 @@ func TestSchemaUpdates_WithBranchingSchemaAndSetActiveSchemaToOtherBranch(t *tes
 
 func TestSchemaUpdates_WithBranchingSchemaAndSetActiveSchemaToOtherBranchThenPatch(t *testing.T) {
 	schemaVersion1ID := "bafkreia3o3cetvcnnxyu5spucimoos77ifungfmacxdkva4zah2is3aooe"
-	schemaVersion2ID := "bafkreibz4g6rkxanzn6ro74ezmbwoe5hvcguwvi34judrk2kfuqqtk5ak4"
-	schemaVersion3ID := "bafkreifswbi23wxvq2zpqnoldolsxk2fhtj5t6rs3pidil3j6tybc62q3m"
-	schemaVersion4ID := "bafkreidjuyxhakc5yx7fucunoxijnfjvgqohf4sjoryzf27mqxidh37kne"
+	schemaVersion2ID := "bafkreidt4i22v4bzga3aezlcxsrfbvuhzcbqo5bnfe2x2dgkpz3eds2afe"
+	schemaVersion3ID := "bafkreifc46y7pk2xfwc3nc442r7iqf6cjixxerxrrnrsouky544gmz4zve"
+	schemaVersion4ID := "bafkreifdkkauc4b4rkazmzijiu2nxlikqatxa5zbmjc4sn3wrtlcqqcrt4"
 
 	test := testUtils.TestCase{
 		Description: "Test schema update, with branching schema toggling between branches then patch",
@@ -472,7 +472,7 @@ func TestSchemaUpdates_WithBranchingSchemaAndSetActiveSchemaToOtherBranchThenPat
 							{
 								Name: "_docID",
 								Kind: client.FieldKind_DocID,
-								Typ:  client.LWW_REGISTER,
+								Typ:  client.NONE_CRDT,
 							},
 							{
 								Name: "name",

--- a/tests/integration/schema/with_update_set_default_test.go
+++ b/tests/integration/schema/with_update_set_default_test.go
@@ -129,7 +129,7 @@ func TestSchema_WithUpdateAndSetDefaultVersionToNew_AllowsQueryingOfNewField(t *
 				SetAsDefaultVersion: immutable.Some(false),
 			},
 			testUtils.SetActiveSchemaVersion{
-				SchemaVersionID: "bafkreibz4g6rkxanzn6ro74ezmbwoe5hvcguwvi34judrk2kfuqqtk5ak4",
+				SchemaVersionID: "bafkreidt4i22v4bzga3aezlcxsrfbvuhzcbqo5bnfe2x2dgkpz3eds2afe",
 			},
 			testUtils.Request{
 				Request: `query {


### PR DESCRIPTION
## Relevant issue(s)

Resolves #2537

## Description

Reworks definition validation, standardizing the rule signatures, allowing rule reuse across different contexts, and hopefully improving their readability.  Performance of the rules will have decreased slightly, but on col/schema update that is unimportant, performance of `createCollections` (called when creating via SDL docs) has probably improved slightly due to a reduction in datastore calls.

This is largely in preparation for https://github.com/sourcenetwork/defradb/issues/2401 and the removal/simplification of `SetActiveVersion`.