### PR TITLE
fix: Enable change detector to detect breaking changes in write opera…

### DIFF
--- a/docs/data_format_changes/i4269-change-detector-write-actions.md
+++ b/docs/data_format_changes/i4269-change-detector-write-actions.md
@@ -1,0 +1,7 @@
+# Fix change detector to detect breaking changes in write actions
+
+This is not a breaking (production code) change.
+
+This modifies the change detector's automatic action splitting logic to no longer treat CreateDoc and UpdateDoc as setup actions. Previously, these actions were always executed by the source branch and skipped by the target branch, which meant breaking changes in write operations would not be detected.
+
+Now, the split will occur before the first non-SchemaUpdate/Restart action (typically CreateDoc), allowing the target branch to execute write operations and catch any breaking changes.

--- a/tests/integration/change_detector_fix_test.go
+++ b/tests/integration/change_detector_fix_test.go
@@ -1,0 +1,244 @@
+// Copyright 2025 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package tests
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/sourcenetwork/defradb/tests/action"
+	"github.com/sourcenetwork/defradb/tests/change_detector"
+)
+
+// TestGetActionRange_WithCreateDoc_SplitsBeforeCreateDoc verifies that the change detector
+// correctly splits BEFORE CreateDoc actions.
+//
+// CreateDoc actions should NOT be treated as setup actions to ensure that both the source
+// and target branches execute document creation operations, enabling detection of
+// breaking changes in write operations.
+func TestGetActionRange_WithCreateDoc_SplitsBeforeCreateDoc(t *testing.T) {
+	originalEnabled := change_detector.Enabled
+	originalSetupOnly := change_detector.SetupOnly
+
+	os.Setenv("DEFRA_CHANGE_DETECTOR_ENABLE", "true")
+	change_detector.Enabled = true
+	change_detector.SetupOnly = false
+
+	defer func() {
+		change_detector.Enabled = originalEnabled
+		change_detector.SetupOnly = originalSetupOnly
+		os.Unsetenv("DEFRA_CHANGE_DETECTOR_ENABLE")
+	}()
+
+	schema := &action.AddSchema{
+		Schema: `
+			type User {
+				name: String
+			}
+		`,
+	}
+
+	testCase := TestCase{
+		Actions: []any{
+			schema,
+			CreateDoc{
+				CollectionID: 0,
+				Doc:          `{"name": "John"}`,
+			},
+			CreateDoc{
+				CollectionID: 0,
+				Doc:          `{"name": "Jane"}`,
+			},
+			Request{
+				Request: `query { User { name } }`,
+			},
+		},
+	}
+
+	startIndex, endIndex := getActionRange(t, testCase)
+
+	// The split should happen BEFORE the first CreateDoc (index 1).
+	// Target branch starts at index 1 (first CreateDoc) and ends at index 3 (Request).
+	assert.Equal(t, 1, startIndex, "startIndex should be at the first CreateDoc action (index 1)")
+	assert.Equal(t, 3, endIndex, "endIndex should be at the last action (Request)")
+}
+
+// TestGetActionRange_WithCreateDoc_SetupModeEndsBeforeCreateDoc verifies that in setup mode,
+// the change detector ends BEFORE the first CreateDoc action.
+//
+// This ensures that the source branch only executes schema setup, while document creation
+// is left for both branches to execute.
+func TestGetActionRange_WithCreateDoc_SetupModeEndsBeforeCreateDoc(t *testing.T) {
+	originalEnabled := change_detector.Enabled
+	originalSetupOnly := change_detector.SetupOnly
+
+	os.Setenv("DEFRA_CHANGE_DETECTOR_ENABLE", "true")
+	os.Setenv("DEFRA_CHANGE_DETECTOR_SETUP_ONLY", "true")
+	change_detector.Enabled = true
+	change_detector.SetupOnly = true
+
+	defer func() {
+		change_detector.Enabled = originalEnabled
+		change_detector.SetupOnly = originalSetupOnly
+		os.Unsetenv("DEFRA_CHANGE_DETECTOR_ENABLE")
+		os.Unsetenv("DEFRA_CHANGE_DETECTOR_SETUP_ONLY")
+	}()
+
+	schema := &action.AddSchema{
+		Schema: `
+			type User {
+				name: String
+			}
+		`,
+	}
+
+	testCase := TestCase{
+		Actions: []any{
+			schema,
+			CreateDoc{
+				CollectionID: 0,
+				Doc:          `{"name": "John"}`,
+			},
+			CreateDoc{
+				CollectionID: 0,
+				Doc:          `{"name": "Jane"}`,
+			},
+			Request{
+				Request: `query { User { name } }`,
+			},
+		},
+	}
+
+	startIndex, endIndex := getActionRange(t, testCase)
+
+	// In setup mode, endIndex should be 0 (only schema) since CreateDoc is not a setup action.
+	assert.Equal(t, 0, startIndex, "startIndex should be 0 in setup mode")
+	assert.Equal(t, 0, endIndex, "endIndex should be 0 (only AddSchema)")
+}
+
+// TestGetActionRange_WithSetupComplete_RespectExplicitSplit verifies that explicit
+// SetupComplete markers placed after schema actions are respected.
+//
+// Note: If SetupComplete is placed after CreateDoc, the split will happen at CreateDoc first
+// because CreateDoc triggers the split.
+func TestGetActionRange_WithSetupComplete_RespectExplicitSplit(t *testing.T) {
+	originalEnabled := change_detector.Enabled
+	originalSetupOnly := change_detector.SetupOnly
+
+	os.Setenv("DEFRA_CHANGE_DETECTOR_ENABLE", "true")
+	change_detector.Enabled = true
+	change_detector.SetupOnly = false
+
+	defer func() {
+		change_detector.Enabled = originalEnabled
+		change_detector.SetupOnly = originalSetupOnly
+		os.Unsetenv("DEFRA_CHANGE_DETECTOR_ENABLE")
+	}()
+
+	schema := &action.AddSchema{
+		Schema: `
+			type User {
+				name: String
+			}
+		`,
+	}
+
+	// SetupComplete is placed AFTER schema, BEFORE any CreateDoc.
+	// This is the correct way to use SetupComplete if you want schema-only setup.
+	testCase := TestCase{
+		Actions: []any{
+			schema,
+			SetupComplete{},
+			CreateDoc{
+				CollectionID: 0,
+				Doc:          `{"name": "John"}`,
+			},
+			CreateDoc{
+				CollectionID: 0,
+				Doc:          `{"name": "Jane"}`,
+			},
+			Request{
+				Request: `query { User { name } }`,
+			},
+		},
+	}
+
+	startIndex, endIndex := getActionRange(t, testCase)
+
+	// With explicit SetupComplete at index 1, split should happen there.
+	// startIndex should be 2 (action after SetupComplete).
+	assert.Equal(t, 2, startIndex, "startIndex should be 2 (after SetupComplete)")
+	assert.Equal(t, 4, endIndex, "endIndex should be 4 (last action)")
+}
+
+// TestGetActionRange_CreateDocWithExpectedError_ExecutedOnTargetBranch verifies that
+// CreateDoc actions with ExpectedError are executed on the target branch.
+//
+// This is critical for detecting breaking changes in write operations. For example,
+// if a test expects an error when creating a duplicate relationship, that error
+// validation must happen on the target branch to catch any regressions.
+func TestGetActionRange_CreateDocWithExpectedError_ExecutedOnTargetBranch(t *testing.T) {
+	originalEnabled := change_detector.Enabled
+	originalSetupOnly := change_detector.SetupOnly
+
+	os.Setenv("DEFRA_CHANGE_DETECTOR_ENABLE", "true")
+	change_detector.Enabled = true
+	change_detector.SetupOnly = false
+
+	defer func() {
+		change_detector.Enabled = originalEnabled
+		change_detector.SetupOnly = originalSetupOnly
+		os.Unsetenv("DEFRA_CHANGE_DETECTOR_ENABLE")
+	}()
+
+	schema := &action.AddSchema{
+		Schema: `
+			type Book {
+				title: String
+			}
+			type Author {
+				name: String
+				book: Book @primary
+			}
+		`,
+	}
+
+	testCase := TestCase{
+		Actions: []any{
+			schema,
+			CreateDoc{
+				CollectionID: 0,
+				Doc:          `{"title": "Book1"}`,
+			},
+			CreateDoc{
+				CollectionID: 1,
+				Doc:          `{"name": "Author1"}`,
+			},
+			// This CreateDoc expects an error - it must be executed on target branch
+			// to verify the error is still raised correctly.
+			CreateDoc{
+				CollectionID:  1,
+				Doc:           `{"name": "Author2"}`,
+				ExpectedError: "already linked",
+			},
+		},
+	}
+
+	startIndex, endIndex := getActionRange(t, testCase)
+
+	// startIndex should be 1 (first CreateDoc), meaning the target branch WILL
+	// execute CreateDoc actions, including the one with ExpectedError.
+	assert.Equal(t, 1, startIndex,
+		"startIndex should be 1 (first CreateDoc), ensuring error validation runs on target branch")
+	assert.Equal(t, 3, endIndex, "endIndex should be 3 (last action)")
+}

