### PR TITLE
chore: Review HTTP support codes

### DIFF
--- a/http/handler_collection.go
+++ b/http/handler_collection.go
@@ -70,7 +70,7 @@ func (s *collectionHandler) Create(rw http.ResponseWriter, req *http.Request) {
 		}
 
 		if err := col.CreateMany(ctx, docList); err != nil {
-			responseJSON(rw, http.StatusBadRequest, errorResponse{err})
+			responseJSON(rw, http.StatusInternalServerError, errorResponse{err})
 			return
 		}
 		rw.WriteHeader(http.StatusOK)
@@ -81,7 +81,7 @@ func (s *collectionHandler) Create(rw http.ResponseWriter, req *http.Request) {
 			return
 		}
 		if err := col.Create(ctx, doc); err != nil {
-			responseJSON(rw, http.StatusBadRequest, errorResponse{err})
+			responseJSON(rw, http.StatusInternalServerError, errorResponse{err})
 			return
 		}
 		rw.WriteHeader(http.StatusOK)
@@ -99,7 +99,7 @@ func (s *collectionHandler) DeleteWithFilter(rw http.ResponseWriter, req *http.R
 
 	result, err := col.DeleteWithFilter(req.Context(), request.Filter)
 	if err != nil {
-		responseJSON(rw, http.StatusBadRequest, errorResponse{err})
+		responseJSON(rw, http.StatusInternalServerError, errorResponse{err})
 		return
 	}
 	responseJSON(rw, http.StatusOK, result)
@@ -116,7 +116,7 @@ func (s *collectionHandler) UpdateWithFilter(rw http.ResponseWriter, req *http.R
 
 	result, err := col.UpdateWithFilter(req.Context(), request.Filter, request.Updater)
 	if err != nil {
-		responseJSON(rw, http.StatusBadRequest, errorResponse{err})
+		responseJSON(rw, http.StatusInternalServerError, errorResponse{err})
 		return
 	}
 	responseJSON(rw, http.StatusOK, result)
@@ -153,7 +153,7 @@ func (s *collectionHandler) Update(rw http.ResponseWriter, req *http.Request) {
 	}
 	err = col.Update(req.Context(), doc)
 	if err != nil {
-		responseJSON(rw, http.StatusBadRequest, errorResponse{err})
+		responseJSON(rw, http.StatusInternalServerError, errorResponse{err})
 		return
 	}
 	rw.WriteHeader(http.StatusOK)
@@ -170,7 +170,7 @@ func (s *collectionHandler) Delete(rw http.ResponseWriter, req *http.Request) {
 
 	_, err = col.Delete(req.Context(), docID)
 	if err != nil {
-		responseJSON(rw, http.StatusBadRequest, errorResponse{err})
+		responseJSON(rw, http.StatusInternalServerError, errorResponse{err})
 		return
 	}
 	rw.WriteHeader(http.StatusOK)
@@ -188,18 +188,19 @@ func (s *collectionHandler) Get(rw http.ResponseWriter, req *http.Request) {
 
 	doc, err := col.Get(req.Context(), docID, showDeleted)
 	if err != nil {
-		responseJSON(rw, http.StatusBadRequest, errorResponse{err})
+		responseJSON(rw, http.StatusInternalServerError, errorResponse{err})
 		return
 	}
 
 	if doc == nil {
+		// To do: This may be better as a new error type
 		responseJSON(rw, http.StatusBadRequest, errorResponse{client.ErrDocumentNotFoundOrNotAuthorized})
 		return
 	}
 
 	docMap, err := doc.ToMap()
 	if err != nil {
-		responseJSON(rw, http.StatusBadRequest, errorResponse{err})
+		responseJSON(rw, http.StatusInternalServerError, errorResponse{err})
 		return
 	}
 	responseJSON(rw, http.StatusOK, docMap)
@@ -221,7 +222,7 @@ func (s *collectionHandler) GetAllDocIDs(rw http.ResponseWriter, req *http.Reque
 
 	docIDsResult, err := col.GetAllDocIDs(req.Context())
 	if err != nil {
-		responseJSON(rw, http.StatusBadRequest, errorResponse{err})
+		responseJSON(rw, http.StatusInternalServerError, errorResponse{err})
 		return
 	}
 
@@ -266,7 +267,7 @@ func (s *collectionHandler) CreateIndex(rw http.ResponseWriter, req *http.Reques
 	}
 	index, err := col.CreateIndex(req.Context(), descWithoutID)
 	if err != nil {
-		responseJSON(rw, http.StatusBadRequest, errorResponse{err})
+		responseJSON(rw, http.StatusInternalServerError, errorResponse{err})
 		return
 	}
 	responseJSON(rw, http.StatusOK, index)
@@ -277,7 +278,7 @@ func (s *collectionHandler) GetIndexes(rw http.ResponseWriter, req *http.Request
 	indexesMap, err := store.GetAllIndexes(req.Context())
 
 	if err != nil {
-		responseJSON(rw, http.StatusBadRequest, errorResponse{err})
+		responseJSON(rw, http.StatusInternalServerError, errorResponse{err})
 		return
 	}
 	indexes := make([]client.IndexDescription, 0, len(indexesMap))
@@ -292,7 +293,7 @@ func (s *collectionHandler) DropIndex(rw http.ResponseWriter, req *http.Request)
 
 	err := col.DropIndex(req.Context(), chi.URLParam(req, "index"))
 	if err != nil {
-		responseJSON(rw, http.StatusBadRequest, errorResponse{err})
+		responseJSON(rw, http.StatusInternalServerError, errorResponse{err})
 		return
 	}
 	rw.WriteHeader(http.StatusOK)

--- a/http/handler_lens.go
+++ b/http/handler_lens.go
@@ -24,7 +24,7 @@ func (s *lensHandler) ReloadLenses(rw http.ResponseWriter, req *http.Request) {
 
 	err := store.LensRegistry().ReloadLenses(req.Context())
 	if err != nil {
-		responseJSON(rw, http.StatusBadRequest, errorResponse{err})
+		responseJSON(rw, http.StatusInternalServerError, errorResponse{err})
 		return
 	}
 	rw.WriteHeader(http.StatusOK)
@@ -41,7 +41,7 @@ func (s *lensHandler) SetMigration(rw http.ResponseWriter, req *http.Request) {
 
 	err := store.LensRegistry().SetMigration(req.Context(), request.CollectionID, request.Config)
 	if err != nil {
-		responseJSON(rw, http.StatusBadRequest, errorResponse{err})
+		responseJSON(rw, http.StatusInternalServerError, errorResponse{err})
 		return
 	}
 	rw.WriteHeader(http.StatusOK)
@@ -66,7 +66,7 @@ func (s *lensHandler) MigrateUp(rw http.ResponseWriter, req *http.Request) {
 		value = append(value, item)
 	})
 	if err != nil {
-		responseJSON(rw, http.StatusBadRequest, errorResponse{err})
+		responseJSON(rw, http.StatusInternalServerError, errorResponse{err})
 		return
 	}
 	responseJSON(rw, http.StatusOK, value)
@@ -91,7 +91,7 @@ func (s *lensHandler) MigrateDown(rw http.ResponseWriter, req *http.Request) {
 		value = append(value, item)
 	})
 	if err != nil {
-		responseJSON(rw, http.StatusBadRequest, errorResponse{err})
+		responseJSON(rw, http.StatusInternalServerError, errorResponse{err})
 		return
 	}
 	responseJSON(rw, http.StatusOK, value)

--- a/http/handler_p2p.go
+++ b/http/handler_p2p.go
@@ -43,7 +43,7 @@ func (s *p2pHandler) SetReplicator(rw http.ResponseWriter, req *http.Request) {
 	}
 	err := p2p.SetReplicator(req.Context(), rep)
 	if err != nil {
-		responseJSON(rw, http.StatusBadRequest, errorResponse{err})
+		responseJSON(rw, http.StatusInternalServerError, errorResponse{err})
 		return
 	}
 	rw.WriteHeader(http.StatusOK)
@@ -63,7 +63,7 @@ func (s *p2pHandler) DeleteReplicator(rw http.ResponseWriter, req *http.Request)
 	}
 	err := p2p.DeleteReplicator(req.Context(), rep)
 	if err != nil {
-		responseJSON(rw, http.StatusBadRequest, errorResponse{err})
+		responseJSON(rw, http.StatusInternalServerError, errorResponse{err})
 		return
 	}
 	rw.WriteHeader(http.StatusOK)
@@ -78,7 +78,7 @@ func (s *p2pHandler) GetAllReplicators(rw http.ResponseWriter, req *http.Request
 
 	reps, err := p2p.GetAllReplicators(req.Context())
 	if err != nil {
-		responseJSON(rw, http.StatusBadRequest, errorResponse{err})
+		responseJSON(rw, http.StatusInternalServerError, errorResponse{err})
 		return
 	}
 	responseJSON(rw, http.StatusOK, reps)
@@ -98,7 +98,7 @@ func (s *p2pHandler) AddP2PCollection(rw http.ResponseWriter, req *http.Request)
 	}
 	err := p2p.AddP2PCollections(req.Context(), collectionIDs)
 	if err != nil {
-		responseJSON(rw, http.StatusBadRequest, errorResponse{err})
+		responseJSON(rw, http.StatusInternalServerError, errorResponse{err})
 		return
 	}
 	rw.WriteHeader(http.StatusOK)
@@ -118,7 +118,7 @@ func (s *p2pHandler) RemoveP2PCollection(rw http.ResponseWriter, req *http.Reque
 	}
 	err := p2p.RemoveP2PCollections(req.Context(), collectionIDs)
 	if err != nil {
-		responseJSON(rw, http.StatusBadRequest, errorResponse{err})
+		responseJSON(rw, http.StatusInternalServerError, errorResponse{err})
 		return
 	}
 	rw.WriteHeader(http.StatusOK)
@@ -133,7 +133,7 @@ func (s *p2pHandler) GetAllP2PCollections(rw http.ResponseWriter, req *http.Requ
 
 	cols, err := p2p.GetAllP2PCollections(req.Context())
 	if err != nil {
-		responseJSON(rw, http.StatusBadRequest, errorResponse{err})
+		responseJSON(rw, http.StatusInternalServerError, errorResponse{err})
 		return
 	}
 	responseJSON(rw, http.StatusOK, cols)

--- a/http/handler_store.go
+++ b/http/handler_store.go
@@ -35,7 +35,7 @@ func (s *storeHandler) BasicImport(rw http.ResponseWriter, req *http.Request) {
 	}
 	err := store.BasicImport(req.Context(), config.Filepath)
 	if err != nil {
-		responseJSON(rw, http.StatusBadRequest, errorResponse{err})
+		responseJSON(rw, http.StatusInternalServerError, errorResponse{err})
 		return
 	}
 	rw.WriteHeader(http.StatusOK)
@@ -51,7 +51,7 @@ func (s *storeHandler) BasicExport(rw http.ResponseWriter, req *http.Request) {
 	}
 	err := store.BasicExport(req.Context(), &config)
 	if err != nil {
-		responseJSON(rw, http.StatusBadRequest, errorResponse{err})
+		responseJSON(rw, http.StatusInternalServerError, errorResponse{err})
 		return
 	}
 	rw.WriteHeader(http.StatusOK)
@@ -67,7 +67,7 @@ func (s *storeHandler) AddSchema(rw http.ResponseWriter, req *http.Request) {
 	}
 	cols, err := store.AddSchema(req.Context(), string(schema))
 	if err != nil {
-		responseJSON(rw, http.StatusBadRequest, errorResponse{err})
+		responseJSON(rw, http.StatusInternalServerError, errorResponse{err})
 		return
 	}
 	responseJSON(rw, http.StatusOK, cols)
@@ -85,7 +85,7 @@ func (s *storeHandler) PatchSchema(rw http.ResponseWriter, req *http.Request) {
 
 	err = store.PatchSchema(req.Context(), message.Patch, message.Migration, message.SetAsDefaultVersion)
 	if err != nil {
-		responseJSON(rw, http.StatusBadRequest, errorResponse{err})
+		responseJSON(rw, http.StatusInternalServerError, errorResponse{err})
 		return
 	}
 	rw.WriteHeader(http.StatusOK)
@@ -103,7 +103,7 @@ func (s *storeHandler) PatchCollection(rw http.ResponseWriter, req *http.Request
 
 	err = store.PatchCollection(req.Context(), patch)
 	if err != nil {
-		responseJSON(rw, http.StatusBadRequest, errorResponse{err})
+		responseJSON(rw, http.StatusInternalServerError, errorResponse{err})
 		return
 	}
 	rw.WriteHeader(http.StatusOK)
@@ -119,7 +119,7 @@ func (s *storeHandler) SetActiveSchemaVersion(rw http.ResponseWriter, req *http.
 	}
 	err = store.SetActiveSchemaVersion(req.Context(), string(schemaVersionID))
 	if err != nil {
-		responseJSON(rw, http.StatusBadRequest, errorResponse{err})
+		responseJSON(rw, http.StatusInternalServerError, errorResponse{err})
 		return
 	}
 	rw.WriteHeader(http.StatusOK)
@@ -137,7 +137,7 @@ func (s *storeHandler) AddView(rw http.ResponseWriter, req *http.Request) {
 
 	defs, err := store.AddView(req.Context(), message.Query, message.SDL, message.Transform)
 	if err != nil {
-		responseJSON(rw, http.StatusBadRequest, errorResponse{err})
+		responseJSON(rw, http.StatusInternalServerError, errorResponse{err})
 		return
 	}
 
@@ -155,7 +155,7 @@ func (s *storeHandler) SetMigration(rw http.ResponseWriter, req *http.Request) {
 
 	err := store.SetMigration(req.Context(), cfg)
 	if err != nil {
-		responseJSON(rw, http.StatusBadRequest, errorResponse{err})
+		responseJSON(rw, http.StatusInternalServerError, errorResponse{err})
 		return
 	}
 	rw.WriteHeader(http.StatusOK)
@@ -187,7 +187,7 @@ func (s *storeHandler) GetCollection(rw http.ResponseWriter, req *http.Request) 
 
 	cols, err := store.GetCollections(req.Context(), options)
 	if err != nil {
-		responseJSON(rw, http.StatusBadRequest, errorResponse{err})
+		responseJSON(rw, http.StatusInternalServerError, errorResponse{err})
 		return
 	}
 	colDesc := make([]client.CollectionDefinition, len(cols))
@@ -213,7 +213,7 @@ func (s *storeHandler) GetSchema(rw http.ResponseWriter, req *http.Request) {
 
 	schema, err := store.GetSchemas(req.Context(), options)
 	if err != nil {
-		responseJSON(rw, http.StatusBadRequest, errorResponse{err})
+		responseJSON(rw, http.StatusInternalServerError, errorResponse{err})
 		return
 	}
 	responseJSON(rw, http.StatusOK, schema)
@@ -245,7 +245,7 @@ func (s *storeHandler) RefreshViews(rw http.ResponseWriter, req *http.Request) {
 
 	err := store.RefreshViews(req.Context(), options)
 	if err != nil {
-		responseJSON(rw, http.StatusBadRequest, errorResponse{err})
+		responseJSON(rw, http.StatusInternalServerError, errorResponse{err})
 		return
 	}
 	rw.WriteHeader(http.StatusOK)
@@ -256,7 +256,7 @@ func (s *storeHandler) GetAllIndexes(rw http.ResponseWriter, req *http.Request) 
 
 	indexes, err := store.GetAllIndexes(req.Context())
 	if err != nil {
-		responseJSON(rw, http.StatusBadRequest, errorResponse{err})
+		responseJSON(rw, http.StatusInternalServerError, errorResponse{err})
 		return
 	}
 	responseJSON(rw, http.StatusOK, indexes)
@@ -266,7 +266,7 @@ func (s *storeHandler) PrintDump(rw http.ResponseWriter, req *http.Request) {
 	db := mustGetContextClientDB(req)
 
 	if err := db.PrintDump(req.Context()); err != nil {
-		responseJSON(rw, http.StatusBadRequest, errorResponse{err})
+		responseJSON(rw, http.StatusInternalServerError, errorResponse{err})
 		return
 	}
 	rw.WriteHeader(http.StatusOK)
@@ -305,7 +305,7 @@ func (s *storeHandler) ExecRequest(rw http.ResponseWriter, req *http.Request) {
 			return
 		}
 	default:
-		responseJSON(rw, http.StatusBadRequest, errorResponse{ErrMissingRequest})
+		responseJSON(rw, http.StatusInternalServerError, errorResponse{ErrMissingRequest})
 		return
 	}
 	var options []client.RequestOption
@@ -360,7 +360,7 @@ func (s *storeHandler) GetNodeIdentity(rw http.ResponseWriter, req *http.Request
 
 	identity, err := db.GetNodeIdentity(req.Context())
 	if err != nil {
-		responseJSON(rw, http.StatusBadRequest, errorResponse{err})
+		responseJSON(rw, http.StatusInternalServerError, errorResponse{err})
 		return
 	}
 	responseJSON(rw, http.StatusOK, identity)


### PR DESCRIPTION
## Relevant issue(s)

Resolves #3139

## Description

Across the code base we sometimes use `http.StatusBadRequest` (400) where we should be using `http.StatusInternalServerError` (500). I have gone through the code and made some of the changes that made logical sense to me.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Testing is in progress.

Specify the platform(s) on which this was tested:
- Windows
