### PR TITLE
feat: Include query source in collection block

### DIFF
--- a/internal/core/crdt/collection_definition.go
+++ b/internal/core/crdt/collection_definition.go
@@ -95,11 +95,7 @@ func (c *CollectionDefinition) Delta(
 			if !bytes.Equal(newQuery, oldQuery) {
 				queryDelta = newQuery
 			}
-		} else {
-			queryDelta = newQuery
 		}
-	} else if old.Query.HasValue() {
-		queryDelta = []byte{}
 	}
 
 	var transformDelta *string

--- a/internal/core/crdt/collection_definition.go
+++ b/internal/core/crdt/collection_definition.go
@@ -24,7 +24,7 @@ type CollectionDefinitionDelta struct {
 	Priority uint64
 
 	Name           string
-	QuerySelect    *[]byte
+	QuerySelect    []byte
 	QueryTransform *string
 }
 
@@ -78,7 +78,7 @@ func (c *CollectionDefinition) Delta(
 		return &CollectionDefinitionDelta{}, false, nil
 	}
 
-	var queryDelta *[]byte
+	var queryDelta []byte
 	if new.Query.HasValue() {
 		newQuery, err := cbor.Marshal(new.Query.Value().Query)
 		if err != nil {
@@ -92,13 +92,13 @@ func (c *CollectionDefinition) Delta(
 			}
 
 			if !bytes.Equal(newQuery, oldQuery) {
-				queryDelta = &newQuery
+				queryDelta = newQuery
 			}
 		} else {
-			queryDelta = &newQuery
+			queryDelta = newQuery
 		}
 	} else if old.Query.HasValue() {
-		queryDelta = &[]byte{}
+		queryDelta = []byte{}
 	}
 
 	var transformDelta *string

