### PR TITLE
fix: Consistent version query semantics

### DIFF
--- a/docs/data_format_changes/i3477-version-query-consistency.md
+++ b/docs/data_format_changes/i3477-version-query-consistency.md
@@ -1,0 +1,2 @@
+# Consistent version query semantics
+Updated semantics for commit/version/time-travel queries when using both DocID and CID.

--- a/internal/planner/commit.go
+++ b/internal/planner/commit.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/request"
+	"github.com/sourcenetwork/defradb/errors"
 	"github.com/sourcenetwork/defradb/internal/core"
 	coreblock "github.com/sourcenetwork/defradb/internal/core/block"
 	"github.com/sourcenetwork/defradb/internal/db/fetcher"
@@ -223,7 +224,7 @@ func (n *dagScanNode) Next() (bool, error) {
 	// clear the cid after
 	block, err := store.Get(n.planner.ctx, *currentCid)
 	if err != nil {
-		return false, err
+		return false, errors.Join(ErrMissingCID, err)
 	}
 
 	dagBlock, err := coreblock.GetFromBytes(block.RawData())
@@ -258,7 +259,13 @@ func (n *dagScanNode) Next() (bool, error) {
 	// HEAD paths.
 	n.depthVisited++
 	n.visitedNodes[currentCid.String()] = true // mark the current node as "visited"
-	if !n.commitSelect.Depth.HasValue() || n.depthVisited < n.commitSelect.Depth.Value() {
+
+	// the default behavior for depth is:
+	// doc ID, max depth
+	// just doc ID + CID, 0 depth
+	// doc ID + CID + depth, use depth
+	if (!n.commitSelect.Depth.HasValue() && !n.commitSelect.Cid.HasValue()) ||
+		(n.commitSelect.Depth.HasValue() && n.depthVisited < n.commitSelect.Depth.Value()) {
 		// Insert the newly fetched cids into the slice of queued items, in reverse order
 		// so that the last new cid will be at the front of the slice
 		n.queuedCids = append(make([]*cid.Cid, len(dagBlock.Heads)), n.queuedCids...)

--- a/internal/planner/commit.go
+++ b/internal/planner/commit.go
@@ -275,14 +275,6 @@ func (n *dagScanNode) Next() (bool, error) {
 		}
 	}
 
-	// // If a specific cid has been requested
-	// // 1) Depth is undefined: then we assume lastestCommit semantics (ie: depth 1)
-	// // 2) Depth is defined,
-	// if n.commitSelect.Cid.HasValue() &&
-	// (currentCid.String() != n.commitSelect.Cid.Value() ||  {
-	// 	return n.Next()
-	// }
-
 	n.currentValue = currentValue
 	return true, nil
 }

--- a/internal/planner/errors.go
+++ b/internal/planner/errors.go
@@ -37,6 +37,7 @@ var (
 	ErrUpsertMultipleDocuments             = errors.New("cannot upsert multiple matching documents")
 	ErrMismatchLengthOnSimilarity          = errors.New("source and vector must be of the same length")
 	ErrIncorrectCIDForDocId                = errors.New("cid does not belong to document")
+	ErrMissingCID                          = errors.New("missing cid")
 )
 
 func NewErrUnknownDependency(name string) error {

--- a/internal/planner/errors.go
+++ b/internal/planner/errors.go
@@ -36,6 +36,7 @@ var (
 	ErrUnknownExplainRequestType           = errors.New("can not explain request of unknown type")
 	ErrUpsertMultipleDocuments             = errors.New("cannot upsert multiple matching documents")
 	ErrMismatchLengthOnSimilarity          = errors.New("source and vector must be of the same length")
+	ErrIncorrectCIDForDocId                = errors.New("cid does not belong to document")
 )
 
 func NewErrUnknownDependency(name string) error {

--- a/internal/planner/select.go
+++ b/internal/planner/select.go
@@ -408,6 +408,7 @@ func (n *selectNode) initFields(selectReq *mapper.Select) ([]aggregateNode, []*s
 					// a OneCommit subquery, with the supplied parameters.
 					commitSlct.DocID = immutable.Some(selectReq.DocIDs.Value()[0]) // @todo check length
 					commitSlct.Cid = selectReq.Cid
+					// commitSlct.Depth = immutable.Some(uint64(math.MaxUint64))
 				}
 
 				commitPlan := n.planner.DAGScan(commitSlct)

--- a/internal/planner/select.go
+++ b/internal/planner/select.go
@@ -11,6 +11,7 @@
 package planner
 
 import (
+	"math"
 	"slices"
 	"strings"
 
@@ -405,10 +406,11 @@ func (n *selectNode) initFields(selectReq *mapper.Select) ([]aggregateNode, []*s
 					// commit. Instead, _version references the CID
 					// of that Target version we are querying.
 					// So instead of a LatestCommit subquery, we need
-					// a OneCommit subquery, with the supplied parameters.
+					// a commits query with max depth starting from the
+					// target CID version
 					commitSlct.DocID = immutable.Some(selectReq.DocIDs.Value()[0]) // @todo check length
 					commitSlct.Cid = selectReq.Cid
-					// commitSlct.Depth = immutable.Some(uint64(math.MaxUint64))
+					commitSlct.Depth = immutable.Some(uint64(math.MaxUint64))
 				}
 
 				commitPlan := n.planner.DAGScan(commitSlct)

--- a/tests/integration/query/commits/branchables/cid_doc_id_test.go
+++ b/tests/integration/query/commits/branchables/cid_doc_id_test.go
@@ -48,6 +48,7 @@ func TestQueryCommitsBranchables_WithCidAndDocIDParam(t *testing.T) {
 				Results: map[string]any{
 					"commits": []map[string]any{},
 				},
+				ExpectedError: "cid does not belong to document",
 			},
 		},
 	}

--- a/tests/integration/query/commits/with_cid_test.go
+++ b/tests/integration/query/commits/with_cid_test.go
@@ -115,6 +115,7 @@ func TestQueryCommitsWithInvalidCid(t *testing.T) {
 				Results: map[string]any{
 					"commits": []map[string]any{},
 				},
+				ExpectedError: "invalid cid",
 			},
 		},
 	}
@@ -145,6 +146,7 @@ func TestQueryCommitsWithInvalidShortCid(t *testing.T) {
 				Results: map[string]any{
 					"commits": []map[string]any{},
 				},
+				ExpectedError: "invalid cid",
 			},
 		},
 	}
