### PR TITLE
feat: Ability to generate a new identity

### DIFF
--- a/acp/identity/errors.go
+++ b/acp/identity/errors.go
@@ -16,9 +16,15 @@ import (
 	"github.com/sourcenetwork/defradb/errors"
 )
 
-const errDIDCreation = "could not produce did for key"
+const (
+	errDIDCreation                            = "could not produce did for key"
+	errFailedToGenerateIdentityFromPrivateKey = "failed to generate identity from private key"
+)
 
-var ErrDIDCreation = errors.New(errDIDCreation)
+var (
+	ErrDIDCreation                            = errors.New(errDIDCreation)
+	ErrFailedToGenerateIdentityFromPrivateKey = errors.New(errFailedToGenerateIdentityFromPrivateKey)
+)
 
 func newErrDIDCreation(inner error, keytype string, pubKey []byte) error {
 	return errors.Wrap(

--- a/acp/identity/generate.go
+++ b/acp/identity/generate.go
@@ -1,0 +1,50 @@
+// Copyright 2024 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package identity
+
+import "github.com/sourcenetwork/defradb/crypto"
+
+// RawIdentity holds the raw bytes that make up an actor's identity.
+type RawIdentity struct {
+	// An actor's private key.
+	PrivateKey []byte
+
+	// An actor's corresponding public key address.
+	PublicKey []byte
+
+	// An actor's DID. Generated from the public key address.
+	DID string
+}
+
+// Generate generates a new identity.
+func Generate() (RawIdentity, error) {
+	privateKey, err := crypto.GenerateSecp256k1()
+	if err != nil {
+		return RawIdentity{}, err
+	}
+
+	maybeNewIdentity, err := FromPrivateKey(privateKey)
+	if err != nil {
+		return RawIdentity{}, err
+	}
+
+	if !maybeNewIdentity.HasValue() {
+		return RawIdentity{}, ErrFailedToGenerateIdentityFromPrivateKey
+	}
+
+	newIdentity := maybeNewIdentity.Value()
+
+	return RawIdentity{
+		PrivateKey: newIdentity.PrivateKey.Serialize(),
+		PublicKey:  newIdentity.PublicKey.SerializeUncompressed(),
+		DID:        newIdentity.DID,
+	}, nil
+}

--- a/acp/identity/identity_test.go
+++ b/acp/identity/identity_test.go
@@ -42,3 +42,37 @@ func Test_DIDFromPublicKey_ReturnsErrorWhenProducerFails(t *testing.T) {
 	require.Empty(t, did)
 	require.ErrorIs(t, err, ErrDIDCreation)
 }
+
+func Test_RawIdentityGeneration_ReturnsNewRawIdentity(t *testing.T) {
+	newIdentity, err := Generate()
+	require.NoError(t, err)
+
+	// Check that both private and public key are not empty.
+	require.NotEmpty(t, newIdentity.PrivateKey)
+	require.NotEmpty(t, newIdentity.PublicKey)
+
+	// Check leading `did:key` prefix.
+	require.Equal(t, newIdentity.DID[:7], "did:key")
+}
+
+func Test_RawIdentityGenerationIsNotFixed_ReturnsUniqueRawIdentites(t *testing.T) {
+	newIdentity1, err1 := Generate()
+	newIdentity2, err2 := Generate()
+	require.NoError(t, err1)
+	require.NoError(t, err2)
+
+	// Check that both private and public key are not empty.
+	require.NotEmpty(t, newIdentity1.PrivateKey)
+	require.NotEmpty(t, newIdentity1.PublicKey)
+	require.NotEmpty(t, newIdentity2.PrivateKey)
+	require.NotEmpty(t, newIdentity2.PublicKey)
+
+	// Check leading `did:key` prefix.
+	require.Equal(t, newIdentity1.DID[:7], "did:key")
+	require.Equal(t, newIdentity2.DID[:7], "did:key")
+
+	// Check both are different.
+	require.NotEqual(t, newIdentity1.PrivateKey, newIdentity2.PrivateKey)
+	require.NotEqual(t, newIdentity1.PublicKey, newIdentity2.PublicKey)
+	require.NotEqual(t, newIdentity1.DID, newIdentity2.DID)
+}

--- a/acp/identity/identity_test.go
+++ b/acp/identity/identity_test.go
@@ -30,7 +30,7 @@ func Test_DIDFromPublicKey_ProducesDIDForPublicKey(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func Test_didFromPublicKey_ReturnsErrorWhenProducerFails(t *testing.T) {
+func Test_DIDFromPublicKey_ReturnsErrorWhenProducerFails(t *testing.T) {
 	mockedProducer := func(crypto.KeyType, []byte) (*key.DIDKey, error) {
 		return nil, fmt.Errorf("did generation err")
 	}

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -129,10 +129,16 @@ func NewDefraCommand() *cobra.Command {
 		MakeKeyringExportCommand(),
 	)
 
+	identity := MakeIdentityCommand()
+	identity.AddCommand(
+		MakeIdentityNewCommand(),
+	)
+
 	root := MakeRootCommand()
 	root.AddCommand(
 		client,
 		keyring,
+		identity,
 		MakeStartCommand(),
 		MakeServerDumpCmd(),
 		MakeVersionCommand(),

--- a/cli/identity.go
+++ b/cli/identity.go
@@ -1,0 +1,25 @@
+// Copyright 2024 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package cli
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func MakeIdentityCommand() *cobra.Command {
+	var cmd = &cobra.Command{
+		Use:   "identity",
+		Short: "Interact with identity features of DefraDB instance",
+		Long:  `Interact with identity features of DefraDB instance`,
+	}
+
+	return cmd
+}

--- a/cli/identity_new.go
+++ b/cli/identity_new.go
@@ -1,0 +1,40 @@
+// Copyright 2024 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package cli
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/sourcenetwork/defradb/acp/identity"
+)
+
+func MakeIdentityNewCommand() *cobra.Command {
+	var cmd = &cobra.Command{
+		Use:   "new",
+		Short: "Generate a new identity",
+		Long: `Generate a new identity
+
+Example: generate a new identity:
+  defradb identity new
+
+`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			newIdentity, err := identity.Generate()
+			if err != nil {
+				return err
+			}
+
+			return writeJSON(cmd, newIdentity)
+		},
+	}
+
+	return cmd
+}

--- a/cli/identity_new_test.go
+++ b/cli/identity_new_test.go
@@ -1,0 +1,26 @@
+// Copyright 2024 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package cli
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewIdentityGeneration(t *testing.T) {
+	cmd := NewDefraCommand()
+
+	cmd.SetArgs([]string{"identity", "new"})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+}

--- a/docs/website/references/cli/defradb_identity.md
+++ b/docs/website/references/cli/defradb_identity.md
@@ -1,18 +1,20 @@
-## defradb
+## defradb identity
 
-DefraDB Edge Database
+Interact with identity features of DefraDB instance
 
 ### Synopsis
 
-DefraDB is the edge database to power the user-centric future.
-
-Start a DefraDB node, interact with a local or remote node, and much more.
-
+Interact with identity features of DefraDB instance
 
 ### Options
 
 ```
-  -h, --help                       help for defradb
+  -h, --help   help for identity
+```
+
+### Options inherited from parent commands
+
+```
       --keyring-backend string     Keyring backend to use. Options are file or system (default "file")
       --keyring-namespace string   Service name to use when using the system backend (default "defradb")
       --keyring-path string        Path to store encrypted keys when using the file backend (default "keys")
@@ -30,10 +32,6 @@ Start a DefraDB node, interact with a local or remote node, and much more.
 
 ### SEE ALSO
 
-* [defradb client](defradb_client.md)	 - Interact with a DefraDB node
-* [defradb identity](defradb_identity.md)	 - Interact with identity features of DefraDB instance
-* [defradb keyring](defradb_keyring.md)	 - Manage DefraDB private keys
-* [defradb server-dump](defradb_server-dump.md)	 - Dumps the state of the entire database
-* [defradb start](defradb_start.md)	 - Start a DefraDB node
-* [defradb version](defradb_version.md)	 - Display the version information of DefraDB and its components
+* [defradb](defradb.md)	 - DefraDB Edge Database
+* [defradb identity new](defradb_identity_new.md)	 - Generate a new identity
 

--- a/docs/website/references/cli/defradb_identity_new.md
+++ b/docs/website/references/cli/defradb_identity_new.md
@@ -1,18 +1,29 @@
-## defradb
+## defradb identity new
 
-DefraDB Edge Database
+Generate a new identity
 
 ### Synopsis
 
-DefraDB is the edge database to power the user-centric future.
+Generate a new identity
 
-Start a DefraDB node, interact with a local or remote node, and much more.
+Example: generate a new identity:
+  defradb identity new
 
+
+
+```
+defradb identity new [flags]
+```
 
 ### Options
 
 ```
-  -h, --help                       help for defradb
+  -h, --help   help for new
+```
+
+### Options inherited from parent commands
+
+```
       --keyring-backend string     Keyring backend to use. Options are file or system (default "file")
       --keyring-namespace string   Service name to use when using the system backend (default "defradb")
       --keyring-path string        Path to store encrypted keys when using the file backend (default "keys")
@@ -30,10 +41,5 @@ Start a DefraDB node, interact with a local or remote node, and much more.
 
 ### SEE ALSO
 
-* [defradb client](defradb_client.md)	 - Interact with a DefraDB node
 * [defradb identity](defradb_identity.md)	 - Interact with identity features of DefraDB instance
-* [defradb keyring](defradb_keyring.md)	 - Manage DefraDB private keys
-* [defradb server-dump](defradb_server-dump.md)	 - Dumps the state of the entire database
-* [defradb start](defradb_start.md)	 - Start a DefraDB node
-* [defradb version](defradb_version.md)	 - Display the version information of DefraDB and its components
 


### PR DESCRIPTION
## Relevant issue(s)
Resolves #2554 

## Description
Now that the `core_acp` work is merged the identity generation becomes much more simple, with a `did` instead of `source address`. This util command can be handy to quickly generate new identity pairs with their did.

### Demo

Issue the command:
```
$ defradb identity new
```

Output:
```json
{
  "PrivateKey": "8wsOdJZCg06ISJxBqUyrD1ovDF5WgJJrSup2i4avnuU=",
  "PublicKey": "BG6dw3UW3rv+IiTXfL0LXvACw7Qz3DSBy1KmS/eSNrsrRkToBsize7zp+xwFrelPylOPgZguG7ZmirAtTaY89ow=",
  "DID": "did:key:z7r8oqgz72xy7Z7V5WGF21iWc7EY8vCpjZA1nGugoKjGeppeMkqeD7FV5AxEQAnciBz5vk5c2zrTZytofJNM8ZxyBzSpT"
}

```


## How has this been tested?
- cli test
- unit tests

Specify the platform(s) on which this was tested:
- WSL2
