### PR TITLE
feat: Allow C binding view functions to take in identities

### DIFF
--- a/cbindings/view.go
+++ b/cbindings/view.go
@@ -28,8 +28,18 @@ import (
 )
 
 //export ViewAdd
-func ViewAdd(nodePtr C.uintptr_t, query *C.char, sdl *C.char, transformStr *C.char) C.Result {
+func ViewAdd(nodePtr C.uintptr_t,
+	query *C.char,
+	sdl *C.char,
+	transformStr *C.char,
+	identityPtr C.uintptr_t,
+) C.Result {
 	ctx := context.Background()
+
+	ctx, err := contextWithIdentity(ctx, identityPtr)
+	if err != nil {
+		return returnC(returnGoC(1, err.Error(), ""))
+	}
 
 	var transform immutable.Option[model.Lens]
 	lensCfgJson := C.GoString(transformStr)
@@ -57,8 +67,16 @@ func ViewAdd(nodePtr C.uintptr_t, query *C.char, sdl *C.char, transformStr *C.ch
 }
 
 //export ViewRefresh
-func ViewRefresh(nodePtr C.uintptr_t, cOptions C.CollectionOptions) C.Result {
+func ViewRefresh(nodePtr C.uintptr_t,
+	cOptions C.CollectionOptions,
+	identityPtr C.uintptr_t,
+) C.Result {
 	ctx := context.Background()
+
+	ctx, err := contextWithIdentity(ctx, identityPtr)
+	if err != nil {
+		return returnC(returnGoC(1, err.Error(), ""))
+	}
 
 	viewName := C.GoString(cOptions.name)
 	collectionID := C.GoString(cOptions.collectionID)

--- a/cbindings/wrapper.go
+++ b/cbindings/wrapper.go
@@ -62,8 +62,8 @@ extern Result AddSchema(uintptr_t nodePtr, char* schema, uintptr_t identity);
 extern Result SetActiveCollection(uintptr_t nodePtr, CollectionOptions options, uintptr_t identityPtr);
 extern NewTxnResult TransactionCreate(uintptr_t nodePtr, int isConcurrent, int isReadOnly);
 extern Result VersionGet(int flagFull, int flagJSON);
-extern Result ViewAdd(uintptr_t nodePtr, char* query, char* sdl, char* transformStr);
-extern Result ViewRefresh(uintptr_t nodePtr, CollectionOptions options);
+extern Result ViewAdd(uintptr_t nodePtr, char* query, char* sdl, char* transformStr, uintptr_t identityPtr);
+extern Result ViewRefresh(uintptr_t nodePtr, CollectionOptions options, uintptr_t identityPtr);
 */
 import "C"
 
@@ -598,6 +598,7 @@ func (w *CWrapper) AddView(
 	sdl string,
 	transform immutable.Option[model.Lens],
 ) ([]client.CollectionVersion, error) {
+	cIdentity := identityFromContext(ctx)
 	transformStr, err := stringFromLensOption(transform)
 	cTransform := C.CString(transformStr)
 	cQuery := C.CString(query)
@@ -605,13 +606,14 @@ func (w *CWrapper) AddView(
 	defer C.free(unsafe.Pointer(cTransform))
 	defer C.free(unsafe.Pointer(cQuery))
 	defer C.free(unsafe.Pointer(cSDL))
+	defer C.IdentityFree(cIdentity)
 
 	if err != nil {
 		return []client.CollectionVersion{}, err
 	}
 
 	callHandle := getNodeOrTxnHandle(w.handle, ctx)
-	res := ConvertAndFreeCResult(C.ViewAdd(callHandle, cQuery, cSDL, cTransform))
+	res := ConvertAndFreeCResult(C.ViewAdd(callHandle, cQuery, cSDL, cTransform, cIdentity))
 
 	if res.Status != 0 {
 		return []client.CollectionVersion{}, errors.New(res.Error)
@@ -625,6 +627,7 @@ func (w *CWrapper) AddView(
 }
 
 func (w *CWrapper) RefreshViews(ctx context.Context, opts client.CollectionFetchOptions) error {
+	cIdentity := identityFromContext(ctx)
 	versionID := C.CString(stringFromImmutableOptionString(opts.VersionID))
 	collectionID := C.CString(stringFromImmutableOptionString(opts.CollectionID))
 	name := C.CString(stringFromImmutableOptionString(opts.Name))
@@ -637,6 +640,7 @@ func (w *CWrapper) RefreshViews(ctx context.Context, opts client.CollectionFetch
 	defer C.free(unsafe.Pointer(versionID))
 	defer C.free(unsafe.Pointer(collectionID))
 	defer C.free(unsafe.Pointer(name))
+	defer C.IdentityFree(cIdentity)
 
 	var copts C.CollectionOptions
 	copts.version = versionID
@@ -645,7 +649,7 @@ func (w *CWrapper) RefreshViews(ctx context.Context, opts client.CollectionFetch
 	copts.getInactive = cGetInactive
 
 	callHandle := getNodeOrTxnHandle(w.handle, ctx)
-	res := ConvertAndFreeCResult(C.ViewRefresh(callHandle, copts))
+	res := ConvertAndFreeCResult(C.ViewRefresh(callHandle, copts, cIdentity))
 
 	if res.Status != 0 {
 		return errors.New(res.Error)


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4240 

## Description

Moving forward, we will be introducing gated permissions to the `ViewAdd` and `ViewRefresh` functions. When that happens, we would expect the integration tests to fail for the C client, and for the functionality to not be accessible to users of the C bindings. The C bindings, before this PR, just did not take in an identity parameter for these two functions. This PR is to get ahead of that problem before it ever crops up, by allowing these functions to take in an identity parameter.

Appropriate changes have been made to the exported functions, as well as to the wrapper functions.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Specify the platform(s) on which this was tested:
- WSL