### PR TITLE
chore(i): Lock mockery down to patch version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -167,7 +167,7 @@ deps\:modules:
 
 .PHONY: deps\:mocks
 deps\:mocks:
-	go install github.com/vektra/mockery/v3@v3.2
+	go install github.com/vektra/mockery/v3@v3.5.2
 
 .PHONY: deps\:playground
 deps\:playground:

--- a/client/mocks/collection.go
+++ b/client/mocks/collection.go
@@ -111,9 +111,9 @@ type Collection_Create_Call struct {
 }
 
 // Create is a helper method to define mock.On call
-//   - ctx
-//   - doc
-//   - opts
+//   - ctx context.Context
+//   - doc *client.Document
+//   - opts ...client.DocCreateOption
 func (_e *Collection_Expecter) Create(ctx interface{}, doc interface{}, opts ...interface{}) *Collection_Create_Call {
 	return &Collection_Create_Call{Call: _e.mock.On("Create",
 		append([]interface{}{ctx, doc}, opts...)...)}
@@ -121,8 +121,25 @@ func (_e *Collection_Expecter) Create(ctx interface{}, doc interface{}, opts ...
 
 func (_c *Collection_Create_Call) Run(run func(ctx context.Context, doc *client.Document, opts ...client.DocCreateOption)) *Collection_Create_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		variadicArgs := args[2].([]client.DocCreateOption)
-		run(args[0].(context.Context), args[1].(*client.Document), variadicArgs...)
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *client.Document
+		if args[1] != nil {
+			arg1 = args[1].(*client.Document)
+		}
+		var arg2 []client.DocCreateOption
+		var variadicArgs []client.DocCreateOption
+		if len(args) > 2 {
+			variadicArgs = args[2].([]client.DocCreateOption)
+		}
+		arg2 = variadicArgs
+		run(
+			arg0,
+			arg1,
+			arg2...,
+		)
 	})
 	return _c
 }
@@ -169,15 +186,26 @@ type Collection_CreateIndex_Call struct {
 }
 
 // CreateIndex is a helper method to define mock.On call
-//   - context1
-//   - indexCreateRequest
+//   - context1 context.Context
+//   - indexCreateRequest client.IndexCreateRequest
 func (_e *Collection_Expecter) CreateIndex(context1 interface{}, indexCreateRequest interface{}) *Collection_CreateIndex_Call {
 	return &Collection_CreateIndex_Call{Call: _e.mock.On("CreateIndex", context1, indexCreateRequest)}
 }
 
 func (_c *Collection_CreateIndex_Call) Run(run func(context1 context.Context, indexCreateRequest client.IndexCreateRequest)) *Collection_CreateIndex_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(client.IndexCreateRequest))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 client.IndexCreateRequest
+		if args[1] != nil {
+			arg1 = args[1].(client.IndexCreateRequest)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -221,9 +249,9 @@ type Collection_CreateMany_Call struct {
 }
 
 // CreateMany is a helper method to define mock.On call
-//   - ctx
-//   - docs
-//   - opts
+//   - ctx context.Context
+//   - docs []*client.Document
+//   - opts ...client.DocCreateOption
 func (_e *Collection_Expecter) CreateMany(ctx interface{}, docs interface{}, opts ...interface{}) *Collection_CreateMany_Call {
 	return &Collection_CreateMany_Call{Call: _e.mock.On("CreateMany",
 		append([]interface{}{ctx, docs}, opts...)...)}
@@ -231,8 +259,25 @@ func (_e *Collection_Expecter) CreateMany(ctx interface{}, docs interface{}, opt
 
 func (_c *Collection_CreateMany_Call) Run(run func(ctx context.Context, docs []*client.Document, opts ...client.DocCreateOption)) *Collection_CreateMany_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		variadicArgs := args[2].([]client.DocCreateOption)
-		run(args[0].(context.Context), args[1].([]*client.Document), variadicArgs...)
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 []*client.Document
+		if args[1] != nil {
+			arg1 = args[1].([]*client.Document)
+		}
+		var arg2 []client.DocCreateOption
+		var variadicArgs []client.DocCreateOption
+		if len(args) > 2 {
+			variadicArgs = args[2].([]client.DocCreateOption)
+		}
+		arg2 = variadicArgs
+		run(
+			arg0,
+			arg1,
+			arg2...,
+		)
 	})
 	return _c
 }
@@ -279,15 +324,26 @@ type Collection_Delete_Call struct {
 }
 
 // Delete is a helper method to define mock.On call
-//   - ctx
-//   - docID
+//   - ctx context.Context
+//   - docID client.DocID
 func (_e *Collection_Expecter) Delete(ctx interface{}, docID interface{}) *Collection_Delete_Call {
 	return &Collection_Delete_Call{Call: _e.mock.On("Delete", ctx, docID)}
 }
 
 func (_c *Collection_Delete_Call) Run(run func(ctx context.Context, docID client.DocID)) *Collection_Delete_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(client.DocID))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 client.DocID
+		if args[1] != nil {
+			arg1 = args[1].(client.DocID)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -336,15 +392,26 @@ type Collection_DeleteWithFilter_Call struct {
 }
 
 // DeleteWithFilter is a helper method to define mock.On call
-//   - ctx
-//   - filter
+//   - ctx context.Context
+//   - filter any
 func (_e *Collection_Expecter) DeleteWithFilter(ctx interface{}, filter interface{}) *Collection_DeleteWithFilter_Call {
 	return &Collection_DeleteWithFilter_Call{Call: _e.mock.On("DeleteWithFilter", ctx, filter)}
 }
 
 func (_c *Collection_DeleteWithFilter_Call) Run(run func(ctx context.Context, filter any)) *Collection_DeleteWithFilter_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(any))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 any
