### PR TITLE
test(i): Move int. test state to state package

### DIFF
--- a/tests/integration/acp_dac.go
+++ b/tests/integration/acp_dac.go
@@ -95,7 +95,7 @@ func addDACPolicy(
 ) {
 	// If we expect an error, then ExpectedPolicyID should never be provided.
 	if action.ExpectedError != "" && action.ExpectedPolicyID.HasValue() {
-		require.Fail(s.t, "Expected error should not have an expected policyID with it.", s.testCase.Description)
+		require.Fail(s.t, "Expected error should not have an expected policyID with it.")
 	}
 
 	nodeIDs, nodes := getNodesWithIDs(action.NodeID, s.nodes)
@@ -114,8 +114,8 @@ func addDACPolicy(
 		ctx := getContextWithIdentity(s.ctx, s, action.Identity, nodeID)
 		policyResult, err := node.AddDACPolicy(ctx, action.Policy)
 
-		expectedErrorRaised := AssertError(s.t, s.testCase.Description, err, action.ExpectedError)
-		assertExpectedErrorRaised(s.t, s.testCase.Description, action.ExpectedError, expectedErrorRaised)
+		expectedErrorRaised := AssertError(s.t, err, action.ExpectedError)
+		assertExpectedErrorRaised(s.t, action.ExpectedError, expectedErrorRaised)
 
 		if !expectedErrorRaised {
 			require.Equal(s.t, action.ExpectedError, "")
@@ -209,8 +209,8 @@ func addDACActorRelationship(
 			getIdentityDID(s, action.TargetIdentity),
 		)
 
-		expectedErrorRaised := AssertError(s.t, s.testCase.Description, err, action.ExpectedError)
-		assertExpectedErrorRaised(s.t, s.testCase.Description, action.ExpectedError, expectedErrorRaised)
+		expectedErrorRaised := AssertError(s.t, err, action.ExpectedError)
+		assertExpectedErrorRaised(s.t, action.ExpectedError, expectedErrorRaised)
 
 		if !expectedErrorRaised {
 			require.Equal(s.t, action.ExpectedError, "")
@@ -299,8 +299,8 @@ func deleteDACActorRelationship(
 			getIdentityDID(s, action.TargetIdentity),
 		)
 
-		expectedErrorRaised := AssertError(s.t, s.testCase.Description, err, action.ExpectedError)
-		assertExpectedErrorRaised(s.t, s.testCase.Description, action.ExpectedError, expectedErrorRaised)
+		expectedErrorRaised := AssertError(s.t, err, action.ExpectedError)
+		assertExpectedErrorRaised(s.t, action.ExpectedError, expectedErrorRaised)
 
 		if !expectedErrorRaised {
 			require.Equal(s.t, action.ExpectedError, "")
@@ -321,7 +321,7 @@ func getCollectionAndDocInfo(s *state, collectionID, docInd, nodeID int) (string
 	if collectionID != -1 {
 		collection := s.nodes[nodeID].collections[collectionID]
 		if collection.Version().Name == "" {
-			require.Fail(s.t, "Expected non-empty collection name, but it was empty.", s.testCase.Description)
+			require.Fail(s.t, "Expected non-empty collection name, but it was empty.")
 		}
 		collectionName = collection.Version().Name
 

--- a/tests/integration/acp_dac.go
+++ b/tests/integration/acp_dac.go
@@ -17,6 +17,8 @@ import (
 
 	"github.com/sourcenetwork/immutable"
 	"github.com/stretchr/testify/require"
+
+	"github.com/sourcenetwork/defradb/tests/state"
 )
 
 type DocumentACPType string
@@ -39,18 +41,15 @@ var (
 	documentACPType DocumentACPType
 )
 
-// KMSType is the type of KMS to use.
-type KMSType string
-
 const (
 	// NoneKMSType is the none KMS type. It is used to indicate that no KMS should be used.
-	NoneKMSType KMSType = "none"
+	NoneKMSType state.KMSType = "none"
 	// PubSubKMSType is the PubSub KMS type.
-	PubSubKMSType KMSType = "pubsub"
+	PubSubKMSType state.KMSType = "pubsub"
 )
 
-func getKMSTypes() []KMSType {
-	return []KMSType{PubSubKMSType}
+func getKMSTypes() []state.KMSType {
+	return []state.KMSType{PubSubKMSType}
 }
 
 func init() {
@@ -72,7 +71,7 @@ type AddDACPolicy struct {
 	Policy string
 
 	// The policy creator identity, i.e. actor creating the policy.
-	Identity immutable.Option[Identity]
+	Identity immutable.Option[state.Identity]
 
 	// The expected policyID generated based on the Policy loaded in to the ACP system.
 	//
@@ -90,7 +89,7 @@ type AddDACPolicy struct {
 
 // addDACPolicy will attempt to add the given policy using DefraDB's Document ACP system.
 func addDACPolicy(
-	s *State,
+	s *state.State,
 	action AddDACPolicy,
 ) {
 	// If we expect an error, then ExpectedPolicyID should never be provided.
@@ -170,13 +169,13 @@ type AddDACActorRelationship struct {
 	// The target public identity, i.e. the identity of the actor to tie the document's relation with.
 	//
 	// This is a required field. To test the invalid usage of not having this arg, use NoIdentity() or leave default.
-	TargetIdentity immutable.Option[Identity]
+	TargetIdentity immutable.Option[state.Identity]
 
 	// The requestor identity, i.e. identity of the actor creating the relationship.
 	// Note: This identity must either own or have managing access defined in the policy.
 	//
 	// This is a required field. To test the invalid usage of not having this arg, use NoIdentity() or leave default.
-	RequestorIdentity immutable.Option[Identity]
+	RequestorIdentity immutable.Option[state.Identity]
 
 	// Result returns true if it was a no-op due to existing before, and false if a new relationship was made.
 	ExpectedExistence bool
@@ -189,7 +188,7 @@ type AddDACActorRelationship struct {
 }
 
 func addDACActorRelationship(
-	s *State,
+	s *state.State,
 	action AddDACActorRelationship,
 ) {
 	var docID string
@@ -262,13 +261,13 @@ type DeleteDACActorRelationship struct {
 	// The target public identity, i.e. the identity of the actor with whom the relationship is with.
 	//
 	// This is a required field. To test the invalid usage of not having this arg, use NoIdentity() or leave default.
-	TargetIdentity immutable.Option[Identity]
+	TargetIdentity immutable.Option[state.Identity]
 
 	// The requestor identity, i.e. identity of the actor deleting the relationship.
 	// Note: This identity must either own or have managing access defined in the policy.
 	//
 	// This is a required field. To test the invalid usage of not having this arg, use NoIdentity() or leave default.
-	RequestorIdentity immutable.Option[Identity]
+	RequestorIdentity immutable.Option[state.Identity]
 
 	// Result returns true if the relationship record was expected to be found and deleted,
 	// and returns false if no matching relationship record was found (no-op).
@@ -282,7 +281,7 @@ type DeleteDACActorRelationship struct {
 }
 
 func deleteDACActorRelationship(
-	s *State,
+	s *state.State,
 	action DeleteDACActorRelationship,
 ) {
 	nodeIDs, nodes := getNodesWithIDs(action.NodeID, s.Nodes)
@@ -315,7 +314,7 @@ func deleteDACActorRelationship(
 	}
 }
 
-func getCollectionAndDocInfo(s *State, collectionID, docInd, nodeID int) (string, string) {
+func getCollectionAndDocInfo(s *state.State, collectionID, docInd, nodeID int) (string, string) {
 	collectionName := ""
 	docID := ""
 	if collectionID != -1 {

--- a/tests/integration/acp_dac_setup.go
+++ b/tests/integration/acp_dac_setup.go
@@ -30,6 +30,7 @@ import (
 	"github.com/sourcenetwork/defradb/node"
 	"github.com/sourcenetwork/defradb/tests/clients/cli"
 	"github.com/sourcenetwork/defradb/tests/clients/http"
+	"github.com/sourcenetwork/defradb/tests/state"
 
 	"github.com/decred/dcrd/dcrec/secp256k1/v4"
 	toml "github.com/pelletier/go-toml"
@@ -37,7 +38,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func getNodeAudience(s *State, nodeIndex int) immutable.Option[string] {
+func getNodeAudience(s *state.State, nodeIndex int) immutable.Option[string] {
 	if nodeIndex >= len(s.Nodes) {
 		return immutable.None[string]()
 	}
@@ -51,7 +52,7 @@ func getNodeAudience(s *State, nodeIndex int) immutable.Option[string] {
 	return immutable.None[string]()
 }
 
-func setupSourceHub(s *State, testCase TestCase) ([]node.DocumentACPOpt, error) {
+func setupSourceHub(s *state.State, testCase TestCase) ([]node.DocumentACPOpt, error) {
 	var isDocumentACPTest bool
 	for _, a := range testCase.Actions {
 		switch a.(type) {

--- a/tests/integration/acp_dac_setup.go
+++ b/tests/integration/acp_dac_setup.go
@@ -51,9 +51,9 @@ func getNodeAudience(s *state, nodeIndex int) immutable.Option[string] {
 	return immutable.None[string]()
 }
 
-func setupSourceHub(s *state) ([]node.DocumentACPOpt, error) {
+func setupSourceHub(s *state, testCase TestCase) ([]node.DocumentACPOpt, error) {
 	var isDocumentACPTest bool
-	for _, a := range s.testCase.Actions {
+	for _, a := range testCase.Actions {
 		switch a.(type) {
 		case
 			AddDACPolicy,

--- a/tests/integration/acp_dac_setup.go
+++ b/tests/integration/acp_dac_setup.go
@@ -37,11 +37,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func getNodeAudience(s *state, nodeIndex int) immutable.Option[string] {
-	if nodeIndex >= len(s.nodes) {
+func getNodeAudience(s *State, nodeIndex int) immutable.Option[string] {
+	if nodeIndex >= len(s.Nodes) {
 		return immutable.None[string]()
 	}
-	switch client := s.nodes[nodeIndex].Client.(type) {
+	switch client := s.Nodes[nodeIndex].Client.(type) {
 	case *http.Wrapper:
 		return immutable.Some(strings.TrimPrefix(client.Host(), "http://"))
 	case *cli.Wrapper:
@@ -51,7 +51,7 @@ func getNodeAudience(s *state, nodeIndex int) immutable.Option[string] {
 	return immutable.None[string]()
 }
 
-func setupSourceHub(s *state, testCase TestCase) ([]node.DocumentACPOpt, error) {
+func setupSourceHub(s *State, testCase TestCase) ([]node.DocumentACPOpt, error) {
 	var isDocumentACPTest bool
 	for _, a := range testCase.Actions {
 		switch a.(type) {
@@ -66,14 +66,14 @@ func setupSourceHub(s *state, testCase TestCase) ([]node.DocumentACPOpt, error) 
 	if !isDocumentACPTest {
 		// Spinning up SourceHub instances is a bit slow, so we should be quite aggressive in trimming down the
 		// runtime of the test suite when SourceHub ACP is selected.
-		s.t.Skipf("test has no document ACP elements when testing with SourceHub ACP")
+		s.T.Skipf("test has no document ACP elements when testing with SourceHub ACP")
 	}
 
 	const moniker string = "foo"
 	const chainID string = "sourcehub-test"
 	const validatorName string = "test-validator"
 	const keyringBackend string = "test"
-	directory := s.t.TempDir()
+	directory := s.T.TempDir()
 
 	kr, err := keyring.OpenFileKeyring(
 		directory,
@@ -90,7 +90,7 @@ func setupSourceHub(s *state, testCase TestCase) ([]node.DocumentACPOpt, error) 
 	r := rand.New(source)
 
 	acpKey, err := secp256k1.GeneratePrivateKeyFromRand(r)
-	require.NoError(s.t, err)
+	require.NoError(s.T, err)
 	acpKeyHex := hex.EncodeToString(acpKey.Serialize())
 
 	err = kr.Set(validatorName, acpKey.Serialize())
@@ -99,9 +99,9 @@ func setupSourceHub(s *state, testCase TestCase) ([]node.DocumentACPOpt, error) 
 	}
 
 	args := []string{"init", moniker, "--chain-id", chainID, "--home", directory}
-	s.t.Log("$ sourcehubd " + strings.Join(args, " "))
+	s.T.Log("$ sourcehubd " + strings.Join(args, " "))
 	out, err := exec.Command("sourcehubd", args...).CombinedOutput()
-	s.t.Log(string(out))
+	s.T.Log(string(out))
 	if err != nil {
 		return nil, err
 	}
@@ -139,9 +139,9 @@ func setupSourceHub(s *state, testCase TestCase) ([]node.DocumentACPOpt, error) 
 		"--home", directory,
 	}
 
-	s.t.Log("$ sourcehubd " + strings.Join(args, " "))
+	s.T.Log("$ sourcehubd " + strings.Join(args, " "))
 	out, err = exec.Command("sourcehubd", args...).CombinedOutput()
-	s.t.Log(string(out))
+	s.T.Log(string(out))
 	if err != nil {
 		return nil, err
 	}
@@ -152,24 +152,24 @@ func setupSourceHub(s *state, testCase TestCase) ([]node.DocumentACPOpt, error) 
 		"--keyring-backend", keyringBackend,
 		"--home", directory,
 	}
-	s.t.Log("$ sourcehubd " + strings.Join(args, " "))
+	s.T.Log("$ sourcehubd " + strings.Join(args, " "))
 	out, err = exec.Command("sourcehubd", args...).CombinedOutput()
-	s.t.Log(string(out))
+	s.T.Log(string(out))
 	if err != nil {
 		return nil, err
 	}
 
 	// The result is suffixed with a newline char so we must trim the whitespace
 	validatorAddress := strings.TrimSpace(string(out))
-	s.sourcehubAddress = validatorAddress
+	s.SourcehubAddress = validatorAddress
 
 	args = []string{"genesis", "add-genesis-account", validatorAddress, "1000000000uopen",
 		"--keyring-backend", keyringBackend,
 		"--home", directory,
 	}
-	s.t.Log("$ sourcehubd " + strings.Join(args, " "))
+	s.T.Log("$ sourcehubd " + strings.Join(args, " "))
 	out, err = exec.Command("sourcehubd", args...).CombinedOutput()
-	s.t.Log(string(out))
+	s.T.Log(string(out))
 	if err != nil {
 		return nil, err
 	}
@@ -178,17 +178,17 @@ func setupSourceHub(s *state, testCase TestCase) ([]node.DocumentACPOpt, error) 
 		"--chain-id", chainID,
 		"--keyring-backend", keyringBackend,
 		"--home", directory}
-	s.t.Log("$ sourcehubd " + strings.Join(args, " "))
+	s.T.Log("$ sourcehubd " + strings.Join(args, " "))
 	out, err = exec.Command("sourcehubd", args...).CombinedOutput()
-	s.t.Log(string(out))
+	s.T.Log(string(out))
 	if err != nil {
 		return nil, err
 	}
 
 	args = []string{"genesis", "collect-gentxs", "--home", directory}
-	s.t.Log("$ sourcehubd " + strings.Join(args, " "))
+	s.T.Log("$ sourcehubd " + strings.Join(args, " "))
 	out, err = exec.Command("sourcehubd", args...).CombinedOutput()
-	s.t.Log(string(out))
+	s.T.Log(string(out))
 	if err != nil {
 		return nil, err
 	}
@@ -246,7 +246,7 @@ func setupSourceHub(s *state, testCase TestCase) ([]node.DocumentACPOpt, error) 
 		"--p2p.laddr", p2pAddress,
 		"--rpc.pprof_laddr", pprofAddress,
 	}
-	s.t.Log("$ sourcehubd " + strings.Join(args, " "))
+	s.T.Log("$ sourcehubd " + strings.Join(args, " "))
 	sourceHubCmd := exec.Command("sourcehubd", args...)
 	var bf testBuffer
 	bf.Lines = make(chan string, 100)
@@ -283,10 +283,10 @@ cmdReaderLoop:
 	// Void the buffer so that it doesn't fill up and block the process under test
 	bf.Void()
 
-	s.t.Cleanup(
+	s.T.Cleanup(
 		func() {
 			err := sourceHubCmd.Process.Kill()
-			require.NoError(s.t, err)
+			require.NoError(s.T, err)
 		},
 	)
 

--- a/tests/integration/acp_dac_setup_js.go
+++ b/tests/integration/acp_dac_setup_js.go
@@ -12,14 +12,15 @@ package tests
 
 import (
 	"github.com/sourcenetwork/defradb/node"
+	"github.com/sourcenetwork/defradb/tests/state"
 
 	"github.com/sourcenetwork/immutable"
 )
 
-func setupSourceHub(s *state) ([]node.DocumentACPOpt, error) {
-	return s.documentACPOptions, nil
+func setupSourceHub(s *state.State) ([]node.DocumentACPOpt, error) {
+	return s.DocumentACPOptions, nil
 }
 
-func getNodeAudience(s *state, nodeIndex int) immutable.Option[string] {
+func getNodeAudience(s *state.State, nodeIndex int) immutable.Option[string] {
 	return immutable.None[string]()
 }

--- a/tests/integration/client.go
+++ b/tests/integration/client.go
@@ -13,6 +13,8 @@ package tests
 import (
 	"os"
 	"strconv"
+
+	"github.com/sourcenetwork/defradb/tests/state"
 )
 
 const (
@@ -21,21 +23,19 @@ const (
 	clientCliEnvName  = "DEFRA_CLIENT_CLI"
 )
 
-type ClientType string
-
 const (
 	// goClientType enables running the test suite using
 	// the go implementation of the client.TxnStore interface.
-	GoClientType ClientType = "go"
+	GoClientType state.ClientType = "go"
 	// httpClientType enables running the test suite using
 	// the http implementation of the client.TxnStore interface.
-	HTTPClientType ClientType = "http"
+	HTTPClientType state.ClientType = "http"
 	// cliClientType enables running the test suite using
 	// the cli implementation of the client.TxnStore interface.
-	CLIClientType ClientType = "cli"
+	CLIClientType state.ClientType = "cli"
 	// JSClientType enables running the test suite using
 	// the JS implementation of the client.TxnStore interface.
-	JSClientType ClientType = "js"
+	JSClientType state.ClientType = "js"
 )
 
 var (

--- a/tests/integration/client_setup.go
+++ b/tests/integration/client_setup.go
@@ -31,19 +31,19 @@ func init() {
 // setupClient returns the client implementation for the current
 // testing state. The client type on the test state is used to
 // select the client implementation to use.
-func setupClient(s *state, node *node.Node) (clients.Client, error) {
-	switch s.clientType {
+func setupClient(s *State, node *node.Node) (clients.Client, error) {
+	switch s.ClientType {
 	case HTTPClientType:
 		return http.NewWrapper(node)
 
 	case CLIClientType:
-		return cli.NewWrapper(node, s.sourcehubAddress)
+		return cli.NewWrapper(node, s.SourcehubAddress)
 
 	case GoClientType:
 		return newGoClientWrapper(node), nil
 
 	default:
-		return nil, fmt.Errorf("invalid client type: %v", s.dbt)
+		return nil, fmt.Errorf("invalid client type: %v", s.Dbt)
 	}
 }
 

--- a/tests/integration/client_setup.go
+++ b/tests/integration/client_setup.go
@@ -19,6 +19,7 @@ import (
 	"github.com/sourcenetwork/defradb/tests/clients"
 	"github.com/sourcenetwork/defradb/tests/clients/cli"
 	"github.com/sourcenetwork/defradb/tests/clients/http"
+	"github.com/sourcenetwork/defradb/tests/state"
 )
 
 func init() {
@@ -31,7 +32,7 @@ func init() {
 // setupClient returns the client implementation for the current
 // testing state. The client type on the test state is used to
 // select the client implementation to use.
-func setupClient(s *State, node *node.Node) (clients.Client, error) {
+func setupClient(s *state.State, node *node.Node) (clients.Client, error) {
 	switch s.ClientType {
 	case HTTPClientType:
 		return http.NewWrapper(node)

--- a/tests/integration/client_setup.go
+++ b/tests/integration/client_setup.go
@@ -44,7 +44,7 @@ func setupClient(s *state.State, node *node.Node) (clients.Client, error) {
 		return newGoClientWrapper(node), nil
 
 	default:
-		return nil, fmt.Errorf("invalid client type: %v", s.Dbt)
+		return nil, fmt.Errorf("invalid client type: %v", s.DbType)
 	}
 }
 

--- a/tests/integration/client_setup_js.go
+++ b/tests/integration/client_setup_js.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sourcenetwork/defradb/node"
 	"github.com/sourcenetwork/defradb/tests/clients"
 	"github.com/sourcenetwork/defradb/tests/clients/js"
+	"github.com/sourcenetwork/defradb/tests/state"
 )
 
 func init() {
@@ -30,6 +31,6 @@ func init() {
 // setupClient returns the client implementation for the current
 // testing state. The client type on the test state is used to
 // select the client implementation to use.
-func setupClient(_ *state, node *node.Node) (impl clients.Client, err error) {
+func setupClient(_ *state.State, node *node.Node) (impl clients.Client, err error) {
 	return js.NewWrapper(node)
 }

--- a/tests/integration/collection/update/simple/with_filter_test.go
+++ b/tests/integration/collection/update/simple/with_filter_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sourcenetwork/immutable"
 
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	"github.com/sourcenetwork/defradb/tests/state"
 )
 
 func TestUpdateWithInvalidFilterType_ReturnsError(t *testing.T) {
@@ -25,7 +26,7 @@ func TestUpdateWithInvalidFilterType_ReturnsError(t *testing.T) {
 		// http and cli clients will pass the serialize filter into json which will result in
 		// the payload deserialized into map[string]any. With Go client the filter is passed as is.
 		SupportedClientTypes: immutable.Some(
-			[]testUtils.ClientType{testUtils.HTTPClientType, testUtils.CLIClientType}),
+			[]state.ClientType{testUtils.HTTPClientType, testUtils.CLIClientType}),
 		Actions: []any{
 			testUtils.UpdateWithFilter{
 				CollectionID:  0,
@@ -43,7 +44,7 @@ func TestUpdateWithInvalidFilterType_WithGoClient_ReturnsError(t *testing.T) {
 	type invalidFilterType struct{ Number int }
 	test := testUtils.TestCase{
 		Description:          "Test update users with invalid filter type (go client)",
-		SupportedClientTypes: immutable.Some([]testUtils.ClientType{testUtils.GoClientType}),
+		SupportedClientTypes: immutable.Some([]state.ClientType{testUtils.GoClientType}),
 		Actions: []any{
 			testUtils.UpdateWithFilter{
 				CollectionID:  0,

--- a/tests/integration/db.go
+++ b/tests/integration/db.go
@@ -18,9 +18,8 @@ import (
 
 	"github.com/sourcenetwork/defradb/node"
 	changeDetector "github.com/sourcenetwork/defradb/tests/change_detector"
+	"github.com/sourcenetwork/defradb/tests/state"
 )
-
-type DatabaseType string
 
 const (
 	memoryBadgerEnvName     = "DEFRA_BADGER_MEMORY"
@@ -31,9 +30,9 @@ const (
 )
 
 const (
-	BadgerIMType   DatabaseType = "badger-in-memory"
-	DefraIMType    DatabaseType = "defra-memory-datastore"
-	BadgerFileType DatabaseType = "badger-file-system"
+	BadgerIMType   state.DatabaseType = "badger-in-memory"
+	DefraIMType    state.DatabaseType = "defra-memory-datastore"
+	BadgerFileType state.DatabaseType = "badger-file-system"
 )
 
 var (

--- a/tests/integration/db_setup.go
+++ b/tests/integration/db_setup.go
@@ -40,9 +40,9 @@ func createBadgerEncryptionKey() error {
 // setupNode returns the database implementation for the current
 // testing state. The database type on the test state is used to
 // select the datastore implementation to use.
-func setupNode(s *state, opts ...node.Option) (*nodeState, error) {
+func setupNode(s *state, testCase TestCase, opts ...node.Option) (*nodeState, error) {
 	opts = append(defaultNodeOpts(), opts...)
-	opts = append(opts, db.WithEnabledSigning(s.testCase.EnableSigning))
+	opts = append(opts, db.WithEnabledSigning(testCase.EnableSigning))
 
 	err := createBadgerEncryptionKey()
 	if err != nil {
@@ -58,7 +58,7 @@ func setupNode(s *state, opts ...node.Option) (*nodeState, error) {
 
 	case SourceHubDocumentACPType:
 		if len(s.documentACPOptions) == 0 {
-			s.documentACPOptions, err = setupSourceHub(s)
+			s.documentACPOptions, err = setupSourceHub(s, testCase)
 			require.NoError(s.t, err)
 		}
 

--- a/tests/integration/db_setup.go
+++ b/tests/integration/db_setup.go
@@ -140,5 +140,9 @@ func setupNode(s *state.State, testCase TestCase, opts ...node.Option) (*state.N
 		NetOpts: netOpts,
 	}
 
+	if node.Peer != nil {
+		st.AddrInfo = node.Peer.PeerInfo()
+	}
+
 	return st, nil
 }

--- a/tests/integration/db_setup.go
+++ b/tests/integration/db_setup.go
@@ -73,7 +73,7 @@ func setupNode(s *state.State, testCase TestCase, opts ...node.Option) (*state.N
 	}
 
 	var path string
-	switch s.Dbt {
+	switch s.DbType {
 	case BadgerIMType:
 		opts = append(opts, node.WithBadgerInMemory(true))
 
@@ -98,10 +98,10 @@ func setupNode(s *state.State, testCase TestCase, opts ...node.Option) (*state.N
 		opts = append(opts, node.WithStoreType(node.MemoryStore))
 
 	default:
-		return nil, fmt.Errorf("invalid database type: %v", s.Dbt)
+		return nil, fmt.Errorf("invalid database type: %v", s.DbType)
 	}
 
-	if s.Kms == PubSubKMSType {
+	if s.KMS == PubSubKMSType {
 		opts = append(opts, node.WithKMS(kms.PubSubServiceType))
 	}
 
@@ -135,7 +135,7 @@ func setupNode(s *state.State, testCase TestCase, opts ...node.Option) (*state.N
 	st := &state.NodeState{
 		Client:  c,
 		Event:   eventState,
-		P2p:     state.NewP2PState(),
+		P2P:     state.NewP2PState(),
 		DbPath:  path,
 		NetOpts: netOpts,
 	}

--- a/tests/integration/db_setup.go
+++ b/tests/integration/db_setup.go
@@ -21,6 +21,7 @@ import (
 	netConfig "github.com/sourcenetwork/defradb/net/config"
 	"github.com/sourcenetwork/defradb/node"
 	changeDetector "github.com/sourcenetwork/defradb/tests/change_detector"
+	"github.com/sourcenetwork/defradb/tests/state"
 
 	"github.com/stretchr/testify/require"
 )
@@ -40,7 +41,7 @@ func createBadgerEncryptionKey() error {
 // setupNode returns the database implementation for the current
 // testing state. The database type on the test state is used to
 // select the datastore implementation to use.
-func setupNode(s *State, testCase TestCase, opts ...node.Option) (*NodeState, error) {
+func setupNode(s *state.State, testCase TestCase, opts ...node.Option) (*state.NodeState, error) {
 	opts = append(defaultNodeOpts(), opts...)
 	opts = append(opts, db.WithEnabledSigning(testCase.EnableSigning))
 
@@ -128,13 +129,13 @@ func setupNode(s *State, testCase TestCase, opts ...node.Option) (*NodeState, er
 	c, err := setupClient(s, node)
 	require.Nil(s.T, err)
 
-	eventState, err := NewEventState(c.Events())
+	eventState, err := state.NewEventState(c.Events())
 	require.NoError(s.T, err)
 
-	st := &NodeState{
+	st := &state.NodeState{
 		Client:  c,
 		Event:   eventState,
-		P2p:     NewP2PState(),
+		P2p:     state.NewP2PState(),
 		DbPath:  path,
 		NetOpts: netOpts,
 	}

--- a/tests/integration/db_setup_js.go
+++ b/tests/integration/db_setup_js.go
@@ -65,6 +65,6 @@ func setupNode(s *state.State, testCase TestCase, opts ...node.Option) (*state.N
 	return &state.NodeState{
 		Client: c,
 		Event:  eventState,
-		P2p:    state.NewP2PState(),
+		P2P:    state.NewP2PState(),
 	}, nil
 }

--- a/tests/integration/events.go
+++ b/tests/integration/events.go
@@ -43,14 +43,14 @@ func waitForReplicatorConfigureEvent(s *state.State, cfg ConfigureReplicator) {
 	}
 
 	// all previous documents should be merged on the subscriber node
-	for key, val := range s.Nodes[cfg.SourceNodeID].P2p.ActualDAGHeads {
-		s.Nodes[cfg.TargetNodeID].P2p.ExpectedDAGHeads[key] = val.Cid
+	for key, val := range s.Nodes[cfg.SourceNodeID].P2P.ActualDAGHeads {
+		s.Nodes[cfg.TargetNodeID].P2P.ExpectedDAGHeads[key] = val.CID
 	}
 
 	// update node connections and replicators
-	s.Nodes[cfg.TargetNodeID].P2p.Connections[cfg.SourceNodeID] = struct{}{}
-	s.Nodes[cfg.SourceNodeID].P2p.Connections[cfg.TargetNodeID] = struct{}{}
-	s.Nodes[cfg.SourceNodeID].P2p.Replicators[cfg.TargetNodeID] = struct{}{}
+	s.Nodes[cfg.TargetNodeID].P2P.Connections[cfg.SourceNodeID] = struct{}{}
+	s.Nodes[cfg.SourceNodeID].P2P.Connections[cfg.TargetNodeID] = struct{}{}
+	s.Nodes[cfg.SourceNodeID].P2P.Replicators[cfg.TargetNodeID] = struct{}{}
 }
 
 // waitForReplicatorDeleteEvent waits for a node to publish a
@@ -66,9 +66,9 @@ func waitForReplicatorDeleteEvent(s *state.State, cfg DeleteReplicator) {
 		require.Fail(s.T, "timeout waiting for replicator event")
 	}
 
-	delete(s.Nodes[cfg.TargetNodeID].P2p.Connections, cfg.SourceNodeID)
-	delete(s.Nodes[cfg.SourceNodeID].P2p.Connections, cfg.TargetNodeID)
-	delete(s.Nodes[cfg.SourceNodeID].P2p.Replicators, cfg.TargetNodeID)
+	delete(s.Nodes[cfg.TargetNodeID].P2P.Connections, cfg.SourceNodeID)
+	delete(s.Nodes[cfg.SourceNodeID].P2P.Connections, cfg.TargetNodeID)
+	delete(s.Nodes[cfg.SourceNodeID].P2P.Replicators, cfg.TargetNodeID)
 }
 
 // waitForSubscribeToCollectionEvent waits for a node to publish a
@@ -81,7 +81,7 @@ func waitForSubscribeToCollectionEvent(s *state.State, action SubscribeToCollect
 		if collectionIndex == NonExistentCollectionID {
 			continue // don't track non existent collections
 		}
-		s.Nodes[action.NodeID].P2p.PeerCollections[collectionIndex] = struct{}{}
+		s.Nodes[action.NodeID].P2P.PeerCollections[collectionIndex] = struct{}{}
 	}
 }
 
@@ -92,7 +92,7 @@ func waitForUnsubscribeToCollectionEvent(s *state.State, action UnsubscribeToCol
 		if collectionIndex == NonExistentCollectionID {
 			continue // don't track non existent collections
 		}
-		delete(s.Nodes[action.NodeID].P2p.PeerCollections, collectionIndex)
+		delete(s.Nodes[action.NodeID].P2P.PeerCollections, collectionIndex)
 	}
 }
 
@@ -106,7 +106,7 @@ func waitForSubscribeToDocumentEvent(s *state.State, action SubscribeToDocument)
 		if colDocIndex.Doc == NonExistentDocID {
 			continue // don't track non existent documents
 		}
-		s.Nodes[action.NodeID].P2p.PeerDocuments[colDocIndex] = struct{}{}
+		s.Nodes[action.NodeID].P2P.PeerDocuments[colDocIndex] = struct{}{}
 	}
 }
 
@@ -117,7 +117,7 @@ func waitForUnsubscribeToDocumentEvent(s *state.State, action UnsubscribeToDocum
 		if colDocIndex.Doc == NonExistentDocID {
 			continue // don't track non existent documents
 		}
-		delete(s.Nodes[action.NodeID].P2p.PeerDocuments, colDocIndex)
+		delete(s.Nodes[action.NodeID].P2P.PeerDocuments, colDocIndex)
 	}
 }
 
@@ -190,12 +190,12 @@ func waitForMergeEvents(s *state.State, action WaitForSync) {
 			continue // node is closed
 		}
 
-		expect := node.P2p.ExpectedDAGHeads
+		expect := node.P2P.ExpectedDAGHeads
 
 		// remove any heads that are already merged
 		// up to the expected head
-		for key, val := range node.P2p.ActualDAGHeads {
-			if head, ok := expect[key]; ok && head.String() == val.Cid.String() {
+		for key, val := range node.P2P.ActualDAGHeads {
+			if head, ok := expect[key]; ok && head.String() == val.CID.String() {
 				delete(expect, key)
 			}
 		}
@@ -206,7 +206,7 @@ func waitForMergeEvents(s *state.State, action WaitForSync) {
 				require.Fail(s.T, "doc index %d out of range", docIndex)
 			}
 			docID := s.DocIDs[0][docIndex].String()
-			actual, hasActual := node.P2p.ActualDAGHeads[docID]
+			actual, hasActual := node.P2P.ActualDAGHeads[docID]
 			if !hasActual || !actual.Decrypted {
 				expectDecrypted[docID] = struct{}{}
 			}
@@ -240,8 +240,8 @@ func waitForMergeEvents(s *state.State, action WaitForSync) {
 			if ok && head.String() == evt.Merge.Cid.String() {
 				delete(expect, getMergeEventKey(evt.Merge))
 			}
-			node.P2p.ActualDAGHeads[getMergeEventKey(evt.Merge)] = state.DocHeadState{
-				Cid:       evt.Merge.Cid,
+			node.P2P.ActualDAGHeads[getMergeEventKey(evt.Merge)] = state.DocHeadState{
+				CID:       evt.Merge.Cid,
 				Decrypted: evt.Decrypted,
 			}
 		}
@@ -271,16 +271,16 @@ func updateNetworkState(s *state.State, nodeID int, evt event.Update, ident immu
 
 	// update the actual document head on the node that updated it
 	// as the node created the document, it is already decrypted
-	node.P2p.ActualDAGHeads[getUpdateEventKey(evt)] = state.DocHeadState{Cid: evt.Cid, Decrypted: true}
+	node.P2P.ActualDAGHeads[getUpdateEventKey(evt)] = state.DocHeadState{CID: evt.Cid, Decrypted: true}
 
 	// update the expected document heads of replicator targets
-	for id := range node.P2p.Replicators {
+	for id := range node.P2P.Replicators {
 		// replicator target nodes push updates to source nodes
-		s.Nodes[id].P2p.ExpectedDAGHeads[getUpdateEventKey(evt)] = evt.Cid
+		s.Nodes[id].P2P.ExpectedDAGHeads[getUpdateEventKey(evt)] = evt.Cid
 	}
 
 	// update the expected document heads of connected nodes
-	for id := range node.P2p.Connections {
+	for id := range node.P2P.Connections {
 		if ident.HasValue() && ident.Value().Selector != strconv.Itoa(id) {
 			// If the document is created by a specific identity, only the node with the
 			// same index as the identity can initially access it.
@@ -289,12 +289,12 @@ func updateNetworkState(s *state.State, nodeID int, evt event.Update, ident immu
 			continue
 		}
 		// peer collection subscribers receive updates from any other subscriber node
-		if _, ok := s.Nodes[id].P2p.PeerCollections[collectionID]; ok {
-			s.Nodes[id].P2p.ExpectedDAGHeads[getUpdateEventKey(evt)] = evt.Cid
+		if _, ok := s.Nodes[id].P2P.PeerCollections[collectionID]; ok {
+			s.Nodes[id].P2P.ExpectedDAGHeads[getUpdateEventKey(evt)] = evt.Cid
 		}
 		// peer document subscribers receive updates from any other subscriber node
-		if _, ok := s.Nodes[id].P2p.PeerDocuments[state.NewColDocIndex(collectionID, docIndex)]; ok {
-			s.Nodes[id].P2p.ExpectedDAGHeads[getUpdateEventKey(evt)] = evt.Cid
+		if _, ok := s.Nodes[id].P2P.PeerDocuments[state.NewColDocIndex(collectionID, docIndex)]; ok {
+			s.Nodes[id].P2P.ExpectedDAGHeads[getUpdateEventKey(evt)] = evt.Cid
 		}
 	}
 }

--- a/tests/integration/events.go
+++ b/tests/integration/events.go
@@ -240,7 +240,10 @@ func waitForMergeEvents(s *state.State, action WaitForSync) {
 			if ok && head.String() == evt.Merge.Cid.String() {
 				delete(expect, getMergeEventKey(evt.Merge))
 			}
-			node.P2p.ActualDAGHeads[getMergeEventKey(evt.Merge)] = state.DocHeadState{Cid: evt.Merge.Cid, Decrypted: evt.Decrypted}
+			node.P2p.ActualDAGHeads[getMergeEventKey(evt.Merge)] = state.DocHeadState{
+				Cid:       evt.Merge.Cid,
+				Decrypted: evt.Decrypted,
+			}
 		}
 	}
 }

--- a/tests/integration/events.go
+++ b/tests/integration/events.go
@@ -30,68 +30,68 @@ const eventTimeout = 1 * time.Second
 // replicator completed event on the local event bus.
 //
 // Expected document heads will be updated for the targeted node.
-func waitForReplicatorConfigureEvent(s *state, cfg ConfigureReplicator) {
+func waitForReplicatorConfigureEvent(s *State, cfg ConfigureReplicator) {
 	select {
-	case _, ok := <-s.nodes[cfg.SourceNodeID].event.replicator.Message():
+	case _, ok := <-s.Nodes[cfg.SourceNodeID].Event.Replicator.Message():
 		if !ok {
-			require.Fail(s.t, "subscription closed waiting for replicator event")
+			require.Fail(s.T, "subscription closed waiting for replicator event")
 		}
 
 	case <-time.After(eventTimeout):
-		require.Fail(s.t, "timeout waiting for replicator event")
+		require.Fail(s.T, "timeout waiting for replicator event")
 	}
 
 	// all previous documents should be merged on the subscriber node
-	for key, val := range s.nodes[cfg.SourceNodeID].p2p.actualDAGHeads {
-		s.nodes[cfg.TargetNodeID].p2p.expectedDAGHeads[key] = val.cid
+	for key, val := range s.Nodes[cfg.SourceNodeID].P2p.ActualDAGHeads {
+		s.Nodes[cfg.TargetNodeID].P2p.ExpectedDAGHeads[key] = val.Cid
 	}
 
 	// update node connections and replicators
-	s.nodes[cfg.TargetNodeID].p2p.connections[cfg.SourceNodeID] = struct{}{}
-	s.nodes[cfg.SourceNodeID].p2p.connections[cfg.TargetNodeID] = struct{}{}
-	s.nodes[cfg.SourceNodeID].p2p.replicators[cfg.TargetNodeID] = struct{}{}
+	s.Nodes[cfg.TargetNodeID].P2p.Connections[cfg.SourceNodeID] = struct{}{}
+	s.Nodes[cfg.SourceNodeID].P2p.Connections[cfg.TargetNodeID] = struct{}{}
+	s.Nodes[cfg.SourceNodeID].P2p.Replicators[cfg.TargetNodeID] = struct{}{}
 }
 
 // waitForReplicatorDeleteEvent waits for a node to publish a
 // replicator completed event on the local event bus.
-func waitForReplicatorDeleteEvent(s *state, cfg DeleteReplicator) {
+func waitForReplicatorDeleteEvent(s *State, cfg DeleteReplicator) {
 	select {
-	case _, ok := <-s.nodes[cfg.SourceNodeID].event.replicator.Message():
+	case _, ok := <-s.Nodes[cfg.SourceNodeID].Event.Replicator.Message():
 		if !ok {
-			require.Fail(s.t, "subscription closed waiting for replicator event")
+			require.Fail(s.T, "subscription closed waiting for replicator event")
 		}
 
 	case <-time.After(eventTimeout):
-		require.Fail(s.t, "timeout waiting for replicator event")
+		require.Fail(s.T, "timeout waiting for replicator event")
 	}
 
-	delete(s.nodes[cfg.TargetNodeID].p2p.connections, cfg.SourceNodeID)
-	delete(s.nodes[cfg.SourceNodeID].p2p.connections, cfg.TargetNodeID)
-	delete(s.nodes[cfg.SourceNodeID].p2p.replicators, cfg.TargetNodeID)
+	delete(s.Nodes[cfg.TargetNodeID].P2p.Connections, cfg.SourceNodeID)
+	delete(s.Nodes[cfg.SourceNodeID].P2p.Connections, cfg.TargetNodeID)
+	delete(s.Nodes[cfg.SourceNodeID].P2p.Replicators, cfg.TargetNodeID)
 }
 
 // waitForSubscribeToCollectionEvent waits for a node to publish a
 // p2p topic completed event on the local event bus.
 //
 // Expected document heads will be updated for the subscriber node.
-func waitForSubscribeToCollectionEvent(s *state, action SubscribeToCollection) {
+func waitForSubscribeToCollectionEvent(s *State, action SubscribeToCollection) {
 	// update peer collections of target node
 	for _, collectionIndex := range action.CollectionIDs {
 		if collectionIndex == NonExistentCollectionID {
 			continue // don't track non existent collections
 		}
-		s.nodes[action.NodeID].p2p.peerCollections[collectionIndex] = struct{}{}
+		s.Nodes[action.NodeID].P2p.PeerCollections[collectionIndex] = struct{}{}
 	}
 }
 
 // waitForUnsubscribeToCollectionEvent waits for a node to publish a
 // p2p topic completed event on the local event bus.
-func waitForUnsubscribeToCollectionEvent(s *state, action UnsubscribeToCollection) {
+func waitForUnsubscribeToCollectionEvent(s *State, action UnsubscribeToCollection) {
 	for _, collectionIndex := range action.CollectionIDs {
 		if collectionIndex == NonExistentCollectionID {
 			continue // don't track non existent collections
 		}
-		delete(s.nodes[action.NodeID].p2p.peerCollections, collectionIndex)
+		delete(s.Nodes[action.NodeID].P2p.PeerCollections, collectionIndex)
 	}
 }
 
@@ -99,24 +99,24 @@ func waitForUnsubscribeToCollectionEvent(s *state, action UnsubscribeToCollectio
 // p2p topic completed event on the local event bus.
 //
 // Expected document heads will be updated for the subscriber node.
-func waitForSubscribeToDocumentEvent(s *state, action SubscribeToDocument) {
+func waitForSubscribeToDocumentEvent(s *State, action SubscribeToDocument) {
 	// update peer documents of target node
 	for _, colDocIndex := range action.DocIDs {
 		if colDocIndex.Doc == NonExistentDocID {
 			continue // don't track non existent documents
 		}
-		s.nodes[action.NodeID].p2p.peerDocuments[colDocIndex] = struct{}{}
+		s.Nodes[action.NodeID].P2p.PeerDocuments[colDocIndex] = struct{}{}
 	}
 }
 
 // waitForUnsubscribeToDocumentEvent waits for a node to publish a
 // p2p topic completed event on the local event bus.
-func waitForUnsubscribeToDocumentEvent(s *state, action UnsubscribeToDocument) {
+func waitForUnsubscribeToDocumentEvent(s *State, action UnsubscribeToDocument) {
 	for _, colDocIndex := range action.DocIDs {
 		if colDocIndex.Doc == NonExistentDocID {
 			continue // don't track non existent documents
 		}
-		delete(s.nodes[action.NodeID].p2p.peerDocuments, colDocIndex)
+		delete(s.Nodes[action.NodeID].P2p.PeerDocuments, colDocIndex)
 	}
 }
 
@@ -125,25 +125,25 @@ func waitForUnsubscribeToDocumentEvent(s *state, action UnsubscribeToDocument) {
 //
 // Expected document heads will be updated for any connected nodes.
 func waitForUpdateEvents(
-	s *state,
+	s *State,
 	nodeID immutable.Option[int],
 	collectionIndex int,
 	docIDs map[string]struct{},
 	ident immutable.Option[Identity],
 ) {
-	for i := 0; i < len(s.nodes); i++ {
+	for i := 0; i < len(s.Nodes); i++ {
 		if nodeID.HasValue() && nodeID.Value() != i {
 			continue // node is not selected
 		}
 
-		node := s.nodes[i]
-		if node.closed {
+		node := s.Nodes[i]
+		if node.Closed {
 			continue // node is closed
 		}
 
 		expect := make(map[string]struct{}, len(docIDs))
 
-		col := node.collections[collectionIndex]
+		col := node.Collections[collectionIndex]
 		if col.Version().IsBranchable {
 			expect[col.SchemaRoot()] = struct{}{}
 		}
@@ -154,24 +154,24 @@ func waitForUpdateEvents(
 		for len(expect) > 0 {
 			var evt event.Update
 			select {
-			case msg, ok := <-node.event.update.Message():
+			case msg, ok := <-node.Event.Update.Message():
 				if !ok {
-					require.Fail(s.t, "subscription closed waiting for update event", "Node %d", i)
+					require.Fail(s.T, "subscription closed waiting for update event", "Node %d", i)
 				}
 				evt = msg.Data.(event.Update)
 
 			case <-time.After(eventTimeout):
-				require.Fail(s.t, "timeout waiting for update event", "Node %d", i)
+				require.Fail(s.T, "timeout waiting for update event", "Node %d", i)
 			}
 
 			// make sure the event is expected
 			_, ok := expect[getUpdateEventKey(evt)]
-			require.True(s.t, ok, "unexpected document update", getUpdateEventKey(evt))
+			require.True(s.T, ok, "unexpected document update", getUpdateEventKey(evt))
 			delete(expect, getUpdateEventKey(evt))
 
 			// we only need to update the network state if the nodes
 			// are configured for networking
-			if s.isNetworkEnabled {
+			if s.IsNetworkEnabled {
 				updateNetworkState(s, i, evt, ident)
 			}
 		}
@@ -182,31 +182,31 @@ func waitForUpdateEvents(
 //
 // Will fail the test if an event is not received within the expected time interval to prevent tests
 // from running forever.
-func waitForMergeEvents(s *state, action WaitForSync) {
-	for nodeID := 0; nodeID < len(s.nodes); nodeID++ {
-		node := s.nodes[nodeID]
-		if node.closed {
+func waitForMergeEvents(s *State, action WaitForSync) {
+	for nodeID := 0; nodeID < len(s.Nodes); nodeID++ {
+		node := s.Nodes[nodeID]
+		if node.Closed {
 			continue // node is closed
 		}
 
-		expect := node.p2p.expectedDAGHeads
+		expect := node.P2p.ExpectedDAGHeads
 
 		// remove any heads that are already merged
 		// up to the expected head
-		for key, val := range node.p2p.actualDAGHeads {
-			if head, ok := expect[key]; ok && head.String() == val.cid.String() {
+		for key, val := range node.P2p.ActualDAGHeads {
+			if head, ok := expect[key]; ok && head.String() == val.Cid.String() {
 				delete(expect, key)
 			}
 		}
 
 		expectDecrypted := make(map[string]struct{}, len(action.Decrypted))
 		for _, docIndex := range action.Decrypted {
-			if len(s.docIDs[0]) <= docIndex {
-				require.Fail(s.t, "doc index %d out of range", docIndex)
+			if len(s.DocIDs[0]) <= docIndex {
+				require.Fail(s.T, "doc index %d out of range", docIndex)
 			}
-			docID := s.docIDs[0][docIndex].String()
-			actual, hasActual := node.p2p.actualDAGHeads[docID]
-			if !hasActual || !actual.decrypted {
+			docID := s.DocIDs[0][docIndex].String()
+			actual, hasActual := node.P2p.ActualDAGHeads[docID]
+			if !hasActual || !actual.Decrypted {
 				expectDecrypted[docID] = struct{}{}
 			}
 		}
@@ -220,14 +220,14 @@ func waitForMergeEvents(s *state, action WaitForSync) {
 		for len(expect) > 0 || len(expectDecrypted) > 0 {
 			var evt event.MergeComplete
 			select {
-			case msg, ok := <-node.event.merge.Message():
+			case msg, ok := <-node.Event.Merge.Message():
 				if !ok {
-					require.Fail(s.t, "subscription closed waiting for merge complete event")
+					require.Fail(s.T, "subscription closed waiting for merge complete event")
 				}
 				evt = msg.Data.(event.MergeComplete)
 
 			case <-time.After(30 * eventTimeout):
-				require.Fail(s.t, "timeout waiting for merge complete event")
+				require.Fail(s.T, "timeout waiting for merge complete event")
 			}
 
 			_, ok := expectDecrypted[evt.Merge.DocID]
@@ -239,45 +239,45 @@ func waitForMergeEvents(s *state, action WaitForSync) {
 			if ok && head.String() == evt.Merge.Cid.String() {
 				delete(expect, getMergeEventKey(evt.Merge))
 			}
-			node.p2p.actualDAGHeads[getMergeEventKey(evt.Merge)] = docHeadState{cid: evt.Merge.Cid, decrypted: evt.Decrypted}
+			node.P2p.ActualDAGHeads[getMergeEventKey(evt.Merge)] = DocHeadState{Cid: evt.Merge.Cid, Decrypted: evt.Decrypted}
 		}
 	}
 }
 
 // updateNetworkState updates the network state by checking which
 // nodes should receive the updated document in the given update event.
-func updateNetworkState(s *state, nodeID int, evt event.Update, ident immutable.Option[Identity]) {
+func updateNetworkState(s *State, nodeID int, evt event.Update, ident immutable.Option[Identity]) {
 	// find the correct collection index for this update
 	collectionID := -1
-	for i, c := range s.nodes[nodeID].collections {
+	for i, c := range s.Nodes[nodeID].Collections {
 		if c.Version().CollectionID == evt.CollectionID {
 			collectionID = i
 		}
 	}
 	docIndex := -1
 	if collectionID != -1 {
-		for i, docID := range s.docIDs[collectionID] {
+		for i, docID := range s.DocIDs[collectionID] {
 			if docID.String() == evt.DocID {
 				docIndex = i
 			}
 		}
 	}
 
-	node := s.nodes[nodeID]
+	node := s.Nodes[nodeID]
 
 	// update the actual document head on the node that updated it
 	// as the node created the document, it is already decrypted
-	node.p2p.actualDAGHeads[getUpdateEventKey(evt)] = docHeadState{cid: evt.Cid, decrypted: true}
+	node.P2p.ActualDAGHeads[getUpdateEventKey(evt)] = DocHeadState{Cid: evt.Cid, Decrypted: true}
 
 	// update the expected document heads of replicator targets
-	for id := range node.p2p.replicators {
+	for id := range node.P2p.Replicators {
 		// replicator target nodes push updates to source nodes
-		s.nodes[id].p2p.expectedDAGHeads[getUpdateEventKey(evt)] = evt.Cid
+		s.Nodes[id].P2p.ExpectedDAGHeads[getUpdateEventKey(evt)] = evt.Cid
 	}
 
 	// update the expected document heads of connected nodes
-	for id := range node.p2p.connections {
-		if ident.HasValue() && ident.Value().selector != strconv.Itoa(id) {
+	for id := range node.P2p.Connections {
+		if ident.HasValue() && ident.Value().Selector != strconv.Itoa(id) {
 			// If the document is created by a specific identity, only the node with the
 			// same index as the identity can initially access it.
 			// If this network state update comes from the adding of an actor relationship,
@@ -285,44 +285,44 @@ func updateNetworkState(s *state, nodeID int, evt event.Update, ident immutable.
 			continue
 		}
 		// peer collection subscribers receive updates from any other subscriber node
-		if _, ok := s.nodes[id].p2p.peerCollections[collectionID]; ok {
-			s.nodes[id].p2p.expectedDAGHeads[getUpdateEventKey(evt)] = evt.Cid
+		if _, ok := s.Nodes[id].P2p.PeerCollections[collectionID]; ok {
+			s.Nodes[id].P2p.ExpectedDAGHeads[getUpdateEventKey(evt)] = evt.Cid
 		}
 		// peer document subscribers receive updates from any other subscriber node
-		if _, ok := s.nodes[id].p2p.peerDocuments[NewColDocIndex(collectionID, docIndex)]; ok {
-			s.nodes[id].p2p.expectedDAGHeads[getUpdateEventKey(evt)] = evt.Cid
+		if _, ok := s.Nodes[id].P2p.PeerDocuments[NewColDocIndex(collectionID, docIndex)]; ok {
+			s.Nodes[id].P2p.ExpectedDAGHeads[getUpdateEventKey(evt)] = evt.Cid
 		}
 	}
 }
 
 // getEventsForUpdateDoc returns a map of docIDs that should be
 // published to the local event bus after an UpdateDoc action.
-func getEventsForUpdateDoc(s *state, action UpdateDoc) map[string]struct{} {
-	docID := s.docIDs[action.CollectionID][action.DocID]
+func getEventsForUpdateDoc(s *State, action UpdateDoc) map[string]struct{} {
+	docID := s.DocIDs[action.CollectionID][action.DocID]
 
 	docMap := make(map[string]any)
 	err := json.Unmarshal([]byte(action.Doc), &docMap)
-	require.NoError(s.t, err)
+	require.NoError(s.T, err)
 
 	return map[string]struct{}{
 		docID.String(): {},
 	}
 }
 
-func waitForSync(s *state, action WaitForSync) {
+func waitForSync(s *State, action WaitForSync) {
 	waitForMergeEvents(s, action)
 }
 
 // getEventsForUpdateWithFilter returns a map of docIDs that should be
 // published to the local event bus after a UpdateWithFilter action.
 func getEventsForUpdateWithFilter(
-	s *state,
+	s *State,
 	action UpdateWithFilter,
 	result *client.UpdateResult,
 ) map[string]struct{} {
 	var docPatch map[string]any
 	err := json.Unmarshal([]byte(action.Updater), &docPatch)
-	require.NoError(s.t, err)
+	require.NoError(s.T, err)
 
 	expect := make(map[string]struct{}, len(result.DocIDs))
 

--- a/tests/integration/explain.go
+++ b/tests/integration/explain.go
@@ -115,7 +115,7 @@ func executeExplainRequest(
 ) {
 	// Must have a non-empty request.
 	if action.Request == "" {
-		require.Fail(s.t, "Explain test must have a non-empty request.", s.testCase.Description)
+		require.Fail(s.t, "Explain test must have a non-empty request.")
 	}
 
 	// If no expected results are provided, then it's invalid use of this explain testing setup.
@@ -123,7 +123,7 @@ func executeExplainRequest(
 		action.ExpectedPatterns == nil &&
 		action.ExpectedTargets == nil &&
 		action.ExpectedFullGraph == nil {
-		require.Fail(s.t, "Atleast one expected explain parameter must be provided.", s.testCase.Description)
+		require.Fail(s.t, "Atleast one expected explain parameter must be provided.")
 	}
 
 	// If we expect an error, then all other expected results should be empty (they shouldn't be provided).
@@ -131,7 +131,7 @@ func executeExplainRequest(
 		(action.ExpectedFullGraph != nil ||
 			action.ExpectedPatterns != nil ||
 			action.ExpectedTargets != nil) {
-		require.Fail(s.t, "Expected error should not have other expected results with it.", s.testCase.Description)
+		require.Fail(s.t, "Expected error should not have other expected results with it.")
 	}
 
 	_, nodes := getNodesWithIDs(action.NodeID, s.nodes)
@@ -152,13 +152,12 @@ func assertExplainRequestResults(
 	// Check expected error matches actual error. If it does we are done.
 	if AssertErrors(
 		s.t,
-		s.testCase.Description,
 		actualResult.Errors,
 		action.ExpectedError,
 	) {
 		return
 	} else if action.ExpectedError != "" { // If didn't find a match but did expected an error, then fail.
-		assert.Fail(s.t, "Expected an error however none was raised.", s.testCase.Description)
+		assert.Fail(s.t, "Expected an error however none was raised.")
 	}
 
 	// Note: if returned gql result is `nil` this panics (the panic seems useful while testing).
@@ -173,7 +172,6 @@ func assertExplainRequestResults(
 			s.clientType,
 			action.ExpectedFullGraph,
 			resultantData,
-			s.testCase.Description,
 		)
 	}
 
@@ -181,13 +179,12 @@ func assertExplainRequestResults(
 	// explain graph nodes are in the correct expected ordering.
 	if action.ExpectedPatterns != nil {
 		// Trim away all attributes (non-plan nodes) from the returned full explain graph result.
-		actualResultWithoutAttributes := trimExplainAttributes(s.t, s.testCase.Description, resultantData)
+		actualResultWithoutAttributes := trimExplainAttributes(s.t, resultantData)
 		assertResultsEqual(
 			s.t,
 			s.clientType,
 			action.ExpectedPatterns,
 			actualResultWithoutAttributes,
-			s.testCase.Description,
 		)
 	}
 
@@ -217,7 +214,6 @@ func assertExplainTargetCase(
 			assert.Fail(
 				s.t,
 				"Expected target ["+targetCase.TargetNodeName+"], was not found in the explain graph.",
-				s.testCase.Description,
 			)
 		}
 
@@ -226,7 +222,6 @@ func assertExplainTargetCase(
 			s.clientType,
 			targetCase.ExpectedAttributes,
 			foundActualTarget,
-			s.testCase.Description,
 		)
 	}
 }
@@ -373,7 +368,6 @@ func trimSubNodes(graph any) any {
 // trimExplainAttributes trims away all keys that aren't plan nodes within the explain graph.
 func trimExplainAttributes(
 	t testing.TB,
-	description string,
 	actualResult any,
 ) map[string]any {
 	trimmedMap := copyMap(actualResult.(map[string]any))
@@ -386,19 +380,18 @@ func trimExplainAttributes(
 
 		switch v := value.(type) {
 		case map[string]any:
-			trimmedMap[key] = trimExplainAttributes(t, description, v)
+			trimmedMap[key] = trimExplainAttributes(t, v)
 
 		case []map[string]any:
-			trimmedMap[key] = trimExplainAttributesArray(t, description, v)
+			trimmedMap[key] = trimExplainAttributesArray(t, v)
 
 		case []any:
-			trimmedMap[key] = trimExplainAttributesArray(t, description, v)
+			trimmedMap[key] = trimExplainAttributesArray(t, v)
 
 		default:
 			assert.Fail(
 				t,
 				"Unsupported explain graph key-value type encountered: "+reflect.TypeOf(v).String(),
-				description,
 			)
 		}
 	}
@@ -409,14 +402,13 @@ func trimExplainAttributes(
 // trimExplainAttributesArray is a helper that runs trimExplainAttributes for each item in an array.
 func trimExplainAttributesArray[T any](
 	t testing.TB,
-	description string,
 	actualResult []T,
 ) []map[string]any {
 	trimmedArrayElements := []map[string]any{}
 	for _, valueItem := range actualResult {
 		trimmedArrayElements = append(
 			trimmedArrayElements,
-			trimExplainAttributes(t, description, valueItem),
+			trimExplainAttributes(t, valueItem),
 		)
 	}
 	return trimmedArrayElements

--- a/tests/integration/explain.go
+++ b/tests/integration/explain.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/sourcenetwork/defradb/client"
+	"github.com/sourcenetwork/defradb/tests/state"
 )
 
 var (
@@ -110,7 +111,7 @@ type ExplainRequest struct {
 }
 
 func executeExplainRequest(
-	s *State,
+	s *state.State,
 	action ExplainRequest,
 ) {
 	// Must have a non-empty request.
@@ -145,7 +146,7 @@ func executeExplainRequest(
 }
 
 func assertExplainRequestResults(
-	s *State,
+	s *state.State,
 	actualResult *client.GQLResult,
 	action ExplainRequest,
 ) {
@@ -198,7 +199,7 @@ func assertExplainRequestResults(
 }
 
 func assertExplainTargetCase(
-	s *State,
+	s *state.State,
 	targetCase PlanNodeTargetCase,
 	actualResults map[string]any,
 ) {

--- a/tests/integration/identity.go
+++ b/tests/integration/identity.go
@@ -12,124 +12,55 @@ package tests
 
 import (
 	"context"
-	"crypto/ed25519"
-	"math/rand"
 	"strconv"
 
-	"github.com/decred/dcrd/dcrec/secp256k1/v4"
 	"github.com/sourcenetwork/immutable"
 	"github.com/stretchr/testify/require"
 
 	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
-	"github.com/sourcenetwork/defradb/crypto"
+	"github.com/sourcenetwork/defradb/tests/state"
 )
-
-type IdentityType int
-
-const (
-	ClientIdentityType IdentityType = iota
-	NodeIdentityType
-)
-
-// Identity helps specify Identity type info and selector/index of Identity to use in a test case.
-type Identity struct {
-	// type of identity
-	Kind IdentityType
-
-	// Selector can be a valid identity index or a selecting pattern like "*".
-	// Note: "*" means to select all identities of the specified [kind] type.
-	Selector string
-}
 
 // NoIdentity returns an reference to an identity that represents no identity.
-func NoIdentity() immutable.Option[Identity] {
-	return immutable.None[Identity]()
+func NoIdentity() immutable.Option[state.Identity] {
+	return immutable.None[state.Identity]()
 }
 
 // AllClientIdentities returns user identity selector specified with the "*".
-func AllClientIdentities() immutable.Option[Identity] {
+func AllClientIdentities() immutable.Option[state.Identity] {
 	return immutable.Some(
-		Identity{
-			Kind:     ClientIdentityType,
+		state.Identity{
+			Kind:     state.ClientIdentityType,
 			Selector: "*",
 		},
 	)
 }
 
 // ClientIdentity returns a user identity at the given index.
-func ClientIdentity(indexSelector int) immutable.Option[Identity] {
+func ClientIdentity(indexSelector int) immutable.Option[state.Identity] {
 	return immutable.Some(
-		Identity{
-			Kind:     ClientIdentityType,
+		state.Identity{
+			Kind:     state.ClientIdentityType,
 			Selector: strconv.Itoa(indexSelector),
 		},
 	)
 }
 
 // ClientIdentity returns a node identity at the given index.
-func NodeIdentity(indexSelector int) immutable.Option[Identity] {
+func NodeIdentity(indexSelector int) immutable.Option[state.Identity] {
 	return immutable.Some(
-		Identity{
-			Kind:     NodeIdentityType,
+		state.Identity{
+			Kind:     state.NodeIdentityType,
 			Selector: strconv.Itoa(indexSelector),
 		},
 	)
 }
 
-// IdentityHolder holds an identity and the generated tokens for each target node.
-// This is used to cache the generated tokens for each node.
-type IdentityHolder struct {
-	// Identity is the identity.
-	Identity acpIdentity.Identity
-	// NodeTokens is a map of node index to the generated token for that node.
-	NodeTokens map[int]string
-}
-
-func newIdentityHolder(ident acpIdentity.Identity) *IdentityHolder {
-	return &IdentityHolder{
-		Identity:   ident,
-		NodeTokens: make(map[int]string),
-	}
-}
-
-// GetIdentity returns the identity for the given reference.
-// If the identity does not exist, it will be generated.
-func GetIdentity(s *State, identity immutable.Option[Identity]) acpIdentity.Identity {
-	if !identity.HasValue() {
-		return nil
-	}
-
-	// The selector must never be "*" here because this function returns a specific identity from the
-	// stored identities, if "*" string needs to be signaled to the acp module then it should be handled
-	// a call before this function.
-	if identity.Value().Selector == "*" {
-		require.Fail(s.T, "Used the \"*\" selector for identity incorrectly.")
-	}
-	return GetIdentityHolder(s, identity.Value()).Identity
-}
-
-// GetIdentityHolder returns the identity holder for the given reference.
-// If the identity does not exist, it will be generated.
-func GetIdentityHolder(s *State, identity Identity) *IdentityHolder {
-	ident, ok := s.Identities[identity]
-	if ok {
-		return ident
-	}
-
-	keyType := crypto.KeyTypeSecp256k1
-	if k, ok := s.IdentityTypes[identity]; ok {
-		keyType = k
-	}
-
-	s.Identities[identity] = newIdentityHolder(generateIdentity(s, keyType))
-	return s.Identities[identity]
-}
-
 // getIdentityForRequest returns the identity for the given reference and node index.
 // It prepares the identity for a request by generating a token if needed, i.e. it will
 // return an identity with [Identity.BearerToken] set.
-func getIdentityForRequest(s *State, identity Identity, nodeIndex int) acpIdentity.Identity {
-	identHolder := GetIdentityHolder(s, identity)
+func getIdentityForRequest(s *state.State, identity state.Identity, nodeIndex int) acpIdentity.Identity {
+	identHolder := state.GetIdentityHolder(s, identity)
 	ident := identHolder.Identity
 
 	if fullIdent, ok := ident.(acpIdentity.FullIdentity); ok {
@@ -148,40 +79,13 @@ func getIdentityForRequest(s *State, identity Identity, nodeIndex int) acpIdenti
 	return ident
 }
 
-// Generate the keys using predefined seed so that multiple runs yield the same private key.
-// This is important for stuff like the change detector.
-func generateIdentity(s *State, keyType crypto.KeyType) acpIdentity.Identity {
-	source := rand.NewSource(int64(s.NextIdentityGenSeed))
-	r := rand.New(source)
-
-	var privateKey crypto.PrivateKey
-	if keyType == crypto.KeyTypeSecp256k1 {
-		privKey, err := secp256k1.GeneratePrivateKeyFromRand(r)
-		require.NoError(s.T, err)
-		privateKey = crypto.NewPrivateKey(privKey)
-	} else if keyType == crypto.KeyTypeEd25519 {
-		_, privKey, err := ed25519.GenerateKey(r)
-		require.NoError(s.T, err)
-		privateKey = crypto.NewPrivateKey(privKey)
-	} else {
-		require.Fail(s.T, "Unsupported signing algorithm")
-	}
-
-	s.NextIdentityGenSeed++
-
-	identity, err := acpIdentity.FromPrivateKey(privateKey)
-	require.NoError(s.T, err)
-
-	return identity
-}
-
 // getContextWithIdentity returns a context with the identity for the given reference and node index.
 // If the identity does not exist, it will be generated.
 // The identity added to the context is prepared for a request, i.e. its [Identity.BearerToken] is set.
 func getContextWithIdentity(
 	ctx context.Context,
-	s *State,
-	identity immutable.Option[Identity],
+	s *state.State,
+	identity immutable.Option[state.Identity],
 	nodeIndex int,
 ) context.Context {
 	if !identity.HasValue() {
@@ -199,12 +103,12 @@ func getContextWithIdentity(
 	)
 }
 
-func getIdentityDID(s *State, identity immutable.Option[Identity]) string {
+func getIdentityDID(s *state.State, identity immutable.Option[state.Identity]) string {
 	if identity.HasValue() {
 		if identity.Value().Selector == "*" {
 			return identity.Value().Selector
 		}
-		return GetIdentity(s, identity).DID()
+		return state.GetIdentity(s, identity).DID()
 	}
 	return ""
 }

--- a/tests/integration/identity.go
+++ b/tests/integration/identity.go
@@ -103,7 +103,7 @@ func getIdentity(s *state, identity immutable.Option[Identity]) acpIdentity.Iden
 	// stored identities, if "*" string needs to be signaled to the acp module then it should be handled
 	// a call before this function.
 	if identity.Value().selector == "*" {
-		require.Fail(s.t, "Used the \"*\" selector for identity incorrectly.", s.testCase.Description)
+		require.Fail(s.t, "Used the \"*\" selector for identity incorrectly.")
 	}
 	return getIdentityHolder(s, identity.Value()).Identity
 }
@@ -117,7 +117,7 @@ func getIdentityHolder(s *state, identity Identity) *identityHolder {
 	}
 
 	keyType := crypto.KeyTypeSecp256k1
-	if k, ok := s.testCase.IdentityTypes[identity]; ok {
+	if k, ok := s.IdentityTypes[identity]; ok {
 		keyType = k
 	}
 
@@ -164,7 +164,7 @@ func generateIdentity(s *state, keyType crypto.KeyType) acpIdentity.Identity {
 		require.NoError(s.t, err)
 		privateKey = crypto.NewPrivateKey(privKey)
 	} else {
-		require.Fail(s.t, "Unsupported signing algorithm", s.testCase.Description)
+		require.Fail(s.t, "Unsupported signing algorithm")
 	}
 
 	s.nextIdentityGenSeed++

--- a/tests/integration/index/query_performance_test.go
+++ b/tests/integration/index/query_performance_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/sourcenetwork/defradb/tests/gen"
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	"github.com/sourcenetwork/defradb/tests/state"
 )
 
 func TestQueryPerformance_Simple(t *testing.T) {
@@ -68,7 +69,7 @@ func TestQueryPerformance_Simple(t *testing.T) {
 						}
 					}`,
 				},
-				FocusClients: []testUtils.ClientType{testUtils.GoClientType},
+				FocusClients: []state.ClientType{testUtils.GoClientType},
 				Factor:       2,
 			},
 		},
@@ -128,7 +129,7 @@ func TestQueryPerformance_WithFloat32(t *testing.T) {
 						}
 					}`,
 				},
-				FocusClients: []testUtils.ClientType{testUtils.GoClientType},
+				FocusClients: []state.ClientType{testUtils.GoClientType},
 				Factor:       2,
 			},
 		},

--- a/tests/integration/issues/2566_test.go
+++ b/tests/integration/issues/2566_test.go
@@ -18,13 +18,14 @@ import (
 	"github.com/sourcenetwork/immutable"
 
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	"github.com/sourcenetwork/defradb/tests/state"
 )
 
 // This test documents https://github.com/sourcenetwork/defradb/issues/2566
 func TestP2PUpdate_WithPNCounterSimultaneousOverflowIncrement_DoesNotReachConsitency(t *testing.T) {
 	test := testUtils.TestCase{
 		SupportedClientTypes: immutable.Some(
-			[]testUtils.ClientType{
+			[]state.ClientType{
 				// This test only supports the Go client at the moment due to
 				// https://github.com/sourcenetwork/defradb/issues/2569
 				testUtils.GoClientType,
@@ -70,14 +71,14 @@ func TestP2PUpdate_WithPNCounterSimultaneousOverflowIncrement_DoesNotReachConsit
 			},
 			testUtils.SubscribeToDocument{
 				NodeID: 0,
-				DocIDs: []testUtils.ColDocIndex{
-					testUtils.NewColDocIndex(0, 0),
+				DocIDs: []state.ColDocIndex{
+					state.NewColDocIndex(0, 0),
 				},
 			},
 			testUtils.SubscribeToDocument{
 				NodeID: 1,
-				DocIDs: []testUtils.ColDocIndex{
-					testUtils.NewColDocIndex(0, 0),
+				DocIDs: []state.ColDocIndex{
+					state.NewColDocIndex(0, 0),
 				},
 			},
 			testUtils.UpdateDoc{
@@ -132,7 +133,7 @@ func TestP2PUpdate_WithPNCounterSimultaneousOverflowIncrement_DoesNotReachConsit
 func TestP2PUpdate_WithPNCounterSimultaneousOverflowDecrement_DoesNotReachConsitency(t *testing.T) {
 	test := testUtils.TestCase{
 		SupportedClientTypes: immutable.Some(
-			[]testUtils.ClientType{
+			[]state.ClientType{
 				// This test only supports the Go client at the moment due to
 				// https://github.com/sourcenetwork/defradb/issues/2569
 				testUtils.GoClientType,
@@ -178,14 +179,14 @@ func TestP2PUpdate_WithPNCounterSimultaneousOverflowDecrement_DoesNotReachConsit
 			},
 			testUtils.SubscribeToDocument{
 				NodeID: 0,
-				DocIDs: []testUtils.ColDocIndex{
-					testUtils.NewColDocIndex(0, 0),
+				DocIDs: []state.ColDocIndex{
+					state.NewColDocIndex(0, 0),
 				},
 			},
 			testUtils.SubscribeToDocument{
 				NodeID: 1,
-				DocIDs: []testUtils.ColDocIndex{
-					testUtils.NewColDocIndex(0, 0),
+				DocIDs: []state.ColDocIndex{
+					state.NewColDocIndex(0, 0),
 				},
 			},
 			testUtils.UpdateDoc{

--- a/tests/integration/issues/2569_test.go
+++ b/tests/integration/issues/2569_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sourcenetwork/immutable"
 
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	"github.com/sourcenetwork/defradb/tests/state"
 )
 
 // These tests document https://github.com/sourcenetwork/defradb/issues/2569
@@ -25,7 +26,7 @@ import (
 func TestP2PUpdate_WithPNCounterFloatOverflowIncrement_PreventsQuerying(t *testing.T) {
 	test := testUtils.TestCase{
 		SupportedClientTypes: immutable.Some(
-			[]testUtils.ClientType{
+			[]state.ClientType{
 				// This issue only affects the http and the cli clients
 				testUtils.HTTPClientType,
 				testUtils.CLIClientType,
@@ -70,7 +71,7 @@ func TestP2PUpdate_WithPNCounterFloatOverflowIncrement_PreventsQuerying(t *testi
 func TestP2PUpdate_WithPNCounterFloatOverflowDecrement_PreventsQuerying(t *testing.T) {
 	test := testUtils.TestCase{
 		SupportedClientTypes: immutable.Some(
-			[]testUtils.ClientType{
+			[]state.ClientType{
 				// This issue only affects the http and the cli clients
 				testUtils.HTTPClientType,
 				testUtils.CLIClientType,
@@ -115,7 +116,7 @@ func TestP2PUpdate_WithPNCounterFloatOverflowDecrement_PreventsQuerying(t *testi
 func TestP2PUpdate_WithPNCounterFloatOverflow_PreventsCollectionGet(t *testing.T) {
 	test := testUtils.TestCase{
 		SupportedClientTypes: immutable.Some(
-			[]testUtils.ClientType{
+			[]state.ClientType{
 				// This issue only affects the http and the cli clients
 				testUtils.HTTPClientType,
 				testUtils.CLIClientType,

--- a/tests/integration/lens.go
+++ b/tests/integration/lens.go
@@ -54,16 +54,16 @@ type ConfigureMigration struct {
 }
 
 func configureMigration(
-	s *state,
+	s *State,
 	action ConfigureMigration,
 ) {
-	_, nodes := getNodesWithIDs(action.NodeID, s.nodes)
+	_, nodes := getNodesWithIDs(action.NodeID, s.Nodes)
 	for _, node := range nodes {
 		txn := getTransaction(s, node.Client, action.TransactionID, action.ExpectedError)
-		ctx := db.InitContext(s.ctx, txn)
+		ctx := db.InitContext(s.Ctx, txn)
 		err := node.SetMigration(ctx, action.LensConfig)
-		expectedErrorRaised := AssertError(s.t, err, action.ExpectedError)
+		expectedErrorRaised := AssertError(s.T, err, action.ExpectedError)
 
-		assertExpectedErrorRaised(s.t, action.ExpectedError, expectedErrorRaised)
+		assertExpectedErrorRaised(s.T, action.ExpectedError, expectedErrorRaised)
 	}
 }

--- a/tests/integration/lens.go
+++ b/tests/integration/lens.go
@@ -62,8 +62,8 @@ func configureMigration(
 		txn := getTransaction(s, node.Client, action.TransactionID, action.ExpectedError)
 		ctx := db.InitContext(s.ctx, txn)
 		err := node.SetMigration(ctx, action.LensConfig)
-		expectedErrorRaised := AssertError(s.t, s.testCase.Description, err, action.ExpectedError)
+		expectedErrorRaised := AssertError(s.t, err, action.ExpectedError)
 
-		assertExpectedErrorRaised(s.t, s.testCase.Description, action.ExpectedError, expectedErrorRaised)
+		assertExpectedErrorRaised(s.t, action.ExpectedError, expectedErrorRaised)
 	}
 }

--- a/tests/integration/lens.go
+++ b/tests/integration/lens.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/internal/db"
 	"github.com/sourcenetwork/defradb/node"
+	"github.com/sourcenetwork/defradb/tests/state"
 )
 
 const (
@@ -54,7 +55,7 @@ type ConfigureMigration struct {
 }
 
 func configureMigration(
-	s *State,
+	s *state.State,
 	action ConfigureMigration,
 ) {
 	_, nodes := getNodesWithIDs(action.NodeID, s.Nodes)

--- a/tests/integration/mutation/create/embeddings/embedding_test.go
+++ b/tests/integration/mutation/create/embeddings/embedding_test.go
@@ -17,12 +17,13 @@ import (
 	"github.com/sourcenetwork/immutable"
 
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	"github.com/sourcenetwork/defradb/tests/state"
 )
 
 func TestMutationCreate_WithMultipleEmbeddingFields_ShouldSucceed(t *testing.T) {
 	test := testUtils.TestCase{
 		Description: "Simple create mutation with multiple embedding fields",
-		SupportedClientTypes: immutable.Some([]testUtils.ClientType{
+		SupportedClientTypes: immutable.Some([]state.ClientType{
 			// Embedding test with mutations are currently only compatible with the Go client.
 			// The docID is updated by collection. Create after vector embedding generation and
 			// the HTTP and CLI clients don't receive that updated docID. This causes the waitForUpdateEvents

--- a/tests/integration/mutation/update/crdt/pcounter_test.go
+++ b/tests/integration/mutation/update/crdt/pcounter_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sourcenetwork/immutable"
 
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	"github.com/sourcenetwork/defradb/tests/state"
 )
 
 func TestPCounterUpdate_IntKindWithNegativeIncrement_ShouldError(t *testing.T) {
@@ -123,7 +124,7 @@ func TestPCounterUpdate_IntKindWithPositiveIncrement_ShouldIncrement(t *testing.
 func TestPCounterUpdate_IntKindWithPositiveIncrementOverflow_RollsOverToMinInt64(t *testing.T) {
 	test := testUtils.TestCase{
 		Description: "Positive increments of a P Counter with Int type causing overflow behaviour",
-		SupportedClientTypes: immutable.Some([]testUtils.ClientType{
+		SupportedClientTypes: immutable.Some([]state.ClientType{
 			// JS client does not support 64 bit integers
 			// See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number#number_encoding
 			testUtils.GoClientType,

--- a/tests/integration/mutation/update/crdt/pncounter_test.go
+++ b/tests/integration/mutation/update/crdt/pncounter_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sourcenetwork/immutable"
 
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	"github.com/sourcenetwork/defradb/tests/state"
 )
 
 func TestPNCounterUpdate_IntKindWithPositiveIncrement_ShouldIncrement(t *testing.T) {
@@ -76,7 +77,7 @@ func TestPNCounterUpdate_IntKindWithPositiveIncrement_ShouldIncrement(t *testing
 func TestPNCounterUpdate_IntKindWithPositiveIncrementOverflow_RollsOverToMinInt64(t *testing.T) {
 	test := testUtils.TestCase{
 		Description: "Positive increments of a PN Counter with Int type causing overflow behaviour",
-		SupportedClientTypes: immutable.Some([]testUtils.ClientType{
+		SupportedClientTypes: immutable.Some([]state.ClientType{
 			// JS client does not support 64 bit integers
 			// See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number#number_encoding
 			testUtils.GoClientType,
@@ -296,7 +297,7 @@ func TestPNCounterUpdate_FloatKindWithPositiveIncrementOverflow_PositiveInf(t *t
 	test := testUtils.TestCase{
 		Description: "Positive increments of a PN Counter with Float type and overflow",
 		SupportedClientTypes: immutable.Some(
-			[]testUtils.ClientType{
+			[]state.ClientType{
 				// This test only supports the Go client at the moment due to
 				// https://github.com/sourcenetwork/defradb/issues/2569
 				testUtils.GoClientType,
@@ -350,7 +351,7 @@ func TestPNCounterUpdate_FloatKindWithDecrementOverflow_NegativeInf(t *testing.T
 	test := testUtils.TestCase{
 		Description: "Positive increments of a PN Counter with Float type and overflow",
 		SupportedClientTypes: immutable.Some(
-			[]testUtils.ClientType{
+			[]state.ClientType{
 				// This test only supports the Go client at the moment due to
 				// https://github.com/sourcenetwork/defradb/issues/2569
 				testUtils.GoClientType,

--- a/tests/integration/mutation/update/embeddings/embedding_test.go
+++ b/tests/integration/mutation/update/embeddings/embedding_test.go
@@ -17,12 +17,13 @@ import (
 	"github.com/sourcenetwork/immutable"
 
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	"github.com/sourcenetwork/defradb/tests/state"
 )
 
 func TestMutationUpdate_WithMultipleEmbeddingFields_ShouldSucceed(t *testing.T) {
 	test := testUtils.TestCase{
 		Description: "Simple update mutation",
-		SupportedClientTypes: immutable.Some([]testUtils.ClientType{
+		SupportedClientTypes: immutable.Some([]state.ClientType{
 			// Embedding test with updates are currently only compatible with the Go client.
 			// The docID is updated by collection.Create after vector embedding generation and
 			// the HTTP and CLI clients don't receive that updated docID. This causes the waitForUpdateEvents
@@ -101,7 +102,7 @@ func TestMutationUpdate_WithMultipleEmbeddingFields_ShouldSucceed(t *testing.T) 
 func TestMutationUpdate_UserDefinedVectorEmbeddingDoesNotTriggerGeneration_ShouldSucceed(t *testing.T) {
 	test := testUtils.TestCase{
 		Description: "Simple update mutation with manually defined vector embedding",
-		SupportedClientTypes: immutable.Some([]testUtils.ClientType{
+		SupportedClientTypes: immutable.Some([]state.ClientType{
 			// Embedding test with updates are currently only compatible with the Go client.
 			// The docID is updated by collection.Create after vector embedding generation and
 			// the HTTP and CLI clients don't receive that updated docID. This causes the waitForUpdateEvents
@@ -157,7 +158,7 @@ func TestMutationUpdate_UserDefinedVectorEmbeddingDoesNotTriggerGeneration_Shoul
 func TestMutationUpdate_FieldsForEmbeddingNotUpdatedDoesNotTriggerGeneration_ShouldSucceed(t *testing.T) {
 	test := testUtils.TestCase{
 		Description: "Simple update mutation with manually defined vector embedding",
-		SupportedClientTypes: immutable.Some([]testUtils.ClientType{
+		SupportedClientTypes: immutable.Some([]state.ClientType{
 			// Embedding test with updates are currently only compatible with the Go client.
 			// The docID is updated by collection.Create after vector embedding generation and
 			// the HTTP and CLI clients don't receive that updated docID. This causes the waitForUpdateEvents

--- a/tests/integration/net/one_to_many/peer/with_create_update_test.go
+++ b/tests/integration/net/one_to_many/peer/with_create_update_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sourcenetwork/immutable"
 
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	"github.com/sourcenetwork/defradb/tests/state"
 )
 
 // This test asserts that relational documents do not fail to sync if their related
@@ -60,8 +61,8 @@ func TestP2POneToManyPeerWithCreateUpdateLinkingSyncedDocToUnsyncedDoc(t *testin
 			},
 			testUtils.SubscribeToDocument{
 				NodeID: 1,
-				DocIDs: []testUtils.ColDocIndex{
-					testUtils.NewColDocIndex(1, 0),
+				DocIDs: []state.ColDocIndex{
+					state.NewColDocIndex(1, 0),
 				},
 			},
 			testUtils.UpdateDoc{

--- a/tests/integration/net/simple/peer/crdt/pcounter_test.go
+++ b/tests/integration/net/simple/peer/crdt/pcounter_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sourcenetwork/immutable"
 
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	"github.com/sourcenetwork/defradb/tests/state"
 )
 
 func TestP2PUpdate_WithPCounter_NoError(t *testing.T) {
@@ -44,8 +45,8 @@ func TestP2PUpdate_WithPCounter_NoError(t *testing.T) {
 			},
 			testUtils.SubscribeToDocument{
 				NodeID: 1,
-				DocIDs: []testUtils.ColDocIndex{
-					testUtils.NewColDocIndex(0, 0),
+				DocIDs: []state.ColDocIndex{
+					state.NewColDocIndex(0, 0),
 				},
 			},
 			testUtils.UpdateDoc{
@@ -102,14 +103,14 @@ func TestP2PUpdate_WithPCounterSimultaneousUpdate_NoError(t *testing.T) {
 			},
 			testUtils.SubscribeToDocument{
 				NodeID: 0,
-				DocIDs: []testUtils.ColDocIndex{
-					testUtils.NewColDocIndex(0, 0),
+				DocIDs: []state.ColDocIndex{
+					state.NewColDocIndex(0, 0),
 				},
 			},
 			testUtils.SubscribeToDocument{
 				NodeID: 1,
-				DocIDs: []testUtils.ColDocIndex{
-					testUtils.NewColDocIndex(0, 0),
+				DocIDs: []state.ColDocIndex{
+					state.NewColDocIndex(0, 0),
 				},
 			},
 			testUtils.UpdateDoc{

--- a/tests/integration/net/simple/peer/crdt/pncounter_test.go
+++ b/tests/integration/net/simple/peer/crdt/pncounter_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sourcenetwork/immutable"
 
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	"github.com/sourcenetwork/defradb/tests/state"
 )
 
 func TestP2PUpdate_WithPNCounter_NoError(t *testing.T) {
@@ -44,8 +45,8 @@ func TestP2PUpdate_WithPNCounter_NoError(t *testing.T) {
 			},
 			testUtils.SubscribeToDocument{
 				NodeID: 1,
-				DocIDs: []testUtils.ColDocIndex{
-					testUtils.NewColDocIndex(0, 0),
+				DocIDs: []state.ColDocIndex{
+					state.NewColDocIndex(0, 0),
 				},
 			},
 			testUtils.UpdateDoc{
@@ -102,14 +103,14 @@ func TestP2PUpdate_WithPNCounterSimultaneousUpdate_NoError(t *testing.T) {
 			},
 			testUtils.SubscribeToDocument{
 				NodeID: 0,
-				DocIDs: []testUtils.ColDocIndex{
-					testUtils.NewColDocIndex(0, 0),
+				DocIDs: []state.ColDocIndex{
+					state.NewColDocIndex(0, 0),
 				},
 			},
 			testUtils.SubscribeToDocument{
 				NodeID: 1,
-				DocIDs: []testUtils.ColDocIndex{
-					testUtils.NewColDocIndex(0, 0),
+				DocIDs: []state.ColDocIndex{
+					state.NewColDocIndex(0, 0),
 				},
 			},
 			testUtils.UpdateDoc{

--- a/tests/integration/net/simple/peer/subscribe/document/with_add_get_remove_test.go
+++ b/tests/integration/net/simple/peer/subscribe/document/with_add_get_remove_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	"github.com/sourcenetwork/defradb/tests/state"
 )
 
 func TestP2PDocumentAddRemoveGetSingle(t *testing.T) {
@@ -39,19 +40,19 @@ func TestP2PDocumentAddRemoveGetSingle(t *testing.T) {
 			},
 			testUtils.SubscribeToDocument{
 				NodeID: 1,
-				DocIDs: []testUtils.ColDocIndex{
-					testUtils.NewColDocIndex(0, 0),
+				DocIDs: []state.ColDocIndex{
+					state.NewColDocIndex(0, 0),
 				},
 			},
 			testUtils.UnsubscribeToDocument{
 				NodeID: 1,
-				DocIDs: []testUtils.ColDocIndex{
-					testUtils.NewColDocIndex(0, 0),
+				DocIDs: []state.ColDocIndex{
+					state.NewColDocIndex(0, 0),
 				},
 			},
 			testUtils.GetAllP2PDocuments{
 				NodeID:         1,
-				ExpectedDocIDs: []testUtils.ColDocIndex{},
+				ExpectedDocIDs: []state.ColDocIndex{},
 			},
 		},
 	}
@@ -87,21 +88,21 @@ func TestP2PDocumentAddRemoveGetMultiple(t *testing.T) {
 			},
 			testUtils.SubscribeToDocument{
 				NodeID: 1,
-				DocIDs: []testUtils.ColDocIndex{
-					testUtils.NewColDocIndex(0, 0),
-					testUtils.NewColDocIndex(0, 1),
+				DocIDs: []state.ColDocIndex{
+					state.NewColDocIndex(0, 0),
+					state.NewColDocIndex(0, 1),
 				},
 			},
 			testUtils.UnsubscribeToDocument{
 				NodeID: 1,
-				DocIDs: []testUtils.ColDocIndex{
-					testUtils.NewColDocIndex(0, 0),
+				DocIDs: []state.ColDocIndex{
+					state.NewColDocIndex(0, 0),
 				},
 			},
 			testUtils.GetAllP2PDocuments{
 				NodeID: 1,
-				ExpectedDocIDs: []testUtils.ColDocIndex{
-					testUtils.NewColDocIndex(0, 1),
+				ExpectedDocIDs: []state.ColDocIndex{
+					state.NewColDocIndex(0, 1),
 				},
 			},
 		},

--- a/tests/integration/net/simple/peer/subscribe/document/with_add_get_test.go
+++ b/tests/integration/net/simple/peer/subscribe/document/with_add_get_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	"github.com/sourcenetwork/defradb/tests/state"
 )
 
 func TestP2PDocumentAddGetSingle(t *testing.T) {
@@ -39,14 +40,14 @@ func TestP2PDocumentAddGetSingle(t *testing.T) {
 			},
 			testUtils.SubscribeToDocument{
 				NodeID: 1,
-				DocIDs: []testUtils.ColDocIndex{
-					testUtils.NewColDocIndex(0, 0),
+				DocIDs: []state.ColDocIndex{
+					state.NewColDocIndex(0, 0),
 				},
 			},
 			testUtils.GetAllP2PDocuments{
 				NodeID: 1,
-				ExpectedDocIDs: []testUtils.ColDocIndex{
-					testUtils.NewColDocIndex(0, 0),
+				ExpectedDocIDs: []state.ColDocIndex{
+					state.NewColDocIndex(0, 0),
 				},
 			},
 		},
@@ -90,16 +91,16 @@ func TestP2PDocumentAddGetMultiple(t *testing.T) {
 			},
 			testUtils.SubscribeToDocument{
 				NodeID: 1,
-				DocIDs: []testUtils.ColDocIndex{
-					testUtils.NewColDocIndex(0, 0),
-					testUtils.NewColDocIndex(0, 1),
+				DocIDs: []state.ColDocIndex{
+					state.NewColDocIndex(0, 0),
+					state.NewColDocIndex(0, 1),
 				},
 			},
 			testUtils.GetAllP2PDocuments{
 				NodeID: 1,
-				ExpectedDocIDs: []testUtils.ColDocIndex{
-					testUtils.NewColDocIndex(0, 0),
-					testUtils.NewColDocIndex(0, 1),
+				ExpectedDocIDs: []state.ColDocIndex{
+					state.NewColDocIndex(0, 0),
+					state.NewColDocIndex(0, 1),
 				},
 			},
 		},

--- a/tests/integration/net/simple/peer/subscribe/document/with_add_remove_test.go
+++ b/tests/integration/net/simple/peer/subscribe/document/with_add_remove_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sourcenetwork/immutable"
 
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	"github.com/sourcenetwork/defradb/tests/state"
 )
 
 func TestP2PDocumentAddAndRemoveSingle(t *testing.T) {
@@ -41,14 +42,14 @@ func TestP2PDocumentAddAndRemoveSingle(t *testing.T) {
 			},
 			testUtils.SubscribeToDocument{
 				NodeID: 1,
-				DocIDs: []testUtils.ColDocIndex{
-					testUtils.NewColDocIndex(0, 0),
+				DocIDs: []state.ColDocIndex{
+					state.NewColDocIndex(0, 0),
 				},
 			},
 			testUtils.UnsubscribeToDocument{
 				NodeID: 1,
-				DocIDs: []testUtils.ColDocIndex{
-					testUtils.NewColDocIndex(0, 0),
+				DocIDs: []state.ColDocIndex{
+					state.NewColDocIndex(0, 0),
 				},
 			},
 			testUtils.UpdateDoc{
@@ -110,15 +111,15 @@ func TestP2PDocumentAddAndRemoveMultiple(t *testing.T) {
 			},
 			testUtils.SubscribeToDocument{
 				NodeID: 1,
-				DocIDs: []testUtils.ColDocIndex{
-					testUtils.NewColDocIndex(0, 0),
-					testUtils.NewColDocIndex(0, 1),
+				DocIDs: []state.ColDocIndex{
+					state.NewColDocIndex(0, 0),
+					state.NewColDocIndex(0, 1),
 				},
 			},
 			testUtils.UnsubscribeToDocument{
 				NodeID: 1,
-				DocIDs: []testUtils.ColDocIndex{
-					testUtils.NewColDocIndex(0, 0),
+				DocIDs: []state.ColDocIndex{
+					state.NewColDocIndex(0, 0),
 				},
 			},
 			testUtils.UpdateDoc{
@@ -202,14 +203,14 @@ func TestP2PDocumentAddSingleAndRemoveErroneous(t *testing.T) {
 			},
 			testUtils.SubscribeToDocument{
 				NodeID: 1,
-				DocIDs: []testUtils.ColDocIndex{
-					testUtils.NewColDocIndex(0, 0),
+				DocIDs: []state.ColDocIndex{
+					state.NewColDocIndex(0, 0),
 				},
 			},
 			testUtils.UnsubscribeToDocument{
 				NodeID: 1,
-				DocIDs: []testUtils.ColDocIndex{
-					testUtils.NewColDocIndex(0, testUtils.NonExistentDocID),
+				DocIDs: []state.ColDocIndex{
+					state.NewColDocIndex(0, testUtils.NonExistentDocID),
 				},
 				ExpectedError: "malformed document ID, missing either version or cid",
 			},
@@ -268,13 +269,13 @@ func TestP2PDocumentAddSingleAndRemoveNone(t *testing.T) {
 			},
 			testUtils.SubscribeToDocument{
 				NodeID: 1,
-				DocIDs: []testUtils.ColDocIndex{
-					testUtils.NewColDocIndex(0, 0),
+				DocIDs: []state.ColDocIndex{
+					state.NewColDocIndex(0, 0),
 				},
 			},
 			testUtils.UnsubscribeToDocument{
 				NodeID: 1,
-				DocIDs: []testUtils.ColDocIndex{},
+				DocIDs: []state.ColDocIndex{},
 			},
 			testUtils.UpdateDoc{
 				NodeID:       immutable.Some(0),

--- a/tests/integration/net/simple/peer/subscribe/document/with_add_test.go
+++ b/tests/integration/net/simple/peer/subscribe/document/with_add_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sourcenetwork/immutable"
 
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	"github.com/sourcenetwork/defradb/tests/state"
 )
 
 func TestP2PDocument_AddSingle_ShouldSync(t *testing.T) {
@@ -48,8 +49,8 @@ func TestP2PDocument_AddSingle_ShouldSync(t *testing.T) {
 			},
 			testUtils.SubscribeToDocument{
 				NodeID: 1,
-				DocIDs: []testUtils.ColDocIndex{
-					testUtils.NewColDocIndex(0, 0),
+				DocIDs: []state.ColDocIndex{
+					state.NewColDocIndex(0, 0),
 				},
 			},
 			testUtils.UpdateDoc{
@@ -124,7 +125,7 @@ func TestP2PDocument_AddSingleErroneousDocID_ShouldNotSync(t *testing.T) {
 			},
 			testUtils.SubscribeToDocument{
 				NodeID:        1,
-				DocIDs:        []testUtils.ColDocIndex{testUtils.NewColDocIndex(0, testUtils.NonExistentDocID)},
+				DocIDs:        []state.ColDocIndex{state.NewColDocIndex(0, testUtils.NonExistentDocID)},
 				ExpectedError: "malformed document ID, missing either version or cid",
 			},
 			testUtils.UpdateDoc{

--- a/tests/integration/net/simple/peer/subscribe/document/with_get_test.go
+++ b/tests/integration/net/simple/peer/subscribe/document/with_get_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	"github.com/sourcenetwork/defradb/tests/state"
 )
 
 func TestP2PDocument_GetAllWithNoneConfigured_ShouldSucceed(t *testing.T) {
@@ -27,11 +28,11 @@ func TestP2PDocument_GetAllWithNoneConfigured_ShouldSucceed(t *testing.T) {
 			},
 			testUtils.GetAllP2PDocuments{
 				NodeID:         0,
-				ExpectedDocIDs: []testUtils.ColDocIndex{},
+				ExpectedDocIDs: []state.ColDocIndex{},
 			},
 			testUtils.GetAllP2PDocuments{
 				NodeID:         1,
-				ExpectedDocIDs: []testUtils.ColDocIndex{},
+				ExpectedDocIDs: []state.ColDocIndex{},
 			},
 		},
 	}

--- a/tests/integration/net/simple/peer/with_delete_test.go
+++ b/tests/integration/net/simple/peer/with_delete_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sourcenetwork/immutable"
 
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	"github.com/sourcenetwork/defradb/tests/state"
 )
 
 // The parent-child distinction in these tests is as much documentation and test
@@ -53,8 +54,8 @@ func TestP2PWithMultipleDocumentsSingleDelete(t *testing.T) {
 			},
 			testUtils.SubscribeToDocument{
 				NodeID: 1,
-				DocIDs: []testUtils.ColDocIndex{
-					testUtils.NewColDocIndex(0, 0),
+				DocIDs: []state.ColDocIndex{
+					state.NewColDocIndex(0, 0),
 				},
 			},
 			testUtils.DeleteDoc{
@@ -119,8 +120,8 @@ func TestP2PWithMultipleDocumentsSingleDeleteWithShowDeleted(t *testing.T) {
 			},
 			testUtils.SubscribeToDocument{
 				NodeID: 1,
-				DocIDs: []testUtils.ColDocIndex{
-					testUtils.NewColDocIndex(0, 0),
+				DocIDs: []state.ColDocIndex{
+					state.NewColDocIndex(0, 0),
 				},
 			},
 			testUtils.DeleteDoc{
@@ -198,8 +199,8 @@ func TestP2PWithMultipleDocumentsWithSingleUpdateBeforeConnectSingleDeleteWithSh
 			},
 			testUtils.SubscribeToDocument{
 				NodeID: 1,
-				DocIDs: []testUtils.ColDocIndex{
-					testUtils.NewColDocIndex(0, 0),
+				DocIDs: []state.ColDocIndex{
+					state.NewColDocIndex(0, 0),
 				},
 			},
 			testUtils.DeleteDoc{
@@ -285,8 +286,8 @@ func TestP2PWithMultipleDocumentsWithMultipleUpdatesBeforeConnectSingleDeleteWit
 			},
 			testUtils.SubscribeToDocument{
 				NodeID: 1,
-				DocIDs: []testUtils.ColDocIndex{
-					testUtils.NewColDocIndex(0, 0),
+				DocIDs: []state.ColDocIndex{
+					state.NewColDocIndex(0, 0),
 				},
 			},
 			testUtils.DeleteDoc{
@@ -376,8 +377,8 @@ func TestP2PWithMultipleDocumentsWithUpdateAndDeleteBeforeConnectSingleDeleteWit
 			},
 			testUtils.SubscribeToDocument{
 				NodeID: 0,
-				DocIDs: []testUtils.ColDocIndex{
-					testUtils.NewColDocIndex(0, 1),
+				DocIDs: []state.ColDocIndex{
+					state.NewColDocIndex(0, 1),
 				},
 			},
 			testUtils.UpdateDoc{

--- a/tests/integration/net/simple/peer/with_update_restart_test.go
+++ b/tests/integration/net/simple/peer/with_update_restart_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sourcenetwork/immutable"
 
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	"github.com/sourcenetwork/defradb/tests/state"
 )
 
 func TestP2PWithSingleDocumentSingleUpdateFromChildAndRestart(t *testing.T) {
@@ -44,8 +45,8 @@ func TestP2PWithSingleDocumentSingleUpdateFromChildAndRestart(t *testing.T) {
 			},
 			testUtils.SubscribeToDocument{
 				NodeID: 1,
-				DocIDs: []testUtils.ColDocIndex{
-					testUtils.NewColDocIndex(0, 0),
+				DocIDs: []state.ColDocIndex{
+					state.NewColDocIndex(0, 0),
 				},
 			},
 			testUtils.Restart{},

--- a/tests/integration/net/simple/peer/with_update_test.go
+++ b/tests/integration/net/simple/peer/with_update_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sourcenetwork/immutable"
 
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	"github.com/sourcenetwork/defradb/tests/state"
 )
 
 // The parent-child distinction in these tests is as much documentation and test
@@ -46,8 +47,8 @@ func TestP2PWithSingleDocumentSingleUpdateFromChild(t *testing.T) {
 			},
 			testUtils.SubscribeToDocument{
 				NodeID: 1,
-				DocIDs: []testUtils.ColDocIndex{
-					testUtils.NewColDocIndex(0, 0),
+				DocIDs: []state.ColDocIndex{
+					state.NewColDocIndex(0, 0),
 				},
 			},
 			testUtils.UpdateDoc{
@@ -106,8 +107,8 @@ func TestP2PWithSingleDocumentSingleUpdateFromParent(t *testing.T) {
 			},
 			testUtils.SubscribeToDocument{
 				NodeID: 0,
-				DocIDs: []testUtils.ColDocIndex{
-					testUtils.NewColDocIndex(0, 0),
+				DocIDs: []state.ColDocIndex{
+					state.NewColDocIndex(0, 0),
 				},
 			},
 			testUtils.UpdateDoc{
@@ -165,14 +166,14 @@ func TestP2PWithSingleDocumentUpdatePerNode(t *testing.T) {
 			},
 			testUtils.SubscribeToDocument{
 				NodeID: 0,
-				DocIDs: []testUtils.ColDocIndex{
-					testUtils.NewColDocIndex(0, 0),
+				DocIDs: []state.ColDocIndex{
+					state.NewColDocIndex(0, 0),
 				},
 			},
 			testUtils.SubscribeToDocument{
 				NodeID: 1,
-				DocIDs: []testUtils.ColDocIndex{
-					testUtils.NewColDocIndex(0, 0),
+				DocIDs: []state.ColDocIndex{
+					state.NewColDocIndex(0, 0),
 				},
 			},
 			testUtils.UpdateDoc{
@@ -238,8 +239,8 @@ func TestP2PWithSingleDocumentSingleUpdateDoesNotSyncToNonPeerNode(t *testing.T)
 			},
 			testUtils.SubscribeToDocument{
 				NodeID: 1,
-				DocIDs: []testUtils.ColDocIndex{
-					testUtils.NewColDocIndex(0, 0),
+				DocIDs: []state.ColDocIndex{
+					state.NewColDocIndex(0, 0),
 				},
 			},
 			testUtils.UpdateDoc{
@@ -417,14 +418,14 @@ func TestP2PWithMultipleDocumentUpdatesPerNode(t *testing.T) {
 			},
 			testUtils.SubscribeToDocument{
 				NodeID: 0,
-				DocIDs: []testUtils.ColDocIndex{
-					testUtils.NewColDocIndex(0, 0),
+				DocIDs: []state.ColDocIndex{
+					state.NewColDocIndex(0, 0),
 				},
 			},
 			testUtils.SubscribeToDocument{
 				NodeID: 1,
-				DocIDs: []testUtils.ColDocIndex{
-					testUtils.NewColDocIndex(0, 0),
+				DocIDs: []state.ColDocIndex{
+					state.NewColDocIndex(0, 0),
 				},
 			},
 			testUtils.UpdateDoc{

--- a/tests/integration/net/simple/peer_replicator/crdt/pcounter_test.go
+++ b/tests/integration/net/simple/peer_replicator/crdt/pcounter_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sourcenetwork/immutable"
 
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	"github.com/sourcenetwork/defradb/tests/state"
 )
 
 func TestP2PPeerReplicatorWithCreate_PCounter_NoError(t *testing.T) {
@@ -137,8 +138,8 @@ func TestP2PPeerReplicatorWithUpdate_PCounter_NoError(t *testing.T) {
 			},
 			testUtils.SubscribeToDocument{
 				NodeID: 1,
-				DocIDs: []testUtils.ColDocIndex{
-					testUtils.NewColDocIndex(0, 0),
+				DocIDs: []state.ColDocIndex{
+					state.NewColDocIndex(0, 0),
 				},
 			},
 			testUtils.ConfigureReplicator{

--- a/tests/integration/net/simple/peer_replicator/crdt/pncounter_test.go
+++ b/tests/integration/net/simple/peer_replicator/crdt/pncounter_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sourcenetwork/immutable"
 
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	"github.com/sourcenetwork/defradb/tests/state"
 )
 
 func TestP2PPeerReplicatorWithCreate_PNCounter_NoError(t *testing.T) {
@@ -137,8 +138,8 @@ func TestP2PPeerReplicatorWithUpdate_PNCounter_NoError(t *testing.T) {
 			},
 			testUtils.SubscribeToDocument{
 				NodeID: 1,
-				DocIDs: []testUtils.ColDocIndex{
-					testUtils.NewColDocIndex(0, 0),
+				DocIDs: []state.ColDocIndex{
+					state.NewColDocIndex(0, 0),
 				},
 			},
 			testUtils.ConfigureReplicator{

--- a/tests/integration/net/simple/peer_replicator/with_delete_test.go
+++ b/tests/integration/net/simple/peer_replicator/with_delete_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sourcenetwork/immutable"
 
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	"github.com/sourcenetwork/defradb/tests/state"
 )
 
 func TestP2PPeerReplicatorWithDeleteShowDeleted(t *testing.T) {
@@ -48,8 +49,8 @@ func TestP2PPeerReplicatorWithDeleteShowDeleted(t *testing.T) {
 			},
 			testUtils.SubscribeToDocument{
 				NodeID: 1,
-				DocIDs: []testUtils.ColDocIndex{
-					testUtils.NewColDocIndex(0, 0),
+				DocIDs: []state.ColDocIndex{
+					state.NewColDocIndex(0, 0),
 				},
 			},
 			testUtils.DeleteDoc{

--- a/tests/integration/net/simple/peer_replicator/with_update_restart_test.go
+++ b/tests/integration/net/simple/peer_replicator/with_update_restart_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sourcenetwork/immutable"
 
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	"github.com/sourcenetwork/defradb/tests/state"
 )
 
 func TestP2PPeerReplicatorWithUpdateAndRestart(t *testing.T) {
@@ -44,8 +45,8 @@ func TestP2PPeerReplicatorWithUpdateAndRestart(t *testing.T) {
 			},
 			testUtils.SubscribeToDocument{
 				NodeID: 1,
-				DocIDs: []testUtils.ColDocIndex{
-					testUtils.NewColDocIndex(0, 0),
+				DocIDs: []state.ColDocIndex{
+					state.NewColDocIndex(0, 0),
 				},
 			},
 			testUtils.ConfigureReplicator{

--- a/tests/integration/net/simple/peer_replicator/with_update_test.go
+++ b/tests/integration/net/simple/peer_replicator/with_update_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sourcenetwork/immutable"
 
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	"github.com/sourcenetwork/defradb/tests/state"
 )
 
 func TestP2PPeerReplicatorWithUpdate(t *testing.T) {
@@ -44,8 +45,8 @@ func TestP2PPeerReplicatorWithUpdate(t *testing.T) {
 			},
 			testUtils.SubscribeToDocument{
 				NodeID: 1,
-				DocIDs: []testUtils.ColDocIndex{
-					testUtils.NewColDocIndex(0, 0),
+				DocIDs: []state.ColDocIndex{
+					state.NewColDocIndex(0, 0),
 				},
 			},
 			testUtils.ConfigureReplicator{

--- a/tests/integration/net/simple/replicator/with_create_test.go
+++ b/tests/integration/net/simple/replicator/with_create_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sourcenetwork/immutable"
 
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	"github.com/sourcenetwork/defradb/tests/state"
 )
 
 // TestP2POneToOneReplicator tests document syncing between a node and a replicator.
@@ -589,7 +590,7 @@ func TestP2POneToOneReplicatorOrderIndependentDirectCreate(t *testing.T) {
 func TestP2POneToOneReplicator_ManyDocsWithTargetNodeTemporarilyOffline_ShouldSucceed(t *testing.T) {
 	test := testUtils.TestCase{
 		SupportedDatabaseTypes: immutable.Some(
-			[]testUtils.DatabaseType{
+			[]state.DatabaseType{
 				// This test only supports file type databases since it requires the ability to
 				// stop and start a node without losing data.
 				testUtils.BadgerFileType,

--- a/tests/integration/net/simple/replicator/with_create_update_test.go
+++ b/tests/integration/net/simple/replicator/with_create_update_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sourcenetwork/immutable"
 
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	"github.com/sourcenetwork/defradb/tests/state"
 )
 
 func TestP2POneToOneReplicatorWithCreateWithUpdate(t *testing.T) {
@@ -105,8 +106,8 @@ func TestP2POneToOneReplicatorWithCreateWithUpdateOnRecipientNode(t *testing.T) 
 			testUtils.WaitForSync{},
 			testUtils.SubscribeToDocument{
 				NodeID: 0,
-				DocIDs: []testUtils.ColDocIndex{
-					testUtils.NewColDocIndex(0, 0),
+				DocIDs: []state.ColDocIndex{
+					state.NewColDocIndex(0, 0),
 				},
 			},
 			testUtils.UpdateDoc{

--- a/tests/integration/net/simple/replicator/with_update_test.go
+++ b/tests/integration/net/simple/replicator/with_update_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sourcenetwork/immutable"
 
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	"github.com/sourcenetwork/defradb/tests/state"
 )
 
 func TestP2POneToOneReplicatorUpdatesDocCreatedBeforeReplicatorConfig(t *testing.T) {
@@ -129,7 +130,7 @@ func TestP2POneToOneReplicatorUpdatesDocCreatedBeforeReplicatorConfigWithNodesIn
 func TestP2POneToOneReplicator_ManyDocsUpdateWithTargetNodeTemporarilyOffline_ShouldSucceed(t *testing.T) {
 	test := testUtils.TestCase{
 		SupportedDatabaseTypes: immutable.Some(
-			[]testUtils.DatabaseType{
+			[]state.DatabaseType{
 				// This test only supports file type databases since it requires the ability to
 				// stop and start a node without losing data.
 				testUtils.BadgerFileType,
@@ -209,7 +210,7 @@ func TestP2POneToOneReplicator_ManyDocsUpdateWithTargetNodeTemporarilyOffline_Sh
 func TestP2POneToOneReplicator_ManyDocsUpdateWithTargetNodeTemporarilyOfflineAfterCreate_ShouldSucceed(t *testing.T) {
 	test := testUtils.TestCase{
 		SupportedDatabaseTypes: immutable.Some(
-			[]testUtils.DatabaseType{
+			[]state.DatabaseType{
 				// This test only supports file type databases since it requires the ability to
 				// stop and start a node without losing data.
 				testUtils.BadgerFileType,

--- a/tests/integration/p2p.go
+++ b/tests/integration/p2p.go
@@ -212,8 +212,8 @@ func connectPeers(
 	err := sourceNode.Connect(s.Ctx, targetNode.PeerInfo())
 	require.NoError(s.T, err)
 
-	s.Nodes[cfg.SourceNodeID].P2p.Connections[cfg.TargetNodeID] = struct{}{}
-	s.Nodes[cfg.TargetNodeID].P2p.Connections[cfg.SourceNodeID] = struct{}{}
+	s.Nodes[cfg.SourceNodeID].P2P.Connections[cfg.TargetNodeID] = struct{}{}
+	s.Nodes[cfg.TargetNodeID].P2P.Connections[cfg.SourceNodeID] = struct{}{}
 
 	// Bootstrap triggers a bunch of async stuff for which we have no good way of waiting on.  It must be
 	// allowed to complete before documentation begins or it will not even try and sync it. So for now, we
@@ -436,7 +436,7 @@ func getAllP2PDocuments(
 // reconnectPeers makes sure that all peers are connected after a node restart action.
 func reconnectPeers(s *state.State) {
 	for i, n := range s.Nodes {
-		for j := range n.P2p.Connections {
+		for j := range n.P2P.Connections {
 			sourceNode := s.Nodes[i]
 			targetNode := s.Nodes[j]
 
@@ -489,7 +489,7 @@ func syncDocs(s *state.State, action SyncDocs) {
 		for i, docInd := range action.DocIDs {
 			nodeID := action.SourceNodes[i]
 			docID := s.DocIDs[action.CollectionID][docInd].String()
-			node.P2p.ExpectedDAGHeads[docID] = s.Nodes[nodeID].P2p.ActualDAGHeads[docID].Cid
+			node.P2P.ExpectedDAGHeads[docID] = s.Nodes[nodeID].P2P.ActualDAGHeads[docID].CID
 		}
 	}
 }

--- a/tests/integration/p2p.go
+++ b/tests/integration/p2p.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	netConfig "github.com/sourcenetwork/defradb/net/config"
+	"github.com/sourcenetwork/defradb/tests/state"
 
 	"github.com/sourcenetwork/corelog"
 	"github.com/stretchr/testify/assert"
@@ -132,15 +133,6 @@ type GetAllP2PCollections struct {
 	ExpectedCollectionIDs []int
 }
 
-type ColDocIndex struct {
-	Col int
-	Doc int
-}
-
-func NewColDocIndex(col, doc int) ColDocIndex {
-	return ColDocIndex{col, doc}
-}
-
 // SubscribeToDocument sets up a subscription on the given node to the given document.
 //
 // Changes made to subscribed documents in peers connected to this node will be synced from
@@ -155,7 +147,7 @@ type SubscribeToDocument struct {
 	// DocIDs are the docIDs (indexes) of the documents to subscribe to.
 	//
 	// A [NonExistentDocID] may be provided to test non-existent  docIDs.
-	DocIDs []ColDocIndex
+	DocIDs []state.ColDocIndex
 
 	// Any error expected from the action. Optional.
 	//
@@ -173,7 +165,7 @@ type UnsubscribeToDocument struct {
 	// DocIDs are the docIDs (indexes) of the documents to unsubscribe from.
 	//
 	// A [NonExistentDocID] may be provided to test non-existent docIDs.
-	DocIDs []ColDocIndex
+	DocIDs []state.ColDocIndex
 
 	// Any error expected from the action. Optional.
 	//
@@ -189,7 +181,7 @@ type GetAllP2PDocuments struct {
 	NodeID int
 
 	// ExpectedDocIDs are the docIDs (indexes) of the documents expected.
-	ExpectedDocIDs []ColDocIndex
+	ExpectedDocIDs []state.ColDocIndex
 }
 
 // WaitForSync is an action that instructs the test framework to wait for all document synchronization
@@ -207,7 +199,7 @@ type WaitForSync struct {
 //
 // Any errors generated whilst configuring the peers or waiting on sync will result in a test failure.
 func connectPeers(
-	s *State,
+	s *state.State,
 	cfg ConnectPeers,
 ) {
 	sourceNode := s.Nodes[cfg.SourceNodeID]
@@ -235,7 +227,7 @@ func connectPeers(
 //
 // Any errors generated whilst configuring the peers or waiting on sync will result in a test failure.
 func configureReplicator(
-	s *State,
+	s *state.State,
 	cfg ConfigureReplicator,
 ) {
 	sourceNode := s.Nodes[cfg.SourceNodeID]
@@ -252,7 +244,7 @@ func configureReplicator(
 }
 
 func deleteReplicator(
-	s *State,
+	s *state.State,
 	cfg DeleteReplicator,
 ) {
 	sourceNode := s.Nodes[cfg.SourceNodeID]
@@ -267,7 +259,7 @@ func deleteReplicator(
 //
 // Any errors generated during this process will result in a test failure.
 func subscribeToCollection(
-	s *State,
+	s *state.State,
 	action SubscribeToCollection,
 ) {
 	n := s.Nodes[action.NodeID]
@@ -301,7 +293,7 @@ func subscribeToCollection(
 //
 // Any errors generated during this process will result in a test failure.
 func unsubscribeToCollection(
-	s *State,
+	s *state.State,
 	action UnsubscribeToCollection,
 ) {
 	n := s.Nodes[action.NodeID]
@@ -336,7 +328,7 @@ func unsubscribeToCollection(
 //
 // Any errors generated during this process will result in a test failure.
 func getAllP2PCollections(
-	s *State,
+	s *state.State,
 	action GetAllP2PCollections,
 ) {
 	expectedCollections := []string{}
@@ -356,7 +348,7 @@ func getAllP2PCollections(
 //
 // Any errors generated during this process will result in a test failure.
 func subscribeToDocument(
-	s *State,
+	s *state.State,
 	action SubscribeToDocument,
 ) {
 	n := s.Nodes[action.NodeID]
@@ -390,7 +382,7 @@ func subscribeToDocument(
 //
 // Any errors generated during this process will result in a test failure.
 func unsubscribeToDocument(
-	s *State,
+	s *state.State,
 	action UnsubscribeToDocument,
 ) {
 	n := s.Nodes[action.NodeID]
@@ -425,7 +417,7 @@ func unsubscribeToDocument(
 //
 // Any errors generated during this process will result in a test failure.
 func getAllP2PDocuments(
-	s *State,
+	s *state.State,
 	action GetAllP2PDocuments,
 ) {
 	expectedDocuments := []string{}
@@ -442,7 +434,7 @@ func getAllP2PDocuments(
 }
 
 // reconnectPeers makes sure that all peers are connected after a node restart action.
-func reconnectPeers(s *State) {
+func reconnectPeers(s *state.State) {
 	for i, n := range s.Nodes {
 		for j := range n.P2p.Connections {
 			sourceNode := s.Nodes[i]
@@ -468,7 +460,7 @@ func RandomNetworkingConfig() ConfigureNode {
 }
 
 // syncDocs requests document sync from peers.
-func syncDocs(s *State, action SyncDocs) {
+func syncDocs(s *state.State, action SyncDocs) {
 	node := s.Nodes[action.NodeID]
 
 	docIDStrings := make([]string, len(action.DocIDs))

--- a/tests/integration/p2p.go
+++ b/tests/integration/p2p.go
@@ -243,8 +243,8 @@ func configureReplicator(
 
 	err := sourceNode.SetReplicator(s.ctx, targetNode.PeerInfo())
 
-	expectedErrorRaised := AssertError(s.t, s.testCase.Description, err, cfg.ExpectedError)
-	assertExpectedErrorRaised(s.t, s.testCase.Description, cfg.ExpectedError, expectedErrorRaised)
+	expectedErrorRaised := AssertError(s.t, err, cfg.ExpectedError)
+	assertExpectedErrorRaised(s.t, cfg.ExpectedError, expectedErrorRaised)
 
 	if err == nil {
 		waitForReplicatorConfigureEvent(s, cfg)
@@ -288,8 +288,8 @@ func subscribeToCollection(
 		waitForSubscribeToCollectionEvent(s, action)
 	}
 
-	expectedErrorRaised := AssertError(s.t, s.testCase.Description, err, action.ExpectedError)
-	assertExpectedErrorRaised(s.t, s.testCase.Description, action.ExpectedError, expectedErrorRaised)
+	expectedErrorRaised := AssertError(s.t, err, action.ExpectedError)
+	assertExpectedErrorRaised(s.t, action.ExpectedError, expectedErrorRaised)
 
 	// The `n.Peer.AddP2PCollections(colIDs)` call above is calling some asynchronous functions
 	// for the pubsub subscription and those functions can take a bit of time to complete,
@@ -322,8 +322,8 @@ func unsubscribeToCollection(
 		waitForUnsubscribeToCollectionEvent(s, action)
 	}
 
-	expectedErrorRaised := AssertError(s.t, s.testCase.Description, err, action.ExpectedError)
-	assertExpectedErrorRaised(s.t, s.testCase.Description, action.ExpectedError, expectedErrorRaised)
+	expectedErrorRaised := AssertError(s.t, err, action.ExpectedError)
+	assertExpectedErrorRaised(s.t, action.ExpectedError, expectedErrorRaised)
 
 	// The `n.Peer.RemoveP2PCollections(colIDs)` call above is calling some asynchronous functions
 	// for the pubsub subscription and those functions can take a bit of time to complete,
@@ -377,8 +377,8 @@ func subscribeToDocument(
 		waitForSubscribeToDocumentEvent(s, action)
 	}
 
-	expectedErrorRaised := AssertError(s.t, s.testCase.Description, err, action.ExpectedError)
-	assertExpectedErrorRaised(s.t, s.testCase.Description, action.ExpectedError, expectedErrorRaised)
+	expectedErrorRaised := AssertError(s.t, err, action.ExpectedError)
+	assertExpectedErrorRaised(s.t, action.ExpectedError, expectedErrorRaised)
 
 	// The `n.Peer.AddP2PDocuments(colIDs)` call above is calling some asynchronous functions
 	// for the pubsub subscription and those functions can take a bit of time to complete,
@@ -411,8 +411,8 @@ func unsubscribeToDocument(
 		waitForUnsubscribeToDocumentEvent(s, action)
 	}
 
-	expectedErrorRaised := AssertError(s.t, s.testCase.Description, err, action.ExpectedError)
-	assertExpectedErrorRaised(s.t, s.testCase.Description, action.ExpectedError, expectedErrorRaised)
+	expectedErrorRaised := AssertError(s.t, err, action.ExpectedError)
+	assertExpectedErrorRaised(s.t, action.ExpectedError, expectedErrorRaised)
 
 	// The `n.Peer.RemoveP2PDocuments(colIDs)` call above is calling some asynchronous functions
 	// for the pubsub subscription and those functions can take a bit of time to complete,
@@ -489,9 +489,9 @@ func syncDocs(s *state, action SyncDocs) {
 		},
 	)
 
-	expectedErrorRaised := AssertError(s.t, s.testCase.Description, err, action.ExpectedError)
+	expectedErrorRaised := AssertError(s.t, err, action.ExpectedError)
 
-	assertExpectedErrorRaised(s.t, s.testCase.Description, action.ExpectedError, expectedErrorRaised)
+	assertExpectedErrorRaised(s.t, action.ExpectedError, expectedErrorRaised)
 
 	if !expectedErrorRaised {
 		for i, docInd := range action.DocIDs {

--- a/tests/integration/query/simple/with_max_test.go
+++ b/tests/integration/query/simple/with_max_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	"github.com/sourcenetwork/defradb/tests/state"
 
 	"github.com/sourcenetwork/immutable"
 )
@@ -101,7 +102,7 @@ func TestQuerySimple_WithMax_Succeeds(t *testing.T) {
 
 func TestQuerySimple_WithMaxAndMaxValueInt_Succeeds(t *testing.T) {
 	test := testUtils.TestCase{
-		SupportedClientTypes: immutable.Some([]testUtils.ClientType{
+		SupportedClientTypes: immutable.Some([]state.ClientType{
 			// JavaScript does not support 64 bit int
 			testUtils.GoClientType,
 			testUtils.CLIClientType,

--- a/tests/integration/query/simple/with_min_test.go
+++ b/tests/integration/query/simple/with_min_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	"github.com/sourcenetwork/defradb/tests/state"
 
 	"github.com/sourcenetwork/immutable"
 )
@@ -101,7 +102,7 @@ func TestQuerySimple_WithMin_Succeeds(t *testing.T) {
 
 func TestQuerySimple_WithMinAndMaxValueInt_Succeeds(t *testing.T) {
 	test := testUtils.TestCase{
-		SupportedClientTypes: immutable.Some([]testUtils.ClientType{
+		SupportedClientTypes: immutable.Some([]state.ClientType{
 			// JavaScript does not support 64 bit int
 			testUtils.GoClientType,
 			testUtils.CLIClientType,

--- a/tests/integration/results.go
+++ b/tests/integration/results.go
@@ -25,8 +25,20 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 )
+
+// TestState is read-only interface for test state. It allows passing the state to custom matchers
+// without allowing them to modify the state.
+type TestState interface {
+	// GetClientType returns the client type of the test.
+	GetClientType() ClientType
+	// GetCurrentNodeID returns the node id that is currently being asserted.
+	GetCurrentNodeID() int
+	// GetIdentity returns the identity for the given node index.
+	GetIdentity(Identity) acpIdentity.Identity
+}
 
 type testStateMatcher struct {
 	s TestState

--- a/tests/integration/results.go
+++ b/tests/integration/results.go
@@ -365,44 +365,44 @@ func areResultArraysEqual[S any](expected []S, actual any) bool {
 }
 
 func assertCollectionVersions(
-	s *state,
+	s *State,
 	expected []client.CollectionVersion,
 	actual []client.CollectionVersion,
 ) {
-	require.Equal(s.t, len(expected), len(actual))
+	require.Equal(s.T, len(expected), len(actual))
 
 	for i, expected := range expected {
 		actual := actual[i]
 		if expected.VersionID != "" {
-			require.Equal(s.t, expected.VersionID, actual.VersionID)
+			require.Equal(s.T, expected.VersionID, actual.VersionID)
 		}
 		if expected.CollectionID != "" {
-			require.Equal(s.t, expected.CollectionID, actual.CollectionID)
+			require.Equal(s.T, expected.CollectionID, actual.CollectionID)
 		}
 
-		require.Equal(s.t, expected.Name, actual.Name)
-		require.Equal(s.t, expected.IsMaterialized, actual.IsMaterialized)
-		require.Equal(s.t, expected.IsBranchable, actual.IsBranchable)
-		require.Equal(s.t, expected.IsActive, actual.IsActive)
+		require.Equal(s.T, expected.Name, actual.Name)
+		require.Equal(s.T, expected.IsMaterialized, actual.IsMaterialized)
+		require.Equal(s.T, expected.IsBranchable, actual.IsBranchable)
+		require.Equal(s.T, expected.IsActive, actual.IsActive)
 
 		if expected.Indexes != nil || len(actual.Indexes) != 0 {
 			// Dont bother asserting this if the expected is nil and the actual is nil/empty.
 			// This is to save each test action from having to bother declaring an empty slice (if there are no indexes)
-			require.Equal(s.t, expected.Indexes, actual.Indexes)
+			require.Equal(s.T, expected.Indexes, actual.Indexes)
 		}
 
 		if expected.Sources != nil {
 			// Dont bother asserting this if the expected is nil and the actual is nil/empty.
 			// This is to save each test action from having to bother declaring an empty slice (if there are no sources)
-			require.Equal(s.t, expected.Sources, actual.Sources)
+			require.Equal(s.T, expected.Sources, actual.Sources)
 		}
 
 		if expected.Fields != nil {
-			require.Equal(s.t, expected.Fields, actual.Fields)
+			require.Equal(s.T, expected.Fields, actual.Fields)
 		}
 
 		if expected.VectorEmbeddings != nil {
-			require.Equal(s.t, expected.VectorEmbeddings, actual.VectorEmbeddings)
+			require.Equal(s.T, expected.VectorEmbeddings, actual.VectorEmbeddings)
 		}
 	}
 }

--- a/tests/integration/results.go
+++ b/tests/integration/results.go
@@ -27,17 +27,18 @@ import (
 
 	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
+	"github.com/sourcenetwork/defradb/tests/state"
 )
 
 // TestState is read-only interface for test state. It allows passing the state to custom matchers
 // without allowing them to modify the state.
 type TestState interface {
 	// GetClientType returns the client type of the test.
-	GetClientType() ClientType
+	GetClientType() state.ClientType
 	// GetCurrentNodeID returns the node id that is currently being asserted.
 	GetCurrentNodeID() int
 	// GetIdentity returns the identity for the given node index.
-	GetIdentity(Identity) acpIdentity.Identity
+	GetIdentity(state.Identity) acpIdentity.Identity
 }
 
 type testStateMatcher struct {
@@ -205,7 +206,7 @@ func (matcher *SameValue) NegatedFailureMessage(actual any) string {
 // assertResultsEqual asserts that actual result is equal to the expected result.
 //
 // The comparison is relaxed when using client types other than goClientType.
-func assertResultsEqual(t testing.TB, client ClientType, expected any, actual any, msgAndArgs ...any) {
+func assertResultsEqual(t testing.TB, client state.ClientType, expected any, actual any, msgAndArgs ...any) {
 	switch client {
 	case HTTPClientType, CLIClientType, JSClientType:
 		if !areResultsEqual(expected, actual) {
@@ -365,7 +366,7 @@ func areResultArraysEqual[S any](expected []S, actual any) bool {
 }
 
 func assertCollectionVersions(
-	s *State,
+	s *state.State,
 	expected []client.CollectionVersion,
 	actual []client.CollectionVersion,
 ) {

--- a/tests/integration/results_test.go
+++ b/tests/integration/results_test.go
@@ -16,15 +16,16 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
+	"github.com/sourcenetwork/defradb/tests/state"
 )
 
 // mockTestState is a simple mock implementation of TestState interface for testing
 type mockTestState struct {
-	clientType    ClientType
+	clientType    state.ClientType
 	currentNodeID int
 }
 
-func (m *mockTestState) GetClientType() ClientType {
+func (m *mockTestState) GetClientType() state.ClientType {
 	return m.clientType
 }
 
@@ -32,14 +33,14 @@ func (m *mockTestState) GetCurrentNodeID() int {
 	return m.currentNodeID
 }
 
-func (m *mockTestState) GetIdentity(_ Identity) acpIdentity.Identity {
+func (m *mockTestState) GetIdentity(_ state.Identity) acpIdentity.Identity {
 	return nil
 }
 
 func TestAnyOfMatcher(t *testing.T) {
 	tests := []struct {
 		name       string
-		clientType ClientType
+		clientType state.ClientType
 		values     []any
 		actual     any
 		want       bool

--- a/tests/integration/signature/acp_test.go
+++ b/tests/integration/signature/acp_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/sourcenetwork/defradb/internal/db"
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	"github.com/sourcenetwork/defradb/tests/state"
 )
 
 const policy = `
@@ -53,7 +54,7 @@ const policy = `
 func TestSignatureACP_IfHasNoAccessToDoc_ShouldError(t *testing.T) {
 	test := testUtils.TestCase{
 		EnableSigning: true,
-		SupportedClientTypes: immutable.Some([]testUtils.ClientType{
+		SupportedClientTypes: immutable.Some([]state.ClientType{
 			// Creating of signed documents over HTTP is not supported yet, because signing
 			// requires a private key which we do not pass over HTTP.
 			testUtils.GoClientType,
@@ -99,7 +100,7 @@ func TestSignatureACP_IfHasNoAccessToDoc_ShouldError(t *testing.T) {
 func TestSignatureACP_IfHasAccessToDoc_ValidateSignature(t *testing.T) {
 	test := testUtils.TestCase{
 		EnableSigning: true,
-		SupportedClientTypes: immutable.Some([]testUtils.ClientType{
+		SupportedClientTypes: immutable.Some([]state.ClientType{
 			// Creating of signed documents over HTTP is not supported yet, because signing
 			// requires a private key which we do not pass over HTTP.
 			testUtils.GoClientType,

--- a/tests/integration/signature/commit_test.go
+++ b/tests/integration/signature/commit_test.go
@@ -20,6 +20,7 @@ import (
 	coreblock "github.com/sourcenetwork/defradb/internal/core/block"
 	corecrdt "github.com/sourcenetwork/defradb/internal/core/crdt"
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	"github.com/sourcenetwork/defradb/tests/state"
 )
 
 func makeFieldBlock(fieldName string, value any) coreblock.Block {
@@ -277,7 +278,7 @@ func TestSignature_WithDeletedDocAndCommitQuery_ShouldIncludeSignatureData(t *te
 func TestSignature_WithEd25519KeyType_ShouldIncludeSignatureData(t *testing.T) {
 	test := testUtils.TestCase{
 		EnableSigning: true,
-		IdentityTypes: map[testUtils.Identity]crypto.KeyType{
+		IdentityTypes: map[state.Identity]crypto.KeyType{
 			testUtils.NodeIdentity(0).Value(): crypto.KeyTypeEd25519,
 		},
 		Actions: []any{
@@ -348,7 +349,7 @@ func TestSignature_WithClientIdentity_ShouldUseItForSigning(t *testing.T) {
 	t.Skip("Skipping test because signing with client identity is not supported yet")
 	test := testUtils.TestCase{
 		EnableSigning: true,
-		IdentityTypes: map[testUtils.Identity]crypto.KeyType{
+		IdentityTypes: map[state.Identity]crypto.KeyType{
 			testUtils.ClientIdentity(0).Value(): crypto.KeyTypeEd25519,
 			testUtils.NodeIdentity(0).Value():   crypto.KeyTypeSecp256k1,
 		},

--- a/tests/integration/signature/fallback_signer_test.go
+++ b/tests/integration/signature/fallback_signer_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sourcenetwork/immutable"
 
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	"github.com/sourcenetwork/defradb/tests/state"
 )
 
 func TestSignature_IfIdentityHasNoPrivateKey_ShouldUseNodeIdentity(t *testing.T) {
@@ -23,7 +24,7 @@ func TestSignature_IfIdentityHasNoPrivateKey_ShouldUseNodeIdentity(t *testing.T)
 		EnableSigning: true,
 		// Default signer can be only tested with HTTP and CLI clients, because with Go client
 		// when providing an identity, it includes the private key.
-		SupportedClientTypes: immutable.Some([]testUtils.ClientType{
+		SupportedClientTypes: immutable.Some([]state.ClientType{
 			testUtils.HTTPClientType,
 			testUtils.CLIClientType,
 		}),

--- a/tests/integration/signature/peer_test.go
+++ b/tests/integration/signature/peer_test.go
@@ -18,12 +18,13 @@ import (
 	"github.com/sourcenetwork/defradb/crypto"
 	coreblock "github.com/sourcenetwork/defradb/internal/core/block"
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	"github.com/sourcenetwork/defradb/tests/state"
 )
 
 func TestDocSignature_WithPeersAndSecp256k1KeyType_ShouldSync(t *testing.T) {
 	test := testUtils.TestCase{
 		EnableSigning: true,
-		IdentityTypes: map[testUtils.Identity]crypto.KeyType{
+		IdentityTypes: map[state.Identity]crypto.KeyType{
 			testUtils.NodeIdentity(0).Value(): crypto.KeyTypeSecp256k1,
 			testUtils.NodeIdentity(1).Value(): crypto.KeyTypeSecp256k1,
 		},
@@ -80,7 +81,7 @@ func TestDocSignature_WithPeersAndSecp256k1KeyType_ShouldSync(t *testing.T) {
 func TestDocSignature_WithPeersAndEd25519KeyType_ShouldSync(t *testing.T) {
 	test := testUtils.TestCase{
 		EnableSigning: true,
-		IdentityTypes: map[testUtils.Identity]crypto.KeyType{
+		IdentityTypes: map[state.Identity]crypto.KeyType{
 			testUtils.NodeIdentity(0).Value(): crypto.KeyTypeEd25519,
 			testUtils.NodeIdentity(1).Value(): crypto.KeyTypeEd25519,
 		},
@@ -137,7 +138,7 @@ func TestDocSignature_WithPeersAndEd25519KeyType_ShouldSync(t *testing.T) {
 func TestDocSignature_WithPeersAnDifferentKeyTypes_ShouldSync(t *testing.T) {
 	test := testUtils.TestCase{
 		EnableSigning: true,
-		IdentityTypes: map[testUtils.Identity]crypto.KeyType{
+		IdentityTypes: map[state.Identity]crypto.KeyType{
 			testUtils.NodeIdentity(0).Value(): crypto.KeyTypeSecp256k1,
 			testUtils.NodeIdentity(1).Value(): crypto.KeyTypeEd25519,
 		},
@@ -235,7 +236,7 @@ func TestDocSignature_WithPeersAnDifferentKeyTypes_ShouldSync(t *testing.T) {
 func TestDocSignature_WithPeersAnDifferentKeyTypesUpdatingSameDoc_ShouldSync(t *testing.T) {
 	test := testUtils.TestCase{
 		EnableSigning: true,
-		IdentityTypes: map[testUtils.Identity]crypto.KeyType{
+		IdentityTypes: map[state.Identity]crypto.KeyType{
 			testUtils.NodeIdentity(0).Value(): crypto.KeyTypeSecp256k1,
 			testUtils.NodeIdentity(1).Value(): crypto.KeyTypeEd25519,
 		},

--- a/tests/integration/signature/utils.go
+++ b/tests/integration/signature/utils.go
@@ -25,6 +25,7 @@ import (
 	"github.com/sourcenetwork/defradb/errors"
 	coreblock "github.com/sourcenetwork/defradb/internal/core/block"
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	"github.com/sourcenetwork/defradb/tests/state"
 )
 
 type signatureMatcher struct {
@@ -115,7 +116,7 @@ func (matcher *signatureMatcher) NegatedFailureMessage(actual any) string {
 // The identity is represented as a byte slice, which is the string representation of the public key of the identity.
 type identityMatcher struct {
 	s        testUtils.TestState
-	identity testUtils.Identity
+	identity state.Identity
 }
 
 // newIdentityMatcher creates a new identity matcher.
@@ -123,7 +124,7 @@ type identityMatcher struct {
 // This is used to match the identity of a node or a client.
 //
 // The identity is represented as a byte slice, which is the string representation of the public key of the identity.
-func newIdentityMatcher(ident testUtils.Identity) *identityMatcher {
+func newIdentityMatcher(ident state.Identity) *identityMatcher {
 	return &identityMatcher{
 		identity: ident,
 	}

--- a/tests/integration/signature/verify_test.go
+++ b/tests/integration/signature/verify_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sourcenetwork/defradb/crypto"
 	coreblock "github.com/sourcenetwork/defradb/internal/core/block"
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	"github.com/sourcenetwork/defradb/tests/state"
 )
 
 func TestSignatureVerify_WithValidData_ShouldVerify(t *testing.T) {
@@ -62,7 +63,7 @@ func TestSignatureVerify_WithValidData_ShouldVerify(t *testing.T) {
 func TestSignatureVerify_WithDifferentKeyType_ShouldVerify(t *testing.T) {
 	test := testUtils.TestCase{
 		EnableSigning: true,
-		IdentityTypes: map[testUtils.Identity]crypto.KeyType{
+		IdentityTypes: map[state.Identity]crypto.KeyType{
 			testUtils.NodeIdentity(0).Value(): crypto.KeyTypeEd25519,
 		},
 		Actions: []any{

--- a/tests/integration/state.go
+++ b/tests/integration/state.go
@@ -15,7 +15,6 @@ import (
 	"testing"
 
 	"github.com/ipfs/go-cid"
-	"github.com/libp2p/go-libp2p/core/peer"
 
 	"github.com/sourcenetwork/immutable"
 
@@ -28,80 +27,80 @@ import (
 	"github.com/sourcenetwork/defradb/tests/clients"
 )
 
-// p2pState contains all p2p related testing state.
-type p2pState struct {
-	// connections contains all connected nodes.
+// P2pState contains all p2p related testing state.
+type P2pState struct {
+	// Connections contains all connected nodes.
 	//
 	// The map key is the connected node id.
-	connections map[int]struct{}
+	Connections map[int]struct{}
 
-	// replicators is a mapping of replicator targets.
+	// Replicators is a mapping of replicator targets.
 	//
 	// The map key is the source node id.
-	replicators map[int]struct{}
+	Replicators map[int]struct{}
 
-	// peerCollections contains all active peer collection subscriptions.
+	// PeerCollections contains all active peer collection subscriptions.
 	//
 	// The map key is the node id of the subscriber.
-	peerCollections map[int]struct{}
+	PeerCollections map[int]struct{}
 
-	// peerDocuments contains all active peer document subscriptions.
+	// PeerDocuments contains all active peer document subscriptions.
 	//
 	// The map key is the node id of the subscriber.
-	peerDocuments map[ColDocIndex]struct{}
+	PeerDocuments map[ColDocIndex]struct{}
 
-	// actualDAGHeads contains all DAG heads that exist on a node.
+	// ActualDAGHeads contains all DAG heads that exist on a node.
 	//
 	// The map key is the doc id. The map value is the doc head.
 	//
 	// This tracks composite commits for documents, and collection commits for
 	// branchable collections
-	actualDAGHeads map[string]docHeadState
+	ActualDAGHeads map[string]DocHeadState
 
-	// expectedDAGHeads contains all DAG heads that are expected to exist on a node.
+	// ExpectedDAGHeads contains all DAG heads that are expected to exist on a node.
 	//
 	// The map key is the doc id. The map value is the DAG head.
 	//
 	// This tracks composite commits for documents, and collection commits for
 	// branchable collections
-	expectedDAGHeads map[string]cid.Cid
+	ExpectedDAGHeads map[string]cid.Cid
 }
 
-// docHeadState contains the state of a document head.
+// DocHeadState contains the state of a document head.
 // It is used to track if a document at a certain head has been decrypted.
-type docHeadState struct {
+type DocHeadState struct {
 	// The actual document head.
-	cid cid.Cid
-	// Indicates if the document at the given head has been decrypted.
-	decrypted bool
+	Cid cid.Cid
+	// Indicates if the document at the given head has been Decrypted.
+	Decrypted bool
 }
 
-// newP2PState returns a new empty p2p state.
-func newP2PState() *p2pState {
-	return &p2pState{
-		connections:      make(map[int]struct{}),
-		replicators:      make(map[int]struct{}),
-		peerCollections:  make(map[int]struct{}),
-		peerDocuments:    make(map[ColDocIndex]struct{}),
-		actualDAGHeads:   make(map[string]docHeadState),
-		expectedDAGHeads: make(map[string]cid.Cid),
+// NewP2PState returns a new empty p2p state.
+func NewP2PState() *P2pState {
+	return &P2pState{
+		Connections:      make(map[int]struct{}),
+		Replicators:      make(map[int]struct{}),
+		PeerCollections:  make(map[int]struct{}),
+		PeerDocuments:    make(map[ColDocIndex]struct{}),
+		ActualDAGHeads:   make(map[string]DocHeadState),
+		ExpectedDAGHeads: make(map[string]cid.Cid),
 	}
 }
 
-// eventState contains all event related testing state for a node.
-type eventState struct {
-	// merge is the `event.MergeCompleteName` subscription
-	merge event.Subscription
+// EventState contains all event related testing state for a node.
+type EventState struct {
+	// Merge is the `event.MergeCompleteName` subscription
+	Merge event.Subscription
 
-	// update is the `event.UpdateName` subscription
-	update event.Subscription
+	// Update is the `event.UpdateName` subscription
+	Update event.Subscription
 
-	// replicator is the `event.ReplicatorCompletedName` subscription
-	replicator event.Subscription
+	// Replicator is the `event.ReplicatorCompletedName` subscription
+	Replicator event.Subscription
 }
 
-// newEventState returns an eventState with all required subscriptions.
-func newEventState(bus event.Bus) (*eventState, error) {
+// NewEventState returns an eventState with all required subscriptions.
+func NewEventState(bus event.Bus) (*EventState, error) {
 	merge, err := bus.Subscribe(event.MergeCompleteName)
 	if err != nil {
 		return nil, err
@@ -114,139 +113,137 @@ func newEventState(bus event.Bus) (*eventState, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &eventState{
-		merge:      merge,
-		update:     update,
-		replicator: replicator,
+	return &EventState{
+		Merge:      merge,
+		Update:     update,
+		Replicator: replicator,
 	}, nil
 }
 
-// nodeState contains all testing state for a node.
-type nodeState struct {
+// NodeState contains all testing state for a node.
+type NodeState struct {
 	// The node's client active in this test.
 	clients.Client
-	// event contains all event node subscriptions.
-	event *eventState
-	// p2p contains p2p states for the node.
-	p2p *p2pState
+	// Event contains all Event node subscriptions.
+	Event *EventState
+	// P2p contains P2p states for the node.
+	P2p *P2pState
 	// The network configurations for the nodes
-	netOpts []netConfig.NodeOpt
+	NetOpts []netConfig.NodeOpt
 	// The path to any file-based databases active in this test.
-	dbPath string
+	DbPath string
 	// Collections by index present in the test.
 	// Indexes matches that of collectionNames.
-	collections []client.Collection
-	// indicates if the node is closed.
-	closed bool
-	// peerInfo contains the peer information for the node.
-	peerInfo peer.AddrInfo
+	Collections []client.Collection
+	// indicates if the node is Closed.
+	Closed bool
 }
 
-// state contains all testing state.
-type state struct {
+// State contains all testing State.
+type State struct {
 	// The test context.
-	ctx context.Context
+	Ctx context.Context
 
 	// The Go Test test state
-	t testing.TB
+	T testing.TB
 
 	// The type of KMS currently being tested.
-	kms KMSType
+	Kms KMSType
 
 	// The type of database currently being tested.
-	dbt DatabaseType
+	Dbt DatabaseType
 
 	// The type of client currently being tested.
-	clientType ClientType
+	ClientType ClientType
 
 	// Any explicit transactions active in this test.
 	//
 	// This is order dependent and the property is accessed by index.
-	txns []client.Txn
+	Txns []client.Txn
 
 	// IdentityTypes is a map of identity to key type.
 	// Use it to customize the key type that is used for identity and signing.
 	IdentityTypes map[Identity]crypto.KeyType
 
-	// identities contains all identities created in this test.
-	// The map key is the identity reference that uniquely identifies identities of different
+	// Identities contains all Identities created in this test.
+	// The map key is the identity reference that uniquely identifies Identities of different
 	// types. See [identRef].
 	// The map value is the identity holder that contains the identity itself and token
 	// generated for different target nodes. See [identityHolder].
-	identities map[Identity]*identityHolder
+	Identities map[Identity]*IdentityHolder
 
 	// The seed for the next identity generation. We want identities to be deterministic.
-	nextIdentityGenSeed int
+	NextIdentityGenSeed int
 
 	// Policy IDs, by node index, by policyID index (in the order they were added).
 	//
-	// Note: In case acp type is sourcehub, all nodes will have the same state of policyIDs.
-	policyIDs [][]string
+	// Note: In case acp type is sourcehub, all nodes will have the same state of PolicyIDs.
+	PolicyIDs [][]string
 
 	// Will receive an item once all actions have finished processing.
-	allActionsDone chan struct{}
+	AllActionsDone chan struct{}
 
 	// These channels will receive a function which asserts results of any subscription requests.
-	subscriptionResultsChans []chan func()
+	SubscriptionResultsChans []chan func()
 
-	// The nodes active in this test.
-	nodes []*nodeState
+	// The Nodes active in this test.
+	Nodes []*NodeState
 
 	// The ACP options to share between each node.
-	documentACPOptions []node.DocumentACPOpt
+	DocumentACPOptions []node.DocumentACPOpt
 
 	// The names of the collections active in this test.
 	// Indexes matches that of initial collections.
-	collectionNames []string
+	CollectionNames []string
 
 	// A map of the collection indexes by their CollectionID, this allows easier
 	// identification of collections in a natural, human readable, order
 	// even when they are renamed.
-	collectionIndexesByCollectionID map[string]int
+	CollectionIndexesByCollectionID map[string]int
 
 	// Document IDs by index, by collection index.
 	//
 	// Each index is assumed to be global, and may be expected across multiple
 	// nodes.
-	docIDs [][]client.DocID
+	DocIDs [][]client.DocID
 
-	// isBench indicates wether the test is currently being benchmarked.
-	isBench bool
+	// IsBench indicates wether the test is currently being benchmarked.
+	IsBench bool
 
 	// The SourceHub address used to pay for SourceHub transactions.
-	sourcehubAddress string
+	SourcehubAddress string
 
-	// isNetworkEnabled indicates whether the network is enabled.
-	isNetworkEnabled bool
+	// IsNetworkEnabled indicates whether the network is enabled.
+	IsNetworkEnabled bool
 
-	// statefulMatchers contains all stateful matchers that have been executed during a single
-	// test run. After a single test run, the statefulMatchers are reset.
-	statefulMatchers []StatefulMatcher
+	// StatefulMatchers contains all stateful matchers that have been executed during a single
+	// test run. After a single test run, the StatefulMatchers are reset.
+	StatefulMatchers []StatefulMatcher
 
 	// node id that is currently being asserted. This is used by [StatefulMatcher]s to know for which
 	// node they should be asserting. For example, the [UniqueValue] matcher checks that it is
 	// called with a value that it didn't see before, but the value should be the same for different
 	// nodes, e.g. within the same node Cids should be unique, but across different nodes the same block
 	// should have the same Cid.
-	currentNodeID int
+	CurrentNodeID int
 }
 
-func (s *state) GetClientType() ClientType {
-	return s.clientType
+func (s *State) GetClientType() ClientType {
+	return s.ClientType
 }
 
-func (s *state) GetCurrentNodeID() int {
-	return s.currentNodeID
+func (s *State) GetCurrentNodeID() int {
+	return s.CurrentNodeID
 }
 
-func (s *state) GetIdentity(ident Identity) acpIdentity.Identity {
-	return getIdentity(s, immutable.Some(ident))
+func (s *State) GetIdentity(ident Identity) acpIdentity.Identity {
+	return GetIdentity(s, immutable.Some(ident))
 }
 
-var _ TestState = &state{}
+var _ TestState = &State{}
 
-// newState returns a new fresh state for the given testCase.
-func newState(
+// NewState returns a new fresh state for the given testCase.
+func NewState(
 	ctx context.Context,
 	t testing.TB,
 	testCase TestCase,
@@ -254,26 +251,26 @@ func newState(
 	dbt DatabaseType,
 	clientType ClientType,
 	collectionNames []string,
-) *state {
-	s := &state{
-		ctx:                             ctx,
-		t:                               t,
-		kms:                             kms,
-		dbt:                             dbt,
-		clientType:                      clientType,
-		txns:                            []client.Txn{},
+) *State {
+	s := &State{
+		Ctx:                             ctx,
+		T:                               t,
+		Kms:                             kms,
+		Dbt:                             dbt,
+		ClientType:                      clientType,
+		Txns:                            []client.Txn{},
 		IdentityTypes:                   testCase.IdentityTypes,
-		identities:                      map[Identity]*identityHolder{},
-		nextIdentityGenSeed:             0,
-		allActionsDone:                  make(chan struct{}),
-		subscriptionResultsChans:        []chan func(){},
-		nodes:                           []*nodeState{},
-		documentACPOptions:              []node.DocumentACPOpt{},
-		collectionNames:                 collectionNames,
-		collectionIndexesByCollectionID: map[string]int{},
-		docIDs:                          [][]client.DocID{},
-		policyIDs:                       [][]string{},
-		isBench:                         false,
+		Identities:                      map[Identity]*IdentityHolder{},
+		NextIdentityGenSeed:             0,
+		AllActionsDone:                  make(chan struct{}),
+		SubscriptionResultsChans:        []chan func(){},
+		Nodes:                           []*NodeState{},
+		DocumentACPOptions:              []node.DocumentACPOpt{},
+		CollectionNames:                 collectionNames,
+		CollectionIndexesByCollectionID: map[string]int{},
+		DocIDs:                          [][]client.DocID{},
+		PolicyIDs:                       [][]string{},
+		IsBench:                         false,
 	}
 	return s
 }

--- a/tests/integration/state.go
+++ b/tests/integration/state.go
@@ -243,17 +243,6 @@ func (s *state) GetIdentity(ident Identity) acpIdentity.Identity {
 	return getIdentity(s, immutable.Some(ident))
 }
 
-// TestState is read-only interface for test state. It allows passing the state to custom matchers
-// without allowing them to modify the state.
-type TestState interface {
-	// GetClientType returns the client type of the test.
-	GetClientType() ClientType
-	// GetCurrentNodeID returns the node id that is currently being asserted.
-	GetCurrentNodeID() int
-	// GetIdentity returns the identity for the given node index.
-	GetIdentity(Identity) acpIdentity.Identity
-}
-
 var _ TestState = &state{}
 
 // newState returns a new fresh state for the given testCase.

--- a/tests/integration/state.go
+++ b/tests/integration/state.go
@@ -21,6 +21,7 @@ import (
 
 	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
+	"github.com/sourcenetwork/defradb/crypto"
 	"github.com/sourcenetwork/defradb/event"
 	netConfig "github.com/sourcenetwork/defradb/net/config"
 	"github.com/sourcenetwork/defradb/node"
@@ -149,9 +150,6 @@ type state struct {
 	// The Go Test test state
 	t testing.TB
 
-	// The TestCase currently being executed.
-	testCase TestCase
-
 	// The type of KMS currently being tested.
 	kms KMSType
 
@@ -165,6 +163,10 @@ type state struct {
 	//
 	// This is order dependent and the property is accessed by index.
 	txns []client.Txn
+
+	// IdentityTypes is a map of identity to key type.
+	// Use it to customize the key type that is used for identity and signing.
+	IdentityTypes map[Identity]crypto.KeyType
 
 	// identities contains all identities created in this test.
 	// The map key is the identity reference that uniquely identifies identities of different
@@ -267,11 +269,11 @@ func newState(
 	s := &state{
 		ctx:                             ctx,
 		t:                               t,
-		testCase:                        testCase,
 		kms:                             kms,
 		dbt:                             dbt,
 		clientType:                      clientType,
 		txns:                            []client.Txn{},
+		IdentityTypes:                   testCase.IdentityTypes,
 		identities:                      map[Identity]*identityHolder{},
 		nextIdentityGenSeed:             0,
 		allActionsDone:                  make(chan struct{}),

--- a/tests/integration/test_case.go
+++ b/tests/integration/test_case.go
@@ -22,6 +22,7 @@ import (
 	netConfig "github.com/sourcenetwork/defradb/net/config"
 	"github.com/sourcenetwork/defradb/tests/gen"
 	"github.com/sourcenetwork/defradb/tests/predefined"
+	"github.com/sourcenetwork/defradb/tests/state"
 )
 
 // TestCase contains the details of the test case to execute.
@@ -46,7 +47,7 @@ type TestCase struct {
 	//
 	// This is to only be used in the very rare cases where we really do want behavioural
 	// differences between client types, or we need to temporarily document a bug.
-	SupportedClientTypes immutable.Option[[]ClientType]
+	SupportedClientTypes immutable.Option[[]state.ClientType]
 
 	// If provided a value, SupportedDocumentACPTypes will cause this test to be skipped
 	// if the active acp type is not within the given set.
@@ -67,7 +68,7 @@ type TestCase struct {
 	//
 	// This is to only be used in the very rare cases where we really do want behavioural
 	// differences between database types, or we need to temporarily document a bug.
-	SupportedDatabaseTypes immutable.Option[[]DatabaseType]
+	SupportedDatabaseTypes immutable.Option[[]state.DatabaseType]
 
 	// Configuration for KMS to be used in the test
 	KMS KMS
@@ -78,7 +79,7 @@ type TestCase struct {
 
 	// IdentityTypes is a map of identity to key type.
 	// Use it to customize the key type that is used for identity and signing.
-	IdentityTypes map[Identity]crypto.KeyType
+	IdentityTypes map[state.Identity]crypto.KeyType
 }
 
 // KMS contains the configuration for KMS to be used in the test
@@ -87,7 +88,7 @@ type KMS struct {
 	Activated bool
 	// ExcludedTypes specifies the KMS types that should be excluded from the test.
 	// If none are specified all types will be used.
-	ExcludedTypes []KMSType
+	ExcludedTypes []state.KMSType
 }
 
 // SetupComplete is a flag to explicitly notify the change detector at which point
@@ -351,7 +352,7 @@ type CreateDoc struct {
 	//
 	// Use `ClientIdentity` to create a client identity and `NodeIdentity` to create a node identity.
 	// Default value is `NoIdentity()`.
-	Identity immutable.Option[Identity]
+	Identity immutable.Option[state.Identity]
 
 	// Specifies whether the document should be encrypted.
 	IsDocEncrypted bool
@@ -423,7 +424,7 @@ type DeleteDoc struct {
 	//
 	// Use `ClientIdentity` to create a client identity and `NodeIdentity` to create a node identity.
 	// Default value is `NoIdentity()`.
-	Identity immutable.Option[Identity]
+	Identity immutable.Option[state.Identity]
 
 	// The collection in which this document should be deleted.
 	CollectionID int
@@ -456,7 +457,7 @@ type UpdateDoc struct {
 	//
 	// Use `ClientIdentity` to create a client identity and `NodeIdentity` to create a node identity.
 	// Default value is `NoIdentity()`.
-	Identity immutable.Option[Identity]
+	Identity immutable.Option[state.Identity]
 
 	// The collection in which this document exists.
 	CollectionID int
@@ -499,7 +500,7 @@ type UpdateWithFilter struct {
 	//
 	// Use `ClientIdentity` to create a client identity and `NodeIdentity` to create a node identity.
 	// Default value is `NoIdentity()`.
-	Identity immutable.Option[Identity]
+	Identity immutable.Option[state.Identity]
 
 	// The collection in which this document exists.
 	CollectionID int
@@ -629,7 +630,7 @@ type Benchmark struct {
 	// Reps is the number of times to run the benchmark.
 	Reps int
 	// FocusClients is the list of clients to run the benchmark on.
-	FocusClients []ClientType
+	FocusClients []state.ClientType
 	// Factor is the factor by which the optimized case should be better than the base case.
 	Factor float64
 }
@@ -651,7 +652,7 @@ type Request struct {
 	//
 	// Use `ClientIdentity` to create a client identity and `NodeIdentity` to create a node identity.
 	// Default value is `NoIdentity()`.
-	Identity immutable.Option[Identity]
+	Identity immutable.Option[state.Identity]
 
 	// Used to identify the transaction for this to run against. Optional.
 	TransactionID immutable.Option[int]
@@ -854,7 +855,7 @@ type GetNodeIdentity struct {
 	//
 	// Use `ClientIdentity` to create a client identity and `NodeIdentity` to create a node identity.
 	// Default value is `NoIdentity()`.
-	ExpectedIdentity immutable.Option[Identity]
+	ExpectedIdentity immutable.Option[state.Identity]
 }
 
 // Wait is an action that will wait for the given duration.
@@ -872,10 +873,10 @@ type VerifyBlockSignature struct {
 	//
 	// Use `ClientIdentity` to create a client identity and `NodeIdentity` to create a node identity.
 	// Default value is `NoIdentity()`.
-	Identity immutable.Option[Identity]
+	Identity immutable.Option[state.Identity]
 
 	// The identity of the author of the block to verify the signature of.
-	SignerIdentity Identity
+	SignerIdentity state.Identity
 
 	// Any error expected from the action. Optional.
 	//

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -783,8 +783,9 @@ func startNodes(s *state.State, testCase TestCase, action Start) {
 		for _, opt := range s.Nodes[nodeIndex].NetOpts {
 			opts = append(opts, opt)
 		}
+
 		var addresses []string
-		for _, addr := range s.Nodes[nodeIndex].PeerInfo().Addrs {
+		for _, addr := range s.Nodes[nodeIndex].AddrInfo.Addrs {
 			addresses = append(addresses, addr.String())
 		}
 		opts = append(opts, netConfig.WithListenAddresses(addresses...))

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -263,7 +263,7 @@ func executeTestCase(
 
 	startActionIndex, endActionIndex := getActionRange(t, testCase)
 
-	s := newState(ctx, t, testCase, kms, dbt, clientType, collectionNames)
+	s := NewState(ctx, t, testCase, kms, dbt, clientType, collectionNames)
 	setStartingNodes(s, testCase)
 
 	// It is very important that the databases are always closed, otherwise resources will leak
@@ -286,9 +286,9 @@ func executeTestCase(
 	resetMatchers(s)
 
 	// Notify any active subscriptions that all requests have been sent.
-	close(s.allActionsDone)
+	close(s.AllActionsDone)
 
-	for _, resultsChan := range s.subscriptionResultsChans {
+	for _, resultsChan := range s.SubscriptionResultsChans {
 		select {
 		case subscriptionAssert := <-resultsChan:
 			// We want to assert back in the main thread so failures get recorded properly
@@ -302,7 +302,7 @@ func executeTestCase(
 }
 
 func performAction(
-	s *state,
+	s *State,
 	testCase TestCase,
 	actionIndex int,
 	act any,
@@ -456,28 +456,28 @@ func performAction(
 		// no-op, just continue.
 
 	default:
-		s.t.Fatalf("Unknown action type %T", action)
+		s.T.Fatalf("Unknown action type %T", action)
 	}
 }
 
-func createGenerateDocs(s *state, docs []gen.GeneratedDoc, nodeID immutable.Option[int]) {
+func createGenerateDocs(s *State, docs []gen.GeneratedDoc, nodeID immutable.Option[int]) {
 	nameToInd := make(map[string]int)
-	for i, name := range s.collectionNames {
+	for i, name := range s.CollectionNames {
 		nameToInd[name] = i
 	}
 	for _, doc := range docs {
 		docJSON, err := doc.Doc.String()
 		if err != nil {
-			s.t.Fatalf("Failed to generate docs %s", err)
+			s.T.Fatalf("Failed to generate docs %s", err)
 		}
 		createDoc(s, CreateDoc{CollectionID: nameToInd[doc.Col.Version.Name], Doc: docJSON, NodeID: nodeID})
 	}
 }
 
-func generateDocs(s *state, action GenerateDocs) {
-	nodeIDs, _ := getNodesWithIDs(action.NodeID, s.nodes)
+func generateDocs(s *State, action GenerateDocs) {
+	nodeIDs, _ := getNodesWithIDs(action.NodeID, s.Nodes)
 	firstNodesID := nodeIDs[0]
-	collections := s.nodes[firstNodesID].collections
+	collections := s.Nodes[firstNodesID].Collections
 	defs := make([]client.CollectionDefinition, 0, len(collections))
 	for _, collection := range collections {
 		if len(action.ForCollections) == 0 || slices.Contains(action.ForCollections, collection.Name()) {
@@ -486,40 +486,40 @@ func generateDocs(s *state, action GenerateDocs) {
 	}
 	docs, err := gen.AutoGenerate(defs, action.Options...)
 	if err != nil {
-		s.t.Fatalf("Failed to generate docs %s", err)
+		s.T.Fatalf("Failed to generate docs %s", err)
 	}
 	createGenerateDocs(s, docs, action.NodeID)
 }
 
-func generatePredefinedDocs(s *state, action CreatePredefinedDocs) {
-	nodeIDs, _ := getNodesWithIDs(action.NodeID, s.nodes)
+func generatePredefinedDocs(s *State, action CreatePredefinedDocs) {
+	nodeIDs, _ := getNodesWithIDs(action.NodeID, s.Nodes)
 	firstNodesID := nodeIDs[0]
-	collections := s.nodes[firstNodesID].collections
+	collections := s.Nodes[firstNodesID].Collections
 	defs := make([]client.CollectionDefinition, 0, len(collections))
 	for _, col := range collections {
 		defs = append(defs, col.Definition())
 	}
 	docs, err := predefined.Create(defs, action.Docs)
 	if err != nil {
-		s.t.Fatalf("Failed to generate docs %s", err)
+		s.T.Fatalf("Failed to generate docs %s", err)
 	}
 	createGenerateDocs(s, docs, action.NodeID)
 }
 
 func benchmarkAction(
-	s *state,
+	s *State,
 	testCase TestCase,
 	actionIndex int,
 	bench Benchmark,
 ) {
-	if s.dbt == DefraIMType {
+	if s.Dbt == DefraIMType {
 		// Benchmarking makes no sense for test in-memory storage
 		return
 	}
 	if len(bench.FocusClients) > 0 {
 		isFound := false
 		for _, clientType := range bench.FocusClients {
-			if s.clientType == clientType {
+			if s.ClientType == clientType {
 				isFound = true
 				break
 			}
@@ -537,14 +537,14 @@ func benchmarkAction(
 		return time.Since(startTime)
 	}
 
-	s.isBench = true
-	defer func() { s.isBench = false }()
+	s.IsBench = true
+	defer func() { s.IsBench = false }()
 
 	baseElapsedTime := runBench(bench.BaseCase)
 	optimizedElapsedTime := runBench(bench.OptimizedCase)
 
 	factoredBaseTime := int64(float64(baseElapsedTime) / bench.Factor)
-	assert.Greater(s.t, factoredBaseTime, optimizedElapsedTime,
+	assert.Greater(s.T, factoredBaseTime, optimizedElapsedTime,
 		"Optimized case should be faster at least by factor of %.2f than the base case. Base: %d, Optimized: %d (μs)",
 		bench.Factor, optimizedElapsedTime.Microseconds(), baseElapsedTime.Microseconds())
 }
@@ -618,13 +618,13 @@ func getCollectionNamesFromSchema(result map[string]int, schema string, nextInde
 
 // closeNodes closes all the given nodes, ensuring that resources are properly released.
 func closeNodes(
-	s *state,
+	s *State,
 	action Close,
 ) {
-	_, nodes := getNodesWithIDs(action.NodeID, s.nodes)
+	_, nodes := getNodesWithIDs(action.NodeID, s.Nodes)
 	for _, node := range nodes {
 		node.Close()
-		node.closed = true
+		node.Closed = true
 	}
 }
 
@@ -638,7 +638,7 @@ func closeNodes(
 // greater than 0. For example if requesting a node with nodeID=2 then the resulting output will contain only
 // one element (at index 0) caller might accidentally assume that this node belongs to node 0. Therefore, the
 // caller should always use the returned IDs, instead of guessing the IDs based on node indexes.
-func getNodesWithIDs(nodeID immutable.Option[int], nodes []*nodeState) ([]int, []*nodeState) {
+func getNodesWithIDs(nodeID immutable.Option[int], nodes []*NodeState) ([]int, []*NodeState) {
 	if !nodeID.HasValue() {
 		indexes := make([]int, len(nodes))
 		for i := range nodes {
@@ -647,7 +647,7 @@ func getNodesWithIDs(nodeID immutable.Option[int], nodes []*nodeState) ([]int, [
 		return indexes, nodes
 	}
 
-	return []int{nodeID.Value()}, []*nodeState{nodes[nodeID.Value()]}
+	return []int{nodeID.Value()}, []*NodeState{nodes[nodeID.Value()]}
 }
 
 func calculateLenForFlattenedActions(testCase *TestCase) int {
@@ -753,45 +753,45 @@ ActionLoop:
 // If a node(s) has been explicitly configured via a `ConfigureNode` action then no new
 // nodes will be added.
 func setStartingNodes(
-	s *state,
+	s *State,
 	testCase TestCase,
 ) {
 	for _, action := range testCase.Actions {
 		switch action.(type) {
 		case ConfigureNode:
-			s.isNetworkEnabled = true
+			s.IsNetworkEnabled = true
 		}
 	}
 
 	// If nodes have not been explicitly configured via actions, setup a default one.
-	if !s.isNetworkEnabled {
-		st, err := setupNode(s, testCase, db.WithNodeIdentity(getIdentity(s, NodeIdentity(0))))
-		require.Nil(s.t, err)
-		s.nodes = append(s.nodes, st)
+	if !s.IsNetworkEnabled {
+		st, err := setupNode(s, testCase, db.WithNodeIdentity(GetIdentity(s, NodeIdentity(0))))
+		require.Nil(s.T, err)
+		s.Nodes = append(s.Nodes, st)
 	}
 }
 
-func startNodes(s *state, testCase TestCase, action Start) {
-	nodeIDs, nodes := getNodesWithIDs(action.NodeID, s.nodes)
+func startNodes(s *State, testCase TestCase, action Start) {
+	nodeIDs, nodes := getNodesWithIDs(action.NodeID, s.Nodes)
 	// We need to restart the nodes in reverse order, to avoid dial backoff issues.
 	for i := len(nodes) - 1; i >= 0; i-- {
 		nodeIndex := nodeIDs[i]
 		originalPath := databaseDir
-		databaseDir = s.nodes[nodeIndex].dbPath
-		opts := []node.Option{db.WithNodeIdentity(getIdentity(s, NodeIdentity(nodeIndex)))}
-		for _, opt := range s.nodes[nodeIndex].netOpts {
+		databaseDir = s.Nodes[nodeIndex].DbPath
+		opts := []node.Option{db.WithNodeIdentity(GetIdentity(s, NodeIdentity(nodeIndex)))}
+		for _, opt := range s.Nodes[nodeIndex].NetOpts {
 			opts = append(opts, opt)
 		}
 		var addresses []string
-		for _, addr := range s.nodes[nodeIndex].peerInfo.Addrs {
+		for _, addr := range s.Nodes[nodeIndex].PeerInfo().Addrs {
 			addresses = append(addresses, addr.String())
 		}
 		opts = append(opts, netConfig.WithListenAddresses(addresses...))
 		node, err := setupNode(s, testCase, opts...)
-		require.NoError(s.t, err)
+		require.NoError(s.T, err)
 		databaseDir = originalPath
-		node.p2p = s.nodes[nodeIndex].p2p
-		s.nodes[nodeIndex] = node
+		node.P2p = s.Nodes[nodeIndex].P2p
+		s.Nodes[nodeIndex] = node
 	}
 
 	// If the db was restarted we need to refresh the collection definitions as the old instances
@@ -800,10 +800,10 @@ func startNodes(s *state, testCase TestCase, action Start) {
 }
 
 func restartNodes(
-	s *state,
+	s *State,
 	testCase TestCase,
 ) {
-	if s.dbt == BadgerIMType || s.dbt == DefraIMType {
+	if s.Dbt == BadgerIMType || s.Dbt == DefraIMType {
 		return
 	}
 	closeNodes(s, Close{})
@@ -816,22 +816,22 @@ func restartNodes(
 // If a given collection is not present in the database the value at the corresponding
 // result-index will be nil.
 func refreshCollections(
-	s *state,
+	s *State,
 ) {
-	for _, node := range s.nodes {
-		node.collections = make([]client.Collection, len(s.collectionNames))
-		allCollections, err := node.GetCollections(s.ctx, client.CollectionFetchOptions{})
-		require.Nil(s.t, err)
+	for _, node := range s.Nodes {
+		node.Collections = make([]client.Collection, len(s.CollectionNames))
+		allCollections, err := node.GetCollections(s.Ctx, client.CollectionFetchOptions{})
+		require.Nil(s.T, err)
 
-		for i, collectionName := range s.collectionNames {
+		for i, collectionName := range s.CollectionNames {
 			for _, collection := range allCollections {
 				if collection.Name() == collectionName {
-					if _, ok := s.collectionIndexesByCollectionID[collection.Version().CollectionID]; !ok {
+					if _, ok := s.CollectionIndexesByCollectionID[collection.Version().CollectionID]; !ok {
 						// If the root is not found here this is likely the first refreshCollections
 						// call of the test, we map it by root in case the collection is renamed -
 						// we still wish to preserve the original index so test maintainers can reference
 						// them in a convenient manner.
-						s.collectionIndexesByCollectionID[collection.Version().CollectionID] = i
+						s.CollectionIndexesByCollectionID[collection.Version().CollectionID] = i
 					}
 					break
 				}
@@ -839,8 +839,8 @@ func refreshCollections(
 		}
 
 		for _, collection := range allCollections {
-			if index, ok := s.collectionIndexesByCollectionID[collection.Version().CollectionID]; ok {
-				node.collections[index] = collection
+			if index, ok := s.CollectionIndexesByCollectionID[collection.Version().CollectionID]; ok {
+				node.Collections[index] = collection
 			}
 		}
 	}
@@ -851,18 +851,18 @@ func refreshCollections(
 // It returns the new node, and its peer address. Any errors generated during configuration
 // will result in a test failure.
 func configureNode(
-	s *state,
+	s *State,
 	testCase TestCase,
 	action ConfigureNode,
 ) {
 	if changeDetector.Enabled {
 		// We do not yet support the change detector for tests running across multiple nodes.
-		s.t.SkipNow()
+		s.T.SkipNow()
 		return
 	}
 
 	privateKey, err := crypto.GenerateEd25519()
-	require.NoError(s.t, err)
+	require.NoError(s.T, err)
 
 	netNodeOpts := action()
 	netNodeOpts = append(netNodeOpts, netConfig.WithPrivateKey(privateKey))
@@ -871,20 +871,20 @@ func configureNode(
 	for _, opt := range netNodeOpts {
 		nodeOpts = append(nodeOpts, opt)
 	}
-	nodeOpts = append(nodeOpts, db.WithNodeIdentity(getIdentity(s, NodeIdentity(len(s.nodes)))))
+	nodeOpts = append(nodeOpts, db.WithNodeIdentity(GetIdentity(s, NodeIdentity(len(s.Nodes)))))
 
 	node, err := setupNode(s, testCase, nodeOpts...) //disable change detector, or allow it?
-	require.NoError(s.t, err)
+	require.NoError(s.T, err)
 
-	s.nodes = append(s.nodes, node)
+	s.Nodes = append(s.Nodes, node)
 }
 
 func refreshDocuments(
-	s *state,
+	s *State,
 	testCase TestCase,
 	startActionIndex int,
 ) {
-	if len(s.nodes) == 0 {
+	if len(s.Nodes) == 0 {
 		// This should only be possible at the moment for P2P testing, for which the
 		// change detector is currently disabled.  We'll likely need some fancier logic
 		// here if/when we wish to enable it.
@@ -894,10 +894,10 @@ func refreshDocuments(
 	// For now just do the initial setup using the collections on the first node,
 	// this may need to become more involved at a later date depending on testing
 	// requirements.
-	s.docIDs = make([][]client.DocID, len(s.nodes[0].collections))
+	s.DocIDs = make([][]client.DocID, len(s.Nodes[0].Collections))
 
-	for i := range s.nodes[0].collections {
-		s.docIDs[i] = []client.DocID{}
+	for i := range s.Nodes[0].Collections {
+		s.DocIDs[i] = []client.DocID{}
 	}
 
 	for i := 0; i < startActionIndex; i++ {
@@ -905,11 +905,11 @@ func refreshDocuments(
 		// otherwise they cannot be referenced correctly by other actions.
 		switch action := testCase.Actions[i].(type) {
 		case CreateDoc:
-			nodeIDs, _ := getNodesWithIDs(action.NodeID, s.nodes)
+			nodeIDs, _ := getNodesWithIDs(action.NodeID, s.Nodes)
 			// Just use the collection from the first relevant node, as all will be the same for this
 			// purpose.
 			firstNodesID := nodeIDs[0]
-			collection := s.nodes[firstNodesID].collections[action.CollectionID]
+			collection := s.Nodes[firstNodesID].Collections[action.CollectionID]
 
 			if action.DocMap != nil {
 				substituteRelations(s, action)
@@ -922,44 +922,44 @@ func refreshDocuments(
 			}
 
 			for _, doc := range docs {
-				s.docIDs[action.CollectionID] = append(s.docIDs[action.CollectionID], doc.ID())
+				s.DocIDs[action.CollectionID] = append(s.DocIDs[action.CollectionID], doc.ID())
 			}
 		}
 	}
 }
 
 func getIndexes(
-	s *state,
+	s *State,
 	action GetIndexes,
 ) {
-	if len(s.nodes) == 0 {
+	if len(s.Nodes) == 0 {
 		return
 	}
 
 	var expectedErrorRaised bool
 
-	nodeIDs, _ := getNodesWithIDs(action.NodeID, s.nodes)
+	nodeIDs, _ := getNodesWithIDs(action.NodeID, s.Nodes)
 	for _, nodeID := range nodeIDs {
-		collections := s.nodes[nodeID].collections
+		collections := s.Nodes[nodeID].Collections
 		err := withRetryOnNode(
-			s.nodes[nodeID],
+			s.Nodes[nodeID],
 			func() error {
-				actualIndexes, err := collections[action.CollectionID].GetIndexes(s.ctx)
+				actualIndexes, err := collections[action.CollectionID].GetIndexes(s.Ctx)
 				if err != nil {
 					return err
 				}
 
 				assertIndexesListsEqual(action.ExpectedIndexes,
-					actualIndexes, s.t)
+					actualIndexes, s.T)
 
 				return nil
 			},
 		)
 		expectedErrorRaised = expectedErrorRaised ||
-			AssertError(s.t, err, action.ExpectedError)
+			AssertError(s.T, err, action.ExpectedError)
 	}
 
-	assertExpectedErrorRaised(s.t, action.ExpectedError, expectedErrorRaised)
+	assertExpectedErrorRaised(s.T, action.ExpectedError, expectedErrorRaised)
 }
 
 func assertIndexesListsEqual(
@@ -1023,27 +1023,27 @@ func assertIndexesEqual(expectedIndex, actualIndex client.IndexDescription, t te
 
 // updateSchema updates the schema using the given details.
 func updateSchema(
-	s *state,
+	s *State,
 	action SchemaUpdate,
 ) {
 	// Do some sanitation checks if PolicyIDs are to be substituted, and error out early if invalid usage.
 	if len(action.Replace) > 0 {
 		for substituteLabel := range action.Replace {
 			if substituteLabel == "" {
-				require.Fail(s.t, "Empty substitution label.")
+				require.Fail(s.T, "Empty substitution label.")
 			}
 
 			howManyLabelsToSub := strings.Count(action.Schema, substituteLabel)
 			if howManyLabelsToSub == 0 {
 				require.Fail(
-					s.t,
+					s.T,
 					"Can't do substitution because no label: "+substituteLabel,
 				)
 			}
 		}
 	}
 
-	nodeIDs, nodes := getNodesWithIDs(action.NodeID, s.nodes)
+	nodeIDs, nodes := getNodesWithIDs(action.NodeID, s.Nodes)
 	for index, node := range nodes {
 		// This schema might be modified if the caller needs some substitution magic done.
 		var modifiedSchema = action.Schema
@@ -1051,12 +1051,12 @@ func updateSchema(
 		// We need to substitute the policyIDs into the `%policyID% place holders.
 		if len(action.Replace) > 0 {
 			nodeID := nodeIDs[index]
-			nodesPolicyIDs := s.policyIDs[nodeID]
+			nodesPolicyIDs := s.PolicyIDs[nodeID]
 			templateData := map[string]string{}
 			// Build template with the replacing values.
 			for substituteLabel, replaceWith := range action.Replace {
 				replacer, err := replaceWith.Replacer(nodesPolicyIDs)
-				require.NoError(s.t, err)
+				require.NoError(s.T, err)
 				templateData[substituteLabel] = replacer
 			}
 
@@ -1065,16 +1065,16 @@ func updateSchema(
 			var renderedSchema bytes.Buffer
 			err := tmpl.Execute(&renderedSchema, templateData)
 			if err != nil {
-				require.Fail(s.t, "Template execution for schema update failed.")
+				require.Fail(s.T, "Template execution for schema update failed.")
 			}
 
 			modifiedSchema = renderedSchema.String()
 		}
 
-		results, err := node.AddSchema(s.ctx, modifiedSchema)
-		expectedErrorRaised := AssertError(s.t, err, action.ExpectedError)
+		results, err := node.AddSchema(s.Ctx, modifiedSchema)
+		expectedErrorRaised := AssertError(s.T, err, action.ExpectedError)
 
-		assertExpectedErrorRaised(s.t, action.ExpectedError, expectedErrorRaised)
+		assertExpectedErrorRaised(s.T, action.ExpectedError, expectedErrorRaised)
 
 		if action.ExpectedResults != nil {
 			assertCollectionVersions(s, action.ExpectedResults, results)
@@ -1086,10 +1086,10 @@ func updateSchema(
 }
 
 func patchSchema(
-	s *state,
+	s *State,
 	action SchemaPatch,
 ) {
-	_, nodes := getNodesWithIDs(action.NodeID, s.nodes)
+	_, nodes := getNodesWithIDs(action.NodeID, s.Nodes)
 	for _, node := range nodes {
 		var setAsDefaultVersion bool
 		if action.SetAsDefaultVersion.HasValue() {
@@ -1098,10 +1098,10 @@ func patchSchema(
 			setAsDefaultVersion = true
 		}
 
-		err := node.PatchSchema(s.ctx, action.Patch, action.Lens, setAsDefaultVersion)
-		expectedErrorRaised := AssertError(s.t, err, action.ExpectedError)
+		err := node.PatchSchema(s.Ctx, action.Patch, action.Lens, setAsDefaultVersion)
+		expectedErrorRaised := AssertError(s.T, err, action.ExpectedError)
 
-		assertExpectedErrorRaised(s.t, action.ExpectedError, expectedErrorRaised)
+		assertExpectedErrorRaised(s.T, action.ExpectedError, expectedErrorRaised)
 	}
 
 	// If the schema was updated we need to refresh the collection definitions.
@@ -1109,15 +1109,15 @@ func patchSchema(
 }
 
 func patchCollection(
-	s *state,
+	s *State,
 	action PatchCollection,
 ) {
-	_, nodes := getNodesWithIDs(action.NodeID, s.nodes)
+	_, nodes := getNodesWithIDs(action.NodeID, s.Nodes)
 	for _, node := range nodes {
-		err := node.PatchCollection(s.ctx, action.Patch)
-		expectedErrorRaised := AssertError(s.t, err, action.ExpectedError)
+		err := node.PatchCollection(s.Ctx, action.Patch)
+		expectedErrorRaised := AssertError(s.T, err, action.ExpectedError)
 
-		assertExpectedErrorRaised(s.t, action.ExpectedError, expectedErrorRaised)
+		assertExpectedErrorRaised(s.T, action.ExpectedError, expectedErrorRaised)
 	}
 
 	// If the schema was updated we need to refresh the collection definitions.
@@ -1125,21 +1125,21 @@ func patchCollection(
 }
 
 func getSchema(
-	s *state,
+	s *State,
 	action GetSchema,
 ) {
-	_, nodes := getNodesWithIDs(action.NodeID, s.nodes)
+	_, nodes := getNodesWithIDs(action.NodeID, s.Nodes)
 	for _, node := range nodes {
 		var results []client.SchemaDescription
 		var err error
 		switch {
 		case action.VersionID.HasValue():
-			result, e := node.GetSchemaByVersionID(s.ctx, action.VersionID.Value())
+			result, e := node.GetSchemaByVersionID(s.Ctx, action.VersionID.Value())
 			err = e
 			results = []client.SchemaDescription{result}
 		default:
 			results, err = node.GetSchemas(
-				s.ctx,
+				s.Ctx,
 				client.SchemaFetchOptions{
 					Root: action.Root,
 					Name: action.Name,
@@ -1147,31 +1147,31 @@ func getSchema(
 			)
 		}
 
-		expectedErrorRaised := AssertError(s.t, err, action.ExpectedError)
-		assertExpectedErrorRaised(s.t, action.ExpectedError, expectedErrorRaised)
+		expectedErrorRaised := AssertError(s.T, err, action.ExpectedError)
+		assertExpectedErrorRaised(s.T, action.ExpectedError, expectedErrorRaised)
 
 		if !expectedErrorRaised {
-			require.Equal(s.t, action.ExpectedResults, results)
+			require.Equal(s.T, action.ExpectedResults, results)
 		}
 	}
 }
 
 func getCollections(
-	s *state,
+	s *State,
 	action GetCollections,
 ) {
-	_, nodes := getNodesWithIDs(action.NodeID, s.nodes)
+	_, nodes := getNodesWithIDs(action.NodeID, s.Nodes)
 	for _, node := range nodes {
 		txn := getTransaction(s, node, action.TransactionID, "")
-		ctx := db.InitContext(s.ctx, txn)
+		ctx := db.InitContext(s.Ctx, txn)
 		results, err := node.GetCollections(ctx, action.FilterOptions)
 		resultDescriptions := make([]client.CollectionVersion, len(results))
 		for i, col := range results {
 			resultDescriptions[i] = col.Version()
 		}
 
-		expectedErrorRaised := AssertError(s.t, err, action.ExpectedError)
-		assertExpectedErrorRaised(s.t, action.ExpectedError, expectedErrorRaised)
+		expectedErrorRaised := AssertError(s.T, err, action.ExpectedError)
+		assertExpectedErrorRaised(s.T, action.ExpectedError, expectedErrorRaised)
 
 		if !expectedErrorRaised {
 			assertCollectionVersions(s, action.ExpectedResults, resultDescriptions)
@@ -1180,22 +1180,22 @@ func getCollections(
 }
 
 func setActiveSchemaVersion(
-	s *state,
+	s *State,
 	action SetActiveSchemaVersion,
 ) {
-	_, nodes := getNodesWithIDs(action.NodeID, s.nodes)
+	_, nodes := getNodesWithIDs(action.NodeID, s.Nodes)
 	for _, node := range nodes {
-		err := node.SetActiveSchemaVersion(s.ctx, action.SchemaVersionID)
-		expectedErrorRaised := AssertError(s.t, err, action.ExpectedError)
+		err := node.SetActiveSchemaVersion(s.Ctx, action.SchemaVersionID)
+		expectedErrorRaised := AssertError(s.T, err, action.ExpectedError)
 
-		assertExpectedErrorRaised(s.t, action.ExpectedError, expectedErrorRaised)
+		assertExpectedErrorRaised(s.T, action.ExpectedError, expectedErrorRaised)
 	}
 
 	refreshCollections(s)
 }
 
 func createView(
-	s *state,
+	s *State,
 	action CreateView,
 ) {
 	if viewType == MaterializedViewType {
@@ -1211,38 +1211,38 @@ func createView(
 		}, "")
 	}
 
-	_, nodes := getNodesWithIDs(action.NodeID, s.nodes)
+	_, nodes := getNodesWithIDs(action.NodeID, s.Nodes)
 	for _, node := range nodes {
-		_, err := node.AddView(s.ctx, action.Query, action.SDL, action.Transform)
-		expectedErrorRaised := AssertError(s.t, err, action.ExpectedError)
+		_, err := node.AddView(s.Ctx, action.Query, action.SDL, action.Transform)
+		expectedErrorRaised := AssertError(s.T, err, action.ExpectedError)
 
-		assertExpectedErrorRaised(s.t, action.ExpectedError, expectedErrorRaised)
+		assertExpectedErrorRaised(s.T, action.ExpectedError, expectedErrorRaised)
 	}
 }
 
 func refreshViews(
-	s *state,
+	s *State,
 	action RefreshViews,
 ) {
-	_, nodes := getNodesWithIDs(action.NodeID, s.nodes)
+	_, nodes := getNodesWithIDs(action.NodeID, s.Nodes)
 	for _, node := range nodes {
-		err := node.RefreshViews(s.ctx, action.FilterOptions)
-		expectedErrorRaised := AssertError(s.t, err, action.ExpectedError)
-		assertExpectedErrorRaised(s.t, action.ExpectedError, expectedErrorRaised)
+		err := node.RefreshViews(s.Ctx, action.FilterOptions)
+		expectedErrorRaised := AssertError(s.T, err, action.ExpectedError)
+		assertExpectedErrorRaised(s.T, action.ExpectedError, expectedErrorRaised)
 	}
 }
 
 // createDoc creates a document using the chosen [mutationType] and caches it in the
 // test state object.
 func createDoc(
-	s *state,
+	s *State,
 	action CreateDoc,
 ) {
 	if action.DocMap != nil {
 		substituteRelations(s, action)
 	}
 
-	var mutation func(*state, CreateDoc, client.TxnStore, int, client.Collection) ([]client.DocID, error)
+	var mutation func(*State, CreateDoc, client.TxnStore, int, client.Collection) ([]client.DocID, error)
 	switch mutationType {
 	case CollectionSaveMutationType:
 		mutation = createDocViaColSave
@@ -1251,16 +1251,16 @@ func createDoc(
 	case GQLRequestMutationType:
 		mutation = createDocViaGQL
 	default:
-		s.t.Fatalf("invalid mutationType: %v", mutationType)
+		s.T.Fatalf("invalid mutationType: %v", mutationType)
 	}
 
 	var expectedErrorRaised bool
 	var docIDs []client.DocID
 
-	nodeIDs, nodes := getNodesWithIDs(action.NodeID, s.nodes)
+	nodeIDs, nodes := getNodesWithIDs(action.NodeID, s.Nodes)
 	for index, node := range nodes {
 		nodeID := nodeIDs[index]
-		collection := s.nodes[nodeID].collections[action.CollectionID]
+		collection := s.Nodes[nodeID].Collections[action.CollectionID]
 		err := withRetryOnNode(
 			node,
 			func() error {
@@ -1275,16 +1275,16 @@ func createDoc(
 				return err
 			},
 		)
-		expectedErrorRaised = AssertError(s.t, err, action.ExpectedError)
+		expectedErrorRaised = AssertError(s.T, err, action.ExpectedError)
 	}
 
-	assertExpectedErrorRaised(s.t, action.ExpectedError, expectedErrorRaised)
+	assertExpectedErrorRaised(s.T, action.ExpectedError, expectedErrorRaised)
 
-	if action.CollectionID >= len(s.docIDs) {
+	if action.CollectionID >= len(s.DocIDs) {
 		// Expand the slice if required, so that the document can be accessed by collection index
-		s.docIDs = append(s.docIDs, make([][]client.DocID, action.CollectionID-len(s.docIDs)+1)...)
+		s.DocIDs = append(s.DocIDs, make([][]client.DocID, action.CollectionID-len(s.DocIDs)+1)...)
 	}
-	s.docIDs[action.CollectionID] = append(s.docIDs[action.CollectionID], docIDs...)
+	s.DocIDs[action.CollectionID] = append(s.DocIDs[action.CollectionID], docIDs...)
 
 	docIDMap := make(map[string]struct{})
 	for _, docID := range docIDs {
@@ -1297,7 +1297,7 @@ func createDoc(
 }
 
 func createDocViaColSave(
-	s *state,
+	s *State,
 	action CreateDoc,
 	node client.TxnStore,
 	nodeIndex int,
@@ -1309,7 +1309,7 @@ func createDocViaColSave(
 	}
 
 	txn := getTransaction(s, node, immutable.None[int](), action.ExpectedError)
-	ctx := makeContextForDocCreate(s, db.InitContext(s.ctx, txn), nodeIndex, &action)
+	ctx := makeContextForDocCreate(s, db.InitContext(s.Ctx, txn), nodeIndex, &action)
 
 	docIDs := make([]client.DocID, len(docs))
 	for i, doc := range docs {
@@ -1322,7 +1322,7 @@ func createDocViaColSave(
 	return docIDs, nil
 }
 
-func makeContextForDocCreate(s *state, ctx context.Context, nodeIndex int, action *CreateDoc) context.Context {
+func makeContextForDocCreate(s *State, ctx context.Context, nodeIndex int, action *CreateDoc) context.Context {
 	ctx = getContextWithIdentity(ctx, s, action.Identity, nodeIndex)
 	return ctx
 }
@@ -1335,7 +1335,7 @@ func makeDocCreateOptions(action *CreateDoc) []client.DocCreateOption {
 }
 
 func createDocViaColCreate(
-	s *state,
+	s *State,
 	action CreateDoc,
 	node client.TxnStore,
 	nodeIndex int,
@@ -1347,7 +1347,7 @@ func createDocViaColCreate(
 	}
 
 	txn := getTransaction(s, node, immutable.None[int](), action.ExpectedError)
-	ctx := makeContextForDocCreate(s, db.InitContext(s.ctx, txn), nodeIndex, &action)
+	ctx := makeContextForDocCreate(s, db.InitContext(s.Ctx, txn), nodeIndex, &action)
 
 	switch {
 	case len(docs) > 1:
@@ -1371,7 +1371,7 @@ func createDocViaColCreate(
 }
 
 func createDocViaGQL(
-	s *state,
+	s *State,
 	action CreateDoc,
 	node client.TxnStore,
 	nodeIndex int,
@@ -1387,12 +1387,12 @@ func createDocViaGQL(
 	} else if client.IsJSONArray([]byte(action.Doc)) {
 		var docMaps []map[string]any
 		err = json.Unmarshal([]byte(action.Doc), &docMaps)
-		require.NoError(s.t, err)
+		require.NoError(s.T, err)
 		input, err = arrayToGQL(docMaps)
 	} else {
 		input, err = jsonToGQL(action.Doc)
 	}
-	require.NoError(s.t, err)
+	require.NoError(s.T, err)
 
 	params := paramName + ": " + input
 
@@ -1408,7 +1408,7 @@ func createDocViaGQL(
 	req := fmt.Sprintf(`mutation { %s(%s) { _docID } }`, key, params)
 
 	txn := getTransaction(s, node, immutable.None[int](), action.ExpectedError)
-	ctx := getContextWithIdentity(db.InitContext(s.ctx, txn), s, action.Identity, nodeIndex)
+	ctx := getContextWithIdentity(db.InitContext(s.Ctx, txn), s, action.Identity, nodeIndex)
 
 	result := node.ExecRequest(ctx, req)
 	if len(result.GQL.Errors) > 0 {
@@ -1416,13 +1416,13 @@ func createDocViaGQL(
 	}
 
 	resultData := result.GQL.Data.(map[string]any)
-	resultDocs := ConvertToArrayOfMaps(s.t, resultData[key])
+	resultDocs := ConvertToArrayOfMaps(s.T, resultData[key])
 
 	docIDs := make([]client.DocID, len(resultDocs))
 	for i, docMap := range resultDocs {
 		docIDString := docMap[request.DocIDFieldName].(string)
 		docID, err := client.NewDocIDFromString(docIDString)
-		require.NoError(s.t, err)
+		require.NoError(s.T, err)
 		docIDs[i] = docID
 	}
 
@@ -1434,7 +1434,7 @@ func createDocViaGQL(
 //
 // If a document at that index is not found it will panic.
 func substituteRelations(
-	s *state,
+	s *State,
 	action CreateDoc,
 ) {
 	for k, v := range action.DocMap {
@@ -1443,7 +1443,7 @@ func substituteRelations(
 			continue
 		}
 
-		docID := s.docIDs[index.CollectionIndex][index.Index]
+		docID := s.DocIDs[index.CollectionIndex][index.Index]
 		action.DocMap[k] = docID.String()
 	}
 }
@@ -1451,18 +1451,18 @@ func substituteRelations(
 // deleteDoc deletes a document using the collection api and caches it in the
 // given documents slice.
 func deleteDoc(
-	s *state,
+	s *State,
 	action DeleteDoc,
 ) {
-	docID := s.docIDs[action.CollectionID][action.DocID]
+	docID := s.DocIDs[action.CollectionID][action.DocID]
 
 	var expectedErrorRaised bool
 
-	nodeIDs, nodes := getNodesWithIDs(action.NodeID, s.nodes)
+	nodeIDs, nodes := getNodesWithIDs(action.NodeID, s.Nodes)
 	for index, node := range nodes {
 		nodeID := nodeIDs[index]
-		collection := s.nodes[nodeID].collections[action.CollectionID]
-		ctx := getContextWithIdentity(s.ctx, s, action.Identity, nodeID)
+		collection := s.Nodes[nodeID].Collections[action.CollectionID]
+		ctx := getContextWithIdentity(s.Ctx, s, action.Identity, nodeID)
 		err := withRetryOnNode(
 			node,
 			func() error {
@@ -1470,10 +1470,10 @@ func deleteDoc(
 				return err
 			},
 		)
-		expectedErrorRaised = AssertError(s.t, err, action.ExpectedError)
+		expectedErrorRaised = AssertError(s.T, err, action.ExpectedError)
 	}
 
-	assertExpectedErrorRaised(s.t, action.ExpectedError, expectedErrorRaised)
+	assertExpectedErrorRaised(s.T, action.ExpectedError, expectedErrorRaised)
 
 	if action.ExpectedError == "" {
 		expect := map[string]struct{}{
@@ -1486,10 +1486,10 @@ func deleteDoc(
 
 // updateDoc updates a document using the chosen [mutationType].
 func updateDoc(
-	s *state,
+	s *State,
 	action UpdateDoc,
 ) {
-	var mutation func(*state, UpdateDoc, client.TxnStore, int, client.Collection) error
+	var mutation func(*State, UpdateDoc, client.TxnStore, int, client.Collection) error
 	switch mutationType {
 	case CollectionSaveMutationType:
 		mutation = updateDocViaColSave
@@ -1498,15 +1498,15 @@ func updateDoc(
 	case GQLRequestMutationType:
 		mutation = updateDocViaGQL
 	default:
-		s.t.Fatalf("invalid mutationType: %v", mutationType)
+		s.T.Fatalf("invalid mutationType: %v", mutationType)
 	}
 
 	var expectedErrorRaised bool
 
-	nodeIDs, nodes := getNodesWithIDs(action.NodeID, s.nodes)
+	nodeIDs, nodes := getNodesWithIDs(action.NodeID, s.Nodes)
 	for index, node := range nodes {
 		nodeID := nodeIDs[index]
-		collection := s.nodes[nodeID].collections[action.CollectionID]
+		collection := s.Nodes[nodeID].Collections[action.CollectionID]
 		err := withRetryOnNode(
 			node,
 			func() error {
@@ -1519,10 +1519,10 @@ func updateDoc(
 				)
 			},
 		)
-		expectedErrorRaised = AssertError(s.t, err, action.ExpectedError)
+		expectedErrorRaised = AssertError(s.T, err, action.ExpectedError)
 	}
 
-	assertExpectedErrorRaised(s.t, action.ExpectedError, expectedErrorRaised)
+	assertExpectedErrorRaised(s.T, action.ExpectedError, expectedErrorRaised)
 
 	if action.ExpectedError == "" && !action.SkipLocalUpdateEvent {
 		waitForUpdateEvents(
@@ -1536,15 +1536,15 @@ func updateDoc(
 }
 
 func updateDocViaColSave(
-	s *state,
+	s *State,
 	action UpdateDoc,
 	node client.TxnStore,
 	nodeIndex int,
 	collection client.Collection,
 ) error {
-	ctx := getContextWithIdentity(s.ctx, s, action.Identity, nodeIndex)
+	ctx := getContextWithIdentity(s.Ctx, s, action.Identity, nodeIndex)
 
-	doc, err := collection.Get(ctx, s.docIDs[action.CollectionID][action.DocID], true)
+	doc, err := collection.Get(ctx, s.DocIDs[action.CollectionID][action.DocID], true)
 	if err != nil {
 		return err
 	}
@@ -1556,15 +1556,15 @@ func updateDocViaColSave(
 }
 
 func updateDocViaColUpdate(
-	s *state,
+	s *State,
 	action UpdateDoc,
 	node client.TxnStore,
 	nodeIndex int,
 	collection client.Collection,
 ) error {
-	ctx := getContextWithIdentity(s.ctx, s, action.Identity, nodeIndex)
+	ctx := getContextWithIdentity(s.Ctx, s, action.Identity, nodeIndex)
 
-	doc, err := collection.Get(ctx, s.docIDs[action.CollectionID][action.DocID], true)
+	doc, err := collection.Get(ctx, s.DocIDs[action.CollectionID][action.DocID], true)
 	if err != nil {
 		return err
 	}
@@ -1576,16 +1576,16 @@ func updateDocViaColUpdate(
 }
 
 func updateDocViaGQL(
-	s *state,
+	s *State,
 	action UpdateDoc,
 	node client.TxnStore,
 	nodeIndex int,
 	collection client.Collection,
 ) error {
-	docID := s.docIDs[action.CollectionID][action.DocID]
+	docID := s.DocIDs[action.CollectionID][action.DocID]
 
 	input, err := jsonToGQL(action.Doc)
-	require.NoError(s.t, err)
+	require.NoError(s.T, err)
 
 	request := fmt.Sprintf(
 		`mutation {
@@ -1598,7 +1598,7 @@ func updateDocViaGQL(
 		input,
 	)
 
-	ctx := getContextWithIdentity(s.ctx, s, action.Identity, nodeIndex)
+	ctx := getContextWithIdentity(s.Ctx, s, action.Identity, nodeIndex)
 
 	result := node.ExecRequest(ctx, request)
 	if len(result.GQL.Errors) > 0 {
@@ -1608,15 +1608,15 @@ func updateDocViaGQL(
 }
 
 // updateWithFilter updates the set of matched documents.
-func updateWithFilter(s *state, action UpdateWithFilter) {
+func updateWithFilter(s *State, action UpdateWithFilter) {
 	var res *client.UpdateResult
 	var expectedErrorRaised bool
 
-	nodeIDs, nodes := getNodesWithIDs(action.NodeID, s.nodes)
+	nodeIDs, nodes := getNodesWithIDs(action.NodeID, s.Nodes)
 	for index, node := range nodes {
 		nodeID := nodeIDs[index]
-		collection := s.nodes[nodeID].collections[action.CollectionID]
-		ctx := getContextWithIdentity(s.ctx, s, action.Identity, nodeID)
+		collection := s.Nodes[nodeID].Collections[action.CollectionID]
+		ctx := getContextWithIdentity(s.Ctx, s, action.Identity, nodeID)
 		err := withRetryOnNode(
 			node,
 			func() error {
@@ -1625,10 +1625,10 @@ func updateWithFilter(s *state, action UpdateWithFilter) {
 				return err
 			},
 		)
-		expectedErrorRaised = AssertError(s.t, err, action.ExpectedError)
+		expectedErrorRaised = AssertError(s.T, err, action.ExpectedError)
 	}
 
-	assertExpectedErrorRaised(s.t, action.ExpectedError, expectedErrorRaised)
+	assertExpectedErrorRaised(s.T, action.ExpectedError, expectedErrorRaised)
 
 	if action.ExpectedError == "" && !action.SkipLocalUpdateEvent {
 		waitForUpdateEvents(
@@ -1643,13 +1643,13 @@ func updateWithFilter(s *state, action UpdateWithFilter) {
 
 // createIndex creates a secondary index using the collection api.
 func createIndex(
-	s *state,
+	s *State,
 	action CreateIndex,
 ) {
-	nodeIDs, nodes := getNodesWithIDs(action.NodeID, s.nodes)
+	nodeIDs, nodes := getNodesWithIDs(action.NodeID, s.Nodes)
 	for index, node := range nodes {
 		nodeID := nodeIDs[index]
-		collection := s.nodes[nodeID].collections[action.CollectionID]
+		collection := s.Nodes[nodeID].Collections[action.CollectionID]
 		indexDesc := client.IndexCreateRequest{
 			Name: action.IndexName,
 		}
@@ -1672,76 +1672,76 @@ func createIndex(
 		err := withRetryOnNode(
 			node,
 			func() error {
-				_, err := collection.CreateIndex(s.ctx, indexDesc)
+				_, err := collection.CreateIndex(s.Ctx, indexDesc)
 				return err
 			},
 		)
-		if AssertError(s.t, err, action.ExpectedError) {
+		if AssertError(s.T, err, action.ExpectedError) {
 			return
 		}
 	}
 
-	assertExpectedErrorRaised(s.t, action.ExpectedError, false)
+	assertExpectedErrorRaised(s.T, action.ExpectedError, false)
 }
 
 // dropIndex drops the secondary index using the collection api.
 func dropIndex(
-	s *state,
+	s *State,
 	action DropIndex,
 ) {
 	var expectedErrorRaised bool
 
-	nodeIDs, nodes := getNodesWithIDs(action.NodeID, s.nodes)
+	nodeIDs, nodes := getNodesWithIDs(action.NodeID, s.Nodes)
 	for index, node := range nodes {
 		nodeID := nodeIDs[index]
-		collection := s.nodes[nodeID].collections[action.CollectionID]
+		collection := s.Nodes[nodeID].Collections[action.CollectionID]
 
 		err := withRetryOnNode(
 			node,
 			func() error {
-				return collection.DropIndex(s.ctx, action.IndexName)
+				return collection.DropIndex(s.Ctx, action.IndexName)
 			},
 		)
-		expectedErrorRaised = AssertError(s.t, err, action.ExpectedError)
+		expectedErrorRaised = AssertError(s.T, err, action.ExpectedError)
 	}
 
-	assertExpectedErrorRaised(s.t, action.ExpectedError, expectedErrorRaised)
+	assertExpectedErrorRaised(s.T, action.ExpectedError, expectedErrorRaised)
 }
 
 // backupExport generates a backup using the db api.
 func backupExport(
-	s *state,
+	s *State,
 	action BackupExport,
 ) {
 	if action.Config.Filepath == "" {
-		action.Config.Filepath = s.t.TempDir() + testJSONFile
+		action.Config.Filepath = s.T.TempDir() + testJSONFile
 	}
 
 	var expectedErrorRaised bool
 
-	_, nodes := getNodesWithIDs(action.NodeID, s.nodes)
+	_, nodes := getNodesWithIDs(action.NodeID, s.Nodes)
 	for _, node := range nodes {
 		err := withRetryOnNode(
 			node,
-			func() error { return node.BasicExport(s.ctx, &action.Config) },
+			func() error { return node.BasicExport(s.Ctx, &action.Config) },
 		)
-		expectedErrorRaised = AssertError(s.t, err, action.ExpectedError)
+		expectedErrorRaised = AssertError(s.T, err, action.ExpectedError)
 
 		if !expectedErrorRaised {
-			assertBackupContent(s.t, action.ExpectedContent, action.Config.Filepath)
+			assertBackupContent(s.T, action.ExpectedContent, action.Config.Filepath)
 		}
 	}
 
-	assertExpectedErrorRaised(s.t, action.ExpectedError, expectedErrorRaised)
+	assertExpectedErrorRaised(s.T, action.ExpectedError, expectedErrorRaised)
 }
 
 // backupImport imports data from a backup using the db api.
 func backupImport(
-	s *state,
+	s *State,
 	action BackupImport,
 ) {
 	if action.Filepath == "" {
-		action.Filepath = s.t.TempDir() + testJSONFile
+		action.Filepath = s.T.TempDir() + testJSONFile
 	}
 
 	// we can avoid checking the error here as this would mean the filepath is invalid
@@ -1750,16 +1750,16 @@ func backupImport(
 
 	var expectedErrorRaised bool
 
-	_, nodes := getNodesWithIDs(action.NodeID, s.nodes)
+	_, nodes := getNodesWithIDs(action.NodeID, s.Nodes)
 	for _, node := range nodes {
 		err := withRetryOnNode(
 			node,
-			func() error { return node.BasicImport(s.ctx, action.Filepath) },
+			func() error { return node.BasicImport(s.Ctx, action.Filepath) },
 		)
-		expectedErrorRaised = AssertError(s.t, err, action.ExpectedError)
+		expectedErrorRaised = AssertError(s.T, err, action.ExpectedError)
 	}
 
-	assertExpectedErrorRaised(s.t, action.ExpectedError, expectedErrorRaised)
+	assertExpectedErrorRaised(s.T, action.ExpectedError, expectedErrorRaised)
 }
 
 // withRetryOnNode attempts to perform the given action, retrying up to a DB-defined
@@ -1785,7 +1785,7 @@ func withRetryOnNode(
 }
 
 func getTransaction(
-	s *state,
+	s *State,
 	db client.TxnStore,
 	transactionSpecifier immutable.Option[int],
 	expectedError string,
@@ -1796,23 +1796,23 @@ func getTransaction(
 
 	transactionID := transactionSpecifier.Value()
 
-	if transactionID >= len(s.txns) {
+	if transactionID >= len(s.Txns) {
 		// Extend the txn slice so this txn can fit and be accessed by TransactionId
-		s.txns = append(s.txns, make([]client.Txn, transactionID-len(s.txns)+1)...)
+		s.Txns = append(s.Txns, make([]client.Txn, transactionID-len(s.Txns)+1)...)
 	}
 
-	if s.txns[transactionID] == nil {
+	if s.Txns[transactionID] == nil {
 		// Create a new transaction if one does not already exist.
-		txn, err := db.NewTxn(s.ctx, false)
-		if AssertError(s.t, err, expectedError) {
-			txn.Discard(s.ctx)
+		txn, err := db.NewTxn(s.Ctx, false)
+		if AssertError(s.T, err, expectedError) {
+			txn.Discard(s.Ctx)
 			return nil
 		}
 
-		s.txns[transactionID] = txn
+		s.Txns[transactionID] = txn
 	}
 
-	return s.txns[transactionID]
+	return s.Txns[transactionID]
 }
 
 // commitTransaction commits the given transaction.
@@ -1820,31 +1820,31 @@ func getTransaction(
 // Will panic if the given transaction does not exist. Discards the transaction if
 // an error is returned on commit.
 func commitTransaction(
-	s *state,
+	s *State,
 	action TransactionCommit,
 ) {
-	err := s.txns[action.TransactionID].Commit(s.ctx)
+	err := s.Txns[action.TransactionID].Commit(s.Ctx)
 	if err != nil {
-		s.txns[action.TransactionID].Discard(s.ctx)
+		s.Txns[action.TransactionID].Discard(s.Ctx)
 	}
 
-	expectedErrorRaised := AssertError(s.t, err, action.ExpectedError)
+	expectedErrorRaised := AssertError(s.T, err, action.ExpectedError)
 
-	assertExpectedErrorRaised(s.t, action.ExpectedError, expectedErrorRaised)
+	assertExpectedErrorRaised(s.T, action.ExpectedError, expectedErrorRaised)
 }
 
 // executeRequest executes the given request.
 func executeRequest(
-	s *state,
+	s *State,
 	action Request,
 ) {
 	var expectedErrorRaised bool
-	nodeIDs, nodes := getNodesWithIDs(action.NodeID, s.nodes)
+	nodeIDs, nodes := getNodesWithIDs(action.NodeID, s.Nodes)
 nodeLoop:
 	for index, node := range nodes {
 		nodeID := nodeIDs[index]
 		txn := getTransaction(s, node, action.TransactionID, action.ExpectedError)
-		ctx := getContextWithIdentity(db.InitContext(s.ctx, txn), s, action.Identity, nodeID)
+		ctx := getContextWithIdentity(db.InitContext(s.Ctx, txn), s, action.Identity, nodeID)
 
 		var options []client.RequestOption
 		if action.OperationName.HasValue() {
@@ -1855,17 +1855,17 @@ nodeLoop:
 		}
 
 		if !expectedErrorRaised && viewType == MaterializedViewType {
-			for _, colName := range s.collectionNames {
+			for _, colName := range s.CollectionNames {
 				// Refresh the views in the order in which they were declared, this way
 				// any views of views should be based off of refreshed data, assuming they were declared in
 				// an intuitive order.
 				err := node.RefreshViews(
-					s.ctx,
+					s.Ctx,
 					client.CollectionFetchOptions{
 						Name: immutable.Some(colName),
 					},
 				)
-				expectedErrorRaised = AssertError(s.t, err, action.ExpectedError)
+				expectedErrorRaised = AssertError(s.T, err, action.ExpectedError)
 				if expectedErrorRaised {
 					continue nodeLoop
 				}
@@ -1884,7 +1884,7 @@ nodeLoop:
 		)
 	}
 
-	assertExpectedErrorRaised(s.t, action.ExpectedError, expectedErrorRaised)
+	assertExpectedErrorRaised(s.T, action.ExpectedError, expectedErrorRaised)
 }
 
 // executeSubscriptionRequest executes the given subscription request, returning
@@ -1896,15 +1896,15 @@ nodeLoop:
 // failures are recorded properly. It will only yield once, once
 // the subscription has terminated.
 func executeSubscriptionRequest(
-	s *state,
+	s *State,
 	action SubscriptionRequest,
 ) {
 	subscriptionAssert := make(chan func())
 
-	_, nodes := getNodesWithIDs(action.NodeID, s.nodes)
+	_, nodes := getNodesWithIDs(action.NodeID, s.Nodes)
 	for _, node := range nodes {
-		result := node.ExecRequest(s.ctx, action.Request)
-		if AssertErrors(s.t, result.GQL.Errors, action.ExpectedError) {
+		result := node.ExecRequest(s.Ctx, action.Request)
+		if AssertErrors(s.T, result.GQL.Errors, action.ExpectedError) {
 			return
 		}
 
@@ -1918,7 +1918,7 @@ func executeSubscriptionRequest(
 				case <-time.After(100 * time.Millisecond):
 				}
 				select {
-				case <-s.allActionsDone:
+				case <-s.AllActionsDone:
 					allActionsAreDone = true
 				case <-time.After(100 * time.Millisecond):
 				}
@@ -1937,13 +1937,13 @@ func executeSubscriptionRequest(
 						0,
 					)
 
-					assertExpectedErrorRaised(s.t, action.ExpectedError, expectedErrorRaised)
+					assertExpectedErrorRaised(s.T, action.ExpectedError, expectedErrorRaised)
 				}
 			}
 		}()
 	}
 
-	s.subscriptionResultsChans = append(s.subscriptionResultsChans, subscriptionAssert)
+	s.SubscriptionResultsChans = append(s.SubscriptionResultsChans, subscriptionAssert)
 }
 
 // Asserts as to whether an error has been raised as expected (or not). If an expected
@@ -1991,16 +1991,16 @@ func AssertErrors(
 }
 
 func assertRequestResults(
-	s *state,
+	s *State,
 	result *client.GQLResult,
 	expectedResults map[string]any,
 	expectedError string,
 	asserter ResultAsserter,
 	nodeID int,
 ) bool {
-	s.currentNodeID = nodeID
+	s.CurrentNodeID = nodeID
 	// we skip assertion benchmark because you don't specify expected result for benchmark.
-	if AssertErrors(s.t, result.Errors, expectedError) || s.isBench {
+	if AssertErrors(s.T, result.Errors, expectedError) || s.IsBench {
 		return true
 	}
 
@@ -2010,10 +2010,10 @@ func assertRequestResults(
 
 	// Note: if result.Data == nil this panics (the panic seems useful while testing).
 	resultantData := result.Data.(map[string]any)
-	log.InfoContext(s.ctx, "", corelog.Any("RequestResults", result.Data))
+	log.InfoContext(s.Ctx, "", corelog.Any("RequestResults", result.Data))
 
 	if asserter != nil {
-		asserter.Assert(s.t, resultantData)
+		asserter.Assert(s.T, resultantData)
 		return true
 	}
 
@@ -2030,14 +2030,14 @@ func assertRequestResults(
 	for key := range keys {
 		stack.pushMap(key)
 		expect, ok := expectedResults[key]
-		require.True(s.t, ok, "expected key not found: %s", key)
+		require.True(s.T, ok, "expected key not found: %s", key)
 
 		actual, ok := resultantData[key]
-		require.True(s.t, ok, "result key not found: %s", key)
+		require.True(s.T, ok, "result key not found: %s", key)
 
 		switch exp := expect.(type) {
 		case []map[string]any:
-			actualDocs := ConvertToArrayOfMaps(s.t, actual)
+			actualDocs := ConvertToArrayOfMaps(s.T, actual)
 			assertRequestResultDocs(
 				s,
 				nodeID,
@@ -2051,8 +2051,8 @@ func assertRequestResults(
 
 		default:
 			assertResultsEqual(
-				s.t,
-				s.clientType,
+				s.T,
+				s.ClientType,
 				expect,
 				actual,
 				fmt.Sprintf("node: %v, path: %s", nodeID, stack),
@@ -2065,21 +2065,21 @@ func assertRequestResults(
 }
 
 func assertRequestResultDocs(
-	s *state,
+	s *State,
 	nodeID int,
 	expectedResults []map[string]any,
 	actualResults []map[string]any,
 	stack *assertStack,
 ) bool {
 	// compare results
-	require.Equal(s.t, len(expectedResults), len(actualResults), "number of results don't match for %s", stack)
+	require.Equal(s.T, len(expectedResults), len(actualResults), "number of results don't match for %s", stack)
 
 	for actualDocIndex, actualDoc := range actualResults {
 		stack.pushArray(actualDocIndex)
 		expectedDoc := expectedResults[actualDocIndex]
 
 		require.Equal(
-			s.t,
+			s.T,
 			len(expectedDoc),
 			len(actualDoc),
 			fmt.Sprintf(
@@ -2097,7 +2097,7 @@ func assertRequestResultDocs(
 }
 
 func assertRequestResultDoc(
-	s *state,
+	s *State,
 	nodeID int,
 	actualDoc map[string]any,
 	expectedDoc map[string]any,
@@ -2111,16 +2111,16 @@ func assertRequestResultDoc(
 			execGomegaMatcher(expectedValue, s, actualValue, stack)
 
 		case DocIndex:
-			expectedDocID := s.docIDs[expectedValue.CollectionIndex][expectedValue.Index].String()
+			expectedDocID := s.DocIDs[expectedValue.CollectionIndex][expectedValue.Index].String()
 			assertResultsEqual(
-				s.t,
-				s.clientType,
+				s.T,
+				s.ClientType,
 				expectedDocID,
 				actualValue,
 				fmt.Sprintf("node: %v, path: %s", nodeID, stack),
 			)
 		case []map[string]any:
-			actualValueMap := ConvertToArrayOfMaps(s.t, actualValue)
+			actualValueMap := ConvertToArrayOfMaps(s.T, actualValue)
 
 			assertRequestResultDocs(
 				s,
@@ -2132,13 +2132,13 @@ func assertRequestResultDoc(
 
 		case map[string]any:
 			actualMap, ok := actualValue.(map[string]any)
-			require.True(s.t, ok, "expected value to be a map %v. Path: %s", actualValue, stack)
+			require.True(s.T, ok, "expected value to be a map %v. Path: %s", actualValue, stack)
 			assertRequestResultDoc(s, nodeID, actualMap, expectedValue, stack)
 
 		default:
 			assertResultsEqual(
-				s.t,
-				s.clientType,
+				s.T,
+				s.ClientType,
 				expectedValue,
 				actualValue,
 				fmt.Sprintf("node: %v, path: %s", nodeID, stack),
@@ -2171,29 +2171,29 @@ func assertExpectedErrorRaised(t testing.TB, expectedError string, wasRaised boo
 }
 
 func assertIntrospectionResults(
-	s *state,
+	s *State,
 	action IntrospectionRequest,
 ) bool {
-	_, nodes := getNodesWithIDs(action.NodeID, s.nodes)
+	_, nodes := getNodesWithIDs(action.NodeID, s.Nodes)
 	for _, node := range nodes {
-		result := node.ExecRequest(s.ctx, action.Request)
+		result := node.ExecRequest(s.Ctx, action.Request)
 
-		if AssertErrors(s.t, result.GQL.Errors, action.ExpectedError) {
+		if AssertErrors(s.T, result.GQL.Errors, action.ExpectedError) {
 			return true
 		}
 		resultantData := result.GQL.Data.(map[string]any)
 
 		if len(action.ExpectedData) == 0 && len(action.ContainsData) == 0 {
-			require.Equal(s.t, action.ExpectedData, resultantData)
+			require.Equal(s.T, action.ExpectedData, resultantData)
 		}
 
 		if len(action.ExpectedData) == 0 && len(action.ContainsData) > 0 {
-			assertContains(s.t, action.ContainsData, resultantData)
+			assertContains(s.T, action.ContainsData, resultantData)
 		} else {
-			require.Equal(s.t, len(action.ExpectedData), len(resultantData))
+			require.Equal(s.T, len(action.ExpectedData), len(resultantData))
 
 			for k, result := range resultantData {
-				assert.Equal(s.t, action.ExpectedData[k], result)
+				assert.Equal(s.T, action.ExpectedData[k], result)
 			}
 		}
 	}
@@ -2203,14 +2203,14 @@ func assertIntrospectionResults(
 
 // Asserts that the client introspection results conform to our expectations.
 func assertClientIntrospectionResults(
-	s *state,
+	s *State,
 	action ClientIntrospectionRequest,
 ) bool {
-	_, nodes := getNodesWithIDs(action.NodeID, s.nodes)
+	_, nodes := getNodesWithIDs(action.NodeID, s.Nodes)
 	for _, node := range nodes {
-		result := node.ExecRequest(s.ctx, action.Request)
+		result := node.ExecRequest(s.Ctx, action.Request)
 
-		if AssertErrors(s.t, result.GQL.Errors, action.ExpectedError) {
+		if AssertErrors(s.T, result.GQL.Errors, action.ExpectedError) {
 			return true
 		}
 		resultantData := result.GQL.Data.(map[string]any)
@@ -2234,12 +2234,12 @@ func assertClientIntrospectionResults(
 			case "OBJECT":
 				fields := typeDef["fields"]
 				if fields == nil {
-					s.t.Errorf("Fields are missing for OBJECT type %v", typeDef["name"])
+					s.T.Errorf("Fields are missing for OBJECT type %v", typeDef["name"])
 				}
 			case "INPUT_OBJECT":
 				inputFields := typeDef["inputFields"]
 				if inputFields == nil {
-					s.t.Errorf("InputFields are missing for INPUT_OBJECT type %v", typeDef["name"])
+					s.T.Errorf("InputFields are missing for INPUT_OBJECT type %v", typeDef["name"])
 				}
 			default:
 				// t.Errorf("Unknown type kind: %v", kind)
@@ -2483,43 +2483,43 @@ func parseCreateDocs(action CreateDoc, collection client.Collection) ([]*client.
 	}
 }
 
-func performGetNodeIdentityAction(s *state, action GetNodeIdentity) {
-	if action.NodeID >= len(s.nodes) {
-		s.t.Fatalf("invalid nodeID: %v", action.NodeID)
+func performGetNodeIdentityAction(s *State, action GetNodeIdentity) {
+	if action.NodeID >= len(s.Nodes) {
+		s.T.Fatalf("invalid nodeID: %v", action.NodeID)
 	}
 
-	actualIdent, err := s.nodes[action.NodeID].GetNodeIdentity(s.ctx)
-	require.NoError(s.t, err)
+	actualIdent, err := s.Nodes[action.NodeID].GetNodeIdentity(s.Ctx)
+	require.NoError(s.T, err)
 
-	expectedIdent := getIdentity(s, action.ExpectedIdentity)
+	expectedIdent := GetIdentity(s, action.ExpectedIdentity)
 	expectedRawIdent := expectedIdent.ToPublicRawIdentity()
 	expectedRawIdentOpt := immutable.Some(expectedRawIdent)
-	require.Equal(s.t, expectedRawIdentOpt, actualIdent, "raw identity at %d mismatch", action.NodeID)
+	require.Equal(s.T, expectedRawIdentOpt, actualIdent, "raw identity at %d mismatch", action.NodeID)
 }
 
 // execGomegaMatcher executes the given gomega matcher and asserts the result.
-func execGomegaMatcher(exp gomega.OmegaMatcher, s *state, actual any, stack *assertStack) {
+func execGomegaMatcher(exp gomega.OmegaMatcher, s *State, actual any, stack *assertStack) {
 	traverseGomegaMatchers(exp, s, func(m TestStateMatcher) { m.SetTestState(s) })
 
 	success, err := exp.Match(actual)
 	if err != nil {
-		assert.Fail(s.t, "the matcher exited with error", "Error: %s. Path: %s", err, stack)
+		assert.Fail(s.T, "the matcher exited with error", "Error: %s. Path: %s", err, stack)
 	}
 
 	if !success {
-		assert.Fail(s.t, exp.FailureMessage(actual), "Path: %s", stack)
+		assert.Fail(s.T, exp.FailureMessage(actual), "Path: %s", stack)
 	}
 
 	traverseGomegaMatchers(exp, s, func(m StatefulMatcher) {
-		if !slices.Contains(s.statefulMatchers, m) {
-			s.statefulMatchers = append(s.statefulMatchers, m)
+		if !slices.Contains(s.StatefulMatchers, m) {
+			s.StatefulMatchers = append(s.StatefulMatchers, m)
 		}
 	})
 }
 
 // traverseGomegaMatchers traverses the given gomega matcher and calls the given function
 // for each matcher found with the type T.
-func traverseGomegaMatchers[T gomega.OmegaMatcher](exp gomega.OmegaMatcher, s *state, f func(T)) {
+func traverseGomegaMatchers[T gomega.OmegaMatcher](exp gomega.OmegaMatcher, s *State, f func(T)) {
 	if m, ok := exp.(T); ok {
 		f(m)
 		return
@@ -2540,24 +2540,24 @@ func traverseGomegaMatchers[T gomega.OmegaMatcher](exp gomega.OmegaMatcher, s *s
 }
 
 // resetMatchers resets the state of all stateful matchers.
-func resetMatchers(s *state) {
-	for _, matcher := range s.statefulMatchers {
+func resetMatchers(s *State) {
+	for _, matcher := range s.StatefulMatchers {
 		matcher.ResetMatcherState()
 	}
 }
 
-func performVerifySignatureAction(s *state, action VerifyBlockSignature) {
-	_, nodes := getNodesWithIDs(immutable.None[int](), s.nodes)
+func performVerifySignatureAction(s *State, action VerifyBlockSignature) {
+	_, nodes := getNodesWithIDs(immutable.None[int](), s.Nodes)
 	for i, node := range nodes {
-		ctx := getContextWithIdentity(s.ctx, s, action.Identity, i)
-		signerIdentity := getIdentity(s, immutable.Some(action.SignerIdentity))
+		ctx := getContextWithIdentity(s.Ctx, s, action.Identity, i)
+		signerIdentity := GetIdentity(s, immutable.Some(action.SignerIdentity))
 		err := node.VerifySignature(ctx, action.Cid, signerIdentity.PublicKey())
 
 		if action.ExpectedError != "" {
-			require.Error(s.t, err)
-			require.Contains(s.t, err.Error(), action.ExpectedError)
+			require.Error(s.T, err)
+			require.Contains(s.T, err.Error(), action.ExpectedError)
 		} else {
-			require.NoError(s.t, err)
+			require.NoError(s.T, err)
 		}
 	}
 }

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -513,7 +513,7 @@ func benchmarkAction(
 	actionIndex int,
 	bench Benchmark,
 ) {
-	if s.Dbt == DefraIMType {
+	if s.DbType == DefraIMType {
 		// Benchmarking makes no sense for test in-memory storage
 		return
 	}
@@ -792,7 +792,7 @@ func startNodes(s *state.State, testCase TestCase, action Start) {
 		node, err := setupNode(s, testCase, opts...)
 		require.NoError(s.T, err)
 		databaseDir = originalPath
-		node.P2p = s.Nodes[nodeIndex].P2p
+		node.P2P = s.Nodes[nodeIndex].P2P
 		s.Nodes[nodeIndex] = node
 	}
 
@@ -805,7 +805,7 @@ func restartNodes(
 	s *state.State,
 	testCase TestCase,
 ) {
-	if s.Dbt == BadgerIMType || s.Dbt == DefraIMType {
+	if s.DbType == BadgerIMType || s.DbType == DefraIMType {
 		return
 	}
 	closeNodes(s, Close{})

--- a/tests/state/identity.go
+++ b/tests/state/identity.go
@@ -1,0 +1,115 @@
+// Copyright 2025 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package state
+
+import (
+	"crypto/ed25519"
+	"math/rand"
+
+	"github.com/decred/dcrd/dcrec/secp256k1/v4"
+	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
+	"github.com/sourcenetwork/defradb/crypto"
+	"github.com/sourcenetwork/immutable"
+	"github.com/stretchr/testify/require"
+)
+
+type IdentityType int
+
+const (
+	ClientIdentityType IdentityType = iota
+	NodeIdentityType
+)
+
+// Identity helps specify Identity type info and selector/index of Identity to use in a test case.
+type Identity struct {
+	// type of identity
+	Kind IdentityType
+
+	// Selector can be a valid identity index or a selecting pattern like "*".
+	// Note: "*" means to select all identities of the specified [kind] type.
+	Selector string
+}
+
+// IdentityHolder holds an identity and the generated tokens for each target node.
+// This is used to cache the generated tokens for each node.
+type IdentityHolder struct {
+	// Identity is the identity.
+	Identity acpIdentity.Identity
+	// NodeTokens is a map of node index to the generated token for that node.
+	NodeTokens map[int]string
+}
+
+func newIdentityHolder(ident acpIdentity.Identity) *IdentityHolder {
+	return &IdentityHolder{
+		Identity:   ident,
+		NodeTokens: make(map[int]string),
+	}
+}
+
+// GetIdentity returns the identity for the given reference.
+// If the identity does not exist, it will be generated.
+func GetIdentity(s *State, identity immutable.Option[Identity]) acpIdentity.Identity {
+	if !identity.HasValue() {
+		return nil
+	}
+
+	// The selector must never be "*" here because this function returns a specific identity from the
+	// stored identities, if "*" string needs to be signaled to the acp module then it should be handled
+	// a call before this function.
+	if identity.Value().Selector == "*" {
+		require.Fail(s.T, "Used the \"*\" selector for identity incorrectly.")
+	}
+	return GetIdentityHolder(s, identity.Value()).Identity
+}
+
+// GetIdentityHolder returns the identity holder for the given reference.
+// If the identity does not exist, it will be generated.
+func GetIdentityHolder(s *State, identity Identity) *IdentityHolder {
+	ident, ok := s.Identities[identity]
+	if ok {
+		return ident
+	}
+
+	keyType := crypto.KeyTypeSecp256k1
+	if k, ok := s.IdentityTypes[identity]; ok {
+		keyType = k
+	}
+
+	s.Identities[identity] = newIdentityHolder(generateIdentity(s, keyType))
+	return s.Identities[identity]
+}
+
+// Generate the keys using predefined seed so that multiple runs yield the same private key.
+// This is important for stuff like the change detector.
+func generateIdentity(s *State, keyType crypto.KeyType) acpIdentity.Identity {
+	source := rand.NewSource(int64(s.NextIdentityGenSeed))
+	r := rand.New(source)
+
+	var privateKey crypto.PrivateKey
+	if keyType == crypto.KeyTypeSecp256k1 {
+		privKey, err := secp256k1.GeneratePrivateKeyFromRand(r)
+		require.NoError(s.T, err)
+		privateKey = crypto.NewPrivateKey(privKey)
+	} else if keyType == crypto.KeyTypeEd25519 {
+		_, privKey, err := ed25519.GenerateKey(r)
+		require.NoError(s.T, err)
+		privateKey = crypto.NewPrivateKey(privKey)
+	} else {
+		require.Fail(s.T, "Unsupported signing algorithm")
+	}
+
+	s.NextIdentityGenSeed++
+
+	identity, err := acpIdentity.FromPrivateKey(privateKey)
+	require.NoError(s.T, err)
+
+	return identity
+}

--- a/tests/state/identity.go
+++ b/tests/state/identity.go
@@ -15,10 +15,11 @@ import (
 	"math/rand"
 
 	"github.com/decred/dcrd/dcrec/secp256k1/v4"
-	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
-	"github.com/sourcenetwork/defradb/crypto"
 	"github.com/sourcenetwork/immutable"
 	"github.com/stretchr/testify/require"
+
+	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
+	"github.com/sourcenetwork/defradb/crypto"
 )
 
 type IdentityType int

--- a/tests/state/state.go
+++ b/tests/state/state.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 
 	"github.com/ipfs/go-cid"
+	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/onsi/gomega/types"
 
 	"github.com/sourcenetwork/immutable"
@@ -161,6 +162,8 @@ type NodeState struct {
 	Collections []client.Collection
 	// indicates if the node is Closed.
 	Closed bool
+	// AddrInfo contains the peer information for the node.
+	AddrInfo peer.AddrInfo
 }
 
 // State contains all testing State.

--- a/tests/state/state.go
+++ b/tests/state/state.go
@@ -52,8 +52,8 @@ func NewColDocIndex(col, doc int) ColDocIndex {
 	return ColDocIndex{col, doc}
 }
 
-// P2pState contains all p2p related testing state.
-type P2pState struct {
+// P2PState contains all p2p related testing state.
+type P2PState struct {
 	// Connections contains all connected nodes.
 	//
 	// The map key is the connected node id.
@@ -95,14 +95,14 @@ type P2pState struct {
 // It is used to track if a document at a certain head has been decrypted.
 type DocHeadState struct {
 	// The actual document head.
-	Cid cid.Cid
+	CID cid.Cid
 	// Indicates if the document at the given head has been Decrypted.
 	Decrypted bool
 }
 
 // NewP2PState returns a new empty p2p state.
-func NewP2PState() *P2pState {
-	return &P2pState{
+func NewP2PState() *P2PState {
+	return &P2PState{
 		Connections:      make(map[int]struct{}),
 		Replicators:      make(map[int]struct{}),
 		PeerCollections:  make(map[int]struct{}),
@@ -151,8 +151,8 @@ type NodeState struct {
 	clients.Client
 	// Event contains all Event node subscriptions.
 	Event *EventState
-	// P2p contains P2p states for the node.
-	P2p *P2pState
+	// P2P contains P2P states for the node.
+	P2P *P2PState
 	// The network configurations for the nodes
 	NetOpts []netConfig.NodeOpt
 	// The path to any file-based databases active in this test.
@@ -175,10 +175,10 @@ type State struct {
 	T testing.TB
 
 	// The type of KMS currently being tested.
-	Kms KMSType
+	KMS KMSType
 
 	// The type of database currently being tested.
-	Dbt DatabaseType
+	DbType DatabaseType
 
 	// The type of client currently being tested.
 	ClientType ClientType
@@ -280,8 +280,8 @@ func NewState(
 	s := &State{
 		Ctx:                             ctx,
 		T:                               t,
-		Kms:                             kms,
-		Dbt:                             dbt,
+		KMS:                             kms,
+		DbType:                          dbt,
 		ClientType:                      clientType,
 		Txns:                            []client.Txn{},
 		IdentityTypes:                   identityTypes,


### PR DESCRIPTION
## Relevant issue(s)

Resolves #3867

## Description

Moves the integration test `state` type and dependencies to a new state package.

The only behaviour change is in the first commit, where `Description` was removed from a lot of failure messages.

The new `state` package lies outside of the `integration` directory - the state, actions and multipliers should all be available for use for other stuff like benchmarks.  

This begins the process of converting our main test framework to `testo`.  Later PRs will convert the actions and multipliers.

I do not agree with the location of all of the properties that are currently on `State` - many of them will need to be removed as the framework is converted.  This includes the `DatabaseType`, `KMSType` and `ClientType` types that were moved to the `state` package out of short-term necessity.  

If tolerable, I would very much like to avoid any changes requiring serious thought in this PR - I am looking to start the process by a fairly simple/dumb move of the `state` type, nothing more.
