### PR TITLE
fix: Add Authorization header to CORS allowed headers

### DIFF
--- a/http/middleware.go
+++ b/http/middleware.go
@@ -36,7 +36,7 @@ func CorsMiddleware(allowedOrigins []string) func(http.Handler) http.Handler {
 			return slices.Contains(allowedOrigins, strings.ToLower(origin))
 		},
 		AllowedMethods: []string{"GET", "HEAD", "POST", "PATCH", "DELETE"},
-		AllowedHeaders: []string{"Content-Type"},
+		AllowedHeaders: []string{"Content-Type", "Authorization"},
 		MaxAge:         300,
 	})
 }

--- a/http/server_test.go
+++ b/http/server_test.go
@@ -183,6 +183,8 @@ func TestServerListenAndServeWithAllowedOrigins(t *testing.T) {
 	req, err := http.NewRequest(http.MethodOptions, "http://127.0.0.1:30001", nil)
 	require.NoError(t, err)
 	req.Header.Add("origin", "localhost")
+	req.Header.Add("Access-Control-Request-Method", "POST")
+	req.Header.Add("Access-Control-Request-Headers", "Authorization, Content-Type")
 
 	res, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)


### PR DESCRIPTION
## Relevant issue(s)

Resolves #3177 

## Description

This PR adds the Authorization header to the CORS list of allowed headers. This bug what flagged from a partner trying to use authorization from a browser app.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

updated unit test with `Access-Control-Request-Headers` header

Specify the platform(s) on which this was tested:
- MacOS
