### PR TITLE
fix: Unify docID type to ID in graphql schema

### DIFF
--- a/internal/request/graphql/schema/generate.go
+++ b/internal/request/graphql/schema/generate.go
@@ -424,7 +424,7 @@ func (g *Generator) createExpandedFieldList(
 		Description: f.Description,
 		Type:        gql.NewList(t),
 		Args: gql.FieldConfigArgument{
-			request.DocIDArgName: schemaTypes.NewArgConfig(gql.NewList(gql.NewNonNull(gql.String)), docIDsArgDescription),
+			request.DocIDArgName: schemaTypes.NewArgConfig(gql.NewList(gql.NewNonNull(gql.ID)), docIDsArgDescription),
 			"filter": schemaTypes.NewArgConfig(
 				g.manager.schema.TypeMap()[typeName+filterInputNameSuffix],
 				listFieldFilterArgDescription,
@@ -1232,7 +1232,7 @@ func (g *Generator) GenerateMutationInputForGQLType(obj *gql.Object) ([]*gql.Fie
 		Description: updateDocumentsDescription,
 		Type:        gql.NewList(obj),
 		Args: gql.FieldConfigArgument{
-			request.DocIDArgName: schemaTypes.NewArgConfig(gql.NewList(gql.ID), updateIDsArgDescription),
+			request.DocIDArgName: schemaTypes.NewArgConfig(gql.NewList(gql.NewNonNull(gql.ID)), updateIDsArgDescription),
 			"filter":             schemaTypes.NewArgConfig(filterInput, updateFilterArgDescription),
 			request.Input:        schemaTypes.NewArgConfig(mutationInput, "Update field values"),
 		},
@@ -1243,7 +1243,7 @@ func (g *Generator) GenerateMutationInputForGQLType(obj *gql.Object) ([]*gql.Fie
 		Description: deleteDocumentsDescription,
 		Type:        gql.NewList(obj),
 		Args: gql.FieldConfigArgument{
-			request.DocIDArgName: schemaTypes.NewArgConfig(gql.NewList(gql.ID), deleteIDsArgDescription),
+			request.DocIDArgName: schemaTypes.NewArgConfig(gql.NewList(gql.NewNonNull(gql.ID)), deleteIDsArgDescription),
 			"filter":             schemaTypes.NewArgConfig(filterInput, deleteFilterArgDescription),
 		},
 	}
@@ -1554,7 +1554,7 @@ func (g *Generator) genTypeQueryableFieldList(
 		Description: obj.Description(),
 		Type:        gql.NewList(obj),
 		Args: gql.FieldConfigArgument{
-			request.DocIDArgName: schemaTypes.NewArgConfig(gql.NewList(gql.NewNonNull(gql.String)), docIDsArgDescription),
+			request.DocIDArgName: schemaTypes.NewArgConfig(gql.NewList(gql.NewNonNull(gql.ID)), docIDsArgDescription),
 			"cid":                schemaTypes.NewArgConfig(gql.String, cidArgDescription),
 			"filter":             schemaTypes.NewArgConfig(config.filter, selectFilterArgDescription),
 			"groupBy": schemaTypes.NewArgConfig(

--- a/internal/request/graphql/schema/generate_encrypted_test.go
+++ b/internal/request/graphql/schema/generate_encrypted_test.go
@@ -90,7 +90,7 @@ func TestGenerateEncryptedQueryField(t *testing.T) {
 		if nonNull, ok := elementType.(*gql.NonNull); ok {
 			elementType = nonNull.OfType
 		}
-		assert.Equal(t, "String", elementType.Name())
+		assert.Equal(t, "ID", elementType.Name())
 	}
 }
 

--- a/internal/request/graphql/schema/types/encrypted_search.go
+++ b/internal/request/graphql/schema/types/encrypted_search.go
@@ -33,7 +33,7 @@ func EncryptedSearchResultObject() *gql.Object {
 		Fields: gql.Fields{
 			request.DocIDsFieldName: &gql.Field{
 				Description: docIDsFieldDescription,
-				Type:        gql.NewNonNull(gql.NewList(gql.NewNonNull(gql.String))),
+				Type:        gql.NewNonNull(gql.NewList(gql.NewNonNull(gql.ID))),
 			},
 		},
 	})


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4215

## Description

This PR ensures consistency in the GraphQL schema by using the `ID` type (specifically `[ID!]`) for all `docID` arguments and fields, replacing the previous inconsistent mix of `String` and `ID`.

Changes include:
- Updating GenerateQueryInputForGQLType to use `[ID!]` for `docID`.
- Updating GenerateMutationInputForGQLType to use `[ID!]` for `docID` in update and delete mutations.
- Updating createExpandedFieldList to use `[ID!]` for `docID`.
- Updating EncryptedSearchResultObject to use `[ID!]` for the `docIDs` field.
- Updating relevant tests to reflect these changes.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

- Updated TestGenerateEncryptedQueryField to assert `ID` type instead of `String`.
- Ran existing tests in `internal/request/graphql/schema/...`.
