### PR TITLE
refactor: Wrap Datastore in key-typed wrapper

### DIFF
--- a/cbindings/wrapper_tx.go
+++ b/cbindings/wrapper_tx.go
@@ -169,7 +169,7 @@ func (txn *Transaction) Blockstore() datastore.Blockstore {
 	return txn.tx.(datastore.Txn).Blockstore() //nolint:forcetypeassert
 }
 
-func (txn *Transaction) Datastore() corekv.ReaderWriter {
+func (txn *Transaction) Datastore() datastore.Keyedstore {
 	return txn.tx.(datastore.Txn).Datastore() //nolint:forcetypeassert
 }
 

--- a/internal/core/crdt/base.go
+++ b/internal/core/crdt/base.go
@@ -17,12 +17,13 @@ import (
 	"github.com/sourcenetwork/corekv"
 
 	"github.com/sourcenetwork/defradb/errors"
+	"github.com/sourcenetwork/defradb/internal/datastore"
 	"github.com/sourcenetwork/defradb/internal/keys"
 )
 
 func setPriority(
 	ctx context.Context,
-	store corekv.ReaderWriter,
+	store datastore.Keyedstore,
 	key keys.DataStoreKey,
 	priority uint64,
 ) error {
@@ -33,17 +34,17 @@ func setPriority(
 		return ErrEncodingPriority
 	}
 
-	return store.Set(ctx, prioK.Bytes(), buf[0:n])
+	return store.Set(ctx, prioK, buf[0:n])
 }
 
 // get the current priority for given key
 func getPriority(
 	ctx context.Context,
-	store corekv.ReaderWriter,
+	store datastore.Keyedstore,
 	key keys.DataStoreKey,
 ) (uint64, error) {
 	pKey := key.WithPriorityFlag()
-	pbuf, err := store.Get(ctx, pKey.Bytes())
+	pbuf, err := store.Get(ctx, pKey)
 	if err != nil {
 		if errors.Is(err, corekv.ErrNotFound) {
 			return 0, nil

--- a/internal/core/crdt/base_test.go
+++ b/internal/core/crdt/base_test.go
@@ -11,10 +11,7 @@
 package crdt
 
 import (
-	"context"
 	"testing"
-
-	"github.com/sourcenetwork/corekv/memory"
 
 	"github.com/sourcenetwork/defradb/internal/keys"
 )
@@ -30,26 +27,5 @@ func TestBaseCRDTprioryKey(t *testing.T) {
 	pk := keys.DataStoreKey{}.WithDocID("mykey").WithPriorityFlag()
 	if pk.ToString() != "/p/mykey" {
 		t.Errorf("Incorrect priorityKey. Have %v, want %v", pk.ToString(), "/p/mykey")
-	}
-}
-
-func TestBaseCRDTSetGetPriority(t *testing.T) {
-	ctx := context.Background()
-	store := memory.NewDatastore(ctx)
-
-	err := setPriority(ctx, store, keys.DataStoreKey{}.WithDocID("mykey"), 10)
-	if err != nil {
-		t.Errorf("baseCRDT failed to set Priority. err: %v", err)
-		return
-	}
-
-	priority, err := getPriority(ctx, store, keys.DataStoreKey{}.WithDocID("mykey"))
-	if err != nil {
-		t.Errorf("baseCRDT failed to get priority. err: %v", err)
-		return
-	}
-
-	if priority != uint64(10) {
-		t.Errorf("baseCRDT incorrect priority. Have %v, want %v", priority, uint64(10))
 	}
 }

--- a/internal/core/crdt/composite.go
+++ b/internal/core/crdt/composite.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/errors"
+	"github.com/sourcenetwork/defradb/internal/datastore"
 	"github.com/sourcenetwork/defradb/internal/db/base"
 	"github.com/sourcenetwork/defradb/internal/keys"
 )
@@ -74,7 +75,7 @@ func (delta *DocCompositeDelta) SetPriority(prio uint64) {
 
 // DocComposite is a MerkleCRDT implementation of the CompositeDAG using MerkleClocks.
 type DocComposite struct {
-	store           corekv.ReaderWriter
+	store           datastore.Keyedstore
 	key             keys.DataStoreKey
 	schemaVersionID string
 }
@@ -84,7 +85,7 @@ var _ ReplicatedData = (*DocComposite)(nil)
 // NewDocComposite creates a new instance (or loaded from DB) of a MerkleCRDT
 // backed by a CompositeDAG CRDT.
 func NewDocComposite(
-	store corekv.ReaderWriter,
+	store datastore.Keyedstore,
 	schemaVersionID string,
 	key keys.DataStoreKey,
 ) *DocComposite {
@@ -127,7 +128,7 @@ func (m *DocComposite) Merge(ctx context.Context, delta Delta) error {
 	}
 
 	if dagDelta.Status.IsDeleted() {
-		err := m.store.Set(ctx, m.key.ToPrimaryDataStoreKey().Bytes(), []byte{base.DeletedObjectMarker})
+		err := m.store.Set(ctx, m.key.ToPrimaryDataStoreKey(), []byte{base.DeletedObjectMarker})
 		if err != nil {
 			return err
 		}
@@ -138,7 +139,7 @@ func (m *DocComposite) Merge(ctx context.Context, delta Delta) error {
 	// reflected in `dagDelta.Status` if sourced via P2P.  Updates synced via P2P should not undelete
 	// the local representation of the document.
 	versionKey := m.key.WithValueFlag().WithFieldID(keys.DATASTORE_DOC_VERSION_FIELD_ID)
-	objectMarker, err := m.store.Get(ctx, m.key.ToPrimaryDataStoreKey().Bytes())
+	objectMarker, err := m.store.Get(ctx, m.key.ToPrimaryDataStoreKey())
 	hasObjectMarker := !errors.Is(err, corekv.ErrNotFound)
 	if err != nil && hasObjectMarker {
 		return err
@@ -148,22 +149,22 @@ func (m *DocComposite) Merge(ctx context.Context, delta Delta) error {
 		versionKey = versionKey.WithDeletedFlag()
 	}
 
-	err = m.store.Set(ctx, versionKey.Bytes(), []byte(dagDelta.SchemaVersionID))
+	err = m.store.Set(ctx, versionKey, []byte(dagDelta.SchemaVersionID))
 	if err != nil {
 		return err
 	}
 
 	if !hasObjectMarker {
 		// ensure object marker exists
-		return m.store.Set(ctx, m.key.ToPrimaryDataStoreKey().Bytes(), []byte{base.ObjectMarker})
+		return m.store.Set(ctx, m.key.ToPrimaryDataStoreKey(), []byte{base.ObjectMarker})
 	}
 
 	return nil
 }
 
 func (m DocComposite) deleteWithPrefix(ctx context.Context, key keys.DataStoreKey) error {
-	iter, err := m.store.Iterator(ctx, corekv.IterOptions{
-		Prefix: key.Bytes(),
+	iter, err := m.store.Iterator(ctx, datastore.IterOptions{
+		Prefix: key,
 	})
 	if err != nil {
 		return err
@@ -207,11 +208,11 @@ func (m DocComposite) deleteWithPrefix(ctx context.Context, key keys.DataStoreKe
 	}
 
 	for _, item := range kvArray {
-		err = m.store.Set(ctx, item.key.WithDeletedFlag().Bytes(), item.value)
+		err = m.store.Set(ctx, item.key.WithDeletedFlag(), item.value)
 		if err != nil {
 			return err
 		}
-		err = m.store.Delete(ctx, item.key.Bytes())
+		err = m.store.Delete(ctx, item.key)
 		if err != nil {
 			return err
 		}

--- a/internal/core/crdt/counter.go
+++ b/internal/core/crdt/counter.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/errors"
+	"github.com/sourcenetwork/defradb/internal/datastore"
 	"github.com/sourcenetwork/defradb/internal/db/base"
 	"github.com/sourcenetwork/defradb/internal/keys"
 )
@@ -76,7 +77,7 @@ func (delta *CounterDelta) SetPriority(prio uint64) {
 
 // Counter is a MerkleCRDT implementation of the Counter using MerkleClocks.
 type Counter struct {
-	store           corekv.ReaderWriter
+	store           datastore.Keyedstore
 	key             keys.DataStoreKey
 	schemaVersionID string
 	fieldName       string
@@ -90,7 +91,7 @@ var _ ReplicatedData = (*Counter)(nil)
 // NewCounter creates a new instance (or loaded from DB) of a MerkleCRDT
 // backed by a Counter CRDT.
 func NewCounter(
-	store corekv.ReaderWriter,
+	store datastore.Keyedstore,
 	schemaVersionID string,
 	key keys.DataStoreKey,
 	fieldName string,
@@ -125,7 +126,7 @@ func (c *Counter) Delta(ctx context.Context, data *DocField) (Delta, error) {
 	// To ensure that the dag block is unique, we add a random number to the delta.
 	// This is done only on update (if the doc doesn't already exist) to ensure that the
 	// initial dag block of a document can be reproducible.
-	exists, err := c.store.Has(ctx, c.key.ToPrimaryDataStoreKey().Bytes())
+	exists, err := c.store.Has(ctx, c.key.ToPrimaryDataStoreKey())
 	if err != nil {
 		return nil, err
 	}
@@ -165,7 +166,7 @@ func (c *Counter) incrementValue(
 	priority uint64,
 ) error {
 	key := c.key.WithValueFlag()
-	marker, err := c.store.Get(ctx, c.key.ToPrimaryDataStoreKey().Bytes())
+	marker, err := c.store.Get(ctx, c.key.ToPrimaryDataStoreKey())
 	if err != nil && !errors.Is(err, corekv.ErrNotFound) {
 		return err
 	}
@@ -195,7 +196,7 @@ func (c *Counter) incrementValue(
 		return NewErrUnsupportedCounterType(c.kind)
 	}
 
-	err = c.store.Set(ctx, key.Bytes(), resultAsBytes)
+	err = c.store.Set(ctx, key, resultAsBytes)
 	if err != nil {
 		return NewErrFailedToStoreValue(err)
 	}
@@ -212,7 +213,7 @@ func (c *Counter) CType() client.CType {
 
 func validateAndIncrement[T Incrementable](
 	ctx context.Context,
-	store corekv.ReaderWriter,
+	store datastore.Keyedstore,
 	key keys.DataStoreKey,
 	valueAsBytes []byte,
 	allowDecrement bool,
@@ -237,10 +238,10 @@ func validateAndIncrement[T Incrementable](
 
 func getCurrentValue[T Incrementable](
 	ctx context.Context,
-	store corekv.ReaderWriter,
+	store datastore.Keyedstore,
 	key keys.DataStoreKey,
 ) (T, error) {
-	curValue, err := store.Get(ctx, key.Bytes())
+	curValue, err := store.Get(ctx, key)
 	if err != nil {
 		if errors.Is(err, corekv.ErrNotFound) {
 			return 0, nil

--- a/internal/core/crdt/lww.go
+++ b/internal/core/crdt/lww.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/errors"
+	"github.com/sourcenetwork/defradb/internal/datastore"
 	"github.com/sourcenetwork/defradb/internal/db/base"
 	"github.com/sourcenetwork/defradb/internal/keys"
 )
@@ -63,7 +64,7 @@ func (d *LWWDelta) SetPriority(prio uint64) {
 
 // LWW is a MerkleCRDT implementation of the LWW using MerkleClocks.
 type LWW struct {
-	store           corekv.ReaderWriter
+	store           datastore.Keyedstore
 	key             keys.DataStoreKey
 	schemaVersionID string
 	fieldName       string
@@ -75,7 +76,7 @@ var _ ReplicatedData = (*LWW)(nil)
 // NewLWW creates a new instance (or loaded from DB) of a MerkleCRDT
 // backed by a LWWRegister CRDT.
 func NewLWW(
-	store corekv.ReaderWriter,
+	store datastore.Keyedstore,
 	schemaVersionID string,
 	key keys.DataStoreKey,
 	fieldName string,
@@ -130,7 +131,7 @@ func (l *LWW) setValue(ctx context.Context, val []byte, priority uint64) error {
 	// else if the current value is lexicographically
 	// greater than the new then ignore
 	key := l.key.WithValueFlag()
-	marker, err := l.store.Get(ctx, l.key.ToPrimaryDataStoreKey().Bytes())
+	marker, err := l.store.Get(ctx, l.key.ToPrimaryDataStoreKey())
 	if err != nil && !errors.Is(err, corekv.ErrNotFound) {
 		return err
 	}
@@ -140,7 +141,7 @@ func (l *LWW) setValue(ctx context.Context, val []byte, priority uint64) error {
 	if priority < curPrio {
 		return nil
 	} else if priority == curPrio {
-		curValue, err := l.store.Get(ctx, key.Bytes())
+		curValue, err := l.store.Get(ctx, key)
 		if err != nil {
 			return err
 		}
@@ -155,12 +156,12 @@ func (l *LWW) setValue(ctx context.Context, val []byte, priority uint64) error {
 		// the field datastore key to exist.  Ommiting the key saves space and is
 		// consistent with what would be found if the user omitted the property on
 		// create.
-		err = l.store.Delete(ctx, key.Bytes())
+		err = l.store.Delete(ctx, key)
 		if err != nil {
 			return err
 		}
 	} else {
-		err = l.store.Set(ctx, key.Bytes(), val)
+		err = l.store.Set(ctx, key, val)
 		if err != nil {
 			return NewErrFailedToStoreValue(err)
 		}

--- a/internal/core/crdt/merklecrdt.go
+++ b/internal/core/crdt/merklecrdt.go
@@ -16,9 +16,8 @@ package crdt
 import (
 	"context"
 
-	"github.com/sourcenetwork/corekv"
-
 	"github.com/sourcenetwork/defradb/client"
+	"github.com/sourcenetwork/defradb/internal/datastore"
 	"github.com/sourcenetwork/defradb/internal/keys"
 )
 
@@ -28,7 +27,7 @@ type FieldLevelCRDT interface {
 }
 
 func FieldLevelCRDTWithStore(
-	store corekv.ReaderWriter,
+	store datastore.Keyedstore,
 	schemaVersionID string,
 	cType client.CType,
 	kind client.FieldKind,

--- a/internal/datastore/datastore.go
+++ b/internal/datastore/datastore.go
@@ -1,0 +1,75 @@
+// Copyright 2025 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package datastore
+
+import (
+	"context"
+
+	"github.com/sourcenetwork/corekv"
+	"github.com/sourcenetwork/corekv/namespace"
+)
+
+type datastore struct {
+	underlying corekv.ReaderWriter
+}
+
+var _ Keyedstore = (*datastore)(nil)
+
+func newDatastore(rootstore corekv.ReaderWriter) *datastore {
+	return &datastore{
+		underlying: namespace.Wrap(rootstore, []byte{dataStoreKey}),
+	}
+}
+
+func (s *datastore) Get(ctx context.Context, key Key) ([]byte, error) {
+	keyBytes := key.Bytes()
+	return s.underlying.Get(ctx, keyBytes)
+}
+
+func (s *datastore) Has(ctx context.Context, key Key) (bool, error) {
+	keyBytes := key.Bytes()
+	return s.underlying.Has(ctx, keyBytes)
+}
+
+func (s *datastore) Iterator(ctx context.Context, opts IterOptions) (corekv.Iterator, error) {
+	var prefix []byte
+	var start []byte
+	var end []byte
+
+	if opts.Prefix != nil {
+		prefix = opts.Prefix.Bytes()
+	}
+	if opts.Start != nil {
+		start = opts.Start.Bytes()
+	}
+	if opts.End != nil {
+		end = opts.End.Bytes()
+	}
+
+	ckvOpts := corekv.IterOptions{
+		Prefix:   prefix,
+		Start:    start,
+		End:      end,
+		KeysOnly: opts.KeysOnly,
+		Reverse:  opts.Reverse,
+	}
+	return s.underlying.Iterator(ctx, ckvOpts)
+}
+
+func (s *datastore) Set(ctx context.Context, key Key, value []byte) error {
+	keyBytes := key.Bytes()
+	return s.underlying.Set(ctx, keyBytes, value)
+}
+
+func (s *datastore) Delete(ctx context.Context, key Key) error {
+	keyBytes := key.Bytes()
+	return s.underlying.Delete(ctx, keyBytes)
+}

--- a/internal/datastore/keyedstore.go
+++ b/internal/datastore/keyedstore.go
@@ -1,0 +1,98 @@
+// Copyright 2025 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package datastore
+
+import (
+	"context"
+
+	"github.com/sourcenetwork/corekv"
+)
+
+// Key represents a typed key for a key-value pair or a prefix within a `Keyedstore`.
+type Key interface {
+	// Bytes returns the serialized for of the key, as it is stored within a `Keyedstore`.
+	Bytes() []byte
+}
+
+// Keyedstore is a corekv.ReaderWriter that takes typed `Key`s instead of `[]byte`
+// for it's key function parameters.
+type Keyedstore interface {
+	// Get returns the value at the given key.
+	//
+	// If no item with the given key is found, nil, and an [ErrNotFound]
+	// error will be returned.
+	Get(ctx context.Context, key Key) ([]byte, error)
+
+	// Has returns true if an item at the given key is found, otherwise
+	// will return false.
+	Has(ctx context.Context, key Key) (bool, error)
+
+	// Iterator returns a read-only iterator using the given options.
+	Iterator(ctx context.Context, opts IterOptions) (corekv.Iterator, error)
+
+	// Set sets the value stored against the given key.
+	//
+	// If an item already exists at the given key it will be overwritten.
+	Set(ctx context.Context, key Key, value []byte) error
+
+	// Delete removes the value at the given key.
+	//
+	// If no matching key is found the behaviour is undefined:
+	// https://github.com/sourcenetwork/corekv/issues/36
+	Delete(ctx context.Context, key Key) error
+}
+
+// IterOptions contains the full set of available iterator options,
+// it can be provided when creating an [Iterator] from a [Store].
+type IterOptions struct {
+	// Prefix iteration, only keys beginning with the designated prefix
+	// with the given prefix will be yielded.
+	//
+	// Keys exactly matching the provided `Prefix` value will not be
+	// yielded.
+	//
+	// Providing a Prefix value should cause the Start and End options
+	// to be ignored, although this is currently untested:
+	// https://github.com/sourcenetwork/corekv/issues/35
+	Prefix Key
+
+	// If Prefix is nil, and Start is provided, the iterator will
+	// only yield items with a key lexographically greater than or
+	// equal to this value.
+	//
+	// Providing an `End` value equal to or smaller than this value
+	// will result in undefined behaviour:
+	// https://github.com/sourcenetwork/corekv/issues/32
+	Start Key
+
+	// If Prefix is nil, and End is provided, the iterator will
+	// only yield items with a key lexographically smaller than this
+	// value.
+	//
+	// Providing an End value equal to or smaller than Start
+	// will result in undefined behaviour:
+	// https://github.com/sourcenetwork/corekv/issues/32
+	End Key
+
+	// Reverse the direction of the iteration, returning items in
+	// lexographically descending order of their keys.
+	Reverse bool
+
+	// Only iterate through keys. Calling Value on the
+	// iterator will return nil and no error.
+	//
+	// This option is currently untested:
+	// https://github.com/sourcenetwork/corekv/issues/34
+	//
+	// It is very likely ignored for the memory store iteration:
+	// https://github.com/sourcenetwork/corekv/issues/33
+	KeysOnly bool
+}

--- a/internal/datastore/multi.go
+++ b/internal/datastore/multi.go
@@ -83,10 +83,6 @@ func (m *Multistore) Systemstore() corekv.ReaderWriter {
 	return m.system
 }
 
-func DatastoreFrom(rootstore corekv.ReaderWriter) corekv.ReaderWriter {
-	return namespace.Wrap(rootstore, []byte{dataStoreKey})
-}
-
 // The key used to calculate keyLen is descriptive only, they are all the same length, and there
 // is nothing special about this one.
 var chunkKeyLen int = len([]byte("bafybeiet6foxcipesjurdqi4zpsgsiok5znqgw4oa5poef6qtiby5hlpzy"))

--- a/internal/datastore/multi.go
+++ b/internal/datastore/multi.go
@@ -35,7 +35,7 @@ var (
 
 type Multistore struct {
 	block  Blockstore
-	data   corekv.ReaderWriter
+	data   *datastore
 	enc    Blockstore
 	head   corekv.ReaderWriter
 	peer   corekv.ReaderWriter
@@ -46,7 +46,7 @@ type Multistore struct {
 func NewMultistore(rootstore corekv.ReaderWriter, chunkSize immutable.Option[int]) *Multistore {
 	return &Multistore{
 		block:  BlockstoreFrom(rootstore, chunkSize),
-		data:   namespace.Wrap(rootstore, []byte{dataStoreKey}),
+		data:   newDatastore(rootstore),
 		enc:    newBlockstore(namespace.Wrap(rootstore, []byte{encStoreKey})),
 		head:   namespace.Wrap(rootstore, []byte{headStoreKey}),
 		peer:   namespace.Wrap(rootstore, []byte{peerStoreKey}),
@@ -59,7 +59,7 @@ func (m *Multistore) Blockstore() Blockstore {
 	return m.block
 }
 
-func (m *Multistore) Datastore() corekv.ReaderWriter {
+func (m *Multistore) Datastore() Keyedstore {
 	return m.data
 }
 

--- a/internal/datastore/multi_test.go
+++ b/internal/datastore/multi_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/sourcenetwork/corekv"
 	"github.com/sourcenetwork/corekv/memory"
+	"github.com/sourcenetwork/defradb/internal/keys"
 	"github.com/sourcenetwork/immutable"
 )
 
@@ -33,7 +34,7 @@ func TestMultistore_HumanReadableKeys_ShouldSucceed(t *testing.T) {
 	require.NoError(t, err)
 	err = P2PBlockstoreFrom(rootstore, immutable.None[int]()).Put(ctx, blocks.NewBlock([]byte("1234")))
 	require.NoError(t, err)
-	err = ms.Datastore().Set(ctx, []byte("/123"), []byte("123"))
+	err = ms.Datastore().Set(ctx, keys.NewViewCacheKey(1, 23), []byte("123"))
 	require.NoError(t, err)
 	err = ms.Encstore().Put(ctx, blocks.NewBlock([]byte("123")))
 	require.NoError(t, err)

--- a/internal/datastore/txn.go
+++ b/internal/datastore/txn.go
@@ -25,7 +25,7 @@ type Txn interface {
 	Blockstore() Blockstore
 
 	// Datastore returns the prefixed store for the datastore
-	Datastore() corekv.ReaderWriter
+	Datastore() Keyedstore
 
 	// Encstore returns the prefixed store for the encryption key store
 	Encstore() Blockstore

--- a/internal/db/collection.go
+++ b/internal/db/collection.go
@@ -233,8 +233,8 @@ func (c *collection) getAllDocIDsChan(
 	prefix := keys.PrimaryDataStoreKey{ // empty path for all keys prefix
 		CollectionShortID: shortID,
 	}
-	iter, err := txn.Datastore().Iterator(ctx, corekv.IterOptions{
-		Prefix:   prefix.Bytes(),
+	iter, err := txn.Datastore().Iterator(ctx, datastore.IterOptions{
+		Prefix:   prefix,
 		KeysOnly: true,
 	})
 	if err != nil {
@@ -450,7 +450,7 @@ func (c *collection) create(
 			InstanceType:      keys.ValueKey,
 		}
 
-		err = txn.Datastore().Set(ctx, valueKey.Bytes(), []byte{base.ObjectMarker})
+		err = txn.Datastore().Set(ctx, valueKey, []byte{base.ObjectMarker})
 		if err != nil {
 			return err
 		}
@@ -998,7 +998,7 @@ func (c *collection) exists(
 	}
 
 	txn := datastore.CtxMustGetTxn(ctx)
-	val, err := txn.Datastore().Get(ctx, primaryKey.Bytes())
+	val, err := txn.Datastore().Get(ctx, primaryKey)
 	if err != nil && errors.Is(err, corekv.ErrNotFound) {
 		return false, false, nil
 	} else if err != nil {

--- a/internal/db/collection_define.go
+++ b/internal/db/collection_define.go
@@ -20,7 +20,6 @@ import (
 	jsonpatch "github.com/evanphx/json-patch/v5"
 	"github.com/ipfs/go-cid"
 
-	"github.com/sourcenetwork/corekv"
 	"github.com/sourcenetwork/immutable"
 	"github.com/sourcenetwork/lens/host-go/config/model"
 
@@ -724,8 +723,8 @@ func collectionHasDocuments(
 		}
 	}
 
-	iter, err := txn.Datastore().Iterator(ctx, corekv.IterOptions{
-		Prefix:   prefixKey.ToDS().Bytes(),
+	iter, err := txn.Datastore().Iterator(ctx, datastore.IterOptions{
+		Prefix:   prefixKey.ToDS(),
 		KeysOnly: true,
 	})
 	if err != nil {

--- a/internal/db/fetcher/document.go
+++ b/internal/db/fetcher/document.go
@@ -63,9 +63,9 @@ func newDocumentFetcher(
 		prefix = prefix.WithDeletedFlag()
 	}
 
-	iter, err := txn.Datastore().Iterator(ctx, corekv.IterOptions{
-		Start: prefix.Bytes(),
-		End:   prefix.PrefixEnd().Bytes(),
+	iter, err := txn.Datastore().Iterator(ctx, datastore.IterOptions{
+		Start: prefix,
+		End:   prefix.PrefixEnd(),
 	})
 	if err != nil {
 		return nil, err

--- a/internal/db/fetcher/indexer_iterators.go
+++ b/internal/db/fetcher/indexer_iterators.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/errors"
 	"github.com/sourcenetwork/defradb/internal/connor"
+	"github.com/sourcenetwork/defradb/internal/datastore"
 	"github.com/sourcenetwork/defradb/internal/db/id"
 	"github.com/sourcenetwork/defradb/internal/keys"
 	"github.com/sourcenetwork/defradb/internal/planner/filter"
@@ -57,13 +58,13 @@ func isArrayCondition(op string) bool {
 // It is used to iterate over the index keys that match a specific condition.
 // For example, iteration over condition _eq and _gt will have completely different logic.
 type indexIterator interface {
-	Init(context.Context, corekv.ReaderWriter) error
+	Init(context.Context, datastore.Keyedstore) error
 	Next() (indexIterResult, error)
 	Close() error
 }
 
 type indexIterResult struct {
-	key      keys.IndexDataStoreKey
+	key      *keys.IndexDataStoreKey
 	foundKey bool
 	value    []byte
 }
@@ -79,21 +80,21 @@ type indexMatchIterator struct {
 	// Iterator state
 	resultIter corekv.Iterator
 	ctx        context.Context
-	store      corekv.ReaderWriter
+	store      datastore.Keyedstore
 	reverse    bool
 
 	matchers []valueMatcher
 
 	// For prefix mode
-	prefixKey []byte
+	prefixKey keys.Key
 	// For range mode
-	startKey []byte
-	endKey   []byte
+	startKey keys.Key
+	endKey   keys.Key
 }
 
 var _ indexIterator = (*indexMatchIterator)(nil)
 
-func (iter *indexMatchIterator) Init(ctx context.Context, store corekv.ReaderWriter) error {
+func (iter *indexMatchIterator) Init(ctx context.Context, store datastore.Keyedstore) error {
 	iter.ctx = ctx
 	iter.store = store
 	if iter.resultIter != nil {
@@ -103,15 +104,15 @@ func (iter *indexMatchIterator) Init(ctx context.Context, store corekv.ReaderWri
 	}
 	iter.resultIter = nil
 
-	var iterOpts corekv.IterOptions
+	var iterOpts datastore.IterOptions
 	if iter.prefixKey == nil {
-		iterOpts = corekv.IterOptions{
+		iterOpts = datastore.IterOptions{
 			Start:   iter.startKey,
 			End:     iter.endKey,
 			Reverse: iter.reverse,
 		}
 	} else {
-		iterOpts = corekv.IterOptions{
+		iterOpts = datastore.IterOptions{
 			Prefix:  iter.prefixKey,
 			Reverse: iter.reverse,
 		}
@@ -163,7 +164,7 @@ func (iter *indexMatchIterator) nextRawResult() (indexIterResult, error) {
 	}
 
 	iter.execInfo.IndexesFetched++
-	return indexIterResult{key: key, value: value, foundKey: true}, nil
+	return indexIterResult{key: &key, value: value, foundKey: true}, nil
 }
 
 func (iter *indexMatchIterator) Close() error {
@@ -182,7 +183,7 @@ func (f *indexFetcher) newPrefixBaseMatchIterator(
 		indexDesc:     f.indexDesc,
 		indexedFields: f.indexedFields,
 		execInfo:      execInfo,
-		prefixKey:     indexKey.Bytes(),
+		prefixKey:     &indexKey,
 		matchers:      matchers,
 	}
 }
@@ -193,16 +194,16 @@ func (iter *indexMatchIterator) Reverse(reverse bool) *indexMatchIterator {
 }
 
 type eqSingleIndexIterator struct {
-	indexKey keys.IndexDataStoreKey
+	indexKey *keys.IndexDataStoreKey
 	execInfo *ExecInfo
 
 	ctx   context.Context
-	store corekv.ReaderWriter
+	store datastore.Keyedstore
 }
 
 var _ indexIterator = (*eqSingleIndexIterator)(nil)
 
-func (iter *eqSingleIndexIterator) Init(ctx context.Context, store corekv.ReaderWriter) error {
+func (iter *eqSingleIndexIterator) Init(ctx context.Context, store datastore.Keyedstore) error {
 	iter.ctx = ctx
 	iter.store = store
 	return nil
@@ -212,7 +213,7 @@ func (iter *eqSingleIndexIterator) Next() (indexIterResult, error) {
 	if iter.store == nil {
 		return indexIterResult{}, nil
 	}
-	val, err := iter.store.Get(iter.ctx, iter.indexKey.Bytes())
+	val, err := iter.store.Get(iter.ctx, iter.indexKey)
 	if err != nil {
 		if errors.Is(err, corekv.ErrNotFound) {
 			return indexIterResult{key: iter.indexKey}, nil
@@ -233,7 +234,7 @@ type inIndexIterator struct {
 	inValues        []client.NormalValue
 	nextValIndex    int
 	ctx             context.Context
-	store           corekv.ReaderWriter
+	store           datastore.Keyedstore
 	hasIterator     bool
 	fetcher         *indexFetcher
 	fieldConditions []fieldFilterCond
@@ -293,7 +294,7 @@ func (iter *inIndexIterator) createIteratorForNextValue() error {
 	return nil
 }
 
-func (iter *inIndexIterator) Init(ctx context.Context, store corekv.ReaderWriter) error {
+func (iter *inIndexIterator) Init(ctx context.Context, store datastore.Keyedstore) error {
 	iter.ctx = ctx
 	iter.store = store
 	var err error
@@ -340,7 +341,7 @@ func (f *indexFetcher) newEqSingleIndexIterator(
 	if err != nil {
 		return nil, err
 	}
-	return &eqSingleIndexIterator{indexKey: key, execInfo: f.execInfo}, nil
+	return &eqSingleIndexIterator{indexKey: &key, execInfo: f.execInfo}, nil
 }
 
 // memorizingIndexIterator is an iterator for set of indexes that belong to the same document
@@ -351,12 +352,12 @@ type memorizingIndexIterator struct {
 	fetchedDocs map[string]struct{}
 
 	ctx   context.Context
-	store corekv.ReaderWriter
+	store datastore.Keyedstore
 }
 
 var _ indexIterator = (*memorizingIndexIterator)(nil)
 
-func (iter *memorizingIndexIterator) Init(ctx context.Context, store corekv.ReaderWriter) error {
+func (iter *memorizingIndexIterator) Init(ctx context.Context, store datastore.Keyedstore) error {
 	iter.ctx = ctx
 	iter.store = store
 	iter.fetchedDocs = make(map[string]struct{})
@@ -510,8 +511,8 @@ func (f *indexFetcher) createKeyWithValue(key keys.IndexDataStoreKey, val client
 
 // createRangeBoundaries creates start and end keys for range queries based on the filter condition.
 func (f *indexFetcher) createRangeBoundaries(cond fieldFilterCond, descending bool) (
-	startKey []byte,
-	endKey []byte,
+	startKey keys.Key,
+	endKey keys.Key,
 	err error,
 ) {
 	var baseKey keys.IndexDataStoreKey
@@ -535,13 +536,13 @@ func (f *indexFetcher) createRangeBoundaries(cond fieldFilterCond, descending bo
 			// For descending index, we want values > X
 			// Since larger values come first, we start from the beginning
 			// and go until just before X
-			startKey = baseKey.Bytes()
+			startKey = &baseKey
 			valueKey := f.createKeyWithValue(baseKey, cond.val)
-			endKey = valueKey.Bytes() // Exclusive, so this works
+			endKey = &valueKey // Exclusive, so this works
 		case opGe:
 			// For descending index, we want values >= X
 			// Start from beginning and go until just after X
-			startKey = baseKey.Bytes()
+			startKey = &baseKey
 			valueKey := f.createKeyWithValue(baseKey, cond.val)
 			endKey = valueKey.PrefixEnd()
 		case opLt:
@@ -554,7 +555,7 @@ func (f *indexFetcher) createRangeBoundaries(cond fieldFilterCond, descending bo
 			// For descending index, we want values <= X
 			// Start from X and go to the end
 			valueKey := f.createKeyWithValue(baseKey, cond.val)
-			startKey = valueKey.Bytes()
+			startKey = &valueKey
 			endKey = baseKey.PrefixEnd()
 		}
 	} else {
@@ -567,16 +568,16 @@ func (f *indexFetcher) createRangeBoundaries(cond fieldFilterCond, descending bo
 		case opGe:
 			// Start >= value: Use value as-is
 			valueKey := f.createKeyWithValue(baseKey, cond.val)
-			startKey = valueKey.Bytes()
+			startKey = &valueKey
 			endKey = baseKey.PrefixEnd()
 		case opLt:
 			// End < value: Use value as-is (End is exclusive)
-			startKey = baseKey.Bytes()
+			startKey = &baseKey
 			valueKey := f.createKeyWithValue(baseKey, cond.val)
-			endKey = valueKey.Bytes()
+			endKey = &valueKey
 		case opLe:
 			// End <= value: Need to include value, so increment it
-			startKey = baseKey.Bytes()
+			startKey = &baseKey
 			valueKey := f.createKeyWithValue(baseKey, cond.val)
 			endKey = valueKey.PrefixEnd()
 		}

--- a/internal/db/index.go
+++ b/internal/db/index.go
@@ -221,14 +221,14 @@ func (index *collectionBaseIndex) deleteIndexKey(
 ) error {
 	txn := datastore.CtxMustGetTxn(ctx)
 	ds := txn.Datastore()
-	exists, err := ds.Has(ctx, key.Bytes())
+	exists, err := ds.Has(ctx, &key)
 	if err != nil {
 		return err
 	}
 	if !exists {
 		return NewErrCorruptedIndex(index.desc.Name)
 	}
-	return ds.Delete(ctx, key.Bytes())
+	return ds.Delete(ctx, &key)
 }
 
 // RemoveAll remove all artifacts of the index from the storage, i.e. all index
@@ -244,14 +244,38 @@ func (index *collectionBaseIndex) RemoveAll(ctx context.Context) error {
 	prefixKey.IndexID = index.desc.ID
 
 	txn := datastore.CtxMustGetTxn(ctx)
-	ds := txn.Datastore()
-	keys, err := datastore.FetchKeysForPrefix(ctx, prefixKey.Bytes(), ds)
+
+	iter, err := txn.Datastore().Iterator(ctx, datastore.IterOptions{
+		Prefix:   &prefixKey,
+		KeysOnly: true,
+	})
 	if err != nil {
 		return err
 	}
 
-	for _, key := range keys {
-		err := ds.Delete(ctx, key)
+	keysToDelete := make([]keys.IndexDataStoreKey, 0)
+	for {
+		hasNext, err := iter.Next()
+		if err != nil {
+			return errors.Join(err, iter.Close())
+		}
+		if !hasNext {
+			break
+		}
+
+		key, err := keys.DecodeIndexDataStoreKey(iter.Key(), &index.desc, index.fieldsDescs)
+		if err != nil {
+			return errors.Join(err, iter.Close())
+		}
+
+		keysToDelete = append(keysToDelete, key)
+	}
+	if err := iter.Close(); err != nil {
+		return err
+	}
+
+	for _, key := range keysToDelete {
+		err := txn.Datastore().Delete(ctx, &key)
 		if err != nil {
 			return NewCanNotDeleteIndexedField(err)
 		}
@@ -330,7 +354,7 @@ func (index *collectionSimpleIndex) Save(
 	txn := datastore.CtxMustGetTxn(ctx)
 
 	return index.generateKeysAndProcess(ctx, doc, true, func(key keys.IndexDataStoreKey) error {
-		return txn.Datastore().Set(ctx, key.Bytes(), []byte{})
+		return txn.Datastore().Set(ctx, &key, []byte{})
 	})
 }
 
@@ -420,7 +444,7 @@ func validateUniqueKeyValue(
 	txn := datastore.CtxMustGetTxn(ctx)
 
 	if len(val) != 0 {
-		exists, err := txn.Datastore().Has(ctx, key.Bytes())
+		exists, err := txn.Datastore().Has(ctx, &key)
 		if err != nil {
 			return err
 		}
@@ -447,7 +471,7 @@ func addNewUniqueKey(
 	if err != nil {
 		return err
 	}
-	err = txn.Datastore().Set(ctx, key.Bytes(), val)
+	err = txn.Datastore().Set(ctx, &key, val)
 	if err != nil {
 		return NewErrFailedToStoreIndexedField(key.ToString(), err)
 	}
@@ -464,7 +488,7 @@ func (index *collectionUniqueIndex) Delete(
 		if err != nil {
 			return err
 		}
-		return txn.Datastore().Delete(ctx, key.Bytes())
+		return txn.Datastore().Delete(ctx, &key)
 	})
 }
 

--- a/internal/db/view.go
+++ b/internal/db/view.go
@@ -14,7 +14,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/sourcenetwork/corekv"
 	"github.com/sourcenetwork/immutable"
 	"github.com/sourcenetwork/lens/host-go/config/model"
 
@@ -224,7 +223,7 @@ func (db *DB) buildViewCache(ctx context.Context, col client.CollectionVersion) 
 		}
 
 		itemKey := keys.NewViewCacheKey(shortID, itemID)
-		err = txn.Datastore().Set(ctx, itemKey.Bytes(), serializedItem)
+		err = txn.Datastore().Set(ctx, itemKey, serializedItem)
 		if err != nil {
 			return err
 		}
@@ -246,8 +245,8 @@ func (db *DB) clearViewCache(ctx context.Context, col client.CollectionVersion) 
 		return err
 	}
 
-	iter, err := txn.Datastore().Iterator(ctx, corekv.IterOptions{
-		Prefix:   keys.NewViewCacheColPrefix(shortID).Bytes(),
+	iter, err := txn.Datastore().Iterator(ctx, datastore.IterOptions{
+		Prefix:   keys.NewViewCacheColPrefix(shortID),
 		KeysOnly: true,
 	})
 	if err != nil {
@@ -263,7 +262,12 @@ func (db *DB) clearViewCache(ctx context.Context, col client.CollectionVersion) 
 			break
 		}
 
-		err = txn.Datastore().Delete(ctx, iter.Key())
+		key, err := keys.NewViewCacheKeyFromRaw(iter.Key())
+		if err != nil {
+			return errors.Join(err, iter.Close())
+		}
+
+		err = txn.Datastore().Delete(ctx, key)
 		if err != nil {
 			return errors.Join(err, iter.Close())
 		}

--- a/internal/keys/datastore_index.go
+++ b/internal/keys/datastore_index.go
@@ -34,8 +34,11 @@ type IndexDataStoreKey struct {
 	IndexID uint32
 	// Fields is the values of the fields in the index
 	Fields []IndexedField
-	// Offset can be set in order to add the given value to the end of the resultant bytes,
-	// allowing fine-grained control over key selection.
+	// Offset can be set in order to control how many times `bytesPrefixEnd` is called when this `IndexDataStoreKey`
+	// is serialized.
+	//
+	// This allows `bytesPrefixEnd` to be managed before serialization, allowing the `bytesPrefixEnd`'ed key to be
+	// passed into strongly typed interfaces, such as `Keyedstore`.
 	Offset uint64
 }
 

--- a/internal/keys/datastore_index.go
+++ b/internal/keys/datastore_index.go
@@ -34,9 +34,12 @@ type IndexDataStoreKey struct {
 	IndexID uint32
 	// Fields is the values of the fields in the index
 	Fields []IndexedField
+	// Offset can be set in order to add the given value to the end of the resultant bytes,
+	// allowing fine-grained control over key selection.
+	Offset uint64
 }
 
-var _ Key = (*IndexDataStoreKey)(nil)
+var _ Walkable = (*IndexDataStoreKey)(nil)
 
 // NewIndexDataStoreKey creates a new IndexDataStoreKey from a collection ID, index ID and fields.
 // It also validates values of the fields.
@@ -180,15 +183,20 @@ func EncodeIndexDataStoreKey(key *IndexDataStoreKey) []byte {
 
 	b := encoding.EncodeUvarintAscending([]byte{'/'}, uint64(key.CollectionShortID))
 
-	if key.IndexID == 0 {
-		return b
+	if key.IndexID != 0 {
+		b = append(b, '/')
+		b = encoding.EncodeUvarintAscending(b, uint64(key.IndexID))
 	}
-	b = append(b, '/')
-	b = encoding.EncodeUvarintAscending(b, uint64(key.IndexID))
 
 	for _, field := range key.Fields {
 		b = append(b, '/')
 		b = encoding.EncodeFieldValue(b, field.Value, field.Descending)
+	}
+
+	if key.Offset != 0 {
+		for i := 0; i < int(key.Offset); i++ {
+			b = bytesPrefixEnd(b)
+		}
 	}
 
 	return b
@@ -197,6 +205,14 @@ func EncodeIndexDataStoreKey(key *IndexDataStoreKey) []byte {
 // PrefixEnd returns a key that would sort immediately after all keys with this prefix.
 // It returns a key such that all keys with the prefix are >= k and < k.PrefixEnd().
 // This is implemented by encoding the key to bytes and incrementing it.
-func (k IndexDataStoreKey) PrefixEnd() []byte {
-	return bytesPrefixEnd(k.Bytes())
+func (k *IndexDataStoreKey) PrefixEnd() Walkable {
+	newFields := make([]IndexedField, len(k.Fields))
+	copy(newFields, k.Fields)
+
+	return &IndexDataStoreKey{
+		CollectionShortID: k.CollectionShortID,
+		IndexID:           k.IndexID,
+		Fields:            newFields,
+		Offset:            k.Offset + 1,
+	}
 }

--- a/internal/keys/datastore_index.go
+++ b/internal/keys/datastore_index.go
@@ -193,10 +193,8 @@ func EncodeIndexDataStoreKey(key *IndexDataStoreKey) []byte {
 		b = encoding.EncodeFieldValue(b, field.Value, field.Descending)
 	}
 
-	if key.Offset != 0 {
-		for i := 0; i < int(key.Offset); i++ {
-			b = bytesPrefixEnd(b)
-		}
+	for i := 0; i < int(key.Offset); i++ {
+		b = bytesPrefixEnd(b)
 	}
 
 	return b

--- a/internal/keys/datastore_index.go
+++ b/internal/keys/datastore_index.go
@@ -189,11 +189,11 @@ func EncodeIndexDataStoreKey(key *IndexDataStoreKey) []byte {
 	if key.IndexID != 0 {
 		b = append(b, '/')
 		b = encoding.EncodeUvarintAscending(b, uint64(key.IndexID))
-	}
 
-	for _, field := range key.Fields {
-		b = append(b, '/')
-		b = encoding.EncodeFieldValue(b, field.Value, field.Descending)
+		for _, field := range key.Fields {
+			b = append(b, '/')
+			b = encoding.EncodeFieldValue(b, field.Value, field.Descending)
+		}
 	}
 
 	for i := 0; i < int(key.Offset); i++ {

--- a/internal/keys/datastore_index_test.go
+++ b/internal/keys/datastore_index_test.go
@@ -84,7 +84,7 @@ func TestIndexDataStoreKey_PrefixEnd(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			keyBytes := tt.key.Bytes()
-			endBytes := tt.key.PrefixEnd()
+			endBytes := tt.key.PrefixEnd().Bytes()
 
 			if tt.wantGreaterThan {
 				assert.True(t, string(endBytes) > string(keyBytes),
@@ -140,33 +140,12 @@ func TestIndexDataStoreKey_PrefixEnd_Ordering(t *testing.T) {
 			},
 			shouldMatch: []bool{true, true, false},
 		},
-		{
-			name: "collection prefix",
-			prefixKey: IndexDataStoreKey{
-				CollectionShortID: 10,
-			},
-			testKeys: []IndexDataStoreKey{
-				{
-					CollectionShortID: 10,
-					IndexID:           1,
-				},
-				{
-					CollectionShortID: 10,
-					IndexID:           2,
-				},
-				{
-					CollectionShortID: 11,
-					IndexID:           1,
-				},
-			},
-			shouldMatch: []bool{true, true, false},
-		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			prefixBytes := tt.prefixKey.Bytes()
-			endBytes := tt.prefixKey.PrefixEnd()
+			endBytes := tt.prefixKey.PrefixEnd().Bytes()
 
 			for i, testKey := range tt.testKeys {
 				testBytes := testKey.Bytes()

--- a/internal/keys/datastore_view_item.go
+++ b/internal/keys/datastore_view_item.go
@@ -11,6 +11,7 @@
 package keys
 
 import (
+	"bytes"
 	"strconv"
 
 	ds "github.com/ipfs/go-datastore"
@@ -47,6 +48,36 @@ func NewViewCacheKey(collectionShortID uint32, itemID uint) ViewCacheKey {
 		CollectionShortID: collectionShortID,
 		ItemID:            itemID,
 	}
+}
+
+func NewViewCacheKeyFromRaw(raw []byte) (ViewCacheKey, error) {
+	if len(raw) == 0 {
+		return ViewCacheKey{}, nil
+	}
+
+	components := bytes.Split(raw, []byte("/"))
+	if len(components) > 2 {
+		return ViewCacheKey{}, ErrInvalidKey
+	}
+
+	_, collectionShortID, err := encoding.DecodeUvarintAscending(components[0])
+	if err != nil {
+		return ViewCacheKey{}, err
+	}
+
+	var itemID uint
+	if len(components) == 2 {
+		_, r, err := encoding.DecodeUvarintAscending(components[1])
+		if err != nil {
+			return ViewCacheKey{}, err
+		}
+		itemID = uint(r)
+	}
+
+	return ViewCacheKey{
+		CollectionShortID: uint32(collectionShortID),
+		ItemID:            itemID,
+	}, nil
 }
 
 func (k ViewCacheKey) ToString() string {

--- a/internal/keys/key_test.go
+++ b/internal/keys/key_test.go
@@ -103,12 +103,6 @@ func TestIndexDatastoreKey_Bytes(t *testing.T) {
 			Expected:     encodeKey(1, 2, 5, false, 7, false),
 		},
 		{
-			Name:         "no index",
-			CollectionID: 1,
-			Fields:       []IndexedField{{Value: client.NewNormalInt(5)}},
-			Expected:     encoding.EncodeUvarintAscending([]byte{'/'}, 1),
-		},
-		{
 			Name:     "no collection",
 			IndexID:  2,
 			Fields:   []IndexedField{{Value: client.NewNormalInt(5)}},

--- a/internal/lens/fetcher.go
+++ b/internal/lens/fetcher.go
@@ -337,14 +337,14 @@ func (f *lensedFetcher) updateDataStore(ctx context.Context, original map[string
 			return err
 		}
 
-		err = txn.Datastore().Set(ctx, fieldKey.Bytes(), bytes)
+		err = txn.Datastore().Set(ctx, fieldKey, bytes)
 		if err != nil {
 			return err
 		}
 	}
 
 	versionKey := datastoreKeyBase.WithFieldID(keys.DATASTORE_DOC_VERSION_FIELD_ID)
-	err = txn.Datastore().Set(ctx, versionKey.Bytes(), []byte(f.targetVersionID))
+	err = txn.Datastore().Set(ctx, versionKey, []byte(f.targetVersionID))
 	if err != nil {
 		return err
 	}

--- a/internal/planner/view.go
+++ b/internal/planner/view.go
@@ -200,8 +200,8 @@ func (n *cachedViewFetcher) Init() error {
 		return err
 	}
 	txn := datastore.CtxMustGetTxn(n.p.ctx)
-	iter, err := txn.Datastore().Iterator(n.p.ctx, corekv.IterOptions{
-		Prefix: keys.NewViewCacheColPrefix(shortID).Bytes(),
+	iter, err := txn.Datastore().Iterator(n.p.ctx, datastore.IterOptions{
+		Prefix: keys.NewViewCacheColPrefix(shortID),
 	})
 	if err != nil {
 		return err

--- a/internal/se/se.go
+++ b/internal/se/se.go
@@ -17,12 +17,12 @@ import (
 	"context"
 	"slices"
 
-	"github.com/sourcenetwork/corekv"
 	"github.com/sourcenetwork/immutable"
 
 	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/errors"
+	"github.com/sourcenetwork/defradb/internal/datastore"
 	"github.com/sourcenetwork/defradb/internal/db/id"
 	"github.com/sourcenetwork/defradb/internal/encoding"
 	"github.com/sourcenetwork/defradb/internal/keys"
@@ -30,7 +30,7 @@ import (
 )
 
 // storeArtifacts stores SE artifacts directly in the datastore.
-func storeArtifacts(ctx context.Context, ds corekv.ReaderWriter, artifacts []secore.Artifact) error {
+func storeArtifacts(ctx context.Context, ds datastore.Keyedstore, artifacts []secore.Artifact) error {
 	for _, artifact := range artifacts {
 		colID, err := id.GetShortCollectionID(ctx, artifact.CollectionID)
 		if err != nil {
@@ -44,7 +44,7 @@ func storeArtifacts(ctx context.Context, ds corekv.ReaderWriter, artifacts []sec
 			DocID:             artifact.DocID,
 		}
 
-		if err := ds.Set(ctx, key.Bytes(), []byte{}); err != nil {
+		if err := ds.Set(ctx, key, []byte{}); err != nil {
 			return err
 		}
 	}
@@ -56,7 +56,7 @@ func storeArtifacts(ctx context.Context, ds corekv.ReaderWriter, artifacts []sec
 // and returns the document IDs for documents that match all queries.
 func fetchDocIDs(
 	ctx context.Context,
-	ds corekv.ReaderWriter,
+	ds datastore.Keyedstore,
 	collectionID string,
 	queries []fieldQuery,
 ) ([]string, error) {
@@ -75,8 +75,8 @@ func fetchDocIDs(
 			SearchTag:         query.SearchTag,
 		}
 
-		iter, err := ds.Iterator(ctx, corekv.IterOptions{
-			Prefix: key.Bytes(),
+		iter, err := ds.Iterator(ctx, datastore.IterOptions{
+			Prefix: key,
 		})
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4233

## Description

Wraps the Datastore in a new `Keyedstore` wrapper around `corekv.ReaderWriter`.

This gives us a single location from which we can manage Defra-specific access to the datastore using they typed keys, which for #4207, will mean enforcing read-locks for collection-specific keys whilst a truncate is being performed.

The new `Keyedstore` interface is store agnostic and can be used for our other stores, and may need to be at some point.  I have only used it for the Datastore in this PR, as I think that is the only store that I will need/want to lock in such a way for `truncate`.  

The only implementation of `Keyedstore` would work for for all stores at the moment, however that will change soon, within the `truncate` PR, as the locking will be very specific to the datastore.

This PR is a pure refactor, no user-behaviour has changed.  The first two commits are semi-unrelated dead-code cleans that I spotted as they got in the way.  Similarly, a couple of unit tests were removed.
