### PR TITLE
feat: Handle invalid CGO handles in C bindings

### DIFF
--- a/cbindings/acp.go
+++ b/cbindings/acp.go
@@ -31,7 +31,11 @@ func ACPAddDACPolicy(nodePtr C.uintptr_t, identityPtr C.uintptr_t, policy *C.cha
 		return returnC(returnGoC(1, err.Error(), ""))
 	}
 
-	store := getStoreFromPointer(nodePtr)
+	store, err := getStoreFromPointer(nodePtr)
+	if err != nil {
+		return returnC(returnGoC(1, err.Error(), ""))
+	}
+
 	policyResult, err := store.AddDACPolicy(ctx, C.GoString(policy))
 	if err != nil {
 		return returnC(returnGoC(1, err.Error(), ""))
@@ -56,7 +60,11 @@ func ACPAddDACActorRelationship(
 		return returnC(returnGoC(1, err.Error(), ""))
 	}
 
-	store := getStoreFromPointer(nodePtr)
+	store, err := getStoreFromPointer(nodePtr)
+	if err != nil {
+		return returnC(returnGoC(1, err.Error(), ""))
+	}
+
 	result, err := store.AddDACActorRelationship(
 		ctx,
 		C.GoString(collection),
@@ -87,7 +95,11 @@ func ACPDeleteDACActorRelationship(
 		return returnC(returnGoC(1, err.Error(), ""))
 	}
 
-	store := getStoreFromPointer(nodePtr)
+	store, err := getStoreFromPointer(nodePtr)
+	if err != nil {
+		return returnC(returnGoC(1, err.Error(), ""))
+	}
+
 	result, err := store.DeleteDACActorRelationship(
 		ctx,
 		C.GoString(collection),
@@ -111,7 +123,11 @@ func ACPDisableNAC(nodePtr C.uintptr_t, identityPtr C.uintptr_t) *C.Result {
 		return returnC(returnGoC(1, err.Error(), ""))
 	}
 
-	store := getStoreFromPointer(nodePtr)
+	store, err := getStoreFromPointer(nodePtr)
+	if err != nil {
+		return returnC(returnGoC(1, err.Error(), ""))
+	}
+
 	if err := store.DisableNAC(ctx); err != nil {
 		return returnC(returnGoC(1, err.Error(), ""))
 	}
@@ -128,7 +144,11 @@ func ACPReEnableNAC(nodePtr C.uintptr_t, identityPtr C.uintptr_t) *C.Result {
 		return returnC(returnGoC(1, err.Error(), ""))
 	}
 
-	store := getStoreFromPointer(nodePtr)
+	store, err := getStoreFromPointer(nodePtr)
+	if err != nil {
+		return returnC(returnGoC(1, err.Error(), ""))
+	}
+
 	if err := store.ReEnableNAC(ctx); err != nil {
 		return returnC(returnGoC(1, err.Error(), ""))
 	}
@@ -150,7 +170,11 @@ func ACPAddNACActorRelationship(
 		return returnC(returnGoC(1, err.Error(), ""))
 	}
 
-	store := getStoreFromPointer(nodePtr)
+	store, err := getStoreFromPointer(nodePtr)
+	if err != nil {
+		return returnC(returnGoC(1, err.Error(), ""))
+	}
+
 	addNACActorRelationshipResult, err := store.AddNACActorRelationship(
 		ctx,
 		C.GoString(relation),
@@ -177,7 +201,11 @@ func ACPDeleteNACActorRelationship(
 		return returnC(returnGoC(1, err.Error(), ""))
 	}
 
-	store := getStoreFromPointer(nodePtr)
+	store, err := getStoreFromPointer(nodePtr)
+	if err != nil {
+		return returnC(returnGoC(1, err.Error(), ""))
+	}
+
 	deleteNACActorRelationshipResult, err := store.DeleteNACActorRelationship(
 		ctx,
 		C.GoString(relation),
@@ -199,7 +227,11 @@ func ACPGetNACStatus(nodePtr C.uintptr_t, identityPtr C.uintptr_t) *C.Result {
 		return returnC(returnGoC(1, err.Error(), ""))
 	}
 
-	store := getStoreFromPointer(nodePtr)
+	store, err := getStoreFromPointer(nodePtr)
+	if err != nil {
+		return returnC(returnGoC(1, err.Error(), ""))
+	}
+
 	status, err := store.GetNACStatus(ctx)
 	if err != nil {
 		return returnC(returnGoC(1, err.Error(), ""))

--- a/cbindings/block.go
+++ b/cbindings/block.go
@@ -36,7 +36,11 @@ func BlockVerifySignature(nodePtr C.uintptr_t, keyType *C.char, publicKey *C.cha
 		return returnC(returnGoC(1, err.Error(), ""))
 	}
 
-	store := getStoreFromPointer(nodePtr)
+	store, err := getStoreFromPointer(nodePtr)
+	if err != nil {
+		return returnC(returnGoC(1, err.Error(), ""))
+	}
+
 	err = store.VerifySignature(ctx, C.GoString(cid), pubKey)
 	if err != nil {
 		return returnC(returnGoC(1, err.Error(), ""))

--- a/cbindings/collection.go
+++ b/cbindings/collection.go
@@ -96,7 +96,11 @@ func CollectionCreate(
 		return returnC(returnGoC(1, err.Error(), ""))
 	}
 
-	store := getStoreFromPointer(nodePtr)
+	store, err := getStoreFromPointer(nodePtr)
+	if err != nil {
+		return returnC(returnGoC(1, err.Error(), ""))
+	}
+
 	col, err := getCollection(store, ctx, colOptions)
 	if err != nil {
 		return returnC(returnGoC(1, err.Error(), ""))
@@ -149,7 +153,11 @@ func CollectionDelete(nodePtr C.uintptr_t, docIDStr *C.char, filterStr *C.char, 
 		return returnC(returnGoC(1, err.Error(), ""))
 	}
 
-	store := getStoreFromPointer(nodePtr)
+	store, err := getStoreFromPointer(nodePtr)
+	if err != nil {
+		return returnC(returnGoC(1, err.Error(), ""))
+	}
+
 	col, err := getCollection(store, ctx, colOptions)
 	if err != nil {
 		return returnC(returnGoC(1, err.Error(), ""))
@@ -196,7 +204,11 @@ func CollectionDescribe(nodePtr C.uintptr_t, options C.CollectionOptions) *C.Res
 		return returnC(returnGoC(1, err.Error(), ""))
 	}
 
-	store := getStoreFromPointer(nodePtr)
+	store, err := getStoreFromPointer(nodePtr)
+	if err != nil {
+		return returnC(returnGoC(1, err.Error(), ""))
+	}
+
 	cols, err := store.GetCollections(ctx, colOptions)
 	if err != nil {
 		return returnC(returnGoC(1, err.Error(), ""))
@@ -220,7 +232,11 @@ func CollectionListDocIDs(nodePtr C.uintptr_t, options C.CollectionOptions) *C.R
 		return returnC(returnGoC(1, err.Error(), ""))
 	}
 
-	store := getStoreFromPointer(nodePtr)
+	store, err := getStoreFromPointer(nodePtr)
+	if err != nil {
+		return returnC(returnGoC(1, err.Error(), ""))
+	}
+
 	col, err := getCollection(store, ctx, colOptions)
 	if err != nil {
 		return returnC(returnGoC(1, err.Error(), ""))
@@ -262,7 +278,11 @@ func CollectionGet(nodePtr C.uintptr_t, docIDStr *C.char, showDeleted C.int, opt
 		return returnC(returnGoC(1, err.Error(), ""))
 	}
 
-	store := getStoreFromPointer(nodePtr)
+	store, err := getStoreFromPointer(nodePtr)
+	if err != nil {
+		return returnC(returnGoC(1, err.Error(), ""))
+	}
+
 	col, err := getCollection(store, ctx, colOptions)
 	if err != nil {
 		return returnC(returnGoC(1, err.Error(), ""))
@@ -309,7 +329,11 @@ func CollectionPatch(nodePtr C.uintptr_t, patch *C.char, lensConfig *C.char, opt
 		}
 	}
 
-	store := getStoreFromPointer(nodePtr)
+	store, err := getStoreFromPointer(nodePtr)
+	if err != nil {
+		return returnC(returnGoC(1, err.Error(), ""))
+	}
+
 	err = store.PatchCollection(ctx, C.GoString(patch), migration)
 	if err != nil {
 		return returnC(returnGoC(1, err.Error(), ""))
@@ -333,7 +357,11 @@ func CollectionUpdate(
 		return returnC(returnGoC(1, err.Error(), ""))
 	}
 
-	store := getStoreFromPointer(nodePtr)
+	store, err := getStoreFromPointer(nodePtr)
+	if err != nil {
+		return returnC(returnGoC(1, err.Error(), ""))
+	}
+
 	col, err := getCollection(store, ctx, colOptions)
 	if err != nil {
 		return returnC(returnGoC(1, err.Error(), ""))
@@ -386,8 +414,12 @@ func CollectionUpdate(
 func SetActiveCollection(nodePtr C.uintptr_t, version *C.char) *C.Result {
 	ctx := context.Background()
 
-	store := getStoreFromPointer(nodePtr)
-	err := store.SetActiveCollectionVersion(ctx, C.GoString(version))
+	store, err := getStoreFromPointer(nodePtr)
+	if err != nil {
+		return returnC(returnGoC(1, err.Error(), ""))
+	}
+
+	err = store.SetActiveCollectionVersion(ctx, C.GoString(version))
 	if err != nil {
 		return returnC(returnGoC(1, err.Error(), ""))
 	}

--- a/cbindings/cutils.go
+++ b/cbindings/cutils.go
@@ -166,8 +166,6 @@ func getIdentityFromPointer(identityPtr C.uintptr_t) (ident identity.Identity, e
 	switch v := v.(type) {
 	case identity.Identity:
 		return v, nil
-	case *identity.Identity:
-		return *v, nil
 	default:
 		return nil, fmt.Errorf(errInvalidTxnPointer, uintptr(identityPtr))
 	}

--- a/cbindings/cutils.go
+++ b/cbindings/cutils.go
@@ -138,7 +138,7 @@ func getStoreFromPointer(nodePtr C.uintptr_t) (store client.Store, err error) {
 	case client.Txn:
 		return v, nil
 	default:
-		return nil, fmt.Errorf(errInvalidStorePointer, uintptr(nodePtr))
+		return nil, fmt.Errorf(errInvalidCGOHandle, uintptr(nodePtr))
 	}
 }
 
@@ -150,7 +150,7 @@ func getNodeFromPointer(nodePtr C.uintptr_t) (n *node.Node, err error) {
 	}
 	n, ok := v.(*node.Node)
 	if !ok || n == nil {
-		return nil, fmt.Errorf(errInvalidStorePointer, uintptr(nodePtr))
+		return nil, fmt.Errorf(errInvalidCGOHandle, uintptr(nodePtr))
 	}
 	return n, nil
 }
@@ -167,7 +167,7 @@ func getIdentityFromPointer(identityPtr C.uintptr_t) (ident identity.Identity, e
 	case identity.Identity:
 		return v, nil
 	default:
-		return nil, fmt.Errorf(errInvalidTxnPointer, uintptr(identityPtr))
+		return nil, fmt.Errorf(errInvalidCGOHandle, uintptr(identityPtr))
 	}
 }
 

--- a/cbindings/cutils.go
+++ b/cbindings/cutils.go
@@ -113,18 +113,25 @@ func convertNodeInitOptionsToGoNodeInitOptions(cOptions C.NodeInitOptions) (GoNo
 	}, nil
 }
 
+// recoverHandleValue is a helper function that recovers a handle's value from a pointer,
+// and recovers from a panic if the handle is invalid
+func recoverHandleValue(ptr C.uintptr_t) (v any, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			v, err = nil, fmt.Errorf(errInvalidCGOHandle, uintptr(ptr))
+		}
+	}()
+	h := cgo.Handle(ptr)
+	return h.Value(), nil
+}
+
 // getStoreFromPointer should be used by functions that can work on a node pointer or
 // on a transaction pointer.
 func getStoreFromPointer(nodePtr C.uintptr_t) (store client.Store, err error) {
-	// Protect against invalid handles
-	defer func() {
-		if r := recover(); r != nil {
-			store, err = nil, fmt.Errorf(errInvalidStorePointer, uintptr(nodePtr))
-		}
-	}()
-
-	h := cgo.Handle(nodePtr)
-	v := h.Value()
+	v, err := recoverHandleValue(nodePtr)
+	if err != nil {
+		return nil, err
+	}
 	switch v := v.(type) {
 	case *node.Node:
 		return v.DB, nil
@@ -135,17 +142,12 @@ func getStoreFromPointer(nodePtr C.uintptr_t) (store client.Store, err error) {
 	}
 }
 
-// getNodeFromPointer should be used by functions that can only work on anode pointer.
+// getNodeFromPointer should be used by functions that can only work on a node pointer.
 func getNodeFromPointer(nodePtr C.uintptr_t) (n *node.Node, err error) {
-	// Protect against invalid handles
-	defer func() {
-		if r := recover(); r != nil {
-			n, err = nil, fmt.Errorf(errInvalidStorePointer, uintptr(nodePtr))
-		}
-	}()
-
-	h := cgo.Handle(nodePtr)
-	v := h.Value()
+	v, err := recoverHandleValue(nodePtr)
+	if err != nil {
+		return nil, err
+	}
 	n, ok := v.(*node.Node)
 	if !ok || n == nil {
 		return nil, fmt.Errorf(errInvalidStorePointer, uintptr(nodePtr))
@@ -157,16 +159,10 @@ func getIdentityFromPointer(identityPtr C.uintptr_t) (ident identity.Identity, e
 	if identityPtr == 0 {
 		return nil, nil
 	}
-
-	// Protect against invalid handles
-	defer func() {
-		if r := recover(); r != nil {
-			ident, err = nil, fmt.Errorf(errInvalidTxnPointer, uintptr(identityPtr))
-		}
-	}()
-
-	h := cgo.Handle(identityPtr)
-	v := h.Value()
+	v, err := recoverHandleValue(identityPtr)
+	if err != nil {
+		return nil, err
+	}
 	switch v := v.(type) {
 	case identity.Identity:
 		return v, nil

--- a/cbindings/cutils.go
+++ b/cbindings/cutils.go
@@ -116,7 +116,6 @@ func convertNodeInitOptionsToGoNodeInitOptions(cOptions C.NodeInitOptions) (GoNo
 // getStoreFromPointer should be used by functions that can work on a node pointer or
 // on a transaction pointer.
 func getStoreFromPointer(nodePtr C.uintptr_t) (store client.Store, err error) {
-
 	// Protect against invalid handles
 	defer func() {
 		if r := recover(); r != nil {

--- a/cbindings/cutils.go
+++ b/cbindings/cutils.go
@@ -22,6 +22,7 @@ package cbindings
 import "C"
 import (
 	"context"
+	"fmt"
 	"runtime/cgo"
 	"unsafe"
 
@@ -93,53 +94,96 @@ func returnNewIdentityResultC(status int, error string, n identity.Identity) C.N
 	return result
 }
 
-func convertNodeInitOptionsToGoNodeInitOptions(cOptions C.NodeInitOptions) GoNodeInitOptions {
+func convertNodeInitOptionsToGoNodeInitOptions(cOptions C.NodeInitOptions) (GoNodeInitOptions, error) {
+	ident, err := getIdentityFromPointer(cOptions.identityPtr)
+	if err != nil {
+		return GoNodeInitOptions{}, err
+	}
 	return GoNodeInitOptions{
 		DbPath:                   C.GoString(cOptions.dbPath),
 		ListeningAddresses:       C.GoString(cOptions.listeningAddresses),
 		ReplicatorRetryIntervals: C.GoString(cOptions.replicatorRetryIntervals),
 		Peers:                    C.GoString(cOptions.peers),
-		Identity:                 getIdentityFromPointer(cOptions.identityPtr),
+		Identity:                 ident,
 		InMemory:                 int(cOptions.inMemory),
 		DisableP2P:               int(cOptions.disableP2P),
 		DisableAPI:               int(cOptions.disableAPI),
 		MaxTransactionRetries:    int(cOptions.maxTransactionRetries),
 		EnableNodeACP:            int(cOptions.enableNodeACP),
-	}
+	}, nil
 }
 
-func getStoreFromPointer(nodePtr C.uintptr_t) client.Store {
+// getStoreFromPointer should be used by functions that can work on a node pointer or
+// on a transaction pointer.
+func getStoreFromPointer(nodePtr C.uintptr_t) (store client.Store, err error) {
+
+	// Protect against invalid handles
+	defer func() {
+		if r := recover(); r != nil {
+			store, err = nil, fmt.Errorf(errInvalidStorePointer, uintptr(nodePtr))
+		}
+	}()
+
 	h := cgo.Handle(nodePtr)
 	v := h.Value()
 	switch v := v.(type) {
 	case *node.Node:
-		return v.DB
+		return v.DB, nil
 	case client.Txn:
-		return v
+		return v, nil
 	default:
-		return nil
+		return nil, fmt.Errorf(errInvalidStorePointer, uintptr(nodePtr))
 	}
 }
 
-func getIdentityFromPointer(identityPtr C.uintptr_t) identity.Identity {
-	if identityPtr == 0 {
-		return nil
+// getNodeFromPointer should be used by functions that can only work on anode pointer.
+func getNodeFromPointer(nodePtr C.uintptr_t) (n *node.Node, err error) {
+	// Protect against invalid handles
+	defer func() {
+		if r := recover(); r != nil {
+			n, err = nil, fmt.Errorf(errInvalidStorePointer, uintptr(nodePtr))
+		}
+	}()
+
+	h := cgo.Handle(nodePtr)
+	v := h.Value()
+	n, ok := v.(*node.Node)
+	if !ok || n == nil {
+		return nil, fmt.Errorf(errInvalidStorePointer, uintptr(nodePtr))
 	}
+	return n, nil
+}
+
+func getIdentityFromPointer(identityPtr C.uintptr_t) (ident identity.Identity, err error) {
+	if identityPtr == 0 {
+		return nil, nil
+	}
+
+	// Protect against invalid handles
+	defer func() {
+		if r := recover(); r != nil {
+			ident, err = nil, fmt.Errorf(errInvalidTxnPointer, uintptr(identityPtr))
+		}
+	}()
+
 	h := cgo.Handle(identityPtr)
 	v := h.Value()
 	switch v := v.(type) {
 	case identity.Identity:
-		return v
+		return v, nil
 	case *identity.Identity:
-		return *v
+		return *v, nil
 	default:
-		return nil
+		return nil, fmt.Errorf(errInvalidTxnPointer, uintptr(identityPtr))
 	}
 }
 
 // contextWithIdentity is a helper function that attaches identity to a context
 func contextWithIdentity(ctx context.Context, identityPtr C.uintptr_t) (context.Context, error) {
-	ident := getIdentityFromPointer(identityPtr)
+	ident, err := getIdentityFromPointer(identityPtr)
+	if err != nil {
+		return ctx, err
+	}
 	if ident == nil {
 		return ctx, nil
 	}

--- a/cbindings/errors.go
+++ b/cbindings/errors.go
@@ -50,4 +50,5 @@ const (
 	errInvalidKeyType      string = "invalid key type: %v"
 	errInvalidStorePointer string = "invalid store pointer: %v"
 	errInvalidTxnPointer   string = "invalid transaction pointer: %v"
+	errInvalidCGOHandle    string = "invalid CGO handle: %v"
 )

--- a/cbindings/errors.go
+++ b/cbindings/errors.go
@@ -45,10 +45,8 @@ const (
 	errGEttingSubscription   string = "error: could not retrieve subscription"
 
 	// Generic
-	errInvalidLensConfig   string = "invalid lens configuration: %v"
-	errMarshallingJSON     string = "error marshalling JSON: %v"
-	errInvalidKeyType      string = "invalid key type: %v"
-	errInvalidStorePointer string = "invalid store pointer: %v"
-	errInvalidTxnPointer   string = "invalid transaction pointer: %v"
-	errInvalidCGOHandle    string = "invalid CGO handle: %v"
+	errInvalidLensConfig string = "invalid lens configuration: %v"
+	errMarshallingJSON   string = "error marshalling JSON: %v"
+	errInvalidKeyType    string = "invalid key type: %v"
+	errInvalidCGOHandle  string = "invalid handle: %v"
 )

--- a/cbindings/errors.go
+++ b/cbindings/errors.go
@@ -45,7 +45,9 @@ const (
 	errGEttingSubscription   string = "error: could not retrieve subscription"
 
 	// Generic
-	errInvalidLensConfig string = "invalid lens configuration: %v"
-	errMarshallingJSON   string = "error marshalling JSON: %v"
-	errInvalidKeyType    string = "invalid key type: %v"
+	errInvalidLensConfig   string = "invalid lens configuration: %v"
+	errMarshallingJSON     string = "error marshalling JSON: %v"
+	errInvalidKeyType      string = "invalid key type: %v"
+	errInvalidStorePointer string = "invalid store pointer: %v"
+	errInvalidTxnPointer   string = "invalid transaction pointer: %v"
 )

--- a/cbindings/identity.go
+++ b/cbindings/identity.go
@@ -41,7 +41,11 @@ func IdentityNew(keyType *C.char) C.NewIdentityResult {
 //export NodeIdentity
 func NodeIdentity(nodePtr C.uintptr_t) *C.Result {
 	ctx := context.Background()
-	store := getStoreFromPointer(nodePtr)
+	store, err := getStoreFromPointer(nodePtr)
+	if err != nil {
+		return returnC(returnGoC(1, err.Error(), ""))
+	}
+
 	identity, err := store.GetNodeIdentity(ctx)
 	if err != nil {
 		return returnC(returnGoC(1, err.Error(), ""))

--- a/cbindings/index.go
+++ b/cbindings/index.go
@@ -63,7 +63,11 @@ func IndexCreate(
 		Fields: fields,
 		Unique: isUnique != 0,
 	}
-	store := getStoreFromPointer(nodePtr)
+	store, err := getStoreFromPointer(nodePtr)
+	if err != nil {
+		return returnC(returnGoC(1, err.Error(), ""))
+	}
+
 	col, err := store.GetCollectionByName(ctx, C.GoString(collectionName))
 	if err != nil {
 		return returnC(returnGoC(1, err.Error(), ""))
@@ -79,7 +83,10 @@ func IndexCreate(
 //export IndexList
 func IndexList(nodePtr C.uintptr_t, collectionName *C.char) *C.Result {
 	ctx := context.Background()
-	store := getStoreFromPointer(nodePtr)
+	store, err := getStoreFromPointer(nodePtr)
+	if err != nil {
+		return returnC(returnGoC(1, err.Error(), ""))
+	}
 
 	colName := C.GoString(collectionName)
 	switch {
@@ -108,7 +115,11 @@ func IndexList(nodePtr C.uintptr_t, collectionName *C.char) *C.Result {
 func IndexDrop(nodePtr C.uintptr_t, collectionName *C.char, indexName *C.char) *C.Result {
 	ctx := context.Background()
 
-	store := getStoreFromPointer(nodePtr)
+	store, err := getStoreFromPointer(nodePtr)
+	if err != nil {
+		return returnC(returnGoC(1, err.Error(), ""))
+	}
+
 	col, err := store.GetCollectionByName(ctx, C.GoString(collectionName))
 	if err != nil {
 		return returnC(returnGoC(1, err.Error(), ""))

--- a/cbindings/lens.go
+++ b/cbindings/lens.go
@@ -43,8 +43,13 @@ func LensSet(nodePtr C.uintptr_t, src *C.char, dst *C.char, cfg *C.char) *C.Resu
 		DestinationSchemaVersionID: C.GoString(dst),
 		Lens:                       lensCfg,
 	}
-	store := getStoreFromPointer(nodePtr)
-	err := store.SetMigration(ctx, migrationCfg)
+
+	store, err := getStoreFromPointer(nodePtr)
+	if err != nil {
+		return returnC(returnGoC(1, err.Error(), ""))
+	}
+
+	err = store.SetMigration(ctx, migrationCfg)
 	if err != nil {
 		return returnC(returnGoC(1, err.Error(), ""))
 	}
@@ -61,7 +66,11 @@ func LensDown(nodePtr C.uintptr_t, collectionID *C.char, documents *C.char) *C.R
 		return returnC(returnGoC(1, err.Error(), ""))
 	}
 
-	store := getStoreFromPointer(nodePtr)
+	store, err := getStoreFromPointer(nodePtr)
+	if err != nil {
+		return returnC(returnGoC(1, err.Error(), ""))
+	}
+
 	out, err := store.LensRegistry().MigrateDown(ctx, enumerable.New(src), C.GoString(collectionID))
 	if err != nil {
 		return returnC(returnGoC(1, err.Error(), ""))
@@ -88,7 +97,11 @@ func LensUp(nodePtr C.uintptr_t, collectionID *C.char, documents *C.char) *C.Res
 		return returnC(returnGoC(1, err.Error(), ""))
 	}
 
-	store := getStoreFromPointer(nodePtr)
+	store, err := getStoreFromPointer(nodePtr)
+	if err != nil {
+		return returnC(returnGoC(1, err.Error(), ""))
+	}
+
 	out, err := store.LensRegistry().MigrateUp(ctx, enumerable.New(src), C.GoString(collectionID))
 	if err != nil {
 		return returnC(returnGoC(1, err.Error(), ""))
@@ -109,8 +122,12 @@ func LensUp(nodePtr C.uintptr_t, collectionID *C.char, documents *C.char) *C.Res
 func LensReload(nodePtr C.uintptr_t) *C.Result {
 	ctx := context.Background()
 
-	store := getStoreFromPointer(nodePtr)
-	err := store.LensRegistry().ReloadLenses(ctx)
+	store, err := getStoreFromPointer(nodePtr)
+	if err != nil {
+		return returnC(returnGoC(1, err.Error(), ""))
+	}
+
+	err = store.LensRegistry().ReloadLenses(ctx)
 	if err != nil {
 		return returnC(returnGoC(1, err.Error(), ""))
 	}
@@ -128,8 +145,12 @@ func LensSetRegistry(nodePtr C.uintptr_t, collectionID *C.char, cfg *C.char) *C.
 		return returnC(returnGoC(1, fmt.Sprintf(errInvalidLensConfig, err), ""))
 	}
 
-	store := getStoreFromPointer(nodePtr)
-	err := store.LensRegistry().SetMigration(ctx, C.GoString(collectionID), lensCfg)
+	store, err := getStoreFromPointer(nodePtr)
+	if err != nil {
+		return returnC(returnGoC(1, err.Error(), ""))
+	}
+
+	err = store.LensRegistry().SetMigration(ctx, C.GoString(collectionID), lensCfg)
 	if err != nil {
 		return returnC(returnGoC(1, err.Error(), ""))
 	}

--- a/cbindings/node.go
+++ b/cbindings/node.go
@@ -19,7 +19,6 @@ import "C"
 import (
 	"context"
 	"fmt"
-	"runtime/cgo"
 	"strconv"
 	"time"
 
@@ -30,8 +29,10 @@ import (
 
 //export NewNode
 func NewNode(cOptions C.NodeInitOptions) C.NewNodeResult {
-	gocOptions := convertNodeInitOptionsToGoNodeInitOptions(cOptions)
-	var err error
+	gocOptions, err := convertNodeInitOptionsToGoNodeInitOptions(cOptions)
+	if err != nil {
+		return returnNewNodeResultC(1, err.Error(), nil)
+	}
 
 	inMemoryFlag := gocOptions.InMemory != 0
 	listeningAddresses := splitCommaSeparatedString(gocOptions.ListeningAddresses)
@@ -115,12 +116,13 @@ func NewNode(cOptions C.NodeInitOptions) C.NewNodeResult {
 
 //export NodeClose
 func NodeClose(nodePtr C.uintptr_t) *C.Result {
-	h := cgo.Handle(nodePtr)
-	n := h.Value().(*node.Node) //nolint:forcetypeassert
-	err := n.Close(context.Background())
+	node, err := getNodeFromPointer(nodePtr)
+	if err != nil {
+		return returnC(returnGoC(1, err.Error(), ""))
+	}
+	err = node.Close(context.Background())
 	if err != nil {
 		return returnC(GoCResult{1, fmt.Sprintf(errStoppingNode, err), ""})
 	}
-
 	return returnC(GoCResult{0, "", ""})
 }

--- a/cbindings/p2p.go
+++ b/cbindings/p2p.go
@@ -19,18 +19,17 @@ import "C"
 import (
 	"context"
 	"encoding/json"
-	"runtime/cgo"
 	"time"
 
 	"github.com/sourcenetwork/defradb/client"
-
-	"github.com/sourcenetwork/defradb/node"
 )
 
 //export P2PInfo
 func P2PInfo(nodePtr C.uintptr_t) *C.Result {
-	h := cgo.Handle(nodePtr)
-	node := h.Value().(*node.Node) //nolint:forcetypeassert
+	node, err := getNodeFromPointer(nodePtr)
+	if err != nil {
+		return returnC(returnGoC(1, err.Error(), ""))
+	}
 	info := node.DB.PeerInfo()
 	return returnC(marshalJSONToGoCResult(info))
 }
@@ -38,8 +37,10 @@ func P2PInfo(nodePtr C.uintptr_t) *C.Result {
 //export P2PgetAllReplicators
 func P2PgetAllReplicators(nodePtr C.uintptr_t) *C.Result {
 	ctx := context.Background()
-	h := cgo.Handle(nodePtr)
-	node := h.Value().(*node.Node) //nolint:forcetypeassert
+	node, err := getNodeFromPointer(nodePtr)
+	if err != nil {
+		return returnC(returnGoC(1, err.Error(), ""))
+	}
 	reps, err := node.DB.GetAllReplicators(ctx)
 	if err != nil {
 		return returnC(returnGoC(1, err.Error(), ""))
@@ -57,9 +58,11 @@ func P2PsetReplicator(nodePtr C.uintptr_t, collections *C.char, peerInfo *C.char
 		return returnC(returnGoC(1, err.Error(), ""))
 	}
 
-	h := cgo.Handle(nodePtr)
-	node := h.Value().(*node.Node) //nolint:forcetypeassert
-	err := node.DB.SetReplicator(ctx, info, colArgs...)
+	node, err := getNodeFromPointer(nodePtr)
+	if err != nil {
+		return returnC(returnGoC(1, err.Error(), ""))
+	}
+	err = node.DB.SetReplicator(ctx, info, colArgs...)
 	if err != nil {
 		return returnC(returnGoC(1, err.Error(), ""))
 	}
@@ -76,9 +79,11 @@ func P2PdeleteReplicator(nodePtr C.uintptr_t, collections *C.char, peerInfo *C.c
 		return returnC(returnGoC(1, err.Error(), ""))
 	}
 
-	h := cgo.Handle(nodePtr)
-	node := h.Value().(*node.Node) //nolint:forcetypeassert
-	err := node.DB.DeleteReplicator(ctx, info, colArgs...)
+	node, err := getNodeFromPointer(nodePtr)
+	if err != nil {
+		return returnC(returnGoC(1, err.Error(), ""))
+	}
+	err = node.DB.DeleteReplicator(ctx, info, colArgs...)
 	if err != nil {
 		return returnC(returnGoC(1, err.Error(), ""))
 	}
@@ -90,9 +95,11 @@ func P2PcollectionAdd(nodePtr C.uintptr_t, collections *C.char) *C.Result {
 	ctx := context.Background()
 	colArgs := splitCommaSeparatedString(C.GoString(collections))
 
-	h := cgo.Handle(nodePtr)
-	node := h.Value().(*node.Node) //nolint:forcetypeassert
-	err := node.DB.AddP2PCollections(ctx, colArgs...)
+	node, err := getNodeFromPointer(nodePtr)
+	if err != nil {
+		return returnC(returnGoC(1, err.Error(), ""))
+	}
+	err = node.DB.AddP2PCollections(ctx, colArgs...)
 	if err != nil {
 		return returnC(returnGoC(1, err.Error(), ""))
 	}
@@ -104,9 +111,11 @@ func P2PcollectionRemove(nodePtr C.uintptr_t, collections *C.char) *C.Result {
 	ctx := context.Background()
 	colArgs := splitCommaSeparatedString(C.GoString(collections))
 
-	h := cgo.Handle(nodePtr)
-	node := h.Value().(*node.Node) //nolint:forcetypeassert
-	err := node.DB.RemoveP2PCollections(ctx, colArgs...)
+	node, err := getNodeFromPointer(nodePtr)
+	if err != nil {
+		return returnC(returnGoC(1, err.Error(), ""))
+	}
+	err = node.DB.RemoveP2PCollections(ctx, colArgs...)
 	if err != nil {
 		return returnC(returnGoC(1, err.Error(), ""))
 	}
@@ -117,8 +126,10 @@ func P2PcollectionRemove(nodePtr C.uintptr_t, collections *C.char) *C.Result {
 func P2PcollectionGetAll(nodePtr C.uintptr_t) *C.Result {
 	ctx := context.Background()
 
-	h := cgo.Handle(nodePtr)
-	node := h.Value().(*node.Node) //nolint:forcetypeassert
+	node, err := getNodeFromPointer(nodePtr)
+	if err != nil {
+		return returnC(returnGoC(1, err.Error(), ""))
+	}
 	cols, err := node.DB.GetAllP2PCollections(ctx)
 
 	if err != nil {
@@ -132,9 +143,11 @@ func P2PdocumentAdd(nodePtr C.uintptr_t, collections *C.char) *C.Result {
 	ctx := context.Background()
 	colArgs := splitCommaSeparatedString(C.GoString(collections))
 
-	h := cgo.Handle(nodePtr)
-	node := h.Value().(*node.Node) //nolint:forcetypeassert
-	err := node.DB.AddP2PDocuments(ctx, colArgs...)
+	node, err := getNodeFromPointer(nodePtr)
+	if err != nil {
+		return returnC(returnGoC(1, err.Error(), ""))
+	}
+	err = node.DB.AddP2PDocuments(ctx, colArgs...)
 	if err != nil {
 		return returnC(returnGoC(1, err.Error(), ""))
 	}
@@ -146,9 +159,11 @@ func P2PdocumentRemove(nodePtr C.uintptr_t, collections *C.char) *C.Result {
 	ctx := context.Background()
 	colArgs := splitCommaSeparatedString(C.GoString(collections))
 
-	h := cgo.Handle(nodePtr)
-	node := h.Value().(*node.Node) //nolint:forcetypeassert
-	err := node.DB.RemoveP2PDocuments(ctx, colArgs...)
+	node, err := getNodeFromPointer(nodePtr)
+	if err != nil {
+		return returnC(returnGoC(1, err.Error(), ""))
+	}
+	err = node.DB.RemoveP2PDocuments(ctx, colArgs...)
 	if err != nil {
 		return returnC(returnGoC(1, err.Error(), ""))
 	}
@@ -158,8 +173,10 @@ func P2PdocumentRemove(nodePtr C.uintptr_t, collections *C.char) *C.Result {
 //export P2PdocumentGetAll
 func P2PdocumentGetAll(nodePtr C.uintptr_t) *C.Result {
 	ctx := context.Background()
-	h := cgo.Handle(nodePtr)
-	node := h.Value().(*node.Node) //nolint:forcetypeassert
+	node, err := getNodeFromPointer(nodePtr)
+	if err != nil {
+		return returnC(returnGoC(1, err.Error(), ""))
+	}
 	cols, err := node.DB.GetAllP2PDocuments(ctx)
 	if err != nil {
 		return returnC(returnGoC(1, err.Error(), ""))
@@ -188,9 +205,11 @@ func P2PdocumentSync(nodePtr C.uintptr_t, collection *C.char, docIDs *C.char, ti
 		defer cancel()
 	}
 
-	h := cgo.Handle(nodePtr)
-	node := h.Value().(*node.Node) //nolint:forcetypeassert
-	err := node.DB.SyncDocuments(ctx, C.GoString(collection), docArgs)
+	node, err := getNodeFromPointer(nodePtr)
+	if err != nil {
+		return returnC(returnGoC(1, err.Error(), ""))
+	}
+	err = node.DB.SyncDocuments(ctx, C.GoString(collection), docArgs)
 	if err != nil {
 		return returnC(returnGoC(1, err.Error(), ""))
 	}
@@ -200,12 +219,14 @@ func P2PdocumentSync(nodePtr C.uintptr_t, collection *C.char, docIDs *C.char, ti
 //export P2Pconnect
 func P2Pconnect(nodePtr C.uintptr_t, peerID *C.char, peerAddresses *C.char) *C.Result {
 	ctx := context.Background()
-	h := cgo.Handle(nodePtr)
-	node := h.Value().(*node.Node) //nolint:forcetypeassert
+	node, err := getNodeFromPointer(nodePtr)
+	if err != nil {
+		return returnC(returnGoC(1, err.Error(), ""))
+	}
 	var info client.PeerInfo
 	info.ID = C.GoString(peerID)
 	info.Addresses = splitCommaSeparatedString(C.GoString(peerAddresses))
-	err := node.DB.Connect(ctx, info)
+	err = node.DB.Connect(ctx, info)
 	if err != nil {
 		return returnC(returnGoC(1, err.Error(), ""))
 	}

--- a/cbindings/query.go
+++ b/cbindings/query.go
@@ -115,7 +115,11 @@ func ExecuteQuery(
 	}
 
 	ctx, cancelFunc := context.WithCancel(ctx)
-	store := getStoreFromPointer(nodePtr)
+	store, err := getStoreFromPointer(nodePtr)
+	if err != nil {
+		return returnC(returnGoC(1, err.Error(), ""))
+	}
+
 	res := store.ExecRequest(ctx, C.GoString(query), opts...)
 	sub := &Subscription{
 		ctxCancel:  cancelFunc,

--- a/cbindings/query.go
+++ b/cbindings/query.go
@@ -114,11 +114,12 @@ func ExecuteQuery(
 		return returnC(returnGoC(1, err.Error(), ""))
 	}
 
-	ctx, cancelFunc := context.WithCancel(ctx)
 	store, err := getStoreFromPointer(nodePtr)
 	if err != nil {
 		return returnC(returnGoC(1, err.Error(), ""))
 	}
+
+	ctx, cancelFunc := context.WithCancel(ctx)
 
 	res := store.ExecRequest(ctx, C.GoString(query), opts...)
 	sub := &Subscription{

--- a/cbindings/schema.go
+++ b/cbindings/schema.go
@@ -30,7 +30,10 @@ func AddSchema(nodePtr C.uintptr_t, schema *C.char, identityPtr C.uintptr_t) *C.
 		return returnC(returnGoC(1, err.Error(), ""))
 	}
 
-	store := getStoreFromPointer(nodePtr)
+	store, err := getStoreFromPointer(nodePtr)
+	if err != nil {
+		return returnC(returnGoC(1, err.Error(), ""))
+	}
 	collectionVersions, err := store.AddSchema(ctx, C.GoString(schema))
 	if err != nil {
 		return returnC(returnGoC(1, fmt.Sprintf(errAddingSchema, err), ""))

--- a/cbindings/view.go
+++ b/cbindings/view.go
@@ -44,7 +44,11 @@ func ViewAdd(nodePtr C.uintptr_t, query *C.char, sdl *C.char, transformStr *C.ch
 		transform = immutable.Some(lensCfg)
 	}
 
-	store := getStoreFromPointer(nodePtr)
+	store, err := getStoreFromPointer(nodePtr)
+	if err != nil {
+		return returnC(returnGoC(1, err.Error(), ""))
+	}
+
 	defs, err := store.AddView(ctx, C.GoString(query), C.GoString(sdl), transform)
 	if err != nil {
 		return returnC(returnGoC(1, err.Error(), ""))
@@ -80,8 +84,12 @@ func ViewRefresh(
 		options.IncludeInactive = immutable.Some(getInactive != 0)
 	}
 
-	store := getStoreFromPointer(nodePtr)
-	err := store.RefreshViews(ctx, options)
+	store, err := getStoreFromPointer(nodePtr)
+	if err != nil {
+		return returnC(returnGoC(1, err.Error(), ""))
+	}
+
+	err = store.RefreshViews(ctx, options)
 	if err != nil {
 		return returnC(returnGoC(1, err.Error(), ""))
 	}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #3965 

## Description

There were many portions of the c binding code base where a pointer (CGO handle) to a node, transaction, or identity CGO handle was passed in, and assumed valid without any error checking. This would result in a panic and crash if the node were actually invalid. While there is always the chance of the user passing in an invalid handle, it needs to be handled gracefully, which is what now happens. The functions will now return the error as part of the `Result` object, and return the error message to the user to help indicate what happened.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Specify the platform(s) on which this was tested:
- WSL
