### PR TITLE
fix: Support one-many self joins without primary directive

### DIFF
--- a/internal/request/graphql/schema/collection.go
+++ b/internal/request/graphql/schema/collection.go
@@ -667,15 +667,13 @@ func finalizeRelations(
 				continue
 			}
 
-			var otherColFieldDescription immutable.Option[client.CollectionFieldDescription]
-			for _, otherField := range otherColDefinition.Value().Description.Fields {
-				if otherField.RelationName.Value() == field.RelationName.Value() {
-					otherColFieldDescription = immutable.Some(otherField)
-					break
-				}
-			}
+			otherColFieldDescription, hasOtherColFieldDescription := otherColDefinition.Value().Description.GetFieldByRelation(
+				field.RelationName.Value(),
+				definition.GetName(),
+				field.Name,
+			)
 
-			if !otherColFieldDescription.HasValue() || otherColFieldDescription.Value().Kind.Value().IsArray() {
+			if !hasOtherColFieldDescription || otherColFieldDescription.Kind.Value().IsArray() {
 				if _, exists := definition.Schema.GetFieldByName(field.Name); !exists {
 					// Relations only defined on one side of the object are possible, and so if this is one of them
 					// or if the other side is an array, we need to add the field to the schema (is primary side)

--- a/tests/integration/schema/one_many_test.go
+++ b/tests/integration/schema/one_many_test.go
@@ -94,7 +94,34 @@ func TestSchemaOneMany_SelfReferenceOneFieldLexographicallyFirst(t *testing.T) {
 						b: [User]
 					}
 				`,
-				ExpectedError: "relation missing field. Object: User, RelationName: user_user",
+				ExpectedResults: []client.CollectionDescription{
+					{
+						Name: immutable.Some("User"),
+						Fields: []client.CollectionFieldDescription{
+							{
+								Name: "_docID",
+							},
+							{
+								Name:         "a",
+								ID:           1,
+								Kind:         immutable.Some[client.FieldKind](client.ObjectKind("User")),
+								RelationName: immutable.Some("user_user"),
+							},
+							{
+								Name:         "a_id",
+								ID:           2,
+								Kind:         immutable.Some[client.FieldKind](client.ScalarKind(client.FieldKind_DocID)),
+								RelationName: immutable.Some("user_user"),
+							},
+							{
+								Name:         "b",
+								ID:           3,
+								Kind:         immutable.Some[client.FieldKind](client.ObjectArrayKind("User")),
+								RelationName: immutable.Some("user_user"),
+							},
+						},
+					},
+				},
 			},
 		},
 	}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #2620

## Description

Support one-many self joins without primary directive.
