### PR TITLE
feat: Operation selection in gql requests

### DIFF
--- a/client/db.go
+++ b/client/db.go
@@ -246,7 +246,16 @@ type Store interface {
 	GetAllIndexes(context.Context) (map[CollectionName][]IndexDescription, error)
 
 	// ExecRequest executes the given GQL request against the [Store].
-	ExecRequest(ctx context.Context, request string) *RequestResult
+	ExecRequest(ctx context.Context, request GQLRequest) *RequestResult
+}
+
+// GQLRequest represents a GraphQL request to execute.
+type GQLRequest struct {
+	// Query contains the GraphQL document that will be executed.
+	Query string `json:"query"`
+
+	// OperationName is the name of the operation in the parsed document to execute.
+	OperationName string `json:"operationName,omitempty"`
 }
 
 // GQLResult represents the immediate results of a GQL request.

--- a/client/mocks/db.go
+++ b/client/mocks/db.go
@@ -527,7 +527,7 @@ func (_c *DB_Events_Call) RunAndReturn(run func() *event.Bus) *DB_Events_Call {
 }
 
 // ExecRequest provides a mock function with given fields: ctx, request
-func (_m *DB) ExecRequest(ctx context.Context, request string) *client.RequestResult {
+func (_m *DB) ExecRequest(ctx context.Context, request client.GQLRequest) *client.RequestResult {
 	ret := _m.Called(ctx, request)
 
 	if len(ret) == 0 {
@@ -535,7 +535,7 @@ func (_m *DB) ExecRequest(ctx context.Context, request string) *client.RequestRe
 	}
 
 	var r0 *client.RequestResult
-	if rf, ok := ret.Get(0).(func(context.Context, string) *client.RequestResult); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, client.GQLRequest) *client.RequestResult); ok {
 		r0 = rf(ctx, request)
 	} else {
 		if ret.Get(0) != nil {
@@ -553,14 +553,14 @@ type DB_ExecRequest_Call struct {
 
 // ExecRequest is a helper method to define mock.On call
 //   - ctx context.Context
-//   - request string
+//   - request client.GQLRequest
 func (_e *DB_Expecter) ExecRequest(ctx interface{}, request interface{}) *DB_ExecRequest_Call {
 	return &DB_ExecRequest_Call{Call: _e.mock.On("ExecRequest", ctx, request)}
 }
 
-func (_c *DB_ExecRequest_Call) Run(run func(ctx context.Context, request string)) *DB_ExecRequest_Call {
+func (_c *DB_ExecRequest_Call) Run(run func(ctx context.Context, request client.GQLRequest)) *DB_ExecRequest_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string))
+		run(args[0].(context.Context), args[1].(client.GQLRequest))
 	})
 	return _c
 }
@@ -570,7 +570,7 @@ func (_c *DB_ExecRequest_Call) Return(_a0 *client.RequestResult) *DB_ExecRequest
 	return _c
 }
 
