### PR TITLE
fix(i): Node identity as default instead of fallback signer

### DIFF
--- a/cli/config.go
+++ b/cli/config.go
@@ -55,7 +55,6 @@ var configFlags = map[string]string{
 	"store":                      "datastore.store",
 	"no-encryption":              "datastore.noencryption",
 	"no-signing":                 "datastore.nosigning",
-	"use-fallback-signer":        "datastore.usefallbacksigner",
 	"default-key-type":           "datastore.defaultkeytype",
 	"valuelogfilesize":           "datastore.badger.valuelogfilesize",
 	"peers":                      "net.peers",

--- a/cli/start.go
+++ b/cli/start.go
@@ -289,11 +289,6 @@ func MakeStartCommand() *cobra.Command {
 		"no-signing",
 		cfg.GetBool(configFlags["no-signing"]),
 		"Disable signing of commits.")
-	cmd.Flags().Bool(
-		"use-fallback-signer",
-		cfg.GetBool(configFlags["use-fallback-signer"]),
-		"Use the node's identity as a fallback signer if a request identity does not have a private key. "+
-			"This is relevant when creating or updating documents via HTTP.")
 	cmd.Flags().String(
 		"default-key-type",
 		cfg.GetString(configFlags["default-key-type"]),
@@ -390,10 +385,6 @@ func getOrCreateIdentity(kr keyring.Keyring, opts []node.Option, cfg *viper.Vipe
 	ident, err := identity.FromPrivateKey(privateKey)
 	if err != nil {
 		return nil, err
-	}
-
-	if cfg.GetBool("datastore.usefallbacksigner") {
-		opts = append(opts, db.WithFallbackSigner(ident))
 	}
 
 	return append(opts, db.WithNodeIdentity(ident)), nil

--- a/docs/website/references/cli/defradb_start.md
+++ b/docs/website/references/cli/defradb_start.md
@@ -31,7 +31,6 @@ defradb start [flags]
       --pubkeypath string                 Path to the public key for tls
       --replicator-retry-intervals ints   Retry intervals for the replicator. Format is a comma-separated list of whole number seconds. Example: 10,20,40,80,160,320 (default [30,60,120,240,480,960,1920])
       --store string                      Specify the datastore to use (supported: badger, memory) (default "badger")
-      --use-fallback-signer               Use the node's identity as a fallback signer if a request identity does not have a private key. This is relevant when creating or updating documents via HTTP.
       --valuelogfilesize int              Specify the datastore value log file size (in bytes). In memory size will be 2*valuelogfilesize (default 1073741824)
 ```
 

--- a/internal/db/collection.go
+++ b/internal/db/collection.go
@@ -650,7 +650,7 @@ func (c *collection) save(
 	txn := mustGetContextTxn(ctx)
 
 	ident := identity.FromContext(ctx)
-	if !ident.HasValue() && ident.Value().PrivateKey == nil && c.db.nodeIdentity.HasValue() {
+	if (!ident.HasValue() || ident.Value().PrivateKey == nil) && c.db.nodeIdentity.HasValue() {
 		ctx = identity.WithContext(ctx, c.db.nodeIdentity)
 	}
 

--- a/internal/db/collection.go
+++ b/internal/db/collection.go
@@ -650,15 +650,12 @@ func (c *collection) save(
 	txn := mustGetContextTxn(ctx)
 
 	ident := identity.FromContext(ctx)
-	if !ident.HasValue() && c.db.nodeIdentity.HasValue() {
+	if !ident.HasValue() && ident.Value().PrivateKey == nil && c.db.nodeIdentity.HasValue() {
 		ctx = identity.WithContext(ctx, c.db.nodeIdentity)
 	}
 
 	if !c.db.signingDisabled {
 		ctx = clock.ContextWithEnabledSigning(ctx)
-		if c.db.fallbackSigner.HasValue() {
-			ctx = clock.ContextWithFallbackSigner(ctx, c.db.fallbackSigner.Value())
-		}
 	}
 
 	// NOTE: We delay the final Clean() call until we know

--- a/internal/db/collection_delete.go
+++ b/internal/db/collection_delete.go
@@ -147,7 +147,7 @@ func (c *collection) applyDelete(
 	txn := mustGetContextTxn(ctx)
 
 	ident := identity.FromContext(ctx)
-	if !ident.HasValue() && ident.Value().PrivateKey == nil && c.db.nodeIdentity.HasValue() {
+	if (!ident.HasValue() || ident.Value().PrivateKey == nil) && c.db.nodeIdentity.HasValue() {
 		ctx = identity.WithContext(ctx, c.db.nodeIdentity)
 	}
 

--- a/internal/db/collection_delete.go
+++ b/internal/db/collection_delete.go
@@ -147,15 +147,12 @@ func (c *collection) applyDelete(
 	txn := mustGetContextTxn(ctx)
 
 	ident := identity.FromContext(ctx)
-	if !ident.HasValue() && c.db.nodeIdentity.HasValue() {
+	if !ident.HasValue() && ident.Value().PrivateKey == nil && c.db.nodeIdentity.HasValue() {
 		ctx = identity.WithContext(ctx, c.db.nodeIdentity)
 	}
 
 	if !c.db.signingDisabled {
 		ctx = clock.ContextWithEnabledSigning(ctx)
-		if c.db.fallbackSigner.HasValue() {
-			ctx = clock.ContextWithFallbackSigner(ctx, c.db.fallbackSigner.Value())
-		}
 	}
 
 	merkleCRDT := merklecrdt.NewMerkleCompositeDAG(

--- a/internal/db/config.go
+++ b/internal/db/config.go
@@ -28,7 +28,6 @@ type dbOptions struct {
 	RetryIntervals []time.Duration
 	identity       immutable.Option[identity.Identity]
 	disableSigning bool
-	fallbackSigner immutable.Option[identity.Identity]
 }
 
 // defaultOptions returns the default db options.
@@ -76,14 +75,5 @@ func WithNodeIdentity(ident identity.Identity) Option {
 func WithEnabledSigning(value bool) Option {
 	return func(opts *dbOptions) {
 		opts.disableSigning = !value
-	}
-}
-
-// WithFallbackSigner sets the fallback signer for the db.
-// If a provided identity for any db request is missing the private key, the fallback signer will
-// be used to sign the block.
-func WithFallbackSigner(ident identity.Identity) Option {
-	return func(opts *dbOptions) {
-		opts.fallbackSigner = immutable.Some(ident)
 	}
 }

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -97,9 +97,6 @@ type DB struct {
 
 	// If true, block signing is disabled. By default, block signing is enabled.
 	signingDisabled bool
-
-	// The fallback signer for the db.
-	fallbackSigner immutable.Option[identity.Identity]
 }
 
 var _ client.DB = (*DB)(nil)
@@ -154,7 +151,6 @@ func newDB(
 
 	db.nodeIdentity = opts.identity
 	db.signingDisabled = opts.disableSigning
-	db.fallbackSigner = opts.fallbackSigner
 
 	if lens != nil {
 		lens.Init(db)

--- a/internal/merkle/clock/errors.go
+++ b/internal/merkle/clock/errors.go
@@ -18,33 +18,31 @@ import (
 )
 
 const (
-	errCreatingBlock                       = "error creating block"
-	errWritingBlock                        = "error writing block"
-	errGettingHeads                        = "error getting heads"
-	errMergingDelta                        = "error merging delta"
-	errAddingHead                          = "error adding head"
-	errCheckingHead                        = "error checking if is head"
-	errReplacingHead                       = "error replacing head"
-	errCouldNotFindBlock                   = "error checking for known block "
-	errFailedToGetNextQResult              = "failed to get next query result"
-	errCouldNotGetEncKey                   = "could not get encryption key"
-	errUnsupportedKeyForSigning            = "unsupported key type for signing"
-	errIdentityWithoutPrivateKeyForSigning = "identity does not have a private key for signing"
+	errCreatingBlock            = "error creating block"
+	errWritingBlock             = "error writing block"
+	errGettingHeads             = "error getting heads"
+	errMergingDelta             = "error merging delta"
+	errAddingHead               = "error adding head"
+	errCheckingHead             = "error checking if is head"
+	errReplacingHead            = "error replacing head"
+	errCouldNotFindBlock        = "error checking for known block "
+	errFailedToGetNextQResult   = "failed to get next query result"
+	errCouldNotGetEncKey        = "could not get encryption key"
+	errUnsupportedKeyForSigning = "unsupported key type for signing"
 )
 
 var (
-	ErrCreatingBlock                       = errors.New(errCreatingBlock)
-	ErrWritingBlock                        = errors.New(errWritingBlock)
-	ErrGettingHeads                        = errors.New(errGettingHeads)
-	ErrMergingDelta                        = errors.New(errMergingDelta)
-	ErrAddingHead                          = errors.New(errAddingHead)
-	ErrCheckingHead                        = errors.New(errCheckingHead)
-	ErrReplacingHead                       = errors.New(errReplacingHead)
-	ErrCouldNotFindBlock                   = errors.New(errCouldNotFindBlock)
-	ErrFailedToGetNextQResult              = errors.New(errFailedToGetNextQResult)
-	ErrDecodingHeight                      = errors.New("error decoding height")
-	ErrCouldNotGetEncKey                   = errors.New(errCouldNotGetEncKey)
-	ErrIdentityWithoutPrivateKeyForSigning = errors.New(errIdentityWithoutPrivateKeyForSigning)
+	ErrCreatingBlock          = errors.New(errCreatingBlock)
+	ErrWritingBlock           = errors.New(errWritingBlock)
+	ErrGettingHeads           = errors.New(errGettingHeads)
+	ErrMergingDelta           = errors.New(errMergingDelta)
+	ErrAddingHead             = errors.New(errAddingHead)
+	ErrCheckingHead           = errors.New(errCheckingHead)
+	ErrReplacingHead          = errors.New(errReplacingHead)
+	ErrCouldNotFindBlock      = errors.New(errCouldNotFindBlock)
+	ErrFailedToGetNextQResult = errors.New(errFailedToGetNextQResult)
+	ErrDecodingHeight         = errors.New("error decoding height")
+	ErrCouldNotGetEncKey      = errors.New(errCouldNotGetEncKey)
 )
 
 func NewErrCreatingBlock(inner error) error {

--- a/tests/integration/db.go
+++ b/tests/integration/db.go
@@ -151,9 +151,6 @@ func setupNode(s *state, opts ...node.Option) (*nodeState, error) {
 	opts = append(defaultOpts, opts...)
 
 	opts = append(opts, db.WithEnabledSigning(s.testCase.EnableSigning))
-	if s.testCase.FallbackSigner.HasValue() {
-		opts = append(opts, db.WithFallbackSigner(getIdentity(s, s.testCase.FallbackSigner)))
-	}
 
 	switch acpType {
 	case LocalACPType:

--- a/tests/integration/signature/fallback_signer_test.go
+++ b/tests/integration/signature/fallback_signer_test.go
@@ -15,15 +15,13 @@ import (
 
 	"github.com/sourcenetwork/immutable"
 
-	"github.com/sourcenetwork/defradb/internal/merkle/clock"
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
 )
 
-func TestSignature_IfIdentityHasNoPrivateKeyButFallbackSignerIsSet_ShouldUseFallbackSigner(t *testing.T) {
+func TestSignature_IfIdentityHasNoPrivateKey_ShouldUseNodeIdentity(t *testing.T) {
 	test := testUtils.TestCase{
-		EnableSigning:  true,
-		FallbackSigner: testUtils.NodeIdentity(0),
-		// Fallback signer can be only tested with HTTP and CLI clients, because with Go client
+		EnableSigning: true,
+		// Default signer can be only tested with HTTP and CLI clients, because with Go client
 		// when providing an identity, it includes the private key.
 		SupportedClientTypes: immutable.Some([]testUtils.ClientType{
 			testUtils.HTTPClientType,
@@ -57,37 +55,6 @@ func TestSignature_IfIdentityHasNoPrivateKeyButFallbackSignerIsSet_ShouldUseFall
 			testUtils.VerifyBlockSignature{
 				SignerIdentity: testUtils.NodeIdentity(0).Value(),
 				Cid:            "bafyreidenvkbjuqismfbng463tfxsjmapvnvdyh4hmdx74ec5skj63ma2a",
-			},
-		},
-	}
-
-	testUtils.ExecuteTestCase(t, test)
-}
-
-func TestSignature_IfIdentityHasNoPrivateKey_ShouldFail(t *testing.T) {
-	test := testUtils.TestCase{
-		EnableSigning: true,
-		// Fallback signer can be only tested with HTTP and CLI clients, because with Go client
-		// when providing an identity, it includes the private key.
-		SupportedClientTypes: immutable.Some([]testUtils.ClientType{
-			testUtils.HTTPClientType,
-			testUtils.CLIClientType,
-		}),
-		Actions: []any{
-			testUtils.SchemaUpdate{
-				Schema: `
-					type Users {
-						name: String
-						age: Int 
-					}`,
-			},
-			testUtils.CreateDoc{
-				Identity: testUtils.ClientIdentity(0),
-				DocMap: map[string]any{
-					"name": "John",
-					"age":  21,
-				},
-				ExpectedError: clock.ErrIdentityWithoutPrivateKeyForSigning.Error(),
 			},
 		},
 	}

--- a/tests/integration/test_case.go
+++ b/tests/integration/test_case.go
@@ -79,10 +79,6 @@ type TestCase struct {
 	// IdentityTypes is a map of identity to key type.
 	// Use it to customize the key type that is used for identity and signing.
 	IdentityTypes map[Identity]crypto.KeyType
-
-	// FallbackSigner is the identity that will be used to sign blocks if provided identity
-	// is missing the private key. This is a case for HTTP
-	FallbackSigner immutable.Option[Identity]
 }
 
 // KMS contains the configuration for KMS to be used in the test


### PR DESCRIPTION
## Relevant issue(s)

Resolves #3628 

## Description

The PR revert the inclusion of the fallback signer configuration. There was a bug where if the request did not provide an identity, then the node identity would be used instead of the fallback signer. This was an opaque bug because in its current state, the fallback signer is always the node identity.

At standup we concluded that it would be best to just keep the node identity as the default at all times for now.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

make test and manual testing.

Specify the platform(s) on which this was tested:
- MacOS
