### PR TITLE
feat: Aggregate order alias targeting

### DIFF
--- a/internal/db/base/compare.go
+++ b/internal/db/base/compare.go
@@ -34,7 +34,7 @@ func Compare(a, b any) int {
 	case bool:
 		return compareBool(v, b.(bool))
 	case int:
-		return compareInt(int64(v), b.(int64))
+		return compareInt(int64(v), int64(b.(int)))
 	case int64:
 		return compareInt(v, b.(int64))
 	case uint64:

--- a/tests/integration/query/one_to_many/with_count_order_test.go
+++ b/tests/integration/query/one_to_many/with_count_order_test.go
@@ -1,0 +1,87 @@
+// Copyright 2024 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package one_to_many
+
+import (
+	"testing"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+func TestQueryOneToMany_WithCountAliasOrder_ShouldOrderResults(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "One-to-many relation query from many side with order alias",
+		Actions: []any{
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				Doc: `{
+					"name": "John Grisham",
+					"age": 65,
+					"verified": true
+				}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				Doc: `{
+					"name": "Cornelia Funke",
+					"age": 62,
+					"verified": false
+				}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				DocMap: map[string]any{
+					"name":      "Painted House",
+					"rating":    4.9,
+					"author_id": testUtils.NewDocIndex(1, 0),
+				},
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				DocMap: map[string]any{
+					"name":      "A Time for Mercy",
+					"rating":    4.5,
+					"author_id": testUtils.NewDocIndex(1, 0),
+				},
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				DocMap: map[string]any{
+					"name":      "Theif Lord",
+					"rating":    4.8,
+					"author_id": testUtils.NewDocIndex(1, 1),
+				},
+			},
+			testUtils.Request{
+				Request: `query {
+					Author(order: {_alias: {publishedCount: DESC}}) {
+						name
+						publishedCount: _count(published: {})
+					}
+				}`,
+				Results: map[string]any{
+					"Author": []map[string]any{
+						{
+							"name":           "John Grisham",
+							"publishedCount": int64(2),
+						},
+						{
+							"name":           "Cornelia Funke",
+							"publishedCount": int64(1),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	executeTestCase(t, test)
+}

--- a/tests/integration/query/one_to_many/with_sum_order_test.go
+++ b/tests/integration/query/one_to_many/with_sum_order_test.go
@@ -1,0 +1,95 @@
+// Copyright 2024 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package one_to_many
+
+import (
+	"testing"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+func TestQueryOneToMany_WithSumWithAliasOrder_ShouldOrderResults(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "One-to-many relation query from many side with sum with order alias",
+		Actions: []any{
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `{
+					"name": "Painted House",
+					"rating": 4.9,
+					"author_id": "bae-e1ea288f-09fa-55fa-b0b5-0ac8941ea35b"
+				}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `{
+					"name": "A Time for Mercy",
+					"rating": 4.5,
+					"author_id": "bae-e1ea288f-09fa-55fa-b0b5-0ac8941ea35b"
+				}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `{
+					"name": "The Associate",
+					"rating": 4.2,
+					"author_id": "bae-e1ea288f-09fa-55fa-b0b5-0ac8941ea35b"
+				}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `{
+					"name": "Theif Lord",
+					"rating": 4.8,
+					"author_id": "bae-72e8c691-9f20-55e7-9228-8af1cf54cace"
+				}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				Doc: `{
+					"name": "John Grisham",
+					"age": 65,
+					"verified": true
+				}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				Doc: `{
+					"name": "Cornelia Funke",
+					"age": 62,
+					"verified": false
+				}`,
+			},
+			testUtils.Request{
+				Request: `query {
+					Author(order: {_alias: {totalRating: DESC}}) {
+						name
+						totalRating: _sum(published: {field: rating})
+					}
+				}`,
+				Results: map[string]any{
+					"Author": []map[string]any{
+						{
+							"name":        "John Grisham",
+							"totalRating": 13.600000000000001,
+						},
+						{
+							"name":        "Cornelia Funke",
+							"totalRating": 4.8,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	executeTestCase(t, test)
+}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #3239
Resolves #2820

## Description

This PR enables ordering by aggregated fields by using an alias to target them. This was mostly implemented in a previous PR, so the changes here are tests to verify that it works.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Added integration tests.

Specify the platform(s) on which this was tested:
- MacOS

