### PR TITLE
feat: Handle P2P with SourceHub ACP

### DIFF
--- a/acp/README.md
+++ b/acp/README.md
@@ -458,9 +458,10 @@ If authentication fails for any reason a `403` forbidden response will be return
 ## _FAC Usage: (coming soon)_
 
 ## Warning / Caveats
+- If using Local ACP, P2P will only work with collections that do not have a policy assigned.  If you wish to use ACP
+on collections connected to a multi-node network, please use SourceHub ACP.
+
 The following features currently don't work with ACP, they are being actively worked on.
-- [P2P: Adding a replicator with permissioned collection](https://github.com/sourcenetwork/defradb/issues/2366)
-- [P2P: Subscription to a permissioned collection](https://github.com/sourcenetwork/defradb/issues/2366)
 - [Adding Secondary Indexes](https://github.com/sourcenetwork/defradb/issues/2365)
 - [Backing/Restoring Private Documents](https://github.com/sourcenetwork/defradb/issues/2430)
 

--- a/acp/acp.go
+++ b/acp/acp.go
@@ -98,4 +98,7 @@ type ACP interface {
 		resourceName string,
 		docID string,
 	) (bool, error)
+
+	// SupportsP2P returns true if the implementation supports ACP across a peer network.
+	SupportsP2P() bool
 }

--- a/acp/source_hub_client.go
+++ b/acp/source_hub_client.go
@@ -335,6 +335,11 @@ func (a *sourceHubBridge) CheckDocAccess(
 	}
 }
 
+func (a *sourceHubBridge) SupportsP2P() bool {
+	_, ok := a.client.(*acpSourceHub)
+	return ok
+}
+
 func (a *sourceHubBridge) Close() error {
 	return a.client.Close()
 }

--- a/internal/db/errors.go
+++ b/internal/db/errors.go
@@ -137,7 +137,6 @@ var (
 	ErrP2PColHasPolicy                          = errors.New("p2p collection specified has a policy on it")
 	ErrNoTransactionInContext                   = errors.New(errNoTransactionInContext)
 	ErrReplicatorColHasPolicy                   = errors.New("replicator collection specified has a policy on it")
-	ErrReplicatorSomeColsHavePolicy             = errors.New("replicator can not use all collections, as some have policy")
 	ErrSelfTargetForReplicator                  = errors.New("can't target ourselves as a replicator")
 	ErrReplicatorCollections                    = errors.New(errReplicatorCollections)
 	ErrReplicatorNotFound                       = errors.New(errReplicatorNotFound)

--- a/internal/db/p2p_replicator.go
+++ b/internal/db/p2p_replicator.go
@@ -45,8 +45,6 @@ func (db *db) SetReplicator(ctx context.Context, rep client.Replicator) error {
 		return ErrSelfTargetForReplicator
 	}
 
-	// TODO-ACP: Support ACP <> P2P - https://github.com/sourcenetwork/defradb/issues/2366
-	// ctx = db.SetContextIdentity(ctx, identity)
 	ctx = SetContextTxn(ctx, txn)
 
 	storedRep := client.Replicator{}
@@ -90,20 +88,19 @@ func (db *db) SetReplicator(ctx context.Context, rep client.Replicator) error {
 		}
 
 	default:
-		// default to all collections (unless a collection contains a policy).
-		// TODO-ACP: default to all collections after resolving https://github.com/sourcenetwork/defradb/issues/2366
 		allCollections, err := db.GetCollections(ctx, client.CollectionFetchOptions{})
 		if err != nil {
 			return NewErrReplicatorCollections(err)
 		}
 
-		for _, col := range allCollections {
-			// Can not default to all collections if any collection has a policy.
-			// TODO-ACP: remove this check/loop after https://github.com/sourcenetwork/defradb/issues/2366
-			if col.Description().Policy.HasValue() {
-				return ErrReplicatorSomeColsHavePolicy
+		if db.acp.HasValue() && !db.acp.Value().SupportsP2P() {
+			for _, col := range allCollections {
+				if col.Description().Policy.HasValue() {
+					return ErrReplicatorSomeColsHavePolicy
+				}
 			}
 		}
+
 		collections = allCollections
 	}
 

--- a/internal/db/p2p_replicator.go
+++ b/internal/db/p2p_replicator.go
@@ -80,28 +80,22 @@ func (db *db) SetReplicator(ctx context.Context, rep client.Replicator) error {
 				return NewErrReplicatorCollections(err)
 			}
 
-			if col.Description().Policy.HasValue() {
-				return ErrReplicatorColHasPolicy
-			}
-
 			collections = append(collections, col)
 		}
 
 	default:
-		allCollections, err := db.GetCollections(ctx, client.CollectionFetchOptions{})
+		collections, err = db.GetCollections(ctx, client.CollectionFetchOptions{})
 		if err != nil {
 			return NewErrReplicatorCollections(err)
 		}
+	}
 
-		if db.acp.HasValue() && !db.acp.Value().SupportsP2P() {
-			for _, col := range allCollections {
-				if col.Description().Policy.HasValue() {
-					return ErrReplicatorSomeColsHavePolicy
-				}
+	if db.acp.HasValue() && !db.acp.Value().SupportsP2P() {
+		for _, col := range collections {
+			if col.Description().Policy.HasValue() {
+				return ErrReplicatorColHasPolicy
 			}
 		}
-
-		collections = allCollections
 	}
 
 	addedCols := []client.Collection{}

--- a/internal/db/p2p_schema_root_test.go
+++ b/internal/db/p2p_schema_root_test.go
@@ -249,9 +249,6 @@ func TestGetAllP2PCollections_WithMultipleValidCollections_ShouldSucceed(t *test
 	require.Equal(t, []string{schema2.Root, schema1.Root}, cols)
 }
 
-// This test documents that we don't allow adding p2p collections that have a policy
-// until the following is implemented:
-// TODO-ACP: ACP <> P2P https://github.com/sourcenetwork/defradb/issues/2366
 func TestAddP2PCollectionsWithPermissionedCollection_Error(t *testing.T) {
 	ctx := context.Background()
 	rootstore := memory.NewDatastore(ctx)

--- a/tests/integration/acp.go
+++ b/tests/integration/acp.go
@@ -99,17 +99,7 @@ func addPolicyACP(
 		require.Fail(s.t, "Expected error should not have an expected policyID with it.", s.testCase.Description)
 	}
 
-	addedToSourceHub := false
-
 	for i, node := range getNodes(action.NodeID, s.nodes) {
-		// The policy should only be added to the SourceHub chain once.
-		if addedToSourceHub {
-			break
-		}
-		if acpType == SourceHubACPType {
-			addedToSourceHub = true
-		}
-
 		identity := getIdentity(s, i, action.Identity)
 		ctx := db.SetContextIdentity(s.ctx, identity)
 		policyResult, err := node.AddPolicy(ctx, action.Policy)
@@ -121,6 +111,12 @@ func addPolicyACP(
 
 		expectedErrorRaised := AssertError(s.t, s.testCase.Description, err, action.ExpectedError)
 		assertExpectedErrorRaised(s.t, s.testCase.Description, action.ExpectedError, expectedErrorRaised)
+
+		// The policy should only be added to a SourceHub chain once - there is no need to loop through
+		// the nodes.
+		if acpType == SourceHubACPType {
+			break
+		}
 	}
 }
 

--- a/tests/integration/acp/p2p/replicator_test.go
+++ b/tests/integration/acp/p2p/replicator_test.go
@@ -74,7 +74,7 @@ func TestACP_P2POneToOneReplicatorWithPermissionedCollection_LocalACP(t *testing
 			testUtils.ConfigureReplicator{
 				SourceNodeID:  0,
 				TargetNodeID:  1,
-				ExpectedError: "replicator can not use all collections, as some have policy",
+				ExpectedError: "replicator collection specified has a policy on it",
 			},
 		},
 	}

--- a/tests/integration/acp/p2p/replicator_test.go
+++ b/tests/integration/acp/p2p/replicator_test.go
@@ -18,23 +18,18 @@ import (
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
 )
 
-// This test documents that we don't allow setting replicator with a collections that has a policy
-// until the following is implemented:
-// TODO-ACP: ACP <> P2P https://github.com/sourcenetwork/defradb/issues/2366
-func TestACP_P2POneToOneReplicatorWithPermissionedCollection_Error(t *testing.T) {
+func TestACP_P2POneToOneReplicatorWithPermissionedCollection_LocalACP(t *testing.T) {
 	test := testUtils.TestCase{
-
-		Description: "Test acp, with p2p replicator with permissioned collection, error",
-
+		SupportedACPTypes: immutable.Some(
+			[]testUtils.ACPType{
+				testUtils.LocalACPType,
+			},
+		),
 		Actions: []any{
-
 			testUtils.RandomNetworkingConfig(),
 			testUtils.RandomNetworkingConfig(),
-
 			testUtils.AddPolicy{
-
 				Identity: immutable.Some(1),
-
 				Policy: `
                     name: test
                     description: a test policy which marks a collection in a database as a resource
@@ -63,10 +58,8 @@ func TestACP_P2POneToOneReplicatorWithPermissionedCollection_Error(t *testing.T)
                             types:
                               - actor
                 `,
-
 				ExpectedPolicyID: "94eb195c0e459aa79e02a1986c7e731c5015721c18a373f2b2a0ed140a04b454",
 			},
-
 			testUtils.SchemaUpdate{
 				Schema: `
 					type Users @policy(
@@ -78,11 +71,120 @@ func TestACP_P2POneToOneReplicatorWithPermissionedCollection_Error(t *testing.T)
 					}
 				`,
 			},
-
 			testUtils.ConfigureReplicator{
 				SourceNodeID:  0,
 				TargetNodeID:  1,
 				ExpectedError: "replicator can not use all collections, as some have policy",
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestACP_P2POneToOneReplicatorWithPermissionedCollection_SourceHubACP(t *testing.T) {
+	test := testUtils.TestCase{
+		SupportedACPTypes: immutable.Some(
+			[]testUtils.ACPType{
+				testUtils.SourceHubACPType,
+			},
+		),
+		Actions: []any{
+			testUtils.RandomNetworkingConfig(),
+			testUtils.RandomNetworkingConfig(),
+			testUtils.AddPolicy{
+				Identity: immutable.Some(1),
+				Policy: `
+                    name: test
+                    description: a test policy which marks a collection in a database as a resource
+
+                    actor:
+                      name: actor
+
+                    resources:
+                      users:
+                        permissions:
+                          read:
+                            expr: owner + reader
+                          write:
+                            expr: owner
+
+                        relations:
+                          owner:
+                            types:
+                              - actor
+                          reader:
+                            types:
+                              - actor
+                          admin:
+                            manages:
+                              - reader
+                            types:
+                              - actor
+                `,
+				ExpectedPolicyID: "94eb195c0e459aa79e02a1986c7e731c5015721c18a373f2b2a0ed140a04b454",
+			},
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users @policy(
+						id: "94eb195c0e459aa79e02a1986c7e731c5015721c18a373f2b2a0ed140a04b454",
+						resource: "users"
+					) {
+						name: String
+						age: Int
+					}
+				`,
+			},
+			testUtils.ConfigureReplicator{
+				SourceNodeID: 0,
+				TargetNodeID: 1,
+			},
+			testUtils.CreateDoc{
+				NodeID:   immutable.Some(0),
+				Identity: immutable.Some(1),
+				DocMap: map[string]any{
+					"name": "John",
+				},
+			},
+			testUtils.WaitForSync{},
+			testUtils.Request{
+				// Ensure that the document is accessible on all nodes to authorized actors
+				Identity: immutable.Some(1),
+				Request: `
+					query {
+						Users {
+							name
+						}
+					}
+				`,
+				Results: []map[string]any{
+					{
+						"name": "John",
+					},
+				},
+			},
+			testUtils.Request{
+				// Ensure that the document is hidden on all nodes to unidentified actors
+				Request: `
+					query {
+						Users {
+							name
+						}
+					}
+				`,
+				Results: []map[string]any{},
+			},
+			testUtils.Request{
+				// Ensure that the document is hidden on all nodes to unauthorized actors
+				Identity: immutable.Some(2),
+				Request: `
+					query {
+						Users {
+							name
+						}
+					}
+				`,
+				Results: []map[string]any{},
 			},
 		},
 	}

--- a/tests/integration/acp/p2p/subscribe_test.go
+++ b/tests/integration/acp/p2p/subscribe_test.go
@@ -18,14 +18,13 @@ import (
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
 )
 
-// This test documents that we don't allow subscribing to a collection that has a policy
-// until the following is implemented:
-// TODO-ACP: ACP <> P2P https://github.com/sourcenetwork/defradb/issues/2366
-func TestACP_P2PSubscribeAddGetSingleWithPermissionedCollection_Error(t *testing.T) {
+func TestACP_P2PSubscribeAddGetSingleWithPermissionedCollection_LocalACP(t *testing.T) {
 	test := testUtils.TestCase{
-
-		Description: "Test acp, with p2p subscribe with permissioned collection, error",
-
+		SupportedACPTypes: immutable.Some(
+			[]testUtils.ACPType{
+				testUtils.LocalACPType,
+			},
+		),
 		Actions: []any{
 
 			testUtils.RandomNetworkingConfig(),
@@ -93,6 +92,121 @@ func TestACP_P2PSubscribeAddGetSingleWithPermissionedCollection_Error(t *testing
 			testUtils.GetAllP2PCollections{
 				NodeID:                1,
 				ExpectedCollectionIDs: []int{}, // Note: Empty
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestACP_P2PSubscribeAddGetSingleWithPermissionedCollection_SourceHubACP(t *testing.T) {
+	test := testUtils.TestCase{
+		SupportedACPTypes: immutable.Some(
+			[]testUtils.ACPType{
+				testUtils.SourceHubACPType,
+			},
+		),
+		Actions: []any{
+			testUtils.RandomNetworkingConfig(),
+			testUtils.RandomNetworkingConfig(),
+			testUtils.AddPolicy{
+				Identity: immutable.Some(1),
+				Policy: `
+                    name: test
+                    description: a test policy which marks a collection in a database as a resource
+
+                    actor:
+                      name: actor
+
+                    resources:
+                      users:
+                        permissions:
+                          read:
+                            expr: owner + reader
+                          write:
+                            expr: owner
+
+                        relations:
+                          owner:
+                            types:
+                              - actor
+                          reader:
+                            types:
+                              - actor
+                          admin:
+                            manages:
+                              - reader
+                            types:
+                              - actor
+                `,
+
+				ExpectedPolicyID: "94eb195c0e459aa79e02a1986c7e731c5015721c18a373f2b2a0ed140a04b454",
+			},
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users @policy(
+						id: "94eb195c0e459aa79e02a1986c7e731c5015721c18a373f2b2a0ed140a04b454",
+						resource: "users"
+					) {
+						name: String
+						age: Int
+					}
+				`,
+			},
+			testUtils.ConnectPeers{
+				SourceNodeID: 1,
+				TargetNodeID: 0,
+			},
+			testUtils.SubscribeToCollection{
+				NodeID:        1,
+				CollectionIDs: []int{0},
+			},
+			testUtils.CreateDoc{
+				NodeID:   immutable.Some(0),
+				Identity: immutable.Some(1),
+				DocMap: map[string]any{
+					"name": "John",
+				},
+			},
+			testUtils.WaitForSync{},
+			testUtils.Request{
+				// Ensure that the document is accessible on all nodes to authorized actors
+				Identity: immutable.Some(1),
+				Request: `
+					query {
+						Users {
+							name
+						}
+					}
+				`,
+				Results: []map[string]any{
+					{
+						"name": "John",
+					},
+				},
+			},
+			testUtils.Request{
+				// Ensure that the document is hidden on all nodes to unidentified actors
+				Request: `
+					query {
+						Users {
+							name
+						}
+					}
+				`,
+				Results: []map[string]any{},
+			},
+			testUtils.Request{
+				// Ensure that the document is hidden on all nodes to unauthorized actors
+				Identity: immutable.Some(2),
+				Request: `
+					query {
+						Users {
+							name
+						}
+					}
+				`,
+				Results: []map[string]any{},
 			},
 		},
 	}

--- a/tests/integration/db.go
+++ b/tests/integration/db.go
@@ -131,11 +131,14 @@ func setupNode(s *state) (*node.Node, string, error) {
 		opts = append(opts, node.WithACPType(node.LocalACPType))
 
 	case SourceHubACPType:
-		acpOpts, err := setupSourceHub(s)
-		require.NoError(s.t, err)
+		if len(s.acpOptions) == 0 {
+			var err error
+			s.acpOptions, err = setupSourceHub(s)
+			require.NoError(s.t, err)
+		}
 
 		opts = append(opts, node.WithACPType(node.SourceHubACPType))
-		for _, opt := range acpOpts {
+		for _, opt := range s.acpOptions {
 			opts = append(opts, opt)
 		}
 

--- a/tests/integration/state.go
+++ b/tests/integration/state.go
@@ -22,6 +22,7 @@ import (
 	"github.com/sourcenetwork/defradb/datastore"
 	"github.com/sourcenetwork/defradb/event"
 	"github.com/sourcenetwork/defradb/net"
+	"github.com/sourcenetwork/defradb/node"
 	"github.com/sourcenetwork/defradb/tests/clients"
 )
 
@@ -175,6 +176,9 @@ type state struct {
 
 	// The SourceHub address used to pay for SourceHub transactions.
 	sourcehubAddress string
+
+	// The ACP options to share between each node.
+	acpOptions []node.ACPOpt
 }
 
 // newState returns a new fresh state for the given testCase.


### PR DESCRIPTION
## Relevant issue(s)

Resolves #2366

## Description

Handles P2P with SourceHub ACP.

Local ACP remains blocked off, as documents synced would essentially become public unless encrypted.

The testing assumes that a distributed SourceHub chain would be tested in the SourceHub repo, and so it doesn't bother spinning up a chain per node and dealing with SourceHub sync stuff.  Long term we'll want some Defra-based testing around this, but I think we can get away without it.  Feel very free to argue against this :)
