### PR TITLE
fix(i): Log graphql server address

### DIFF
--- a/http/handler_playground.go
+++ b/http/handler_playground.go
@@ -25,4 +25,5 @@ func init() {
 		panic(err)
 	}
 	playgroundHandler = http.FileServer(http.FS(sub))
+	PlaygroundEnabled = true
 }

--- a/http/server.go
+++ b/http/server.go
@@ -21,6 +21,10 @@ import (
 	"github.com/go-chi/chi/v5/middleware"
 )
 
+// PlaygroundEnabled is used to detect if the playground is enabled
+// on the current http server instance.
+var PlaygroundEnabled = false
+
 // We only allow cipher suites that are marked secure
 // by ssllabs
 var tlsCipherSuites = []uint16{

--- a/node/node.go
+++ b/node/node.go
@@ -165,7 +165,9 @@ func (n *Node) Start(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		log.InfoContext(ctx, fmt.Sprintf("Providing HTTP API at %s.", n.Server.Address()))
+		log.InfoContext(ctx,
+			fmt.Sprintf("Providing HTTP API at %s PlaygroundEnabled=%t", n.Server.Address(), http.PlaygroundEnabled))
+		log.InfoContext(ctx, fmt.Sprintf("Providing GraphQL endpoint at %s/v0/graphql", n.Server.Address()))
 		go func() {
 			if err := n.Server.Serve(); err != nil && !errors.Is(err, gohttp.ErrServerClosed) {
 				log.ErrorContextE(ctx, "HTTP server stopped", err)


### PR DESCRIPTION
## Relevant issue(s)

Resolves #2795

## Description

This PR adds a log showing the graphql server address. It also updates the API log to show if the playground is enabled.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Manually tested by running `defradb start`

Specify the platform(s) on which this was tested:
- MacOS

