### PR TITLE
fix: Secondary index on sub query filter

### DIFF
--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -393,7 +393,7 @@ func (p *Planner) tryOptimizeJoinDirectionByFilter(node *invertibleTypeJoin, par
 			// the parent filter. This prevents re-evaluation at the parent level which would fail
 			// when the sub-filter modifies the child docs (e.g., filtering by model="Galaxy" when
 			// parent filter is model="Walkman").
-			// 
+			//
 			// Example:
 			// 	User(filter: {devices: {model: {_eq: "Walkman"}}}) {
 			// 		name
@@ -475,7 +475,37 @@ func (p *Planner) expandTypeJoin(node *invertibleTypeJoin, parentPlan *selectTop
 		return err
 	}
 
+	ensureOrderNodeForRelationIndex(node)
+
 	return p.expandPlan(node.childSide.plan, parentPlan)
+}
+
+// ensureOrderNodeForRelationIndex clears the child's index if a relation ID index exists,
+// ensuring orderNode is added during plan expansion. Without this, isOrderedByIndex might
+// see an ordering index that can satisfy ordering, so orderNode won't be added. But
+// retrievePrimaryDocs might use a relation ID index instead, which can't satisfy ordering.
+func ensureOrderNodeForRelationIndex(node *invertibleTypeJoin) {
+	childTop, ok := node.childSide.plan.(*selectTopNode)
+	if !ok || childTop.order == nil {
+		return
+	}
+
+	if !node.childSide.relFieldDef.HasValue() || !node.childSide.isPrimary() {
+		return
+	}
+
+	relIDFieldName := request.ToFieldID(node.childSide.relFieldDef.Value().Name)
+	relIDIndex := findIndexByFieldName(node.childSide.col, relIDFieldName)
+	if !relIDIndex.HasValue() {
+		return
+	}
+
+	// A relation ID index exists and might be used instead of ordering index.
+	// Clear the current index to ensure orderNode is added.
+	childScan := getNode[*scanNode](node.childSide.plan)
+	if childScan != nil {
+		childScan.index = immutable.None[client.IndexDescription]()
+	}
 }
 
 func (p *Planner) expandGroupNodePlan(topNodeSelect *selectTopNode) error {

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -389,6 +389,21 @@ func (p *Planner) tryOptimizeJoinDirectionByFilter(node *invertibleTypeJoin, par
 			if err != nil {
 				return false, err
 			}
+			// If there's a sub-filter on the child side, remove the related field condition from
+			// the parent filter. This prevents re-evaluation at the parent level which would fail
+			// when the sub-filter modifies the child docs (e.g., filtering by model="Galaxy" when
+			// parent filter is model="Walkman").
+			// 
+			// Example:
+			// 	User(filter: {devices: {model: {_eq: "Walkman"}}}) {
+			// 		name
+			// 		devices(filter: {model: {_eq: "Galaxy"}}) {
+			// 			model
+			// 		}
+			// 	}
+			if node.subFilter != nil {
+				filter.RemoveField(parentPlan.selectNode.filter, relatedField)
+			}
 			return true, nil
 		}
 	}

