### PR TITLE
fix: Connect peers with retries in tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -411,3 +411,5 @@ require (
 )
 
 replace github.com/wlynxg/anet => github.com/sourcenetwork/anet v0.0.0-20250417190629-7c87cba7799e
+
+replace github.com/sourcenetwork/go-p2p => ../go-p2p

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/sourcenetwork/corekv/memory v0.2.4
 	github.com/sourcenetwork/corekv/namespace v0.2.4
 	github.com/sourcenetwork/corelog v0.0.8
-	github.com/sourcenetwork/go-p2p v0.1.6
+	github.com/sourcenetwork/go-p2p v0.1.7
 	github.com/sourcenetwork/goji v0.0.8
 	github.com/sourcenetwork/graphql-go v0.7.4-0.20251208194504-a831d1b53d40
 	github.com/sourcenetwork/immutable v0.3.0
@@ -411,5 +411,3 @@ require (
 )
 
 replace github.com/wlynxg/anet => github.com/sourcenetwork/anet v0.0.0-20250417190629-7c87cba7799e
-
-replace github.com/sourcenetwork/go-p2p => ../go-p2p

--- a/go.sum
+++ b/go.sum
@@ -2328,6 +2328,8 @@ github.com/sourcenetwork/corelog v0.0.8 h1:jCo0mFBpWrfhUCGzzN3uUtPGyQv3jnITdPO1s
 github.com/sourcenetwork/corelog v0.0.8/go.mod h1:cMabHgs3kARgYTQeQYSOmaGGP8XMU6sZrHd8LFrL3zA=
 github.com/sourcenetwork/go-libp2p-pubsub-rpc v0.0.14 h1:620zKV4rOn7U5j/WsPkk4SFj0z9/pVV4bBx0BpZQgro=
 github.com/sourcenetwork/go-libp2p-pubsub-rpc v0.0.14/go.mod h1:jUoQv592uUX1u7QBjAY4C+l24X9ArhPfifOqXpDHz4U=
+github.com/sourcenetwork/go-p2p v0.1.7 h1:eKNoFrgVaYFvgpKHRbjc9o5kODOkPehfTtcXVxkegSw=
+github.com/sourcenetwork/go-p2p v0.1.7/go.mod h1:gpPc76Bxm6ZzY76KE+MAH4li4FIkyES0yMdoleVdRfQ=
 github.com/sourcenetwork/goji v0.0.8 h1:6EqGFt18yJ/CxyiPUKZFbK3KFuzGJ5oLnTvFYObZj5k=
 github.com/sourcenetwork/goji v0.0.8/go.mod h1:A/dsoaCbLQ1a5PQfUVCA1zYMHnNAprVhZEmQHIlCfjE=
 github.com/sourcenetwork/graphql-go v0.7.4-0.20251208194504-a831d1b53d40 h1:wiL6+capi8zP/jUeyPr6OrtHEpaCo23O2SnryyX2yvo=

--- a/go.sum
+++ b/go.sum
@@ -2328,8 +2328,6 @@ github.com/sourcenetwork/corelog v0.0.8 h1:jCo0mFBpWrfhUCGzzN3uUtPGyQv3jnITdPO1s
 github.com/sourcenetwork/corelog v0.0.8/go.mod h1:cMabHgs3kARgYTQeQYSOmaGGP8XMU6sZrHd8LFrL3zA=
 github.com/sourcenetwork/go-libp2p-pubsub-rpc v0.0.14 h1:620zKV4rOn7U5j/WsPkk4SFj0z9/pVV4bBx0BpZQgro=
 github.com/sourcenetwork/go-libp2p-pubsub-rpc v0.0.14/go.mod h1:jUoQv592uUX1u7QBjAY4C+l24X9ArhPfifOqXpDHz4U=
-github.com/sourcenetwork/go-p2p v0.1.6 h1:iaxKtVuTYfCnwghlBoxOB7zHpLcVqrlmwzrEShxJ5h8=
-github.com/sourcenetwork/go-p2p v0.1.6/go.mod h1:gpPc76Bxm6ZzY76KE+MAH4li4FIkyES0yMdoleVdRfQ=
 github.com/sourcenetwork/goji v0.0.8 h1:6EqGFt18yJ/CxyiPUKZFbK3KFuzGJ5oLnTvFYObZj5k=
 github.com/sourcenetwork/goji v0.0.8/go.mod h1:A/dsoaCbLQ1a5PQfUVCA1zYMHnNAprVhZEmQHIlCfjE=
 github.com/sourcenetwork/graphql-go v0.7.4-0.20251208194504-a831d1b53d40 h1:wiL6+capi8zP/jUeyPr6OrtHEpaCo23O2SnryyX2yvo=

