### PR TITLE
fix: Index-based order for nested queries

### DIFF
--- a/internal/planner/type_join.go
+++ b/internal/planner/type_join.go
@@ -612,13 +612,12 @@ func (r *primaryObjectsRetriever) retrievePrimaryDocs() ([]core.Doc, error) {
 
 	oldFetcher := r.primaryScan.fetcher
 	oldIndex := r.primaryScan.index
-	oldOrdering := r.primaryScan.ordering
 
 	r.primaryScan.index = findIndexByFieldName(r.primaryScan.col, r.relIDFieldDef.Name)
-	r.primaryScan.ordering = nil
 
 	canOrderByIndex := false
 
+	// if there is not index for filter, we try to find one for ordering
 	if !r.primaryScan.index.HasValue() {
 		var orderIndex immutable.Option[client.IndexDescription]
 		orderIndex, canOrderByIndex = r.findOrderingIndex()
@@ -642,7 +641,6 @@ func (r *primaryObjectsRetriever) retrievePrimaryDocs() ([]core.Doc, error) {
 
 	r.primaryScan.fetcher = oldFetcher
 	r.primaryScan.index = oldIndex
-	r.primaryScan.ordering = oldOrdering
 
 	return docs, nil
 }

--- a/internal/planner/type_join.go
+++ b/internal/planner/type_join.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sourcenetwork/defradb/client/request"
 	"github.com/sourcenetwork/defradb/internal/connor"
 	"github.com/sourcenetwork/defradb/internal/core"
+	"github.com/sourcenetwork/defradb/internal/db/fetcher"
 	"github.com/sourcenetwork/defradb/internal/db/id"
 	"github.com/sourcenetwork/defradb/internal/keys"
 	"github.com/sourcenetwork/defradb/internal/planner/filter"
@@ -372,13 +373,16 @@ func (p *Planner) newInvertableTypeJoin(
 		isParent:           false,
 	}
 
+	childScan := getNode[*scanNode](childSide.plan)
 	join := invertibleTypeJoin{
 		docMapper:  docMapper{parent.documentMapping},
 		parentSide: parentSide,
 		childSide:  childSide,
 		skipChild:  skipChild,
 		// we store child's own filter in case an index kicks in and replaces it with it's own filter
-		subFilter: getNode[*scanNode](childSide.plan).filter,
+		subFilter: childScan.filter,
+		// we store child's ordering to apply when fetching child documents
+		subOrdering: childScan.ordering,
 	}
 
 	return join, nil
@@ -486,6 +490,9 @@ type invertibleTypeJoin struct {
 	// the filter of the subnode to store in case it's replaced by an index filter
 	subFilter *mapper.Filter
 
+	// the ordering of the subnode to apply when fetching child documents
+	subOrdering []mapper.OrderCondition
+
 	secondaryFetchLimit uint
 
 	// docsToYield contains documents read and ready to be yielded by this node.
@@ -532,6 +539,7 @@ type primaryObjectsRetriever struct {
 
 	targetSecondaryDoc core.Doc
 	filter             *mapper.Filter
+	ordering           []mapper.OrderCondition
 
 	primaryScan *scanNode
 
@@ -604,8 +612,22 @@ func (r *primaryObjectsRetriever) retrievePrimaryDocs() ([]core.Doc, error) {
 
 	oldFetcher := r.primaryScan.fetcher
 	oldIndex := r.primaryScan.index
+	oldOrdering := r.primaryScan.ordering
 
 	r.primaryScan.index = findIndexByFieldName(r.primaryScan.col, r.relIDFieldDef.Name)
+	r.primaryScan.ordering = nil
+
+	canOrderByIndex := false
+
+	if !r.primaryScan.index.HasValue() {
+		var orderIndex immutable.Option[client.IndexDescription]
+		orderIndex, canOrderByIndex = r.findOrderingIndex()
+		if canOrderByIndex {
+			r.primaryScan.index = orderIndex
+			r.primaryScan.ordering = r.ordering
+		}
+	}
+
 	r.primaryScan.initFetcher(immutable.None[string]())
 
 	docs, err := r.collectDocs(0)
@@ -620,6 +642,7 @@ func (r *primaryObjectsRetriever) retrievePrimaryDocs() ([]core.Doc, error) {
 
 	r.primaryScan.fetcher = oldFetcher
 	r.primaryScan.index = oldIndex
+	r.primaryScan.ordering = oldOrdering
 
 	return docs, nil
 }
@@ -672,12 +695,14 @@ func fetchPrimaryDocsReferencingSecondaryDoc(
 	primarySide, secondarySide *joinSide,
 	secondaryDoc core.Doc,
 	filter *mapper.Filter,
+	ordering []mapper.OrderCondition,
 ) ([]core.Doc, core.Doc, error) {
 	retriever := primaryObjectsRetriever{
 		primarySide:        primarySide,
 		secondarySide:      secondarySide,
 		targetSecondaryDoc: secondaryDoc,
 		filter:             filter,
+		ordering:           ordering,
 	}
 	err := retriever.retrievePrimaryDocsReferencingSecondaryDoc()
 	return retriever.resultPrimaryDocs, retriever.resultSecondaryDoc, err
@@ -706,7 +731,7 @@ func (join *invertibleTypeJoin) Next() (bool, error) {
 		return join.fetchRelatedSecondaryDocWithChildren(firstSide.plan.Value())
 	} else {
 		primaryDocs, secondaryDoc, err := fetchPrimaryDocsReferencingSecondaryDoc(
-			join.getPrimarySide(), join.getSecondarySide(), firstSide.plan.Value(), join.subFilter)
+			join.getPrimarySide(), join.getSecondarySide(), firstSide.plan.Value(), join.subFilter, join.subOrdering)
 		if err != nil {
 			return false, err
 		}
@@ -776,7 +801,7 @@ func (join *invertibleTypeJoin) fetchRelatedSecondaryDocWithChildren(primaryDoc 
 				[]core.Doc{firstSide.plan.Value()}, secondaryDoc, join.getPrimarySide(), join.getSecondSide())
 		} else {
 			primaryDocs, secondaryDoc, err = fetchPrimaryDocsReferencingSecondaryDoc(
-				join.getPrimarySide(), join.getSecondarySide(), secondaryDoc, join.subFilter)
+				join.getPrimarySide(), join.getSecondarySide(), secondaryDoc, join.subFilter, join.subOrdering)
 			if err != nil {
 				return false, err
 			}
@@ -859,4 +884,22 @@ func getNode[T planNode](plan planNode) T {
 	}
 	var zero T
 	return zero
+}
+
+// findOrderingIndex finds an index that can satisfy the ordering requirement.
+// Returns the index and whether it can provide ordering.
+func (r *primaryObjectsRetriever) findOrderingIndex() (immutable.Option[client.IndexDescription], bool) {
+	if len(r.ordering) == 0 {
+		return immutable.None[client.IndexDescription](), false
+	}
+
+	indexes := r.primaryScan.col.Version().Indexes
+	for _, idx := range indexes {
+		canOrder, _ := fetcher.CanBeOrderedByIndex(r.ordering, idx, r.primaryScan.documentMapping)
+		if canOrder {
+			return immutable.Some(idx), true
+		}
+	}
+
+	return immutable.None[client.IndexDescription](), false
 }

--- a/tests/integration/index/query_with_relation_sub_order_test.go
+++ b/tests/integration/index/query_with_relation_sub_order_test.go
@@ -321,7 +321,7 @@ func TestQueryWithOrderOnOneToMany_WithMultipleAuthors_ShouldOrderEachAuthorsBoo
 				},
 			},
 			testUtils.Request{
-				Request:  makeExplainQuery(req),
+				Request: makeExplainQuery(req),
 				// index fetches 8: 4 for ordering all books for each author
 				Asserter: testUtils.NewExplainAsserter().WithOrder().WithIndexFetches(8),
 			},

--- a/tests/integration/index/query_with_relation_sub_order_test.go
+++ b/tests/integration/index/query_with_relation_sub_order_test.go
@@ -1,0 +1,331 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package index
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/defradb/tests/action"
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+func TestQueryWithOrderOnOneToMany_WithIndexOnOrderFieldDescending_ShouldOrder(t *testing.T) {
+	req := `query {
+		Author {
+			name
+			published(order: {rating: DESC}) {
+				rating
+			}
+		}
+	}`
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddSchema{
+				Schema: `
+					type Author {
+						name: String
+						published: [Book]
+					}
+					type Book {
+						rating: Float @index
+						author: Author
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc:          `{"name": "John"}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"rating": 4.5,
+					"author": testUtils.NewDocIndex(0, 0),
+				},
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"rating": 4.9,
+					"author": testUtils.NewDocIndex(0, 0),
+				},
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"rating": 4.2,
+					"author": testUtils.NewDocIndex(0, 0),
+				},
+			},
+			testUtils.Request{
+				Request: req,
+				Results: map[string]any{
+					"Author": []map[string]any{
+						{
+							"name": "John",
+							"published": []map[string]any{
+								{"rating": 4.9},
+								{"rating": 4.5},
+								{"rating": 4.2},
+							},
+						},
+					},
+				},
+			},
+			testUtils.Request{
+				Request:  makeExplainQuery(req),
+				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(3),
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestQueryWithOrderOnOneToMany_WithIndexOnOrderFieldAscending_ShouldOrder(t *testing.T) {
+	req := `query {
+		Author {
+			name
+			published(order: {rating: ASC}) {
+				rating
+			}
+		}
+	}`
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddSchema{
+				Schema: `
+					type Author {
+						name: String
+						published: [Book]
+					}
+					type Book {
+						rating: Float @index
+						author: Author
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc:          `{"name": "John"}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"rating": 4.5,
+					"author": testUtils.NewDocIndex(0, 0),
+				},
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"rating": 4.9,
+					"author": testUtils.NewDocIndex(0, 0),
+				},
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"rating": 4.2,
+					"author": testUtils.NewDocIndex(0, 0),
+				},
+			},
+			testUtils.Request{
+				Request: req,
+				Results: map[string]any{
+					"Author": []map[string]any{
+						{
+							"name": "John",
+							"published": []map[string]any{
+								{"rating": 4.2},
+								{"rating": 4.5},
+								{"rating": 4.9},
+							},
+						},
+					},
+				},
+			},
+			testUtils.Request{
+				Request:  makeExplainQuery(req),
+				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(3),
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestQueryWithOrderOnOneToMany_WithIndexOnOrderFieldAscendingWithLimit_ShouldOrderAndLimit(t *testing.T) {
+	req := `query {
+		Author {
+			name
+			published(order: {rating: ASC}, limit: 1) {
+				rating
+			}
+		}
+	}`
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddSchema{
+				Schema: `
+					type Author {
+						name: String
+						published: [Book]
+					}
+					type Book {
+						rating: Float @index
+						author: Author
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc:          `{"name": "John"}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"rating": 4.5,
+					"author": testUtils.NewDocIndex(0, 0),
+				},
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"rating": 4.9,
+					"author": testUtils.NewDocIndex(0, 0),
+				},
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"rating": 4.2,
+					"author": testUtils.NewDocIndex(0, 0),
+				},
+			},
+			testUtils.Request{
+				Request: req,
+				Results: map[string]any{
+					"Author": []map[string]any{
+						{
+							"name": "John",
+							"published": []map[string]any{
+								{"rating": 4.2},
+							},
+						},
+					},
+				},
+			},
+			testUtils.Request{
+				Request:  makeExplainQuery(req),
+				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(1),
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestQueryWithOrderOnOneToMany_WithMultipleAuthors_ShouldOrderEachAuthorsBooks(t *testing.T) {
+	req := `query {
+		Author(order: {name: ASC}) {
+			name
+			published(order: {rating: DESC}) {
+				title
+				rating
+			}
+		}
+	}`
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddSchema{
+				Schema: `
+					type Author {
+						name: String
+						published: [Book]
+					}
+					type Book {
+						title: String
+						rating: Float @index
+						author: Author
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc:          `{"name": "Alice"}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc:          `{"name": "Bob"}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"title":  "Book A1",
+					"rating": 3.5,
+					"author": testUtils.NewDocIndex(0, 0),
+				},
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"title":  "Book A2",
+					"rating": 4.8,
+					"author": testUtils.NewDocIndex(0, 0),
+				},
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"title":  "Book B1",
+					"rating": 4.0,
+					"author": testUtils.NewDocIndex(0, 1),
+				},
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"title":  "Book B2",
+					"rating": 2.5,
+					"author": testUtils.NewDocIndex(0, 1),
+				},
+			},
+			testUtils.Request{
+				Request: req,
+				Results: map[string]any{
+					"Author": []map[string]any{
+						{
+							"name": "Alice",
+							"published": []map[string]any{
+								{"title": "Book A2", "rating": 4.8},
+								{"title": "Book A1", "rating": 3.5},
+							},
+						},
+						{
+							"name": "Bob",
+							"published": []map[string]any{
+								{"title": "Book B1", "rating": 4.0},
+								{"title": "Book B2", "rating": 2.5},
+							},
+						},
+					},
+				},
+			},
+			testUtils.Request{
+				Request:  makeExplainQuery(req),
+				Asserter: testUtils.NewExplainAsserter().WithOrder().WithIndexFetches(8),
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/index/query_with_relation_sub_order_test.go
+++ b/tests/integration/index/query_with_relation_sub_order_test.go
@@ -322,6 +322,7 @@ func TestQueryWithOrderOnOneToMany_WithMultipleAuthors_ShouldOrderEachAuthorsBoo
 			},
 			testUtils.Request{
 				Request:  makeExplainQuery(req),
+				// index fetches 8: 4 for ordering all books for each author
 				Asserter: testUtils.NewExplainAsserter().WithOrder().WithIndexFetches(8),
 			},
 		},


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4321

## Description

Now secondary indexes are used for sub queries with `order` command.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Integration tests

Specify the platform(s) on which this was tested:
- MacOS
