### PR TITLE
fix(i): Null compound filter panic

### DIFF
--- a/internal/connor/and.go
+++ b/internal/connor/and.go
@@ -16,6 +16,9 @@ func and(condition, data any) (bool, error) {
 		}
 		return true, nil
 
+	case nil:
+		return true, nil
+
 	default:
 		return false, client.NewErrUnhandledType("condition", cn)
 	}

--- a/internal/connor/or.go
+++ b/internal/connor/or.go
@@ -14,8 +14,11 @@ func or(condition, data any) (bool, error) {
 				return true, nil
 			}
 		}
-
 		return false, nil
+
+	case nil:
+		return true, nil
+
 	default:
 		return false, client.NewErrUnhandledType("condition", cn)
 	}

--- a/internal/planner/mapper/mapper.go
+++ b/internal/planner/mapper/mapper.go
@@ -966,7 +966,10 @@ func resolveInnerFilterDependencies(
 
 	for key := range source {
 		if key == request.FilterOpAnd || key == request.FilterOpOr {
-			compoundFilter := source[key].([]any)
+			compoundFilter, ok := source[key].([]any)
+			if !ok {
+				continue // filter is nil
+			}
 			for _, innerFilter := range compoundFilter {
 				innerFields, err := resolveInnerFilterDependencies(
 					ctx,
@@ -987,7 +990,10 @@ func resolveInnerFilterDependencies(
 			}
 			continue
 		} else if key == request.FilterOpNot {
-			notFilter := source[key].(map[string]any)
+			notFilter, ok := source[key].(map[string]any)
+			if !ok {
+				continue // filter is nil
+			}
 			innerFields, err := resolveInnerFilterDependencies(
 				ctx,
 				store,

--- a/internal/planner/mapper/mapper.go
+++ b/internal/planner/mapper/mapper.go
@@ -964,12 +964,12 @@ func resolveInnerFilterDependencies(
 ) ([]Requestable, error) {
 	newFields := []Requestable{}
 
-	for key := range source {
+	for key, value := range source {
 		if key == request.FilterOpAnd || key == request.FilterOpOr {
-			compoundFilter, ok := source[key].([]any)
-			if !ok {
-				continue // filter is nil
+			if value == nil {
+				continue
 			}
+			compoundFilter := value.([]any)
 			for _, innerFilter := range compoundFilter {
 				innerFields, err := resolveInnerFilterDependencies(
 					ctx,
@@ -990,10 +990,10 @@ func resolveInnerFilterDependencies(
 			}
 			continue
 		} else if key == request.FilterOpNot {
-			notFilter, ok := source[key].(map[string]any)
-			if !ok {
-				continue // filter is nil
+			if value == nil {
+				continue
 			}
+			notFilter := value.(map[string]any)
 			innerFields, err := resolveInnerFilterDependencies(
 				ctx,
 				store,
@@ -1050,8 +1050,7 @@ func resolveInnerFilterDependencies(
 			newFields = append(newFields, childSelect)
 		}
 
-		childSource := source[key]
-		childFilter, isChildFilter := childSource.(map[string]any)
+		childFilter, isChildFilter := value.(map[string]any)
 		if !isChildFilter {
 			// If the filter is not a child filter then the will be no inner dependencies to add and
 			// we can continue.

--- a/internal/planner/mapper/targetable.go
+++ b/internal/planner/mapper/targetable.go
@@ -126,7 +126,10 @@ func filterObjectToMap(mapping *core.DocumentMapping, obj map[connor.FilterKey]a
 		case *Operator:
 			switch keyType.Operation {
 			case request.FilterOpAnd, request.FilterOpOr:
-				v := v.([]any)
+				v, ok := v.([]any)
+				if !ok {
+					continue // value is nil
+				}
 				logicMapEntries := make([]any, len(v))
 				for i, item := range v {
 					itemMap := item.(map[connor.FilterKey]any)
@@ -134,8 +137,10 @@ func filterObjectToMap(mapping *core.DocumentMapping, obj map[connor.FilterKey]a
 				}
 				outmap[keyType.Operation] = logicMapEntries
 			case request.FilterOpNot:
-				itemMap := v.(map[connor.FilterKey]any)
-				outmap[keyType.Operation] = filterObjectToMap(mapping, itemMap)
+				itemMap, ok := v.(map[connor.FilterKey]any)
+				if ok {
+					outmap[keyType.Operation] = filterObjectToMap(mapping, itemMap)
+				}
 			default:
 				outmap[keyType.Operation] = v
 			}

--- a/internal/request/graphql/schema/generate.go
+++ b/internal/request/graphql/schema/generate.go
@@ -1138,11 +1138,11 @@ func (g *Generator) genTypeFilterArgInput(obj *gql.Object) *gql.InputObject {
 
 			fields["_and"] = &gql.InputObjectFieldConfig{
 				Description: schemaTypes.AndOperatorDescription,
-				Type:        gql.NewList(selfRefType),
+				Type:        gql.NewList(gql.NewNonNull(selfRefType)),
 			}
 			fields["_or"] = &gql.InputObjectFieldConfig{
 				Description: schemaTypes.OrOperatorDescription,
-				Type:        gql.NewList(selfRefType),
+				Type:        gql.NewList(gql.NewNonNull(selfRefType)),
 			}
 			fields["_not"] = &gql.InputObjectFieldConfig{
 				Description: schemaTypes.NotOperatorDescription,
@@ -1220,7 +1220,7 @@ func (g *Generator) genLeafFilterArgInput(obj gql.Type) *gql.InputObject {
 		fields := gql.InputObjectConfigFieldMap{}
 
 		compoundListType := &gql.InputObjectFieldConfig{
-			Type: gql.NewList(selfRefType),
+			Type: gql.NewList(gql.NewNonNull(selfRefType)),
 		}
 
 		fields["_and"] = compoundListType

--- a/tests/integration/query/simple/with_null_input_test.go
+++ b/tests/integration/query/simple/with_null_input_test.go
@@ -334,3 +334,213 @@ func TestQuerySimple_WithNullShowDeleted_Succeeds(t *testing.T) {
 
 	executeTestCase(t, test)
 }
+
+func TestQuerySimple_WithFilterWithNullOr_Succeeds(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "Simple query, with filter with null or",
+		Actions: []any{
+			testUtils.CreateDoc{
+				Doc: `{
+					"Name": "John"
+				}`,
+			},
+			testUtils.Request{
+				Request: `query {
+					Users(filter: {_or: null}) {
+						Name
+					}
+				}`,
+				Results: map[string]any{
+					"Users": []map[string]any{
+						{
+							"Name": "John",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	executeTestCase(t, test)
+}
+
+func TestQuerySimple_WithFilterWithNullOrElement_ReturnsError(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "Simple query, with filter with null or element",
+		Actions: []any{
+			testUtils.Request{
+				Request: `query {
+					Users(filter: {_or: [null]}) {
+						Name
+					}
+				}`,
+				ExpectedError: `Expected "UsersFilterArg!", found null`,
+			},
+		},
+	}
+
+	executeTestCase(t, test)
+}
+
+func TestQuerySimple_WithFilterWithNullOrField_ReturnsError(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "Simple query, with filter with or with null field",
+		Actions: []any{
+			testUtils.CreateDoc{
+				Doc: `{
+					"Name": null
+				}`,
+			},
+			testUtils.Request{
+				Request: `query {
+					Users(filter: {_or: [{Name: null}]}) {
+						Name
+					}
+				}`,
+				Results: map[string]any{
+					"Users": []map[string]any{
+						{
+							"Name": nil,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	executeTestCase(t, test)
+}
+
+func TestQuerySimple_WithFilterWithNullAnd_Succeeds(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "Simple query, with filter with null and",
+		Actions: []any{
+			testUtils.CreateDoc{
+				Doc: `{
+					"Name": "John"
+				}`,
+			},
+			testUtils.Request{
+				Request: `query {
+					Users(filter: {_and: null}) {
+						Name
+					}
+				}`,
+				Results: map[string]any{
+					"Users": []map[string]any{
+						{
+							"Name": "John",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	executeTestCase(t, test)
+}
+
+func TestQuerySimple_WithFilterWithNullAndElement_ReturnsError(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "Simple query, with filter with null and element",
+		Actions: []any{
+			testUtils.Request{
+				Request: `query {
+					Users(filter: {_and: [null]}) {
+						Name
+					}
+				}`,
+				ExpectedError: `Expected "UsersFilterArg!", found null`,
+			},
+		},
+	}
+
+	executeTestCase(t, test)
+}
+
+func TestQuerySimple_WithFilterWithNullAndField_ReturnsError(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "Simple query, with filter with and with null field",
+		Actions: []any{
+			testUtils.CreateDoc{
+				Doc: `{
+					"Name": null
+				}`,
+			},
+			testUtils.Request{
+				Request: `query {
+					Users(filter: {_and: [{Name: null}]}) {
+						Name
+					}
+				}`,
+				Results: map[string]any{
+					"Users": []map[string]any{
+						{
+							"Name": nil,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	executeTestCase(t, test)
+}
+
+func TestQuerySimple_WithFilterWithNullNot_Succeeds(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "Simple query, with filter with null not",
+		Actions: []any{
+			testUtils.CreateDoc{
+				Doc: `{
+					"Name": "John"
+				}`,
+			},
+			testUtils.Request{
+				Request: `query {
+					Users(filter: {_not: null}) {
+						Name
+					}
+				}`,
+				Results: map[string]any{
+					"Users": []map[string]any{
+						{
+							"Name": "John",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	executeTestCase(t, test)
+}
+
+func TestQuerySimple_WithFilterWithNullNotField_Succeeds(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "Simple query, with filter with null not field",
+		Actions: []any{
+			testUtils.CreateDoc{
+				Doc: `{
+					"Name": "John"
+				}`,
+			},
+			testUtils.Request{
+				Request: `query {
+					Users(filter: {_not: {Name: null}}) {
+						Name
+					}
+				}`,
+				Results: map[string]any{
+					"Users": []map[string]any{
+						{
+							"Name": "John",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	executeTestCase(t, test)
+}

--- a/tests/integration/schema/default_fields.go
+++ b/tests/integration/schema/default_fields.go
@@ -215,14 +215,14 @@ func buildFilterArg(objectName string, fields []argDef) Field {
 
 	inputFields := []any{
 		makeInputObject("_and", nil, map[string]any{
-			"kind": "INPUT_OBJECT",
-			"name": filterArgName,
+			"kind": "NON_NULL",
+			"name": nil,
 		}),
 		makeInputObject("_docID", "IDOperatorBlock", nil),
 		makeInputObject("_not", filterArgName, nil),
 		makeInputObject("_or", nil, map[string]any{
-			"kind": "INPUT_OBJECT",
-			"name": filterArgName,
+			"kind": "NON_NULL",
+			"name": nil,
 		}),
 	}
 

--- a/tests/integration/schema/filter_test.go
+++ b/tests/integration/schema/filter_test.go
@@ -71,7 +71,7 @@ func TestFilterForSimpleSchema(t *testing.T) {
 														"type": map[string]any{
 															"name": nil,
 															"ofType": map[string]any{
-																"name": "UsersFilterArg",
+																"name": nil,
 															},
 														},
 													},
@@ -94,7 +94,7 @@ func TestFilterForSimpleSchema(t *testing.T) {
 														"type": map[string]any{
 															"name": nil,
 															"ofType": map[string]any{
-																"name": "UsersFilterArg",
+																"name": nil,
 															},
 														},
 													},
@@ -203,7 +203,7 @@ func TestFilterForOneToOneSchema(t *testing.T) {
 														"type": map[string]any{
 															"name": nil,
 															"ofType": map[string]any{
-																"name": "BookFilterArg",
+																"name": nil,
 															},
 														},
 													},
@@ -226,7 +226,7 @@ func TestFilterForOneToOneSchema(t *testing.T) {
 														"type": map[string]any{
 															"name": nil,
 															"ofType": map[string]any{
-																"name": "BookFilterArg",
+																"name": nil,
 															},
 														},
 													},


### PR DESCRIPTION
## Relevant issue(s)

Resolves #3079

## Description

This PR fixes an issue where null values within compound filters would panic.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Added integration tests

Specify the platform(s) on which this was tested:
- MacOS

