### PR TITLE
ci(i): Bump github actions for node.js 24

### DIFF
--- a/.github/composites/install-sourcehub/action.yml
+++ b/.github/composites/install-sourcehub/action.yml
@@ -24,7 +24,7 @@ runs:
 
   steps:
     - name: Checkout sourcehub code into the directory
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: sourcenetwork/sourcehub
         path: _sourceHub

--- a/.github/composites/setup-defradb/action.yml
+++ b/.github/composites/setup-defradb/action.yml
@@ -33,7 +33,7 @@ runs:
         echo "CARGO_CACHE=~/.cargo" >> "${GITHUB_OUTPUT}"
 
     - name: Go cache/restore
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.mod') }}
         path: |
@@ -42,7 +42,7 @@ runs:
 
     - name: Cargo cache/restore
       # A very cool post: https://blog.arriven.wtf/posts/rust-ci-cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
           # Here are some directories we shouldn't forget about:

--- a/.github/composites/setup-defradb/action.yml
+++ b/.github/composites/setup-defradb/action.yml
@@ -18,7 +18,7 @@ runs:
 
   steps:
     - name: Setup Go environment explicitly
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version-file: 'go.mod'
         check-latest: true

--- a/.github/composites/upload-coverage-artifact/action.yml
+++ b/.github/composites/upload-coverage-artifact/action.yml
@@ -29,7 +29,7 @@ runs:
 
   steps:
     - name: Upload coverage artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         # Make sure the name is always unique per job as artifacts are now immutable.
         # Note Issue: https://github.com/actions/upload-artifact/issues/478

--- a/.github/workflows/build-dependencies.yml
+++ b/.github/workflows/build-dependencies.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
 
       - name: Checkout code into the directory
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Go environment explicitly
         uses: actions/setup-go@v5

--- a/.github/workflows/build-dependencies.yml
+++ b/.github/workflows/build-dependencies.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Go environment explicitly
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
           check-latest: true

