### PR TITLE
chore: Reduce size of store prefixes

### DIFF
--- a/docs/data_format_changes/i4026-prefix-change.md
+++ b/docs/data_format_changes/i4026-prefix-change.md
@@ -1,0 +1,3 @@
+# Reduce size of store prefixes
+
+Reduces the size of the prefixes used across the different sub-stores. As a result, the expected keys have changed and that results in a breaking change.

--- a/internal/datastore/blockstore.go
+++ b/internal/datastore/blockstore.go
@@ -46,11 +46,15 @@ func (bs *bstore) AsIPLDStorage() IPLDStorage {
 
 const (
 	objectMarker       = byte(0xff)
-	toMergeIndexPrefix = "m"
+	toMergeIndexPrefix = byte('m')
 )
 
-func newToMergeKey(cid string) []byte {
-	return []byte(toMergeIndexPrefix + cid)
+func newToMergeKey(cid []byte) []byte {
+	l := len(cid)
+	key := make([]byte, l+1)
+	copy(key[1:], cid)
+	key[0] = toMergeIndexPrefix
+	return key
 }
 
 func (bs *bstore) IsMerged(ctx context.Context, cid cid.Cid) (bool, error) {
@@ -61,7 +65,7 @@ func (bs *bstore) IsMerged(ctx context.Context, cid cid.Cid) (bool, error) {
 	if !hasBlock {
 		return false, nil
 	}
-	notMerged, err := bs.store.Has(ctx, newToMergeKey(cid.String()))
+	notMerged, err := bs.store.Has(ctx, newToMergeKey(cid.Bytes()))
 	if err != nil {
 		return false, err
 	}
@@ -69,7 +73,7 @@ func (bs *bstore) IsMerged(ctx context.Context, cid cid.Cid) (bool, error) {
 }
 
 func (bs *bstore) MarkAsMerged(ctx context.Context, cid cid.Cid) error {
-	return bs.store.Delete(ctx, newToMergeKey(cid.String()))
+	return bs.store.Delete(ctx, newToMergeKey(cid.Bytes()))
 }
 
 type p2pBlockStore struct {
@@ -85,7 +89,7 @@ func (bs *p2pBlockStore) Put(ctx context.Context, block blocks.Block) error {
 	if err == nil && exists {
 		return nil // already stored.
 	}
-	err = bs.store.Set(ctx, newToMergeKey(string(key)), []byte{objectMarker})
+	err = bs.store.Set(ctx, newToMergeKey(key), []byte{objectMarker})
 	if err != nil {
 		return err
 	}
@@ -99,7 +103,7 @@ func (bs *p2pBlockStore) PutMany(ctx context.Context, blocks []blocks.Block) err
 		if err == nil && exists {
 			continue
 		}
-		err = bs.store.Set(ctx, newToMergeKey(string(key)), []byte{objectMarker})
+		err = bs.store.Set(ctx, newToMergeKey(key), []byte{objectMarker})
 		if err != nil {
 			return err
 		}

--- a/internal/datastore/blockstore.go
+++ b/internal/datastore/blockstore.go
@@ -46,11 +46,11 @@ func (bs *bstore) AsIPLDStorage() IPLDStorage {
 
 const (
 	objectMarker       = byte(0xff)
-	toMergeIndexPrefix = "/tm"
+	toMergeIndexPrefix = "m"
 )
 
 func newToMergeKey(cid string) []byte {
-	return []byte(toMergeIndexPrefix + "/" + cid)
+	return []byte(toMergeIndexPrefix + cid)
 }
 
 func (bs *bstore) IsMerged(ctx context.Context, cid cid.Cid) (bool, error) {
@@ -85,7 +85,7 @@ func (bs *p2pBlockStore) Put(ctx context.Context, block blocks.Block) error {
 	if err == nil && exists {
 		return nil // already stored.
 	}
-	err = bs.store.Set(ctx, newToMergeKey(block.Cid().String()), []byte{objectMarker})
+	err = bs.store.Set(ctx, newToMergeKey(string(key)), []byte{objectMarker})
 	if err != nil {
 		return err
 	}
@@ -99,7 +99,7 @@ func (bs *p2pBlockStore) PutMany(ctx context.Context, blocks []blocks.Block) err
 		if err == nil && exists {
 			continue
 		}
-		err = bs.store.Set(ctx, newToMergeKey(b.Cid().String()), []byte{objectMarker})
+		err = bs.store.Set(ctx, newToMergeKey(string(key)), []byte{objectMarker})
 		if err != nil {
 			return err
 		}

--- a/internal/datastore/blockstore.go
+++ b/internal/datastore/blockstore.go
@@ -89,7 +89,7 @@ func (bs *p2pBlockStore) Put(ctx context.Context, block blocks.Block) error {
 	if err == nil && exists {
 		return nil // already stored.
 	}
-	err = bs.store.Set(ctx, newToMergeKey(key), []byte{objectMarker})
+	err = bs.store.Set(ctx, newToMergeKey(block.Cid().Bytes()), []byte{objectMarker})
 	if err != nil {
 		return err
 	}
@@ -103,7 +103,7 @@ func (bs *p2pBlockStore) PutMany(ctx context.Context, blocks []blocks.Block) err
 		if err == nil && exists {
 			continue
 		}
-		err = bs.store.Set(ctx, newToMergeKey(key), []byte{objectMarker})
+		err = bs.store.Set(ctx, newToMergeKey(b.Cid().Bytes()), []byte{objectMarker})
 		if err != nil {
 			return err
 		}

--- a/internal/datastore/multi.go
+++ b/internal/datastore/multi.go
@@ -11,20 +11,22 @@
 package datastore
 
 import (
-	ds "github.com/ipfs/go-datastore"
+	"bytes"
 
+	"github.com/ipfs/go-cid"
 	"github.com/sourcenetwork/corekv"
+	"github.com/sourcenetwork/corekv/namespace"
+	"github.com/sourcenetwork/defradb/errors"
 )
 
 var (
 	// Individual Store Keys
-	rootStoreKey   = ds.NewKey("db")
-	systemStoreKey = rootStoreKey.ChildString("system")
-	dataStoreKey   = rootStoreKey.ChildString("data")
-	headStoreKey   = rootStoreKey.ChildString("heads")
-	blockStoreKey  = rootStoreKey.ChildString("blocks")
-	peerStoreKey   = rootStoreKey.ChildString("ps")
-	encStoreKey    = rootStoreKey.ChildString("enc")
+	systemStoreKey = byte('s')
+	dataStoreKey   = byte('d')
+	headStoreKey   = byte('h')
+	blockStoreKey  = byte('b')
+	peerStoreKey   = byte('p')
+	encStoreKey    = byte('e')
 )
 
 type Multistore struct {
@@ -39,13 +41,13 @@ type Multistore struct {
 
 func NewMultistore(rootstore corekv.ReaderWriter) *Multistore {
 	return &Multistore{
-		block:  newBlockstore(prefix(rootstore, blockStoreKey.Bytes())),
-		data:   prefix(rootstore, dataStoreKey.Bytes()),
-		enc:    newBlockstore(prefix(rootstore, encStoreKey.Bytes())),
-		head:   prefix(rootstore, headStoreKey.Bytes()),
-		peer:   prefix(rootstore, peerStoreKey.Bytes()),
+		block:  newBlockstore(namespace.Wrap(rootstore, []byte{blockStoreKey})),
+		data:   namespace.Wrap(rootstore, []byte{dataStoreKey}),
+		enc:    newBlockstore(namespace.Wrap(rootstore, []byte{encStoreKey})),
+		head:   namespace.Wrap(rootstore, []byte{headStoreKey}),
+		peer:   namespace.Wrap(rootstore, []byte{peerStoreKey}),
 		root:   rootstore,
-		system: prefix(rootstore, systemStoreKey.Bytes()),
+		system: namespace.Wrap(rootstore, []byte{systemStoreKey}),
 	}
 }
 
@@ -78,31 +80,67 @@ func (m *Multistore) Systemstore() corekv.ReaderWriter {
 }
 
 func DatastoreFrom(rootstore corekv.ReaderWriter) corekv.ReaderWriter {
-	return prefix(rootstore, dataStoreKey.Bytes())
+	return namespace.Wrap(rootstore, []byte{dataStoreKey})
 }
 
 func EncstoreFrom(rootstore corekv.ReaderWriter) Blockstore {
-	return newBlockstore(prefix(rootstore, encStoreKey.Bytes()))
+	return newBlockstore(namespace.Wrap(rootstore, []byte{encStoreKey}))
 }
 
 func HeadstoreFrom(rootstore corekv.ReaderWriter) corekv.ReaderWriter {
-	return prefix(rootstore, headStoreKey.Bytes())
+	return namespace.Wrap(rootstore, []byte{headStoreKey})
 }
 
 func BlockstoreFrom(rootstore corekv.ReaderWriter) Blockstore {
-	return newBlockstore(prefix(rootstore, blockStoreKey.Bytes()))
+	return newBlockstore(namespace.Wrap(rootstore, []byte{blockStoreKey}))
 }
 
 func P2PBlockstoreFrom(rootstore corekv.ReaderWriter) Blockstore {
 	return &p2pBlockStore{
-		bstore: newBlockstore(prefix(rootstore, blockStoreKey.Bytes())),
+		bstore: newBlockstore(namespace.Wrap(rootstore, []byte{blockStoreKey})),
 	}
 }
 
 func SystemstoreFrom(rootstore corekv.ReaderWriter) corekv.ReaderWriter {
-	return prefix(rootstore, systemStoreKey.Bytes())
+	return namespace.Wrap(rootstore, []byte{systemStoreKey})
 }
 
 func PeerstoreFrom(rootstore corekv.ReaderWriter) corekv.ReaderWriter {
-	return prefix(rootstore, peerStoreKey.Bytes())
+	return namespace.Wrap(rootstore, []byte{peerStoreKey})
+}
+
+// HumanReadableKey converts a raw byte and representation of a key into a human redable format.
+func HumanReadableKey(key []byte) (string, error) {
+	switch key[0] {
+	case blockStoreKey:
+		if bytes.HasPrefix(key[1:], []byte(toMergeIndexPrefix)) {
+			cid, err := cid.Cast(key[2:])
+			if err != nil {
+				return "", errors.WithStack(err)
+			}
+			return "blocks/to_merge/" + cid.String(), nil
+		}
+		cid, err := cid.Cast(key[1:])
+		if err != nil {
+			return "", errors.WithStack(err)
+		}
+		return "blocks/" + cid.String(), nil
+	case dataStoreKey:
+		return "data" + string(key[1:]), nil
+	case encStoreKey:
+		cid, err := cid.Cast(key[1:])
+		if err != nil {
+			return "", errors.WithStack(err)
+		}
+		return "encryption/" + cid.String(), nil
+	case encStoreKey:
+		return "system" + string(key[1:]), nil
+	case headStoreKey:
+		return "heads" + string(key[1:]), nil
+	case peerStoreKey:
+		return "peers" + string(key[1:]), nil
+	case systemStoreKey:
+		return "system" + string(key[1:]), nil
+	}
+	return string(key), nil
 }

--- a/internal/datastore/multi.go
+++ b/internal/datastore/multi.go
@@ -113,7 +113,7 @@ func PeerstoreFrom(rootstore corekv.ReaderWriter) corekv.ReaderWriter {
 func HumanReadableKey(key []byte) (string, error) {
 	switch key[0] {
 	case blockStoreKey:
-		if bytes.HasPrefix(key[1:], []byte(toMergeIndexPrefix)) {
+		if bytes.HasPrefix(key[1:], []byte{toMergeIndexPrefix}) {
 			cid, err := cid.Cast(key[2:])
 			if err != nil {
 				return "", errors.WithStack(err)

--- a/internal/datastore/multi.go
+++ b/internal/datastore/multi.go
@@ -14,8 +14,10 @@ import (
 	"bytes"
 
 	"github.com/ipfs/go-cid"
+
 	"github.com/sourcenetwork/corekv"
 	"github.com/sourcenetwork/corekv/namespace"
+
 	"github.com/sourcenetwork/defradb/errors"
 )
 

--- a/internal/datastore/multi_test.go
+++ b/internal/datastore/multi_test.go
@@ -1,0 +1,96 @@
+// Copyright 20225Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package datastore
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	blocks "github.com/ipfs/go-block-format"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcenetwork/corekv"
+	"github.com/sourcenetwork/corekv/memory"
+)
+
+func TestMultistore_HumanReadableKeys_ShouldSucceed(t *testing.T) {
+	ctx := context.Background()
+	rootstore := memory.NewDatastore(ctx)
+
+	ms := NewMultistore(rootstore)
+
+	err := ms.Blockstore().Put(ctx, blocks.NewBlock([]byte("123")))
+	require.NoError(t, err)
+	err = P2PBlockstoreFrom(rootstore).Put(ctx, blocks.NewBlock([]byte("1234")))
+	require.NoError(t, err)
+	err = ms.Datastore().Set(ctx, []byte("/123"), []byte("123"))
+	require.NoError(t, err)
+	err = ms.Encstore().Put(ctx, blocks.NewBlock([]byte("123")))
+	require.NoError(t, err)
+	err = ms.Headstore().Set(ctx, []byte("/123"), []byte("123"))
+	require.NoError(t, err)
+	err = ms.Peerstore().Set(ctx, []byte("/123"), []byte("123"))
+	require.NoError(t, err)
+	err = ms.Systemstore().Set(ctx, []byte("/123"), []byte("123"))
+	require.NoError(t, err)
+
+	iter, err := rootstore.Iterator(ctx, corekv.IterOptions{KeysOnly: true})
+	require.NoError(t, err)
+
+	expectedKVs := []struct {
+		key string
+	}{
+		{
+			key: "blocks/",
+		},
+		{
+			key: "blocks/",
+		},
+		{
+			key: "blocks/to_merge/",
+		},
+		{
+			key: "data/",
+		},
+		{
+			key: "encryption",
+		},
+		{
+			key: "heads/",
+		},
+		{
+			key: "peers/",
+		},
+		{
+			key: "system/",
+		},
+	}
+
+	expectedIndex := 0
+	for {
+		hasNext, err := iter.Next()
+		require.NoError(t, err)
+
+		if !hasNext {
+			break
+		}
+
+		key, err := HumanReadableKey(iter.Key())
+		require.NoError(t, err)
+
+		require.True(t, strings.HasPrefix(key, expectedKVs[expectedIndex].key), key, expectedKVs[expectedIndex].key)
+
+		expectedIndex++
+	}
+
+	iter.Close()
+}

--- a/internal/datastore/multi_test.go
+++ b/internal/datastore/multi_test.go
@@ -1,4 +1,4 @@
-// Copyright 20225Democratized Data Foundation
+// Copyright 2025 Democratized Data Foundation
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt.

--- a/internal/datastore/store.go
+++ b/internal/datastore/store.go
@@ -16,9 +16,6 @@ import (
 	"github.com/ipfs/boxo/blockstore"
 	"github.com/ipfs/go-cid"
 	"github.com/ipld/go-ipld-prime/storage"
-
-	"github.com/sourcenetwork/corekv"
-	"github.com/sourcenetwork/corekv/namespace"
 )
 
 // Blockstore proxies the ipld.DAGService under the /core namespace for future-proofing
@@ -36,8 +33,4 @@ type Blockstore interface {
 type IPLDStorage interface {
 	storage.ReadableStorage
 	storage.WritableStorage
-}
-
-func prefix(root corekv.ReaderWriter, prefix []byte) corekv.ReaderWriter {
-	return namespace.Wrap(root, prefix)
 }

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -16,9 +16,12 @@ package db
 
 import (
 	"context"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/ipfs/go-cid"
 
 	"github.com/sourcenetwork/corekv"
 	"github.com/sourcenetwork/corelog"
@@ -528,8 +531,34 @@ func printStore(ctx context.Context, store corekv.ReaderWriter) error {
 			return errors.Join(err, iter.Close())
 		}
 
-		log.InfoContext(ctx, "", corelog.Any(string(iter.Key()), value))
+		key, err := makeHumanReadable(string(iter.Key()))
+		if err != nil {
+			return errors.Join(err, iter.Close())
+		}
+
+		log.InfoContext(ctx, "", corelog.Any(key, value))
 	}
 
 	return iter.Close()
+}
+
+const (
+	blocksPrefix        = "/db/blocks/"
+	blocksToMergePrefix = "/db/blocks/tm"
+)
+
+// makeHumanReadable converts a raw byte representation of a key into a human redable format.
+//
+// It currently only works for block keys but it could also apply to index keys or any other
+// keys that benefit from using raw bytes.
+func makeHumanReadable(s string) (string, error) {
+	if strings.HasPrefix(s, blocksPrefix) && !strings.HasPrefix(s, blocksToMergePrefix) {
+		cidbytes := []byte(strings.TrimPrefix(s, blocksPrefix))
+		cid, err := cid.Cast(cidbytes)
+		if err != nil {
+			return "", err
+		}
+		return blocksPrefix + cid.String(), nil
+	}
+	return s, nil
 }

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -16,12 +16,9 @@ package db
 
 import (
 	"context"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
-
-	"github.com/ipfs/go-cid"
 
 	"github.com/sourcenetwork/corekv"
 	"github.com/sourcenetwork/corelog"
@@ -531,7 +528,7 @@ func printStore(ctx context.Context, store corekv.ReaderWriter) error {
 			return errors.Join(err, iter.Close())
 		}
 
-		key, err := makeHumanReadable(string(iter.Key()))
+		key, err := datastore.HumanReadableKey(iter.Key())
 		if err != nil {
 			return errors.Join(err, iter.Close())
 		}
@@ -540,25 +537,4 @@ func printStore(ctx context.Context, store corekv.ReaderWriter) error {
 	}
 
 	return iter.Close()
-}
-
-const (
-	blocksPrefix        = "/db/blocks/"
-	blocksToMergePrefix = "/db/blocks/tm"
-)
-
-// makeHumanReadable converts a raw byte representation of a key into a human redable format.
-//
-// It currently only works for block keys but it could also apply to index keys or any other
-// keys that benefit from using raw bytes.
-func makeHumanReadable(s string) (string, error) {
-	if strings.HasPrefix(s, blocksPrefix) && !strings.HasPrefix(s, blocksToMergePrefix) {
-		cidbytes := []byte(strings.TrimPrefix(s, blocksPrefix))
-		cid, err := cid.Cast(cidbytes)
-		if err != nil {
-			return "", err
-		}
-		return blocksPrefix + cid.String(), nil
-	}
-	return s, nil
 }


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4026 

## Description

~~This PR changes the blockstore keys to use the full cid information (version+codec+hash instead of only hash). It also uses raw bytes instead of a base32 encoded string which reduces storage overhead.~~

This PR no only focuses on reducing the size of the store prefixes. The blockstore portion won't be needed shortly as Andy is moving it outside of Defra. This PR will wait for that change to happen before getting merged.

Using raw bytes has the drawback of being difficult to use for debugging. A `HumanReadableKey` function was added and used with `printStore`.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

make test

Specify the platform(s) on which this was tested:
- MacOS