+		if args[1] != nil {
+			arg1 = args[1].(any)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -382,15 +449,26 @@ type Collection_DropIndex_Call struct {
 }
 
 // DropIndex is a helper method to define mock.On call
-//   - ctx
-//   - indexName
+//   - ctx context.Context
+//   - indexName string
 func (_e *Collection_Expecter) DropIndex(ctx interface{}, indexName interface{}) *Collection_DropIndex_Call {
 	return &Collection_DropIndex_Call{Call: _e.mock.On("DropIndex", ctx, indexName)}
 }
 
 func (_c *Collection_DropIndex_Call) Run(run func(ctx context.Context, indexName string)) *Collection_DropIndex_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -437,15 +515,26 @@ type Collection_Exists_Call struct {
 }
 
 // Exists is a helper method to define mock.On call
-//   - ctx
-//   - docID
+//   - ctx context.Context
+//   - docID client.DocID
 func (_e *Collection_Expecter) Exists(ctx interface{}, docID interface{}) *Collection_Exists_Call {
 	return &Collection_Exists_Call{Call: _e.mock.On("Exists", ctx, docID)}
 }
 
 func (_c *Collection_Exists_Call) Run(run func(ctx context.Context, docID client.DocID)) *Collection_Exists_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(client.DocID))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 client.DocID
+		if args[1] != nil {
+			arg1 = args[1].(client.DocID)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -494,16 +583,32 @@ type Collection_Get_Call struct {
 }
 
 // Get is a helper method to define mock.On call
-//   - ctx
-//   - docID
-//   - showDeleted
+//   - ctx context.Context
+//   - docID client.DocID
+//   - showDeleted bool
 func (_e *Collection_Expecter) Get(ctx interface{}, docID interface{}, showDeleted interface{}) *Collection_Get_Call {
 	return &Collection_Get_Call{Call: _e.mock.On("Get", ctx, docID, showDeleted)}
 }
 
 func (_c *Collection_Get_Call) Run(run func(ctx context.Context, docID client.DocID, showDeleted bool)) *Collection_Get_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(client.DocID), args[2].(bool))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 client.DocID
+		if args[1] != nil {
+			arg1 = args[1].(client.DocID)
+		}
+		var arg2 bool
+		if args[2] != nil {
+			arg2 = args[2].(bool)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
 	})
 	return _c
 }
@@ -552,14 +657,20 @@ type Collection_GetAllDocIDs_Call struct {
 }
 
 // GetAllDocIDs is a helper method to define mock.On call
-//   - ctx
+//   - ctx context.Context
 func (_e *Collection_Expecter) GetAllDocIDs(ctx interface{}) *Collection_GetAllDocIDs_Call {
 	return &Collection_GetAllDocIDs_Call{Call: _e.mock.On("GetAllDocIDs", ctx)}
 }
 
 func (_c *Collection_GetAllDocIDs_Call) Run(run func(ctx context.Context)) *Collection_GetAllDocIDs_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
 	})
 	return _c
 }
@@ -608,14 +719,20 @@ type Collection_GetIndexes_Call struct {
 }
 
 // GetIndexes is a helper method to define mock.On call
-//   - ctx
+//   - ctx context.Context
 func (_e *Collection_Expecter) GetIndexes(ctx interface{}) *Collection_GetIndexes_Call {
 	return &Collection_GetIndexes_Call{Call: _e.mock.On("GetIndexes", ctx)}
 }
 
 func (_c *Collection_GetIndexes_Call) Run(run func(ctx context.Context)) *Collection_GetIndexes_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
 	})
 	return _c
 }
@@ -703,9 +820,9 @@ type Collection_Save_Call struct {
 }
 
 // Save is a helper method to define mock.On call
-//   - ctx
-//   - doc
-//   - opts
+//   - ctx context.Context
+//   - doc *client.Document
+//   - opts ...client.DocCreateOption
 func (_e *Collection_Expecter) Save(ctx interface{}, doc interface{}, opts ...interface{}) *Collection_Save_Call {
 	return &Collection_Save_Call{Call: _e.mock.On("Save",
 		append([]interface{}{ctx, doc}, opts...)...)}
@@ -713,8 +830,25 @@ func (_e *Collection_Expecter) Save(ctx interface{}, doc interface{}, opts ...in
 
 func (_c *Collection_Save_Call) Run(run func(ctx context.Context, doc *client.Document, opts ...client.DocCreateOption)) *Collection_Save_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		variadicArgs := args[2].([]client.DocCreateOption)
-		run(args[0].(context.Context), args[1].(*client.Document), variadicArgs...)
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *client.Document
+		if args[1] != nil {
+			arg1 = args[1].(*client.Document)
+		}
+		var arg2 []client.DocCreateOption
+		var variadicArgs []client.DocCreateOption
+		if len(args) > 2 {
+			variadicArgs = args[2].([]client.DocCreateOption)
+		}
+		arg2 = variadicArgs
+		run(
+			arg0,
+			arg1,
+			arg2...,
+		)
 	})
 	return _c
 }
@@ -752,15 +886,26 @@ type Collection_Update_Call struct {
 }
 
 // Update is a helper method to define mock.On call
-//   - ctx
-//   - docs
+//   - ctx context.Context
+//   - docs *client.Document
 func (_e *Collection_Expecter) Update(ctx interface{}, docs interface{}) *Collection_Update_Call {
 	return &Collection_Update_Call{Call: _e.mock.On("Update", ctx, docs)}
 }
 
 func (_c *Collection_Update_Call) Run(run func(ctx context.Context, docs *client.Document)) *Collection_Update_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(*client.Document))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *client.Document
