### PR TITLE
docs: Rename _key to _docID in docs

### DIFF
--- a/docs/website/getting-started.md
+++ b/docs/website/getting-started.md
@@ -71,7 +71,7 @@ Submit a `mutation` request to create a document of the `User` type:
 defradb client query '
   mutation {
       create_User(input: {age: 31, verified: true, points: 90, name: "Bob"}) {
-          _key
+          _docID
       }
   }
 '
@@ -83,13 +83,13 @@ Expected response:
 {
   "data": [
     {
-      "_key": "bae-91171025-ed21-50e3-b0dc-e31bccdfa1ab",
+      "_docID": "bae-91171025-ed21-50e3-b0dc-e31bccdfa1ab",
     }
   ]
 }
 ```
 
-`_key` is the document's key, a unique identifier of the document, determined by its schema and initial data.
+`_docID` is the document's key, a unique identifier of the document, determined by its schema and initial data.
 
 ## Query documents
 
@@ -99,7 +99,7 @@ Once you have populated your node with data, you can query it:
 defradb client query '
   query {
     User {
-      _key
+      _docID
       age
       name
       points
@@ -108,7 +108,7 @@ defradb client query '
 '
 ```
 
-This query obtains *all* users and returns their fields `_key, age, name, points`. GraphQL queries only return the exact fields requested.
+This query obtains *all* users and returns their fields `_docID, age, name, points`. GraphQL queries only return the exact fields requested.
 
 You can further filter results with the `filter` argument.
 
@@ -116,7 +116,7 @@ You can further filter results with the `filter` argument.
 defradb client query '
   query {
     User(filter: {points: {_ge: 50}}) {
-      _key
+      _docID
       age
       name
       points

--- a/docs/website/guides/explain-systems.md
+++ b/docs/website/guides/explain-systems.md
@@ -13,7 +13,7 @@ The DefraDB Explain System is a powerful tool designed to introspect requests, e
 ```graphql
 query {
     Author {
-      _key
+      _docID
       name
       age
     }
@@ -25,7 +25,7 @@ query {
 ```graphql
 query @explain {
     Author {
-      _key
+      _docID
       name
       age
     }

--- a/docs/website/guides/schema-relationship.md
+++ b/docs/website/guides/schema-relationship.md
@@ -74,7 +74,7 @@ type Address {
 ```graphql
 mutation {
   create_Address(input: {streetNumber: "123", streetName: "Test road", country: "Canada"}) {
-  	_key
+  	_docID
   }
 }
 ```
@@ -82,7 +82,7 @@ mutation {
 ```graphql
 mutation {
   create_User(input: {name: "Alice", username: "awesomealice", age: 35, address_id: "bae-be6d8024-4953-5a92-84b4-f042d25230c6"}) {
-  	_key
+  	_docID
   }
 }
 ```
@@ -178,7 +178,7 @@ defradb client schema add -f schema.graphql
 ```graphql
 mutation {
     create_Author(input: {name: "Saadi", dateOfBirth: "1210-07-23T03:46:56.647Z"}) {
-    	_key
+    	_docID
     }
 }
 ```
@@ -187,7 +187,7 @@ mutation {
 ```graphql
 mutation {
   	create_Book(input: {name: "Gulistan", genre: "Poetry", author_id: "bae-0e7c3bb5-4917-5d98-9fcf-b9db369ea6e4"}) {
-      	_key
+      	_docID
     }
 }
 ```
@@ -196,7 +196,7 @@ mutation {
 ```graphql
 mutation {
   	update_Author(id: "bae-0e7c3bb5-4917-5d98-9fcf-b9db369ea6e4", input: {name: "Saadi Shirazi"}) {
-      	_key
+      	_docID
     }
 }
 ```
@@ -205,7 +205,7 @@ mutation {
 ```graphql
 mutation {
   	update_Book(filter: {name: {_eq: "Gulistan"}}, input: {description: "Persian poetry of ideas"}) {
-      	_key
+      	_docID
     }
 }
 ```

--- a/docs/website/references/query-specification/database-api.md
+++ b/docs/website/references/query-specification/database-api.md
@@ -86,7 +86,7 @@ In addition to using `Commits` specific queries, include commit version sub-fiel
 ```graphql 
 query {
     User {
-        _key
+        _docID
         name
         age
         

--- a/docs/website/references/query-specification/mutation-block.md
+++ b/docs/website/references/query-specification/mutation-block.md
@@ -89,28 +89,28 @@ A basic example is provided below:
 ```graphql
 mutation {
     update_Book(dockey: '123', input: {name: "John"}) {
-        _key
+        _docID
         name
     }
 }
 
 ```
 
-Here, we can see that after applying the mutation, we return the `_key` and `name` fields. We can return any field from the document (not just the updated ones). We can even return and filter on related types.
+Here, we can see that after applying the mutation, we return the `_docID` and `name` fields. We can return any field from the document (not just the updated ones). We can even return and filter on related types.
 
 Beyond updating by an ID or IDs, we can use a query filter to select which fields to apply our update to. This filter works the same as the queries.
 
 ```graphql
 mutation {
     update_Book(filter: {rating: {_le: 1.0}}, input: {rating: 1.5}) {
-        _key
+        _docID
         rating
         name
     }
 }
 ```
 
-Here, we select all documents with a rating less than or equal to 1.0, update the rating value to 1.5, and return all the affected documents `_key`, `rating`, and `name` fields.
+Here, we select all documents with a rating less than or equal to 1.0, update the rating value to 1.5, and return all the affected documents `_docID`, `rating`, and `name` fields.
 
 For additional filter details, see the above `Query Block` section.
 
@@ -132,13 +132,13 @@ Here, we can delete a document with ID '123':
 ```graphql
 mutation {
     delete_User(dockey: '123') {
-        _key
+        _docID
         name
     }
 }
 ```
 
-This will delete the specific document, and return the `_key` and `name` for the deleted document.
+This will delete the specific document, and return the `_docID` and `name` for the deleted document.
 
 DefraDB currently uses a Hard Delete system, which means that when a document is deleted, it is completely removed from the database.
 
@@ -147,7 +147,7 @@ Similar to the Update system, you can use a filter to select which documents to 
 ```graphql
 mutation {
     delete_User(filter: {rating: {_gt: 3}}) {
-        _key
+        _docID
         name
     }
 }


### PR DESCRIPTION
## Relevant issue(s)

Resolves #2977 

## Description

This PR renames occurrences of _key to _docID when using schemas in the project's markdown documentation.

## Tasks

- [ ] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [ ] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Github markdown preview

Specify the platform(s) on which this was tested:
- Debian Linux
