### PR TITLE
feat: Add methods AddLens and ListLenses

### DIFF
--- a/cbindings/lens.go
+++ b/cbindings/lens.go
@@ -53,3 +53,26 @@ func LensSet(nodePtr C.uintptr_t, src *C.char, dst *C.char, cfg *C.char) C.Resul
 	}
 	return returnC(returnGoC(0, "", lensID))
 }
+
+//export LensAdd
+func LensAdd(nodePtr C.uintptr_t, cfg *C.char) C.Result {
+	ctx := context.Background()
+
+	decoder := json.NewDecoder(strings.NewReader(C.GoString(cfg)))
+	decoder.DisallowUnknownFields()
+	var lensCfg model.Lens
+	if err := decoder.Decode(&lensCfg); err != nil {
+		return returnC(returnGoC(1, err.Error(), ""))
+	}
+
+	store, err := getStoreFromPointer(nodePtr)
+	if err != nil {
+		return returnC(returnGoC(1, err.Error(), ""))
+	}
+
+	lensID, err := store.AddLens(ctx, lensCfg)
+	if err != nil {
+		return returnC(returnGoC(1, err.Error(), ""))
+	}
+	return returnC(returnGoC(0, "", lensID))
+}

--- a/cbindings/lens.go
+++ b/cbindings/lens.go
@@ -76,3 +76,24 @@ func LensAdd(nodePtr C.uintptr_t, cfg *C.char) C.Result {
 	}
 	return returnC(returnGoC(0, "", lensID))
 }
+
+//export LensList
+func LensList(nodePtr C.uintptr_t) C.Result {
+	ctx := context.Background()
+
+	store, err := getStoreFromPointer(nodePtr)
+	if err != nil {
+		return returnC(returnGoC(1, err.Error(), ""))
+	}
+
+	lenses, err := store.ListLenses(ctx)
+	if err != nil {
+		return returnC(returnGoC(1, err.Error(), ""))
+	}
+
+	lensesJSON, err := json.Marshal(lenses)
+	if err != nil {
+		return returnC(returnGoC(1, err.Error(), ""))
+	}
+	return returnC(returnGoC(0, "", string(lensesJSON)))
+}

