### PR TITLE
test: Allow test harness to execute benchmarks

### DIFF
--- a/tests/change_detector/utils.go
+++ b/tests/change_detector/utils.go
@@ -76,7 +76,7 @@ func DatabaseDir(t testing.TB) string {
 }
 
 // PreTestChecks skips any test that can't be run by the change detector.
-func PreTestChecks(t *testing.T, collectionNames []string) {
+func PreTestChecks(t testing.TB, collectionNames []string) {
 	if !Enabled {
 		return
 	}

--- a/tests/integration/explain.go
+++ b/tests/integration/explain.go
@@ -375,7 +375,7 @@ func trimSubNodes(graph any) any {
 
 // trimExplainAttributes trims away all keys that aren't plan nodes within the explain graph.
 func trimExplainAttributes(
-	t *testing.T,
+	t testing.TB,
 	description string,
 	actualResult any,
 ) map[string]any {
@@ -411,7 +411,7 @@ func trimExplainAttributes(
 
 // trimExplainAttributesArray is a helper that runs trimExplainAttributes for each item in an array.
 func trimExplainAttributesArray[T any](
-	t *testing.T,
+	t testing.TB,
 	description string,
 	actualResult []T,
 ) []map[string]any {

--- a/tests/integration/explain_result_asserter.go
+++ b/tests/integration/explain_result_asserter.go
@@ -41,7 +41,7 @@ type ExplainResultAsserter struct {
 	planExecutions immutable.Option[uint64]
 }
 
-func readNumberProp(t *testing.T, val any, prop string) uint64 {
+func readNumberProp(t testing.TB, val any, prop string) uint64 {
 	switch v := val.(type) {
 	case uint64:
 		return v
@@ -55,7 +55,7 @@ func readNumberProp(t *testing.T, val any, prop string) uint64 {
 	return 0
 }
 
-func (a *ExplainResultAsserter) Assert(t *testing.T, result []dataMap) {
+func (a *ExplainResultAsserter) Assert(t testing.TB, result []dataMap) {
 	require.Len(t, result, 1, "Expected len(result) = 1, got %d", len(result))
 	explainNode, ok := result[0]["explain"].(dataMap)
 	require.True(t, ok, "Expected explain none")

--- a/tests/integration/results.go
+++ b/tests/integration/results.go
@@ -28,7 +28,7 @@ type AnyOf []any
 // assertResultsAnyOf asserts that actual result is equal to at least one of the expected results.
 //
 // The comparison is relaxed when using client types other than goClientType.
-func assertResultsAnyOf(t *testing.T, client ClientType, expected AnyOf, actual any, msgAndArgs ...any) {
+func assertResultsAnyOf(t testing.TB, client ClientType, expected AnyOf, actual any, msgAndArgs ...any) {
 	switch client {
 	case HTTPClientType, CLIClientType:
 		if !areResultsAnyOf(expected, actual) {
@@ -42,7 +42,7 @@ func assertResultsAnyOf(t *testing.T, client ClientType, expected AnyOf, actual 
 // assertResultsEqual asserts that actual result is equal to the expected result.
 //
 // The comparison is relaxed when using client types other than goClientType.
-func assertResultsEqual(t *testing.T, client ClientType, expected any, actual any, msgAndArgs ...any) {
+func assertResultsEqual(t testing.TB, client ClientType, expected any, actual any, msgAndArgs ...any) {
 	switch client {
 	case HTTPClientType, CLIClientType:
 		if !areResultsEqual(expected, actual) {

--- a/tests/integration/state.go
+++ b/tests/integration/state.go
@@ -27,7 +27,7 @@ type state struct {
 	ctx context.Context
 
 	// The Go Test test state
-	t *testing.T
+	t testing.TB
 
 	// The TestCase currently being executed.
 	testCase TestCase
@@ -88,7 +88,7 @@ type state struct {
 // newState returns a new fresh state for the given testCase.
 func newState(
 	ctx context.Context,
-	t *testing.T,
+	t testing.TB,
 	testCase TestCase,
 	dbt DatabaseType,
 	clientType ClientType,

--- a/tests/integration/test_case.go
+++ b/tests/integration/test_case.go
@@ -429,13 +429,13 @@ type GetIndexes struct {
 // assertions.
 type ResultAsserter interface {
 	// Assert will be called with the test and the result of the request.
-	Assert(t *testing.T, result []map[string]any)
+	Assert(t testing.TB, result []map[string]any)
 }
 
 // ResultAsserterFunc is a function that can be used to implement the ResultAsserter
-type ResultAsserterFunc func(*testing.T, []map[string]any) (bool, string)
+type ResultAsserterFunc func(testing.TB, []map[string]any) (bool, string)
 
-func (f ResultAsserterFunc) Assert(t *testing.T, result []map[string]any) {
+func (f ResultAsserterFunc) Assert(t testing.TB, result []map[string]any) {
 	f(t, result)
 }
 

--- a/tests/integration/utils2.go
+++ b/tests/integration/utils2.go
@@ -133,7 +133,7 @@ func AssertPanic(t *testing.T, f assert.PanicTestFunc) bool {
 // Will also attempt to detect incompatible changes in the persisted data if
 // configured to do so (the CI will do so, but disabled by default as it is slow).
 func ExecuteTestCase(
-	t *testing.T,
+	t testing.TB,
 	testCase TestCase,
 ) {
 	flattenActions(&testCase)
@@ -181,7 +181,7 @@ func ExecuteTestCase(
 
 func executeTestCase(
 	ctx context.Context,
-	t *testing.T,
+	t testing.TB,
 	collectionNames []string,
 	testCase TestCase,
 	dbt DatabaseType,
@@ -578,7 +578,7 @@ func flattenActions(testCase *TestCase) {
 //
 // If a SetupComplete action is provided, the actions will be split there, if not
 // they will be split at the first non SchemaUpdate/CreateDoc/UpdateDoc action.
-func getActionRange(t *testing.T, testCase TestCase) (int, int) {
+func getActionRange(t testing.TB, testCase TestCase) (int, int) {
 	startIndex := 0
 	endIndex := len(testCase.Actions) - 1
 
@@ -927,7 +927,7 @@ func getIndexes(
 func assertIndexesListsEqual(
 	expectedIndexes []client.IndexDescription,
 	actualIndexes []client.IndexDescription,
-	t *testing.T,
+	t testing.TB,
 	testDescription string,
 ) {
 	toNames := func(indexes []client.IndexDescription) []string {
@@ -956,7 +956,7 @@ func assertIndexesListsEqual(
 }
 
 func assertIndexesEqual(expectedIndex, actualIndex client.IndexDescription,
-	t *testing.T,
+	t testing.TB,
 	testDescription string,
 ) {
 	assert.Equal(t, expectedIndex.Name, actualIndex.Name, testDescription)
@@ -1767,7 +1767,7 @@ func executeSubscriptionRequest(
 
 // Asserts as to whether an error has been raised as expected (or not). If an expected
 // error has been raised it will return true, returns false in all other cases.
-func AssertError(t *testing.T, description string, err error, expectedError string) bool {
+func AssertError(t testing.TB, description string, err error, expectedError string) bool {
 	if err == nil {
 		return false
 	}
@@ -1788,7 +1788,7 @@ func AssertError(t *testing.T, description string, err error, expectedError stri
 // Asserts as to whether an error has been raised as expected (or not). If an expected
 // error has been raised it will return true, returns false in all other cases.
 func AssertErrors(
-	t *testing.T,
+	t testing.TB,
 	description string,
 	errs []error,
 	expectedError string,
@@ -1888,7 +1888,7 @@ func assertRequestResults(
 	return false
 }
 
-func assertExpectedErrorRaised(t *testing.T, description string, expectedError string, wasRaised bool) {
+func assertExpectedErrorRaised(t testing.TB, description string, expectedError string, wasRaised bool) {
 	if expectedError != "" && !wasRaised {
 		assert.Fail(t, "Expected an error however none was raised.", description)
 	}
@@ -1974,7 +1974,7 @@ func assertClientIntrospectionResults(
 
 // Asserts that the `actual` contains the given `contains` value according to the logic
 // described on the [RequestTestCase.ContainsData] property.
-func assertContains(t *testing.T, contains map[string]any, actual map[string]any) {
+func assertContains(t testing.TB, contains map[string]any, actual map[string]any) {
 	for k, expected := range contains {
 		innerActual := actual[k]
 		if innerExpected, innerIsMap := expected.(map[string]any); innerIsMap {
@@ -2005,7 +2005,7 @@ func assertContains(t *testing.T, contains map[string]any, actual map[string]any
 	}
 }
 
-func assertBackupContent(t *testing.T, expectedContent, filepath string) {
+func assertBackupContent(t testing.TB, expectedContent, filepath string) {
 	b, err := os.ReadFile(filepath)
 	assert.NoError(t, err)
 	assert.Equal(
@@ -2017,7 +2017,7 @@ func assertBackupContent(t *testing.T, expectedContent, filepath string) {
 
 // skipIfMutationTypeUnsupported skips the current test if the given supportedMutationTypes option has value
 // and the active mutation type is not contained within that value set.
-func skipIfMutationTypeUnsupported(t *testing.T, supportedMutationTypes immutable.Option[[]MutationType]) {
+func skipIfMutationTypeUnsupported(t testing.TB, supportedMutationTypes immutable.Option[[]MutationType]) {
 	if supportedMutationTypes.HasValue() {
 		var isTypeSupported bool
 		for _, supportedMutationType := range supportedMutationTypes.Value() {
@@ -2038,7 +2038,7 @@ func skipIfMutationTypeUnsupported(t *testing.T, supportedMutationTypes immutabl
 // If supportedClientTypes is none no filtering will take place and the input client set will be returned.
 // If the resultant filtered set is empty the test will be skipped.
 func skipIfClientTypeUnsupported(
-	t *testing.T,
+	t testing.TB,
 	clients []ClientType,
 	supportedClientTypes immutable.Option[[]ClientType],
 ) []ClientType {
@@ -2065,7 +2065,7 @@ func skipIfClientTypeUnsupported(
 
 // skipIfNetworkTest skips the current test if the given actions
 // contain network actions and skipNetworkTests is true.
-func skipIfNetworkTest(t *testing.T, actions []any) {
+func skipIfNetworkTest(t testing.TB, actions []any) {
 	hasNetworkAction := false
 	for _, act := range actions {
 		switch act.(type) {


### PR DESCRIPTION
## Relevant issue(s)

Resolves #2739

## Description

Allows test harness to execute benchmark tests as well as normal-tests.

Broken out of https://github.com/sourcenetwork/defradb/issues/2545 - is a good change independent of that though anyway and will allow us to use the integration test actions in benchmarks.