### PR TITLE
fix: On doc-sync wait for docs from all peers

### DIFF
--- a/http/client_p2p.go
+++ b/http/client_p2p.go
@@ -240,7 +240,19 @@ func (c *Client) SyncDocuments(
 		return err
 	}
 
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, methodURL.String(), bytes.NewBuffer(body))
+	// Use a separate context for HTTP request with extra buffer time.
+	// The server will use the timeout from the request body for the actual sync operation.
+	// We add buffer time to account for HTTP overhead and response transmission.
+	// This is necessary because the node handling this request will usually wait whole timeout
+	// duration as it might receive responses from multiple peers.
+	httpCtx := context.Background()
+	if hasDeadline {
+		var cancel context.CancelFunc
+		httpCtx, cancel = context.WithTimeout(httpCtx, time.Until(deadline)+500*time.Millisecond)
+		defer cancel()
+	}
+
+	httpReq, err := http.NewRequestWithContext(httpCtx, http.MethodPost, methodURL.String(), bytes.NewBuffer(body))
 	if err != nil {
 		return err
 	}

--- a/internal/db/p2p/sync_doc.go
+++ b/internal/db/p2p/sync_doc.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"time"
 
 	"github.com/fxamacker/cbor/v2"
 	"github.com/ipfs/go-cid"
