### PR TITLE
fix(i): Checkout sourcehub submodules

### DIFF
--- a/.github/workflows/test-and-upload-coverage.yml
+++ b/.github/workflows/test-and-upload-coverage.yml
@@ -179,6 +179,7 @@ jobs:
         with:
           repository: sourcenetwork/sourcehub
           path: _sourceHub
+          submodules: recursive
 
       - name: Install SourceHub CLI
         if: ${{ matrix.acp-type == 'source-hub' }}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #2863

## Description

This PR fixes an issue with the test workflow not checking out sourcehub submodules.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

CI

Specify the platform(s) on which this was tested:
- MacOS