--- a/tests/integration/db_setup.go
+++ b/tests/integration/db_setup.go
@@ -14,11 +14,8 @@ package tests
 
 import (
 	"fmt"
-	"net"
-	"time"
 
 	"github.com/multiformats/go-multiaddr"
-	manet "github.com/multiformats/go-multiaddr/net"
 	"github.com/stretchr/testify/require"
 
 	"github.com/sourcenetwork/immutable"
@@ -152,16 +149,6 @@ func setupNode(
 		return nil, err
 	}
 
-	if s.IsNetworkEnabled {
-		addresses, err := nodeObj.DB.PeerInfo()
-		if err != nil {
-			return nil, fmt.Errorf("failed to get peer info: %w", err)
-		}
-		if err := waitForListenerReady(addresses); err != nil {
-			return nil, fmt.Errorf("node listener not ready: %w", err)
-		}
-	}
-
 	c, err := setupClient(s, nodeObj)
 
 	resetStateContext(s)
@@ -212,48 +199,4 @@ func removePeerID(addr string) (string, error) {
 		return "", errors.New("address does not contain a /p2p/ part")
 	}
 	return justAddr.String(), nil
-}
-
-// waitForListenerReady waits until the node's TCP listener is ready to accept connections.
-// This prevents race conditions where peer connection attempts fail because the listener
-// isn't fully ready yet, which can trigger libp2p's dial backoff mechanism.
-func waitForListenerReady(addresses []string) error {
-	const maxAttempts = 50
-	const retryDelay = 10 * time.Millisecond
-
-	for _, addr := range addresses {
-		maddr, err := multiaddr.NewMultiaddr(addr)
-		if err != nil {
-			continue
-		}
-
-		// Extract just the network address part (without /p2p/...)
-		networkAddr, _ := multiaddr.SplitFunc(maddr, func(c multiaddr.Component) bool {
-			return c.Protocol().Code == multiaddr.P_P2P
-		})
-		if networkAddr == nil {
-			networkAddr = maddr
-		}
-
-		netAddr, err := manet.ToNetAddr(networkAddr)
-		if err != nil {
-			continue
-		}
-
-		for attempt := 0; attempt < maxAttempts; attempt++ {
-			conn, err := net.DialTimeout("tcp", netAddr.String(), 100*time.Millisecond)
-			if err == nil {
-				_ = conn.Close()
-				// Add a small delay after TCP connection succeeds to allow
-				// libp2p's protocol handlers to fully initialize
-				time.Sleep(10 * time.Millisecond)
-				return nil
-			}
-			time.Sleep(retryDelay)
-		}
-
-		return fmt.Errorf("listener not ready after %d attempts: %s", maxAttempts, addr)
-	}
-
-	return nil
 }

--- a/tests/integration/db_setup.go
+++ b/tests/integration/db_setup.go
@@ -14,8 +14,11 @@ package tests
 
 import (
 	"fmt"
+	"net"
+	"time"
 
 	"github.com/multiformats/go-multiaddr"
+	manet "github.com/multiformats/go-multiaddr/net"
 	"github.com/stretchr/testify/require"
 
 	"github.com/sourcenetwork/immutable"
@@ -149,6 +152,16 @@ func setupNode(
 		return nil, err
 	}
 
+	if s.IsNetworkEnabled {
+		addresses, err := nodeObj.DB.PeerInfo()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get peer info: %w", err)
+		}
+		if err := waitForListenerReady(addresses); err != nil {
+			return nil, fmt.Errorf("node listener not ready: %w", err)
+		}
+	}
+
 	c, err := setupClient(s, nodeObj)
 
 	resetStateContext(s)
@@ -199,4 +212,48 @@ func removePeerID(addr string) (string, error) {
 		return "", errors.New("address does not contain a /p2p/ part")
 	}
 	return justAddr.String(), nil
+}
+
+// waitForListenerReady waits until the node's TCP listener is ready to accept connections.
+// This prevents race conditions where peer connection attempts fail because the listener
+// isn't fully ready yet, which can trigger libp2p's dial backoff mechanism.
+func waitForListenerReady(addresses []string) error {
+	const maxAttempts = 50
+	const retryDelay = 10 * time.Millisecond
+
+	for _, addr := range addresses {
+		maddr, err := multiaddr.NewMultiaddr(addr)
+		if err != nil {
+			continue
+		}
+
+		// Extract just the network address part (without /p2p/...)
+		networkAddr, _ := multiaddr.SplitFunc(maddr, func(c multiaddr.Component) bool {
+			return c.Protocol().Code == multiaddr.P_P2P
+		})
+		if networkAddr == nil {
+			networkAddr = maddr
+		}
+
+		netAddr, err := manet.ToNetAddr(networkAddr)
+		if err != nil {
+			continue
+		}
+
+		for attempt := 0; attempt < maxAttempts; attempt++ {
+			conn, err := net.DialTimeout("tcp", netAddr.String(), 100*time.Millisecond)
+			if err == nil {
+				_ = conn.Close()
+				// Add a small delay after TCP connection succeeds to allow
+				// libp2p's protocol handlers to fully initialize
+				time.Sleep(10 * time.Millisecond)
+				return nil
+			}
+			time.Sleep(retryDelay)
+		}
+
+		return fmt.Errorf("listener not ready after %d attempts: %s", maxAttempts, addr)
+	}
+
+	return nil
 }

