### PR TITLE
test: Update test Lens modules to latest SDK

### DIFF
--- a/tests/lenses/rust_wasm32_copy/Cargo.toml
+++ b/tests/lenses/rust_wasm32_copy/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rust-wasm32-copy"
 version = "0.1.0"
-edition = "2018"
+edition = "2024"
 
 [lib]
 crate-type = ["cdylib"]
@@ -9,4 +9,4 @@ crate-type = ["cdylib"]
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.87"
-lens_sdk = "^0.5"
+lens_sdk = "^0.8"

--- a/tests/lenses/rust_wasm32_copy/src/lib.rs
+++ b/tests/lenses/rust_wasm32_copy/src/lib.rs
@@ -5,28 +5,23 @@
 use std::collections::HashMap;
 use std::sync::RwLock;
 use std::error::Error;
-use std::{fmt, error};
+use std::fmt;
 use serde::Deserialize;
 use lens_sdk::StreamOption;
-use lens_sdk::option::StreamOption::{Some, None, EndOfStream};
+use lens_sdk::error::LensError;
 
-#[link(wasm_import_module = "lens")]
-extern "C" {
-    fn next() -> *mut u8;
-}
+lens_sdk::define!(PARAMETERS: Parameters, try_transform);
 
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
 enum ModuleError {
-    ParametersNotSetError,
     PropertyNotFoundError{requested: String},
 }
 
-impl error::Error for ModuleError { }
+impl Error for ModuleError { }
 
 impl fmt::Display for ModuleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match &*self {
-            ModuleError::ParametersNotSetError => f.write_str("Parameters have not been set."),
             ModuleError::PropertyNotFoundError { requested } =>
                 write!(f, "The requested property was not found. Requested: {}", requested),
         }
@@ -39,65 +34,29 @@ pub struct Parameters {
     pub dst: String,
 }
 
-static PARAMETERS: RwLock<StreamOption<Parameters>> = RwLock::new(None);
+static PARAMETERS: RwLock<Option<Parameters>> = RwLock::new(None);
 
