### PR TITLE
test: Enable all TestSignature tests for C client

### DIFF
--- a/tests/integration/signature/commit_test.go
+++ b/tests/integration/signature/commit_test.go
@@ -16,8 +16,6 @@ import (
 	"github.com/fxamacker/cbor/v2"
 	"github.com/onsi/gomega"
 
-	"github.com/sourcenetwork/immutable"
-
 	"github.com/sourcenetwork/defradb/crypto"
 	coreblock "github.com/sourcenetwork/defradb/internal/core/block"
 	"github.com/sourcenetwork/defradb/internal/core/crdt"
@@ -52,13 +50,6 @@ func TestSignature_WithCommitQuery_ShouldIncludeSignatureData(t *testing.T) {
 
 	test := testUtils.TestCase{
 		EnableSigning: true,
-		SupportedClientTypes: immutable.Some([]state.ClientType{
-			// C bindings do not support calling functions with non-Secp256k key yet
-			state.GoClientType,
-			state.CLIClientType,
-			state.HTTPClientType,
-			state.JSClientType,
-		}),
 		Actions: []any{
 			&action.AddSchema{
 				Schema: `
@@ -132,13 +123,6 @@ func TestSignature_WithUpdatedDocsAndCommitQuery_ShouldSignOnlyFirstFieldBlocks(
 
 	test := testUtils.TestCase{
 		EnableSigning: true,
-		SupportedClientTypes: immutable.Some([]state.ClientType{
-			// C bindings do not support calling functions with non-Secp256k key yet
-			state.GoClientType,
-			state.CLIClientType,
-			state.HTTPClientType,
-			state.JSClientType,
-		}),
 		Actions: []any{
 			&action.AddSchema{
 				Schema: `
@@ -237,13 +221,6 @@ func TestSignature_WithDeletedDocAndCommitQuery_ShouldIncludeSignatureData(t *te
 
 	test := testUtils.TestCase{
 		EnableSigning: true,
-		SupportedClientTypes: immutable.Some([]state.ClientType{
-			// C bindings do not support calling functions with non-Secp256k key yet
-			state.GoClientType,
-			state.CLIClientType,
-			state.HTTPClientType,
-			state.JSClientType,
-		}),
 		Actions: []any{
 			&action.AddSchema{
 				Schema: `
@@ -306,13 +283,6 @@ func TestSignature_WithEd25519KeyType_ShouldIncludeSignatureData(t *testing.T) {
 		IdentityTypes: map[state.Identity]crypto.KeyType{
 			testUtils.NodeIdentity(0).Value(): crypto.KeyTypeEd25519,
 		},
-		SupportedClientTypes: immutable.Some([]state.ClientType{
-			// C bindings do not support calling functions with non-Secp256k key yet
-			state.GoClientType,
-			state.CLIClientType,
-			state.HTTPClientType,
-			state.JSClientType,
-		}),
 		Actions: []any{
 			&action.AddSchema{
 				Schema: `


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4156 

## Description

The following tests were disabled for the C client, when they didn't need to be. The tests work as expected. This PR simply enables them.

`TestSignature_WithEd25519KeyType_ShouldIncludeSignatureData`
`TestSignature_WithDeletedDocAndCommitQuery_ShouldIncludeSignatureData`
`TestSignature_WithUpdatedDocsAndCommitQuery_ShouldSignOnlyFirstFieldBlocks`
`TestSignature_WithCommitQuery_ShouldIncludeSignatureData`

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [ ] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

(*replace*) Describe the tests performed to verify the changes. Provide instructions to reproduce them.

Specify the platform(s) on which this was tested:
- WSL
