### PR TITLE
fix: Get indexes for a specific collection

### DIFF
--- a/http/handler_collection.go
+++ b/http/handler_collection.go
@@ -282,7 +282,7 @@ func (s *collectionHandler) GetIndexes(rw http.ResponseWriter, req *http.Request
 	}
 	indexes, err := col.GetIndexes(req.Context())
 	if err != nil {
-		responseJSON(rw, http.StatusBadRequest, errorResponse{err})
+		responseJSON(rw, http.StatusInternalServerError, errorResponse{err})
 		return
 	}
 	responseJSON(rw, http.StatusOK, indexes)

--- a/http/handler_collection.go
+++ b/http/handler_collection.go
@@ -274,15 +274,16 @@ func (s *collectionHandler) CreateIndex(rw http.ResponseWriter, req *http.Reques
 
 func (s *collectionHandler) GetIndexes(rw http.ResponseWriter, req *http.Request) {
 	store := mustGetContextClientStore(req)
-	indexesMap, err := store.GetAllIndexes(req.Context())
-
+	name := chi.URLParam(req, "name")
+	col, err := store.GetCollectionByName(req.Context(), name)
 	if err != nil {
 		responseJSON(rw, http.StatusBadRequest, errorResponse{err})
 		return
 	}
-	indexes := make([]client.IndexDescription, 0, len(indexesMap))
-	for _, index := range indexesMap {
-		indexes = append(indexes, index...)
+	indexes, err := col.GetIndexes(req.Context())
+	if err != nil {
+		responseJSON(rw, http.StatusBadRequest, errorResponse{err})
+		return
 	}
 	responseJSON(rw, http.StatusOK, indexes)
 }

--- a/tests/integration/index/create_get_test.go
+++ b/tests/integration/index/create_get_test.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/sourcenetwork/defradb/client"
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
-	"github.com/sourcenetwork/immutable"
 )
 
 func TestIndexGet_ShouldReturnListOfExistingIndexes(t *testing.T) {
@@ -59,16 +58,9 @@ func TestIndexGet_ShouldReturnListOfExistingIndexes(t *testing.T) {
 	testUtils.ExecuteTestCase(t, test)
 }
 
-// This test documents a bug where requesting the list of indexes for a given collection
-// returns the list of all indexes on the database. This happens over HTTP which affects
-// the CLI client as well.
 func TestIndexGet_GetIndexesForACollection_ReturnCollectionSpecificList(t *testing.T) {
 	test := testUtils.TestCase{
-		Description: "Getting indexes should return empty list if there are no indexes",
-		SupportedClientTypes: immutable.Some([]testUtils.ClientType{
-			testUtils.HTTPClientType,
-			testUtils.CLIClientType,
-		}),
+		Description: "Getting indexes for a collection should return only the indexes on that collection",
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
@@ -84,9 +76,7 @@ func TestIndexGet_GetIndexesForACollection_ReturnCollectionSpecificList(t *testi
 				`,
 			},
 			testUtils.GetIndexes{
-				// Asking for the indexes on User specifically
 				CollectionID: 0,
-				// Returns all indexes
 				ExpectedIndexes: []client.IndexDescription{
 					{
 						Name: "User_age_ASC",
@@ -99,6 +89,11 @@ func TestIndexGet_GetIndexesForACollection_ReturnCollectionSpecificList(t *testi
 						},
 						Unique: false,
 					},
+				},
+			},
+			testUtils.GetIndexes{
+				CollectionID: 1,
+				ExpectedIndexes: []client.IndexDescription{
 					{
 						Name: "Address_postalCode_ASC",
 						ID:   1,


### PR DESCRIPTION
## Relevant issue(s)

Resolves #3642 

## Description

This PR fixes a bug where the http handler for `GetIndexes` would call `GetAllIndexes` instead of collection specific indexes.

Note that the first commit documents the bug.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

make test

Specify the platform(s) on which this was tested:
- MacOS
