### PR TITLE
fix: Filter with date and document with nil date value

### DIFF
--- a/internal/connor/ge.go
+++ b/internal/connor/ge.go
@@ -26,6 +26,8 @@ func ge(condition, data any) (bool, error) {
 				return false, err
 			}
 			return dt.After(c) || dt.Equal(c), nil
+		case nil:
+			return false, nil
 		default:
 			return false, client.NewErrUnhandledType("data", d)
 		}

--- a/internal/connor/gt.go
+++ b/internal/connor/gt.go
@@ -25,6 +25,8 @@ func gt(condition, data any) (bool, error) {
 				return false, err
 			}
 			return dt.After(c), nil
+		case nil:
+			return false, nil
 		default:
 			return false, client.NewErrUnhandledType("data", d)
 		}

--- a/internal/connor/le.go
+++ b/internal/connor/le.go
@@ -26,6 +26,8 @@ func le(condition, data any) (bool, error) {
 				return false, err
 			}
 			return dt.Before(c) || dt.Equal(c), nil
+		case nil:
+			return false, nil
 		default:
 			return false, client.NewErrUnhandledType("data", d)
 		}

--- a/internal/connor/lt.go
+++ b/internal/connor/lt.go
@@ -26,6 +26,8 @@ func lt(condition, data any) (bool, error) {
 				return false, err
 			}
 			return dt.Before(c), nil
+		case nil:
+			return false, nil
 		default:
 			return false, client.NewErrUnhandledType("data", d)
 		}

