### PR TITLE
feat: Rename gql fields to use consistent underscoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,13 +217,13 @@ To get the most recent commit in the MerkleDAG for the document identified as `b
 ```shell
 defradb client query '
   query {
-    latestCommits(docID: "bae-91171025-ed21-50e3-b0dc-e31bccdfa1ab") {
-      cid
-      delta
-      height
-      links {
-        cid
-        name
+    _latestCommits(docID: "bae-91171025-ed21-50e3-b0dc-e31bccdfa1ab") {
+      _cid
+      _delta
+      _height
+      _links {
+        _cid
+        _name
       }
     }
   }
@@ -235,27 +235,27 @@ It returns a structure similar to the following, which contains the update paylo
 ```json
 {
   "data": {
-    "latestCommits": [
+    "_latestCommits": [
       {
-        "cid": "bafybeifhtfs6vgu7cwbhkojneh7gghwwinh5xzmf7nqkqqdebw5rqino7u",
-        "delta": "pGNhZ2UYH2RuYW1lY0JvYmZwb2ludHMYWmh2ZXJpZmllZPU=",
-        "height": 1,
-        "links": [
+        "_cid": "bafybeifhtfs6vgu7cwbhkojneh7gghwwinh5xzmf7nqkqqdebw5rqino7u",
+        "_delta": "pGNhZ2UYH2RuYW1lY0JvYmZwb2ludHMYWmh2ZXJpZmllZPU=",
+        "_height": 1,
+        "_links": [
           {
-            "cid": "bafybeiet6foxcipesjurdqi4zpsgsiok5znqgw4oa5poef6qtiby5hlpzy",
-            "name": "age"
+            "_cid": "bafybeiet6foxcipesjurdqi4zpsgsiok5znqgw4oa5poef6qtiby5hlpzy",
+            "_name": "age"
           },
           {
-            "cid": "bafybeielahxy3r3ulykwoi5qalvkluojta4jlg6eyxvt7lbon3yd6ignby",
-            "name": "name"
+            "_cid": "bafybeielahxy3r3ulykwoi5qalvkluojta4jlg6eyxvt7lbon3yd6ignby",
+            "_name": "name"
           },
           {
-            "cid": "bafybeia3tkpz52s3nx4uqadbm7t5tir6gagkvjkgipmxs2xcyzlkf4y4dm",
-            "name": "points"
+            "_cid": "bafybeia3tkpz52s3nx4uqadbm7t5tir6gagkvjkgipmxs2xcyzlkf4y4dm",
+            "_name": "points"
           },
           {
-            "cid": "bafybeia4off4javopmxcdyvr6fgb5clo7m5bblxic5sqr2vd52s6khyksm",
-            "name": "verified"
+            "_cid": "bafybeia4off4javopmxcdyvr6fgb5clo7m5bblxic5sqr2vd52s6khyksm",
+            "_name": "verified"
           }
         ]
       }
@@ -269,7 +269,7 @@ Obtain a specific commit by its content identifier (`cid`):
 ```shell
 defradb client query '
   query {
-    commits(cid: "bafybeifhtfs6vgu7cwbhkojneh7gghwwinh5xzmf7nqkqqdebw5rqino7u") {
+    _commits(cid: "bafybeifhtfs6vgu7cwbhkojneh7gghwwinh5xzmf7nqkqqdebw5rqino7u") {
       cid
       delta
       height

--- a/README.md
+++ b/README.md
@@ -218,12 +218,12 @@ To get the most recent commit in the MerkleDAG for the document identified as `b
 defradb client query '
   query {
     _latestCommits(docID: "bae-91171025-ed21-50e3-b0dc-e31bccdfa1ab") {
-      _cid
-      _delta
-      _height
-      _links {
-        _cid
-        _name
+      cid
+      delta
+      height
+      links {
+        cid
+        name
       }
     }
   }
@@ -237,25 +237,25 @@ It returns a structure similar to the following, which contains the update paylo
   "data": {
     "_latestCommits": [
       {
-        "_cid": "bafybeifhtfs6vgu7cwbhkojneh7gghwwinh5xzmf7nqkqqdebw5rqino7u",
-        "_delta": "pGNhZ2UYH2RuYW1lY0JvYmZwb2ludHMYWmh2ZXJpZmllZPU=",
-        "_height": 1,
-        "_links": [
+        "cid": "bafybeifhtfs6vgu7cwbhkojneh7gghwwinh5xzmf7nqkqqdebw5rqino7u",
+        "delta": "pGNhZ2UYH2RuYW1lY0JvYmZwb2ludHMYWmh2ZXJpZmllZPU=",
+        "height": 1,
+        "links": [
           {
-            "_cid": "bafybeiet6foxcipesjurdqi4zpsgsiok5znqgw4oa5poef6qtiby5hlpzy",
-            "_name": "age"
+            "cid": "bafybeiet6foxcipesjurdqi4zpsgsiok5znqgw4oa5poef6qtiby5hlpzy",
+            "name": "age"
           },
           {
-            "_cid": "bafybeielahxy3r3ulykwoi5qalvkluojta4jlg6eyxvt7lbon3yd6ignby",
-            "_name": "name"
+            "cid": "bafybeielahxy3r3ulykwoi5qalvkluojta4jlg6eyxvt7lbon3yd6ignby",
+            "name": "name"
           },
           {
-            "_cid": "bafybeia3tkpz52s3nx4uqadbm7t5tir6gagkvjkgipmxs2xcyzlkf4y4dm",
-            "_name": "points"
+            "cid": "bafybeia3tkpz52s3nx4uqadbm7t5tir6gagkvjkgipmxs2xcyzlkf4y4dm",
+            "name": "points"
           },
           {
-            "_cid": "bafybeia4off4javopmxcdyvr6fgb5clo7m5bblxic5sqr2vd52s6khyksm",
-            "_name": "verified"
+            "cid": "bafybeia4off4javopmxcdyvr6fgb5clo7m5bblxic5sqr2vd52s6khyksm",
+            "name": "verified"
           }
         ]
       }

--- a/client/request/consts.go
+++ b/client/request/consts.go
@@ -22,7 +22,8 @@ const (
 	Input              = "input"
 	CreateInput        = "create"
 	UpdateInput        = "update"
-	FieldName          = "field"
+	FieldArgName       = "field"
+	FieldNameArgName   = "fieldName"
 	FieldIDName        = "fieldId"
 	FieldNameName      = "fieldName"
 	CompositeFieldName = "_C"
@@ -40,7 +41,9 @@ const (
 	OrderClause   = "order"
 	DepthClause   = "depth"
 
-	DocIDArgName = "docID"
+	DocIDArgName  = "docID"
+	CidArgName    = "cid"
+	HeightArgName = "height"
 
 	AverageFieldName    = "_avg"
 	CountFieldName      = "_count"
@@ -60,8 +63,8 @@ const (
 
 	ExplainLabel = "explain"
 
-	LatestCommitsName = "latestCommits"
-	CommitsName       = "commits"
+	LatestCommitsName = "_latestCommits"
+	CommitsName       = "_commits"
 
 	CommitTypeName           = "Commit"
 	LinksFieldName           = "links"

--- a/docs/website/getting-started.md
+++ b/docs/website/getting-started.md
@@ -129,14 +129,14 @@ This returns only user documents which have a value for the `points` field *Grea
 
 ## Obtain document commits
 
-DefraDB's data model is based on [MerkleCRDTs](./guides/merkle-crdt.md). Each document has a graph of all of its updates, similar to Git. The updates are called `commits` and are identified by `cid`, a content identifier. Each references its parents by their `cid`s.
+DefraDB's data model is based on [MerkleCRDTs](./guides/merkle-crdt.md). Each document has a graph of all of its updates, similar to Git. The updates are called `_commits` and are identified by `cid`, a content identifier. Each references its parents by their `cid`s.
 
 To get the most recent commits in the MerkleDAG for the document identified as `bae-91171025-ed21-50e3-b0dc-e31bccdfa1ab`:
 
 ```shell
 defradb client query '
   query {
-    latestCommits(dockey: "bae-91171025-ed21-50e3-b0dc-e31bccdfa1ab") {
+    _latestCommits(dockey: "bae-91171025-ed21-50e3-b0dc-e31bccdfa1ab") {
       cid
       delta
       height
@@ -154,26 +154,26 @@ It returns a structure similar to the following, which contains the update paylo
 ```json
 {
   "data": {
-    "latestCommits": [
+    "_latestCommits": [
       {
         "cid": "bafybeifhtfs6vgu7cwbhkojneh7gghwwinh5xzmf7nqkqqdebw5rqino7u",
         "delta": "pGNhZ2UYH2RuYW1lY0JvYmZwb2ludHMYWmh2ZXJpZmllZPU=",
         "height": 1,
         "links": [
           {
-            "cid": "bafybeiet6foxcipesjurdqi4zpsgsiok5znqgw4oa5poef6qtiby5hlpzy",
+            "_cid": "bafybeiet6foxcipesjurdqi4zpsgsiok5znqgw4oa5poef6qtiby5hlpzy",
             "name": "age"
           },
           {
-            "cid": "bafybeielahxy3r3ulykwoi5qalvkluojta4jlg6eyxvt7lbon3yd6ignby",
+            "_cid": "bafybeielahxy3r3ulykwoi5qalvkluojta4jlg6eyxvt7lbon3yd6ignby",
             "name": "name"
           },
           {
-            "cid": "bafybeia3tkpz52s3nx4uqadbm7t5tir6gagkvjkgipmxs2xcyzlkf4y4dm",
+            "_cid": "bafybeia3tkpz52s3nx4uqadbm7t5tir6gagkvjkgipmxs2xcyzlkf4y4dm",
             "name": "points"
           },
           {
-            "cid": "bafybeia4off4javopmxcdyvr6fgb5clo7m5bblxic5sqr2vd52s6khyksm",
+            "_cid": "bafybeia4off4javopmxcdyvr6fgb5clo7m5bblxic5sqr2vd52s6khyksm",
             "name": "verified"
           }
         ]
@@ -188,7 +188,7 @@ Obtain a specific commit by its content identifier (`cid`):
 ```shell
 defradb client query '
   query {
-    commits(cid: "bafybeifhtfs6vgu7cwbhkojneh7gghwwinh5xzmf7nqkqqdebw5rqino7u") {
+    _commits(cid: "bafybeifhtfs6vgu7cwbhkojneh7gghwwinh5xzmf7nqkqqdebw5rqino7u") {
       cid
       delta
       height

--- a/docs/website/getting-started.md
+++ b/docs/website/getting-started.md
@@ -161,19 +161,19 @@ It returns a structure similar to the following, which contains the update paylo
         "height": 1,
         "links": [
           {
-            "_cid": "bafybeiet6foxcipesjurdqi4zpsgsiok5znqgw4oa5poef6qtiby5hlpzy",
+            "cid": "bafybeiet6foxcipesjurdqi4zpsgsiok5znqgw4oa5poef6qtiby5hlpzy",
             "name": "age"
           },
           {
-            "_cid": "bafybeielahxy3r3ulykwoi5qalvkluojta4jlg6eyxvt7lbon3yd6ignby",
+            "cid": "bafybeielahxy3r3ulykwoi5qalvkluojta4jlg6eyxvt7lbon3yd6ignby",
             "name": "name"
           },
           {
-            "_cid": "bafybeia3tkpz52s3nx4uqadbm7t5tir6gagkvjkgipmxs2xcyzlkf4y4dm",
+            "cid": "bafybeia3tkpz52s3nx4uqadbm7t5tir6gagkvjkgipmxs2xcyzlkf4y4dm",
             "name": "points"
           },
           {
-            "_cid": "bafybeia4off4javopmxcdyvr6fgb5clo7m5bblxic5sqr2vd52s6khyksm",
+            "cid": "bafybeia4off4javopmxcdyvr6fgb5clo7m5bblxic5sqr2vd52s6khyksm",
             "name": "verified"
           }
         ]

--- a/docs/website/references/query-specification/database-api.md
+++ b/docs/website/references/query-specification/database-api.md
@@ -45,20 +45,7 @@ type Delta {
 To query the latest commit of an object (with id: '123'):
 ```graphql
 query {
-    latestCommits(docid: "123") {
-        cid
-        height
-        delta {
-            payload
-        }
-    }
-}
-```
-
-To query all the commits of an object (with id: '123'):
-```graphql
-query {
-    allCommits(docid: "123") {
+    _latestCommits(docid: "123") {
         cid
         height
         delta {
@@ -98,15 +85,15 @@ query {
 }
 ```
 
-The above example shows how to query for the additional `_version` field that is generated automatically for each added schema type. The `_version` has the same execution as `latestCommits`.
+The above example shows how to query for the additional `_version` field that is generated automatically for each added schema type. The `_version` has the same execution as `_latestCommits`.
 
-Both `_version` and `latestCommits` return an array of `Commits` types because the `HEAD` of the MerkleDAG can point to more than one DAG node. This is caused by two concurrent updates to the DAG at the same height. The DAG usually has a single head. However, it can also have multiple heads.
+Both `_version` and `_latestCommits` return an array of `Commits` types because the `HEAD` of the MerkleDAG can point to more than one DAG node. This is caused by two concurrent updates to the DAG at the same height. The DAG usually has a single head. However, it can also have multiple heads.
 
 Commits queries also work with aggregates, grouping, limit, offset, order, dockey, cid, and depth
 There is __typename introspection keyword that works on all queries that does not appear to be documented anywhere, for example:
 
 ```graphql 
-commits(dockey: "bae-75cb8b0a-00d7-57c8-8906-29687cbbb15c") {
+_commits(dockey: "bae-75cb8b0a-00d7-57c8-8906-29687cbbb15c") {
     cid
     __typename
 }

--- a/internal/planner/commit.go
+++ b/internal/planner/commit.go
@@ -266,7 +266,7 @@ func (n *dagScanNode) Next() (bool, error) {
 		return false, err
 	}
 
-	// if this is a time travel query or a latestCommits
+	// if this is a time travel query or a _latestCommits
 	// (cid + undefined depth + docId) then we need to make sure the
 	// target block actually belongs to the doc, since we are
 	// bypassing the HeadFetcher for the first cid

--- a/internal/planner/mapper/commitSelect.go
+++ b/internal/planner/mapper/commitSelect.go
@@ -14,7 +14,7 @@ import "github.com/sourcenetwork/immutable"
 
 // CommitSelect represents a commit request from a consumer.
 //
-// E.g. commits, or latestCommits.
+// E.g. _commits, or _latestCommits.
 type CommitSelect struct {
 	// The underlying Select, defining the information requested.
 	Select

--- a/internal/request/graphql/parser/commit.go
+++ b/internal/request/graphql/parser/commit.go
@@ -98,9 +98,9 @@ func parseCommitSelect(
 		}
 	}
 
-	// latestCommits is just syntax sugar around a commits operation.
+	// _latestCommits is just syntax sugar around a commits operation.
 	if commit.Name == request.LatestCommitsName {
-		// Depth is not exposed as an input parameter for latestCommits,
+		// Depth is not exposed as an input parameter for _latestCommits,
 		// so we can blindly set it here without worrying about existing
 		// values
 		commit.Depth = immutable.Some(uint64(1))

--- a/internal/request/graphql/parser/query.go
+++ b/internal/request/graphql/parser/query.go
@@ -266,7 +266,7 @@ func parseAggregateTarget(
 
 	for name, value := range arguments {
 		switch name {
-		case request.FieldName:
+		case request.FieldArgName:
 			if v, ok := value.(string); ok {
 				childName = v
 			}

--- a/internal/request/graphql/parser/subscription.go
+++ b/internal/request/graphql/parser/subscription.go
@@ -43,7 +43,7 @@ func parseSubscriptionOperationDefinition(
 // which includes sub fields, and may include
 // filters, IDs, etc.
 func parseSubscription(exe *gql.ExecutionContext, field *ast.Field) (request.Selection, error) {
-	if field.Name.Value == "commits" {
+	if field.Name.Value == request.CommitsName {
 		return parseCommitSelect(exe, exe.Schema.SubscriptionType(), field)
 	}
 	return parseObjectSubscription(exe, field)

--- a/internal/request/graphql/schema/types/commits.go
+++ b/internal/request/graphql/schema/types/commits.go
@@ -99,7 +99,7 @@ func CommitObject(commitLinkObject *gql.Object) *gql.Object {
 				Description: CountFieldDescription,
 				Type:        gql.Int,
 				Args: gql.FieldConfigArgument{
-					request.FieldName: &gql.ArgumentConfig{
+					request.FieldArgName: &gql.ArgumentConfig{
 						Type: gql.NewEnum(gql.EnumConfig{
 							Name:        "commitCountFieldArg",
 							Description: CountFieldDescription,
@@ -124,11 +124,11 @@ func CommitLinkObject() *gql.Object {
 		Name:        "CommitLink",
 		Description: commitLinksDescription,
 		Fields: gql.Fields{
-			"name": &gql.Field{
+			request.LinksNameFieldName: &gql.Field{
 				Description: commitLinkNameFieldDescription,
 				Type:        gql.String,
 			},
-			"cid": &gql.Field{
+			request.CidFieldName: &gql.Field{
 				Description: commitLinkCIDFieldDescription,
 				Type:        gql.String,
 			},
@@ -142,11 +142,11 @@ func CommitsOrderArg(orderEnum *gql.Enum) *gql.InputObject {
 			Name:        "commitsOrderArg",
 			Description: OrderArgDescription,
 			Fields: gql.InputObjectConfigFieldMap{
-				"height": &gql.InputObjectFieldConfig{
+				request.HeightArgName: &gql.InputObjectFieldConfig{
 					Description: commitHeightFieldDescription,
 					Type:        orderEnum,
 				},
-				"cid": &gql.InputObjectFieldConfig{
+				request.CidArgName: &gql.InputObjectFieldConfig{
 					Description: commitCIDFieldDescription,
 					Type:        orderEnum,
 				},
@@ -161,14 +161,14 @@ func CommitsOrderArg(orderEnum *gql.Enum) *gql.InputObject {
 
 func QueryCommits(commitObject *gql.Object, commitsOrderArg *gql.InputObject) *gql.Field {
 	return &gql.Field{
-		Name:        "commits",
+		Name:        request.CommitsName,
 		Description: commitsQueryDescription,
 		Type:        gql.NewList(commitObject),
 		Args: gql.FieldConfigArgument{
 			request.DocIDArgName:  NewArgConfig(gql.ID, commitDocIDArgDescription),
 			request.FieldNameName: NewArgConfig(gql.String, commitFieldNameArgDescription),
 			"order":               NewArgConfig(gql.NewList(commitsOrderArg), OrderArgDescription),
-			"cid":                 NewArgConfig(gql.ID, commitCIDArgDescription),
+			request.CidArgName:    NewArgConfig(gql.ID, commitCIDArgDescription),
 			"groupBy": NewArgConfig(
 				gql.NewList(
 					gql.NewNonNull(
@@ -177,20 +177,20 @@ func QueryCommits(commitObject *gql.Object, commitsOrderArg *gql.InputObject) *g
 								Name:        "commitFields",
 								Description: commitFieldsEnumDescription,
 								Values: gql.EnumValueConfigMap{
-									"height": &gql.EnumValueConfig{
-										Value:       "height",
+									request.HeightArgName: &gql.EnumValueConfig{
+										Value:       request.HeightArgName,
 										Description: commitHeightFieldDescription,
 									},
-									"cid": &gql.EnumValueConfig{
-										Value:       "cid",
+									request.CidArgName: &gql.EnumValueConfig{
+										Value:       request.CidArgName,
 										Description: commitCIDFieldDescription,
 									},
 									request.DocIDArgName: &gql.EnumValueConfig{
 										Value:       request.DocIDArgName,
 										Description: commitDocIDFieldDescription,
 									},
-									"fieldName": &gql.EnumValueConfig{
-										Value:       "fieldName",
+									request.FieldNameArgName: &gql.EnumValueConfig{
+										Value:       request.FieldNameArgName,
 										Description: commitFieldNameFieldDescription,
 									},
 								},
@@ -209,7 +209,7 @@ func QueryCommits(commitObject *gql.Object, commitsOrderArg *gql.InputObject) *g
 
 func QueryLatestCommits(commitObject *gql.Object) *gql.Field {
 	return &gql.Field{
-		Name:        "latestCommits",
+		Name:        request.LatestCommitsName,
 		Description: latestCommitsQueryDescription,
 		Type:        gql.NewList(commitObject),
 		Args: gql.FieldConfigArgument{

--- a/internal/request/graphql/schema/types/descriptions.go
+++ b/internal/request/graphql/schema/types/descriptions.go
@@ -99,7 +99,7 @@ The Name of the field that this linked commit mutated.
 The CID of this linked commit.
 `
 	commitFieldsEnumDescription string = `
-These are the set of fields supported for grouping by in a commits query.
+These are the set of fields supported for grouping by in a _commits query.
 `
 	commitsQueryDescription string = `
 Returns a set of commits matching any provided criteria. If no arguments are
@@ -109,7 +109,7 @@ Returns a set of commits matching any provided criteria. If no arguments are
 Returns a set of head commits matching any provided criteria. If no arguments are
  provided all head commits in the system will be returned. If no 'field' argument
  is provided only composite commits will be returned. This is equivalent to
- a 'commits' query with Depth: 1, and a differing 'field' default value.
+ a '_commits' query with Depth: 1, and a differing 'field' default value.
 `
 	CountFieldDescription string = `
 Returns the total number of items within the specified child sets. If multiple child

--- a/tests/integration/assert_stack.go
+++ b/tests/integration/assert_stack.go
@@ -18,7 +18,7 @@ import (
 // assertStack keeps track of the current assertion path.
 // GraphQL response can be traversed by a key of a map and/or an index of an array.
 // So whenever we have a mismatch in a large response, we can use this stack to find the exact path.
-// Example output: "commits[2].links[1].cid"
+// Example output: "_commits[2].links[1].cid"
 type assertStack struct {
 	stack []string
 	isMap []bool

--- a/tests/integration/collection_version/updates/add/field/create_update_test.go
+++ b/tests/integration/collection_version/updates/add/field/create_update_test.go
@@ -145,12 +145,12 @@ func TestSchemaUpdatesAddFieldWithCreateWithUpdateAfterSchemaUpdateAndCommitQuer
 			},
 			testUtils.Request{
 				Request: `query {
-					commits (fieldName: "_C") {
+					_commits (fieldName: "_C") {
 						schemaVersionId
 					}
 				}`,
 				Results: map[string]any{
-					"commits": []map[string]any{
+					"_commits": []map[string]any{
 						{
 							// Update commit
 							"schemaVersionId": updatedSchemaVersionID,

--- a/tests/integration/collection_version/updates/move/simple_test.go
+++ b/tests/integration/collection_version/updates/move/simple_test.go
@@ -69,12 +69,12 @@ func TestSchemaUpdatesMoveCollectionDoesNothing(t *testing.T) {
 			testUtils.Request{
 				// Assert that the version ID remains the same
 				Request: `query {
-					commits (fieldName: "_C") {
+					_commits (fieldName: "_C") {
 						schemaVersionId
 					}
 				}`,
 				Results: map[string]any{
-					"commits": []map[string]any{
+					"_commits": []map[string]any{
 						{
 							// Update commit
 							"schemaVersionId": schemaVersionID,

--- a/tests/integration/encryption/commit_relation_test.go
+++ b/tests/integration/encryption/commit_relation_test.go
@@ -56,7 +56,7 @@ func TestDocEncryption_WithEncryptionSecondaryRelations_ShouldStoreEncryptedComm
 			testUtils.Request{
 				Request: `
 					query {
-						commits {
+						_commits {
 							delta
 							docID
 							fieldName
@@ -64,7 +64,7 @@ func TestDocEncryption_WithEncryptionSecondaryRelations_ShouldStoreEncryptedComm
 					}
 				`,
 				Results: map[string]any{
-					"commits": []map[string]any{
+					"_commits": []map[string]any{
 						{
 							"delta":     encrypt(testUtils.CBORValue("Sony"), deviceDocID, ""),
 							"docID":     deviceDocID,

--- a/tests/integration/encryption/commit_test.go
+++ b/tests/integration/encryption/commit_test.go
@@ -31,7 +31,7 @@ func TestDocEncryption_WithEncryptionOnLWWCRDT_ShouldStoreCommitsDeltaEncrypted(
 			testUtils.Request{
 				Request: `
 					query {
-						commits {
+						_commits {
 							cid
 							delta
 							docID
@@ -45,7 +45,7 @@ func TestDocEncryption_WithEncryptionOnLWWCRDT_ShouldStoreCommitsDeltaEncrypted(
 					}
 				`,
 				Results: map[string]any{
-					"commits": []map[string]any{
+					"_commits": []map[string]any{
 						{
 							"cid":       "bafyreia37txi77ajmma3t3o4hlnkx7qdbzymioplbuscla576i52rr5hri",
 							"delta":     encrypt(testUtils.CBORValue(21), john21DocID, ""),
@@ -104,13 +104,13 @@ func TestDocEncryption_UponUpdateOnLWWCRDT_ShouldEncryptCommitDelta(t *testing.T
 			testUtils.Request{
 				Request: `
 					query {
-						commits(fieldName: "age") {
+						_commits(fieldName: "age") {
 							delta
 						}
 					}
 				`,
 				Results: map[string]any{
-					"commits": []map[string]any{
+					"_commits": []map[string]any{
 						{
 							"delta": encrypt(testUtils.CBORValue(22), john21DocID, ""),
 						},
@@ -152,14 +152,14 @@ func TestDocEncryption_WithMultipleDocsUponUpdate_ShouldEncryptOnlyRelevantDocs(
 			testUtils.Request{
 				Request: `
 					query {
-						commits(fieldName: "age") {
+						_commits(fieldName: "age") {
 							delta
 							docID
 						}
 					}
 				`,
 				Results: map[string]any{
-					"commits": []map[string]any{
+					"_commits": []map[string]any{
 						{
 							"delta": testUtils.CBORValue(34),
 							"docID": islam33DocID,
@@ -203,14 +203,14 @@ func TestDocEncryption_WithEncryptionOnCounterCRDT_ShouldStoreCommitsDeltaEncryp
 			testUtils.Request{
 				Request: `
 					query {
-						commits {
+						_commits {
 							delta
 							docID
 						}
 					}
 				`,
 				Results: map[string]any{
-					"commits": []map[string]any{
+					"_commits": []map[string]any{
 						{
 							"delta": encrypt(testUtils.CBORValue(5), docID, ""),
 							"docID": docID,
@@ -251,13 +251,13 @@ func TestDocEncryption_UponUpdateOnCounterCRDT_ShouldEncryptedCommitDelta(t *tes
 			testUtils.Request{
 				Request: `
 					query {
-						commits(fieldName: "points") {
+						_commits(fieldName: "points") {
 							delta
 						}
 					}
 				`,
 				Results: map[string]any{
-					"commits": []map[string]any{
+					"_commits": []map[string]any{
 						{
 							"delta": encrypt(testUtils.CBORValue(3), docID, ""),
 						},
@@ -284,14 +284,14 @@ func TestDocEncryption_UponEncryptionSeveralDocs_ShouldStoreAllCommitsDeltaEncry
 			testUtils.Request{
 				Request: `
 					query {
-						commits {
+						_commits {
 							delta
 							docID
 						}
 					}
 				`,
 				Results: map[string]any{
-					"commits": []map[string]any{
+					"_commits": []map[string]any{
 						{
 							"delta": encrypt(testUtils.CBORValue(33), islam33DocID, ""),
 							"docID": testUtils.NewDocIndex(0, 0),
@@ -346,14 +346,14 @@ func TestDocEncryption_IfTwoDocsHaveSameFieldValue_CipherTextShouldBeDifferent(t
 			testUtils.Request{
 				Request: `
 					query {
-						commits(fieldName: "age") {
+						_commits(fieldName: "age") {
 							delta
 							fieldName
 						}
 					}
 				`,
 				Asserter: testUtils.ResultAsserterFunc(func(t testing.TB, result map[string]any) (bool, string) {
-					commits := testUtils.ConvertToArrayOfMaps(t, result["commits"])
+					commits := testUtils.ConvertToArrayOfMaps(t, result["_commits"])
 					require.Equal(t, 2, len(commits), "Expected 2 commits")
 					require.Equal(t, commits[0]["fieldName"], "age")
 					delta1 := commits[0]["delta"]

--- a/tests/integration/encryption/field_commit_test.go
+++ b/tests/integration/encryption/field_commit_test.go
@@ -30,7 +30,7 @@ func TestDocEncryptionField_WithEncryptionOnField_ShouldStoreOnlyFieldsDeltaEncr
 			testUtils.Request{
 				Request: `
 					query {
-						commits {
+						_commits {
 							delta
 							docID
 							fieldName
@@ -38,7 +38,7 @@ func TestDocEncryptionField_WithEncryptionOnField_ShouldStoreOnlyFieldsDeltaEncr
 					}
 				`,
 				Results: map[string]any{
-					"commits": []map[string]any{
+					"_commits": []map[string]any{
 						{
 							"delta":     encrypt(testUtils.CBORValue(21), john21DocID, "age"),
 							"docID":     john21DocID,
@@ -98,7 +98,7 @@ func TestDocEncryptionField_WithDocAndFieldEncryption_ShouldUseDedicatedEncKeyFo
 			testUtils.Request{
 				Request: `
 					query {
-						commits {
+						_commits {
 							cid
 							delta
 							fieldName
@@ -106,7 +106,7 @@ func TestDocEncryptionField_WithDocAndFieldEncryption_ShouldUseDedicatedEncKeyFo
 					}
 				`,
 				Asserter: testUtils.ResultAsserterFunc(func(t testing.TB, result map[string]any) (bool, string) {
-					commits := testUtils.ConvertToArrayOfMaps(t, result["commits"])
+					commits := testUtils.ConvertToArrayOfMaps(t, result["_commits"])
 					name1 := deltaForField("name1", commits)
 					name2 := deltaForField("name2", commits)
 					name3 := deltaForField("name3", commits)
@@ -167,7 +167,7 @@ func TestDocEncryptionField_UponUpdateWithDocAndFieldEncryption_ShouldUseDedicat
 			testUtils.Request{
 				Request: `
 					query {
-						commits(order: {height: DESC}, limit: 5) {
+						_commits(order: {height: DESC}, limit: 5) {
 							cid
 							delta
 							fieldName
@@ -176,7 +176,7 @@ func TestDocEncryptionField_UponUpdateWithDocAndFieldEncryption_ShouldUseDedicat
 					}
 				`,
 				Asserter: testUtils.ResultAsserterFunc(func(_ testing.TB, result map[string]any) (bool, string) {
-					commits := testUtils.ConvertToArrayOfMaps(t, result["commits"])
+					commits := testUtils.ConvertToArrayOfMaps(t, result["_commits"])
 					name1 := deltaForField("name1", commits)
 					name2 := deltaForField("name2", commits)
 					name3 := deltaForField("name3", commits)

--- a/tests/integration/encryption/peer_acp_test.go
+++ b/tests/integration/encryption/peer_acp_test.go
@@ -227,14 +227,14 @@ func TestDocEncryptionACP_IfUserHasAccessButNotNode_ShouldNotFetch(t *testing.T)
 				Identity: testUtils.ClientIdentity(1),
 				Request: `
 					query {
-						commits {
+						_commits {
 							delta
 							docID
 						}
 					}
 				`,
 				Results: map[string]any{
-					"commits": []map[string]any{},
+					"_commits": []map[string]any{},
 				},
 			},
 		},

--- a/tests/integration/encryption/peer_test.go
+++ b/tests/integration/encryption/peer_test.go
@@ -43,7 +43,7 @@ func TestDocEncryptionPeer_UponSync_ShouldSyncEncryptedDAG(t *testing.T) {
 				NodeID: immutable.Some(1),
 				Request: `
 					query {
-						commits {
+						_commits {
 							cid
 							delta
 							docID
@@ -57,7 +57,7 @@ func TestDocEncryptionPeer_UponSync_ShouldSyncEncryptedDAG(t *testing.T) {
 					}
 				`,
 				Results: map[string]any{
-					"commits": []map[string]any{
+					"_commits": []map[string]any{
 						{
 							"cid":       "bafyreia37txi77ajmma3t3o4hlnkx7qdbzymioplbuscla576i52rr5hri",
 							"delta":     encrypt(testUtils.CBORValue(21), john21DocID, ""),

--- a/tests/integration/explain/debug/dagscan_test.go
+++ b/tests/integration/explain/debug/dagscan_test.go
@@ -40,7 +40,7 @@ func TestDebugExplainCommitsDagScanQueryOp(t *testing.T) {
 			testUtils.ExplainRequest{
 
 				Request: `query @explain(type: debug) {
-					commits (docID: "bae-9e70648f-c722-5875-97f5-574ec6f703e9", fieldName: "name") {
+					_commits (docID: "bae-9e70648f-c722-5875-97f5-574ec6f703e9", fieldName: "name") {
 						links {
 							cid
 						}
@@ -64,7 +64,7 @@ func TestDebugExplainCommitsDagScanQueryOpWithoutField(t *testing.T) {
 			testUtils.ExplainRequest{
 
 				Request: `query @explain(type: debug) {
-					commits (docID: "bae-9e70648f-c722-5875-97f5-574ec6f703e9") {
+					_commits (docID: "bae-9e70648f-c722-5875-97f5-574ec6f703e9") {
 						links {
 							cid
 						}
@@ -88,7 +88,7 @@ func TestDebugExplainLatestCommitsDagScanQueryOp(t *testing.T) {
 			testUtils.ExplainRequest{
 
 				Request: `query @explain(type: debug) {
-					latestCommits(docID: "bae-9e70648f-c722-5875-97f5-574ec6f703e9", fieldName: "name") {
+					_latestCommits(docID: "bae-9e70648f-c722-5875-97f5-574ec6f703e9", fieldName: "name") {
 						cid
 						links {
 							cid
@@ -113,7 +113,7 @@ func TestDebugExplainLatestCommitsDagScanQueryOpWithoutField(t *testing.T) {
 			testUtils.ExplainRequest{
 
 				Request: `query @explain(type: debug) {
-					latestCommits(docID: "bae-9e70648f-c722-5875-97f5-574ec6f703e9") {
+					_latestCommits(docID: "bae-9e70648f-c722-5875-97f5-574ec6f703e9") {
 						cid
 						links {
 							cid
@@ -138,7 +138,7 @@ func TestDebugExplainLatestCommitsDagScanWithoutDocID_Failure(t *testing.T) {
 			testUtils.ExplainRequest{
 
 				Request: `query @explain(type: debug) {
-					latestCommits(fieldName: "name") {
+					_latestCommits(fieldName: "name") {
 						cid
 						links {
 							cid
@@ -146,7 +146,7 @@ func TestDebugExplainLatestCommitsDagScanWithoutDocID_Failure(t *testing.T) {
 					}
 				}`,
 
-				ExpectedError: "Field \"latestCommits\" argument \"docID\" of type \"ID!\" is required but not provided.",
+				ExpectedError: "Field \"_latestCommits\" argument \"docID\" of type \"ID!\" is required but not provided.",
 			},
 		},
 	}
@@ -163,7 +163,7 @@ func TestDebugExplainLatestCommitsDagScanWithoutAnyArguments_Failure(t *testing.
 			testUtils.ExplainRequest{
 
 				Request: `query @explain(type: debug) {
-					latestCommits {
+					_latestCommits {
 						cid
 						links {
 							cid
@@ -171,7 +171,7 @@ func TestDebugExplainLatestCommitsDagScanWithoutAnyArguments_Failure(t *testing.
 					}
 				}`,
 
-				ExpectedError: "Field \"latestCommits\" argument \"docID\" of type \"ID!\" is required but not provided.",
+				ExpectedError: "Field \"_latestCommits\" argument \"docID\" of type \"ID!\" is required but not provided.",
 			},
 		},
 	}

--- a/tests/integration/explain/default/dagscan_test.go
+++ b/tests/integration/explain/default/dagscan_test.go
@@ -40,7 +40,7 @@ func TestDefaultExplainCommitsDagScanQueryOp(t *testing.T) {
 			testUtils.ExplainRequest{
 
 				Request: `query @explain {
-					commits (docID: "bae-9e70648f-c722-5875-97f5-574ec6f703e9", fieldName: "name") {
+					_commits (docID: "bae-9e70648f-c722-5875-97f5-574ec6f703e9", fieldName: "name") {
 						links {
 							cid
 						}
@@ -78,7 +78,7 @@ func TestDefaultExplainCommitsDagScanQueryOpWithoutField(t *testing.T) {
 			testUtils.ExplainRequest{
 
 				Request: `query @explain {
-					commits (docID: "bae-9e70648f-c722-5875-97f5-574ec6f703e9") {
+					_commits (docID: "bae-9e70648f-c722-5875-97f5-574ec6f703e9") {
 						links {
 							cid
 						}
@@ -116,7 +116,7 @@ func TestDefaultExplainLatestCommitsDagScanQueryOp(t *testing.T) {
 			testUtils.ExplainRequest{
 
 				Request: `query @explain {
-					latestCommits(docID: "bae-9e70648f-c722-5875-97f5-574ec6f703e9", fieldName: "name") {
+					_latestCommits(docID: "bae-9e70648f-c722-5875-97f5-574ec6f703e9", fieldName: "name") {
 						cid
 						links {
 							cid
@@ -155,7 +155,7 @@ func TestDefaultExplainLatestCommitsDagScanQueryOpWithoutField(t *testing.T) {
 			testUtils.ExplainRequest{
 
 				Request: `query @explain {
-					latestCommits(docID: "bae-9e70648f-c722-5875-97f5-574ec6f703e9") {
+					_latestCommits(docID: "bae-9e70648f-c722-5875-97f5-574ec6f703e9") {
 						cid
 						links {
 							cid
@@ -194,7 +194,7 @@ func TestDefaultExplainLatestCommitsDagScanWithoutDocID_Failure(t *testing.T) {
 			testUtils.ExplainRequest{
 
 				Request: `query @explain {
-					latestCommits(fieldName: "name") {
+					_latestCommits(fieldName: "name") {
 						cid
 						links {
 							cid
@@ -202,7 +202,7 @@ func TestDefaultExplainLatestCommitsDagScanWithoutDocID_Failure(t *testing.T) {
 					}
 				}`,
 
-				ExpectedError: "Field \"latestCommits\" argument \"docID\" of type \"ID!\" is required but not provided.",
+				ExpectedError: "Field \"_latestCommits\" argument \"docID\" of type \"ID!\" is required but not provided.",
 			},
 		},
 	}
@@ -219,7 +219,7 @@ func TestDefaultExplainLatestCommitsDagScanWithoutAnyArguments_Failure(t *testin
 			testUtils.ExplainRequest{
 
 				Request: `query @explain {
-					latestCommits {
+					_latestCommits {
 						cid
 						links {
 							cid
@@ -227,7 +227,7 @@ func TestDefaultExplainLatestCommitsDagScanWithoutAnyArguments_Failure(t *testin
 					}
 				}`,
 
-				ExpectedError: "Field \"latestCommits\" argument \"docID\" of type \"ID!\" is required but not provided.",
+				ExpectedError: "Field \"_latestCommits\" argument \"docID\" of type \"ID!\" is required but not provided.",
 			},
 		},
 	}

--- a/tests/integration/explain/execute/dagscan_test.go
+++ b/tests/integration/explain/execute/dagscan_test.go
@@ -27,7 +27,7 @@ func TestExecuteExplainCommitsDagScan(t *testing.T) {
 
 			testUtils.ExplainRequest{
 				Request: `query @explain(type: execute) {
-					commits (docID: "bae-b7bb2486-6364-58c0-bf60-91ff90ee72be") {
+					_commits (docID: "bae-b7bb2486-6364-58c0-bf60-91ff90ee72be") {
 						links {
 							cid
 						}
@@ -73,7 +73,7 @@ func TestExecuteExplainLatestCommitsDagScan(t *testing.T) {
 
 			testUtils.ExplainRequest{
 				Request: `query @explain(type: execute) {
-					latestCommits(docID: "bae-b7bb2486-6364-58c0-bf60-91ff90ee72be") {
+					_latestCommits(docID: "bae-b7bb2486-6364-58c0-bf60-91ff90ee72be") {
 						cid
 						links {
 							cid

--- a/tests/integration/query/commits/branchables/cid_doc_id_test.go
+++ b/tests/integration/query/commits/branchables/cid_doc_id_test.go
@@ -39,7 +39,7 @@ func TestQueryCommitsBranchables_WithCidAndDocIDParam(t *testing.T) {
 				// It would be very nice if this worked:
 				// https://github.com/sourcenetwork/defradb/issues/3213
 				Request: `query {
-						commits(
+						_commits(
 							docID: "bae-f895da58-3326-510a-87f3-d043ff5424ea",
 							cid: "bafyreiai57cngq2fthjmwmdnqhkugj6u5nqz5wtvpphnel6l2i6jyumevu"
 						) {
@@ -47,7 +47,7 @@ func TestQueryCommitsBranchables_WithCidAndDocIDParam(t *testing.T) {
 						}
 					}`,
 				Results: map[string]any{
-					"commits": []map[string]any{},
+					"_commits": []map[string]any{},
 				},
 				ExpectedError: "cid either does not exist or belong to document",
 			},

--- a/tests/integration/query/commits/branchables/cid_test.go
+++ b/tests/integration/query/commits/branchables/cid_test.go
@@ -36,7 +36,7 @@ func TestQueryCommitsBranchables_WithCidParam(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: `query {
-						commits(
+						_commits(
 							cid: "bafyreiai57cngq2fthjmwmdnqhkugj6u5nqz5wtvpphnel6l2i6jyumevu"
 						) {
 							cid
@@ -45,7 +45,7 @@ func TestQueryCommitsBranchables_WithCidParam(t *testing.T) {
 						}
 					}`,
 				Results: map[string]any{
-					"commits": []map[string]any{
+					"_commits": []map[string]any{
 						{
 							"cid": "bafyreiai57cngq2fthjmwmdnqhkugj6u5nqz5wtvpphnel6l2i6jyumevu",
 							// Extra params are used to verify this is a collection level cid

--- a/tests/integration/query/commits/branchables/create_test.go
+++ b/tests/integration/query/commits/branchables/create_test.go
@@ -55,7 +55,7 @@ func TestQueryCommitsBranchables_WithMultipleCreate(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: `query {
-						commits {
+						_commits {
 							cid
 							links {
 								cid
@@ -63,7 +63,7 @@ func TestQueryCommitsBranchables_WithMultipleCreate(t *testing.T) {
 						}
 					}`,
 				Results: map[string]any{
-					"commits": []map[string]any{
+					"_commits": []map[string]any{
 						{
 							"cid": gomega.And(doc2CollectionCid, uniqueCid),
 							"links": []map[string]any{

--- a/tests/integration/query/commits/branchables/delete_test.go
+++ b/tests/integration/query/commits/branchables/delete_test.go
@@ -50,7 +50,7 @@ func TestQueryCommitsBranchables_WithDelete(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: `query {
-						commits {
+						_commits {
 							cid
 							links {
 								cid
@@ -58,7 +58,7 @@ func TestQueryCommitsBranchables_WithDelete(t *testing.T) {
 						}
 					}`,
 				Results: map[string]any{
-					"commits": []map[string]any{
+					"_commits": []map[string]any{
 						{
 							"cid": gomega.And(collectionDeleteCid, uniqueCid),
 							"links": []map[string]any{

--- a/tests/integration/query/commits/branchables/field_id_test.go
+++ b/tests/integration/query/commits/branchables/field_id_test.go
@@ -36,7 +36,7 @@ func TestQueryCommitsBranchables_WithFieldName(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: `query {
-						commits(
+						_commits(
 							fieldName: null
 						) {
 							schemaVersionId
@@ -45,7 +45,7 @@ func TestQueryCommitsBranchables_WithFieldName(t *testing.T) {
 						}
 					}`,
 				Results: map[string]any{
-					"commits": []map[string]any{
+					"_commits": []map[string]any{
 						{
 							// Extra params are used to verify this is a collection level cid
 							"schemaVersionId": "bafyreifnbhwntycylk2l6n4khiocdt3vks46tizjdaz6yx4tsmdjtdtlma",

--- a/tests/integration/query/commits/branchables/if_test.go
+++ b/tests/integration/query/commits/branchables/if_test.go
@@ -45,12 +45,12 @@ func TestQueryCommitsBranchables_WithIfDirectiveTrue(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: `query {
-						commits {
+						_commits {
 							cid
 						}
 					}`,
 				Results: map[string]any{
-					"commits": []map[string]any{
+					"_commits": []map[string]any{
 						{
 							"cid": gomega.And(collectionCid, uniqueCid),
 						},
@@ -97,12 +97,12 @@ func TestQueryCommitsBranchables_WithIfDirectiveFalse(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: `query {
-						commits {
+						_commits {
 							cid
 						}
 					}`,
 				Results: map[string]any{
-					"commits": []map[string]any{
+					"_commits": []map[string]any{
 						// Note: This collection is not branchable, there is no collection
 						// level commit
 						{

--- a/tests/integration/query/commits/branchables/peer_test.go
+++ b/tests/integration/query/commits/branchables/peer_test.go
@@ -59,7 +59,7 @@ func TestQueryCommitsBranchables_SyncsAcrossPeerConnection(t *testing.T) {
 			testUtils.WaitForSync{},
 			testUtils.Request{
 				Request: `query {
-						commits {
+						_commits {
 							cid
 							links {
 								cid
@@ -67,7 +67,7 @@ func TestQueryCommitsBranchables_SyncsAcrossPeerConnection(t *testing.T) {
 						}
 					}`,
 				Results: map[string]any{
-					"commits": []map[string]any{
+					"_commits": []map[string]any{
 						{
 							"cid": gomega.And(collectionCid, uniqueCid),
 							"links": []map[string]any{
@@ -153,7 +153,7 @@ func TestQueryCommitsBranchables_SyncsMultipleAcrossPeerConnection(t *testing.T)
 			testUtils.WaitForSync{},
 			testUtils.Request{
 				Request: `query {
-						commits {
+						_commits {
 							cid
 							links {
 								cid
@@ -161,7 +161,7 @@ func TestQueryCommitsBranchables_SyncsMultipleAcrossPeerConnection(t *testing.T)
 						}
 					}`,
 				Results: map[string]any{
-					"commits": []map[string]any{
+					"_commits": []map[string]any{
 						{
 							"cid": gomega.And(collectionDoc2CreateCid, uniqueCid),
 							"links": []map[string]any{

--- a/tests/integration/query/commits/branchables/peer_update_test.go
+++ b/tests/integration/query/commits/branchables/peer_update_test.go
@@ -83,7 +83,7 @@ func TestQueryCommitsBranchables_HandlesConcurrentUpdatesAcrossPeerConnection(t 
 			testUtils.WaitForSync{},
 			testUtils.UpdateDoc{
 				// Update node 1 after the peer connection has been established, this will cause the `Shahzad` commit
-				// to be synced to node 0, as well as the related collection commits.
+				// to be synced to node 0, as well as the related collection _commits.
 				NodeID: immutable.Some(1),
 				Doc: `{
 					"name":	"Chris"
@@ -92,8 +92,8 @@ func TestQueryCommitsBranchables_HandlesConcurrentUpdatesAcrossPeerConnection(t 
 			testUtils.WaitForSync{},
 			testUtils.UpdateDoc{
 				// Update node 0 after `Chris` and `Shahzad` have synced to node 0.  As this update happens after the peer
-				// connection has been established, this will cause the `Fred` and `Addo` doc commits, and their corresponding
-				// collection-level commits to sync to node 1.
+				// connection has been established, this will cause the `Fred` and `Addo` doc _commits, and their corresponding
+				// collection-level _commits to sync to node 1.
 				//
 				// Now, all nodes should have a full history, including the 'offline' changes made before establishing the
 				// peer connection.
@@ -107,7 +107,7 @@ func TestQueryCommitsBranchables_HandlesConcurrentUpdatesAcrossPeerConnection(t 
 				// Strong eventual consistency must now have been established across both nodes, the result of this query
 				// *must* exactly match across both nodes.
 				Request: `query {
-						commits {
+						_commits {
 							cid
 							links {
 								cid
@@ -115,7 +115,7 @@ func TestQueryCommitsBranchables_HandlesConcurrentUpdatesAcrossPeerConnection(t 
 						}
 					}`,
 				Results: map[string]any{
-					"commits": []map[string]any{
+					"_commits": []map[string]any{
 						{
 							"cid": gomega.And(collectionNode0Update3Cid, uniqueCid),
 							"links": []map[string]any{

--- a/tests/integration/query/commits/branchables/simple_test.go
+++ b/tests/integration/query/commits/branchables/simple_test.go
@@ -40,12 +40,12 @@ func TestQueryCommitsBranchables(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: `query {
-						commits {
+						_commits {
 							cid
 						}
 					}`,
 				Results: map[string]any{
-					"commits": []map[string]any{
+					"_commits": []map[string]any{
 						{
 							"cid": uniqueCid,
 						},
@@ -93,7 +93,7 @@ func TestQueryCommitsBranchables_WithAllFields(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: `query {
-						commits {
+						_commits {
 							cid
 							schemaVersionId
 							delta
@@ -107,7 +107,7 @@ func TestQueryCommitsBranchables_WithAllFields(t *testing.T) {
 						}
 					}`,
 				Results: map[string]any{
-					"commits": []map[string]any{
+					"_commits": []map[string]any{
 						{
 							"cid":             gomega.And(collectionCid, uniqueCid),
 							"schemaVersionId": "bafyreifnbhwntycylk2l6n4khiocdt3vks46tizjdaz6yx4tsmdjtdtlma",

--- a/tests/integration/query/commits/branchables/update_test.go
+++ b/tests/integration/query/commits/branchables/update_test.go
@@ -53,7 +53,7 @@ func TestQueryCommitsBranchables_WithDocUpdate(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: `query {
-						commits {
+						_commits {
 							cid
 							links {
 								cid
@@ -61,7 +61,7 @@ func TestQueryCommitsBranchables_WithDocUpdate(t *testing.T) {
 						}
 					}`,
 				Results: map[string]any{
-					"commits": []map[string]any{
+					"_commits": []map[string]any{
 						{
 							"cid": gomega.And(collectionUpdateCid, uniqueCid),
 							"links": []map[string]any{

--- a/tests/integration/query/commits/simple_test.go
+++ b/tests/integration/query/commits/simple_test.go
@@ -37,12 +37,12 @@ func TestQueryCommits(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: `query {
-						commits {
+						_commits {
 							cid
 						}
 					}`,
 				Results: map[string]any{
-					"commits": []map[string]any{
+					"_commits": []map[string]any{
 						{
 							"cid": gomega.And(nameCid, uniqueCid),
 						},
@@ -81,12 +81,12 @@ func TestQueryCommitsMultipleDocs(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: `query {
-						commits {
+						_commits {
 							cid
 						}
 					}`,
 				Results: map[string]any{
-					"commits": []map[string]any{
+					"_commits": []map[string]any{
 						{
 							"cid": "bafyreigyslrbac5tgyapdtdo5jrqwon4hewndxjztlbenx632zgmqsma2y",
 						},
@@ -127,13 +127,13 @@ func TestQueryCommitsWithSchemaVersionIDField(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: `query {
-						commits {
+						_commits {
 							cid
 							schemaVersionId
 						}
 					}`,
 				Results: map[string]any{
-					"commits": []map[string]any{
+					"_commits": []map[string]any{
 						{
 							"cid":             "bafyreiae763hq5srsefplqrehpsuyieuwmbvblgzdma7srss522yciumhu",
 							"schemaVersionId": "bafyreigk2gtae2irmijtkb7z736r3lpssqv7cvmbrp3p6x6ouw7nakc4nm",
@@ -168,13 +168,13 @@ func TestQueryCommitsWithFieldNameField(t *testing.T) {
 			testUtils.Request{
 				Request: `
 					query {
-						commits {
+						_commits {
 							fieldName
 						}
 					}
 				`,
 				Results: map[string]any{
-					"commits": []map[string]any{
+					"_commits": []map[string]any{
 						{
 							"fieldName": "age",
 						},
@@ -211,13 +211,13 @@ func TestQueryCommitsWithFieldNameFieldAndUpdate(t *testing.T) {
 			testUtils.Request{
 				Request: `
 					query {
-						commits {
+						_commits {
 							fieldName
 						}
 					}
 				`,
 				Results: map[string]any{
-					"commits": []map[string]any{
+					"_commits": []map[string]any{
 						{
 							"fieldName": "age",
 						},
@@ -268,7 +268,7 @@ func TestQuery_CommitsWithAllFieldsWithUpdate_NoError(t *testing.T) {
 			testUtils.Request{
 				Request: `
 					query {
-						commits {
+						_commits {
 							cid
 							delta
 							docID
@@ -280,12 +280,12 @@ func TestQuery_CommitsWithAllFieldsWithUpdate_NoError(t *testing.T) {
 							}
 							signature {
 								type
-						}
+							}
 						}
 					}
 				`,
 				Results: map[string]any{
-					"commits": []map[string]any{
+					"_commits": []map[string]any{
 						{
 							"cid":       gomega.And(ageUpdateCid, uniqueCid),
 							"delta":     testUtils.CBORValue(22),
@@ -352,7 +352,7 @@ func TestQuery_CommitsWithAllFieldsWithUpdate_NoError(t *testing.T) {
 									"name": "name",
 								},
 							},
-							"signature": nil,
+							"_signature": nil,
 						},
 					},
 				},
@@ -376,7 +376,7 @@ func TestQueryCommits_WithAlias_Succeeds(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: `query {
-					history: commits {
+					history: _commits {
 						cid
 					}
 				}`,

--- a/tests/integration/query/commits/with_cid_test.go
+++ b/tests/integration/query/commits/with_cid_test.go
@@ -36,14 +36,14 @@ func TestQueryCommitsWithCid(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: `query {
-						commits(
+						_commits(
 							cid: "bafyreidtdklweht7ainl5rrdeqscr3cwr72sr4lehzrpmmnnbvnvstavnm"
 						) {
 							cid
 						}
 					}`,
 				Results: map[string]any{
-					"commits": []map[string]any{
+					"_commits": []map[string]any{
 						{
 							"cid": "bafyreidtdklweht7ainl5rrdeqscr3cwr72sr4lehzrpmmnnbvnvstavnm",
 						},
@@ -75,14 +75,14 @@ func TestQueryCommitsWithCidForFieldCommit(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: `query {
-						commits(
+						_commits(
 							cid: "bafyreiht7yhnnrgbwgyu5toe3exvpkovzrefzr6midu5secnlr546oel3q"
 						) {
 							cid
 						}
 					}`,
 				Results: map[string]any{
-					"commits": []map[string]any{
+					"_commits": []map[string]any{
 						{
 							"cid": "bafyreiht7yhnnrgbwgyu5toe3exvpkovzrefzr6midu5secnlr546oel3q",
 						},
@@ -108,14 +108,14 @@ func TestQueryCommitsWithInvalidCid(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: `query {
-						commits(cid: "fhbnjfahfhfhanfhga") {
+						_commits(cid: "fhbnjfahfhfhanfhga") {
 							cid
 							height
 							delta
 						}
 					}`,
 				Results: map[string]any{
-					"commits": []map[string]any{},
+					"_commits": []map[string]any{},
 				},
 				ExpectedError: "invalid cid",
 			},
@@ -138,14 +138,14 @@ func TestQueryCommitsWithInvalidShortCid(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: `query {
-						commits(cid: "bafybeidfhbnjfahfhfhanfhga") {
+						_commits(cid: "bafybeidfhbnjfahfhfhanfhga") {
 							cid
 							height
 							delta
 						}
 					}`,
 				Results: map[string]any{
-					"commits": []map[string]any{},
+					"_commits": []map[string]any{},
 				},
 				ExpectedError: "invalid cid",
 			},
@@ -168,14 +168,14 @@ func TestQueryCommitsWithUnknownCid(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: `query {
-						commits(cid: "bafybeid57gpbwi4i6bg7g35hhhhhhhhhhhhhhhhhhhhhhhdoesnotexist") {
+						_commits(cid: "bafybeid57gpbwi4i6bg7g35hhhhhhhhhhhhhhhhhhhhhhhdoesnotexist") {
 							cid
 							height
 							delta
 						}
 					}`,
 				Results: map[string]any{
-					"commits": []map[string]any{},
+					"_commits": []map[string]any{},
 				},
 				ExpectedError: "cid either does not exist or belong to document",
 			},

--- a/tests/integration/query/commits/with_delete_test.go
+++ b/tests/integration/query/commits/with_delete_test.go
@@ -49,7 +49,7 @@ func TestQueryCommits_AfterDocDeletion_ShouldStillFetch(t *testing.T) {
 			testUtils.Request{
 				Request: `
 					query {
-						commits(fieldName: "_C") {
+						_commits(fieldName: "_C") {
 							cid
 							fieldName
 							links {
@@ -60,7 +60,7 @@ func TestQueryCommits_AfterDocDeletion_ShouldStillFetch(t *testing.T) {
 					}
 				`,
 				Results: map[string]any{
-					"commits": []map[string]any{
+					"_commits": []map[string]any{
 						{
 							"cid":       gomega.And(deleteCid, uniqueCid),
 							"fieldName": "_C",

--- a/tests/integration/query/commits/with_depth_test.go
+++ b/tests/integration/query/commits/with_depth_test.go
@@ -29,12 +29,12 @@ func TestQueryCommitsWithDepth1(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: `query {
-						commits(depth: 1) {
+						_commits(depth: 1) {
 							cid
 						}
 					}`,
 				Results: map[string]any{
-					"commits": []map[string]any{
+					"_commits": []map[string]any{
 						{
 							"cid": "bafyreiae763hq5srsefplqrehpsuyieuwmbvblgzdma7srss522yciumhu",
 						},
@@ -73,13 +73,13 @@ func TestQueryCommitsWithDepth1WithUpdate(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: `query {
-						commits(depth: 1) {
+						_commits(depth: 1) {
 							cid
 							height
 						}
 					}`,
 				Results: map[string]any{
-					"commits": []map[string]any{
+					"_commits": []map[string]any{
 						{
 							// "Age" field head
 							"cid":    "bafyreic5mqzoba47yzm5pugx5b35visawxi2al2tq7p7x2b6yayklwomga",
@@ -130,13 +130,13 @@ func TestQueryCommitsWithDepth2WithUpdate(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: `query {
-						commits(depth: 2) {
+						_commits(depth: 2) {
 							cid
 							height
 						}
 					}`,
 				Results: map[string]any{
-					"commits": []map[string]any{
+					"_commits": []map[string]any{
 						{
 							// Composite head
 							"cid":    "bafyreiaa6r6d6ure3murz63ebfbmwlmtgm5rc5wbqvucufnku2k3vlgsga",
@@ -191,12 +191,12 @@ func TestQueryCommitsWithDepth1AndMultipleDocs(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: `query {
-						commits(depth: 1) {
+						_commits(depth: 1) {
 							cid
 						}
 					}`,
 				Results: map[string]any{
-					"commits": []map[string]any{
+					"_commits": []map[string]any{
 						{
 							"cid": "bafyreifpabjgptgmwx4xw5vmvkp55xqrlnenvb2qfl2jazmq7crfzhmxz4",
 						},

--- a/tests/integration/query/commits/with_doc_id_cid_test.go
+++ b/tests/integration/query/commits/with_doc_id_cid_test.go
@@ -29,7 +29,7 @@ func TestQueryCommitsWithDocIDAndCidForDifferentDoc(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: ` {
-						commits(
+						_commits(
 							docID: "bae-not-this-doc",
 							cid: "bafybeica4js2abwqjjrz7dcialbortbz32uxp7ufxu7yljbwvmhjqqxzny"
 						) {
@@ -37,7 +37,7 @@ func TestQueryCommitsWithDocIDAndCidForDifferentDoc(t *testing.T) {
 						}
 					}`,
 				Results: map[string]any{
-					"commits": []map[string]any{},
+					"_commits": []map[string]any{},
 				},
 				ExpectedError: "cid either does not exist or belong to document",
 			},
@@ -67,7 +67,7 @@ func TestQueryCommitsWithDocIDAndCidForDifferentDocWithUpdate(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: ` {
-						commits(
+						_commits(
 							docID: "bae-not-this-doc",
 							cid: "bafyreido4fwolghako5ogh4jcy6tr3butjicfwubk27uyuimlm366rtdmy"
 						) {
@@ -75,7 +75,7 @@ func TestQueryCommitsWithDocIDAndCidForDifferentDocWithUpdate(t *testing.T) {
 						}
 					}`,
 				Results: map[string]any{
-					"commits": []map[string]any{},
+					"_commits": []map[string]any{},
 				},
 				ExpectedError: "cid either does not exist or belong to document",
 			},
@@ -105,7 +105,7 @@ func TestQueryCommitsWithDocIDAndCidWithUpdate(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: ` {
-						commits(
+						_commits(
 							docID: "bae-dfeea2ca-5e6d-5333-85e8-213a80b508f7",
 							cid: "bafyreido4fwolghako5ogh4jcy6tr3butjicfwubk27uyuimlm366rtdmy"
 						) {
@@ -113,7 +113,7 @@ func TestQueryCommitsWithDocIDAndCidWithUpdate(t *testing.T) {
 						}
 					}`,
 				Results: map[string]any{
-					"commits": []map[string]any{
+					"_commits": []map[string]any{
 						{
 							"cid": "bafyreido4fwolghako5ogh4jcy6tr3butjicfwubk27uyuimlm366rtdmy",
 						},
@@ -148,7 +148,7 @@ func TestQueryCommitsWithDocIDAndCidWithUpdateAndDepth(t *testing.T) {
 			// from the target cid (ie >=2)
 			testUtils.Request{
 				Request: ` {
-						commits(
+						_commits(
 							docID: "bae-dfeea2ca-5e6d-5333-85e8-213a80b508f7",
 							cid: "bafyreido4fwolghako5ogh4jcy6tr3butjicfwubk27uyuimlm366rtdmy",
 							depth: 5
@@ -157,7 +157,7 @@ func TestQueryCommitsWithDocIDAndCidWithUpdateAndDepth(t *testing.T) {
 						}
 					}`,
 				Results: map[string]any{
-					"commits": []map[string]any{
+					"_commits": []map[string]any{
 						{
 							"cid": "bafyreido4fwolghako5ogh4jcy6tr3butjicfwubk27uyuimlm366rtdmy",
 						},

--- a/tests/integration/query/commits/with_doc_id_count_test.go
+++ b/tests/integration/query/commits/with_doc_id_count_test.go
@@ -29,13 +29,13 @@ func TestQueryCommitsWithDocIDAndLinkCount(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: `query {
-						commits(docID: "bae-dfeea2ca-5e6d-5333-85e8-213a80b508f7") {
+						_commits(docID: "bae-dfeea2ca-5e6d-5333-85e8-213a80b508f7") {
 							cid
 							_count(field: links)
 						}
 					}`,
 				Results: map[string]any{
-					"commits": []map[string]any{
+					"_commits": []map[string]any{
 						{
 							"cid":    "bafyreiae763hq5srsefplqrehpsuyieuwmbvblgzdma7srss522yciumhu",
 							"_count": 0,

--- a/tests/integration/query/commits/with_doc_id_field_test.go
+++ b/tests/integration/query/commits/with_doc_id_field_test.go
@@ -29,12 +29,12 @@ func TestQueryCommitsWithDocIDAndUnknownField(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: `query {
-						commits(docID: "bae-dfeea2ca-5e6d-5333-85e8-213a80b508f7", fieldName: "not a field") {
+						_commits(docID: "bae-dfeea2ca-5e6d-5333-85e8-213a80b508f7", fieldName: "not a field") {
 							cid
 						}
 					}`,
 				Results: map[string]any{
-					"commits": []map[string]any{},
+					"_commits": []map[string]any{},
 				},
 			},
 		},
@@ -56,12 +56,12 @@ func TestQueryCommitsWithDocIDAndUnknownFieldId(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: `query {
-						commits(docID: "bae-dfeea2ca-5e6d-5333-85e8-213a80b508f7", fieldName: "999999") {
+						_commits(docID: "bae-dfeea2ca-5e6d-5333-85e8-213a80b508f7", fieldName: "999999") {
 							cid
 						}
 					}`,
 				Results: map[string]any{
-					"commits": []map[string]any{},
+					"_commits": []map[string]any{},
 				},
 			},
 		},
@@ -83,12 +83,12 @@ func TestQueryCommitsWithDocIDAndField(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: `query {
-						commits(docID: "bae-dfeea2ca-5e6d-5333-85e8-213a80b508f7", fieldName: "age") {
+						_commits(docID: "bae-dfeea2ca-5e6d-5333-85e8-213a80b508f7", fieldName: "age") {
 							cid
 						}
 					}`,
 				Results: map[string]any{
-					"commits": []map[string]any{
+					"_commits": []map[string]any{
 						{
 							"cid": "bafyreiae763hq5srsefplqrehpsuyieuwmbvblgzdma7srss522yciumhu",
 						},
@@ -114,12 +114,12 @@ func TestQueryCommitsWithDocIDAndCompositeField(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: `query {
-						commits(docID: "bae-dfeea2ca-5e6d-5333-85e8-213a80b508f7", fieldName: "_C") {
+						_commits(docID: "bae-dfeea2ca-5e6d-5333-85e8-213a80b508f7", fieldName: "_C") {
 							cid
 						}
 					}`,
 				Results: map[string]any{
-					"commits": []map[string]any{
+					"_commits": []map[string]any{
 						{
 							"cid": "bafyreidtdklweht7ainl5rrdeqscr3cwr72sr4lehzrpmmnnbvnvstavnm",
 						},

--- a/tests/integration/query/commits/with_doc_id_group_order_test.go
+++ b/tests/integration/query/commits/with_doc_id_group_order_test.go
@@ -36,12 +36,12 @@ func TestQueryCommitsOrderedAndGroupedByDocID(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: ` {
-					commits(groupBy: [docID], order: {docID: DESC}) {
+					_commits(groupBy: [docID], order: {docID: DESC}) {
 						docID
 					}
 				}`,
 				Results: map[string]any{
-					"commits": []map[string]any{
+					"_commits": []map[string]any{
 						{
 							"docID": "bae-dfeea2ca-5e6d-5333-85e8-213a80b508f7",
 						},

--- a/tests/integration/query/commits/with_doc_id_limit_offset_test.go
+++ b/tests/integration/query/commits/with_doc_id_limit_offset_test.go
@@ -50,12 +50,12 @@ func TestQueryCommitsWithDocIDAndLimitAndOffset(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: ` {
-						commits(docID: "bae-dfeea2ca-5e6d-5333-85e8-213a80b508f7", limit: 2, offset: 1) {
+						_commits(docID: "bae-dfeea2ca-5e6d-5333-85e8-213a80b508f7", limit: 2, offset: 1) {
 							cid
 						}
 					}`,
 				Results: map[string]any{
-					"commits": []map[string]any{
+					"_commits": []map[string]any{
 						{
 							"cid": "bafyreiaa6r6d6ure3murz63ebfbmwlmtgm5rc5wbqvucufnku2k3vlgsga",
 						},

--- a/tests/integration/query/commits/with_doc_id_limit_test.go
+++ b/tests/integration/query/commits/with_doc_id_limit_test.go
@@ -43,12 +43,12 @@ func TestQueryCommitsWithDocIDAndLimit(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: ` {
-						commits(docID: "bae-dfeea2ca-5e6d-5333-85e8-213a80b508f7", limit: 2) {
+						_commits(docID: "bae-dfeea2ca-5e6d-5333-85e8-213a80b508f7", limit: 2) {
 							cid
 						}
 					}`,
 				Results: map[string]any{
-					"commits": []map[string]any{
+					"_commits": []map[string]any{
 						{
 							"cid": "bafyreiaa6r6d6ure3murz63ebfbmwlmtgm5rc5wbqvucufnku2k3vlgsga",
 						},

--- a/tests/integration/query/commits/with_doc_id_order_limit_offset_test.go
+++ b/tests/integration/query/commits/with_doc_id_order_limit_offset_test.go
@@ -50,13 +50,13 @@ func TestQueryCommitsWithDocIDAndOrderAndLimitAndOffset(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: `query {
-						commits(docID: "bae-dfeea2ca-5e6d-5333-85e8-213a80b508f7", order: {height: ASC}, limit: 2, offset: 4) {
+						_commits(docID: "bae-dfeea2ca-5e6d-5333-85e8-213a80b508f7", order: {height: ASC}, limit: 2, offset: 4) {
 							cid
 							height
 						}
 					}`,
 				Results: map[string]any{
-					"commits": []map[string]any{
+					"_commits": []map[string]any{
 						{
 							"cid":    "bafyreido4fwolghako5ogh4jcy6tr3butjicfwubk27uyuimlm366rtdmy",
 							"height": int64(2),

--- a/tests/integration/query/commits/with_doc_id_order_test.go
+++ b/tests/integration/query/commits/with_doc_id_order_test.go
@@ -36,13 +36,13 @@ func TestQueryCommitsWithDocIDAndOrderHeightDesc(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: `query {
-						commits(docID: "bae-dfeea2ca-5e6d-5333-85e8-213a80b508f7", order: {height: DESC}) {
+						_commits(docID: "bae-dfeea2ca-5e6d-5333-85e8-213a80b508f7", order: {height: DESC}) {
 							cid
 							height
 						}
 					}`,
 				Results: map[string]any{
-					"commits": []map[string]any{
+					"_commits": []map[string]any{
 						{
 							"cid":    "bafyreic5mqzoba47yzm5pugx5b35visawxi2al2tq7p7x2b6yayklwomga",
 							"height": int64(2),
@@ -92,13 +92,13 @@ func TestQueryCommitsWithDocIDAndOrderHeightAsc(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: `query {
-						commits(docID: "bae-dfeea2ca-5e6d-5333-85e8-213a80b508f7", order: {height: ASC}) {
+						_commits(docID: "bae-dfeea2ca-5e6d-5333-85e8-213a80b508f7", order: {height: ASC}) {
 							cid
 							height
 						}
 					}`,
 				Results: map[string]any{
-					"commits": []map[string]any{
+					"_commits": []map[string]any{
 						{
 							"cid":    "bafyreiae763hq5srsefplqrehpsuyieuwmbvblgzdma7srss522yciumhu",
 							"height": int64(1),
@@ -148,13 +148,13 @@ func TestQueryCommitsWithDocIDAndOrderCidDesc(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: `query {
-						commits(docID: "bae-dfeea2ca-5e6d-5333-85e8-213a80b508f7", order: {cid: DESC}) {
+						_commits(docID: "bae-dfeea2ca-5e6d-5333-85e8-213a80b508f7", order: {cid: DESC}) {
 							cid
 							height
 						}
 					}`,
 				Results: map[string]any{
-					"commits": []map[string]any{
+					"_commits": []map[string]any{
 						{
 							"cid":    "bafyreiht7yhnnrgbwgyu5toe3exvpkovzrefzr6midu5secnlr546oel3q",
 							"height": int64(1),
@@ -204,13 +204,13 @@ func TestQueryCommitsWithDocIDAndOrderCidAsc(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: `query {
-						commits(docID: "bae-dfeea2ca-5e6d-5333-85e8-213a80b508f7", order: {cid: ASC}) {
+						_commits(docID: "bae-dfeea2ca-5e6d-5333-85e8-213a80b508f7", order: {cid: ASC}) {
 							cid
 							height
 						}
 					}`,
 				Results: map[string]any{
-					"commits": []map[string]any{
+					"_commits": []map[string]any{
 						{
 							"cid":    "bafyreiae763hq5srsefplqrehpsuyieuwmbvblgzdma7srss522yciumhu",
 							"height": int64(1),
@@ -274,13 +274,13 @@ func TestQueryCommitsWithDocIDAndOrderAndMultiUpdatesCidAsc(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: `query {
-						 commits(docID: "bae-dfeea2ca-5e6d-5333-85e8-213a80b508f7", order: {height: ASC}) {
+						 _commits(docID: "bae-dfeea2ca-5e6d-5333-85e8-213a80b508f7", order: {height: ASC}) {
 							 cid
 							 height
 						 }
 					 }`,
 				Results: map[string]any{
-					"commits": []map[string]any{
+					"_commits": []map[string]any{
 						{
 							"cid":    "bafyreiae763hq5srsefplqrehpsuyieuwmbvblgzdma7srss522yciumhu",
 							"height": int64(1),

--- a/tests/integration/query/commits/with_doc_id_prop_test.go
+++ b/tests/integration/query/commits/with_doc_id_prop_test.go
@@ -29,12 +29,12 @@ func TestQueryCommitsWithDocIDProperty(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: `query {
-						commits {
+						_commits {
 							docID
 						}
 					}`,
 				Results: map[string]any{
-					"commits": []map[string]any{
+					"_commits": []map[string]any{
 						{
 							"docID": "bae-dfeea2ca-5e6d-5333-85e8-213a80b508f7",
 						},

--- a/tests/integration/query/commits/with_doc_id_test.go
+++ b/tests/integration/query/commits/with_doc_id_test.go
@@ -29,12 +29,12 @@ func TestQueryCommitsWithUnknownDocID(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: `query {
-						commits(docID: "unknown document ID") {
+						_commits(docID: "unknown document ID") {
 							cid
 						}
 					}`,
 				Results: map[string]any{
-					"commits": []map[string]any{},
+					"_commits": []map[string]any{},
 				},
 			},
 		},
@@ -56,12 +56,12 @@ func TestQueryCommitsWithDocID(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: `query {
-						commits(docID: "bae-dfeea2ca-5e6d-5333-85e8-213a80b508f7") {
+						_commits(docID: "bae-dfeea2ca-5e6d-5333-85e8-213a80b508f7") {
 							cid
 						}
 					}`,
 				Results: map[string]any{
-					"commits": []map[string]any{
+					"_commits": []map[string]any{
 						{
 							"cid": "bafyreiae763hq5srsefplqrehpsuyieuwmbvblgzdma7srss522yciumhu",
 						},
@@ -93,7 +93,7 @@ func TestQueryCommitsWithDocIDAndLinks(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: `query {
-						commits(docID: "bae-dfeea2ca-5e6d-5333-85e8-213a80b508f7") {
+						_commits(docID: "bae-dfeea2ca-5e6d-5333-85e8-213a80b508f7") {
 							cid
 							links {
 								cid
@@ -102,7 +102,7 @@ func TestQueryCommitsWithDocIDAndLinks(t *testing.T) {
 						}
 					}`,
 				Results: map[string]any{
-					"commits": []map[string]any{
+					"_commits": []map[string]any{
 						{
 							"cid":   "bafyreiae763hq5srsefplqrehpsuyieuwmbvblgzdma7srss522yciumhu",
 							"links": []map[string]any{},
@@ -153,13 +153,13 @@ func TestQueryCommitsWithDocIDAndUpdate(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: `query {
-						commits(docID: "bae-dfeea2ca-5e6d-5333-85e8-213a80b508f7") {
+						_commits(docID: "bae-dfeea2ca-5e6d-5333-85e8-213a80b508f7") {
 							cid
 							height
 						}
 					}`,
 				Results: map[string]any{
-					"commits": []map[string]any{
+					"_commits": []map[string]any{
 						{
 							"cid":    "bafyreic5mqzoba47yzm5pugx5b35visawxi2al2tq7p7x2b6yayklwomga",
 							"height": int64(2),
@@ -212,7 +212,7 @@ func TestQueryCommitsWithDocIDAndUpdateAndLinks(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: `query {
-						commits(docID: "bae-dfeea2ca-5e6d-5333-85e8-213a80b508f7") {
+						_commits(docID: "bae-dfeea2ca-5e6d-5333-85e8-213a80b508f7") {
 							cid
 							links {
 								cid
@@ -221,7 +221,7 @@ func TestQueryCommitsWithDocIDAndUpdateAndLinks(t *testing.T) {
 						}
 					}`,
 				Results: map[string]any{
-					"commits": []map[string]any{
+					"_commits": []map[string]any{
 						{
 							"cid": "bafyreic5mqzoba47yzm5pugx5b35visawxi2al2tq7p7x2b6yayklwomga",
 							"links": []map[string]any{

--- a/tests/integration/query/commits/with_doc_id_typename_test.go
+++ b/tests/integration/query/commits/with_doc_id_typename_test.go
@@ -29,13 +29,13 @@ func TestQueryCommitsWithDocIDWithTypeName(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: `query {
-						commits(docID: "bae-dfeea2ca-5e6d-5333-85e8-213a80b508f7") {
+						_commits(docID: "bae-dfeea2ca-5e6d-5333-85e8-213a80b508f7") {
 							cid
 							__typename
 						}
 					}`,
 				Results: map[string]any{
-					"commits": []map[string]any{
+					"_commits": []map[string]any{
 						{
 							"cid":        "bafyreiae763hq5srsefplqrehpsuyieuwmbvblgzdma7srss522yciumhu",
 							"__typename": "Commit",

--- a/tests/integration/query/commits/with_field_test.go
+++ b/tests/integration/query/commits/with_field_test.go
@@ -29,12 +29,12 @@ func TestQueryCommitsWithField(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: `query {
-						commits (fieldName: "age") {
+						_commits (fieldName: "age") {
 							cid
 						}
 					}`,
 				Results: map[string]any{
-					"commits": []map[string]any{
+					"_commits": []map[string]any{
 						{
 							"cid": "bafyreiae763hq5srsefplqrehpsuyieuwmbvblgzdma7srss522yciumhu",
 						},
@@ -60,12 +60,12 @@ func TestQueryCommitsWithFieldId(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: `query {
-						commits (fieldName: "1") {
+						_commits (fieldName: "1") {
 							cid
 						}
 					}`,
 				Results: map[string]any{
-					"commits": []map[string]any{},
+					"_commits": []map[string]any{},
 				},
 			},
 		},
@@ -87,12 +87,12 @@ func TestQueryCommitsWithCompositeField(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: `query {
-						commits(fieldName: "_C") {
+						_commits(fieldName: "_C") {
 							cid
 						}
 					}`,
 				Results: map[string]any{
-					"commits": []map[string]any{
+					"_commits": []map[string]any{
 						{
 							"cid": "bafyreidtdklweht7ainl5rrdeqscr3cwr72sr4lehzrpmmnnbvnvstavnm",
 						},
@@ -120,13 +120,13 @@ func TestQueryCommitsWithCompositeFieldIdWithReturnedSchemaVersionID(t *testing.
 			},
 			testUtils.Request{
 				Request: `query {
-						commits(fieldName: "_C") {
+						_commits(fieldName: "_C") {
 							cid
 							schemaVersionId
 						}
 					}`,
 				Results: map[string]any{
-					"commits": []map[string]any{
+					"_commits": []map[string]any{
 						{
 							"cid":             "bafyreidtdklweht7ainl5rrdeqscr3cwr72sr4lehzrpmmnnbvnvstavnm",
 							"schemaVersionId": "bafyreigk2gtae2irmijtkb7z736r3lpssqv7cvmbrp3p6x6ouw7nakc4nm",
@@ -153,12 +153,12 @@ func TestQueryCommitsWithFieldAndCID(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: `query {
-						commits (fieldName: "age", cid: "bafyreiae763hq5srsefplqrehpsuyieuwmbvblgzdma7srss522yciumhu") {
+						_commits (fieldName: "age", cid: "bafyreiae763hq5srsefplqrehpsuyieuwmbvblgzdma7srss522yciumhu") {
 							cid
 						}
 					}`,
 				Results: map[string]any{
-					"commits": []map[string]any{
+					"_commits": []map[string]any{
 						{
 							"cid": "bafyreiae763hq5srsefplqrehpsuyieuwmbvblgzdma7srss522yciumhu",
 						},
@@ -184,12 +184,12 @@ func TestQueryCommits_WithWrongFieldAndCID_ReturnEmptyList(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: `query {
-						commits (fieldName: "name", cid: "bafyreiae763hq5srsefplqrehpsuyieuwmbvblgzdma7srss522yciumhu") {
+						_commits (fieldName: "name", cid: "bafyreiae763hq5srsefplqrehpsuyieuwmbvblgzdma7srss522yciumhu") {
 							cid
 						}
 					}`,
 				Results: map[string]any{
-					"commits": []map[string]any{},
+					"_commits": []map[string]any{},
 				},
 			},
 		},
@@ -211,12 +211,12 @@ func TestQueryCommits_WithInvalidFieldAndCID_ReturnEmptyList(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: `query {
-						commits (fieldName: "NOT_A_FIELD", cid: "bafyreiae763hq5srsefplqrehpsuyieuwmbvblgzdma7srss522yciumhu") {
+						_commits (fieldName: "NOT_A_FIELD", cid: "bafyreiae763hq5srsefplqrehpsuyieuwmbvblgzdma7srss522yciumhu") {
 							cid
 						}
 					}`,
 				Results: map[string]any{
-					"commits": []map[string]any{},
+					"_commits": []map[string]any{},
 				},
 			},
 		},

--- a/tests/integration/query/commits/with_group_test.go
+++ b/tests/integration/query/commits/with_group_test.go
@@ -36,12 +36,12 @@ func TestQueryCommitsWithGroupBy(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: ` {
-						commits(groupBy: [height]) {
+						_commits(groupBy: [height]) {
 							height
 						}
 					}`,
 				Results: map[string]any{
-					"commits": []map[string]any{
+					"_commits": []map[string]any{
 						{
 							"height": int64(2),
 						},
@@ -77,7 +77,7 @@ func TestQueryCommitsWithGroupByHeightWithChild(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: ` {
-						commits(groupBy: [height]) {
+						_commits(groupBy: [height]) {
 							height
 							_group {
 								cid
@@ -85,7 +85,7 @@ func TestQueryCommitsWithGroupByHeightWithChild(t *testing.T) {
 						}
 					}`,
 				Results: map[string]any{
-					"commits": []map[string]any{
+					"_commits": []map[string]any{
 						{
 							"height": int64(2),
 							"_group": []map[string]any{
@@ -134,7 +134,7 @@ func TestQueryCommitsWithGroupByCidWithChild(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: ` {
-						commits(groupBy: [cid]) {
+						_commits(groupBy: [cid]) {
 							cid
 							_group {
 								height
@@ -142,7 +142,7 @@ func TestQueryCommitsWithGroupByCidWithChild(t *testing.T) {
 						}
 					}`,
 				Results: map[string]any{
-					"commits": []map[string]any{
+					"_commits": []map[string]any{
 						{
 							"cid": "bafyreiae763hq5srsefplqrehpsuyieuwmbvblgzdma7srss522yciumhu",
 							"_group": []map[string]any{
@@ -210,12 +210,12 @@ func TestQueryCommitsWithGroupByDocID(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: ` {
-						commits(groupBy: [docID]) {
+						_commits(groupBy: [docID]) {
 							docID
 						}
 					}`,
 				Results: map[string]any{
-					"commits": []map[string]any{
+					"_commits": []map[string]any{
 						{
 							"docID": "bae-2bb3e007-c40c-5264-8656-45e024cc4776",
 						},
@@ -251,12 +251,12 @@ func TestQueryCommitsWithGroupByFieldName(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: ` {
-						commits(groupBy: [fieldName]) {
+						_commits(groupBy: [fieldName]) {
 							fieldName
 						}
 					}`,
 				Results: map[string]any{
-					"commits": []map[string]any{
+					"_commits": []map[string]any{
 						{
 							"fieldName": "age",
 						},
@@ -295,7 +295,7 @@ func TestQueryCommitsWithGroupByFieldNameWithChild(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: ` {
-						commits(groupBy: [fieldName]) {
+						_commits(groupBy: [fieldName]) {
 							fieldName
 							_group {
 								height
@@ -303,7 +303,7 @@ func TestQueryCommitsWithGroupByFieldNameWithChild(t *testing.T) {
 						}
 					}`,
 				Results: map[string]any{
-					"commits": []map[string]any{
+					"_commits": []map[string]any{
 						{
 							"fieldName": "age",
 							"_group": []map[string]any{

--- a/tests/integration/query/commits/with_null_input_test.go
+++ b/tests/integration/query/commits/with_null_input_test.go
@@ -29,12 +29,12 @@ func TestQueryCommitsWithNullDepth(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: `query {
-						commits(depth: null) {
+						_commits(depth: null) {
 							cid
 						}
 					}`,
 				Results: map[string]any{
-					"commits": []map[string]any{
+					"_commits": []map[string]any{
 						{
 							"cid": "bafyreiae763hq5srsefplqrehpsuyieuwmbvblgzdma7srss522yciumhu",
 						},
@@ -66,12 +66,12 @@ func TestQueryCommitsWithNullCID(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: `query {
-						commits(cid: null) {
+						_commits(cid: null) {
 							cid
 						}
 					}`,
 				Results: map[string]any{
-					"commits": []map[string]any{
+					"_commits": []map[string]any{
 						{
 							"cid": "bafyreiae763hq5srsefplqrehpsuyieuwmbvblgzdma7srss522yciumhu",
 						},
@@ -103,12 +103,12 @@ func TestQueryCommitsWithNullField(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: `query {
-						commits(fieldName: null) {
+						_commits(fieldName: null) {
 							cid
 						}
 					}`,
 				Results: map[string]any{
-					"commits": []map[string]any{},
+					"_commits": []map[string]any{},
 				},
 			},
 		},
@@ -130,12 +130,12 @@ func TestQueryCommitsWithNullOrder(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: `query {
-						commits(order: null) {
+						_commits(order: null) {
 							cid
 						}
 					}`,
 				Results: map[string]any{
-					"commits": []map[string]any{
+					"_commits": []map[string]any{
 						{
 							"cid": "bafyreiae763hq5srsefplqrehpsuyieuwmbvblgzdma7srss522yciumhu",
 						},
@@ -167,12 +167,12 @@ func TestQueryCommitsWithNullOrderField(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: `query {
-						commits(docID: null) {
+						_commits(docID: null) {
 							cid
 						}
 					}`,
 				Results: map[string]any{
-					"commits": []map[string]any{
+					"_commits": []map[string]any{
 						{
 							"cid": "bafyreiae763hq5srsefplqrehpsuyieuwmbvblgzdma7srss522yciumhu",
 						},
@@ -204,12 +204,12 @@ func TestQueryCommitsWithNullLimit(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: `query {
-						commits(limit: null) {
+						_commits(limit: null) {
 							cid
 						}
 					}`,
 				Results: map[string]any{
-					"commits": []map[string]any{
+					"_commits": []map[string]any{
 						{
 							"cid": "bafyreiae763hq5srsefplqrehpsuyieuwmbvblgzdma7srss522yciumhu",
 						},
@@ -241,12 +241,12 @@ func TestQueryCommitsWithNullOffset(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: `query {
-						commits(offset: null) {
+						_commits(offset: null) {
 							cid
 						}
 					}`,
 				Results: map[string]any{
-					"commits": []map[string]any{
+					"_commits": []map[string]any{
 						{
 							"cid": "bafyreiae763hq5srsefplqrehpsuyieuwmbvblgzdma7srss522yciumhu",
 						},
@@ -278,12 +278,12 @@ func TestQueryCommitsWithNullGroupBy(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: `query {
-						commits(groupBy: null) {
+						_commits(groupBy: null) {
 							cid
 						}
 					}`,
 				Results: map[string]any{
-					"commits": []map[string]any{
+					"_commits": []map[string]any{
 						{
 							"cid": "bafyreiae763hq5srsefplqrehpsuyieuwmbvblgzdma7srss522yciumhu",
 						},

--- a/tests/integration/query/latest_commits/simple_test.go
+++ b/tests/integration/query/latest_commits/simple_test.go
@@ -29,7 +29,7 @@ func TestQueryLatestCommits(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: `query {
-					latestCommits {
+					_latestCommits {
 						cid
 						links {
 							cid
@@ -37,7 +37,7 @@ func TestQueryLatestCommits(t *testing.T) {
 						}
 					}
 				}`,
-				ExpectedError: "Field \"latestCommits\" argument \"docID\" of type \"ID!\" is required but not provided.",
+				ExpectedError: "Field \"_latestCommits\" argument \"docID\" of type \"ID!\" is required but not provided.",
 			},
 		},
 	}

--- a/tests/integration/query/latest_commits/with_doc_id_field_test.go
+++ b/tests/integration/query/latest_commits/with_doc_id_field_test.go
@@ -29,7 +29,7 @@ func TestQueryLatestCommitsWithDocIDAndFieldName(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: `query {
-					latestCommits(docID: "bae-dfeea2ca-5e6d-5333-85e8-213a80b508f7", fieldName: "age") {
+					_latestCommits(docID: "bae-dfeea2ca-5e6d-5333-85e8-213a80b508f7", fieldName: "age") {
 						cid
 						links {
 							cid
@@ -38,7 +38,7 @@ func TestQueryLatestCommitsWithDocIDAndFieldName(t *testing.T) {
 					}
 				}`,
 				Results: map[string]any{
-					"latestCommits": []map[string]any{
+					"_latestCommits": []map[string]any{
 						{
 							"cid":   "bafyreiae763hq5srsefplqrehpsuyieuwmbvblgzdma7srss522yciumhu",
 							"links": []map[string]any{},
@@ -63,7 +63,7 @@ func TestQueryLatestCommitsWithDocIDAndFieldId(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: `query {
-					latestCommits(docID: "bae-dfeea2ca-5e6d-5333-85e8-213a80b508f7", fieldName: "1") {
+					_latestCommits(docID: "bae-dfeea2ca-5e6d-5333-85e8-213a80b508f7", fieldName: "1") {
 						cid
 						links {
 							cid
@@ -72,7 +72,7 @@ func TestQueryLatestCommitsWithDocIDAndFieldId(t *testing.T) {
 					}
 				}`,
 				Results: map[string]any{
-					"latestCommits": []map[string]any{},
+					"_latestCommits": []map[string]any{},
 				},
 			},
 		},
@@ -94,7 +94,7 @@ func TestQueryLatestCommitsWithDocIDAndCompositeFieldId(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: `query {
-					latestCommits(docID: "bae-dfeea2ca-5e6d-5333-85e8-213a80b508f7", fieldName: "_C") {
+					_latestCommits(docID: "bae-dfeea2ca-5e6d-5333-85e8-213a80b508f7", fieldName: "_C") {
 						cid
 						links {
 							cid
@@ -103,7 +103,7 @@ func TestQueryLatestCommitsWithDocIDAndCompositeFieldId(t *testing.T) {
 					}
 				}`,
 				Results: map[string]any{
-					"latestCommits": []map[string]any{
+					"_latestCommits": []map[string]any{
 						{
 							"cid": "bafyreidtdklweht7ainl5rrdeqscr3cwr72sr4lehzrpmmnnbvnvstavnm",
 							"links": []map[string]any{

--- a/tests/integration/query/latest_commits/with_doc_id_prop_test.go
+++ b/tests/integration/query/latest_commits/with_doc_id_prop_test.go
@@ -28,12 +28,12 @@ func TestQueryLastCommitsWithDocIDProperty(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: `query {
-						latestCommits(docID: "bae-dfeea2ca-5e6d-5333-85e8-213a80b508f7") {
+						_latestCommits(docID: "bae-dfeea2ca-5e6d-5333-85e8-213a80b508f7") {
 							docID
 						}
 					}`,
 				Results: map[string]any{
-					"latestCommits": []map[string]any{
+					"_latestCommits": []map[string]any{
 						{
 							"docID": "bae-dfeea2ca-5e6d-5333-85e8-213a80b508f7",
 						},

--- a/tests/integration/query/latest_commits/with_doc_id_test.go
+++ b/tests/integration/query/latest_commits/with_doc_id_test.go
@@ -27,7 +27,7 @@ func TestQueryLatestCommitsWithDocID(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: `query {
-					latestCommits(docID: "bae-dfeea2ca-5e6d-5333-85e8-213a80b508f7") {
+					_latestCommits(docID: "bae-dfeea2ca-5e6d-5333-85e8-213a80b508f7") {
 						cid
 						links {
 							cid
@@ -36,7 +36,7 @@ func TestQueryLatestCommitsWithDocID(t *testing.T) {
 					}
 				}`,
 				Results: map[string]any{
-					"latestCommits": []map[string]any{
+					"_latestCommits": []map[string]any{
 						{
 							"cid": "bafyreidtdklweht7ainl5rrdeqscr3cwr72sr4lehzrpmmnnbvnvstavnm",
 							"links": []map[string]any{
@@ -70,13 +70,13 @@ func TestQueryLatestCommitsWithDocIDWithSchemaVersionIDField(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: `query {
-					latestCommits(docID: "bae-dfeea2ca-5e6d-5333-85e8-213a80b508f7") {
+					_latestCommits(docID: "bae-dfeea2ca-5e6d-5333-85e8-213a80b508f7") {
 						cid
 						schemaVersionId
 					}
 				}`,
 				Results: map[string]any{
-					"latestCommits": []map[string]any{
+					"_latestCommits": []map[string]any{
 						{
 							"cid":             "bafyreidtdklweht7ainl5rrdeqscr3cwr72sr4lehzrpmmnnbvnvstavnm",
 							"schemaVersionId": "bafyreigk2gtae2irmijtkb7z736r3lpssqv7cvmbrp3p6x6ouw7nakc4nm",
@@ -101,7 +101,7 @@ func TestQueryLatestCommits_WithDocIDAndAliased_Succeeds(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: `query {
-					history: latestCommits(docID: "bae-dfeea2ca-5e6d-5333-85e8-213a80b508f7") {
+					history: _latestCommits(docID: "bae-dfeea2ca-5e6d-5333-85e8-213a80b508f7") {
 						cid
 						links {
 							cid

--- a/tests/integration/query/latest_commits/with_field_test.go
+++ b/tests/integration/query/latest_commits/with_field_test.go
@@ -30,7 +30,7 @@ func TestQueryLatestCommitsWithField(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: `query {
-					latestCommits (fieldName: "Age") {
+					_latestCommits (fieldName: "Age") {
 						cid
 						links {
 							cid
@@ -38,7 +38,7 @@ func TestQueryLatestCommitsWithField(t *testing.T) {
 						}
 					}
 				}`,
-				ExpectedError: "Field \"latestCommits\" argument \"docID\" of type \"ID!\" is required but not provided.",
+				ExpectedError: "Field \"_latestCommits\" argument \"docID\" of type \"ID!\" is required but not provided.",
 			},
 		},
 	}
@@ -60,7 +60,7 @@ func TestQueryLatestCommitsWithFieldId(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: `query {
-					latestCommits (fieldName: "1") {
+					_latestCommits (fieldName: "1") {
 						cid
 						links {
 							cid
@@ -68,7 +68,7 @@ func TestQueryLatestCommitsWithFieldId(t *testing.T) {
 						}
 					}
 				}`,
-				ExpectedError: "Field \"latestCommits\" argument \"docID\" of type \"ID!\" is required but not provided.",
+				ExpectedError: "Field \"_latestCommits\" argument \"docID\" of type \"ID!\" is required but not provided.",
 			},
 		},
 	}

--- a/tests/integration/searchable_encryption/peer_acp_test.go
+++ b/tests/integration/searchable_encryption/peer_acp_test.go
@@ -152,7 +152,7 @@ func TestDocEncryptionPeer_WithACP_ReplicatorShouldNotHaveAccess(t *testing.T) {
 				Identity: testUtils.NodeIdentity(0),
 				Request: `
 					query {
-						commits {
+						_commits {
 							delta
 						}
 					}
@@ -161,7 +161,7 @@ func TestDocEncryptionPeer_WithACP_ReplicatorShouldNotHaveAccess(t *testing.T) {
 				// commit blocks. Once we introduce a dedicated permission for replication,
 				// this should be updated to return the commits with encrypted deltas.
 				Results: map[string]any{
-					"commits": []map[string]any{},
+					"_commits": []map[string]any{},
 				},
 			},
 		},

--- a/tests/integration/signature/branchable_test.go
+++ b/tests/integration/signature/branchable_test.go
@@ -48,7 +48,7 @@ func TestSignature_WithBranchableCollection_ShouldSignCollectionBlocks(t *testin
 			},
 			testUtils.Request{
 				Request: `query {
-						commits {
+						_commits {
 							fieldName
 							signature {
 								type
@@ -58,7 +58,7 @@ func TestSignature_WithBranchableCollection_ShouldSignCollectionBlocks(t *testin
 						}
 					}`,
 				Results: map[string]any{
-					"commits": []map[string]any{
+					"_commits": []map[string]any{
 						{
 							"fieldName": nil,
 							"signature": map[string]any{

--- a/tests/integration/signature/commit_test.go
+++ b/tests/integration/signature/commit_test.go
@@ -76,7 +76,7 @@ func TestSignature_WithCommitQuery_ShouldIncludeSignatureData(t *testing.T) {
 			testUtils.Request{
 				Request: `
 					query {
-						commits {
+						_commits {
 							fieldName
 							signature {
 								type
@@ -87,7 +87,7 @@ func TestSignature_WithCommitQuery_ShouldIncludeSignatureData(t *testing.T) {
 					}
 				`,
 				Results: map[string]any{
-					"commits": []map[string]any{
+					"_commits": []map[string]any{
 						{
 							"fieldName": "age",
 							"signature": map[string]any{
@@ -163,7 +163,7 @@ func TestSignature_WithUpdatedDocsAndCommitQuery_ShouldSignOnlyFirstFieldBlocks(
 			testUtils.Request{
 				Request: `
 					query {
-						commits(order: {height: DESC}) {
+						_commits(order: {height: DESC}) {
 							fieldName
 							height
 							signature {
@@ -175,7 +175,7 @@ func TestSignature_WithUpdatedDocsAndCommitQuery_ShouldSignOnlyFirstFieldBlocks(
 					}
 				`,
 				Results: map[string]any{
-					"commits": []map[string]any{
+					"_commits": []map[string]any{
 						{
 							"fieldName": "name",
 							"height":    3,
@@ -259,7 +259,7 @@ func TestSignature_WithDeletedDocAndCommitQuery_ShouldIncludeSignatureData(t *te
 			testUtils.Request{
 				Request: `
 					query {
-						commits(order: {height: DESC}, fieldName: "_C") {
+						_commits(order: {height: DESC}, fieldName: "_C") {
 							fieldName
 							height
 							signature {
@@ -271,7 +271,7 @@ func TestSignature_WithDeletedDocAndCommitQuery_ShouldIncludeSignatureData(t *te
 					}
 				`,
 				Results: map[string]any{
-					"commits": []map[string]any{
+					"_commits": []map[string]any{
 						{
 							"fieldName": "_C",
 							"height":    2,
@@ -329,7 +329,7 @@ func TestSignature_WithEd25519KeyType_ShouldIncludeSignatureData(t *testing.T) {
 			testUtils.Request{
 				Request: `
 					query {
-						commits {
+						_commits {
 							fieldName
 							signature {
 								type
@@ -340,7 +340,7 @@ func TestSignature_WithEd25519KeyType_ShouldIncludeSignatureData(t *testing.T) {
 					}
 				`,
 				Results: map[string]any{
-					"commits": []map[string]any{
+					"_commits": []map[string]any{
 						{
 							"fieldName": "age",
 							"signature": map[string]any{
@@ -413,7 +413,7 @@ func TestSignature_WithClientIdentity_ShouldUseItForSigning(t *testing.T) {
 			testUtils.Request{
 				Request: `
 					query {
-						commits(fieldName: "_C", order: {height: DESC}) {
+						_commits(fieldName: "_C", order: {height: DESC}) {
 							height
 							signature {
 								type
@@ -423,7 +423,7 @@ func TestSignature_WithClientIdentity_ShouldUseItForSigning(t *testing.T) {
 					}
 				`,
 				Results: map[string]any{
-					"commits": []map[string]any{
+					"_commits": []map[string]any{
 						{
 							"height": 3,
 							"signature": map[string]any{

--- a/tests/integration/signature/peer_test.go
+++ b/tests/integration/signature/peer_test.go
@@ -204,7 +204,7 @@ func TestDocSignature_WithPeersAnDifferentKeyTypes_ShouldSync(t *testing.T) {
 			},
 			testUtils.Request{
 				Request: `query {
-						commits(fieldName: "_C") {
+						_commits(fieldName: "_C") {
 							signature {
 								type
 								identity
@@ -212,7 +212,7 @@ func TestDocSignature_WithPeersAnDifferentKeyTypes_ShouldSync(t *testing.T) {
 						}
 					}`,
 				Results: map[string]any{
-					"commits": []map[string]any{
+					"_commits": []map[string]any{
 						{
 							"signature": map[string]any{
 								"type":     coreblock.SignatureTypeEd25519,
@@ -308,7 +308,7 @@ func TestDocSignature_WithPeersAnDifferentKeyTypesUpdatingSameDoc_ShouldSync(t *
 			},
 			testUtils.Request{
 				Request: `query {
-						commits(fieldName: "_C", order: {height: DESC}) {
+						_commits(fieldName: "_C", order: {height: DESC}) {
 							signature {
 								type
 								identity
@@ -316,7 +316,7 @@ func TestDocSignature_WithPeersAnDifferentKeyTypesUpdatingSameDoc_ShouldSync(t *
 						}
 					}`,
 				Results: map[string]any{
-					"commits": []map[string]any{
+					"_commits": []map[string]any{
 						{
 							"signature": map[string]any{
 								"type":     coreblock.SignatureTypeECDSA256K,

--- a/tests/integration/subscription/with_commit_test.go
+++ b/tests/integration/subscription/with_commit_test.go
@@ -21,20 +21,20 @@ func TestCommitSubscription_WithCreateMutations_ReturnCommits(t *testing.T) {
 		Actions: []any{
 			testUtils.SubscriptionRequest{
 				Request: `subscription {
-					commits {
+					_commits {
 						cid
 					}
 				}`,
 				Results: []map[string]any{
 					{
-						"commits": []map[string]any{
+						"_commits": []map[string]any{
 							{
 								"cid": "bafyreigpqtbobuikkvne7wkszl6xqgatsvhhzmwjh4uunpf5xldnjouu4a",
 							},
 						},
 					},
 					{
-						"commits": []map[string]any{
+						"_commits": []map[string]any{
 							{
 								"cid": "bafyreihsducixg7n6wdbqoyjao4pecsalt4zjx2ybyncizqhq2ci46gyoa",
 							},
@@ -74,7 +74,7 @@ func TestCommitSubscription_WithCommitLinksCreateMutations_ValidLinks(t *testing
 		Actions: []any{
 			testUtils.SubscriptionRequest{
 				Request: `subscription {
-					commits {
+					_commits {
 						cid
 						links {
 							cid
@@ -84,7 +84,7 @@ func TestCommitSubscription_WithCommitLinksCreateMutations_ValidLinks(t *testing
 				}`,
 				Results: []map[string]any{
 					{
-						"commits": []map[string]any{
+						"_commits": []map[string]any{
 							{
 								"cid":   "bafyreigpqtbobuikkvne7wkszl6xqgatsvhhzmwjh4uunpf5xldnjouu4a",
 								"links": create1Links,
@@ -92,7 +92,7 @@ func TestCommitSubscription_WithCommitLinksCreateMutations_ValidLinks(t *testing
 						},
 					},
 					{
-						"commits": []map[string]any{
+						"_commits": []map[string]any{
 							{
 								"cid":   "bafyreihsducixg7n6wdbqoyjao4pecsalt4zjx2ybyncizqhq2ci46gyoa",
 								"links": create2Links,
@@ -172,14 +172,14 @@ func TestCommitSubscription_WithDocFilterAndMultipleMutations_FilteredDoc(t *tes
 			},
 			testUtils.SubscriptionRequest{
 				Request: `subscription {
-					commits(docID: "bae-029c4d47-4790-5cd4-9c41-fd5991d88915") {
+					_commits(docID: "bae-029c4d47-4790-5cd4-9c41-fd5991d88915") {
 						cid		
 						docID
 					}
 				}`,
 				Results: []map[string]any{
 					{
-						"commits": []map[string]any{
+						"_commits": []map[string]any{
 							{
 								"cid":   updateCid,
 								"docID": docID,

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -1037,7 +1037,7 @@ func refreshDocuments(
 				// they can be referenced later in the test if required.
 				result := s.Nodes[firstNodesID].Client.ExecRequest(s.Ctx, `query ($docID: ID!) {
 					_commits(docID: $docID, fieldName: "_C", order: {height: ASC}) {
-						_cid
+						cid
 					}
 				}`, client.WithVariables(map[string]any{
 					"docID": doc.ID().String(),

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -1036,16 +1036,16 @@ func refreshDocuments(
 				// We fetch the list of composite commits for the document so that
 				// they can be referenced later in the test if required.
 				result := s.Nodes[firstNodesID].Client.ExecRequest(s.Ctx, `query ($docID: ID!) {
-					commits(docID: $docID, fieldName: "_C", order: {height: ASC}) {
-						cid
+					_commits(docID: $docID, fieldName: "_C", order: {height: ASC}) {
+						_cid
 					}
 				}`, client.WithVariables(map[string]any{
 					"docID": doc.ID().String(),
 				}))
 				if data, ok := result.GQL.Data.(map[string]any); ok {
-					if commits, ok := data["commits"].([]map[string]any); ok {
+					if commits, ok := data["_commits"].([]map[string]any); ok {
 						for _, commit := range commits {
-							cid := cid.MustParse(commit["cid"].(string))
+							cid := cid.MustParse(commit[request.CidFieldName].(string))
 							s.Nodes[firstNodesID].Composites[doc.ID().String()] = append(
 								s.Nodes[firstNodesID].Composites[doc.ID().String()],
 								cid,


### PR DESCRIPTION
## Relevant issue(s)

Resolves #2162

## Description

This PR makes sure there is consistent naming of gql fields: all top-level system fields have underscore prefixed.
All nested fields of system fields don't have underscore.
The following top-level fields are renamed:
`commits` -> `_commits`
`latestCommits` -> `_latestCommits`