### PR TITLE
refactor: Replace string literals with constants

### DIFF
--- a/internal/db/fetcher/indexer_iterators.go
+++ b/internal/db/fetcher/indexer_iterators.go
@@ -26,22 +26,22 @@ import (
 )
 
 const (
-	opEq       = "_eq"
-	opGt       = "_gt"
-	opGe       = "_ge"
-	opLt       = "_lt"
-	opLe       = "_le"
-	opNe       = "_ne"
-	opIn       = "_in"
-	opNin      = "_nin"
-	opLike     = "_like"
-	opNlike    = "_nlike"
-	opILike    = "_ilike"
-	opNILike   = "_nilike"
-	compOpAny  = "_any"
-	compOpAll  = "_all"
-	compOpNone = "_none"
-	opNot      = "_not"
+	opEq       = connor.EqualOp
+	opGt       = connor.GreaterOp
+	opGe       = connor.GreaterOrEqualOp
+	opLt       = connor.LesserOp
+	opLe       = connor.LesserOrEqualOp
+	opNe       = connor.NotEqualOp
+	opIn       = connor.InOp
+	opNin      = connor.NotInOp
+	opLike     = connor.LikeOp
+	opNlike    = connor.NotLikeOp
+	opILike    = connor.CaseInsensitiveLikeOp
+	opNILike   = connor.CaseInsensitiveNotLikeOp
+	compOpAny  = connor.AnyOp
+	compOpAll  = connor.AllOp
+	compOpNone = connor.NoneOp
+	opNot      = connor.NotOp
 	// it's just there for composite indexes. We construct a slice of value matchers with
 	// every matcher being responsible for a corresponding field in the index to match.
 	// For some fields there might not be any criteria to match. For examples if you have

--- a/internal/planner/mapper/mapper.go
+++ b/internal/planner/mapper/mapper.go
@@ -32,7 +32,7 @@ const (
 )
 
 var (
-	FilterEqOp = &Operator{Operation: "_eq"}
+	FilterEqOp = &Operator{Operation: connor.EqualOp}
 )
 
 // SelectionType is the type of selection.
@@ -1906,5 +1906,5 @@ func appendNotNilFilter(field *aggregateRequestTarget, childField string) {
 	}
 
 	typedChildBlock := childBlock.(map[string]any)
-	typedChildBlock["_ne"] = nil
+	typedChildBlock[connor.NotEqualOp] = nil
 }

--- a/internal/planner/se_scan.go
+++ b/internal/planner/se_scan.go
@@ -13,6 +13,7 @@ package planner
 import (
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/request"
+	"github.com/sourcenetwork/defradb/internal/connor"
 	"github.com/sourcenetwork/defradb/internal/keys"
 	"github.com/sourcenetwork/defradb/internal/planner/mapper"
 	"github.com/sourcenetwork/defradb/internal/se"
@@ -67,7 +68,7 @@ func (n *seScanNode) queryRemoteNodes() ([]string, error) {
 		}
 
 		// Extract the equality value
-		value, hasEq := condition.(map[string]any)["_eq"]
+		value, hasEq := condition.(map[string]any)[connor.EqualOp]
 		if !hasEq {
 			return nil, NewErrUnsupportedEncryptedOperator(fieldName)
 		}

--- a/internal/request/graphql/schema/generate.go
+++ b/internal/request/graphql/schema/generate.go
@@ -20,6 +20,7 @@ import (
 	"github.com/sourcenetwork/defradb/client"
 
 	"github.com/sourcenetwork/defradb/client/request"
+	"github.com/sourcenetwork/defradb/internal/connor"
 	"github.com/sourcenetwork/defradb/internal/db/description"
 	schemaTypes "github.com/sourcenetwork/defradb/internal/request/graphql/schema/types"
 )
@@ -1469,7 +1470,7 @@ func (g *Generator) genEncryptedLeafFilterArgInput(obj gql.Type) *gql.InputObjec
 			underlyingType = notNull.OfType
 		}
 
