### PR TITLE
docs: Fix typo in docs, _commits will not work, commits will work

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ Obtain a specific commit by its content identifier (`cid`):
 ```shell
 defradb client query '
   query {
-    _commits(cid: "bafybeifhtfs6vgu7cwbhkojneh7gghwwinh5xzmf7nqkqqdebw5rqino7u") {
+    commits(cid: "bafybeifhtfs6vgu7cwbhkojneh7gghwwinh5xzmf7nqkqqdebw5rqino7u") {
       cid
       delta
       height


### PR DESCRIPTION
## Relevant issue(s)

Resolves #

## Description

I was testing with fetching commits and noticed that using `_commits` as in the readme did not work. I got this error: `failed to execute query: graphql errors: [Cannot query field "_commits" on type "Query". Did you mean "commits" or "_count"?`

I modified my test to use `commits` and my queries started to return results 🙂 

## Tasks

- [ ] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [ ] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

See description.

Specify the platform(s) on which this was tested:
N/A