### PR TITLE
fix: Null json index panic

### DIFF
--- a/internal/db/index.go
+++ b/internal/db/index.go
@@ -127,6 +127,13 @@ type JSONFieldGenerator struct{}
 
 func (g *JSONFieldGenerator) Generate(value client.NormalValue, f func(client.NormalValue) error) error {
 	json, _ := value.JSON()
+	if json == nil {
+		val, err := client.NewNormalNil(client.FieldKind_NILLABLE_JSON)
+		if err != nil {
+			return err
+		}
+		return f(val)
+	}
 	return client.TraverseJSON(json, func(value client.JSON) error {
 		val, err := client.NewNormalValue(value)
 		if err != nil {

--- a/tests/integration/index/json_test.go
+++ b/tests/integration/index/json_test.go
@@ -1545,3 +1545,49 @@ func TestJSONIndex_WithNeFilterAgainstNullField_ShouldFetchNonNullValues(t *test
 	}
 	testUtils.ExecuteTestCase(t, test)
 }
+
+func TestJSONIndex_WithEqFilterAgainstNullField_ShouldFetchNullValues(t *testing.T) {
+	req := `query {
+		User(filter: {custom: {_eq: null}}) {
+			name
+		}
+	}`
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddSchema{
+				Schema: `
+					type User {
+						name: String 
+						custom: JSON @index
+					}`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
+					"name": "John",
+					"custom": null
+				}`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
+					"name": "Islam",
+					"custom": 100
+				}`,
+			},
+			testUtils.Request{
+				Request: req,
+				Results: map[string]any{
+					"User": []map[string]any{
+						{"name": "John"},
+					},
+				},
+				NonOrderedResults: true,
+			},
+			testUtils.Request{
+				Request:  makeExplainQuery(req),
+				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(1),
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/index/json_test.go
+++ b/tests/integration/index/json_test.go
@@ -1546,7 +1546,7 @@ func TestJSONIndex_WithNeFilterAgainstNullField_ShouldFetchNonNullValues(t *test
 	testUtils.ExecuteTestCase(t, test)
 }
 
-func TestJSONIndex_WithEqFilterAgainstNullField_ShouldFetchNullValues(t *testing.T) {
+func TestJSONIndex_WithEqFilterAgainstExplicitNullField_ShouldFetchNullValues(t *testing.T) {
 	req := `query {
 		User(filter: {custom: {_eq: null}}) {
 			name
@@ -1578,6 +1578,51 @@ func TestJSONIndex_WithEqFilterAgainstNullField_ShouldFetchNullValues(t *testing
 				Results: map[string]any{
 					"User": []map[string]any{
 						{"name": "John"},
+					},
+				},
+				NonOrderedResults: true,
+			},
+			testUtils.Request{
+				Request:  makeExplainQuery(req),
+				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(1),
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestJSONIndex_WithEqFilterAgainstOmittedNullField_ShouldFetchNullValues(t *testing.T) {
+	req := `query {
+		User(filter: {custom: {_eq: null}}) {
+			name
+		}
+	}`
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddSchema{
+				Schema: `
+					type User {
+						name: String 
+						custom: JSON @index
+					}`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
+					"name": "Kyle"
+				}`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
+					"name": "Islam",
+					"custom": 100
+				}`,
+			},
+			testUtils.Request{
+				Request: req,
+				Results: map[string]any{
+					"User": []map[string]any{
+						{"name": "Kyle"},
 					},
 				},
 				NonOrderedResults: true,


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4337

## Description

This PR fixes an issue where null JSON value indexes would cause a panic.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Added integration test.

Specify the platform(s) on which this was tested:
- MacOS