--- a/internal/planner/type_join.go
+++ b/internal/planner/type_join.go
@@ -612,6 +612,7 @@ func (r *primaryObjectsRetriever) retrievePrimaryDocs() ([]core.Doc, error) {
 
 	oldFetcher := r.primaryScan.fetcher
 	oldIndex := r.primaryScan.index
+	oldOrdering := r.primaryScan.ordering
 
 	// we first try to find an index based on sub-filter fields
 	r.primaryScan.index = findIndexByFilteringField(r.primaryScan)
@@ -621,12 +622,20 @@ func (r *primaryObjectsRetriever) retrievePrimaryDocs() ([]core.Doc, error) {
 		r.primaryScan.index = findIndexByFieldName(r.primaryScan.col, r.relIDFieldDef.Name)
 	}
 
-	canOrderByIndex := false
-
-	// if there is no index for filter, we try to find one for ordering
-	if !r.primaryScan.index.HasValue() {
-		var orderIndex immutable.Option[client.IndexDescription]
-		orderIndex, canOrderByIndex = r.findOrderingIndex()
+	// Check if the selected index can satisfy ordering. Use the same function (CanBeOrderedByIndex)
+	// that isOrderedByIndex uses to ensure consistent behavior between plan expansion and execution.
+	if r.primaryScan.index.HasValue() && len(r.ordering) > 0 {
+		canOrder, _ := fetcher.CanBeOrderedByIndex(r.ordering, r.primaryScan.index.Value(), r.primaryScan.documentMapping)
+		if canOrder {
+			r.primaryScan.ordering = r.ordering
+		} else {
+			// Clear ordering so the fetcher doesn't try to use it with an incompatible index.
+			// The orderNode (added during plan expansion) will handle in-memory sorting.
+			r.primaryScan.ordering = nil
+		}
+	} else if !r.primaryScan.index.HasValue() && len(r.ordering) > 0 {
+		// if there is no index for filter, we try to find one for ordering
+		orderIndex, canOrderByIndex := r.findOrderingIndex()
 		if canOrderByIndex {
 			r.primaryScan.index = orderIndex
 			r.primaryScan.ordering = r.ordering
@@ -647,6 +656,7 @@ func (r *primaryObjectsRetriever) retrievePrimaryDocs() ([]core.Doc, error) {
 
 	r.primaryScan.fetcher = oldFetcher
 	r.primaryScan.index = oldIndex
+	r.primaryScan.ordering = oldOrdering
 
 	return docs, nil
 }
@@ -772,10 +782,8 @@ func (join *invertibleTypeJoin) fetchRelatedSecondaryDocWithChildren(primaryDoc 
 	if secondSide.isParent {
 		// child primary docs reference the same secondary parent doc. So if we already encountered
 		// the secondary parent doc, we continue to the next primary doc.
-		for i := range join.encounteredDocIDs {
-			if join.encounteredDocIDs[i] == secondaryDocID {
-				return join.Next()
-			}
+		if slices.Contains(join.encounteredDocIDs, secondaryDocID) {
+			return join.Next()
 		}
 		join.encounteredDocIDs = append(join.encounteredDocIDs, secondaryDocID)
 	}

--- a/internal/planner/type_join.go
+++ b/internal/planner/type_join.go
@@ -11,6 +11,8 @@
 package planner
 
 import (
+	"slices"
+
 	"github.com/sourcenetwork/immutable"
 
 	"github.com/sourcenetwork/defradb/client"
@@ -465,6 +467,12 @@ func fetchDocWithIDAndItsSubDocs(node planNode, docID string) (immutable.Option[
 	prefixes := []keys.Walkable{dsKey}
 
 	node.Prefixes(prefixes)
+
+	// Temporarily clear the index for direct docID lookup. When the scan node has an index,
+	// the fetcher uses the index keys instead of the docID prefix, which breaks the lookup.
+	oldIndex := scan.index
+	scan.index = immutable.None[client.IndexDescription]()
+	defer func() { scan.index = oldIndex }()
 
 	if err := node.Init(); err != nil {
 		return immutable.None[core.Doc](), NewErrSubTypeInit(err)

--- a/internal/planner/type_join.go
+++ b/internal/planner/type_join.go
@@ -613,11 +613,17 @@ func (r *primaryObjectsRetriever) retrievePrimaryDocs() ([]core.Doc, error) {
 	oldFetcher := r.primaryScan.fetcher
 	oldIndex := r.primaryScan.index
 
-	r.primaryScan.index = findIndexByFieldName(r.primaryScan.col, r.relIDFieldDef.Name)
+	// we first try to find an index based on sub-filter fields
+	r.primaryScan.index = findIndexByFilteringField(r.primaryScan)
+
+	if !r.primaryScan.index.HasValue() {
+		// if no index can be used for sub-filter fall back to relation ID field index
+		r.primaryScan.index = findIndexByFieldName(r.primaryScan.col, r.relIDFieldDef.Name)
+	}
 
 	canOrderByIndex := false
 
-	// if there is not index for filter, we try to find one for ordering
+	// if there is no index for filter, we try to find one for ordering
 	if !r.primaryScan.index.HasValue() {
 		var orderIndex immutable.Option[client.IndexDescription]
 		orderIndex, canOrderByIndex = r.findOrderingIndex()

--- a/tests/integration/index/query_with_relation_sub_filter_test.go
+++ b/tests/integration/index/query_with_relation_sub_filter_test.go
@@ -541,3 +541,350 @@ func TestQueryWithIndexOnOneToMany_WithSameFilterOnParentAndSubType_ShouldFilter
 
 	testUtils.ExecuteTestCase(t, test)
 }
+
+func TestQueryWithIndexOnOneToMany_WithSameFilterValueOnParentAndSubType_ShouldReturnMatchingDocs(t *testing.T) {
+	req := `query {
+		User(filter: {devices: {model: {_eq: "Walkman"}}}) {
+			name
+			devices(filter: {model: {_eq: "Walkman"}}) {
+				model
+			}
+		}
+	}`
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddSchema{
+				Schema: `
+					type User {
+						name: String @index
+						devices: [Device]
+					}
+					type Device {
+						model: String @index
+						owner: User
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc:          `{"name": "Alice"}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc:          `{"name": "Bob"}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"model": "Walkman",
+					"owner": testUtils.NewDocIndex(0, 0),
+				},
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"model": "iPod",
+					"owner": testUtils.NewDocIndex(0, 0),
+				},
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"model": "Pixel",
+					"owner": testUtils.NewDocIndex(0, 1),
+				},
+			},
+			testUtils.Request{
+				Request: req,
+				Results: map[string]any{
+					"User": []map[string]any{
+						{
+							"name": "Alice",
+							"devices": []map[string]any{
+								{"model": "Walkman"},
+							},
+						},
+					},
+				},
+			},
+			testUtils.Request{
+				Request: makeExplainQuery(req),
+				// 2 indexFetches: 1 for parent filter (Walkman) + 1 for sub-filter (same Walkman)
+				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(2),
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestQueryWithIndexOnOneToMany_WithParentFilterOnRelationAndSubFilterOnDifferentIndexedField_ShouldUseBothIndexes(t *testing.T) {
+	req := `query {
+		User(filter: {devices: {model: {_eq: "Walkman"}}}) {
+			name
+			devices(filter: {manufacturer: {_eq: "Sony"}}) {
+				model
+				manufacturer
+			}
+		}
+	}`
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddSchema{
+				Schema: `
+					type User {
+						name: String @index
+						devices: [Device]
+					}
+					type Device {
+						model: String @index
+						manufacturer: String @index
+						owner: User
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc:          `{"name": "Alice"}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc:          `{"name": "Bob"}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"model":        "Walkman",
+					"manufacturer": "Sony",
+					"owner":        testUtils.NewDocIndex(0, 0),
+				},
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"model":        "Walkman",
+					"manufacturer": "Aiwa",
+					"owner":        testUtils.NewDocIndex(0, 0),
+				},
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"model":        "Walkman",
+					"manufacturer": "Toshiba",
+					"owner":        testUtils.NewDocIndex(0, 0),
+				},
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"model":        "iPod",
+					"manufacturer": "Apple",
+					"owner":        testUtils.NewDocIndex(0, 0),
+				},
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"model":        "Pixel",
+					"manufacturer": "Google",
+					"owner":        testUtils.NewDocIndex(0, 1),
+				},
+			},
+			testUtils.Request{
+				Request: req,
+				Results: map[string]any{
+					"User": []map[string]any{
+						{
+							"name": "Alice",
+							"devices": []map[string]any{
+								{"model": "Walkman", "manufacturer": "Sony"},
+							},
+						},
+					},
+				},
+			},
+			testUtils.Request{
+				Request: makeExplainQuery(req),
+				// 4 indexFetches: 3 for parent filter (3 Walkman devices owned by Alice) + 1 for sub-filter (Sony)
+				// Note: For existence checks, we only need 1 match per user, but currently the index fetcher
+				// doesn't know about parent relationships. https://github.com/sourcenetwork/defradb/issues/4347
+				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(4),
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestQueryWithIndexOnOneToMany_WithParentFilterOnRelationAndSubFilterOnNonIndexedField_ShouldUseParentIndex(t *testing.T) {
+	req := `query {
+		User(filter: {devices: {model: {_eq: "Walkman"}}}) {
+			name
+			devices(filter: {manufacturer: {_eq: "Sony"}}) {
+				model
+				manufacturer
+			}
+		}
+	}`
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddSchema{
+				Schema: `
+					type User {
+						name: String @index
+						devices: [Device]
+					}
+					type Device {
+						model: String @index
+						manufacturer: String
+						owner: User
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc:          `{"name": "Alice"}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc:          `{"name": "Bob"}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"model":        "Walkman",
+					"manufacturer": "Sony",
+					"owner":        testUtils.NewDocIndex(0, 0),
+				},
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"model":        "Walkman",
+					"manufacturer": "Aiwa",
+					"owner":        testUtils.NewDocIndex(0, 0),
+				},
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"model":        "Pixel",
+					"manufacturer": "Google",
+					"owner":        testUtils.NewDocIndex(0, 1),
+				},
+			},
+			testUtils.Request{
+				Request: req,
+				Results: map[string]any{
+					"User": []map[string]any{
+						{
+							"name": "Alice",
+							"devices": []map[string]any{
+								{"model": "Walkman", "manufacturer": "Sony"},
+							},
+						},
+					},
+				},
+			},
+			testUtils.Request{
+				Request: makeExplainQuery(req),
+				// 2 indexFetches: for parent filter (2 Walkman devices owned by Alice), sub-filter applied in-memory
+				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(2),
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestQueryWithIndexOnOneToMany_WithParentFilterOnOwnFieldAndRelationAndSubFilter_ShouldCombineAllFilters(t *testing.T) {
+	req := `query {
+		User(filter: {name: {_eq: "Alice"}, devices: {model: {_eq: "Walkman"}}}) {
+			name
+			devices(filter: {manufacturer: {_eq: "Sony"}}) {
+				model
+				manufacturer
+			}
+		}
+	}`
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddSchema{
+				Schema: `
+					type User {
+						name: String @index
+						devices: [Device]
+					}
+					type Device {
+						model: String @index
+						manufacturer: String @index
+						owner: User
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc:          `{"name": "Alice"}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc:          `{"name": "Bob"}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"model":        "Walkman",
+					"manufacturer": "Sony",
+					"owner":        testUtils.NewDocIndex(0, 0),
+				},
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"model":        "Walkman",
+					"manufacturer": "Aiwa",
+					"owner":        testUtils.NewDocIndex(0, 0),
+				},
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"model":        "iPod",
+					"manufacturer": "Apple",
+					"owner":        testUtils.NewDocIndex(0, 0),
+				},
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"model":        "Walkman",
+					"manufacturer": "Sony",
+					"owner":        testUtils.NewDocIndex(0, 1),
+				},
+			},
+			testUtils.Request{
+				Request: req,
+				Results: map[string]any{
+					"User": []map[string]any{
+						{
+							"name": "Alice",
+							"devices": []map[string]any{
+								{"model": "Walkman", "manufacturer": "Sony"},
+							},
+						},
+					},
+				},
+			},
+			testUtils.Request{
+				Request: makeExplainQuery(req),
+				// 5 indexFetches: 3 device.model fetches (3 Walkman devices: 2 Alice, 1 Bob)
+				// and 2 device.manufacturer fetches (2 Sony devices)
+				// Note: name="Alice" filter is checked after docID lookup (no index)
+				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(5),
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/index/query_with_relation_sub_filter_test.go
+++ b/tests/integration/index/query_with_relation_sub_filter_test.go
@@ -1,0 +1,460 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package index
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/defradb/tests/action"
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+func TestQueryWithIndexOnOneToMany_IfSubFilterOnIndexedField_ShouldFilter(t *testing.T) {
+	req := `query {
+		User {
+			name
+			devices(filter: {model: {_eq: "Walkman"}}) {
+				model
+				manufacturer
+			}
+		}
+	}`
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddSchema{
+				Schema: `
+					type User {
+						name: String
+						devices: [Device]
+					}
+					type Device {
+						model: String @index
+						manufacturer: String
+						owner: User
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc:          `{"name": "Chris"}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"model":        "Walkman",
+					"manufacturer": "Sony",
+					"owner":        testUtils.NewDocIndex(0, 0),
+				},
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"model":        "Discman",
+					"manufacturer": "Sony",
+					"owner":        testUtils.NewDocIndex(0, 0),
+				},
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"model":        "Walkman",
+					"manufacturer": "Aiwa",
+					"owner":        testUtils.NewDocIndex(0, 0),
+				},
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"model":        "iPod",
+					"manufacturer": "Apple",
+					"owner":        testUtils.NewDocIndex(0, 0),
+				},
+			},
+			testUtils.Request{
+				Request: req,
+				Results: map[string]any{
+					"User": []map[string]any{
+						{
+							"name": "Chris",
+							"devices": []map[string]any{
+								{"model": "Walkman", "manufacturer": "Aiwa"},
+								{"model": "Walkman", "manufacturer": "Sony"},
+							},
+						},
+					},
+				},
+				NonOrderedResults: true,
+			},
+			testUtils.Request{
+				Request:  makeExplainQuery(req),
+				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(2),
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestQueryWithIndexOnOneToMany_IfSubFilterOnNonIndexedField_ShouldNotUseIndex(t *testing.T) {
+	req := `query {
+		User {
+			name
+			devices(filter: {manufacturer: {_eq: "Sony"}}) {
+				model
+				manufacturer
+			}
+		}
+	}`
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddSchema{
+				Schema: `
+					type User {
+						name: String
+						devices: [Device]
+					}
+					type Device {
+						model: String @index
+						manufacturer: String
+						owner: User
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc:          `{"name": "Chris"}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"model":        "Walkman",
+					"manufacturer": "Sony",
+					"owner":        testUtils.NewDocIndex(0, 0),
+				},
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"model":        "Discman",
+					"manufacturer": "Sony",
+					"owner":        testUtils.NewDocIndex(0, 0),
+				},
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"model":        "Walkman",
+					"manufacturer": "Aiwa",
+					"owner":        testUtils.NewDocIndex(0, 0),
+				},
+			},
+			testUtils.Request{
+				Request: req,
+				Results: map[string]any{
+					"User": []map[string]any{
+						{
+							"name": "Chris",
+							"devices": []map[string]any{
+								{"model": "Discman", "manufacturer": "Sony"},
+								{"model": "Walkman", "manufacturer": "Sony"},
+							},
+						},
+					},
+				},
+				NonOrderedResults: true,
+			},
+			testUtils.Request{
+				Request:  makeExplainQuery(req),
+				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(0),
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestQueryWithIndexOnOneToMany_IfSubFilterAndOrderOnIndexedField_ShouldUseIndexForFilter(t *testing.T) {
+	req := `query {
+		User {
+			name
+			devices(filter: {model: {_like: "%man"}}, order: {model: ASC}, limit: 2) {
+				model
+			}
+		}
+	}`
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddSchema{
+				Schema: `
+					type User {
+						name: String
+						devices: [Device]
+					}
+					type Device {
+						model: String @index
+						owner: User
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc:          `{"name": "Chris"}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"model": "Walkman",
+					"owner": testUtils.NewDocIndex(0, 0),
+				},
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"model": "Discman",
+					"owner": testUtils.NewDocIndex(0, 0),
+				},
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"model": "Someman",
+					"owner": testUtils.NewDocIndex(0, 0),
+				},
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"model": "Jumpman",
+					"owner": testUtils.NewDocIndex(0, 0),
+				},
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"model": "Galaxy",
+					"owner": testUtils.NewDocIndex(0, 0),
+				},
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"model": "iPod",
+					"owner": testUtils.NewDocIndex(0, 0),
+				},
+			},
+			testUtils.Request{
+				Request: req,
+				Results: map[string]any{
+					"User": []map[string]any{
+						{
+							"name": "Chris",
+							"devices": []map[string]any{
+								{"model": "Discman"},
+								{"model": "Jumpman"},
+							},
+						},
+					},
+				},
+			},
+			testUtils.Request{
+				Request: makeExplainQuery(req),
+				// 3 indexFetches: process indexes in order "Discman", "Galaxy", "Jumpman", stop when 2 found
+				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(3),
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestQueryWithIndexOnOneToMany_WithOrderOnParentAndSubFilter_ShouldFilterPerParent(t *testing.T) {
+	req := `query {
+		User(order: {name: ASC}) {
+			name
+			devices(filter: {model: {_eq: "Walkman"}}) {
+				model
+				manufacturer
+			}
+		}
+	}`
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddSchema{
+				Schema: `
+					type User {
+						name: String @index
+						devices: [Device]
+					}
+					type Device {
+						model: String @index
+						manufacturer: String
+						owner: User
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc:          `{"name": "Alice"}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc:          `{"name": "Bob"}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"model":        "Walkman",
+					"manufacturer": "Sony",
+					"owner":        testUtils.NewDocIndex(0, 0),
+				},
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"model":        "iPod",
+					"manufacturer": "Apple",
+					"owner":        testUtils.NewDocIndex(0, 0),
+				},
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"model":        "Walkman",
+					"manufacturer": "Aiwa",
+					"owner":        testUtils.NewDocIndex(0, 1),
+				},
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"model":        "Discman",
+					"manufacturer": "Sony",
+					"owner":        testUtils.NewDocIndex(0, 1),
+				},
+			},
+			testUtils.Request{
+				Request: req,
+				Results: map[string]any{
+					"User": []map[string]any{
+						{
+							"name": "Alice",
+							"devices": []map[string]any{
+								{"model": "Walkman", "manufacturer": "Sony"},
+							},
+						},
+						{
+							"name": "Bob",
+							"devices": []map[string]any{
+								{"model": "Walkman", "manufacturer": "Aiwa"},
+							},
+						},
+					},
+				},
+			},
+			testUtils.Request{
+				Request: makeExplainQuery(req),
+				// 6 indexFetches: 2 user order + 2 Walkman devices for each user
+				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(6),
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestQueryWithIndexOnOneToMany_WithOrderOnParentAndSubFilter_ShouldFilterBothWithIndexes(t *testing.T) {
+	req := `query {
+		User(filter: {name: {_eq: "Alice"}}) {
+			name
+			devices(filter: {model: {_eq: "Walkman"}}) {
+				model
+				manufacturer
+			}
+		}
+	}`
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddSchema{
+				Schema: `
+					type User {
+						name: String @index
+						devices: [Device]
+					}
+					type Device {
+						model: String @index
+						manufacturer: String
+						owner: User
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc:          `{"name": "Alice"}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc:          `{"name": "Bob"}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"model":        "Walkman",
+					"manufacturer": "Sony",
+					"owner":        testUtils.NewDocIndex(0, 0),
+				},
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"model":        "iPod",
+					"manufacturer": "Apple",
+					"owner":        testUtils.NewDocIndex(0, 0),
+				},
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"model":        "Walkman",
+					"manufacturer": "Aiwa",
+					"owner":        testUtils.NewDocIndex(0, 1),
+				},
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"model":        "Discman",
+					"manufacturer": "Sony",
+					"owner":        testUtils.NewDocIndex(0, 1),
+				},
+			},
+			testUtils.Request{
+				Request: req,
+				Results: map[string]any{
+					"User": []map[string]any{
+						{
+							"name": "Alice",
+							"devices": []map[string]any{
+								{"model": "Walkman", "manufacturer": "Sony"},
+							},
+						},
+					},
+				},
+			},
+			testUtils.Request{
+				Request: makeExplainQuery(req),
+				// 3 indexFetches: 1 for parent filter (Alice) + 2 for Walkman devices
+				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(3),
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/index/query_with_relation_sub_filter_test.go
+++ b/tests/integration/index/query_with_relation_sub_filter_test.go
@@ -458,3 +458,86 @@ func TestQueryWithIndexOnOneToMany_WithOrderOnParentAndSubFilter_ShouldFilterBot
 
 	testUtils.ExecuteTestCase(t, test)
 }
