### PR TITLE
fix: Handle multiple child index joins

### DIFF
--- a/internal/db/fetcher/indexer.go
+++ b/internal/db/fetcher/indexer.go
@@ -68,6 +68,8 @@ func (f *IndexFetcher) Init(
 	reverse bool,
 	showDeleted bool,
 ) error {
+	f.resetState()
+
 	f.col = col
 	f.docFilter = filter
 	f.doc = &encodedDocument{}
@@ -206,4 +208,20 @@ func (f *IndexFetcher) Close() error {
 		return f.indexIter.Close()
 	}
 	return nil
+}
+
+// resetState resets the mutable state of this IndexFetcher, returning the state to how it
+// was immediately after construction.
+func (f *IndexFetcher) resetState() {
+	// WARNING: Do not reset properties set in the constructor!
+
+	f.col = nil
+	f.txn = nil
+	f.docFilter = nil
+	f.doc = nil
+	f.mapping = nil
+	f.indexedFields = nil
+	f.docFields = nil
+	f.indexIter = nil
+	f.execInfo = ExecInfo{}
 }

--- a/internal/db/fetcher/indexer.go
+++ b/internal/db/fetcher/indexer.go
@@ -223,5 +223,5 @@ func (f *IndexFetcher) resetState() {
 	f.indexedFields = nil
 	f.docFields = nil
 	f.indexIter = nil
-	f.execInfo = ExecInfo{}
+	f.execInfo.Reset()
 }

--- a/tests/integration/index/query_with_relation_filter_test.go
+++ b/tests/integration/index/query_with_relation_filter_test.go
@@ -963,7 +963,16 @@ func TestQueryWithIndexOnManyToOne_MultipleViaOneToMany(t *testing.T) {
 						}
 					}
 				}`,
-				Results: []map[string]any{},
+				Results: []map[string]any{
+					{
+						"devices": []map[string]any{
+							{
+								"owner_id":        "bae-1ef746f8-821e-586f-99b2-4cb1fb9b782f",
+								"manufacturer_id": "bae-18c7d707-c44d-552f-b6d6-9e3d05bbf9c1",
+							},
+						},
+					},
+				},
 			},
 		},
 	}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #2862

## Description

Handles multiple child index joins.

Init is called multiple times (IIRC when joining in this direction it is called 1+NPrimaryDocs times) and the state was preserved between calls.  The new `resetState` func duplicates the overwriting of props set in init, but I see that as worth it (very cheap, and means devs don't have to care what is set outside of the constructor). 