### PR TITLE
chore(i): Bump mockery to `v2.43.0` & fix deprecated config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,7 +160,7 @@ deps\:modules:
 
 .PHONY: deps\:mocks
 deps\:mocks:
-	go install github.com/vektra/mockery/v2@v2.32.0
+	go install github.com/vektra/mockery/v2@v2.43.0
 
 .PHONY: deps\:playground
 deps\:playground:

--- a/client/mocks/collection.go
+++ b/client/mocks/collection.go
@@ -29,6 +29,10 @@ func (_m *Collection) EXPECT() *Collection_Expecter {
 func (_m *Collection) Create(ctx context.Context, doc *client.Document) error {
 	ret := _m.Called(ctx, doc)
 
+	if len(ret) == 0 {
+		panic("no return value specified for Create")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, *client.Document) error); ok {
 		r0 = rf(ctx, doc)
@@ -71,6 +75,10 @@ func (_c *Collection_Create_Call) RunAndReturn(run func(context.Context, *client
 // CreateIndex provides a mock function with given fields: _a0, _a1
 func (_m *Collection) CreateIndex(_a0 context.Context, _a1 client.IndexDescription) (client.IndexDescription, error) {
 	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CreateIndex")
+	}
 
 	var r0 client.IndexDescription
 	var r1 error
@@ -125,6 +133,10 @@ func (_c *Collection_CreateIndex_Call) RunAndReturn(run func(context.Context, cl
 func (_m *Collection) CreateMany(ctx context.Context, docs []*client.Document) error {
 	ret := _m.Called(ctx, docs)
 
+	if len(ret) == 0 {
+		panic("no return value specified for CreateMany")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, []*client.Document) error); ok {
 		r0 = rf(ctx, docs)
@@ -168,6 +180,10 @@ func (_c *Collection_CreateMany_Call) RunAndReturn(run func(context.Context, []*
 func (_m *Collection) Definition() client.CollectionDefinition {
 	ret := _m.Called()
 
+	if len(ret) == 0 {
+		panic("no return value specified for Definition")
+	}
+
 	var r0 client.CollectionDefinition
 	if rf, ok := ret.Get(0).(func() client.CollectionDefinition); ok {
 		r0 = rf()
@@ -208,6 +224,10 @@ func (_c *Collection_Definition_Call) RunAndReturn(run func() client.CollectionD
 // Delete provides a mock function with given fields: ctx, docID
 func (_m *Collection) Delete(ctx context.Context, docID client.DocID) (bool, error) {
 	ret := _m.Called(ctx, docID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Delete")
+	}
 
 	var r0 bool
 	var r1 error
@@ -261,6 +281,10 @@ func (_c *Collection_Delete_Call) RunAndReturn(run func(context.Context, client.
 // DeleteWithFilter provides a mock function with given fields: ctx, filter
 func (_m *Collection) DeleteWithFilter(ctx context.Context, filter interface{}) (*client.DeleteResult, error) {
 	ret := _m.Called(ctx, filter)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteWithFilter")
+	}
 
 	var r0 *client.DeleteResult
 	var r1 error
@@ -317,6 +341,10 @@ func (_c *Collection_DeleteWithFilter_Call) RunAndReturn(run func(context.Contex
 func (_m *Collection) Description() client.CollectionDescription {
 	ret := _m.Called()
 
+	if len(ret) == 0 {
+		panic("no return value specified for Description")
+	}
+
 	var r0 client.CollectionDescription
 	if rf, ok := ret.Get(0).(func() client.CollectionDescription); ok {
 		r0 = rf()
@@ -357,6 +385,10 @@ func (_c *Collection_Description_Call) RunAndReturn(run func() client.Collection
 // DropIndex provides a mock function with given fields: ctx, indexName
 func (_m *Collection) DropIndex(ctx context.Context, indexName string) error {
 	ret := _m.Called(ctx, indexName)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DropIndex")
+	}
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
@@ -400,6 +432,10 @@ func (_c *Collection_DropIndex_Call) RunAndReturn(run func(context.Context, stri
 // Exists provides a mock function with given fields: ctx, docID
 func (_m *Collection) Exists(ctx context.Context, docID client.DocID) (bool, error) {
 	ret := _m.Called(ctx, docID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Exists")
+	}
 
 	var r0 bool
 	var r1 error
@@ -453,6 +489,10 @@ func (_c *Collection_Exists_Call) RunAndReturn(run func(context.Context, client.
 // Get provides a mock function with given fields: ctx, docID, showDeleted
 func (_m *Collection) Get(ctx context.Context, docID client.DocID, showDeleted bool) (*client.Document, error) {
 	ret := _m.Called(ctx, docID, showDeleted)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Get")
+	}
 
 	var r0 *client.Document
 	var r1 error
@@ -510,6 +550,10 @@ func (_c *Collection_Get_Call) RunAndReturn(run func(context.Context, client.Doc
 func (_m *Collection) GetAllDocIDs(ctx context.Context) (<-chan client.DocIDResult, error) {
 	ret := _m.Called(ctx)
 
+	if len(ret) == 0 {
+		panic("no return value specified for GetAllDocIDs")
+	}
+
 	var r0 <-chan client.DocIDResult
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context) (<-chan client.DocIDResult, error)); ok {
@@ -563,6 +607,10 @@ func (_c *Collection_GetAllDocIDs_Call) RunAndReturn(run func(context.Context) (
 // GetIndexes provides a mock function with given fields: ctx
 func (_m *Collection) GetIndexes(ctx context.Context) ([]client.IndexDescription, error) {
 	ret := _m.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetIndexes")
+	}
 
 	var r0 []client.IndexDescription
 	var r1 error
@@ -618,6 +666,10 @@ func (_c *Collection_GetIndexes_Call) RunAndReturn(run func(context.Context) ([]
 func (_m *Collection) ID() uint32 {
 	ret := _m.Called()
 
+	if len(ret) == 0 {
+		panic("no return value specified for ID")
+	}
+
 	var r0 uint32
 	if rf, ok := ret.Get(0).(func() uint32); ok {
 		r0 = rf()
@@ -659,6 +711,10 @@ func (_c *Collection_ID_Call) RunAndReturn(run func() uint32) *Collection_ID_Cal
 func (_m *Collection) Name() immutable.Option[string] {
 	ret := _m.Called()
 
+	if len(ret) == 0 {
+		panic("no return value specified for Name")
+	}
+
 	var r0 immutable.Option[string]
 	if rf, ok := ret.Get(0).(func() immutable.Option[string]); ok {
 		r0 = rf()
@@ -699,6 +755,10 @@ func (_c *Collection_Name_Call) RunAndReturn(run func() immutable.Option[string]
 // Save provides a mock function with given fields: ctx, doc
 func (_m *Collection) Save(ctx context.Context, doc *client.Document) error {
 	ret := _m.Called(ctx, doc)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Save")
+	}
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, *client.Document) error); ok {
@@ -743,6 +803,10 @@ func (_c *Collection_Save_Call) RunAndReturn(run func(context.Context, *client.D
 func (_m *Collection) Schema() client.SchemaDescription {
 	ret := _m.Called()
 
+	if len(ret) == 0 {
+		panic("no return value specified for Schema")
+	}
+
 	var r0 client.SchemaDescription
 	if rf, ok := ret.Get(0).(func() client.SchemaDescription); ok {
 		r0 = rf()
@@ -784,6 +848,10 @@ func (_c *Collection_Schema_Call) RunAndReturn(run func() client.SchemaDescripti
 func (_m *Collection) SchemaRoot() string {
 	ret := _m.Called()
 
+	if len(ret) == 0 {
+		panic("no return value specified for SchemaRoot")
+	}
+
 	var r0 string
 	if rf, ok := ret.Get(0).(func() string); ok {
 		r0 = rf()
@@ -824,6 +892,10 @@ func (_c *Collection_SchemaRoot_Call) RunAndReturn(run func() string) *Collectio
 // Update provides a mock function with given fields: ctx, docs
 func (_m *Collection) Update(ctx context.Context, docs *client.Document) error {
 	ret := _m.Called(ctx, docs)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Update")
+	}
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, *client.Document) error); ok {
@@ -867,6 +939,10 @@ func (_c *Collection_Update_Call) RunAndReturn(run func(context.Context, *client
 // UpdateWithFilter provides a mock function with given fields: ctx, filter, updater
 func (_m *Collection) UpdateWithFilter(ctx context.Context, filter interface{}, updater string) (*client.UpdateResult, error) {
 	ret := _m.Called(ctx, filter, updater)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateWithFilter")
+	}
 
 	var r0 *client.UpdateResult
 	var r1 error

--- a/client/mocks/db.go
+++ b/client/mocks/db.go
@@ -37,6 +37,10 @@ func (_m *DB) EXPECT() *DB_Expecter {
 func (_m *DB) AddPolicy(ctx context.Context, policy string) (client.AddPolicyResult, error) {
 	ret := _m.Called(ctx, policy)
 
+	if len(ret) == 0 {
+		panic("no return value specified for AddPolicy")
+	}
+
 	var r0 client.AddPolicyResult
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, string) (client.AddPolicyResult, error)); ok {
@@ -89,6 +93,10 @@ func (_c *DB_AddPolicy_Call) RunAndReturn(run func(context.Context, string) (cli
 // AddSchema provides a mock function with given fields: _a0, _a1
 func (_m *DB) AddSchema(_a0 context.Context, _a1 string) ([]client.CollectionDescription, error) {
 	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for AddSchema")
+	}
 
 	var r0 []client.CollectionDescription
 	var r1 error
@@ -144,6 +152,10 @@ func (_c *DB_AddSchema_Call) RunAndReturn(run func(context.Context, string) ([]c
 // AddView provides a mock function with given fields: ctx, gqlQuery, sdl, transform
 func (_m *DB) AddView(ctx context.Context, gqlQuery string, sdl string, transform immutable.Option[model.Lens]) ([]client.CollectionDefinition, error) {
 	ret := _m.Called(ctx, gqlQuery, sdl, transform)
+
+	if len(ret) == 0 {
+		panic("no return value specified for AddView")
+	}
 
 	var r0 []client.CollectionDefinition
 	var r1 error
@@ -202,6 +214,10 @@ func (_c *DB_AddView_Call) RunAndReturn(run func(context.Context, string, string
 func (_m *DB) BasicExport(ctx context.Context, config *client.BackupConfig) error {
 	ret := _m.Called(ctx, config)
 
+	if len(ret) == 0 {
+		panic("no return value specified for BasicExport")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, *client.BackupConfig) error); ok {
 		r0 = rf(ctx, config)
@@ -245,6 +261,10 @@ func (_c *DB_BasicExport_Call) RunAndReturn(run func(context.Context, *client.Ba
 func (_m *DB) BasicImport(ctx context.Context, filepath string) error {
 	ret := _m.Called(ctx, filepath)
 
+	if len(ret) == 0 {
+		panic("no return value specified for BasicImport")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
 		r0 = rf(ctx, filepath)
@@ -287,6 +307,10 @@ func (_c *DB_BasicImport_Call) RunAndReturn(run func(context.Context, string) er
 // Blockstore provides a mock function with given fields:
 func (_m *DB) Blockstore() datastore.DAGStore {
 	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for Blockstore")
+	}
 
 	var r0 datastore.DAGStore
 	if rf, ok := ret.Get(0).(func() datastore.DAGStore); ok {
@@ -363,6 +387,10 @@ func (_c *DB_Close_Call) RunAndReturn(run func()) *DB_Close_Call {
 func (_m *DB) Events() *event.Bus {
 	ret := _m.Called()
 
+	if len(ret) == 0 {
+		panic("no return value specified for Events")
+	}
+
 	var r0 *event.Bus
 	if rf, ok := ret.Get(0).(func() *event.Bus); ok {
 		r0 = rf()
@@ -405,6 +433,10 @@ func (_c *DB_Events_Call) RunAndReturn(run func() *event.Bus) *DB_Events_Call {
 // ExecRequest provides a mock function with given fields: ctx, request
 func (_m *DB) ExecRequest(ctx context.Context, request string) *client.RequestResult {
 	ret := _m.Called(ctx, request)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ExecRequest")
+	}
 
 	var r0 *client.RequestResult
 	if rf, ok := ret.Get(0).(func(context.Context, string) *client.RequestResult); ok {
@@ -450,6 +482,10 @@ func (_c *DB_ExecRequest_Call) RunAndReturn(run func(context.Context, string) *c
 // GetAllIndexes provides a mock function with given fields: _a0
 func (_m *DB) GetAllIndexes(_a0 context.Context) (map[string][]client.IndexDescription, error) {
 	ret := _m.Called(_a0)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetAllIndexes")
+	}
 
 	var r0 map[string][]client.IndexDescription
 	var r1 error
@@ -504,6 +540,10 @@ func (_c *DB_GetAllIndexes_Call) RunAndReturn(run func(context.Context) (map[str
 // GetCollectionByName provides a mock function with given fields: _a0, _a1
 func (_m *DB) GetCollectionByName(_a0 context.Context, _a1 string) (client.Collection, error) {
 	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetCollectionByName")
+	}
 
 	var r0 client.Collection
 	var r1 error
@@ -560,6 +600,10 @@ func (_c *DB_GetCollectionByName_Call) RunAndReturn(run func(context.Context, st
 func (_m *DB) GetCollections(_a0 context.Context, _a1 client.CollectionFetchOptions) ([]client.Collection, error) {
 	ret := _m.Called(_a0, _a1)
 
+	if len(ret) == 0 {
+		panic("no return value specified for GetCollections")
+	}
+
 	var r0 []client.Collection
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, client.CollectionFetchOptions) ([]client.Collection, error)); ok {
@@ -615,6 +659,10 @@ func (_c *DB_GetCollections_Call) RunAndReturn(run func(context.Context, client.
 func (_m *DB) GetSchemaByVersionID(_a0 context.Context, _a1 string) (client.SchemaDescription, error) {
 	ret := _m.Called(_a0, _a1)
 
+	if len(ret) == 0 {
+		panic("no return value specified for GetSchemaByVersionID")
+	}
+
 	var r0 client.SchemaDescription
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, string) (client.SchemaDescription, error)); ok {
@@ -667,6 +715,10 @@ func (_c *DB_GetSchemaByVersionID_Call) RunAndReturn(run func(context.Context, s
 // GetSchemas provides a mock function with given fields: _a0, _a1
 func (_m *DB) GetSchemas(_a0 context.Context, _a1 client.SchemaFetchOptions) ([]client.SchemaDescription, error) {
 	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetSchemas")
+	}
 
 	var r0 []client.SchemaDescription
 	var r1 error
@@ -723,6 +775,10 @@ func (_c *DB_GetSchemas_Call) RunAndReturn(run func(context.Context, client.Sche
 func (_m *DB) Headstore() go_datastore.Read {
 	ret := _m.Called()
 
+	if len(ret) == 0 {
+		panic("no return value specified for Headstore")
+	}
+
 	var r0 go_datastore.Read
 	if rf, ok := ret.Get(0).(func() go_datastore.Read); ok {
 		r0 = rf()
@@ -765,6 +821,10 @@ func (_c *DB_Headstore_Call) RunAndReturn(run func() go_datastore.Read) *DB_Head
 // LensRegistry provides a mock function with given fields:
 func (_m *DB) LensRegistry() client.LensRegistry {
 	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for LensRegistry")
+	}
 
 	var r0 client.LensRegistry
 	if rf, ok := ret.Get(0).(func() client.LensRegistry); ok {
@@ -809,6 +869,10 @@ func (_c *DB_LensRegistry_Call) RunAndReturn(run func() client.LensRegistry) *DB
 func (_m *DB) MaxTxnRetries() int {
 	ret := _m.Called()
 
+	if len(ret) == 0 {
+		panic("no return value specified for MaxTxnRetries")
+	}
+
 	var r0 int
 	if rf, ok := ret.Get(0).(func() int); ok {
 		r0 = rf()
@@ -849,6 +913,10 @@ func (_c *DB_MaxTxnRetries_Call) RunAndReturn(run func() int) *DB_MaxTxnRetries_
 // NewConcurrentTxn provides a mock function with given fields: _a0, _a1
 func (_m *DB) NewConcurrentTxn(_a0 context.Context, _a1 bool) (datastore.Txn, error) {
 	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for NewConcurrentTxn")
+	}
 
 	var r0 datastore.Txn
 	var r1 error
@@ -905,6 +973,10 @@ func (_c *DB_NewConcurrentTxn_Call) RunAndReturn(run func(context.Context, bool)
 func (_m *DB) NewTxn(_a0 context.Context, _a1 bool) (datastore.Txn, error) {
 	ret := _m.Called(_a0, _a1)
 
+	if len(ret) == 0 {
+		panic("no return value specified for NewTxn")
+	}
+
 	var r0 datastore.Txn
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, bool) (datastore.Txn, error)); ok {
@@ -960,6 +1032,10 @@ func (_c *DB_NewTxn_Call) RunAndReturn(run func(context.Context, bool) (datastor
 func (_m *DB) PatchCollection(_a0 context.Context, _a1 string) error {
 	ret := _m.Called(_a0, _a1)
 
+	if len(ret) == 0 {
+		panic("no return value specified for PatchCollection")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
 		r0 = rf(_a0, _a1)
@@ -1002,6 +1078,10 @@ func (_c *DB_PatchCollection_Call) RunAndReturn(run func(context.Context, string
 // PatchSchema provides a mock function with given fields: _a0, _a1, _a2, _a3
 func (_m *DB) PatchSchema(_a0 context.Context, _a1 string, _a2 immutable.Option[model.Lens], _a3 bool) error {
 	ret := _m.Called(_a0, _a1, _a2, _a3)
+
+	if len(ret) == 0 {
+		panic("no return value specified for PatchSchema")
+	}
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, string, immutable.Option[model.Lens], bool) error); ok {
@@ -1048,6 +1128,10 @@ func (_c *DB_PatchSchema_Call) RunAndReturn(run func(context.Context, string, im
 func (_m *DB) Peerstore() datastore.DSBatching {
 	ret := _m.Called()
 
+	if len(ret) == 0 {
+		panic("no return value specified for Peerstore")
+	}
+
 	var r0 datastore.DSBatching
 	if rf, ok := ret.Get(0).(func() datastore.DSBatching); ok {
 		r0 = rf()
@@ -1091,6 +1175,10 @@ func (_c *DB_Peerstore_Call) RunAndReturn(run func() datastore.DSBatching) *DB_P
 func (_m *DB) PrintDump(ctx context.Context) error {
 	ret := _m.Called(ctx)
 
+	if len(ret) == 0 {
+		panic("no return value specified for PrintDump")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context) error); ok {
 		r0 = rf(ctx)
@@ -1132,6 +1220,10 @@ func (_c *DB_PrintDump_Call) RunAndReturn(run func(context.Context) error) *DB_P
 // Root provides a mock function with given fields:
 func (_m *DB) Root() datastore.RootStore {
 	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for Root")
+	}
 
 	var r0 datastore.RootStore
 	if rf, ok := ret.Get(0).(func() datastore.RootStore); ok {
@@ -1176,6 +1268,10 @@ func (_c *DB_Root_Call) RunAndReturn(run func() datastore.RootStore) *DB_Root_Ca
 func (_m *DB) SetActiveSchemaVersion(_a0 context.Context, _a1 string) error {
 	ret := _m.Called(_a0, _a1)
 
+	if len(ret) == 0 {
+		panic("no return value specified for SetActiveSchemaVersion")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
 		r0 = rf(_a0, _a1)
@@ -1218,6 +1314,10 @@ func (_c *DB_SetActiveSchemaVersion_Call) RunAndReturn(run func(context.Context,
 // SetMigration provides a mock function with given fields: _a0, _a1
 func (_m *DB) SetMigration(_a0 context.Context, _a1 client.LensConfig) error {
 	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SetMigration")
+	}
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, client.LensConfig) error); ok {

--- a/datastore/mocks/dag_store.go
+++ b/datastore/mocks/dag_store.go
@@ -30,6 +30,10 @@ func (_m *DAGStore) EXPECT() *DAGStore_Expecter {
 func (_m *DAGStore) AllKeysChan(ctx context.Context) (<-chan cid.Cid, error) {
 	ret := _m.Called(ctx)
 
+	if len(ret) == 0 {
+		panic("no return value specified for AllKeysChan")
+	}
+
 	var r0 <-chan cid.Cid
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context) (<-chan cid.Cid, error)); ok {
@@ -84,6 +88,10 @@ func (_c *DAGStore_AllKeysChan_Call) RunAndReturn(run func(context.Context) (<-c
 func (_m *DAGStore) AsIPLDStorage() datastore.IPLDStorage {
 	ret := _m.Called()
 
+	if len(ret) == 0 {
+		panic("no return value specified for AsIPLDStorage")
+	}
+
 	var r0 datastore.IPLDStorage
 	if rf, ok := ret.Get(0).(func() datastore.IPLDStorage); ok {
 		r0 = rf()
@@ -127,6 +135,10 @@ func (_c *DAGStore_AsIPLDStorage_Call) RunAndReturn(run func() datastore.IPLDSto
 func (_m *DAGStore) DeleteBlock(_a0 context.Context, _a1 cid.Cid) error {
 	ret := _m.Called(_a0, _a1)
 
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteBlock")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, cid.Cid) error); ok {
 		r0 = rf(_a0, _a1)
@@ -169,6 +181,10 @@ func (_c *DAGStore_DeleteBlock_Call) RunAndReturn(run func(context.Context, cid.
 // Get provides a mock function with given fields: _a0, _a1
 func (_m *DAGStore) Get(_a0 context.Context, _a1 cid.Cid) (blocks.Block, error) {
 	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Get")
+	}
 
 	var r0 blocks.Block
 	var r1 error
@@ -225,6 +241,10 @@ func (_c *DAGStore_Get_Call) RunAndReturn(run func(context.Context, cid.Cid) (bl
 func (_m *DAGStore) GetSize(_a0 context.Context, _a1 cid.Cid) (int, error) {
 	ret := _m.Called(_a0, _a1)
 
+	if len(ret) == 0 {
+		panic("no return value specified for GetSize")
+	}
+
 	var r0 int
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, cid.Cid) (int, error)); ok {
@@ -277,6 +297,10 @@ func (_c *DAGStore_GetSize_Call) RunAndReturn(run func(context.Context, cid.Cid)
 // Has provides a mock function with given fields: _a0, _a1
 func (_m *DAGStore) Has(_a0 context.Context, _a1 cid.Cid) (bool, error) {
 	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Has")
+	}
 
 	var r0 bool
 	var r1 error
@@ -364,6 +388,10 @@ func (_c *DAGStore_HashOnRead_Call) RunAndReturn(run func(bool)) *DAGStore_HashO
 func (_m *DAGStore) Put(_a0 context.Context, _a1 blocks.Block) error {
 	ret := _m.Called(_a0, _a1)
 
+	if len(ret) == 0 {
+		panic("no return value specified for Put")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, blocks.Block) error); ok {
 		r0 = rf(_a0, _a1)
@@ -406,6 +434,10 @@ func (_c *DAGStore_Put_Call) RunAndReturn(run func(context.Context, blocks.Block
 // PutMany provides a mock function with given fields: _a0, _a1
 func (_m *DAGStore) PutMany(_a0 context.Context, _a1 []blocks.Block) error {
 	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for PutMany")
+	}
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, []blocks.Block) error); ok {

--- a/datastore/mocks/ds_reader_writer.go
+++ b/datastore/mocks/ds_reader_writer.go
@@ -31,6 +31,10 @@ func (_m *DSReaderWriter) EXPECT() *DSReaderWriter_Expecter {
 func (_m *DSReaderWriter) Delete(ctx context.Context, key datastore.Key) error {
 	ret := _m.Called(ctx, key)
 
+	if len(ret) == 0 {
+		panic("no return value specified for Delete")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, datastore.Key) error); ok {
 		r0 = rf(ctx, key)
@@ -73,6 +77,10 @@ func (_c *DSReaderWriter_Delete_Call) RunAndReturn(run func(context.Context, dat
 // Get provides a mock function with given fields: ctx, key
 func (_m *DSReaderWriter) Get(ctx context.Context, key datastore.Key) ([]byte, error) {
 	ret := _m.Called(ctx, key)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Get")
+	}
 
 	var r0 []byte
 	var r1 error
@@ -129,6 +137,10 @@ func (_c *DSReaderWriter_Get_Call) RunAndReturn(run func(context.Context, datast
 func (_m *DSReaderWriter) GetIterator(q query.Query) (iterable.Iterator, error) {
 	ret := _m.Called(q)
 
+	if len(ret) == 0 {
+		panic("no return value specified for GetIterator")
+	}
+
 	var r0 iterable.Iterator
 	var r1 error
 	if rf, ok := ret.Get(0).(func(query.Query) (iterable.Iterator, error)); ok {
@@ -183,6 +195,10 @@ func (_c *DSReaderWriter_GetIterator_Call) RunAndReturn(run func(query.Query) (i
 func (_m *DSReaderWriter) GetSize(ctx context.Context, key datastore.Key) (int, error) {
 	ret := _m.Called(ctx, key)
 
+	if len(ret) == 0 {
+		panic("no return value specified for GetSize")
+	}
+
 	var r0 int
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, datastore.Key) (int, error)); ok {
@@ -235,6 +251,10 @@ func (_c *DSReaderWriter_GetSize_Call) RunAndReturn(run func(context.Context, da
 // Has provides a mock function with given fields: ctx, key
 func (_m *DSReaderWriter) Has(ctx context.Context, key datastore.Key) (bool, error) {
 	ret := _m.Called(ctx, key)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Has")
+	}
 
 	var r0 bool
 	var r1 error
@@ -289,6 +309,10 @@ func (_c *DSReaderWriter_Has_Call) RunAndReturn(run func(context.Context, datast
 func (_m *DSReaderWriter) Put(ctx context.Context, key datastore.Key, value []byte) error {
 	ret := _m.Called(ctx, key, value)
 
+	if len(ret) == 0 {
+		panic("no return value specified for Put")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, datastore.Key, []byte) error); ok {
 		r0 = rf(ctx, key, value)
@@ -332,6 +356,10 @@ func (_c *DSReaderWriter_Put_Call) RunAndReturn(run func(context.Context, datast
 // Query provides a mock function with given fields: ctx, q
 func (_m *DSReaderWriter) Query(ctx context.Context, q query.Query) (query.Results, error) {
 	ret := _m.Called(ctx, q)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Query")
+	}
 
 	var r0 query.Results
 	var r1 error

--- a/datastore/mocks/results.go
+++ b/datastore/mocks/results.go
@@ -26,6 +26,10 @@ func (_m *Results) EXPECT() *Results_Expecter {
 func (_m *Results) Close() error {
 	ret := _m.Called()
 
+	if len(ret) == 0 {
+		panic("no return value specified for Close")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func() error); ok {
 		r0 = rf()
@@ -66,6 +70,10 @@ func (_c *Results_Close_Call) RunAndReturn(run func() error) *Results_Close_Call
 // Next provides a mock function with given fields:
 func (_m *Results) Next() <-chan query.Result {
 	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for Next")
+	}
 
 	var r0 <-chan query.Result
 	if rf, ok := ret.Get(0).(func() <-chan query.Result); ok {
@@ -109,6 +117,10 @@ func (_c *Results_Next_Call) RunAndReturn(run func() <-chan query.Result) *Resul
 // NextSync provides a mock function with given fields:
 func (_m *Results) NextSync() (query.Result, bool) {
 	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for NextSync")
+	}
 
 	var r0 query.Result
 	var r1 bool
@@ -161,6 +173,10 @@ func (_c *Results_NextSync_Call) RunAndReturn(run func() (query.Result, bool)) *
 func (_m *Results) Process() goprocess.Process {
 	ret := _m.Called()
 
+	if len(ret) == 0 {
+		panic("no return value specified for Process")
+	}
+
 	var r0 goprocess.Process
 	if rf, ok := ret.Get(0).(func() goprocess.Process); ok {
 		r0 = rf()
@@ -204,6 +220,10 @@ func (_c *Results_Process_Call) RunAndReturn(run func() goprocess.Process) *Resu
 func (_m *Results) Query() query.Query {
 	ret := _m.Called()
 
+	if len(ret) == 0 {
+		panic("no return value specified for Query")
+	}
+
 	var r0 query.Query
 	if rf, ok := ret.Get(0).(func() query.Query); ok {
 		r0 = rf()
@@ -244,6 +264,10 @@ func (_c *Results_Query_Call) RunAndReturn(run func() query.Query) *Results_Quer
 // Rest provides a mock function with given fields:
 func (_m *Results) Rest() ([]query.Entry, error) {
 	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for Rest")
+	}
 
 	var r0 []query.Entry
 	var r1 error

--- a/datastore/mocks/root_store.go
+++ b/datastore/mocks/root_store.go
@@ -29,6 +29,10 @@ func (_m *RootStore) EXPECT() *RootStore_Expecter {
 func (_m *RootStore) Batch(ctx context.Context) (datastore.Batch, error) {
 	ret := _m.Called(ctx)
 
+	if len(ret) == 0 {
+		panic("no return value specified for Batch")
+	}
+
 	var r0 datastore.Batch
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context) (datastore.Batch, error)); ok {
@@ -83,6 +87,10 @@ func (_c *RootStore_Batch_Call) RunAndReturn(run func(context.Context) (datastor
 func (_m *RootStore) Close() error {
 	ret := _m.Called()
 
+	if len(ret) == 0 {
+		panic("no return value specified for Close")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func() error); ok {
 		r0 = rf()
@@ -123,6 +131,10 @@ func (_c *RootStore_Close_Call) RunAndReturn(run func() error) *RootStore_Close_
 // Delete provides a mock function with given fields: ctx, key
 func (_m *RootStore) Delete(ctx context.Context, key datastore.Key) error {
 	ret := _m.Called(ctx, key)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Delete")
+	}
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, datastore.Key) error); ok {
@@ -166,6 +178,10 @@ func (_c *RootStore_Delete_Call) RunAndReturn(run func(context.Context, datastor
 // Get provides a mock function with given fields: ctx, key
 func (_m *RootStore) Get(ctx context.Context, key datastore.Key) ([]byte, error) {
 	ret := _m.Called(ctx, key)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Get")
+	}
 
 	var r0 []byte
 	var r1 error
@@ -222,6 +238,10 @@ func (_c *RootStore_Get_Call) RunAndReturn(run func(context.Context, datastore.K
 func (_m *RootStore) GetSize(ctx context.Context, key datastore.Key) (int, error) {
 	ret := _m.Called(ctx, key)
 
+	if len(ret) == 0 {
+		panic("no return value specified for GetSize")
+	}
+
 	var r0 int
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, datastore.Key) (int, error)); ok {
@@ -275,6 +295,10 @@ func (_c *RootStore_GetSize_Call) RunAndReturn(run func(context.Context, datasto
 func (_m *RootStore) Has(ctx context.Context, key datastore.Key) (bool, error) {
 	ret := _m.Called(ctx, key)
 
+	if len(ret) == 0 {
+		panic("no return value specified for Has")
+	}
+
 	var r0 bool
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, datastore.Key) (bool, error)); ok {
@@ -327,6 +351,10 @@ func (_c *RootStore_Has_Call) RunAndReturn(run func(context.Context, datastore.K
 // NewTransaction provides a mock function with given fields: ctx, readOnly
 func (_m *RootStore) NewTransaction(ctx context.Context, readOnly bool) (datastore.Txn, error) {
 	ret := _m.Called(ctx, readOnly)
+
+	if len(ret) == 0 {
+		panic("no return value specified for NewTransaction")
+	}
 
 	var r0 datastore.Txn
 	var r1 error
@@ -383,6 +411,10 @@ func (_c *RootStore_NewTransaction_Call) RunAndReturn(run func(context.Context, 
 func (_m *RootStore) Put(ctx context.Context, key datastore.Key, value []byte) error {
 	ret := _m.Called(ctx, key, value)
 
+	if len(ret) == 0 {
+		panic("no return value specified for Put")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, datastore.Key, []byte) error); ok {
 		r0 = rf(ctx, key, value)
@@ -426,6 +458,10 @@ func (_c *RootStore_Put_Call) RunAndReturn(run func(context.Context, datastore.K
 // Query provides a mock function with given fields: ctx, q
 func (_m *RootStore) Query(ctx context.Context, q query.Query) (query.Results, error) {
 	ret := _m.Called(ctx, q)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Query")
+	}
 
 	var r0 query.Results
 	var r1 error
@@ -481,6 +517,10 @@ func (_c *RootStore_Query_Call) RunAndReturn(run func(context.Context, query.Que
 // Sync provides a mock function with given fields: ctx, prefix
 func (_m *RootStore) Sync(ctx context.Context, prefix datastore.Key) error {
 	ret := _m.Called(ctx, prefix)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Sync")
+	}
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, datastore.Key) error); ok {

--- a/datastore/mocks/txn.go
+++ b/datastore/mocks/txn.go
@@ -26,6 +26,10 @@ func (_m *Txn) EXPECT() *Txn_Expecter {
 func (_m *Txn) Commit(ctx context.Context) error {
 	ret := _m.Called(ctx)
 
+	if len(ret) == 0 {
+		panic("no return value specified for Commit")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context) error); ok {
 		r0 = rf(ctx)
@@ -67,6 +71,10 @@ func (_c *Txn_Commit_Call) RunAndReturn(run func(context.Context) error) *Txn_Co
 // DAGstore provides a mock function with given fields:
 func (_m *Txn) DAGstore() datastore.DAGStore {
 	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for DAGstore")
+	}
 
 	var r0 datastore.DAGStore
 	if rf, ok := ret.Get(0).(func() datastore.DAGStore); ok {
@@ -110,6 +118,10 @@ func (_c *Txn_DAGstore_Call) RunAndReturn(run func() datastore.DAGStore) *Txn_DA
 // Datastore provides a mock function with given fields:
 func (_m *Txn) Datastore() datastore.DSReaderWriter {
 	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for Datastore")
+	}
 
 	var r0 datastore.DSReaderWriter
 	if rf, ok := ret.Get(0).(func() datastore.DSReaderWriter); ok {
@@ -187,6 +199,10 @@ func (_c *Txn_Discard_Call) RunAndReturn(run func(context.Context)) *Txn_Discard
 func (_m *Txn) Headstore() datastore.DSReaderWriter {
 	ret := _m.Called()
 
+	if len(ret) == 0 {
+		panic("no return value specified for Headstore")
+	}
+
 	var r0 datastore.DSReaderWriter
 	if rf, ok := ret.Get(0).(func() datastore.DSReaderWriter); ok {
 		r0 = rf()
@@ -229,6 +245,10 @@ func (_c *Txn_Headstore_Call) RunAndReturn(run func() datastore.DSReaderWriter) 
 // ID provides a mock function with given fields:
 func (_m *Txn) ID() uint64 {
 	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for ID")
+	}
 
 	var r0 uint64
 	if rf, ok := ret.Get(0).(func() uint64); ok {
@@ -469,6 +489,10 @@ func (_c *Txn_OnSuccessAsync_Call) RunAndReturn(run func(func())) *Txn_OnSuccess
 func (_m *Txn) Peerstore() datastore.DSBatching {
 	ret := _m.Called()
 
+	if len(ret) == 0 {
+		panic("no return value specified for Peerstore")
+	}
+
 	var r0 datastore.DSBatching
 	if rf, ok := ret.Get(0).(func() datastore.DSBatching); ok {
 		r0 = rf()
@@ -512,6 +536,10 @@ func (_c *Txn_Peerstore_Call) RunAndReturn(run func() datastore.DSBatching) *Txn
 func (_m *Txn) Rootstore() datastore.DSReaderWriter {
 	ret := _m.Called()
 
+	if len(ret) == 0 {
+		panic("no return value specified for Rootstore")
+	}
+
 	var r0 datastore.DSReaderWriter
 	if rf, ok := ret.Get(0).(func() datastore.DSReaderWriter); ok {
 		r0 = rf()
@@ -554,6 +582,10 @@ func (_c *Txn_Rootstore_Call) RunAndReturn(run func() datastore.DSReaderWriter) 
 // Systemstore provides a mock function with given fields:
 func (_m *Txn) Systemstore() datastore.DSReaderWriter {
 	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for Systemstore")
+	}
 
 	var r0 datastore.DSReaderWriter
 	if rf, ok := ret.Get(0).(func() datastore.DSReaderWriter); ok {

--- a/internal/db/fetcher/mocks/encoded_document.go
+++ b/internal/db/fetcher/mocks/encoded_document.go
@@ -25,6 +25,10 @@ func (_m *EncodedDocument) EXPECT() *EncodedDocument_Expecter {
 func (_m *EncodedDocument) ID() []byte {
 	ret := _m.Called()
 
+	if len(ret) == 0 {
+		panic("no return value specified for ID")
+	}
+
 	var r0 []byte
 	if rf, ok := ret.Get(0).(func() []byte); ok {
 		r0 = rf()
@@ -67,6 +71,10 @@ func (_c *EncodedDocument_ID_Call) RunAndReturn(run func() []byte) *EncodedDocum
 // Properties provides a mock function with given fields: onlyFilterProps
 func (_m *EncodedDocument) Properties(onlyFilterProps bool) (map[client.FieldDefinition]interface{}, error) {
 	ret := _m.Called(onlyFilterProps)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Properties")
+	}
 
 	var r0 map[client.FieldDefinition]interface{}
 	var r1 error
@@ -154,6 +162,10 @@ func (_c *EncodedDocument_Reset_Call) RunAndReturn(run func()) *EncodedDocument_
 func (_m *EncodedDocument) SchemaVersionID() string {
 	ret := _m.Called()
 
+	if len(ret) == 0 {
+		panic("no return value specified for SchemaVersionID")
+	}
+
 	var r0 string
 	if rf, ok := ret.Get(0).(func() string); ok {
 		r0 = rf()
@@ -194,6 +206,10 @@ func (_c *EncodedDocument_SchemaVersionID_Call) RunAndReturn(run func() string) 
 // Status provides a mock function with given fields:
 func (_m *EncodedDocument) Status() client.DocumentStatus {
 	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for Status")
+	}
 
 	var r0 client.DocumentStatus
 	if rf, ok := ret.Get(0).(func() client.DocumentStatus); ok {

--- a/internal/db/fetcher/mocks/fetcher.go
+++ b/internal/db/fetcher/mocks/fetcher.go
@@ -40,6 +40,10 @@ func (_m *Fetcher) EXPECT() *Fetcher_Expecter {
 func (_m *Fetcher) Close() error {
 	ret := _m.Called()
 
+	if len(ret) == 0 {
+		panic("no return value specified for Close")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func() error); ok {
 		r0 = rf()
@@ -80,6 +84,10 @@ func (_c *Fetcher_Close_Call) RunAndReturn(run func() error) *Fetcher_Close_Call
 // FetchNext provides a mock function with given fields: ctx
 func (_m *Fetcher) FetchNext(ctx context.Context) (fetcher.EncodedDocument, fetcher.ExecInfo, error) {
 	ret := _m.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for FetchNext")
+	}
 
 	var r0 fetcher.EncodedDocument
 	var r1 fetcher.ExecInfo
@@ -142,6 +150,10 @@ func (_c *Fetcher_FetchNext_Call) RunAndReturn(run func(context.Context) (fetche
 func (_m *Fetcher) Init(ctx context.Context, _a1 immutable.Option[identity.Identity], txn datastore.Txn, _a3 immutable.Option[acp.ACP], col client.Collection, fields []client.FieldDefinition, filter *mapper.Filter, docmapper *core.DocumentMapping, reverse bool, showDeleted bool) error {
 	ret := _m.Called(ctx, _a1, txn, _a3, col, fields, filter, docmapper, reverse, showDeleted)
 
+	if len(ret) == 0 {
+		panic("no return value specified for Init")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, immutable.Option[identity.Identity], datastore.Txn, immutable.Option[acp.ACP], client.Collection, []client.FieldDefinition, *mapper.Filter, *core.DocumentMapping, bool, bool) error); ok {
 		r0 = rf(ctx, _a1, txn, _a3, col, fields, filter, docmapper, reverse, showDeleted)
@@ -192,6 +204,10 @@ func (_c *Fetcher_Init_Call) RunAndReturn(run func(context.Context, immutable.Op
 // Start provides a mock function with given fields: ctx, spans
 func (_m *Fetcher) Start(ctx context.Context, spans core.Spans) error {
 	ret := _m.Called(ctx, spans)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Start")
+	}
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, core.Spans) error); ok {

--- a/tools/configs/mockery.yaml
+++ b/tools/configs/mockery.yaml
@@ -4,8 +4,6 @@ with-expecter: true
 
 quiet: False
 
-keeptree: True
-
 disable-version-string: True
 
 log-level: "info"


### PR DESCRIPTION
## Relevant issue(s)
Resolves #2775

## Description
- Remove the deprecated config option that causes errors.
- Bump mockery to `2.43.0`

## How has this been tested?
locally

Specify the platform(s) on which this was tested:
- WSL2