### PR TITLE
ci: Fine tune self-hosted workflows

### DIFF
--- a/.github/workflows/check-data-format-changes.yml
+++ b/.github/workflows/check-data-format-changes.yml
@@ -1,4 +1,4 @@
-# Copyright 2024 Democratized Data Foundation
+# Copyright 2025 Democratized Data Foundation
 #
 # Use of this software is governed by the Business Source License
 # included in the file licenses/BSL.txt.
@@ -25,7 +25,8 @@ on:
 
 # Cancel the workflow if its in progress when there is a new commit. This will reduce unecessary resource usage.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref == github.ref_protected && github.run_id || github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-\
+    ${{ github.ref == github.ref_protected && github.run_id || github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -33,7 +34,7 @@ jobs:
     name: Check data format changes job
 
     runs-on: runs-on=${{ github.run_id }}-${{ github.run_attempt }}-${{ strategy.job-index }}/\
-      spot=pco/cpu=16+32/family=m7*+c7*/extras=s3-cache
+      spot=pco/cpu=16+32/family=c6*+c7*/disk=large/extras=s3-cache
 
     steps:
       - name: Enable RunsOn action

--- a/.github/workflows/check-data-format-changes.yml
+++ b/.github/workflows/check-data-format-changes.yml
@@ -24,6 +24,7 @@ on:
       - develop
 
 # Cancel the workflow if its in progress when there is a new commit. This will reduce unecessary resource usage.
+
 concurrency:
   group: ${{ github.workflow }}-\
     ${{ github.ref == github.ref_protected && github.run_id || github.event.pull_request.number || github.ref }}

--- a/.github/workflows/check-data-format-changes.yml
+++ b/.github/workflows/check-data-format-changes.yml
@@ -24,7 +24,6 @@ on:
       - develop
 
 # Cancel the workflow if its in progress when there is a new commit. This will reduce unecessary resource usage.
-
 concurrency:
   group: ${{ github.workflow }}-\
     ${{ github.ref == github.ref_protected && github.run_id || github.event.pull_request.number || github.ref }}

--- a/.github/workflows/check-data-format-changes.yml
+++ b/.github/workflows/check-data-format-changes.yml
@@ -23,6 +23,11 @@ on:
       - master
       - develop
 
+# Cancel the workflow if its in progress when there is a new commit. This will reduce unecessary resource usage.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref == github.ref_protected && github.run_id || github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check-data-format-changes:
     name: Check data format changes job

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-# Copyright 2023 Democratized Data Foundation
+# Copyright 2025 Democratized Data Foundation
 #
 # Use of this software is governed by the Business Source License
 # included in the file licenses/BSL.txt.
@@ -162,7 +162,7 @@ jobs:
   docker-build-push:
     name: Build and push Docker image
     runs-on: runs-on=${{ github.run_id }}-${{ github.run_attempt }}-${{ strategy.job-index }}/\
-      spot=pco/cpu=16+32/family=m7*+c7*/extras=s3-cache
+      spot=pco/cpu=16+32/family=c6*+c7*/disk=large/extras=s3-cache
     steps:
       - name: Enable RunsOn action
         uses: runs-on/action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,11 @@ on:
         description: 'New tag name'
         required: true
 
+# Cancel the workflow if its in progress when there is a new commit. This will reduce unecessary resource usage.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
   packages: write

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -23,6 +23,10 @@ on:
       - master
       - develop
 
+# Cancel the workflow if its in progress when there is a new commit. This will reduce unecessary resource usage.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref == github.ref_protected && github.run_id || github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 # Default environment configuration settings.
 env:

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -1,4 +1,4 @@
-# Copyright 2024 Democratized Data Foundation
+# Copyright 2025 Democratized Data Foundation
 #
 # Use of this software is governed by the Business Source License
 # included in the file licenses/BSL.txt.
@@ -25,7 +25,8 @@ on:
 
 # Cancel the workflow if its in progress when there is a new commit. This will reduce unecessary resource usage.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref == github.ref_protected && github.run_id || github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-\
+    ${{ github.ref == github.ref_protected && github.run_id || github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 # Default environment configuration settings.
@@ -70,7 +71,7 @@ jobs:
         mutation-type: [gql, collection-named, collection-save]
 
     runs-on: runs-on=${{ github.run_id }}-${{ github.run_attempt }}-${{ strategy.job-index }}/\
-      spot=pco/cpu=16+32/family=m7*+c7*/extras=s3-cache
+      spot=pco/cpu=16+32/family=c6*+c7*/disk=large/extras=s3-cache
 
     # Overwrite the defaults based on the basic matrix
     env:
@@ -155,7 +156,7 @@ jobs:
         document-acp-type: [source-hub]
 
     runs-on: runs-on=${{ github.run_id }}-${{ github.run_attempt }}-${{ strategy.job-index }}/\
-      spot=pco/cpu=16+32/family=m7*+c7*/extras=s3-cache
+      spot=pco/cpu=16+32/family=c6*+c7*/disk=large/extras=s3-cache
 
     env:
       DEFRA_DOCUMENT_ACP_TYPE: ${{ matrix.document-acp-type }}
@@ -208,7 +209,7 @@ jobs:
         lens-type: [wazero, wasmer]
 
     runs-on: runs-on=${{ github.run_id }}-${{ github.run_attempt }}-${{ strategy.job-index }}/\
-      spot=pco/cpu=16+32/family=m7*+c7*/extras=s3-cache
+      spot=pco/cpu=16+32/family=c6*+c7*/disk=large/extras=s3-cache
 
     env:
       DEFRA_LENS_TYPE: ${{ matrix.lens-type }}
@@ -237,7 +238,7 @@ jobs:
     name: Test view job
 
     runs-on: runs-on=${{ github.run_id }}-${{ github.run_attempt }}-${{ strategy.job-index }}/\
-      spot=pco/cpu=16+32/family=m7*+c7*/extras=s3-cache
+      spot=pco/cpu=16+32/family=c6*+c7*/disk=large/extras=s3-cache
 
     env:
       DEFRA_VIEW_TYPE: materialized
@@ -266,7 +267,7 @@ jobs:
     name: Test encryption job
 
     runs-on: runs-on=${{ github.run_id }}-${{ github.run_attempt }}-${{ strategy.job-index }}/\
-      spot=pco/cpu=16+32/family=m7*+c7*/extras=s3-cache
+      spot=pco/cpu=16+32/family=c6*+c7*/disk=large/extras=s3-cache
 
     env:
       DEFRA_BADGER_ENCRYPTION: true
@@ -294,7 +295,7 @@ jobs:
     name: Test telemetry job
 
     runs-on: runs-on=${{ github.run_id }}-${{ github.run_attempt }}-${{ strategy.job-index }}/\
-      spot=pco/cpu=16+32/family=m7*+c7*/extras=s3-cache
+      spot=pco/cpu=16+32/family=c6*+c7*/disk=large/extras=s3-cache
 
     env:
       GOFLAGS: -tags=telemetry
@@ -322,7 +323,7 @@ jobs:
     name: Test JS job
 
     runs-on: runs-on=${{ github.run_id }}-${{ github.run_attempt }}-${{ strategy.job-index }}/\
-      spot=pco/cpu=16+32/family=m7*+c7*/extras=s3-cache
+      spot=pco/cpu=16+32/family=c6*+c7*/disk=large/extras=s3-cache
 
     env:
       CGO_ENABLED: 0

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ ifdef BUILD_TAGS
 BUILD_FLAGS+=-tags $(BUILD_TAGS)
 endif
 
-TEST_FLAGS=-race -shuffle=on -timeout 10m
+TEST_FLAGS=-race -shuffle=on -timeout 2m
 
 JS_TEST_DIRS=./tests/integration/... ./event/... ./node/...
 JS_TEST_FLAGS=-exec="$$(go env GOROOT)/lib/wasm/go_js_wasm_exec" -shuffle=on -timeout 10m

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ ifdef BUILD_TAGS
 BUILD_FLAGS+=-tags $(BUILD_TAGS)
 endif
 
-TEST_FLAGS=-race -shuffle=on -timeout 2m
+TEST_FLAGS=-race -shuffle=on -timeout 10m
 
 JS_TEST_DIRS=./tests/integration/... ./event/... ./node/...
 JS_TEST_FLAGS=-exec="$$(go env GOROOT)/lib/wasm/go_js_wasm_exec" -shuffle=on -timeout 10m


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4112

## Description

This PR changes the instance type to use from memory optimized to cpu optimized to reduce workflow costs. This shouldn't affect performance since the memory optimized instances only used at most 25% of their memory.

We also make it so pushing a new commit on a PR will cancel the previously running workflows that were using self-hosted runners. This should avoid unnecessary costs.
