### PR TITLE
[Experiment]: Struct Field Align

### DIFF
--- a/acp/acp_local.go
+++ b/acp/acp_local.go
@@ -30,9 +30,9 @@ const localACPStoreName = "local_acp"
 
 // ACPLocal represents a local acp implementation that makes no remote calls.
 type ACPLocal struct {
-	pathToStore immutable.Option[string]
 	engine      types.ACPEngineServer
 	manager     runtime.RuntimeManager
+	pathToStore immutable.Option[string]
 	closed      bool
 }
 

--- a/acp/types.go
+++ b/acp/types.go
@@ -35,15 +35,15 @@ const (
 // policy is a data container carrying the necessary data
 // to verify whether a policy meets DPI requirements
 type policy struct {
-	ID        string
 	Resources map[string]*resource
+	ID        string
 }
 
 // resource is a data container carrying the necessary data
 // to verify whether it meets DPI requirements.
 type resource struct {
-	Name        string
 	Permissions map[string]*permission
+	Name        string
 }
 
 // permission is a data container carrying the necessary data

--- a/client/backup.go
+++ b/client/backup.go
@@ -29,8 +29,8 @@ type BackupConfig struct {
 	Filepath string `json:"filepath"`
 	// Only JSON is supported at the moment.
 	Format string `json:"format"`
-	// Pretty print JSON.
-	Pretty bool `json:"pretty"`
 	// List of collection names to select which one to backup.
 	Collections []string `json:"collections"`
+	// Pretty print JSON.
+	Pretty bool `json:"pretty"`
 }

--- a/client/collection.go
+++ b/client/collection.go
@@ -126,26 +126,26 @@ type Collection interface {
 
 // DocIDResult wraps the result of an attempt at a DocID retrieval operation.
 type DocIDResult struct {
-	// If a DocID was successfully retrieved, this will be that DocID.
-	ID DocID
 	// If an error was generated whilst attempting to retrieve the DocID, this will be the error.
 	Err error
+	// If a DocID was successfully retrieved, this will be that DocID.
+	ID DocID
 }
 
 // UpdateResult wraps the result of an update call.
 type UpdateResult struct {
-	// Count contains the number of documents updated by the update call.
-	Count int64
 	// DocIDs contains the DocIDs of all the documents updated by the update call.
 	DocIDs []string
+	// Count contains the number of documents updated by the update call.
+	Count int64
 }
 
 // DeleteResult wraps the result of an delete call.
 type DeleteResult struct {
-	// Count contains the number of documents deleted by the delete call.
-	Count int64
 	// DocIDs contains the DocIDs of all the documents deleted by the delete call.
 	DocIDs []string
+	// Count contains the number of documents deleted by the delete call.
+	Count int64
 }
 
 // P2PCollection is the gRPC response representation of a P2P collection topic

--- a/client/collection_field_description.go
+++ b/client/collection_field_description.go
@@ -22,11 +22,6 @@ type FieldID uint32
 
 // CollectionFieldDescription describes the local components of a field on a collection.
 type CollectionFieldDescription struct {
-	// Name contains the name of the [SchemaFieldDescription] that this field uses.
-	Name string
-
-	// ID contains the local, internal ID of this field.
-	ID FieldID
 
 	// Kind contains the local field kind if this is a local-only field (e.g. the secondary
 	// side of a relation).
@@ -34,21 +29,27 @@ type CollectionFieldDescription struct {
 	// If the field is globaly defined (on the Schema), this will be [None].
 	Kind immutable.Option[FieldKind]
 
+	// DefaultValue contains the default value for this field.
+	//
+	// This value has no effect on views.
+	DefaultValue any
+
 	// RelationName contains the name of this relation, if this field is part of a relationship.
 	//
 	// Otherwise will be [None].
 	RelationName immutable.Option[string]
 
-	// DefaultValue contains the default value for this field.
-	//
-	// This value has no effect on views.
-	DefaultValue any
+	// Name contains the name of the [SchemaFieldDescription] that this field uses.
+	Name string
 
 	// Size is a constraint that can be applied to fields that are arrays.
 	//
 	// Mutations on fields with a size constraint will fail if the size of the array
 	// does not match the constraint.
 	Size int
+
+	// ID contains the local, internal ID of this field.
+	ID FieldID
 }
 
 func (f FieldID) String() string {
@@ -58,14 +59,15 @@ func (f FieldID) String() string {
 // collectionFieldDescription is a private type used to facilitate the unmarshalling
 // of json to a [CollectionFieldDescription].
 type collectionFieldDescription struct {
-	Name         string
-	ID           FieldID
-	RelationName immutable.Option[string]
 	DefaultValue any
-	Size         int
+	RelationName immutable.Option[string]
+	Name         string
 
 	// Properties below this line are unmarshalled using custom logic in [UnmarshalJSON]
 	Kind json.RawMessage
+	Size int
+
+	ID FieldID
 }
 
 func (f *CollectionFieldDescription) UnmarshalJSON(bytes []byte) error {

--- a/client/db.go
+++ b/client/db.go
@@ -304,10 +304,10 @@ type Store interface {
 
 // GQLOptions contains optional arguments for GQL requests.
 type GQLOptions struct {
-	// OperationName is the name of the operation to exec.
-	OperationName string
 	// Variables is a map of names to varible values.
 	Variables map[string]any
+	// OperationName is the name of the operation to exec.
+	OperationName string
 }
 
 // RequestOption sets an optional request setting.
@@ -331,16 +331,16 @@ func WithVariables(variables map[string]any) RequestOption {
 //
 // It does not handle subscription channels. This object and its children are json serializable.
 type GQLResult struct {
-	// Errors contains any errors generated whilst attempting to execute the request.
-	//
-	// If there are values in this slice the request will likely not have run to completion
-	// and [Data] will be nil.
-	Errors []error `json:"errors,omitempty"`
 
 	// Data contains the resultant data produced by the GQL request.
 	//
 	// It will be nil if any errors were raised during execution.
 	Data any `json:"data"`
+	// Errors contains any errors generated whilst attempting to execute the request.
+	//
+	// If there are values in this slice the request will likely not have run to completion
+	// and [Data] will be nil.
+	Errors []error `json:"errors,omitempty"`
 }
 
 // gqlError represents an error that was encountered during a GQL request.
@@ -355,10 +355,10 @@ type gqlError struct {
 //
 // The serialized data should always match the graphQL spec.
 type gqlResult struct {
-	// Errors contains the formatted result errors
-	Errors []gqlError `json:"errors,omitempty"`
 	// Data contains the result data
 	Data any `json:"data"`
+	// Errors contains the formatted result errors
+	Errors []gqlError `json:"errors,omitempty"`
 }
 
 func (res *GQLResult) UnmarshalJSON(data []byte) error {
@@ -387,12 +387,12 @@ func (res GQLResult) MarshalJSON() ([]byte, error) {
 
 // RequestResult represents the results of a GQL request.
 type RequestResult struct {
-	// GQL contains the immediate results of the GQL request.
-	GQL GQLResult
 
 	// Subscription is an optional channel which returns results
 	// from a subscription request.
 	Subscription <-chan GQLResult
+	// GQL contains the immediate results of the GQL request.
+	GQL GQLResult
 }
 
 // CollectionFetchOptions represents a set of options used for fetching collections.
@@ -403,11 +403,11 @@ type CollectionFetchOptions struct {
 	// If provided, only collections with schemas of this root will be returned.
 	SchemaRoot immutable.Option[string]
 
-	// If provided, only collections with this root will be returned.
-	Root immutable.Option[uint32]
-
 	// If provided, only collections with this name will be returned.
 	Name immutable.Option[string]
+
+	// If provided, only collections with this root will be returned.
+	Root immutable.Option[uint32]
 
 	// If IncludeInactive is true, then inactive collections will also be returned.
 	IncludeInactive immutable.Option[bool]

--- a/client/definitions.go
+++ b/client/definitions.go
@@ -28,10 +28,10 @@ import (
 // from various functions as a convienient means to access the computated convergence of schema
 // and collection descriptions.
 type CollectionDefinition struct {
-	// Description returns the CollectionDescription of this Collection.
-	Description CollectionDescription `json:"description"`
 	// Schema returns the SchemaDescription used to define this Collection.
 	Schema SchemaDescription `json:"schema"`
+	// Description returns the CollectionDescription of this Collection.
+	Description CollectionDescription `json:"description"`
 }
 
 // GetFieldByName returns the field for the given field name. If such a field is found it
@@ -123,20 +123,30 @@ func (def CollectionDefinition) GetName() string {
 // from various functions as a convienient means to access the computated convergence of schema
 // and collection descriptions.
 type FieldDefinition struct {
-	// Name contains the name of this field.
-	Name string
-
-	// ID contains the local, internal ID of this field.
-	ID FieldID
 
 	// The data type that this field holds.
 	//
 	// Must contain a valid value. It is currently immutable.
 	Kind FieldKind
 
+	// DefaultValue contains the default value for this field.
+	DefaultValue any
+
+	// Name contains the name of this field.
+	Name string
+
 	// RelationName the name of the relationship that this field represents if this field is
 	// a relation field.  Otherwise this will be empty.
 	RelationName string
+
+	// Size is a constraint that can be applied to fields that are arrays.
+	//
+	// Mutations on fields with a size constraint will fail if the size of the array
+	// does not match the constraint.
+	Size int
+
+	// ID contains the local, internal ID of this field.
+	ID FieldID
 
 	// The CRDT Type of this field. If no type has been provided it will default to [LWW_REGISTER].
 	//
@@ -145,15 +155,6 @@ type FieldDefinition struct {
 
 	// If true, this is the primary half of a relation, otherwise is false.
 	IsPrimaryRelation bool
-
-	// DefaultValue contains the default value for this field.
-	DefaultValue any
-
-	// Size is a constraint that can be applied to fields that are arrays.
-	//
-	// Mutations on fields with a size constraint will fail if the size of the array
-	// does not match the constraint.
-	Size int
 }
 
 // NewFieldDefinition returns a new [FieldDefinition], combining the given local and global elements
@@ -217,14 +218,14 @@ func (f FieldDefinition) GetSecondaryRelationField(c CollectionDefinition) (Fiel
 
 // DefinitionCache is an object providing easy access to cached collection definitions.
 type DefinitionCache struct {
-	// The full set of [CollectionDefinition]s within this cache
-	Definitions []CollectionDefinition
 
 	// The cached Definitions mapped by the Root of their [SchemaDescription]
 	DefinitionsBySchemaRoot map[string]CollectionDefinition
 
 	// The cached Definitions mapped by the Root of their [CollectionDescription]
 	DefinitionsByCollectionRoot map[uint32]CollectionDefinition
+	// The full set of [CollectionDefinition]s within this cache
+	Definitions []CollectionDefinition
 }
 
 // NewDefinitionCache creates a new [DefinitionCache] populated with the given [CollectionDefinition]s.

--- a/client/doc_id.go
+++ b/client/doc_id.go
@@ -37,9 +37,9 @@ var (
 
 // DocID is the root identifier for documents in DefraDB.
 type DocID struct {
+	cid     cid.Cid
 	version uint16
 	uuid    uuid.UUID
-	cid     cid.Cid
 }
 
 // NewDocIDV0 creates a new DocID identified by the root data CID, peerID, and namespaced by the versionNS.

--- a/client/document.go
+++ b/client/document.go
@@ -89,15 +89,15 @@ var CborNil []byte
 // @body: A document interface can be implemented by both a TypedDocument and a
 // UnTypedDocument, which use a schema and schemaless approach respectively.
 type Document struct {
-	id     DocID
 	fields map[string]Field
 	values map[Field]*FieldValue
 	head   cid.Cid
-	mu     sync.RWMutex
-	// marks if document has unsaved changes
-	isDirty bool
 
 	collectionDefinition CollectionDefinition
+	id                   DocID
+	mu                   sync.RWMutex
+	// marks if document has unsaved changes
+	isDirty bool
 }
 
 func newEmptyDoc(collectionDefinition CollectionDefinition) (*Document, error) {

--- a/client/index.go
+++ b/client/index.go
@@ -28,10 +28,10 @@ type IndexedFieldDescription struct {
 type IndexDescription struct {
 	// Name contains the name of the index.
 	Name string
-	// ID is the local identifier of this index.
-	ID uint32
 	// Fields contains the fields that are being indexed.
 	Fields []IndexedFieldDescription
+	// ID is the local identifier of this index.
+	ID uint32
 	// Unique indicates whether the index is unique.
 	Unique bool
 }

--- a/client/json.go
+++ b/client/json.go
@@ -207,10 +207,10 @@ type JSONVisitor func(value JSON) error
 
 // traverseJSONOptions configures how the JSON tree is traversed.
 type traverseJSONOptions struct {
-	// onlyLeaves when true visits only leaf nodes (not objects or arrays)
-	onlyLeaves bool
 	// pathPrefix when set visits only paths that start with this prefix
 	pathPrefix JSONPath
+	// onlyLeaves when true visits only leaf nodes (not objects or arrays)
+	onlyLeaves bool
 	// visitArrayElements when true visits array elements
 	visitArrayElements bool
 	// recurseVisitedArrayElements when true visits array elements recursively

--- a/client/replicator.go
+++ b/client/replicator.go
@@ -26,10 +26,10 @@ type ReplicatorParams struct {
 
 // Replicator is a peer that a set of local collections are replicated to.
 type Replicator struct {
+	LastStatusChange time.Time
 	Info             peer.AddrInfo
 	Schemas          []string
 	Status           ReplicatorStatus
-	LastStatusChange time.Time
 }
 
 // ReplicatorStatus is the status of a Replicator.

--- a/client/request/aggregate.go
+++ b/client/request/aggregate.go
@@ -30,16 +30,7 @@ type Aggregate struct {
 
 // AggregateTarget represents the target of an [Aggregate].
 type AggregateTarget struct {
-	Limitable
-	Offsetable
-	Orderable
 	Filterable
-
-	// HostName is the name of the immediate field on the object hosting the aggregate.
-	//
-	// For example if averaging Friends.Age on the User collection, this property would be
-	// "Friends".
-	HostName string
 
 	// ChildName is the name of the child field on the object navigated to via [HostName].
 	//
@@ -49,4 +40,14 @@ type AggregateTarget struct {
 	// When averaging Friends.Age on the User collection, this property would be
 	// "Age".
 	ChildName immutable.Option[string]
+
+	// HostName is the name of the immediate field on the object hosting the aggregate.
+	//
+	// For example if averaging Friends.Age on the User collection, this property would be
+	// "Friends".
+	HostName string
+
+	Orderable
+	Limitable
+	Offsetable
 }

--- a/client/request/commit.go
+++ b/client/request/commit.go
@@ -19,14 +19,8 @@ var (
 // CommitSelect represents the selection of database commits to Defra documents.
 type CommitSelect struct {
 	Field
-	ChildSelect
 
 	CIDFilter
-
-	Limitable
-	Offsetable
-	Orderable
-	Groupable
 
 	// DocID is an optional filter which when provided will limit commits to those
 	// belonging to the given document.
@@ -37,6 +31,14 @@ type CommitSelect struct {
 	//
 	// `C` may be provided for document-level (composite) commits.
 	FieldID immutable.Option[string]
+
+	Orderable
+	Groupable
+
+	ChildSelect
+
+	Limitable
+	Offsetable
 
 	// Depth limits the returned commits to being X places in the history away from the
 	// most current.

--- a/client/request/mutation.go
+++ b/client/request/mutation.go
@@ -23,31 +23,33 @@ const (
 // ObjectMutation is a field on the `mutation` operation of a graphql request. It includes
 // all the possible arguments.
 type ObjectMutation struct {
+	Filterable
+
+	// UpdateInput is a map of fields and values used for an update mutation.
+	UpdateInput map[string]any
+
 	Field
+
+	// Collection is the target collection name.
+	Collection string
+
+	DocIDsFilter
+
 	ChildSelect
 
-	Filterable
-	DocIDsFilter
+	// CreateInput is the array of maps of fields and values used for a create mutation.
+	CreateInput []map[string]any
+
+	// EncryptFields is a list of doc fields from input data that should be encrypted.
+	EncryptFields []string
 
 	// Type is the type of mutatation that this object represents.
 	//
 	// For example [CreateObjects].
 	Type MutationType
 
-	// Collection is the target collection name.
-	Collection string
-
-	// CreateInput is the array of maps of fields and values used for a create mutation.
-	CreateInput []map[string]any
-
-	// UpdateInput is a map of fields and values used for an update mutation.
-	UpdateInput map[string]any
-
 	// Encrypt is a boolean flag that indicates whether the input data should be encrypted.
 	Encrypt bool
-
-	// EncryptFields is a list of doc fields from input data that should be encrypted.
-	EncryptFields []string
 }
 
 // ToSelect returns a basic Select object, with the same Name, Alias, and Fields as

--- a/client/request/order.go
+++ b/client/request/order.go
@@ -16,6 +16,7 @@ type (
 	OrderDirection string
 
 	OrderCondition struct {
+		Direction OrderDirection
 		// field may be a compound field statement
 		// since the order statement allows ordering on
 		// sub objects.
@@ -23,8 +24,7 @@ type (
 		// Given the statement: {order: {author: {birthday: DESC}}}
 		// The field value would be "author.birthday"
 		// and the direction would be "DESC"
-		Fields    []string
-		Direction OrderDirection
+		Fields []string
 	}
 
 	OrderBy struct {

--- a/client/request/request.go
+++ b/client/request/request.go
@@ -32,6 +32,6 @@ type Directives struct {
 }
 
 type OperationDefinition struct {
-	Selections []Selection
 	Directives Directives
+	Selections []Selection
 }

--- a/client/request/select.go
+++ b/client/request/select.go
@@ -18,16 +18,17 @@ import (
 // It is used for sub-types in a request.
 // Includes fields, and request arguments like filters, limits, etc.
 type Select struct {
+	Filterable
 	Field
+	CIDFilter
+	Orderable
+	DocIDsFilter
+	Groupable
+
 	ChildSelect
 
 	Limitable
 	Offsetable
-	Orderable
-	Filterable
-	DocIDsFilter
-	CIDFilter
-	Groupable
 
 	// ShowDeleted will return deleted documents along with non-deleted ones
 	// if set to true.
@@ -113,14 +114,14 @@ func (s *Select) validateGroupBy() []error {
 // It contains everything minus the [ChildSelect], which uses a custom UnmarshalJSON
 // and is skipped over when embedding due to the way the std lib json pkg works.
 type selectJson struct {
+	Filterable
 	Field
+	CIDFilter
+	Orderable
+	DocIDsFilter
+	Groupable
 	Limitable
 	Offsetable
-	Orderable
-	Filterable
-	DocIDsFilter
-	CIDFilter
-	Groupable
 	ShowDeleted bool
 }
 

--- a/client/request/subscription.go
+++ b/client/request/subscription.go
@@ -18,13 +18,13 @@ import (
 // of a graphql request. It includes all the possible
 // arguments
 type ObjectSubscription struct {
-	Field
-	ChildSelect
-
 	Filterable
+
+	Field
 
 	// Collection is the target collection name
 	Collection string
+	ChildSelect
 }
 
 // ToSelect returns a basic Select object, with the same Name, Alias, and Fields as

--- a/client/schema_field_description.go
+++ b/client/schema_field_description.go
@@ -36,15 +36,16 @@ type FieldKind interface {
 
 // SchemaFieldDescription describes a field on a Schema and its associated metadata.
 type SchemaFieldDescription struct {
-	// Name contains the name of this field.
-	//
-	// It is currently immutable.
-	Name string
 
 	// The data type that this field holds.
 	//
 	// Must contain a valid value. It is currently immutable.
 	Kind FieldKind
+
+	// Name contains the name of this field.
+	//
+	// It is currently immutable.
+	Name string
 
 	// The CRDT Type of this field. If no type has been provided it will default to [LWW_REGISTER].
 	//
@@ -69,11 +70,11 @@ type CollectionKind struct {
 
 // SchemaKind represents a relationship with a [SchemaDescription].
 type SchemaKind struct {
-	// If true, this side of the relationship points to many related records.
-	Array bool
 
 	// The root ID of the related [SchemaDescription].
 	Root string
+	// If true, this side of the relationship points to many related records.
+	Array bool
 }
 
 // NamedKind represents a temporary declaration of a relationship to another
@@ -400,10 +401,10 @@ func (f SchemaFieldDescription) IsRelation() bool {
 // of json to a [SchemaFieldDescription].
 type schemaFieldDescription struct {
 	Name string
-	Typ  CType
 
 	// Properties below this line are unmarshalled using custom logic in [UnmarshalJSON]
 	Kind json.RawMessage
+	Typ  CType
 }
 
 func (f *SchemaFieldDescription) UnmarshalJSON(bytes []byte) error {
@@ -426,9 +427,9 @@ func (f *SchemaFieldDescription) UnmarshalJSON(bytes []byte) error {
 // objectKind is a private type used to facilitate the unmarshalling
 // of json to a [FieldKind].
 type objectKind struct {
-	Array      bool
 	Root       any
 	RelativeID string
+	Array      bool
 }
 
 func parseFieldKind(bytes json.RawMessage) (FieldKind, error) {

--- a/client/value.go
+++ b/client/value.go
@@ -15,8 +15,8 @@ import (
 )
 
 type FieldValue struct {
-	t       CType
 	value   NormalValue
+	t       CType
 	isDirty bool
 }
 

--- a/datastore/badger/v4/datastore.go
+++ b/datastore/badger/v4/datastore.go
@@ -27,14 +27,15 @@ var log = logger.Logger("badger")
 type Datastore struct {
 	DB *badger.DB
 
-	closeLk   sync.RWMutex
-	closed    bool
-	closeOnce sync.Once
-	closing   chan struct{}
+	closing chan struct{}
 
 	gcDiscardRatio float64
 	gcSleep        time.Duration
 	gcInterval     time.Duration
+
+	closeLk   sync.RWMutex
+	closeOnce sync.Once
+	closed    bool
 
 	syncWrites bool
 }
@@ -59,6 +60,7 @@ type txn struct {
 
 // Options are the badger datastore options, reexported here for convenience.
 type Options struct {
+	badger.Options
 	// Please refer to the Badger docs to see what this is for
 	GcDiscardRatio float64
 
@@ -72,8 +74,6 @@ type Options struct {
 	// If zero, the datastore will only perform one round of GC per
 	// GcInterval.
 	GcSleep time.Duration
-
-	badger.Options
 }
 
 // DefaultOptions are the default options for the badger datastore.

--- a/datastore/badger/v4/iterator.go
+++ b/datastore/badger/v4/iterator.go
@@ -28,12 +28,12 @@ import (
 type BadgerIterator struct {
 	iterator       *badger.Iterator
 	resultsBuilder *dsq.ResultBuilder
-	query          dsq.Query
 	txn            txn
+	query          dsq.Query
 	skipped        int
 	sent           int
-	closedEarly    bool
 	iteratorLock   sync.RWMutex
+	closedEarly    bool
 	reversedOrder  bool
 }
 

--- a/datastore/iterable/iterable_transaction_shim.go
+++ b/datastore/iterable/iterable_transaction_shim.go
@@ -27,8 +27,8 @@ type iterableShim struct {
 
 type iteratorShim struct {
 	readable iterableShim
-	q        dsq.Query
 	results  dsq.Results
+	q        dsq.Query
 }
 
 func NewIterable(readable ds.Read) Iterable {

--- a/datastore/txn.go
+++ b/datastore/txn.go
@@ -56,8 +56,7 @@ type Txn interface {
 
 type txn struct {
 	MultiStore
-	t  ds.Txn
-	id uint64
+	t ds.Txn
 
 	successFns []func()
 	errorFns   []func()
@@ -66,6 +65,7 @@ type txn struct {
 	successAsyncFns []func()
 	errorAsyncFns   []func()
 	discardAsyncFns []func()
+	id              uint64
 }
 
 var _ Txn = (*txn)(nil)

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -27,8 +27,8 @@ const MaxStackDepth int = 50
 
 // KV is a key-value pair.
 type KV struct {
-	key   string
 	value any
+	key   string
 }
 
 // NewKV creates a new key-value pair.

--- a/event/bus.go
+++ b/event/bus.go
@@ -25,8 +25,6 @@ type closeCommand struct{}
 
 // Bus uses a buffered channel to manage subscribers and publish messages.
 type Bus struct {
-	// subID is incremented for each subscriber and used to set subscriber ids.
-	subID atomic.Uint64
 	// subs is a mapping of subscriber ids to subscriptions.
 	subs map[uint64]*Subscription
 	// events is a mapping of event names to subscriber ids.
@@ -38,12 +36,14 @@ type Bus struct {
 	//
 	// This does mean that non-event commands can block the database if the buffer
 	// size is breached (e.g. if many subscribe commands occupy the buffer).
-	commandChannel  chan any
+	commandChannel chan any
+	hasClosedChan  chan struct{}
+	// subID is incremented for each subscriber and used to set subscriber ids.
+	subID           atomic.Uint64
 	eventBufferSize int
-	hasClosedChan   chan struct{}
-	isClosed        bool
 	// closeMutex is only locked when the bus is closing.
 	closeMutex sync.RWMutex
+	isClosed   bool
 }
 
 // NewBus creates a new event bus with the given commandBufferSize and

--- a/http/client_lens.go
+++ b/http/client_lens.go
@@ -31,8 +31,8 @@ type LensRegistry struct {
 }
 
 type setMigrationRequest struct {
-	CollectionID uint32
 	Config       model.Lens
+	CollectionID uint32
 }
 
 func (w *LensRegistry) Init(txnSource client.TxnSource) {}
@@ -67,8 +67,8 @@ func (c *LensRegistry) ReloadLenses(ctx context.Context) error {
 }
 
 type migrateRequest struct {
-	CollectionID uint32
 	Data         []map[string]any
+	CollectionID uint32
 }
 
 func (c *LensRegistry) MigrateUp(

--- a/http/handler_store.go
+++ b/http/handler_store.go
@@ -273,9 +273,9 @@ func (s *storeHandler) PrintDump(rw http.ResponseWriter, req *http.Request) {
 }
 
 type GraphQLRequest struct {
+	Variables     map[string]any `json:"variables"`
 	Query         string         `json:"query"`
 	OperationName string         `json:"operationName"`
-	Variables     map[string]any `json:"variables"`
 }
 
 func (s *storeHandler) ExecRequest(rw http.ResponseWriter, req *http.Request) {

--- a/http/server.go
+++ b/http/server.go
@@ -39,12 +39,12 @@ var tlsCipherSuites = []uint16{
 type ServerOptions struct {
 	// Address is the bind address the server listens on.
 	Address string
-	// AllowedOrigins is the list of allowed origins for CORS.
-	AllowedOrigins []string
 	// TLSCertPath is the path to the TLS certificate.
 	TLSCertPath string
 	// TLSKeyPath is the path to the TLS key.
 	TLSKeyPath string
+	// AllowedOrigins is the list of allowed origins for CORS.
+	AllowedOrigins []string
 	// ReadTimeout is the read timeout for connections.
 	ReadTimeout time.Duration
 	// WriteTimeout is the write timeout for connections.

--- a/internal/connor/key.go
+++ b/internal/connor/key.go
@@ -4,12 +4,12 @@ package connor
 type KeyResult struct {
 	// Data is the data that should be used to filter the value matching the key.
 	Data any
-	// MissProp is true if the key is missing a property, otherwise false.
-	// It's relevant for object of dynamic type, like JSON.
-	MissProp bool
 	// Operator is the operator that should be used to filter the value matching the key.
 	// If the key does not have an operator the given defaultOp will be returned.
 	Operator string
+	// MissProp is true if the key is missing a property, otherwise false.
+	// It's relevant for object of dynamic type, like JSON.
+	MissProp bool
 }
 
 // FilterKey represents a type that may be used as a map key

--- a/internal/core/doc.go
+++ b/internal/core/doc.go
@@ -28,15 +28,16 @@ type DocFields []any
 
 // Doc is a document.
 type Doc struct {
+	// The id of the schema version that this document is currently at.  This includes
+	// any migrations that may have been run.
+	SchemaVersionID string
+
+	Fields DocFields
 	// If true, this Doc will not be rendered, but will still be passed through
 	// the plan graph just like any other document.
 	Hidden bool
 
-	Fields DocFields
 	Status client.DocumentStatus
-	// The id of the schema version that this document is currently at.  This includes
-	// any migrations that may have been run.
-	SchemaVersionID string
 }
 
 // GetID returns the DocID for this document.
@@ -80,23 +81,32 @@ func (d *Doc) Clone() Doc {
 
 // RenderKey is a key that should be rendered into the document.
 type RenderKey struct {
-	// The field index to be rendered.
-	Index int
 
 	// The key by which the field contents should be rendered into.
 	Key string
+	// The field index to be rendered.
+	Index int
 }
 
 type mappingTypeInfo struct {
-	// The index at which the type name is to be held
-	Index int
 
 	// The name of the host type
 	Name string
+	// The index at which the type name is to be held
+	Index int
 }
 
 // DocumentMapping is a mapping of a document.
 type DocumentMapping struct {
+
+	// The set of fields available using this mapping.
+	//
+	// If a field-name is not in this collection, it essentially doesn't exist.
+	// Collection should include fields that are not rendered to the consumer.
+	// Multiple fields may exist for any given name (for example if a property
+	// exists under different aliases/filters).
+	IndexesByName map[string][]int
+
 	// The type information for the object, if provided.
 	typeInfo immutable.Option[mappingTypeInfo]
 
@@ -107,24 +117,16 @@ type DocumentMapping struct {
 	// items should not be accessed this way.
 	RenderKeys []RenderKey
 
-	// The set of fields available using this mapping.
-	//
-	// If a field-name is not in this collection, it essentially doesn't exist.
-	// Collection should include fields that are not rendered to the consumer.
-	// Multiple fields may exist for any given name (for example if a property
-	// exists under different aliases/filters).
-	IndexesByName map[string][]int
-
-	// The next index available for use.
-	//
-	// Also useful for identifying how many fields a document should have.
-	nextIndex int
-
 	// The collection of child mappings for this object.
 	//
 	// Indexes correspond exactly to field indexes, however entries may be default
 	// if the field is unmappable (e.g. integer fields).
 	ChildMappings []*DocumentMapping
+
+	// The next index available for use.
+	//
+	// Also useful for identifying how many fields a document should have.
+	nextIndex int
 }
 
 // NewDocumentMapping instantiates a new DocumentMapping instance.

--- a/internal/db/collection.go
+++ b/internal/db/collection.go
@@ -43,9 +43,9 @@ var _ client.Collection = (*collection)(nil)
 // together under a collection name. This is analogous to SQL Tables.
 type collection struct {
 	db             *DB
-	def            client.CollectionDefinition
-	indexes        []CollectionIndex
 	fetcherFactory func() fetcher.Fetcher
+	indexes        []CollectionIndex
+	def            client.CollectionDefinition
 }
 
 // @todo: Move the base Descriptions to an internal API within the db/ package.

--- a/internal/db/config.go
+++ b/internal/db/config.go
@@ -24,9 +24,9 @@ const (
 )
 
 type dbOptions struct {
-	maxTxnRetries  immutable.Option[int]
-	RetryIntervals []time.Duration
 	identity       immutable.Option[identity.Identity]
+	RetryIntervals []time.Duration
+	maxTxnRetries  immutable.Option[int]
 }
 
 // defaultOptions returns the default db options.

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -57,44 +57,45 @@ const (
 
 // DB is the main struct for DefraDB's storage layer.
 type DB struct {
-	glock sync.RWMutex
+
+	// Contains ACP if it exists
+	acp immutable.Option[acp.ACP]
 
 	rootstore  datastore.Rootstore
 	multistore datastore.MultiStore
-
-	events *event.Bus
 
 	parser core.Parser
 
 	lensRegistry client.LensRegistry
 
-	// The maximum number of retries per transaction.
-	maxTxnRetries immutable.Option[int]
-
-	// The options used to init the database
-	options []Option
-
-	// The ID of the last transaction created.
-	previousTxnID atomic.Uint64
-
-	// The identity of the current node
-	nodeIdentity immutable.Option[identity.Identity]
-
-	// Contains ACP if it exists
-	acp immutable.Option[acp.ACP]
-
 	// The peer ID and network address information for the current node
 	// if network is enabled. The `atomic.Value` should hold a `peer.AddrInfo` struct.
 	peerInfo atomic.Value
+
+	events *event.Bus
 
 	// To be able to close the context passed to NewDB on DB close,
 	// we need to keep a reference to the cancel function. Otherwise,
 	// some goroutines might leak.
 	ctxCancel context.CancelFunc
 
+	// The identity of the current node
+	nodeIdentity immutable.Option[identity.Identity]
+
+	// The options used to init the database
+	options []Option
+
 	// The intervals at which to retry replicator failures.
 	// For example, this can define an exponential backoff strategy.
 	retryIntervals []time.Duration
+
+	// The maximum number of retries per transaction.
+	maxTxnRetries immutable.Option[int]
+
+	// The ID of the last transaction created.
+	previousTxnID atomic.Uint64
+
+	glock sync.RWMutex
 }
 
 var _ client.DB = (*DB)(nil)

--- a/internal/db/definition_validation.go
+++ b/internal/db/definition_validation.go
@@ -23,14 +23,14 @@ import (
 //
 // It is read only and will not and should not be mutated.
 type definitionState struct {
-	collections     []client.CollectionDescription
+	definitionCache client.DefinitionCache
 	collectionsByID map[uint32]client.CollectionDescription
 
 	schemaByID   map[string]client.SchemaDescription
 	schemaByName map[string]client.SchemaDescription
 
 	definitionsByName map[string]client.CollectionDefinition
-	definitionCache   client.DefinitionCache
+	collections       []client.CollectionDescription
 }
 
 // newDefinitionState creates a new definitionState object given the provided

--- a/internal/db/fetcher/dag.go
+++ b/internal/db/fetcher/dag.go
@@ -23,9 +23,8 @@ import (
 
 // HeadFetcher is a utility to incrementally fetch all the MerkleCRDT heads of a given doc/field.
 type HeadFetcher struct {
+	kvIter  dsq.Results
 	fieldId immutable.Option[string]
-
-	kvIter dsq.Results
 }
 
 // Start starts/initializes the fetcher, performing all the work it can do outside

--- a/internal/db/fetcher/document.go
+++ b/internal/db/fetcher/document.go
@@ -27,23 +27,24 @@ import (
 //
 // It does not filter the data in any way.
 type documentFetcher struct {
-	// The set of fields to fetch, mapped by field ID.
-	fieldsByID map[uint32]client.FieldDefinition
-	// The status to assign fetched documents.
-	status client.DocumentStatus
-	// Statistics on the actions of this instance.
-	execInfo *ExecInfo
 	// The iterable results that documents will be fetched from.
 	kvResultsIter dsq.Results
 
-	// The most recently yielded item from kvResultsIter.
-	currentKV keyValue
+	// The set of fields to fetch, mapped by field ID.
+	fieldsByID map[uint32]client.FieldDefinition
+	// Statistics on the actions of this instance.
+	execInfo *ExecInfo
 	// nextKV may hold a datastore key value retrieved from kvResultsIter
 	// that was not yet ready to be yielded from the instance.
 	//
 	// When the next document is requested, this value should be yielded
 	// before resuming iteration through the kvResultsIter.
 	nextKV immutable.Option[keyValue]
+
+	// The most recently yielded item from kvResultsIter.
+	currentKV keyValue
+	// The status to assign fetched documents.
+	status client.DocumentStatus
 }
 
 var _ fetcher = (*documentFetcher)(nil)

--- a/internal/db/fetcher/encoded_doc.go
+++ b/internal/db/fetcher/encoded_doc.go
@@ -41,8 +41,9 @@ type EPTuple []encProperty
 
 // EncProperty is an encoded property of a EncodedDocument
 type encProperty struct {
+	Raw []byte
+
 	Desc client.FieldDefinition
-	Raw  []byte
 
 	// Filter flag to determine if this flag
 	// is needed for eager filter evaluation
@@ -65,9 +66,6 @@ func (e encProperty) Decode() (any, error) {
 
 // @todo: Implement Encoded Document type
 type encodedDocument struct {
-	id                   []byte
-	schemaVersionID      string
-	status               client.DocumentStatus
 	properties           map[client.FieldDefinition]*encProperty
 	decodedPropertyCache map[client.FieldDefinition]any
 
@@ -76,8 +74,11 @@ type encodedDocument struct {
 	// 0 means we we ignore the field
 	// we update the bitsets as we collect values
 	// by clearing the bit for the FieldID
-	filterSet *bitset.BitSet // filter fields
-	selectSet *bitset.BitSet // select fields
+	filterSet       *bitset.BitSet // filter fields
+	selectSet       *bitset.BitSet // select fields
+	schemaVersionID string
+	id              []byte
+	status          client.DocumentStatus
 }
 
 var _ EncodedDocument = (*encodedDocument)(nil)

--- a/internal/db/fetcher/indexer.go
+++ b/internal/db/fetcher/indexer.go
@@ -31,14 +31,14 @@ type indexFetcher struct {
 	ctx           context.Context
 	txn           datastore.Txn
 	col           client.Collection
+	indexIter     indexIterator
 	indexFilter   *mapper.Filter
 	mapping       *core.DocumentMapping
-	indexedFields []client.FieldDefinition
 	fieldsByID    map[uint32]client.FieldDefinition
-	indexDesc     client.IndexDescription
-	indexIter     indexIterator
-	currentDocID  immutable.Option[string]
 	execInfo      *ExecInfo
+	currentDocID  immutable.Option[string]
+	indexedFields []client.FieldDefinition
+	indexDesc     client.IndexDescription
 }
 
 var _ fetcher = (*indexFetcher)(nil)

--- a/internal/db/fetcher/indexer_iterators.go
+++ b/internal/db/fetcher/indexer_iterators.go
@@ -65,21 +65,21 @@ type indexIterator interface {
 }
 
 type indexIterResult struct {
+	value    []byte
 	key      keys.IndexDataStoreKey
 	foundKey bool
-	value    []byte
 }
 
 // indexPrefixIterator is an iterator over index keys with a specific prefix.
 type indexPrefixIterator struct {
-	indexDesc     client.IndexDescription
-	indexedFields []client.FieldDefinition
-	indexKey      keys.IndexDataStoreKey
-	matchers      []valueMatcher
-	execInfo      *ExecInfo
 	resultIter    query.Results
 	ctx           context.Context
 	store         datastore.DSReaderWriter
+	execInfo      *ExecInfo
+	indexKey      keys.IndexDataStoreKey
+	indexedFields []client.FieldDefinition
+	matchers      []valueMatcher
+	indexDesc     client.IndexDescription
 }
 
 var _ indexIterator = (*indexPrefixIterator)(nil)
@@ -154,11 +154,11 @@ func (iter *indexPrefixIterator) Close() error {
 }
 
 type eqSingleIndexIterator struct {
-	indexKey keys.IndexDataStoreKey
+	ctx      context.Context
+	store    datastore.DSReaderWriter
 	execInfo *ExecInfo
 
-	ctx   context.Context
-	store datastore.DSReaderWriter
+	indexKey keys.IndexDataStoreKey
 }
 
 var _ indexIterator = (*eqSingleIndexIterator)(nil)
@@ -191,10 +191,10 @@ func (iter *eqSingleIndexIterator) Close() error {
 
 type inIndexIterator struct {
 	indexIterator
-	inValues     []client.NormalValue
-	nextValIndex int
 	ctx          context.Context
 	store        datastore.DSReaderWriter
+	inValues     []client.NormalValue
+	nextValIndex int
 	hasIterator  bool
 }
 
@@ -475,11 +475,11 @@ func doConditionsHaveArrayOrJSON(conditions []fieldFilterCond) bool {
 }
 
 type fieldFilterCond struct {
+	val      client.NormalValue
+	kind     client.FieldKind
 	op       string
 	arrOp    string
 	jsonPath client.JSONPath
-	val      client.NormalValue
-	kind     client.FieldKind
 }
 
 // determineFieldFilterConditions determines the conditions and their corresponding operation

--- a/internal/db/fetcher/indexer_matchers.go
+++ b/internal/db/fetcher/indexer_matchers.go
@@ -38,8 +38,8 @@ type valueMatcher interface {
 }
 
 type intMatcher struct {
-	value    int64
 	evalFunc func(int64, int64) bool
+	value    int64
 }
 
 func (m *intMatcher) Match(value client.NormalValue) (bool, error) {
@@ -56,8 +56,8 @@ func (m *intMatcher) Match(value client.NormalValue) (bool, error) {
 }
 
 type float32Matcher struct {
-	value    float32
 	evalFunc func(float32, float32) bool
+	value    float32
 }
 
 func (m *float32Matcher) Match(value client.NormalValue) (bool, error) {
@@ -74,8 +74,8 @@ func (m *float32Matcher) Match(value client.NormalValue) (bool, error) {
 }
 
 type float64Matcher struct {
-	value    float64
 	evalFunc func(float64, float64) bool
+	value    float64
 }
 
 func (m *float64Matcher) Match(value client.NormalValue) (bool, error) {
@@ -92,8 +92,8 @@ func (m *float64Matcher) Match(value client.NormalValue) (bool, error) {
 }
 
 type stringMatcher struct {
-	value    string
 	evalFunc func(string, string) bool
+	value    string
 }
 
 func (m *stringMatcher) Match(value client.NormalValue) (bool, error) {
@@ -110,8 +110,8 @@ func (m *stringMatcher) Match(value client.NormalValue) (bool, error) {
 }
 
 type timeMatcher struct {
-	op    string
 	value time.Time
+	op    string
 }
 
 func (m *timeMatcher) Match(value client.NormalValue) (bool, error) {
@@ -204,12 +204,12 @@ func (m *indexInArrayMatcher) Match(value client.NormalValue) (bool, error) {
 
 // checks if the index value satisfies the LIKE condition
 type indexLikeMatcher struct {
+	value             string
+	startAndEnd       []string
 	hasPrefix         bool
 	hasSuffix         bool
-	startAndEnd       []string
 	isLike            bool
 	isCaseInsensitive bool
-	value             string
 }
 
 func newLikeIndexCmp(filterValue string, isLike bool, isCaseInsensitive bool) (*indexLikeMatcher, error) {

--- a/internal/db/fetcher/permissioned.go
+++ b/internal/db/fetcher/permissioned.go
@@ -25,11 +25,12 @@ import (
 type permissionedFetcher struct {
 	ctx context.Context
 
-	identity immutable.Option[acpIdentity.Identity]
-	acp      acp.ACP
-	col      client.Collection
+	acp acp.ACP
+	col client.Collection
 
 	fetcher fetcher
+
+	identity immutable.Option[acpIdentity.Identity]
 }
 
 var _ fetcher = (*permissionedFetcher)(nil)

--- a/internal/db/fetcher/prefix.go
+++ b/internal/db/fetcher/prefix.go
@@ -28,22 +28,23 @@ import (
 //
 // It manages the document fetcher instances that will do the actual scanning.
 type prefixFetcher struct {
-	// The prefixes that this prefix fetcher must fetch from.
-	prefixes []keys.DataStoreKey
 	// The Iterator this prefix fetcher will use to scan.
 	kvIter iterable.Iterator
 
-	// The index of the current prefix being fetched.
-	currentPrefix int
+	// The below properties are only held here in order to pass them on to the next
+	// child fetcher instance.
+	ctx context.Context
 	// The child document fetcher, specific to the current prefix.
 	fetcher *documentFetcher
 
-	// The below properties are only held here in order to pass them on to the next
-	// child fetcher instance.
-	ctx        context.Context
 	fieldsByID map[uint32]client.FieldDefinition
-	status     client.DocumentStatus
 	execInfo   *ExecInfo
+	// The prefixes that this prefix fetcher must fetch from.
+	prefixes []keys.DataStoreKey
+
+	// The index of the current prefix being fetched.
+	currentPrefix int
+	status        client.DocumentStatus
 }
 
 var _ fetcher = (*prefixFetcher)(nil)

--- a/internal/db/fetcher/wrapper.go
+++ b/internal/db/fetcher/wrapper.go
@@ -28,19 +28,20 @@ import (
 // wrappingFetcher is a fetcher type that bridges between the existing [Fetcher] interface
 // and the newer [fetcher] interface.
 type wrappingFetcher struct {
-	fetcher  fetcher
-	execInfo ExecInfo
+	acp       immutable.Option[acp.ACP]
+	fetcher   fetcher
+	txn       datastore.Txn
+	col       client.Collection
+	filter    *mapper.Filter
+	docMapper *core.DocumentMapping
 
 	// The below properties are only held in state in order to temporarily adhere to the [Fetcher]
 	// interface.  They can be remove from state once the [Fetcher] interface is cleaned up.
-	identity    immutable.Option[acpIdentity.Identity]
-	txn         datastore.Txn
-	acp         immutable.Option[acp.ACP]
-	index       immutable.Option[client.IndexDescription]
-	col         client.Collection
-	fields      []client.FieldDefinition
-	filter      *mapper.Filter
-	docMapper   *core.DocumentMapping
+	identity immutable.Option[acpIdentity.Identity]
+	fields   []client.FieldDefinition
+	index    immutable.Option[client.IndexDescription]
+	execInfo ExecInfo
+
 	showDeleted bool
 }
 

--- a/internal/db/index.go
+++ b/internal/db/index.go
@@ -158,11 +158,11 @@ func getFieldGenerator(kind client.FieldKind) FieldIndexGenerator {
 
 type collectionBaseIndex struct {
 	collection client.Collection
-	desc       client.IndexDescription
 	// fieldsDescs is a slice of field descriptions for the fields that form the index
 	// If there is more than 1 field, the index is composite
 	fieldsDescs     []client.SchemaFieldDescription
 	fieldGenerators []FieldIndexGenerator
+	desc            client.IndexDescription
 }
 
 // getDocFieldValues retrieves the values of the indexed fields from the given document.

--- a/internal/encryption/config.go
+++ b/internal/encryption/config.go
@@ -12,8 +12,8 @@ package encryption
 
 // DocEncConfig is the configuration for document encryption.
 type DocEncConfig struct {
-	// IsDocEncrypted is a flag to indicate if the document should be encrypted.
-	IsDocEncrypted bool
 	//  EncryptedFields is a list of fields individual that should be encrypted.
 	EncryptedFields []string
+	// IsDocEncrypted is a flag to indicate if the document should be encrypted.
+	IsDocEncrypted bool
 }

--- a/internal/encryption/encryptor.go
+++ b/internal/encryption/encryptor.go
@@ -50,9 +50,9 @@ func generateTestEncryptionKey(docID string, fieldName immutable.Option[string])
 // receives an UpdateEvent on a document (or any other event) a new DocEncryptor is created and stored
 // in the context, so that the same DocEncryptor can be used by other object down the call chain.
 type DocEncryptor struct {
-	conf          immutable.Option[DocEncConfig]
 	ctx           context.Context
 	generatedKeys map[genK][]byte
+	conf          immutable.Option[DocEncConfig]
 }
 
 type genK struct {

--- a/internal/encryption/event.go
+++ b/internal/encryption/event.go
@@ -23,10 +23,9 @@ const RequestKeysEventName = event.Name("enc-keys-request")
 //
 // It must only contain public elements not protected by ACP.
 type RequestKeysEvent struct {
+	Resp chan<- Result
 	// Keys is a list of the keys that are being requested.
 	Keys []cidlink.Link
-
-	Resp chan<- Result
 }
 
 // RequestedKeyEventData represents the data that was retrieved for a specific key.
@@ -42,8 +41,8 @@ type Item struct {
 }
 
 type Result struct {
-	Items []Item
 	Error error
+	Items []Item
 }
 
 type Results struct {

--- a/internal/keys/datastore_doc.go
+++ b/internal/keys/datastore_doc.go
@@ -35,10 +35,10 @@ const (
 
 // DataStoreKey is a type that represents a key in the database.
 type DataStoreKey struct {
-	CollectionRootID uint32
 	InstanceType     InstanceType
 	DocID            string
 	FieldID          string
+	CollectionRootID uint32
 }
 
 var _ Walkable = (*DataStoreKey)(nil)

--- a/internal/keys/datastore_index.go
+++ b/internal/keys/datastore_index.go
@@ -28,12 +28,12 @@ type IndexedField struct {
 
 // IndexDataStoreKey is key of an indexed document in the database.
 type IndexDataStoreKey struct {
+	// Fields is the values of the fields in the index
+	Fields []IndexedField
 	// CollectionID is the id of the collection
 	CollectionID uint32
 	// IndexID is the id of the index
 	IndexID uint32
-	// Fields is the values of the fields in the index
-	Fields []IndexedField
 }
 
 var _ Key = (*IndexDataStoreKey)(nil)

--- a/internal/keys/datastore_primary_doc.go
+++ b/internal/keys/datastore_primary_doc.go
@@ -21,8 +21,8 @@ const (
 )
 
 type PrimaryDataStoreKey struct {
-	CollectionRootID uint32
 	DocID            string
+	CollectionRootID uint32
 }
 
 var _ Key = (*PrimaryDataStoreKey)(nil)

--- a/internal/keys/headstore_collection.go
+++ b/internal/keys/headstore_collection.go
@@ -20,14 +20,14 @@ import (
 
 // HeadstoreColKey are used to store the current collection head in the headstore.
 type HeadstoreColKey struct {
+
+	// Cid is the cid of this head block.
+	Cid cid.Cid
 	// CollectionRoot is the root of the collection that this head refers to.
 	//
 	// Including it in the key allows easier identification of a given collection's
 	// head.
 	CollectionRoot uint32
-
-	// Cid is the cid of this head block.
-	Cid cid.Cid
 }
 
 var _ HeadstoreKey = (*HeadstoreColKey)(nil)

--- a/internal/keys/systemstore_collection_index.go
+++ b/internal/keys/systemstore_collection_index.go
@@ -21,10 +21,10 @@ import (
 
 // CollectionIndexKey to a stored description of an index
 type CollectionIndexKey struct {
-	// CollectionID is the id of the collection that the index is on
-	CollectionID immutable.Option[uint32]
 	// IndexName is the name of the index
 	IndexName string
+	// CollectionID is the id of the collection that the index is on
+	CollectionID immutable.Option[uint32]
 }
 
 var _ Key = (*CollectionIndexKey)(nil)

--- a/internal/lens/fetcher.go
+++ b/internal/lens/fetcher.go
@@ -331,10 +331,10 @@ func (f *lensedFetcher) updateDataStore(ctx context.Context, original map[string
 }
 
 type lensEncodedDocument struct {
-	key             []byte
-	schemaVersionID string
-	status          client.DocumentStatus
 	properties      map[client.FieldDefinition]any
+	schemaVersionID string
+	key             []byte
+	status          client.DocumentStatus
 }
 
 var _ fetcher.EncodedDocument = (*lensEncodedDocument)(nil)

--- a/internal/lens/lens.go
+++ b/internal/lens/lens.go
@@ -24,8 +24,8 @@ type schemaVersionID = string
 type LensDoc = map[string]any
 
 type lensInput struct {
-	SchemaVersionID schemaVersionID
 	Doc             LensDoc
+	SchemaVersionID schemaVersionID
 }
 
 // Lens migrate items fed in to the target schema version.

--- a/internal/merkle/crdt/field.go
+++ b/internal/merkle/crdt/field.go
@@ -19,12 +19,12 @@ import (
 // For example, to check if the field value needs to be encrypted depending on the document-level
 // encryption is enabled or not.
 type DocField struct {
+	// FieldValue is the field value.
+	FieldValue *client.FieldValue
 	// DocID is the ID of a document associated with the field value.
 	DocID string
 	// FieldName is the name of the field.
 	FieldName string
-	// FieldValue is the field value.
-	FieldValue *client.FieldValue
 }
 
 // NewDocField creates a new DocField instance.

--- a/internal/planner/arbitrary_join.go
+++ b/internal/planner/arbitrary_join.go
@@ -226,8 +226,8 @@ func generateKey(doc core.Doc, keyFields []mapper.Field) string {
 // A specialized collection that allows retrieval of items by key whilst preserving the order
 // in which they were added.
 type orderedMap struct {
-	values       []core.Doc
 	indexesByKey map[string]int
+	values       []core.Doc
 }
 
 func (m *orderedMap) mergeParent(key string, childIndexes []int, value core.Doc) {

--- a/internal/planner/average.go
+++ b/internal/planner/average.go
@@ -18,18 +18,18 @@ import (
 )
 
 type averageNode struct {
-	documentIterator
+	plan planNode
+
 	docMapper
 
-	plan planNode
+	aggregateFilter *mapper.Filter
+	documentIterator
 
 	sumFieldIndex     int
 	countFieldIndex   int
 	virtualFieldIndex int
 
 	execInfo averageExecInfo
-
-	aggregateFilter *mapper.Filter
 }
 
 type averageExecInfo struct {

--- a/internal/planner/commit.go
+++ b/internal/planner/commit.go
@@ -26,19 +26,22 @@ import (
 )
 
 type dagScanNode struct {
-	documentIterator
+	prefix immutable.Option[keys.HeadstoreKey]
 	docMapper
 
 	planner *Planner
 
-	depthVisited uint64
 	visitedNodes map[string]bool
+
+	commitSelect *mapper.CommitSelect
+
+	fetcher fetcher.HeadFetcher
 
 	queuedCids []*cid.Cid
 
-	fetcher      fetcher.HeadFetcher
-	prefix       immutable.Option[keys.HeadstoreKey]
-	commitSelect *mapper.CommitSelect
+	documentIterator
+
+	depthVisited uint64
 
 	execInfo dagScanExecInfo
 }

--- a/internal/planner/count.go
+++ b/internal/planner/count.go
@@ -27,15 +27,18 @@ import (
 )
 
 type countNode struct {
-	documentIterator
-	docMapper
-
-	p    *Planner
 	plan planNode
 
+	docMapper
+
+	p               *Planner
+	aggregateFilter *mapper.Filter
+
+	aggregateMapping []mapper.AggregateTarget
+
+	documentIterator
+
 	virtualFieldIndex int
-	aggregateMapping  []mapper.AggregateTarget
-	aggregateFilter   *mapper.Filter
 
 	execInfo countExecInfo
 }

--- a/internal/planner/create.go
+++ b/internal/planner/create.go
@@ -27,24 +27,26 @@ import (
 // document, until we've exhausted the payload. No filtering
 // or Select plans
 type createNode struct {
-	documentIterator
-	docMapper
-
-	p *Planner
 
 	// cache information about the original data source
 	// collection name, meta-data, etc.
 	collection client.Collection
 
+	results planNode
+
+	docMapper
+
+	p *Planner
+
 	// input map of fields and values
 	input []map[string]any
 	docs  []*client.Document
 
-	didCreate bool
-
-	results planNode
+	documentIterator
 
 	execInfo createExecInfo
+
+	didCreate bool
 }
 
 type createExecInfo struct {

--- a/internal/planner/delete.go
+++ b/internal/planner/delete.go
@@ -18,16 +18,17 @@ import (
 )
 
 type deleteNode struct {
-	documentIterator
+	collection client.Collection
+	source     planNode
+
 	docMapper
 
 	p *Planner
 
-	collection client.Collection
-	source     planNode
-
 	filter *mapper.Filter
 	docIDs []string
+
+	documentIterator
 
 	execInfo deleteExecInfo
 }

--- a/internal/planner/filter/extract_properties.go
+++ b/internal/planner/filter/extract_properties.go
@@ -19,8 +19,8 @@ import (
 // It contains the index of the field in the core.DocumentMapping
 // as well as index -> Property map of the fields in case the field is an object.
 type Property struct {
-	Index  int
 	Fields map[int]Property
+	Index  int
 }
 
 func (p Property) IsRelation() bool {

--- a/internal/planner/group.go
+++ b/internal/planner/group.go
@@ -20,7 +20,6 @@ import (
 
 // A node responsible for the grouping of documents by a given selection of fields.
 type groupNode struct {
-	documentIterator
 	docMapper
 
 	p *Planner
@@ -35,10 +34,11 @@ type groupNode struct {
 	// The data sources that this node will draw data from.
 	dataSources []*dataSource
 
-	values       []core.Doc
-	currentIndex int
+	values []core.Doc
+	documentIterator
 
-	execInfo groupExecInfo
+	execInfo     groupExecInfo
+	currentIndex int
 }
 
 type groupExecInfo struct {

--- a/internal/planner/lens.go
+++ b/internal/planner/lens.go
@@ -25,15 +25,16 @@ import (
 // and there is no guarentee that those documents will actually exist as documents
 // in Defra (they may be created by the transform).
 type lensNode struct {
-	docMapper
-	documentIterator
-
-	p          *Planner
-	source     planNode
-	collection client.CollectionDescription
+	source planNode
 
 	input  enumerable.Queue[map[string]any]
 	output enumerable.Enumerable[map[string]any]
+	docMapper
+
+	p *Planner
+	documentIterator
+
+	collection client.CollectionDescription
 }
 
 func (p *Planner) Lens(source planNode, docMap *core.DocumentMapping, col client.Collection) *lensNode {

--- a/internal/planner/mapper/aggregate.go
+++ b/internal/planner/mapper/aggregate.go
@@ -14,11 +14,12 @@ import "github.com/sourcenetwork/defradb/internal/core"
 
 // An optional child target.
 type OptionalChildTarget struct {
-	// The field index of this target.
-	Index int
 
 	// The name of the target, for example '_sum' or 'Age'.
 	Name string
+
+	// The field index of this target.
+	Index int
 
 	// If true this child target exists and has been requested.
 	//

--- a/internal/planner/mapper/commitSelect.go
+++ b/internal/planner/mapper/commitSelect.go
@@ -16,8 +16,6 @@ import "github.com/sourcenetwork/immutable"
 //
 // E.g. commits, or latestCommits.
 type CommitSelect struct {
-	// The underlying Select, defining the information requested.
-	Select
 
 	// The key of the target document for which to get commits for.
 	DocID immutable.Option[string]
@@ -25,14 +23,16 @@ type CommitSelect struct {
 	// The field for which commits have been requested.
 	FieldID immutable.Option[string]
 
-	// The maximum depth to yield results for.
-	Depth immutable.Option[uint64]
-
 	// The parent Cid for which commit information has been requested.
 	Cid immutable.Option[string]
 
 	// The SchemaVersionID at the time of commit.
 	SchemaVersionID immutable.Option[string]
+	// The underlying Select, defining the information requested.
+	Select
+
+	// The maximum depth to yield results for.
+	Depth immutable.Option[uint64]
 }
 
 func (s *CommitSelect) CloneTo(index int) Requestable {

--- a/internal/planner/mapper/field.go
+++ b/internal/planner/mapper/field.go
@@ -12,11 +12,11 @@ package mapper
 
 // Field contains the most basic information about a requestable.
 type Field struct {
-	// The location of this field within it's parent.
-	Index int
 
 	// The name of this field.  For example 'Age', or '_group'.
 	Name string
+	// The location of this field within it's parent.
+	Index int
 }
 
 func (f *Field) GetIndex() int {

--- a/internal/planner/mapper/mutation.go
+++ b/internal/planner/mapper/mutation.go
@@ -22,21 +22,21 @@ const (
 
 // Mutation represents a request to mutate data stored in Defra.
 type Mutation struct {
+
+	// UpdateInput is a map of fields and values used for an update mutation.
+	UpdateInput map[string]any
+
+	// CreateInput is the array of maps of fields and values used for a create mutation.
+	CreateInput []map[string]any
+
+	// EncryptFields is a list of fields from the input data that should be encrypted.
+	EncryptFields []string
 	// The underlying Select, defining the information requested upon return.
 	Select
 
 	// The type of mutation. For example a create request.
 	Type MutationType
 
-	// CreateInput is the array of maps of fields and values used for a create mutation.
-	CreateInput []map[string]any
-
-	// UpdateInput is a map of fields and values used for an update mutation.
-	UpdateInput map[string]any
-
 	// Encrypt is a flag to indicate if the input data should be encrypted.
 	Encrypt bool
-
-	// EncryptFields is a list of fields from the input data that should be encrypted.
-	EncryptFields []string
 }

--- a/internal/planner/mapper/select.go
+++ b/internal/planner/mapper/select.go
@@ -20,8 +20,6 @@ import (
 //
 // It wraps child Fields belonging to this Select.
 type Select struct {
-	// Targeting information used to restrict or format the result.
-	Targetable
 
 	// The document mapping for this select, describing how items yielded
 	// for this select can be accessed and rendered.
@@ -38,6 +36,9 @@ type Select struct {
 	// These can include stuff such as version information, aggregates, and other
 	// Selects.
 	Fields []Requestable
+
+	// Targeting information used to restrict or format the result.
+	Targetable
 
 	// SkipResolve is a flag that indicates that the fields in this Select don't need to be resolved,
 	// i.e. it's value doesn't need to be fetched and provided to the user.

--- a/internal/planner/mapper/similarity.go
+++ b/internal/planner/mapper/similarity.go
@@ -14,13 +14,14 @@ import "github.com/sourcenetwork/defradb/internal/core"
 
 // Similarity represents an cosine similarity operation definition.
 type Similarity struct {
-	Field
-	// The mapping of this aggregate's parent/host.
-	*core.DocumentMapping
-
-	// The targetted field for the cosine similarity
-	SimilarityTarget Targetable
 
 	// The vector to compare the target field to.
 	Vector any
+	// The mapping of this aggregate's parent/host.
+	*core.DocumentMapping
+
+	Field
+
+	// The targetted field for the cosine similarity
+	SimilarityTarget Targetable
 }

--- a/internal/planner/mapper/targetable.go
+++ b/internal/planner/mapper/targetable.go
@@ -211,13 +211,13 @@ const (
 // OrderCondition represents a single property by which request results should
 // be ordered, and the direction in which they should be ordered.
 type OrderCondition struct {
+
+	// The direction in which the sort should be applied.
+	Direction SortDirection
 	// A chain of field indexes by which the property to sort by may be found.
 	// This is relative to the host/defining object and may traverse through
 	// multiple object layers.
 	FieldIndexes []int
-
-	// The direction in which the sort should be applied.
-	Direction SortDirection
 }
 
 type OrderBy struct {
@@ -226,12 +226,6 @@ type OrderBy struct {
 
 // Targetable represents a targetable property.
 type Targetable struct {
-	// The basic field information of this property.
-	Field
-
-	// A optional collection of docIDs that can be specified to restrict results
-	// to belonging to this set.
-	DocIDs immutable.Option[[]string]
 
 	// An optional filter, that can be specified to restrict results to documents
 	// that satisfies all of its conditions.
@@ -248,6 +242,13 @@ type Targetable struct {
 	// An optional order clause, that can be specified to order results by property
 	// value
 	OrderBy *OrderBy
+
+	// The basic field information of this property.
+	Field
+
+	// A optional collection of docIDs that can be specified to restrict results
+	// to belonging to this set.
+	DocIDs immutable.Option[[]string]
 
 	ShowDeleted bool
 }

--- a/internal/planner/max.go
+++ b/internal/planner/max.go
@@ -22,18 +22,21 @@ import (
 )
 
 type maxNode struct {
-	documentIterator
+	plan planNode
 	docMapper
 
 	p      *Planner
-	plan   planNode
 	parent *mapper.Select
+
+	aggregateFilter *mapper.Filter
+
+	aggregateMapping []mapper.AggregateTarget
+
+	documentIterator
 
 	// virtualFieldIndex is the index of the field
 	// that contains the result of the aggregate.
 	virtualFieldIndex int
-	aggregateMapping  []mapper.AggregateTarget
-	aggregateFilter   *mapper.Filter
 
 	execInfo maxExecInfo
 }

--- a/internal/planner/min.go
+++ b/internal/planner/min.go
@@ -22,18 +22,21 @@ import (
 )
 
 type minNode struct {
-	documentIterator
+	plan planNode
 	docMapper
 
 	p      *Planner
-	plan   planNode
 	parent *mapper.Select
+
+	aggregateFilter *mapper.Filter
+
+	aggregateMapping []mapper.AggregateTarget
+
+	documentIterator
 
 	// virtualFieldIndex is the index of the field
 	// that contains the result of the aggregate.
 	virtualFieldIndex int
-	aggregateMapping  []mapper.AggregateTarget
-	aggregateFilter   *mapper.Filter
 
 	execInfo minExecInfo
 }

--- a/internal/planner/multi.go
+++ b/internal/planner/multi.go
@@ -55,15 +55,15 @@ type MultiNode interface {
 // However, they are entirely independent graphs, so they can
 // be executed in parallel.
 type parallelNode struct { // serialNode?
-	documentIterator
 	docMapper
 
 	p *Planner
 
+	multiscan *multiScanNode
+
 	children     []planNode
 	childIndexes []int
-
-	multiscan *multiScanNode
+	documentIterator
 }
 
 func (p *parallelNode) applyToPlans(fn func(n planNode) error) error {

--- a/internal/planner/operation.go
+++ b/internal/planner/operation.go
@@ -22,11 +22,11 @@ const operationNodeKind string = "operationNode"
 // operationNode is the top level node for operations with
 // one or more child selections, such as queries or mutations.
 type operationNode struct {
-	documentIterator
 	docMapper
 
 	children map[int]planNode
-	isDone   bool
+	documentIterator
+	isDone bool
 }
 
 func (n *operationNode) Prefixes(prefixes []keys.Walkable) {

--- a/internal/planner/order.go
+++ b/internal/planner/order.go
@@ -41,12 +41,7 @@ type orderingStrategy interface {
 
 // order the results
 type orderNode struct {
-	docMapper
-
-	p    *Planner
 	plan planNode
-
-	ordering []mapper.OrderCondition
 
 	// simplified planNode interface
 	// used for iterating through
@@ -58,11 +53,17 @@ type orderNode struct {
 	// sorted
 	orderStrategy orderingStrategy
 
+	docMapper
+
+	p *Planner
+
+	ordering []mapper.OrderCondition
+
+	execInfo orderExecInfo
+
 	// indicates if our underlying orderStrategy is still
 	// consuming and sorting data.
 	needSort bool
-
-	execInfo orderExecInfo
 }
 
 type orderExecInfo struct {

--- a/internal/planner/pipe.go
+++ b/internal/planner/pipe.go
@@ -20,12 +20,13 @@ import (
 // The node will start empty, and then load items as they are requested.  Items that are
 // requested more than once will not be re-loaded from source.
 type pipeNode struct {
-	documentIterator
-	docMapper
-
 	source planNode
 
+	docMapper
+
 	docs *container.DocumentContainer
+
+	documentIterator
 
 	// The index of the current value - will be -1 if nothinghas been read yet
 	docIndex int

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -87,12 +87,12 @@ type PlanContext struct {
 // Planner combines session state and database state to
 // produce a request plan, which is run by the execution context.
 type Planner struct {
-	txn      datastore.Txn
-	identity immutable.Option[acpIdentity.Identity]
-	acp      immutable.Option[acp.ACP]
-	db       client.Store
+	acp immutable.Option[acp.ACP]
+	txn datastore.Txn
+	db  client.Store
 
-	ctx context.Context
+	ctx      context.Context
+	identity immutable.Option[acpIdentity.Identity]
 }
 
 func New(

--- a/internal/planner/scan.go
+++ b/internal/planner/scan.go
@@ -35,25 +35,28 @@ type scanExecInfo struct {
 
 // scans an index for records
 type scanNode struct {
-	documentIterator
-	docMapper
-
-	p   *Planner
 	col client.Collection
 
-	fields []client.FieldDefinition
+	fetcher fetcher.Fetcher
 
-	showDeleted bool
+	docMapper
 
-	prefixes []keys.Walkable
+	p *Planner
 
 	filter *mapper.Filter
 	slct   *mapper.Select
 
-	index   immutable.Option[client.IndexDescription]
-	fetcher fetcher.Fetcher
+	documentIterator
+
+	fields []client.FieldDefinition
+
+	prefixes []keys.Walkable
+
+	index immutable.Option[client.IndexDescription]
 
 	execInfo scanExecInfo
+
+	showDeleted bool
 }
 
 func (n *scanNode) Kind() string {
@@ -319,6 +322,7 @@ func (p *Planner) Scan(
 // doesn't not provide idempotency guarantees. Counting is purely for performance
 // reasons and removing it should be safe.
 type multiScanNode struct {
+	err        error
 	scanNode   *scanNode
 	numReaders int
 	nextCount  int
@@ -327,7 +331,6 @@ type multiScanNode struct {
 	closeCount int
 
 	nextResult bool
-	err        error
 }
 
 // Init initializes the multiScanNode.

--- a/internal/planner/similarity.go
+++ b/internal/planner/similarity.go
@@ -17,17 +17,18 @@ import (
 )
 
 type similarityNode struct {
-	documentIterator
-	docMapper
-
-	p    *Planner
 	plan planNode
 
+	vector any
+	docMapper
+
+	p         *Planner
+	simFilter *mapper.Filter
+	target    mapper.Targetable
+	documentIterator
+
 	virtualFieldIndex int
-	target            mapper.Targetable
-	vector            any
 	execInfo          similarityExecInfo
-	simFilter         *mapper.Filter
 }
 
 type similarityExecInfo struct {

--- a/internal/planner/sum.go
+++ b/internal/planner/sum.go
@@ -21,18 +21,21 @@ import (
 )
 
 type sumNode struct {
-	documentIterator
-	docMapper
-
-	p    *Planner
 	plan planNode
 
-	isFloat           bool
+	docMapper
+
+	p               *Planner
+	aggregateFilter *mapper.Filter
+
+	aggregateMapping []mapper.AggregateTarget
+
+	documentIterator
 	virtualFieldIndex int
-	aggregateMapping  []mapper.AggregateTarget
-	aggregateFilter   *mapper.Filter
 
 	execInfo sumExecInfo
+
+	isFloat bool
 }
 
 type sumExecInfo struct {

--- a/internal/planner/top.go
+++ b/internal/planner/top.go
@@ -23,12 +23,12 @@ const topLevelNodeKind string = "topLevelNode"
 // plan graph. It has no source, and will only yield a single item
 // containing all of its children.
 type topLevelNode struct {
-	documentIterator
 	docMapper
 
 	children     []planNode
 	childIndexes []int
-	isdone       bool
+	documentIterator
+	isdone bool
 
 	// This node's children may use this node as a source
 	// this property controls the recursive flow preventing

--- a/internal/planner/update.go
+++ b/internal/planner/update.go
@@ -18,25 +18,26 @@ import (
 )
 
 type updateNode struct {
-	documentIterator
+	collection client.Collection
+
+	results planNode
+
 	docMapper
 
 	p *Planner
 
-	collection client.Collection
-
 	filter *mapper.Filter
-
-	docIDs []string
 
 	// input map of fields and values
 	input map[string]any
 
-	isUpdating bool
+	docIDs []string
 
-	results planNode
+	documentIterator
 
 	execInfo updateExecInfo
+
+	isUpdating bool
 }
 
 type updateExecInfo struct {

--- a/internal/planner/upsert.go
+++ b/internal/planner/upsert.go
@@ -18,16 +18,16 @@ import (
 )
 
 type upsertNode struct {
-	documentIterator
+	collection client.Collection
+	source     planNode
 	docMapper
 
-	p             *Planner
-	collection    client.Collection
-	filter        *mapper.Filter
-	createInput   map[string]any
-	updateInput   map[string]any
+	p           *Planner
+	filter      *mapper.Filter
+	createInput map[string]any
+	updateInput map[string]any
+	documentIterator
 	isInitialized bool
-	source        planNode
 }
 
 // Next only returns once.

--- a/internal/planner/values.go
+++ b/internal/planner/values.go
@@ -32,9 +32,10 @@ type valuesNode struct {
 	p *Planner
 	// plan planNode
 
+	docs *container.DocumentContainer
+
 	ordering []mapper.OrderCondition
 
-	docs     *container.DocumentContainer
 	docIndex int
 }
 

--- a/internal/planner/view.go
+++ b/internal/planner/view.go
@@ -21,11 +21,12 @@ import (
 
 // viewNode processes queries to a Defra View constructed from a base query ahead of time.
 type viewNode struct {
+	source planNode
+
 	docMapper
 
-	p      *Planner
-	desc   client.CollectionDescription
-	source planNode
+	p    *Planner
+	desc client.CollectionDescription
 
 	// This is cached as a boolean to save rediscovering this in the main Next/Value iteration loop
 	hasTransform bool
@@ -169,13 +170,13 @@ func convertBetweenMaps(srcMap *core.DocumentMapping, dstMap *core.DocumentMappi
 
 // cachedViewFetcher is a planner node that fetches view items from a materialized cache.
 type cachedViewFetcher struct {
+	queryResults query.Results
 	docMapper
+	p *Planner
+
 	documentIterator
 
 	def client.CollectionDefinition
-	p   *Planner
-
-	queryResults query.Results
 }
 
 var _ planNode = (*cachedViewFetcher)(nil)

--- a/internal/request/graphql/schema/generate.go
+++ b/internal/request/graphql/schema/generate.go
@@ -41,10 +41,10 @@ const (
 // Generator creates all the necessary typed schema definitions from an AST Document
 // and adds them to the Schema via the SchemaManager
 type Generator struct {
-	typeDefs []*gql.Object
-	manager  *SchemaManager
+	manager *SchemaManager
 
 	expandedFields map[string]bool
+	typeDefs       []*gql.Object
 }
 
 // NewGenerator creates a new instance of the Generator

--- a/internal/request/graphql/schema/manager.go
+++ b/internal/request/graphql/schema/manager.go
@@ -22,8 +22,8 @@ import (
 // SchemaManager creates an instanced management point
 // for schema intake/outtake, and updates.
 type SchemaManager struct {
-	schema    gql.Schema
 	Generator *Generator
+	schema    gql.Schema
 }
 
 // NewSchemaManager returns a new instance of a SchemaManager

--- a/net/config.go
+++ b/net/config.go
@@ -20,11 +20,11 @@ import (
 type Options struct {
 	ListenAddresses   []string
 	PrivateKey        []byte
-	EnablePubSub      bool
-	EnableRelay       bool
 	GRPCServerOptions []grpc.ServerOption
 	GRPCDialOptions   []grpc.DialOption
 	BootstrapPeers    []string
+	EnablePubSub      bool
+	EnableRelay       bool
 }
 
 // DefaultOptions returns the default net options.

--- a/net/server.go
+++ b/net/server.go
@@ -44,17 +44,18 @@ import (
 // but not the API calls.
 type server struct {
 	peer *Peer
-	opts []grpc.DialOption
 
 	topics map[string]pubsubTopic
 	// replicators is a map from collectionName => peerId
 	replicators map[string]map[libpeer.ID]struct{}
-	mu          sync.Mutex
 
 	conns map[libpeer.ID]*grpc.ClientConn
 
 	peerIdentities map[libpeer.ID]identity.Identity
-	piMux          sync.RWMutex
+	opts           []grpc.DialOption
+
+	piMux sync.RWMutex
+	mu    sync.Mutex
 }
 
 // pubsubTopic is a wrapper of rpc.Topic to be able to track if the topic has

--- a/node/node.go
+++ b/node/node.go
@@ -42,10 +42,10 @@ type Option any
 
 // Options contains start configuration values.
 type Options struct {
+	kmsType           immutable.Option[kms.ServiceType]
 	disableP2P        bool
 	disableAPI        bool
 	enableDevelopment bool
-	kmsType           immutable.Option[kms.ServiceType]
 }
 
 // DefaultOptions returns options with default settings.

--- a/node/store.go
+++ b/node/store.go
@@ -41,8 +41,8 @@ var storePurgeFuncs = map[StoreType]func(ctx context.Context, options *StoreOpti
 type StoreOptions struct {
 	store               StoreType
 	path                string
-	badgerFileSize      int64
 	badgerEncryptionKey []byte
+	badgerFileSize      int64
 	badgerInMemory      bool
 }
 

--- a/tests/bench/fixtures/fixtures.go
+++ b/tests/bench/fixtures/fixtures.go
@@ -46,10 +46,11 @@ func OptionFieldDirective(typeName, field, directive string) Option {
 type Generator struct {
 	ctx context.Context
 
-	schema string
-	types  []any
 	// map of type name to field name to list of directives
 	directives map[string]map[string][]string
+
+	schema string
+	types  []any
 }
 
 func ForSchema(ctx context.Context, schemaName string, options ...Option) Generator {

--- a/tests/gen/gen_auto.go
+++ b/tests/gen/gen_auto.go
@@ -72,10 +72,10 @@ func newRandomDocGenerator(types map[string]client.CollectionDefinition, config 
 }
 
 type genDoc struct {
+	doc *client.Document
 	// the docID of the document. Its cached value from doc.ID().String() just to avoid
 	// calculating it multiple times.
 	docID string
-	doc   *client.Document
 }
 
 type randomDocGenerator struct {

--- a/tests/gen/gen_auto_config.go
+++ b/tests/gen/gen_auto_config.go
@@ -18,9 +18,9 @@ import (
 
 // genConfig is a configuration for a generation of a field.
 type genConfig struct {
-	labels         []string
 	props          map[string]any
 	fieldGenerator GenerateFieldFunc
+	labels         []string
 }
 
 // configsMap is a map of type name to a map of field name to a generation configuration.

--- a/tests/gen/gen_auto_configurator.go
+++ b/tests/gen/gen_auto_configurator.go
@@ -37,15 +37,16 @@ func (d typeDemand) getAverage() int {
 // demand for each type, setting up the relation usage counters, and setting up
 // the random seed.
 type docsGenConfigurator struct {
-	types           map[string]client.CollectionDefinition
+	usageCounter typeUsageCounters
+	types        map[string]client.CollectionDefinition
+
+	config          configsMap
+	primaryGraph    map[string][]string
+	docsDemand      map[string]typeDemand
+	random          *rand.Rand
 	definitionCache client.DefinitionCache
 
-	config       configsMap
-	primaryGraph map[string][]string
-	typesOrder   []string
-	docsDemand   map[string]typeDemand
-	usageCounter typeUsageCounters
-	random       *rand.Rand
+	typesOrder []string
 }
 
 type collectionID = uint32
@@ -107,12 +108,7 @@ func (c *typeUsageCounters) getNextTypeIndForField(secondaryType string, field *
 }
 
 type relationUsage struct {
-	// counter is the number of primary documents that have been used for the relation.
-	counter int
-	// minSecDocsPerPrimary is the minimum number of primary documents that should be used for the relation.
-	minSecDocsPerPrimary int
-	// maxSecDocsPerPrimary is the maximum number of primary documents that should be used for the relation.
-	maxSecDocsPerPrimary int
+	random *rand.Rand
 	// docIDsCounter is a slice of structs that keep track of the number of times
 	// each primary document has been used for the relation.
 	docIDsCounter []struct {
@@ -121,10 +117,15 @@ type relationUsage struct {
 		// count is the number of times the primary document has been used for the relation.
 		count int
 	}
+	// counter is the number of primary documents that have been used for the relation.
+	counter int
+	// minSecDocsPerPrimary is the minimum number of primary documents that should be used for the relation.
+	minSecDocsPerPrimary int
+	// maxSecDocsPerPrimary is the maximum number of primary documents that should be used for the relation.
+	maxSecDocsPerPrimary int
 	// numAvailablePrimaryDocs is the number of documents of the primary type that are available
 	// for the relation.
 	numAvailablePrimaryDocs int
-	random                  *rand.Rand
 }
 
 func newRelationUsage(minSecDocPerPrim, maxSecDocPerPrim, numDocs int, random *rand.Rand) *relationUsage {

--- a/tests/integration/acp.go
+++ b/tests/integration/acp.go
@@ -78,17 +78,12 @@ func init() {
 
 // AddPolicy will attempt to add the given policy using DefraDB's ACP system.
 type AddPolicy struct {
-	// NodeID may hold the ID (index) of the node we want to add policy to.
-	//
-	// If a value is not provided the policy will be added in all nodes, unless testing with
-	// sourcehub ACP, in which case the policy will only be defined once.
-	NodeID immutable.Option[int]
-
-	// The raw policy string.
-	Policy string
 
 	// The policy creator identity, i.e. actor creating the policy.
 	Identity immutable.Option[identity]
+
+	// The raw policy string.
+	Policy string
 
 	// The expected policyID generated based on the Policy loaded in to the ACP system.
 	ExpectedPolicyID string
@@ -98,6 +93,11 @@ type AddPolicy struct {
 	// String can be a partial, and the test will pass if an error is returned that
 	// contains this string.
 	ExpectedError string
+	// NodeID may hold the ID (index) of the node we want to add policy to.
+	//
+	// If a value is not provided the policy will be added in all nodes, unless testing with
+	// sourcehub ACP, in which case the policy will only be defined once.
+	NodeID immutable.Option[int]
 }
 
 // addPolicyACP will attempt to add the given policy using DefraDB's ACP system.
@@ -133,6 +133,28 @@ func addPolicyACP(
 
 // AddDocActorRelationship will attempt to create a new relationship for a document with an actor.
 type AddDocActorRelationship struct {
+
+	// The target public identity, i.e. the identity of the actor to tie the document's relation with.
+	//
+	// This is a required field. To test the invalid usage of not having this arg, use NoIdentity() or leave default.
+	TargetIdentity immutable.Option[identity]
+
+	// The requestor identity, i.e. identity of the actor creating the relationship.
+	// Note: This identity must either own or have managing access defined in the policy.
+	//
+	// This is a required field. To test the invalid usage of not having this arg, use NoIdentity() or leave default.
+	RequestorIdentity immutable.Option[identity]
+
+	// The name of the relation to set between document and target actor (should be defined in the policy).
+	//
+	// This is a required field.
+	Relation string
+
+	// Any error expected from the action. Optional.
+	//
+	// String can be a partial, and the test will pass if an error is returned that
+	// contains this string.
+	ExpectedError string
 	// NodeID may hold the ID (index) of the node we want to add doc actor relationship on.
 	//
 	// If a value is not provided the relationship will be added in all nodes, unless testing with
@@ -151,30 +173,8 @@ type AddDocActorRelationship struct {
 	// This is a required field. To test the invalid usage of not having this arg, use -1 index.
 	DocID int
 
-	// The name of the relation to set between document and target actor (should be defined in the policy).
-	//
-	// This is a required field.
-	Relation string
-
-	// The target public identity, i.e. the identity of the actor to tie the document's relation with.
-	//
-	// This is a required field. To test the invalid usage of not having this arg, use NoIdentity() or leave default.
-	TargetIdentity immutable.Option[identity]
-
-	// The requestor identity, i.e. identity of the actor creating the relationship.
-	// Note: This identity must either own or have managing access defined in the policy.
-	//
-	// This is a required field. To test the invalid usage of not having this arg, use NoIdentity() or leave default.
-	RequestorIdentity immutable.Option[identity]
-
 	// Result returns true if it was a no-op due to existing before, and false if a new relationship was made.
 	ExpectedExistence bool
-
-	// Any error expected from the action. Optional.
-	//
-	// String can be a partial, and the test will pass if an error is returned that
-	// contains this string.
-	ExpectedError string
 }
 
 func addDocActorRelationshipACP(
@@ -225,6 +225,28 @@ func addDocActorRelationshipACP(
 
 // DeleteDocActorRelationship will attempt to delete a relationship between a document and an actor.
 type DeleteDocActorRelationship struct {
+
+	// The target public identity, i.e. the identity of the actor with whom the relationship is with.
+	//
+	// This is a required field. To test the invalid usage of not having this arg, use NoIdentity() or leave default.
+	TargetIdentity immutable.Option[identity]
+
+	// The requestor identity, i.e. identity of the actor deleting the relationship.
+	// Note: This identity must either own or have managing access defined in the policy.
+	//
+	// This is a required field. To test the invalid usage of not having this arg, use NoIdentity() or leave default.
+	RequestorIdentity immutable.Option[identity]
+
+	// The name of the relation within the relationship we want to delete (should be defined in the policy).
+	//
+	// This is a required field.
+	Relation string
+
+	// Any error expected from the action. Optional.
+	//
+	// String can be a partial, and the test will pass if an error is returned that
+	// contains this string.
+	ExpectedError string
 	// NodeID may hold the ID (index) of the node we want to delete doc actor relationship on.
 	//
 	// If a value is not provided the relationship will be deleted on all nodes, unless testing with
@@ -243,31 +265,9 @@ type DeleteDocActorRelationship struct {
 	// This is a required field. To test the invalid usage of not having this arg, use -1 index.
 	DocID int
 
-	// The name of the relation within the relationship we want to delete (should be defined in the policy).
-	//
-	// This is a required field.
-	Relation string
-
-	// The target public identity, i.e. the identity of the actor with whom the relationship is with.
-	//
-	// This is a required field. To test the invalid usage of not having this arg, use NoIdentity() or leave default.
-	TargetIdentity immutable.Option[identity]
-
-	// The requestor identity, i.e. identity of the actor deleting the relationship.
-	// Note: This identity must either own or have managing access defined in the policy.
-	//
-	// This is a required field. To test the invalid usage of not having this arg, use NoIdentity() or leave default.
-	RequestorIdentity immutable.Option[identity]
-
 	// Result returns true if the relationship record was expected to be found and deleted,
 	// and returns false if no matching relationship record was found (no-op).
 	ExpectedRecordFound bool
-
-	// Any error expected from the action. Optional.
-	//
-	// String can be a partial, and the test will pass if an error is returned that
-	// contains this string.
-	ExpectedError string
 }
 
 func deleteDocActorRelationshipACP(

--- a/tests/integration/explain.go
+++ b/tests/integration/explain.go
@@ -66,6 +66,9 @@ var (
 )
 
 type PlanNodeTargetCase struct {
+
+	// Expected value of the target node's attribute(s).
+	ExpectedAttributes any
 	// Name of the plan node, whose attribute(s) we are targetting to be asserted.
 	TargetNodeName string
 
@@ -74,20 +77,9 @@ type PlanNodeTargetCase struct {
 
 	// If set to 'true' will include the nested node(s), with their attribute(s) as well.
 	IncludeChildNodes bool
-
-	// Expected value of the target node's attribute(s).
-	ExpectedAttributes any
 }
 
 type ExplainRequest struct {
-	// NodeID is the node ID (index) of the node in which to explain.
-	NodeID immutable.Option[int]
-
-	// The identity of this request.
-	Identity string
-
-	// Has to be a valid explain request type (one of: 'simple', 'debug', 'execute', 'predict').
-	Request string
 
 	// The raw expected explain graph with everything (helpful for debugging purposes).
 	// Note: This is not always asserted (i.e. ignored from the comparison if not provided).
@@ -98,6 +90,15 @@ type ExplainRequest struct {
 	//       - This is not always asserted (i.e. ignored from the comparison if not provided).
 	ExpectedPatterns map[string]any
 
+	// The identity of this request.
+	Identity string
+
+	// Has to be a valid explain request type (one of: 'simple', 'debug', 'execute', 'predict').
+	Request string
+
+	// The expected error from the explain request.
+	ExpectedError string
+
 	// Every target helps assert an individual node somewhere in the explain graph (node's position is omitted).
 	// Each target assertion is only responsible to check if the node's attributes are correct.
 	// This is the only test that sorts the keys and traverses the map in a deterministic order to ensure
@@ -105,8 +106,8 @@ type ExplainRequest struct {
 	// Note: This is not always asserted (i.e. ignored from the comparison if not provided).
 	ExpectedTargets []PlanNodeTargetCase
 
-	// The expected error from the explain request.
-	ExpectedError string
+	// NodeID is the node ID (index) of the node in which to explain.
+	NodeID immutable.Option[int]
 }
 
 func executeExplainRequest(

--- a/tests/integration/identity.go
+++ b/tests/integration/identity.go
@@ -31,12 +31,12 @@ const (
 
 // identity helps specify identity type info and selector/index of identity to use in a test case.
 type identity struct {
-	// type of identity
-	kind identityType
 
 	// selector can be a valid identity index or a selecting pattern like "*".
 	// Note: "*" means to select all identities of the specified [kind] type.
 	selector string
+	// type of identity
+	kind identityType
 }
 
 // NoIdentity returns an reference to an identity that represents no identity.
@@ -77,10 +77,10 @@ func NodeIdentity(indexSelector int) immutable.Option[identity] {
 // identityHolder holds an identity and the generated tokens for each target node.
 // This is used to cache the generated tokens for each node.
 type identityHolder struct {
-	// Identity is the identity.
-	Identity acpIdentity.Identity
 	// NodeTokens is a map of node index to the generated token for that node.
 	NodeTokens map[int]string
+	// Identity is the identity.
+	Identity acpIdentity.Identity
 }
 
 func newIdentityHolder(ident acpIdentity.Identity) *identityHolder {

--- a/tests/integration/lens.go
+++ b/tests/integration/lens.go
@@ -35,22 +35,23 @@ func init() {
 // ConfigureMigration is a test action which will configure a Lens migration using the
 // provided configuration.
 type ConfigureMigration struct {
-	// NodeID is the node ID (index) of the node in which to configure the migration.
-	NodeID immutable.Option[int]
-
-	// Used to identify the transaction for this to run against. Optional.
-	TransactionID immutable.Option[int]
-
-	// The configuration to use.
-	//
-	// Paths to WASM Lens modules may be found in: github.com/sourcenetwork/defradb/tests/lenses
-	client.LensConfig
 
 	// Any error expected from the action. Optional.
 	//
 	// String can be a partial, and the test will pass if an error is returned that
 	// contains this string.
 	ExpectedError string
+
+	// The configuration to use.
+	//
+	// Paths to WASM Lens modules may be found in: github.com/sourcenetwork/defradb/tests/lenses
+	client.LensConfig
+
+	// NodeID is the node ID (index) of the node in which to configure the migration.
+	NodeID immutable.Option[int]
+
+	// Used to identify the transaction for this to run against. Optional.
+	TransactionID immutable.Option[int]
 }
 
 func configureMigration(

--- a/tests/integration/p2p.go
+++ b/tests/integration/p2p.go
@@ -48,17 +48,17 @@ type ConnectPeers struct {
 // however updates in the target node to documents synced from the source node will
 // be synced back to the source node.
 type ConfigureReplicator struct {
-	// SourceNodeID is the node ID (index) of the node from which data should be replicated.
-	SourceNodeID int
-
-	// TargetNodeID is the node ID (index) of the node to which data should be replicated.
-	TargetNodeID int
 
 	// Any error expected from the action. Optional.
 	//
 	// String can be a partial, and the test will pass if an error is returned that
 	// contains this string.
 	ExpectedError string
+	// SourceNodeID is the node ID (index) of the node from which data should be replicated.
+	SourceNodeID int
+
+	// TargetNodeID is the node ID (index) of the node to which data should be replicated.
+	TargetNodeID int
 }
 
 // DeleteReplicator deletes a directional replicator relationship between two nodes.
@@ -82,50 +82,52 @@ const (
 // Changes made to subscribed collections in peers connected to this node will be synced from
 // them to this node.
 type SubscribeToCollection struct {
-	// NodeID is the node ID (index) of the node in which to activate the subscription.
+
+	// Any error expected from the action. Optional.
 	//
-	// Changes made to subscribed collections in peers connected to this node will be synced from
-	// them to this node.
-	NodeID int
+	// String can be a partial, and the test will pass if an error is returned that
+	// contains this string.
+	ExpectedError string
 
 	// CollectionIDs are the collection IDs (indexes) of the collections to subscribe to.
 	//
 	// A [NonExistentCollectionID] may be provided to test non-existent collection IDs.
 	CollectionIDs []int
 
-	// Any error expected from the action. Optional.
+	// NodeID is the node ID (index) of the node in which to activate the subscription.
 	//
-	// String can be a partial, and the test will pass if an error is returned that
-	// contains this string.
-	ExpectedError string
+	// Changes made to subscribed collections in peers connected to this node will be synced from
+	// them to this node.
+	NodeID int
 }
 
 // UnsubscribeToCollection removes the given collections from the set of active subscriptions on
 // the given node.
 type UnsubscribeToCollection struct {
-	// NodeID is the node ID (index) of the node in which to remove the subscription.
-	NodeID int
+
+	// Any error expected from the action. Optional.
+	//
+	// String can be a partial, and the test will pass if an error is returned that
+	// contains this string.
+	ExpectedError string
 
 	// CollectionIDs are the collection IDs (indexes) of the collections to unsubscribe from.
 	//
 	// A [NonExistentCollectionID] may be provided to test non-existent collection IDs.
 	CollectionIDs []int
 
-	// Any error expected from the action. Optional.
-	//
-	// String can be a partial, and the test will pass if an error is returned that
-	// contains this string.
-	ExpectedError string
+	// NodeID is the node ID (index) of the node in which to remove the subscription.
+	NodeID int
 }
 
 // GetAllP2PCollections gets the active subscriptions for the given node and compares them against the
 // expected results.
 type GetAllP2PCollections struct {
-	// NodeID is the node ID (index) of the node in which to get the subscriptions for.
-	NodeID int
 
 	// ExpectedCollectionIDs are the collection IDs (indexes) of the collections expected.
 	ExpectedCollectionIDs []int
+	// NodeID is the node ID (index) of the node in which to get the subscriptions for.
+	NodeID int
 }
 
 // WaitForSync is an action that instructs the test framework to wait for all document synchronization

--- a/tests/integration/results.go
+++ b/tests/integration/results.go
@@ -112,14 +112,15 @@ func areResultsAnyOf(expected []any, actual any) bool {
 // It will also ensure that all Cids described by this [UniqueCid] have the same
 // valid, Cid value.
 type UniqueCid struct {
-	stateMatcher
 	// id is the arbitrary, but hopefully descriptive, id of this [UniqueCid].
 	id any
 
+	duplicatedID any
+	cidDecodeErr error
+	stateMatcher
+
 	valuesMismatch bool
-	duplicatedID   any
 	castFailed     bool
-	cidDecodeErr   error
 }
 
 // var _ Validator = (*UniqueCid)(nil)

--- a/tools/configs/golangci.yaml
+++ b/tools/configs/golangci.yaml
@@ -342,7 +342,7 @@ linters-settings:
     disable-all: false
     disable:
       - shadow
-      - fieldalignment
+      # - fieldalignment
 
 
   lll:


### PR DESCRIPTION
Just like C++ I found out go also depends on struct field ordering to pack bytes efficiently.

There is a built in linter in golangci lint for this.

Here are all our bytes we can save by reordering struct fields:

Since I did the work already in the last cool down, was wondering what people thought about this?

Here are some tools I played with to get this (none are perfect):
- https://github.com/mdempsky/maligned
- https://github.com/orijtech/structslop
- golang-ci lint `fieldalignment`
- https://github.com/dkorunic/betteralign

```
errors/errors.go:29:9: 8 bytes saved: struct with 32 pointer bytes could be 24
acp/acp_local.go:32:15: 8 bytes saved: struct with 56 pointer bytes could be 48
acp/types.go:37:13: 8 bytes saved: struct with 24 pointer bytes could be 16
acp/types.go:44:15: 8 bytes saved: struct with 24 pointer bytes could be 16
client/request/aggregate.go:32:22: 40 bytes saved: struct with 112 pointer bytes could be 72
client/request/commit.go:20:19: 40 bytes saved: struct with 224 pointer bytes could be 184
client/request/mutation.go:25:21: 16 bytes saved: struct with 184 pointer bytes could be 168
client/request/order.go:18:17: 8 bytes saved: struct with 32 pointer bytes could be 24
client/request/request.go:34:26: 8 bytes saved: struct with 40 pointer bytes could be 32
client/request/select.go:20:13: 32 bytes saved: struct with 216 pointer bytes could be 184
client/request/select.go:115:17: 32 bytes saved: struct with 192 pointer bytes could be 160
client/request/subscription.go:20:25: 8 bytes saved: struct with 88 pointer bytes could be 80
datastore/iterable/iterable_transaction_shim.go:28:19: 40 bytes saved: struct with 120 pointer bytes could be 80
datastore/txn.go:57:10: 8 bytes saved: struct with 168 pointer bytes could be 160
event/bus.go:27:10: 16 bytes saved: struct with 48 pointer bytes could be 32
event/event.go:59:13: 24 bytes saved: struct with 88 pointer bytes could be 64
event/event.go:109:14: 8 bytes saved: struct with 32 pointer bytes could be 24
event/event.go:123:19: 8 bytes saved: struct with 24 pointer bytes could be 16
event/event.go:146:17: 16 bytes saved: struct with 56 pointer bytes could be 40
client/backup.go:27:19: 8 bytes saved: struct with 48 pointer bytes could be 40
client/collection.go:128:18: 8 bytes saved: struct with 56 pointer bytes could be 48
client/collection.go:136:19: 8 bytes saved: struct with 16 pointer bytes could be 8
client/collection.go:144:19: 8 bytes saved: struct with 16 pointer bytes could be 8
client/collection_description.go:33:28: 16 bytes saved: struct with 176 pointer bytes could be 160
client/collection_description.go:122:18: 8 bytes saved: struct with 256 pointer bytes could be 248
client/collection_description.go:140:23: 8 bytes saved: struct with 24 pointer bytes could be 16
client/collection_description.go:210:28: 16 bytes saved: struct with 176 pointer bytes could be 160
client/collection_description.go:288:33: 8 bytes saved: struct with 96 pointer bytes could be 88
client/collection_field_description.go:24:33: 16 bytes saved: struct with 88 pointer bytes could be 72
client/collection_field_description.go:60:33: 16 bytes saved: struct with 80 pointer bytes could be 64
client/db.go:306:17: 8 bytes saved: struct with 24 pointer bytes could be 16
client/db.go:333:16: 16 bytes saved: struct with 40 pointer bytes could be 24
client/db.go:357:16: 16 bytes saved: struct with 40 pointer bytes could be 24
client/db.go:399:29: 8 bytes saved: struct with 72 pointer bytes could be 64
client/definitions.go:125:22: 8 bytes saved: struct of size 88 could be 80
client/definitions.go:219:22: 16 bytes saved: struct with 40 pointer bytes could be 24
client/doc_id.go:39:12: 24 bytes saved: struct with 32 pointer bytes could be 8
client/document.go:91:15: 32 bytes saved: struct with 352 pointer bytes could be 320
client/index.go:28:23: 8 bytes saved: struct of size 56 could be 48
client/json.go:209:26: 8 bytes saved: struct of size 40 could be 32
client/replicator.go:28:17: 24 bytes saved: struct with 96 pointer bytes could be 72
client/schema_field_description.go:38:29: 8 bytes saved: struct with 32 pointer bytes could be 24
client/schema_field_description.go:71:17: 8 bytes saved: struct with 16 pointer bytes could be 8
client/schema_field_description.go:401:29: 8 bytes saved: struct with 32 pointer bytes could be 24
client/schema_field_description.go:428:17: 8 bytes saved: struct with 32 pointer bytes could be 24
client/value.go:17:17: 8 bytes saved: struct of size 32 could be 24
internal/core/doc.go:30:10: 8 bytes saved: struct of size 56 could be 48
internal/core/doc.go:82:16: 8 bytes saved: struct with 16 pointer bytes could be 8
internal/core/doc.go:90:22: 8 bytes saved: struct with 16 pointer bytes could be 8
internal/core/doc.go:99:22: 8 bytes saved: struct with 80 pointer bytes could be 72
internal/keys/datastore_doc.go:37:19: 8 bytes saved: struct with 48 pointer bytes could be 40
internal/keys/datastore_index.go:30:24: 8 bytes saved: struct with 16 pointer bytes could be 8
internal/keys/datastore_primary_doc.go:23:26: 8 bytes saved: struct with 16 pointer bytes could be 8
internal/keys/headstore_collection.go:22:22: 8 bytes saved: struct with 16 pointer bytes could be 8
internal/keys/systemstore_collection_index.go:23:25: 8 bytes saved: struct with 16 pointer bytes could be 8
internal/core/crdt/collection.go:50:22: 8 bytes saved: struct with 16 pointer bytes could be 8
internal/core/crdt/composite.go:29:24: 16 bytes saved: struct with 40 pointer bytes could be 24
internal/core/crdt/counter.go:37:19: 16 bytes saved: struct with 80 pointer bytes could be 64
internal/core/crdt/counter.go:80:14: 8 bytes saved: struct with 104 pointer bytes could be 96
internal/core/crdt/lwwreg.go:29:18: 8 bytes saved: struct with 72 pointer bytes could be 64
internal/core/crdt/lwwreg.go:68:18: 8 bytes saved: struct with 104 pointer bytes could be 96
internal/core/block/block.go:127:12: 16 bytes saved: struct with 88 pointer bytes could be 72
datastore/memory/batch.go:21:9: 8 bytes saved: struct with 16 pointer bytes could be 8
datastore/memory/batch.go:27:17: 8 bytes saved: struct with 24 pointer bytes could be 16
datastore/memory/memory.go:24:12: 16 bytes saved: struct with 48 pointer bytes could be 32
datastore/memory/memory.go:42:13: 8 bytes saved: struct with 32 pointer bytes could be 24
internal/connor/key.go:4:16: 8 bytes saved: struct with 32 pointer bytes could be 24
internal/encryption/config.go:14:19: 8 bytes saved: struct with 16 pointer bytes could be 8
internal/encryption/encryptor.go:52:19: 16 bytes saved: struct with 64 pointer bytes could be 48
internal/encryption/event.go:25:23: 16 bytes saved: struct with 32 pointer bytes could be 16
internal/encryption/event.go:44:13: 16 bytes saved: struct with 40 pointer bytes could be 24
internal/merkle/crdt/field.go:21:15: 8 bytes saved: struct with 40 pointer bytes could be 32
internal/planner/mapper/aggregate.go:16:26: 8 bytes saved: struct with 16 pointer bytes could be 8
internal/planner/mapper/commitSelect.go:18:19: 32 bytes saved: struct with 280 pointer bytes could be 248
internal/planner/mapper/field.go:14:12: 8 bytes saved: struct with 16 pointer bytes could be 8
internal/planner/mapper/mutation.go:24:15: 24 bytes saved: struct with 232 pointer bytes could be 208
internal/planner/mapper/similarity.go:16:17: 8 bytes saved: struct with 144 pointer bytes could be 136
internal/planner/mapper/targetable.go:213:21: 8 bytes saved: struct with 32 pointer bytes could be 24
internal/planner/mapper/targetable.go:228:17: 16 bytes saved: struct with 88 pointer bytes could be 72
internal/planner/filter/extract_properties.go:21:15: 8 bytes saved: struct with 16 pointer bytes could be 8
internal/request/graphql/schema/generate.go:43:16: 16 bytes saved: struct with 40 pointer bytes could be 24
internal/request/graphql/schema/manager.go:24:20: 16 bytes saved: struct with 104 pointer bytes could be 88
internal/db/fetcher/dag.go:25:18: 8 bytes saved: struct with 40 pointer bytes could be 32
internal/db/fetcher/document.go:29:22: 8 bytes saved: struct with 192 pointer bytes could be 184
internal/db/fetcher/encoded_doc.go:67:22: 24 bytes saved: struct with 80 pointer bytes could be 56
internal/db/fetcher/indexer.go:30:19: 24 bytes saved: struct with 200 pointer bytes could be 176
internal/db/fetcher/indexer_iterators.go:67:22: 8 bytes saved: struct with 48 pointer bytes could be 40
internal/db/fetcher/indexer_iterators.go:74:26: 24 bytes saved: struct with 192 pointer bytes could be 168
internal/db/fetcher/indexer_iterators.go:156:28: 16 bytes saved: struct with 72 pointer bytes could be 56
internal/db/fetcher/indexer_iterators.go:192:22: 24 bytes saved: struct with 80 pointer bytes could be 56
internal/db/fetcher/indexer_iterators.go:477:22: 16 bytes saved: struct with 88 pointer bytes could be 72
internal/db/fetcher/indexer_matchers.go:40:17: 8 bytes saved: struct with 16 pointer bytes could be 8
internal/db/fetcher/indexer_matchers.go:58:21: 8 bytes saved: struct with 16 pointer bytes could be 8
internal/db/fetcher/indexer_matchers.go:76:21: 8 bytes saved: struct with 16 pointer bytes could be 8
internal/db/fetcher/indexer_matchers.go:94:20: 8 bytes saved: struct with 24 pointer bytes could be 16
internal/db/fetcher/indexer_matchers.go:112:18: 8 bytes saved: struct with 40 pointer bytes could be 32
internal/db/fetcher/indexer_matchers.go:206:23: 8 bytes saved: struct of size 56 could be 48
internal/db/fetcher/permissioned.go:25:26: 8 bytes saved: struct with 120 pointer bytes could be 112
internal/db/fetcher/prefix.go:30:20: 32 bytes saved: struct with 96 pointer bytes could be 64
internal/db/fetcher/wrapper.go:30:22: 48 bytes saved: struct with 256 pointer bytes could be 208
internal/lens/fetcher.go:333:26: 24 bytes saved: struct with 56 pointer bytes could be 32
internal/lens/lens.go:26:16: 8 bytes saved: struct with 24 pointer bytes could be 16
internal/lens/registry.go:35:19: 40 bytes saved: struct with 88 pointer bytes could be 48
internal/lens/registry.go:293:15: 16 bytes saved: struct with 40 pointer bytes could be 24
internal/planner/arbitrary_join.go:228:17: 16 bytes saved: struct with 32 pointer bytes could be 16
internal/planner/average.go:20:18: 40 bytes saved: struct with 120 pointer bytes could be 80
internal/planner/commit.go:28:18: 24 bytes saved: struct with 184 pointer bytes could be 160
internal/planner/count.go:29:16: 24 bytes saved: struct with 128 pointer bytes could be 104
internal/planner/create.go:29:17: 24 bytes saved: struct with 160 pointer bytes could be 136
internal/planner/lens.go:27:15: 16 bytes saved: struct with 312 pointer bytes could be 296
internal/planner/max.go:24:14: 24 bytes saved: struct with 136 pointer bytes could be 112
internal/planner/min.go:24:14: 24 bytes saved: struct with 136 pointer bytes could be 112
internal/planner/multi.go:57:19: 16 bytes saved: struct with 128 pointer bytes could be 112
internal/planner/operation.go:24:20: 8 bytes saved: struct with 72 pointer bytes could be 64
internal/planner/order.go:43:16: 16 bytes saved: struct with 88 pointer bytes could be 72
internal/planner/pipe.go:22:15: 8 bytes saved: struct with 88 pointer bytes could be 80
internal/planner/planner.go:89:14: 8 bytes saved: struct with 128 pointer bytes could be 120
internal/planner/scan.go:37:15: 32 bytes saved: struct with 240 pointer bytes could be 208
internal/planner/scan.go:321:20: 48 bytes saved: struct with 72 pointer bytes could be 24
internal/planner/select.go:54:20: 16 bytes saved: struct with 104 pointer bytes could be 88
internal/planner/similarity.go:19:21: 24 bytes saved: struct with 224 pointer bytes could be 200
internal/planner/sum.go:23:14: 32 bytes saved: struct with 136 pointer bytes could be 104
internal/planner/type_join.go:387:15: 40 bytes saved: struct with 160 pointer bytes could be 120
internal/planner/type_join.go:469:25: 16 bytes saved: struct with 400 pointer bytes could be 384
internal/planner/type_join.go:519:30: 8 bytes saved: struct with 248 pointer bytes could be 240
internal/planner/update.go:20:17: 24 bytes saved: struct with 152 pointer bytes could be 128
internal/planner/upsert.go:20:17: 16 bytes saved: struct with 136 pointer bytes could be 120
internal/planner/values.go:29:17: 16 bytes saved: struct with 48 pointer bytes could be 32
internal/planner/view.go:23:15: 16 bytes saved: struct with 224 pointer bytes could be 208
internal/planner/view.go:171:24: 16 bytes saved: struct with 352 pointer bytes could be 336
internal/db/collection.go:44:17: 16 bytes saved: struct with 304 pointer bytes could be 288
internal/db/config.go:26:16: 24 bytes saved: struct with 88 pointer bytes could be 64
internal/db/db.go:59:9: 48 bytes saved: struct with 256 pointer bytes could be 208
internal/db/definition_validation.go:25:22: 16 bytes saved: struct with 96 pointer bytes could be 80
internal/db/index.go:159:26: 8 bytes saved: struct with 104 pointer bytes could be 96
http/client.go:134:25: 8 bytes saved: struct with 40 pointer bytes could be 32
http/client_lens.go:33:26: 8 bytes saved: struct with 16 pointer bytes could be 8
http/client_lens.go:69:21: 8 bytes saved: struct with 16 pointer bytes could be 8
http/client_tx.go:24:18: 8 bytes saved: struct with 16 pointer bytes could be 8
http/handler_store.go:275:21: 8 bytes saved: struct with 40 pointer bytes could be 32
http/server.go:39:20: 8 bytes saved: struct with 64 pointer bytes could be 56
datastore/badger/v4/datastore.go:27:16: 8 bytes saved: struct of size 88 could be 80
datastore/badger/v4/datastore.go:61:14: 24 bytes saved: struct with 296 pointer bytes could be 272
datastore/badger/v4/iterator.go:28:21: 32 bytes saved: struct with 120 pointer bytes could be 88
net/config.go:20:14: 8 bytes saved: struct with 112 pointer bytes could be 104
net/server.go:45:13: 24 bytes saved: struct with 72 pointer bytes could be 48
node/node.go:44:14: 8 bytes saved: struct with 24 pointer bytes could be 16
node/store.go:41:19: 8 bytes saved: struct with 48 pointer bytes could be 40
tests/gen/gen_auto.go:74:13: 8 bytes saved: struct with 24 pointer bytes could be 16
tests/gen/gen_auto_config.go:20:16: 16 bytes saved: struct with 40 pointer bytes could be 24
tests/gen/gen_auto_configurator.go:39:26: 16 bytes saved: struct with 120 pointer bytes could be 104
tests/gen/gen_auto_configurator.go:109:20: 48 bytes saved: struct with 64 pointer bytes could be 16
tests/bench/fixtures/fixtures.go:46:16: 16 bytes saved: struct with 64 pointer bytes could be 48
tests/integration/acp.go:80:16: 16 bytes saved: struct with 88 pointer bytes could be 72
tests/integration/acp.go:135:30: 40 bytes saved: struct with 128 pointer bytes could be 88
tests/integration/acp.go:227:33: 40 bytes saved: struct with 128 pointer bytes could be 88
tests/integration/explain.go:68:25: 24 bytes saved: struct with 48 pointer bytes could be 24
tests/integration/explain.go:82:21: 24 bytes saved: struct with 96 pointer bytes could be 72
tests/integration/identity.go:33:15: 8 bytes saved: struct with 16 pointer bytes could be 8
tests/integration/identity.go:79:21: 8 bytes saved: struct with 56 pointer bytes could be 48
tests/integration/lens.go:37:25: 40 bytes saved: struct with 96 pointer bytes could be 56
tests/integration/p2p.go:50:26: 16 bytes saved: struct with 24 pointer bytes could be 8
tests/integration/p2p.go:84:28: 16 bytes saved: struct with 40 pointer bytes could be 24
tests/integration/p2p.go:105:30: 16 bytes saved: struct with 40 pointer bytes could be 24
tests/integration/p2p.go:123:27: 8 bytes saved: struct with 16 pointer bytes could be 8
tests/integration/results.go:114:16: 8 bytes saved: struct of size 72 could be 64
tests/integration/state.go:124:16: 8 bytes saved: struct with 152 pointer bytes could be 144
tests/integration/state.go:147:12: 8 bytes saved: struct of size 528 could be 520
tests/integration/test_case.go:76:10: 8 bytes saved: struct with 16 pointer bytes could be 8
tests/integration/test_case.go:124:19: 24 bytes saved: struct with 64 pointer bytes could be 40
tests/integration/test_case.go:149:18: 32 bytes saved: struct with 80 pointer bytes could be 48
tests/integration/test_case.go:166:22: 16 bytes saved: struct with 40 pointer bytes could be 24
tests/integration/test_case.go:179:16: 24 bytes saved: struct with 120 pointer bytes could be 96
tests/integration/test_case.go:206:21: 40 bytes saved: struct with 152 pointer bytes could be 112
tests/integration/test_case.go:233:29: 16 bytes saved: struct with 40 pointer bytes could be 24
tests/integration/test_case.go:244:17: 24 bytes saved: struct with 88 pointer bytes could be 64
tests/integration/test_case.go:267:19: 24 bytes saved: struct with 112 pointer bytes could be 88
tests/integration/test_case.go:285:16: 40 bytes saved: struct with 120 pointer bytes could be 80
tests/integration/test_case.go:357:16: 32 bytes saved: struct with 72 pointer bytes could be 40
tests/integration/test_case.go:390:16: 32 bytes saved: struct with 88 pointer bytes could be 56
tests/integration/test_case.go:433:23: 24 bytes saved: struct with 96 pointer bytes could be 72
tests/integration/test_case.go:482:18: 40 bytes saved: struct with 96 pointer bytes could be 56
tests/integration/test_case.go:512:16: 32 bytes saved: struct with 56 pointer bytes could be 24
tests/integration/test_case.go:539:17: 32 bytes saved: struct with 56 pointer bytes could be 24
tests/integration/test_case.go:575:16: 8 bytes saved: struct with 48 pointer bytes could be 40
tests/integration/test_case.go:589:14: 32 bytes saved: struct with 152 pointer bytes could be 120
tests/integration/test_case.go:633:19: 16 bytes saved: struct with 48 pointer bytes could be 32
tests/integration/test_case.go:666:27: 16 bytes saved: struct with 40 pointer bytes could be 24
tests/integration/test_case.go:677:24: 8 bytes saved: struct with 16 pointer bytes could be 8
tests/integration/test_case.go:692:26: 24 bytes saved: struct with 64 pointer bytes could be 40
tests/integration/test_case.go:709:27: 16 bytes saved: struct with 56 pointer bytes could be 40
tests/integration/test_case.go:742:33: 16 bytes saved: struct with 40 pointer bytes could be 24
tests/integration/test_case.go:757:19: 24 bytes saved: struct with 104 pointer bytes could be 80
tests/integration/test_case.go:778:19: 16 bytes saved: struct with 56 pointer bytes could be 40
tests/integration/test_case.go:800:22: 8 bytes saved: struct with 32 pointer bytes could be 24
```