+		if args[1] != nil {
+			arg1 = args[1].(*client.Document)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -809,16 +954,32 @@ type Collection_UpdateWithFilter_Call struct {
 }
 
 // UpdateWithFilter is a helper method to define mock.On call
-//   - ctx
-//   - filter
-//   - updater
+//   - ctx context.Context
+//   - filter any
+//   - updater string
 func (_e *Collection_Expecter) UpdateWithFilter(ctx interface{}, filter interface{}, updater interface{}) *Collection_UpdateWithFilter_Call {
 	return &Collection_UpdateWithFilter_Call{Call: _e.mock.On("UpdateWithFilter", ctx, filter, updater)}
 }
 
 func (_c *Collection_UpdateWithFilter_Call) Run(run func(ctx context.Context, filter any, updater string)) *Collection_UpdateWithFilter_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(any), args[2].(string))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 any
+		if args[1] != nil {
+			arg1 = args[1].(any)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
 	})
 	return _c
 }

--- a/client/mocks/txn_store.go
+++ b/client/mocks/txn_store.go
@@ -74,18 +74,44 @@ type TxnStore_AddDACActorRelationship_Call struct {
 }
 
 // AddDACActorRelationship is a helper method to define mock.On call
-//   - ctx
-//   - collectionName
-//   - docID
-//   - relation
-//   - targetActor
+//   - ctx context.Context
+//   - collectionName string
+//   - docID string
+//   - relation string
+//   - targetActor string
 func (_e *TxnStore_Expecter) AddDACActorRelationship(ctx interface{}, collectionName interface{}, docID interface{}, relation interface{}, targetActor interface{}) *TxnStore_AddDACActorRelationship_Call {
 	return &TxnStore_AddDACActorRelationship_Call{Call: _e.mock.On("AddDACActorRelationship", ctx, collectionName, docID, relation, targetActor)}
 }
 
 func (_c *TxnStore_AddDACActorRelationship_Call) Run(run func(ctx context.Context, collectionName string, docID string, relation string, targetActor string)) *TxnStore_AddDACActorRelationship_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(string), args[4].(string))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		var arg3 string
+		if args[3] != nil {
+			arg3 = args[3].(string)
+		}
+		var arg4 string
+		if args[4] != nil {
+			arg4 = args[4].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+			arg4,
+		)
 	})
 	return _c
 }
@@ -132,15 +158,26 @@ type TxnStore_AddDACPolicy_Call struct {
 }
 
 // AddDACPolicy is a helper method to define mock.On call
-//   - ctx
-//   - policy
+//   - ctx context.Context
+//   - policy string
 func (_e *TxnStore_Expecter) AddDACPolicy(ctx interface{}, policy interface{}) *TxnStore_AddDACPolicy_Call {
 	return &TxnStore_AddDACPolicy_Call{Call: _e.mock.On("AddDACPolicy", ctx, policy)}
 }
 
 func (_c *TxnStore_AddDACPolicy_Call) Run(run func(ctx context.Context, policy string)) *TxnStore_AddDACPolicy_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -187,16 +224,32 @@ type TxnStore_AddNACActorRelationship_Call struct {
 }
 
 // AddNACActorRelationship is a helper method to define mock.On call
-//   - ctx
-//   - relation
-//   - targetActor
+//   - ctx context.Context
+//   - relation string
+//   - targetActor string
 func (_e *TxnStore_Expecter) AddNACActorRelationship(ctx interface{}, relation interface{}, targetActor interface{}) *TxnStore_AddNACActorRelationship_Call {
 	return &TxnStore_AddNACActorRelationship_Call{Call: _e.mock.On("AddNACActorRelationship", ctx, relation, targetActor)}
 }
 
 func (_c *TxnStore_AddNACActorRelationship_Call) Run(run func(ctx context.Context, relation string, targetActor string)) *TxnStore_AddNACActorRelationship_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(string))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
 	})
 	return _c
 }
@@ -245,15 +298,26 @@ type TxnStore_AddSchema_Call struct {
 }
 
 // AddSchema is a helper method to define mock.On call
-//   - ctx
-//   - sdl
+//   - ctx context.Context
+//   - sdl string
 func (_e *TxnStore_Expecter) AddSchema(ctx interface{}, sdl interface{}) *TxnStore_AddSchema_Call {
 	return &TxnStore_AddSchema_Call{Call: _e.mock.On("AddSchema", ctx, sdl)}
 }
 
 func (_c *TxnStore_AddSchema_Call) Run(run func(ctx context.Context, sdl string)) *TxnStore_AddSchema_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -302,17 +366,38 @@ type TxnStore_AddView_Call struct {
 }
 
 // AddView is a helper method to define mock.On call
-//   - ctx
-//   - gqlQuery
-//   - sdl
-//   - transform
+//   - ctx context.Context
+//   - gqlQuery string
+//   - sdl string
+//   - transform immutable.Option[model.Lens]
 func (_e *TxnStore_Expecter) AddView(ctx interface{}, gqlQuery interface{}, sdl interface{}, transform interface{}) *TxnStore_AddView_Call {
 	return &TxnStore_AddView_Call{Call: _e.mock.On("AddView", ctx, gqlQuery, sdl, transform)}
 }
 
 func (_c *TxnStore_AddView_Call) Run(run func(ctx context.Context, gqlQuery string, sdl string, transform immutable.Option[model.Lens])) *TxnStore_AddView_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(immutable.Option[model.Lens]))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		var arg3 immutable.Option[model.Lens]
+		if args[3] != nil {
+			arg3 = args[3].(immutable.Option[model.Lens])
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+		)
 	})
 	return _c
 }
@@ -350,15 +435,26 @@ type TxnStore_BasicExport_Call struct {
 }
 
 // BasicExport is a helper method to define mock.On call
-//   - ctx
-//   - config
+//   - ctx context.Context
+//   - config *client.BackupConfig
 func (_e *TxnStore_Expecter) BasicExport(ctx interface{}, config interface{}) *TxnStore_BasicExport_Call {
 	return &TxnStore_BasicExport_Call{Call: _e.mock.On("BasicExport", ctx, config)}
 }
 
 func (_c *TxnStore_BasicExport_Call) Run(run func(ctx context.Context, config *client.BackupConfig)) *TxnStore_BasicExport_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(*client.BackupConfig))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *client.BackupConfig
