### PR TITLE
fix(i): Fetcher wrapper panic

### DIFF
--- a/internal/db/fetcher/wrapper.go
+++ b/internal/db/fetcher/wrapper.go
@@ -123,13 +123,13 @@ func (f *wrappingFetcher) Start(ctx context.Context, prefixes ...keys.Walkable) 
 	var top fetcher
 	top, err = newPrefixFetcher(ctx, f.txn, dsPrefixes, f.col, fieldsByID, client.Active, &execInfo)
 	if err != nil {
-		return nil
+		return err
 	}
 
 	if f.showDeleted {
 		deletedFetcher, err := newPrefixFetcher(ctx, f.txn, dsPrefixes, f.col, fieldsByID, client.Deleted, &execInfo)
 		if err != nil {
-			return nil
+			return err
 		}
 
 		top = newMultiFetcher(top, deletedFetcher)


### PR DESCRIPTION
## Relevant issue(s)

Resolves #3399

## Description

This PR fixes an issue where the `Start` function of `wrappingFetcher` would not return an error causing a seg fault when trying to access the fetcher in a subsequent `FetchNext` call.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

No added tests. I'm unsure if this is worth testing with mocks, but open to suggestions.

Specify the platform(s) on which this was tested:
- MacOS

