### PR TITLE
fix: Ignore badger path if in-memory

### DIFF
--- a/datastore/badger/v4/datastore.go
+++ b/datastore/badger/v4/datastore.go
@@ -142,8 +142,11 @@ func NewDatastore(path string, options *Options) (*Datastore, error) {
 		gcSleep = gcInterval
 	}
 
-	opt.Dir = path
-	opt.ValueDir = path
+	if !opt.InMemory {
+	    opt.Dir = path
+	    opt.ValueDir = path
+    }
+
 	opt.Logger = &compatLogger{
 		SugaredLogger: *log.Desugar().WithOptions(zap.AddCallerSkip(1)).Sugar(),
 		skipLogger:    *log.Desugar().WithOptions(zap.AddCallerSkip(2)).Sugar(),

--- a/datastore/badger/v4/datastore.go
+++ b/datastore/badger/v4/datastore.go
@@ -143,9 +143,9 @@ func NewDatastore(path string, options *Options) (*Datastore, error) {
 	}
 
 	if !opt.InMemory {
-	    opt.Dir = path
-	    opt.ValueDir = path
-    }
+		opt.Dir = path
+		opt.ValueDir = path
+	}
 
 	opt.Logger = &compatLogger{
 		SugaredLogger: *log.Desugar().WithOptions(zap.AddCallerSkip(1)).Sugar(),


### PR DESCRIPTION
## Relevant issue(s)

Resolves #2964 

## Description

Small change that now only sets the badger options `Dir` and `ValueDir` to the  `path`  parameter if the badger option `InMemory` is not `true`.

The crash was happening because badger expects the two Dir values to be nil if InMemory is true.

I chose this fix because it's very simple and requires the least changes. The bulk of the problem is that the `datastore.badger.path` config value gets set to `data` by default regardless of whether  `datastore.store` is set to `memory` and this value gets passed as the `path`  parameter. I didn't think it would be nice to change any of the upstream logic or the signature of the NewDatastore function.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Running standard test suite and using both commands provided in #2964 .

Specify the platform(s) on which this was tested:
- Debian Linux
