### PR TITLE
ci(i): Make change detector an independent workflow

### DIFF
--- a/.github/workflows/check-data-format-changes.yml
+++ b/.github/workflows/check-data-format-changes.yml
@@ -1,0 +1,50 @@
+# Copyright 2024 Democratized Data Foundation
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.txt.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0, included in the file
+# licenses/APL.txt.
+
+name: Check Data Format Changes Workflow
+
+on:
+  pull_request:
+    branches:
+      - master
+      - develop
+
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+    branches:
+      - master
+      - develop
+
+jobs:
+  check-data-format-changes:
+    name: Check data format changes job
+
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - name: Checkout code into the directory
+        uses: actions/checkout@v4
+
+      - name: Setup Go environment explicitly
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+          check-latest: true
+          cache: false
+
+      - name: Build dependencies
+        run: |
+          make deps:modules
+          make deps:test
+
+      - name: Run data format change detection tests
+        run: make test:changes

--- a/.github/workflows/test-and-upload-coverage.yml
+++ b/.github/workflows/test-and-upload-coverage.yml
@@ -35,7 +35,6 @@ jobs:
         database-type: [badger-file, badger-memory]
         mutation-type: [gql, collection-named, collection-save]
         lens-type: [wasm-time]
-        detect-changes: [false]
         database-encryption: [false]
         include:
           - os: ubuntu-latest
@@ -43,21 +42,18 @@ jobs:
             database-type: badger-memory
             mutation-type: collection-save
             lens-type: wasm-time
-            detect-changes: true
             database-encryption: false
           - os: ubuntu-latest
             client-type: go
             database-type: badger-memory
             mutation-type: collection-save
             lens-type: wasm-time
-            detect-changes: false
             database-encryption: true
           - os: macos-latest
             client-type: go
             database-type: badger-memory
             mutation-type: collection-save
             lens-type: wasm-time
-            detect-changes: false
             database-encryption: false
 ## TODO: https://github.com/sourcenetwork/defradb/issues/2080
 ## Uncomment the lines below to Re-enable the windows build once this todo is resolved.
@@ -65,21 +61,18 @@ jobs:
 ##          client-type: go
 ##          database-type: badger-memory
 ##          mutation-type: collection-save
-##          detect-changes: false
 ##          database-encryption: false
           - os: ubuntu-latest
             client-type: go
             database-type: badger-memory
             mutation-type: collection-save
             lens-type: wazero
-            detect-changes: false
             database-encryption: false
           - os: ubuntu-latest
             client-type: go
             database-type: badger-memory
             mutation-type: collection-save
             lens-type: wasmer
-            detect-changes: false
             database-encryption: false
 
     runs-on: ${{ matrix.os }}
@@ -156,15 +149,9 @@ jobs:
           make deps:test
 
       - name: Run integration tests
-        if: ${{ !matrix.detect-changes }}
         run: make test:coverage
 
-      - name: Run change detector tests
-        if: ${{ matrix.detect-changes }}
-        run: make test:changes
-
       - name: Upload coverage artifact
-        if: ${{ !matrix.detect-changes }}
         uses: actions/upload-artifact@v4
         with:
           # Make sure the name is always unique per job as artifacts are now immutable.


### PR DESCRIPTION
## Relevant issue(s)
Resolves #2736

## Description
- Move change detection to a separate workflow to not block code coverage upload to be dependent / blocked by it.
- More reasons in the issue (#2736) on why we want this.

### Note will need to change required checks naming, will do it pre-merge and after an approval.

## How has this been tested?
- Manually

Specify the platform(s) on which this was tested:
- WSL2