### PR TITLE
fix(i): SetReplicator and DeleteReplicator params

### DIFF
--- a/cli/p2p_replicator_delete.go
+++ b/cli/p2p_replicator_delete.go
@@ -38,9 +38,9 @@ Example:
 			if err := json.Unmarshal([]byte(args[0]), &info); err != nil {
 				return err
 			}
-			rep := client.Replicator{
-				Info:    info,
-				Schemas: collections,
+			rep := client.ReplicatorParams{
+				Info:        info,
+				Collections: collections,
 			}
 			return p2p.DeleteReplicator(cmd.Context(), rep)
 		},

--- a/cli/p2p_replicator_set.go
+++ b/cli/p2p_replicator_set.go
@@ -38,9 +38,9 @@ Example:
 			if err := json.Unmarshal([]byte(args[0]), &info); err != nil {
 				return err
 			}
-			rep := client.Replicator{
-				Info:    info,
-				Schemas: collections,
+			rep := client.ReplicatorParams{
+				Info:        info,
+				Collections: collections,
 			}
 			return p2p.SetReplicator(cmd.Context(), rep)
 		},

--- a/client/mocks/db.go
+++ b/client/mocks/db.go
@@ -553,7 +553,7 @@ func (_c *DB_DeleteDocActorRelationship_Call) RunAndReturn(run func(context.Cont
 }
 
 // DeleteReplicator provides a mock function with given fields: ctx, rep
-func (_m *DB) DeleteReplicator(ctx context.Context, rep client.Replicator) error {
+func (_m *DB) DeleteReplicator(ctx context.Context, rep client.ReplicatorParams) error {
 	ret := _m.Called(ctx, rep)
 
 	if len(ret) == 0 {
@@ -561,7 +561,7 @@ func (_m *DB) DeleteReplicator(ctx context.Context, rep client.Replicator) error
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, client.Replicator) error); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, client.ReplicatorParams) error); ok {
 		r0 = rf(ctx, rep)
 	} else {
 		r0 = ret.Error(0)
@@ -577,14 +577,14 @@ type DB_DeleteReplicator_Call struct {
 
 // DeleteReplicator is a helper method to define mock.On call
 //   - ctx context.Context
-//   - rep client.Replicator
+//   - rep client.ReplicatorParams
 func (_e *DB_Expecter) DeleteReplicator(ctx interface{}, rep interface{}) *DB_DeleteReplicator_Call {
 	return &DB_DeleteReplicator_Call{Call: _e.mock.On("DeleteReplicator", ctx, rep)}
 }
 
-func (_c *DB_DeleteReplicator_Call) Run(run func(ctx context.Context, rep client.Replicator)) *DB_DeleteReplicator_Call {
+func (_c *DB_DeleteReplicator_Call) Run(run func(ctx context.Context, rep client.ReplicatorParams)) *DB_DeleteReplicator_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(client.Replicator))
+		run(args[0].(context.Context), args[1].(client.ReplicatorParams))
 	})
 	return _c
 }
@@ -594,7 +594,7 @@ func (_c *DB_DeleteReplicator_Call) Return(_a0 error) *DB_DeleteReplicator_Call 
 	return _c
 }
 
