### PR TITLE
feat: Add materialized views

### DIFF
--- a/.github/workflows/test-and-upload-coverage.yml
+++ b/.github/workflows/test-and-upload-coverage.yml
@@ -37,6 +37,7 @@ jobs:
         lens-type: [wasm-time]
         acp-type: [local]
         database-encryption: [false]
+        view-type: [cacheless]
         include:
           - os: ubuntu-latest
             client-type: go
@@ -45,6 +46,7 @@ jobs:
             lens-type: wasm-time
             acp-type: local
             database-encryption: true
+            view-type: cacheless
           - os: ubuntu-latest
             client-type: go
             database-type: badger-memory
@@ -52,6 +54,7 @@ jobs:
             lens-type: wazero
             acp-type: local
             database-encryption: false
+            view-type: cacheless
           - os: ubuntu-latest
             client-type: go
             database-type: badger-memory
@@ -59,6 +62,7 @@ jobs:
             lens-type: wasmer
             acp-type: local
             database-encryption: false
+            view-type: cacheless
           - os: ubuntu-latest
             client-type: go
             database-type: badger-memory
@@ -66,6 +70,7 @@ jobs:
             lens-type: wasm-time
             acp-type: source-hub
             database-encryption: false
+            view-type: cacheless
           - os: ubuntu-latest
             client-type: http
             database-type: badger-memory
@@ -73,6 +78,7 @@ jobs:
             lens-type: wasm-time
             acp-type: source-hub
             database-encryption: false
+            view-type: cacheless
           - os: ubuntu-latest
             client-type: cli
             database-type: badger-memory
@@ -80,6 +86,15 @@ jobs:
             lens-type: wasm-time
             acp-type: source-hub
             database-encryption: false
+            view-type: cacheless
+          - os: ubuntu-latest
+            client-type: go
+            database-type: badger-memory
+            mutation-type: collection-save
+            lens-type: wasm-time
+            acp-type: local
+            database-encryption: false
+            view-type: materialized
           - os: macos-latest
             client-type: go
             database-type: badger-memory
@@ -87,6 +102,7 @@ jobs:
             lens-type: wasm-time
             acp-type: local
             database-encryption: false
+            view-type: cacheless
 ## TODO: https://github.com/sourcenetwork/defradb/issues/2080
 ## Uncomment the lines below to Re-enable the windows build once this todo is resolved.
 ##        - os: windows-latest
@@ -96,6 +112,7 @@ jobs:
 ##          lens-type: wasm-time
 ##          acp-type: local
 ##          database-encryption: false
+##          view-type: cacheless
 
     runs-on: ${{ matrix.os }}
 
@@ -115,6 +132,7 @@ jobs:
       DEFRA_MUTATION_TYPE: ${{ matrix.mutation-type }}
       DEFRA_LENS_TYPE: ${{ matrix.lens-type }}
       DEFRA_ACP_TYPE: ${{ matrix.acp-type }}
+      DEFRA_VIEW_TYPE: ${{ matrix.view-type }}
 
     steps:
       - name: Checkout code into the directory

--- a/.github/workflows/test-and-upload-coverage.yml
+++ b/.github/workflows/test-and-upload-coverage.yml
@@ -222,6 +222,7 @@ jobs:
             _${{ matrix.mutation-type }}\
             _${{ matrix.lens-type }}\
             _${{ matrix.acp-type }}\
+            _${{ matrix.matrix.view-type }}\
             _${{ matrix.database-encryption }}\
           "
           path: coverage.txt

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -75,6 +75,7 @@ func NewDefraCommand() *cobra.Command {
 	view := MakeViewCommand()
 	view.AddCommand(
 		MakeViewAddCommand(),
+		MakeViewRefreshCommand(),
 	)
 
 	index := MakeIndexCommand()

--- a/cli/view_refresh.go
+++ b/cli/view_refresh.go
@@ -29,7 +29,7 @@ func MakeViewRefreshCommand() *cobra.Command {
 persisting the results.
 
 View is refreshed as the current user, meaning results returned for all subsequent query requests
-to the view will recieve items accessible to the user refreshing the view's permissions.
+to the view will receive items generated using the user refreshing the view's permissions.
 
 Example: refresh all views
   defradb client view refresh

--- a/cli/view_refresh.go
+++ b/cli/view_refresh.go
@@ -1,0 +1,74 @@
+// Copyright 2024 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package cli
+
+import (
+	"github.com/sourcenetwork/immutable"
+	"github.com/spf13/cobra"
+
+	"github.com/sourcenetwork/defradb/client"
+)
+
+func MakeViewRefreshCommand() *cobra.Command {
+	var name string
+	var schemaRoot string
+	var versionID string
+	var getInactive bool
+	var cmd = &cobra.Command{
+		Use:   "refresh",
+		Short: "Refresh views.",
+		Long: `Refresh views, executing the underlying query and LensVm transforms and
+persisting the results.
+
+View is refreshed as the current user, meaning results returned for all subsequent query requests
+to the view will recieve items accessible to the user refreshing the view's permissions.
+
+Example: refresh all views
+  defradb view refresh
+
+Example: refresh views by name
+  defradb view refresh --name UserView
+
+Example: refresh views by schema root id
+  defradb view refresh --schema bae123
+
+Example: refresh views by version id. This will also return inactive views
+  defradb view refresh --version bae123
+		`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			store := mustGetContextStore(cmd)
+
+			options := client.CollectionFetchOptions{}
+			if versionID != "" {
+				options.SchemaVersionID = immutable.Some(versionID)
+			}
+			if schemaRoot != "" {
+				options.SchemaRoot = immutable.Some(schemaRoot)
+			}
+			if name != "" {
+				options.Name = immutable.Some(name)
+			}
+			if getInactive {
+				options.IncludeInactive = immutable.Some(getInactive)
+			}
+
+			return store.RefreshViews(
+				cmd.Context(),
+				options,
+			)
+		},
+	}
+	cmd.Flags().StringVar(&name, "name", "", "View name")
+	cmd.Flags().StringVar(&schemaRoot, "schema", "", "View schema Root")
+	cmd.Flags().StringVar(&versionID, "version", "", "View version ID")
+	cmd.Flags().BoolVar(&getInactive, "get-inactive", false, "Get inactive views as well as active")
+	return cmd
+}

--- a/cli/view_refresh.go
+++ b/cli/view_refresh.go
@@ -28,8 +28,9 @@ func MakeViewRefreshCommand() *cobra.Command {
 		Long: `Refresh views, executing the underlying query and LensVm transforms and
 persisting the results.
 
-View is refreshed as the current user, meaning results returned for all subsequent query requests
-to the view will receive items generated using the user refreshing the view's permissions.
+View is refreshed as the current user, meaning the cached items will reflect that user's
+permissions. Subsequent query requests to the view, regardless of user, will receive
+items from that cache.
 
 Example: refresh all views
   defradb client view refresh

--- a/cli/view_refresh.go
+++ b/cli/view_refresh.go
@@ -32,16 +32,16 @@ View is refreshed as the current user, meaning results returned for all subseque
 to the view will recieve items accessible to the user refreshing the view's permissions.
 
 Example: refresh all views
-  defradb view refresh
+  defradb client view refresh
 
 Example: refresh views by name
-  defradb view refresh --name UserView
+  defradb client view refresh --name UserView
 
 Example: refresh views by schema root id
-  defradb view refresh --schema bae123
+  defradb client view refresh --schema bae123
 
 Example: refresh views by version id. This will also return inactive views
-  defradb view refresh --version bae123
+  defradb client view refresh --version bae123
 		`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			store := mustGetContextStore(cmd)

--- a/client/collection_description.go
+++ b/client/collection_description.go
@@ -79,6 +79,15 @@ type CollectionDescription struct {
 	// parsing is done, to avoid storing an invalid policyID or policy resource
 	// that may not even exist on acp.
 	Policy immutable.Option[PolicyDescription]
+
+	// IsMaterialized defines whether the items in this collection are cached or not.
+	//
+	// If it is true, they will be, if false, the data returned on query will be calculated
+	// at query-time from source.
+	//
+	// At the moment this can only be set to `false` if this collection sources it's data from
+	// another collection/query (is a View).
+	IsMaterialized bool
 }
 
 // QuerySource represents a collection data source from a query.
@@ -179,6 +188,7 @@ type collectionDescription struct {
 	ID              uint32
 	RootID          uint32
 	SchemaVersionID string
+	IsMaterialized  bool
 	Policy          immutable.Option[PolicyDescription]
 	Indexes         []IndexDescription
 	Fields          []CollectionFieldDescription
@@ -198,6 +208,7 @@ func (c *CollectionDescription) UnmarshalJSON(bytes []byte) error {
 	c.ID = descMap.ID
 	c.RootID = descMap.RootID
 	c.SchemaVersionID = descMap.SchemaVersionID
+	c.IsMaterialized = descMap.IsMaterialized
 	c.Indexes = descMap.Indexes
 	c.Fields = descMap.Fields
 	c.Sources = make([]any, len(descMap.Sources))

--- a/client/collection_description.go
+++ b/client/collection_description.go
@@ -85,7 +85,7 @@ type CollectionDescription struct {
 	// If it is true, they will be, if false, the data returned on query will be calculated
 	// at query-time from source.
 	//
-	// At the moment this can only be set to `false` if this collection sources it's data from
+	// At the moment this can only be set to `false` if this collection sources its data from
 	// another collection/query (is a View).
 	IsMaterialized bool
 }

--- a/client/db.go
+++ b/client/db.go
@@ -196,6 +196,14 @@ type Store interface {
 		transform immutable.Option[model.Lens],
 	) ([]CollectionDefinition, error)
 
+	// RefreshViews refreshes the caches of all views matching the given options.  If no options are set all views
+	// will be refreshed.
+	//
+	// The cached result is dependent on the ACP settings of the source data and the permissions of the user making
+	// the call.  At the moment only one cache can be active at a time, so please pay attention to access rights
+	// when making this call.
+	RefreshViews(context.Context, CollectionFetchOptions) error
+
 	// SetMigration sets the migration for all collections using the given source-destination schema version IDs.
 	//
 	// There may only be one migration per collection version.  If another migration was registered it will be

--- a/client/db.go
+++ b/client/db.go
@@ -196,7 +196,7 @@ type Store interface {
 		transform immutable.Option[model.Lens],
 	) ([]CollectionDefinition, error)
 
-	// RefreshViews refreshes the caches of all views matching the given options.  If no options are set all views
+	// RefreshViews refreshes the caches of all views matching the given options.  If no options are set, all views
 	// will be refreshed.
 	//
 	// The cached result is dependent on the ACP settings of the source data and the permissions of the user making

--- a/client/mocks/db.go
+++ b/client/mocks/db.go
@@ -1489,6 +1489,53 @@ func (_c *DB_PrintDump_Call) RunAndReturn(run func(context.Context) error) *DB_P
 	return _c
 }
 
+// RefreshViews provides a mock function with given fields: _a0, _a1
+func (_m *DB) RefreshViews(_a0 context.Context, _a1 client.CollectionFetchOptions) error {
+	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for RefreshViews")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, client.CollectionFetchOptions) error); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// DB_RefreshViews_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RefreshViews'
+type DB_RefreshViews_Call struct {
+	*mock.Call
+}
+
+// RefreshViews is a helper method to define mock.On call
+//   - _a0 context.Context
+//   - _a1 client.CollectionFetchOptions
+func (_e *DB_Expecter) RefreshViews(_a0 interface{}, _a1 interface{}) *DB_RefreshViews_Call {
+	return &DB_RefreshViews_Call{Call: _e.mock.On("RefreshViews", _a0, _a1)}
+}
+
+func (_c *DB_RefreshViews_Call) Run(run func(_a0 context.Context, _a1 client.CollectionFetchOptions)) *DB_RefreshViews_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(client.CollectionFetchOptions))
+	})
+	return _c
+}
+
+func (_c *DB_RefreshViews_Call) Return(_a0 error) *DB_RefreshViews_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *DB_RefreshViews_Call) RunAndReturn(run func(context.Context, client.CollectionFetchOptions) error) *DB_RefreshViews_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // RemoveP2PCollections provides a mock function with given fields: ctx, collectionIDs
 func (_m *DB) RemoveP2PCollections(ctx context.Context, collectionIDs []string) error {
 	ret := _m.Called(ctx, collectionIDs)

--- a/docs/data_format_changes/i2951-no-change-tests-updated.md
+++ b/docs/data_format_changes/i2951-no-change-tests-updated.md
@@ -1,0 +1,3 @@
+# Materialized views
+
+Views have been made materialized by default, this caused the tests to change slightly.

--- a/docs/website/references/cli/defradb_client_view_refresh.md
+++ b/docs/website/references/cli/defradb_client_view_refresh.md
@@ -7,8 +7,9 @@ Refresh views.
 Refresh views, executing the underlying query and LensVm transforms and
 persisting the results.
 
-View is refreshed as the current user, meaning results returned for all subsequent query requests
-to the view will receive items generated using the user refreshing the view's permissions.
+View is refreshed as the current user, meaning the cached items will reflect that user's
+permissions. Subsequent query requests to the view, regardless of user, will receive
+items from that cache.
 
 Example: refresh all views
   defradb client view refresh

--- a/docs/website/references/cli/defradb_client_view_refresh.md
+++ b/docs/website/references/cli/defradb_client_view_refresh.md
@@ -1,15 +1,40 @@
-## defradb client view
+## defradb client view refresh
 
-Manage views within a running DefraDB instance
+Refresh views.
 
 ### Synopsis
 
-Manage (add) views withing a running DefraDB instance
+Refresh views, executing the underlying query and LensVm transforms and
+persisting the results.
+
+View is refreshed as the current user, meaning results returned for all subsequent query requests
+to the view will receive items generated using the user refreshing the view's permissions.
+
+Example: refresh all views
+  defradb client view refresh
+
+Example: refresh views by name
+  defradb client view refresh --name UserView
+
+Example: refresh views by schema root id
+  defradb client view refresh --schema bae123
+
+Example: refresh views by version id. This will also return inactive views
+  defradb client view refresh --version bae123
+		
+
+```
+defradb client view refresh [flags]
+```
 
 ### Options
 
 ```
-  -h, --help   help for view
+      --get-inactive     Get inactive views as well as active
+  -h, --help             help for refresh
+      --name string      View name
+      --schema string    View schema Root
+      --version string   View version ID
 ```
 
 ### Options inherited from parent commands
@@ -35,7 +60,5 @@ Manage (add) views withing a running DefraDB instance
 
 ### SEE ALSO
 
-* [defradb client](defradb_client.md)	 - Interact with a DefraDB node
-* [defradb client view add](defradb_client_view_add.md)	 - Add new view
-* [defradb client view refresh](defradb_client_view_refresh.md)	 - Refresh views.
+* [defradb client view](defradb_client_view.md)	 - Manage views within a running DefraDB instance
 

--- a/docs/website/references/http/openapi.json
+++ b/docs/website/references/http/openapi.json
@@ -137,6 +137,9 @@
                         },
                         "type": "array"
                     },