+		if args[1] != nil {
+			arg1 = args[1].(*client.BackupConfig)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -396,15 +492,26 @@ type TxnStore_BasicImport_Call struct {
 }
 
 // BasicImport is a helper method to define mock.On call
-//   - ctx
-//   - filepath
+//   - ctx context.Context
+//   - filepath string
 func (_e *TxnStore_Expecter) BasicImport(ctx interface{}, filepath interface{}) *TxnStore_BasicImport_Call {
 	return &TxnStore_BasicImport_Call{Call: _e.mock.On("BasicImport", ctx, filepath)}
 }
 
 func (_c *TxnStore_BasicImport_Call) Run(run func(ctx context.Context, filepath string)) *TxnStore_BasicImport_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -451,18 +558,44 @@ type TxnStore_DeleteDACActorRelationship_Call struct {
 }
 
 // DeleteDACActorRelationship is a helper method to define mock.On call
-//   - ctx
-//   - collectionName
-//   - docID
-//   - relation
-//   - targetActor
+//   - ctx context.Context
+//   - collectionName string
+//   - docID string
+//   - relation string
+//   - targetActor string
 func (_e *TxnStore_Expecter) DeleteDACActorRelationship(ctx interface{}, collectionName interface{}, docID interface{}, relation interface{}, targetActor interface{}) *TxnStore_DeleteDACActorRelationship_Call {
 	return &TxnStore_DeleteDACActorRelationship_Call{Call: _e.mock.On("DeleteDACActorRelationship", ctx, collectionName, docID, relation, targetActor)}
 }
 
 func (_c *TxnStore_DeleteDACActorRelationship_Call) Run(run func(ctx context.Context, collectionName string, docID string, relation string, targetActor string)) *TxnStore_DeleteDACActorRelationship_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(string), args[4].(string))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		var arg3 string
+		if args[3] != nil {
+			arg3 = args[3].(string)
+		}
+		var arg4 string
+		if args[4] != nil {
+			arg4 = args[4].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+			arg4,
+		)
 	})
 	return _c
 }
@@ -509,16 +642,32 @@ type TxnStore_DeleteNACActorRelationship_Call struct {
 }
 
 // DeleteNACActorRelationship is a helper method to define mock.On call
-//   - ctx
-//   - relation
-//   - targetActor
+//   - ctx context.Context
+//   - relation string
+//   - targetActor string
 func (_e *TxnStore_Expecter) DeleteNACActorRelationship(ctx interface{}, relation interface{}, targetActor interface{}) *TxnStore_DeleteNACActorRelationship_Call {
 	return &TxnStore_DeleteNACActorRelationship_Call{Call: _e.mock.On("DeleteNACActorRelationship", ctx, relation, targetActor)}
 }
 
 func (_c *TxnStore_DeleteNACActorRelationship_Call) Run(run func(ctx context.Context, relation string, targetActor string)) *TxnStore_DeleteNACActorRelationship_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(string))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
 	})
 	return _c
 }
@@ -556,14 +705,20 @@ type TxnStore_DisableNAC_Call struct {
 }
 
 // DisableNAC is a helper method to define mock.On call
-//   - ctx
+//   - ctx context.Context
 func (_e *TxnStore_Expecter) DisableNAC(ctx interface{}) *TxnStore_DisableNAC_Call {
 	return &TxnStore_DisableNAC_Call{Call: _e.mock.On("DisableNAC", ctx)}
 }
 
 func (_c *TxnStore_DisableNAC_Call) Run(run func(ctx context.Context)) *TxnStore_DisableNAC_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
 	})
 	return _c
 }
@@ -609,9 +764,9 @@ type TxnStore_ExecRequest_Call struct {
 }
 
 // ExecRequest is a helper method to define mock.On call
-//   - ctx
-//   - request
-//   - opts
+//   - ctx context.Context
+//   - request string
+//   - opts ...client.RequestOption
 func (_e *TxnStore_Expecter) ExecRequest(ctx interface{}, request interface{}, opts ...interface{}) *TxnStore_ExecRequest_Call {
 	return &TxnStore_ExecRequest_Call{Call: _e.mock.On("ExecRequest",
 		append([]interface{}{ctx, request}, opts...)...)}
@@ -619,8 +774,25 @@ func (_e *TxnStore_Expecter) ExecRequest(ctx interface{}, request interface{}, o
 
 func (_c *TxnStore_ExecRequest_Call) Run(run func(ctx context.Context, request string, opts ...client.RequestOption)) *TxnStore_ExecRequest_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		variadicArgs := args[2].([]client.RequestOption)
-		run(args[0].(context.Context), args[1].(string), variadicArgs...)
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 []client.RequestOption
+		var variadicArgs []client.RequestOption
+		if len(args) > 2 {
+			variadicArgs = args[2].([]client.RequestOption)
+		}
+		arg2 = variadicArgs
+		run(
+			arg0,
+			arg1,
+			arg2...,
+		)
 	})
 	return _c
 }
@@ -669,14 +841,20 @@ type TxnStore_GetAllIndexes_Call struct {
 }
 
 // GetAllIndexes is a helper method to define mock.On call
-//   - ctx
+//   - ctx context.Context
 func (_e *TxnStore_Expecter) GetAllIndexes(ctx interface{}) *TxnStore_GetAllIndexes_Call {
 	return &TxnStore_GetAllIndexes_Call{Call: _e.mock.On("GetAllIndexes", ctx)}
 }
 
 func (_c *TxnStore_GetAllIndexes_Call) Run(run func(ctx context.Context)) *TxnStore_GetAllIndexes_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
 	})
 	return _c
 }
