### PR TITLE
feat: Gate schema add op with NAC

### DIFF
--- a/acp/types/types.go
+++ b/acp/types/types.go
@@ -88,6 +88,7 @@ const (
 	NodeNACStatusPerm
 	NodeNACRelationAddPerm
 	NodeNACRelationDeletePerm
+	NodeSchemaAddPerm
 )
 
 // List of all valid resource interface permissions for node access control, the order of
@@ -108,6 +109,7 @@ var RequiredResourcePermissionsForNode = []string{
 	"nac-status",
 	"nac-relation-add",
 	"nac-relation-delete",
+	"schema-add",
 }
 
 const NodeACPObject = "NodeObject"
@@ -151,6 +153,8 @@ resources:
       nac-relation-add:
         expr: owner + admin
       nac-relation-delete:
+        expr: owner + admin
+      schema-add:
         expr: owner + admin
 
     relations:

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/sourcenetwork/immutable"
 
+	acpTypes "github.com/sourcenetwork/defradb/acp/types"
 	"github.com/sourcenetwork/defradb/client"
 )
 
@@ -106,6 +107,10 @@ func (db *DB) GetAllIndexes(
 func (db *DB) AddSchema(ctx context.Context, schemaString string) ([]client.CollectionVersion, error) {
 	ctx, span := tracer.Start(ctx)
 	defer span.End()
+
+	if err := db.checkNodeAccess(ctx, acpTypes.NodeSchemaAddPerm); err != nil {
+		return nil, err
+	}
 
 	ctx, txn, err := ensureContextTxn(ctx, db, false)
 	if err != nil {

--- a/tests/action/add_schema.go
+++ b/tests/action/add_schema.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sourcenetwork/immutable"
 
 	"github.com/sourcenetwork/defradb/client"
+	"github.com/sourcenetwork/defradb/tests/state"
 )
 
 // AddSchema is an action that will add the given GQL schema to the Defra nodes.
@@ -24,6 +25,11 @@ type AddSchema struct {
 	//
 	// If a value is not provided the update will be applied to all nodes.
 	NodeID immutable.Option[int]
+
+	// The identity of this request. Optional.
+	//
+	// If node acp is enabled, identity will be used to check if this operation can be performed.
+	Identity immutable.Option[state.Identity]
 
 	// The schema to add.
 	Schema string
@@ -54,7 +60,9 @@ func (a *AddSchema) Execute() {
 
 		schema := replace(a.s, nodeID, a.Schema)
 
+		a.s.Ctx = getContextWithIdentity(a.s.Ctx, a.s, a.Identity, nodeID)
 		results, err := node.AddSchema(a.s.Ctx, schema)
+		resetStateContext(a.s)
 		expectedErrorRaised := assertError(a.s.T, err, a.ExpectedError)
 
 		assertExpectedErrorRaised(a.s.T, a.ExpectedError, expectedErrorRaised)

--- a/tests/action/identity.go
+++ b/tests/action/identity.go
@@ -8,66 +8,23 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-package tests
+package action
 
 import (
 	"context"
-	"strconv"
+	"time"
 
 	"github.com/sourcenetwork/immutable"
 	"github.com/stretchr/testify/require"
 
 	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
-	"github.com/sourcenetwork/defradb/tests/action"
 	"github.com/sourcenetwork/defradb/tests/state"
 )
 
-// NoIdentity returns an reference to an identity that represents no identity.
-func NoIdentity() immutable.Option[state.Identity] {
-	return immutable.None[state.Identity]()
-}
-
-// AllClientIdentities returns user identity selector specified with the "*".
-func AllClientIdentities() immutable.Option[state.Identity] {
-	return immutable.Some(
-		state.Identity{
-			Kind:     state.ClientIdentityType,
-			Selector: "*",
-		},
-	)
-}
-
-// ClientIdentity returns a user identity at the given index.
-func ClientIdentity(indexSelector int) immutable.Option[state.Identity] {
-	return immutable.Some(
-		state.Identity{
-			Kind:     state.ClientIdentityType,
-			Selector: strconv.Itoa(indexSelector),
-		},
-	)
-}
-
-// ClientIdentity returns a node identity at the given index.
-func NodeIdentity(indexSelector int) immutable.Option[state.Identity] {
-	return immutable.Some(
-		state.Identity{
-			Kind:     state.NodeIdentityType,
-			Selector: strconv.Itoa(indexSelector),
-		},
-	)
-}
-
-// getIdentityOption returns the identity similar to [getIdentity] but in immutable.Option.
-func getIdentityOption(
-	s *state.State,
-	identity immutable.Option[state.Identity],
-) immutable.Option[acpIdentity.Identity] {
-	ident := state.GetIdentity(s, identity)
-	if ident == nil {
-		return acpIdentity.None
-	}
-	return immutable.Some(ident)
-}
+const (
+	// AuthTokenExpiration is the expiration time for auth tokens.
+	AuthTokenExpiration = time.Minute * 1
+)
 
 // getIdentityForRequest returns the identity for the given reference and node index.
 // It prepares the identity for a request by generating a token if needed, i.e. it will
@@ -84,7 +41,7 @@ func getIdentityForRequest(s *state.State, identity state.Identity, nodeIndex in
 			audience := state.GetNodeAudience(s, nodeIndex)
 			if s.DocumentACPType == state.SourceHubDocumentACPType || audience.HasValue() {
 				err := fullIdent.UpdateToken(
-					action.AuthTokenExpiration,
+					AuthTokenExpiration,
 					audience,
 					immutable.Some(s.SourcehubAddress),
 				)
@@ -118,16 +75,6 @@ func getContextWithIdentity(
 	nodeIndex int,
 ) context.Context {
 	return acpIdentity.WithContext(ctx, getIdentityForRequestSpecificToNode(s, identity, nodeIndex))
-}
-
-func getIdentityDID(s *state.State, identity immutable.Option[state.Identity]) string {
-	if identity.HasValue() {
-		if identity.Value().Selector == "*" {
-			return identity.Value().Selector
-		}
-		return state.GetIdentity(s, identity).DID()
-	}
-	return ""
 }
 
 // resetContextWithNoIdentity resets identity for the ctx to avoid, leaving it there and having the ctx

--- a/tests/integration/acp/dac/add_policy/with_no_resources_test.go
+++ b/tests/integration/acp/dac/add_policy/with_no_resources_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sourcenetwork/immutable"
 
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	"github.com/sourcenetwork/defradb/tests/state"
 )
 
 // Eventhough empty resources make no sense from a DefraDB (DRI) perspective,
@@ -69,10 +70,10 @@ func TestACP_AddPolicy_NoResourceLabel_ValidID(t *testing.T) {
 // A Policy can have no resources (incompatible with DRI) but it needs a name.
 func TestACP_AddPolicy_PolicyWithOnlySpace_NameIsRequired(t *testing.T) {
 	test := testUtils.TestCase{
-		SupportedDocumentACPTypes: immutable.Some([]testUtils.DocumentACPType{
+		SupportedDocumentACPTypes: immutable.Some([]state.DocumentACPType{
 			// This is currently a local-acp only limitation, this test-restriction
 			// can be lifted if/when SourceHub introduces the same limitation.
-			testUtils.LocalDocumentACPType,
+			state.LocalDocumentACPType,
 		}),
 		Actions: []any{
 			testUtils.AddDACPolicy{

--- a/tests/integration/acp/dac/p2p/create_test.go
+++ b/tests/integration/acp/dac/p2p/create_test.go
@@ -17,14 +17,15 @@ import (
 
 	"github.com/sourcenetwork/defradb/tests/action"
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	"github.com/sourcenetwork/defradb/tests/state"
 )
 
 func TestACP_P2PCreatePrivateDocumentsOnDifferentNodes_SourceHubACP(t *testing.T) {
 	test := testUtils.TestCase{
 
 		SupportedDocumentACPTypes: immutable.Some(
-			[]testUtils.DocumentACPType{
-				testUtils.SourceHubDocumentACPType,
+			[]state.DocumentACPType{
+				state.SourceHubDocumentACPType,
 			},
 		),
 
@@ -133,8 +134,8 @@ func TestACP_P2PCreatePrivateDocumentsOnDifferentNodes_SourceHubACP(t *testing.T
 func TestACP_P2PCreatePrivateDocumentAndSyncAfterAddingRelationship_SourceHubACP(t *testing.T) {
 	test := testUtils.TestCase{
 		SupportedDocumentACPTypes: immutable.Some(
-			[]testUtils.DocumentACPType{
-				testUtils.SourceHubDocumentACPType,
+			[]state.DocumentACPType{
+				state.SourceHubDocumentACPType,
 			},
 		),
 		Actions: []any{

--- a/tests/integration/acp/dac/p2p/delete_test.go
+++ b/tests/integration/acp/dac/p2p/delete_test.go
@@ -17,14 +17,15 @@ import (
 
 	"github.com/sourcenetwork/defradb/tests/action"
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	"github.com/sourcenetwork/defradb/tests/state"
 )
 
 func TestACP_P2PDeletePrivateDocumentsOnDifferentNodes_SourceHubACP(t *testing.T) {
 	test := testUtils.TestCase{
 
 		SupportedDocumentACPTypes: immutable.Some(
-			[]testUtils.DocumentACPType{
-				testUtils.SourceHubDocumentACPType,
+			[]state.DocumentACPType{
+				state.SourceHubDocumentACPType,
 			},
 		),
 

--- a/tests/integration/acp/dac/p2p/replicator_test.go
+++ b/tests/integration/acp/dac/p2p/replicator_test.go
@@ -17,13 +17,14 @@ import (
 
 	"github.com/sourcenetwork/defradb/tests/action"
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	"github.com/sourcenetwork/defradb/tests/state"
 )
 
 func TestACP_P2POneToOneReplicatorWithPermissionedCollection_LocalACP(t *testing.T) {
 	test := testUtils.TestCase{
 		SupportedDocumentACPTypes: immutable.Some(
-			[]testUtils.DocumentACPType{
-				testUtils.LocalDocumentACPType,
+			[]state.DocumentACPType{
+				state.LocalDocumentACPType,
 			},
 		),
 		Actions: []any{
@@ -86,8 +87,8 @@ func TestACP_P2POneToOneReplicatorWithPermissionedCollection_LocalACP(t *testing
 func TestACP_P2POneToOneReplicatorWithPermissionedCollection_SourceHubACP(t *testing.T) {
 	test := testUtils.TestCase{
 		SupportedDocumentACPTypes: immutable.Some(
-			[]testUtils.DocumentACPType{
-				testUtils.SourceHubDocumentACPType,
+			[]state.DocumentACPType{
+				state.SourceHubDocumentACPType,
 			},
 		),
 		Actions: []any{

--- a/tests/integration/acp/dac/p2p/replicator_with_doc_actor_relationship_test.go
+++ b/tests/integration/acp/dac/p2p/replicator_with_doc_actor_relationship_test.go
@@ -17,14 +17,15 @@ import (
 
 	"github.com/sourcenetwork/defradb/tests/action"
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	"github.com/sourcenetwork/defradb/tests/state"
 )
 
 func TestACP_P2PReplicatorWithPermissionedCollectionCreateDocActorRelationship_SourceHubACP(t *testing.T) {
 	test := testUtils.TestCase{
 
 		SupportedDocumentACPTypes: immutable.Some(
-			[]testUtils.DocumentACPType{
-				testUtils.SourceHubDocumentACPType,
+			[]state.DocumentACPType{
+				state.SourceHubDocumentACPType,
 			},
 		),
 

--- a/tests/integration/acp/dac/p2p/subscribe_test.go
+++ b/tests/integration/acp/dac/p2p/subscribe_test.go
@@ -17,13 +17,14 @@ import (
 
 	"github.com/sourcenetwork/defradb/tests/action"
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	"github.com/sourcenetwork/defradb/tests/state"
 )
 
 func TestACP_P2PSubscribeAddGetSingleWithPermissionedCollection_LocalACP(t *testing.T) {
 	test := testUtils.TestCase{
 		SupportedDocumentACPTypes: immutable.Some(
-			[]testUtils.DocumentACPType{
-				testUtils.LocalDocumentACPType,
+			[]state.DocumentACPType{
+				state.LocalDocumentACPType,
 			},
 		),
 		Actions: []any{
@@ -102,8 +103,8 @@ func TestACP_P2PSubscribeAddGetSingleWithPermissionedCollection_LocalACP(t *test
 func TestACP_P2PSubscribeAddGetSingleWithPermissionedCollection_SourceHubACP(t *testing.T) {
 	test := testUtils.TestCase{
 		SupportedDocumentACPTypes: immutable.Some(
-			[]testUtils.DocumentACPType{
-				testUtils.SourceHubDocumentACPType,
+			[]state.DocumentACPType{
+				state.SourceHubDocumentACPType,
 			},
 		),
 		Actions: []any{

--- a/tests/integration/acp/dac/p2p/subscribe_with_doc_actor_relationship_test.go
+++ b/tests/integration/acp/dac/p2p/subscribe_with_doc_actor_relationship_test.go
@@ -17,14 +17,15 @@ import (
 
 	"github.com/sourcenetwork/defradb/tests/action"
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	"github.com/sourcenetwork/defradb/tests/state"
 )
 
 func TestACP_P2PSubscribeAddGetSingleWithPermissionedCollectionCreateDocActorRelationship_SourceHubACP(t *testing.T) {
 	test := testUtils.TestCase{
 
 		SupportedDocumentACPTypes: immutable.Some(
-			[]testUtils.DocumentACPType{
-				testUtils.SourceHubDocumentACPType,
+			[]state.DocumentACPType{
+				state.SourceHubDocumentACPType,
 			},
 		),
 

--- a/tests/integration/acp/dac/p2p/update_test.go
+++ b/tests/integration/acp/dac/p2p/update_test.go
@@ -17,14 +17,15 @@ import (
 
 	"github.com/sourcenetwork/defradb/tests/action"
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	"github.com/sourcenetwork/defradb/tests/state"
 )
 
 func TestACP_P2PUpdatePrivateDocumentsOnDifferentNodes_SourceHubACP(t *testing.T) {
 	test := testUtils.TestCase{
 
 		SupportedDocumentACPTypes: immutable.Some(
-			[]testUtils.DocumentACPType{
-				testUtils.SourceHubDocumentACPType,
+			[]state.DocumentACPType{
+				state.SourceHubDocumentACPType,
 			},
 		),
 

--- a/tests/integration/acp/nac/relation_admin/schema_add_test.go
+++ b/tests/integration/acp/nac/relation_admin/schema_add_test.go
@@ -1,0 +1,62 @@
+// Copyright 2025 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package test_acp_nac_relation_admin
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/defradb/tests/action"
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+func TestNAC_AdminRelation_CanAddSchema(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			// Starting with NAC, so only authorized user(s) can perform operations from here on out.
+			testUtils.Close{},
+			testUtils.Start{
+				Identity:  testUtils.ClientIdentity(1),
+				EnableNAC: true,
+			},
+
+			// This user, can not perform this gated operation yet.
+			&action.AddSchema{
+				Identity: testUtils.ClientIdentity(2),
+				Schema: `
+					type Users {
+						name: String
+					}
+				`,
+				ExpectedError: "not authorized to perform operation",
+			},
+
+			// Grant access to user.
+			testUtils.AddNACActorRelationship{
+				RequestorIdentity: testUtils.ClientIdentity(1),
+				TargetIdentity:    testUtils.ClientIdentity(2), // Grant this user "admin" relation
+				Relation:          "admin",
+				ExpectedExistence: false,
+			},
+
+			// This user, can now perform this gated operation.
+			&action.AddSchema{
+				Identity: testUtils.ClientIdentity(2),
+				Schema: `
+					type Users {
+						name: String
+					}
+				`,
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/acp/nac/relation_admin/schema_add_test.go
+++ b/tests/integration/acp/nac/relation_admin/schema_add_test.go
@@ -13,12 +13,26 @@ package test_acp_nac_relation_admin
 import (
 	"testing"
 
+	"github.com/sourcenetwork/immutable"
+
 	"github.com/sourcenetwork/defradb/tests/action"
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	"github.com/sourcenetwork/defradb/tests/state"
 )
 
 func TestNAC_AdminRelation_CanAddSchema(t *testing.T) {
 	test := testUtils.TestCase{
+		SupportedClientTypes: immutable.Some(
+			[]state.ClientType{
+				// TODO: C binding test harness must be reworked to support this test
+				// See: https://github.com/sourcenetwork/defradb/issues/3919
+				testUtils.GoClientType,
+				testUtils.CLIClientType,
+				testUtils.HTTPClientType,
+				testUtils.JSClientType,
+			},
+		),
+
 		Actions: []any{
 			// Starting with NAC, so only authorized user(s) can perform operations from here on out.
 			testUtils.Close{},

--- a/tests/integration/acp/nac/schema_add_test.go
+++ b/tests/integration/acp/nac/schema_add_test.go
@@ -1,0 +1,65 @@
+// Copyright 2025 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package test_acp_nac
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/defradb/tests/action"
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+func TestNAC_GatesSchemaAdd_AllowIfAuthorizedElseError(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			// Starting with NAC, so only authorized user(s) can perform operations from here on out.
+			testUtils.Close{},
+			testUtils.Start{
+				Identity:  testUtils.ClientIdentity(1),
+				EnableNAC: true,
+			},
+
+			// We haven't authorized non-identities. So, this should error.
+			&action.AddSchema{
+				Identity: testUtils.NoIdentity(),
+				Schema: `
+					type Users {
+						name: String
+					}
+				`,
+				ExpectedError: "not authorized to perform operation",
+			},
+
+			// Wrong user/identity will also not be authorized.
+			&action.AddSchema{
+				Identity: testUtils.ClientIdentity(2),
+				Schema: `
+					type Users {
+						name: String
+					}
+				`,
+				ExpectedError: "not authorized to perform operation",
+			},
+
+			// This should work as the identity is authorized.
+			&action.AddSchema{
+				Identity: testUtils.ClientIdentity(1),
+				Schema: `
+					type Users {
+						name: String
+					}
+				`,
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/acp/nac/schema_add_test.go
+++ b/tests/integration/acp/nac/schema_add_test.go
@@ -13,12 +13,26 @@ package test_acp_nac
 import (
 	"testing"
 
+	"github.com/sourcenetwork/immutable"
+
 	"github.com/sourcenetwork/defradb/tests/action"
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	"github.com/sourcenetwork/defradb/tests/state"
 )
 
 func TestNAC_GatesSchemaAdd_AllowIfAuthorizedElseError(t *testing.T) {
 	test := testUtils.TestCase{
+		SupportedClientTypes: immutable.Some(
+			[]state.ClientType{
+				// TODO: C binding test harness must be reworked to support this test
+				// See: https://github.com/sourcenetwork/defradb/issues/3919
+				testUtils.GoClientType,
+				testUtils.CLIClientType,
+				testUtils.HTTPClientType,
+				testUtils.JSClientType,
+			},
+		),
+
 		Actions: []any{
 			// Starting with NAC, so only authorized user(s) can perform operations from here on out.
 			testUtils.Close{},

--- a/tests/integration/acp_dac.go
+++ b/tests/integration/acp_dac.go
@@ -13,7 +13,6 @@ package tests
 import (
 	"os"
 	"slices"
-	"time"
 
 	"github.com/sourcenetwork/immutable"
 	"github.com/stretchr/testify/require"
@@ -21,24 +20,12 @@ import (
 	"github.com/sourcenetwork/defradb/tests/state"
 )
 
-type DocumentACPType string
-
 const (
 	documentACPTypeEnvName = "DEFRA_DOCUMENT_ACP_TYPE"
 )
 
-const (
-	SourceHubDocumentACPType DocumentACPType = "source-hub"
-	LocalDocumentACPType     DocumentACPType = "local"
-)
-
-const (
-	// authTokenExpiration is the expiration time for auth tokens.
-	authTokenExpiration = time.Minute * 1
-)
-
 var (
-	documentACPType DocumentACPType
+	documentACPType state.DocumentACPType
 )
 
 const (
@@ -53,9 +40,9 @@ func getKMSTypes() []state.KMSType {
 }
 
 func init() {
-	documentACPType = DocumentACPType(os.Getenv(documentACPTypeEnvName))
+	documentACPType = state.DocumentACPType(os.Getenv(documentACPTypeEnvName))
 	if documentACPType == "" {
-		documentACPType = LocalDocumentACPType
+		documentACPType = state.LocalDocumentACPType
 	}
 }
 
@@ -129,7 +116,7 @@ func addDACPolicy(
 
 		// The policy should only be added to a SourceHub chain once - there is no need to loop through
 		// the nodes.
-		if documentACPType == SourceHubDocumentACPType {
+		if s.DocumentACPType == state.SourceHubDocumentACPType {
 			// Note: If we break here the state will only preserve the policyIDs result on the
 			// first node if acp type is sourcehub, make sure to replicate the policyIDs state
 			// on all the nodes, so we don't have to handle all the edge cases later in actions.
@@ -218,7 +205,7 @@ func addDACActorRelationship(
 
 		// The relationship should only be added to a SourceHub chain once - there is no need to loop through
 		// the nodes.
-		if documentACPType == SourceHubDocumentACPType {
+		if s.DocumentACPType == state.SourceHubDocumentACPType {
 			actionNodeID = immutable.Some(0)
 			break
 		}
@@ -308,7 +295,7 @@ func deleteDACActorRelationship(
 
 		// The relationship should only be added to a SourceHub chain once - there is no need to loop through
 		// the nodes.
-		if documentACPType == SourceHubDocumentACPType {
+		if s.DocumentACPType == state.SourceHubDocumentACPType {
 			break
 		}
 	}

--- a/tests/integration/acp_dac_setup.go
+++ b/tests/integration/acp_dac_setup.go
@@ -28,8 +28,6 @@ import (
 
 	"github.com/sourcenetwork/defradb/keyring"
 	"github.com/sourcenetwork/defradb/node"
-	"github.com/sourcenetwork/defradb/tests/clients/cli"
-	"github.com/sourcenetwork/defradb/tests/clients/http"
 	"github.com/sourcenetwork/defradb/tests/state"
 
 	"github.com/decred/dcrd/dcrec/secp256k1/v4"
@@ -37,20 +35,6 @@ import (
 	"github.com/sourcenetwork/immutable"
 	"github.com/stretchr/testify/require"
 )
-
-func getNodeAudience(s *state.State, nodeIndex int) immutable.Option[string] {
-	if nodeIndex >= len(s.Nodes) {
-		return immutable.None[string]()
-	}
-	switch client := s.Nodes[nodeIndex].Client.(type) {
-	case *http.Wrapper:
-		return immutable.Some(strings.TrimPrefix(client.Host(), "http://"))
-	case *cli.Wrapper:
-		return immutable.Some(strings.TrimPrefix(client.Host(), "http://"))
-	}
-
-	return immutable.None[string]()
-}
 
 func setupSourceHub(s *state.State, testCase TestCase) ([]node.DocumentACPOpt, error) {
 	var isDocumentACPTest bool

--- a/tests/integration/db_setup.go
+++ b/tests/integration/db_setup.go
@@ -66,11 +66,11 @@ func setupNode(
 		opts = append(opts, node.WithBadgerEncryptionKey(encryptionKey))
 	}
 
-	switch documentACPType {
-	case LocalDocumentACPType:
+	switch s.DocumentACPType {
+	case state.LocalDocumentACPType:
 		opts = append(opts, node.WithDocumentACPType(node.LocalDocumentACPType))
 
-	case SourceHubDocumentACPType:
+	case state.SourceHubDocumentACPType:
 		if len(s.DocumentACPOptions) == 0 {
 			s.DocumentACPOptions, err = setupSourceHub(s, testCase)
 			require.NoError(s.T, err)

--- a/tests/integration/db_setup_js.go
+++ b/tests/integration/db_setup_js.go
@@ -39,10 +39,10 @@ func setupNode(
 	opts = append(opts, node.WithBadgerInMemory(true))
 
 	switch documentACPType {
-	case LocalDocumentACPType:
+	case state.LocalDocumentACPType:
 		opts = append(opts, node.WithDocumentACPType(node.LocalDocumentACPType))
 
-	case SourceHubDocumentACPType:
+	case state.SourceHubDocumentACPType:
 		if len(s.DocumentACPOptions) == 0 {
 			var err error
 			s.DocumentACPOptions, err = setupSourceHub(s)

--- a/tests/integration/encryption/peer_acp_test.go
+++ b/tests/integration/encryption/peer_acp_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/sourcenetwork/defradb/tests/action"
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	"github.com/sourcenetwork/defradb/tests/state"
 )
 
 const policy = `
@@ -75,8 +76,8 @@ func TestDocEncryptionACP_IfUserAndNodeHaveAccess_ShouldFetch(t *testing.T) {
 	test := testUtils.TestCase{
 		KMS: testUtils.KMS{Activated: true},
 		SupportedDocumentACPTypes: immutable.Some(
-			[]testUtils.DocumentACPType{
-				testUtils.SourceHubDocumentACPType,
+			[]state.DocumentACPType{
+				state.SourceHubDocumentACPType,
 			},
 		),
 		Actions: []any{
@@ -157,8 +158,8 @@ func TestDocEncryptionACP_IfUserHasAccessButNotNode_ShouldNotFetch(t *testing.T)
 	test := testUtils.TestCase{
 		KMS: testUtils.KMS{Activated: true},
 		SupportedDocumentACPTypes: immutable.Some(
-			[]testUtils.DocumentACPType{
-				testUtils.SourceHubDocumentACPType,
+			[]state.DocumentACPType{
+				state.SourceHubDocumentACPType,
 			},
 		),
 		Actions: []any{
@@ -229,8 +230,8 @@ func TestDocEncryptionACP_IfNodeHasAccessToSomeDocs_ShouldFetchOnlyThem(t *testi
 	test := testUtils.TestCase{
 		KMS: testUtils.KMS{Activated: true},
 		SupportedDocumentACPTypes: immutable.Some(
-			[]testUtils.DocumentACPType{
-				testUtils.SourceHubDocumentACPType,
+			[]state.DocumentACPType{
+				state.SourceHubDocumentACPType,
 			},
 		),
 		Actions: []any{
@@ -370,8 +371,8 @@ func TestDocEncryptionACP_IfClientNodeHasDocPermissionButServerNodeIsNotAvailabl
 	test := testUtils.TestCase{
 		KMS: testUtils.KMS{Activated: true},
 		SupportedDocumentACPTypes: immutable.Some(
-			[]testUtils.DocumentACPType{
-				testUtils.SourceHubDocumentACPType,
+			[]state.DocumentACPType{
+				state.SourceHubDocumentACPType,
 			},
 		),
 		Actions: []any{

--- a/tests/integration/test_case.go
+++ b/tests/integration/test_case.go
@@ -51,7 +51,7 @@ type TestCase struct {
 	//
 	// This is to only be used in the very rare cases where we really do want behavioural
 	// differences between acp types, or we need to temporarily document a bug.
-	SupportedDocumentACPTypes immutable.Option[[]DocumentACPType]
+	SupportedDocumentACPTypes immutable.Option[[]state.DocumentACPType]
 
 	// If provided a value, SupportedACPTypes will cause this test to be skipped
 	// if the active view type is not within the given set.

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -230,7 +230,16 @@ func ExecuteTestCase(
 	for _, ct := range clients {
 		for _, dbt := range databases {
 			for _, kms := range kmsList {
-				executeTestCase(ctx, t, collectionNames, testCase, kms, dbt, ct)
+				executeTestCase(
+					ctx,
+					t,
+					collectionNames,
+					testCase,
+					kms,
+					dbt,
+					ct,
+					documentACPType,
+				)
 			}
 		}
 	}
@@ -244,6 +253,7 @@ func executeTestCase(
 	kms state.KMSType,
 	dbt state.DatabaseType,
 	clientType state.ClientType,
+	documentACPType state.DocumentACPType,
 ) {
 	logAttrs := []slog.Attr{
 		corelog.Any("database", dbt),
@@ -267,7 +277,16 @@ func executeTestCase(
 
 	startActionIndex, endActionIndex := getActionRange(t, testCase)
 
-	s := state.NewState(ctx, t, testCase.IdentityTypes, kms, dbt, clientType, collectionNames)
+	s := state.NewState(
+		ctx,
+		t,
+		testCase.IdentityTypes,
+		kms,
+		dbt,
+		clientType,
+		documentACPType,
+		collectionNames,
+	)
 	setStartingNodes(s, testCase)
 
 	// It is very important that the databases are always closed, otherwise resources will leak
@@ -867,9 +886,9 @@ func refreshTokens(
 		if fullIdentityToUpdate, ok := identityToUpdate.(acpIdentity.FullIdentity); ok {
 			nodeTokensToUpdate := identHolder.NodeTokens
 			for nodeKey := range identHolder.NodeTokens {
-				if audience := getNodeAudience(s, nodeKey); audience.HasValue() {
+				if audience := state.GetNodeAudience(s, nodeKey); audience.HasValue() {
 					err := fullIdentityToUpdate.UpdateToken(
-						authTokenExpiration,
+						action.AuthTokenExpiration,
 						audience,
 						immutable.Some(s.SourcehubAddress),
 					)
@@ -2311,7 +2330,7 @@ func skipIfClientTypeUnsupported(
 	return filteredClients
 }
 
-func skipIfDocumentACPTypeUnsupported(t testing.TB, supportedACPTypes immutable.Option[[]DocumentACPType]) {
+func skipIfDocumentACPTypeUnsupported(t testing.TB, supportedACPTypes immutable.Option[[]state.DocumentACPType]) {
 	if supportedACPTypes.HasValue() {
 		var isTypeSupported bool
 		for _, supportedType := range supportedACPTypes.Value() {

--- a/tests/state/audience.go
+++ b/tests/state/audience.go
@@ -1,0 +1,36 @@
+// Copyright 2025 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+//go:build !js
+
+package state
+
+import (
+	"strings"
+
+	"github.com/sourcenetwork/immutable"
+
+	"github.com/sourcenetwork/defradb/tests/clients/cli"
+	"github.com/sourcenetwork/defradb/tests/clients/http"
+)
+
+func GetNodeAudience(s *State, nodeIndex int) immutable.Option[string] {
+	if nodeIndex >= len(s.Nodes) {
+		return immutable.None[string]()
+	}
+	switch client := s.Nodes[nodeIndex].Client.(type) {
+	case *http.Wrapper:
+		return immutable.Some(strings.TrimPrefix(client.Host(), "http://"))
+	case *cli.Wrapper:
+		return immutable.Some(strings.TrimPrefix(client.Host(), "http://"))
+	}
+
+	return immutable.None[string]()
+}

--- a/tests/state/audience_js.go
+++ b/tests/state/audience_js.go
@@ -8,13 +8,12 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-package tests
+package state
 
 import (
-	"github.com/sourcenetwork/defradb/node"
-	"github.com/sourcenetwork/defradb/tests/state"
+	"github.com/sourcenetwork/immutable"
 )
 
-func setupSourceHub(s *state.State) ([]node.DocumentACPOpt, error) {
-	return s.DocumentACPOptions, nil
+func GetNodeAudience(s *State, nodeIndex int) immutable.Option[string] {
+	return immutable.None[string]()
 }

--- a/tests/state/state.go
+++ b/tests/state/state.go
@@ -43,6 +43,14 @@ type KMSType string
 
 type ClientType string
 
+// DocumentACPType is the type of document acp to use.
+type DocumentACPType string
+
+const (
+	SourceHubDocumentACPType DocumentACPType = "source-hub"
+	LocalDocumentACPType     DocumentACPType = "local"
+)
+
 type ColDocIndex struct {
 	Col int
 	Doc int
@@ -183,6 +191,12 @@ type State struct {
 	// The type of client currently being tested.
 	ClientType ClientType
 
+	// The type of Document ACP
+	DocumentACPType DocumentACPType
+
+	// The Document ACP options to share between each node (currently only used for sourcehub).
+	DocumentACPOptions []node.DocumentACPOpt
+
 	// Any explicit transactions active in this test.
 	//
 	// This is order dependent and the property is accessed by index.
@@ -215,9 +229,6 @@ type State struct {
 
 	// The Nodes active in this test.
 	Nodes []*NodeState
-
-	// The ACP options to share between each node.
-	DocumentACPOptions []node.DocumentACPOpt
 
 	// The names of the collections active in this test.
 	// Indexes matches that of initial collections.
@@ -275,6 +286,7 @@ func NewState(
 	kms KMSType,
 	dbt DatabaseType,
 	clientType ClientType,
+	documentACPType DocumentACPType,
 	collectionNames []string,
 ) *State {
 	s := &State{
@@ -283,6 +295,8 @@ func NewState(
 		KMS:                             kms,
 		DbType:                          dbt,
 		ClientType:                      clientType,
+		DocumentACPType:                 documentACPType,
+		DocumentACPOptions:              []node.DocumentACPOpt{},
 		Txns:                            []client.Txn{},
 		IdentityTypes:                   identityTypes,
 		Identities:                      map[Identity]*IdentityHolder{},
@@ -290,7 +304,6 @@ func NewState(
 		AllActionsDone:                  make(chan struct{}),
 		SubscriptionResultsChans:        []chan func(){},
 		Nodes:                           []*NodeState{},
-		DocumentACPOptions:              []node.DocumentACPOpt{},
 		CollectionNames:                 collectionNames,
 		CollectionIndexesByCollectionID: map[string]int{},
 		DocIDs:                          [][]client.DocID{},


### PR DESCRIPTION
## Relevant issue(s)
Resolves #3904

## Description
- Follow-up to #3758 
- Gate Schema Add Node Operation
- Ensure `admin` behaves properly with new operation.

## Additional Context
- Original PR when opened only had this commit: https://github.com/sourcenetwork/defradb/pull/3905/commits/b307e6a1c22c429972176a24883f4ff698078774
- This PR (https://github.com/sourcenetwork/defradb/pull/3918) moved the test action under `tests/action` folder
- So, the first commit handles the refactoring of testing framework to add the missing identity util functions in the `action` package.

## How has this been tested?
Integration tests.

Specify the platform(s) on which this was tested:
- WSL 2 (Manjaro)