+
+func TestQueryWithIndexOnOneToMany_WithSameFilterOnParentAndSubType_ShouldFilterBothWithIndexes(t *testing.T) {
+	req := `query {
+		User(filter: {devices: {model: {_eq: "Walkman"}}}) {
+			name
+			devices(filter: {model: {_eq: "Galaxy"}}) {
+				model
+			}
+		}
+	}`
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddSchema{
+				Schema: `
+					type User {
+						name: String @index
+						devices: [Device]
+					}
+					type Device {
+						model: String @index
+						owner: User
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc:          `{"name": "Alice"}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc:          `{"name": "Bob"}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"model": "Walkman",
+					"owner": testUtils.NewDocIndex(0, 0),
+				},
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"model": "iPod",
+					"owner": testUtils.NewDocIndex(0, 0),
+				},
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"model": "Galaxy",
+					"owner": testUtils.NewDocIndex(0, 0),
+				},
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"model": "Pixel",
+					"owner": testUtils.NewDocIndex(0, 1),
+				},
+			},
+			testUtils.Request{
+				Request: req,
+				Results: map[string]any{
+					"User": []map[string]any{
+						{
+							"name": "Alice",
+							"devices": []map[string]any{
+								{"model": "Galaxy"},
+							},
+						},
+					},
+				},
+			},
+			testUtils.Request{
+				Request: makeExplainQuery(req),
+				// 2 indexFetches: 1 for parent filter (users with Walkman) + 1 for Galaxy devices
+				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(2),
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/index/query_with_relation_sub_order_test.go
+++ b/tests/integration/index/query_with_relation_sub_order_test.go
@@ -506,7 +506,7 @@ func TestQueryWithOrderOnOneToMany_WithSubFilterAndOrderAndRelationIndex_ShouldF
 							},
 						},
 						{
-							"name": "Fred",
+							"name":      "Fred",
 							"published": []map[string]any{},
 						},
 					},
@@ -606,7 +606,7 @@ func TestQueryWithOrderOnOneToMany_WithParentFilterOnRelationAndSubOrder_ShouldO
 			testUtils.Request{
 				Request: makeExplainQuery(req),
 				// 5 indexFetch: parent filter uses rating index via inverted join (1 book matches _gte: 4.0)
-				// For the matched author full index scan is done to get all 4 books 
+				// For the matched author full index scan is done to get all 4 books
 				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(5),
 			},
 		},

--- a/tests/integration/index/query_with_relation_sub_order_test.go
+++ b/tests/integration/index/query_with_relation_sub_order_test.go
@@ -514,7 +514,7 @@ func TestQueryWithOrderOnOneToMany_WithSubFilterAndOrderAndRelationIndex_ShouldF
 			},
 			testUtils.Request{
 				Request: makeExplainQuery(req),
-				// 6 indexFetches: sub-filter uses rating index (3 books match for each author),
+				// 6 indexFetches: sub-filter uses rating index (3 books match filter rating _ge: 4.0) for 2 authors,
 				// DESC instructs the index to iterate in reverse order, so no in-memory sort needed
 				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(6),
 			},

--- a/tests/integration/index/query_with_relation_sub_order_test.go
+++ b/tests/integration/index/query_with_relation_sub_order_test.go
@@ -428,3 +428,189 @@ func TestQueryWithOrderOnOneToMany_WithMultipleAuthorsAndIndexOnRelation_ShouldO
 	testUtils.ExecuteTestCase(t, test)
 }
 
+func TestQueryWithOrderOnOneToMany_WithSubFilterAndOrderAndRelationIndex_ShouldFilterThenOrder(t *testing.T) {
+	req := `query {
+		Author {
+			name
+			published(filter: {rating: {_ge: 4.0}}, order: {rating: DESC}) {
+				title
+				rating
+			}
+		}
+	}`
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddSchema{
+				Schema: `
+					type Author {
+						name: String
+						published: [Book]
+					}
+					type Book {
+						title: String
+						rating: Float @index
+						author: Author @index
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc:          `{"name": "John"}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc:          `{"name": "Fred"}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"title":  "Book1",
+					"rating": 3.5,
+					"author": testUtils.NewDocIndex(0, 0),
+				},
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"title":  "Book2",
+					"rating": 4.8,
+					"author": testUtils.NewDocIndex(0, 0),
+				},
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"title":  "Book3",
+					"rating": 4.2,
+					"author": testUtils.NewDocIndex(0, 0),
+				},
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"title":  "Book4",
+					"rating": 4.4,
+					"author": testUtils.NewDocIndex(0, 0),
+				},
+			},
+			testUtils.Request{
+				Request: req,
+				Results: map[string]any{
+					"Author": []map[string]any{
+						{
+							"name": "John",
+							"published": []map[string]any{
+								{"title": "Book2", "rating": 4.8},
+								{"title": "Book4", "rating": 4.4},
+								{"title": "Book3", "rating": 4.2},
+							},
+						},
+						{
+							"name": "Fred",
+							"published": []map[string]any{},
+						},
+					},
+				},
+			},
+			testUtils.Request{
+				Request: makeExplainQuery(req),
+				// 6 indexFetches: sub-filter uses rating index (3 books match for each author),
+				// DESC instructs the index to iterate in reverse order, so no in-memory sort needed
+				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(6),
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestQueryWithOrderOnOneToMany_WithParentFilterOnRelationAndSubOrder_ShouldOrderChildren(t *testing.T) {
+	req := `query {
+		Author(filter: {published: {rating: {_ge: 4.0}}}) {
+			name
+			published(order: {rating: DESC}) {
+				title
+				rating
+			}
+		}
+	}`
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddSchema{
+				Schema: `
+					type Author {
+						name: String
+						published: [Book]
+					}
+					type Book {
+						title: String
+						rating: Float @index
+						author: Author
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc:          `{"name": "Alice"}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc:          `{"name": "Bob"}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"title":  "Book A1",
+					"rating": 4.8,
+					"author": testUtils.NewDocIndex(0, 0),
+				},
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"title":  "Book A2",
+					"rating": 3.5,
+					"author": testUtils.NewDocIndex(0, 0),
+				},
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"title":  "Book B1",
+					"rating": 2.5,
+					"author": testUtils.NewDocIndex(0, 1),
+				},
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"title":  "Book B2",
+					"rating": 3.0,
+					"author": testUtils.NewDocIndex(0, 1),
+				},
+			},
+			testUtils.Request{
+				Request: req,
+				Results: map[string]any{
+					"Author": []map[string]any{
+						{
+							"name": "Alice",
+							"published": []map[string]any{
+								{"title": "Book A1", "rating": 4.8},
+								{"title": "Book A2", "rating": 3.5},
+							},
+						},
+					},
+				},
+			},
+			testUtils.Request{
+				Request: makeExplainQuery(req),
+				// 5 indexFetch: parent filter uses rating index via inverted join (1 book matches _gte: 4.0)
+				// For the matched author full index scan is done to get all 4 books 
+				Asserter: testUtils.NewExplainAsserter().WithIndexFetches(5),
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/index/query_with_relation_sub_order_test.go
+++ b/tests/integration/index/query_with_relation_sub_order_test.go
@@ -330,3 +330,101 @@ func TestQueryWithOrderOnOneToMany_WithMultipleAuthors_ShouldOrderEachAuthorsBoo
 
 	testUtils.ExecuteTestCase(t, test)
 }
+
+func TestQueryWithOrderOnOneToMany_WithMultipleAuthorsAndIndexOnRelation_ShouldOrderEachAuthorsBooks(t *testing.T) {
+	req := `query {
+		Author(order: {name: ASC}) {
+			name
+			published(order: {rating: DESC}) {
+				title
+				rating
+			}
+		}
+	}`
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddSchema{
+				Schema: `
+					type Author {
+						name: String
+						published: [Book]
+					}
+					type Book {
+						title: String
+						rating: Float @index
+						author: Author @index
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc:          `{"name": "Alice"}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc:          `{"name": "Bob"}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"title":  "Book A1",
+					"rating": 3.5,
+					"author": testUtils.NewDocIndex(0, 0),
+				},
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"title":  "Book A2",
+					"rating": 4.8,
+					"author": testUtils.NewDocIndex(0, 0),
+				},
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"title":  "Book B1",
+					"rating": 4.0,
+					"author": testUtils.NewDocIndex(0, 1),
+				},
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"title":  "Book B2",
+					"rating": 2.5,
+					"author": testUtils.NewDocIndex(0, 1),
+				},
+			},
+			testUtils.Request{
+				Request: req,
+				Results: map[string]any{
+					"Author": []map[string]any{
+						{
+							"name": "Alice",
+							"published": []map[string]any{
+								{"title": "Book A2", "rating": 4.8},
+								{"title": "Book A1", "rating": 3.5},
+							},
+						},
+						{
+							"name": "Bob",
+							"published": []map[string]any{
+								{"title": "Book B1", "rating": 4.0},
+								{"title": "Book B2", "rating": 2.5},
+							},
+						},
+					},
+				},
+			},
+			testUtils.Request{
+				Request: makeExplainQuery(req),
+				// index fetches 4: relation ID index fetches 2 books per author, then sorts in memory
+				Asserter: testUtils.NewExplainAsserter().WithOrder().WithIndexFetches(4),
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4343

## Description

This change makes planner check if there are any filters on sub-queries that can be processed by indexes.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Integration tests

Specify the platform(s) on which this was tested:
- MacOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Ordering support for one-to-many relation queries with propagation of child ordering so results honor requested sorts when possible.

* **Bug Fixes**
  * Improved filter propagation and join handling to avoid parent/child filter conflicts and preserve correct ordering, with smarter index selection for ordered retrieval.

* **Tests**
  * Added comprehensive integration tests covering relation sub-filters, ordering, per-parent limits, and explain/index behaviors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->