### PR TITLE
feat: Replace commit query fieldID with fieldName

### DIFF
--- a/client/request/commit.go
+++ b/client/request/commit.go
@@ -32,11 +32,12 @@ type CommitSelect struct {
 	// belonging to the given document.
 	DocID immutable.Option[string]
 
-	// FieldID is an optional filter which when provided will limit commits to those
+	// FieldName is an optional filter which when provided will limit commits to those
 	// belonging to the given field.
 	//
-	// `C` may be provided for document-level (composite) commits.
-	FieldID immutable.Option[string]
+	// `_C` may be provided for document-level (composite) commits. An explicit empty
+	// value will return branchable collection commits only.
+	FieldName immutable.Option[string]
 
 	// Depth limits the returned commits to being X places in the history away from the
 	// most current.

--- a/client/request/consts.go
+++ b/client/request/consts.go
@@ -19,13 +19,15 @@ const (
 	// that corresponds to the related object's join relation id, i.e. `Author_id`.
 	RelatedObjectID = "_id"
 
-	Cid         = "cid"
-	Input       = "input"
-	CreateInput = "create"
-	UpdateInput = "update"
-	FieldName   = "field"
-	FieldIDName = "fieldId"
-	ShowDeleted = "showDeleted"
+	Cid                = "cid"
+	Input              = "input"
+	CreateInput        = "create"
+	UpdateInput        = "update"
+	FieldName          = "field"
+	FieldIDName        = "fieldId"
+	FieldNameName      = "fieldName"
+	CompositeFieldName = "_C"
+	ShowDeleted        = "showDeleted"
 
 	EncryptDocArgName    = "encrypt"
 	EncryptFieldsArgName = "encryptFields"
@@ -68,7 +70,6 @@ const (
 	CidFieldName             = "cid"
 	SchemaVersionIDFieldName = "schemaVersionId"
 	FieldNameFieldName       = "fieldName"
-	FieldIDFieldName         = "fieldId"
 	DeltaFieldName           = "delta"
 
 	DeltaArgFieldName       = "FieldName"
@@ -142,7 +143,6 @@ var (
 		DocIDArgName,
 		SchemaVersionIDFieldName,
 		FieldNameFieldName,
-		FieldIDFieldName,
 		DeltaFieldName,
 	}
 

--- a/internal/planner/mapper/commitSelect.go
+++ b/internal/planner/mapper/commitSelect.go
@@ -23,7 +23,7 @@ type CommitSelect struct {
 	DocID immutable.Option[string]
 
 	// The field for which commits have been requested.
-	FieldID immutable.Option[string]
+	FieldName immutable.Option[string]
 
 	// The maximum depth to yield results for.
 	Depth immutable.Option[uint64]
@@ -41,9 +41,9 @@ func (s *CommitSelect) CloneTo(index int) Requestable {
 
 func (s *CommitSelect) cloneTo(index int) *CommitSelect {
 	return &CommitSelect{
-		Select:  *s.Select.cloneTo(index),
-		DocID:   s.DocID,
-		FieldID: s.FieldID,
-		Cid:     s.Cid,
+		Select:    *s.Select.cloneTo(index),
+		DocID:     s.DocID,
+		FieldName: s.FieldName,
+		Cid:       s.Cid,
 	}
 }

--- a/internal/planner/mapper/mapper.go
+++ b/internal/planner/mapper/mapper.go
@@ -1267,11 +1267,11 @@ func toCommitSelect(
 		return nil, err
 	}
 	return &CommitSelect{
-		Select:  *underlyingSelect,
-		DocID:   selectRequest.DocID,
-		FieldID: selectRequest.FieldID,
-		Depth:   selectRequest.Depth,
-		Cid:     selectRequest.CID,
+		Select:    *underlyingSelect,
+		DocID:     selectRequest.DocID,
+		FieldName: selectRequest.FieldName,
+		Depth:     selectRequest.Depth,
+		Cid:       selectRequest.CID,
 	}, nil
 }
 

--- a/internal/request/graphql/parser/commit.go
+++ b/internal/request/graphql/parser/commit.go
@@ -16,7 +16,6 @@ import (
 	"github.com/sourcenetwork/immutable"
 
 	"github.com/sourcenetwork/defradb/client/request"
-	"github.com/sourcenetwork/defradb/internal/core"
 )
 
 func parseCommitSelect(
@@ -49,11 +48,11 @@ func parseCommitSelect(
 				commit.CID = immutable.Some(v)
 			}
 
-		case request.FieldIDName:
+		case request.FieldNameName:
 			if value == nil {
-				commit.FieldID = immutable.Some("")
+				commit.FieldName = immutable.Some("")
 			} else if v, ok := value.(string); ok {
-				commit.FieldID = immutable.Some(v)
+				commit.FieldName = immutable.Some(v)
 			}
 
 		case request.OrderClause:
@@ -106,9 +105,9 @@ func parseCommitSelect(
 		// values
 		commit.Depth = immutable.Some(uint64(1))
 
-		if !commit.FieldID.HasValue() {
-			// latest commits defaults to composite commits only at the moment
-			commit.FieldID = immutable.Some(core.COMPOSITE_NAMESPACE)
+		if !commit.FieldName.HasValue() {
+			// latest commits defaults to composite commits only
+			commit.FieldName = immutable.Some(request.CompositeFieldName)
 		}
 	}
 

--- a/internal/request/graphql/schema/types/commits.go
+++ b/internal/request/graphql/schema/types/commits.go
@@ -63,10 +63,6 @@ func CommitObject(commitLinkObject *gql.Object) *gql.Object {
 				Description: commitFieldNameFieldDescription,
 				Type:        gql.String,
 			},
-			request.FieldIDFieldName: &gql.Field{
-				Type:        gql.String,
-				Description: commitFieldIDFieldDescription,
-			},
 			request.DeltaFieldName: &gql.Field{
 				Description: commitDeltaFieldDescription,
 				Type:        gql.String,
@@ -169,10 +165,10 @@ func QueryCommits(commitObject *gql.Object, commitsOrderArg *gql.InputObject) *g
 		Description: commitsQueryDescription,
 		Type:        gql.NewList(commitObject),
 		Args: gql.FieldConfigArgument{
-			request.DocIDArgName: NewArgConfig(gql.ID, commitDocIDArgDescription),
-			request.FieldIDName:  NewArgConfig(gql.String, commitFieldIDArgDescription),
-			"order":              NewArgConfig(gql.NewList(commitsOrderArg), OrderArgDescription),
-			"cid":                NewArgConfig(gql.ID, commitCIDArgDescription),
+			request.DocIDArgName:  NewArgConfig(gql.ID, commitDocIDArgDescription),
+			request.FieldNameName: NewArgConfig(gql.String, commitFieldNameArgDescription),
+			"order":               NewArgConfig(gql.NewList(commitsOrderArg), OrderArgDescription),
+			"cid":                 NewArgConfig(gql.ID, commitCIDArgDescription),
 			"groupBy": NewArgConfig(
 				gql.NewList(
 					gql.NewNonNull(
@@ -197,10 +193,6 @@ func QueryCommits(commitObject *gql.Object, commitsOrderArg *gql.InputObject) *g
 										Value:       "fieldName",
 										Description: commitFieldNameFieldDescription,
 									},
-									"fieldId": &gql.EnumValueConfig{
-										Value:       "fieldId",
-										Description: commitFieldIDFieldDescription,
-									},
 								},
 							},
 						),
@@ -221,8 +213,8 @@ func QueryLatestCommits(commitObject *gql.Object) *gql.Field {
 		Description: latestCommitsQueryDescription,
 		Type:        gql.NewList(commitObject),
 		Args: gql.FieldConfigArgument{
-			request.DocIDArgName: NewArgConfig(gql.NewNonNull(gql.ID), commitDocIDArgDescription),
-			request.FieldIDName:  NewArgConfig(gql.String, commitFieldIDArgDescription),
+			request.DocIDArgName:  NewArgConfig(gql.NewNonNull(gql.ID), commitDocIDArgDescription),
+			request.FieldNameName: NewArgConfig(gql.String, commitFieldNameArgDescription),
 		},
 	}
 }

--- a/internal/request/graphql/schema/types/descriptions.go
+++ b/internal/request/graphql/schema/types/descriptions.go
@@ -44,11 +44,10 @@ An optional docID parameter for this commit query. Only commits for a document
  with a matching docID will be returned.  If no documents match, the result
  set will be empty.
 `
-	commitFieldIDArgDescription string = `
-An optional field ID parameter for this commit query. Only commits for a fields
- matching this ID will be returned. Specifying 'C' will limit the results to 
- composite (document level) commits only, otherwise field IDs are numeric. If no
- fields match, the result set will be empty.
+	commitFieldNameArgDescription string = `
+An optional field name parameter for this commit query. Only commits for a fields
+ matching this name will be returned. Specifying '_C' will limit the results to
+ composite (document level) commits only. If no fields match, the result set will be empty.
 `
 	commitCIDArgDescription string = `
 An optional value that specifies the commit ID of the commits to return. If a
@@ -89,10 +88,6 @@ The ID of the schema version that this commit was committed against. This ID all
 	commitFieldNameFieldDescription string = `
 The name of the field that this commit was committed against. If this is a composite
  or a collection the value will be null.
-`
-	commitFieldIDFieldDescription string = `
-The id of the field that this commit was committed against. If this is a composite field
- the value will be "C". If it is a collection level commit it will be null.
 `
 	commitDeltaFieldDescription string = `
 The CBOR encoded representation of the value that is saved as part of this commit.

--- a/tests/integration/encryption/commit_relation_test.go
+++ b/tests/integration/encryption/commit_relation_test.go
@@ -82,7 +82,7 @@ func TestDocEncryption_WithEncryptionSecondaryRelations_ShouldStoreEncryptedComm
 						{
 							"delta":     nil,
 							"docID":     deviceDocID,
-							"fieldName": nil,
+							"fieldName": "_C",
 						},
 						{
 							"delta":     encrypt(testUtils.CBORValue("Chris"), userDocID, ""),
@@ -92,7 +92,7 @@ func TestDocEncryption_WithEncryptionSecondaryRelations_ShouldStoreEncryptedComm
 						{
 							"delta":     nil,
 							"docID":     userDocID,
-							"fieldName": nil,
+							"fieldName": "_C",
 						},
 					},
 				},

--- a/tests/integration/encryption/commit_test.go
+++ b/tests/integration/encryption/commit_test.go
@@ -34,7 +34,6 @@ func TestDocEncryption_WithEncryptionOnLWWCRDT_ShouldStoreCommitsDeltaEncrypted(
 							cid
 							delta
 							docID
-							fieldId
 							fieldName
 							height
 							links {
@@ -50,7 +49,6 @@ func TestDocEncryption_WithEncryptionOnLWWCRDT_ShouldStoreCommitsDeltaEncrypted(
 							"cid":       "bafyreiba7bxnqquldhojcnkak7afamaxssvjk4uav4ev4lwqgixarvvp4i",
 							"delta":     encrypt(testUtils.CBORValue(21), john21DocID, ""),
 							"docID":     john21DocID,
-							"fieldId":   "1",
 							"fieldName": "age",
 							"height":    int64(1),
 							"links":     []map[string]any{},
@@ -59,7 +57,6 @@ func TestDocEncryption_WithEncryptionOnLWWCRDT_ShouldStoreCommitsDeltaEncrypted(
 							"cid":       "bafyreigawlzc5zi2juad5vldnwvels5qsehymb45maoeamdbckajwcao24",
 							"delta":     encrypt(testUtils.CBORValue("John"), john21DocID, ""),
 							"docID":     john21DocID,
-							"fieldId":   "2",
 							"fieldName": "name",
 							"height":    int64(1),
 							"links":     []map[string]any{},
@@ -68,8 +65,7 @@ func TestDocEncryption_WithEncryptionOnLWWCRDT_ShouldStoreCommitsDeltaEncrypted(
 							"cid":       "bafyreidl77w6pex7uworttm5bsqyvli5qxqoqy3q2n2xqor5vrqfr3woee",
 							"delta":     nil,
 							"docID":     john21DocID,
-							"fieldId":   "C",
-							"fieldName": nil,
+							"fieldName": "_C",
 							"height":    int64(1),
 							"links": []map[string]any{
 								{
@@ -107,7 +103,7 @@ func TestDocEncryption_UponUpdateOnLWWCRDT_ShouldEncryptCommitDelta(t *testing.T
 			testUtils.Request{
 				Request: `
 					query {
-						commits(fieldId: "1") {
+						commits(fieldName: "age") {
 							delta
 						}
 					}
@@ -155,7 +151,7 @@ func TestDocEncryption_WithMultipleDocsUponUpdate_ShouldEncryptOnlyRelevantDocs(
 			testUtils.Request{
 				Request: `
 					query {
-						commits(fieldId: "1") {
+						commits(fieldName: "age") {
 							delta
 							docID
 						}
@@ -254,7 +250,7 @@ func TestDocEncryption_UponUpdateOnCounterCRDT_ShouldEncryptedCommitDelta(t *tes
 			testUtils.Request{
 				Request: `
 					query {
-						commits(fieldId: "1") {
+						commits(fieldName: "points") {
 							delta
 						}
 					}
@@ -349,7 +345,7 @@ func TestDocEncryption_IfTwoDocsHaveSameFieldValue_CipherTextShouldBeDifferent(t
 			testUtils.Request{
 				Request: `
 					query {
-						commits(fieldId: "1") {
+						commits(fieldName: "age") {
 							delta
 							fieldName
 						}

--- a/tests/integration/encryption/field_commit_test.go
+++ b/tests/integration/encryption/field_commit_test.go
@@ -51,7 +51,7 @@ func TestDocEncryptionField_WithEncryptionOnField_ShouldStoreOnlyFieldsDeltaEncr
 						{
 							"delta":     nil,
 							"docID":     john21DocID,
-							"fieldName": nil,
+							"fieldName": "_C",
 						},
 					},
 				},

--- a/tests/integration/encryption/peer_test.go
+++ b/tests/integration/encryption/peer_test.go
@@ -47,7 +47,6 @@ func TestDocEncryptionPeer_UponSync_ShouldSyncEncryptedDAG(t *testing.T) {
 							cid
 							delta
 							docID
-							fieldId
 							fieldName
 							height
 							links {
@@ -63,7 +62,6 @@ func TestDocEncryptionPeer_UponSync_ShouldSyncEncryptedDAG(t *testing.T) {
 							"cid":       "bafyreiba7bxnqquldhojcnkak7afamaxssvjk4uav4ev4lwqgixarvvp4i",
 							"delta":     encrypt(testUtils.CBORValue(21), john21DocID, ""),
 							"docID":     john21DocID,
-							"fieldId":   "1",
 							"fieldName": "age",
 							"height":    int64(1),
 							"links":     []map[string]any{},
@@ -72,7 +70,6 @@ func TestDocEncryptionPeer_UponSync_ShouldSyncEncryptedDAG(t *testing.T) {
 							"cid":       "bafyreigawlzc5zi2juad5vldnwvels5qsehymb45maoeamdbckajwcao24",
 							"delta":     encrypt(testUtils.CBORValue("John"), john21DocID, ""),
 							"docID":     john21DocID,
-							"fieldId":   "2",
 							"fieldName": "name",
 							"height":    int64(1),
 							"links":     []map[string]any{},
@@ -81,8 +78,7 @@ func TestDocEncryptionPeer_UponSync_ShouldSyncEncryptedDAG(t *testing.T) {
 							"cid":       "bafyreidl77w6pex7uworttm5bsqyvli5qxqoqy3q2n2xqor5vrqfr3woee",
 							"delta":     nil,
 							"docID":     john21DocID,
-							"fieldId":   "C",
-							"fieldName": nil,
+							"fieldName": "_C",
 							"height":    int64(1),
 							"links": []map[string]any{
 								{

--- a/tests/integration/explain/debug/dagscan_test.go
+++ b/tests/integration/explain/debug/dagscan_test.go
@@ -42,7 +42,7 @@ func TestDebugExplainCommitsDagScanQueryOp(t *testing.T) {
 			testUtils.ExplainRequest{
 
 				Request: `query @explain(type: debug) {
-					commits (docID: "bae-7aabc9d2-fbbc-5911-b0d0-b49a2a1d0e84", fieldId: "1") {
+					commits (docID: "bae-7aabc9d2-fbbc-5911-b0d0-b49a2a1d0e84", fieldName: "name") {
 						links {
 							cid
 						}
@@ -94,7 +94,7 @@ func TestDebugExplainLatestCommitsDagScanQueryOp(t *testing.T) {
 			testUtils.ExplainRequest{
 
 				Request: `query @explain(type: debug) {
-					latestCommits(docID: "bae-7aabc9d2-fbbc-5911-b0d0-b49a2a1d0e84", fieldId: "1") {
+					latestCommits(docID: "bae-7aabc9d2-fbbc-5911-b0d0-b49a2a1d0e84", fieldName: "name") {
 						cid
 						links {
 							cid
@@ -148,7 +148,7 @@ func TestDebugExplainLatestCommitsDagScanWithoutDocID_Failure(t *testing.T) {
 			testUtils.ExplainRequest{
 
 				Request: `query @explain(type: debug) {
-					latestCommits(fieldId: "1") {
+					latestCommits(fieldName: "name") {
 						cid
 						links {
 							cid

--- a/tests/integration/explain/default/dagscan_test.go
+++ b/tests/integration/explain/default/dagscan_test.go
@@ -42,7 +42,7 @@ func TestDefaultExplainCommitsDagScanQueryOp(t *testing.T) {
 			testUtils.ExplainRequest{
 
 				Request: `query @explain {
-					commits (docID: "bae-7aabc9d2-fbbc-5911-b0d0-b49a2a1d0e84", fieldId: "1") {
+					commits (docID: "bae-7aabc9d2-fbbc-5911-b0d0-b49a2a1d0e84", fieldName: "name") {
 						links {
 							cid
 						}
@@ -56,10 +56,10 @@ func TestDefaultExplainCommitsDagScanQueryOp(t *testing.T) {
 						TargetNodeName:    "dagScanNode",
 						IncludeChildNodes: true, // Shouldn't have any as this is the last node in the chain.
 						ExpectedAttributes: dataMap{
-							"cid":     nil,
-							"fieldId": "1",
+							"cid":       nil,
+							"fieldName": "name",
 							"prefixes": []string{
-								"/d/bae-7aabc9d2-fbbc-5911-b0d0-b49a2a1d0e84/1",
+								"/d/bae-7aabc9d2-fbbc-5911-b0d0-b49a2a1d0e84",
 							},
 						},
 					},
@@ -96,8 +96,8 @@ func TestDefaultExplainCommitsDagScanQueryOpWithoutField(t *testing.T) {
 						TargetNodeName:    "dagScanNode",
 						IncludeChildNodes: true, // Shouldn't have any as this is the last node in the chain.
 						ExpectedAttributes: dataMap{
-							"cid":     nil,
-							"fieldId": nil,
+							"cid":       nil,
+							"fieldName": nil,
 							"prefixes": []string{
 								"/d/bae-7aabc9d2-fbbc-5911-b0d0-b49a2a1d0e84",
 							},
@@ -122,7 +122,7 @@ func TestDefaultExplainLatestCommitsDagScanQueryOp(t *testing.T) {
 			testUtils.ExplainRequest{
 
 				Request: `query @explain {
-					latestCommits(docID: "bae-7aabc9d2-fbbc-5911-b0d0-b49a2a1d0e84", fieldId: "1") {
+					latestCommits(docID: "bae-7aabc9d2-fbbc-5911-b0d0-b49a2a1d0e84", fieldName: "name") {
 						cid
 						links {
 							cid
@@ -137,10 +137,10 @@ func TestDefaultExplainLatestCommitsDagScanQueryOp(t *testing.T) {
 						TargetNodeName:    "dagScanNode",
 						IncludeChildNodes: true, // Shouldn't have any as this is the last node in the chain.
 						ExpectedAttributes: dataMap{
-							"cid":     nil,
-							"fieldId": "1",
+							"cid":       nil,
+							"fieldName": "name",
 							"prefixes": []string{
-								"/d/bae-7aabc9d2-fbbc-5911-b0d0-b49a2a1d0e84/1",
+								"/d/bae-7aabc9d2-fbbc-5911-b0d0-b49a2a1d0e84",
 							},
 						},
 					},
@@ -178,8 +178,8 @@ func TestDefaultExplainLatestCommitsDagScanQueryOpWithoutField(t *testing.T) {
 						TargetNodeName:    "dagScanNode",
 						IncludeChildNodes: true, // Shouldn't have any as this is the last node in the chain.
 						ExpectedAttributes: dataMap{
-							"cid":     nil,
-							"fieldId": "C",
+							"cid":       nil,
+							"fieldName": "_C",
 							"prefixes": []string{
 								"/d/bae-7aabc9d2-fbbc-5911-b0d0-b49a2a1d0e84/C",
 							},
@@ -204,7 +204,7 @@ func TestDefaultExplainLatestCommitsDagScanWithoutDocID_Failure(t *testing.T) {
 			testUtils.ExplainRequest{
 
 				Request: `query @explain {
-					latestCommits(fieldId: "1") {
+					latestCommits(fieldName: "name") {
 						cid
 						links {
 							cid

--- a/tests/integration/query/commits/branchables/field_id_test.go
+++ b/tests/integration/query/commits/branchables/field_id_test.go
@@ -16,7 +16,7 @@ import (
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
 )
 
-func TestQueryCommitsBranchables_WithFieldID(t *testing.T) {
+func TestQueryCommitsBranchables_WithFieldName(t *testing.T) {
 	test := testUtils.TestCase{
 		Actions: []any{
 			testUtils.SchemaUpdate{
@@ -36,11 +36,11 @@ func TestQueryCommitsBranchables_WithFieldID(t *testing.T) {
 			testUtils.Request{
 				Request: `query {
 						commits(
-							fieldId: null
+							fieldName: null
 						) {
 							schemaVersionId
 							docID
-							fieldId
+							fieldName
 						}
 					}`,
 				Results: map[string]any{
@@ -49,7 +49,7 @@ func TestQueryCommitsBranchables_WithFieldID(t *testing.T) {
 							// Extra params are used to verify this is a collection level cid
 							"schemaVersionId": "bafkreihhd6bqrjhl5zidwztgxzeseveplv3cj3fwtn3unjkdx7j2vr2vrq",
 							"docID":           nil,
-							"fieldId":         nil,
+							"fieldName":       nil,
 						},
 					},
 				},

--- a/tests/integration/query/commits/branchables/simple_test.go
+++ b/tests/integration/query/commits/branchables/simple_test.go
@@ -97,7 +97,6 @@ func TestQueryCommitsBranchables_WithAllFields(t *testing.T) {
 							schemaVersionId
 							delta
 							docID
-							fieldId
 							fieldName
 							height
 							links {
@@ -113,7 +112,6 @@ func TestQueryCommitsBranchables_WithAllFields(t *testing.T) {
 							"schemaVersionId": "bafkreihhd6bqrjhl5zidwztgxzeseveplv3cj3fwtn3unjkdx7j2vr2vrq",
 							"delta":           nil,
 							"docID":           nil,
-							"fieldId":         nil,
 							"fieldName":       nil,
 							"height":          int64(1),
 							"links": []map[string]any{
@@ -128,7 +126,6 @@ func TestQueryCommitsBranchables_WithAllFields(t *testing.T) {
 							"schemaVersionId": "bafkreihhd6bqrjhl5zidwztgxzeseveplv3cj3fwtn3unjkdx7j2vr2vrq",
 							"delta":           testUtils.CBORValue(21),
 							"docID":           "bae-0b2f15e5-bfe7-5cb7-8045-471318d7dbc3",
-							"fieldId":         "1",
 							"fieldName":       "age",
 							"height":          int64(1),
 							"links":           []map[string]any{},
@@ -138,7 +135,6 @@ func TestQueryCommitsBranchables_WithAllFields(t *testing.T) {
 							"schemaVersionId": "bafkreihhd6bqrjhl5zidwztgxzeseveplv3cj3fwtn3unjkdx7j2vr2vrq",
 							"delta":           testUtils.CBORValue("John"),
 							"docID":           "bae-0b2f15e5-bfe7-5cb7-8045-471318d7dbc3",
-							"fieldId":         "2",
 							"fieldName":       "name",
 							"height":          int64(1),
 							"links":           []map[string]any{},
@@ -148,8 +144,7 @@ func TestQueryCommitsBranchables_WithAllFields(t *testing.T) {
 							"schemaVersionId": "bafkreihhd6bqrjhl5zidwztgxzeseveplv3cj3fwtn3unjkdx7j2vr2vrq",
 							"delta":           nil,
 							"docID":           "bae-0b2f15e5-bfe7-5cb7-8045-471318d7dbc3",
-							"fieldId":         "C",
-							"fieldName":       nil,
+							"fieldName":       "_C",
 							"height":          int64(1),
 							"links": []map[string]any{
 								{

--- a/tests/integration/query/commits/simple_test.go
+++ b/tests/integration/query/commits/simple_test.go
@@ -186,7 +186,7 @@ func TestQueryCommitsWithFieldNameField(t *testing.T) {
 							"fieldName": "name",
 						},
 						{
-							"fieldName": nil,
+							"fieldName": "_C",
 						},
 					},
 				},
@@ -233,99 +233,10 @@ func TestQueryCommitsWithFieldNameFieldAndUpdate(t *testing.T) {
 							"fieldName": "name",
 						},
 						{
-							"fieldName": nil,
+							"fieldName": "_C",
 						},
 						{
-							"fieldName": nil,
-						},
-					},
-				},
-			},
-		},
-	}
-
-	testUtils.ExecuteTestCase(t, test)
-}
-
-func TestQueryCommitsWithFieldIDField(t *testing.T) {
-	test := testUtils.TestCase{
-		Description: "Simple commits query yielding fieldId",
-		Actions: []any{
-			updateUserCollectionSchema(),
-			testUtils.CreateDoc{
-				Doc: `{
-						"name":	"John",
-						"age":	21
-					}`,
-			},
-			testUtils.Request{
-				Request: `
-					query {
-						commits {
-							fieldId
-						}
-					}
-				`,
-				Results: map[string]any{
-					"commits": []map[string]any{
-						{
-							"fieldId": "1",
-						},
-						{
-							"fieldId": "2",
-						},
-						{
-							"fieldId": "C",
-						},
-					},
-				},
-			},
-		},
-	}
-
-	testUtils.ExecuteTestCase(t, test)
-}
-
-func TestQueryCommitsWithFieldIDFieldWithUpdate(t *testing.T) {
-	test := testUtils.TestCase{
-		Description: "Simple commits query yielding fieldId",
-		Actions: []any{
-			updateUserCollectionSchema(),
-			testUtils.CreateDoc{
-				Doc: `{
-						"name":	"John",
-						"age":	21
-					}`,
-			},
-			testUtils.UpdateDoc{
-				Doc: `{
-					"age":	22
-				}`,
-			},
-			testUtils.Request{
-				Request: `
-					query {
-						commits {
-							fieldId
-						}
-					}
-				`,
-				Results: map[string]any{
-					"commits": []map[string]any{
-						{
-							"fieldId": "1",
-						},
-						{
-							"fieldId": "1",
-						},
-						{
-							"fieldId": "2",
-						},
-						{
-							"fieldId": "C",
-						},
-						{
-							"fieldId": "C",
+							"fieldName": "_C",
 						},
 					},
 				},
@@ -366,7 +277,6 @@ func TestQuery_CommitsWithAllFieldsWithUpdate_NoError(t *testing.T) {
 							cid
 							delta
 							docID
-							fieldId
 							fieldName
 							height
 							links {
@@ -385,7 +295,6 @@ func TestQuery_CommitsWithAllFieldsWithUpdate_NoError(t *testing.T) {
 							"cid":       gomega.And(ageUpdateCid, uniqueCid),
 							"delta":     testUtils.CBORValue(22),
 							"docID":     "bae-c9fb0fa4-1195-589c-aa54-e68333fb90b3",
-							"fieldId":   "1",
 							"fieldName": "age",
 							"height":    int64(2),
 							"links": []map[string]any{
@@ -400,7 +309,6 @@ func TestQuery_CommitsWithAllFieldsWithUpdate_NoError(t *testing.T) {
 							"cid":       gomega.And(ageCreateCid, uniqueCid),
 							"delta":     testUtils.CBORValue(21),
 							"docID":     "bae-c9fb0fa4-1195-589c-aa54-e68333fb90b3",
-							"fieldId":   "1",
 							"fieldName": "age",
 							"height":    int64(1),
 							"links":     []map[string]any{},
@@ -410,7 +318,6 @@ func TestQuery_CommitsWithAllFieldsWithUpdate_NoError(t *testing.T) {
 							"cid":       gomega.And(nameCreateCid, uniqueCid),
 							"delta":     testUtils.CBORValue("John"),
 							"docID":     "bae-c9fb0fa4-1195-589c-aa54-e68333fb90b3",
-							"fieldId":   "2",
 							"fieldName": "name",
 							"height":    int64(1),
 							"links":     []map[string]any{},
@@ -420,8 +327,7 @@ func TestQuery_CommitsWithAllFieldsWithUpdate_NoError(t *testing.T) {
 							"cid":       gomega.And(updateCompositeCid, uniqueCid),
 							"delta":     nil,
 							"docID":     "bae-c9fb0fa4-1195-589c-aa54-e68333fb90b3",
-							"fieldId":   "C",
-							"fieldName": nil,
+							"fieldName": "_C",
 							"height":    int64(2),
 							"links": []map[string]any{
 								{
@@ -439,8 +345,7 @@ func TestQuery_CommitsWithAllFieldsWithUpdate_NoError(t *testing.T) {
 							"cid":       gomega.And(createCompositeCid, uniqueCid),
 							"delta":     nil,
 							"docID":     "bae-c9fb0fa4-1195-589c-aa54-e68333fb90b3",
-							"fieldId":   "C",
-							"fieldName": nil,
+							"fieldName": "_C",
 							"height":    int64(1),
 							"links": []map[string]any{
 								{

--- a/tests/integration/query/commits/with_delete_test.go
+++ b/tests/integration/query/commits/with_delete_test.go
@@ -48,7 +48,7 @@ func TestQueryCommits_AfterDocDeletion_ShouldStillFetch(t *testing.T) {
 			testUtils.Request{
 				Request: `
 					query {
-						commits(fieldId: "C") {
+						commits(fieldName: "_C") {
 							cid
 							fieldName
 							links {
@@ -62,7 +62,7 @@ func TestQueryCommits_AfterDocDeletion_ShouldStillFetch(t *testing.T) {
 					"commits": []map[string]any{
 						{
 							"cid":       gomega.And(deleteCid, uniqueCid),
-							"fieldName": nil,
+							"fieldName": "_C",
 							"links": []map[string]any{
 								{
 									"cid":  createCompositeCid,
@@ -72,7 +72,7 @@ func TestQueryCommits_AfterDocDeletion_ShouldStillFetch(t *testing.T) {
 						},
 						{
 							"cid":       gomega.And(createCompositeCid, uniqueCid),
-							"fieldName": nil,
+							"fieldName": "_C",
 							"links": []map[string]any{
 								{
 									"cid":  createAgeCid,

--- a/tests/integration/query/commits/with_doc_id_field_test.go
+++ b/tests/integration/query/commits/with_doc_id_field_test.go
@@ -30,7 +30,7 @@ func TestQueryCommitsWithDocIDAndUnknownField(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: `query {
-						commits(docID: "bae-c9fb0fa4-1195-589c-aa54-e68333fb90b3", fieldId: "not a field") {
+						commits(docID: "bae-c9fb0fa4-1195-589c-aa54-e68333fb90b3", fieldName: "not a field") {
 							cid
 						}
 					}`,
@@ -58,7 +58,7 @@ func TestQueryCommitsWithDocIDAndUnknownFieldId(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: `query {
-						commits(docID: "bae-c9fb0fa4-1195-589c-aa54-e68333fb90b3", fieldId: "999999") {
+						commits(docID: "bae-c9fb0fa4-1195-589c-aa54-e68333fb90b3", fieldName: "999999") {
 							cid
 						}
 					}`,
@@ -72,8 +72,6 @@ func TestQueryCommitsWithDocIDAndUnknownFieldId(t *testing.T) {
 	testUtils.ExecuteTestCase(t, test)
 }
 
-// This test is for documentation reasons only. This is not
-// desired behaviour (should return all commits for docID-field).
 func TestQueryCommitsWithDocIDAndField(t *testing.T) {
 	test := testUtils.TestCase{
 		Description: "Simple all commits query with docID and field",
@@ -88,37 +86,7 @@ func TestQueryCommitsWithDocIDAndField(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: `query {
-						commits(docID: "bae-c9fb0fa4-1195-589c-aa54-e68333fb90b3", fieldId: "Age") {
-							cid
-						}
-					}`,
-				Results: map[string]any{
-					"commits": []map[string]any{},
-				},
-			},
-		},
-	}
-
-	testUtils.ExecuteTestCase(t, test)
-}
-
-// This test is for documentation reasons only. This is not
-// desired behaviour (Users should not be specifying field ids).
-func TestQueryCommitsWithDocIDAndFieldId(t *testing.T) {
-	test := testUtils.TestCase{
-		Description: "Simple all commits query with docID and field id",
-		Actions: []any{
-			updateUserCollectionSchema(),
-			testUtils.CreateDoc{
-				CollectionID: 0,
-				Doc: `{
-						"name":	"John",
-						"age":	21
-					}`,
-			},
-			testUtils.Request{
-				Request: `query {
-						commits(docID: "bae-c9fb0fa4-1195-589c-aa54-e68333fb90b3", fieldId: "1") {
+						commits(docID: "bae-c9fb0fa4-1195-589c-aa54-e68333fb90b3", fieldName: "age") {
 							cid
 						}
 					}`,
@@ -136,9 +104,7 @@ func TestQueryCommitsWithDocIDAndFieldId(t *testing.T) {
 	testUtils.ExecuteTestCase(t, test)
 }
 
-// This test is for documentation reasons only. This is not
-// desired behaviour (Users should not be specifying field ids).
-func TestQueryCommitsWithDocIDAndCompositeFieldId(t *testing.T) {
+func TestQueryCommitsWithDocIDAndCompositeField(t *testing.T) {
 	test := testUtils.TestCase{
 		Description: "Simple all commits query with docID and field id",
 		Actions: []any{
@@ -152,7 +118,7 @@ func TestQueryCommitsWithDocIDAndCompositeFieldId(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: `query {
-						commits(docID: "bae-c9fb0fa4-1195-589c-aa54-e68333fb90b3", fieldId: "C") {
+						commits(docID: "bae-c9fb0fa4-1195-589c-aa54-e68333fb90b3", fieldName: "_C") {
 							cid
 						}
 					}`,

--- a/tests/integration/query/commits/with_field_test.go
+++ b/tests/integration/query/commits/with_field_test.go
@@ -16,8 +16,6 @@ import (
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
 )
 
-// This test is for documentation reasons only. This is not
-// desired behaviour (should return all commits for docID-field).
 func TestQueryCommitsWithField(t *testing.T) {
 	test := testUtils.TestCase{
 		Description: "Simple all commits query with field",
@@ -32,37 +30,7 @@ func TestQueryCommitsWithField(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: `query {
-						commits (fieldId: "Age") {
-							cid
-						}
-					}`,
-				Results: map[string]any{
-					"commits": []map[string]any{},
-				},
-			},
-		},
-	}
-
-	testUtils.ExecuteTestCase(t, test)
-}
-
-// This test is for documentation reasons only. This is not
-// desired behaviour (Users should not be specifying field ids).
-func TestQueryCommitsWithFieldId(t *testing.T) {
-	test := testUtils.TestCase{
-		Description: "Simple all commits query with field id",
-		Actions: []any{
-			updateUserCollectionSchema(),
-			testUtils.CreateDoc{
-				CollectionID: 0,
-				Doc: `{
-						"name":	"John",
-						"age":	21
-					}`,
-			},
-			testUtils.Request{
-				Request: `query {
-						commits (fieldId: "1") {
+						commits (fieldName: "age") {
 							cid
 						}
 					}`,
@@ -80,11 +48,9 @@ func TestQueryCommitsWithFieldId(t *testing.T) {
 	testUtils.ExecuteTestCase(t, test)
 }
 
-// This test is for documentation reasons only. This is not
-// desired behaviour (Users should not be specifying field ids).
-func TestQueryCommitsWithCompositeFieldId(t *testing.T) {
+func TestQueryCommitsWithFieldId(t *testing.T) {
 	test := testUtils.TestCase{
-		Description: "Simple all commits query with docID and field id",
+		Description: "Simple all commits query with field id",
 		Actions: []any{
 			updateUserCollectionSchema(),
 			testUtils.CreateDoc{
@@ -96,7 +62,34 @@ func TestQueryCommitsWithCompositeFieldId(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: `query {
-						commits(fieldId: "C") {
+						commits (fieldName: "1") {
+							cid
+						}
+					}`,
+				Results: map[string]any{
+					"commits": []map[string]any{},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestQueryCommitsWithCompositeField(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			updateUserCollectionSchema(),
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `{
+						"name":	"John",
+						"age":	21
+					}`,
+			},
+			testUtils.Request{
+				Request: `query {
+						commits(fieldName: "_C") {
 							cid
 						}
 					}`,
@@ -130,7 +123,7 @@ func TestQueryCommitsWithCompositeFieldIdWithReturnedSchemaVersionID(t *testing.
 			},
 			testUtils.Request{
 				Request: `query {
-						commits(fieldId: "C") {
+						commits(fieldName: "_C") {
 							cid
 							schemaVersionId
 						}

--- a/tests/integration/query/commits/with_group_test.go
+++ b/tests/integration/query/commits/with_group_test.go
@@ -269,7 +269,7 @@ func TestQueryCommitsWithGroupByFieldName(t *testing.T) {
 							"fieldName": "name",
 						},
 						{
-							"fieldName": nil,
+							"fieldName": "_C",
 						},
 					},
 				},
@@ -330,121 +330,7 @@ func TestQueryCommitsWithGroupByFieldNameWithChild(t *testing.T) {
 							},
 						},
 						{
-							"fieldName": nil,
-							"_group": []map[string]any{
-								{
-									"height": int64(2),
-								},
-								{
-									"height": int64(1),
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-
-	testUtils.ExecuteTestCase(t, test)
-}
-
-func TestQueryCommitsWithGroupByFieldID(t *testing.T) {
-	test := testUtils.TestCase{
-		Description: "Simple all commits query, group by fieldId",
-		Actions: []any{
-			updateUserCollectionSchema(),
-			testUtils.CreateDoc{
-				CollectionID: 0,
-				Doc: `{
-						"name":	"John",
-						"age":	21
-					}`,
-			},
-			testUtils.UpdateDoc{
-				CollectionID: 0,
-				DocID:        0,
-				Doc: `{
-					"age":	22
-				}`,
-			},
-			testUtils.Request{
-				Request: ` {
-						commits(groupBy: [fieldId]) {
-							fieldId
-						}
-					}`,
-				Results: map[string]any{
-					"commits": []map[string]any{
-						{
-							"fieldId": "1",
-						},
-						{
-							"fieldId": "2",
-						},
-						{
-							"fieldId": "C",
-						},
-					},
-				},
-			},
-		},
-	}
-
-	testUtils.ExecuteTestCase(t, test)
-}
-
-func TestQueryCommitsWithGroupByFieldIDWithChild(t *testing.T) {
-	test := testUtils.TestCase{
-		Description: "Simple all commits query, group by fieldId",
-		Actions: []any{
-			updateUserCollectionSchema(),
-			testUtils.CreateDoc{
-				CollectionID: 0,
-				Doc: `{
-						"name":	"John",
-						"age":	21
-					}`,
-			},
-			testUtils.UpdateDoc{
-				CollectionID: 0,
-				DocID:        0,
-				Doc: `{
-					"age":	22
-				}`,
-			},
-			testUtils.Request{
-				Request: ` {
-						commits(groupBy: [fieldId]) {
-							fieldId
-							_group {
-								height
-							}
-						}
-					}`,
-				Results: map[string]any{
-					"commits": []map[string]any{
-						{
-							"fieldId": "1",
-							"_group": []map[string]any{
-								{
-									"height": int64(2),
-								},
-								{
-									"height": int64(1),
-								},
-							},
-						},
-						{
-							"fieldId": "2",
-							"_group": []map[string]any{
-								{
-									"height": int64(1),
-								},
-							},
-						},
-						{
-							"fieldId": "C",
+							"fieldName": "_C",
 							"_group": []map[string]any{
 								{
 									"height": int64(2),

--- a/tests/integration/query/commits/with_null_input_test.go
+++ b/tests/integration/query/commits/with_null_input_test.go
@@ -92,9 +92,8 @@ func TestQueryCommitsWithNullCID(t *testing.T) {
 	testUtils.ExecuteTestCase(t, test)
 }
 
-func TestQueryCommitsWithNullFieldID(t *testing.T) {
+func TestQueryCommitsWithNullField(t *testing.T) {
 	test := testUtils.TestCase{
-		Description: "Simple all commits query with null fieldId",
 		Actions: []any{
 			updateUserCollectionSchema(),
 			testUtils.CreateDoc{
@@ -106,7 +105,7 @@ func TestQueryCommitsWithNullFieldID(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: `query {
-						commits(fieldId: null) {
+						commits(fieldName: null) {
 							cid
 						}
 					}`,

--- a/tests/integration/query/latest_commits/with_doc_id_field_test.go
+++ b/tests/integration/query/latest_commits/with_doc_id_field_test.go
@@ -30,39 +30,7 @@ func TestQueryLatestCommitsWithDocIDAndFieldName(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: `query {
-					latestCommits(docID: "bae-c9fb0fa4-1195-589c-aa54-e68333fb90b3", fieldId: "age") {
-						cid
-						links {
-							cid
-							name
-						}
-					}
-				}`,
-				Results: map[string]any{
-					"latestCommits": []map[string]any{},
-				},
-			},
-		},
-	}
-
-	executeTestCase(t, test)
-}
-
-// This test is for documentation reasons only. This is not
-// desired behaviour (Users should not be specifying field ids).
-func TestQueryLatestCommitsWithDocIDAndFieldId(t *testing.T) {
-	test := testUtils.TestCase{
-		Description: "Simple latest commits query with docID and field id",
-		Actions: []any{
-			testUtils.CreateDoc{
-				Doc: `{
-					"name": "John",
-					"age": 21
-				}`,
-			},
-			testUtils.Request{
-				Request: `query {
-					latestCommits(docID: "bae-c9fb0fa4-1195-589c-aa54-e68333fb90b3", fieldId: "1") {
+					latestCommits(docID: "bae-c9fb0fa4-1195-589c-aa54-e68333fb90b3", fieldName: "age") {
 						cid
 						links {
 							cid
@@ -85,6 +53,36 @@ func TestQueryLatestCommitsWithDocIDAndFieldId(t *testing.T) {
 	executeTestCase(t, test)
 }
 
+func TestQueryLatestCommitsWithDocIDAndFieldId(t *testing.T) {
+	test := testUtils.TestCase{
+		Description: "Simple latest commits query with docID and field id",
+		Actions: []any{
+			testUtils.CreateDoc{
+				Doc: `{
+					"name": "John",
+					"age": 21
+				}`,
+			},
+			testUtils.Request{
+				Request: `query {
+					latestCommits(docID: "bae-c9fb0fa4-1195-589c-aa54-e68333fb90b3", fieldName: "1") {
+						cid
+						links {
+							cid
+							name
+						}
+					}
+				}`,
+				Results: map[string]any{
+					"latestCommits": []map[string]any{},
+				},
+			},
+		},
+	}
+
+	executeTestCase(t, test)
+}
+
 // This test is for documentation reasons only. This is not
 // desired behaviour (Users should not be specifying field ids).
 func TestQueryLatestCommitsWithDocIDAndCompositeFieldId(t *testing.T) {
@@ -99,7 +97,7 @@ func TestQueryLatestCommitsWithDocIDAndCompositeFieldId(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: `query {
-					latestCommits(docID: "bae-c9fb0fa4-1195-589c-aa54-e68333fb90b3", fieldId: "C") {
+					latestCommits(docID: "bae-c9fb0fa4-1195-589c-aa54-e68333fb90b3", fieldName: "_C") {
 						cid
 						links {
 							cid

--- a/tests/integration/query/latest_commits/with_field_test.go
+++ b/tests/integration/query/latest_commits/with_field_test.go
@@ -31,7 +31,7 @@ func TestQueryLatestCommitsWithField(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: `query {
-					latestCommits (fieldId: "Age") {
+					latestCommits (fieldName: "Age") {
 						cid
 						links {
 							cid
@@ -62,7 +62,7 @@ func TestQueryLatestCommitsWithFieldId(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: `query {
-					latestCommits (fieldId: "1") {
+					latestCommits (fieldName: "1") {
 						cid
 						links {
 							cid

--- a/tests/integration/query/simple/with_version_test.go
+++ b/tests/integration/query/simple/with_version_test.go
@@ -240,7 +240,6 @@ func TestQuery_WithAllCommitFields_NoError(t *testing.T) {
 							cid
 							delta
 							docID
-							fieldId
 							fieldName
 							height
 							links {
@@ -261,8 +260,7 @@ func TestQuery_WithAllCommitFields_NoError(t *testing.T) {
 									"cid":       "bafyreidwu4r345cq63vwr7p3hjekedge457y3tp32w7run76uj3le2zx34",
 									"delta":     nil,
 									"docID":     "bae-d4303725-7db9-53d2-b324-f3ee44020e52",
-									"fieldId":   "C",
-									"fieldName": nil,
+									"fieldName": "_C",
 									"height":    int64(1),
 									"links": []map[string]any{
 										{
@@ -318,7 +316,6 @@ func TestQuery_WithAllCommitFieldsWithUpdate_NoError(t *testing.T) {
 							cid
 							delta
 							docID
-							fieldId
 							fieldName
 							height
 							links {
@@ -340,8 +337,7 @@ func TestQuery_WithAllCommitFieldsWithUpdate_NoError(t *testing.T) {
 									"cid":       "bafyreichg2fm3tzwibfzakwmzguk5wlmyw7vmyhz6zt6gqu37pnzywk564",
 									"delta":     nil,
 									"docID":     docID,
-									"fieldId":   "C",
-									"fieldName": nil,
+									"fieldName": "_C",
 									"height":    int64(2),
 									"links": []map[string]any{
 										{
@@ -359,8 +355,7 @@ func TestQuery_WithAllCommitFieldsWithUpdate_NoError(t *testing.T) {
 									"cid":       "bafyreidwu4r345cq63vwr7p3hjekedge457y3tp32w7run76uj3le2zx34",
 									"delta":     nil,
 									"docID":     docID,
-									"fieldId":   "C",
-									"fieldName": nil,
+									"fieldName": "_C",
 									"height":    int64(1),
 									"links": []map[string]any{
 										{

--- a/tests/integration/schema/updates/add/field/create_update_test.go
+++ b/tests/integration/schema/updates/add/field/create_update_test.go
@@ -44,6 +44,7 @@ func TestSchemaUpdatesAddFieldWithCreateWithUpdateAfterSchemaUpdateAndVersionJoi
 						name
 						_version {
 							schemaVersionId
+							fieldName
 						}
 					}
 				}`,
@@ -54,6 +55,7 @@ func TestSchemaUpdatesAddFieldWithCreateWithUpdateAfterSchemaUpdateAndVersionJoi
 							"_version": []map[string]any{
 								{
 									"schemaVersionId": initialSchemaVersionID,
+									"fieldName":       "_C",
 								},
 							},
 						},
@@ -144,7 +146,7 @@ func TestSchemaUpdatesAddFieldWithCreateWithUpdateAfterSchemaUpdateAndCommitQuer
 			},
 			testUtils.Request{
 				Request: `query {
-					commits (fieldId: "C") {
+					commits (fieldName: "_C") {
 						schemaVersionId
 					}
 				}`,

--- a/tests/integration/schema/updates/move/simple_test.go
+++ b/tests/integration/schema/updates/move/simple_test.go
@@ -69,7 +69,7 @@ func TestSchemaUpdatesMoveCollectionDoesNothing(t *testing.T) {
 			testUtils.Request{
 				// Assert that the version ID remains the same
 				Request: `query {
-					commits (fieldId: "C") {
+					commits (fieldName: "_C") {
 						schemaVersionId
 					}
 				}`,

--- a/tests/integration/signature/branchable_test.go
+++ b/tests/integration/signature/branchable_test.go
@@ -39,7 +39,6 @@ func TestSignature_WithBranchableCollection_ShouldSignCollectionBlocks(t *testin
 				Request: `query {
 						commits {
 							fieldName
-							fieldId
 							signature {
 								type
 								identity
@@ -51,7 +50,6 @@ func TestSignature_WithBranchableCollection_ShouldSignCollectionBlocks(t *testin
 					"commits": []map[string]any{
 						{
 							"fieldName": nil,
-							"fieldId":   nil,
 							"signature": map[string]any{
 								"type":     coreblock.SignatureTypeECDSA256K,
 								"identity": gomega.Not(gomega.BeEmpty()),
@@ -60,7 +58,6 @@ func TestSignature_WithBranchableCollection_ShouldSignCollectionBlocks(t *testin
 						},
 						{
 							"fieldName": "name",
-							"fieldId":   "1",
 							"signature": map[string]any{
 								"type":     coreblock.SignatureTypeECDSA256K,
 								"identity": gomega.Not(gomega.BeEmpty()),
@@ -68,8 +65,7 @@ func TestSignature_WithBranchableCollection_ShouldSignCollectionBlocks(t *testin
 							},
 						},
 						{
-							"fieldName": nil,
-							"fieldId":   "C",
+							"fieldName": "_C",
 							"signature": map[string]any{
 								"type":     coreblock.SignatureTypeECDSA256K,
 								"identity": gomega.Not(gomega.BeEmpty()),

--- a/tests/integration/signature/commit_test.go
+++ b/tests/integration/signature/commit_test.go
@@ -98,7 +98,7 @@ func TestSignature_WithCommitQuery_ShouldIncludeSignatureData(t *testing.T) {
 							},
 						},
 						{
-							"fieldName": nil,
+							"fieldName": "_C",
 							"signature": map[string]any{
 								"type":     coreblock.SignatureTypeECDSA256K,
 								"identity": sameIdentity,
@@ -164,7 +164,7 @@ func TestSignature_WithUpdatedDocsAndCommitQuery_ShouldSignOnlyFirstFieldBlocks(
 							"signature": nil,
 						},
 						{
-							"fieldName": nil,
+							"fieldName": "_C",
 							"height":    3,
 							"signature": map[string]any{
 								"type":     coreblock.SignatureTypeECDSA256K,
@@ -178,7 +178,7 @@ func TestSignature_WithUpdatedDocsAndCommitQuery_ShouldSignOnlyFirstFieldBlocks(
 							"signature": nil,
 						},
 						{
-							"fieldName": nil,
+							"fieldName": "_C",
 							"height":    2,
 							"signature": map[string]any{
 								"type":     coreblock.SignatureTypeECDSA256K,
@@ -196,7 +196,7 @@ func TestSignature_WithUpdatedDocsAndCommitQuery_ShouldSignOnlyFirstFieldBlocks(
 							},
 						},
 						{
-							"fieldName": nil,
+							"fieldName": "_C",
 							"height":    1,
 							"signature": map[string]any{
 								"type":     coreblock.SignatureTypeECDSA256K,
@@ -234,7 +234,7 @@ func TestSignature_WithDeletedDocAndCommitQuery_ShouldIncludeSignatureData(t *te
 			testUtils.Request{
 				Request: `
 					query {
-						commits(order: {height: DESC}, fieldId: "C") {
+						commits(order: {height: DESC}, fieldName: "_C") {
 							fieldName
 							height
 							signature {
@@ -248,7 +248,7 @@ func TestSignature_WithDeletedDocAndCommitQuery_ShouldIncludeSignatureData(t *te
 				Results: map[string]any{
 					"commits": []map[string]any{
 						{
-							"fieldName": nil,
+							"fieldName": "_C",
 							"height":    2,
 							"signature": map[string]any{
 								"type":     coreblock.SignatureTypeECDSA256K,
@@ -257,7 +257,7 @@ func TestSignature_WithDeletedDocAndCommitQuery_ShouldIncludeSignatureData(t *te
 							},
 						},
 						{
-							"fieldName": nil,
+							"fieldName": "_C",
 							"height":    1,
 							"signature": map[string]any{
 								"type":     coreblock.SignatureTypeECDSA256K,
@@ -326,7 +326,7 @@ func TestSignature_WithEd25519KeyType_ShouldIncludeSignatureData(t *testing.T) {
 							},
 						},
 						{
-							"fieldName": nil,
+							"fieldName": "_C",
 							"signature": map[string]any{
 								"type":     coreblock.SignatureTypeEd25519,
 								"identity": newIdentityMatcher(testUtils.NodeIdentity(0).Value()),
@@ -381,7 +381,7 @@ func TestSignature_WithClientIdentity_ShouldUseItForSigning(t *testing.T) {
 			testUtils.Request{
 				Request: `
 					query {
-						commits(fieldId: "C", order: {height: DESC}) {
+						commits(fieldName: "_C", order: {height: DESC}) {
 							height
 							signature {
 								type

--- a/tests/integration/signature/peer_test.go
+++ b/tests/integration/signature/peer_test.go
@@ -202,7 +202,7 @@ func TestDocSignature_WithPeersAnDifferentKeyTypes_ShouldSync(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: `query {
-						commits(fieldId: "C") {
+						commits(fieldName: "_C") {
 							signature {
 								type
 								identity
@@ -306,7 +306,7 @@ func TestDocSignature_WithPeersAnDifferentKeyTypesUpdatingSameDoc_ShouldSync(t *
 			},
 			testUtils.Request{
 				Request: `query {
-						commits(fieldId: "C", order: {height: DESC}) {
+						commits(fieldName: "_C", order: {height: DESC}) {
 							signature {
 								type
 								identity


### PR DESCRIPTION
## Relevant issue(s)

Resolves #1453

## Description

Replaces the commit query fieldID parameter with a new fieldName param.  Also removes the commit query fieldID field for the same reason (a fieldName field already exists).

Whilst fieldName is less efficient (for now) when providing anything but the composite identifier (the most common/important case and includes the `_version` object in doc queries), it is much simpler for users.  FieldID is soon to become an internal-only concept, and will make even less sense to users than it currently does.

FieldID may return at some point, using the field CID that will be introduced in later PR (hopefully this sprint).

Using `_C` to identify composites is questionable, IMO, it is good enough for now, and lets me crack on with my primary goal.  Long term we might want to split this out to another param, e.g. '_compositesOnly'.

This PR was broken out of https://github.com/sourcenetwork/defradb/issues/3699 and so is part of the epic https://github.com/sourcenetwork/defradb/issues/3556