### PR TITLE
chore: Bump Go version to 1.24

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ endif
 TEST_FLAGS=-race -shuffle=on -timeout 10m
 
 JS_TEST_DIRS=./tests/integration/... ./event/... ./node/...
-JS_TEST_FLAGS=-exec="$$(go env GOROOT)/misc/wasm/go_js_wasm_exec" -shuffle=on -timeout 10m
+JS_TEST_FLAGS=-exec="$$(go env GOROOT)/lib/wasm/go_js_wasm_exec" -shuffle=on -timeout 10m
 
 COVERAGE_DIRECTORY=$(PWD)/coverage
 COVERAGE_FILE=coverage.txt

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sourcenetwork/defradb
 
-go 1.23.8
+go 1.24.6
 
 require (
 	github.com/bits-and-blooms/bitset v1.22.0

--- a/playground/README.md
+++ b/playground/README.md
@@ -15,7 +15,7 @@ A web based playground for DefraDB.
 <!--te-->
 
 ## Prerequisites
-- Go `v1.23` or later
+- Go `v1.24` or later
 - Node.js `^20.19.0 || >=22.12.0`
 
 ## Getting Started

--- a/tools/cloud/aws/packer/build_aws_ami.pkr.hcl
+++ b/tools/cloud/aws/packer/build_aws_ami.pkr.hcl
@@ -66,8 +66,8 @@ build {
     inline = [
       "/usr/bin/cloud-init status --wait",
       "sudo apt-get update && sudo apt-get install make build-essential -y",
-      "curl -OL https://golang.org/dl/go1.23.8.linux-amd64.tar.gz",
-      "rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.23.8.linux-amd64.tar.gz",
+      "curl -OL https://golang.org/dl/go1.24.6.linux-amd64.tar.gz",
+      "rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.24.6.linux-amd64.tar.gz",
       "export PATH=$PATH:/usr/local/go/bin",
       "git clone \"https://git@$DEFRADB_GIT_REPO\"",
       "cd ./defradb || { printf \"\\\ncd into defradb failed.\\\n\" && exit 2; }",

--- a/tools/configs/golangci.yaml
+++ b/tools/configs/golangci.yaml
@@ -53,7 +53,7 @@ run:
 
   # Define the Go version limit.
   # Default: use Go version from the go.mod file, fallback on the env var `GOVERSION`.
-  go: "1.23"
+  go: "1.24"
 
 #=====================================================================================[ Output Configuration Options ]
 output:
@@ -412,7 +412,7 @@ linters-settings:
 
   unused:
     # Select the Go version to target.
-    go: "1.23"
+    go: "1.24"
 
   whitespace:
     # Enforces newlines (or comments) after every multi-line if statement.

--- a/tools/defradb.containerfile
+++ b/tools/defradb.containerfile
@@ -11,7 +11,7 @@ RUN npm run build
 
 # Stage: build
 # Several steps are involved to enable caching and because of the behavior of COPY regarding directories.
-FROM docker.io/golang:1.23 AS build
+FROM docker.io/golang:1.24 AS build
 WORKDIR /repo/
 COPY go.mod go.sum Makefile ./
 RUN make deps:modules


### PR DESCRIPTION
## Relevant issue(s)

Resolves #3442

## Description

Bump Go version to 1.24
