### PR TITLE
test: Allow assertion of AddSchema results

### DIFF
--- a/tests/integration/results.go
+++ b/tests/integration/results.go
@@ -220,5 +220,9 @@ func assertCollectionDescriptions(
 			// This is to say each test action from having to bother declaring an empty slice (if there are no sources)
 			require.Equal(s.t, expected.Sources, actual.Sources)
 		}
+
+		if expected.Fields != nil {
+			require.Equal(s.t, expected.Fields, actual.Fields)
+		}
 	}
 }

--- a/tests/integration/results.go
+++ b/tests/integration/results.go
@@ -18,6 +18,9 @@ import (
 
 	"github.com/sourcenetwork/immutable"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcenetwork/defradb/client"
 )
 
 // AnyOf may be used as `Results` field where the value may
@@ -183,4 +186,39 @@ func areResultArraysEqual[S any](expected []S, actual any) bool {
 		}
 	}
 	return true
+}
+
+func assertCollectionDescriptions(
+	s *state,
+	expected []client.CollectionDescription,
+	actual []client.CollectionDescription,
+) {
+	require.Equal(s.t, len(expected), len(actual))
+
+	for i, expected := range expected {
+		actual := actual[i]
+		if expected.ID != 0 {
+			require.Equal(s.t, expected.ID, actual.ID)
+		}
+		if expected.RootID != 0 {
+			require.Equal(s.t, expected.RootID, actual.RootID)
+		}
+		if expected.SchemaVersionID != "" {
+			require.Equal(s.t, expected.SchemaVersionID, actual.SchemaVersionID)
+		}
+
+		require.Equal(s.t, expected.Name, actual.Name)
+
+		if expected.Indexes != nil || len(actual.Indexes) != 0 {
+			// Dont bother asserting this if the expected is nil and the actual is nil/empty.
+			// This is to say each test action from having to bother declaring an empty slice (if there are no indexes)
+			require.Equal(s.t, expected.Indexes, actual.Indexes)
+		}
+
+		if expected.Sources != nil || len(actual.Sources) != 0 {
+			// Dont bother asserting this if the expected is nil and the actual is nil/empty.
+			// This is to say each test action from having to bother declaring an empty slice (if there are no sources)
+			require.Equal(s.t, expected.Sources, actual.Sources)
+		}
+	}
 }

--- a/tests/integration/schema/simple_test.go
+++ b/tests/integration/schema/simple_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sourcenetwork/immutable"
 
 	"github.com/sourcenetwork/defradb/client"
+	"github.com/sourcenetwork/defradb/client/request"
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
 )
 
@@ -28,6 +29,16 @@ func TestSchemaSimpleCreatesSchemaGivenEmptyType(t *testing.T) {
 				Schema: `
 					type Users {}
 				`,
+				ExpectedResults: []client.CollectionDescription{
+					{
+						Name: immutable.Some("Users"),
+						Fields: []client.CollectionFieldDescription{
+							{
+								Name: request.DocIDFieldName,
+							},
+						},
+					},
+				},
 			},
 			testUtils.IntrospectionRequest{
 				Request: `

--- a/tests/integration/test_case.go
+++ b/tests/integration/test_case.go
@@ -81,6 +81,15 @@ type SchemaUpdate struct {
 	// The schema update.
 	Schema string
 
+	// Optionally, the expected results.
+	//
+	// Each item will be compared individually, if ID, RootID, SchemaVersionID or Fields on the
+	// expected item are default they will not be compared with the actual.
+	//
+	// Assertions on Indexes and Sources will not distinguish between nil and empty (in order
+	// to allow their ommission in most cases).
+	ExpectedResults []client.CollectionDescription
+
 	// Any error expected from the action. Optional.
 	//
 	// String can be a partial, and the test will pass if an error is returned that

--- a/tests/integration/utils2.go
+++ b/tests/integration/utils2.go
@@ -1000,10 +1000,14 @@ func updateSchema(
 	action SchemaUpdate,
 ) {
 	for _, node := range getNodes(action.NodeID, s.nodes) {
-		_, err := node.AddSchema(s.ctx, action.Schema)
+		results, err := node.AddSchema(s.ctx, action.Schema)
 		expectedErrorRaised := AssertError(s.t, s.testCase.Description, err, action.ExpectedError)
 
 		assertExpectedErrorRaised(s.t, s.testCase.Description, action.ExpectedError, expectedErrorRaised)
+
+		if action.ExpectedResults != nil {
+			assertCollectionDescriptions(s, action.ExpectedResults, results)
+		}
 	}
 
 	// If the schema was updated we need to refresh the collection definitions.

--- a/tests/integration/utils2.go
+++ b/tests/integration/utils2.go
@@ -1089,39 +1089,16 @@ func getCollections(
 		txn := getTransaction(s, node, action.TransactionID, "")
 		ctx := db.SetContextTxn(s.ctx, txn)
 		results, err := node.GetCollections(ctx, action.FilterOptions)
+		resultDescriptions := make([]client.CollectionDescription, len(results))
+		for i, col := range results {
+			resultDescriptions[i] = col.Description()
+		}
 
 		expectedErrorRaised := AssertError(s.t, s.testCase.Description, err, action.ExpectedError)
 		assertExpectedErrorRaised(s.t, s.testCase.Description, action.ExpectedError, expectedErrorRaised)
 
 		if !expectedErrorRaised {
-			require.Equal(s.t, len(action.ExpectedResults), len(results))
-
-			for i, expected := range action.ExpectedResults {
-				actual := results[i].Description()
-				if expected.ID != 0 {
-					require.Equal(s.t, expected.ID, actual.ID)
-				}
-				if expected.RootID != 0 {
-					require.Equal(s.t, expected.RootID, actual.RootID)
-				}
-				if expected.SchemaVersionID != "" {
-					require.Equal(s.t, expected.SchemaVersionID, actual.SchemaVersionID)
-				}
-
-				require.Equal(s.t, expected.Name, actual.Name)
-
-				if expected.Indexes != nil || len(actual.Indexes) != 0 {
-					// Dont bother asserting this if the expected is nil and the actual is nil/empty.
-					// This is to say each test action from having to bother declaring an empty slice (if there are no indexes)
-					require.Equal(s.t, expected.Indexes, actual.Indexes)
-				}
-
-				if expected.Sources != nil || len(actual.Sources) != 0 {
-					// Dont bother asserting this if the expected is nil and the actual is nil/empty.
-					// This is to say each test action from having to bother declaring an empty slice (if there are no sources)
-					require.Equal(s.t, expected.Sources, actual.Sources)
-				}
-			}
+			assertCollectionDescriptions(s, action.ExpectedResults, resultDescriptions)
 		}
 	}
 }


### PR DESCRIPTION
## Relevant issue(s)

Resolves #2766

## Description

Allows assertion of AddSchema results.

PR Does not attempt to spread it's usage (out of scope).