### PR TITLE
fix: Allow JSON variables in GQL

### DIFF
--- a/internal/request/graphql/schema/collection.go
+++ b/internal/request/graphql/schema/collection.go
@@ -434,9 +434,9 @@ func defaultFromAST(
 	case types.DefaultDirectivePropDateTime:
 		value = gql.DateTime.ParseLiteral(arg.Value, nil)
 	case types.DefaultDirectivePropJSON:
-		value = types.JSONScalarType().ParseLiteral(arg.Value, nil)
+		value = types.JSON.ParseLiteral(arg.Value, nil)
 	case types.DefaultDirectivePropBlob:
-		value = types.BlobScalarType().ParseLiteral(arg.Value, nil)
+		value = types.Blob.ParseLiteral(arg.Value, nil)
 	}
 	// If the value is nil, then parsing has failed, or a nil value was provided.
 	// Since setting a default value to nil is the same as not providing one,

--- a/internal/request/graphql/schema/descriptions.go
+++ b/internal/request/graphql/schema/descriptions.go
@@ -36,8 +36,8 @@ var (
 		client.FieldKind_NILLABLE_STRING:        gql.String,
 		client.FieldKind_STRING_ARRAY:           gql.NewList(gql.NewNonNull(gql.String)),
 		client.FieldKind_NILLABLE_STRING_ARRAY:  gql.NewList(gql.String),
-		client.FieldKind_NILLABLE_BLOB:          schemaTypes.BlobScalarType(),
-		client.FieldKind_NILLABLE_JSON:          schemaTypes.JSONScalarType(),
+		client.FieldKind_NILLABLE_BLOB:          schemaTypes.Blob,
+		client.FieldKind_NILLABLE_JSON:          schemaTypes.JSON,
 	}
 
 	defaultCRDTForFieldKind = map[client.FieldKind]client.CType{

--- a/internal/request/graphql/schema/generate.go
+++ b/internal/request/graphql/schema/generate.go
@@ -1245,7 +1245,7 @@ func (g *Generator) genTypeFilterArgInput(obj *gql.Object) *gql.InputObject {
 			}
 			fields[request.AliasFieldName] = &gql.InputObjectFieldConfig{
 				Description: "The alias operator allows filters to target aliased fields.",
-				Type:        schemaTypes.JSONScalarType(),
+				Type:        schemaTypes.JSON,
 			}
 
 			// generate basic filter operator blocks
@@ -1336,7 +1336,7 @@ func (g *Generator) genTypeOrderArgInput(obj *gql.Object) *gql.InputObject {
 			fields := gql.InputObjectConfigFieldMap{}
 			fields[request.AliasFieldName] = &gql.InputObjectFieldConfig{
 				Description: "The alias field allows ordering by aliased fields.",
-				Type:        schemaTypes.JSONScalarType(),
+				Type:        schemaTypes.JSON,
 			}
 
 			for f, field := range obj.Fields() {

--- a/internal/request/graphql/schema/schema.go
+++ b/internal/request/graphql/schema/schema.go
@@ -136,16 +136,13 @@ func defaultTypes(
 	explainEnum *gql.Enum,
 	indexFieldInput *gql.InputObject,
 ) []gql.Type {
-	blobScalarType := types.BlobScalarType()
-	jsonScalarType := types.JSONScalarType()
-
 	idOpBlock := types.IDOperatorBlock()
 	intOpBlock := types.IntOperatorBlock()
 	float64OpBlock := types.Float64OperatorBlock()
 	float32OpBlock := types.Float32OperatorBlock()
 	booleanOpBlock := types.BooleanOperatorBlock()
 	stringOpBlock := types.StringOperatorBlock()
-	blobOpBlock := types.BlobOperatorBlock(blobScalarType)
+	blobOpBlock := types.BlobOperatorBlock(types.Blob)
 	dateTimeOpBlock := types.DateTimeOperatorBlock()
 
 	notNullIntOpBlock := types.NotNullIntOperatorBlock()
@@ -153,7 +150,7 @@ func defaultTypes(
 	notNullFloat32OpBlock := types.NotNullFloat32OperatorBlock()
 	notNullBooleanOpBlock := types.NotNullBooleanOperatorBlock()
 	notNullStringOpBlock := types.NotNullStringOperatorBlock()
-	notNullBlobOpBlock := types.NotNullBlobOperatorBlock(blobScalarType)
+	notNullBlobOpBlock := types.NotNullBlobOperatorBlock(types.Blob)
 
 	return []gql.Type{
 		// Base Scalar types
@@ -167,8 +164,8 @@ func defaultTypes(
 		gql.String,
 
 		// Custom Scalar types
-		blobScalarType,
-		jsonScalarType,
+		types.Blob,
+		types.JSON,
 
 		// Base Query types
 

--- a/internal/request/graphql/schema/types/scalars.go
+++ b/internal/request/graphql/schema/types/scalars.go
@@ -46,26 +46,24 @@ func coerceBlob(value any) any {
 	}
 }
 
-func BlobScalarType() *graphql.Scalar {
-	return graphql.NewScalar(graphql.ScalarConfig{
-		Name:        "Blob",
-		Description: "The `Blob` scalar type represents a binary large object.",
-		// Serialize converts the value to a hex string
-		Serialize: coerceBlob,
-		// ParseValue converts the value to a hex string
-		ParseValue: coerceBlob,
-		// ParseLiteral converts the ast value to a hex string
-		ParseLiteral: func(valueAST ast.Value, variables map[string]any) any {
-			switch valueAST := valueAST.(type) {
-			case *ast.StringValue:
-				return coerceBlob(valueAST.Value)
-			default:
-				// return nil if the value cannot be parsed
-				return nil
-			}
-		},
-	})
-}
+var Blob = graphql.NewScalar(graphql.ScalarConfig{
+	Name:        "Blob",
+	Description: "The `Blob` scalar type represents a binary large object.",
+	// Serialize converts the value to a hex string
+	Serialize: coerceBlob,
+	// ParseValue converts the value to a hex string
+	ParseValue: coerceBlob,
+	// ParseLiteral converts the ast value to a hex string
+	ParseLiteral: func(valueAST ast.Value, variables map[string]any) any {
+		switch valueAST := valueAST.(type) {
+		case *ast.StringValue:
+			return coerceBlob(valueAST.Value)
+		default:
+			// return nil if the value cannot be parsed
+			return nil
+		}
+	},
+})
 
 func parseJSON(valueAST ast.Value, variables map[string]any) any {
 	switch valueAST := valueAST.(type) {
@@ -106,22 +104,20 @@ func parseJSON(valueAST ast.Value, variables map[string]any) any {
 	}
 }
 
-func JSONScalarType() *graphql.Scalar {
-	return graphql.NewScalar(graphql.ScalarConfig{
-		Name:        "JSON",
-		Description: "The `JSON` scalar type represents a JSON value.",
-		// Serialize converts the value to json value
-		Serialize: func(value any) any {
-			return value
-		},
-		// ParseValue converts the value to json value
-		ParseValue: func(value any) any {
-			return value
-		},
-		// ParseLiteral converts the ast value to a json value
-		ParseLiteral: parseJSON,
-	})
-}
+var JSON = graphql.NewScalar(graphql.ScalarConfig{
+	Name:        "JSON",
+	Description: "The `JSON` scalar type represents a JSON value.",
+	// Serialize converts the value to json value
+	Serialize: func(value any) any {
+		return value
+	},
+	// ParseValue converts the value to json value
+	ParseValue: func(value any) any {
+		return value
+	},
+	// ParseLiteral converts the ast value to a json value
+	ParseLiteral: parseJSON,
+})
 
 func coerceFloat32(value any) any {
 	switch value := value.(type) {

--- a/internal/request/graphql/schema/types/scalars_test.go
+++ b/internal/request/graphql/schema/types/scalars_test.go
@@ -36,7 +36,7 @@ func TestBlobScalarTypeSerialize(t *testing.T) {
 		{false, nil},
 	}
 	for _, c := range cases {
-		result := BlobScalarType().Serialize(c.input)
+		result := Blob.Serialize(c.input)
 		assert.Equal(t, c.expect, result)
 	}
 }
@@ -62,7 +62,7 @@ func TestBlobScalarTypeParseValue(t *testing.T) {
 		{false, nil},
 	}
 	for _, c := range cases {
-		result := BlobScalarType().ParseValue(c.input)
+		result := Blob.ParseValue(c.input)
 		assert.Equal(t, c.expect, result)
 	}
 }
@@ -84,7 +84,7 @@ func TestBlobScalarTypeParseLiteral(t *testing.T) {
 		{&ast.ObjectValue{}, nil},
 	}
 	for _, c := range cases {
-		result := BlobScalarType().ParseLiteral(c.input, nil)
+		result := Blob.ParseLiteral(c.input, nil)
 		assert.Equal(t, c.expect, result)
 	}
 }
@@ -126,7 +126,7 @@ func TestJSONScalarTypeParseLiteral(t *testing.T) {
 		"message": "hello",
 	}
 	for _, c := range cases {
-		result := JSONScalarType().ParseLiteral(c.input, variables)
+		result := JSON.ParseLiteral(c.input, variables)
 		assert.Equal(t, c.expect, result)
 	}
 }

--- a/internal/request/graphql/schema/types/types.go
+++ b/internal/request/graphql/schema/types/types.go
@@ -144,10 +144,10 @@ func DefaultDirective() *gql.Directive {
 				Type: gql.DateTime,
 			},
 			DefaultDirectivePropJSON: &gql.ArgumentConfig{
-				Type: JSONScalarType(),
+				Type: JSON,
 			},
 			DefaultDirectivePropBlob: &gql.ArgumentConfig{
-				Type: BlobScalarType(),
+				Type: Blob,
 			},
 		},
 		Locations: []string{

--- a/tests/integration/mutation/create/with_variables_test.go
+++ b/tests/integration/mutation/create/with_variables_test.go
@@ -84,7 +84,7 @@ func TestMutationCreateWithDefaultVariable(t *testing.T) {
 	testUtils.ExecuteTestCase(t, test)
 }
 
-func TestMutationCreate_WithJSONVariable_Succeeds(t *testing.T) {
+func TestMutationCreate_WithVariableInJSONObject_Succeeds(t *testing.T) {
 	test := testUtils.TestCase{
 		Actions: []any{
 			&action.AddSchema{
@@ -108,6 +108,43 @@ func TestMutationCreate_WithJSONVariable_Succeeds(t *testing.T) {
 						{
 							"embed": map[string]any{
 								"message": "hello",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestMutationCreate_WithJSONVariable_Succeeds(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddSchema{
+				Schema: `
+					type Users {
+						embed: JSON
+					}
+				`,
+			},
+			testUtils.Request{
+				Variables: immutable.Some(map[string]any{
+					"embed": map[string]any{
+						"bar": 1,
+					},
+				}),
+				Request: `mutation($embed: JSON) {
+					create_Users(input: {embed: $embed}) {
+						embed
+					}
+				}`,
+				Results: map[string]any{
+					"create_Users": []map[string]any{
+						{
+							"embed": map[string]any{
+								"bar": 1,
 							},
 						},
 					},


### PR DESCRIPTION
## Relevant issue(s)

Resolves #3989 

## Description

This PR fixes an issue where a JSON variable in GQL would cause a parsing error. This was due to the JSON scalar type being defined twice in the process and the parser interpreting it as two different types. The Blob scalar type usage was also preemptively changed.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Added a test with a query that would fail before applying the fix.

Specify the platform(s) on which this was tested:
- MacOS
