### PR TITLE
fix: Log GQL endpoint correctly on node start

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -163,7 +163,7 @@ func (n *Node) Start(ctx context.Context) error {
 		}
 		log.InfoContext(ctx,
 			fmt.Sprintf("Providing HTTP API at %s PlaygroundEnabled=%t", n.Server.Address(), http.PlaygroundEnabled))
-		log.InfoContext(ctx, fmt.Sprintf("Providing GraphQL endpoint at %s/v0/graphql", n.Server.Address()))
+		log.InfoContext(ctx, fmt.Sprintf("Providing GraphQL endpoint at %s/api/v0/graphql", n.Server.Address()))
 		go func() {
 			if err := n.Server.Serve(); err != nil && !errors.Is(err, gohttp.ErrServerClosed) {
 				log.ErrorContextE(ctx, "HTTP server stopped", err)


### PR DESCRIPTION
## Relevant issue(s)

Resolves #3036

## Description

Logs the GQL endpoint correctly on node start.
