### PR TITLE
chore: Make C binding return types consistent

### DIFF
--- a/cbindings/acp.go
+++ b/cbindings/acp.go
@@ -23,7 +23,7 @@ import (
 )
 
 //export ACPAddDACPolicy
-func ACPAddDACPolicy(nodePtr C.uintptr_t, identityPtr C.uintptr_t, policy *C.char) *C.Result {
+func ACPAddDACPolicy(nodePtr C.uintptr_t, identityPtr C.uintptr_t, policy *C.char) C.Result {
 	ctx := context.Background()
 
 	ctx, err := contextWithIdentity(ctx, identityPtr)
@@ -52,7 +52,7 @@ func ACPAddDACActorRelationship(
 	docID *C.char,
 	relation *C.char,
 	actor *C.char,
-) *C.Result {
+) C.Result {
 	ctx := context.Background()
 
 	ctx, err := contextWithIdentity(ctx, identityPtr)
@@ -87,7 +87,7 @@ func ACPDeleteDACActorRelationship(
 	docID *C.char,
 	relation *C.char,
 	actor *C.char,
-) *C.Result {
+) C.Result {
 	ctx := context.Background()
 
 	ctx, err := contextWithIdentity(ctx, identityPtr)
@@ -115,7 +115,7 @@ func ACPDeleteDACActorRelationship(
 }
 
 //export ACPDisableNAC
-func ACPDisableNAC(nodePtr C.uintptr_t, identityPtr C.uintptr_t) *C.Result {
+func ACPDisableNAC(nodePtr C.uintptr_t, identityPtr C.uintptr_t) C.Result {
 	ctx := context.Background()
 
 	ctx, err := contextWithIdentity(ctx, identityPtr)
@@ -136,7 +136,7 @@ func ACPDisableNAC(nodePtr C.uintptr_t, identityPtr C.uintptr_t) *C.Result {
 }
 
 //export ACPReEnableNAC
-func ACPReEnableNAC(nodePtr C.uintptr_t, identityPtr C.uintptr_t) *C.Result {
+func ACPReEnableNAC(nodePtr C.uintptr_t, identityPtr C.uintptr_t) C.Result {
 	ctx := context.Background()
 
 	ctx, err := contextWithIdentity(ctx, identityPtr)
@@ -162,7 +162,7 @@ func ACPAddNACActorRelationship(
 	identityPtr C.uintptr_t,
 	relation *C.char,
 	actor *C.char,
-) *C.Result {
+) C.Result {
 	ctx := context.Background()
 
 	ctx, err := contextWithIdentity(ctx, identityPtr)
@@ -193,7 +193,7 @@ func ACPDeleteNACActorRelationship(
 	identityPtr C.uintptr_t,
 	relation *C.char,
 	actor *C.char,
-) *C.Result {
+) C.Result {
 	ctx := context.Background()
 
 	ctx, err := contextWithIdentity(ctx, identityPtr)
@@ -219,7 +219,7 @@ func ACPDeleteNACActorRelationship(
 }
 
 //export ACPGetNACStatus
-func ACPGetNACStatus(nodePtr C.uintptr_t, identityPtr C.uintptr_t) *C.Result {
+func ACPGetNACStatus(nodePtr C.uintptr_t, identityPtr C.uintptr_t) C.Result {
 	ctx := context.Background()
 
 	ctx, err := contextWithIdentity(ctx, identityPtr)

--- a/cbindings/block.go
+++ b/cbindings/block.go
@@ -23,7 +23,7 @@ import (
 )
 
 //export BlockVerifySignature
-func BlockVerifySignature(nodePtr C.uintptr_t, keyType *C.char, publicKey *C.char, cid *C.char) *C.Result {
+func BlockVerifySignature(nodePtr C.uintptr_t, keyType *C.char, publicKey *C.char, cid *C.char) C.Result {
 	ctx := context.Background()
 	keyTypeStr := C.GoString(keyType)
 	pubKeyStr := C.GoString(publicKey)

--- a/cbindings/collection.go
+++ b/cbindings/collection.go
@@ -85,7 +85,7 @@ func CollectionCreate(
 	isEncrypted C.int,
 	encryptedFields *C.char,
 	options C.CollectionOptions,
-) *C.Result {
+) C.Result {
 	ctx := context.Background()
 	colOptions := parseCollectionOptions(options)
 
@@ -142,7 +142,7 @@ func CollectionCreate(
 }
 
 //export CollectionDelete
-func CollectionDelete(nodePtr C.uintptr_t, docIDStr *C.char, filterStr *C.char, options C.CollectionOptions) *C.Result {
+func CollectionDelete(nodePtr C.uintptr_t, docIDStr *C.char, filterStr *C.char, options C.CollectionOptions) C.Result {
 	ctx := context.Background()
 	colOptions := parseCollectionOptions(options)
 
@@ -193,7 +193,7 @@ func CollectionDelete(nodePtr C.uintptr_t, docIDStr *C.char, filterStr *C.char, 
 }
 
 //export CollectionDescribe
-func CollectionDescribe(nodePtr C.uintptr_t, options C.CollectionOptions) *C.Result {
+func CollectionDescribe(nodePtr C.uintptr_t, options C.CollectionOptions) C.Result {
 	ctx := context.Background()
 	colOptions := parseCollectionOptions(options)
 
@@ -221,7 +221,7 @@ func CollectionDescribe(nodePtr C.uintptr_t, options C.CollectionOptions) *C.Res
 }
 
 //export CollectionListDocIDs
-func CollectionListDocIDs(nodePtr C.uintptr_t, options C.CollectionOptions) *C.Result {
+func CollectionListDocIDs(nodePtr C.uintptr_t, options C.CollectionOptions) C.Result {
 	ctx := context.Background()
 	colOptions := parseCollectionOptions(options)
 
@@ -267,7 +267,7 @@ func CollectionListDocIDs(nodePtr C.uintptr_t, options C.CollectionOptions) *C.R
 }
 
 //export CollectionGet
-func CollectionGet(nodePtr C.uintptr_t, docIDStr *C.char, showDeleted C.int, options C.CollectionOptions) *C.Result {
+func CollectionGet(nodePtr C.uintptr_t, docIDStr *C.char, showDeleted C.int, options C.CollectionOptions) C.Result {
 	ctx := context.Background()
 	colOptions := parseCollectionOptions(options)
 
@@ -303,7 +303,7 @@ func CollectionGet(nodePtr C.uintptr_t, docIDStr *C.char, showDeleted C.int, opt
 }
 
 //export CollectionPatch
-func CollectionPatch(nodePtr C.uintptr_t, patch *C.char, lensConfig *C.char, options C.CollectionOptions) *C.Result {
+func CollectionPatch(nodePtr C.uintptr_t, patch *C.char, lensConfig *C.char, options C.CollectionOptions) C.Result {
 	ctx := context.Background()
 
 	ctx, err := contextWithIdentity(ctx, options.identityPtr)
@@ -346,7 +346,7 @@ func CollectionUpdate(
 	filterStr *C.char,
 	updaterStr *C.char,
 	options C.CollectionOptions,
-) *C.Result {
+) C.Result {
 	ctx := context.Background()
 	colOptions := parseCollectionOptions(options)
 
@@ -409,7 +409,7 @@ func CollectionUpdate(
 }
 
 //export SetActiveCollection
-func SetActiveCollection(nodePtr C.uintptr_t, version *C.char) *C.Result {
+func SetActiveCollection(nodePtr C.uintptr_t, version *C.char) C.Result {
 	ctx := context.Background()
 
 	store, err := getStoreFromPointer(nodePtr)

--- a/cbindings/cutils.go
+++ b/cbindings/cutils.go
@@ -33,13 +33,11 @@ import (
 )
 
 // Helper function which builds a return struct from Go to C
-func returnC(gcr GoCResult) *C.Result {
-	result := (*C.Result)(C.malloc(C.size_t(unsafe.Sizeof(C.Result{}))))
-
+func returnC(gcr GoCResult) C.Result {
+	result := C.Result{}
 	result.status = C.int(gcr.Status)
 	result.error = C.CString(gcr.Error)
 	result.value = C.CString(gcr.Value)
-
 	return result
 }
 
@@ -184,7 +182,7 @@ func contextWithIdentity(ctx context.Context, identityPtr C.uintptr_t) (context.
 
 // ConvertAndFreeCResult exists to convert C.Result to GoCResult for use in integration tests
 // It will, in converting,consume the C.Result, freeing the memory for it
-func ConvertAndFreeCResult(cResult *C.Result) GoCResult {
+func ConvertAndFreeCResult(cResult C.Result) GoCResult {
 	defer C.free(unsafe.Pointer(cResult.error))
 	defer C.free(unsafe.Pointer(cResult.value))
 	return GoCResult{

--- a/cbindings/identity.go
+++ b/cbindings/identity.go
@@ -39,7 +39,7 @@ func IdentityNew(keyType *C.char) C.NewIdentityResult {
 }
 
 //export NodeIdentity
-func NodeIdentity(nodePtr C.uintptr_t) *C.Result {
+func NodeIdentity(nodePtr C.uintptr_t) C.Result {
 	ctx := context.Background()
 	store, err := getStoreFromPointer(nodePtr)
 	if err != nil {

--- a/cbindings/index.go
+++ b/cbindings/index.go
@@ -30,7 +30,7 @@ func IndexCreate(
 	indexName *C.char,
 	fieldsStr *C.char,
 	isUnique C.int,
-) *C.Result {
+) C.Result {
 	ctx := context.Background()
 	fieldsArg := splitCommaSeparatedString(C.GoString(fieldsStr))
 
@@ -81,7 +81,7 @@ func IndexCreate(
 }
 
 //export IndexList
-func IndexList(nodePtr C.uintptr_t, collectionName *C.char) *C.Result {
+func IndexList(nodePtr C.uintptr_t, collectionName *C.char) C.Result {
 	ctx := context.Background()
 	store, err := getStoreFromPointer(nodePtr)
 	if err != nil {
@@ -112,7 +112,7 @@ func IndexList(nodePtr C.uintptr_t, collectionName *C.char) *C.Result {
 }
 
 //export IndexDrop
-func IndexDrop(nodePtr C.uintptr_t, collectionName *C.char, indexName *C.char) *C.Result {
+func IndexDrop(nodePtr C.uintptr_t, collectionName *C.char, indexName *C.char) C.Result {
 	ctx := context.Background()
 
 	store, err := getStoreFromPointer(nodePtr)

--- a/cbindings/lens.go
+++ b/cbindings/lens.go
@@ -28,7 +28,7 @@ import (
 )
 
 //export LensSet
-func LensSet(nodePtr C.uintptr_t, src *C.char, dst *C.char, cfg *C.char) *C.Result {
+func LensSet(nodePtr C.uintptr_t, src *C.char, dst *C.char, cfg *C.char) C.Result {
 	ctx := context.Background()
 
 	decoder := json.NewDecoder(strings.NewReader(C.GoString(cfg)))
@@ -56,7 +56,7 @@ func LensSet(nodePtr C.uintptr_t, src *C.char, dst *C.char, cfg *C.char) *C.Resu
 }
 
 //export LensDown
-func LensDown(nodePtr C.uintptr_t, collectionID *C.char, documents *C.char) *C.Result {
+func LensDown(nodePtr C.uintptr_t, collectionID *C.char, documents *C.char) C.Result {
 	ctx := context.Background()
 	srcData := []byte(C.GoString(documents))
 
@@ -87,7 +87,7 @@ func LensDown(nodePtr C.uintptr_t, collectionID *C.char, documents *C.char) *C.R
 }
 
 //export LensUp
-func LensUp(nodePtr C.uintptr_t, collectionID *C.char, documents *C.char) *C.Result {
+func LensUp(nodePtr C.uintptr_t, collectionID *C.char, documents *C.char) C.Result {
 	ctx := context.Background()
 	srcData := []byte(C.GoString(documents))
 
@@ -118,7 +118,7 @@ func LensUp(nodePtr C.uintptr_t, collectionID *C.char, documents *C.char) *C.Res
 }
 
 //export LensReload
-func LensReload(nodePtr C.uintptr_t) *C.Result {
+func LensReload(nodePtr C.uintptr_t) C.Result {
 	ctx := context.Background()
 
 	store, err := getStoreFromPointer(nodePtr)
@@ -134,7 +134,7 @@ func LensReload(nodePtr C.uintptr_t) *C.Result {
 }
 
 //export LensSetRegistry
-func LensSetRegistry(nodePtr C.uintptr_t, collectionID *C.char, cfg *C.char) *C.Result {
+func LensSetRegistry(nodePtr C.uintptr_t, collectionID *C.char, cfg *C.char) C.Result {
 	ctx := context.Background()
 
 	decoder := json.NewDecoder(strings.NewReader(C.GoString(cfg)))

--- a/cbindings/node.go
+++ b/cbindings/node.go
@@ -114,7 +114,7 @@ func NewNode(cOptions C.NodeInitOptions) C.NewNodeResult {
 }
 
 //export NodeClose
-func NodeClose(nodePtr C.uintptr_t) *C.Result {
+func NodeClose(nodePtr C.uintptr_t) C.Result {
 	node, err := getNodeFromPointer(nodePtr)
 	if err != nil {
 		return returnC(returnGoC(1, err.Error(), ""))

--- a/cbindings/p2p.go
+++ b/cbindings/p2p.go
@@ -25,7 +25,7 @@ import (
 )
 
 //export P2PInfo
-func P2PInfo(nodePtr C.uintptr_t) *C.Result {
+func P2PInfo(nodePtr C.uintptr_t) C.Result {
 	node, err := getNodeFromPointer(nodePtr)
 	if err != nil {
 		return returnC(returnGoC(1, err.Error(), ""))
@@ -35,7 +35,7 @@ func P2PInfo(nodePtr C.uintptr_t) *C.Result {
 }
 
 //export P2PgetAllReplicators
-func P2PgetAllReplicators(nodePtr C.uintptr_t) *C.Result {
+func P2PgetAllReplicators(nodePtr C.uintptr_t) C.Result {
 	ctx := context.Background()
 	node, err := getNodeFromPointer(nodePtr)
 	if err != nil {
@@ -49,7 +49,7 @@ func P2PgetAllReplicators(nodePtr C.uintptr_t) *C.Result {
 }
 
 //export P2PsetReplicator
-func P2PsetReplicator(nodePtr C.uintptr_t, collections *C.char, peerInfo *C.char) *C.Result {
+func P2PsetReplicator(nodePtr C.uintptr_t, collections *C.char, peerInfo *C.char) C.Result {
 	ctx := context.Background()
 	colArgs := splitCommaSeparatedString(C.GoString(collections))
 
@@ -70,7 +70,7 @@ func P2PsetReplicator(nodePtr C.uintptr_t, collections *C.char, peerInfo *C.char
 }
 
 //export P2PdeleteReplicator
-func P2PdeleteReplicator(nodePtr C.uintptr_t, collections *C.char, peerInfo *C.char) *C.Result {
+func P2PdeleteReplicator(nodePtr C.uintptr_t, collections *C.char, peerInfo *C.char) C.Result {
 	ctx := context.Background()
 	colArgs := splitCommaSeparatedString(C.GoString(collections))
 
@@ -91,7 +91,7 @@ func P2PdeleteReplicator(nodePtr C.uintptr_t, collections *C.char, peerInfo *C.c
 }
 
 //export P2PcollectionAdd
-func P2PcollectionAdd(nodePtr C.uintptr_t, collections *C.char) *C.Result {
+func P2PcollectionAdd(nodePtr C.uintptr_t, collections *C.char) C.Result {
 	ctx := context.Background()
 	colArgs := splitCommaSeparatedString(C.GoString(collections))
 
@@ -107,7 +107,7 @@ func P2PcollectionAdd(nodePtr C.uintptr_t, collections *C.char) *C.Result {
 }
 
 //export P2PcollectionRemove
-func P2PcollectionRemove(nodePtr C.uintptr_t, collections *C.char) *C.Result {
+func P2PcollectionRemove(nodePtr C.uintptr_t, collections *C.char) C.Result {
 	ctx := context.Background()
 	colArgs := splitCommaSeparatedString(C.GoString(collections))
 
@@ -123,7 +123,7 @@ func P2PcollectionRemove(nodePtr C.uintptr_t, collections *C.char) *C.Result {
 }
 
 //export P2PcollectionGetAll
-func P2PcollectionGetAll(nodePtr C.uintptr_t) *C.Result {
+func P2PcollectionGetAll(nodePtr C.uintptr_t) C.Result {
 	ctx := context.Background()
 
 	node, err := getNodeFromPointer(nodePtr)
@@ -139,7 +139,7 @@ func P2PcollectionGetAll(nodePtr C.uintptr_t) *C.Result {
 }
 
 //export P2PdocumentAdd
-func P2PdocumentAdd(nodePtr C.uintptr_t, collections *C.char) *C.Result {
+func P2PdocumentAdd(nodePtr C.uintptr_t, collections *C.char) C.Result {
 	ctx := context.Background()
 	colArgs := splitCommaSeparatedString(C.GoString(collections))
 
@@ -155,7 +155,7 @@ func P2PdocumentAdd(nodePtr C.uintptr_t, collections *C.char) *C.Result {
 }
 
 //export P2PdocumentRemove
-func P2PdocumentRemove(nodePtr C.uintptr_t, collections *C.char) *C.Result {
+func P2PdocumentRemove(nodePtr C.uintptr_t, collections *C.char) C.Result {
 	ctx := context.Background()
 	colArgs := splitCommaSeparatedString(C.GoString(collections))
 
@@ -171,7 +171,7 @@ func P2PdocumentRemove(nodePtr C.uintptr_t, collections *C.char) *C.Result {
 }
 
 //export P2PdocumentGetAll
-func P2PdocumentGetAll(nodePtr C.uintptr_t) *C.Result {
+func P2PdocumentGetAll(nodePtr C.uintptr_t) C.Result {
 	ctx := context.Background()
 	node, err := getNodeFromPointer(nodePtr)
 	if err != nil {
@@ -185,7 +185,7 @@ func P2PdocumentGetAll(nodePtr C.uintptr_t) *C.Result {
 }
 
 //export P2PdocumentSync
-func P2PdocumentSync(nodePtr C.uintptr_t, collection *C.char, docIDs *C.char, timeoutStr *C.char) *C.Result {
+func P2PdocumentSync(nodePtr C.uintptr_t, collection *C.char, docIDs *C.char, timeoutStr *C.char) C.Result {
 	ctx := context.Background()
 	docArgs := splitCommaSeparatedString(C.GoString(docIDs))
 	timeoutDuration := time.Duration(0)
@@ -217,7 +217,7 @@ func P2PdocumentSync(nodePtr C.uintptr_t, collection *C.char, docIDs *C.char, ti
 }
 
 //export P2Pconnect
-func P2Pconnect(nodePtr C.uintptr_t, peerID *C.char, peerAddresses *C.char) *C.Result {
+func P2Pconnect(nodePtr C.uintptr_t, peerID *C.char, peerAddresses *C.char) C.Result {
 	ctx := context.Background()
 	node, err := getNodeFromPointer(nodePtr)
 	if err != nil {

--- a/cbindings/query.go
+++ b/cbindings/query.go
@@ -71,7 +71,7 @@ func removeSubscription(id string) {
 // and the payload of the message. If an error occurs, status 1 is returned.
 //
 //export PollSubscription
-func PollSubscription(id *C.char) *C.Result {
+func PollSubscription(id *C.char) C.Result {
 	subID := C.GoString(id)
 	sub, ok := getSubscription(subID)
 	if !ok {
@@ -90,7 +90,7 @@ func PollSubscription(id *C.char) *C.Result {
 }
 
 //export CloseSubscription
-func CloseSubscription(id *C.char) *C.Result {
+func CloseSubscription(id *C.char) C.Result {
 	removeSubscription(C.GoString(id))
 	return returnC(returnGoC(0, "", ""))
 }
@@ -102,7 +102,7 @@ func ExecuteQuery(
 	identityPtr C.uintptr_t,
 	operationName *C.char,
 	variables *C.char,
-) *C.Result {
+) C.Result {
 	ctx := context.Background()
 	opts, err := buildRequestOptions(C.GoString(operationName), C.GoString(variables))
 	if err != nil {

--- a/cbindings/schema.go
+++ b/cbindings/schema.go
@@ -21,7 +21,7 @@ import (
 )
 
 //export AddSchema
-func AddSchema(nodePtr C.uintptr_t, schema *C.char, identityPtr C.uintptr_t) *C.Result {
+func AddSchema(nodePtr C.uintptr_t, schema *C.char, identityPtr C.uintptr_t) C.Result {
 	ctx := context.Background()
 
 	ctx, err := contextWithIdentity(ctx, identityPtr)

--- a/cbindings/txn.go
+++ b/cbindings/txn.go
@@ -46,7 +46,7 @@ func TransactionCreate(nodePtr C.uintptr_t, isConcurrent C.int, isReadOnly C.int
 }
 
 //export TransactionCommit
-func TransactionCommit(txnPtr C.uintptr_t) *C.Result {
+func TransactionCommit(txnPtr C.uintptr_t) C.Result {
 	ctx := context.Background()
 
 	h := cgo.Handle(txnPtr)

--- a/cbindings/version.go
+++ b/cbindings/version.go
@@ -21,7 +21,7 @@ import (
 )
 
 //export VersionGet
-func VersionGet(flagFull C.int, flagJSON C.int) *C.Result {
+func VersionGet(flagFull C.int, flagJSON C.int) C.Result {
 	dv, err := version.NewDefraVersion()
 	if err != nil {
 		return returnC(returnGoC(1, err.Error(), ""))

--- a/cbindings/view.go
+++ b/cbindings/view.go
@@ -28,7 +28,7 @@ import (
 )
 
 //export ViewAdd
-func ViewAdd(nodePtr C.uintptr_t, query *C.char, sdl *C.char, transformStr *C.char) *C.Result {
+func ViewAdd(nodePtr C.uintptr_t, query *C.char, sdl *C.char, transformStr *C.char) C.Result {
 	ctx := context.Background()
 
 	var transform immutable.Option[model.Lens]
@@ -63,7 +63,7 @@ func ViewRefresh(
 	collectionIDStr *C.char,
 	versionIDStr *C.char,
 	getInactive C.int,
-) *C.Result {
+) C.Result {
 	ctx := context.Background()
 
 	viewName := C.GoString(viewNameStr)

--- a/cbindings/wrapper.go
+++ b/cbindings/wrapper.go
@@ -14,49 +14,49 @@ package cbindings
 #include <stdlib.h>
 #include <stdint.h>
 #include "defra_structs.h"
-extern Result* ACPAddDACPolicy(uintptr_t nodePtr, uintptr_t identity, char* policy);
-extern Result* ACPAddDACActorRelationship(uintptr_t nodePtr, uintptr_t identityPtr,
+extern Result ACPAddDACPolicy(uintptr_t nodePtr, uintptr_t identity, char* policy);
+extern Result ACPAddDACActorRelationship(uintptr_t nodePtr, uintptr_t identityPtr,
 char* collection, char* docID, char* relation, char* actor);
-extern Result* ACPDeleteDACActorRelationship(uintptr_t nodePtr, uintptr_t identity,
+extern Result ACPDeleteDACActorRelationship(uintptr_t nodePtr, uintptr_t identity,
 char* collection, char* docID, char* relation, char* actor);
-extern Result* ACPDisableNAC(uintptr_t nodePtr, uintptr_t identityPtr);
-extern Result* ACPReEnableNAC(uintptr_t nodePtr, uintptr_t identity);
-extern Result* ACPAddNACActorRelationship(uintptr_t nodePtr, uintptr_t identity,
+extern Result ACPDisableNAC(uintptr_t nodePtr, uintptr_t identityPtr);
+extern Result ACPReEnableNAC(uintptr_t nodePtr, uintptr_t identity);
+extern Result ACPAddNACActorRelationship(uintptr_t nodePtr, uintptr_t identity,
 char* relation, char* actor);
-extern Result* ACPDeleteNACActorRelationship(uintptr_t nodePtr, uintptr_t identity,
+extern Result ACPDeleteNACActorRelationship(uintptr_t nodePtr, uintptr_t identity,
 char* relation, char* actor);
-extern Result* ACPGetNACStatus(uintptr_t nodePtr, uintptr_t identity);
-extern Result* BlockVerifySignature(uintptr_t nodePtr, char* keyType, char* publicKey, char* cid);
-extern Result* CollectionDescribe(uintptr_t nodePtr, CollectionOptions options);
-extern Result* CollectionPatch(uintptr_t nodePtr, char* patch, char* lensConfig, CollectionOptions options);
-extern Result* IdentityNew(char* keyType);
-extern Result* NodeIdentity(uintptr_t nodePtr);
-extern Result* IndexList(uintptr_t nodePtr, char* collectionName);
-extern Result* LensSet(uintptr_t nodePtr, char* src, char* dst, char* cfg);
+extern Result ACPGetNACStatus(uintptr_t nodePtr, uintptr_t identity);
+extern Result BlockVerifySignature(uintptr_t nodePtr, char* keyType, char* publicKey, char* cid);
+extern Result CollectionDescribe(uintptr_t nodePtr, CollectionOptions options);
+extern Result CollectionPatch(uintptr_t nodePtr, char* patch, char* lensConfig, CollectionOptions options);
+extern Result IdentityNew(char* keyType);
+extern Result NodeIdentity(uintptr_t nodePtr);
+extern Result IndexList(uintptr_t nodePtr, char* collectionName);
+extern Result LensSet(uintptr_t nodePtr, char* src, char* dst, char* cfg);
 extern NewNodeResult NewNode(NodeInitOptions cOptions);
-extern Result* NodeClose(uintptr_t nodePtr);
-extern Result* P2PInfo(uintptr_t nodePtr);
-extern Result* P2PgetAllReplicators(uintptr_t nodePtr);
-extern Result* P2PsetReplicator(uintptr_t nodePtr, char* collections, char* peerInfo);
-extern Result* P2PdeleteReplicator(uintptr_t nodePtr, char* collections, char* peerInfo);
-extern Result* P2PcollectionAdd(uintptr_t nodePtr, char* collections);
-extern Result* P2PcollectionRemove(uintptr_t nodePtr, char* collections);
-extern Result* P2PcollectionGetAll(uintptr_t nodePtr);
-extern Result* P2Pconnect(uintptr_t nodePtr, char* peerID, char* peerAddresses);
-extern Result* P2PdocumentAdd(uintptr_t nodePtr, char* collections);
-extern Result* P2PdocumentRemove(uintptr_t nodePtr, char* collections);
-extern Result* P2PdocumentGetAll(uintptr_t nodePtr);
-extern Result* P2PdocumentSync(uintptr_t nodePtr, char* collection, char* docIDs, char* timeoutStr);
-extern Result* PollSubscription(char* id);
-extern Result* CloseSubscription(char* id);
-extern Result* ExecuteQuery(uintptr_t nodePtr, char* query, uintptr_t identity,
+extern Result NodeClose(uintptr_t nodePtr);
+extern Result P2PInfo(uintptr_t nodePtr);
+extern Result P2PgetAllReplicators(uintptr_t nodePtr);
+extern Result P2PsetReplicator(uintptr_t nodePtr, char* collections, char* peerInfo);
+extern Result P2PdeleteReplicator(uintptr_t nodePtr, char* collections, char* peerInfo);
+extern Result P2PcollectionAdd(uintptr_t nodePtr, char* collections);
+extern Result P2PcollectionRemove(uintptr_t nodePtr, char* collections);
+extern Result P2PcollectionGetAll(uintptr_t nodePtr);
+extern Result P2Pconnect(uintptr_t nodePtr, char* peerID, char* peerAddresses);
+extern Result P2PdocumentAdd(uintptr_t nodePtr, char* collections);
+extern Result P2PdocumentRemove(uintptr_t nodePtr, char* collections);
+extern Result P2PdocumentGetAll(uintptr_t nodePtr);
+extern Result P2PdocumentSync(uintptr_t nodePtr, char* collection, char* docIDs, char* timeoutStr);
+extern Result PollSubscription(char* id);
+extern Result CloseSubscription(char* id);
+extern Result ExecuteQuery(uintptr_t nodePtr, char* query, uintptr_t identity,
 char* operationName, char* variables);
-extern Result* AddSchema(uintptr_t nodePtr, char* schema, uintptr_t identity);
-extern Result* SetActiveCollection(uintptr_t nodePtr, char* version);
+extern Result AddSchema(uintptr_t nodePtr, char* schema, uintptr_t identity);
+extern Result SetActiveCollection(uintptr_t nodePtr, char* version);
 extern NewTxnResult TransactionCreate(uintptr_t nodePtr, int isConcurrent, int isReadOnly);
-extern Result* VersionGet(int flagFull, int flagJSON);
-extern Result* ViewAdd(uintptr_t nodePtr, char* query, char* sdl, char* transformStr);
-extern Result* ViewRefresh(uintptr_t nodePtr, char* viewNameStr,
+extern Result VersionGet(int flagFull, int flagJSON);
+extern Result ViewAdd(uintptr_t nodePtr, char* query, char* sdl, char* transformStr);
+extern Result ViewRefresh(uintptr_t nodePtr, char* viewNameStr,
 char* collectionIDStr, char* versionIDStr, int getInactive);
 */
 import "C"

--- a/cbindings/wrapper_collection.go
+++ b/cbindings/wrapper_collection.go
@@ -14,17 +14,17 @@ package cbindings
 #include <stdlib.h>
 #include <stdint.h>
 #include "defra_structs.h"
-extern Result* CollectionCreate(uintptr_t nodePtr, char* json, int isEncrypted,
+extern Result CollectionCreate(uintptr_t nodePtr, char* json, int isEncrypted,
 char* encryptedFields, CollectionOptions options);
-extern Result* CollectionDelete(uintptr_t nodePtr, char* docIDStr, char* filterStr, CollectionOptions options);
-extern Result* CollectionDescribe(uintptr_t nodePtr, CollectionOptions options);
-extern Result* CollectionListDocIDs(uintptr_t nodePtr, CollectionOptions options);
-extern Result* CollectionGet(uintptr_t nodePtr, char* docIDStr, int showDeleted, CollectionOptions options);
-extern Result* CollectionUpdate(uintptr_t nodePtr, char* docIDStr, char* filterStr,
+extern Result CollectionDelete(uintptr_t nodePtr, char* docIDStr, char* filterStr, CollectionOptions options);
+extern Result CollectionDescribe(uintptr_t nodePtr, CollectionOptions options);
+extern Result CollectionListDocIDs(uintptr_t nodePtr, CollectionOptions options);
+extern Result CollectionGet(uintptr_t nodePtr, char* docIDStr, int showDeleted, CollectionOptions options);
+extern Result CollectionUpdate(uintptr_t nodePtr, char* docIDStr, char* filterStr,
 char* updaterStr, CollectionOptions options);
-extern Result* IndexCreate(uintptr_t nodePtr, char* collectionName, char* indexName, char* fieldsStr, int isUnique);
-extern Result* IndexList(uintptr_t nodePtr, char* collectionName);
-extern Result* IndexDrop(uintptr_t nodePtr, char* collectionName, char* indexName);
+extern Result IndexCreate(uintptr_t nodePtr, char* collectionName, char* indexName, char* fieldsStr, int isUnique);
+extern Result IndexList(uintptr_t nodePtr, char* collectionName);
+extern Result IndexDrop(uintptr_t nodePtr, char* collectionName, char* indexName);
 */
 import "C"
 

--- a/cbindings/wrapper_lens.go
+++ b/cbindings/wrapper_lens.go
@@ -14,10 +14,10 @@ package cbindings
 #include <stdlib.h>
 #include <stdint.h>
 #include "defra_structs.h"
-extern Result* LensDown(uintptr_t nodePtr, char* collectionID, char* documents);
-extern Result* LensUp(uintptr_t nodePtr, char* collectionID, char* documents);
-extern Result* LensReload(uintptr_t nodePtr);
-extern Result* LensSetRegistry(uintptr_t nodePtr, char* collectionID, char* cfg);
+extern Result LensDown(uintptr_t nodePtr, char* collectionID, char* documents);
+extern Result LensUp(uintptr_t nodePtr, char* collectionID, char* documents);
+extern Result LensReload(uintptr_t nodePtr);
+extern Result LensSetRegistry(uintptr_t nodePtr, char* collectionID, char* cfg);
 */
 import "C"
 

--- a/cbindings/wrapper_tx.go
+++ b/cbindings/wrapper_tx.go
@@ -14,7 +14,7 @@ package cbindings
 #include <stdlib.h>
 #include <stdint.h>
 #include "defra_structs.h"
-extern Result* TransactionCommit(uintptr_t txnPtr);
+extern Result TransactionCommit(uintptr_t txnPtr);
 extern void TransactionDiscard(uintptr_t txnPtr);
 */
 import "C"


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4001 

## Description

In all places that we returned `*C.Result` to the user, we now return `C.Result.` This required some changes be made to the utility functions used by the integration test wrappers, and the CGO directives at the top of the wrapper files. With these changes, the C bindings are more consistent, as now all returned types are by value.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [ ] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Specify the platform(s) on which this was tested:
- WSL