### PR TITLE
fix: Handle queries with _version prop and order param

### DIFF
--- a/internal/planner/multi.go
+++ b/internal/planner/multi.go
@@ -63,6 +63,7 @@ type parallelNode struct { // serialNode?
 	children     []planNode
 	childIndexes []int
 
+	source    planNode
 	multiscan *multiScanNode
 }
 
@@ -181,7 +182,7 @@ func (p *parallelNode) nextAppend(index int, plan planNode) (bool, error) {
 	return true, nil
 }
 
-func (p *parallelNode) Source() planNode { return p.multiscan }
+func (p *parallelNode) Source() planNode { return p.source }
 
 func (p *parallelNode) Children() []planNode {
 	return p.children
@@ -202,6 +203,7 @@ func (n *selectNode) addSubPlan(fieldIndex int, newPlan planNode) error {
 		case *dagScanNode:
 			m := &parallelNode{
 				p:         n.planner,
+				source:    newPlan,
 				docMapper: docMapper{n.source.DocumentMap()},
 			}
 			m.addChild(-1, n.source)
@@ -226,6 +228,7 @@ func (n *selectNode) addSubPlan(fieldIndex int, newPlan planNode) error {
 		parallelNode := &parallelNode{
 			p:         n.planner,
 			multiscan: multiscan,
+			source:    multiscan,
 			docMapper: docMapper{n.source.DocumentMap()},
 		}
 		parallelNode.addChild(-1, n.source)

--- a/tests/integration/query/simple/with_version_order_test.go
+++ b/tests/integration/query/simple/with_version_order_test.go
@@ -1,0 +1,74 @@
+// Copyright 2025 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package simple
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/defradb/tests/action"
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+func TestQuerySimpleWithVersionAndOrder(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddSchema{
+				Schema: `
+					type Users {
+						Name: String
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				DocMap: map[string]any{
+					"Name": "John",
+				},
+			},
+			testUtils.CreateDoc{
+				DocMap: map[string]any{
+					"Name": "Chris",
+				},
+			},
+			testUtils.Request{
+				Request: `query {
+					Users(order: {Name: ASC}) {
+						Name
+						_version {
+							fieldName
+						}
+					}
+				}`,
+				Results: map[string]any{
+					"Users": []map[string]any{
+						{
+							"Name": "Chris",
+							"_version": []map[string]any{
+								{
+									"fieldName": "_C",
+								},
+							},
+						},
+						{
+							"Name": "John",
+							"_version": []map[string]any{
+								{
+									"fieldName": "_C",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/query/simple/with_version_order_test.go
+++ b/tests/integration/query/simple/with_version_order_test.go
@@ -23,24 +23,24 @@ func TestQuerySimpleWithVersionAndOrder(t *testing.T) {
 			&action.AddSchema{
 				Schema: `
 					type Users {
-						Name: String
+						name: String
 					}
 				`,
 			},
 			testUtils.CreateDoc{
 				DocMap: map[string]any{
-					"Name": "John",
+					"name": "John",
 				},
 			},
 			testUtils.CreateDoc{
 				DocMap: map[string]any{
-					"Name": "Chris",
+					"name": "Chris",
 				},
 			},
 			testUtils.Request{
 				Request: `query {
-					Users(order: {Name: ASC}) {
-						Name
+					Users(order: {name: ASC}) {
+						name
 						_version {
 							fieldName
 						}
@@ -49,7 +49,7 @@ func TestQuerySimpleWithVersionAndOrder(t *testing.T) {
 				Results: map[string]any{
 					"Users": []map[string]any{
 						{
-							"Name": "Chris",
+							"name": "Chris",
 							"_version": []map[string]any{
 								{
 									"fieldName": "_C",
@@ -57,7 +57,7 @@ func TestQuerySimpleWithVersionAndOrder(t *testing.T) {
 							},
 						},
 						{
-							"Name": "John",
+							"name": "John",
 							"_version": []map[string]any{
 								{
 									"fieldName": "_C",


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4144

## Description

Handle queries with `_version` property and order parameter instead of panicing.

I also had a look at #1709 - it is still failing, but for very similar reasons, however the fix is proving to be a bit more involved, so I'm sorting that out in another PR.

#4021 was also looked at, it has a very easy fix, but is a separate issue, so I'm going to sort that separately too.