### PR TITLE
fix: Set FieldID when syncing collections

### DIFF
--- a/internal/db/p2p/sync_col.go
+++ b/internal/db/p2p/sync_col.go
@@ -145,9 +145,10 @@ func (p *P2P) syncCollection(
 		}
 
 		field := client.CollectionFieldDescription{
-			Name: *fieldDelta.Name,
-			Typ:  *fieldDelta.Crdt,
-			Kind: kind,
+			FieldID: fieldCid.String(),
+			Name:    *fieldDelta.Name,
+			Typ:     *fieldDelta.Crdt,
+			Kind:    kind,
 		}
 
 		if *fieldDelta.Name == request.DocIDFieldName {

--- a/tests/integration/net/sync/collection_version/simple_test.go
+++ b/tests/integration/net/sync/collection_version/simple_test.go
@@ -95,3 +95,65 @@ func TestColSync_WithInitialColVersion(t *testing.T) {
 
 	testUtils.ExecuteTestCase(t, test)
 }
+
+func TestColSync_WithInitialColVersion_CanBeActivatedAndQueried(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.RandomNetworkingConfig(),
+			testUtils.RandomNetworkingConfig(),
+			&action.AddSchema{
+				NodeID: immutable.Some(0),
+				// Note - at the time of writing, having two fields of different kinds is important
+				// and an important bug did not surface when testing with a single field/kind.
+				Schema: `
+					type Users {
+						name: String
+						age: Int
+					}
+				`,
+			},
+			testUtils.ConnectPeers{
+				SourceNodeID: 0,
+				TargetNodeID: 1,
+			},
+			&action.SyncCollection{
+				NodeID:     1,
+				VersionIDs: []string{"{{.CollectionVersionID0}}"},
+			},
+			testUtils.WaitForSync{},
+			testUtils.SetActiveCollectionVersion{
+				NodeID:    immutable.Some(1),
+				VersionID: "{{.CollectionVersionID0}}",
+			},
+			testUtils.CreateDoc{
+				NodeID: immutable.Some(0),
+				DocMap: map[string]any{
+					"name": "John",
+					"age":  4,
+				},
+			},
+			testUtils.SyncDocs{
+				NodeID:       1,
+				CollectionID: 0,
+				DocIDs:       []int{0},
+				SourceNodes:  []int{0},
+			},
+			testUtils.Request{
+				Request: `query {
+					Users {
+						name
+					}
+				}`,
+				Results: map[string]any{
+					"Users": []map[string]any{
+						{
+							"name": "John",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4138

## Description

Sets FieldID when syncing collections.

Previously, if the collection had more than one field, the writing of documents would fail, probably due to zero-id-clashes.
