### PR TITLE
chore: Make C bindings ViewRefresh take C.CollectionOptions

### DIFF
--- a/cbindings/view.go
+++ b/cbindings/view.go
@@ -57,18 +57,13 @@ func ViewAdd(nodePtr C.uintptr_t, query *C.char, sdl *C.char, transformStr *C.ch
 }
 
 //export ViewRefresh
-func ViewRefresh(
-	nodePtr C.uintptr_t,
-	viewNameStr *C.char,
-	collectionIDStr *C.char,
-	versionIDStr *C.char,
-	getInactive C.int,
-) C.Result {
+func ViewRefresh(nodePtr C.uintptr_t, cOptions C.CollectionOptions) C.Result {
 	ctx := context.Background()
 
-	viewName := C.GoString(viewNameStr)
-	collectionID := C.GoString(collectionIDStr)
-	versionID := C.GoString(versionIDStr)
+	viewName := C.GoString(cOptions.name)
+	collectionID := C.GoString(cOptions.collectionID)
+	versionID := C.GoString(cOptions.version)
+
 	options := client.CollectionFetchOptions{}
 	if versionID != "" {
 		options.VersionID = immutable.Some(versionID)
@@ -79,8 +74,8 @@ func ViewRefresh(
 	if viewName != "" {
 		options.Name = immutable.Some(viewName)
 	}
-	if getInactive != 0 {
-		options.IncludeInactive = immutable.Some(getInactive != 0)
+	if cOptions.getInactive != 0 {
+		options.IncludeInactive = immutable.Some(true)
 	}
 
 	store, err := getStoreFromPointer(nodePtr)

--- a/cbindings/wrapper.go
+++ b/cbindings/wrapper.go
@@ -63,8 +63,7 @@ extern Result SetActiveCollection(uintptr_t nodePtr, CollectionOptions options, 
 extern NewTxnResult TransactionCreate(uintptr_t nodePtr, int isConcurrent, int isReadOnly);
 extern Result VersionGet(int flagFull, int flagJSON);
 extern Result ViewAdd(uintptr_t nodePtr, char* query, char* sdl, char* transformStr);
-extern Result ViewRefresh(uintptr_t nodePtr, char* viewNameStr,
-char* collectionIDStr, char* versionIDStr, int getInactive);
+extern Result ViewRefresh(uintptr_t nodePtr, CollectionOptions options);
 */
 import "C"
 

--- a/cbindings/wrapper.go
+++ b/cbindings/wrapper.go
@@ -638,8 +638,14 @@ func (w *CWrapper) RefreshViews(ctx context.Context, opts client.CollectionFetch
 	defer C.free(unsafe.Pointer(collectionID))
 	defer C.free(unsafe.Pointer(name))
 
+	var copts C.CollectionOptions
+	copts.version = versionID
+	copts.collectionID = collectionID
+	copts.name = name
+	copts.getInactive = cGetInactive
+
 	callHandle := getNodeOrTxnHandle(w.handle, ctx)
-	res := ConvertAndFreeCResult(C.ViewRefresh(callHandle, name, collectionID, versionID, cGetInactive))
+	res := ConvertAndFreeCResult(C.ViewRefresh(callHandle, copts))
 
 	if res.Status != 0 {
 		return errors.New(res.Error)

--- a/tests/integration/results.go
+++ b/tests/integration/results.go
@@ -539,7 +539,9 @@ func assertCollectionVersions(
 
 // CurrentTimestampMatcher is a matcher that checks if the actual value is a
 //
-//	time.Time within 5 seconds of the current time.
+//	time.Time within 60 seconds of the current time. The reason for this window
+//
+// is to allow for some latency in our test runs.
 type CurrentTimestampMatcher struct {
 	testStateMatcher
 }
@@ -578,17 +580,17 @@ func (matcher *CurrentTimestampMatcher) Match(actual any) (bool, error) {
 		diff = -diff
 	}
 
-	if diff > 5*time.Second {
-		return false, fmt.Errorf("timestamp %v is more than 5 seconds away from now", ts)
+	if diff > 60*time.Second {
+		return false, fmt.Errorf("timestamp %v is more than 60 seconds away from now", ts)
 	}
 
 	return true, nil
 }
 
 func (matcher *CurrentTimestampMatcher) FailureMessage(actual any) string {
-	return fmt.Sprintf("Expected timestamp %v to be within 5 seconds of now", actual)
+	return fmt.Sprintf("Expected timestamp %v to be within 60 seconds of now", actual)
 }
 
 func (matcher *CurrentTimestampMatcher) NegatedFailureMessage(actual any) string {
-	return fmt.Sprintf("Expected timestamp %v not to be within 5 seconds of now", actual)
+	return fmt.Sprintf("Expected timestamp %v not to be within 60 seconds of now", actual)
 }


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4204

## Description

This changes the function signature of the `ViewRefresh` function of the C bindings. It now uses a `C.CollectionOptions` struct instead of individual parameters.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Specify the platform(s) on which this was tested:
- WSL
