### PR TITLE
fix: Panic with different composite-indexed child objects

### DIFF
--- a/internal/db/fetcher/indexer_iterators.go
+++ b/internal/db/fetcher/indexer_iterators.go
@@ -81,6 +81,11 @@ var _ indexIterator = (*indexPrefixIterator)(nil)
 func (iter *indexPrefixIterator) Init(ctx context.Context, store datastore.DSReaderWriter) error {
 	iter.ctx = ctx
 	iter.store = store
+	if iter.resultIter != nil {
+		if err := iter.resultIter.Close(); err != nil {
+			return err
+		}
+	}
 	iter.resultIter = nil
 	return nil
 }

--- a/internal/planner/multi.go
+++ b/internal/planner/multi.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Democratized Data Foundation
+// Copyright 2024 Democratized Data Foundation
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt.
@@ -214,22 +214,22 @@ func (s *selectNode) addSubPlan(fieldIndex int, newPlan planNode) error {
 		if err := s.planner.walkAndReplacePlan(s.source, origScan, multiscan); err != nil {
 			return err
 		}
-		// create multinode
-		multinode := &parallelNode{
+		// create parallelNode
+		parallelNode := &parallelNode{
 			p:         s.planner,
 			multiscan: multiscan,
 			docMapper: docMapper{s.source.DocumentMap()},
 		}
-		multinode.addChild(-1, s.source)
+		parallelNode.addChild(-1, s.source)
 		multiscan.addReader()
 		// replace our new node internal scanNode with our new multiscanner
 		if err := s.planner.walkAndReplacePlan(newPlan, origScan, multiscan); err != nil {
 			return err
 		}
 		// add our newly updated plan to the multinode
-		multinode.addChild(fieldIndex, newPlan)
+		parallelNode.addChild(fieldIndex, newPlan)
 		multiscan.addReader()
-		s.source = multinode
+		s.source = parallelNode
 
 	// we already have an existing parallelNode as our source
 	case *parallelNode:

--- a/internal/planner/scan.go
+++ b/internal/planner/scan.go
@@ -322,6 +322,10 @@ func (p *Planner) Scan(
 // If we have two readers on our multiScanNode, then
 // we call Next() on the underlying scanNode only
 // once every 2 Next() calls on the multiScan
+//
+// NOTE: calling Init() on multiScanNode is subject to counting as well and as such
+// doesn't not provide idempotency guarantees. Counting is purely for performance
+// reasons and removing it should be safe.
 type multiScanNode struct {
 	scanNode   *scanNode
 	numReaders int
@@ -334,6 +338,10 @@ type multiScanNode struct {
 	err        error
 }
 
+// Init initializes the multiScanNode.
+// NOTE: this function is subject to counting based on the number of readers and as such
+// doesn't not provide idempotency guarantees. Counting is purely for performance
+// reasons and removing it should be safe.
 func (n *multiScanNode) Init() error {
 	n.countAndCall(&n.initCount, func() error {
 		return n.scanNode.Init()

--- a/tests/integration/index/query_with_composite_inxed_on_relation_test.go
+++ b/tests/integration/index/query_with_composite_inxed_on_relation_test.go
@@ -19,7 +19,7 @@ import (
 // This test was added during https://github.com/sourcenetwork/defradb/issues/2924
 // The issue was that [multiScanNode] that keeps track of how many calls to [Next()] should
 // be made, would call [Init()] and [Start()] every time without tracking, which would result
-// child nodes being initialized and started multiple times, which in turn created
+// in child nodes being initialized and started multiple times, which in turn created
 // index iterators without closing them.
 func TestQueryWithCompositeIndexOnManyToOne_WithMultipleIndexedChildNodes_ShouldSucceed(t *testing.T) {
 	test := testUtils.TestCase{

--- a/tests/integration/index/query_with_composite_inxed_on_relation_test.go
+++ b/tests/integration/index/query_with_composite_inxed_on_relation_test.go
@@ -1,0 +1,116 @@
+// Copyright 2024 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package index
+
+import (
+	"testing"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+// This test was added during https://github.com/sourcenetwork/defradb/issues/2924
+// The issue was that [multiScanNode] that keeps track of how many calls to [Next()] should
+// be made, would call [Init()] and [Start()] every time without tracking, which would result
+// child nodes being initialized and started multiple times, which in turn created
+// index iterators without closing them.
+func TestQueryWithCompositeIndexOnManyToOne_WithMultipleIndexedChildNodes_ShouldSucceed(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type User {
+						name: String 
+						devices: [Device]
+					}
+
+					type Device @index(fields: ["owner_id", "manufacturer_id"]) {
+						model: String
+						owner: User 
+						manufacturer: Manufacturer 
+					}
+
+					type Manufacturer {
+						name: String
+						devices: [Device]
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				DocMap: map[string]any{
+					"name": "John",
+				},
+			},
+			testUtils.CreateDoc{
+				CollectionID: 2,
+				DocMap: map[string]any{
+					"name": "Apple",
+				},
+			},
+			testUtils.CreateDoc{
+				CollectionID: 2,
+				DocMap: map[string]any{
+					"name": "Sony",
+				},
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"model":        "MacBook Pro",
+					"owner":        testUtils.NewDocIndex(0, 0),
+					"manufacturer": testUtils.NewDocIndex(2, 0),
+				},
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"model":        "PlayStation 5",
+					"owner":        testUtils.NewDocIndex(0, 0),
+					"manufacturer": testUtils.NewDocIndex(2, 1),
+				},
+			},
+			testUtils.Request{
+				Request: `query {
+					User {
+						devices {
+							model
+							owner {
+								name
+							}
+							manufacturer {
+								name
+							}
+						}
+					}
+				}`,
+				Results: map[string]any{
+					"User": []map[string]any{
+						{
+							"devices": []map[string]any{
+								{
+									"model":        "MacBook Pro",
+									"owner":        map[string]any{"name": "John"},
+									"manufacturer": map[string]any{"name": "Apple"},
+								},
+								{
+									"model":        "PlayStation 5",
+									"owner":        map[string]any{"name": "John"},
+									"manufacturer": map[string]any{"name": "Sony"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #2924

## Description

Make multiScanNode keep track of all calls.

The issue was that multiScanNode that keeps track of how many calls to Next() should be made, would call Init() and Start() every time without tracking, which would result in child nodes being initialized and started multiple times, which in turn created index iterators without closing them.