### PR TITLE
test: Add assert on DocIndex for child documents

### DIFF
--- a/tests/integration/index/query_with_relation_filter_test.go
+++ b/tests/integration/index/query_with_relation_filter_test.go
@@ -864,19 +864,19 @@ func TestQueryWithIndexOnOneToMany_IfIndexedRelationIsNil_EqNilFilterShouldUseIn
 			},
 			testUtils.CreateDoc{
 				CollectionID: 1,
-				Doc: `{
-					"model":	"Walkman",
+				DocMap: map[string]any{
+					"model":        "Walkman",
 					"manufacturer": "Sony",
-					"owner": "bae-5622129c-b893-5768-a3f4-8f745db4cc04"
-				}`,
+					"owner":        testUtils.NewDocIndex(0, 0),
+				},
 			},
 			testUtils.CreateDoc{
 				CollectionID: 1,
-				Doc: `{
-					"model":	"iPhone",
+				DocMap: map[string]any{
+					"model":        "iPhone",
 					"manufacturer": "Apple",
-					"owner": "bae-5622129c-b893-5768-a3f4-8f745db4cc04"
-				}`,
+					"owner":        testUtils.NewDocIndex(0, 0),
+				},
 			},
 			testUtils.CreateDoc{
 				CollectionID: 1,
@@ -967,8 +967,8 @@ func TestQueryWithIndexOnManyToOne_MultipleViaOneToMany(t *testing.T) {
 					{
 						"devices": []map[string]any{
 							{
-								"owner_id":        "bae-1ef746f8-821e-586f-99b2-4cb1fb9b782f",
-								"manufacturer_id": "bae-18c7d707-c44d-552f-b6d6-9e3d05bbf9c1",
+								"owner_id":        testUtils.NewDocIndex(0, 0),
+								"manufacturer_id": testUtils.NewDocIndex(2, 0),
 							},
 						},
 					},

--- a/tests/integration/query/one_to_many_to_many/joins_test.go
+++ b/tests/integration/query/one_to_many_to_many/joins_test.go
@@ -187,20 +187,20 @@ func TestOneToManyToManyJoinsAreLinkedProperly(t *testing.T) {
 				}`,
 				Results: []map[string]any{
 					{
-						"_docID": "bae-4819f8a1-b519-5b46-ae39-4fdda8558e4f",
+						"_docID": testUtils.NewDocIndex(0, 2),
 						"book":   []map[string]any{},
 						"name":   "Not a Writer",
 					},
 					{
 						"name":   "Cornelia Funke",
-						"_docID": "bae-72e8c691-9f20-55e7-9228-8af1cf54cace",
+						"_docID": testUtils.NewDocIndex(0, 1),
 						"book": []map[string]any{
 							{
-								"_docID": "bae-4dbc2bbc-0652-5412-8063-486499f1c341",
+								"_docID": testUtils.NewDocIndex(1, 0),
 								"name":   "The Rooster Bar",
 								"publisher": []map[string]any{
 									{
-										"_docID": "bae-8a8cbab7-65db-5955-b618-b82f44761cee",
+										"_docID": testUtils.NewDocIndex(2, 0),
 										"name":   "Only Publisher of The Rooster Bar",
 									},
 								},
@@ -209,53 +209,53 @@ func TestOneToManyToManyJoinsAreLinkedProperly(t *testing.T) {
 					},
 					{
 						"name":   "John Grisham",
-						"_docID": "bae-e1ea288f-09fa-55fa-b0b5-0ac8941ea35b",
+						"_docID": testUtils.NewDocIndex(0, 0),
 						"book": []map[string]any{
 							{
-								"_docID": "bae-13164fd9-60fd-5c32-9cb5-8bff3ef8ea53",
+								"_docID": testUtils.NewDocIndex(1, 1),
 								"name":   "Theif Lord",
 								"publisher": []map[string]any{
 									{
-										"_docID": "bae-0107f5cc-c25a-5295-8439-2b08a286af83",
+										"_docID": testUtils.NewDocIndex(2, 1),
 										"name":   "Only Publisher of Theif Lord",
 									},
 								},
 							},
 							{
-								"_docID":    "bae-1ccf3043-d760-543e-be1b-6691fa6aa7a8",
+								"_docID":    testUtils.NewDocIndex(1, 2),
 								"name":      "The Associate",
 								"publisher": []map[string]any{},
 							},
 							{
-								"_docID": "bae-5366ba09-54e8-5381-8169-a770aa9282ae",
+								"_docID": testUtils.NewDocIndex(1, 3),
 								"name":   "Painted House",
 								"publisher": []map[string]any{
 									{
-										"_docID": "bae-35f1e55a-c51b-53d7-9b28-9beb904a1343",
+										"_docID": testUtils.NewDocIndex(2, 2),
 										"name":   "Only Publisher of Painted House",
 									},
 								},
 							},
 							{
-								"_docID": "bae-96c9de0f-2903-5589-9604-b42882afde8c",
+								"_docID": testUtils.NewDocIndex(1, 4),
 								"name":   "A Time for Mercy",
 								"publisher": []map[string]any{
 									{
-										"_docID": "bae-37451579-7e50-541d-8a3c-849b290ea416",
+										"_docID": testUtils.NewDocIndex(2, 3),
 										"name":   "Only Publisher of A Time for Mercy",
 									},
 								},
 							},
 							{
-								"_docID": "bae-f52abfc3-9026-5713-9622-2d3458a386e0",
+								"_docID": testUtils.NewDocIndex(1, 5),
 								"name":   "Sooley",
 								"publisher": []map[string]any{
 									{
-										"_docID": "bae-c46b7771-843e-51ac-92be-d145aa2cfc07",
+										"_docID": testUtils.NewDocIndex(2, 5),
 										"name":   "Second of Two Publishers of Sooley",
 									},
 									{
-										"_docID": "bae-fc233f9c-f117-59de-be2b-60e4f6f0a898",
+										"_docID": testUtils.NewDocIndex(2, 4),
 										"name":   "First of Two Publishers of Sooley",
 									},
 								},

--- a/tests/integration/utils2.go
+++ b/tests/integration/utils2.go
@@ -1899,8 +1899,7 @@ func assertRequestResultDocs(
 					fmt.Sprintf("node: %v, doc: %v", nodeID, actualDocIndex),
 				)
 			case []map[string]any:
-				actualValueMap, ok := actualValue.([]map[string]any)
-				require.True(s.t, ok, "expected array of maps, got %T", actualValue)
+				actualValueMap := convertToArrayOfMaps(s.t, actualValue)
 
 				assertRequestResultDocs(
 					s,
@@ -1923,6 +1922,22 @@ func assertRequestResultDocs(
 	}
 
 	return false
+}
+
+func convertToArrayOfMaps(t testing.TB, value any) []map[string]any {
+	valueArrayMap, ok := value.([]map[string]any)
+	if ok {
+		return valueArrayMap
+	}
+	valueArray, ok := value.([]any)
+	require.True(t, ok, "expected value to be an array of maps %v", value)
+
+	valueArrayMap = make([]map[string]any, len(valueArray))
+	for i, v := range valueArray {
+		valueArrayMap[i], ok = v.(map[string]any)
+		require.True(t, ok, "expected value to be an array of maps %v", value)
+	}
+	return valueArrayMap
 }
 
 func assertExpectedErrorRaised(t testing.TB, description string, expectedError string, wasRaised bool) {


### PR DESCRIPTION
## Relevant issue(s)

Resolves #2870

## Description

Enables asserting using `testUsilts.NewDocIndex` on child documents