--- a/tests/integration/p2p.go
+++ b/tests/integration/p2p.go
@@ -11,6 +11,8 @@
 package tests
 
 import (
+	"context"
+	"strings"
 	"time"
 
 	"github.com/stretchr/testify/require"
@@ -90,7 +92,9 @@ func connectPeers(
 		corelog.Any("Target", targetAddresses))
 
 	ctx := getContextWithIdentity(s.Ctx, s, cfg.Identity, cfg.SourceNodeID)
-	err = sourceNode.Connect(ctx, targetAddresses)
+
+	err = connectWithRetry(ctx, sourceNode, targetAddresses)
+
 	expectedErrorRaised := AssertError(s.T, err, cfg.ExpectedError)
 	assertExpectedErrorRaised(s.T, cfg.ExpectedError, expectedErrorRaised)
 
@@ -125,10 +129,33 @@ func reconnectPeers(s *state.State) {
 				corelog.Any("Source", sourceAddresses),
 				corelog.Any("Target", targetAddresses))
 
-			err = sourceNode.Connect(ctx, targetAddresses)
+			err = connectWithRetry(ctx, sourceNode, targetAddresses)
 			require.NoError(s.T, err)
 		}
 	}
+}
+
+// connectWithRetry attempts to connect to target addresses with retry logic
+// to handle transient "dial backoff" errors that can occur when libp2p's host
+// is not fully ready to accept connections.
+func connectWithRetry(ctx context.Context, node *state.NodeState, targetAddresses []string) error {
+	const maxRetries = 20
+	const baseRetryDelay = 100 * time.Millisecond
+
+	var lastErr error
+	for attempt := range maxRetries {
+		lastErr = node.Connect(ctx, targetAddresses)
+		if lastErr == nil {
+			return nil
+		}
+		if strings.Contains(lastErr.Error(), "dial backoff") && attempt < maxRetries-1 {
+			delay := baseRetryDelay * time.Duration(1<<min(attempt, 4))
+			time.Sleep(delay)
+			continue
+		}
+		break
+	}
+	return lastErr
 }
 
 // syncDocs requests document sync from peers.

--- a/tests/integration/p2p.go
+++ b/tests/integration/p2p.go
@@ -12,7 +12,6 @@ package tests
 
 import (
 	"context"
-	"strings"
 	"time"
 
 	"github.com/stretchr/testify/require"
@@ -136,11 +135,10 @@ func reconnectPeers(s *state.State) {
 }
 
 // connectWithRetry attempts to connect to target addresses with retry logic
-// to handle transient "dial backoff" errors that can occur when libp2p's host
-// is not fully ready to accept connections.
+// to handle transient connection failures.
 func connectWithRetry(ctx context.Context, node *state.NodeState, targetAddresses []string) error {
-	const maxRetries = 20
-	const baseRetryDelay = 100 * time.Millisecond
+	const maxRetries = 5
+	const retryDelay = 50 * time.Millisecond
 
 	var lastErr error
 	for attempt := range maxRetries {
@@ -148,12 +146,9 @@ func connectWithRetry(ctx context.Context, node *state.NodeState, targetAddresse
 		if lastErr == nil {
 			return nil
 		}
-		if strings.Contains(lastErr.Error(), "dial backoff") && attempt < maxRetries-1 {
-			delay := baseRetryDelay * time.Duration(1<<min(attempt, 4))
-			time.Sleep(delay)
-			continue
+		if attempt < maxRetries-1 {
+			time.Sleep(retryDelay)
 		}
-		break
 	}
 	return lastErr
 }

--- a/tests/integration/p2p_config.go
+++ b/tests/integration/p2p_config.go
@@ -25,6 +25,7 @@ func RandomNetworkingConfig() ConfigureNode {
 		return []node.Option{
 			p2p.WithListenAddresses("/ip4/" + getIPString() + "/tcp/0"),
 			p2p.WithEnableRelay(true),
+			p2p.WithClearBackoffOnRetry(true),
 		}
 	}
 }


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4287

## Description

Implement peer connection retries in testing framework.