### PR TITLE
chore: Bump to GoLang v1.25

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sourcenetwork/defradb
 
-go 1.24.6
+go 1.25.5
 
 require (
 	github.com/bits-and-blooms/bitset v1.22.0

--- a/tools/cloud/aws/packer/build_aws_ami.pkr.hcl
+++ b/tools/cloud/aws/packer/build_aws_ami.pkr.hcl
@@ -66,8 +66,8 @@ build {
     inline = [
       "/usr/bin/cloud-init status --wait",
       "sudo apt-get update && sudo apt-get install make build-essential -y",
-      "curl -OL https://golang.org/dl/go1.24.6.linux-amd64.tar.gz",
-      "rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.24.6.linux-amd64.tar.gz",
+      "curl -OL https://golang.org/dl/go1.25.5.linux-amd64.tar.gz",
+      "rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.25.5.linux-amd64.tar.gz",
       "export PATH=$PATH:/usr/local/go/bin",
       "git clone \"https://git@$DEFRADB_GIT_REPO\"",
       "cd ./defradb || { printf \"\\\ncd into defradb failed.\\\n\" && exit 2; }",

--- a/tools/configs/golangci.yaml
+++ b/tools/configs/golangci.yaml
@@ -24,7 +24,7 @@ run:
 
   # Define the Go version limit.
   # Default: use Go version from the go.mod file, fallback on the env var `GOVERSION`, fallback on 1.22.
-  go: '1.24'
+  go: '1.25'
 
   # If set, we pass it to "go list -mod={option}". From "go help modules":
   # If invoked with -mod=readonly, the go command is disallowed from the implicit

--- a/tools/defradb.containerfile
+++ b/tools/defradb.containerfile
@@ -7,7 +7,7 @@
 # WARNING: The build image SHOULD use the same OS version as the run image. Otherwise they may have
 # different versions of GLIBC and the dynamic linking of libraries will fail.
 # `bookworm` is Debian 12.
-FROM docker.io/golang:1.24-bookworm AS build
+FROM docker.io/golang:1.25-bookworm AS build
 WORKDIR /repo/
 COPY go.mod go.sum Makefile ./
 RUN make deps:modules


### PR DESCRIPTION
## Relevant issue(s)
Resolves #4257

## Description
- This is a routine version bump of GoLang, the previous bump was done in (https://github.com/sourcenetwork/defradb/pull/3946)
- Also updates the golang version for AWS AMI generation.

### Routine Todo(s)
- [x] Open ticket for next GoLang version bump (#4258)