@@ -725,15 +903,26 @@ type TxnStore_GetCollectionByName_Call struct {
 }
 
 // GetCollectionByName is a helper method to define mock.On call
-//   - ctx
-//   - name
+//   - ctx context.Context
+//   - name client.CollectionName
 func (_e *TxnStore_Expecter) GetCollectionByName(ctx interface{}, name interface{}) *TxnStore_GetCollectionByName_Call {
 	return &TxnStore_GetCollectionByName_Call{Call: _e.mock.On("GetCollectionByName", ctx, name)}
 }
 
 func (_c *TxnStore_GetCollectionByName_Call) Run(run func(ctx context.Context, name client.CollectionName)) *TxnStore_GetCollectionByName_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(client.CollectionName))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 client.CollectionName
+		if args[1] != nil {
+			arg1 = args[1].(client.CollectionName)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -782,15 +971,26 @@ type TxnStore_GetCollections_Call struct {
 }
 
 // GetCollections is a helper method to define mock.On call
-//   - ctx
-//   - options
+//   - ctx context.Context
+//   - options client.CollectionFetchOptions
 func (_e *TxnStore_Expecter) GetCollections(ctx interface{}, options interface{}) *TxnStore_GetCollections_Call {
 	return &TxnStore_GetCollections_Call{Call: _e.mock.On("GetCollections", ctx, options)}
 }
 
 func (_c *TxnStore_GetCollections_Call) Run(run func(ctx context.Context, options client.CollectionFetchOptions)) *TxnStore_GetCollections_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(client.CollectionFetchOptions))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 client.CollectionFetchOptions
+		if args[1] != nil {
+			arg1 = args[1].(client.CollectionFetchOptions)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -837,14 +1037,20 @@ type TxnStore_GetNACStatus_Call struct {
 }
 
 // GetNACStatus is a helper method to define mock.On call
-//   - ctx
+//   - ctx context.Context
 func (_e *TxnStore_Expecter) GetNACStatus(ctx interface{}) *TxnStore_GetNACStatus_Call {
 	return &TxnStore_GetNACStatus_Call{Call: _e.mock.On("GetNACStatus", ctx)}
 }
 
 func (_c *TxnStore_GetNACStatus_Call) Run(run func(ctx context.Context)) *TxnStore_GetNACStatus_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
 	})
 	return _c
 }
@@ -891,14 +1097,20 @@ type TxnStore_GetNodeIdentity_Call struct {
 }
 
 // GetNodeIdentity is a helper method to define mock.On call
-//   - ctx
+//   - ctx context.Context
 func (_e *TxnStore_Expecter) GetNodeIdentity(ctx interface{}) *TxnStore_GetNodeIdentity_Call {
 	return &TxnStore_GetNodeIdentity_Call{Call: _e.mock.On("GetNodeIdentity", ctx)}
 }
 
 func (_c *TxnStore_GetNodeIdentity_Call) Run(run func(ctx context.Context)) *TxnStore_GetNodeIdentity_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
 	})
 	return _c
 }
@@ -993,15 +1205,26 @@ type TxnStore_NewConcurrentTxn_Call struct {
 }
 
 // NewConcurrentTxn is a helper method to define mock.On call
-//   - ctx
-//   - readOnly
+//   - ctx context.Context
+//   - readOnly bool
 func (_e *TxnStore_Expecter) NewConcurrentTxn(ctx interface{}, readOnly interface{}) *TxnStore_NewConcurrentTxn_Call {
 	return &TxnStore_NewConcurrentTxn_Call{Call: _e.mock.On("NewConcurrentTxn", ctx, readOnly)}
 }
 
 func (_c *TxnStore_NewConcurrentTxn_Call) Run(run func(ctx context.Context, readOnly bool)) *TxnStore_NewConcurrentTxn_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(bool))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 bool
+		if args[1] != nil {
+			arg1 = args[1].(bool)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -1050,15 +1273,26 @@ type TxnStore_NewTxn_Call struct {
 }
 
 // NewTxn is a helper method to define mock.On call
-//   - ctx
-//   - readOnly
+//   - ctx context.Context
+//   - readOnly bool
 func (_e *TxnStore_Expecter) NewTxn(ctx interface{}, readOnly interface{}) *TxnStore_NewTxn_Call {
 	return &TxnStore_NewTxn_Call{Call: _e.mock.On("NewTxn", ctx, readOnly)}
 }
 
 func (_c *TxnStore_NewTxn_Call) Run(run func(ctx context.Context, readOnly bool)) *TxnStore_NewTxn_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(bool))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 bool
+		if args[1] != nil {
+			arg1 = args[1].(bool)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -1096,16 +1330,32 @@ type TxnStore_PatchCollection_Call struct {
 }
 
 // PatchCollection is a helper method to define mock.On call
-//   - ctx
-//   - patch
-//   - migration
+//   - ctx context.Context
+//   - patch string
+//   - migration immutable.Option[model.Lens]
 func (_e *TxnStore_Expecter) PatchCollection(ctx interface{}, patch interface{}, migration interface{}) *TxnStore_PatchCollection_Call {
 	return &TxnStore_PatchCollection_Call{Call: _e.mock.On("PatchCollection", ctx, patch, migration)}
 }
 
 func (_c *TxnStore_PatchCollection_Call) Run(run func(ctx context.Context, patch string, migration immutable.Option[model.Lens])) *TxnStore_PatchCollection_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(immutable.Option[model.Lens]))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 immutable.Option[model.Lens]
+		if args[2] != nil {
+			arg2 = args[2].(immutable.Option[model.Lens])
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
 	})
 	return _c
 }
@@ -1143,14 +1393,20 @@ type TxnStore_PrintDump_Call struct {
 }
 
 // PrintDump is a helper method to define mock.On call
