### PR TITLE
refactor: Rework core.Spans

### DIFF
--- a/internal/core/data.go
+++ b/internal/core/data.go
@@ -19,14 +19,14 @@ import (
 // Span is a range of keys from [Start, End).
 type Span struct {
 	// Start represents the starting key of the Span.
-	Start keys.DataStoreKey
+	Start keys.Walkable
 
 	// End represents the ending key of the Span.
-	End keys.DataStoreKey
+	End keys.Walkable
 }
 
 // NewSpan creates a new Span from the provided start and end keys.
-func NewSpan(start, end keys.DataStoreKey) Span {
+func NewSpan(start, end keys.Walkable) Span {
 	return Span{
 		Start: start,
 		End:   end,
@@ -122,7 +122,7 @@ func (this Span) Compare(other Span) SpanComparisonResult {
 	return After
 }
 
-func isAdjacent(this keys.DataStoreKey, other keys.DataStoreKey) bool {
+func isAdjacent(this keys.Walkable, other keys.Walkable) bool {
 	return len(this.ToString()) == len(other.ToString()) &&
 		(this.PrefixEnd().ToString() == other.ToString() ||
 			this.ToString() == other.PrefixEnd().ToString())

--- a/internal/core/data.go
+++ b/internal/core/data.go
@@ -147,15 +147,11 @@ func isAdjacent(this keys.DataStoreKey, other keys.DataStoreKey) bool {
 }
 
 // Spans is a collection of individual spans.
-type Spans struct {
-	Value []Span
-}
+type Spans = []Span
 
 // NewSpans creates a new Spans from the provided spans.
 func NewSpans(spans ...Span) Spans {
-	return Spans{
-		Value: spans,
-	}
+	return spans
 }
 
 // Merges an unordered, potentially overlapping and/or duplicated collection of Spans into

--- a/internal/core/data.go
+++ b/internal/core/data.go
@@ -148,15 +148,13 @@ func isAdjacent(this keys.DataStoreKey, other keys.DataStoreKey) bool {
 
 // Spans is a collection of individual spans.
 type Spans struct {
-	HasValue bool
-	Value    []Span
+	Value []Span
 }
 
 // NewSpans creates a new Spans from the provided spans.
 func NewSpans(spans ...Span) Spans {
 	return Spans{
-		HasValue: true,
-		Value:    spans,
+		Value: spans,
 	}
 }
 

--- a/internal/core/data.go
+++ b/internal/core/data.go
@@ -146,14 +146,6 @@ func isAdjacent(this keys.DataStoreKey, other keys.DataStoreKey) bool {
 			this.ToString() == other.PrefixEnd().ToString())
 }
 
-// Spans is a collection of individual spans.
-type Spans = []Span
-
-// NewSpans creates a new Spans from the provided spans.
-func NewSpans(spans ...Span) Spans {
-	return spans
-}
-
 // Merges an unordered, potentially overlapping and/or duplicated collection of Spans into
 // a unique set in ascending order, where overlapping spans are merged into a single span.
 // Will handle spans with keys of different lengths, where one might be a prefix of another.

--- a/internal/core/data_test.go
+++ b/internal/core/data_test.go
@@ -34,8 +34,8 @@ func TestMergeAscending_ReturnsSingle_GivenSingle(t *testing.T) {
 	result := MergeAscending(input)
 
 	assert.Len(t, result, 1)
-	assert.Equal(t, start1, result[0].Start())
-	assert.Equal(t, end1, result[0].End())
+	assert.Equal(t, start1, result[0].Start)
+	assert.Equal(t, end1, result[0].End)
 }
 
 func TestMergeAscending_ReturnsSecondBeforeFirst_GivenKeysInReverseOrder(t *testing.T) {
@@ -52,10 +52,10 @@ func TestMergeAscending_ReturnsSecondBeforeFirst_GivenKeysInReverseOrder(t *test
 	result := MergeAscending(input)
 
 	assert.Len(t, result, 2)
-	assert.Equal(t, start2, result[0].Start())
-	assert.Equal(t, end2, result[0].End())
-	assert.Equal(t, start1, result[1].Start())
-	assert.Equal(t, end1, result[1].End())
+	assert.Equal(t, start2, result[0].Start)
+	assert.Equal(t, end2, result[0].End)
+	assert.Equal(t, start1, result[1].Start)
+	assert.Equal(t, end1, result[1].End)
 }
 
 func TestMergeAscending_ReturnsItemsInOrder_GivenKeysInMixedOrder(t *testing.T) {
@@ -75,13 +75,13 @@ func TestMergeAscending_ReturnsItemsInOrder_GivenKeysInMixedOrder(t *testing.T) 
 	result := MergeAscending(input)
 
 	assert.Len(t, result, 3)
-	assert.Equal(t, start1, result[0].Start())
-	assert.Equal(t, end1, result[0].End())
+	assert.Equal(t, start1, result[0].Start)
+	assert.Equal(t, end1, result[0].End)
 	// Span 3 should be returned between one and two
-	assert.Equal(t, start3, result[1].Start())
-	assert.Equal(t, end3, result[1].End())
-	assert.Equal(t, start2, result[2].Start())
-	assert.Equal(t, end2, result[2].End())
+	assert.Equal(t, start3, result[1].Start)
+	assert.Equal(t, end3, result[1].End)
+	assert.Equal(t, start2, result[2].Start)
+	assert.Equal(t, end2, result[2].End)
 }
 
 func TestMergeAscending_ReturnsSingle_GivenStartBeforeEndEqualToStart(t *testing.T) {
@@ -97,8 +97,8 @@ func TestMergeAscending_ReturnsSingle_GivenStartBeforeEndEqualToStart(t *testing
 	result := MergeAscending(input)
 
 	assert.Len(t, result, 1)
-	assert.Equal(t, start2, result[0].Start())
-	assert.Equal(t, end1, result[0].End())
+	assert.Equal(t, start2, result[0].Start)
+	assert.Equal(t, end1, result[0].End)
 }
 
 func TestMergeAscending_ReturnsSingle_GivenStartBeforeEndAdjacentToStart(t *testing.T) {
@@ -114,8 +114,8 @@ func TestMergeAscending_ReturnsSingle_GivenStartBeforeEndAdjacentToStart(t *test
 	result := MergeAscending(input)
 
 	assert.Len(t, result, 1)
-	assert.Equal(t, start2, result[0].Start())
-	assert.Equal(t, end1, result[0].End())
+	assert.Equal(t, start2, result[0].Start)
+	assert.Equal(t, end1, result[0].End)
 }
 
 func TestMergeAscending_ReturnsSingle_GivenStartBeforeEndWithin(t *testing.T) {
@@ -131,8 +131,8 @@ func TestMergeAscending_ReturnsSingle_GivenStartBeforeEndWithin(t *testing.T) {
 	result := MergeAscending(input)
 
 	assert.Len(t, result, 1)
-	assert.Equal(t, start2, result[0].Start())
-	assert.Equal(t, end1, result[0].End())
+	assert.Equal(t, start2, result[0].Start)
+	assert.Equal(t, end1, result[0].End)
 }
 
 func TestMergeAscending_ReturnsSingle_GivenStartPrefixesEndWithin(t *testing.T) {
@@ -148,8 +148,8 @@ func TestMergeAscending_ReturnsSingle_GivenStartPrefixesEndWithin(t *testing.T) 
 	result := MergeAscending(input)
 
 	assert.Len(t, result, 1)
-	assert.Equal(t, start2, result[0].Start())
-	assert.Equal(t, end1, result[0].End())
+	assert.Equal(t, start2, result[0].Start)
+	assert.Equal(t, end1, result[0].End)
 }
 
 func TestMergeAscending_ReturnsSingle_GivenStartBeforeEndWithinEndPrefix(t *testing.T) {
@@ -165,8 +165,8 @@ func TestMergeAscending_ReturnsSingle_GivenStartBeforeEndWithinEndPrefix(t *test
 	result := MergeAscending(input)
 
 	assert.Len(t, result, 1)
-	assert.Equal(t, start2, result[0].Start())
-	assert.Equal(t, end1, result[0].End())
+	assert.Equal(t, start2, result[0].Start)
+	assert.Equal(t, end1, result[0].End)
 }
 
 func TestMergeAscending_ReturnsSingle_GivenStartPrefixesEndWithinEndPrefix(t *testing.T) {
@@ -182,8 +182,8 @@ func TestMergeAscending_ReturnsSingle_GivenStartPrefixesEndWithinEndPrefix(t *te
 	result := MergeAscending(input)
 
 	assert.Len(t, result, 1)
-	assert.Equal(t, start2, result[0].Start())
-	assert.Equal(t, end1, result[0].End())
+	assert.Equal(t, start2, result[0].Start)
+	assert.Equal(t, end1, result[0].End)
 }
 
 func TestMergeAscending_ReturnsSingle_GivenStartBeforeEndEqual(t *testing.T) {
@@ -199,8 +199,8 @@ func TestMergeAscending_ReturnsSingle_GivenStartBeforeEndEqual(t *testing.T) {
 	result := MergeAscending(input)
 
 	assert.Len(t, result, 1)
-	assert.Equal(t, start2, result[0].Start())
-	assert.Equal(t, end1, result[0].End())
+	assert.Equal(t, start2, result[0].Start)
+	assert.Equal(t, end1, result[0].End)
 }
 
 func TestMergeAscending_ReturnsSingle_GivenStartBeforeEndAdjacentAndBefore(t *testing.T) {
@@ -216,8 +216,8 @@ func TestMergeAscending_ReturnsSingle_GivenStartBeforeEndAdjacentAndBefore(t *te
 	result := MergeAscending(input)
 
 	assert.Len(t, result, 1)
-	assert.Equal(t, start2, result[0].Start())
-	assert.Equal(t, end1, result[0].End())
+	assert.Equal(t, start2, result[0].Start)
+	assert.Equal(t, end1, result[0].End)
 }
 
 func TestMergeAscending_ReturnsSingle_GivenStartBeforeEndAdjacentAndGreater(t *testing.T) {
@@ -233,8 +233,8 @@ func TestMergeAscending_ReturnsSingle_GivenStartBeforeEndAdjacentAndGreater(t *t
 	result := MergeAscending(input)
 
 	assert.Len(t, result, 1)
-	assert.Equal(t, start2, result[0].Start())
-	assert.Equal(t, end2, result[0].End())
+	assert.Equal(t, start2, result[0].Start)
+	assert.Equal(t, end2, result[0].End)
 }
 
 func TestMergeAscending_ReturnsSingle_GivenStartPrefixesEndEqual(t *testing.T) {
@@ -250,8 +250,8 @@ func TestMergeAscending_ReturnsSingle_GivenStartPrefixesEndEqual(t *testing.T) {
 	result := MergeAscending(input)
 
 	assert.Len(t, result, 1)
-	assert.Equal(t, start2, result[0].Start())
-	assert.Equal(t, end1, result[0].End())
+	assert.Equal(t, start2, result[0].Start)
+	assert.Equal(t, end1, result[0].End)
 }
 
 func TestMergeAscending_ReturnsSingle_GivenStartPrefixesEndAdjacentAndBefore(t *testing.T) {
@@ -267,8 +267,8 @@ func TestMergeAscending_ReturnsSingle_GivenStartPrefixesEndAdjacentAndBefore(t *
 	result := MergeAscending(input)
 
 	assert.Len(t, result, 1)
-	assert.Equal(t, start2, result[0].Start())
-	assert.Equal(t, end1, result[0].End())
+	assert.Equal(t, start2, result[0].Start)
+	assert.Equal(t, end1, result[0].End)
 }
 
 func TestMergeAscending_ReturnsSingle_GivenStartPrefixesEndAdjacentAndAfter(t *testing.T) {
@@ -284,8 +284,8 @@ func TestMergeAscending_ReturnsSingle_GivenStartPrefixesEndAdjacentAndAfter(t *t
 	result := MergeAscending(input)
 
 	assert.Len(t, result, 1)
-	assert.Equal(t, start2, result[0].Start())
-	assert.Equal(t, end2, result[0].End())
+	assert.Equal(t, start2, result[0].Start)
+	assert.Equal(t, end2, result[0].End)
 }
 
 func TestMergeAscending_ReturnsMiddleSpansMerged_GivenSpanCoveringMiddleSpans(t *testing.T) {
@@ -310,13 +310,13 @@ func TestMergeAscending_ReturnsMiddleSpansMerged_GivenSpanCoveringMiddleSpans(t 
 	result := MergeAscending(input)
 
 	assert.Len(t, result, 3)
-	assert.Equal(t, start1, result[0].Start())
-	assert.Equal(t, end1, result[0].End())
+	assert.Equal(t, start1, result[0].Start)
+	assert.Equal(t, end1, result[0].End)
 	// Spans 2 and 3 are within span 5
-	assert.Equal(t, start5, result[1].Start())
-	assert.Equal(t, end5, result[1].End())
-	assert.Equal(t, start4, result[2].Start())
-	assert.Equal(t, end4, result[2].End())
+	assert.Equal(t, start5, result[1].Start)
+	assert.Equal(t, end5, result[1].End)
+	assert.Equal(t, start4, result[2].Start)
+	assert.Equal(t, end4, result[2].End)
 }
 
 func TestMergeAscending_ReturnsSingle_GivenStartEqualEndWithin(t *testing.T) {
@@ -332,8 +332,8 @@ func TestMergeAscending_ReturnsSingle_GivenStartEqualEndWithin(t *testing.T) {
 	result := MergeAscending(input)
 
 	assert.Len(t, result, 1)
-	assert.Equal(t, start1, result[0].Start())
-	assert.Equal(t, end1, result[0].End())
+	assert.Equal(t, start1, result[0].Start)
+	assert.Equal(t, end1, result[0].End)
 }
 
 func TestMergeAscending_ReturnsSingle_GivenStartEqualEndWithinEndPrefix(t *testing.T) {
@@ -349,8 +349,8 @@ func TestMergeAscending_ReturnsSingle_GivenStartEqualEndWithinEndPrefix(t *testi
 	result := MergeAscending(input)
 
 	assert.Len(t, result, 1)
-	assert.Equal(t, start1, result[0].Start())
-	assert.Equal(t, end1, result[0].End())
+	assert.Equal(t, start1, result[0].Start)
+	assert.Equal(t, end1, result[0].End)
 }
 
 func TestMergeAscending_ReturnsSingle_GivenDuplicates(t *testing.T) {
@@ -364,8 +364,8 @@ func TestMergeAscending_ReturnsSingle_GivenDuplicates(t *testing.T) {
 	result := MergeAscending(input)
 
 	assert.Len(t, result, 1)
-	assert.Equal(t, start1, result[0].Start())
-	assert.Equal(t, end1, result[0].End())
+	assert.Equal(t, start1, result[0].Start)
+	assert.Equal(t, end1, result[0].End)
 }
 
 func TestMergeAscending_ReturnsSingle_GivenStartWithinEndWithin(t *testing.T) {
@@ -381,8 +381,8 @@ func TestMergeAscending_ReturnsSingle_GivenStartWithinEndWithin(t *testing.T) {
 	result := MergeAscending(input)
 
 	assert.Len(t, result, 1)
-	assert.Equal(t, start1, result[0].Start())
-	assert.Equal(t, end1, result[0].End())
+	assert.Equal(t, start1, result[0].Start)
+	assert.Equal(t, end1, result[0].End)
 }
 
 func TestMergeAscending_ReturnsSingle_GivenStartWithinEndWithinEndPrefix(t *testing.T) {
@@ -398,8 +398,8 @@ func TestMergeAscending_ReturnsSingle_GivenStartWithinEndWithinEndPrefix(t *test
 	result := MergeAscending(input)
 
 	assert.Len(t, result, 1)
-	assert.Equal(t, start1, result[0].Start())
-	assert.Equal(t, end1, result[0].End())
+	assert.Equal(t, start1, result[0].Start)
+	assert.Equal(t, end1, result[0].End)
 }
 
 func TestMergeAscending_ReturnsSingle_GivenStartWithinEndEqual(t *testing.T) {
@@ -415,8 +415,8 @@ func TestMergeAscending_ReturnsSingle_GivenStartWithinEndEqual(t *testing.T) {
 	result := MergeAscending(input)
 
 	assert.Len(t, result, 1)
-	assert.Equal(t, start1, result[0].Start())
-	assert.Equal(t, end1, result[0].End())
+	assert.Equal(t, start1, result[0].Start)
+	assert.Equal(t, end1, result[0].End)
 }
 
 func TestMergeAscending_ReturnsSingle_GivenStartWithinEndAdjacentAndBefore(t *testing.T) {
@@ -432,8 +432,8 @@ func TestMergeAscending_ReturnsSingle_GivenStartWithinEndAdjacentAndBefore(t *te
 	result := MergeAscending(input)
 
 	assert.Len(t, result, 1)
-	assert.Equal(t, start1, result[0].Start())
-	assert.Equal(t, end1, result[0].End())
+	assert.Equal(t, start1, result[0].Start)
+	assert.Equal(t, end1, result[0].End)
 }
 
 func TestMergeAscending_ReturnsSingle_GivenStartWithinEndAdjacentAndAfter(t *testing.T) {
@@ -449,8 +449,8 @@ func TestMergeAscending_ReturnsSingle_GivenStartWithinEndAdjacentAndAfter(t *tes
 	result := MergeAscending(input)
 
 	assert.Len(t, result, 1)
-	assert.Equal(t, start1, result[0].Start())
-	assert.Equal(t, end2, result[0].End())
+	assert.Equal(t, start1, result[0].Start)
+	assert.Equal(t, end2, result[0].End)
 }
 
 func TestMergeAscending_ReturnsMiddleSpansMerged_GivenStartEqualEndAfterSpanCoveringMiddleSpans(
@@ -477,13 +477,13 @@ func TestMergeAscending_ReturnsMiddleSpansMerged_GivenStartEqualEndAfterSpanCove
 	result := MergeAscending(input)
 
 	assert.Len(t, result, 3)
-	assert.Equal(t, start1, result[0].Start())
-	assert.Equal(t, end1, result[0].End())
+	assert.Equal(t, start1, result[0].Start)
+	assert.Equal(t, end1, result[0].End)
 	// Spans 2 and 3 are within span 5
-	assert.Equal(t, start5, result[1].Start())
-	assert.Equal(t, end5, result[1].End())
-	assert.Equal(t, start4, result[2].Start())
-	assert.Equal(t, end4, result[2].End())
+	assert.Equal(t, start5, result[1].Start)
+	assert.Equal(t, end5, result[1].End)
+	assert.Equal(t, start4, result[2].Start)
+	assert.Equal(t, end4, result[2].End)
 }
 
 func TestMergeAscending_ReturnsMiddleSpansMerged_GivenStartWithinEndAfterSpanCoveringMiddleSpans(
@@ -510,12 +510,12 @@ func TestMergeAscending_ReturnsMiddleSpansMerged_GivenStartWithinEndAfterSpanCov
 	result := MergeAscending(input)
 
 	assert.Len(t, result, 3)
-	assert.Equal(t, start1, result[0].Start())
-	assert.Equal(t, end1, result[0].End())
-	assert.Equal(t, start2, result[1].Start())
-	assert.Equal(t, end5, result[1].End())
-	assert.Equal(t, start4, result[2].Start())
-	assert.Equal(t, end4, result[2].End())
+	assert.Equal(t, start1, result[0].Start)
+	assert.Equal(t, end1, result[0].End)
+	assert.Equal(t, start2, result[1].Start)
+	assert.Equal(t, end5, result[1].End)
+	assert.Equal(t, start4, result[2].Start)
+	assert.Equal(t, end4, result[2].End)
 }
 
 func TestMergeAscending_ReturnsMiddleSpansMerged_GivenStartEqualToEndEndAfterSpanCoveringMiddleSpans(
@@ -542,12 +542,12 @@ func TestMergeAscending_ReturnsMiddleSpansMerged_GivenStartEqualToEndEndAfterSpa
 	result := MergeAscending(input)
 
 	assert.Len(t, result, 3)
-	assert.Equal(t, start1, result[0].Start())
-	assert.Equal(t, end1, result[0].End())
-	assert.Equal(t, start2, result[1].Start())
-	assert.Equal(t, end5, result[1].End())
-	assert.Equal(t, start4, result[2].Start())
-	assert.Equal(t, end4, result[2].End())
+	assert.Equal(t, start1, result[0].Start)
+	assert.Equal(t, end1, result[0].End)
+	assert.Equal(t, start2, result[1].Start)
+	assert.Equal(t, end5, result[1].End)
+	assert.Equal(t, start4, result[2].Start)
+	assert.Equal(t, end4, result[2].End)
 }
 
 func TestMergeAscending_ReturnsMiddleSpansMerged_GivenStartAdjacentAndBeforeEndEndAfterSpanCoveringMiddleSpans(
@@ -574,12 +574,12 @@ func TestMergeAscending_ReturnsMiddleSpansMerged_GivenStartAdjacentAndBeforeEndE
 	result := MergeAscending(input)
 
 	assert.Len(t, result, 3)
-	assert.Equal(t, start1, result[0].Start())
-	assert.Equal(t, end1, result[0].End())
-	assert.Equal(t, start2, result[1].Start())
-	assert.Equal(t, end5, result[1].End())
-	assert.Equal(t, start4, result[2].Start())
-	assert.Equal(t, end4, result[2].End())
+	assert.Equal(t, start1, result[0].Start)
+	assert.Equal(t, end1, result[0].End)
+	assert.Equal(t, start2, result[1].Start)
+	assert.Equal(t, end5, result[1].End)
+	assert.Equal(t, start4, result[2].Start)
+	assert.Equal(t, end4, result[2].End)
 }
 
 func TestMergeAscending_ReturnsMiddleSpansMerged_GivenStartAdjacentAndAfterEndEndAfterSpanCoveringMiddleSpans(
@@ -606,12 +606,12 @@ func TestMergeAscending_ReturnsMiddleSpansMerged_GivenStartAdjacentAndAfterEndEn
 	result := MergeAscending(input)
 
 	assert.Len(t, result, 3)
-	assert.Equal(t, start1, result[0].Start())
-	assert.Equal(t, end1, result[0].End())
-	assert.Equal(t, start2, result[1].Start())
-	assert.Equal(t, end5, result[1].End())
-	assert.Equal(t, start4, result[2].Start())
-	assert.Equal(t, end4, result[2].End())
+	assert.Equal(t, start1, result[0].Start)
+	assert.Equal(t, end1, result[0].End)
+	assert.Equal(t, start2, result[1].Start)
+	assert.Equal(t, end5, result[1].End)
+	assert.Equal(t, start4, result[2].Start)
+	assert.Equal(t, end4, result[2].End)
 }
 
 func TestMergeAscending_ReturnsTwoItems_GivenSecondItemAfterFirst(t *testing.T) {
@@ -627,10 +627,10 @@ func TestMergeAscending_ReturnsTwoItems_GivenSecondItemAfterFirst(t *testing.T) 
 	result := MergeAscending(input)
 
 	assert.Len(t, result, 2)
-	assert.Equal(t, start1, result[0].Start())
-	assert.Equal(t, end1, result[0].End())
-	assert.Equal(t, start2, result[1].Start())
-	assert.Equal(t, end2, result[1].End())
+	assert.Equal(t, start1, result[0].Start)
+	assert.Equal(t, end1, result[0].End)
+	assert.Equal(t, start2, result[1].Start)
+	assert.Equal(t, end2, result[1].End)
 }
 
 func TestMergeAscending_ReturnsSingle_GivenStartAdjacentAndBeforeEndEndEqual(t *testing.T) {
@@ -646,8 +646,8 @@ func TestMergeAscending_ReturnsSingle_GivenStartAdjacentAndBeforeEndEndEqual(t *
 	result := MergeAscending(input)
 
 	assert.Len(t, result, 1)
-	assert.Equal(t, start1, result[0].Start())
-	assert.Equal(t, end2, result[0].End())
+	assert.Equal(t, start1, result[0].Start)
+	assert.Equal(t, end2, result[0].End)
 }
 
 func TestMergeAscending_ReturnsSingle_GivenStartAdjacentAndBeforeEndEndAdjacentAndAfter(
@@ -665,8 +665,8 @@ func TestMergeAscending_ReturnsSingle_GivenStartAdjacentAndBeforeEndEndAdjacentA
 	result := MergeAscending(input)
 
 	assert.Len(t, result, 1)
-	assert.Equal(t, start1, result[0].Start())
-	assert.Equal(t, end2, result[0].End())
+	assert.Equal(t, start1, result[0].Start)
+	assert.Equal(t, end2, result[0].End)
 }
 
 func TestMergeAscending_ReturnsSingle_GivenStartAdjacentAndBeforeEndEndAfter(t *testing.T) {
@@ -682,8 +682,8 @@ func TestMergeAscending_ReturnsSingle_GivenStartAdjacentAndBeforeEndEndAfter(t *
 	result := MergeAscending(input)
 
 	assert.Len(t, result, 1)
-	assert.Equal(t, start1, result[0].Start())
-	assert.Equal(t, end2, result[0].End())
+	assert.Equal(t, start1, result[0].Start)
+	assert.Equal(t, end2, result[0].End)
 }
 
 func TestMergeAscending_ReturnsSingle_GivenStartAdjacentAndAfterEndEndAfter(t *testing.T) {
@@ -699,6 +699,6 @@ func TestMergeAscending_ReturnsSingle_GivenStartAdjacentAndAfterEndEndAfter(t *t
 	result := MergeAscending(input)
 
 	assert.Len(t, result, 1)
-	assert.Equal(t, start1, result[0].Start())
-	assert.Equal(t, end2, result[0].End())
+	assert.Equal(t, start1, result[0].Start)
+	assert.Equal(t, end2, result[0].End)
 }

--- a/internal/db/collection_get.go
+++ b/internal/db/collection_get.go
@@ -73,7 +73,7 @@ func (c *collection) get(
 	// construct target DS key from DocID.
 	targetKey := base.MakeDataStoreKeyWithCollectionAndDocID(c.Description(), primaryKey.DocID)
 	// run the doc fetcher
-	err = df.Start(ctx, core.NewSpans(core.NewSpan(targetKey, targetKey.PrefixEnd())))
+	err = df.Start(ctx, core.NewSpan(targetKey, targetKey.PrefixEnd()))
 	if err != nil {
 		_ = df.Close()
 		return nil, err

--- a/internal/db/collection_index.go
+++ b/internal/db/collection_index.go
@@ -317,7 +317,7 @@ func (c *collection) iterateAllDocs(
 		return errors.Join(err, df.Close())
 	}
 	start := base.MakeDataStoreKeyWithCollectionDescription(c.Description())
-	spans := core.NewSpans(core.NewSpan(start, start.PrefixEnd()))
+	spans := core.NewSpan(start, start.PrefixEnd())
 
 	err = df.Start(ctx, spans)
 	if err != nil {

--- a/internal/db/fetcher/dag.go
+++ b/internal/db/fetcher/dag.go
@@ -38,7 +38,7 @@ func (hf *HeadFetcher) Start(
 	spans core.Spans,
 	fieldId immutable.Option[string],
 ) error {
-	if len(spans.Value) == 0 {
+	if len(spans) == 0 {
 		spans = core.NewSpans(
 			core.NewSpan(
 				keys.DataStoreKey{},
@@ -47,21 +47,21 @@ func (hf *HeadFetcher) Start(
 		)
 	}
 
-	if len(spans.Value) > 1 {
+	if len(spans) > 1 {
 		// if we have multiple spans, we need to sort them by their start position
 		// so we can do a single iterative sweep
-		sort.Slice(spans.Value, func(i, j int) bool {
+		sort.Slice(spans, func(i, j int) bool {
 			// compare by strings if i < j.
 			// apply the '!= df.reverse' to reverse the sort
 			// if we need to
-			return (strings.Compare(spans.Value[i].Start().ToString(), spans.Value[j].Start().ToString()) < 0)
+			return (strings.Compare(spans[i].Start().ToString(), spans[j].Start().ToString()) < 0)
 		})
 	}
 	hf.spans = spans
 	hf.fieldId = fieldId
 
 	q := dsq.Query{
-		Prefix: hf.spans.Value[0].Start().ToString(),
+		Prefix: hf.spans[0].Start().ToString(),
 		Orders: []dsq.Order{dsq.OrderByKey{}},
 	}
 

--- a/internal/db/fetcher/dag.go
+++ b/internal/db/fetcher/dag.go
@@ -54,14 +54,14 @@ func (hf *HeadFetcher) Start(
 			// compare by strings if i < j.
 			// apply the '!= df.reverse' to reverse the sort
 			// if we need to
-			return (strings.Compare(spans[i].Start().ToString(), spans[j].Start().ToString()) < 0)
+			return (strings.Compare(spans[i].Start.ToString(), spans[j].Start.ToString()) < 0)
 		})
 	}
 	hf.spans = spans
 	hf.fieldId = fieldId
 
 	q := dsq.Query{
-		Prefix: hf.spans[0].Start().ToString(),
+		Prefix: hf.spans[0].Start.ToString(),
 		Orders: []dsq.Order{dsq.OrderByKey{}},
 	}
 

--- a/internal/db/fetcher/dag.go
+++ b/internal/db/fetcher/dag.go
@@ -26,7 +26,7 @@ import (
 
 // HeadFetcher is a utility to incrementally fetch all the MerkleCRDT heads of a given doc/field.
 type HeadFetcher struct {
-	spans   core.Spans
+	spans   []core.Span
 	fieldId immutable.Option[string]
 
 	kvIter dsq.Results
@@ -35,16 +35,16 @@ type HeadFetcher struct {
 func (hf *HeadFetcher) Start(
 	ctx context.Context,
 	txn datastore.Txn,
-	spans core.Spans,
+	spans []core.Span,
 	fieldId immutable.Option[string],
 ) error {
 	if len(spans) == 0 {
-		spans = core.NewSpans(
+		spans = []core.Span{
 			core.NewSpan(
 				keys.DataStoreKey{},
 				keys.DataStoreKey{}.PrefixEnd(),
 			),
-		)
+		}
 	}
 
 	if len(spans) > 1 {

--- a/internal/db/fetcher/errors.go
+++ b/internal/db/fetcher/errors.go
@@ -18,49 +18,42 @@ import (
 )
 
 const (
-	errFieldIdNotFound              string = "unable to find SchemaFieldDescription for given FieldId"
-	errFailedToDecodeCIDForVFetcher string = "failed to decode CID for VersionedFetcher"
-	errFailedToSeek                 string = "seek failed"
-	errFailedToMergeState           string = "failed merging state"
-	errVFetcherFailedToFindBlock    string = "(version fetcher) failed to find block in blockstore"
-	errVFetcherFailedToGetBlock     string = "(version fetcher) failed to get block in blockstore"
-	errVFetcherFailedToWriteBlock   string = "(version fetcher) failed to write block to blockstore"
-	errVFetcherFailedToDecodeNode   string = "(version fetcher) failed to decode protobuf"
-	errVFetcherFailedToGetDagLink   string = "(version fetcher) failed to get node link from DAG"
-	errFailedToGetDagNode           string = "failed to get DAG Node"
-	errMissingMapper                string = "missing document mapper"
-	errInvalidInOperatorValue       string = "invalid _in/_nin value"
-	errInvalidFilterOperator        string = "invalid filter operator is provided"
-	errNotSupportedKindByIndex      string = "kind is not supported by index"
-	errUnexpectedTypeValue          string = "unexpected type value"
+	errFieldIdNotFound            string = "unable to find SchemaFieldDescription for given FieldId"
+	errFailedToSeek               string = "seek failed"
+	errFailedToMergeState         string = "failed merging state"
+	errVFetcherFailedToFindBlock  string = "(version fetcher) failed to find block in blockstore"
+	errVFetcherFailedToGetBlock   string = "(version fetcher) failed to get block in blockstore"
+	errVFetcherFailedToWriteBlock string = "(version fetcher) failed to write block to blockstore"
+	errVFetcherFailedToDecodeNode string = "(version fetcher) failed to decode protobuf"
+	errVFetcherFailedToGetDagLink string = "(version fetcher) failed to get node link from DAG"
+	errFailedToGetDagNode         string = "failed to get DAG Node"
+	errMissingMapper              string = "missing document mapper"
+	errInvalidInOperatorValue     string = "invalid _in/_nin value"
+	errInvalidFilterOperator      string = "invalid filter operator is provided"
+	errNotSupportedKindByIndex    string = "kind is not supported by index"
+	errUnexpectedTypeValue        string = "unexpected type value"
 )
 
 var (
-	ErrFieldIdNotFound              = errors.New(errFieldIdNotFound)
-	ErrFailedToDecodeCIDForVFetcher = errors.New(errFailedToDecodeCIDForVFetcher)
-	ErrFailedToSeek                 = errors.New(errFailedToSeek)
-	ErrFailedToMergeState           = errors.New(errFailedToMergeState)
-	ErrVFetcherFailedToFindBlock    = errors.New(errVFetcherFailedToFindBlock)
-	ErrVFetcherFailedToGetBlock     = errors.New(errVFetcherFailedToGetBlock)
-	ErrVFetcherFailedToWriteBlock   = errors.New(errVFetcherFailedToWriteBlock)
-	ErrVFetcherFailedToDecodeNode   = errors.New(errVFetcherFailedToDecodeNode)
-	ErrVFetcherFailedToGetDagLink   = errors.New(errVFetcherFailedToGetDagLink)
-	ErrFailedToGetDagNode           = errors.New(errFailedToGetDagNode)
-	ErrMissingMapper                = errors.New(errMissingMapper)
-	ErrSingleSpanOnly               = errors.New("spans must contain only a single entry")
-	ErrInvalidInOperatorValue       = errors.New(errInvalidInOperatorValue)
-	ErrInvalidFilterOperator        = errors.New(errInvalidFilterOperator)
-	ErrUnexpectedTypeValue          = errors.New(errUnexpectedTypeValue)
+	ErrFieldIdNotFound            = errors.New(errFieldIdNotFound)
+	ErrFailedToSeek               = errors.New(errFailedToSeek)
+	ErrFailedToMergeState         = errors.New(errFailedToMergeState)
+	ErrVFetcherFailedToFindBlock  = errors.New(errVFetcherFailedToFindBlock)
+	ErrVFetcherFailedToGetBlock   = errors.New(errVFetcherFailedToGetBlock)
+	ErrVFetcherFailedToWriteBlock = errors.New(errVFetcherFailedToWriteBlock)
+	ErrVFetcherFailedToDecodeNode = errors.New(errVFetcherFailedToDecodeNode)
+	ErrVFetcherFailedToGetDagLink = errors.New(errVFetcherFailedToGetDagLink)
+	ErrFailedToGetDagNode         = errors.New(errFailedToGetDagNode)
+	ErrMissingMapper              = errors.New(errMissingMapper)
+	ErrSingleSpanOnly             = errors.New("spans must contain only a single entry")
+	ErrInvalidInOperatorValue     = errors.New(errInvalidInOperatorValue)
+	ErrInvalidFilterOperator      = errors.New(errInvalidFilterOperator)
+	ErrUnexpectedTypeValue        = errors.New(errUnexpectedTypeValue)
 )
 
 // NewErrFieldIdNotFound returns an error indicating that the given FieldId was not found.
 func NewErrFieldIdNotFound(fieldId uint32) error {
 	return errors.New(errFieldIdNotFound, errors.NewKV("FieldId", fieldId))
-}
-
-// NewErrFailedToDecodeCIDForVFetcher returns an error indicating that the given CID could not be decoded.
-func NewErrFailedToDecodeCIDForVFetcher(inner error) error {
-	return errors.Wrap(errFailedToDecodeCIDForVFetcher, inner)
 }
 
 // NewErrFailedToSeek returns an error indicating that the given target could not be seeked to.

--- a/internal/db/fetcher/fetcher.go
+++ b/internal/db/fetcher/fetcher.go
@@ -278,11 +278,20 @@ func (df *DocumentFetcher) start(ctx context.Context, spans []core.Span, withDel
 	} else {
 		valueSpans := make([]core.Span, len(spans))
 		for i, span := range spans {
-			// We can only handle value keys, so here we ensure we only read value keys
 			if withDeleted {
-				valueSpans[i] = core.NewSpan(span.Start.WithDeletedFlag(), span.End.WithDeletedFlag())
+				// DocumentFetcher only ever recieves document keys
+				//nolint:forcetypeassert
+				valueSpans[i] = core.NewSpan(
+					span.Start.(keys.DataStoreKey).WithDeletedFlag(),
+					span.End.(keys.DataStoreKey).WithDeletedFlag(),
+				)
 			} else {
-				valueSpans[i] = core.NewSpan(span.Start.WithValueFlag(), span.End.WithValueFlag())
+				// DocumentFetcher only ever recieves document keys
+				//nolint:forcetypeassert
+				valueSpans[i] = core.NewSpan(
+					span.Start.(keys.DataStoreKey).WithValueFlag(),
+					span.End.(keys.DataStoreKey).WithValueFlag(),
+				)
 			}
 		}
 

--- a/internal/db/fetcher/fetcher.go
+++ b/internal/db/fetcher/fetcher.go
@@ -267,7 +267,7 @@ func (df *DocumentFetcher) start(ctx context.Context, spans core.Spans, withDele
 
 	df.deletedDocs = withDeleted
 
-	if !spans.HasValue { // no specified spans so create a prefix scan key for the entire collection
+	if len(spans.Value) == 0 { // no specified spans so create a prefix scan key for the entire collection
 		start := base.MakeDataStoreKeyWithCollectionDescription(df.col.Description())
 		if withDeleted {
 			start = start.WithDeletedFlag()

--- a/internal/db/fetcher/fetcher.go
+++ b/internal/db/fetcher/fetcher.go
@@ -280,9 +280,9 @@ func (df *DocumentFetcher) start(ctx context.Context, spans []core.Span, withDel
 		for i, span := range spans {
 			// We can only handle value keys, so here we ensure we only read value keys
 			if withDeleted {
-				valueSpans[i] = core.NewSpan(span.Start().WithDeletedFlag(), span.End().WithDeletedFlag())
+				valueSpans[i] = core.NewSpan(span.Start.WithDeletedFlag(), span.End.WithDeletedFlag())
 			} else {
-				valueSpans[i] = core.NewSpan(span.Start().WithValueFlag(), span.End().WithValueFlag())
+				valueSpans[i] = core.NewSpan(span.Start.WithValueFlag(), span.End.WithValueFlag())
 			}
 		}
 
@@ -331,7 +331,7 @@ func (df *DocumentFetcher) startNextSpan(ctx context.Context) (bool, error) {
 	}
 
 	span := df.spans[nextSpanIndex]
-	df.kvResultsIter, err = df.kvIter.IteratePrefix(ctx, span.Start().ToDS(), span.End().ToDS())
+	df.kvResultsIter, err = df.kvIter.IteratePrefix(ctx, span.Start.ToDS(), span.End.ToDS())
 	if err != nil {
 		return false, err
 	}

--- a/internal/db/fetcher/fetcher.go
+++ b/internal/db/fetcher/fetcher.go
@@ -267,7 +267,7 @@ func (df *DocumentFetcher) start(ctx context.Context, spans core.Spans, withDele
 
 	df.deletedDocs = withDeleted
 
-	if len(spans.Value) == 0 { // no specified spans so create a prefix scan key for the entire collection
+	if len(spans) == 0 { // no specified spans so create a prefix scan key for the entire collection
 		start := base.MakeDataStoreKeyWithCollectionDescription(df.col.Description())
 		if withDeleted {
 			start = start.WithDeletedFlag()
@@ -276,8 +276,8 @@ func (df *DocumentFetcher) start(ctx context.Context, spans core.Spans, withDele
 		}
 		df.spans = core.NewSpans(core.NewSpan(start, start.PrefixEnd()))
 	} else {
-		valueSpans := make([]core.Span, len(spans.Value))
-		for i, span := range spans.Value {
+		valueSpans := make([]core.Span, len(spans))
+		for i, span := range spans {
 			// We can only handle value keys, so here we ensure we only read value keys
 			if withDeleted {
 				valueSpans[i] = core.NewSpan(span.Start().WithDeletedFlag(), span.End().WithDeletedFlag())
@@ -309,7 +309,7 @@ func (df *DocumentFetcher) start(ctx context.Context, spans core.Spans, withDele
 
 func (df *DocumentFetcher) startNextSpan(ctx context.Context) (bool, error) {
 	nextSpanIndex := df.curSpanIndex + 1
-	if nextSpanIndex >= len(df.spans.Value) {
+	if nextSpanIndex >= len(df.spans) {
 		return false, nil
 	}
 
@@ -330,7 +330,7 @@ func (df *DocumentFetcher) startNextSpan(ctx context.Context) (bool, error) {
 		}
 	}
 
-	span := df.spans.Value[nextSpanIndex]
+	span := df.spans[nextSpanIndex]
 	df.kvResultsIter, err = df.kvIter.IteratePrefix(ctx, span.Start().ToDS(), span.End().ToDS())
 	if err != nil {
 		return false, err

--- a/internal/db/fetcher/indexer.go
+++ b/internal/db/fetcher/indexer.go
@@ -124,9 +124,9 @@ outer:
 	return err
 }
 
-func (f *IndexFetcher) Start(ctx context.Context, spans core.Spans) error {
+func (f *IndexFetcher) Start(ctx context.Context, spans ...core.Span) error {
 	if f.indexIter == nil {
-		return f.docFetcher.Start(ctx, spans)
+		return f.docFetcher.Start(ctx, spans...)
 	}
 	return f.indexIter.Init(ctx, f.txn.Datastore())
 }
@@ -192,8 +192,8 @@ func (f *IndexFetcher) FetchNext(ctx context.Context) (EncodedDocument, ExecInfo
 
 		if len(f.docFields) > 0 {
 			targetKey := base.MakeDataStoreKeyWithCollectionAndDocID(f.col.Description(), string(f.doc.id))
-			spans := core.NewSpans(core.NewSpan(targetKey, targetKey.PrefixEnd()))
-			err := f.docFetcher.Start(ctx, spans)
+			span := core.NewSpan(targetKey, targetKey.PrefixEnd())
+			err := f.docFetcher.Start(ctx, span)
 			if err != nil {
 				return nil, ExecInfo{}, err
 			}

--- a/internal/db/fetcher/mocks/fetcher.go
+++ b/internal/db/fetcher/mocks/fetcher.go
@@ -202,16 +202,23 @@ func (_c *Fetcher_Init_Call) RunAndReturn(run func(context.Context, immutable.Op
 }
 
 // Start provides a mock function with given fields: ctx, spans
-func (_m *Fetcher) Start(ctx context.Context, spans core.Spans) error {
-	ret := _m.Called(ctx, spans)
+func (_m *Fetcher) Start(ctx context.Context, spans ...core.Span) error {
+	_va := make([]interface{}, len(spans))
+	for _i := range spans {
+		_va[_i] = spans[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Start")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, core.Spans) error); ok {
-		r0 = rf(ctx, spans)
+	if rf, ok := ret.Get(0).(func(context.Context, ...core.Span) error); ok {
+		r0 = rf(ctx, spans...)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -226,14 +233,21 @@ type Fetcher_Start_Call struct {
 
 // Start is a helper method to define mock.On call
 //   - ctx context.Context
-//   - spans core.Spans
-func (_e *Fetcher_Expecter) Start(ctx interface{}, spans interface{}) *Fetcher_Start_Call {
-	return &Fetcher_Start_Call{Call: _e.mock.On("Start", ctx, spans)}
+//   - spans ...core.Span
+func (_e *Fetcher_Expecter) Start(ctx interface{}, spans ...interface{}) *Fetcher_Start_Call {
+	return &Fetcher_Start_Call{Call: _e.mock.On("Start",
+		append([]interface{}{ctx}, spans...)...)}
 }
 
-func (_c *Fetcher_Start_Call) Run(run func(ctx context.Context, spans core.Spans)) *Fetcher_Start_Call {
+func (_c *Fetcher_Start_Call) Run(run func(ctx context.Context, spans ...core.Span)) *Fetcher_Start_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(core.Spans))
+		variadicArgs := make([]core.Span, len(args)-1)
+		for i, a := range args[1:] {
+			if a != nil {
+				variadicArgs[i] = a.(core.Span)
+			}
+		}
+		run(args[0].(context.Context), variadicArgs...)
 	})
 	return _c
 }
@@ -243,7 +257,7 @@ func (_c *Fetcher_Start_Call) Return(_a0 error) *Fetcher_Start_Call {
 	return _c
 }
 
-func (_c *Fetcher_Start_Call) RunAndReturn(run func(context.Context, core.Spans) error) *Fetcher_Start_Call {
+func (_c *Fetcher_Start_Call) RunAndReturn(run func(context.Context, ...core.Span) error) *Fetcher_Start_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/db/fetcher/versioned.go
+++ b/internal/db/fetcher/versioned.go
@@ -158,14 +158,14 @@ func (vf *VersionedFetcher) Start(ctx context.Context, spans core.Spans) error {
 		return client.NewErrUninitializeProperty("VersionedFetcher", "CollectionDescription")
 	}
 
-	if len(spans.Value) != 1 {
+	if len(spans) != 1 {
 		return ErrSingleSpanOnly
 	}
 
 	// For the VersionedFetcher, the spans needs to be in the format
 	// Span{Start: DocID, End: CID}
-	dk := spans.Value[0].Start()
-	cidRaw := spans.Value[0].End()
+	dk := spans[0].Start()
+	cidRaw := spans[0].End()
 	if dk.DocID == "" {
 		return client.NewErrUninitializeProperty("Spans", "DocID")
 	} else if cidRaw.DocID == "" { // todo: dont abuse DataStoreKey/Span like this!

--- a/internal/db/fetcher/versioned.go
+++ b/internal/db/fetcher/versioned.go
@@ -164,8 +164,8 @@ func (vf *VersionedFetcher) Start(ctx context.Context, spans ...core.Span) error
 
 	// For the VersionedFetcher, the spans needs to be in the format
 	// Span{Start: DocID, End: CID}
-	dk := spans[0].Start()
-	cidRaw := spans[0].End()
+	dk := spans[0].Start
+	cidRaw := spans[0].End
 	if dk.DocID == "" {
 		return client.NewErrUninitializeProperty("Spans", "DocID")
 	} else if cidRaw.DocID == "" { // todo: dont abuse DataStoreKey/Span like this!

--- a/internal/db/fetcher/versioned.go
+++ b/internal/db/fetcher/versioned.go
@@ -153,7 +153,7 @@ func (vf *VersionedFetcher) Init(
 }
 
 // Start serializes the correct state according to the Key and CID.
-func (vf *VersionedFetcher) Start(ctx context.Context, spans core.Spans) error {
+func (vf *VersionedFetcher) Start(ctx context.Context, spans ...core.Span) error {
 	if vf.col == nil {
 		return client.NewErrUninitializeProperty("VersionedFetcher", "CollectionDescription")
 	}
@@ -188,7 +188,7 @@ func (vf *VersionedFetcher) Start(ctx context.Context, spans core.Spans) error {
 		return NewErrFailedToSeek(c, err)
 	}
 
-	return vf.DocumentFetcher.Start(ctx, core.Spans{})
+	return vf.DocumentFetcher.Start(ctx)
 }
 
 // Rootstore returns the rootstore of the VersionedFetcher.
@@ -217,7 +217,7 @@ func (vf *VersionedFetcher) SeekTo(ctx context.Context, c cid.Cid) error {
 		return err
 	}
 
-	return vf.DocumentFetcher.Start(ctx, core.Spans{})
+	return vf.DocumentFetcher.Start(ctx)
 }
 
 // seekTo seeks to the given CID version by stepping through the CRDT state graph from the beginning
@@ -423,7 +423,7 @@ func (vf *VersionedFetcher) Close() error {
 }
 
 // NewVersionedSpan creates a new VersionedSpan from a DataStoreKey and a version CID.
-func NewVersionedSpan(dsKey keys.DataStoreKey, version cid.Cid) core.Spans {
+func NewVersionedSpan(dsKey keys.DataStoreKey, version cid.Cid) core.Span {
 	// Todo: Dont abuse DataStoreKey for version cid!
-	return core.NewSpans(core.NewSpan(dsKey, keys.DataStoreKey{DocID: version.String()}))
+	return core.NewSpan(dsKey, keys.DataStoreKey{DocID: version.String()})
 }

--- a/internal/db/fetcher_test.go
+++ b/internal/db/fetcher_test.go
@@ -16,13 +16,12 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/sourcenetwork/defradb/internal/core"
 	"github.com/sourcenetwork/defradb/internal/db/fetcher"
 )
 
 func TestFetcherStartWithoutInit(t *testing.T) {
 	ctx := context.Background()
 	df := new(fetcher.DocumentFetcher)
-	err := df.Start(ctx, core.Spans{})
+	err := df.Start(ctx)
 	assert.Error(t, err)
 }

--- a/internal/keys/datastore_doc.go
+++ b/internal/keys/datastore_doc.go
@@ -41,7 +41,7 @@ type DataStoreKey struct {
 	FieldID          string
 }
 
-var _ Key = (*DataStoreKey)(nil)
+var _ Walkable = (*DataStoreKey)(nil)
 
 // Creates a new DataStoreKey from a string as best as it can,
 // splitting the input using '/' as a field deliminator.  It assumes
@@ -167,7 +167,7 @@ func (k DataStoreKey) ToPrimaryDataStoreKey() PrimaryDataStoreKey {
 // PrefixEnd determines the end key given key as a prefix, that is the key that sorts precisely
 // behind all keys starting with prefix: "1" is added to the final byte and the carry propagated.
 // The special cases of nil and KeyMin always returns KeyMax.
-func (k DataStoreKey) PrefixEnd() DataStoreKey {
+func (k DataStoreKey) PrefixEnd() Walkable {
 	newKey := k
 
 	if k.FieldID != "" {

--- a/internal/keys/headstore_doc.go
+++ b/internal/keys/headstore_doc.go
@@ -23,7 +23,7 @@ type HeadStoreKey struct {
 	Cid     cid.Cid
 }
 
-var _ Key = (*HeadStoreKey)(nil)
+var _ Walkable = (*HeadStoreKey)(nil)
 
 // Creates a new HeadStoreKey from a string as best as it can,
 // splitting the input using '/' as a field deliminator.  It assumes
@@ -91,4 +91,23 @@ func (k HeadStoreKey) Bytes() []byte {
 
 func (k HeadStoreKey) ToDS() ds.Key {
 	return ds.NewKey(k.ToString())
+}
+
+func (k HeadStoreKey) PrefixEnd() Walkable {
+	newKey := k
+
+	if k.FieldID != "" {
+		newKey.FieldID = string(bytesPrefixEnd([]byte(k.FieldID)))
+		return newKey
+	}
+	if k.DocID != "" {
+		newKey.DocID = string(bytesPrefixEnd([]byte(k.DocID)))
+		return newKey
+	}
+	if k.Cid.Defined() {
+		newKey.Cid = cid.MustParse(bytesPrefixEnd(k.Cid.Bytes()))
+		return newKey
+	}
+
+	return newKey
 }

--- a/internal/keys/key.go
+++ b/internal/keys/key.go
@@ -20,3 +20,20 @@ type Key interface {
 	Bytes() []byte
 	ToDS() ds.Key
 }
+
+// Walkable represents a key in the database that can be 'walked along'
+// by prefixing the end of the key.
+type Walkable interface {
+	Key
+	PrefixEnd() Walkable
+}
+
+// PrettyPrint returns the human readable version of the given key.
+func PrettyPrint(k Key) string {
+	switch typed := k.(type) {
+	case DataStoreKey:
+		return typed.PrettyPrint()
+	default:
+		return typed.ToString()
+	}
+}

--- a/internal/lens/fetcher.go
+++ b/internal/lens/fetcher.go
@@ -127,8 +127,8 @@ historyLoop:
 	)
 }
 
-func (f *lensedFetcher) Start(ctx context.Context, spans core.Spans) error {
-	return f.source.Start(ctx, spans)
+func (f *lensedFetcher) Start(ctx context.Context, spans ...core.Span) error {
+	return f.source.Start(ctx, spans...)
 }
 
 func (f *lensedFetcher) FetchNext(ctx context.Context) (fetcher.EncodedDocument, fetcher.ExecInfo, error) {

--- a/internal/planner/arbitrary_join.go
+++ b/internal/planner/arbitrary_join.go
@@ -79,7 +79,7 @@ func (n *dataSource) Start() error {
 	return nil
 }
 
-func (n *dataSource) Spans(spans core.Spans) {
+func (n *dataSource) Spans(spans []core.Span) {
 	if n.parentSource != nil {
 		n.parentSource.Spans(spans)
 	}

--- a/internal/planner/average.go
+++ b/internal/planner/average.go
@@ -64,11 +64,11 @@ func (n *averageNode) Init() error {
 	return n.plan.Init()
 }
 
-func (n *averageNode) Kind() string           { return "averageNode" }
-func (n *averageNode) Start() error           { return n.plan.Start() }
-func (n *averageNode) Spans(spans core.Spans) { n.plan.Spans(spans) }
-func (n *averageNode) Close() error           { return n.plan.Close() }
-func (n *averageNode) Source() planNode       { return n.plan }
+func (n *averageNode) Kind() string            { return "averageNode" }
+func (n *averageNode) Start() error            { return n.plan.Start() }
+func (n *averageNode) Spans(spans []core.Span) { n.plan.Spans(spans) }
+func (n *averageNode) Close() error            { return n.plan.Close() }
+func (n *averageNode) Source() planNode        { return n.plan }
 
 func (n *averageNode) Next() (bool, error) {
 	n.execInfo.iterations++

--- a/internal/planner/commit.go
+++ b/internal/planner/commit.go
@@ -67,7 +67,7 @@ func (n *dagScanNode) Kind() string {
 }
 
 func (n *dagScanNode) Init() error {
-	if len(n.spans.Value) == 0 {
+	if len(n.spans) == 0 {
 		if n.commitSelect.DocID.HasValue() {
 			dsKey := keys.DataStoreKey{}.WithDocID(n.commitSelect.DocID.Value())
 
@@ -93,15 +93,13 @@ func (n *dagScanNode) Start() error {
 // If its a CID, set the node CID val
 // if its a DocID, set the node Key val (headset)
 func (n *dagScanNode) Spans(spans core.Spans) {
-	if len(spans.Value) == 0 {
+	if len(spans) == 0 {
 		return
 	}
 
 	// copy the input spans so that we may mutate freely
-	headSetSpans := core.Spans{
-		Value: make([]core.Span, len(spans.Value)),
-	}
-	copy(headSetSpans.Value, spans.Value)
+	headSetSpans := make([]core.Span, len(spans))
+	copy(headSetSpans, spans)
 
 	var fieldID string
 	if n.commitSelect.FieldID.HasValue() {
@@ -110,9 +108,9 @@ func (n *dagScanNode) Spans(spans core.Spans) {
 		fieldID = core.COMPOSITE_NAMESPACE
 	}
 
-	for i, span := range headSetSpans.Value {
+	for i, span := range headSetSpans {
 		if span.Start().FieldID != fieldID {
-			headSetSpans.Value[i] = core.NewSpan(span.Start().WithFieldID(fieldID), keys.DataStoreKey{})
+			headSetSpans[i] = core.NewSpan(span.Start().WithFieldID(fieldID), keys.DataStoreKey{})
 		}
 	}
 
@@ -145,7 +143,7 @@ func (n *dagScanNode) simpleExplain() (map[string]any, error) {
 	// Build the explanation of the spans attribute.
 	spansExplainer := []map[string]any{}
 	// Note: n.headset is `nil` for single commit selection query, so must check for it.
-	for _, span := range n.spans.Value {
+	for _, span := range n.spans {
 		spansExplainer = append(
 			spansExplainer,
 			map[string]any{

--- a/internal/planner/commit.go
+++ b/internal/planner/commit.go
@@ -109,8 +109,8 @@ func (n *dagScanNode) Spans(spans []core.Span) {
 	}
 
 	for i, span := range headSetSpans {
-		if span.Start().FieldID != fieldID {
-			headSetSpans[i] = core.NewSpan(span.Start().WithFieldID(fieldID), keys.DataStoreKey{})
+		if span.Start.FieldID != fieldID {
+			headSetSpans[i] = core.NewSpan(span.Start.WithFieldID(fieldID), keys.DataStoreKey{})
 		}
 	}
 
@@ -147,8 +147,8 @@ func (n *dagScanNode) simpleExplain() (map[string]any, error) {
 		spansExplainer = append(
 			spansExplainer,
 			map[string]any{
-				"start": span.Start().ToString(),
-				"end":   span.End().ToString(),
+				"start": span.Start.ToString(),
+				"end":   span.End.ToString(),
 			},
 		)
 	}

--- a/internal/planner/commit.go
+++ b/internal/planner/commit.go
@@ -36,7 +36,7 @@ type dagScanNode struct {
 	queuedCids []*cid.Cid
 
 	fetcher      fetcher.HeadFetcher
-	spans        core.Spans
+	spans        []core.Span
 	commitSelect *mapper.CommitSelect
 
 	execInfo dagScanExecInfo
@@ -76,7 +76,7 @@ func (n *dagScanNode) Init() error {
 				dsKey = dsKey.WithFieldID(field)
 			}
 
-			n.spans = core.NewSpans(core.NewSpan(dsKey, dsKey.PrefixEnd()))
+			n.spans = []core.Span{core.NewSpan(dsKey, dsKey.PrefixEnd())}
 		}
 	}
 
@@ -92,7 +92,7 @@ func (n *dagScanNode) Start() error {
 // either a CID or a DocID.
 // If its a CID, set the node CID val
 // if its a DocID, set the node Key val (headset)
-func (n *dagScanNode) Spans(spans core.Spans) {
+func (n *dagScanNode) Spans(spans []core.Span) {
 	if len(spans) == 0 {
 		return
 	}

--- a/internal/planner/commit.go
+++ b/internal/planner/commit.go
@@ -99,8 +99,7 @@ func (n *dagScanNode) Spans(spans core.Spans) {
 
 	// copy the input spans so that we may mutate freely
 	headSetSpans := core.Spans{
-		HasValue: spans.HasValue,
-		Value:    make([]core.Span, len(spans.Value)),
+		Value: make([]core.Span, len(spans.Value)),
 	}
 	copy(headSetSpans.Value, spans.Value)
 
@@ -146,16 +145,14 @@ func (n *dagScanNode) simpleExplain() (map[string]any, error) {
 	// Build the explanation of the spans attribute.
 	spansExplainer := []map[string]any{}
 	// Note: n.headset is `nil` for single commit selection query, so must check for it.
-	if n.spans.HasValue {
-		for _, span := range n.spans.Value {
-			spansExplainer = append(
-				spansExplainer,
-				map[string]any{
-					"start": span.Start().ToString(),
-					"end":   span.End().ToString(),
-				},
-			)
-		}
+	for _, span := range n.spans.Value {
+		spansExplainer = append(
+			spansExplainer,
+			map[string]any{
+				"start": span.Start().ToString(),
+				"end":   span.End().ToString(),
+			},
+		)
 	}
 	// Add the built spans attribute, if it was valid.
 	simpleExplainMap[spansLabel] = spansExplainer

--- a/internal/planner/count.go
+++ b/internal/planner/count.go
@@ -62,7 +62,7 @@ func (n *countNode) Init() error {
 
 func (n *countNode) Start() error { return n.plan.Start() }
 
-func (n *countNode) Spans(spans core.Spans) { n.plan.Spans(spans) }
+func (n *countNode) Spans(spans []core.Span) { n.plan.Spans(spans) }
 
 func (n *countNode) Close() error { return n.plan.Close() }
 

--- a/internal/planner/create.go
+++ b/internal/planner/create.go
@@ -56,13 +56,13 @@ func (n *createNode) Kind() string { return "createNode" }
 
 func (n *createNode) Init() error { return nil }
 
-func docIDsToSpans(ids []string, desc client.CollectionDescription) core.Spans {
+func docIDsToSpans(ids []string, desc client.CollectionDescription) []core.Span {
 	spans := make([]core.Span, len(ids))
 	for i, id := range ids {
 		docID := base.MakeDataStoreKeyWithCollectionAndDocID(desc, id)
 		spans[i] = core.NewSpan(docID, docID.PrefixEnd())
 	}
-	return core.NewSpans(spans...)
+	return spans
 }
 
 func documentsToDocIDs(docs ...*client.Document) []string {
@@ -115,7 +115,7 @@ func (n *createNode) Next() (bool, error) {
 	return next, err
 }
 
-func (n *createNode) Spans(spans core.Spans) { /* no-op */ }
+func (n *createNode) Spans(spans []core.Span) { /* no-op */ }
 
 func (n *createNode) Close() error {
 	return n.results.Close()

--- a/internal/planner/delete.go
+++ b/internal/planner/delete.go
@@ -67,7 +67,7 @@ func (n *deleteNode) Next() (bool, error) {
 	return true, nil
 }
 
-func (n *deleteNode) Spans(spans core.Spans) {
+func (n *deleteNode) Spans(spans []core.Span) {
 	n.source.Spans(spans)
 }
 

--- a/internal/planner/group.go
+++ b/internal/planner/group.go
@@ -127,7 +127,7 @@ func (n *groupNode) Start() error {
 	return nil
 }
 
-func (n *groupNode) Spans(spans core.Spans) {
+func (n *groupNode) Spans(spans []core.Span) {
 	for _, dataSource := range n.dataSources {
 		dataSource.Spans(spans)
 	}

--- a/internal/planner/lens.go
+++ b/internal/planner/lens.go
@@ -61,7 +61,7 @@ func (n *lensNode) Start() error {
 	return n.source.Start()
 }
 
-func (n *lensNode) Spans(spans core.Spans) {
+func (n *lensNode) Spans(spans []core.Span) {
 	n.source.Spans(spans)
 }
 

--- a/internal/planner/limit.go
+++ b/internal/planner/limit.go
@@ -59,10 +59,10 @@ func (n *limitNode) Init() error {
 	return n.plan.Init()
 }
 
-func (n *limitNode) Start() error           { return n.plan.Start() }
-func (n *limitNode) Spans(spans core.Spans) { n.plan.Spans(spans) }
-func (n *limitNode) Close() error           { return n.plan.Close() }
-func (n *limitNode) Value() core.Doc        { return n.plan.Value() }
+func (n *limitNode) Start() error            { return n.plan.Start() }
+func (n *limitNode) Spans(spans []core.Span) { n.plan.Spans(spans) }
+func (n *limitNode) Close() error            { return n.plan.Close() }
+func (n *limitNode) Value() core.Doc         { return n.plan.Value() }
 
 func (n *limitNode) Next() (bool, error) {
 	n.execInfo.iterations++

--- a/internal/planner/max.go
+++ b/internal/planner/max.go
@@ -54,13 +54,13 @@ func (p *Planner) Max(
 	}, nil
 }
 
-func (n *maxNode) Kind() string           { return "maxNode" }
-func (n *maxNode) Init() error            { return n.plan.Init() }
-func (n *maxNode) Start() error           { return n.plan.Start() }
-func (n *maxNode) Spans(spans core.Spans) { n.plan.Spans(spans) }
-func (n *maxNode) Close() error           { return n.plan.Close() }
-func (n *maxNode) Source() planNode       { return n.plan }
-func (n *maxNode) SetPlan(p planNode)     { n.plan = p }
+func (n *maxNode) Kind() string            { return "maxNode" }
+func (n *maxNode) Init() error             { return n.plan.Init() }
+func (n *maxNode) Start() error            { return n.plan.Start() }
+func (n *maxNode) Spans(spans []core.Span) { n.plan.Spans(spans) }
+func (n *maxNode) Close() error            { return n.plan.Close() }
+func (n *maxNode) Source() planNode        { return n.plan }
+func (n *maxNode) SetPlan(p planNode)      { n.plan = p }
 
 func (n *maxNode) simpleExplain() (map[string]any, error) {
 	sourceExplanations := make([]map[string]any, len(n.aggregateMapping))

--- a/internal/planner/min.go
+++ b/internal/planner/min.go
@@ -54,13 +54,13 @@ func (p *Planner) Min(
 	}, nil
 }
 
-func (n *minNode) Kind() string           { return "minNode" }
-func (n *minNode) Init() error            { return n.plan.Init() }
-func (n *minNode) Start() error           { return n.plan.Start() }
-func (n *minNode) Spans(spans core.Spans) { n.plan.Spans(spans) }
-func (n *minNode) Close() error           { return n.plan.Close() }
-func (n *minNode) Source() planNode       { return n.plan }
-func (n *minNode) SetPlan(p planNode)     { n.plan = p }
+func (n *minNode) Kind() string            { return "minNode" }
+func (n *minNode) Init() error             { return n.plan.Init() }
+func (n *minNode) Start() error            { return n.plan.Start() }
+func (n *minNode) Spans(spans []core.Span) { n.plan.Spans(spans) }
+func (n *minNode) Close() error            { return n.plan.Close() }
+func (n *minNode) Source() planNode        { return n.plan }
+func (n *minNode) SetPlan(p planNode)      { n.plan = p }
 
 func (n *minNode) simpleExplain() (map[string]any, error) {
 	sourceExplanations := make([]map[string]any, len(n.aggregateMapping))

--- a/internal/planner/multi.go
+++ b/internal/planner/multi.go
@@ -91,7 +91,7 @@ func (p *parallelNode) Start() error {
 	})
 }
 
-func (p *parallelNode) Spans(spans core.Spans) {
+func (p *parallelNode) Spans(spans []core.Span) {
 	_ = p.applyToPlans(func(n planNode) error {
 		n.Spans(spans)
 		return nil
@@ -157,7 +157,7 @@ func (p *parallelNode) nextAppend(index int, plan planNode) (bool, error) {
 	}
 
 	// pass the doc key as a reference through the spans interface
-	spans := core.NewSpans(core.NewSpan(keys.DataStoreKey{DocID: key}, keys.DataStoreKey{}))
+	spans := []core.Span{core.NewSpan(keys.DataStoreKey{DocID: key}, keys.DataStoreKey{})}
 	plan.Spans(spans)
 	err := plan.Init()
 	if err != nil {

--- a/internal/planner/operation.go
+++ b/internal/planner/operation.go
@@ -28,7 +28,7 @@ type operationNode struct {
 	isDone   bool
 }
 
-func (n *operationNode) Spans(spans core.Spans) {
+func (n *operationNode) Spans(spans []core.Span) {
 	for _, child := range n.children {
 		child.Spans(spans)
 	}

--- a/internal/planner/order.go
+++ b/internal/planner/order.go
@@ -98,7 +98,7 @@ func (n *orderNode) Init() error {
 }
 func (n *orderNode) Start() error { return n.plan.Start() }
 
-func (n *orderNode) Spans(spans core.Spans) { n.plan.Spans(spans) }
+func (n *orderNode) Spans(spans []core.Span) { n.plan.Spans(spans) }
 
 func (n *orderNode) Value() core.Doc {
 	return n.valueIter.Value()

--- a/internal/planner/pipe.go
+++ b/internal/planner/pipe.go
@@ -51,10 +51,10 @@ func (n *pipeNode) Init() error {
 	return n.source.Init()
 }
 
-func (n *pipeNode) Start() error           { return n.source.Start() }
-func (n *pipeNode) Spans(spans core.Spans) { n.source.Spans(spans) }
-func (n *pipeNode) Close() error           { return n.source.Close() }
-func (n *pipeNode) Source() planNode       { return n.source }
+func (n *pipeNode) Start() error            { return n.source.Start() }
+func (n *pipeNode) Spans(spans []core.Span) { n.source.Spans(spans) }
+func (n *pipeNode) Close() error            { return n.source.Close() }
+func (n *pipeNode) Source() planNode        { return n.source }
 
 func (n *pipeNode) Next() (bool, error) {
 	// we need to load all docs up until the requested point - this allows us to

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -36,7 +36,7 @@ type planNode interface {
 
 	// Spans sets the planNodes target spans. This is primarily only used for a scanNode,
 	// but based on the tree structure, may need to be propagated Eg. From a selectNode -> scanNode.
-	Spans(core.Spans)
+	Spans([]core.Span)
 
 	// Next processes the next result doc from the request. Can only be called *after* Start().
 	// Can't be called again if any previous call returns false.

--- a/internal/planner/scan.go
+++ b/internal/planner/scan.go
@@ -45,7 +45,7 @@ type scanNode struct {
 
 	showDeleted bool
 
-	spans   core.Spans
+	spans   []core.Span
 	reverse bool
 
 	filter *mapper.Filter
@@ -203,10 +203,10 @@ func (n *scanNode) Start() error {
 func (n *scanNode) initScan() error {
 	if len(n.spans) == 0 {
 		start := base.MakeDataStoreKeyWithCollectionDescription(n.col.Description())
-		n.spans = core.NewSpans(core.NewSpan(start, start.PrefixEnd()))
+		n.spans = []core.Span{core.NewSpan(start, start.PrefixEnd())}
 	}
 
-	err := n.fetcher.Start(n.p.ctx, n.spans)
+	err := n.fetcher.Start(n.p.ctx, n.spans...)
 	if err != nil {
 		return err
 	}
@@ -248,7 +248,7 @@ func (n *scanNode) Next() (bool, error) {
 	return true, nil
 }
 
-func (n *scanNode) Spans(spans core.Spans) {
+func (n *scanNode) Spans(spans []core.Span) {
 	n.spans = spans
 }
 
@@ -419,7 +419,7 @@ func (n *multiScanNode) Value() core.Doc {
 	return n.scanNode.documentIterator.Value()
 }
 
-func (n *multiScanNode) Spans(spans core.Spans) {
+func (n *multiScanNode) Spans(spans []core.Span) {
 	n.scanNode.Spans(spans)
 }
 

--- a/internal/planner/scan.go
+++ b/internal/planner/scan.go
@@ -201,7 +201,7 @@ func (n *scanNode) Start() error {
 }
 
 func (n *scanNode) initScan() error {
-	if len(n.spans.Value) == 0 {
+	if len(n.spans) == 0 {
 		start := base.MakeDataStoreKeyWithCollectionDescription(n.col.Description())
 		n.spans = core.NewSpans(core.NewSpan(start, start.PrefixEnd()))
 	}
@@ -220,7 +220,7 @@ func (n *scanNode) initScan() error {
 func (n *scanNode) Next() (bool, error) {
 	n.execInfo.iterations++
 
-	if len(n.spans.Value) == 0 {
+	if len(n.spans) == 0 {
 		return false, nil
 	}
 
@@ -261,7 +261,7 @@ func (n *scanNode) Source() planNode { return nil }
 // explainSpans explains the spans attribute.
 func (n *scanNode) explainSpans() []map[string]any {
 	spansExplainer := []map[string]any{}
-	for _, span := range n.spans.Value {
+	for _, span := range n.spans {
 		spanExplainer := map[string]any{
 			// These must be pretty printed as the explain results need to be returnable
 			// as json via some clients (e.g. http and cli)

--- a/internal/planner/scan.go
+++ b/internal/planner/scan.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sourcenetwork/defradb/internal/core"
 	"github.com/sourcenetwork/defradb/internal/db/base"
 	"github.com/sourcenetwork/defradb/internal/db/fetcher"
+	"github.com/sourcenetwork/defradb/internal/keys"
 	"github.com/sourcenetwork/defradb/internal/lens"
 	"github.com/sourcenetwork/defradb/internal/planner/filter"
 	"github.com/sourcenetwork/defradb/internal/planner/mapper"
@@ -263,10 +264,8 @@ func (n *scanNode) explainSpans() []map[string]any {
 	spansExplainer := []map[string]any{}
 	for _, span := range n.spans {
 		spanExplainer := map[string]any{
-			// These must be pretty printed as the explain results need to be returnable
-			// as json via some clients (e.g. http and cli)
-			"start": span.Start.PrettyPrint(),
-			"end":   span.End.PrettyPrint(),
+			"start": keys.PrettyPrint(span.Start),
+			"end":   keys.PrettyPrint(span.End),
 		}
 
 		spansExplainer = append(spansExplainer, spanExplainer)

--- a/internal/planner/scan.go
+++ b/internal/planner/scan.go
@@ -265,8 +265,8 @@ func (n *scanNode) explainSpans() []map[string]any {
 		spanExplainer := map[string]any{
 			// These must be pretty printed as the explain results need to be returnable
 			// as json via some clients (e.g. http and cli)
-			"start": span.Start().PrettyPrint(),
-			"end":   span.End().PrettyPrint(),
+			"start": span.Start.PrettyPrint(),
+			"end":   span.End.PrettyPrint(),
 		}
 
 		spansExplainer = append(spansExplainer, spanExplainer)

--- a/internal/planner/scan.go
+++ b/internal/planner/scan.go
@@ -201,7 +201,7 @@ func (n *scanNode) Start() error {
 }
 
 func (n *scanNode) initScan() error {
-	if !n.spans.HasValue {
+	if len(n.spans.Value) == 0 {
 		start := base.MakeDataStoreKeyWithCollectionDescription(n.col.Description())
 		n.spans = core.NewSpans(core.NewSpan(start, start.PrefixEnd()))
 	}
@@ -220,7 +220,7 @@ func (n *scanNode) initScan() error {
 func (n *scanNode) Next() (bool, error) {
 	n.execInfo.iterations++
 
-	if n.spans.HasValue && len(n.spans.Value) == 0 {
+	if len(n.spans.Value) == 0 {
 		return false, nil
 	}
 

--- a/internal/planner/select.go
+++ b/internal/planner/select.go
@@ -70,7 +70,7 @@ func (n *selectTopNode) Start() error { return n.planNode.Start() }
 
 func (n *selectTopNode) Next() (bool, error) { return n.planNode.Next() }
 
-func (n *selectTopNode) Spans(spans core.Spans) { n.planNode.Spans(spans) }
+func (n *selectTopNode) Spans(spans []core.Span) { n.planNode.Spans(spans) }
 
 func (n *selectTopNode) Value() core.Doc { return n.planNode.Value() }
 
@@ -182,7 +182,7 @@ func (n *selectNode) Next() (bool, error) {
 	}
 }
 
-func (n *selectNode) Spans(spans core.Spans) {
+func (n *selectNode) Spans(spans []core.Span) {
 	n.source.Spans(spans)
 }
 
@@ -264,11 +264,11 @@ func (n *selectNode) initSource() ([]aggregateNode, error) {
 			if err != nil {
 				return nil, err
 			}
-			spans := fetcher.NewVersionedSpan(
+			span := fetcher.NewVersionedSpan(
 				keys.DataStoreKey{DocID: n.selectReq.DocIDs.Value()[0]},
 				c,
 			) // @todo check len
-			origScan.Spans(spans)
+			origScan.Spans([]core.Span{span})
 		} else if n.selectReq.DocIDs.HasValue() {
 			// If we *just* have a DocID(s), run a FindByDocID(s) optimization
 			// if we have a FindByDocID filter, create a span for it
@@ -281,7 +281,7 @@ func (n *selectNode) initSource() ([]aggregateNode, error) {
 				docIDIndexKey := base.MakeDataStoreKeyWithCollectionAndDocID(sourcePlan.collection.Description(), docID)
 				spans[i] = core.NewSpan(docIDIndexKey, docIDIndexKey.PrefixEnd())
 			}
-			origScan.Spans(core.NewSpans(spans...))
+			origScan.Spans(spans)
 		}
 	}
 

--- a/internal/planner/select.go
+++ b/internal/planner/select.go
@@ -18,7 +18,6 @@ import (
 	"github.com/sourcenetwork/defradb/client/request"
 	"github.com/sourcenetwork/defradb/internal/core"
 	"github.com/sourcenetwork/defradb/internal/db/base"
-	"github.com/sourcenetwork/defradb/internal/db/fetcher"
 	"github.com/sourcenetwork/defradb/internal/keys"
 	"github.com/sourcenetwork/defradb/internal/planner/mapper"
 )
@@ -264,11 +263,17 @@ func (n *selectNode) initSource() ([]aggregateNode, error) {
 			if err != nil {
 				return nil, err
 			}
-			span := fetcher.NewVersionedSpan(
-				keys.DataStoreKey{DocID: n.selectReq.DocIDs.Value()[0]},
-				c,
-			) // @todo check len
-			origScan.Spans([]core.Span{span})
+			origScan.Spans(
+				[]core.Span{
+					core.NewSpan(
+						keys.HeadStoreKey{
+							DocID: n.selectReq.DocIDs.Value()[0],
+							Cid:   c,
+						},
+						keys.HeadStoreKey{},
+					),
+				},
+			)
 		} else if n.selectReq.DocIDs.HasValue() {
 			// If we *just* have a DocID(s), run a FindByDocID(s) optimization
 			// if we have a FindByDocID filter, create a span for it

--- a/internal/planner/sum.go
+++ b/internal/planner/sum.go
@@ -149,7 +149,7 @@ func (n *sumNode) Init() error {
 
 func (n *sumNode) Start() error { return n.plan.Start() }
 
-func (n *sumNode) Spans(spans core.Spans) { n.plan.Spans(spans) }
+func (n *sumNode) Spans(spans []core.Span) { n.plan.Spans(spans) }
 
 func (n *sumNode) Close() error { return n.plan.Close() }
 

--- a/internal/planner/top.go
+++ b/internal/planner/top.go
@@ -35,7 +35,7 @@ type topLevelNode struct {
 	isInRecurse bool
 }
 
-func (n *topLevelNode) Spans(spans core.Spans) {
+func (n *topLevelNode) Spans(spans []core.Span) {
 	if n.isInRecurse {
 		return
 	}

--- a/internal/planner/type_join.go
+++ b/internal/planner/type_join.go
@@ -114,7 +114,7 @@ func (n *typeIndexJoin) Start() error {
 	return n.joinPlan.Start()
 }
 
-func (n *typeIndexJoin) Spans(spans core.Spans) {
+func (n *typeIndexJoin) Spans(spans []core.Span) {
 	n.joinPlan.Spans(spans)
 }
 
@@ -444,7 +444,7 @@ func fetchDocWithID(node planNode, docID string) (bool, error) {
 	}
 	dsKey := base.MakeDataStoreKeyWithCollectionAndDocID(scan.col.Description(), docID)
 
-	spans := core.NewSpans(core.NewSpan(dsKey, dsKey.PrefixEnd()))
+	spans := []core.Span{core.NewSpan(dsKey, dsKey.PrefixEnd())}
 
 	node.Spans(spans)
 
@@ -502,7 +502,7 @@ func (join *invertibleTypeJoin) Close() error {
 	return join.childSide.plan.Close()
 }
 
-func (join *invertibleTypeJoin) Spans(spans core.Spans) {
+func (join *invertibleTypeJoin) Spans(spans []core.Span) {
 	join.parentSide.plan.Spans(spans)
 }
 

--- a/internal/planner/update.go
+++ b/internal/planner/update.go
@@ -107,7 +107,7 @@ func (n *updateNode) Next() (bool, error) {
 
 func (n *updateNode) Kind() string { return "updateNode" }
 
-func (n *updateNode) Spans(spans core.Spans) { n.results.Spans(spans) }
+func (n *updateNode) Spans(spans []core.Span) { n.results.Spans(spans) }
 
 func (n *updateNode) Init() error { return n.results.Init() }
 

--- a/internal/planner/upsert.go
+++ b/internal/planner/upsert.go
@@ -96,7 +96,7 @@ func (n *upsertNode) Kind() string {
 	return "upsertNode"
 }
 
-func (n *upsertNode) Spans(spans core.Spans) {
+func (n *upsertNode) Spans(spans []core.Span) {
 	n.source.Spans(spans)
 }
 

--- a/internal/planner/values.go
+++ b/internal/planner/values.go
@@ -46,9 +46,9 @@ func (p *Planner) newContainerValuesNode(ordering []mapper.OrderCondition) *valu
 	}
 }
 
-func (n *valuesNode) Init() error            { return nil }
-func (n *valuesNode) Start() error           { return nil }
-func (n *valuesNode) Spans(spans core.Spans) {}
+func (n *valuesNode) Init() error             { return nil }
+func (n *valuesNode) Start() error            { return nil }
+func (n *valuesNode) Spans(spans []core.Span) {}
 
 func (n *valuesNode) Kind() string {
 	return "valuesNode"

--- a/internal/planner/view.go
+++ b/internal/planner/view.go
@@ -74,7 +74,7 @@ func (n *viewNode) Start() error {
 	return n.source.Start()
 }
 
-func (n *viewNode) Spans(spans core.Spans) {
+func (n *viewNode) Spans(spans []core.Span) {
 	n.source.Spans(spans)
 }
 
@@ -217,7 +217,7 @@ func (n *cachedViewFetcher) Start() error {
 	return nil
 }
 
-func (n *cachedViewFetcher) Spans(spans core.Spans) {
+func (n *cachedViewFetcher) Spans(spans []core.Span) {
 	// no-op
 }
 

--- a/tests/integration/explain/default/delete_test.go
+++ b/tests/integration/explain/default/delete_test.go
@@ -292,7 +292,12 @@ func TestDefaultExplainMutationRequestWithDeleteUsingNoIds(t *testing.T) {
 							"collectionID":   "3",
 							"collectionName": "Author",
 							"filter":         nil,
-							"spans":          []dataMap{},
+							"spans": []dataMap{
+								{
+									"end":   "/4",
+									"start": "/3",
+								},
+							},
 						},
 					},
 				},


### PR DESCRIPTION
## Relevant issue(s)

Resolves #3209

## Description

Simplifies core.Spans a little bit, before removing some old hacky code allowing a nicer way of handling headstore keys within the planner/fetcher system.

Is probably easier to review this commit by commit, the changes are documented by the commit messages.