### PR TITLE
fix: Make requests with no identity work with "*" target

### DIFF
--- a/acp/README.md
+++ b/acp/README.md
@@ -631,7 +631,8 @@ Result:
 Error: document not found or not authorized to access
 ```
 
-Sometimes we might want to give a specific access (form a relationship) not just to one identity, but any identity.
+Sometimes we might want to give a specific access (i.e. form a relationship) not just with one identity, but with
+any identity (includes even requests with no-identity).
 In that case we can specify "*" instead of specifying an explicit `actor`:
 ```sh
 defradb client acp relationship add \

--- a/internal/db/permission/check.go
+++ b/internal/db/permission/check.go
@@ -67,18 +67,22 @@ func CheckAccessOfDocOnCollectionWithACP(
 		return true, nil
 	}
 
-	// At this point if the request is not signatured, then it has no access, because:
-	// the collection has a policy on it, and the acp is enabled/available,
-	// and the document is not public (is registered with acp).
+	var identityValue string
 	if !identity.HasValue() {
-		return false, nil
+		// We can't assume that there is no-access just because there is no identity even if the document
+		// is registered with acp, this is because it is possible that acp has a registered relation targeting
+		// "*" (any) actor which would mean that even a request without an identity might be able to access
+		// a document registered with acp. So we pass an empty `did` to accommodate that case.
+		identityValue = ""
+	} else {
+		identityValue = identity.Value().DID
 	}
 
 	// Now actually check using the signature if this identity has access or not.
 	hasAccess, err := acpSystem.CheckDocAccess(
 		ctx,
 		permission,
-		identity.Value().DID,
+		identityValue,
 		policyID,
 		resourceName,
 		docID,

--- a/tests/integration/acp/relationship/doc_actor/add/with_manager_gql_test.go
+++ b/tests/integration/acp/relationship/doc_actor/add/with_manager_gql_test.go
@@ -26,10 +26,13 @@ func TestACP_OwnerMakesAManagerThatGivesItSelfReadAndWriteAccess_GQL_ManagerCanR
 
 		Description: "Test acp, owner makes a manager that gives itself read and write access",
 
-		SupportedMutationTypes: immutable.Some([]testUtils.MutationType{
-			// GQL mutation will return no error when wrong identity is used so test that separately.
-			testUtils.GQLRequestMutationType,
-		}),
+		SupportedMutationTypes: immutable.Some(
+			[]testUtils.MutationType{
+				// GQL mutation will return no error when wrong identity is used (only for update requests),
+				// so test that separately.
+				testUtils.GQLRequestMutationType,
+			},
+		),
 
 		Actions: []any{
 			testUtils.AddPolicy{
@@ -274,10 +277,13 @@ func TestACP_OwnerMakesManagerButManagerCanNotPerformOperations_GQL_ManagerCantR
 
 		Description: "Test acp, owner makes a manager, manager can't read or write",
 
-		SupportedMutationTypes: immutable.Some([]testUtils.MutationType{
-			// GQL mutation will return no error when wrong identity is used so test that separately.
-			testUtils.GQLRequestMutationType,
-		}),
+		SupportedMutationTypes: immutable.Some(
+			[]testUtils.MutationType{
+				// GQL mutation will return no error when wrong identity is used (only for update requests),
+				// so test that separately.
+				testUtils.GQLRequestMutationType,
+			},
+		),
 
 		Actions: []any{
 			testUtils.AddPolicy{
@@ -442,10 +448,13 @@ func TestACP_ManagerAddsRelationshipWithRelationItDoesNotManageAccordingToPolicy
 
 		Description: "Test acp, manager adds relationship with relation it does not manage according to policy, error",
 
-		SupportedMutationTypes: immutable.Some([]testUtils.MutationType{
-			// GQL mutation will return no error when wrong identity is used so test that separately.
-			testUtils.GQLRequestMutationType,
-		}),
+		SupportedMutationTypes: immutable.Some(
+			[]testUtils.MutationType{
+				// GQL mutation will return no error when wrong identity is used (only for update requests),
+				// so test that separately.
+				testUtils.GQLRequestMutationType,
+			},
+		),
 
 		Actions: []any{
 			testUtils.AddPolicy{

--- a/tests/integration/acp/relationship/doc_actor/add/with_manager_test.go
+++ b/tests/integration/acp/relationship/doc_actor/add/with_manager_test.go
@@ -601,11 +601,12 @@ func TestACP_OwnerMakesAManagerThatGivesItSelfReadAndWriteAccess_ManagerCanReadA
 
 		Description: "Test acp, owner makes a manager that gives itself read and write access",
 
-		SupportedMutationTypes: immutable.Some([]testUtils.MutationType{
-			// GQL mutation will return no error when wrong identity is used with gql (only for update requests),
-			testUtils.CollectionNamedMutationType,
-			testUtils.CollectionSaveMutationType,
-		}),
+		SupportedMutationTypes: immutable.Some(
+			[]testUtils.MutationType{
+				// GQL mutation will return no error when wrong identity is used with gql (only for update requests),
+				testUtils.CollectionNamedMutationType,
+				testUtils.CollectionSaveMutationType,
+			}),
 
 		Actions: []any{
 			testUtils.AddPolicy{
@@ -850,11 +851,12 @@ func TestACP_ManagerAddsRelationshipWithRelationItDoesNotManageAccordingToPolicy
 
 		Description: "Test acp, manager adds relationship with relation it does not manage according to policy, error",
 
-		SupportedMutationTypes: immutable.Some([]testUtils.MutationType{
-			// GQL mutation will return no error when wrong identity is used with gql (only for update requests),
-			testUtils.CollectionNamedMutationType,
-			testUtils.CollectionSaveMutationType,
-		}),
+		SupportedMutationTypes: immutable.Some(
+			[]testUtils.MutationType{
+				// GQL mutation will return no error when wrong identity is used with gql (only for update requests),
+				testUtils.CollectionNamedMutationType,
+				testUtils.CollectionSaveMutationType,
+			}),
 
 		Actions: []any{
 			testUtils.AddPolicy{
@@ -1019,11 +1021,12 @@ func TestACP_OwnerMakesManagerButManagerCanNotPerformOperations_ManagerCantReadO
 
 		Description: "Test acp, owner makes a manager, manager can't read or write",
 
-		SupportedMutationTypes: immutable.Some([]testUtils.MutationType{
-			// GQL mutation will return no error when wrong identity is used with gql (only for update requests),
-			testUtils.CollectionNamedMutationType,
-			testUtils.CollectionSaveMutationType,
-		}),
+		SupportedMutationTypes: immutable.Some(
+			[]testUtils.MutationType{
+				// GQL mutation will return no error when wrong identity is used with gql (only for update requests),
+				testUtils.CollectionNamedMutationType,
+				testUtils.CollectionSaveMutationType,
+			}),
 
 		Actions: []any{
 			testUtils.AddPolicy{

--- a/tests/integration/acp/relationship/doc_actor/add/with_manager_test.go
+++ b/tests/integration/acp/relationship/doc_actor/add/with_manager_test.go
@@ -602,6 +602,7 @@ func TestACP_OwnerMakesAManagerThatGivesItSelfReadAndWriteAccess_ManagerCanReadA
 		Description: "Test acp, owner makes a manager that gives itself read and write access",
 
 		SupportedMutationTypes: immutable.Some([]testUtils.MutationType{
+			// GQL mutation will return no error when wrong identity is used with gql (only for update requests),
 			testUtils.CollectionNamedMutationType,
 			testUtils.CollectionSaveMutationType,
 		}),
@@ -850,6 +851,7 @@ func TestACP_ManagerAddsRelationshipWithRelationItDoesNotManageAccordingToPolicy
 		Description: "Test acp, manager adds relationship with relation it does not manage according to policy, error",
 
 		SupportedMutationTypes: immutable.Some([]testUtils.MutationType{
+			// GQL mutation will return no error when wrong identity is used with gql (only for update requests),
 			testUtils.CollectionNamedMutationType,
 			testUtils.CollectionSaveMutationType,
 		}),
@@ -1018,6 +1020,7 @@ func TestACP_OwnerMakesManagerButManagerCanNotPerformOperations_ManagerCantReadO
 		Description: "Test acp, owner makes a manager, manager can't read or write",
 
 		SupportedMutationTypes: immutable.Some([]testUtils.MutationType{
+			// GQL mutation will return no error when wrong identity is used with gql (only for update requests),
 			testUtils.CollectionNamedMutationType,
 			testUtils.CollectionSaveMutationType,
 		}),

--- a/tests/integration/acp/relationship/doc_actor/add/with_only_write_gql_test.go
+++ b/tests/integration/acp/relationship/doc_actor/add/with_only_write_gql_test.go
@@ -26,10 +26,13 @@ func TestACP_OwnerGivesUpdateWriteAccessToAnotherActorWithoutExplicitReadPerm_GQ
 
 		Description: "Test acp, owner gives write(update) access without explicit read permission, can still update",
 
-		SupportedMutationTypes: immutable.Some([]testUtils.MutationType{
-			// GQL mutation will return no error when wrong identity is used so test that separately.
-			testUtils.GQLRequestMutationType,
-		}),
+		SupportedMutationTypes: immutable.Some(
+			[]testUtils.MutationType{
+				// GQL mutation will return no error when wrong identity is used (only for update requests),
+				// so test that separately.
+				testUtils.GQLRequestMutationType,
+			},
+		),
 
 		Actions: []any{
 			testUtils.AddPolicy{

--- a/tests/integration/acp/relationship/doc_actor/add/with_only_write_test.go
+++ b/tests/integration/acp/relationship/doc_actor/add/with_only_write_test.go
@@ -26,11 +26,12 @@ func TestACP_OwnerGivesUpdateWriteAccessToAnotherActorWithoutExplicitReadPerm_Ot
 
 		Description: "Test acp, owner gives write(update) access without explicit read permission, can still update",
 
-		SupportedMutationTypes: immutable.Some([]testUtils.MutationType{
-			// GQL mutation will return no error when wrong identity is used with gql (only for update requests),
-			testUtils.CollectionNamedMutationType,
-			testUtils.CollectionSaveMutationType,
-		}),
+		SupportedMutationTypes: immutable.Some(
+			[]testUtils.MutationType{
+				// GQL mutation will return no error when wrong identity is used with gql (only for update requests),
+				testUtils.CollectionNamedMutationType,
+				testUtils.CollectionSaveMutationType,
+			}),
 
 		Actions: []any{
 			testUtils.AddPolicy{

--- a/tests/integration/acp/relationship/doc_actor/add/with_only_write_test.go
+++ b/tests/integration/acp/relationship/doc_actor/add/with_only_write_test.go
@@ -27,6 +27,7 @@ func TestACP_OwnerGivesUpdateWriteAccessToAnotherActorWithoutExplicitReadPerm_Ot
 		Description: "Test acp, owner gives write(update) access without explicit read permission, can still update",
 
 		SupportedMutationTypes: immutable.Some([]testUtils.MutationType{
+			// GQL mutation will return no error when wrong identity is used with gql (only for update requests),
 			testUtils.CollectionNamedMutationType,
 			testUtils.CollectionSaveMutationType,
 		}),

--- a/tests/integration/acp/relationship/doc_actor/add/with_reader_gql_test.go
+++ b/tests/integration/acp/relationship/doc_actor/add/with_reader_gql_test.go
@@ -26,10 +26,13 @@ func TestACP_OwnerGivesOnlyReadAccessToAnotherActor_GQL_OtherActorCanReadButNotU
 
 		Description: "Test acp, owner gives read access to another actor, but the other actor can't update",
 
-		SupportedMutationTypes: immutable.Some([]testUtils.MutationType{
-			// GQL mutation will return no error when wrong identity is used so test that separately.
-			testUtils.GQLRequestMutationType,
-		}),
+		SupportedMutationTypes: immutable.Some(
+			[]testUtils.MutationType{
+				// GQL mutation will return no error when wrong identity is used (only for update requests),
+				// so test that separately.
+				testUtils.GQLRequestMutationType,
+			},
+		),
 
 		Actions: []any{
 			testUtils.AddPolicy{

--- a/tests/integration/acp/relationship/doc_actor/add/with_reader_test.go
+++ b/tests/integration/acp/relationship/doc_actor/add/with_reader_test.go
@@ -465,10 +465,11 @@ func TestACP_OwnerGivesOnlyReadAccessToAnotherActor_OtherActorCanReadButNotUpdat
 
 		Description: "Test acp, owner gives read access to another actor, but the other actor can't update",
 
-		SupportedMutationTypes: immutable.Some([]testUtils.MutationType{
-			testUtils.CollectionNamedMutationType,
-			testUtils.CollectionSaveMutationType,
-		}),
+		SupportedMutationTypes: immutable.Some(
+			[]testUtils.MutationType{
+				testUtils.CollectionNamedMutationType,
+				testUtils.CollectionSaveMutationType,
+			}),
 
 		Actions: []any{
 			testUtils.AddPolicy{

--- a/tests/integration/acp/relationship/doc_actor/add/with_target_all_actors_gql_test.go
+++ b/tests/integration/acp/relationship/doc_actor/add/with_target_all_actors_gql_test.go
@@ -28,7 +28,8 @@ func TestACP_OwnerGivesOnlyReadAccessToAllActors_GQL_AllActorsCanReadButNotUpdat
 
 		SupportedMutationTypes: immutable.Some(
 			[]testUtils.MutationType{
-				// GQL mutation will return no error when wrong identity is used so test that separately.
+				// GQL mutation will return no error when wrong identity is used (only for update requests),
+				// so test that separately.
 				testUtils.GQLRequestMutationType,
 			},
 		),
@@ -258,7 +259,8 @@ func TestACP_OwnerGivesOnlyReadAccessToAllActors_GQL_CanReadEvenWithoutIdentityB
 
 		SupportedMutationTypes: immutable.Some(
 			[]testUtils.MutationType{
-				// GQL mutation will return no error when wrong identity is used so test that separately.
+				// GQL mutation will return no error when wrong identity is used (only for update requests),
+				// so test that separately.
 				testUtils.GQLRequestMutationType,
 			},
 		),

--- a/tests/integration/acp/relationship/doc_actor/add/with_target_all_actors_gql_test.go
+++ b/tests/integration/acp/relationship/doc_actor/add/with_target_all_actors_gql_test.go
@@ -248,3 +248,209 @@ func TestACP_OwnerGivesOnlyReadAccessToAllActors_GQL_AllActorsCanReadButNotUpdat
 
 	testUtils.ExecuteTestCase(t, test)
 }
+
+func TestACP_OwnerGivesOnlyReadAccessToAllActors_GQL_CanReadEvenWithoutIdentityButNotUpdateOrDelete(t *testing.T) {
+	expectedPolicyID := "fc56b7509c20ac8ce682b3b9b4fdaad868a9c70dda6ec16720298be64f16e9a4"
+
+	test := testUtils.TestCase{
+
+		Description: "Test acp, owner gives read access to all actors (gql), can read without an identity but can't update or delete",
+
+		SupportedMutationTypes: immutable.Some(
+			[]testUtils.MutationType{
+				// GQL mutation will return no error when wrong identity is used so test that separately.
+				testUtils.GQLRequestMutationType,
+			},
+		),
+
+		Actions: []any{
+			testUtils.AddPolicy{
+
+				Identity: testUtils.ClientIdentity(1),
+
+				Policy: `
+                    name: Test Policy
+
+                    description: A Policy
+
+                    actor:
+                      name: actor
+
+                    resources:
+                      users:
+                        permissions:
+                          read:
+                            expr: owner + reader + writer
+
+                          write:
+                            expr: owner + writer
+
+                          nothing:
+                            expr: dummy
+
+                        relations:
+                          owner:
+                            types:
+                              - actor
+
+                          reader:
+                            types:
+                              - actor
+
+                          writer:
+                            types:
+                              - actor
+
+                          admin:
+                            manages:
+                              - reader
+                            types:
+                              - actor
+
+                          dummy:
+                            types:
+                              - actor
+                `,
+
+				ExpectedPolicyID: expectedPolicyID,
+			},
+
+			testUtils.SchemaUpdate{
+				Schema: fmt.Sprintf(`
+						type Users @policy(
+							id: "%s",
+							resource: "users"
+						) {
+							name: String
+							age: Int
+						}
+					`,
+					expectedPolicyID,
+				),
+			},
+
+			testUtils.CreateDoc{
+				Identity: testUtils.ClientIdentity(1),
+
+				CollectionID: 0,
+
+				Doc: `
+					{
+						"name": "Shahzad",
+						"age": 28
+					}
+				`,
+			},
+
+			testUtils.Request{
+				Identity: testUtils.NoIdentity(), // Can not read without an identity.
+
+				Request: `
+					query {
+						Users {
+							_docID
+							name
+							age
+						}
+					}
+				`,
+
+				Results: map[string]any{
+					"Users": []map[string]any{}, // Can't see the documents yet
+				},
+			},
+
+			testUtils.DeleteDoc{ // Since can't read without identity, can't delete either.
+				CollectionID: 0,
+
+				Identity: testUtils.NoIdentity(),
+
+				DocID: 0,
+
+				ExpectedError: "document not found or not authorized to access",
+			},
+
+			testUtils.UpdateDoc{ // Since can't read without identity, can't update either.
+				CollectionID: 0,
+
+				Identity: testUtils.NoIdentity(),
+
+				DocID: 0,
+
+				Doc: `
+					{
+						"name": "Shahzad Lone"
+					}
+				`,
+
+				SkipLocalUpdateEvent: true,
+			},
+
+			testUtils.AddDocActorRelationship{
+				RequestorIdentity: testUtils.ClientIdentity(1),
+
+				TargetIdentity: testUtils.AllClientIdentities(),
+
+				CollectionID: 0,
+
+				DocID: 0,
+
+				Relation: "reader",
+
+				ExpectedExistence: false,
+			},
+
+			testUtils.Request{
+				Identity: testUtils.NoIdentity(), // Now any identity can read, even if there is no identity
+
+				Request: `
+					query {
+						Users {
+							_docID
+							name
+							age
+						}
+					}
+				`,
+
+				Results: map[string]any{
+					"Users": []map[string]any{
+						{
+							"_docID": "bae-9d443d0c-52f6-568b-8f74-e8ff0825697b",
+							"name":   "Shahzad",
+							"age":    int64(28),
+						},
+					},
+				},
+			},
+
+			testUtils.UpdateDoc{ // But doesn't mean they can update.
+				CollectionID: 0,
+
+				Identity: testUtils.NoIdentity(),
+
+				DocID: 0,
+
+				Doc: `
+					{
+						"name": "Shahzad Lone"
+					}
+				`,
+
+				ExpectedError: "document not found or not authorized to access",
+			},
+
+			testUtils.DeleteDoc{ // But doesn't mean they can delete.
+				CollectionID: 0,
+
+				Identity: testUtils.NoIdentity(),
+
+				DocID: 0,
+
+				ExpectedError: "document not found or not authorized to access",
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/acp/relationship/doc_actor/add/with_target_all_actors_test.go
+++ b/tests/integration/acp/relationship/doc_actor/add/with_target_all_actors_test.go
@@ -28,6 +28,7 @@ func TestACP_OwnerGivesOnlyReadAccessToAllActors_AllActorsCanReadButNotUpdateOrD
 
 		SupportedMutationTypes: immutable.Some(
 			[]testUtils.MutationType{
+				// GQL mutation will return no error when wrong identity is used with gql (only for update requests),
 				testUtils.CollectionNamedMutationType,
 				testUtils.CollectionSaveMutationType,
 			},
@@ -258,6 +259,7 @@ func TestACP_OwnerGivesOnlyReadAccessToAllActors_CanReadEvenWithoutIdentityButNo
 
 		SupportedMutationTypes: immutable.Some(
 			[]testUtils.MutationType{
+				// GQL mutation will return no error when wrong identity is used with gql (only for update requests),
 				testUtils.CollectionNamedMutationType,
 				testUtils.CollectionSaveMutationType,
 			},

--- a/tests/integration/acp/relationship/doc_actor/add/with_target_all_actors_test.go
+++ b/tests/integration/acp/relationship/doc_actor/add/with_target_all_actors_test.go
@@ -248,3 +248,209 @@ func TestACP_OwnerGivesOnlyReadAccessToAllActors_AllActorsCanReadButNotUpdateOrD
 
 	testUtils.ExecuteTestCase(t, test)
 }
+
+func TestACP_OwnerGivesOnlyReadAccessToAllActors_CanReadEvenWithoutIdentityButNotUpdateOrDelete(t *testing.T) {
+	expectedPolicyID := "fc56b7509c20ac8ce682b3b9b4fdaad868a9c70dda6ec16720298be64f16e9a4"
+
+	test := testUtils.TestCase{
+
+		Description: "Test acp, owner gives read access to all actors, can read without an identity but can't update or delete",
+
+		SupportedMutationTypes: immutable.Some(
+			[]testUtils.MutationType{
+				testUtils.CollectionNamedMutationType,
+				testUtils.CollectionSaveMutationType,
+			},
+		),
+
+		Actions: []any{
+			testUtils.AddPolicy{
+
+				Identity: testUtils.ClientIdentity(1),
+
+				Policy: `
+                    name: Test Policy
+
+                    description: A Policy
+
+                    actor:
+                      name: actor
+
+                    resources:
+                      users:
+                        permissions:
+                          read:
+                            expr: owner + reader + writer
+
+                          write:
+                            expr: owner + writer
+
+                          nothing:
+                            expr: dummy
+
+                        relations:
+                          owner:
+                            types:
+                              - actor
+
+                          reader:
+                            types:
+                              - actor
+
+                          writer:
+                            types:
+                              - actor
+
+                          admin:
+                            manages:
+                              - reader
+                            types:
+                              - actor
+
+                          dummy:
+                            types:
+                              - actor
+                `,
+
+				ExpectedPolicyID: expectedPolicyID,
+			},
+
+			testUtils.SchemaUpdate{
+				Schema: fmt.Sprintf(`
+						type Users @policy(
+							id: "%s",
+							resource: "users"
+						) {
+							name: String
+							age: Int
+						}
+					`,
+					expectedPolicyID,
+				),
+			},
+
+			testUtils.CreateDoc{
+				Identity: testUtils.ClientIdentity(1),
+
+				CollectionID: 0,
+
+				Doc: `
+					{
+						"name": "Shahzad",
+						"age": 28
+					}
+				`,
+			},
+
+			testUtils.Request{
+				Identity: testUtils.NoIdentity(), // Can not read without an identity.
+
+				Request: `
+					query {
+						Users {
+							_docID
+							name
+							age
+						}
+					}
+				`,
+
+				Results: map[string]any{
+					"Users": []map[string]any{}, // Can't see the documents yet
+				},
+			},
+
+			testUtils.DeleteDoc{ // Since can't read without identity, can't delete either.
+				CollectionID: 0,
+
+				Identity: testUtils.NoIdentity(),
+
+				DocID: 0,
+
+				ExpectedError: "document not found or not authorized to access",
+			},
+
+			testUtils.UpdateDoc{ // Since can't read without identity, can't update either.
+				CollectionID: 0,
+
+				Identity: testUtils.NoIdentity(),
+
+				DocID: 0,
+
+				Doc: `
+					{
+						"name": "Shahzad Lone"
+					}
+				`,
+
+				ExpectedError: "document not found or not authorized to access",
+			},
+
+			testUtils.AddDocActorRelationship{
+				RequestorIdentity: testUtils.ClientIdentity(1),
+
+				TargetIdentity: testUtils.AllClientIdentities(),
+
+				CollectionID: 0,
+
+				DocID: 0,
+
+				Relation: "reader",
+
+				ExpectedExistence: false,
+			},
+
+			testUtils.Request{
+				Identity: testUtils.NoIdentity(), // Now any identity can read, even if there is no identity
+
+				Request: `
+					query {
+						Users {
+							_docID
+							name
+							age
+						}
+					}
+				`,
+
+				Results: map[string]any{
+					"Users": []map[string]any{
+						{
+							"_docID": "bae-9d443d0c-52f6-568b-8f74-e8ff0825697b",
+							"name":   "Shahzad",
+							"age":    int64(28),
+						},
+					},
+				},
+			},
+
+			testUtils.UpdateDoc{ // But doesn't mean they can update.
+				CollectionID: 0,
+
+				Identity: testUtils.NoIdentity(),
+
+				DocID: 0,
+
+				Doc: `
+					{
+						"name": "Shahzad Lone"
+					}
+				`,
+
+				ExpectedError: "document not found or not authorized to access",
+			},
+
+			testUtils.DeleteDoc{ // But doesn't mean they can delete.
+				CollectionID: 0,
+
+				Identity: testUtils.NoIdentity(),
+
+				DocID: 0,
+
+				ExpectedError: "document not found or not authorized to access",
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/acp/relationship/doc_actor/add/with_update_gql_test.go
+++ b/tests/integration/acp/relationship/doc_actor/add/with_update_gql_test.go
@@ -26,10 +26,11 @@ func TestACP_OwnerGivesUpdateWriteAccessToAnotherActorTwice_GQL_ShowThatTheRelat
 
 		Description: "Test acp, owner gives write(update) access to another actor twice, no-op",
 
-		SupportedMutationTypes: immutable.Some([]testUtils.MutationType{
-			// GQL mutation will return no error when wrong identity is used so test that separately.
-			testUtils.GQLRequestMutationType,
-		}),
+		SupportedMutationTypes: immutable.Some(
+			[]testUtils.MutationType{
+				// GQL mutation will return no error when wrong identity is used so test that separately.
+				testUtils.GQLRequestMutationType,
+			}),
 
 		Actions: []any{
 			testUtils.AddPolicy{
@@ -184,10 +185,11 @@ func TestACP_OwnerGivesUpdateWriteAccessToAnotherActor_GQL_OtherActorCanUpdate(t
 
 		Description: "Test acp, owner gives write(update) access to another actor",
 
-		SupportedMutationTypes: immutable.Some([]testUtils.MutationType{
-			// GQL mutation will return no error when wrong identity is used so test that separately.
-			testUtils.GQLRequestMutationType,
-		}),
+		SupportedMutationTypes: immutable.Some(
+			[]testUtils.MutationType{
+				// GQL mutation will return no error when wrong identity is used so test that separately.
+				testUtils.GQLRequestMutationType,
+			}),
 
 		Actions: []any{
 			testUtils.AddPolicy{

--- a/tests/integration/acp/relationship/doc_actor/add/with_update_test.go
+++ b/tests/integration/acp/relationship/doc_actor/add/with_update_test.go
@@ -26,11 +26,12 @@ func TestACP_OwnerGivesUpdateWriteAccessToAnotherActorTwice_ShowThatTheRelations
 
 		Description: "Test acp, owner gives write(update) access to another actor twice, no-op",
 
-		SupportedMutationTypes: immutable.Some([]testUtils.MutationType{
-			// GQL mutation will return no error when wrong identity is used with gql (only for update requests),
-			testUtils.CollectionNamedMutationType,
-			testUtils.CollectionSaveMutationType,
-		}),
+		SupportedMutationTypes: immutable.Some(
+			[]testUtils.MutationType{
+				// GQL mutation will return no error when wrong identity is used with gql (only for update requests),
+				testUtils.CollectionNamedMutationType,
+				testUtils.CollectionSaveMutationType,
+			}),
 
 		Actions: []any{
 			testUtils.AddPolicy{
@@ -185,11 +186,12 @@ func TestACP_OwnerGivesUpdateWriteAccessToAnotherActor_OtherActorCanUpdate(t *te
 
 		Description: "Test acp, owner gives write(update) access to another actor",
 
-		SupportedMutationTypes: immutable.Some([]testUtils.MutationType{
-			// GQL mutation will return no error when wrong identity is used with gql (only for update requests),
-			testUtils.CollectionNamedMutationType,
-			testUtils.CollectionSaveMutationType,
-		}),
+		SupportedMutationTypes: immutable.Some(
+			[]testUtils.MutationType{
+				// GQL mutation will return no error when wrong identity is used with gql (only for update requests),
+				testUtils.CollectionNamedMutationType,
+				testUtils.CollectionSaveMutationType,
+			}),
 
 		Actions: []any{
 			testUtils.AddPolicy{

--- a/tests/integration/acp/relationship/doc_actor/add/with_update_test.go
+++ b/tests/integration/acp/relationship/doc_actor/add/with_update_test.go
@@ -27,6 +27,7 @@ func TestACP_OwnerGivesUpdateWriteAccessToAnotherActorTwice_ShowThatTheRelations
 		Description: "Test acp, owner gives write(update) access to another actor twice, no-op",
 
 		SupportedMutationTypes: immutable.Some([]testUtils.MutationType{
+			// GQL mutation will return no error when wrong identity is used with gql (only for update requests),
 			testUtils.CollectionNamedMutationType,
 			testUtils.CollectionSaveMutationType,
 		}),
@@ -185,6 +186,7 @@ func TestACP_OwnerGivesUpdateWriteAccessToAnotherActor_OtherActorCanUpdate(t *te
 		Description: "Test acp, owner gives write(update) access to another actor",
 
 		SupportedMutationTypes: immutable.Some([]testUtils.MutationType{
+			// GQL mutation will return no error when wrong identity is used with gql (only for update requests),
 			testUtils.CollectionNamedMutationType,
 			testUtils.CollectionSaveMutationType,
 		}),


### PR DESCRIPTION
## Relevant issue(s)

Resolves #3276 

## Description
- Fix the bug where a request without an identity still wouldn't be able to access a document even if there was a "*" relationship

## Tasks
- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?
- Added tests

Specify the platform(s) on which this was tested:
- WSL2 (Manjaro)