### PR TITLE
fix: Forbid default null value for json field type

### DIFF
--- a/internal/request/graphql/schema/collection.go
+++ b/internal/request/graphql/schema/collection.go
@@ -455,8 +455,7 @@ func defaultFromAST(
 	// If the value is nil, then parsing has failed, or a nil value was provided.
 	// Since setting a default value to nil is the same as not providing one,
 	// it is safer to return an error to let the user know something is wrong.
-	// Exception: JSON fields can have nil as a valid default value
-	if value == nil && propName != types.DefaultDirectivePropJSON {
+	if value == nil {
 		return nil, NewErrDefaultValueInvalid(field.Name.Value, propName)
 	}
 	return value, nil
@@ -486,7 +485,7 @@ func fieldsFromAST(
 				return nil, err
 			}
 		case types.ConstraintsDirectiveLabel:
-			constraints, err = contraintsFromAST(kind, directive)
+			constraints, err = constraintsFromAST(kind, directive)
 			if err != nil {
 				return nil, err
 			}
@@ -609,7 +608,7 @@ type constraintDescription struct {
 	Size int
 }
 
-func contraintsFromAST(kind client.FieldKind, directive *ast.Directive) (constraintDescription, error) {
+func constraintsFromAST(kind client.FieldKind, directive *ast.Directive) (constraintDescription, error) {
 	constraints := constraintDescription{}
 	for _, arg := range directive.Arguments {
 		switch arg.Name.Value {

--- a/tests/integration/mutation/create/with_default_values_test.go
+++ b/tests/integration/mutation/create/with_default_values_test.go
@@ -389,7 +389,7 @@ func TestMutationCreate_WithDefaultJSONBoolValue_ShouldBeSet(t *testing.T) {
 	testUtils.ExecuteTestCase(t, test)
 }
 
-func TestMutationCreate_WithDefaultJSONNullValue_ShouldBeSet(t *testing.T) {
+func TestMutationCreate_WithDefaultJSONNullValue_ReturnError(t *testing.T) {
 	test := testUtils.TestCase{
 		Actions: []any{
 			&action.AddSchema{
@@ -399,25 +399,7 @@ func TestMutationCreate_WithDefaultJSONNullValue_ShouldBeSet(t *testing.T) {
 						metadata: JSON @default(json: null)
 					}
 				`,
-			},
-			testUtils.CreateDoc{
-				DocMap: map[string]any{
-					"name": "John",
-				},
-			},
-			testUtils.Request{
-				Request: `query {
-					User {
-						metadata
-					}
-				}`,
-				Results: map[string]any{
-					"User": []map[string]any{
-						{
-							"metadata": nil,
-						},
-					},
-				},
+				ExpectedError: "default value is invalid",
 			},
 		},
 	}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4068

## Description

This change forbids setting `null` as default value for json field type (only top level) so that it behaves as all other field types.
