### PR TITLE
refactor: Replace SE key collection root cid with short id

### DIFF
--- a/docs/data_format_changes/i4223-se-col-short-id.md
+++ b/docs/data_format_changes/i4223-se-col-short-id.md
@@ -1,0 +1,3 @@
+# Use collection short id for SE datastore key
+
+Replaces the collection root cid in the SE artifact key with the collection short id.

--- a/internal/db/p2p/protocol/comm_channel.go
+++ b/internal/db/p2p/protocol/comm_channel.go
@@ -15,6 +15,8 @@ import (
 	"io"
 
 	"github.com/sourcenetwork/defradb/client"
+	"github.com/sourcenetwork/defradb/internal/db/description"
+	"github.com/sourcenetwork/defradb/internal/db/id"
 	"github.com/sourcenetwork/defradb/internal/db/p2p/message"
 )
 
@@ -96,6 +98,9 @@ func (c *commChannel[Req, Reply, ReqP, ReplyP]) SendRequest(
 
 func (c *commChannel[Req, Reply, ReqP, ReplyP]) onRequest(stream io.Reader, peerID string) {
 	ctx := context.Background()
+	ctx = id.InitCollectionShortIDCache(ctx)
+	ctx = id.InitFieldShortIDCache(ctx)
+	ctx = description.InitCollectionCache(ctx)
 
 	var req Req
 	reqPtr := ReqP(&req)

--- a/internal/keys/datastore_se.go
+++ b/internal/keys/datastore_se.go
@@ -17,6 +17,7 @@ import (
 	ds "github.com/ipfs/go-datastore"
 
 	"github.com/sourcenetwork/defradb/errors"
+	"github.com/sourcenetwork/defradb/internal/encoding"
 )
 
 const (
@@ -25,10 +26,10 @@ const (
 
 // DatastoreSE provides key generation for SE artifacts
 type DatastoreSE struct {
-	CollectionID string
-	IndexID      string
-	SearchTag    []byte
-	DocID        string
+	CollectionShortID uint32
+	IndexID           string
+	SearchTag         []byte
+	DocID             string
 }
 
 var _ Key = (*DatastoreSE)(nil)
@@ -41,9 +42,11 @@ func (k DatastoreSE) ToString() string {
 	var sb strings.Builder
 	sb.WriteString(SE_PREFIX)
 
-	if k.CollectionID != "" {
+	if k.CollectionShortID != 0 {
 		sb.WriteString("/")
-		sb.WriteString(k.CollectionID)
+
+		colIDBytes := encoding.EncodeUvarintAscending([]byte{}, uint64(k.CollectionShortID))
+		sb.Write(colIDBytes)
 
 		if k.IndexID != "" {
 			sb.WriteString("/")
@@ -78,8 +81,12 @@ func NewDatastoreSEFromString(key string) (DatastoreSE, error) {
 
 	k := DatastoreSE{}
 
-	if len(parts) > 2 {
-		k.CollectionID = parts[2]
+	if len(parts) > 2 && len(parts[2]) != 0 {
+		_, colShortID, err := encoding.DecodeUvarintAscending([]byte(parts[2]))
+		if err != nil {
+			return DatastoreSE{}, err
+		}
+		k.CollectionShortID = uint32(colShortID)
 	}
 
 	if len(parts) > 3 {

--- a/internal/keys/datastore_se_test.go
+++ b/internal/keys/datastore_se_test.go
@@ -32,36 +32,36 @@ func TestDatastoreSE_ToString(t *testing.T) {
 		{
 			name: "collection only",
 			key: DatastoreSE{
-				CollectionID: "col123",
+				CollectionShortID: 1,
 			},
-			expected: "/se/col123",
+			expected: "/se/\x89",
 		},
 		{
 			name: "collection and index",
 			key: DatastoreSE{
-				CollectionID: "col123",
-				IndexID:      "idx456",
+				CollectionShortID: 1,
+				IndexID:           "idx456",
 			},
-			expected: "/se/col123/idx456",
+			expected: "/se/\x89/idx456",
 		},
 		{
 			name: "collection, index, and search tag",
 			key: DatastoreSE{
-				CollectionID: "col123",
-				IndexID:      "idx456",
-				SearchTag:    []byte{0x01, 0x02, 0x03},
+				CollectionShortID: 1,
+				IndexID:           "idx456",
+				SearchTag:         []byte{0x01, 0x02, 0x03},
 			},
-			expected: "/se/col123/idx456/010203",
+			expected: "/se/\x89/idx456/010203",
 		},
 		{
 			name: "full key with all fields",
 			key: DatastoreSE{
-				CollectionID: "col123",
-				IndexID:      "idx456",
-				SearchTag:    []byte{0x01, 0x02, 0x03},
-				DocID:        "doc789",
+				CollectionShortID: 1,
+				IndexID:           "idx456",
+				SearchTag:         []byte{0x01, 0x02, 0x03},
+				DocID:             "doc789",
 			},
-			expected: "/se/col123/idx456/010203/doc789",
+			expected: "/se/\x89/idx456/010203/doc789",
 		},
 		{
 			name: "skip index when no collection",
@@ -75,20 +75,20 @@ func TestDatastoreSE_ToString(t *testing.T) {
 		{
 			name: "skip search tag when no index",
 			key: DatastoreSE{
-				CollectionID: "col123",
-				SearchTag:    []byte{0x01, 0x02, 0x03},
-				DocID:        "doc789",
+				CollectionShortID: 1,
+				SearchTag:         []byte{0x01, 0x02, 0x03},
+				DocID:             "doc789",
 			},
-			expected: "/se/col123",
+			expected: "/se/\x89",
 		},
 		{
 			name: "skip doc id when no search tag",
 			key: DatastoreSE{
-				CollectionID: "col123",
-				IndexID:      "idx456",
-				DocID:        "doc789",
+				CollectionShortID: 1,
+				IndexID:           "idx456",
+				DocID:             "doc789",
 			},
-			expected: "/se/col123/idx456",
+			expected: "/se/\x89/idx456",
 		},
 	}
 
@@ -102,27 +102,27 @@ func TestDatastoreSE_ToString(t *testing.T) {
 
 func TestDatastoreSE_Bytes(t *testing.T) {
 	key := DatastoreSE{
-		CollectionID: "col123",
-		IndexID:      "idx456",
-		SearchTag:    []byte{0x01, 0x02, 0x03},
-		DocID:        "doc789",
+		CollectionShortID: 1,
+		IndexID:           "idx456",
+		SearchTag:         []byte{0x01, 0x02, 0x03},
+		DocID:             "doc789",
 	}
 
-	expected := []byte("/se/col123/idx456/010203/doc789")
+	expected := []byte("/se/\x89/idx456/010203/doc789")
 	result := key.Bytes()
 	assert.Equal(t, expected, result)
 }
 
 func TestDatastoreSE_ToDS(t *testing.T) {
 	key := DatastoreSE{
-		CollectionID: "col123",
-		IndexID:      "idx456",
-		SearchTag:    []byte{0x01, 0x02, 0x03},
-		DocID:        "doc789",
+		CollectionShortID: 1,
+		IndexID:           "idx456",
+		SearchTag:         []byte{0x01, 0x02, 0x03},
+		DocID:             "doc789",
 	}
 
 	dsKey := key.ToDS()
-	assert.Equal(t, "/se/col123/idx456/010203/doc789", dsKey.String())
+	assert.Equal(t, "/se/\x89/idx456/010203/doc789", dsKey.String())
 }
 
 func TestNewDatastoreSEFromString(t *testing.T) {
@@ -135,45 +135,45 @@ func TestNewDatastoreSEFromString(t *testing.T) {
 	}{
 		{
 			name:  "full valid key",
-			input: "/se/col123/idx456/010203/doc789",
+			input: "/se/\x89/idx456/010203/doc789",
 			expected: DatastoreSE{
-				CollectionID: "col123",
-				IndexID:      "idx456",
-				SearchTag:    []byte{0x01, 0x02, 0x03},
-				DocID:        "doc789",
+				CollectionShortID: 1,
+				IndexID:           "idx456",
+				SearchTag:         []byte{0x01, 0x02, 0x03},
+				DocID:             "doc789",
 			},
 			expectError: false,
 		},
 		{
 			name:  "key with only collection",
-			input: "/se/col123",
+			input: "/se/\x89",
 			expected: DatastoreSE{
-				CollectionID: "col123",
+				CollectionShortID: 1,
 			},
 			expectError: false,
 		},
 		{
 			name:  "key with collection and index",
-			input: "/se/col123/idx456",
+			input: "/se/\x89/idx456",
 			expected: DatastoreSE{
-				CollectionID: "col123",
-				IndexID:      "idx456",
+				CollectionShortID: 1,
+				IndexID:           "idx456",
 			},
 			expectError: false,
 		},
 		{
 			name:  "key with collection, index, and search tag",
-			input: "/se/col123/idx456/010203",
+			input: "/se/\x89/idx456/010203",
 			expected: DatastoreSE{
-				CollectionID: "col123",
-				IndexID:      "idx456",
-				SearchTag:    []byte{0x01, 0x02, 0x03},
+				CollectionShortID: 1,
+				IndexID:           "idx456",
+				SearchTag:         []byte{0x01, 0x02, 0x03},
 			},
 			expectError: false,
 		},
 		{
 			name:        "invalid prefix",
-			input:       "/notse/col123",
+			input:       "/notse/\x89",
 			expected:    DatastoreSE{},
 			expectError: true,
 			errorMsg:    "invalid SE key format",
@@ -194,7 +194,7 @@ func TestNewDatastoreSEFromString(t *testing.T) {
 		},
 		{
 			name:        "invalid hex in search tag",
-			input:       "/se/col123/idx456/xyz/doc789",
+			input:       "/se/\x89/idx456/xyz/doc789",
 			expected:    DatastoreSE{},
 			expectError: true,
 			errorMsg:    "failed to decode search tag",
@@ -203,20 +203,20 @@ func TestNewDatastoreSEFromString(t *testing.T) {
 			name:  "minimum valid key",
 			input: "/se",
 			expected: DatastoreSE{
-				CollectionID: "",
-				IndexID:      "",
-				SearchTag:    nil,
-				DocID:        "",
+				CollectionShortID: 0,
+				IndexID:           "",
+				SearchTag:         nil,
+				DocID:             "",
 			},
 			expectError: false,
 		},
 		{
 			name:  "complex search tag",
-			input: "/se/col123/idx456/" + hex.EncodeToString([]byte("complex search tag")),
+			input: "/se/\x89/idx456/" + hex.EncodeToString([]byte("complex search tag")),
 			expected: DatastoreSE{
-				CollectionID: "col123",
-				IndexID:      "idx456",
-				SearchTag:    []byte("complex search tag"),
+				CollectionShortID: 1,
+				IndexID:           "idx456",
+				SearchTag:         []byte("complex search tag"),
 			},
 			expectError: false,
 		},
@@ -224,20 +224,20 @@ func TestNewDatastoreSEFromString(t *testing.T) {
 			name:  "key with empty components",
 			input: "/se///",
 			expected: DatastoreSE{
-				CollectionID: "",
-				IndexID:      "",
-				SearchTag:    []byte{},
+				CollectionShortID: 0,
+				IndexID:           "",
+				SearchTag:         []byte{},
 			},
 			expectError: false,
 		},
 		{
 			name:  "key with trailing slash",
-			input: "/se/col123/idx456/010203/doc789/",
+			input: "/se/\x89/idx456/010203/doc789/",
 			expected: DatastoreSE{
-				CollectionID: "col123",
-				IndexID:      "idx456",
-				SearchTag:    []byte{0x01, 0x02, 0x03},
-				DocID:        "doc789",
+				CollectionShortID: 1,
+				IndexID:           "idx456",
+				SearchTag:         []byte{0x01, 0x02, 0x03},
+				DocID:             "doc789",
 			},
 			expectError: false,
 		},
@@ -252,7 +252,7 @@ func TestNewDatastoreSEFromString(t *testing.T) {
 				assert.Contains(t, err.Error(), tt.errorMsg)
 			} else {
 				require.NoError(t, err)
-				assert.Equal(t, tt.expected.CollectionID, result.CollectionID)
+				assert.Equal(t, tt.expected.CollectionShortID, result.CollectionShortID)
 				assert.Equal(t, tt.expected.IndexID, result.IndexID)
 				assert.Equal(t, tt.expected.SearchTag, result.SearchTag)
 				assert.Equal(t, tt.expected.DocID, result.DocID)

--- a/internal/se/se.go
+++ b/internal/se/se.go
@@ -23,6 +23,7 @@ import (
 	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/errors"
+	"github.com/sourcenetwork/defradb/internal/db/id"
 	"github.com/sourcenetwork/defradb/internal/encoding"
 	"github.com/sourcenetwork/defradb/internal/keys"
 	secore "github.com/sourcenetwork/defradb/internal/se/core"
@@ -31,11 +32,16 @@ import (
 // storeArtifacts stores SE artifacts directly in the datastore.
 func storeArtifacts(ctx context.Context, ds corekv.ReaderWriter, artifacts []secore.Artifact) error {
 	for _, artifact := range artifacts {
+		colID, err := id.GetShortCollectionID(ctx, artifact.CollectionID)
+		if err != nil {
+			return err
+		}
+
 		key := keys.DatastoreSE{
-			CollectionID: artifact.CollectionID,
-			IndexID:      artifact.IndexID,
-			SearchTag:    artifact.SearchTag,
-			DocID:        artifact.DocID,
+			CollectionShortID: colID,
+			IndexID:           artifact.IndexID,
+			SearchTag:         artifact.SearchTag,
+			DocID:             artifact.DocID,
 		}
 
 		if err := ds.Set(ctx, key.Bytes(), []byte{}); err != nil {
@@ -56,12 +62,17 @@ func fetchDocIDs(
 ) ([]string, error) {
 	docIDSet := make(map[string]struct{})
 
+	colID, err := id.GetShortCollectionID(ctx, collectionID)
+	if err != nil {
+		return nil, err
+	}
+
 	isFirstPass := true
 	for _, query := range queries {
 		key := keys.DatastoreSE{
-			CollectionID: collectionID,
-			IndexID:      query.IndexID,
-			SearchTag:    query.SearchTag,
+			CollectionShortID: colID,
+			IndexID:           query.IndexID,
+			SearchTag:         query.SearchTag,
 		}
 
 		iter, err := ds.Iterator(ctx, corekv.IterOptions{


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4223

## Description

Replaces the collection root cid in the SE artifact key with the collection short id.

This saves storage space and makes the key consistent with the rest of the datastore keys.