### PR TITLE
fix: Remove recursive issue in versioned fetcher

### DIFF
--- a/internal/db/fetcher/versioned.go
+++ b/internal/db/fetcher/versioned.go
@@ -407,7 +407,9 @@ func (vf *VersionedFetcher) merge(c cid.Cid) error {
 		return err
 	}
 
-	// handle subgraphs
+	// Handle subgraphs. We range over `Links` only (not `Heads``) because the trunk is already accounted for
+	// by the initial caller or `merge`. Including `Heads` would result in unnecessary recursion and possible
+	// wrong final value for the fields.
 	for _, l := range block.Links {
 		err = vf.merge(l.Cid)
 		if err != nil {

--- a/internal/db/fetcher/versioned.go
+++ b/internal/db/fetcher/versioned.go
@@ -408,7 +408,7 @@ func (vf *VersionedFetcher) merge(c cid.Cid) error {
 	}
 
 	// handle subgraphs
-	for _, l := range block.AllLinks() {
+	for _, l := range block.Links {
 		err = vf.merge(l.Cid)
 		if err != nil {
 			return err

--- a/tests/action/identity.go
+++ b/tests/action/identity.go
@@ -78,7 +78,7 @@ func getContextWithIdentity(
 	return acpIdentity.WithContext(ctx, getIdentityForRequestSpecificToNode(s, identity, nodeIndex))
 }
 
-// resetContextWithNoIdentity resets identity for the ctx to avoid, leaving it there and having the ctx
+// resetStateContext resets identity for the ctx to avoid leaving it there and having the ctx
 // reuse the same identity for other requests that don't specify an identity.
 func resetStateContext(s *state.State) {
 	s.Ctx = acpIdentity.WithContext(s.Ctx, acpIdentity.None)

--- a/tests/integration/events.go
+++ b/tests/integration/events.go
@@ -15,6 +15,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/ipfs/go-cid"
 	"github.com/stretchr/testify/require"
 
 	"github.com/sourcenetwork/immutable"
@@ -165,6 +166,14 @@ func waitForUpdateEvents(
 						require.Fail(s.T, "subscription closed waiting for update event", "Node %d", i)
 					}
 					evt = msg.Data.(event.Update)
+					// We keep track of the list of cids for all documents in the test
+					// in case we want to use them in subsequent test actions without having
+					// to know in advance what the CID will be.
+					if node.Composites == nil {
+						node.Composites = make(map[string][]cid.Cid)
+					}
+					node.Composites[evt.DocID] = append(node.Composites[evt.DocID], evt.Cid)
+
 					if !evt.IsRelay {
 						break relayCheck
 					}

--- a/tests/integration/query/simple/with_cid_test.go
+++ b/tests/integration/query/simple/with_cid_test.go
@@ -118,3 +118,44 @@ func TestQuerySimpleWithCid_MultipleDocs(t *testing.T) {
 
 	testUtils.ExecuteTestCase(t, test)
 }
+
+func TestQuerySimpple_WithCIDAndCounterAfterUpdate_ShouldSucceed(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			action.AddSchema{
+				Schema: `
+					type User {
+						counter: Int @crdt(type: pcounter)
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				DocMap: map[string]any{
+					"counter": int64(1),
+				},
+			},
+			testUtils.UpdateDoc{
+				CollectionID: 0,
+				DocID:        0,
+				Doc:          `{"counter": 1}`,
+			},
+			testUtils.Request{
+				Request: `query {
+					User(cid: "{{.CID0_0_1}}") {
+						counter
+					}
+				}`,
+				Results: map[string]any{
+					"User": []map[string]any{
+						{
+							"counter": int64(2),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/query/simple/with_cid_test.go
+++ b/tests/integration/query/simple/with_cid_test.go
@@ -122,7 +122,7 @@ func TestQuerySimpleWithCid_MultipleDocs(t *testing.T) {
 func TestQuerySimpple_WithCIDAndCounterAfterUpdate_ShouldSucceed(t *testing.T) {
 	test := testUtils.TestCase{
 		Actions: []any{
-			action.AddSchema{
+			&action.AddSchema{
 				Schema: `
 					type User {
 						counter: Int @crdt(type: pcounter)

--- a/tests/integration/query/simple/with_cid_test.go
+++ b/tests/integration/query/simple/with_cid_test.go
@@ -119,7 +119,7 @@ func TestQuerySimpleWithCid_MultipleDocs(t *testing.T) {
 	testUtils.ExecuteTestCase(t, test)
 }
 
-func TestQuerySimpple_WithCIDAndCounterAfterUpdate_ShouldSucceed(t *testing.T) {
+func TestQuerySimple_WithCIDAndCounterAfterUpdate_ShouldSucceed(t *testing.T) {
 	test := testUtils.TestCase{
 		Actions: []any{
 			&action.AddSchema{

--- a/tests/integration/replace.go
+++ b/tests/integration/replace.go
@@ -1,0 +1,60 @@
+package tests
+
+import (
+	"bytes"
+	"html/template"
+	"maps"
+	"strconv"
+	"strings"
+
+	"github.com/sourcenetwork/defradb/errors"
+	"github.com/sourcenetwork/defradb/tests/state"
+	"github.com/stretchr/testify/require"
+)
+
+// templateDataGenerators contains a set of data generators by their template prefix.
+//
+// Supporting action properties will replace any templated elements with data drawn from these
+// sets.
+var templateDataGenerators = map[string]func(*state.State, int) map[string]string{
+	"CID": func(s *state.State, nodeID int) map[string]string {
+
+		docIDsToCIDs := s.Nodes[nodeID].Composites
+
+		res := map[string]string{}
+		for colIndex, docIndexes := range s.DocIDs {
+			for dIndex, docID := range docIndexes {
+				cids := docIDsToCIDs[docID.String()]
+				for cidIndex, cid := range cids {
+					res["CID"+strconv.Itoa(colIndex)+"_"+strconv.Itoa(dIndex)+"_"+strconv.Itoa(cidIndex)] = cid.String()
+				}
+			}
+		}
+		return res
+	},
+}
+
+// replace returns a new string with any templating placholders (see "text/template") with data drawn
+// from `state`.
+func replace(s *state.State, nodeId int, input string) string {
+	if !strings.Contains(input, "{{") {
+		// If the input doesn't contain any templating elements we can return early
+		return input
+	}
+
+	templateData := map[string]string{}
+	for _, datasetGenerator := range templateDataGenerators {
+		// Having to regenerate the full dataset for every node-action is horribly inefficient, but
+		// it is tolerable for now.
+		maps.Copy(templateData, datasetGenerator(s, nodeId))
+	}
+
+	tmpl := template.Must(template.New("").Parse(input))
+	var buf bytes.Buffer
+	err := tmpl.Execute(&buf, templateData)
+	if err != nil {
+		require.Fail(s.T, errors.WithStack(err).Error())
+	}
+
+	return buf.String()
+}

--- a/tests/integration/replace.go
+++ b/tests/integration/replace.go
@@ -23,10 +23,19 @@ var templateDataGenerators = map[string]func(*state.State, int) map[string]strin
 
 		res := map[string]string{}
 		for colIndex, docIndexes := range s.DocIDs {
-			for dIndex, docID := range docIndexes {
+			for docIndex, docID := range docIndexes {
 				cids := docIDsToCIDs[docID.String()]
 				for cidIndex, cid := range cids {
-					res["CID"+strconv.Itoa(colIndex)+"_"+strconv.Itoa(dIndex)+"_"+strconv.Itoa(cidIndex)] = cid.String()
+					templateCIDRef := "CID" +
+						// The index of the collection in the test.
+						strconv.Itoa(colIndex) + "_" +
+						// The index of the document within that collection.
+						strconv.Itoa(docIndex) + "_" +
+						// The index of the CID for that document.
+						// WARNING: This mights be difficult for the writer of the
+						// test to accurately determine when testing P2P functionalities.
+						strconv.Itoa(cidIndex)
+					res[templateCIDRef] = cid.String()
 				}
 			}
 		}

--- a/tests/integration/replace.go
+++ b/tests/integration/replace.go
@@ -1,3 +1,13 @@
+// Copyright 2025 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
 package tests
 
 import (
@@ -7,9 +17,10 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/sourcenetwork/defradb/errors"
 	"github.com/sourcenetwork/defradb/tests/state"
-	"github.com/stretchr/testify/require"
 )
 
 // templateDataGenerators contains a set of data generators by their template prefix.

--- a/tests/integration/subscription/subscription_test.go
+++ b/tests/integration/subscription/subscription_test.go
@@ -368,7 +368,7 @@ func TestSubscription_WithClose_WontBlock(t *testing.T) {
 func TestSubscription_WithCounterCRDT_ShouldSucceed(t *testing.T) {
 	test := testUtils.TestCase{
 		Actions: []any{
-			action.AddSchema{
+			&action.AddSchema{
 				Schema: `
 					type User {
 						counter: Int @crdt(type: pcounter)

--- a/tests/integration/subscription/subscription_test.go
+++ b/tests/integration/subscription/subscription_test.go
@@ -13,6 +13,7 @@ package subscription
 import (
 	"testing"
 
+	"github.com/sourcenetwork/defradb/tests/action"
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
 )
 
@@ -362,4 +363,54 @@ func TestSubscription_WithClose_WontBlock(t *testing.T) {
 	}
 
 	execute(t, test)
+}
+
+func TestSubscription_WithCounterCRDT_ShouldSucceed(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			action.AddSchema{
+				Schema: `
+					type User {
+						counter: Int @crdt(type: pcounter)
+					}
+				`,
+			},
+			testUtils.SubscriptionRequest{
+				Request: `subscription {
+					User {
+						counter
+					}
+				}`,
+				Results: []map[string]any{
+					{
+						"User": []map[string]any{
+							{
+								"counter": int64(1),
+							},
+						},
+					},
+					{
+						"User": []map[string]any{
+							{
+								"counter": int64(2),
+							},
+						},
+					},
+				},
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				DocMap: map[string]any{
+					"counter": int64(1),
+				},
+			},
+			testUtils.UpdateDoc{
+				CollectionID: 0,
+				DocID:        0,
+				Doc:          `{"counter": 1}`,
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
 }

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -1845,8 +1845,9 @@ nodeLoop:
 				}
 			}
 		}
-
-		result := node.ExecRequest(ctx, action.Request, options...)
+		// Replace any template placeholders with the appropriate data.
+		request := replace(s, nodeID, action.Request)
+		result := node.ExecRequest(ctx, request, options...)
 
 		expectedErrorRaised = assertRequestResults(
 			s,

--- a/tests/state/state.go
+++ b/tests/state/state.go
@@ -170,6 +170,8 @@ type NodeState struct {
 	// CachedPeerInfo holds the node's PeerInfo so that the node can be
 	// restarded with the same address configuration.
 	CachedPeerInfo client.PeerInfo
+	// Map of docIDs to their composite CIDs.
+	Composites map[string][]cid.Cid
 }
 
 // State contains all testing State.


### PR DESCRIPTION
## Relevant issue(s)

Resolves #3988 

## Description

This PR resolves an issue where a version query (`query { User (cid: "someCID") {...}}`) would merge each commit recursively all the way down to the root. 

Assume updates 1, 2 and 3 on field A. When specifying version 3 in the query, for example,  the versioned fetcher loads Composites `C1`, `C2` and `C3` into memory and merges to the datastore waling from `C1` to `C3`. 

What happened was this:
Merge `C1`-`A1` -> Merge `C2`- `C1` - `A1` - `A2` - `A1` -> Merge `C3` - `C2` - `C1` - `A1` -  `A2` - `A1` - `A3` - `A2` - `A1`. 

Basically the merge function was walking all links (heads included) instead of only the non-head links.

We never detected this because all our tests that do a version query (including subscriptions) only use LWW CRDTs and this recursion yields the same result for the type.

With Counter CRDTs, imagine 3 increments of 1. The create would yield 1, the first update would yield 4 and the second update would yield 10.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Added 2 new integrations tests

Specify the platform(s) on which this was tested:
- MacOS
