### PR TITLE
test(i): Wait for database to close before progressing

### DIFF
--- a/cli/test/action/start.go
+++ b/cli/test/action/start.go
@@ -40,7 +40,7 @@ func (a *StartCli) Execute() {
 	logPrefix := "Providing GraphQL endpoint at "
 	exampleUrl := "http://127.0.0.1:42571"
 
-	logLine, err := executeUntil(a.s.Ctx, args, logPrefix)
+	logLine, err := executeUntil(a.s.Ctx, a.s, args, logPrefix)
 
 	startIndex := strings.Index(logLine, logPrefix)
 	// Take the url from the logs so that it may be passed into other commands later.

--- a/cli/test/integration/test.go
+++ b/cli/test/integration/test.go
@@ -57,10 +57,14 @@ func (test *Test) Execute(t testing.TB) {
 
 	testo.Log(t, actions)
 
-	testo.ExecuteS(actions, &state.State{
-		T:   t,
-		Ctx: ctx,
-	})
+	state := &state.State{
+		T:    t,
+		Ctx:  ctx,
+		Wait: func() {},
+	}
+	testo.ExecuteS(actions, state)
+
+	state.Wait()
 }
 
 func prependStart(actions action.Actions) action.Actions {

--- a/cli/test/state/state.go
+++ b/cli/test/state/state.go
@@ -18,6 +18,12 @@ import (
 type State struct {
 	Ctx context.Context
 	T   testing.TB
+	// Wait must be called at the end of the test execution, to block
+	// continuation of the thread until Wait completes.
+	//
+	// Actions that do stuff that must be waited on before the next test
+	// begins (such as mutating global state) should append to this function.
+	Wait func()
 
 	// The root directory in which the defra config file should exist.
 	RootDir string


### PR DESCRIPTION
## Relevant issue(s)

Resolves #3592

## Description

Wait for the database to close before progressing to the next test.

Previously the database would close in the background while the next test began, this created a race condition when setting `os.Stderr`.

It was not noticed earlier as I only added a single example test per package - the bug surfaces when there are at least 2.

Credit to Chris, as he suffered with this bug for a while and was a bug help in figuring out where it was. 

## How has this been tested?

I added temporary tests to the package and ran with the `-race` flag.
