### PR TITLE
refactor: replace Split in loops with more efficient SplitSeq

### DIFF
--- a/cli/p2p_collection_add.go
+++ b/cli/p2p_collection_add.go
@@ -28,7 +28,7 @@ The collections are synchronized between nodes of a pubsub network.`,
 			cliClient := mustGetContextCLIClient(cmd)
 
 			var collectionNames []string
-			for _, id := range strings.Split(args[0], ",") {
+			for id := range strings.SplitSeq(args[0], ",") {
 				id = strings.TrimSpace(id)
 				if id == "" {
 					continue

--- a/cli/p2p_collection_remove.go
+++ b/cli/p2p_collection_remove.go
@@ -28,7 +28,7 @@ The removed collections will no longer be synchronized between nodes.`,
 			cliClient := mustGetContextCLIClient(cmd)
 
 			var collectionNames []string
-			for _, id := range strings.Split(args[0], ",") {
+			for id := range strings.SplitSeq(args[0], ",") {
 				id = strings.TrimSpace(id)
 				if id == "" {
 					continue

--- a/cli/p2p_document_add.go
+++ b/cli/p2p_document_add.go
@@ -28,7 +28,7 @@ The documents are synchronized between nodes of a pubsub network.`,
 			cliClient := mustGetContextCLIClient(cmd)
 
 			var collectionIDs []string
-			for _, id := range strings.Split(args[0], ",") {
+			for id := range strings.SplitSeq(args[0], ",") {
 				id = strings.TrimSpace(id)
 				if id == "" {
 					continue

--- a/cli/p2p_document_remove.go
+++ b/cli/p2p_document_remove.go
@@ -28,7 +28,7 @@ The removed documents will no longer be synchronized between nodes.`,
 			cliClient := mustGetContextCLIClient(cmd)
 
 			var collectionIDs []string
-			for _, id := range strings.Split(args[0], ",") {
+			for id := range strings.SplitSeq(args[0], ",") {
 				id = strings.TrimSpace(id)
 				if id == "" {
 					continue

--- a/tests/gen/schema_parser.go
+++ b/tests/gen/schema_parser.go
@@ -147,8 +147,8 @@ func (p *configParser) parseLine(line string) error {
 func (p *configParser) parse(gqlSDL string) error {
 	p.genConfigs = make(map[string]map[string]genConfig)
 
-	schemaLines := strings.Split(gqlSDL, "\n")
-	for _, line := range schemaLines {
+	schemaLines := strings.SplitSeq(gqlSDL, "\n")
+	for line := range schemaLines {
 		err := p.parseLine(line)
 		if err != nil {
 			return err
@@ -164,8 +164,8 @@ func parseGenConfig(configStr string) (genConfig, error) {
 	}
 
 	config := genConfig{props: make(map[string]any)}
-	configParts := strings.Split(configStr, ",")
-	for _, part := range configParts {
+	configParts := strings.SplitSeq(configStr, ",")
+	for part := range configParts {
 		part = strings.TrimSpace(part)
 		if part == "" {
 			continue


### PR DESCRIPTION
## Relevant issue(s)

Resolves #

## Description

strings.SplitSeq (introduced in Go 1.23)  returns a lazy sequence (strings.Seq), allowing gopher to iterate over tokens one by one without creating an intermediate slice.

It significantly reduces memory allocations and can improve performance for long strings.

More info: https://github.com/golang/go/issues/61901



## Tasks

- [ ] I made sure the code is well commented, particularly hard-to-understand areas.
- [ ] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [ ] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

No need. The Go team provides official support.  https://pkg.go.dev/golang.org/x/tools/gopls/internal/analysis/modernize  
