### PR TITLE
feat: Purge ACP state on DB purge

### DIFF
--- a/acp/acp.go
+++ b/acp/acp.go
@@ -43,6 +43,9 @@ type ACP interface {
 	// Close closes the resources in use by acp.
 	Close() error
 
+	// DropAll purges the entire ACP state.
+	DropAll(ctx context.Context) error
+
 	// AddPolicy attempts to add the given policy. Detects the format of the policy automatically
 	// by assuming YAML format if JSON validation fails. Upon success a policyID is returned,
 	// otherwise returns error.

--- a/acp/acp.go
+++ b/acp/acp.go
@@ -44,6 +44,7 @@ type ACP interface {
 	Close() error
 
 	// ResetState purges the entire ACP state.
+	// Resetting will close the ACP engine, purge the state, then restart it
 	ResetState(ctx context.Context) error
 
 	// AddPolicy attempts to add the given policy. Detects the format of the policy automatically

--- a/acp/acp.go
+++ b/acp/acp.go
@@ -43,8 +43,8 @@ type ACP interface {
 	// Close closes the resources in use by acp.
 	Close() error
 
-	// DropAll purges the entire ACP state.
-	DropAll(ctx context.Context) error
+	// ResetState purges the entire ACP state.
+	ResetState(ctx context.Context) error
 
 	// AddPolicy attempts to add the given policy. Detects the format of the policy automatically
 	// by assuming YAML format if JSON validation fails. Upon success a policyID is returned,

--- a/acp/acp_local.go
+++ b/acp/acp_local.go
@@ -107,8 +107,11 @@ func (l *ACPLocal) Start(ctx context.Context) error {
 
 func (l *ACPLocal) Close() error {
 	if !l.closed {
+		err := l.manager.Terminate()
+		if err != nil {
+			return err
+		}
 		l.closed = true
-		return l.manager.Terminate()
 	}
 	return nil
 }

--- a/acp/acp_local_test.go
+++ b/acp/acp_local_test.go
@@ -213,6 +213,39 @@ func Test_LocalACP_Persistent_AddPolicy_CreatingSamePolicyAfterResetStateReturns
 	require.Nil(t, errClose)
 }
 
+func Test_LocalACP_InMemory_ResetStateAfterClose(t *testing.T) {
+	ctx := context.Background()
+	localACP := NewLocalACP()
+
+	localACP.Init(ctx, "")
+	errStart := localACP.Start(ctx)
+	require.Nil(t, errStart)
+
+	errClose := localACP.Close()
+	require.NoError(t, errClose)
+
+	errReset := localACP.ResetState(ctx)
+	require.NoError(t, errReset)
+}
+
+func Test_LocalACP_Persistent_ResetStateAfterClose(t *testing.T) {
+	acpPath := t.TempDir()
+	require.NotEqual(t, "", acpPath)
+
+	ctx := context.Background()
+	localACP := NewLocalACP()
+
+	localACP.Init(ctx, acpPath)
+	errStart := localACP.Start(ctx)
+	require.Nil(t, errStart)
+
+	errClose := localACP.Close()
+	require.NoError(t, errClose)
+
+	errReset := localACP.ResetState(ctx)
+	require.NoError(t, errReset)
+}
+
 func Test_LocalACP_PersistentMemory_AddPolicy_CreatingSamePolicyReturnsDifferentIDs(t *testing.T) {
 	acpPath := t.TempDir()
 	require.NotEqual(t, "", acpPath)

--- a/acp/acp_local_test.go
+++ b/acp/acp_local_test.go
@@ -149,8 +149,8 @@ func Test_LocalACP_InMemory_AddPolicy_CreatingSamePolicyAfterResetStateReturnsSa
 		policyID,
 	)
 
-	errDrop := localACP.ResetState(ctx)
-	require.Nil(t, errDrop)
+	errReset := localACP.ResetState(ctx)
+	require.Nil(t, errReset)
 
 	// Since nothing is persisted should allow adding same policy again with same ID
 
@@ -192,8 +192,8 @@ func Test_LocalACP_Persistent_AddPolicy_CreatingSamePolicyAfterResetStateReturns
 		policyID,
 	)
 
-	errDrop := localACP.ResetState(ctx)
-	require.Nil(t, errDrop)
+	errReset := localACP.ResetState(ctx)
+	require.Nil(t, errReset)
 
 	// Since nothing is persisted should allow adding same policy again with same ID
 

--- a/acp/acp_local_test.go
+++ b/acp/acp_local_test.go
@@ -128,7 +128,7 @@ func Test_LocalACP_InMemory_AddPolicy_CreatingSamePolicyAfterWipeReturnsSameID(t
 	require.Nil(t, errClose)
 }
 
-func Test_LocalACP_InMemory_AddPolicy_CreatingSamePolicyAfterDropAllReturnsSameID(t *testing.T) {
+func Test_LocalACP_InMemory_AddPolicy_CreatingSamePolicyAfterResetStateReturnsSameID(t *testing.T) {
 	ctx := context.Background()
 	localACP := NewLocalACP()
 
@@ -149,7 +149,7 @@ func Test_LocalACP_InMemory_AddPolicy_CreatingSamePolicyAfterDropAllReturnsSameI
 		policyID,
 	)
 
-	errDrop := localACP.DropAll(ctx)
+	errDrop := localACP.ResetState(ctx)
 	require.Nil(t, errDrop)
 
 	// Since nothing is persisted should allow adding same policy again with same ID
@@ -170,7 +170,7 @@ func Test_LocalACP_InMemory_AddPolicy_CreatingSamePolicyAfterDropAllReturnsSameI
 	require.Nil(t, errClose)
 }
 
-func Test_LocalACP_Persistent_AddPolicy_CreatingSamePolicyAfterDropAllReturnsSameID(t *testing.T) {
+func Test_LocalACP_Persistent_AddPolicy_CreatingSamePolicyAfterResetStateReturnsSameID(t *testing.T) {
 	ctx := context.Background()
 	localACP := NewLocalACP()
 
@@ -192,7 +192,7 @@ func Test_LocalACP_Persistent_AddPolicy_CreatingSamePolicyAfterDropAllReturnsSam
 		policyID,
 	)
 
-	errDrop := localACP.DropAll(ctx)
+	errDrop := localACP.ResetState(ctx)
 	require.Nil(t, errDrop)
 
 	// Since nothing is persisted should allow adding same policy again with same ID

--- a/acp/acp_local_test.go
+++ b/acp/acp_local_test.go
@@ -128,6 +128,91 @@ func Test_LocalACP_InMemory_AddPolicy_CreatingSamePolicyAfterWipeReturnsSameID(t
 	require.Nil(t, errClose)
 }
 
+func Test_LocalACP_InMemory_AddPolicy_CreatingSamePolicyAfterDropAllReturnsSameID(t *testing.T) {
+	ctx := context.Background()
+	localACP := NewLocalACP()
+
+	localACP.Init(ctx, "")
+	errStart := localACP.Start(ctx)
+	require.Nil(t, errStart)
+
+	policyID, errAddPolicy := localACP.AddPolicy(
+		ctx,
+		identity1,
+		validPolicy,
+	)
+	require.Nil(t, errAddPolicy)
+
+	require.Equal(
+		t,
+		validPolicyID,
+		policyID,
+	)
+
+	errDrop := localACP.DropAll(ctx)
+	require.Nil(t, errDrop)
+
+	// Since nothing is persisted should allow adding same policy again with same ID
+
+	policyID, errAddPolicy = localACP.AddPolicy(
+		ctx,
+		identity1,
+		validPolicy,
+	)
+	require.Nil(t, errAddPolicy)
+	require.Equal(
+		t,
+		validPolicyID,
+		policyID,
+	)
+
+	errClose := localACP.Close()
+	require.Nil(t, errClose)
+}
+
+func Test_LocalACP_Persistent_AddPolicy_CreatingSamePolicyAfterDropAllReturnsSameID(t *testing.T) {
+	ctx := context.Background()
+	localACP := NewLocalACP()
+
+	acpPath := t.TempDir()
+	localACP.Init(ctx, acpPath)
+	errStart := localACP.Start(ctx)
+	require.Nil(t, errStart)
+
+	policyID, errAddPolicy := localACP.AddPolicy(
+		ctx,
+		identity1,
+		validPolicy,
+	)
+	require.Nil(t, errAddPolicy)
+
+	require.Equal(
+		t,
+		validPolicyID,
+		policyID,
+	)
+
+	errDrop := localACP.DropAll(ctx)
+	require.Nil(t, errDrop)
+
+	// Since nothing is persisted should allow adding same policy again with same ID
+
+	policyID, errAddPolicy = localACP.AddPolicy(
+		ctx,
+		identity1,
+		validPolicy,
+	)
+	require.Nil(t, errAddPolicy)
+	require.Equal(
+		t,
+		validPolicyID,
+		policyID,
+	)
+
+	errClose := localACP.Close()
+	require.Nil(t, errClose)
+}
+
 func Test_LocalACP_PersistentMemory_AddPolicy_CreatingSamePolicyReturnsDifferentIDs(t *testing.T) {
 	acpPath := t.TempDir()
 	require.NotEqual(t, "", acpPath)

--- a/acp/acp_source_hub.go
+++ b/acp/acp_source_hub.go
@@ -263,8 +263,8 @@ func (a *acpSourceHub) Close() error {
 	return nil
 }
 
-func (a *acpSourceHub) DropAll(_ context.Context) error {
-	return fmt.Errorf("sourcehub acp DropAll() unimplemented")
+func (a *acpSourceHub) ResetState(_ context.Context) error {
+	return fmt.Errorf("sourcehub acp ResetState() unimplemented")
 }
 
 func (a *acpSourceHub) AddActorRelationship(

--- a/acp/acp_source_hub.go
+++ b/acp/acp_source_hub.go
@@ -12,6 +12,7 @@ package acp
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	protoTypes "github.com/cosmos/gogoproto/types"
@@ -260,6 +261,10 @@ func (a *acpSourceHub) VerifyAccessRequest(
 
 func (a *acpSourceHub) Close() error {
 	return nil
+}
+
+func (a *acpSourceHub) DropAll(_ context.Context) error {
+	return fmt.Errorf("SourceHub.DropAll() unimplemented.")
 }
 
 func (a *acpSourceHub) AddActorRelationship(

--- a/acp/acp_source_hub.go
+++ b/acp/acp_source_hub.go
@@ -264,7 +264,7 @@ func (a *acpSourceHub) Close() error {
 }
 
 func (a *acpSourceHub) DropAll(_ context.Context) error {
-	return fmt.Errorf("SourceHub.DropAll() unimplemented.")
+	return fmt.Errorf("sourcehub acp DropAll() unimplemented")
 }
 
 func (a *acpSourceHub) AddActorRelationship(

--- a/acp/errors.go
+++ b/acp/errors.go
@@ -57,6 +57,7 @@ var (
 
 	ErrPolicyDataMustNotBeEmpty    = errors.New("policy data can not be empty")
 	ErrPolicyCreatorMustNotBeEmpty = errors.New("policy creator can not be empty")
+	ErrACPResetState               = errors.New("acp could not be reset")
 	ErrObjectDidNotRegister        = errors.New(errObjectDidNotRegister)
 	ErrNoPolicyArgs                = errors.New(errNoPolicyArgs)
 	ErrPolicyIDMustNotBeEmpty      = errors.New(errPolicyIDMustNotBeEmpty)

--- a/acp/source_hub_client.go
+++ b/acp/source_hub_client.go
@@ -130,6 +130,9 @@ type sourceHubClient interface {
 
 	// Close closes any resources in use by acp.
 	Close() error
+
+	// DropAll purges the entire ACP state.
+	DropAll(context.Context) error
 }
 
 // sourceHubBridge wraps a sourceHubClient, hosting the Defra-specific logic away from client-specific
@@ -560,4 +563,8 @@ func (a *sourceHubBridge) SupportsP2P() bool {
 
 func (a *sourceHubBridge) Close() error {
 	return a.client.Close()
+}
+
+func (a *sourceHubBridge) DropAll(ctx context.Context) error {
+	return a.client.DropAll(ctx)
 }

--- a/acp/source_hub_client.go
+++ b/acp/source_hub_client.go
@@ -131,8 +131,8 @@ type sourceHubClient interface {
 	// Close closes any resources in use by acp.
 	Close() error
 
-	// DropAll purges the entire ACP state.
-	DropAll(context.Context) error
+	// ResetState purges the entire ACP state.
+	ResetState(context.Context) error
 }
 
 // sourceHubBridge wraps a sourceHubClient, hosting the Defra-specific logic away from client-specific
@@ -565,6 +565,6 @@ func (a *sourceHubBridge) Close() error {
 	return a.client.Close()
 }
 
-func (a *sourceHubBridge) DropAll(ctx context.Context) error {
-	return a.client.DropAll(ctx)
+func (a *sourceHubBridge) ResetState(ctx context.Context) error {
+	return a.client.ResetState(ctx)
 }

--- a/node/node.go
+++ b/node/node.go
@@ -244,7 +244,7 @@ func (n *Node) PurgeAndRestart(ctx context.Context) error {
 	}
 	if n.acp.HasValue() {
 		acp := n.acp.Value()
-		err := acp.DropAll(ctx)
+		err := acp.ResetState(ctx)
 		if err != nil {
 			// for now we will just log this error, since SourceHub ACP doesn't yet
 			// implement the DropAll.

--- a/node/node.go
+++ b/node/node.go
@@ -247,8 +247,8 @@ func (n *Node) PurgeAndRestart(ctx context.Context) error {
 		err := acp.ResetState(ctx)
 		if err != nil {
 			// for now we will just log this error, since SourceHub ACP doesn't yet
-			// implement the DropAll.
-			log.ErrorE("Failed to drop ACP state", err)
+			// implement the ResetState.
+			log.ErrorE("Failed to reset ACP state", err)
 		}
 		// follow up close call on ACP is required since the node.Start function starts
 		// ACP again anyways so we need to gracefully close before starting again

--- a/node/node.go
+++ b/node/node.go
@@ -246,7 +246,9 @@ func (n *Node) PurgeAndRestart(ctx context.Context) error {
 		acp := n.acp.Value()
 		err := acp.DropAll(ctx)
 		if err != nil {
-			return err
+			// for now we will just log this error, since SourceHub ACP doesn't yet
+			// implement the DropAll.
+			log.ErrorE("Failed to drop ACP state", err)
 		}
 		// follow up close call on ACP is required since the node.Start function starts
 		// ACP again anyways so we need to gracefully close before starting again


### PR DESCRIPTION
## Relevant issue(s)

Resolves #3358 

## Description
***Crude*** implementation to purge the ACP state for LocalACP implementation (SourceHub ACP returns error at the moment). Basically it deletes the entire underlying KVStore and reinitializes it.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?
Manually, also added unit tests. No current integration purge tests (afaik)

Specify the platform(s) on which this was tested:
- *(modify the list accordingly*)
- Arch Linux
- Debian Linux
- MacOS
- Windows