-//   - ctx
+//   - ctx context.Context
 func (_e *TxnStore_Expecter) PrintDump(ctx interface{}) *TxnStore_PrintDump_Call {
 	return &TxnStore_PrintDump_Call{Call: _e.mock.On("PrintDump", ctx)}
 }
 
 func (_c *TxnStore_PrintDump_Call) Run(run func(ctx context.Context)) *TxnStore_PrintDump_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
 	})
 	return _c
 }
@@ -1188,14 +1444,20 @@ type TxnStore_ReEnableNAC_Call struct {
 }
 
 // ReEnableNAC is a helper method to define mock.On call
-//   - ctx
+//   - ctx context.Context
 func (_e *TxnStore_Expecter) ReEnableNAC(ctx interface{}) *TxnStore_ReEnableNAC_Call {
 	return &TxnStore_ReEnableNAC_Call{Call: _e.mock.On("ReEnableNAC", ctx)}
 }
 
 func (_c *TxnStore_ReEnableNAC_Call) Run(run func(ctx context.Context)) *TxnStore_ReEnableNAC_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
 	})
 	return _c
 }
@@ -1233,15 +1495,26 @@ type TxnStore_RefreshViews_Call struct {
 }
 
 // RefreshViews is a helper method to define mock.On call
-//   - ctx
-//   - options
+//   - ctx context.Context
+//   - options client.CollectionFetchOptions
 func (_e *TxnStore_Expecter) RefreshViews(ctx interface{}, options interface{}) *TxnStore_RefreshViews_Call {
 	return &TxnStore_RefreshViews_Call{Call: _e.mock.On("RefreshViews", ctx, options)}
 }
 
 func (_c *TxnStore_RefreshViews_Call) Run(run func(ctx context.Context, options client.CollectionFetchOptions)) *TxnStore_RefreshViews_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(client.CollectionFetchOptions))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 client.CollectionFetchOptions
+		if args[1] != nil {
+			arg1 = args[1].(client.CollectionFetchOptions)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -1279,15 +1552,26 @@ type TxnStore_SetActiveCollectionVersion_Call struct {
 }
 
 // SetActiveCollectionVersion is a helper method to define mock.On call
-//   - ctx
-//   - versionID
+//   - ctx context.Context
+//   - versionID string
 func (_e *TxnStore_Expecter) SetActiveCollectionVersion(ctx interface{}, versionID interface{}) *TxnStore_SetActiveCollectionVersion_Call {
 	return &TxnStore_SetActiveCollectionVersion_Call{Call: _e.mock.On("SetActiveCollectionVersion", ctx, versionID)}
 }
 
 func (_c *TxnStore_SetActiveCollectionVersion_Call) Run(run func(ctx context.Context, versionID string)) *TxnStore_SetActiveCollectionVersion_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -1325,15 +1609,26 @@ type TxnStore_SetMigration_Call struct {
 }
 
 // SetMigration is a helper method to define mock.On call
-//   - ctx
-//   - config
+//   - ctx context.Context
+//   - config client.LensConfig
 func (_e *TxnStore_Expecter) SetMigration(ctx interface{}, config interface{}) *TxnStore_SetMigration_Call {
 	return &TxnStore_SetMigration_Call{Call: _e.mock.On("SetMigration", ctx, config)}
 }
 
 func (_c *TxnStore_SetMigration_Call) Run(run func(ctx context.Context, config client.LensConfig)) *TxnStore_SetMigration_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(client.LensConfig))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 client.LensConfig
+		if args[1] != nil {
+			arg1 = args[1].(client.LensConfig)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -1371,16 +1666,32 @@ type TxnStore_VerifySignature_Call struct {
 }
 
 // VerifySignature is a helper method to define mock.On call
-//   - ctx
-//   - blockCid
-//   - pubKey
+//   - ctx context.Context
+//   - blockCid string
+//   - pubKey crypto.PublicKey
 func (_e *TxnStore_Expecter) VerifySignature(ctx interface{}, blockCid interface{}, pubKey interface{}) *TxnStore_VerifySignature_Call {
 	return &TxnStore_VerifySignature_Call{Call: _e.mock.On("VerifySignature", ctx, blockCid, pubKey)}
 }
 
 func (_c *TxnStore_VerifySignature_Call) Run(run func(ctx context.Context, blockCid string, pubKey crypto.PublicKey)) *TxnStore_VerifySignature_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(crypto.PublicKey))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 crypto.PublicKey
+		if args[2] != nil {
+			arg2 = args[2].(crypto.PublicKey)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
 	})
 	return _c
 }

--- a/internal/datastore/mocks/blockstore.go
+++ b/internal/datastore/mocks/blockstore.go
@@ -74,14 +74,20 @@ type Blockstore_AllKeysChan_Call struct {
 }
 
 // AllKeysChan is a helper method to define mock.On call
-//   - ctx
+//   - ctx context.Context
 func (_e *Blockstore_Expecter) AllKeysChan(ctx interface{}) *Blockstore_AllKeysChan_Call {
 	return &Blockstore_AllKeysChan_Call{Call: _e.mock.On("AllKeysChan", ctx)}
 }
 
 func (_c *Blockstore_AllKeysChan_Call) Run(run func(ctx context.Context)) *Blockstore_AllKeysChan_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
 	})
 	return _c
 }
@@ -165,15 +171,26 @@ type Blockstore_DeleteBlock_Call struct {
 }
 
 // DeleteBlock is a helper method to define mock.On call
-//   - context1
-//   - cid1
+//   - context1 context.Context
+//   - cid1 cid.Cid
 func (_e *Blockstore_Expecter) DeleteBlock(context1 interface{}, cid1 interface{}) *Blockstore_DeleteBlock_Call {
 	return &Blockstore_DeleteBlock_Call{Call: _e.mock.On("DeleteBlock", context1, cid1)}
 }
 
 func (_c *Blockstore_DeleteBlock_Call) Run(run func(context1 context.Context, cid1 cid.Cid)) *Blockstore_DeleteBlock_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(cid.Cid))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 cid.Cid