+                    "IsMaterialized": {
+                        "type": "boolean"
+                    },
                     "Name": {},
                     "Policy": {},
                     "RootID": {
@@ -214,6 +217,9 @@
                                     "type": "object"
                                 },
                                 "type": "array"
+                            },
+                            "IsMaterialized": {
+                                "type": "boolean"
                             },
                             "Name": {},
                             "Policy": {},
@@ -2031,6 +2037,60 @@
                             }
                         },
                         "description": "The created collection and embedded schemas for the added view."
+                    },
+                    "400": {
+                        "$ref": "#/components/responses/error"
+                    },
+                    "default": {
+                        "description": ""
+                    }
+                },
+                "tags": [
+                    "view"
+                ]
+            }
+        },
+        "/view/refresh": {
+            "post": {
+                "description": "Refresh view(s) by name, schema id, or version id.",
+                "operationId": "view_refresh",
+                "parameters": [
+                    {
+                        "description": "Collection name",
+                        "in": "query",
+                        "name": "name",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Collection schema root",
+                        "in": "query",
+                        "name": "schema_root",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Collection schema version id",
+                        "in": "query",
+                        "name": "version_id",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "If true, inactive collections will be returned in addition to active ones",
+                        "in": "query",
+                        "name": "get_inactive",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/success"
                     },
                     "400": {
                         "$ref": "#/components/responses/error"

--- a/http/client.go
+++ b/http/client.go
@@ -219,6 +219,32 @@ func (c *Client) AddView(
 	return descriptions, nil
 }
 
+func (c *Client) RefreshViews(ctx context.Context, options client.CollectionFetchOptions) error {
+	methodURL := c.http.baseURL.JoinPath("view", "refresh")
+	params := url.Values{}
+	if options.Name.HasValue() {
+		params.Add("name", options.Name.Value())
+	}
+	if options.SchemaVersionID.HasValue() {
+		params.Add("version_id", options.SchemaVersionID.Value())
+	}
+	if options.SchemaRoot.HasValue() {
+		params.Add("schema_root", options.SchemaRoot.Value())
+	}
+	if options.IncludeInactive.HasValue() {
+		params.Add("get_inactive", strconv.FormatBool(options.IncludeInactive.Value()))
+	}
+	methodURL.RawQuery = params.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, methodURL.String(), nil)
+	if err != nil {
+		return err
+	}
+
+	_, err = c.http.request(req)
+	return err
+}
+
 func (c *Client) SetMigration(ctx context.Context, config client.LensConfig) error {
 	methodURL := c.http.baseURL.JoinPath("lens")
 

--- a/http/http_client.go
+++ b/http/http_client.go
@@ -81,7 +81,7 @@ func (c *httpClient) request(req *http.Request) ([]byte, error) {
 	// attempt to parse json error
 	var errRes errorResponse
 	if err := json.Unmarshal(data, &errRes); err != nil {
-		return nil, fmt.Errorf("%s", data)
+		return nil, fmt.Errorf("%v: %s", res.StatusCode, data)
 	}
 	return nil, errRes.Error
 }

--- a/internal/core/key.go
+++ b/internal/core/key.go
@@ -88,7 +88,7 @@ type ViewCacheKey struct {
 	// CollectionRootID is the Root of the Collection that this item belongs to.
 	CollectionRootID uint32
 
-	// ItemID is the unique (to this CollectionRootID) of the View item.
+	// ItemID is the unique (to this CollectionRootID) ID of the View item.
 	//
 	// For now this is essentially just the index of the item in the result-set, however
 	// that is likely to change in the near future.

--- a/internal/core/key.go
+++ b/internal/core/key.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/errors"
+	"github.com/sourcenetwork/defradb/internal/encoding"
 )
 
 var (
@@ -49,6 +50,7 @@ const (
 	COLLECTION_SCHEMA_VERSION      = "/collection/version"
 	COLLECTION_ROOT                = "/collection/root"
 	COLLECTION_INDEX               = "/collection/index"
+	COLLECTION_VIEW_ITEMS          = "/collection/vi"
 	SCHEMA_VERSION                 = "/schema/version/v"
 	SCHEMA_VERSION_ROOT            = "/schema/version/r"
 	COLLECTION_SEQ                 = "/seq/collection"
@@ -76,6 +78,24 @@ type DataStoreKey struct {
 }
 
 var _ Key = (*DataStoreKey)(nil)
+
+// ViewCacheKey is a trimmed down [DataStoreKey] used for caching the results
+// of View items.
+//
+// It is stored in the format `/collection/vi/[CollectionRootID]/[ItemID]`. It points to the
+// full serialized View item.
+type ViewCacheKey struct {
+	// CollectionRootID is the Root of the Collection that this item belongs to.
+	CollectionRootID uint32
+
+	// ItemID is the unique (to this CollectionRootID) of the View item.
+	//
+	// For now this is essentially just the index of the item in the result-set, however
+	// that is likely to change in the near future.
+	ItemID uint
+}
+
+var _ Key = (*ViewCacheKey)(nil)
 
 // IndexedField contains information necessary for storing a single
 // value of a field in an index.
@@ -525,6 +545,56 @@ func (k DataStoreKey) ToPrimaryDataStoreKey() PrimaryDataStoreKey {
 		CollectionRootID: k.CollectionRootID,
 		DocID:            k.DocID,
 	}
+}
+
+func NewViewCacheColPrefix(rootID uint32) ViewCacheKey {
+	return ViewCacheKey{
+		CollectionRootID: rootID,
+	}
+}
+
+func NewViewCacheKey(rootID uint32, itemID uint) ViewCacheKey {
+	return ViewCacheKey{
+		CollectionRootID: rootID,
+		ItemID:           itemID,
+	}
+}
+
+func (k ViewCacheKey) ToString() string {
+	return string(k.Bytes())
+}
+
+func (k ViewCacheKey) Bytes() []byte {
+	result := []byte(COLLECTION_VIEW_ITEMS)
+
+	if k.CollectionRootID != 0 {
+		result = append(result, '/')
+		result = encoding.EncodeUvarintAscending(result, uint64(k.CollectionRootID))
+	}
+
+	if k.ItemID != 0 {
+		result = append(result, '/')
+		result = encoding.EncodeUvarintAscending(result, uint64(k.ItemID))
+	}
+
+	return result
+}
+
+func (k ViewCacheKey) ToDS() ds.Key {
+	return ds.NewKey(k.ToString())
+}
+
+func (k ViewCacheKey) PrettyPrint() string {
+	result := COLLECTION_VIEW_ITEMS
+
+	if k.CollectionRootID != 0 {
+		result = result + "/" + strconv.Itoa(int(k.CollectionRootID))
+	}
+	if k.ItemID != 0 {
+		result = result + "/" + strconv.Itoa(int(k.ItemID))
+	}
+
+	return result
 }
 
 // NewIndexDataStoreKey creates a new IndexDataStoreKey from a collection ID, index ID and fields.

--- a/internal/core/view_item.go
+++ b/internal/core/view_item.go
@@ -1,0 +1,129 @@
+// Copyright 2024 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package core
+
+import (
+	"encoding/json"
+
+	"github.com/sourcenetwork/defradb/client"
+)
+
+// MarshalViewItem marshals the given doc ready for storage.
+//
+// It first trims the doc leaving only an array of field values (including
+// relations), and then marshals that into json.
+//
+// Note: MarshalViewItem and UnmarshalViewItem rely on the Doc (and DocumentMapping)
+// being consistent at write and read time.
+func MarshalViewItem(doc Doc) ([]byte, error) {
+	trimmedDoc := trimDoc(doc)
+	return json.Marshal(trimmedDoc)
+}
+
+func trimDoc(doc Doc) []any {
+	fields := make([]any, 0, len(doc.Fields))
+	for _, field := range doc.Fields {
+		switch typedField := field.(type) {
+		case []Doc:
+			trimmedField := make([]any, 0, len(typedField))
+			for _, innerDoc := range typedField {
+				trimmedField = append(
+					trimmedField,
+					trimDoc(innerDoc),
+				)
+			}
+			fields = append(fields, trimmedField)
+
+		case Doc:
+			fields = append(
+				fields,
+				trimDoc(typedField),
+			)
+
+		default:
+			fields = append(fields, typedField)
+		}
+	}
+
+	return fields
+}
+
+// UnmarshalViewItem unmarshals the given byte array into a [Doc] using the given
+// mapping.
+//
+// It assumes that `bytes` is in the appropriate format (see MarshalViewItem) and
+// will only error if the json unmarshalling fails.
+//
+// Note: MarshalViewItem and UnmarshalViewItem rely on the Doc (and DocumentMapping)
+// being consistent at write and read time.
+func UnmarshalViewItem(documentMap *DocumentMapping, bytes []byte) (Doc, error) {
+	var trimmedDoc []any
+	err := json.Unmarshal(bytes, &trimmedDoc)
+	if err != nil {
+		return Doc{}, err
+	}
+
+	return expandViewItem(documentMap, trimmedDoc), nil
+}
+
+func expandViewItem(documentMap *DocumentMapping, trimmed []any) Doc {
+	fields := make(DocFields, len(trimmed))
+
+	for _, indexes := range documentMap.IndexesByName {
+		for _, index := range indexes {
+			fieldValue := trimmed[index]
+			var childMapping *DocumentMapping
+			if index < len(documentMap.ChildMappings) {
+				childMapping = documentMap.ChildMappings[index]
+			}
+
+			if childMapping == nil {
+				// If the childMapping is nil, this property must not be a relation and we can
+				// set the value and continue.
+				fields[index] = fieldValue
+				continue
+			}
+
+			if untypedArray, ok := fieldValue.([]any); ok {
+				isArrayOfDocs := true
+				for _, inner := range untypedArray {
+					if _, ok := inner.([]any); !ok {
+						// To know if this is an array of documents we need to check the inner values to see if
+						// this is esentially an `[][]any`
+						isArrayOfDocs = false
+						break
+					}
+				}
+
+				if isArrayOfDocs {
+					innerDocs := make([]Doc, 0, len(untypedArray))
+					for _, inner := range untypedArray {
+						innerDocs = append(innerDocs, expandViewItem(childMapping, inner.([]any)))
+					}
+					fields[index] = innerDocs
+				} else {
+					fields[index] = expandViewItem(childMapping, untypedArray)
+				}
+			}
+			// else: no-op
+			//
+			// The relation must be either an empty array (many side of one-many), or
+			// nil (one side of either a one-many or one-one).  Either way the value is nil/default
+			// and we can continue
+		}
+	}
+
+	return Doc{
+		Hidden: false,
+		Fields: fields,
+		Status: client.Active,
+	}
+}

--- a/internal/db/collection_define.go
+++ b/internal/db/collection_define.go
@@ -157,6 +157,18 @@ func (db *db) patchCollection(
 
 		existingCol, ok := existingColsByID[col.ID]
 		if ok {
+			if existingCol.IsMaterialized && !col.IsMaterialized {
+				// If the collection is being de-materialized - delete any cached values.
+				// Leaving them around will not break anything, but it would be a waste of
+				// storage space.
+				err := db.clearViewCache(ctx, client.CollectionDefinition{
+					Description: col,
+				})
+				if err != nil {
+					return err
+				}
+			}
+
 			// Clear any existing migrations in the registry, using this semi-hacky way
 			// to avoid adding more functions to a public interface that we wish to remove.
 

--- a/internal/db/definition_validation.go
+++ b/internal/db/definition_validation.go
@@ -165,7 +165,7 @@ var globalValidators = []definitionValidator{
 	validateFieldNotDuplicated,
 	validateSelfReferences,
 	validateCollectionMaterialized,
-	validateMaterializedHasNoACP,
+	validateMaterializedHasNoPolicy,
 }
 
 var createValidators = append(
@@ -999,10 +999,10 @@ func validateCollectionMaterialized(
 	return nil
 }
 
-// validateCollectionMaterialized verifies that a materialized view has no ACP policy.
+// validateMaterializedHasNoPolicy verifies that a materialized view has no ACP policy.
 //
 // Long term we wish to support this, however for now we block it off.
-func validateMaterializedHasNoACP(
+func validateMaterializedHasNoPolicy(
 	ctx context.Context,
 	db *db,
 	newState *definitionState,

--- a/internal/db/errors.go
+++ b/internal/db/errors.go
@@ -102,6 +102,8 @@ const (
 	errReplicatorNotFound                       string = "replicator not found"
 	errCanNotEncryptBuiltinField                string = "can not encrypt build-in field"
 	errSelfReferenceWithoutSelf                 string = "must specify 'Self' kind for self referencing relations"
+	errColNotMaterialized                       string = "non-materialized collections (only views) are not supported"
+	errMaterializedViewAndACPNotSupported       string = "materialized views do not support ACP"
 )
 
 var (
@@ -143,6 +145,8 @@ var (
 	ErrReplicatorNotFound                       = errors.New(errReplicatorNotFound)
 	ErrCanNotEncryptBuiltinField                = errors.New(errCanNotEncryptBuiltinField)
 	ErrSelfReferenceWithoutSelf                 = errors.New(errSelfReferenceWithoutSelf)
+	ErrColNotMaterialized                       = errors.New(errColNotMaterialized)
+	ErrMaterializedViewAndACPNotSupported       = errors.New(errMaterializedViewAndACPNotSupported)
 )
 
 // NewErrFailedToGetHeads returns a new error indicating that the heads of a document
@@ -657,5 +661,19 @@ func NewErrSelfReferenceWithoutSelf(fieldName string) error {
 	return errors.New(
 		errSelfReferenceWithoutSelf,
 		errors.NewKV("Field", fieldName),
+	)
+}
+
+func NewErrColNotMaterialized(collection string) error {
+	return errors.New(
+		errColNotMaterialized,
+		errors.NewKV("Collection", collection),
+	)
+}
+
+func NewErrMaterializedViewAndACPNotSupported(collection string) error {
+	return errors.New(
+		errMaterializedViewAndACPNotSupported,
+		errors.NewKV("Collection", collection),
 	)
 }

--- a/internal/db/errors.go
+++ b/internal/db/errors.go
@@ -102,7 +102,7 @@ const (
 	errReplicatorNotFound                       string = "replicator not found"
 	errCanNotEncryptBuiltinField                string = "can not encrypt build-in field"
 	errSelfReferenceWithoutSelf                 string = "must specify 'Self' kind for self referencing relations"
-	errColNotMaterialized                       string = "non-materialized collections (only views) are not supported"
+	errColNotMaterialized                       string = "non-materialized collections are not supported"
 	errMaterializedViewAndACPNotSupported       string = "materialized views do not support ACP"
 )
 

--- a/internal/db/lens.go
+++ b/internal/db/lens.go
@@ -52,6 +52,7 @@ func (db *db) setMigration(ctx context.Context, cfg client.LensConfig) error {
 			ID:              uint32(colID),
 			RootID:          client.OrphanRootID,
 			SchemaVersionID: cfg.SourceSchemaVersionID,
+			IsMaterialized:  true,
 		}
 
 		col, err := description.SaveCollection(ctx, txn, desc)
@@ -96,6 +97,7 @@ func (db *db) setMigration(ctx context.Context, cfg client.LensConfig) error {
 				ID:              uint32(colID),
 				RootID:          sourceCol.RootID,
 				SchemaVersionID: cfg.DestinationSchemaVersionID,
+				IsMaterialized:  true,
 				Sources: []any{
 					&client.CollectionSource{
 						SourceCollectionID: sourceCol.ID,

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -242,6 +242,26 @@ func (db *db) AddView(
 	return defs, nil
 }
 
+func (db *db) RefreshViews(ctx context.Context, opts client.CollectionFetchOptions) error {
+	ctx, txn, err := ensureContextTxn(ctx, db, false)
+	if err != nil {
+		return err
+	}
+	defer txn.Discard(ctx)
+
+	err = db.refreshViews(ctx, opts)
+	if err != nil {
+		return err
+	}
+
+	err = txn.Commit(ctx)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // BasicImport imports a json dataset.
 // filepath must be accessible to the node.
 func (db *db) BasicImport(ctx context.Context, filepath string) error {

--- a/internal/db/view.go
+++ b/internal/db/view.go
@@ -193,7 +193,7 @@ func (db *db) buildViewCache(ctx context.Context, col client.CollectionDefinitio
 		return err
 	}
 
-	hasNext, err := source.Next()
+	hasValue, err := source.Next()
 	if err != nil {
 		return err
 	}
@@ -202,7 +202,7 @@ func (db *db) buildViewCache(ctx context.Context, col client.CollectionDefinitio
 	// The order in which results are returned must be consistent with the results of the
 	// underlying query/transform.
 	var itemID uint
-	for itemID = 1; hasNext; itemID++ {
+	for itemID = 1; hasValue; itemID++ {
 		doc := source.Value()
 
 		serializedItem, err := core.MarshalViewItem(doc)
@@ -216,7 +216,7 @@ func (db *db) buildViewCache(ctx context.Context, col client.CollectionDefinitio
 			return err
 		}
 
-		hasNext, err = source.Next()
+		hasValue, err = source.Next()
 		if err != nil {
 			return err
 		}

--- a/internal/db/view.go
+++ b/internal/db/view.go
@@ -15,11 +15,16 @@ import (
 	"errors"
 	"fmt"
 
+	ds "github.com/ipfs/go-datastore"
+	"github.com/ipfs/go-datastore/query"
 	"github.com/lens-vm/lens/host-go/config/model"
 	"github.com/sourcenetwork/immutable"
 
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/request"
+	"github.com/sourcenetwork/defradb/internal/core"
+	"github.com/sourcenetwork/defradb/internal/db/description"
+	"github.com/sourcenetwork/defradb/internal/planner"
 )
 
 func (db *db) addView(
@@ -87,4 +92,219 @@ func (db *db) addView(
 	}
 
 	return returnDescriptions, nil
+}
+
+func (db *db) refreshViews(ctx context.Context, opts client.CollectionFetchOptions) error {
+	// For now, we only support user-cache management of views, not all collections
+	cols, err := db.getViews(ctx, opts)
+	if err != nil {
+		return err
+	}
+
+	for _, col := range cols {
+		if !col.Description.IsMaterialized {
+			// We only care about materialized views here, so skip any that aren't
+			continue
+		}
+
+		// Clearing and then constructing is a bit inefficient, but it should do for now.
+		// Long term we probably want to update inline as much as possible to avoid unnessecarily
+		// moving/adding/deleting keys in storage
+		err := db.clearViewCache(ctx, col)
+		if err != nil {
+			return err
+		}
+
+		err = db.buildViewCache(ctx, col)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (db *db) getViews(ctx context.Context, opts client.CollectionFetchOptions) ([]client.CollectionDefinition, error) {
+	cols, err := db.getCollections(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	var views []client.CollectionDefinition
+	for _, col := range cols {
+		if querySrcs := col.Description().QuerySources(); len(querySrcs) == 0 {
+			continue
+		}
+
+		views = append(views, col.Definition())
+	}
+
+	return views, nil
+}
+
+func (db *db) buildViewCache(ctx context.Context, col client.CollectionDefinition) (err error) {
+	txn := mustGetContextTxn(ctx)
+	identity := GetContextIdentity(ctx)
+
+	p := planner.New(ctx, identity, db.acp, db, txn)
+
+	// temporarily disable the cache in order to query without using it
+	col.Description.IsMaterialized = false
+	col.Description, err = description.SaveCollection(ctx, txn, col.Description)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		var defErr error
+		col.Description.IsMaterialized = true
+		col.Description, defErr = description.SaveCollection(ctx, txn, col.Description)
+		if err == nil {
+			// Do not overwrite the original error if there is one, defErr is probably an artifact of the original
+			// failue and can be discarded.
+			err = defErr
+		}
+	}()
+
+	request, err := db.generateMaximalSelectFromCollection(ctx, col, immutable.None[string](), map[string]struct{}{})
+	if err != nil {
+		return err
+	}
+
+	source, err := p.MakeSelectionPlan(request)
+	if err != nil {
+		return err
+	}
+
+	err = source.Init()
+	if err != nil {
+		return err
+	}
+	defer func() {
+		defErr := source.Close()
+		if err == nil {
+			// Do not overwrite the original error if there is one, defErr is probably an artifact of the original
+			// failue and can be discarded.
+			err = defErr
+		}
+	}()
+
+	err = source.Start()
+	if err != nil {
+		return err
+	}
+
+	hasNext, err := source.Next()
+	if err != nil {
+		return err
+	}
+
+	// View items are currently keyed by their index, starting at 1.
+	// The order in which results are returned must be consistent with the results of the
+	// underlying query/transform.
+	var itemID uint
+	for itemID = 1; hasNext; itemID++ {
+		doc := source.Value()
+
+		serializedItem, err := core.MarshalViewItem(doc)
+		if err != nil {
+			return err
+		}
+
+		itemKey := core.NewViewCacheKey(col.Description.RootID, itemID)
+		err = txn.Datastore().Put(ctx, itemKey.ToDS(), serializedItem)
+		if err != nil {
+			return err
+		}
+
+		hasNext, err = source.Next()
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (db *db) clearViewCache(ctx context.Context, col client.CollectionDefinition) error {
+	txn := mustGetContextTxn(ctx)
+	prefix := core.NewViewCacheColPrefix(col.Description.RootID)
+
+	q, err := txn.Datastore().Query(ctx, query.Query{
+		Prefix:   prefix.ToString(),
+		KeysOnly: true,
+	})
+	if err != nil {
+		return err
+	}
+
+	for res := range q.Next() {
+		if res.Error != nil {
+			return errors.Join(res.Error, q.Close())
+		}
+
+		err = txn.Datastore().Delete(ctx, ds.NewKey(res.Key))
+		if err != nil {
+			return errors.Join(err, q.Close())
+		}
+	}
+
+	return q.Close()
+}
+
+func (db *db) generateMaximalSelectFromCollection(
+	ctx context.Context,
+	col client.CollectionDefinition,
+	fieldName immutable.Option[string],
+	typesHit map[string]struct{},
+) (*request.Select, error) {
+	// `__-` is an impossible field name prefix, so we can safely concat using it as a separator without risk
+	// of collision.
+	identifier := col.GetName() + "__-" + fieldName.Value()
+	if _, ok := typesHit[identifier]; ok {
+		// If this identifier is already in the set, the schema must be circular and we should return
+		return nil, nil
+	}
+	typesHit[identifier] = struct{}{}
+
+	childRequests := []request.Selection{}
+	for _, field := range col.GetFields() {
+		if field.IsRelation() && field.Kind.IsObject() {
+			relatedCol, _, err := client.GetDefinitionFromStore(ctx, db, col, field.Kind)
+			if err != nil {
+				return nil, err
+			}
+
+			innerSelect, err := db.generateMaximalSelectFromCollection(
+				ctx,
+				relatedCol,
+				immutable.Some(field.Name),
+				typesHit,
+			)
+			if err != nil {
+				return nil, err
+			}
+
+			if innerSelect != nil {
+				// innerSelect may be nil if a circular relationship is defined in the schema and we have already
+				// added this field
+				childRequests = append(childRequests, innerSelect)
+			}
+		}
+	}
+
+	var name string
+	if fieldName.HasValue() {
+		name = fieldName.Value()
+	} else {
+		name = col.GetName()
+	}
+
+	return &request.Select{
+		Field: request.Field{
+			Name: name,
+		},
+		ChildSelect: request.ChildSelect{
+			Fields: childRequests,
+		},
+	}, nil
 }

--- a/internal/planner/view.go
+++ b/internal/planner/view.go
@@ -11,6 +11,8 @@
 package planner
 
 import (
+	"github.com/ipfs/go-datastore/query"
+
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/internal/core"
 	"github.com/sourcenetwork/defradb/internal/planner/mapper"
@@ -33,18 +35,23 @@ func (p *Planner) View(query *mapper.Select, col client.Collection) (planNode, e
 	querySource := (col.Description().Sources[0].(*client.QuerySource))
 	hasTransform := querySource.Transform.HasValue()
 
-	m, err := mapper.ToSelect(p.ctx, p.db, mapper.ObjectSelection, &querySource.Query)
-	if err != nil {
-		return nil, err
-	}
+	var source planNode
+	if col.Description().IsMaterialized {
+		source = p.newCachedViewFetcher(col.Definition(), query.DocumentMapping)
+	} else {
+		m, err := mapper.ToSelect(p.ctx, p.db, mapper.ObjectSelection, &querySource.Query)
+		if err != nil {
+			return nil, err
+		}
 
-	source, err := p.Select(m)
-	if err != nil {
-		return nil, err
-	}
+		source, err = p.Select(m)
+		if err != nil {
+			return nil, err
+		}
 
-	if hasTransform {
-		source = p.Lens(source, query.DocumentMapping, col)
+		if hasTransform {
+			source = p.Lens(source, query.DocumentMapping, col)
+		}
 	}
 
 	viewNode := &viewNode{
@@ -75,28 +82,11 @@ func (n *viewNode) Next() (bool, error) {
 }
 
 func (n *viewNode) Value() core.Doc {
-	sourceValue := n.source.Value()
-	if n.hasTransform {
-		// If this view has a transform the source document will already have been
-		// converted to the new document mapping.
-		return sourceValue
-	}
-
-	sourceMap := n.source.DocumentMap().ToMap(sourceValue)
-
-	// We must convert the document from the source mapping (which was constructed using the
-	// view's base query) to a document using the output mapping (which was constructed using
-	// the current query and the output schemas).  We do this by source output name, which
-	// will take into account any aliases defined in the base query.
-	doc := n.docMapper.documentMapping.NewDoc()
-	for fieldName, fieldValue := range sourceMap {
-		// If the field does not exist, ignore it an continue.  It likely means that
-		// the field was declared in the query but not the SDL, and if it is not in the
-		// SDL it cannot be requested/rendered by the user and would be dropped later anyway.
-		_ = n.docMapper.documentMapping.TrySetFirstOfName(&doc, fieldName, fieldValue)
-	}
-
-	return doc
+	// The source mapping will differ from this node's (request) mapping if either a Lens transform is
+	// involved, if the the view is materialized, or if any kind of operation is performed on the result
+	// of the query (such as a filter or aggregate in the user-request), so we must convert the returned
+	// documents to the request mapping
+	return convertBetweenMaps(n.source.DocumentMap(), n.documentMapping, n.source.Value())
 }
 
 func (n *viewNode) Source() planNode {
@@ -116,4 +106,143 @@ func (n *viewNode) Close() error {
 	}
 
 	return nil
+}
+
+func convertBetweenMaps(srcMap *core.DocumentMapping, dstMap *core.DocumentMapping, src core.Doc) core.Doc {
+	dst := dstMap.NewDoc()
+
+	srcRenderKeysByIndex := map[int]string{}
+	for _, renderKey := range srcMap.RenderKeys {
+		srcRenderKeysByIndex[renderKey.Index] = renderKey.Key
+	}
+
+	for underlyingName, srcIndexes := range srcMap.IndexesByName {
+		for _, srcIndex := range srcIndexes {
+			if srcIndex >= len(src.Fields) {
+				// Several system fields are not included in schema only types, and there is a mismatch somewhere
+				// that means we have to handle them here with a continue
+				continue
+			}
+
+			var dstName string
+			if key, ok := srcRenderKeysByIndex[srcIndex]; ok {
+				dstName = key
+			} else {
+				dstName = underlyingName
+			}
+
+			dstIndexes, dstHasField := dstMap.IndexesByName[dstName]
+			if !dstHasField {
+				continue
+			}
+
+			for _, dstIndex := range dstIndexes {
+				var srcValue any
+				if srcIndex < len(srcMap.ChildMappings) && srcMap.ChildMappings[srcIndex] != nil {
+					if dstIndex >= len(dstMap.ChildMappings) || dstMap.ChildMappings[dstIndex] == nil {
+						continue
+					}
+
+					switch inner := src.Fields[srcIndex].(type) {
+					case core.Doc:
+						srcValue = convertBetweenMaps(srcMap.ChildMappings[srcIndex], dstMap.ChildMappings[dstIndex], inner)
+
+					case []core.Doc:
+						dstInners := make([]core.Doc, len(inner))
+						for i, srcInnerDoc := range inner {
+							dstInners[i] = convertBetweenMaps(srcMap.ChildMappings[srcIndex], dstMap.ChildMappings[dstIndex], srcInnerDoc)
+						}
+						srcValue = dstInners
+					}
+				} else {
+					srcValue = src.Fields[srcIndex]
+				}
+
+				dst.Fields[dstIndex] = srcValue
+			}
+		}
+	}
+
+	return dst
+}
+
+// cachedViewFetcher is a planner node that fetches view items from a materialized cache.
+type cachedViewFetcher struct {
+	docMapper
+	documentIterator
+
+	def client.CollectionDefinition
+	p   *Planner
+
+	queryResults query.Results
+}
+
+var _ planNode = (*cachedViewFetcher)(nil)
+
+func (p *Planner) newCachedViewFetcher(
+	def client.CollectionDefinition,
+	mapping *core.DocumentMapping,
+) *cachedViewFetcher {
+	return &cachedViewFetcher{
+		def:       def,
+		p:         p,
+		docMapper: docMapper{mapping},
+	}
+}
+
+func (n *cachedViewFetcher) Init() error {
+	if n.queryResults != nil {
+		err := n.queryResults.Close()
+		if err != nil {
+			return err
+		}
+		n.queryResults = nil
+	}
+
+	prefix := core.NewViewCacheColPrefix(n.def.Description.RootID)
+
+	var err error
+	n.queryResults, err = n.p.txn.Datastore().Query(n.p.ctx, query.Query{
+		Prefix: prefix.ToString(),
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (n *cachedViewFetcher) Start() error {
+	return nil
+}
+
+func (n *cachedViewFetcher) Spans(spans core.Spans) {
+	// no-op
+}
+
+func (n *cachedViewFetcher) Next() (bool, error) {
+	result, hasNext := n.queryResults.NextSync()
+	if !hasNext || result.Error != nil {
+		return false, result.Error
+	}
+
+	var err error
+	n.currentValue, err = core.UnmarshalViewItem(n.documentMapping, result.Value)
+	if err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+func (n *cachedViewFetcher) Source() planNode {
+	return nil
+}
+
+func (n *cachedViewFetcher) Kind() string {
+	return "cachedViewFetcher"
+}
+
+func (n *cachedViewFetcher) Close() error {
+	return n.queryResults.Close()
 }

--- a/internal/request/graphql/schema/collection.go
+++ b/internal/request/graphql/schema/collection.go
@@ -186,6 +186,7 @@ func collectionFromAstDefinition(
 		return collectionFieldDescriptions[i].Name < collectionFieldDescriptions[j].Name
 	})
 
+	isMaterialized := immutable.None[bool]()
 	for _, directive := range def.Directives {
 		switch directive.Name.Value {
 		case types.IndexDirectiveLabel:
@@ -201,15 +202,35 @@ func collectionFromAstDefinition(
 				return client.CollectionDefinition{}, err
 			}
 			policyDescription = immutable.Some(policy)
+
+		case types.MaterializedDirectiveLabel:
+			if isMaterialized.Value() {
+				continue
+			}
+
+			explicitIsMaterialized := immutable.None[bool]()
+			for _, arg := range directive.Arguments {
+				if arg.Name.Value == types.MaterializedDirectivePropIf {
+					explicitIsMaterialized = immutable.Some(arg.Value.GetValue().(bool))
+					break
+				}
+			}
+
+			if explicitIsMaterialized.HasValue() {
+				isMaterialized = immutable.Some(isMaterialized.Value() || explicitIsMaterialized.Value())
+			} else {
+				isMaterialized = immutable.Some(true)
+			}
 		}
 	}
 
 	return client.CollectionDefinition{
 		Description: client.CollectionDescription{
-			Name:    immutable.Some(def.Name.Value),
-			Indexes: indexDescriptions,
-			Policy:  policyDescription,
-			Fields:  collectionFieldDescriptions,
+			Name:           immutable.Some(def.Name.Value),
+			Indexes:        indexDescriptions,
+			Policy:         policyDescription,
+			Fields:         collectionFieldDescriptions,
+			IsMaterialized: !isMaterialized.HasValue() || isMaterialized.Value(),
 		},
 		Schema: client.SchemaDescription{
 			Name:   def.Name.Value,

--- a/internal/request/graphql/schema/collection.go
+++ b/internal/request/graphql/schema/collection.go
@@ -187,14 +187,15 @@ func collectionFromAstDefinition(
 	})
 
 	for _, directive := range def.Directives {
-		if directive.Name.Value == types.IndexDirectiveLabel {
+		switch directive.Name.Value {
+		case types.IndexDirectiveLabel:
 			index, err := indexFromAST(directive, nil)
 			if err != nil {
 				return client.CollectionDefinition{}, err
 			}
 			indexDescriptions = append(indexDescriptions, index)
-		}
-		if directive.Name.Value == types.PolicySchemaDirectiveLabel {
+
+		case types.PolicySchemaDirectiveLabel:
 			policy, err := policyFromAST(directive)
 			if err != nil {
 				return client.CollectionDefinition{}, err

--- a/internal/request/graphql/schema/manager.go
+++ b/internal/request/graphql/schema/manager.go
@@ -158,6 +158,7 @@ func defaultDirectivesType(
 		schemaTypes.IndexDirective(orderEnum, indexFieldInput),
 		schemaTypes.PrimaryDirective(),
 		schemaTypes.RelationDirective(),
+		schemaTypes.MaterializedDirective(),
 	}
 }
 

--- a/internal/request/graphql/schema/types/types.go
+++ b/internal/request/graphql/schema/types/types.go
@@ -51,6 +51,9 @@ const (
 	DefaultDirectivePropJSON     = "json"
 	DefaultDirectivePropBlob     = "blob"
 
+	MaterializedDirectiveLabel  = "materialized"
+	MaterializedDirectivePropIf = "if"
+
 	FieldOrderASC  = "ASC"
 	FieldOrderDESC = "DESC"
 )
@@ -213,6 +216,23 @@ func IndexDirective(orderingEnum *gql.Enum, indexFieldInputObject *gql.InputObje
 		Locations: []string{
 			gql.DirectiveLocationObject,
 			gql.DirectiveLocationFieldDefinition,
+		},
+	})
+}
+
+func MaterializedDirective() *gql.Directive {
+	return gql.NewDirective(gql.DirectiveConfig{
+		Name: MaterializedDirectiveLabel,
+		Description: `@materialized is a directive that specifies whether a collection is cached or not.
+ It will default to true if ommited.  If multiple @materialized directives are provided, they will aggregated
+ with OR logic (if any are true, the collection will be cached).`,
+		Args: gql.FieldConfigArgument{
+			MaterializedDirectivePropIf: &gql.ArgumentConfig{
+				Type: gql.Boolean,
+			},
+		},
+		Locations: []string{
+			gql.DirectiveLocationSchema,
 		},
 	})
 }

--- a/tests/clients/cli/wrapper.go
+++ b/tests/clients/cli/wrapper.go
@@ -281,6 +281,25 @@ func (w *Wrapper) AddView(
 	return defs, nil
 }
 
+func (w *Wrapper) RefreshViews(ctx context.Context, options client.CollectionFetchOptions) error {
+	args := []string{"client", "view", "refresh"}
+	if options.Name.HasValue() {
+		args = append(args, "--name", options.Name.Value())
+	}
+	if options.SchemaVersionID.HasValue() {
+		args = append(args, "--version", options.SchemaVersionID.Value())
+	}
+	if options.SchemaRoot.HasValue() {
+		args = append(args, "--schema", options.SchemaRoot.Value())
+	}
+	if options.IncludeInactive.HasValue() {
+		args = append(args, "--get-inactive", strconv.FormatBool(options.IncludeInactive.Value()))
+	}
+
+	_, err := w.cmd.execute(ctx, args)
+	return err
+}
+
 func (w *Wrapper) SetMigration(ctx context.Context, config client.LensConfig) error {
 	args := []string{"client", "schema", "migration", "set"}
 

--- a/tests/clients/http/wrapper.go
+++ b/tests/clients/http/wrapper.go
@@ -134,6 +134,10 @@ func (w *Wrapper) AddView(
 	return w.client.AddView(ctx, query, sdl, transform)
 }
 
+func (w *Wrapper) RefreshViews(ctx context.Context, opts client.CollectionFetchOptions) error {
+	return w.client.RefreshViews(ctx, opts)
+}
+
 func (w *Wrapper) SetMigration(ctx context.Context, config client.LensConfig) error {
 	return w.client.SetMigration(ctx, config)
 }

--- a/tests/integration/collection_description/simple_test.go
+++ b/tests/integration/collection_description/simple_test.go
@@ -30,8 +30,9 @@ func TestColDescrSimpleCreatesColGivenEmptyType(t *testing.T) {
 			testUtils.GetCollections{
 				ExpectedResults: []client.CollectionDescription{
 					{
-						ID:   1,
-						Name: immutable.Some("Users"),
+						ID:             1,
+						Name:           immutable.Some("Users"),
+						IsMaterialized: true,
 					},
 				},
 			},

--- a/tests/integration/collection_description/updates/replace/materialized_test.go
+++ b/tests/integration/collection_description/updates/replace/materialized_test.go
@@ -1,0 +1,121 @@
+// Copyright 2024 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package replace
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/immutable"
+
+	"github.com/sourcenetwork/defradb/client"
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+func TestColDescrUpdateReplaceIsMaterialized_GivenFalseAndCollection_Errors(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type User {
+						name: String
+					}
+				`,
+			},
+			testUtils.PatchCollection{
+				Patch: `
+					[
+						{ "op": "replace", "path": "/1/IsMaterialized", "value": false }
+					]
+				`,
+				ExpectedError: "non-materialized collections (only views) are not supported. Collection: User",
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestColDescrUpdateReplaceIsMaterialized_GivenFalseAndView(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type User {
+						name: String
+					}
+				`,
+			},
+			testUtils.CreateView{
+				Query: `
+					User {
+						name
+					}
+				`,
+				SDL: `
+					type UserView {
+						name: String
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				// Create John when the view is materialized
+				DocMap: map[string]any{
+					"name": "John",
+				},
+			},
+			testUtils.PatchCollection{
+				Patch: `
+					[
+						{ "op": "replace", "path": "/2/IsMaterialized", "value": false }
+					]
+				`,
+			},
+			testUtils.CreateDoc{
+				// Create Fred when the view is not materialized, noting that there is no `RefreshView`
+				// call after this action, meaning that if the view was still materialized Fred would not
+				// be returned by the query.
+				DocMap: map[string]any{
+					"name": "Fred",
+				},
+			},
+			testUtils.GetCollections{
+				FilterOptions: client.CollectionFetchOptions{
+					Name: immutable.Some("UserView"),
+				},
+				ExpectedResults: []client.CollectionDescription{
+					{
+						Name:           immutable.Some("UserView"),
+						IsMaterialized: false,
+					},
+				},
+			},
+			testUtils.Request{
+				Request: `query {
+					User {
+						name
+					}
+				}`,
+				Results: map[string]any{
+					"User": []map[string]any{
+						{
+							"name": "John",
+						},
+						{
+							"name": "Fred",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/collection_description/updates/replace/materialized_test.go
+++ b/tests/integration/collection_description/updates/replace/materialized_test.go
@@ -35,7 +35,7 @@ func TestColDescrUpdateReplaceIsMaterialized_GivenFalseAndCollection_Errors(t *t
 						{ "op": "replace", "path": "/1/IsMaterialized", "value": false }
 					]
 				`,
-				ExpectedError: "non-materialized collections (only views) are not supported. Collection: User",
+				ExpectedError: "non-materialized collections are not supported. Collection: User",
 			},
 		},
 	}

--- a/tests/integration/collection_description/updates/replace/name_test.go
+++ b/tests/integration/collection_description/updates/replace/name_test.go
@@ -44,8 +44,9 @@ func TestColDescrUpdateReplaceName_GivenExistingName(t *testing.T) {
 			testUtils.GetCollections{
 				ExpectedResults: []client.CollectionDescription{
 					{
-						ID:   1,
-						Name: immutable.Some("Actors"),
+						ID:             1,
+						Name:           immutable.Some("Actors"),
+						IsMaterialized: true,
 					},
 				},
 			},
@@ -180,11 +181,13 @@ func TestColDescrUpdateReplaceName_RemoveExistingName(t *testing.T) {
 				},
 				ExpectedResults: []client.CollectionDescription{
 					{
-						ID: 1,
+						ID:             1,
+						IsMaterialized: true,
 					},
 					{
-						ID:   2,
-						Name: immutable.Some("Actors"),
+						ID:             2,
+						Name:           immutable.Some("Actors"),
+						IsMaterialized: true,
 						Sources: []any{
 							&client.CollectionSource{
 								SourceCollectionID: 1,

--- a/tests/integration/collection_description/updates/replace/query_source_query_test.go
+++ b/tests/integration/collection_description/updates/replace/query_source_query_test.go
@@ -41,7 +41,7 @@ func TestColDescrUpdateReplaceQuerySourceQuery(t *testing.T) {
 					}
 				`,
 				SDL: `
-					type View {
+					type View @materialized(if: false) {
 						name: String
 					}
 				`,
@@ -105,7 +105,7 @@ func TestColDescrUpdateReplaceQuerySourceQueryName(t *testing.T) {
 					}
 				`,
 				SDL: `
-					type View {
+					type View @materialized(if: false) {
 						name: String
 					}
 				`,

--- a/tests/integration/collection_description/updates/replace/query_source_transform_test.go
+++ b/tests/integration/collection_description/updates/replace/query_source_transform_test.go
@@ -58,7 +58,7 @@ func TestColDescrUpdateReplaceQuerySourceTransform(t *testing.T) {
 					}
 				`,
 				SDL: `
-					type UserView {
+					type UserView @materialized(if: false) {
 						fullName: String
 					}
 				`,

--- a/tests/integration/collection_description/updates/replace/view_policy_test.go
+++ b/tests/integration/collection_description/updates/replace/view_policy_test.go
@@ -1,0 +1,95 @@
+// Copyright 2024 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package replace
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/immutable"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+// todo: The inverse of this test is not currently possible, make sure it also is tested when
+// resolving https://github.com/sourcenetwork/defradb/issues/2983
+func TestColDescrUpdateReplaceIsMaterialized_GivenPolicyOnNonMAterializedView_Errors(t *testing.T) {
+	test := testUtils.TestCase{
+		SupportedViewTypes: immutable.Some([]testUtils.ViewType{
+			testUtils.CachelessViewType,
+		}),
+		Actions: []any{
+			testUtils.AddPolicy{
+				Identity: immutable.Some(1),
+				Policy: `
+                    name: test
+                    description: a test policy which marks a collection in a database as a resource
+
+                    actor:
+                      name: actor
+
+                    resources:
+                      userView:
+                        permissions:
+                          read:
+                            expr: owner + reader
+                          write:
+                            expr: owner
+
+                        relations:
+                          owner:
+                            types:
+                              - actor
+                          reader:
+                            types:
+                              - actor
+                          admin:
+                            manages:
+                              - reader
+                            types:
+                              - actor
+                `,
+				ExpectedPolicyID: "7a698a9c5fe74a5854c2e1e8d00c606926c64ad883a157db2f345749e8609fcb",
+			},
+			testUtils.SchemaUpdate{
+				Schema: `
+					type User {
+						name: String
+					}
+				`,
+			},
+			testUtils.CreateView{
+				Query: `
+					User {
+						name
+					}
+				`,
+				SDL: `
+					type UserView @policy(
+						id: "7a698a9c5fe74a5854c2e1e8d00c606926c64ad883a157db2f345749e8609fcb",
+						resource: "userView"
+					) @materialized(if: false) {
+						name: String
+					}
+				`,
+			},
+			testUtils.PatchCollection{
+				Patch: `
+					[
+						{ "op": "replace", "path": "/2/IsMaterialized", "value": true }
+					]
+				`,
+				ExpectedError: "materialized views do not support ACP. Collection: UserView",
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/collection_description/with_default_fields_test.go
+++ b/tests/integration/collection_description/with_default_fields_test.go
@@ -38,7 +38,8 @@ func TestCollectionDescription_WithDefaultFieldValues(t *testing.T) {
 			testUtils.GetCollections{
 				ExpectedResults: []client.CollectionDescription{
 					{
-						Name: immutable.Some("Users"),
+						Name:           immutable.Some("Users"),
+						IsMaterialized: true,
 						Fields: []client.CollectionFieldDescription{
 							{
 								ID:   0,

--- a/tests/integration/explain/debug/with_view_test.go
+++ b/tests/integration/explain/debug/with_view_test.go
@@ -13,6 +13,8 @@ package test_explain_debug
 import (
 	"testing"
 
+	"github.com/sourcenetwork/immutable"
+
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
 )
 
@@ -38,8 +40,8 @@ var viewPattern = dataMap{
 
 func TestDebugExplainRequestWithView(t *testing.T) {
 	test := testUtils.TestCase{
-
-		Description: "Explain (debug) request with view",
+		SupportedViewTypes: immutable.Some([]testUtils.ViewType{testUtils.CachelessViewType}),
+		Description:        "Explain (debug) request with view",
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
@@ -55,7 +57,7 @@ func TestDebugExplainRequestWithView(t *testing.T) {
 					}
 				`,
 				SDL: `
-					type UserView {
+					type UserView @materialized(if: false) {
 						name: String
 					}
 				`,

--- a/tests/integration/explain/debug/with_view_transform_test.go
+++ b/tests/integration/explain/debug/with_view_transform_test.go
@@ -44,8 +44,8 @@ var transformViewPattern = dataMap{
 
 func TestDebugExplainRequestWithViewWithTransform(t *testing.T) {
 	test := testUtils.TestCase{
-
-		Description: "Explain (debug) request with view with transform",
+		SupportedViewTypes: immutable.Some([]testUtils.ViewType{testUtils.CachelessViewType}),
+		Description:        "Explain (debug) request with view with transform",
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
@@ -61,7 +61,7 @@ func TestDebugExplainRequestWithViewWithTransform(t *testing.T) {
 					}
 				`,
 				SDL: `
-					type UserView {
+					type UserView @materialized(if: false) {
 						fullName: String
 					}
 				`,

--- a/tests/integration/index/create_unique_test.go
+++ b/tests/integration/index/create_unique_test.go
@@ -339,7 +339,6 @@ func TestUniqueQueryWithIndex_UponAddingDocWithSameDateTime_Error(t *testing.T) 
 					}`,
 				ExpectedError: db.NewErrCanNotIndexNonUniqueFields(
 					"bae-7e20b26e-5d93-572a-9724-d8f862efbe63",
-					errors.NewKV("birthday", testUtils.MustParseTime("2000-07-23T03:00:00-00:00")),
 				).Error(),
 			},
 		},

--- a/tests/integration/results.go
+++ b/tests/integration/results.go
@@ -208,6 +208,7 @@ func assertCollectionDescriptions(
 		}
 
 		require.Equal(s.t, expected.Name, actual.Name)
+		require.Equal(s.t, expected.IsMaterialized, actual.IsMaterialized)
 
 		if expected.Indexes != nil || len(actual.Indexes) != 0 {
 			// Dont bother asserting this if the expected is nil and the actual is nil/empty.
@@ -215,7 +216,7 @@ func assertCollectionDescriptions(
 			require.Equal(s.t, expected.Indexes, actual.Indexes)
 		}
 
-		if expected.Sources != nil || len(actual.Sources) != 0 {
+		if expected.Sources != nil {
 			// Dont bother asserting this if the expected is nil and the actual is nil/empty.
 			// This is to save each test action from having to bother declaring an empty slice (if there are no sources)
 			require.Equal(s.t, expected.Sources, actual.Sources)

--- a/tests/integration/schema/migrations/simple_test.go
+++ b/tests/integration/schema/migrations/simple_test.go
@@ -52,10 +52,12 @@ func TestSchemaMigrationDoesNotErrorGivenUnknownSchemaRoots(t *testing.T) {
 					{
 						ID:              1,
 						SchemaVersionID: "does not exist",
+						IsMaterialized:  true,
 					},
 					{
 						ID:              2,
 						SchemaVersionID: "also does not exist",
+						IsMaterialized:  true,
 						Sources: []any{
 							&client.CollectionSource{
 								SourceCollectionID: 1,
@@ -129,10 +131,12 @@ func TestSchemaMigrationGetMigrationsReturnsMultiple(t *testing.T) {
 					{
 						ID:              1,
 						SchemaVersionID: "does not exist",
+						IsMaterialized:  true,
 					},
 					{
 						ID:              2,
 						SchemaVersionID: "also does not exist",
+						IsMaterialized:  true,
 						Sources: []any{
 							&client.CollectionSource{
 								SourceCollectionID: 1,
@@ -154,10 +158,12 @@ func TestSchemaMigrationGetMigrationsReturnsMultiple(t *testing.T) {
 					},
 					{
 						ID:              3,
+						IsMaterialized:  true,
 						SchemaVersionID: "bafkreia3o3cetvcnnxyu5spucimoos77ifungfmacxdkva4zah2is3aooe",
 					},
 					{
 						ID:              4,
+						IsMaterialized:  true,
 						SchemaVersionID: "bafkreiahhaeagyfsxaxmv3d665qvnbtyn3ts6jshhghy5bijwztbe7efpq",
 						Sources: []any{
 							&client.CollectionSource{
@@ -233,10 +239,12 @@ func TestSchemaMigrationReplacesExistingMigationBasedOnSourceID(t *testing.T) {
 					{
 						ID:              1,
 						SchemaVersionID: "a",
+						IsMaterialized:  true,
 					},
 					{
 						ID:              2,
 						SchemaVersionID: "b",
+						IsMaterialized:  true,
 						Sources: []any{
 							&client.CollectionSource{
 								SourceCollectionID: 1,
@@ -259,6 +267,7 @@ func TestSchemaMigrationReplacesExistingMigationBasedOnSourceID(t *testing.T) {
 					{
 						ID:              3,
 						SchemaVersionID: "c",
+						IsMaterialized:  true,
 						Sources: []any{
 							&client.CollectionSource{
 								SourceCollectionID: 1,

--- a/tests/integration/schema/migrations/with_txn_test.go
+++ b/tests/integration/schema/migrations/with_txn_test.go
@@ -52,10 +52,12 @@ func TestSchemaMigrationGetMigrationsWithTxn(t *testing.T) {
 					{
 						ID:              1,
 						SchemaVersionID: "does not exist",
+						IsMaterialized:  true,
 					},
 					{
 						ID:              2,
 						SchemaVersionID: "also does not exist",
+						IsMaterialized:  true,
 						Sources: []any{
 							&client.CollectionSource{
 								SourceCollectionID: 1,

--- a/tests/integration/schema/one_many_test.go
+++ b/tests/integration/schema/one_many_test.go
@@ -36,7 +36,8 @@ func TestSchemaOneMany_Primary(t *testing.T) {
 				`,
 				ExpectedResults: []client.CollectionDescription{
 					{
-						Name: immutable.Some("User"),
+						Name:           immutable.Some("User"),
+						IsMaterialized: true,
 						Fields: []client.CollectionFieldDescription{
 							{
 								Name: "_docID",
@@ -54,7 +55,8 @@ func TestSchemaOneMany_Primary(t *testing.T) {
 						},
 					},
 					{
-						Name: immutable.Some("Dog"),
+						Name:           immutable.Some("Dog"),
+						IsMaterialized: true,
 						Fields: []client.CollectionFieldDescription{
 							{
 								Name: "_docID",
@@ -97,7 +99,8 @@ func TestSchemaOneMany_SelfReferenceOneFieldLexographicallyFirst(t *testing.T) {
 				`,
 				ExpectedResults: []client.CollectionDescription{
 					{
-						Name: immutable.Some("User"),
+						Name:           immutable.Some("User"),
+						IsMaterialized: true,
 						Fields: []client.CollectionFieldDescription{
 							{
 								Name: "_docID",
@@ -142,7 +145,8 @@ func TestSchemaOneMany_SelfReferenceManyFieldLexographicallyFirst(t *testing.T) 
 				`,
 				ExpectedResults: []client.CollectionDescription{
 					{
-						Name: immutable.Some("User"),
+						Name:           immutable.Some("User"),
+						IsMaterialized: true,
 						Fields: []client.CollectionFieldDescription{
 							{
 								Name: "_docID",
@@ -192,7 +196,8 @@ func TestSchemaOneMany_SelfUsingActualName(t *testing.T) {
 			testUtils.GetCollections{
 				ExpectedResults: []client.CollectionDescription{
 					{
-						Name: immutable.Some("User"),
+						Name:           immutable.Some("User"),
+						IsMaterialized: true,
 						Fields: []client.CollectionFieldDescription{
 							{
 								Name: request.DocIDFieldName,

--- a/tests/integration/schema/one_one_test.go
+++ b/tests/integration/schema/one_one_test.go
@@ -80,7 +80,8 @@ func TestSchemaOneOne_SelfUsingActualName(t *testing.T) {
 			testUtils.GetCollections{
 				ExpectedResults: []client.CollectionDescription{
 					{
-						Name: immutable.Some("User"),
+						Name:           immutable.Some("User"),
+						IsMaterialized: true,
 						Fields: []client.CollectionFieldDescription{
 							{
 								Name: request.DocIDFieldName,

--- a/tests/integration/schema/simple_test.go
+++ b/tests/integration/schema/simple_test.go
@@ -31,7 +31,8 @@ func TestSchemaSimpleCreatesSchemaGivenEmptyType(t *testing.T) {
 				`,
 				ExpectedResults: []client.CollectionDescription{
 					{
-						Name: immutable.Some("Users"),
+						Name:           immutable.Some("Users"),
+						IsMaterialized: true,
 						Fields: []client.CollectionFieldDescription{
 							{
 								Name: request.DocIDFieldName,

--- a/tests/integration/schema/updates/with_schema_branch_test.go
+++ b/tests/integration/schema/updates/with_schema_branch_test.go
@@ -139,12 +139,14 @@ func TestSchemaUpdates_WithBranchingSchema(t *testing.T) {
 						// The original collection version is present, it has no source and is inactive (has no name).
 						ID:              1,
 						SchemaVersionID: schemaVersion1ID,
+						IsMaterialized:  true,
 					},
 					{
 						// The collection version for schema version 2 is present, it has the first collection as a source
 						// and is inactive.
 						ID:              2,
 						SchemaVersionID: schemaVersion2ID,
+						IsMaterialized:  true,
 						Sources: []any{
 							&client.CollectionSource{
 								SourceCollectionID: 1,
@@ -157,6 +159,7 @@ func TestSchemaUpdates_WithBranchingSchema(t *testing.T) {
 						ID:              3,
 						Name:            immutable.Some("Users"),
 						SchemaVersionID: schemaVersion3ID,
+						IsMaterialized:  true,
 						Sources: []any{
 							&client.CollectionSource{
 								SourceCollectionID: 1,
@@ -268,12 +271,14 @@ func TestSchemaUpdates_WithPatchOnBranchedSchema(t *testing.T) {
 						// The original collection version is present, it has no source and is inactive (has no name).
 						ID:              1,
 						SchemaVersionID: schemaVersion1ID,
+						IsMaterialized:  true,
 					},
 					{
 						// The collection version for schema version 2 is present, it has the first collection as a source
 						// and is inactive.
 						ID:              2,
 						SchemaVersionID: schemaVersion2ID,
+						IsMaterialized:  true,
 						Sources: []any{
 							&client.CollectionSource{
 								SourceCollectionID: 1,
@@ -285,6 +290,7 @@ func TestSchemaUpdates_WithPatchOnBranchedSchema(t *testing.T) {
 						// as source.
 						ID:              3,
 						SchemaVersionID: schemaVersion3ID,
+						IsMaterialized:  true,
 						Sources: []any{
 							&client.CollectionSource{
 								SourceCollectionID: 1,
@@ -297,6 +303,7 @@ func TestSchemaUpdates_WithPatchOnBranchedSchema(t *testing.T) {
 						ID:              4,
 						Name:            immutable.Some("Users"),
 						SchemaVersionID: schemaVersion4ID,
+						IsMaterialized:  true,
 						Sources: []any{
 							&client.CollectionSource{
 								SourceCollectionID: 3,
@@ -378,12 +385,14 @@ func TestSchemaUpdates_WithBranchingSchemaAndSetActiveSchemaToOtherBranch(t *tes
 						// The original collection version is present, it has no source and is inactive (has no name).
 						ID:              1,
 						SchemaVersionID: schemaVersion1ID,
+						IsMaterialized:  true,
 					},
 					{
 						// The collection version for schema version 2 is present and is active, it has the first collection as a source
 						ID:              2,
 						Name:            immutable.Some("Users"),
 						SchemaVersionID: schemaVersion2ID,
+						IsMaterialized:  true,
 						Sources: []any{
 							&client.CollectionSource{
 								SourceCollectionID: 1,
@@ -395,6 +404,7 @@ func TestSchemaUpdates_WithBranchingSchemaAndSetActiveSchemaToOtherBranch(t *tes
 						// as source.
 						ID:              3,
 						SchemaVersionID: schemaVersion3ID,
+						IsMaterialized:  true,
 						Sources: []any{
 							&client.CollectionSource{
 								SourceCollectionID: 1,
@@ -510,12 +520,14 @@ func TestSchemaUpdates_WithBranchingSchemaAndSetActiveSchemaToOtherBranchThenPat
 						// The original collection version is present, it has no source and is inactive (has no name).
 						ID:              1,
 						SchemaVersionID: schemaVersion1ID,
+						IsMaterialized:  true,
 					},
 					{
 						// The collection version for schema version 2 is present, it has the first collection as a source
 						// and is inactive.
 						ID:              2,
 						SchemaVersionID: schemaVersion2ID,
+						IsMaterialized:  true,
 						Sources: []any{
 							&client.CollectionSource{
 								SourceCollectionID: 1,
@@ -527,6 +539,7 @@ func TestSchemaUpdates_WithBranchingSchemaAndSetActiveSchemaToOtherBranchThenPat
 						// as source.
 						ID:              3,
 						SchemaVersionID: schemaVersion3ID,
+						IsMaterialized:  true,
 						Sources: []any{
 							&client.CollectionSource{
 								SourceCollectionID: 1,
@@ -539,6 +552,7 @@ func TestSchemaUpdates_WithBranchingSchemaAndSetActiveSchemaToOtherBranchThenPat
 						ID:              4,
 						Name:            immutable.Some("Users"),
 						SchemaVersionID: schemaVersion4ID,
+						IsMaterialized:  true,
 						Sources: []any{
 							&client.CollectionSource{
 								SourceCollectionID: 2,
@@ -584,6 +598,7 @@ collection at a specific version`,
 						// The original collection version is present, it has no source and is inactive (has no name).
 						ID:              1,
 						SchemaVersionID: schemaVersion1ID,
+						IsMaterialized:  true,
 					},
 				},
 			},

--- a/tests/integration/test_case.go
+++ b/tests/integration/test_case.go
@@ -52,6 +52,13 @@ type TestCase struct {
 	// This is to only be used in the very rare cases where we really do want behavioural
 	// differences between acp types, or we need to temporarily document a bug.
 	SupportedACPTypes immutable.Option[[]ACPType]
+
+	// If provided a value, SupportedACPTypes will cause this test to be skipped
+	// if the active view type is not within the given set.
+	//
+	// This is to only be used in the very rare cases where we really do want behavioural
+	// differences between view types, or we need to temporarily document a bug.
+	SupportedViewTypes immutable.Option[[]ViewType]
 }
 
 // SetupComplete is a flag to explicitly notify the change detector at which point
@@ -212,6 +219,22 @@ type CreateView struct {
 
 	// An optional Lens transform to add to the view.
 	Transform immutable.Option[model.Lens]
+
+	// Any error expected from the action. Optional.
+	//
+	// String can be a partial, and the test will pass if an error is returned that
+	// contains this string.
+	ExpectedError string
+}
+
+type RefreshViews struct {
+	// NodeID may hold the ID (index) of a node to create this View on.
+	//
+	// If a value is not provided the view will be created on all nodes.
+	NodeID immutable.Option[int]
+
+	// The set of fetch options for the views.
+	FilterOptions client.CollectionFetchOptions
 
 	// Any error expected from the action. Optional.
 	//

--- a/tests/integration/test_case.go
+++ b/tests/integration/test_case.go
@@ -227,6 +227,7 @@ type CreateView struct {
 	ExpectedError string
 }
 
+// RefreshViews action will execute a call to `store.RefreshViews` using the provided options.
 type RefreshViews struct {
 	// NodeID may hold the ID (index) of a node to create this View on.
 	//

--- a/tests/integration/view/one_to_many/simple_test.go
+++ b/tests/integration/view/one_to_many/simple_test.go
@@ -42,7 +42,7 @@ func TestView_OneToMany(t *testing.T) {
 					}
 				`,
 				SDL: `
-					type AuthorView {
+					type AuthorView @materialized(if: false) {
 						name: String
 						books: [BookView]
 					}
@@ -118,7 +118,7 @@ func TestView_OneToManyWithMixedSDL_Errors(t *testing.T) {
 					}
 				`,
 				SDL: `
-					type AuthorView {
+					type AuthorView @materialized(if: false) {
 						name: String
 						books: [Book]
 					}
@@ -157,7 +157,7 @@ func TestView_OneToManyFromInnerSide_Errors(t *testing.T) {
 					}
 				`,
 				SDL: `
-					type AuthorView {
+					type AuthorView @materialized(if: false) {
 						name: String
 						books: [BookView]
 					}
@@ -212,7 +212,7 @@ func TestView_OneToManyOuterToInnerToOuter_Errors(t *testing.T) {
 					}
 				`,
 				SDL: `
-					type AuthorView {
+					type AuthorView @materialized(if: false) {
 						name: String
 						books: [BookView]
 					}
@@ -268,7 +268,7 @@ func TestView_OneToManyWithRelationInQueryButNotInSDL(t *testing.T) {
 					}
 				`,
 				SDL: `
-					type AuthorView {
+					type AuthorView @materialized(if: false) {
 						name: String
 					}
 				`,
@@ -333,7 +333,7 @@ func TestView_OneToManyMultipleViewsWithEmbeddedSchema(t *testing.T) {
 					}
 				`,
 				SDL: `
-					type BookView {
+					type BookView @materialized(if: false) {
 						name: String
 						author: AuthorView
 					}
@@ -352,7 +352,7 @@ func TestView_OneToManyMultipleViewsWithEmbeddedSchema(t *testing.T) {
 					}
 				`,
 				SDL: `
-					type BookView2 {
+					type BookView2 @materialized(if: false) {
 						name: String
 						author: AuthorView2
 					}
@@ -393,7 +393,7 @@ func TestView_OneToManyWithDoubleSidedRelation_Errors(t *testing.T) {
 					}
 				`,
 				SDL: `
-					type AuthorView {
+					type AuthorView @materialized(if: false) {
 						name: String
 						books: [BookView]
 					}
@@ -402,25 +402,26 @@ func TestView_OneToManyWithDoubleSidedRelation_Errors(t *testing.T) {
 					}
 				`,
 			},
-			testUtils.CreateView{
-				Query: `
-					AuthorView {
-						name
-						books {
+			/*
+				testUtils.CreateView{
+					Query: `
+						AuthorView {
 							name
+							books {
+								name
+							}
 						}
-					}
-				`,
-				SDL: `
-					type AuthorViewView {
-						name: String
-						books: [BookViewView]
-					}
-					interface BookViewView {
-						name: String
-					}
-				`,
-			},
+					`,
+					SDL: `
+						type AuthorViewView @materialized(if: false) {
+							name: String
+							books: [BookViewView]
+						}
+						interface BookViewView {
+							name: String
+						}
+					`,
+				},*/
 			testUtils.CreateDoc{
 				CollectionID: 0,
 				Doc: `{
@@ -436,7 +437,7 @@ func TestView_OneToManyWithDoubleSidedRelation_Errors(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: `query {
-							AuthorViewView {
+							AuthorView {
 								name
 								books {
 									name
@@ -444,7 +445,7 @@ func TestView_OneToManyWithDoubleSidedRelation_Errors(t *testing.T) {
 							}
 						}`,
 				Results: map[string]any{
-					"AuthorViewView": []map[string]any{
+					"AuthorView": []map[string]any{
 						{
 							"name": "Harper Lee",
 							"books": []map[string]any{

--- a/tests/integration/view/one_to_many/simple_test.go
+++ b/tests/integration/view/one_to_many/simple_test.go
@@ -402,26 +402,25 @@ func TestView_OneToManyWithDoubleSidedRelation_Errors(t *testing.T) {
 					}
 				`,
 			},
-			/*
-				testUtils.CreateView{
-					Query: `
-						AuthorView {
+			testUtils.CreateView{
+				Query: `
+					AuthorView {
+						name
+						books {
 							name
-							books {
-								name
-							}
 						}
-					`,
-					SDL: `
-						type AuthorViewView @materialized(if: false) {
-							name: String
-							books: [BookViewView]
-						}
-						interface BookViewView {
-							name: String
-						}
-					`,
-				},*/
+					}
+				`,
+				SDL: `
+					type AuthorViewView @materialized(if: false) {
+						name: String
+						books: [BookViewView]
+					}
+					interface BookViewView {
+						name: String
+					}
+				`,
+			},
 			testUtils.CreateDoc{
 				CollectionID: 0,
 				Doc: `{
@@ -437,7 +436,7 @@ func TestView_OneToManyWithDoubleSidedRelation_Errors(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: `query {
-							AuthorView {
+							AuthorViewView {
 								name
 								books {
 									name
@@ -445,7 +444,7 @@ func TestView_OneToManyWithDoubleSidedRelation_Errors(t *testing.T) {
 							}
 						}`,
 				Results: map[string]any{
-					"AuthorView": []map[string]any{
+					"AuthorViewView": []map[string]any{
 						{
 							"name": "Harper Lee",
 							"books": []map[string]any{

--- a/tests/integration/view/one_to_many/with_alias_test.go
+++ b/tests/integration/view/one_to_many/with_alias_test.go
@@ -42,7 +42,7 @@ func TestView_OneToManyWithAliasOnOuter(t *testing.T) {
 					}
 				`,
 				SDL: `
-					type AuthorView {
+					type AuthorView @materialized(if: false) {
 						fullName: String
 						books: [BookView]
 					}
@@ -118,7 +118,7 @@ func TestView_OneToManyWithAliasOnInner(t *testing.T) {
 					}
 				`,
 				SDL: `
-					type AuthorView {
+					type AuthorView @materialized(if: false) {
 						name: String
 						books: [BookView]
 					}

--- a/tests/integration/view/one_to_many/with_count_test.go
+++ b/tests/integration/view/one_to_many/with_count_test.go
@@ -42,7 +42,7 @@ func TestView_OneToManyWithCount_Errors(t *testing.T) {
 					}
 				`,
 				SDL: `
-					type AuthorView {
+					type AuthorView @materialized(if: false) {
 						name: String
 						_count: Int
 					}
@@ -108,7 +108,7 @@ func TestView_OneToManyWithAliasedCount(t *testing.T) {
 					}
 				`,
 				SDL: `
-					type AuthorView {
+					type AuthorView @materialized(if: false) {
 						name: String
 						numberOfBooks: Int
 					}
@@ -182,7 +182,7 @@ func TestView_OneToManyWithCountInQueryButNotSDL(t *testing.T) {
 					}
 				`,
 				SDL: `
-					type AuthorView {
+					type AuthorView @materialized(if: false) {
 						name: String
 					}
 				`,

--- a/tests/integration/view/one_to_many/with_introspection_test.go
+++ b/tests/integration/view/one_to_many/with_introspection_test.go
@@ -43,7 +43,7 @@ func TestView_OneToMany_GQLIntrospectionTest(t *testing.T) {
 					}
 				`,
 				SDL: `
-					type AuthorView {
+					type AuthorView @materialized(if: false) {
 						name: String
 						books: [BookView]
 					}

--- a/tests/integration/view/one_to_many/with_transform_test.go
+++ b/tests/integration/view/one_to_many/with_transform_test.go
@@ -46,7 +46,7 @@ func TestView_OneToManyWithTransformOnOuter(t *testing.T) {
 					}
 				`,
 				SDL: `
-					type AuthorView {
+					type AuthorView @materialized(if: false) {
 						fullName: String
 						books: [BookView]
 					}
@@ -96,8 +96,8 @@ func TestView_OneToManyWithTransformOnOuter(t *testing.T) {
 					"AuthorView": []map[string]any{
 						{
 							"fullName": "Ferdowsi",
-							"books": []any{
-								map[string]any{
+							"books": []map[string]any{
+								{
 									"name": "Shahnameh",
 								},
 							},
@@ -129,7 +129,7 @@ func TestView_OneToManyWithTransformAddingInnerDocs(t *testing.T) {
 					}
 				`,
 				SDL: `
-					type AuthorView {
+					type AuthorView @materialized(if: false) {
 						name: String
 						books: [BookView]
 					}
@@ -177,11 +177,11 @@ func TestView_OneToManyWithTransformAddingInnerDocs(t *testing.T) {
 					"AuthorView": []map[string]any{
 						{
 							"name": "Ferdowsi",
-							"books": []any{
-								map[string]any{
+							"books": []map[string]any{
+								{
 									"name": "The Tragedy of Sohrab and Rostam",
 								},
-								map[string]any{
+								{
 									"name": "The Legend of Seyavash",
 								},
 							},

--- a/tests/integration/view/one_to_one/identical_schema_test.go
+++ b/tests/integration/view/one_to_one/identical_schema_test.go
@@ -46,7 +46,7 @@ func TestView_OneToOneSameSchema(t *testing.T) {
 				// todo - such a setup appears to work, yet prevents the querying of `RightHand`s as the primary return object
 				// thought - although, perhaps if the view is defined as such, Left and right hands *could* be merged by us into a single table
 				SDL: `
-					type HandView {
+					type HandView @materialized(if: false) {
 						name: String
 						holding: HandView @primary
 						heldBy: HandView
@@ -120,7 +120,7 @@ func TestView_OneToOneEmbeddedSchemaIsNotLostOnNextUpdate(t *testing.T) {
 					}
 				`,
 				SDL: `
-					type AuthorView {
+					type AuthorView @materialized(if: false) {
 						name: String
 						books: [BookView]
 					}

--- a/tests/integration/view/one_to_one/simple_test.go
+++ b/tests/integration/view/one_to_one/simple_test.go
@@ -42,7 +42,7 @@ func TestView_OneToOneDuplicateEmbeddedSchema_Errors(t *testing.T) {
 					}
 				`,
 				SDL: `
-					type AuthorView {
+					type AuthorView @materialized(if: false) {
 						name: String
 						books: [BookView]
 					}
@@ -63,7 +63,7 @@ func TestView_OneToOneDuplicateEmbeddedSchema_Errors(t *testing.T) {
 					}
 				`,
 				SDL: `
-					type AuthorAliasView {
+					type AuthorAliasView @materialized(if: false) {
 						authorName: String
 						books: [BookView]
 					}

--- a/tests/integration/view/one_to_one/with_restart_test.go
+++ b/tests/integration/view/one_to_one/with_restart_test.go
@@ -42,7 +42,7 @@ func TestView_OneToOneEmbeddedSchemaIsNotLostORestart(t *testing.T) {
 					}
 				`,
 				SDL: `
-					type AuthorView {
+					type AuthorView @materialized(if: false) {
 						name: String
 						books: [BookView]
 					}

--- a/tests/integration/view/one_to_one/with_transform_test.go
+++ b/tests/integration/view/one_to_one/with_transform_test.go
@@ -46,7 +46,7 @@ func TestView_OneToOneWithTransformOnOuter(t *testing.T) {
 					}
 				`,
 				SDL: `
-					type AuthorView {
+					type AuthorView @materialized(if: false) {
 						fullName: String
 						book: BookView
 					}

--- a/tests/integration/view/simple/materialized_test.go
+++ b/tests/integration/view/simple/materialized_test.go
@@ -1,0 +1,129 @@
+// Copyright 2024 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package simple
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/immutable"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+func TestView_SimpleMaterialized_DoesNotAutoUpdateOnViewCreate(t *testing.T) {
+	test := testUtils.TestCase{
+		SupportedViewTypes: immutable.Some([]testUtils.ViewType{
+			// As the MaterializedViewType will auto refresh views immediately prior
+			// to executing requests, this test of materialized views actually only
+			// supports running with the CachelessViewType flag.
+			testUtils.CachelessViewType,
+		}),
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type User {
+						name: String
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
+					"name":	"John"
+				}`,
+			},
+			testUtils.CreateView{
+				Query: `
+					User {
+						name
+					}
+				`,
+				SDL: `
+					type UserView {
+						name: String
+					}
+				`,
+			},
+			testUtils.Request{
+				Request: `query {
+							UserView {
+								name
+							}
+						}`,
+				Results: map[string]any{
+					// Even though UserView was created after the document was created, the results are
+					// empty because the view will not populate until RefreshView is called.
+					"UserView": []map[string]any{},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestView_SimpleMaterialized_DoesNotAutoUpdate(t *testing.T) {
+	test := testUtils.TestCase{
+		SupportedViewTypes: immutable.Some([]testUtils.ViewType{
+			// As the MaterializedViewType will auto refresh views immediately prior
+			// to executing requests, this test of materialized views actually only
+			// supports running with the CachelessViewType flag.
+			testUtils.CachelessViewType,
+		}),
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type User {
+						name: String
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
+					"name":	"John"
+				}`,
+			},
+			testUtils.CreateView{
+				Query: `
+					User {
+						name
+					}
+				`,
+				SDL: `
+					type UserView {
+						name: String
+					}
+				`,
+			},
+			testUtils.RefreshViews{},
+			testUtils.CreateDoc{
+				Doc: `{
+					"name":	"Fred"
+				}`,
+			},
+			testUtils.Request{
+				Request: `query {
+							UserView {
+								name
+							}
+						}`,
+				Results: map[string]any{
+					"UserView": []map[string]any{
+						{
+							"name": "John",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/view/simple/simple_test.go
+++ b/tests/integration/view/simple/simple_test.go
@@ -34,7 +34,7 @@ func TestView_Simple(t *testing.T) {
 					}
 				`,
 				SDL: `
-					type UserView {
+					type UserView @materialized(if: false) {
 						name: String
 					}
 				`,
@@ -82,7 +82,7 @@ func TestView_SimpleMultipleDocs(t *testing.T) {
 					}
 				`,
 				SDL: `
-					type UserView {
+					type UserView @materialized(if: false) {
 						name: String
 					}
 				`,
@@ -139,7 +139,7 @@ func TestView_SimpleWithFieldSubset_ErrorsSelectingExcludedField(t *testing.T) {
 					}
 				`,
 				SDL: `
-					type UserView {
+					type UserView @materialized(if: false) {
 						name: String
 					}
 				`,
@@ -185,7 +185,7 @@ func TestView_SimpleWithExtraFieldInViewSDL(t *testing.T) {
 				`,
 				// `age` is present in SDL but not the query
 				SDL: `
-					type UserView {
+					type UserView @materialized(if: false) {
 						name: String
 						age: Int
 					}
@@ -237,7 +237,7 @@ func TestView_SimpleWithExtraFieldInViewQuery(t *testing.T) {
 					}
 				`,
 				SDL: `
-					type UserView {
+					type UserView @materialized(if: false) {
 						name: String
 					}
 				`,
@@ -287,7 +287,7 @@ func TestView_SimpleViewOfView(t *testing.T) {
 					}
 				`,
 				SDL: `
-					type UserView {
+					type UserView @materialized(if: false) {
 						name: String
 					}
 				`,
@@ -299,7 +299,7 @@ func TestView_SimpleViewOfView(t *testing.T) {
 					}
 				`,
 				SDL: `
-					type UserViewView {
+					type UserViewView @materialized(if: false) {
 						name: String
 					}
 				`,

--- a/tests/integration/view/simple/with_alias_test.go
+++ b/tests/integration/view/simple/with_alias_test.go
@@ -34,7 +34,7 @@ func TestView_SimpleWithAlias(t *testing.T) {
 					}
 				`,
 				SDL: `
-					type UserView {
+					type UserView @materialized(if: false) {
 						fullname: String
 					}
 				`,

--- a/tests/integration/view/simple/with_default_value_test.go
+++ b/tests/integration/view/simple/with_default_value_test.go
@@ -34,7 +34,7 @@ func TestView_SimpleWithDefaultValue_DoesNotSetFieldValue(t *testing.T) {
 					}
 				`,
 				SDL: `
-					type UserView {
+					type UserView @materialized(if: false) {
 						name: String
 						age: Int @default(int: 40)
 					}

--- a/tests/integration/view/simple/with_filter_test.go
+++ b/tests/integration/view/simple/with_filter_test.go
@@ -34,7 +34,7 @@ func TestView_SimpleWithFilter(t *testing.T) {
 					}
 				`,
 				SDL: `
-					type UserView {
+					type UserView @materialized(if: false) {
 						name: String
 					}
 				`,
@@ -91,7 +91,7 @@ func TestView_SimpleWithFilterOnViewAndQuery(t *testing.T) {
 					}
 				`,
 				SDL: `
-					type UserView {
+					type UserView @materialized(if: false) {
 						name: String
 						age: Int
 					}

--- a/tests/integration/view/simple/with_introspection_test.go
+++ b/tests/integration/view/simple/with_introspection_test.go
@@ -35,7 +35,7 @@ func TestView_Simple_GQLIntrospectionTest(t *testing.T) {
 					}
 				`,
 				SDL: `
-					type UserView {
+					type UserView @materialized(if: false) {
 						name: String
 					}
 				`,

--- a/tests/integration/view/simple/with_transform_test.go
+++ b/tests/integration/view/simple/with_transform_test.go
@@ -38,7 +38,7 @@ func TestView_SimpleWithTransform(t *testing.T) {
 					}
 				`,
 				SDL: `
-					type UserView {
+					type UserView @materialized(if: false) {
 						fullName: String
 					}
 				`,
@@ -111,7 +111,7 @@ func TestView_SimpleWithMultipleTransforms(t *testing.T) {
 					}
 				`,
 				SDL: `
-					type UserView {
+					type UserView @materialized(if: false) {
 						fullName: String
 						age: Int
 					}
@@ -196,7 +196,7 @@ func TestView_SimpleWithTransformReturningMoreDocsThanInput(t *testing.T) {
 					}
 				`,
 				SDL: `
-					type UserView {
+					type UserView @materialized(if: false) {
 						name: String
 					}
 				`,
@@ -271,7 +271,7 @@ func TestView_SimpleWithTransformReturningFewerDocsThanInput(t *testing.T) {
 					}
 				`,
 				SDL: `
-					type UserView {
+					type UserView @materialized(if: false) {
 						name: String
 					}
 				`,


### PR DESCRIPTION
## Relevant issue(s)

Resolves #2951

## Description

Adds materialized views.  Also makes materialized views the default (see discord discussion).

The caching behaviour of views in tests is now selected via an environment variable, meaning (with the exception of a few specific examples) a test with a view will test both cacheless and materialized variants - in the CI this adds a new dimension to the matrix, although materialized views are only executed using the simple settings (in-mem store, go client, etc) for now.

https://github.com/sourcenetwork/defradb/issues/2999 has been mostly fixed in this PR, but not completely - this is why some logic in the lens node has changed.