### PR TITLE
ci(i): Bump all gh-action versions to support node20

### DIFF
--- a/.github/workflows/build-dependencies.yml
+++ b/.github/workflows/build-dependencies.yml
@@ -32,13 +32,14 @@ jobs:
     steps:
 
       - name: Checkout code into the directory
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Go environment explicitly
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version-file: 'go.mod'
           check-latest: true
+          cache: false
 
       - name: Build all dependencies
         run: make deps

--- a/.github/workflows/build-then-deploy-ami.yml
+++ b/.github/workflows/build-then-deploy-ami.yml
@@ -48,7 +48,7 @@ jobs:
 
     steps:
       - name: Checkout code into the directory
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Environment version target
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> ${GITHUB_ENV}
@@ -89,10 +89,10 @@ jobs:
 
     steps:
       - name: Checkout code into the directory
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Terraform action setup
-        uses: hashicorp/setup-terraform@v2
+        uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: 1.3.7
 

--- a/.github/workflows/check-documentation.yml
+++ b/.github/workflows/check-documentation.yml
@@ -33,13 +33,14 @@ jobs:
 
     steps:
       - name: Checkout code into the directory
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Go environment explicitly
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version-file: 'go.mod'
           check-latest: true
+          cache: false
 
       - name: Try generating cli documentation
         run: make docs:cli
@@ -58,13 +59,14 @@ jobs:
 
     steps:
       - name: Checkout code into the directory
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Go environment explicitly
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version-file: 'go.mod'
           check-latest: true
+          cache: false
 
       - name: Try generating http documentation
         run: make docs:http
@@ -83,13 +85,14 @@ jobs:
 
     steps:
       - name: Checkout code into the directory
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Go environment explicitly
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version-file: 'go.mod'
           check-latest: true
+          cache: false
 
       - name: Try generating readme toc
         run: make toc

--- a/.github/workflows/check-mocks.yml
+++ b/.github/workflows/check-mocks.yml
@@ -33,13 +33,14 @@ jobs:
 
     steps:
       - name: Checkout code into the directory
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Go environment explicitly
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version-file: 'go.mod'
           check-latest: true
+          cache: false
 
       - name: Try generating mocks
         run: make mocks

--- a/.github/workflows/check-tidy.yml
+++ b/.github/workflows/check-tidy.yml
@@ -37,13 +37,14 @@ jobs:
     steps:
 
       - name: Checkout code into the directory
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Go environment explicitly
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version-file: 'go.mod'
           check-latest: true
+          cache: false
 
       # This checks mod tidy is not broken.
       - name: Check mod tidy

--- a/.github/workflows/check-vulnerabilities.yml
+++ b/.github/workflows/check-vulnerabilities.yml
@@ -36,4 +36,4 @@ jobs:
           go-version-input: "1.21"
           go-package: ./...
           check-latest: true
-          cache: true
+          cache: false

--- a/.github/workflows/combine-bot-prs.yml
+++ b/.github/workflows/combine-bot-prs.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Create combined pr
         id: create-combined-pr
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/lint-then-benchmark.yml
+++ b/.github/workflows/lint-then-benchmark.yml
@@ -62,7 +62,7 @@ jobs:
           cache: false
 
       - name: Run the golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v6
 
         with:
           # Required: the version of golangci-lint is required.

--- a/.github/workflows/lint-then-benchmark.yml
+++ b/.github/workflows/lint-then-benchmark.yml
@@ -51,14 +51,15 @@ jobs:
 
     steps:
       - name: Checkout code into the directory
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Setting up Go explicitly is required for v3.0.0+ of golangci/golangci-lint-action.
       - name: Setup Go environment explicitly
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version-file: 'go.mod'
           check-latest: true
+          cache: false
 
       - name: Run the golangci-lint
         uses: golangci/golangci-lint-action@v3
@@ -192,7 +193,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run the full bechmarking suite
         if: needs.decide-benchmark-type.outputs.benchmark-type == 'FULL'