@@ -24,6 +25,7 @@ import (
 	"github.com/sourcenetwork/immutable"
 
 	"github.com/sourcenetwork/defradb/client"
+	"github.com/sourcenetwork/defradb/errors"
 	"github.com/sourcenetwork/defradb/event"
 	"github.com/sourcenetwork/defradb/internal/core"
 	coreblock "github.com/sourcenetwork/defradb/internal/core/block"
@@ -81,6 +83,20 @@ func (p *P2P) syncDocuments(
 	collectionID string,
 	docIDs []string,
 ) (map[string][]cid.Cid, error) {
+	activePeers, err := p.ActivePeers(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(activePeers) == 0 {
+		return nil, ErrTimeoutDocSync
+	}
+
+	pendingPeers := make(map[string]struct{}, len(activePeers))
+	for _, peer := range activePeers {
+		pendingPeers[peer] = struct{}{}
+	}
+
 	pubsubReq := &docSyncRequest{DocIDs: docIDs}
 
 	data, err := cbor.Marshal(pubsubReq)
@@ -93,33 +109,43 @@ func (p *P2P) syncDocuments(
 		return nil, err
 	}
 
-	return p.waitAndHandleDocSyncResponses(ctx, collectionID, docIDs, pubSubRespChan)
+	waitCtx := ctx
+	if _, hasDeadline := ctx.Deadline(); !hasDeadline {
+		var cancel context.CancelFunc
+		waitCtx, cancel = context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+	}
+
+	return p.waitAndHandleDocSyncResponses(waitCtx, collectionID, docIDs, pubSubRespChan, pendingPeers)
 }
 
-// waitAndHandleDocSyncResponses handles multiple responses from different peers.
+// waitAndHandleDocSyncResponses handles responses from multiple peers.
+// It waits for all peers to respond or timeout, collecting all document heads.
 func (p *P2P) waitAndHandleDocSyncResponses(
 	ctx context.Context,
 	collectionID string,
 	docIDs []string,
 	pubSubRespChan <-chan client.PubsubResponse,
-) (results map[string][]cid.Cid, err error) {
+	pendingPeers map[string]struct{},
+) (map[string][]cid.Cid, error) {
 	result := make(map[string][]cid.Cid)
 
-loop:
-	for {
+	requestedDocIDs := make(map[string]struct{}, len(docIDs))
+	for _, docID := range docIDs {
+		requestedDocIDs[docID] = struct{}{}
+	}
+
+	for len(pendingPeers) > 0 {
 		select {
 		case resp := <-pubSubRespChan:
-			p.handleDocSyncResponse(ctx, resp, collectionID, result)
-
-			if len(result) >= len(docIDs) {
-				break loop
-			}
+			senderID := p.handleDocSyncResponse(ctx, resp, collectionID, requestedDocIDs, result)
+			delete(pendingPeers, senderID)
 
 		case <-ctx.Done():
 			if len(result) == 0 {
 				return nil, ErrTimeoutDocSync
 			}
-			break loop
+			return result, nil
 		}
 	}
 
@@ -127,27 +153,38 @@ loop:
 }
 
 // handleDocSyncResponse processes a single response from a peer.
-// It mutates the results map with the document IDs and their corresponding CIDs.
+// It validates docIDs against the requested set and mutates the results map.
+// Returns the sender ID for peer tracking.
 func (p *P2P) handleDocSyncResponse(
 	ctx context.Context,
 	resp client.PubsubResponse,
 	collectionID string,
+	requestedDocIDs map[string]struct{},
 	results map[string][]cid.Cid,
-) {
+) string {
 	if resp.Err != nil {
 		log.ErrorE("Received error response from peer", resp.Err)
-		return
+		return ""
 	}
 
 	var reply docSyncReply
 	if err := cbor.Unmarshal(resp.Data, &reply); err != nil {
 		log.ErrorE("Failed to unmarshal doc sync reply", err)
-		return
+		return ""
 	}
 
 	for _, item := range reply.Results {
+		if _, ok := requestedDocIDs[item.DocID]; !ok {
+			log.ErrorE("Received unrequested docID",
+				errors.New("docID not in request"),
+				corelog.String("DocID", item.DocID),
+				corelog.String("Sender", reply.Sender))
+			continue
+		}
 		p.handleDocSyncItem(ctx, item, reply.Sender, collectionID, results)
 	}
+
+	return reply.Sender
 }
 
 // handleDocSyncItem handles a single document sync item from a peer response.

--- a/tests/integration/net/sync/documents_test.go
+++ b/tests/integration/net/sync/documents_test.go
@@ -222,6 +222,113 @@ func TestDocSync_WithSingleDocAvailableOnMultipleNode_ShouldSync(t *testing.T) {
 	testUtils.ExecuteTestCase(t, test)
 }
 
+const docSyncTopic = "doc-sync"
+
+func TestDocSync_WithDifferentVersionsOnPeers_ShouldSyncLatest(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.RandomNetworkingConfig(),
+			testUtils.RandomNetworkingConfig(),
+			testUtils.RandomNetworkingConfig(),
+			testUtils.RandomNetworkingConfig(),
+			&action.AddSchema{
+				Schema: `
+					type Users {
+						Name: String
+						Age: Int
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
+					"Name": "John",
+					"Age": 21
+				}`,
+			},
+			testUtils.UpdateDoc{
+				NodeID: immutable.Some(1),
+				Doc: `{
+					"Age": 22
+				}`,
+			},
+			testUtils.UpdateDoc{
+				NodeID: immutable.Some(2),
+				Doc: `{
+					"Age": 23
+				}`,
+			},
+			testUtils.UpdateDoc{
+				NodeID: immutable.Some(3),
+				Doc: `{
+					"Age": 24
+				}`,
+			},
+			testUtils.UpdateDoc{
+				NodeID: immutable.Some(1),
+				Doc: `{
+					"Age": 25
+				}`,
+			},
+			testUtils.UpdateDoc{
+				NodeID: immutable.Some(3),
+				Doc: `{
+					"Age": 26
+				}`,
+			},
+			testUtils.UpdateDoc{
+				NodeID: immutable.Some(3),
+				Doc: `{
+					"Age": 27
+				}`,
+			},
+			testUtils.ConnectPeers{
+				SourceNodeID: 0,
+				TargetNodeID: 1,
+			},
+			testUtils.ConnectPeers{
+				SourceNodeID: 1,
+				TargetNodeID: 2,
+			},
+			testUtils.ConnectPeers{
+				SourceNodeID: 2,
+				TargetNodeID: 3,
+			},
+			&action.WaitForPeersEvents{
+				NodeID: 0,
+				ExpectedPeersByTopic: map[string][]int{
+					docSyncTopic: {1, 2, 3},
+				},
+			},
+			testUtils.SyncDocs{
+				NodeID:       0,
+				CollectionID: 0,
+				DocIDs:       []int{0},
+				SourceNodes:  []int{1, 2, 3},
+			},
+			testUtils.WaitForSync{},
+			testUtils.Request{
+				NodeID: immutable.Some(0),
+				Request: `query {
+					Users {
+						Name
+						Age
+					}
+				}`,
+				Results: map[string]any{
+					"Users": []map[string]any{
+						{
+							"Name": "John",
+							"Age":  int64(27),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
 func TestDocSync_AfterSync_ShouldNotSubscribeToDocUpdates(t *testing.T) {
 	test := testUtils.TestCase{
 		Actions: []any{


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4265

## Description

Make doc-sync tracks responses from active peers and wait for all of them instead of just aborting further sync processing after the first response.