### PR TITLE
feat: Enable range queries for secondary indexes

### DIFF
--- a/docs/data_format_changes/i3788-sec-index-range-queries.md
+++ b/docs/data_format_changes/i3788-sec-index-range-queries.md
@@ -1,0 +1,3 @@
+# Enable range queries in secondary indexes
+
+This changes fetching behavior of secondary indexes.

--- a/internal/db/fetcher/indexer.go
+++ b/internal/db/fetcher/indexer.go
@@ -162,7 +162,7 @@ func CanBeOrderedByIndex(
 	index client.IndexDescription,
 	mapping *core.DocumentMapping,
 ) (bool, bool) {
-	// if there is not ordering in the query or the query requests ordering on more fields, then index
+	// if there is no ordering in the query or the query requests ordering on more fields, then index
 	// contains, we can't use index
 	if len(ordering) == 0 || len(ordering) > len(index.Fields) {
 		return false, false

--- a/internal/db/fetcher/indexer_iterators.go
+++ b/internal/db/fetcher/indexer_iterators.go
@@ -501,8 +501,12 @@ func (f *indexFetcher) newIndexDataStoreKeyWithValues(values []client.NormalValu
 // incrementKeyBytes increments a key by appending bytes to create the next possible key boundary.
 // This works because keys are compared lexicographically.
 func incrementKeyBytes(key []byte) []byte {
-	// For non-unique indexes, we need to account for the document ID that comes after the value
-	// Append multiple 0xFF bytes to ensure we include all documents with this value
+	// For partial index keys (used in range queries), we need to create a boundary that's
+	// greater than any possible completion of this key, including:
+	// - Additional field values (for composite indexes)
+	// - The document ID that's always appended at the end for non-unique indexes
+	// Append multiple 0xFF bytes to ensure we're beyond any possible extension
+	// The specific number 4 is just a reasonable choice that ensures the boundary works reliably.
 	return append(key, 0xFF, 0xFF, 0xFF, 0xFF)
 }
 

--- a/internal/db/fetcher/indexer_iterators.go
+++ b/internal/db/fetcher/indexer_iterators.go
@@ -687,8 +687,7 @@ func (f *indexFetcher) createIndexIterator() (indexIterator, error) {
 				return nil, err
 			}
 		}
-		// TODO: try to combine range ops with other ops, i.e. to get rid of len(fieldConditions) == 1
-	} else if f.isRangeCompatible(fieldConditions[0]) && len(fieldConditions) == 1 {
+	} else if f.isRangeCompatible(fieldConditions[0]) {
 		iter, err = f.newRangeIterator(fieldConditions[0])
 		if err != nil {
 			return nil, err

--- a/internal/db/fetcher/indexer_iterators.go
+++ b/internal/db/fetcher/indexer_iterators.go
@@ -231,12 +231,11 @@ func (iter *eqSingleIndexIterator) Close() error {
 
 type inIndexIterator struct {
 	indexIterator
-	inValues     []client.NormalValue
-	nextValIndex int
-	ctx          context.Context
-	store        datastore.DSReaderWriter
-	hasIterator  bool
-	// Store iterator creation info to recreate with different values
+	inValues        []client.NormalValue
+	nextValIndex    int
+	ctx             context.Context
+	store           datastore.DSReaderWriter
+	hasIterator     bool
 	fetcher         *indexFetcher
 	fieldConditions []fieldFilterCond
 	matchers        []valueMatcher
@@ -585,7 +584,6 @@ func (f *indexFetcher) createRangeBoundaries(cond fieldFilterCond, descending bo
 
 // isRangeCompatible checks if a filter condition is compatible with range queries.
 func (f *indexFetcher) isRangeCompatible(cond fieldFilterCond) bool {
-
 	switch cond.op {
 	case opGt, opGe, opLt, opLe:
 		switch cond.kind {

--- a/internal/keys/datastore_index.go
+++ b/internal/keys/datastore_index.go
@@ -116,6 +116,10 @@ func DecodeIndexDataStoreKey(
 
 	key := IndexDataStoreKey{CollectionShortID: uint32(colID)}
 
+	if len(data) == 0 {
+		return key, nil
+	}
+
 	if data[0] != '/' {
 		return IndexDataStoreKey{}, ErrInvalidKey
 	}

--- a/internal/keys/datastore_index.go
+++ b/internal/keys/datastore_index.go
@@ -189,3 +189,10 @@ func EncodeIndexDataStoreKey(key *IndexDataStoreKey) []byte {
 
 	return b
 }
+
+// PrefixEnd returns a key that would sort immediately after all keys with this prefix.
+// It returns a key such that all keys with the prefix are >= k and < k.PrefixEnd().
+// This is implemented by encoding the key to bytes and incrementing it.
+func (k IndexDataStoreKey) PrefixEnd() []byte {
+	return bytesPrefixEnd(k.Bytes())
+}

--- a/internal/keys/datastore_index_test.go
+++ b/internal/keys/datastore_index_test.go
@@ -1,0 +1,597 @@
+// Copyright 2025 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package keys
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcenetwork/defradb/client"
+)
+
+func TestIndexDataStoreKey_PrefixEnd(t *testing.T) {
+	tests := []struct {
+		name            string
+		key             IndexDataStoreKey
+		wantGreaterThan bool // Should PrefixEnd be > original key bytes
+	}{
+		{
+			name:            "empty key",
+			key:             IndexDataStoreKey{},
+			wantGreaterThan: false, // Empty key can't be incremented
+		},
+		{
+			name: "collection only",
+			key: IndexDataStoreKey{
+				CollectionShortID: 123,
+			},
+			wantGreaterThan: true,
+		},
+		{
+			name: "collection and index",
+			key: IndexDataStoreKey{
+				CollectionShortID: 123,
+				IndexID:           456,
+			},
+			wantGreaterThan: true,
+		},
+		{
+			name: "with single field",
+			key: IndexDataStoreKey{
+				CollectionShortID: 123,
+				IndexID:           456,
+				Fields: []IndexedField{
+					{Value: client.NewNormalInt(42), Descending: false},
+				},
+			},
+			wantGreaterThan: true,
+		},
+		{
+			name: "with multiple fields",
+			key: IndexDataStoreKey{
+				CollectionShortID: 123,
+				IndexID:           456,
+				Fields: []IndexedField{
+					{Value: client.NewNormalString("hello"), Descending: false},
+					{Value: client.NewNormalInt(42), Descending: false},
+				},
+			},
+			wantGreaterThan: true,
+		},
+		{
+			name: "with descending field",
+			key: IndexDataStoreKey{
+				CollectionShortID: 123,
+				IndexID:           456,
+				Fields: []IndexedField{
+					{Value: client.NewNormalInt(42), Descending: true},
+				},
+			},
+			wantGreaterThan: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			keyBytes := tt.key.Bytes()
+			endBytes := tt.key.PrefixEnd()
+
+			if tt.wantGreaterThan {
+				assert.True(t, string(endBytes) > string(keyBytes),
+					"PrefixEnd should be greater than original key")
+			} else {
+				assert.Equal(t, keyBytes, endBytes,
+					"PrefixEnd should equal original for empty key")
+			}
+		})
+	}
+}
+
+func TestIndexDataStoreKey_PrefixEnd_Ordering(t *testing.T) {
+	tests := []struct {
+		name        string
+		prefixKey   IndexDataStoreKey
+		testKeys    []IndexDataStoreKey
+		shouldMatch []bool // which test keys should be included
+	}{
+		{
+			name: "single field prefix",
+			prefixKey: IndexDataStoreKey{
+				CollectionShortID: 1,
+				IndexID:           2,
+				Fields: []IndexedField{
+					{Value: client.NewNormalInt(25), Descending: false},
+				},
+			},
+			testKeys: []IndexDataStoreKey{
+				{
+					CollectionShortID: 1,
+					IndexID:           2,
+					Fields: []IndexedField{
+						{Value: client.NewNormalInt(25), Descending: false},
+						{Value: client.NewNormalString("Alice"), Descending: false},
+					},
+				},
+				{
+					CollectionShortID: 1,
+					IndexID:           2,
+					Fields: []IndexedField{
+						{Value: client.NewNormalInt(25), Descending: false},
+						{Value: client.NewNormalString("Bob"), Descending: false},
+					},
+				},
+				{
+					CollectionShortID: 1,
+					IndexID:           2,
+					Fields: []IndexedField{
+						{Value: client.NewNormalInt(26), Descending: false},
+					},
+				},
+			},
+			shouldMatch: []bool{true, true, false},
+		},
+		{
+			name: "collection prefix",
+			prefixKey: IndexDataStoreKey{
+				CollectionShortID: 10,
+			},
+			testKeys: []IndexDataStoreKey{
+				{
+					CollectionShortID: 10,
+					IndexID:           1,
+				},
+				{
+					CollectionShortID: 10,
+					IndexID:           2,
+				},
+				{
+					CollectionShortID: 11,
+					IndexID:           1,
+				},
+			},
+			shouldMatch: []bool{true, true, false},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			prefixBytes := tt.prefixKey.Bytes()
+			endBytes := tt.prefixKey.PrefixEnd()
+
+			for i, testKey := range tt.testKeys {
+				testBytes := testKey.Bytes()
+
+				// Check if test key is >= prefix and < end
+				afterPrefix := string(testBytes) >= string(prefixBytes)
+				beforeEnd := string(testBytes) < string(endBytes)
+				inRange := afterPrefix && beforeEnd
+
+				assert.Equal(t, tt.shouldMatch[i], inRange,
+					"Key %d: expected %v but got %v for key %v",
+					i, tt.shouldMatch[i], inRange, testKey)
+			}
+		})
+	}
+}
+
+func TestNewIndexDataStoreKey(t *testing.T) {
+	fields := []IndexedField{
+		{Value: client.NewNormalString("test"), Descending: false},
+		{Value: client.NewNormalInt(42), Descending: true},
+	}
+
+	key := NewIndexDataStoreKey(123, 456, fields)
+
+	assert.Equal(t, uint32(123), key.CollectionShortID)
+	assert.Equal(t, uint32(456), key.IndexID)
+	assert.Equal(t, 2, len(key.Fields))
+	assert.True(t, key.Fields[0].Value.Equal(client.NewNormalString("test")))
+	assert.False(t, key.Fields[0].Descending)
+	assert.True(t, key.Fields[1].Value.Equal(client.NewNormalInt(42)))
+	assert.True(t, key.Fields[1].Descending)
+}
+
+func TestIndexDataStoreKey_Bytes(t *testing.T) {
+	tests := []struct {
+		name string
+		key  IndexDataStoreKey
+		want string
+	}{
+		{
+			name: "empty key",
+			key:  IndexDataStoreKey{},
+			want: "",
+		},
+		{
+			name: "collection only",
+			key: IndexDataStoreKey{
+				CollectionShortID: 123,
+			},
+		},
+		{
+			name: "collection and index",
+			key: IndexDataStoreKey{
+				CollectionShortID: 123,
+				IndexID:           456,
+			},
+		},
+		{
+			name: "with fields",
+			key: IndexDataStoreKey{
+				CollectionShortID: 123,
+				IndexID:           456,
+				Fields: []IndexedField{
+					{Value: client.NewNormalString("test"), Descending: false},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bytes1 := tt.key.Bytes()
+			bytes2 := tt.key.Bytes()
+
+			assert.Equal(t, bytes1, bytes2, "Bytes() should return consistent results")
+
+			if tt.name == "empty key" {
+				assert.Empty(t, bytes1)
+			} else {
+				assert.NotEmpty(t, bytes1)
+			}
+		})
+	}
+}
+
+func TestIndexDataStoreKey_ToDS(t *testing.T) {
+	key := IndexDataStoreKey{
+		CollectionShortID: 123,
+		IndexID:           456,
+		Fields: []IndexedField{
+			{Value: client.NewNormalString("test"), Descending: false},
+		},
+	}
+
+	dsKey := key.ToDS()
+	assert.NotNil(t, dsKey)
+
+	assert.Equal(t, key.ToString(), dsKey.String())
+}
+
+func TestIndexDataStoreKey_ToString(t *testing.T) {
+	tests := []struct {
+		name string
+		key  IndexDataStoreKey
+	}{
+		{
+			name: "empty key",
+			key:  IndexDataStoreKey{},
+		},
+		{
+			name: "with collection",
+			key: IndexDataStoreKey{
+				CollectionShortID: 123,
+			},
+		},
+		{
+			name: "with collection and index",
+			key: IndexDataStoreKey{
+				CollectionShortID: 123,
+				IndexID:           456,
+			},
+		},
+		{
+			name: "with fields",
+			key: IndexDataStoreKey{
+				CollectionShortID: 123,
+				IndexID:           456,
+				Fields: []IndexedField{
+					{Value: client.NewNormalString("test"), Descending: false},
+					{Value: client.NewNormalInt(42), Descending: false},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			str := tt.key.ToString()
+
+			assert.Equal(t, string(tt.key.Bytes()), str)
+
+			if tt.key.CollectionShortID != 0 {
+				assert.True(t, len(str) > 0 && str[0] == '/')
+			}
+		})
+	}
+}
+
+func TestIndexDataStoreKey_Equal(t *testing.T) {
+	tests := []struct {
+		name  string
+		key1  IndexDataStoreKey
+		key2  IndexDataStoreKey
+		equal bool
+	}{
+		{
+			name:  "empty keys",
+			key1:  IndexDataStoreKey{},
+			key2:  IndexDataStoreKey{},
+			equal: true,
+		},
+		{
+			name: "same keys",
+			key1: IndexDataStoreKey{
+				CollectionShortID: 123,
+				IndexID:           456,
+				Fields: []IndexedField{
+					{Value: client.NewNormalString("test"), Descending: false},
+				},
+			},
+			key2: IndexDataStoreKey{
+				CollectionShortID: 123,
+				IndexID:           456,
+				Fields: []IndexedField{
+					{Value: client.NewNormalString("test"), Descending: false},
+				},
+			},
+			equal: true,
+		},
+		{
+			name:  "different collection",
+			key1:  IndexDataStoreKey{CollectionShortID: 123},
+			key2:  IndexDataStoreKey{CollectionShortID: 124},
+			equal: false,
+		},
+		{
+			name:  "different index",
+			key1:  IndexDataStoreKey{CollectionShortID: 123, IndexID: 456},
+			key2:  IndexDataStoreKey{CollectionShortID: 123, IndexID: 457},
+			equal: false,
+		},
+		{
+			name: "different field count",
+			key1: IndexDataStoreKey{
+				CollectionShortID: 123,
+				IndexID:           456,
+				Fields: []IndexedField{
+					{Value: client.NewNormalString("test"), Descending: false},
+				},
+			},
+			key2: IndexDataStoreKey{
+				CollectionShortID: 123,
+				IndexID:           456,
+				Fields: []IndexedField{
+					{Value: client.NewNormalString("test"), Descending: false},
+					{Value: client.NewNormalInt(42), Descending: false},
+				},
+			},
+			equal: false,
+		},
+		{
+			name: "different field value",
+			key1: IndexDataStoreKey{
+				CollectionShortID: 123,
+				IndexID:           456,
+				Fields: []IndexedField{
+					{Value: client.NewNormalString("test1"), Descending: false},
+				},
+			},
+			key2: IndexDataStoreKey{
+				CollectionShortID: 123,
+				IndexID:           456,
+				Fields: []IndexedField{
+					{Value: client.NewNormalString("test2"), Descending: false},
+				},
+			},
+			equal: false,
+		},
+		{
+			name: "different field descending",
+			key1: IndexDataStoreKey{
+				CollectionShortID: 123,
+				IndexID:           456,
+				Fields: []IndexedField{
+					{Value: client.NewNormalString("test"), Descending: false},
+				},
+			},
+			key2: IndexDataStoreKey{
+				CollectionShortID: 123,
+				IndexID:           456,
+				Fields: []IndexedField{
+					{Value: client.NewNormalString("test"), Descending: true},
+				},
+			},
+			equal: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.key1.Equal(tt.key2)
+			assert.Equal(t, tt.equal, result)
+
+			// Equal should be symmetric
+			assert.Equal(t, tt.equal, tt.key2.Equal(tt.key1))
+		})
+	}
+}
+
+func TestIndexDataStoreKey_EncodeDecode(t *testing.T) {
+	indexDesc := &client.IndexDescription{
+		Fields: []client.IndexedFieldDescription{
+			{Descending: false},
+			{Descending: true},
+		},
+	}
+
+	fieldDefs := []client.FieldDefinition{
+		{Kind: client.FieldKind_NILLABLE_STRING},
+		{Kind: client.FieldKind_NILLABLE_INT},
+	}
+
+	tests := []struct {
+		name      string
+		key       IndexDataStoreKey
+		wantError bool
+	}{
+		{
+			name: "empty key encoding",
+			key:  IndexDataStoreKey{},
+		},
+		{
+			name: "collection only",
+			key: IndexDataStoreKey{
+				CollectionShortID: 123,
+			},
+		},
+		{
+			name: "collection and index",
+			key: IndexDataStoreKey{
+				CollectionShortID: 123,
+				IndexID:           456,
+			},
+		},
+		{
+			name: "with single field",
+			key: IndexDataStoreKey{
+				CollectionShortID: 123,
+				IndexID:           456,
+				Fields: []IndexedField{
+					{Value: client.NewNormalString("test"), Descending: false},
+				},
+			},
+		},
+		{
+			name: "with multiple fields",
+			key: IndexDataStoreKey{
+				CollectionShortID: 123,
+				IndexID:           456,
+				Fields: []IndexedField{
+					{Value: client.NewNormalString("test"), Descending: false},
+					{Value: client.NewNormalInt(42), Descending: true},
+				},
+			},
+		},
+		{
+			name: "with nil value",
+			key: IndexDataStoreKey{
+				CollectionShortID: 123,
+				IndexID:           456,
+				Fields: []IndexedField{
+					{Value: func() client.NormalValue {
+						v, _ := client.NewNormalNil(client.FieldKind_NILLABLE_STRING)
+						return v
+					}(), Descending: false},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			encoded := EncodeIndexDataStoreKey(&tt.key)
+
+			if tt.key.CollectionShortID == 0 {
+				assert.Empty(t, encoded)
+				return
+			}
+
+			decoded, err := DecodeIndexDataStoreKey(encoded, indexDesc, fieldDefs)
+
+			if tt.wantError {
+				assert.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.key.CollectionShortID, decoded.CollectionShortID)
+			assert.Equal(t, tt.key.IndexID, decoded.IndexID)
+			assert.Equal(t, len(tt.key.Fields), len(decoded.Fields))
+
+			for i := range tt.key.Fields {
+				assert.True(t, tt.key.Fields[i].Value.Equal(decoded.Fields[i].Value),
+					"Field %d value mismatch", i)
+				assert.Equal(t, tt.key.Fields[i].Descending, decoded.Fields[i].Descending,
+					"Field %d descending mismatch", i)
+			}
+		})
+	}
+}
+
+func TestIndexDataStoreKey_Decode(t *testing.T) {
+	indexDesc := &client.IndexDescription{
+		Fields: []client.IndexedFieldDescription{
+			{Descending: false},
+		},
+	}
+
+	fieldDefs := []client.FieldDefinition{
+		{Kind: client.FieldKind_NILLABLE_STRING},
+	}
+
+	tests := []struct {
+		name    string
+		data    []byte
+		wantErr error
+	}{
+		{
+			name:    "empty data",
+			data:    []byte{},
+			wantErr: ErrEmptyKey,
+		},
+		{
+			name:    "invalid start",
+			data:    []byte("invalid"),
+			wantErr: ErrInvalidKey,
+		},
+		{
+			name:    "missing separator",
+			data:    []byte("/123"),
+			wantErr: ErrInvalidKey,
+		},
+		{
+			name: "valid with doc ID field",
+			data: EncodeIndexDataStoreKey(&IndexDataStoreKey{
+				CollectionShortID: 123,
+				IndexID:           456,
+				Fields: []IndexedField{
+					{Value: client.NewNormalString("test"), Descending: false},
+					{Value: client.NewNormalString("docID"), Descending: false},
+				},
+			}),
+			wantErr: nil, // This is valid - second field is treated as doc ID
+		},
+		{
+			name: "too many fields",
+			data: EncodeIndexDataStoreKey(&IndexDataStoreKey{
+				CollectionShortID: 123,
+				IndexID:           456,
+				Fields: []IndexedField{
+					{Value: client.NewNormalString("test"), Descending: false},
+					{Value: client.NewNormalString("docID"), Descending: false},
+					{Value: client.NewNormalString("extra"), Descending: false},
+				},
+			}),
+			wantErr: ErrInvalidKey,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := DecodeIndexDataStoreKey(tt.data, indexDesc, fieldDefs)
+			assert.ErrorIs(t, err, tt.wantErr)
+		})
+	}
+}

--- a/tests/integration/explain_result_asserter.go
+++ b/tests/integration/explain_result_asserter.go
@@ -134,37 +134,37 @@ func (a *ExplainResultAsserter) Assert(t testing.TB, result map[string]any) {
 }
 
 func (a *ExplainResultAsserter) WithIterations(iterations int) *ExplainResultAsserter {
-	a.iterations = immutable.Some[int](iterations)
+	a.iterations = immutable.Some(iterations)
 	return a
 }
 
 func (a *ExplainResultAsserter) WithDocFetches(docFetches int) *ExplainResultAsserter {
-	a.docFetches = immutable.Some[int](docFetches)
+	a.docFetches = immutable.Some(docFetches)
 	return a
 }
 
 func (a *ExplainResultAsserter) WithFieldFetches(fieldFetches int) *ExplainResultAsserter {
-	a.fieldFetches = immutable.Some[int](fieldFetches)
+	a.fieldFetches = immutable.Some(fieldFetches)
 	return a
 }
 
 func (a *ExplainResultAsserter) WithIndexFetches(indexFetches int) *ExplainResultAsserter {
-	a.indexFetches = immutable.Some[int](indexFetches)
+	a.indexFetches = immutable.Some(indexFetches)
 	return a
 }
 
 func (a *ExplainResultAsserter) WithFilterMatches(filterMatches int) *ExplainResultAsserter {
-	a.filterMatches = immutable.Some[int](filterMatches)
+	a.filterMatches = immutable.Some(filterMatches)
 	return a
 }
 
 func (a *ExplainResultAsserter) WithSizeOfResults(sizeOfResults int) *ExplainResultAsserter {
-	a.sizeOfResults = immutable.Some[int](sizeOfResults)
+	a.sizeOfResults = immutable.Some(sizeOfResults)
 	return a
 }
 
 func (a *ExplainResultAsserter) WithPlanExecutions(planExecutions uint64) *ExplainResultAsserter {
-	a.planExecutions = immutable.Some[uint64](planExecutions)
+	a.planExecutions = immutable.Some(planExecutions)
 	return a
 }
 

--- a/tests/integration/index/array_test.go
+++ b/tests/integration/index/array_test.go
@@ -114,7 +114,7 @@ func TestArrayIndex_WithFilterOnIndexedArrayUsingAll_ShouldUseIndex(t *testing.T
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(9),
+				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(5),
 			},
 		},
 	}

--- a/tests/integration/index/docs.go
+++ b/tests/integration/index/docs.go
@@ -10,10 +10,18 @@
 
 package index
 
-import "github.com/sourcenetwork/defradb/tests/predefined"
+import (
+	"strings"
+
+	"github.com/sourcenetwork/defradb/tests/predefined"
+)
 
 func makeExplainQuery(req string) string {
-	return "query @explain(type: execute) " + req[6:]
+	ind := strings.Index(req, "query")
+	if ind < 0 {
+		panic("Invalid query: " + req)
+	}
+	return "query @explain(type: execute) " + req[ind+5:]
 }
 
 func getUserDocs() predefined.DocsList {

--- a/tests/integration/index/json_array_test.go
+++ b/tests/integration/index/json_array_test.go
@@ -235,7 +235,7 @@ func TestJSONArrayIndex_WithAnyAndComparisonFilter_ShouldNotConsiderThem(t *test
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(5),
+				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(2),
 			},
 		},
 	}
@@ -542,7 +542,7 @@ func TestJSONArrayIndex_WithAllEqAndComparisonFilter_ShouldFetchCorrectlyUsingIn
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(5),
+				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(4),
 			},
 		},
 	}

--- a/tests/integration/index/json_composite_test.go
+++ b/tests/integration/index/json_composite_test.go
@@ -233,7 +233,7 @@ func TestJSONCompositeIndex_JSONWithScalarWithOtherFilters_ShouldFetchUsingIndex
 					{"name": "Addo"},
 				},
 			},
