### PR TITLE
refactor: Make SourceHub dep internal-only

### DIFF
--- a/cli/start.go
+++ b/cli/start.go
@@ -16,7 +16,6 @@ import (
 	"syscall"
 
 	"github.com/sourcenetwork/immutable"
-	"github.com/sourcenetwork/sourcehub/sdk"
 	"github.com/spf13/cobra"
 
 	"github.com/sourcenetwork/defradb/errors"
@@ -101,7 +100,7 @@ func MakeStartCommand() *cobra.Command {
 					if err != nil {
 						return err
 					}
-					opts = append(opts, node.WithTxnSigner(immutable.Some[sdk.TxSigner](signer)))
+					opts = append(opts, node.WithTxnSigner(immutable.Some[node.TxSigner](signer)))
 				}
 			}
 

--- a/keyring/signer.go
+++ b/keyring/signer.go
@@ -14,7 +14,8 @@ import (
 	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	cosmostypes "github.com/cosmos/cosmos-sdk/types"
-	"github.com/sourcenetwork/sourcehub/sdk"
+
+	"github.com/sourcenetwork/defradb/node"
 )
 
 type txnSigner struct {
@@ -25,7 +26,7 @@ type txnSigner struct {
 	accAddress string
 }
 
-var _ sdk.TxSigner = (*txnSigner)(nil)
+var _ node.TxSigner = (*txnSigner)(nil)
 
 // NewTxSignerFromKeyringKey creates a new TxSigner backed by a keyring.
 //

--- a/node/acp.go
+++ b/node/acp.go
@@ -13,8 +13,8 @@ package node
 import (
 	"context"
 
+	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	"github.com/sourcenetwork/immutable"
-	"github.com/sourcenetwork/sourcehub/sdk"
 
 	"github.com/sourcenetwork/defradb/acp"
 )
@@ -36,10 +36,19 @@ type ACPOptions struct {
 	// This is only used for local acp.
 	path string
 
-	signer                   immutable.Option[sdk.TxSigner]
+	signer                   immutable.Option[TxSigner]
 	sourceHubChainID         string
 	sourceHubGRPCAddress     string
 	sourceHubCometRPCAddress string
+}
+
+// TxSigner models an entity capable of providing signatures for a Tx.
+//
+// Effectively, it can be either a secp256k1 cosmos-sdk key or a pointer to a
+// secp256k1 key in a cosmos-sdk like keyring.
+type TxSigner interface {
+	GetAccAddress() string
+	GetPrivateKey() cryptotypes.PrivKey
 }
 
 // DefaultACPOptions returns new options with default values.
@@ -71,7 +80,7 @@ func WithACPPath(path string) ACPOpt {
 // WithKeyring sets the txn signer for Defra to use.
 //
 // It is only required when SourceHub ACP is active.
-func WithTxnSigner(signer immutable.Option[sdk.TxSigner]) ACPOpt {
+func WithTxnSigner(signer immutable.Option[TxSigner]) ACPOpt {
 	return func(o *ACPOptions) {
 		o.signer = signer
 	}

--- a/tests/integration/acp.go
+++ b/tests/integration/acp.go
@@ -27,7 +27,6 @@ import (
 	"github.com/decred/dcrd/dcrec/secp256k1/v4"
 	toml "github.com/pelletier/go-toml"
 	"github.com/sourcenetwork/immutable"
-	"github.com/sourcenetwork/sourcehub/sdk"
 	"github.com/stretchr/testify/require"
 
 	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
@@ -352,7 +351,7 @@ cmdReaderLoop:
 	}
 
 	return []node.ACPOpt{
-		node.WithTxnSigner(immutable.Some[sdk.TxSigner](signer)),
+		node.WithTxnSigner(immutable.Some[node.TxSigner](signer)),
 		node.WithSourceHubChainID(chainID),
 		node.WithSourceHubGRPCAddress(gRpcAddress),
 		node.WithSourceHubCometRPCAddress(rpcAddress),


### PR DESCRIPTION
## Relevant issue(s)

Resolves #2962

## Description

I was mostly curious if this will make the vuln checker go green (it doesn't, it just reports it from our internal acp package now), but it is a good change anyway IMO to avoid embedded Go client users from having to directly import the dependency.