### PR TITLE
perf: Cache collection short ids within txn context

### DIFF
--- a/cli/utils.go
+++ b/cli/utils.go
@@ -141,7 +141,7 @@ func setContextTransaction(cmd *cobra.Command, txId uint64) error {
 	if err != nil {
 		return err
 	}
-	ctx := db.SetContextTxn(cmd.Context(), tx)
+	ctx := db.InitContext(cmd.Context(), tx)
 	cmd.SetContext(ctx)
 	return nil
 }

--- a/http/middleware.go
+++ b/http/middleware.go
@@ -75,7 +75,7 @@ func TransactionMiddleware(next http.Handler) http.Handler {
 		}
 		ctx := req.Context()
 		if val, ok := tx.(datastore.Txn); ok {
-			ctx = db.SetContextTxn(ctx, val)
+			ctx = db.InitContext(ctx, val)
 		}
 		next.ServeHTTP(rw, req.WithContext(ctx))
 	})

--- a/internal/db/backup_test.go
+++ b/internal/db/backup_test.go
@@ -68,7 +68,7 @@ func TestBasicExport_WithNormalFormatting_NoError(t *testing.T) {
 	defer txn.Discard(ctx)
 
 	ctx = identity.WithContext(ctx, acpIdentity.None)
-	ctx = SetContextTxn(ctx, txn)
+	ctx = InitContext(ctx, txn)
 
 	filepath := t.TempDir() + "/test.json"
 	err = db.basicExport(ctx, &client.BackupConfig{Filepath: filepath})
@@ -133,7 +133,7 @@ func TestBasicExport_WithPrettyFormatting_NoError(t *testing.T) {
 	defer txn.Discard(ctx)
 
 	ctx = identity.WithContext(ctx, acpIdentity.None)
-	ctx = SetContextTxn(ctx, txn)
+	ctx = InitContext(ctx, txn)
 
 	filepath := t.TempDir() + "/test.json"
 	err = db.basicExport(ctx, &client.BackupConfig{Filepath: filepath, Pretty: true})
@@ -198,7 +198,7 @@ func TestBasicExport_WithSingleCollection_NoError(t *testing.T) {
 	defer txn.Discard(ctx)
 
 	ctx = identity.WithContext(ctx, acpIdentity.None)
-	ctx = SetContextTxn(ctx, txn)
+	ctx = InitContext(ctx, txn)
 
 	filepath := t.TempDir() + "/test.json"
 	err = db.basicExport(ctx, &client.BackupConfig{Filepath: filepath, Collections: []string{"Address"}})
@@ -275,7 +275,7 @@ func TestBasicExport_WithMultipleCollectionsAndUpdate_NoError(t *testing.T) {
 	defer txn.Discard(ctx)
 
 	ctx = identity.WithContext(ctx, acpIdentity.None)
-	ctx = SetContextTxn(ctx, txn)
+	ctx = InitContext(ctx, txn)
 
 	filepath := t.TempDir() + "/test.json"
 	err = db.basicExport(ctx, &client.BackupConfig{Filepath: filepath})
@@ -340,7 +340,7 @@ func TestBasicExport_EnsureFileOverwrite_NoError(t *testing.T) {
 	defer txn.Discard(ctx)
 
 	ctx = identity.WithContext(ctx, acpIdentity.None)
-	ctx = SetContextTxn(ctx, txn)
+	ctx = InitContext(ctx, txn)
 
 	filepath := t.TempDir() + "/test.json"
 
@@ -388,7 +388,7 @@ func TestBasicImport_WithMultipleCollectionsAndObjects_NoError(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx = identity.WithContext(ctx, acpIdentity.None)
-	ctx = SetContextTxn(ctx, txn)
+	ctx = InitContext(ctx, txn)
 
 	filepath := t.TempDir() + "/test.json"
 
@@ -408,7 +408,7 @@ func TestBasicImport_WithMultipleCollectionsAndObjects_NoError(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx = identity.WithContext(ctx, acpIdentity.None)
-	ctx = SetContextTxn(ctx, txn)
+	ctx = InitContext(ctx, txn)
 
 	col1, err := db.getCollectionByName(ctx, "Address")
 	require.NoError(t, err)
@@ -451,7 +451,7 @@ func TestBasicImport_WithJSONArray_ReturnError(t *testing.T) {
 
 	txn, err := db.NewTxn(ctx, false)
 	require.NoError(t, err)
-	ctx = SetContextTxn(ctx, txn)
+	ctx = InitContext(ctx, txn)
 
 	filepath := t.TempDir() + "/test.json"
 
@@ -487,7 +487,7 @@ func TestBasicImport_WithObjectCollection_ReturnError(t *testing.T) {
 
 	txn, err := db.NewTxn(ctx, false)
 	require.NoError(t, err)
-	ctx = SetContextTxn(ctx, txn)
+	ctx = InitContext(ctx, txn)
 
 	filepath := t.TempDir() + "/test.json"
 
@@ -523,7 +523,7 @@ func TestBasicImport_WithInvalidFilepath_ReturnError(t *testing.T) {
 
 	txn, err := db.NewTxn(ctx, false)
 	require.NoError(t, err)
-	ctx = SetContextTxn(ctx, txn)
+	ctx = InitContext(ctx, txn)
 
 	filepath := t.TempDir() + "/test.json"
 
@@ -560,7 +560,7 @@ func TestBasicImport_WithInvalidCollection_ReturnError(t *testing.T) {
 
 	txn, err := db.NewTxn(ctx, false)
 	require.NoError(t, err)
-	ctx = SetContextTxn(ctx, txn)
+	ctx = InitContext(ctx, txn)
 
 	filepath := t.TempDir() + "/test.json"
 

--- a/internal/db/context.go
+++ b/internal/db/context.go
@@ -16,66 +16,12 @@ import (
 	"github.com/sourcenetwork/defradb/datastore"
 )
 
-// txnContextKey is the key type for transaction context values.
-type txnContextKey struct{}
-
-// explicitTxn is a transaction that is managed outside of a db operation.
-type explicitTxn struct {
-	datastore.Txn
-}
-
-func (t *explicitTxn) Commit(ctx context.Context) error {
-	return nil // do nothing
-}
-
-func (t *explicitTxn) Discard(ctx context.Context) {
-	// do nothing
-}
-
-// transactionDB is a db that can create transactions.
-type transactionDB interface {
-	NewTxn(context.Context, bool) (datastore.Txn, error)
-}
-
-// ensureContextTxn ensures that the returned context has a transaction
-// and an identity.
+// InitContext returns a new context with all caches initialized and linked to
+// the given transaction.
 //
-// If a transactions exists on the context it will be made explicit,
-// otherwise a new implicit transaction will be created.
-//
-// The returned context will contain the transaction and identity
-// along with the copied values from the input context.
-func ensureContextTxn(ctx context.Context, db transactionDB, readOnly bool) (context.Context, datastore.Txn, error) {
-	// explicit transaction
-	txn, ok := TryGetContextTxn(ctx)
-	if ok {
-		return SetContextTxn(ctx, &explicitTxn{txn}), &explicitTxn{txn}, nil
-	}
-	txn, err := db.NewTxn(ctx, readOnly)
-	if err != nil {
-		return nil, txn, err
-	}
-	return SetContextTxn(ctx, txn), txn, nil
-}
-
-// mustGetContextTxn returns the transaction from the context or panics.
-//
-// This should only be called from private functions within the db package
-// where we ensure an implicit or explicit transaction always exists.
-func mustGetContextTxn(ctx context.Context) datastore.Txn {
-	return ctx.Value(txnContextKey{}).(datastore.Txn)
-}
-
-// TryGetContextTxn returns a transaction and a bool indicating if the
-// txn was retrieved from the given context.
-func TryGetContextTxn(ctx context.Context) (datastore.Txn, bool) {
-	txn, ok := ctx.Value(txnContextKey{}).(datastore.Txn)
-	return txn, ok
-}
-
-// SetContextTxn returns a new context with the txn value set.
-//
-// This will overwrite any previously set transaction value.
-func SetContextTxn(ctx context.Context, txn datastore.Txn) context.Context {
-	return context.WithValue(ctx, txnContextKey{}, txn)
+// This will overwrite any previously set cached values - this is desirable as
+// the cached values must be tied to the transaction, otherwise we risk leaking
+// information between transactions.
+func InitContext(ctx context.Context, txn datastore.Txn) context.Context {
+	return setContextTxn(ctx, txn)
 }

--- a/internal/db/context.go
+++ b/internal/db/context.go
@@ -14,6 +14,7 @@ import (
 	"context"
 
 	"github.com/sourcenetwork/defradb/datastore"
+	"github.com/sourcenetwork/defradb/internal/db/id"
 )
 
 // InitContext returns a new context with all caches initialized and linked to
@@ -23,5 +24,8 @@ import (
 // the cached values must be tied to the transaction, otherwise we risk leaking
 // information between transactions.
 func InitContext(ctx context.Context, txn datastore.Txn) context.Context {
-	return setContextTxn(ctx, txn)
+	ctx = setContextTxn(ctx, txn)
+	ctx = id.InitCollectionShortIDCache(ctx)
+
+	return ctx
 }

--- a/internal/db/context_test.go
+++ b/internal/db/context_test.go
@@ -28,7 +28,7 @@ func TestEnsureContextTxnExplicit(t *testing.T) {
 	require.NoError(t, err)
 
 	// set an explicit transaction
-	ctx = SetContextTxn(ctx, txn)
+	ctx = InitContext(ctx, txn)
 
 	ctx, txn, err = ensureContextTxn(ctx, db, true)
 	require.NoError(t, err)

--- a/internal/db/id/collection.go
+++ b/internal/db/id/collection.go
@@ -26,6 +26,12 @@ func GetShortCollectionID(
 	txn datastore.Txn,
 	collectionID string,
 ) (uint32, error) {
+	cache := getCollectionShortIDCache(ctx)
+	shortID, ok := cache[collectionID]
+	if ok {
+		return shortID, nil
+	}
+
 	key := keys.NewCollectionID(collectionID)
 
 	valueBytes, err := txn.Systemstore().Get(ctx, key.Bytes())
@@ -37,7 +43,10 @@ func GetShortCollectionID(
 	if err != nil {
 		return 0, err
 	}
-	return uint32(v), nil
+	shortID = uint32(v)
+
+	cache[collectionID] = shortID
+	return shortID, nil
 }
 
 // SetShortCollectionID sets and stores the short collection id, if it does not already exist.
@@ -46,6 +55,12 @@ func SetShortCollectionID(
 	txn datastore.Txn,
 	collectionID string,
 ) error {
+	cache := getCollectionShortIDCache(ctx)
+	_, ok := cache[collectionID]
+	if ok {
+		return nil
+	}
+
 	key := keys.NewCollectionID(collectionID)
 
 	hasShortID, err := txn.Systemstore().Has(ctx, key.Bytes())
@@ -61,10 +76,38 @@ func SetShortCollectionID(
 		return err
 	}
 
-	shortID, err := colSeq.Next(ctx, txn)
+	sID, err := colSeq.Next(ctx, txn)
+	if err != nil {
+		return err
+	}
+	shortID := uint32(sID)
+
+	err = txn.Systemstore().Set(ctx, key.Bytes(), []byte(strconv.Itoa(int(shortID))))
 	if err != nil {
 		return err
 	}
 
-	return txn.Systemstore().Set(ctx, key.Bytes(), []byte(strconv.Itoa(int(shortID))))
+	cache[collectionID] = shortID
+
+	return nil
+}
+
+type collectionShortIDCacheKey struct{}
+
+var collectionShortIDCacheKeyValue = collectionShortIDCacheKey{}
+
+type collectionShortIDCache map[string]uint32
+
+// InitCollectionShortIDCache initialializes the context with a none-nil collection
+// short-id cache.
+//
+// It is done to avoid an extra check to see if the cache exists or not when fetching
+// it from the context.
+func InitCollectionShortIDCache(ctx context.Context) context.Context {
+	return context.WithValue(ctx, collectionShortIDCacheKeyValue, collectionShortIDCache{})
+}
+
+// getCollectionShortIDCache retrieves the collection short-id cache from the given context.
+func getCollectionShortIDCache(ctx context.Context) collectionShortIDCache {
+	return ctx.Value(collectionShortIDCacheKeyValue).(collectionShortIDCache) //nolint:forcetypeassert
 }

--- a/internal/db/id/collection.go
+++ b/internal/db/id/collection.go
@@ -94,8 +94,6 @@ func SetShortCollectionID(
 
 type collectionShortIDCacheKey struct{}
 
-var collectionShortIDCacheKeyValue = collectionShortIDCacheKey{}
-
 type collectionShortIDCache map[string]uint32
 
 // InitCollectionShortIDCache initialializes the context with a none-nil collection
@@ -104,10 +102,10 @@ type collectionShortIDCache map[string]uint32
 // It is done to avoid an extra check to see if the cache exists or not when fetching
 // it from the context.
 func InitCollectionShortIDCache(ctx context.Context) context.Context {
-	return context.WithValue(ctx, collectionShortIDCacheKeyValue, collectionShortIDCache{})
+	return context.WithValue(ctx, collectionShortIDCacheKey{}, collectionShortIDCache{})
 }
 
 // getCollectionShortIDCache retrieves the collection short-id cache from the given context.
 func getCollectionShortIDCache(ctx context.Context) collectionShortIDCache {
-	return ctx.Value(collectionShortIDCacheKeyValue).(collectionShortIDCache) //nolint:forcetypeassert
+	return ctx.Value(collectionShortIDCacheKey{}).(collectionShortIDCache) //nolint:forcetypeassert
 }

--- a/internal/db/index_test.go
+++ b/internal/db/index_test.go
@@ -149,7 +149,7 @@ func (f *indexTestFixture) createUserCollectionIndexOnAge() client.IndexDescript
 }
 
 func (f *indexTestFixture) dropIndex(colName, indexName string) error {
-	ctx := SetContextTxn(f.ctx, f.txn)
+	ctx := InitContext(f.ctx, f.txn)
 	return f.db.dropCollectionIndex(ctx, colName, indexName)
 }
 
@@ -165,7 +165,7 @@ func (f *indexTestFixture) createCollectionIndexFor(
 	collectionName string,
 	desc client.IndexDescriptionCreateRequest,
 ) (client.IndexDescription, error) {
-	ctx := SetContextTxn(f.ctx, f.txn)
+	ctx := InitContext(f.ctx, f.txn)
 	index, err := f.db.createCollectionIndex(ctx, collectionName, desc)
 	if err == nil {
 		f.commitTxn()
@@ -480,7 +480,7 @@ func TestDropIndex_IfCollectionDoesntExist_ReturnError(t *testing.T) {
 func TestDropIndex_ShouldUpdateCollectionsDescription(t *testing.T) {
 	f := newIndexTestFixture(t)
 	defer f.db.Close()
-	ctx := SetContextTxn(f.ctx, f.txn)
+	ctx := InitContext(f.ctx, f.txn)
 	_, err := f.users.CreateIndex(ctx, getUsersIndexDescOnName())
 	require.NoError(t, err)
 	indOnAge, err := f.users.CreateIndex(ctx, getUsersIndexDescOnAge())

--- a/internal/db/merge.go
+++ b/internal/db/merge.go
@@ -575,7 +575,7 @@ func syncIndexedDoc(
 	col *collection,
 ) error {
 	// remove transaction from old context
-	oldCtx := SetContextTxn(ctx, nil)
+	oldCtx := InitContext(ctx, nil)
 
 	oldDoc, err := col.Get(oldCtx, docID, false)
 	isNewDoc := errors.Is(err, client.ErrDocumentNotFoundOrNotAuthorized)

--- a/internal/db/p2p_replicator.go
+++ b/internal/db/p2p_replicator.go
@@ -62,7 +62,7 @@ func (db *DB) SetReplicator(ctx context.Context, rep client.ReplicatorParams) er
 		return ErrSelfTargetForReplicator
 	}
 
-	ctx = SetContextTxn(ctx, txn)
+	ctx = InitContext(ctx, txn)
 
 	storedRep := client.Replicator{}
 	storedSchemas := make(map[string]struct{})
@@ -162,7 +162,7 @@ func (db *DB) getDocsHeads(
 			return
 		}
 		defer txn.Discard(ctx)
-		ctx = SetContextTxn(ctx, txn)
+		ctx = InitContext(ctx, txn)
 		for _, col := range cols {
 			keysCh, err := col.GetAllDocIDs(ctx)
 			if err != nil {
@@ -232,7 +232,7 @@ func (db *DB) DeleteReplicator(ctx context.Context, rep client.ReplicatorParams)
 	}
 
 	// set transaction for all operations
-	ctx = SetContextTxn(ctx, txn)
+	ctx = InitContext(ctx, txn)
 
 	storedRep := client.Replicator{}
 	storedSchemas := make(map[string]struct{})

--- a/internal/db/p2p_schema_root.go
+++ b/internal/db/p2p_schema_root.go
@@ -36,7 +36,7 @@ func (db *DB) AddP2PCollections(ctx context.Context, collectionIDs []string) err
 	}
 	defer txn.Discard(ctx)
 
-	ctx = SetContextTxn(ctx, txn)
+	ctx = InitContext(ctx, txn)
 
 	// first let's make sure the collections actually exists
 	storeCollections := []client.Collection{}
@@ -106,7 +106,7 @@ func (db *DB) RemoveP2PCollections(ctx context.Context, collectionIDs []string) 
 	}
 	defer txn.Discard(ctx)
 
-	ctx = SetContextTxn(ctx, txn)
+	ctx = InitContext(ctx, txn)
 
 	// first let's make sure the collections actually exists
 	storeCollections := []client.Collection{}

--- a/internal/db/subscriptions.go
+++ b/internal/db/subscriptions.go
@@ -65,7 +65,7 @@ func (db *DB) handleSubscription(ctx context.Context, r *request.Request) (<-cha
 				continue
 			}
 
-			ctx := SetContextTxn(ctx, txn)
+			ctx := InitContext(ctx, txn)
 
 			p := planner.New(ctx, identity.FromContext(ctx), db.documentACP, db, txn)
 			s := subRequest.ToSelect(evt.DocID, evt.Cid.String())

--- a/internal/db/txn.go
+++ b/internal/db/txn.go
@@ -1,0 +1,81 @@
+// Copyright 2024 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package db
+
+import (
+	"context"
+
+	"github.com/sourcenetwork/defradb/datastore"
+)
+
+// txnContextKey is the key type for transaction context values.
+type txnContextKey struct{}
+
+// explicitTxn is a transaction that is managed outside of a db operation.
+type explicitTxn struct {
+	datastore.Txn
+}
+
+func (t *explicitTxn) Commit(ctx context.Context) error {
+	return nil // do nothing
+}
+
+func (t *explicitTxn) Discard(ctx context.Context) {
+	// do nothing
+}
+
+// transactionDB is a db that can create transactions.
+type transactionDB interface {
+	NewTxn(context.Context, bool) (datastore.Txn, error)
+}
+
+// ensureContextTxn ensures that the returned context has a transaction
+// and an identity.
+//
+// If a transactions exists on the context it will be made explicit,
+// otherwise a new implicit transaction will be created.
+//
+// The returned context will contain the transaction and identity
+// along with the copied values from the input context.
+func ensureContextTxn(ctx context.Context, db transactionDB, readOnly bool) (context.Context, datastore.Txn, error) {
+	// explicit transaction
+	txn, ok := TryGetContextTxn(ctx)
+	if ok {
+		return InitContext(ctx, &explicitTxn{txn}), &explicitTxn{txn}, nil
+	}
+	txn, err := db.NewTxn(ctx, readOnly)
+	if err != nil {
+		return nil, txn, err
+	}
+	return InitContext(ctx, txn), txn, nil
+}
+
+// mustGetContextTxn returns the transaction from the context or panics.
+//
+// This should only be called from private functions within the db package
+// where we ensure an implicit or explicit transaction always exists.
+func mustGetContextTxn(ctx context.Context) datastore.Txn {
+	return ctx.Value(txnContextKey{}).(datastore.Txn) //nolint:forcetypeassert
+}
+
+// TryGetContextTxn returns a transaction and a bool indicating if the
+// txn was retrieved from the given context.
+func TryGetContextTxn(ctx context.Context) (datastore.Txn, bool) {
+	txn, ok := ctx.Value(txnContextKey{}).(datastore.Txn)
+	return txn, ok
+}
+
+// setContextTxn returns a new context with the txn value set.
+//
+// This will overwrite any previously set transaction value.
+func setContextTxn(ctx context.Context, txn datastore.Txn) context.Context {
+	return context.WithValue(ctx, txnContextKey{}, txn)
+}

--- a/js/utils.go
+++ b/js/utils.go
@@ -83,7 +83,7 @@ func contextArg(args []js.Value, index int, txns *sync.Map) (context.Context, er
 	encrypt, encryptFields := contextEncryptionArg(args[index])
 	ctx = encryption.SetContextConfigFromParams(ctx, encrypt, encryptFields)
 	ctx = acpIdentity.WithContext(ctx, identity)
-	ctx = db.SetContextTxn(ctx, txn)
+	ctx = db.InitContext(ctx, txn)
 	return ctx, nil
 }
 

--- a/tests/integration/lens.go
+++ b/tests/integration/lens.go
@@ -60,7 +60,7 @@ func configureMigration(
 	_, nodes := getNodesWithIDs(action.NodeID, s.nodes)
 	for _, node := range nodes {
 		txn := getTransaction(s, node.Client, action.TransactionID, action.ExpectedError)
-		ctx := db.SetContextTxn(s.ctx, txn)
+		ctx := db.InitContext(s.ctx, txn)
 
 		err := node.SetMigration(ctx, action.LensConfig)
 		expectedErrorRaised := AssertError(s.t, s.testCase.Description, err, action.ExpectedError)

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -1178,7 +1178,7 @@ func getCollections(
 	_, nodes := getNodesWithIDs(action.NodeID, s.nodes)
 	for _, node := range nodes {
 		txn := getTransaction(s, node, action.TransactionID, "")
-		ctx := db.SetContextTxn(s.ctx, txn)
+		ctx := db.InitContext(s.ctx, txn)
 		results, err := node.GetCollections(ctx, action.FilterOptions)
 		resultDescriptions := make([]client.CollectionVersion, len(results))
 		for i, col := range results {
@@ -1325,7 +1325,7 @@ func createDocViaColSave(
 	}
 
 	txn := getTransaction(s, node, immutable.None[int](), action.ExpectedError)
-	ctx := makeContextForDocCreate(s, db.SetContextTxn(s.ctx, txn), nodeIndex, &action)
+	ctx := makeContextForDocCreate(s, db.InitContext(s.ctx, txn), nodeIndex, &action)
 
 	docIDs := make([]client.DocID, len(docs))
 	for i, doc := range docs {
@@ -1357,7 +1357,7 @@ func createDocViaColCreate(
 	}
 
 	txn := getTransaction(s, node, immutable.None[int](), action.ExpectedError)
-	ctx := makeContextForDocCreate(s, db.SetContextTxn(s.ctx, txn), nodeIndex, &action)
+	ctx := makeContextForDocCreate(s, db.InitContext(s.ctx, txn), nodeIndex, &action)
 
 	switch {
 	case len(docs) > 1:
@@ -1418,7 +1418,7 @@ func createDocViaGQL(
 	req := fmt.Sprintf(`mutation { %s(%s) { _docID } }`, key, params)
 
 	txn := getTransaction(s, node, immutable.None[int](), action.ExpectedError)
-	ctx := getContextWithIdentity(db.SetContextTxn(s.ctx, txn), s, action.Identity, nodeIndex)
+	ctx := getContextWithIdentity(db.InitContext(s.ctx, txn), s, action.Identity, nodeIndex)
 
 	result := node.ExecRequest(ctx, req)
 	if len(result.GQL.Errors) > 0 {
@@ -1866,7 +1866,7 @@ nodeLoop:
 		nodeID := nodeIDs[index]
 		txn := getTransaction(s, node, action.TransactionID, action.ExpectedError)
 
-		ctx := getContextWithIdentity(db.SetContextTxn(s.ctx, txn), s, action.Identity, nodeID)
+		ctx := getContextWithIdentity(db.InitContext(s.ctx, txn), s, action.Identity, nodeID)
 
 		var options []client.RequestOption
 		if action.OperationName.HasValue() {


### PR DESCRIPTION
## Relevant issue(s)

Resolves #3702

## Description

Caches collection short ids within txn context, introducing a framework for all future txn-scoped caches to use (such as collection versions, and field short ids).

Performance impact of this PR will be quite small, this will have a much bigger impact when applied to collection versions, and field short-ids.