### PR TITLE
docs: Update discord link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ This document will guide you through the process of contributing to the project.
 
 All contributions are appreciated, whether it's identifying problems, highlighting missing features, or contributing to the codebase in simple or complex ways.
 
-You are encouraged to join the [Source Network Discord](discord.gg/w7jYQVJ) to discuss ideas, ask questions, and find inspiration for future developments.
+You are encouraged to join the [Source Network Discord](https://discord.gg/w7jYQVJ) to discuss ideas, ask questions, and find inspiration for future developments.
 
 ## Getting started
 To get started, clone the repository, build, and run it:


### PR DESCRIPTION
## Relevant issue(s)

Resolves #3236

## Description

Small PR - adds `https://` to the Discord link to prevent GitHub from interpreting it as an internal repository link.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [ ] I made sure the repository-held documentation is changed accordingly.
- [ ] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [ ] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

(*replace*) Describe the tests performed to verify the changes. Provide instructions to reproduce them.

Specify the platform(s) on which this was tested:
- *(modify the list accordingly*)
- Arch Linux
- Debian Linux
- MacOS
- Windows
