### PR TITLE
refactor(i): Subscription test results

### DIFF
--- a/tests/integration/subscription/subscription_test.go
+++ b/tests/integration/subscription/subscription_test.go
@@ -28,16 +28,20 @@ func TestSubscriptionWithCreateMutations(t *testing.T) {
 						age
 					}
 				}`,
-				Results: []map[string]any{
+				Results: [][]map[string]any{
 					{
-						"_docID": "bae-b3ce089b-f543-5984-be9f-ad7d08969f4e",
-						"age":    int64(27),
-						"name":   "John",
+						{
+							"_docID": "bae-b3ce089b-f543-5984-be9f-ad7d08969f4e",
+							"age":    int64(27),
+							"name":   "John",
+						},
 					},
 					{
-						"_docID": "bae-bc20b854-10b3-5408-b28c-f273ddda9434",
-						"age":    int64(31),
-						"name":   "Addo",
+						{
+							"_docID": "bae-bc20b854-10b3-5408-b28c-f273ddda9434",
+							"age":    int64(31),
+							"name":   "Addo",
+						},
 					},
 				},
 			},
@@ -82,10 +86,12 @@ func TestSubscriptionWithFilterAndOneCreateMutation(t *testing.T) {
 						age
 					}
 				}`,
-				Results: []map[string]any{
+				Results: [][]map[string]any{
 					{
-						"age":  int64(27),
-						"name": "John",
+						{
+							"age":  int64(27),
+							"name": "John",
+						},
 					},
 				},
 			},
@@ -119,7 +125,7 @@ func TestSubscriptionWithFilterAndOneCreateMutationOutsideFilter(t *testing.T) {
 						age
 					}
 				}`,
-				Results: []map[string]any{},
+				Results: [][]map[string]any{},
 			},
 			testUtils.Request{
 				Request: `mutation {
@@ -150,10 +156,12 @@ func TestSubscriptionWithFilterAndCreateMutations(t *testing.T) {
 						age
 					}
 				}`,
-				Results: []map[string]any{
+				Results: [][]map[string]any{
 					{
-						"age":  int64(27),
-						"name": "John",
+						{
+							"age":  int64(27),
+							"name": "John",
+						},
 					},
 				},
 			},
@@ -217,11 +225,13 @@ func TestSubscriptionWithUpdateMutations(t *testing.T) {
 						points
 					}
 				}`,
-				Results: []map[string]any{
+				Results: [][]map[string]any{
 					{
-						"age":    int64(27),
-						"name":   "John",
-						"points": float64(45),
+						{
+							"age":    int64(27),
+							"name":   "John",
+							"points": float64(45),
+						},
 					},
 				},
 			},
@@ -273,16 +283,20 @@ func TestSubscriptionWithUpdateAllMutations(t *testing.T) {
 						points
 					}
 				}`,
-				Results: []map[string]any{
+				Results: [][]map[string]any{
 					{
-						"age":    int64(31),
-						"name":   "Addo",
-						"points": float64(55),
+						{
+							"age":    int64(31),
+							"name":   "Addo",
+							"points": float64(55),
+						},
 					},
 					{
-						"age":    int64(27),
-						"name":   "John",
-						"points": float64(55),
+						{
+							"age":    int64(27),
+							"name":   "John",
+							"points": float64(55),
+						},
 					},
 				},
 			},

--- a/tests/integration/test_case.go
+++ b/tests/integration/test_case.go
@@ -616,7 +616,7 @@ type SubscriptionRequest struct {
 	Request string
 
 	// The expected (data) results yielded through the subscription across its lifetime.
-	Results []map[string]any
+	Results [][]map[string]any
 
 	// Any error expected from the action. Optional.
 	//


### PR DESCRIPTION
## Relevant issue(s)

Resolves #2873

## Description

This PR is small refactor of the subscription tests to make it easier to test ordering of results and eventually multiple selections within the results.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

`make test`

Specify the platform(s) on which this was tested:
- MacOS

