### PR TITLE
chore: Improve node startup sync and feedback

### DIFF
--- a/cli/start.go
+++ b/cli/start.go
@@ -190,6 +190,13 @@ func MakeStartCommand() *cobra.Command {
 			if err := n.Start(cmd.Context()); err != nil {
 				return err
 			}
+			// If the context has a messageChans defined, we pass along the relevant information.
+			// For now this is mostly useful for the CLI integration tests.
+			messageChans, ok := tryGetContextMessageChans(cmd.Context())
+			if ok && messageChans.APIURL != nil {
+				messageChans.APIURL <- n.APIURL
+				close(messageChans.APIURL)
+			}
 
 		RESTART:
 			// after a restart we need to resubscribe

--- a/cli/start.go
+++ b/cli/start.go
@@ -192,7 +192,7 @@ func MakeStartCommand() *cobra.Command {
 			}
 			// If the context has a messageChans defined, we pass along the relevant information.
 			// For now this is mostly useful for the CLI integration tests.
-			messageChans, ok := tryGetContextMessageChans(cmd.Context())
+			messageChans, ok := node.TryGetContextMessageChans(cmd.Context())
 			if ok && messageChans.APIURL != nil {
 				messageChans.APIURL <- n.APIURL
 				close(messageChans.APIURL)

--- a/cli/test/action/action.go
+++ b/cli/test/action/action.go
@@ -11,24 +11,16 @@
 package action
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
 	"io"
-	"os"
-	"strings"
-	"sync"
-	"time"
 
 	"github.com/sourcenetwork/testo/action"
 
 	"github.com/sourcenetwork/defradb/cli"
 	"github.com/sourcenetwork/defradb/cli/test/state"
-	"github.com/sourcenetwork/defradb/errors"
 )
-
-var stdErr *os.File = os.Stderr
 
 type Action = action.Action
 type Actions = action.Actions
@@ -117,6 +109,22 @@ func execute(ctx context.Context, args []string) error {
 	return err
 }
 
+func executeSimple(ctx context.Context, args []string) error {
+	cmd := cli.NewDefraCommand()
+	cmd.SetArgs(args)
+
+	return cmd.ExecuteContext(ctx)
+}
+
+func asyncExecute(ctx context.Context, args []string) chan error {
+	err := make(chan error)
+	go func() {
+		err <- executeSimple(ctx, args)
+		close(err)
+	}()
+	return err
+}
+
 func executeStream(ctx context.Context, args []string) (io.ReadCloser, io.ReadCloser, error) {
 	stdOutRead, stdOutWrite := io.Pipe()
 	stdErrRead, stdErrWrite := io.Pipe()
@@ -136,88 +144,4 @@ func executeStream(ctx context.Context, args []string) (io.ReadCloser, io.ReadCl
 	}()
 
 	return stdOutRead, stdErrRead, nil
-}
-
-// executeUntil executes a defra command with the given args and will block until it reads the given
-// until string in stderr.
-func executeUntil(ctx context.Context, s *state.State, args []string, until string) (string, error) {
-	read, write, err := os.Pipe()
-	if err != nil {
-		return "", err
-	}
-
-	cmd := cli.NewDefraCommand()
-	os.Stderr = write
-	cmd.SetArgs(args)
-
-	var wg sync.WaitGroup
-	wg.Add(1)
-
-	var targetLine string
-	scanner := bufio.NewScanner(read)
-	go func() {
-		targetReached := false
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			default:
-			}
-
-			hasValue := scanner.Scan()
-			if !hasValue {
-				time.Sleep(100 * time.Microsecond)
-				continue
-			}
-
-			// The scanner splits by new line (useful), we have to remember to add it back in.
-			// We could write our own split function to avoid this, but this is easier for now.
-			_, err := stdErr.Write(append(scanner.Bytes(), []byte("\n")...))
-			if err != nil {
-				panic(err)
-			}
-
-			if !targetReached {
-				targetReached = strings.Contains(scanner.Text(), until)
-				if targetReached {
-					targetLine = scanner.Text()
-					wg.Add(-1)
-				}
-			}
-		}
-	}()
-
-	var isDoneWg sync.WaitGroup
-	isDoneWg.Add(1)
-	go func() {
-		err := cmd.ExecuteContext(ctx)
-		if err != nil {
-			_, innerErr := stdErr.WriteString(err.Error())
-			if innerErr != nil {
-				panic(errors.Join(err, innerErr))
-			}
-		}
-		err = write.Close()
-		if err != nil {
-			panic(err)
-		}
-		isDoneWg.Done()
-	}()
-
-	originalWait := s.Wait
-	s.Wait = func() {
-		originalWait()
-		// Because we are overwriting a singleton (os.Stderr) we must wait for the full command
-		// to finish executing before we allow the next test to execute, else the next test may
-		// try and overwrite os.Stderr before this execution finishes closing down the database.
-		//
-		// That might not cause any real bother, but the go test -race flag will complain.
-		isDoneWg.Wait()
-		os.Stderr = stdErr
-	}
-
-	// Block, until until is read from stderr
-	wg.Wait()
-
-	return targetLine, nil
 }

