### PR TITLE
fix: Allow Lenses to pull docs from source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ tests/lenses/rust_wasm32_prepend/pkg
 tests/lenses/rust_wasm32_filter/Cargo.lock
 tests/lenses/rust_wasm32_filter/target
 tests/lenses/rust_wasm32_filter/pkg
+tests/lenses/rust_wasm32_std_dev/Cargo.lock
+tests/lenses/rust_wasm32_std_dev/target
+tests/lenses/rust_wasm32_std_dev/pkg
 
 # Ignore OS X metadata files.
 .history

--- a/internal/planner/lens.go
+++ b/internal/planner/lens.go
@@ -32,8 +32,8 @@ type lensNode struct {
 	source     planNode
 	collection client.CollectionVersion
 
-	input  enumerable.Queue[map[string]any]
-	output enumerable.Enumerable[map[string]any]
+	srcEnumerable enumerable.Enumerable[map[string]any]
+	output        enumerable.Enumerable[map[string]any]
 }
 
 func (p *Planner) Lens(source planNode, docMap *core.DocumentMapping, col client.Collection) *lensNode {
@@ -46,12 +46,14 @@ func (p *Planner) Lens(source planNode, docMap *core.DocumentMapping, col client
 }
 
 func (n *lensNode) Init() error {
-	n.input = enumerable.NewQueue[map[string]any]()
+	n.srcEnumerable = &nodeEnumerable{
+		src: n.source,
+	}
 
 	var pipe enumerable.Enumerable[map[string]any]
 	if n.collection.Query.HasValue() && n.collection.Query.Value().Transform.HasValue() {
 		var err error
-		pipe, err = n.p.lensStore.Transform(n.p.ctx, n.input, n.collection.Query.Value().Transform.Value())
+		pipe, err = n.p.lensStore.Transform(n.p.ctx, n.srcEnumerable, n.collection.Query.Value().Transform.Value())
 		if err != nil {
 			return err
 		}
@@ -59,7 +61,7 @@ func (n *lensNode) Init() error {
 		var err error
 		pipe, err = n.p.lensStore.Transform(
 			n.p.ctx,
-			n.input,
+			n.srcEnumerable,
 			n.collection.PreviousVersion.Value().Transform.Value(),
 		)
 		if err != nil {
@@ -103,14 +105,6 @@ func (n *lensNode) Next() (bool, error) {
 
 	if !sourceHasNext {
 		return false, nil
-	}
-
-	sourceDoc := n.source.Value()
-	sourceLensDoc := n.source.Source().DocumentMap().ToMap(sourceDoc)
-
-	err = n.input.Put(sourceLensDoc)
-	if err != nil {
-		return false, err
 	}
 
 	return n.Next()
@@ -196,4 +190,25 @@ func (n *lensNode) Close() error {
 	}
 
 	return nil
+}
+
+type nodeEnumerable struct {
+	src planNode
+}
+
+var _ enumerable.Enumerable[map[string]any] = (*nodeEnumerable)(nil)
+
+func (e *nodeEnumerable) Next() (bool, error) {
+	return e.src.Next()
+}
+
+func (e *nodeEnumerable) Value() (map[string]any, error) {
+	doc := e.src.Value()
+	lensDoc := e.src.Source().DocumentMap().ToMap(doc)
+
+	return lensDoc, nil
+}
+
+func (e *nodeEnumerable) Reset() {
+	panic("reset not supported - programming error")
 }

--- a/tests/integration/view/simple/with_transform_aggregate_test.go
+++ b/tests/integration/view/simple/with_transform_aggregate_test.go
@@ -1,0 +1,98 @@
+// Copyright 2025 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package simple
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/defradb/tests/action"
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	"github.com/sourcenetwork/defradb/tests/lenses"
+	"github.com/sourcenetwork/immutable"
+	"github.com/sourcenetwork/lens/host-go/config/model"
+)
+
+func TestView_SimpleWithTransformAggregate(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddSchema{
+				Schema: `
+					type User {
+						age: Int
+					}
+				`,
+			},
+			testUtils.CreateView{
+				Query: `
+					User {
+						age
+					}
+				`,
+				SDL: `
+					type UserStdDev @materialized(if: false) {
+						stddev: String
+					}
+				`,
+				Transform: immutable.Some(model.Lens{
+					Lenses: []model.LensModule{
+						{
+							Path: lenses.StandardDeviationModulePath,
+							Arguments: map[string]any{
+								"src": "age",
+								"dst": "stddev",
+							},
+						},
+					},
+				}),
+			},
+			testUtils.CreateDoc{
+				DocMap: map[string]any{
+					"age": 30,
+				},
+			},
+			testUtils.CreateDoc{
+				DocMap: map[string]any{
+					"age": 26,
+				},
+			},
+			testUtils.CreateDoc{
+				DocMap: map[string]any{
+					"age": 34,
+				},
+			},
+			testUtils.Request{
+				Request: `
+					query {
+						UserStdDev {
+							stddev
+						}
+					}
+				`,
+				Results: map[string]any{
+					"UserStdDev": []map[string]any{
+						// This is unwanted behaviour, we want a single, non-zero result
+						{
+							"stddev": float64(0),
+						},
+						{
+							"stddev": float64(0),
+						},
+						{
+							"stddev": float64(0),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/view/simple/with_transform_aggregate_test.go
+++ b/tests/integration/view/simple/with_transform_aggregate_test.go
@@ -78,15 +78,8 @@ func TestView_SimpleWithTransformAggregate(t *testing.T) {
 				`,
 				Results: map[string]any{
 					"UserStdDev": []map[string]any{
-						// This is unwanted behaviour, we want a single, non-zero result
 						{
-							"stddev": float64(0),
-						},
-						{
-							"stddev": float64(0),
-						},
-						{
-							"stddev": float64(0),
+							"stddev": float64(3.265986323710904),
 						},
 					},
 				},

--- a/tests/lenses/Makefile
+++ b/tests/lenses/Makefile
@@ -4,3 +4,4 @@ build:
 	cargo build --target wasm32-unknown-unknown --manifest-path "./rust_wasm32_copy/Cargo.toml"
 	cargo build --target wasm32-unknown-unknown --manifest-path "./rust_wasm32_prepend/Cargo.toml"
 	cargo build --target wasm32-unknown-unknown --manifest-path "./rust_wasm32_filter/Cargo.toml"
+	cargo build --target wasm32-unknown-unknown --manifest-path "./rust_wasm32_std_dev/Cargo.toml"

--- a/tests/lenses/rust_wasm32_std_dev/Cargo.toml
+++ b/tests/lenses/rust_wasm32_std_dev/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "std-dev"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0.87"
+lens_sdk = "^0.8"

--- a/tests/lenses/rust_wasm32_std_dev/src/lib.rs
+++ b/tests/lenses/rust_wasm32_std_dev/src/lib.rs
@@ -1,7 +1,7 @@
-use std::collections::HashMap;
 use std::sync::RwLock;
 use std::error::Error;
 use serde::Deserialize;
+use serde_json::{Value, Map};
 use lens_sdk::StreamOption;
 use lens_sdk::error::LensError;
 
@@ -16,8 +16,8 @@ pub struct Parameters {
 static PARAMETERS: RwLock<Option<Parameters>> = RwLock::new(None);
 
 fn try_transform(
-    iter: &mut dyn Iterator<Item = lens_sdk::Result<Option<HashMap<String, serde_json::Value>>>>,
-) -> Result<StreamOption<HashMap<String, serde_json::Value>>, Box<dyn Error>> {
+    iter: &mut dyn Iterator<Item = lens_sdk::Result<Option<Value>>>,
+) -> Result<StreamOption<Value>, Box<dyn Error>> {
     let params = PARAMETERS.read()?
         .clone()
         .ok_or(LensError::ParametersNotSetError)?;
@@ -58,10 +58,10 @@ fn try_transform(
     let variance = sum_dev / count;
     let std_dev = variance.sqrt();
 
-    let mut result = HashMap::<String, serde_json::Value>::new();
-    result.insert(params.dst, std_dev.into());
+    let mut result = Map::new();
+    result.insert(params.dst, Value::from(std_dev));
 
-    Ok(StreamOption::Some(result))
+    Ok(StreamOption::Some(Value::Object(result)))
 }
 
 #[cfg(test)]
@@ -78,20 +78,20 @@ mod tests {
         });
         drop(ptr);
 
-        let mut input_doc_1 = HashMap::<String, serde_json::Value>::new();
-        input_doc_1.insert(src_f.clone(), 10.into());
-        let mut input_doc_2 = HashMap::<String, serde_json::Value>::new();
-        input_doc_2.insert(src_f.clone(), 14.into());
+        let mut input_doc_1 = Map::new();
+        input_doc_1.insert(src_f.clone(), Value::Number(10));
+        let mut input_doc_2 = Map::new();
+        input_doc_2.insert(src_f.clone(), Value::Number(14));
 
         let input = [
             Ok(
                 Some(
-                    input_doc_1,
+                    Value::Object(input_doc_1),
                 ),
             ),
             Ok(
                 Some(
-                    input_doc_2,
+                    Value::Object(input_doc_2),
                 ),
             ),
         ];
@@ -100,12 +100,12 @@ mod tests {
 
         let result = try_transform(&mut it).unwrap();
 
-        let mut expected_result = HashMap::<String, serde_json::Value>::new();
-        expected_result.insert("DST".to_string(), 2f64.into());
+        let mut expected_result = Map::new();
+        expected_result.insert("DST".to_string(), Value::from(2f64));
 
         assert_eq!(
             result,
-            StreamOption::Some(expected_result.clone()),
+            StreamOption::Some(Value::Object(expected_result.clone())),
         );
 
         let result_2 = try_transform(&mut it).unwrap();

--- a/tests/lenses/rust_wasm32_std_dev/src/lib.rs
+++ b/tests/lenses/rust_wasm32_std_dev/src/lib.rs
@@ -1,0 +1,117 @@
+use std::collections::HashMap;
+use std::sync::RwLock;
+use std::error::Error;
+use serde::Deserialize;
+use lens_sdk::StreamOption;
+use lens_sdk::error::LensError;
+
+lens_sdk::define!(PARAMETERS: Parameters, try_transform);
+
+#[derive(Deserialize, Clone)]
+pub struct Parameters {
+    pub src: String,
+    pub dst: String,
+}
+
+static PARAMETERS: RwLock<Option<Parameters>> = RwLock::new(None);
+
+fn try_transform(
+    iter: &mut dyn Iterator<Item = lens_sdk::Result<Option<HashMap<String, serde_json::Value>>>>,
+) -> Result<StreamOption<HashMap<String, serde_json::Value>>, Box<dyn Error>> {
+    let params = PARAMETERS.read()?
+        .clone()
+        .ok_or(LensError::ParametersNotSetError)?;
+
+    let mut values = Vec::<f64>::new();
+    for item in iter {
+        let mut input = match item? {
+            Some(v) => v,
+            None => break,
+        };
+        
+        let value = input.get_mut(&params.src)
+            .unwrap()
+            .clone();
+
+        values.push(value.as_u64().unwrap() as f64);
+    }
+
+    if values.len() == 0 {
+        return Ok(StreamOption::EndOfStream);
+    }
+
+    let mut sum = 0f64;
+    let count = values.len() as f64;
+    for v in &values {
+        sum = sum + v;
+    }
+
+    let mean = sum / count;
+
+    let mut sum_dev = 0f64;
+    for v in &values {
+        let dev = v - mean;
+        let dev_sqd = dev*dev;
+        sum_dev = sum_dev + dev_sqd;
+    }
+
+    let variance = sum_dev / count;
+    let std_dev = variance.sqrt();
+
+    let mut result = HashMap::<String, serde_json::Value>::new();
+    result.insert(params.dst, std_dev.into());
+
+    Ok(StreamOption::Some(result))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_try_transform_pass() {
+        let src_f = "SRC".to_string();
+        let mut ptr = PARAMETERS.write().unwrap();
+        *ptr = Some(Parameters{
+            src: src_f.clone(),
+            dst: "DST".to_string(),
+        });
+        drop(ptr);
+
+        let mut input_doc_1 = HashMap::<String, serde_json::Value>::new();
+        input_doc_1.insert(src_f.clone(), 10.into());
+        let mut input_doc_2 = HashMap::<String, serde_json::Value>::new();
+        input_doc_2.insert(src_f.clone(), 14.into());
+
+        let input = [
+            Ok(
+                Some(
+                    input_doc_1,
+                ),
+            ),
+            Ok(
+                Some(
+                    input_doc_2,
+                ),
+            ),
+        ];
+
+        let mut it = input.into_iter();
+
+        let result = try_transform(&mut it).unwrap();
+
+        let mut expected_result = HashMap::<String, serde_json::Value>::new();
+        expected_result.insert("DST".to_string(), 2f64.into());
+
+        assert_eq!(
+            result,
+            StreamOption::Some(expected_result.clone()),
+        );
+
+        let result_2 = try_transform(&mut it).unwrap();
+        assert_eq!(
+            result_2,
+            StreamOption::EndOfStream,
+        );
+    }
+}

--- a/tests/lenses/utils.go
+++ b/tests/lenses/utils.go
@@ -63,6 +63,15 @@ var FilterModulePath string = getPathRelativeToProjectRoot(
 	"/tests/lenses/rust_wasm32_filter/target/wasm32-unknown-unknown/debug/rust_wasm32_filter.wasm",
 )
 
+// StandardDeviationModulePath is the path to the `Standard deviation` lens module compiled to wasm.
+//
+// The module has two parameters:
+//   - `src` is a string and is the name of the property you wish to evaluate
+//   - `dst` is a string and is the name of the property you wish to write the standard deviation to.
+var StandardDeviationModulePath string = getPathRelativeToProjectRoot(
+	"/tests/lenses/rust_wasm32_std_dev/target/wasm32-unknown-unknown/debug/std_dev.wasm",
+)
+
 func getPathRelativeToProjectRoot(relativePath string) string {
 	_, filename, _, _ := runtime.Caller(0)
 	root := path.Dir(path.Dir(path.Dir(filename)))


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4133

## Description

Allow Lenses to pull docs from source, instead of pushing them in.  Allowing Lenses to correctly aggregate data. 