### PR TITLE
feat: Enable indexing for DateTime fields

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	github.com/multiformats/go-multicodec v0.9.0
 	github.com/multiformats/go-multihash v0.2.3
 	github.com/pelletier/go-toml v1.9.5
+	github.com/pkg/errors v0.9.1
 	github.com/sourcenetwork/acp_core v0.0.0-20240607160510-47a5306b2ad2
 	github.com/sourcenetwork/badger/v4 v4.2.1-0.20231113215945-a63444ca5276
 	github.com/sourcenetwork/corelog v0.0.8
@@ -304,7 +305,6 @@ require (
 	github.com/pion/turn/v2 v2.1.6 // indirect
 	github.com/pion/webrtc/v3 v3.2.50 // indirect
 	github.com/piprate/json-gold v0.5.0 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/polydawn/refmt v0.89.0 // indirect
 	github.com/pquerna/cachecontrol v0.1.0 // indirect

--- a/internal/encoding/encoding.go
+++ b/internal/encoding/encoding.go
@@ -27,6 +27,7 @@ const (
 	floatNaNDesc
 	bytesMarker
 	bytesDescMarker
+	timeMarker
 
 	// These constants define a range of values and are used to determine how many bytes are
 	// needed to represent the given uint64 value. The constants IntMin and IntMax define the

--- a/internal/encoding/time.go
+++ b/internal/encoding/time.go
@@ -1,0 +1,78 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+
+package encoding
+
+import (
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// EncodeTimeAscending encodes a time value, appends it to the supplied buffer,
+// and returns the final buffer. The encoding is guaranteed to be ordered
+// Such that if t1.Before(t2) then after EncodeTime(b1, t1), and
+// EncodeTime(b2, t2), Compare(b1, b2) < 0. The time zone offset not
+// included in the encoding.
+func EncodeTimeAscending(b []byte, t time.Time) []byte {
+	return encodeTime(b, t.Unix(), int64(t.Nanosecond()))
+}
+
+// EncodeTimeDescending is the descending version of EncodeTimeAscending.
+func EncodeTimeDescending(b []byte, t time.Time) []byte {
+	return encodeTime(b, ^t.Unix(), ^int64(t.Nanosecond()))
+}
+
+func encodeTime(b []byte, unix, nanos int64) []byte {
+	// Read the unix absolute time. This is the absolute time and is
+	// not time zone offset dependent.
+	b = append(b, timeMarker)
+	b = EncodeVarintAscending(b, unix)
+	b = EncodeVarintAscending(b, nanos)
+	return b
+}
+
+// DecodeTimeAscending decodes a time.Time value which was encoded using
+// EncodeTime. The remainder of the input buffer and the decoded
+// time.Time are returned.
+func DecodeTimeAscending(b []byte) ([]byte, time.Time, error) {
+	b, sec, nsec, err := decodeTime(b)
+	if err != nil {
+		return b, time.Time{}, err
+	}
+	return b, time.Unix(sec, nsec).UTC(), nil
+}
+
+// DecodeTimeDescending is the descending version of DecodeTimeAscending.
+func DecodeTimeDescending(b []byte) ([]byte, time.Time, error) {
+	b, sec, nsec, err := decodeTime(b)
+	if err != nil {
+		return b, time.Time{}, err
+	}
+	return b, time.Unix(^sec, ^nsec).UTC(), nil
+}
+
+func decodeTime(b []byte) (r []byte, sec int64, nsec int64, err error) {
+	if PeekType(b) != Time {
+		return nil, 0, 0, errors.Errorf("did not find marker")
+	}
+	b = b[1:]
+	b, sec, err = DecodeVarintAscending(b)
+	if err != nil {
+		return b, 0, 0, err
+	}
+	b, nsec, err = DecodeVarintAscending(b)
+	if err != nil {
+		return b, 0, 0, err
+	}
+	return b, sec, nsec, nil
+}

--- a/internal/encoding/type.go
+++ b/internal/encoding/type.go
@@ -23,6 +23,7 @@ const (
 	Float     Type = 4
 	Bytes     Type = 6
 	BytesDesc Type = 7
+	Time      Type = 8
 )
 
 // PeekType peeks at the type of the value encoded at the start of b.
@@ -40,6 +41,8 @@ func PeekType(b []byte) Type {
 			return Int
 		case m >= floatNaN && m <= floatNaNDesc:
 			return Float
+		case m == timeMarker:
+			return Time
 		}
 	}
 	return Unknown

--- a/tests/integration/index/create_unique_test.go
+++ b/tests/integration/index/create_unique_test.go
@@ -315,3 +315,35 @@ func TestUniqueIndexCreate_UponAddingDocWithExistingNilValue_ShouldSucceed(t *te
 
 	testUtils.ExecuteTestCase(t, test)
 }
+
+func TestUniqueQueryWithIndex_UponAddingDocWithSameDateTime_Error(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type User {
+						name: String 
+						birthday: DateTime @index(unique: true)
+					}`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
+						"name":	"Fred",
+						"birthday": "2000-07-23T03:00:00-00:00"
+					}`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
+						"name":	"Andy",
+						"birthday": "2000-07-23T03:00:00-00:00"
+					}`,
+				ExpectedError: db.NewErrCanNotIndexNonUniqueFields(
+					"bae-2000529a-8b27-539b-91e9-c35f431fb78e",
+					errors.NewKV("birthday", testUtils.MustParseTime("2000-07-23T03:00:00-00:00")),
+				).Error(),
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/index/query_with_index_on_datetime.go
+++ b/tests/integration/index/query_with_index_on_datetime.go
@@ -1,0 +1,276 @@
+// Copyright 2024 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package index
+
+import (
+	"testing"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+func TestQueryWithIndex_WithEqFilterOnDateTimeField_ShouldIndex(t *testing.T) {
+	req := `query {
+		User(filter: {birthday: {_eq: "2000-07-23T03:00:00-00:00"}}) {
+			name
+		}
+	}`
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type User {
+						name: String 
+						birthday: DateTime @index
+					}`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
+						"name":	"Fred",
+						"birthday": "2000-07-23T03:00:00-00:00"
+					}`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
+						"name":	"Andy",
+						"birthday": "2001-08-23T03:00:00-00:00"
+					}`,
+			},
+			testUtils.Request{
+				Request: req,
+				Results: map[string]any{
+					"User": []map[string]any{
+						{"name": "Fred"},
+					},
+				},
+			},
+			testUtils.Request{
+				Request:  makeExplainQuery(req),
+				Asserter: testUtils.NewExplainAsserter().WithFieldFetches(1).WithIndexFetches(1),
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestQueryWithIndex_WithGtFilterOnDateTimeField_ShouldIndex(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type User {
+						name: String 
+						birthday: DateTime @index
+					}`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
+						"name":	"Fred",
+						"birthday": "2000-07-23T03:00:00-00:00"
+					}`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
+						"name":	"Andy",
+						"birthday": "2001-08-23T03:00:00-00:00"
+					}`,
+			},
+			testUtils.Request{
+				Request: `query {
+					User(filter: {birthday: {_gt: "2001-01-01T00:00:00-00:00"}}) {
+						name
+					}
+				}`,
+				Results: map[string]any{
+					"User": []map[string]any{
+						{"name": "Andy"},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestQueryWithIndex_WithGeFilterOnDateTimeField_ShouldIndex(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type User {
+						name: String 
+						birthday: DateTime @index
+					}`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
+						"name":	"Fred",
+						"birthday": "2000-07-23T03:00:00-00:00"
+					}`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
+						"name":	"Andy",
+						"birthday": "2001-08-23T03:00:00-00:00"
+					}`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
+						"name":	"Keenan",
+						"birthday": "2001-01-01T00:00:00-00:00"
+					}`,
+			},
+			testUtils.Request{
+				Request: `query {
+					User(filter: {birthday: {_ge: "2001-01-01T00:00:00-00:00"}}) {
+						name
+					}
+				}`,
+				Results: map[string]any{
+					"User": []map[string]any{
+						{"name": "Keenan"},
+						{"name": "Andy"},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestQueryWithIndex_WithLtFilterOnDateTimeField_ShouldIndex(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type User {
+						name: String 
+						birthday: DateTime @index
+					}`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
+						"name":	"Fred",
+						"birthday": "2000-07-23T03:00:00-00:00"
+					}`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
+						"name":	"Andy",
+						"birthday": "2001-08-23T03:00:00-00:00"
+					}`,
+			},
+			testUtils.Request{
+				Request: `query {
+					User(filter: {birthday: {_lt: "2001-01-01T00:00:00-00:00"}}) {
+						name
+					}
+				}`,
+				Results: map[string]any{
+					"User": []map[string]any{
+						{"name": "Fred"},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestQueryWithIndex_WithLeFilterOnDateTimeField_ShouldIndex(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type User {
+						name: String 
+						birthday: DateTime @index
+					}`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
+						"name":	"Fred",
+						"birthday": "2000-07-23T03:00:00-00:00"
+					}`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
+						"name":	"Andy",
+						"birthday": "2001-08-23T03:00:00-00:00"
+					}`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
+						"name":	"Keenan",
+						"birthday": "2001-01-01T00:00:00-00:00"
+					}`,
+			},
+			testUtils.Request{
+				Request: `query {
+					User(filter: {birthday: {_le: "2001-01-01T00:00:00-00:00"}}) {
+						name
+					}
+				}`,
+				Results: map[string]any{
+					"User": []map[string]any{
+						{"name": "Fred"},
+						{"name": "Keenan"},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestQueryWithIndex_WithNeFilterOnDateTimeField_ShouldIndex(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type User {
+						name: String 
+						birthday: DateTime @index
+					}`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
+						"name":	"Fred",
+						"birthday": "2000-07-23T03:00:00-00:00"
+					}`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
+						"name":	"Andy",
+						"birthday": "2001-08-23T03:00:00-00:00"
+					}`,
+			},
+			testUtils.Request{
+				Request: `query {
+					User(filter: {birthday: {_ne: "2000-07-23T03:00:00-00:00"}}) {
+						name
+					}
+				}`,
+				Results: map[string]any{
+					"User": []map[string]any{
+						{"name": "Andy"},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #2914

## Description

Make indexes handle time.Time type as well.
For this encoding/decoding of time type is added to encoding package.