### PR TITLE
feat: GraphQL upsert mutation

### DIFF
--- a/client/request/consts.go
+++ b/client/request/consts.go
@@ -21,6 +21,8 @@ const (
 
 	Cid         = "cid"
 	Input       = "input"
+	CreateInput = "create"
+	UpdateInput = "update"
 	FieldName   = "field"
 	FieldIDName = "fieldId"
 	ShowDeleted = "showDeleted"

--- a/client/request/mutation.go
+++ b/client/request/mutation.go
@@ -17,6 +17,7 @@ const (
 	CreateObjects
 	UpdateObjects
 	DeleteObjects
+	UpsertObjects
 )
 
 // ObjectMutation is a field on the `mutation` operation of a graphql request. It includes

--- a/client/request/mutation.go
+++ b/client/request/mutation.go
@@ -40,7 +40,7 @@ type ObjectMutation struct {
 	// CreateInput is the array of maps of fields and values used for a create mutation.
 	CreateInput []map[string]any
 
-	// CreateInput is a map of fields and values used for an update mutation.
+	// UpdateInput is a map of fields and values used for an update mutation.
 	UpdateInput map[string]any
 
 	// Encrypt is a boolean flag that indicates whether the input data should be encrypted.

--- a/client/request/mutation.go
+++ b/client/request/mutation.go
@@ -37,11 +37,11 @@ type ObjectMutation struct {
 	// Collection is the target collection name.
 	Collection string
 
-	// Input is the array of json representations of the fieldName-value pairs of document
-	// properties to mutate.
-	//
-	// This is ignored for [DeleteObjects] mutations.
-	Input []map[string]any
+	// CreateInput is the array of maps of fields and values used for a create mutation.
+	CreateInput []map[string]any
+
+	// CreateInput is a map of fields and values used for an update mutation.
+	UpdateInput map[string]any
 
 	// Encrypt is a boolean flag that indicates whether the input data should be encrypted.
 	Encrypt bool

--- a/internal/planner/create.go
+++ b/internal/planner/create.go
@@ -65,7 +65,7 @@ func docIDsToSpans(ids []string, desc client.CollectionDescription) core.Spans {
 	return core.NewSpans(spans...)
 }
 
-func documentsToDocIDs(docs []*client.Document) []string {
+func documentsToDocIDs(docs ...*client.Document) []string {
 	docIDs := make([]string, len(docs))
 	for i, doc := range docs {
 		docIDs[i] = doc.ID().String()
@@ -96,7 +96,7 @@ func (n *createNode) Next() (bool, error) {
 			return false, err
 		}
 
-		n.results.Spans(docIDsToSpans(documentsToDocIDs(n.docs), n.collection.Description()))
+		n.results.Spans(docIDsToSpans(documentsToDocIDs(n.docs...), n.collection.Description()))
 
 		err = n.results.Init()
 		if err != nil {
@@ -151,7 +151,7 @@ func (p *Planner) CreateDocs(parsed *mapper.Mutation) (planNode, error) {
 	// create a mutation createNode.
 	create := &createNode{
 		p:         p,
-		input:     parsed.Input,
+		input:     parsed.CreateInput,
 		results:   results,
 		docMapper: docMapper{parsed.DocumentMapping},
 	}

--- a/internal/planner/errors.go
+++ b/internal/planner/errors.go
@@ -34,6 +34,7 @@ var (
 	ErrMissingChildValue                   = errors.New("expected child value, however none was yielded")
 	ErrUnknownRelationType                 = errors.New("failed sub selection, unknown relation type")
 	ErrUnknownExplainRequestType           = errors.New("can not explain request of unknown type")
+	ErrUpsertMultipleDocuments             = errors.New("cannot upsert multiple matching documents")
 )
 
 func NewErrUnknownDependency(name string) error {

--- a/internal/planner/explain.go
+++ b/internal/planner/explain.go
@@ -47,6 +47,7 @@ var (
 	_ explainablePlanNode = (*topLevelNode)(nil)
 	_ explainablePlanNode = (*typeIndexJoin)(nil)
 	_ explainablePlanNode = (*updateNode)(nil)
+	_ explainablePlanNode = (*upsertNode)(nil)
 )
 
 const (

--- a/internal/planner/explain.go
+++ b/internal/planner/explain.go
@@ -54,6 +54,8 @@ const (
 	collectionIDLabel   = "collectionID"
 	collectionNameLabel = "collectionName"
 	inputLabel          = "input"
+	createInputLabel    = "create"
+	updateInputLabel    = "update"
 	fieldNameLabel      = "fieldName"
 	filterLabel         = "filter"
 	joinRootLabel       = "root"

--- a/internal/planner/mapper/mapper.go
+++ b/internal/planner/mapper/mapper.go
@@ -1245,7 +1245,8 @@ func toMutation(
 	return &Mutation{
 		Select:        *underlyingSelect,
 		Type:          MutationType(mutationRequest.Type),
-		Input:         mutationRequest.Input,
+		CreateInput:   mutationRequest.CreateInput,
+		UpdateInput:   mutationRequest.UpdateInput,
 		Encrypt:       mutationRequest.Encrypt,
 		EncryptFields: mutationRequest.EncryptFields,
 	}, nil

--- a/internal/planner/mapper/mutation.go
+++ b/internal/planner/mapper/mutation.go
@@ -31,7 +31,7 @@ type Mutation struct {
 	// CreateInput is the array of maps of fields and values used for a create mutation.
 	CreateInput []map[string]any
 
-	// CreateInput is a map of fields and values used for an update mutation.
+	// UpdateInput is a map of fields and values used for an update mutation.
 	UpdateInput map[string]any
 
 	// Encrypt is a flag to indicate if the input data should be encrypted.

--- a/internal/planner/mapper/mutation.go
+++ b/internal/planner/mapper/mutation.go
@@ -17,6 +17,7 @@ const (
 	CreateObjects
 	UpdateObjects
 	DeleteObjects
+	UpsertObjects
 )
 
 // Mutation represents a request to mutate data stored in Defra.
@@ -27,8 +28,11 @@ type Mutation struct {
 	// The type of mutation. For example a create request.
 	Type MutationType
 
-	// Input is the array of maps of fields and values used for the mutation.
-	Input []map[string]any
+	// CreateInput is the array of maps of fields and values used for a create mutation.
+	CreateInput []map[string]any
+
+	// CreateInput is a map of fields and values used for an update mutation.
+	UpdateInput map[string]any
 
 	// Encrypt is a flag to indicate if the input data should be encrypted.
 	Encrypt bool

--- a/internal/planner/operations.go
+++ b/internal/planner/operations.go
@@ -31,6 +31,7 @@ var (
 	_ planNode = (*typeJoinMany)(nil)
 	_ planNode = (*typeJoinOne)(nil)
 	_ planNode = (*updateNode)(nil)
+	_ planNode = (*upsertNode)(nil)
 	_ planNode = (*valuesNode)(nil)
 	_ planNode = (*viewNode)(nil)
 	_ planNode = (*lensNode)(nil)

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -188,7 +188,7 @@ func (p *Planner) expandPlan(planNode planNode, parentPlan *selectTopNode) error
 		return p.expandPlan(n.source, parentPlan)
 
 	case *upsertNode:
-		return p.expandPlan(n.results, parentPlan)
+		return p.expandPlan(n.source, parentPlan)
 
 	case *viewNode:
 		return p.expandPlan(n.source, parentPlan)

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -121,6 +121,9 @@ func (p *Planner) newObjectMutationPlan(stmt *mapper.Mutation) (planNode, error)
 	case mapper.DeleteObjects:
 		return p.DeleteDocs(stmt)
 
+	case mapper.UpsertObjects:
+		return p.UpsertDocs(stmt)
+
 	default:
 		return nil, client.NewErrUnhandledType("mutation", stmt.Type)
 	}
@@ -183,6 +186,9 @@ func (p *Planner) expandPlan(planNode planNode, parentPlan *selectTopNode) error
 
 	case *deleteNode:
 		return p.expandPlan(n.source, parentPlan)
+
+	case *upsertNode:
+		return p.expandPlan(n.results, parentPlan)
 
 	case *viewNode:
 		return p.expandPlan(n.source, parentPlan)

--- a/internal/planner/upsert.go
+++ b/internal/planner/upsert.go
@@ -146,6 +146,9 @@ func (n *upsertNode) Explain(explainType request.ExplainType) (map[string]any, e
 	case request.SimpleExplain:
 		return n.simpleExplain()
 
+	case request.ExecuteExplain:
+		return map[string]any{}, nil
+
 	default:
 		return nil, ErrUnknownExplainRequestType
 	}

--- a/internal/planner/upsert.go
+++ b/internal/planner/upsert.go
@@ -17,52 +17,39 @@ import (
 	"github.com/sourcenetwork/defradb/internal/planner/mapper"
 )
 
-type updateNode struct {
+type upsertNode struct {
 	documentIterator
 	docMapper
 
-	p *Planner
-
-	collection client.Collection
-
-	filter *mapper.Filter
-
-	docIDs []string
-
-	// input map of fields and values
-	input map[string]any
-
-	isUpdating bool
-
-	results planNode
-
-	execInfo updateExecInfo
-}
-
-type updateExecInfo struct {
-	// Total number of times updateNode was executed.
-	iterations uint64
-
-	// Total number of successful updates.
-	updates uint64
+	p           *Planner
+	collection  client.Collection
+	filter      *mapper.Filter
+	createInput map[string]any
+	updateInput map[string]any
+	doc         *client.Document
+	isUpserting bool
+	results     planNode
 }
 
 // Next only returns once.
-func (n *updateNode) Next() (bool, error) {
-	n.execInfo.iterations++
+func (n *upsertNode) Next() (bool, error) {
+	if n.isUpserting {
+		next, err := n.results.Next()
+		if err != nil {
+			return false, err
+		}
 
-	if n.isUpdating {
-		for {
+		switch next {
+		case true:
+			n.currentValue = n.results.Value()
+			// make sure multiple documents do not match
 			next, err := n.results.Next()
 			if err != nil {
 				return false, err
 			}
-			if !next {
-				break
+			if next {
+				return false, ErrUpsertMultipleDocuments
 			}
-
-			n.currentValue = n.results.Value()
-
 			docID, err := client.NewDocIDFromString(n.currentValue.GetID())
 			if err != nil {
 				return false, err
@@ -71,7 +58,7 @@ func (n *updateNode) Next() (bool, error) {
 			if err != nil {
 				return false, err
 			}
-			for k, v := range n.input {
+			for k, v := range n.updateInput {
 				if err := doc.Set(k, v); err != nil {
 					return false, err
 				}
@@ -80,17 +67,18 @@ func (n *updateNode) Next() (bool, error) {
 			if err != nil {
 				return false, err
 			}
-
-			n.execInfo.updates++
+		case false:
+			err := n.collection.Create(n.p.ctx, n.doc)
+			if err != nil {
+				return false, err
+			}
+			n.results.Spans(docIDsToSpans(documentsToDocIDs(n.doc), n.collection.Description()))
 		}
-		n.isUpdating = false
-
-		// Re-init the results node, so that they can be properly yielded with the updated
-		// values, as well as any formatting (e.g. aggregates, groupings, etc)
-		err := n.results.Init()
+		err = n.results.Init()
 		if err != nil {
 			return false, err
 		}
+		n.isUpserting = false
 	}
 
 	next, err := n.results.Next()
@@ -100,32 +88,42 @@ func (n *updateNode) Next() (bool, error) {
 	if !next {
 		return false, nil
 	}
-
 	n.currentValue = n.results.Value()
 	return true, nil
 }
 
-func (n *updateNode) Kind() string { return "updateNode" }
+func (n *upsertNode) Kind() string {
+	return "upsertNode"
+}
 
-func (n *updateNode) Spans(spans core.Spans) { n.results.Spans(spans) }
+func (n *upsertNode) Spans(spans core.Spans) {
+	n.results.Spans(spans)
+}
 
-func (n *updateNode) Init() error { return n.results.Init() }
+func (n *upsertNode) Init() error {
+	return n.results.Init()
+}
 
-func (n *updateNode) Start() error {
+func (n *upsertNode) Start() error {
+	doc, err := client.NewDocFromMap(n.createInput, n.collection.Definition())
+	if err != nil {
+		return err
+	}
+	n.doc = doc
+
 	return n.results.Start()
 }
 
-func (n *updateNode) Close() error {
+func (n *upsertNode) Close() error {
 	return n.results.Close()
 }
 
-func (n *updateNode) Source() planNode { return n.results }
+func (n *upsertNode) Source() planNode {
+	return n.results
+}
 
-func (n *updateNode) simpleExplain() (map[string]any, error) {
+func (n *upsertNode) simpleExplain() (map[string]any, error) {
 	simpleExplainMap := map[string]any{}
-
-	// Add the document id(s) that request wants to update.
-	simpleExplainMap[request.DocIDArgName] = n.docIDs
 
 	// Add the filter attribute if it exists, otherwise have it nil.
 	if n.filter == nil {
@@ -134,38 +132,36 @@ func (n *updateNode) simpleExplain() (map[string]any, error) {
 		simpleExplainMap[filterLabel] = n.filter.ToMap(n.documentMapping)
 	}
 
-	// Add the attribute that represents the patch to update with.
-	simpleExplainMap[inputLabel] = n.input
+	// Add the attribute that represents the values to create or update.
+	simpleExplainMap[updateInputLabel] = n.updateInput
+	simpleExplainMap[createInputLabel] = n.createInput
 
 	return simpleExplainMap, nil
 }
 
 // Explain method returns a map containing all attributes of this node that
 // are to be explained, subscribes / opts-in this node to be an explainablePlanNode.
-func (n *updateNode) Explain(explainType request.ExplainType) (map[string]any, error) {
+func (n *upsertNode) Explain(explainType request.ExplainType) (map[string]any, error) {
 	switch explainType {
 	case request.SimpleExplain:
 		return n.simpleExplain()
-
-	case request.ExecuteExplain:
-		return map[string]any{
-			"iterations": n.execInfo.iterations,
-			"updates":    n.execInfo.updates,
-		}, nil
 
 	default:
 		return nil, ErrUnknownExplainRequestType
 	}
 }
 
-func (p *Planner) UpdateDocs(parsed *mapper.Mutation) (planNode, error) {
-	update := &updateNode{
-		p:          p,
-		filter:     parsed.Filter,
-		docIDs:     parsed.DocIDs.Value(),
-		input:      parsed.UpdateInput,
-		isUpdating: true,
-		docMapper:  docMapper{parsed.DocumentMapping},
+func (p *Planner) UpsertDocs(parsed *mapper.Mutation) (planNode, error) {
+	upsert := &upsertNode{
+		p:           p,
+		filter:      parsed.Filter,
+		updateInput: parsed.UpdateInput,
+		isUpserting: true,
+		docMapper:   docMapper{parsed.DocumentMapping},
+	}
+
+	if len(parsed.CreateInput) > 0 {
+		upsert.createInput = parsed.CreateInput[0]
 	}
 
 	// get collection
@@ -173,14 +169,14 @@ func (p *Planner) UpdateDocs(parsed *mapper.Mutation) (planNode, error) {
 	if err != nil {
 		return nil, err
 	}
-	update.collection = col
+	upsert.collection = col
 
 	// create the results Select node
 	resultsNode, err := p.Select(&parsed.Select)
 	if err != nil {
 		return nil, err
 	}
-	update.results = resultsNode
+	upsert.results = resultsNode
 
-	return update, nil
+	return upsert, nil
 }

--- a/internal/request/graphql/parser/mutation.go
+++ b/internal/request/graphql/parser/mutation.go
@@ -25,6 +25,7 @@ var (
 		"create": request.CreateObjects,
 		"update": request.UpdateObjects,
 		"delete": request.DeleteObjects,
+		"upsert": request.UpsertObjects,
 	}
 )
 

--- a/internal/request/graphql/parser/mutation.go
+++ b/internal/request/graphql/parser/mutation.go
@@ -20,15 +20,6 @@ import (
 	"github.com/sourcenetwork/defradb/client/request"
 )
 
-var (
-	mutationNameToType = map[string]request.MutationType{
-		"create": request.CreateObjects,
-		"update": request.UpdateObjects,
-		"delete": request.DeleteObjects,
-		"upsert": request.UpsertObjects,
-	}
-)
-
 // parseMutationOperationDefinition parses the individual GraphQL
 // 'mutation' operations, which there may be multiple of.
 func parseMutationOperationDefinition(
@@ -65,9 +56,6 @@ func parseMutation(exe *gql.ExecutionContext, parent *gql.Object, field *ast.Fie
 		},
 	}
 
-	fieldDef := gql.GetFieldDef(exe.Schema, parent, mut.Name)
-	arguments := gql.GetArgumentValues(fieldDef.Args, field.Arguments, exe.VariableValues)
-
 	// parse the mutation type
 	// mutation names are either generated from a type
 	// which means they are in the form name_type, where
@@ -78,11 +66,6 @@ func parseMutation(exe *gql.ExecutionContext, parent *gql.Object, field *ast.Fie
 	// get back one of our defined types.
 	mutNameParts := strings.Split(mut.Name, "_")
 	typeStr := mutNameParts[0]
-	var ok bool
-	mut.Type, ok = mutationNameToType[typeStr]
-	if !ok {
-		return nil, ErrUnknownMutationName
-	}
 
 	if len(mutNameParts) > 1 { // only generated object mutations
 		// reconstruct the name.
@@ -93,58 +76,28 @@ func parseMutation(exe *gql.ExecutionContext, parent *gql.Object, field *ast.Fie
 		mut.Collection = strings.Join(mutNameParts[1:], "_")
 	}
 
-	for _, argument := range field.Arguments {
-		name := argument.Name.Value
-		value := arguments[name]
+	fieldDef := gql.GetFieldDef(exe.Schema, parent, mut.Name)
+	arguments := gql.GetArgumentValues(fieldDef.Args, field.Arguments, exe.VariableValues)
 
-		switch name {
-		case request.Input:
-			switch v := value.(type) {
-			case []any:
-				// input for create is a list
-				inputs := make([]map[string]any, len(v))
-				for i, v := range v {
-					inputs[i] = v.(map[string]any)
-				}
-				mut.Input = inputs
+	switch typeStr {
+	case "create":
+		mut.Type = request.CreateObjects
+		parseCreateMutationArgs(mut, arguments)
 
-			case map[string]any:
-				// input for update is an object
-				mut.Input = []map[string]any{v}
-			}
+	case "update":
+		mut.Type = request.UpdateObjects
+		parseUpdateMutationArgs(mut, arguments)
 
-		case request.FilterClause:
-			if v, ok := value.(map[string]any); ok {
-				mut.Filter = immutable.Some(request.Filter{Conditions: v})
-			}
+	case "delete":
+		mut.Type = request.DeleteObjects
+		parseDeleteMutationArgs(mut, arguments)
 
-		case request.DocIDArgName:
-			v, ok := value.([]any)
-			if !ok {
-				continue // value is nil
-			}
-			docIDs := make([]string, len(v))
-			for i, v := range v {
-				docIDs[i] = v.(string)
-			}
-			mut.DocIDs = immutable.Some(docIDs)
+	case "upsert":
+		mut.Type = request.UpsertObjects
+		parseUpsertMutationArgs(mut, arguments)
 
-		case request.EncryptDocArgName:
-			if v, ok := value.(bool); ok {
-				mut.Encrypt = v
-			}
-
-		case request.EncryptFieldsArgName:
-			v, ok := value.([]any)
-			if !ok {
-				continue // value is nil
-			}
-			fields := make([]string, len(v))
-			for i, v := range v {
-				fields[i] = v.(string)
-			}
-			mut.EncryptFields = fields
-		}
+	default:
+		return nil, ErrUnknownMutationName
 	}
 
 	// if theres no field selections, just return
@@ -163,4 +116,107 @@ func parseMutation(exe *gql.ExecutionContext, parent *gql.Object, field *ast.Fie
 	}
 
 	return mut, err
+}
+
+func parseCreateMutationArgs(mut *request.ObjectMutation, args map[string]any) {
+	for name, value := range args {
+		switch name {
+		case request.Input:
+			v, ok := value.([]any)
+			if !ok {
+				continue // value is nil
+			}
+			inputs := make([]map[string]any, len(v))
+			for i, v := range v {
+				inputs[i] = v.(map[string]any)
+			}
+			mut.CreateInput = inputs
+
+		case request.EncryptDocArgName:
+			if v, ok := value.(bool); ok {
+				mut.Encrypt = v
+			}
+
+		case request.EncryptFieldsArgName:
+			v, ok := value.([]any)
+			if !ok {
+				continue // value is nil
+			}
+			fields := make([]string, len(v))
+			for i, v := range v {
+				fields[i] = v.(string)
+			}
+			mut.EncryptFields = fields
+		}
+	}
+}
+
+func parseDeleteMutationArgs(mut *request.ObjectMutation, args map[string]any) {
+	for name, value := range args {
+		switch name {
+		case request.DocIDArgName:
+			v, ok := value.([]any)
+			if !ok {
+				continue // value is nil
+			}
+			docIDs := make([]string, len(v))
+			for i, v := range v {
+				docIDs[i] = v.(string)
+			}
+			mut.DocIDs = immutable.Some(docIDs)
+
+		case request.FilterClause:
+			if v, ok := value.(map[string]any); ok {
+				mut.Filter = immutable.Some(request.Filter{Conditions: v})
+			}
+		}
+	}
+}
+
+func parseUpdateMutationArgs(mut *request.ObjectMutation, args map[string]any) {
+	for name, value := range args {
+		switch name {
+		case request.Input:
+			if v, ok := value.(map[string]any); ok {
+				mut.UpdateInput = v
+			}
+
+		case request.DocIDArgName:
+			v, ok := value.([]any)
+			if !ok {
+				continue // value is nil
+			}
+			docIDs := make([]string, len(v))
+			for i, v := range v {
+				docIDs[i] = v.(string)
+			}
+			mut.DocIDs = immutable.Some(docIDs)
+
+		case request.FilterClause:
+			if v, ok := value.(map[string]any); ok {
+				mut.Filter = immutable.Some(request.Filter{Conditions: v})
+			}
+		}
+	}
+}
+
+func parseUpsertMutationArgs(mut *request.ObjectMutation, args map[string]any) {
+	for name, value := range args {
+		switch name {
+		case request.CreateInput:
+			if v, ok := value.(map[string]any); ok {
+				mut.CreateInput = []map[string]any{v}
+			}
+
+		case request.UpdateInput:
+			if v, ok := value.(map[string]any); ok {
+				mut.UpdateInput = v
+			}
+
+		case request.FilterClause:
+			if v, ok := value.(map[string]any); ok {
+				mut.Filter = immutable.Some(request.Filter{Conditions: v})
+			}
+		}
+	}
 }

--- a/internal/request/graphql/schema/descriptions.go
+++ b/internal/request/graphql/schema/descriptions.go
@@ -105,9 +105,9 @@ An optional value that specifies as to whether deleted documents may be
 Creates one or more documents of this type using the data provided.
 `
 	upsertDocumentDescription string = `
-Update or create a document in this collection using the data provided. The unique
- document matching the provided filter will be updated with the provided update input,
- or if no matching document is found, a new document will be created with the
+Update or create a document in this collection using the data provided. The provided filter
+ must match at most one document. The matching document will be updated with the provided 
+ update input, or if no matching document is found, a new document will be created with the
  provided create input.
 
 NOTE: It is highly recommended to create an index on the fields used to filter.`

--- a/internal/request/graphql/schema/descriptions.go
+++ b/internal/request/graphql/schema/descriptions.go
@@ -104,6 +104,13 @@ An optional value that specifies as to whether deleted documents may be
 	createDocumentDescription string = `
 Creates one or more documents of this type using the data provided.
 `
+	upsertDocumentDescription string = `
+Update or create a document in this collection using the data provided. The unique
+ document matching the provided filter will be updated with the provided update input,
+ or if no matching document is found, a new document will be created with the
+ provided create input.
+
+NOTE: It is highly recommended to create an index on the fields used to filter.`
 	updateDocumentsDescription string = `
 Updates documents in this collection using the data provided. Only documents
  matching any provided criteria will be updated, if no criteria are provided
@@ -123,6 +130,11 @@ An optional set of docID values that will limit the update to documents
 An optional filter for this update that will limit the update to the documents
  matching the given criteria. If no matching documents are found, the operation
  will succeed, but no documents will be updated.
+`
+	upsertFilterArgDescription string = `
+A required filter for this upsert that must match one or zero documents.
+ If a matching document is found it will be updated, otherwise a new
+ document will be created.
 `
 	deleteDocumentsDescription string = `
 Deletes documents in this collection matching any provided criteria. If no

--- a/internal/request/graphql/schema/generate.go
+++ b/internal/request/graphql/schema/generate.go
@@ -1082,7 +1082,18 @@ func (g *Generator) GenerateMutationInputForGQLType(obj *gql.Object) ([]*gql.Fie
 		},
 	}
 
-	return []*gql.Field{create, update, delete}, nil
+	upsert := &gql.Field{
+		Name:        "upsert_" + obj.Name(),
+		Description: upsertDocumentDescription,
+		Type:        obj,
+		Args: gql.FieldConfigArgument{
+			"filter": schemaTypes.NewArgConfig(gql.NewNonNull(filterInput), upsertFilterArgDescription),
+			"create": schemaTypes.NewArgConfig(gql.NewNonNull(mutationInput), "Create field values"),
+			"update": schemaTypes.NewArgConfig(gql.NewNonNull(mutationInput), "Update field values"),
+		},
+	}
+
+	return []*gql.Field{create, update, delete, upsert}, nil
 }
 
 func (g *Generator) genTypeFieldsEnum(obj *gql.Object) *gql.Enum {

--- a/internal/request/graphql/schema/generate.go
+++ b/internal/request/graphql/schema/generate.go
@@ -1085,11 +1085,11 @@ func (g *Generator) GenerateMutationInputForGQLType(obj *gql.Object) ([]*gql.Fie
 	upsert := &gql.Field{
 		Name:        "upsert_" + obj.Name(),
 		Description: upsertDocumentDescription,
-		Type:        obj,
+		Type:        gql.NewList(obj),
 		Args: gql.FieldConfigArgument{
-			"filter": schemaTypes.NewArgConfig(gql.NewNonNull(filterInput), upsertFilterArgDescription),
-			"create": schemaTypes.NewArgConfig(gql.NewNonNull(mutationInput), "Create field values"),
-			"update": schemaTypes.NewArgConfig(gql.NewNonNull(mutationInput), "Update field values"),
+			request.FilterClause: schemaTypes.NewArgConfig(gql.NewNonNull(filterInput), upsertFilterArgDescription),
+			request.CreateInput:  schemaTypes.NewArgConfig(gql.NewNonNull(mutationInput), "Create field values"),
+			request.UpdateInput:  schemaTypes.NewArgConfig(gql.NewNonNull(mutationInput), "Update field values"),
 		},
 	}
 

--- a/tests/integration/explain.go
+++ b/tests/integration/explain.go
@@ -54,6 +54,7 @@ var (
 		"typeJoinMany":  {},
 		"typeJoinOne":   {},
 		"updateNode":    {},
+		"upsertNode":    {},
 		"valuesNode":    {},
 		"viewNode":      {},
 		"lensNode":      {},

--- a/tests/integration/explain/debug/upsert_test.go
+++ b/tests/integration/explain/debug/upsert_test.go
@@ -1,0 +1,64 @@
+// Copyright 2024 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package test_explain_debug
+
+import (
+	"testing"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	explainUtils "github.com/sourcenetwork/defradb/tests/integration/explain"
+)
+
+var upsertPattern = dataMap{
+	"explain": dataMap{
+		"operationNode": []dataMap{
+			{
+				"upsertNode": dataMap{
+					"selectTopNode": dataMap{
+						"selectNode": dataMap{
+							"scanNode": dataMap{},
+						},
+					},
+				},
+			},
+		},
+	},
+}
+
+func TestDebugExplainMutationRequest_WithUpsert_Succeeds(t *testing.T) {
+	test := testUtils.TestCase{
+
+		Description: "Explain (debug) mutation request with upsert.",
+
+		Actions: []any{
+			explainUtils.SchemaForExplainTests,
+
+			testUtils.ExplainRequest{
+
+				Request: `mutation @explain(type: debug) {
+					upsert_Author(
+						filter: {name: {_eq: "Bob"}},
+						update: {age: 59},
+						create: {name: "Bob", age: 59}
+					) {
+						_docID
+						name
+						age
+					}
+				}`,
+
+				ExpectedPatterns: upsertPattern,
+			},
+		},
+	}
+
+	explainUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/explain/default/upsert_test.go
+++ b/tests/integration/explain/default/upsert_test.go
@@ -1,0 +1,104 @@
+// Copyright 2024 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package test_explain_default
+
+import (
+	"testing"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	explainUtils "github.com/sourcenetwork/defradb/tests/integration/explain"
+)
+
+var upsertPattern = dataMap{
+	"explain": dataMap{
+		"operationNode": []dataMap{
+			{
+				"upsertNode": dataMap{
+					"selectTopNode": dataMap{
+						"selectNode": dataMap{
+							"scanNode": dataMap{},
+						},
+					},
+				},
+			},
+		},
+	},
+}
+
+func TestDefaultExplainMutationRequest_WithUpsert_Succeeds(t *testing.T) {
+	test := testUtils.TestCase{
+
+		Description: "Explain (default) mutation request with upsert.",
+
+		Actions: []any{
+			explainUtils.SchemaForExplainTests,
+
+			testUtils.ExplainRequest{
+
+				Request: `mutation @explain {
+					upsert_Author(
+						filter: {name: {_eq: "Bob"}},
+						create: {name: "Bob", age: 59},
+						update: {age: 59}
+					) {
+						_docID
+						name
+						age
+					}
+				}`,
+
+				ExpectedPatterns: upsertPattern,
+
+				ExpectedTargets: []testUtils.PlanNodeTargetCase{
+					{
+						TargetNodeName:    "upsertNode",
+						IncludeChildNodes: false,
+						ExpectedAttributes: dataMap{
+							"create": dataMap{
+								"name": "Bob",
+								"age":  int32(59),
+							},
+							"update": dataMap{
+								"age": int32(59),
+							},
+							"filter": dataMap{
+								"name": dataMap{
+									"_eq": "Bob",
+								},
+							},
+						},
+					},
+					{
+						TargetNodeName:    "scanNode",
+						IncludeChildNodes: true, // should be last node, so will have no child nodes.
+						ExpectedAttributes: dataMap{
+							"collectionID":   "3",
+							"collectionName": "Author",
+							"filter": dataMap{
+								"name": dataMap{
+									"_eq": "Bob",
+								},
+							},
+							"spans": []dataMap{
+								{
+									"end":   "/4",
+									"start": "/3",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	explainUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/explain/execute/upsert_test.go
+++ b/tests/integration/explain/execute/upsert_test.go
@@ -1,0 +1,125 @@
+// Copyright 2024 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package test_explain_execute
+
+import (
+	"testing"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	explainUtils "github.com/sourcenetwork/defradb/tests/integration/explain"
+)
+
+func TestExecuteExplainMutationRequest_WithUpsertAndMatchingFilter_Succeeds(t *testing.T) {
+	test := testUtils.TestCase{
+
+		Description: "Explain (execute) mutation request with upsert and matching filter.",
+
+		Actions: []any{
+			explainUtils.SchemaForExplainTests,
+
+			// Addresses
+			create2AddressDocuments(),
+
+			testUtils.ExplainRequest{
+				Request: `mutation @explain(type: execute) {
+					upsert_ContactAddress(
+						filter: {city: {_eq: "Waterloo"}},
+						create: {city: "Waterloo", country: "USA"},
+						update: {country: "USA"}
+					) {
+						country
+						city
+					}
+				}`,
+
+				ExpectedFullGraph: dataMap{
+					"explain": dataMap{
+						"executionSuccess": true,
+						"sizeOfResult":     1,
+						"planExecutions":   uint64(2),
+						"operationNode": []dataMap{
+							{
+								"upsertNode": dataMap{
+									"selectTopNode": dataMap{
+										"selectNode": dataMap{
+											"iterations":    uint64(4),
+											"filterMatches": uint64(2),
+											"scanNode": dataMap{
+												"iterations":   uint64(4),
+												"docFetches":   uint64(4),
+												"fieldFetches": uint64(6),
+												"indexFetches": uint64(0),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	explainUtils.ExecuteTestCase(t, test)
+}
+
+func TestExecuteExplainMutationRequest_WithUpsertAndNoMatchingFilter_Succeeds(t *testing.T) {
+	test := testUtils.TestCase{
+
+		Description: "Explain (execute) mutation request with upsert and no matching filter.",
+
+		Actions: []any{
+			explainUtils.SchemaForExplainTests,
+
+			testUtils.ExplainRequest{
+				Request: `mutation @explain(type: execute) {
+					upsert_ContactAddress(
+						filter: {city: {_eq: "Waterloo"}},
+						create: {city: "Waterloo", country: "USA"},
+						update: {country: "USA"}
+					) {
+						country
+						city
+					}
+				}`,
+
+				ExpectedFullGraph: dataMap{
+					"explain": dataMap{
+						"executionSuccess": true,
+						"sizeOfResult":     1,
+						"planExecutions":   uint64(2),
+						"operationNode": []dataMap{
+							{
+								"upsertNode": dataMap{
+									"selectTopNode": dataMap{
+										"selectNode": dataMap{
+											"iterations":    uint64(3),
+											"filterMatches": uint64(1),
+											"scanNode": dataMap{
+												"iterations":   uint64(3),
+												"docFetches":   uint64(1),
+												"fieldFetches": uint64(2),
+												"indexFetches": uint64(0),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	explainUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/mutation/upsert/simple_test.go
+++ b/tests/integration/mutation/upsert/simple_test.go
@@ -1,0 +1,191 @@
+// Copyright 2024 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package upsert
+
+import (
+	"testing"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+func TestMutationUpsertSimple_WithNoFilterMatch_CreatesNewDoc(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "Simple upsert mutation with no filter match",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users {
+						name: String 
+						age: Int
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
+					"name": "Alice",
+					"age": 40
+				}`,
+			},
+			testUtils.Request{
+				Request: `mutation {
+					upsert_Users(
+						filter: {name: {_eq: "Bob"}},
+						create: {name: "Bob", age: 40},
+						update: {age: 40}
+					) {
+						name
+						age
+					}
+				}`,
+				Results: map[string]any{
+					"upsert_Users": []map[string]any{
+						{
+							"name": "Bob",
+							"age":  int64(40),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestMutationUpsertSimple_WithFilterMatch_UpdatesDoc(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "Simple upsert mutation with filter match",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users {
+						name: String 
+						age: Int
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
+					"name": "Bob",
+					"age": 30
+				}`,
+			},
+			testUtils.Request{
+				Request: `mutation {
+					upsert_Users(
+						filter: {name: {_eq: "Bob"}},
+						create: {name: "Bob", age: 40},
+						update: {age: 40}
+					) {
+						name
+						age
+					}
+				}`,
+				Results: map[string]any{
+					"upsert_Users": []map[string]any{
+						{
+							"name": "Bob",
+							"age":  int64(40),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestMutationUpsertSimple_WithFilterMatchMultiple_ReturnsError(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "Simple upsert mutation with multiple filter matches",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users {
+						name: String 
+						age: Int
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
+					"name": "Bob",
+					"age": 30
+				}`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
+					"name": "Alice",
+					"age": 40
+				}`,
+			},
+			testUtils.Request{
+				Request: `mutation {
+					upsert_Users(
+						filter: {},
+						create: {name: "Alice", age: 40},
+						update: {age: 50}
+					) {
+						name
+						age
+					}
+				}`,
+				ExpectedError: `cannot upsert multiple matching documents`,
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestMutationUpsertSimple_WithUniqueCompositeIndexAndDuplicateUpdate_ReturnsError(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "Simple upsert mutation with unique composite index and update",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users @index(includes: [{name: "name"}, {name: "age"}], unique: true) {
+						name: String 
+						age: Int
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
+					"name": "Alice",
+					"age": 40
+				}`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
+					"name": "Bob",
+					"age": 50
+				}`,
+			},
+			testUtils.Request{
+				Request: `mutation {
+					upsert_Users(
+						filter: {name: {_eq: "Bob"}},
+						create: {name: "Alice", age: 40},
+						update: {name: "Alice", age: 40}
+					) {
+						name
+						age
+					}
+				}`,
+				ExpectedError: `can not index a doc's field(s) that violates unique index`,
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/mutation/upsert/simple_test.go
+++ b/tests/integration/mutation/upsert/simple_test.go
@@ -54,6 +54,26 @@ func TestMutationUpsertSimple_WithNoFilterMatch_CreatesNewDoc(t *testing.T) {
 					},
 				},
 			},
+			testUtils.Request{
+				Request: `query {
+					Users {
+						name
+						age
+					}
+				}`,
+				Results: map[string]any{
+					"Users": []map[string]any{
+						{
+							"name": "Bob",
+							"age":  int64(40),
+						},
+						{
+							"name": "Alice",
+							"age":  int64(40),
+						},
+					},
+				},
+			},
 		},
 	}
 
@@ -74,6 +94,12 @@ func TestMutationUpsertSimple_WithFilterMatch_UpdatesDoc(t *testing.T) {
 			},
 			testUtils.CreateDoc{
 				Doc: `{
+					"name": "Alice",
+					"age": 40
+				}`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
 					"name": "Bob",
 					"age": 30
 				}`,
@@ -91,6 +117,26 @@ func TestMutationUpsertSimple_WithFilterMatch_UpdatesDoc(t *testing.T) {
 				}`,
 				Results: map[string]any{
 					"upsert_Users": []map[string]any{
+						{
+							"name": "Bob",
+							"age":  int64(40),
+						},
+					},
+				},
+			},
+			testUtils.Request{
+				Request: `query {
+					Users {
+						name
+						age
+					}
+				}`,
+				Results: map[string]any{
+					"Users": []map[string]any{
+						{
+							"name": "Alice",
+							"age":  int64(40),
+						},
 						{
 							"name": "Bob",
 							"age":  int64(40),
@@ -140,6 +186,99 @@ func TestMutationUpsertSimple_WithFilterMatchMultiple_ReturnsError(t *testing.T)
 					}
 				}`,
 				ExpectedError: `cannot upsert multiple matching documents`,
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestMutationUpsertSimple_WithNullCreateInput_ReturnsError(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "Simple upsert mutation with null create input",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users {
+						name: String 
+						age: Int
+					}
+				`,
+			},
+			testUtils.Request{
+				Request: `mutation {
+					upsert_Users(
+						filter: {},
+						create: null,
+						update: {age: 50}
+					) {
+						name
+						age
+					}
+				}`,
+				ExpectedError: `Argument "create" has invalid value <nil>`,
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestMutationUpsertSimple_WithNullUpdateInput_ReturnsError(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "Simple upsert mutation with null update input",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users {
+						name: String 
+						age: Int
+					}
+				`,
+			},
+			testUtils.Request{
+				Request: `mutation {
+					upsert_Users(
+						filter: {},
+						create: {name: "Alice", age: 40},
+						update: null,
+					) {
+						name
+						age
+					}
+				}`,
+				ExpectedError: `Argument "update" has invalid value <nil>`,
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestMutationUpsertSimple_WithNullFilterInput_ReturnsError(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "Simple upsert mutation with null filter input",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users {
+						name: String 
+						age: Int
+					}
+				`,
+			},
+			testUtils.Request{
+				Request: `mutation {
+					upsert_Users(
+						filter: null,
+						create: {name: "Alice", age: 40},
+						update: {age: 50}
+					) {
+						name
+						age
+					}
+				}`,
+				ExpectedError: `Argument "filter" has invalid value <nil>`,
 			},
 		},
 	}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #783

## Description

This PR adds a new upsert GraphQL mutation operation.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Added integration tests.

Specify the platform(s) on which this was tested:
- MacOS

