### PR TITLE
fix: Passive sync with node chain

### DIFF
--- a/event/event.go
+++ b/event/event.go
@@ -91,6 +91,9 @@ type Update struct {
 
 	// IsRetry is true if this update is a retry of a previously failed update.
 	IsRetry bool
+
+	// Is relay is set to true if this update is created from a P2P sync.
+	IsRelay bool
 }
 
 // Merge is a notification that a merge can be performed up to the provided CID.

--- a/internal/core/block/errors.go
+++ b/internal/core/block/errors.go
@@ -66,6 +66,7 @@ var (
 	ErrFailedToGetNextQResult      = errors.New(errFailedToGetNextQResult)
 	ErrDecodingHeight              = errors.New("error decoding height")
 	ErrCouldNotGetEncKey           = errors.New(errCouldNotGetEncKey)
+	ErrMarkingAsMerged             = errors.New("failed to mark block as merged")
 )
 
 // NewErrFailedToGetPriority returns an error indicating that the priority could not be retrieved.
@@ -152,4 +153,8 @@ func NewErrFailedToGetNextQResult(inner error) error {
 
 func NewErrUnsupportedKeyForSigning(keyType crypto.KeyType) error {
 	return errors.New(errUnsupportedKeyForSigning, errors.NewKV("KeyType", keyType))
+}
+
+func NewErrMarkingAsMerged(cid cid.Cid, inner error) error {
+	return errors.WithStack(errors.Join(ErrMarkingAsMerged, inner), errors.NewKV("Cid", cid))
 }

--- a/internal/core/block/store.go
+++ b/internal/core/block/store.go
@@ -226,11 +226,21 @@ func updateHeads(
 		}
 	}
 
