### PR TITLE
chore: Make keyring non-interactive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ crash.log
 
 # Ignore .zip files, such as Lambda Function code slugs.
 **.zip
+
+# Ignore .env files containing sensitive information.
+.env

--- a/README.md
+++ b/README.md
@@ -68,7 +68,11 @@ The following keys are loaded from the keyring on start:
 - `peer-key` Ed25519 private key (required)
 - `encryption-key` AES-128, AES-192, or AES-256 key (optional)
 
-To randomly generate the required keys, run the following command:
+A secret to unlock the keyring is required on start and must be provided via the `DEFRADB_KEYRING_SECRET` environment variable. If a `.env` file is available at the root of the project, the secret can be stored there.
+
+The keys will be randomly generated on the inital start of the node if they are not found.
+
+Alternatively, to randomly generate the required keys, run the following command:
 
 ```
 defradb keyring generate

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The following keys are loaded from the keyring on start:
 - `peer-key` Ed25519 private key (required)
 - `encryption-key` AES-128, AES-192, or AES-256 key (optional)
 
-A secret to unlock the keyring is required on start and must be provided via the `DEFRADB_KEYRING_SECRET` environment variable. If a `.env` file is available at the root of the project, the secret can be stored there.
+A secret to unlock the keyring is required on start and must be provided via the `DEFRADB_KEYRING_SECRET` environment variable. If a `.env` file is available in the working directory, the secret can be stored there or via a file at a path defined by the `--keyring-secret-file` flag.
 
 The keys will be randomly generated on the inital start of the node if they are not found.
 

--- a/cli/config.go
+++ b/cli/config.go
@@ -43,30 +43,31 @@ var configPaths = []string{
 
 // configFlags is a mapping of cli flag names to config keys to bind.
 var configFlags = map[string]string{
-	"log-level":          "log.level",
-	"log-output":         "log.output",
-	"log-format":         "log.format",
-	"log-stacktrace":     "log.stacktrace",
-	"log-source":         "log.source",
-	"log-overrides":      "log.overrides",
-	"no-log-color":       "log.colordisabled",
-	"url":                "api.address",
-	"max-txn-retries":    "datastore.maxtxnretries",
-	"store":              "datastore.store",
-	"valuelogfilesize":   "datastore.badger.valuelogfilesize",
-	"peers":              "net.peers",
-	"p2paddr":            "net.p2paddresses",
-	"no-p2p":             "net.p2pdisabled",
-	"allowed-origins":    "api.allowed-origins",
-	"pubkeypath":         "api.pubkeypath",
-	"privkeypath":        "api.privkeypath",
-	"keyring-namespace":  "keyring.namespace",
-	"keyring-backend":    "keyring.backend",
-	"keyring-path":       "keyring.path",
-	"no-keyring":         "keyring.disabled",
-	"no-encryption-key":  "keyring.noencryptionkey",
-	"source-hub-address": "acp.sourceHub.address",
-	"development":        "development",
+	"log-level":           "log.level",
+	"log-output":          "log.output",
+	"log-format":          "log.format",
+	"log-stacktrace":      "log.stacktrace",
+	"log-source":          "log.source",
+	"log-overrides":       "log.overrides",
+	"no-log-color":        "log.colordisabled",
+	"url":                 "api.address",
+	"max-txn-retries":     "datastore.maxtxnretries",
+	"store":               "datastore.store",
+	"valuelogfilesize":    "datastore.badger.valuelogfilesize",
+	"peers":               "net.peers",
+	"p2paddr":             "net.p2paddresses",
+	"no-p2p":              "net.p2pdisabled",
+	"allowed-origins":     "api.allowed-origins",
+	"pubkeypath":          "api.pubkeypath",
+	"privkeypath":         "api.privkeypath",
+	"keyring-namespace":   "keyring.namespace",
+	"keyring-backend":     "keyring.backend",
+	"keyring-path":        "keyring.path",
+	"no-keyring":          "keyring.disabled",
+	"no-encryption-key":   "keyring.noencryptionkey",
+	"keyring-secret-file": "keyring.secretfile",
+	"source-hub-address":  "acp.sourceHub.address",
+	"development":         "development",
 }
 
 // configDefaults contains default values for config entries.
@@ -87,6 +88,7 @@ var configDefaults = map[string]any{
 	"keyring.disabled":                  false,
 	"keyring.namespace":                 "defradb",
 	"keyring.path":                      "keys",
+	"keyring.secretfile":                ".env",
 	"log.caller":                        false,
 	"log.colordisabled":                 false,
 	"log.format":                        "text",
@@ -98,9 +100,6 @@ var configDefaults = map[string]any{
 
 // defaultConfig returns a new config with default values.
 func defaultConfig() *viper.Viper {
-	// load environment variables from .env file if one exists
-	_ = godotenv.Load()
-
 	cfg := viper.New()
 
 	cfg.AutomaticEnv()
@@ -163,6 +162,9 @@ func loadConfig(rootdir string, flags *pflag.FlagSet) (*viper.Viper, error) {
 			cfg.Set(key, filepath.Join(rootdir, path))
 		}
 	}
+
+	// load environment variables from .env file if one exists
+	_ = godotenv.Load(cfg.GetString("keyring.secretfile"))
 
 	// set logging config
 	corelog.SetConfig(corelog.Config{

--- a/cli/config.go
+++ b/cli/config.go
@@ -43,31 +43,31 @@ var configPaths = []string{
 
 // configFlags is a mapping of cli flag names to config keys to bind.
 var configFlags = map[string]string{
-	"log-level":           "log.level",
-	"log-output":          "log.output",
-	"log-format":          "log.format",
-	"log-stacktrace":      "log.stacktrace",
-	"log-source":          "log.source",
-	"log-overrides":       "log.overrides",
-	"no-log-color":        "log.colordisabled",
-	"url":                 "api.address",
-	"max-txn-retries":     "datastore.maxtxnretries",
-	"store":               "datastore.store",
-	"valuelogfilesize":    "datastore.badger.valuelogfilesize",
-	"peers":               "net.peers",
-	"p2paddr":             "net.p2paddresses",
-	"no-p2p":              "net.p2pdisabled",
-	"allowed-origins":     "api.allowed-origins",
-	"pubkeypath":          "api.pubkeypath",
-	"privkeypath":         "api.privkeypath",
-	"keyring-namespace":   "keyring.namespace",
-	"keyring-backend":     "keyring.backend",
-	"keyring-path":        "keyring.path",
-	"no-keyring":          "keyring.disabled",
-	"no-encryption-key":   "keyring.noencryptionkey",
-	"keyring-secret-file": "keyring.secretfile",
-	"source-hub-address":  "acp.sourceHub.address",
-	"development":         "development",
+	"log-level":          "log.level",
+	"log-output":         "log.output",
+	"log-format":         "log.format",
+	"log-stacktrace":     "log.stacktrace",
+	"log-source":         "log.source",
+	"log-overrides":      "log.overrides",
+	"no-log-color":       "log.colordisabled",
+	"url":                "api.address",
+	"max-txn-retries":    "datastore.maxtxnretries",
+	"store":              "datastore.store",
+	"no-encryption":      "datastore.noencryption",
+	"valuelogfilesize":   "datastore.badger.valuelogfilesize",
+	"peers":              "net.peers",
+	"p2paddr":            "net.p2paddresses",
+	"no-p2p":             "net.p2pdisabled",
+	"allowed-origins":    "api.allowed-origins",
+	"pubkeypath":         "api.pubkeypath",
+	"privkeypath":        "api.privkeypath",
+	"keyring-namespace":  "keyring.namespace",
+	"keyring-backend":    "keyring.backend",
+	"keyring-path":       "keyring.path",
+	"no-keyring":         "keyring.disabled",
+	"source-hub-address": "acp.sourceHub.address",
+	"development":        "development",
+	"secret-file":        "secretfile",
 }
 
 // configDefaults contains default values for config entries.
@@ -88,7 +88,6 @@ var configDefaults = map[string]any{
 	"keyring.disabled":                  false,
 	"keyring.namespace":                 "defradb",
 	"keyring.path":                      "keys",
-	"keyring.secretfile":                ".env",
 	"log.caller":                        false,
 	"log.colordisabled":                 false,
 	"log.format":                        "text",
@@ -96,6 +95,7 @@ var configDefaults = map[string]any{
 	"log.output":                        "stderr",
 	"log.source":                        false,
 	"log.stacktrace":                    false,
+	"secretfile":                        ".env",
 }
 
 // defaultConfig returns a new config with default values.
@@ -164,7 +164,7 @@ func loadConfig(rootdir string, flags *pflag.FlagSet) (*viper.Viper, error) {
 	}
 
 	// load environment variables from .env file if one exists
-	_ = godotenv.Load(cfg.GetString("keyring.secretfile"))
+	_ = godotenv.Load(cfg.GetString("secretfile"))
 
 	// set logging config
 	corelog.SetConfig(corelog.Config{

--- a/cli/config.go
+++ b/cli/config.go
@@ -16,6 +16,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/joho/godotenv"
 	"github.com/sourcenetwork/corelog"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
@@ -63,6 +64,7 @@ var configFlags = map[string]string{
 	"keyring-backend":    "keyring.backend",
 	"keyring-path":       "keyring.path",
 	"no-keyring":         "keyring.disabled",
+	"no-encryption-key":  "keyring.noencryptionkey",
 	"source-hub-address": "acp.sourceHub.address",
 	"development":        "development",
 }
@@ -96,6 +98,9 @@ var configDefaults = map[string]any{
 
 // defaultConfig returns a new config with default values.
 func defaultConfig() *viper.Viper {
+	// load environment variables from .env file if one exists
+	_ = godotenv.Load()
+
 	cfg := viper.New()
 
 	cfg.AutomaticEnv()

--- a/cli/config.go
+++ b/cli/config.go
@@ -164,7 +164,10 @@ func loadConfig(rootdir string, flags *pflag.FlagSet) (*viper.Viper, error) {
 	}
 
 	// load environment variables from .env file if one exists
-	_ = godotenv.Load(cfg.GetString("secretfile"))
+	err = godotenv.Load(cfg.GetString("secretfile"))
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return nil, err
+	}
 
 	// set logging config
 	corelog.SetConfig(corelog.Config{

--- a/cli/errors.go
+++ b/cli/errors.go
@@ -16,14 +16,6 @@ import (
 	"github.com/sourcenetwork/defradb/errors"
 )
 
-const errKeyringHelp = `%w
-
-Did you forget to initialize the keyring?
-
-Use the following command to generate the required keys: 
-  defradb keyring generate
-`
-
 const (
 	errInvalidLensConfig        string = "invalid lens configuration"
 	errSchemaVersionNotOfSchema string = "the given schema version is from a different schema"
@@ -41,6 +33,7 @@ var (
 	ErrViewAddMissingArgs         = errors.New("please provide a base query and output SDL for this view")
 	ErrPolicyFileArgCanNotBeEmpty = errors.New("policy file argument can not be empty")
 	ErrPurgeForceFlagRequired     = errors.New("run this command again with --force if you really want to purge all data")
+	ErrMissingKeyringSecret       = errors.New("missing keyring secret")
 )
 
 func NewErrRequiredFlagEmpty(longName string, shortName string) error {
@@ -61,8 +54,4 @@ func NewErrSchemaVersionNotOfSchema(schemaRoot string, schemaVersionID string) e
 		errors.NewKV("SchemaRoot", schemaRoot),
 		errors.NewKV("SchemaVersionID", schemaVersionID),
 	)
-}
-
-func NewErrKeyringHelp(inner error) error {
-	return fmt.Errorf(errKeyringHelp, inner)
 }

--- a/cli/keyring_export.go
+++ b/cli/keyring_export.go
@@ -22,7 +22,8 @@ func MakeKeyringExportCommand() *cobra.Command {
 Prints the hexadecimal representation of a private key.
 
 The DEFRA_KEYRING_SECRET environment variable must be set to unlock the keyring.
-This can also be done with a .env file in the root directory.
+This can also be done with a .env file in the working directory or at a path
+defined with the --keyring-secret-file flag.
 
 Example:
   defradb keyring export encryption-key`,

