### PR TITLE
ci(i): Fix view-type typo to avoid coverage file name clash

### DIFF
--- a/.github/workflows/test-and-upload-coverage.yml
+++ b/.github/workflows/test-and-upload-coverage.yml
@@ -222,7 +222,7 @@ jobs:
             _${{ matrix.mutation-type }}\
             _${{ matrix.lens-type }}\
             _${{ matrix.acp-type }}\
-            _${{ matrix.matrix.view-type }}\
+            _${{ matrix.view-type }}\
             _${{ matrix.database-encryption }}\
           "
           path: coverage.txt


### PR DESCRIPTION
## Relevant issue(s)

Resolves #3014 

## Description

Failed run due to code-cov upload file's name clashing:
https://github.com/sourcenetwork/defradb/actions/runs/10893445627/job/30228379591

Happened in merge commit: [#4989901](https://github.com/sourcenetwork/defradb/commit/49899011a75999543b246d9a852526aa96f60e5c)

Just needed to fix the typo introduced in [`15f244d` (#3000)](https://github.com/sourcenetwork/defradb/pull/3000/commits/15f244d313e33abfa3704cc966560db6cb36276b)

Should be `matrix.view-type` not `matrix.matrix.view-type`, my bad I missed it even while re-reviewing.
