### PR TITLE
fix: Check if collection exists in index cli commands

### DIFF
--- a/cli/index_drop.go
+++ b/cli/index_drop.go
@@ -23,7 +23,7 @@ func MakeIndexDropCommand() *cobra.Command {
 		Long: `Drop a collection's secondary index.
 		
 Example: drop the index 'UsersByName' for 'Users' collection:
-  defradb client index create --collection Users --name UsersByName`,
+  defradb client index drop --collection Users --name UsersByName`,
 		ValidArgs: []string{"collection", "name"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			store := mustGetContextStore(cmd)

--- a/cli/test/action/index_create.go
+++ b/cli/test/action/index_create.go
@@ -1,0 +1,101 @@
+// Copyright 2025 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package action
+
+import (
+	"github.com/sourcenetwork/immutable"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcenetwork/defradb/client"
+)
+
+// IndexCreate executes the `client index create` command and requires that the returned
+// result matches the expected value.
+type IndexCreate struct {
+	stateful
+	augmented
+
+	// The collection name to create the index on (required).
+	Collection string
+
+	// The name of the index (optional).
+	// If not provided, a name will be generated automatically.
+	Name string
+
+	// The fields to index (required).
+	// Format: "fieldName" or "fieldName:ASC" or "fieldName:DESC"
+	Fields []string
+
+	// Whether the index should be unique (optional, default: false).
+	Unique bool
+
+	// The expected index description.
+	// If provided, it will be compared with the actual result.
+	Expected immutable.Option[client.IndexDescription]
+
+	// ExpectError is the expected error string. If empty, no error is expected.
+	ExpectError string
+}
+
+var _ Action = (*IndexCreate)(nil)
+
+func (a *IndexCreate) Execute() {
+	args := []string{"client", "index", "create"}
+
+	if a.Collection != "" {
+		args = append(args, "--collection", a.Collection)
+	}
+
+	if a.Name != "" {
+		args = append(args, "--name", a.Name)
+	}
+
+	if len(a.Fields) > 0 {
+		args = append(args, "--fields")
+		fieldsStr := ""
+		for i, field := range a.Fields {
+			if i > 0 {
+				fieldsStr += ","
+			}
+			fieldsStr += field
+		}
+		args = append(args, fieldsStr)
+	}
+
+	if a.Unique {
+		args = append(args, "--unique")
+	}
+
+	args = append(args, a.AdditionalArgs...)
+	args = a.AppendDirections(args)
+
+	result, err := executeJson[client.IndexDescription](a.s.Ctx, args)
+
+	if a.ExpectError != "" {
+		require.Error(a.s.T, err)
+		require.Contains(a.s.T, err.Error(), a.ExpectError)
+		return
+	}
+
+	require.NoError(a.s.T, err)
+
+	if a.Expected.HasValue() {
+		expected := a.Expected.Value()
+		if expected.ID != 0 {
+			require.Equal(a.s.T, expected.ID, result.ID)
+		}
+		if expected.Name != "" {
+			require.Equal(a.s.T, expected.Name, result.Name)
+		}
+		require.Equal(a.s.T, expected.Fields, result.Fields)
+		require.Equal(a.s.T, expected.Unique, result.Unique)
+	}
+}

--- a/cli/test/action/index_drop.go
+++ b/cli/test/action/index_drop.go
@@ -1,0 +1,57 @@
+// Copyright 2025 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package action
+
+import (
+	"github.com/stretchr/testify/require"
+)
+
+// IndexDrop executes the `client index drop` command.
+type IndexDrop struct {
+	stateful
+	augmented
+
+	// The collection name containing the index (required).
+	Collection string
+
+	// The name of the index to drop (required).
+	Name string
+
+	// ExpectError is the expected error string. If empty, no error is expected.
+	ExpectError string
+}
+
+var _ Action = (*IndexDrop)(nil)
+
+func (a *IndexDrop) Execute() {
+	args := []string{"client", "index", "drop"}
+
+	if a.Collection != "" {
+		args = append(args, "--collection", a.Collection)
+	}
+
+	if a.Name != "" {
+		args = append(args, "--name", a.Name)
+	}
+
+	args = append(args, a.AdditionalArgs...)
+	args = a.AppendDirections(args)
+
+	err := execute(a.s.Ctx, args)
+
+	if a.ExpectError != "" {
+		require.Error(a.s.T, err)
+		require.Contains(a.s.T, err.Error(), a.ExpectError)
+		return
+	}
+
+	require.NoError(a.s.T, err)
+}

--- a/cli/test/action/index_list.go
+++ b/cli/test/action/index_list.go
@@ -1,0 +1,110 @@
+// Copyright 2025 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package action
+
+import (
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcenetwork/defradb/client"
+)
+
+// IndexList executes the `client index list` command and requires that the returned
+// result matches the expected value.
+type IndexList struct {
+	stateful
+	augmented
+
+	// The collection name to list indexes for (optional).
+	// If not provided, all indexes in the database will be listed.
+	Collection string
+
+	// The expected indexes when listing for a specific collection.
+	ExpectedIndexes []client.IndexDescription
+
+	// The expected indexes when listing all indexes (map of collection name to indexes).
+	ExpectedAllIndexes map[client.CollectionName][]client.IndexDescription
+
+	// ExpectError is the expected error string. If empty, no error is expected.
+	ExpectError string
+}
+
+var _ Action = (*IndexList)(nil)
+
+func (a *IndexList) Execute() {
+	args := []string{"client", "index", "list"}
+
+	if a.Collection != "" {
+		args = append(args, "--collection", a.Collection)
+	}
+
+	args = append(args, a.AdditionalArgs...)
+	args = a.AppendDirections(args)
+
+	if a.Collection != "" {
+		// Listing indexes for a specific collection
+		result, err := executeJson[[]client.IndexDescription](a.s.Ctx, args)
+
+		if a.ExpectError != "" {
+			require.Error(a.s.T, err)
+			require.Contains(a.s.T, err.Error(), a.ExpectError)
+			return
+		}
+
+		require.NoError(a.s.T, err)
+
+		if a.ExpectedIndexes != nil {
+			require.Equal(a.s.T, len(a.ExpectedIndexes), len(result))
+
+			for i, expected := range a.ExpectedIndexes {
+				actual := result[i]
+
+				if expected.ID != 0 {
+					require.Equal(a.s.T, expected.ID, actual.ID)
+				}
+				require.Equal(a.s.T, expected.Name, actual.Name)
+				require.Equal(a.s.T, expected.Fields, actual.Fields)
+				require.Equal(a.s.T, expected.Unique, actual.Unique)
+			}
+		}
+	} else {
+		// Listing all indexes
+		result, err := executeJson[map[client.CollectionName][]client.IndexDescription](a.s.Ctx, args)
+
+		if a.ExpectError != "" {
+			require.Error(a.s.T, err)
+			require.Contains(a.s.T, err.Error(), a.ExpectError)
+			return
+		}
+
+		require.NoError(a.s.T, err)
+
+		if a.ExpectedAllIndexes != nil {
+			require.Equal(a.s.T, len(a.ExpectedAllIndexes), len(result))
+
+			for collectionName, expectedIndexes := range a.ExpectedAllIndexes {
+				actualIndexes, ok := result[collectionName]
+				require.True(a.s.T, ok, "Expected collection %s not found in result", collectionName)
+				require.Equal(a.s.T, len(expectedIndexes), len(actualIndexes))
+
+				for i, expected := range expectedIndexes {
+					actual := actualIndexes[i]
+
+					if expected.ID != 0 {
+						require.Equal(a.s.T, expected.ID, actual.ID)
+					}
+					require.Equal(a.s.T, expected.Name, actual.Name)
+					require.Equal(a.s.T, expected.Fields, actual.Fields)
+					require.Equal(a.s.T, expected.Unique, actual.Unique)
+				}
+			}
+		}
+	}
+}

--- a/cli/test/integration/index/create_test.go
+++ b/cli/test/integration/index/create_test.go
@@ -1,0 +1,269 @@
+// Copyright 2025 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package index
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/immutable"
+
+	"github.com/sourcenetwork/defradb/cli/test/action"
+	"github.com/sourcenetwork/defradb/cli/test/integration"
+	"github.com/sourcenetwork/defradb/client"
+)
+
+func TestIndexCreate_WithSingleField_ShouldSucceed(t *testing.T) {
+	test := &integration.Test{
+		Actions: []action.Action{
+			&action.SchemaAdd{
+				InlineSchema: `
+					type User {
+						name: String
+						age: Int
+						email: String
+					}
+				`,
+			},
+			&action.IndexCreate{
+				Collection: "User",
+				Name:       "UsersByName",
+				Fields:     []string{"name"},
+				Expected: immutable.Some(client.IndexDescription{
+					Name: "UsersByName",
+					Fields: []client.IndexedFieldDescription{
+						{Name: "name", Descending: false},
+					},
+					Unique: false,
+				}),
+			},
+		},
+	}
+
+	test.Execute(t)
+}
+
+func TestIndexCreate_WithMultipleFieldsAndOrders_ShouldSucceed(t *testing.T) {
+	test := &integration.Test{
+		Actions: []action.Action{
+			&action.SchemaAdd{
+				InlineSchema: `
+					type User {
+						name: String
+						age: Int
+						email: String
+					}
+				`,
+			},
+			&action.IndexCreate{
+				Collection: "User",
+				Name:       "UsersByNameAndAge",
+				Fields:     []string{"name:ASC", "age:DESC"},
+				Expected: immutable.Some(client.IndexDescription{
+					Name: "UsersByNameAndAge",
+					Fields: []client.IndexedFieldDescription{
+						{Name: "name", Descending: false},
+						{Name: "age", Descending: true},
+					},
+					Unique: false,
+				}),
+			},
+		},
+	}
+
+	test.Execute(t)
+}
+
+func TestIndexCreate_WithUniqueFlag_ShouldCreateUniqueIndex(t *testing.T) {
+	test := &integration.Test{
+		Actions: []action.Action{
+			&action.SchemaAdd{
+				InlineSchema: `
+					type User {
+						name: String
+						age: Int
+						email: String
+					}
+				`,
+			},
+			&action.IndexCreate{
+				Collection: "User",
+				Name:       "UniqueEmail",
+				Fields:     []string{"email"},
+				Unique:     true,
+				Expected: immutable.Some(client.IndexDescription{
+					Name: "UniqueEmail",
+					Fields: []client.IndexedFieldDescription{
+						{Name: "email", Descending: false},
+					},
+					Unique: true,
+				}),
+			},
+		},
+	}
+
+	test.Execute(t)
+}
+
+func TestIndexCreate_WithoutName_ShouldGenerateName(t *testing.T) {
+	test := &integration.Test{
+		Actions: []action.Action{
+			&action.SchemaAdd{
+				InlineSchema: `
+					type User {
+						name: String
+						age: Int
+						email: String
+					}
+				`,
+			},
+			&action.IndexCreate{
+				Collection: "User",
+				Fields:     []string{"age"},
+				Expected: immutable.Some(client.IndexDescription{
+					// Name will be auto-generated, so we don't check it
+					Fields: []client.IndexedFieldDescription{
+						{Name: "age", Descending: false},
+					},
+					Unique: false,
+				}),
+			},
+		},
+	}
+
+	test.Execute(t)
+}
+
+func TestIndexCreate_WithUnknownCollection_ShouldReturnError(t *testing.T) {
+	test := &integration.Test{
+		Actions: []action.Action{
+			&action.IndexCreate{
+				Collection:  "NonExistentCollection",
+				Name:        "TestIndex",
+				Fields:      []string{"field1"},
+				ExpectError: "collection not found",
+			},
+		},
+	}
+
+	test.Execute(t)
+}
+
+func TestIndexCreate_WithoutCollection_ShouldReturnError(t *testing.T) {
+	test := &integration.Test{
+		Actions: []action.Action{
+			&action.IndexCreate{
+				// Collection is empty
+				Name:        "TestIndex",
+				Fields:      []string{"field1"},
+				ExpectError: "error expected",
+			},
+		},
+	}
+
+	test.Execute(t)
+}
+
+func TestIndexCreate_WithoutFields_ShouldReturnError(t *testing.T) {
+	test := &integration.Test{
+		Actions: []action.Action{
+			&action.SchemaAdd{
+				InlineSchema: `
+					type User {
+						name: String
+						age: Int
+					}
+				`,
+			},
+			&action.IndexCreate{
+				Collection: "User",
+				Name:       "EmptyIndex",
+				// Fields is empty
+				ExpectError: "error expected",
+			},
+		},
+	}
+
+	test.Execute(t)
+}
+
+func TestIndexCreate_WithInvalidFieldOrder_ShouldReturnError(t *testing.T) {
+	test := &integration.Test{
+		Actions: []action.Action{
+			&action.SchemaAdd{
+				InlineSchema: `
+					type User {
+						name: String
+						age: Int
+					}
+				`,
+			},
+			&action.IndexCreate{
+				Collection:  "User",
+				Name:        "InvalidOrderIndex",
+				Fields:      []string{"name:INVALID"},
+				ExpectError: "invalid ascension order",
+			},
+		},
+	}
+
+	test.Execute(t)
+}
+
+func TestIndexCreate_WithNonExistentField_ShouldReturnError(t *testing.T) {
+	test := &integration.Test{
+		Actions: []action.Action{
+			&action.SchemaAdd{
+				InlineSchema: `
+					type User {
+						name: String
+						age: Int
+					}
+				`,
+			},
+			&action.IndexCreate{
+				Collection:  "User",
+				Name:        "InvalidFieldIndex",
+				Fields:      []string{"nonexistent"},
+				ExpectError: "field not found",
+			},
+		},
+	}
+
+	test.Execute(t)
+}
+
+func TestIndexCreate_WithDuplicateName_ShouldReturnError(t *testing.T) {
+	test := &integration.Test{
+		Actions: []action.Action{
+			&action.SchemaAdd{
+				InlineSchema: `
+					type User {
+						name: String
+						age: Int
+					}
+				`,
+			},
+			&action.IndexCreate{
+				Collection: "User",
+				Name:       "DuplicateIndex",
+				Fields:     []string{"name"},
+			},
+			&action.IndexCreate{
+				Collection:  "User",
+				Name:        "DuplicateIndex",
+				Fields:      []string{"age"},
+				ExpectError: "already exists",
+			},
+		},
+	}
+
+	test.Execute(t)
+}

--- a/cli/test/integration/index/create_test.go
+++ b/cli/test/integration/index/create_test.go
@@ -163,7 +163,7 @@ func TestIndexCreate_WithoutCollection_ShouldReturnError(t *testing.T) {
 				// Collection is empty
 				Name:        "TestIndex",
 				Fields:      []string{"field1"},
-				ExpectError: "error expected",
+				ExpectError: "collection not found",
 			},
 		},
 	}
@@ -186,7 +186,7 @@ func TestIndexCreate_WithoutFields_ShouldReturnError(t *testing.T) {
 				Collection: "User",
 				Name:       "EmptyIndex",
 				// Fields is empty
-				ExpectError: "error expected",
+				ExpectError: "index missing fields",
 			},
 		},
 	}
@@ -209,7 +209,7 @@ func TestIndexCreate_WithInvalidFieldOrder_ShouldReturnError(t *testing.T) {
 				Collection:  "User",
 				Name:        "InvalidOrderIndex",
 				Fields:      []string{"name:INVALID"},
-				ExpectError: "invalid ascension order",
+				ExpectError: "invalid order: expected ASC or DESC",
 			},
 		},
 	}
@@ -232,7 +232,7 @@ func TestIndexCreate_WithNonExistentField_ShouldReturnError(t *testing.T) {
 				Collection:  "User",
 				Name:        "InvalidFieldIndex",
 				Fields:      []string{"nonexistent"},
-				ExpectError: "field not found",
+				ExpectError: "creating an index on a non-existing property",
 			},
 		},
 	}

--- a/cli/test/integration/index/drop_test.go
+++ b/cli/test/integration/index/drop_test.go
@@ -81,7 +81,7 @@ func TestIndexDrop_WithoutCollection_ShouldReturnError(t *testing.T) {
 			&action.IndexDrop{
 				// Collection is empty
 				Name:        "SomeIndex",
-				ExpectError: "error expected",
+				ExpectError: "collection not found",
 			},
 		},
 	}
@@ -102,7 +102,7 @@ func TestIndexDrop_WithoutName_ShouldReturnError(t *testing.T) {
 			&action.IndexDrop{
 				Collection: "User",
 				// Name is empty
-				ExpectError: "error expected",
+				ExpectError: "malformed document ID",
 			},
 		},
 	}
@@ -124,7 +124,7 @@ func TestIndexDrop_WithNonExistentIndex_ShouldReturnError(t *testing.T) {
 			&action.IndexDrop{
 				Collection:  "User",
 				Name:        "NonExistentIndex",
-				ExpectError: "index not found",
+				ExpectError: "index with name doesn't exists",
 			},
 		},
 	}

--- a/cli/test/integration/index/drop_test.go
+++ b/cli/test/integration/index/drop_test.go
@@ -1,0 +1,220 @@
+// Copyright 2025 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package index
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/defradb/cli/test/action"
+	"github.com/sourcenetwork/defradb/cli/test/integration"
+	"github.com/sourcenetwork/defradb/client"
+)
+
+func TestIndexDrop_WithExistingIndex_ShouldSucceed(t *testing.T) {
+	test := &integration.Test{
+		Actions: []action.Action{
+			&action.SchemaAdd{
+				InlineSchema: `
+					type User {
+						name: String
+						age: Int
+						email: String
+					}
+				`,
+			},
+			&action.IndexCreate{
+				Collection: "User",
+				Name:       "UsersByName",
+				Fields:     []string{"name"},
+			},
+			&action.IndexList{
+				Collection: "User",
+				ExpectedIndexes: []client.IndexDescription{
+					{
+						Name: "UsersByName",
+						Fields: []client.IndexedFieldDescription{
+							{Name: "name", Descending: false},
+						},
+						Unique: false,
+					},
+				},
+			},
+			&action.IndexDrop{
+				Collection: "User",
+				Name:       "UsersByName",
+			},
+			&action.IndexList{
+				Collection:      "User",
+				ExpectedIndexes: []client.IndexDescription{},
+			},
+		},
+	}
+
+	test.Execute(t)
+}
+
+func TestIndexDrop_WithUnknownCollection_ShouldReturnError(t *testing.T) {
+	test := &integration.Test{
+		Actions: []action.Action{
+			&action.IndexDrop{
+				Collection:  "NonExistentCollection",
+				Name:        "SomeIndex",
+				ExpectError: "collection not found",
+			},
+		},
+	}
+
+	test.Execute(t)
+}
+
+func TestIndexDrop_WithoutCollection_ShouldReturnError(t *testing.T) {
+	test := &integration.Test{
+		Actions: []action.Action{
+			&action.IndexDrop{
+				// Collection is empty
+				Name:        "SomeIndex",
+				ExpectError: "error expected",
+			},
+		},
+	}
+
+	test.Execute(t)
+}
+
+func TestIndexDrop_WithoutName_ShouldReturnError(t *testing.T) {
+	test := &integration.Test{
+		Actions: []action.Action{
+			&action.SchemaAdd{
+				InlineSchema: `
+					type User {
+						name: String
+					}
+				`,
+			},
+			&action.IndexDrop{
+				Collection: "User",
+				// Name is empty
+				ExpectError: "error expected",
+			},
+		},
+	}
+
+	test.Execute(t)
+}
+
+func TestIndexDrop_WithNonExistentIndex_ShouldReturnError(t *testing.T) {
+	test := &integration.Test{
+		Actions: []action.Action{
+			&action.SchemaAdd{
+				InlineSchema: `
+					type User {
+						name: String
+						age: Int
+					}
+				`,
+			},
+			&action.IndexDrop{
+				Collection:  "User",
+				Name:        "NonExistentIndex",
+				ExpectError: "index not found",
+			},
+		},
+	}
+
+	test.Execute(t)
+}
+
+func TestIndexDrop_WithMultipleIndexes_ShouldDropOnlySpecified(t *testing.T) {
+	test := &integration.Test{
+		Actions: []action.Action{
+			&action.SchemaAdd{
+				InlineSchema: `
+					type User {
+						name: String
+						age: Int
+						email: String
+					}
+				`,
+			},
+			// Create multiple indexes
+			&action.IndexCreate{
+				Collection: "User",
+				Name:       "UsersByName",
+				Fields:     []string{"name"},
+			},
+			&action.IndexCreate{
+				Collection: "User",
+				Name:       "UsersByAge",
+				Fields:     []string{"age"},
+			},
+			&action.IndexCreate{
+				Collection: "User",
+				Name:       "UsersByEmail",
+				Fields:     []string{"email"},
+				Unique:     true,
+			},
+			// Verify all indexes exist
+			&action.IndexList{
+				Collection: "User",
+				ExpectedIndexes: []client.IndexDescription{
+					{
+						Name: "UsersByName",
+						Fields: []client.IndexedFieldDescription{
+							{Name: "name", Descending: false},
+						},
+						Unique: false,
+					},
+					{
+						Name: "UsersByAge",
+						Fields: []client.IndexedFieldDescription{
+							{Name: "age", Descending: false},
+						},
+						Unique: false,
+					},
+					{
+						Name: "UsersByEmail",
+						Fields: []client.IndexedFieldDescription{
+							{Name: "email", Descending: false},
+						},
+						Unique: true,
+					},
+				},
+			},
+			// Drop one index
+			&action.IndexDrop{
+				Collection: "User",
+				Name:       "UsersByAge",
+			},
+			// Verify only two indexes remain
+			&action.IndexList{
+				Collection: "User",
+				ExpectedIndexes: []client.IndexDescription{
+					{
+						Name: "UsersByName",
+						Fields: []client.IndexedFieldDescription{
+							{Name: "name", Descending: false},
+						},
+						Unique: false,
+					},
+					{
+						Name: "UsersByEmail",
+						Fields: []client.IndexedFieldDescription{
+							{Name: "email", Descending: false},
+						},
+						Unique: true,
+					},
+				},
+			},
+		},
+	}
+
+	test.Execute(t)
+}

--- a/cli/test/integration/index/list_test.go
+++ b/cli/test/integration/index/list_test.go
@@ -1,0 +1,195 @@
+// Copyright 2025 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package index
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/defradb/cli/test/action"
+	"github.com/sourcenetwork/defradb/cli/test/integration"
+	"github.com/sourcenetwork/defradb/client"
+)
+
+func TestIndexList_WithEmptyCollection_ShouldReturnEmptyList(t *testing.T) {
+	test := &integration.Test{
+		Actions: []action.Action{
+			&action.SchemaAdd{
+				InlineSchema: `
+					type User {
+						name: String
+						age: Int
+					}
+				`,
+			},
+			&action.IndexList{
+				Collection:      "User",
+				ExpectedIndexes: []client.IndexDescription{},
+			},
+		},
+	}
+
+	test.Execute(t)
+}
+
+func TestIndexList_WithSingleCollection_ShouldReturnAllCollectionIndexes(t *testing.T) {
+	test := &integration.Test{
+		Actions: []action.Action{
+			&action.SchemaAdd{
+				InlineSchema: `
+					type User {
+						name: String
+						age: Int
+						email: String
+					}
+				`,
+			},
+			&action.IndexCreate{
+				Collection: "User",
+				Name:       "UsersByName",
+				Fields:     []string{"name"},
+			},
+			&action.IndexCreate{
+				Collection: "User",
+				Name:       "UsersByAge",
+				Fields:     []string{"age:DESC"},
+			},
+			&action.IndexList{
+				Collection: "User",
+				ExpectedIndexes: []client.IndexDescription{
+					{
+						Name: "UsersByName",
+						Fields: []client.IndexedFieldDescription{
+							{Name: "name", Descending: false},
+						},
+						Unique: false,
+					},
+					{
+						Name: "UsersByAge",
+						Fields: []client.IndexedFieldDescription{
+							{Name: "age", Descending: true},
+						},
+						Unique: false,
+					},
+				},
+			},
+		},
+	}
+
+	test.Execute(t)
+}
+
+func TestIndexList_WithoutCollectionFlag_ShouldReturnAllIndexes(t *testing.T) {
+	test := &integration.Test{
+		Actions: []action.Action{
+			&action.SchemaAdd{
+				InlineSchema: `
+					type User {
+						name: String
+						age: Int
+					}
+					
+					type Product {
+						title: String
+						price: Float
+					}
+				`,
+			},
+			// Create indexes for User collection
+			&action.IndexCreate{
+				Collection: "User",
+				Name:       "UsersByName",
+				Fields:     []string{"name"},
+			},
+			&action.IndexCreate{
+				Collection: "User",
+				Name:       "UsersByAge",
+				Fields:     []string{"age"},
+			},
+			// Create indexes for Product collection
+			&action.IndexCreate{
+				Collection: "Product",
+				Name:       "ProductsByTitle",
+				Fields:     []string{"title"},
+			},
+			&action.IndexCreate{
+				Collection: "Product",
+				Name:       "ProductsByPrice",
+				Fields:     []string{"price:DESC"},
+				Unique:     true,
+			},
+			// List all indexes
+			&action.IndexList{
+				ExpectedAllIndexes: map[client.CollectionName][]client.IndexDescription{
+					"User": {
+						{
+							Name: "UsersByName",
+							Fields: []client.IndexedFieldDescription{
+								{Name: "name", Descending: false},
+							},
+							Unique: false,
+						},
+						{
+							Name: "UsersByAge",
+							Fields: []client.IndexedFieldDescription{
+								{Name: "age", Descending: false},
+							},
+							Unique: false,
+						},
+					},
+					"Product": {
+						{
+							Name: "ProductsByTitle",
+							Fields: []client.IndexedFieldDescription{
+								{Name: "title", Descending: false},
+							},
+							Unique: false,
+						},
+						{
+							Name: "ProductsByPrice",
+							Fields: []client.IndexedFieldDescription{
+								{Name: "price", Descending: true},
+							},
+							Unique: true,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	test.Execute(t)
+}
+
+func TestIndexList_WithEmptyDatabase_ShouldReturnEmptyMap(t *testing.T) {
+	test := &integration.Test{
+		Actions: []action.Action{
+			// List all indexes when no collections exist
+			&action.IndexList{
+				ExpectedAllIndexes: map[client.CollectionName][]client.IndexDescription{},
+			},
+		},
+	}
+
+	test.Execute(t)
+}
+
+func TestIndexList_WithUnknownCollection_ShouldReturnError(t *testing.T) {
+	test := &integration.Test{
+		Actions: []action.Action{
+			&action.IndexList{
+				Collection:  "NonExistentCollection",
+				ExpectError: "collection not found",
+			},
+		},
+	}
+
+	test.Execute(t)
+}

--- a/docs/website/references/cli/defradb_client_index_drop.md
+++ b/docs/website/references/cli/defradb_client_index_drop.md
@@ -7,7 +7,7 @@ Drop a collection's secondary index
 Drop a collection's secondary index.
 		
 Example: drop the index 'UsersByName' for 'Users' collection:
-  defradb client index create --collection Users --name UsersByName
+  defradb client index drop --collection Users --name UsersByName
 
 ```
 defradb client index drop -c --collection <collection> -n --name <name> [flags]

--- a/docs/website/references/http/openapi.json
+++ b/docs/website/references/http/openapi.json
@@ -1149,6 +1149,39 @@
                 ]
             }
         },
