### PR TITLE
feat: Remove IsObjectArray

### DIFF
--- a/client/document.go
+++ b/client/document.go
@@ -186,11 +186,11 @@ func validateFieldSchema(val any, field FieldDefinition) (NormalValue, error) {
 		}
 	}
 
-	if field.Kind.IsObjectArray() {
-		return nil, NewErrFieldNotExist(field.Name)
-	}
-
 	if field.Kind.IsObject() {
+		if field.Kind.IsArray() {
+			return nil, NewErrFieldNotExist(field.Name)
+		}
+
 		v, err := getString(val)
 		if err != nil {
 			return nil, err
@@ -592,7 +592,7 @@ func (doc *Document) Set(field string, value any) error {
 	if !exists {
 		return NewErrFieldNotExist(field)
 	}
-	if fd.Kind.IsObject() && !fd.Kind.IsObjectArray() {
+	if fd.Kind.IsObject() && !fd.Kind.IsArray() {
 		if !strings.HasSuffix(field, request.RelatedObjectID) {
 			field = field + request.RelatedObjectID
 		}

--- a/client/schema_field_description.go
+++ b/client/schema_field_description.go
@@ -33,9 +33,6 @@ type FieldKind interface {
 	// IsObject returns true if this FieldKind is an object type, or an array of object types.
 	IsObject() bool
 
-	// IsObjectArray returns true if this FieldKind is an object array type.
-	IsObjectArray() bool
-
 	// IsArray returns true if this FieldKind is an array type which includes inline arrays as well
 	// as relation arrays.
 	IsArray() bool
@@ -111,10 +108,6 @@ func (k ScalarKind) IsObject() bool {
 	return false
 }
 
-func (k ScalarKind) IsObjectArray() bool {
-	return false
-}
-
 func (k ScalarKind) IsArray() bool {
 	return false
 }
@@ -154,10 +147,6 @@ func (k ScalarArrayKind) IsObject() bool {
 	return false
 }
 
-func (k ScalarArrayKind) IsObjectArray() bool {
-	return false
-}
-
 func (k ScalarArrayKind) IsArray() bool {
 	return true
 }
@@ -178,10 +167,6 @@ func (k ObjectKind) IsObject() bool {
 	return true
 }
 
-func (k ObjectKind) IsObjectArray() bool {
-	return false
-}
-
 func (k ObjectKind) IsArray() bool {
 	return false
 }
@@ -199,10 +184,6 @@ func (k ObjectArrayKind) IsNillable() bool {
 }
 
 func (k ObjectArrayKind) IsObject() bool {
-	return true
-}
-
-func (k ObjectArrayKind) IsObjectArray() bool {
 	return true
 }
 

--- a/internal/db/collection.go
+++ b/internal/db/collection.go
@@ -948,7 +948,7 @@ func (c *collection) tryGetFieldKey(primaryKey core.PrimaryDataStoreKey, fieldNa
 func (c *collection) tryGetFieldID(fieldName string) (uint32, bool) {
 	for _, field := range c.Definition().GetFields() {
 		if field.Name == fieldName {
-			if field.Kind.IsObject() || field.Kind.IsObjectArray() {
+			if field.Kind.IsObject() {
 				// We do not wish to match navigational properties, only
 				// fields directly on the collection.
 				return uint32(0), false

--- a/internal/db/definition_validation.go
+++ b/internal/db/definition_validation.go
@@ -851,7 +851,7 @@ func validateSecondaryNotOnSchema(
 ) error {
 	for _, newSchema := range newState.schemaByName {
 		for _, newField := range newSchema.Fields {
-			if newField.Kind.IsObjectArray() {
+			if newField.Kind.IsObject() && newField.Kind.IsArray() {
 				return NewErrSecondaryFieldOnSchema(newField.Name)
 			}
 		}

--- a/internal/planner/mapper/mapper.go
+++ b/internal/planner/mapper/mapper.go
@@ -140,10 +140,11 @@ func toSelect(
 		// Remap all alias field names to use their internal field name mappings.
 		for index, groupByField := range groupByFields {
 			fieldDesc, ok := definition.GetFieldByName(groupByField)
-			if ok && fieldDesc.Kind.IsObject() && !fieldDesc.Kind.IsObjectArray() {
+			if ok && fieldDesc.Kind.IsObject() {
+				if fieldDesc.Kind.IsArray() {
+					return nil, NewErrInvalidFieldToGroupBy(groupByField)
+				}
 				groupByFields[index] = groupByField + request.RelatedObjectID
-			} else if ok && fieldDesc.Kind.IsObjectArray() {
-				return nil, NewErrInvalidFieldToGroupBy(groupByField)
 			}
 		}
 

--- a/internal/planner/type_join.go
+++ b/internal/planner/type_join.go
@@ -85,12 +85,14 @@ func (p *Planner) makeTypeIndexJoin(
 		return nil, client.NewErrFieldNotExist(subType.Name)
 	}
 
-	if typeFieldDesc.Kind.IsObject() && !typeFieldDesc.Kind.IsArray() { // One-to-One, or One side of One-to-Many
-		joinPlan, err = p.makeTypeJoinOne(parent, source, subType)
-	} else if typeFieldDesc.Kind.IsObjectArray() { // Many side of One-to-Many
-		joinPlan, err = p.makeTypeJoinMany(parent, source, subType)
-	} else { // more to come, Many-to-Many, Embedded?
+	if !typeFieldDesc.Kind.IsObject() {
 		return nil, ErrUnknownRelationType
+	}
+
+	if typeFieldDesc.Kind.IsArray() {
+		joinPlan, err = p.makeTypeJoinMany(parent, source, subType)
+	} else {
+		joinPlan, err = p.makeTypeJoinOne(parent, source, subType)
 	}
 	if err != nil {
 		return nil, err

--- a/internal/request/graphql/schema/collection.go
+++ b/internal/request/graphql/schema/collection.go
@@ -494,11 +494,10 @@ func setCRDTType(field *ast.FieldDefinition, kind client.FieldKind) (client.CTyp
 		}
 	}
 
-	if kind.IsObjectArray() {
-		return client.NONE_CRDT, nil
-	}
-
 	if kind.IsObject() {
+		if kind.IsArray() {
+			return client.NONE_CRDT, nil
+		}
 		return client.LWW_REGISTER, nil
 	}
 

--- a/internal/request/graphql/schema/generate.go
+++ b/internal/request/graphql/schema/generate.go
@@ -471,18 +471,15 @@ func (g *Generator) buildTypes(
 				}
 
 				var ttype gql.Type
-				if field.Kind.IsObject() && !field.Kind.IsArray() {
+				if field.Kind.IsObject() {
 					var ok bool
 					ttype, ok = g.manager.schema.TypeMap()[field.Kind.Underlying()]
 					if !ok {
 						return nil, NewErrTypeNotFound(field.Kind.Underlying())
 					}
-				} else if field.Kind.IsObjectArray() {
-					t, ok := g.manager.schema.TypeMap()[field.Kind.Underlying()]
-					if !ok {
-						return nil, NewErrTypeNotFound(field.Kind.Underlying())
+					if field.Kind.IsArray() {
+						ttype = gql.NewList(ttype)
 					}
-					ttype = gql.NewList(t)
 				} else {
 					var ok bool
 					ttype, ok = fieldKindToGQLType[field.Kind]
@@ -576,10 +573,12 @@ func (g *Generator) buildMutationInputTypes(collections []client.CollectionDefin
 				}
 
 				var ttype gql.Type
-				if field.Kind.IsObject() && !field.Kind.IsArray() {
-					ttype = gql.ID
-				} else if field.Kind.IsObjectArray() {
-					ttype = gql.NewList(gql.ID)
+				if field.Kind.IsObject() {
+					if field.Kind.IsArray() {
+						ttype = gql.NewList(gql.ID)
+					} else {
+						ttype = gql.ID
+					}
 				} else {
 					var ok bool
 					ttype, ok = fieldKindToGQLType[field.Kind]


### PR DESCRIPTION
## Relevant issue(s)

Resolves #2356

## Description

Removes IsObjectArray.

As well as causing confused code, and an overly-large interface, where their are multiple overlapping ways to check the same thing, this func also dirties the solution for #2493 and #2619.

PR is marked as a feature as it is a public change, could be called 'fix', I think it is a bit vague here give me a shout if you have a strong preference.