@@ -175,6 +177,7 @@ func TestQueryCommitsWithUnknownCid(t *testing.T) {
 				Results: map[string]any{
 					"commits": []map[string]any{},
 				},
+				ExpectedError: "missing cid",
 			},
 		},
 	}

--- a/tests/integration/query/commits/with_cid_test.go
+++ b/tests/integration/query/commits/with_cid_test.go
@@ -70,10 +70,15 @@ func TestQueryCommitsWithCidForFieldCommit(t *testing.T) {
 						"age":	21
 					}`,
 			},
+			testUtils.UpdateDoc{
+				Doc: `{
+					"name": "Johnn"
+				}`,
+			},
 			testUtils.Request{
 				Request: `query {
 						commits(
-							cid: "bafyreia2vlbfkcbyogdjzmbqcjneabwwwtw7ti2xbd7yor5mbu2sk4pcoy"
+							cid: "bafyreiexx65zeu6rln4yiw7lav4up5bnfnbkti4kguw3vdencwddqhv45e"
 						) {
 							cid
 						}
@@ -81,7 +86,7 @@ func TestQueryCommitsWithCidForFieldCommit(t *testing.T) {
 				Results: map[string]any{
 					"commits": []map[string]any{
 						{
-							"cid": "bafyreia2vlbfkcbyogdjzmbqcjneabwwwtw7ti2xbd7yor5mbu2sk4pcoy",
+							"cid": "bafyreiexx65zeu6rln4yiw7lav4up5bnfnbkti4kguw3vdencwddqhv45e",
 						},
 					},
 				},

--- a/tests/integration/query/commits/with_doc_id_cid_test.go
+++ b/tests/integration/query/commits/with_doc_id_cid_test.go
@@ -40,6 +40,7 @@ func TestQueryCommitsWithDocIDAndCidForDifferentDoc(t *testing.T) {
 				Results: map[string]any{
 					"commits": []map[string]any{},
 				},
+				ExpectedError: "missing cid",
 			},
 		},
 	}
