### PR TITLE
chore: Utilize default db path if blank string passed in

### DIFF
--- a/cbindings/errors.go
+++ b/cbindings/errors.go
@@ -24,6 +24,7 @@ const (
 	errInvalidSubscriptionID        = "invalid subscription ID"
 	errGettingSubscription          = "could not retrieve subscription"
 	errInvalidCGOHandle             = "invalid handle"
+	errDatabasePathNotSet           = "database path not set, and home directory could not be determined"
 )
 
 func NewErrAmbiguousCollection() error {

--- a/cbindings/errors.go
+++ b/cbindings/errors.go
@@ -24,7 +24,6 @@ const (
 	errInvalidSubscriptionID        = "invalid subscription ID"
 	errGettingSubscription          = "could not retrieve subscription"
 	errInvalidCGOHandle             = "invalid handle"
-	errDatabasePathNotSet           = "database path not set, and home directory could not be determined"
 )
 
 func NewErrAmbiguousCollection() error {

--- a/cbindings/node.go
+++ b/cbindings/node.go
@@ -18,8 +18,6 @@ import "C"
 
 import (
 	"context"
-	"os"
-	"path/filepath"
 	"runtime/cgo"
 	"strconv"
 	"time"
@@ -42,23 +40,11 @@ func NewNode(cOptions C.NodeInitOptions) C.NewNodeResult {
 
 	ctx := context.Background()
 
-	// Use a database path if one is provided, otherwise try to determine the
-	// home directory and use that.
-	var defraPath string
-	if gocOptions.DbPath == "" {
-		home, err := os.UserHomeDir()
-		// This error should not happen on any major platform.
-		if err != nil {
-			return returnNewNodeResultC(1, errDatabasePathNotSet, nil)
-		}
-		defraPath = filepath.Join(home, ".defradb")
-	} else {
-		defraPath = gocOptions.DbPath
-	}
-
 	opts := []node.Option{
-		node.WithStorePath(defraPath),
 		db.WithLensRuntime(db.Wazero),
+	}
+	if gocOptions.DbPath != "" {
+		opts = append(opts, node.WithStorePath(gocOptions.DbPath))
 	}
 	if len(listeningAddresses) > 0 {
 		opts = append(opts, p2p.WithListenAddresses(listeningAddresses...))

--- a/cbindings/node.go
+++ b/cbindings/node.go
@@ -18,6 +18,8 @@ import "C"
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"runtime/cgo"
 	"strconv"
 	"time"
@@ -40,20 +42,22 @@ func NewNode(cOptions C.NodeInitOptions) C.NewNodeResult {
 
 	ctx := context.Background()
 
-	// // Create the directory if it doesn't exist, and inMemory flag is not set
-	// For now this is not done, but we leave it here because we might need it in
-	// the future, when running on mobile platforms.
-	// if !inMemoryFlag {
-	// 	if _, err = os.Stat(gocOptions.DbPath); os.IsNotExist(err) {
-	// 		err := os.MkdirAll(gocOptions.DbPath, 0755)
-	// 		if err != nil {
-	// 			return returnGoC(1, err.Error(), "")
-	// 		}
-	// 	}
-	// }
+	// Use a database path if one is provided, otherwise try to determine the
+	// home directory and use that.
+	var defraPath string
+	if gocOptions.DbPath == "" {
+		home, err := os.UserHomeDir()
+		// This errorshould not happen on any major platform.
+		if err != nil {
+			return returnNewNodeResultC(1, errDatabasePathNotSet, nil)
+		}
+		defraPath = filepath.Join(home, ".defradb")
+	} else {
+		defraPath = gocOptions.DbPath
+	}
 
 	opts := []node.Option{
-		node.WithStorePath(gocOptions.DbPath),
+		node.WithStorePath(defraPath),
 		db.WithLensRuntime(db.Wazero),
 	}
 	if len(listeningAddresses) > 0 {

--- a/cbindings/node.go
+++ b/cbindings/node.go
@@ -47,7 +47,7 @@ func NewNode(cOptions C.NodeInitOptions) C.NewNodeResult {
 	var defraPath string
 	if gocOptions.DbPath == "" {
 		home, err := os.UserHomeDir()
-		// This errorshould not happen on any major platform.
+		// This error should not happen on any major platform.
 		if err != nil {
 			return returnNewNodeResultC(1, errDatabasePathNotSet, nil)
 		}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4160 

## Description

Previously, the `CreateNode` function of the c bindings would return an error if the `inMemory` flag was set to 0, but the `dbPath` field was a blank string. This PR changes the behavior to rely on Go's `os.UserHomeDir()` function to create a `.defradb` directory in the home directory, instead of erroring out.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

(*replace*) Describe the tests performed to verify the changes. Provide instructions to reproduce them.

Specify the platform(s) on which this was tested:
- WSL
- Android
