### PR TITLE
chore: Update secp256r1 logic

### DIFF
--- a/crypto/keys.go
+++ b/crypto/keys.go
@@ -12,7 +12,6 @@ package crypto
 
 import (
 	"bytes"
-	"crypto/ecdh"
 	"crypto/ecdsa"
 	"crypto/ed25519"
 	"crypto/rand"
@@ -197,27 +196,11 @@ func PublicKeyFromString(keyType KeyType, keyString string) (PublicKey, error) {
 			if keyBytes[0] != 0x04 {
 				return nil, ErrInvalidECDSAPubKey
 			}
-			_, err := ecdh.P256().NewPublicKey(keyBytes)
+			pubKey, err := ecdsa.ParseUncompressedPublicKey(elliptic.P256(), keyBytes)
 			if err != nil {
 				return nil, ErrInvalidECDSAPubKey
 			}
-			if len(keyBytes) != 65 {
-				return nil, ErrInvalidECDSAPubKey
-			}
-			x := new(big.Int).SetBytes(keyBytes[1:33])
-			y := new(big.Int).SetBytes(keyBytes[33:65])
-			pubKey = &ecdsa.PublicKey{
-				Curve: elliptic.P256(),
-				X:     x,
-				Y:     y,
-			}
-			compressedBytes = elliptic.MarshalCompressed(elliptic.P256(), x, y)
-			// TODO: use this approach after upgrading to Go v1.25+ (https://github.com/sourcenetwork/defradb/issues/4205)
-			// pubKey, err := ecdsa.ParseUncompressedPublicKey(elliptic.P256(), keyBytes)
-			// if err != nil {
-			// 	return nil, ErrInvalidECDSAPubKey
-			// }
-			// compressedBytes = elliptic.MarshalCompressed(elliptic.P256(), pubKey.X, pubKey.Y)
+			compressedBytes = elliptic.MarshalCompressed(elliptic.P256(), pubKey.X, pubKey.Y)
 		} else {
 			return nil, ErrInvalidECDSAPubKey
 		}
@@ -418,24 +401,10 @@ func PrivateKeyFromBytes(keyType KeyType, keyBytes []byte) (PrivateKey, error) {
 		if len(keyBytes) != 32 {
 			return nil, ErrInvalidECDSAPrivKeyBytes
 		}
-		ecdhPrivKey, err := ecdh.P256().NewPrivateKey(keyBytes)
+		privKey, err := ecdsa.ParseRawPrivateKey(elliptic.P256(), keyBytes)
 		if err != nil {
 			return nil, err
 		}
-		pubKeyBytes := ecdhPrivKey.PublicKey().Bytes()
-		privKey := &ecdsa.PrivateKey{
-			D: new(big.Int).SetBytes(keyBytes),
-			PublicKey: ecdsa.PublicKey{
-				Curve: elliptic.P256(),
-				X:     new(big.Int).SetBytes(pubKeyBytes[1:33]),
-				Y:     new(big.Int).SetBytes(pubKeyBytes[33:65]),
-			},
-		}
-		// TODO: use this approach after upgrading to Go v1.25+ (https://github.com/sourcenetwork/defradb/issues/4205)
-		// privKey, err := ecdsa.ParseRawPrivateKey(elliptic.P256(), keyBytes)
-		// if err != nil {
-		// 	return nil, err
-		// }
 		return &secp256r1PrivateKey{key: privKey}, nil
 
 	case KeyTypeEd25519:

--- a/crypto/keys.go
+++ b/crypto/keys.go
@@ -196,7 +196,7 @@ func PublicKeyFromString(keyType KeyType, keyString string) (PublicKey, error) {
 			if keyBytes[0] != 0x04 {
 				return nil, ErrInvalidECDSAPubKey
 			}
-			pubKey, err := ecdsa.ParseUncompressedPublicKey(elliptic.P256(), keyBytes)
+			pubKey, err = ecdsa.ParseUncompressedPublicKey(elliptic.P256(), keyBytes)
 			if err != nil {
 				return nil, ErrInvalidECDSAPubKey
 			}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4205 

## Description

This PR updates secp256r1 logic to use new crypto utils available in `go 1.25+`.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

(*replace*) Describe the tests performed to verify the changes. Provide instructions to reproduce them.

Specify the platform(s) on which this was tested:
- Debian Linux
- MacOS