### PR TITLE
refactor: Pass identity consistently in C binding functions

### DIFF
--- a/cbindings/collection.go
+++ b/cbindings/collection.go
@@ -85,9 +85,10 @@ func CollectionCreate(
 	isEncrypted C.int,
 	encryptedFields *C.char,
 	options C.CollectionOptions,
+	identityPtr C.uintptr_t,
 ) C.Result {
 	ctx := context.Background()
-	ctx, err := contextWithIdentity(ctx, options.identityPtr)
+	ctx, err := contextWithIdentity(ctx, identityPtr)
 	if err != nil {
 		return returnC(returnGoC(1, err.Error(), ""))
 	}
@@ -142,11 +143,16 @@ func CollectionCreate(
 }
 
 //export CollectionDelete
-func CollectionDelete(nodePtr C.uintptr_t, docIDStr *C.char, filterStr *C.char, options C.CollectionOptions) C.Result {
+func CollectionDelete(nodePtr C.uintptr_t,
+	docIDStr *C.char,
+	filterStr *C.char,
+	options C.CollectionOptions,
+	identityPtr C.uintptr_t,
+) C.Result {
 	ctx := context.Background()
 	colOptions := parseCollectionOptions(options)
 
-	ctx, err := contextWithIdentity(ctx, options.identityPtr)
+	ctx, err := contextWithIdentity(ctx, identityPtr)
 	if err != nil {
 		return returnC(returnGoC(1, err.Error(), ""))
 	}
@@ -193,11 +199,11 @@ func CollectionDelete(nodePtr C.uintptr_t, docIDStr *C.char, filterStr *C.char, 
 }
 
 //export CollectionDescribe
-func CollectionDescribe(nodePtr C.uintptr_t, options C.CollectionOptions) C.Result {
+func CollectionDescribe(nodePtr C.uintptr_t, options C.CollectionOptions, identityPtr C.uintptr_t) C.Result {
 	ctx := context.Background()
 	colOptions := parseCollectionOptions(options)
 
-	ctx, err := contextWithIdentity(ctx, options.identityPtr)
+	ctx, err := contextWithIdentity(ctx, identityPtr)
 	if err != nil {
 		return returnC(returnGoC(1, err.Error(), ""))
 	}
@@ -221,11 +227,11 @@ func CollectionDescribe(nodePtr C.uintptr_t, options C.CollectionOptions) C.Resu
 }
 
 //export CollectionListDocIDs
-func CollectionListDocIDs(nodePtr C.uintptr_t, options C.CollectionOptions) C.Result {
+func CollectionListDocIDs(nodePtr C.uintptr_t, options C.CollectionOptions, identityPtr C.uintptr_t) C.Result {
 	ctx := context.Background()
 	colOptions := parseCollectionOptions(options)
 
-	ctx, err := contextWithIdentity(ctx, options.identityPtr)
+	ctx, err := contextWithIdentity(ctx, identityPtr)
 	if err != nil {
 		return returnC(returnGoC(1, err.Error(), ""))
 	}
@@ -267,11 +273,16 @@ func CollectionListDocIDs(nodePtr C.uintptr_t, options C.CollectionOptions) C.Re
 }
 
 //export CollectionGet
-func CollectionGet(nodePtr C.uintptr_t, docIDStr *C.char, showDeleted C.int, options C.CollectionOptions) C.Result {
+func CollectionGet(nodePtr C.uintptr_t,
+	docIDStr *C.char,
+	showDeleted C.int,
+	options C.CollectionOptions,
+	identityPtr C.uintptr_t,
+) C.Result {
 	ctx := context.Background()
 	colOptions := parseCollectionOptions(options)
 
-	ctx, err := contextWithIdentity(ctx, options.identityPtr)
+	ctx, err := contextWithIdentity(ctx, identityPtr)
 	if err != nil {
 		return returnC(returnGoC(1, err.Error(), ""))
 	}
@@ -303,10 +314,13 @@ func CollectionGet(nodePtr C.uintptr_t, docIDStr *C.char, showDeleted C.int, opt
 }
 
 //export CollectionPatch
-func CollectionPatch(nodePtr C.uintptr_t, patch *C.char, lensConfig *C.char, options C.CollectionOptions) C.Result {
+func CollectionPatch(nodePtr C.uintptr_t,
+	patch *C.char, lensConfig *C.char,
+	identityPtr C.uintptr_t,
+) C.Result {
 	ctx := context.Background()
 
-	ctx, err := contextWithIdentity(ctx, options.identityPtr)
+	ctx, err := contextWithIdentity(ctx, identityPtr)
 	if err != nil {
 		return returnC(returnGoC(1, err.Error(), ""))
 	}
@@ -346,11 +360,12 @@ func CollectionUpdate(
 	filterStr *C.char,
 	updaterStr *C.char,
 	options C.CollectionOptions,
+	identityPtr C.uintptr_t,
 ) C.Result {
 	ctx := context.Background()
 	colOptions := parseCollectionOptions(options)
 
-	ctx, err := contextWithIdentity(ctx, options.identityPtr)
+	ctx, err := contextWithIdentity(ctx, identityPtr)
 	if err != nil {
 		return returnC(returnGoC(1, err.Error(), ""))
 	}
@@ -409,10 +424,10 @@ func CollectionUpdate(
 }
 
 //export SetActiveCollection
-func SetActiveCollection(nodePtr C.uintptr_t, options C.CollectionOptions) C.Result {
+func SetActiveCollection(nodePtr C.uintptr_t, options C.CollectionOptions, identityPtr C.uintptr_t) C.Result {
 	ctx := context.Background()
 
-	ctx, err := contextWithIdentity(ctx, options.identityPtr)
+	ctx, err := contextWithIdentity(ctx, identityPtr)
 	if err != nil {
 		return returnC(returnGoC(1, err.Error(), ""))
 	}

--- a/cbindings/defra_structs.h
+++ b/cbindings/defra_structs.h
@@ -31,7 +31,6 @@ typedef struct {
     const char* version;
     const char* collectionID;
     const char* name;
-    uintptr_t identityPtr;
     int getInactive;
 } CollectionOptions;
 

--- a/cbindings/index.go
+++ b/cbindings/index.go
@@ -30,9 +30,10 @@ func IndexCreate(
 	fieldsStr *C.char,
 	isUnique C.int,
 	options C.CollectionOptions,
+	identityPtr C.uintptr_t,
 ) C.Result {
 	ctx := context.Background()
-	ctx, err := contextWithIdentity(ctx, options.identityPtr)
+	ctx, err := contextWithIdentity(ctx, identityPtr)
 	if err != nil {
 		return returnC(returnGoC(1, err.Error(), ""))
 	}
@@ -87,10 +88,9 @@ func IndexCreate(
 }
 
 //export IndexList
-func IndexList(nodePtr C.uintptr_t, options C.CollectionOptions) C.Result {
+func IndexList(nodePtr C.uintptr_t, options C.CollectionOptions, identityPtr C.uintptr_t) C.Result {
 	ctx := context.Background()
-
-	ctx, err := contextWithIdentity(ctx, options.identityPtr)
+	ctx, err := contextWithIdentity(ctx, identityPtr)
 	if err != nil {
 		return returnC(returnGoC(1, err.Error(), ""))
 	}
@@ -124,9 +124,12 @@ func IndexList(nodePtr C.uintptr_t, options C.CollectionOptions) C.Result {
 }
 
 //export IndexDrop
-func IndexDrop(nodePtr C.uintptr_t, indexName *C.char, options C.CollectionOptions) C.Result {
+func IndexDrop(nodePtr C.uintptr_t,
+	indexName *C.char,
+	options C.CollectionOptions,
+	identityPtr C.uintptr_t) C.Result {
 	ctx := context.Background()
-	ctx, err := contextWithIdentity(ctx, options.identityPtr)
+	ctx, err := contextWithIdentity(ctx, identityPtr)
 	if err != nil {
 		return returnC(returnGoC(1, err.Error(), ""))
 	}

--- a/cbindings/wrapper.go
+++ b/cbindings/wrapper.go
@@ -28,12 +28,12 @@ char* relation, char* actor);
 extern Result ACPGetNACStatus(uintptr_t nodePtr, uintptr_t identity);
 extern Result BlockVerifySignature(uintptr_t nodePtr, char* keyType, char* publicKey, char* cid,
 uintptr_t identity);
-extern Result CollectionDescribe(uintptr_t nodePtr, CollectionOptions options);
-extern Result CollectionPatch(uintptr_t nodePtr, char* patch, char* lensConfig, CollectionOptions options);
+extern Result CollectionDescribe(uintptr_t nodePtr, CollectionOptions options, uintptr_t identityPtr);
+extern Result CollectionPatch(uintptr_t nodePtr, char* patch, char* lensConfig, uintptr_t identityPtr);
 extern Result IdentityNew(char* keyType);
 extern void IdentityFree(uintptr_t identityPtr);
 extern Result NodeIdentity(uintptr_t nodePtr);
-extern Result IndexList(uintptr_t nodePtr, CollectionOptions options);
+extern Result IndexList(uintptr_t nodePtr, CollectionOptions options, uintptr_t identityPtr);
 extern Result EncryptedIndexCreate(uintptr_t nodePtr, char* collectionName, char* fieldName);
 extern Result EncryptedIndexList(uintptr_t nodePtr, char* collectionName);
 extern Result EncryptedIndexDelete(uintptr_t nodePtr, char* collectionName, char* fieldName);
@@ -58,7 +58,7 @@ extern Result CloseSubscription(char* id);
 extern Result ExecuteQuery(uintptr_t nodePtr, char* query, uintptr_t identity,
 char* operationName, char* variables);
 extern Result AddSchema(uintptr_t nodePtr, char* schema, uintptr_t identity);
-extern Result SetActiveCollection(uintptr_t nodePtr, CollectionOptions options);
+extern Result SetActiveCollection(uintptr_t nodePtr, CollectionOptions options, uintptr_t identityPtr);
 extern NewTxnResult TransactionCreate(uintptr_t nodePtr, int isConcurrent, int isReadOnly);
 extern Result VersionGet(int flagFull, int flagJSON);
 extern Result ViewAdd(uintptr_t nodePtr, char* query, char* sdl, char* transformStr);
@@ -533,13 +533,6 @@ func (w *CWrapper) PatchCollection(
 	defer C.free(unsafe.Pointer(cName))
 	defer C.IdentityFree(cIdentity)
 
-	var opts C.CollectionOptions
-	opts.identityPtr = cIdentity
-	opts.version = cVersion
-	opts.collectionID = cCollectionID
-	opts.name = cName
-	opts.getInactive = 0
-
 	migrationStr, migrationErr := optionToString(migration)
 	if migrationErr != nil {
 		return migrationErr
@@ -548,7 +541,7 @@ func (w *CWrapper) PatchCollection(
 	defer C.free(unsafe.Pointer(cMigration))
 
 	callHandle := getNodeOrTxnHandle(w.handle, ctx)
-	res := ConvertAndFreeCResult(C.CollectionPatch(callHandle, cPatch, cMigration, opts))
+	res := ConvertAndFreeCResult(C.CollectionPatch(callHandle, cPatch, cMigration, cIdentity))
 
 	if res.Status != 0 {
 		return errors.New(res.Error)
@@ -568,14 +561,13 @@ func (w *CWrapper) SetActiveCollectionVersion(ctx context.Context, collectionVer
 	defer C.IdentityFree(cIdentity)
 
 	var opts C.CollectionOptions
-	opts.identityPtr = cIdentity
 	opts.version = cVersion
 	opts.collectionID = cCollectionID
 	opts.name = cName
 	opts.getInactive = 0
 
 	callHandle := getNodeOrTxnHandle(w.handle, ctx)
-	res := ConvertAndFreeCResult(C.SetActiveCollection(callHandle, opts))
+	res := ConvertAndFreeCResult(C.SetActiveCollection(callHandle, opts, cIdentity))
 
 	if res.Status != 0 {
 		return errors.New(res.Error)
@@ -718,11 +710,10 @@ func (w *CWrapper) GetCollections(
 	opts.version = cVersion
 	opts.collectionID = cCollectionID
 	opts.name = cName
-	opts.identityPtr = cIdentity
 	opts.getInactive = C.int(includeInactive)
 
 	callHandle := getNodeOrTxnHandle(w.handle, ctx)
-	res := ConvertAndFreeCResult(C.CollectionDescribe(callHandle, opts))
+	res := ConvertAndFreeCResult(C.CollectionDescribe(callHandle, opts, cIdentity))
 
 	if res.Status != 0 {
 		return []client.Collection{}, errors.New(res.Error)
@@ -754,11 +745,10 @@ func (w *CWrapper) GetAllIndexes(ctx context.Context) (map[client.CollectionName
 	opts.version = cVersion
 	opts.collectionID = cCollectionID
 	opts.name = cName
-	opts.identityPtr = cIdentity
 	opts.getInactive = 0
 
 	callHandle := getNodeOrTxnHandle(w.handle, ctx)
-	res := ConvertAndFreeCResult(C.IndexList(callHandle, opts))
+	res := ConvertAndFreeCResult(C.IndexList(callHandle, opts, cIdentity))
 
 	if res.Status != 0 {
 		return nil, errors.New(res.Error)

--- a/cbindings/wrapper_collection.go
+++ b/cbindings/wrapper_collection.go
@@ -15,16 +15,19 @@ package cbindings
 #include <stdint.h>
 #include "defra_structs.h"
 extern Result CollectionCreate(uintptr_t nodePtr, char* json, int isEncrypted,
-char* encryptedFields, CollectionOptions options);
-extern Result CollectionDelete(uintptr_t nodePtr, char* docIDStr, char* filterStr, CollectionOptions options);
-extern Result CollectionDescribe(uintptr_t nodePtr, CollectionOptions options);
-extern Result CollectionListDocIDs(uintptr_t nodePtr, CollectionOptions options);
-extern Result CollectionGet(uintptr_t nodePtr, char* docIDStr, int showDeleted, CollectionOptions options);
+char* encryptedFields, CollectionOptions options, uintptr_t identityPtr);
+extern Result CollectionDelete(uintptr_t nodePtr, char* docIDStr, char* filterStr,
+CollectionOptions options, uintptr_t identityPtr);
+extern Result CollectionDescribe(uintptr_t nodePtr, CollectionOptions options, uintptr_t identityPtr);
+extern Result CollectionListDocIDs(uintptr_t nodePtr, CollectionOptions options, uintptr_t identityPtr);
+extern Result CollectionGet(uintptr_t nodePtr, char* docIDStr, int showDeleted,
+CollectionOptions options, uintptr_t identityPtr);
 extern Result CollectionUpdate(uintptr_t nodePtr, char* docIDStr, char* filterStr,
-char* updaterStr, CollectionOptions options);
-extern Result IndexCreate(uintptr_t nodePtr, char* indexName, char* fieldsStr, int isUnique, CollectionOptions options);
-extern Result IndexList(uintptr_t nodePtr, CollectionOptions options);
-extern Result IndexDrop(uintptr_t nodePtr, char* indexName, CollectionOptions options);
+char* updaterStr, CollectionOptions options, uintptr_t identityPtr);
+extern Result IndexCreate(uintptr_t nodePtr, char* indexName, char* fieldsStr, int isUnique,
+CollectionOptions options, uintptr_t identityPtr);
+extern Result IndexList(uintptr_t nodePtr, CollectionOptions options, uintptr_t identityPtr);
+extern Result IndexDrop(uintptr_t nodePtr, char* indexName, CollectionOptions options, uintptr_t identityPtr);
 extern Result EncryptedIndexCreate(uintptr_t nodePtr, char* collectionName, char* fieldName);
 extern Result EncryptedIndexList(uintptr_t nodePtr, char* collectionName);
 extern Result EncryptedIndexDelete(uintptr_t nodePtr, char* collectionName, char* fieldName);
@@ -88,7 +91,6 @@ func (c *Collection) Create(
 	copts.version = cVersion
 	copts.collectionID = cCollectionID
 	copts.name = cName
-	copts.identityPtr = cIdentity
 	copts.getInactive = 0
 
 	docJSONbytes, err := doc.MarshalJSON()
@@ -104,6 +106,7 @@ func (c *Collection) Create(
 		isEncrypted,
 		encryptedFields,
 		copts,
+		cIdentity,
 	))
 
 	if res.Status != 0 {
@@ -136,7 +139,6 @@ func (c *Collection) CreateMany(
 	copts.version = cVersion
 	copts.collectionID = cCollectionID
 	copts.name = cName
-	copts.identityPtr = cIdentity
 	copts.getInactive = 0
 
 	var jsonDocs []json.RawMessage
@@ -160,6 +162,7 @@ func (c *Collection) CreateMany(
 		isEncrypted,
 		encryptedFields,
 		copts,
+		cIdentity,
 	))
 
 	if res.Status != 0 {
@@ -198,7 +201,6 @@ func (c *Collection) Update(
 	copts.version = cVersion
 	copts.collectionID = cCollectionID
 	copts.name = cName
-	copts.identityPtr = cIdentity
 	copts.getInactive = 0
 
 	res := ConvertAndFreeCResult(C.CollectionUpdate(
@@ -207,6 +209,7 @@ func (c *Collection) Update(
 		filter,
 		updater,
 		copts,
+		cIdentity,
 	))
 
 	if res.Status != 0 {
@@ -253,7 +256,6 @@ func (c *Collection) Delete(
 	copts.version = cVersion
 	copts.collectionID = cCollectionID
 	copts.name = cName
-	copts.identityPtr = cIdentity
 	copts.getInactive = 0
 
 	res := ConvertAndFreeCResult(C.CollectionDelete(
@@ -261,6 +263,7 @@ func (c *Collection) Delete(
 		docIDStr,
 		filter,
 		copts,
+		cIdentity,
 	))
 
 	if res.Status != 0 {
@@ -290,7 +293,6 @@ func (c *Collection) Exists(
 	copts.version = cVersion
 	copts.collectionID = cCollectionID
 	copts.name = cName
-	copts.identityPtr = cIdentity
 	copts.getInactive = 0
 
 	res := ConvertAndFreeCResult(C.CollectionGet(
@@ -298,6 +300,7 @@ func (c *Collection) Exists(
 		docIDStr,
 		cShowDeleted,
 		copts,
+		cIdentity,
 	))
 
 	if res.Status != 0 {
@@ -334,7 +337,6 @@ func (c *Collection) UpdateWithFilter(
 	copts.version = cVersion
 	copts.collectionID = cCollectionID
 	copts.name = cName
-	copts.identityPtr = cIdentity
 	copts.getInactive = 0
 
 	res := ConvertAndFreeCResult(C.CollectionUpdate(
@@ -343,6 +345,7 @@ func (c *Collection) UpdateWithFilter(
 		filterStr,
 		cUpdater,
 		copts,
+		cIdentity,
 	))
 
 	if res.Status != 0 {
@@ -383,7 +386,6 @@ func (c *Collection) DeleteWithFilter(
 	copts.version = cVersion
 	copts.collectionID = cCollectionID
 	copts.name = cName
-	copts.identityPtr = cIdentity
 	copts.getInactive = 0
 
 	res := ConvertAndFreeCResult(C.CollectionDelete(
@@ -391,6 +393,7 @@ func (c *Collection) DeleteWithFilter(
 		docID,
 		filterStr,
 		copts,
+		cIdentity,
 	))
 
 	if res.Status != 0 {
@@ -430,7 +433,6 @@ func (c *Collection) Get(
 	copts.version = cVersion
 	copts.collectionID = cCollectionID
 	copts.name = cName
-	copts.identityPtr = cIdentity
 	copts.getInactive = 0
 
 	res := ConvertAndFreeCResult(C.CollectionGet(
@@ -438,6 +440,7 @@ func (c *Collection) Get(
 		docIDStr,
 		cShowDeleted,
 		copts,
+		cIdentity,
 	))
 
 	if res.Status != 0 {
@@ -473,10 +476,9 @@ func (c *Collection) GetAllDocIDs(
 	copts.version = cVersion
 	copts.collectionID = cCollectionID
 	copts.name = cName
-	copts.identityPtr = cIdentity
 	copts.getInactive = 0
 
-	res := ConvertAndFreeCResult(C.CollectionListDocIDs(C.uintptr_t(c.w.handle), copts))
+	res := ConvertAndFreeCResult(C.CollectionListDocIDs(C.uintptr_t(c.w.handle), copts, cIdentity))
 
 	if res.Status != 0 {
 		return nil, errors.New(res.Error)
@@ -535,7 +537,6 @@ func (c *Collection) CreateIndex(
 	copts.version = cVersion
 	copts.collectionID = cCollectionID
 	copts.name = cName
-	copts.identityPtr = cIdentity
 	copts.getInactive = 0
 
 	orderedFields := make([]string, len(indexDesc.Fields))
@@ -560,6 +561,7 @@ func (c *Collection) CreateIndex(
 		fields,
 		cUnique,
 		copts,
+		cIdentity,
 	))
 
 	if res.Status != 0 {
@@ -590,13 +592,13 @@ func (c *Collection) DropIndex(ctx context.Context, indexName string) error {
 	copts.version = cVersion
 	copts.collectionID = cCollectionID
 	copts.name = cName
-	copts.identityPtr = cIdentity
 	copts.getInactive = 0
 
 	res := ConvertAndFreeCResult(C.IndexDrop(
 		C.uintptr_t(c.w.handle),
 		cIndexName,
 		copts,
+		cIdentity,
 	))
 
 	if res.Status != 0 {
@@ -622,10 +624,9 @@ func (c *Collection) GetIndexes(ctx context.Context) ([]client.IndexDescription,
 	copts.version = cVersion
 	copts.collectionID = cCollectionID
 	copts.name = cName
-	copts.identityPtr = cIdentity
 	copts.getInactive = 0
 
-	res := ConvertAndFreeCResult(C.IndexList(C.uintptr_t(c.w.handle), copts))
+	res := ConvertAndFreeCResult(C.IndexList(C.uintptr_t(c.w.handle), copts, cIdentity))
 
 	if res.Status != 0 {
 		return []client.IndexDescription{}, errors.New(res.Error)


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4179 

## Description

There were some spots across the c binding code that passed in identity pointers as raw `uintptr_t` values. However, there were other spots that passed in identity as a parameter in the `CollectionOptions` struct. This PR brings consistency by making sure we always pass it in by pointer. It removes the `identityPtr` field from the struct entirely. 

This change results in various changes needing to be made to the integration test wrapper, so this PR also takes care of that.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Specify the platform(s) on which this was tested:
- WSL
