### PR TITLE
test: Allow soft-referencing of Cids in tests

### DIFF
--- a/tests/integration/query/commits/simple_test.go
+++ b/tests/integration/query/commits/simple_test.go
@@ -37,13 +37,13 @@ func TestQueryCommits(t *testing.T) {
 				Results: map[string]any{
 					"commits": []map[string]any{
 						{
-							"cid": "bafyreif6dqbkr7t37jcjfxxrjnxt7cspxzvs7qwlbtjca57cc663he4s7e",
+							"cid": testUtils.NewUniqueCid("name"),
 						},
 						{
-							"cid": "bafyreigtnj6ntulcilkmin4pgukjwv3nwglqpiiyddz3dyfexdbltze7sy",
+							"cid": testUtils.NewUniqueCid("age"),
 						},
 						{
-							"cid": "bafyreia2vlbfkcbyogdjzmbqcjneabwwwtw7ti2xbd7yor5mbu2sk4pcoy",
+							"cid": testUtils.NewUniqueCid("head"),
 						},
 					},
 				},
@@ -364,7 +364,7 @@ func TestQuery_CommitsWithAllFieldsWithUpdate_NoError(t *testing.T) {
 				Results: map[string]any{
 					"commits": []map[string]any{
 						{
-							"cid":          "bafyreih5h6i6ohfsgrcjtg76iarebqcurpaft73gpobl2z2cfsvihsgdqu",
+							"cid":          testUtils.NewUniqueCid("age update"),
 							"collectionID": int64(1),
 							"delta":        testUtils.CBORValue(22),
 							"docID":        "bae-c9fb0fa4-1195-589c-aa54-e68333fb90b3",
@@ -373,13 +373,13 @@ func TestQuery_CommitsWithAllFieldsWithUpdate_NoError(t *testing.T) {
 							"height":       int64(2),
 							"links": []map[string]any{
 								{
-									"cid":  "bafyreif6dqbkr7t37jcjfxxrjnxt7cspxzvs7qwlbtjca57cc663he4s7e",
+									"cid":  testUtils.NewUniqueCid("age create"),
 									"name": "_head",
 								},
 							},
 						},
 						{
-							"cid":          "bafyreif6dqbkr7t37jcjfxxrjnxt7cspxzvs7qwlbtjca57cc663he4s7e",
+							"cid":          testUtils.NewUniqueCid("age create"),
 							"collectionID": int64(1),
 							"delta":        testUtils.CBORValue(21),
 							"docID":        "bae-c9fb0fa4-1195-589c-aa54-e68333fb90b3",
@@ -389,7 +389,7 @@ func TestQuery_CommitsWithAllFieldsWithUpdate_NoError(t *testing.T) {
 							"links":        []map[string]any{},
 						},
 						{
-							"cid":          "bafyreigtnj6ntulcilkmin4pgukjwv3nwglqpiiyddz3dyfexdbltze7sy",
+							"cid":          testUtils.NewUniqueCid("name create"),
 							"collectionID": int64(1),
 							"delta":        testUtils.CBORValue("John"),
 							"docID":        "bae-c9fb0fa4-1195-589c-aa54-e68333fb90b3",
@@ -399,7 +399,7 @@ func TestQuery_CommitsWithAllFieldsWithUpdate_NoError(t *testing.T) {
 							"links":        []map[string]any{},
 						},
 						{
-							"cid":          "bafyreiale6qsjc7qewod3c6h2odwamfwcf7vt4zlqtw7ldcm57xdkgxja4",
+							"cid":          testUtils.NewUniqueCid("update composite"),
 							"collectionID": int64(1),
 							"delta":        nil,
 							"docID":        "bae-c9fb0fa4-1195-589c-aa54-e68333fb90b3",
@@ -408,17 +408,17 @@ func TestQuery_CommitsWithAllFieldsWithUpdate_NoError(t *testing.T) {
 							"height":       int64(2),
 							"links": []map[string]any{
 								{
-									"cid":  "bafyreia2vlbfkcbyogdjzmbqcjneabwwwtw7ti2xbd7yor5mbu2sk4pcoy",
+									"cid":  testUtils.NewUniqueCid("create composite"),
 									"name": "_head",
 								},
 								{
-									"cid":  "bafyreih5h6i6ohfsgrcjtg76iarebqcurpaft73gpobl2z2cfsvihsgdqu",
+									"cid":  testUtils.NewUniqueCid("age update"),
 									"name": "age",
 								},
 							},
 						},
 						{
-							"cid":          "bafyreia2vlbfkcbyogdjzmbqcjneabwwwtw7ti2xbd7yor5mbu2sk4pcoy",
+							"cid":          testUtils.NewUniqueCid("create composite"),
 							"collectionID": int64(1),
 							"delta":        nil,
 							"docID":        "bae-c9fb0fa4-1195-589c-aa54-e68333fb90b3",
@@ -427,11 +427,11 @@ func TestQuery_CommitsWithAllFieldsWithUpdate_NoError(t *testing.T) {
 							"height":       int64(1),
 							"links": []map[string]any{
 								{
-									"cid":  "bafyreif6dqbkr7t37jcjfxxrjnxt7cspxzvs7qwlbtjca57cc663he4s7e",
+									"cid":  testUtils.NewUniqueCid("age create"),
 									"name": "age",
 								},
 								{
-									"cid":  "bafyreigtnj6ntulcilkmin4pgukjwv3nwglqpiiyddz3dyfexdbltze7sy",
+									"cid":  testUtils.NewUniqueCid("name create"),
 									"name": "name",
 								},
 							},

--- a/tests/integration/query/commits/with_delete_test.go
+++ b/tests/integration/query/commits/with_delete_test.go
@@ -40,8 +40,10 @@ func TestQueryCommits_AfterDocDeletion_ShouldStillFetch(t *testing.T) {
 				Request: `
 					query {
 						commits(fieldId: "C") {
+							cid
 							fieldName
 							links {
+								cid
 								name
 							}
 						}
@@ -50,20 +52,25 @@ func TestQueryCommits_AfterDocDeletion_ShouldStillFetch(t *testing.T) {
 				Results: map[string]any{
 					"commits": []map[string]any{
 						{
+							"cid":       testUtils.NewUniqueCid("delete"),
 							"fieldName": nil,
 							"links": []map[string]any{
 								{
+									"cid":  testUtils.NewUniqueCid("create composite"),
 									"name": "_head",
 								},
 							},
 						},
 						{
+							"cid":       testUtils.NewUniqueCid("create composite"),
 							"fieldName": nil,
 							"links": []map[string]any{
 								{
+									"cid":  testUtils.NewUniqueCid("create age"),
 									"name": "age",
 								},
 								{
+									"cid":  testUtils.NewUniqueCid("create name"),
 									"name": "name",
 								},
 							},

--- a/tests/integration/state.go
+++ b/tests/integration/state.go
@@ -175,6 +175,9 @@ type state struct {
 	// nodes.
 	docIDs [][]client.DocID
 
+	// Valid Cid string values by [UniqueCid] ID.
+	cids map[any]string
+
 	// Indexes, by index, by collection index, by node index.
 	indexes [][][]client.IndexDescription
 
@@ -218,6 +221,7 @@ func newState(
 		collectionNames:          collectionNames,
 		collectionIndexesByRoot:  map[uint32]int{},
 		docIDs:                   [][]client.DocID{},
+		cids:                     map[any]string{},
 		indexes:                  [][][]client.IndexDescription{},
 		isBench:                  false,
 	}

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -2022,8 +2022,10 @@ func assertRequestResults(
 				actualDocs,
 				stack,
 			)
-		case AnyOf:
-			assertResultsAnyOf(s.t, s.clientType, exp, actual)
+
+		case Validator:
+			exp.Validate(s, actual)
+
 		default:
 			assertResultsEqual(
 				s.t,
@@ -2067,9 +2069,12 @@ func assertRequestResultDocs(
 
 		for field, actualValue := range actualDoc {
 			stack.pushMap(field)
+			pathInfo := fmt.Sprintf("node: %v, path: %s", nodeID, stack)
+
 			switch expectedValue := expectedDoc[field].(type) {
-			case AnyOf:
-				assertResultsAnyOf(s.t, s.clientType, expectedValue, actualValue)
+			case Validator:
+				expectedValue.Validate(s, actualValue, pathInfo)
+
 			case DocIndex:
 				expectedDocID := s.docIDs[expectedValue.CollectionIndex][expectedValue.Index].String()
 				assertResultsEqual(
@@ -2077,7 +2082,7 @@ func assertRequestResultDocs(
 					s.clientType,
 					expectedDocID,
 					actualValue,
-					fmt.Sprintf("node: %v, path: %s", nodeID, stack),
+					pathInfo,
 				)
 			case []map[string]any:
 				actualValueMap := ConvertToArrayOfMaps(s.t, actualValue)
@@ -2096,7 +2101,7 @@ func assertRequestResultDocs(
 					s.clientType,
 					expectedValue,
 					actualValue,
-					fmt.Sprintf("node: %v, path: %s", nodeID, stack),
+					pathInfo,
 				)
 			}
 			stack.pop()


### PR DESCRIPTION
## Relevant issue(s)

Resolves #3172

## Description

Allows soft-referencing of Cids in tests.

When encountering an unpleasant change-detector problem in https://github.com/sourcenetwork/defradb/pull/3173 I realised we had no need to reference Cids based on index, and we really only ever cared that they were valid, and either not the same as another cid, or the same.

This change allows us to soft-reference them without ever really caring about where they came from.  This allows us to give them descriptive ids, and avoids having to have the test framework from having to fetch them independently from the DB - something that raises questions over whether we are testing the test framework or the production code, especially in the change detector.

The system can be extended to other types fairly easily. 

## How has this been tested?

I had a fairly long play around giving it bad ids in tests to make sure it would actually fail when appropriate.