### PR TITLE
refactor: Make net.Host interface easier to consume

### DIFF
--- a/client/p2p.go
+++ b/client/p2p.go
@@ -106,8 +106,8 @@ type Host interface {
 	PeerInfo() PeerInfo
 	// Pubkey return the byte slice representation of the host's public key.
 	Pubkey() ([]byte, error)
-	// Connect tries to connect to the peer with the given [PeerInfo].
-	Connect(ctx context.Context, info PeerInfo) error
+	// Connect tries to connect to the peer with the given peer info.
+	Connect(ctx context.Context, id string, addresses []string) error
 	// Disconnect will try to disconnect from the peer with the given ID.
 	Disconnect(ctx context.Context, peerID string) error
 	// Send will try to send the given data to a peer.

--- a/client/p2p.go
+++ b/client/p2p.go
@@ -72,9 +72,9 @@ type P2P interface {
 	SyncDocuments(ctx context.Context, collectionName string, docIDs []string) error
 }
 
-type StreamHandler func(stream io.Reader, peerID string)
-type PubsubMessageHandler func(from string, topic string, msg []byte) ([]byte, error)
-type BlockAccessFunc func(ctx context.Context, peerID string, c cid.Cid) bool
+type StreamHandler = func(stream io.Reader, peerID string)
+type PubsubMessageHandler = func(from string, topic string, msg []byte) ([]byte, error)
+type BlockAccessFunc = func(ctx context.Context, peerID string, c cid.Cid) bool
 
 type PeerInfo struct {
 	ID        string

--- a/internal/db/p2p.go
+++ b/internal/db/p2p.go
@@ -37,7 +37,7 @@ func (db *DB) PeerInfo() client.PeerInfo {
 
 // Connect tries to connect to the peer with the given [PeerInfo].
 func (db *DB) Connect(ctx context.Context, info client.PeerInfo) error {
-	return db.p2p.Connect(ctx, info)
+	return db.p2p.Connect(ctx, info.ID, info.Addresses)
 }
 
 // SetReplicator adds a replicator to the persisted list or adds

--- a/internal/db/p2p/p2p.go
+++ b/internal/db/p2p/p2p.go
@@ -124,8 +124,8 @@ func (p *P2P) PeerInfo() client.PeerInfo {
 }
 
 // Connect initiates a connection to the peer with the given addresp.
-func (p *P2P) Connect(ctx context.Context, info client.PeerInfo) error {
-	return p.host.Connect(ctx, info)
+func (p *P2P) Connect(ctx context.Context, id string, addresses []string) error {
+	return p.host.Connect(ctx, id, addresses)
 }
 
 func (p *P2P) updateReplicators(ctx context.Context, rep client.PeerInfo, collectionIDs map[string]struct{}) {
@@ -135,7 +135,7 @@ func (p *P2P) updateReplicators(ctx context.Context, rep client.PeerInfo, collec
 			log.ErrorE("Failed to disconnect from replicator peer", err)
 		}
 	} else {
-		if err := p.host.Connect(ctx, rep); err != nil {
+		if err := p.host.Connect(ctx, rep.ID, rep.Addresses); err != nil {
 			log.ErrorE("Failed to connect to replicator peer", err)
 		}
 	}

--- a/net/host.go
+++ b/net/host.go
@@ -109,13 +109,13 @@ func (p *Peer) Pubkey() ([]byte, error) {
 	return crypto.MarshalPublicKey(p.host.Peerstore().PubKey(p.host.ID()))
 }
 
-func (p *Peer) Connect(ctx context.Context, info client.PeerInfo) error {
-	peerID, err := peer.Decode(info.ID)
+func (p *Peer) Connect(ctx context.Context, id string, addresses []string) error {
+	peerID, err := peer.Decode(id)
 	if err != nil {
 		return err
 	}
 	addrs := []ma.Multiaddr{}
-	for _, addr := range info.Addresses {
+	for _, addr := range addresses {
 		maddr, err := ma.NewMultiaddr(addr)
 		if err != nil {
 			return err

--- a/net/peer_test.go
+++ b/net/peer_test.go
@@ -48,7 +48,7 @@ func TestStart_WithKnownPeer_NoError(t *testing.T) {
 	require.NoError(t, err)
 	defer n2.Close()
 
-	err = n2.Connect(ctx, n1.PeerInfo())
+	err = n2.Connect(ctx, n1.PeerInfo().ID, n1.PeerInfo().Addresses)
 	require.NoError(t, err)
 }
 


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4007

## Description

Tweaks the `net.Host` interface easier to consume by removing elements that require direct reference to the exact concrete type.

This is required by Lens, so that a trimmed down `net.Host` interface can be consumed without making Lens dependant on Defra.  The alternative is to extract `net` to a new repository - this may be desirable long term, so Lens can spin up a `net.Host` instance, but even if we go that route I'd be in favour of this change as it allows external apps to consume the interface without a direct reference.

`net.Host.PeerInfo()` should now be the only interface member containing a a concrete custom type, I have left it, as this function is syntax sugar around `ID()` and `Addrs()` and is never going to be required by anything consuming the type.

The Lens code may be viewed in this PR: https://github.com/sourcenetwork/lens/pull/122 - see `host-go/p2p/host.go` for the re declaration of a subset of the `net.Host` interface. 
