### PR TITLE
test: Allow referencing of Cids by index in test framework

### DIFF
--- a/tests/integration/query/commits/simple_test.go
+++ b/tests/integration/query/commits/simple_test.go
@@ -37,13 +37,13 @@ func TestQueryCommits(t *testing.T) {
 				Results: map[string]any{
 					"commits": []map[string]any{
 						{
-							"cid": "bafyreif6dqbkr7t37jcjfxxrjnxt7cspxzvs7qwlbtjca57cc663he4s7e",
+							"cid": testUtils.NewCidIndex(0, 0, "1", 0),
 						},
 						{
-							"cid": "bafyreigtnj6ntulcilkmin4pgukjwv3nwglqpiiyddz3dyfexdbltze7sy",
+							"cid": testUtils.NewCidIndex(0, 0, "2", 0),
 						},
 						{
-							"cid": "bafyreia2vlbfkcbyogdjzmbqcjneabwwwtw7ti2xbd7yor5mbu2sk4pcoy",
+							"cid": testUtils.NewCompCidIndex(0, 0, 0),
 						},
 					},
 				},
@@ -364,7 +364,7 @@ func TestQuery_CommitsWithAllFieldsWithUpdate_NoError(t *testing.T) {
 				Results: map[string]any{
 					"commits": []map[string]any{
 						{
-							"cid":          "bafyreih5h6i6ohfsgrcjtg76iarebqcurpaft73gpobl2z2cfsvihsgdqu",
+							"cid":          testUtils.NewCidIndex(0, 0, "1", 1),
 							"collectionID": int64(1),
 							"delta":        testUtils.CBORValue(22),
 							"docID":        "bae-c9fb0fa4-1195-589c-aa54-e68333fb90b3",
@@ -373,13 +373,13 @@ func TestQuery_CommitsWithAllFieldsWithUpdate_NoError(t *testing.T) {
 							"height":       int64(2),
 							"links": []map[string]any{
 								{
-									"cid":  "bafyreif6dqbkr7t37jcjfxxrjnxt7cspxzvs7qwlbtjca57cc663he4s7e",
+									"cid":  testUtils.NewCidIndex(0, 0, "1", 0),
 									"name": "_head",
 								},
 							},
 						},
 						{
-							"cid":          "bafyreif6dqbkr7t37jcjfxxrjnxt7cspxzvs7qwlbtjca57cc663he4s7e",
+							"cid":          testUtils.NewCidIndex(0, 0, "1", 0),
 							"collectionID": int64(1),
 							"delta":        testUtils.CBORValue(21),
 							"docID":        "bae-c9fb0fa4-1195-589c-aa54-e68333fb90b3",
@@ -389,7 +389,7 @@ func TestQuery_CommitsWithAllFieldsWithUpdate_NoError(t *testing.T) {
 							"links":        []map[string]any{},
 						},
 						{
-							"cid":          "bafyreigtnj6ntulcilkmin4pgukjwv3nwglqpiiyddz3dyfexdbltze7sy",
+							"cid":          testUtils.NewCidIndex(0, 0, "2", 0),
 							"collectionID": int64(1),
 							"delta":        testUtils.CBORValue("John"),
 							"docID":        "bae-c9fb0fa4-1195-589c-aa54-e68333fb90b3",
@@ -399,7 +399,7 @@ func TestQuery_CommitsWithAllFieldsWithUpdate_NoError(t *testing.T) {
 							"links":        []map[string]any{},
 						},
 						{
-							"cid":          "bafyreiale6qsjc7qewod3c6h2odwamfwcf7vt4zlqtw7ldcm57xdkgxja4",
+							"cid":          testUtils.NewCompCidIndex(0, 0, 1),
 							"collectionID": int64(1),
 							"delta":        nil,
 							"docID":        "bae-c9fb0fa4-1195-589c-aa54-e68333fb90b3",
@@ -408,17 +408,17 @@ func TestQuery_CommitsWithAllFieldsWithUpdate_NoError(t *testing.T) {
 							"height":       int64(2),
 							"links": []map[string]any{
 								{
-									"cid":  "bafyreia2vlbfkcbyogdjzmbqcjneabwwwtw7ti2xbd7yor5mbu2sk4pcoy",
+									"cid":  testUtils.NewCompCidIndex(0, 0, 0),
 									"name": "_head",
 								},
 								{
-									"cid":  "bafyreih5h6i6ohfsgrcjtg76iarebqcurpaft73gpobl2z2cfsvihsgdqu",
+									"cid":  testUtils.NewCidIndex(0, 0, "1", 1),
 									"name": "age",
 								},
 							},
 						},
 						{
-							"cid":          "bafyreia2vlbfkcbyogdjzmbqcjneabwwwtw7ti2xbd7yor5mbu2sk4pcoy",
+							"cid":          testUtils.NewCompCidIndex(0, 0, 0),
 							"collectionID": int64(1),
 							"delta":        nil,
 							"docID":        "bae-c9fb0fa4-1195-589c-aa54-e68333fb90b3",
@@ -427,11 +427,11 @@ func TestQuery_CommitsWithAllFieldsWithUpdate_NoError(t *testing.T) {
 							"height":       int64(1),
 							"links": []map[string]any{
 								{
-									"cid":  "bafyreif6dqbkr7t37jcjfxxrjnxt7cspxzvs7qwlbtjca57cc663he4s7e",
+									"cid":  testUtils.NewCidIndex(0, 0, "1", 0),
 									"name": "age",
 								},
 								{
-									"cid":  "bafyreigtnj6ntulcilkmin4pgukjwv3nwglqpiiyddz3dyfexdbltze7sy",
+									"cid":  testUtils.NewCidIndex(0, 0, "2", 0),
 									"name": "name",
 								},
 							},

--- a/tests/integration/query/commits/with_delete_test.go
+++ b/tests/integration/query/commits/with_delete_test.go
@@ -40,8 +40,10 @@ func TestQueryCommits_AfterDocDeletion_ShouldStillFetch(t *testing.T) {
 				Request: `
 					query {
 						commits(fieldId: "C") {
+							cid
 							fieldName
 							links {
+								cid
 								name
 							}
 						}
@@ -50,20 +52,25 @@ func TestQueryCommits_AfterDocDeletion_ShouldStillFetch(t *testing.T) {
 				Results: map[string]any{
 					"commits": []map[string]any{
 						{
+							"cid":       testUtils.NewCompCidIndex(0, 0, 1),
 							"fieldName": nil,
 							"links": []map[string]any{
 								{
+									"cid":  testUtils.NewCompCidIndex(0, 0, 0),
 									"name": "_head",
 								},
 							},
 						},
 						{
+							"cid":       testUtils.NewCompCidIndex(0, 0, 0),
 							"fieldName": nil,
 							"links": []map[string]any{
 								{
+									"cid":  testUtils.NewCidIndex(0, 0, "1", 0),
 									"name": "age",
 								},
 								{
+									"cid":  testUtils.NewCidIndex(0, 0, "2", 0),
 									"name": "name",
 								},
 							},

--- a/tests/integration/state.go
+++ b/tests/integration/state.go
@@ -175,6 +175,9 @@ type state struct {
 	// nodes.
 	docIDs [][]client.DocID
 
+	// CIDs by index, by field name, by doc index, by collection index.
+	cids [][]map[string][]cid.Cid
+
 	// Indexes, by index, by collection index, by node index.
 	indexes [][][]client.IndexDescription
 

--- a/tests/integration/test_case.go
+++ b/tests/integration/test_case.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sourcenetwork/immutable"
 
 	"github.com/sourcenetwork/defradb/client"
+	"github.com/sourcenetwork/defradb/internal/core"
 	"github.com/sourcenetwork/defradb/net"
 	"github.com/sourcenetwork/defradb/tests/gen"
 	"github.com/sourcenetwork/defradb/tests/predefined"
@@ -344,6 +345,50 @@ type DocIndex struct {
 func NewDocIndex(collectionIndex int, index int) DocIndex {
 	return DocIndex{
 		CollectionIndex: collectionIndex,
+		Index:           index,
+	}
+}
+
+// CidIndex represents a Cid previously stored in the node, it allows Cids to be referenced without worrying
+// about the specific bytes.
+type CidIndex struct {
+	// CollectionIndex is the index of the collection used to create the document that the Cid belongs to.
+	CollectionIndex int
+
+	// DocIndex is the index of the document that the Cid belongs to.
+	DocIndex int
+
+	// FieldName is the name of the field that this cid is for.
+	//
+	// Composite commits can be targetted with "C".
+	FieldName string
+
+	// The index of the Cid given the other parameters.
+	//
+	// This is typically equal to commit height - 1.
+	Index int
+}
+
+// NewCompCidIndex creates a new [CidIndex] instance targetting the cid of a composite commit.
+//
+// It allows cids to be referenced without worrying about the specific bytes that form it.
+func NewCompCidIndex(collectionIndex int, docIndex int, index int) CidIndex {
+	return CidIndex{
+		CollectionIndex: collectionIndex,
+		DocIndex:        docIndex,
+		FieldName:       core.COMPOSITE_NAMESPACE,
+		Index:           index,
+	}
+}
+
+// NewCidIndex creates a new [CidIndex] instance targetting a cid of a commit.
+//
+// It allows cids to be referenced without worrying about the specific bytes that form it.
+func NewCidIndex(collectionIndex int, docIndex int, fieldName string, index int) CidIndex {
+	return CidIndex{
+		CollectionIndex: collectionIndex,
+		DocIndex:        docIndex,
+		FieldName:       fieldName,
 		Index:           index,
 	}
 }


### PR DESCRIPTION
## Relevant issue(s)

Resolves #3172

## Description

Allows referencing of Cids by index in test framework and migrates a handful of tests to the new system.

Migrating all the tests to this system is out of scope.  New tests can now be written using this system where appropriate.

Does not appear to have a significant effect on test execution time, there are a few things we can do to reduce this if we want to in the future.

## How has this been tested?

I verified that specifying the incorrect index(es) results in test failure.
