### PR TITLE
feat: Add support for branchable collections

### DIFF
--- a/client/collection_description.go
+++ b/client/collection_description.go
@@ -89,7 +89,7 @@ type CollectionDescription struct {
 	// another collection/query (is a View).
 	IsMaterialized bool
 
-	// IsMaterialized defines whether the history of this collection is tracked as a single,
+	// IsBranchable defines whether the history of this collection is tracked as a single,
 	// verifiable entity.
 	//
 	// If set to `true` any change to the contents of this set will be linked to a collection

--- a/client/collection_description.go
+++ b/client/collection_description.go
@@ -88,6 +88,21 @@ type CollectionDescription struct {
 	// At the moment this can only be set to `false` if this collection sources its data from
 	// another collection/query (is a View).
 	IsMaterialized bool
+
+	// IsMaterialized defines whether the history of this collection is tracked as a single,
+	// verifiable entity.
+	//
+	// If set to `true` any change to the contents of this set will be linked to a collection
+	// level commit via the document(s) composite commit.
+	//
+	// This enables multiple nodes to verify that they have the same state/history.
+	//
+	// The history may be queried like a document history can be queried, for example via 'commits'
+	// GQL queries.
+	//
+	// Currently this property is immutable and can only be set on collection creation, however
+	// that will change in the future.
+	IsBranchable bool
 }
 
 // QuerySource represents a collection data source from a query.
@@ -189,6 +204,7 @@ type collectionDescription struct {
 	RootID          uint32
 	SchemaVersionID string
 	IsMaterialized  bool
+	IsBranchable    bool
 	Policy          immutable.Option[PolicyDescription]
 	Indexes         []IndexDescription
 	Fields          []CollectionFieldDescription
@@ -209,6 +225,7 @@ func (c *CollectionDescription) UnmarshalJSON(bytes []byte) error {
 	c.RootID = descMap.RootID
 	c.SchemaVersionID = descMap.SchemaVersionID
 	c.IsMaterialized = descMap.IsMaterialized
+	c.IsBranchable = descMap.IsBranchable
 	c.Indexes = descMap.Indexes
 	c.Fields = descMap.Fields
 	c.Sources = make([]any, len(descMap.Sources))

--- a/docs/data_format_changes/i3038-branchable-collections.md
+++ b/docs/data_format_changes/i3038-branchable-collections.md
@@ -1,0 +1,3 @@
+# Add support for branchable collections
+
+The existing keys in the headstore gained a '/d' prefix in order to accommodate new types of keys within the headstore.

--- a/docs/website/references/http/openapi.json
+++ b/docs/website/references/http/openapi.json
@@ -195,6 +195,9 @@
                         },
                         "type": "array"
                     },
+                    "IsBranchable": {
+                        "type": "boolean"
+                    },
                     "IsMaterialized": {
                         "type": "boolean"
                     },
@@ -275,6 +278,9 @@
                                     "type": "object"
                                 },
                                 "type": "array"
