### PR TITLE
feat: Add keyring overwrite protection

### DIFF
--- a/cli/keyring_generate.go
+++ b/cli/keyring_generate.go
@@ -12,15 +12,19 @@ package cli
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
 	"github.com/spf13/cobra"
 
 	"github.com/sourcenetwork/defradb/crypto"
+	"github.com/sourcenetwork/defradb/keyring"
 )
 
 func MakeKeyringGenerateCommand(ctx context.Context) *cobra.Command {
 	var noEncryptionKey bool
 	var noPeerKey bool
+	var force bool
 	var cmd = &cobra.Command{
 		Use:   "generate",
 		Short: "Generate private keys",
@@ -34,27 +38,45 @@ defined with the --secret-file flag.
 
 WARNING: This will overwrite existing keys in the keyring.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			keyring, err := openKeyring(cmd)
+			k, err := openKeyring(cmd)
 			if err != nil {
 				return err
 			}
 			if !noEncryptionKey {
+				if !force {
+					_, err := k.Get(encryptionKeyName)
+					if err == nil {
+						return fmt.Errorf("key %s already exists, use --force to overwrite", encryptionKeyName)
+					}
+					if !errors.Is(err, keyring.ErrNotFound) {
+						return err
+					}
+				}
 				encryptionKey, err := crypto.GenerateAES256()
 				if err != nil {
 					return err
 				}
-				err = keyring.Set(encryptionKeyName, encryptionKey)
+				err = k.Set(encryptionKeyName, encryptionKey)
 				if err != nil {
 					return err
 				}
 				log.Info("generated encryption key")
 			}
 			if !noPeerKey {
+				if !force {
+					_, err := k.Get(peerKeyName)
+					if err == nil {
+						return fmt.Errorf("key %s already exists, use --force to overwrite", peerKeyName)
+					}
+					if !errors.Is(err, keyring.ErrNotFound) {
+						return err
+					}
+				}
 				peerKey, err := crypto.GenerateEd25519()
 				if err != nil {
 					return err
 				}
-				err = keyring.Set(peerKeyName, peerKey)
+				err = k.Set(peerKeyName, peerKey)
 				if err != nil {
 					return err
 				}
@@ -80,5 +102,6 @@ WARNING: This will overwrite existing keys in the keyring.`,
 		"Skip generating an encryption key. Encryption at rest will be disabled")
 	cmd.Flags().BoolVar(&noPeerKey, "no-peer-key", false,
 		"Skip generating a peer key.")
+	cmd.Flags().BoolVar(&force, "force", false, "Overwrite existing keys without confirmation")
 	return cmd
 }

--- a/cli/keyring_generate_test.go
+++ b/cli/keyring_generate_test.go
@@ -64,3 +64,39 @@ func TestKeyringGenerateNoPeerKey(t *testing.T) {
 	assert.FileExists(t, filepath.Join(rootdir, "keys", encryptionKeyName))
 	assert.NoFileExists(t, filepath.Join(rootdir, "keys", peerKeyName))
 }
+
+func TestKeyringGenerateOverwrite(t *testing.T) {
+	rootdir := t.TempDir()
+	err := os.Setenv("DEFRA_KEYRING_SECRET", "password")
+	require.NoError(t, err)
+
+	cmd := NewDefraCommand(context.Background())
+	cmd.SetArgs([]string{"keyring", "generate", "--rootdir", rootdir})
+
+	err = cmd.Execute()
+	require.NoError(t, err)
+
+	cmd2 := NewDefraCommand(context.Background())
+	cmd2.SetArgs([]string{"keyring", "generate", "--rootdir", rootdir})
+	err = cmd2.Execute()
+
+	require.Error(t, err)
+}
+
+func TestKeyringGenerateOverwriteForce(t *testing.T) {
+	rootdir := t.TempDir()
+	err := os.Setenv("DEFRA_KEYRING_SECRET", "password")
+	require.NoError(t, err)
+
+	cmd := NewDefraCommand(context.Background())
+	cmd.SetArgs([]string{"keyring", "generate", "--rootdir", rootdir})
+
+	err = cmd.Execute()
+	require.NoError(t, err)
+
+	cmd2 := NewDefraCommand(context.Background())
+	cmd2.SetArgs([]string{"keyring", "generate", "--rootdir", rootdir, "--force"})
+	err = cmd2.Execute()
+
+	require.NoError(t, err)
+}

--- a/docs/website/references/cli/defradb_keyring_generate.md
+++ b/docs/website/references/cli/defradb_keyring_generate.md
@@ -37,6 +37,7 @@ with system keyring:
 ### Options
 
 ```
+      --force           Overwrite existing keys without confirmation
   -h, --help            help for generate
       --no-encryption   Skip generating an encryption key. Encryption at rest will be disabled
       --no-peer-key     Skip generating a peer key.


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4255

## Description

This PR adds protection to the `keyring generate` command to prevent accidental overwriting of existing keys (encryption key and peer key). 

Previously, running `keyring generate` would silently overwrite existing keys, potentially leading to data loss (bricking the database) if the encryption key was replaced.

This change:
- Checks if `encryption-key` or `peer-key` already exists before generating new ones.
- Introduces a new `--force` flag.
- Errors out if keys exist and `--force` is not provided.
- Updates the CLI documentation to reflect the new flag.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

New unit tests were added to [cli/keyring_generate_test.go](cci:7://file:///home/sharanrp/Desktop/projects/defradb/cli/keyring_generate_test.go:0:0-0:0) to verify the behavior:
1. [TestKeyringGenerateOverwrite](cci:1://file:///home/sharanrp/Desktop/projects/defradb/cli/keyring_generate_test.go:67:0-83:1): Confirms that the command fails when keys exist and no flag is provided.
2. [TestKeyringGenerateOverwriteForce](cci:1://file:///home/sharanrp/Desktop/projects/defradb/cli/keyring_generate_test.go:85:0-101:1): Confirms that the command succeeds and overwrites when the `--force` flag is used.

I ran the tests using:
```bash
go test ./cli/... -run TestKeyringGenerateOverwrite
```

## Specify the platform(s) on which this was tested:

- Linux