-func (_c *DB_DeleteReplicator_Call) RunAndReturn(run func(context.Context, client.Replicator) error) *DB_DeleteReplicator_Call {
+func (_c *DB_DeleteReplicator_Call) RunAndReturn(run func(context.Context, client.ReplicatorParams) error) *DB_DeleteReplicator_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -1892,7 +1892,7 @@ func (_c *DB_SetMigration_Call) RunAndReturn(run func(context.Context, client.Le
 }
 
 // SetReplicator provides a mock function with given fields: ctx, rep
-func (_m *DB) SetReplicator(ctx context.Context, rep client.Replicator) error {
+func (_m *DB) SetReplicator(ctx context.Context, rep client.ReplicatorParams) error {
 	ret := _m.Called(ctx, rep)
 
 	if len(ret) == 0 {
@@ -1900,7 +1900,7 @@ func (_m *DB) SetReplicator(ctx context.Context, rep client.Replicator) error {
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, client.Replicator) error); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, client.ReplicatorParams) error); ok {
 		r0 = rf(ctx, rep)
 	} else {
 		r0 = ret.Error(0)
@@ -1916,14 +1916,14 @@ type DB_SetReplicator_Call struct {
 
 // SetReplicator is a helper method to define mock.On call
 //   - ctx context.Context
-//   - rep client.Replicator
+//   - rep client.ReplicatorParams
 func (_e *DB_Expecter) SetReplicator(ctx interface{}, rep interface{}) *DB_SetReplicator_Call {
 	return &DB_SetReplicator_Call{Call: _e.mock.On("SetReplicator", ctx, rep)}
 }
 
-func (_c *DB_SetReplicator_Call) Run(run func(ctx context.Context, rep client.Replicator)) *DB_SetReplicator_Call {
+func (_c *DB_SetReplicator_Call) Run(run func(ctx context.Context, rep client.ReplicatorParams)) *DB_SetReplicator_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(client.Replicator))
+		run(args[0].(context.Context), args[1].(client.ReplicatorParams))
 	})
 	return _c
 }
@@ -1933,7 +1933,7 @@ func (_c *DB_SetReplicator_Call) Return(_a0 error) *DB_SetReplicator_Call {
 	return _c
 }
 
-func (_c *DB_SetReplicator_Call) RunAndReturn(run func(context.Context, client.Replicator) error) *DB_SetReplicator_Call {
+func (_c *DB_SetReplicator_Call) RunAndReturn(run func(context.Context, client.ReplicatorParams) error) *DB_SetReplicator_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/client/p2p.go
+++ b/client/p2p.go
@@ -23,10 +23,10 @@ type P2P interface {
 
 	// SetReplicator adds a replicator to the persisted list or adds
 	// schemas if the replicator already exists.
-	SetReplicator(ctx context.Context, rep Replicator) error
+	SetReplicator(ctx context.Context, rep ReplicatorParams) error
 	// DeleteReplicator deletes a replicator from the persisted list
 	// or specific schemas if they are specified.
-	DeleteReplicator(ctx context.Context, rep Replicator) error
+	DeleteReplicator(ctx context.Context, rep ReplicatorParams) error
 	// GetAllReplicators returns the full list of replicators with their
 	// subscribed schemas.
 	GetAllReplicators(ctx context.Context) ([]Replicator, error)

--- a/client/replicator.go
+++ b/client/replicator.go
@@ -16,6 +16,14 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 )
 
+// ReplicatorParams contains the replicator fields that can be modified by the user.
+type ReplicatorParams struct {
+	// Info is the address of the peer to replicate to.
+	Info peer.AddrInfo
+	// Collections is the list of collection names to replicate.
+	Collections []string
+}
+
 // Replicator is a peer that a set of local collections are replicated to.
 type Replicator struct {
 	Info             peer.AddrInfo

--- a/docs/website/references/http/openapi.json
+++ b/docs/website/references/http/openapi.json
@@ -527,6 +527,29 @@
                 },
                 "type": "object"
             },
+            "replicator_params": {
+                "properties": {
+                    "Collections": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "Info": {
+                        "properties": {
+                            "Addrs": {
+                                "items": {},
+                                "type": "array"
+                            },
+                            "ID": {
+                                "type": "string"
+                            }
+                        },
+                        "type": "object"
+                    }
+                },
+                "type": "object"
+            },
             "schema": {
                 "properties": {
                     "Fields": {
@@ -1803,7 +1826,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/replicator"
+                                "$ref": "#/components/schemas/replicator_params"
                             }
                         }
                     },
@@ -1859,7 +1882,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/replicator"
+                                "$ref": "#/components/schemas/replicator_params"
                             }
                         }
                     },

--- a/http/client_p2p.go
+++ b/http/client_p2p.go
@@ -35,7 +35,7 @@ func (c *Client) PeerInfo() peer.AddrInfo {
 	return res
 }
 
