### PR TITLE
chore(i): Remove flaky tests

### DIFF
--- a/tests/integration/net/sync/branchable_collection/complex_network_test.go
+++ b/tests/integration/net/sync/branchable_collection/complex_network_test.go
@@ -10,6 +10,11 @@
 
 package branchable_collection
 
+/*
+todo - these tests are too flaky and block the merging of PRs during the working day (EST)
+They should be added back in as part of https://github.com/sourcenetwork/defradb/issues/4308
+when their flakiness has at least been reduced to a tolerable level.
+
 import (
 	"testing"
 
@@ -546,3 +551,4 @@ func TestBranchableCollectionSync_WithDocumentsFromPeersAndNewHeadAfterSync_Shou
 
 	testUtils.ExecuteTestCase(t, test)
 }
+*/


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4306

## Description

Removes the flaky branchable collection tests.  They can be added back in once they start passing reliably, their definitions are preserved in the the git history.

I've added a high priority issue to add them back in here https://github.com/sourcenetwork/defradb/issues/4308