### PR TITLE
feat: Make DAC write permission more granular

### DIFF
--- a/acp/README.md
+++ b/acp/README.md
@@ -174,6 +174,8 @@ defradb client ... --identity e3b722906ee4e56368f581cd8b18ab0f48af1ea53e635e3f7b
 
 We have in `examples/dpi_policy/user_dpi_policy.yml`:
 ```yaml
+name: An Example Policy
+
 description: A Valid DefraDB Policy Interface (DPI)
 
 actor:
@@ -183,15 +185,23 @@ resources:
   users:
     permissions:
       read:
-        expr: owner + reader
-      write:
-        expr: owner
+        expr: owner + reader + updater + deleter
+      update:
+        expr: owner + updater
+      delete:
+        expr: owner + deleter
 
     relations:
       owner:
         types:
           - actor
       reader:
+        types:
+          - actor
+      updater:
+        types:
+          - actor
+      deleter:
         types:
           - actor
 ```
@@ -443,8 +453,8 @@ Note:
   - The collection with the target document must have a valid policy and resource linked.
   - The target document must be registered with ACP already (private document).
   - The requesting identity MUST either be the owner OR the manager (manages the relation) of the resource.
-  - If the specified relation was not granted the miminum DPI permissions (read or write) within the policy,
-  and a relationship is formed, the subject/actor will still not be able to access (read or write) the resource.
+  - If the specified relation was not granted the miminum DPI permissions (read or update or delete) within the policy,
+  and a relationship is formed, the subject/actor will still not be able to access (read or update or delete) the resource.
   - If the relationship already exists, then it will just be a no-op.
 
 Consider the following policy that we have under `examples/dpi_policy/user_dpi_policy_with_manages.yml`:
@@ -461,10 +471,13 @@ resources:
   users:
     permissions:
       read:
-        expr: owner + reader + writer
+        expr: owner + reader + updater + deleter
 
-      write:
-        expr: owner + writer
+      update:
+        expr: owner + updater
+
+      delete:
+        expr: owner + deleter
 
       nothing:
         expr: dummy
@@ -475,6 +488,14 @@ resources:
           - actor
 
       reader:
+        types:
+          - actor
+
+      updater:
+        types:
+          - actor
+
+      deleter:
         types:
           - actor
 

