### PR TITLE
docs: Switch git clone URL to use https

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ DISCLAIMER: The software is provided "as is" and is not guaranteed to be stable,
 Install `defradb` by [downloading an executable](https://github.com/sourcenetwork/defradb/releases) or building it locally using the [Go toolchain](https://golang.org/):
 
 ```sh
-git clone git@github.com:sourcenetwork/defradb.git
+git clone https://github.com/sourcenetwork/defradb.git
 cd defradb
 make install
 ```


### PR DESCRIPTION
in README, swapping out:

```
git clone git@github.com:sourcenetwork/defradb.git
```

for:

```
https://github.com/sourcenetwork/defradb.git
```

## Relevant issue(s)

Resolves #4176

## Description

The authenticated SSH URL requires a registered public-key, but that's only needed if you're later going to do git:write operations (contributions).

The README should be optimized to its natural default use-case, which is just a git:read operation for fetching and building. That's what the https:// URL provides.

## Tasks

- [X] I made sure the code is well commented, particularly hard-to-understand areas.
- [X] I made sure the repository-held documentation is changed accordingly.
- [X] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [X] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

n/a