--- a/internal/core/crdt/collection_definition.go
+++ b/internal/core/crdt/collection_definition.go
@@ -11,7 +11,10 @@
 package crdt
 
 import (
+	"bytes"
 	"context"
+
+	"github.com/fxamacker/cbor/v2"
 
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/internal/keys"
@@ -20,7 +23,9 @@ import (
 type CollectionDefinitionDelta struct {
 	Priority uint64
 
-	Name string
+	Name           string
+	QuerySelect    *[]byte
+	QueryTransform *string
 }
 
 var _ Delta = (*CollectionDefinitionDelta)(nil)
@@ -30,6 +35,8 @@ func (d *CollectionDefinitionDelta) IPLDSchemaBytes() []byte {
 	type CollectionDefinitionDelta struct {
 		priority  		Int
 		name String
+		querySelect optional Bytes
+		queryTransform optional String
 	}`)
 }
 
@@ -66,14 +73,55 @@ func (c *CollectionDefinition) HeadstorePrefix() keys.HeadstoreKey {
 func (c *CollectionDefinition) Delta(
 	new client.CollectionVersion,
 	old client.CollectionVersion,
-) (*CollectionDefinitionDelta, bool) {
+) (*CollectionDefinitionDelta, bool, error) {
 	if new.Name == old.Name {
-		return &CollectionDefinitionDelta{}, false
+		return &CollectionDefinitionDelta{}, false, nil
+	}
+
+	var queryDelta *[]byte
+	if new.Query.HasValue() {
+		newQuery, err := cbor.Marshal(new.Query.Value().Query)
+		if err != nil {
+			return &CollectionDefinitionDelta{}, false, err
+		}
+
+		if old.Query.HasValue() {
+			oldQuery, err := cbor.Marshal(old.Query.Value().Query)
+			if err != nil {
+				return &CollectionDefinitionDelta{}, false, err
+			}
+
+			if !bytes.Equal(newQuery, oldQuery) {
+				queryDelta = &newQuery
+			}
+		} else {
+			queryDelta = &newQuery
+		}
+	} else if old.Query.HasValue() {
+		queryDelta = &[]byte{}
+	}
+
+	var transformDelta *string
+	if new.Query.HasValue() && new.Query.Value().Transform.HasValue() {
+		newLensID := new.Query.Value().Transform.Value()
+
+		if old.Query.HasValue() && old.Query.Value().Transform.HasValue() {
+			if new.Query.Value().Transform.Value() != old.Query.Value().Transform.Value() {
+				transformDelta = &newLensID
+			}
+		} else {
+			transformDelta = &newLensID
+		}
+	} else if old.Query.HasValue() && old.Query.Value().Transform.HasValue() {
+		newLensID := ""
+		transformDelta = &newLensID
 	}
 
 	return &CollectionDefinitionDelta{
-		Name: new.Name,
-	}, true
+		Name:           new.Name,
+		QuerySelect:    queryDelta,
+		QueryTransform: transformDelta,
+	}, true, nil
 }
 
 func (c *CollectionDefinition) Merge(ctx context.Context, other Delta) error {

--- a/internal/core/crdt/collection_definition.go
+++ b/internal/core/crdt/collection_definition.go
@@ -23,7 +23,7 @@ import (
 type CollectionDefinitionDelta struct {
 	Priority uint64
 
-	Name           string
+	Name           *string
 	QuerySelect    []byte
 	QueryTransform *string
 }
@@ -34,7 +34,7 @@ func (d *CollectionDefinitionDelta) IPLDSchemaBytes() []byte {
 	return []byte(`
 	type CollectionDefinitionDelta struct {
 		priority  		Int
-		name String
+		name optional String
 		querySelect optional Bytes
 		queryTransform optional String
 	}`)
@@ -74,8 +74,9 @@ func (c *CollectionDefinition) Delta(
 	new client.CollectionVersion,
 	old client.CollectionVersion,
 ) (*CollectionDefinitionDelta, bool, error) {
-	if new.Name == old.Name {
-		return &CollectionDefinitionDelta{}, false, nil
+	var name *string
+	if new.Name != old.Name {
+		name = &new.Name
 	}
 
 	var queryDelta []byte
@@ -117,8 +118,12 @@ func (c *CollectionDefinition) Delta(
 		transformDelta = &newLensID
 	}
 
+	if name == nil && queryDelta == nil && transformDelta == nil {
+		return &CollectionDefinitionDelta{}, false, nil
+	}
+
 	return &CollectionDefinitionDelta{
-		Name:           new.Name,
+		Name:           name,
 		QuerySelect:    queryDelta,
 		QueryTransform: transformDelta,
 	}, true, nil

--- a/internal/db/collection_id.go
+++ b/internal/db/collection_id.go
@@ -459,7 +459,10 @@ func saveBlocks(
 		}
 
 		colCRDT := crdt.NewCollectionDefinition(collection.Name)
-		delta, hasCollectionChanged := colCRDT.Delta(*collection, oldCol)
+		delta, hasCollectionChanged, err := colCRDT.Delta(*collection, oldCol)
+		if err != nil {
+			return err
+		}
 
 		if !hasFieldsChanged && !hasCollectionChanged {
 			// If the global collection state has not changed, there is nothing to do here and we

--- a/internal/db/definition_validation.go
+++ b/internal/db/definition_validation.go
@@ -424,7 +424,7 @@ func validateSourcesNotRedefined(
 ) error {
 	var errs []error
 	for _, newCol := range newState.collections {
-		oldCol, ok := oldState.collectionsByID[newCol.VersionID]
+		oldCol, ok := oldState.activeCollectionsByName[newCol.Name]
 		if !ok {
 			continue
 		}
@@ -432,15 +432,17 @@ func validateSourcesNotRedefined(
 			continue
 		}
 
-		if newCol.PreviousVersion.HasValue() != oldCol.PreviousVersion.HasValue() {
-			errs = append(errs, NewErrCollectionSourcesCannotBeAddedRemoved(newCol.VersionID))
-		} else if newCol.PreviousVersion.HasValue() &&
-			newCol.PreviousVersion.Value().SourceCollectionID != oldCol.PreviousVersion.Value().SourceCollectionID {
-			errs = append(errs, NewErrCollectionSourceIDMutated(
-				newCol.VersionID,
-				newCol.PreviousVersion.Value().SourceCollectionID,
-				oldCol.PreviousVersion.Value().SourceCollectionID,
-			))
+		if newCol.VersionID == oldCol.VersionID {
+			if newCol.PreviousVersion.HasValue() != oldCol.PreviousVersion.HasValue() {
+				errs = append(errs, NewErrCollectionSourcesCannotBeAddedRemoved(newCol.VersionID))
+			} else if newCol.PreviousVersion.HasValue() &&
+				newCol.PreviousVersion.Value().SourceCollectionID != oldCol.PreviousVersion.Value().SourceCollectionID {
+				errs = append(errs, NewErrCollectionSourceIDMutated(
+					newCol.VersionID,
+					newCol.PreviousVersion.Value().SourceCollectionID,
+					oldCol.PreviousVersion.Value().SourceCollectionID,
+				))
+			}
 		}
 
 		if newCol.Query.HasValue() != oldCol.Query.HasValue() {

--- a/tests/integration/collection_version/get_schema_test.go
+++ b/tests/integration/collection_version/get_schema_test.go
@@ -104,26 +104,6 @@ func TestGetSchema_ReturnsAllSchema(t *testing.T) {
 				},
 				ExpectedResults: []client.CollectionVersion{
 					{
-						Name:           "Users",
-						IsActive:       false,
-						IsMaterialized: true,
-						PreviousVersion: immutable.Some(client.CollectionSource{
-							SourceCollectionID: "bafyreihdbjfazsx5vq2tpzedqdktrjyn6lq22qle7el2s42b3q4zpxmwqq",
-						}),
-						Fields: []client.CollectionFieldDescription{
-							{
-								Name: "_docID",
-								Kind: client.FieldKind_DocID,
-								Typ:  client.NONE_CRDT,
-							},
-							{
-								Name: "name",
-								Kind: client.FieldKind_NILLABLE_STRING,
-								Typ:  client.LWW_REGISTER,
-							},
-						},
-					},
-					{
 						Name:           "Books",
 						IsActive:       true,
 						IsMaterialized: true,
@@ -145,6 +125,26 @@ func TestGetSchema_ReturnsAllSchema(t *testing.T) {
 							},
 						},
 					},
+					{
+						Name:           "Users",
+						IsActive:       false,
+						IsMaterialized: true,
+						PreviousVersion: immutable.Some(client.CollectionSource{
+							SourceCollectionID: "bafyreihdbjfazsx5vq2tpzedqdktrjyn6lq22qle7el2s42b3q4zpxmwqq",
+						}),
+						Fields: []client.CollectionFieldDescription{
+							{
+								Name: "_docID",
+								Kind: client.FieldKind_DocID,
+								Typ:  client.NONE_CRDT,
+							},
+							{
+								Name: "name",
+								Kind: client.FieldKind_NILLABLE_STRING,
+								Typ:  client.LWW_REGISTER,
+							},
+						},
+					},
 				},
 			},
 		},
@@ -155,7 +155,7 @@ func TestGetSchema_ReturnsAllSchema(t *testing.T) {
 
 func TestGetSchema_ReturnsSchemaForGivenRoot(t *testing.T) {
 	usersSchemaVersion1ID := "bafyreihdbjfazsx5vq2tpzedqdktrjyn6lq22qle7el2s42b3q4zpxmwqq"
-	usersSchemaVersion2ID := "bafyreidfzu2x6i4akqlmt5lloaeflwep4ykq2f4unwm2utkmrkgpfyf7bi"
+	usersSchemaVersion2ID := "bafyreihkqi5vwtq7wh66mgjw7biyhrf7ilwzsulzfhrvmzvfppnqmpt5ne"
 
 	test := testUtils.TestCase{
 		Actions: []any{
@@ -255,6 +255,17 @@ func TestGetSchema_ReturnsSchemaForGivenName(t *testing.T) {
 				ExpectedResults: []client.CollectionVersion{
 					{
 						Name:           "Users",
+						IsActive:       true,
+						IsMaterialized: true,
+						Fields: []client.CollectionFieldDescription{
+							{
+								Name: "_docID",
+								Kind: client.FieldKind_DocID,
+							},
+						},
+					},
+					{
+						Name:           "Users",
 						IsActive:       false,
 						IsMaterialized: true,
 						PreviousVersion: immutable.Some(client.CollectionSource{
@@ -270,17 +281,6 @@ func TestGetSchema_ReturnsSchemaForGivenName(t *testing.T) {
 								Name: "name",
 								Kind: client.FieldKind_NILLABLE_STRING,
 								Typ:  client.LWW_REGISTER,
-							},
-						},
-					},
-					{
-						Name:           "Users",
-						IsActive:       true,
-						IsMaterialized: true,
-						Fields: []client.CollectionFieldDescription{
-							{
-								Name: "_docID",
-								Kind: client.FieldKind_DocID,
 							},
 						},
 					},

--- a/tests/integration/collection_version/migrations/query/simple_test.go
+++ b/tests/integration/collection_version/migrations/query/simple_test.go
@@ -46,7 +46,7 @@ func TestSchemaMigrationQuery(t *testing.T) {
 			testUtils.ConfigureMigration{
 				LensConfig: client.LensConfig{
 					SourceSchemaVersionID:      "bafyreigsld6ten2pppcu2tgkbexqwdndckp6zt2vfjhuuheykqkgpmwk7i",
-					DestinationSchemaVersionID: "bafyreig2nfxuzl3cob7txuvybcct6mmsylt57oirzsrehffkho6bdxlvwy",
+					DestinationSchemaVersionID: "bafyreiav7tu2ugw7ksj7fpebd2y4onpt2w2pzg7j6aiwblo7rx56qeuovq",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{
@@ -117,7 +117,7 @@ func TestSchemaMigrationQueryMultipleDocs(t *testing.T) {
 			testUtils.ConfigureMigration{
 				LensConfig: client.LensConfig{
 					SourceSchemaVersionID:      "bafyreigsld6ten2pppcu2tgkbexqwdndckp6zt2vfjhuuheykqkgpmwk7i",
-					DestinationSchemaVersionID: "bafyreig2nfxuzl3cob7txuvybcct6mmsylt57oirzsrehffkho6bdxlvwy",
+					DestinationSchemaVersionID: "bafyreiav7tu2ugw7ksj7fpebd2y4onpt2w2pzg7j6aiwblo7rx56qeuovq",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{
@@ -181,7 +181,7 @@ func TestSchemaMigrationQueryWithMigrationRegisteredBeforePatchCollection(t *tes
 			testUtils.ConfigureMigration{
 				LensConfig: client.LensConfig{
 					SourceSchemaVersionID:      "bafyreigsld6ten2pppcu2tgkbexqwdndckp6zt2vfjhuuheykqkgpmwk7i",
-					DestinationSchemaVersionID: "bafyreig2nfxuzl3cob7txuvybcct6mmsylt57oirzsrehffkho6bdxlvwy",
+					DestinationSchemaVersionID: "bafyreiav7tu2ugw7ksj7fpebd2y4onpt2w2pzg7j6aiwblo7rx56qeuovq",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{
@@ -258,7 +258,7 @@ func TestSchemaMigrationQueryMigratesToIntermediaryVersion(t *testing.T) {
 				// there should be no migration from version 2 to version 3.
 				LensConfig: client.LensConfig{
 					SourceSchemaVersionID:      "bafyreigsld6ten2pppcu2tgkbexqwdndckp6zt2vfjhuuheykqkgpmwk7i",
-					DestinationSchemaVersionID: "bafyreig2nfxuzl3cob7txuvybcct6mmsylt57oirzsrehffkho6bdxlvwy",
+					DestinationSchemaVersionID: "bafyreiav7tu2ugw7ksj7fpebd2y4onpt2w2pzg7j6aiwblo7rx56qeuovq",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{
@@ -329,8 +329,8 @@ func TestSchemaMigrationQueryMigratesFromIntermediaryVersion(t *testing.T) {
 				// Register a migration from schema version 2 to schema version 3 **only** -
 				// there should be no migration from version 1 to version 2.
 				LensConfig: client.LensConfig{
-					SourceSchemaVersionID:      "bafyreig2nfxuzl3cob7txuvybcct6mmsylt57oirzsrehffkho6bdxlvwy",
-					DestinationSchemaVersionID: "bafyreiccm7djewbzmay7yzincqcy5aggh33k74yh6mhm4gwbzxojxeqkve",
+					SourceSchemaVersionID:      "bafyreiav7tu2ugw7ksj7fpebd2y4onpt2w2pzg7j6aiwblo7rx56qeuovq",
+					DestinationSchemaVersionID: "bafyreid5g3tyf75aaddkgnl2yyq77lvdrx4yeascza6tk7vuqgfxqs2poy",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{
@@ -400,7 +400,7 @@ func TestSchemaMigrationQueryMigratesAcrossMultipleVersions(t *testing.T) {
 			testUtils.ConfigureMigration{
 				LensConfig: client.LensConfig{
 					SourceSchemaVersionID:      "bafyreigsld6ten2pppcu2tgkbexqwdndckp6zt2vfjhuuheykqkgpmwk7i",
-					DestinationSchemaVersionID: "bafyreig2nfxuzl3cob7txuvybcct6mmsylt57oirzsrehffkho6bdxlvwy",
+					DestinationSchemaVersionID: "bafyreiav7tu2ugw7ksj7fpebd2y4onpt2w2pzg7j6aiwblo7rx56qeuovq",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{
@@ -416,8 +416,8 @@ func TestSchemaMigrationQueryMigratesAcrossMultipleVersions(t *testing.T) {
 			},
 			testUtils.ConfigureMigration{
 				LensConfig: client.LensConfig{
-					SourceSchemaVersionID:      "bafyreig2nfxuzl3cob7txuvybcct6mmsylt57oirzsrehffkho6bdxlvwy",
-					DestinationSchemaVersionID: "bafyreiccm7djewbzmay7yzincqcy5aggh33k74yh6mhm4gwbzxojxeqkve",
+					SourceSchemaVersionID:      "bafyreiav7tu2ugw7ksj7fpebd2y4onpt2w2pzg7j6aiwblo7rx56qeuovq",
+					DestinationSchemaVersionID: "bafyreid5g3tyf75aaddkgnl2yyq77lvdrx4yeascza6tk7vuqgfxqs2poy",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{
@@ -473,7 +473,7 @@ func TestSchemaMigrationQueryMigratesAcrossMultipleVersionsBeforePatches(t *test
 			testUtils.ConfigureMigration{
 				LensConfig: client.LensConfig{
 					SourceSchemaVersionID:      "bafyreigsld6ten2pppcu2tgkbexqwdndckp6zt2vfjhuuheykqkgpmwk7i",
-					DestinationSchemaVersionID: "bafyreig2nfxuzl3cob7txuvybcct6mmsylt57oirzsrehffkho6bdxlvwy",
+					DestinationSchemaVersionID: "bafyreiav7tu2ugw7ksj7fpebd2y4onpt2w2pzg7j6aiwblo7rx56qeuovq",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{
@@ -489,8 +489,8 @@ func TestSchemaMigrationQueryMigratesAcrossMultipleVersionsBeforePatches(t *test
 			},
 			testUtils.ConfigureMigration{
 				LensConfig: client.LensConfig{
-					SourceSchemaVersionID:      "bafyreig2nfxuzl3cob7txuvybcct6mmsylt57oirzsrehffkho6bdxlvwy",
-					DestinationSchemaVersionID: "bafyreiccm7djewbzmay7yzincqcy5aggh33k74yh6mhm4gwbzxojxeqkve",
+					SourceSchemaVersionID:      "bafyreiav7tu2ugw7ksj7fpebd2y4onpt2w2pzg7j6aiwblo7rx56qeuovq",
+					DestinationSchemaVersionID: "bafyreid5g3tyf75aaddkgnl2yyq77lvdrx4yeascza6tk7vuqgfxqs2poy",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{
@@ -560,8 +560,8 @@ func TestSchemaMigrationQueryMigratesAcrossMultipleVersionsBeforePatchesWrongOrd
 			testUtils.ConfigureMigration{
 				// Declare the migration from v2=>v3 before declaring the migration from v1=>v2
 				LensConfig: client.LensConfig{
-					SourceSchemaVersionID:      "bafyreig2nfxuzl3cob7txuvybcct6mmsylt57oirzsrehffkho6bdxlvwy",
-					DestinationSchemaVersionID: "bafyreiccm7djewbzmay7yzincqcy5aggh33k74yh6mhm4gwbzxojxeqkve",
+					SourceSchemaVersionID:      "bafyreiav7tu2ugw7ksj7fpebd2y4onpt2w2pzg7j6aiwblo7rx56qeuovq",
+					DestinationSchemaVersionID: "bafyreid5g3tyf75aaddkgnl2yyq77lvdrx4yeascza6tk7vuqgfxqs2poy",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{
@@ -578,7 +578,7 @@ func TestSchemaMigrationQueryMigratesAcrossMultipleVersionsBeforePatchesWrongOrd
 			testUtils.ConfigureMigration{
 				LensConfig: client.LensConfig{
 					SourceSchemaVersionID:      "bafyreigsld6ten2pppcu2tgkbexqwdndckp6zt2vfjhuuheykqkgpmwk7i",
-					DestinationSchemaVersionID: "bafyreig2nfxuzl3cob7txuvybcct6mmsylt57oirzsrehffkho6bdxlvwy",
+					DestinationSchemaVersionID: "bafyreiav7tu2ugw7ksj7fpebd2y4onpt2w2pzg7j6aiwblo7rx56qeuovq",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{
@@ -722,7 +722,7 @@ func TestSchemaMigrationQueryMigrationMutatesExistingScalarField(t *testing.T) {
 			testUtils.ConfigureMigration{
 				LensConfig: client.LensConfig{
 					SourceSchemaVersionID:      "bafyreigsld6ten2pppcu2tgkbexqwdndckp6zt2vfjhuuheykqkgpmwk7i",
-					DestinationSchemaVersionID: "bafyreig2nfxuzl3cob7txuvybcct6mmsylt57oirzsrehffkho6bdxlvwy",
+					DestinationSchemaVersionID: "bafyreiav7tu2ugw7ksj7fpebd2y4onpt2w2pzg7j6aiwblo7rx56qeuovq",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{
@@ -784,7 +784,7 @@ func TestSchemaMigrationQueryMigrationMutatesExistingInlineArrayField(t *testing
 			testUtils.ConfigureMigration{
 				LensConfig: client.LensConfig{
 					SourceSchemaVersionID:      "bafyreigpjfwigs367x4whcna37qsad4undunew4dkxt3himzlspqlkigo4",
-					DestinationSchemaVersionID: "bafyreid62abbjl4ykrzibdoh2ba4kba3nnrvfgnclla4xbaicd3xvujjr4",
+					DestinationSchemaVersionID: "bafyreihgrzenxplrrqu56uax6itvexyvb34ezjobv7maecar55dbvmf2aa",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{
@@ -848,7 +848,7 @@ func TestSchemaMigrationQueryMigrationRemovesExistingField(t *testing.T) {
 			testUtils.ConfigureMigration{
 				LensConfig: client.LensConfig{
 					SourceSchemaVersionID:      "bafyreifnbhwntycylk2l6n4khiocdt3vks46tizjdaz6yx4tsmdjtdtlma",
-					DestinationSchemaVersionID: "bafyreicaau76vo3av2oi6gioxpkglmsozf7g44fbahsfabq7agqzj5wzdm",
+					DestinationSchemaVersionID: "bafyreie5r5foyxwnktx3gxjfwcuex7eethexpqjn2tylrz4znen4qmksza",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{
@@ -910,7 +910,7 @@ func TestSchemaMigrationQueryMigrationPreservesExistingFieldWhenFieldNotRequeste
 			testUtils.ConfigureMigration{
 				LensConfig: client.LensConfig{
 					SourceSchemaVersionID:      "bafyreifnbhwntycylk2l6n4khiocdt3vks46tizjdaz6yx4tsmdjtdtlma",
-					DestinationSchemaVersionID: "bafyreicaau76vo3av2oi6gioxpkglmsozf7g44fbahsfabq7agqzj5wzdm",
+					DestinationSchemaVersionID: "bafyreie5r5foyxwnktx3gxjfwcuex7eethexpqjn2tylrz4znen4qmksza",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{
@@ -987,7 +987,7 @@ func TestSchemaMigrationQueryMigrationCopiesExistingFieldWhenSrcFieldNotRequeste
 			testUtils.ConfigureMigration{
 				LensConfig: client.LensConfig{
 					SourceSchemaVersionID:      "bafyreifnbhwntycylk2l6n4khiocdt3vks46tizjdaz6yx4tsmdjtdtlma",
-					DestinationSchemaVersionID: "bafyreigftwdgktzs2dytrukiu3w4bmim3hsjlrb4j356fcal6u7ez3jkdq",
+					DestinationSchemaVersionID: "bafyreih5adzei6bhzn2wykwsbxs4obecfffrzi3fjgx7y5cn5clkfosx2u",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{
@@ -1050,7 +1050,7 @@ func TestSchemaMigrationQueryMigrationCopiesExistingFieldWhenSrcAndDstFieldNotRe
 			testUtils.ConfigureMigration{
 				LensConfig: client.LensConfig{
 					SourceSchemaVersionID:      "bafyreifnbhwntycylk2l6n4khiocdt3vks46tizjdaz6yx4tsmdjtdtlma",
-					DestinationSchemaVersionID: "bafyreigftwdgktzs2dytrukiu3w4bmim3hsjlrb4j356fcal6u7ez3jkdq",
+					DestinationSchemaVersionID: "bafyreih5adzei6bhzn2wykwsbxs4obecfffrzi3fjgx7y5cn5clkfosx2u",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{

--- a/tests/integration/collection_version/migrations/query/with_doc_id_test.go
+++ b/tests/integration/collection_version/migrations/query/with_doc_id_test.go
@@ -53,7 +53,7 @@ func TestSchemaMigrationQueryByDocID(t *testing.T) {
 			testUtils.ConfigureMigration{
 				LensConfig: client.LensConfig{
 					SourceSchemaVersionID:      "bafyreigsld6ten2pppcu2tgkbexqwdndckp6zt2vfjhuuheykqkgpmwk7i",
-					DestinationSchemaVersionID: "bafyreig2nfxuzl3cob7txuvybcct6mmsylt57oirzsrehffkho6bdxlvwy",
+					DestinationSchemaVersionID: "bafyreiav7tu2ugw7ksj7fpebd2y4onpt2w2pzg7j6aiwblo7rx56qeuovq",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{
@@ -160,7 +160,7 @@ func TestSchemaMigrationQueryMultipleQueriesByDocID(t *testing.T) {
 			testUtils.ConfigureMigration{
 				LensConfig: client.LensConfig{
 					SourceSchemaVersionID:      "bafyreigsld6ten2pppcu2tgkbexqwdndckp6zt2vfjhuuheykqkgpmwk7i",
-					DestinationSchemaVersionID: "bafyreig2nfxuzl3cob7txuvybcct6mmsylt57oirzsrehffkho6bdxlvwy",
+					DestinationSchemaVersionID: "bafyreiav7tu2ugw7ksj7fpebd2y4onpt2w2pzg7j6aiwblo7rx56qeuovq",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{

--- a/tests/integration/collection_version/migrations/query/with_inverse_test.go
+++ b/tests/integration/collection_version/migrations/query/with_inverse_test.go
@@ -50,7 +50,7 @@ func TestSchemaMigrationQueryInversesAcrossMultipleVersions(t *testing.T) {
 			testUtils.ConfigureMigration{
 				LensConfig: client.LensConfig{
 					SourceSchemaVersionID:      "bafyreih7useaapqn4pf6k5rxb2oufmsjb3e7xnccmbjr2njva3bgpdwyzu",
-					DestinationSchemaVersionID: "bafyreih5sk2gsbddpvkil76x5sgbdgx6gmglhycpyvgli3szatqnfmxaka",
+					DestinationSchemaVersionID: "bafyreidaalpcihwrmovhq6plgvqsmxjkzzxs6eakwakfj342esc2y54bbq",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{
@@ -66,8 +66,8 @@ func TestSchemaMigrationQueryInversesAcrossMultipleVersions(t *testing.T) {
 			},
 			testUtils.ConfigureMigration{
 				LensConfig: client.LensConfig{
-					SourceSchemaVersionID:      "bafyreih5sk2gsbddpvkil76x5sgbdgx6gmglhycpyvgli3szatqnfmxaka",
-					DestinationSchemaVersionID: "bafyreicrtehvnvxkjdxac523mb7kkiwyn3wntj3yiuljskcco5ixhcpk7y",
+					SourceSchemaVersionID:      "bafyreidaalpcihwrmovhq6plgvqsmxjkzzxs6eakwakfj342esc2y54bbq",
+					DestinationSchemaVersionID: "bafyreiehn7n6uox2x4rjkiunezy2q3deom4keocn7riqpa5xa64c7gqx7u",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{

--- a/tests/integration/collection_version/migrations/query/with_p2p_schema_branch_test.go
+++ b/tests/integration/collection_version/migrations/query/with_p2p_schema_branch_test.go
@@ -48,7 +48,7 @@ func TestSchemaMigrationQueryWithP2PReplicatedDocOnOtherSchemaBranch(t *testing.
 				// Register the migration on both nodes.
 				LensConfig: client.LensConfig{
 					SourceSchemaVersionID:      "bafyreibvat5vc4nxjbxlewe7y2gpskfugypzqbqwal2zwaa7bnuiedyuyy",
-					DestinationSchemaVersionID: "bafyreiecoh66au3ofetd7lyetuqm7xlsj3ln777l7sw324jsutel3w6u5m",
+					DestinationSchemaVersionID: "bafyreiafmkxnf34mdekbx22ooihw7zy2iauw4xqzxbpdxa54umf7vmd2qu",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{

--- a/tests/integration/collection_version/migrations/query/with_p2p_test.go
+++ b/tests/integration/collection_version/migrations/query/with_p2p_test.go
@@ -48,7 +48,7 @@ func TestSchemaMigrationQueryWithP2PReplicatedDocAtOlderSchemaVersion(t *testing
 				// Register the migration on both nodes.
 				LensConfig: client.LensConfig{
 					SourceSchemaVersionID:      "bafyreibvat5vc4nxjbxlewe7y2gpskfugypzqbqwal2zwaa7bnuiedyuyy",
-					DestinationSchemaVersionID: "bafyreiecoh66au3ofetd7lyetuqm7xlsj3ln777l7sw324jsutel3w6u5m",
+					DestinationSchemaVersionID: "bafyreiafmkxnf34mdekbx22ooihw7zy2iauw4xqzxbpdxa54umf7vmd2qu",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{
@@ -151,7 +151,7 @@ func TestSchemaMigrationQueryWithP2PReplicatedDocAtMuchOlderSchemaVersion(t *tes
 				// Register the migration on both nodes.
 				LensConfig: client.LensConfig{
 					SourceSchemaVersionID:      "bafyreibvat5vc4nxjbxlewe7y2gpskfugypzqbqwal2zwaa7bnuiedyuyy",
-					DestinationSchemaVersionID: "bafyreiecoh66au3ofetd7lyetuqm7xlsj3ln777l7sw324jsutel3w6u5m",
+					DestinationSchemaVersionID: "bafyreiafmkxnf34mdekbx22ooihw7zy2iauw4xqzxbpdxa54umf7vmd2qu",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{
@@ -168,8 +168,8 @@ func TestSchemaMigrationQueryWithP2PReplicatedDocAtMuchOlderSchemaVersion(t *tes
 			testUtils.ConfigureMigration{
 				// Register the migration on both nodes.
 				LensConfig: client.LensConfig{
-					SourceSchemaVersionID:      "bafyreiecoh66au3ofetd7lyetuqm7xlsj3ln777l7sw324jsutel3w6u5m",
-					DestinationSchemaVersionID: "bafyreiak72mztt2g3dbfegfutrxuchisw2qjvhxz2jbr54qebfihsbga5u",
+					SourceSchemaVersionID:      "bafyreiafmkxnf34mdekbx22ooihw7zy2iauw4xqzxbpdxa54umf7vmd2qu",
+					DestinationSchemaVersionID: "bafyreidivdcrlxg3uzdduudsgwn3hkmb244vpbu5oz5azw6ycyca4hqyuu",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{
@@ -263,7 +263,7 @@ func TestSchemaMigrationQueryWithP2PReplicatedDocAtNewerSchemaVersion(t *testing
 				// Register the migration on both nodes.
 				LensConfig: client.LensConfig{
 					SourceSchemaVersionID:      "bafyreibvat5vc4nxjbxlewe7y2gpskfugypzqbqwal2zwaa7bnuiedyuyy",
-					DestinationSchemaVersionID: "bafyreiecoh66au3ofetd7lyetuqm7xlsj3ln777l7sw324jsutel3w6u5m",
+					DestinationSchemaVersionID: "bafyreiafmkxnf34mdekbx22ooihw7zy2iauw4xqzxbpdxa54umf7vmd2qu",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{
@@ -368,8 +368,8 @@ func TestSchemaMigrationQueryWithP2PReplicatedDocAtMuchNewerSchemaVersionWithSch
 				// Register a migration from version 2 to version 3 on both nodes.
 				// There is no migration from version 1 to 2, thus node 1 has no knowledge of schema version 2.
 				LensConfig: client.LensConfig{
-					SourceSchemaVersionID:      "bafyreig2nfxuzl3cob7txuvybcct6mmsylt57oirzsrehffkho6bdxlvwy",
-					DestinationSchemaVersionID: "bafyreiccm7djewbzmay7yzincqcy5aggh33k74yh6mhm4gwbzxojxeqkve",
+					SourceSchemaVersionID:      "bafyreiav7tu2ugw7ksj7fpebd2y4onpt2w2pzg7j6aiwblo7rx56qeuovq",
+					DestinationSchemaVersionID: "bafyreid5g3tyf75aaddkgnl2yyq77lvdrx4yeascza6tk7vuqgfxqs2poy",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{

--- a/tests/integration/collection_version/migrations/query/with_restart_test.go
+++ b/tests/integration/collection_version/migrations/query/with_restart_test.go
@@ -46,7 +46,7 @@ func TestSchemaMigrationQueryWithRestart(t *testing.T) {
 			testUtils.ConfigureMigration{
 				LensConfig: client.LensConfig{
 					SourceSchemaVersionID:      "bafyreigsld6ten2pppcu2tgkbexqwdndckp6zt2vfjhuuheykqkgpmwk7i",
-					DestinationSchemaVersionID: "bafyreig2nfxuzl3cob7txuvybcct6mmsylt57oirzsrehffkho6bdxlvwy",
+					DestinationSchemaVersionID: "bafyreiav7tu2ugw7ksj7fpebd2y4onpt2w2pzg7j6aiwblo7rx56qeuovq",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{
@@ -101,7 +101,7 @@ func TestSchemaMigrationQueryWithRestartAndMigrationBeforePatchCollection(t *tes
 			testUtils.ConfigureMigration{
 				LensConfig: client.LensConfig{
 					SourceSchemaVersionID:      "bafyreigsld6ten2pppcu2tgkbexqwdndckp6zt2vfjhuuheykqkgpmwk7i",
-					DestinationSchemaVersionID: "bafyreig2nfxuzl3cob7txuvybcct6mmsylt57oirzsrehffkho6bdxlvwy",
+					DestinationSchemaVersionID: "bafyreiav7tu2ugw7ksj7fpebd2y4onpt2w2pzg7j6aiwblo7rx56qeuovq",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{

--- a/tests/integration/collection_version/migrations/query/with_set_default_test.go
+++ b/tests/integration/collection_version/migrations/query/with_set_default_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestSchemaMigrationQuery_WithSetDefaultToLatest_AppliesForwardMigration(t *testing.T) {
-	schemaVersionID2 := "bafyreiecoh66au3ofetd7lyetuqm7xlsj3ln777l7sw324jsutel3w6u5m"
+	schemaVersionID2 := "bafyreiafmkxnf34mdekbx22ooihw7zy2iauw4xqzxbpdxa54umf7vmd2qu"
 
 	test := testUtils.TestCase{
 		Actions: []any{
@@ -86,7 +86,7 @@ func TestSchemaMigrationQuery_WithSetDefaultToLatest_AppliesForwardMigration(t *
 
 func TestSchemaMigrationQuery_WithSetDefaultToOriginal_AppliesInverseMigration(t *testing.T) {
 	schemaVersionID1 := "bafyreibvat5vc4nxjbxlewe7y2gpskfugypzqbqwal2zwaa7bnuiedyuyy"
-	schemaVersionID2 := "bafyreiecoh66au3ofetd7lyetuqm7xlsj3ln777l7sw324jsutel3w6u5m"
+	schemaVersionID2 := "bafyreiafmkxnf34mdekbx22ooihw7zy2iauw4xqzxbpdxa54umf7vmd2qu"
 
 	test := testUtils.TestCase{
 		Actions: []any{
@@ -162,7 +162,7 @@ func TestSchemaMigrationQuery_WithSetDefaultToOriginal_AppliesInverseMigration(t
 
 func TestSchemaMigrationQuery_WithSetDefaultToOriginalVersionThatDocWasCreatedAt_ClearsMigrations(t *testing.T) {
 	schemaVersionID1 := "bafyreibvat5vc4nxjbxlewe7y2gpskfugypzqbqwal2zwaa7bnuiedyuyy"
-	schemaVersionID2 := "bafyreiecoh66au3ofetd7lyetuqm7xlsj3ln777l7sw324jsutel3w6u5m"
+	schemaVersionID2 := "bafyreiafmkxnf34mdekbx22ooihw7zy2iauw4xqzxbpdxa54umf7vmd2qu"
 
 	test := testUtils.TestCase{
 		Actions: []any{

--- a/tests/integration/collection_version/migrations/query/with_txn_test.go
+++ b/tests/integration/collection_version/migrations/query/with_txn_test.go
@@ -48,7 +48,7 @@ func TestSchemaMigrationQueryWithTxn(t *testing.T) {
 				TransactionID: immutable.Some(0),
 				LensConfig: client.LensConfig{
 					SourceSchemaVersionID:      "bafyreigsld6ten2pppcu2tgkbexqwdndckp6zt2vfjhuuheykqkgpmwk7i",
-					DestinationSchemaVersionID: "bafyreig2nfxuzl3cob7txuvybcct6mmsylt57oirzsrehffkho6bdxlvwy",
+					DestinationSchemaVersionID: "bafyreiav7tu2ugw7ksj7fpebd2y4onpt2w2pzg7j6aiwblo7rx56qeuovq",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{
@@ -111,7 +111,7 @@ func TestSchemaMigrationQueryWithTxnAndCommit(t *testing.T) {
 				TransactionID: immutable.Some(0),
 				LensConfig: client.LensConfig{
 					SourceSchemaVersionID:      "bafyreigsld6ten2pppcu2tgkbexqwdndckp6zt2vfjhuuheykqkgpmwk7i",
-					DestinationSchemaVersionID: "bafyreig2nfxuzl3cob7txuvybcct6mmsylt57oirzsrehffkho6bdxlvwy",
+					DestinationSchemaVersionID: "bafyreiav7tu2ugw7ksj7fpebd2y4onpt2w2pzg7j6aiwblo7rx56qeuovq",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{

--- a/tests/integration/collection_version/migrations/query/with_update_test.go
+++ b/tests/integration/collection_version/migrations/query/with_update_test.go
@@ -46,7 +46,7 @@ func TestSchemaMigrationQueryWithUpdateRequest(t *testing.T) {
 			testUtils.ConfigureMigration{
 				LensConfig: client.LensConfig{
 					SourceSchemaVersionID:      "bafyreigsld6ten2pppcu2tgkbexqwdndckp6zt2vfjhuuheykqkgpmwk7i",
-					DestinationSchemaVersionID: "bafyreig2nfxuzl3cob7txuvybcct6mmsylt57oirzsrehffkho6bdxlvwy",
+					DestinationSchemaVersionID: "bafyreiav7tu2ugw7ksj7fpebd2y4onpt2w2pzg7j6aiwblo7rx56qeuovq",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{
@@ -133,7 +133,7 @@ func TestSchemaMigrationQueryWithMigrationRegisteredAfterUpdate(t *testing.T) {
 			testUtils.ConfigureMigration{
 				LensConfig: client.LensConfig{
 					SourceSchemaVersionID:      "bafyreigsld6ten2pppcu2tgkbexqwdndckp6zt2vfjhuuheykqkgpmwk7i",
-					DestinationSchemaVersionID: "bafyreig2nfxuzl3cob7txuvybcct6mmsylt57oirzsrehffkho6bdxlvwy",
+					DestinationSchemaVersionID: "bafyreiav7tu2ugw7ksj7fpebd2y4onpt2w2pzg7j6aiwblo7rx56qeuovq",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{

--- a/tests/integration/collection_version/migrations/simple_test.go
+++ b/tests/integration/collection_version/migrations/simple_test.go
@@ -92,7 +92,7 @@ func TestSchemaMigrationGetMigrationsReturnsMultiple(t *testing.T) {
 			testUtils.ConfigureMigration{
 				LensConfig: client.LensConfig{
 					SourceSchemaVersionID:      "bafyreigsld6ten2pppcu2tgkbexqwdndckp6zt2vfjhuuheykqkgpmwk7i",
-					DestinationSchemaVersionID: "bafyreig2nfxuzl3cob7txuvybcct6mmsylt57oirzsrehffkho6bdxlvwy",
+					DestinationSchemaVersionID: "bafyreiav7tu2ugw7ksj7fpebd2y4onpt2w2pzg7j6aiwblo7rx56qeuovq",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{
@@ -121,7 +121,7 @@ func TestSchemaMigrationGetMigrationsReturnsMultiple(t *testing.T) {
 					},
 					{
 						IsMaterialized: true,
-						VersionID:      "bafyreig2nfxuzl3cob7txuvybcct6mmsylt57oirzsrehffkho6bdxlvwy",
+						VersionID:      "bafyreiav7tu2ugw7ksj7fpebd2y4onpt2w2pzg7j6aiwblo7rx56qeuovq",
 						PreviousVersion: immutable.Some(client.CollectionSource{
 							SourceCollectionID: "bafyreigsld6ten2pppcu2tgkbexqwdndckp6zt2vfjhuuheykqkgpmwk7i",
 							Transform:          immutable.Some("{{.LensID1}}"),
@@ -215,7 +215,7 @@ func TestSchemaMigrationReplacesExistingMigationBasedOnSourceID(t *testing.T) {
 }
 func TestSchemaMigration_ConfigureMigrationSkippingVersion_Errors(t *testing.T) {
 	version1 := "bafyreihdbjfazsx5vq2tpzedqdktrjyn6lq22qle7el2s42b3q4zpxmwqq"
-	version3 := "bafyreigrzh2d7nca4bsdzlkbzqlsahhzdvkhqzj6it3seeyxwuia544vhy"
+	version3 := "bafyreiagzh4vxxqmhtja255ahnflur5l5oj5oxuztkbl4pfyvpmst25irm"
 
 	test := testUtils.TestCase{
 		Actions: []any{

--- a/tests/integration/collection_version/updates/add/field/create_update_test.go
+++ b/tests/integration/collection_version/updates/add/field/create_update_test.go
@@ -19,7 +19,7 @@ import (
 
 func TestSchemaUpdatesAddFieldWithCreateWithUpdateAfterSchemaUpdateAndVersionJoin(t *testing.T) {
 	initialSchemaVersionID := "bafyreigsld6ten2pppcu2tgkbexqwdndckp6zt2vfjhuuheykqkgpmwk7i"
-	updatedSchemaVersionID := "bafyreiav27gqgcudly2dige7m72giaaucv4fr2ko225rnvfyyauvpmho6a"
+	updatedSchemaVersionID := "bafyreiaxqzrqv4kecnwweii4ejdccldsjmxhzwbfmxtrsv3itcpfkp4dda"
 
 	test := testUtils.TestCase{
 		Actions: []any{
@@ -112,7 +112,7 @@ func TestSchemaUpdatesAddFieldWithCreateWithUpdateAfterSchemaUpdateAndVersionJoi
 
 func TestSchemaUpdatesAddFieldWithCreateWithUpdateAfterSchemaUpdateAndCommitQuery(t *testing.T) {
 	initialSchemaVersionID := "bafyreigsld6ten2pppcu2tgkbexqwdndckp6zt2vfjhuuheykqkgpmwk7i"
-	updatedSchemaVersionID := "bafyreiav27gqgcudly2dige7m72giaaucv4fr2ko225rnvfyyauvpmho6a"
+	updatedSchemaVersionID := "bafyreiaxqzrqv4kecnwweii4ejdccldsjmxhzwbfmxtrsv3itcpfkp4dda"
 
 	test := testUtils.TestCase{
 		Actions: []any{

--- a/tests/integration/collection_version/updates/add/field/simple_test.go
+++ b/tests/integration/collection_version/updates/add/field/simple_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestSchemaUpdatesAddFieldSimple(t *testing.T) {
 	schemaVersion1ID := "bafyreigsld6ten2pppcu2tgkbexqwdndckp6zt2vfjhuuheykqkgpmwk7i"
-	schemaVersion2ID := "bafyreiav27gqgcudly2dige7m72giaaucv4fr2ko225rnvfyyauvpmho6a"
+	schemaVersion2ID := "bafyreiaxqzrqv4kecnwweii4ejdccldsjmxhzwbfmxtrsv3itcpfkp4dda"
 
 	test := testUtils.TestCase{
 		Actions: []any{
@@ -124,7 +124,7 @@ func TestSchemaUpdates_AddFieldSimpleInactiveFalse_Errors(t *testing.T) {
 
 func TestSchemaUpdates_AddFieldSimpleDoNotSetDefault_VersionIsQueryable(t *testing.T) {
 	schemaVersion1ID := "bafyreigsld6ten2pppcu2tgkbexqwdndckp6zt2vfjhuuheykqkgpmwk7i"
-	schemaVersion2ID := "bafyreiav27gqgcudly2dige7m72giaaucv4fr2ko225rnvfyyauvpmho6a"
+	schemaVersion2ID := "bafyreiaxqzrqv4kecnwweii4ejdccldsjmxhzwbfmxtrsv3itcpfkp4dda"
 
 	test := testUtils.TestCase{
 		Actions: []any{

--- a/tests/integration/collection_version/updates/replace/col_source_transform_test.go
+++ b/tests/integration/collection_version/updates/replace/col_source_transform_test.go
@@ -30,7 +30,7 @@ func TestColVersionUpdateReplaceCollectionSourceTransform(t *testing.T) {
 			testUtils.ConfigureMigration{
 				LensConfig: client.LensConfig{
 					SourceSchemaVersionID:      "bafyreih7useaapqn4pf6k5rxb2oufmsjb3e7xnccmbjr2njva3bgpdwyzu",
-					DestinationSchemaVersionID: "bafyreicrtehvnvxkjdxac523mb7kkiwyn3wntj3yiuljskcco5ixhcpk7y",
+					DestinationSchemaVersionID: "bafyreiehn7n6uox2x4rjkiunezy2q3deom4keocn7riqpa5xa64c7gqx7u",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{

--- a/tests/integration/collection_version/updates/replace/id_test.go
+++ b/tests/integration/collection_version/updates/replace/id_test.go
@@ -90,11 +90,11 @@ func TestColVersionUpdateReplaceID_WithExistingSameRoot_Errors(t *testing.T) {
 						{
 							"op": "replace",
 							"path": "/bafyreihdbjfazsx5vq2tpzedqdktrjyn6lq22qle7el2s42b3q4zpxmwqq/VersionID",
-							"value": "bafyreidfzu2x6i4akqlmt5lloaeflwep4ykq2f4unwm2utkmrkgpfyf7bi"
+							"value": "bafyreihkqi5vwtq7wh66mgjw7biyhrf7ilwzsulzfhrvmzvfppnqmpt5ne"
 						},
 						{
 							"op": "replace",
-							"path": "/bafyreidfzu2x6i4akqlmt5lloaeflwep4ykq2f4unwm2utkmrkgpfyf7bi/VersionID",
+							"path": "/bafyreihkqi5vwtq7wh66mgjw7biyhrf7ilwzsulzfhrvmzvfppnqmpt5ne/VersionID",
 							"value": "bafyreihdbjfazsx5vq2tpzedqdktrjyn6lq22qle7el2s42b3q4zpxmwqq"
 						}
 					]

--- a/tests/integration/collection_version/updates/replace/query_source_transform_test.go
+++ b/tests/integration/collection_version/updates/replace/query_source_transform_test.go
@@ -65,7 +65,7 @@ func TestColVersionUpdateReplaceQuerySourceTransform(t *testing.T) {
 			testUtils.ConfigureMigration{
 				LensConfig: client.LensConfig{
 					SourceSchemaVersionID:      "bafyreih7useaapqn4pf6k5rxb2oufmsjb3e7xnccmbjr2njva3bgpdwyzu",
-					DestinationSchemaVersionID: "bafyreicrtehvnvxkjdxac523mb7kkiwyn3wntj3yiuljskcco5ixhcpk7y",
+					DestinationSchemaVersionID: "bafyreiehn7n6uox2x4rjkiunezy2q3deom4keocn7riqpa5xa64c7gqx7u",
 					Lens: model.Lens{
 						Lenses: []model.LensModule{
 							{

--- a/tests/integration/collection_version/updates/replace/sources_test.go
+++ b/tests/integration/collection_version/updates/replace/sources_test.go
@@ -30,7 +30,7 @@ func TestColVersionUpdateReplaceSources_Errors(t *testing.T) {
 					[
 						{
 							"op": "replace",
-							"path": "/bafyreihdbjfazsx5vq2tpzedqdktrjyn6lq22qle7el2s42b3q4zpxmwqq/PreviousVersion",
+							"path": "/Users/PreviousVersion",
 							"value": {"SourceCollectionID": "bafyreihdbjfazsx5vq2tpzedqdktrjyn6lq22qle7el2s42b3q4zpxmwqq"}
 						}
 					]
@@ -56,7 +56,7 @@ func TestColVersionUpdateReplaceSourcesWithQuerySource_Errors(t *testing.T) {
 					[
 						{
 							"op": "replace",
-							"path": "/bafyreihdbjfazsx5vq2tpzedqdktrjyn6lq22qle7el2s42b3q4zpxmwqq/Query",
+							"path": "/Users/Query",
 							"value": {"Query": {"Name": "Users"}}
 						}
 					]

--- a/tests/integration/collection_version/updates/with_version_branch_test.go
+++ b/tests/integration/collection_version/updates/with_version_branch_test.go
@@ -22,8 +22,8 @@ import (
 
 func TestSchemaUpdates_WithBranchingSchema(t *testing.T) {
 	schemaVersion1ID := "bafyreigsld6ten2pppcu2tgkbexqwdndckp6zt2vfjhuuheykqkgpmwk7i"
-	schemaVersion2ID := "bafyreiav27gqgcudly2dige7m72giaaucv4fr2ko225rnvfyyauvpmho6a"
-	schemaVersion3ID := "bafyreih3tqiftewsy5mb2wpsuuinkfptxlrh36c7a36bkehnmyn6lodvau"
+	schemaVersion2ID := "bafyreiaxqzrqv4kecnwweii4ejdccldsjmxhzwbfmxtrsv3itcpfkp4dda"
+	schemaVersion3ID := "bafyreic4xohr7idybbfpdabs6foed5i2uv5v3hdgyvse5p2x4yrlp7et3i"
 
 	test := testUtils.TestCase{
 		Actions: []any{
@@ -160,12 +160,6 @@ func TestSchemaUpdates_WithBranchingSchema(t *testing.T) {
 						}),
 					},
 					{
-						// The original collection version is present, it has no source and is inactive (has no name).
-						VersionID:      schemaVersion1ID,
-						IsMaterialized: true,
-						Name:           "Users",
-					},
-					{
 						// The collection version for schema version 3 is present and is active, it also has the first collection
 						// as source.
 						Name:           "Users",
@@ -176,6 +170,12 @@ func TestSchemaUpdates_WithBranchingSchema(t *testing.T) {
 							SourceCollectionID: schemaVersion1ID,
 						}),
 					},
+					{
+						// The original collection version is present, it has no source and is inactive (has no name).
+						VersionID:      schemaVersion1ID,
+						IsMaterialized: true,
+						Name:           "Users",
+					},
 				},
 			},
 		},
@@ -185,9 +185,9 @@ func TestSchemaUpdates_WithBranchingSchema(t *testing.T) {
 
 func TestSchemaUpdates_WithPatchOnBranchedSchema(t *testing.T) {
 	schemaVersion1ID := "bafyreigsld6ten2pppcu2tgkbexqwdndckp6zt2vfjhuuheykqkgpmwk7i"
-	schemaVersion2ID := "bafyreiav27gqgcudly2dige7m72giaaucv4fr2ko225rnvfyyauvpmho6a"
-	schemaVersion3ID := "bafyreih3tqiftewsy5mb2wpsuuinkfptxlrh36c7a36bkehnmyn6lodvau"
-	schemaVersion4ID := "bafyreih3jgjlud3h3xnnjysgtvfegcn2xdixlavwzbw7s6as65atwfhtvi"
+	schemaVersion2ID := "bafyreiaxqzrqv4kecnwweii4ejdccldsjmxhzwbfmxtrsv3itcpfkp4dda"
+	schemaVersion3ID := "bafyreic4xohr7idybbfpdabs6foed5i2uv5v3hdgyvse5p2x4yrlp7et3i"
+	schemaVersion4ID := "bafyreid47ua6uiszzdhlotafzv2e32nopt2uow3fgigtt2flc2e2abcvwq"
 
 	test := testUtils.TestCase{
 		Actions: []any{
@@ -295,11 +295,15 @@ func TestSchemaUpdates_WithPatchOnBranchedSchema(t *testing.T) {
 						}),
 					},
 					{
-						// The original collection version is present, it has no source and is inactive
+						// The collection version for schema version 3 is present and inactive, it has the first collection
+						// as source.
 						Name:           "Users",
-						VersionID:      schemaVersion1ID,
+						VersionID:      schemaVersion3ID,
 						IsMaterialized: true,
 						IsActive:       false,
+						PreviousVersion: immutable.Some(client.CollectionSource{
+							SourceCollectionID: schemaVersion1ID,
+						}),
 					},
 					{
 						// The collection version for schema version 4 is present and is active, it also has the third collection
@@ -313,15 +317,11 @@ func TestSchemaUpdates_WithPatchOnBranchedSchema(t *testing.T) {
 						}),
 					},
 					{
-						// The collection version for schema version 3 is present and inactive, it has the first collection
-						// as source.
+						// The original collection version is present, it has no source and is inactive
 						Name:           "Users",
-						VersionID:      schemaVersion3ID,
+						VersionID:      schemaVersion1ID,
 						IsMaterialized: true,
 						IsActive:       false,
-						PreviousVersion: immutable.Some(client.CollectionSource{
-							SourceCollectionID: schemaVersion1ID,
-						}),
 					},
 				},
 			},
@@ -332,8 +332,8 @@ func TestSchemaUpdates_WithPatchOnBranchedSchema(t *testing.T) {
 
 func TestSchemaUpdates_WithBranchingSchemaAndSetActiveSchemaToOtherBranch(t *testing.T) {
 	schemaVersion1ID := "bafyreigsld6ten2pppcu2tgkbexqwdndckp6zt2vfjhuuheykqkgpmwk7i"
-	schemaVersion2ID := "bafyreiav27gqgcudly2dige7m72giaaucv4fr2ko225rnvfyyauvpmho6a"
-	schemaVersion3ID := "bafyreih3tqiftewsy5mb2wpsuuinkfptxlrh36c7a36bkehnmyn6lodvau"
+	schemaVersion2ID := "bafyreiaxqzrqv4kecnwweii4ejdccldsjmxhzwbfmxtrsv3itcpfkp4dda"
+	schemaVersion3ID := "bafyreic4xohr7idybbfpdabs6foed5i2uv5v3hdgyvse5p2x4yrlp7et3i"
 
 	test := testUtils.TestCase{
 		Actions: []any{
@@ -404,13 +404,6 @@ func TestSchemaUpdates_WithBranchingSchemaAndSetActiveSchemaToOtherBranch(t *tes
 						}),
 					},
 					{
-						// The original collection version is present, it has no source and is inactive.
-						Name:           "Users",
-						VersionID:      schemaVersion1ID,
-						IsMaterialized: true,
-						IsActive:       false,
-					},
-					{
 						// The collection version for schema version 3 is present and is inactive, it also has the first collection
 						// as source.
 						Name:           "Users",
@@ -421,6 +414,13 @@ func TestSchemaUpdates_WithBranchingSchemaAndSetActiveSchemaToOtherBranch(t *tes
 							SourceCollectionID: schemaVersion1ID,
 						}),
 					},
+					{
+						// The original collection version is present, it has no source and is inactive.
+						Name:           "Users",
+						VersionID:      schemaVersion1ID,
+						IsMaterialized: true,
+						IsActive:       false,
+					},
 				},
 			},
 		},
@@ -430,9 +430,9 @@ func TestSchemaUpdates_WithBranchingSchemaAndSetActiveSchemaToOtherBranch(t *tes
 
 func TestSchemaUpdates_WithBranchingSchemaAndSetActiveSchemaToOtherBranchThenPatch(t *testing.T) {
 	schemaVersion1ID := "bafyreigsld6ten2pppcu2tgkbexqwdndckp6zt2vfjhuuheykqkgpmwk7i"
-	schemaVersion2ID := "bafyreiav27gqgcudly2dige7m72giaaucv4fr2ko225rnvfyyauvpmho6a"
-	schemaVersion3ID := "bafyreih3tqiftewsy5mb2wpsuuinkfptxlrh36c7a36bkehnmyn6lodvau"
-	schemaVersion4ID := "bafyreih3jgjlud3h3xnnjysgtvfegcn2xdixlavwzbw7s6as65atwfhtvi"
+	schemaVersion2ID := "bafyreiaxqzrqv4kecnwweii4ejdccldsjmxhzwbfmxtrsv3itcpfkp4dda"
+	schemaVersion3ID := "bafyreic4xohr7idybbfpdabs6foed5i2uv5v3hdgyvse5p2x4yrlp7et3i"
+	schemaVersion4ID := "bafyreid47ua6uiszzdhlotafzv2e32nopt2uow3fgigtt2flc2e2abcvwq"
 
 	test := testUtils.TestCase{
 		Actions: []any{
@@ -544,11 +544,15 @@ func TestSchemaUpdates_WithBranchingSchemaAndSetActiveSchemaToOtherBranchThenPat
 						}),
 					},
 					{
-						// The original collection version is present, it has no source and is inactive.
+						// The collection version for schema version 3 is present and inactive, it has the first collection
+						// as source.
 						Name:           "Users",
-						VersionID:      schemaVersion1ID,
+						VersionID:      schemaVersion3ID,
 						IsMaterialized: true,
 						IsActive:       false,
+						PreviousVersion: immutable.Some(client.CollectionSource{
+							SourceCollectionID: schemaVersion1ID,
+						}),
 					},
 					{
 						// The collection version for schema version 4 is present and is active, it also has the second collection
@@ -562,15 +566,11 @@ func TestSchemaUpdates_WithBranchingSchemaAndSetActiveSchemaToOtherBranchThenPat
 						}),
 					},
 					{
-						// The collection version for schema version 3 is present and inactive, it has the first collection
-						// as source.
+						// The original collection version is present, it has no source and is inactive.
 						Name:           "Users",
-						VersionID:      schemaVersion3ID,
+						VersionID:      schemaVersion1ID,
 						IsMaterialized: true,
 						IsActive:       false,
-						PreviousVersion: immutable.Some(client.CollectionSource{
-							SourceCollectionID: schemaVersion1ID,
-						}),
 					},
 				},
 			},

--- a/tests/integration/collection_version/with_update_set_default_test.go
+++ b/tests/integration/collection_version/with_update_set_default_test.go
@@ -124,7 +124,7 @@ func TestSchema_WithUpdateAndSetDefaultVersionToNew_AllowsQueryingOfNewField(t *
 				`,
 			},
 			testUtils.SetActiveCollectionVersion{
-				VersionID: "bafyreiav27gqgcudly2dige7m72giaaucv4fr2ko225rnvfyyauvpmho6a",
+				VersionID: "bafyreiaxqzrqv4kecnwweii4ejdccldsjmxhzwbfmxtrsv3itcpfkp4dda",
 			},
 			testUtils.Request{
 				Request: `query {


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4053

## Description

Includes the query source delta in the collection blocks.

Required in order to send Views over P2P.

Based off of #4070 - please review that first.