### PR TITLE
fix: Create mutation introspection

### DIFF
--- a/internal/request/graphql/schema/descriptions.go
+++ b/internal/request/graphql/schema/descriptions.go
@@ -102,7 +102,7 @@ An optional value that specifies as to whether deleted documents may be
  returned. This argument will propagate down through any child selects/joins.
 `
 	createDocumentDescription string = `
-Creates a single document of this type using the data provided.
+Creates one or more documents of this type using the data provided.
 `
 	updateDocumentsDescription string = `
 Updates documents in this collection using the data provided. Only documents

--- a/internal/request/graphql/schema/generate.go
+++ b/internal/request/graphql/schema/generate.go
@@ -1057,7 +1057,7 @@ func (g *Generator) GenerateMutationInputForGQLType(obj *gql.Object) ([]*gql.Fie
 	create := &gql.Field{
 		Name:        "create_" + obj.Name(),
 		Description: createDocumentDescription,
-		Type:        obj,
+		Type:        gql.NewList(obj),
 		Args: gql.FieldConfigArgument{
 			request.Input: schemaTypes.NewArgConfig(mutationInput, "Create a "+obj.Name()+" document"),
 			request.Inputs: schemaTypes.NewArgConfig(gql.NewList(gql.NewNonNull(mutationInput)),


### PR DESCRIPTION
## Relevant issue(s)

Resolves #2868

## Description

This PR fixes the create mutation return type.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

manually tested in playground

Specify the platform(s) on which this was tested:
- MacOS

