### PR TITLE
fix(i): Remove flakyness of AES decrypt test

### DIFF
--- a/crypto/aes_test.go
+++ b/crypto/aes_test.go
@@ -149,9 +149,10 @@ func TestDecryptAES(t *testing.T) {
 			errorContains:  "message authentication failed",
 		},
 		{
-			name:           "Tampered ciphertext",
-			nonce:          validNonce,
-			cipherText:     append([]byte{0}, validCiphertext[AESNonceSize+1:]...),
+			name:  "Tampered ciphertext",
+			nonce: validNonce,
+			// Flip a byte in the ciphertext to corrupt it.
+			cipherText:     append([]byte{^validCiphertext[AESNonceSize]}, validCiphertext[AESNonceSize+1:]...),
 			key:            validKey,
 			additionalData: validAAD,
 			expectError:    true,


### PR DESCRIPTION
## Relevant issue(s)

Resolves #3240 

## Description

This PR fixes a flaky test where the modification of the cypher text was supposed to cause it to fail decryption. The modification turned out to sometime be the same as the actual cypher text.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).

## How has this been tested?

Run the `TestDecryptAES` test.

Specify the platform(s) on which this was tested:
- MacOS
