### PR TITLE
test: Incorporate gomega matchers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	github.com/multiformats/go-multibase v0.2.0
 	github.com/multiformats/go-multicodec v0.9.0
 	github.com/multiformats/go-multihash v0.2.3
+	github.com/onsi/gomega v1.36.2
 	github.com/pelletier/go-toml v1.9.5
 	github.com/philippgille/chromem-go v0.7.0
 	github.com/pkg/errors v0.9.1

--- a/tests/integration/encryption/peer_test.go
+++ b/tests/integration/encryption/peer_test.go
@@ -140,7 +140,7 @@ func TestDocEncryptionPeer_IfPeerDidNotReceiveKey_ShouldNotFetch(t *testing.T) {
 					}
 				}`,
 				Results: map[string]any{
-					"Users": testUtils.AnyOf{
+					"Users": testUtils.AnyOf(
 						// The key-sync has not yet completed
 						[]map[string]any{},
 						// The key-sync has completed
@@ -149,7 +149,7 @@ func TestDocEncryptionPeer_IfPeerDidNotReceiveKey_ShouldNotFetch(t *testing.T) {
 								"age": int64(21),
 							},
 						},
-					},
+					),
 				},
 			},
 		},

--- a/tests/integration/mutation/create/embeddings/embedding_test.go
+++ b/tests/integration/mutation/create/embeddings/embedding_test.go
@@ -13,6 +13,7 @@ package constraints
 import (
 	"testing"
 
+	"github.com/onsi/gomega"
 	"github.com/sourcenetwork/immutable"
 
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
@@ -23,9 +24,9 @@ func TestMutationCreate_WithMultipleEmbeddingFields_ShouldSucceed(t *testing.T) 
 		Description: "Simple create mutation with multiple embedding fields",
 		SupportedClientTypes: immutable.Some([]testUtils.ClientType{
 			// Embedding test with mutations are currently only compatible with the Go client.
-			// The docID is updated by collection.Create after vector embedding generation and
+			// The docID is updated by collection. Create after vector embedding generation and
 			// the HTTP and CLI clients don't receive that updated docID. This causes the waitForUpdateEvents
-			// to fail sinces it receives an update on a docID that wasn't expected. We will look for a solution
+			// to fail since it receives an update on a docID that wasn't expected. We will look for a solution
 			// and update the test accordingly.
 			testUtils.GoClientType,
 		}),
@@ -63,10 +64,16 @@ func TestMutationCreate_WithMultipleEmbeddingFields_ShouldSucceed(t *testing.T) 
 				Results: map[string]any{
 					"User": []map[string]any{
 						{
-							"name_v": testUtils.NewArrayDescription[float32](768),
+							"name_v": gomega.And(
+								gomega.BeAssignableToTypeOf([]float32{}),
+								gomega.HaveLen(768),
+							),
 						},
 						{
-							"name_v": testUtils.NewArrayDescription[float32](768),
+							"name_v": gomega.And(
+								gomega.BeAssignableToTypeOf([]float32{}),
+								gomega.HaveLen(768),
+							),
 						},
 					},
 				},

--- a/tests/integration/mutation/update/embeddings/embedding_test.go
+++ b/tests/integration/mutation/update/embeddings/embedding_test.go
@@ -13,6 +13,7 @@ package constraints
 import (
 	"testing"
 
+	"github.com/onsi/gomega"
 	"github.com/sourcenetwork/immutable"
 
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
@@ -77,10 +78,16 @@ func TestMutationUpdate_WithMultipleEmbeddingFields_ShouldSucceed(t *testing.T) 
 				Results: map[string]any{
 					"User": []map[string]any{
 						{
-							"name_v": testUtils.NewArrayDescription[float32](768),
+							"name_v": gomega.And(
+								gomega.BeAssignableToTypeOf([]float32{}),
+								gomega.HaveLen(768),
+							),
 						},
 						{
-							"name_v": testUtils.NewArrayDescription[float32](768),
+							"name_v": gomega.And(
+								gomega.BeAssignableToTypeOf([]float32{}),
+								gomega.HaveLen(768),
+							),
 						},
 					},
 				},

--- a/tests/integration/net/simple/peer/with_update_test.go
+++ b/tests/integration/net/simple/peer/with_update_test.go
@@ -175,7 +175,7 @@ func TestP2PWithSingleDocumentUpdatePerNode(t *testing.T) {
 				Results: map[string]any{
 					"Users": []map[string]any{
 						{
-							"Age": testUtils.AnyOf{int64(45), int64(60)},
+							"Age": testUtils.AnyOf(int64(45), int64(60)),
 						},
 					},
 				},
@@ -431,7 +431,7 @@ func TestP2PWithMultipleDocumentUpdatesPerNode(t *testing.T) {
 				Results: map[string]any{
 					"Users": []map[string]any{
 						{
-							"Age": testUtils.AnyOf{int64(47), int64(62)},
+							"Age": testUtils.AnyOf(int64(47), int64(62)),
 						},
 					},
 				},
@@ -614,7 +614,7 @@ func TestP2PWithMultipleDocumentUpdatesPerNodeWithP2PCollection(t *testing.T) {
 				Results: map[string]any{
 					"Users": []map[string]any{
 						{
-							"Age": testUtils.AnyOf{int64(47), int64(62)},
+							"Age": testUtils.AnyOf(int64(47), int64(62)),
 						},
 						{
 							"Age": int64(60),

--- a/tests/integration/test_case.go
+++ b/tests/integration/test_case.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/lens-vm/lens/host-go/config/model"
 	"github.com/sourcenetwork/immutable"
-	"github.com/stretchr/testify/require"
 
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/net"
@@ -813,29 +812,4 @@ type GetNodeIdentity struct {
 type Wait struct {
 	// Duration is the duration to wait.
 	Duration time.Duration
-}
-
-// ArrayDescription represents an array field.
-//
-// The test harness will call the Validate method to ensure that the returned array size and type
-// match what is described by this struct.
-type ArrayDescription[T any] struct {
-	// Size of the array
-	Size int
-}
-
-// NewArrayDescription creates a new [ArrayDescription] instance allowing validation of the array
-// characteristics instead of the content of the array itself.
-func NewArrayDescription[T any](size int) ArrayDescription[T] {
-	return ArrayDescription[T]{
-		Size: size,
-	}
-}
-
-func (d ArrayDescription[T]) Validate(s *state, actualValue any, msgAndArgs ...any) {
-	var expT []T
-	require.IsType(s.t, expT, actualValue, msgAndArgs)
-	typedActualValue, ok := actualValue.([]T)
-	require.True(s.t, ok)
-	require.Equal(s.t, d.Size, len(typedActualValue), msgAndArgs)
 }


### PR DESCRIPTION
## Relevant issue(s)

Resolves https://github.com/sourcenetwork/defradb/issues/3189

## Description

Replace the `Validator` interface with `gomega.OmegaMatcher` that doesn't assert directly, but instead matches the actual value against the expected value and returns `bool` as a result. This allows different matchers to be combined.

Moreover, gomega provides a number of very handy matchers that we can use.