### PR TITLE
fix: Make node apply a default store path

### DIFF
--- a/cbindings/node.go
+++ b/cbindings/node.go
@@ -40,21 +40,11 @@ func NewNode(cOptions C.NodeInitOptions) C.NewNodeResult {
 
 	ctx := context.Background()
 
-	// // Create the directory if it doesn't exist, and inMemory flag is not set
-	// For now this is not done, but we leave it here because we might need it in
-	// the future, when running on mobile platforms.
-	// if !inMemoryFlag {
-	// 	if _, err = os.Stat(gocOptions.DbPath); os.IsNotExist(err) {
-	// 		err := os.MkdirAll(gocOptions.DbPath, 0755)
-	// 		if err != nil {
-	// 			return returnGoC(1, err.Error(), "")
-	// 		}
-	// 	}
-	// }
-
 	opts := []node.Option{
-		node.WithStorePath(gocOptions.DbPath),
 		db.WithLensRuntime(db.Wazero),
+	}
+	if gocOptions.DbPath != "" {
+		opts = append(opts, node.WithStorePath(gocOptions.DbPath))
 	}
 	if len(listeningAddresses) > 0 {
 		opts = append(opts, p2p.WithListenAddresses(listeningAddresses...))

--- a/cbindings/node.go
+++ b/cbindings/node.go
@@ -40,11 +40,21 @@ func NewNode(cOptions C.NodeInitOptions) C.NewNodeResult {
 
 	ctx := context.Background()
 
+	// // Create the directory if it doesn't exist, and inMemory flag is not set
+	// For now this is not done, but we leave it here because we might need it in
+	// the future, when running on mobile platforms.
+	// if !inMemoryFlag {
+	// 	if _, err = os.Stat(gocOptions.DbPath); os.IsNotExist(err) {
+	// 		err := os.MkdirAll(gocOptions.DbPath, 0755)
+	// 		if err != nil {
+	// 			return returnGoC(1, err.Error(), "")
+	// 		}
+	// 	}
+	// }
+
 	opts := []node.Option{
+		node.WithStorePath(gocOptions.DbPath),
 		db.WithLensRuntime(db.Wazero),
-	}
-	if gocOptions.DbPath != "" {
-		opts = append(opts, node.WithStorePath(gocOptions.DbPath))
 	}
 	if len(listeningAddresses) > 0 {
 		opts = append(opts, p2p.WithListenAddresses(listeningAddresses...))

--- a/cli/utils.go
+++ b/cli/utils.go
@@ -16,7 +16,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -32,6 +31,7 @@ import (
 	"github.com/sourcenetwork/defradb/http"
 	"github.com/sourcenetwork/defradb/internal/datastore"
 	"github.com/sourcenetwork/defradb/keyring"
+	"github.com/sourcenetwork/defradb/node"
 )
 
 const (
@@ -172,11 +172,7 @@ func setContextRootDir(cmd *cobra.Command) error {
 		return err
 	}
 	if rootdir == "" {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return err
-		}
-		rootdir = filepath.Join(home, ".defradb")
+		rootdir = node.GetDefaultStorePath()
 	}
 	ctx := context.WithValue(cmd.Context(), rootDirContextKey, rootdir)
 	cmd.SetContext(ctx)

--- a/node/store.go
+++ b/node/store.go
@@ -12,6 +12,8 @@ package node
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 
 	"github.com/sourcenetwork/corekv"
 )
@@ -46,9 +48,22 @@ type StoreOptions struct {
 	badgerInMemory      bool
 }
 
+// GetDefaultStorePath is a helper function that returns '$HOME/.defradb', but which
+// relies on Go to handle the platform-specific path resolution.
+func GetDefaultStorePath() string {
+	home, err := os.UserHomeDir()
+	// This should never error on any major platform. But if it does, as a fallback,
+	// we will leave the root directory path blank.
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".defradb")
+}
+
 // DefaultStoreOptions returns new options with default values.
 func DefaultStoreOptions() *StoreOptions {
 	return &StoreOptions{
+		path:           GetDefaultStorePath(),
 		badgerInMemory: false,
 		badgerFileSize: 1 << 30,
 	}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4184

## Description

If a Defra node was created without the `node.WithStorePath` option, the default store path, `$HOME/.defradb`, would never actually get set. The `cli` package did contain a function, `setContextRootDir` which set such a path in its context, but this logic was unique to that package. This PR changes this by creating a new function in the `node` package, `GetDefaultStorePath`. This function is used by the `DefaultStoreOptions` function, to apply the default value to the `path` field. Additionally, this function is called by the CLI inside the `setContextRootDir` function so as not to break any of the ways context is passed around or used, while also making sure the logic remains consistent across clients, without ever being repeated in different locations.

One note, is that this PR does not yet adjust how the way in which the C bindings package pass in the `node.WithStorePath` option to the new node. The reason for this, is that a PR already exists for exactly that issue. Presumably, it can be closed and merged after this one gets merged and closed.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

I used the C bindings on WSL and on Android, and the CLI with WSL.

Specify the platform(s) on which this was tested:
- WSL
- Android
