### PR TITLE
feat: Add secp256r1 support

### DIFF
--- a/crypto/keys.go
+++ b/crypto/keys.go
@@ -194,11 +194,30 @@ func PublicKeyFromString(keyType KeyType, keyString string) (PublicKey, error) {
 				Y:     nil,
 			}
 		} else if len(keyBytes) == 65 {
-			pubKey, err := ecdsa.ParseUncompressedPublicKey(elliptic.P256(), keyBytes)
+			if keyBytes[0] != 0x04 {
+				return nil, ErrInvalidECDSAPubKey
+			}
+			_, err := ecdh.P256().NewPublicKey(keyBytes)
 			if err != nil {
 				return nil, ErrInvalidECDSAPubKey
 			}
-			compressedBytes = elliptic.MarshalCompressed(elliptic.P256(), pubKey.X, pubKey.Y)
+			if len(keyBytes) != 65 {
+				return nil, ErrInvalidECDSAPubKey
+			}
+			x := new(big.Int).SetBytes(keyBytes[1:33])
+			y := new(big.Int).SetBytes(keyBytes[33:65])
+			pubKey = &ecdsa.PublicKey{
+				Curve: elliptic.P256(),
+				X:     x,
+				Y:     y,
+			}
+			compressedBytes = elliptic.MarshalCompressed(elliptic.P256(), x, y)
+			// TODO: use this approach after upgrading to Go v1.25+
+			// pubKey, err := ecdsa.ParseUncompressedPublicKey(elliptic.P256(), keyBytes)
+			// if err != nil {
+			// 	return nil, ErrInvalidECDSAPubKey
+			// }
+			// compressedBytes = elliptic.MarshalCompressed(elliptic.P256(), pubKey.X, pubKey.Y)
 		} else {
 			return nil, ErrInvalidECDSAPubKey
 		}