+		if args[1] != nil {
+			arg1 = args[1].(cid.Cid)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -222,15 +239,26 @@ type Blockstore_Get_Call struct {
 }
 
 // Get is a helper method to define mock.On call
-//   - context1
-//   - cid1
+//   - context1 context.Context
+//   - cid1 cid.Cid
 func (_e *Blockstore_Expecter) Get(context1 interface{}, cid1 interface{}) *Blockstore_Get_Call {
 	return &Blockstore_Get_Call{Call: _e.mock.On("Get", context1, cid1)}
 }
 
 func (_c *Blockstore_Get_Call) Run(run func(context1 context.Context, cid1 cid.Cid)) *Blockstore_Get_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(cid.Cid))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 cid.Cid
+		if args[1] != nil {
+			arg1 = args[1].(cid.Cid)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -277,15 +305,26 @@ type Blockstore_GetSize_Call struct {
 }
 
 // GetSize is a helper method to define mock.On call
-//   - context1
-//   - cid1
+//   - context1 context.Context
+//   - cid1 cid.Cid
 func (_e *Blockstore_Expecter) GetSize(context1 interface{}, cid1 interface{}) *Blockstore_GetSize_Call {
 	return &Blockstore_GetSize_Call{Call: _e.mock.On("GetSize", context1, cid1)}
 }
 
 func (_c *Blockstore_GetSize_Call) Run(run func(context1 context.Context, cid1 cid.Cid)) *Blockstore_GetSize_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(cid.Cid))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 cid.Cid
+		if args[1] != nil {
+			arg1 = args[1].(cid.Cid)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -332,15 +371,26 @@ type Blockstore_Has_Call struct {
 }
 
 // Has is a helper method to define mock.On call
-//   - context1
-//   - cid1
+//   - context1 context.Context
+//   - cid1 cid.Cid
 func (_e *Blockstore_Expecter) Has(context1 interface{}, cid1 interface{}) *Blockstore_Has_Call {
 	return &Blockstore_Has_Call{Call: _e.mock.On("Has", context1, cid1)}
 }
 
 func (_c *Blockstore_Has_Call) Run(run func(context1 context.Context, cid1 cid.Cid)) *Blockstore_Has_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(cid.Cid))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 cid.Cid
+		if args[1] != nil {
+			arg1 = args[1].(cid.Cid)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -367,14 +417,20 @@ type Blockstore_HashOnRead_Call struct {
 }
 
 // HashOnRead is a helper method to define mock.On call
-//   - enabled
+//   - enabled bool
 func (_e *Blockstore_Expecter) HashOnRead(enabled interface{}) *Blockstore_HashOnRead_Call {
 	return &Blockstore_HashOnRead_Call{Call: _e.mock.On("HashOnRead", enabled)}
 }
 
 func (_c *Blockstore_HashOnRead_Call) Run(run func(enabled bool)) *Blockstore_HashOnRead_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(bool))
+		var arg0 bool
+		if args[0] != nil {
+			arg0 = args[0].(bool)
+		}
+		run(
+			arg0,
+		)
 	})
 	return _c
 }
@@ -412,15 +468,26 @@ type Blockstore_Put_Call struct {
 }
 
 // Put is a helper method to define mock.On call
-//   - context1
-//   - block
+//   - context1 context.Context
+//   - block blocks.Block
 func (_e *Blockstore_Expecter) Put(context1 interface{}, block interface{}) *Blockstore_Put_Call {
 	return &Blockstore_Put_Call{Call: _e.mock.On("Put", context1, block)}
 }
 
 func (_c *Blockstore_Put_Call) Run(run func(context1 context.Context, block blocks.Block)) *Blockstore_Put_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(blocks.Block))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 blocks.Block
+		if args[1] != nil {
+			arg1 = args[1].(blocks.Block)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -458,15 +525,26 @@ type Blockstore_PutMany_Call struct {
 }
 
 // PutMany is a helper method to define mock.On call
-//   - context1
-//   - blocks1
+//   - context1 context.Context
+//   - blocks1 []blocks.Block
 func (_e *Blockstore_Expecter) PutMany(context1 interface{}, blocks1 interface{}) *Blockstore_PutMany_Call {
 	return &Blockstore_PutMany_Call{Call: _e.mock.On("PutMany", context1, blocks1)}
 }
 
 func (_c *Blockstore_PutMany_Call) Run(run func(context1 context.Context, blocks1 []blocks.Block)) *Blockstore_PutMany_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].([]blocks.Block))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 []blocks.Block
+		if args[1] != nil {
+			arg1 = args[1].([]blocks.Block)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }

--- a/internal/db/fetcher/mocks/encoded_document.go
+++ b/internal/db/fetcher/mocks/encoded_document.go
@@ -116,14 +116,20 @@ type EncodedDocument_Properties_Call struct {
 }
 
 // Properties is a helper method to define mock.On call
-//   - onlyFilterProps
+//   - onlyFilterProps bool
 func (_e *EncodedDocument_Expecter) Properties(onlyFilterProps interface{}) *EncodedDocument_Properties_Call {
 	return &EncodedDocument_Properties_Call{Call: _e.mock.On("Properties", onlyFilterProps)}
 }
 
 func (_c *EncodedDocument_Properties_Call) Run(run func(onlyFilterProps bool)) *EncodedDocument_Properties_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(bool))
+		var arg0 bool
+		if args[0] != nil {
+			arg0 = args[0].(bool)
+		}
+		run(
+			arg0,
+		)
 	})
 	return _c
 }

