### PR TITLE
fix: fix incorrect nil return value

### DIFF
--- a/internal/db/description/collection.go
+++ b/internal/db/description/collection.go
@@ -168,7 +168,7 @@ func GetCollectionsByRoot(
 			if err := iter.Close(); err != nil {
 				return nil, NewErrFailedToCloseCollectionQuery(err)
 			}
-			return nil, err
+			return nil, res.Error
 		}
 
 		if !hasValue {
@@ -218,7 +218,7 @@ func GetCollectionsBySchemaVersionID(
 			if err := iter.Close(); err != nil {
 				return nil, NewErrFailedToCloseSchemaQuery(err)
 			}
-			return nil, err
+			return nil, res.Error
 		}
 
 		if !hasValue {

--- a/internal/db/description/schema.go
+++ b/internal/db/description/schema.go
@@ -163,7 +163,7 @@ func GetSchemas(
 			if err := iter.Close(); err != nil {
 				return nil, NewErrFailedToCloseSchemaQuery(err)
 			}
-			return nil, err
+			return nil, res.Error
 		}
 
 		var desc client.SchemaDescription
@@ -221,7 +221,7 @@ func GetAllSchemas(
 			if err := iter.Close(); err != nil {
 				return nil, NewErrFailedToCloseSchemaQuery(err)
 			}
-			return nil, err
+			return nil, res.Error
 		}
 
 		var desc client.SchemaDescription
@@ -266,7 +266,7 @@ func GetSchemaVersionIDs(
 			if err := iter.Close(); err != nil {
 				return nil, NewErrFailedToCloseSchemaQuery(err)
 			}
-			return nil, err
+			return nil, res.Error
 		}
 
 		if !hasValue {


### PR DESCRIPTION
## Relevant issue(s)

Resolves #

## Description


Since we have already checked err before and returned != nil, err must be nil here. In fact, it should return  `res.Error`.


## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [ ] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

(*replace*) Describe the tests performed to verify the changes. Provide instructions to reproduce them.

Specify the platform(s) on which this was tested:
- *(modify the list accordingly*)
- Arch Linux
- Debian Linux
- MacOS
- Windows
