### PR TITLE
ci(i): Fix vulnerabilities scan by ignoring x/crises

### DIFF
--- a/.github/workflows/check-vulnerabilities.yml
+++ b/.github/workflows/check-vulnerabilities.yml
@@ -30,10 +30,32 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Run govulncheck
-        uses: golang/govulncheck-action@v1
+      - name: Checkout code into the directory
+        uses: actions/checkout@v4
+
+      - name: Setup Go environment explicitly
+        uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
           check-latest: true
           cache: false
-          go-package: ./...
+
+      - name: Install govulncheck
+        run: make deps:vulncheck
+
+      - name: Run govulncheck scan
+        run: govulncheck -C . -format text ./... | tee govulncheck.txt
+
+      - name: Check if only known vulnerabilities were found (there are new vulnerabilities if this fails)
+        run: cat govulncheck.txt | grep "Your code is affected by 2 vulnerabilities from 1 module."
+
+    # Use the steps below once the x/crisis (crisis.init) bug is fixed or if the
+    # ability to silence is implemented: https://github.com/golang/go/issues/61211
+    #steps:
+    # - name: Run govulncheck
+    #   uses: golang/govulncheck-action@v1
+    #   with:
+    #     go-version-file: 'go.mod'
+    #     check-latest: true
+    #     cache: false
+    #     go-package: ./...

--- a/Makefile
+++ b/Makefile
@@ -135,6 +135,10 @@ else
 	$(info YAML linter 'yamllint' already installed.)
 endif
 
+.PHONY: deps\:vulncheck
+deps\:vulncheck:
+	go install golang.org/x/vuln/cmd/govulncheck@latest
+
 .PHONY: deps\:lint
 deps\:lint:
 	@$(MAKE) deps:lint-go && \
@@ -172,6 +176,7 @@ deps:
 	$(MAKE) deps:bench && \
 	$(MAKE) deps:chglog && \
 	$(MAKE) deps:lint && \
+	$(MAKE) deps:vulncheck && \
 	$(MAKE) deps:test && \
 	$(MAKE) deps:mocks
 


### PR DESCRIPTION
## Relevant issue(s)
Resolves #3090

## Description
- Hacky fix for the vulnerability scanner until they improve the tool (or we solve the vulnerability).
- Make the vulnerability scan fail if new vulnerabilities are introduced and pass if previous known ones remain.


## How has this been tested?
- Tried introducing a vul and it works and ignores the current `x/crisis` one
- Run: https://github.com/sourcenetwork/defradb/actions/runs/11110357130/job/30867868823?pr=3091