+        "/collections/indexes": {
+            "get": {
+                "description": "List all indexes for all collections",
+                "operationId": "indexes_list_all",
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "additionalProperties": {
+                                        "items": {
+                                            "$ref": "#/components/schemas/index"
+                                        },
+                                        "type": "array"
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Map of collection names to their indexes"
+                    },
+                    "400": {
+                        "$ref": "#/components/responses/error"
+                    },
+                    "default": {
+                        "description": ""
+                    }
+                },
+                "tags": [
+                    "index"
+                ]
+            }
+        },
         "/collections/{name}": {
             "delete": {
                 "description": "Delete document(s) from a collection",

--- a/http/client.go
+++ b/http/client.go
@@ -356,7 +356,7 @@ func (c *Client) GetSchemas(
 }
 
 func (c *Client) GetAllIndexes(ctx context.Context) (map[client.CollectionName][]client.IndexDescription, error) {
-	methodURL := c.http.apiURL.JoinPath("indexes")
+	methodURL := c.http.apiURL.JoinPath("collections", "indexes")
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, methodURL.String(), nil)
 	if err != nil {

--- a/http/client.go
+++ b/http/client.go
@@ -274,6 +274,10 @@ func (c *Client) GetCollectionByName(ctx context.Context, name client.Collection
 		return nil, err
 	}
 
+	if len(cols) == 0 {
+		return nil, NewErrCollectionNotFound(name)
+	}
+
 	// cols will always have length == 1 here
 	return cols[0], nil
 }

--- a/http/errors.go
+++ b/http/errors.go
@@ -24,6 +24,7 @@ const (
 	errFailedToGetContext           string = "failed to get context"
 	errPurgeRequestNonDeveloperMode string = "cannot purge database when development mode is disabled"
 	errMissingRequiredParameter     string = "required parameter %s is missing"
+	errCollectionNotFound           string = "collection not found"
 )
 
 // Errors returnable from this package.
@@ -83,4 +84,11 @@ func NewErrFailedToLoadKeys(inner error, publicKeyPath, privateKeyPath string) e
 // NewErrMissingRequiredParameter creates a new error for a missing required parameter
 func NewErrMissingRequiredParameter(paramName string) error {
 	return errors.New(fmt.Sprintf(errMissingRequiredParameter, paramName))
+}
+
+func NewErrCollectionNotFound(collectionName string) error {
+	return errors.New(
+		errCollectionNotFound,
+		errors.NewKV("CollectionName", collectionName),
+	)
 }

--- a/http/handler_store.go
+++ b/http/handler_store.go
@@ -667,10 +667,33 @@ func (h *storeHandler) bindRoutes(router *Router) {
 	nodeIdentity.AddResponse(200, identityResponse)
 	nodeIdentity.Responses.Set("400", errorResponse)
 
+	indexSchema := &openapi3.SchemaRef{
+		Ref: "#/components/schemas/index",
+	}
+	indexArraySchema := openapi3.NewArraySchema()
+	indexArraySchema.Items = indexSchema
+
+	getAllIndexesMapSchema := openapi3.NewObjectSchema()
+	getAllIndexesMapSchema.AdditionalProperties = openapi3.AdditionalProperties{
+		Schema: openapi3.NewSchemaRef("", indexArraySchema),
+	}
+
+	getAllIndexesResponse := openapi3.NewResponse().
+		WithDescription("Map of collection names to their indexes").
+		WithJSONSchema(getAllIndexesMapSchema)
+
+	getAllIndexes := openapi3.NewOperation()
+	getAllIndexes.OperationID = "indexes_list_all"
+	getAllIndexes.Description = "List all indexes for all collections"
+	getAllIndexes.Tags = []string{"index"}
+	getAllIndexes.AddResponse(200, getAllIndexesResponse)
+	getAllIndexes.Responses.Set("400", errorResponse)
+
 	router.AddRoute("/backup/export", http.MethodPost, backupExport, h.BasicExport)
 	router.AddRoute("/backup/import", http.MethodPost, backupImport, h.BasicImport)
 	router.AddRoute("/collections", http.MethodGet, collectionDescribe, h.GetCollection)
 	router.AddRoute("/collections", http.MethodPatch, patchCollection, h.PatchCollection)
+	router.AddRoute("/collections/indexes", http.MethodGet, getAllIndexes, h.GetAllIndexes)
 	router.AddRoute("/view", http.MethodPost, views, h.AddView)
 	router.AddRoute("/view/refresh", http.MethodPost, viewRefresh, h.RefreshViews)
 	router.AddRoute("/graphql", http.MethodGet, graphQLGet, h.ExecRequest)


### PR DESCRIPTION
## Relevant issue(s)

Resolves #3770

## Description

Make http client check if collection with given name is found when GetCollectionByName called.

Add endpoint for returning all indexes in db.