--- a/tests/integration/query/simple/with_filter/with_eq_datetime_test.go
+++ b/tests/integration/query/simple/with_filter/with_eq_datetime_test.go
@@ -60,7 +60,7 @@ func TestQuerySimpleWithDateTimeEqualsFilterBlock(t *testing.T) {
 
 func TestQuerySimpleWithDateTimeEqualsNilFilterBlock(t *testing.T) {
 	test := testUtils.TestCase{
-		Description: "Simple query with basic filter(age)",
+		Description: "Simple query with basic filter(CreatedAt)",
 		Actions: []any{
 			testUtils.CreateDoc{
 				Doc: `{
@@ -96,6 +96,54 @@ func TestQuerySimpleWithDateTimeEqualsNilFilterBlock(t *testing.T) {
 							"Name":      "Fred",
 							"Age":       int64(44),
 							"CreatedAt": nil,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	executeTestCase(t, test)
+}
+
+func TestQuerySimple_WithNilDateTimeEqualsAndNonNilFilterBlock_ShouldSucceed(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "Simple query with basic filter with nil value and non-nil filter",
+		Actions: []any{
+			testUtils.CreateDoc{
+				DocMap: map[string]any{
+					"Name":      "John",
+					"Age":       int64(21),
+					"CreatedAt": "2017-07-23T03:46:56-05:00",
+				},
+			},
+			testUtils.CreateDoc{
+				DocMap: map[string]any{
+					"Name":      "Bob",
+					"Age":       int64(32),
+					"CreatedAt": "2016-07-23T03:46:56-05:00",
+				},
+			},
+			testUtils.CreateDoc{
+				DocMap: map[string]any{
+					"Name": "Fred",
+					"Age":  44,
+				},
+			},
+			testUtils.Request{
+				Request: `query {
+					Users(filter: {CreatedAt: {_eq: "2016-07-23T03:46:56-05:00"}}) {
+						Name
+						Age
+						CreatedAt
+					}
+				}`,
+				Results: map[string]any{
+					"Users": []map[string]any{
+						{
+							"Name":      "Bob",
+							"Age":       int64(32),
+							"CreatedAt": testUtils.MustParseTime("2016-07-23T03:46:56-05:00"),
 						},
 					},
 				},

--- a/tests/integration/query/simple/with_filter/with_ge_datetime_test.go
+++ b/tests/integration/query/simple/with_filter/with_ge_datetime_test.go
@@ -163,3 +163,56 @@ func TestQuerySimpleWithDateTimeGEFilterBlockWithNilValue(t *testing.T) {
 
 	executeTestCase(t, test)
 }
+
+func TestQuerySimple_WithNilDateTimeGEAndNonNilFilterBlock_ShouldSucceed(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "Simple query with basic filter with nil value and non-nil filter",
+		Actions: []any{
+			testUtils.CreateDoc{
+				DocMap: map[string]any{
+					"Name":      "John",
+					"Age":       int64(21),
+					"CreatedAt": "2017-07-23T03:46:56-05:00",
+				},
+			},
+			testUtils.CreateDoc{
+				DocMap: map[string]any{
+					"Name":      "Bob",
+					"Age":       int64(32),
+					"CreatedAt": "2016-07-23T03:46:56-05:00",
+				},
+			},
+			testUtils.CreateDoc{
+				DocMap: map[string]any{
+					"Name": "Fred",
+					"Age":  44,
+				},
+			},
+			testUtils.Request{
+				Request: `query {
+					Users(filter: {CreatedAt: {_ge: "2016-07-23T03:46:56-05:00"}}) {
+						Name
+						Age
+						CreatedAt
+					}
+				}`,
+				Results: map[string]any{
+					"Users": []map[string]any{
+						{
+							"Name":      "Bob",
+							"Age":       int64(32),
+							"CreatedAt": testUtils.MustParseTime("2016-07-23T03:46:56-05:00"),
+						},
+						{
+							"Name":      "John",
+							"Age":       int64(21),
+							"CreatedAt": testUtils.MustParseTime("2017-07-23T03:46:56-05:00"),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	executeTestCase(t, test)
+}

--- a/tests/integration/query/simple/with_filter/with_gt_datetime_test.go
+++ b/tests/integration/query/simple/with_filter/with_gt_datetime_test.go
@@ -160,3 +160,51 @@ func TestQuerySimpleWithDateTimeGTFilterBlockWithNilValue(t *testing.T) {
 
 	executeTestCase(t, test)
 }
+
+func TestQuerySimple_WithNilDateTimeGTAndNonNilFilterBlock_ShouldSucceed(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "Simple query with basic filter with nil value and non-nil filter",
+		Actions: []any{
+			testUtils.CreateDoc{
+				DocMap: map[string]any{
+					"Name":      "John",
+					"Age":       int64(21),
+					"CreatedAt": "2017-07-23T03:46:56-05:00",
+				},
+			},
+			testUtils.CreateDoc{
+				DocMap: map[string]any{
+					"Name":      "Bob",
+					"Age":       int64(32),
+					"CreatedAt": "2016-07-23T03:46:56-05:00",
+				},
+			},
+			testUtils.CreateDoc{
+				DocMap: map[string]any{
+					"Name": "Fred",
+					"Age":  44,
+				},
+			},
+			testUtils.Request{
+				Request: `query {
+					Users(filter: {CreatedAt: {_gt: "2016-07-23T03:46:56-05:00"}}) {
+						Name
+						Age
+						CreatedAt
+					}
+				}`,
+				Results: map[string]any{
+					"Users": []map[string]any{
+						{
+							"Name":      "John",
+							"Age":       int64(21),
+							"CreatedAt": testUtils.MustParseTime("2017-07-23T03:46:56-05:00"),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	executeTestCase(t, test)
+}

--- a/tests/integration/query/simple/with_filter/with_le_datetime_test.go
+++ b/tests/integration/query/simple/with_filter/with_le_datetime_test.go
@@ -128,3 +128,56 @@ func TestQuerySimpleWithDateTimeLEFilterBlockWithNullValue(t *testing.T) {
 
 	executeTestCase(t, test)
 }
+
+func TestQuerySimple_WithNilDateTimeLEAndNonNilFilterBlock_ShouldSucceed(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "Simple query with basic filter with nil value and non-nil filter",
+		Actions: []any{
+			testUtils.CreateDoc{
+				DocMap: map[string]any{
+					"Name":      "John",
+					"Age":       int64(21),
+					"CreatedAt": "2017-07-23T03:46:56-05:00",
+				},
+			},
+			testUtils.CreateDoc{
+				DocMap: map[string]any{
+					"Name":      "Bob",
+					"Age":       int64(32),
+					"CreatedAt": "2016-07-23T03:46:56-05:00",
+				},
+			},
+			testUtils.CreateDoc{
+				DocMap: map[string]any{
+					"Name": "Fred",
+					"Age":  44,
+				},
+			},
+			testUtils.Request{
+				Request: `query {
+					Users(filter: {CreatedAt: {_le: "2017-07-23T03:46:56-05:00"}}) {
+						Name
+						Age
+						CreatedAt
+					}
+				}`,
+				Results: map[string]any{
+					"Users": []map[string]any{
+						{
+							"Name":      "Bob",
+							"Age":       int64(32),
+							"CreatedAt": testUtils.MustParseTime("2016-07-23T03:46:56-05:00"),
+						},
+						{
+							"Name":      "John",
+							"Age":       int64(21),
+							"CreatedAt": testUtils.MustParseTime("2017-07-23T03:46:56-05:00"),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	executeTestCase(t, test)
+}

--- a/tests/integration/query/simple/with_filter/with_lt_datetime_test.go
+++ b/tests/integration/query/simple/with_filter/with_lt_datetime_test.go
@@ -86,3 +86,52 @@ func TestQuerySimpleWithDateTimeLTFilterBlockWithNullValue(t *testing.T) {
 
 	executeTestCase(t, test)
 }
+
+func TestQuerySimple_WithNilDateTimeLTAndNonNilFilterBlock_ShouldSucceed(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "Simple query with basic filter with nil value and non-nil filter",
+		Actions: []any{
+			testUtils.CreateDoc{
+				DocMap: map[string]any{
+					"Name":      "John",
+					"Age":       int64(21),
+					"CreatedAt": "2017-07-23T03:46:56-05:00",
+				},
+			},
+			testUtils.CreateDoc{
+				DocMap: map[string]any{
+					"Name":      "Bob",
+					"Age":       int64(32),
+					"CreatedAt": "2016-07-23T03:46:56-05:00",
+				},
+			},
+			testUtils.CreateDoc{
+				DocMap: map[string]any{
+					"Name": "Fred",
+					"Age":  44,
+				},
+			},
+			testUtils.Request{
+				Request: `query {
+					Users(filter: {CreatedAt: {_lt: "2017-07-23T03:46:56-05:00"}}) {
+						Name
+						Age
+						CreatedAt
+					}
+				}`,
+				Results: map[string]any{
+					"Users": []map[string]any{
+
+						{
+							"Name":      "Bob",
+							"Age":       int64(32),
+							"CreatedAt": testUtils.MustParseTime("2016-07-23T03:46:56-05:00"),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	executeTestCase(t, test)
+}

--- a/tests/integration/query/simple/with_filter/with_ne_datetime_test.go
+++ b/tests/integration/query/simple/with_filter/with_ne_datetime_test.go
@@ -100,3 +100,56 @@ func TestQuerySimpleWithDateTimeNotEqualsNilFilterBlock(t *testing.T) {
 
 	executeTestCase(t, test)
 }
+
+func TestQuerySimple_WithNilDateTimeNotEqualAndNonNilFilterBlock_ShouldSucceed(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "Simple query with basic filter with nil value and non-nil filter",
+		Actions: []any{
+			testUtils.CreateDoc{
+				DocMap: map[string]any{
+					"Name":      "John",
+					"Age":       int64(21),
+					"CreatedAt": "2017-07-23T03:46:56-05:00",
+				},
+			},
+			testUtils.CreateDoc{
+				DocMap: map[string]any{
+					"Name":      "Bob",
+					"Age":       int64(32),
+					"CreatedAt": "2016-07-23T03:46:56-05:00",
+				},
+			},
+			testUtils.CreateDoc{
+				DocMap: map[string]any{
+					"Name": "Fred",
+					"Age":  44,
+				},
+			},
+			testUtils.Request{
+				Request: `query {
+					Users(filter: {CreatedAt: {_ne: "2016-07-23T03:46:56-05:00"}}) {
+						Name
+						Age
+						CreatedAt
+					}
+				}`,
+				Results: map[string]any{
+					"Users": []map[string]any{
+						{
+							"Name":      "John",
+							"Age":       int64(21),
+							"CreatedAt": testUtils.MustParseTime("2017-07-23T03:46:56-05:00"),
+						},
+						{
+							"Name":      "Fred",
+							"Age":       int64(44),
+							"CreatedAt": nil,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	executeTestCase(t, test)
+}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #2945 

## Description

This PR ensure that no error occurs when filtering for a date while having documents with `nil` date value.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

added filter integration tests for date

Specify the platform(s) on which this was tested:
- MacOS