-		fields["_eq"] = &gql.InputObjectFieldConfig{
+		fields[connor.EqualOp] = &gql.InputObjectFieldConfig{
 			Type: underlyingType,
 		}
 

--- a/internal/request/graphql/schema/types/base.go
+++ b/internal/request/graphql/schema/types/base.go
@@ -12,6 +12,8 @@ package types
 
 import (
 	gql "github.com/sourcenetwork/graphql-go"
+
+	"github.com/sourcenetwork/defradb/internal/connor"
 )
 
 // BooleanOperatorBlock filter block for boolean types.
@@ -20,11 +22,11 @@ func BooleanOperatorBlock() *gql.InputObject {
 		Name:        "BooleanOperatorBlock",
 		Description: booleanOperatorBlockDescription,
 		Fields: gql.InputObjectConfigFieldMap{
-			"_eq": &gql.InputObjectFieldConfig{
+			connor.EqualOp: &gql.InputObjectFieldConfig{
 				Description: eqOperatorDescription,
 				Type:        gql.Boolean,
 			},
-			"_ne": &gql.InputObjectFieldConfig{
+			connor.NotEqualOp: &gql.InputObjectFieldConfig{
 				Description: neOperatorDescription,
 				Type:        gql.Boolean,
 			},
@@ -68,11 +70,11 @@ func NotNullBooleanOperatorBlock() *gql.InputObject {
 		Name:        "NotNullBooleanOperatorBlock",
 		Description: notNullBooleanOperatorBlockDescription,
 		Fields: gql.InputObjectConfigFieldMap{
-			"_eq": &gql.InputObjectFieldConfig{
+			connor.EqualOp: &gql.InputObjectFieldConfig{
 				Description: eqOperatorDescription,
 				Type:        gql.Boolean,
 			},
-			"_ne": &gql.InputObjectFieldConfig{
+			connor.NotEqualOp: &gql.InputObjectFieldConfig{
 				Description: neOperatorDescription,
 				Type:        gql.Boolean,
 			},
@@ -116,11 +118,11 @@ func DateTimeOperatorBlock() *gql.InputObject {
 		Name:        "DateTimeOperatorBlock",
 		Description: dateTimeOperatorBlockDescription,
 		Fields: gql.InputObjectConfigFieldMap{
-			"_eq": &gql.InputObjectFieldConfig{
+			connor.EqualOp: &gql.InputObjectFieldConfig{
 				Description: eqOperatorDescription,
 				Type:        gql.DateTime,
 			},
-			"_ne": &gql.InputObjectFieldConfig{
+			connor.NotEqualOp: &gql.InputObjectFieldConfig{
 				Description: neOperatorDescription,
 				Type:        gql.DateTime,
 			},
@@ -158,11 +160,11 @@ func Float64OperatorBlock() *gql.InputObject {
 		Name:        "Float64OperatorBlock",
 		Description: float64OperatorBlockDescription,
 		Fields: gql.InputObjectConfigFieldMap{
-			"_eq": &gql.InputObjectFieldConfig{
+			connor.EqualOp: &gql.InputObjectFieldConfig{
 				Description: eqOperatorDescription,
 				Type:        Float64,
 			},
-			"_ne": &gql.InputObjectFieldConfig{
+			connor.NotEqualOp: &gql.InputObjectFieldConfig{
 				Description: neOperatorDescription,
 				Type:        Float64,
 			},
@@ -222,11 +224,11 @@ func NotNullFloat64OperatorBlock() *gql.InputObject {
 		Name:        "NotNullFloat64OperatorBlock",
 		Description: notNullFloat64OperatorBlockDescription,
 		Fields: gql.InputObjectConfigFieldMap{
-			"_eq": &gql.InputObjectFieldConfig{
+			connor.EqualOp: &gql.InputObjectFieldConfig{
 				Description: eqOperatorDescription,
 				Type:        Float64,
 			},
-			"_ne": &gql.InputObjectFieldConfig{
+			connor.NotEqualOp: &gql.InputObjectFieldConfig{
 				Description: neOperatorDescription,
 				Type:        Float64,
 			},
@@ -286,11 +288,11 @@ func Float32OperatorBlock() *gql.InputObject {
 		Name:        "Float32OperatorBlock",
 		Description: float32OperatorBlockDescription,
 		Fields: gql.InputObjectConfigFieldMap{
-			"_eq": &gql.InputObjectFieldConfig{
+			connor.EqualOp: &gql.InputObjectFieldConfig{
 				Description: eqOperatorDescription,
 				Type:        Float32,
 			},
-			"_ne": &gql.InputObjectFieldConfig{
+			connor.NotEqualOp: &gql.InputObjectFieldConfig{
 				Description: neOperatorDescription,
 				Type:        Float32,
 			},
@@ -350,11 +352,11 @@ func NotNullFloat32OperatorBlock() *gql.InputObject {
 		Name:        "NotNullFloat32OperatorBlock",
 		Description: notNullFloat32OperatorBlockDescription,
 		Fields: gql.InputObjectConfigFieldMap{
-			"_eq": &gql.InputObjectFieldConfig{
+			connor.EqualOp: &gql.InputObjectFieldConfig{
 				Description: eqOperatorDescription,
 				Type:        Float32,
 			},
-			"_ne": &gql.InputObjectFieldConfig{
+			connor.NotEqualOp: &gql.InputObjectFieldConfig{
 				Description: neOperatorDescription,
 				Type:        Float32,
 			},
@@ -414,11 +416,11 @@ func IntOperatorBlock() *gql.InputObject {
 		Name:        "IntOperatorBlock",
 		Description: intOperatorBlockDescription,
 		Fields: gql.InputObjectConfigFieldMap{
-			"_eq": &gql.InputObjectFieldConfig{
+			connor.EqualOp: &gql.InputObjectFieldConfig{
 				Description: eqOperatorDescription,
 				Type:        gql.Int,
 			},
-			"_ne": &gql.InputObjectFieldConfig{
+			connor.NotEqualOp: &gql.InputObjectFieldConfig{
 				Description: neOperatorDescription,
 				Type:        gql.Int,
 			},
@@ -478,11 +480,11 @@ func NotNullIntOperatorBlock() *gql.InputObject {
 		Name:        "NotNullIntOperatorBlock",
 		Description: notNullIntOperatorBlockDescription,
 		Fields: gql.InputObjectConfigFieldMap{
-			"_eq": &gql.InputObjectFieldConfig{
+			connor.EqualOp: &gql.InputObjectFieldConfig{
 				Description: eqOperatorDescription,
 				Type:        gql.Int,
 			},
-			"_ne": &gql.InputObjectFieldConfig{
+			connor.NotEqualOp: &gql.InputObjectFieldConfig{
 				Description: neOperatorDescription,
 				Type:        gql.Int,
 			},
@@ -542,11 +544,11 @@ func StringOperatorBlock() *gql.InputObject {
 		Name:        "StringOperatorBlock",
 		Description: stringOperatorBlockDescription,
 		Fields: gql.InputObjectConfigFieldMap{
-			"_eq": &gql.InputObjectFieldConfig{
+			connor.EqualOp: &gql.InputObjectFieldConfig{
 				Description: eqOperatorDescription,
 				Type:        gql.String,
 			},
-			"_ne": &gql.InputObjectFieldConfig{
+			connor.NotEqualOp: &gql.InputObjectFieldConfig{
 				Description: neOperatorDescription,
 				Type:        gql.String,
 			},
@@ -606,11 +608,11 @@ func NotNullStringOperatorBlock() *gql.InputObject {
 		Name:        "NotNullStringOperatorBlock",
 		Description: notNullStringOperatorBlockDescription,
 		Fields: gql.InputObjectConfigFieldMap{
-			"_eq": &gql.InputObjectFieldConfig{
+			connor.EqualOp: &gql.InputObjectFieldConfig{
 				Description: eqOperatorDescription,
 				Type:        gql.String,
 			},
-			"_ne": &gql.InputObjectFieldConfig{
+			connor.NotEqualOp: &gql.InputObjectFieldConfig{
 				Description: neOperatorDescription,
 				Type:        gql.String,
 			},
@@ -669,11 +671,11 @@ func BlobOperatorBlock(blobScalarType *gql.Scalar) *gql.InputObject {
 		Name:        "BlobOperatorBlock",
 		Description: stringOperatorBlockDescription,
 		Fields: gql.InputObjectConfigFieldMap{
-			"_eq": &gql.InputObjectFieldConfig{
+			connor.EqualOp: &gql.InputObjectFieldConfig{
 				Description: eqOperatorDescription,
 				Type:        blobScalarType,
 			},
-			"_ne": &gql.InputObjectFieldConfig{
+			connor.NotEqualOp: &gql.InputObjectFieldConfig{
 				Description: neOperatorDescription,
 				Type:        blobScalarType,
 			},
@@ -711,11 +713,11 @@ func NotNullBlobOperatorBlock(blobScalarType *gql.Scalar) *gql.InputObject {
 		Name:        "NotNullBlobOperatorBlock",
 		Description: notNullStringOperatorBlockDescription,
 		Fields: gql.InputObjectConfigFieldMap{
-			"_eq": &gql.InputObjectFieldConfig{
+			connor.EqualOp: &gql.InputObjectFieldConfig{
 				Description: eqOperatorDescription,
 				Type:        blobScalarType,
 			},
-			"_ne": &gql.InputObjectFieldConfig{
+			connor.NotEqualOp: &gql.InputObjectFieldConfig{
 				Description: neOperatorDescription,
 				Type:        blobScalarType,
 			},
@@ -753,11 +755,11 @@ func IDOperatorBlock() *gql.InputObject {
 		Name:        "IDOperatorBlock",
 		Description: idOperatorBlockDescription,
 		Fields: gql.InputObjectConfigFieldMap{
-			"_eq": &gql.InputObjectFieldConfig{
+			connor.EqualOp: &gql.InputObjectFieldConfig{
 				Description: eqOperatorDescription,
 				Type:        gql.ID,
 			},
-			"_ne": &gql.InputObjectFieldConfig{
+			connor.NotEqualOp: &gql.InputObjectFieldConfig{
 				Description: neOperatorDescription,
 				Type:        gql.ID,
 			},

--- a/internal/request/graphql/schema/types/commits.go
+++ b/internal/request/graphql/schema/types/commits.go
@@ -14,6 +14,7 @@ import (
 	gql "github.com/sourcenetwork/graphql-go"
 
 	"github.com/sourcenetwork/defradb/client/request"
+	"github.com/sourcenetwork/defradb/internal/connor"
 )
 
 // Commit represents an individual commit to a MerkleCRDT
@@ -155,11 +156,11 @@ func CommitsFilterFieldNameArg() *gql.InputObject {
 		Name:        "CommitsFieldNameFilterArg",
 		Description: "Filter operators for commit fieldName.",
 		Fields: gql.InputObjectConfigFieldMap{
-			"_eq": &gql.InputObjectFieldConfig{
+			connor.EqualOp: &gql.InputObjectFieldConfig{
 				Description: eqOperatorDescription,
 				Type:        gql.String,
 			},
-			"_ne": &gql.InputObjectFieldConfig{
+			connor.NotEqualOp: &gql.InputObjectFieldConfig{
 				Description: neOperatorDescription,
 				Type:        gql.String,
 			},


### PR DESCRIPTION
## Relevant issue(s)

Resolves #3031

## Description

Replace hardcoded filter operation string literals (e.g., "_eq", "_ne", "_gt") with their corresponding constants from the internal/connor package (e.g., connor.EqualOp, connor.NotEqualOp, connor.GreaterOp).

## Tasks

  - I made sure the code is well commented, particularly hard-to-understand areas.
  - I made sure the repository-held documentation is changed accordingly.
  - I made sure the pull request title adheres to the conventional commit style.
  - I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...


## How has this been tested?
- Full test suite passed
- Linting passed

Platform(s) tested:
- MacOS