### PR TITLE
fix: Allow configuring node identity with embedded Defra

### DIFF
--- a/node/config.go
+++ b/node/config.go
@@ -11,6 +11,8 @@
 package node
 
 import (
+	"github.com/sourcenetwork/defradb/acp/identity"
+	"github.com/sourcenetwork/defradb/internal/db"
 	"github.com/sourcenetwork/defradb/internal/kms"
 
 	"github.com/sourcenetwork/immutable"
@@ -68,6 +70,12 @@ func WithEnableDevelopment(enable bool) NodeOpt {
 	return func(o *Config) {
 		o.enableDevelopment = enable
 	}
+}
+
+// WithNodeIdentity sets the identity for the node. This is the identity that
+// will be used for things like block signatures and P2P sync operations.
+func WithNodeIdentity(ident identity.Identity) db.Option {
+	return db.WithNodeIdentity(ident)
 }
 
 // filterOptions returns a list of options containing


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4022

## Description

This PR simply exposes a node config to set the internal db node identity config.

Our test framework couldn't catch this since it has access to the internal package.

We had discussed making DB public again. I'll be looking into doing this in order to prevent these kinds of problems in the future.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

manual embedded defra test

Specify the platform(s) on which this was tested:
- MacOS
