### PR TITLE
fix(i): Rename ColllectionFetchOptions.ID

### DIFF
--- a/cli/collection.go
+++ b/cli/collection.go
@@ -27,7 +27,7 @@ func MakeCollectionCommand() *cobra.Command {
 	var versionID string
 	var getInactive bool
 	var cmd = &cobra.Command{
-		Use:   "collection [--name <name> --collection-id <collectionID> --version <versionID>]",
+		Use:   "collection [--name <name> --collection-id <collectionID> --version-id <versionID>]",
 		Short: "Interact with a collection.",
 		Long:  `Create, read, update, and delete documents within a collection.`,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) (err error) {
@@ -51,7 +51,7 @@ func MakeCollectionCommand() *cobra.Command {
 
 			options := client.CollectionFetchOptions{}
 			if versionID != "" {
-				options.ID = immutable.Some(versionID)
+				options.VersionID = immutable.Some(versionID)
 			}
 			if collectionID != "" {
 				options.CollectionID = immutable.Some(collectionID)
@@ -84,7 +84,7 @@ func MakeCollectionCommand() *cobra.Command {
 		"Hex formatted private key used to authenticate with ACP")
 	cmd.PersistentFlags().StringVar(&name, "name", "", "Collection name")
 	cmd.PersistentFlags().StringVar(&collectionID, "collection-id", "", "Collection ID")
-	cmd.PersistentFlags().StringVar(&versionID, "version", "", "Collection version ID")
+	cmd.PersistentFlags().StringVar(&versionID, "version-id", "", "Collection version ID")
 	cmd.PersistentFlags().BoolVar(&getInactive, "get-inactive", false, "Get inactive collections as well as active")
 	return cmd
 }

--- a/cli/collection_describe.go
+++ b/cli/collection_describe.go
@@ -37,14 +37,14 @@ Example: view collection by collection id
   defradb client collection describe --collection-id bae123
 		
 Example: view collection by version id. This will also return inactive collections
-  defradb client collection describe --version bae123
+  defradb client collection describe --version-id bae123
 		`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			store := mustGetContextStore(cmd)
 
 			options := client.CollectionFetchOptions{}
 			if versionID != "" {
-				options.ID = immutable.Some(versionID)
+				options.VersionID = immutable.Some(versionID)
 			}
 			if collectionID != "" {
 				options.CollectionID = immutable.Some(collectionID)
@@ -72,7 +72,7 @@ Example: view collection by version id. This will also return inactive collectio
 	}
 	cmd.Flags().StringVar(&name, "name", "", "Collection name")
 	cmd.Flags().StringVar(&collectionID, "collection-id", "", "Collection P2P identifier")
-	cmd.Flags().StringVar(&versionID, "version", "", "Collection version ID")
+	cmd.Flags().StringVar(&versionID, "version-id", "", "Collection version ID")
 	cmd.Flags().BoolVar(&getInactive, "get-inactive", false, "Get inactive collections as well as active")
 	return cmd
 }

--- a/cli/view_refresh.go
+++ b/cli/view_refresh.go
@@ -42,14 +42,14 @@ Example: refresh views by schema root id
   defradb client view refresh --schema bae123
 
 Example: refresh views by version id. This will also return inactive views
-  defradb client view refresh --version bae123
+  defradb client view refresh --version-id bae123
 		`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			store := mustGetContextStore(cmd)
 
 			options := client.CollectionFetchOptions{}
 			if versionID != "" {
-				options.ID = immutable.Some(versionID)
+				options.VersionID = immutable.Some(versionID)
 			}
 			if collectionID != "" {
 				options.CollectionID = immutable.Some(collectionID)
@@ -69,7 +69,7 @@ Example: refresh views by version id. This will also return inactive views
 	}
 	cmd.Flags().StringVar(&name, "name", "", "View name")
 	cmd.Flags().StringVar(&collectionID, "collection-id", "", "View collection ID")
-	cmd.Flags().StringVar(&versionID, "version", "", "View version ID")
+	cmd.Flags().StringVar(&versionID, "version-id", "", "View version ID")
 	cmd.Flags().BoolVar(&getInactive, "get-inactive", false, "Get inactive views as well as active")
 	return cmd
 }

--- a/client/db.go
+++ b/client/db.go
@@ -403,7 +403,7 @@ type RequestResult struct {
 // CollectionFetchOptions represents a set of options used for fetching collections.
 type CollectionFetchOptions struct {
 	// If provided, only collections with this version id will be returned.
-	ID immutable.Option[string]
+	VersionID immutable.Option[string]
 
 	// If provided, only collections with this CollectionID will be returned.
 	CollectionID immutable.Option[string]

--- a/docs/website/references/cli/defradb_client_collection.md
+++ b/docs/website/references/cli/defradb_client_collection.md
@@ -15,7 +15,7 @@ Create, read, update, and delete documents within a collection.
   -i, --identity string        Hex formatted private key used to authenticate with ACP
       --name string            Collection name
       --tx uint                Transaction ID
-      --version string         Collection version ID
+      --version-id string      Collection version ID
 ```
 
 ### Options inherited from parent commands

--- a/docs/website/references/cli/defradb_client_collection_create.md
+++ b/docs/website/references/cli/defradb_client_collection_create.md
@@ -74,7 +74,7 @@ defradb client collection create [-i --identity] [-e --encrypt] [--encrypt-field
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --tx uint                     Transaction ID
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
-      --version string              Collection version ID
+      --version-id string           Collection version ID
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_collection_delete.md
+++ b/docs/website/references/cli/defradb_client_collection_delete.md
@@ -52,7 +52,7 @@ defradb client collection delete [-i --identity] [--filter <filter> --docID <doc
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --tx uint                     Transaction ID
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
-      --version string              Collection version ID
+      --version-id string           Collection version ID
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_collection_describe.md
+++ b/docs/website/references/cli/defradb_client_collection_describe.md
@@ -16,7 +16,7 @@ Example: view collection by collection id
   defradb client collection describe --collection-id bae123
 		
 Example: view collection by version id. This will also return inactive collections
-  defradb client collection describe --version bae123
+  defradb client collection describe --version-id bae123
 		
 
 ```
@@ -30,7 +30,7 @@ defradb client collection describe [flags]
       --get-inactive           Get inactive collections as well as active
   -h, --help                   help for describe
       --name string            Collection name
-      --version string         Collection version ID
+      --version-id string      Collection version ID
 ```
 
 ### Options inherited from parent commands

--- a/docs/website/references/cli/defradb_client_collection_docIDs.md
+++ b/docs/website/references/cli/defradb_client_collection_docIDs.md
@@ -46,7 +46,7 @@ defradb client collection docIDs [-i --identity] [flags]
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --tx uint                     Transaction ID
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
-      --version string              Collection version ID
+      --version-id string           Collection version ID
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_collection_get.md
+++ b/docs/website/references/cli/defradb_client_collection_get.md
@@ -47,7 +47,7 @@ defradb client collection get [-i --identity] [--show-deleted] <docID>  [flags]
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --tx uint                     Transaction ID
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
-      --version string              Collection version ID
+      --version-id string           Collection version ID
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_collection_patch.md
+++ b/docs/website/references/cli/defradb_client_collection_patch.md
@@ -53,7 +53,7 @@ defradb client collection patch [patch] [flags]
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --tx uint                     Transaction ID
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
-      --version string              Collection version ID
+      --version-id string           Collection version ID
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_collection_update.md
+++ b/docs/website/references/cli/defradb_client_collection_update.md
@@ -55,7 +55,7 @@ defradb client collection update [-i --identity] [--filter <filter> --docID <doc
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --tx uint                     Transaction ID
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
-      --version string              Collection version ID
+      --version-id string           Collection version ID
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_view_refresh.md
+++ b/docs/website/references/cli/defradb_client_view_refresh.md
@@ -21,7 +21,7 @@ Example: refresh views by schema root id
   defradb client view refresh --schema bae123
 
 Example: refresh views by version id. This will also return inactive views
-  defradb client view refresh --version bae123
+  defradb client view refresh --version-id bae123
 		
 
 ```
@@ -35,7 +35,7 @@ defradb client view refresh [flags]
       --get-inactive           Get inactive views as well as active
   -h, --help                   help for refresh
       --name string            View name
-      --version string         View version ID
+      --version-id string      View version ID
 ```
 
 ### Options inherited from parent commands

--- a/http/client.go
+++ b/http/client.go
@@ -227,8 +227,8 @@ func (c *Client) RefreshViews(ctx context.Context, options client.CollectionFetc
 	if options.Name.HasValue() {
 		params.Add("name", options.Name.Value())
 	}
-	if options.ID.HasValue() {
-		params.Add("version_id", options.ID.Value())
+	if options.VersionID.HasValue() {
+		params.Add("version_id", options.VersionID.Value())
 	}
 	if options.CollectionID.HasValue() {
 		params.Add("collection_id", options.CollectionID.Value())
@@ -287,8 +287,8 @@ func (c *Client) GetCollections(
 	if options.Name.HasValue() {
 		params.Add("name", options.Name.Value())
 	}
-	if options.ID.HasValue() {
-		params.Add("version_id", options.ID.Value())
+	if options.VersionID.HasValue() {
+		params.Add("version_id", options.VersionID.Value())
 	}
 	if options.CollectionID.HasValue() {
 		params.Add("collection_id", options.CollectionID.Value())

--- a/http/handler_store.go
+++ b/http/handler_store.go
@@ -169,7 +169,7 @@ func (s *storeHandler) GetCollection(rw http.ResponseWriter, req *http.Request) 
 		options.Name = immutable.Some(req.URL.Query().Get("name"))
 	}
 	if req.URL.Query().Has("version_id") {
-		options.ID = immutable.Some(req.URL.Query().Get("version_id"))
+		options.VersionID = immutable.Some(req.URL.Query().Get("version_id"))
 	}
 	if req.URL.Query().Has("collection_id") {
 		options.CollectionID = immutable.Some(req.URL.Query().Get("collection_id"))
@@ -227,7 +227,7 @@ func (s *storeHandler) RefreshViews(rw http.ResponseWriter, req *http.Request) {
 		options.Name = immutable.Some(req.URL.Query().Get("name"))
 	}
 	if req.URL.Query().Has("version_id") {
-		options.ID = immutable.Some(req.URL.Query().Get("version_id"))
+		options.VersionID = immutable.Some(req.URL.Query().Get("version_id"))
 	}
 	if req.URL.Query().Has("collection_id") {
 		options.CollectionID = immutable.Some(req.URL.Query().Get("collection_id"))

--- a/internal/db/collection.go
+++ b/internal/db/collection.go
@@ -147,8 +147,8 @@ func (db *DB) getCollections(
 		}
 		cols = append(cols, col)
 
-	case options.ID.HasValue():
-		col, err := description.GetCollectionByID(ctx, txn, options.ID.Value())
+	case options.VersionID.HasValue():
+		col, err := description.GetCollectionByID(ctx, txn, options.VersionID.Value())
 		if err != nil {
 			return nil, err
 		}
@@ -179,14 +179,14 @@ func (db *DB) getCollections(
 
 	collections := []client.Collection{}
 	for _, col := range cols {
-		if options.ID.HasValue() {
-			if col.VersionID != options.ID.Value() {
+		if options.VersionID.HasValue() {
+			if col.VersionID != options.VersionID.Value() {
 				continue
 			}
 		}
 
 		// By default, we don't return inactive collections unless a specific version is requested.
-		if !options.IncludeInactive.Value() && !col.IsActive && !options.ID.HasValue() {
+		if !options.IncludeInactive.Value() && !col.IsActive && !options.VersionID.HasValue() {
 			continue
 		}
 

--- a/internal/db/collection_retriever.go
+++ b/internal/db/collection_retriever.go
@@ -57,7 +57,7 @@ func (r collectionRetriever) RetrieveCollectionFromDocID(
 	cols, err := r.db.GetCollections(
 		ctx,
 		client.CollectionFetchOptions{
-			ID: immutable.Some(headIterator.CurrentBlock().Delta.GetSchemaVersionID()),
+			VersionID: immutable.Some(headIterator.CurrentBlock().Delta.GetSchemaVersionID()),
 		},
 	)
 

--- a/internal/planner/commit.go
+++ b/internal/planner/commit.go
@@ -350,7 +350,7 @@ func (n *dagScanNode) dagBlockToNodeDoc(block *coreblock.Block) (core.Doc, error
 		n.planner.ctx,
 		client.CollectionFetchOptions{
 			IncludeInactive: immutable.Some(true),
-			ID:              immutable.Some(schemaVersionId),
+			VersionID:       immutable.Some(schemaVersionId),
 		},
 	)
 	if err != nil {

--- a/net/server.go
+++ b/net/server.go
@@ -490,7 +490,7 @@ func (s *server) hasAccess(p libpeer.ID, c cid.Cid) bool {
 	cols, err := s.peer.db.GetCollections(
 		s.peer.ctx,
 		client.CollectionFetchOptions{
-			ID: immutable.Some(block.Delta.GetSchemaVersionID()),
+			VersionID: immutable.Some(block.Delta.GetSchemaVersionID()),
 		},
 	)
 	if err != nil {

--- a/tests/clients/cli/wrapper.go
+++ b/tests/clients/cli/wrapper.go
@@ -268,8 +268,8 @@ func (w *Wrapper) RefreshViews(ctx context.Context, options client.CollectionFet
 	if options.Name.HasValue() {
 		args = append(args, "--name", options.Name.Value())
 	}
-	if options.ID.HasValue() {
-		args = append(args, "--version", options.ID.Value())
+	if options.VersionID.HasValue() {
+		args = append(args, "--version-id", options.VersionID.Value())
 	}
 	if options.CollectionID.HasValue() {
 		args = append(args, "--collection-id", options.CollectionID.Value())
@@ -319,8 +319,8 @@ func (w *Wrapper) GetCollections(
 	if options.Name.HasValue() {
 		args = append(args, "--name", options.Name.Value())
 	}
-	if options.ID.HasValue() {
-		args = append(args, "--version", options.ID.Value())
+	if options.VersionID.HasValue() {
+		args = append(args, "--version-id", options.VersionID.Value())
 	}
 	if options.CollectionID.HasValue() {
 		args = append(args, "--collection-id", options.CollectionID.Value())

--- a/tests/integration/schema/updates/with_schema_branch_test.go
+++ b/tests/integration/schema/updates/with_schema_branch_test.go
@@ -599,7 +599,7 @@ collection at a specific version`,
 			},
 			testUtils.GetCollections{
 				FilterOptions: client.CollectionFetchOptions{
-					ID: immutable.Some(schemaVersion1ID),
+					VersionID: immutable.Some(schemaVersion1ID),
 				},
 				ExpectedResults: []client.CollectionVersion{
 					{


### PR DESCRIPTION
## Relevant issue(s)

Resolves #3728

## Description

Rename ColllectionFetchOptions.ID to VersionID, making it consistent with the corresponding property on CollectionVersion.

Also renames the CLI params which were not matching the prop, or the http api (already `version_id`).

I missed this in an earlier PR and it was spotted by Chris.