### PR TITLE
docs: Remove reference to client ping from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ defradb keyring --help
 
 Start a node by executing `defradb start`. Keep the node running while going through the following examples.
 
-Verify the local connection to the node works by executing `defradb client ping` in another terminal.
+Verify the local connection to the node works by executing `defradb client collection describe` in another terminal.
 
 ## Configuration
 


### PR DESCRIPTION
## Relevant issue(s)

Resolves #2792

## Description

Removes the reference to client ping from readme.  The ping command no longer exists.

## How has this been tested?

Tested locally, command fails with `Error: Get "http://127.0.0.1:9181/api/v0/collections": dial tcp 127.0.0.1:9181: connect: connection refused` if the server is down.
