### PR TITLE
fix(i): Default field value validation

### DIFF
--- a/docs/data_format_changes/i3137-default-value-fix.md
+++ b/docs/data_format_changes/i3137-default-value-fix.md
@@ -1,0 +1,3 @@
+# Default Value Fix
+
+Default value parsing has changed slightly and causes the change detector to fail.

--- a/internal/db/definition_validation.go
+++ b/internal/db/definition_validation.go
@@ -166,6 +166,7 @@ var globalValidators = []definitionValidator{
 	validateSelfReferences,
 	validateCollectionMaterialized,
 	validateMaterializedHasNoPolicy,
+	validateCollectionFieldDefaultValue,
 }
 
 var createValidators = append(
@@ -1013,6 +1014,23 @@ func validateMaterializedHasNoPolicy(
 	for _, col := range newState.collections {
 		if col.IsMaterialized && len(col.QuerySources()) != 0 && col.Policy.HasValue() {
 			return NewErrMaterializedViewAndACPNotSupported(col.Name.Value())
+		}
+	}
+
+	return nil
+}
+
+func validateCollectionFieldDefaultValue(
+	ctx context.Context,
+	db *db,
+	newState *definitionState,
+	oldState *definitionState,
+) error {
+	for name, col := range newState.definitionsByName {
+		// default values are set when a doc is first created
+		_, err := client.NewDocFromMap(map[string]any{}, col)
+		if err != nil {
+			return NewErrDefaultFieldValueInvalid(name, err)
 		}
 	}
 

--- a/internal/db/errors.go
+++ b/internal/db/errors.go
@@ -105,6 +105,7 @@ const (
 	errSelfReferenceWithoutSelf                 string = "must specify 'Self' kind for self referencing relations"
 	errColNotMaterialized                       string = "non-materialized collections are not supported"
 	errMaterializedViewAndACPNotSupported       string = "materialized views do not support ACP"
+	errInvalidDefaultFieldValue                 string = "default field value is invalid"
 )
 
 var (
@@ -679,5 +680,13 @@ func NewErrMaterializedViewAndACPNotSupported(collection string) error {
 	return errors.New(
 		errMaterializedViewAndACPNotSupported,
 		errors.NewKV("Collection", collection),
+	)
+}
+
+func NewErrDefaultFieldValueInvalid(collection string, inner error) error {
+	return errors.New(
+		errInvalidDefaultFieldValue,
+		errors.NewKV("Collection", collection),
+		errors.NewKV("Inner", inner),
 	)
 }

--- a/internal/request/graphql/schema/errors.go
+++ b/internal/request/graphql/schema/errors.go
@@ -30,8 +30,10 @@ const (
 	errPolicyUnknownArgument         string = "policy with unknown argument"
 	errPolicyInvalidIDProp           string = "policy directive with invalid id property"
 	errPolicyInvalidResourceProp     string = "policy directive with invalid resource property"
-	errDefaultValueInvalid           string = "default value type must match field type"
+	errDefaultValueType              string = "default value type must match field type"
 	errDefaultValueNotAllowed        string = "default value is not allowed for this field type"
+	errDefaultValueInvalid           string = "default value is invalid"
+	errDefaultValueOneArg            string = "default value must specify one argument"
 	errFieldTypeNotSpecified         string = "field type not specified"
 )
 
@@ -141,9 +143,24 @@ func NewErrRelationNotFound(relationName string) error {
 	)
 }
 
-func NewErrDefaultValueInvalid(name string, expected string, actual string) error {
+func NewErrDefaultValueOneArg(field string) error {
+	return errors.New(
+		errDefaultValueOneArg,
+		errors.NewKV("Field", field),
+	)
+}
+
+func NewErrDefaultValueInvalid(field string, arg string) error {
 	return errors.New(
 		errDefaultValueInvalid,
+		errors.NewKV("Field", field),
+		errors.NewKV("Arg", arg),
+	)
+}
+
+func NewErrDefaultValueType(name string, expected string, actual string) error {
+	return errors.New(
+		errDefaultValueType,
 		errors.NewKV("Name", name),
 		errors.NewKV("Expected", expected),
 		errors.NewKV("Actual", actual),

--- a/tests/integration/collection_description/with_default_fields_test.go
+++ b/tests/integration/collection_description/with_default_fields_test.go
@@ -58,7 +58,7 @@ func TestCollectionDescription_WithDefaultFieldValues(t *testing.T) {
 							{
 								ID:           3,
 								Name:         "created",
-								DefaultValue: "2000-07-23T03:00:00-00:00",
+								DefaultValue: "2000-07-23T03:00:00Z",
 							},
 							{
 								ID:           4,
@@ -83,6 +83,23 @@ func TestCollectionDescription_WithDefaultFieldValues(t *testing.T) {
 						},
 					},
 				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestCollectionDescription_WithInvalidDefaultFieldValueType_ReturnsError(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users {
+						active: Boolean @default(bool: invalid)
+					}
+				`,
+				ExpectedError: "default value is invalid. Field: active, Arg: bool",
 			},
 		},
 	}
@@ -116,7 +133,7 @@ func TestCollectionDescription_WithMultipleDefaultFieldValueTypes_ReturnsError(t
 						name: String @default(string: "Bob", int: 10, bool: true, float: 10)
 					}
 				`,
-				ExpectedError: "default value type must match field type. Name: name, Expected: string, Actual: int",
+				ExpectedError: "default value must specify one argument. Field: name",
 			},
 		},
 	}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #3133

## Description

This PR fixes a bug where default field value types were not properly validated and would cause a panic when creating a new document.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Added an integration test.

Specify the platform(s) on which this was tested:
- *(modify the list accordingly*)
- Arch Linux
- Debian Linux
- MacOS
- Windows
