### PR TITLE
test: Add example CLI integration tests

### DIFF
--- a/cli/config.go
+++ b/cli/config.go
@@ -67,6 +67,7 @@ var configFlags = map[string]string{
 	"keyring-backend":    "keyring.backend",
 	"keyring-path":       "keyring.path",
 	"no-keyring":         "keyring.disabled",
+	"acp-type":           "acp.type",
 	"source-hub-address": "acp.sourceHub.address",
 	"development":        "development",
 	"secret-file":        "secretfile",
@@ -102,6 +103,7 @@ var configDefaults = map[string]any{
 	"telemetry.disabled":                false,
 	"datastore.nosigning":               false,
 	"datastore.defaultkeytype":          "secp256k1",
+	"acp.type":                          "none",
 }
 
 // defaultConfig returns a new config with default values.

--- a/cli/start.go
+++ b/cli/start.go
@@ -281,6 +281,11 @@ func MakeStartCommand() *cobra.Command {
 		"Default key type to generate new node identity if one doesn't exist in the keyring. "+
 			"Valid values are 'secp256k1' and 'ed25519'. "+
 			"If not specified, the default key type will be 'secp256k1'.")
+	cmd.PersistentFlags().String(
+		"acp-type",
+		cfg.GetString(configFlags["acp.type"]),
+		"Specify the acp engine to use (supported: none (default), local, source-hub)",
+	)
 	return cmd
 }
 

--- a/cli/test/action/action.go
+++ b/cli/test/action/action.go
@@ -32,18 +32,18 @@ type Action = action.Action
 type Actions = action.Actions
 type Stateful = action.Stateful[*state.State]
 
-// Argmented provides a function through which additional CLI arguments may be provided.
+// Augmented provides a function through which additional CLI arguments may be provided.
 //
 // It is typically used by multipliers in order to provide additional args to Actions
 // implementing this interface.
