### PR TITLE
feat: add optional file flags for cli view add command

### DIFF
--- a/cli/view_add_test.go
+++ b/cli/view_add_test.go
@@ -1,0 +1,83 @@
+// Copyright 2023 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package cli
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFileOrArgData(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        []string
+		filePaths   []string
+		expectedRes []string
+		readFile    readFileFn
+	}{
+		{
+			name:        "NoFile",
+			args:        []string{"arg0", "arg1", "arg2"},
+			filePaths:   []string{"", "", ""},
+			expectedRes: []string{"arg0", "arg1", "arg2"},
+		},
+		{
+			name:        "FileFirst",
+			args:        []string{"arg1", "arg2"},
+			filePaths:   []string{"file0", "", ""},
+			expectedRes: []string{"file0", "arg1", "arg2"},
+		},
+		{
+			name:        "FileMiddle",
+			args:        []string{"arg0", "arg2"},
+			filePaths:   []string{"", "file0", ""},
+			expectedRes: []string{"arg0", "file0", "arg2"},
+		},
+		{
+			name:        "FileLast",
+			args:        []string{"arg0", "arg1"},
+			filePaths:   []string{"", "", "file0"},
+			expectedRes: []string{"arg0", "arg1", "file0"},
+		},
+		{
+			name:        "FileFirstLast",
+			args:        []string{"arg1"},
+			filePaths:   []string{"file0", "", "file1"},
+			expectedRes: []string{"file0", "arg1", "file1"},
+		},
+	}
+
+	for _, test := range tests {
+		fileReader := newMockReadFile()
+		getData := newFileOrArgData(test.args, fileReader.Read)
+		for i := range test.filePaths {
+			res, err := getData.next(test.filePaths[i])
+			require.NoError(t, err)
+			require.Equal(t, test.expectedRes[i], res)
+		}
+	}
+}
+
+type mockReadFile struct {
+	index int
+}
+
+func newMockReadFile() mockReadFile {
+	return mockReadFile{}
+}
+
+func (f *mockReadFile) Read(string) ([]byte, error) {
+	data := []byte(fmt.Sprintf("file%d", f.index))
+	f.index += 1
+	return data, nil
+}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #3280 

## Description

This PR adds add optional way to provide query and sdl data from a file when using cli `view add` command.
(*replace*) Include a summary of the changes. List the issue(s) it solves in the section above, and
create one if none exists.  Include relevant motivation and context. Detail new dependencies required for this change.

## Tasks

- [X] I made sure the code is well commented, particularly hard-to-understand areas.
- [ ] I made sure the repository-held documentation is changed accordingly.
- [X] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [ ] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

It has been tested adding new unit tests.

Specify the platform(s) on which this was tested:
- MacOS