@@ -214,7 +215,7 @@ jobs:
         if: |
           github.event_name == 'push' &&
           github.ref_name == 'develop'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: bench-artifact-${{ github.sha }}
           path: bench-artifact-${{ github.sha }}.txt
@@ -245,7 +246,7 @@ jobs:
         if: |
           github.event_name == 'pull_request' &&
           github.base_ref == 'develop'
-        uses: dawidd6/action-download-artifact@v2
+        uses: dawidd6/action-download-artifact@v6
         with:
           github_token: ${{ secrets.ONLY_DEFRADB_REPO_CI_PAT }}
           workflow: lint-then-benchmark.yml

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,9 +19,12 @@ on:
   push:
 
 permissions:
-  # Allow read access to pull request (Required for the `only-new-issues` option.)
+  # Required for the `only-new-issues` option.
   pull-requests: read
+  # Required for analysis.
   contents: read
+  # Required to annotate code in the PR.
+  checks: write
 
 jobs:
   lint-go:
@@ -33,6 +36,7 @@ jobs:
       - name: Checkout code into the directory
         uses: actions/checkout@v4
 
+      # Setting up Go explicitly is required for v3.0.0+ of golangci/golangci-lint-action.
       - name: Setup Go environment explicitly
         uses: actions/setup-go@v5
         with:
@@ -41,7 +45,7 @@ jobs:
           cache: false
 
       - name: Run golangci-lint linter
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v6
         with:
           # Required: the version of golangci-lint is required.
           # Note: The version should not pick the patch version as the latest patch

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,13 +31,14 @@ jobs:
 
     steps:
       - name: Checkout code into the directory
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Go environment explicitly
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version-file: 'go.mod'
           check-latest: true
+          cache: false
 
       - name: Run golangci-lint linter
         uses: golangci/golangci-lint-action@v3
@@ -75,7 +76,7 @@ jobs:
 
     steps:
       - name: Checkout code into the directory
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run yamllint linter
         uses: ibiqlik/action-yamllint@v3

--- a/.github/workflows/preview-ami-with-terraform-plan.yml
+++ b/.github/workflows/preview-ami-with-terraform-plan.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Stop and notify the use of unprivileged flow or missing tokens
         if: env.AWS_ACCESS_KEY_ID == '' || env.AWS_SECRET_ACCESS_KEY == ''
         # Note: Fail this step, as we don't want unprivileged access doing these changes.
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             let unprivileged_warning =
@@ -64,10 +64,10 @@ jobs:
             core.setFailed(unprivileged_warning)
 
       - name: Checkout code into the directory
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Terraform action setup
-        uses: hashicorp/setup-terraform@v2
+        uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: 1.3.7
 
@@ -93,7 +93,7 @@ jobs:
         continue-on-error: true
 
       - name: Comment results on pull request
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         env:
           TERRAFORM_PLAN_OUTPUT: "Terraform Plan Output:\n${{ steps.terraform-plan.outputs.stdout }}\n"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,16 +31,16 @@ jobs:
 
     steps:
       - name: Checkout code into the directory
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Setup Go environment explicitly
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version-file: 'go.mod'
           check-latest: true
-          cache: true
+          cache: false
 
       - name: Apply tag
         run: git tag ${{ github.event.inputs.tag }}
@@ -50,18 +50,18 @@ jobs:
 
       - name: Set up QEMU
         if: matrix.os == 'ubuntu-latest'
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       - name: Log in to Docker Hub
         if: matrix.os == 'ubuntu-latest'
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Log in to the Container registry
         if: matrix.os == 'ubuntu-latest'
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -109,7 +109,7 @@ jobs:
     needs: prepare
     steps:
       - name: Checkout code into the directory
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -117,14 +117,14 @@ jobs:
         run: git tag ${{ github.event.inputs.tag }}
 
       - name: Setup Go environment explicitly
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version-file: 'go.mod'
           check-latest: true
