### PR TITLE
fix: Return slice of correct length from db.AddSchema

### DIFF
--- a/internal/db/collection_define.go
+++ b/internal/db/collection_define.go
@@ -29,7 +29,7 @@ func (db *db) createCollections(
 	ctx context.Context,
 	newDefinitions []client.CollectionDefinition,
 ) ([]client.CollectionDefinition, error) {
-	returnDescriptions := make([]client.CollectionDefinition, len(newDefinitions))
+	returnDescriptions := make([]client.CollectionDefinition, 0, len(newDefinitions))
 
 	existingDefinitions, err := db.getAllActiveDefinitions(ctx)
 	if err != nil {


### PR DESCRIPTION
## Relevant issue(s)

Resolves #2764

## Description

Return slice of correct length from db.AddSchema, values are appended to this slice later in the function, but the result declaration is done as if they will be set by index.

Bug also affected `db.AddView`.

~~I'll create a ticket to allow us to test this properly (the results of `AddSchema and `AddView` are never asserted by our integration tests atm).~~ Ticket created: https://github.com/sourcenetwork/defradb/issues/2766
 