### PR TITLE
fix: Handle missing type in an SDL

### DIFF
--- a/internal/request/graphql/schema/errors.go
+++ b/internal/request/graphql/schema/errors.go
@@ -32,6 +32,7 @@ const (
 	errPolicyInvalidResourceProp     string = "policy directive with invalid resource property"
 	errDefaultValueInvalid           string = "default value type must match field type"
 	errDefaultValueNotAllowed        string = "default value is not allowed for this field type"
+	errFieldTypeNotSpecified         string = "field type not specified"
 )
 
 var (
@@ -58,6 +59,7 @@ var (
 	ErrPolicyWithUnknownArg      = errors.New(errPolicyUnknownArgument)
 	ErrPolicyInvalidIDProp       = errors.New(errPolicyInvalidIDProp)
 	ErrPolicyInvalidResourceProp = errors.New(errPolicyInvalidResourceProp)
+	ErrFieldTypeNotSpecified     = errors.New(errFieldTypeNotSpecified)
 )
 
 func NewErrDuplicateField(objectName, fieldName string) error {
@@ -153,5 +155,13 @@ func NewErrDefaultValueNotAllowed(fieldName, fieldType string) error {
 		errDefaultValueNotAllowed,
 		errors.NewKV("Name", fieldName),
 		errors.NewKV("Type", fieldType),
+	)
+}
+
+func NewErrFieldTypeNotSpecified(objectName, fieldName string) error {
+	return errors.New(
+		errFieldTypeNotSpecified,
+		errors.NewKV("Object", objectName),
+		errors.NewKV("Field", fieldName),
 	)
 }

--- a/tests/integration/schema/nil_type_test.go
+++ b/tests/integration/schema/nil_type_test.go
@@ -13,8 +13,6 @@ package schema
 import (
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
 )
 
@@ -27,14 +25,10 @@ func TestSchema_WithMissingType_Errors(t *testing.T) {
 						name:
 					}
 				`,
+				ExpectedError: "field type not specified. Object: User, Field: name",
 			},
 		},
 	}
 
-	require.Panics(
-		t,
-		func() {
-			testUtils.ExecuteTestCase(t, test)
-		},
-	)
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/schema/nil_type_test.go
+++ b/tests/integration/schema/nil_type_test.go
@@ -1,0 +1,40 @@
+// Copyright 2024 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package schema
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+func TestSchema_WithMissingType_Errors(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type User {
+						name:
+					}
+				`,
+			},
+		},
+	}
+
+	require.Panics(
+		t,
+		func() {
+			testUtils.ExecuteTestCase(t, test)
+		},
+	)
+}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #3022

## Description

Handles missing type in an SDL instead of panicing.