### PR TITLE
fix: Ensure no ACP doc check when action is node specific

### DIFF
--- a/internal/db/collection_acp.go
+++ b/internal/db/collection_acp.go
@@ -55,6 +55,10 @@ func (c *collection) checkAccessOfDocWithACP(
 	if !c.db.acp.HasValue() {
 		return true, nil
 	}
+	ident := identity.FromContext(ctx)
+	if ident.HasValue() && c.db.nodeIdentity.HasValue() && ident.Value().DID == c.db.nodeIdentity.Value().DID {
+		return true, nil
+	}
 	return permission.CheckAccessOfDocOnCollectionWithACP(
 		ctx,
 		identity.FromContext(ctx),

--- a/internal/db/p2p_replicator.go
+++ b/internal/db/p2p_replicator.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/sourcenetwork/corelog"
 
+	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/datastore"
 	dbErrors "github.com/sourcenetwork/defradb/errors"
@@ -156,6 +157,8 @@ func (db *db) getDocsHeads(
 		}
 		defer txn.Discard(ctx)
 		ctx = SetContextTxn(ctx, txn)
+		// This is a node specific action which means the actor is the node itself.
+		ctx = identity.WithContext(ctx, db.nodeIdentity)
 		for _, col := range cols {
 			keysCh, err := col.GetAllDocIDs(ctx)
 			if err != nil {

--- a/internal/db/p2p_schema_root.go
+++ b/internal/db/p2p_schema_root.go
@@ -17,6 +17,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/sourcenetwork/immutable"
 
+	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/event"
 	"github.com/sourcenetwork/defradb/internal/keys"
@@ -72,6 +73,8 @@ func (db *db) AddP2PCollections(ctx context.Context, collectionIDs []string) err
 		evt.ToAdd = append(evt.ToAdd, col.SchemaRoot())
 	}
 
+	// This is a node specific action which means the actor is the node itself.
+	ctx = identity.WithContext(ctx, db.nodeIdentity)
 	for _, col := range storeCollections {
 		keyChan, err := col.GetAllDocIDs(ctx)
 		if err != nil {
@@ -129,6 +132,8 @@ func (db *db) RemoveP2PCollections(ctx context.Context, collectionIDs []string) 
 		evt.ToRemove = append(evt.ToRemove, col.SchemaRoot())
 	}
 
+	// This is a node specific action which means the actor is the node itself.
+	ctx = identity.WithContext(ctx, db.nodeIdentity)
 	for _, col := range storeCollections {
 		keyChan, err := col.GetAllDocIDs(ctx)
 		if err != nil {
@@ -202,6 +207,8 @@ func (db *db) loadAndPublishP2PCollections(ctx context.Context) error {
 		colMap[schemaRoot] = struct{}{}
 	}
 
+	// This is a node specific action which means the actor is the node itself.
+	ctx = identity.WithContext(ctx, db.nodeIdentity)
 	for _, col := range cols {
 		// If we subscribed to the collection, we skip subscribing to the collection's docIDs.
 		if _, ok := colMap[col.SchemaRoot()]; ok {


### PR DESCRIPTION
## Relevant issue(s)

Resolves #3386 

## Description

This PR resolve the issue where re-adding docs to the p2p tropics on startup resulted in checking doc access. If we know the operation is node specific, meaning it is not to be returned to a client, then we don't need to check access through the ACP engine.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Manual startup test.

Specify the platform(s) on which this was tested:
- MacOS