-func (c *Client) SetReplicator(ctx context.Context, rep client.Replicator) error {
+func (c *Client) SetReplicator(ctx context.Context, rep client.ReplicatorParams) error {
 	methodURL := c.http.baseURL.JoinPath("p2p", "replicators")
 
 	body, err := json.Marshal(rep)
@@ -50,7 +50,7 @@ func (c *Client) SetReplicator(ctx context.Context, rep client.Replicator) error
 	return err
 }
 
-func (c *Client) DeleteReplicator(ctx context.Context, rep client.Replicator) error {
+func (c *Client) DeleteReplicator(ctx context.Context, rep client.ReplicatorParams) error {
 	methodURL := c.http.baseURL.JoinPath("p2p", "replicators")
 
 	body, err := json.Marshal(rep)

--- a/http/handler_p2p.go
+++ b/http/handler_p2p.go
@@ -36,7 +36,7 @@ func (s *p2pHandler) SetReplicator(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	var rep client.Replicator
+	var rep client.ReplicatorParams
 	if err := requestJSON(req, &rep); err != nil {
 		responseJSON(rw, http.StatusBadRequest, errorResponse{err})
 		return
@@ -56,7 +56,7 @@ func (s *p2pHandler) DeleteReplicator(rw http.ResponseWriter, req *http.Request)
 		return
 	}
 
-	var rep client.Replicator
+	var rep client.ReplicatorParams
 	if err := requestJSON(req, &rep); err != nil {
 		responseJSON(rw, http.StatusBadRequest, errorResponse{err})
 		return
@@ -152,6 +152,9 @@ func (h *p2pHandler) bindRoutes(router *Router) {
 	replicatorSchema := &openapi3.SchemaRef{
 		Ref: "#/components/schemas/replicator",
 	}
+	replicatorParamsSchema := &openapi3.SchemaRef{
+		Ref: "#/components/schemas/replicator_params",
+	}
 
 	peerInfoResponse := openapi3.NewResponse().
 		WithDescription("Peer network info").
@@ -178,7 +181,7 @@ func (h *p2pHandler) bindRoutes(router *Router) {
 
 	replicatorRequest := openapi3.NewRequestBody().
 		WithRequired(true).
-		WithContent(openapi3.NewContentWithJSONSchemaRef(replicatorSchema))
+		WithContent(openapi3.NewContentWithJSONSchemaRef(replicatorParamsSchema))
 
 	setReplicator := openapi3.NewOperation()
 	setReplicator.Description = "Add peer replicators"

--- a/http/openapi.go
+++ b/http/openapi.go
@@ -35,6 +35,7 @@ var openApiSchemas = map[string]any{
 	"update_result":                   &client.UpdateResult{},
 	"lens_config":                     &client.LensConfig{},
 	"replicator":                      &client.Replicator{},
+	"replicator_params":               &client.ReplicatorParams{},
 	"ccip_request":                    &CCIPRequest{},
 	"ccip_response":                   &CCIPResponse{},
 	"patch_schema_request":            &patchSchemaRequest{},

--- a/internal/db/p2p_replicator.go
+++ b/internal/db/p2p_replicator.go
@@ -38,7 +38,7 @@ const (
 	retryTimeout = 10 * time.Second
 )
 
-func (db *db) SetReplicator(ctx context.Context, rep client.Replicator) error {
+func (db *db) SetReplicator(ctx context.Context, rep client.ReplicatorParams) error {
 	txn, err := db.NewTxn(ctx, false)
 	if err != nil {
 		return err
@@ -85,9 +85,9 @@ func (db *db) SetReplicator(ctx context.Context, rep client.Replicator) error {
 
 	var collections []client.Collection
 	switch {
-	case len(rep.Schemas) > 0:
+	case len(rep.Collections) > 0:
 		// if specific collections are chosen get them by name
-		for _, name := range rep.Schemas {
+		for _, name := range rep.Collections {
 			col, err := db.GetCollectionByName(ctx, name)
 			if err != nil {
 				return NewErrReplicatorCollections(err)
@@ -210,7 +210,7 @@ func (db *db) getDocsHeads(
 	return updateChan
 }
 
-func (db *db) DeleteReplicator(ctx context.Context, rep client.Replicator) error {
+func (db *db) DeleteReplicator(ctx context.Context, rep client.ReplicatorParams) error {
 	txn, err := db.NewTxn(ctx, false)
 	if err != nil {
 		return err
@@ -247,9 +247,9 @@ func (db *db) DeleteReplicator(ctx context.Context, rep client.Replicator) error
 	}
 
 	var collections []client.Collection
-	if len(rep.Schemas) > 0 {
+	if len(rep.Collections) > 0 {
 		// if specific collections are chosen get them by name
-		for _, name := range rep.Schemas {
+		for _, name := range rep.Collections {
 			col, err := db.GetCollectionByName(ctx, name)
 			if err != nil {
 				return NewErrReplicatorCollections(err)
@@ -277,7 +277,7 @@ func (db *db) DeleteReplicator(ctx context.Context, rep client.Replicator) error
 
 	// Persist the replicator to the store, deleting it if no schemas remain
 	key := core.NewReplicatorKey(rep.Info.ID.String())
-	if len(rep.Schemas) == 0 {
+	if len(rep.Collections) == 0 {
 		err := txn.Peerstore().Delete(ctx, key.ToDS())
 		if err != nil {
 			return err

--- a/tests/clients/cli/wrapper.go
+++ b/tests/clients/cli/wrapper.go
@@ -77,9 +77,9 @@ func (w *Wrapper) PeerInfo() peer.AddrInfo {
 	return info
 }
 
-func (w *Wrapper) SetReplicator(ctx context.Context, rep client.Replicator) error {
+func (w *Wrapper) SetReplicator(ctx context.Context, rep client.ReplicatorParams) error {
 	args := []string{"client", "p2p", "replicator", "set"}
-	args = append(args, "--collection", strings.Join(rep.Schemas, ","))
+	args = append(args, "--collection", strings.Join(rep.Collections, ","))
 
 	info, err := json.Marshal(rep.Info)
 	if err != nil {
@@ -91,9 +91,9 @@ func (w *Wrapper) SetReplicator(ctx context.Context, rep client.Replicator) erro
 	return err
 }
 
-func (w *Wrapper) DeleteReplicator(ctx context.Context, rep client.Replicator) error {
+func (w *Wrapper) DeleteReplicator(ctx context.Context, rep client.ReplicatorParams) error {
 	args := []string{"client", "p2p", "replicator", "delete"}
-	args = append(args, "--collection", strings.Join(rep.Schemas, ","))
+	args = append(args, "--collection", strings.Join(rep.Collections, ","))
 
 	info, err := json.Marshal(rep.Info)
 	if err != nil {

--- a/tests/clients/http/wrapper.go
+++ b/tests/clients/http/wrapper.go
@@ -62,11 +62,11 @@ func (w *Wrapper) PeerInfo() peer.AddrInfo {
 	return w.client.PeerInfo()
 }
 
-func (w *Wrapper) SetReplicator(ctx context.Context, rep client.Replicator) error {
+func (w *Wrapper) SetReplicator(ctx context.Context, rep client.ReplicatorParams) error {
 	return w.client.SetReplicator(ctx, rep)
 }
 
-func (w *Wrapper) DeleteReplicator(ctx context.Context, rep client.Replicator) error {
+func (w *Wrapper) DeleteReplicator(ctx context.Context, rep client.ReplicatorParams) error {
 	return w.client.DeleteReplicator(ctx, rep)
 }
 

--- a/tests/integration/p2p.go
+++ b/tests/integration/p2p.go
@@ -174,7 +174,7 @@ func configureReplicator(
 	sourceNode := s.nodes[cfg.SourceNodeID]
 	targetNode := s.nodes[cfg.TargetNodeID]
 
-	err := sourceNode.SetReplicator(s.ctx, client.Replicator{
+	err := sourceNode.SetReplicator(s.ctx, client.ReplicatorParams{
 		Info: targetNode.PeerInfo(),
 	})
 
@@ -193,7 +193,7 @@ func deleteReplicator(
 	sourceNode := s.nodes[cfg.SourceNodeID]
 	targetNode := s.nodes[cfg.TargetNodeID]
 
-	err := sourceNode.DeleteReplicator(s.ctx, client.Replicator{
+	err := sourceNode.DeleteReplicator(s.ctx, client.ReplicatorParams{
 		Info: targetNode.PeerInfo(),
 	})
 	require.NoError(s.t, err)


### PR DESCRIPTION
## Relevant issue(s)

Resolves #3159

## Description

This PR fixes an issue where replicator params that are not modifiable were exposed to the client API.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Existing integration tests.

Specify the platform(s) on which this was tested:
- *(modify the list accordingly*)
- MacOS