-			indexFetches: 8,
+			indexFetches: 6,
 		},
 		{
 			name: "With _lt and _eq filters",

--- a/tests/integration/index/json_test.go
+++ b/tests/integration/index/json_test.go
@@ -147,7 +147,7 @@ func TestJSONIndex_WithGtFilterOnNumberField_ShouldUseIndex(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(5),
+				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(2),
 			},
 		},
 	}
@@ -217,7 +217,7 @@ func TestJSONIndex_WithGeFilterOnNumberField_ShouldUseIndex(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(5),
+				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(3),
 			},
 		},
 	}
@@ -286,7 +286,7 @@ func TestJSONIndex_WithLtFilterOnNumberField_ShouldUseIndex(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(5),
+				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(2),
 			},
 		},
 	}
@@ -356,7 +356,7 @@ func TestJSONIndex_WithLeFilterOnNumberField_ShouldUseIndex(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(5),
+				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(3),
 			},
 		},
 	}

--- a/tests/integration/index/order_query_test.go
+++ b/tests/integration/index/order_query_test.go
@@ -319,7 +319,7 @@ func TestOrderQueryWithIndex_WithFilterOnIndexedFieldAscending_ShouldUseIndex(t 
 			testUtils.Request{
 				Request: makeExplainQuery(req),
 				// we fetch docs starting from the lowest age and skip the first one
-				Asserter: testUtils.NewExplainAsserter().WithLimit().WithIndexFetches(4),
+				Asserter: testUtils.NewExplainAsserter().WithLimit().WithIndexFetches(3),
 			},
 		},
 	}