--- a/cli/test/action/start.go
+++ b/cli/test/action/start.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/sourcenetwork/defradb/cli"
+	"github.com/sourcenetwork/defradb/node"
 )
 
 type StartCli struct {
@@ -78,10 +78,10 @@ func (a *StartCli) Execute() {
 
 	// Define a messageChans and store it on the context so that
 	// we can be notified when the node is ready.
-	messageChans := &cli.MessageChans{
+	messageChans := &node.MessageChans{
 		APIURL: make(chan string),
 	}
-	ctx := cli.SetContextMessageChans(a.s.Ctx, messageChans)
+	ctx := node.SetContextMessageChans(a.s.Ctx, messageChans)
 
 	select {
 	case err := <-asyncExecute(ctx, args):

--- a/cli/utils.go
+++ b/cli/utils.go
@@ -51,6 +51,8 @@ var (
 	// If a transaction exists, all operations will be executed
 	// in the current transaction context.
 	colContextKey = contextKey("col")
+	// messageChansContextKey is the context key for the messageChans
+	messageChansContextKey = contextKey("messageChans")
 )
 
 const (
@@ -93,6 +95,24 @@ func mustGetContextConfig(cmd *cobra.Command) *viper.Viper {
 	return cmd.Context().Value(cfgContextKey).(*viper.Viper) //nolint:forcetypeassert
 }
 
+// MessageChans contains message channels that can be used to relay important information
+// after calling `cli.Start`.
+type MessageChans struct {
+	APIURL chan string
+}
+
+// tryGetContextMessageChans returns the message channels for the current command context
+// and a boolean indicating if the message channels struct was set.
+func tryGetContextMessageChans(ctx context.Context) (*MessageChans, bool) {
+	node, ok := ctx.Value(messageChansContextKey).(*MessageChans)
+	return node, ok
+}
+
+// SetContextMessageChans sets the message channels for the current command context.
+func SetContextMessageChans(ctx context.Context, w *MessageChans) context.Context {
+	return context.WithValue(ctx, messageChansContextKey, w)
+}
+
 // mustGetContextRootDir returns the rootdir for the current command context.
 //
 // If a rootdir is not set in the current context this function panics.
@@ -119,7 +139,7 @@ func setContextDB(cmd *cobra.Command) error {
 	return nil
 }
 
-// setContextConfig sets teh config for the current command context.
+// setContextConfig sets the config for the current command context.
 func setContextConfig(cmd *cobra.Command) error {
 	rootdir := mustGetContextRootDir(cmd)
 	cfg, err := loadConfig(rootdir, cmd.Flags())

--- a/cli/utils.go
+++ b/cli/utils.go
@@ -51,8 +51,6 @@ var (
 	// If a transaction exists, all operations will be executed
 	// in the current transaction context.
 	colContextKey = contextKey("col")
-	// messageChansContextKey is the context key for the messageChans
-	messageChansContextKey = contextKey("messageChans")
 )
 
 const (
@@ -93,24 +91,6 @@ func mustGetContextHTTP(cmd *cobra.Command) *http.Client {
 // If a config is not set in the current context this function panics.
 func mustGetContextConfig(cmd *cobra.Command) *viper.Viper {
 	return cmd.Context().Value(cfgContextKey).(*viper.Viper) //nolint:forcetypeassert
-}
-
-// MessageChans contains message channels that can be used to relay important information
-// after calling `cli.Start`.
-type MessageChans struct {
-	APIURL chan string
-}
-
-// tryGetContextMessageChans returns the message channels for the current command context
-// and a boolean indicating if the message channels struct was set.
-func tryGetContextMessageChans(ctx context.Context) (*MessageChans, bool) {
-	node, ok := ctx.Value(messageChansContextKey).(*MessageChans)
-	return node, ok
-}
-
-// SetContextMessageChans sets the message channels for the current command context.
-func SetContextMessageChans(ctx context.Context, w *MessageChans) context.Context {
-	return context.WithValue(ctx, messageChansContextKey, w)
 }
 
 // mustGetContextRootDir returns the rootdir for the current command context.

--- a/http/client.go
+++ b/http/client.go
@@ -54,7 +54,7 @@ func (c *Client) NewTxn(ctx context.Context, readOnly bool) (datastore.Txn, erro
 		query.Add("read_only", "true")
 	}
 
-	methodURL := c.http.baseURL.JoinPath("tx")
+	methodURL := c.http.apiURL.JoinPath("tx")
 	methodURL.RawQuery = query.Encode()
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, methodURL.String(), nil)
@@ -74,7 +74,7 @@ func (c *Client) NewConcurrentTxn(ctx context.Context, readOnly bool) (datastore
 		query.Add("read_only", "true")
 	}
 
-	methodURL := c.http.baseURL.JoinPath("tx", "concurrent")
+	methodURL := c.http.apiURL.JoinPath("tx", "concurrent")
 	methodURL.RawQuery = query.Encode()
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, methodURL.String(), nil)
@@ -89,7 +89,7 @@ func (c *Client) NewConcurrentTxn(ctx context.Context, readOnly bool) (datastore
 }
 
 func (c *Client) BasicImport(ctx context.Context, filepath string) error {
-	methodURL := c.http.baseURL.JoinPath("backup", "import")
+	methodURL := c.http.apiURL.JoinPath("backup", "import")
 
 	body, err := json.Marshal(&client.BackupConfig{Filepath: filepath})
 	if err != nil {
@@ -104,7 +104,7 @@ func (c *Client) BasicImport(ctx context.Context, filepath string) error {
 }
 
 func (c *Client) BasicExport(ctx context.Context, config *client.BackupConfig) error {
-	methodURL := c.http.baseURL.JoinPath("backup", "export")
+	methodURL := c.http.apiURL.JoinPath("backup", "export")
 
 	body, err := json.Marshal(config)
 	if err != nil {
@@ -119,7 +119,7 @@ func (c *Client) BasicExport(ctx context.Context, config *client.BackupConfig) e
 }
 
 func (c *Client) AddSchema(ctx context.Context, schema string) ([]client.CollectionVersion, error) {
-	methodURL := c.http.baseURL.JoinPath("schema")
+	methodURL := c.http.apiURL.JoinPath("schema")
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, methodURL.String(), strings.NewReader(schema))
 	if err != nil {
@@ -144,7 +144,7 @@ func (c *Client) PatchSchema(
 	migration immutable.Option[model.Lens],
 	setAsDefaultVersion bool,
 ) error {
-	methodURL := c.http.baseURL.JoinPath("schema")
+	methodURL := c.http.apiURL.JoinPath("schema")
 
 	body, err := json.Marshal(patchSchemaRequest{patch, setAsDefaultVersion, migration})
 	if err != nil {
@@ -163,7 +163,7 @@ func (c *Client) PatchCollection(
 	ctx context.Context,
 	patch string,
 ) error {
-	methodURL := c.http.baseURL.JoinPath("collections")
+	methodURL := c.http.apiURL.JoinPath("collections")
 
 	body, err := json.Marshal(patch)
 	if err != nil {
@@ -179,7 +179,7 @@ func (c *Client) PatchCollection(
 }
 
 func (c *Client) SetActiveSchemaVersion(ctx context.Context, schemaVersionID string) error {
-	methodURL := c.http.baseURL.JoinPath("schema", "default")
+	methodURL := c.http.apiURL.JoinPath("schema", "default")
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, methodURL.String(), strings.NewReader(schemaVersionID))
 	if err != nil {
@@ -201,7 +201,7 @@ func (c *Client) AddView(
 	sdl string,
 	transform immutable.Option[model.Lens],
 ) ([]client.CollectionDefinition, error) {
-	methodURL := c.http.baseURL.JoinPath("view")
+	methodURL := c.http.apiURL.JoinPath("view")
 
 	body, err := json.Marshal(addViewRequest{query, sdl, transform})
 	if err != nil {
@@ -222,7 +222,7 @@ func (c *Client) AddView(
 }
 
 func (c *Client) RefreshViews(ctx context.Context, options client.CollectionFetchOptions) error {
-	methodURL := c.http.baseURL.JoinPath("view", "refresh")
+	methodURL := c.http.apiURL.JoinPath("view", "refresh")
 	params := url.Values{}
 	if options.Name.HasValue() {
 		params.Add("name", options.Name.Value())
@@ -248,7 +248,7 @@ func (c *Client) RefreshViews(ctx context.Context, options client.CollectionFetc
 }
 
 func (c *Client) SetMigration(ctx context.Context, config client.LensConfig) error {
-	methodURL := c.http.baseURL.JoinPath("lens")
+	methodURL := c.http.apiURL.JoinPath("lens")
 
 	body, err := json.Marshal(config)
 	if err != nil {
@@ -282,7 +282,7 @@ func (c *Client) GetCollections(
 	ctx context.Context,
 	options client.CollectionFetchOptions,
 ) ([]client.Collection, error) {
-	methodURL := c.http.baseURL.JoinPath("collections")
+	methodURL := c.http.apiURL.JoinPath("collections")
 	params := url.Values{}
 	if options.Name.HasValue() {
 		params.Add("name", options.Name.Value())
@@ -327,7 +327,7 @@ func (c *Client) GetSchemas(
 	ctx context.Context,
 	options client.SchemaFetchOptions,
 ) ([]client.SchemaDescription, error) {
-	methodURL := c.http.baseURL.JoinPath("schema")
+	methodURL := c.http.apiURL.JoinPath("schema")
 	params := url.Values{}
 	if options.ID.HasValue() {
 		params.Add("version_id", options.ID.Value())
@@ -352,7 +352,7 @@ func (c *Client) GetSchemas(
 }
 
 func (c *Client) GetAllIndexes(ctx context.Context) (map[client.CollectionName][]client.IndexDescription, error) {
-	methodURL := c.http.baseURL.JoinPath("indexes")
+	methodURL := c.http.apiURL.JoinPath("indexes")
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, methodURL.String(), nil)
 	if err != nil {
@@ -370,7 +370,7 @@ func (c *Client) ExecRequest(
 	query string,
 	opts ...client.RequestOption,
 ) *client.RequestResult {
-	methodURL := c.http.baseURL.JoinPath("graphql")
+	methodURL := c.http.apiURL.JoinPath("graphql")
 	result := &client.RequestResult{}
 
 	gqlOptions := &client.GQLOptions{}
@@ -458,7 +458,7 @@ func (c *Client) execRequestSubscription(r io.ReadCloser) chan client.GQLResult 
 }
 
 func (c *Client) PrintDump(ctx context.Context) error {
-	methodURL := c.http.baseURL.JoinPath("debug", "dump")
+	methodURL := c.http.apiURL.JoinPath("debug", "dump")
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, methodURL.String(), nil)
 	if err != nil {
@@ -469,9 +469,19 @@ func (c *Client) PrintDump(ctx context.Context) error {
 }
 
 func (c *Client) Purge(ctx context.Context) error {
-	methodURL := c.http.baseURL.JoinPath("purge")
+	methodURL := c.http.apiURL.JoinPath("purge")
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, methodURL.String(), nil)
+	if err != nil {
+		return err
+	}
+	_, err = c.http.request(req)
+	return err
+}
+
+func (c *Client) HealthCheck(ctx context.Context) error {
+	methodURL := c.http.baseURL.JoinPath("health-check")
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, methodURL.String(), nil)
 	if err != nil {
 		return err
 	}
@@ -512,7 +522,7 @@ func (c *Client) MaxTxnRetries() int {
 }
 
 func (c *Client) GetNodeIdentity(ctx context.Context) (immutable.Option[identity.PublicRawIdentity], error) {
-	methodURL := c.http.baseURL.JoinPath("node", "identity")
+	methodURL := c.http.apiURL.JoinPath("node", "identity")
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, methodURL.String(), nil)
 	if err != nil {
@@ -526,7 +536,7 @@ func (c *Client) GetNodeIdentity(ctx context.Context) (immutable.Option[identity
 }
 
 func (c *Client) VerifySignature(ctx context.Context, cid string, pubKey crypto.PublicKey) error {
-	methodURL := c.http.baseURL.JoinPath("block", "verify-signature")
+	methodURL := c.http.apiURL.JoinPath("block", "verify-signature")
 
 	params := url.Values{}
 	params.Add("cid", cid)

--- a/http/client_acp.go
+++ b/http/client_acp.go
@@ -24,7 +24,7 @@ func (c *Client) AddPolicy(
 	ctx context.Context,
 	policy string,
 ) (client.AddPolicyResult, error) {
-	methodURL := c.http.baseURL.JoinPath("acp", "policy")
+	methodURL := c.http.apiURL.JoinPath("acp", "policy")
 
 	req, err := http.NewRequestWithContext(
 		ctx,
@@ -59,7 +59,7 @@ func (c *Client) AddDocActorRelationship(
 	relation string,
 	targetActor string,
 ) (client.AddDocActorRelationshipResult, error) {
-	methodURL := c.http.baseURL.JoinPath("acp", "relationship")
+	methodURL := c.http.apiURL.JoinPath("acp", "relationship")
 
 	body, err := json.Marshal(
 		addDocActorRelationshipRequest{
@@ -107,7 +107,7 @@ func (c *Client) DeleteDocActorRelationship(
 	relation string,
 	targetActor string,
 ) (client.DeleteDocActorRelationshipResult, error) {
-	methodURL := c.http.baseURL.JoinPath("acp", "relationship")
+	methodURL := c.http.apiURL.JoinPath("acp", "relationship")
 
 	body, err := json.Marshal(
 		deleteDocActorRelationshipRequest{

--- a/http/client_collection.go
+++ b/http/client_collection.go
@@ -62,7 +62,7 @@ func (c *Collection) Create(
 	ctx context.Context,
 	doc *client.Document,
 ) error {
-	methodURL := c.http.baseURL.JoinPath("collections", c.Version().Name)
+	methodURL := c.http.apiURL.JoinPath("collections", c.Version().Name)
 
 	body, err := doc.String()
 	if err != nil {
@@ -88,7 +88,7 @@ func (c *Collection) CreateMany(
 	ctx context.Context,
 	docs []*client.Document,
 ) error {
-	methodURL := c.http.baseURL.JoinPath("collections", c.Version().Name)
+	methodURL := c.http.apiURL.JoinPath("collections", c.Version().Name)
 
 	var docMapList []json.RawMessage
 	for _, doc := range docs {
@@ -140,7 +140,7 @@ func (c *Collection) Update(
 	ctx context.Context,
 	doc *client.Document,
 ) error {
-	methodURL := c.http.baseURL.JoinPath("collections", c.Version().Name, doc.ID().String())
+	methodURL := c.http.apiURL.JoinPath("collections", c.Version().Name, doc.ID().String())
 
 	body, err := doc.ToJSONPatch()
 	if err != nil {
@@ -177,7 +177,7 @@ func (c *Collection) Delete(
 	ctx context.Context,
 	docID client.DocID,
 ) (bool, error) {
-	methodURL := c.http.baseURL.JoinPath("collections", c.Version().Name, docID.String())
+	methodURL := c.http.apiURL.JoinPath("collections", c.Version().Name, docID.String())
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, methodURL.String(), nil)
 	if err != nil {
@@ -207,7 +207,7 @@ func (c *Collection) UpdateWithFilter(
 	filter any,
 	updater string,
 ) (*client.UpdateResult, error) {
-	methodURL := c.http.baseURL.JoinPath("collections", c.Version().Name)
+	methodURL := c.http.apiURL.JoinPath("collections", c.Version().Name)
 
 	request := CollectionUpdateRequest{
 		Filter:  filter,
@@ -234,7 +234,7 @@ func (c *Collection) DeleteWithFilter(
 	ctx context.Context,
 	filter any,
 ) (*client.DeleteResult, error) {
-	methodURL := c.http.baseURL.JoinPath("collections", c.Version().Name)
+	methodURL := c.http.apiURL.JoinPath("collections", c.Version().Name)
 
 	request := CollectionDeleteRequest{
 		Filter: filter,
@@ -267,7 +267,7 @@ func (c *Collection) Get(
 		query.Add("show_deleted", "true")
 	}
 
-	methodURL := c.http.baseURL.JoinPath("collections", c.Version().Name, docID.String())
+	methodURL := c.http.apiURL.JoinPath("collections", c.Version().Name, docID.String())
 	methodURL.RawQuery = query.Encode()
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, methodURL.String(), nil)
@@ -294,7 +294,7 @@ func (c *Collection) Get(
 func (c *Collection) GetAllDocIDs(
 	ctx context.Context,
 ) (<-chan client.DocIDResult, error) {
-	methodURL := c.http.baseURL.JoinPath("collections", c.Version().Name)
+	methodURL := c.http.apiURL.JoinPath("collections", c.Version().Name)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, methodURL.String(), nil)
 	if err != nil {
@@ -350,7 +350,7 @@ func (c *Collection) CreateIndex(
 	ctx context.Context,
 	indexDesc client.IndexDescriptionCreateRequest,
 ) (client.IndexDescription, error) {
-	methodURL := c.http.baseURL.JoinPath("collections", c.Version().Name, "indexes")
+	methodURL := c.http.apiURL.JoinPath("collections", c.Version().Name, "indexes")
 
 	body, err := json.Marshal(&indexDesc)
 	if err != nil {
@@ -368,7 +368,7 @@ func (c *Collection) CreateIndex(
 }
 
 func (c *Collection) DropIndex(ctx context.Context, indexName string) error {
-	methodURL := c.http.baseURL.JoinPath("collections", c.Version().Name, "indexes", indexName)
+	methodURL := c.http.apiURL.JoinPath("collections", c.Version().Name, "indexes", indexName)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, methodURL.String(), nil)
 	if err != nil {
@@ -379,7 +379,7 @@ func (c *Collection) DropIndex(ctx context.Context, indexName string) error {
 }
 
 func (c *Collection) GetIndexes(ctx context.Context) ([]client.IndexDescription, error) {
-	methodURL := c.http.baseURL.JoinPath("collections", c.Version().Name, "indexes")
+	methodURL := c.http.apiURL.JoinPath("collections", c.Version().Name, "indexes")
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, methodURL.String(), nil)
 	if err != nil {

--- a/http/client_lens.go
+++ b/http/client_lens.go
@@ -38,7 +38,7 @@ type setMigrationRequest struct {
 func (w *LensRegistry) Init(txnSource client.TxnSource) {}
 
 func (c *LensRegistry) SetMigration(ctx context.Context, collectionID string, config model.Lens) error {
-	methodURL := c.http.baseURL.JoinPath("lens", "registry")
+	methodURL := c.http.apiURL.JoinPath("lens", "registry")
 
 	body, err := json.Marshal(setMigrationRequest{
 		CollectionID: collectionID,
@@ -56,7 +56,7 @@ func (c *LensRegistry) SetMigration(ctx context.Context, collectionID string, co
 }
 
 func (c *LensRegistry) ReloadLenses(ctx context.Context) error {
-	methodURL := c.http.baseURL.JoinPath("lens", "registry", "reload")
+	methodURL := c.http.apiURL.JoinPath("lens", "registry", "reload")
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, methodURL.String(), nil)
 	if err != nil {
@@ -76,7 +76,7 @@ func (c *LensRegistry) MigrateUp(
 	src enumerable.Enumerable[map[string]any],
 	collectionID string,
 ) (enumerable.Enumerable[map[string]any], error) {
-	methodURL := c.http.baseURL.JoinPath("lens", "registry", fmt.Sprint(collectionID), "up")
+	methodURL := c.http.apiURL.JoinPath("lens", "registry", fmt.Sprint(collectionID), "up")
 
 	var data []map[string]any
 	err := enumerable.ForEach(src, func(item map[string]any) {
@@ -111,7 +111,7 @@ func (c *LensRegistry) MigrateDown(
 	src enumerable.Enumerable[map[string]any],
 	collectionID string,
 ) (enumerable.Enumerable[map[string]any], error) {
-	methodURL := c.http.baseURL.JoinPath("lens", "registry", fmt.Sprint(collectionID), "down")
+	methodURL := c.http.apiURL.JoinPath("lens", "registry", fmt.Sprint(collectionID), "down")
 
 	var data []map[string]any
 	err := enumerable.ForEach(src, func(item map[string]any) {

--- a/http/client_p2p.go
+++ b/http/client_p2p.go
@@ -22,7 +22,7 @@ import (
 )
 
 func (c *Client) PeerInfo() peer.AddrInfo {
-	methodURL := c.http.baseURL.JoinPath("p2p", "info")
+	methodURL := c.http.apiURL.JoinPath("p2p", "info")
 
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, methodURL.String(), nil)
 	if err != nil {
@@ -36,7 +36,7 @@ func (c *Client) PeerInfo() peer.AddrInfo {
 }
 
 func (c *Client) SetReplicator(ctx context.Context, rep client.ReplicatorParams) error {
-	methodURL := c.http.baseURL.JoinPath("p2p", "replicators")
+	methodURL := c.http.apiURL.JoinPath("p2p", "replicators")
 
 	body, err := json.Marshal(rep)
 	if err != nil {
@@ -51,7 +51,7 @@ func (c *Client) SetReplicator(ctx context.Context, rep client.ReplicatorParams)
 }
 
 func (c *Client) DeleteReplicator(ctx context.Context, rep client.ReplicatorParams) error {
-	methodURL := c.http.baseURL.JoinPath("p2p", "replicators")
+	methodURL := c.http.apiURL.JoinPath("p2p", "replicators")
 
 	body, err := json.Marshal(rep)
 	if err != nil {
@@ -66,7 +66,7 @@ func (c *Client) DeleteReplicator(ctx context.Context, rep client.ReplicatorPara
 }
 
 func (c *Client) GetAllReplicators(ctx context.Context) ([]client.Replicator, error) {
-	methodURL := c.http.baseURL.JoinPath("p2p", "replicators")
+	methodURL := c.http.apiURL.JoinPath("p2p", "replicators")
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, methodURL.String(), nil)
 	if err != nil {
@@ -80,7 +80,7 @@ func (c *Client) GetAllReplicators(ctx context.Context) ([]client.Replicator, er
 }
 
 func (c *Client) AddP2PCollections(ctx context.Context, collectionIDs []string) error {
-	methodURL := c.http.baseURL.JoinPath("p2p", "collections")
+	methodURL := c.http.apiURL.JoinPath("p2p", "collections")
 
 	body, err := json.Marshal(collectionIDs)
 	if err != nil {
@@ -95,7 +95,7 @@ func (c *Client) AddP2PCollections(ctx context.Context, collectionIDs []string) 
 }
 
 func (c *Client) RemoveP2PCollections(ctx context.Context, collectionIDs []string) error {
-	methodURL := c.http.baseURL.JoinPath("p2p", "collections")
+	methodURL := c.http.apiURL.JoinPath("p2p", "collections")
 
 	body, err := json.Marshal(collectionIDs)
 	if err != nil {
@@ -110,7 +110,7 @@ func (c *Client) RemoveP2PCollections(ctx context.Context, collectionIDs []strin
 }
 
 func (c *Client) GetAllP2PCollections(ctx context.Context) ([]string, error) {
-	methodURL := c.http.baseURL.JoinPath("p2p", "collections")
+	methodURL := c.http.apiURL.JoinPath("p2p", "collections")
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, methodURL.String(), nil)
 	if err != nil {

--- a/http/client_tx.go
+++ b/http/client_tx.go
@@ -39,7 +39,7 @@ func (c *Transaction) ID() uint64 {
 }
 
 func (c *Transaction) Commit(ctx context.Context) error {
-	methodURL := c.http.baseURL.JoinPath("tx", fmt.Sprintf("%d", c.id))
+	methodURL := c.http.apiURL.JoinPath("tx", fmt.Sprintf("%d", c.id))
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, methodURL.String(), nil)
 	if err != nil {
@@ -50,7 +50,7 @@ func (c *Transaction) Commit(ctx context.Context) error {
 }
 
 func (c *Transaction) Discard(ctx context.Context) {
-	methodURL := c.http.baseURL.JoinPath("tx", fmt.Sprintf("%d", c.id))
+	methodURL := c.http.apiURL.JoinPath("tx", fmt.Sprintf("%d", c.id))
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, methodURL.String(), nil)
 	if err != nil {

--- a/http/handler.go
+++ b/http/handler.go
@@ -94,6 +94,10 @@ func NewHandler(db client.DB) (*Handler, error) {
 	mux.Get("/openapi.json", func(rw http.ResponseWriter, req *http.Request) {
 		responseJSON(rw, http.StatusOK, router.OpenAPI())
 	})
+	mux.Get("/health-check", func(rw http.ResponseWriter, req *http.Request) {
+		rw.WriteHeader(http.StatusOK)
+		rw.Write([]byte("Healthy"))
+	})
 	mux.Handle("/*", playgroundHandler)
 	return &Handler{
 		db:  db,

--- a/http/handler.go
+++ b/http/handler.go
@@ -95,8 +95,7 @@ func NewHandler(db client.DB) (*Handler, error) {
 		responseJSON(rw, http.StatusOK, router.OpenAPI())
 	})
 	mux.Get("/health-check", func(rw http.ResponseWriter, req *http.Request) {
-		rw.WriteHeader(http.StatusOK)
-		rw.Write([]byte("Healthy"))
+		responseJSON(rw, http.StatusOK, "Healthy")
 	})
 	mux.Handle("/*", playgroundHandler)
 	return &Handler{

--- a/http/http_client.go
+++ b/http/http_client.go
@@ -25,6 +25,7 @@ import (
 type httpClient struct {
 	client  *http.Client
 	baseURL *url.URL
+	apiURL  *url.URL
 }
 
 func newHttpClient(rawURL string) (*httpClient, error) {
@@ -37,7 +38,8 @@ func newHttpClient(rawURL string) (*httpClient, error) {
 	}
 	return &httpClient{
 		client:  http.DefaultClient,
-		baseURL: baseURL.JoinPath("/api/v0"),
+		baseURL: baseURL,
+		apiURL:  baseURL.JoinPath("/api/v0"),
 	}, nil
 }
 

--- a/node/message.go
+++ b/node/message.go
@@ -1,0 +1,36 @@
+// Copyright 2025 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package node
+
+import "context"
+
+type contextKey string
+
+// messageChansContextKey is the context key for the messageChans
+var messageChansContextKey = contextKey("messageChans")
+
+// MessageChans contains message channels that can be used to relay important information
+// after calling `cli.Start`.
+type MessageChans struct {
+	APIURL chan string
+}
+
+// TryGetContextMessageChans returns the message channels for the current command context
+// and a boolean indicating if the message channels struct was set.
+func TryGetContextMessageChans(ctx context.Context) (*MessageChans, bool) {
+	node, ok := ctx.Value(messageChansContextKey).(*MessageChans)
+	return node, ok
+}
+
+// SetContextMessageChans sets the message channels for the current command context.
+func SetContextMessageChans(ctx context.Context, w *MessageChans) context.Context {
+	return context.WithValue(ctx, messageChansContextKey, w)
+}

--- a/node/node.go
+++ b/node/node.go
@@ -46,6 +46,8 @@ type Node struct {
 	config *Config
 	// options the node was created with
 	options []Option
+	// the URL the API is served at.
+	APIURL string
 }
 
 // New returns a new node instance configured with the given options.

--- a/node/node_api.go
+++ b/node/node_api.go
@@ -43,5 +43,15 @@ func (n *Node) startAPI(ctx context.Context) error {
 			log.ErrorContextE(ctx, "HTTP server stopped", err)
 		}
 	}()
+	n.APIURL = n.server.Address()
+	// Check that the server is ready before returning.
+	c, err := http.NewClient(n.APIURL)
+	if err != nil {
+		return err
+	}
+	err = c.HealthCheck(ctx)
+	if err != nil {
+		return err
+	}
 	return nil
 }

--- a/node/node_api.go
+++ b/node/node_api.go
@@ -44,7 +44,8 @@ func (n *Node) startAPI(ctx context.Context) error {
 		}
 	}()
 	n.APIURL = n.server.Address()
-	// Check that the server is ready before returning.
+	// Check that the server is ready before returning. We do this to ensure that
+	// subsequent operation will behave as expected.
 	c, err := http.NewClient(n.APIURL)
 	if err != nil {
 		return err

--- a/tests/integration/events.go
+++ b/tests/integration/events.go
@@ -312,11 +312,6 @@ func updateNetworkState(s *state, nodeID int, evt event.Update, ident immutable.
 			s.nodes[id].p2p.expectedDAGHeads[getUpdateEventKey(evt)] = evt.Cid
 		}
 	}
-
-	// make sure the event is published on the network before proceeding
-	// this prevents nodes from missing messages that are sent before
-	// subscriptions are setup
-	time.Sleep(100 * time.Millisecond)
 }
 
 // getEventsForUpdateDoc returns a map of docIDs that should be

--- a/tests/integration/p2p.go
+++ b/tests/integration/p2p.go
@@ -162,7 +162,7 @@ func connectPeers(
 	// Bootstrap triggers a bunch of async stuff for which we have no good way of waiting on.  It must be
 	// allowed to complete before documentation begins or it will not even try and sync it. So for now, we
 	// sleep a little.
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(10 * time.Millisecond)
 }
 
 // configureReplicator configures a replicator relationship between two existing, started, nodes.


### PR DESCRIPTION
## Relevant issue(s)

Resolves #3706

## Description

This PR introduces a message channels struct to use the cli command context to relay node information outside of the `cli.Start` command. This removes the need to use logs to figure out node state. Some improvement to the synchronousness of the startup process was introduced.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

make start

Specify the platform(s) on which this was tested:
- MacOS