--- a/.github/workflows/build-then-deploy-ami.yml
+++ b/.github/workflows/build-then-deploy-ami.yml
@@ -55,7 +55,7 @@ jobs:
         # run: echo ${{ env.RELEASE_VERSION }}
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v5.1.1
         with:
           aws-region: ${{ env.AWS_REGION }}
           aws-access-key-id: ${{ env.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/build-then-deploy-ami.yml
+++ b/.github/workflows/build-then-deploy-ami.yml
@@ -48,7 +48,7 @@ jobs:
 
     steps:
       - name: Checkout code into the directory
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Environment version target
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> ${GITHUB_ENV}
@@ -89,7 +89,7 @@ jobs:
 
     steps:
       - name: Checkout code into the directory
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Terraform action setup
         uses: hashicorp/setup-terraform@v3

--- a/.github/workflows/check-data-format-changes.yml
+++ b/.github/workflows/check-data-format-changes.yml
@@ -43,7 +43,7 @@ jobs:
           metrics: cpu,network,memory,disk,io
 
       - name: Checkout code into the directory
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup defradb
         uses: ./.github/composites/setup-defradb

--- a/.github/workflows/check-documentation.yml
+++ b/.github/workflows/check-documentation.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout code into the directory
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Go environment explicitly
         uses: actions/setup-go@v5
@@ -59,7 +59,7 @@ jobs:
 
     steps:
       - name: Checkout code into the directory
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Go environment explicitly
         uses: actions/setup-go@v5
@@ -85,7 +85,7 @@ jobs:
 
     steps:
       - name: Checkout code into the directory
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Go environment explicitly
         uses: actions/setup-go@v5

--- a/.github/workflows/check-documentation.yml
+++ b/.github/workflows/check-documentation.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Go environment explicitly
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
           check-latest: true
@@ -62,7 +62,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Go environment explicitly
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
           check-latest: true
@@ -88,7 +88,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Go environment explicitly
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
           check-latest: true

--- a/.github/workflows/check-mocks.yml
+++ b/.github/workflows/check-mocks.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout code into the directory
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Go environment explicitly
         uses: actions/setup-go@v5

--- a/.github/workflows/check-mocks.yml
+++ b/.github/workflows/check-mocks.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Go environment explicitly
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
           check-latest: true

--- a/.github/workflows/check-tidy.yml
+++ b/.github/workflows/check-tidy.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
 
       - name: Checkout code into the directory
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Go environment explicitly
         uses: actions/setup-go@v5

--- a/.github/workflows/check-tidy.yml
+++ b/.github/workflows/check-tidy.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Go environment explicitly
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
           check-latest: true

--- a/.github/workflows/check-vulnerabilities.yml
+++ b/.github/workflows/check-vulnerabilities.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout code into the directory
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Go environment explicitly
         uses: actions/setup-go@v5

--- a/.github/workflows/check-vulnerabilities.yml
+++ b/.github/workflows/check-vulnerabilities.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Go environment explicitly
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
           check-latest: true

--- a/.github/workflows/check-wizard-health.yml
+++ b/.github/workflows/check-wizard-health.yml
@@ -8,27 +8,37 @@
 # by the Apache License, Version 2.0, included in the file
 # licenses/APL.txt.
 
-name: Validate Wizard Workflow
+name: Check Wizard Health Workflow
 
 on:
   pull_request:
-    types:
-      - edited
-      - opened
-      - reopened
-      - synchronize
     branches:
+      - master
+      - develop
+
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+    branches:
+      - master
       - develop
 
 jobs:
-  test-wizard:
+  check-wizard-health:
+    name: Check wizard health job
+
     runs-on: ubuntu-latest
+
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout code into the directory
+        uses: actions/checkout@v4
+
       - name: Install Expect
         run: sudo apt-get update && sudo apt-get install -y expect
+
       - name: Build binary
         run: make build
+
       - name: Run wizard test
         run: |
           chmod +x ./tools/scripts/wizard_test.sh

--- a/.github/workflows/check-wizard-health.yml
+++ b/.github/workflows/check-wizard-health.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout code into the directory
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Expect
         run: sudo apt-get update && sudo apt-get install -y expect

--- a/.github/workflows/combine-bot-prs.yml
+++ b/.github/workflows/combine-bot-prs.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Create combined pr
         id: create-combined-pr
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -39,7 +39,7 @@ jobs:
           metrics: cpu,network,memory,disk,io
 
       - name: Checkout code into the directory
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/lint-then-benchmark.yml
+++ b/.github/workflows/lint-then-benchmark.yml
@@ -306,7 +306,7 @@ jobs:
 
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v5.1.1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/lint-then-benchmark.yml
+++ b/.github/workflows/lint-then-benchmark.yml
@@ -55,7 +55,7 @@ jobs:
 
       # Setting up Go explicitly is required for v3.0.0+ of golangci/golangci-lint-action.
       - name: Setup Go environment explicitly
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
           check-latest: true

--- a/.github/workflows/lint-then-benchmark.yml
+++ b/.github/workflows/lint-then-benchmark.yml
@@ -51,7 +51,7 @@ jobs:
 
     steps:
       - name: Checkout code into the directory
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Setting up Go explicitly is required for v3.0.0+ of golangci/golangci-lint-action.
       - name: Setup Go environment explicitly
@@ -193,7 +193,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run the full bechmarking suite
         if: needs.decide-benchmark-type.outputs.benchmark-type == 'FULL'

--- a/.github/workflows/lint-then-benchmark.yml
+++ b/.github/workflows/lint-then-benchmark.yml
@@ -62,13 +62,13 @@ jobs:
           cache: false
 
       - name: Run the golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
 
         with:
           # Required: the version of golangci-lint is required.
           # Note: The version should not pick the patch version as the latest patch
           #  version is what will always be used.
-          version: v1.51
+          version: v2.3
 
           # Optional: working directory, useful for monorepos or if we wanted to run this
           #  on a non-root directory.

--- a/.github/workflows/lint-then-benchmark.yml
+++ b/.github/workflows/lint-then-benchmark.yml
@@ -215,7 +215,7 @@ jobs:
         if: |
           github.event_name == 'push' &&
           github.ref_name == 'develop'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: bench-artifact-${{ github.sha }}
           path: bench-artifact-${{ github.sha }}.txt

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -45,7 +45,7 @@ jobs:
           cache: false
 
       - name: Run golangci-lint linter
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@v9
         with:
           # Required: the version of golangci-lint is required.
           # Note: The version should not pick the patch version as the latest patch

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -38,7 +38,7 @@ jobs:
 
       # Setting up Go explicitly is required for v3.0.0+ of golangci/golangci-lint-action.
       - name: Setup Go environment explicitly
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
           check-latest: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout code into the directory
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Setting up Go explicitly is required for v3.0.0+ of golangci/golangci-lint-action.
       - name: Setup Go environment explicitly
@@ -87,7 +87,7 @@ jobs:
 
     steps:
       - name: Checkout code into the directory
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run yamllint linter
         uses: ibiqlik/action-yamllint@v3

--- a/.github/workflows/preview-ami-with-terraform-plan.yml
+++ b/.github/workflows/preview-ami-with-terraform-plan.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Stop and notify the use of unprivileged flow or missing tokens
         if: env.AWS_ACCESS_KEY_ID == '' || env.AWS_SECRET_ACCESS_KEY == ''
         # Note: Fail this step, as we don't want unprivileged access doing these changes.
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             let unprivileged_warning =
@@ -93,7 +93,7 @@ jobs:
         continue-on-error: true
 
       - name: Comment results on pull request
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           TERRAFORM_PLAN_OUTPUT: "Terraform Plan Output:\n${{ steps.terraform-plan.outputs.stdout }}\n"
 

--- a/.github/workflows/preview-ami-with-terraform-plan.yml
+++ b/.github/workflows/preview-ami-with-terraform-plan.yml
@@ -64,7 +64,7 @@ jobs:
             core.setFailed(unprivileged_warning)
 
       - name: Checkout code into the directory
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Terraform action setup
         uses: hashicorp/setup-terraform@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Go environment explicitly
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
           check-latest: true
@@ -103,7 +103,7 @@ jobs:
         run: git tag v${{ github.event.inputs.tag }}
 
       - name: Setup Go environment explicitly
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
           check-latest: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,21 +70,21 @@ jobs:
 
       - name: Save cache on Linux
         if: matrix.os == 'ubuntu-latest'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: dist/linux_amd64
           key: linux-${{ env.sha_short }}
 
       - name: Save cache on MacOS
         if: matrix.os == 'macos-latest'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: dist/darwin_arm64
           key: darwin-${{ env.sha_short }}
 
       - name: Save cache on Windows
         if: matrix.os == 'windows-latest'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: dist/windows_amd64
           key: windows-${{ env.sha_short }}
@@ -116,7 +116,7 @@ jobs:
       # Restore the cashes that were prepared for all OS
       - name: Restore from cache on Linux
         id: restore-linux
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: dist/linux_amd64
           key: linux-${{ env.sha_short }}
@@ -124,7 +124,7 @@ jobs:
 
       - name: Save from cache on MacOS
         id: restore-macos
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: dist/darwin_arm64
           key: darwin-${{ env.sha_short }}
@@ -132,7 +132,7 @@ jobs:
 
       - name: Restore from cache on Windows
         id: restore-windows
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: dist/windows_amd64
           key: windows-${{ env.sha_short }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
 
     steps:
       - name: Checkout code into the directory
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -95,7 +95,7 @@ jobs:
     needs: prepare
     steps:
       - name: Checkout code into the directory
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -170,7 +170,7 @@ jobs:
           metrics: cpu,network,memory,disk,io
 
       - name: Checkout code into the directory
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/start-binary.yml
+++ b/.github/workflows/start-binary.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
 
       - name: Checkout code into the directory
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Go environment explicitly
         uses: actions/setup-go@v5

--- a/.github/workflows/start-binary.yml
+++ b/.github/workflows/start-binary.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Go environment explicitly
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
           check-latest: true

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -102,7 +102,7 @@ jobs:
           metrics: cpu,network,memory,disk,io
 
       - name: Checkout code into the directory
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup defradb
         uses: ./.github/composites/setup-defradb
@@ -144,7 +144,7 @@ jobs:
 
     steps:
       - name: Checkout code into the directory
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup defradb
         uses: ./.github/composites/setup-defradb
@@ -183,7 +183,7 @@ jobs:
           metrics: cpu,network,memory,disk,io
 
       - name: Checkout code into the directory
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup defradb
         uses: ./.github/composites/setup-defradb
@@ -232,7 +232,7 @@ jobs:
           metrics: cpu,network,memory,disk,io
 
       - name: Checkout code into the directory
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup defradb
         uses: ./.github/composites/setup-defradb
@@ -261,7 +261,7 @@ jobs:
           metrics: cpu,network,memory,disk,io
 
       - name: Checkout code into the directory
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup defradb
         uses: ./.github/composites/setup-defradb
@@ -290,7 +290,7 @@ jobs:
           metrics: cpu,network,memory,disk,io
 
       - name: Checkout code into the directory
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup defradb
         uses: ./.github/composites/setup-defradb
@@ -318,7 +318,7 @@ jobs:
           metrics: cpu,network,memory,disk,io
 
       - name: Checkout code into the directory
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup defradb
         uses: ./.github/composites/setup-defradb
@@ -346,7 +346,7 @@ jobs:
           metrics: cpu,network,memory,disk,io
 
       - name: Checkout code into the directory
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup defradb
         uses: ./.github/composites/setup-defradb
@@ -389,7 +389,7 @@ jobs:
 
     steps:
       - name: Checkout code into the directory
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download coverage reports
         uses: actions/download-artifact@v4

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -392,7 +392,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Download coverage reports
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: coverage_*
           # Note: https://github.com/actions/download-artifact/blob/main/docs/MIGRATION.md

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -400,7 +400,7 @@ jobs:
           path: coverage_reports
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           name: defradb-codecov

--- a/.github/workflows/test-introspection.yml
+++ b/.github/workflows/test-introspection.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout code into the directory
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup defradb
         uses: ./.github/composites/setup-defradb

--- a/.github/workflows/test-limited-resource.yml
+++ b/.github/workflows/test-limited-resource.yml
@@ -71,7 +71,7 @@ jobs:
 
     steps:
       - name: Checkout code into the directory
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup defradb
         uses: ./.github/composites/setup-defradb

--- a/.github/workflows/validate-containerfile.yml
+++ b/.github/workflows/validate-containerfile.yml
@@ -36,7 +36,7 @@ jobs:
 
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/validate-title.yml
+++ b/.github/workflows/validate-title.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout code into the directory
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Ensure the scripts are not broken
         run: make test:scripts


### PR DESCRIPTION
## Relevant issue(s)
Resolves #4333

## Description
- Tweaks the new wizard action to be able to find easily to make required.
- Bumps the outdated actions in github workflows:
  - Update codecov action from v4 to v5
  - Update golangci-lint action to v9
  - Update github script action from v7 to v8
  - Update aws cred config action from v1 to v5.1.1
  - Update upload-artifact action from v4 to v6
  - Update download-artifact action from v4 to v7
  - Update cache action from v4 to v5
  - Update setup-go action from v5 to v6
  - Update checkout version from v4 to v6

