### PR TITLE
docs(i): Fix incorrect flag and env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The following keys are loaded from the keyring on start:
 - `peer-key` Ed25519 private key (required)
 - `encryption-key` AES-128, AES-192, or AES-256 key (optional)
 
-A secret to unlock the keyring is required on start and must be provided via the `DEFRADB_KEYRING_SECRET` environment variable. If a `.env` file is available in the working directory, the secret can be stored there or via a file at a path defined by the `--keyring-secret-file` flag.
+A secret to unlock the keyring is required on start and must be provided via the `DEFRA_KEYRING_SECRET` environment variable. If a `.env` file is available in the working directory, the secret can be stored there or via a file at a path defined by the `--secret-file` flag.
 
 The keys will be randomly generated on the inital start of the node if they are not found.
 

--- a/cli/keyring_export.go
+++ b/cli/keyring_export.go
@@ -23,7 +23,7 @@ Prints the hexadecimal representation of a private key.
 
 The DEFRA_KEYRING_SECRET environment variable must be set to unlock the keyring.
 This can also be done with a .env file in the working directory or at a path
-defined with the --keyring-secret-file flag.
+defined with the --secret-file flag.
 
 Example:
   defradb keyring export encryption-key`,

--- a/cli/keyring_generate.go
+++ b/cli/keyring_generate.go
@@ -28,7 +28,7 @@ By default peer and encryption keys will be generated.
 
 The DEFRA_KEYRING_SECRET environment variable must be set to unlock the keyring.
 This can also be done with a .env file in the working directory or at a path
-defined with the --keyring-secret-file flag.
+defined with the --secret-file flag.
 
 WARNING: This will overwrite existing keys in the keyring.
 

--- a/cli/keyring_import.go
+++ b/cli/keyring_import.go
@@ -25,7 +25,7 @@ Store an externally generated key in the keyring.
 
 The DEFRA_KEYRING_SECRET environment variable must be set to unlock the keyring.
 This can also be done with a .env file in the working directory or at a path
-defined with the --keyring-secret-file flag.
+defined with the --secret-file flag.
 
 Example:
   defradb keyring import encryption-key 0000000000000000`,

--- a/docs/website/references/cli/defradb_keyring_export.md
+++ b/docs/website/references/cli/defradb_keyring_export.md
@@ -9,7 +9,7 @@ Prints the hexadecimal representation of a private key.
 
 The DEFRA_KEYRING_SECRET environment variable must be set to unlock the keyring.
 This can also be done with a .env file in the working directory or at a path
-defined with the --keyring-secret-file flag.
+defined with the --secret-file flag.
 
 Example:
   defradb keyring export encryption-key

--- a/docs/website/references/cli/defradb_keyring_generate.md
+++ b/docs/website/references/cli/defradb_keyring_generate.md
@@ -10,7 +10,7 @@ By default peer and encryption keys will be generated.
 
 The DEFRA_KEYRING_SECRET environment variable must be set to unlock the keyring.
 This can also be done with a .env file in the working directory or at a path
-defined with the --keyring-secret-file flag.
+defined with the --secret-file flag.
 
 WARNING: This will overwrite existing keys in the keyring.
 

--- a/docs/website/references/cli/defradb_keyring_import.md
+++ b/docs/website/references/cli/defradb_keyring_import.md
@@ -9,7 +9,7 @@ Store an externally generated key in the keyring.
 
 The DEFRA_KEYRING_SECRET environment variable must be set to unlock the keyring.
 This can also be done with a .env file in the working directory or at a path
-defined with the --keyring-secret-file flag.
+defined with the --secret-file flag.
 
 Example:
   defradb keyring import encryption-key 0000000000000000


### PR DESCRIPTION
## Relevant issue(s)

Resolves #3033 

## Description

The flag and environment variable was kept unchanged from an initial commit in the non-interactive keyring PR. This fixes the mistake.