### PR TITLE
refactor: Standardize errors in C bindings

### DIFF
--- a/cbindings/collection.go
+++ b/cbindings/collection.go
@@ -19,8 +19,6 @@ import "C"
 import (
 	"context"
 	"encoding/json"
-	"errors"
-	"fmt"
 	"strings"
 
 	"github.com/sourcenetwork/immutable"
@@ -67,15 +65,15 @@ func getCollection(
 ) (client.Collection, error) {
 	cols, err := store.GetCollections(ctx, options)
 	if err != nil {
-		return nil, fmt.Errorf(errGettingCollection, err)
+		return nil, err
 	}
 
 	// Only one collection should match the criteria
 	if len(cols) == 0 {
-		return nil, errors.New(errNoMatchingCollection)
+		return nil, NewErrNoMatchingCollection()
 	}
 	if len(cols) > 1 {
-		return nil, errors.New(errAmbiguousCollection)
+		return nil, NewErrAmbiguousCollection()
 	}
 	return cols[0], nil
 }
@@ -320,7 +318,7 @@ func CollectionPatch(nodePtr C.uintptr_t, patch *C.char, lensConfig *C.char, opt
 		decoder := json.NewDecoder(strings.NewReader(lensString))
 		decoder.DisallowUnknownFields()
 		if err := decoder.Decode(&lensCfg); err != nil {
-			return returnC(returnGoC(1, fmt.Sprintf(errInvalidLensConfig, err), ""))
+			return returnC(returnGoC(1, err.Error(), ""))
 		}
 
 		// Length being greater than 0 also means it is not nil, so no need to check

--- a/cbindings/cutils.go
+++ b/cbindings/cutils.go
@@ -22,7 +22,6 @@ package cbindings
 import "C"
 import (
 	"context"
-	"fmt"
 	"runtime/cgo"
 	"unsafe"
 
@@ -118,7 +117,7 @@ func convertNodeInitOptionsToGoNodeInitOptions(cOptions C.NodeInitOptions) (GoNo
 func recoverHandleValue(ptr C.uintptr_t) (v any, err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			v, err = nil, fmt.Errorf(errInvalidCGOHandle, uintptr(ptr))
+			v, err = nil, NewErrInvalidCGOHandle(uintptr(ptr))
 		}
 	}()
 	h := cgo.Handle(ptr)
@@ -138,7 +137,7 @@ func getStoreFromPointer(nodePtr C.uintptr_t) (store client.Store, err error) {
 	case client.Txn:
 		return v, nil
 	default:
-		return nil, fmt.Errorf(errInvalidCGOHandle, uintptr(nodePtr))
+		return nil, NewErrInvalidCGOHandle(uintptr(nodePtr))
 	}
 }
 
@@ -150,7 +149,7 @@ func getNodeFromPointer(nodePtr C.uintptr_t) (n *node.Node, err error) {
 	}
 	n, ok := v.(*node.Node)
 	if !ok || n == nil {
-		return nil, fmt.Errorf(errInvalidCGOHandle, uintptr(nodePtr))
+		return nil, NewErrInvalidCGOHandle(uintptr(nodePtr))
 	}
 	return n, nil
 }
@@ -167,7 +166,7 @@ func getIdentityFromPointer(identityPtr C.uintptr_t) (ident identity.Identity, e
 	case identity.Identity:
 		return v, nil
 	default:
-		return nil, fmt.Errorf(errInvalidCGOHandle, uintptr(identityPtr))
+		return nil, NewErrInvalidCGOHandle(uintptr(identityPtr))
 	}
 }
 

--- a/cbindings/errors.go
+++ b/cbindings/errors.go
@@ -26,20 +26,12 @@ const (
 	errInvalidCGOHandle             = "invalid handle"
 )
 
