### PR TITLE
fix: Handle _version property in time travel queries

### DIFF
--- a/internal/planner/select.go
+++ b/internal/planner/select.go
@@ -446,18 +446,11 @@ func (n *selectNode) initFields(selectReq *mapper.Select) ([]aggregateNode, []*s
 				commitSlct := &mapper.CommitSelect{
 					Select: *f,
 				}
-				// handle _version sub selection query differently
-				// if we are executing a regular Scan query
-				// or a TimeTravel query.
+
 				if selectReq.Cid.HasValue() {
-					// for a TimeTravel query, we don't need the Latest
-					// commit. Instead, _version references the CID
-					// of that Target version we are querying.
-					// So instead of a LatestCommit subquery, we need
-					// a commits query with max depth starting from the
-					// target CID version
-					commitSlct.DocID = immutable.Some(selectReq.DocIDs.Value()[0]) // @todo check length
 					commitSlct.Cid = selectReq.Cid
+
+					// We want all the commits, so set the maximum depth
 					commitSlct.Depth = immutable.Some(uint64(math.MaxUint64))
 				}
 

--- a/tests/integration/query/simple/with_version_cid_doc_ids_test.go
+++ b/tests/integration/query/simple/with_version_cid_doc_ids_test.go
@@ -1,0 +1,159 @@
+// Copyright 2025 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package simple
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/defradb/tests/action"
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+func TestQuerySimpleWithVersionAndCidAndCorrectDocID(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddSchema{
+				Schema: `
+					type Users {
+						Name: String
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				DocMap: map[string]any{
+					"Name": "John",
+				},
+			},
+			testUtils.CreateDoc{
+				DocMap: map[string]any{
+					"Name": "Chris",
+				},
+			},
+			testUtils.Request{
+				Request: `query {
+					Users(cid: "bafyreihepwppwzqiig5taz3pm22ae5oi2b4amqzgyk37ruspe3cjbzs35q", docID: ["bae-97a6033e-d2b5-564d-828f-d5edd9d4d536"]) {
+						Name
+						_version {
+							fieldName
+						}
+					}
+				}`,
+				Results: map[string]any{
+					"Users": []map[string]any{
+						{
+							"Name": "Chris",
+							"_version": []map[string]any{
+								{
+									"fieldName": "_C",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestQuerySimpleWithVersionAndCidAndCorrectAndIncorrectDocID(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddSchema{
+				Schema: `
+					type Users {
+						Name: String
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				DocMap: map[string]any{
+					"Name": "John",
+				},
+			},
+			testUtils.CreateDoc{
+				DocMap: map[string]any{
+					"Name": "Chris",
+				},
+			},
+			testUtils.Request{
+				Request: `query {
+					Users(
+						cid: "bafyreihepwppwzqiig5taz3pm22ae5oi2b4amqzgyk37ruspe3cjbzs35q",
+						docID: ["bae-97a6033e-d2b5-564d-828f-d5edd9d4d536", "bae-fda35cb5-cd39-5d52-80b8-b324f2d7a8b0"]
+					) {
+						Name
+						_version {
+							fieldName
+						}
+					}
+				}`,
+				Results: map[string]any{
+					"Users": []map[string]any{
+						{
+							"Name": "Chris",
+							"_version": []map[string]any{
+								{
+									"fieldName": "_C",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestQuerySimpleWithVersionAndCidAndIncorrectDocID(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddSchema{
+				Schema: `
+					type Users {
+						Name: String
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				DocMap: map[string]any{
+					"Name": "John",
+				},
+			},
+			testUtils.CreateDoc{
+				DocMap: map[string]any{
+					"Name": "Chris",
+				},
+			},
+			testUtils.Request{
+				Request: `query {
+					Users(
+						cid: "bafyreihepwppwzqiig5taz3pm22ae5oi2b4amqzgyk37ruspe3cjbzs35q",
+						docID: ["bae-fda35cb5-cd39-5d52-80b8-b324f2d7a8b0"]
+					) {
+						Name
+						_version {
+							fieldName
+						}
+					}
+				}`,
+				Results: map[string]any{
+					"Users": []map[string]any{},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/query/simple/with_version_cid_test.go
+++ b/tests/integration/query/simple/with_version_cid_test.go
@@ -1,0 +1,66 @@
+// Copyright 2025 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package simple
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/defradb/tests/action"
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+func TestQuerySimpleWithVersionAndCid(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddSchema{
+				Schema: `
+					type Users {
+						Name: String
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				DocMap: map[string]any{
+					"Name": "John",
+				},
+			},
+			testUtils.CreateDoc{
+				DocMap: map[string]any{
+					"Name": "Chris",
+				},
+			},
+			testUtils.Request{
+				Request: `query {
+					Users(cid: "bafyreihepwppwzqiig5taz3pm22ae5oi2b4amqzgyk37ruspe3cjbzs35q") {
+						Name
+						_version {
+							fieldName
+						}
+					}
+				}`,
+				Results: map[string]any{
+					"Users": []map[string]any{
+						{
+							"Name": "Chris",
+							"_version": []map[string]any{
+								{
+									"fieldName": "_C",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4021

## Description

Handle the `_version` property in time travel queries.
