### PR TITLE
chore: Expand git version support for Makefile build version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ $(error "No git in $(PATH), version information won't be included")
 else
 VERSION_GOINFO=$(shell go version)
 VERSION_GITCOMMIT=$(shell git rev-parse HEAD)
-VERSION_GITCOMMITDATE=$(shell git show -s --format=%cs HEAD)
+VERSION_GITCOMMITDATE=$(shell git show -s --date=short --format=%cd HEAD)
 ifneq ($(shell git symbolic-ref -q --short HEAD),master)
 VERSION_GITRELEASE=dev-$(shell git symbolic-ref -q --short HEAD)
 else


### PR DESCRIPTION
`%cs` was a more "recent" git formatting feature, but the `%cd` formatting (along with `--date=short`) does the same thing and works even on older git versions (such as 2.11).

## Relevant issue(s)

Resolves #3997

## Description

For makefile build version tagging, switching from `%cs` formatting string to `%cd` and `--date=short`, which extends support to older versions of git, and does the same thing as our current `%cs` usage.

## Tasks

- [X] I made sure the code is well commented, particularly hard-to-understand areas.
- [X] I made sure the repository-held documentation is changed accordingly.
- [X] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [X] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Made this change locally and rebuilt, and it worked fine.

Specify the platform(s) on which this was tested:
- Debian Linux 9.13
- Debian Linux 12