@@ -368,7 +368,7 @@ func TestOrderQueryWithIndex_WithFilterOnIndexedFieldDescending_ShouldUseIndex(t
 			testUtils.Request{
 				Request: makeExplainQuery(req),
 				// we fetch docs starting from the highest age, skipping the first 2
-				Asserter: testUtils.NewExplainAsserter().WithLimit().WithIndexFetches(5),
+				Asserter: testUtils.NewExplainAsserter().WithLimit().WithIndexFetches(3),
 			},
 		},
 	}

--- a/tests/integration/index/query_with_composite_index_field_order_test.go
+++ b/tests/integration/index/query_with_composite_index_field_order_test.go
@@ -878,7 +878,7 @@ func TestQueryWithCompositeIndex_WithRangeQueryOnFirstField_ShouldUseRangeOptimi
 	testUtils.ExecuteTestCase(t, test)
 }
 
-func TestQueryWithCompositeIndex_WithRangeQueryOnFirstFieldWithMultipleFilters_ShouldUseMatchers(t *testing.T) {
+func TestQueryWithCompositeIndex_WithRangeQueryOnFirstFieldWithMultipleFilters_ShouldUseRangeOptimization(t *testing.T) {
 	req := `
 		query {
 			User(filter: {age: {_gt: 25}, name: {_eq: "Bob"}}) {

--- a/tests/integration/index/query_with_composite_index_field_order_test.go
+++ b/tests/integration/index/query_with_composite_index_field_order_test.go
@@ -955,7 +955,7 @@ func TestQueryWithCompositeIndex_WithRangeQueryOnFirstFieldWithMultipleFilters_S
 				},
 			},
 			testUtils.Request{
-				Request:  makeExplainQuery(req),
+				Request: makeExplainQuery(req),
 				// Should fetch all entries with age > 25, then filter by name
 				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(4),
 			},

--- a/tests/integration/index/query_with_composite_index_only_filter_test.go
+++ b/tests/integration/index/query_with_composite_index_only_filter_test.go
@@ -115,7 +115,7 @@ func TestQueryWithCompositeIndex_WithGreaterThanFilterOnFirstField_ShouldFetch(t
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(2),
 			},
 		},
 	}
@@ -192,7 +192,7 @@ func TestQueryWithCompositeIndex_WithGreaterOrEqualFilterOnFirstField_ShouldFetc
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(3),
 			},
 		},
 	}
@@ -269,7 +269,7 @@ func TestQueryWithCompositeIndex_WithLessThanFilterOnFirstField_ShouldFetch(t *t
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(2),
 			},
 		},
 	}
@@ -346,7 +346,7 @@ func TestQueryWithCompositeIndex_WithLessOrEqualFilterOnFirstField_ShouldFetch(t
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(3),
 			},
 		},
 	}

--- a/tests/integration/index/query_with_index_combined_filter_test.go
+++ b/tests/integration/index/query_with_index_combined_filter_test.go
@@ -90,7 +90,7 @@ func TestQueryWithIndex_IfMultipleIndexFiltersWithRegular_ShouldFilter(t *testin
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(6),
 			},
 		},
 	}
@@ -132,7 +132,7 @@ func TestQueryWithIndex_IfMultipleIndexFiltersWithRegularCaseInsensitive_ShouldF
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(6),
 			},
 		},
 	}

--- a/tests/integration/index/query_with_index_on_datetime_test.go
+++ b/tests/integration/index/query_with_index_on_datetime_test.go
@@ -62,6 +62,12 @@ func TestQueryWithIndex_WithEqFilterOnDateTimeField_ShouldIndex(t *testing.T) {
 }
 
 func TestQueryWithIndex_WithGtFilterOnDateTimeField_ShouldIndex(t *testing.T) {
+	req := `query {
+		User(filter: {birthday: {_gt: "2001-08-23T03:00:00-00:00"}}) {
+			name
+		}
+	}`
+
 	test := testUtils.TestCase{
 		Actions: []any{
 			testUtils.SchemaUpdate{
@@ -73,8 +79,14 @@ func TestQueryWithIndex_WithGtFilterOnDateTimeField_ShouldIndex(t *testing.T) {
 			},
 			testUtils.CreateDoc{
 				Doc: `{
+						"name":	"Shahzad",
+						"birthday": "2001-08-24T03:00:00-00:00"
+					}`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
 						"name":	"Fred",
-						"birthday": "2000-07-23T03:00:00-00:00"
+						"birthday": "2000-08-22T03:00:00-00:00"
 					}`,
 			},
 			testUtils.CreateDoc{
@@ -83,17 +95,24 @@ func TestQueryWithIndex_WithGtFilterOnDateTimeField_ShouldIndex(t *testing.T) {
 						"birthday": "2001-08-23T03:00:00-00:00"
 					}`,
 			},
+			testUtils.CreateDoc{
+				Doc: `{
+						"name":	"John",
+						"birthday": "2001-08-25T03:00:00-00:00"
+					}`,
+			},
 			testUtils.Request{
-				Request: `query {
-					User(filter: {birthday: {_gt: "2001-01-01T00:00:00-00:00"}}) {
-						name
-					}
-				}`,
+				Request: req,
 				Results: map[string]any{
 					"User": []map[string]any{
-						{"name": "Andy"},
+						{"name": "Shahzad"},
+						{"name": "John"},
 					},
 				},
+			},
+			testUtils.Request{
+				Request:  makeExplainQuery(req),
+				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(2),
 			},
 		},
 	}
@@ -102,6 +121,12 @@ func TestQueryWithIndex_WithGtFilterOnDateTimeField_ShouldIndex(t *testing.T) {
 }
 
 func TestQueryWithIndex_WithGeFilterOnDateTimeField_ShouldIndex(t *testing.T) {
+	req := `query {
+		User(filter: {birthday: {_ge: "2001-01-01T00:00:00-00:00"}}) {
+			name
+		}
+	}`
+
 	test := testUtils.TestCase{
 		Actions: []any{
 			testUtils.SchemaUpdate{
@@ -130,17 +155,17 @@ func TestQueryWithIndex_WithGeFilterOnDateTimeField_ShouldIndex(t *testing.T) {
 					}`,
 			},
 			testUtils.Request{
-				Request: `query {
-					User(filter: {birthday: {_ge: "2001-01-01T00:00:00-00:00"}}) {
-						name
-					}
-				}`,
+				Request: req,
 				Results: map[string]any{
 					"User": []map[string]any{
 						{"name": "Keenan"},
 						{"name": "Andy"},
 					},
 				},
+			},
+			testUtils.Request{
+				Request:  makeExplainQuery(req),
+				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(2),
 			},
 		},
 	}
