### PR TITLE
feat: Remove unused context from Txn funcs

### DIFF
--- a/cbindings/txn.go
+++ b/cbindings/txn.go
@@ -26,17 +26,15 @@ import (
 
 //export TransactionCreate
 func TransactionCreate(nodePtr C.uintptr_t, isConcurrent C.int, isReadOnly C.int) C.NewTxnResult {
-	ctx := context.Background()
-
 	h := cgo.Handle(nodePtr)
 	n := h.Value().(*node.Node) //nolint:forcetypeassert
 
 	var tx client.Txn
 	var err error
 	if isConcurrent != 0 {
-		tx, err = n.DB.NewConcurrentTxn(ctx, isReadOnly != 0)
+		tx, err = n.DB.NewConcurrentTxn(isReadOnly != 0)
 	} else {
-		tx, err = n.DB.NewTxn(ctx, isReadOnly != 0)
+		tx, err = n.DB.NewTxn(isReadOnly != 0)
 	}
 	if err != nil {
 		return returnNewTxnResultC(1, err.Error(), nil)

--- a/cbindings/txn.go
+++ b/cbindings/txn.go
@@ -17,7 +17,6 @@ package cbindings
 import "C"
 
 import (
-	"context"
 	"runtime/cgo"
 
 	"github.com/sourcenetwork/defradb/client"
@@ -45,13 +44,11 @@ func TransactionCreate(nodePtr C.uintptr_t, isConcurrent C.int, isReadOnly C.int
 
 //export TransactionCommit
 func TransactionCommit(txnPtr C.uintptr_t) C.Result {
-	ctx := context.Background()
-
 	h := cgo.Handle(txnPtr)
 	defer h.Delete()
 	txn := h.Value().(client.Txn) //nolint:forcetypeassert
 
-	err := txn.Commit(ctx)
+	err := txn.Commit()
 	if err != nil {
 		return returnC(returnGoC(1, err.Error(), ""))
 	}
@@ -61,8 +58,6 @@ func TransactionCommit(txnPtr C.uintptr_t) C.Result {
 
 //export TransactionDiscard
 func TransactionDiscard(txnPtr C.uintptr_t) {
-	ctx := context.Background()
-
 	// Avoid panic in the case of a double discard
 	defer func() {
 		if r := recover(); r != nil {
@@ -72,6 +67,6 @@ func TransactionDiscard(txnPtr C.uintptr_t) {
 
 	h := cgo.Handle(txnPtr)
 	txn := h.Value().(client.Txn) //nolint:forcetypeassert
-	txn.Discard(ctx)
+	txn.Discard()
 	h.Delete()
 }

--- a/cbindings/wrapper.go
+++ b/cbindings/wrapper.go
@@ -736,7 +736,7 @@ func (w *CWrapper) ExecRequest(
 	return retval
 }
 
-func (w *CWrapper) NewTxn(ctx context.Context, readOnly bool) (client.Txn, error) {
+func (w *CWrapper) NewTxn(readOnly bool) (client.Txn, error) {
 	var concurrent C.int = 0
 	var cReadOnly C.int = 0
 	if readOnly {
@@ -759,7 +759,7 @@ func (w *CWrapper) NewTxn(ctx context.Context, readOnly bool) (client.Txn, error
 	return retTxn, nil
 }
 
-func (w *CWrapper) NewConcurrentTxn(ctx context.Context, readOnly bool) (client.Txn, error) {
+func (w *CWrapper) NewConcurrentTxn(readOnly bool) (client.Txn, error) {
 	var concurrent C.int = 1
 	var cReadOnly C.int = 0
 	if readOnly {

--- a/cbindings/wrapper_tx.go
+++ b/cbindings/wrapper_tx.go
@@ -46,7 +46,7 @@ func (txn *Transaction) ID() uint64 {
 	return txn.tx.ID()
 }
 
-func (txn *Transaction) Commit(ctx context.Context) error {
+func (txn *Transaction) Commit() error {
 	res := ConvertAndFreeCResult(C.TransactionCommit(C.uintptr_t(txn.handle)))
 	txnHandleMap.Delete(txn.ID())
 	if res.Status != 0 {
@@ -55,7 +55,7 @@ func (txn *Transaction) Commit(ctx context.Context) error {
 	return nil
 }
 
-func (txn *Transaction) Discard(ctx context.Context) {
+func (txn *Transaction) Discard() {
 	C.TransactionDiscard(C.uintptr_t(txn.handle))
 	txnHandleMap.Delete(txn.ID())
 }

--- a/cli/tx_commit.go
+++ b/cli/tx_commit.go
@@ -35,7 +35,7 @@ func MakeTxCommitCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return tx.Commit(cmd.Context())
+			return tx.Commit()
 		},
 	}
 	return cmd

--- a/cli/tx_create.go
+++ b/cli/tx_create.go
@@ -28,9 +28,9 @@ func MakeTxCreateCommand() *cobra.Command {
 
 			var tx client.Txn
 			if concurrent {
-				tx, err = cliClient.NewConcurrentTxn(cmd.Context(), readOnly)
+				tx, err = cliClient.NewConcurrentTxn(readOnly)
 			} else {
-				tx, err = cliClient.NewTxn(cmd.Context(), readOnly)
+				tx, err = cliClient.NewTxn(readOnly)
 			}
 			if err != nil {
 				return err

--- a/cli/tx_discard.go
+++ b/cli/tx_discard.go
@@ -35,7 +35,7 @@ func MakeTxDiscardCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			tx.Discard(cmd.Context())
+			tx.Discard()
 			return nil
 		},
 	}

--- a/client/db.go
+++ b/client/db.go
@@ -33,13 +33,13 @@ type TxnStore interface {
 	// NewTxn returns a new transaction on the root store that may be managed externally.
 	//
 	// It may be used with other functions in the client package. It is not threadsafe.
-	NewTxn(ctx context.Context, readOnly bool) (Txn, error)
+	NewTxn(readOnly bool) (Txn, error)
 
 	// NewConcurrentTxn returns a new transaction on the root store that may be managed externally.
 	//
 	// It may be used with other functions in the client package. It is threadsafe and multiple threads/Go routines
 	// can safely operate on it concurrently.
-	NewConcurrentTxn(ctx context.Context, readOnly bool) (Txn, error)
+	NewConcurrentTxn(readOnly bool) (Txn, error)
 }
 
 type Store interface {

--- a/client/db.go
+++ b/client/db.go
@@ -308,13 +308,13 @@ type Txn interface {
 	// Commit finalizes a transaction, attempting to commit it to the Datastore.
 	// May return an error if the transaction has gone stale. The presence of an
 	// error is an indication that the data was not committed to the Datastore.
-	Commit(ctx context.Context) error
+	Commit() error
 
 	// Discard throws away changes recorded in a transaction without committing
 	// them to the underlying Datastore. Any calls made to Discard after Commit
 	// has been successfully called will have no effect on the transaction and
 	// state of the Datastore, making it safe to defer.
-	Discard(ctx context.Context)
+	Discard()
 }
 
 // GQLOptions contains optional arguments for GQL requests.

--- a/client/lens.go
+++ b/client/lens.go
@@ -41,7 +41,7 @@ type LensConfig struct {
 // TxnSource represents an object capable of constructing the transactions that
 // implicit-transaction registries need internally.
 type TxnSource interface {
-	NewTxn(context.Context, bool) (Txn, error)
+	NewTxn(bool) (Txn, error)
 }
 
 // LensRegistry exposes several useful thread-safe migration related functions which may

--- a/client/mocks/txn_store.go
+++ b/client/mocks/txn_store.go
@@ -1619,8 +1619,8 @@ func (_c *TxnStore_LensRegistry_Call) RunAndReturn(run func() client.LensRegistr
 }
 
 // NewConcurrentTxn provides a mock function for the type TxnStore
-func (_mock *TxnStore) NewConcurrentTxn(ctx context.Context, readOnly bool) (client.Txn, error) {
-	ret := _mock.Called(ctx, readOnly)
+func (_mock *TxnStore) NewConcurrentTxn(readOnly bool) (client.Txn, error) {
+	ret := _mock.Called(readOnly)
 
 	if len(ret) == 0 {
 		panic("no return value specified for NewConcurrentTxn")
@@ -1628,18 +1628,18 @@ func (_mock *TxnStore) NewConcurrentTxn(ctx context.Context, readOnly bool) (cli
 
 	var r0 client.Txn
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, bool) (client.Txn, error)); ok {
-		return returnFunc(ctx, readOnly)
+	if returnFunc, ok := ret.Get(0).(func(bool) (client.Txn, error)); ok {
+		return returnFunc(readOnly)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, bool) client.Txn); ok {
-		r0 = returnFunc(ctx, readOnly)
+	if returnFunc, ok := ret.Get(0).(func(bool) client.Txn); ok {
+		r0 = returnFunc(readOnly)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(client.Txn)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, bool) error); ok {
-		r1 = returnFunc(ctx, readOnly)
+	if returnFunc, ok := ret.Get(1).(func(bool) error); ok {
+		r1 = returnFunc(readOnly)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1652,25 +1652,19 @@ type TxnStore_NewConcurrentTxn_Call struct {
 }
 
 // NewConcurrentTxn is a helper method to define mock.On call
-//   - ctx context.Context
 //   - readOnly bool
-func (_e *TxnStore_Expecter) NewConcurrentTxn(ctx interface{}, readOnly interface{}) *TxnStore_NewConcurrentTxn_Call {
-	return &TxnStore_NewConcurrentTxn_Call{Call: _e.mock.On("NewConcurrentTxn", ctx, readOnly)}
+func (_e *TxnStore_Expecter) NewConcurrentTxn(readOnly interface{}) *TxnStore_NewConcurrentTxn_Call {
+	return &TxnStore_NewConcurrentTxn_Call{Call: _e.mock.On("NewConcurrentTxn", readOnly)}
 }
 
-func (_c *TxnStore_NewConcurrentTxn_Call) Run(run func(ctx context.Context, readOnly bool)) *TxnStore_NewConcurrentTxn_Call {
+func (_c *TxnStore_NewConcurrentTxn_Call) Run(run func(readOnly bool)) *TxnStore_NewConcurrentTxn_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
+		var arg0 bool
 		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		var arg1 bool
-		if args[1] != nil {
-			arg1 = args[1].(bool)
+			arg0 = args[0].(bool)
 		}
 		run(
 			arg0,
-			arg1,
 		)
 	})
 	return _c
@@ -1681,14 +1675,14 @@ func (_c *TxnStore_NewConcurrentTxn_Call) Return(txn client.Txn, err error) *Txn
 	return _c
 }
 
-func (_c *TxnStore_NewConcurrentTxn_Call) RunAndReturn(run func(ctx context.Context, readOnly bool) (client.Txn, error)) *TxnStore_NewConcurrentTxn_Call {
+func (_c *TxnStore_NewConcurrentTxn_Call) RunAndReturn(run func(readOnly bool) (client.Txn, error)) *TxnStore_NewConcurrentTxn_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // NewTxn provides a mock function for the type TxnStore
-func (_mock *TxnStore) NewTxn(ctx context.Context, readOnly bool) (client.Txn, error) {
-	ret := _mock.Called(ctx, readOnly)
+func (_mock *TxnStore) NewTxn(readOnly bool) (client.Txn, error) {
+	ret := _mock.Called(readOnly)
 
 	if len(ret) == 0 {
 		panic("no return value specified for NewTxn")
@@ -1696,18 +1690,18 @@ func (_mock *TxnStore) NewTxn(ctx context.Context, readOnly bool) (client.Txn, e
 
 	var r0 client.Txn
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, bool) (client.Txn, error)); ok {
-		return returnFunc(ctx, readOnly)
+	if returnFunc, ok := ret.Get(0).(func(bool) (client.Txn, error)); ok {
+		return returnFunc(readOnly)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, bool) client.Txn); ok {
-		r0 = returnFunc(ctx, readOnly)
+	if returnFunc, ok := ret.Get(0).(func(bool) client.Txn); ok {
+		r0 = returnFunc(readOnly)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(client.Txn)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, bool) error); ok {
-		r1 = returnFunc(ctx, readOnly)
+	if returnFunc, ok := ret.Get(1).(func(bool) error); ok {
+		r1 = returnFunc(readOnly)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1720,25 +1714,19 @@ type TxnStore_NewTxn_Call struct {
 }
 
 // NewTxn is a helper method to define mock.On call
-//   - ctx context.Context
 //   - readOnly bool
-func (_e *TxnStore_Expecter) NewTxn(ctx interface{}, readOnly interface{}) *TxnStore_NewTxn_Call {
-	return &TxnStore_NewTxn_Call{Call: _e.mock.On("NewTxn", ctx, readOnly)}
+func (_e *TxnStore_Expecter) NewTxn(readOnly interface{}) *TxnStore_NewTxn_Call {
+	return &TxnStore_NewTxn_Call{Call: _e.mock.On("NewTxn", readOnly)}
 }
 
-func (_c *TxnStore_NewTxn_Call) Run(run func(ctx context.Context, readOnly bool)) *TxnStore_NewTxn_Call {
+func (_c *TxnStore_NewTxn_Call) Run(run func(readOnly bool)) *TxnStore_NewTxn_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
+		var arg0 bool
 		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		var arg1 bool
-		if args[1] != nil {
-			arg1 = args[1].(bool)
+			arg0 = args[0].(bool)
 		}
 		run(
 			arg0,
-			arg1,
 		)
 	})
 	return _c
@@ -1749,7 +1737,7 @@ func (_c *TxnStore_NewTxn_Call) Return(txn client.Txn, err error) *TxnStore_NewT
 	return _c
 }
 
-func (_c *TxnStore_NewTxn_Call) RunAndReturn(run func(ctx context.Context, readOnly bool) (client.Txn, error)) *TxnStore_NewTxn_Call {
+func (_c *TxnStore_NewTxn_Call) RunAndReturn(run func(readOnly bool) (client.Txn, error)) *TxnStore_NewTxn_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/http/client.go
+++ b/http/client.go
@@ -49,7 +49,7 @@ func NewClient(rawURL string) (*Client, error) {
 	return &Client{httpClient}, nil
 }
 
-func (c *Client) NewTxn(ctx context.Context, readOnly bool) (client.Txn, error) {
+func (c *Client) NewTxn(readOnly bool) (client.Txn, error) {
 	query := url.Values{}
 	if readOnly {
 		query.Add("read_only", "true")
@@ -58,7 +58,7 @@ func (c *Client) NewTxn(ctx context.Context, readOnly bool) (client.Txn, error) 
 	methodURL := c.http.apiURL.JoinPath("tx")
 	methodURL.RawQuery = query.Encode()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, methodURL.String(), nil)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, methodURL.String(), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -69,7 +69,7 @@ func (c *Client) NewTxn(ctx context.Context, readOnly bool) (client.Txn, error) 
 	return &Transaction{&Client{c.http}, txRes.ID}, nil
 }
 
-func (c *Client) NewConcurrentTxn(ctx context.Context, readOnly bool) (client.Txn, error) {
+func (c *Client) NewConcurrentTxn(readOnly bool) (client.Txn, error) {
 	query := url.Values{}
 	if readOnly {
 		query.Add("read_only", "true")
@@ -78,7 +78,7 @@ func (c *Client) NewConcurrentTxn(ctx context.Context, readOnly bool) (client.Tx
 	methodURL := c.http.apiURL.JoinPath("tx", "concurrent")
 	methodURL.RawQuery = query.Encode()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, methodURL.String(), nil)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, methodURL.String(), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/http/client_tx.go
+++ b/http/client_tx.go
@@ -44,10 +44,10 @@ func (txn *Transaction) ID() uint64 {
 	return txn.id
 }
 
-func (txn *Transaction) Commit(ctx context.Context) error {
+func (txn *Transaction) Commit() error {
 	methodURL := txn.http.apiURL.JoinPath("tx", fmt.Sprintf("%d", txn.id))
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, methodURL.String(), nil)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, methodURL.String(), nil)
 	if err != nil {
 		return err
 	}
@@ -55,10 +55,10 @@ func (txn *Transaction) Commit(ctx context.Context) error {
 	return err
 }
 
-func (txn *Transaction) Discard(ctx context.Context) {
+func (txn *Transaction) Discard() {
 	methodURL := txn.http.apiURL.JoinPath("tx", fmt.Sprintf("%d", txn.id))
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, methodURL.String(), nil)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodDelete, methodURL.String(), nil)
 	if err != nil {
 		return
 	}

--- a/http/handler_tx.go
+++ b/http/handler_tx.go
@@ -67,7 +67,7 @@ func (h *txHandler) Commit(rw http.ResponseWriter, req *http.Request) {
 	}
 
 	dsTxn := mustGetDataStoreTxn(txVal)
-	err = dsTxn.Commit(req.Context())
+	err = dsTxn.Commit()
 	if err != nil {
 		responseJSON(rw, http.StatusBadRequest, errorResponse{err})
 		return
@@ -91,7 +91,7 @@ func (h *txHandler) Discard(rw http.ResponseWriter, req *http.Request) {
 	}
 
 	dsTxn := mustGetDataStoreTxn(txVal)
-	dsTxn.Discard(req.Context())
+	dsTxn.Discard()
 
 	rw.WriteHeader(http.StatusOK)
 }

--- a/http/handler_tx.go
+++ b/http/handler_tx.go
@@ -29,7 +29,7 @@ func (h *txHandler) NewTxn(rw http.ResponseWriter, req *http.Request) {
 	txs := mustGetContextSyncMap(req)
 	readOnly, _ := strconv.ParseBool(req.URL.Query().Get("read_only"))
 
-	tx, err := db.NewTxn(req.Context(), readOnly)
+	tx, err := db.NewTxn(readOnly)
 	if err != nil {
 		responseJSON(rw, http.StatusBadRequest, errorResponse{err})
 		return
@@ -43,7 +43,7 @@ func (h *txHandler) NewConcurrentTxn(rw http.ResponseWriter, req *http.Request) 
 	txs := mustGetContextSyncMap(req)
 	readOnly, _ := strconv.ParseBool(req.URL.Query().Get("read_only"))
 
-	tx, err := db.NewConcurrentTxn(req.Context(), readOnly)
+	tx, err := db.NewConcurrentTxn(readOnly)
 	if err != nil {
 		responseJSON(rw, http.StatusBadRequest, errorResponse{err})
 		return

--- a/internal/datastore/concurrent_txn.go
+++ b/internal/datastore/concurrent_txn.go
@@ -29,7 +29,7 @@ type concurrentTxn struct {
 }
 
 // newConcurrentTxnFrom creates a new Txn from rootstore that supports concurrent API calls
-func NewConcurrentTxnFrom(ctx context.Context, rootstore corekv.TxnStore, id uint64, readonly bool) *BasicTxn {
+func NewConcurrentTxnFrom(rootstore corekv.TxnStore, id uint64, readonly bool) *BasicTxn {
 	rootTxn := rootstore.NewTxn(readonly)
 	rootConcurentTxn := &concurrentTxn{Txn: rootTxn}
 	multistore := NewMultistore(rootTxn)

--- a/internal/datastore/concurrent_txt_test.go
+++ b/internal/datastore/concurrent_txt_test.go
@@ -31,12 +31,11 @@ func getBadgerTxnDB(t *testing.T) *badger.Datastore {
 }
 
 func TestNewConcurrentTxnFrom(t *testing.T) {
-	ctx := context.Background()
 	rootstore := getBadgerTxnDB(t)
 
 	txn := NewConcurrentTxnFrom(rootstore, 0, false)
 
-	err := txn.Commit(ctx)
+	err := txn.Commit()
 	require.NoError(t, err)
 }
 
@@ -46,7 +45,7 @@ func TestNewConcurrentTxnFromNonIterable(t *testing.T) {
 
 	txn := NewConcurrentTxnFrom(rootstore, 0, false)
 
-	err := txn.Commit(ctx)
+	err := txn.Commit()
 	require.NoError(t, err)
 }
 

--- a/internal/datastore/concurrent_txt_test.go
+++ b/internal/datastore/concurrent_txt_test.go
@@ -34,7 +34,7 @@ func TestNewConcurrentTxnFrom(t *testing.T) {
 	ctx := context.Background()
 	rootstore := getBadgerTxnDB(t)
 
-	txn := NewConcurrentTxnFrom(ctx, rootstore, 0, false)
+	txn := NewConcurrentTxnFrom(rootstore, 0, false)
 
 	err := txn.Commit(ctx)
 	require.NoError(t, err)
@@ -44,7 +44,7 @@ func TestNewConcurrentTxnFromNonIterable(t *testing.T) {
 	ctx := context.Background()
 	rootstore := memory.NewDatastore(ctx)
 
-	txn := NewConcurrentTxnFrom(ctx, rootstore, 0, false)
+	txn := NewConcurrentTxnFrom(rootstore, 0, false)
 
 	err := txn.Commit(ctx)
 	require.NoError(t, err)

--- a/internal/datastore/txn.go
+++ b/internal/datastore/txn.go
@@ -47,12 +47,12 @@ type Txn interface {
 	// Commit finalizes a transaction, attempting to commit it to the Datastore.
 	// May return an error if the transaction has gone stale. The presence of an
 	// error is an indication that the data was not committed to the Datastore.
-	Commit(ctx context.Context) error
+	Commit() error
 	// Discard throws away changes recorded in a transaction without committing
 	// them to the underlying Datastore. Any calls made to Discard after Commit
 	// has been successfully called will have no effect on the transaction and
 	// state of the Datastore, making it safe to defer.
-	Discard(ctx context.Context)
+	Discard()
 
 	// OnSuccess registers a function to be called when the transaction is committed.
 	OnSuccess(fn func())
@@ -105,7 +105,7 @@ func (t *BasicTxn) ID() uint64 {
 	return t.id
 }
 
-func (t *BasicTxn) Commit(ctx context.Context) error {
+func (t *BasicTxn) Commit() error {
 	var fns []func()
 	var asyncFns []func()
 
@@ -127,7 +127,7 @@ func (t *BasicTxn) Commit(ctx context.Context) error {
 	return err
 }
 
-func (t *BasicTxn) Discard(ctx context.Context) {
+func (t *BasicTxn) Discard() {
 	t.txn.Discard()
 
 	for _, fn := range t.discardAsyncFns {

--- a/internal/datastore/txn.go
+++ b/internal/datastore/txn.go
@@ -91,7 +91,7 @@ type BasicTxn struct {
 var _ Txn = (*BasicTxn)(nil)
 
 // newTxnFrom returns a new Txn from the rootstore.
-func NewTxnFrom(ctx context.Context, rootstore corekv.TxnStore, id uint64, readonly bool) *BasicTxn {
+func NewTxnFrom(rootstore corekv.TxnStore, id uint64, readonly bool) *BasicTxn {
 	rootTxn := rootstore.NewTxn(readonly)
 	multistore := NewMultistore(rootTxn)
 	return &BasicTxn{

--- a/internal/datastore/txn_test.go
+++ b/internal/datastore/txn_test.go
@@ -25,7 +25,7 @@ func TestNewTxnFrom(t *testing.T) {
 	ctx := context.Background()
 	rootstore := memory.NewDatastore(ctx)
 
-	txn := NewTxnFrom(ctx, rootstore, 0, false)
+	txn := NewTxnFrom(rootstore, 0, false)
 
 	err := txn.Commit(ctx)
 	require.NoError(t, err)
@@ -35,7 +35,7 @@ func TestOnSuccess(t *testing.T) {
 	ctx := context.Background()
 	rootstore := memory.NewDatastore(ctx)
 
-	txn := NewTxnFrom(ctx, rootstore, 0, false)
+	txn := NewTxnFrom(rootstore, 0, false)
 
 	text := "Source"
 	txn.OnSuccess(func() {
@@ -51,7 +51,7 @@ func TestOnSuccessAsync(t *testing.T) {
 	ctx := context.Background()
 	rootstore := memory.NewDatastore(ctx)
 
-	txn := NewTxnFrom(ctx, rootstore, 0, false)
+	txn := NewTxnFrom(rootstore, 0, false)
 
 	var wg sync.WaitGroup
 	txn.OnSuccessAsync(func() {
@@ -68,7 +68,7 @@ func TestOnError(t *testing.T) {
 	ctx := context.Background()
 	rootstore := memory.NewDatastore(ctx)
 
-	txn := NewTxnFrom(ctx, rootstore, 0, false)
+	txn := NewTxnFrom(rootstore, 0, false)
 
 	text := "Source"
 	txn.OnError(func() {
@@ -88,7 +88,7 @@ func TestOnErrorAsync(t *testing.T) {
 	ctx := context.Background()
 	rootstore := memory.NewDatastore(ctx)
 
-	txn := NewTxnFrom(ctx, rootstore, 0, false)
+	txn := NewTxnFrom(rootstore, 0, false)
 
 	var wg sync.WaitGroup
 	txn.OnErrorAsync(func() {
@@ -108,7 +108,7 @@ func TestOnDiscard(t *testing.T) {
 	ctx := context.Background()
 	rootstore := memory.NewDatastore(ctx)
 
-	txn := NewTxnFrom(ctx, rootstore, 0, false)
+	txn := NewTxnFrom(rootstore, 0, false)
 
 	text := "Source"
 	txn.OnDiscard(func() {
@@ -123,7 +123,7 @@ func TestOnDiscardAsync(t *testing.T) {
 	ctx := context.Background()
 	rootstore := memory.NewDatastore(ctx)
 
-	txn := NewTxnFrom(ctx, rootstore, 0, false)
+	txn := NewTxnFrom(rootstore, 0, false)
 
 	var wg sync.WaitGroup
 	txn.OnDiscardAsync(func() {

--- a/internal/datastore/txn_test.go
+++ b/internal/datastore/txn_test.go
@@ -27,7 +27,7 @@ func TestNewTxnFrom(t *testing.T) {
 
 	txn := NewTxnFrom(rootstore, 0, false)
 
-	err := txn.Commit(ctx)
+	err := txn.Commit()
 	require.NoError(t, err)
 }
 
@@ -41,7 +41,7 @@ func TestOnSuccess(t *testing.T) {
 	txn.OnSuccess(func() {
 		text += " Inc"
 	})
-	err := txn.Commit(ctx)
+	err := txn.Commit()
 	require.NoError(t, err)
 
 	require.Equal(t, text, "Source Inc")
@@ -59,7 +59,7 @@ func TestOnSuccessAsync(t *testing.T) {
 	})
 
 	wg.Add(1)
-	err := txn.Commit(ctx)
+	err := txn.Commit()
 	require.NoError(t, err)
 	wg.Wait()
 }
@@ -78,7 +78,7 @@ func TestOnError(t *testing.T) {
 	err := rootstore.Close()
 	require.NoError(t, err)
 
-	err = txn.Commit(ctx)
+	err = txn.Commit()
 	require.ErrorIs(t, err, corekv.ErrDBClosed)
 
 	require.Equal(t, text, "Source Inc")
@@ -99,7 +99,7 @@ func TestOnErrorAsync(t *testing.T) {
 	require.NoError(t, err)
 
 	wg.Add(1)
-	err = txn.Commit(ctx)
+	err = txn.Commit()
 	require.ErrorIs(t, err, corekv.ErrDBClosed)
 	wg.Wait()
 }
@@ -114,7 +114,7 @@ func TestOnDiscard(t *testing.T) {
 	txn.OnDiscard(func() {
 		text += " Inc"
 	})
-	txn.Discard(ctx)
+	txn.Discard()
 
 	require.Equal(t, text, "Source Inc")
 }
@@ -131,6 +131,6 @@ func TestOnDiscardAsync(t *testing.T) {
 	})
 
 	wg.Add(1)
-	txn.Discard(ctx)
+	txn.Discard()
 	wg.Wait()
 }

--- a/internal/db/backup_test.go
+++ b/internal/db/backup_test.go
@@ -64,7 +64,7 @@ func TestBasicExport_WithNormalFormatting_NoError(t *testing.T) {
 
 	txn, err := db.NewTxn(true)
 	require.NoError(t, err)
-	defer txn.Discard(ctx)
+	defer txn.Discard()
 
 	ctx = identity.WithContext(ctx, identity.None)
 	ctx = InitContext(ctx, txn)
@@ -129,7 +129,7 @@ func TestBasicExport_WithPrettyFormatting_NoError(t *testing.T) {
 
 	txn, err := db.NewTxn(true)
 	require.NoError(t, err)
-	defer txn.Discard(ctx)
+	defer txn.Discard()
 
 	ctx = identity.WithContext(ctx, identity.None)
 	ctx = InitContext(ctx, txn)
@@ -194,7 +194,7 @@ func TestBasicExport_WithSingleCollection_NoError(t *testing.T) {
 
 	txn, err := db.NewTxn(true)
 	require.NoError(t, err)
-	defer txn.Discard(ctx)
+	defer txn.Discard()
 
 	ctx = identity.WithContext(ctx, identity.None)
 	ctx = InitContext(ctx, txn)
@@ -271,7 +271,7 @@ func TestBasicExport_WithMultipleCollectionsAndUpdate_NoError(t *testing.T) {
 
 	txn, err := db.NewTxn(true)
 	require.NoError(t, err)
-	defer txn.Discard(ctx)
+	defer txn.Discard()
 
 	ctx = identity.WithContext(ctx, identity.None)
 	ctx = InitContext(ctx, txn)
@@ -336,7 +336,7 @@ func TestBasicExport_EnsureFileOverwrite_NoError(t *testing.T) {
 
 	txn, err := db.NewTxn(true)
 	require.NoError(t, err)
-	defer txn.Discard(ctx)
+	defer txn.Discard()
 
 	ctx = identity.WithContext(ctx, identity.None)
 	ctx = InitContext(ctx, txn)
@@ -400,7 +400,7 @@ func TestBasicImport_WithMultipleCollectionsAndObjects_NoError(t *testing.T) {
 
 	err = db.basicImport(ctx, filepath)
 	require.NoError(t, err)
-	err = txn.Commit(ctx)
+	err = txn.Commit()
 	require.NoError(t, err)
 
 	txn, err = db.NewTxn(true)
@@ -463,7 +463,7 @@ func TestBasicImport_WithJSONArray_ReturnError(t *testing.T) {
 
 	err = db.basicImport(ctx, filepath)
 	require.ErrorIs(t, err, ErrExpectedJSONObject)
-	err = txn.Commit(ctx)
+	err = txn.Commit()
 	require.NoError(t, err)
 }
 
@@ -499,7 +499,7 @@ func TestBasicImport_WithObjectCollection_ReturnError(t *testing.T) {
 
 	err = db.basicImport(ctx, filepath)
 	require.ErrorIs(t, err, ErrExpectedJSONArray)
-	err = txn.Commit(ctx)
+	err = txn.Commit()
 	require.NoError(t, err)
 }
 
@@ -536,7 +536,7 @@ func TestBasicImport_WithInvalidFilepath_ReturnError(t *testing.T) {
 	wrongFilepath := t.TempDir() + "/some/test.json"
 	err = db.basicImport(ctx, wrongFilepath)
 	require.ErrorIs(t, err, os.ErrNotExist)
-	err = txn.Commit(ctx)
+	err = txn.Commit()
 	require.NoError(t, err)
 }
 
@@ -572,6 +572,6 @@ func TestBasicImport_WithInvalidCollection_ReturnError(t *testing.T) {
 
 	err = db.basicImport(ctx, filepath)
 	require.ErrorIs(t, err, ErrFailedToGetCollection)
-	err = txn.Commit(ctx)
+	err = txn.Commit()
 	require.NoError(t, err)
 }

--- a/internal/db/backup_test.go
+++ b/internal/db/backup_test.go
@@ -62,7 +62,7 @@ func TestBasicExport_WithNormalFormatting_NoError(t *testing.T) {
 	err = col2.Create(ctx, doc3)
 	require.NoError(t, err)
 
-	txn, err := db.NewTxn(ctx, true)
+	txn, err := db.NewTxn(true)
 	require.NoError(t, err)
 	defer txn.Discard(ctx)
 
@@ -127,7 +127,7 @@ func TestBasicExport_WithPrettyFormatting_NoError(t *testing.T) {
 	err = col2.Create(ctx, doc3)
 	require.NoError(t, err)
 
-	txn, err := db.NewTxn(ctx, true)
+	txn, err := db.NewTxn(true)
 	require.NoError(t, err)
 	defer txn.Discard(ctx)
 
@@ -192,7 +192,7 @@ func TestBasicExport_WithSingleCollection_NoError(t *testing.T) {
 	err = col2.Create(ctx, doc3)
 	require.NoError(t, err)
 
-	txn, err := db.NewTxn(ctx, true)
+	txn, err := db.NewTxn(true)
 	require.NoError(t, err)
 	defer txn.Discard(ctx)
 
@@ -269,7 +269,7 @@ func TestBasicExport_WithMultipleCollectionsAndUpdate_NoError(t *testing.T) {
 	err = col1.Update(ctx, doc1)
 	require.NoError(t, err)
 
-	txn, err := db.NewTxn(ctx, true)
+	txn, err := db.NewTxn(true)
 	require.NoError(t, err)
 	defer txn.Discard(ctx)
 
@@ -334,7 +334,7 @@ func TestBasicExport_EnsureFileOverwrite_NoError(t *testing.T) {
 	err = col2.Create(ctx, doc3)
 	require.NoError(t, err)
 
-	txn, err := db.NewTxn(ctx, true)
+	txn, err := db.NewTxn(true)
 	require.NoError(t, err)
 	defer txn.Discard(ctx)
 
@@ -383,7 +383,7 @@ func TestBasicImport_WithMultipleCollectionsAndObjects_NoError(t *testing.T) {
 	}`)
 	require.NoError(t, err)
 
-	txn, err := db.NewTxn(ctx, false)
+	txn, err := db.NewTxn(false)
 	require.NoError(t, err)
 
 	ctx = identity.WithContext(ctx, identity.None)
@@ -403,7 +403,7 @@ func TestBasicImport_WithMultipleCollectionsAndObjects_NoError(t *testing.T) {
 	err = txn.Commit(ctx)
 	require.NoError(t, err)
 
-	txn, err = db.NewTxn(ctx, true)
+	txn, err = db.NewTxn(true)
 	require.NoError(t, err)
 
 	ctx = identity.WithContext(ctx, identity.None)
@@ -448,7 +448,7 @@ func TestBasicImport_WithJSONArray_ReturnError(t *testing.T) {
 	}`)
 	require.NoError(t, err)
 
-	txn, err := db.NewTxn(ctx, false)
+	txn, err := db.NewTxn(false)
 	require.NoError(t, err)
 	ctx = InitContext(ctx, txn)
 
@@ -484,7 +484,7 @@ func TestBasicImport_WithObjectCollection_ReturnError(t *testing.T) {
 	}`)
 	require.NoError(t, err)
 
-	txn, err := db.NewTxn(ctx, false)
+	txn, err := db.NewTxn(false)
 	require.NoError(t, err)
 	ctx = InitContext(ctx, txn)
 
@@ -520,7 +520,7 @@ func TestBasicImport_WithInvalidFilepath_ReturnError(t *testing.T) {
 	}`)
 	require.NoError(t, err)
 
-	txn, err := db.NewTxn(ctx, false)
+	txn, err := db.NewTxn(false)
 	require.NoError(t, err)
 	ctx = InitContext(ctx, txn)
 
@@ -557,7 +557,7 @@ func TestBasicImport_WithInvalidCollection_ReturnError(t *testing.T) {
 	}`)
 	require.NoError(t, err)
 
-	txn, err := db.NewTxn(ctx, false)
+	txn, err := db.NewTxn(false)
 	require.NoError(t, err)
 	ctx = InitContext(ctx, txn)
 

--- a/internal/db/collection.go
+++ b/internal/db/collection.go
@@ -340,14 +340,14 @@ func (c *collection) Create(
 	if err != nil {
 		return err
 	}
-	defer txn.Discard(ctx)
+	defer txn.Discard()
 
 	err = c.create(ctx, doc, opts)
 	if err != nil {
 		return err
 	}
 
-	return txn.Commit(ctx)
+	return txn.Commit()
 }
 
 // CreateMany creates a collection of documents at once.
@@ -364,7 +364,7 @@ func (c *collection) CreateMany(
 	if err != nil {
 		return err
 	}
-	defer txn.Discard(ctx)
+	defer txn.Discard()
 
 	for _, doc := range docs {
 		err = c.create(ctx, doc, opts)
@@ -372,7 +372,7 @@ func (c *collection) CreateMany(
 			return err
 		}
 	}
-	return txn.Commit(ctx)
+	return txn.Commit()
 }
 
 func (c *collection) getDocIDAndPrimaryKeyFromDoc(
@@ -484,7 +484,7 @@ func (c *collection) Update(
 	if err != nil {
 		return err
 	}
-	defer txn.Discard(ctx)
+	defer txn.Discard()
 
 	primaryKey, err := c.getPrimaryKeyFromDocID(ctx, doc.ID())
 	if err != nil {
@@ -507,7 +507,7 @@ func (c *collection) Update(
 		return err
 	}
 
-	return txn.Commit(ctx)
+	return txn.Commit()
 }
 
 // Contract: DB Exists check is already performed, and a doc with the given ID exists.
@@ -558,7 +558,7 @@ func (c *collection) Save(
 	if err != nil {
 		return err
 	}
-	defer txn.Discard(ctx)
+	defer txn.Discard()
 
 	// Check if document already exists with primary DS key.
 	primaryKey, err := c.getPrimaryKeyFromDocID(ctx, doc.ID())
@@ -584,7 +584,7 @@ func (c *collection) Save(
 		return err
 	}
 
-	return txn.Commit(ctx)
+	return txn.Commit()
 }
 
 // hasPrivateKey checks if the identity is a FullIdentity and has a non-nil private key.
@@ -908,7 +908,7 @@ func (c *collection) Delete(
 	if err != nil {
 		return false, err
 	}
-	defer txn.Discard(ctx)
+	defer txn.Discard()
 
 	primaryKey, err := c.getPrimaryKeyFromDocID(ctx, docID)
 	if err != nil {
@@ -924,7 +924,7 @@ func (c *collection) Delete(
 	if err != nil {
 		return false, err
 	}
-	return true, txn.Commit(ctx)
+	return true, txn.Commit()
 }
 
 // Exists checks if a given document exists with supplied DocID.
@@ -939,7 +939,7 @@ func (c *collection) Exists(
 	if err != nil {
 		return false, err
 	}
-	defer txn.Discard(ctx)
+	defer txn.Discard()
 
 	primaryKey, err := c.getPrimaryKeyFromDocID(ctx, docID)
 	if err != nil {
@@ -950,7 +950,7 @@ func (c *collection) Exists(
 	if err != nil && !errors.Is(err, corekv.ErrNotFound) {
 		return false, err
 	}
-	return exists && !isDeleted, txn.Commit(ctx)
+	return exists && !isDeleted, txn.Commit()
 }
 
 // check if a document exists with the given primary key

--- a/internal/db/collection_delete.go
+++ b/internal/db/collection_delete.go
@@ -37,14 +37,14 @@ func (c *collection) DeleteWithFilter(
 	if err != nil {
 		return nil, err
 	}
-	defer txn.Discard(ctx)
+	defer txn.Discard()
 
 	res, err := c.deleteWithFilter(ctx, filter, client.Deleted)
 	if err != nil {
 		return nil, err
 	}
 
-	return res, txn.Commit(ctx)
+	return res, txn.Commit()
 }
 
 func (c *collection) deleteWithFilter(

--- a/internal/db/collection_get.go
+++ b/internal/db/collection_get.go
@@ -36,7 +36,7 @@ func (c *collection) Get(
 	if err != nil {
 		return nil, err
 	}
-	defer txn.Discard(ctx)
+	defer txn.Discard()
 	primaryKey, err := c.getPrimaryKeyFromDocID(ctx, docID)
 	if err != nil {
 		return nil, err
@@ -59,7 +59,7 @@ func (c *collection) Get(
 		return nil, client.ErrDocumentNotFoundOrNotAuthorized
 	}
 
-	return doc, txn.Commit(ctx)
+	return doc, txn.Commit()
 }
 
 func (c *collection) get(

--- a/internal/db/collection_index.go
+++ b/internal/db/collection_index.go
@@ -165,13 +165,13 @@ func (c *collection) CreateIndex(
 	if err != nil {
 		return client.IndexDescription{}, err
 	}
-	defer txn.Discard(ctx)
+	defer txn.Discard()
 
 	index, err := c.createIndex(ctx, desc)
 	if err != nil {
 		return client.IndexDescription{}, err
 	}
-	return index.Description(), txn.Commit(ctx)
+	return index.Description(), txn.Commit()
 }
 
 func processCreateIndexRequest(
@@ -346,13 +346,13 @@ func (c *collection) DropIndex(ctx context.Context, indexName string) error {
 	if err != nil {
 		return err
 	}
-	defer txn.Discard(ctx)
+	defer txn.Discard()
 
 	err = c.dropIndex(ctx, indexName)
 	if err != nil {
 		return err
 	}
-	return txn.Commit(ctx)
+	return txn.Commit()
 }
 
 func (c *collection) dropIndex(ctx context.Context, indexName string) error {

--- a/internal/db/collection_retriever.go
+++ b/internal/db/collection_retriever.go
@@ -39,7 +39,7 @@ func (r collectionRetriever) RetrieveCollectionFromDocID(
 	if err != nil {
 		return nil, err
 	}
-	defer txn.Discard(ctx)
+	defer txn.Discard()
 
 	headIterator, err := NewHeadBlocksIteratorFromTxn(ctx, docID)
 	if err != nil {

--- a/internal/db/collection_update.go
+++ b/internal/db/collection_update.go
@@ -38,13 +38,13 @@ func (c *collection) UpdateWithFilter(
 	if err != nil {
 		return nil, err
 	}
-	defer txn.Discard(ctx)
+	defer txn.Discard()
 
 	res, err := c.updateWithFilter(ctx, filter, updater)
 	if err != nil {
 		return nil, err
 	}
-	return res, txn.Commit(ctx)
+	return res, txn.Commit()
 }
 
 func (c *collection) updateWithFilter(

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -400,7 +400,7 @@ func (db *DB) initialize(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	defer txn.Discard(ctx)
+	defer txn.Discard()
 
 	if err := db.initializeNodeACP(ctx, txn); err != nil {
 		return err
@@ -434,7 +434,7 @@ func (db *DB) initialize(ctx context.Context) error {
 		// The query language types are only updated on successful commit
 		// so we must not forget to do so on success regardless of whether
 		// we have written to the datastores.
-		return txn.Commit(ctx)
+		return txn.Commit()
 	}
 
 	err = txn.Systemstore().Set(ctx, []byte("/init"), []byte{1})
@@ -442,7 +442,7 @@ func (db *DB) initialize(ctx context.Context) error {
 		return err
 	}
 
-	return txn.Commit(ctx)
+	return txn.Commit()
 }
 
 func (db *DB) Rootstore() corekv.TxnStore {

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -179,16 +179,16 @@ func newDB(
 }
 
 // NewTxn creates a new transaction.
-func (db *DB) NewTxn(ctx context.Context, readonly bool) (client.Txn, error) {
+func (db *DB) NewTxn(readonly bool) (client.Txn, error) {
 	txnId := db.previousTxnID.Add(1)
-	txn := datastore.NewTxnFrom(ctx, db.rootstore, txnId, readonly)
+	txn := datastore.NewTxnFrom(db.rootstore, txnId, readonly)
 	return wrapDatastoreTxn(txn, db), nil
 }
 
 // NewConcurrentTxn creates a new transaction that supports concurrent API calls.
-func (db *DB) NewConcurrentTxn(ctx context.Context, readonly bool) (client.Txn, error) {
+func (db *DB) NewConcurrentTxn(readonly bool) (client.Txn, error) {
 	txnId := db.previousTxnID.Add(1)
-	txn := datastore.NewConcurrentTxnFrom(ctx, db.rootstore, txnId, readonly)
+	txn := datastore.NewConcurrentTxnFrom(db.rootstore, txnId, readonly)
 	return wrapDatastoreTxn(txn, db), nil
 }
 

--- a/internal/db/fetcher/versioned.go
+++ b/internal/db/fetcher/versioned.go
@@ -155,7 +155,6 @@ func (vf *VersionedFetcher) Init(
 	}
 
 	vf.store = datastore.NewTxnFrom(
-		ctx,
 		vf.root,
 		// We can take the parent txn id here
 		txn.ID(),

--- a/internal/db/index_test.go
+++ b/internal/db/index_test.go
@@ -79,7 +79,7 @@ func (f *indexTestFixture) addUsersCollection() client.Collection {
 	col, err := f.db.GetCollectionByName(f.ctx, usersColName)
 	require.NoError(f.t, err)
 
-	f.txn, err = f.db.NewTxn(f.ctx, false)
+	f.txn, err = f.db.NewTxn(false)
 	require.NoError(f.t, err)
 
 	return col
@@ -89,7 +89,7 @@ func newIndexTestFixtureBare(t *testing.T) *indexTestFixture {
 	ctx := context.Background()
 	db, err := newBadgerDB(ctx)
 	require.NoError(t, err)
-	txn, err := db.NewTxn(ctx, false)
+	txn, err := db.NewTxn(false)
 	require.NoError(t, err)
 
 	return &indexTestFixture{
@@ -145,7 +145,7 @@ func (f *indexTestFixture) createUserCollectionIndexOnAge() client.IndexDescript
 func (f *indexTestFixture) commitTxn() {
 	err := f.txn.Commit(f.ctx)
 	require.NoError(f.t, err)
-	txn, err := f.db.NewTxn(f.ctx, false)
+	txn, err := f.db.NewTxn(false)
 	require.NoError(f.t, err)
 	f.txn = txn
 }
@@ -413,7 +413,7 @@ func TestCollectionGetIndexes_ShouldReturnIndexesInOrderedByName(t *testing.T) {
 	collection, err := f.db.GetCollectionByName(f.ctx, "testCollection")
 	require.NoError(f.t, err)
 
-	f.txn, err = f.db.NewTxn(f.ctx, false)
+	f.txn, err = f.db.NewTxn(false)
 	require.NoError(f.t, err)
 	for i := 1; i <= num; i++ {
 		iStr := toSuffix(i)

--- a/internal/db/index_test.go
+++ b/internal/db/index_test.go
@@ -143,7 +143,7 @@ func (f *indexTestFixture) createUserCollectionIndexOnAge() client.IndexDescript
 }
 
 func (f *indexTestFixture) commitTxn() {
-	err := f.txn.Commit(f.ctx)
+	err := f.txn.Commit()
 	require.NoError(f.t, err)
 	txn, err := f.db.NewTxn(false)
 	require.NoError(f.t, err)

--- a/internal/db/merge.go
+++ b/internal/db/merge.go
@@ -81,7 +81,7 @@ func (db *DB) executeMerge(ctx context.Context, col *collection, dagMerge event.
 	if err != nil {
 		return err
 	}
-	defer txn.Discard(ctx)
+	defer txn.Discard()
 
 	var key keys.HeadstoreKey
 	if dagMerge.DocID != "" {
@@ -129,7 +129,7 @@ func (db *DB) executeMerge(ctx context.Context, col *collection, dagMerge event.
 		}
 	}
 
-	err = txn.Commit(ctx)
+	err = txn.Commit()
 	if err != nil {
 		return err
 	}
@@ -549,7 +549,7 @@ func getCollectionFromCollectionID(ctx context.Context, db *DB, collectionID str
 	if err != nil {
 		return nil, err
 	}
-	defer txn.Discard(ctx)
+	defer txn.Discard()
 
 	cols, err := db.getCollections(
 		ctx,

--- a/internal/db/nac.go
+++ b/internal/db/nac.go
@@ -171,7 +171,7 @@ func (db *DB) resetNodeACP(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	defer txn.Discard(ctx)
+	defer txn.Discard()
 
 	err = db.nodeACP.NodeACP.ResetState(ctx)
 	if err != nil {
@@ -183,7 +183,7 @@ func (db *DB) resetNodeACP(ctx context.Context) error {
 		return err
 	}
 
-	err = txn.Commit(ctx)
+	err = txn.Commit()
 	if err != nil {
 		return err
 	}
@@ -198,7 +198,7 @@ func (db *DB) saveNodeACPDesc(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	defer txn.Discard(ctx)
+	defer txn.Discard()
 
 	nodeDescBytes, err := json.Marshal(db.nodeACP.NodeACPDesc)
 	if err != nil {
@@ -210,7 +210,7 @@ func (db *DB) saveNodeACPDesc(ctx context.Context) error {
 		return err
 	}
 
-	err = txn.Commit(ctx)
+	err = txn.Commit()
 	if err != nil {
 		return err
 	}

--- a/internal/db/p2p.go
+++ b/internal/db/p2p.go
@@ -50,14 +50,14 @@ func (db *DB) SetReplicator(ctx context.Context, info client.PeerInfo, collectio
 	if err != nil {
 		return err
 	}
-	defer txn.Discard(ctx)
+	defer txn.Discard()
 
 	err = db.p2p.SetReplicator(ctx, info, collectionNames...)
 	if err != nil {
 		return err
 	}
 
-	return txn.Commit(ctx)
+	return txn.Commit()
 }
 
 // DeleteReplicator deletes a replicator from the persisted list
@@ -70,14 +70,14 @@ func (db *DB) DeleteReplicator(ctx context.Context, info client.PeerInfo, collec
 	if err != nil {
 		return err
 	}
-	defer txn.Discard(ctx)
+	defer txn.Discard()
 
 	err = db.p2p.DeleteReplicator(ctx, info, collectionNames...)
 	if err != nil {
 		return err
 	}
 
-	return txn.Commit(ctx)
+	return txn.Commit()
 }
 
 // GetAllReplicators returns the full list of replicators with their
@@ -90,7 +90,7 @@ func (db *DB) GetAllReplicators(ctx context.Context) ([]client.Replicator, error
 	if err != nil {
 		return nil, err
 	}
-	defer txn.Discard(ctx)
+	defer txn.Discard()
 	return db.p2p.GetAllReplicators(ctx)
 }
 
@@ -105,14 +105,14 @@ func (db *DB) AddP2PCollections(ctx context.Context, collectionNames ...string) 
 	if err != nil {
 		return err
 	}
-	defer txn.Discard(ctx)
+	defer txn.Discard()
 
 	err = db.p2p.AddP2PCollections(ctx, collectionNames...)
 	if err != nil {
 		return err
 	}
 
-	return txn.Commit(ctx)
+	return txn.Commit()
 }
 
 // RemoveP2PCollections removes the given collections from the P2P system and
@@ -126,14 +126,14 @@ func (db *DB) RemoveP2PCollections(ctx context.Context, collectionNames ...strin
 	if err != nil {
 		return err
 	}
-	defer txn.Discard(ctx)
+	defer txn.Discard()
 
 	err = db.p2p.RemoveP2PCollections(ctx, collectionNames...)
 	if err != nil {
 		return err
 	}
 
-	return txn.Commit(ctx)
+	return txn.Commit()
 }
 
 // GetAllP2PCollections returns the list of persisted collection names that
@@ -146,7 +146,7 @@ func (db *DB) GetAllP2PCollections(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer txn.Discard(ctx)
+	defer txn.Discard()
 
 	return db.p2p.GetAllP2PCollections(ctx)
 }
@@ -162,14 +162,14 @@ func (db *DB) AddP2PDocuments(ctx context.Context, docIDs ...string) error {
 	if err != nil {
 		return err
 	}
-	defer txn.Discard(ctx)
+	defer txn.Discard()
 
 	err = db.p2p.AddP2PDocuments(ctx, docIDs...)
 	if err != nil {
 		return err
 	}
 
-	return txn.Commit(ctx)
+	return txn.Commit()
 }
 
 // RemoveP2PDocuments removes the given docIDs from the P2P system and
@@ -183,14 +183,14 @@ func (db *DB) RemoveP2PDocuments(ctx context.Context, docIDs ...string) error {
 	if err != nil {
 		return err
 	}
-	defer txn.Discard(ctx)
+	defer txn.Discard()
 
 	err = db.p2p.RemoveP2PDocuments(ctx, docIDs...)
 	if err != nil {
 		return err
 	}
 
-	return txn.Commit(ctx)
+	return txn.Commit()
 }
 
 // GetAllP2PDocuments returns the list of persisted docIDs that
@@ -203,7 +203,7 @@ func (db *DB) GetAllP2PDocuments(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer txn.Discard(ctx)
+	defer txn.Discard()
 
 	return db.p2p.GetAllP2PDocuments(ctx)
 }

--- a/internal/db/p2p/collection.go
+++ b/internal/db/p2p/collection.go
@@ -205,7 +205,7 @@ func (p *P2P) loadAndPublishP2PCollections(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	defer clientTxn.Discard(ctx)
+	defer clientTxn.Discard()
 	ctx = datastore.CtxSetFromClientTxn(ctx, clientTxn)
 
 	collectionIDs, err := p.getAllP2PCollectionIDs(ctx)

--- a/internal/db/p2p/collection.go
+++ b/internal/db/p2p/collection.go
@@ -201,7 +201,7 @@ func (p *P2P) getAllP2PCollectionIDs(ctx context.Context) ([]string, error) {
 }
 
 func (p *P2P) loadAndPublishP2PCollections(ctx context.Context) error {
-	clientTxn, err := p.db.NewTxn(ctx, false)
+	clientTxn, err := p.db.NewTxn(false)
 	if err != nil {
 		return err
 	}

--- a/internal/db/p2p/document.go
+++ b/internal/db/p2p/document.go
@@ -123,7 +123,7 @@ func (p *P2P) GetAllP2PDocuments(ctx context.Context) ([]string, error) {
 }
 
 func (p *P2P) loadAndPublishP2PDocuments(ctx context.Context) error {
-	clientTxn, err := p.db.NewTxn(ctx, false)
+	clientTxn, err := p.db.NewTxn(false)
 	if err != nil {
 		return err
 	}

--- a/internal/db/p2p/document.go
+++ b/internal/db/p2p/document.go
@@ -127,7 +127,7 @@ func (p *P2P) loadAndPublishP2PDocuments(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	defer clientTxn.Discard(ctx)
+	defer clientTxn.Discard()
 	ctx = datastore.CtxSetFromClientTxn(ctx, clientTxn)
 
 	docIDs, err := p.GetAllP2PDocuments(ctx)

--- a/internal/db/p2p/p2p.go
+++ b/internal/db/p2p/p2p.go
@@ -45,7 +45,7 @@ const networkRequestTimeout = 10 * time.Second
 // DB hold the database related methods that are required by P2P.
 type DB interface {
 	// NewTxn returns a new transaction on the root store that may be managed externally.
-	NewTxn(ctx context.Context, readOnly bool) (client.Txn, error)
+	NewTxn(readOnly bool) (client.Txn, error)
 	// GetNodeIndentityToken returns an identity token for the given audience.
 	GetNodeIdentityToken(ctx context.Context, audience immutable.Option[string]) ([]byte, error)
 	// GetCollections returns all collections and their descriptions matching the given options
@@ -179,7 +179,7 @@ func (p *P2P) hasAccess(ctx context.Context, pid string, c cid.Cid) bool {
 		return true
 	}
 
-	clientTxn, err := p.db.NewTxn(ctx, false)
+	clientTxn, err := p.db.NewTxn(false)
 	if err != nil {
 		log.ErrorE("Failed to get new transaction", err)
 		return false
@@ -291,7 +291,7 @@ func (p *P2P) trySelfHasAccess(ctx context.Context, block *coreblock.Block, coll
 		return true, nil
 	}
 
-	clientTxn, err := p.db.NewTxn(ctx, false)
+	clientTxn, err := p.db.NewTxn(false)
 	if err != nil {
 		return false, err
 	}
@@ -379,7 +379,7 @@ func (p *P2P) processPushlogRequest(
 	defer done()
 
 	// Check if we've already merged this block. If so, skip the sink process.
-	txn, err := p.db.NewTxn(ctx, true)
+	txn, err := p.db.NewTxn(true)
 	if err != nil {
 		return err
 	}

--- a/internal/db/p2p/p2p.go
+++ b/internal/db/p2p/p2p.go
@@ -184,7 +184,7 @@ func (p *P2P) hasAccess(ctx context.Context, pid string, c cid.Cid) bool {
 		log.ErrorE("Failed to get new transaction", err)
 		return false
 	}
-	defer clientTxn.Discard(ctx)
+	defer clientTxn.Discard()
 	txn := datastore.MustGetFromClientTxn(clientTxn)
 
 	rawblock, err := txn.Blockstore().Get(ctx, c)
@@ -295,7 +295,7 @@ func (p *P2P) trySelfHasAccess(ctx context.Context, block *coreblock.Block, coll
 	if err != nil {
 		return false, err
 	}
-	defer clientTxn.Discard(ctx)
+	defer clientTxn.Discard()
 
 	cols, err := clientTxn.GetCollections(
 		ctx,
@@ -385,7 +385,7 @@ func (p *P2P) processPushlogRequest(
 	}
 	clientTxn := datastore.MustGetFromClientTxn(txn)
 	isMerged, err := clientTxn.Blockstore().IsMerged(ctx, headCID)
-	txn.Discard(ctx)
+	txn.Discard()
 	if err != nil {
 		return err
 	}

--- a/internal/db/p2p/replicator.go
+++ b/internal/db/p2p/replicator.go
@@ -140,7 +140,7 @@ func (p *P2P) SetReplicator(ctx context.Context, repInfo client.PeerInfo, collec
 // pushHeadsForAllDocs gets all the docID for the given collection and sends them to get
 // pushed to the given peer.
 func (p *P2P) pushHeadsForAllDocs(ctx context.Context, col client.Collection, peerID string) error {
-	clientTxn, err := p.db.NewTxn(ctx, false)
+	clientTxn, err := p.db.NewTxn(false)
 	if err != nil {
 		return err
 	}
@@ -316,7 +316,7 @@ func (p *P2P) pushLogToReplicators(lg event.Update) {
 }
 
 func (p *P2P) loadAndPublishReplicators(ctx context.Context) error {
-	clientTxn, err := p.db.NewTxn(ctx, false)
+	clientTxn, err := p.db.NewTxn(false)
 	if err != nil {
 		return err
 	}
@@ -358,7 +358,7 @@ func (p *P2P) handleReplicatorFailure(ctx context.Context, peerID, docID string)
 	p.handleRetryMutex.Lock()
 	defer p.handleRetryMutex.Unlock()
 
-	clientTxn, err := p.db.NewTxn(ctx, false)
+	clientTxn, err := p.db.NewTxn(false)
 	if err != nil {
 		return err
 	}
@@ -383,7 +383,7 @@ func (p *P2P) handleReplicatorFailure(ctx context.Context, peerID, docID string)
 }
 
 func (p *P2P) handleCompletedReplicatorRetry(ctx context.Context, peerID string, success bool) error {
-	clientTxn, err := p.db.NewTxn(ctx, false)
+	clientTxn, err := p.db.NewTxn(false)
 	if err != nil {
 		return err
 	}
@@ -490,7 +490,7 @@ func createIfNotExistsReplicatorRetry(
 }
 
 func (p *P2P) retryReplicators(ctx context.Context) {
-	clientTxn, err := p.db.NewTxn(ctx, false)
+	clientTxn, err := p.db.NewTxn(false)
 	if err != nil {
 		log.ErrorContextE(ctx, "Failed to get new transaction on replicator retry", err)
 	}
@@ -542,7 +542,7 @@ func (p *P2P) retryReplicators(ctx context.Context) {
 		}
 		// If the next retry time has passed and the replicator is not already retrying.
 		if now.After(rInfo.NextRetry) && !rInfo.Retrying {
-			clientTxn, err := p.db.NewTxn(ctx, false)
+			clientTxn, err := p.db.NewTxn(false)
 			if err != nil {
 				log.ErrorContextE(ctx, "Failed to get new transaction on replicator retry", err)
 			}
@@ -581,7 +581,7 @@ func (p *P2P) setReplicatorAsRetrying(ctx context.Context, key keys.ReplicatorRe
 	if err != nil {
 		return err
 	}
-	clientTxn, err := p.db.NewTxn(ctx, false)
+	clientTxn, err := p.db.NewTxn(false)
 	if err != nil {
 		log.ErrorContextE(ctx, "Failed to get new transaction on replicator retry", err)
 	}
@@ -636,7 +636,7 @@ func setReplicatorNextRetry(
 func (p *P2P) retryReplicator(ctx context.Context, peerID string) {
 	log.InfoContext(ctx, "Retrying replicator", corelog.String("PeerID", peerID))
 
-	clientTxn, err := p.db.NewTxn(ctx, false)
+	clientTxn, err := p.db.NewTxn(false)
 	if err != nil {
 		log.ErrorContextE(ctx, "Failed to get new transaction on replicator retry", err)
 	}
@@ -683,7 +683,7 @@ func (p *P2P) retryReplicator(ctx context.Context, peerID string) {
 			// if one doc fails, stop retrying the rest and just wait for the next retry
 			return
 		}
-		clientTxn, err := p.db.NewTxn(ctx, false)
+		clientTxn, err := p.db.NewTxn(false)
 		if err != nil {
 			log.ErrorContextE(ctx, "Failed to get new transaction on replicator retry", err)
 		}
@@ -763,7 +763,7 @@ func (p *P2P) getHeads(ctx context.Context, docID string) ([]head, error) {
 }
 
 func (p *P2P) retryDoc(ctx context.Context, peerID string, docID string) error {
-	clientTxn, err := p.db.NewTxn(ctx, false)
+	clientTxn, err := p.db.NewTxn(false)
 	if err != nil {
 		return err
 	}
@@ -829,7 +829,7 @@ func deleteReplicatorRetryIfNoMoreDocs(
 
 // deleteReplicatorRetryAndDocs deletes the replicator retry and all retry docs.
 func (p *P2P) deleteReplicatorRetryAndDocs(ctx context.Context, peerID string) error {
-	clientTxn, err := p.db.NewTxn(ctx, false)
+	clientTxn, err := p.db.NewTxn(false)
 	if err != nil {
 		return err
 	}

--- a/internal/db/p2p/replicator.go
+++ b/internal/db/p2p/replicator.go
@@ -144,7 +144,7 @@ func (p *P2P) pushHeadsForAllDocs(ctx context.Context, col client.Collection, pe
 	if err != nil {
 		return err
 	}
-	defer clientTxn.Discard(ctx)
+	defer clientTxn.Discard()
 	txn := datastore.MustGetFromClientTxn(clientTxn)
 	ctx = datastore.CtxSetTxn(ctx, txn)
 
@@ -320,7 +320,7 @@ func (p *P2P) loadAndPublishReplicators(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	defer clientTxn.Discard(ctx)
+	defer clientTxn.Discard()
 	ctx = datastore.CtxSetFromClientTxn(ctx, clientTxn)
 
 	replicators, err := p.GetAllReplicators(ctx)
@@ -362,7 +362,7 @@ func (p *P2P) handleReplicatorFailure(ctx context.Context, peerID, docID string)
 	if err != nil {
 		return err
 	}
-	defer clientTxn.Discard(ctx)
+	defer clientTxn.Discard()
 	txn := datastore.MustGetFromClientTxn(clientTxn)
 	ctx = datastore.CtxSetTxn(ctx, txn)
 
@@ -379,7 +379,7 @@ func (p *P2P) handleReplicatorFailure(ctx context.Context, peerID, docID string)
 	if err != nil {
 		return err
 	}
-	return txn.Commit(ctx)
+	return txn.Commit()
 }
 
 func (p *P2P) handleCompletedReplicatorRetry(ctx context.Context, peerID string, success bool) error {
@@ -387,7 +387,7 @@ func (p *P2P) handleCompletedReplicatorRetry(ctx context.Context, peerID string,
 	if err != nil {
 		return err
 	}
-	defer clientTxn.Discard(ctx)
+	defer clientTxn.Discard()
 	txn := datastore.MustGetFromClientTxn(clientTxn)
 	ctx = datastore.CtxSetTxn(ctx, txn)
 
@@ -414,7 +414,7 @@ func (p *P2P) handleCompletedReplicatorRetry(ctx context.Context, peerID string,
 			return err
 		}
 	}
-	return txn.Commit(ctx)
+	return txn.Commit()
 }
 
 // updateReplicatorStatus updates the status of a replicator in the peerstore.
@@ -494,7 +494,7 @@ func (p *P2P) retryReplicators(ctx context.Context) {
 	if err != nil {
 		log.ErrorContextE(ctx, "Failed to get new transaction on replicator retry", err)
 	}
-	defer clientTxn.Discard(ctx)
+	defer clientTxn.Discard()
 	txn := datastore.MustGetFromClientTxn(clientTxn)
 	iter, err := txn.Peerstore().Iterator(ctx, corekv.IterOptions{
 		Prefix: []byte(keys.REPLICATOR_RETRY_ID),
@@ -551,7 +551,7 @@ func (p *P2P) retryReplicators(ctx context.Context) {
 			// The replicator might have been deleted by the time we reach this point.
 			// If it no longer exists, we delete the retry key and all retry docs.
 			exists, err := txn.Peerstore().Has(ctx, keys.NewReplicatorKey(key.PeerID).Bytes())
-			clientTxn.Discard(ctx)
+			clientTxn.Discard()
 			if err != nil {
 				log.ErrorContextE(ctx, "Failed to check if replicator exists", err)
 				continue
@@ -585,7 +585,7 @@ func (p *P2P) setReplicatorAsRetrying(ctx context.Context, key keys.ReplicatorRe
 	if err != nil {
 		log.ErrorContextE(ctx, "Failed to get new transaction on replicator retry", err)
 	}
-	defer clientTxn.Discard(ctx)
+	defer clientTxn.Discard()
 	txn := datastore.MustGetFromClientTxn(clientTxn)
 
 	return txn.Peerstore().Set(ctx, key.Bytes(), b)
@@ -640,7 +640,7 @@ func (p *P2P) retryReplicator(ctx context.Context, peerID string) {
 	if err != nil {
 		log.ErrorContextE(ctx, "Failed to get new transaction on replicator retry", err)
 	}
-	defer clientTxn.Discard(ctx)
+	defer clientTxn.Discard()
 	txn := datastore.MustGetFromClientTxn(clientTxn)
 
 	iter, err := txn.Peerstore().Iterator(ctx, corekv.IterOptions{
@@ -689,7 +689,7 @@ func (p *P2P) retryReplicator(ctx context.Context, peerID string) {
 		}
 		txn := datastore.MustGetFromClientTxn(clientTxn)
 		err = txn.Peerstore().Delete(ctx, key.Bytes())
-		clientTxn.Discard(ctx)
+		clientTxn.Discard()
 		if err != nil {
 			log.ErrorContextE(ctx, "Failed to delete retry docID", err)
 		}
@@ -767,7 +767,7 @@ func (p *P2P) retryDoc(ctx context.Context, peerID string, docID string) error {
 	if err != nil {
 		return err
 	}
-	defer clientTxn.Discard(ctx)
+	defer clientTxn.Discard()
 	txn := datastore.MustGetFromClientTxn(clientTxn)
 	ctx = datastore.CtxSetTxn(ctx, txn)
 
@@ -833,7 +833,7 @@ func (p *P2P) deleteReplicatorRetryAndDocs(ctx context.Context, peerID string) e
 	if err != nil {
 		return err
 	}
-	defer clientTxn.Discard(ctx)
+	defer clientTxn.Discard()
 	txn := datastore.MustGetFromClientTxn(clientTxn)
 	ctx = datastore.CtxSetTxn(ctx, txn)
 

--- a/internal/db/p2p/sync_doc.go
+++ b/internal/db/p2p/sync_doc.go
@@ -260,7 +260,7 @@ func (p *P2P) processDocSyncItem(docID string) (docSyncItem, error) {
 	if err != nil {
 		return docSyncItem{}, err
 	}
-	defer clientTxn.Discard(p.ctx)
+	defer clientTxn.Discard()
 	txn := datastore.MustGetFromClientTxn(clientTxn)
 
 	key := keys.HeadstoreDocKey{

--- a/internal/db/p2p/sync_doc.go
+++ b/internal/db/p2p/sync_doc.go
@@ -256,7 +256,7 @@ func (p *P2P) docSyncMessageHandler(from string, topic string, msg []byte) ([]by
 
 // processDocSyncItem processes a single document sync request and returns the result.
 func (p *P2P) processDocSyncItem(docID string) (docSyncItem, error) {
-	clientTxn, err := p.db.NewTxn(p.ctx, true)
+	clientTxn, err := p.db.NewTxn(true)
 	if err != nil {
 		return docSyncItem{}, err
 	}

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -32,7 +32,7 @@ func (db *DB) ExecRequest(ctx context.Context, request string, opts ...client.Re
 		res.GQL.Errors = append(res.GQL.Errors, err)
 		return res
 	}
-	defer txn.Discard(ctx)
+	defer txn.Discard()
 
 	options := &client.GQLOptions{}
 	for _, o := range opts {
@@ -44,7 +44,7 @@ func (db *DB) ExecRequest(ctx context.Context, request string, opts ...client.Re
 		return res
 	}
 
-	if err := txn.Commit(ctx); err != nil {
+	if err := txn.Commit(); err != nil {
 		res.GQL.Errors = append(res.GQL.Errors, err)
 		return res
 	}
@@ -61,7 +61,7 @@ func (db *DB) GetCollectionByName(ctx context.Context, name string) (client.Coll
 	if err != nil {
 		return nil, err
 	}
-	defer txn.Discard(ctx)
+	defer txn.Discard()
 
 	return db.getCollectionByName(ctx, name)
 }
@@ -78,7 +78,7 @@ func (db *DB) GetCollections(
 	if err != nil {
 		return nil, err
 	}
-	defer txn.Discard(ctx)
+	defer txn.Discard()
 
 	return db.getCollections(ctx, options)
 }
@@ -94,7 +94,7 @@ func (db *DB) GetAllIndexes(
 	if err != nil {
 		return nil, err
 	}
-	defer txn.Discard(ctx)
+	defer txn.Discard()
 
 	return db.getAllIndexDescriptions(ctx)
 }
@@ -116,14 +116,14 @@ func (db *DB) AddSchema(ctx context.Context, schemaString string) ([]client.Coll
 	if err != nil {
 		return nil, err
 	}
-	defer txn.Discard(ctx)
+	defer txn.Discard()
 
 	cols, err := db.addSchema(ctx, schemaString)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := txn.Commit(ctx); err != nil {
+	if err := txn.Commit(); err != nil {
 		return nil, err
 	}
 	return cols, nil
@@ -157,14 +157,14 @@ func (db *DB) PatchCollection(
 	if err != nil {
 		return err
 	}
-	defer txn.Discard(ctx)
+	defer txn.Discard()
 
 	err = db.patchCollection(ctx, patchString, migration)
 	if err != nil {
 		return err
 	}
 
-	return txn.Commit(ctx)
+	return txn.Commit()
 }
 
 func (db *DB) SetActiveCollectionVersion(ctx context.Context, schemaVersionID string) error {
@@ -175,14 +175,14 @@ func (db *DB) SetActiveCollectionVersion(ctx context.Context, schemaVersionID st
 	if err != nil {
 		return err
 	}
-	defer txn.Discard(ctx)
+	defer txn.Discard()
 
 	err = db.setActiveCollectionVersion(ctx, schemaVersionID)
 	if err != nil {
 		return err
 	}
 
-	return txn.Commit(ctx)
+	return txn.Commit()
 }
 
 func (db *DB) SetMigration(ctx context.Context, cfg client.LensConfig) error {
@@ -193,14 +193,14 @@ func (db *DB) SetMigration(ctx context.Context, cfg client.LensConfig) error {
 	if err != nil {
 		return err
 	}
-	defer txn.Discard(ctx)
+	defer txn.Discard()
 
 	err = db.setMigration(ctx, cfg)
 	if err != nil {
 		return err
 	}
 
-	return txn.Commit(ctx)
+	return txn.Commit()
 }
 
 func (db *DB) AddView(
@@ -216,14 +216,14 @@ func (db *DB) AddView(
 	if err != nil {
 		return nil, err
 	}
-	defer txn.Discard(ctx)
+	defer txn.Discard()
 
 	defs, err := db.addView(ctx, query, sdl, transform)
 	if err != nil {
 		return nil, err
 	}
 
-	err = txn.Commit(ctx)
+	err = txn.Commit()
 	if err != nil {
 		return nil, err
 	}
@@ -239,14 +239,14 @@ func (db *DB) RefreshViews(ctx context.Context, opts client.CollectionFetchOptio
 	if err != nil {
 		return err
 	}
-	defer txn.Discard(ctx)
+	defer txn.Discard()
 
 	err = db.refreshViews(ctx, opts)
 	if err != nil {
 		return err
 	}
 
-	err = txn.Commit(ctx)
+	err = txn.Commit()
 	if err != nil {
 		return err
 	}
@@ -264,14 +264,14 @@ func (db *DB) BasicImport(ctx context.Context, filepath string) error {
 	if err != nil {
 		return err
 	}
-	defer txn.Discard(ctx)
+	defer txn.Discard()
 
 	err = db.basicImport(ctx, filepath)
 	if err != nil {
 		return err
 	}
 
-	return txn.Commit(ctx)
+	return txn.Commit()
 }
 
 // BasicExport exports the current data or subset of data to file in json format.
@@ -283,12 +283,12 @@ func (db *DB) BasicExport(ctx context.Context, config *client.BackupConfig) erro
 	if err != nil {
 		return err
 	}
-	defer txn.Discard(ctx)
+	defer txn.Discard()
 
 	err = db.basicExport(ctx, config)
 	if err != nil {
 		return err
 	}
 
-	return txn.Commit(ctx)
+	return txn.Commit()
 }

--- a/internal/db/subscriptions.go
+++ b/internal/db/subscriptions.go
@@ -63,7 +63,7 @@ func (db *DB) handleSubscription(ctx context.Context, r *request.Request) (<-cha
 					continue // invalid event value
 				}
 			}
-			txn, err := db.NewTxn(ctx, false)
+			txn, err := db.NewTxn(false)
 			if err != nil {
 				log.ErrorContext(ctx, err.Error())
 				continue

--- a/internal/db/subscriptions.go
+++ b/internal/db/subscriptions.go
@@ -75,7 +75,7 @@ func (db *DB) handleSubscription(ctx context.Context, r *request.Request) (<-cha
 
 			result, err := p.RunSelection(ctx, s)
 			if err == nil && len(result) == 0 {
-				txn.Discard(ctx)
+				txn.Discard()
 				continue // Don't send anything back to the client if the request yields an empty dataset.
 			}
 
@@ -98,7 +98,7 @@ func (db *DB) handleSubscription(ctx context.Context, r *request.Request) (<-cha
 
 			// now that weve filtered empty result sets, lets recheck
 			if len(result) == 0 {
-				txn.Discard(ctx)
+				txn.Discard()
 				continue
 			}
 
@@ -114,10 +114,10 @@ func (db *DB) handleSubscription(ctx context.Context, r *request.Request) (<-cha
 
 			select {
 			case <-ctx.Done():
-				txn.Discard(ctx)
+				txn.Discard()
 				return // context cancelled
 			case resCh <- res:
-				txn.Discard(ctx)
+				txn.Discard()
 			}
 		}
 	}()

--- a/internal/db/txn.go
+++ b/internal/db/txn.go
@@ -93,24 +93,24 @@ func wrapDatastoreTxn(txn *datastore.BasicTxn, db *DB) *Txn {
 	}
 }
 
-func (txn *Txn) Commit(ctx context.Context) error {
+func (txn *Txn) Commit() error {
 	if txn.explicit {
 		// If the transaction has been explicitly defined, `Commit` should
 		// only be executed by the transaction creator. As such, a call to
 		// `Commit` on an explicit transaction should result in a no-op.
 		return nil
 	}
-	return txn.BasicTxn.Commit(ctx)
+	return txn.BasicTxn.Commit()
 }
 
-func (txn *Txn) Discard(ctx context.Context) {
+func (txn *Txn) Discard() {
 	if txn.explicit {
 		// If the transaction has been explicitly defined, `Discard` should
 		// only be executed by the transaction creator. As such, a call to
 		// `Discard` on an explicit transaction should result in a no-op.
 		return
 	}
-	txn.BasicTxn.Discard(ctx)
+	txn.BasicTxn.Discard()
 }
 
 func (txn *Txn) PrintDump(ctx context.Context) error {

--- a/internal/db/txn.go
+++ b/internal/db/txn.go
@@ -24,7 +24,7 @@ import (
 
 // transactionDB is a db that can create transactions.
 type transactionDB interface {
-	NewTxn(context.Context, bool) (client.Txn, error)
+	NewTxn(bool) (client.Txn, error)
 }
 
 // ensureContextTxn ensures that the returned context has a transaction.
@@ -69,7 +69,7 @@ func ensureContextTxn(ctx context.Context, db transactionDB, readOnly bool) (con
 			return nil, nil, NewErrUnsupportedTxnType(ctxTxn)
 		}
 	}
-	clientTxn, err := db.NewTxn(ctx, readOnly)
+	clientTxn, err := db.NewTxn(readOnly)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/lens/registry.go
+++ b/internal/lens/registry.go
@@ -111,5 +111,17 @@ func (s *txnSource) NewTxn(ctx context.Context, readOnly bool) (repository.Txn, 
 		return nil, err
 	}
 
-	return datastore.MustGetFromClientTxn(txn), nil
+	return &wrappedTxn{Txn: datastore.MustGetFromClientTxn(txn)}, nil
+}
+
+type wrappedTxn struct {
+	datastore.Txn
+}
+
+func (t *wrappedTxn) Discard(context.Context) {
+	t.Txn.Discard()
+}
+
+func (t *wrappedTxn) Commit(context.Context) error {
+	return t.Txn.Commit()
 }

--- a/internal/lens/registry.go
+++ b/internal/lens/registry.go
@@ -106,7 +106,7 @@ func wrapSource(s client.TxnSource) *txnSource {
 }
 
 func (s *txnSource) NewTxn(ctx context.Context, readOnly bool) (repository.Txn, error) {
-	txn, err := s.txnSource.NewTxn(ctx, readOnly)
+	txn, err := s.txnSource.NewTxn(readOnly)
 	if err != nil {
 		return nil, err
 	}

--- a/js/client_db.go
+++ b/js/client_db.go
@@ -229,11 +229,7 @@ func (c *Client) newTxn(this js.Value, args []js.Value) (js.Value, error) {
 	if err != nil {
 		return js.Undefined(), err
 	}
-	ctx, err := contextArg(args, 1, c.txns)
-	if err != nil {
-		return js.Undefined(), err
-	}
-	txn, err := c.node.DB.NewTxn(ctx, readOnly)
+	txn, err := c.node.DB.NewTxn(readOnly)
 	if err != nil {
 		return js.Undefined(), err
 	}
@@ -246,11 +242,7 @@ func (c *Client) newConcurrentTxn(this js.Value, args []js.Value) (js.Value, err
 	if err != nil {
 		return js.Undefined(), err
 	}
-	ctx, err := contextArg(args, 1, c.txns)
-	if err != nil {
-		return js.Undefined(), err
-	}
-	txn, err := c.node.DB.NewConcurrentTxn(ctx, readOnly)
+	txn, err := c.node.DB.NewConcurrentTxn(readOnly)
 	if err != nil {
 		return js.Undefined(), err
 	}

--- a/js/client_tx.go
+++ b/js/client_tx.go
@@ -13,7 +13,6 @@
 package js
 
 import (
-	"context"
 	"fmt"
 	"sync"
 	"syscall/js"
@@ -63,12 +62,12 @@ func newTransaction(txn client.Txn, txns *sync.Map) js.Value {
 }
 
 func (t *transaction) commit(this js.Value, args []js.Value) (js.Value, error) {
-	err := t.txn.Commit(context.Background())
+	err := t.txn.Commit()
 	return js.Undefined(), err
 }
 
 func (t *transaction) discard(this js.Value, args []js.Value) (js.Value, error) {
-	t.txn.Discard(context.Background())
+	t.txn.Discard()
 	return js.Undefined(), nil
 }
 

--- a/tests/bench/storage/utils.go
+++ b/tests/bench/storage/utils.go
@@ -83,7 +83,7 @@ func runStorageBenchTxnGet(
 	if err != nil {
 		return err
 	}
-	defer clientTxn.Discard(ctx)
+	defer clientTxn.Discard()
 
 	txn := datastore.MustGetFromClientTxn(clientTxn)
 
@@ -125,7 +125,7 @@ func runStorageBenchTxnIterator(
 	if err != nil {
 		return err
 	}
-	defer clientTxn.Discard(ctx)
+	defer clientTxn.Discard()
 
 	txn := datastore.MustGetFromClientTxn(clientTxn)
 
@@ -239,7 +239,7 @@ func backfillBenchmarkTxn(
 	if err != nil {
 		return nil, err
 	}
-	defer clientTxn.Discard(ctx)
+	defer clientTxn.Discard()
 
 	txn := datastore.MustGetFromClientTxn(clientTxn)
 
@@ -261,7 +261,7 @@ func backfillBenchmarkTxn(
 	}
 
 	sort.Strings(keys)
-	return keys, txn.Commit(ctx)
+	return keys, txn.Commit()
 }
 
 func getSampledIndex(populationSize int, sampleSize int, i int) int {

--- a/tests/bench/storage/utils.go
+++ b/tests/bench/storage/utils.go
@@ -79,7 +79,7 @@ func runStorageBenchTxnGet(
 		return err
 	}
 
-	clientTxn, err := db.NewTxn(ctx, false)
+	clientTxn, err := db.NewTxn(false)
 	if err != nil {
 		return err
 	}
@@ -121,7 +121,7 @@ func runStorageBenchTxnIterator(
 		return err
 	}
 
-	clientTxn, err := db.NewTxn(ctx, false)
+	clientTxn, err := db.NewTxn(false)
 	if err != nil {
 		return err
 	}
@@ -235,7 +235,7 @@ func backfillBenchmarkTxn(
 	objCount int,
 	valueSize int,
 ) ([]string, error) {
-	clientTxn, err := db.NewTxn(ctx, false)
+	clientTxn, err := db.NewTxn(false)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/clients/cli/wrapper.go
+++ b/tests/clients/cli/wrapper.go
@@ -488,13 +488,13 @@ func (w *Wrapper) execRequestSubscription(r io.Reader) chan client.GQLResult {
 	return resCh
 }
 
-func (w *Wrapper) NewTxn(ctx context.Context, readOnly bool) (client.Txn, error) {
+func (w *Wrapper) NewTxn(readOnly bool) (client.Txn, error) {
 	args := []string{"client", "tx", "create"}
 	if readOnly {
 		args = append(args, "--read-only")
 	}
 
-	data, err := w.cmd.execute(ctx, args)
+	data, err := w.cmd.execute(context.Background(), args)
 	if err != nil {
 		return nil, err
 	}
@@ -509,7 +509,7 @@ func (w *Wrapper) NewTxn(ctx context.Context, readOnly bool) (client.Txn, error)
 	return &Transaction{w, tx}, nil
 }
 
-func (w *Wrapper) NewConcurrentTxn(ctx context.Context, readOnly bool) (client.Txn, error) {
+func (w *Wrapper) NewConcurrentTxn(readOnly bool) (client.Txn, error) {
 	args := []string{"client", "tx", "create"}
 	args = append(args, "--concurrent")
 
@@ -517,7 +517,7 @@ func (w *Wrapper) NewConcurrentTxn(ctx context.Context, readOnly bool) (client.T
 		args = append(args, "--read-only")
 	}
 
-	data, err := w.cmd.execute(ctx, args)
+	data, err := w.cmd.execute(context.Background(), args)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/clients/cli/wrapper_tx.go
+++ b/tests/clients/cli/wrapper_tx.go
@@ -34,19 +34,19 @@ func (txn *Transaction) ID() uint64 {
 	return txn.tx.ID()
 }
 
-func (txn *Transaction) Commit(ctx context.Context) error {
+func (txn *Transaction) Commit() error {
 	args := []string{"client", "tx", "commit"}
 	args = append(args, fmt.Sprintf("%d", txn.tx.ID()))
 
-	_, err := txn.cmd.execute(ctx, args)
+	_, err := txn.cmd.execute(context.Background(), args)
 	return err
 }
 
-func (txn *Transaction) Discard(ctx context.Context) {
+func (txn *Transaction) Discard() {
 	args := []string{"client", "tx", "discard"}
 	args = append(args, fmt.Sprintf("%d", txn.tx.ID()))
 
-	txn.cmd.execute(ctx, args) //nolint:errcheck
+	txn.cmd.execute(context.Background(), args) //nolint:errcheck
 }
 
 func (txn *Transaction) PrintDump(ctx context.Context) error {

--- a/tests/clients/http/wrapper.go
+++ b/tests/clients/http/wrapper.go
@@ -257,8 +257,8 @@ func (w *Wrapper) ExecRequest(
 	return w.client.ExecRequest(ctx, query, opts...)
 }
 
-func (w *Wrapper) NewTxn(ctx context.Context, readOnly bool) (client.Txn, error) {
-	clientTxn, err := w.client.NewTxn(ctx, readOnly)
+func (w *Wrapper) NewTxn(readOnly bool) (client.Txn, error) {
+	clientTxn, err := w.client.NewTxn(readOnly)
 	if err != nil {
 		return nil, err
 	}
@@ -269,8 +269,8 @@ func (w *Wrapper) NewTxn(ctx context.Context, readOnly bool) (client.Txn, error)
 	return &Transaction{w, serverTxn}, nil
 }
 
-func (w *Wrapper) NewConcurrentTxn(ctx context.Context, readOnly bool) (client.Txn, error) {
-	clientTxn, err := w.client.NewConcurrentTxn(ctx, readOnly)
+func (w *Wrapper) NewConcurrentTxn(readOnly bool) (client.Txn, error) {
+	clientTxn, err := w.client.NewConcurrentTxn(readOnly)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/clients/http/wrapper_tx.go
+++ b/tests/clients/http/wrapper_tx.go
@@ -35,12 +35,12 @@ func (txn *Transaction) ID() uint64 {
 	return txn.txn.ID()
 }
 
-func (txn *Transaction) Commit(ctx context.Context) error {
-	return txn.txn.Commit(ctx)
+func (txn *Transaction) Commit() error {
+	return txn.txn.Commit()
 }
 
-func (txn *Transaction) Discard(ctx context.Context) {
-	txn.txn.Discard(ctx)
+func (txn *Transaction) Discard() {
+	txn.txn.Discard()
 }
 
 func (txn *Transaction) PrintDump(ctx context.Context) error {

--- a/tests/clients/js/wrapper.go
+++ b/tests/clients/js/wrapper.go
@@ -382,8 +382,8 @@ func handleSubscription(value sysjs.Value) <-chan client.GQLResult {
 	return sub
 }
 
-func (w *Wrapper) NewTxn(ctx context.Context, readOnly bool) (client.Txn, error) {
-	res, err := execute(ctx, w.value, "newTxn", readOnly)
+func (w *Wrapper) NewTxn(readOnly bool) (client.Txn, error) {
+	res, err := execute(context.Background(), w.value, "newTxn", readOnly)
 	if err != nil {
 		return nil, err
 	}
@@ -396,8 +396,8 @@ func (w *Wrapper) NewTxn(ctx context.Context, readOnly bool) (client.Txn, error)
 	return &Transaction{w, txn}, nil
 }
 
-func (w *Wrapper) NewConcurrentTxn(ctx context.Context, readOnly bool) (client.Txn, error) {
-	res, err := execute(ctx, w.value, "newConcurrentTxn", readOnly)
+func (w *Wrapper) NewConcurrentTxn(readOnly bool) (client.Txn, error) {
+	res, err := execute(context.Background(), w.value, "newConcurrentTxn", readOnly)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/clients/js/wrapper_tx.go
+++ b/tests/clients/js/wrapper_tx.go
@@ -37,12 +37,12 @@ func (txn *Transaction) ID() uint64 {
 	return txn.txn.ID()
 }
 
-func (txn *Transaction) Commit(ctx context.Context) error {
-	return txn.txn.Commit(ctx)
+func (txn *Transaction) Commit() error {
+	return txn.txn.Commit()
 }
 
-func (txn *Transaction) Discard(ctx context.Context) {
-	txn.txn.Discard(ctx)
+func (txn *Transaction) Discard() {
+	txn.txn.Discard()
 }
 
 func (txn *Transaction) PrintDump(ctx context.Context) error {

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -1807,7 +1807,7 @@ func getTransaction(
 		// Create a new transaction if one does not already exist.
 		txn, err := db.NewTxn(false)
 		if AssertError(s.T, err, expectedError) {
-			txn.Discard(s.Ctx)
+			txn.Discard()
 			return nil
 		}
 
@@ -1825,9 +1825,9 @@ func commitTransaction(
 	s *state.State,
 	action TransactionCommit,
 ) {
-	err := s.Txns[action.TransactionID].Commit(s.Ctx)
+	err := s.Txns[action.TransactionID].Commit()
 	if err != nil {
-		s.Txns[action.TransactionID].Discard(s.Ctx)
+		s.Txns[action.TransactionID].Discard()
 	}
 
 	expectedErrorRaised := AssertError(s.T, err, action.ExpectedError)

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -1805,7 +1805,7 @@ func getTransaction(
 
 	if s.Txns[transactionID] == nil {
 		// Create a new transaction if one does not already exist.
-		txn, err := db.NewTxn(s.Ctx, false)
+		txn, err := db.NewTxn(false)
 		if AssertError(s.T, err, expectedError) {
 			txn.Discard(s.Ctx)
 			return nil


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4055

## Description

Removes the unused context parameter from `NewTxn`, `NewConcurrentTxn`, `Commit` and `Discard`.

It has already been removed from Lens, as it was quite an annoying and unwanted complication there.  The `New` funcs also made it look like the txn was scoped to the context.

Broken out of https://github.com/sourcenetwork/defradb/issues/4054 as this is a breaking API change and deserves its own commit.