### PR TITLE
feat: Configure fallback signer

### DIFF
--- a/cli/config.go
+++ b/cli/config.go
@@ -55,6 +55,7 @@ var configFlags = map[string]string{
 	"store":                      "datastore.store",
 	"no-encryption":              "datastore.noencryption",
 	"no-signing":                 "datastore.nosigning",
+	"use-fallback-signer":        "datastore.usefallbacksigner",
 	"default-key-type":           "datastore.defaultkeytype",
 	"valuelogfilesize":           "datastore.badger.valuelogfilesize",
 	"peers":                      "net.peers",

--- a/cli/start.go
+++ b/cli/start.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/sourcenetwork/immutable"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 
 	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/crypto"
@@ -132,7 +133,7 @@ func MakeStartCommand() *cobra.Command {
 					}
 				}
 
-				opts, err = getOrCreateIdentity(kr, opts, cfg.GetString("datastore.defaultkeytype"))
+				opts, err = getOrCreateIdentity(kr, opts, cfg)
 				if err != nil {
 					return err
 				}
@@ -147,6 +148,8 @@ func MakeStartCommand() *cobra.Command {
 					opts = append(opts, node.WithTxnSigner(immutable.Some[node.TxSigner](signer)))
 				}
 			}
+
+			opts = append(opts, db.WithEnabledSigning(!cfg.GetBool("datastore.nosigning")))
 
 			isDevMode := cfg.GetBool("development")
 			http.IsDevMode = isDevMode
@@ -286,6 +289,10 @@ func MakeStartCommand() *cobra.Command {
 		"no-signing",
 		cfg.GetBool(configFlags["no-signing"]),
 		"Disable signing of commits.")
