### PR TITLE
fix: Handle index queries where child found without parent

### DIFF
--- a/internal/planner/type_join.go
+++ b/internal/planner/type_join.go
@@ -687,6 +687,13 @@ func (join *invertibleTypeJoin) Next() (bool, error) {
 		} else {
 			join.docsToYield = append(join.docsToYield, secondaryDoc)
 		}
+
+		// If we reach this line and there are no docs to yield, it likely means that a child
+		// document was found but not a parent - this can happen when inverting the join, for
+		// example when working with a secondary index.
+		if len(join.docsToYield) == 0 {
+			return false, nil
+		}
 	}
 
 	return true, nil

--- a/tests/integration/index/query_with_relation_filter_test.go
+++ b/tests/integration/index/query_with_relation_filter_test.go
@@ -1017,3 +1017,41 @@ func TestQueryWithIndexOnManyToOne_MultipleViaOneToMany(t *testing.T) {
 
 	testUtils.ExecuteTestCase(t, test)
 }
+
+func TestQueryWithIndex_UniqueIndexOnChildWithEmptyParentCollection(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Action {
+						key: String @index(unique: true)
+						playerActions: [PlayerAction]
+					}
+
+					type PlayerAction {
+						deleted: Boolean
+						action: Action
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				DocMap: map[string]any{
+					"key": "ACTION_KEY",
+				},
+			},
+			testUtils.Request{
+				Request: `query {
+					PlayerAction(filter: {action: {key: {_eq: "ACTION_KEY"}}}) {
+						deleted
+					}
+				}`,
+				Results: map[string]any{
+					"PlayerAction": []map[string]any{},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #2925

## Description

Handles secondary index queries where child found without parent.

Previously the new test would panic further up the callstack (to the prod change), as the parent doc would be nil minus the joined property.