-type Argmented interface {
+type Augmented interface {
 	// Augments the host object (typically an action) with additional CLI arguments.
 	AddArgs(...string)
 }
 
-type ArgmentedAction interface {
+type AugmentedAction interface {
 	Action
-	Argmented
+	Augmented
 }
 
 type stateful struct {
@@ -65,14 +65,14 @@ func (a *stateful) AppendDirections(args []string) []string {
 	return append(args, "--url", a.s.Url, "--rootdir", a.s.RootDir)
 }
 
-type argmented struct {
+type augmented struct {
 	// Additional CLI arguments that should be sent along with the action-defined args.
 	AdditionalArgs []string
 }
 
-var _ Argmented = (*argmented)(nil)
+var _ Augmented = (*augmented)(nil)
 
-func (a *argmented) AddArgs(args ...string) {
+func (a *augmented) AddArgs(args ...string) {
 	a.AdditionalArgs = append(a.AdditionalArgs, args...)
 }
 

--- a/cli/test/action/action.go
+++ b/cli/test/action/action.go
@@ -1,0 +1,225 @@
+// Copyright 2025 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package action
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/sourcenetwork/testo/action"
+
+	"github.com/sourcenetwork/defradb/cli"
+	"github.com/sourcenetwork/defradb/cli/test/state"
+	"github.com/sourcenetwork/defradb/errors"
+)
+
+type Action = action.Action
+type Actions = action.Actions
+type Stateful = action.Stateful[*state.State]
+
+// Argmented provides a function through which additional CLI arguments may be provided.
+//
+// It is typically used by multipliers in order to provide additional args to Actions
+// implementing this interface.
+type Argmented interface {
+	// Augments the host object (typically an action) with additional CLI arguments.
+	AddArgs(...string)
+}
+
+type ArgmentedAction interface {
+	Action
+	Argmented
+}
+
+type stateful struct {
+	s *state.State
+}
+
+var _ Stateful = (*stateful)(nil)
+
+func (a *stateful) SetState(s *state.State) {
+	if a == nil {
+		a = &stateful{}
+	}
+	a.s = s
+}
+
+// AppendDirections appends the cli params responsible for letting the client know which
+// Defra instance to act upon.
+func (a *stateful) AppendDirections(args []string) []string {
+	return append(args, "--url", a.s.Url, "--rootdir", a.s.RootDir)
+}
+
+type argmented struct {
+	// Additional CLI arguments that should be sent along with the action-defined args.
+	AdditionalArgs []string
+}
+
+var _ Argmented = (*argmented)(nil)
+
+func (a *argmented) AddArgs(args ...string) {
+	a.AdditionalArgs = append(a.AdditionalArgs, args...)
+}
+
+func executeJson[TReturn any](ctx context.Context, args []string) (TReturn, error) {
+	var result TReturn
+
+	data, err := executeBytes(ctx, args)
+	if err != nil {
+		return result, err
+	}
+
+	if err := json.Unmarshal(data, &result); err != nil {
+		return result, err
+	}
+
+	return result, nil
+}
+
+func executeBytes(ctx context.Context, args []string) ([]byte, error) {
+	stdOut, stdErr, err := executeStream(ctx, args)
+	if err != nil {
+		return nil, err
+	}
+	stdOutData, err := io.ReadAll(stdOut)
+	if err != nil {
+		return nil, err
+	}
+	stdErrData, err := io.ReadAll(stdErr)
+	if err != nil {
+		return nil, err
+	}
+	if len(stdErrData) != 0 {
+		return nil, fmt.Errorf("%s", stdErrData)
+	}
+	return stdOutData, nil
+}
+
+func execute(ctx context.Context, args []string) error {
+	stdOut, stdErr, err := executeStream(ctx, args)
+	if err != nil {
+		return err
+	}
+	_, err = io.ReadAll(stdOut)
+	if err != nil {
+		return err
+	}
+	stdErrData, err := io.ReadAll(stdErr)
+	if err != nil {
+		return err
+	}
+	if len(stdErrData) != 0 {
+		return fmt.Errorf("%s", stdErrData)
+	}
+	return nil
+}
+
+func executeStream(ctx context.Context, args []string) (io.ReadCloser, io.ReadCloser, error) {
+	stdOutRead, stdOutWrite := io.Pipe()
+	stdErrRead, stdErrWrite := io.Pipe()
+
+	cmd := cli.NewDefraCommand()
+	cmd.SetOut(stdOutWrite)
+	cmd.SetErr(stdErrWrite)
+	cmd.SetArgs(args)
+
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+
+	go func() {
+		err := cmd.ExecuteContext(ctx)
+		stdOutWrite.CloseWithError(err)
+		stdErrWrite.CloseWithError(err)
+	}()
+
+	return stdOutRead, stdErrRead, nil
+}
+
+// executeUntil executes a defra command with the given args and will block until it reads the given
+// `until` string in stderr.
+func executeUntil(ctx context.Context, args []string, until string) error {
+	read, write, err := os.Pipe()
+	if err != nil {
+		return err
+	}
+
+	// We cannot simply restore this once `until` was reached whilst the command is still exectuting,
+	// as that would create a race condition between the setting of os.Stderr here, and the writing to
+	// it in the production code.  That is reasonably minor, but the Golang race detector will complain.
+	//
+	// Instead we need to maintain our pipe whilst the command is executing.
+	stdErr := os.Stderr
+
+	cmd := cli.NewDefraCommand()
+	os.Stderr = write
+	cmd.SetArgs(args)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	scanner := bufio.NewScanner(read)
+	go func() {
+		targetReached := false
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+
+			hasValue := scanner.Scan()
+			if !hasValue {
+				time.Sleep(100 * time.Microsecond)
+				continue
+			}
+
+			// The scanner splits by new line (useful), we have to remember to add it back in.
+			// We could write our own split function to avoid this, but this is easier for now.
+			_, err := stdErr.Write(append(scanner.Bytes(), []byte("\n")...))
+			if err != nil {
+				panic(err)
+			}
+
+			if !targetReached {
+				targetReached = strings.Contains(scanner.Text(), until)
+				if targetReached {
+					wg.Add(-1)
+				}
+			}
+		}
+	}()
+
+	go func() {
+		err := cmd.ExecuteContext(ctx)
+		if err != nil {
+			_, innerErr := write.WriteString(err.Error())
+			if innerErr != nil {
+				panic(errors.Join(err, innerErr))
+			}
+		}
+		err = write.Close()
+		if err != nil {
+			panic(err)
+		}
+	}()
+
+	// Block, until `until` is read from stderr
+	wg.Wait()
+
+	return nil
+}

--- a/cli/test/action/action.go
+++ b/cli/test/action/action.go
@@ -111,22 +111,8 @@ func executeBytes(ctx context.Context, args []string) ([]byte, error) {
 }
 
 func execute(ctx context.Context, args []string) error {
-	stdOut, stdErr, err := executeStream(ctx, args)
-	if err != nil {
-		return err
-	}
-	_, err = io.ReadAll(stdOut)
-	if err != nil {
-		return err
-	}
-	stdErrData, err := io.ReadAll(stdErr)
-	if err != nil {
-		return err
-	}
-	if len(stdErrData) != 0 {
-		return fmt.Errorf("%s", stdErrData)
-	}
-	return nil
+	_, err := executeBytes(ctx, args)
+	return err
 }
 
 func executeStream(ctx context.Context, args []string) (io.ReadCloser, io.ReadCloser, error) {

--- a/cli/test/action/collection_describe.go
+++ b/cli/test/action/collection_describe.go
@@ -1,0 +1,84 @@
+// Copyright 2025 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package action
+
+import (
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcenetwork/defradb/client"
+)
+
+// CollectionDescribe executes the `client collection describe` command and requires that the returned
+// result matches the expected value.
+type CollectionDescribe struct {
+	stateful
+	argmented
+
+	// The expected results.
+	//
+	// Each item will be compared individually, if ID, RootID or SchemaVersionID on the
+	// expected item are default they will not be compared with the actual.
+	//
+	// Assertions on Indexes and Sources will not distinguish between nil and empty (in order
+	// to allow their ommission in most cases).
+	Expected []client.CollectionDefinition
+}
+
+var _ Action = (*CollectionDescribe)(nil)
+
+func (a *CollectionDescribe) Execute() {
+	args := []string{"client", "collection", "describe"}
+	args = append(args, a.AdditionalArgs...)
+	args = a.AppendDirections(args)
+
+	result, err := executeJson[[]client.CollectionDefinition](a.s.Ctx, args)
+	require.NoError(a.s.T, err)
+
+	require.Equal(a.s.T, len(a.Expected), len(result))
+
+	for i, expected := range a.Expected {
+		actual := result[i]
+
+		if expected.Description.ID != 0 {
+			require.Equal(a.s.T, expected.Description.ID, actual.Description.ID)
+		}
+		if expected.Description.RootID != 0 {
+			require.Equal(a.s.T, expected.Description.RootID, actual.Description.RootID)
+		}
+		if expected.Description.SchemaVersionID != "" {
+			require.Equal(a.s.T, expected.Description.SchemaVersionID, actual.Description.SchemaVersionID)
+		}
+
+		require.Equal(a.s.T, expected.Description.Name, actual.Description.Name)
+		require.Equal(a.s.T, expected.Description.IsMaterialized, actual.Description.IsMaterialized)
+		require.Equal(a.s.T, expected.Description.IsBranchable, actual.Description.IsBranchable)
+
+		if expected.Description.Indexes != nil || len(actual.Description.Indexes) != 0 {
+			// Dont bother asserting this if the expected is nil and the actual is nil/empty.
+			// This is to save each test action from having to bother declaring an empty slice (if there are no indexes)
+			require.Equal(a.s.T, expected.Description.Indexes, actual.Description.Indexes)
+		}
+
+		if expected.Description.Sources != nil {
+			// Dont bother asserting this if the expected is nil and the actual is nil/empty.
+			// This is to save each test action from having to bother declaring an empty slice (if there are no sources)
+			require.Equal(a.s.T, expected.Description.Sources, actual.Description.Sources)
+		}
+
+		if expected.Description.Fields != nil {
+			require.Equal(a.s.T, expected.Description.Fields, actual.Description.Fields)
+		}
+
+		if expected.Description.VectorEmbeddings != nil {
+			require.Equal(a.s.T, expected.Description.VectorEmbeddings, actual.Description.VectorEmbeddings)
+		}
+	}
+}

--- a/cli/test/action/collection_describe.go
+++ b/cli/test/action/collection_describe.go
@@ -20,7 +20,7 @@ import (
 // result matches the expected value.
 type CollectionDescribe struct {
 	stateful
-	argmented
+	augmented
 
 	// The expected results.
 	//

--- a/cli/test/action/schema_add.go
+++ b/cli/test/action/schema_add.go
@@ -1,0 +1,36 @@
+// Copyright 2025 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package action
+
+import "github.com/stretchr/testify/require"
+
+// SchemaAdd executes the `client schema add` command using the given schema.
+type SchemaAdd struct {
+	stateful
+	argmented
+
+	// The schema string value to be passed directly to the command (i.e. not via a file)
+	InlineSchema string
+}
+
+var _ Action = (*SchemaAdd)(nil)
+
+func (a *SchemaAdd) Execute() {
+	args := []string{"client", "schema", "add"}
+
+	args = append(args, a.InlineSchema)
+
+	args = a.AppendDirections(args)
+	args = append(args, a.AdditionalArgs...)
+
+	err := execute(a.s.Ctx, args)
+	require.NoError(a.s.T, err)
+}

--- a/cli/test/action/schema_add.go
+++ b/cli/test/action/schema_add.go
@@ -15,7 +15,7 @@ import "github.com/stretchr/testify/require"
 // SchemaAdd executes the `client schema add` command using the given schema.
 type SchemaAdd struct {
 	stateful
-	argmented
+	augmented
 
 	// The schema string value to be passed directly to the command (i.e. not via a file)
 	InlineSchema string

--- a/cli/test/action/start.go
+++ b/cli/test/action/start.go
@@ -28,7 +28,14 @@ func Start() *StartCli {
 
 func (a *StartCli) Execute() {
 	a.s.RootDir = a.s.T.TempDir()
-	args := []string{"start", "--no-keyring", "--store=memory", "--rootdir", a.s.RootDir, "--url", "127.0.0.1:"}
+	args := []string{
+		"start",
+		"--no-keyring",
+		"--store=memory",
+		"--rootdir", a.s.RootDir,
+		"--url=127.0.0.1:",
+		"--acp-type=local",
+	}
 
 	logPrefix := "Providing GraphQL endpoint at "
 	exampleUrl := "http://127.0.0.1:42571"

--- a/cli/test/action/start.go
+++ b/cli/test/action/start.go
@@ -1,0 +1,85 @@
+// Copyright 2025 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package action
+
+import (
+	"fmt"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+type StartCli struct {
+	stateful
+}
+
+var _ Action = (*StartCli)(nil)
+
+func Start() *StartCli {
+	return &StartCli{}
+}
+
+func (a *StartCli) Execute() {
+	// We need to lock across all processes in order to allocate the port.
+	// We could alternatively let Defra assign the port and then read it from the logs,
+	// but explicit assignment is currently the prefered approach.
+	unlock, err := crossLock(44445)
+	require.NoError(a.s.T, err)
+	defer unlock()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(a.s.T, err)
+
+	args := []string{"start", "--no-keyring", "--store=memory"}
+
+	a.s.Url = listener.Addr().String()
+	a.s.RootDir = a.s.T.TempDir()
+
+	args = a.AppendDirections(args)
+
+	err = listener.Close()
+	require.NoError(a.s.T, err)
+
+	err = executeUntil(a.s.Ctx, args, "Providing GraphQL endpoint at")
+	require.NoError(a.s.T, err)
+}
+
+// crossLock forms a cross process lock by attempting to listen to the given port.
+//
+// This function will only return once the port is free or the timeout is reached.
+// A function to unbind from the port is returned - this unlock function may be called
+// multiple times without issue.
+func crossLock(port uint16) (func(), error) {
+	timeout := time.After(20 * time.Second)
+	for {
+		select {
+		case <-timeout:
+			return nil, fmt.Errorf("timeout reached while trying to acquire cross process lock on port %v", port)
+		default:
+			l, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%v", port))
+			if err != nil {
+				if strings.Contains(err.Error(), "address already in use") {
+					time.Sleep(5 * time.Millisecond)
+					continue
+				}
+				return nil, err
+			}
+
+			return func() {
+					// there are no errors that this returns that we actually care about
+					_ = l.Close()
+				},
+				nil
+		}
+	}
+}

--- a/cli/test/action/tx_commit.go
+++ b/cli/test/action/tx_commit.go
@@ -1,0 +1,35 @@
+// Copyright 2025 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package action
+
+import (
+	"fmt"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TxnCommit executes the `client txn commit` command using the txn id at the given
+// state-index.
+type TxCommit struct {
+	stateful
+
+	TxnIndex int
+}
+
+var _ Action = (*TxCommit)(nil)
+
+func (a *TxCommit) Execute() {
+	args := []string{"client", "tx", "commit", fmt.Sprint(a.s.Txns[a.TxnIndex])}
+	args = a.AppendDirections(args)
+
+	err := execute(a.s.Ctx, args)
+	require.NoError(a.s.T, err)
+}

--- a/cli/test/action/tx_create.go
+++ b/cli/test/action/tx_create.go
@@ -1,0 +1,31 @@
+// Copyright 2025 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package action
+
+import "github.com/stretchr/testify/require"
+
+// TxCreate executes the `client tx create` command and appends the returned transaction id
+// to state.Txns.
+type TxCreate struct {
+	stateful
+}
+
+var _ Action = (*TxCreate)(nil)
+
+func (a *TxCreate) Execute() {
+	result, err := executeJson[map[string]any](a.s.Ctx, a.AppendDirections([]string{"client", "tx", "create"}))
+	require.NoError(a.s.T, err)
+
+	txId, ok := result["id"].(float64)
+	require.True(a.s.T, ok)
+
+	a.s.Txns = append(a.s.Txns, uint64(txId))
+}

--- a/cli/test/action/txn_action.go
+++ b/cli/test/action/txn_action.go
@@ -20,21 +20,21 @@ import (
 //
 // Executing this TxnAction will execute the given action within the scope
 // of the given transaction.
-type TxnAction[T ArgmentedAction] struct {
+type TxnAction[T AugmentedAction] struct {
 	s *state.State
-	argmented
+	augmented
 
 	TxnIndex int
 	Action   T
 }
 
-var _ Action = (*TxnAction[ArgmentedAction])(nil)
+var _ Action = (*TxnAction[AugmentedAction])(nil)
 
 // WithTxn wraps the given action within the scope of the default (ID: 0) transaction.
 //
 // If a transaction with the default ID (0) has not been created by the time this action
 // executes, executing the transaction will panic.
-func WithTxn[T ArgmentedAction](action T) *TxnAction[T] {
+func WithTxn[T AugmentedAction](action T) *TxnAction[T] {
 	return &TxnAction[T]{
 		Action: action,
 	}
@@ -44,7 +44,7 @@ func WithTxn[T ArgmentedAction](action T) *TxnAction[T] {
 //
 // If a transaction with the given ID has not been created by the time this action
 // executes, executing the transaction will panic.
-func WithTxnI[T ArgmentedAction](action T, txnIndex int) *TxnAction[T] {
+func WithTxnI[T AugmentedAction](action T, txnIndex int) *TxnAction[T] {
 	return &TxnAction[T]{
 		TxnIndex: txnIndex,
 		Action:   action,

--- a/cli/test/action/txn_action.go
+++ b/cli/test/action/txn_action.go
@@ -1,0 +1,64 @@
+// Copyright 2025 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package action
+
+import (
+	"fmt"
+
+	"github.com/sourcenetwork/defradb/cli/test/state"
+)
+
+// TxnAction wraps an action within the context of a transaction.
+//
+// Executing this TxnAction will execute the given action within the scope
+// of the given transaction.
+type TxnAction[T ArgmentedAction] struct {
+	s *state.State
+	argmented
+
+	TxnIndex int
+	Action   T
+}
+
+var _ Action = (*TxnAction[ArgmentedAction])(nil)
+
+// WithTxn wraps the given action within the scope of the default (ID: 0) transaction.
+//
+// If a transaction with the default ID (0) has not been created by the time this action
+// executes, executing the transaction will panic.
+func WithTxn[T ArgmentedAction](action T) *TxnAction[T] {
+	return &TxnAction[T]{
+		Action: action,
+	}
+}
+
+// WithTxn wraps the given action within the scope of given transaction.
+//
+// If a transaction with the given ID has not been created by the time this action
+// executes, executing the transaction will panic.
+func WithTxnI[T ArgmentedAction](action T, txnIndex int) *TxnAction[T] {
+	return &TxnAction[T]{
+		TxnIndex: txnIndex,
+		Action:   action,
+	}
+}
+
+func (a *TxnAction[T]) SetState(s *state.State) {
+	a.s = s
+	if inner, ok := any(a.Action).(Stateful); ok {
+		inner.SetState(s)
+	}
+}
+
+func (a *TxnAction[T]) Execute() {
+	a.Action.AddArgs("tx", fmt.Sprint(a.s.Txns[a.TxnIndex]))
+	a.Action.Execute()
+}

--- a/cli/test/integration/schema_add/simple_test.go
+++ b/cli/test/integration/schema_add/simple_test.go
@@ -1,0 +1,45 @@
+// Copyright 2025 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package schema_add
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/immutable"
+
+	"github.com/sourcenetwork/defradb/cli/test/action"
+	"github.com/sourcenetwork/defradb/cli/test/integration"
+	"github.com/sourcenetwork/defradb/client"
+)
+
+func TestSchemaAdd(t *testing.T) {
+	test := &integration.Test{
+		Actions: []action.Action{
+			&action.SchemaAdd{
+				InlineSchema: `
+					type User {}
+				`,
+			},
+			&action.CollectionDescribe{
+				Expected: []client.CollectionDefinition{
+					{
+						Description: client.CollectionDescription{
+							Name:           immutable.Some("User"),
+							IsMaterialized: true,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	test.Execute(t)
+}

--- a/cli/test/integration/start/simple_test.go
+++ b/cli/test/integration/start/simple_test.go
@@ -1,0 +1,28 @@
+// Copyright 2025 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package start
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/defradb/cli/test/action"
+	"github.com/sourcenetwork/defradb/cli/test/integration"
+)
+
+func TestStart(t *testing.T) {
+	test := &integration.Test{
+		Actions: []action.Action{
+			action.Start(),
+		},
+	}
+
+	test.Execute(t)
+}

--- a/cli/test/integration/test.go
+++ b/cli/test/integration/test.go
@@ -44,8 +44,8 @@ type Test struct {
 
 func (test *Test) Execute(t testing.TB) {
 	ctx := context.Background()
-	var cancel context.CancelFunc
-	ctx, cancel = context.WithTimeout(ctx, 1*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
+	defer cancel()
 
 	multiplier.Skip(t, test.Includes, test.Excludes)
 
@@ -58,9 +58,8 @@ func (test *Test) Execute(t testing.TB) {
 	testo.Log(t, actions)
 
 	testo.ExecuteS(actions, &state.State{
-		T:       t,
-		Ctx:     ctx,
-		Cancels: []context.CancelFunc{cancel},
+		T:   t,
+		Ctx: ctx,
 	})
 }
 

--- a/cli/test/integration/test.go
+++ b/cli/test/integration/test.go
@@ -1,0 +1,89 @@
+// Copyright 2025 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/sourcenetwork/testo"
+	"github.com/sourcenetwork/testo/multiplier"
+
+	"github.com/sourcenetwork/defradb/cli/test/action"
+	_ "github.com/sourcenetwork/defradb/cli/test/multiplier"
+	"github.com/sourcenetwork/defradb/cli/test/state"
+)
+
+func init() {
+	multiplier.Init("DEFRA_MULTIPLIERS")
+}
+
+// Test is a single, self-contained, test.
+type Test struct {
+	// The test will be skipped if the current active set of multipliers
+	// does not contain all of the given multiplier names.
+	Includes []multiplier.Name
+
+	// The test will be skipped if the current active set of multipliers
+	// contains any of the given multiplier names.
+	Excludes []multiplier.Name
+
+	// Actions contains the set of actions that should be
+	// executed as part of this test.
+	Actions action.Actions
+}
+
+func (test *Test) Execute(t testing.TB) {
+	ctx := context.Background()
+	var cancel context.CancelFunc
+	ctx, cancel = context.WithTimeout(ctx, 1*time.Second)
+
+	multiplier.Skip(t, test.Includes, test.Excludes)
+
+	// Prepend a start action if there is not already one present, this saves each test from
+	// having to redeclare the same initial action.
+	actions := prependStart(test.Actions)
+
+	actions = multiplier.Apply(actions)
+
+	testo.Log(t, actions)
+
+	testo.ExecuteS(actions, &state.State{
+		T:       t,
+		Ctx:     ctx,
+		Cancels: []context.CancelFunc{cancel},
+	})
+}
+
+func prependStart(actions action.Actions) action.Actions {
+	if hasType[*action.StartCli](actions) {
+		return actions
+	}
+
+	result := make(action.Actions, 1, len(actions)+1)
+	result[0] = action.Start()
+	result = append(result, actions...)
+
+	return result
+}
+
+// hasType returns true if any of the items in the given set are of the given type.
+func hasType[TAction any](actions action.Actions) bool {
+	for _, action := range actions {
+		_, ok := action.(TAction)
+		if ok {
+			return true
+		}
+	}
+
+	return false
+}

--- a/cli/test/multiplier/multiplier.go
+++ b/cli/test/multiplier/multiplier.go
@@ -1,0 +1,16 @@
+// Copyright 2025 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package multiplier
+
+import m "github.com/sourcenetwork/testo/multiplier"
+
+type Multiplier = m.Multiplier
+type Name = m.Name

--- a/cli/test/multiplier/txn.go
+++ b/cli/test/multiplier/txn.go
@@ -1,0 +1,89 @@
+// Copyright 2025 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package multiplier
+
+import (
+	"github.com/sourcenetwork/testo/multiplier"
+
+	"github.com/sourcenetwork/defradb/cli/test/action"
+)
+
+func init() {
+	multiplier.Register(&txnCommit{})
+}
+
+const TxnCommit Name = "txn-commit"
+
+type txnCommit struct{}
+
+var _ Multiplier = (*txnCommit)(nil)
+
+func (n *txnCommit) Name() Name {
+	return TxnCommit
+}
+
+func (n *txnCommit) Apply(source action.Actions) action.Actions {
+	lastStartIndex := 0
+	lastWriteIndex := 0
+
+	for i, a := range source {
+		switch a.(type) {
+		case *action.StartCli:
+			lastStartIndex = i
+
+		case *action.SchemaAdd:
+			lastWriteIndex = i
+
+		case *action.TxCreate:
+			// If the action set already contains txns we should not adjust it
+			return source
+		}
+	}
+
+	result := make(action.Actions, 0, len(source)+2)
+
+	for i, a := range source {
+		switch a.(type) {
+		case *action.StartCli:
+			result = append(result, a)
+			result = append(result, &action.TxCreate{})
+
+		default:
+			if argumentedAction, ok := a.(action.ArgmentedAction); ok && i > lastStartIndex {
+				result = append(result, action.WithTxn(argumentedAction))
+			} else {
+				result = append(result, a)
+			}
+		}
+	}
+
+	result = append(result, &action.TxCommit{})
+
+	for i, a := range source {
+		if i <= lastStartIndex {
+			continue
+		}
+
+		if i <= lastWriteIndex {
+			continue
+		}
+
+		switch a.(type) {
+		// Append orginal, read-only actions that occured after the last write action,
+		// after the transaction has been commited.  This allows the automatic of whether
+		// or not the transaction-state has been persisted.
+		case *action.CollectionDescribe:
+			result = append(result, a)
+		}
+	}
+
+	return result
+}

--- a/cli/test/multiplier/txn.go
+++ b/cli/test/multiplier/txn.go
@@ -20,6 +20,23 @@ func init() {
 	multiplier.Register(&txnCommit{})
 }
 
+// The TxnCommit multiplier adapts tests to cover the commiting of a single transaction.
+//
+// It will ensure that any write actions are reflected within the transaction scope pre-commit,
+// and will ensure that those writes are later persisted in the backing store after transaction
+// commit.
+//
+// It does this by:
+//   - Creating a new new transaction immediately after the last [action.StartCli] action.
+//   - Scoping any following actions that implement the [action.AugmentedAction] interface to the
+//     new transaction.
+//   - Creating a [action.TxCommit] action to commit the transaction.
+//   - Duplicating the original read actions occuring after the last write action to re-execute them
+//     outside of the transaction scope following commit.
+//
+// Whether or not an action is a 'read' or 'write' is currently handled by switches within this
+// implementation, new action types will need to amend these switches should they wish to take
+// advantage of this multiplier.  Long term we should find a better solution.
 const TxnCommit Name = "txn-commit"
 
 type txnCommit struct{}

--- a/cli/test/multiplier/txn.go
+++ b/cli/test/multiplier/txn.go
@@ -57,8 +57,8 @@ func (n *txnCommit) Apply(source action.Actions) action.Actions {
 			result = append(result, &action.TxCreate{})
 
 		default:
-			if argumentedAction, ok := a.(action.ArgmentedAction); ok && i > lastStartIndex {
-				result = append(result, action.WithTxn(argumentedAction))
+			if augmentedAction, ok := a.(action.AugmentedAction); ok && i > lastStartIndex {
+				result = append(result, action.WithTxn(augmentedAction))
 			} else {
 				result = append(result, a)
 			}

--- a/cli/test/multiplier/txn.go
+++ b/cli/test/multiplier/txn.go
@@ -95,8 +95,8 @@ func (n *txnCommit) Apply(source action.Actions) action.Actions {
 
 		switch a.(type) {
 		// Append orginal, read-only actions that occured after the last write action,
-		// after the transaction has been commited.  This allows the automatic of whether
-		// or not the transaction-state has been persisted.
+		// after the transaction has been commited.  This allows the automatic coverage
+		// of whether or not the transaction-state has been persisted.
 		case *action.CollectionDescribe:
 			result = append(result, a)
 		}

--- a/cli/test/state/state.go
+++ b/cli/test/state/state.go
@@ -1,0 +1,31 @@
+// Copyright 2025 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package state
+
+import (
+	"context"
+	"testing"
+)
+
+type State struct {
+	Ctx     context.Context
+	Cancels []context.CancelFunc
+	T       testing.TB
+
+	// The root directory in which the defra config file should exist.
+	RootDir string
+
+	// The base url to the http endpoints.
+	Url string
+
+	// The set of available transaction ids.
+	Txns []uint64
+}

--- a/cli/test/state/state.go
+++ b/cli/test/state/state.go
@@ -16,9 +16,8 @@ import (
 )
 
 type State struct {
-	Ctx     context.Context
-	Cancels []context.CancelFunc
-	T       testing.TB
+	Ctx context.Context
+	T   testing.TB
 
 	// The root directory in which the defra config file should exist.
 	RootDir string

--- a/docs/website/references/cli/defradb_start.md
+++ b/docs/website/references/cli/defradb_start.md
@@ -13,6 +13,7 @@ defradb start [flags]
 ### Options
 
 ```
+      --acp-type string               Specify the acp engine to use (supported: none (default), local, source-hub)
       --allowed-origins stringArray   List of origins to allow for CORS requests
       --default-key-type string       Default key type to generate new node identity if one doesn't exist in the keyring. Valid values are 'secp256k1' and 'ed25519'. If not specified, the default key type will be 'secp256k1'. (default "secp256k1")
       --development                   Enables a set of features that make development easier but should not be enabled in production:

--- a/go.mod
+++ b/go.mod
@@ -50,6 +50,7 @@ require (
 	github.com/sourcenetwork/graphql-go v0.7.10-0.20241003221550-224346887b4a
 	github.com/sourcenetwork/immutable v0.3.0
 	github.com/sourcenetwork/sourcehub v0.2.1-0.20250310083845-94a8142548bf
+	github.com/sourcenetwork/testo v0.1.0
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.6
 	github.com/spf13/viper v1.20.0

--- a/go.sum
+++ b/go.sum
@@ -1867,6 +1867,8 @@ github.com/sourcenetwork/raccoondb/v2 v2.0.0 h1:Gb0SjsZUbrbkHCEg7PyyNs0+2IzPxjE/
 github.com/sourcenetwork/raccoondb/v2 v2.0.0/go.mod h1:tPKAWHUgYcSoXNMt01iWJ+Y51AQYc2knY93IjmmbejY=
 github.com/sourcenetwork/sourcehub v0.2.1-0.20250310083845-94a8142548bf h1:AFak3vTANR+TH0yOhU/78fQa8UWyEJItk27roxJmf4Q=
 github.com/sourcenetwork/sourcehub v0.2.1-0.20250310083845-94a8142548bf/go.mod h1:0R571ioIrJSiuqLVD2YwyxCt+EMGI/r9ZF/CHj75/5U=
+github.com/sourcenetwork/testo v0.1.0 h1:mGhNDMOu6qvBTodlfPwy9NH1X4pOSc9AQ6mbOdqbmIg=
+github.com/sourcenetwork/testo v0.1.0/go.mod h1:CwCk0OPI7XLc0ypBS2QVoCtwOxyybv5x8gJxDkNCd14=
 github.com/sourcenetwork/zanzi v0.3.1-0.20250119215940-5b0336b71030 h1:MV+7W7HyJyyyKqPGk6A858xOw3ixXHyFW/nuHIXiJT4=
 github.com/sourcenetwork/zanzi v0.3.1-0.20250119215940-5b0336b71030/go.mod h1:A/KKCfhcKHKhdqL41aKGue7KtJNdGY8DlLpG6/Vh4QI=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=


### PR DESCRIPTION
## Relevant issue(s)

Resolves #3569

## Description

Adds the example CLI integration tests using new test framework.

Largely as seen in the demo last week, but with a little more polish.  I think it is good to commit these now and then we can expand them as/when we feel like, and use it as an example for other user-facing stuff (like http).

I have not added the txn-commit multiplier to the CI, as the workflow test files are fairly coupled to executing all tests in the entire repository and I wanted to limit scope here. 

## Tasks

- [x] The testing repo dependency is currently a local, relative, path and needs to be pointed at https://github.com/sourcenetwork/testing when https://github.com/sourcenetwork/testing/pull/1 gets merged.
- [x] Link this to a proper issue if/when https://github.com/sourcenetwork/testing/pull/1 is merged
