### PR TITLE
chore(i): Bump linter (`golangci-lint`) to v1.61

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -50,7 +50,7 @@ jobs:
           # Required: the version of golangci-lint is required.
           # Note: The version should not pick the patch version as the latest patch
           #  version is what will always be used.
-          version: v1.54
+          version: v1.61
 
           # Optional: working directory, useful for monorepos or if we wanted to run this
           #  on a non-root directory.

--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ client\:add-schema:
 
 .PHONY: deps\:lint-go
 deps\:lint-go:
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.54
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.61
 
 .PHONY: deps\:lint-yaml
 deps\:lint-yaml:

--- a/cmd/genopenapi/main.go
+++ b/cmd/genopenapi/main.go
@@ -29,5 +29,8 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	fmt.Fprint(os.Stdout, string(json))
+	_, err = fmt.Fprint(os.Stdout, string(json))
+	if err != nil {
+		panic(err)
+	}
 }

--- a/http/client_collection.go
+++ b/http/client_collection.go
@@ -15,7 +15,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
@@ -369,7 +368,7 @@ func (c *Collection) GetAllDocIDs(
 				ID: docID,
 			}
 			if res.Error != "" {
-				docIDResult.Err = fmt.Errorf(res.Error)
+				docIDResult.Err = errors.New(res.Error)
 			}
 			docIDCh <- docIDResult
 		}

--- a/http/handler_collection.go
+++ b/http/handler_collection.go
@@ -243,7 +243,10 @@ func (s *collectionHandler) GetAllDocIDs(rw http.ResponseWriter, req *http.Reque
 		if err != nil {
 			return
 		}
-		fmt.Fprintf(rw, "data: %s\n\n", data)
+		_, err = fmt.Fprintf(rw, "data: %s\n\n", data)
+		if err != nil {
+			return
+		}
 		flusher.Flush()
 	}
 }

--- a/http/handler_store.go
+++ b/http/handler_store.go
@@ -333,7 +333,10 @@ func (s *storeHandler) ExecRequest(rw http.ResponseWriter, req *http.Request) {
 			if err != nil {
 				return
 			}
-			fmt.Fprintf(rw, "data: %s\n\n", data)
+			_, err = fmt.Fprintf(rw, "data: %s\n\n", data)
+			if err != nil {
+				return
+			}
 			flusher.Flush()
 		}
 	}

--- a/tests/clients/cli/wrapper_collection.go
+++ b/tests/clients/cli/wrapper_collection.go
@@ -13,7 +13,6 @@ package cli
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"strings"
 
 	"github.com/sourcenetwork/immutable"
@@ -322,7 +321,7 @@ func (c *Collection) GetAllDocIDs(
 				ID: docID,
 			}
 			if res.Error != "" {
-				docIDResult.Err = fmt.Errorf(res.Error)
+				docIDResult.Err = errors.New(res.Error)
 			}
 			docIDCh <- docIDResult
 		}

--- a/tools/configs/golangci.yaml
+++ b/tools/configs/golangci.yaml
@@ -61,8 +61,10 @@ run:
 
 #=====================================================================================[ Output Configuration Options ]
 output:
-  # colored-line-number|line-number|json|tab|checkstyle|code-climate|junit-xml|github-actions
-  format: colored-line-number
+  formats:
+    # colored-line-number|line-number|json|tab|checkstyle|code-climate|junit-xml|github-actions
+    - format: colored-line-number
+      path: stdout
 
   # print lines of code with issue.
   print-issued-lines: true

--- a/tools/configs/golangci.yaml
+++ b/tools/configs/golangci.yaml
@@ -353,8 +353,6 @@ linters-settings:
             - must not end in punctuation
 
   staticcheck:
-    # Select the Go version to target.
-    go: "1.22"
     # https://staticcheck.io/docs/options#checks
     checks: ["all"]
 

--- a/tools/configs/golangci.yaml
+++ b/tools/configs/golangci.yaml
@@ -260,8 +260,6 @@ linters-settings:
     local-prefixes: github.com/sourcenetwork/defradb
 
   gosimple:
-    # Select the Go version to target.
-    go: "1.22"
     # https://staticcheck.io/docs/options#checks
     checks: ["all", "-S1038"]
     # Turn on all except (these are disabled):


### PR DESCRIPTION
## Relevant issue(s)
Resolves #3104 

## Description
- Bump linter
- Resolve deprecated stuff
- Resolve new linter warning improvements