### PR TITLE
fix: Signature selection panic

### DIFF
--- a/internal/planner/commit.go
+++ b/internal/planner/commit.go
@@ -380,7 +380,8 @@ func (n *dagScanNode) dagBlockToNodeDoc(block *coreblock.Block) (core.Doc, error
 		n.commitSelect.DocumentMapping.SetFirstOfName(&commit, request.DeltaFieldName, nil)
 	}
 
-	if block.Signature != nil {
+	if block.Signature != nil &&
+		n.commitSelect.DocumentMapping.IndexesByName[request.SignatureFieldName] != nil {
 		err := n.addSignatureFieldToDoc(*block.Signature, &commit)
 		if err != nil {
 			return core.Doc{}, err
@@ -446,8 +447,11 @@ func (n *dagScanNode) addSignatureFieldToDoc(link cidlink.Link, commit *core.Doc
 	if err != nil {
 		return err
 	}
-	sigFieldIndex := n.commitSelect.DocumentMapping.IndexesByName[request.SignatureFieldName][0]
-	sigMapping := n.commitSelect.DocumentMapping.ChildMappings[sigFieldIndex]
+	sigFieldIndexes, exists := n.commitSelect.DocumentMapping.IndexesByName[request.SignatureFieldName]
+	if !exists {
+		return NewErrMissingFieldSelection(request.SignatureFieldName)
+	}
+	sigMapping := n.commitSelect.DocumentMapping.ChildMappings[sigFieldIndexes[0]]
 
 	sigDoc := sigMapping.NewDoc()
 	sigMapping.SetFirstOfName(&sigDoc, request.SignatureTypeFieldName, sigBlock.Header.Type)

--- a/internal/planner/errors.go
+++ b/internal/planner/errors.go
@@ -17,6 +17,7 @@ const (
 	errFailedToClosePlan              string = "failed to close the plan"
 	errFailedToCollectExecExplainInfo string = "failed to collect execution explain information"
 	errSubTypeInit                    string = "sub-type initialization error at scan node reset"
+	errMissingFieldSelection          string = "missing field selection"
 )
 
 var (
@@ -62,4 +63,8 @@ func NewErrMismatchLengthOnSimilarity(source, vector int) error {
 		errors.NewKV("Source", source),
 		errors.NewKV("Vector", vector),
 	)
+}
+
+func NewErrMissingFieldSelection(field string) error {
+	return errors.New(errMissingFieldSelection, errors.NewKV("Field", field))
 }

--- a/tests/integration/signature/query_test.go
+++ b/tests/integration/signature/query_test.go
@@ -58,3 +58,54 @@ func TestDocSignature_WithEnabledSigning_ShouldQuery(t *testing.T) {
 
 	testUtils.ExecuteTestCase(t, test)
 }
+
+func TestDocSignature_WithEnabledSigning_ShouldQueryCommitsWithoutSignature(t *testing.T) {
+	test := testUtils.TestCase{
+		EnableSigning: true,
+		Actions: []any{
+			&action.AddSchema{
+				Schema: `
+                    type Users {
+                        name: String
+                        age: Int
+                    }
+                `},
+			testUtils.CreateDoc{
+				Doc: `{
+					"name":	"John",
+					"age":	21
+				}`,
+			},
+			testUtils.Request{
+				Request: `
+                    query {
+                        Users {
+                            _docID
+                            name
+                            age
+
+							_version {
+								height
+							}
+                        }
+                    }`,
+				Results: map[string]any{
+					"Users": []map[string]any{
+						{
+							"_docID": testUtils.NewDocIndex(0, 0),
+							"name":   "John",
+							"age":    int64(21),
+							"_version": []map[string]any{
+								{
+									"height": 1,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4003 

## Description

When document/block signature are enabled, and you query for a `Commit` type without selecting the `signature` type, it will panic.

This is caused by the `addSignatureFieldToDoc` code *always* attempting to add the signature whenever the `Commit` type is requested, but if you don't include the `signature` type, the mapper indexer lookup panics as it doesn't exist.

Note: The fix is applied in two spots. Proactively to prevent adding the signature entirely, and again reactively when trying to add the signature.

The surprising thing is that this wasn't caught by the test suite. Turns out, the only tests that use the `EnableSigning` either A) Never query the `Commit` type without also including the `signature` field B) Use the builtin `testUtils.VerifyBlockSignature` and therefore skip this bug altogether.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Updated tests to cover this panic

Specify the platform(s) on which this was tested:
- Ubuntu (WSL)
