### PR TITLE
fix: Prevent infinite float values in documents

### DIFF
--- a/client/errors.go
+++ b/client/errors.go
@@ -45,6 +45,7 @@ const (
 	errEmptyModelForEmbedding              string = "embedding Model cannot be empty"
 	errUnknownEmbeddingProvider            string = "unknown embedding provider"
 	errEmbeddingFieldEmbedding             string = "embedding fields cannot refer to self or another embedding field"
+	errInfiniteFloatValue                  string = "field %s must not be NaN, Inf, or -Inf"
 )
 
 // Errors returnable from this package.
@@ -241,4 +242,8 @@ func NewErrUnknownEmbeddingProvider(provider string) error {
 
 func NewErrEmbeddingFieldEmbedding(fieldName string) error {
 	return errors.New(errEmbeddingFieldEmbedding, errors.NewKV("Field", fieldName))
+}
+
+func NewErrInfiniteFloatValue(fieldName string) error {
+	return errors.New(fmt.Sprintf(errInfiniteFloatValue, fieldName))
 }

--- a/http/client_collection.go
+++ b/http/client_collection.go
@@ -148,6 +148,7 @@ func (c *Collection) Update(
 	ctx context.Context,
 	doc *client.Document,
 ) error {
+
 	if !c.Description().Name.HasValue() {
 		return client.ErrOperationNotPermittedOnNamelessCols
 	}
@@ -158,6 +159,7 @@ func (c *Collection) Update(
 	if err != nil {
 		return err
 	}
+
 	req, err := http.NewRequestWithContext(ctx, http.MethodPatch, methodURL.String(), bytes.NewBuffer(body))
 	if err != nil {
 		return err

--- a/internal/core/crdt/errors.go
+++ b/internal/core/crdt/errors.go
@@ -33,8 +33,9 @@ var (
 	ErrEncodingPriority    = errors.New("error encoding priority")
 	ErrDecodingPriority    = errors.New("error decoding priority")
 	// ErrMismatchedMergeType - Tying to merge two ReplicatedData of different types
-	ErrMismatchedMergeType    = errors.New("given type to merge does not match source")
-	ErrUnsupportedCounterType = errors.New(errUnsupportedCounterType)
+	ErrMismatchedMergeType              = errors.New("given type to merge does not match source")
+	ErrUnsupportedCounterType           = errors.New(errUnsupportedCounterType)
+	errCounterInfiniteOverflowOperation = errors.New("operation results in a NaN, Inf, or -Inf value")
 )
 
 // NewErrFailedToGetPriority returns an error indicating that the priority could not be retrieved.

--- a/internal/db/collection.go
+++ b/internal/db/collection.go
@@ -576,6 +576,7 @@ func (c *collection) Save(
 	ctx context.Context,
 	doc *client.Document,
 ) error {
+
 	ctx, span := tracer.Start(ctx)
 	defer span.End()
 
@@ -681,6 +682,7 @@ func (c *collection) save(
 		}
 
 		if val.IsDirty() {
+
 			fieldKey, fieldExists := c.tryGetFieldKey(primaryKey, k)
 
 			if !fieldExists {

--- a/internal/db/collection_index.go
+++ b/internal/db/collection_index.go
@@ -143,6 +143,7 @@ func (c *collection) updateIndexedDoc(
 	if err != nil {
 		return err
 	}
+
 	// TODO-ACP: https://github.com/sourcenetwork/defradb/issues/2365 - ACP <> Indexing, possibly also check
 	// and handle the case of when oldDoc == nil (will be nil if inaccessible document).
 	oldDoc, err := c.get(


### PR DESCRIPTION
## Relevant issue(s)

Resolves #2569

## Description
It was possible to store an integer so large, or so largely negative, that it overflowed and was stored as `Inf` or `-Inf`. This resulted in future Updates to silently fail, and future Get requests to fail with an error. Both behaviors are undesirable. The proposed solution in this fix is to explicitly check that floats are not `NaN`, `Inf`, or `-Inf` when Creating or Updating a document. The proposed solution also adds logic to check for an overflow when incrementing a PNCounter.

**This is still in progress, do not merge.**

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [ ] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [ ] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

I have written a set of tests inside `2569_test.go`. These tests do the following:

- Prevent creation of a document with a positively infinite float value
- Prevent creation of a document with a negatively infinite float value
- Prevent the updating of a document that would set a value to `Inf`
- Prevent the updating of a document that would set a value to `-Inf`
- Prevent the updating of a document that would increment a PNCounter to `Inf`
- Prevent the updating of a document that would decrement a PNCounter to `-Inf`

Specify the platform(s) on which this was tested:
- Windows
