### PR TITLE
fix: ordering on indexed field of one-to-many relation

### DIFF
--- a/internal/planner/type_join.go
+++ b/internal/planner/type_join.go
@@ -11,6 +11,8 @@
 package planner
 
 import (
+	"sort"
+
 	"github.com/sourcenetwork/immutable"
 
 	"github.com/sourcenetwork/defradb/client"
@@ -532,6 +534,7 @@ type primaryObjectsRetriever struct {
 
 	targetSecondaryDoc core.Doc
 	filter             *mapper.Filter
+	ordering           []mapper.OrderCondition
 
 	primaryScan *scanNode
 
@@ -604,6 +607,7 @@ func (r *primaryObjectsRetriever) retrievePrimaryDocs() ([]core.Doc, error) {
 
 	oldFetcher := r.primaryScan.fetcher
 	oldIndex := r.primaryScan.index
+	oldOrdering := r.primaryScan.ordering
 
 	r.primaryScan.index = findIndexByFieldName(r.primaryScan.col, r.relIDFieldDef.Name)
 	r.primaryScan.initFetcher(immutable.None[string]())
@@ -620,8 +624,105 @@ func (r *primaryObjectsRetriever) retrievePrimaryDocs() ([]core.Doc, error) {
 
 	r.primaryScan.fetcher = oldFetcher
 	r.primaryScan.index = oldIndex
+	r.primaryScan.ordering = oldOrdering
+
+	// Sort the collected docs based on the ordering conditions
+	if len(r.ordering) > 0 {
+		sortDocsByOrdering(docs, r.ordering)
+	}
 
 	return docs, nil
+}
+
+// sortDocsByOrdering sorts the documents based on the given ordering conditions.
+// This is used to apply ordering when fetching related documents in one-to-many joins,
+// where the index-based ordering might be lost during the lookup process.
+func sortDocsByOrdering(docs []core.Doc, ordering []mapper.OrderCondition) {
+	if len(docs) <= 1 || len(ordering) == 0 {
+		return
+	}
+	sort.SliceStable(docs, func(i, j int) bool {
+		return docValueLess(docs[i], docs[j], ordering)
+	})
+}
+
+// docValueLess compares two documents based on the ordering conditions.
+// Returns true if docA should come before docB.
+func docValueLess(docA, docB core.Doc, ordering []mapper.OrderCondition) bool {
+	for _, order := range ordering {
+		compare := compareDocProps(
+			getDocProp(docA, order.FieldIndexes),
+			getDocProp(docB, order.FieldIndexes),
+		)
+
+		if compare == 0 {
+			continue
+		}
+
+		if order.Direction == mapper.DESC {
+			return compare > 0
+		}
+		return compare < 0
+	}
+	return false
+}
+
+// compareDocProps compares two property values for sorting.
+// Returns -1 if a < b, 0 if a == b, 1 if a > b.
+func compareDocProps(a, b any) int {
+	if a == nil && b == nil {
+		return 0
+	}
+	if a == nil {
+		return -1
+	}
+	if b == nil {
+		return 1
+	}
+
+	switch va := a.(type) {
+	case int64:
+		if vb, ok := b.(int64); ok {
+			if va < vb {
+				return -1
+			}
+			if va > vb {
+				return 1
+			}
+			return 0
+		}
+	case float64:
+		if vb, ok := b.(float64); ok {
+			if va < vb {
+				return -1
+			}
+			if va > vb {
+				return 1
+			}
+			return 0
+		}
+	case string:
+		if vb, ok := b.(string); ok {
+			if va < vb {
+				return -1
+			}
+			if va > vb {
+				return 1
+			}
+			return 0
+		}
+	case bool:
+		if vb, ok := b.(bool); ok {
+			if !va && vb {
+				return -1
+			}
+			if va && !vb {
+				return 1
+			}
+			return 0
+		}
+	}
+	return 0
 }
 
 func docsToDocIDs(docs []core.Doc) []string {
@@ -672,12 +773,14 @@ func fetchPrimaryDocsReferencingSecondaryDoc(
 	primarySide, secondarySide *joinSide,
 	secondaryDoc core.Doc,
 	filter *mapper.Filter,
+	ordering []mapper.OrderCondition,
 ) ([]core.Doc, core.Doc, error) {
 	retriever := primaryObjectsRetriever{
 		primarySide:        primarySide,
 		secondarySide:      secondarySide,
 		targetSecondaryDoc: secondaryDoc,
 		filter:             filter,
+		ordering:           ordering,
 	}
 	err := retriever.retrievePrimaryDocsReferencingSecondaryDoc()
 	return retriever.resultPrimaryDocs, retriever.resultSecondaryDoc, err
@@ -705,8 +808,13 @@ func (join *invertibleTypeJoin) Next() (bool, error) {
 	if firstSide.isPrimary() {
 		return join.fetchRelatedSecondaryDocWithChildren(firstSide.plan.Value())
 	} else {
+		primaryScan := getNode[*scanNode](join.getPrimarySide().plan)
+		var ordering []mapper.OrderCondition
+		if primaryScan != nil {
+			ordering = primaryScan.ordering
+		}
 		primaryDocs, secondaryDoc, err := fetchPrimaryDocsReferencingSecondaryDoc(
-			join.getPrimarySide(), join.getSecondarySide(), firstSide.plan.Value(), join.subFilter)
+			join.getPrimarySide(), join.getSecondarySide(), firstSide.plan.Value(), join.subFilter, ordering)
 		if err != nil {
 			return false, err
 		}
@@ -775,8 +883,13 @@ func (join *invertibleTypeJoin) fetchRelatedSecondaryDocWithChildren(primaryDoc 
 			primaryDocs, secondaryDoc = joinPrimaryDocs(
 				[]core.Doc{firstSide.plan.Value()}, secondaryDoc, join.getPrimarySide(), join.getSecondSide())
 		} else {
+			primaryScan := getNode[*scanNode](join.getPrimarySide().plan)
+			var ordering []mapper.OrderCondition
+			if primaryScan != nil {
+				ordering = primaryScan.ordering
+			}
 			primaryDocs, secondaryDoc, err = fetchPrimaryDocsReferencingSecondaryDoc(
-				join.getPrimarySide(), join.getSecondarySide(), secondaryDoc, join.subFilter)
+				join.getPrimarySide(), join.getSecondarySide(), secondaryDoc, join.subFilter, ordering)
 			if err != nil {
 				return false, err
 			}

--- a/tests/integration/index/query_with_order_on_relation_test.go
+++ b/tests/integration/index/query_with_order_on_relation_test.go
@@ -1,0 +1,139 @@
+// Copyright 2025 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package index
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/defradb/tests/action"
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+// TestOrderQueryWithIndex_WithOrderOnIndexedFieldOfOneToMany_ShouldRespectOrder tests that
+// ordering on an indexed field of a one-to-many relation yields different results for ASC and DESC.
+func TestOrderQueryWithIndex_WithOrderOnIndexedFieldOfOneToMany_ShouldRespectOrder(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddSchema{
+				Schema: `
+					type Author {
+						name: String
+						published: [Book]
+					}
+
+					type Book {
+						name: String
+						rating: Float @index
+						author: Author
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `{
+					"name": "John Grisham"
+				}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"name":   "A Time for Mercy",
+					"rating": 4.5,
+					"author": testUtils.NewDocIndex(0, 0),
+				},
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"name":   "Painted House",
+					"rating": 4.9,
+					"author": testUtils.NewDocIndex(0, 0),
+				},
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"name":   "Sooley",
+					"rating": 4.2,
+					"author": testUtils.NewDocIndex(0, 0),
+				},
+			},
+			// Test ASC ordering
+			testUtils.Request{
+				Request: `query {
+					Author {
+						name
+						published(order: {rating: ASC}) {
+							name
+							rating
+						}
+					}
+				}`,
+				Results: map[string]any{
+					"Author": []map[string]any{
+						{
+							"name": "John Grisham",
+							"published": []map[string]any{
+								{
+									"name":   "Sooley",
+									"rating": 4.2,
+								},
+								{
+									"name":   "A Time for Mercy",
+									"rating": 4.5,
+								},
+								{
+									"name":   "Painted House",
+									"rating": 4.9,
+								},
+							},
+						},
+					},
+				},
+			},
+			// Test DESC ordering (should be different from ASC)
+			testUtils.Request{
+				Request: `query {
+					Author {
+						name
+						published(order: {rating: DESC}) {
+							name
+							rating
+						}
+					}
+				}`,
+				Results: map[string]any{
+					"Author": []map[string]any{
+						{
+							"name": "John Grisham",
+							"published": []map[string]any{
+								{
+									"name":   "Painted House",
+									"rating": 4.9,
+								},
+								{
+									"name":   "A Time for Mercy",
+									"rating": 4.5,
+								},
+								{
+									"name":   "Sooley",
+									"rating": 4.2,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4321

## Description

This PR fixes a bug where ordering on an indexed field within a one-to-many relation was ignored, resulting in unsorted output regardless of the requested order direction (ASC/DESC).

The issue occurred because the ordering configuration on the scan node was being overwritten and lost during the internal retrieval process for the relation.

**Solution:**
The retrieval logic was updated to explicitly pass down ordering conditions from the plan and ensuring that the scan node's configuration is properly preserved and restored during execution. Additionally, an in-memory sort was added to the final result set to guarantee the correct order is returned, addressing cases where the underlying index scan might not maintain the sequence during the join operation.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Added a new integration test case.
- **Verification:** Queried a one-to-many relation with both ASC and DESC ordering on an indexed field.
- **Result:** Confirmed that the results are sorted correctly in both directions, demonstrating the fix.

## Specify the platform(s) on which this was tested:
- Linux