### PR TITLE
fix(i): Convert error logs to `ErrorE` func

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/multiformats/go-multicodec v0.9.0
 	github.com/multiformats/go-multihash v0.2.3
 	github.com/sourcenetwork/badger/v4 v4.2.1-0.20231113215945-a63444ca5276
-	github.com/sourcenetwork/corelog v0.0.7
+	github.com/sourcenetwork/corelog v0.0.8
 	github.com/sourcenetwork/go-libp2p-pubsub-rpc v0.0.14
 	github.com/sourcenetwork/graphql-go v0.7.10-0.20231113214537-a9560c1898dd
 	github.com/sourcenetwork/immutable v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -1073,8 +1073,8 @@ github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIK
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
 github.com/sourcenetwork/badger/v4 v4.2.1-0.20231113215945-a63444ca5276 h1:TpQDDPfucDgCNH0NVqVUk6SSq6T6G8p9HIocmwZh9Tg=
 github.com/sourcenetwork/badger/v4 v4.2.1-0.20231113215945-a63444ca5276/go.mod h1:lxiZTDBw0vheFMqSwX2OvB6RTDI1+/UtVCSU4rpThFM=
-github.com/sourcenetwork/corelog v0.0.7 h1:vztssVAUDcsYN5VUOW3PKYhLprHfzoc8UbKewQuD1qw=
-github.com/sourcenetwork/corelog v0.0.7/go.mod h1:cMabHgs3kARgYTQeQYSOmaGGP8XMU6sZrHd8LFrL3zA=
+github.com/sourcenetwork/corelog v0.0.8 h1:jCo0mFBpWrfhUCGzzN3uUtPGyQv3jnITdPO1s2ME3RY=
+github.com/sourcenetwork/corelog v0.0.8/go.mod h1:cMabHgs3kARgYTQeQYSOmaGGP8XMU6sZrHd8LFrL3zA=
 github.com/sourcenetwork/go-libp2p-pubsub-rpc v0.0.14 h1:620zKV4rOn7U5j/WsPkk4SFj0z9/pVV4bBx0BpZQgro=
 github.com/sourcenetwork/go-libp2p-pubsub-rpc v0.0.14/go.mod h1:jUoQv592uUX1u7QBjAY4C+l24X9ArhPfifOqXpDHz4U=
 github.com/sourcenetwork/graphql-go v0.7.10-0.20231113214537-a9560c1898dd h1:lmpW39/8wPJ0khWRhOcj7Bj0HYKbSmQ8rXMJw1cMB8U=

--- a/internal/db/merge.go
+++ b/internal/db/merge.go
@@ -67,7 +67,6 @@ func (db *db) handleMerges(ctx context.Context, merges events.Subscription[event
 						ctx,
 						"Failed to execute merge",
 						err,
-						corelog.Any("Error", err),
 						corelog.Any("Event", merge))
 				}
 				if merge.Wg != nil {

--- a/net/node.go
+++ b/net/node.go
@@ -226,7 +226,7 @@ func (n *Node) Bootstrap(addrs []peer.AddrInfo) {
 			defer wg.Done()
 			err := n.host.Connect(n.ctx, pinfo)
 			if err != nil {
-				log.InfoContext(n.ctx, "Cannot connect to peer", corelog.Any("Error", err))
+				log.ErrorContextE(n.ctx, "Cannot connect to peer", err)
 				return
 			}
 			log.InfoContext(n.ctx, "Connected", corelog.Any("PeerID", pinfo.ID))

--- a/net/peer.go
+++ b/net/peer.go
@@ -130,9 +130,7 @@ func (p *Peer) Start() error {
 				log.InfoContext(
 					p.ctx,
 					"Failure while reconnecting to a known peer",
-					corelog.Any("peer", id),
-					corelog.Any("error", err),
-				)
+					corelog.Any("peer", id))
 			}
 		}(id)
 	}
@@ -193,12 +191,12 @@ func (p *Peer) Close() {
 	// close event emitters
 	if p.server.pubSubEmitter != nil {
 		if err := p.server.pubSubEmitter.Close(); err != nil {
-			log.InfoContext(p.ctx, "Could not close pubsub event emitter", corelog.Any("Error", err.Error()))
+			log.ErrorContextE(p.ctx, "Could not close pubsub event emitter", err)
 		}
 	}
 	if p.server.pushLogEmitter != nil {
 		if err := p.server.pushLogEmitter.Close(); err != nil {
-			log.InfoContext(p.ctx, "Could not close push log event emitter", corelog.Any("Error", err.Error()))
+			log.ErrorContextE(p.ctx, "Could not close push log event emitter", err)
 		}
 	}
 

--- a/net/server.go
+++ b/net/server.go
@@ -113,11 +113,11 @@ func newServer(p *Peer, opts ...grpc.DialOption) (*server, error) {
 	var err error
 	s.pubSubEmitter, err = s.peer.host.EventBus().Emitter(new(EvtPubSub))
 	if err != nil {
-		log.InfoContext(s.peer.ctx, "could not create event emitter", corelog.String("Error", err.Error()))
+		log.ErrorContextE(s.peer.ctx, "could not create event emitter", err)
 	}
 	s.pushLogEmitter, err = s.peer.host.EventBus().Emitter(new(EvtReceivedPushLog))
 	if err != nil {
-		log.InfoContext(s.peer.ctx, "could not create event emitter", corelog.String("Error", err.Error()))
+		log.ErrorContextE(s.peer.ctx, "could not create event emitter", err)
 	}
 
 	return s, nil
@@ -167,7 +167,7 @@ func (s *server) PushLog(ctx context.Context, req *pb.PushLogRequest) (*pb.PushL
 		if s.pushLogEmitter != nil {
 			byPeer, err := libpeer.Decode(req.Body.Creator)
 			if err != nil {
-				log.InfoContext(ctx, "could not decode the PeerID of the log creator", corelog.String("Error", err.Error()))
+				log.ErrorContextE(ctx, "could not decode the PeerID of the log creator", err)
 			}
 			err = s.pushLogEmitter.Emit(EvtReceivedPushLog{
 				FromPeer: pid,
@@ -176,7 +176,7 @@ func (s *server) PushLog(ctx context.Context, req *pb.PushLogRequest) (*pb.PushL
 			if err != nil {
 				// logging instead of returning an error because the event bus should
 				// not break the PushLog execution.
-				log.InfoContext(ctx, "could not emit push log event", corelog.String("Error", err.Error()))
+				log.ErrorContextE(ctx, "could not emit push log event", err)
 			}
 		}
 	}()
@@ -349,7 +349,7 @@ func (s *server) pubSubEventHandler(from libpeer.ID, topic string, msg []byte) {
 			Peer: from,
 		})
 		if err != nil {
-			log.InfoContext(s.peer.ctx, "could not emit pubsub event", corelog.Any("Error", err.Error()))
+			log.ErrorContextE(s.peer.ctx, "could not emit pubsub event", err)
 		}
 	}
 }


### PR DESCRIPTION
## Relevant issue(s)

Resolves #2737

## Description

This PR bumps corelog to v0.0.8 and converts error logs to `ErrorE` or `ErrorContextE`.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

`make test`

Specify the platform(s) on which this was tested:
- MacOS

