### PR TITLE
chore(i): Fix inaccurate comment for resetStateContext function

### DIFF
--- a/tests/integration/identity.go
+++ b/tests/integration/identity.go
@@ -131,8 +131,8 @@ func getIdentityDID(s *state.State, identity immutable.Option[state.Identity]) s
 	return ""
 }
 
-// resetContextWithNoIdentity resets identity for the ctx to avoid, leaving it there and having the ctx
-// reuse the same identity for other requests that don't specify an identity.
+// resetStateContext resets the context identity to prevent reusing the same identity
+// in subsequent requests that don't specify an identity.
 func resetStateContext(s *state.State) {
 	s.Ctx = acpIdentity.WithContext(s.Ctx, acpIdentity.None)
 }


### PR DESCRIPTION
## Relevant issue(s)

Resolves #

## Description


The comment for the resetStateContext function in [tests/integration/identity.go](file:///Users/mac/other-333/202506-old/defradb/tests/integration/identity.go) was grammatically incorrect and unclear. It has been updated to accurately describe the function's purpose: resetting the context identity to prevent reusing the same identity in subsequent requests that don't specify an identity.



## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [ ] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [ ] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

No need.


Specify the platform(s) on which this was tested:

- MacOS

