### PR TITLE
fix(i): Release cache path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         uses: actions/cache/save@v4
         with:
-          path: dist/linux_amd64_v1
+          path: dist/linux_amd64
           key: linux-${{ env.sha_short }}
 
       - name: Save cache on MacOS
@@ -81,7 +81,7 @@ jobs:
         if: matrix.os == 'windows-latest'
         uses: actions/cache/save@v4
         with:
-          path: dist/windows_amd64_v1
+          path: dist/windows_amd64
           key: windows-${{ env.sha_short }}
           enableCrossOsArchive: true
 
@@ -113,7 +113,7 @@ jobs:
         id: restore-linux
         uses: actions/cache/restore@v4
         with:
-          path: dist/linux_amd64_v1
+          path: dist/linux_amd64
           key: linux-${{ env.sha_short }}
           fail-on-cache-miss: true
 
@@ -129,7 +129,7 @@ jobs:
         id: restore-windows
         uses: actions/cache/restore@v4
         with:
-          path: dist/windows_amd64_v1
+          path: dist/windows_amd64
           key: windows-${{ env.sha_short }}
           fail-on-cache-miss: true
           enableCrossOsArchive: true


### PR DESCRIPTION
## Relevant issue(s)

Resolves #3478 

## Description

Some change again with the goreleaser target name. This simply fixed the path for the release action cache.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Tested on my fork