### PR TITLE
chore: Bump to GoLang v1.22

### DIFF
--- a/.github/workflows/check-tidy.yml
+++ b/.github/workflows/check-tidy.yml
@@ -9,8 +9,8 @@
 # licenses/APL.txt.
 
 # This workflow checks that go mod tidy command we have set for the specific
-# go version is not broken, for example `go mod tidy -go=1.21.3`. This
-# can cause some head scratching at times, so better catch this in the PR.
+# go version is not broken. This can cause some head scratching at times,
+# so better catch this in the PR.
 #
 # Inaddition to that also checks that we are currently in a `tidy` state.
 name: Check Tidy Workflow

--- a/.github/workflows/check-vulnerabilities.yml
+++ b/.github/workflows/check-vulnerabilities.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Run govulncheck
         uses: golang/govulncheck-action@v1
         with:
-          go-version-input: "1.21"
-          go-package: ./...
+          go-version-file: 'go.mod'
           check-latest: true
           cache: false
+          go-package: ./...

--- a/Makefile
+++ b/Makefile
@@ -202,7 +202,7 @@ verify:
 
 .PHONY: tidy
 tidy:
-	go mod tidy -go=1.21.3
+	go mod tidy -go=1.22
 
 .PHONY: clean
 clean:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sourcenetwork/defradb
 
-go 1.21.3
+go 1.22
 
 require (
 	github.com/bits-and-blooms/bitset v1.13.0

--- a/internal/lens/history.go
+++ b/internal/lens/history.go
@@ -157,11 +157,7 @@ func getCollectionHistory(
 	history := map[schemaVersionID]*collectionHistoryLink{}
 	schemaVersionsByColID := map[uint32]schemaVersionID{}
 
-	for _, c := range cols {
-		// Todo - this `col := c` can be removed with Go 1.22:
-		// https://github.com/sourcenetwork/defradb/issues/2431
-		col := c
-
+	for _, col := range cols {
 		// Convert the temporary types to the cleaner return type:
 		history[col.SchemaVersionID] = &collectionHistoryLink{
 			collection: &col,

--- a/internal/planner/commit.go
+++ b/internal/planner/commit.go
@@ -241,9 +241,8 @@ func (n *dagScanNode) Next() (bool, error) {
 		// so that the last new cid will be at the front of the slice
 		n.queuedCids = append(make([]*cid.Cid, len(heads)), n.queuedCids...)
 
-		for i, h := range heads {
-			link := h // TODO remove when Go 1.22 #2431
-			n.queuedCids[len(heads)-i-1] = &link.Cid
+		for i, head := range heads {
+			n.queuedCids[len(heads)-i-1] = &head.Cid
 		}
 	}
 

--- a/internal/request/graphql/schema/generate.go
+++ b/internal/request/graphql/schema/generate.go
@@ -420,11 +420,7 @@ func (g *Generator) buildTypes(
 	// get all the defined types from the AST
 	objs := make([]*gql.Object, 0)
 
-	for _, c := range collections {
-		// Copy the loop variable before usage within the loop or it
-		// will be reassigned before the thunk is run
-		// TODO remove when Go 1.22
-		collection := c
+	for _, collection := range collections {
 		fieldDescriptions := collection.GetFields()
 		isEmbeddedObject := !collection.Description.Name.HasValue()
 		isQuerySource := len(collection.Description.QuerySources()) > 0
@@ -536,18 +532,14 @@ func (g *Generator) buildTypes(
 // buildMutationInputTypes creates the input object types
 // for collection create and update mutation operations.
 func (g *Generator) buildMutationInputTypes(collections []client.CollectionDefinition) error {
-	for _, c := range collections {
-		if !c.Description.Name.HasValue() {
+	for _, collection := range collections {
+		if !collection.Description.Name.HasValue() {
 			// If the definition's collection is empty, this must be a collectionless
 			// schema, in which case users cannot mutate documents through it and we
 			// have no need to build mutation input types for it.
 			continue
 		}
 
-		// Copy the loop variable before usage within the loop or it
-		// will be reassigned before the thunk is run
-		// TODO remove when Go 1.22
-		collection := c
 		mutationInputName := collection.Description.Name.Value() + mutationInputNameSuffix
 
 		// check if mutation input type exists

--- a/tools/cloud/aws/packer/build_aws_ami.pkr.hcl
+++ b/tools/cloud/aws/packer/build_aws_ami.pkr.hcl
@@ -66,8 +66,8 @@ build {
     inline = [
       "/usr/bin/cloud-init status --wait",
       "sudo apt-get update && sudo apt-get install make build-essential -y",
-      "curl -OL https://golang.org/dl/go1.21.6.linux-amd64.tar.gz",
-      "rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.21.6.linux-amd64.tar.gz",
+      "curl -OL https://golang.org/dl/go1.22.6.linux-amd64.tar.gz",
+      "rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.22.6.linux-amd64.tar.gz",
       "export PATH=$PATH:/usr/local/go/bin",
       "git clone \"https://git@$DEFRADB_GIT_REPO\"",
       "cd ./defradb || { printf \"\\\ncd into defradb failed.\\\n\" && exit 2; }",

--- a/tools/configs/golangci.yaml
+++ b/tools/configs/golangci.yaml
@@ -105,15 +105,11 @@ linters:
 
   enable-all: false
 
-  disable:
-    # - prealloc
-
   disable-all: true
 
   enable:
     - errcheck
     - errorlint
-    - exportloopref
     - forbidigo
     - goconst
     - gofmt

--- a/tools/configs/golangci.yaml
+++ b/tools/configs/golangci.yaml
@@ -57,7 +57,7 @@ run:
 
   # Define the Go version limit.
   # Default: use Go version from the go.mod file, fallback on the env var `GOVERSION`.
-  go: "1.21"
+  go: "1.22"
 
 #=====================================================================================[ Output Configuration Options ]
 output:
@@ -263,7 +263,7 @@ linters-settings:
 
   gosimple:
     # Select the Go version to target.
-    go: "1.21"
+    go: "1.22"
     # https://staticcheck.io/docs/options#checks
     checks: ["all", "-S1038"]
     # Turn on all except (these are disabled):
@@ -356,13 +356,13 @@ linters-settings:
 
   staticcheck:
     # Select the Go version to target.
-    go: "1.21"
+    go: "1.22"
     # https://staticcheck.io/docs/options#checks
     checks: ["all"]
 
   unused:
     # Select the Go version to target.
-    go: "1.21"
+    go: "1.22"
 
   whitespace:
     # Enforces newlines (or comments) after every multi-line if statement.

--- a/tools/defradb.containerfile
+++ b/tools/defradb.containerfile
@@ -11,7 +11,7 @@ RUN npm run build
 
 # Stage: build
 # Several steps are involved to enable caching and because of the behavior of COPY regarding directories.
-FROM docker.io/golang:1.21 AS build
+FROM docker.io/golang:1.22 AS build
 WORKDIR /repo/
 COPY go.mod go.sum Makefile ./
 RUN make deps:modules


### PR DESCRIPTION

## Relevant issue(s)
Resolves #2431

## Description
- This is a routine version bump of GoLang, the previous bump was done in (https://github.com/sourcenetwork/defradb/pull/2195)
- Also updates the golang version for AWS AMI generation.
- Update all loop todos for 1.22 by removing the copy variables.