--- a/cli/keyring_export.go
+++ b/cli/keyring_export.go
@@ -21,6 +21,9 @@ func MakeKeyringExportCommand() *cobra.Command {
 		Long: `Export a private key.
 Prints the hexadecimal representation of a private key.
 
+The DEFRA_KEYRING_SECRET environment variable must be set to unlock the keyring.
+This can also be done with a .env file in the root directory.
+
 Example:
   defradb keyring export encryption-key`,
 		Args: cobra.ExactArgs(1),

--- a/cli/keyring_export_test.go
+++ b/cli/keyring_export_test.go
@@ -13,21 +13,20 @@ package cli
 import (
 	"bytes"
 	"encoding/hex"
+	"os"
 	"strings"
 	"testing"
 
 	"github.com/sourcenetwork/defradb/crypto"
 
-	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestKeyringExport(t *testing.T) {
 	rootdir := t.TempDir()
-	readPassword = func(_ *cobra.Command, _ string) ([]byte, error) {
-		return []byte("secret"), nil
-	}
+	err := os.Setenv("DEFRA_KEYRING_SECRET", "password")
+	require.NoError(t, err)
 
 	keyBytes, err := crypto.GenerateAES256()
 	require.NoError(t, err)

--- a/cli/keyring_generate.go
+++ b/cli/keyring_generate.go
@@ -26,6 +26,9 @@ func MakeKeyringGenerateCommand() *cobra.Command {
 Randomly generate and store private keys in the keyring.
 By default peer and encryption keys will be generated.
 
+The DEFRA_KEYRING_SECRET environment variable must be set to unlock the keyring.
+This can also be done with a .env file in the root directory.
+
 WARNING: This will overwrite existing keys in the keyring.
 
 Example:

--- a/cli/keyring_generate.go
+++ b/cli/keyring_generate.go
@@ -27,7 +27,8 @@ Randomly generate and store private keys in the keyring.
 By default peer and encryption keys will be generated.
 
 The DEFRA_KEYRING_SECRET environment variable must be set to unlock the keyring.
-This can also be done with a .env file in the root directory.
+This can also be done with a .env file in the working directory or at a path
+defined with the --keyring-secret-file flag.
 
 WARNING: This will overwrite existing keys in the keyring.
 

--- a/cli/keyring_generate.go
+++ b/cli/keyring_generate.go
@@ -36,7 +36,7 @@ Example:
   defradb keyring generate
 
 Example: with no encryption key
-  defradb keyring generate --no-encryption-key
+  defradb keyring generate --no-encryption
 
 Example: with no peer key
   defradb keyring generate --no-peer-key
@@ -73,7 +73,7 @@ Example: with system keyring
 			return nil
 		},
 	}
-	cmd.Flags().BoolVar(&noEncryptionKey, "no-encryption-key", false,
+	cmd.Flags().BoolVar(&noEncryptionKey, "no-encryption", false,
 		"Skip generating an encryption key. Encryption at rest will be disabled")
 	cmd.Flags().BoolVar(&noPeerKey, "no-peer-key", false,
 		"Skip generating a peer key.")

--- a/cli/keyring_generate_test.go
+++ b/cli/keyring_generate_test.go
@@ -40,7 +40,7 @@ func TestKeyringGenerateNoEncryptionKey(t *testing.T) {
 	require.NoError(t, err)
 
 	cmd := NewDefraCommand()
-	cmd.SetArgs([]string{"keyring", "generate", "--no-encryption-key", "--rootdir", rootdir})
+	cmd.SetArgs([]string{"keyring", "generate", "--no-encryption", "--rootdir", rootdir})
 
 	err = cmd.Execute()
 	require.NoError(t, err)

--- a/cli/keyring_generate_test.go
+++ b/cli/keyring_generate_test.go
@@ -11,24 +11,23 @@
 package cli
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
-	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestKeyringGenerate(t *testing.T) {
 	rootdir := t.TempDir()
-	readPassword = func(_ *cobra.Command, _ string) ([]byte, error) {
-		return []byte("secret"), nil
-	}
+	err := os.Setenv("DEFRA_KEYRING_SECRET", "password")
+	require.NoError(t, err)
 
 	cmd := NewDefraCommand()
 	cmd.SetArgs([]string{"keyring", "generate", "--rootdir", rootdir})
 
-	err := cmd.Execute()
+	err = cmd.Execute()
 	require.NoError(t, err)
 
 	assert.FileExists(t, filepath.Join(rootdir, "keys", encryptionKeyName))
@@ -37,14 +36,13 @@ func TestKeyringGenerate(t *testing.T) {
 
 func TestKeyringGenerateNoEncryptionKey(t *testing.T) {
 	rootdir := t.TempDir()
-	readPassword = func(_ *cobra.Command, _ string) ([]byte, error) {
-		return []byte("secret"), nil
-	}
+	err := os.Setenv("DEFRA_KEYRING_SECRET", "password")
+	require.NoError(t, err)
 
 	cmd := NewDefraCommand()
 	cmd.SetArgs([]string{"keyring", "generate", "--no-encryption-key", "--rootdir", rootdir})
 
-	err := cmd.Execute()
+	err = cmd.Execute()
 	require.NoError(t, err)
 
 	assert.NoFileExists(t, filepath.Join(rootdir, "keys", encryptionKeyName))
@@ -53,14 +51,13 @@ func TestKeyringGenerateNoEncryptionKey(t *testing.T) {
 
 func TestKeyringGenerateNoPeerKey(t *testing.T) {
 	rootdir := t.TempDir()
-	readPassword = func(_ *cobra.Command, _ string) ([]byte, error) {
-		return []byte("secret"), nil
-	}
+	err := os.Setenv("DEFRA_KEYRING_SECRET", "password")
+	require.NoError(t, err)
 
 	cmd := NewDefraCommand()
 	cmd.SetArgs([]string{"keyring", "generate", "--no-peer-key", "--rootdir", rootdir})
 
-	err := cmd.Execute()
+	err = cmd.Execute()
 	require.NoError(t, err)
 
 	assert.FileExists(t, filepath.Join(rootdir, "keys", encryptionKeyName))

--- a/cli/keyring_import.go
+++ b/cli/keyring_import.go
@@ -24,7 +24,8 @@ func MakeKeyringImportCommand() *cobra.Command {
 Store an externally generated key in the keyring.
 
 The DEFRA_KEYRING_SECRET environment variable must be set to unlock the keyring.
-This can also be done with a .env file in the root directory.
+This can also be done with a .env file in the working directory or at a path
+defined with the --keyring-secret-file flag.
 
 Example:
   defradb keyring import encryption-key 0000000000000000`,

--- a/cli/keyring_import.go
+++ b/cli/keyring_import.go
@@ -23,6 +23,9 @@ func MakeKeyringImportCommand() *cobra.Command {
 		Long: `Import a private key.
 Store an externally generated key in the keyring.
 
+The DEFRA_KEYRING_SECRET environment variable must be set to unlock the keyring.
+This can also be done with a .env file in the root directory.
+
 Example:
   defradb keyring import encryption-key 0000000000000000`,
 		Args: cobra.ExactArgs(2),

--- a/cli/keyring_import_test.go
+++ b/cli/keyring_import_test.go
@@ -12,21 +12,20 @@ package cli
 
 import (
 	"encoding/hex"
+	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/sourcenetwork/defradb/crypto"
 
-	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestKeyringImport(t *testing.T) {
 	rootdir := t.TempDir()
-	readPassword = func(_ *cobra.Command, _ string) ([]byte, error) {
-		return []byte("secret"), nil
-	}
+	err := os.Setenv("DEFRA_KEYRING_SECRET", "password")
+	require.NoError(t, err)
 
 	keyBytes, err := crypto.GenerateAES256()
 	require.NoError(t, err)

--- a/cli/root.go
+++ b/cli/root.go
@@ -92,6 +92,10 @@ Start a DefraDB node, interact with a local or remote node, and much more.
 		cfg.GetString(configFlags["keyring-path"]),
 		"Path to store encrypted keys when using the file backend",
 	)
+	cmd.PersistentFlags().String(
+		"keyring-secret-file",
+		cfg.GetString(configFlags["keyring-secret-file"]),
+		"Path to the file containing the keyring secret")
 	cmd.PersistentFlags().Bool(
 		"no-keyring",
 		cfg.GetBool(configFlags["no-keyring"]),

--- a/cli/root.go
+++ b/cli/root.go
@@ -92,10 +92,6 @@ Start a DefraDB node, interact with a local or remote node, and much more.
 		cfg.GetString(configFlags["keyring-path"]),
 		"Path to store encrypted keys when using the file backend",
 	)
-	cmd.PersistentFlags().String(
-		"keyring-secret-file",
-		cfg.GetString(configFlags["keyring-secret-file"]),
-		"Path to the file containing the keyring secret")
 	cmd.PersistentFlags().Bool(
 		"no-keyring",
 		cfg.GetBool(configFlags["no-keyring"]),
@@ -106,5 +102,9 @@ Start a DefraDB node, interact with a local or remote node, and much more.
 		cfg.GetString(configFlags["source-hub-address"]),
 		"The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor",
 	)
+	cmd.PersistentFlags().String(
+		"secret-file",
+		cfg.GetString(configFlags["secret-file"]),
+		"Path to the file containing secrets")
 	return cmd
 }

--- a/cli/start.go
+++ b/cli/start.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sourcenetwork/immutable"
 	"github.com/spf13/cobra"
 
+	"github.com/sourcenetwork/defradb/crypto"
 	"github.com/sourcenetwork/defradb/errors"
 	"github.com/sourcenetwork/defradb/event"
 	"github.com/sourcenetwork/defradb/http"
@@ -97,19 +98,43 @@ func MakeStartCommand() *cobra.Command {
 			if !cfg.GetBool("keyring.disabled") {
 				kr, err := openKeyring(cmd)
 				if err != nil {
-					return NewErrKeyringHelp(err)
-				}
-				// load the required peer key
-				peerKey, err := kr.Get(peerKeyName)
-				if err != nil {
-					return NewErrKeyringHelp(err)
-				}
-				opts = append(opts, net.WithPrivateKey(peerKey))
-				// load the optional encryption key
-				encryptionKey, err := kr.Get(encryptionKeyName)
-				if err != nil && !errors.Is(err, keyring.ErrNotFound) {
 					return err
 				}
+<<<<<<< HEAD
+=======
+				// load the required peer key or generate one if it doesn't exist
+				peerKey, err := kr.Get(peerKeyName)
+				if err != nil && errors.Is(err, keyring.ErrNotFound) {
+					peerKey, err = crypto.GenerateEd25519()
+					if err != nil {
+						return err
+					}
+					err = kr.Set(peerKeyName, peerKey)
+					if err != nil {
+						return err
+					}
+					log.Info("generated peer key")
+				} else if err != nil {
+					return err
+				}
+				opts = append(opts, net.WithPrivateKey(peerKey))
+
+				// load the optional encryption key
+				encryptionKey, err := kr.Get(encryptionKeyName)
+				if err != nil && errors.Is(err, keyring.ErrNotFound) && !cfg.GetBool("keyring.noencryptionkey") {
+					encryptionKey, err = crypto.GenerateAES256()
+					if err != nil {
+						return err
+					}
+					err = kr.Set(encryptionKeyName, encryptionKey)
+					if err != nil {
+						return err
+					}
+					log.Info("generated encryption key")
+				} else if err != nil && !errors.Is(err, keyring.ErrNotFound) {
+					return err
+				}
+>>>>>>> 2cdf9388 (make keyring non-interactive)
 				opts = append(opts, node.WithBadgerEncryptionKey(encryptionKey))
 				// setup the sourcehub transaction signer
 				sourceHubKeyName := cfg.GetString("acp.sourceHub.KeyName")
@@ -224,5 +249,9 @@ func MakeStartCommand() *cobra.Command {
 		cfg.GetBool(configFlags["development"]),
 		"Enables a set of features that make development easier but should not be enabled in production",
 	)
+	cmd.Flags().Bool(
+		"no-encryption-key",
+		cfg.GetBool(configFlags["no-encryption-key"]),
+		"Skip generating an encryption key. Encryption at rest will be disabled. WARNING: This cannot be undone.")
 	return cmd
 }

--- a/cli/start.go
+++ b/cli/start.go
@@ -119,7 +119,7 @@ func MakeStartCommand() *cobra.Command {
 
 				// load the optional encryption key
 				encryptionKey, err := kr.Get(encryptionKeyName)
-				if err != nil && errors.Is(err, keyring.ErrNotFound) && !cfg.GetBool("keyring.noencryptionkey") {
+				if err != nil && errors.Is(err, keyring.ErrNotFound) && !cfg.GetBool("datastore.noencryption") {
 					encryptionKey, err = crypto.GenerateAES256()
 					if err != nil {
 						return err
@@ -247,8 +247,8 @@ func MakeStartCommand() *cobra.Command {
 		"Enables a set of features that make development easier but should not be enabled in production",
 	)
 	cmd.Flags().Bool(
-		"no-encryption-key",
-		cfg.GetBool(configFlags["no-encryption-key"]),
+		"no-encryption",
+		cfg.GetBool(configFlags["no-encryption"]),
 		"Skip generating an encryption key. Encryption at rest will be disabled. WARNING: This cannot be undone.")
 	return cmd
 }

--- a/cli/start.go
+++ b/cli/start.go
@@ -100,8 +100,6 @@ func MakeStartCommand() *cobra.Command {
 				if err != nil {
 					return err
 				}
-<<<<<<< HEAD
-=======
 				// load the required peer key or generate one if it doesn't exist
 				peerKey, err := kr.Get(peerKeyName)
 				if err != nil && errors.Is(err, keyring.ErrNotFound) {
@@ -134,7 +132,6 @@ func MakeStartCommand() *cobra.Command {
 				} else if err != nil && !errors.Is(err, keyring.ErrNotFound) {
 					return err
 				}
->>>>>>> 2cdf9388 (make keyring non-interactive)
 				opts = append(opts, node.WithBadgerEncryptionKey(encryptionKey))
 				// setup the sourcehub transaction signer
 				sourceHubKeyName := cfg.GetString("acp.sourceHub.KeyName")

--- a/docs/config.md
+++ b/docs/config.md
@@ -21,6 +21,10 @@ The number of retries to make in the event of a transaction conflict. Defaults t
 
 Currently this is only used within the P2P system and will not affect operations initiated by users.
 
+## `datastore.noencryption`
+
+Skip generating an encryption key. Encryption at rest will be disabled. **WARNING**: This cannot be undone.
+
 ## `datastore.badger.path`
 
 The path to the database data file(s). Defaults to `data`.
@@ -156,3 +160,7 @@ transactions created by the node is stored. Required when using `acp.type`:`sour
 The SourceHub address of the actor that client-side actions should permit to make SourceHub actions on
 their behalf.  This is a client-side only config param.  It is required if the client wishes to make
 SourceHub ACP requests in order to create protected data.
+
+## `secretfile`
+
+Path to the file containing secrets. Defaults to `.env`.

--- a/docs/website/references/cli/defradb.md
+++ b/docs/website/references/cli/defradb.md
@@ -12,21 +12,22 @@ Start a DefraDB node, interact with a local or remote node, and much more.
 ### Options
 
 ```
-  -h, --help                        help for defradb
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
-      --log-format string           Log format to use. Options are text or json (default "text")
-      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                  Include source location in logs
-      --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
-      --no-log-color                Disable colored log output
-      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -h, --help                         help for defradb
+      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
+      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
+      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
+      --log-format string            Log format to use. Options are text or json (default "text")
+      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                   Include source location in logs
+      --log-stacktrace               Include stacktrace in error and fatal logs
+      --no-keyring                   Disable the keyring and generate ephemeral keys
+      --no-log-color                 Disable colored log output
+      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
+      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb.md
+++ b/docs/website/references/cli/defradb.md
@@ -12,22 +12,22 @@ Start a DefraDB node, interact with a local or remote node, and much more.
 ### Options
 
 ```
-  -h, --help                         help for defradb
-      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
-      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
-      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
-      --log-format string            Log format to use. Options are text or json (default "text")
-      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                   Include source location in logs
-      --log-stacktrace               Include stacktrace in error and fatal logs
-      --no-keyring                   Disable the keyring and generate ephemeral keys
-      --no-log-color                 Disable colored log output
-      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -h, --help                        help for defradb
+      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
+      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
+      --log-format string           Log format to use. Options are text or json (default "text")
+      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                  Include source location in logs
+      --log-stacktrace              Include stacktrace in error and fatal logs
+      --no-keyring                  Disable the keyring and generate ephemeral keys
+      --no-log-color                Disable colored log output
+      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
+      --secret-file string          Path to the file containing secrets (default ".env")
+      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client.md
+++ b/docs/website/references/cli/defradb_client.md
@@ -18,20 +18,21 @@ Execute queries, add schema types, obtain node info, etc.
 ### Options inherited from parent commands
 
 ```
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
-      --log-format string           Log format to use. Options are text or json (default "text")
-      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                  Include source location in logs
-      --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
-      --no-log-color                Disable colored log output
-      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
+      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
+      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
+      --log-format string            Log format to use. Options are text or json (default "text")
+      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                   Include source location in logs
+      --log-stacktrace               Include stacktrace in error and fatal logs
+      --no-keyring                   Disable the keyring and generate ephemeral keys
+      --no-log-color                 Disable colored log output
+      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
+      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client.md
+++ b/docs/website/references/cli/defradb_client.md
@@ -18,21 +18,21 @@ Execute queries, add schema types, obtain node info, etc.
 ### Options inherited from parent commands
 
 ```
-      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
-      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
-      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
-      --log-format string            Log format to use. Options are text or json (default "text")
-      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                   Include source location in logs
-      --log-stacktrace               Include stacktrace in error and fatal logs
-      --no-keyring                   Disable the keyring and generate ephemeral keys
-      --no-log-color                 Disable colored log output
-      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
+      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
+      --log-format string           Log format to use. Options are text or json (default "text")
+      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                  Include source location in logs
+      --log-stacktrace              Include stacktrace in error and fatal logs
+      --no-keyring                  Disable the keyring and generate ephemeral keys
+      --no-log-color                Disable colored log output
+      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
+      --secret-file string          Path to the file containing secrets (default ".env")
+      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_acp.md
+++ b/docs/website/references/cli/defradb_client_acp.md
@@ -19,23 +19,23 @@ Learn more about [ACP](/acp/README.md)
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string              Hex formatted private key used to authenticate with ACP
-      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
-      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
-      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
-      --log-format string            Log format to use. Options are text or json (default "text")
-      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                   Include source location in logs
-      --log-stacktrace               Include stacktrace in error and fatal logs
-      --no-keyring                   Disable the keyring and generate ephemeral keys
-      --no-log-color                 Disable colored log output
-      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                      Transaction ID
-      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string             Hex formatted private key used to authenticate with ACP
+      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
+      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
+      --log-format string           Log format to use. Options are text or json (default "text")
+      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                  Include source location in logs
+      --log-stacktrace              Include stacktrace in error and fatal logs
+      --no-keyring                  Disable the keyring and generate ephemeral keys
+      --no-log-color                Disable colored log output
+      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
+      --secret-file string          Path to the file containing secrets (default ".env")
+      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                     Transaction ID
+      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_acp.md
+++ b/docs/website/references/cli/defradb_client_acp.md
@@ -19,22 +19,23 @@ Learn more about [ACP](/acp/README.md)
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
-      --log-format string           Log format to use. Options are text or json (default "text")
-      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                  Include source location in logs
-      --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
-      --no-log-color                Disable colored log output
-      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                     Transaction ID
-      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string              Hex formatted private key used to authenticate with ACP
+      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
+      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
+      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
+      --log-format string            Log format to use. Options are text or json (default "text")
+      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                   Include source location in logs
+      --log-stacktrace               Include stacktrace in error and fatal logs
+      --no-keyring                   Disable the keyring and generate ephemeral keys
+      --no-log-color                 Disable colored log output
+      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
+      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                      Transaction ID
+      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_acp_policy.md
+++ b/docs/website/references/cli/defradb_client_acp_policy.md
@@ -15,23 +15,23 @@ Interact with the acp policy features of DefraDB instance
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string              Hex formatted private key used to authenticate with ACP
-      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
-      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
-      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
-      --log-format string            Log format to use. Options are text or json (default "text")
-      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                   Include source location in logs
-      --log-stacktrace               Include stacktrace in error and fatal logs
-      --no-keyring                   Disable the keyring and generate ephemeral keys
-      --no-log-color                 Disable colored log output
-      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                      Transaction ID
-      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string             Hex formatted private key used to authenticate with ACP
+      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
+      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
+      --log-format string           Log format to use. Options are text or json (default "text")
+      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                  Include source location in logs
+      --log-stacktrace              Include stacktrace in error and fatal logs
+      --no-keyring                  Disable the keyring and generate ephemeral keys
+      --no-log-color                Disable colored log output
+      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
+      --secret-file string          Path to the file containing secrets (default ".env")
+      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                     Transaction ID
+      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_acp_policy.md
+++ b/docs/website/references/cli/defradb_client_acp_policy.md
@@ -15,22 +15,23 @@ Interact with the acp policy features of DefraDB instance
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
-      --log-format string           Log format to use. Options are text or json (default "text")
-      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                  Include source location in logs
-      --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
-      --no-log-color                Disable colored log output
-      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                     Transaction ID
-      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string              Hex formatted private key used to authenticate with ACP
+      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
+      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
+      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
+      --log-format string            Log format to use. Options are text or json (default "text")
+      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                   Include source location in logs
+      --log-stacktrace               Include stacktrace in error and fatal logs
+      --no-keyring                   Disable the keyring and generate ephemeral keys
+      --no-log-color                 Disable colored log output
+      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
+      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                      Transaction ID
+      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_acp_policy_add.md
+++ b/docs/website/references/cli/defradb_client_acp_policy_add.md
@@ -66,23 +66,23 @@ defradb client acp policy add [-i --identity] [policy] [flags]
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string              Hex formatted private key used to authenticate with ACP
-      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
-      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
-      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
-      --log-format string            Log format to use. Options are text or json (default "text")
-      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                   Include source location in logs
-      --log-stacktrace               Include stacktrace in error and fatal logs
-      --no-keyring                   Disable the keyring and generate ephemeral keys
-      --no-log-color                 Disable colored log output
-      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                      Transaction ID
-      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string             Hex formatted private key used to authenticate with ACP
+      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
+      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
+      --log-format string           Log format to use. Options are text or json (default "text")
+      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                  Include source location in logs
+      --log-stacktrace              Include stacktrace in error and fatal logs
+      --no-keyring                  Disable the keyring and generate ephemeral keys
+      --no-log-color                Disable colored log output
+      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
+      --secret-file string          Path to the file containing secrets (default ".env")
+      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                     Transaction ID
+      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_acp_policy_add.md
+++ b/docs/website/references/cli/defradb_client_acp_policy_add.md
@@ -66,22 +66,23 @@ defradb client acp policy add [-i --identity] [policy] [flags]
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
-      --log-format string           Log format to use. Options are text or json (default "text")
-      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                  Include source location in logs
-      --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
-      --no-log-color                Disable colored log output
-      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                     Transaction ID
-      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string              Hex formatted private key used to authenticate with ACP
+      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
+      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
+      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
+      --log-format string            Log format to use. Options are text or json (default "text")
+      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                   Include source location in logs
+      --log-stacktrace               Include stacktrace in error and fatal logs
+      --no-keyring                   Disable the keyring and generate ephemeral keys
+      --no-log-color                 Disable colored log output
+      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
+      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                      Transaction ID
+      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_backup.md
+++ b/docs/website/references/cli/defradb_client_backup.md
@@ -16,23 +16,23 @@ Currently only supports JSON format.
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string              Hex formatted private key used to authenticate with ACP
-      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
-      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
-      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
-      --log-format string            Log format to use. Options are text or json (default "text")
-      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                   Include source location in logs
-      --log-stacktrace               Include stacktrace in error and fatal logs
-      --no-keyring                   Disable the keyring and generate ephemeral keys
-      --no-log-color                 Disable colored log output
-      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                      Transaction ID
-      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string             Hex formatted private key used to authenticate with ACP
+      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
+      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
+      --log-format string           Log format to use. Options are text or json (default "text")
+      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                  Include source location in logs
+      --log-stacktrace              Include stacktrace in error and fatal logs
+      --no-keyring                  Disable the keyring and generate ephemeral keys
+      --no-log-color                Disable colored log output
+      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
+      --secret-file string          Path to the file containing secrets (default ".env")
+      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                     Transaction ID
+      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_backup.md
+++ b/docs/website/references/cli/defradb_client_backup.md
@@ -16,22 +16,23 @@ Currently only supports JSON format.
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
-      --log-format string           Log format to use. Options are text or json (default "text")
-      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                  Include source location in logs
-      --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
-      --no-log-color                Disable colored log output
-      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                     Transaction ID
-      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string              Hex formatted private key used to authenticate with ACP
+      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
+      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
+      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
+      --log-format string            Log format to use. Options are text or json (default "text")
+      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                   Include source location in logs
+      --log-stacktrace               Include stacktrace in error and fatal logs
+      --no-keyring                   Disable the keyring and generate ephemeral keys
+      --no-log-color                 Disable colored log output
+      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
+      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                      Transaction ID
+      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_backup_export.md
+++ b/docs/website/references/cli/defradb_client_backup_export.md
@@ -30,23 +30,23 @@ defradb client backup export  [-c --collections | -p --pretty | -f --format] <ou
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string              Hex formatted private key used to authenticate with ACP
-      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
-      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
-      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
-      --log-format string            Log format to use. Options are text or json (default "text")
-      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                   Include source location in logs
-      --log-stacktrace               Include stacktrace in error and fatal logs
-      --no-keyring                   Disable the keyring and generate ephemeral keys
-      --no-log-color                 Disable colored log output
-      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                      Transaction ID
-      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string             Hex formatted private key used to authenticate with ACP
+      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
+      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
+      --log-format string           Log format to use. Options are text or json (default "text")
+      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                  Include source location in logs
+      --log-stacktrace              Include stacktrace in error and fatal logs
+      --no-keyring                  Disable the keyring and generate ephemeral keys
+      --no-log-color                Disable colored log output
+      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
+      --secret-file string          Path to the file containing secrets (default ".env")
+      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                     Transaction ID
+      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_backup_export.md
+++ b/docs/website/references/cli/defradb_client_backup_export.md
@@ -30,22 +30,23 @@ defradb client backup export  [-c --collections | -p --pretty | -f --format] <ou
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
-      --log-format string           Log format to use. Options are text or json (default "text")
-      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                  Include source location in logs
-      --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
-      --no-log-color                Disable colored log output
-      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                     Transaction ID
-      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string              Hex formatted private key used to authenticate with ACP
+      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
+      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
+      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
+      --log-format string            Log format to use. Options are text or json (default "text")
+      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                   Include source location in logs
+      --log-stacktrace               Include stacktrace in error and fatal logs
+      --no-keyring                   Disable the keyring and generate ephemeral keys
+      --no-log-color                 Disable colored log output
+      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
+      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                      Transaction ID
+      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_backup_import.md
+++ b/docs/website/references/cli/defradb_client_backup_import.md
@@ -22,22 +22,23 @@ defradb client backup import <input_path> [flags]
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
-      --log-format string           Log format to use. Options are text or json (default "text")
-      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                  Include source location in logs
-      --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
-      --no-log-color                Disable colored log output
-      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                     Transaction ID
-      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string              Hex formatted private key used to authenticate with ACP
+      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
+      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
+      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
+      --log-format string            Log format to use. Options are text or json (default "text")
+      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                   Include source location in logs
+      --log-stacktrace               Include stacktrace in error and fatal logs
+      --no-keyring                   Disable the keyring and generate ephemeral keys
+      --no-log-color                 Disable colored log output
+      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
+      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                      Transaction ID
+      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_backup_import.md
+++ b/docs/website/references/cli/defradb_client_backup_import.md
@@ -22,23 +22,23 @@ defradb client backup import <input_path> [flags]
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string              Hex formatted private key used to authenticate with ACP
-      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
-      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
-      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
-      --log-format string            Log format to use. Options are text or json (default "text")
-      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                   Include source location in logs
-      --log-stacktrace               Include stacktrace in error and fatal logs
-      --no-keyring                   Disable the keyring and generate ephemeral keys
-      --no-log-color                 Disable colored log output
-      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                      Transaction ID
-      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string             Hex formatted private key used to authenticate with ACP
+      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
+      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
+      --log-format string           Log format to use. Options are text or json (default "text")
+      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                  Include source location in logs
+      --log-stacktrace              Include stacktrace in error and fatal logs
+      --no-keyring                  Disable the keyring and generate ephemeral keys
+      --no-log-color                Disable colored log output
+      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
+      --secret-file string          Path to the file containing secrets (default ".env")
+      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                     Transaction ID
+      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_collection.md
+++ b/docs/website/references/cli/defradb_client_collection.md
@@ -21,21 +21,21 @@ Create, read, update, and delete documents within a collection.
 ### Options inherited from parent commands
 
 ```
-      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
-      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
-      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
-      --log-format string            Log format to use. Options are text or json (default "text")
-      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                   Include source location in logs
-      --log-stacktrace               Include stacktrace in error and fatal logs
-      --no-keyring                   Disable the keyring and generate ephemeral keys
-      --no-log-color                 Disable colored log output
-      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
+      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
+      --log-format string           Log format to use. Options are text or json (default "text")
+      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                  Include source location in logs
+      --log-stacktrace              Include stacktrace in error and fatal logs
+      --no-keyring                  Disable the keyring and generate ephemeral keys
+      --no-log-color                Disable colored log output
+      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
+      --secret-file string          Path to the file containing secrets (default ".env")
+      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_collection.md
+++ b/docs/website/references/cli/defradb_client_collection.md
@@ -21,20 +21,21 @@ Create, read, update, and delete documents within a collection.
 ### Options inherited from parent commands
 
 ```
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
-      --log-format string           Log format to use. Options are text or json (default "text")
-      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                  Include source location in logs
-      --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
-      --no-log-color                Disable colored log output
-      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
+      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
+      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
+      --log-format string            Log format to use. Options are text or json (default "text")
+      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                   Include source location in logs
+      --log-stacktrace               Include stacktrace in error and fatal logs
+      --no-keyring                   Disable the keyring and generate ephemeral keys
+      --no-log-color                 Disable colored log output
+      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
+      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_collection_create.md
+++ b/docs/website/references/cli/defradb_client_collection_create.md
@@ -54,26 +54,27 @@ defradb client collection create [-i --identity] [-e --encrypt] [--encrypt-field
 ### Options inherited from parent commands
 
 ```
-      --get-inactive                Get inactive collections as well as active
-  -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
-      --log-format string           Log format to use. Options are text or json (default "text")
-      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                  Include source location in logs
-      --log-stacktrace              Include stacktrace in error and fatal logs
-      --name string                 Collection name
-      --no-keyring                  Disable the keyring and generate ephemeral keys
-      --no-log-color                Disable colored log output
-      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --schema string               Collection schema Root
-      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                     Transaction ID
-      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
-      --version string              Collection version ID
+      --get-inactive                 Get inactive collections as well as active
+  -i, --identity string              Hex formatted private key used to authenticate with ACP
+      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
+      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
+      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
+      --log-format string            Log format to use. Options are text or json (default "text")
+      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                   Include source location in logs
+      --log-stacktrace               Include stacktrace in error and fatal logs
+      --name string                  Collection name
+      --no-keyring                   Disable the keyring and generate ephemeral keys
+      --no-log-color                 Disable colored log output
+      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
+      --schema string                Collection schema Root
+      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                      Transaction ID
+      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+      --version string               Collection version ID
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_collection_create.md
+++ b/docs/website/references/cli/defradb_client_collection_create.md
@@ -54,27 +54,27 @@ defradb client collection create [-i --identity] [-e --encrypt] [--encrypt-field
 ### Options inherited from parent commands
 
 ```
-      --get-inactive                 Get inactive collections as well as active
-  -i, --identity string              Hex formatted private key used to authenticate with ACP
-      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
-      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
-      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
-      --log-format string            Log format to use. Options are text or json (default "text")
-      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                   Include source location in logs
-      --log-stacktrace               Include stacktrace in error and fatal logs
-      --name string                  Collection name
-      --no-keyring                   Disable the keyring and generate ephemeral keys
-      --no-log-color                 Disable colored log output
-      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
-      --schema string                Collection schema Root
-      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                      Transaction ID
-      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
-      --version string               Collection version ID
+      --get-inactive                Get inactive collections as well as active
+  -i, --identity string             Hex formatted private key used to authenticate with ACP
+      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
+      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
+      --log-format string           Log format to use. Options are text or json (default "text")
+      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                  Include source location in logs
+      --log-stacktrace              Include stacktrace in error and fatal logs
+      --name string                 Collection name
+      --no-keyring                  Disable the keyring and generate ephemeral keys
+      --no-log-color                Disable colored log output
+      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
+      --schema string               Collection schema Root
+      --secret-file string          Path to the file containing secrets (default ".env")
+      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                     Transaction ID
+      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+      --version string              Collection version ID
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_collection_delete.md
+++ b/docs/website/references/cli/defradb_client_collection_delete.md
@@ -32,26 +32,27 @@ defradb client collection delete [-i --identity] [--filter <filter> --docID <doc
 ### Options inherited from parent commands
 
 ```
-      --get-inactive                Get inactive collections as well as active
-  -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
-      --log-format string           Log format to use. Options are text or json (default "text")
-      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                  Include source location in logs
-      --log-stacktrace              Include stacktrace in error and fatal logs
-      --name string                 Collection name
-      --no-keyring                  Disable the keyring and generate ephemeral keys
-      --no-log-color                Disable colored log output
-      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --schema string               Collection schema Root
-      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                     Transaction ID
-      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
-      --version string              Collection version ID
+      --get-inactive                 Get inactive collections as well as active
+  -i, --identity string              Hex formatted private key used to authenticate with ACP
+      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
+      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
+      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
+      --log-format string            Log format to use. Options are text or json (default "text")
+      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                   Include source location in logs
+      --log-stacktrace               Include stacktrace in error and fatal logs
+      --name string                  Collection name
+      --no-keyring                   Disable the keyring and generate ephemeral keys
+      --no-log-color                 Disable colored log output
+      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
+      --schema string                Collection schema Root
+      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                      Transaction ID
+      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+      --version string               Collection version ID
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_collection_delete.md
+++ b/docs/website/references/cli/defradb_client_collection_delete.md
@@ -32,27 +32,27 @@ defradb client collection delete [-i --identity] [--filter <filter> --docID <doc
 ### Options inherited from parent commands
 
 ```
-      --get-inactive                 Get inactive collections as well as active
-  -i, --identity string              Hex formatted private key used to authenticate with ACP
-      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
-      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
-      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
-      --log-format string            Log format to use. Options are text or json (default "text")
-      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                   Include source location in logs
-      --log-stacktrace               Include stacktrace in error and fatal logs
-      --name string                  Collection name
-      --no-keyring                   Disable the keyring and generate ephemeral keys
-      --no-log-color                 Disable colored log output
-      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
-      --schema string                Collection schema Root
-      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                      Transaction ID
-      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
-      --version string               Collection version ID
+      --get-inactive                Get inactive collections as well as active
+  -i, --identity string             Hex formatted private key used to authenticate with ACP
+      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
+      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
+      --log-format string           Log format to use. Options are text or json (default "text")
+      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                  Include source location in logs
+      --log-stacktrace              Include stacktrace in error and fatal logs
+      --name string                 Collection name
+      --no-keyring                  Disable the keyring and generate ephemeral keys
+      --no-log-color                Disable colored log output
+      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
+      --schema string               Collection schema Root
+      --secret-file string          Path to the file containing secrets (default ".env")
+      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                     Transaction ID
+      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+      --version string              Collection version ID
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_collection_describe.md
+++ b/docs/website/references/cli/defradb_client_collection_describe.md
@@ -36,22 +36,23 @@ defradb client collection describe [flags]
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
-      --log-format string           Log format to use. Options are text or json (default "text")
-      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                  Include source location in logs
-      --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
-      --no-log-color                Disable colored log output
-      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                     Transaction ID
-      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string              Hex formatted private key used to authenticate with ACP
+      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
+      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
+      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
+      --log-format string            Log format to use. Options are text or json (default "text")
+      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                   Include source location in logs
+      --log-stacktrace               Include stacktrace in error and fatal logs
+      --no-keyring                   Disable the keyring and generate ephemeral keys
+      --no-log-color                 Disable colored log output
+      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
+      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                      Transaction ID
+      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_collection_describe.md
+++ b/docs/website/references/cli/defradb_client_collection_describe.md
@@ -36,23 +36,23 @@ defradb client collection describe [flags]
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string              Hex formatted private key used to authenticate with ACP
-      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
-      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
-      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
-      --log-format string            Log format to use. Options are text or json (default "text")
-      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                   Include source location in logs
-      --log-stacktrace               Include stacktrace in error and fatal logs
-      --no-keyring                   Disable the keyring and generate ephemeral keys
-      --no-log-color                 Disable colored log output
-      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                      Transaction ID
-      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string             Hex formatted private key used to authenticate with ACP
+      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
+      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
+      --log-format string           Log format to use. Options are text or json (default "text")
+      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                  Include source location in logs
+      --log-stacktrace              Include stacktrace in error and fatal logs
+      --no-keyring                  Disable the keyring and generate ephemeral keys
+      --no-log-color                Disable colored log output
+      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
+      --secret-file string          Path to the file containing secrets (default ".env")
+      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                     Transaction ID
+      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_collection_docIDs.md
+++ b/docs/website/references/cli/defradb_client_collection_docIDs.md
@@ -26,26 +26,27 @@ defradb client collection docIDs [-i --identity] [flags]
 ### Options inherited from parent commands
 
 ```
-      --get-inactive                Get inactive collections as well as active
-  -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
-      --log-format string           Log format to use. Options are text or json (default "text")
-      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                  Include source location in logs
-      --log-stacktrace              Include stacktrace in error and fatal logs
-      --name string                 Collection name
-      --no-keyring                  Disable the keyring and generate ephemeral keys
-      --no-log-color                Disable colored log output
-      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --schema string               Collection schema Root
-      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                     Transaction ID
-      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
-      --version string              Collection version ID
+      --get-inactive                 Get inactive collections as well as active
+  -i, --identity string              Hex formatted private key used to authenticate with ACP
+      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
+      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
+      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
+      --log-format string            Log format to use. Options are text or json (default "text")
+      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                   Include source location in logs
+      --log-stacktrace               Include stacktrace in error and fatal logs
+      --name string                  Collection name
+      --no-keyring                   Disable the keyring and generate ephemeral keys
+      --no-log-color                 Disable colored log output
+      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
+      --schema string                Collection schema Root
+      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                      Transaction ID
+      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+      --version string               Collection version ID
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_collection_docIDs.md
+++ b/docs/website/references/cli/defradb_client_collection_docIDs.md
@@ -26,27 +26,27 @@ defradb client collection docIDs [-i --identity] [flags]
 ### Options inherited from parent commands
 
 ```
-      --get-inactive                 Get inactive collections as well as active
-  -i, --identity string              Hex formatted private key used to authenticate with ACP
-      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
-      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
-      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
-      --log-format string            Log format to use. Options are text or json (default "text")
-      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                   Include source location in logs
-      --log-stacktrace               Include stacktrace in error and fatal logs
-      --name string                  Collection name
-      --no-keyring                   Disable the keyring and generate ephemeral keys
-      --no-log-color                 Disable colored log output
-      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
-      --schema string                Collection schema Root
-      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                      Transaction ID
-      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
-      --version string               Collection version ID
+      --get-inactive                Get inactive collections as well as active
+  -i, --identity string             Hex formatted private key used to authenticate with ACP
+      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
+      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
+      --log-format string           Log format to use. Options are text or json (default "text")
+      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                  Include source location in logs
+      --log-stacktrace              Include stacktrace in error and fatal logs
+      --name string                 Collection name
+      --no-keyring                  Disable the keyring and generate ephemeral keys
+      --no-log-color                Disable colored log output
+      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
+      --schema string               Collection schema Root
+      --secret-file string          Path to the file containing secrets (default ".env")
+      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                     Transaction ID
+      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+      --version string              Collection version ID
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_collection_get.md
+++ b/docs/website/references/cli/defradb_client_collection_get.md
@@ -27,27 +27,27 @@ defradb client collection get [-i --identity] [--show-deleted] <docID>  [flags]
 ### Options inherited from parent commands
 
 ```
-      --get-inactive                 Get inactive collections as well as active
-  -i, --identity string              Hex formatted private key used to authenticate with ACP
-      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
-      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
-      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
-      --log-format string            Log format to use. Options are text or json (default "text")
-      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                   Include source location in logs
-      --log-stacktrace               Include stacktrace in error and fatal logs
-      --name string                  Collection name
-      --no-keyring                   Disable the keyring and generate ephemeral keys
-      --no-log-color                 Disable colored log output
-      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
-      --schema string                Collection schema Root
-      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                      Transaction ID
-      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
-      --version string               Collection version ID
+      --get-inactive                Get inactive collections as well as active
+  -i, --identity string             Hex formatted private key used to authenticate with ACP
+      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
+      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
+      --log-format string           Log format to use. Options are text or json (default "text")
+      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                  Include source location in logs
+      --log-stacktrace              Include stacktrace in error and fatal logs
+      --name string                 Collection name
+      --no-keyring                  Disable the keyring and generate ephemeral keys
+      --no-log-color                Disable colored log output
+      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
+      --schema string               Collection schema Root
+      --secret-file string          Path to the file containing secrets (default ".env")
+      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                     Transaction ID
+      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+      --version string              Collection version ID
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_collection_get.md
+++ b/docs/website/references/cli/defradb_client_collection_get.md
@@ -27,26 +27,27 @@ defradb client collection get [-i --identity] [--show-deleted] <docID>  [flags]
 ### Options inherited from parent commands
 
 ```
-      --get-inactive                Get inactive collections as well as active
-  -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
-      --log-format string           Log format to use. Options are text or json (default "text")
-      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                  Include source location in logs
-      --log-stacktrace              Include stacktrace in error and fatal logs
-      --name string                 Collection name
-      --no-keyring                  Disable the keyring and generate ephemeral keys
-      --no-log-color                Disable colored log output
-      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --schema string               Collection schema Root
-      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                     Transaction ID
-      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
-      --version string              Collection version ID
+      --get-inactive                 Get inactive collections as well as active
+  -i, --identity string              Hex formatted private key used to authenticate with ACP
+      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
+      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
+      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
+      --log-format string            Log format to use. Options are text or json (default "text")
+      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                   Include source location in logs
+      --log-stacktrace               Include stacktrace in error and fatal logs
+      --name string                  Collection name
+      --no-keyring                   Disable the keyring and generate ephemeral keys
+      --no-log-color                 Disable colored log output
+      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
+      --schema string                Collection schema Root
+      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                      Transaction ID
+      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+      --version string               Collection version ID
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_collection_patch.md
+++ b/docs/website/references/cli/defradb_client_collection_patch.md
@@ -33,27 +33,27 @@ defradb client collection patch [patch] [flags]
 ### Options inherited from parent commands
 
 ```
-      --get-inactive                 Get inactive collections as well as active
-  -i, --identity string              Hex formatted private key used to authenticate with ACP
-      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
-      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
-      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
-      --log-format string            Log format to use. Options are text or json (default "text")
-      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                   Include source location in logs
-      --log-stacktrace               Include stacktrace in error and fatal logs
-      --name string                  Collection name
-      --no-keyring                   Disable the keyring and generate ephemeral keys
-      --no-log-color                 Disable colored log output
-      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
-      --schema string                Collection schema Root
-      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                      Transaction ID
-      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
-      --version string               Collection version ID
+      --get-inactive                Get inactive collections as well as active
+  -i, --identity string             Hex formatted private key used to authenticate with ACP
+      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
+      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
+      --log-format string           Log format to use. Options are text or json (default "text")
+      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                  Include source location in logs
+      --log-stacktrace              Include stacktrace in error and fatal logs
+      --name string                 Collection name
+      --no-keyring                  Disable the keyring and generate ephemeral keys
+      --no-log-color                Disable colored log output
+      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
+      --schema string               Collection schema Root
+      --secret-file string          Path to the file containing secrets (default ".env")
+      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                     Transaction ID
+      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+      --version string              Collection version ID
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_collection_patch.md
+++ b/docs/website/references/cli/defradb_client_collection_patch.md
@@ -33,26 +33,27 @@ defradb client collection patch [patch] [flags]
 ### Options inherited from parent commands
 
 ```
-      --get-inactive                Get inactive collections as well as active
-  -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
-      --log-format string           Log format to use. Options are text or json (default "text")
-      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                  Include source location in logs
-      --log-stacktrace              Include stacktrace in error and fatal logs
-      --name string                 Collection name
-      --no-keyring                  Disable the keyring and generate ephemeral keys
-      --no-log-color                Disable colored log output
-      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --schema string               Collection schema Root
-      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                     Transaction ID
-      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
-      --version string              Collection version ID
+      --get-inactive                 Get inactive collections as well as active
+  -i, --identity string              Hex formatted private key used to authenticate with ACP
+      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
+      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
+      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
+      --log-format string            Log format to use. Options are text or json (default "text")
+      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                   Include source location in logs
+      --log-stacktrace               Include stacktrace in error and fatal logs
+      --name string                  Collection name
+      --no-keyring                   Disable the keyring and generate ephemeral keys
+      --no-log-color                 Disable colored log output
+      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
+      --schema string                Collection schema Root
+      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                      Transaction ID
+      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+      --version string               Collection version ID
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_collection_update.md
+++ b/docs/website/references/cli/defradb_client_collection_update.md
@@ -38,27 +38,27 @@ defradb client collection update [-i --identity] [--filter <filter> --docID <doc
 ### Options inherited from parent commands
 
 ```
-      --get-inactive                 Get inactive collections as well as active
-  -i, --identity string              Hex formatted private key used to authenticate with ACP
-      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
-      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
-      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
-      --log-format string            Log format to use. Options are text or json (default "text")
-      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                   Include source location in logs
-      --log-stacktrace               Include stacktrace in error and fatal logs
-      --name string                  Collection name
-      --no-keyring                   Disable the keyring and generate ephemeral keys
-      --no-log-color                 Disable colored log output
-      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
-      --schema string                Collection schema Root
-      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                      Transaction ID
-      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
-      --version string               Collection version ID
+      --get-inactive                Get inactive collections as well as active
+  -i, --identity string             Hex formatted private key used to authenticate with ACP
+      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
+      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
+      --log-format string           Log format to use. Options are text or json (default "text")
+      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                  Include source location in logs
+      --log-stacktrace              Include stacktrace in error and fatal logs
+      --name string                 Collection name
+      --no-keyring                  Disable the keyring and generate ephemeral keys
+      --no-log-color                Disable colored log output
+      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
+      --schema string               Collection schema Root
+      --secret-file string          Path to the file containing secrets (default ".env")
+      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                     Transaction ID
+      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+      --version string              Collection version ID
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_collection_update.md
+++ b/docs/website/references/cli/defradb_client_collection_update.md
@@ -38,26 +38,27 @@ defradb client collection update [-i --identity] [--filter <filter> --docID <doc
 ### Options inherited from parent commands
 
 ```
-      --get-inactive                Get inactive collections as well as active
-  -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
-      --log-format string           Log format to use. Options are text or json (default "text")
-      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                  Include source location in logs
-      --log-stacktrace              Include stacktrace in error and fatal logs
-      --name string                 Collection name
-      --no-keyring                  Disable the keyring and generate ephemeral keys
-      --no-log-color                Disable colored log output
-      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --schema string               Collection schema Root
-      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                     Transaction ID
-      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
-      --version string              Collection version ID
+      --get-inactive                 Get inactive collections as well as active
+  -i, --identity string              Hex formatted private key used to authenticate with ACP
+      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
+      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
+      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
+      --log-format string            Log format to use. Options are text or json (default "text")
+      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                   Include source location in logs
+      --log-stacktrace               Include stacktrace in error and fatal logs
+      --name string                  Collection name
+      --no-keyring                   Disable the keyring and generate ephemeral keys
+      --no-log-color                 Disable colored log output
+      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
+      --schema string                Collection schema Root
+      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                      Transaction ID
+      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+      --version string               Collection version ID
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_dump.md
+++ b/docs/website/references/cli/defradb_client_dump.md
@@ -15,22 +15,23 @@ defradb client dump [flags]
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
-      --log-format string           Log format to use. Options are text or json (default "text")
-      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                  Include source location in logs
-      --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
-      --no-log-color                Disable colored log output
-      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                     Transaction ID
-      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string              Hex formatted private key used to authenticate with ACP
+      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
+      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
+      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
+      --log-format string            Log format to use. Options are text or json (default "text")
+      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                   Include source location in logs
+      --log-stacktrace               Include stacktrace in error and fatal logs
+      --no-keyring                   Disable the keyring and generate ephemeral keys
+      --no-log-color                 Disable colored log output
+      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
+      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                      Transaction ID
+      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_dump.md
+++ b/docs/website/references/cli/defradb_client_dump.md
@@ -15,23 +15,23 @@ defradb client dump [flags]
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string              Hex formatted private key used to authenticate with ACP
-      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
-      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
-      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
-      --log-format string            Log format to use. Options are text or json (default "text")
-      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                   Include source location in logs
-      --log-stacktrace               Include stacktrace in error and fatal logs
-      --no-keyring                   Disable the keyring and generate ephemeral keys
-      --no-log-color                 Disable colored log output
-      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                      Transaction ID
-      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string             Hex formatted private key used to authenticate with ACP
+      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
+      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
+      --log-format string           Log format to use. Options are text or json (default "text")
+      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                  Include source location in logs
+      --log-stacktrace              Include stacktrace in error and fatal logs
+      --no-keyring                  Disable the keyring and generate ephemeral keys
+      --no-log-color                Disable colored log output
+      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
+      --secret-file string          Path to the file containing secrets (default ".env")
+      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                     Transaction ID
+      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_index.md
+++ b/docs/website/references/cli/defradb_client_index.md
@@ -15,23 +15,23 @@ Manage (create, drop, or list) collection indexes on a DefraDB node.
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string              Hex formatted private key used to authenticate with ACP
-      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
-      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
-      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
-      --log-format string            Log format to use. Options are text or json (default "text")
-      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                   Include source location in logs
-      --log-stacktrace               Include stacktrace in error and fatal logs
-      --no-keyring                   Disable the keyring and generate ephemeral keys
-      --no-log-color                 Disable colored log output
-      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                      Transaction ID
-      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string             Hex formatted private key used to authenticate with ACP
+      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
+      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
+      --log-format string           Log format to use. Options are text or json (default "text")
+      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                  Include source location in logs
+      --log-stacktrace              Include stacktrace in error and fatal logs
+      --no-keyring                  Disable the keyring and generate ephemeral keys
+      --no-log-color                Disable colored log output
+      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
+      --secret-file string          Path to the file containing secrets (default ".env")
+      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                     Transaction ID
+      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_index.md
+++ b/docs/website/references/cli/defradb_client_index.md
@@ -15,22 +15,23 @@ Manage (create, drop, or list) collection indexes on a DefraDB node.
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
-      --log-format string           Log format to use. Options are text or json (default "text")
-      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                  Include source location in logs
-      --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
-      --no-log-color                Disable colored log output
-      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                     Transaction ID
-      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string              Hex formatted private key used to authenticate with ACP
+      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
+      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
+      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
+      --log-format string            Log format to use. Options are text or json (default "text")
+      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                   Include source location in logs
+      --log-stacktrace               Include stacktrace in error and fatal logs
+      --no-keyring                   Disable the keyring and generate ephemeral keys
+      --no-log-color                 Disable colored log output
+      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
+      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                      Transaction ID
+      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_index_create.md
+++ b/docs/website/references/cli/defradb_client_index_create.md
@@ -32,23 +32,23 @@ defradb client index create -c --collection <collection> --fields <fields> [-n -
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string              Hex formatted private key used to authenticate with ACP
-      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
-      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
-      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
-      --log-format string            Log format to use. Options are text or json (default "text")
-      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                   Include source location in logs
-      --log-stacktrace               Include stacktrace in error and fatal logs
-      --no-keyring                   Disable the keyring and generate ephemeral keys
-      --no-log-color                 Disable colored log output
-      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                      Transaction ID
-      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string             Hex formatted private key used to authenticate with ACP
+      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
+      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
+      --log-format string           Log format to use. Options are text or json (default "text")
+      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                  Include source location in logs
+      --log-stacktrace              Include stacktrace in error and fatal logs
+      --no-keyring                  Disable the keyring and generate ephemeral keys
+      --no-log-color                Disable colored log output
+      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
+      --secret-file string          Path to the file containing secrets (default ".env")
+      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                     Transaction ID
+      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_index_create.md
+++ b/docs/website/references/cli/defradb_client_index_create.md
@@ -32,22 +32,23 @@ defradb client index create -c --collection <collection> --fields <fields> [-n -
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
-      --log-format string           Log format to use. Options are text or json (default "text")
-      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                  Include source location in logs
-      --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
-      --no-log-color                Disable colored log output
-      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                     Transaction ID
-      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string              Hex formatted private key used to authenticate with ACP
+      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
+      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
+      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
+      --log-format string            Log format to use. Options are text or json (default "text")
+      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                   Include source location in logs
+      --log-stacktrace               Include stacktrace in error and fatal logs
+      --no-keyring                   Disable the keyring and generate ephemeral keys
+      --no-log-color                 Disable colored log output
+      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
+      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                      Transaction ID
+      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_index_drop.md
+++ b/docs/website/references/cli/defradb_client_index_drop.md
@@ -24,22 +24,23 @@ defradb client index drop -c --collection <collection> -n --name <name> [flags]
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
-      --log-format string           Log format to use. Options are text or json (default "text")
-      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                  Include source location in logs
-      --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
-      --no-log-color                Disable colored log output
-      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                     Transaction ID
-      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string              Hex formatted private key used to authenticate with ACP
+      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
+      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
+      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
+      --log-format string            Log format to use. Options are text or json (default "text")
+      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                   Include source location in logs
+      --log-stacktrace               Include stacktrace in error and fatal logs
+      --no-keyring                   Disable the keyring and generate ephemeral keys
+      --no-log-color                 Disable colored log output
+      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
+      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                      Transaction ID
+      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_index_drop.md
+++ b/docs/website/references/cli/defradb_client_index_drop.md
@@ -24,23 +24,23 @@ defradb client index drop -c --collection <collection> -n --name <name> [flags]
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string              Hex formatted private key used to authenticate with ACP
-      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
-      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
-      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
-      --log-format string            Log format to use. Options are text or json (default "text")
-      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                   Include source location in logs
-      --log-stacktrace               Include stacktrace in error and fatal logs
-      --no-keyring                   Disable the keyring and generate ephemeral keys
-      --no-log-color                 Disable colored log output
-      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                      Transaction ID
-      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string             Hex formatted private key used to authenticate with ACP
+      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
+      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
+      --log-format string           Log format to use. Options are text or json (default "text")
+      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                  Include source location in logs
+      --log-stacktrace              Include stacktrace in error and fatal logs
+      --no-keyring                  Disable the keyring and generate ephemeral keys
+      --no-log-color                Disable colored log output
+      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
+      --secret-file string          Path to the file containing secrets (default ".env")
+      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                     Transaction ID
+      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_index_list.md
+++ b/docs/website/references/cli/defradb_client_index_list.md
@@ -26,22 +26,23 @@ defradb client index list [-c --collection <collection>] [flags]
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
-      --log-format string           Log format to use. Options are text or json (default "text")
-      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                  Include source location in logs
-      --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
-      --no-log-color                Disable colored log output
-      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                     Transaction ID
-      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string              Hex formatted private key used to authenticate with ACP
+      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
+      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
+      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
+      --log-format string            Log format to use. Options are text or json (default "text")
+      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                   Include source location in logs
+      --log-stacktrace               Include stacktrace in error and fatal logs
+      --no-keyring                   Disable the keyring and generate ephemeral keys
+      --no-log-color                 Disable colored log output
+      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
+      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                      Transaction ID
+      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_index_list.md
+++ b/docs/website/references/cli/defradb_client_index_list.md
@@ -26,23 +26,23 @@ defradb client index list [-c --collection <collection>] [flags]
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string              Hex formatted private key used to authenticate with ACP
-      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
-      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
-      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
-      --log-format string            Log format to use. Options are text or json (default "text")
-      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                   Include source location in logs
-      --log-stacktrace               Include stacktrace in error and fatal logs
-      --no-keyring                   Disable the keyring and generate ephemeral keys
-      --no-log-color                 Disable colored log output
-      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                      Transaction ID
-      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string             Hex formatted private key used to authenticate with ACP
+      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
+      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
+      --log-format string           Log format to use. Options are text or json (default "text")
+      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                  Include source location in logs
+      --log-stacktrace              Include stacktrace in error and fatal logs
+      --no-keyring                  Disable the keyring and generate ephemeral keys
+      --no-log-color                Disable colored log output
+      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
+      --secret-file string          Path to the file containing secrets (default ".env")
+      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                     Transaction ID
+      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_p2p.md
+++ b/docs/website/references/cli/defradb_client_p2p.md
@@ -15,23 +15,23 @@ Interact with the DefraDB P2P system
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string              Hex formatted private key used to authenticate with ACP
-      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
-      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
-      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
-      --log-format string            Log format to use. Options are text or json (default "text")
-      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                   Include source location in logs
-      --log-stacktrace               Include stacktrace in error and fatal logs
-      --no-keyring                   Disable the keyring and generate ephemeral keys
-      --no-log-color                 Disable colored log output
-      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                      Transaction ID
-      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string             Hex formatted private key used to authenticate with ACP
+      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
+      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
+      --log-format string           Log format to use. Options are text or json (default "text")
+      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                  Include source location in logs
+      --log-stacktrace              Include stacktrace in error and fatal logs
+      --no-keyring                  Disable the keyring and generate ephemeral keys
+      --no-log-color                Disable colored log output
+      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
+      --secret-file string          Path to the file containing secrets (default ".env")
+      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                     Transaction ID
+      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_p2p.md
+++ b/docs/website/references/cli/defradb_client_p2p.md
@@ -15,22 +15,23 @@ Interact with the DefraDB P2P system
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
-      --log-format string           Log format to use. Options are text or json (default "text")
-      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                  Include source location in logs
-      --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
-      --no-log-color                Disable colored log output
-      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                     Transaction ID
-      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string              Hex formatted private key used to authenticate with ACP
+      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
+      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
+      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
+      --log-format string            Log format to use. Options are text or json (default "text")
+      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                   Include source location in logs
+      --log-stacktrace               Include stacktrace in error and fatal logs
+      --no-keyring                   Disable the keyring and generate ephemeral keys
+      --no-log-color                 Disable colored log output
+      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
+      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                      Transaction ID
+      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_p2p_collection.md
+++ b/docs/website/references/cli/defradb_client_p2p_collection.md
@@ -16,23 +16,23 @@ The selected collections synchronize their events on the pubsub network.
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string              Hex formatted private key used to authenticate with ACP
-      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
-      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
-      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
-      --log-format string            Log format to use. Options are text or json (default "text")
-      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                   Include source location in logs
-      --log-stacktrace               Include stacktrace in error and fatal logs
-      --no-keyring                   Disable the keyring and generate ephemeral keys
-      --no-log-color                 Disable colored log output
-      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                      Transaction ID
-      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string             Hex formatted private key used to authenticate with ACP
+      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
+      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
+      --log-format string           Log format to use. Options are text or json (default "text")
+      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                  Include source location in logs
+      --log-stacktrace              Include stacktrace in error and fatal logs
+      --no-keyring                  Disable the keyring and generate ephemeral keys
+      --no-log-color                Disable colored log output
+      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
+      --secret-file string          Path to the file containing secrets (default ".env")
+      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                     Transaction ID
+      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_p2p_collection.md
+++ b/docs/website/references/cli/defradb_client_p2p_collection.md
@@ -16,22 +16,23 @@ The selected collections synchronize their events on the pubsub network.
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
-      --log-format string           Log format to use. Options are text or json (default "text")
-      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                  Include source location in logs
-      --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
-      --no-log-color                Disable colored log output
-      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                     Transaction ID
-      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string              Hex formatted private key used to authenticate with ACP
+      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
+      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
+      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
+      --log-format string            Log format to use. Options are text or json (default "text")
+      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                   Include source location in logs
+      --log-stacktrace               Include stacktrace in error and fatal logs
+      --no-keyring                   Disable the keyring and generate ephemeral keys
+      --no-log-color                 Disable colored log output
+      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
+      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                      Transaction ID
+      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_p2p_collection_add.md
+++ b/docs/website/references/cli/defradb_client_p2p_collection_add.md
@@ -27,22 +27,23 @@ defradb client p2p collection add [collectionIDs] [flags]
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
-      --log-format string           Log format to use. Options are text or json (default "text")
-      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                  Include source location in logs
-      --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
-      --no-log-color                Disable colored log output
-      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                     Transaction ID
-      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string              Hex formatted private key used to authenticate with ACP
+      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
+      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
+      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
+      --log-format string            Log format to use. Options are text or json (default "text")
+      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                   Include source location in logs
+      --log-stacktrace               Include stacktrace in error and fatal logs
+      --no-keyring                   Disable the keyring and generate ephemeral keys
+      --no-log-color                 Disable colored log output
+      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
+      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                      Transaction ID
+      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_p2p_collection_add.md
+++ b/docs/website/references/cli/defradb_client_p2p_collection_add.md
@@ -27,23 +27,23 @@ defradb client p2p collection add [collectionIDs] [flags]
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string              Hex formatted private key used to authenticate with ACP
-      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
-      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
-      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
-      --log-format string            Log format to use. Options are text or json (default "text")
-      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                   Include source location in logs
-      --log-stacktrace               Include stacktrace in error and fatal logs
-      --no-keyring                   Disable the keyring and generate ephemeral keys
-      --no-log-color                 Disable colored log output
-      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                      Transaction ID
-      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string             Hex formatted private key used to authenticate with ACP
+      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
+      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
+      --log-format string           Log format to use. Options are text or json (default "text")
+      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                  Include source location in logs
+      --log-stacktrace              Include stacktrace in error and fatal logs
+      --no-keyring                  Disable the keyring and generate ephemeral keys
+      --no-log-color                Disable colored log output
+      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
+      --secret-file string          Path to the file containing secrets (default ".env")
+      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                     Transaction ID
+      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_p2p_collection_getall.md
+++ b/docs/website/references/cli/defradb_client_p2p_collection_getall.md
@@ -20,23 +20,23 @@ defradb client p2p collection getall [flags]
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string              Hex formatted private key used to authenticate with ACP
-      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
-      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
-      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
-      --log-format string            Log format to use. Options are text or json (default "text")
-      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                   Include source location in logs
-      --log-stacktrace               Include stacktrace in error and fatal logs
-      --no-keyring                   Disable the keyring and generate ephemeral keys
-      --no-log-color                 Disable colored log output
-      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                      Transaction ID
-      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string             Hex formatted private key used to authenticate with ACP
+      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
+      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
+      --log-format string           Log format to use. Options are text or json (default "text")
+      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                  Include source location in logs
+      --log-stacktrace              Include stacktrace in error and fatal logs
+      --no-keyring                  Disable the keyring and generate ephemeral keys
+      --no-log-color                Disable colored log output
+      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
+      --secret-file string          Path to the file containing secrets (default ".env")
+      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                     Transaction ID
+      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_p2p_collection_getall.md
+++ b/docs/website/references/cli/defradb_client_p2p_collection_getall.md
@@ -20,22 +20,23 @@ defradb client p2p collection getall [flags]
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
-      --log-format string           Log format to use. Options are text or json (default "text")
-      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                  Include source location in logs
-      --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
-      --no-log-color                Disable colored log output
-      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                     Transaction ID
-      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string              Hex formatted private key used to authenticate with ACP
+      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
+      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
+      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
+      --log-format string            Log format to use. Options are text or json (default "text")
+      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                   Include source location in logs
+      --log-stacktrace               Include stacktrace in error and fatal logs
+      --no-keyring                   Disable the keyring and generate ephemeral keys
+      --no-log-color                 Disable colored log output
+      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
+      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                      Transaction ID
+      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_p2p_collection_remove.md
+++ b/docs/website/references/cli/defradb_client_p2p_collection_remove.md
@@ -27,22 +27,23 @@ defradb client p2p collection remove [collectionIDs] [flags]
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
-      --log-format string           Log format to use. Options are text or json (default "text")
-      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                  Include source location in logs
-      --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
-      --no-log-color                Disable colored log output
-      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                     Transaction ID
-      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string              Hex formatted private key used to authenticate with ACP
+      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
+      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
+      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
+      --log-format string            Log format to use. Options are text or json (default "text")
+      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                   Include source location in logs
+      --log-stacktrace               Include stacktrace in error and fatal logs
+      --no-keyring                   Disable the keyring and generate ephemeral keys
+      --no-log-color                 Disable colored log output
+      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
+      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                      Transaction ID
+      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_p2p_collection_remove.md
+++ b/docs/website/references/cli/defradb_client_p2p_collection_remove.md
@@ -27,23 +27,23 @@ defradb client p2p collection remove [collectionIDs] [flags]
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string              Hex formatted private key used to authenticate with ACP
-      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
-      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
-      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
-      --log-format string            Log format to use. Options are text or json (default "text")
-      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                   Include source location in logs
-      --log-stacktrace               Include stacktrace in error and fatal logs
-      --no-keyring                   Disable the keyring and generate ephemeral keys
-      --no-log-color                 Disable colored log output
-      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                      Transaction ID
-      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string             Hex formatted private key used to authenticate with ACP
+      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
+      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
+      --log-format string           Log format to use. Options are text or json (default "text")
+      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                  Include source location in logs
+      --log-stacktrace              Include stacktrace in error and fatal logs
+      --no-keyring                  Disable the keyring and generate ephemeral keys
+      --no-log-color                Disable colored log output
+      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
+      --secret-file string          Path to the file containing secrets (default ".env")
+      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                     Transaction ID
+      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_p2p_info.md
+++ b/docs/website/references/cli/defradb_client_p2p_info.md
@@ -19,23 +19,23 @@ defradb client p2p info [flags]
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string              Hex formatted private key used to authenticate with ACP
-      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
-      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
-      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
-      --log-format string            Log format to use. Options are text or json (default "text")
-      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                   Include source location in logs
-      --log-stacktrace               Include stacktrace in error and fatal logs
-      --no-keyring                   Disable the keyring and generate ephemeral keys
-      --no-log-color                 Disable colored log output
-      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                      Transaction ID
-      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string             Hex formatted private key used to authenticate with ACP
+      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
+      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
+      --log-format string           Log format to use. Options are text or json (default "text")
+      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                  Include source location in logs
+      --log-stacktrace              Include stacktrace in error and fatal logs
+      --no-keyring                  Disable the keyring and generate ephemeral keys
+      --no-log-color                Disable colored log output
+      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
+      --secret-file string          Path to the file containing secrets (default ".env")
+      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                     Transaction ID
+      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_p2p_info.md
+++ b/docs/website/references/cli/defradb_client_p2p_info.md
@@ -19,22 +19,23 @@ defradb client p2p info [flags]
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
-      --log-format string           Log format to use. Options are text or json (default "text")
-      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                  Include source location in logs
-      --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
-      --no-log-color                Disable colored log output
-      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                     Transaction ID
-      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string              Hex formatted private key used to authenticate with ACP
+      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
+      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
+      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
+      --log-format string            Log format to use. Options are text or json (default "text")
+      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                   Include source location in logs
+      --log-stacktrace               Include stacktrace in error and fatal logs
+      --no-keyring                   Disable the keyring and generate ephemeral keys
+      --no-log-color                 Disable colored log output
+      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
+      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                      Transaction ID
+      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_p2p_replicator.md
+++ b/docs/website/references/cli/defradb_client_p2p_replicator.md
@@ -16,22 +16,23 @@ A replicator replicates one or all collection(s) from one node to another.
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
-      --log-format string           Log format to use. Options are text or json (default "text")
-      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                  Include source location in logs
-      --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
-      --no-log-color                Disable colored log output
-      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                     Transaction ID
-      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string              Hex formatted private key used to authenticate with ACP
+      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
+      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
+      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
+      --log-format string            Log format to use. Options are text or json (default "text")
+      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                   Include source location in logs
+      --log-stacktrace               Include stacktrace in error and fatal logs
+      --no-keyring                   Disable the keyring and generate ephemeral keys
+      --no-log-color                 Disable colored log output
+      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
+      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                      Transaction ID
+      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_p2p_replicator.md
+++ b/docs/website/references/cli/defradb_client_p2p_replicator.md
@@ -16,23 +16,23 @@ A replicator replicates one or all collection(s) from one node to another.
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string              Hex formatted private key used to authenticate with ACP
-      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
-      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
-      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
-      --log-format string            Log format to use. Options are text or json (default "text")
-      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                   Include source location in logs
-      --log-stacktrace               Include stacktrace in error and fatal logs
-      --no-keyring                   Disable the keyring and generate ephemeral keys
-      --no-log-color                 Disable colored log output
-      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                      Transaction ID
-      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string             Hex formatted private key used to authenticate with ACP
+      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
+      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
+      --log-format string           Log format to use. Options are text or json (default "text")
+      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                  Include source location in logs
+      --log-stacktrace              Include stacktrace in error and fatal logs
+      --no-keyring                  Disable the keyring and generate ephemeral keys
+      --no-log-color                Disable colored log output
+      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
+      --secret-file string          Path to the file containing secrets (default ".env")
+      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                     Transaction ID
+      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_p2p_replicator_delete.md
+++ b/docs/website/references/cli/defradb_client_p2p_replicator_delete.md
@@ -25,22 +25,23 @@ defradb client p2p replicator delete [-c, --collection] <peer> [flags]
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
-      --log-format string           Log format to use. Options are text or json (default "text")
-      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                  Include source location in logs
-      --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
-      --no-log-color                Disable colored log output
-      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                     Transaction ID
-      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string              Hex formatted private key used to authenticate with ACP
+      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
+      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
+      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
+      --log-format string            Log format to use. Options are text or json (default "text")
+      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                   Include source location in logs
+      --log-stacktrace               Include stacktrace in error and fatal logs
+      --no-keyring                   Disable the keyring and generate ephemeral keys
+      --no-log-color                 Disable colored log output
+      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
+      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                      Transaction ID
+      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_p2p_replicator_delete.md
+++ b/docs/website/references/cli/defradb_client_p2p_replicator_delete.md
@@ -25,23 +25,23 @@ defradb client p2p replicator delete [-c, --collection] <peer> [flags]
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string              Hex formatted private key used to authenticate with ACP
-      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
-      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
-      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
-      --log-format string            Log format to use. Options are text or json (default "text")
-      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                   Include source location in logs
-      --log-stacktrace               Include stacktrace in error and fatal logs
-      --no-keyring                   Disable the keyring and generate ephemeral keys
-      --no-log-color                 Disable colored log output
-      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                      Transaction ID
-      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string             Hex formatted private key used to authenticate with ACP
+      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
+      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
+      --log-format string           Log format to use. Options are text or json (default "text")
+      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                  Include source location in logs
+      --log-stacktrace              Include stacktrace in error and fatal logs
+      --no-keyring                  Disable the keyring and generate ephemeral keys
+      --no-log-color                Disable colored log output
+      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
+      --secret-file string          Path to the file containing secrets (default ".env")
+      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                     Transaction ID
+      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_p2p_replicator_getall.md
+++ b/docs/website/references/cli/defradb_client_p2p_replicator_getall.md
@@ -24,22 +24,23 @@ defradb client p2p replicator getall [flags]
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
-      --log-format string           Log format to use. Options are text or json (default "text")
-      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                  Include source location in logs
-      --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
-      --no-log-color                Disable colored log output
-      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                     Transaction ID
-      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string              Hex formatted private key used to authenticate with ACP
+      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
+      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
+      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
+      --log-format string            Log format to use. Options are text or json (default "text")
+      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                   Include source location in logs
+      --log-stacktrace               Include stacktrace in error and fatal logs
+      --no-keyring                   Disable the keyring and generate ephemeral keys
+      --no-log-color                 Disable colored log output
+      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
+      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                      Transaction ID
+      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_p2p_replicator_getall.md
+++ b/docs/website/references/cli/defradb_client_p2p_replicator_getall.md
@@ -24,23 +24,23 @@ defradb client p2p replicator getall [flags]
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string              Hex formatted private key used to authenticate with ACP
-      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
-      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
-      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
-      --log-format string            Log format to use. Options are text or json (default "text")
-      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                   Include source location in logs
-      --log-stacktrace               Include stacktrace in error and fatal logs
-      --no-keyring                   Disable the keyring and generate ephemeral keys
-      --no-log-color                 Disable colored log output
-      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                      Transaction ID
-      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string             Hex formatted private key used to authenticate with ACP
+      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
+      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
+      --log-format string           Log format to use. Options are text or json (default "text")
+      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                  Include source location in logs
+      --log-stacktrace              Include stacktrace in error and fatal logs
+      --no-keyring                  Disable the keyring and generate ephemeral keys
+      --no-log-color                Disable colored log output
+      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
+      --secret-file string          Path to the file containing secrets (default ".env")
+      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                     Transaction ID
+      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_p2p_replicator_set.md
+++ b/docs/website/references/cli/defradb_client_p2p_replicator_set.md
@@ -25,22 +25,23 @@ defradb client p2p replicator set [-c, --collection] <peer> [flags]
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
-      --log-format string           Log format to use. Options are text or json (default "text")
-      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                  Include source location in logs
-      --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
-      --no-log-color                Disable colored log output
-      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                     Transaction ID
-      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string              Hex formatted private key used to authenticate with ACP
+      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
+      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
+      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
+      --log-format string            Log format to use. Options are text or json (default "text")
+      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                   Include source location in logs
+      --log-stacktrace               Include stacktrace in error and fatal logs
+      --no-keyring                   Disable the keyring and generate ephemeral keys
+      --no-log-color                 Disable colored log output
+      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
+      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                      Transaction ID
+      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_p2p_replicator_set.md
+++ b/docs/website/references/cli/defradb_client_p2p_replicator_set.md
@@ -25,23 +25,23 @@ defradb client p2p replicator set [-c, --collection] <peer> [flags]
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string              Hex formatted private key used to authenticate with ACP
-      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
-      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
-      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
-      --log-format string            Log format to use. Options are text or json (default "text")
-      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                   Include source location in logs
-      --log-stacktrace               Include stacktrace in error and fatal logs
-      --no-keyring                   Disable the keyring and generate ephemeral keys
-      --no-log-color                 Disable colored log output
-      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                      Transaction ID
-      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string             Hex formatted private key used to authenticate with ACP
+      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
+      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
+      --log-format string           Log format to use. Options are text or json (default "text")
+      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                  Include source location in logs
+      --log-stacktrace              Include stacktrace in error and fatal logs
+      --no-keyring                  Disable the keyring and generate ephemeral keys
+      --no-log-color                Disable colored log output
+      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
+      --secret-file string          Path to the file containing secrets (default ".env")
+      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                     Transaction ID
+      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_purge.md
+++ b/docs/website/references/cli/defradb_client_purge.md
@@ -21,22 +21,23 @@ defradb client purge [flags]
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
-      --log-format string           Log format to use. Options are text or json (default "text")
-      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                  Include source location in logs
-      --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
-      --no-log-color                Disable colored log output
-      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                     Transaction ID
-      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string              Hex formatted private key used to authenticate with ACP
+      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
+      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
+      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
+      --log-format string            Log format to use. Options are text or json (default "text")
+      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                   Include source location in logs
+      --log-stacktrace               Include stacktrace in error and fatal logs
+      --no-keyring                   Disable the keyring and generate ephemeral keys
+      --no-log-color                 Disable colored log output
+      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
+      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                      Transaction ID
+      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_purge.md
+++ b/docs/website/references/cli/defradb_client_purge.md
@@ -21,23 +21,23 @@ defradb client purge [flags]
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string              Hex formatted private key used to authenticate with ACP
-      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
-      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
-      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
-      --log-format string            Log format to use. Options are text or json (default "text")
-      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                   Include source location in logs
-      --log-stacktrace               Include stacktrace in error and fatal logs
-      --no-keyring                   Disable the keyring and generate ephemeral keys
-      --no-log-color                 Disable colored log output
-      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                      Transaction ID
-      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string             Hex formatted private key used to authenticate with ACP
+      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
+      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
+      --log-format string           Log format to use. Options are text or json (default "text")
+      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                  Include source location in logs
+      --log-stacktrace              Include stacktrace in error and fatal logs
+      --no-keyring                  Disable the keyring and generate ephemeral keys
+      --no-log-color                Disable colored log output
+      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
+      --secret-file string          Path to the file containing secrets (default ".env")
+      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                     Transaction ID
+      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_query.md
+++ b/docs/website/references/cli/defradb_client_query.md
@@ -39,22 +39,23 @@ defradb client query [-i --identity] [request] [flags]
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
-      --log-format string           Log format to use. Options are text or json (default "text")
-      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                  Include source location in logs
-      --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
-      --no-log-color                Disable colored log output
-      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                     Transaction ID
-      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string              Hex formatted private key used to authenticate with ACP
+      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
+      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
+      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
+      --log-format string            Log format to use. Options are text or json (default "text")
+      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                   Include source location in logs
+      --log-stacktrace               Include stacktrace in error and fatal logs
+      --no-keyring                   Disable the keyring and generate ephemeral keys
+      --no-log-color                 Disable colored log output
+      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
+      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                      Transaction ID
+      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_query.md
+++ b/docs/website/references/cli/defradb_client_query.md
@@ -39,23 +39,23 @@ defradb client query [-i --identity] [request] [flags]
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string              Hex formatted private key used to authenticate with ACP
-      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
-      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
-      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
-      --log-format string            Log format to use. Options are text or json (default "text")
-      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                   Include source location in logs
-      --log-stacktrace               Include stacktrace in error and fatal logs
-      --no-keyring                   Disable the keyring and generate ephemeral keys
-      --no-log-color                 Disable colored log output
-      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                      Transaction ID
-      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string             Hex formatted private key used to authenticate with ACP
+      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
+      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
+      --log-format string           Log format to use. Options are text or json (default "text")
+      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                  Include source location in logs
+      --log-stacktrace              Include stacktrace in error and fatal logs
+      --no-keyring                  Disable the keyring and generate ephemeral keys
+      --no-log-color                Disable colored log output
+      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
+      --secret-file string          Path to the file containing secrets (default ".env")
+      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                     Transaction ID
+      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_schema.md
+++ b/docs/website/references/cli/defradb_client_schema.md
@@ -15,23 +15,23 @@ Make changes, updates, or look for existing schema types.
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string              Hex formatted private key used to authenticate with ACP
-      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
-      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
-      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
-      --log-format string            Log format to use. Options are text or json (default "text")
-      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                   Include source location in logs
-      --log-stacktrace               Include stacktrace in error and fatal logs
-      --no-keyring                   Disable the keyring and generate ephemeral keys
-      --no-log-color                 Disable colored log output
-      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                      Transaction ID
-      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string             Hex formatted private key used to authenticate with ACP
+      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
+      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
+      --log-format string           Log format to use. Options are text or json (default "text")
+      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                  Include source location in logs
+      --log-stacktrace              Include stacktrace in error and fatal logs
+      --no-keyring                  Disable the keyring and generate ephemeral keys
+      --no-log-color                Disable colored log output
+      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
+      --secret-file string          Path to the file containing secrets (default ".env")
+      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                     Transaction ID
+      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_schema.md
+++ b/docs/website/references/cli/defradb_client_schema.md
@@ -15,22 +15,23 @@ Make changes, updates, or look for existing schema types.
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
-      --log-format string           Log format to use. Options are text or json (default "text")
-      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                  Include source location in logs
-      --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
-      --no-log-color                Disable colored log output
-      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                     Transaction ID
-      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string              Hex formatted private key used to authenticate with ACP
+      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
+      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
+      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
+      --log-format string            Log format to use. Options are text or json (default "text")
+      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                   Include source location in logs
+      --log-stacktrace               Include stacktrace in error and fatal logs
+      --no-keyring                   Disable the keyring and generate ephemeral keys
+      --no-log-color                 Disable colored log output
+      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
+      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                      Transaction ID
+      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_schema_add.md
+++ b/docs/website/references/cli/defradb_client_schema_add.md
@@ -36,22 +36,23 @@ defradb client schema add [schema] [flags]
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
-      --log-format string           Log format to use. Options are text or json (default "text")
-      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                  Include source location in logs
-      --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
-      --no-log-color                Disable colored log output
-      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                     Transaction ID
-      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string              Hex formatted private key used to authenticate with ACP
+      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
+      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
+      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
+      --log-format string            Log format to use. Options are text or json (default "text")
+      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                   Include source location in logs
+      --log-stacktrace               Include stacktrace in error and fatal logs
+      --no-keyring                   Disable the keyring and generate ephemeral keys
+      --no-log-color                 Disable colored log output
+      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
+      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                      Transaction ID
+      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_schema_add.md
+++ b/docs/website/references/cli/defradb_client_schema_add.md
@@ -36,23 +36,23 @@ defradb client schema add [schema] [flags]
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string              Hex formatted private key used to authenticate with ACP
-      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
-      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
-      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
-      --log-format string            Log format to use. Options are text or json (default "text")
-      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                   Include source location in logs
-      --log-stacktrace               Include stacktrace in error and fatal logs
-      --no-keyring                   Disable the keyring and generate ephemeral keys
-      --no-log-color                 Disable colored log output
-      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                      Transaction ID
-      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string             Hex formatted private key used to authenticate with ACP
+      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
+      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
+      --log-format string           Log format to use. Options are text or json (default "text")
+      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                  Include source location in logs
+      --log-stacktrace              Include stacktrace in error and fatal logs
+      --no-keyring                  Disable the keyring and generate ephemeral keys
+      --no-log-color                Disable colored log output
+      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
+      --secret-file string          Path to the file containing secrets (default ".env")
+      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                     Transaction ID
+      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_schema_describe.md
+++ b/docs/website/references/cli/defradb_client_schema_describe.md
@@ -35,23 +35,23 @@ defradb client schema describe [flags]
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string              Hex formatted private key used to authenticate with ACP
-      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
-      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
-      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
-      --log-format string            Log format to use. Options are text or json (default "text")
-      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                   Include source location in logs
-      --log-stacktrace               Include stacktrace in error and fatal logs
-      --no-keyring                   Disable the keyring and generate ephemeral keys
-      --no-log-color                 Disable colored log output
-      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                      Transaction ID
-      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string             Hex formatted private key used to authenticate with ACP
+      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
+      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
+      --log-format string           Log format to use. Options are text or json (default "text")
+      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                  Include source location in logs
+      --log-stacktrace              Include stacktrace in error and fatal logs
+      --no-keyring                  Disable the keyring and generate ephemeral keys
+      --no-log-color                Disable colored log output
+      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
+      --secret-file string          Path to the file containing secrets (default ".env")
+      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                     Transaction ID
+      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_schema_describe.md
+++ b/docs/website/references/cli/defradb_client_schema_describe.md
@@ -35,22 +35,23 @@ defradb client schema describe [flags]
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
-      --log-format string           Log format to use. Options are text or json (default "text")
-      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                  Include source location in logs
-      --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
-      --no-log-color                Disable colored log output
-      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                     Transaction ID
-      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string              Hex formatted private key used to authenticate with ACP
+      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
+      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
+      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
+      --log-format string            Log format to use. Options are text or json (default "text")
+      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                   Include source location in logs
+      --log-stacktrace               Include stacktrace in error and fatal logs
+      --no-keyring                   Disable the keyring and generate ephemeral keys
+      --no-log-color                 Disable colored log output
+      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
+      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                      Transaction ID
+      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_schema_migration.md
+++ b/docs/website/references/cli/defradb_client_schema_migration.md
@@ -15,22 +15,23 @@ Make set or look for existing schema migrations on a DefraDB node.
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
-      --log-format string           Log format to use. Options are text or json (default "text")
-      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                  Include source location in logs
-      --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
-      --no-log-color                Disable colored log output
-      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                     Transaction ID
-      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string              Hex formatted private key used to authenticate with ACP
+      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
+      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
+      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
+      --log-format string            Log format to use. Options are text or json (default "text")
+      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                   Include source location in logs
+      --log-stacktrace               Include stacktrace in error and fatal logs
+      --no-keyring                   Disable the keyring and generate ephemeral keys
+      --no-log-color                 Disable colored log output
+      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
+      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                      Transaction ID
+      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_schema_migration.md
+++ b/docs/website/references/cli/defradb_client_schema_migration.md
@@ -15,23 +15,23 @@ Make set or look for existing schema migrations on a DefraDB node.
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string              Hex formatted private key used to authenticate with ACP
-      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
-      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
-      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
-      --log-format string            Log format to use. Options are text or json (default "text")
-      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                   Include source location in logs
-      --log-stacktrace               Include stacktrace in error and fatal logs
-      --no-keyring                   Disable the keyring and generate ephemeral keys
-      --no-log-color                 Disable colored log output
-      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                      Transaction ID
-      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string             Hex formatted private key used to authenticate with ACP
+      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
+      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
+      --log-format string           Log format to use. Options are text or json (default "text")
+      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                  Include source location in logs
+      --log-stacktrace              Include stacktrace in error and fatal logs
+      --no-keyring                  Disable the keyring and generate ephemeral keys
+      --no-log-color                Disable colored log output
+      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
+      --secret-file string          Path to the file containing secrets (default ".env")
+      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                     Transaction ID
+      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_schema_migration_down.md
+++ b/docs/website/references/cli/defradb_client_schema_migration_down.md
@@ -32,23 +32,23 @@ defradb client schema migration down --collection <collectionID> <documents> [fl
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string              Hex formatted private key used to authenticate with ACP
-      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
-      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
-      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
-      --log-format string            Log format to use. Options are text or json (default "text")
-      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                   Include source location in logs
-      --log-stacktrace               Include stacktrace in error and fatal logs
-      --no-keyring                   Disable the keyring and generate ephemeral keys
-      --no-log-color                 Disable colored log output
-      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                      Transaction ID
-      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string             Hex formatted private key used to authenticate with ACP
+      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
+      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
+      --log-format string           Log format to use. Options are text or json (default "text")
+      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                  Include source location in logs
+      --log-stacktrace              Include stacktrace in error and fatal logs
+      --no-keyring                  Disable the keyring and generate ephemeral keys
+      --no-log-color                Disable colored log output
+      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
+      --secret-file string          Path to the file containing secrets (default ".env")
+      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                     Transaction ID
+      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_schema_migration_down.md
+++ b/docs/website/references/cli/defradb_client_schema_migration_down.md
@@ -32,22 +32,23 @@ defradb client schema migration down --collection <collectionID> <documents> [fl
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
-      --log-format string           Log format to use. Options are text or json (default "text")
-      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                  Include source location in logs
-      --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
-      --no-log-color                Disable colored log output
-      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                     Transaction ID
-      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string              Hex formatted private key used to authenticate with ACP
+      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
+      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
+      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
+      --log-format string            Log format to use. Options are text or json (default "text")
+      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                   Include source location in logs
+      --log-stacktrace               Include stacktrace in error and fatal logs
+      --no-keyring                   Disable the keyring and generate ephemeral keys
+      --no-log-color                 Disable colored log output
+      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
+      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                      Transaction ID
+      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_schema_migration_reload.md
+++ b/docs/website/references/cli/defradb_client_schema_migration_reload.md
@@ -19,23 +19,23 @@ defradb client schema migration reload [flags]
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string              Hex formatted private key used to authenticate with ACP
-      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
-      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
-      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
-      --log-format string            Log format to use. Options are text or json (default "text")
-      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                   Include source location in logs
-      --log-stacktrace               Include stacktrace in error and fatal logs
-      --no-keyring                   Disable the keyring and generate ephemeral keys
-      --no-log-color                 Disable colored log output
-      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                      Transaction ID
-      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string             Hex formatted private key used to authenticate with ACP
+      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
+      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
+      --log-format string           Log format to use. Options are text or json (default "text")
+      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                  Include source location in logs
+      --log-stacktrace              Include stacktrace in error and fatal logs
+      --no-keyring                  Disable the keyring and generate ephemeral keys
+      --no-log-color                Disable colored log output
+      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
+      --secret-file string          Path to the file containing secrets (default ".env")
+      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                     Transaction ID
+      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_schema_migration_reload.md
+++ b/docs/website/references/cli/defradb_client_schema_migration_reload.md
@@ -19,22 +19,23 @@ defradb client schema migration reload [flags]
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
-      --log-format string           Log format to use. Options are text or json (default "text")
-      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                  Include source location in logs
-      --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
-      --no-log-color                Disable colored log output
-      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                     Transaction ID
-      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string              Hex formatted private key used to authenticate with ACP
+      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
+      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
+      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
+      --log-format string            Log format to use. Options are text or json (default "text")
+      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                   Include source location in logs
+      --log-stacktrace               Include stacktrace in error and fatal logs
+      --no-keyring                   Disable the keyring and generate ephemeral keys
+      --no-log-color                 Disable colored log output
+      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
+      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                      Transaction ID
+      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_schema_migration_set-registry.md
+++ b/docs/website/references/cli/defradb_client_schema_migration_set-registry.md
@@ -25,22 +25,23 @@ defradb client schema migration set-registry [collectionID] [cfg] [flags]
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
-      --log-format string           Log format to use. Options are text or json (default "text")
-      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                  Include source location in logs
-      --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
-      --no-log-color                Disable colored log output
-      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                     Transaction ID
-      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string              Hex formatted private key used to authenticate with ACP
+      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
+      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
+      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
+      --log-format string            Log format to use. Options are text or json (default "text")
+      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                   Include source location in logs
+      --log-stacktrace               Include stacktrace in error and fatal logs
+      --no-keyring                   Disable the keyring and generate ephemeral keys
+      --no-log-color                 Disable colored log output
+      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
+      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                      Transaction ID
+      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_schema_migration_set-registry.md
+++ b/docs/website/references/cli/defradb_client_schema_migration_set-registry.md
@@ -25,23 +25,23 @@ defradb client schema migration set-registry [collectionID] [cfg] [flags]
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string              Hex formatted private key used to authenticate with ACP
-      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
-      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
-      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
-      --log-format string            Log format to use. Options are text or json (default "text")
-      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                   Include source location in logs
-      --log-stacktrace               Include stacktrace in error and fatal logs
-      --no-keyring                   Disable the keyring and generate ephemeral keys
-      --no-log-color                 Disable colored log output
-      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                      Transaction ID
-      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string             Hex formatted private key used to authenticate with ACP
+      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
+      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
+      --log-format string           Log format to use. Options are text or json (default "text")
+      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                  Include source location in logs
+      --log-stacktrace              Include stacktrace in error and fatal logs
+      --no-keyring                  Disable the keyring and generate ephemeral keys
+      --no-log-color                Disable colored log output
+      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
+      --secret-file string          Path to the file containing secrets (default ".env")
+      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                     Transaction ID
+      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_schema_migration_set.md
+++ b/docs/website/references/cli/defradb_client_schema_migration_set.md
@@ -32,23 +32,23 @@ defradb client schema migration set [src] [dst] [cfg] [flags]
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string              Hex formatted private key used to authenticate with ACP
-      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
-      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
-      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
-      --log-format string            Log format to use. Options are text or json (default "text")
-      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                   Include source location in logs
-      --log-stacktrace               Include stacktrace in error and fatal logs
-      --no-keyring                   Disable the keyring and generate ephemeral keys
-      --no-log-color                 Disable colored log output
-      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                      Transaction ID
-      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string             Hex formatted private key used to authenticate with ACP
+      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
+      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
+      --log-format string           Log format to use. Options are text or json (default "text")
+      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                  Include source location in logs
+      --log-stacktrace              Include stacktrace in error and fatal logs
+      --no-keyring                  Disable the keyring and generate ephemeral keys
+      --no-log-color                Disable colored log output
+      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
+      --secret-file string          Path to the file containing secrets (default ".env")
+      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                     Transaction ID
+      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_schema_migration_set.md
+++ b/docs/website/references/cli/defradb_client_schema_migration_set.md
@@ -32,22 +32,23 @@ defradb client schema migration set [src] [dst] [cfg] [flags]
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
-      --log-format string           Log format to use. Options are text or json (default "text")
-      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                  Include source location in logs
-      --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
-      --no-log-color                Disable colored log output
-      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                     Transaction ID
-      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string              Hex formatted private key used to authenticate with ACP
+      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
+      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
+      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
+      --log-format string            Log format to use. Options are text or json (default "text")
+      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                   Include source location in logs
+      --log-stacktrace               Include stacktrace in error and fatal logs
+      --no-keyring                   Disable the keyring and generate ephemeral keys
+      --no-log-color                 Disable colored log output
+      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
+      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                      Transaction ID
+      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_schema_migration_up.md
+++ b/docs/website/references/cli/defradb_client_schema_migration_up.md
@@ -32,23 +32,23 @@ defradb client schema migration up --collection <collectionID> <documents> [flag
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string              Hex formatted private key used to authenticate with ACP
-      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
-      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
-      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
-      --log-format string            Log format to use. Options are text or json (default "text")
-      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                   Include source location in logs
-      --log-stacktrace               Include stacktrace in error and fatal logs
-      --no-keyring                   Disable the keyring and generate ephemeral keys
-      --no-log-color                 Disable colored log output
-      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                      Transaction ID
-      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string             Hex formatted private key used to authenticate with ACP
+      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
+      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
+      --log-format string           Log format to use. Options are text or json (default "text")
+      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                  Include source location in logs
+      --log-stacktrace              Include stacktrace in error and fatal logs
+      --no-keyring                  Disable the keyring and generate ephemeral keys
+      --no-log-color                Disable colored log output
+      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
+      --secret-file string          Path to the file containing secrets (default ".env")
+      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                     Transaction ID
+      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_schema_migration_up.md
+++ b/docs/website/references/cli/defradb_client_schema_migration_up.md
@@ -32,22 +32,23 @@ defradb client schema migration up --collection <collectionID> <documents> [flag
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
-      --log-format string           Log format to use. Options are text or json (default "text")
-      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                  Include source location in logs
-      --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
-      --no-log-color                Disable colored log output
-      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                     Transaction ID
-      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string              Hex formatted private key used to authenticate with ACP
+      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
+      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
+      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
+      --log-format string            Log format to use. Options are text or json (default "text")
+      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                   Include source location in logs
+      --log-stacktrace               Include stacktrace in error and fatal logs
+      --no-keyring                   Disable the keyring and generate ephemeral keys
+      --no-log-color                 Disable colored log output
+      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
+      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                      Transaction ID
+      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_schema_patch.md
+++ b/docs/website/references/cli/defradb_client_schema_patch.md
@@ -35,23 +35,23 @@ defradb client schema patch [schema] [migration] [flags]
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string              Hex formatted private key used to authenticate with ACP
-      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
-      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
-      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
-      --log-format string            Log format to use. Options are text or json (default "text")
-      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                   Include source location in logs
-      --log-stacktrace               Include stacktrace in error and fatal logs
-      --no-keyring                   Disable the keyring and generate ephemeral keys
-      --no-log-color                 Disable colored log output
-      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                      Transaction ID
-      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string             Hex formatted private key used to authenticate with ACP
+      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
+      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
+      --log-format string           Log format to use. Options are text or json (default "text")
+      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                  Include source location in logs
+      --log-stacktrace              Include stacktrace in error and fatal logs
+      --no-keyring                  Disable the keyring and generate ephemeral keys
+      --no-log-color                Disable colored log output
+      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
+      --secret-file string          Path to the file containing secrets (default ".env")
+      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                     Transaction ID
+      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_schema_patch.md
+++ b/docs/website/references/cli/defradb_client_schema_patch.md
@@ -35,22 +35,23 @@ defradb client schema patch [schema] [migration] [flags]
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
-      --log-format string           Log format to use. Options are text or json (default "text")
-      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                  Include source location in logs
-      --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
-      --no-log-color                Disable colored log output
-      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                     Transaction ID
-      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string              Hex formatted private key used to authenticate with ACP
+      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
+      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
+      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
+      --log-format string            Log format to use. Options are text or json (default "text")
+      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                   Include source location in logs
+      --log-stacktrace               Include stacktrace in error and fatal logs
+      --no-keyring                   Disable the keyring and generate ephemeral keys
+      --no-log-color                 Disable colored log output
+      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
+      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                      Transaction ID
+      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_schema_set-active.md
+++ b/docs/website/references/cli/defradb_client_schema_set-active.md
@@ -20,22 +20,23 @@ defradb client schema set-active [versionID] [flags]
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
-      --log-format string           Log format to use. Options are text or json (default "text")
-      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                  Include source location in logs
-      --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
-      --no-log-color                Disable colored log output
-      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                     Transaction ID
-      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string              Hex formatted private key used to authenticate with ACP
+      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
+      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
+      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
+      --log-format string            Log format to use. Options are text or json (default "text")
+      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                   Include source location in logs
+      --log-stacktrace               Include stacktrace in error and fatal logs
+      --no-keyring                   Disable the keyring and generate ephemeral keys
+      --no-log-color                 Disable colored log output
+      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
+      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                      Transaction ID
+      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_schema_set-active.md
+++ b/docs/website/references/cli/defradb_client_schema_set-active.md
@@ -20,23 +20,23 @@ defradb client schema set-active [versionID] [flags]
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string              Hex formatted private key used to authenticate with ACP
-      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
-      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
-      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
-      --log-format string            Log format to use. Options are text or json (default "text")
-      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                   Include source location in logs
-      --log-stacktrace               Include stacktrace in error and fatal logs
-      --no-keyring                   Disable the keyring and generate ephemeral keys
-      --no-log-color                 Disable colored log output
-      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                      Transaction ID
-      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string             Hex formatted private key used to authenticate with ACP
+      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
+      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
+      --log-format string           Log format to use. Options are text or json (default "text")
+      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                  Include source location in logs
+      --log-stacktrace              Include stacktrace in error and fatal logs
+      --no-keyring                  Disable the keyring and generate ephemeral keys
+      --no-log-color                Disable colored log output
+      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
+      --secret-file string          Path to the file containing secrets (default ".env")
+      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                     Transaction ID
+      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_tx.md
+++ b/docs/website/references/cli/defradb_client_tx.md
@@ -15,22 +15,23 @@ Create, commit, and discard DefraDB transactions
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
-      --log-format string           Log format to use. Options are text or json (default "text")
-      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                  Include source location in logs
-      --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
-      --no-log-color                Disable colored log output
-      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                     Transaction ID
-      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string              Hex formatted private key used to authenticate with ACP
+      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
+      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
+      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
+      --log-format string            Log format to use. Options are text or json (default "text")
+      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                   Include source location in logs
+      --log-stacktrace               Include stacktrace in error and fatal logs
+      --no-keyring                   Disable the keyring and generate ephemeral keys
+      --no-log-color                 Disable colored log output
+      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
+      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                      Transaction ID
+      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_tx.md
+++ b/docs/website/references/cli/defradb_client_tx.md
@@ -15,23 +15,23 @@ Create, commit, and discard DefraDB transactions
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string              Hex formatted private key used to authenticate with ACP
-      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
-      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
-      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
-      --log-format string            Log format to use. Options are text or json (default "text")
-      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                   Include source location in logs
-      --log-stacktrace               Include stacktrace in error and fatal logs
-      --no-keyring                   Disable the keyring and generate ephemeral keys
-      --no-log-color                 Disable colored log output
-      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                      Transaction ID
-      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string             Hex formatted private key used to authenticate with ACP
+      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
+      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
+      --log-format string           Log format to use. Options are text or json (default "text")
+      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                  Include source location in logs
+      --log-stacktrace              Include stacktrace in error and fatal logs
+      --no-keyring                  Disable the keyring and generate ephemeral keys
+      --no-log-color                Disable colored log output
+      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
+      --secret-file string          Path to the file containing secrets (default ".env")
+      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                     Transaction ID
+      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_tx_commit.md
+++ b/docs/website/references/cli/defradb_client_tx_commit.md
@@ -19,23 +19,23 @@ defradb client tx commit [id] [flags]
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string              Hex formatted private key used to authenticate with ACP
-      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
-      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
-      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
-      --log-format string            Log format to use. Options are text or json (default "text")
-      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                   Include source location in logs
-      --log-stacktrace               Include stacktrace in error and fatal logs
-      --no-keyring                   Disable the keyring and generate ephemeral keys
-      --no-log-color                 Disable colored log output
-      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                      Transaction ID
-      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string             Hex formatted private key used to authenticate with ACP
+      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
+      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
+      --log-format string           Log format to use. Options are text or json (default "text")
+      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                  Include source location in logs
+      --log-stacktrace              Include stacktrace in error and fatal logs
+      --no-keyring                  Disable the keyring and generate ephemeral keys
+      --no-log-color                Disable colored log output
+      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
+      --secret-file string          Path to the file containing secrets (default ".env")
+      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                     Transaction ID
+      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_tx_commit.md
+++ b/docs/website/references/cli/defradb_client_tx_commit.md
@@ -19,22 +19,23 @@ defradb client tx commit [id] [flags]
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
-      --log-format string           Log format to use. Options are text or json (default "text")
-      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                  Include source location in logs
-      --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
-      --no-log-color                Disable colored log output
-      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                     Transaction ID
-      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string              Hex formatted private key used to authenticate with ACP
+      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
+      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
+      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
+      --log-format string            Log format to use. Options are text or json (default "text")
+      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                   Include source location in logs
+      --log-stacktrace               Include stacktrace in error and fatal logs
+      --no-keyring                   Disable the keyring and generate ephemeral keys
+      --no-log-color                 Disable colored log output
+      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
+      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                      Transaction ID
+      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_tx_create.md
+++ b/docs/website/references/cli/defradb_client_tx_create.md
@@ -21,22 +21,23 @@ defradb client tx create [flags]
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
-      --log-format string           Log format to use. Options are text or json (default "text")
-      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                  Include source location in logs
-      --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
-      --no-log-color                Disable colored log output
-      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                     Transaction ID
-      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string              Hex formatted private key used to authenticate with ACP
+      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
+      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
+      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
+      --log-format string            Log format to use. Options are text or json (default "text")
+      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                   Include source location in logs
+      --log-stacktrace               Include stacktrace in error and fatal logs
+      --no-keyring                   Disable the keyring and generate ephemeral keys
+      --no-log-color                 Disable colored log output
+      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
+      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                      Transaction ID
+      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_tx_create.md
+++ b/docs/website/references/cli/defradb_client_tx_create.md
@@ -21,23 +21,23 @@ defradb client tx create [flags]
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string              Hex formatted private key used to authenticate with ACP
-      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
-      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
-      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
-      --log-format string            Log format to use. Options are text or json (default "text")
-      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                   Include source location in logs
-      --log-stacktrace               Include stacktrace in error and fatal logs
-      --no-keyring                   Disable the keyring and generate ephemeral keys
-      --no-log-color                 Disable colored log output
-      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                      Transaction ID
-      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string             Hex formatted private key used to authenticate with ACP
+      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
+      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
+      --log-format string           Log format to use. Options are text or json (default "text")
+      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                  Include source location in logs
+      --log-stacktrace              Include stacktrace in error and fatal logs
+      --no-keyring                  Disable the keyring and generate ephemeral keys
+      --no-log-color                Disable colored log output
+      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
+      --secret-file string          Path to the file containing secrets (default ".env")
+      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                     Transaction ID
+      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_tx_discard.md
+++ b/docs/website/references/cli/defradb_client_tx_discard.md
@@ -19,22 +19,23 @@ defradb client tx discard [id] [flags]
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
-      --log-format string           Log format to use. Options are text or json (default "text")
-      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                  Include source location in logs
-      --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
-      --no-log-color                Disable colored log output
-      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                     Transaction ID
-      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string              Hex formatted private key used to authenticate with ACP
+      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
+      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
+      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
+      --log-format string            Log format to use. Options are text or json (default "text")
+      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                   Include source location in logs
+      --log-stacktrace               Include stacktrace in error and fatal logs
+      --no-keyring                   Disable the keyring and generate ephemeral keys
+      --no-log-color                 Disable colored log output
+      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
+      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                      Transaction ID
+      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_tx_discard.md
+++ b/docs/website/references/cli/defradb_client_tx_discard.md
@@ -19,23 +19,23 @@ defradb client tx discard [id] [flags]
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string              Hex formatted private key used to authenticate with ACP
-      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
-      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
-      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
-      --log-format string            Log format to use. Options are text or json (default "text")
-      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                   Include source location in logs
-      --log-stacktrace               Include stacktrace in error and fatal logs
-      --no-keyring                   Disable the keyring and generate ephemeral keys
-      --no-log-color                 Disable colored log output
-      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                      Transaction ID
-      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string             Hex formatted private key used to authenticate with ACP
+      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
+      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
+      --log-format string           Log format to use. Options are text or json (default "text")
+      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                  Include source location in logs
+      --log-stacktrace              Include stacktrace in error and fatal logs
+      --no-keyring                  Disable the keyring and generate ephemeral keys
+      --no-log-color                Disable colored log output
+      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
+      --secret-file string          Path to the file containing secrets (default ".env")
+      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                     Transaction ID
+      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_view.md
+++ b/docs/website/references/cli/defradb_client_view.md
@@ -15,22 +15,23 @@ Manage (add) views withing a running DefraDB instance
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
-      --log-format string           Log format to use. Options are text or json (default "text")
-      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                  Include source location in logs
-      --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
-      --no-log-color                Disable colored log output
-      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                     Transaction ID
-      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string              Hex formatted private key used to authenticate with ACP
+      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
+      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
+      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
+      --log-format string            Log format to use. Options are text or json (default "text")
+      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                   Include source location in logs
+      --log-stacktrace               Include stacktrace in error and fatal logs
+      --no-keyring                   Disable the keyring and generate ephemeral keys
+      --no-log-color                 Disable colored log output
+      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
+      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                      Transaction ID
+      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_view.md
+++ b/docs/website/references/cli/defradb_client_view.md
@@ -15,23 +15,23 @@ Manage (add) views withing a running DefraDB instance
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string              Hex formatted private key used to authenticate with ACP
-      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
-      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
-      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
-      --log-format string            Log format to use. Options are text or json (default "text")
-      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                   Include source location in logs
-      --log-stacktrace               Include stacktrace in error and fatal logs
-      --no-keyring                   Disable the keyring and generate ephemeral keys
-      --no-log-color                 Disable colored log output
-      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                      Transaction ID
-      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string             Hex formatted private key used to authenticate with ACP
+      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
+      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
+      --log-format string           Log format to use. Options are text or json (default "text")
+      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                  Include source location in logs
+      --log-stacktrace              Include stacktrace in error and fatal logs
+      --no-keyring                  Disable the keyring and generate ephemeral keys
+      --no-log-color                Disable colored log output
+      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
+      --secret-file string          Path to the file containing secrets (default ".env")
+      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                     Transaction ID
+      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_view_add.md
+++ b/docs/website/references/cli/defradb_client_view_add.md
@@ -25,22 +25,23 @@ defradb client view add [query] [sdl] [transform] [flags]
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
-      --log-format string           Log format to use. Options are text or json (default "text")
-      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                  Include source location in logs
-      --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
-      --no-log-color                Disable colored log output
-      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                     Transaction ID
-      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string              Hex formatted private key used to authenticate with ACP
+      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
+      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
+      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
+      --log-format string            Log format to use. Options are text or json (default "text")
+      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                   Include source location in logs
+      --log-stacktrace               Include stacktrace in error and fatal logs
+      --no-keyring                   Disable the keyring and generate ephemeral keys
+      --no-log-color                 Disable colored log output
+      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
+      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                      Transaction ID
+      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_view_add.md
+++ b/docs/website/references/cli/defradb_client_view_add.md
@@ -25,23 +25,23 @@ defradb client view add [query] [sdl] [transform] [flags]
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string              Hex formatted private key used to authenticate with ACP
-      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
-      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
-      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
-      --log-format string            Log format to use. Options are text or json (default "text")
-      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                   Include source location in logs
-      --log-stacktrace               Include stacktrace in error and fatal logs
-      --no-keyring                   Disable the keyring and generate ephemeral keys
-      --no-log-color                 Disable colored log output
-      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                      Transaction ID
-      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string             Hex formatted private key used to authenticate with ACP
+      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
+      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
+      --log-format string           Log format to use. Options are text or json (default "text")
+      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                  Include source location in logs
+      --log-stacktrace              Include stacktrace in error and fatal logs
+      --no-keyring                  Disable the keyring and generate ephemeral keys
+      --no-log-color                Disable colored log output
+      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
+      --secret-file string          Path to the file containing secrets (default ".env")
+      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                     Transaction ID
+      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_view_refresh.md
+++ b/docs/website/references/cli/defradb_client_view_refresh.md
@@ -41,22 +41,23 @@ defradb client view refresh [flags]
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
-      --log-format string           Log format to use. Options are text or json (default "text")
-      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                  Include source location in logs
-      --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
-      --no-log-color                Disable colored log output
-      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                     Transaction ID
-      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string              Hex formatted private key used to authenticate with ACP
+      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
+      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
+      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
+      --log-format string            Log format to use. Options are text or json (default "text")
+      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                   Include source location in logs
+      --log-stacktrace               Include stacktrace in error and fatal logs
+      --no-keyring                   Disable the keyring and generate ephemeral keys
+      --no-log-color                 Disable colored log output
+      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
+      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                      Transaction ID
+      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_view_refresh.md
+++ b/docs/website/references/cli/defradb_client_view_refresh.md
@@ -41,23 +41,23 @@ defradb client view refresh [flags]
 ### Options inherited from parent commands
 
 ```
-  -i, --identity string              Hex formatted private key used to authenticate with ACP
-      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
-      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
-      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
-      --log-format string            Log format to use. Options are text or json (default "text")
-      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                   Include source location in logs
-      --log-stacktrace               Include stacktrace in error and fatal logs
-      --no-keyring                   Disable the keyring and generate ephemeral keys
-      --no-log-color                 Disable colored log output
-      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --tx uint                      Transaction ID
-      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -i, --identity string             Hex formatted private key used to authenticate with ACP
+      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
+      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
+      --log-format string           Log format to use. Options are text or json (default "text")
+      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                  Include source location in logs
+      --log-stacktrace              Include stacktrace in error and fatal logs
+      --no-keyring                  Disable the keyring and generate ephemeral keys
+      --no-log-color                Disable colored log output
+      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
+      --secret-file string          Path to the file containing secrets (default ".env")
+      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                     Transaction ID
+      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_identity.md
+++ b/docs/website/references/cli/defradb_identity.md
@@ -15,20 +15,21 @@ Interact with identity features of DefraDB instance
 ### Options inherited from parent commands
 
 ```
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
-      --log-format string           Log format to use. Options are text or json (default "text")
-      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                  Include source location in logs
-      --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
-      --no-log-color                Disable colored log output
-      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
+      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
+      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
+      --log-format string            Log format to use. Options are text or json (default "text")
+      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                   Include source location in logs
+      --log-stacktrace               Include stacktrace in error and fatal logs
+      --no-keyring                   Disable the keyring and generate ephemeral keys
+      --no-log-color                 Disable colored log output
+      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
+      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_identity.md
+++ b/docs/website/references/cli/defradb_identity.md
@@ -15,21 +15,21 @@ Interact with identity features of DefraDB instance
 ### Options inherited from parent commands
 
 ```
-      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
-      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
-      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
-      --log-format string            Log format to use. Options are text or json (default "text")
-      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                   Include source location in logs
-      --log-stacktrace               Include stacktrace in error and fatal logs
-      --no-keyring                   Disable the keyring and generate ephemeral keys
-      --no-log-color                 Disable colored log output
-      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
+      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
+      --log-format string           Log format to use. Options are text or json (default "text")
+      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                  Include source location in logs
+      --log-stacktrace              Include stacktrace in error and fatal logs
+      --no-keyring                  Disable the keyring and generate ephemeral keys
+      --no-log-color                Disable colored log output
+      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
+      --secret-file string          Path to the file containing secrets (default ".env")
+      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_identity_new.md
+++ b/docs/website/references/cli/defradb_identity_new.md
@@ -30,20 +30,21 @@ defradb identity new [flags]
 ### Options inherited from parent commands
 
 ```
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
-      --log-format string           Log format to use. Options are text or json (default "text")
-      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                  Include source location in logs
-      --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
-      --no-log-color                Disable colored log output
-      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
+      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
+      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
+      --log-format string            Log format to use. Options are text or json (default "text")
+      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                   Include source location in logs
+      --log-stacktrace               Include stacktrace in error and fatal logs
+      --no-keyring                   Disable the keyring and generate ephemeral keys
+      --no-log-color                 Disable colored log output
+      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
+      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_identity_new.md
+++ b/docs/website/references/cli/defradb_identity_new.md
@@ -30,21 +30,21 @@ defradb identity new [flags]
 ### Options inherited from parent commands
 
 ```
-      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
-      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
-      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
-      --log-format string            Log format to use. Options are text or json (default "text")
-      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                   Include source location in logs
-      --log-stacktrace               Include stacktrace in error and fatal logs
-      --no-keyring                   Disable the keyring and generate ephemeral keys
-      --no-log-color                 Disable colored log output
-      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
+      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
+      --log-format string           Log format to use. Options are text or json (default "text")
+      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                  Include source location in logs
+      --log-stacktrace              Include stacktrace in error and fatal logs
+      --no-keyring                  Disable the keyring and generate ephemeral keys
+      --no-log-color                Disable colored log output
+      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
+      --secret-file string          Path to the file containing secrets (default ".env")
+      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_keyring.md
+++ b/docs/website/references/cli/defradb_keyring.md
@@ -30,20 +30,21 @@ To learn more about the available options:
 ### Options inherited from parent commands
 
 ```
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
-      --log-format string           Log format to use. Options are text or json (default "text")
-      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                  Include source location in logs
-      --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
-      --no-log-color                Disable colored log output
-      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
+      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
+      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
+      --log-format string            Log format to use. Options are text or json (default "text")
+      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                   Include source location in logs
+      --log-stacktrace               Include stacktrace in error and fatal logs
+      --no-keyring                   Disable the keyring and generate ephemeral keys
+      --no-log-color                 Disable colored log output
+      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
+      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_keyring.md
+++ b/docs/website/references/cli/defradb_keyring.md
@@ -30,21 +30,21 @@ To learn more about the available options:
 ### Options inherited from parent commands
 
 ```
-      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
-      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
-      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
-      --log-format string            Log format to use. Options are text or json (default "text")
-      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                   Include source location in logs
-      --log-stacktrace               Include stacktrace in error and fatal logs
-      --no-keyring                   Disable the keyring and generate ephemeral keys
-      --no-log-color                 Disable colored log output
-      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
+      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
+      --log-format string           Log format to use. Options are text or json (default "text")
+      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                  Include source location in logs
+      --log-stacktrace              Include stacktrace in error and fatal logs
+      --no-keyring                  Disable the keyring and generate ephemeral keys
+      --no-log-color                Disable colored log output
+      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
+      --secret-file string          Path to the file containing secrets (default ".env")
+      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_keyring_export.md
+++ b/docs/website/references/cli/defradb_keyring_export.md
@@ -26,20 +26,21 @@ defradb keyring export <name> [flags]
 ### Options inherited from parent commands
 
 ```
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
-      --log-format string           Log format to use. Options are text or json (default "text")
-      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                  Include source location in logs
-      --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
-      --no-log-color                Disable colored log output
-      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
+      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
+      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
+      --log-format string            Log format to use. Options are text or json (default "text")
+      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                   Include source location in logs
+      --log-stacktrace               Include stacktrace in error and fatal logs
+      --no-keyring                   Disable the keyring and generate ephemeral keys
+      --no-log-color                 Disable colored log output
+      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
+      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_keyring_export.md
+++ b/docs/website/references/cli/defradb_keyring_export.md
@@ -8,7 +8,8 @@ Export a private key.
 Prints the hexadecimal representation of a private key.
 
 The DEFRA_KEYRING_SECRET environment variable must be set to unlock the keyring.
-This can also be done with a .env file in the root directory.
+This can also be done with a .env file in the working directory or at a path
+defined with the --keyring-secret-file flag.
 
 Example:
   defradb keyring export encryption-key

--- a/docs/website/references/cli/defradb_keyring_export.md
+++ b/docs/website/references/cli/defradb_keyring_export.md
@@ -27,21 +27,21 @@ defradb keyring export <name> [flags]
 ### Options inherited from parent commands
 
 ```
-      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
-      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
-      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
-      --log-format string            Log format to use. Options are text or json (default "text")
-      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                   Include source location in logs
-      --log-stacktrace               Include stacktrace in error and fatal logs
-      --no-keyring                   Disable the keyring and generate ephemeral keys
-      --no-log-color                 Disable colored log output
-      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
+      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
+      --log-format string           Log format to use. Options are text or json (default "text")
+      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                  Include source location in logs
+      --log-stacktrace              Include stacktrace in error and fatal logs
+      --no-keyring                  Disable the keyring and generate ephemeral keys
+      --no-log-color                Disable colored log output
+      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
+      --secret-file string          Path to the file containing secrets (default ".env")
+      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_keyring_export.md
+++ b/docs/website/references/cli/defradb_keyring_export.md
@@ -7,6 +7,9 @@ Export a private key
 Export a private key.
 Prints the hexadecimal representation of a private key.
 
+The DEFRA_KEYRING_SECRET environment variable must be set to unlock the keyring.
+This can also be done with a .env file in the root directory.
+
 Example:
   defradb keyring export encryption-key
 

--- a/docs/website/references/cli/defradb_keyring_generate.md
+++ b/docs/website/references/cli/defradb_keyring_generate.md
@@ -40,20 +40,21 @@ defradb keyring generate [flags]
 ### Options inherited from parent commands
 
 ```
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
-      --log-format string           Log format to use. Options are text or json (default "text")
-      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                  Include source location in logs
-      --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
-      --no-log-color                Disable colored log output
-      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
+      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
+      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
+      --log-format string            Log format to use. Options are text or json (default "text")
+      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                   Include source location in logs
+      --log-stacktrace               Include stacktrace in error and fatal logs
+      --no-keyring                   Disable the keyring and generate ephemeral keys
+      --no-log-color                 Disable colored log output
+      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
+      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_keyring_generate.md
+++ b/docs/website/references/cli/defradb_keyring_generate.md
@@ -18,7 +18,7 @@ Example:
   defradb keyring generate
 
 Example: with no encryption key
-  defradb keyring generate --no-encryption-key
+  defradb keyring generate --no-encryption
 
 Example: with no peer key
   defradb keyring generate --no-peer-key
@@ -33,29 +33,29 @@ defradb keyring generate [flags]
 ### Options
 
 ```
-  -h, --help                help for generate
-      --no-encryption-key   Skip generating an encryption key. Encryption at rest will be disabled
-      --no-peer-key         Skip generating a peer key.
+  -h, --help            help for generate
+      --no-encryption   Skip generating an encryption key. Encryption at rest will be disabled
+      --no-peer-key     Skip generating a peer key.
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
-      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
-      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
-      --log-format string            Log format to use. Options are text or json (default "text")
-      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                   Include source location in logs
-      --log-stacktrace               Include stacktrace in error and fatal logs
-      --no-keyring                   Disable the keyring and generate ephemeral keys
-      --no-log-color                 Disable colored log output
-      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
+      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
+      --log-format string           Log format to use. Options are text or json (default "text")
+      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                  Include source location in logs
+      --log-stacktrace              Include stacktrace in error and fatal logs
+      --no-keyring                  Disable the keyring and generate ephemeral keys
+      --no-log-color                Disable colored log output
+      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
+      --secret-file string          Path to the file containing secrets (default ".env")
+      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_keyring_generate.md
+++ b/docs/website/references/cli/defradb_keyring_generate.md
@@ -8,6 +8,9 @@ Generate private keys.
 Randomly generate and store private keys in the keyring.
 By default peer and encryption keys will be generated.
 
+The DEFRA_KEYRING_SECRET environment variable must be set to unlock the keyring.
+This can also be done with a .env file in the root directory.
+
 WARNING: This will overwrite existing keys in the keyring.
 
 Example:

--- a/docs/website/references/cli/defradb_keyring_generate.md
+++ b/docs/website/references/cli/defradb_keyring_generate.md
@@ -9,7 +9,8 @@ Randomly generate and store private keys in the keyring.
 By default peer and encryption keys will be generated.
 
 The DEFRA_KEYRING_SECRET environment variable must be set to unlock the keyring.
-This can also be done with a .env file in the root directory.
+This can also be done with a .env file in the working directory or at a path
+defined with the --keyring-secret-file flag.
 
 WARNING: This will overwrite existing keys in the keyring.
 

--- a/docs/website/references/cli/defradb_keyring_import.md
+++ b/docs/website/references/cli/defradb_keyring_import.md
@@ -8,7 +8,8 @@ Import a private key.
 Store an externally generated key in the keyring.
 
 The DEFRA_KEYRING_SECRET environment variable must be set to unlock the keyring.
-This can also be done with a .env file in the root directory.
+This can also be done with a .env file in the working directory or at a path
+defined with the --keyring-secret-file flag.
 
 Example:
   defradb keyring import encryption-key 0000000000000000

--- a/docs/website/references/cli/defradb_keyring_import.md
+++ b/docs/website/references/cli/defradb_keyring_import.md
@@ -26,20 +26,21 @@ defradb keyring import <name> <private-key-hex> [flags]
 ### Options inherited from parent commands
 
 ```
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
-      --log-format string           Log format to use. Options are text or json (default "text")
-      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                  Include source location in logs
-      --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
-      --no-log-color                Disable colored log output
-      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
+      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
+      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
+      --log-format string            Log format to use. Options are text or json (default "text")
+      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                   Include source location in logs
+      --log-stacktrace               Include stacktrace in error and fatal logs
+      --no-keyring                   Disable the keyring and generate ephemeral keys
+      --no-log-color                 Disable colored log output
+      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
+      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_keyring_import.md
+++ b/docs/website/references/cli/defradb_keyring_import.md
@@ -27,21 +27,21 @@ defradb keyring import <name> <private-key-hex> [flags]
 ### Options inherited from parent commands
 
 ```
-      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
-      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
-      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
-      --log-format string            Log format to use. Options are text or json (default "text")
-      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                   Include source location in logs
-      --log-stacktrace               Include stacktrace in error and fatal logs
-      --no-keyring                   Disable the keyring and generate ephemeral keys
-      --no-log-color                 Disable colored log output
-      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
+      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
+      --log-format string           Log format to use. Options are text or json (default "text")
+      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                  Include source location in logs
+      --log-stacktrace              Include stacktrace in error and fatal logs
+      --no-keyring                  Disable the keyring and generate ephemeral keys
+      --no-log-color                Disable colored log output
+      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
+      --secret-file string          Path to the file containing secrets (default ".env")
+      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_keyring_import.md
+++ b/docs/website/references/cli/defradb_keyring_import.md
@@ -7,6 +7,9 @@ Import a private key
 Import a private key.
 Store an externally generated key in the keyring.
 
+The DEFRA_KEYRING_SECRET environment variable must be set to unlock the keyring.
+This can also be done with a .env file in the root directory.
+
 Example:
   defradb keyring import encryption-key 0000000000000000
 

--- a/docs/website/references/cli/defradb_server-dump.md
+++ b/docs/website/references/cli/defradb_server-dump.md
@@ -15,21 +15,21 @@ defradb server-dump [flags]
 ### Options inherited from parent commands
 
 ```
-      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
-      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
-      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
-      --log-format string            Log format to use. Options are text or json (default "text")
-      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                   Include source location in logs
-      --log-stacktrace               Include stacktrace in error and fatal logs
-      --no-keyring                   Disable the keyring and generate ephemeral keys
-      --no-log-color                 Disable colored log output
-      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
+      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
+      --log-format string           Log format to use. Options are text or json (default "text")
+      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                  Include source location in logs
+      --log-stacktrace              Include stacktrace in error and fatal logs
+      --no-keyring                  Disable the keyring and generate ephemeral keys
+      --no-log-color                Disable colored log output
+      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
+      --secret-file string          Path to the file containing secrets (default ".env")
+      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_server-dump.md
+++ b/docs/website/references/cli/defradb_server-dump.md
@@ -15,20 +15,21 @@ defradb server-dump [flags]
 ### Options inherited from parent commands
 
 ```
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
-      --log-format string           Log format to use. Options are text or json (default "text")
-      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                  Include source location in logs
-      --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
-      --no-log-color                Disable colored log output
-      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
+      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
+      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
+      --log-format string            Log format to use. Options are text or json (default "text")
+      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                   Include source location in logs
+      --log-stacktrace               Include stacktrace in error and fatal logs
+      --no-keyring                   Disable the keyring and generate ephemeral keys
+      --no-log-color                 Disable colored log output
+      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
+      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_start.md
+++ b/docs/website/references/cli/defradb_start.md
@@ -30,20 +30,21 @@ defradb start [flags]
 ### Options inherited from parent commands
 
 ```
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
-      --log-format string           Log format to use. Options are text or json (default "text")
-      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                  Include source location in logs
-      --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
-      --no-log-color                Disable colored log output
-      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
+      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
+      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
+      --log-format string            Log format to use. Options are text or json (default "text")
+      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                   Include source location in logs
+      --log-stacktrace               Include stacktrace in error and fatal logs
+      --no-keyring                   Disable the keyring and generate ephemeral keys
+      --no-log-color                 Disable colored log output
+      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
+      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_start.md
+++ b/docs/website/references/cli/defradb_start.md
@@ -17,6 +17,7 @@ defradb start [flags]
       --development                   Enables a set of features that make development easier but should not be enabled in production
   -h, --help                          help for start
       --max-txn-retries int           Specify the maximum number of retries per transaction (default 5)
+      --no-encryption-key             Skip generating an encryption key. Encryption at rest will be disabled. WARNING: This cannot be undone.
       --no-p2p                        Disable the peer-to-peer network synchronization system
       --p2paddr strings               Listen addresses for the p2p network (formatted as a libp2p MultiAddr) (default [/ip4/127.0.0.1/tcp/9171])
       --peers stringArray             List of peers to connect to

--- a/docs/website/references/cli/defradb_start.md
+++ b/docs/website/references/cli/defradb_start.md
@@ -17,7 +17,7 @@ defradb start [flags]
       --development                   Enables a set of features that make development easier but should not be enabled in production
   -h, --help                          help for start
       --max-txn-retries int           Specify the maximum number of retries per transaction (default 5)
-      --no-encryption-key             Skip generating an encryption key. Encryption at rest will be disabled. WARNING: This cannot be undone.
+      --no-encryption                 Skip generating an encryption key. Encryption at rest will be disabled. WARNING: This cannot be undone.
       --no-p2p                        Disable the peer-to-peer network synchronization system
       --p2paddr strings               Listen addresses for the p2p network (formatted as a libp2p MultiAddr) (default [/ip4/127.0.0.1/tcp/9171])
       --peers stringArray             List of peers to connect to
@@ -30,21 +30,21 @@ defradb start [flags]
 ### Options inherited from parent commands
 
 ```
-      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
-      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
-      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
-      --log-format string            Log format to use. Options are text or json (default "text")
-      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                   Include source location in logs
-      --log-stacktrace               Include stacktrace in error and fatal logs
-      --no-keyring                   Disable the keyring and generate ephemeral keys
-      --no-log-color                 Disable colored log output
-      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
+      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
+      --log-format string           Log format to use. Options are text or json (default "text")
+      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                  Include source location in logs
+      --log-stacktrace              Include stacktrace in error and fatal logs
+      --no-keyring                  Disable the keyring and generate ephemeral keys
+      --no-log-color                Disable colored log output
+      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
+      --secret-file string          Path to the file containing secrets (default ".env")
+      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_version.md
+++ b/docs/website/references/cli/defradb_version.md
@@ -17,21 +17,21 @@ defradb version [flags]
 ### Options inherited from parent commands
 
 ```
-      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
-      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
-      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
-      --log-format string            Log format to use. Options are text or json (default "text")
-      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                   Include source location in logs
-      --log-stacktrace               Include stacktrace in error and fatal logs
-      --no-keyring                   Disable the keyring and generate ephemeral keys
-      --no-log-color                 Disable colored log output
-      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
+      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
+      --log-format string           Log format to use. Options are text or json (default "text")
+      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                  Include source location in logs
+      --log-stacktrace              Include stacktrace in error and fatal logs
+      --no-keyring                  Disable the keyring and generate ephemeral keys
+      --no-log-color                Disable colored log output
+      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
+      --secret-file string          Path to the file containing secrets (default ".env")
+      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_version.md
+++ b/docs/website/references/cli/defradb_version.md
@@ -17,20 +17,21 @@ defradb version [flags]
 ### Options inherited from parent commands
 
 ```
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
-      --log-format string           Log format to use. Options are text or json (default "text")
-      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                  Include source location in logs
-      --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
-      --no-log-color                Disable colored log output
-      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+      --keyring-backend string       Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string     Service name to use when using the system backend (default "defradb")
+      --keyring-path string          Path to store encrypted keys when using the file backend (default "keys")
+      --keyring-secret-file string   Path to the file containing the keyring secret (default ".env")
+      --log-format string            Log format to use. Options are text or json (default "text")
+      --log-level string             Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string            Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string         Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                   Include source location in logs
+      --log-stacktrace               Include stacktrace in error and fatal logs
+      --no-keyring                   Disable the keyring and generate ephemeral keys
+      --no-log-color                 Disable colored log output
+      --rootdir string               Directory for persistent data (default: $HOME/.defradb)
+      --source-hub-address string    The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --url string                   URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### SEE ALSO

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/ipld/go-ipld-prime/storage/bsadapter v0.0.0-20240322071758-198d7dba8fb8
 	github.com/ipld/go-ipld-prime/storage/bsrvadapter v0.0.0-20240322071758-198d7dba8fb8
 	github.com/jbenet/goprocess v0.1.4
+	github.com/joho/godotenv v1.5.1
 	github.com/lens-vm/lens/host-go v0.0.0-20231127204031-8d858ed2926c
 	github.com/lestrrat-go/jwx/v2 v2.1.1
 	github.com/libp2p/go-libp2p v0.36.3
@@ -62,7 +63,6 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.30.0
 	go.uber.org/zap v1.27.0
 	golang.org/x/exp v0.0.0-20240808152545-0cdaa3abc0fa
-	golang.org/x/term v0.24.0
 	google.golang.org/grpc v1.66.2
 	google.golang.org/protobuf v1.34.2
 )
@@ -365,6 +365,7 @@ require (
 	golang.org/x/oauth2 v0.21.0 // indirect
 	golang.org/x/sync v0.8.0 // indirect
 	golang.org/x/sys v0.25.0 // indirect
+	golang.org/x/term v0.24.0 // indirect
 	golang.org/x/text v0.17.0 // indirect
 	golang.org/x/time v0.5.0 // indirect
 	golang.org/x/tools v0.24.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -917,6 +917,8 @@ github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGw
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/jmhodges/levigo v1.0.0 h1:q5EC36kV79HWeTBWsod3mG11EgStG3qArTKcvlksN1U=
 github.com/jmhodges/levigo v1.0.0/go.mod h1:Q6Qx+uH3RAqyK4rFQroq9RL7mdkABMcfhEI+nNuzMJQ=
+github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
+github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/jorrizza/ed2curve25519 v0.1.0 h1:P58ZEiVKW4vknYuGyOXuskMm82rTJyGhgRGrMRcCE8E=
 github.com/jorrizza/ed2curve25519 v0.1.0/go.mod h1:27VPNk2FnNqLQNvvVymiX41VE/nokPyn5HHP7gtfYlo=

--- a/keyring/file_test.go
+++ b/keyring/file_test.go
@@ -19,11 +19,7 @@ import (
 )
 
 func TestFileKeyring(t *testing.T) {
-	prompt := PromptFunc(func(s string) ([]byte, error) {
-		return []byte("secret"), nil
-	})
-
-	kr, err := OpenFileKeyring(t.TempDir(), prompt)
+	kr, err := OpenFileKeyring(t.TempDir(), []byte("secret"))
 	require.NoError(t, err)
 
 	err = kr.Set("peer_key", []byte("abc"))

--- a/tests/integration/acp.go
+++ b/tests/integration/acp.go
@@ -141,9 +141,7 @@ func setupSourceHub(s *state) ([]node.ACPOpt, error) {
 
 	kr, err := keyring.OpenFileKeyring(
 		directory,
-		keyring.PromptFunc(func(s string) ([]byte, error) {
-			return []byte("secret"), nil
-		}),
+		[]byte("secret"),
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Relevant issue(s)

Resolves #2995 

## Description

This PR makes the keyring interactions non-interactive by requiring the keyring password to be set as an environment variable secret. It also adds support for that secret to be stored in a `.env` file in the working directory or in a file at a path defined by the `--secret-file` flag.

Making the keyring non-interactive is necessary to support automated deployments. 

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

make test

Also tested manually starting Defra with a `.env` file to make sure that the secret was picked up.

Specify the platform(s) on which this was tested:
- MacOS