-          cache: true
+          cache: false
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -193,7 +193,7 @@ jobs:
 
     steps:
       - name: Log in to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/start-binary.yml
+++ b/.github/workflows/start-binary.yml
@@ -32,13 +32,14 @@ jobs:
     steps:
 
       - name: Checkout code into the directory
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Go environment explicitly
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version-file: 'go.mod'
           check-latest: true
+          cache: false
 
       - name: Build modules
         run: make deps:modules

--- a/.github/workflows/test-and-upload-coverage.yml
+++ b/.github/workflows/test-and-upload-coverage.yml
@@ -102,13 +102,14 @@ jobs:
 
     steps:
       - name: Checkout code into the directory
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Go environment explicitly
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version-file: 'go.mod'
           check-latest: true
+          cache: false
 
       - name: Set cache paths
         id: cache-paths
@@ -164,7 +165,7 @@ jobs:
 
       - name: Upload coverage artifact
         if: ${{ !matrix.detect-changes }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.os }}_${{ matrix.client-type }}_${{ matrix.database-type }}_${{ matrix.mutation-type }}
           path: coverage.txt
@@ -185,10 +186,10 @@ jobs:
 
     steps:
       - name: Checkout code into the directory
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Download coverage reports
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: coverage_reports
 

--- a/.github/workflows/test-and-upload-coverage.yml
+++ b/.github/workflows/test-and-upload-coverage.yml
@@ -167,7 +167,17 @@ jobs:
         if: ${{ !matrix.detect-changes }}
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.os }}_${{ matrix.client-type }}_${{ matrix.database-type }}_${{ matrix.mutation-type }}
+          # Make sure the name is always unique per job as artifacts are now immutable.
+          # Note Issue: https://github.com/actions/upload-artifact/issues/478
+          # Solve: https://github.com/actions/upload-artifact/issues/478#issuecomment-1885470013
+          name: "coverage\
+            _${{ matrix.os }}\
+            _${{ matrix.client-type }}\
+            _${{ matrix.database-type }}\
+            _${{ matrix.mutation-type }}\
+            _${{ matrix.lens-type }}\
+            _${{ matrix.database-encryption }}\
+          "
           path: coverage.txt
           if-no-files-found: error
           retention-days: 7
@@ -191,6 +201,9 @@ jobs:
       - name: Download coverage reports
         uses: actions/download-artifact@v4
         with:
+          pattern: coverage_*
+          # Note: https://github.com/actions/download-artifact/blob/main/docs/MIGRATION.md
+          merge-multiple: false
           path: coverage_reports
 
       - name: Upload coverage to Codecov
@@ -198,6 +211,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           name: defradb-codecov
+          files: coverage_reports/**/*.txt
           flags: all-tests
           os: 'linux'
           fail_ci_if_error: true

--- a/.github/workflows/validate-containerfile.yml
+++ b/.github/workflows/validate-containerfile.yml
@@ -36,16 +36,16 @@ jobs:
 
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Build Docker image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: tools/defradb.containerfile

--- a/.github/workflows/validate-title.yml
+++ b/.github/workflows/validate-title.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout code into the directory
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Ensure the scripts are not broken
         run: make test:scripts


### PR DESCRIPTION
## Relevant issue(s)
Resolves #2778

## Description
- Similar to #990
- Update all actions to `node20` versions
- There was a bug the way we were using artifacts previously such that it would overwrite some generated code coverage reports due to artifact name clashing, this was caught as the behavior of "artifact name clashing" now causes error instead of "merging" them. The fix is in the last commit, which will now ensure "more" accurate coverage as the missing 3 reports are also included.

### Go Releaser
- This should be done outside this PR, made an issue here: https://github.com/sourcenetwork/defradb/issues/2781 

## How has this been tested?
- `act` tool
- ci

Specify the platform(s) on which this was tested:
- WSL2