--- a/cbindings/wrapper.go
+++ b/cbindings/wrapper.go
@@ -38,6 +38,7 @@ extern Result EncryptedIndexCreate(uintptr_t nodePtr, char* collectionName, char
 extern Result EncryptedIndexList(uintptr_t nodePtr, char* collectionName);
 extern Result EncryptedIndexDelete(uintptr_t nodePtr, char* collectionName, char* fieldName);
 extern Result LensSet(uintptr_t nodePtr, char* src, char* dst, char* cfg);
+extern Result LensAdd(uintptr_t nodePtr, char* cfg);
 extern NewNodeResult NewNode(NodeInitOptions cOptions);
 extern Result NodeClose(uintptr_t nodePtr);
 extern Result P2PInfo(uintptr_t nodePtr);
@@ -671,6 +672,23 @@ func (w *CWrapper) SetMigration(ctx context.Context, config client.LensConfig) (
 
 	callHandle := getNodeOrTxnHandle(w.handle, ctx)
 	res := ConvertAndFreeCResult(C.LensSet(callHandle, src, dst, lens))
+
+	if res.Status != 0 {
+		return "", errors.New(res.Error)
+	}
+	return res.Value, nil
+}
+
+func (w *CWrapper) AddLens(ctx context.Context, lens model.Lens) (string, error) {
+	lensConfig, err := json.Marshal(lens)
+	if err != nil {
+		return "", err
+	}
+	lensStr := C.CString(string(lensConfig))
+	defer C.free(unsafe.Pointer(lensStr))
+
+	callHandle := getNodeOrTxnHandle(w.handle, ctx)
+	res := ConvertAndFreeCResult(C.LensAdd(callHandle, lensStr))
 
 	if res.Status != 0 {
 		return "", errors.New(res.Error)

--- a/cbindings/wrapper.go
+++ b/cbindings/wrapper.go
@@ -39,6 +39,7 @@ extern Result EncryptedIndexList(uintptr_t nodePtr, char* collectionName);
 extern Result EncryptedIndexDelete(uintptr_t nodePtr, char* collectionName, char* fieldName);
 extern Result LensSet(uintptr_t nodePtr, char* src, char* dst, char* cfg);
 extern Result LensAdd(uintptr_t nodePtr, char* cfg);
+extern Result LensList(uintptr_t nodePtr);
 extern NewNodeResult NewNode(NodeInitOptions cOptions);
 extern Result NodeClose(uintptr_t nodePtr);
 extern Result P2PInfo(uintptr_t nodePtr);
@@ -694,6 +695,21 @@ func (w *CWrapper) AddLens(ctx context.Context, lens model.Lens) (string, error)
 		return "", errors.New(res.Error)
 	}
 	return res.Value, nil
+}
+
+func (w *CWrapper) ListLenses(ctx context.Context) (map[string]model.Lens, error) {
+	callHandle := getNodeOrTxnHandle(w.handle, ctx)
+	res := ConvertAndFreeCResult(C.LensList(callHandle))
+
+	if res.Status != 0 {
+		return nil, errors.New(res.Error)
+	}
+
+	var lenses map[string]model.Lens
+	if err := json.Unmarshal([]byte(res.Value), &lenses); err != nil {
+		return nil, err
+	}
+	return lenses, nil
 }
 
 func (w *CWrapper) GetCollectionByName(ctx context.Context, name client.CollectionName) (client.Collection, error) {

--- a/cbindings/wrapper_tx.go
+++ b/cbindings/wrapper_tx.go
@@ -133,6 +133,10 @@ func (txn *Transaction) AddLens(ctx context.Context, lens model.Lens) (string, e
 	return txn.CWrapper.AddLens(ctx, lens)
 }
 
+func (txn *Transaction) ListLenses(ctx context.Context) (map[string]model.Lens, error) {
+	return txn.CWrapper.ListLenses(ctx)
+}
+
 func (txn *Transaction) GetCollectionByName(
 	ctx context.Context,
 	name client.CollectionName,

--- a/cbindings/wrapper_tx.go
+++ b/cbindings/wrapper_tx.go
@@ -129,6 +129,10 @@ func (txn *Transaction) SetMigration(ctx context.Context, config client.LensConf
 	return txn.CWrapper.SetMigration(ctx, config)
 }
 
+func (txn *Transaction) AddLens(ctx context.Context, lens model.Lens) (string, error) {
+	return txn.CWrapper.AddLens(ctx, lens)
+}
+
 func (txn *Transaction) GetCollectionByName(
 	ctx context.Context,
 	name client.CollectionName,

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -69,6 +69,7 @@ func NewDefraCommand(ctx context.Context) *cobra.Command {
 	lens := MakeLensCommand(ctx)
 	lens.AddCommand(
 		MakeLensSetCommand(ctx),
+		MakeLensAddCommand(ctx),
 	)
 
 	schema := MakeSchemaCommand(ctx)

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -70,6 +70,7 @@ func NewDefraCommand(ctx context.Context) *cobra.Command {
 	lens.AddCommand(
 		MakeLensSetCommand(ctx),
 		MakeLensAddCommand(ctx),
+		MakeLensListCommand(ctx),
 	)
 
 	schema := MakeSchemaCommand(ctx)

--- a/cli/lens_add.go
+++ b/cli/lens_add.go
@@ -1,0 +1,86 @@
+// Copyright 2024 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/sourcenetwork/lens/host-go/config/model"
+)
+
+func MakeLensAddCommand(ctx context.Context) *cobra.Command {
+	var lensFile string
+	var cmd = &cobra.Command{
+		Use:   "add [cfg]",
+		Short: "Add a lens to the lens store",
+		Long: `Add a lens configuration to the lens store and return its CID.
+
+The lens store is content-addressed, so identical lens configurations
+will return the same CID without duplicating storage.`,
+		Args: cobra.RangeArgs(0, 1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cliClient := mustGetContextCLIClient(cmd)
+
+			var lensCfgJson string
+			switch {
+			case lensFile != "":
+				data, err := os.ReadFile(lensFile)
+				if err != nil {
+					return err
+				}
+				lensCfgJson = string(data)
+			case len(args) == 1 && args[0] == "-":
+				data, err := io.ReadAll(cmd.InOrStdin())
+				if err != nil {
+					return err
+				}
+				lensCfgJson = string(data)
+			case len(args) == 1:
+				lensCfgJson = args[0]
+			default:
+				return ErrNoLensConfig
+			}
+
+			decoder := json.NewDecoder(strings.NewReader(lensCfgJson))
+			decoder.DisallowUnknownFields()
+
+			var lensCfg model.Lens
+			if err := decoder.Decode(&lensCfg); err != nil {
+				return NewErrInvalidLensConfig(err)
+			}
+
+			lensID, err := cliClient.AddLens(cmd.Context(), lensCfg)
+			if err != nil {
+				return err
+			}
+
+			return writeJSON(cmd, lensID)
+		},
+	}
+
+	EmbedCLIExample(ctx, cmd, "add from an argument string",
+		`defradb client lens add '{"lenses": [...'`)
+
+	EmbedCLIExample(ctx, cmd, "add from file",
+		`defradb client lens add -f lens_config.json`)
+
+	EmbedCLIExample(ctx, cmd, "add from stdin",
+		`cat lens_config.json | defradb client lens add -`)
+
+	cmd.Flags().StringVarP(&lensFile, "file", "f", "", "Lens configuration file")
+	return cmd
+}

--- a/cli/lens_list.go
+++ b/cli/lens_list.go
@@ -1,0 +1,43 @@
+// Copyright 2025 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package cli
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+)
+
+func MakeLensListCommand(ctx context.Context) *cobra.Command {
+	var cmd = &cobra.Command{
+		Use:   "list",
+		Short: "List all stored lenses",
+		Long: `List all lenses stored in the lens store.
+
+Returns a map of lens CIDs to their configurations.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cliClient := mustGetContextCLIClient(cmd)
+
+			lenses, err := cliClient.ListLenses(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			return writeJSON(cmd, lenses)
+		},
+	}
+
+	EmbedCLIExample(ctx, cmd, "list all lenses",
+		`defradb client lens list`)
+
+	return cmd
+}

--- a/client/db.go
+++ b/client/db.go
@@ -256,6 +256,12 @@ type Store interface {
 	// Returns the ID of the Lens transform.
 	SetMigration(ctx context.Context, config LensConfig) (string, error)
 
+	// AddLens stores a lens configuration and returns its CID.
+	//
+	// The lens store is content-addressed, so identical lens configurations
+	// will return the same CID without duplicating storage.
+	AddLens(ctx context.Context, lens model.Lens) (string, error)
+
 	// GetCollectionByName attempts to retrieve a collection matching the given name.
 	//
 	// If no matching collection is found an error will be returned.

--- a/client/db.go
+++ b/client/db.go
@@ -262,6 +262,9 @@ type Store interface {
 	// will return the same CID without duplicating storage.
 	AddLens(ctx context.Context, lens model.Lens) (string, error)
 
+	// ListLenses returns all stored lenses mapped by their CID.
+	ListLenses(ctx context.Context) (map[string]model.Lens, error)
+
 	// GetCollectionByName attempts to retrieve a collection matching the given name.
 	//
 	// If no matching collection is found an error will be returned.

--- a/client/mocks/txn.go
+++ b/client/mocks/txn.go
@@ -254,6 +254,72 @@ func (_c *Txn_AddDACPolicy_Call) RunAndReturn(run func(ctx context.Context, poli
 	return _c
 }
 
+// AddLens provides a mock function for the type Txn
+func (_mock *Txn) AddLens(ctx context.Context, lens model.Lens) (string, error) {
+	ret := _mock.Called(ctx, lens)
+
+	if len(ret) == 0 {
+		panic("no return value specified for AddLens")
+	}
+
+	var r0 string
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, model.Lens) (string, error)); ok {
+		return returnFunc(ctx, lens)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, model.Lens) string); ok {
+		r0 = returnFunc(ctx, lens)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, model.Lens) error); ok {
+		r1 = returnFunc(ctx, lens)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// Txn_AddLens_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AddLens'
+type Txn_AddLens_Call struct {
+	*mock.Call
+}
+
+// AddLens is a helper method to define mock.On call
+//   - ctx context.Context
+//   - lens model.Lens
+func (_e *Txn_Expecter) AddLens(ctx interface{}, lens interface{}) *Txn_AddLens_Call {
+	return &Txn_AddLens_Call{Call: _e.mock.On("AddLens", ctx, lens)}
+}
+
+func (_c *Txn_AddLens_Call) Run(run func(ctx context.Context, lens model.Lens)) *Txn_AddLens_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 model.Lens
+		if args[1] != nil {
+			arg1 = args[1].(model.Lens)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *Txn_AddLens_Call) Return(s string, err error) *Txn_AddLens_Call {
+	_c.Call.Return(s, err)
+	return _c
+}
+
+func (_c *Txn_AddLens_Call) RunAndReturn(run func(ctx context.Context, lens model.Lens) (string, error)) *Txn_AddLens_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // AddNACActorRelationship provides a mock function for the type Txn
 func (_mock *Txn) AddNACActorRelationship(ctx context.Context, relation string, targetActor string) (client.AddActorRelationshipResult, error) {
 	ret := _mock.Called(ctx, relation, targetActor)

--- a/client/mocks/txn.go
+++ b/client/mocks/txn.go
@@ -1883,6 +1883,68 @@ func (_c *Txn_ListAllEncryptedIndexes_Call) RunAndReturn(run func(context1 conte
 	return _c
 }
 
+// ListLenses provides a mock function for the type Txn
+func (_mock *Txn) ListLenses(ctx context.Context) (map[string]model.Lens, error) {
+	ret := _mock.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListLenses")
+	}
+
+	var r0 map[string]model.Lens
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context) (map[string]model.Lens, error)); ok {
+		return returnFunc(ctx)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context) map[string]model.Lens); ok {
+		r0 = returnFunc(ctx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[string]model.Lens)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = returnFunc(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// Txn_ListLenses_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListLenses'
+type Txn_ListLenses_Call struct {
+	*mock.Call
+}
+
+// ListLenses is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *Txn_Expecter) ListLenses(ctx interface{}) *Txn_ListLenses_Call {
+	return &Txn_ListLenses_Call{Call: _e.mock.On("ListLenses", ctx)}
+}
+
+func (_c *Txn_ListLenses_Call) Run(run func(ctx context.Context)) *Txn_ListLenses_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *Txn_ListLenses_Call) Return(stringToLens map[string]model.Lens, err error) *Txn_ListLenses_Call {
+	_c.Call.Return(stringToLens, err)
+	return _c
+}
+
+func (_c *Txn_ListLenses_Call) RunAndReturn(run func(ctx context.Context) (map[string]model.Lens, error)) *Txn_ListLenses_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // PatchCollection provides a mock function for the type Txn
 func (_mock *Txn) PatchCollection(ctx context.Context, patch string, migration immutable.Option[model.Lens]) error {
 	ret := _mock.Called(ctx, patch, migration)

--- a/docs/website/references/cli/defradb_client_lens_add.md
+++ b/docs/website/references/cli/defradb_client_lens_add.md
@@ -1,15 +1,36 @@
-## defradb client lens
+## defradb client lens add
 
-Interact with the schema migration system of a running DefraDB instance
+Add a lens to the lens store
 
 ### Synopsis
 
-Make set or look for existing schema migrations on a DefraDB node.
+Add a lens configuration to the lens store and return its CID.
+
+The lens store is content-addressed, so identical lens configurations
+will return the same CID without duplicating storage.
+
+```
+defradb client lens add [cfg] [flags]
+```
+
+### Examples
+
+```
+add from an argument string:  
+  defradb client lens add '{"lenses": [...'
+
+add from file:  
+  defradb client lens add -f lens_config.json
+
+add from stdin:  
+  cat lens_config.json | defradb client lens add -
+```
 
 ### Options
 
 ```
-  -h, --help   help for lens
+  -f, --file string   Lens configuration file
+  -h, --help          help for add
 ```
 
 ### Options inherited from parent commands
@@ -36,7 +57,5 @@ Make set or look for existing schema migrations on a DefraDB node.
 
 ### SEE ALSO
 
-* [defradb client](defradb_client.md)	 - Interact with a DefraDB node
-* [defradb client lens add](defradb_client_lens_add.md)	 - Add a lens to the lens store
-* [defradb client lens set](defradb_client_lens_set.md)	 - Set a schema migration within DefraDB
+* [defradb client lens](defradb_client_lens.md)	 - Interact with the schema migration system of a running DefraDB instance
 

--- a/docs/website/references/cli/defradb_client_lens_list.md
+++ b/docs/website/references/cli/defradb_client_lens_list.md
@@ -1,15 +1,28 @@
-## defradb client lens
+## defradb client lens list
 
-Interact with the schema migration system of a running DefraDB instance
+List all stored lenses
 
 ### Synopsis
 
-Make set or look for existing schema migrations on a DefraDB node.
+List all lenses stored in the lens store.
+
+Returns a map of lens CIDs to their configurations.
+
+```
+defradb client lens list [flags]
+```
+
+### Examples
+
+```
+list all lenses:  
+  defradb client lens list
+```
 
 ### Options
 
 ```
-  -h, --help   help for lens
+  -h, --help   help for list
 ```
 
 ### Options inherited from parent commands
@@ -36,8 +49,5 @@ Make set or look for existing schema migrations on a DefraDB node.
 
 ### SEE ALSO
 
-* [defradb client](defradb_client.md)	 - Interact with a DefraDB node
-* [defradb client lens add](defradb_client_lens_add.md)	 - Add a lens to the lens store
-* [defradb client lens list](defradb_client_lens_list.md)	 - List all stored lenses
-* [defradb client lens set](defradb_client_lens_set.md)	 - Set a schema migration within DefraDB
+* [defradb client lens](defradb_client_lens.md)	 - Interact with the schema migration system of a running DefraDB instance
 

--- a/docs/website/references/http/openapi.json
+++ b/docs/website/references/http/openapi.json
@@ -1948,6 +1948,36 @@
             }
         },
         "/lens": {
+            "get": {
+                "description": "List all stored lenses",
+                "operationId": "lens_list",
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "lenses": {
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "List of stored lenses"
+                    },
+                    "400": {
+                        "$ref": "#/components/responses/error"
+                    },
+                    "default": {
+                        "description": ""
+                    }
+                },
+                "tags": [
+                    "lens"
+                ]
+            },
             "post": {
                 "description": "Add a new lens migration",
                 "operationId": "lens_set_migration",

--- a/docs/website/references/http/openapi.json
+++ b/docs/website/references/http/openapi.json
@@ -1245,6 +1245,43 @@
                 ]
             }
         },
+        "/collections/migrations": {
+            "post": {
+                "description": "Set a lens migration between collection versions",
+                "operationId": "collection_set_migration",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/lens_config"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/set_migration"
+                                }
+                            }
+                        },
+                        "description": "Lens info"
+                    },
+                    "400": {
+                        "$ref": "#/components/responses/error"
+                    },
+                    "default": {
+                        "description": ""
+                    }
+                },
+                "tags": [
+                    "collection"
+                ]
+            }
+        },
         "/collections/{name}": {
             "delete": {
                 "description": "Delete document(s) from a collection",
@@ -1978,43 +2015,6 @@
                     "lens"
                 ]
             },
-            "post": {
-                "description": "Add a new lens migration",
-                "operationId": "lens_set_migration",
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/lens_config"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/set_migration"
-                                }
-                            }
-                        },
-                        "description": "Lens info"
-                    },
-                    "400": {
-                        "$ref": "#/components/responses/error"
-                    },
-                    "default": {
-                        "description": ""
-                    }
-                },
-                "tags": [
-                    "lens"
-                ]
-            }
-        },
-        "/lens/add": {
             "post": {
                 "description": "Add a lens to the lens store",
                 "operationId": "lens_add",

--- a/docs/website/references/http/openapi.json
+++ b/docs/website/references/http/openapi.json
@@ -115,6 +115,42 @@
                 },
                 "type": "object"
             },
+            "add_lens_request": {
+                "properties": {
+                    "lens": {
+                        "properties": {
+                            "Lenses": {
+                                "items": {
+                                    "properties": {
+                                        "Arguments": {
+                                            "additionalProperties": {},
+                                            "type": "object"
+                                        },
+                                        "Inverse": {
+                                            "type": "boolean"
+                                        },
+                                        "Path": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "type": "object"
+                                },
+                                "type": "array"
+                            }
+                        },
+                        "type": "object"
+                    }
+                },
+                "type": "object"
+            },
+            "add_lens_response": {
+                "properties": {
+                    "lensId": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
             "add_view_request": {
                 "properties": {
                     "Query": {
@@ -1935,6 +1971,43 @@
                             }
                         },
                         "description": "Lens info"
+                    },
+                    "400": {
+                        "$ref": "#/components/responses/error"
+                    },
+                    "default": {
+                        "description": ""
+                    }
+                },
+                "tags": [
+                    "lens"
+                ]
+            }
+        },
+        "/lens/add": {
+            "post": {
+                "description": "Add a lens to the lens store",
+                "operationId": "lens_add",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/add_lens_request"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/add_lens_response"
+                                }
+                            }
+                        },
+                        "description": "Lens CID"
                     },
                     "400": {
                         "$ref": "#/components/responses/error"

--- a/http/client.go
+++ b/http/client.go
@@ -269,6 +269,22 @@ func (c *Client) AddLens(ctx context.Context, lens model.Lens) (string, error) {
 	return res.LensID, nil
 }
 
+func (c *Client) ListLenses(ctx context.Context) (map[string]model.Lens, error) {
+	methodURL := c.http.apiURL.JoinPath("lens")
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, methodURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var res ListLensesResponse
+	if err := c.http.requestJson(req, &res); err != nil {
+		return nil, err
+	}
+
+	return res.Lenses, nil
+}
+
 func (c *Client) GetCollectionByName(ctx context.Context, name client.CollectionName) (client.Collection, error) {
 	cols, err := c.GetCollections(ctx, client.CollectionFetchOptions{Name: immutable.Some(name)})
 	if err != nil {

--- a/http/client.go
+++ b/http/client.go
@@ -248,6 +248,27 @@ func (c *Client) SetMigration(ctx context.Context, config client.LensConfig) (st
 	return res.LensID, nil
 }
 
+func (c *Client) AddLens(ctx context.Context, lens model.Lens) (string, error) {
+	methodURL := c.http.apiURL.JoinPath("lens", "add")
+
+	body, err := json.Marshal(AddLensRequest{Lens: lens})
+	if err != nil {
+		return "", err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, methodURL.String(), bytes.NewBuffer(body))
+	if err != nil {
+		return "", err
+	}
+
+	var res AddLensResponse
+	if err := c.http.requestJson(req, &res); err != nil {
+		return "", err
+	}
+
+	return res.LensID, nil
+}
+
 func (c *Client) GetCollectionByName(ctx context.Context, name client.CollectionName) (client.Collection, error) {
 	cols, err := c.GetCollections(ctx, client.CollectionFetchOptions{Name: immutable.Some(name)})
 	if err != nil {

--- a/http/client.go
+++ b/http/client.go
@@ -228,7 +228,7 @@ func (c *Client) RefreshViews(ctx context.Context, options client.CollectionFetc
 }
 
 func (c *Client) SetMigration(ctx context.Context, config client.LensConfig) (string, error) {
-	methodURL := c.http.apiURL.JoinPath("lens")
+	methodURL := c.http.apiURL.JoinPath("collections", "migrations")
 
 	body, err := json.Marshal(config)
 	if err != nil {
@@ -249,7 +249,7 @@ func (c *Client) SetMigration(ctx context.Context, config client.LensConfig) (st
 }
 
 func (c *Client) AddLens(ctx context.Context, lens model.Lens) (string, error) {
-	methodURL := c.http.apiURL.JoinPath("lens", "add")
+	methodURL := c.http.apiURL.JoinPath("lens")
 
 	body, err := json.Marshal(AddLensRequest{Lens: lens})
 	if err != nil {

--- a/http/client_tx.go
+++ b/http/client_tx.go
@@ -151,6 +151,11 @@ func (txn *Transaction) AddLens(ctx context.Context, lens model.Lens) (string, e
 	return txn.Client.AddLens(ctx, lens)
 }
 
+func (txn *Transaction) ListLenses(ctx context.Context) (map[string]model.Lens, error) {
+	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
+	return txn.Client.ListLenses(ctx)
+}
+
 func (txn *Transaction) GetCollectionByName(
 	ctx context.Context,
 	name client.CollectionName,

--- a/http/client_tx.go
+++ b/http/client_tx.go
@@ -146,6 +146,11 @@ func (txn *Transaction) SetMigration(ctx context.Context, config client.LensConf
 	return txn.Client.SetMigration(ctx, config)
 }
 
+func (txn *Transaction) AddLens(ctx context.Context, lens model.Lens) (string, error) {
+	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
+	return txn.Client.AddLens(ctx, lens)
+}
+
 func (txn *Transaction) GetCollectionByName(
 	ctx context.Context,
 	name client.CollectionName,

--- a/http/handler_store.go
+++ b/http/handler_store.go
@@ -181,6 +181,22 @@ func (h *storeHandler) AddLens(rw http.ResponseWriter, req *http.Request) {
 	responseJSON(rw, http.StatusOK, &AddLensResponse{LensID: lensID})
 }
 
+type ListLensesResponse struct {
+	Lenses map[string]model.Lens `json:"lenses"`
+}
+
+func (h *storeHandler) ListLenses(rw http.ResponseWriter, req *http.Request) {
+	db := mustGetContextClientDB(req)
+
+	lenses, err := db.ListLenses(req.Context())
+	if err != nil {
+		responseJSON(rw, http.StatusBadRequest, errorResponse{err})
+		return
+	}
+
+	responseJSON(rw, http.StatusOK, &ListLensesResponse{Lenses: lenses})
+}
+
 func (h *storeHandler) GetCollection(rw http.ResponseWriter, req *http.Request) {
 	db := mustGetContextClientDB(req)
 
@@ -694,6 +710,22 @@ func (h *storeHandler) bindRoutes(router *Router) {
 	addLens.AddResponse(200, addLensResponse)
 	addLens.Responses.Set("400", errorResponse)
 
+	listLensesResponseSchema := &openapi3.SchemaRef{
+		Value: openapi3.NewObjectSchema().
+			WithProperty("lenses", openapi3.NewObjectSchema()),
+	}
+	listLensesResponse := openapi3.NewResponse().
+		WithDescription("List of stored lenses").
+		WithJSONSchemaRef(listLensesResponseSchema)
+
+	listLenses := openapi3.NewOperation()
+	listLenses.OperationID = "lens_list"
+	listLenses.Description = "List all stored lenses"
+	listLenses.Tags = []string{"lens"}
+	listLenses.Responses = openapi3.NewResponses()
+	listLenses.AddResponse(200, listLensesResponse)
+	listLenses.Responses.Set("400", errorResponse)
+
 	graphQLRequest := openapi3.NewRequestBody().
 		WithContent(openapi3.NewContentWithJSONSchemaRef(graphQLRequestSchema))
 
@@ -799,6 +831,7 @@ func (h *storeHandler) bindRoutes(router *Router) {
 	router.AddRoute("/debug/dump", http.MethodGet, debugDump, h.PrintDump)
 	router.AddRoute("/schema", http.MethodPost, addSchema, h.AddSchema)
 	router.AddRoute("/lens", http.MethodPost, setMigration, h.SetMigration)
+	router.AddRoute("/lens", http.MethodGet, listLenses, h.ListLenses)
 	router.AddRoute("/lens/add", http.MethodPost, addLens, h.AddLens)
 	router.AddRoute("/node/identity", http.MethodGet, nodeIdentity, h.GetNodeIdentity)
 }

--- a/http/handler_store.go
+++ b/http/handler_store.go
@@ -675,9 +675,9 @@ func (h *storeHandler) bindRoutes(router *Router) {
 		WithDescription("Lens info").
 		WithJSONSchemaRef(setMigrationSchema)
 	setMigration := openapi3.NewOperation()
-	setMigration.OperationID = "lens_set_migration"
-	setMigration.Description = "Add a new lens migration"
-	setMigration.Tags = []string{"lens"}
+	setMigration.OperationID = "collection_set_migration"
+	setMigration.Description = "Set a lens migration between collection versions"
+	setMigration.Tags = []string{"collection"}
 	setMigration.RequestBody = &openapi3.RequestBodyRef{
 		Value: setMigrationRequest,
 	}
@@ -824,14 +824,14 @@ func (h *storeHandler) bindRoutes(router *Router) {
 	router.AddRoute("/collections/indexes", http.MethodGet, getAllIndexes, h.GetAllIndexes)
 	router.AddRoute("/encrypted-indexes", http.MethodGet, getAllEncryptedIndexes, h.ListAllEncryptedIndexes)
 	router.AddRoute("/collections/default", http.MethodPost, setActiveCollectionVersion, h.SetActiveCollectionVersion)
+	router.AddRoute("/collections/migrations", http.MethodPost, setMigration, h.SetMigration)
 	router.AddRoute("/view", http.MethodPost, views, h.AddView)
 	router.AddRoute("/view/refresh", http.MethodPost, viewRefresh, h.RefreshViews)
 	router.AddRoute("/graphql", http.MethodGet, graphQLGet, h.ExecRequest)
 	router.AddRoute("/graphql", http.MethodPost, graphQLPost, h.ExecRequest)
 	router.AddRoute("/debug/dump", http.MethodGet, debugDump, h.PrintDump)
 	router.AddRoute("/schema", http.MethodPost, addSchema, h.AddSchema)
-	router.AddRoute("/lens", http.MethodPost, setMigration, h.SetMigration)
+	router.AddRoute("/lens", http.MethodPost, addLens, h.AddLens)
 	router.AddRoute("/lens", http.MethodGet, listLenses, h.ListLenses)
-	router.AddRoute("/lens/add", http.MethodPost, addLens, h.AddLens)
 	router.AddRoute("/node/identity", http.MethodGet, nodeIdentity, h.GetNodeIdentity)
 }

--- a/http/handler_store.go
+++ b/http/handler_store.go
@@ -20,6 +20,7 @@ import (
 	"github.com/getkin/kin-openapi/openapi3"
 
 	"github.com/sourcenetwork/immutable"
+	"github.com/sourcenetwork/lens/host-go/config/model"
 
 	"github.com/sourcenetwork/defradb/client"
 )
@@ -152,6 +153,32 @@ func (h *storeHandler) SetMigration(rw http.ResponseWriter, req *http.Request) {
 	}
 
 	responseJSON(rw, http.StatusOK, &SetMigrationResponse{LensID: lensID})
+}
+
+type AddLensRequest struct {
+	Lens model.Lens `json:"lens"`
+}
+
+type AddLensResponse struct {
+	LensID string `json:"lensId"`
+}
+
+func (h *storeHandler) AddLens(rw http.ResponseWriter, req *http.Request) {
+	db := mustGetContextClientDB(req)
+
+	var addLensReq AddLensRequest
+	if err := requestJSON(req, &addLensReq); err != nil {
+		responseJSON(rw, http.StatusBadRequest, errorResponse{err})
+		return
+	}
+
+	lensID, err := db.AddLens(req.Context(), addLensReq.Lens)
+	if err != nil {
+		responseJSON(rw, http.StatusBadRequest, errorResponse{err})
+		return
+	}
+
+	responseJSON(rw, http.StatusOK, &AddLensResponse{LensID: lensID})
 }
 
 func (h *storeHandler) GetCollection(rw http.ResponseWriter, req *http.Request) {
@@ -642,6 +669,31 @@ func (h *storeHandler) bindRoutes(router *Router) {
 	setMigration.AddResponse(200, setMigrationResponse)
 	setMigration.Responses.Set("400", errorResponse)
 
+	addLensRequestSchema := &openapi3.SchemaRef{
+		Ref: "#/components/schemas/add_lens_request",
+	}
+	addLensRequestBody := openapi3.NewRequestBody().
+		WithRequired(true).
+		WithJSONSchemaRef(addLensRequestSchema)
+
+	addLensResponseSchema := &openapi3.SchemaRef{
+		Ref: "#/components/schemas/add_lens_response",
+	}
+	addLensResponse := openapi3.NewResponse().
+		WithDescription("Lens CID").
+		WithJSONSchemaRef(addLensResponseSchema)
+
+	addLens := openapi3.NewOperation()
+	addLens.OperationID = "lens_add"
+	addLens.Description = "Add a lens to the lens store"
+	addLens.Tags = []string{"lens"}
+	addLens.RequestBody = &openapi3.RequestBodyRef{
+		Value: addLensRequestBody,
+	}
+	addLens.Responses = openapi3.NewResponses()
+	addLens.AddResponse(200, addLensResponse)
+	addLens.Responses.Set("400", errorResponse)
+
 	graphQLRequest := openapi3.NewRequestBody().
 		WithContent(openapi3.NewContentWithJSONSchemaRef(graphQLRequestSchema))
 
@@ -747,5 +799,6 @@ func (h *storeHandler) bindRoutes(router *Router) {
 	router.AddRoute("/debug/dump", http.MethodGet, debugDump, h.PrintDump)
 	router.AddRoute("/schema", http.MethodPost, addSchema, h.AddSchema)
 	router.AddRoute("/lens", http.MethodPost, setMigration, h.SetMigration)
+	router.AddRoute("/lens/add", http.MethodPost, addLens, h.AddLens)
 	router.AddRoute("/node/identity", http.MethodGet, nodeIdentity, h.GetNodeIdentity)
 }

--- a/http/openapi.go
+++ b/http/openapi.go
@@ -52,6 +52,8 @@ var openApiSchemas = map[string]any{
 	"acp_document_relationship_delete_request": &deleteDACActorRelationshipRequest{},
 	"identity":                                 &identity.PublicRawIdentity{},
 	"set_migration":                            &SetMigrationResponse{},
+	"add_lens_request":                         &AddLensRequest{},
+	"add_lens_response":                        &AddLensResponse{},
 }
 
 func NewOpenAPISpec() (*openapi3.T, error) {

--- a/internal/db/lens.go
+++ b/internal/db/lens.go
@@ -44,6 +44,19 @@ func (db *DB) addLens(ctx context.Context, lens model.Lens) (string, error) {
 	return cid.String(), nil
 }
 
+func (db *DB) listLenses(ctx context.Context) (map[string]model.Lens, error) {
+	lenses, err := db.getLensStore(ctx).List(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make(map[string]model.Lens, len(lenses))
+	for cid, lens := range lenses {
+		result[cid.String()] = lens
+	}
+	return result, nil
+}
+
 func (db *DB) setMigration(ctx context.Context, cfg client.LensConfig) (string, error) {
 	dstFound := true
 	dstCol, err := description.GetCollectionByID(ctx, cfg.DestinationSchemaVersionID)

--- a/internal/db/lens.go
+++ b/internal/db/lens.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/sourcenetwork/corekv"
 	"github.com/sourcenetwork/immutable"
+	"github.com/sourcenetwork/lens/host-go/config/model"
 	"github.com/sourcenetwork/lens/host-go/store"
 
 	"github.com/sourcenetwork/defradb/client"
@@ -33,6 +34,14 @@ func (db *DB) getLensStore(ctx context.Context) store.Store {
 	}
 
 	return db.lensNode.Store
+}
+
+func (db *DB) addLens(ctx context.Context, lens model.Lens) (string, error) {
+	cid, err := db.getLensStore(ctx).Add(ctx, lens)
+	if err != nil {
+		return "", err
+	}
+	return cid.String(), nil
 }
 
 func (db *DB) setMigration(ctx context.Context, cfg client.LensConfig) (string, error) {

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -263,6 +263,19 @@ func (db *DB) AddLens(ctx context.Context, lens model.Lens) (string, error) {
 	return lensID, nil
 }
 
+func (db *DB) ListLenses(ctx context.Context) (map[string]model.Lens, error) {
+	ctx, span := tracer.Start(ctx)
+	defer span.End()
+
+	ctx, txn, err := ensureContextTxn(ctx, db, false)
+	if err != nil {
+		return nil, err
+	}
+	defer txn.Discard()
+
+	return db.listLenses(ctx)
+}
+
 func (db *DB) AddView(
 	ctx context.Context,
 	query string,

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -240,6 +240,29 @@ func (db *DB) SetMigration(ctx context.Context, cfg client.LensConfig) (string, 
 	return lensID, nil
 }
 
+func (db *DB) AddLens(ctx context.Context, lens model.Lens) (string, error) {
+	ctx, span := tracer.Start(ctx)
+	defer span.End()
+
+	ctx, txn, err := ensureContextTxn(ctx, db, false)
+	if err != nil {
+		return "", err
+	}
+	defer txn.Discard()
+
+	lensID, err := db.addLens(ctx, lens)
+	if err != nil {
+		return "", err
+	}
+
+	err = txn.Commit()
+	if err != nil {
+		return "", err
+	}
+
+	return lensID, nil
+}
+
 func (db *DB) AddView(
 	ctx context.Context,
 	query string,

--- a/internal/db/txn.go
+++ b/internal/db/txn.go
@@ -231,6 +231,11 @@ func (txn *Txn) AddLens(ctx context.Context, lens model.Lens) (string, error) {
 	return txn.db.addLens(ctx, lens)
 }
 
+func (txn *Txn) ListLenses(ctx context.Context) (map[string]model.Lens, error) {
+	ctx = InitContext(ctx, txn)
+	return txn.db.listLenses(ctx)
+}
+
 func (txn *Txn) GetCollectionByName(ctx context.Context, name client.CollectionName) (client.Collection, error) {
 	ctx = InitContext(ctx, txn)
 	return txn.db.GetCollectionByName(ctx, name)

--- a/internal/db/txn.go
+++ b/internal/db/txn.go
@@ -226,6 +226,11 @@ func (txn *Txn) SetMigration(ctx context.Context, config client.LensConfig) (str
 	return txn.db.SetMigration(ctx, config)
 }
 
+func (txn *Txn) AddLens(ctx context.Context, lens model.Lens) (string, error) {
+	ctx = InitContext(ctx, txn)
+	return txn.db.addLens(ctx, lens)
+}
+
 func (txn *Txn) GetCollectionByName(ctx context.Context, name client.CollectionName) (client.Collection, error) {
 	ctx = InitContext(ctx, txn)
 	return txn.db.GetCollectionByName(ctx, name)

--- a/js/client.go
+++ b/js/client.go
@@ -46,6 +46,7 @@ func (c *Client) JSValue() js.Value {
 		"refreshViews":               goji.Async(c.refreshViews),
 		"setMigration":               goji.Async(c.setMigration),
 		"addLens":                    goji.Async(c.addLens),
+		"listLenses":                 goji.Async(c.listLenses),
 		"getCollectionByName":        goji.Async(c.getCollectionByName),
 		"getCollections":             goji.Async(c.getCollections),
 		"getAllIndexes":              goji.Async(c.getAllIndexes),

--- a/js/client.go
+++ b/js/client.go
@@ -45,6 +45,7 @@ func (c *Client) JSValue() js.Value {
 		"addView":                    goji.Async(c.addView),
 		"refreshViews":               goji.Async(c.refreshViews),
 		"setMigration":               goji.Async(c.setMigration),
+		"addLens":                    goji.Async(c.addLens),
 		"getCollectionByName":        goji.Async(c.getCollectionByName),
 		"getCollections":             goji.Async(c.getCollections),
 		"getAllIndexes":              goji.Async(c.getAllIndexes),

--- a/js/client_store.go
+++ b/js/client_store.go
@@ -138,6 +138,18 @@ func (c *Client) addLens(this js.Value, args []js.Value) (js.Value, error) {
 	return js.ValueOf(lensID), err
 }
 
+func (c *Client) listLenses(this js.Value, args []js.Value) (js.Value, error) {
+	ctx, err := contextArg(args, 0, c.txns)
+	if err != nil {
+		return js.Undefined(), err
+	}
+	lenses, err := c.node.DB.ListLenses(ctx)
+	if err != nil {
+		return js.Undefined(), err
+	}
+	return goji.MarshalJS(lenses)
+}
+
 func (c *Client) getCollectionByName(this js.Value, args []js.Value) (js.Value, error) {
 	name, err := stringArg(args, 0, "name")
 	if err != nil {

--- a/js/client_store.go
+++ b/js/client_store.go
@@ -122,6 +122,22 @@ func (c *Client) setMigration(this js.Value, args []js.Value) (js.Value, error) 
 	return js.ValueOf(lensID), err
 }
 
+func (c *Client) addLens(this js.Value, args []js.Value) (js.Value, error) {
+	var lens model.Lens
+	if err := structArg(args, 0, "lens", &lens); err != nil {
+		return js.Undefined(), err
+	}
+	ctx, err := contextArg(args, 1, c.txns)
+	if err != nil {
+		return js.Undefined(), err
+	}
+	lensID, err := c.node.DB.AddLens(ctx, lens)
+	if err != nil {
+		return js.Undefined(), err
+	}
+	return js.ValueOf(lensID), err
+}
+
 func (c *Client) getCollectionByName(this js.Value, args []js.Value) (js.Value, error) {
 	name, err := stringArg(args, 0, "name")
 	if err != nil {

--- a/js/client_tx.go
+++ b/js/client_tx.go
@@ -43,6 +43,7 @@ func newTransaction(txn client.Txn, txns *sync.Map) js.Value {
 		"addView":                    goji.Async(wrapper.addView),
 		"refreshViews":               goji.Async(wrapper.refreshViews),
 		"setMigration":               goji.Async(wrapper.setMigration),
+		"addLens":                    goji.Async(wrapper.addLens),
 		"getCollectionByName":        goji.Async(wrapper.getCollectionByName),
 		"getCollections":             goji.Async(wrapper.getCollections),
 		"getAllIndexes":              goji.Async(wrapper.getAllIndexes),
@@ -164,6 +165,22 @@ func (t *transaction) setMigration(this js.Value, args []js.Value) (js.Value, er
 		return js.Undefined(), err
 	}
 	lensID, err := t.txn.SetMigration(ctx, config)
+	if err != nil {
+		return js.Undefined(), err
+	}
+	return js.ValueOf(lensID), err
+}
+
+func (t *transaction) addLens(this js.Value, args []js.Value) (js.Value, error) {
+	var lens model.Lens
+	if err := structArg(args, 0, "lens", &lens); err != nil {
+		return js.Undefined(), err
+	}
+	ctx, err := contextArg(args, 1, t.txns)
+	if err != nil {
+		return js.Undefined(), err
+	}
+	lensID, err := t.txn.AddLens(ctx, lens)
 	if err != nil {
 		return js.Undefined(), err
 	}

--- a/js/client_tx.go
+++ b/js/client_tx.go
@@ -44,6 +44,7 @@ func newTransaction(txn client.Txn, txns *sync.Map) js.Value {
 		"refreshViews":               goji.Async(wrapper.refreshViews),
 		"setMigration":               goji.Async(wrapper.setMigration),
 		"addLens":                    goji.Async(wrapper.addLens),
+		"listLenses":                 goji.Async(wrapper.listLenses),
 		"getCollectionByName":        goji.Async(wrapper.getCollectionByName),
 		"getCollections":             goji.Async(wrapper.getCollections),
 		"getAllIndexes":              goji.Async(wrapper.getAllIndexes),
@@ -185,6 +186,18 @@ func (t *transaction) addLens(this js.Value, args []js.Value) (js.Value, error) 
 		return js.Undefined(), err
 	}
 	return js.ValueOf(lensID), err
+}
+
+func (t *transaction) listLenses(this js.Value, args []js.Value) (js.Value, error) {
+	ctx, err := contextArg(args, 0, t.txns)
+	if err != nil {
+		return js.Undefined(), err
+	}
+	lenses, err := t.txn.ListLenses(ctx)
+	if err != nil {
+		return js.Undefined(), err
+	}
+	return goji.MarshalJS(lenses)
 }
 
 func (t *transaction) getCollectionByName(this js.Value, args []js.Value) (js.Value, error) {

--- a/tests/action/add_lens.go
+++ b/tests/action/add_lens.go
@@ -1,0 +1,61 @@
+// Copyright 2025 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package action
+
+import (
+	"github.com/sourcenetwork/immutable"
+	"github.com/sourcenetwork/lens/host-go/config/model"
+
+	"github.com/sourcenetwork/defradb/tests/state"
+)
+
+// AddLens is an action that adds a lens to the lens store and stores its CID.
+type AddLens struct {
+	stateful
+
+	// NodeID may hold the ID (index) of a node to add the lens to.
+	//
+	// If a value is not provided the lens will be added to all nodes.
+	NodeID immutable.Option[int]
+
+	// The identity of this request. Optional.
+	Identity immutable.Option[state.Identity]
+
+	// The lens configuration to add.
+	//
+	// Paths to WASM Lens modules may be found in: github.com/sourcenetwork/defradb/tests/lenses
+	Lens model.Lens
+}
+
+var _ Action = (*AddLens)(nil)
+var _ Stateful = (*AddLens)(nil)
+
+func (a *AddLens) Execute() {
+	var lensID string
+
+	nodeIDs, nodes := getNodesWithIDs(a.NodeID, a.s.Nodes)
+	for index, node := range nodes {
+		nodeID := nodeIDs[index]
+
+		a.s.Ctx = getContextWithIdentity(a.s.Ctx, a.s, a.Identity, nodeID)
+
+		var err error
+		lensID, err = node.AddLens(a.s.Ctx, a.Lens)
+
+		resetStateContext(a.s)
+
+		if err != nil {
+			a.s.T.Fatalf("failed to add lens: %v", err)
+		}
+	}
+
+	a.s.LensIDs = append(a.s.LensIDs, lensID)
+}

--- a/tests/action/add_lens.go
+++ b/tests/action/add_lens.go
@@ -30,8 +30,6 @@ type AddLens struct {
 	Identity immutable.Option[state.Identity]
 
 	// The lens configuration to add.
-	//
-	// Paths to WASM Lens modules may be found in: github.com/sourcenetwork/defradb/tests/lenses
 	Lens model.Lens
 }
 

--- a/tests/action/list_lenses.go
+++ b/tests/action/list_lenses.go
@@ -11,10 +11,11 @@
 package action
 
 import (
-	"github.com/sourcenetwork/immutable"
-	"github.com/sourcenetwork/lens/host-go/config/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/sourcenetwork/immutable"
+	"github.com/sourcenetwork/lens/host-go/config/model"
 
 	"github.com/sourcenetwork/defradb/tests/state"
 )

--- a/tests/action/list_lenses.go
+++ b/tests/action/list_lenses.go
@@ -32,14 +32,11 @@ type ListLenses struct {
 	// The identity of this request. Optional.
 	Identity immutable.Option[state.Identity]
 
-	// ExpectedCount is the expected number of lenses.
-	// If set, the action will verify the count matches.
-	ExpectedCount immutable.Option[int]
-
-	// ExpectedLenses is a map of lens index to expected lens configuration.
-	// The key is the index into s.LensIDs (e.g., 0 for LensID0, 1 for LensID1).
+	// ExpectedLenses is a map of lens CID to expected lens configuration.
+	// Keys can use template syntax (e.g., "{{.LensID0}}") which will be resolved
+	// to actual CIDs at execution time.
 	// If set, the action will verify the lens content matches.
-	ExpectedLenses map[int]model.Lens
+	ExpectedLenses map[string]model.Lens
 }
 
 var _ Action = (*ListLenses)(nil)
@@ -60,35 +57,36 @@ func (a *ListLenses) Execute() {
 			a.s.T.Fatalf("failed to list lenses: %v", err)
 		}
 
-		if a.ExpectedCount.HasValue() {
-			assert.Equal(a.s.T, a.ExpectedCount.Value(), len(lenses),
-				"expected %d lenses, got %d", a.ExpectedCount.Value(), len(lenses))
+		if a.ExpectedLenses == nil {
+			return
 		}
 
-		for _, lensID := range a.s.LensIDs {
-			_, exists := lenses[lensID]
-			assert.True(a.s.T, exists, "expected lens %s not found in list", lensID)
+		templateKeys := make([]string, 0, len(a.ExpectedLenses))
+		for key := range a.ExpectedLenses {
+			templateKeys = append(templateKeys, key)
 		}
+		resolvedKeys := replaceMap(a.s, nodeID, templateKeys)
+
+		assert.Equal(a.s.T, len(a.ExpectedLenses), len(lenses),
+			"expected %d lenses, got %d", len(a.ExpectedLenses), len(lenses))
 
 		// We compare module count, arguments, and inverse flag, but not the Path field
 		// because when stored, the Path changes from a file path to embedded WASM data.
-		for lensIndex, expectedLens := range a.ExpectedLenses {
-			require.Less(a.s.T, lensIndex, len(a.s.LensIDs),
-				"lens index %d out of range (only %d lenses added)", lensIndex, len(a.s.LensIDs))
+		for templateKey, expectedLens := range a.ExpectedLenses {
+			lensID := resolvedKeys[templateKey]
 
-			lensID := a.s.LensIDs[lensIndex]
 			actualLens, exists := lenses[lensID]
-			require.True(a.s.T, exists, "expected lens at index %d (ID: %s) not found", lensIndex, lensID)
+			require.True(a.s.T, exists, "expected lens %s (resolved from %s) not found", lensID, templateKey)
 
 			require.Equal(a.s.T, len(expectedLens.Lenses), len(actualLens.Lenses),
-				"lens module count mismatch for lens at index %d (ID: %s)", lensIndex, lensID)
+				"lens module count mismatch for lens %s", lensID)
 
 			for i, expectedModule := range expectedLens.Lenses {
 				actualModule := actualLens.Lenses[i]
 				assert.Equal(a.s.T, expectedModule.Inverse, actualModule.Inverse,
-					"lens module[%d] inverse mismatch for lens at index %d (ID: %s)", i, lensIndex, lensID)
+					"lens module[%d] inverse mismatch for lens %s", i, lensID)
 				assert.Equal(a.s.T, expectedModule.Arguments, actualModule.Arguments,
-					"lens module[%d] arguments mismatch for lens at index %d (ID: %s)", i, lensIndex, lensID)
+					"lens module[%d] arguments mismatch for lens %s", i, lensID)
 			}
 		}
 	}

--- a/tests/action/list_lenses.go
+++ b/tests/action/list_lenses.go
@@ -1,0 +1,94 @@
+// Copyright 2025 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package action
+
+import (
+	"github.com/sourcenetwork/immutable"
+	"github.com/sourcenetwork/lens/host-go/config/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcenetwork/defradb/tests/state"
+)
+
+// ListLenses is an action that lists all stored lenses and optionally verifies them.
+type ListLenses struct {
+	stateful
+
+	// NodeID may hold the ID (index) of a node to list lenses from.
+	//
+	// If a value is not provided the lenses will be listed from all nodes.
+	NodeID immutable.Option[int]
+
+	// The identity of this request. Optional.
+	Identity immutable.Option[state.Identity]
+
+	// ExpectedCount is the expected number of lenses.
+	// If set, the action will verify the count matches.
+	ExpectedCount immutable.Option[int]
+
+	// ExpectedLenses is a map of lens index to expected lens configuration.
+	// The key is the index into s.LensIDs (e.g., 0 for LensID0, 1 for LensID1).
+	// If set, the action will verify the lens content matches.
+	ExpectedLenses map[int]model.Lens
+}
+
+var _ Action = (*ListLenses)(nil)
+var _ Stateful = (*ListLenses)(nil)
+
+func (a *ListLenses) Execute() {
+	nodeIDs, nodes := getNodesWithIDs(a.NodeID, a.s.Nodes)
+	for index, node := range nodes {
+		nodeID := nodeIDs[index]
+
+		a.s.Ctx = getContextWithIdentity(a.s.Ctx, a.s, a.Identity, nodeID)
+
+		lenses, err := node.ListLenses(a.s.Ctx)
+
+		resetStateContext(a.s)
+
+		if err != nil {
+			a.s.T.Fatalf("failed to list lenses: %v", err)
+		}
+
+		if a.ExpectedCount.HasValue() {
+			assert.Equal(a.s.T, a.ExpectedCount.Value(), len(lenses),
+				"expected %d lenses, got %d", a.ExpectedCount.Value(), len(lenses))
+		}
+
+		for _, lensID := range a.s.LensIDs {
+			_, exists := lenses[lensID]
+			assert.True(a.s.T, exists, "expected lens %s not found in list", lensID)
+		}
+
+		// We compare module count, arguments, and inverse flag, but not the Path field
+		// because when stored, the Path changes from a file path to embedded WASM data.
+		for lensIndex, expectedLens := range a.ExpectedLenses {
+			require.Less(a.s.T, lensIndex, len(a.s.LensIDs),
+				"lens index %d out of range (only %d lenses added)", lensIndex, len(a.s.LensIDs))
+
+			lensID := a.s.LensIDs[lensIndex]
+			actualLens, exists := lenses[lensID]
+			require.True(a.s.T, exists, "expected lens at index %d (ID: %s) not found", lensIndex, lensID)
+
+			require.Equal(a.s.T, len(expectedLens.Lenses), len(actualLens.Lenses),
+				"lens module count mismatch for lens at index %d (ID: %s)", lensIndex, lensID)
+
+			for i, expectedModule := range expectedLens.Lenses {
+				actualModule := actualLens.Lenses[i]
+				assert.Equal(a.s.T, expectedModule.Inverse, actualModule.Inverse,
+					"lens module[%d] inverse mismatch for lens at index %d (ID: %s)", i, lensIndex, lensID)
+				assert.Equal(a.s.T, expectedModule.Arguments, actualModule.Arguments,
+					"lens module[%d] arguments mismatch for lens at index %d (ID: %s)", i, lensIndex, lensID)
+			}
+		}
+	}
+}

--- a/tests/action/replace.go
+++ b/tests/action/replace.go
@@ -61,6 +61,13 @@ var templateDataGenerators = map[string]func(*state.State, int) map[string]strin
 		}
 		return res
 	},
+	"LensID": func(s *state.State, _ int) map[string]string {
+		res := map[string]string{}
+		for i, lensID := range s.LensIDs {
+			res["LensID"+strconv.Itoa(i)] = lensID
+		}
+		return res
+	},
 }
 
 // replace returns a new string with any templating placholders (see "text/template") with data drawn

--- a/tests/clients/cli/wrapper.go
+++ b/tests/clients/cli/wrapper.go
@@ -372,6 +372,27 @@ func (w *Wrapper) SetMigration(ctx context.Context, config client.LensConfig) (s
 	return lensID, nil
 }
 
+func (w *Wrapper) AddLens(ctx context.Context, lens model.Lens) (string, error) {
+	args := []string{"client", "lens", "add"}
+
+	lensJSON, err := json.Marshal(lens)
+	if err != nil {
+		return "", err
+	}
+	args = append(args, string(lensJSON))
+
+	data, err := w.cmd.execute(ctx, args)
+	if err != nil {
+		return "", err
+	}
+
+	var lensID string
+	if err := json.Unmarshal(data, &lensID); err != nil {
+		return "", err
+	}
+	return lensID, nil
+}
+
 func (w *Wrapper) GetCollectionByName(ctx context.Context, name client.CollectionName) (client.Collection, error) {
 	cols, err := w.GetCollections(ctx, client.CollectionFetchOptions{Name: immutable.Some(name)})
 	if err != nil {

--- a/tests/clients/cli/wrapper.go
+++ b/tests/clients/cli/wrapper.go
@@ -393,6 +393,21 @@ func (w *Wrapper) AddLens(ctx context.Context, lens model.Lens) (string, error) 
 	return lensID, nil
 }
 
+func (w *Wrapper) ListLenses(ctx context.Context) (map[string]model.Lens, error) {
+	args := []string{"client", "lens", "list"}
+
+	data, err := w.cmd.execute(ctx, args)
+	if err != nil {
+		return nil, err
+	}
+
+	var lenses map[string]model.Lens
+	if err := json.Unmarshal(data, &lenses); err != nil {
+		return nil, err
+	}
+	return lenses, nil
+}
+
 func (w *Wrapper) GetCollectionByName(ctx context.Context, name client.CollectionName) (client.Collection, error) {
 	cols, err := w.GetCollections(ctx, client.CollectionFetchOptions{Name: immutable.Some(name)})
 	if err != nil {

--- a/tests/clients/cli/wrapper_tx.go
+++ b/tests/clients/cli/wrapper_tx.go
@@ -135,6 +135,11 @@ func (txn *Transaction) AddLens(ctx context.Context, lens model.Lens) (string, e
 	return txn.Wrapper.AddLens(ctx, lens)
 }
 
+func (txn *Transaction) ListLenses(ctx context.Context) (map[string]model.Lens, error) {
+	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
+	return txn.Wrapper.ListLenses(ctx)
+}
+
 func (txn *Transaction) GetCollectionByName(
 	ctx context.Context,
 	name client.CollectionName,

--- a/tests/clients/cli/wrapper_tx.go
+++ b/tests/clients/cli/wrapper_tx.go
@@ -130,6 +130,11 @@ func (txn *Transaction) SetMigration(ctx context.Context, config client.LensConf
 	return txn.Wrapper.SetMigration(ctx, config)
 }
 
+func (txn *Transaction) AddLens(ctx context.Context, lens model.Lens) (string, error) {
+	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
+	return txn.Wrapper.AddLens(ctx, lens)
+}
+
 func (txn *Transaction) GetCollectionByName(
 	ctx context.Context,
 	name client.CollectionName,

--- a/tests/clients/http/wrapper.go
+++ b/tests/clients/http/wrapper.go
@@ -238,6 +238,10 @@ func (w *Wrapper) SetMigration(ctx context.Context, config client.LensConfig) (s
 	return w.client.SetMigration(ctx, config)
 }
 
+func (w *Wrapper) AddLens(ctx context.Context, lens model.Lens) (string, error) {
+	return w.client.AddLens(ctx, lens)
+}
+
 func (w *Wrapper) GetCollectionByName(ctx context.Context, name client.CollectionName) (client.Collection, error) {
 	return w.client.GetCollectionByName(ctx, name)
 }

--- a/tests/clients/http/wrapper.go
+++ b/tests/clients/http/wrapper.go
@@ -242,6 +242,10 @@ func (w *Wrapper) AddLens(ctx context.Context, lens model.Lens) (string, error) 
 	return w.client.AddLens(ctx, lens)
 }
 
+func (w *Wrapper) ListLenses(ctx context.Context) (map[string]model.Lens, error) {
+	return w.client.ListLenses(ctx)
+}
+
 func (w *Wrapper) GetCollectionByName(ctx context.Context, name client.CollectionName) (client.Collection, error) {
 	return w.client.GetCollectionByName(ctx, name)
 }

--- a/tests/clients/http/wrapper_tx.go
+++ b/tests/clients/http/wrapper_tx.go
@@ -124,6 +124,11 @@ func (txn *Transaction) SetMigration(ctx context.Context, config client.LensConf
 	return txn.Wrapper.SetMigration(ctx, config)
 }
 
+func (txn *Transaction) AddLens(ctx context.Context, lens model.Lens) (string, error) {
+	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
+	return txn.Wrapper.AddLens(ctx, lens)
+}
+
 func (txn *Transaction) GetCollectionByName(
 	ctx context.Context,
 	name client.CollectionName,

--- a/tests/clients/http/wrapper_tx.go
+++ b/tests/clients/http/wrapper_tx.go
@@ -129,6 +129,11 @@ func (txn *Transaction) AddLens(ctx context.Context, lens model.Lens) (string, e
 	return txn.Wrapper.AddLens(ctx, lens)
 }
 
+func (txn *Transaction) ListLenses(ctx context.Context) (map[string]model.Lens, error) {
+	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
+	return txn.Wrapper.ListLenses(ctx)
+}
+
 func (txn *Transaction) GetCollectionByName(
 	ctx context.Context,
 	name client.CollectionName,

--- a/tests/clients/js/wrapper.go
+++ b/tests/clients/js/wrapper.go
@@ -285,6 +285,18 @@ func (w *Wrapper) SetMigration(ctx context.Context, config client.LensConfig) (s
 	return res[0].String(), err
 }
 
+func (w *Wrapper) AddLens(ctx context.Context, lens model.Lens) (string, error) {
+	lensVal, err := goji.MarshalJS(lens)
+	if err != nil {
+		return "", err
+	}
+	res, err := execute(ctx, w.value, "addLens", lensVal)
+	if err != nil {
+		return "", err
+	}
+	return res[0].String(), err
+}
+
 func (w *Wrapper) GetCollectionByName(ctx context.Context, name client.CollectionName) (client.Collection, error) {
 	res, err := execute(ctx, w.value, "getCollectionByName", name)
 	if err != nil {

--- a/tests/clients/js/wrapper.go
+++ b/tests/clients/js/wrapper.go
@@ -297,6 +297,18 @@ func (w *Wrapper) AddLens(ctx context.Context, lens model.Lens) (string, error) 
 	return res[0].String(), err
 }
 
+func (w *Wrapper) ListLenses(ctx context.Context) (map[string]model.Lens, error) {
+	res, err := execute(ctx, w.value, "listLenses")
+	if err != nil {
+		return nil, err
+	}
+	var lenses map[string]model.Lens
+	if err := goji.UnmarshalJS(res[0], &lenses); err != nil {
+		return nil, err
+	}
+	return lenses, nil
+}
+
 func (w *Wrapper) GetCollectionByName(ctx context.Context, name client.CollectionName) (client.Collection, error) {
 	res, err := execute(ctx, w.value, "getCollectionByName", name)
 	if err != nil {

--- a/tests/clients/js/wrapper_tx.go
+++ b/tests/clients/js/wrapper_tx.go
@@ -131,6 +131,11 @@ func (txn *Transaction) AddLens(ctx context.Context, lens model.Lens) (string, e
 	return txn.Wrapper.AddLens(ctx, lens)
 }
 
+func (txn *Transaction) ListLenses(ctx context.Context) (map[string]model.Lens, error) {
+	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
+	return txn.Wrapper.ListLenses(ctx)
+}
+
 func (txn *Transaction) GetCollectionByName(
 	ctx context.Context,
 	name client.CollectionName,

--- a/tests/clients/js/wrapper_tx.go
+++ b/tests/clients/js/wrapper_tx.go
@@ -126,6 +126,11 @@ func (txn *Transaction) SetMigration(ctx context.Context, config client.LensConf
 	return txn.Wrapper.SetMigration(ctx, config)
 }
 
+func (txn *Transaction) AddLens(ctx context.Context, lens model.Lens) (string, error) {
+	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
+	return txn.Wrapper.AddLens(ctx, lens)
+}
+
 func (txn *Transaction) GetCollectionByName(
 	ctx context.Context,
 	name client.CollectionName,

--- a/tests/integration/collection_version/migrations/add_lens_test.go
+++ b/tests/integration/collection_version/migrations/add_lens_test.go
@@ -13,6 +13,7 @@ package migrations
 import (
 	"testing"
 
+	"github.com/sourcenetwork/immutable"
 	"github.com/sourcenetwork/lens/host-go/config/model"
 
 	"github.com/sourcenetwork/defradb/tests/action"
@@ -20,7 +21,117 @@ import (
 	"github.com/sourcenetwork/defradb/tests/lenses"
 )
 
-func TestAddLens_WithSimpleLens_ReturnsLensID(t *testing.T) {
+func TestAddLens_WithSimpleLens_CanBeListedBack(t *testing.T) {
+	expectedLens := model.Lens{
+		Lenses: []model.LensModule{
+			{
+				Path: lenses.SetDefaultModulePath,
+				Arguments: map[string]any{
+					"dst":   "name",
+					"value": "Fred",
+				},
+			},
+		},
+	}
+
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddLens{
+				Lens: expectedLens,
+			},
+			&action.ListLenses{
+				ExpectedCount: immutable.Some(1),
+				ExpectedLenses: map[int]model.Lens{
+					0: expectedLens,
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestAddLens_WithMultipleLenses_ReturnsUniqueLensIDs(t *testing.T) {
+	lens1 := model.Lens{
+		Lenses: []model.LensModule{
+			{
+				Path: lenses.SetDefaultModulePath,
+				Arguments: map[string]any{
+					"dst":   "name",
+					"value": "John",
+				},
+			},
+		},
+	}
+
+	lens2 := model.Lens{
+		Lenses: []model.LensModule{
+			{
+				Path: lenses.SetDefaultModulePath,
+				Arguments: map[string]any{
+					"dst":   "name",
+					"value": "Andy",
+				},
+			},
+		},
+	}
+
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddLens{
+				Lens: lens1,
+			},
+			&action.AddLens{
+				Lens: lens2,
+			},
+			&action.ListLenses{
+				ExpectedCount: immutable.Some(2),
+				ExpectedLenses: map[int]model.Lens{
+					0: lens1,
+					1: lens2,
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestAddLens_WithIdenticalLenses_ReturnsSameCID(t *testing.T) {
+	expectedLens := model.Lens{
+		Lenses: []model.LensModule{
+			{
+				Path: lenses.SetDefaultModulePath,
+				Arguments: map[string]any{
+					"dst":   "name",
+					"value": "Fred",
+				},
+			},
+		},
+	}
+
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddLens{
+				Lens: expectedLens,
+			},
+			&action.AddLens{
+				Lens: expectedLens,
+			},
+			// Both lenses are identical, so only one should be stored
+			&action.ListLenses{
+				ExpectedCount: immutable.Some(1),
+				ExpectedLenses: map[int]model.Lens{
+					0: expectedLens,
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestAddLens_WithPatchCollection_TransformsDocuments(t *testing.T) {
 	test := testUtils.TestCase{
 		Actions: []any{
 			&action.AddLens{
@@ -62,164 +173,6 @@ func TestAddLens_WithSimpleLens_ReturnsLensID(t *testing.T) {
 							"op": "replace",
 							"path": "/Users/PreviousVersion/Transform",
 							"value": "{{.LensID0}}"
-						}
-					]
-				`,
-			},
-			testUtils.Request{
-				Request: `query {
-					Users {
-						name
-					}
-				}`,
-				Results: map[string]any{
-					"Users": []map[string]any{
-						{
-							"name": "Fred",
-						},
-					},
-				},
-			},
-		},
-	}
-
-	testUtils.ExecuteTestCase(t, test)
-}
-
-func TestAddLens_WithMultipleLenses_ReturnsUniqueLensIDs(t *testing.T) {
-	test := testUtils.TestCase{
-		Actions: []any{
-			&action.AddLens{
-				Lens: model.Lens{
-					Lenses: []model.LensModule{
-						{
-							Path: lenses.SetDefaultModulePath,
-							Arguments: map[string]any{
-								"dst":   "name",
-								"value": "John",
-							},
-						},
-					},
-				},
-			},
-			&action.AddLens{
-				Lens: model.Lens{
-					Lenses: []model.LensModule{
-						{
-							Path: lenses.SetDefaultModulePath,
-							Arguments: map[string]any{
-								"dst":   "name",
-								"value": "Andy",
-							},
-						},
-					},
-				},
-			},
-			&action.AddSchema{
-				Schema: `
-					type Users {
-						name: String
-					}
-				`,
-			},
-			testUtils.CreateDoc{
-				Doc: `{
-					"name": "Islam"
-				}`,
-			},
-			testUtils.PatchCollection{
-				Patch: `
-					[
-						{ "op": "add", "path": "/Users/Fields/-", "value": {"Name": "email", "Kind": 11} }
-					]
-				`,
-			},
-			testUtils.PatchCollection{
-				Patch: `
-					[
-						{
-							"op": "replace",
-							"path": "/Users/PreviousVersion/Transform",
-							"value": "{{.LensID1}}"
-						}
-					]
-				`,
-			},
-			testUtils.Request{
-				Request: `query {
-					Users {
-						name
-					}
-				}`,
-				Results: map[string]any{
-					"Users": []map[string]any{
-						{
-							"name": "Andy",
-						},
-					},
-				},
-			},
-		},
-	}
-
-	testUtils.ExecuteTestCase(t, test)
-}
-
-func TestAddLens_WithIdenticalLenses_ReturnsSameCID(t *testing.T) {
-	test := testUtils.TestCase{
-		Actions: []any{
-			&action.AddLens{
-				Lens: model.Lens{
-					Lenses: []model.LensModule{
-						{
-							Path: lenses.SetDefaultModulePath,
-							Arguments: map[string]any{
-								"dst":   "name",
-								"value": "Fred",
-							},
-						},
-					},
-				},
-			},
-			&action.AddLens{
-				Lens: model.Lens{
-					Lenses: []model.LensModule{
-						{
-							Path: lenses.SetDefaultModulePath,
-							Arguments: map[string]any{
-								"dst":   "name",
-								"value": "Fred",
-							},
-						},
-					},
-				},
-			},
-			&action.AddSchema{
-				Schema: `
-					type Users {
-						name: String
-					}
-				`,
-			},
-			testUtils.CreateDoc{
-				Doc: `{
-					"name": "Shahzad"
-				}`,
-			},
-			testUtils.PatchCollection{
-				Patch: `
-					[
-						{ "op": "add", "path": "/Users/Fields/-", "value": {"Name": "email", "Kind": 11} }
-					]
-				`,
-			},
-			testUtils.PatchCollection{
-				Patch: `
-					[
-						{
-							"op": "replace",
-							"path": "/Users/PreviousVersion/Transform",
-							"value": "{{.LensID1}}"
 						}
 					]
 				`,

--- a/tests/integration/collection_version/migrations/add_lens_test.go
+++ b/tests/integration/collection_version/migrations/add_lens_test.go
@@ -1,0 +1,245 @@
+// Copyright 2025 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package migrations
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/lens/host-go/config/model"
+
+	"github.com/sourcenetwork/defradb/tests/action"
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	"github.com/sourcenetwork/defradb/tests/lenses"
+)
+
+func TestAddLens_WithSimpleLens_ReturnsLensID(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddLens{
+				Lens: model.Lens{
+					Lenses: []model.LensModule{
+						{
+							Path: lenses.SetDefaultModulePath,
+							Arguments: map[string]any{
+								"dst":   "name",
+								"value": "Fred",
+							},
+						},
+					},
+				},
+			},
+			&action.AddSchema{
+				Schema: `
+					type Users {
+						name: String
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
+					"name": "Shahzad"
+				}`,
+			},
+			testUtils.PatchCollection{
+				Patch: `
+					[
+						{ "op": "add", "path": "/Users/Fields/-", "value": {"Name": "email", "Kind": 11} }
+					]
+				`,
+			},
+			testUtils.PatchCollection{
+				Patch: `
+					[
+						{
+							"op": "replace",
+							"path": "/Users/PreviousVersion/Transform",
+							"value": "{{.LensID0}}"
+						}
+					]
+				`,
+			},
+			testUtils.Request{
+				Request: `query {
+					Users {
+						name
+					}
+				}`,
+				Results: map[string]any{
+					"Users": []map[string]any{
+						{
+							"name": "Fred",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestAddLens_WithMultipleLenses_ReturnsUniqueLensIDs(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddLens{
+				Lens: model.Lens{
+					Lenses: []model.LensModule{
+						{
+							Path: lenses.SetDefaultModulePath,
+							Arguments: map[string]any{
+								"dst":   "name",
+								"value": "John",
+							},
+						},
+					},
+				},
+			},
+			&action.AddLens{
+				Lens: model.Lens{
+					Lenses: []model.LensModule{
+						{
+							Path: lenses.SetDefaultModulePath,
+							Arguments: map[string]any{
+								"dst":   "name",
+								"value": "Andy",
+							},
+						},
+					},
+				},
+			},
+			&action.AddSchema{
+				Schema: `
+					type Users {
+						name: String
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
+					"name": "Islam"
+				}`,
+			},
+			testUtils.PatchCollection{
+				Patch: `
+					[
+						{ "op": "add", "path": "/Users/Fields/-", "value": {"Name": "email", "Kind": 11} }
+					]
+				`,
+			},
+			testUtils.PatchCollection{
+				Patch: `
+					[
+						{
+							"op": "replace",
+							"path": "/Users/PreviousVersion/Transform",
+							"value": "{{.LensID1}}"
+						}
+					]
+				`,
+			},
+			testUtils.Request{
+				Request: `query {
+					Users {
+						name
+					}
+				}`,
+				Results: map[string]any{
+					"Users": []map[string]any{
+						{
+							"name": "Andy",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestAddLens_WithIdenticalLenses_ReturnsSameCID(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddLens{
+				Lens: model.Lens{
+					Lenses: []model.LensModule{
+						{
+							Path: lenses.SetDefaultModulePath,
+							Arguments: map[string]any{
+								"dst":   "name",
+								"value": "Fred",
+							},
+						},
+					},
+				},
+			},
+			&action.AddLens{
+				Lens: model.Lens{
+					Lenses: []model.LensModule{
+						{
+							Path: lenses.SetDefaultModulePath,
+							Arguments: map[string]any{
+								"dst":   "name",
+								"value": "Fred",
+							},
+						},
+					},
+				},
+			},
+			&action.AddSchema{
+				Schema: `
+					type Users {
+						name: String
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
+					"name": "Shahzad"
+				}`,
+			},
+			testUtils.PatchCollection{
+				Patch: `
+					[
+						{ "op": "add", "path": "/Users/Fields/-", "value": {"Name": "email", "Kind": 11} }
+					]
+				`,
+			},
+			testUtils.PatchCollection{
+				Patch: `
+					[
+						{
+							"op": "replace",
+							"path": "/Users/PreviousVersion/Transform",
+							"value": "{{.LensID1}}"
+						}
+					]
+				`,
+			},
+			testUtils.Request{
+				Request: `query {
+					Users {
+						name
+					}
+				}`,
+				Results: map[string]any{
+					"Users": []map[string]any{
+						{
+							"name": "Fred",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/collection_version/migrations/add_lens_test.go
+++ b/tests/integration/collection_version/migrations/add_lens_test.go
@@ -13,7 +13,6 @@ package migrations
 import (
 	"testing"
 
-	"github.com/sourcenetwork/immutable"
 	"github.com/sourcenetwork/lens/host-go/config/model"
 
 	"github.com/sourcenetwork/defradb/tests/action"
@@ -40,9 +39,8 @@ func TestAddLens_WithSimpleLens_CanBeListedBack(t *testing.T) {
 				Lens: expectedLens,
 			},
 			&action.ListLenses{
-				ExpectedCount: immutable.Some(1),
-				ExpectedLenses: map[int]model.Lens{
-					0: expectedLens,
+				ExpectedLenses: map[string]model.Lens{
+					"{{.LensID0}}": expectedLens,
 				},
 			},
 		},
@@ -85,10 +83,9 @@ func TestAddLens_WithMultipleLenses_ReturnsUniqueLensIDs(t *testing.T) {
 				Lens: lens2,
 			},
 			&action.ListLenses{
-				ExpectedCount: immutable.Some(2),
-				ExpectedLenses: map[int]model.Lens{
-					0: lens1,
-					1: lens2,
+				ExpectedLenses: map[string]model.Lens{
+					"{{.LensID0}}": lens1,
+					"{{.LensID1}}": lens2,
 				},
 			},
 		},
@@ -119,9 +116,8 @@ func TestAddLens_WithIdenticalLenses_ReturnsSameCID(t *testing.T) {
 				Lens: expectedLens,
 			},
 			&action.ListLenses{
-				ExpectedCount: immutable.Some(1),
-				ExpectedLenses: map[int]model.Lens{
-					0: expectedLens,
+				ExpectedLenses: map[string]model.Lens{
+					"{{.LensID0}}": expectedLens,
 				},
 			},
 		},

--- a/tests/integration/collection_version/migrations/add_lens_test.go
+++ b/tests/integration/collection_version/migrations/add_lens_test.go
@@ -118,7 +118,6 @@ func TestAddLens_WithIdenticalLenses_ReturnsSameCID(t *testing.T) {
 			&action.AddLens{
 				Lens: expectedLens,
 			},
-			// Both lenses are identical, so only one should be stored
 			&action.ListLenses{
 				ExpectedCount: immutable.Some(1),
 				ExpectedLenses: map[int]model.Lens{

--- a/tests/integration/lens.go
+++ b/tests/integration/lens.go
@@ -77,4 +77,3 @@ func configureMigration(
 	// Originally was added for [CreateIndex] to be able to index docs with migrated values.
 	refreshCollections(s)
 }
-

--- a/tests/integration/lens.go
+++ b/tests/integration/lens.go
@@ -77,3 +77,4 @@ func configureMigration(
 	// Originally was added for [CreateIndex] to be able to index docs with migrated values.
 	refreshCollections(s)
 }
+


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4262

## Description

This change introduces `AddLens` and `ListLenses` methods that allows adding and retrieving lenses to/from defra. 

The CID returned by `AddLens` can be used for example for `PatchCollection`, but opens open possibility to improve other API methods that currently take entire lens modules like `AddView`. Instead they can be change to accept just lens id