### PR TITLE
fix: Handle _version alongside type joins

### DIFF
--- a/internal/planner/lens.go
+++ b/internal/planner/lens.go
@@ -204,7 +204,7 @@ func (e *nodeEnumerable) Next() (bool, error) {
 
 func (e *nodeEnumerable) Value() (map[string]any, error) {
 	doc := e.src.Value()
-	lensDoc := e.src.Source().DocumentMap().ToMap(doc)
+	lensDoc := e.src.DocumentMap().ToMap(doc)
 
 	return lensDoc, nil
 }

--- a/internal/planner/multi.go
+++ b/internal/planner/multi.go
@@ -81,6 +81,29 @@ func (p *parallelNode) Kind() string {
 }
 
 func (p *parallelNode) Init() error {
+	newChildren := make([]planNode, len(p.children))
+	newChildIndexes := make([]int, len(p.childIndexes))
+
+	endIndex := len(p.children) - 1
+	startIndex := 0
+	for i, child := range p.children {
+		switch child.(type) {
+		case *dagScanNode:
+			// Any node types that result in `nextAppend` calls must be executed last, as they are
+			// dependent on the docID set by the `nextMerge` calls.
+			newChildren[endIndex] = child
+			newChildIndexes[endIndex] = p.childIndexes[i]
+			endIndex--
+		default:
+			newChildren[startIndex] = child
+			newChildIndexes[startIndex] = p.childIndexes[i]
+			startIndex++
+		}
+	}
+
+	p.children = newChildren
+	p.childIndexes = newChildIndexes
+
 	return p.applyToPlans(func(n planNode) error {
 		return n.Init()
 	})
@@ -214,32 +237,33 @@ func (n *selectNode) addSubPlan(fieldIndex int, newPlan planNode) error {
 		}
 
 	case *typeIndexJoin:
+		var multiscan *multiScanNode
+		var source planNode
 		origScan, _ := walkAndFindPlanType[*scanNode](newPlan)
-		if origScan == nil {
-			return ErrFailedToFindScanNode
+		if origScan != nil {
+			multiscan = &multiScanNode{scanNode: origScan}
+			if err := n.planner.walkAndReplacePlan(n.source, origScan, multiscan); err != nil {
+				return err
+			}
+			if err := n.planner.walkAndReplacePlan(newPlan, origScan, multiscan); err != nil {
+				return err
+			}
+			multiscan.addReader()
+			multiscan.addReader()
+
+			source = multiscan
+		} else {
+			source = newPlan
 		}
-		// create our new multiscanner
-		multiscan := &multiScanNode{scanNode: origScan}
-		// replace our current source internal scanNode with our new multiscanner
-		if err := n.planner.walkAndReplacePlan(n.source, origScan, multiscan); err != nil {
-			return err
-		}
-		// create parallelNode
+
 		parallelNode := &parallelNode{
 			p:         n.planner,
 			multiscan: multiscan,
-			source:    multiscan,
+			source:    source,
 			docMapper: docMapper{n.source.DocumentMap()},
 		}
 		parallelNode.addChild(-1, n.source)
-		multiscan.addReader()
-		// replace our new node internal scanNode with our new multiscanner
-		if err := n.planner.walkAndReplacePlan(newPlan, origScan, multiscan); err != nil {
-			return err
-		}
-		// add our newly updated plan to the multinode
 		parallelNode.addChild(fieldIndex, newPlan)
-		multiscan.addReader()
 		n.source = parallelNode
 
 	// we already have an existing parallelNode as our source
@@ -247,14 +271,28 @@ func (n *selectNode) addSubPlan(fieldIndex int, newPlan planNode) error {
 		switch newPlan.(type) {
 		// We have a internal multiscanNode on our MultiNode
 		case *scanNode, *typeIndexJoin:
-			// replace our new node internal scanNode with our existing multiscanner
-			if err := n.planner.walkAndReplacePlan(newPlan, sourceNode.multiscan.Source(), sourceNode.multiscan); err != nil {
-				return err
+			if sourceNode.multiscan != nil {
+				if err := n.planner.walkAndReplacePlan(newPlan, sourceNode.multiscan.Source(), sourceNode.multiscan); err != nil {
+					return err
+				}
+				sourceNode.multiscan.addReader()
 			}
-			sourceNode.multiscan.addReader()
+		}
+
+		if _, ok := newPlan.(*typeIndexJoin); ok {
+			for i, child := range sourceNode.children {
+				if _, ok := child.(*scanNode); ok {
+					// `typeIndexJoin` contain the `scanNode`, so if the `scanNode` has already been added to the
+					// `parallelNode` it must be overwritten by the `typeIndexJoin` that wraps it.
+					sourceNode.children[i] = newPlan
+					sourceNode.childIndexes[i] = fieldIndex
+					return nil
+				}
+			}
 		}
 
 		sourceNode.addChild(fieldIndex, newPlan)
 	}
+
 	return nil
 }

--- a/internal/planner/multi.go
+++ b/internal/planner/multi.go
@@ -91,6 +91,10 @@ func (p *parallelNode) Init() error {
 		case *dagScanNode:
 			// Any node types that result in `nextAppend` calls must be executed last, as they are
 			// dependent on the docID set by the `nextMerge` calls.
+			//
+			// For example, there might be two children, a `scanNode` and a `dagScanNode`. As per the logic
+			// in `parallelNode.Next`, the `scanNode` must be executed before the `dagScanNode` as the
+			// `dagScanNode` uses the DocID yielded from the `scanNode`.
 			newChildren[endIndex] = child
 			newChildIndexes[endIndex] = p.childIndexes[i]
 			endIndex--

--- a/internal/planner/multi.go
+++ b/internal/planner/multi.go
@@ -198,7 +198,7 @@ func (n *selectNode) addSubPlan(fieldIndex int, newPlan planNode) error {
 	// if its a scan node, we either replace or create a multinode
 	case *scanNode, *pipeNode:
 		switch newPlan.(type) {
-		case *scanNode, *typeIndexJoin:
+		case *typeIndexJoin:
 			n.source = newPlan
 		case *dagScanNode:
 			m := &parallelNode{

--- a/tests/integration/query/one_to_one/with_version_test.go
+++ b/tests/integration/query/one_to_one/with_version_test.go
@@ -10,12 +10,14 @@
 
 package one_to_one
 
-// This test documents unwanted behaviour, see the linked ticket for more info:
-// https://github.com/sourcenetwork/defradb/issues/1709
-//
-// It is currently commented out because the panic is caught in the CLI and HTTP clients
-// and we have no good way atm to skip it.
-/*func TestQueryOneToOne_WithVersionOnOuter(t *testing.T) {
+import (
+	"testing"
+
+	"github.com/sourcenetwork/defradb/tests/action"
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+func TestQueryOneToOne_WithVersionOnOuterBeforeJoin(t *testing.T) {
 	test := testUtils.TestCase{
 		Actions: []any{
 			&action.AddSchema{
@@ -41,7 +43,72 @@ package one_to_one
 				CollectionID: 1,
 				Doc: `{
 					"name": "نمی دانم",
-					"published": "bae-c052eade-23f6-5ee3-8067-20004e746be3"
+					"published": "bae-7183862b-1638-5fc1-a3dd-b567fc1346e3"
+				}`,
+			},
+			testUtils.Request{
+				Request: `
+					query {
+						Book {
+							name
+							author {
+								name
+							}
+							_version {
+								docID
+							}
+						}
+					}
+				`,
+				Results: map[string]any{
+					"Book": []map[string]any{
+						{
+							"name": "فارسی دوم دبستان",
+							"_version": []map[string]any{
+								{
+									"docID": "bae-7183862b-1638-5fc1-a3dd-b567fc1346e3",
+								},
+							},
+							"author": map[string]any{
+								"name": "نمی دانم",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestQueryOneToOne_WithVersionOnOuterAfterJoin(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddSchema{
+				Schema: `
+					type Book {
+						name: String
+						author: Author
+					}
+
+					type Author {
+						name: String
+						published: Book @primary
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `{
+					"name": "فارسی دوم دبستان"
+				}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				Doc: `{
+					"name": "نمی دانم",
+					"published": "bae-7183862b-1638-5fc1-a3dd-b567fc1346e3"
 				}`,
 			},
 			testUtils.Request{
@@ -58,16 +125,18 @@ package one_to_one
 						}
 					}
 				`,
-				Results: []map[string]any{
-					{
-						"name": "نمی دانم",
-						"_version": []map[string]any{
-							{
-								"docID": "bae-c052eade-23f6-5ee3-8067-20004e746be3",
-							},
-						},
-						"author": map[string]any{
+				Results: map[string]any{
+					"Book": []map[string]any{
+						{
 							"name": "فارسی دوم دبستان",
+							"_version": []map[string]any{
+								{
+									"docID": "bae-7183862b-1638-5fc1-a3dd-b567fc1346e3",
+								},
+							},
+							"author": map[string]any{
+								"name": "نمی دانم",
+							},
 						},
 					},
 				},
@@ -75,8 +144,5 @@ package one_to_one
 		},
 	}
 
-	require.Panics(t,
-		func() { testUtils.ExecuteTestCase(t, test) },
-	)
+	testUtils.ExecuteTestCase(t, test)
 }
-*/


### PR DESCRIPTION
## Relevant issue(s)

Resolves #1709

## Description

Handles `_version` properties that exist alongside type joins.