-func (_c *DB_ExecRequest_Call) RunAndReturn(run func(context.Context, string) *client.RequestResult) *DB_ExecRequest_Call {
+func (_c *DB_ExecRequest_Call) RunAndReturn(run func(context.Context, client.GQLRequest) *client.RequestResult) *DB_ExecRequest_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/client/request/errors.go
+++ b/client/request/errors.go
@@ -23,7 +23,9 @@ const (
 // This list is incomplete and undefined errors may also be returned.
 // Errors returned from this package may be tested against these errors with errors.Is.
 var (
-	ErrSelectOfNonGroupField = errors.New(errSelectOfNonGroupField)
+	ErrSelectOfNonGroupField  = errors.New(errSelectOfNonGroupField)
+	ErrMissingOperationName   = errors.New("request with multiple operations must have an operationName")
+	ErrMissingQueryOrMutation = errors.New("request is missing query or mutation operation statements")
 )
 
 // NewErrSelectOfNonGroupField returns an error indicating that a non-group-by field

--- a/client/request/request.go
+++ b/client/request/request.go
@@ -20,6 +20,41 @@ type Request struct {
 	Subscription []*OperationDefinition
 }
 
+// Operation returns the operation that should be executed from the request.
+//
+// The operationName is used to select an operation when multiple are defined.
+func (r *Request) Operation(operationName string) (*OperationDefinition, error) {
+	switch {
+	case len(r.Queries) == 1 && len(r.Mutations) == 0 && len(r.Subscription) == 0:
+		return r.Queries[0], nil
+
+	case len(r.Queries) == 0 && len(r.Mutations) == 1 && len(r.Subscription) == 0:
+		return r.Mutations[0], nil
+
+	case len(r.Queries) == 0 && len(r.Mutations) == 0 && len(r.Subscription) == 1:
+		return r.Subscription[0], nil
+
+	case len(r.Queries) == 0 && len(r.Mutations) == 0 && len(r.Subscription) == 0:
+		return nil, ErrMissingQueryOrMutation
+	}
+	for _, op := range r.Queries {
+		if op.Name == operationName {
+			return op, nil
+		}
+	}
+	for _, op := range r.Mutations {
+		if op.Name == operationName {
+			return op, nil
+		}
+	}
+	for _, op := range r.Subscription {
+		if op.Name == operationName {
+			return op, nil
+		}
+	}
+	return nil, ErrMissingOperationName
+}
+
 type Selection any
 
 // Directives contains all the optional and non-optional
@@ -32,6 +67,7 @@ type Directives struct {
 }
 
 type OperationDefinition struct {
+	Name       string
 	Selections []Selection
 	Directives Directives
 }

--- a/docs/website/references/cli/defradb_client_query.md
+++ b/docs/website/references/cli/defradb_client_query.md
@@ -24,14 +24,15 @@ with the database more conveniently.
 To learn more about the DefraDB GraphQL Query Language, refer to https://docs.source.network.
 
 ```
-defradb client query [-i --identity] [request] [flags]
+defradb client query [-i --identity] [request] [--operation <name>] [flags]
 ```
 
 ### Options
 
 ```
-  -f, --file string   File containing the query request
-  -h, --help          help for query
+  -f, --file string        File containing the query request
+  -h, --help               help for query
+  -o, --operation string   Name of the operation to execute
 ```
 
 ### Options inherited from parent commands

--- a/docs/website/references/http/openapi.json
+++ b/docs/website/references/http/openapi.json
@@ -316,6 +316,9 @@
             },
             "graphql_request": {
                 "properties": {
+                    "operationName": {
+                        "type": "string"
+                    },
                     "query": {
                         "type": "string"
                     }
@@ -1270,6 +1273,13 @@
                     {
                         "in": "query",
                         "name": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "operationName",
                         "schema": {
                             "type": "string"
                         }

--- a/http/client.go
+++ b/http/client.go
@@ -339,12 +339,12 @@ func (c *Client) GetAllIndexes(ctx context.Context) (map[client.CollectionName][
 
 func (c *Client) ExecRequest(
 	ctx context.Context,
-	query string,
+	request client.GQLRequest,
 ) *client.RequestResult {
 	methodURL := c.http.baseURL.JoinPath("graphql")
 	result := &client.RequestResult{}
 
-	body, err := json.Marshal(&GraphQLRequest{query})
+	body, err := json.Marshal(&request)
 	if err != nil {
 		result.GQL.Errors = []error{err}
 		return result

--- a/http/handler_ccip.go
+++ b/http/handler_ccip.go
@@ -54,13 +54,13 @@ func (c *ccipHandler) ExecCCIP(rw http.ResponseWriter, req *http.Request) {
 		responseJSON(rw, http.StatusBadRequest, errorResponse{err})
 		return
 	}
-	var request GraphQLRequest
+	var request client.GQLRequest
 	if err := json.Unmarshal(data, &request); err != nil {
 		responseJSON(rw, http.StatusBadRequest, errorResponse{err})
 		return
 	}
 
-	result := store.ExecRequest(req.Context(), request.Query)
+	result := store.ExecRequest(req.Context(), request)
 	if result.Subscription != nil {
 		responseJSON(rw, http.StatusBadRequest, errorResponse{ErrStreamingNotSupported})
 		return

--- a/http/handler_ccip_test.go
+++ b/http/handler_ccip_test.go
@@ -34,7 +34,7 @@ import (
 func TestCCIPGet_WithValidData(t *testing.T) {
 	cdb := setupDatabase(t)
 
-	gqlData, err := json.Marshal(&GraphQLRequest{
+	gqlData, err := json.Marshal(&client.GQLRequest{
 		Query: `query {
 			User {
 				name
@@ -73,7 +73,7 @@ func TestCCIPGet_WithValidData(t *testing.T) {
 func TestCCIPGet_WithSubscription(t *testing.T) {
 	cdb := setupDatabase(t)
 
-	gqlData, err := json.Marshal(&GraphQLRequest{
+	gqlData, err := json.Marshal(&client.GQLRequest{
 		Query: `subscription {
 			User {
 				name
@@ -118,7 +118,7 @@ func TestCCIPGet_WithInvalidData(t *testing.T) {
 func TestCCIPPost_WithValidData(t *testing.T) {
 	cdb := setupDatabase(t)
 
-	gqlJSON, err := json.Marshal(&GraphQLRequest{
+	gqlJSON, err := json.Marshal(&client.GQLRequest{
 		Query: `query {
 			User {
 				name

--- a/http/openapi.go
+++ b/http/openapi.go
@@ -25,7 +25,7 @@ var openApiSchemas = map[string]any{
 	"collection_update":     &CollectionUpdateRequest{},
 	"collection_delete":     &CollectionDeleteRequest{},
 	"peer_info":             &peer.AddrInfo{},
-	"graphql_request":       &GraphQLRequest{},
+	"graphql_request":       &client.GQLRequest{},
 	"graphql_response":      &GraphQLResponse{},
 	"backup_config":         &client.BackupConfig{},
 	"collection":            &client.CollectionDescription{},

--- a/internal/db/request.go
+++ b/internal/db/request.go
@@ -18,15 +18,15 @@ import (
 )
 
 // execRequest executes a request against the database.
-func (db *db) execRequest(ctx context.Context, request string) *client.RequestResult {
+func (db *db) execRequest(ctx context.Context, request client.GQLRequest) *client.RequestResult {
 	res := &client.RequestResult{}
-	ast, err := db.parser.BuildRequestAST(request)
+	ast, err := db.parser.BuildRequestAST(request.Query)
 	if err != nil {
 		res.GQL.Errors = []error{err}
 		return res
 	}
 	if db.parser.IsIntrospection(ast) {
-		return db.parser.ExecuteIntrospection(request)
+		return db.parser.ExecuteIntrospection(request.Query)
 	}
 
 	parsedRequest, errors := db.parser.Parse(ast)
@@ -50,7 +50,7 @@ func (db *db) execRequest(ctx context.Context, request string) *client.RequestRe
 	identity := GetContextIdentity(ctx)
 	planner := planner.New(ctx, identity, db.acp, db, txn)
 
-	results, err := planner.RunRequest(ctx, parsedRequest)
+	results, err := planner.RunRequest(ctx, parsedRequest, request.OperationName)
 	if err != nil {
 		res.GQL.Errors = []error{err}
 	}

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -21,7 +21,7 @@ import (
 )
 
 // ExecRequest executes a request against the database.
-func (db *db) ExecRequest(ctx context.Context, request string) *client.RequestResult {
+func (db *db) ExecRequest(ctx context.Context, request client.GQLRequest) *client.RequestResult {
 	ctx, txn, err := ensureContextTxn(ctx, db, false)
 	if err != nil {
 		res := &client.RequestResult{}

--- a/internal/planner/errors.go
+++ b/internal/planner/errors.go
@@ -25,7 +25,6 @@ var (
 	ErrDeltaMissingDocID                   = errors.New("commit Delta missing document ID")
 	ErrDeltaMissingFieldName               = errors.New("commit Delta missing field name")
 	ErrFailedToFindScanNode                = errors.New("failed to find original scan node in plan graph")
-	ErrMissingQueryOrMutation              = errors.New("request is missing query or mutation operation statements")
 	ErrOperationDefinitionMissingSelection = errors.New("operationDefinition is missing selections")
 	ErrFailedToFindGroupSource             = errors.New("failed to identify group source")
 	ErrCantExplainSubscriptionRequest      = errors.New("can not explain a subscription request")

--- a/internal/request/graphql/parser/mutation.go
+++ b/internal/request/graphql/parser/mutation.go
@@ -36,6 +36,7 @@ func parseMutationOperationDefinition(
 	def *ast.OperationDefinition,
 ) (*request.OperationDefinition, error) {
 	qdef := &request.OperationDefinition{
+		Name:       def.Name.Value,
 		Selections: make([]request.Selection, len(def.SelectionSet.Selections)),
 	}
 

--- a/internal/request/graphql/parser/mutation.go
+++ b/internal/request/graphql/parser/mutation.go
@@ -36,8 +36,10 @@ func parseMutationOperationDefinition(
 	def *ast.OperationDefinition,
 ) (*request.OperationDefinition, error) {
 	qdef := &request.OperationDefinition{
-		Name:       def.Name.Value,
 		Selections: make([]request.Selection, len(def.SelectionSet.Selections)),
+	}
+	if def.Name != nil {
+		qdef.Name = def.Name.Value
 	}
 
 	for i, selection := range def.SelectionSet.Selections {

--- a/internal/request/graphql/parser/query.go
+++ b/internal/request/graphql/parser/query.go
@@ -29,8 +29,10 @@ func parseQueryOperationDefinition(
 	def *ast.OperationDefinition,
 ) (*request.OperationDefinition, []error) {
 	qdef := &request.OperationDefinition{
-		Name:       def.Name.Value,
 		Selections: make([]request.Selection, len(def.SelectionSet.Selections)),
+	}
+	if def.Name != nil {
+		qdef.Name = def.Name.Value
 	}
 
 	for i, selection := range def.SelectionSet.Selections {

--- a/internal/request/graphql/parser/query.go
+++ b/internal/request/graphql/parser/query.go
@@ -29,6 +29,7 @@ func parseQueryOperationDefinition(
 	def *ast.OperationDefinition,
 ) (*request.OperationDefinition, []error) {
 	qdef := &request.OperationDefinition{
+		Name:       def.Name.Value,
 		Selections: make([]request.Selection, len(def.SelectionSet.Selections)),
 	}
 

--- a/internal/request/graphql/parser/subscription.go
+++ b/internal/request/graphql/parser/subscription.go
@@ -24,8 +24,10 @@ func parseSubscriptionOperationDefinition(
 	def *ast.OperationDefinition,
 ) (*request.OperationDefinition, error) {
 	sdef := &request.OperationDefinition{
-		Name:       def.Name.Value,
 		Selections: make([]request.Selection, len(def.SelectionSet.Selections)),
+	}
+	if def.Name != nil {
+		sdef.Name = def.Name.Value
 	}
 
 	for i, selection := range def.SelectionSet.Selections {

--- a/internal/request/graphql/parser/subscription.go
+++ b/internal/request/graphql/parser/subscription.go
@@ -24,6 +24,7 @@ func parseSubscriptionOperationDefinition(
 	def *ast.OperationDefinition,
 ) (*request.OperationDefinition, error) {
 	sdef := &request.OperationDefinition{
+		Name:       def.Name.Value,
 		Selections: make([]request.Selection, len(def.SelectionSet.Selections)),
 	}
 

--- a/tests/bench/query/planner/utils.go
+++ b/tests/bench/query/planner/utils.go
@@ -87,7 +87,7 @@ func runMakePlanBench(
 			d,
 			txn,
 		)
-		plan, err := planner.MakePlan(q)
+		plan, err := planner.MakePlan(q, "")
 		if err != nil {
 			return errors.Wrap("failed to make plan", err)
 		}

--- a/tests/bench/query/simple/utils.go
+++ b/tests/bench/query/simple/utils.go
@@ -70,7 +70,7 @@ func runQueryBenchGetSync(
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		res := db.ExecRequest(ctx, query)
+		res := db.ExecRequest(ctx, client.GQLRequest{Query: query})
 		if len(res.GQL.Errors) > 0 {
 			return errors.New(fmt.Sprintf("Query error: %v", res.GQL.Errors))
 		}

--- a/tests/clients/cli/wrapper.go
+++ b/tests/clients/cli/wrapper.go
@@ -395,10 +395,13 @@ func (w *Wrapper) GetAllIndexes(ctx context.Context) (map[client.CollectionName]
 
 func (w *Wrapper) ExecRequest(
 	ctx context.Context,
-	query string,
+	request client.GQLRequest,
 ) *client.RequestResult {
 	args := []string{"client", "query"}
-	args = append(args, query)
+	args = append(args, request.Query)
+	if request.OperationName != "" {
+		args = append(args, "--operation", request.OperationName)
+	}
 
 	result := &client.RequestResult{}
 

--- a/tests/clients/http/wrapper.go
+++ b/tests/clients/http/wrapper.go
@@ -170,9 +170,9 @@ func (w *Wrapper) GetAllIndexes(ctx context.Context) (map[client.CollectionName]
 
 func (w *Wrapper) ExecRequest(
 	ctx context.Context,
-	query string,
+	request client.GQLRequest,
 ) *client.RequestResult {
-	return w.client.ExecRequest(ctx, query)
+	return w.client.ExecRequest(ctx, request)
 }
 
 func (w *Wrapper) NewTxn(ctx context.Context, readOnly bool) (datastore.Txn, error) {

--- a/tests/integration/explain.go
+++ b/tests/integration/explain.go
@@ -133,7 +133,7 @@ func executeExplainRequest(
 	for _, node := range getNodes(action.NodeID, s.nodes) {
 		result := node.ExecRequest(
 			s.ctx,
-			action.Request,
+			client.GQLRequest{Query: action.Request},
 		)
 		assertExplainRequestResults(s, &result.GQL, action)
 	}

--- a/tests/integration/query/simple/with_operation_name_test.go
+++ b/tests/integration/query/simple/with_operation_name_test.go
@@ -1,0 +1,83 @@
+// Copyright 2024 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package simple
+
+import (
+	"testing"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+func TestQuerySimpleWithMultipleOperationsAndOperationName_ShouldSucceed(t *testing.T) {
+	test := testUtils.RequestTestCase{
+		Description: "Simple query with multiple operations",
+		Request: `query usersWithAge {
+					Users {
+						_docID
+						Age
+					}
+				}
+				query usersWithName {
+					Users {
+						_docID
+						Name
+					}
+				}`,
+		OperationName: "usersWithAge",
+		Docs: map[int][]string{
+			0: {
+				`{
+					"Name": "John",
+					"Age": 21
+				}`,
+			},
+		},
+		Results: map[string]any{
+			"Users": []map[string]any{
+				{
+					"_docID": "bae-d4303725-7db9-53d2-b324-f3ee44020e52",
+					"Age":    int64(21),
+				},
+			},
+		},
+	}
+
+	executeTestCase(t, test)
+}
+
+func TestQuerySimpleWithMultipleOperationsAndNoOperationName_ShouldReturnError(t *testing.T) {
+	test := testUtils.RequestTestCase{
+		Description: "Simple query with multiple operations",
+		Request: `query usersWithAge {
+					Users {
+						_docID
+						Age
+					}
+				}
+				query usersWithName {
+					Users {
+						_docID
+						Name
+					}
+				}`,
+		Docs: map[int][]string{
+			0: {
+				`{
+					"Name": "John",
+					"Age": 21
+				}`,
+			},
+		},
+		ExpectedError: "request with multiple operations must have an operationName",
+	}
+
+	executeTestCase(t, test)
+}

--- a/tests/integration/test_case.go
+++ b/tests/integration/test_case.go
@@ -535,6 +535,9 @@ type Request struct {
 	// The request to execute.
 	Request string
 
+	// Name of the operation within the request to execute.
+	OperationName string
+
 	// The expected (data) results of the issued request.
 	Results map[string]any
 

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -15,8 +15,9 @@ import (
 )
 
 type RequestTestCase struct {
-	Description string
-	Request     string
+	Description   string
+	Request       string
+	OperationName string
 
 	// docs is a map from Collection Index, to a list
 	// of docs in stringified JSON format
@@ -59,6 +60,7 @@ func ExecuteRequestTestCase(
 				ExpectedError: test.ExpectedError,
 				Request:       test.Request,
 				Results:       test.Results,
+				OperationName: test.OperationName,
 			},
 		)
 	}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #1395

## Description

This PR allows multiple operations to be defined within a request and selected using an `operationName` param.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

added tests

Specify the platform(s) on which this was tested:
- MacOS