--- a/acp/acp.go
+++ b/acp/acp.go
@@ -89,7 +89,7 @@ type ACP interface {
 	// Otherwise if check failed then an error is returned (and the boolean result should not be used).
 	//
 	// Note(s):
-	// - permission here is a valid DPI permission we are checking for ("read" or "write").
+	// - permission here is a valid DPI permission we are checking for ("read" or "update" or "delete").
 	CheckDocAccess(
 		ctx context.Context,
 		permission DPIPermission,

--- a/acp/acp_local_test.go
+++ b/acp/acp_local_test.go
@@ -29,7 +29,7 @@ var invalidIdentity = identity.Identity{
 	DID: "did:something",
 }
 
-var validPolicyID string = "d59f91ba65fe142d35fc7df34482eafc7e99fed7c144961ba32c4664634e61b7"
+var validPolicyID string = "87480b693bdaccdbbe1c1334204b31fd1cb44d3ad70b66fab57595283714fbfe"
 var validPolicy string = `
 name: test
 description: a policy
@@ -40,10 +40,12 @@ actor:
 resources:
   users:
     permissions:
-      write:
-        expr: owner
       read:
         expr: owner + reader
+      update:
+        expr: owner
+      delete:
+        expr: owner
 
     relations:
       owner:
@@ -495,10 +497,23 @@ func Test_LocalACP_InMemory_CheckDocAccess_TrueIfHaveAccessFalseIfNotErrorOtherw
 	require.ErrorIs(t, errCheckDocAccess, ErrFailedToVerifyDocAccessWithACP)
 	require.False(t, hasAccess)
 
-	// Invalid empty arguments such that we can't check doc access (write).
+	// Invalid empty arguments such that we can't check doc access (update).
 	hasAccess, errCheckDocAccess = localACP.CheckDocAccess(
 		ctx,
-		WritePermission,
+		UpdatePermission,
+		identity1.DID,
+		validPolicyID,
+		"",
+		"",
+	)
+	require.Error(t, errCheckDocAccess)
+	require.ErrorIs(t, errCheckDocAccess, ErrFailedToVerifyDocAccessWithACP)
+	require.False(t, hasAccess)
+
+	// Invalid empty arguments such that we can't check doc access (delete).
+	hasAccess, errCheckDocAccess = localACP.CheckDocAccess(
+		ctx,
+		DeletePermission,
 		identity1.DID,
 		validPolicyID,
 		"",
@@ -594,10 +609,23 @@ func Test_LocalACP_PersistentMemory_CheckDocAccess_TrueIfHaveAccessFalseIfNotErr
 	require.ErrorIs(t, errCheckDocAccess, ErrFailedToVerifyDocAccessWithACP)
 	require.False(t, hasAccess)
 
-	// Invalid empty arguments such that we can't check doc access (write).
+	// Invalid empty arguments such that we can't check doc access (update).
 	hasAccess, errCheckDocAccess = localACP.CheckDocAccess(
 		ctx,
-		WritePermission,
+		UpdatePermission,
+		identity1.DID,
+		validPolicyID,
+		"",
+		"",
+	)
+	require.Error(t, errCheckDocAccess)
+	require.ErrorIs(t, errCheckDocAccess, ErrFailedToVerifyDocAccessWithACP)
+	require.False(t, hasAccess)
+
+	// Invalid empty arguments such that we can't check doc access (delete).
+	hasAccess, errCheckDocAccess = localACP.CheckDocAccess(
+		ctx,
+		DeletePermission,
 		identity1.DID,
 		validPolicyID,
 		"",

--- a/acp/dpi.go
+++ b/acp/dpi.go
@@ -19,22 +19,25 @@ type DPIPermission int
 // Valid DefraDB Policy Interface Permission Type.
 const (
 	ReadPermission DPIPermission = iota
-	WritePermission
+	UpdatePermission
+	DeletePermission
 )
 
 // permissionsThatImplyRead is a list of any permissions that if we have, we assume that the user can read.
-// This is because for DefraDB's purposes if an identity has access to the write permission, then they don't
-// need to explicitly have read permission inorder to read, we can just imply that they have read access.
+// This is because for DefraDB's purposes if an identity has access to any write permission (delete or update),
+// then they don't need to explicitly have read permission inorder to read, we can just imply that they have read access.
 var permissionsThatImplyRead = []DPIPermission{
 	ReadPermission,
-	WritePermission,
+	UpdatePermission,
+	DeletePermission,
 }
 
 // List of all valid DPI permissions, the order of permissions in this list must match
 // the above defined ordering such that iota matches the index position within the list.
 var dpiRequiredPermissions = []string{
 	"read",
-	"write",
+	"update",
+	"delete",
 }
 
 func (dpiPermission DPIPermission) String() string {

--- a/examples/dpi_policy/user_dpi_policy.json
+++ b/examples/dpi_policy/user_dpi_policy.json
@@ -8,10 +8,13 @@
     "users": {
       "permissions": {
         "read": {
-          "expr": "owner + reader"
+          "expr": "owner + reader + updater + deleter"
         },
-        "write": {
-          "expr": "owner"
+        "update": {
+          "expr": "owner + updater"
+        }
+        "delete": {
+          "expr": "owner + deleter"
         }
       },
       "relations": {
@@ -21,6 +24,16 @@
           ]
         },
         "reader": {
+          "types": [
+            "actor"
+          ]
+        }
+        "updater": {
+          "types": [
+            "actor"
+          ]
+        }
+        "deleter": {
           "types": [
             "actor"
           ]

--- a/examples/dpi_policy/user_dpi_policy.yml
+++ b/examples/dpi_policy/user_dpi_policy.yml
@@ -18,14 +18,22 @@ resources:
   users:
     permissions:
       read:
-        expr: owner + reader
-      write:
-        expr: owner
+        expr: owner + reader + updater + deleter
+      update:
+        expr: owner + updater
+      delete:
+        expr: owner + deleter
 
     relations:
       owner:
         types:
           - actor
       reader:
+        types:
+          - actor
+      updater:
+        types:
+          - actor
+      deleter:
         types:
           - actor

--- a/examples/dpi_policy/user_dpi_policy_with_manages.yml
+++ b/examples/dpi_policy/user_dpi_policy_with_manages.yml
@@ -17,10 +17,13 @@ resources:
   users:
     permissions:
       read:
-        expr: owner + reader + writer
+        expr: owner + reader + updater + deleter + writer
 
-      write:
-        expr: owner + writer
+      update:
+        expr: owner + updater
+
+      delete:
+        expr: owner + deleter
 
       nothing:
         expr: dummy
@@ -31,6 +34,14 @@ resources:
           - actor
 
       reader:
+        types:
+          - actor
+
+      updater:
+        types:
+          - actor
+
+      deleter:
         types:
           - actor
 

--- a/internal/db/collection.go
+++ b/internal/db/collection.go
@@ -523,7 +523,7 @@ func (c *collection) update(
 	// Stop the update if the correct permissions aren't there.
 	canUpdate, err := c.checkAccessOfDocWithACP(
 		ctx,
-		acp.WritePermission,
+		acp.UpdatePermission,
 		doc.ID().String(),
 	)
 	if err != nil {

--- a/internal/db/collection_delete.go
+++ b/internal/db/collection_delete.go
@@ -127,7 +127,7 @@ func (c *collection) applyDelete(
 	// Stop deletion of document if the correct permissions aren't there.
 	canDelete, err := c.checkAccessOfDocWithACP(
 		ctx,
-		acp.WritePermission,
+		acp.DeletePermission,
 		primaryKey.DocID,
 	)
 


### PR DESCRIPTION
## Relevant issue(s)

Resolves #2905 

## Description
Split `write` into `update` and `delete` permission.

## How has this been tested?
- [ ] todo: Update previous test once migration of policyID is done
- [ ] todo: Split previous write tests