### PR TITLE
feat(i): Handle collection commits over P2P

### DIFF
--- a/internal/db/merge.go
+++ b/internal/db/merge.go
@@ -43,20 +43,19 @@ func (db *db) executeMerge(ctx context.Context, col *collection, dagMerge event.
 	}
 	defer txn.Discard(ctx)
 
-	var mt mergeTarget
+	var key keys.HeadstoreKey
 	if dagMerge.DocID != "" {
-		mt, err = getHeadsAsMergeTarget(ctx, txn, keys.HeadstoreDocKey{
+		key = keys.HeadstoreDocKey{
 			DocID:   dagMerge.DocID,
 			FieldID: core.COMPOSITE_NAMESPACE,
-		})
-		if err != nil {
-			return err
 		}
 	} else {
-		mt, err = getHeadsAsMergeTarget(ctx, txn, keys.NewHeadstoreColKey(col.Description().RootID))
-		if err != nil {
-			return err
-		}
+		key = keys.NewHeadstoreColKey(col.Description().RootID)
+	}
+
+	mt, err := getHeadsAsMergeTarget(ctx, txn, key)
+	if err != nil {
+		return err
 	}
 
 	mp, err := db.newMergeProcessor(txn, col)

--- a/internal/db/merge_test.go
+++ b/internal/db/merge_test.go
@@ -58,7 +58,7 @@ func TestMerge_SingleBranch_NoError(t *testing.T) {
 	compInfo2, err := d.generateCompositeUpdate(&lsys, map[string]any{"name": "Johny"}, compInfo)
 	require.NoError(t, err)
 
-	err = db.executeMerge(ctx, event.Merge{
+	err = db.executeMerge(ctx, col.(*collection), event.Merge{
 		DocID:      docID.String(),
 		Cid:        compInfo2.link.Cid,
 		SchemaRoot: col.SchemaRoot(),
@@ -103,7 +103,7 @@ func TestMerge_DualBranch_NoError(t *testing.T) {
 	compInfo2, err := d.generateCompositeUpdate(&lsys, map[string]any{"name": "Johny"}, compInfo)
 	require.NoError(t, err)
 
-	err = db.executeMerge(ctx, event.Merge{
+	err = db.executeMerge(ctx, col.(*collection), event.Merge{
 		DocID:      docID.String(),
 		Cid:        compInfo2.link.Cid,
 		SchemaRoot: col.SchemaRoot(),
@@ -113,7 +113,7 @@ func TestMerge_DualBranch_NoError(t *testing.T) {
 	compInfo3, err := d.generateCompositeUpdate(&lsys, map[string]any{"age": 30}, compInfo)
 	require.NoError(t, err)
 
-	err = db.executeMerge(ctx, event.Merge{
+	err = db.executeMerge(ctx, col.(*collection), event.Merge{
 		DocID:      docID.String(),
 		Cid:        compInfo3.link.Cid,
 		SchemaRoot: col.SchemaRoot(),
@@ -161,7 +161,7 @@ func TestMerge_DualBranchWithOneIncomplete_CouldNotFindCID(t *testing.T) {
 	compInfo2, err := d.generateCompositeUpdate(&lsys, map[string]any{"name": "Johny"}, compInfo)
 	require.NoError(t, err)
 
-	err = db.executeMerge(ctx, event.Merge{
+	err = db.executeMerge(ctx, col.(*collection), event.Merge{
 		DocID:      docID.String(),
 		Cid:        compInfo2.link.Cid,
 		SchemaRoot: col.SchemaRoot(),
@@ -180,7 +180,7 @@ func TestMerge_DualBranchWithOneIncomplete_CouldNotFindCID(t *testing.T) {
 	compInfo3, err := d.generateCompositeUpdate(&lsys, map[string]any{"name": "Johny"}, compInfoUnkown)
 	require.NoError(t, err)
 
-	err = db.executeMerge(ctx, event.Merge{
+	err = db.executeMerge(ctx, col.(*collection), event.Merge{
 		DocID:      docID.String(),
 		Cid:        compInfo3.link.Cid,
 		SchemaRoot: col.SchemaRoot(),
@@ -304,15 +304,15 @@ func TestMergeQueue(t *testing.T) {
 	go q.add(testDocID)
 	// give time for the goroutine to block
 	time.Sleep(10 * time.Millisecond)
-	require.Len(t, q.docs, 1)
+	require.Len(t, q.keys, 1)
 	q.done(testDocID)
 	// give time for the goroutine to add the docID
 	time.Sleep(10 * time.Millisecond)
 	q.mutex.Lock()
-	require.Len(t, q.docs, 1)
+	require.Len(t, q.keys, 1)
 	q.mutex.Unlock()
 	q.done(testDocID)
 	q.mutex.Lock()
-	require.Len(t, q.docs, 0)
+	require.Len(t, q.keys, 0)
 	q.mutex.Unlock()
 }

--- a/internal/db/messages.go
+++ b/internal/db/messages.go
@@ -22,7 +22,7 @@ import (
 )
 
 func (db *db) handleMessages(ctx context.Context, sub *event.Subscription) {
-	docIdQueue := newMergeQueue()
+	docIDQueue := newMergeQueue()
 	schemaRootQueue := newMergeQueue()
 
 	// This is used to ensure we only trigger loadAndPublishP2PCollections and loadAndPublishReplicators
@@ -57,8 +57,8 @@ func (db *db) handleMessages(ctx context.Context, sub *event.Subscription) {
 						defer schemaRootQueue.done(evt.SchemaRoot)
 					} else {
 						// ensure only one merge per docID
-						docIdQueue.add(evt.DocID)
-						defer docIdQueue.done(evt.DocID)
+						docIDQueue.add(evt.DocID)
+						defer docIDQueue.done(evt.DocID)
 					}
 
 					// retry the merge process if a conflict occurs

--- a/net/peer.go
+++ b/net/peer.go
@@ -255,9 +255,11 @@ func (p *Peer) handleMessageLoop() {
 }
 
 func (p *Peer) handleLog(evt event.Update) error {
-	_, err := client.NewDocIDFromString(evt.DocID)
-	if err != nil {
-		return NewErrFailedToGetDocID(err)
+	if evt.DocID != "" {
+		_, err := client.NewDocIDFromString(evt.DocID)
+		if err != nil {
+			return NewErrFailedToGetDocID(err)
+		}
 	}
 
 	// push to each peer (replicator)
@@ -273,8 +275,10 @@ func (p *Peer) handleLog(evt event.Update) error {
 			Block:      evt.Block,
 		}
 
-		if err := p.server.publishLog(p.ctx, evt.DocID, req); err != nil {
-			return NewErrPublishingToDocIDTopic(err, evt.Cid.String(), evt.DocID)
+		if evt.DocID != "" {
+			if err := p.server.publishLog(p.ctx, evt.DocID, req); err != nil {
+				return NewErrPublishingToDocIDTopic(err, evt.Cid.String(), evt.DocID)
+			}
 		}
 
 		if err := p.server.publishLog(p.ctx, evt.SchemaRoot, req); err != nil {

--- a/tests/integration/acp.go
+++ b/tests/integration/acp.go
@@ -215,7 +215,12 @@ func addDocActorRelationshipACP(
 	}
 
 	if action.ExpectedError == "" && !action.ExpectedExistence {
-		waitForUpdateEvents(s, actionNodeID, map[string]struct{}{docID: {}})
+		expect := make([]map[string]struct{}, action.CollectionID+1)
+		expect[action.CollectionID] = map[string]struct{}{
+			docID: {},
+		}
+
+		waitForUpdateEvents(s, actionNodeID, expect)
 	}
 }
 

--- a/tests/integration/acp.go
+++ b/tests/integration/acp.go
@@ -215,12 +215,11 @@ func addDocActorRelationshipACP(
 	}
 
 	if action.ExpectedError == "" && !action.ExpectedExistence {
-		expect := make([]map[string]struct{}, action.CollectionID+1)
-		expect[action.CollectionID] = map[string]struct{}{
+		expect := map[string]struct{}{
 			docID: {},
 		}
 
-		waitForUpdateEvents(s, actionNodeID, expect)
+		waitForUpdateEvents(s, actionNodeID, action.CollectionID, expect)
 	}
 }
 

--- a/tests/integration/events.go
+++ b/tests/integration/events.go
@@ -73,8 +73,8 @@ func waitForReplicatorConfigureEvent(s *state, cfg ConfigureReplicator) {
 	}
 
 	// all previous documents should be merged on the subscriber node
-	for key, val := range s.nodes[cfg.SourceNodeID].p2p.actualDocHeads {
-		s.nodes[cfg.TargetNodeID].p2p.expectedDocHeads[key] = val.cid
+	for key, val := range s.nodes[cfg.SourceNodeID].p2p.actualDAGHeads {
+		s.nodes[cfg.TargetNodeID].p2p.expectedDAGHeads[key] = val.cid
 	}
 
 	// update node connections and replicators
@@ -153,7 +153,7 @@ func waitForUnsubscribeToCollectionEvent(s *state, action UnsubscribeToCollectio
 func waitForUpdateEvents(
 	s *state,
 	nodeID immutable.Option[int],
-	docIDs map[string]struct{},
+	docIDs []map[string]struct{},
 ) {
 	for i := 0; i < len(s.nodes); i++ {
 		if nodeID.HasValue() && nodeID.Value() != i {
@@ -166,8 +166,15 @@ func waitForUpdateEvents(
 		}
 
 		expect := make(map[string]struct{}, len(docIDs))
-		for k := range docIDs {
-			expect[k] = struct{}{}
+		for collectionIndex, collectionDocIDs := range docIDs {
+			for k := range collectionDocIDs {
+				expect[k] = struct{}{}
+
+				col := node.collections[collectionIndex]
+				if col.Description().IsBranchable {
+					expect[col.SchemaRoot()] = struct{}{}
+				}
+			}
 		}
 
 		for len(expect) > 0 {
@@ -183,16 +190,10 @@ func waitForUpdateEvents(
 				require.Fail(s.t, "timeout waiting for update event", "Node %d", i)
 			}
 
-			if evt.DocID == "" {
-				// Todo: This will almost certainly need to change once P2P for collection-level commits
-				// is enabled. See: https://github.com/sourcenetwork/defradb/issues/3212
-				continue
-			}
-
 			// make sure the event is expected
-			_, ok := expect[evt.DocID]
-			require.True(s.t, ok, "unexpected document update", "Node %d", i)
-			delete(expect, evt.DocID)
+			_, ok := expect[getUpdateEventKey(evt)]
+			require.True(s.t, ok, "unexpected document update", getUpdateEventKey(evt))
+			delete(expect, getUpdateEventKey(evt))
 
 			// we only need to update the network state if the nodes
 			// are configured for networking
@@ -203,7 +204,7 @@ func waitForUpdateEvents(
 	}
 }
 
-// waitForMergeEvents waits for all expected document heads to be merged to all nodes.
+// waitForMergeEvents waits for all expected heads to be merged to all nodes.
 //
 // Will fail the test if an event is not received within the expected time interval to prevent tests
 // from running forever.
@@ -214,11 +215,11 @@ func waitForMergeEvents(s *state, action WaitForSync) {
 			continue // node is closed
 		}
 
-		expect := node.p2p.expectedDocHeads
+		expect := node.p2p.expectedDAGHeads
 
-		// remove any docs that are already merged
-		// up to the expected document head
-		for key, val := range node.p2p.actualDocHeads {
+		// remove any heads that are already merged
+		// up to the expected head
+		for key, val := range node.p2p.actualDAGHeads {
 			if head, ok := expect[key]; ok && head.String() == val.cid.String() {
 				delete(expect, key)
 			}
@@ -230,13 +231,13 @@ func waitForMergeEvents(s *state, action WaitForSync) {
 				require.Fail(s.t, "doc index %d out of range", docIndex)
 			}
 			docID := s.docIDs[0][docIndex].String()
-			actual, hasActual := node.p2p.actualDocHeads[docID]
+			actual, hasActual := node.p2p.actualDAGHeads[docID]
 			if !hasActual || !actual.decrypted {
 				expectDecrypted[docID] = struct{}{}
 			}
 		}
 
-		// wait for all expected doc heads to be merged
+		// wait for all expected heads to be merged
 		//
 		// the order of merges does not matter as we only
 		// expect the latest head to eventually be merged
@@ -260,11 +261,11 @@ func waitForMergeEvents(s *state, action WaitForSync) {
 				delete(expectDecrypted, evt.Merge.DocID)
 			}
 
-			head, ok := expect[evt.Merge.DocID]
+			head, ok := expect[getMergeEventKey(evt.Merge)]
 			if ok && head.String() == evt.Merge.Cid.String() {
-				delete(expect, evt.Merge.DocID)
+				delete(expect, getMergeEventKey(evt.Merge))
 			}
-			node.p2p.actualDocHeads[evt.Merge.DocID] = docHeadState{cid: evt.Merge.Cid, decrypted: evt.Decrypted}
+			node.p2p.actualDAGHeads[getMergeEventKey(evt.Merge)] = docHeadState{cid: evt.Merge.Cid, decrypted: evt.Decrypted}
 		}
 	}
 }
@@ -284,23 +285,23 @@ func updateNetworkState(s *state, nodeID int, evt event.Update) {
 
 	// update the actual document head on the node that updated it
 	// as the node created the document, it is already decrypted
-	node.p2p.actualDocHeads[evt.DocID] = docHeadState{cid: evt.Cid, decrypted: true}
+	node.p2p.actualDAGHeads[getUpdateEventKey(evt)] = docHeadState{cid: evt.Cid, decrypted: true}
 
 	// update the expected document heads of replicator targets
 	for id := range node.p2p.replicators {
 		// replicator target nodes push updates to source nodes
-		s.nodes[id].p2p.expectedDocHeads[evt.DocID] = evt.Cid
+		s.nodes[id].p2p.expectedDAGHeads[getUpdateEventKey(evt)] = evt.Cid
 	}
 
 	// update the expected document heads of connected nodes
 	for id := range node.p2p.connections {
 		// connected nodes share updates of documents they have in common
-		if _, ok := s.nodes[id].p2p.actualDocHeads[evt.DocID]; ok {
-			s.nodes[id].p2p.expectedDocHeads[evt.DocID] = evt.Cid
+		if _, ok := s.nodes[id].p2p.actualDAGHeads[getUpdateEventKey(evt)]; ok {
+			s.nodes[id].p2p.expectedDAGHeads[getUpdateEventKey(evt)] = evt.Cid
 		}
 		// peer collection subscribers receive updates from any other subscriber node
 		if _, ok := s.nodes[id].p2p.peerCollections[collectionID]; ok {
-			s.nodes[id].p2p.expectedDocHeads[evt.DocID] = evt.Cid
+			s.nodes[id].p2p.expectedDAGHeads[getUpdateEventKey(evt)] = evt.Cid
 		}
 	}
 
@@ -312,21 +313,24 @@ func updateNetworkState(s *state, nodeID int, evt event.Update) {
 
 // getEventsForUpdateDoc returns a map of docIDs that should be
 // published to the local event bus after an UpdateDoc action.
-func getEventsForUpdateDoc(s *state, action UpdateDoc) map[string]struct{} {
+func getEventsForUpdateDoc(s *state, action UpdateDoc) []map[string]struct{} {
 	docID := s.docIDs[action.CollectionID][action.DocID]
 
 	docMap := make(map[string]any)
 	err := json.Unmarshal([]byte(action.Doc), &docMap)
 	require.NoError(s.t, err)
 
-	return map[string]struct{}{
+	expect := make([]map[string]struct{}, action.CollectionID+1)
+	expect[action.CollectionID] = map[string]struct{}{
 		docID.String(): {},
 	}
+
+	return expect
 }
 
 // getEventsForCreateDoc returns a map of docIDs that should be
 // published to the local event bus after a CreateDoc action.
-func getEventsForCreateDoc(s *state, action CreateDoc) map[string]struct{} {
+func getEventsForCreateDoc(s *state, action CreateDoc) []map[string]struct{} {
 	var collection client.Collection
 	if action.NodeID.HasValue() {
 		collection = s.nodes[action.NodeID.Value()].collections[action.CollectionID]
@@ -337,10 +341,11 @@ func getEventsForCreateDoc(s *state, action CreateDoc) map[string]struct{} {
 	docs, err := parseCreateDocs(action, collection)
 	require.NoError(s.t, err)
 
-	expect := make(map[string]struct{})
+	expect := make([]map[string]struct{}, action.CollectionID+1)
+	expect[action.CollectionID] = map[string]struct{}{}
 
 	for _, doc := range docs {
-		expect[doc.ID().String()] = struct{}{}
+		expect[action.CollectionID][doc.ID().String()] = struct{}{}
 	}
 
 	return expect
@@ -356,16 +361,41 @@ func getEventsForUpdateWithFilter(
 	s *state,
 	action UpdateWithFilter,
 	result *client.UpdateResult,
-) map[string]struct{} {
+) []map[string]struct{} {
 	var docPatch map[string]any
 	err := json.Unmarshal([]byte(action.Updater), &docPatch)
 	require.NoError(s.t, err)
 
-	expect := make(map[string]struct{})
+	expect := make([]map[string]struct{}, action.CollectionID+1)
+	expect[action.CollectionID] = map[string]struct{}{}
 
 	for _, docID := range result.DocIDs {
-		expect[docID] = struct{}{}
+		expect[action.CollectionID][docID] = struct{}{}
 	}
 
 	return expect
+}
+
+// getUpdateEventKey gets the identifier to which this event is scoped to.
+//
+// For example, if this is scoped to a document, the document ID will be
+// returned.  If it is scoped to a schema, the schema root will be returned.
+func getUpdateEventKey(evt event.Update) string {
+	if evt.DocID == "" {
+		return evt.SchemaRoot
+	}
+
+	return evt.DocID
+}
+
+// getMergeEventKey gets the identifier to which this event is scoped to.
+//
+// For example, if this is scoped to a document, the document ID will be
+// returned.  If it is scoped to a schema, the schema root will be returned.
+func getMergeEventKey(evt event.Merge) string {
+	if evt.DocID == "" {
+		return evt.SchemaRoot
+	}
+
+	return evt.DocID
 }

--- a/tests/integration/query/commits/branchables/peer_index_test.go
+++ b/tests/integration/query/commits/branchables/peer_index_test.go
@@ -1,0 +1,68 @@
+// Copyright 2024 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package branchables
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/immutable"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+func TestQueryCommitsBranchables_SyncsIndexAcrossPeerConnection(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.RandomNetworkingConfig(),
+			testUtils.RandomNetworkingConfig(),
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users @branchable {
+						name: String @index
+					}
+				`,
+			},
+			testUtils.ConnectPeers{
+				SourceNodeID: 1,
+				TargetNodeID: 0,
+			},
+			testUtils.SubscribeToCollection{
+				NodeID:        1,
+				CollectionIDs: []int{0},
+			},
+			testUtils.CreateDoc{
+				NodeID: immutable.Some(0),
+				Doc: `{
+					"name":	"John"
+				}`,
+			},
+			testUtils.WaitForSync{},
+			testUtils.Request{
+				// This query errors out if the document's index has not been correctly
+				// constructed
+				Request: `query {
+					Users (filter: {name: {_eq: "John"}}){
+						name
+					}
+				}`,
+				Results: map[string]any{
+					"Users": []map[string]any{
+						{
+							"name": "John",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/query/commits/branchables/peer_test.go
+++ b/tests/integration/query/commits/branchables/peer_test.go
@@ -59,29 +59,29 @@ func TestQueryCommitsBranchables_SyncsAcrossPeerConnection(t *testing.T) {
 				Results: map[string]any{
 					"commits": []map[string]any{
 						{
-							"cid": testUtils.NewUniqueCid(0),
+							"cid": testUtils.NewUniqueCid("collection"),
 							"links": []map[string]any{
 								{
-									"cid": testUtils.NewUniqueCid(1),
+									"cid": testUtils.NewUniqueCid("composite"),
 								},
 							},
 						},
 						{
-							"cid":   testUtils.NewUniqueCid(2),
+							"cid":   testUtils.NewUniqueCid("age"),
 							"links": []map[string]any{},
 						},
 						{
-							"cid":   testUtils.NewUniqueCid(3),
+							"cid":   testUtils.NewUniqueCid("name"),
 							"links": []map[string]any{},
 						},
 						{
-							"cid": testUtils.NewUniqueCid(1),
+							"cid": testUtils.NewUniqueCid("composite"),
 							"links": []map[string]any{
 								{
-									"cid": testUtils.NewUniqueCid(2),
+									"cid": testUtils.NewUniqueCid("age"),
 								},
 								{
-									"cid": testUtils.NewUniqueCid(3),
+									"cid": testUtils.NewUniqueCid("name"),
 								},
 							},
 						},

--- a/tests/integration/query/commits/branchables/peer_update_test.go
+++ b/tests/integration/query/commits/branchables/peer_update_test.go
@@ -88,16 +88,16 @@ func TestQueryCommitsBranchables_HandlesConcurrentUpdatesAcrossPeerConnection(t 
 				Results: map[string]any{
 					"commits": []map[string]any{
 						{
-							"cid": testUtils.NewUniqueCid("collection, update3"),
+							"cid": testUtils.NewUniqueCid("collection, node0 update3"),
 							"links": []map[string]any{
 								{
-									"cid": testUtils.NewUniqueCid("collection, update2"),
+									"cid": testUtils.NewUniqueCid("collection, node1 update2"),
 								},
 								{
 									"cid": testUtils.NewUniqueCid("collection, node1 update1"),
 								},
 								{
-									"cid": testUtils.NewUniqueCid("doc, update3"),
+									"cid": testUtils.NewUniqueCid("doc, node0 update3"),
 								},
 							},
 						},
@@ -121,13 +121,13 @@ func TestQueryCommitsBranchables_HandlesConcurrentUpdatesAcrossPeerConnection(t 
 							},
 						},
 						{
-							"cid": testUtils.NewUniqueCid("collection, update2"),
+							"cid": testUtils.NewUniqueCid("collection, node1 update2"),
 							"links": []map[string]any{
 								{
 									"cid": testUtils.NewUniqueCid("collection, node0 update1"),
 								},
 								{
-									"cid": testUtils.NewUniqueCid("doc, update2"),
+									"cid": testUtils.NewUniqueCid("doc, node1 update2"),
 								},
 							},
 						},
@@ -143,18 +143,18 @@ func TestQueryCommitsBranchables_HandlesConcurrentUpdatesAcrossPeerConnection(t 
 							},
 						},
 						{
-							"cid": testUtils.NewUniqueCid("name, update3"),
+							"cid": testUtils.NewUniqueCid("name, node0 update3"),
 							"links": []map[string]any{
 								{
 									"cid": testUtils.NewUniqueCid("name, node1 update1"),
 								},
 								{
-									"cid": testUtils.NewUniqueCid("name, update2"),
+									"cid": testUtils.NewUniqueCid("name, node1 update2"),
 								},
 							},
 						},
 						{
-							"cid": testUtils.NewUniqueCid("name, update2"),
+							"cid": testUtils.NewUniqueCid("name, node1 update2"),
 							"links": []map[string]any{
 								{
 									"cid": testUtils.NewUniqueCid("name, node0 update1"),
@@ -182,16 +182,16 @@ func TestQueryCommitsBranchables_HandlesConcurrentUpdatesAcrossPeerConnection(t 
 							},
 						},
 						{
-							"cid": testUtils.NewUniqueCid("doc, update3"),
+							"cid": testUtils.NewUniqueCid("doc, node0 update3"),
 							"links": []map[string]any{
 								{
-									"cid": testUtils.NewUniqueCid("doc, update2"),
+									"cid": testUtils.NewUniqueCid("doc, node1 update2"),
 								},
 								{
 									"cid": testUtils.NewUniqueCid("doc, node1 update1"),
 								},
 								{
-									"cid": testUtils.NewUniqueCid("name, update3"),
+									"cid": testUtils.NewUniqueCid("name, node0 update3"),
 								},
 							},
 						},
@@ -215,13 +215,13 @@ func TestQueryCommitsBranchables_HandlesConcurrentUpdatesAcrossPeerConnection(t 
 							},
 						},
 						{
-							"cid": testUtils.NewUniqueCid("doc, update2"),
+							"cid": testUtils.NewUniqueCid("doc, node1 update2"),
 							"links": []map[string]any{
 								{
 									"cid": testUtils.NewUniqueCid("doc, node0 update1"),
 								},
 								{
-									"cid": testUtils.NewUniqueCid("name, update2"),
+									"cid": testUtils.NewUniqueCid("name, node1 update2"),
 								},
 							},
 						},

--- a/tests/integration/query/commits/branchables/peer_update_test.go
+++ b/tests/integration/query/commits/branchables/peer_update_test.go
@@ -1,0 +1,303 @@
+// Copyright 2024 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package branchables
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/immutable"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+func TestQueryCommitsBranchables_HandlesConcurrentUpdatesAcrossPeerConnection(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.RandomNetworkingConfig(),
+			testUtils.RandomNetworkingConfig(),
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users @branchable {
+						name: String
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
+					"name":	"John"
+				}`,
+			},
+			testUtils.UpdateDoc{
+				NodeID: immutable.Some(0),
+				Doc: `{
+					"name":	"Fred"
+				}`,
+			},
+			testUtils.UpdateDoc{
+				NodeID: immutable.Some(1),
+				Doc: `{
+					"name":	"Shahzad"
+				}`,
+			},
+			testUtils.ConnectPeers{
+				SourceNodeID: 1,
+				TargetNodeID: 0,
+			},
+			testUtils.WaitForSync{},
+			testUtils.UpdateDoc{
+				NodeID: immutable.Some(1),
+				Doc: `{
+					"name":	"Chris"
+				}`,
+			},
+			testUtils.WaitForSync{},
+			// Note: node 1 does not recieve the first update from node 0 as it occured before the nodes were connected
+			// node 0 has it as it recieved it when recieving the second update from node 1.  The cids and blocks remain
+			// consistent across both nodes (minus the missing commits).
+			testUtils.Request{
+				NodeID: immutable.Some(0),
+				Request: `query {
+						commits {
+							cid
+							links {
+								cid
+							}
+						}
+					}`,
+				Results: map[string]any{
+					"commits": []map[string]any{
+						{
+							"cid": testUtils.NewUniqueCid("collection, update2"),
+							"links": []map[string]any{
+								{
+									"cid": testUtils.NewUniqueCid("collection, node1 update1"),
+								},
+								{
+									"cid": testUtils.NewUniqueCid("doc, update2"),
+								},
+							},
+						},
+						{
+							"cid": testUtils.NewUniqueCid("collection, node1 update1"),
+							"links": []map[string]any{
+								{
+									"cid": testUtils.NewUniqueCid("collection, create"),
+								},
+								{
+									"cid": testUtils.NewUniqueCid("doc, node1 update1"),
+								},
+							},
+						},
+						{
+							"cid": testUtils.NewUniqueCid("collection, create"),
+							"links": []map[string]any{
+								{
+									"cid": testUtils.NewUniqueCid("doc, create"),
+								},
+							},
+						},
+						{
+							"cid": testUtils.NewUniqueCid("collection, node0 update1"),
+							"links": []map[string]any{
+								{
+									"cid": testUtils.NewUniqueCid("collection, create"),
+								},
+								{
+									"cid": testUtils.NewUniqueCid("doc, node0 update1"),
+								},
+							},
+						},
+						{
+							"cid": testUtils.NewUniqueCid("name, node0 update1"),
+							"links": []map[string]any{
+								{
+									"cid": testUtils.NewUniqueCid("name, create"),
+								},
+							},
+						},
+						{
+							"cid":   testUtils.NewUniqueCid("name, create"),
+							"links": []map[string]any{},
+						},
+						{
+							"cid": testUtils.NewUniqueCid("name, update2"),
+							"links": []map[string]any{
+								{
+									"cid": testUtils.NewUniqueCid("name, node1 update1"),
+								},
+							},
+						},
+						{
+							"cid": testUtils.NewUniqueCid("name, node1 update1"),
+							"links": []map[string]any{
+								{
+									"cid": testUtils.NewUniqueCid("name, create"),
+								},
+							},
+						},
+						{
+							"cid": testUtils.NewUniqueCid("doc, update2"),
+							"links": []map[string]any{
+								{
+									"cid": testUtils.NewUniqueCid("doc, node1 update1"),
+								},
+								{
+									"cid": testUtils.NewUniqueCid("name, update2"),
+								},
+							},
+						},
+						{
+							"cid": testUtils.NewUniqueCid("doc, node1 update1"),
+							"links": []map[string]any{
+								{
+									"cid": testUtils.NewUniqueCid("doc, create"),
+								},
+								{
+									"cid": testUtils.NewUniqueCid("name, node1 update1"),
+								},
+							},
+						},
+						{
+							"cid": testUtils.NewUniqueCid("doc, create"),
+							"links": []map[string]any{
+								{
+									"cid": testUtils.NewUniqueCid("name, create"),
+								},
+							},
+						},
+						{
+							"cid": testUtils.NewUniqueCid("doc, node0 update1"),
+							"links": []map[string]any{
+								{
+									"cid": testUtils.NewUniqueCid("doc, create"),
+								},
+								{
+									"cid": testUtils.NewUniqueCid("name, node0 update1"),
+								},
+							},
+						},
+					},
+				},
+			},
+			testUtils.Request{
+				NodeID: immutable.Some(1),
+				Request: `query {
+						commits {
+							cid
+							links {
+								cid
+							}
+						}
+					}`,
+				Results: map[string]any{
+					"commits": []map[string]any{
+						{
+							"cid": testUtils.NewUniqueCid("collection, update2"),
+							"links": []map[string]any{
+								{
+									"cid": testUtils.NewUniqueCid("collection, node1 update1"),
+								},
+								{
+									"cid": testUtils.NewUniqueCid("doc, update2"),
+								},
+							},
+						},
+						{
+							"cid": testUtils.NewUniqueCid("collection, node1 update1"),
+							"links": []map[string]any{
+								{
+									"cid": testUtils.NewUniqueCid("collection, create"),
+								},
+								{
+									"cid": testUtils.NewUniqueCid("doc, node1 update1"),
+								},
+							},
+						},
+						{
+							"cid": testUtils.NewUniqueCid("collection, create"),
+							"links": []map[string]any{
+								{
+									"cid": testUtils.NewUniqueCid("doc, create"),
+								},
+							},
+						},
+						{
+							"cid": testUtils.NewUniqueCid("name, update2"),
+							"links": []map[string]any{
+								{
+									"cid": testUtils.NewUniqueCid("name, node1 update1"),
+								},
+							},
+						},
+						{
+							"cid": testUtils.NewUniqueCid("name, node1 update1"),
+							"links": []map[string]any{
+								{
+									"cid": testUtils.NewUniqueCid("name, create"),
+								},
+							},
+						},
+						{
+							"cid":   testUtils.NewUniqueCid("name, create"),
+							"links": []map[string]any{},
+						},
+						{
+							"cid": testUtils.NewUniqueCid("doc, update2"),
+							"links": []map[string]any{
+								{
+									"cid": testUtils.NewUniqueCid("doc, node1 update1"),
+								},
+								{
+									"cid": testUtils.NewUniqueCid("name, update2"),
+								},
+							},
+						},
+						{
+							"cid": testUtils.NewUniqueCid("doc, node1 update1"),
+							"links": []map[string]any{
+								{
+									"cid": testUtils.NewUniqueCid("doc, create"),
+								},
+								{
+									"cid": testUtils.NewUniqueCid("name, node1 update1"),
+								},
+							},
+						},
+						{
+							"cid": testUtils.NewUniqueCid("doc, create"),
+							"links": []map[string]any{
+								{
+									"cid": testUtils.NewUniqueCid("name, create"),
+								},
+							},
+						},
+					},
+				},
+			},
+			testUtils.Request{
+				Request: `query {
+					Users {
+						name
+					}
+				}`,
+				Results: map[string]any{
+					"Users": []map[string]any{
+						{
+							"name": "Chris",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/state.go
+++ b/tests/integration/state.go
@@ -42,15 +42,21 @@ type p2pState struct {
 	// The map key is the node id of the subscriber.
 	peerCollections map[int]struct{}
 
-	// actualDocHeads contains all document heads that exist on a node.
+	// actualDAGHeads contains all DAG heads that exist on a node.
 	//
 	// The map key is the doc id. The map value is the doc head.
-	actualDocHeads map[string]docHeadState
+	//
+	// This tracks composite commits for documents, and collection commits for
+	// branchable collections
+	actualDAGHeads map[string]docHeadState
 
-	// expectedDocHeads contains all document heads that are expected to exist on a node.
+	// expectedDAGHeads contains all DAG heads that are expected to exist on a node.
 	//
-	// The map key is the doc id. The map value is the doc head.
-	expectedDocHeads map[string]cid.Cid
+	// The map key is the doc id. The map value is the DAG head.
+	//
+	// This tracks composite commits for documents, and collection commits for
+	// branchable collections
+	expectedDAGHeads map[string]cid.Cid
 }
 
 // docHeadState contains the state of a document head.
@@ -68,8 +74,8 @@ func newP2PState() *p2pState {
 		connections:      make(map[int]struct{}),
 		replicators:      make(map[int]struct{}),
 		peerCollections:  make(map[int]struct{}),
-		actualDocHeads:   make(map[string]docHeadState),
-		expectedDocHeads: make(map[string]cid.Cid),
+		actualDAGHeads:   make(map[string]docHeadState),
+		expectedDAGHeads: make(map[string]cid.Cid),
 	}
 }
 

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -1404,10 +1404,12 @@ func deleteDoc(
 	assertExpectedErrorRaised(s.t, s.testCase.Description, action.ExpectedError, expectedErrorRaised)
 
 	if action.ExpectedError == "" {
-		docIDs := map[string]struct{}{
+		expect := make([]map[string]struct{}, action.CollectionID+1)
+		expect[action.CollectionID] = map[string]struct{}{
 			docID.String(): {},
 		}
-		waitForUpdateEvents(s, action.NodeID, docIDs)
+
+		waitForUpdateEvents(s, action.NodeID, expect)
 	}
 }
 

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -1226,7 +1226,7 @@ func createDoc(
 	s.docIDs[action.CollectionID] = append(s.docIDs[action.CollectionID], docIDs...)
 
 	if action.ExpectedError == "" {
-		waitForUpdateEvents(s, action.NodeID, getEventsForCreateDoc(s, action))
+		waitForUpdateEvents(s, action.NodeID, action.CollectionID, getEventsForCreateDoc(s, action))
 	}
 }
 
@@ -1404,12 +1404,11 @@ func deleteDoc(
 	assertExpectedErrorRaised(s.t, s.testCase.Description, action.ExpectedError, expectedErrorRaised)
 
 	if action.ExpectedError == "" {
-		expect := make([]map[string]struct{}, action.CollectionID+1)
-		expect[action.CollectionID] = map[string]struct{}{
+		expect := map[string]struct{}{
 			docID.String(): {},
 		}
 
-		waitForUpdateEvents(s, action.NodeID, expect)
+		waitForUpdateEvents(s, action.NodeID, action.CollectionID, expect)
 	}
 }
 
@@ -1454,7 +1453,7 @@ func updateDoc(
 	assertExpectedErrorRaised(s.t, s.testCase.Description, action.ExpectedError, expectedErrorRaised)
 
 	if action.ExpectedError == "" && !action.SkipLocalUpdateEvent {
-		waitForUpdateEvents(s, action.NodeID, getEventsForUpdateDoc(s, action))
+		waitForUpdateEvents(s, action.NodeID, action.CollectionID, getEventsForUpdateDoc(s, action))
 	}
 }
 
@@ -1554,7 +1553,7 @@ func updateWithFilter(s *state, action UpdateWithFilter) {
 	assertExpectedErrorRaised(s.t, s.testCase.Description, action.ExpectedError, expectedErrorRaised)
 
 	if action.ExpectedError == "" && !action.SkipLocalUpdateEvent {
-		waitForUpdateEvents(s, action.NodeID, getEventsForUpdateWithFilter(s, action, res))
+		waitForUpdateEvents(s, action.NodeID, action.CollectionID, getEventsForUpdateWithFilter(s, action, res))
 	}
 }
 


### PR DESCRIPTION
## Relevant issue(s)

Resolves #3212 

## Description

Handles the syncing of collection commits over P2P.

~~Note: The behaviour in `TestQueryCommitsBranchables_HandlesConcurrentUpdatesAcrossPeerConnection` is currently under discussion and may be changed or linked to #3245 and #3246 before this PR is merged.~~ Discussed, and test updated.

## Todo

- [x] I forgot to update the wait for sync test action and it looks like some of the new tests are flaking in the CI because of this