### PR TITLE
fix(i): Sort out invalid testing framework node indexing

### DIFF
--- a/tests/integration/acp/p2p/create_test.go
+++ b/tests/integration/acp/p2p/create_test.go
@@ -123,8 +123,6 @@ func TestACP_P2PCreatePrivateDocumentsOnDifferentNodes_SourceHubACP(t *testing.T
 				DocMap: map[string]any{
 					"name": "Shahzad Lone",
 				},
-
-				ExpectedError: "403: forbidden", // TODO: FIX THIS BUG
 			},
 		},
 	}

--- a/tests/integration/acp/p2p/create_test.go
+++ b/tests/integration/acp/p2p/create_test.go
@@ -1,0 +1,133 @@
+// Copyright 2024 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package test_acp_p2p
+
+import (
+	"fmt"
+	"testing"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	"github.com/sourcenetwork/immutable"
+)
+
+func TestACP_P2PCreatePrivateDocumentsOnDifferentNodes_SourceHubACP(t *testing.T) {
+	expectedPolicyID := "fc56b7509c20ac8ce682b3b9b4fdaad868a9c70dda6ec16720298be64f16e9a4"
+
+	test := testUtils.TestCase{
+
+		Description: "Test acp, p2p create private documents on different nodes, with source-hub",
+
+		SupportedACPTypes: immutable.Some(
+			[]testUtils.ACPType{
+				testUtils.SourceHubACPType,
+			},
+		),
+
+		Actions: []any{
+			testUtils.RandomNetworkingConfig(),
+
+			testUtils.RandomNetworkingConfig(),
+
+			testUtils.AddPolicy{
+
+				Identity: immutable.Some(1),
+
+				Policy: `
+                    name: Test Policy
+
+                    description: A Policy
+
+                    actor:
+                      name: actor
+
+                    resources:
+                      users:
+                        permissions:
+                          read:
+                            expr: owner + reader + writer
+
+                          write:
+                            expr: owner + writer
+
+                          nothing:
+                            expr: dummy
+
+                        relations:
+                          owner:
+                            types:
+                              - actor
+
+                          reader:
+                            types:
+                              - actor
+
+                          writer:
+                            types:
+                              - actor
+
+                          admin:
+                            manages:
+                              - reader
+                            types:
+                              - actor
+
+                          dummy:
+                            types:
+                              - actor
+                `,
+
+				ExpectedPolicyID: expectedPolicyID,
+			},
+
+			testUtils.SchemaUpdate{
+				Schema: fmt.Sprintf(`
+						type Users @policy(
+							id: "%s",
+							resource: "users"
+						) {
+							name: String
+							age: Int
+						}
+					`,
+					expectedPolicyID,
+				),
+			},
+
+			testUtils.CreateDoc{
+				Identity: immutable.Some(1),
+
+				NodeID: immutable.Some(0),
+
+				CollectionID: 0,
+
+				DocMap: map[string]any{
+					"name": "Shahzad",
+				},
+			},
+
+			testUtils.CreateDoc{
+				Identity: immutable.Some(1),
+
+				NodeID: immutable.Some(1),
+
+				CollectionID: 0,
+
+				DocMap: map[string]any{
+					"name": "Shahzad Lone",
+				},
+
+				ExpectedError: "403: forbidden", // TODO: FIX THIS BUG
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/acp/p2p/create_test.go
+++ b/tests/integration/acp/p2p/create_test.go
@@ -14,8 +14,9 @@ import (
 	"fmt"
 	"testing"
 
-	testUtils "github.com/sourcenetwork/defradb/tests/integration"
 	"github.com/sourcenetwork/immutable"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
 )
 
 func TestACP_P2PCreatePrivateDocumentsOnDifferentNodes_SourceHubACP(t *testing.T) {

--- a/tests/integration/acp/p2p/delete_test.go
+++ b/tests/integration/acp/p2p/delete_test.go
@@ -1,0 +1,159 @@
+// Copyright 2024 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package test_acp_p2p
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/sourcenetwork/immutable"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+func TestACP_P2PDeletePrivateDocumentsOnDifferentNodes_SourceHubACP(t *testing.T) {
+	expectedPolicyID := "fc56b7509c20ac8ce682b3b9b4fdaad868a9c70dda6ec16720298be64f16e9a4"
+
+	test := testUtils.TestCase{
+
+		Description: "Test acp, p2p delete private documents on different nodes, with source-hub",
+
+		SupportedACPTypes: immutable.Some(
+			[]testUtils.ACPType{
+				testUtils.SourceHubACPType,
+			},
+		),
+
+		Actions: []any{
+			testUtils.RandomNetworkingConfig(),
+
+			testUtils.RandomNetworkingConfig(),
+
+			testUtils.AddPolicy{
+
+				Identity: immutable.Some(1),
+
+				Policy: `
+                    name: Test Policy
+
+                    description: A Policy
+
+                    actor:
+                      name: actor
+
+                    resources:
+                      users:
+                        permissions:
+                          read:
+                            expr: owner + reader + writer
+
+                          write:
+                            expr: owner + writer
+
+                          nothing:
+                            expr: dummy
+
+                        relations:
+                          owner:
+                            types:
+                              - actor
+
+                          reader:
+                            types:
+                              - actor
+
+                          writer:
+                            types:
+                              - actor
+
+                          admin:
+                            manages:
+                              - reader
+                            types:
+                              - actor
+
+                          dummy:
+                            types:
+                              - actor
+                `,
+
+				ExpectedPolicyID: expectedPolicyID,
+			},
+
+			testUtils.SchemaUpdate{
+				Schema: fmt.Sprintf(`
+						type Users @policy(
+							id: "%s",
+							resource: "users"
+						) {
+							name: String
+							age: Int
+						}
+					`,
+					expectedPolicyID,
+				),
+			},
+
+			testUtils.ConfigureReplicator{
+				SourceNodeID: 0,
+				TargetNodeID: 1,
+			},
+
+			testUtils.CreateDoc{
+				Identity: immutable.Some(1),
+
+				NodeID: immutable.Some(0),
+
+				CollectionID: 0,
+
+				DocMap: map[string]any{
+					"name": "Shahzad",
+				},
+			},
+
+			testUtils.CreateDoc{
+				Identity: immutable.Some(1),
+
+				NodeID: immutable.Some(1),
+
+				CollectionID: 0,
+
+				DocMap: map[string]any{
+					"name": "Shahzad Lone",
+				},
+			},
+
+			testUtils.WaitForSync{},
+
+			testUtils.DeleteDoc{
+				Identity: immutable.Some(1),
+
+				NodeID: immutable.Some(0),
+
+				CollectionID: 0,
+
+				DocID: 0,
+			},
+
+			testUtils.DeleteDoc{
+				Identity: immutable.Some(1),
+
+				NodeID: immutable.Some(1),
+
+				CollectionID: 0,
+
+				DocID: 1,
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/acp/p2p/update_test.go
+++ b/tests/integration/acp/p2p/update_test.go
@@ -1,0 +1,171 @@
+// Copyright 2024 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package test_acp_p2p
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/sourcenetwork/immutable"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+func TestACP_P2PUpdatePrivateDocumentsOnDifferentNodes_SourceHubACP(t *testing.T) {
+	expectedPolicyID := "fc56b7509c20ac8ce682b3b9b4fdaad868a9c70dda6ec16720298be64f16e9a4"
+
+	test := testUtils.TestCase{
+
+		Description: "Test acp, p2p update private documents on different nodes, with source-hub",
+
+		SupportedACPTypes: immutable.Some(
+			[]testUtils.ACPType{
+				testUtils.SourceHubACPType,
+			},
+		),
+
+		Actions: []any{
+			testUtils.RandomNetworkingConfig(),
+
+			testUtils.RandomNetworkingConfig(),
+
+			testUtils.AddPolicy{
+
+				Identity: immutable.Some(1),
+
+				Policy: `
+                    name: Test Policy
+
+                    description: A Policy
+
+                    actor:
+                      name: actor
+
+                    resources:
+                      users:
+                        permissions:
+                          read:
+                            expr: owner + reader + writer
+
+                          write:
+                            expr: owner + writer
+
+                          nothing:
+                            expr: dummy
+
+                        relations:
+                          owner:
+                            types:
+                              - actor
+
+                          reader:
+                            types:
+                              - actor
+
+                          writer:
+                            types:
+                              - actor
+
+                          admin:
+                            manages:
+                              - reader
+                            types:
+                              - actor
+
+                          dummy:
+                            types:
+                              - actor
+                `,
+
+				ExpectedPolicyID: expectedPolicyID,
+			},
+
+			testUtils.SchemaUpdate{
+				Schema: fmt.Sprintf(`
+						type Users @policy(
+							id: "%s",
+							resource: "users"
+						) {
+							name: String
+							age: Int
+						}
+					`,
+					expectedPolicyID,
+				),
+			},
+
+			testUtils.ConfigureReplicator{
+				SourceNodeID: 0,
+				TargetNodeID: 1,
+			},
+
+			testUtils.CreateDoc{
+				Identity: immutable.Some(1),
+
+				NodeID: immutable.Some(0),
+
+				CollectionID: 0,
+
+				DocMap: map[string]any{
+					"name": "Shahzad",
+				},
+			},
+
+			testUtils.CreateDoc{
+				Identity: immutable.Some(1),
+
+				NodeID: immutable.Some(1),
+
+				CollectionID: 0,
+
+				DocMap: map[string]any{
+					"name": "Shahzad Lone",
+				},
+			},
+
+			testUtils.WaitForSync{},
+
+			testUtils.UpdateDoc{
+				Identity: immutable.Some(1),
+
+				NodeID: immutable.Some(0),
+
+				CollectionID: 0,
+
+				DocID: 0,
+
+				Doc: `
+					{
+						"name": "ShahzadLone"
+					}
+				`,
+			},
+
+			testUtils.UpdateDoc{
+				Identity: immutable.Some(1),
+
+				NodeID: immutable.Some(1),
+
+				CollectionID: 0,
+
+				DocID: 1,
+
+				Doc: `
+					{
+						"name": "ShahzadLone"
+					}
+				`,
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/test_case.go
+++ b/tests/integration/test_case.go
@@ -718,7 +718,8 @@ type ClientIntrospectionRequest struct {
 type BackupExport struct {
 	// NodeID may hold the ID (index) of a node to generate the backup from.
 	//
-	// If a value is not provided the indexes will be retrieved from the first nodes.
+	// If a value is not provided the backup export will be done for all the nodes.
+	// todo: https://github.com/sourcenetwork/defradb/issues/3067
 	NodeID immutable.Option[int]
 
 	// The backup configuration.
@@ -738,7 +739,8 @@ type BackupExport struct {
 type BackupImport struct {
 	// NodeID may hold the ID (index) of a node to generate the backup from.
 	//
-	// If a value is not provided the indexes will be retrieved from the first nodes.
+	// If a value is not provided the backup import will be done for all the nodes.
+	// todo: https://github.com/sourcenetwork/defradb/issues/3067
 	NodeID immutable.Option[int]
 
 	// The backup file path.

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -1441,20 +1441,34 @@ func deleteDoc(
 	docID := s.docIDs[action.CollectionID][action.DocID]
 
 	var expectedErrorRaised bool
-	actionNodes := getNodes(action.NodeID, s.nodes)
-	for nodeID, collections := range getNodeCollections(action.NodeID, s.collections) {
+
+	if action.NodeID.HasValue() {
+		nodeID := action.NodeID.Value()
+		actionNode := s.nodes[nodeID]
+		collections := s.collections[nodeID]
 		identity := getIdentity(s, nodeID, action.Identity)
 		ctx := db.SetContextIdentity(s.ctx, identity)
-
-		err := withRetry(
-			actionNodes,
-			nodeID,
+		err := withRetryOnNode(
+			actionNode,
 			func() error {
 				_, err := collections[action.CollectionID].Delete(ctx, docID)
 				return err
 			},
 		)
 		expectedErrorRaised = AssertError(s.t, s.testCase.Description, err, action.ExpectedError)
+	} else {
+		for nodeID, collections := range s.collections {
+			identity := getIdentity(s, nodeID, action.Identity)
+			ctx := db.SetContextIdentity(s.ctx, identity)
+			err := withRetryOnNode(
+				s.nodes[nodeID],
+				func() error {
+					_, err := collections[action.CollectionID].Delete(ctx, docID)
+					return err
+				},
+			)
+			expectedErrorRaised = AssertError(s.t, s.testCase.Description, err, action.ExpectedError)
+		}
 	}
 
 	assertExpectedErrorRaised(s.t, s.testCase.Description, action.ExpectedError, expectedErrorRaised)

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -976,7 +976,6 @@ func getIndexes(
 			expectedErrorRaised = expectedErrorRaised ||
 				AssertError(s.t, s.testCase.Description, err, action.ExpectedError)
 		}
-
 	}
 
 	assertExpectedErrorRaised(s.t, s.testCase.Description, action.ExpectedError, expectedErrorRaised)
@@ -1534,7 +1533,6 @@ func updateDoc(
 			)
 			expectedErrorRaised = AssertError(s.t, s.testCase.Description, err, action.ExpectedError)
 		}
-
 	}
 
 	assertExpectedErrorRaised(s.t, s.testCase.Description, action.ExpectedError, expectedErrorRaised)
@@ -1862,7 +1860,6 @@ func backupImport(
 			func() error { return node.BasicImport(s.ctx, action.Filepath) },
 		)
 		expectedErrorRaised = AssertError(s.t, s.testCase.Description, err, action.ExpectedError)
-
 	} else {
 		for _, node := range s.nodes {
 			err := withRetryOnNode(
@@ -1871,7 +1868,6 @@ func backupImport(
 			)
 			expectedErrorRaised = AssertError(s.t, s.testCase.Description, err, action.ExpectedError)
 		}
-
 	}
 
 	assertExpectedErrorRaised(s.t, s.testCase.Description, action.ExpectedError, expectedErrorRaised)

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -1877,29 +1877,6 @@ func backupImport(
 	assertExpectedErrorRaised(s.t, s.testCase.Description, action.ExpectedError, expectedErrorRaised)
 }
 
-// withRetry attempts to perform the given action, retrying up to a DB-defined
-// maximum attempt count if a transaction conflict error is returned.
-//
-// If a P2P-sync commit for the given document is already in progress this
-// Save call can fail as the transaction will conflict. We dont want to worry
-// about this in our tests so we just retry a few times until it works (or the
-// retry limit is breached - important incase this is a different error)
-func withRetry(
-	nodes []clients.Client,
-	nodeID int,
-	action func() error,
-) error {
-	for i := 0; i < nodes[nodeID].MaxTxnRetries(); i++ {
-		err := action()
-		if errors.Is(err, datastore.ErrTxnConflict) {
-			time.Sleep(100 * time.Millisecond)
-			continue
-		}
-		return err
-	}
-	return nil
-}
-
 // withRetryOnNode attempts to perform the given action, retrying up to a DB-defined
 // maximum attempt count if a transaction conflict error is returned.
 //


### PR DESCRIPTION
## Relevant issue(s)
Resolves #3065 

## Description
The main bug was only visible on sourcehub acp using http, due to the identity being copied with the audience value of another node's host failing authentication (the bearer tokens should be unique using correct node's audience). The biggest issue was the way we use `getNodes` and `getNodeCollections`. I would be in favor of completely removing them as they are more troublesome than the utility they provide.

- First commit documents the bug
- Some utility functions were overwriting and producing the wrong node index
- Forbidden bug happening on sourcehub<>http test run: https://github.com/sourcenetwork/defradb/actions/runs/10930293192/job/30342883535?pr=2907

### Future:
- Resolve import/export documentation and implementation if different (#3067)
- Should likely clean this test utils up and make helper methods to avoid code duplication (https://github.com/sourcenetwork/defradb/issues/3069)
- Likely should remove all usages of `getNodeCollections`  (https://github.com/sourcenetwork/defradb/issues/3069)
- Likely should remove all usages of `getNodes` (https://github.com/sourcenetwork/defradb/issues/3069)


## How has this been tested?
- Very painfully haha, had to install Linux bare-metal to investigate the first bug (sourcehub doesn't build on wsl for me) that was only occurring on sourcehub acp using http, due to the identity being copied with the audience value of another node the way we use `getNodes` and `getNodeCollections` 