@@ -70,7 +71,7 @@ func TestQueryCommitsWithDocIDAndCidForDifferentDocWithUpdate(t *testing.T) {
 				Request: ` {
 						commits(
 							docID: "bae-not-this-doc",
-							cid: "bafybeica4js2abwqjjrz7dcialbortbz32uxp7ufxu7yljbwvmhjqqxzny"
+							cid: "bafyreiale6qsjc7qewod3c6h2odwamfwcf7vt4zlqtw7ldcm57xdkgxja4"
 						) {
 							cid
 						}
@@ -78,6 +79,7 @@ func TestQueryCommitsWithDocIDAndCidForDifferentDocWithUpdate(t *testing.T) {
 				Results: map[string]any{
 					"commits": []map[string]any{},
 				},
+				ExpectedError: "cid does not belong to document",
 			},
 		},
 	}

--- a/tests/integration/query/commits/with_doc_id_cid_test.go
+++ b/tests/integration/query/commits/with_doc_id_cid_test.go
@@ -128,3 +128,51 @@ func TestQueryCommitsWithDocIDAndCidWithUpdate(t *testing.T) {
 
 	testUtils.ExecuteTestCase(t, test)
 }
+
+func TestQueryCommitsWithDocIDAndCidWithUpdateAndDepth(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "Simple all commits query with docID and cid, with update",
+		Actions: []any{
+			updateUserCollectionSchema(),
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `{
+						"name":	"John",
+						"age":	21
+					}`,
+			},
+			testUtils.UpdateDoc{
+				CollectionID: 0,
+				DocID:        0,
+				Doc: `{
+					"age":	22
+				}`,
+			},
+			// depth is pretty arbitrary here, as long as its big enough to cover the updates
+			// from the target cid (ie >=2)
+			testUtils.Request{
+				Request: ` {
+						commits(
+							docID: "bae-c9fb0fa4-1195-589c-aa54-e68333fb90b3",
+							cid: "bafyreiale6qsjc7qewod3c6h2odwamfwcf7vt4zlqtw7ldcm57xdkgxja4",
+							depth: 5
+						) {
+							cid
+						}
+					}`,
+				Results: map[string]any{
+					"commits": []map[string]any{
+						{
+							"cid": "bafyreiale6qsjc7qewod3c6h2odwamfwcf7vt4zlqtw7ldcm57xdkgxja4",
+						},
+						{
+							"cid": "bafyreia2vlbfkcbyogdjzmbqcjneabwwwtw7ti2xbd7yor5mbu2sk4pcoy",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/query/latest_commits/simple_test.go
+++ b/tests/integration/query/latest_commits/simple_test.go
@@ -20,7 +20,7 @@ import (
 // desired behaviour (should return all latest commits).
 func TestQueryLatestCommits(t *testing.T) {
 	test := testUtils.TestCase{
-		Description: "Simple latest commits query",
+		Description: "Simple latest commits querys",
 		Actions: []any{
 			testUtils.CreateDoc{
 				Doc: `{

--- a/tests/integration/query/latest_commits/simple_test.go
+++ b/tests/integration/query/latest_commits/simple_test.go
@@ -20,7 +20,7 @@ import (
 // desired behaviour (should return all latest commits).
 func TestQueryLatestCommits(t *testing.T) {
 	test := testUtils.TestCase{
-		Description: "Simple latest commits queries",
+		Description: "Simple latest commits query",
 		Actions: []any{
 			testUtils.CreateDoc{
 				Doc: `{

--- a/tests/integration/query/latest_commits/simple_test.go
+++ b/tests/integration/query/latest_commits/simple_test.go
@@ -20,7 +20,7 @@ import (
 // desired behaviour (should return all latest commits).
 func TestQueryLatestCommits(t *testing.T) {
 	test := testUtils.TestCase{
-		Description: "Simple latest commits querys",
+		Description: "Simple latest commits queries",
 		Actions: []any{
 			testUtils.CreateDoc{
 				Doc: `{

--- a/tests/integration/query/simple/with_cid_doc_id_test.go
+++ b/tests/integration/query/simple/with_cid_doc_id_test.go
@@ -234,12 +234,23 @@ func TestQuerySimpleWithUpdateAndMiddleCidAndDocID(t *testing.T) {
 							docID: "bae-6845cfdf-cb0f-56a3-be3a-b5a67be5fbdc"
 						) {
 						name
+						_version {
+							cid
+						}
 					}
 				}`,
 				Results: map[string]any{
 					"Users": []map[string]any{
 						{
 							"name": "Johnn",
+							"_version": []map[string]any{
+								{
+									"cid": "bafyreig2j5zwcozovwzrxr7ivfnptlj7urlabzjbv4lls64hlkh6jmhfim",
+								},
+								{
+									"cid": "bafyreib7afkd5hepl45wdtwwpai433bhnbd3ps5m2rv3masctda7b6mmxe",
+								},
+							},
 						},
 					},
 				},


### PR DESCRIPTION
## Relevant issue(s)

Resolves #3476 

## Description

Fixes the consistency between regular queries and time-travel queries with respect to the `_version` subquery. Before, the regular queries would return all commits from the start to the current, but time-travel queries only used a "latestCommit" query at the target version, which meant only returning a single commit entry.

This PR implements some semantics changes to the overall commits API, but maintains all necessary backwards compatibility (however, it does introduce new errors when using invalid cid/docid combinations).

New semantics:
- Only doc ID, default max depth, start from "latest" cid
- doc ID + CID, default 0 depth, start from "target" cid
- doc ID + CID + depth, use depth, start from "target" cid

Unchanged semantics:
- doc ID + depth, use depth, start from "latest" cid

Technically, there is also an optimization where we no longer use the `HeadFetcher` in the commit queries if a `CID` is specified.

## Tasks
- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

(*replace*) Describe the tests performed to verify the changes. Provide instructions to reproduce them.

Specify the platform(s) on which this was tested:
- *(modify the list accordingly*)
- Ubuntu (WSL2)
