### PR TITLE
chore: Import defradb/errors for Join

### DIFF
--- a/client/definitions.go
+++ b/client/definitions.go
@@ -12,7 +12,6 @@ package client
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 
@@ -20,6 +19,7 @@ import (
 
 	"github.com/sourcenetwork/defradb/client/request"
 	"github.com/sourcenetwork/defradb/datastore"
+	"github.com/sourcenetwork/defradb/errors"
 )
 
 // CollectionDefinition contains the metadata defining what a Collection is.

--- a/client/document.go
+++ b/client/document.go
@@ -12,7 +12,6 @@ package client
 
 import (
 	"encoding/json"
-	"errors"
 	"regexp"
 	"strings"
 	"sync"
@@ -24,6 +23,7 @@ import (
 	"github.com/valyala/fastjson"
 
 	"github.com/sourcenetwork/defradb/client/request"
+	"github.com/sourcenetwork/defradb/errors"
 	ccid "github.com/sourcenetwork/defradb/internal/core/cid"
 )
 

--- a/datastore/prefix_query.go
+++ b/datastore/prefix_query.go
@@ -13,11 +13,12 @@ package datastore
 import (
 	"context"
 	"encoding/json"
-	"errors"
 
 	ds "github.com/ipfs/go-datastore"
 
 	"github.com/ipfs/go-datastore/query"
+
+	"github.com/sourcenetwork/defradb/errors"
 )
 
 // DeserializePrefix deserializes all elements with the given prefix from the given storage.

--- a/http/client_collection.go
+++ b/http/client_collection.go
@@ -14,13 +14,14 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"net/http"
 	"net/url"
 	"strings"
 
 	"github.com/sourcenetwork/immutable"
 	sse "github.com/vito/go-sse/sse"
+
+	"github.com/sourcenetwork/defradb/errors"
 
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/internal/encryption"

--- a/internal/db/description/collection.go
+++ b/internal/db/description/collection.go
@@ -13,7 +13,6 @@ package description
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"sort"
 
 	ds "github.com/ipfs/go-datastore"
@@ -21,6 +20,7 @@ import (
 
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/datastore"
+	"github.com/sourcenetwork/defradb/errors"
 	"github.com/sourcenetwork/defradb/internal/keys"
 )
 

--- a/internal/db/fetcher/indexer_iterators.go
+++ b/internal/db/fetcher/indexer_iterators.go
@@ -13,7 +13,6 @@ package fetcher
 import (
 	"cmp"
 	"context"
-	"errors"
 	"strings"
 	"time"
 
@@ -21,6 +20,7 @@ import (
 
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/datastore"
+	"github.com/sourcenetwork/defradb/errors"
 	"github.com/sourcenetwork/defradb/internal/connor"
 	"github.com/sourcenetwork/defradb/internal/keys"
 	"github.com/sourcenetwork/defradb/internal/planner/mapper"

--- a/internal/db/fetcher/multi.go
+++ b/internal/db/fetcher/multi.go
@@ -11,9 +11,9 @@
 package fetcher
 
 import (
-	"errors"
-
 	"github.com/sourcenetwork/immutable"
+
+	"github.com/sourcenetwork/defradb/errors"
 )
 
 // multiFetcher is a fetcher that orchastrates the fetching of documents via multiple child fetchers.

--- a/internal/db/indexed_docs_test.go
+++ b/internal/db/indexed_docs_test.go
@@ -13,7 +13,6 @@ package db
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"testing"
 
 	ipfsDatastore "github.com/ipfs/go-datastore"
@@ -28,6 +27,7 @@ import (
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/datastore"
 	"github.com/sourcenetwork/defradb/datastore/mocks"
+	"github.com/sourcenetwork/defradb/errors"
 	"github.com/sourcenetwork/defradb/internal/core"
 	"github.com/sourcenetwork/defradb/internal/db/fetcher"
 	fetcherMocks "github.com/sourcenetwork/defradb/internal/db/fetcher/mocks"

--- a/internal/db/view.go
+++ b/internal/db/view.go
@@ -12,7 +12,6 @@ package db
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	ds "github.com/ipfs/go-datastore"
@@ -23,6 +22,7 @@ import (
 	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/request"
+	"github.com/sourcenetwork/defradb/errors"
 	"github.com/sourcenetwork/defradb/internal/core"
 	"github.com/sourcenetwork/defradb/internal/db/description"
 	"github.com/sourcenetwork/defradb/internal/keys"

--- a/internal/request/graphql/schema/manager.go
+++ b/internal/request/graphql/schema/manager.go
@@ -11,9 +11,8 @@
 package schema
 
 import (
-	"errors"
-
 	"github.com/sourcenetwork/defradb/client"
+	"github.com/sourcenetwork/defradb/errors"
 
 	gql "github.com/sourcenetwork/graphql-go"
 	gqlp "github.com/sourcenetwork/graphql-go/language/parser"

--- a/node/node.go
+++ b/node/node.go
@@ -12,7 +12,6 @@ package node
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	gohttp "net/http"
 
@@ -20,6 +19,7 @@ import (
 	"github.com/sourcenetwork/immutable"
 
 	"github.com/sourcenetwork/defradb/client"
+	"github.com/sourcenetwork/defradb/errors"
 	"github.com/sourcenetwork/defradb/http"
 	"github.com/sourcenetwork/defradb/internal/db"
 	"github.com/sourcenetwork/defradb/internal/kms"


### PR DESCRIPTION
## Relevant issue(s)

Resolves #3334 

## Description

In many locations in the code base, we were importing the `"errors"` package in order to utilize the `Join` function. However, we now have this functionality as part of our own errors package. So throughout the codebase import statements, `"errors"` has been changed to `"github.com/sourcenetwork/defradb/errors"`

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [ ] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Specify the platform(s) on which this was tested:
- Windows
