### PR TITLE
fix(i): Index directive field arg name

### DIFF
--- a/internal/request/graphql/schema/collection.go
+++ b/internal/request/graphql/schema/collection.go
@@ -381,14 +381,14 @@ func indexFieldFromAST(value ast.Value, defaultDirection *ast.EnumValue) (client
 
 	for _, field := range argTypeObject.Fields {
 		switch field.Name.Value {
-		case types.IndexFieldInputName:
+		case types.IncludesPropField:
 			nameVal, ok := field.Value.(*ast.StringValue)
 			if !ok {
 				return client.IndexedFieldDescription{}, ErrIndexWithInvalidArg
 			}
 			name = nameVal.Value
 
-		case types.IndexFieldInputDirection:
+		case types.IncludesPropDirection:
 			directionVal, ok := field.Value.(*ast.EnumValue)
 			if !ok {
 				return client.IndexedFieldDescription{}, ErrIndexWithInvalidArg

--- a/internal/request/graphql/schema/index_parse_test.go
+++ b/internal/request/graphql/schema/index_parse_test.go
@@ -24,7 +24,7 @@ func TestParseIndexOnStruct(t *testing.T) {
 	cases := []indexTestCase{
 		{
 			description: "Index with a single field",
-			sdl:         `type user @index(includes: [{name: "name"}]) {}`,
+			sdl:         `type user @index(includes: [{field: "name"}]) {}`,
 			targetDescriptions: []client.IndexDescription{
 				{
 					Name: "",
@@ -37,7 +37,7 @@ func TestParseIndexOnStruct(t *testing.T) {
 		},
 		{
 			description: "Index with a name",
-			sdl:         `type user @index(name: "userIndex", includes: [{name: "name"}]) {}`,
+			sdl:         `type user @index(name: "userIndex", includes: [{field: "name"}]) {}`,
 			targetDescriptions: []client.IndexDescription{
 				{
 					Name: "userIndex",
@@ -49,7 +49,7 @@ func TestParseIndexOnStruct(t *testing.T) {
 		},
 		{
 			description: "Unique index",
-			sdl:         `type user @index(includes: [{name: "name"}], unique: true) {}`,
+			sdl:         `type user @index(includes: [{field: "name"}], unique: true) {}`,
 			targetDescriptions: []client.IndexDescription{
 				{
 					Fields: []client.IndexedFieldDescription{
@@ -61,7 +61,7 @@ func TestParseIndexOnStruct(t *testing.T) {
 		},
 		{
 			description: "Index explicitly not unique",
-			sdl:         `type user @index(includes: [{name: "name"}], unique: false) {}`,
+			sdl:         `type user @index(includes: [{field: "name"}], unique: false) {}`,
 			targetDescriptions: []client.IndexDescription{
 				{
 					Fields: []client.IndexedFieldDescription{
@@ -73,7 +73,7 @@ func TestParseIndexOnStruct(t *testing.T) {
 		},
 		{
 			description: "Index with explicit ascending field",
-			sdl:         `type user @index(includes: [{name: "name", direction: ASC}]) {}`,
+			sdl:         `type user @index(includes: [{field: "name", direction: ASC}]) {}`,
 			targetDescriptions: []client.IndexDescription{
 				{
 					Fields: []client.IndexedFieldDescription{
@@ -83,7 +83,7 @@ func TestParseIndexOnStruct(t *testing.T) {
 		},
 		{
 			description: "Index with descending field",
-			sdl:         `type user @index(includes: [{name: "name", direction: DESC}]) {}`,
+			sdl:         `type user @index(includes: [{field: "name", direction: DESC}]) {}`,
 			targetDescriptions: []client.IndexDescription{
 				{
 					Fields: []client.IndexedFieldDescription{
@@ -93,7 +93,7 @@ func TestParseIndexOnStruct(t *testing.T) {
 		},
 		{
 			description: "Index with 2 fields",
-			sdl:         `type user @index(includes: [{name: "name"}, {name: "age"}]) {}`,
+			sdl:         `type user @index(includes: [{field: "name"}, {field: "age"}]) {}`,
 			targetDescriptions: []client.IndexDescription{
 				{
 					Fields: []client.IndexedFieldDescription{
@@ -105,7 +105,7 @@ func TestParseIndexOnStruct(t *testing.T) {
 		},
 		{
 			description: "Index with 2 fields and 2 directions",
-			sdl:         `type user @index(includes: [{name: "name", direction: ASC}, {name: "age", direction: DESC}]) {}`,
+			sdl:         `type user @index(includes: [{field: "name", direction: ASC}, {field: "age", direction: DESC}]) {}`,
 			targetDescriptions: []client.IndexDescription{
 				{
 					Fields: []client.IndexedFieldDescription{
@@ -131,37 +131,37 @@ func TestParseInvalidIndexOnStruct(t *testing.T) {
 		},
 		{
 			description: "unknown argument",
-			sdl:         `type user @index(unknown: "something", includes: [{name: "name"}]) {}`,
+			sdl:         `type user @index(unknown: "something", includes: [{field: "name"}]) {}`,
 			expectedErr: errIndexUnknownArgument,
 		},
 		{
 			description: "invalid index name type",
-			sdl:         `type user @index(name: 1, includes: [{name: "name"}]) {}`,
+			sdl:         `type user @index(name: 1, includes: [{field: "name"}]) {}`,
 			expectedErr: errIndexInvalidArgument,
 		},
 		{
 			description: "index name starts with a number",
-			sdl:         `type user @index(name: "1_user_name", includes: [{name: "name"}]) {}`,
+			sdl:         `type user @index(name: "1_user_name", includes: [{field: "name"}]) {}`,
 			expectedErr: errIndexInvalidName,
 		},
 		{
 			description: "index with empty name",
-			sdl:         `type user @index(name: "", includes: [{name: "name"}]) {}`,
+			sdl:         `type user @index(name: "", includes: [{field: "name"}]) {}`,
 			expectedErr: errIndexInvalidName,
 		},
 		{
 			description: "index name with spaces",
-			sdl:         `type user @index(name: "user name", includes: [{name: "name"}]) {}`,
+			sdl:         `type user @index(name: "user name", includes: [{field: "name"}]) {}`,
 			expectedErr: errIndexInvalidName,
 		},
 		{
 			description: "index name with special symbols",
-			sdl:         `type user @index(name: "user!name", includes: [{name: "name"}]) {}`,
+			sdl:         `type user @index(name: "user!name", includes: [{field: "name"}]) {}`,
 			expectedErr: errIndexInvalidName,
 		},
 		{
 			description: "invalid 'unique' value type",
-			sdl:         `type user @index(includes: [{name: "name"}], unique: "true") {}`,
+			sdl:         `type user @index(includes: [{field: "name"}], unique: "true") {}`,
 			expectedErr: errIndexInvalidArgument,
 		},
 		{
@@ -272,7 +272,7 @@ func TestParseIndexOnField(t *testing.T) {
 		{
 			description: "composite field index with implicit include and implicit ordering",
 			sdl: `type user {
-				name: String @index(direction: DESC, includes: [{name: "age"}])
+				name: String @index(direction: DESC, includes: [{field: "age"}])
 				age: Int
 			}`,
 			targetDescriptions: []client.IndexDescription{
@@ -289,7 +289,7 @@ func TestParseIndexOnField(t *testing.T) {
 		{
 			description: "composite field index with implicit include and explicit ordering",
 			sdl: `type user {
-				name: String @index(direction: DESC, includes: [{name: "age", direction: ASC}])
+				name: String @index(direction: DESC, includes: [{field: "age", direction: ASC}])
 				age: Int
 			}`,
 			targetDescriptions: []client.IndexDescription{
@@ -306,7 +306,7 @@ func TestParseIndexOnField(t *testing.T) {
 		{
 			description: "composite field index with explicit includes",
 			sdl: `type user {
-				name: String @index(includes: [{name: "age"}, {name: "name"}])
+				name: String @index(includes: [{field: "age"}, {field: "name"}])
 				age: Int
 			}`,
 			targetDescriptions: []client.IndexDescription{

--- a/internal/request/graphql/schema/types/types.go
+++ b/internal/request/graphql/schema/types/types.go
@@ -39,8 +39,8 @@ const (
 	IndexDirectivePropDirection = "direction"
 	IndexDirectivePropIncludes  = "includes"
 
-	IndexFieldInputName      = "field"
-	IndexFieldInputDirection = "direction"
+	IncludesPropField     = "field"
+	IncludesPropDirection = "direction"
 
 	DefaultDirectiveLabel        = "default"
 	DefaultDirectivePropString   = "string"
@@ -175,10 +175,10 @@ func IndexFieldInputObject(orderingEnum *gql.Enum) *gql.InputObject {
 		Name:        "IndexField",
 		Description: "Used to create an index from a field.",
 		Fields: gql.InputObjectConfigFieldMap{
-			IndexFieldInputName: &gql.InputObjectFieldConfig{
+			IncludesPropField: &gql.InputObjectFieldConfig{
 				Type: gql.String,
 			},
-			IndexFieldInputDirection: &gql.InputObjectFieldConfig{
+			IncludesPropDirection: &gql.InputObjectFieldConfig{
 				Type: orderingEnum,
 			},
 		},

--- a/internal/request/graphql/schema/types/types.go
+++ b/internal/request/graphql/schema/types/types.go
@@ -39,7 +39,7 @@ const (
 	IndexDirectivePropDirection = "direction"
 	IndexDirectivePropIncludes  = "includes"
 
-	IndexFieldInputName      = "name"
+	IndexFieldInputName      = "field"
 	IndexFieldInputDirection = "direction"
 
 	DefaultDirectiveLabel        = "default"

--- a/tests/integration/index/array_composite_test.go
+++ b/tests/integration/index/array_composite_test.go
@@ -27,7 +27,7 @@ func TestArrayCompositeIndex_WithFilterOnIndexedArrayUsingAny_ShouldUseIndex(t *
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
-					type User @index(includes: [{name: "name"}, {name: "numbers"}, {name: "age"}]) {
+					type User @index(includes: [{field: "name"}, {field: "numbers"}, {field: "age"}]) {
 						name: String 
 						numbers: [Int!] 
 						age: Int
@@ -93,7 +93,7 @@ func TestArrayCompositeIndex_WithFilterOnIndexedArrayUsingAll_ShouldUseIndex(t *
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
-					type User @index(includes: [{name: "name"}, {name: "numbers"}, {name: "age"}]) {
+					type User @index(includes: [{field: "name"}, {field: "numbers"}, {field: "age"}]) {
 						name: String 
 						numbers: [Int!] 
 						age: Int
@@ -160,7 +160,7 @@ func TestArrayCompositeIndex_WithFilterOnIndexedArrayUsingNone_ShouldUseIndex(t 
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
-					type User @index(includes: [{name: "name"}, {name: "numbers"}, {name: "age"}]) {
+					type User @index(includes: [{field: "name"}, {field: "numbers"}, {field: "age"}]) {
 						name: String 
 						numbers: [Int!] 
 						age: Int
@@ -228,7 +228,7 @@ func TestArrayCompositeIndex_With2ConsecutiveArrayFields_Succeed(t *testing.T) {
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
-					type User @index(includes: [{name: "name"}, {name: "numbers"}, {name: "hobbies"}, {name: "age"}]) {
+					type User @index(includes: [{field: "name"}, {field: "numbers"}, {field: "hobbies"}, {field: "age"}]) {
 						name: String 
 						numbers: [Int!] 
 						hobbies: [String!] 
@@ -302,7 +302,7 @@ func TestArrayCompositeIndex_With2SeparateArrayFields_Succeed(t *testing.T) {
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
-					type User @index(includes: [{name: "numbers"}, {name: "name"}, {name: "age"}, {name: "hobbies"}]) {
+					type User @index(includes: [{field: "numbers"}, {field: "name"}, {field: "age"}, {field: "hobbies"}]) {
 						name: String 
 						numbers: [Int!] 
 						hobbies: [String!] 
@@ -377,7 +377,7 @@ func TestArrayCompositeIndex_WithAnyNoneAll_Succeed(t *testing.T) {
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
-					type User @index(includes: [{name: "numbers1"}, {name: "numbers2"}, {name: "numbers3"}]) {
+					type User @index(includes: [{field: "numbers1"}, {field: "numbers2"}, {field: "numbers3"}]) {
 						name: String 
 						numbers1: [Int!] 
 						numbers2: [Int!] 
@@ -444,7 +444,7 @@ func TestArrayCompositeIndexUpdate_With2ArrayFields_Succeed(t *testing.T) {
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
-					type User @index(includes: [{name: "name"}, {name: "numbers"}, {name: "hobbies"}]) {
+					type User @index(includes: [{field: "name"}, {field: "numbers"}, {field: "hobbies"}]) {
 						name: String 
 						numbers: [Int!] 
 						hobbies: [String!] 
@@ -549,7 +549,7 @@ func TestArrayCompositeIndexDelete_With2ConsecutiveArrayFields_Succeed(t *testin
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
-					type User @index(includes: [{name: "name"}, {name: "numbers"}, {name: "hobbies"}]) {
+					type User @index(includes: [{field: "name"}, {field: "numbers"}, {field: "hobbies"}]) {
 						name: String 
 						numbers: [Int!] 
 						hobbies: [String!] 

--- a/tests/integration/index/array_unique_composite_test.go
+++ b/tests/integration/index/array_unique_composite_test.go
@@ -28,7 +28,7 @@ func TestArrayUniqueCompositeIndex_WithUniqueCombinations_Succeed(t *testing.T) 
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
-					type User @index(unique: true, includes: [{name: "nfts1"}, {name: "nfts2"}]) {
+					type User @index(unique: true, includes: [{field: "nfts1"}, {field: "nfts2"}]) {
 						name: String 
 						nfts1: [Int!] 
 						nfts2: [Int!] 
@@ -78,7 +78,7 @@ func TestArrayUniqueCompositeIndex_IfDocIsCreatedThatViolatesUniqueness_Error(t 
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
-					type User @index(unique: true, includes: [{name: "nfts1"}, {name: "nfts2"}]) {
+					type User @index(unique: true, includes: [{field: "nfts1"}, {field: "nfts2"}]) {
 						name: String 
 						nfts1: [Int!] 
 						nfts2: [Int!] 
@@ -122,7 +122,7 @@ func TestArrayUniqueCompositeIndex_IfDocIsUpdatedThatViolatesUniqueness_Error(t 
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
-					type User @index(unique: true, includes: [{name: "nfts1"}, {name: "nfts2"}]) {
+					type User @index(unique: true, includes: [{field: "nfts1"}, {field: "nfts2"}]) {
 						name: String 
 						nfts1: [Int!] 
 						nfts2: [Int!] 
@@ -164,7 +164,7 @@ func TestArrayUniqueCompositeIndex_IfDocsHaveNilValues_Succeed(t *testing.T) {
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
-					type User @index(unique: true, includes: [{name: "nfts1"}, {name: "nfts2"}]) {
+					type User @index(unique: true, includes: [{field: "nfts1"}, {field: "nfts2"}]) {
 						name: String 
 						nfts1: [Int] 
 						nfts2: [Int] 

--- a/tests/integration/index/create_composite_test.go
+++ b/tests/integration/index/create_composite_test.go
@@ -79,7 +79,7 @@ func TestCompositeIndexCreate_UsingObjectDirective_SetsDefaultDirection(t *testi
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
-					type User @index(direction: DESC, includes: [{name: "name"}, {name: "age"}]) {
+					type User @index(direction: DESC, includes: [{field: "name"}, {field: "age"}]) {
 						name: String
 						age: Int 
 					}
@@ -117,7 +117,7 @@ func TestCompositeIndexCreate_UsingObjectDirective_OverridesDefaultDirection(t *
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
-					type User @index(direction: DESC, includes: [{name: "name"}, {name: "age", direction: ASC}]) {
+					type User @index(direction: DESC, includes: [{field: "name"}, {field: "age", direction: ASC}]) {
 						name: String
 						age: Int 
 					}
@@ -156,7 +156,7 @@ func TestCompositeIndexCreate_UsingFieldDirective_ImplicitlyAddsField(t *testing
 			testUtils.SchemaUpdate{
 				Schema: `
 					type User {
-						name: String @index(includes: [{name: "age"}])
+						name: String @index(includes: [{field: "age"}])
 						age: Int 
 					}
 				`,
@@ -191,7 +191,7 @@ func TestCompositeIndexCreate_UsingFieldDirective_SetsDefaultDirection(t *testin
 			testUtils.SchemaUpdate{
 				Schema: `
 					type User {
-						name: String @index(direction: DESC, includes: [{name: "age"}])
+						name: String @index(direction: DESC, includes: [{field: "age"}])
 						age: Int 
 					}
 				`,
@@ -229,7 +229,7 @@ func TestCompositeIndexCreate_UsingFieldDirective_OverridesDefaultDirection(t *t
 			testUtils.SchemaUpdate{
 				Schema: `
 					type User {
-						name: String @index(direction: DESC, includes: [{name: "age", direction: ASC}])
+						name: String @index(direction: DESC, includes: [{field: "age", direction: ASC}])
 						age: Int 
 					}
 				`,
@@ -267,7 +267,7 @@ func TestCompositeIndexCreate_UsingFieldDirective_WithExplicitIncludes_RespectsO
 			testUtils.SchemaUpdate{
 				Schema: `
 					type User {
-						name: String @index(includes: [{name: "age"}, {name: "name"}])
+						name: String @index(includes: [{field: "age"}, {field: "name"}])
 						age: Int 
 					}
 				`,

--- a/tests/integration/index/create_get_test.go
+++ b/tests/integration/index/create_get_test.go
@@ -23,7 +23,7 @@ func TestIndexGet_ShouldReturnListOfExistingIndexes(t *testing.T) {
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
-					type User @index(name: "age_index", includes: [{name: "age"}]) {
+					type User @index(name: "age_index", includes: [{field: "age"}]) {
 						name: String @index(name: "name_index")
 						age: Int
 					}

--- a/tests/integration/index/create_unique_composite_test.go
+++ b/tests/integration/index/create_unique_composite_test.go
@@ -75,7 +75,7 @@ func TestUniqueCompositeIndexCreate_UponAddingDocWithExistingFieldValue_ReturnEr
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
-					type User @index(unique: true, includes: [{name: "name"}, {name: "age"}]) {
+					type User @index(unique: true, includes: [{field: "name"}, {field: "age"}]) {
 						name: String 
 						age: Int 
 						email: String

--- a/tests/integration/index/query_with_composite_index_field_order_test.go
+++ b/tests/integration/index/query_with_composite_index_field_order_test.go
@@ -22,7 +22,7 @@ func TestQueryWithCompositeIndex_WithDefaultOrder_ShouldFetchInDefaultOrder(t *t
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
-					type User @index(includes: [{name: "name"},  {name: "age"}]) {
+					type User @index(includes: [{field: "name"},  {field: "age"}]) {
 						name: String
 						age: Int
 					}`,
@@ -100,7 +100,7 @@ func TestQueryWithCompositeIndex_WithDefaultOrderCaseInsensitive_ShouldFetchInDe
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
-					type User @index(includes: [{name: "name"},  {name: "age"}]) {
+					type User @index(includes: [{field: "name"},  {field: "age"}]) {
 						name: String
 						age: Int
 					}`,
@@ -178,7 +178,7 @@ func TestQueryWithCompositeIndex_WithRevertedOrderOnFirstField_ShouldFetchInReve
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
-					type User @index(includes: [{name: "name", direction: DESC}, {name: "age", direction: ASC}]) {
+					type User @index(includes: [{field: "name", direction: DESC}, {field: "age", direction: ASC}]) {
 						name: String
 						age: Int
 					}`,
@@ -268,7 +268,7 @@ func TestQueryWithCompositeIndex_WithRevertedOrderOnFirstFieldCaseInsensitive_Sh
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
-					type User @index(includes: [{name: "name", direction: DESC}, {name: "age", direction: ASC}]) {
+					type User @index(includes: [{field: "name", direction: DESC}, {field: "age", direction: ASC}]) {
 						name: String
 						age: Int
 					}`,
@@ -358,7 +358,7 @@ func TestQueryWithCompositeIndex_WithRevertedOrderOnSecondField_ShouldFetchInRev
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
-					type User @index(includes: [{name: "name", direction: ASC}, {name: "age", direction: DESC}]) {
+					type User @index(includes: [{field: "name", direction: ASC}, {field: "age", direction: DESC}]) {
 						name: String
 						age: Int
 					}`,
@@ -438,7 +438,7 @@ func TestQueryWithCompositeIndex_WithRevertedOrderOnSecondFieldCaseInsensitive_S
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
-					type User @index(includes: [{name: "name", direction: ASC}, {name: "age", direction: DESC}]) {
+					type User @index(includes: [{field: "name", direction: ASC}, {field: "age", direction: DESC}]) {
 						name: String
 						age: Int
 					}`,
@@ -516,7 +516,7 @@ func TestQueryWithCompositeIndex_IfExactMatchWithRevertedOrderOnFirstField_Shoul
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
-					type User @index(includes: [{name: "name", direction: DESC}, {name: "age", direction: ASC}]) {
+					type User @index(includes: [{field: "name", direction: DESC}, {field: "age", direction: ASC}]) {
 						name: String
 						age: Int
 					}`,
@@ -574,7 +574,7 @@ func TestQueryWithCompositeIndex_IfExactMatchWithRevertedOrderOnSecondField_Shou
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
-					type User @index(includes: [{name: "name", direction: ASC}, {name: "age", direction: DESC}]) {
+					type User @index(includes: [{field: "name", direction: ASC}, {field: "age", direction: DESC}]) {
 						name: String
 						age: Int
 					}`,
@@ -632,7 +632,7 @@ func TestQueryWithCompositeIndex_WithInFilterOnFirstFieldWithRevertedOrder_Shoul
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
-					type User @index(includes: [{name: "name", direction: DESC}, {name: "age", direction: ASC}]) {
+					type User @index(includes: [{field: "name", direction: DESC}, {field: "age", direction: ASC}]) {
 						name: String
 						age: Int
 						email: String
@@ -667,7 +667,7 @@ func TestQueryWithCompositeIndex_WithInFilterOnSecondFieldWithRevertedOrder_Shou
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
-					type User @index(includes: [{name: "name", direction: ASC}, {name: "age", direction: DESC}]) {
+					type User @index(includes: [{field: "name", direction: ASC}, {field: "age", direction: DESC}]) {
 						name: String
 						age: Int
 						email: String

--- a/tests/integration/index/query_with_composite_index_only_filter_test.go
+++ b/tests/integration/index/query_with_composite_index_only_filter_test.go
@@ -40,7 +40,7 @@ func TestQueryWithCompositeIndex_WithEqualFilter_ShouldFetch(t *testing.T) {
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
-					type User @index(includes: [{name: "name"}, {name: "age"}]) {
+					type User @index(includes: [{field: "name"}, {field: "age"}]) {
 						name: String
 						age: Int
 						email: String
@@ -96,7 +96,7 @@ func TestQueryWithCompositeIndex_WithGreaterThanFilterOnFirstField_ShouldFetch(t
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
-					type User @index(includes: [{name: "age"}, {name: "name"}]) {
+					type User @index(includes: [{field: "age"}, {field: "name"}]) {
 						name: String
 						age: Int
 						email: String
@@ -134,7 +134,7 @@ func TestQueryWithCompositeIndex_WithGreaterThanFilterOnSecondField_ShouldFetch(
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
-					type User @index(includes: [{name: "name"}, {name: "age"}]) {
+					type User @index(includes: [{field: "name"}, {field: "age"}]) {
 						name: String
 						age: Int
 						email: String
@@ -172,7 +172,7 @@ func TestQueryWithCompositeIndex_WithGreaterOrEqualFilterOnFirstField_ShouldFetc
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
-					type User @index(includes: [{name: "age"}, {name: "name"}]) {
+					type User @index(includes: [{field: "age"}, {field: "name"}]) {
 						name: String
 						age: Int
 						email: String
@@ -211,7 +211,7 @@ func TestQueryWithCompositeIndex_WithGreaterOrEqualFilterOnSecondField_ShouldFet
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
-					type User @index(includes: [{name: "name"}, {name: "age"}]) {
+					type User @index(includes: [{field: "name"}, {field: "age"}]) {
 						name: String
 						age: Int
 						email: String
@@ -250,7 +250,7 @@ func TestQueryWithCompositeIndex_WithLessThanFilterOnFirstField_ShouldFetch(t *t
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
-					type User @index(includes: [{name: "age"}, {name: "name"}]) {
+					type User @index(includes: [{field: "age"}, {field: "name"}]) {
 						name: String
 						age: Int
 						email: String
@@ -288,7 +288,7 @@ func TestQueryWithCompositeIndex_WithLessThanFilterOnSecondField_ShouldFetch(t *
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
-					type User @index(includes: [{name: "name"}, {name: "age"}]) {
+					type User @index(includes: [{field: "name"}, {field: "age"}]) {
 						name: String
 						age: Int
 						email: String
@@ -326,7 +326,7 @@ func TestQueryWithCompositeIndex_WithLessOrEqualFilterOnFirstField_ShouldFetch(t
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
-					type User @index(includes: [{name: "age"}, {name: "name"}]) {
+					type User @index(includes: [{field: "age"}, {field: "name"}]) {
 						name: String
 						age: Int
 						email: String
@@ -365,7 +365,7 @@ func TestQueryWithCompositeIndex_WithLessOrEqualFilterOnSecondField_ShouldFetch(
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
-					type User @index(includes: [{name: "name"}, {name: "age"}]) {
+					type User @index(includes: [{field: "name"}, {field: "age"}]) {
 						name: String
 						age: Int
 						email: String
@@ -404,7 +404,7 @@ func TestQueryWithCompositeIndex_WithNotEqualFilter_ShouldFetch(t *testing.T) {
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
-					type User @index(includes: [{name: "name"}, {name: "age"}]) {
+					type User @index(includes: [{field: "name"}, {field: "age"}]) {
 						name: String
 						age: Int
 						email: String
@@ -449,7 +449,7 @@ func TestQueryWithCompositeIndex_WithInFilter_ShouldFetch(t *testing.T) {
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
-					type User @index(includes: [{name: "name"}, {name: "age"}]) {
+					type User @index(includes: [{field: "name"}, {field: "age"}]) {
 						name: String
 						age: Int
 						email: String
@@ -488,7 +488,7 @@ func TestQueryWithCompositeIndex_WithNotInFilter_ShouldFetch(t *testing.T) {
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
-					type User @index(includes: [{name: "name"}, {name: "age"}]) {
+					type User @index(includes: [{field: "name"}, {field: "age"}]) {
 						name: String
 						age: Int
 						email: String
@@ -558,7 +558,7 @@ func TestQueryWithCompositeIndex_WithLikeFilter_ShouldFetch(t *testing.T) {
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
-					type User @index(includes: [{name: "name"}, {name: "email"}]) {
+					type User @index(includes: [{field: "name"}, {field: "email"}]) {
 						name: String 
 						email: String 
 					}`,
@@ -655,7 +655,7 @@ func TestQueryWithCompositeIndex_WithNotLikeFilter_ShouldFetch(t *testing.T) {
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
-					type User @index(includes: [{name: "name"}, {name: "email"}]) {
+					type User @index(includes: [{field: "name"}, {field: "email"}]) {
 						name: String 
 						email: String 
 					}`,
@@ -690,7 +690,7 @@ func TestQueryWithCompositeIndex_IfFirstFieldIsNotInFilter_ShouldNotUseIndex(t *
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
-					type User @index(includes: [{name: "name"}, {name: "age"}]) {
+					type User @index(includes: [{field: "name"}, {field: "age"}]) {
 						name: String
 						age: Int
 						email: String
@@ -719,7 +719,7 @@ func TestQueryWithCompositeIndex_WithEqualFilterOnNilValueOnFirst_ShouldFetch(t 
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
-					type User @index(includes: [{name: "name"}, {name: "age"}]) {
+					type User @index(includes: [{field: "name"}, {field: "age"}]) {
 						name: String
 						age: Int
 						email: String
@@ -766,7 +766,7 @@ func TestQueryWithCompositeIndex_WithEqualFilterOnNilValueOnSecond_ShouldFetch(t
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
-					type User @index(includes: [{name: "name"}, {name: "age"}]) {
+					type User @index(includes: [{field: "name"}, {field: "age"}]) {
 						name: String
 						age: Int
 						email: String
@@ -823,7 +823,7 @@ func TestQueryWithCompositeIndex_IfMiddleFieldIsNotInFilter_ShouldIgnoreValue(t 
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
-					type User @index(includes: [{name: "name"}, {name: "email"}, {name: "age"}]) {
+					type User @index(includes: [{field: "name"}, {field: "email"}, {field: "age"}]) {
 						name: String
 						email: String
 						age: Int
@@ -898,7 +898,7 @@ func TestQueryWithCompositeIndex_IfConsecutiveEqOps_ShouldUseAllToOptimizeQuery(
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
-					type User @index(includes: [{name: "name"}, {name: "age"}, {name: "numChildren"}]) {
+					type User @index(includes: [{field: "name"}, {field: "age"}, {field: "numChildren"}]) {
 						name: String
 						age: Int
 						numChildren: Int

--- a/tests/integration/index/query_with_composite_inxed_on_relation_test.go
+++ b/tests/integration/index/query_with_composite_inxed_on_relation_test.go
@@ -31,7 +31,7 @@ func TestQueryWithCompositeIndexOnManyToOne_WithMultipleIndexedChildNodes_Should
 						devices: [Device]
 					}
 
-					type Device @index(includes: [{name: "owner_id"}, {name: "manufacturer_id"}]) {
+					type Device @index(includes: [{field: "owner_id"}, {field: "manufacturer_id"}]) {
 						model: String
 						owner: User 
 						manufacturer: Manufacturer 

--- a/tests/integration/index/query_with_unique_composite_index_filter_test.go
+++ b/tests/integration/index/query_with_unique_composite_index_filter_test.go
@@ -40,7 +40,7 @@ func TestQueryWithUniqueCompositeIndex_WithEqualFilter_ShouldFetch(t *testing.T)
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
-					type User @index(unique: true, includes: [{name: "name"}, {name: "age"}]) {
+					type User @index(unique: true, includes: [{field: "name"}, {field: "age"}]) {
 						name: String
 						age: Int
 						email: String
@@ -114,7 +114,7 @@ func TestQueryWithUniqueCompositeIndex_WithGreaterThanFilterOnFirstField_ShouldF
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
-					type User @index(unique: true, includes: [{name: "age"}, {name: "name"}]) {
+					type User @index(unique: true, includes: [{field: "age"}, {field: "name"}]) {
 						name: String
 						age: Int
 						email: String
@@ -152,7 +152,7 @@ func TestQueryWithUniqueCompositeIndex_WithGreaterThanFilterOnSecondField_Should
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
-					type User @index(unique: true, includes: [{name: "name"}, {name: "age"}]) {
+					type User @index(unique: true, includes: [{field: "name"}, {field: "age"}]) {
 						name: String
 						age: Int
 						email: String
@@ -190,7 +190,7 @@ func TestQueryWithUniqueCompositeIndex_WithGreaterOrEqualFilterOnFirstField_Shou
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
-					type User @index(unique: true, includes: [{name: "age"}, {name: "name"}]) {
+					type User @index(unique: true, includes: [{field: "age"}, {field: "name"}]) {
 						name: String
 						age: Int
 						email: String
@@ -229,7 +229,7 @@ func TestQueryWithUniqueCompositeIndex_WithGreaterOrEqualFilterOnSecondField_Sho
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
-					type User @index(unique: true, includes: [{name: "name"}, {name: "age"}]) {
+					type User @index(unique: true, includes: [{field: "name"}, {field: "age"}]) {
 						name: String
 						age: Int
 						email: String
@@ -268,7 +268,7 @@ func TestQueryWithUniqueCompositeIndex_WithLessThanFilterOnFirstField_ShouldFetc
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
-					type User @index(unique: true, includes: [{name: "age"}, {name: "name"}]) {
+					type User @index(unique: true, includes: [{field: "age"}, {field: "name"}]) {
 						name: String
 						age: Int
 						email: String
@@ -306,7 +306,7 @@ func TestQueryWithUniqueCompositeIndex_WithLessThanFilterOnSecondField_ShouldFet
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
-					type User @index(unique: true, includes: [{name: "name"}, {name: "age"}]) {
+					type User @index(unique: true, includes: [{field: "name"}, {field: "age"}]) {
 						name: String
 						age: Int
 						email: String
@@ -344,7 +344,7 @@ func TestQueryWithUniqueCompositeIndex_WithLessOrEqualFilterOnFirstField_ShouldF
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
-					type User @index(unique: true, includes: [{name: "age"}, {name: "name"}]) {
+					type User @index(unique: true, includes: [{field: "age"}, {field: "name"}]) {
 						name: String
 						age: Int
 						email: String
@@ -383,7 +383,7 @@ func TestQueryWithUniqueCompositeIndex_WithLessOrEqualFilterOnSecondField_Should
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
-					type User @index(unique: true, includes: [{name: "name"}, {name: "age"}]) {
+					type User @index(unique: true, includes: [{field: "name"}, {field: "age"}]) {
 						name: String
 						age: Int
 						email: String
@@ -422,7 +422,7 @@ func TestQueryWithUniqueCompositeIndex_WithNotEqualFilter_ShouldFetch(t *testing
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
-					type User @index(unique: true, includes: [{name: "name"}, {name: "age"}]) {
+					type User @index(unique: true, includes: [{field: "name"}, {field: "age"}]) {
 						name: String
 						age: Int
 						email: String
@@ -468,7 +468,7 @@ func TestQueryWithUniqueCompositeIndex_WithInForFirstAndEqForRest_ShouldFetchEff
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
-					type User @index(unique: true, includes: [{name: "name"}, {name: "age"}]) {
+					type User @index(unique: true, includes: [{field: "name"}, {field: "age"}]) {
 						name: String
 						age: Int
 						email: String
@@ -544,7 +544,7 @@ func TestQueryWithUniqueCompositeIndex_WithInFilter_ShouldFetch(t *testing.T) {
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
-					type User @index(unique: true, includes: [{name: "name"}, {name: "age"}]) {
+					type User @index(unique: true, includes: [{field: "name"}, {field: "age"}]) {
 						name: String
 						age: Int
 						email: String
@@ -599,7 +599,7 @@ func TestQueryWithUniqueCompositeIndex_WithNotInFilter_ShouldFetch(t *testing.T)
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
-					type User @index(unique: true, includes: [{name: "name"}, {name: "age"}]) {
+					type User @index(unique: true, includes: [{field: "name"}, {field: "age"}]) {
 						name: String
 						age: Int
 						email: String
@@ -669,7 +669,7 @@ func TestQueryWithUniqueCompositeIndex_WithLikeFilter_ShouldFetch(t *testing.T) 
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
-					type User @index(unique: true, includes: [{name: "name"}, {name: "email"}]) {
+					type User @index(unique: true, includes: [{field: "name"}, {field: "email"}]) {
 						name: String 
 						email: String 
 					}`,
@@ -766,7 +766,7 @@ func TestQueryWithUniqueCompositeIndex_WithNotLikeFilter_ShouldFetch(t *testing.
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
-					type User @index(unique: true, includes: [{name: "name"}, {name: "email"}]) {
+					type User @index(unique: true, includes: [{field: "name"}, {field: "email"}]) {
 						name: String 
 						email: String 
 					}`,
@@ -806,7 +806,7 @@ func TestQueryWithUniqueCompositeIndex_WithNotCaseInsensitiveLikeFilter_ShouldFe
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
-					type User @index(unique: true, includes: [{name: "name"}, {name: "email"}]) {
+					type User @index(unique: true, includes: [{field: "name"}, {field: "email"}]) {
 						name: String 
 						email: String 
 					}`,
@@ -842,7 +842,7 @@ func TestQueryWithUniqueCompositeIndex_IfFirstFieldIsNotInFilter_ShouldNotUseInd
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
-					type User @index(unique: true, includes: [{name: "name"}, {name: "age"}]) {
+					type User @index(unique: true, includes: [{field: "name"}, {field: "age"}]) {
 						name: String
 						age: Int
 						email: String
@@ -871,7 +871,7 @@ func TestQueryWithUniqueCompositeIndex_WithEqualFilterOnNilValueOnFirst_ShouldFe
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
-					type User @index(unique: true, includes: [{name: "name"}, {name: "age"}]) {
+					type User @index(unique: true, includes: [{field: "name"}, {field: "age"}]) {
 						name: String
 						age: Int
 						email: String
@@ -925,7 +925,7 @@ func TestQueryWithUniqueCompositeIndex_WithMultipleNilOnFirstFieldAndNilFilter_S
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
-					type User @index(unique: true, includes: [{name: "name"}, {name: "age"}]) {
+					type User @index(unique: true, includes: [{field: "name"}, {field: "age"}]) {
 						name: String
 						age: Int
 						email: String
@@ -981,7 +981,7 @@ func TestQueryWithUniqueCompositeIndex_WithEqualFilterOnNilValueOnSecond_ShouldF
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
-					type User @index(unique: true, includes: [{name: "name"}, {name: "age"}]) {
+					type User @index(unique: true, includes: [{field: "name"}, {field: "age"}]) {
 						name: String
 						age: Int
 						about: String
@@ -1048,7 +1048,7 @@ func TestQueryWithUniqueCompositeIndex_WithMultipleNilOnSecondFieldsAndNilFilter
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
-					type User @index(unique: true, includes: [{name: "name"}, {name: "age"}]) {
+					type User @index(unique: true, includes: [{field: "name"}, {field: "age"}]) {
 						name: String
 						age: Int
 						email: String
@@ -1113,7 +1113,7 @@ func TestQueryWithUniqueCompositeIndex_WithMultipleNilOnBothFieldsAndNilFilter_S
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
-					type User @index(unique: true, includes: [{name: "name"}, {name: "age"}]) {
+					type User @index(unique: true, includes: [{field: "name"}, {field: "age"}]) {
 						name: String
 						age: Int
 						about: String
@@ -1214,7 +1214,7 @@ func TestQueryWithUniqueCompositeIndex_AfterUpdateOnNilFields_ShouldFetch(t *tes
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
-					type User @index(unique: true, includes: [{name: "name"}, {name: "age"}]) {
+					type User @index(unique: true, includes: [{field: "name"}, {field: "age"}]) {
 						name: String
 						age: Int
 						about: String
@@ -1355,7 +1355,7 @@ func TestQueryWithUniqueCompositeIndex_IfMiddleFieldIsNotInFilter_ShouldIgnoreVa
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
-					type User @index(unique: true, includes: [{name: "name"}, {name: "email"}, {name: "age"}]) {
+					type User @index(unique: true, includes: [{field: "name"}, {field: "email"}, {field: "age"}]) {
 						name: String
 						email: String
 						age: Int

--- a/tests/integration/index/query_with_unique_index_on_relation_filter_test.go
+++ b/tests/integration/index/query_with_unique_index_on_relation_filter_test.go
@@ -28,7 +28,7 @@ func TestQueryWithUniqueCompositeIndex_WithFilterOnIndexedRelation_ShouldFilter(
 
 					type Device  {
 						manufacturer: String 
-						owner: User @index(unique: true, includes: [{name: "manufacturer"}])
+						owner: User @index(unique: true, includes: [{field: "manufacturer"}])
 					}
 				`,
 			},

--- a/tests/integration/index/update_unique_composite_test.go
+++ b/tests/integration/index/update_unique_composite_test.go
@@ -22,7 +22,7 @@ func TestUniqueCompositeIndexUpdate_UponUpdatingDocWithExistingFieldValue_Should
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
-					type User @index(unique: true, includes: [{name: "name"}, {name: "age"}]) {
+					type User @index(unique: true, includes: [{field: "name"}, {field: "age"}]) {
 						name: String 
 						age: Int 
 						email: String

--- a/tests/integration/mutation/upsert/simple_test.go
+++ b/tests/integration/mutation/upsert/simple_test.go
@@ -292,7 +292,7 @@ func TestMutationUpsertSimple_WithUniqueCompositeIndexAndDuplicateUpdate_Returns
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
-					type Users @index(includes: [{name: "name"}, {name: "age"}], unique: true) {
+					type Users @index(includes: [{field: "name"}, {field: "age"}], unique: true) {
 						name: String 
 						age: Int
 					}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #3132

## Description

This PR fixes a mistake I made when refactoring the index directive. The `name` argument of the `includes` fields has been changed to `field`.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Updated unit and integration tests.

Specify the platform(s) on which this was tested:
- MacOS

