### PR TITLE
ci(i): Remove redundant matrix rule that is repeated

### DIFF
--- a/.github/workflows/test-and-upload-coverage.yml
+++ b/.github/workflows/test-and-upload-coverage.yml
@@ -42,12 +42,6 @@ jobs:
             database-type: badger-memory
             mutation-type: collection-save
             lens-type: wasm-time
-            database-encryption: false
-          - os: ubuntu-latest
-            client-type: go
-            database-type: badger-memory
-            mutation-type: collection-save
-            lens-type: wasm-time
             database-encryption: true
           - os: macos-latest
             client-type: go

--- a/.github/workflows/test-and-upload-coverage.yml
+++ b/.github/workflows/test-and-upload-coverage.yml
@@ -43,19 +43,6 @@ jobs:
             mutation-type: collection-save
             lens-type: wasm-time
             database-encryption: true
-          - os: macos-latest
-            client-type: go
-            database-type: badger-memory
-            mutation-type: collection-save
-            lens-type: wasm-time
-            database-encryption: false
-## TODO: https://github.com/sourcenetwork/defradb/issues/2080
-## Uncomment the lines below to Re-enable the windows build once this todo is resolved.
-##        - os: windows-latest
-##          client-type: go
-##          database-type: badger-memory
-##          mutation-type: collection-save
-##          database-encryption: false
           - os: ubuntu-latest
             client-type: go
             database-type: badger-memory
@@ -68,6 +55,20 @@ jobs:
             mutation-type: collection-save
             lens-type: wasmer
             database-encryption: false
+          - os: macos-latest
+            client-type: go
+            database-type: badger-memory
+            mutation-type: collection-save
+            lens-type: wasm-time
+            database-encryption: false
+## TODO: https://github.com/sourcenetwork/defradb/issues/2080
+## Uncomment the lines below to Re-enable the windows build once this todo is resolved.
+##        - os: windows-latest
+##          client-type: go
+##          database-type: badger-memory
+##          mutation-type: collection-save
+##          lens-type: wasm-time
+##          database-encryption: false
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
## Description
- Remove redundant matrix rule that is repeated (1st commit)
- Move all non-ubuntu special rules at the bottom

## How has this been tested?
- `act` tool
- ci

Specify the platform(s) on which this was tested:
- WSL2