### PR TITLE
feat: Only allow zero or one query sources

### DIFF
--- a/cli/test/action/collection_describe.go
+++ b/cli/test/action/collection_describe.go
@@ -64,10 +64,10 @@ func (a *CollectionDescribe) Execute() {
 			require.Equal(a.s.T, expected.Indexes, actual.Indexes)
 		}
 
-		if expected.Sources != nil {
+		if expected.VersionSources != nil {
 			// Dont bother asserting this if the expected is nil and the actual is nil/empty.
 			// This is to save each test action from having to bother declaring an empty slice (if there are no sources)
-			require.Equal(a.s.T, expected.Sources, actual.Sources)
+			require.Equal(a.s.T, expected.VersionSources, actual.VersionSources)
 		}
 
 		if expected.Query.HasValue() {

--- a/cli/test/action/collection_describe.go
+++ b/cli/test/action/collection_describe.go
@@ -71,7 +71,7 @@ func (a *CollectionDescribe) Execute() {
 		}
 
 		if expected.Query.HasValue() {
-			// Dont bother asserting this by default, the query object is to complex to bother with in most cases.
+			// Dont bother asserting this by default, the query object is too complex to bother with in most cases.
 			require.Equal(a.s.T, expected.Query, actual.Query)
 		}
 

--- a/cli/test/action/collection_describe.go
+++ b/cli/test/action/collection_describe.go
@@ -70,6 +70,11 @@ func (a *CollectionDescribe) Execute() {
 			require.Equal(a.s.T, expected.Sources, actual.Sources)
 		}
 
+		if expected.Query.HasValue() {
+			// Dont bother asserting this by default, the query object is to complex to bother with in most cases.
+			require.Equal(a.s.T, expected.Query, actual.Query)
+		}
+
 		if expected.Fields != nil {
 			require.Equal(a.s.T, expected.Fields, actual.Fields)
 		}

--- a/client/collection_description.go
+++ b/client/collection_description.go
@@ -11,7 +11,6 @@
 package client
 
 import (
-	"encoding/json"
 	"reflect"
 
 	"github.com/sourcenetwork/immutable"
@@ -224,78 +223,6 @@ func (col CollectionVersion) GetFieldByRelation(
 // Equal returns true if this and the given [CollectionVersion] are equal.
 func (col CollectionVersion) Equal(other CollectionVersion) bool {
 	return reflect.DeepEqual(col, other)
-}
-
-// collectionVersion is a private type used to facilitate the unmarshalling
-// of json to a [CollectionVersion].
-type collectionVersion struct {
-	// These properties are unmarshalled using the default json unmarshaller
-	Name             string
-	VersionID        string
-	CollectionID     string
-	RootID           uint32
-	CollectionSet    immutable.Option[CollectionSetDescription]
-	IsMaterialized   bool
-	IsBranchable     bool
-	IsEmbeddedOnly   bool
-	IsActive         bool
-	IsPlaceholder    bool
-	Policy           immutable.Option[PolicyDescription]
-	Indexes          []IndexDescription
-	Fields           []CollectionFieldDescription
-	VectorEmbeddings []VectorEmbeddingDescription
-	Query            immutable.Option[QuerySource]
-
-	// Properties below this line are unmarshalled using custom logic in [UnmarshalJSON]
-	VersionSources []map[string]json.RawMessage
-}
-
-func (col *CollectionVersion) UnmarshalJSON(bytes []byte) error {
-	var descMap collectionVersion
-	err := json.Unmarshal(bytes, &descMap)
-	if err != nil {
-		return err
-	}
-
-	col.Name = descMap.Name
-	col.VersionID = descMap.VersionID
-	col.CollectionID = descMap.CollectionID
-	col.CollectionSet = descMap.CollectionSet
-	col.IsMaterialized = descMap.IsMaterialized
-	col.IsBranchable = descMap.IsBranchable
-	col.IsEmbeddedOnly = descMap.IsEmbeddedOnly
-	col.IsActive = descMap.IsActive
-	col.IsPlaceholder = descMap.IsPlaceholder
-	col.Indexes = descMap.Indexes
-	col.Fields = descMap.Fields
-	col.VersionSources = make([]CollectionSource, len(descMap.VersionSources))
-	col.Policy = descMap.Policy
-	col.VectorEmbeddings = descMap.VectorEmbeddings
-	col.Query = descMap.Query
-
-	for i, source := range descMap.VersionSources {
-		sourceJson, err := json.Marshal(source)
-		if err != nil {
-			return err
-		}
-
-		var sourceValue CollectionSource
-		if _, ok := source["SourceCollectionID"]; ok {
-			// This must be a CollectionSource, as only the `CollectionSource` type has a `SourceCollectionID` field
-			var collectionSource CollectionSource
-			err := json.Unmarshal(sourceJson, &collectionSource)
-			if err != nil {
-				return err
-			}
-			sourceValue = collectionSource
-		} else {
-			return ErrFailedToUnmarshalCollection
-		}
-
-		col.VersionSources[i] = sourceValue
-	}
-
-	return nil
 }
 
 // VectorEmbeddingDescription hold the relevant information to generate embeddings.

--- a/client/collection_description.go
+++ b/client/collection_description.go
@@ -57,7 +57,7 @@ type CollectionVersion struct {
 	// and it may not (yet) have its documents synced across the P2P network.
 	Query immutable.Option[QuerySource]
 
-	// VersionSources is the set of versions from which this collection may draws data from.
+	// VersionSources is the set of versions from which this collection may draw data from.
 	VersionSources []CollectionSource
 
 	// Fields contains the fields local to the node within this Collection.

--- a/client/collection_description.go
+++ b/client/collection_description.go
@@ -58,12 +58,8 @@ type CollectionVersion struct {
 	// and it may not (yet) have its documents synced across the P2P network.
 	Query immutable.Option[QuerySource]
 
-	// Sources is the set of sources from which this collection draws data.
-	//
-	// Currently supported source types are:
-	// - [QuerySource]
-	// - [CollectionSource]
-	Sources []any
+	// VersionSources is the set of versions from which this collection may draws data from.
+	VersionSources []any
 
 	// Fields contains the fields local to the node within this Collection.
 	//
@@ -232,7 +228,7 @@ func (col CollectionVersion) CollectionSources() []*CollectionSource {
 
 func sourcesOfType[ResultType any](col CollectionVersion) []ResultType {
 	result := []ResultType{}
-	for _, source := range col.Sources {
+	for _, source := range col.VersionSources {
 		if typedSource, isOfType := source.(ResultType); isOfType {
 			result = append(result, typedSource)
 		}
@@ -266,7 +262,7 @@ type collectionVersion struct {
 	Query            immutable.Option[*QuerySource]
 
 	// Properties below this line are unmarshalled using custom logic in [UnmarshalJSON]
-	Sources []map[string]json.RawMessage
+	VersionSources []map[string]json.RawMessage
 }
 
 func (col *CollectionVersion) UnmarshalJSON(bytes []byte) error {
@@ -287,12 +283,12 @@ func (col *CollectionVersion) UnmarshalJSON(bytes []byte) error {
 	col.IsPlaceholder = descMap.IsPlaceholder
 	col.Indexes = descMap.Indexes
 	col.Fields = descMap.Fields
-	col.Sources = make([]any, len(descMap.Sources))
+	col.VersionSources = make([]any, len(descMap.VersionSources))
 	col.Policy = descMap.Policy
 	col.VectorEmbeddings = descMap.VectorEmbeddings
 	col.Query = descMap.Query
 
-	for i, source := range descMap.Sources {
+	for i, source := range descMap.VersionSources {
 		sourceJson, err := json.Marshal(source)
 		if err != nil {
 			return err
@@ -324,7 +320,7 @@ func (col *CollectionVersion) UnmarshalJSON(bytes []byte) error {
 			return ErrFailedToUnmarshalCollection
 		}
 
-		col.Sources[i] = sourceValue
+		col.VersionSources[i] = sourceValue
 	}
 
 	return nil

--- a/client/collection_description.go
+++ b/client/collection_description.go
@@ -59,7 +59,7 @@ type CollectionVersion struct {
 	Query immutable.Option[QuerySource]
 
 	// VersionSources is the set of versions from which this collection may draws data from.
-	VersionSources []any
+	VersionSources []CollectionSource
 
 	// Fields contains the fields local to the node within this Collection.
 	//
@@ -221,21 +221,6 @@ func (col CollectionVersion) GetFieldByRelation(
 	return CollectionFieldDescription{}, false
 }
 
-// CollectionSources returns all the Sources of type [CollectionSource]
-func (col CollectionVersion) CollectionSources() []*CollectionSource {
-	return sourcesOfType[*CollectionSource](col)
-}
-
-func sourcesOfType[ResultType any](col CollectionVersion) []ResultType {
-	result := []ResultType{}
-	for _, source := range col.VersionSources {
-		if typedSource, isOfType := source.(ResultType); isOfType {
-			result = append(result, typedSource)
-		}
-	}
-	return result
-}
-
 // Equal returns true if this and the given [CollectionVersion] are equal.
 func (col CollectionVersion) Equal(other CollectionVersion) bool {
 	return reflect.DeepEqual(col, other)
@@ -259,7 +244,7 @@ type collectionVersion struct {
 	Indexes          []IndexDescription
 	Fields           []CollectionFieldDescription
 	VectorEmbeddings []VectorEmbeddingDescription
-	Query            immutable.Option[*QuerySource]
+	Query            immutable.Option[QuerySource]
 
 	// Properties below this line are unmarshalled using custom logic in [UnmarshalJSON]
 	VersionSources []map[string]json.RawMessage
@@ -283,7 +268,7 @@ func (col *CollectionVersion) UnmarshalJSON(bytes []byte) error {
 	col.IsPlaceholder = descMap.IsPlaceholder
 	col.Indexes = descMap.Indexes
 	col.Fields = descMap.Fields
-	col.VersionSources = make([]any, len(descMap.VersionSources))
+	col.VersionSources = make([]CollectionSource, len(descMap.VersionSources))
 	col.Policy = descMap.Policy
 	col.VectorEmbeddings = descMap.VectorEmbeddings
 	col.Query = descMap.Query
@@ -294,28 +279,15 @@ func (col *CollectionVersion) UnmarshalJSON(bytes []byte) error {
 			return err
 		}
 
-		var sourceValue any
-		// We detect which concrete type each `Source` object is by detecting
-		// non-nillable fields, if the key is present it must be of that type.
-		// They must be non-nillable as nil values may have their keys omitted from
-		// the json. This also relies on the fields being unique.  We may wish to change
-		// this later to custom-serialize with a `_type` property.
-		if _, ok := source["Query"]; ok {
-			// This must be a QuerySource, as only the `QuerySource` type has a `Query` field
-			var querySource QuerySource
-			err := json.Unmarshal(sourceJson, &querySource)
-			if err != nil {
-				return err
-			}
-			sourceValue = &querySource
-		} else if _, ok := source["SourceCollectionID"]; ok {
+		var sourceValue CollectionSource
+		if _, ok := source["SourceCollectionID"]; ok {
 			// This must be a CollectionSource, as only the `CollectionSource` type has a `SourceCollectionID` field
 			var collectionSource CollectionSource
 			err := json.Unmarshal(sourceJson, &collectionSource)
 			if err != nil {
 				return err
 			}
-			sourceValue = &collectionSource
+			sourceValue = collectionSource
 		} else {
 			return ErrFailedToUnmarshalCollection
 		}

--- a/client/collection_description.go
+++ b/client/collection_description.go
@@ -52,6 +52,12 @@ type CollectionVersion struct {
 	// If this CollectionVersion is not part of a collection set, this property will be None.
 	CollectionSet immutable.Option[CollectionSetDescription]
 
+	// Query may hold a query, along with a Lens transform to source data from.
+	//
+	// If a value is provided, this Collection may not be directly written too,
+	// and it may not (yet) have its documents synced across the P2P network.
+	Query immutable.Option[QuerySource]
+
 	// Sources is the set of sources from which this collection draws data.
 	//
 	// Currently supported source types are:
@@ -219,11 +225,6 @@ func (col CollectionVersion) GetFieldByRelation(
 	return CollectionFieldDescription{}, false
 }
 
-// QuerySources returns all the Sources of type [QuerySource]
-func (col CollectionVersion) QuerySources() []*QuerySource {
-	return sourcesOfType[*QuerySource](col)
-}
-
 // CollectionSources returns all the Sources of type [CollectionSource]
 func (col CollectionVersion) CollectionSources() []*CollectionSource {
 	return sourcesOfType[*CollectionSource](col)
@@ -262,6 +263,7 @@ type collectionVersion struct {
 	Indexes          []IndexDescription
 	Fields           []CollectionFieldDescription
 	VectorEmbeddings []VectorEmbeddingDescription
+	Query            immutable.Option[*QuerySource]
 
 	// Properties below this line are unmarshalled using custom logic in [UnmarshalJSON]
 	Sources []map[string]json.RawMessage
@@ -288,6 +290,7 @@ func (col *CollectionVersion) UnmarshalJSON(bytes []byte) error {
 	col.Sources = make([]any, len(descMap.Sources))
 	col.Policy = descMap.Policy
 	col.VectorEmbeddings = descMap.VectorEmbeddings
+	col.Query = descMap.Query
 
 	for i, source := range descMap.Sources {
 		sourceJson, err := json.Marshal(source)

--- a/docs/website/references/http/openapi.json
+++ b/docs/website/references/http/openapi.json
@@ -252,10 +252,7 @@
                         "type": "string"
                     },
                     "Policy": {},
-                    "Sources": {
-                        "items": {},
-                        "type": "array"
-                    },
+                    "Query": {},
                     "VectorEmbeddings": {
                         "items": {
                             "properties": {
@@ -287,6 +284,18 @@
                     },
                     "VersionID": {
                         "type": "string"
+                    },
+                    "VersionSources": {
+                        "items": {
+                            "properties": {
+                                "SourceCollectionID": {
+                                    "type": "string"
+                                },
+                                "Transform": {}
+                            },
+                            "type": "object"
+                        },
+                        "type": "array"
                     }
                 },
                 "type": "object"

--- a/internal/db/collection_define.go
+++ b/internal/db/collection_define.go
@@ -139,6 +139,12 @@ func (db *DB) patchCollection(
 	existingColsByName := map[string]client.CollectionVersion{}
 	existingColsByID := map[string]client.CollectionVersion{}
 	for _, col := range existingCols {
+		if col.VersionSources == nil {
+			// JSON patch only allows the `-` array-path to be used on non-nil
+			// arrays, so we assign any previously nil arrays to nil here
+			col.VersionSources = []client.CollectionSource{}
+		}
+
 		if col.IsActive {
 			existingColsByName[col.Name] = col
 		}

--- a/internal/db/collection_define.go
+++ b/internal/db/collection_define.go
@@ -141,7 +141,7 @@ func (db *DB) patchCollection(
 	for _, col := range existingCols {
 		if col.VersionSources == nil {
 			// JSON patch only allows the `-` array-path to be used on non-nil
-			// arrays, so we assign any previously nil arrays to nil here
+			// arrays, so we assign any previously nil arrays to empty here
 			col.VersionSources = []client.CollectionSource{}
 		}
 

--- a/internal/db/collection_define.go
+++ b/internal/db/collection_define.go
@@ -298,12 +298,10 @@ func (db *DB) patchCollection(
 					}
 				}
 			}
-			for _, src := range existingCol.QuerySources() {
-				if src.Transform.HasValue() {
-					err = db.LensRegistry().SetMigration(ctx, existingCol.VersionID, model.Lens{})
-					if err != nil {
-						return err
-					}
+			if existingCol.Query.HasValue() && existingCol.Query.Value().Transform.HasValue() {
+				err = db.LensRegistry().SetMigration(ctx, existingCol.VersionID, model.Lens{})
+				if err != nil {
+					return err
 				}
 			}
 		}
@@ -317,12 +315,10 @@ func (db *DB) patchCollection(
 			}
 		}
 
-		for _, src := range col.QuerySources() {
-			if src.Transform.HasValue() {
-				err = db.LensRegistry().SetMigration(ctx, col.VersionID, src.Transform.Value())
-				if err != nil {
-					return err
-				}
+		if col.Query.HasValue() && col.Query.Value().Transform.HasValue() {
+			err = db.LensRegistry().SetMigration(ctx, col.VersionID, col.Query.Value().Transform.Value())
+			if err != nil {
+				return err
 			}
 		}
 	}

--- a/internal/db/collection_define.go
+++ b/internal/db/collection_define.go
@@ -290,7 +290,7 @@ func (db *DB) patchCollection(
 			// Clear any existing migrations in the registry, using this semi-hacky way
 			// to avoid adding more functions to a public interface that we wish to remove.
 
-			for _, src := range existingCol.CollectionSources() {
+			for _, src := range existingCol.VersionSources {
 				if src.Transform.HasValue() {
 					err = db.LensRegistry().SetMigration(ctx, existingCol.VersionID, model.Lens{})
 					if err != nil {
@@ -306,7 +306,7 @@ func (db *DB) patchCollection(
 			}
 		}
 
-		for _, src := range col.CollectionSources() {
+		for _, src := range col.VersionSources {
 			if src.Transform.HasValue() {
 				err = db.LensRegistry().SetMigration(ctx, col.VersionID, src.Transform.Value())
 				if err != nil {

--- a/internal/db/collection_define.go
+++ b/internal/db/collection_define.go
@@ -245,7 +245,7 @@ func (db *DB) patchCollection(
 			isFound := false
 			for j, col := range newCollections {
 				if col.VersionID == placeholder.VersionID && !col.IsPlaceholder {
-					newCollections[j].Sources = placeholder.Sources
+					newCollections[j].VersionSources = placeholder.VersionSources
 					isFound = true
 					break
 				}

--- a/internal/db/collection_id.go
+++ b/internal/db/collection_id.go
@@ -501,7 +501,7 @@ func saveBlocks(
 				// it is incorrect and needs to be replaced by a reference to the new-old collection,
 				// using the new migration (if any) - this source was likely inherited by a patch command.
 
-				for i, _ := range oldCol.VersionSources {
+				for i := range oldCol.VersionSources {
 					collection.VersionSources[i] = newSource
 					break
 				}

--- a/internal/db/collection_id.go
+++ b/internal/db/collection_id.go
@@ -497,15 +497,15 @@ func saveBlocks(
 			if len(newColSources) == 0 {
 				// If the new collection has no collection sources, this is easy and we can just append
 				// one that references the old collection version.
-				collection.Sources = append(collection.Sources, newSource)
+				collection.VersionSources = append(collection.VersionSources, newSource)
 			} else if newColSources[0].SourceCollectionID == oldColSources[0].SourceCollectionID {
 				// If the new collection source references the same version as the old collection source
 				// it is incorrect and needs to be replaced by a reference to the new-old collection,
 				// using the new migration (if any) - this source was likely inherited by a patch command.
 
-				for i, source := range oldCol.Sources {
+				for i, source := range oldCol.VersionSources {
 					if _, ok := source.(*client.CollectionSource); ok {
-						collection.Sources[i] = newSource
+						collection.VersionSources[i] = newSource
 						break
 					}
 				}

--- a/internal/db/collection_id.go
+++ b/internal/db/collection_id.go
@@ -483,31 +483,27 @@ func saveBlocks(
 
 		colIds = append(colIds, cid)
 
-		newColSources := collection.CollectionSources()
-		oldColSources := oldCol.CollectionSources()
-		if oldCol.VersionID != "" && len(newColSources) == len(oldColSources) {
+		if oldCol.VersionID != "" && len(collection.VersionSources) == len(oldCol.VersionSources) {
 			// The new collection source may have been copied from the old collection source,
 			// or, it may not have been added and needs to be done here.  Either way the new
 			// collection needs a collection source that references the old collection version.
-			newSource := &client.CollectionSource{
+			newSource := client.CollectionSource{
 				SourceCollectionID: oldCol.VersionID,
 				Transform:          migration,
 			}
 
-			if len(newColSources) == 0 {
+			if len(collection.VersionSources) == 0 {
 				// If the new collection has no collection sources, this is easy and we can just append
 				// one that references the old collection version.
 				collection.VersionSources = append(collection.VersionSources, newSource)
-			} else if newColSources[0].SourceCollectionID == oldColSources[0].SourceCollectionID {
+			} else if collection.VersionSources[0].SourceCollectionID == oldCol.VersionSources[0].SourceCollectionID {
 				// If the new collection source references the same version as the old collection source
 				// it is incorrect and needs to be replaced by a reference to the new-old collection,
 				// using the new migration (if any) - this source was likely inherited by a patch command.
 
-				for i, source := range oldCol.VersionSources {
-					if _, ok := source.(*client.CollectionSource); ok {
-						collection.VersionSources[i] = newSource
-						break
-					}
+				for i, _ := range oldCol.VersionSources {
+					collection.VersionSources[i] = newSource
+					break
 				}
 			}
 		}

--- a/internal/db/definition_validation.go
+++ b/internal/db/definition_validation.go
@@ -268,7 +268,7 @@ func validateSecondaryFieldsPairUp(
 ) error {
 	var errs []error
 	for _, newCollection := range newState.collections {
-		if len(newCollection.QuerySources()) > 0 {
+		if newCollection.Query.HasValue() {
 			// Views do not require both sides of the relation to be defined.
 			continue
 		}
@@ -450,10 +450,7 @@ func validateSourcesNotRedefined(
 			}
 		}
 
-		newQuerySources := newCol.QuerySources()
-		oldQuerySources := oldCol.QuerySources()
-
-		if len(newQuerySources) != len(oldQuerySources) {
+		if newCol.Query.HasValue() != oldCol.Query.HasValue() {
 			errs = append(errs, NewErrCollectionSourcesCannotBeAddedRemoved(newCol.VersionID))
 		}
 	}
@@ -1059,7 +1056,7 @@ func validateCollectionMaterialized(
 ) error {
 	var errs []error
 	for _, col := range newState.collections {
-		if len(col.QuerySources()) == 0 && !col.IsMaterialized {
+		if !col.Query.HasValue() && !col.IsMaterialized {
 			errs = append(errs, NewErrColNotMaterialized(col.Name))
 		}
 	}
@@ -1078,7 +1075,7 @@ func validateMaterializedHasNoPolicy(
 ) error {
 	var errs []error
 	for _, col := range newState.collections {
-		if col.IsMaterialized && len(col.QuerySources()) != 0 && col.Policy.HasValue() {
+		if col.IsMaterialized && col.Query.HasValue() && col.Policy.HasValue() {
 			errs = append(errs, NewErrMaterializedViewAndACPNotSupported(col.Name))
 		}
 	}

--- a/internal/db/definition_validation.go
+++ b/internal/db/definition_validation.go
@@ -430,22 +430,19 @@ func validateSourcesNotRedefined(
 			continue
 		}
 
-		newColSources := newCol.CollectionSources()
-		oldColSources := oldCol.CollectionSources()
-
-		if len(newColSources) != len(oldColSources) {
+		if len(newCol.VersionSources) != len(oldCol.VersionSources) {
 			errs = append(errs, NewErrCollectionSourcesCannotBeAddedRemoved(newCol.VersionID))
 		}
 
-		for i := range newColSources {
-			if i >= len(oldColSources) {
+		for i := range newCol.VersionSources {
+			if i >= len(oldCol.VersionSources) {
 				continue // Avoid out-of-bounds panic
 			}
-			if newColSources[i].SourceCollectionID != oldColSources[i].SourceCollectionID {
+			if newCol.VersionSources[i].SourceCollectionID != oldCol.VersionSources[i].SourceCollectionID {
 				errs = append(errs, NewErrCollectionSourceIDMutated(
 					newCol.VersionID,
-					newColSources[i].SourceCollectionID,
-					oldColSources[i].SourceCollectionID,
+					newCol.VersionSources[i].SourceCollectionID,
+					oldCol.VersionSources[i].SourceCollectionID,
 				))
 			}
 		}
@@ -1032,7 +1029,7 @@ func validateCollectionSourceFromSameCollection(
 			continue
 		}
 
-		for _, source := range col.CollectionSources() {
+		for _, source := range col.VersionSources {
 			for _, otherCol := range newState.collections {
 				if otherCol.VersionID == source.SourceCollectionID &&
 					otherCol.CollectionID != col.CollectionID {

--- a/internal/db/lens.go
+++ b/internal/db/lens.go
@@ -64,12 +64,12 @@ func (db *DB) setMigration(ctx context.Context, cfg client.LensConfig) error {
 			// If the destingation collection has no sources at all, it must have been added as an orphaned source
 			// by another migration.  This can happen if the migrations are added in an unusual order, before
 			// their schemas have been defined locally.
-			dstCol.VersionSources = append(dstCol.VersionSources, &client.CollectionSource{
+			dstCol.VersionSources = append(dstCol.VersionSources, client.CollectionSource{
 				SourceCollectionID: sourceCol.VersionID,
 			})
 		}
 
-		for _, source := range dstCol.CollectionSources() {
+		for _, source := range dstCol.VersionSources {
 			if source.SourceCollectionID == sourceCol.VersionID {
 				isDstCollectionFound = true
 				break
@@ -84,8 +84,8 @@ func (db *DB) setMigration(ctx context.Context, cfg client.LensConfig) error {
 			IsMaterialized: true,
 			IsPlaceholder:  true,
 			CollectionID:   sourceCol.CollectionID,
-			VersionSources: []any{
-				&client.CollectionSource{
+			VersionSources: []client.CollectionSource{
+				{
 					SourceCollectionID: sourceCol.VersionID,
 					// The transform will be set later, when updating all destination collections
 					// whether they are newly created or not.
@@ -99,13 +99,12 @@ func (db *DB) setMigration(ctx context.Context, cfg client.LensConfig) error {
 		}
 	}
 
-	collectionSources := dstCol.CollectionSources()
-	for _, source := range collectionSources {
+	for i := range dstCol.VersionSources {
 		// WARNING: Here we assume that the collection source points at a collection of the source schema version.
 		// This works currently, as collections only have a single source.  If/when this changes we need to make
 		// sure we only update the correct source.
 
-		source.Transform = immutable.Some(cfg.Lens)
+		dstCol.VersionSources[i].Transform = immutable.Some(cfg.Lens)
 
 		err = db.LensRegistry().SetMigration(ctx, dstCol.VersionID, cfg.Lens)
 		if err != nil {

--- a/internal/db/lens.go
+++ b/internal/db/lens.go
@@ -60,11 +60,11 @@ func (db *DB) setMigration(ctx context.Context, cfg client.LensConfig) error {
 
 	isDstCollectionFound := false
 	if dstFound {
-		if len(dstCol.Sources) == 0 {
+		if len(dstCol.VersionSources) == 0 {
 			// If the destingation collection has no sources at all, it must have been added as an orphaned source
 			// by another migration.  This can happen if the migrations are added in an unusual order, before
 			// their schemas have been defined locally.
-			dstCol.Sources = append(dstCol.Sources, &client.CollectionSource{
+			dstCol.VersionSources = append(dstCol.VersionSources, &client.CollectionSource{
 				SourceCollectionID: sourceCol.VersionID,
 			})
 		}
@@ -84,7 +84,7 @@ func (db *DB) setMigration(ctx context.Context, cfg client.LensConfig) error {
 			IsMaterialized: true,
 			IsPlaceholder:  true,
 			CollectionID:   sourceCol.CollectionID,
-			Sources: []any{
+			VersionSources: []any{
 				&client.CollectionSource{
 					SourceCollectionID: sourceCol.VersionID,
 					// The transform will be set later, when updating all destination collections

--- a/internal/db/view.go
+++ b/internal/db/view.go
@@ -70,7 +70,7 @@ func (db *DB) addView(
 			Query:     *baseQuery,
 			Transform: transform,
 		}
-		parseResults[i].Definition.Sources = append(parseResults[i].Definition.Sources, &source)
+		parseResults[i].Definition.Query = immutable.Some(source)
 	}
 
 	returnDescriptions, err := db.createCollections(ctx, parseResults)
@@ -79,12 +79,10 @@ func (db *DB) addView(
 	}
 
 	for _, definition := range returnDescriptions {
-		for _, source := range definition.QuerySources() {
-			if source.Transform.HasValue() {
-				err = db.LensRegistry().SetMigration(ctx, definition.VersionID, source.Transform.Value())
-				if err != nil {
-					return nil, err
-				}
+		if definition.Query.HasValue() && definition.Query.Value().Transform.HasValue() {
+			err = db.LensRegistry().SetMigration(ctx, definition.VersionID, definition.Query.Value().Transform.Value())
+			if err != nil {
+				return nil, err
 			}
 		}
 	}
@@ -135,7 +133,7 @@ func (db *DB) getViews(ctx context.Context, opts client.CollectionFetchOptions) 
 
 	var views []client.CollectionVersion
 	for _, col := range cols {
-		if querySrcs := col.Version().QuerySources(); len(querySrcs) == 0 {
+		if !col.Version().Query.HasValue() {
 			continue
 		}
 

--- a/internal/lens/fetcher.go
+++ b/internal/lens/fetcher.go
@@ -98,7 +98,7 @@ func (f *lensedFetcher) Init(
 
 historyLoop:
 	for _, historyItem := range history {
-		sources := historyItem.collection.CollectionSources()
+		sources := historyItem.collection.VersionSources
 		for _, source := range sources {
 			if source.Transform.HasValue() {
 				f.hasMigrations = true

--- a/internal/lens/history.go
+++ b/internal/lens/history.go
@@ -161,7 +161,7 @@ func getCollectionHistory(
 	}
 
 	for _, historyItem := range history {
-		for _, source := range historyItem.collection.CollectionSources() {
+		for _, source := range historyItem.collection.VersionSources {
 			src := history[source.SourceCollectionID]
 			historyItem.previous = append(
 				historyItem.previous,

--- a/internal/lens/registry.go
+++ b/internal/lens/registry.go
@@ -56,9 +56,7 @@ func (r *LensRegistry) ReloadLenses(ctx context.Context) error {
 	}
 
 	for _, col := range cols {
-		sources := col.CollectionSources()
-
-		if len(sources) == 0 {
+		if len(col.VersionSources) == 0 {
 			continue
 		}
 
@@ -66,11 +64,11 @@ func (r *LensRegistry) ReloadLenses(ctx context.Context) error {
 		// currently collections can only have one source, however this code will need to change if/when
 		// collections support multiple sources.
 
-		if !sources[0].Transform.HasValue() {
+		if !col.VersionSources[0].Transform.HasValue() {
 			continue
 		}
 
-		err = r.SetMigration(ctx, col.VersionID, sources[0].Transform.Value())
+		err = r.SetMigration(ctx, col.VersionID, col.VersionSources[0].Transform.Value())
 		if err != nil {
 			return err
 		}

--- a/internal/planner/datasource.go
+++ b/internal/planner/datasource.go
@@ -32,7 +32,7 @@ func (p *Planner) getCollectionScanPlan(mapperSelect *mapper.Select) (planSource
 	}
 
 	var plan planNode
-	if len(col.Version().QuerySources()) > 0 {
+	if col.Version().Query.HasValue() {
 		var err error
 		plan, err = p.View(mapperSelect, col)
 		if err != nil {

--- a/internal/planner/select.go
+++ b/internal/planner/select.go
@@ -473,7 +473,7 @@ func (n *selectNode) initFields(selectReq *mapper.Select) ([]aggregateNode, []*s
 				n.groupSelects = append(n.groupSelects, f)
 			} else if isSpecialNoOpField(f, selectReq) {
 				// no-op
-			} else if !(n.collection != nil && len(n.collection.Version().QuerySources()) > 0) {
+			} else if !(n.collection != nil && n.collection.Version().Query.HasValue()) {
 				// Collections sourcing data from queries only contain embedded objects and don't require
 				// a traditional join here
 				err := n.addTypeIndexJoin(f)

--- a/internal/planner/view.go
+++ b/internal/planner/view.go
@@ -34,15 +34,14 @@ type viewNode struct {
 }
 
 func (p *Planner) View(query *mapper.Select, col client.Collection) (planNode, error) {
-	// For now, we assume a single source.  This will need to change if/when we support multiple sources
-	querySource := (col.Version().Sources[0].(*client.QuerySource))
-	hasTransform := querySource.Transform.HasValue()
+	hasTransform := col.Version().Query.Value().Transform.HasValue()
 
 	var source planNode
 	if col.Version().IsMaterialized {
 		source = p.newCachedViewFetcher(col.Version(), query.DocumentMapping)
 	} else {
-		m, err := mapper.ToSelect(p.ctx, p.db, mapper.ObjectSelection, &querySource.Query)
+		viewQuery := col.Version().Query.Value().Query
+		m, err := mapper.ToSelect(p.ctx, p.db, mapper.ObjectSelection, &viewQuery)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/request/graphql/schema/generate.go
+++ b/internal/request/graphql/schema/generate.go
@@ -219,7 +219,7 @@ func (g *Generator) generate(ctx context.Context, collections []client.Collectio
 		var collectionFound bool
 		for _, definition := range collections {
 			if t.Name() == definition.Name {
-				isReadOnly = len(definition.QuerySources()) > 0
+				isReadOnly = definition.Query.HasValue()
 				collectionFound = true
 				break
 			}
@@ -435,7 +435,7 @@ func (g *Generator) buildTypes(
 
 	for _, collection := range collections {
 		fieldDescriptions := collection.Fields
-		isQuerySource := len(collection.QuerySources()) > 0
+		isQuerySource := collection.Query.HasValue()
 		isViewObject := collection.IsEmbeddedOnly || isQuerySource
 
 		// check if type exists

--- a/tests/action/results.go
+++ b/tests/action/results.go
@@ -86,10 +86,10 @@ func assertCollectionVersions(
 			require.Equal(s.T, expected.Indexes, actual.Indexes)
 		}
 
-		if expected.Sources != nil {
+		if expected.VersionSources != nil {
 			// Dont bother asserting this if the expected is nil and the actual is nil/empty.
 			// This is to save each test action from having to bother declaring an empty slice (if there are no sources)
-			require.Equal(s.T, expected.Sources, actual.Sources)
+			require.Equal(s.T, expected.VersionSources, actual.VersionSources)
 		}
 
 		if expected.Query.HasValue() {

--- a/tests/action/results.go
+++ b/tests/action/results.go
@@ -92,6 +92,11 @@ func assertCollectionVersions(
 			require.Equal(s.T, expected.Sources, actual.Sources)
 		}
 
+		if expected.Query.HasValue() {
+			// Dont bother asserting this by default, the query object is to complex to bother with in most cases.
+			require.Equal(s.T, expected.Query, actual.Query)
+		}
+
 		if expected.Fields != nil {
 			require.Equal(s.T, len(expected.Fields), len(actual.Fields))
 			for i := range expected.Fields {

--- a/tests/integration/collection_version/migrations/simple_test.go
+++ b/tests/integration/collection_version/migrations/simple_test.go
@@ -51,8 +51,8 @@ func TestSchemaMigrationDoesNotErrorGivenUnknownSchemaRoots(t *testing.T) {
 					{
 						VersionID:      "also does not exist",
 						IsMaterialized: true,
-						VersionSources: []any{
-							&client.CollectionSource{
+						VersionSources: []client.CollectionSource{
+							{
 								SourceCollectionID: "does not exist",
 								Transform: immutable.Some(
 									model.Lens{
@@ -127,8 +127,8 @@ func TestSchemaMigrationGetMigrationsReturnsMultiple(t *testing.T) {
 					{
 						VersionID:      "also does not exist",
 						IsMaterialized: true,
-						VersionSources: []any{
-							&client.CollectionSource{
+						VersionSources: []client.CollectionSource{
+							{
 								SourceCollectionID: "does not exist",
 								Transform: immutable.Some(
 									model.Lens{
@@ -149,8 +149,8 @@ func TestSchemaMigrationGetMigrationsReturnsMultiple(t *testing.T) {
 					{
 						IsMaterialized: true,
 						VersionID:      "bafyreig2nfxuzl3cob7txuvybcct6mmsylt57oirzsrehffkho6bdxlvwy",
-						VersionSources: []any{
-							&client.CollectionSource{
+						VersionSources: []client.CollectionSource{
+							{
 								SourceCollectionID: "bafyreigsld6ten2pppcu2tgkbexqwdndckp6zt2vfjhuuheykqkgpmwk7i",
 								Transform: immutable.Some(
 									model.Lens{
@@ -234,8 +234,8 @@ func TestSchemaMigrationReplacesExistingMigationBasedOnSourceID(t *testing.T) {
 					{
 						VersionID:      "b",
 						IsMaterialized: true,
-						VersionSources: []any{
-							&client.CollectionSource{
+						VersionSources: []client.CollectionSource{
+							{
 								SourceCollectionID: "a",
 								Transform: immutable.Some(
 									model.Lens{
@@ -256,8 +256,8 @@ func TestSchemaMigrationReplacesExistingMigationBasedOnSourceID(t *testing.T) {
 					{
 						VersionID:      "c",
 						IsMaterialized: true,
-						VersionSources: []any{
-							&client.CollectionSource{
+						VersionSources: []client.CollectionSource{
+							{
 								SourceCollectionID: "a",
 								Transform: immutable.Some(
 									model.Lens{

--- a/tests/integration/collection_version/migrations/simple_test.go
+++ b/tests/integration/collection_version/migrations/simple_test.go
@@ -51,7 +51,7 @@ func TestSchemaMigrationDoesNotErrorGivenUnknownSchemaRoots(t *testing.T) {
 					{
 						VersionID:      "also does not exist",
 						IsMaterialized: true,
-						Sources: []any{
+						VersionSources: []any{
 							&client.CollectionSource{
 								SourceCollectionID: "does not exist",
 								Transform: immutable.Some(
@@ -127,7 +127,7 @@ func TestSchemaMigrationGetMigrationsReturnsMultiple(t *testing.T) {
 					{
 						VersionID:      "also does not exist",
 						IsMaterialized: true,
-						Sources: []any{
+						VersionSources: []any{
 							&client.CollectionSource{
 								SourceCollectionID: "does not exist",
 								Transform: immutable.Some(
@@ -149,7 +149,7 @@ func TestSchemaMigrationGetMigrationsReturnsMultiple(t *testing.T) {
 					{
 						IsMaterialized: true,
 						VersionID:      "bafyreig2nfxuzl3cob7txuvybcct6mmsylt57oirzsrehffkho6bdxlvwy",
-						Sources: []any{
+						VersionSources: []any{
 							&client.CollectionSource{
 								SourceCollectionID: "bafyreigsld6ten2pppcu2tgkbexqwdndckp6zt2vfjhuuheykqkgpmwk7i",
 								Transform: immutable.Some(
@@ -234,7 +234,7 @@ func TestSchemaMigrationReplacesExistingMigationBasedOnSourceID(t *testing.T) {
 					{
 						VersionID:      "b",
 						IsMaterialized: true,
-						Sources: []any{
+						VersionSources: []any{
 							&client.CollectionSource{
 								SourceCollectionID: "a",
 								Transform: immutable.Some(
@@ -256,7 +256,7 @@ func TestSchemaMigrationReplacesExistingMigationBasedOnSourceID(t *testing.T) {
 					{
 						VersionID:      "c",
 						IsMaterialized: true,
-						Sources: []any{
+						VersionSources: []any{
 							&client.CollectionSource{
 								SourceCollectionID: "a",
 								Transform: immutable.Some(

--- a/tests/integration/collection_version/migrations/with_txn_test.go
+++ b/tests/integration/collection_version/migrations/with_txn_test.go
@@ -51,7 +51,7 @@ func TestSchemaMigrationGetMigrationsWithTxn(t *testing.T) {
 					{
 						VersionID:      "also does not exist",
 						IsMaterialized: true,
-						Sources: []any{
+						VersionSources: []any{
 							&client.CollectionSource{
 								SourceCollectionID: "does not exist",
 								Transform: immutable.Some(

--- a/tests/integration/collection_version/migrations/with_txn_test.go
+++ b/tests/integration/collection_version/migrations/with_txn_test.go
@@ -51,8 +51,8 @@ func TestSchemaMigrationGetMigrationsWithTxn(t *testing.T) {
 					{
 						VersionID:      "also does not exist",
 						IsMaterialized: true,
-						VersionSources: []any{
-							&client.CollectionSource{
+						VersionSources: []client.CollectionSource{
+							{
 								SourceCollectionID: "does not exist",
 								Transform: immutable.Some(
 									model.Lens{

--- a/tests/integration/collection_version/updates/add/simple_test.go
+++ b/tests/integration/collection_version/updates/add/simple_test.go
@@ -50,8 +50,6 @@ func TestSchemaUpdatesAddSimpleErrorsAddingSchema(t *testing.T) {
 	testUtils.ExecuteTestCase(t, test)
 }
 
-// This test documents unwanted behaviour, it should fail but it does not, likely due to the `Sources` json
-// deserialization magic.  This bug is documented by https://github.com/sourcenetwork/defradb/issues/3795
 func TestSchemaUpdatesAddSimpleErrorsAddingSchemaProp(t *testing.T) {
 	test := testUtils.TestCase{
 		Actions: []any{
@@ -68,9 +66,7 @@ func TestSchemaUpdatesAddSimpleErrorsAddingSchemaProp(t *testing.T) {
 						{ "op": "add", "path": "/Users/-", "value": {"Foo": "Bar"} }
 					]
 				`,
-				ExpectedError: "",
-				// Below is the desired error
-				//ExpectedError: `json: unknown field "-"`,
+				ExpectedError: `json: unknown field "-"`,
 			},
 		},
 	}

--- a/tests/integration/collection_version/updates/add/sources_test.go
+++ b/tests/integration/collection_version/updates/add/sources_test.go
@@ -30,7 +30,7 @@ func TestColVersionUpdateAddSources_Errors(t *testing.T) {
 					[
 						{
 							"op": "add",
-							"path": "/bafyreihdbjfazsx5vq2tpzedqdktrjyn6lq22qle7el2s42b3q4zpxmwqq/Sources/-",
+							"path": "/bafyreihdbjfazsx5vq2tpzedqdktrjyn6lq22qle7el2s42b3q4zpxmwqq/VersionSources/-",
 							"value": {"SourceCollectionID": "bafyreihdbjfazsx5vq2tpzedqdktrjyn6lq22qle7el2s42b3q4zpxmwqq"}
 						}
 					]

--- a/tests/integration/collection_version/updates/remove/col_source_transform_test.go
+++ b/tests/integration/collection_version/updates/remove/col_source_transform_test.go
@@ -59,7 +59,7 @@ func TestColVersionUpdateRemoveCollectionSourceTransform(t *testing.T) {
 					[
 						{
 							"op": "remove",
-							"path": "/Users/Sources/0/Transform"
+							"path": "/Users/VersionSources/0/Transform"
 						}
 					]
 				`,

--- a/tests/integration/collection_version/updates/replace/col_source_source_id_test.go
+++ b/tests/integration/collection_version/updates/replace/col_source_source_id_test.go
@@ -44,7 +44,7 @@ func TestColVersionUpdateReplaceCollectionSourceSourceCollectionID_Errors(t *tes
 					[
 						{
 							"op": "replace",
-							"path": "/Users/Sources/0/SourceCollectionID",
+							"path": "/Users/VersionSources/0/SourceCollectionID",
 							"value": "gfddsfaa"
 						}
 					]

--- a/tests/integration/collection_version/updates/replace/col_source_transform_test.go
+++ b/tests/integration/collection_version/updates/replace/col_source_transform_test.go
@@ -66,7 +66,7 @@ func TestColVersionUpdateReplaceCollectionSourceTransform(t *testing.T) {
 						[
 							{
 								"op": "replace",
-								"path": "/Users/Sources/0/Transform",
+								"path": "/Users/VersionSources/0/Transform",
 								"value": %s
 							}
 						]

--- a/tests/integration/collection_version/updates/replace/query_source_query_test.go
+++ b/tests/integration/collection_version/updates/replace/query_source_query_test.go
@@ -58,7 +58,7 @@ func TestColVersionUpdateReplaceQuerySourceQuery(t *testing.T) {
 					[
 						{
 							"op": "replace",
-							"path": "/View/Sources/0/Query",
+							"path": "/View/Query/Query",
 							"value": {"Name": "Users", "Fields":[{"Name":"name"}]}
 						}
 					]
@@ -126,7 +126,7 @@ func TestColVersionUpdateReplaceQuerySourceQueryName(t *testing.T) {
 					[
 						{
 							"op": "replace",
-							"path": "/View/Sources/0/Query/Name",
+							"path": "/View/Query/Query/Name",
 							"value": "Users"
 						}
 					]

--- a/tests/integration/collection_version/updates/replace/query_source_transform_test.go
+++ b/tests/integration/collection_version/updates/replace/query_source_transform_test.go
@@ -82,7 +82,7 @@ func TestColVersionUpdateReplaceQuerySourceTransform(t *testing.T) {
 						[
 							{
 								"op": "replace",
-								"path": "/UserView/Sources/0/Transform",
+								"path": "/UserView/Query/Transform",
 								"value": %s
 							}
 						]

--- a/tests/integration/collection_version/updates/replace/sources_test.go
+++ b/tests/integration/collection_version/updates/replace/sources_test.go
@@ -56,8 +56,8 @@ func TestColVersionUpdateReplaceSourcesWithQuerySource_Errors(t *testing.T) {
 					[
 						{
 							"op": "replace",
-							"path": "/bafyreihdbjfazsx5vq2tpzedqdktrjyn6lq22qle7el2s42b3q4zpxmwqq/Sources",
-							"value": [{"Query": {"Name": "Users"}}]
+							"path": "/bafyreihdbjfazsx5vq2tpzedqdktrjyn6lq22qle7el2s42b3q4zpxmwqq/Query",
+							"value": {"Query": {"Name": "Users"}}
 						}
 					]
 				`,

--- a/tests/integration/collection_version/updates/replace/sources_test.go
+++ b/tests/integration/collection_version/updates/replace/sources_test.go
@@ -30,7 +30,7 @@ func TestColVersionUpdateReplaceSources_Errors(t *testing.T) {
 					[
 						{
 							"op": "replace",
-							"path": "/bafyreihdbjfazsx5vq2tpzedqdktrjyn6lq22qle7el2s42b3q4zpxmwqq/Sources",
+							"path": "/bafyreihdbjfazsx5vq2tpzedqdktrjyn6lq22qle7el2s42b3q4zpxmwqq/VersionSources",
 							"value": [{"SourceCollectionID": "bafyreihdbjfazsx5vq2tpzedqdktrjyn6lq22qle7el2s42b3q4zpxmwqq"}]
 						}
 					]

--- a/tests/integration/collection_version/updates/with_version_branch_test.go
+++ b/tests/integration/collection_version/updates/with_version_branch_test.go
@@ -149,7 +149,7 @@ func TestSchemaUpdates_WithBranchingSchema(t *testing.T) {
 						Name:           "Users",
 						VersionID:      schemaVersion2ID,
 						IsMaterialized: true,
-						Sources: []any{
+						VersionSources: []any{
 							&client.CollectionSource{
 								SourceCollectionID: schemaVersion1ID,
 							},
@@ -168,7 +168,7 @@ func TestSchemaUpdates_WithBranchingSchema(t *testing.T) {
 						VersionID:      schemaVersion3ID,
 						IsMaterialized: true,
 						IsActive:       true,
-						Sources: []any{
+						VersionSources: []any{
 							&client.CollectionSource{
 								SourceCollectionID: schemaVersion1ID,
 							},
@@ -285,7 +285,7 @@ func TestSchemaUpdates_WithPatchOnBranchedSchema(t *testing.T) {
 						VersionID:      schemaVersion2ID,
 						IsMaterialized: true,
 						IsActive:       false,
-						Sources: []any{
+						VersionSources: []any{
 							&client.CollectionSource{
 								SourceCollectionID: schemaVersion1ID,
 							},
@@ -305,7 +305,7 @@ func TestSchemaUpdates_WithPatchOnBranchedSchema(t *testing.T) {
 						VersionID:      schemaVersion4ID,
 						IsMaterialized: true,
 						IsActive:       true,
-						Sources: []any{
+						VersionSources: []any{
 							&client.CollectionSource{
 								SourceCollectionID: schemaVersion3ID,
 							},
@@ -318,7 +318,7 @@ func TestSchemaUpdates_WithPatchOnBranchedSchema(t *testing.T) {
 						VersionID:      schemaVersion3ID,
 						IsMaterialized: true,
 						IsActive:       false,
-						Sources: []any{
+						VersionSources: []any{
 							&client.CollectionSource{
 								SourceCollectionID: schemaVersion1ID,
 							},
@@ -400,7 +400,7 @@ func TestSchemaUpdates_WithBranchingSchemaAndSetActiveSchemaToOtherBranch(t *tes
 						VersionID:      schemaVersion2ID,
 						IsMaterialized: true,
 						IsActive:       true,
-						Sources: []any{
+						VersionSources: []any{
 							&client.CollectionSource{
 								SourceCollectionID: schemaVersion1ID,
 							},
@@ -420,7 +420,7 @@ func TestSchemaUpdates_WithBranchingSchemaAndSetActiveSchemaToOtherBranch(t *tes
 						VersionID:      schemaVersion3ID,
 						IsMaterialized: true,
 						IsActive:       false,
-						Sources: []any{
+						VersionSources: []any{
 							&client.CollectionSource{
 								SourceCollectionID: schemaVersion1ID,
 							},
@@ -541,7 +541,7 @@ func TestSchemaUpdates_WithBranchingSchemaAndSetActiveSchemaToOtherBranchThenPat
 						VersionID:      schemaVersion2ID,
 						IsMaterialized: true,
 						IsActive:       false,
-						Sources: []any{
+						VersionSources: []any{
 							&client.CollectionSource{
 								SourceCollectionID: schemaVersion1ID,
 							},
@@ -561,7 +561,7 @@ func TestSchemaUpdates_WithBranchingSchemaAndSetActiveSchemaToOtherBranchThenPat
 						VersionID:      schemaVersion4ID,
 						IsMaterialized: true,
 						IsActive:       true,
-						Sources: []any{
+						VersionSources: []any{
 							&client.CollectionSource{
 								SourceCollectionID: schemaVersion2ID,
 							},
@@ -574,7 +574,7 @@ func TestSchemaUpdates_WithBranchingSchemaAndSetActiveSchemaToOtherBranchThenPat
 						VersionID:      schemaVersion3ID,
 						IsMaterialized: true,
 						IsActive:       false,
-						Sources: []any{
+						VersionSources: []any{
 							&client.CollectionSource{
 								SourceCollectionID: schemaVersion1ID,
 							},

--- a/tests/integration/collection_version/updates/with_version_branch_test.go
+++ b/tests/integration/collection_version/updates/with_version_branch_test.go
@@ -149,8 +149,8 @@ func TestSchemaUpdates_WithBranchingSchema(t *testing.T) {
 						Name:           "Users",
 						VersionID:      schemaVersion2ID,
 						IsMaterialized: true,
-						VersionSources: []any{
-							&client.CollectionSource{
+						VersionSources: []client.CollectionSource{
+							{
 								SourceCollectionID: schemaVersion1ID,
 							},
 						},
@@ -168,8 +168,8 @@ func TestSchemaUpdates_WithBranchingSchema(t *testing.T) {
 						VersionID:      schemaVersion3ID,
 						IsMaterialized: true,
 						IsActive:       true,
-						VersionSources: []any{
-							&client.CollectionSource{
+						VersionSources: []client.CollectionSource{
+							{
 								SourceCollectionID: schemaVersion1ID,
 							},
 						},
@@ -285,8 +285,8 @@ func TestSchemaUpdates_WithPatchOnBranchedSchema(t *testing.T) {
 						VersionID:      schemaVersion2ID,
 						IsMaterialized: true,
 						IsActive:       false,
-						VersionSources: []any{
-							&client.CollectionSource{
+						VersionSources: []client.CollectionSource{
+							{
 								SourceCollectionID: schemaVersion1ID,
 							},
 						},
@@ -305,8 +305,8 @@ func TestSchemaUpdates_WithPatchOnBranchedSchema(t *testing.T) {
 						VersionID:      schemaVersion4ID,
 						IsMaterialized: true,
 						IsActive:       true,
-						VersionSources: []any{
-							&client.CollectionSource{
+						VersionSources: []client.CollectionSource{
+							{
 								SourceCollectionID: schemaVersion3ID,
 							},
 						},
@@ -318,8 +318,8 @@ func TestSchemaUpdates_WithPatchOnBranchedSchema(t *testing.T) {
 						VersionID:      schemaVersion3ID,
 						IsMaterialized: true,
 						IsActive:       false,
-						VersionSources: []any{
-							&client.CollectionSource{
+						VersionSources: []client.CollectionSource{
+							{
 								SourceCollectionID: schemaVersion1ID,
 							},
 						},
@@ -400,8 +400,8 @@ func TestSchemaUpdates_WithBranchingSchemaAndSetActiveSchemaToOtherBranch(t *tes
 						VersionID:      schemaVersion2ID,
 						IsMaterialized: true,
 						IsActive:       true,
-						VersionSources: []any{
-							&client.CollectionSource{
+						VersionSources: []client.CollectionSource{
+							{
 								SourceCollectionID: schemaVersion1ID,
 							},
 						},
@@ -420,8 +420,8 @@ func TestSchemaUpdates_WithBranchingSchemaAndSetActiveSchemaToOtherBranch(t *tes
 						VersionID:      schemaVersion3ID,
 						IsMaterialized: true,
 						IsActive:       false,
-						VersionSources: []any{
-							&client.CollectionSource{
+						VersionSources: []client.CollectionSource{
+							{
 								SourceCollectionID: schemaVersion1ID,
 							},
 						},
@@ -541,8 +541,8 @@ func TestSchemaUpdates_WithBranchingSchemaAndSetActiveSchemaToOtherBranchThenPat
 						VersionID:      schemaVersion2ID,
 						IsMaterialized: true,
 						IsActive:       false,
-						VersionSources: []any{
-							&client.CollectionSource{
+						VersionSources: []client.CollectionSource{
+							{
 								SourceCollectionID: schemaVersion1ID,
 							},
 						},
@@ -561,8 +561,8 @@ func TestSchemaUpdates_WithBranchingSchemaAndSetActiveSchemaToOtherBranchThenPat
 						VersionID:      schemaVersion4ID,
 						IsMaterialized: true,
 						IsActive:       true,
-						VersionSources: []any{
-							&client.CollectionSource{
+						VersionSources: []client.CollectionSource{
+							{
 								SourceCollectionID: schemaVersion2ID,
 							},
 						},
@@ -574,8 +574,8 @@ func TestSchemaUpdates_WithBranchingSchemaAndSetActiveSchemaToOtherBranchThenPat
 						VersionID:      schemaVersion3ID,
 						IsMaterialized: true,
 						IsActive:       false,
-						VersionSources: []any{
-							&client.CollectionSource{
+						VersionSources: []client.CollectionSource{
+							{
 								SourceCollectionID: schemaVersion1ID,
 							},
 						},

--- a/tests/integration/results.go
+++ b/tests/integration/results.go
@@ -405,6 +405,11 @@ func assertCollectionVersions(
 			require.Equal(s.T, expected.Sources, actual.Sources)
 		}
 
+		if expected.Query.HasValue() {
+			// Dont bother asserting this by default, the query object is to complex to bother with in most cases.
+			require.Equal(s.T, expected.Query, actual.Query)
+		}
+
 		if expected.Fields != nil {
 			require.Equal(s.T, len(expected.Fields), len(actual.Fields))
 			for i := range expected.Fields {

--- a/tests/integration/results.go
+++ b/tests/integration/results.go
@@ -399,10 +399,10 @@ func assertCollectionVersions(
 			require.Equal(s.T, expected.Indexes, actual.Indexes)
 		}
 
-		if expected.Sources != nil {
+		if expected.VersionSources != nil {
 			// Dont bother asserting this if the expected is nil and the actual is nil/empty.
 			// This is to save each test action from having to bother declaring an empty slice (if there are no sources)
-			require.Equal(s.T, expected.Sources, actual.Sources)
+			require.Equal(s.T, expected.VersionSources, actual.VersionSources)
 		}
 
 		if expected.Query.HasValue() {


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4049
Resolves #3795 

## Description

Only allows zero or one query sources, and splits the `Sources` property into two strongly typed ones.

I think I made a mistake in adding the query stuff to the existing set, it cost a lot of time, and will have made the collection-dag more complex in the very near future.
