### PR TITLE
chore(i): Add ollama pull script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -214,7 +214,7 @@ ollama:
 ollama\:nomic:
 # make sure ollama is running before continuing
 	time curl --retry 5 --retry-connrefused --retry-delay 0 -sf http://localhost:11434
-	OLLAMA_MODELS=~/.ollama/models tools/scripts/ollama-pull.sh nomic-embed-text
+	tools/scripts/ollama-pull.sh nomic-embed-text
 
 .PHONY: dev\:start
 dev\:start:

--- a/Makefile
+++ b/Makefile
@@ -214,7 +214,7 @@ ollama:
 ollama\:nomic:
 # make sure ollama is running before continuing
 	time curl --retry 5 --retry-connrefused --retry-delay 0 -sf http://localhost:11434
-	ollama pull nomic-embed-text
+	OLLAMA_MODELS=~/.ollama/models tools/scripts/ollama-pull.sh nomic-embed-text
 
 .PHONY: dev\:start
 dev\:start:

--- a/tools/scripts/ollama-pull.sh
+++ b/tools/scripts/ollama-pull.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+die(){
+  echo "$1"
+  exit 1
+}
+
+#DRYRUN=echo
+
+_=$(command -v jq) || die "Need jq"
+_=$(command -v curl) || die "Need curl"
+
+[ -z "$1" ] && die "usage: $0 modelname"
+
+name=${1%%:*}
+[[ "$1" = *:* ]] && tag="${1##*:}" || tag=latest
+
+OLLAMA_MODELS=${OLLAMA_MODELS-/usr/share/ollama/.ollama/models}
+
+cd $OLLAMA_MODELS || die "Couldn't cd to OLLAMA_MODELS ($OLLAMA_MODELS)"
+[ ! -d blobs ] && mkdir -p blobs
+[ ! -d manifests ] && mkdir -p manifests
+manifest_dir="manifests/registry.ollama.ai/library/$name"
+[ -e "$manifest_dir/$tag" ] && die "$name:$tag already exists"
+[ ! -d "$manifest_dir" ] && { $DRYRUN mkdir -p "$manifest_dir" || die "Couldn't mkdir manifest dir ($manifest_dir)" ; }
+
+manifest=$(curl -sL https://registry.ollama.ai/v2/library/$name/manifests/$tag) || die "Couldn't fetch manifest"
+errors=$(jq -cn "$manifest |.errors")
+[ "$errors" = "null" ] || die "$errors"
+
+config=$(jq -rn "$manifest | .config.digest") || die "No config digest"
+
+$DRYRUN curl -#L -C - -o blobs/${config/:/-} https://registry.ollama.ai/v2/library/$name/blobs/$config || die "Couldn't fetch config blob"
+
+for layer in $(jq -rn "$manifest | .layers[].digest") ; do
+  $DRYRUN curl -#L -C - -o blobs/${layer/:/-} https://registry.ollama.ai/v2/library/$name/blobs/$layer || die "Couldn't fetch layer"
+done
+
+[ -n "$DRYRUN" ] && echo "echo '$manifest' > '$manifest_dir/$tag'" || { echo "$manifest" > "$manifest_dir/$tag" || die "Couldn't write manifest" ; }

--- a/tools/scripts/ollama-pull.sh
+++ b/tools/scripts/ollama-pull.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# Script to manually pull Ollama models by directly downloading blobs and manifests
+# Source: https://www.andreagrandi.it/posts/how-to-workaround-ollama-pull-issues/
+# Author: Andrea Grandi
+
 die(){
   echo "$1"
   exit 1

--- a/tools/scripts/ollama-pull.sh
+++ b/tools/scripts/ollama-pull.sh
@@ -18,9 +18,11 @@ _=$(command -v curl) || die "Need curl"
 name=${1%%:*}
 [[ "$1" = *:* ]] && tag="${1##*:}" || tag=latest
 
-OLLAMA_MODELS=${OLLAMA_MODELS-/usr/share/ollama/.ollama/models}
-
-cd $OLLAMA_MODELS || die "Couldn't cd to OLLAMA_MODELS ($OLLAMA_MODELS)"
+OLLAMA_PATH=$HOME/.ollama
+[ ! -d $OLLAMA_PATH ] && { mkdir -p "$OLLAMA_PATH" || die "Couldn't mkdir OLLAMA_PATH ($OLLAMA_PATH)" ; }
+cd $OLLAMA_PATH || die "Couldn't cd to OLLAMA_PATH ($OLLAMA_PATH)"
+[ ! -d models ] && mkdir -p models
+cd models || die "Couldn't cd to models dir"
 [ ! -d blobs ] && mkdir -p blobs
 [ ! -d manifests ] && mkdir -p manifests
 manifest_dir="manifests/registry.ollama.ai/library/$name"


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4318 

## Description

This PR adds a script to manually pull the model manifest instead of relying on Ollama to do so. This seems to prevent the error `Error: digest mismatch, file must be downloaded again` from randomly happening.

The script was taken from https://www.andreagrandi.it/posts/how-to-workaround-ollama-pull-issues/ and attribution has been given in the script file itself.
