### PR TITLE
fix: PeerInfo sync issue

### DIFF
--- a/net/errors.go
+++ b/net/errors.go
@@ -29,12 +29,13 @@ const (
 )
 
 var (
-	ErrPeerConnectionWaitTimout = errors.New("waiting for peer connection timed out")
-	ErrPubSubWaitTimeout        = errors.New("waiting for pubsub timed out")
-	ErrPushLogWaitTimeout       = errors.New("waiting for pushlog timed out")
-	ErrNilDB                    = errors.New("database object can't be nil")
-	ErrNilUpdateChannel         = errors.New("tried to subscribe to update channel, but update channel is nil")
-	ErrCheckingForExistingBlock = errors.New(errCheckingForExistingBlock)
+	ErrPeerConnectionWaitTimout  = errors.New("waiting for peer connection timed out")
+	ErrPubSubWaitTimeout         = errors.New("waiting for pubsub timed out")
+	ErrPushLogWaitTimeout        = errors.New("waiting for pushlog timed out")
+	ErrNilDB                     = errors.New("database object can't be nil")
+	ErrNilUpdateChannel          = errors.New("tried to subscribe to update channel, but update channel is nil")
+	ErrCheckingForExistingBlock  = errors.New(errCheckingForExistingBlock)
+	ErrTimeoutWaitingForPeerInfo = errors.New("timeout waiting for peer info")
 )
 
 func NewErrPushLog(inner error, kv ...errors.KV) error {

--- a/net/peer.go
+++ b/net/peer.go
@@ -24,6 +24,7 @@ import (
 	blocks "github.com/ipfs/go-block-format"
 	gostream "github.com/libp2p/go-libp2p-gostream"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	libp2pevent "github.com/libp2p/go-libp2p/core/event"
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/routing"
@@ -184,6 +185,20 @@ func NewPeer(
 			log.ErrorE("Fatal P2P RPC server error", err)
 		}
 	}()
+
+	// There is a possibility for the PeerInfo event to trigger before the PeerInfo has been set for the host.
+	// To avoid this, we wait for the host to indicate that its local address has been updated.
+	sub, err := h.EventBus().Subscribe(&libp2pevent.EvtLocalAddressesUpdated{})
+	if err != nil {
+		return nil, err
+	}
+	select {
+	case <-sub.Out():
+		break
+	case <-time.After(5 * time.Second):
+		// This can only happen if the listening address has been mistakenly set to a zero value.
+		return nil, ErrTimeoutWaitingForPeerInfo
+	}
 
 	bus.Publish(event.NewMessage(event.PeerInfoName, event.PeerInfo{Info: p.PeerInfo()}))
 


### PR DESCRIPTION
## Relevant issue(s)

Resolves #3605 

## Description

This PR fixes an issue where the PeerInfo sent to DB was sometimes not established before being sent which cased issues on node restart. This is primarily an issue that exists in tests but could also happen on embedded usecases.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

make test

Specify the platform(s) on which this was tested:
- MacOS