-#[no_mangle]
-pub extern fn alloc(size: usize) -> *mut u8 {
-    lens_sdk::alloc(size)
-}
-
-#[no_mangle]
-pub extern fn set_param(ptr: *mut u8) -> *mut u8 {
-    match try_set_param(ptr) {
-        Ok(_) => lens_sdk::nil_ptr(),
-        Err(e) => lens_sdk::to_mem(lens_sdk::ERROR_TYPE_ID, &e.to_string().as_bytes())
-    }
-}
-
-fn try_set_param(ptr: *mut u8) -> Result<(), Box<dyn Error>> {
-    let parameter = lens_sdk::try_from_mem::<Parameters>(ptr)?
-        .ok_or(ModuleError::ParametersNotSetError)?;
-
-    let mut dst = PARAMETERS.write()?;
-    *dst = Some(parameter);
-    Ok(())
-}
-
-#[no_mangle]
-pub extern fn transform() -> *mut u8 {
-    match try_transform() {
-        Ok(o) => match o {
-            Some(result_json) => lens_sdk::to_mem(lens_sdk::JSON_TYPE_ID, &result_json),
-            None => lens_sdk::nil_ptr(),
-            EndOfStream => lens_sdk::to_mem(lens_sdk::EOS_TYPE_ID, &[]),
-        },
-        Err(e) => lens_sdk::to_mem(lens_sdk::ERROR_TYPE_ID, &e.to_string().as_bytes())
-    }
-}
-
-fn try_transform() -> Result<StreamOption<Vec<u8>>, Box<dyn Error>> {
-    let ptr = unsafe { next() };
-    let mut input = match lens_sdk::try_from_mem::<HashMap<String, serde_json::Value>>(ptr)? {
-        Some(v) => v,
-        // Implementations of `transform` are free to handle nil however they like. In this
-        // implementation we chose to return nil given a nil input.
-        None => return Ok(None),
-        EndOfStream => return Ok(EndOfStream)
-    };
-
+fn try_transform(
+    iter: &mut dyn Iterator<Item = lens_sdk::Result<Option<HashMap<String, serde_json::Value>>>>,
+) -> Result<StreamOption<HashMap<String, serde_json::Value>>, Box<dyn Error>> {
     let params = PARAMETERS.read()?
         .clone()
-        .ok_or(ModuleError::ParametersNotSetError)?
-        .clone();
+        .ok_or(LensError::ParametersNotSetError)?;
 
-    let value = input.get_mut(&params.src)
-        .ok_or(ModuleError::PropertyNotFoundError{requested: params.src.clone()})?
-        .clone();
+    for item in iter {
+        let mut input = match item? {
+            Some(v) => v,
+            None => return Ok(StreamOption::None),
+        };
 
-    let mut result = input.clone();
-    result.insert(params.dst, value);
+        let value = input.get_mut(&params.src)
+            .ok_or(ModuleError::PropertyNotFoundError{requested: params.src.clone()})?
+            .clone();
 
-    let result_json = serde_json::to_vec(&result)?;
-    lens_sdk::free_transport_buffer(ptr)?;
-    Ok(Some(result_json))
+        input.insert(params.dst, value);
+
+        return Ok(StreamOption::Some(input))
+    }
+
+    Ok(StreamOption::EndOfStream)
 }

--- a/tests/lenses/rust_wasm32_filter/Cargo.toml
+++ b/tests/lenses/rust_wasm32_filter/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rust-wasm32-filter"
 version = "0.1.0"
-edition = "2018"
+edition = "2024"
 
 [lib]
 crate-type = ["cdylib"]
@@ -9,4 +9,4 @@ crate-type = ["cdylib"]
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.87"
-lens_sdk = "^0.5"
+lens_sdk = "^0.8"

--- a/tests/lenses/rust_wasm32_filter/src/lib.rs
+++ b/tests/lenses/rust_wasm32_filter/src/lib.rs
@@ -5,28 +5,23 @@
 use std::collections::HashMap;
 use std::sync::RwLock;
 use std::error::Error;
-use std::{fmt, error};
+use std::fmt;
 use serde::Deserialize;
 use lens_sdk::StreamOption;
-use lens_sdk::option::StreamOption::{Some, None, EndOfStream};
+use lens_sdk::error::LensError;
 
-#[link(wasm_import_module = "lens")]
-extern "C" {
-    fn next() -> *mut u8;
-}
+lens_sdk::define!(PARAMETERS: Parameters, try_transform);
 
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
 enum ModuleError {
-    ParametersNotSetError,
     PropertyNotFoundError{requested: String},
 }
 
-impl error::Error for ModuleError { }
+impl Error for ModuleError { }
 
 impl fmt::Display for ModuleError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match &*self {
-            ModuleError::ParametersNotSetError => f.write_str("Parameters have not been set."),
             ModuleError::PropertyNotFoundError { requested } =>
                 write!(f, "The requested property was not found. Requested: {}", requested),
         }
@@ -39,68 +34,31 @@ pub struct Parameters {
     pub value: serde_json::Value,
 }
 
-static PARAMETERS: RwLock<StreamOption<Parameters>> = RwLock::new(None);
+static PARAMETERS: RwLock<Option<Parameters>> = RwLock::new(None);
 
-#[no_mangle]
-pub extern fn alloc(size: usize) -> *mut u8 {
-    lens_sdk::alloc(size)
-}
-
-#[no_mangle]
-pub extern fn set_param(ptr: *mut u8) -> *mut u8 {
-    match try_set_param(ptr) {
-        Ok(_) => lens_sdk::nil_ptr(),
-        Err(e) => lens_sdk::to_mem(lens_sdk::ERROR_TYPE_ID, &e.to_string().as_bytes())
-    }
-}
-
-fn try_set_param(ptr: *mut u8) -> Result<(), Box<dyn Error>> {
-    let parameter = lens_sdk::try_from_mem::<Parameters>(ptr)?
-        .ok_or(ModuleError::ParametersNotSetError)?;
-
-    let mut dst = PARAMETERS.write()?;
-    *dst = Some(parameter);
-    Ok(())
-}
-
-#[no_mangle]
-pub extern fn transform() -> *mut u8 {
-    match try_transform() {
-        Ok(o) => match o {
-            Some(result_json) => lens_sdk::to_mem(lens_sdk::JSON_TYPE_ID, &result_json),
-            None => lens_sdk::nil_ptr(),
-            EndOfStream => lens_sdk::to_mem(lens_sdk::EOS_TYPE_ID, &[]),
-        },
-        Err(e) => lens_sdk::to_mem(lens_sdk::ERROR_TYPE_ID, &e.to_string().as_bytes())
-    }
-}
-
-fn try_transform() -> Result<StreamOption<Vec<u8>>, Box<dyn Error>> {
-    let ptr = unsafe { next() };
-    let mut input = match lens_sdk::try_from_mem::<HashMap<String, serde_json::Value>>(ptr)? {
-        Some(v) => v,
-        // Implementations of `transform` are free to handle nil however they like. In this
-        // implementation we chose to return nil given a nil input.
-        None => return Ok(None),
-        EndOfStream => return Ok(EndOfStream)
-    };
-
+fn try_transform(
+    iter: &mut dyn Iterator<Item = lens_sdk::Result<Option<HashMap<String, serde_json::Value>>>>,
+) -> Result<StreamOption<HashMap<String, serde_json::Value>>, Box<dyn Error>> {
     let params = PARAMETERS.read()?
         .clone()
-        .ok_or(ModuleError::ParametersNotSetError)?
-        .clone();
+        .ok_or(LensError::ParametersNotSetError)?;
 
-    let value = input.get_mut(&params.src)
-        .ok_or(ModuleError::PropertyNotFoundError{requested: params.src.clone()})?
-        .clone();
+    for item in iter {
+        let mut input = match item? {
+            Some(v) => v,
+            None => return Ok(StreamOption::None),
+        };
 
-    if value != params.value {
-        return try_transform();
+        let value = input.get_mut(&params.src)
+            .ok_or(ModuleError::PropertyNotFoundError{requested: params.src.clone()})?
+            .clone();
+
+        if value != params.value {
+            continue
+        }
+
+        return Ok(StreamOption::Some(input))
     }
 
-    let result = input.clone();
-
-    let result_json = serde_json::to_vec(&result)?;
-    lens_sdk::free_transport_buffer(ptr)?;
-    Ok(Some(result_json))
+    Ok(StreamOption::EndOfStream)
 }

--- a/tests/lenses/rust_wasm32_prepend/Cargo.toml
+++ b/tests/lenses/rust_wasm32_prepend/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rust-wasm32-prepend"
 version = "0.1.0"
-edition = "2018"
+edition = "2024"
 
 [lib]
 crate-type = ["cdylib"]
@@ -9,4 +9,4 @@ crate-type = ["cdylib"]
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.87"
-lens_sdk = "^0.5"
+lens_sdk = "^0.8"

--- a/tests/lenses/rust_wasm32_prepend/src/lib.rs
+++ b/tests/lenses/rust_wasm32_prepend/src/lib.rs
@@ -5,107 +5,47 @@
 use std::collections::HashMap;
 use std::sync::RwLock;
 use std::error::Error;
-use std::{fmt, error};
 use serde::Deserialize;
 use lens_sdk::StreamOption;
-use lens_sdk::option::StreamOption::{Some, None, EndOfStream};
+use lens_sdk::error::LensError;
 
-#[link(wasm_import_module = "lens")]
-extern "C" {
-    fn next() -> *mut u8;
-}
-
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
-enum ModuleError {
-    ParametersNotSetError,
-}
-
-impl error::Error for ModuleError { }
-
-impl fmt::Display for ModuleError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match &*self {
-            ModuleError::ParametersNotSetError => f.write_str("Parameters have not been set."),
-        }
-    }
-}
+lens_sdk::define!(PARAMETERS: Parameters, try_transform);
 
 #[derive(Deserialize, Clone)]
 pub struct Parameters {
-    pub values: Vec<HashMap<String, String>>,
+    pub values: Vec<HashMap<String, serde_json::Value>>,
 }
 
-static PARAMETERS: RwLock<StreamOption<Parameters>> = RwLock::new(None);
+static PARAMETERS: RwLock<Option<Parameters>> = RwLock::new(None);
 static PARAM_INDEX: RwLock<usize> = RwLock::new(0);
 
-#[no_mangle]
-pub extern fn alloc(size: usize) -> *mut u8 {
-    lens_sdk::alloc(size)
-}
-
-#[no_mangle]
-pub extern fn set_param(ptr: *mut u8) -> *mut u8 {
-    match try_set_param(ptr) {
-        Ok(_) => lens_sdk::nil_ptr(),
-        Err(e) => lens_sdk::to_mem(lens_sdk::ERROR_TYPE_ID, &e.to_string().as_bytes())
-    }
-}
-
-fn try_set_param(ptr: *mut u8) -> Result<(), Box<dyn Error>> {
-    let parameter = lens_sdk::try_from_mem::<Parameters>(ptr)?
-        .ok_or(ModuleError::ParametersNotSetError)?
-        .clone();
-
-    let mut dst = PARAMETERS.write()?;
-    *dst = Some(parameter);
-    Ok(())
-}
-
-#[no_mangle]
-pub extern fn transform() -> *mut u8 {
-    match try_transform() {
-        Ok(o) => match o {
-            Some(result_json) => lens_sdk::to_mem(lens_sdk::JSON_TYPE_ID, &result_json),
-            None => lens_sdk::nil_ptr(),
-            EndOfStream => lens_sdk::to_mem(lens_sdk::EOS_TYPE_ID, &[]),
-        },
-        Err(e) => lens_sdk::to_mem(lens_sdk::ERROR_TYPE_ID, &e.to_string().as_bytes())
-    }
-}
-
-fn try_transform() -> Result<StreamOption<Vec<u8>>, Box<dyn Error>> {
+fn try_transform(
+    iter: &mut dyn Iterator<Item = lens_sdk::Result<Option<HashMap<String, serde_json::Value>>>>,
+) -> Result<StreamOption<HashMap<String, serde_json::Value>>, Box<dyn Error>> {
     let params = PARAMETERS.read()?
         .clone()
-        .ok_or(ModuleError::ParametersNotSetError)?
-        .clone();
+        .ok_or(LensError::ParametersNotSetError)?;
 
     let param_index = PARAM_INDEX.read()?
         .clone();
 
     if param_index < params.values.len() {
         let result = &params.values[param_index];
-        let result_json = serde_json::to_vec(&result)?;
 
         let mut dst = PARAM_INDEX.write()?;
         *dst = param_index+1;
-        return Ok(Some(result_json))
+
+        return Ok(StreamOption::Some(result.clone()))
     }
 
-    // Note: The following is a very unperformant, but simple way of yielding the input documents,
-    // as this module is only used for testing, this is preferred.
+    for item in iter {
+        let input = match item? {
+            Some(v) => v,
+            None => return Ok(StreamOption::None),
+        };
 
-    let ptr = unsafe { next() };
-    let input = match lens_sdk::try_from_mem::<HashMap<String, serde_json::Value>>(ptr)? {
-        Some(v) => v,
-        // Implementations of `transform` are free to handle nil however they like. In this
-        // implementation we chose to return nil given a nil input.
-        None => return Ok(None),
-        EndOfStream => return Ok(EndOfStream)
-    };
+        return Ok(StreamOption::Some(input))
+    }
 
-    let result = input.clone();
-
-    let result_json = serde_json::to_vec(&result)?;
-    lens_sdk::free_transport_buffer(ptr)?;
-    Ok(Some(result_json))
+    Ok(StreamOption::EndOfStream)
 }

--- a/tests/lenses/rust_wasm32_remove/Cargo.toml
+++ b/tests/lenses/rust_wasm32_remove/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rust-wasm32-remove"
 version = "0.1.0"
-edition = "2018"
+edition = "2024"
 
 [lib]
 crate-type = ["cdylib"]
@@ -9,4 +9,4 @@ crate-type = ["cdylib"]
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.87"
-lens_sdk = "^0.5"
+lens_sdk = "^0.8"

--- a/tests/lenses/rust_wasm32_remove/src/lib.rs
+++ b/tests/lenses/rust_wasm32_remove/src/lib.rs
@@ -1,90 +1,36 @@
 use std::collections::HashMap;
 use std::sync::RwLock;
 use std::error::Error;
-use std::{fmt, error};
 use serde::Deserialize;
 use lens_sdk::StreamOption;
-use lens_sdk::option::StreamOption::{Some, None, EndOfStream};
+use lens_sdk::error::LensError;
 
-#[link(wasm_import_module = "lens")]
-extern "C" {
-    fn next() -> *mut u8;
-}
-
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
-enum ModuleError {
-    ParametersNotSetError,
-}
-
-impl error::Error for ModuleError { }
-
-impl fmt::Display for ModuleError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match &*self {
-            ModuleError::ParametersNotSetError => f.write_str("Parameters have not been set."),
-        }
-    }
-}
+lens_sdk::define!(PARAMETERS: Parameters, try_transform);
 
 #[derive(Deserialize, Clone)]
 pub struct Parameters {
     pub target: String,
 }
 