--- a/crypto/keys.go
+++ b/crypto/keys.go
@@ -373,7 +373,9 @@ func (k *secp256r1PrivateKey) Equal(other Key) bool {
 }
 
 func (k *secp256r1PrivateKey) Raw() []byte {
-	return k.key.D.Bytes()
+	buf := make([]byte, 32)
+	k.key.D.FillBytes(buf)
+	return buf
 }
 
 func (k *secp256r1PrivateKey) Type() KeyType {
@@ -381,7 +383,7 @@ func (k *secp256r1PrivateKey) Type() KeyType {
 }
 
 func (k *secp256r1PrivateKey) String() string {
-	return hex.EncodeToString(k.key.D.Bytes())
+	return hex.EncodeToString(k.Raw())
 }
 
 func (k *secp256r1PrivateKey) Sign(data []byte) ([]byte, error) {

--- a/crypto/keys.go
+++ b/crypto/keys.go
@@ -108,6 +108,11 @@ type secp256r1PublicKey struct {
 	compressedBytes []byte
 }
 
+// secp256r1PrivateKey wraps ecdsa.PrivateKey to implement PrivateKey interface
+type secp256r1PrivateKey struct {
+	key *ecdsa.PrivateKey
+}
+
 // NewPrivateKey creates a new private key of a specific type based on the input
 func NewPrivateKey[T *secp256k1.PrivateKey | *ecdsa.PrivateKey | ed25519.PrivateKey](key T) PrivateKey {
 	switch k := any(key).(type) {
@@ -117,8 +122,10 @@ func NewPrivateKey[T *secp256k1.PrivateKey | *ecdsa.PrivateKey | ed25519.Private
 		}
 		return &secp256k1PrivateKey{key: k}
 	case *ecdsa.PrivateKey:
-		// Private keys for secp256r1 are not supported
-		return nil
+		if k == nil || k.Curve != elliptic.P256() {
+			return nil
+		}
+		return &secp256r1PrivateKey{key: k}
 	case ed25519.PrivateKey:
 		if k == nil || len(k) != ed25519.PrivateKeySize {
 			return nil
@@ -187,24 +194,11 @@ func PublicKeyFromString(keyType KeyType, keyString string) (PublicKey, error) {
 				Y:     nil,
 			}
 		} else if len(keyBytes) == 65 {
-			if keyBytes[0] != 0x04 {
-				return nil, ErrInvalidECDSAPubKey
-			}
-			_, err := ecdh.P256().NewPublicKey(keyBytes)
+			pubKey, err := ecdsa.ParseUncompressedPublicKey(elliptic.P256(), keyBytes)
 			if err != nil {
 				return nil, ErrInvalidECDSAPubKey
 			}
-			if len(keyBytes) != 65 {
-				return nil, ErrInvalidECDSAPubKey
-			}
-			x := new(big.Int).SetBytes(keyBytes[1:33])
-			y := new(big.Int).SetBytes(keyBytes[33:65])
-			pubKey = &ecdsa.PublicKey{
-				Curve: elliptic.P256(),
-				X:     x,
-				Y:     y,
-			}
-			compressedBytes = elliptic.MarshalCompressed(elliptic.P256(), x, y)
+			compressedBytes = elliptic.MarshalCompressed(elliptic.P256(), pubKey.X, pubKey.Y)
 		} else {
 			return nil, ErrInvalidECDSAPubKey
 		}
@@ -352,6 +346,42 @@ func (k *ed25519PublicKey) Underlying() any {
 	return k.key
 }
 
+func (k *secp256r1PrivateKey) Equal(other Key) bool {
+	if other.Type() != KeyTypeSecp256r1 {
+		return false
+	}
+	return bytes.Equal(k.Raw(), other.Raw())
+}
+
+func (k *secp256r1PrivateKey) Raw() []byte {
+	return k.key.D.Bytes()
+}
+
+func (k *secp256r1PrivateKey) Type() KeyType {
+	return KeyTypeSecp256r1
+}
+
+func (k *secp256r1PrivateKey) String() string {
+	return hex.EncodeToString(k.key.D.Bytes())
+}
+
+func (k *secp256r1PrivateKey) Sign(data []byte) ([]byte, error) {
+	hash := sha256.Sum256(data)
+	signature, err := ecdsa.SignASN1(rand.Reader, k.key, hash[:])
+	if err != nil {
+		return nil, err
+	}
+	return signature, nil
+}
+
+func (k *secp256r1PrivateKey) GetPublic() PublicKey {
+	return NewPublicKey(&k.key.PublicKey)
+}
+
+func (k *secp256r1PrivateKey) Underlying() any {
+	return k.key
+}
+
 // PrivateKeyFromBytes creates a private key from raw bytes and key type.
 // This is useful for deserializing private keys.
 func PrivateKeyFromBytes(keyType KeyType, keyBytes []byte) (PrivateKey, error) {
@@ -364,8 +394,28 @@ func PrivateKeyFromBytes(keyType KeyType, keyBytes []byte) (PrivateKey, error) {
 		return &secp256k1PrivateKey{key: privKey}, nil
 
 	case KeyTypeSecp256r1:
-		// Private keys for secp256r1 are not supported
-		return nil, NewErrUnsupportedKeyType(keyType)
+		if len(keyBytes) != 32 {
+			return nil, ErrInvalidECDSAPrivKeyBytes
+		}
+		ecdhPrivKey, err := ecdh.P256().NewPrivateKey(keyBytes)
+		if err != nil {
+			return nil, err
+		}
+		pubKeyBytes := ecdhPrivKey.PublicKey().Bytes()
+		privKey := &ecdsa.PrivateKey{
+			D: new(big.Int).SetBytes(keyBytes),
+			PublicKey: ecdsa.PublicKey{
+				Curve: elliptic.P256(),
+				X:     new(big.Int).SetBytes(pubKeyBytes[1:33]),
+				Y:     new(big.Int).SetBytes(pubKeyBytes[33:65]),
+			},
+		}
+		// TODO: use this approach after upgrading to Go v1.25+
+		// privKey, err := ecdsa.ParseRawPrivateKey(elliptic.P256(), keyBytes)
+		// if err != nil {
+		// 	return nil, err
+		// }
+		return &secp256r1PrivateKey{key: privKey}, nil
 
 	case KeyTypeEd25519:
 		if len(keyBytes) != ed25519.PrivateKeySize {
@@ -399,8 +449,11 @@ func GenerateKey(keyType KeyType) (PrivateKey, error) {
 		}
 		return NewPrivateKey(key), nil
 	case KeyTypeSecp256r1:
-		// Private keys for secp256r1 are not supported
-		return nil, NewErrUnsupportedKeyType(keyType)
+		key, err := GenerateSecp256r1()
+		if err != nil {
+			return nil, err
+		}
+		return NewPrivateKey(key), nil
 	case KeyTypeEd25519:
 		key, err := GenerateEd25519()
 		if err != nil {
@@ -423,6 +476,11 @@ func GenerateEd25519() (ed25519.PrivateKey, error) {
 	return priv, err
 }
 
+// GenerateSecp256r1 generates a new secp256r1 (P-256) private key.
+func GenerateSecp256r1() (*ecdsa.PrivateKey, error) {
+	return ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+}
+
 // secp256r1PublicKey implementations
 func (k *secp256r1PublicKey) Equal(other Key) bool {
 	if other.Type() != KeyTypeSecp256r1 {
@@ -440,8 +498,24 @@ func (k *secp256r1PublicKey) Type() KeyType {
 }
 
 func (k *secp256r1PublicKey) Verify(data []byte, sig []byte) (bool, error) {
-	// secp256r1 public keys do not support verification
-	return false, NewErrUnsupportedKeyType(KeyTypeSecp256r1)
+	pubKey := k.key
+	if pubKey.Y == nil {
+		if len(k.compressedBytes) != 33 {
+			return false, ErrInvalidECDSAPubKey
+		}
+		x, y := elliptic.UnmarshalCompressed(elliptic.P256(), k.compressedBytes)
+		if x == nil || y == nil {
+			return false, ErrInvalidECDSAPubKey
+		}
+		pubKey = &ecdsa.PublicKey{
+			Curve: elliptic.P256(),
+			X:     x,
+			Y:     y,
+		}
+	}
+	hash := sha256.Sum256(data)
+	valid := ecdsa.VerifyASN1(pubKey, hash[:], sig)
+	return valid, nil
 }
 
 func (k *secp256r1PublicKey) String() string {

--- a/crypto/keys.go
+++ b/crypto/keys.go
@@ -212,7 +212,7 @@ func PublicKeyFromString(keyType KeyType, keyString string) (PublicKey, error) {
 				Y:     y,
 			}
 			compressedBytes = elliptic.MarshalCompressed(elliptic.P256(), x, y)
-			// TODO: use this approach after upgrading to Go v1.25+
+			// TODO: use this approach after upgrading to Go v1.25+ (https://github.com/sourcenetwork/defradb/issues/4205)
 			// pubKey, err := ecdsa.ParseUncompressedPublicKey(elliptic.P256(), keyBytes)
 			// if err != nil {
 			// 	return nil, ErrInvalidECDSAPubKey
@@ -429,7 +429,7 @@ func PrivateKeyFromBytes(keyType KeyType, keyBytes []byte) (PrivateKey, error) {
 				Y:     new(big.Int).SetBytes(pubKeyBytes[33:65]),
 			},
 		}
-		// TODO: use this approach after upgrading to Go v1.25+
+		// TODO: use this approach after upgrading to Go v1.25+ (https://github.com/sourcenetwork/defradb/issues/4205)
 		// privKey, err := ecdsa.ParseRawPrivateKey(elliptic.P256(), keyBytes)
 		// if err != nil {
 		// 	return nil, err

--- a/crypto/keys_test.go
+++ b/crypto/keys_test.go
@@ -586,9 +586,8 @@ func TestSecp256r1_Verify(t *testing.T) {
 	require.NoError(t, err)
 
 	valid, err := wrappedPubKey.Verify(message, sig)
-	assert.Error(t, err)
-	assert.False(t, valid)
-	assert.ErrorIs(t, err, NewErrUnsupportedKeyType(KeyTypeSecp256r1))
+	assert.NoError(t, err)
+	assert.True(t, valid)
 }
 
 func TestSecp256r1_DID(t *testing.T) {
@@ -668,34 +667,55 @@ func TestPublicKeyFromString_InvalidSecp256r1UncompressedPrefix(t *testing.T) {
 	assert.Equal(t, ErrInvalidECDSAPubKey, err)
 }
 
-func TestPrivateKeyFromBytes_Secp256r1NotSupported(t *testing.T) {
-	parsedKey, err := PrivateKeyFromBytes(KeyTypeSecp256r1, make([]byte, 32))
-	assert.Error(t, err)
-	assert.Nil(t, parsedKey)
-	assert.ErrorIs(t, err, NewErrUnsupportedKeyType(KeyTypeSecp256r1))
+func TestPrivateKeyFromBytes_Secp256r1(t *testing.T) {
+	privKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	keyBytes := privKey.D.Bytes()
+	if len(keyBytes) < 32 {
+		padded := make([]byte, 32)
+		copy(padded[32-len(keyBytes):], keyBytes)
+		keyBytes = padded
+	}
+
+	parsedKey, err := PrivateKeyFromBytes(KeyTypeSecp256r1, keyBytes)
+	require.NoError(t, err)
+	require.NotNil(t, parsedKey)
+	assert.Equal(t, KeyTypeSecp256r1, parsedKey.Type())
 }
 
-func TestPrivateKeyFromString_Secp256r1NotSupported(t *testing.T) {
-	keyString := hex.EncodeToString(make([]byte, 32))
+func TestPrivateKeyFromString_Secp256r1(t *testing.T) {
+	privKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	keyBytes := privKey.D.Bytes()
+	if len(keyBytes) < 32 {
+		padded := make([]byte, 32)
+		copy(padded[32-len(keyBytes):], keyBytes)
+		keyBytes = padded
+	}
+
+	keyString := hex.EncodeToString(keyBytes)
 	parsedKey, err := PrivateKeyFromString(KeyTypeSecp256r1, keyString)
-	assert.Error(t, err)
-	assert.Nil(t, parsedKey)
-	assert.ErrorIs(t, err, NewErrUnsupportedKeyType(KeyTypeSecp256r1))
+	require.NoError(t, err)
+	require.NotNil(t, parsedKey)
+	assert.Equal(t, KeyTypeSecp256r1, parsedKey.Type())
 }
 
-func TestGenerateKey_Secp256r1NotSupported(t *testing.T) {
+func TestGenerateKey_Secp256r1(t *testing.T) {
 	key, err := GenerateKey(KeyTypeSecp256r1)
-	assert.Error(t, err)
-	assert.Nil(t, key)
-	assert.ErrorIs(t, err, NewErrUnsupportedKeyType(KeyTypeSecp256r1))
+	require.NoError(t, err)
+	require.NotNil(t, key)
+	assert.Equal(t, KeyTypeSecp256r1, key.Type())
 }
 
-func TestNewPrivateKey_Secp256r1NotSupported(t *testing.T) {
+func TestNewPrivateKey_Secp256r1(t *testing.T) {
 	privKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	require.NoError(t, err)
 
 	wrappedKey := NewPrivateKey(privKey)
-	assert.Nil(t, wrappedKey, "secp256r1 private keys should not be supported")
+	require.NotNil(t, wrappedKey)
+	assert.Equal(t, KeyTypeSecp256r1, wrappedKey.Type())
 }
 
 func TestSecp256r1_DID_Comprehensive(t *testing.T) {
@@ -769,4 +789,172 @@ func TestSecp256r1_DID_Comprehensive(t *testing.T) {
 
 		assert.Equal(t, compressedDID, uncompressedDID)
 	})
+}
+
+func TestSecp256r1PrivateKey_SignAndVerify(t *testing.T) {
+	privKey, err := GenerateKey(KeyTypeSecp256r1)
+	require.NoError(t, err)
+	require.NotNil(t, privKey)
+
+	message := []byte("secp256r1")
+	signature, err := privKey.Sign(message)
+	require.NoError(t, err)
+	require.NotEmpty(t, signature)
+
+	pubKey := privKey.GetPublic()
+	require.NotNil(t, pubKey)
+	assert.Equal(t, KeyTypeSecp256r1, pubKey.Type())
+
+	valid, err := pubKey.Verify(message, signature)
+	require.NoError(t, err)
+	assert.True(t, valid)
+
+	wrongMessage := []byte("Wrong message")
+	valid, err = pubKey.Verify(wrongMessage, signature)
+	require.NoError(t, err)
+	assert.False(t, valid)
+}
+
+func TestSecp256r1PrivateKey_SignAndVerifyCompressedKey(t *testing.T) {
+	privKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	wrappedPrivKey := NewPrivateKey(privKey)
+	require.NotNil(t, wrappedPrivKey)
+
+	message := []byte("test message")
+	signature, err := wrappedPrivKey.Sign(message)
+	require.NoError(t, err)
+
+	pubKey := NewPublicKey(&privKey.PublicKey)
+	compressedString := pubKey.String()
+	parsedPubKey, err := PublicKeyFromString(KeyTypeSecp256r1, compressedString)
+	require.NoError(t, err)
+
+	valid, err := parsedPubKey.Verify(message, signature)
+	require.NoError(t, err)
+	assert.True(t, valid)
+}
+
+func TestSecp256r1PrivateKey_RawAndString(t *testing.T) {
+	privKey, err := GenerateKey(KeyTypeSecp256r1)
+	require.NoError(t, err)
+
+	rawBytes := privKey.Raw()
+	assert.Len(t, rawBytes, 32)
+
+	keyString := privKey.String()
+	assert.NotEmpty(t, keyString)
+
+	decoded, err := hex.DecodeString(keyString)
+	require.NoError(t, err)
+	assert.Equal(t, rawBytes, decoded)
+}
+
+func TestSecp256r1PrivateKey_Equal(t *testing.T) {
+	privKey1, err := GenerateKey(KeyTypeSecp256r1)
+	require.NoError(t, err)
+
+	privKey2, err := GenerateKey(KeyTypeSecp256r1)
+	require.NoError(t, err)
+	assert.True(t, privKey1.Equal(privKey1))
+	assert.False(t, privKey1.Equal(privKey2))
+
+	rawBytes := privKey1.Raw()
+	if len(rawBytes) < 32 {
+		padded := make([]byte, 32)
+		copy(padded[32-len(rawBytes):], rawBytes)
+		rawBytes = padded
+	}
+	privKey3, err := PrivateKeyFromBytes(KeyTypeSecp256r1, rawBytes)
+	require.NoError(t, err)
+	assert.True(t, privKey1.Equal(privKey3))
+}
+
+func TestSecp256r1PrivateKey_GetPublic(t *testing.T) {
+	privKey, err := GenerateKey(KeyTypeSecp256r1)
+	require.NoError(t, err)
+
+	pubKey := privKey.GetPublic()
+	require.NotNil(t, pubKey)
+	assert.Equal(t, KeyTypeSecp256r1, pubKey.Type())
+
+	message := []byte("test")
+	signature, err := privKey.Sign(message)
+	require.NoError(t, err)
+
+	valid, err := pubKey.Verify(message, signature)
+	require.NoError(t, err)
+	assert.True(t, valid)
+}
+
+func TestSecp256r1PrivateKey_Underlying(t *testing.T) {
+	privKey, err := GenerateKey(KeyTypeSecp256r1)
+	require.NoError(t, err)
+
+	underlying := privKey.Underlying()
+	require.NotNil(t, underlying)
+
+	ecdsaKey, ok := underlying.(*ecdsa.PrivateKey)
+	require.True(t, ok)
+	assert.Equal(t, elliptic.P256(), ecdsaKey.Curve)
+}
+
+func TestSecp256r1PrivateKey_RoundTripSerialization(t *testing.T) {
+	privKey, err := GenerateKey(KeyTypeSecp256r1)
+	require.NoError(t, err)
+
+	keyString := privKey.String()
+	parsedKey, err := PrivateKeyFromString(KeyTypeSecp256r1, keyString)
+	require.NoError(t, err)
+	assert.True(t, privKey.Equal(parsedKey))
+
+	message := []byte("round trip test")
+	sig1, err := privKey.Sign(message)
+	require.NoError(t, err)
+
+	sig2, err := parsedKey.Sign(message)
+	require.NoError(t, err)
+
+	pubKey := privKey.GetPublic()
+	valid1, err := pubKey.Verify(message, sig1)
+	require.NoError(t, err)
+	assert.True(t, valid1)
+
+	valid2, err := pubKey.Verify(message, sig2)
+	require.NoError(t, err)
+	assert.True(t, valid2)
+}
+
+func TestSecp256r1PrivateKeyFromBytes_InvalidLength(t *testing.T) {
+	_, err := PrivateKeyFromBytes(KeyTypeSecp256r1, make([]byte, 16))
+	assert.Error(t, err)
+	assert.Equal(t, ErrInvalidECDSAPrivKeyBytes, err)
+
+	_, err = PrivateKeyFromBytes(KeyTypeSecp256r1, make([]byte, 64))
+	assert.Error(t, err)
+	assert.Equal(t, ErrInvalidECDSAPrivKeyBytes, err)
+}
+
+func TestSecp256r1_VerifyWithInvalidSignature(t *testing.T) {
+	privKey, err := GenerateKey(KeyTypeSecp256r1)
+	require.NoError(t, err)
+
+	pubKey := privKey.GetPublic()
+	message := []byte("test message")
+
+	invalidSig := []byte{0x01, 0x02, 0x03, 0x04}
+	valid, err := pubKey.Verify(message, invalidSig)
+	require.NoError(t, err)
+	assert.False(t, valid)
+}
+
+func TestGenerateSecp256r1(t *testing.T) {
+	key, err := GenerateSecp256r1()
+	require.NoError(t, err)
+	require.NotNil(t, key)
+	assert.Equal(t, elliptic.P256(), key.Curve)
+	assert.NotNil(t, key.D)
+	assert.NotNil(t, key.PublicKey.X)
+	assert.NotNil(t, key.PublicKey.Y)
 }


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4150 

## Description

This PR adds full support for the `secp256r1` key type.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?
- New tests were added
- Existing tests were updated

Specify the platform(s) on which this was tested:
- Debian Linux
- MacOS