### PR TITLE
feat: Add support for cid-only time travel queries

### DIFF
--- a/internal/db/fetcher/versioned.go
+++ b/internal/db/fetcher/versioned.go
@@ -153,33 +153,18 @@ func (vf *VersionedFetcher) Init(
 
 // Start serializes the correct state according to the Key and CID.
 func (vf *VersionedFetcher) Start(ctx context.Context, spans ...core.Span) error {
-	if vf.col == nil {
-		return client.NewErrUninitializeProperty("VersionedFetcher", "CollectionDescription")
-	}
-
-	if len(spans) != 1 {
-		return ErrSingleSpanOnly
-	}
-
 	// VersionedFetcher only ever recieves a headstore key
 	//nolint:forcetypeassert
 	prefix := spans[0].Start.(keys.HeadstoreDocKey)
-	dk := prefix.DocID
-	cid := prefix.Cid
-	if dk == "" {
-		return client.NewErrUninitializeProperty("Spans", "DocID")
-	} else if !cid.Defined() {
-		return client.NewErrUninitializeProperty("Spans", "CID")
-	}
 
 	vf.ctx = ctx
 	vf.dsKey = keys.DataStoreKey{
 		CollectionRootID: vf.col.Description().RootID,
-		DocID:            dk,
+		DocID:            prefix.DocID,
 	}
 
-	if err := vf.seekTo(cid); err != nil {
-		return NewErrFailedToSeek(cid, err)
+	if err := vf.seekTo(prefix.Cid); err != nil {
+		return NewErrFailedToSeek(prefix.Cid, err)
 	}
 
 	return vf.DocumentFetcher.Start(ctx)

--- a/internal/planner/select.go
+++ b/internal/planner/select.go
@@ -255,19 +255,24 @@ func (n *selectNode) initSource() ([]aggregateNode, error) {
 		origScan.filter = n.filter
 		n.filter = nil
 
-		// If we have both a DocID and a CID, then we need to run
-		// a TimeTravel (History-Traversing Versioned) query, which means
-		// we need to propagate the values to the underlying VersionedFetcher
+		// If we have a CID, then we need to run a TimeTravel (History-Traversing Versioned)
+		// query, which means we need to propagate the values to the underlying VersionedFetcher
 		if n.selectReq.Cid.HasValue() {
 			c, err := cid.Decode(n.selectReq.Cid.Value())
 			if err != nil {
 				return nil, err
 			}
+
+			var docID string
+			if len(n.selectReq.DocIDs.Value()) > 0 {
+				docID = n.selectReq.DocIDs.Value()[0]
+			}
+
 			origScan.Spans(
 				[]core.Span{
 					core.NewSpan(
 						keys.HeadstoreDocKey{
-							DocID: n.selectReq.DocIDs.Value()[0],
+							DocID: docID,
 							Cid:   c,
 						},
 						keys.HeadstoreDocKey{},

--- a/internal/request/graphql/schema/descriptions.go
+++ b/internal/request/graphql/schema/descriptions.go
@@ -73,7 +73,7 @@ An optional set of docIDs for this field. Only documents with a docID
  be ignored.
 `
 	cidArgDescription string = `
-An optional value that specifies the commit ID of the document to return.
+An optional value that specifies the commit ID of a document to return.
  This CID does not need to be the most recent for a document, if it
  corresponds to an older version of a document the document will be returned
  at the state it was in at the time of that commit. If a matching commit is


### PR DESCRIPTION
## Relevant issue(s)

Resolves #3214

## Description

Adds support for cid-only time travel queries. 

Collection-level commit don't work yet, but I'm going to sort that out in another branch.

Also removes some dead code.