### PR TITLE
fix: prevent txn commit/discard during active operations

### DIFF
--- a/internal/datastore/errors.go
+++ b/internal/datastore/errors.go
@@ -25,6 +25,9 @@ const (
 var (
 	// ErrHashMismatch is an error returned when the hash of a block is different than expected.
 	ErrHashMismatch = errors.New("block in storage has different hash than requested")
+	// ErrTxnHasActiveOps is returned when trying to commit or discard a transaction that has
+	// operations still in progress.
+	ErrTxnHasActiveOps = errors.New("cannot commit or discard transaction while operations are in progress")
 )
 
 // NewErrInvalidStoredValue returns a new error indicating that the stored

--- a/internal/datastore/txn.go
+++ b/internal/datastore/txn.go
@@ -12,13 +12,17 @@ package datastore
 
 import (
 	"context"
+	"sync/atomic"
 	"time"
 
 	"github.com/sourcenetwork/corekv"
+	"github.com/sourcenetwork/corelog"
 	"github.com/sourcenetwork/immutable"
 
 	"github.com/sourcenetwork/defradb/client"
 )
+
+var log = corelog.NewLogger("datastore")
 
 // Txn is a common interface to the BasicTxn struct.
 type Txn interface {
@@ -76,6 +80,14 @@ type Txn interface {
 
 	// OnDiscardAsync registers a function to be called asynchronously when the transaction is discarded.
 	OnDiscardAsync(fn func())
+
+	// StartOp marks the beginning of an operation on this transaction.
+	// Must be paired with EndOp. Used to prevent concurrent commit/discard while operations are in progress.
+	StartOp()
+
+	// EndOp marks the end of an operation on this transaction.
+	// Must be paired with StartOp.
+	EndOp()
 }
 
 type BasicTxn struct {
@@ -84,6 +96,10 @@ type BasicTxn struct {
 	txn corekv.Txn
 	id  uint64
 	ts  time.Time // timestamp
+
+	// activeOps tracks the number of operations currently in progress on this transaction.
+	// Used to prevent commit/discard while operations are executing.
+	activeOps atomic.Int64
 
 	successFns []func()
 	errorFns   []func()
@@ -117,6 +133,10 @@ func (t *BasicTxn) StartTS() time.Time {
 }
 
 func (t *BasicTxn) Commit() error {
+	if t.activeOps.Load() > 0 {
+		return ErrTxnHasActiveOps
+	}
+
 	var fns []func()
 	var asyncFns []func()
 
@@ -139,6 +159,11 @@ func (t *BasicTxn) Commit() error {
 }
 
 func (t *BasicTxn) Discard() {
+	if t.activeOps.Load() > 0 {
+		log.Error("Attempted to discard transaction while operations are in progress; ignoring discard")
+		return
+	}
+
 	t.txn.Discard()
 
 	for _, fn := range t.discardAsyncFns {
@@ -171,6 +196,14 @@ func (t *BasicTxn) OnErrorAsync(fn func()) {
 
 func (t *BasicTxn) OnDiscardAsync(fn func()) {
 	t.discardAsyncFns = append(t.discardAsyncFns, fn)
+}
+
+func (t *BasicTxn) StartOp() {
+	t.activeOps.Add(1)
+}
+
+func (t *BasicTxn) EndOp() {
+	t.activeOps.Add(-1)
 }
 
 type txnKey struct{}

--- a/internal/datastore/txn_ops_test.go
+++ b/internal/datastore/txn_ops_test.go
@@ -1,0 +1,114 @@
+// Copyright 2025 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package datastore
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sourcenetwork/corekv/memory"
+	"github.com/sourcenetwork/immutable"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBasicTxn_CommitWhileOperationInProgress_ReturnsError(t *testing.T) {
+	ctx := context.Background()
+	// Create a rootstore
+	rootstore := memory.NewDatastore(ctx)
+
+	// Create a transaction
+	txn := NewTxnFrom(rootstore, 1, false, immutable.None[int]())
+
+	// Simulate an operation in progress
+	txn.StartOp()
+
+	// Attempt to commit while operation is in progress
+	err := txn.Commit()
+
+	// Should receive an error
+	require.ErrorIs(t, err, ErrTxnHasActiveOps)
+
+	// End the operation
+	txn.EndOp()
+
+	// Now commit should work
+	err = txn.Commit()
+	require.NoError(t, err)
+}
+
+func TestBasicTxn_DiscardWhileOperationInProgress_IsIgnored(t *testing.T) {
+	ctx := context.Background()
+	// Create a rootstore
+	rootstore := memory.NewDatastore(ctx)
+
+	// Create a transaction
+	txn := NewTxnFrom(rootstore, 1, false, immutable.None[int]())
+
+	// Simulate an operation in progress
+	txn.StartOp()
+
+	// Discard is ignored when operation is in progress (logs error but returns)
+	txn.Discard()
+
+	// The txn should still be usable after the ignored discard
+	// End the operation
+	txn.EndOp()
+
+	// Now discard should work
+	txn.Discard()
+}
+
+func TestBasicTxn_MultipleOperations_TrackedCorrectly(t *testing.T) {
+	ctx := context.Background()
+	// Create a rootstore
+	rootstore := memory.NewDatastore(ctx)
+
+	// Create a transaction
+	txn := NewTxnFrom(rootstore, 1, false, immutable.None[int]())
+
+	// Start multiple operations
+	txn.StartOp()
+	txn.StartOp()
+	txn.StartOp()
+
+	// Should not be able to commit
+	err := txn.Commit()
+	require.ErrorIs(t, err, ErrTxnHasActiveOps)
+
+	// End one operation
+	txn.EndOp()
+
+	// Still should not be able to commit
+	err = txn.Commit()
+	require.ErrorIs(t, err, ErrTxnHasActiveOps)
+
+	// End remaining operations
+	txn.EndOp()
+	txn.EndOp()
+
+	// Now commit should work
+	err = txn.Commit()
+	require.NoError(t, err)
+}
+
+func TestBasicTxn_NoOperations_CommitWorks(t *testing.T) {
+	ctx := context.Background()
+	// Create a rootstore
+	rootstore := memory.NewDatastore(ctx)
+
+	// Create a transaction
+	txn := NewTxnFrom(rootstore, 1, false, immutable.None[int]())
+
+	// Commit without any operations should work
+	err := txn.Commit()
+	require.NoError(t, err)
+}

--- a/internal/db/txn.go
+++ b/internal/db/txn.go
@@ -46,6 +46,8 @@ func ensureContextTxn(ctx context.Context, db transactionDB, readOnly bool) (con
 			}
 			// If the txn has already been set on the context but it hasn't already been set as explicit,
 			// we create a copy of the txn and mark it as an explicit txn.
+			// Start an operation to prevent concurrent commit/discard.
+			txn.BasicTxn.StartOp()
 			explicitTxn := &Txn{
 				txn.BasicTxn,
 				txn.db,
@@ -59,6 +61,8 @@ func ensureContextTxn(ctx context.Context, db transactionDB, readOnly bool) (con
 			//
 			// WARNING: This scenario creates a transaction where `*DB` is nil. Calling any method that requires this
 			// will result in a panic.
+			// Start an operation to prevent concurrent commit/discard.
+			txn.StartOp()
 			explicitTxn := &Txn{
 				txn,
 				nil,
@@ -98,6 +102,8 @@ func (txn *Txn) Commit() error {
 		// If the transaction has been explicitly defined, `Commit` should
 		// only be executed by the transaction creator. As such, a call to
 		// `Commit` on an explicit transaction should result in a no-op.
+		// End the operation to allow the creator to commit/discard.
+		txn.BasicTxn.EndOp()
 		return nil
 	}
 	return txn.BasicTxn.Commit()
@@ -108,6 +114,8 @@ func (txn *Txn) Discard() {
 		// If the transaction has been explicitly defined, `Discard` should
 		// only be executed by the transaction creator. As such, a call to
 		// `Discard` on an explicit transaction should result in a no-op.
+		// End the operation to allow the creator to commit/discard.
+		txn.BasicTxn.EndOp()
 		return
 	}
 	txn.BasicTxn.Discard()

--- a/internal/db/txn.go
+++ b/internal/db/txn.go
@@ -49,9 +49,9 @@ func ensureContextTxn(ctx context.Context, db transactionDB, readOnly bool) (con
 			// Start an operation to prevent concurrent commit/discard.
 			txn.BasicTxn.StartOp()
 			explicitTxn := &Txn{
-				txn.BasicTxn,
-				txn.db,
-				true,
+				BasicTxn: txn.BasicTxn,
+				db:       txn.db,
+				explicit: true,
 			}
 			return InitContext(ctx, explicitTxn), explicitTxn, nil
 		case *datastore.BasicTxn:
@@ -64,9 +64,9 @@ func ensureContextTxn(ctx context.Context, db transactionDB, readOnly bool) (con
 			// Start an operation to prevent concurrent commit/discard.
 			txn.StartOp()
 			explicitTxn := &Txn{
-				txn,
-				nil,
-				true,
+				BasicTxn: txn,
+				db:       nil,
+				explicit: true,
 			}
 			return InitContext(ctx, explicitTxn), explicitTxn, nil
 		default:
@@ -85,6 +85,9 @@ type Txn struct {
 	*datastore.BasicTxn
 	db       *DB
 	explicit bool
+	// opEnded tracks whether EndOp has already been called for this explicit txn.
+	// This prevents multiple Commit/Discard calls from decrementing activeOps multiple times.
+	opEnded bool
 }
 
 var _ client.Txn = (*Txn)(nil)
@@ -103,7 +106,10 @@ func (txn *Txn) Commit() error {
 		// only be executed by the transaction creator. As such, a call to
 		// `Commit` on an explicit transaction should result in a no-op.
 		// End the operation to allow the creator to commit/discard.
-		txn.BasicTxn.EndOp()
+		if !txn.opEnded {
+			txn.BasicTxn.EndOp()
+			txn.opEnded = true
+		}
 		return nil
 	}
 	return txn.BasicTxn.Commit()
@@ -115,7 +121,10 @@ func (txn *Txn) Discard() {
 		// only be executed by the transaction creator. As such, a call to
 		// `Discard` on an explicit transaction should result in a no-op.
 		// End the operation to allow the creator to commit/discard.
-		txn.BasicTxn.EndOp()
+		if !txn.opEnded {
+			txn.BasicTxn.EndOp()
+			txn.opEnded = true
+		}
 		return
 	}
 	txn.BasicTxn.Discard()

--- a/internal/db/txn_test.go
+++ b/internal/db/txn_test.go
@@ -1,0 +1,143 @@
+// Copyright 2025 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package db
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcenetwork/defradb/internal/datastore"
+)
+
+// TestTxn_CommitWhileOperationInProgress verifies that a transaction cannot be committed
+// while operations are still running on it. This prevents database corruption that could
+// occur if a user commits a transaction before an operation using it has completed.
+func TestTxn_CommitWhileOperationInProgress(t *testing.T) {
+	ctx := context.Background()
+	db, err := newBadgerDB(ctx)
+	require.NoError(t, err)
+	defer db.Close()
+
+	// Create a manual transaction as a user would
+	txn, err := db.NewTxn(false)
+	require.NoError(t, err)
+
+	// Simulate that an operation is in progress by calling StartOp
+	// (this happens automatically in ensureContextTxn when operations use the txn)
+	basicTxn := datastore.MustGetFromClientTxn(txn)
+	basicTxn.StartOp()
+
+	// Now try to commit the transaction while "operation" is in progress
+	err = txn.Commit()
+
+	// Should return an error since operations are in progress
+	require.ErrorIs(t, err, datastore.ErrTxnHasActiveOps,
+		"Commit should fail when operations are in progress")
+
+	// End the operation
+	basicTxn.EndOp()
+
+	// Now commit should work
+	err = txn.Commit()
+	require.NoError(t, err)
+}
+
+// TestTxn_ConcurrentCommitDuringOperation verifies that concurrent commit attempts
+// are correctly rejected while an operation is using the transaction.
+func TestTxn_ConcurrentCommitDuringOperation(t *testing.T) {
+	ctx := context.Background()
+	db, err := newBadgerDB(ctx)
+	require.NoError(t, err)
+	defer db.Close()
+
+	// Create a manual transaction
+	txn, err := db.NewTxn(false)
+	require.NoError(t, err)
+
+	basicTxn := datastore.MustGetFromClientTxn(txn)
+
+	var wg sync.WaitGroup
+	var commitErr error
+	operationDone := make(chan struct{})
+
+	// Goroutine 1: Simulates a long-running operation
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		basicTxn.StartOp()
+		defer basicTxn.EndOp()
+
+		// Simulate some work
+		time.Sleep(100 * time.Millisecond)
+		close(operationDone)
+	}()
+
+	// Goroutine 2: User tries to commit while operation is running
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		// Wait a bit to ensure operation has started
+		time.Sleep(20 * time.Millisecond)
+
+		// Try to commit - should fail because operation is in progress
+		commitErr = txn.Commit()
+	}()
+
+	wg.Wait()
+
+	// The concurrent commit should have failed
+	require.ErrorIs(t, commitErr, datastore.ErrTxnHasActiveOps,
+		"Concurrent commit during operation should fail")
+
+	// After operation is done, commit should work
+	err = txn.Commit()
+	require.NoError(t, err)
+}
+
+// TestTxn_ExplicitTxnOperationTracking verifies that when a user-created transaction
+// is used in an operation via ensureContextTxn, the operation tracking works correctly
+// and prevents premature commits.
+func TestTxn_ExplicitTxnOperationTracking(t *testing.T) {
+	ctx := context.Background()
+	db, err := newBadgerDB(ctx)
+	require.NoError(t, err)
+	defer db.Close()
+
+	// Create a manual transaction
+	userTxn, err := db.NewTxn(false)
+	require.NoError(t, err)
+
+	// Set the transaction on the context (as a user would do)
+	ctx = datastore.CtxSetFromClientTxn(ctx, userTxn)
+
+	// Call ensureContextTxn (which is what operations do internally)
+	// This should call StartOp on the underlying BasicTxn
+	ctx, opTxn, err := ensureContextTxn(ctx, db, false)
+	require.NoError(t, err)
+
+	// Now the user-created txn should not be committable because ensureContextTxn
+	// called StartOp
+	err = userTxn.Commit()
+	require.ErrorIs(t, err, datastore.ErrTxnHasActiveOps,
+		"User txn should not be committable while operation is using it")
+
+	// When the operation "completes" (calls Commit/Discard on explicit wrapper),
+	// EndOp is called automatically
+	opTxn.Discard()
+
+	// Now user should be able to commit
+	err = userTxn.Commit()
+	require.NoError(t, err)
+}

--- a/internal/db/txn_test.go
+++ b/internal/db/txn_test.go
@@ -49,20 +49,19 @@ func TestTxn_CommitWhileOperationInProgress(t *testing.T) {
 	// End the operation
 	basicTxn.EndOp()
 
-	// Now commit should work
+	// Now commit should succeed
 	err = txn.Commit()
 	require.NoError(t, err)
 }
 
 // TestTxn_ConcurrentCommitDuringOperation verifies that concurrent commit attempts
-// are correctly rejected while an operation is using the transaction.
+// are rejected while an operation is using the transaction.
 func TestTxn_ConcurrentCommitDuringOperation(t *testing.T) {
 	ctx := context.Background()
 	db, err := newBadgerDB(ctx)
 	require.NoError(t, err)
 	defer db.Close()
 
-	// Create a manual transaction
 	txn, err := db.NewTxn(false)
 	require.NoError(t, err)
 
@@ -70,7 +69,6 @@ func TestTxn_ConcurrentCommitDuringOperation(t *testing.T) {
 
 	var wg sync.WaitGroup
 	var commitErr error
-	operationDone := make(chan struct{})
 
 	// Goroutine 1: Simulates a long-running operation
 	wg.Add(1)
@@ -78,66 +76,158 @@ func TestTxn_ConcurrentCommitDuringOperation(t *testing.T) {
 		defer wg.Done()
 		basicTxn.StartOp()
 		defer basicTxn.EndOp()
-
-		// Simulate some work
 		time.Sleep(100 * time.Millisecond)
-		close(operationDone)
 	}()
 
-	// Goroutine 2: User tries to commit while operation is running
+	// Goroutine 2: Attempts to commit while operation is running
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		// Wait a bit to ensure operation has started
 		time.Sleep(20 * time.Millisecond)
-
-		// Try to commit - should fail because operation is in progress
 		commitErr = txn.Commit()
 	}()
 
 	wg.Wait()
 
-	// The concurrent commit should have failed
-	require.ErrorIs(t, commitErr, datastore.ErrTxnHasActiveOps,
-		"Concurrent commit during operation should fail")
+	// Concurrent commit should have failed
+	require.ErrorIs(t, commitErr, datastore.ErrTxnHasActiveOps)
 
-	// After operation is done, commit should work
+	// After operation completes, commit should succeed
 	err = txn.Commit()
 	require.NoError(t, err)
 }
 
-// TestTxn_ExplicitTxnOperationTracking verifies that when a user-created transaction
-// is used in an operation via ensureContextTxn, the operation tracking works correctly
-// and prevents premature commits.
+// TestTxn_ExplicitTxnOperationTracking verifies that ensureContextTxn correctly
+// tracks operations and prevents premature commits.
 func TestTxn_ExplicitTxnOperationTracking(t *testing.T) {
 	ctx := context.Background()
 	db, err := newBadgerDB(ctx)
 	require.NoError(t, err)
 	defer db.Close()
 
-	// Create a manual transaction
 	userTxn, err := db.NewTxn(false)
 	require.NoError(t, err)
 
-	// Set the transaction on the context (as a user would do)
+	// Set transaction on context and create explicit wrapper
 	ctx = datastore.CtxSetFromClientTxn(ctx, userTxn)
-
-	// Call ensureContextTxn (which is what operations do internally)
-	// This should call StartOp on the underlying BasicTxn
-	ctx, opTxn, err := ensureContextTxn(ctx, db, false)
+	_, opTxn, err := ensureContextTxn(ctx, db, false)
 	require.NoError(t, err)
 
-	// Now the user-created txn should not be committable because ensureContextTxn
-	// called StartOp
+	// User cannot commit while operation wrapper exists
 	err = userTxn.Commit()
-	require.ErrorIs(t, err, datastore.ErrTxnHasActiveOps,
-		"User txn should not be committable while operation is using it")
+	require.ErrorIs(t, err, datastore.ErrTxnHasActiveOps)
 
-	// When the operation "completes" (calls Commit/Discard on explicit wrapper),
-	// EndOp is called automatically
+	// Operation completes
 	opTxn.Discard()
 
-	// Now user should be able to commit
+	// Now user can commit
 	err = userTxn.Commit()
+	require.NoError(t, err)
+}
+
+// TestTxn_MultipleDiscardCalls verifies that calling Discard multiple times
+// on an explicit transaction does not cause incorrect activeOps count.
+func TestTxn_MultipleDiscardCalls(t *testing.T) {
+	ctx := context.Background()
+	db, err := newBadgerDB(ctx)
+	require.NoError(t, err)
+	defer db.Close()
+
+	userTxn, err := db.NewTxn(false)
+	require.NoError(t, err)
+
+	ctx = datastore.CtxSetFromClientTxn(ctx, userTxn)
+	_, opTxn, err := ensureContextTxn(ctx, db, false)
+	require.NoError(t, err)
+
+	// Multiple Discard calls should not cause negative activeOps
+	opTxn.Discard()
+	opTxn.Discard()
+	opTxn.Discard()
+
+	// Commit should still work (activeOps should be 0, not negative)
+	err = userTxn.Commit()
+	require.NoError(t, err)
+}
+
+// TestTxn_MultipleOperationsThenCommit verifies that multiple sequential operations
+// can be performed on a transaction before a single commit.
+func TestTxn_MultipleOperationsThenCommit(t *testing.T) {
+	ctx := context.Background()
+	db, err := newBadgerDB(ctx)
+	require.NoError(t, err)
+	defer db.Close()
+
+	userTxn, err := db.NewTxn(false)
+	require.NoError(t, err)
+
+	ctx = datastore.CtxSetFromClientTxn(ctx, userTxn)
+
+	// First operation
+	_, opTxn1, err := ensureContextTxn(ctx, db, false)
+	require.NoError(t, err)
+	opTxn1.Discard()
+
+	// Second operation
+	_, opTxn2, err := ensureContextTxn(ctx, db, false)
+	require.NoError(t, err)
+	opTxn2.Discard()
+
+	// Third operation
+	_, opTxn3, err := ensureContextTxn(ctx, db, false)
+	require.NoError(t, err)
+	opTxn3.Discard()
+
+	// Single commit at the end
+	err = userTxn.Commit()
+	require.NoError(t, err)
+}
+
+// TestTxn_DiscardThenOperationThenCommit verifies that a transaction can be
+// used after being discarded, if supported by the underlying store.
+func TestTxn_DiscardThenOperationThenCommit(t *testing.T) {
+	ctx := context.Background()
+	db, err := newBadgerDB(ctx)
+	require.NoError(t, err)
+	defer db.Close()
+
+	userTxn, err := db.NewTxn(false)
+	require.NoError(t, err)
+
+	// Discard multiple times before any operation
+	userTxn.Discard()
+	userTxn.Discard()
+
+	// Perform an operation
+	ctx = datastore.CtxSetFromClientTxn(context.Background(), userTxn)
+	_, opTxn, err := ensureContextTxn(ctx, db, false)
+	require.NoError(t, err)
+
+	opTxn.Discard()
+
+	// Commit should work
+	err = userTxn.Commit()
+	require.NoError(t, err)
+}
+
+// TestTxn_ImmediateDiscard verifies that discarding a transaction immediately
+// after creation without performing any operations works correctly.
+func TestTxn_ImmediateDiscard(t *testing.T) {
+	ctx := context.Background()
+	db, err := newBadgerDB(ctx)
+	require.NoError(t, err)
+	defer db.Close()
+
+	userTxn, err := db.NewTxn(false)
+	require.NoError(t, err)
+
+	// Discard immediately without any operations
+	userTxn.Discard()
+	userTxn.Discard()
+
+	// Verify database is still functional
+	userTxn2, err := db.NewTxn(false)
+	require.NoError(t, err)
+	err = userTxn2.Commit()
 	require.NoError(t, err)
 }


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4288

## Description

This PR prevents users from committing or discarding manually-managed transactions while database operations are still in progress, which could lead to database corruption with partially-written data.

### The Problem

When users create manual transactions via `NewTxn()` and pass them to database operations, they could concurrently call `Commit()` or `Discard()` on the transaction before the operation completes. This could leave the database in a corrupted state (e.g., collections and/or documents partially written).

### The Solution

Added an atomic operation counter (`activeOps`) to track active operations on a transaction:

1. **`StartOp()`** - Called when an operation begins using the transaction (in `ensureContextTxn()`)
2. **`EndOp()`** - Called when an operation completes (in explicit txn's `Commit()`/`Discard()`)
3. **`Commit()`** - Returns `ErrTxnHasActiveOps` if `activeOps > 0`
4. **`Discard()`** - Logs error and skips discarding if `activeOps > 0`

### Changes

| File | Change |
|------|--------|
| `internal/datastore/errors.go` | Added `ErrTxnHasActiveOps` error |
| `internal/datastore/txn.go` | Added `activeOps` counter, `StartOp()`/`EndOp()` methods, and checks in `Commit()`/`Discard()` |
| `internal/db/txn.go` | Added `StartOp()` call in `ensureContextTxn()` and `EndOp()` calls in explicit txn wrappers |
| `internal/datastore/txn_ops_test.go` | Unit tests for operation tracking |
| `internal/db/txn_test.go` | Integration tests for transaction operation tracking |

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

### Limitations

- The `Discard()` method cannot return an error (interface constraint), so when called during active operations it logs an error and returns without discarding. This prevents corruption but may be unexpected to users.
- The atomic counter adds minimal overhead (increment/decrement) but is necessary for thread-safety.

## How has this been tested?

- Added unit tests in `internal/datastore/txn_ops_test.go` for the low-level `StartOp()`/`EndOp()` mechanism
- Added integration tests in `internal/db/txn_test.go` for full transaction operation tracking including concurrent scenarios
- All existing tests pass

### Specify the platform(s) on which this was tested

- Pop!_OS (Linux)
