### PR TITLE
test(i): Skip test when detecting changes

### DIFF
--- a/tests/integration/query/simple/with_cid_test.go
+++ b/tests/integration/query/simple/with_cid_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sourcenetwork/immutable"
 	"github.com/stretchr/testify/require"
 
+	"github.com/sourcenetwork/defradb/tests/change_detector"
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
 )
 
@@ -46,6 +47,10 @@ func TestQuerySimpleWithInvalidCid(t *testing.T) {
 // This test documents a bug:
 // https://github.com/sourcenetwork/defradb/issues/3214
 func TestQuerySimpleWithCid(t *testing.T) {
+	if change_detector.Enabled {
+		t.Skipf("Change detector does not support requiring panics")
+	}
+
 	test := testUtils.TestCase{
 		SupportedClientTypes: immutable.Some(
 			[]testUtils.ClientType{


### PR DESCRIPTION
## Relevant issue(s)

Resolves #3233

## Description

Skip test `TestQuerySimpleWithCid` when detecting changes as the change detector does not support asserting panics.

Note: The CI wont pass until *after* this is merged to develop, so someone will need to change the requiredness of the job so that this can merge.