### PR TITLE
refactor: Replace schema-only collections with boolean

### DIFF
--- a/client/collection_description.go
+++ b/client/collection_description.go
@@ -84,6 +84,12 @@ type CollectionDescription struct {
 	// that will change in the future.
 	IsBranchable bool
 
+	// IsBranchable defines whether this collection exists only as a child object embedded within
+	// another collection or not.
+	//
+	// If true, it will not be directly queriable.
+	IsEmbeddedOnly bool
+
 	// VectorEmbeddings contains the configuration for generating embedding vectors.
 	//
 	// This is only usable with array fields.
@@ -190,6 +196,7 @@ type collectionDescription struct {
 	RootID           uint32
 	IsMaterialized   bool
 	IsBranchable     bool
+	IsEmbeddedOnly   bool
 	Policy           immutable.Option[PolicyDescription]
 	Indexes          []IndexDescription
 	Fields           []CollectionFieldDescription
@@ -211,6 +218,7 @@ func (c *CollectionDescription) UnmarshalJSON(bytes []byte) error {
 	c.CollectionID = descMap.CollectionID
 	c.IsMaterialized = descMap.IsMaterialized
 	c.IsBranchable = descMap.IsBranchable
+	c.IsEmbeddedOnly = descMap.IsEmbeddedOnly
 	c.Indexes = descMap.Indexes
 	c.Fields = descMap.Fields
 	c.Sources = make([]any, len(descMap.Sources))

--- a/client/collection_description.go
+++ b/client/collection_description.go
@@ -84,7 +84,7 @@ type CollectionDescription struct {
 	// that will change in the future.
 	IsBranchable bool
 
-	// IsBranchable defines whether this collection exists only as a child object embedded within
+	// IsEmbeddedOnly defines whether this collection exists only as a child object embedded within
 	// another collection or not.
 	//
 	// If true, it will not be directly queriable.

--- a/client/definitions.go
+++ b/client/definitions.go
@@ -51,12 +51,6 @@ func (def CollectionDefinition) GetFieldByName(fieldName string) (FieldDefinitio
 		return NewLocalFieldDefinition(
 			collectionField,
 		), true
-	} else if !existsOnCollection && existsOnSchema {
-		// If the field only exist on the schema it is likely that this is a schema-only object
-		// definition, for example for an embedded object.
-		return NewSchemaOnlyFieldDefinition(
-			schemaField,
-		), true
 	}
 
 	return FieldDefinition{}, false
@@ -66,7 +60,6 @@ func (def CollectionDefinition) GetFieldByName(fieldName string) (FieldDefinitio
 // as a single set.
 func (def CollectionDefinition) GetFields() []FieldDefinition {
 	fields := []FieldDefinition{}
-	localFieldNames := map[string]struct{}{}
 
 	for _, localField := range def.Description.Fields {
 		globalField, ok := def.Schema.GetFieldByName(localField.Name)
@@ -82,18 +75,6 @@ func (def CollectionDefinition) GetFields() []FieldDefinition {
 				NewLocalFieldDefinition(localField),
 			)
 		}
-		localFieldNames[localField.Name] = struct{}{}
-	}
-
-	for _, schemaField := range def.Schema.Fields {
-		if _, ok := localFieldNames[schemaField.Name]; ok {
-			continue
-		}
-		// This must be a global only field, for example on an embedded object.
-		fields = append(
-			fields,
-			NewSchemaOnlyFieldDefinition(schemaField),
-		)
 	}
 
 	return fields

--- a/client/schema_description.go
+++ b/client/schema_description.go
@@ -37,9 +37,6 @@ type SchemaDescription struct {
 	// set that contains all of these fields, plus any local only fields (such as the secondary side
 	// of a relation).
 	//
-	// Embedded objects (including within Views) are schema-only, and as such fields of embedded
-	// objects will not have a corresponding [CollectionFieldDescription].
-	//
 	// Currently new fields may be added after initial declaration, but they cannot be removed.
 	Fields []SchemaFieldDescription
 }

--- a/docs/data_format_changes/i3646-rm-schema-only-cols.md
+++ b/docs/data_format_changes/i3646-rm-schema-only-cols.md
@@ -1,0 +1,3 @@
+# Replace schema-only collections with boolean
+
+The way Collection/SchemaDescriptions are serialized and saved to disk has changed.  Embedded types (e.g. inner View objects) are no longer represented only by a schema, they now have a collection description with a IsEmbeddedOnly boolean set to true.

--- a/docs/website/references/http/openapi.json
+++ b/docs/website/references/http/openapi.json
@@ -202,6 +202,9 @@
                     "IsBranchable": {
                         "type": "boolean"
                     },
+                    "IsEmbeddedOnly": {
+                        "type": "boolean"
+                    },
                     "IsMaterialized": {
                         "type": "boolean"
                     },
@@ -309,6 +312,9 @@
                                 "type": "array"
                             },
                             "IsBranchable": {
+                                "type": "boolean"
+                            },
+                            "IsEmbeddedOnly": {
                                 "type": "boolean"
                             },
                             "IsMaterialized": {

--- a/internal/db/definition_validation.go
+++ b/internal/db/definition_validation.go
@@ -281,7 +281,7 @@ func validateSecondaryFieldsPairUp(
 				continue
 			}
 
-			if len(otherDef.Description.Fields) == 0 {
+			if otherDef.Description.IsEmbeddedOnly {
 				// Views/embedded objects do not require both sides of the relation to be defined.
 				continue
 			}

--- a/internal/planner/mapper/mapper.go
+++ b/internal/planner/mapper/mapper.go
@@ -918,34 +918,7 @@ func getTopLevelInfo(
 		var definition client.CollectionDefinition
 		collection, err := store.GetCollectionByName(ctx, collectionName)
 		if err != nil {
-			// If the collection is not found, check to see if a schema of that name exists,
-			// if so, this must be an embedded object.
-			//
-			// Note: This is a poor way to check if a collection exists or not, see
-			// https://github.com/sourcenetwork/defradb/issues/2146
-			schemas, err := store.GetSchemas(
-				ctx,
-				client.SchemaFetchOptions{
-					Name: immutable.Some(collectionName),
-				},
-			)
-			if err != nil {
-				return nil, client.CollectionDefinition{}, err
-			}
-			if len(schemas) == 0 {
-				return nil, client.CollectionDefinition{}, NewErrTypeNotFound(collectionName)
-			}
-
-			for i, f := range schemas[0].Fields {
-				// As embedded objects do not have collections/field-ids, we just take the index
-				mapping.Add(int(i), f.Name)
-			}
-
-			definition = client.CollectionDefinition{
-				// `schemas` will contain all versions of that name, as views cannot be updated atm this should
-				// be fine for now
-				Schema: schemas[0],
-			}
+			return nil, client.CollectionDefinition{}, err
 		} else {
 			mapping.Add(core.DocIDFieldIndex, request.DocIDFieldName)
 			definition = collection.Definition()

--- a/tests/integration/collection/update/simple/with_filter_test.go
+++ b/tests/integration/collection/update/simple/with_filter_test.go
@@ -31,7 +31,7 @@ func TestUpdateWithInvalidFilterType_ReturnsError(t *testing.T) {
 				CollectionID:  0,
 				Filter:        invalidFilterType{Number: 1},
 				Updater:       `{"name": "Eric"}`,
-				ExpectedError: "type not found",
+				ExpectedError: "key not found",
 			},
 		},
 	}

--- a/tests/integration/view/one_to_one/simple_test.go
+++ b/tests/integration/view/one_to_one/simple_test.go
@@ -71,7 +71,7 @@ func TestView_OneToOneDuplicateEmbeddedSchema_Errors(t *testing.T) {
 						bookName: String
 					}
 				`,
-				ExpectedError: "schema type already exists. Name: BookView",
+				ExpectedError: "collection already exists. Name: BookView",
 			},
 			testUtils.IntrospectionRequest{
 				Request: `


### PR DESCRIPTION
## Relevant issue(s)

Resolves #3646

## Description

Replaces schema-only collections with a boolean `IsEmbeddedOnly` boolean.

I've kept the existing `interface` GQL syntax as-is, we can change that later if we wish, but I'd rather not get into that right now.