--- a/internal/db/fetcher/mocks/fetcher.go
+++ b/internal/db/fetcher/mocks/fetcher.go
@@ -130,14 +130,20 @@ type Fetcher_FetchNext_Call struct {
 }
 
 // FetchNext is a helper method to define mock.On call
-//   - ctx
+//   - ctx context.Context
 func (_e *Fetcher_Expecter) FetchNext(ctx interface{}) *Fetcher_FetchNext_Call {
 	return &Fetcher_FetchNext_Call{Call: _e.mock.On("FetchNext", ctx)}
 }
 
 func (_c *Fetcher_FetchNext_Call) Run(run func(ctx context.Context)) *Fetcher_FetchNext_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
 	})
 	return _c
 }
@@ -175,24 +181,80 @@ type Fetcher_Init_Call struct {
 }
 
 // Init is a helper method to define mock.On call
-//   - ctx
-//   - identity1
-//   - txn
-//   - documentACP
-//   - index
-//   - col
-//   - fields
-//   - filter
-//   - ordering
-//   - docmapper
-//   - showDeleted
+//   - ctx context.Context
+//   - identity1 immutable.Option[identity.Identity]
+//   - txn datastore.Txn
+//   - documentACP immutable.Option[dac.DocumentACP]
+//   - index immutable.Option[client.IndexDescription]
+//   - col client.Collection
+//   - fields []client.CollectionFieldDescription
+//   - filter *mapper.Filter
+//   - ordering []mapper.OrderCondition
+//   - docmapper *core.DocumentMapping
+//   - showDeleted bool
 func (_e *Fetcher_Expecter) Init(ctx interface{}, identity1 interface{}, txn interface{}, documentACP interface{}, index interface{}, col interface{}, fields interface{}, filter interface{}, ordering interface{}, docmapper interface{}, showDeleted interface{}) *Fetcher_Init_Call {
 	return &Fetcher_Init_Call{Call: _e.mock.On("Init", ctx, identity1, txn, documentACP, index, col, fields, filter, ordering, docmapper, showDeleted)}
 }
 
 func (_c *Fetcher_Init_Call) Run(run func(ctx context.Context, identity1 immutable.Option[identity.Identity], txn datastore.Txn, documentACP immutable.Option[dac.DocumentACP], index immutable.Option[client.IndexDescription], col client.Collection, fields []client.CollectionFieldDescription, filter *mapper.Filter, ordering []mapper.OrderCondition, docmapper *core.DocumentMapping, showDeleted bool)) *Fetcher_Init_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(immutable.Option[identity.Identity]), args[2].(datastore.Txn), args[3].(immutable.Option[dac.DocumentACP]), args[4].(immutable.Option[client.IndexDescription]), args[5].(client.Collection), args[6].([]client.CollectionFieldDescription), args[7].(*mapper.Filter), args[8].([]mapper.OrderCondition), args[9].(*core.DocumentMapping), args[10].(bool))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 immutable.Option[identity.Identity]
+		if args[1] != nil {
+			arg1 = args[1].(immutable.Option[identity.Identity])
+		}
+		var arg2 datastore.Txn
+		if args[2] != nil {
+			arg2 = args[2].(datastore.Txn)
+		}
+		var arg3 immutable.Option[dac.DocumentACP]
+		if args[3] != nil {
+			arg3 = args[3].(immutable.Option[dac.DocumentACP])
+		}
+		var arg4 immutable.Option[client.IndexDescription]
+		if args[4] != nil {
+			arg4 = args[4].(immutable.Option[client.IndexDescription])
+		}
+		var arg5 client.Collection
+		if args[5] != nil {
+			arg5 = args[5].(client.Collection)
+		}
+		var arg6 []client.CollectionFieldDescription
+		if args[6] != nil {
+			arg6 = args[6].([]client.CollectionFieldDescription)
+		}
+		var arg7 *mapper.Filter
+		if args[7] != nil {
+			arg7 = args[7].(*mapper.Filter)
+		}
+		var arg8 []mapper.OrderCondition
+		if args[8] != nil {
+			arg8 = args[8].([]mapper.OrderCondition)
+		}
+		var arg9 *core.DocumentMapping
+		if args[9] != nil {
+			arg9 = args[9].(*core.DocumentMapping)
+		}
+		var arg10 bool
+		if args[10] != nil {
+			arg10 = args[10].(bool)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+			arg4,
+			arg5,
+			arg6,
+			arg7,
+			arg8,
+			arg9,
+			arg10,
+		)
 	})
 	return _c
 }
@@ -236,8 +298,8 @@ type Fetcher_Start_Call struct {
 }
 
 // Start is a helper method to define mock.On call
-//   - ctx
-//   - prefixes
+//   - ctx context.Context
+//   - prefixes ...keys.Walkable
 func (_e *Fetcher_Expecter) Start(ctx interface{}, prefixes ...interface{}) *Fetcher_Start_Call {
 	return &Fetcher_Start_Call{Call: _e.mock.On("Start",
 		append([]interface{}{ctx}, prefixes...)...)}
@@ -245,8 +307,20 @@ func (_e *Fetcher_Expecter) Start(ctx interface{}, prefixes ...interface{}) *Fet
 
 func (_c *Fetcher_Start_Call) Run(run func(ctx context.Context, prefixes ...keys.Walkable)) *Fetcher_Start_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		variadicArgs := args[1].([]keys.Walkable)
-		run(args[0].(context.Context), variadicArgs...)
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 []keys.Walkable
+		var variadicArgs []keys.Walkable
+		if len(args) > 1 {
+			variadicArgs = args[1].([]keys.Walkable)
+		}
+		arg1 = variadicArgs
+		run(
+			arg0,
+			arg1...,
+		)
 	})
 	return _c
 }


### PR DESCRIPTION
## Relevant issue(s)

Resolves #3944

## Description

Lock mockery down to patch version to stop it from breaking our build.