### PR TITLE
feat: Gate PeerInfo with NAC & Add Context

### DIFF
--- a/acp/types/types.go
+++ b/acp/types/types.go
@@ -97,6 +97,7 @@ const (
 	NodeIndexListPerm
 	NodeIndexCreatePerm
 	NodeIndexDropPerm
+	NodeP2PPeerInfo
 	NodeP2PPeerConnectPerm
 	NodeP2PReplicatorCreatePerm
 	NodeP2PReplicatorDeletePerm
@@ -137,6 +138,7 @@ var RequiredResourcePermissionsForNode = []string{
 	"index-list",
 	"index-create",
 	"index-drop",
+	"p2p-peer-info",
 	"p2p-peer-connect",
 	"p2p-replicator-create",
 	"p2p-replicator-delete",
@@ -211,6 +213,8 @@ resources:
   - name: index-drop
     expr: admin
 
+  - name: p2p-peer-info
+    expr: admin
   - name: p2p-peer-connect
     expr: admin
   - name: p2p-replicator-create

--- a/cbindings/p2p.go
+++ b/cbindings/p2p.go
@@ -33,8 +33,6 @@ func P2PInfo(nodePtr C.uintptr_t, identityPtr C.uintptr_t) C.Result {
 	if err != nil {
 		return returnC(returnGoC(1, err.Error(), ""))
 	}
-	// TODO: Support / patch the c-binding bug with NAC gate and P2P info
-	// https://github.com/sourcenetwork/defradb/issues/4250
 	addresses, err := node.DB.PeerInfo(ctx)
 	if err != nil {
 		return returnC(returnGoC(1, err.Error(), ""))

--- a/cbindings/p2p.go
+++ b/cbindings/p2p.go
@@ -22,12 +22,20 @@ import (
 )
 
 //export P2PInfo
-func P2PInfo(nodePtr C.uintptr_t) C.Result {
+func P2PInfo(nodePtr C.uintptr_t, identityPtr C.uintptr_t) C.Result {
+	ctx := context.Background()
+	ctx, err := contextWithIdentity(ctx, identityPtr)
+	if err != nil {
+		return returnC(returnGoC(1, err.Error(), ""))
+	}
+
 	node, err := getNodeFromPointer(nodePtr)
 	if err != nil {
 		return returnC(returnGoC(1, err.Error(), ""))
 	}
-	addresses, err := node.DB.PeerInfo()
+	// TODO: Support / patch the c-binding bug with NAC gate and P2P info
+	// https://github.com/sourcenetwork/defradb/issues/4250
+	addresses, err := node.DB.PeerInfo(ctx)
 	if err != nil {
 		return returnC(returnGoC(1, err.Error(), ""))
 	}

--- a/cbindings/wrapper.go
+++ b/cbindings/wrapper.go
@@ -42,7 +42,7 @@ extern Result LensAdd(uintptr_t nodePtr, char* cfg);
 extern Result LensList(uintptr_t nodePtr);
 extern NewNodeResult NewNode(NodeInitOptions cOptions);
 extern Result NodeClose(uintptr_t nodePtr);
-extern Result P2PInfo(uintptr_t nodePtr);
+extern Result P2PInfo(uintptr_t nodePtr, uintptr_t identity);
 extern Result P2PActivePeers(uintptr_t nodePtr, uintptr_t identity);
 extern Result P2PlistReplicators(uintptr_t nodePtr, uintptr_t identity);
 extern Result P2PcreateReplicator(uintptr_t nodePtr, char* collections, char* addresses, uintptr_t identity);
@@ -110,8 +110,11 @@ func NewCWrapper(node *node.Node) (*CWrapper, error) {
 	}, nil
 }
 
-func (w *CWrapper) PeerInfo() ([]string, error) {
-	res := ConvertAndFreeCResult(C.P2PInfo(C.uintptr_t(w.handle)))
+func (w *CWrapper) PeerInfo(ctx context.Context) ([]string, error) {
+	cIdentity := identityFromContext(ctx)
+	defer C.IdentityFree(cIdentity)
+
+	res := ConvertAndFreeCResult(C.P2PInfo(C.uintptr_t(w.handle), cIdentity))
 
 	if res.Status != 0 {
 		return nil, errors.New(res.Error)

--- a/cli/p2p_info.go
+++ b/cli/p2p_info.go
@@ -23,7 +23,7 @@ func MakeP2PInfoCommand(ctx context.Context) *cobra.Command {
 		Long:  `Get peer info from a DefraDB node`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cliClient := mustGetContextCLIClient(cmd)
-			addresses, err := cliClient.PeerInfo()
+			addresses, err := cliClient.PeerInfo(cmd.Context())
 			if err != nil {
 				return err
 			}

--- a/client/mocks/txn.go
+++ b/client/mocks/txn.go
@@ -2214,8 +2214,8 @@ func (_c *Txn_PatchCollection_Call) RunAndReturn(run func(ctx context.Context, p
 }
 
 // PeerInfo provides a mock function for the type Txn
-func (_mock *Txn) PeerInfo() ([]string, error) {
-	ret := _mock.Called()
+func (_mock *Txn) PeerInfo(ctx context.Context) ([]string, error) {
+	ret := _mock.Called(ctx)
 
 	if len(ret) == 0 {
 		panic("no return value specified for PeerInfo")
@@ -2223,18 +2223,18 @@ func (_mock *Txn) PeerInfo() ([]string, error) {
 
 	var r0 []string
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func() ([]string, error)); ok {
-		return returnFunc()
+	if returnFunc, ok := ret.Get(0).(func(context.Context) ([]string, error)); ok {
+		return returnFunc(ctx)
 	}
-	if returnFunc, ok := ret.Get(0).(func() []string); ok {
-		r0 = returnFunc()
+	if returnFunc, ok := ret.Get(0).(func(context.Context) []string); ok {
+		r0 = returnFunc(ctx)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]string)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func() error); ok {
-		r1 = returnFunc()
+	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = returnFunc(ctx)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -2247,13 +2247,20 @@ type Txn_PeerInfo_Call struct {
 }
 
 // PeerInfo is a helper method to define mock.On call
-func (_e *Txn_Expecter) PeerInfo() *Txn_PeerInfo_Call {
-	return &Txn_PeerInfo_Call{Call: _e.mock.On("PeerInfo")}
+//   - ctx context.Context
+func (_e *Txn_Expecter) PeerInfo(ctx interface{}) *Txn_PeerInfo_Call {
+	return &Txn_PeerInfo_Call{Call: _e.mock.On("PeerInfo", ctx)}
 }
 
-func (_c *Txn_PeerInfo_Call) Run(run func()) *Txn_PeerInfo_Call {
+func (_c *Txn_PeerInfo_Call) Run(run func(ctx context.Context)) *Txn_PeerInfo_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
 	})
 	return _c
 }
@@ -2263,7 +2270,7 @@ func (_c *Txn_PeerInfo_Call) Return(strings []string, err error) *Txn_PeerInfo_C
 	return _c
 }
 
-func (_c *Txn_PeerInfo_Call) RunAndReturn(run func() ([]string, error)) *Txn_PeerInfo_Call {
+func (_c *Txn_PeerInfo_Call) RunAndReturn(run func(ctx context.Context) ([]string, error)) *Txn_PeerInfo_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/client/p2p.go
+++ b/client/p2p.go
@@ -23,7 +23,7 @@ import (
 // P2P is a peer connected database implementation.
 type P2P interface {
 	// PeerInfo returns the p2p host list of addresses.
-	PeerInfo() ([]string, error)
+	PeerInfo(ctx context.Context) ([]string, error)
 
 	// ActivePeers returns the addresses of peers that are currently connected to.
 	//

--- a/http/client_p2p.go
+++ b/http/client_p2p.go
@@ -38,10 +38,10 @@ type DeleteReplicatorParams struct {
 	Collections []string
 }
 
-func (c *Client) PeerInfo() ([]string, error) {
+func (c *Client) PeerInfo(ctx context.Context) ([]string, error) {
 	methodURL := c.http.apiURL.JoinPath("p2p", "info")
 
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, methodURL.String(), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, methodURL.String(), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -55,7 +55,7 @@ func (c *Client) PeerInfo() ([]string, error) {
 func (c *Client) ActivePeers(ctx context.Context) ([]string, error) {
 	methodURL := c.http.apiURL.JoinPath("p2p", "active-peers")
 
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, methodURL.String(), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, methodURL.String(), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/http/handler_p2p.go
+++ b/http/handler_p2p.go
@@ -22,7 +22,7 @@ type p2pHandler struct{}
 
 func (h *p2pHandler) PeerInfo(rw http.ResponseWriter, req *http.Request) {
 	db := mustGetContextClientDB(req)
-	addresses, err := db.PeerInfo()
+	addresses, err := db.PeerInfo(req.Context())
 	if err != nil {
 		responseJSON(rw, http.StatusInternalServerError, errorResponse{err})
 		return

--- a/internal/db/config.go
+++ b/internal/db/config.go
@@ -71,9 +71,7 @@ func WithMaxRetries(num int) Option {
 
 func WithNodeIdentity(ident identity.Identity) Option {
 	return func(opts *dbOptions) {
-		if ident != nil {
-			opts.identity = immutable.Some(ident)
-		}
+		opts.identity = immutable.Some(ident)
 	}
 }
 

--- a/internal/db/config.go
+++ b/internal/db/config.go
@@ -71,7 +71,9 @@ func WithMaxRetries(num int) Option {
 
 func WithNodeIdentity(ident identity.Identity) Option {
 	return func(opts *dbOptions) {
-		opts.identity = immutable.Some(ident)
+		if ident != nil {
+			opts.identity = immutable.Some(ident)
+		}
 	}
 }
 

--- a/internal/db/p2p.go
+++ b/internal/db/p2p.go
@@ -29,7 +29,11 @@ func (db *DB) sendUpdate(evt event.Update) {
 }
 
 // PeerInfo returns the p2p host id and listening addresses.
-func (db *DB) PeerInfo() ([]string, error) {
+func (db *DB) PeerInfo(ctx context.Context) ([]string, error) {
+	if err := db.checkNodeAccess(ctx, acpTypes.NodeP2PPeerInfo); err != nil {
+		return nil, err
+	}
+
 	if db.p2p == nil {
 		return nil, nil
 	}

--- a/internal/db/txn.go
+++ b/internal/db/txn.go
@@ -276,8 +276,8 @@ func (txn *Txn) BasicExport(ctx context.Context, config *client.BackupConfig) er
 	return txn.db.BasicExport(ctx, config)
 }
 
-func (txn *Txn) PeerInfo() ([]string, error) {
-	return txn.db.PeerInfo()
+func (txn *Txn) PeerInfo(ctx context.Context) ([]string, error) {
+	return txn.db.PeerInfo(ctx)
 }
 
 func (txn *Txn) ActivePeers(ctx context.Context) ([]string, error) {

--- a/tests/action/assert_request.go
+++ b/tests/action/assert_request.go
@@ -90,7 +90,7 @@ func assertRequestResults(
 	nodeID int,
 	ordered bool,
 ) bool {
-	s.CurrentNodeID = nodeID
+	s.CurrentAssertingNodeID = nodeID
 	// we skip assertion benchmark because you don't specify expected result for benchmark.
 	if assertErrors(s.T, result.Errors, expectedError) || s.IsBench {
 		return true

--- a/tests/action/identity.go
+++ b/tests/action/identity.go
@@ -46,11 +46,18 @@ func getIdentityForRequest(s *state.State, identity state.Identity, nodeIndex in
 	ident := identHolder.Identity
 
 	if fullIdent, ok := ident.(acpIdentity.FullIdentity); ok {
+		audience := state.GetNodeAudience(s, nodeIndex)
 		token, ok := identHolder.NodeTokens[nodeIndex]
 		if ok {
 			fullIdent.SetBearerToken(token)
-		} else {
-			audience := state.GetNodeAudience(s, nodeIndex)
+		}
+
+		// Generate/regenerate the token if:
+		// - No token exists yet, OR
+		// - An audience is now available but the token was generated without one
+		//   (this can happen when the token is created during node setup before the
+		//    HTTP wrapper is ready, causing the audience to be unavailable at that time).
+		if !ok || (audience.HasValue() && !state.TokenHasAudience(token)) {
 			if s.DocumentACPType == state.SourceHubDocumentACPType || audience.HasValue() {
 				err := fullIdent.UpdateToken(
 					AuthTokenExpiration,

--- a/tests/action/peer_info.go
+++ b/tests/action/peer_info.go
@@ -1,0 +1,70 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package action
+
+import (
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/multiformats/go-multiaddr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcenetwork/defradb/tests/state"
+	"github.com/sourcenetwork/immutable"
+)
+
+// PeerInfo returns the p2p host list of addresses.
+type PeerInfo struct {
+	stateful
+
+	// NodeID is the ID (index) of the node to execute the PeerInfo request on.
+	NodeID int
+
+	// The identity of this request. Optional.
+	//
+	// If node acp is enabled, identity will be used to check if this operation can be performed.
+	Identity immutable.Option[state.Identity]
+
+	// Expected number of total peers in the list of peers that will be returned, they will all
+	// be validated, we just don't assert them individually due to maintainance cost.
+	ExpectedNumberOfPeers int
+
+	// Any error expected from the action. Optional.
+	//
+	// String can be a partial, and the test will pass if an error is returned that
+	// contains this string.
+	ExpectedError string
+}
+
+var _ Action = (*PeerInfo)(nil)
+var _ Stateful = (*PeerInfo)(nil)
+
+func (a *PeerInfo) Execute() {
+	node := a.s.Nodes[a.NodeID]
+
+	ctx := getContextWithIdentity(a.s.Ctx, a.s, a.Identity, a.NodeID)
+	peerInfos, err := node.PeerInfo(ctx)
+
+	expectedErrorRaised := assertError(a.s.T, err, a.ExpectedError)
+	assertExpectedErrorRaised(a.s.T, a.ExpectedError, expectedErrorRaised)
+
+	if !expectedErrorRaised {
+		assert.Equal(a.s.T, a.ExpectedNumberOfPeers, len(peerInfos))
+
+		// Check that all the returned addresses in the list are valid.
+		for _, peerInfo := range peerInfos {
+			maddr, err := multiaddr.NewMultiaddr(peerInfo)
+			require.NoError(a.s.T, err)
+
+			_, err = peer.IDFromP2PAddr(maddr)
+			require.NoError(a.s.T, err)
+		}
+	}
+}

--- a/tests/action/replace.go
+++ b/tests/action/replace.go
@@ -80,7 +80,12 @@ var templateDataGenerators = map[string]func(*state.State, int) map[string]strin
 	"PeerAddresses": func(s *state.State, nodeID int) map[string]string {
 		res := map[string]string{}
 		for i, node := range s.Nodes {
-			addresses, err := node.PeerInfo()
+			// Inject node's identity into the context while generating templates, to bypass NAC for
+			// the gated [PeerInfo] operation, otherwise due to lack of authorization(s) we might not
+			// be able to see the peer addresses at all.
+			nodeIdentity := NodeIdentity(i)
+			ctx := getContextWithIdentity(s.Ctx, s, nodeIdentity, i)
+			addresses, err := node.PeerInfo(ctx)
 			require.NoError(s.T, err)
 
 			for j, address := range addresses {

--- a/tests/action/wait_for_peer_events.go
+++ b/tests/action/wait_for_peer_events.go
@@ -70,7 +70,7 @@ func (a *WaitForPeersEvents) Execute() {
 		}
 		for _, peerNodeID := range peerNodeIDs {
 			targetNode := a.s.Nodes[peerNodeID]
-			targetAddresses, err := targetNode.PeerInfo()
+			targetAddresses, err := targetNode.PeerInfo(a.s.Ctx)
 			require.NoError(a.s.T, err)
 			require.NotEmpty(a.s.T, targetAddresses, "target node %d has no addresses", peerNodeID)
 

--- a/tests/clients/cli/wrapper.go
+++ b/tests/clients/cli/wrapper.go
@@ -68,10 +68,10 @@ func NewWrapper(node *node.Node, sourceHubAddress string) (*Wrapper, error) {
 	}, nil
 }
 
-func (w *Wrapper) PeerInfo() ([]string, error) {
+func (w *Wrapper) PeerInfo(ctx context.Context) ([]string, error) {
 	args := []string{"client", "p2p", "info"}
 
-	data, err := w.cmd.execute(context.Background(), args)
+	data, err := w.cmd.execute(ctx, args)
 	if err != nil {
 		return nil, err
 	}
@@ -214,7 +214,7 @@ func (w *Wrapper) SyncDocuments(
 	args = append(args, collectionName)
 	args = append(args, docIDs...)
 
-	_, err := w.cmd.execute(context.Background(), args)
+	_, err := w.cmd.execute(ctx, args)
 	return err
 }
 
@@ -228,7 +228,7 @@ func (w *Wrapper) SyncCollectionVersions(ctx context.Context, versionIDs ...stri
 
 	args = append(args, versionIDs...)
 
-	_, err := w.cmd.execute(context.Background(), args)
+	_, err := w.cmd.execute(ctx, args)
 	return err
 }
 

--- a/tests/clients/http/wrapper.go
+++ b/tests/clients/http/wrapper.go
@@ -62,8 +62,8 @@ func NewWrapper(node *node.Node) (*Wrapper, error) {
 	}, nil
 }
 
-func (w *Wrapper) PeerInfo() ([]string, error) {
-	return w.client.PeerInfo()
+func (w *Wrapper) PeerInfo(ctx context.Context) ([]string, error) {
+	return w.client.PeerInfo(ctx)
 }
 
 func (w *Wrapper) ActivePeers(ctx context.Context) ([]string, error) {

--- a/tests/clients/js/wrapper.go
+++ b/tests/clients/js/wrapper.go
@@ -48,7 +48,7 @@ func NewWrapper(node *node.Node) (*Wrapper, error) {
 }
 
 func (w *Wrapper) PeerInfo(ctx context.Context) ([]string, error) {
-	panic("not implemented")
+	return nil, nil
 }
 
 func (w *Wrapper) ActivePeers(ctx context.Context) ([]string, error) {

--- a/tests/clients/js/wrapper.go
+++ b/tests/clients/js/wrapper.go
@@ -47,8 +47,8 @@ func NewWrapper(node *node.Node) (*Wrapper, error) {
 	}, nil
 }
 
-func (w *Wrapper) PeerInfo() ([]string, error) {
-	return nil, nil
+func (w *Wrapper) PeerInfo(ctx context.Context) ([]string, error) {
+	panic("not implemented")
 }
 
 func (w *Wrapper) ActivePeers(ctx context.Context) ([]string, error) {

--- a/tests/integration/acp/nac/p2p_peer_info_test.go
+++ b/tests/integration/acp/nac/p2p_peer_info_test.go
@@ -13,6 +13,7 @@ package test_acp_nac
 import (
 	"testing"
 
+	"github.com/sourcenetwork/defradb/tests/action"
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
 	"github.com/sourcenetwork/defradb/tests/state"
 	"github.com/sourcenetwork/immutable"
@@ -40,7 +41,7 @@ func TestNAC_GatesP2PPeerInfo_AuthorizedIdentity_AllowAccess(t *testing.T) {
 			},
 
 			// This should work as the identity is authorized.
-			testUtils.PeerInfo{
+			&action.PeerInfo{
 				Identity:              testUtils.ClientIdentity(1),
 				NodeID:                1,
 				ExpectedNumberOfPeers: 1,
@@ -65,7 +66,7 @@ func TestNAC_GatesP2PPeerInfo_NoIdentity_NotAuthorizedError(t *testing.T) {
 			},
 
 			// We haven't authorized non-identities. So, this should error.
-			testUtils.PeerInfo{
+			&action.PeerInfo{
 				Identity:      testUtils.NoIdentity(),
 				NodeID:        1,
 				ExpectedError: "not authorized to perform operation",
@@ -90,7 +91,7 @@ func TestNAC_GatesP2PPeerInfo_WrongIdentity_NotAuthorizedError(t *testing.T) {
 			},
 
 			// Wrong user/identity will also not be authorized.
-			testUtils.PeerInfo{
+			&action.PeerInfo{
 				Identity:      testUtils.ClientIdentity(2),
 				NodeID:        1,
 				ExpectedError: "not authorized to perform operation",

--- a/tests/integration/acp/nac/p2p_peer_info_test.go
+++ b/tests/integration/acp/nac/p2p_peer_info_test.go
@@ -1,0 +1,102 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package test_acp_nac
+
+import (
+	"testing"
+
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	"github.com/sourcenetwork/defradb/tests/state"
+	"github.com/sourcenetwork/immutable"
+)
+
+func TestNAC_GatesP2PPeerInfo_AuthorizedIdentity_AllowAccess(t *testing.T) {
+	test := testUtils.TestCase{
+		SupportedClientTypes: immutable.Some(
+			[]state.ClientType{
+				state.HTTPClientType,
+				state.CLIClientType,
+				state.GoClientType,
+				state.CClientType,
+			},
+		),
+		Actions: []any{
+			// Doing this in the beggining is important to start all nodes with NAC enabled.
+			testUtils.RandomNetworkingConfig(),
+			testUtils.RandomNetworkingConfig(),
+			// Starting all nodes with NAC, so only authorized user(s) can perform operations from here on out.
+			testUtils.Close{},
+			testUtils.Start{
+				Identity:  testUtils.ClientIdentity(1),
+				EnableNAC: true,
+			},
+
+			// This should work as the identity is authorized.
+			testUtils.PeerInfo{
+				Identity:              testUtils.ClientIdentity(1),
+				NodeID:                1,
+				ExpectedNumberOfPeers: 1,
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestNAC_GatesP2PPeerInfo_NoIdentity_NotAuthorizedError(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			// Doing this in the beggining is important to start all nodes with NAC enabled.
+			testUtils.RandomNetworkingConfig(),
+			testUtils.RandomNetworkingConfig(),
+			// Starting all nodes with NAC, so only authorized user(s) can perform operations from here on out.
+			testUtils.Close{},
+			testUtils.Start{
+				Identity:  testUtils.ClientIdentity(1),
+				EnableNAC: true,
+			},
+
+			// We haven't authorized non-identities. So, this should error.
+			testUtils.PeerInfo{
+				Identity:      testUtils.NoIdentity(),
+				NodeID:        1,
+				ExpectedError: "not authorized to perform operation",
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestNAC_GatesP2PPeerInfo_WrongIdentity_NotAuthorizedError(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			// Doing this in the beggining is important to start all nodes with NAC enabled.
+			testUtils.RandomNetworkingConfig(),
+			testUtils.RandomNetworkingConfig(),
+			// Starting all nodes with NAC, so only authorized user(s) can perform operations from here on out.
+			testUtils.Close{},
+			testUtils.Start{
+				Identity:  testUtils.ClientIdentity(1),
+				EnableNAC: true,
+			},
+
+			// Wrong user/identity will also not be authorized.
+			testUtils.PeerInfo{
+				Identity:      testUtils.ClientIdentity(2),
+				NodeID:        1,
+				ExpectedError: "not authorized to perform operation",
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/acp/nac/relation_admin/p2p_peer_info_test.go
+++ b/tests/integration/acp/nac/relation_admin/p2p_peer_info_test.go
@@ -1,0 +1,70 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package test_acp_nac_relation_admin
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/immutable"
+
+	"github.com/sourcenetwork/defradb/tests/action"
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	"github.com/sourcenetwork/defradb/tests/state"
+)
+
+func TestNAC_AdminRelation_CanP2PPeerInfo(t *testing.T) {
+	test := testUtils.TestCase{
+		SupportedClientTypes: immutable.Some(
+			[]state.ClientType{
+				state.HTTPClientType,
+				state.CLIClientType,
+				state.GoClientType,
+				state.CClientType,
+			},
+		),
+		Actions: []any{
+			// Doing this in the beggining is important to start all nodes with NAC enabled.
+			testUtils.RandomNetworkingConfig(),
+			testUtils.RandomNetworkingConfig(),
+			// Starting all nodes with NAC, so only authorized user(s) can perform operations from here on out.
+			testUtils.Close{},
+			testUtils.Start{
+				Identity:  testUtils.ClientIdentity(1),
+				EnableNAC: true,
+			},
+
+			// This user, can not perform this gated operation yet.
+			&action.PeerInfo{
+				Identity:              testUtils.ClientIdentity(2),
+				NodeID:                1,
+				ExpectedNumberOfPeers: 1,
+				ExpectedError:         "not authorized to perform operation",
+			},
+
+			// Grant access to user.
+			testUtils.AddNACActorRelationship{
+				RequestorIdentity: testUtils.ClientIdentity(1),
+				TargetIdentity:    testUtils.ClientIdentity(2), // Grant this user "admin" relation
+				Relation:          "admin",
+				ExpectedExistence: false,
+			},
+
+			// This user, can now perform this gated operation.
+			&action.PeerInfo{
+				Identity:              testUtils.ClientIdentity(2),
+				NodeID:                1,
+				ExpectedNumberOfPeers: 1,
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/db_setup.go
+++ b/tests/integration/db_setup.go
@@ -21,7 +21,6 @@ import (
 	"github.com/sourcenetwork/immutable"
 
 	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
-	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/crypto"
 	"github.com/sourcenetwork/defradb/errors"
 	"github.com/sourcenetwork/defradb/internal/db"
@@ -168,24 +167,12 @@ func setupNode(
 
 	var addresses []string
 
-	// Temporarily turn NAC off if enabled to get the peer info we need to setup the node,
-	// otherwise we will get authorization errors as NAC gates [PeerInfo]. Re-nable NAC
-	// once [PeerInfo] operation is successfully bypassed.
-	nacStatus, err := nodeObj.DB.GetNACStatus(ctx)
+	// Inject node identity to bypass NAC inorder to be able to call [PeerInfo] operation,
+	// otherwise when NAC is enabled, we will get authorization error.
+	nodeIdentity := NodeIdentity(s.CurrentSetupNodeID)
+	ctxWithNodeIdentity := getContextWithIdentity(s.Ctx, s, nodeIdentity, s.CurrentSetupNodeID)
+	addresses, err = nodeObj.DB.PeerInfo(ctxWithNodeIdentity)
 	require.NoError(s.T, err)
-	if nacStatus.Status == client.NACEnabled.String() {
-		err := nodeObj.DB.DisableNAC(ctx)
-		require.NoError(s.T, err)
-
-		addresses, err = nodeObj.DB.PeerInfo(ctx)
-		require.NoError(s.T, err)
-
-		err = nodeObj.DB.ReEnableNAC(ctx)
-		require.NoError(s.T, err)
-	} else {
-		addresses, err = nodeObj.DB.PeerInfo(ctx)
-		require.NoError(s.T, err)
-	}
 
 	// The addresses returned by PeerInfo include the /p2p/<peerID> part, but
 	// the libp2p.ListenAddrStrings cannot include it, so we need to remove it

--- a/tests/integration/db_setup.go
+++ b/tests/integration/db_setup.go
@@ -182,7 +182,6 @@ func setupNode(
 
 		err = nodeObj.DB.ReEnableNAC(ctx)
 		require.NoError(s.T, err)
-
 	} else {
 		addresses, err = nodeObj.DB.PeerInfo(ctx)
 		require.NoError(s.T, err)

--- a/tests/integration/db_setup.go
+++ b/tests/integration/db_setup.go
@@ -21,6 +21,7 @@ import (
 	"github.com/sourcenetwork/immutable"
 
 	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
+	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/crypto"
 	"github.com/sourcenetwork/defradb/errors"
 	"github.com/sourcenetwork/defradb/internal/db"
@@ -144,16 +145,14 @@ func setupNode(
 		return nil, err
 	}
 
-	s.Ctx = acpIdentity.WithContext(s.Ctx, identity)
-	err = nodeObj.Start(s.Ctx)
+	ctx := acpIdentity.WithContext(s.Ctx, identity)
+	err = nodeObj.Start(ctx)
 
 	if err != nil {
 		return nil, err
 	}
 
 	c, err := setupClient(s, nodeObj)
-
-	resetStateContext(s)
 	require.Nil(s.T, err)
 
 	eventState, err := state.NewEventState(c.Events())
@@ -167,8 +166,28 @@ func setupNode(
 		NetOpts: netOpts,
 	}
 
-	addresses, err := nodeObj.DB.PeerInfo()
+	var addresses []string
+
+	// Temporarily turn NAC off if enabled to get the peer info we need to setup the node,
+	// otherwise we will get authorization errors as NAC gates [PeerInfo]. Re-nable NAC
+	// once [PeerInfo] operation is successfully bypassed.
+	nacStatus, err := nodeObj.DB.GetNACStatus(ctx)
 	require.NoError(s.T, err)
+	if nacStatus.Status == client.NACEnabled.String() {
+		err := nodeObj.DB.DisableNAC(ctx)
+		require.NoError(s.T, err)
+
+		addresses, err = nodeObj.DB.PeerInfo(ctx)
+		require.NoError(s.T, err)
+
+		err = nodeObj.DB.ReEnableNAC(ctx)
+		require.NoError(s.T, err)
+
+	} else {
+		addresses, err = nodeObj.DB.PeerInfo(ctx)
+		require.NoError(s.T, err)
+	}
+
 	// The addresses returned by PeerInfo include the /p2p/<peerID> part, but
 	// the libp2p.ListenAddrStrings cannot include it, so we need to remove it
 	// before caching the addresses on the state.

--- a/tests/integration/db_setup_js.go
+++ b/tests/integration/db_setup_js.go
@@ -62,9 +62,8 @@ func setupNode(
 	if err != nil {
 		return nil, err
 	}
-	s.Ctx = acpIdentity.WithContext(s.Ctx, identity)
-	err = nodeObj.Start(s.Ctx)
-	resetStateContext(s)
+	ctx := acpIdentity.WithContext(s.Ctx, identity)
+	err = nodeObj.Start(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/integration/identity.go
+++ b/tests/integration/identity.go
@@ -78,11 +78,18 @@ func getIdentityForRequest(s *state.State, identity state.Identity, nodeIndex in
 	ident := identHolder.Identity
 
 	if fullIdent, ok := ident.(acpIdentity.FullIdentity); ok {
+		audience := state.GetNodeAudience(s, nodeIndex)
 		token, ok := identHolder.NodeTokens[nodeIndex]
 		if ok {
 			fullIdent.SetBearerToken(token)
-		} else {
-			audience := state.GetNodeAudience(s, nodeIndex)
+		}
+
+		// Generate/regenerate the token if:
+		// - No token exists yet, OR
+		// - An audience is now available but the token was generated without one
+		//   (this can happen when the token is created during node setup before the
+		//    HTTP wrapper is ready, causing the audience to be unavailable at that time).
+		if !ok || (audience.HasValue() && !state.TokenHasAudience(token)) {
 			if s.DocumentACPType == state.SourceHubDocumentACPType || audience.HasValue() {
 				err := fullIdent.UpdateToken(
 					action.AuthTokenExpiration,

--- a/tests/integration/identity.go
+++ b/tests/integration/identity.go
@@ -130,9 +130,3 @@ func getIdentityDID(s *state.State, identity immutable.Option[state.Identity]) s
 	}
 	return ""
 }
-
-// resetContextWithNoIdentity resets identity for the ctx to avoid, leaving it there and having the ctx
-// reuse the same identity for other requests that don't specify an identity.
-func resetStateContext(s *state.State) {
-	s.Ctx = acpIdentity.WithContext(s.Ctx, acpIdentity.None)
-}

--- a/tests/integration/p2p.go
+++ b/tests/integration/p2p.go
@@ -14,9 +14,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/libp2p/go-libp2p/core/peer"
-	"github.com/multiformats/go-multiaddr"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/sourcenetwork/corelog"
@@ -24,54 +21,6 @@ import (
 
 	"github.com/sourcenetwork/defradb/tests/state"
 )
-
-// PeerInfo returns the p2p host list of addresses.
-type PeerInfo struct {
-	// NodeID is the ID (index) of the node to execute the PeerInfo request on.
-	NodeID int
-
-	// The identity of this request. Optional.
-	//
-	// If node acp is enabled, identity will be used to check if this operation can be performed.
-	Identity immutable.Option[state.Identity]
-
-	// Expected number of total peers in the list of peers that will be returned, they will all
-	// be validated, we just don't assert them individually due to maintainance cost.
-	ExpectedNumberOfPeers int
-
-	// Any error expected from the action. Optional.
-	//
-	// String can be a partial, and the test will pass if an error is returned that
-	// contains this string.
-	ExpectedError string
-}
-
-// peerInfo returns the p2p host list of addresses.
-func peerInfo(
-	s *state.State,
-	action PeerInfo,
-) {
-	node := s.Nodes[action.NodeID]
-
-	ctx := getContextWithIdentity(s.Ctx, s, action.Identity, action.NodeID)
-	peerInfos, err := node.PeerInfo(ctx)
-
-	expectedErrorRaised := AssertError(s.T, err, action.ExpectedError)
-	assertExpectedErrorRaised(s.T, action.ExpectedError, expectedErrorRaised)
-
-	if !expectedErrorRaised {
-		assert.Equal(s.T, action.ExpectedNumberOfPeers, len(peerInfos))
-
-		// Check that all the returned addresses in the list are valid.
-		for _, peerInfo := range peerInfos {
-			maddr, err := multiaddr.NewMultiaddr(peerInfo)
-			require.NoError(s.T, err)
-
-			_, err = peer.IDFromP2PAddr(maddr)
-			require.NoError(s.T, err)
-		}
-	}
-}
 
 // ConnectPeers connects two nodes together as peers.
 //

--- a/tests/integration/p2p.go
+++ b/tests/integration/p2p.go
@@ -14,6 +14,9 @@ import (
 	"context"
 	"time"
 
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/multiformats/go-multiaddr"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/sourcenetwork/corelog"
@@ -21,6 +24,54 @@ import (
 
 	"github.com/sourcenetwork/defradb/tests/state"
 )
+
+// PeerInfo returns the p2p host list of addresses.
+type PeerInfo struct {
+	// NodeID is the ID (index) of the node to execute the PeerInfo request on.
+	NodeID int
+
+	// The identity of this request. Optional.
+	//
+	// If node acp is enabled, identity will be used to check if this operation can be performed.
+	Identity immutable.Option[state.Identity]
+
+	// Expected number of total peers in the list of peers that will be returned, they will all
+	// be validated, we just don't assert them individually due to maintainance cost.
+	ExpectedNumberOfPeers int
+
+	// Any error expected from the action. Optional.
+	//
+	// String can be a partial, and the test will pass if an error is returned that
+	// contains this string.
+	ExpectedError string
+}
+
+// peerInfo returns the p2p host list of addresses.
+func peerInfo(
+	s *state.State,
+	action PeerInfo,
+) {
+	node := s.Nodes[action.NodeID]
+
+	ctx := getContextWithIdentity(s.Ctx, s, action.Identity, action.NodeID)
+	peerInfos, err := node.PeerInfo(ctx)
+
+	expectedErrorRaised := AssertError(s.T, err, action.ExpectedError)
+	assertExpectedErrorRaised(s.T, action.ExpectedError, expectedErrorRaised)
+
+	if !expectedErrorRaised {
+		assert.Equal(s.T, action.ExpectedNumberOfPeers, len(peerInfos))
+
+		// Check that all the returned addresses in the list are valid.
+		for _, peerInfo := range peerInfos {
+			maddr, err := multiaddr.NewMultiaddr(peerInfo)
+			require.NoError(s.T, err)
+
+			_, err = peer.IDFromP2PAddr(maddr)
+			require.NoError(s.T, err)
+		}
+	}
+}
 
 // ConnectPeers connects two nodes together as peers.
 //
@@ -81,9 +132,9 @@ func connectPeers(
 	sourceNode := s.Nodes[cfg.SourceNodeID]
 	targetNode := s.Nodes[cfg.TargetNodeID]
 
-	sourceAddresses, err := sourceNode.PeerInfo()
+	sourceAddresses, err := sourceNode.PeerInfo(s.Ctx)
 	require.NoError(s.T, err)
-	targetAddresses, err := targetNode.PeerInfo()
+	targetAddresses, err := targetNode.PeerInfo(s.Ctx)
 	require.NoError(s.T, err)
 
 	log.InfoContext(s.Ctx, "Connect peers",
@@ -119,9 +170,9 @@ func reconnectPeers(s *state.State) {
 			sourceNode := s.Nodes[index]
 			targetNode := s.Nodes[targetIndex]
 
-			sourceAddresses, err := sourceNode.PeerInfo()
+			sourceAddresses, err := sourceNode.PeerInfo(s.Ctx)
 			require.NoError(s.T, err)
-			targetAddresses, err := targetNode.PeerInfo()
+			targetAddresses, err := targetNode.PeerInfo(s.Ctx)
 			require.NoError(s.T, err)
 
 			log.InfoContext(ctx, "Connect peers",

--- a/tests/integration/p2p.go
+++ b/tests/integration/p2p.go
@@ -132,18 +132,32 @@ func connectPeers(
 	sourceNode := s.Nodes[cfg.SourceNodeID]
 	targetNode := s.Nodes[cfg.TargetNodeID]
 
-	sourceAddresses, err := sourceNode.PeerInfo(s.Ctx)
+	// Inject source/target node's identity into the context to bypass NAC for the gated [PeerInfo] operation,
+	// otherwise due to lack of authorization(s) we might not be able to see the peer addresses at all.
+	ctxWithSourceNodeIdentity := getContextWithIdentity(
+		s.Ctx,
+		s,
+		NodeIdentity(cfg.SourceNodeID),
+		cfg.SourceNodeID,
+	)
+	ctxWithTargetNodeIdentity := getContextWithIdentity(
+		s.Ctx,
+		s,
+		NodeIdentity(cfg.TargetNodeID),
+		cfg.TargetNodeID,
+	)
+	sourceAddresses, err := sourceNode.PeerInfo(ctxWithSourceNodeIdentity)
 	require.NoError(s.T, err)
-	targetAddresses, err := targetNode.PeerInfo(s.Ctx)
+	targetAddresses, err := targetNode.PeerInfo(ctxWithTargetNodeIdentity)
 	require.NoError(s.T, err)
 
 	log.InfoContext(s.Ctx, "Connect peers",
 		corelog.Any("Source", sourceAddresses),
-		corelog.Any("Target", targetAddresses))
+		corelog.Any("Target", targetAddresses),
+	)
 
-	ctx := getContextWithIdentity(s.Ctx, s, cfg.Identity, cfg.SourceNodeID)
-
-	err = connectWithRetry(ctx, sourceNode, targetAddresses)
+	ctxWithSourceNodeUserIdentity := getContextWithIdentity(s.Ctx, s, cfg.Identity, cfg.SourceNodeID)
+	err = connectWithRetry(ctxWithSourceNodeUserIdentity, sourceNode, targetAddresses)
 
 	expectedErrorRaised := AssertError(s.T, err, cfg.ExpectedError)
 	assertExpectedErrorRaised(s.T, cfg.ExpectedError, expectedErrorRaised)
@@ -160,26 +174,39 @@ func connectPeers(
 // reconnectPeers makes sure that all peers are connected after a node restart action.
 func reconnectPeers(s *state.State) {
 	nodeIDs, nodes := getNodesWithIDs(immutable.None[int](), s.Nodes)
-	for index, node := range nodes {
-		nodeID := nodeIDs[index]
-		// Inject every source node's identity into the context while refreshing so the
-		// [Connect] call doesn't fail due to lack of authorization(s) if NAC is enabled.
-		nodeIdentity := NodeIdentity(nodeID)
-		ctx := getContextWithIdentity(s.Ctx, s, nodeIdentity, nodeID)
-		for targetIndex := range node.P2P.Connections {
-			sourceNode := s.Nodes[index]
-			targetNode := s.Nodes[targetIndex]
+	for sourceIndex, sourceNode := range nodes {
+		sourceNodeID := nodeIDs[sourceIndex]
+		// Inject every source node's identity into the context while refreshing so the [Connect] & [PeerInfo]
+		// call doesn't fail due to lack of authorization(s) if NAC is enabled.
+		ctxWithSourceNodeIdentity := getContextWithIdentity(
+			s.Ctx,
+			s,
+			NodeIdentity(sourceNodeID),
+			sourceNodeID,
+		)
 
-			sourceAddresses, err := sourceNode.PeerInfo(s.Ctx)
+		for targetIndex := range sourceNode.P2P.Connections {
+			targetNode := nodes[targetIndex]
+			targetNodeID := nodeIDs[targetIndex]
+			// Inject target node's identity into the context to bypass NAC for the gated [PeerInfo] operation,
+			// otherwise due to lack of authorization(s) we might not be able to see the peer addresses at all.
+			ctxWithTargetNodeIdentity := getContextWithIdentity(
+				s.Ctx,
+				s,
+				NodeIdentity(targetNodeID),
+				targetNodeID,
+			)
+			sourceAddresses, err := sourceNode.PeerInfo(ctxWithSourceNodeIdentity)
 			require.NoError(s.T, err)
-			targetAddresses, err := targetNode.PeerInfo(s.Ctx)
+			targetAddresses, err := targetNode.PeerInfo(ctxWithTargetNodeIdentity)
 			require.NoError(s.T, err)
 
-			log.InfoContext(ctx, "Connect peers",
+			log.InfoContext(s.Ctx, "Connect peers",
 				corelog.Any("Source", sourceAddresses),
-				corelog.Any("Target", targetAddresses))
+				corelog.Any("Target", targetAddresses),
+			)
 
-			err = connectWithRetry(ctx, sourceNode, targetAddresses)
+			err = connectWithRetry(ctxWithSourceNodeIdentity, sourceNode, targetAddresses)
 			require.NoError(s.T, err)
 		}
 	}
@@ -187,6 +214,9 @@ func reconnectPeers(s *state.State) {
 
 // connectWithRetry attempts to connect to target addresses with retry logic
 // to handle transient connection failures.
+//
+// Note: The input context should have the appropriate identity injected, if the caller
+// forgets to do that, and NAC system is enabled, there will be authorization error(s).
 func connectWithRetry(ctx context.Context, node *state.NodeState, targetAddresses []string) error {
 	const maxRetries = 5
 	const retryDelay = 50 * time.Millisecond

--- a/tests/integration/p2p_replicator.go
+++ b/tests/integration/p2p_replicator.go
@@ -108,7 +108,7 @@ func createReplicator(
 	sourceNode := s.Nodes[cfg.SourceNodeID]
 	targetNode := s.Nodes[cfg.TargetNodeID]
 
-	targetAddresses, err := targetNode.PeerInfo()
+	targetAddresses, err := targetNode.PeerInfo(s.Ctx)
 	require.NoError(s.T, err)
 
 	ctx := getContextWithIdentity(s.Ctx, s, cfg.Identity, cfg.SourceNodeID)
@@ -129,7 +129,7 @@ func deleteReplicator(
 	sourceNode := s.Nodes[cfg.SourceNodeID]
 	targetNode := s.Nodes[cfg.TargetNodeID]
 
-	targetAddresses, err := targetNode.PeerInfo()
+	targetAddresses, err := targetNode.PeerInfo(s.Ctx)
 	require.NoError(s.T, err)
 	require.NotZero(s.T, len(targetAddresses))
 

--- a/tests/integration/p2p_replicator.go
+++ b/tests/integration/p2p_replicator.go
@@ -108,11 +108,15 @@ func createReplicator(
 	sourceNode := s.Nodes[cfg.SourceNodeID]
 	targetNode := s.Nodes[cfg.TargetNodeID]
 
-	targetAddresses, err := targetNode.PeerInfo(s.Ctx)
+	// Inject target node's identity into the context to bypass NAC for the gated [PeerInfo] operation,
+	// otherwise due to lack of authorization(s) we might not be able to see the peer addresses at all.
+	nodeIdentity := NodeIdentity(cfg.TargetNodeID)
+	ctxWithTargetNodeIdentity := getContextWithIdentity(s.Ctx, s, nodeIdentity, cfg.TargetNodeID)
+	targetAddresses, err := targetNode.PeerInfo(ctxWithTargetNodeIdentity)
 	require.NoError(s.T, err)
 
-	ctx := getContextWithIdentity(s.Ctx, s, cfg.Identity, cfg.SourceNodeID)
-	err = sourceNode.CreateReplicator(ctx, targetAddresses)
+	ctxWithSourceNodeUserIdentity := getContextWithIdentity(s.Ctx, s, cfg.Identity, cfg.SourceNodeID)
+	err = sourceNode.CreateReplicator(ctxWithSourceNodeUserIdentity, targetAddresses)
 
 	expectedErrorRaised := AssertError(s.T, err, cfg.ExpectedError)
 	assertExpectedErrorRaised(s.T, cfg.ExpectedError, expectedErrorRaised)
@@ -129,7 +133,11 @@ func deleteReplicator(
 	sourceNode := s.Nodes[cfg.SourceNodeID]
 	targetNode := s.Nodes[cfg.TargetNodeID]
 
-	targetAddresses, err := targetNode.PeerInfo(s.Ctx)
+	// Inject target node's identity into the context to bypass NAC for the gated [PeerInfo] operation,
+	// otherwise due to lack of authorization(s) we might not be able to see the peer addresses at all.
+	nodeIdentity := NodeIdentity(cfg.TargetNodeID)
+	ctxWithTargetNodeIdentity := getContextWithIdentity(s.Ctx, s, nodeIdentity, cfg.TargetNodeID)
+	targetAddresses, err := targetNode.PeerInfo(ctxWithTargetNodeIdentity)
 	require.NoError(s.T, err)
 	require.NotZero(s.T, len(targetAddresses))
 
@@ -138,8 +146,8 @@ func deleteReplicator(
 	id, err := maddr.ValueForProtocol(multiaddr.P_P2P)
 	require.NoError(s.T, err)
 
-	ctx := getContextWithIdentity(s.Ctx, s, cfg.Identity, cfg.SourceNodeID)
-	err = sourceNode.DeleteReplicator(ctx, id)
+	ctxWithSourceNodeUserIdentity := getContextWithIdentity(s.Ctx, s, cfg.Identity, cfg.SourceNodeID)
+	err = sourceNode.DeleteReplicator(ctxWithSourceNodeUserIdentity, id)
 
 	expectedErrorRaised := AssertError(s.T, err, cfg.ExpectedError)
 	assertExpectedErrorRaised(s.T, cfg.ExpectedError, expectedErrorRaised)

--- a/tests/integration/results.go
+++ b/tests/integration/results.go
@@ -111,7 +111,7 @@ func (matcher *UniqueValue) ResetMatcherState() {
 }
 
 func (matcher *UniqueValue) Match(actual any) (bool, error) {
-	nodeID := matcher.s.GetCurrentNodeID()
+	nodeID := matcher.s.GetCurrentAssertingNodeID()
 	for nodeID >= len(matcher.seenValues) {
 		matcher.seenValues = append(matcher.seenValues, make(map[any]bool))
 	}

--- a/tests/integration/results_test.go
+++ b/tests/integration/results_test.go
@@ -30,7 +30,7 @@ func (m *mockTestState) GetClientType() state.ClientType {
 	return m.clientType
 }
 
-func (m *mockTestState) GetCurrentNodeID() int {
+func (m *mockTestState) GetCurrentAssertingNodeID() int {
 	return m.currentNodeID
 }
 

--- a/tests/integration/signature/utils.go
+++ b/tests/integration/signature/utils.go
@@ -55,7 +55,7 @@ func (matcher *signatureMatcher) Match(actual any) (bool, error) {
 		return false, err
 	}
 
-	ident := matcher.s.GetIdentity(testUtils.NodeIdentity(matcher.s.GetCurrentNodeID()).Value())
+	ident := matcher.s.GetIdentity(testUtils.NodeIdentity(matcher.s.GetCurrentAssertingNodeID()).Value())
 	fullIdent, ok := ident.(acpIdentity.FullIdentity)
 	if !ok {
 		return false, fmt.Errorf("identity does not implement FullIdentity")

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -342,9 +342,6 @@ func performAction(
 	case Start:
 		startNodes(s, testCase, action)
 
-	case PeerInfo:
-		peerInfo(s, action)
-
 	case ConnectPeers:
 		connectPeers(s, action)
 

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -812,11 +812,12 @@ func setStartingNodes(
 
 	// If nodes have not been explicitly configured via actions, setup a default one.
 	if !s.IsNetworkEnabled {
+		s.CurrentSetupNodeID = 0
 		st, err := setupNode(
 			s,
 			acpIdentity.None,
 			testCase,
-			db.WithNodeIdentity(state.GetIdentity(s, NodeIdentity(0))),
+			db.WithNodeIdentity(state.GetIdentity(s, NodeIdentity(s.CurrentSetupNodeID))),
 		)
 		require.Nil(s.T, err)
 		s.Nodes = append(s.Nodes, st)
@@ -826,16 +827,18 @@ func setStartingNodes(
 func startNodes(s *state.State, testCase TestCase, action Start) {
 	nodeIDs, nodes := getNodesWithIDs(action.NodeID, s.Nodes)
 	// We need to restart the nodes in reverse order, to avoid dial backoff issues.
-	for i := len(nodes) - 1; i >= 0; i-- {
-		nodeIndex := nodeIDs[i]
+	for index := len(nodes) - 1; index >= 0; index-- {
+		nodeID := nodeIDs[index]
 		originalPath := databaseDir
-		databaseDir = s.Nodes[nodeIndex].DbPath
-		opts := []node.Option{
-			db.WithNodeIdentity(state.GetIdentity(s, NodeIdentity(nodeIndex))),
-		}
-		opts = append(opts, s.Nodes[nodeIndex].NetOpts...)
+		databaseDir = s.Nodes[nodeID].DbPath
 
-		opts = withWithListenAddresses(opts, s.Nodes[nodeIndex].CachedAddresses...)
+		s.CurrentSetupNodeID = nodeID
+		opts := []node.Option{
+			db.WithNodeIdentity(state.GetIdentity(s, NodeIdentity(s.CurrentSetupNodeID))),
+		}
+
+		opts = append(opts, s.Nodes[nodeID].NetOpts...)
+		opts = withWithListenAddresses(opts, s.Nodes[nodeID].CachedAddresses...)
 		opts = append(opts, node.WithEnableNodeACP(action.EnableNAC))
 		node, err := setupNode(
 			s,
@@ -854,9 +857,8 @@ func startNodes(s *state.State, testCase TestCase, action Start) {
 		}
 
 		require.Equal(s.T, action.ExpectedError, "")
-
-		node.P2P = s.Nodes[nodeIndex].P2P
-		s.Nodes[nodeIndex] = node
+		node.P2P = s.Nodes[nodeID].P2P
+		s.Nodes[nodeID] = node
 	}
 
 	// If the db was restarted we need to refresh the existing tokens as the audiance value changed,
@@ -974,7 +976,14 @@ func configureNode(
 
 	nodeOpts := []node.Option{db.WithRetryInterval([]time.Duration{time.Millisecond * 1})}
 	nodeOpts = append(nodeOpts, netNodeOpts...)
-	nodeOpts = append(nodeOpts, db.WithNodeIdentity(state.GetIdentity(s, NodeIdentity(len(s.Nodes)))))
+
+	s.CurrentSetupNodeID = len(s.Nodes)
+	nodeOpts = append(
+		nodeOpts,
+		db.WithNodeIdentity(
+			state.GetIdentity(s, NodeIdentity(s.CurrentSetupNodeID)),
+		),
+	)
 
 	node, err := setupNode(s, acpIdentity.None, testCase, nodeOpts...) //disable change detector, or allow it?
 	require.NoError(s.T, err)

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -342,6 +342,9 @@ func performAction(
 	case Start:
 		startNodes(s, testCase, action)
 
+	case PeerInfo:
+		peerInfo(s, action)
+
 	case ConnectPeers:
 		connectPeers(s, action)
 

--- a/tests/state/identity.go
+++ b/tests/state/identity.go
@@ -12,7 +12,9 @@ package state
 
 import (
 	"crypto/ed25519"
+	"encoding/base64"
 	"math/rand"
+	"strings"
 
 	"github.com/decred/dcrd/dcrec/secp256k1/v4"
 	"github.com/stretchr/testify/require"
@@ -87,6 +89,24 @@ func GetIdentityHolder(s *State, identity Identity) *IdentityHolder {
 
 	s.Identities[identity] = newIdentityHolder(generateIdentity(s, keyType))
 	return s.Identities[identity]
+}
+
+// TokenHasAudience returns true if the given JWT token string contains an audience claim.
+// This is used to detect tokens that were generated before the node's HTTP host was available,
+// and need to be regenerated with the correct audience.
+func TokenHasAudience(token string) bool {
+	if token == "" {
+		return false
+	}
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return false
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return false
+	}
+	return strings.Contains(string(payload), `"aud"`)
 }
 
 // Generate the keys using predefined seed so that multiple runs yield the same private key.

--- a/tests/state/state.go
+++ b/tests/state/state.go
@@ -314,6 +314,10 @@ type State struct {
 	// test run. After a single test run, the StatefulMatchers are reset.
 	StatefulMatchers []StatefulMatcher
 
+	// CurrentSetupNodeID is used during setup stage to find specific attributes that are unique to a
+	// node's unique ID, for example finding a specific node's NodeIdentity inorder to bypass NAC.
+	CurrentSetupNodeID int
+
 	// node id that is currently being asserted. This is used by [StatefulMatcher]s to know for which
 	// node they should be asserting. For example, the [UniqueValue] matcher checks that it is
 	// called with a value that it didn't see before, but the value should be the same for different

--- a/tests/state/state.go
+++ b/tests/state/state.go
@@ -40,8 +40,8 @@ type StatefulMatcher interface {
 type TestState interface {
 	// GetClientType returns the client type of the test.
 	GetClientType() ClientType
-	// GetCurrentNodeID returns the node id that is currently being asserted.
-	GetCurrentNodeID() int
+	// GetCurrentAssertingNodeID returns the node id that is currently being asserted.
+	GetCurrentAssertingNodeID() int
 	// GetIdentity returns the identity for the given node index.
 	GetIdentity(Identity) acpIdentity.Identity
 	// GetDocID returns the document ID for the given collection index and document index.
@@ -315,7 +315,7 @@ type State struct {
 	StatefulMatchers []StatefulMatcher
 
 	// CurrentSetupNodeID is used during setup stage to find specific attributes that are unique to a
-	// node's unique ID, for example finding a specific node's NodeIdentity inorder to bypass NAC.
+	// node, for example finding a specific node's NodeIdentity inorder to bypass NAC.
 	CurrentSetupNodeID int
 
 	// node id that is currently being asserted. This is used by [StatefulMatcher]s to know for which
@@ -323,7 +323,7 @@ type State struct {
 	// called with a value that it didn't see before, but the value should be the same for different
 	// nodes, e.g. within the same node Cids should be unique, but across different nodes the same block
 	// should have the same Cid.
-	CurrentNodeID int
+	CurrentAssertingNodeID int
 
 	// LenIDs of lenses added to Defra.
 	LensIDs []string
@@ -333,8 +333,8 @@ func (s *State) GetClientType() ClientType {
 	return s.ClientType
 }
 
-func (s *State) GetCurrentNodeID() int {
-	return s.CurrentNodeID
+func (s *State) GetCurrentAssertingNodeID() int {
+	return s.CurrentAssertingNodeID
 }
 
 func (s *State) GetIdentity(ident Identity) acpIdentity.Identity {


### PR DESCRIPTION
## Relevant issue(s)
Resolves #4249 
Resolves #4250 

## Description
- Add context to `PeerInfo`
- Add integration test util functionality for `PeerInfo`
- Gate `PeerInfo` with NAC
- Test `PeerInfo` gate.
- Test `PeerInfo` gate with relationship.

### For reviewers:
- Better to review all together rather than commit by commit as commits aren't clean anymore.
~~- Please give a shout or push back  on how the internal NAC bypassing in integration tests is being done if you disagree, in particular please review these closely:~~
~~- This Commit: `PR(BY_PASS): Skip NAC for testing internal setup calls`~~
~~- And this hacky change: https://github.com/sourcenetwork/defradb/pull/4282#discussion_r2630146875~~

### Todo(s) before merge:
- [x] Fix the JS build
- [x] Fix the Http issue
- [x] Fix the locking issue
- [x] Fix the one branchable test
- [x] Fix the sourcehub bug
- [x] Wait for #4237 to merge