@@ -149,6 +174,12 @@ func TestQueryWithIndex_WithGeFilterOnDateTimeField_ShouldIndex(t *testing.T) {
 }
 
 func TestQueryWithIndex_WithLtFilterOnDateTimeField_ShouldIndex(t *testing.T) {
+	req := `query {
+		User(filter: {birthday: {_lt: "2001-01-01T00:00:00-00:00"}}) {
+			name
+		}
+	}`
+
 	test := testUtils.TestCase{
 		Actions: []any{
 			testUtils.SchemaUpdate{
@@ -171,16 +202,16 @@ func TestQueryWithIndex_WithLtFilterOnDateTimeField_ShouldIndex(t *testing.T) {
 					}`,
 			},
 			testUtils.Request{
-				Request: `query {
-					User(filter: {birthday: {_lt: "2001-01-01T00:00:00-00:00"}}) {
-						name
-					}
-				}`,
+				Request: req,
 				Results: map[string]any{
 					"User": []map[string]any{
 						{"name": "Fred"},
 					},
 				},
+			},
+			testUtils.Request{
+				Request:  makeExplainQuery(req),
+				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(1),
 			},
 		},
 	}
@@ -189,6 +220,12 @@ func TestQueryWithIndex_WithLtFilterOnDateTimeField_ShouldIndex(t *testing.T) {
 }
 
 func TestQueryWithIndex_WithLeFilterOnDateTimeField_ShouldIndex(t *testing.T) {
+	req := `query {
+		User(filter: {birthday: {_le: "2001-01-01T00:00:00-00:00"}}) {
+			name
+		}
+	}`
+
 	test := testUtils.TestCase{
 		Actions: []any{
 			testUtils.SchemaUpdate{
@@ -217,17 +254,17 @@ func TestQueryWithIndex_WithLeFilterOnDateTimeField_ShouldIndex(t *testing.T) {
 					}`,
 			},
 			testUtils.Request{
-				Request: `query {
-					User(filter: {birthday: {_le: "2001-01-01T00:00:00-00:00"}}) {
-						name
-					}
-				}`,
+				Request: req,
 				Results: map[string]any{
 					"User": []map[string]any{
 						{"name": "Fred"},
 						{"name": "Keenan"},
 					},
 				},
+			},
+			testUtils.Request{
+				Request:  makeExplainQuery(req),
+				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(2),
 			},
 		},
 	}

--- a/tests/integration/index/query_with_index_only_field_order_test.go
+++ b/tests/integration/index/query_with_index_only_field_order_test.go
@@ -16,9 +16,17 @@ import (
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
 )
 
-func TestQueryWithIndex_IfIntFieldInDescOrder_ShouldFetchInRevertedOrder(t *testing.T) {
+func TestQueryWithIndex_IfIntFieldInDescOrderWithGt_ShouldFetchInRevertedOrder(t *testing.T) {
+	req := `
+		query {
+			User(filter: {age: {_gt: 20}}) {
+				name
+				age
+			}
+		}`
+
 	test := testUtils.TestCase{
-		Description: "If indexed int field is in DESC order, it should be fetched in reverted order",
+		Description: "If indexed int field is in DESC order with _gt, it should be fetched in reverted order",
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
@@ -37,6 +45,20 @@ func TestQueryWithIndex_IfIntFieldInDescOrder_ShouldFetchInRevertedOrder(t *test
 			testUtils.CreateDoc{
 				Doc: `
 					{
+						"name":	"John",
+						"age":	20
+					}`,
+			},
+			testUtils.CreateDoc{
+				Doc: `
+					{
+						"name":	"Fred",
+						"age":	18
+					}`,
+			},
+			testUtils.CreateDoc{
+				Doc: `
+					{
 						"name":	"Bob",
 						"age":	24
 					}`,
@@ -49,13 +71,7 @@ func TestQueryWithIndex_IfIntFieldInDescOrder_ShouldFetchInRevertedOrder(t *test
 					}`,
 			},
 			testUtils.Request{
-				Request: `
-					query {
-						User(filter: {age: {_gt: 1}}) {
-							name
-							age
-						}
-					}`,
+				Request: req,
 				Results: map[string]any{
 					"User": []map[string]any{
 						{
@@ -73,15 +89,272 @@ func TestQueryWithIndex_IfIntFieldInDescOrder_ShouldFetchInRevertedOrder(t *test
 					},
 				},
 			},
+			testUtils.Request{
+				Request:  makeExplainQuery(req),
+				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(3),
+			},
 		},
 	}
 
 	testUtils.ExecuteTestCase(t, test)
 }
 
-func TestQueryWithIndex_IfFloatFieldInDescOrder_ShouldFetchInRevertedOrder(t *testing.T) {
+func TestQueryWithIndex_IfIntFieldInDescOrderWithGe_ShouldFetchInRevertedOrder(t *testing.T) {
+	req := `
+		query {
+			User(filter: {age: {_ge: 22}}) {
+				name
+				age
+			}
+		}`
+
 	test := testUtils.TestCase{
-		Description: "If indexed float field is in DESC order, it should be fetched in reverted order",
+		Description: "If indexed int field is in DESC order with _ge, it should be fetched in reverted order",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type User {
+						name: String
+						age: Int @index(direction: DESC)
+					}`,
+			},
+			testUtils.CreateDoc{
+				Doc: `
+					{
+						"name":	"Alice",
+						"age":	22
+					}`,
+			},
+			testUtils.CreateDoc{
+				Doc: `
+					{
+						"name":	"John",
+						"age":	20
+					}`,
+			},
+			testUtils.CreateDoc{
+				Doc: `
+					{
+						"name":	"Fred",
+						"age":	18
+					}`,
+			},
+			testUtils.CreateDoc{
+				Doc: `
+					{
+						"name":	"Bob",
+						"age":	24
+					}`,
+			},
+			testUtils.CreateDoc{
+				Doc: `
+					{
+						"name":	"Kate",
+						"age":	23
+					}`,
+			},
+			testUtils.Request{
+				Request: req,
+				Results: map[string]any{
+					"User": []map[string]any{
+						{
+							"name": "Bob",
+							"age":  24,
+						},
+						{
+							"name": "Kate",
+							"age":  23,
+						},
+						{
+							"name": "Alice",
+							"age":  22,
+						},
+					},
+				},
+			},
+			testUtils.Request{
+				Request:  makeExplainQuery(req),
+				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(3),
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestQueryWithIndex_IfIntFieldInDescOrderWithLt_ShouldFetchInRevertedOrder(t *testing.T) {
+	req := `
+		query {
+			User(filter: {age: {_lt: 22}}) {
+				name
+				age
+			}
+		}`
+
+	test := testUtils.TestCase{
+		Description: "If indexed int field is in DESC order with _lt, it should be fetched in reverted order",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type User {
+						name: String
+						age: Int @index(direction: DESC)
+					}`,
+			},
+			testUtils.CreateDoc{
+				Doc: `
+					{
+						"name":	"Alice",
+						"age":	22
+					}`,
+			},
+			testUtils.CreateDoc{
+				Doc: `
+					{
+						"name":	"John",
+						"age":	20
+					}`,
+			},
+			testUtils.CreateDoc{
+				Doc: `
+					{
+						"name":	"Fred",
+						"age":	18
+					}`,
+			},
+			testUtils.CreateDoc{
+				Doc: `
+					{
+						"name":	"Bob",
+						"age":	24
+					}`,
+			},
+			testUtils.CreateDoc{
+				Doc: `
+					{
+						"name":	"Kate",
+						"age":	23
+					}`,
+			},
+			testUtils.Request{
+				Request: req,
+				Results: map[string]any{
+					"User": []map[string]any{
+						{
+							"name": "John",
+							"age":  20,
+						},
+						{
+							"name": "Fred",
+							"age":  18,
+						},
+					},
+				},
+			},
+			testUtils.Request{
+				Request:  makeExplainQuery(req),
+				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(2),
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestQueryWithIndex_IfIntFieldInDescOrderWithLe_ShouldFetchInRevertedOrder(t *testing.T) {
+	req := `
+		query {
+			User(filter: {age: {_le: 22}}) {
+				name
+				age
+			}
+		}`
+
+	test := testUtils.TestCase{
+		Description: "If indexed int field is in DESC order with _le, it should be fetched in reverted order",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type User {
+						name: String
+						age: Int @index(direction: DESC)
+					}`,
+			},
+			testUtils.CreateDoc{
+				Doc: `
+					{
+						"name":	"Alice",
+						"age":	22
+					}`,
+			},
+			testUtils.CreateDoc{
+				Doc: `
+					{
+						"name":	"John",
+						"age":	20
+					}`,
+			},
+			testUtils.CreateDoc{
+				Doc: `
+					{
+						"name":	"Fred",
+						"age":	18
+					}`,
+			},
+			testUtils.CreateDoc{
+				Doc: `
+					{
+						"name":	"Bob",
+						"age":	24
+					}`,
+			},
+			testUtils.CreateDoc{
+				Doc: `
+					{
+						"name":	"Kate",
+						"age":	23
+					}`,
+			},
+			testUtils.Request{
+				Request: req,
+				Results: map[string]any{
+					"User": []map[string]any{
+						{
+							"name": "Alice",
+							"age":  22,
+						},
+						{
+							"name": "John",
+							"age":  20,
+						},
+						{
+							"name": "Fred",
+							"age":  18,
+						},
+					},
+				},
+			},
+			testUtils.Request{
+				Request:  makeExplainQuery(req),
+				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(3),
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestQueryWithIndex_IfFloatFieldInDescOrderWithLt_ShouldFetchInRevertedOrder(t *testing.T) {
+	req := `
+		query {
+			User(filter: {iq: {_lt: 0.35}}) {
+				name
+				iq
+			}
+		}`
+
+	test := testUtils.TestCase{
+		Description: "If indexed float field is in DESC order with _lt, it should be fetched in reverted order",
 		Actions: []any{
 			testUtils.SchemaUpdate{
 				Schema: `
@@ -111,20 +384,24 @@ func TestQueryWithIndex_IfFloatFieldInDescOrder_ShouldFetchInRevertedOrder(t *te
 						"iq":	0.3
 					}`,
 			},
-			testUtils.Request{
-				Request: `
-					query {
-						User(filter: {iq: {_lt: 1}}) {
-							name
-							iq
-						}
+			testUtils.CreateDoc{
+				Doc: `
+					{
+						"name":	"David",
+						"iq":	0.5
 					}`,
+			},
+			testUtils.CreateDoc{
+				Doc: `
+					{
+						"name":	"Emma",
+						"iq":	0.1
+					}`,
+			},
+			testUtils.Request{
+				Request: req,
 				Results: map[string]any{
 					"User": []map[string]any{
-						{
-							"name": "Bob",
-							"iq":   0.4,
-						},
 						{
 							"name": "Kate",
 							"iq":   0.3,
@@ -133,8 +410,265 @@ func TestQueryWithIndex_IfFloatFieldInDescOrder_ShouldFetchInRevertedOrder(t *te
 							"name": "Alice",
 							"iq":   0.2,
 						},
+						{
+							"name": "Emma",
+							"iq":   0.1,
+						},
 					},
 				},
+			},
+			testUtils.Request{
+				Request:  makeExplainQuery(req),
+				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(3),
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestQueryWithIndex_IfFloatFieldInDescOrderWithGt_ShouldFetchInRevertedOrder(t *testing.T) {
+	req := `
+		query {
+			User(filter: {iq: {_gt: 0.25}}) {
+				name
+				iq
+			}
+		}`
+
+	test := testUtils.TestCase{
+		Description: "If indexed float field is in DESC order with _gt, it should be fetched in reverted order",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type User {
+						name: String
+						iq: Float @index(direction: DESC)
+					}`,
+			},
+			testUtils.CreateDoc{
+				Doc: `
+					{
+						"name":	"Alice",
+						"iq":	0.2
+					}`,
+			},
+			testUtils.CreateDoc{
+				Doc: `
+					{
+						"name":	"Bob",
+						"iq":	0.4
+					}`,
+			},
+			testUtils.CreateDoc{
+				Doc: `
+					{
+						"name":	"Kate",
+						"iq":	0.3
+					}`,
+			},
+			testUtils.CreateDoc{
+				Doc: `
+					{
+						"name":	"David",
+						"iq":	0.5
+					}`,
+			},
+			testUtils.CreateDoc{
+				Doc: `
+					{
+						"name":	"Emma",
+						"iq":	0.1
+					}`,
+			},
+			testUtils.Request{
+				Request: req,
+				Results: map[string]any{
+					"User": []map[string]any{
+						{
+							"name": "David",
+							"iq":   0.5,
+						},
+						{
+							"name": "Bob",
+							"iq":   0.4,
+						},
+						{
+							"name": "Kate",
+							"iq":   0.3,
+						},
+					},
+				},
+			},
+			testUtils.Request{
+				Request:  makeExplainQuery(req),
+				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(3),
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestQueryWithIndex_IfFloatFieldInDescOrderWithGe_ShouldFetchInRevertedOrder(t *testing.T) {
+	req := `
+		query {
+			User(filter: {iq: {_ge: 0.3}}) {
+				name
+				iq
+			}
+		}`
+
+	test := testUtils.TestCase{
+		Description: "If indexed float field is in DESC order with _ge, it should be fetched in reverted order",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type User {
+						name: String
+						iq: Float @index(direction: DESC)
+					}`,
+			},
+			testUtils.CreateDoc{
+				Doc: `
+					{
+						"name":	"Alice",
+						"iq":	0.2
+					}`,
+			},
+			testUtils.CreateDoc{
+				Doc: `
+					{
+						"name":	"Bob",
+						"iq":	0.4
+					}`,
+			},
+			testUtils.CreateDoc{
+				Doc: `
+					{
+						"name":	"Kate",
+						"iq":	0.3
+					}`,
+			},
+			testUtils.CreateDoc{
+				Doc: `
+					{
+						"name":	"David",
+						"iq":	0.5
+					}`,
+			},
+			testUtils.CreateDoc{
+				Doc: `
+					{
+						"name":	"Emma",
+						"iq":	0.1
+					}`,
+			},
+			testUtils.Request{
+				Request: req,
+				Results: map[string]any{
+					"User": []map[string]any{
+						{
+							"name": "David",
+							"iq":   0.5,
+						},
+						{
+							"name": "Bob",
+							"iq":   0.4,
+						},
+						{
+							"name": "Kate",
+							"iq":   0.3,
+						},
+					},
+				},
+			},
+			testUtils.Request{
+				Request:  makeExplainQuery(req),
+				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(3),
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestQueryWithIndex_IfFloatFieldInDescOrderWithLe_ShouldFetchInRevertedOrder(t *testing.T) {
+	req := `
+		query {
+			User(filter: {iq: {_le: 0.3}}) {
+				name
+				iq
+			}
+		}`
+
+	test := testUtils.TestCase{
+		Description: "If indexed float field is in DESC order with _le, it should be fetched in reverted order",
+		Actions: []any{
+			testUtils.SchemaUpdate{
+				Schema: `
+					type User {
+						name: String
+						iq: Float @index(direction: DESC)
+					}`,
+			},
+			testUtils.CreateDoc{
+				Doc: `
+					{
+						"name":	"Alice",
+						"iq":	0.2
+					}`,
+			},
+			testUtils.CreateDoc{
+				Doc: `
+					{
+						"name":	"Bob",
+						"iq":	0.4
+					}`,
+			},
+			testUtils.CreateDoc{
+				Doc: `
+					{
+						"name":	"Kate",
+						"iq":	0.3
+					}`,
+			},
+			testUtils.CreateDoc{
+				Doc: `
+					{
+						"name":	"David",
+						"iq":	0.5
+					}`,
+			},
+			testUtils.CreateDoc{
+				Doc: `
+					{
+						"name":	"Emma",
+						"iq":	0.1
+					}`,
+			},
+			testUtils.Request{
+				Request: req,
+				Results: map[string]any{
+					"User": []map[string]any{
+						{
+							"name": "Kate",
+							"iq":   0.3,
+						},
+						{
+							"name": "Alice",
+							"iq":   0.2,
+						},
+						{
+							"name": "Emma",
+							"iq":   0.1,
+						},
+					},
+				},
+			},
+			testUtils.Request{
+				Request:  makeExplainQuery(req),
+				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(3),
 			},
 		},
 	}

--- a/tests/integration/index/query_with_index_only_filter_test.go
+++ b/tests/integration/index/query_with_index_only_filter_test.go
@@ -167,7 +167,7 @@ func TestQueryWithIndex_WithGreaterThanFilter_ShouldFetch(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(1),
 			},
 		},
 	}
@@ -205,7 +205,7 @@ func TestQueryWithIndex_WithGreaterOrEqualFilter_ShouldFetch(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(2),
 			},
 		},
 	}
@@ -242,7 +242,7 @@ func TestQueryWithIndex_WithLessThanFilter_ShouldFetch(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(1),
 			},
 		},
 	}
@@ -280,7 +280,7 @@ func TestQueryWithIndex_WithLessOrEqualFilter_ShouldFetch(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(2),
 			},
 		},
 	}

--- a/tests/integration/index/query_with_unique_composite_index_filter_test.go
+++ b/tests/integration/index/query_with_unique_composite_index_filter_test.go
@@ -133,7 +133,7 @@ func TestQueryWithUniqueCompositeIndex_WithGreaterThanFilterOnFirstField_ShouldF
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(2),
 			},
 		},
 	}
@@ -210,7 +210,7 @@ func TestQueryWithUniqueCompositeIndex_WithGreaterOrEqualFilterOnFirstField_Shou
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(3),
 			},
 		},
 	}
@@ -287,7 +287,7 @@ func TestQueryWithUniqueCompositeIndex_WithLessThanFilterOnFirstField_ShouldFetc
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(2),
 			},
 		},
 	}
@@ -364,7 +364,7 @@ func TestQueryWithUniqueCompositeIndex_WithLessOrEqualFilterOnFirstField_ShouldF
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(3),
 			},
 		},
 	}

--- a/tests/integration/index/query_with_unique_index_only_filter_test.go
+++ b/tests/integration/index/query_with_unique_index_only_filter_test.go
@@ -81,7 +81,7 @@ func TestQueryWithUniqueIndex_WithGreaterThanFilter_ShouldFetch(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(1),
 			},
 		},
 	}
@@ -119,7 +119,7 @@ func TestQueryWithUniqueIndex_WithGreaterOrEqualFilter_ShouldFetch(t *testing.T)
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(2),
 			},
 		},
 	}
@@ -156,7 +156,7 @@ func TestQueryWithUniqueIndex_WithLessThanFilter_ShouldFetch(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(1),
 			},
 		},
 	}
@@ -194,7 +194,7 @@ func TestQueryWithUniqueIndex_WithLessOrEqualFilter_ShouldFetch(t *testing.T) {
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
-				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(10),
+				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(2),
 			},
 		},
 	}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #3651

## Description

Make secondary indexes use range capabilities of corekv storage.