### PR TITLE
fix: Change new identity keys to hex format

### DIFF
--- a/acp/identity/generate.go
+++ b/acp/identity/generate.go
@@ -10,17 +10,22 @@
 
 package identity
 
-import "github.com/sourcenetwork/defradb/crypto"
+import (
+	"encoding/hex"
+
+	"github.com/sourcenetwork/defradb/crypto"
+)
 
 // RawIdentity holds the raw bytes that make up an actor's identity.
 type RawIdentity struct {
-	// An actor's private key.
-	PrivateKey []byte
+	// PrivateKey is a secp256k1 private key that is a 256-bit big-endian
+	// binary-encoded number, padded to a length of 32 bytes in HEX format.
+	PrivateKey string
 
-	// An actor's corresponding public key address.
-	PublicKey []byte
+	// PublicKey is a compressed 33-byte secp256k1 public key in HEX format.
+	PublicKey string
 
-	// An actor's DID. Generated from the public key address.
+	// DID is `did:key` key generated from the public key address.
 	DID string
 }
 
@@ -43,8 +48,8 @@ func Generate() (RawIdentity, error) {
 	newIdentity := maybeNewIdentity.Value()
 
 	return RawIdentity{
-		PrivateKey: newIdentity.PrivateKey.Serialize(),
-		PublicKey:  newIdentity.PublicKey.SerializeUncompressed(),
+		PrivateKey: hex.EncodeToString(newIdentity.PrivateKey.Serialize()),
+		PublicKey:  hex.EncodeToString(newIdentity.PublicKey.SerializeCompressed()),
 		DID:        newIdentity.DID,
 	}, nil
 }

--- a/cli/identity_new.go
+++ b/cli/identity_new.go
@@ -22,6 +22,12 @@ func MakeIdentityNewCommand() *cobra.Command {
 		Short: "Generate a new identity",
 		Long: `Generate a new identity
 
+The generated identity contains:
+- A secp256k1 private key that is a 256-bit big-endian binary-encoded number,
+padded to a length of 32 bytes in HEX format.
+- A compressed 33-byte secp256k1 public key in HEX format.
+- A "did:key" generated from the public key.
+
 Example: generate a new identity:
   defradb identity new
 

--- a/docs/website/references/cli/defradb_identity_new.md
+++ b/docs/website/references/cli/defradb_identity_new.md
@@ -6,6 +6,12 @@ Generate a new identity
 
 Generate a new identity
 
+The generated identity contains:
+- A secp256k1 private key that is a 256-bit big-endian binary-encoded number,
+padded to a length of 32 bytes in HEX format.
+- A compressed 33-byte secp256k1 public key in HEX format.
+- A "did:key" generated from the public key.
+
 Example: generate a new identity:
   defradb identity new
 


### PR DESCRIPTION
## Relevant issue(s)
Resolves #2770 

## Description
- Return the priv/pub keys in hex

Specify the platform(s) on which this was tested:
- WSL2
