### PR TITLE
fix: Prevent blocking on server close

### DIFF
--- a/http/handler_store.go
+++ b/http/handler_store.go
@@ -294,9 +294,28 @@ func (s *storeHandler) ExecRequest(rw http.ResponseWriter, req *http.Request) {
 	rw.WriteHeader(http.StatusOK)
 	flusher.Flush()
 
+	serverCtx, hasServerCtx := tryGetContexCtx(req)
+	var serverDone <-chan struct{}
+	if hasServerCtx {
+		serverDone = serverCtx.Done()
+	}
 	for {
 		select {
 		case <-req.Context().Done():
+			return
+		case <-serverDone:
+			// We need to check for closure of the server context
+			// otherwise the server won't gracefully shutdown until all
+			// connections are closed.
+			_, err := fmt.Fprintf(rw, "event: complete\n")
+			if err != nil {
+				return
+			}
+			_, err = fmt.Fprintf(rw, "data: {}\n\n")
+			if err != nil {
+				return
+			}
+			flusher.Flush()
 			return
 		case item, open := <-result.Subscription:
 			if !open {

--- a/http/server.go
+++ b/http/server.go
@@ -114,10 +114,11 @@ func WithTLSKeyPath(path string) ServerOpt {
 
 // Server struct holds the Handler for the HTTP API.
 type Server struct {
-	options  *ServerOptions
-	server   *http.Server
-	listener net.Listener
-	isTLS    bool
+	options   *ServerOptions
+	server    *http.Server
+	listener  net.Listener
+	isTLS     bool
+	ctxCancel context.CancelFunc
 }
 
 // NewServer instantiates a new server with the given http.Handler.
@@ -126,10 +127,11 @@ func NewServer(handler http.Handler, opts ...ServerOpt) (*Server, error) {
 	for _, opt := range opts {
 		opt(options)
 	}
-
+	ctx, cancel := context.WithCancel(context.Background())
 	// setup a mux with the default middleware stack
 	mux := chi.NewMux()
 	mux.Use(
+		InjectServerContext(ctx),
 		middleware.RequestLogger(&logFormatter{}),
 		middleware.Recoverer,
 		CorsMiddleware(options.AllowedOrigins),
@@ -144,13 +146,15 @@ func NewServer(handler http.Handler, opts ...ServerOpt) (*Server, error) {
 	}
 
 	return &Server{
-		options: options,
-		server:  server,
+		options:   options,
+		server:    server,
+		ctxCancel: cancel,
 	}, nil
 }
 
 // Shutdown gracefully shuts down the server without interrupting any active connections.
 func (s *Server) Shutdown(ctx context.Context) error {
+	s.ctxCancel()
 	return s.server.Shutdown(ctx)
 }
 
@@ -200,4 +204,15 @@ func (s *Server) Address() string {
 		return "https://" + s.listener.Addr().String()
 	}
 	return "http://" + s.listener.Addr().String()
+}
+
+// InjectServerContext sets the server context on each handler calls.
+func InjectServerContext(serverCtx context.Context) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			ctx := req.Context()
+			ctx = context.WithValue(ctx, ctxContextKey, serverCtx)
+			next.ServeHTTP(rw, req.WithContext(ctx))
+		})
+	}
 }

--- a/http/utils.go
+++ b/http/utils.go
@@ -11,6 +11,7 @@
 package http
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -37,6 +38,8 @@ var (
 	// If a transaction exists, all operations will be executed
 	// in the current transaction context.
 	colContextKey = contextKey("col")
+	// ctxContextKey is the context key for the server context.
+	ctxContextKey = contextKey("ctx")
 )
 
 // mustGetContextClientCollection returns the client collection from the http request context or panics.
@@ -65,6 +68,14 @@ func mustGetContextClientDB(req *http.Request) DB {
 // This should only be called from functions within the http package.
 func mustGetDataStoreTxn(tx any) client.Txn {
 	return tx.(client.Txn) //nolint:forcetypeassert
+}
+
+// tryGetContexCtx returns the server context if it exists.
+//
+// This should only be called from functions within the http package.
+func tryGetContexCtx(req *http.Request) (context.Context, bool) {
+	ctx, ok := req.Context().Value(ctxContextKey).(context.Context)
+	return ctx, ok
 }
 
 func requestJSON(req *http.Request, out any) error {

--- a/tests/clients/cli/wrapper.go
+++ b/tests/clients/cli/wrapper.go
@@ -38,10 +38,11 @@ var _ client.TxnStore = (*Wrapper)(nil)
 var _ client.P2P = (*Wrapper)(nil)
 
 type Wrapper struct {
-	node       *node.Node
-	cmd        *cliWrapper
-	handler    *http.Handler
-	httpServer *httptest.Server
+	node         *node.Node
+	cmd          *cliWrapper
+	handler      *http.Handler
+	httpServer   *httptest.Server
+	serverCancel context.CancelFunc
 }
 
 // NewWrapper takes a Node, and a SourceHub address used to pay for SourceHub transactions.
@@ -53,14 +54,17 @@ func NewWrapper(node *node.Node, sourceHubAddress string) (*Wrapper, error) {
 		return nil, err
 	}
 
-	httpServer := httptest.NewServer(handler)
+	ctx, cancel := context.WithCancel(context.Background())
+	handlerWithCtx := http.InjectServerContext(ctx)(handler)
+	httpServer := httptest.NewServer(handlerWithCtx)
 	cmd := newCliWrapper(httpServer.URL, sourceHubAddress)
 
 	return &Wrapper{
-		node:       node,
-		cmd:        cmd,
-		httpServer: httpServer,
-		handler:    handler,
+		node:         node,
+		cmd:          cmd,
+		httpServer:   httpServer,
+		handler:      handler,
+		serverCancel: cancel,
 	}, nil
 }
 
@@ -529,7 +533,7 @@ func (w *Wrapper) NewConcurrentTxn(ctx context.Context, readOnly bool) (client.T
 }
 
 func (w *Wrapper) Close() {
-	w.httpServer.CloseClientConnections()
+	w.serverCancel()
 	w.httpServer.Close()
 	_ = w.node.Close(context.Background())
 }

--- a/tests/clients/http/wrapper.go
+++ b/tests/clients/http/wrapper.go
@@ -32,10 +32,11 @@ var _ client.P2P = (*Wrapper)(nil)
 // Wrapper combines an HTTP client and server into a
 // single struct that implements the client.TxnStore interface.
 type Wrapper struct {
-	node       *node.Node
-	handler    *http.Handler
-	client     *http.Client
-	httpServer *httptest.Server
+	node         *node.Node
+	handler      *http.Handler
+	client       *http.Client
+	httpServer   *httptest.Server
+	serverCancel context.CancelFunc
 }
 
 func NewWrapper(node *node.Node) (*Wrapper, error) {
@@ -43,10 +44,12 @@ func NewWrapper(node *node.Node) (*Wrapper, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	httpServer := httptest.NewServer(handler)
+	ctx, cancel := context.WithCancel(context.Background())
+	handlerWithCtx := http.InjectServerContext(ctx)(handler)
+	httpServer := httptest.NewServer(handlerWithCtx)
 	client, err := http.NewClient(httpServer.URL)
 	if err != nil {
+		cancel()
 		return nil, err
 	}
 
@@ -55,6 +58,7 @@ func NewWrapper(node *node.Node) (*Wrapper, error) {
 		handler,
 		client,
 		httpServer,
+		cancel,
 	}, nil
 }
 
@@ -278,7 +282,7 @@ func (w *Wrapper) NewConcurrentTxn(ctx context.Context, readOnly bool) (client.T
 }
 
 func (w *Wrapper) Close() {
-	w.httpServer.CloseClientConnections()
+	w.serverCancel()
 	w.httpServer.Close()
 	_ = w.node.Close(context.Background())
 }

--- a/tests/integration/subscription/subscription_test.go
+++ b/tests/integration/subscription/subscription_test.go
@@ -344,3 +344,22 @@ func TestSubscriptionWithUpdateAllMutations(t *testing.T) {
 
 	execute(t, test)
 }
+
+func TestSubscription_WithClose_WontBlock(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.SubscriptionRequest{
+				Request: `subscription {
+					User{
+						name
+						age
+					}
+				}`,
+				Results: nil,
+			},
+			testUtils.Close{},
+		},
+	}
+
+	execute(t, test)
+}

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -226,10 +226,13 @@ func ExecuteTestCase(
 	databases = skipIfDatabaseTypeUnsupported(t, databases, testCase.SupportedDatabaseTypes)
 	clients = skipIfClientTypeUnsupported(t, clients, testCase.SupportedClientTypes)
 
-	ctx := context.Background()
 	for _, ct := range clients {
 		for _, dbt := range databases {
 			for _, kms := range kmsList {
+				// Some goroutine depend on the context to be cancelled in order to exit.
+				// Cancelling the context after each text case should limit the chances of
+				// having leaking goroutines.
+				ctx, cancel := context.WithCancel(context.Background())
 				executeTestCase(
 					ctx,
 					t,
@@ -240,6 +243,7 @@ func ExecuteTestCase(
 					ct,
 					documentACPType,
 				)
+				cancel()
 			}
 		}
 	}

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -1879,18 +1879,9 @@ func executeSubscriptionRequest(
 
 		go func() {
 			var results []*client.GQLResult
-			allActionsAreDone := false
-			for !allActionsAreDone || len(results) < len(action.Results) {
-				select {
-				case s := <-result.Subscription:
-					results = append(results, &s)
-				case <-time.After(100 * time.Millisecond):
-				}
-				select {
-				case <-s.AllActionsDone:
-					allActionsAreDone = true
-				case <-time.After(100 * time.Millisecond):
-				}
+			for len(results) < len(action.Results) {
+				s := <-result.Subscription
+				results = append(results, &s)
 			}
 
 			subscriptionAssert <- func() {

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -1884,8 +1884,11 @@ func executeSubscriptionRequest(
 		go func() {
 			var results []*client.GQLResult
 			for len(results) < len(action.Results) {
-				s := <-result.Subscription
-				results = append(results, &s)
+				select {
+				case s := <-result.Subscription:
+					results = append(results, &s)
+				case <-time.After(subscriptionTimeout):
+				}
 			}
 
 			subscriptionAssert <- func() {


### PR DESCRIPTION
## Relevant issue(s)

Resolves #3976 

## Description

This PR fixes an issue where the Defra would block on close when a graphql subscription was active. This was only problematic for graphql subscriptions over HTTP.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Changed the test util and clients using HTTP to not automatically exit when all actions are done.

Specify the platform(s) on which this was tested:
- MacOS
