### PR TITLE
chore: Bump to GoLang v1.23

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sourcenetwork/defradb
 
-go 1.22.11
+go 1.23.6
 
 require (
 	github.com/bits-and-blooms/bitset v1.20.0

--- a/tools/cloud/aws/packer/build_aws_ami.pkr.hcl
+++ b/tools/cloud/aws/packer/build_aws_ami.pkr.hcl
@@ -66,8 +66,8 @@ build {
     inline = [
       "/usr/bin/cloud-init status --wait",
       "sudo apt-get update && sudo apt-get install make build-essential -y",
-      "curl -OL https://golang.org/dl/go1.22.6.linux-amd64.tar.gz",
-      "rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.22.6.linux-amd64.tar.gz",
+      "curl -OL https://golang.org/dl/go1.23.6.linux-amd64.tar.gz",
+      "rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.23.6.linux-amd64.tar.gz",
       "export PATH=$PATH:/usr/local/go/bin",
       "git clone \"https://git@$DEFRADB_GIT_REPO\"",
       "cd ./defradb || { printf \"\\\ncd into defradb failed.\\\n\" && exit 2; }",

--- a/tools/configs/golangci.yaml
+++ b/tools/configs/golangci.yaml
@@ -57,7 +57,7 @@ run:
 
   # Define the Go version limit.
   # Default: use Go version from the go.mod file, fallback on the env var `GOVERSION`.
-  go: "1.22"
+  go: "1.23"
 
 #=====================================================================================[ Output Configuration Options ]
 output:
@@ -420,7 +420,7 @@ linters-settings:
 
   unused:
     # Select the Go version to target.
-    go: "1.22"
+    go: "1.23"
 
   whitespace:
     # Enforces newlines (or comments) after every multi-line if statement.

--- a/tools/defradb.containerfile
+++ b/tools/defradb.containerfile
@@ -11,7 +11,7 @@ RUN npm run build
 
 # Stage: build
 # Several steps are involved to enable caching and because of the behavior of COPY regarding directories.
-FROM docker.io/golang:1.22 AS build
+FROM docker.io/golang:1.23 AS build
 WORKDIR /repo/
 COPY go.mod go.sum Makefile ./
 RUN make deps:modules


### PR DESCRIPTION
## Relevant issue(s)
Resolves #2912 

## Description
- This is a routine version bump of GoLang, the previous bump was done in (https://github.com/sourcenetwork/defradb/pull/2913)
- Also updates the golang version for AWS AMI generation.

### Routine Todo(s)
- [x] Open ticket for next GoLang version bump (https://github.com/sourcenetwork/defradb/issues/3442)