+	err := txn.Blockstore().MarkAsMerged(ctx, blockLink.Cid)
+	if err != nil {
+		return NewErrMarkingAsMerged(blockLink.Cid, err)
+	}
+
 	for _, l := range block.AllLinks() {
 		linkCid := l.Cid
 		isHead, err := headset.IsHead(ctx, linkCid)
 		if err != nil {
 			return NewErrCheckingHead(linkCid, err)
+		}
+
+		err = txn.Blockstore().MarkAsMerged(ctx, blockLink.Cid)
+		if err != nil {
+			return NewErrMarkingAsMerged(blockLink.Cid, err)
 		}
 
 		if isHead {

--- a/internal/core/block/store.go
+++ b/internal/core/block/store.go
@@ -238,7 +238,7 @@ func updateHeads(
 			return NewErrCheckingHead(linkCid, err)
 		}
 
-		err = txn.Blockstore().MarkAsMerged(ctx, blockLink.Cid)
+		err = txn.Blockstore().MarkAsMerged(ctx, linkCid)
 		if err != nil {
 			return NewErrMarkingAsMerged(blockLink.Cid, err)
 		}

--- a/internal/core/block/store.go
+++ b/internal/core/block/store.go
@@ -226,6 +226,8 @@ func updateHeads(
 		}
 	}
 
+	// Marking the block as merged removes the to-merge index. It signals that nothing
+	// else needs to be done for that block.
 	err := txn.Blockstore().MarkAsMerged(ctx, blockLink.Cid)
 	if err != nil {
 		return NewErrMarkingAsMerged(blockLink.Cid, err)
@@ -238,6 +240,8 @@ func updateHeads(
 			return NewErrCheckingHead(linkCid, err)
 		}
 
+		// Marking the block as merged removes the to-merge index. It signals that nothing
+		// else needs to be done for that block.
 		err = txn.Blockstore().MarkAsMerged(ctx, linkCid)
 		if err != nil {
 			return NewErrMarkingAsMerged(blockLink.Cid, err)

--- a/internal/datastore/blockstore.go
+++ b/internal/datastore/blockstore.go
@@ -11,7 +11,6 @@
 package datastore
 
 import (
-	"bytes"
 	"context"
 
 	"github.com/ipfs/boxo/blockstore"
@@ -84,13 +83,9 @@ func (bs *bstore) Get(ctx context.Context, k cid.Cid) (blocks.Block, error) {
 	if !k.Defined() {
 		return nil, ipld.ErrNotFound{Cid: k}
 	}
-	mergedKey, notMergedKey := getKeys(k)
-	bdata, err := bs.store.Get(ctx, mergedKey)
+	bdata, err := bs.store.Get(ctx, dshelp.MultihashToDsKey(k.Hash()).Bytes())
 	if errors.Is(err, corekv.ErrNotFound) {
-		bdata, err = bs.store.Get(ctx, notMergedKey)
-		if errors.Is(err, corekv.ErrNotFound) {
-			return nil, ipld.ErrNotFound{Cid: k}
-		}
+		return nil, ipld.ErrNotFound{Cid: k}
 	}
 	if err != nil {
 		return nil, err
@@ -112,34 +107,26 @@ func (bs *bstore) Get(ctx context.Context, k cid.Cid) (blocks.Block, error) {
 
 // Put stores a block to the blockstore.
 func (bs *bstore) Put(ctx context.Context, block blocks.Block) error {
-	mergedKey, notMergedKey := getKeys(block.Cid())
+	k := dshelp.MultihashToDsKey(block.Cid().Hash())
 
 	// Has is cheaper than Set, so see if we already have it
-	exists, err := bs.store.Has(ctx, mergedKey)
+	exists, err := bs.store.Has(ctx, k.Bytes())
 	if err == nil && exists {
 		return nil // already stored.
 	}
-	exists, err = bs.store.Has(ctx, notMergedKey)
-	if err == nil && exists {
-		return nil // already stored.
-	}
-	return bs.store.Set(ctx, notMergedKey, block.RawData())
+	return bs.store.Set(ctx, k.Bytes(), block.RawData())
 }
 
 // PutMany stores multiple blocks to the blockstore.
 func (bs *bstore) PutMany(ctx context.Context, blocks []blocks.Block) error {
 	for _, b := range blocks {
-		mergedKey, notMergedKey := getKeys(b.Cid())
-		exists, err := bs.store.Has(ctx, mergedKey)
-		if err == nil && exists {
-			continue
-		}
-		exists, err = bs.store.Has(ctx, notMergedKey)
+		k := dshelp.MultihashToDsKey(b.Cid().Hash())
+		exists, err := bs.store.Has(ctx, k.Bytes())
 		if err == nil && exists {
 			continue
 		}
 
-		err = bs.store.Set(ctx, notMergedKey, b.RawData())
+		err = bs.store.Set(ctx, k.Bytes(), b.RawData())
 		if err != nil {
 			return err
 		}
@@ -149,35 +136,21 @@ func (bs *bstore) PutMany(ctx context.Context, blocks []blocks.Block) error {
 
 // Has returns whether a block is stored in the blockstore.
 func (bs *bstore) Has(ctx context.Context, k cid.Cid) (bool, error) {
-	mergedKey, notMergedKey := getKeys(k)
-	exists, err := bs.store.Has(ctx, mergedKey)
-	if err == nil && exists {
-		return true, nil
-	}
-	return bs.store.Has(ctx, notMergedKey)
+	return bs.store.Has(ctx, dshelp.MultihashToDsKey(k.Hash()).Bytes())
 }
 
 // GetSize returns the size of a block in the blockstore.
 func (bs *bstore) GetSize(ctx context.Context, k cid.Cid) (int, error) {
-	mergedKey, notMergedKey := getKeys(k)
-	buf, err := bs.store.Get(ctx, mergedKey)
+	buf, err := bs.store.Get(ctx, dshelp.MultihashToDsKey(k.Hash()).Bytes())
 	if errors.Is(err, corekv.ErrNotFound) {
-		buf, err = bs.store.Get(ctx, notMergedKey)
-		if errors.Is(err, corekv.ErrNotFound) {
-			return -1, ipld.ErrNotFound{Cid: k}
-		}
+		return -1, ipld.ErrNotFound{Cid: k}
 	}
 	return len(buf), err
 }
 
 // DeleteBlock removes a block from the blockstore.
 func (bs *bstore) DeleteBlock(ctx context.Context, k cid.Cid) error {
-	mergedKey, notMergedKey := getKeys(k)
-	err := bs.store.Delete(ctx, mergedKey)
-	if errors.Is(err, corekv.ErrNotFound) {
-		return bs.store.Delete(ctx, notMergedKey)
-	}
-	return err
+	return bs.store.Delete(ctx, dshelp.MultihashToDsKey(k.Hash()).Bytes())
 }
 
 // AllKeysChan runs a query for keys from the blockstore.
@@ -213,7 +186,8 @@ func (bs *bstore) AllKeysChan(ctx context.Context) (<-chan cid.Cid, error) {
 				break
 			}
 
-			key := cleanKey(iter.Key())
+			key := iter.Key()
+
 			hash, err := dshelp.DsKeyToMultihash(ds.RawKey(string(key)))
 			if err != nil {
 				log.ErrorContextE(ctx, "Error parsing key from binary", err)
@@ -231,45 +205,72 @@ func (bs *bstore) AllKeysChan(ctx context.Context) (<-chan cid.Cid, error) {
 	return output, nil
 }
 
-// MarkAsMerged sets a block as merged.
-func (bs *bstore) MarkAsMerged(ctx context.Context, k cid.Cid) error {
-	mergedKey, notMergedKey := getKeys(k)
-	exists, err := bs.store.Has(ctx, mergedKey)
+const (
+	objectMarker       = byte(0xff)
+	toMergeIndexPrefix = "/tm"
+)
+
+func newToMergeKey(cid string) []byte {
+	return []byte(toMergeIndexPrefix + "/" + cid)
+}
+
+func (bs *bstore) IsMerged(ctx context.Context, cid cid.Cid) (bool, error) {
+	hasBlock, err := bs.Has(ctx, cid)
+	if err != nil {
+		return false, err
+	}
+	if !hasBlock {
+		return false, nil
+	}
+	notMerged, err := bs.store.Has(ctx, newToMergeKey(cid.String()))
+	if err != nil {
+		return false, err
+	}
+	return !notMerged, nil
+}
+
+func (bs *bstore) MarkAsMerged(ctx context.Context, cid cid.Cid) error {
+	return bs.store.Delete(ctx, newToMergeKey(cid.String()))
+}
+
+type p2pBlockStore struct {
+	*bstore
+}
+
+var _ Blockstore = (*p2pBlockStore)(nil)
+
+// Put stores a block to the blockstore.
+func (bs *p2pBlockStore) Put(ctx context.Context, block blocks.Block) error {
+	k := dshelp.MultihashToDsKey(block.Cid().Hash())
+
+	// Has is cheaper than Set, so see if we already have it
+	exists, err := bs.store.Has(ctx, k.Bytes())
 	if err == nil && exists {
-		// already marked as merged
-		return nil
+		return nil // already stored.
 	}
-	data, err := bs.store.Get(ctx, notMergedKey)
-	if errors.Is(err, corekv.ErrNotFound) {
-		return ipld.ErrNotFound{Cid: k}
-	}
-	err = bs.store.Delete(ctx, notMergedKey)
+	err = bs.store.Set(ctx, newToMergeKey(block.Cid().String()), []byte{objectMarker})
 	if err != nil {
 		return err
 	}
-	return bs.store.Set(ctx, mergedKey, data)
+	return bs.store.Set(ctx, k.Bytes(), block.RawData())
 }
 
-// IsMerged returns whether a block has been marked as merged.
-func (bs *bstore) IsMerged(ctx context.Context, k cid.Cid) (bool, error) {
-	mergedKey, _ := getKeys(k)
-	exists, err := bs.store.Has(ctx, mergedKey)
-	if err == nil && exists {
-		// already marked as merged
-		return true, nil
+// PutMany stores multiple blocks to the blockstore.
+func (bs *p2pBlockStore) PutMany(ctx context.Context, blocks []blocks.Block) error {
+	for _, b := range blocks {
+		k := dshelp.MultihashToDsKey(b.Cid().Hash())
+		exists, err := bs.store.Has(ctx, k.Bytes())
+		if err == nil && exists {
+			continue
+		}
+		err = bs.store.Set(ctx, newToMergeKey(b.Cid().String()), []byte{objectMarker})
+		if err != nil {
+			return err
+		}
+		err = bs.store.Set(ctx, k.Bytes(), b.RawData())
+		if err != nil {
+			return err
+		}
 	}
-	return false, err
-}
-
-// getKeys returns both the mergedKey and the notMergedKey for a given cid.
-func getKeys(k cid.Cid) (mergedKey, notMergedKey []byte) {
-	key := dshelp.MultihashToDsKey(k.Hash())
-	mergedKey = append(key.Bytes(), []byte("/1")...)
-	notMergedKey = append(key.Bytes(), []byte("/0")...)
-	return mergedKey, notMergedKey
-}
-
-// cleanKey removes the merged or notMerged suffix from the key.
-func cleanKey(key []byte) []byte {
-	return bytes.TrimSuffix(bytes.TrimSuffix(key, []byte("/0")), []byte("/1"))
+	return nil
 }

--- a/internal/datastore/blockstore.go
+++ b/internal/datastore/blockstore.go
@@ -11,6 +11,7 @@
 package datastore
 
 import (
+	"bytes"
 	"context"
 
 	"github.com/ipfs/boxo/blockstore"
@@ -83,9 +84,13 @@ func (bs *bstore) Get(ctx context.Context, k cid.Cid) (blocks.Block, error) {
 	if !k.Defined() {
 		return nil, ipld.ErrNotFound{Cid: k}
 	}
-	bdata, err := bs.store.Get(ctx, dshelp.MultihashToDsKey(k.Hash()).Bytes())
+	mergedKey, notMergedKey := getKeys(k)
+	bdata, err := bs.store.Get(ctx, mergedKey)
 	if errors.Is(err, corekv.ErrNotFound) {
-		return nil, ipld.ErrNotFound{Cid: k}
+		bdata, err = bs.store.Get(ctx, notMergedKey)
+		if errors.Is(err, corekv.ErrNotFound) {
+			return nil, ipld.ErrNotFound{Cid: k}
+		}
 	}
 	if err != nil {
 		return nil, err
@@ -107,26 +112,34 @@ func (bs *bstore) Get(ctx context.Context, k cid.Cid) (blocks.Block, error) {
 
 // Put stores a block to the blockstore.
 func (bs *bstore) Put(ctx context.Context, block blocks.Block) error {
-	k := dshelp.MultihashToDsKey(block.Cid().Hash())
+	mergedKey, notMergedKey := getKeys(block.Cid())
 
 	// Has is cheaper than Set, so see if we already have it
-	exists, err := bs.store.Has(ctx, k.Bytes())
+	exists, err := bs.store.Has(ctx, mergedKey)
 	if err == nil && exists {
 		return nil // already stored.
 	}
-	return bs.store.Set(ctx, k.Bytes(), block.RawData())
+	exists, err = bs.store.Has(ctx, notMergedKey)
+	if err == nil && exists {
+		return nil // already stored.
+	}
+	return bs.store.Set(ctx, notMergedKey, block.RawData())
 }
 
 // PutMany stores multiple blocks to the blockstore.
 func (bs *bstore) PutMany(ctx context.Context, blocks []blocks.Block) error {
 	for _, b := range blocks {
-		k := dshelp.MultihashToDsKey(b.Cid().Hash())
-		exists, err := bs.store.Has(ctx, k.Bytes())
+		mergedKey, notMergedKey := getKeys(b.Cid())
+		exists, err := bs.store.Has(ctx, mergedKey)
+		if err == nil && exists {
+			continue
+		}
+		exists, err = bs.store.Has(ctx, notMergedKey)
 		if err == nil && exists {
 			continue
 		}
 
-		err = bs.store.Set(ctx, k.Bytes(), b.RawData())
+		err = bs.store.Set(ctx, notMergedKey, b.RawData())
 		if err != nil {
 			return err
 		}
@@ -136,21 +149,35 @@ func (bs *bstore) PutMany(ctx context.Context, blocks []blocks.Block) error {
 
 // Has returns whether a block is stored in the blockstore.
 func (bs *bstore) Has(ctx context.Context, k cid.Cid) (bool, error) {
-	return bs.store.Has(ctx, dshelp.MultihashToDsKey(k.Hash()).Bytes())
+	mergedKey, notMergedKey := getKeys(k)
+	exists, err := bs.store.Has(ctx, mergedKey)
+	if err == nil && exists {
+		return true, nil
+	}
+	return bs.store.Has(ctx, notMergedKey)
 }
 
 // GetSize returns the size of a block in the blockstore.
 func (bs *bstore) GetSize(ctx context.Context, k cid.Cid) (int, error) {
-	buf, err := bs.store.Get(ctx, dshelp.MultihashToDsKey(k.Hash()).Bytes())
+	mergedKey, notMergedKey := getKeys(k)
+	buf, err := bs.store.Get(ctx, mergedKey)
 	if errors.Is(err, corekv.ErrNotFound) {
-		return -1, ipld.ErrNotFound{Cid: k}
+		buf, err = bs.store.Get(ctx, notMergedKey)
+		if errors.Is(err, corekv.ErrNotFound) {
+			return -1, ipld.ErrNotFound{Cid: k}
+		}
 	}
 	return len(buf), err
 }
 
 // DeleteBlock removes a block from the blockstore.
 func (bs *bstore) DeleteBlock(ctx context.Context, k cid.Cid) error {
-	return bs.store.Delete(ctx, dshelp.MultihashToDsKey(k.Hash()).Bytes())
+	mergedKey, notMergedKey := getKeys(k)
+	err := bs.store.Delete(ctx, mergedKey)
+	if errors.Is(err, corekv.ErrNotFound) {
+		return bs.store.Delete(ctx, notMergedKey)
+	}
+	return err
 }
 
 // AllKeysChan runs a query for keys from the blockstore.
@@ -186,8 +213,7 @@ func (bs *bstore) AllKeysChan(ctx context.Context) (<-chan cid.Cid, error) {
 				break
 			}
 
-			key := iter.Key()
-
+			key := cleanKey(iter.Key())
 			hash, err := dshelp.DsKeyToMultihash(ds.RawKey(string(key)))
 			if err != nil {
 				log.ErrorContextE(ctx, "Error parsing key from binary", err)
@@ -203,4 +229,47 @@ func (bs *bstore) AllKeysChan(ctx context.Context) (<-chan cid.Cid, error) {
 	}()
 
 	return output, nil
+}
+
+// MarkAsMerged sets a block as merged.
+func (bs *bstore) MarkAsMerged(ctx context.Context, k cid.Cid) error {
+	mergedKey, notMergedKey := getKeys(k)
+	exists, err := bs.store.Has(ctx, mergedKey)
+	if err == nil && exists {
+		// already marked as merged
+		return nil
+	}
+	data, err := bs.store.Get(ctx, notMergedKey)
+	if errors.Is(err, corekv.ErrNotFound) {
+		return ipld.ErrNotFound{Cid: k}
+	}
+	err = bs.store.Delete(ctx, notMergedKey)
+	if err != nil {
+		return err
+	}
+	return bs.store.Set(ctx, mergedKey, data)
+}
+
+// IsMerged returns whether a block has been marked as merged.
+func (bs *bstore) IsMerged(ctx context.Context, k cid.Cid) (bool, error) {
+	mergedKey, _ := getKeys(k)
+	exists, err := bs.store.Has(ctx, mergedKey)
+	if err == nil && exists {
+		// already marked as merged
+		return true, nil
+	}
+	return false, err
+}
+
+// getKeys returns both the mergedKey and the notMergedKey for a given cid.
+func getKeys(k cid.Cid) (mergedKey, notMergedKey []byte) {
+	key := dshelp.MultihashToDsKey(k.Hash())
+	mergedKey = append(key.Bytes(), []byte("/1")...)
+	notMergedKey = append(key.Bytes(), []byte("/0")...)
+	return mergedKey, notMergedKey
+}
+
+// cleanKey removes the merged or notMerged suffix from the key.
+func cleanKey(key []byte) []byte {
+	return bytes.TrimSuffix(bytes.TrimSuffix(key, []byte("/0")), []byte("/1"))
 }

--- a/internal/datastore/mocks/blockstore.go
+++ b/internal/datastore/mocks/blockstore.go
@@ -445,6 +445,129 @@ func (_c *Blockstore_HashOnRead_Call) RunAndReturn(run func(enabled bool)) *Bloc
 	return _c
 }
 
+// IsMerged provides a mock function for the type Blockstore
+func (_mock *Blockstore) IsMerged(ctx context.Context, k cid.Cid) (bool, error) {
+	ret := _mock.Called(ctx, k)
+
+	if len(ret) == 0 {
+		panic("no return value specified for IsMerged")
+	}
+
+	var r0 bool
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, cid.Cid) (bool, error)); ok {
+		return returnFunc(ctx, k)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, cid.Cid) bool); ok {
+		r0 = returnFunc(ctx, k)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, cid.Cid) error); ok {
+		r1 = returnFunc(ctx, k)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// Blockstore_IsMerged_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsMerged'
+type Blockstore_IsMerged_Call struct {
+	*mock.Call
+}
+
+// IsMerged is a helper method to define mock.On call
+//   - ctx context.Context
+//   - k cid.Cid
+func (_e *Blockstore_Expecter) IsMerged(ctx interface{}, k interface{}) *Blockstore_IsMerged_Call {
+	return &Blockstore_IsMerged_Call{Call: _e.mock.On("IsMerged", ctx, k)}
+}
+
+func (_c *Blockstore_IsMerged_Call) Run(run func(ctx context.Context, k cid.Cid)) *Blockstore_IsMerged_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 cid.Cid
+		if args[1] != nil {
+			arg1 = args[1].(cid.Cid)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *Blockstore_IsMerged_Call) Return(b bool, err error) *Blockstore_IsMerged_Call {
+	_c.Call.Return(b, err)
+	return _c
+}
+
+func (_c *Blockstore_IsMerged_Call) RunAndReturn(run func(ctx context.Context, k cid.Cid) (bool, error)) *Blockstore_IsMerged_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// MarkAsMerged provides a mock function for the type Blockstore
+func (_mock *Blockstore) MarkAsMerged(ctx context.Context, k cid.Cid) error {
+	ret := _mock.Called(ctx, k)
+
+	if len(ret) == 0 {
+		panic("no return value specified for MarkAsMerged")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, cid.Cid) error); ok {
+		r0 = returnFunc(ctx, k)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// Blockstore_MarkAsMerged_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'MarkAsMerged'
+type Blockstore_MarkAsMerged_Call struct {
+	*mock.Call
+}
+
+// MarkAsMerged is a helper method to define mock.On call
+//   - ctx context.Context
+//   - k cid.Cid
+func (_e *Blockstore_Expecter) MarkAsMerged(ctx interface{}, k interface{}) *Blockstore_MarkAsMerged_Call {
+	return &Blockstore_MarkAsMerged_Call{Call: _e.mock.On("MarkAsMerged", ctx, k)}
+}
+
+func (_c *Blockstore_MarkAsMerged_Call) Run(run func(ctx context.Context, k cid.Cid)) *Blockstore_MarkAsMerged_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 cid.Cid
+		if args[1] != nil {
+			arg1 = args[1].(cid.Cid)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *Blockstore_MarkAsMerged_Call) Return(err error) *Blockstore_MarkAsMerged_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *Blockstore_MarkAsMerged_Call) RunAndReturn(run func(ctx context.Context, k cid.Cid) error) *Blockstore_MarkAsMerged_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Put provides a mock function for the type Blockstore
 func (_mock *Blockstore) Put(context1 context.Context, block blocks.Block) error {
 	ret := _mock.Called(context1, block)

--- a/internal/datastore/multi.go
+++ b/internal/datastore/multi.go
@@ -93,6 +93,12 @@ func BlockstoreFrom(rootstore corekv.ReaderWriter) Blockstore {
 	return newBlockstore(prefix(rootstore, blockStoreKey.Bytes()))
 }
 
+func P2PBlockstoreFrom(rootstore corekv.ReaderWriter) Blockstore {
+	return &p2pBlockStore{
+		bstore: newBlockstore(prefix(rootstore, blockStoreKey.Bytes())),
+	}
+}
+
 func SystemstoreFrom(rootstore corekv.ReaderWriter) corekv.ReaderWriter {
 	return prefix(rootstore, systemStoreKey.Bytes())
 }

--- a/internal/datastore/store.go
+++ b/internal/datastore/store.go
@@ -11,7 +11,10 @@
 package datastore
 
 import (
+	"context"
+
 	"github.com/ipfs/boxo/blockstore"
+	"github.com/ipfs/go-cid"
 	"github.com/ipld/go-ipld-prime/storage"
 
 	"github.com/sourcenetwork/corekv"
@@ -27,6 +30,8 @@ var (
 type Blockstore interface {
 	blockstore.Blockstore
 	AsIPLDStorage() IPLDStorage
+	MarkAsMerged(ctx context.Context, k cid.Cid) error
+	IsMerged(ctx context.Context, k cid.Cid) (bool, error)
 }
 
 // IPLDStorage provides the methods needed for an IPLD LinkSystem.

--- a/internal/datastore/store.go
+++ b/internal/datastore/store.go
@@ -30,7 +30,10 @@ var (
 type Blockstore interface {
 	blockstore.Blockstore
 	AsIPLDStorage() IPLDStorage
+	// Mark the block as merged by removing the to-merge index.
 	MarkAsMerged(ctx context.Context, k cid.Cid) error
+	// Check if the block has been merged. It will return false if either the CID is not found
+	// or the CID is found AND the to-mege index is aslo found.
 	IsMerged(ctx context.Context, k cid.Cid) (bool, error)
 }
 

--- a/internal/db/config.go
+++ b/internal/db/config.go
@@ -30,6 +30,8 @@ type dbOptions struct {
 	disableSigning bool
 	p2p            immutable.Option[client.Host]
 	retryIntervals []time.Duration
+	// timeout duration for syncing block links.
+	p2pBlockSyncTimeout time.Duration
 }
 
 func defaultDBOptions() *dbOptions {
@@ -45,6 +47,7 @@ func defaultDBOptions() *dbOptions {
 			time.Minute * 16,
 			time.Minute * 32,
 		},
+		p2pBlockSyncTimeout: time.Second * 5,
 	}
 }
 
@@ -83,5 +86,11 @@ func WithRetryInterval(interval []time.Duration) Option {
 func WithP2P(host client.Host) Option {
 	return func(opts *dbOptions) {
 		opts.p2p = immutable.Some(host)
+	}
+}
+
+func WithP2PBlockSyncTimeout(timeout time.Duration) Option {
+	return func(opt *dbOptions) {
+		opt.p2pBlockSyncTimeout = timeout
 	}
 }

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -98,6 +98,8 @@ type DB struct {
 	p2p *p2p.P2P
 	// Retry intervals when a replicator failure occurs.
 	retryIntervals []time.Duration
+	// timeout duration for syncing block links.
+	p2pBlockSyncTimeout time.Duration
 }
 
 var _ client.TxnStore = (*DB)(nil)
@@ -135,17 +137,18 @@ func newDB(
 	ctx, cancel := context.WithCancel(ctx)
 
 	db := &DB{
-		rootstore:      rootstore,
-		nodeACP:        nodeACP,
-		documentACP:    documentACP,
-		lensRegistry:   lens,
-		parser:         parser,
-		options:        options,
-		events:         event.NewChannelBus(commandBufferSize, eventBufferSize),
-		ctxCancel:      cancel,
-		docMergeQueue:  newMergeQueue(),
-		colMergeQueue:  newMergeQueue(),
-		retryIntervals: opts.retryIntervals,
+		rootstore:           rootstore,
+		nodeACP:             nodeACP,
+		documentACP:         documentACP,
+		lensRegistry:        lens,
+		parser:              parser,
+		options:             options,
+		events:              event.NewChannelBus(commandBufferSize, eventBufferSize),
+		ctxCancel:           cancel,
+		docMergeQueue:       newMergeQueue(),
+		colMergeQueue:       newMergeQueue(),
+		retryIntervals:      opts.retryIntervals,
+		p2pBlockSyncTimeout: opts.p2pBlockSyncTimeout,
 	}
 
 	if opts.maxTxnRetries.HasValue() {
@@ -463,6 +466,11 @@ func (db *DB) MaxTxnRetries() int {
 // RetryIntervals returns the replicator retry configuration.
 func (db *DB) RetryIntervals() []time.Duration {
 	return db.retryIntervals
+}
+
+// P2PBlockSyncTimeout is the timeout duration for syncing block links.
+func (db *DB) P2PBlockSyncTimeout() time.Duration {
+	return db.p2pBlockSyncTimeout
 }
 
 // PrintDump prints the entire database to console.

--- a/internal/db/p2p/p2p.go
+++ b/internal/db/p2p/p2p.go
@@ -402,9 +402,9 @@ func (p *P2P) processPushlogRequest(
 	// underlying pubsub topic and this brings along potential pitfalls. One of them being that
 	// if this initial sync call had a negative response for a given link, the subsequent calls will
 	// assume a negative response for that same link without retrying.
-	p.processQueue.add(headCID.String())
+	p.processQueue.add(headCID)
 	err = p.syncDAG(ctx, p.host.BlockService(), block)
-	p.processQueue.done(headCID.String())
+	p.processQueue.done(headCID)
 	if err != nil {
 		return err
 	}
@@ -481,13 +481,13 @@ func (p *P2P) SendUpdate(evt event.Update) error {
 // processQueue is synchronization source to ensure that concurrent
 // document merges do not cause transaction conflicts.
 type processQueue struct {
-	cids  map[string]chan struct{}
+	cids  map[cid.Cid]chan struct{}
 	mutex sync.Mutex
 }
 
 func newProcessQueue() *processQueue {
 	return &processQueue{
-		cids: make(map[string]chan struct{}),
+		cids: make(map[cid.Cid]chan struct{}),
 	}
 }
 
@@ -495,7 +495,7 @@ func newProcessQueue() *processQueue {
 // wait for the cid to be removed from the queue. For every add call, done must
 // be called to remove the cid from the queue. Otherwise, subsequent add calls will
 // block forever.
-func (m *processQueue) add(cid string) {
+func (m *processQueue) add(cid cid.Cid) {
 	for {
 		m.mutex.Lock()
 		done, ok := m.cids[cid]
@@ -509,7 +509,7 @@ func (m *processQueue) add(cid string) {
 	}
 }
 
-func (m *processQueue) done(cid string) {
+func (m *processQueue) done(cid cid.Cid) {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 	done, ok := m.cids[cid]

--- a/internal/db/p2p/p2p.go
+++ b/internal/db/p2p/p2p.go
@@ -59,6 +59,8 @@ type DB interface {
 	RetryIntervals() []time.Duration
 	// DocumentACP returns the DocumentACP implementation configured on the database.
 	DocumentACP() immutable.Option[dac.DocumentACP]
+	// P2PBlockSyncTimeout is the timeout duration for syncing block links.
+	P2PBlockSyncTimeout() time.Duration
 }
 
 type P2P struct {
@@ -83,19 +85,23 @@ type P2P struct {
 
 	// a cid queue for the processing of Pushlogs
 	processQueue *processQueue
+
+	// timeout duration for syncing block links.
+	syncBlockLinkTimeout time.Duration
 }
 
 // New returns a new configured P2P instance.
 func New(ctx context.Context, db DB, host client.Host) (*P2P, error) {
 	p := P2P{
-		ctx:              ctx,
-		db:               db,
-		host:             host,
-		identityProtocol: protocol.NewIdentityProtocol(host, db.GetNodeIdentityToken),
-		replicators:      make(map[string]map[string]client.PeerInfo),
-		peerIdentities:   make(map[string]identity.Identity),
-		retryIntervals:   db.RetryIntervals(),
-		processQueue:     newProcessQueue(),
+		ctx:                  ctx,
+		db:                   db,
+		host:                 host,
+		identityProtocol:     protocol.NewIdentityProtocol(host, db.GetNodeIdentityToken),
+		replicators:          make(map[string]map[string]client.PeerInfo),
+		peerIdentities:       make(map[string]identity.Identity),
+		retryIntervals:       db.RetryIntervals(),
+		processQueue:         newProcessQueue(),
+		syncBlockLinkTimeout: db.P2PBlockSyncTimeout(),
 	}
 	p.replicatorProtocol = protocol.NewReplicatorProtocol(host, p.processPushlogRequest, p.handleReplicatorFailure)
 
@@ -377,14 +383,28 @@ func (p *P2P) processPushlogRequest(
 		return err
 	}
 
+	// Check if we've already merged this block. If so, skip the sink process.
+	txn, err := p.db.NewTxn(ctx, true)
+	if err != nil {
+		return err
+	}
+	defer txn.Discard(ctx)
+	clientTxn := datastore.MustGetFromClientTxn(txn)
+	merged, err := clientTxn.Blockstore().IsMerged(ctx, headCID)
+	if err != nil {
+		return err
+	}
+	if merged {
+		return nil
+	}
+
 	// Calls to syncDAG should not overlap for a given CID. If they do, they will use the same
 	// underlying pubsub topic and this brings along potential pitfalls. One of them being that
 	// if this initial sync call had a negative response for a given link, the subsequent calls will
 	// assume a negative response for that same link without retrying.
 	p.processQueue.add(headCID.String())
-	defer p.processQueue.done(headCID.String())
-
-	err = syncDAG(ctx, p.host.BlockService(), block)
+	err = p.syncDAG(ctx, p.host.BlockService(), block)
+	p.processQueue.done(headCID.String())
 	if err != nil {
 		return err
 	}
@@ -475,15 +495,16 @@ func newProcessQueue() *processQueue {
 // be called to remove the cid from the queue. Otherwise, subsequent add calls will
 // block forever.
 func (m *processQueue) add(cid string) {
-	m.mutex.Lock()
-	done, ok := m.cids[cid]
-	if !ok {
-		m.cids[cid] = make(chan struct{})
-	}
-	m.mutex.Unlock()
-	if ok {
+	for {
+		m.mutex.Lock()
+		done, ok := m.cids[cid]
+		if !ok {
+			m.cids[cid] = make(chan struct{})
+			m.mutex.Unlock()
+			return
+		}
+		m.mutex.Unlock()
 		<-done
-		m.add(cid)
 	}
 }
 

--- a/internal/db/p2p/p2p.go
+++ b/internal/db/p2p/p2p.go
@@ -388,13 +388,13 @@ func (p *P2P) processPushlogRequest(
 	if err != nil {
 		return err
 	}
-	defer txn.Discard(ctx)
 	clientTxn := datastore.MustGetFromClientTxn(txn)
-	merged, err := clientTxn.Blockstore().IsMerged(ctx, headCID)
+	isMerged, err := clientTxn.Blockstore().IsMerged(ctx, headCID)
+	txn.Discard(ctx)
 	if err != nil {
 		return err
 	}
-	if merged {
+	if isMerged {
 		return nil
 	}
 

--- a/internal/db/p2p/p2p.go
+++ b/internal/db/p2p/p2p.go
@@ -80,6 +80,9 @@ type P2P struct {
 	// For example, this can define an exponential backoff strategy.
 	retryIntervals   []time.Duration
 	handleRetryMutex sync.Mutex
+
+	// a cid queue for the processing of Pushlogs
+	processQueue *processQueue
 }
 
 // New returns a new configured P2P instance.
@@ -92,6 +95,7 @@ func New(ctx context.Context, db DB, host client.Host) (*P2P, error) {
 		replicators:      make(map[string]map[string]client.PeerInfo),
 		peerIdentities:   make(map[string]identity.Identity),
 		retryIntervals:   db.RetryIntervals(),
+		processQueue:     newProcessQueue(),
 	}
 	p.replicatorProtocol = protocol.NewReplicatorProtocol(host, p.processPushlogRequest, p.handleReplicatorFailure)
 
@@ -368,12 +372,19 @@ func (p *P2P) processPushlogRequest(
 		}
 	}
 
-	err = syncDAG(ctx, p.host.BlockService(), block)
+	headCID, err := cid.Cast(req.CID)
 	if err != nil {
 		return err
 	}
 
-	headCID, err := cid.Cast(req.CID)
+	// Calls to syncDAG should not overlap for a given CID. If they do, they will use the same
+	// underlying pubsub topic and this brings along potential pitfalls. One of them being that
+	// if this initial sync call had a negative response for a given link, the subsequent calls will
+	// assume a negative response for that same link without retrying.
+	p.processQueue.add(headCID.String())
+	defer p.processQueue.done(headCID.String())
+
+	err = syncDAG(ctx, p.host.BlockService(), block)
 	if err != nil {
 		return err
 	}
@@ -395,6 +406,20 @@ func (p *P2P) processPushlogRequest(
 				corelog.Any("Event", evt))
 		}
 	}()
+
+	// Notify bus subscribers and the network of peers that we have a new document available.
+	evt := event.Update{
+		DocID:        req.DocID,
+		Cid:          headCID,
+		CollectionID: req.CollectionID,
+		Block:        req.Block,
+	}
+	p.db.Events().Publish(event.NewMessage(event.UpdateName, evt))
+	if err := p.SendUpdate(evt); err != nil {
+		// We don't need to return the error for this side-effect-function call.
+		// It's a bonus action that shouldn't affect the caller of `processPuslogRequest`.
+		log.ErrorE("Failed to send update after sync", err)
+	}
 
 	return nil
 }
@@ -430,4 +455,44 @@ func (p *P2P) SendUpdate(evt event.Update) error {
 	}
 
 	return nil
+}
+
+// processQueue is synchronization source to ensure that concurrent
+// document merges do not cause transaction conflicts.
+type processQueue struct {
+	cids  map[string]chan struct{}
+	mutex sync.Mutex
+}
+
+func newProcessQueue() *processQueue {
+	return &processQueue{
+		cids: make(map[string]chan struct{}),
+	}
+}
+
+// add adds a cid to the queue. If the cid is already in the queue, it will
+// wait for the cid to be removed from the queue. For every add call, done must
+// be called to remove the cid from the queue. Otherwise, subsequent add calls will
+// block forever.
+func (m *processQueue) add(cid string) {
+	m.mutex.Lock()
+	done, ok := m.cids[cid]
+	if !ok {
+		m.cids[cid] = make(chan struct{})
+	}
+	m.mutex.Unlock()
+	if ok {
+		<-done
+		m.add(cid)
+	}
+}
+
+func (m *processQueue) done(cid string) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	done, ok := m.cids[cid]
+	if ok {
+		delete(m.cids, cid)
+		close(done)
+	}
 }

--- a/internal/db/p2p/p2p.go
+++ b/internal/db/p2p/p2p.go
@@ -433,6 +433,7 @@ func (p *P2P) processPushlogRequest(
 		Cid:          headCID,
 		CollectionID: req.CollectionID,
 		Block:        req.Block,
+		IsRelay:      true,
 	}
 	p.db.Events().Publish(event.NewMessage(event.UpdateName, evt))
 	if err := p.SendUpdate(evt); err != nil {

--- a/internal/db/p2p/p2p.go
+++ b/internal/db/p2p/p2p.go
@@ -365,23 +365,18 @@ func (p *P2P) processPushlogRequest(
 		return err
 	}
 
-	// No need to check access if the message is for replication as the node sending
-	// will have done so deliberately.
-	if !isReplicator {
-		mightHaveAccess, err := p.trySelfHasAccess(ctx, block, req.CollectionID)
-		if err != nil {
-			return err
-		}
-		if !mightHaveAccess {
-			// If we know we don't have access, we can skip the rest of the processing.
-			return nil
-		}
-	}
-
 	headCID, err := cid.Cast(req.CID)
 	if err != nil {
 		return err
 	}
+
+	// Calls to syncDAG should not overlap for a given CID. If they do, they will use the same
+	// underlying pubsub topic and this brings along potential pitfalls. One of them being that
+	// if this initial sync call had a negative response for a given link, the subsequent calls will
+	// assume a negative response for that same link without retrying.
+	p.processQueue.add(headCID)
+	done := p.processQueue.doneOnce(headCID)
+	defer done()
 
 	// Check if we've already merged this block. If so, skip the sink process.
 	txn, err := p.db.NewTxn(ctx, true)
@@ -398,16 +393,25 @@ func (p *P2P) processPushlogRequest(
 		return nil
 	}
 
-	// Calls to syncDAG should not overlap for a given CID. If they do, they will use the same
-	// underlying pubsub topic and this brings along potential pitfalls. One of them being that
-	// if this initial sync call had a negative response for a given link, the subsequent calls will
-	// assume a negative response for that same link without retrying.
-	p.processQueue.add(headCID)
+	// No need to check access if the message is for replication as the node sending
+	// will have done so deliberately.
+	if !isReplicator {
+		mightHaveAccess, err := p.trySelfHasAccess(ctx, block, req.CollectionID)
+		if err != nil {
+			return err
+		}
+		if !mightHaveAccess {
+			// If we know we don't have access, we can skip the rest of the processing.
+			return nil
+		}
+	}
+
 	err = p.syncDAG(ctx, p.host.BlockService(), block)
-	p.processQueue.done(headCID)
 	if err != nil {
 		return err
 	}
+	// we call done as soon as we can to release the lock.
+	done()
 
 	go func() {
 		evt := event.Merge{
@@ -517,4 +521,11 @@ func (m *processQueue) done(cid cid.Cid) {
 		delete(m.cids, cid)
 		close(done)
 	}
+}
+
+// doneOnce returns a function that invokes done only once.
+func (m *processQueue) doneOnce(cid cid.Cid) func() {
+	return sync.OnceFunc(func() {
+		m.done(cid)
+	})
 }

--- a/internal/db/p2p/sync_dag.go
+++ b/internal/db/p2p/sync_dag.go
@@ -13,7 +13,6 @@ package p2p
 import (
 	"context"
 	"sync"
-	"time"
 
 	"github.com/ipfs/boxo/blockservice"
 	"github.com/ipld/go-ipld-prime/linking"
@@ -22,10 +21,6 @@ import (
 
 	coreblock "github.com/sourcenetwork/defradb/internal/core/block"
 )
-
-// syncBlockLinkTimeout is the maximum amount of time
-// to wait for a block link to be fetched.
-var syncBlockLinkTimeout = 5 * time.Second
 
 func makeLinkSystem(blockService blockservice.BlockService) linking.LinkSystem {
 	blockStore := &bsrvadapter.Adapter{Wrapped: blockService}

--- a/internal/db/p2p/sync_dag.go
+++ b/internal/db/p2p/sync_dag.go
@@ -43,7 +43,7 @@ func makeLinkSystem(blockService blockservice.BlockService) linking.LinkSystem {
 //
 // This process walks the entire DAG until the issue below is resolved.
 // https://github.com/sourcenetwork/defradb/issues/2722
-func syncDAG(ctx context.Context, blockService blockservice.BlockService, block *coreblock.Block) error {
+func (p *P2P) syncDAG(ctx context.Context, blockService blockservice.BlockService, block *coreblock.Block) error {
 	// use a session to make remote fetches more efficient
 	ctx = blockservice.ContextWithSession(ctx, blockService)
 
@@ -55,7 +55,7 @@ func syncDAG(ctx context.Context, blockService blockservice.BlockService, block 
 		return err
 	}
 
-	err = loadBlockLinks(ctx, &linkSystem, block)
+	err = p.loadBlockLinks(ctx, &linkSystem, block)
 	if err != nil {
 		return err
 	}
@@ -66,7 +66,7 @@ func syncDAG(ctx context.Context, blockService blockservice.BlockService, block 
 //
 // If it encounters errors in the concurrent loading of links, it will return
 // the first error it encountered.
-func loadBlockLinks(ctx context.Context, linkSys *linking.LinkSystem, block *coreblock.Block) error {
+func (p *P2P) loadBlockLinks(ctx context.Context, linkSys *linking.LinkSystem, block *coreblock.Block) error {
 	ctxWithCancel, cancel := context.WithCancel(ctx)
 	defer cancel()
 	var wg sync.WaitGroup
@@ -97,7 +97,7 @@ func loadBlockLinks(ctx context.Context, linkSys *linking.LinkSystem, block *cor
 			if ctxWithCancel.Err() != nil {
 				return
 			}
-			ctxWithTimeout, cancel := context.WithTimeout(ctx, syncBlockLinkTimeout)
+			ctxWithTimeout, cancel := context.WithTimeout(ctx, p.syncBlockLinkTimeout)
 			defer cancel()
 			nd, err := linkSys.Load(linking.LinkContext{Ctx: ctxWithTimeout}, lnk, coreblock.BlockSchemaPrototype)
 			if err != nil {
@@ -110,7 +110,7 @@ func loadBlockLinks(ctx context.Context, linkSys *linking.LinkSystem, block *cor
 				return
 			}
 
-			err = loadBlockLinks(ctx, linkSys, linkBlock)
+			err = p.loadBlockLinks(ctx, linkSys, linkBlock)
 			if err != nil {
 				asyncErrOnce.Do(func() { setAsyncErr(err) })
 				return

--- a/internal/db/p2p/sync_doc.go
+++ b/internal/db/p2p/sync_doc.go
@@ -225,7 +225,7 @@ func (p *P2P) syncDocumentDAG(ctx context.Context, docCid cid.Cid) error {
 		return err
 	}
 
-	return syncDAG(ctx, p.host.BlockService(), linkBlock)
+	return p.syncDAG(ctx, p.host.BlockService(), linkBlock)
 }
 
 // docSyncMessageHandler handles incoming document sync requests from the pubsub network.

--- a/node/node_p2p.go
+++ b/node/node_p2p.go
@@ -32,7 +32,7 @@ func (n *Node) startP2P(ctx context.Context, store corekv.ReaderWriter) error {
 
 	peer, err := net.NewPeer(
 		ctx,
-		datastore.BlockstoreFrom(store),
+		datastore.P2PBlockstoreFrom(store),
 		filterOptions[netConfig.NodeOpt](n.options)...,
 	)
 	if err != nil {

--- a/tests/integration/db.go
+++ b/tests/integration/db.go
@@ -77,6 +77,8 @@ func defaultNodeOpts() []node.Option {
 		// to keep the tests as lightweight as possible.
 		node.WithDisableP2P(true),
 		node.WithLensRuntime(lensType),
+		// The default is 5 and that is never going to be needed in a testing scenario where all the
+		// nodes are on the same machine with no network latency.
 		db.WithP2PBlockSyncTimeout(1 * time.Second),
 	}
 }

--- a/tests/integration/db.go
+++ b/tests/integration/db.go
@@ -15,7 +15,9 @@ import (
 	"os"
 	"strconv"
 	"testing"
+	"time"
 
+	"github.com/sourcenetwork/defradb/internal/db"
 	"github.com/sourcenetwork/defradb/node"
 	changeDetector "github.com/sourcenetwork/defradb/tests/change_detector"
 	"github.com/sourcenetwork/defradb/tests/state"
@@ -75,6 +77,7 @@ func defaultNodeOpts() []node.Option {
 		// to keep the tests as lightweight as possible.
 		node.WithDisableP2P(true),
 		node.WithLensRuntime(lensType),
+		db.WithP2PBlockSyncTimeout(1 * time.Second),
 	}
 }
 

--- a/tests/integration/events.go
+++ b/tests/integration/events.go
@@ -280,8 +280,27 @@ func updateNetworkState(s *state.State, nodeID int, evt event.Update, ident immu
 		s.Nodes[id].P2P.ExpectedDAGHeads[getUpdateEventKey(evt)] = evt.Cid
 	}
 
-	// update the expected document heads of connected nodes
-	for id := range node.P2P.Connections {
+	updateConnectedNodes(s, nodeID, map[int]struct{}{}, ident, collectionID, docIndex, evt)
+}
+
+// updateConnectedNodes updates the expected document heads of connected nodes
+func updateConnectedNodes(
+	s *state.State,
+	nodeID int,
+	nodesCovered map[int]struct{},
+	ident immutable.Option[state.Identity],
+	collectionID int,
+	docIndex int,
+	evt event.Update,
+) {
+	if _, ok := nodesCovered[nodeID]; ok {
+		return
+	}
+	nodesCovered[nodeID] = struct{}{}
+	for id := range s.Nodes[nodeID].P2P.Connections {
+		if _, ok := nodesCovered[id]; ok {
+			continue
+		}
 		if ident.HasValue() && ident.Value().Selector != strconv.Itoa(id) {
 			// If the document is created by a specific identity, only the node with the
 			// same index as the identity can initially access it.
@@ -297,6 +316,8 @@ func updateNetworkState(s *state.State, nodeID int, evt event.Update, ident immu
 		if _, ok := s.Nodes[id].P2P.PeerDocuments[state.NewColDocIndex(collectionID, docIndex)]; ok {
 			s.Nodes[id].P2P.ExpectedDAGHeads[getUpdateEventKey(evt)] = evt.Cid
 		}
+
+		updateConnectedNodes(s, id, nodesCovered, ident, collectionID, docIndex, evt)
 	}
 }
 

--- a/tests/integration/events.go
+++ b/tests/integration/events.go
@@ -155,15 +155,23 @@ func waitForUpdateEvents(
 
 		for len(expect) > 0 {
 			var evt event.Update
-			select {
-			case msg, ok := <-node.Event.Update.Message():
-				if !ok {
-					require.Fail(s.T, "subscription closed waiting for update event", "Node %d", i)
-				}
-				evt = msg.Data.(event.Update)
+		relayCheck:
+			// We need to ensure the message was not from a previously relayed update.
+			// If it is, we try the next one.
+			for {
+				select {
+				case msg, ok := <-node.Event.Update.Message():
+					if !ok {
+						require.Fail(s.T, "subscription closed waiting for update event", "Node %d", i)
+					}
+					evt = msg.Data.(event.Update)
+					if !evt.IsRelay {
+						break relayCheck
+					}
 
-			case <-time.After(eventTimeout):
-				require.Fail(s.T, "timeout waiting for update event", "Node %d", i)
+				case <-time.After(eventTimeout):
+					require.Fail(s.T, "timeout waiting for update event", "Node %d", i)
+				}
 			}
 
 			// make sure the event is expected

--- a/tests/integration/net/simple/peer/with_create_test.go
+++ b/tests/integration/net/simple/peer/with_create_test.go
@@ -202,6 +202,8 @@ func TestP2PCreate_WithP2PCollectionWithNodeChain_ShouldSucceed(t *testing.T) {
 			testUtils.RandomNetworkingConfig(),
 			testUtils.RandomNetworkingConfig(),
 			testUtils.RandomNetworkingConfig(),
+			testUtils.RandomNetworkingConfig(),
+			testUtils.RandomNetworkingConfig(),
 			&action.AddSchema{
 				Schema: `
                     type Users {
@@ -218,12 +220,28 @@ func TestP2PCreate_WithP2PCollectionWithNodeChain_ShouldSucceed(t *testing.T) {
 				SourceNodeID: 2,
 				TargetNodeID: 1,
 			},
+			testUtils.ConnectPeers{
+				SourceNodeID: 3,
+				TargetNodeID: 2,
+			},
+			testUtils.ConnectPeers{
+				SourceNodeID: 4,
+				TargetNodeID: 3,
+			},
 			testUtils.SubscribeToCollection{
 				NodeID:        1,
 				CollectionIDs: []int{0},
 			},
 			testUtils.SubscribeToCollection{
 				NodeID:        2,
+				CollectionIDs: []int{0},
+			},
+			testUtils.SubscribeToCollection{
+				NodeID:        3,
+				CollectionIDs: []int{0},
+			},
+			testUtils.SubscribeToCollection{
+				NodeID:        4,
 				CollectionIDs: []int{0},
 			},
 			testUtils.CreateDoc{

--- a/tests/integration/net/simple/peer/with_create_test.go
+++ b/tests/integration/net/simple/peer/with_create_test.go
@@ -195,3 +195,113 @@ func TestP2PCreateWithP2PCollection(t *testing.T) {
 
 	testUtils.ExecuteTestCase(t, test)
 }
+
+func TestP2PCreate_WithP2PCollectionWithNodeChain_ShouldSucceed(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.RandomNetworkingConfig(),
+			testUtils.RandomNetworkingConfig(),
+			testUtils.RandomNetworkingConfig(),
+			&action.AddSchema{
+				Schema: `
+                    type Users {
+                        Name: String
+                        Age: Int
+                    }
+                `,
+			},
+			testUtils.ConnectPeers{
+				SourceNodeID: 1,
+				TargetNodeID: 0,
+			},
+			testUtils.ConnectPeers{
+				SourceNodeID: 2,
+				TargetNodeID: 1,
+			},
+			testUtils.SubscribeToCollection{
+				NodeID:        1,
+				CollectionIDs: []int{0},
+			},
+			testUtils.SubscribeToCollection{
+				NodeID:        2,
+				CollectionIDs: []int{0},
+			},
+			testUtils.CreateDoc{
+				NodeID: immutable.Some(0),
+				Doc: `{
+                    "Name": "John",
+                    "Age": 21
+                }`,
+			},
+			testUtils.WaitForSync{},
+			testUtils.Request{
+				Request: `query {
+                    Users {
+                        Age
+                    }
+                }`,
+				Results: map[string]any{
+					"Users": []map[string]any{
+						{
+							"Age": int64(21),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestP2PCreate_WithP2PCollectionAndSubscription_ShouldSucceed(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.RandomNetworkingConfig(),
+			testUtils.RandomNetworkingConfig(),
+			&action.AddSchema{
+				Schema: `
+                    type Users {
+                        Name: String
+                        Age: Int
+                    }
+                `,
+			},
+			testUtils.ConnectPeers{
+				SourceNodeID: 1,
+				TargetNodeID: 0,
+			},
+			testUtils.SubscribeToCollection{
+				NodeID:        1,
+				CollectionIDs: []int{0},
+			},
+			testUtils.SubscriptionRequest{
+				NodeID: immutable.Some(1),
+				Request: `subscription {
+					Users {
+						Age
+					}
+				}`,
+				Results: []map[string]any{
+					{
+						"Users": []map[string]any{
+							{
+								"Age": int64(21),
+							},
+						},
+					},
+				},
+			},
+			testUtils.CreateDoc{
+				NodeID: immutable.Some(0),
+				Doc: `{
+                    "Name": "John",
+                    "Age": 21
+                }`,
+			},
+			testUtils.WaitForSync{},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/net/simple/peer/with_create_test.go
+++ b/tests/integration/net/simple/peer/with_create_test.go
@@ -199,6 +199,9 @@ func TestP2PCreateWithP2PCollection(t *testing.T) {
 func TestP2PCreate_WithP2PCollectionWithNodeChain_ShouldSucceed(t *testing.T) {
 	test := testUtils.TestCase{
 		Actions: []any{
+			// Having more than 3 nodes is important to test the robustness of the doc update message
+			// processing function. Having more than 3 connected nodes means that there is a chance that
+			// the message can be received multiple times simultaneously.
 			testUtils.RandomNetworkingConfig(),
 			testUtils.RandomNetworkingConfig(),
 			testUtils.RandomNetworkingConfig(),


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4010 
Resolves #2744  

## Description

This PR ensures that every node in a chain of connected nodes receives a document update if they subscribe to the appropriate topic. 

The issue was caused by the nodes receiving the update message trying to fetch the new blocks, but the nodes that they were connected to didn't yet have it themselves. We solve this by sending the update message again once a node completes a sync.

By fixing this, we also fixed the gql subscription missing new doc updates when those updates came from the p2p system.

Additionally, the blockstore now as the capability to track if a block has been merged or not. This helps to prevent unnecessarily walking the dag upon receiving an update and trying to sync.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

New integration tests

Specify the platform(s) on which this was tested:
- MacOS