-static PARAMETERS: RwLock<StreamOption<Parameters>> = RwLock::new(None);
+static PARAMETERS: RwLock<Option<Parameters>> = RwLock::new(None);
 
-#[no_mangle]
-pub extern fn alloc(size: usize) -> *mut u8 {
-    lens_sdk::alloc(size)
-}
-
-#[no_mangle]
-pub extern fn set_param(ptr: *mut u8) -> *mut u8 {
-    match try_set_param(ptr) {
-        Ok(_) => lens_sdk::nil_ptr(),
-        Err(e) => lens_sdk::to_mem(lens_sdk::ERROR_TYPE_ID, &e.to_string().as_bytes())
-    }
-}
-
-fn try_set_param(ptr: *mut u8) -> Result<(), Box<dyn Error>> {
-    let parameter = lens_sdk::try_from_mem::<Parameters>(ptr)?
-        .ok_or(ModuleError::ParametersNotSetError)?;
-
-    let mut dst = PARAMETERS.write()?;
-    *dst = Some(parameter);
-    Ok(())
-}
-
-#[no_mangle]
-pub extern fn transform() -> *mut u8 {
-    match try_transform() {
-        Ok(o) => match o {
-            Some(result_json) => lens_sdk::to_mem(lens_sdk::JSON_TYPE_ID, &result_json),
-            None => lens_sdk::nil_ptr(),
-            EndOfStream => lens_sdk::to_mem(lens_sdk::EOS_TYPE_ID, &[]),
-        },
-        Err(e) => lens_sdk::to_mem(lens_sdk::ERROR_TYPE_ID, &e.to_string().as_bytes())
-    }
-}
-
-fn try_transform() -> Result<StreamOption<Vec<u8>>, Box<dyn Error>> {
-    let ptr = unsafe { next() };
-    let mut input = match lens_sdk::try_from_mem::<HashMap<String, serde_json::Value>>(ptr)? {
-        Some(v) => v,
-        // Implementations of `transform` are free to handle nil however they like. In this
-        // implementation we chose to return nil given a nil input.
-        None => return Ok(None),
-        EndOfStream => return Ok(EndOfStream)
-    };
-
+fn try_transform(
+    iter: &mut dyn Iterator<Item = lens_sdk::Result<Option<HashMap<String, serde_json::Value>>>>,
+) -> Result<StreamOption<HashMap<String, serde_json::Value>>, Box<dyn Error>> {
     let params = PARAMETERS.read()?
         .clone()
-        .ok_or(ModuleError::ParametersNotSetError)?
-        .clone();
+        .ok_or(LensError::ParametersNotSetError)?;
 
-    input.remove(&params.target);
+    for item in iter {
+        let mut input = match item? {
+            Some(v) => v,
+            None => return Ok(StreamOption::None),
+        };
 
-    let result_json = serde_json::to_vec(&input.clone())?;
-    lens_sdk::free_transport_buffer(ptr)?;
-    Ok(Some(result_json))
+        input.remove(&params.target);
+
+        return Ok(StreamOption::Some(input))
+    }
+
+    Ok(StreamOption::EndOfStream)
 }

--- a/tests/lenses/rust_wasm32_set_default/Cargo.toml
+++ b/tests/lenses/rust_wasm32_set_default/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rust-wasm32-set-default"
 version = "0.1.0"
-edition = "2018"
+edition = "2024"
 
 [lib]
 crate-type = ["cdylib"]
@@ -9,4 +9,4 @@ crate-type = ["cdylib"]
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.87"
-lens_sdk = "^0.5"
+lens_sdk = "^0.8"

--- a/tests/lenses/rust_wasm32_set_default/src/lib.rs
+++ b/tests/lenses/rust_wasm32_set_default/src/lib.rs
@@ -1,30 +1,11 @@
 use std::collections::HashMap;
 use std::sync::RwLock;
 use std::error::Error;
-use std::{fmt, error};
 use serde::Deserialize;
 use lens_sdk::StreamOption;
-use lens_sdk::option::StreamOption::{Some, None, EndOfStream};
+use lens_sdk::error::LensError;
 
-#[link(wasm_import_module = "lens")]
-extern "C" {
-    fn next() -> *mut u8;
-}
-
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
-enum ModuleError {
-    ParametersNotSetError,
-}
-
-impl error::Error for ModuleError { }
-
-impl fmt::Display for ModuleError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match &*self {
-            ModuleError::ParametersNotSetError => f.write_str("Parameters have not been set."),
-        }
-    }
-}
+lens_sdk::define!(PARAMETERS: Parameters, try_transform, try_inverse);
 
 #[derive(Deserialize, Clone)]
 pub struct Parameters {
@@ -32,94 +13,46 @@ pub struct Parameters {
     pub value: serde_json::Value,
 }
 
-static PARAMETERS: RwLock<StreamOption<Parameters>> = RwLock::new(None);
+static PARAMETERS: RwLock<Option<Parameters>> = RwLock::new(None);
 
-#[no_mangle]
-pub extern fn alloc(size: usize) -> *mut u8 {
-    lens_sdk::alloc(size)
-}
-
-#[no_mangle]
-pub extern fn set_param(ptr: *mut u8) -> *mut u8 {
-    match try_set_param(ptr) {
-        Ok(_) => lens_sdk::nil_ptr(),
-        Err(e) => lens_sdk::to_mem(lens_sdk::ERROR_TYPE_ID, &e.to_string().as_bytes())
-    }
-}
-
-fn try_set_param(ptr: *mut u8) -> Result<(), Box<dyn Error>> {
-    let parameter = lens_sdk::try_from_mem::<Parameters>(ptr)?
-        .ok_or(ModuleError::ParametersNotSetError)?;
-
-    let mut dst = PARAMETERS.write()?;
-    *dst = Some(parameter);
-    Ok(())
-}
-
-#[no_mangle]
-pub extern fn transform() -> *mut u8 {
-    match try_transform() {
-        Ok(o) => match o {
-            Some(result_json) => lens_sdk::to_mem(lens_sdk::JSON_TYPE_ID, &result_json),
-            None => lens_sdk::nil_ptr(),
-            EndOfStream => lens_sdk::to_mem(lens_sdk::EOS_TYPE_ID, &[]),
-        },
-        Err(e) => lens_sdk::to_mem(lens_sdk::ERROR_TYPE_ID, &e.to_string().as_bytes())
-    }
-}
-
-fn try_transform() -> Result<StreamOption<Vec<u8>>, Box<dyn Error>> {
-    let ptr = unsafe { next() };
-    let mut input = match lens_sdk::try_from_mem::<HashMap<String, serde_json::Value>>(ptr)? {
-        Some(v) => v,
-        // Implementations of `transform` are free to handle nil however they like. In this
-        // implementation we chose to return nil given a nil input.
-        None => return Ok(None),
-        EndOfStream => return Ok(EndOfStream)
-    };
-
+fn try_transform(
+    iter: &mut dyn Iterator<Item = lens_sdk::Result<Option<HashMap<String, serde_json::Value>>>>,
+) -> Result<StreamOption<HashMap<String, serde_json::Value>>, Box<dyn Error>> {
     let params = PARAMETERS.read()?
         .clone()
-        .ok_or(ModuleError::ParametersNotSetError)?
-        .clone();
+        .ok_or(LensError::ParametersNotSetError)?;
 
-    input.insert(params.dst, params.value);
+    for item in iter {
+        let mut input = match item? {
+            Some(v) => v,
+            None => return Ok(StreamOption::None),
+        };
 
-    let result_json = serde_json::to_vec(&input.clone())?;
-    lens_sdk::free_transport_buffer(ptr)?;
-    Ok(Some(result_json))
-}
+        input.insert(params.dst, params.value.clone());
 
-#[no_mangle]
-pub extern fn inverse() -> *mut u8 {
-    match try_inverse() {
-        Ok(o) => match o {
-            Some(result_json) => lens_sdk::to_mem(lens_sdk::JSON_TYPE_ID, &result_json),
-            None => lens_sdk::nil_ptr(),
-            EndOfStream => lens_sdk::to_mem(lens_sdk::EOS_TYPE_ID, &[]),
-        },
-        Err(e) => lens_sdk::to_mem(lens_sdk::ERROR_TYPE_ID, &e.to_string().as_bytes())
+        return Ok(StreamOption::Some(input))
     }
+
+    Ok(StreamOption::EndOfStream)
 }
 
-fn try_inverse() -> Result<StreamOption<Vec<u8>>, Box<dyn Error>> {
-    let ptr = unsafe { next() };
-    let mut input = match lens_sdk::try_from_mem::<HashMap<String, serde_json::Value>>(ptr)? {
-        Some(v) => v,
-        // Implementations of `transform` are free to handle nil however they like. In this
-        // implementation we chose to return nil given a nil input.
-        None => return Ok(None),
-        EndOfStream => return Ok(EndOfStream)
-    };
-
+fn try_inverse(
+    iter: &mut dyn Iterator<Item = lens_sdk::Result<Option<HashMap<String, serde_json::Value>>>>,
+) -> Result<StreamOption<HashMap<String, serde_json::Value>>, Box<dyn Error>> {
     let params = PARAMETERS.read()?
         .clone()
-        .ok_or(ModuleError::ParametersNotSetError)?
-        .clone();
+        .ok_or(LensError::ParametersNotSetError)?;
 
-    input.remove(&params.dst);
+    for item in iter {
+        let mut input = match item? {
+            Some(v) => v,
+            None => return Ok(StreamOption::None),
+        };
 
-    let result_json = serde_json::to_vec(&input.clone())?;
-    lens_sdk::free_transport_buffer(ptr)?;
-    Ok(Some(result_json))
+        input.remove(&params.dst);
+
+        return Ok(StreamOption::Some(input))
+    }
+
+    Ok(StreamOption::EndOfStream)
 }


### PR DESCRIPTION
## Relevant issue(s)

Resolves #3772

## Description

Updates the test Lens modules to the latest Rust SDK.

Is good to try and keep these up to date, as users use them as examples.