+	cmd.Flags().Bool(
+		"use-fallback-signer",
+		cfg.GetBool(configFlags["use-fallback-signer"]),
+		"Use the node's identity as a fallback signer if a request identity does not have a private key. This is relevant when creating or updating documents via HTTP.")
 	cmd.Flags().String(
 		"default-key-type",
 		cfg.GetString(configFlags["default-key-type"]),
@@ -342,18 +349,19 @@ func getOrCreatePeerKey(kr keyring.Keyring, opts []node.Option) ([]node.Option, 
 	return append(opts, net.WithPrivateKey(peerKey)), nil
 }
 
-func getOrCreateIdentity(kr keyring.Keyring, opts []node.Option, keyTypeToCreate string) ([]node.Option, error) {
+func getOrCreateIdentity(kr keyring.Keyring, opts []node.Option, cfg *viper.Viper) ([]node.Option, error) {
 	identityBytes, err := kr.Get(nodeIdentityKeyName)
 	if err != nil {
 		if !errors.Is(err, keyring.ErrNotFound) {
 			return nil, err
 		}
-		ident, err := generateIdentity(keyTypeToCreate)
+		keyType := cfg.GetString("datastore.defaultkeytype")
+		ident, err := generateIdentity(keyType)
 		if err != nil {
 			return nil, err
 		}
 		rawKey := ident.PrivateKey.Raw()
-		err = kr.Set(nodeIdentityKeyName, append([]byte(keyTypeToCreate+":"), rawKey...))
+		err = kr.Set(nodeIdentityKeyName, append([]byte(keyType+":"), rawKey...))
 		if err != nil {
 			return nil, err
 		}
@@ -368,7 +376,7 @@ func getOrCreateIdentity(kr keyring.Keyring, opts []node.Option, keyTypeToCreate
 		if err != nil {
 			return nil, err
 		}
-		return getOrCreateIdentity(kr, opts, keyTypeToCreate)
+		return getOrCreateIdentity(kr, opts, cfg)
 	}
 	keyType := string(identityBytes[:sepPos])
 	privateKey, err := crypto.PrivateKeyFromBytes(crypto.KeyType(keyType), identityBytes[sepPos+1:])
@@ -378,6 +386,10 @@ func getOrCreateIdentity(kr keyring.Keyring, opts []node.Option, keyTypeToCreate
 	ident, err := identity.FromPrivateKey(privateKey)
 	if err != nil {
 		return nil, err
+	}
+
+	if cfg.GetBool("datastore.usefallbacksigner") {
+		opts = append(opts, db.WithFallbackSigner(ident))
 	}
 
 	return append(opts, db.WithNodeIdentity(ident)), nil

--- a/cli/start.go
+++ b/cli/start.go
@@ -292,7 +292,8 @@ func MakeStartCommand() *cobra.Command {
 	cmd.Flags().Bool(
 		"use-fallback-signer",
 		cfg.GetBool(configFlags["use-fallback-signer"]),
-		"Use the node's identity as a fallback signer if a request identity does not have a private key. This is relevant when creating or updating documents via HTTP.")
+		"Use the node's identity as a fallback signer if a request identity does not have a private key. "+
+			"This is relevant when creating or updating documents via HTTP.")
 	cmd.Flags().String(
 		"default-key-type",
 		cfg.GetString(configFlags["default-key-type"]),

--- a/docs/website/references/cli/defradb_start.md
+++ b/docs/website/references/cli/defradb_start.md
@@ -31,6 +31,7 @@ defradb start [flags]
       --pubkeypath string                 Path to the public key for tls
       --replicator-retry-intervals ints   Retry intervals for the replicator. Format is a comma-separated list of durations. Example: 10,20,40,80,160,320 (default [30,60,120,240,480,960,1920])
       --store string                      Specify the datastore to use (supported: badger, memory) (default "badger")
+      --use-fallback-signer               Use the node's identity as a fallback signer if a request identity does not have a private key. This is relevant when creating or updating documents via HTTP.
       --valuelogfilesize int              Specify the datastore value log file size (in bytes). In memory size will be 2*valuelogfilesize (default 1073741824)
 ```
 

--- a/internal/db/collection.go
+++ b/internal/db/collection.go
@@ -664,7 +664,7 @@ func (c *collection) save(
 	})
 
 	if !c.db.signingDisabled {
-		ctx = clock.ContextWithEnabledSigning(ctx)
+		ctx = clock.ContextWithSigning(ctx, c.db.fallbackSigner)
 	}
 
 	// New batch transaction/store (optional/todo)

--- a/internal/db/collection.go
+++ b/internal/db/collection.go
@@ -655,7 +655,10 @@ func (c *collection) save(
 	}
 
 	if !c.db.signingDisabled {
-		ctx = clock.ContextWithSigning(ctx, c.db.fallbackSigner)
+		ctx = clock.ContextWithEnabledSigning(ctx)
+		if c.db.fallbackSigner.HasValue() {
+			ctx = clock.ContextWithFallbackSigner(ctx, c.db.fallbackSigner.Value())
+		}
 	}
 
 	// NOTE: We delay the final Clean() call until we know

--- a/internal/db/collection.go
+++ b/internal/db/collection.go
@@ -654,6 +654,10 @@ func (c *collection) save(
 		ctx = identity.WithContext(ctx, c.db.nodeIdentity)
 	}
 
+	if !c.db.signingDisabled {
+		ctx = clock.ContextWithSigning(ctx, c.db.fallbackSigner)
+	}
+
 	// NOTE: We delay the final Clean() call until we know
 	// the commit on the transaction is successful. If we didn't
 	// wait, and just did it here, then *if* the commit fails down
@@ -662,10 +666,6 @@ func (c *collection) save(
 	txn.OnSuccess(func() {
 		doc.Clean()
 	})
-
-	if !c.db.signingDisabled {
-		ctx = clock.ContextWithSigning(ctx, c.db.fallbackSigner)
-	}
 
 	// New batch transaction/store (optional/todo)
 	// Ensute/Set doc object marker

--- a/internal/db/collection_delete.go
+++ b/internal/db/collection_delete.go
@@ -152,7 +152,10 @@ func (c *collection) applyDelete(
 	}
 
 	if !c.db.signingDisabled {
-		ctx = clock.ContextWithSigning(ctx, c.db.fallbackSigner)
+		ctx = clock.ContextWithEnabledSigning(ctx)
+		if c.db.fallbackSigner.HasValue() {
+			ctx = clock.ContextWithFallbackSigner(ctx, c.db.fallbackSigner.Value())
+		}
 	}
 
 	merkleCRDT := merklecrdt.NewMerkleCompositeDAG(

--- a/internal/db/collection_delete.go
+++ b/internal/db/collection_delete.go
@@ -14,11 +14,13 @@ import (
 	"context"
 
 	"github.com/sourcenetwork/defradb/acp"
+	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/event"
 	"github.com/sourcenetwork/defradb/internal/core"
 	coreblock "github.com/sourcenetwork/defradb/internal/core/block"
 	"github.com/sourcenetwork/defradb/internal/keys"
+	"github.com/sourcenetwork/defradb/internal/merkle/clock"
 	merklecrdt "github.com/sourcenetwork/defradb/internal/merkle/crdt"
 )
 
@@ -143,6 +145,15 @@ func (c *collection) applyDelete(
 	}
 
 	txn := mustGetContextTxn(ctx)
+
+	ident := identity.FromContext(ctx)
+	if !ident.HasValue() && c.db.nodeIdentity.HasValue() {
+		ctx = identity.WithContext(ctx, c.db.nodeIdentity)
+	}
+
+	if !c.db.signingDisabled {
+		ctx = clock.ContextWithSigning(ctx, c.db.fallbackSigner)
+	}
 
 	merkleCRDT := merklecrdt.NewMerkleCompositeDAG(
 		txn,

--- a/internal/db/config.go
+++ b/internal/db/config.go
@@ -28,6 +28,7 @@ type dbOptions struct {
 	RetryIntervals []time.Duration
 	identity       immutable.Option[identity.Identity]
 	disableSigning bool
+	fallbackSigner immutable.Option[identity.Identity]
 }
 
 // defaultOptions returns the default db options.
@@ -75,5 +76,14 @@ func WithNodeIdentity(ident identity.Identity) Option {
 func WithEnabledSigning(value bool) Option {
 	return func(opts *dbOptions) {
 		opts.disableSigning = !value
+	}
+}
+
+// WithFallbackSigner sets the fallback signer for the db.
+// If a provided identity for any db request is missing the private key, the fallback signer will
+// be used to sign the block.
+func WithFallbackSigner(ident identity.Identity) Option {
+	return func(opts *dbOptions) {
+		opts.fallbackSigner = immutable.Some(ident)
 	}
 }

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -97,6 +97,9 @@ type DB struct {
 
 	// If true, block signing is disabled. By default, block signing is enabled.
 	signingDisabled bool
+
+	// The fallback signer for the db.
+	fallbackSigner immutable.Option[identity.Identity]
 }
 
 var _ client.DB = (*DB)(nil)
@@ -151,6 +154,7 @@ func newDB(
 
 	db.nodeIdentity = opts.identity
 	db.signingDisabled = opts.disableSigning
+	db.fallbackSigner = opts.fallbackSigner
 
 	if lens != nil {
 		lens.Init(db)

--- a/internal/merkle/clock/errors.go
+++ b/internal/merkle/clock/errors.go
@@ -18,31 +18,33 @@ import (
 )
 
 const (
-	errCreatingBlock            = "error creating block"
-	errWritingBlock             = "error writing block"
-	errGettingHeads             = "error getting heads"
-	errMergingDelta             = "error merging delta"
-	errAddingHead               = "error adding head"
-	errCheckingHead             = "error checking if is head"
-	errReplacingHead            = "error replacing head"
-	errCouldNotFindBlock        = "error checking for known block "
-	errFailedToGetNextQResult   = "failed to get next query result"
-	errCouldNotGetEncKey        = "could not get encryption key"
-	errUnsupportedKeyForSigning = "unsupported key type for signing"
+	errCreatingBlock                       = "error creating block"
+	errWritingBlock                        = "error writing block"
+	errGettingHeads                        = "error getting heads"
+	errMergingDelta                        = "error merging delta"
+	errAddingHead                          = "error adding head"
+	errCheckingHead                        = "error checking if is head"
+	errReplacingHead                       = "error replacing head"
+	errCouldNotFindBlock                   = "error checking for known block "
+	errFailedToGetNextQResult              = "failed to get next query result"
+	errCouldNotGetEncKey                   = "could not get encryption key"
+	errUnsupportedKeyForSigning            = "unsupported key type for signing"
+	errIdentityWithoutPrivateKeyForSigning = "identity does not have a private key for signing"
 )
 
 var (
-	ErrCreatingBlock          = errors.New(errCreatingBlock)
-	ErrWritingBlock           = errors.New(errWritingBlock)
-	ErrGettingHeads           = errors.New(errGettingHeads)
-	ErrMergingDelta           = errors.New(errMergingDelta)
-	ErrAddingHead             = errors.New(errAddingHead)
-	ErrCheckingHead           = errors.New(errCheckingHead)
-	ErrReplacingHead          = errors.New(errReplacingHead)
-	ErrCouldNotFindBlock      = errors.New(errCouldNotFindBlock)
-	ErrFailedToGetNextQResult = errors.New(errFailedToGetNextQResult)
-	ErrDecodingHeight         = errors.New("error decoding height")
-	ErrCouldNotGetEncKey      = errors.New(errCouldNotGetEncKey)
+	ErrCreatingBlock                       = errors.New(errCreatingBlock)
+	ErrWritingBlock                        = errors.New(errWritingBlock)
+	ErrGettingHeads                        = errors.New(errGettingHeads)
+	ErrMergingDelta                        = errors.New(errMergingDelta)
+	ErrAddingHead                          = errors.New(errAddingHead)
+	ErrCheckingHead                        = errors.New(errCheckingHead)
+	ErrReplacingHead                       = errors.New(errReplacingHead)
+	ErrCouldNotFindBlock                   = errors.New(errCouldNotFindBlock)
+	ErrFailedToGetNextQResult              = errors.New(errFailedToGetNextQResult)
+	ErrDecodingHeight                      = errors.New("error decoding height")
+	ErrCouldNotGetEncKey                   = errors.New(errCouldNotGetEncKey)
+	ErrIdentityWithoutPrivateKeyForSigning = errors.New(errIdentityWithoutPrivateKeyForSigning)
 )
 
 func NewErrCreatingBlock(inner error) error {

--- a/tests/integration/db.go
+++ b/tests/integration/db.go
@@ -151,6 +151,9 @@ func setupNode(s *state, opts ...node.Option) (*nodeState, error) {
 	opts = append(defaultOpts, opts...)
 
 	opts = append(opts, db.WithEnabledSigning(s.testCase.EnableSigning))
+	if s.testCase.FallbackSigner.HasValue() {
+		opts = append(opts, db.WithFallbackSigner(getIdentity(s, s.testCase.FallbackSigner)))
+	}
 
 	switch acpType {
 	case LocalACPType:

--- a/tests/integration/signature/fallback_signer_test.go
+++ b/tests/integration/signature/fallback_signer_test.go
@@ -13,9 +13,10 @@ package signature
 import (
 	"testing"
 
+	"github.com/sourcenetwork/immutable"
+
 	"github.com/sourcenetwork/defradb/internal/merkle/clock"
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
-	"github.com/sourcenetwork/immutable"
 )
 
 func TestSignature_IfIdentityHasNoPrivateKeyButFallbackSignerIsSet_ShouldUseFallbackSigner(t *testing.T) {

--- a/tests/integration/signature/fallback_signer_test.go
+++ b/tests/integration/signature/fallback_signer_test.go
@@ -1,0 +1,95 @@
+// Copyright 2025 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package signature
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/defradb/internal/merkle/clock"
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	"github.com/sourcenetwork/immutable"
+)
+
+func TestSignature_IfIdentityHasNoPrivateKeyButFallbackSignerIsSet_ShouldUseFallbackSigner(t *testing.T) {
+	test := testUtils.TestCase{
+		EnableSigning:  true,
+		FallbackSigner: testUtils.NodeIdentity(0),
+		// Fallback signer can be only tested with HTTP and CLI clients, because with Go client
+		// when providing an identity, it includes the private key.
+		SupportedClientTypes: immutable.Some([]testUtils.ClientType{
+			testUtils.HTTPClientType,
+			testUtils.CLIClientType,
+		}),
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users {
+						name: String
+						age: Int 
+					}`,
+			},
+			testUtils.CreateDoc{
+				Identity: testUtils.ClientIdentity(0),
+				DocMap: map[string]any{
+					"name": "John",
+					"age":  21,
+				},
+			},
+			testUtils.VerifyBlockSignature{
+				SignerIdentity: testUtils.NodeIdentity(0).Value(),
+				Cid:            "bafyreicwhd5s762awsrx6eowwqkkfpq7r5nnjosiru7blgaxo32wx6enp4",
+			},
+			testUtils.UpdateDoc{
+				Identity: testUtils.ClientIdentity(0),
+				Doc: `{
+					"age": 23
+				}`,
+			},
+			testUtils.VerifyBlockSignature{
+				SignerIdentity: testUtils.NodeIdentity(0).Value(),
+				Cid:            "bafyreidenvkbjuqismfbng463tfxsjmapvnvdyh4hmdx74ec5skj63ma2a",
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestSignature_IfIdentityHasNoPrivateKey_ShouldFail(t *testing.T) {
+	test := testUtils.TestCase{
+		EnableSigning: true,
+		// Fallback signer can be only tested with HTTP and CLI clients, because with Go client
+		// when providing an identity, it includes the private key.
+		SupportedClientTypes: immutable.Some([]testUtils.ClientType{
+			testUtils.HTTPClientType,
+			testUtils.CLIClientType,
+		}),
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type Users {
+						name: String
+						age: Int 
+					}`,
+			},
+			testUtils.CreateDoc{
+				Identity: testUtils.ClientIdentity(0),
+				DocMap: map[string]any{
+					"name": "John",
+					"age":  21,
+				},
+				ExpectedError: clock.ErrIdentityWithoutPrivateKeyForSigning.Error(),
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/signature/verify_test.go
+++ b/tests/integration/signature/verify_test.go
@@ -48,6 +48,11 @@ func TestSignatureVerify_WithValidData_ShouldVerify(t *testing.T) {
 				SignerIdentity: testUtils.NodeIdentity(0).Value(),
 				Cid:            "bafyreidenvkbjuqismfbng463tfxsjmapvnvdyh4hmdx74ec5skj63ma2a",
 			},
+			testUtils.DeleteDoc{},
+			testUtils.VerifyBlockSignature{
+				SignerIdentity: testUtils.NodeIdentity(0).Value(),
+				Cid:            "bafyreih3xjkq7vmfxjajfshr56nbuw6p2bfx4ow4bqayoaih55wq26vsuq",
+			},
 		},
 	}
 

--- a/tests/integration/test_case.go
+++ b/tests/integration/test_case.go
@@ -79,6 +79,10 @@ type TestCase struct {
 	// IdentityTypes is a map of identity to key type.
 	// Use it to customize the key type that is used for identity and signing.
 	IdentityTypes map[Identity]crypto.KeyType
+
+	// FallbackSigner is the identity that will be used to sign blocks if provided identity
+	// is missing the private key. This is a case for HTTP
+	FallbackSigner immutable.Option[Identity]
 }
 
 // KMS contains the configuration for KMS to be used in the test


### PR DESCRIPTION
## Relevant issue(s)

Resolves https://github.com/sourcenetwork/defradb/issues/3607

## Description

Allow configuring fallback identity that is used when signing is activated and the identity provided for a request is missing the private key. This happens when requests are sent over HTTP where we do not pass private keys.

Sign deletion blocks (forgot to include it in the previous commits).