### PR TITLE
fix: Enable doc encryption for embedded client

### DIFF
--- a/client/collection.go
+++ b/client/collection.go
@@ -24,7 +24,7 @@ type DocCreateOptions struct {
 }
 
 // Apply applies the given DocCreateOptions to the DocCreateOptions receiver.
-func (o *DocCreateOptions) Apply(opts ...DocCreateOption) {
+func (o *DocCreateOptions) Apply(opts []DocCreateOption) {
 	for _, opt := range opts {
 		opt(o)
 	}

--- a/client/collection.go
+++ b/client/collection.go
@@ -14,6 +14,36 @@ import (
 	"context"
 )
 
+// DocCreateOption is a functional option for creating a document.
+type DocCreateOption func(*DocCreateOptions)
+
+// DocCreateOptions contains options for creating a document.
+type DocCreateOptions struct {
+	EncryptDoc      bool
+	EncryptedFields []string
+}
+
+// Apply applies the given DocCreateOptions to the DocCreateOptions receiver.
+func (o *DocCreateOptions) Apply(opts ...DocCreateOption) {
+	for _, opt := range opts {
+		opt(o)
+	}
+}
+
+// CreateDocEncrypted enables or disables document encryption when creating a document.
+func CreateDocEncrypted(encryptDoc bool) DocCreateOption {
+	return func(opts *DocCreateOptions) {
+		opts.EncryptDoc = encryptDoc
+	}
+}
+
+// CreateDocWithEncryptedFields specifies a list of fields to be encrypted when creating a document.
+func CreateDocWithEncryptedFields(encryptedFields []string) DocCreateOption {
+	return func(opts *DocCreateOptions) {
+		opts.EncryptedFields = encryptedFields
+	}
+}
+
 // Collection represents a defradb collection.
 //
 // A Collection is mostly analogous to a SQL table, however a collection is specific to its
@@ -42,12 +72,12 @@ type Collection interface {
 	// Create a new document.
 	//
 	// Will verify the DocID/CID to ensure that the new document is correctly formatted.
-	Create(ctx context.Context, doc *Document) error
+	Create(ctx context.Context, doc *Document, opts ...DocCreateOption) error
 
 	// CreateMany new documents.
 	//
 	// Will verify the DocIDs/CIDs to ensure that the new documents are correctly formatted.
-	CreateMany(ctx context.Context, docs []*Document) error
+	CreateMany(ctx context.Context, docs []*Document, opts ...DocCreateOption) error
 
 	// Update an existing document with the new values.
 	//
@@ -61,7 +91,7 @@ type Collection interface {
 	//
 	// If a document exists with the given DocID it will update it. Otherwise a new document
 	// will be created.
-	Save(ctx context.Context, doc *Document) error
+	Save(ctx context.Context, doc *Document, opts ...DocCreateOption) error
 
 	// Delete will attempt to delete a document by DocID.
 	//

--- a/client/mocks/collection.go
+++ b/client/mocks/collection.go
@@ -39,16 +39,22 @@ func (_m *Collection) EXPECT() *Collection_Expecter {
 }
 
 // Create provides a mock function for the type Collection
-func (_mock *Collection) Create(ctx context.Context, doc *client.Document) error {
-	ret := _mock.Called(ctx, doc)
+func (_mock *Collection) Create(ctx context.Context, doc *client.Document, opts ...client.DocCreateOption) error {
+	var tmpRet mock.Arguments
+	if len(opts) > 0 {
+		tmpRet = _mock.Called(ctx, doc, opts)
+	} else {
+		tmpRet = _mock.Called(ctx, doc)
+	}
+	ret := tmpRet
 
 	if len(ret) == 0 {
 		panic("no return value specified for Create")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, *client.Document) error); ok {
-		r0 = returnFunc(ctx, doc)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *client.Document, ...client.DocCreateOption) error); ok {
+		r0 = returnFunc(ctx, doc, opts...)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -63,13 +69,16 @@ type Collection_Create_Call struct {
 // Create is a helper method to define mock.On call
 //   - ctx
 //   - doc
-func (_e *Collection_Expecter) Create(ctx interface{}, doc interface{}) *Collection_Create_Call {
-	return &Collection_Create_Call{Call: _e.mock.On("Create", ctx, doc)}
+//   - opts
+func (_e *Collection_Expecter) Create(ctx interface{}, doc interface{}, opts ...interface{}) *Collection_Create_Call {
+	return &Collection_Create_Call{Call: _e.mock.On("Create",
+		append([]interface{}{ctx, doc}, opts...)...)}
 }
 
-func (_c *Collection_Create_Call) Run(run func(ctx context.Context, doc *client.Document)) *Collection_Create_Call {
+func (_c *Collection_Create_Call) Run(run func(ctx context.Context, doc *client.Document, opts ...client.DocCreateOption)) *Collection_Create_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(*client.Document))
+		variadicArgs := args[2].([]client.DocCreateOption)
+		run(args[0].(context.Context), args[1].(*client.Document), variadicArgs...)
 	})
 	return _c
 }
@@ -79,7 +88,7 @@ func (_c *Collection_Create_Call) Return(err error) *Collection_Create_Call {
 	return _c
 }
 
-func (_c *Collection_Create_Call) RunAndReturn(run func(ctx context.Context, doc *client.Document) error) *Collection_Create_Call {
+func (_c *Collection_Create_Call) RunAndReturn(run func(ctx context.Context, doc *client.Document, opts ...client.DocCreateOption) error) *Collection_Create_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -140,16 +149,22 @@ func (_c *Collection_CreateIndex_Call) RunAndReturn(run func(context1 context.Co
 }
 
 // CreateMany provides a mock function for the type Collection
-func (_mock *Collection) CreateMany(ctx context.Context, docs []*client.Document) error {
-	ret := _mock.Called(ctx, docs)
+func (_mock *Collection) CreateMany(ctx context.Context, docs []*client.Document, opts ...client.DocCreateOption) error {
+	var tmpRet mock.Arguments
+	if len(opts) > 0 {
+		tmpRet = _mock.Called(ctx, docs, opts)
+	} else {
+		tmpRet = _mock.Called(ctx, docs)
+	}
+	ret := tmpRet
 
 	if len(ret) == 0 {
 		panic("no return value specified for CreateMany")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, []*client.Document) error); ok {
-		r0 = returnFunc(ctx, docs)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []*client.Document, ...client.DocCreateOption) error); ok {
+		r0 = returnFunc(ctx, docs, opts...)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -164,13 +179,16 @@ type Collection_CreateMany_Call struct {
 // CreateMany is a helper method to define mock.On call
 //   - ctx
 //   - docs
-func (_e *Collection_Expecter) CreateMany(ctx interface{}, docs interface{}) *Collection_CreateMany_Call {
-	return &Collection_CreateMany_Call{Call: _e.mock.On("CreateMany", ctx, docs)}
+//   - opts
+func (_e *Collection_Expecter) CreateMany(ctx interface{}, docs interface{}, opts ...interface{}) *Collection_CreateMany_Call {
+	return &Collection_CreateMany_Call{Call: _e.mock.On("CreateMany",
+		append([]interface{}{ctx, docs}, opts...)...)}
 }
 
-func (_c *Collection_CreateMany_Call) Run(run func(ctx context.Context, docs []*client.Document)) *Collection_CreateMany_Call {
+func (_c *Collection_CreateMany_Call) Run(run func(ctx context.Context, docs []*client.Document, opts ...client.DocCreateOption)) *Collection_CreateMany_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].([]*client.Document))
+		variadicArgs := args[2].([]client.DocCreateOption)
+		run(args[0].(context.Context), args[1].([]*client.Document), variadicArgs...)
 	})
 	return _c
 }
@@ -180,7 +198,7 @@ func (_c *Collection_CreateMany_Call) Return(err error) *Collection_CreateMany_C
 	return _c
 }
 
-func (_c *Collection_CreateMany_Call) RunAndReturn(run func(ctx context.Context, docs []*client.Document) error) *Collection_CreateMany_Call {
+func (_c *Collection_CreateMany_Call) RunAndReturn(run func(ctx context.Context, docs []*client.Document, opts ...client.DocCreateOption) error) *Collection_CreateMany_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -657,16 +675,22 @@ func (_c *Collection_Name_Call) RunAndReturn(run func() string) *Collection_Name
 }
 
 // Save provides a mock function for the type Collection
-func (_mock *Collection) Save(ctx context.Context, doc *client.Document) error {
-	ret := _mock.Called(ctx, doc)
+func (_mock *Collection) Save(ctx context.Context, doc *client.Document, opts ...client.DocCreateOption) error {
+	var tmpRet mock.Arguments
+	if len(opts) > 0 {
+		tmpRet = _mock.Called(ctx, doc, opts)
+	} else {
+		tmpRet = _mock.Called(ctx, doc)
+	}
+	ret := tmpRet
 
 	if len(ret) == 0 {
 		panic("no return value specified for Save")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, *client.Document) error); ok {
-		r0 = returnFunc(ctx, doc)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *client.Document, ...client.DocCreateOption) error); ok {
+		r0 = returnFunc(ctx, doc, opts...)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -681,13 +705,16 @@ type Collection_Save_Call struct {
 // Save is a helper method to define mock.On call
 //   - ctx
 //   - doc
-func (_e *Collection_Expecter) Save(ctx interface{}, doc interface{}) *Collection_Save_Call {
-	return &Collection_Save_Call{Call: _e.mock.On("Save", ctx, doc)}
+//   - opts
+func (_e *Collection_Expecter) Save(ctx interface{}, doc interface{}, opts ...interface{}) *Collection_Save_Call {
+	return &Collection_Save_Call{Call: _e.mock.On("Save",
+		append([]interface{}{ctx, doc}, opts...)...)}
 }
 
-func (_c *Collection_Save_Call) Run(run func(ctx context.Context, doc *client.Document)) *Collection_Save_Call {
+func (_c *Collection_Save_Call) Run(run func(ctx context.Context, doc *client.Document, opts ...client.DocCreateOption)) *Collection_Save_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(*client.Document))
+		variadicArgs := args[2].([]client.DocCreateOption)
+		run(args[0].(context.Context), args[1].(*client.Document), variadicArgs...)
 	})
 	return _c
 }
@@ -697,7 +724,7 @@ func (_c *Collection_Save_Call) Return(err error) *Collection_Save_Call {
 	return _c
 }
 
-func (_c *Collection_Save_Call) RunAndReturn(run func(ctx context.Context, doc *client.Document) error) *Collection_Save_Call {
+func (_c *Collection_Save_Call) RunAndReturn(run func(ctx context.Context, doc *client.Document, opts ...client.DocCreateOption) error) *Collection_Save_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/http/client.go
+++ b/http/client.go
@@ -396,8 +396,6 @@ func (c *Client) ExecRequest(
 	}
 	err = c.http.setDefaultHeaders(req)
 
-	setDocEncryptionFlagIfNeeded(ctx, req)
-
 	if err != nil {
 		result.GQL.Errors = append(result.GQL.Errors, err)
 		return result

--- a/http/client_collection.go
+++ b/http/client_collection.go
@@ -23,7 +23,6 @@ import (
 	"github.com/sourcenetwork/defradb/errors"
 
 	"github.com/sourcenetwork/defradb/client"
-	"github.com/sourcenetwork/defradb/internal/encryption"
 )
 
 var _ client.Collection = (*Collection)(nil)
@@ -61,6 +60,7 @@ func (c *Collection) Definition() client.CollectionDefinition {
 func (c *Collection) Create(
 	ctx context.Context,
 	doc *client.Document,
+	opts ...client.DocCreateOption,
 ) error {
 	methodURL := c.http.apiURL.JoinPath("collections", c.Version().Name)
 
@@ -74,7 +74,7 @@ func (c *Collection) Create(
 		return err
 	}
 
-	setDocEncryptionFlagIfNeeded(ctx, req)
+	setDocEncryptionFlagIfNeeded(req, opts...)
 
 	_, err = c.http.request(req)
 	if err != nil {
@@ -87,6 +87,7 @@ func (c *Collection) Create(
 func (c *Collection) CreateMany(
 	ctx context.Context,
 	docs []*client.Document,
+	opts ...client.DocCreateOption,
 ) error {
 	methodURL := c.http.apiURL.JoinPath("collections", c.Version().Name)
 
@@ -109,7 +110,7 @@ func (c *Collection) CreateMany(
 		return err
 	}
 
-	setDocEncryptionFlagIfNeeded(ctx, req)
+	setDocEncryptionFlagIfNeeded(req, opts...)
 
 	_, err = c.http.request(req)
 	if err != nil {
@@ -122,16 +123,18 @@ func (c *Collection) CreateMany(
 	return nil
 }
 
-func setDocEncryptionFlagIfNeeded(ctx context.Context, req *http.Request) {
-	encConf := encryption.GetContextConfig(ctx)
-	if encConf.HasValue() {
-		q := req.URL.Query()
-		if encConf.Value().IsDocEncrypted {
-			q.Set(docEncryptParam, "true")
-		}
-		if len(encConf.Value().EncryptedFields) > 0 {
-			q.Set(docEncryptFieldsParam, strings.Join(encConf.Value().EncryptedFields, ","))
-		}
+func setDocEncryptionFlagIfNeeded(req *http.Request, opts ...client.DocCreateOption) {
+	createDocsOptions := client.DocCreateOptions{}
+	createDocsOptions.Apply(opts...)
+
+	q := req.URL.Query()
+	if createDocsOptions.EncryptDoc {
+		q.Set(docEncryptParam, "true")
+	}
+	if len(createDocsOptions.EncryptedFields) > 0 {
+		q.Set(docEncryptFieldsParam, strings.Join(createDocsOptions.EncryptedFields, ","))
+	}
+	if len(q) > 0 {
 		req.URL.RawQuery = q.Encode()
 	}
 }
@@ -162,13 +165,14 @@ func (c *Collection) Update(
 func (c *Collection) Save(
 	ctx context.Context,
 	doc *client.Document,
+	opts ...client.DocCreateOption,
 ) error {
 	_, err := c.Get(ctx, doc.ID(), true)
 	if err == nil {
 		return c.Update(ctx, doc)
 	}
 	if errors.Is(err, client.ErrDocumentNotFoundOrNotAuthorized) {
-		return c.Create(ctx, doc)
+		return c.Create(ctx, doc, opts...)
 	}
 	return err
 }

--- a/http/client_collection.go
+++ b/http/client_collection.go
@@ -74,7 +74,7 @@ func (c *Collection) Create(
 		return err
 	}
 
-	setDocEncryptionFlagIfNeeded(req, opts...)
+	setDocEncryptionFlagIfNeeded(req, opts)
 
 	_, err = c.http.request(req)
 	if err != nil {
@@ -110,7 +110,7 @@ func (c *Collection) CreateMany(
 		return err
 	}
 
-	setDocEncryptionFlagIfNeeded(req, opts...)
+	setDocEncryptionFlagIfNeeded(req, opts)
 
 	_, err = c.http.request(req)
 	if err != nil {
@@ -123,9 +123,9 @@ func (c *Collection) CreateMany(
 	return nil
 }
 
-func setDocEncryptionFlagIfNeeded(req *http.Request, opts ...client.DocCreateOption) {
+func setDocEncryptionFlagIfNeeded(req *http.Request, opts []client.DocCreateOption) {
 	createDocsOptions := client.DocCreateOptions{}
-	createDocsOptions.Apply(opts...)
+	createDocsOptions.Apply(opts)
 
 	q := req.URL.Query()
 	if createDocsOptions.EncryptDoc {

--- a/http/handler_collection.go
+++ b/http/handler_collection.go
@@ -57,8 +57,10 @@ func (s *collectionHandler) Create(rw http.ResponseWriter, req *http.Request) {
 	if q.Get(docEncryptFieldsParam) != "" {
 		encConf.EncryptedFields = strings.Split(q.Get(docEncryptFieldsParam), ",")
 	}
-	if encConf.IsDocEncrypted || len(encConf.EncryptedFields) > 0 {
-		ctx = encryption.SetContextConfig(ctx, encConf)
+
+	createOpts := []client.DocCreateOption{
+		client.CreateDocEncrypted(encConf.IsDocEncrypted),
+		client.CreateDocWithEncryptedFields(encConf.EncryptedFields),
 	}
 
 	switch {
@@ -69,7 +71,7 @@ func (s *collectionHandler) Create(rw http.ResponseWriter, req *http.Request) {
 			return
 		}
 
-		if err := col.CreateMany(ctx, docList); err != nil {
+		if err := col.CreateMany(ctx, docList, createOpts...); err != nil {
 			responseJSON(rw, http.StatusBadRequest, errorResponse{err})
 			return
 		}
@@ -80,7 +82,7 @@ func (s *collectionHandler) Create(rw http.ResponseWriter, req *http.Request) {
 			responseJSON(rw, http.StatusBadRequest, errorResponse{err})
 			return
 		}
-		if err := col.Create(ctx, doc); err != nil {
+		if err := col.Create(ctx, doc, createOpts...); err != nil {
 			responseJSON(rw, http.StatusBadRequest, errorResponse{err})
 			return
 		}

--- a/internal/db/collection.go
+++ b/internal/db/collection.go
@@ -395,7 +395,7 @@ func (c *collection) Create(
 	}
 	defer txn.Discard(ctx)
 
-	err = c.create(ctx, doc, opts...)
+	err = c.create(ctx, doc, opts)
 	if err != nil {
 		return err
 	}
@@ -420,7 +420,7 @@ func (c *collection) CreateMany(
 	defer txn.Discard(ctx)
 
 	for _, doc := range docs {
-		err = c.create(ctx, doc, opts...)
+		err = c.create(ctx, doc, opts)
 		if err != nil {
 			return err
 		}
@@ -452,7 +452,7 @@ func (c *collection) getDocIDAndPrimaryKeyFromDoc(
 func (c *collection) create(
 	ctx context.Context,
 	doc *client.Document,
-	opts ...client.DocCreateOption,
+	opts []client.DocCreateOption,
 ) error {
 	err := c.setEmbedding(ctx, doc, true)
 	if err != nil {
@@ -497,7 +497,7 @@ func (c *collection) create(
 		}
 	}
 
-	ctx = setContextDocEncryption(ctx, opts...)
+	ctx = setContextDocEncryption(ctx, opts)
 
 	// write data to DB via MerkleClock/CRDT
 	err = c.save(ctx, doc, true)
@@ -513,9 +513,9 @@ func (c *collection) create(
 	return c.registerDocWithACP(ctx, doc.ID().String())
 }
 
-func setContextDocEncryption(ctx context.Context, opts ...client.DocCreateOption) context.Context {
+func setContextDocEncryption(ctx context.Context, opts []client.DocCreateOption) context.Context {
 	createOptions := client.DocCreateOptions{}
-	createOptions.Apply(opts...)
+	createOptions.Apply(opts)
 	if !createOptions.EncryptDoc && len(createOptions.EncryptedFields) == 0 {
 		return ctx
 	}
@@ -631,7 +631,7 @@ func (c *collection) Save(
 	if exists {
 		err = c.update(ctx, doc)
 	} else {
-		err = c.create(ctx, doc, opts...)
+		err = c.create(ctx, doc, opts)
 	}
 	if err != nil {
 		return err

--- a/js/client_collection.go
+++ b/js/client_collection.go
@@ -13,7 +13,6 @@
 package js
 
 import (
-	"fmt"
 	"sync"
 	"syscall/js"
 
@@ -128,34 +127,18 @@ func (c *clientCollection) createMany(this js.Value, args []js.Value) (js.Value,
 }
 
 func getCreateOptionsFromArg(args []js.Value, argIndex int) ([]client.DocCreateOption, error) {
-	var createOptions map[string]any
+	var createOptions client.DocCreateOptions
 	if err := structArg(args, argIndex, "options", &createOptions); err != nil {
 		return nil, err
 	}
 
 	opts := []client.DocCreateOption{}
-	if v, ok := createOptions["encryptedFields"]; ok {
-		if encryptedFields, ok := v.([]any); ok {
-			fields := []string{}
-			for _, f := range encryptedFields {
-				if field, ok := f.(string); ok {
-					fields = append(fields, field)
-				} else {
-					return nil, fmt.Errorf("encryptedFields must be an array of strings")
-				}
-			}
-			opts = append(opts, client.CreateDocWithEncryptedFields(fields))
-		} else {
-			return nil, fmt.Errorf("encryptedFields must be an array of strings")
-		}
+	if len(createOptions.EncryptedFields) > 0 {
+		opts = append(opts, client.CreateDocWithEncryptedFields(createOptions.EncryptedFields))
 	}
 
-	if v, ok := createOptions["encrypt"]; ok {
-		if encrypt, ok := v.(bool); ok {
-			opts = append(opts, client.CreateDocEncrypted(encrypt))
-		} else {
-			return nil, fmt.Errorf("encrypt must be a boolean")
-		}
+	if createOptions.EncryptDoc {
+		opts = append(opts, client.CreateDocEncrypted(true))
 	}
 	return opts, nil
 }

--- a/js/utils.go
+++ b/js/utils.go
@@ -27,7 +27,6 @@ import (
 	"github.com/sourcenetwork/defradb/crypto"
 	"github.com/sourcenetwork/defradb/datastore"
 	"github.com/sourcenetwork/defradb/internal/db"
-	"github.com/sourcenetwork/defradb/internal/encryption"
 )
 
 func stringArg(args []js.Value, index int, name string) (string, error) {
@@ -80,25 +79,9 @@ func contextArg(args []js.Value, index int, txns *sync.Map) (context.Context, er
 	if err != nil {
 		return ctx, err
 	}
-	encrypt, encryptFields := contextEncryptionArg(args[index])
-	ctx = encryption.SetContextConfigFromParams(ctx, encrypt, encryptFields)
 	ctx = acpIdentity.WithContext(ctx, identity)
 	ctx = db.InitContext(ctx, txn)
 	return ctx, nil
-}
-
-func contextEncryptionArg(value js.Value) (bool, []string) {
-	var encrypt bool
-	if v := value.Get("encrypt"); v.Type() == js.TypeBoolean {
-		encrypt = v.Bool()
-	}
-	var encryptFields []string
-	if v := value.Get("encryptFields"); v.Type() == js.TypeObject {
-		for i := 0; i < v.Length(); i++ {
-			encryptFields = append(encryptFields, v.Index(i).String())
-		}
-	}
-	return encrypt, encryptFields
 }
 
 func contextTransactionArg(value js.Value, txns *sync.Map) (datastore.Txn, error) {

--- a/tests/clients/cli/wrapper_collection.go
+++ b/tests/clients/cli/wrapper_collection.go
@@ -18,7 +18,6 @@ import (
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/errors"
 	"github.com/sourcenetwork/defradb/http"
-	"github.com/sourcenetwork/defradb/internal/encryption"
 )
 
 var _ client.Collection = (*Collection)(nil)
@@ -55,8 +54,9 @@ func (c *Collection) Definition() client.CollectionDefinition {
 func (c *Collection) Create(
 	ctx context.Context,
 	doc *client.Document,
+	opts ...client.DocCreateOption,
 ) error {
-	args := makeDocCreateArgs(ctx, c)
+	args := makeDocCreateArgs(c, opts...)
 
 	document, err := doc.String()
 	if err != nil {
@@ -75,8 +75,9 @@ func (c *Collection) Create(
 func (c *Collection) CreateMany(
 	ctx context.Context,
 	docs []*client.Document,
+	opts ...client.DocCreateOption,
 ) error {
-	args := makeDocCreateArgs(ctx, c)
+	args := makeDocCreateArgs(c, opts...)
 
 	docStrings := make([]string, len(docs))
 	for i, doc := range docs {
@@ -99,20 +100,20 @@ func (c *Collection) CreateMany(
 }
 
 func makeDocCreateArgs(
-	ctx context.Context,
 	c *Collection,
+	opts ...client.DocCreateOption,
 ) []string {
 	args := []string{"client", "collection", "create"}
 	args = append(args, "--name", c.Version().Name)
 
-	encConf := encryption.GetContextConfig(ctx)
-	if encConf.HasValue() {
-		if encConf.Value().IsDocEncrypted {
-			args = append(args, "--encrypt")
-		}
-		if len(encConf.Value().EncryptedFields) > 0 {
-			args = append(args, "--encrypt-fields", strings.Join(encConf.Value().EncryptedFields, ","))
-		}
+	createDocOpts := client.DocCreateOptions{}
+	createDocOpts.Apply(opts...)
+
+	if createDocOpts.EncryptDoc {
+		args = append(args, "--encrypt")
+	}
+	if len(createDocOpts.EncryptedFields) > 0 {
+		args = append(args, "--encrypt-fields", strings.Join(createDocOpts.EncryptedFields, ","))
 	}
 
 	return args
@@ -143,13 +144,14 @@ func (c *Collection) Update(
 func (c *Collection) Save(
 	ctx context.Context,
 	doc *client.Document,
+	opts ...client.DocCreateOption,
 ) error {
 	_, err := c.Get(ctx, doc.ID(), true)
 	if err == nil {
 		return c.Update(ctx, doc)
 	}
 	if errors.Is(err, client.ErrDocumentNotFoundOrNotAuthorized) {
-		return c.Create(ctx, doc)
+		return c.Create(ctx, doc, opts...)
 	}
 	return err
 }

--- a/tests/clients/cli/wrapper_collection.go
+++ b/tests/clients/cli/wrapper_collection.go
@@ -56,7 +56,7 @@ func (c *Collection) Create(
 	doc *client.Document,
 	opts ...client.DocCreateOption,
 ) error {
-	args := makeDocCreateArgs(c, opts...)
+	args := makeDocCreateArgs(c, opts)
 
 	document, err := doc.String()
 	if err != nil {
@@ -77,7 +77,7 @@ func (c *Collection) CreateMany(
 	docs []*client.Document,
 	opts ...client.DocCreateOption,
 ) error {
-	args := makeDocCreateArgs(c, opts...)
+	args := makeDocCreateArgs(c, opts)
 
 	docStrings := make([]string, len(docs))
 	for i, doc := range docs {
@@ -101,13 +101,13 @@ func (c *Collection) CreateMany(
 
 func makeDocCreateArgs(
 	c *Collection,
-	opts ...client.DocCreateOption,
+	opts []client.DocCreateOption,
 ) []string {
 	args := []string{"client", "collection", "create"}
 	args = append(args, "--name", c.Version().Name)
 
 	createDocOpts := client.DocCreateOptions{}
-	createDocOpts.Apply(opts...)
+	createDocOpts.Apply(opts)
 
 	if createDocOpts.EncryptDoc {
 		args = append(args, "--encrypt")

--- a/tests/clients/js/wrapper_collection.go
+++ b/tests/clients/js/wrapper_collection.go
@@ -95,6 +95,7 @@ func (c *Collection) Definition() client.CollectionDefinition {
 func (c *Collection) Create(
 	ctx context.Context,
 	doc *client.Document,
+	opts ...client.DocCreateOption,
 ) error {
 	docVal, err := goji.MarshalJS(doc)
 	if err != nil {
@@ -111,6 +112,7 @@ func (c *Collection) Create(
 func (c *Collection) CreateMany(
 	ctx context.Context,
 	docs []*client.Document,
+	opts ...client.DocCreateOption,
 ) error {
 	docsVal, err := goji.MarshalJS(docs)
 	if err != nil {
@@ -146,6 +148,7 @@ func (c *Collection) Update(
 func (c *Collection) Save(
 	ctx context.Context,
 	doc *client.Document,
+	opts ...client.DocCreateOption,
 ) error {
 	_, err := c.Get(ctx, doc.ID(), true)
 	if err == nil {

--- a/tests/clients/js/wrapper_collection.go
+++ b/tests/clients/js/wrapper_collection.go
@@ -109,18 +109,15 @@ func (c *Collection) Create(
 	return nil
 }
 
-func makeDocCreateOptions(opts []client.DocCreateOption) map[string]any {
+func makeDocCreateOptions(opts []client.DocCreateOption) js.Value {
 	createOpts := client.DocCreateOptions{}
 	createOpts.Apply(opts)
 
-	options := make(map[string]any)
-	if createOpts.EncryptDoc {
-		options["encrypt"] = true
+	optsVal, err := goji.MarshalJS(createOpts)
+	if err != nil {
+		return js.Undefined()
 	}
-	if len(createOpts.EncryptedFields) > 0 {
-		options["encryptFields"] = createOpts.EncryptedFields
-	}
-	return options
+	return optsVal
 }
 
 func (c *Collection) CreateMany(

--- a/tests/clients/js/wrapper_collection.go
+++ b/tests/clients/js/wrapper_collection.go
@@ -101,12 +101,26 @@ func (c *Collection) Create(
 	if err != nil {
 		return err
 	}
-	_, err = execute(ctx, c.client, "create", docVal)
+	_, err = execute(ctx, c.client, "create", docVal, makeDocCreateOptions(opts))
 	if err != nil {
 		return err
 	}
 	doc.Clean()
 	return nil
+}
+
+func makeDocCreateOptions(opts []client.DocCreateOption) map[string]any {
+	createOpts := client.DocCreateOptions{}
+	createOpts.Apply(opts)
+
+	options := make(map[string]any)
+	if createOpts.EncryptDoc {
+		options["encrypt"] = true
+	}
+	if len(createOpts.EncryptedFields) > 0 {
+		options["encryptFields"] = createOpts.EncryptedFields
+	}
+	return options
 }
 
 func (c *Collection) CreateMany(
@@ -118,7 +132,7 @@ func (c *Collection) CreateMany(
 	if err != nil {
 		return err
 	}
-	_, err = execute(ctx, c.client, "createMany", docsVal)
+	_, err = execute(ctx, c.client, "createMany", docsVal, makeDocCreateOptions(opts))
 	if err != nil {
 		return err
 	}
@@ -155,7 +169,7 @@ func (c *Collection) Save(
 		return c.Update(ctx, doc)
 	}
 	if err.Error() == client.ErrDocumentNotFoundOrNotAuthorized.Error() {
-		return c.Create(ctx, doc)
+		return c.Create(ctx, doc, opts...)
 	}
 	return err
 }

--- a/tests/clients/js/wrapper_js.go
+++ b/tests/clients/js/wrapper_js.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/internal/db/txnctx"
-	"github.com/sourcenetwork/defradb/internal/encryption"
 
 	"github.com/sourcenetwork/goji"
 )
@@ -32,16 +31,6 @@ func execute(ctx context.Context, value js.Value, method string, args ...any) ([
 	id := identity.FromContext(ctx)
 	if id.HasValue() && id.Value().PrivateKey != nil {
 		contextValues["identity"] = id.Value().PrivateKey.String()
-	}
-	enc := encryption.GetContextConfig(ctx)
-	if enc.HasValue() {
-		config := enc.Value()
-		fields := make([]any, len(config.EncryptedFields))
-		for i, f := range config.EncryptedFields {
-			fields[i] = f
-		}
-		contextValues["encrypt"] = config.IsDocEncrypted
-		contextValues["encryptFields"] = fields
 	}
 	args = append(args, contextValues)
 	prom := value.Call(method, args...)


### PR DESCRIPTION
## Relevant issue(s)

Resolves [#3754](https://github.com/sourcenetwork/defradb/issues/3754)

## Description

Add create doc options to collection create-doc-related methods. 
The options allow specifying parameters for doc encryption.

As opposed to the previous approach with passing the context, this moves parameters handing into the interface and unifies it for all clients.