-func NewErrNegativeReplicatorTime() error {
-	return errors.New(errNegativeReplicatorTime)
-}
-
 func NewErrAmbiguousCollection() error {
 	return errors.New(errAmbiguousCollection)
 }
 
 func NewErrNoMatchingCollection() error {
 	return errors.New(errNoMatchingCollection)
-}
-
-func NewErrNoDocIDOrFilter() error {
-	return errors.New(errNoDocIDOrFilter)
 }
 
 func NewErrInvalidIndexFieldDescription(field string) error {

--- a/cbindings/errors.go
+++ b/cbindings/errors.go
@@ -42,6 +42,6 @@ func NewErrInvalidSubscriptionID(id string) error {
 	return errors.New(errInvalidSubscriptionID, errors.NewKV("SubscriptionID", id))
 }
 
-func NewErrInvalidCGOHandle(inner error) error {
-	return errors.Wrap(errInvalidCGOHandle, inner)
+func NewErrInvalidCGOHandle(id uintptr) error {
+	return errors.New(errInvalidCGOHandle, errors.NewKV("Handle", id))
 }

--- a/cbindings/errors.go
+++ b/cbindings/errors.go
@@ -10,43 +10,46 @@
 
 package cbindings
 
-const (
-	// Node
-	errClosingNode            string = "error closing node: %v"
-	errCreatingStoreDirectory string = "error creating the store directory: %v"
-	errCreatingNode           string = "error creating node: %v"
-	errUninitializedNode      string = "error: node is not initialized. Call initNode() first"
-	errStoppedNode            string = "error stopping node: node is not initialized, or was already stopped"
-	errStoppingNode           string = "error stopping node: %v"
-	errParsingReplicatorTimes string = "error parsing replicator retry time intervals: %v"
-	errNegativeReplicatorTime string = "error: negative time intervals are not allowed for replicator retries"
-	errUnreadyStart           string = "Node is still starting (timeout waiting for readiness)"
-	errNACWithoutIdentity     string = "can not start nac without identity"
-
-	// Schema
-	errAddingSchema    string = "error adding schema: %v"
-	errGettingSchema   string = "error getting schema: %v"
-	errPatchingSchema  string = "error patching schema: %v"
-	errSetActiveSchema string = "error setting active version of schema: %v"
-	errEmptyPatch      string = "patch cannot be empty"
-
-	// Collection
-	errGettingCollection    string = "error getting collection: %v"
-	errAmbiguousCollection  string = "error: more than one collection matches the given criteria, could not set context"
-	errNoMatchingCollection string = "error: no collection matches the given criteria, could not set context"
-	errNoDocIDOrFilter      string = "error: performing the operation requires a DocID or filter"
-
-	// Index
-	errInvalidAscensionOrder        string = "invalid ascension order: expected ASC or DESC"
-	errInvalidIndexFieldDescription string = "invalid or malformed field descriptiona"
-
-	// Subscription
-	errInvalidSubscriptionID string = "error: invalid subscription ID"
-	errGEttingSubscription   string = "error: could not retrieve subscription"
-
-	// Generic
-	errInvalidLensConfig string = "invalid lens configuration: %v"
-	errMarshallingJSON   string = "error marshalling JSON: %v"
-	errInvalidKeyType    string = "invalid key type: %v"
-	errInvalidCGOHandle  string = "invalid handle: %v"
+import (
+	"github.com/sourcenetwork/defradb/errors"
 )
+
+const (
+	errNegativeReplicatorTime       = "negative time intervals are not allowed for replicator retries"
+	errAmbiguousCollection          = "more than one collection matches the given criteria"
+	errNoMatchingCollection         = "no collection matches the given criteria"
+	errNoDocIDOrFilter              = "operation requires a DocID or filter"
+	errInvalidAscensionOrder        = "invalid ascension order: expected ASC or DESC"
+	errInvalidIndexFieldDescription = "invalid or malformed field description"
+	errInvalidSubscriptionID        = "invalid subscription ID"
+	errGettingSubscription          = "could not retrieve subscription"
+	errInvalidCGOHandle             = "invalid handle"
+)
+
+func NewErrNegativeReplicatorTime() error {
+	return errors.New(errNegativeReplicatorTime)
+}
+
+func NewErrAmbiguousCollection() error {
+	return errors.New(errAmbiguousCollection)
+}
+
+func NewErrNoMatchingCollection() error {
+	return errors.New(errNoMatchingCollection)
+}
+
+func NewErrNoDocIDOrFilter() error {
+	return errors.New(errNoDocIDOrFilter)
+}
+
+func NewErrInvalidIndexFieldDescription(field string) error {
+	return errors.New(errInvalidIndexFieldDescription, errors.NewKV("Field", field))
+}
+
+func NewErrInvalidSubscriptionID(id string) error {
+	return errors.New(errInvalidSubscriptionID, errors.NewKV("SubscriptionID", id))
+}
+
+func NewErrInvalidCGOHandle(inner error) error {
+	return errors.Wrap(errInvalidCGOHandle, inner)
+}

--- a/cbindings/index.go
+++ b/cbindings/index.go
@@ -50,7 +50,7 @@ func IndexCreate(
 				return returnC(returnGoC(1, errInvalidAscensionOrder, ""))
 			}
 		} else if len(parts) > 2 {
-			return returnC(returnGoC(1, errInvalidIndexFieldDescription, ""))
+			return returnC(returnGoC(1, NewErrInvalidIndexFieldDescription(field).Error(), ""))
 		}
 		fields = append(fields, client.IndexedFieldDescription{
 			Name:       fieldName,

--- a/cbindings/lens.go
+++ b/cbindings/lens.go
@@ -19,7 +19,6 @@ import "C"
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"strings"
 
 	"github.com/sourcenetwork/immutable/enumerable"
@@ -36,7 +35,7 @@ func LensSet(nodePtr C.uintptr_t, src *C.char, dst *C.char, cfg *C.char) *C.Resu
 	decoder.DisallowUnknownFields()
 	var lensCfg model.Lens
 	if err := decoder.Decode(&lensCfg); err != nil {
-		return returnC(returnGoC(1, fmt.Sprintf(errInvalidLensConfig, err), ""))
+		return returnC(returnGoC(1, err.Error(), ""))
 	}
 	migrationCfg := client.LensConfig{
 		SourceSchemaVersionID:      C.GoString(src),
@@ -142,7 +141,7 @@ func LensSetRegistry(nodePtr C.uintptr_t, collectionID *C.char, cfg *C.char) *C.
 	decoder.DisallowUnknownFields()
 	var lensCfg model.Lens
 	if err := decoder.Decode(&lensCfg); err != nil {
-		return returnC(returnGoC(1, fmt.Sprintf(errInvalidLensConfig, err), ""))
+		return returnC(returnGoC(1, err.Error(), ""))
 	}
 
 	store, err := getStoreFromPointer(nodePtr)

--- a/cbindings/node.go
+++ b/cbindings/node.go
@@ -18,7 +18,6 @@ import "C"
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 	"time"
 
@@ -46,7 +45,7 @@ func NewNode(cOptions C.NodeInitOptions) C.NewNodeResult {
 	// 	if _, err = os.Stat(gocOptions.DbPath); os.IsNotExist(err) {
 	// 		err := os.MkdirAll(gocOptions.DbPath, 0755)
 	// 		if err != nil {
-	// 			return returnGoC(1, fmt.Sprintf(errCreatingStoreDirectory, err), "")
+	// 			return returnGoC(1, err.Error(), "")
 	// 		}
 	// 	}
 	// }
@@ -122,7 +121,7 @@ func NodeClose(nodePtr C.uintptr_t) *C.Result {
 	}
 	err = node.Close(context.Background())
 	if err != nil {
-		return returnC(GoCResult{1, fmt.Sprintf(errStoppingNode, err), ""})
+		return returnC(GoCResult{1, err.Error(), ""})
 	}
 	return returnC(GoCResult{0, "", ""})
 }

--- a/cbindings/query.go
+++ b/cbindings/query.go
@@ -75,13 +75,13 @@ func PollSubscription(id *C.char) *C.Result {
 	subID := C.GoString(id)
 	sub, ok := getSubscription(subID)
 	if !ok {
-		return returnC(returnGoC(1, errInvalidSubscriptionID, ""))
+		return returnC(returnGoC(1, NewErrInvalidSubscriptionID(subID).Error(), ""))
 	}
 	select {
 	case msg, ok := <-sub.resultChan:
 		if !ok {
 			removeSubscription(subID)
-			return returnC(returnGoC(1, errGEttingSubscription, ""))
+			return returnC(returnGoC(1, errGettingSubscription, ""))
 		}
 		return returnC(marshalJSONToGoCResult(msg))
 	default:

--- a/cbindings/schema.go
+++ b/cbindings/schema.go
@@ -18,7 +18,6 @@ import "C"
 
 import (
 	"context"
-	"fmt"
 )
 
 //export AddSchema
@@ -36,7 +35,7 @@ func AddSchema(nodePtr C.uintptr_t, schema *C.char, identityPtr C.uintptr_t) *C.
 	}
 	collectionVersions, err := store.AddSchema(ctx, C.GoString(schema))
 	if err != nil {
-		return returnC(returnGoC(1, fmt.Sprintf(errAddingSchema, err), ""))
+		return returnC(returnGoC(1, err.Error(), ""))
 	}
 	return returnC(marshalJSONToGoCResult(collectionVersions))
 }

--- a/cbindings/utils.go
+++ b/cbindings/utils.go
@@ -59,7 +59,7 @@ func returnGoC(status int, errortext string, valuetext string) GoCResult {
 func marshalJSONToGoCResult(value any) GoCResult {
 	dataJSON, err := json.Marshal(value)
 	if err != nil {
-		return returnGoC(1, fmt.Sprintf(errMarshallingJSON, err), "")
+		return returnGoC(1, err.Error(), "")
 	}
 	return returnGoC(0, "", string(dataJSON))
 }

--- a/cbindings/view.go
+++ b/cbindings/view.go
@@ -19,7 +19,6 @@ import "C"
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"strings"
 
 	"github.com/sourcenetwork/immutable"
@@ -39,7 +38,7 @@ func ViewAdd(nodePtr C.uintptr_t, query *C.char, sdl *C.char, transformStr *C.ch
 		decoder.DisallowUnknownFields()
 		var lensCfg model.Lens
 		if err := decoder.Decode(&lensCfg); err != nil {
-			return returnC(returnGoC(1, fmt.Sprintf(errInvalidLensConfig, err), ""))
+			return returnC(returnGoC(1, err.Error(), ""))
 		}
 		transform = immutable.Some(lensCfg)
 	}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #3969 

## Description

The way that errors were utilized in the C bindings was somewhat different than in most other parts of our codebase. It largely just utilized strings with format verbs; it also used them in a lot of locations that perhaps it should not have used them. This PR seeks to do a few things. **One)** C binding functions should now prefer returning the error received from the Defra function, wrapped as a `Result` structure, where possible, instead of wrapping it as a new error type first. **Two)** When using a new error type unique to the C binding package, the code now avoids using strings with format verbs, instead opting to utilize functions which return new errors. When applicable, these functions will use `errors.NewKV` and `errors.Wrap` to attach additional information to the error. **Three**) Errors that had been left over, from previous commits, but which are no longer directly used anywhere, have simply been removed.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Specify the platform(s) on which this was tested:
- WSL