--- a/tests/integration/test_case.go
+++ b/tests/integration/test_case.go
@@ -96,7 +96,7 @@ type KMS struct {
 // setup is complete so that it may split actions across database code-versions.
 //
 // If a SetupComplete action is not provided the change detector will split before
-// the first item that is neither a SchemaUpdate, CreateDoc or UpdateDoc action.
+// the first item that is neither a SchemaUpdate nor Restart action.
 type SetupComplete struct{}
 
 // ConfigureNode allows the explicit configuration of new Defra nodes.

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -751,7 +751,7 @@ func flattenActions(testCase *TestCase) {
 // will be split.
 //
 // If a SetupComplete action is provided, the actions will be split there, if not
-// they will be split at the first non SchemaUpdate/CreateDoc/UpdateDoc action.
+// they will be split at the first non SchemaUpdate/Restart action.
 func getActionRange(t testing.TB, testCase TestCase) (int, int) {
 	startIndex := 0
 	endIndex := len(testCase.Actions) - 1
@@ -771,7 +771,7 @@ ActionLoop:
 			// We don't care about anything else if this has been explicitly provided
 			break ActionLoop
 
-		case *action.AddSchema, CreateDoc, UpdateDoc, Restart:
+		case *action.AddSchema, Restart:
 			continue
 
 		default:


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4269

## Description

The change detector was not catching breaking changes in write operations because [CreateDoc](cci:2://file:///home/sharanrp/Desktop/projects/defradb/tests/integration/test_case.go:285:0-328:1) and [UpdateDoc](cci:2://file:///home/sharanrp/Desktop/projects/defradb/tests/integration/test_case.go:394:0-436:1) actions were automatically classified as "setup" actions. This meant they were only executed by the source branch during setup and skipped by the target branch, preventing detection of regressions in mutation behavior.

This PR modifies the [getActionRange()](cci:1://file:///home/sharanrp/Desktop/projects/defradb/tests/integration/utils.go:747:0-805:1) function to no longer treat [CreateDoc](cci:2://file:///home/sharanrp/Desktop/projects/defradb/tests/integration/test_case.go:285:0-328:1) and [UpdateDoc](cci:2://file:///home/sharanrp/Desktop/projects/defradb/tests/integration/test_case.go:394:0-436:1) as automatic setup actions. Now the change detector will split **before** the first write action, ensuring both source and target branches execute document creation/update operations.

**Key change:** Removed [CreateDoc](cci:2://file:///home/sharanrp/Desktop/projects/defradb/tests/integration/test_case.go:285:0-328:1) and [UpdateDoc](cci:2://file:///home/sharanrp/Desktop/projects/defradb/tests/integration/test_case.go:394:0-436:1) from the setup action classification in `tests/integration/utils.go:774`.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

**Limitations:**
- Tests requiring documents in setup should use an explicit `SetupComplete{}` action

## How has this been tested?

Added 4 unit tests in [tests/integration/change_detector_fix_test.go](cci:7://file:///home/sharanrp/Desktop/projects/defradb/tests/integration/change_detector_fix_test.go:0:0-0:0) verifying the split behavior. All tests pass.

## Specify the platform(s) on which this was tested:
- Pop!_OS (Linux)