### PR TITLE
docs: Update broken docs link in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ defradb client query '
 
 DQL is compatible with GraphQL but features various extensions.
 
-Read its documentation at [docs.source.network](https://docs.source.network/references/query-specification/query-language-overview) to discover its filtering, ordering, limiting, relationships, variables, aggregate functions, and other useful features.
+Read its documentation at [docs.source.network](https://docs.source.network/defradb/references/query-specification/query-language-overview) to discover its filtering, ordering, limiting, relationships, variables, aggregate functions, and other useful features.
 
 ## Peer-to-peer data synchronization
 


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4116 

## Description

This PR fixes a link where the path to the docs was missing `/defradb` in the path.