### PR TITLE
feat: Utilize secondary indexes for ordering

### DIFF
--- a/internal/db/collection_get.go
+++ b/internal/db/collection_get.go
@@ -72,7 +72,7 @@ func (c *collection) get(
 	df := c.newFetcher()
 	// initialize it with the primary index
 	err := df.Init(ctx, identity.FromContext(ctx), txn, c.db.acp, immutable.Option[client.IndexDescription]{},
-		c, fields, nil, nil, showDeleted)
+		c, fields, nil, nil, nil, showDeleted)
 	if err != nil {
 		_ = df.Close()
 		return nil, err

--- a/internal/db/collection_index.go
+++ b/internal/db/collection_index.go
@@ -340,6 +340,7 @@ func (c *collection) iterateAllDocs(
 		fields,
 		nil,
 		nil,
+		nil,
 		false,
 	)
 	if err != nil {

--- a/internal/db/fetcher/fetcher.go
+++ b/internal/db/fetcher/fetcher.go
@@ -60,6 +60,7 @@ type Fetcher interface {
 		col client.Collection,
 		fields []client.FieldDefinition,
 		filter *mapper.Filter,
+		ordering []mapper.OrderCondition,
 		docmapper *core.DocumentMapping,
 		showDeleted bool,
 	) error

--- a/internal/db/fetcher/indexer.go
+++ b/internal/db/fetcher/indexer.go
@@ -39,6 +39,7 @@ type indexFetcher struct {
 	indexIter     indexIterator
 	currentDocID  immutable.Option[string]
 	execInfo      *ExecInfo
+	ordering      []mapper.OrderCondition
 }
 
 var _ fetcher = (*indexFetcher)(nil)
@@ -54,6 +55,7 @@ func newIndexFetcher(
 	col client.Collection,
 	docMapper *core.DocumentMapping,
 	execInfo *ExecInfo,
+	ordering []mapper.OrderCondition,
 ) (*indexFetcher, error) {
 	f := &indexFetcher{
 		ctx:        ctx,
@@ -63,6 +65,7 @@ func newIndexFetcher(
 		indexDesc:  indexDesc,
 		fieldsByID: fieldsByID,
 		execInfo:   execInfo,
+		ordering:   ordering,
 	}
 
 	fieldsToCopy := make([]mapper.Field, 0, len(indexDesc.Fields))

--- a/internal/db/fetcher/indexer_iterators.go
+++ b/internal/db/fetcher/indexer_iterators.go
@@ -453,6 +453,9 @@ func (f *indexFetcher) tryCreateOrderedIndexIterator() (indexIterator, error) {
 	return nil, nil
 }
 
+// isIndexOrdered checks if the index is ordered by the first field in the ordering array.
+// The first return value specifies ordered-by field is indexed
+// The second one specifies if the index is ordered in the opposite direction to the given ordering, i.e. reversed.
 func (f *indexFetcher) isIndexOrdered() (bool, bool) {
 	if len(f.ordering) > 0 {
 		orderField, found := f.mapping.TryToFindNameFromIndex(f.ordering[0].FieldIndexes[0])

--- a/internal/db/fetcher/mocks/fetcher.go
+++ b/internal/db/fetcher/mocks/fetcher.go
@@ -148,17 +148,17 @@ func (_c *Fetcher_FetchNext_Call) RunAndReturn(run func(context.Context) (fetche
 	return _c
 }
 
-// Init provides a mock function with given fields: ctx, _a1, txn, _a3, index, col, fields, filter, docmapper, showDeleted
-func (_m *Fetcher) Init(ctx context.Context, _a1 immutable.Option[identity.Identity], txn datastore.Txn, _a3 immutable.Option[acp.ACP], index immutable.Option[client.IndexDescription], col client.Collection, fields []client.FieldDefinition, filter *mapper.Filter, docmapper *core.DocumentMapping, showDeleted bool) error {
-	ret := _m.Called(ctx, _a1, txn, _a3, index, col, fields, filter, docmapper, showDeleted)
+// Init provides a mock function with given fields: ctx, _a1, txn, _a3, index, col, fields, filter, ordering, docmapper, showDeleted
+func (_m *Fetcher) Init(ctx context.Context, _a1 immutable.Option[identity.Identity], txn datastore.Txn, _a3 immutable.Option[acp.ACP], index immutable.Option[client.IndexDescription], col client.Collection, fields []client.FieldDefinition, filter *mapper.Filter, ordering []mapper.OrderCondition, docmapper *core.DocumentMapping, showDeleted bool) error {
+	ret := _m.Called(ctx, _a1, txn, _a3, index, col, fields, filter, ordering, docmapper, showDeleted)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Init")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, immutable.Option[identity.Identity], datastore.Txn, immutable.Option[acp.ACP], immutable.Option[client.IndexDescription], client.Collection, []client.FieldDefinition, *mapper.Filter, *core.DocumentMapping, bool) error); ok {
-		r0 = rf(ctx, _a1, txn, _a3, index, col, fields, filter, docmapper, showDeleted)
+	if rf, ok := ret.Get(0).(func(context.Context, immutable.Option[identity.Identity], datastore.Txn, immutable.Option[acp.ACP], immutable.Option[client.IndexDescription], client.Collection, []client.FieldDefinition, *mapper.Filter, []mapper.OrderCondition, *core.DocumentMapping, bool) error); ok {
+		r0 = rf(ctx, _a1, txn, _a3, index, col, fields, filter, ordering, docmapper, showDeleted)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -180,15 +180,16 @@ type Fetcher_Init_Call struct {
 //   - col client.Collection
 //   - fields []client.FieldDefinition
 //   - filter *mapper.Filter
+//   - ordering []mapper.OrderCondition
 //   - docmapper *core.DocumentMapping
 //   - showDeleted bool
-func (_e *Fetcher_Expecter) Init(ctx interface{}, _a1 interface{}, txn interface{}, _a3 interface{}, index interface{}, col interface{}, fields interface{}, filter interface{}, docmapper interface{}, showDeleted interface{}) *Fetcher_Init_Call {
-	return &Fetcher_Init_Call{Call: _e.mock.On("Init", ctx, _a1, txn, _a3, index, col, fields, filter, docmapper, showDeleted)}
+func (_e *Fetcher_Expecter) Init(ctx interface{}, _a1 interface{}, txn interface{}, _a3 interface{}, index interface{}, col interface{}, fields interface{}, filter interface{}, ordering interface{}, docmapper interface{}, showDeleted interface{}) *Fetcher_Init_Call {
+	return &Fetcher_Init_Call{Call: _e.mock.On("Init", ctx, _a1, txn, _a3, index, col, fields, filter, ordering, docmapper, showDeleted)}
 }
 
-func (_c *Fetcher_Init_Call) Run(run func(ctx context.Context, _a1 immutable.Option[identity.Identity], txn datastore.Txn, _a3 immutable.Option[acp.ACP], index immutable.Option[client.IndexDescription], col client.Collection, fields []client.FieldDefinition, filter *mapper.Filter, docmapper *core.DocumentMapping, showDeleted bool)) *Fetcher_Init_Call {
+func (_c *Fetcher_Init_Call) Run(run func(ctx context.Context, _a1 immutable.Option[identity.Identity], txn datastore.Txn, _a3 immutable.Option[acp.ACP], index immutable.Option[client.IndexDescription], col client.Collection, fields []client.FieldDefinition, filter *mapper.Filter, ordering []mapper.OrderCondition, docmapper *core.DocumentMapping, showDeleted bool)) *Fetcher_Init_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(immutable.Option[identity.Identity]), args[2].(datastore.Txn), args[3].(immutable.Option[acp.ACP]), args[4].(immutable.Option[client.IndexDescription]), args[5].(client.Collection), args[6].([]client.FieldDefinition), args[7].(*mapper.Filter), args[8].(*core.DocumentMapping), args[9].(bool))
+		run(args[0].(context.Context), args[1].(immutable.Option[identity.Identity]), args[2].(datastore.Txn), args[3].(immutable.Option[acp.ACP]), args[4].(immutable.Option[client.IndexDescription]), args[5].(client.Collection), args[6].([]client.FieldDefinition), args[7].(*mapper.Filter), args[8].([]mapper.OrderCondition), args[9].(*core.DocumentMapping), args[10].(bool))
 	})
 	return _c
 }
@@ -198,7 +199,7 @@ func (_c *Fetcher_Init_Call) Return(_a0 error) *Fetcher_Init_Call {
 	return _c
 }
 
-func (_c *Fetcher_Init_Call) RunAndReturn(run func(context.Context, immutable.Option[identity.Identity], datastore.Txn, immutable.Option[acp.ACP], immutable.Option[client.IndexDescription], client.Collection, []client.FieldDefinition, *mapper.Filter, *core.DocumentMapping, bool) error) *Fetcher_Init_Call {
+func (_c *Fetcher_Init_Call) RunAndReturn(run func(context.Context, immutable.Option[identity.Identity], datastore.Txn, immutable.Option[acp.ACP], immutable.Option[client.IndexDescription], client.Collection, []client.FieldDefinition, *mapper.Filter, []mapper.OrderCondition, *core.DocumentMapping, bool) error) *Fetcher_Init_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/db/fetcher/mocks/utils.go
+++ b/internal/db/fetcher/mocks/utils.go
@@ -29,6 +29,7 @@ func NewStubbedFetcher(t *testing.T) *Fetcher {
 		mock.Anything,
 		mock.Anything,
 		mock.Anything,
+		mock.Anything,
 	).Maybe().Return(nil)
 	f.EXPECT().Start(mock.Anything, mock.Anything).Maybe().Return(nil)
 	f.EXPECT().FetchNext(mock.Anything).Maybe().Return(nil, nil)

--- a/internal/db/fetcher/versioned.go
+++ b/internal/db/fetcher/versioned.go
@@ -109,6 +109,7 @@ func (vf *VersionedFetcher) Init(
 	col client.Collection,
 	fields []client.FieldDefinition,
 	filter *mapper.Filter,
+	ordering []mapper.OrderCondition,
 	docmapper *core.DocumentMapping,
 	showDeleted bool,
 ) error {
@@ -172,6 +173,7 @@ func (vf *VersionedFetcher) Init(
 		col,
 		fields,
 		filter,
+		ordering,
 		docmapper,
 		showDeleted,
 	)

--- a/internal/db/fetcher/wrapper.go
+++ b/internal/db/fetcher/wrapper.go
@@ -40,6 +40,7 @@ type wrappingFetcher struct {
 	col         client.Collection
 	fields      []client.FieldDefinition
 	filter      *mapper.Filter
+	ordering    []mapper.OrderCondition
 	docMapper   *core.DocumentMapping
 	showDeleted bool
 }
@@ -59,6 +60,7 @@ func (f *wrappingFetcher) Init(
 	col client.Collection,
 	fields []client.FieldDefinition,
 	filter *mapper.Filter,
+	ordering []mapper.OrderCondition,
 	docMapper *core.DocumentMapping,
 	showDeleted bool,
 ) error {
@@ -69,6 +71,7 @@ func (f *wrappingFetcher) Init(
 	f.col = col
 	f.fields = fields
 	f.filter = filter
+	f.ordering = ordering
 	f.docMapper = docMapper
 	f.showDeleted = showDeleted
 
@@ -125,7 +128,7 @@ func (f *wrappingFetcher) Start(ctx context.Context, prefixes ...keys.Walkable) 
 	var top fetcher
 	if f.index.HasValue() {
 		indexFetcher, err := newIndexFetcher(ctx, f.txn, fieldsByID, f.index.Value(), f.filter, f.col,
-			f.docMapper, &f.execInfo)
+			f.docMapper, &f.execInfo, f.ordering)
 		if err != nil {
 			return err
 		}

--- a/internal/lens/fetcher.go
+++ b/internal/lens/fetcher.go
@@ -71,6 +71,7 @@ func (f *lensedFetcher) Init(
 	col client.Collection,
 	fields []client.FieldDefinition,
 	filter *mapper.Filter,
+	ordering []mapper.OrderCondition,
 	docmapper *core.DocumentMapping,
 	showDeleted bool,
 ) error {
@@ -123,6 +124,7 @@ historyLoop:
 		col,
 		innerFetcherFields,
 		filter,
+		ordering,
 		docmapper,
 		showDeleted,
 	)

--- a/internal/planner/order.go
+++ b/internal/planner/order.go
@@ -62,9 +62,6 @@ type orderNode struct {
 	// consuming and sorting data.
 	needSort bool
 
-	// indicates if we should ignore sorting
-	ignoreSorting bool
-
 	execInfo orderExecInfo
 }
 
@@ -99,19 +96,6 @@ func (n *orderNode) Init() error {
 	n.needSort = true
 	n.orderStrategy = nil
 
-	scanNode := getScanNode(n.plan)
-	if scanNode != nil && scanNode.index.HasValue() {
-		colDesc := scanNode.col.Description()
-		orderField := colDesc.Fields[n.ordering[0].FieldIndexes[0]]
-		indexes := colDesc.GetIndexesOnField(orderField.Name)
-		if len(indexes) == 0 {
-			return nil
-		}
-		if indexes[0].ID == scanNode.index.Value().ID {
-			n.ignoreSorting = true
-		}
-	}
-
 	return n.plan.Init()
 }
 
@@ -120,9 +104,6 @@ func (n *orderNode) Start() error { return n.plan.Start() }
 func (n *orderNode) Prefixes(prefixes []keys.Walkable) { n.plan.Prefixes(prefixes) }
 
 func (n *orderNode) Value() core.Doc {
-	if n.ignoreSorting {
-		return n.plan.Value()
-	}
 	return n.valueIter.Value()
 }
 
@@ -180,10 +161,6 @@ func (n *orderNode) Explain(explainType request.ExplainType) (map[string]any, er
 }
 
 func (n *orderNode) Next() (bool, error) {
-	if n.ignoreSorting {
-		return n.plan.Next()
-	}
-
 	n.execInfo.iterations++
 
 	for n.needSort {

--- a/internal/planner/scan.go
+++ b/internal/planner/scan.go
@@ -47,8 +47,9 @@ type scanNode struct {
 
 	prefixes []keys.Walkable
 
-	filter *mapper.Filter
-	slct   *mapper.Select
+	filter   *mapper.Filter
+	ordering []mapper.OrderCondition
+	slct     *mapper.Select
 
 	index   immutable.Option[client.IndexDescription]
 	fetcher fetcher.Fetcher
@@ -71,6 +72,7 @@ func (n *scanNode) Init() error {
 		n.col,
 		n.fields,
 		n.filter,
+		n.ordering,
 		n.slct.DocumentMapping,
 		n.showDeleted,
 	); err != nil {

--- a/internal/planner/select.go
+++ b/internal/planner/select.go
@@ -322,6 +322,7 @@ func (n *selectNode) initSource() ([]aggregateNode, []*similarityNode, error) {
 	if isScanNode {
 		origScan.index = findIndexByFilteringField(origScan)
 		if !origScan.index.HasValue() {
+			// if we can not use index for filtering, try to use index for ordering
 			origScan.index = findIndexByOrderingField(origScan)
 		}
 		origScan.initFetcher(n.selectReq.Cid)
@@ -364,7 +365,6 @@ func findIndexByFilteringField(scanNode *scanNode) immutable.Option[client.Index
 }
 
 func findIndexByOrderingField(scanNode *scanNode) immutable.Option[client.IndexDescription] {
-	// if we can not use index for filtering, try to use index for ordering
 	if len(scanNode.ordering) > 0 {
 		colDesc := scanNode.col.Description()
 

--- a/internal/planner/type_join.go
+++ b/internal/planner/type_join.go
@@ -202,10 +202,10 @@ func (n *typeIndexJoin) Explain(explainType request.ExplainType) (map[string]any
 		}
 		var subScan *scanNode
 		if joinMany, isJoinMany := n.joinPlan.(*typeJoinMany); isJoinMany {
-			subScan = getScanNode(joinMany.childSide.plan)
+			subScan = getNode[*scanNode](joinMany.childSide.plan)
 		}
 		if joinOne, isJoinOne := n.joinPlan.(*typeJoinOne); isJoinOne {
-			subScan = getScanNode(joinOne.childSide.plan)
+			subScan = getNode[*scanNode](joinOne.childSide.plan)
 		}
 		if subScan != nil {
 			subScanExplain, err := subScan.Explain(explainType)
@@ -378,7 +378,7 @@ func (p *Planner) newInvertableTypeJoin(
 		childSide:  childSide,
 		skipChild:  skipChild,
 		// we store child's own filter in case an index kicks in and replaces it with it's own filter
-		subFilter: getScanNode(childSide.plan).filter,
+		subFilter: getNode[*scanNode](childSide.plan).filter,
 	}
 
 	return join, nil
@@ -443,7 +443,7 @@ func getForeignKey(node planNode, relFieldName string) string {
 
 // fetchDocWithIDAndItsSubDocs fetches a document with the given docID from the given planNode.
 func fetchDocWithIDAndItsSubDocs(node planNode, docID string) (immutable.Option[core.Doc], error) {
-	scan := getScanNode(node)
+	scan := getNode[*scanNode](node)
 	if scan == nil {
 		return immutable.None[core.Doc](), nil
 	}
@@ -546,7 +546,7 @@ func (r *primaryObjectsRetriever) retrievePrimaryDocsReferencingSecondaryDoc() e
 		return client.NewErrFieldNotExist(r.primarySide.relFieldDef.Value().Name + request.RelatedObjectID)
 	}
 
-	r.primaryScan = getScanNode(r.primarySide.plan)
+	r.primaryScan = getNode[*scanNode](r.primarySide.plan)
 
 	r.relIDFieldDef = relIDFieldDef
 
@@ -808,21 +808,45 @@ func (join *invertibleTypeJoin) Value() core.Doc {
 }
 
 func (join *invertibleTypeJoin) invertJoinDirectionWithIndex(
-	fieldFilter *mapper.Filter,
 	index client.IndexDescription,
+	fieldFilter *mapper.Filter,
+	ordering []mapper.OrderCondition,
 ) error {
-	childScan := getScanNode(join.childSide.plan)
+	childScan := getNode[*scanNode](join.childSide.plan)
 	childScan.tryAddFieldWithName(join.childSide.relFieldDef.Value().Name + request.RelatedObjectID)
 	// replace child's filter with the filter that utilizes the index
 	// the original child's filter is stored in join.subFilter
 	childScan.filter = fieldFilter
 	childScan.index = immutable.Some(index)
+	childScan.ordering = ordering
 	childScan.initFetcher(immutable.Option[string]{})
 
 	join.childSide.isFirst = join.parentSide.isFirst
 	join.parentSide.isFirst = !join.parentSide.isFirst
 
 	return nil
+}
+
+// isOrderedByIndex checks if the plan is ordered by an index.
+func isOrderedByIndex(plan planNode) bool {
+	var scan *scanNode
+	// the typeIndexJoin has 2 scan nodes for every side of the join
+	// so we need to make sure we the scan node that is scheduled first, that is more optimal
+	typeJoin := getNode[*typeIndexJoin](plan)
+	if typeJoin != nil {
+		if j, ok := typeJoin.joinPlan.(*typeJoinOne); ok {
+			scan = getNode[*scanNode](j.getFirstSide().plan)
+		} else if j, ok := typeJoin.joinPlan.(*typeJoinMany); ok {
+			scan = getNode[*scanNode](j.getFirstSide().plan)
+		}
+	} else {
+		scan = getNode[*scanNode](plan)
+	}
+	if scan == nil || !scan.index.HasValue() {
+		return false
+	}
+	fieldIndexes := scan.documentMapping.IndexesByName[scan.index.Value().Fields[0].Name]
+	return len(fieldIndexes) > 0 && len(scan.ordering) > 0 && scan.ordering[0].FieldIndexes[0] == fieldIndexes[0]
 }
 
 func addFilterOnIDField(f *mapper.Filter, propIndex int, docID string) *mapper.Filter {
@@ -842,12 +866,11 @@ func addFilterOnIDField(f *mapper.Filter, propIndex int, docID string) *mapper.F
 	return f
 }
 
-func getScanNode(plan planNode) *scanNode {
+func getNode[T planNode](plan planNode) T {
 	node := plan
 	for node != nil {
-		scanNode, ok := node.(*scanNode)
-		if ok {
-			return scanNode
+		if node, ok := node.(T); ok {
+			return node
 		}
 		node = node.Source()
 		if node == nil {
@@ -856,5 +879,6 @@ func getScanNode(plan planNode) *scanNode {
 			}
 		}
 	}
-	return nil
+	var zero T
+	return zero
 }

--- a/internal/planner/type_join.go
+++ b/internal/planner/type_join.go
@@ -827,28 +827,6 @@ func (join *invertibleTypeJoin) invertJoinDirectionWithIndex(
 	return nil
 }
 
-// isOrderedByIndex checks if the plan is ordered by an index.
-func isOrderedByIndex(plan planNode) bool {
-	var scan *scanNode
-	// the typeIndexJoin has 2 scan nodes for every side of the join
-	// so we need to make sure we get the scan node that is scheduled first, i.e. more optimal
-	typeJoin := getNode[*typeIndexJoin](plan)
-	if typeJoin != nil {
-		if j, ok := typeJoin.joinPlan.(*typeJoinOne); ok {
-			scan = getNode[*scanNode](j.getFirstSide().plan)
-		} else if j, ok := typeJoin.joinPlan.(*typeJoinMany); ok {
-			scan = getNode[*scanNode](j.getFirstSide().plan)
-		}
-	} else {
-		scan = getNode[*scanNode](plan)
-	}
-	if scan == nil || !scan.index.HasValue() {
-		return false
-	}
-	fieldIndexes := scan.documentMapping.IndexesByName[scan.index.Value().Fields[0].Name]
-	return len(fieldIndexes) > 0 && len(scan.ordering) > 0 && scan.ordering[0].FieldIndexes[0] == fieldIndexes[0]
-}
-
 func addFilterOnIDField(f *mapper.Filter, propIndex int, docID string) *mapper.Filter {
 	if f == nil {
 		f = mapper.NewFilter()

--- a/internal/planner/type_join.go
+++ b/internal/planner/type_join.go
@@ -831,7 +831,7 @@ func (join *invertibleTypeJoin) invertJoinDirectionWithIndex(
 func isOrderedByIndex(plan planNode) bool {
 	var scan *scanNode
 	// the typeIndexJoin has 2 scan nodes for every side of the join
-	// so we need to make sure we the scan node that is scheduled first, that is more optimal
+	// so we need to make sure we get the scan node that is scheduled first, i.e. more optimal
 	typeJoin := getNode[*typeIndexJoin](plan)
 	if typeJoin != nil {
 		if j, ok := typeJoin.joinPlan.(*typeJoinOne); ok {

--- a/tests/integration/index/order_query_test.go
+++ b/tests/integration/index/order_query_test.go
@@ -84,7 +84,7 @@ func TestOrderQueryWithIndex_WithAscendingOrder_ShouldUseIndex(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithOrder().WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(10),
 			},
 		},
 	}
@@ -132,7 +132,7 @@ func TestOrderQueryWithIndex_WithLimitDescending_ShouldUseIndex(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithLimit().WithOrder().WithIndexFetches(3),
+				Asserter: testUtils.NewExplainAsserter().WithLimit().WithIndexFetches(3),
 			},
 		},
 	}
@@ -180,7 +180,7 @@ func TestOrderQueryWithIndex_WithLimitAscending_ShouldUseIndex(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithLimit().WithOrder().WithIndexFetches(3),
+				Asserter: testUtils.NewExplainAsserter().WithLimit().WithIndexFetches(3),
 			},
 		},
 	}
@@ -223,9 +223,9 @@ func TestOrderQueryWithIndex_WithFilterOnNonIndexedFieldAscending_ShouldUseIndex
 				},
 			},
 			testUtils.Request{
-				Request:  makeExplainQuery(req),
+				Request: makeExplainQuery(req),
 				// we fetch all available docs with index
-				Asserter: testUtils.NewExplainAsserter().WithOrder().WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(10),
 			},
 		},
 	}
@@ -268,9 +268,187 @@ func TestOrderQueryWithIndex_WithFilterOnNonIndexedFieldDescending_ShouldUseInde
 				},
 			},
 			testUtils.Request{
-				Request:  makeExplainQuery(req),
+				Request: makeExplainQuery(req),
 				// we fetch all available docs with index
-				Asserter: testUtils.NewExplainAsserter().WithOrder().WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(10),
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestOrderQueryWithIndex_WithFilterOnIndexedFieldAscending_ShouldUseIndex(t *testing.T) {
+	req := `query {
+		User(order: {age: ASC}, filter: {age: {_gt: 22}}, limit: 3) {
+			name
+			age
+		}
+	}`
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type User {
+						name: String 
+						age: Int @index
+					}`,
+			},
+			testUtils.CreatePredefinedDocs{
+				Docs: getUserDocs(),
+			},
+			testUtils.Request{
+				Request: req,
+				Results: map[string]any{
+					"User": []map[string]any{
+						{
+							"name": "Bruno",
+							"age":  int64(23),
+						},
+						{
+							"name": "Fred",
+							"age":  int64(28),
+						},
+						{
+							"name": "John",
+							"age":  int64(30),
+						},
+					},
+				},
+			},
+			testUtils.Request{
+				Request: makeExplainQuery(req),
+				// we fetch docs starting from the lowest age and skip the first one
+				Asserter: testUtils.NewExplainAsserter().WithLimit().WithIndexFetches(4),
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestOrderQueryWithIndex_WithFilterOnIndexedFieldDescending_ShouldUseIndex(t *testing.T) {
+	req := `query {
+		User(order: {age: DESC}, filter: {age: {_lt: 45}}, limit: 3) {
+			name
+			age
+		}
+	}`
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type User {
+						name: String 
+						age: Int @index
+					}`,
+			},
+			testUtils.CreatePredefinedDocs{
+				Docs: getUserDocs(),
+			},
+			testUtils.Request{
+				Request: req,
+				Results: map[string]any{
+					"User": []map[string]any{
+						{
+							"name": "Roy",
+							"age":  int64(44),
+						},
+						{
+							"name": "Addo",
+							"age":  int64(42),
+						},
+						{
+							"name": "Andy",
+							"age":  int64(33),
+						},
+					},
+				},
+			},
+			testUtils.Request{
+				Request: makeExplainQuery(req),
+				// we fetch docs starting from the highest age, skipping the first 2
+				Asserter: testUtils.NewExplainAsserter().WithLimit().WithIndexFetches(5),
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestOrderQueryWithIndex_WithOrderOnNestedField_ShouldUseIndexForOrdering(t *testing.T) {
+	req := `query {
+		User(order: {device: {model: ASC}}) {
+			name
+		}
+	}`
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type User {
+						name: String
+						device: Device 
+					}
+
+					type Device {
+						model: String @index
+						owner: User @primary
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `{
+					"name":	"Fred"
+				}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `{
+					"name":	"Addo"
+				}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `{
+					"name":	"Shahzad"
+				}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"model": "walkman",
+					"owner": testUtils.NewDocIndex(0, 0),
+				},
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"model": "iPhone",
+					"owner": testUtils.NewDocIndex(0, 1),
+				},
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"model": "pixel",
+					"owner": testUtils.NewDocIndex(0, 2),
+				},
+			},
+			testUtils.Request{
+				Request: req,
+				Results: map[string]any{
+					"User": []map[string]any{
+						{"name": "Addo"},    // iPhone
+						{"name": "Shahzad"}, // pixel
+						{"name": "Fred"},    // walkman
+					},
+				},
+			},
+			testUtils.Request{
+				Request:  makeExplainQuery(req),
+				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(3),
 			},
 		},
 	}

--- a/tests/integration/index/order_query_test.go
+++ b/tests/integration/index/order_query_test.go
@@ -1,0 +1,190 @@
+// Copyright 2025 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package index
+
+import (
+	"testing"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+func TestOrderQueryWithIndex_WithAscendingOrder_ShouldUseIndex(t *testing.T) {
+	req := `query {
+		User(order: {age: ASC}) {
+			name
+			age
+		}
+	}`
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type User {
+						name: String 
+						age: Int @index
+					}`,
+			},
+			testUtils.CreatePredefinedDocs{
+				Docs: getUserDocs(),
+			},
+			testUtils.Request{
+				Request: req,
+				Results: map[string]any{
+					"User": []map[string]any{
+						{
+							"name": "Shahzad",
+							"age":  int64(20),
+						},
+						{
+							"name": "Bruno",
+							"age":  int64(23),
+						},
+						{
+							"name": "Fred",
+							"age":  int64(28),
+						},
+						{
+							"name": "John",
+							"age":  int64(30),
+						},
+						{
+							"name": "Islam",
+							"age":  int64(32),
+						},
+						{
+							"name": "Andy",
+							"age":  int64(33),
+						},
+						{
+							"name": "Addo",
+							"age":  int64(42),
+						},
+						{
+							"name": "Roy",
+							"age":  int64(44),
+						},
+						{
+							"name": "Keenan",
+							"age":  int64(48),
+						},
+						{
+							"name": "Chris",
+							"age":  int64(55),
+						},
+					},
+				},
+			},
+			testUtils.Request{
+				Request:  makeExplainQuery(req),
+				Asserter: testUtils.NewExplainAsserter().WithOrder().WithIndexFetches(10),
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestOrderQueryWithIndex_WithLimitDescending_ShouldUseIndex(t *testing.T) {
+	req := `query {
+		User(order: {age: DESC}, limit: 3) {
+			name
+			age
+		}
+	}`
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type User {
+						name: String 
+						age: Int @index
+					}`,
+			},
+			testUtils.CreatePredefinedDocs{
+				Docs: getUserDocs(),
+			},
+			testUtils.Request{
+				Request: req,
+				Results: map[string]any{
+					"User": []map[string]any{
+						{
+							"name": "Chris",
+							"age":  int64(55),
+						},
+						{
+							"name": "Keenan",
+							"age":  int64(48),
+						},
+						{
+							"name": "Roy",
+							"age":  int64(44),
+						},
+					},
+				},
+			},
+			testUtils.Request{
+				Request:  makeExplainQuery(req),
+				Asserter: testUtils.NewExplainAsserter().WithLimit().WithOrder().WithIndexFetches(3),
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestOrderQueryWithIndex_WithLimitAscending_ShouldUseIndex(t *testing.T) {
+	req := `query {
+		User(order: {age: ASC}, limit: 3) {
+			name
+			age
+		}
+	}`
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type User {
+						name: String 
+						age: Int @index
+					}`,
+			},
+			testUtils.CreatePredefinedDocs{
+				Docs: getUserDocs(),
+			},
+			testUtils.Request{
+				Request: req,
+				Results: map[string]any{
+					"User": []map[string]any{
+						{
+							"name": "Shahzad",
+							"age":  int64(20),
+						},
+						{
+							"name": "Bruno",
+							"age":  int64(23),
+						},
+						{
+							"name": "Fred",
+							"age":  int64(28),
+						},
+					},
+				},
+			},
+			testUtils.Request{
+				Request:  makeExplainQuery(req),
+				Asserter: testUtils.NewExplainAsserter().WithLimit().WithOrder().WithIndexFetches(3),
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+


### PR DESCRIPTION
## Relevant issue(s)

Resolves https://github.com/sourcenetwork/defradb/issues/3650

## Description

This change utilizes secondary indexes for order queries, so that not only filtering but, also sorting is optimized.
Whenever a secondary index takes care of ordering on the documents, the planner optimization pass will detect it and ignore `planner.orderNode`.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Tests

Specify the platform(s) on which this was tested:
- MacOS