+                            },
+                            "IsBranchable": {
+                                "type": "boolean"
                             },
                             "IsMaterialized": {
                                 "type": "boolean"

--- a/internal/core/block/block.go
+++ b/internal/core/block/block.go
@@ -44,6 +44,7 @@ func init() {
 		&crdt.LWWRegDelta{},
 		&crdt.CompositeDAGDelta{},
 		&crdt.CounterDelta{},
+		&crdt.CollectionDelta{},
 	)
 
 	EncryptionSchema, EncryptionSchemaPrototype = mustSetSchema(

--- a/internal/core/crdt/collection.go
+++ b/internal/core/crdt/collection.go
@@ -13,7 +13,6 @@ package crdt
 import (
 	"context"
 
-	"github.com/sourcenetwork/defradb/datastore"
 	"github.com/sourcenetwork/defradb/internal/core"
 	"github.com/sourcenetwork/defradb/internal/keys"
 )
@@ -22,8 +21,6 @@ import (
 // collection in a similar way to a document composite commit, only simpler,
 // without the need to track status and a simpler [Merge] function.
 type Collection struct {
-	store datastore.DSReaderWriter
-
 	// schemaVersionKey is the schema version datastore key at the time of commit.
 	//
 	// It can be used to identify the collection datastructure state at the time of commit.
@@ -32,9 +29,8 @@ type Collection struct {
 
 var _ core.ReplicatedData = (*Collection)(nil)
 
-func NewCollection(store datastore.DSReaderWriter, schemaVersionKey keys.CollectionSchemaVersionKey) *Collection {
+func NewCollection(schemaVersionKey keys.CollectionSchemaVersionKey) *Collection {
 	return &Collection{
-		store:            store,
 		schemaVersionKey: schemaVersionKey,
 	}
 }

--- a/internal/core/crdt/collection.go
+++ b/internal/core/crdt/collection.go
@@ -1,0 +1,78 @@
+// Copyright 2024 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package crdt
+
+import (
+	"context"
+
+	"github.com/sourcenetwork/defradb/datastore"
+	"github.com/sourcenetwork/defradb/internal/core"
+	"github.com/sourcenetwork/defradb/internal/keys"
+)
+
+// Collection is a simple CRDT type that tracks changes to the contents of a
+// collection in a similar way to a document composite commit.
+type Collection struct {
+	store datastore.DSReaderWriter
+
+	// schemaVersionKey is the schema version datastore key at the time of commit.
+	//
+	// It can be used to identify the collection datastructure state at the time of commit.
+	schemaVersionKey keys.CollectionSchemaVersionKey
+}
+
+var _ core.ReplicatedData = (*Collection)(nil)
+
+func NewCollection(store datastore.DSReaderWriter, schemaVersionKey keys.CollectionSchemaVersionKey) *Collection {
+	return &Collection{
+		store:            store,
+		schemaVersionKey: schemaVersionKey,
+	}
+}
+
+func (c *Collection) Merge(ctx context.Context, other core.Delta) error {
+	// Collection merges don't actually need to do anything, as the delta is empty,
+	// and doc-level merges are handled by the document commits.
+	return nil
+}
+
+func (c *Collection) Append() *CollectionDelta {
+	return &CollectionDelta{
+		SchemaVersionID: c.schemaVersionKey.SchemaVersionID,
+	}
+}
+
+type CollectionDelta struct {
+	Priority uint64
+
+	// As we do not yet have a global collection id we temporarily rely on the schema
+	// version id for tracking which collection this belongs to.  See:
+	// https://github.com/sourcenetwork/defradb/issues/3215
+	SchemaVersionID string
+}
+
+var _ core.Delta = (*CollectionDelta)(nil)
+
+func (delta *CollectionDelta) IPLDSchemaBytes() []byte {
+	return []byte(`
+	type CollectionDelta struct {
+		priority  		Int
+		schemaVersionID String
+	}`)
+}
+
+func (d *CollectionDelta) GetPriority() uint64 {
+	return d.Priority
+}
+
+func (d *CollectionDelta) SetPriority(priority uint64) {
+	d.Priority = priority
+}

--- a/internal/core/crdt/collection.go
+++ b/internal/core/crdt/collection.go
@@ -19,7 +19,8 @@ import (
 )
 
 // Collection is a simple CRDT type that tracks changes to the contents of a
-// collection in a similar way to a document composite commit.
+// collection in a similar way to a document composite commit, only simpler,
+// without the need to track status and a simpler [Merge] function.
 type Collection struct {
 	store datastore.DSReaderWriter
 

--- a/internal/core/crdt/collection.go
+++ b/internal/core/crdt/collection.go
@@ -41,7 +41,7 @@ func (c *Collection) Merge(ctx context.Context, other core.Delta) error {
 	return nil
 }
 
-func (c *Collection) Append() *CollectionDelta {
+func (c *Collection) NewDelta() *CollectionDelta {
 	return &CollectionDelta{
 		SchemaVersionID: c.schemaVersionKey.SchemaVersionID,
 	}

--- a/internal/core/crdt/composite.go
+++ b/internal/core/crdt/composite.go
@@ -101,7 +101,7 @@ func NewCompositeDAG(
 }
 
 // Set returns a new composite DAG delta CRDT with the given status.
-func (c CompositeDAG) Append(status client.DocumentStatus) *CompositeDAGDelta {
+func (c CompositeDAG) NewDelta(status client.DocumentStatus) *CompositeDAGDelta {
 	return &CompositeDAGDelta{
 		DocID:           []byte(c.key.DocID),
 		SchemaVersionID: c.schemaVersionKey.SchemaVersionID,

--- a/internal/core/crdt/composite.go
+++ b/internal/core/crdt/composite.go
@@ -101,7 +101,7 @@ func NewCompositeDAG(
 }
 
 // Set returns a new composite DAG delta CRDT with the given status.
-func (c CompositeDAG) Set(status client.DocumentStatus) *CompositeDAGDelta {
+func (c CompositeDAG) Append(status client.DocumentStatus) *CompositeDAGDelta {
 	return &CompositeDAGDelta{
 		DocID:           []byte(c.key.DocID),
 		SchemaVersionID: c.schemaVersionKey.SchemaVersionID,

--- a/internal/core/crdt/ipld_union.go
+++ b/internal/core/crdt/ipld_union.go
@@ -17,6 +17,7 @@ type CRDT struct {
 	LWWRegDelta       *LWWRegDelta
 	CompositeDAGDelta *CompositeDAGDelta
 	CounterDelta      *CounterDelta
+	CollectionDelta   *CollectionDelta
 }
 
 // NewCRDT returns a new CRDT.
@@ -28,6 +29,8 @@ func NewCRDT(delta core.Delta) CRDT {
 		return CRDT{CompositeDAGDelta: d}
 	case *CounterDelta:
 		return CRDT{CounterDelta: d}
+	case *CollectionDelta:
+		return CRDT{CollectionDelta: d}
 	}
 	return CRDT{}
 }
@@ -41,6 +44,7 @@ func (c CRDT) IPLDSchemaBytes() []byte {
 		| LWWRegDelta "lww"
 		| CompositeDAGDelta "composite"
 		| CounterDelta "counter"
+		| CollectionDelta "collection"
 	} representation keyed`)
 }
 
@@ -53,6 +57,8 @@ func (c CRDT) GetDelta() core.Delta {
 		return c.CompositeDAGDelta
 	case c.CounterDelta != nil:
 		return c.CounterDelta
+	case c.CollectionDelta != nil:
+		return c.CollectionDelta
 	}
 	return nil
 }
@@ -66,6 +72,8 @@ func (c CRDT) GetPriority() uint64 {
 		return c.CompositeDAGDelta.GetPriority()
 	case c.CounterDelta != nil:
 		return c.CounterDelta.GetPriority()
+	case c.CollectionDelta != nil:
+		return c.CollectionDelta.GetPriority()
 	}
 	return 0
 }
@@ -90,6 +98,8 @@ func (c CRDT) GetDocID() []byte {
 		return c.CompositeDAGDelta.DocID
 	case c.CounterDelta != nil:
 		return c.CounterDelta.DocID
+	case c.CollectionDelta != nil:
+		return nil
 	}
 	return nil
 }
@@ -103,6 +113,8 @@ func (c CRDT) GetSchemaVersionID() string {
 		return c.CompositeDAGDelta.SchemaVersionID
 	case c.CounterDelta != nil:
 		return c.CounterDelta.SchemaVersionID
+	case c.CollectionDelta != nil:
+		return c.CollectionDelta.SchemaVersionID
 	}
 	return ""
 }
@@ -134,6 +146,11 @@ func (c CRDT) Clone() CRDT {
 			SchemaVersionID: c.CounterDelta.SchemaVersionID,
 			Nonce:           c.CounterDelta.Nonce,
 			Data:            c.CounterDelta.Data,
+		}
+	case c.CollectionDelta != nil:
+		cloned.CollectionDelta = &CollectionDelta{
+			Priority:        c.CollectionDelta.Priority,
+			SchemaVersionID: c.CollectionDelta.SchemaVersionID,
 		}
 	}
 	return cloned
@@ -171,4 +188,9 @@ func (c CRDT) SetData(data []byte) {
 // IsComposite returns true if the CRDT is a composite CRDT.
 func (c CRDT) IsComposite() bool {
 	return c.CompositeDAGDelta != nil
+}
+
+// IsCollection returns true if the CRDT is a collection CRDT.
+func (c CRDT) IsCollection() bool {
+	return c.CollectionDelta != nil
 }

--- a/internal/db/definition_validation.go
+++ b/internal/db/definition_validation.go
@@ -1040,6 +1040,7 @@ func validateCollectionFieldDefaultValue(
 
 // validateCollectionIsBranchableNotMutated is a temporary restriction that prevents users from toggling
 // whether or not a collection is branchable.
+// https://github.com/sourcenetwork/defradb/issues/3219
 func validateCollectionIsBranchableNotMutated(
 	ctx context.Context,
 	db *db,

--- a/internal/db/definition_validation.go
+++ b/internal/db/definition_validation.go
@@ -146,6 +146,7 @@ var collectionUpdateValidators = append(
 		validateIDExists,
 		validateSchemaVersionIDNotMutated,
 		validateCollectionNotRemoved,
+		validateCollectionIsBranchableNotMutated,
 	),
 	globalValidators...,
 )
@@ -1031,6 +1032,25 @@ func validateCollectionFieldDefaultValue(
 		_, err := client.NewDocFromMap(map[string]any{}, col)
 		if err != nil {
 			return NewErrDefaultFieldValueInvalid(name, err)
+		}
+	}
+
+	return nil
+}
+
+// validateCollectionIsBranchableNotMutated is a temporary restriction that prevents users from toggling
+// whether or not a collection is branchable.
+func validateCollectionIsBranchableNotMutated(
+	ctx context.Context,
+	db *db,
+	newState *definitionState,
+	oldState *definitionState,
+) error {
+	for _, newCol := range newState.collections {
+		oldCol := oldState.collectionsByID[newCol.ID]
+
+		if newCol.IsBranchable != oldCol.IsBranchable {
+			return NewErrColMutatingIsBranchable(newCol.Name.Value())
 		}
 	}
 

--- a/internal/db/errors.go
+++ b/internal/db/errors.go
@@ -104,6 +104,7 @@ const (
 	errFailedToHandleEncKeysReceivedEvent       string = "failed to handle encryption-keys-received event"
 	errSelfReferenceWithoutSelf                 string = "must specify 'Self' kind for self referencing relations"
 	errColNotMaterialized                       string = "non-materialized collections are not supported"
+	errColMutatingIsBranchable                  string = "mutating IsBranchable is not supported"
 	errMaterializedViewAndACPNotSupported       string = "materialized views do not support ACP"
 	errInvalidDefaultFieldValue                 string = "default field value is invalid"
 	errDocIDNotFound                            string = "docID not found"
@@ -156,6 +157,7 @@ var (
 	ErrTimeoutDocRetry                          = errors.New("timeout while retrying doc")
 	ErrDocIDNotFound                            = errors.New(errDocIDNotFound)
 	ErrorCollectionWithSchemaRootNotFound       = errors.New(errCollectionWithSchemaRootNotFound)
+	ErrColMutatingIsBranchable                  = errors.New(errColMutatingIsBranchable)
 )
 
 // NewErrFailedToGetHeads returns a new error indicating that the heads of a document
@@ -676,6 +678,13 @@ func NewErrSelfReferenceWithoutSelf(fieldName string) error {
 func NewErrColNotMaterialized(collection string) error {
 	return errors.New(
 		errColNotMaterialized,
+		errors.NewKV("Collection", collection),
+	)
+}
+
+func NewErrColMutatingIsBranchable(collection string) error {
+	return errors.New(
+		errColMutatingIsBranchable,
 		errors.NewKV("Collection", collection),
 	)
 }

--- a/internal/db/fetcher/dag.go
+++ b/internal/db/fetcher/dag.go
@@ -28,6 +28,12 @@ type HeadFetcher struct {
 	kvIter dsq.Results
 }
 
+// Start starts/initializes the fetcher, performing all the work it can do outside
+// of the main iteration loop/funcs.
+//
+// prefix - Optional. The headstore prefix to scan across.  If None, the entire
+// headstore will be scanned - for example, in order to fetch document and collection
+// heads.
 func (hf *HeadFetcher) Start(
 	ctx context.Context,
 	txn datastore.Txn,

--- a/internal/db/fetcher/dag.go
+++ b/internal/db/fetcher/dag.go
@@ -31,7 +31,7 @@ type HeadFetcher struct {
 func (hf *HeadFetcher) Start(
 	ctx context.Context,
 	txn datastore.Txn,
-	prefix keys.HeadStoreKey,
+	prefix keys.HeadstoreDocKey,
 	fieldId immutable.Option[string],
 ) error {
 	hf.fieldId = fieldId
@@ -64,7 +64,7 @@ func (hf *HeadFetcher) FetchNext() (*cid.Cid, error) {
 		return nil, nil
 	}
 
-	headStoreKey, err := keys.NewHeadStoreKey(res.Key)
+	headStoreKey, err := keys.NewHeadstoreDocKey(res.Key)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/db/fetcher/versioned.go
+++ b/internal/db/fetcher/versioned.go
@@ -163,7 +163,7 @@ func (vf *VersionedFetcher) Start(ctx context.Context, spans ...core.Span) error
 
 	// VersionedFetcher only ever recieves a headstore key
 	//nolint:forcetypeassert
-	prefix := spans[0].Start.(keys.HeadStoreKey)
+	prefix := spans[0].Start.(keys.HeadstoreDocKey)
 	dk := prefix.DocID
 	cid := prefix.Cid
 	if dk == "" {

--- a/internal/db/iterator.go
+++ b/internal/db/iterator.go
@@ -40,7 +40,7 @@ func NewHeadBlocksIterator(
 	blockstore datastore.Blockstore,
 	docID string,
 ) (*DocHeadBlocksIterator, error) {
-	headStoreKey := keys.HeadStoreKey{
+	headStoreKey := keys.HeadstoreDocKey{
 		DocID:   docID,
 		FieldID: core.COMPOSITE_NAMESPACE,
 	}

--- a/internal/db/merge.go
+++ b/internal/db/merge.go
@@ -418,7 +418,7 @@ func decryptBlock(
 ) (*coreblock.Block, error) {
 	_, encryptor := encryption.EnsureContextWithEncryptor(ctx)
 
-	if block.Delta.IsComposite() {
+	if block.Delta.IsComposite() || block.Delta.IsCollection() {
 		// for composite blocks there is nothing to decrypt
 		return block, nil
 	}

--- a/internal/keys/datastore_doc.go
+++ b/internal/keys/datastore_doc.go
@@ -112,8 +112,8 @@ func (k DataStoreKey) WithFieldID(fieldID string) DataStoreKey {
 	return newKey
 }
 
-func (k DataStoreKey) ToHeadStoreKey() HeadStoreKey {
-	return HeadStoreKey{
+func (k DataStoreKey) ToHeadStoreKey() HeadstoreDocKey {
+	return HeadstoreDocKey{
 		DocID:   k.DocID,
 		FieldID: k.FieldID,
 	}

--- a/internal/keys/headstore.go
+++ b/internal/keys/headstore.go
@@ -10,6 +10,38 @@
 
 package keys
 
+import (
+	"strings"
+
+	"github.com/ipfs/go-cid"
+)
+
 const (
 	HEADSTORE_DOC = "/d"
+	HEADSTORE_COL = "/c"
 )
+
+// HeadstoreKey represents any key that may be stored in the headstore.
+type HeadstoreKey interface {
+	Walkable
+
+	// GetCid returns the cid that forms part of this key.
+	GetCid() cid.Cid
+
+	// WithCid returns a new HeadstoreKey with the same values as the original,
+	// apart from the cid which will have been replaced by the given value.
+	WithCid(c cid.Cid) HeadstoreKey
+}
+
+// NewHeadstoreKey returns the typed representation of the given key string, or
+// an [ErrInvalidKey] error if it's type could not be determined.
+func NewHeadstoreKey(key string) (HeadstoreKey, error) {
+	switch {
+	case strings.HasPrefix(key, HEADSTORE_DOC):
+		return NewHeadstoreDocKey(key)
+	case strings.HasPrefix(key, HEADSTORE_COL):
+		return NewHeadstoreColKeyFromString(key)
+	default:
+		return nil, ErrInvalidKey
+	}
+}

--- a/internal/keys/headstore.go
+++ b/internal/keys/headstore.go
@@ -1,0 +1,15 @@
+// Copyright 2024 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package keys
+
+const (
+	HEADSTORE_DOC = "/d"
+)

--- a/internal/keys/headstore_collection.go
+++ b/internal/keys/headstore_collection.go
@@ -1,0 +1,109 @@
+// Copyright 2024 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package keys
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/ipfs/go-cid"
+	ds "github.com/ipfs/go-datastore"
+)
+
+// HeadstoreColKey are used to store the current collection head in the headstore.
+type HeadstoreColKey struct {
+	// CollectionRoot is the root of the collection that this head refers to.
+	//
+	// Including it in the key allows easier identification of a given collection's
+	// head.
+	CollectionRoot uint32
+
+	// Cid is the cid of this head block.
+	Cid cid.Cid
+}
+
+var _ HeadstoreKey = (*HeadstoreColKey)(nil)
+
+func NewHeadstoreColKey(colRoot uint32) HeadstoreColKey {
+	return HeadstoreColKey{
+		CollectionRoot: colRoot,
+	}
+}
+
+func NewHeadstoreColKeyFromString(key string) (HeadstoreColKey, error) {
+	elements := strings.Split(key, "/")
+	if len(elements) != 4 {
+		return HeadstoreColKey{}, ErrInvalidKey
+	}
+
+	root, err := strconv.Atoi(elements[2])
+	if err != nil {
+		return HeadstoreColKey{}, err
+	}
+
+	cid, err := cid.Decode(elements[3])
+	if err != nil {
+		return HeadstoreColKey{}, err
+	}
+
+	return HeadstoreColKey{
+		// elements[0] is empty (key has leading '/')
+		CollectionRoot: uint32(root),
+		Cid:            cid,
+	}, nil
+}
+
+func (k HeadstoreColKey) WithCid(c cid.Cid) HeadstoreKey {
+	newKey := k
+	newKey.Cid = c
+	return newKey
+}
+
+func (k HeadstoreColKey) GetCid() cid.Cid {
+	return k.Cid
+}
+
+func (k HeadstoreColKey) ToString() string {
+	result := HEADSTORE_COL
+
+	if k.CollectionRoot != 0 {
+		result = result + "/" + strconv.Itoa(int(k.CollectionRoot))
+	}
+	if k.Cid.Defined() {
+		result = result + "/" + k.Cid.String()
+	}
+
+	return result
+}
+
+func (k HeadstoreColKey) Bytes() []byte {
+	return []byte(k.ToString())
+}
+
+func (k HeadstoreColKey) ToDS() ds.Key {
+	return ds.NewKey(k.ToString())
+}
+
+func (k HeadstoreColKey) PrefixEnd() Walkable {
+	newKey := k
+
+	if k.Cid.Defined() {
+		newKey.Cid = cid.MustParse(bytesPrefixEnd(k.Cid.Bytes()))
+		return newKey
+	}
+
+	if k.CollectionRoot != 0 {
+		newKey.CollectionRoot = k.CollectionRoot + 1
+		return newKey
+	}
+
+	return newKey
+}

--- a/internal/keys/headstore_doc.go
+++ b/internal/keys/headstore_doc.go
@@ -29,24 +29,24 @@ var _ Walkable = (*HeadStoreKey)(nil)
 // splitting the input using '/' as a field deliminator.  It assumes
 // that the input string is in the following format:
 //
-// /[DocID]/[FieldId]/[Cid]
+// /d/[DocID]/[FieldId]/[Cid]
 //
 // Any properties before the above are ignored
 func NewHeadStoreKey(key string) (HeadStoreKey, error) {
 	elements := strings.Split(key, "/")
-	if len(elements) != 4 {
+	if len(elements) != 5 {
 		return HeadStoreKey{}, ErrInvalidKey
 	}
 
-	cid, err := cid.Decode(elements[3])
+	cid, err := cid.Decode(elements[4])
 	if err != nil {
 		return HeadStoreKey{}, err
 	}
 
 	return HeadStoreKey{
 		// elements[0] is empty (key has leading '/')
-		DocID:   elements[1],
-		FieldID: elements[2],
+		DocID:   elements[2],
+		FieldID: elements[3],
 		Cid:     cid,
 	}, nil
 }
@@ -70,7 +70,7 @@ func (k HeadStoreKey) WithFieldID(fieldID string) HeadStoreKey {
 }
 
 func (k HeadStoreKey) ToString() string {
-	var result string
+	result := HEADSTORE_DOC
 
 	if k.DocID != "" {
 		result = result + "/" + k.DocID

--- a/internal/keys/headstore_doc.go
+++ b/internal/keys/headstore_doc.go
@@ -17,33 +17,33 @@ import (
 	ds "github.com/ipfs/go-datastore"
 )
 
-type HeadStoreKey struct {
+type HeadstoreDocKey struct {
 	DocID   string
 	FieldID string //can be 'C'
 	Cid     cid.Cid
 }
 
-var _ Walkable = (*HeadStoreKey)(nil)
+var _ Walkable = (*HeadstoreDocKey)(nil)
 
-// Creates a new HeadStoreKey from a string as best as it can,
+// Creates a new HeadstoreDocKey from a string as best as it can,
 // splitting the input using '/' as a field deliminator.  It assumes
 // that the input string is in the following format:
 //
 // /d/[DocID]/[FieldId]/[Cid]
 //
 // Any properties before the above are ignored
-func NewHeadStoreKey(key string) (HeadStoreKey, error) {
+func NewHeadstoreDocKey(key string) (HeadstoreDocKey, error) {
 	elements := strings.Split(key, "/")
 	if len(elements) != 5 {
-		return HeadStoreKey{}, ErrInvalidKey
+		return HeadstoreDocKey{}, ErrInvalidKey
 	}
 
 	cid, err := cid.Decode(elements[4])
 	if err != nil {
-		return HeadStoreKey{}, err
+		return HeadstoreDocKey{}, err
 	}
 
-	return HeadStoreKey{
+	return HeadstoreDocKey{
 		// elements[0] is empty (key has leading '/')
 		DocID:   elements[2],
 		FieldID: elements[3],
@@ -51,25 +51,25 @@ func NewHeadStoreKey(key string) (HeadStoreKey, error) {
 	}, nil
 }
 
-func (k HeadStoreKey) WithDocID(docID string) HeadStoreKey {
+func (k HeadstoreDocKey) WithDocID(docID string) HeadstoreDocKey {
 	newKey := k
 	newKey.DocID = docID
 	return newKey
 }
 
-func (k HeadStoreKey) WithCid(c cid.Cid) HeadStoreKey {
+func (k HeadstoreDocKey) WithCid(c cid.Cid) HeadstoreDocKey {
 	newKey := k
 	newKey.Cid = c
 	return newKey
 }
 
-func (k HeadStoreKey) WithFieldID(fieldID string) HeadStoreKey {
+func (k HeadstoreDocKey) WithFieldID(fieldID string) HeadstoreDocKey {
 	newKey := k
 	newKey.FieldID = fieldID
 	return newKey
 }
 
-func (k HeadStoreKey) ToString() string {
+func (k HeadstoreDocKey) ToString() string {
 	result := HEADSTORE_DOC
 
 	if k.DocID != "" {
@@ -85,15 +85,15 @@ func (k HeadStoreKey) ToString() string {
 	return result
 }
 
-func (k HeadStoreKey) Bytes() []byte {
+func (k HeadstoreDocKey) Bytes() []byte {
 	return []byte(k.ToString())
 }
 
-func (k HeadStoreKey) ToDS() ds.Key {
+func (k HeadstoreDocKey) ToDS() ds.Key {
 	return ds.NewKey(k.ToString())
 }
 
-func (k HeadStoreKey) PrefixEnd() Walkable {
+func (k HeadstoreDocKey) PrefixEnd() Walkable {
 	newKey := k
 
 	if k.FieldID != "" {

--- a/internal/keys/headstore_doc.go
+++ b/internal/keys/headstore_doc.go
@@ -23,7 +23,7 @@ type HeadstoreDocKey struct {
 	Cid     cid.Cid
 }
 
-var _ Walkable = (*HeadstoreDocKey)(nil)
+var _ HeadstoreKey = (*HeadstoreDocKey)(nil)
 
 // Creates a new HeadstoreDocKey from a string as best as it can,
 // splitting the input using '/' as a field deliminator.  It assumes
@@ -57,10 +57,14 @@ func (k HeadstoreDocKey) WithDocID(docID string) HeadstoreDocKey {
 	return newKey
 }
 
-func (k HeadstoreDocKey) WithCid(c cid.Cid) HeadstoreDocKey {
+func (k HeadstoreDocKey) WithCid(c cid.Cid) HeadstoreKey {
 	newKey := k
 	newKey.Cid = c
 	return newKey
+}
+
+func (k HeadstoreDocKey) GetCid() cid.Cid {
+	return k.Cid
 }
 
 func (k HeadstoreDocKey) WithFieldID(fieldID string) HeadstoreDocKey {

--- a/internal/merkle/clock/clock.go
+++ b/internal/merkle/clock/clock.go
@@ -48,7 +48,7 @@ func NewMerkleClock(
 	headstore datastore.DSReaderWriter,
 	blockstore datastore.Blockstore,
 	encstore datastore.Blockstore,
-	namespace keys.HeadStoreKey,
+	namespace keys.HeadstoreDocKey,
 	crdt core.ReplicatedData,
 ) *MerkleClock {
 	return &MerkleClock{

--- a/internal/merkle/clock/clock.go
+++ b/internal/merkle/clock/clock.go
@@ -48,7 +48,7 @@ func NewMerkleClock(
 	headstore datastore.DSReaderWriter,
 	blockstore datastore.Blockstore,
 	encstore datastore.Blockstore,
-	namespace keys.HeadstoreDocKey,
+	namespace keys.HeadstoreKey,
 	crdt core.ReplicatedData,
 ) *MerkleClock {
 	return &MerkleClock{
@@ -207,7 +207,7 @@ func encryptBlock(
 	block *coreblock.Block,
 	encBlock *coreblock.Encryption,
 ) (*coreblock.Block, error) {
-	if block.Delta.IsComposite() {
+	if block.Delta.IsComposite() || block.Delta.IsCollection() {
 		return block, nil
 	}
 

--- a/internal/merkle/clock/clock_test.go
+++ b/internal/merkle/clock/clock_test.go
@@ -38,7 +38,7 @@ func newTestMerkleClock() *MerkleClock {
 		multistore.Headstore(),
 		multistore.Blockstore(),
 		multistore.Encstore(),
-		keys.HeadStoreKey{DocID: request.DocIDArgName, FieldID: "1"},
+		keys.HeadstoreDocKey{DocID: request.DocIDArgName, FieldID: "1"},
 		reg,
 	)
 }
@@ -47,7 +47,7 @@ func TestNewMerkleClock(t *testing.T) {
 	s := newDS()
 	multistore := datastore.MultiStoreFrom(s)
 	reg := crdt.NewLWWRegister(multistore.Rootstore(), keys.CollectionSchemaVersionKey{}, keys.DataStoreKey{}, "")
-	clk := NewMerkleClock(multistore.Headstore(), multistore.Blockstore(), multistore.Encstore(), keys.HeadStoreKey{}, reg)
+	clk := NewMerkleClock(multistore.Headstore(), multistore.Blockstore(), multistore.Encstore(), keys.HeadstoreDocKey{}, reg)
 
 	if clk.headstore != multistore.Headstore() {
 		t.Error("MerkleClock store not correctly set")

--- a/internal/merkle/clock/heads.go
+++ b/internal/merkle/clock/heads.go
@@ -27,17 +27,17 @@ import (
 // heads manages the current Merkle-CRDT heads.
 type heads struct {
 	store     datastore.DSReaderWriter
-	namespace keys.HeadStoreKey
+	namespace keys.HeadstoreDocKey
 }
 
-func NewHeadSet(store datastore.DSReaderWriter, namespace keys.HeadStoreKey) *heads {
+func NewHeadSet(store datastore.DSReaderWriter, namespace keys.HeadstoreDocKey) *heads {
 	return &heads{
 		store:     store,
 		namespace: namespace,
 	}
 }
 
-func (hh *heads) key(c cid.Cid) keys.HeadStoreKey {
+func (hh *heads) key(c cid.Cid) keys.HeadstoreDocKey {
 	return hh.namespace.WithCid(c)
 }
 
@@ -102,7 +102,7 @@ func (hh *heads) List(ctx context.Context) ([]cid.Cid, uint64, error) {
 			return nil, 0, NewErrFailedToGetNextQResult(r.Error)
 		}
 
-		headKey, err := keys.NewHeadStoreKey(r.Key)
+		headKey, err := keys.NewHeadstoreDocKey(r.Key)
 		if err != nil {
 			return nil, 0, err
 		}

--- a/internal/merkle/clock/heads.go
+++ b/internal/merkle/clock/heads.go
@@ -27,17 +27,17 @@ import (
 // heads manages the current Merkle-CRDT heads.
 type heads struct {
 	store     datastore.DSReaderWriter
-	namespace keys.HeadstoreDocKey
+	namespace keys.HeadstoreKey
 }
 
-func NewHeadSet(store datastore.DSReaderWriter, namespace keys.HeadstoreDocKey) *heads {
+func NewHeadSet(store datastore.DSReaderWriter, namespace keys.HeadstoreKey) *heads {
 	return &heads{
 		store:     store,
 		namespace: namespace,
 	}
 }
 
-func (hh *heads) key(c cid.Cid) keys.HeadstoreDocKey {
+func (hh *heads) key(c cid.Cid) keys.HeadstoreKey {
 	return hh.namespace.WithCid(c)
 }
 
@@ -102,7 +102,7 @@ func (hh *heads) List(ctx context.Context) ([]cid.Cid, uint64, error) {
 			return nil, 0, NewErrFailedToGetNextQResult(r.Error)
 		}
 
-		headKey, err := keys.NewHeadstoreDocKey(r.Key)
+		headKey, err := keys.NewHeadstoreKey(r.Key)
 		if err != nil {
 			return nil, 0, err
 		}
@@ -111,7 +111,7 @@ func (hh *heads) List(ctx context.Context) ([]cid.Cid, uint64, error) {
 		if n <= 0 {
 			return nil, 0, ErrDecodingHeight
 		}
-		heads = append(heads, headKey.Cid)
+		heads = append(heads, headKey.GetCid())
 		if height > maxHeight {
 			maxHeight = height
 		}

--- a/internal/merkle/clock/heads_test.go
+++ b/internal/merkle/clock/heads_test.go
@@ -45,7 +45,7 @@ func newHeadSet() *heads {
 
 	return NewHeadSet(
 		datastore.AsDSReaderWriter(s),
-		keys.HeadStoreKey{}.WithDocID("myDocID").WithFieldID("1"),
+		keys.HeadstoreDocKey{}.WithDocID("myDocID").WithFieldID("1"),
 	)
 }
 

--- a/internal/merkle/crdt/collection.go
+++ b/internal/merkle/crdt/collection.go
@@ -33,7 +33,7 @@ func NewMerkleCollection(
 	schemaVersionKey keys.CollectionSchemaVersionKey,
 	key keys.HeadstoreColKey,
 ) *MerkleCollection {
-	register := crdt.NewCollection(store.Datastore(), schemaVersionKey)
+	register := crdt.NewCollection(schemaVersionKey)
 
 	clk := clock.NewMerkleClock(store.Headstore(), store.Blockstore(), store.Encstore(), key, register)
 

--- a/internal/merkle/crdt/collection.go
+++ b/internal/merkle/crdt/collection.go
@@ -1,0 +1,53 @@
+// Copyright 2024 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package merklecrdt
+
+import (
+	"context"
+
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+
+	coreblock "github.com/sourcenetwork/defradb/internal/core/block"
+	"github.com/sourcenetwork/defradb/internal/core/crdt"
+	"github.com/sourcenetwork/defradb/internal/keys"
+	"github.com/sourcenetwork/defradb/internal/merkle/clock"
+)
+
+type MerkleCollection struct {
+	clock *clock.MerkleClock
+	reg   *crdt.Collection
+}
+
+var _ MerkleCRDT = (*MerkleCollection)(nil)
+
+func NewMerkleCollection(
+	store Stores,
+	schemaVersionKey keys.CollectionSchemaVersionKey,
+	key keys.HeadstoreColKey,
+) *MerkleCollection {
+	register := crdt.NewCollection(store.Datastore(), schemaVersionKey)
+
+	clk := clock.NewMerkleClock(store.Headstore(), store.Blockstore(), store.Encstore(), key, register)
+
+	return &MerkleCollection{
+		clock: clk,
+		reg:   register,
+	}
+}
+
+func (m *MerkleCollection) Clock() *clock.MerkleClock {
+	return m.clock
+}
+
+func (m *MerkleCollection) Save(ctx context.Context, links []coreblock.DAGLink) (cidlink.Link, []byte, error) {
+	delta := m.reg.Append()
+	return m.clock.AddDelta(ctx, delta, links...)
+}

--- a/internal/merkle/crdt/collection.go
+++ b/internal/merkle/crdt/collection.go
@@ -48,6 +48,6 @@ func (m *MerkleCollection) Clock() *clock.MerkleClock {
 }
 
 func (m *MerkleCollection) Save(ctx context.Context, links []coreblock.DAGLink) (cidlink.Link, []byte, error) {
-	delta := m.reg.Append()
+	delta := m.reg.NewDelta()
 	return m.clock.AddDelta(ctx, delta, links...)
 }

--- a/internal/merkle/crdt/composite.go
+++ b/internal/merkle/crdt/composite.go
@@ -61,12 +61,12 @@ func (m *MerkleCompositeDAG) Clock() *clock.MerkleClock {
 func (m *MerkleCompositeDAG) Delete(
 	ctx context.Context,
 ) (cidlink.Link, []byte, error) {
-	delta := m.reg.Set(client.Deleted)
+	delta := m.reg.Append(client.Deleted)
 	return m.clock.AddDelta(ctx, delta)
 }
 
 // Save the value of the composite CRDT to DAG.
 func (m *MerkleCompositeDAG) Save(ctx context.Context, links []coreblock.DAGLink) (cidlink.Link, []byte, error) {
-	delta := m.reg.Set(client.Active)
+	delta := m.reg.Append(client.Active)
 	return m.clock.AddDelta(ctx, delta, links...)
 }

--- a/internal/merkle/crdt/composite.go
+++ b/internal/merkle/crdt/composite.go
@@ -61,12 +61,12 @@ func (m *MerkleCompositeDAG) Clock() *clock.MerkleClock {
 func (m *MerkleCompositeDAG) Delete(
 	ctx context.Context,
 ) (cidlink.Link, []byte, error) {
-	delta := m.reg.Append(client.Deleted)
+	delta := m.reg.NewDelta(client.Deleted)
 	return m.clock.AddDelta(ctx, delta)
 }
 
 // Save the value of the composite CRDT to DAG.
 func (m *MerkleCompositeDAG) Save(ctx context.Context, links []coreblock.DAGLink) (cidlink.Link, []byte, error) {
-	delta := m.reg.Append(client.Active)
+	delta := m.reg.NewDelta(client.Active)
 	return m.clock.AddDelta(ctx, delta, links...)
 }

--- a/internal/planner/commit.go
+++ b/internal/planner/commit.go
@@ -36,7 +36,7 @@ type dagScanNode struct {
 	queuedCids []*cid.Cid
 
 	fetcher      fetcher.HeadFetcher
-	prefix       keys.HeadStoreKey
+	prefix       keys.HeadstoreDocKey
 	commitSelect *mapper.CommitSelect
 
 	execInfo dagScanExecInfo
@@ -67,10 +67,10 @@ func (n *dagScanNode) Kind() string {
 }
 
 func (n *dagScanNode) Init() error {
-	undefined := keys.HeadStoreKey{}
+	undefined := keys.HeadstoreDocKey{}
 	if n.prefix == undefined {
 		if n.commitSelect.DocID.HasValue() {
-			key := keys.HeadStoreKey{}.WithDocID(n.commitSelect.DocID.Value())
+			key := keys.HeadstoreDocKey{}.WithDocID(n.commitSelect.DocID.Value())
 
 			if n.commitSelect.FieldID.HasValue() {
 				field := n.commitSelect.FieldID.Value()
@@ -106,11 +106,11 @@ func (n *dagScanNode) Spans(spans []core.Span) {
 	}
 
 	for _, span := range spans {
-		var start keys.HeadStoreKey
+		var start keys.HeadstoreDocKey
 		switch s := span.Start.(type) {
 		case keys.DataStoreKey:
 			start = s.ToHeadStoreKey()
-		case keys.HeadStoreKey:
+		case keys.HeadstoreDocKey:
 			start = s
 		}
 
@@ -144,7 +144,7 @@ func (n *dagScanNode) simpleExplain() (map[string]any, error) {
 
 	// Build the explanation of the spans attribute.
 	spansExplainer := []map[string]any{}
-	undefinedHsKey := keys.HeadStoreKey{}
+	undefinedHsKey := keys.HeadstoreDocKey{}
 	// Note: n.headset is `nil` for single commit selection query, so must check for it.
 	if n.prefix != undefinedHsKey {
 		spansExplainer = append(

--- a/internal/planner/select.go
+++ b/internal/planner/select.go
@@ -266,11 +266,11 @@ func (n *selectNode) initSource() ([]aggregateNode, error) {
 			origScan.Spans(
 				[]core.Span{
 					core.NewSpan(
-						keys.HeadStoreKey{
+						keys.HeadstoreDocKey{
 							DocID: n.selectReq.DocIDs.Value()[0],
 							Cid:   c,
 						},
-						keys.HeadStoreKey{},
+						keys.HeadstoreDocKey{},
 					),
 				},
 			)

--- a/internal/request/graphql/parser/commit.go
+++ b/internal/request/graphql/parser/commit.go
@@ -50,7 +50,9 @@ func parseCommitSelect(
 			}
 
 		case request.FieldIDName:
-			if v, ok := value.(string); ok {
+			if value == nil {
+				commit.FieldID = immutable.Some("")
+			} else if v, ok := value.(string); ok {
 				commit.FieldID = immutable.Some(v)
 			}
 

--- a/internal/request/graphql/schema/schema.go
+++ b/internal/request/graphql/schema/schema.go
@@ -105,6 +105,7 @@ func defaultDirectivesType(
 		types.PrimaryDirective(),
 		types.RelationDirective(),
 		types.MaterializedDirective(),
+		types.BranchableDirective(),
 	}
 }
 

--- a/internal/request/graphql/schema/types/descriptions.go
+++ b/internal/request/graphql/schema/types/descriptions.go
@@ -36,7 +36,8 @@ An optional value that skips the given number of results that would have
 Commit represents an individual commit to a MerkleCRDT, every mutation to a
  document will result in a new commit per modified field, and one composite
  commit composed of the field level commits and, in the case of an update,
- the prior composite commit.
+ the prior composite commit.  If the collection is branchable, there will
+ also be a collection-level commit for each mutation.
 `
 	commitDocIDArgDescription string = `
 An optional docID parameter for this commit query. Only commits for a document
@@ -60,10 +61,10 @@ An optional value that specifies the maximum depth to which the commit DAG graph
 	commitLinksDescription string = `
 Child commits in the DAG that contribute to the composition of this commit.
  Composite commits will link to the field commits for the fields modified during
- the single mutation.
+ the single mutation.  Collection commits will link to composites.
 `
 	commitHeightFieldDescription string = `
-Height represents the location of the commit in the DAG. All commits (composite,
+Height represents the location of the commit in the DAG. All commits (collection, composite,
  and field level) on create will have a height of '1', each subsequent local update
  will increment this by one for the new commits.
 `
@@ -82,12 +83,12 @@ The ID of the schema version that this commit was committed against. This ID all
  to determine the state of the data model at the time of commit.
 `
 	commitFieldNameFieldDescription string = `
-The name of the field that this commit was committed against. If this is a composite field
- the value will be null.
+The name of the field that this commit was committed against. If this is a composite
+ or a collection the value will be null.
 `
 	commitFieldIDFieldDescription string = `
 The id of the field that this commit was committed against. If this is a composite field
- the value will be "C".
+ the value will be "C". If it is a collection level commit it will be null.
 `
 	commitDeltaFieldDescription string = `
 The CBOR encoded representation of the value that is saved as part of this commit.

--- a/internal/request/graphql/schema/types/types.go
+++ b/internal/request/graphql/schema/types/types.go
@@ -54,6 +54,9 @@ const (
 	MaterializedDirectiveLabel  = "materialized"
 	MaterializedDirectivePropIf = "if"
 
+	BranchableDirectiveLabel  = "branchable"
+	BranchableDirectivePropIf = "if"
+
 	FieldOrderASC  = "ASC"
 	FieldOrderDESC = "DESC"
 )
@@ -228,6 +231,31 @@ func MaterializedDirective() *gql.Directive {
  with OR logic (if any are true, the collection will be cached).`,
 		Args: gql.FieldConfigArgument{
 			MaterializedDirectivePropIf: &gql.ArgumentConfig{
+				Type: gql.Boolean,
+			},
+		},
+		Locations: []string{
+			gql.DirectiveLocationObject,
+		},
+	})
+}
+
+func BranchableDirective() *gql.Directive {
+	return gql.NewDirective(gql.DirectiveConfig{
+		Name: BranchableDirectiveLabel,
+		Description: `@branchable is a directive that defines whether the history of this collection is tracked
+ as a single, verifiable entity or not. It will default to false if ommited.
+
+ If multiple @branchable directives are provided, they will aggregated with OR logic (if any are true, the
+ collection history will be tracked).
+
+ The history may be queried like a document history can be queried, for example via 'commits'
+ GQL queries.
+
+ Currently this property is immutable and can only be set on collection creation, however
+ that will change in the future.`,
+		Args: gql.FieldConfigArgument{
+			BranchableDirectivePropIf: &gql.ArgumentConfig{
 				Type: gql.Boolean,
 			},
 		},

--- a/internal/request/graphql/schema/types/types.go
+++ b/internal/request/graphql/schema/types/types.go
@@ -243,6 +243,8 @@ func MaterializedDirective() *gql.Directive {
 func BranchableDirective() *gql.Directive {
 	return gql.NewDirective(gql.DirectiveConfig{
 		Name: BranchableDirectiveLabel,
+		// Todo: This description will need to be changed with:
+		// https://github.com/sourcenetwork/defradb/issues/3219
 		Description: `@branchable is a directive that defines whether the history of this collection is tracked
  as a single, verifiable entity or not. It will default to false if ommited.
 

--- a/net/server_test.go
+++ b/net/server_test.go
@@ -86,7 +86,7 @@ func getHead(ctx context.Context, db client.DB, docID client.DocID) (cid.Cid, er
 	}
 
 	if len(entries) > 0 {
-		hsKey, err := keys.NewHeadStoreKey(entries[0].Key)
+		hsKey, err := keys.NewHeadstoreDocKey(entries[0].Key)
 		if err != nil {
 			return cid.Undef, err
 		}

--- a/tests/integration/collection_description/branchable_test.go
+++ b/tests/integration/collection_description/branchable_test.go
@@ -1,0 +1,92 @@
+// Copyright 2024 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package collection_description
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/immutable"
+
+	"github.com/sourcenetwork/defradb/client"
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+func TestColDescr_Branchable(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users @branchable {}
+				`,
+			},
+			testUtils.GetCollections{
+				ExpectedResults: []client.CollectionDescription{
+					{
+						ID:             1,
+						Name:           immutable.Some("Users"),
+						IsMaterialized: true,
+						IsBranchable:   true,
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestColDescr_BranchableIfTrue(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users @branchable(if: true) {}
+				`,
+			},
+			testUtils.GetCollections{
+				ExpectedResults: []client.CollectionDescription{
+					{
+						ID:             1,
+						Name:           immutable.Some("Users"),
+						IsMaterialized: true,
+						IsBranchable:   true,
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestColDescr_BranchableIfFalse(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users @branchable(if: false) {}
+				`,
+			},
+			testUtils.GetCollections{
+				ExpectedResults: []client.CollectionDescription{
+					{
+						ID:             1,
+						Name:           immutable.Some("Users"),
+						IsMaterialized: true,
+						IsBranchable:   false,
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/collection_description/updates/replace/branchable_test.go
+++ b/tests/integration/collection_description/updates/replace/branchable_test.go
@@ -1,0 +1,65 @@
+// Copyright 2024 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package replace
+
+import (
+	"testing"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+func TestColDescrUpdateReplaceIsBranchable_UpdatingFromTrueToFalse_Errors(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type User @branchable {
+						name: String
+					}
+				`,
+			},
+			testUtils.PatchCollection{
+				Patch: `
+					[
+						{ "op": "replace", "path": "/1/IsBranchable", "value": false }
+					]
+				`,
+				ExpectedError: "mutating IsBranchable is not supported. Collection: User",
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestColDescrUpdateReplaceIsBranchable_UpdatingFromFalseToTrue_Errors(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type User @branchable(if: false) {
+						name: String
+					}
+				`,
+			},
+			testUtils.PatchCollection{
+				Patch: `
+					[
+						{ "op": "replace", "path": "/1/IsBranchable", "value": true }
+					]
+				`,
+				ExpectedError: "mutating IsBranchable is not supported. Collection: User",
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/events.go
+++ b/tests/integration/events.go
@@ -182,6 +182,12 @@ func waitForUpdateEvents(
 				require.Fail(s.t, "timeout waiting for update event", "Node %d", i)
 			}
 
+			if evt.DocID == "" {
+				// Todo: This will almost certainly need to change once P2P for collection-level commits
+				// is enabled. See: https://github.com/sourcenetwork/defradb/issues/3212
+				continue
+			}
+
 			// make sure the event is expected
 			_, ok := expect[evt.DocID]
 			require.True(s.t, ok, "unexpected document update", "Node %d", i)

--- a/tests/integration/explain/default/dagscan_test.go
+++ b/tests/integration/explain/default/dagscan_test.go
@@ -60,8 +60,8 @@ func TestDefaultExplainCommitsDagScanQueryOp(t *testing.T) {
 							"fieldId": "1",
 							"spans": []dataMap{
 								{
-									"start": "/bae-7aabc9d2-fbbc-5911-b0d0-b49a2a1d0e84/1",
-									"end":   "/bae-7aabc9d2-fbbc-5911-b0d0-b49a2a1d0e84/2",
+									"start": "/d/bae-7aabc9d2-fbbc-5911-b0d0-b49a2a1d0e84/1",
+									"end":   "/d/bae-7aabc9d2-fbbc-5911-b0d0-b49a2a1d0e84/2",
 								},
 							},
 						},
@@ -103,8 +103,8 @@ func TestDefaultExplainCommitsDagScanQueryOpWithoutField(t *testing.T) {
 							"fieldId": nil,
 							"spans": []dataMap{
 								{
-									"start": "/bae-7aabc9d2-fbbc-5911-b0d0-b49a2a1d0e84",
-									"end":   "/bae-7aabc9d2-fbbc-5911-b0d0-b49a2a1d0e85",
+									"start": "/d/bae-7aabc9d2-fbbc-5911-b0d0-b49a2a1d0e84",
+									"end":   "/d/bae-7aabc9d2-fbbc-5911-b0d0-b49a2a1d0e85",
 								},
 							},
 						},
@@ -147,8 +147,8 @@ func TestDefaultExplainLatestCommitsDagScanQueryOp(t *testing.T) {
 							"fieldId": "1",
 							"spans": []dataMap{
 								{
-									"start": "/bae-7aabc9d2-fbbc-5911-b0d0-b49a2a1d0e84/1",
-									"end":   "/bae-7aabc9d2-fbbc-5911-b0d0-b49a2a1d0e84/2",
+									"start": "/d/bae-7aabc9d2-fbbc-5911-b0d0-b49a2a1d0e84/1",
+									"end":   "/d/bae-7aabc9d2-fbbc-5911-b0d0-b49a2a1d0e84/2",
 								},
 							},
 						},
@@ -191,8 +191,8 @@ func TestDefaultExplainLatestCommitsDagScanQueryOpWithoutField(t *testing.T) {
 							"fieldId": "C",
 							"spans": []dataMap{
 								{
-									"start": "/bae-7aabc9d2-fbbc-5911-b0d0-b49a2a1d0e84/C",
-									"end":   "/bae-7aabc9d2-fbbc-5911-b0d0-b49a2a1d0e84/D",
+									"start": "/d/bae-7aabc9d2-fbbc-5911-b0d0-b49a2a1d0e84/C",
+									"end":   "/d/bae-7aabc9d2-fbbc-5911-b0d0-b49a2a1d0e84/D",
 								},
 							},
 						},

--- a/tests/integration/query/commits/branchables/cid_doc_id_test.go
+++ b/tests/integration/query/commits/branchables/cid_doc_id_test.go
@@ -1,0 +1,56 @@
+// Copyright 2024 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package branchables
+
+import (
+	"testing"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+func TestQueryCommitsBranchables_WithCidAndDocIDParam(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users @branchable {
+						name: String
+						age: Int
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
+					"name":	"John",
+					"age":	21
+				}`,
+			},
+			testUtils.Request{
+				// This request uses the document's docID, and the collection's cid.
+				// It would be very nice if this worked:
+				// https://github.com/sourcenetwork/defradb/issues/3213
+				Request: `query {
+						commits(
+							docID: "bae-0b2f15e5-bfe7-5cb7-8045-471318d7dbc3",
+							cid: "bafyreifi7borlnkazxrcohgl7r36cm5ga7moyiiajov3om7urexbx7cyl4"
+						) {
+							cid
+						}
+					}`,
+				Results: map[string]any{
+					"commits": []map[string]any{},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/query/commits/branchables/cid_test.go
+++ b/tests/integration/query/commits/branchables/cid_test.go
@@ -1,0 +1,63 @@
+// Copyright 2024 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package branchables
+
+import (
+	"testing"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+func TestQueryCommitsBranchables_WithCidParam(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users @branchable {
+						name: String
+						age: Int
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
+					"name":	"John",
+					"age":	21
+				}`,
+			},
+			testUtils.Request{
+				Request: `query {
+						commits(
+							cid: "bafyreifi7borlnkazxrcohgl7r36cm5ga7moyiiajov3om7urexbx7cyl4"
+						) {
+							cid
+							collectionID
+							docID
+							fieldName
+						}
+					}`,
+				Results: map[string]any{
+					"commits": []map[string]any{
+						{
+							"cid": testUtils.NewUniqueCid("collection"),
+							// Extra params are used to verify this is a collection level cid
+							"collectionID": int64(1),
+							"docID":        nil,
+							"fieldName":    nil,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/query/commits/branchables/create_test.go
+++ b/tests/integration/query/commits/branchables/create_test.go
@@ -1,0 +1,117 @@
+// Copyright 2024 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package branchables
+
+import (
+	"testing"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+func TestQueryCommitsBranchables_WithMultipleCreate(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users @branchable {
+						name: String
+						age: Int
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
+					"name":	"John",
+					"age":	21
+				}`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
+					"name":	"Fred",
+					"age":	25
+				}`,
+			},
+			testUtils.Request{
+				Request: `query {
+						commits {
+							cid
+							links {
+								cid
+							}
+						}
+					}`,
+				Results: map[string]any{
+					"commits": []map[string]any{
+						{
+							"cid": testUtils.NewUniqueCid("collection, doc2 create"),
+							"links": []map[string]any{
+								{
+									"cid": testUtils.NewUniqueCid("collection, doc1 create"),
+								},
+								{
+									"cid": testUtils.NewUniqueCid("doc2 create"),
+								},
+							},
+						},
+						{
+							"cid": testUtils.NewUniqueCid("collection, doc1 create"),
+							"links": []map[string]any{
+								{
+									"cid": testUtils.NewUniqueCid("doc1 create"),
+								},
+							},
+						},
+						{
+							"cid":   testUtils.NewUniqueCid("doc1 name"),
+							"links": []map[string]any{},
+						},
+						{
+							"cid":   testUtils.NewUniqueCid("doc1 age"),
+							"links": []map[string]any{},
+						},
+						{
+							"cid": testUtils.NewUniqueCid("doc1 create"),
+							"links": []map[string]any{
+								{
+									"cid": testUtils.NewUniqueCid("doc1 name"),
+								},
+								{
+									"cid": testUtils.NewUniqueCid("doc1 age"),
+								},
+							},
+						},
+						{
+							"cid":   testUtils.NewUniqueCid("doc2 name"),
+							"links": []map[string]any{},
+						},
+						{
+							"cid":   testUtils.NewUniqueCid("doc2 age"),
+							"links": []map[string]any{},
+						},
+						{
+							"cid": testUtils.NewUniqueCid("doc2 create"),
+							"links": []map[string]any{
+								{
+									"cid": testUtils.NewUniqueCid("doc2 name"),
+								},
+								{
+									"cid": testUtils.NewUniqueCid("doc2 age"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/query/commits/branchables/delete_test.go
+++ b/tests/integration/query/commits/branchables/delete_test.go
@@ -1,0 +1,103 @@
+// Copyright 2024 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package branchables
+
+import (
+	"testing"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+func TestQueryCommitsBranchables_WithDelete(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users @branchable {
+						name: String
+						age: Int
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
+					"name":	"John",
+					"age":	21
+				}`,
+			},
+			testUtils.DeleteDoc{
+				DocID: 0,
+			},
+			testUtils.Request{
+				Request: `query {
+						commits {
+							cid
+							links {
+								cid
+							}
+						}
+					}`,
+				Results: map[string]any{
+					"commits": []map[string]any{
+						{
+							"cid": testUtils.NewUniqueCid("collection, delete"),
+							"links": []map[string]any{
+								{
+									"cid": testUtils.NewUniqueCid("collection, create"),
+								},
+								{
+									"cid": testUtils.NewUniqueCid("delete"),
+								},
+							},
+						},
+						{
+							"cid": testUtils.NewUniqueCid("collection, create"),
+							"links": []map[string]any{
+								{
+									"cid": testUtils.NewUniqueCid("create"),
+								},
+							},
+						},
+						{
+							"cid":   testUtils.NewUniqueCid("name"),
+							"links": []map[string]any{},
+						},
+						{
+							"cid":   testUtils.NewUniqueCid("age"),
+							"links": []map[string]any{},
+						},
+						{
+							"cid": testUtils.NewUniqueCid("delete"),
+							"links": []map[string]any{
+								{
+									"cid": testUtils.NewUniqueCid("create"),
+								},
+							},
+						},
+						{
+							"cid": testUtils.NewUniqueCid("create"),
+							"links": []map[string]any{
+								{
+									"cid": testUtils.NewUniqueCid("name"),
+								},
+								{
+									"cid": testUtils.NewUniqueCid("age"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/query/commits/branchables/field_id_test.go
+++ b/tests/integration/query/commits/branchables/field_id_test.go
@@ -1,0 +1,63 @@
+// Copyright 2024 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package branchables
+
+import (
+	"testing"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+func TestQueryCommitsBranchables_WithFieldID(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users @branchable {
+						name: String
+						age: Int
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
+					"name":	"John",
+					"age":	21
+				}`,
+			},
+			testUtils.Request{
+				Request: `query {
+						commits(
+							fieldId: null
+						) {
+							cid
+							collectionID
+							docID
+							fieldId
+						}
+					}`,
+				Results: map[string]any{
+					"commits": []map[string]any{
+						{
+							"cid": testUtils.NewUniqueCid("collection"),
+							// Extra params are used to verify this is a collection level cid
+							"collectionID": int64(1),
+							"docID":        nil,
+							"fieldId":      nil,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/query/commits/branchables/if_test.go
+++ b/tests/integration/query/commits/branchables/if_test.go
@@ -1,0 +1,108 @@
+// Copyright 2024 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package branchables
+
+import (
+	"testing"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+func TestQueryCommitsBranchables_WithIfDirectiveTrue(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users @branchable(if: true) {
+						name: String
+						age: Int
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
+					"name":	"John",
+					"age":	21
+				}`,
+			},
+			testUtils.Request{
+				Request: `query {
+						commits {
+							cid
+						}
+					}`,
+				Results: map[string]any{
+					"commits": []map[string]any{
+						{
+							"cid": testUtils.NewUniqueCid("collection"),
+						},
+						{
+							"cid": testUtils.NewUniqueCid("name"),
+						},
+						{
+							"cid": testUtils.NewUniqueCid("age"),
+						},
+						{
+							"cid": testUtils.NewUniqueCid("head"),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestQueryCommitsBranchables_WithIfDirectiveFalse(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users @branchable(if: false) {
+						name: String
+						age: Int
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
+					"name":	"John",
+					"age":	21
+				}`,
+			},
+			testUtils.Request{
+				Request: `query {
+						commits {
+							cid
+						}
+					}`,
+				Results: map[string]any{
+					"commits": []map[string]any{
+						// Note: This collection is not branchable, there is no collection
+						// level commit
+						{
+							"cid": testUtils.NewUniqueCid("name"),
+						},
+						{
+							"cid": testUtils.NewUniqueCid("age"),
+						},
+						{
+							"cid": testUtils.NewUniqueCid("head"),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/query/commits/branchables/peer_test.go
+++ b/tests/integration/query/commits/branchables/peer_test.go
@@ -1,0 +1,133 @@
+// Copyright 2024 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package branchables
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/immutable"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+// TODO: This test documents an unimplemented feature. Tracked by:
+// https://github.com/sourcenetwork/defradb/issues/3212
+func TestQueryCommitsBranchables_AcrossPeerConnection(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.RandomNetworkingConfig(),
+			testUtils.RandomNetworkingConfig(),
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users @branchable {
+						name: String
+						age: Int
+					}
+				`,
+			},
+			testUtils.ConnectPeers{
+				SourceNodeID: 1,
+				TargetNodeID: 0,
+			},
+			testUtils.SubscribeToCollection{
+				NodeID:        1,
+				CollectionIDs: []int{0},
+			},
+			testUtils.CreateDoc{
+				NodeID: immutable.Some(0),
+				Doc: `{
+					"name":	"John",
+					"age":	21
+				}`,
+			},
+			testUtils.WaitForSync{},
+			testUtils.Request{
+				NodeID: immutable.Some(0),
+				Request: `query {
+					commits {
+						cid
+						links {
+							cid
+						}
+					}
+				}`,
+				Results: map[string]any{
+					"commits": []map[string]any{
+						{
+							"cid": testUtils.NewUniqueCid("collection"),
+							"links": []map[string]any{
+								{
+									"cid": testUtils.NewUniqueCid("composite"),
+								},
+							},
+						},
+						{
+							"cid":   testUtils.NewUniqueCid("age"),
+							"links": []map[string]any{},
+						},
+						{
+							"cid":   testUtils.NewUniqueCid("name"),
+							"links": []map[string]any{},
+						},
+						{
+							"cid": testUtils.NewUniqueCid("composite"),
+							"links": []map[string]any{
+								{
+									"cid": testUtils.NewUniqueCid("age"),
+								},
+								{
+									"cid": testUtils.NewUniqueCid("name"),
+								},
+							},
+						},
+					},
+				},
+			},
+			testUtils.Request{
+				NodeID: immutable.Some(1),
+				Request: `query {
+					commits {
+						cid
+						links {
+							cid
+						}
+					}
+				}`,
+				Results: map[string]any{
+					"commits": []map[string]any{
+						// Note: The collection commit has not synced.
+						{
+							"cid":   testUtils.NewUniqueCid("age"),
+							"links": []map[string]any{},
+						},
+						{
+							"cid":   testUtils.NewUniqueCid("name"),
+							"links": []map[string]any{},
+						},
+						{
+							"cid": testUtils.NewUniqueCid("composite"),
+							"links": []map[string]any{
+								{
+									"cid": testUtils.NewUniqueCid("age"),
+								},
+								{
+									"cid": testUtils.NewUniqueCid("name"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/query/commits/branchables/peer_test.go
+++ b/tests/integration/query/commits/branchables/peer_test.go
@@ -20,7 +20,7 @@ import (
 
 // TODO: This test documents an unimplemented feature. Tracked by:
 // https://github.com/sourcenetwork/defradb/issues/3212
-func TestQueryCommitsBranchables_AcrossPeerConnection(t *testing.T) {
+func TestQueryCommitsBranchables_SyncsAcrossPeerConnection(t *testing.T) {
 	test := testUtils.TestCase{
 		Actions: []any{
 			testUtils.RandomNetworkingConfig(),

--- a/tests/integration/query/commits/branchables/simple_test.go
+++ b/tests/integration/query/commits/branchables/simple_test.go
@@ -1,0 +1,161 @@
+// Copyright 2024 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package branchables
+
+import (
+	"testing"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+func TestQueryCommitsBranchables(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users @branchable {
+						name: String
+						age: Int
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
+					"name":	"John",
+					"age":	21
+				}`,
+			},
+			testUtils.Request{
+				Request: `query {
+						commits {
+							cid
+						}
+					}`,
+				Results: map[string]any{
+					"commits": []map[string]any{
+						{
+							"cid": testUtils.NewUniqueCid("collection"),
+						},
+						{
+							"cid": testUtils.NewUniqueCid("name"),
+						},
+						{
+							"cid": testUtils.NewUniqueCid("age"),
+						},
+						{
+							"cid": testUtils.NewUniqueCid("head"),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestQueryCommitsBranchables_WithAllFields(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users @branchable {
+						name: String
+						age: Int
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
+					"name":	"John",
+					"age":	21
+				}`,
+			},
+			testUtils.Request{
+				Request: `query {
+						commits {
+							cid
+							collectionID
+							delta
+							docID
+							fieldId
+							fieldName
+							height
+							links {
+								cid
+								name
+							}
+						}
+					}`,
+				Results: map[string]any{
+					"commits": []map[string]any{
+						{
+							"cid":          testUtils.NewUniqueCid("collection"),
+							"collectionID": int64(1),
+							"delta":        nil,
+							"docID":        nil,
+							"fieldId":      nil,
+							"fieldName":    nil,
+							"height":       int64(1),
+							"links": []map[string]any{
+								{
+									"cid":  testUtils.NewUniqueCid("composite"),
+									"name": nil,
+								},
+							},
+						},
+						{
+							"cid":          testUtils.NewUniqueCid("age"),
+							"collectionID": int64(1),
+							"delta":        testUtils.CBORValue(21),
+							"docID":        "bae-0b2f15e5-bfe7-5cb7-8045-471318d7dbc3",
+							"fieldId":      "1",
+							"fieldName":    "age",
+							"height":       int64(1),
+							"links":        []map[string]any{},
+						},
+						{
+							"cid":          testUtils.NewUniqueCid("name"),
+							"collectionID": int64(1),
+							"delta":        testUtils.CBORValue("John"),
+							"docID":        "bae-0b2f15e5-bfe7-5cb7-8045-471318d7dbc3",
+							"fieldId":      "2",
+							"fieldName":    "name",
+							"height":       int64(1),
+							"links":        []map[string]any{},
+						},
+						{
+							"cid":          testUtils.NewUniqueCid("composite"),
+							"collectionID": int64(1),
+							"delta":        nil,
+							"docID":        "bae-0b2f15e5-bfe7-5cb7-8045-471318d7dbc3",
+							"fieldId":      "C",
+							"fieldName":    nil,
+							"height":       int64(1),
+							"links": []map[string]any{
+								{
+									"cid":  testUtils.NewUniqueCid("age"),
+									"name": "age",
+								},
+								{
+									"cid":  testUtils.NewUniqueCid("name"),
+									"name": "name",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/query/commits/branchables/update_test.go
+++ b/tests/integration/query/commits/branchables/update_test.go
@@ -1,0 +1,116 @@
+// Copyright 2024 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package branchables
+
+import (
+	"testing"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+func TestQueryCommitsBranchables_WithDocUpdate(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users @branchable {
+						name: String
+						age: Int
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
+					"name":	"John",
+					"age":	21
+				}`,
+			},
+			testUtils.UpdateDoc{
+				Doc: `{
+					"name":	"Fred"
+				}`,
+			},
+			testUtils.Request{
+				Request: `query {
+						commits {
+							cid
+							links {
+								cid
+							}
+						}
+					}`,
+				Results: map[string]any{
+					"commits": []map[string]any{
+						{
+							"cid": testUtils.NewUniqueCid("collection, update"),
+							"links": []map[string]any{
+								{
+									"cid": testUtils.NewUniqueCid("collection, create"),
+								},
+								{
+									"cid": testUtils.NewUniqueCid("update"),
+								},
+							},
+						},
+						{
+							"cid": testUtils.NewUniqueCid("collection, create"),
+							"links": []map[string]any{
+								{
+									"cid": testUtils.NewUniqueCid("create"),
+								},
+							},
+						},
+						{
+							"cid":   testUtils.NewUniqueCid("age, create"),
+							"links": []map[string]any{},
+						},
+						{
+							"cid": testUtils.NewUniqueCid("name, update"),
+							"links": []map[string]any{
+								{
+									"cid": testUtils.NewUniqueCid("name, create"),
+								},
+							},
+						},
+						{
+							"cid":   testUtils.NewUniqueCid("name, create"),
+							"links": []map[string]any{},
+						},
+						{
+							"cid": testUtils.NewUniqueCid("update"),
+							"links": []map[string]any{
+								{
+									"cid": testUtils.NewUniqueCid("create"),
+								},
+								{
+									"cid": testUtils.NewUniqueCid("name, update"),
+								},
+							},
+						},
+						{
+							"cid": testUtils.NewUniqueCid("create"),
+							"links": []map[string]any{
+								{
+									"cid": testUtils.NewUniqueCid("age, create"),
+								},
+								{
+									"cid": testUtils.NewUniqueCid("name, create"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/query/commits/with_null_input_test.go
+++ b/tests/integration/query/commits/with_null_input_test.go
@@ -111,17 +111,7 @@ func TestQueryCommitsWithNullFieldID(t *testing.T) {
 						}
 					}`,
 				Results: map[string]any{
-					"commits": []map[string]any{
-						{
-							"cid": "bafyreif6dqbkr7t37jcjfxxrjnxt7cspxzvs7qwlbtjca57cc663he4s7e",
-						},
-						{
-							"cid": "bafyreigtnj6ntulcilkmin4pgukjwv3nwglqpiiyddz3dyfexdbltze7sy",
-						},
-						{
-							"cid": "bafyreia2vlbfkcbyogdjzmbqcjneabwwwtw7ti2xbd7yor5mbu2sk4pcoy",
-						},
-					},
+					"commits": []map[string]any{},
 				},
 			},
 		},

--- a/tests/integration/results.go
+++ b/tests/integration/results.go
@@ -274,6 +274,7 @@ func assertCollectionDescriptions(
 
 		require.Equal(s.t, expected.Name, actual.Name)
 		require.Equal(s.t, expected.IsMaterialized, actual.IsMaterialized)
+		require.Equal(s.t, expected.IsBranchable, actual.IsBranchable)
 
 		if expected.Indexes != nil || len(actual.Indexes) != 0 {
 			// Dont bother asserting this if the expected is nil and the actual is nil/empty.


### PR DESCRIPTION
## Relevant issue(s)

Resolves #3038

## Description

Adds support for branchable collections.

Does not add support for syncing the collection level commits via the P2P system (broken out, lots of people working in the space, significant changes required, I'm not so familiar with that part of the code so will take longer).  This does mean that the somewhat surprising (to me at least) implementation of `Collection.Merge` is currently untested.

Commits are queriable via the `commits` GQL queries.

Time travel queries do not work due to an existing bug: https://github.com/sourcenetwork/defradb/issues/3214  - once that bug is fixed I expect there to be some more work (definitely testing) in order to get it to work with branchable collections.

This is a breaking change due to the moving/namespacing of the existing document headstore keys. 