### PR TITLE
fix(i): Identity key storage on initial start

### DIFF
--- a/cli/start.go
+++ b/cli/start.go
@@ -363,7 +363,9 @@ func getOrCreateIdentity(kr keyring.Keyring, opts []node.Option, cfg *viper.Vipe
 			return nil, err
 		}
 		rawKey := ident.PrivateKey.Raw()
-		err = kr.Set(nodeIdentityKeyName, append([]byte(keyType+":"), rawKey...))
+		// Make sure the outerscope knows about the newly created identity
+		identityBytes = append([]byte(keyType+":"), rawKey...)
+		err = kr.Set(nodeIdentityKeyName, identityBytes)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #3626 

## Description

This PR fixes a small mistake that caused a misconfigured identity key to be stored when initially starting DefraDB. This should be better tested with the new integration test framework but it's currently lacking some functionalities. Will look into doing this after the release.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Manual start test

Specify the platform(s) on which this was tested:
- MacOS
