### PR TITLE
test: Fix refreshing of docs in change detector

### DIFF
--- a/tests/integration/utils2.go
+++ b/tests/integration/utils2.go
@@ -870,33 +870,48 @@ func refreshDocuments(
 	}
 
 	for i := 0; i < startActionIndex; i++ {
+		// We need to add the existing documents in the order in which the test case lists them
+		// otherwise they cannot be referenced correctly by other actions.
 		switch action := s.testCase.Actions[i].(type) {
 		case CreateDoc:
 			// Just use the collection from the first relevant node, as all will be the same for this
 			// purpose.
 			collection := getNodeCollections(action.NodeID, s.collections)[0][action.CollectionID]
 
-			// We need to add the existing documents in the order in which the test case lists them
-			// otherwise they cannot be referenced correctly by other actions.
-			doc, err := client.NewDocFromJSON([]byte(action.Doc), collection.Definition())
+			var doc *client.Document
+			var docs []*client.Document
+			var err error
+			if action.DocMap != nil {
+				substituteRelations(s, action)
+				doc, err = client.NewDocFromMap(action.DocMap, collection.Definition())
+				docs = append(docs, doc)
+			} else if client.IsJSONArray([]byte(action.Doc)) {
+				docs, err = client.NewDocsFromJSON([]byte(action.Doc), collection.Definition())
+			} else {
+				doc, err = client.NewDocFromJSON([]byte(action.Doc), collection.Definition())
+				docs = append(docs, doc)
+			}
+
 			if err != nil {
 				// If an err has been returned, ignore it - it may be expected and if not
 				// the test will fail later anyway
 				continue
 			}
 
-			ctx := makeContextForDocCreate(s, s.ctx, &action)
+			for _, doc := range docs {
+				ctx := makeContextForDocCreate(s, s.ctx, &action)
 
-			// The document may have been mutated by other actions, so to be sure we have the latest
-			// version without having to worry about the individual update mechanics we fetch it.
-			doc, err = collection.Get(ctx, doc.ID(), false)
-			if err != nil {
-				// If an err has been returned, ignore it - it may be expected and if not
-				// the test will fail later anyway
-				continue
+				// The document may have been mutated by other actions, so to be sure we have the latest
+				// version without having to worry about the individual update mechanics we fetch it.
+				doc, err = collection.Get(ctx, doc.ID(), false)
+				if err != nil {
+					// If an err has been returned, ignore it - it may be expected and if not
+					// the test will fail later anyway
+					continue
+				}
+
+				s.documents[action.CollectionID] = append(s.documents[action.CollectionID], doc)
 			}
-
-			s.documents[action.CollectionID] = append(s.documents[action.CollectionID], doc)
 		}
 	}
 }


### PR DESCRIPTION
## Relevant issue(s)

Resolves #2812 

## Description

This fixes two issues in `refreshDocuments`.
- `DocIndex`es were not accounted for in refresh documents, this was introduced a while ago and lay hiding until recently
- Creating multiple docs in a single action was not handled

`refreshDocuments` is called in the second half of the change detector to populate the test document cache with docs created in the setup stage.

The hardcoding of cyrpto stuff was discussed as a problem for the change detector, however that is innocent - I think I was looking at an older CI log originally.  I did manage to remove the test cyrpto stuff (#2801), but it requires cleanup and doesn't really belong in this PR.