### PR TITLE
fix: Add missing composite commits for change detector

### DIFF
--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/fxamacker/cbor/v2"
+	"github.com/ipfs/go-cid"
 	"github.com/onsi/gomega"
 	"github.com/onsi/gomega/matchers"
 	"github.com/stretchr/testify/assert"
@@ -1011,9 +1012,31 @@ func refreshDocuments(
 				// the test will fail later anyway
 				continue
 			}
-
+			if s.Nodes[firstNodesID].Composites == nil {
+				s.Nodes[firstNodesID].Composites = make(map[string][]cid.Cid)
+			}
 			for _, doc := range docs {
 				s.DocIDs[action.CollectionID] = append(s.DocIDs[action.CollectionID], doc.ID())
+				// We fetch the list of composite commits for the document so that
+				// they can be referenced later in the test if required.
+				result := s.Nodes[firstNodesID].Client.ExecRequest(s.Ctx, `query ($docID: ID!) {
+					commits(docID: $docID, fieldName: "_C", order: {height: ASC}) {
+						cid
+					}
+				}`, client.WithVariables(map[string]any{
+					"docID": doc.ID().String(),
+				}))
+				if data, ok := result.GQL.Data.(map[string]any); ok {
+					if commits, ok := data["commits"].([]map[string]any); ok {
+						for _, commit := range commits {
+							cid := cid.MustParse(commit["cid"].(string))
+							s.Nodes[firstNodesID].Composites[doc.ID().String()] = append(s.Nodes[firstNodesID].Composites[doc.ID().String()], cid)
+						}
+					}
+				}
+				if len(result.GQL.Errors) > 0 {
+					s.T.Fatalf("Failed to get existing commits for doc %s: %v", doc.ID(), result.GQL.Errors)
+				}
 			}
 		}
 	}

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -1030,7 +1030,10 @@ func refreshDocuments(
 					if commits, ok := data["commits"].([]map[string]any); ok {
 						for _, commit := range commits {
 							cid := cid.MustParse(commit["cid"].(string))
-							s.Nodes[firstNodesID].Composites[doc.ID().String()] = append(s.Nodes[firstNodesID].Composites[doc.ID().String()], cid)
+							s.Nodes[firstNodesID].Composites[doc.ID().String()] = append(
+								s.Nodes[firstNodesID].Composites[doc.ID().String()],
+								cid,
+							)
 						}
 					}
 				}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4039

## Description

This PR fixes the change detector issue where the list of composite commits was never populated because create document actions are skipped.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

`make test:changes` locally

Specify the platform(s) on which this was tested:
- MacOS
