### PR TITLE
fix: Windows build

### DIFF
--- a/internal/db/lens_wasmtime.go
+++ b/internal/db/lens_wasmtime.go
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-//go:build !js && !android
+//go:build !js && !android && !windows
 
 package db
 

--- a/playground/playground_windows.go
+++ b/playground/playground_windows.go
@@ -8,9 +8,9 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-//go:build playground && !windows
+//go:build playground
 
-//go:generate ../tools/scripts/download_playground.sh
+//go:generate powershell -ExecutionPolicy Bypass -File ../tools/scripts/download_playground.ps1
 
 package playground
 

--- a/tools/scripts/download_playground.ps1
+++ b/tools/scripts/download_playground.ps1
@@ -1,0 +1,24 @@
+# Download static assets from: `github.com/sourcenetwork/defradb-playground`.
+#
+# Bump the release tag in the URL below to change versions.
+
+$url = "https://github.com/sourcenetwork/defradb-playground/releases/download/v1.0.0/dist.tar.gz"
+$tarFile = "dist.tar.gz"
+
+try {
+    # Download the file
+    Write-Host "Downloading playground assets..."
+    Invoke-WebRequest -Uri $url -OutFile $tarFile -ErrorAction Stop
+
+    # Extract the tar.gz file
+    Write-Host "Extracting assets..."
+    tar -xzf $tarFile
+
+    # Clean up the downloaded archive
+    Remove-Item $tarFile
+
+    Write-Host "Download complete!"
+} catch {
+    Write-Error "Failed to download or extract playground assets: $_"
+    exit 1
+}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4123

## Description

This PR fixes the windows build by making the playground download compatible with windows and by ensuring windows doesn't try to use wasmtime.