### PR TITLE
perf: Remove compound condition from 1-1 validation filter

### DIFF
--- a/internal/db/collection.go
+++ b/internal/db/collection.go
@@ -779,7 +779,7 @@ func (c *collection) validateOneToOneLinkDoesntAlreadyExist(
 	}
 
 	filter := fmt.Sprintf(
-		`{_and: [{%s: {_ne: "%s"}}, {%s: {_eq: "%s"}}]}`,
+		`%s: {_ne: "%s"}, %s: {_eq: "%s"}`,
 		request.DocIDFieldName,
 		docID,
 		fieldDescription.Name,


### PR DESCRIPTION
## Relevant issue(s)

Resolves #3190

## Description

Remove compound condition from 1-to-1 validation filter.

At the moment indexes don't work if compound conditions are present. For more details read https://github.com/sourcenetwork/defradb/issues/3299
