### PR TITLE
test: Support asserting on doc index in test results

### DIFF
--- a/tests/integration/net/one_to_many/peer/with_create_update_test.go
+++ b/tests/integration/net/one_to_many/peer/with_create_update_test.go
@@ -81,7 +81,7 @@ func TestP2POneToManyPeerWithCreateUpdateLinkingSyncedDocToUnsyncedDoc(t *testin
 				Results: []map[string]any{
 					{
 						"Name":      "Gulistan",
-						"Author_id": "bae-6a4c24c0-7b0b-5f51-a274-132d7ca90499",
+						"Author_id": testUtils.NewDocIndex(0, 0),
 						"Author": map[string]any{
 							"Name": "Saadi",
 						},
@@ -102,7 +102,7 @@ func TestP2POneToManyPeerWithCreateUpdateLinkingSyncedDocToUnsyncedDoc(t *testin
 				Results: []map[string]any{
 					{
 						"Name":      "Gulistan",
-						"Author_id": "bae-6a4c24c0-7b0b-5f51-a274-132d7ca90499",
+						"Author_id": testUtils.NewDocIndex(0, 0),
 						// "Saadi" was not synced to node 1, the update did not
 						// result in an error and synced to relational id even though "Saadi"
 						// does not exist in this node.

--- a/tests/integration/utils2.go
+++ b/tests/integration/utils2.go
@@ -1880,6 +1880,16 @@ func assertRequestResults(
 				valueSet := anyOfByField[dfk]
 				valueSet = append(valueSet, actualValue)
 				anyOfByField[dfk] = valueSet
+			case DocIndex:
+				expectedDocID := s.documents[r.CollectionIndex][r.Index].ID().String()
+				assertResultsEqual(
+					s.t,
+					s.clientType,
+					expectedDocID,
+					actualValue,
+					fmt.Sprintf("node: %v, doc: %v", nodeID, docIndex),
+				)
+
 			default:
 				assertResultsEqual(
 					s.t,


### PR DESCRIPTION
## Relevant issue(s)

Resolves #2785

## Description

Support asserting on doc index in test results.

PR does not seek to propagate it's usage, only to permit it's usage.

## How has this been tested?

I also checked that it fails correctly if the results do not pair up.
