### PR TITLE
feat: Add replicator retry

### DIFF
--- a/client/db.go
+++ b/client/db.go
@@ -60,7 +60,7 @@ type DB interface {
 	// Peerstore returns the peerstore where known host information is stored.
 	//
 	// It sits within the rootstore returned by [Root].
-	Peerstore() datastore.DSBatching
+	Peerstore() datastore.DSReaderWriter
 
 	// Headstore returns the headstore where the current heads of the database are stored.
 	//

--- a/client/mocks/db.go
+++ b/client/mocks/db.go
@@ -1564,19 +1564,19 @@ func (_c *DB_PeerInfo_Call) RunAndReturn(run func() peer.AddrInfo) *DB_PeerInfo_
 }
 
 // Peerstore provides a mock function with given fields:
-func (_m *DB) Peerstore() datastore.DSBatching {
+func (_m *DB) Peerstore() datastore.DSReaderWriter {
 	ret := _m.Called()
 
 	if len(ret) == 0 {
 		panic("no return value specified for Peerstore")
 	}
 
-	var r0 datastore.DSBatching
-	if rf, ok := ret.Get(0).(func() datastore.DSBatching); ok {
+	var r0 datastore.DSReaderWriter
+	if rf, ok := ret.Get(0).(func() datastore.DSReaderWriter); ok {
 		r0 = rf()
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(datastore.DSBatching)
+			r0 = ret.Get(0).(datastore.DSReaderWriter)
 		}
 	}
 
@@ -1600,12 +1600,12 @@ func (_c *DB_Peerstore_Call) Run(run func()) *DB_Peerstore_Call {
 	return _c
 }
 
-func (_c *DB_Peerstore_Call) Return(_a0 datastore.DSBatching) *DB_Peerstore_Call {
+func (_c *DB_Peerstore_Call) Return(_a0 datastore.DSReaderWriter) *DB_Peerstore_Call {
 	_c.Call.Return(_a0)
 	return _c
 }
 
-func (_c *DB_Peerstore_Call) RunAndReturn(run func() datastore.DSBatching) *DB_Peerstore_Call {
+func (_c *DB_Peerstore_Call) RunAndReturn(run func() datastore.DSReaderWriter) *DB_Peerstore_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/client/replicator.go
+++ b/client/replicator.go
@@ -10,10 +10,26 @@
 
 package client
 
-import "github.com/libp2p/go-libp2p/core/peer"
+import (
+	"time"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+)
 
 // Replicator is a peer that a set of local collections are replicated to.
 type Replicator struct {
-	Info    peer.AddrInfo
-	Schemas []string
+	Info             peer.AddrInfo
+	Schemas          []string
+	Status           ReplicatorStatus
+	LastStatusChange time.Time
 }
+
+// ReplicatorStatus is the status of a Replicator.
+type ReplicatorStatus uint8
+
+const (
+	// ReplicatorStatusActive is the status of a Replicator that is actively replicating.
+	ReplicatorStatusActive ReplicatorStatus = iota
+	// ReplicatorStatusInactive is the status of a Replicator that is inactive/offline.
+	ReplicatorStatusInactive
+)

--- a/datastore/mocks/txn.go
+++ b/datastore/mocks/txn.go
@@ -533,19 +533,19 @@ func (_c *Txn_OnSuccessAsync_Call) RunAndReturn(run func(func())) *Txn_OnSuccess
 }
 
 // Peerstore provides a mock function with given fields:
-func (_m *Txn) Peerstore() datastore.DSBatching {
+func (_m *Txn) Peerstore() datastore.DSReaderWriter {
 	ret := _m.Called()
 
 	if len(ret) == 0 {
 		panic("no return value specified for Peerstore")
 	}
 
-	var r0 datastore.DSBatching
-	if rf, ok := ret.Get(0).(func() datastore.DSBatching); ok {
+	var r0 datastore.DSReaderWriter
+	if rf, ok := ret.Get(0).(func() datastore.DSReaderWriter); ok {
 		r0 = rf()
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(datastore.DSBatching)
+			r0 = ret.Get(0).(datastore.DSReaderWriter)
 		}
 	}
 
@@ -569,12 +569,12 @@ func (_c *Txn_Peerstore_Call) Run(run func()) *Txn_Peerstore_Call {
 	return _c
 }
 
-func (_c *Txn_Peerstore_Call) Return(_a0 datastore.DSBatching) *Txn_Peerstore_Call {
+func (_c *Txn_Peerstore_Call) Return(_a0 datastore.DSReaderWriter) *Txn_Peerstore_Call {
 	_c.Call.Return(_a0)
 	return _c
 }
 
-func (_c *Txn_Peerstore_Call) RunAndReturn(run func() datastore.DSBatching) *Txn_Peerstore_Call {
+func (_c *Txn_Peerstore_Call) RunAndReturn(run func() datastore.DSReaderWriter) *Txn_Peerstore_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/datastore/multi.go
+++ b/datastore/multi.go
@@ -12,7 +12,6 @@ package datastore
 
 import (
 	ds "github.com/ipfs/go-datastore"
-	"github.com/ipfs/go-datastore/namespace"
 )
 
 var (
@@ -31,7 +30,7 @@ type multistore struct {
 	data   DSReaderWriter
 	enc    Blockstore
 	head   DSReaderWriter
-	peer   DSBatching
+	peer   DSReaderWriter
 	system DSReaderWriter
 	dag    Blockstore
 }
@@ -46,7 +45,7 @@ func MultiStoreFrom(rootstore ds.Datastore) MultiStore {
 		data:   prefix(rootRW, dataStoreKey),
 		enc:    newBlockstore(prefix(rootRW, encStoreKey)),
 		head:   prefix(rootRW, headStoreKey),
-		peer:   namespace.Wrap(rootstore, peerStoreKey),
+		peer:   prefix(rootRW, peerStoreKey),
 		system: prefix(rootRW, systemStoreKey),
 		dag:    newBlockstore(prefix(rootRW, blockStoreKey)),
 	}
@@ -70,7 +69,7 @@ func (ms multistore) Headstore() DSReaderWriter {
 }
 
 // Peerstore implements MultiStore.
-func (ms multistore) Peerstore() DSBatching {
+func (ms multistore) Peerstore() DSReaderWriter {
 	return ms.peer
 }
 

--- a/datastore/store.go
+++ b/datastore/store.go
@@ -47,7 +47,7 @@ type MultiStore interface {
 
 	// Peerstore is a wrapped root DSReaderWriter as a ds.Batching, embedded into a DSBatching
 	// under the /peers namespace
-	Peerstore() DSBatching
+	Peerstore() DSReaderWriter
 
 	// Blockstore is a wrapped root DSReaderWriter as a Blockstore, embedded into a Blockstore
 	// under the /blocks namespace
@@ -80,9 +80,4 @@ type Blockstore interface {
 type IPLDStorage interface {
 	storage.ReadableStorage
 	storage.WritableStorage
-}
-
-// DSBatching wraps the Batching interface from go-datastore
-type DSBatching interface {
-	ds.Batching
 }

--- a/docs/website/references/http/openapi.json
+++ b/docs/website/references/http/openapi.json
@@ -509,11 +509,20 @@
                         },
                         "type": "object"
                     },
+                    "LastStatusChange": {
+                        "format": "date-time",
+                        "type": "string"
+                    },
                     "Schemas": {
                         "items": {
                             "type": "string"
                         },
                         "type": "array"
+                    },
+                    "Status": {
+                        "maximum": 255,
+                        "minimum": 0,
+                        "type": "integer"
                     }
                 },
                 "type": "object"

--- a/event/event.go
+++ b/event/event.go
@@ -35,6 +35,8 @@ const (
 	PeerInfoName = Name("peer-info")
 	// ReplicatorName is the name of the replicator event.
 	ReplicatorName = Name("replicator")
+	// ReplicatorFailureName is the name of the replicator failure event.
+	ReplicatorFailureName = Name("replicator-failure")
 	// P2PTopicCompletedName is the name of the network p2p topic update completed event.
 	P2PTopicCompletedName = Name("p2p-topic-completed")
 	// ReplicatorCompletedName is the name of the replicator completed event.
@@ -68,8 +70,12 @@ type Update struct {
 	// also formed this update.
 	Block []byte
 
-	// IsCreate is true if this update is the creation of a new document.
-	IsCreate bool
+	// IsRetry is true if this update is a retry of a previously failed update.
+	IsRetry bool
+
+	// Success is a channel that will receive a boolean value indicating if the update was successful.
+	// It is used during retries.
+	Success chan bool
 }
 
 // Merge is a notification that a merge can be performed up to the provided CID.
@@ -136,4 +142,12 @@ type Replicator struct {
 	// Docs will receive Updates if new collections have been added to the replicator
 	// and those collections have documents to be replicated.
 	Docs <-chan Update
+}
+
+// ReplicatorFailure is an event that is published when a replicator fails to replicate a document.
+type ReplicatorFailure struct {
+	// PeerID is the id of the peer that failed to replicate the document.
+	PeerID peer.ID
+	// DocID is the unique immutable identifier of the document that failed to replicate.
+	DocID string
 }

--- a/http/client.go
+++ b/http/client.go
@@ -493,7 +493,7 @@ func (c *Client) Encstore() datastore.Blockstore {
 	panic("client side database")
 }
 
-func (c *Client) Peerstore() datastore.DSBatching {
+func (c *Client) Peerstore() datastore.DSReaderWriter {
 	panic("client side database")
 }
 

--- a/http/client_tx.go
+++ b/http/client_tx.go
@@ -99,7 +99,7 @@ func (c *Transaction) Headstore() datastore.DSReaderWriter {
 	panic("client side transaction")
 }
 
-func (c *Transaction) Peerstore() datastore.DSBatching {
+func (c *Transaction) Peerstore() datastore.DSReaderWriter {
 	panic("client side transaction")
 }
 

--- a/internal/core/key.go
+++ b/internal/core/key.go
@@ -58,8 +58,10 @@ const (
 	FIELD_ID_SEQ                   = "/seq/field"
 	PRIMARY_KEY                    = "/pk"
 	DATASTORE_DOC_VERSION_FIELD_ID = "v"
-	REPLICATOR                     = "/replicator/id"
 	P2P_COLLECTION                 = "/p2p/collection"
+	REPLICATOR                     = "/rep/id"
+	REPLICATOR_RETRY_ID            = "/rep/retry/id"
+	REPLICATOR_RETRY_DOC           = "/rep/retry/doc"
 )
 
 // Key is an interface that represents a key in the database.
@@ -945,4 +947,74 @@ func bytesPrefixEnd(b []byte) []byte {
 	// This statement will only be reached if the key is already a
 	// maximal byte string (i.e. already \xff...).
 	return b
+}
+
+type ReplicatorRetryIDKey struct {
+	PeerID string
+}
+
+var _ Key = (*ReplicatorRetryIDKey)(nil)
+
+func NewReplicatorRetryIDKey(peerID string) ReplicatorRetryIDKey {
+	return ReplicatorRetryIDKey{
+		PeerID: peerID,
+	}
+}
+
+func NewReplicatorRetryIDKeyFromString(key string) (ReplicatorRetryIDKey, error) {
+	keyArr := strings.Split(key, "/")
+	if len(keyArr) != 5 {
+		return ReplicatorRetryIDKey{}, errors.WithStack(ErrInvalidKey, errors.NewKV("Key", key))
+	}
+	return NewReplicatorRetryIDKey(keyArr[4]), nil
+}
+
+func (k ReplicatorRetryIDKey) ToString() string {
+	return REPLICATOR_RETRY_ID + "/" + k.PeerID
+}
+
+func (k ReplicatorRetryIDKey) Bytes() []byte {
+	return []byte(k.ToString())
+}
+
+func (k ReplicatorRetryIDKey) ToDS() ds.Key {
+	return ds.NewKey(k.ToString())
+}
+
+type ReplicatorRetryDocIDKey struct {
+	PeerID string
+	DocID  string
+}
+
+var _ Key = (*ReplicatorRetryDocIDKey)(nil)
+
+func NewReplicatorRetryDocIDKey(peerID, docID string) ReplicatorRetryDocIDKey {
+	return ReplicatorRetryDocIDKey{
+		PeerID: peerID,
+		DocID:  docID,
+	}
+}
+
+func NewReplicatorRetryDocIDKeyFromString(key string) (ReplicatorRetryDocIDKey, error) {
+	keyArr := strings.Split(key, "/")
+	if len(keyArr) != 6 {
+		return ReplicatorRetryDocIDKey{}, errors.WithStack(ErrInvalidKey, errors.NewKV("Key", key))
+	}
+	return NewReplicatorRetryDocIDKey(keyArr[4], keyArr[5]), nil
+}
+
+func (k ReplicatorRetryDocIDKey) ToString() string {
+	keyString := REPLICATOR_RETRY_DOC + "/" + k.PeerID
+	if k.DocID != "" {
+		keyString += "/" + k.DocID
+	}
+	return keyString
+}
+
+func (k ReplicatorRetryDocIDKey) Bytes() []byte {
+	return []byte(k.ToString())
+}
+
+func (k ReplicatorRetryDocIDKey) ToDS() ds.Key {
+	return ds.NewKey(k.ToString())
 }

--- a/internal/core/key.go
+++ b/internal/core/key.go
@@ -961,12 +961,15 @@ func NewReplicatorRetryIDKey(peerID string) ReplicatorRetryIDKey {
 	}
 }
 
+// NewReplicatorRetryIDKeyFromString creates a new [ReplicatorRetryIDKey] from a string.
+//
+// It expects the input string to be in the format `/rep/retry/id/[PeerID]`.
 func NewReplicatorRetryIDKeyFromString(key string) (ReplicatorRetryIDKey, error) {
-	keyArr := strings.Split(key, "/")
-	if len(keyArr) != 5 {
+	peerID := strings.TrimPrefix(key, REPLICATOR_RETRY_ID+"/")
+	if peerID == "" {
 		return ReplicatorRetryIDKey{}, errors.WithStack(ErrInvalidKey, errors.NewKV("Key", key))
 	}
-	return NewReplicatorRetryIDKey(keyArr[4]), nil
+	return NewReplicatorRetryIDKey(peerID), nil
 }
 
 func (k ReplicatorRetryIDKey) ToString() string {
@@ -995,12 +998,16 @@ func NewReplicatorRetryDocIDKey(peerID, docID string) ReplicatorRetryDocIDKey {
 	}
 }
 
+// NewReplicatorRetryDocIDKeyFromString creates a new [ReplicatorRetryDocIDKey] from a string.
+//
+// It expects the input string to be in the format `/rep/retry/doc/[PeerID]/[DocID]`.
 func NewReplicatorRetryDocIDKeyFromString(key string) (ReplicatorRetryDocIDKey, error) {
-	keyArr := strings.Split(key, "/")
-	if len(keyArr) != 6 {
+	trimmedKey := strings.TrimPrefix(key, REPLICATOR_RETRY_DOC+"/")
+	keyArr := strings.Split(trimmedKey, "/")
+	if len(keyArr) != 2 {
 		return ReplicatorRetryDocIDKey{}, errors.WithStack(ErrInvalidKey, errors.NewKV("Key", key))
 	}
-	return NewReplicatorRetryDocIDKey(keyArr[4], keyArr[5]), nil
+	return NewReplicatorRetryDocIDKey(keyArr[0], keyArr[1]), nil
 }
 
 func (k ReplicatorRetryDocIDKey) ToString() string {

--- a/internal/db/collection.go
+++ b/internal/db/collection.go
@@ -702,7 +702,6 @@ func (c *collection) save(
 		Cid:        link.Cid,
 		SchemaRoot: c.Schema().Root,
 		Block:      headNode,
-		IsCreate:   isCreate,
 	}
 	txn.OnSuccess(func() {
 		c.db.events.Publish(event.NewMessage(event.UpdateName, updateEvent))

--- a/internal/db/config.go
+++ b/internal/db/config.go
@@ -11,6 +11,8 @@
 package db
 
 import (
+	"time"
+
 	"github.com/sourcenetwork/immutable"
 )
 
@@ -20,7 +22,24 @@ const (
 )
 
 type dbOptions struct {
-	maxTxnRetries immutable.Option[int]
+	maxTxnRetries  immutable.Option[int]
+	RetryIntervals []time.Duration
+}
+
+// defaultOptions returns the default db options.
+func defaultOptions() *dbOptions {
+	return &dbOptions{
+		RetryIntervals: []time.Duration{
+			// exponential backoff retry intervals
+			time.Second * 30,
+			time.Minute,
+			time.Minute * 2,
+			time.Minute * 4,
+			time.Minute * 8,
+			time.Minute * 16,
+			time.Minute * 32,
+		},
+	}
 }
 
 // Option is a funtion that sets a config value on the db.
@@ -30,5 +49,13 @@ type Option func(*dbOptions)
 func WithMaxRetries(num int) Option {
 	return func(opts *dbOptions) {
 		opts.maxTxnRetries = immutable.Some(num)
+	}
+}
+
+func WithRetryInterval(interval []time.Duration) Option {
+	return func(opt *dbOptions) {
+		if len(interval) > 0 {
+			opt.RetryIntervals = interval
+		}
 	}
 }

--- a/internal/db/config_test.go
+++ b/internal/db/config_test.go
@@ -12,6 +12,7 @@ package db
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -21,4 +22,10 @@ func TestWithMaxRetries(t *testing.T) {
 	WithMaxRetries(10)(&d)
 	assert.True(t, d.maxTxnRetries.HasValue())
 	assert.Equal(t, 10, d.maxTxnRetries.Value())
+}
+
+func TestWithRetryInterval(t *testing.T) {
+	d := dbOptions{}
+	WithRetryInterval([]time.Duration{time.Minute, time.Hour})(&d)
+	assert.Equal(t, []time.Duration{time.Minute, time.Hour}, d.RetryIntervals)
 }

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	ds "github.com/ipfs/go-datastore"
 	dsq "github.com/ipfs/go-datastore/query"
@@ -80,6 +81,15 @@ type db struct {
 	// The peer ID and network address information for the current node
 	// if network is enabled. The `atomic.Value` should hold a `peer.AddrInfo` struct.
 	peerInfo atomic.Value
+
+	// To be able to close the context passed to NewDB on DB close,
+	// we need to keep a reference to the cancel function. Otherwise,
+	// some goroutines might leak.
+	ctxCancel context.CancelFunc
+
+	retryIntervals []time.Duration
+	retryChan      chan event.ReplicatorFailure
+	retryDone      chan retryStatus
 }
 
 // NewDB creates a new instance of the DB using the given options.
@@ -107,20 +117,25 @@ func newDB(
 		return nil, err
 	}
 
-	db := &db{
-		rootstore:    rootstore,
-		multistore:   multistore,
-		acp:          acp,
-		lensRegistry: lens,
-		parser:       parser,
-		options:      options,
-		events:       event.NewBus(commandBufferSize, eventBufferSize),
+	opts := defaultOptions()
+	for _, opt := range options {
+		opt(opts)
 	}
 
-	// apply options
-	var opts dbOptions
-	for _, opt := range options {
-		opt(&opts)
+	ctx, cancel := context.WithCancel(ctx)
+
+	db := &db{
+		rootstore:      rootstore,
+		multistore:     multistore,
+		acp:            acp,
+		lensRegistry:   lens,
+		parser:         parser,
+		options:        options,
+		events:         event.NewBus(commandBufferSize, eventBufferSize),
+		retryChan:      make(chan event.ReplicatorFailure, 100),
+		retryDone:      make(chan retryStatus),
+		retryIntervals: opts.RetryIntervals,
+		ctxCancel:      cancel,
 	}
 
 	if opts.maxTxnRetries.HasValue() {
@@ -136,11 +151,12 @@ func newDB(
 		return nil, err
 	}
 
-	sub, err := db.events.Subscribe(event.MergeName, event.PeerInfoName)
+	sub, err := db.events.Subscribe(event.MergeName, event.PeerInfoName, event.ReplicatorFailureName)
 	if err != nil {
 		return nil, err
 	}
 	go db.handleMessages(ctx, sub)
+	go db.handleReplicatorRetries(ctx)
 
 	return db, nil
 }
@@ -173,7 +189,7 @@ func (db *db) Encstore() datastore.Blockstore {
 }
 
 // Peerstore returns the internal DAG store which contains IPLD blocks.
-func (db *db) Peerstore() datastore.DSBatching {
+func (db *db) Peerstore() datastore.DSReaderWriter {
 	return db.multistore.Peerstore()
 }
 
@@ -369,6 +385,8 @@ func (db *db) PrintDump(ctx context.Context) error {
 // This is the place for any last minute cleanup or releasing of resources (i.e.: Badger instance).
 func (db *db) Close() {
 	log.Info("Closing DefraDB process...")
+
+	db.ctxCancel()
 
 	db.events.Close()
 

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -87,9 +87,9 @@ type db struct {
 	// some goroutines might leak.
 	ctxCancel context.CancelFunc
 
+	// The intervals at which to retry replicator failures.
+	// For example, this can define an exponential backoff strategy.
 	retryIntervals []time.Duration
-	retryChan      chan event.ReplicatorFailure
-	retryDone      chan retryStatus
 }
 
 // NewDB creates a new instance of the DB using the given options.
@@ -132,10 +132,8 @@ func newDB(
 		parser:         parser,
 		options:        options,
 		events:         event.NewBus(commandBufferSize, eventBufferSize),
-		retryChan:      make(chan event.ReplicatorFailure, 100),
-		retryDone:      make(chan retryStatus),
-		retryIntervals: opts.RetryIntervals,
 		ctxCancel:      cancel,
+		retryIntervals: opts.RetryIntervals,
 	}
 
 	if opts.maxTxnRetries.HasValue() {

--- a/internal/db/errors.go
+++ b/internal/db/errors.go
@@ -148,6 +148,8 @@ var (
 	ErrSelfReferenceWithoutSelf                 = errors.New(errSelfReferenceWithoutSelf)
 	ErrColNotMaterialized                       = errors.New(errColNotMaterialized)
 	ErrMaterializedViewAndACPNotSupported       = errors.New(errMaterializedViewAndACPNotSupported)
+	ErrContextDone                              = errors.New("context done")
+	ErrTimeoutDocRetry                          = errors.New("timeout while retrying doc")
 )
 
 // NewErrFailedToGetHeads returns a new error indicating that the heads of a document

--- a/internal/db/errors.go
+++ b/internal/db/errors.go
@@ -149,6 +149,7 @@ var (
 	ErrColNotMaterialized                       = errors.New(errColNotMaterialized)
 	ErrMaterializedViewAndACPNotSupported       = errors.New(errMaterializedViewAndACPNotSupported)
 	ErrContextDone                              = errors.New("context done")
+	ErrFailedToRetryDoc                         = errors.New("failed to retry doc")
 	ErrTimeoutDocRetry                          = errors.New("timeout while retrying doc")
 )
 

--- a/internal/db/messages.go
+++ b/internal/db/messages.go
@@ -78,6 +78,9 @@ func (db *db) handleMessages(ctx context.Context, sub *event.Subscription) {
 						log.ErrorContextE(ctx, "Failed to load replicators", err)
 					}
 				})
+			case event.ReplicatorFailure:
+				// ReplicatorFailure is a notification that a replicator has failed to replicate a document.
+				db.retryChan <- evt
 			}
 		}
 	}

--- a/internal/db/messages.go
+++ b/internal/db/messages.go
@@ -80,7 +80,10 @@ func (db *db) handleMessages(ctx context.Context, sub *event.Subscription) {
 				})
 			case event.ReplicatorFailure:
 				// ReplicatorFailure is a notification that a replicator has failed to replicate a document.
-				db.retryChan <- evt
+				err := db.handleReplicatorFailure(ctx, evt.PeerID.String(), evt.DocID)
+				if err != nil {
+					log.ErrorContextE(ctx, "Failed to handle replicator failure", err)
+				}
 			}
 		}
 	}

--- a/net/client.go
+++ b/net/client.go
@@ -32,6 +32,8 @@ var (
 // over libp2p grpc connection
 func (s *server) pushLog(evt event.Update, pid peer.ID) (err error) {
 	defer func() {
+		// When the event is a retry, we don't need to republish the failure as
+		// it is already being handled by the retry mechanism through the success channel.
 		if err != nil && !evt.IsRetry {
 			s.peer.bus.Publish(event.NewMessage(event.ReplicatorFailureName, event.ReplicatorFailure{
 				DocID:  evt.DocID,

--- a/net/client_test.go
+++ b/net/client_test.go
@@ -95,7 +95,7 @@ func TestPushlogWithInvalidPeerID(t *testing.T) {
 	require.Contains(t, err.Error(), "failed to parse peer ID")
 }
 
-func TestPushlogW_WithValidPeerID_NoError(t *testing.T) {
+func TestPushlog_WithValidPeerID_NoError(t *testing.T) {
 	ctx := context.Background()
 	db1, p1 := newTestPeer(ctx, t)
 	defer db1.Close()

--- a/net/peer.go
+++ b/net/peer.go
@@ -263,6 +263,7 @@ func (p *Peer) handleLog(evt event.Update) error {
 	// push to each peer (replicator)
 	p.pushLogToReplicators(evt)
 
+	// Retries are for replicators only and should not polluting the pubsub network.
 	if !evt.IsRetry {
 		req := &pushLogRequest{
 			DocID:      evt.DocID,

--- a/net/peer.go
+++ b/net/peer.go
@@ -22,7 +22,6 @@ import (
 	"github.com/ipfs/boxo/blockservice"
 	"github.com/ipfs/boxo/bootstrap"
 	blocks "github.com/ipfs/go-block-format"
-	"github.com/ipfs/go-cid"
 	gostream "github.com/libp2p/go-libp2p-gostream"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/libp2p/go-libp2p/core/host"
@@ -237,13 +236,7 @@ func (p *Peer) handleMessageLoop() {
 
 		switch evt := msg.Data.(type) {
 		case event.Update:
-			var err error
-			if evt.IsCreate {
-				err = p.handleDocCreateLog(evt)
-			} else {
-				err = p.handleDocUpdateLog(evt)
-			}
-
+			err := p.handleLog(evt)
 			if err != nil {
 				log.ErrorE("Error while handling broadcast log", err)
 			}
@@ -253,6 +246,7 @@ func (p *Peer) handleMessageLoop() {
 
 		case event.Replicator:
 			p.server.updateReplicators(evt)
+
 		default:
 			// ignore other events
 			continue
@@ -260,77 +254,31 @@ func (p *Peer) handleMessageLoop() {
 	}
 }
 
-// RegisterNewDocument registers a new document with the peer node.
-func (p *Peer) RegisterNewDocument(
-	ctx context.Context,
-	docID client.DocID,
-	c cid.Cid,
-	rawBlock []byte,
-	schemaRoot string,
-) error {
-	// register topic
-	err := p.server.addPubSubTopic(docID.String(), !p.server.hasPubSubTopic(schemaRoot), nil)
-	if err != nil {
-		log.ErrorE(
-			"Failed to create new pubsub topic",
-			err,
-			corelog.String("DocID", docID.String()),
-		)
-		return err
-	}
-
-	req := &pushLogRequest{
-		DocID:      docID.String(),
-		CID:        c.Bytes(),
-		SchemaRoot: schemaRoot,
-		Creator:    p.host.ID().String(),
-		Block:      rawBlock,
-	}
-
-	return p.server.publishLog(ctx, schemaRoot, req)
-}
-
-func (p *Peer) handleDocCreateLog(evt event.Update) error {
-	docID, err := client.NewDocIDFromString(evt.DocID)
-	if err != nil {
-		return NewErrFailedToGetDocID(err)
-	}
-
-	// We need to register the document before pushing to the replicators if we want to
-	// ensure that we have subscribed to the topic.
-	err = p.RegisterNewDocument(p.ctx, docID, evt.Cid, evt.Block, evt.SchemaRoot)
-	if err != nil {
-		return err
-	}
-	// push to each peer (replicator)
-	p.pushLogToReplicators(evt)
-
-	return nil
-}
-
-func (p *Peer) handleDocUpdateLog(evt event.Update) error {
-	// push to each peer (replicator)
-	p.pushLogToReplicators(evt)
-
+func (p *Peer) handleLog(evt event.Update) error {
 	_, err := client.NewDocIDFromString(evt.DocID)
 	if err != nil {
 		return NewErrFailedToGetDocID(err)
 	}
 
-	req := &pushLogRequest{
-		DocID:      evt.DocID,
-		CID:        evt.Cid.Bytes(),
-		SchemaRoot: evt.SchemaRoot,
-		Creator:    p.host.ID().String(),
-		Block:      evt.Block,
-	}
+	// push to each peer (replicator)
+	p.pushLogToReplicators(evt)
 
-	if err := p.server.publishLog(p.ctx, evt.DocID, req); err != nil {
-		return NewErrPublishingToDocIDTopic(err, evt.Cid.String(), evt.DocID)
-	}
+	if !evt.IsRetry {
+		req := &pushLogRequest{
+			DocID:      evt.DocID,
+			CID:        evt.Cid.Bytes(),
+			SchemaRoot: evt.SchemaRoot,
+			Creator:    p.host.ID().String(),
+			Block:      evt.Block,
+		}
 
-	if err := p.server.publishLog(p.ctx, evt.SchemaRoot, req); err != nil {
-		return NewErrPublishingToSchemaTopic(err, evt.Cid.String(), evt.SchemaRoot)
+		if err := p.server.publishLog(p.ctx, evt.DocID, req); err != nil {
+			return NewErrPublishingToDocIDTopic(err, evt.Cid.String(), evt.DocID)
+		}
+
+		if err := p.server.publishLog(p.ctx, evt.SchemaRoot, req); err != nil {
+			return NewErrPublishingToSchemaTopic(err, evt.Cid.String(), evt.SchemaRoot)
+		}
 	}
 
 	return nil
@@ -344,26 +292,12 @@ func (p *Peer) pushLogToReplicators(lg event.Update) {
 		log.ErrorE("Failed to notify new blocks", err)
 	}
 
-	// push to each peer (replicator)
-	peers := make(map[string]struct{})
-	for _, peer := range p.ps.ListPeers(lg.DocID) {
-		peers[peer.String()] = struct{}{}
-	}
-	for _, peer := range p.ps.ListPeers(lg.SchemaRoot) {
-		peers[peer.String()] = struct{}{}
-	}
-
 	p.server.mu.Lock()
 	reps, exists := p.server.replicators[lg.SchemaRoot]
 	p.server.mu.Unlock()
 
 	if exists {
 		for pid := range reps {
-			// Don't push if pid is in the list of peers for the topic.
-			// It will be handled by the pubsub system.
-			if _, ok := peers[pid.String()]; ok {
-				continue
-			}
 			go func(peerID peer.ID) {
 				if err := p.server.pushLog(lg, peerID); err != nil {
 					log.ErrorE(

--- a/net/server.go
+++ b/net/server.go
@@ -273,9 +273,9 @@ func (s *server) publishLog(ctx context.Context, topic string, req *pushLogReque
 	t, ok := s.topics[topic]
 	s.mu.Unlock()
 	if !ok {
-		subscribe := true
-		if topic != req.SchemaRoot && s.hasPubSubTopic(req.SchemaRoot) {
-			subscribe = false
+		subscribe := false
+		if topic != req.SchemaRoot && !s.hasPubSubTopic(req.SchemaRoot) {
+			subscribe = true
 		}
 		err := s.addPubSubTopic(topic, subscribe, nil)
 		if err != nil {

--- a/tests/bench/query/planner/utils.go
+++ b/tests/bench/query/planner/utils.go
@@ -137,7 +137,7 @@ func (*dummyTxn) Rootstore() datastore.DSReaderWriter   { return nil }
 func (*dummyTxn) Datastore() datastore.DSReaderWriter   { return nil }
 func (*dummyTxn) Encstore() datastore.Blockstore        { return nil }
 func (*dummyTxn) Headstore() datastore.DSReaderWriter   { return nil }
-func (*dummyTxn) Peerstore() datastore.DSBatching       { return nil }
+func (*dummyTxn) Peerstore() datastore.DSReaderWriter   { return nil }
 func (*dummyTxn) Blockstore() datastore.Blockstore      { return nil }
 func (*dummyTxn) Systemstore() datastore.DSReaderWriter { return nil }
 func (*dummyTxn) Commit(ctx context.Context) error      { return nil }

--- a/tests/clients/cli/wrapper.go
+++ b/tests/clients/cli/wrapper.go
@@ -531,7 +531,7 @@ func (w *Wrapper) Headstore() ds.Read {
 	return w.node.DB.Headstore()
 }
 
-func (w *Wrapper) Peerstore() datastore.DSBatching {
+func (w *Wrapper) Peerstore() datastore.DSReaderWriter {
 	return w.node.DB.Peerstore()
 }
 

--- a/tests/clients/cli/wrapper_tx.go
+++ b/tests/clients/cli/wrapper_tx.go
@@ -83,7 +83,7 @@ func (w *Transaction) Headstore() datastore.DSReaderWriter {
 	return w.tx.Headstore()
 }
 
-func (w *Transaction) Peerstore() datastore.DSBatching {
+func (w *Transaction) Peerstore() datastore.DSReaderWriter {
 	return w.tx.Peerstore()
 }
 

--- a/tests/clients/http/wrapper.go
+++ b/tests/clients/http/wrapper.go
@@ -252,7 +252,7 @@ func (w *Wrapper) Headstore() ds.Read {
 	return w.node.DB.Headstore()
 }
 
-func (w *Wrapper) Peerstore() datastore.DSBatching {
+func (w *Wrapper) Peerstore() datastore.DSReaderWriter {
 	return w.node.DB.Peerstore()
 }
 

--- a/tests/clients/http/wrapper_tx.go
+++ b/tests/clients/http/wrapper_tx.go
@@ -77,7 +77,7 @@ func (w *TxWrapper) Headstore() datastore.DSReaderWriter {
 	return w.server.Headstore()
 }
 
-func (w *TxWrapper) Peerstore() datastore.DSBatching {
+func (w *TxWrapper) Peerstore() datastore.DSReaderWriter {
 	return w.server.Peerstore()
 }
 

--- a/tests/integration/db.go
+++ b/tests/integration/db.go
@@ -37,9 +37,9 @@ const (
 )
 
 const (
-	badgerIMType   DatabaseType = "badger-in-memory"
-	defraIMType    DatabaseType = "defra-memory-datastore"
-	badgerFileType DatabaseType = "badger-file-system"
+	BadgerIMType   DatabaseType = "badger-in-memory"
+	DefraIMType    DatabaseType = "defra-memory-datastore"
+	BadgerFileType DatabaseType = "badger-file-system"
 )
 
 var (
@@ -165,10 +165,10 @@ func setupNode(s *state, opts ...node.Option) (*node.Node, string, error) {
 
 	var path string
 	switch s.dbt {
-	case badgerIMType:
+	case BadgerIMType:
 		opts = append(opts, node.WithBadgerInMemory(true))
 
-	case badgerFileType:
+	case BadgerFileType:
 		switch {
 		case databaseDir != "":
 			// restarting database
@@ -185,7 +185,7 @@ func setupNode(s *state, opts ...node.Option) (*node.Node, string, error) {
 
 		opts = append(opts, node.WithStorePath(path), node.WithACPPath(path))
 
-	case defraIMType:
+	case DefraIMType:
 		opts = append(opts, node.WithStoreType(node.MemoryStore))
 
 	default:

--- a/tests/integration/net/simple/replicator/with_update_test.go
+++ b/tests/integration/net/simple/replicator/with_update_test.go
@@ -125,3 +125,83 @@ func TestP2POneToOneReplicatorUpdatesDocCreatedBeforeReplicatorConfigWithNodesIn
 
 	testUtils.ExecuteTestCase(t, test)
 }
+
+func TestP2POneToOneReplicator_ManyDocsUpdateWithTargetNodeTemporarilyOffline_ShouldSucceed(t *testing.T) {
+	test := testUtils.TestCase{
+		SupportedDatabaseTypes: immutable.Some(
+			[]testUtils.DatabaseType{
+				// This test only supports file type databases since it requires the ability to
+				// stop and start a node without losing data.
+				testUtils.BadgerFileType,
+			},
+		),
+		Actions: []any{
+			testUtils.RandomNetworkingConfig(),
+			testUtils.RandomNetworkingConfig(),
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users {
+						Name: String
+						Age: Int
+					}
+				`,
+			},
+			testUtils.ConfigureReplicator{
+				SourceNodeID: 0,
+				TargetNodeID: 1,
+			},
+			testUtils.Close{
+				NodeID: immutable.Some(1),
+			},
+			testUtils.CreateDoc{
+				// Create John on the first (source) node only, and allow the value to sync
+				NodeID: immutable.Some(0),
+				Doc: `{
+					"Name": "John",
+					"Age": 21
+				}`,
+			},
+			testUtils.CreateDoc{
+				// Create Fred on the first (source) node only, and allow the value to sync
+				NodeID: immutable.Some(0),
+				Doc: `{
+					"Name": "Fred",
+					"Age": 22
+				}`,
+			},
+			testUtils.UpdateDoc{
+				NodeID: immutable.Some(0),
+				DocID:  0,
+				Doc:    `{Age: 22}`,
+			},
+			testUtils.UpdateDoc{
+				NodeID: immutable.Some(0),
+				DocID:  1,
+				Doc:    `{Age: 23}`,
+			},
+			testUtils.Start{
+				NodeID: immutable.Some(1),
+			},
+			testUtils.WaitForSync{},
+			testUtils.Request{
+				Request: `query {
+					Users {
+						Age
+					}
+				}`,
+				Results: map[string]any{
+					"Users": []map[string]any{
+						{
+							"Age": int64(23),
+						},
+						{
+							"Age": int64(21),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/test_case.go
+++ b/tests/integration/test_case.go
@@ -60,6 +60,13 @@ type TestCase struct {
 	// differences between view types, or we need to temporarily document a bug.
 	SupportedViewTypes immutable.Option[[]ViewType]
 
+	// If provided a value, SupportedDatabaseTypes will cause this test to be skipped
+	// if the active database type is not within the given set.
+	//
+	// This is to only be used in the very rare cases where we really do want behavioural
+	// differences between database types, or we need to temporarily document a bug.
+	SupportedDatabaseTypes immutable.Option[[]DatabaseType]
+
 	// Configuration for KMS to be used in the test
 	KMS KMS
 }
@@ -92,6 +99,22 @@ type ConfigureNode func() []net.NodeOpt
 
 // Restart is an action that will close and then start all nodes.
 type Restart struct{}
+
+// Close is an action that will close a node.
+type Close struct {
+	// NodeID may hold the ID (index) of a node to close.
+	//
+	// If a value is not provided the close will be applied to all nodes.
+	NodeID immutable.Option[int]
+}
+
+// Start is an action that will start a node that has been previously closed.
+type Start struct {
+	// NodeID may hold the ID (index) of a node to start.
+	//
+	// If a value is not provided the start will be applied to all nodes.
+	NodeID immutable.Option[int]
+}
 
 // SchemaUpdate is an action that will update the database schema.
 //


### PR DESCRIPTION
## Relevant issue(s)

Resolves #3072 

## Description

This PR adds a replication retry functionality to the database. It uses an exponential backoff until 32 minutes is reached and then it will continuously retry every 32 minutes until the inactive peer is removed from the list of replicators.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

make test

Specify the platform(s) on which this was tested:
- MacOS
