### PR TITLE
fix(i): Validate nearby relation fields in SchemaPatch

### DIFF
--- a/internal/db/definition_validation.go
+++ b/internal/db/definition_validation.go
@@ -818,7 +818,9 @@ func validateFieldNotMutated(
 
 		for _, newField := range newSchema.Fields {
 			oldField, exists := oldFieldsByName[newField.Name]
-			if exists && oldField != newField {
+
+			// DeepEqual is temporary, as this validation is temporary
+			if exists && !reflect.DeepEqual(oldField, newField) {
 				return NewErrCannotMutateField(newField.Name)
 			}
 		}

--- a/internal/db/schema.go
+++ b/internal/db/schema.go
@@ -371,6 +371,16 @@ func (db *db) updateSchema(
 		proposedDescriptionsByName[schema.Name] = schema
 	}
 
+	allExistingCols, err := db.getCollections(ctx, client.CollectionFetchOptions{})
+	if err != nil {
+		return err
+	}
+
+	oldDefs := make([]client.CollectionDefinition, 0, len(allExistingCols))
+	for _, col := range allExistingCols {
+		oldDefs = append(oldDefs, col.Definition())
+	}
+
 	for _, schema := range proposedDescriptionsByName {
 		previousSchema := existingSchemaByName[schema.Name]
 
@@ -486,16 +496,6 @@ func (db *db) updateSchema(
 		err = db.setCollectionIDs(ctx, definitions)
 		if err != nil {
 			return err
-		}
-
-		allExistingCols, err := db.getCollections(ctx, client.CollectionFetchOptions{})
-		if err != nil {
-			return err
-		}
-
-		oldDefs := make([]client.CollectionDefinition, 0, len(allExistingCols))
-		for _, col := range allExistingCols {
-			oldDefs = append(oldDefs, col.Definition())
 		}
 
 		err = db.validateSchemaUpdate(ctx, oldDefs, definitions)

--- a/tests/integration/schema/updates/add/field/with_relation_test.go
+++ b/tests/integration/schema/updates/add/field/with_relation_test.go
@@ -1,0 +1,46 @@
+// Copyright 2024 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package field
+
+import (
+	"testing"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+func TestSchemaUpdatesAddField_DoesNotAffectExistingRelation(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Book {
+						name: String
+						author: Author
+					}
+
+					type Author {
+						name: String
+						books: [Book]
+					}
+				`,
+			},
+			testUtils.SchemaPatch{
+				Patch: `
+					[
+						{ "op": "add", "path": "/Book/Fields/-", "value": {"Name": "rating", "Kind": 4} }
+					]
+				`,
+				ExpectedError: "mutating an existing field is not supported.",
+			},
+		},
+	}
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/schema/updates/add/field/with_relation_test.go
+++ b/tests/integration/schema/updates/add/field/with_relation_test.go
@@ -16,6 +16,7 @@ import (
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
 )
 
+// This test ensures that nearby relation fields are not failing validation during a schema patch.
 func TestSchemaUpdatesAddField_DoesNotAffectExistingRelation(t *testing.T) {
 	test := testUtils.TestCase{
 		Actions: []any{
@@ -38,7 +39,6 @@ func TestSchemaUpdatesAddField_DoesNotAffectExistingRelation(t *testing.T) {
 						{ "op": "add", "path": "/Book/Fields/-", "value": {"Name": "rating", "Kind": 4} }
 					]
 				`,
-				ExpectedError: "mutating an existing field is not supported.",
 			},
 		},
 	}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #3074

## Description

Correctly handles validation of nearby relation fields in schema patch.

Previously the equality check failed to account for `Kind` being a pointer and thus always flagged relation fields as having mutated.  This was likely introduced in https://github.com/sourcenetwork/defradb/pull/2961 when `Kind` became a pointer.

Collections referenced by relation fields were also not included in the validation set, causing the rules to think that the related object did not exist.
