### PR TITLE
Fix: Preserve parent filter when inverting join direction for index optimization.

### DIFF
--- a/internal/planner/type_join.go
+++ b/internal/planner/type_join.go
@@ -836,6 +836,15 @@ func (join *invertibleTypeJoin) invertJoinDirectionWithIndex(
 	ordering []mapper.OrderCondition,
 ) error {
 	childScan := getNode[*scanNode](join.childSide.plan)
+	parentScan := getNode[*scanNode](join.parentSide.plan)
+
+	// Preserve the parent's filter when inverting the join. After inversion,
+	// docs are fetched from the parent via foreign key, so the original parent
+	// filter must still be applied.
+	if parentScan != nil && parentScan.filter != nil {
+		join.subFilter = filter.Merge(join.subFilter, parentScan.filter)
+	}
+
 	childScan.tryAddFieldWithName(request.ToFieldID(join.childSide.relFieldDef.Value().Name))
 	// replace child's filter with the filter that utilizes the index
 	// the original child's filter is stored in join.subFilter

--- a/tests/integration/index/query_with_index_and_relation_filter_test.go
+++ b/tests/integration/index/query_with_index_and_relation_filter_test.go
@@ -1,0 +1,227 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package index
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/defradb/tests/action"
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+// TestQueryWithIndex_FilterOnIndexedFieldAndRelation_ShouldAND tests that when filtering
+// by both an indexed field on the root type AND fields on a related type, the filters are
+// combined with AND semantics, not OR.
+func TestQueryWithIndex_FilterOnIndexedFieldAndRelation_ShouldAND(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddSchema{
+				Schema: `
+					type User {
+						publicID: String @index(unique: true)
+						isEnabled: Boolean
+						passkeys: [PasskeyCredential]
+					}
+					
+					type PasskeyCredential {
+						credentialID: String @index(unique: true)
+						user: User
+					}
+				`,
+			},
+			// Create a user
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `{
+					"publicID": "user-abc-123",
+					"isEnabled": true
+				}`,
+			},
+			// Create 3 passkey credentials for the same user
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"credentialID": "credential-1",
+					"user":         testUtils.NewDocIndex(0, 0),
+				},
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"credentialID": "credential-2",
+					"user":         testUtils.NewDocIndex(0, 0),
+				},
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"credentialID": "credential-3",
+					"user":         testUtils.NewDocIndex(0, 0),
+				},
+			},
+			// Query for a specific credentialID AND user conditions
+			// Should return only 1 result (credential-2), not all 3
+			testUtils.Request{
+				Request: `query {
+					PasskeyCredential(filter: {
+						credentialID: {_eq: "credential-2"},
+						user: {
+							isEnabled: {_eq: true},
+							publicID: {_eq: "user-abc-123"}
+						}
+					}) {
+						credentialID
+						user {
+							publicID
+						}
+					}
+				}`,
+				Results: map[string]any{
+					"PasskeyCredential": []map[string]any{
+						{
+							"credentialID": "credential-2",
+							"user": map[string]any{
+								"publicID": "user-abc-123",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+// TestQueryWithIndex_FilterOnIndexedFieldAndRelation_NoMatch tests that when conditions
+// don't match on both sides, no documents are returned.
+func TestQueryWithIndex_FilterOnIndexedFieldAndRelation_NoMatch(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddSchema{
+				Schema: `
+					type User {
+						publicID: String @index(unique: true)
+						isEnabled: Boolean
+						passkeys: [PasskeyCredential]
+					}
+					
+					type PasskeyCredential {
+						credentialID: String @index(unique: true)
+						user: User
+					}
+				`,
+			},
+			// Create a user
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `{
+					"publicID": "user-abc-123",
+					"isEnabled": true
+				}`,
+			},
+			// Create passkey credential
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"credentialID": "credential-1",
+					"user":         testUtils.NewDocIndex(0, 0),
+				},
+			},
+			// Query for non-existent credentialID but matching user
+			// Should return 0 results (AND semantics)
+			// If OR semantics are used, it would incorrectly return 1 result
+			testUtils.Request{
+				Request: `query {
+					PasskeyCredential(filter: {
+						credentialID: {_eq: "non-existent"},
+						user: {
+							isEnabled: {_eq: true},
+							publicID: {_eq: "user-abc-123"}
+						}
+					}) {
+						credentialID
+					}
+				}`,
+				Results: map[string]any{
+					"PasskeyCredential": []map[string]any{},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+// TestQueryWithIndex_FilterOnIndexedFieldAndRelation_WrongUser tests that when the
+// user conditions don't match, no documents are returned even if credentialID matches.
+func TestQueryWithIndex_FilterOnIndexedFieldAndRelation_WrongUser(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddSchema{
+				Schema: `
+					type User {
+						publicID: String @index(unique: true)
+						isEnabled: Boolean
+						passkeys: [PasskeyCredential]
+					}
+					
+					type PasskeyCredential {
+						credentialID: String @index(unique: true)
+						user: User
+					}
+				`,
+			},
+			// Create two users
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `{
+					"publicID": "user-1",
+					"isEnabled": true
+				}`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0,
+				Doc: `{
+					"publicID": "user-2",
+					"isEnabled": true
+				}`,
+			},
+			// Create credential for user-1
+			testUtils.CreateDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"credentialID": "credential-1",
+					"user":         testUtils.NewDocIndex(0, 0),
+				},
+			},
+			// Query for credential-1 but with user-2's publicID
+			// Should return 0 results (AND semantics)
+			testUtils.Request{
+				Request: `query {
+					PasskeyCredential(filter: {
+						credentialID: {_eq: "credential-1"},
+						user: {
+							publicID: {_eq: "user-2"}
+						}
+					}) {
+						credentialID
+					}
+				}`,
+				Results: map[string]any{
+					"PasskeyCredential": []map[string]any{},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4314

## Description

Fixes filters being lost when join direction is inverted for index optimization. When filtering on both an indexed root field and relation fields, the root filter was discarded during join inversion, causing incorrect results.

**Bug:**
```graphql
PasskeyCredential(filter: {
  credentialID: {_eq: "credential-2"},
  user: {publicID: {_eq: "user-abc-123"}}
})
```
- Expected: 1 result
- Actual: 3 results (root filter ignored)

**Fix:**
Preserve parent filter in `subFilter` during join inversion in [invertJoinDirectionWithIndex](cci:1://file:///home/sharanrp/Desktop/projects/defradb/internal/planner/type_join.go:832:0-859:1).

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Added 3 test cases in [tests/integration/index/query_with_index_and_relation_filter_test.go](cci:7://file:///home/sharanrp/Desktop/projects/defradb/tests/integration/index/query_with_index_and_relation_filter_test.go:0:0-0:0):

1. [TestQueryWithIndex_FilterOnIndexedFieldAndRelation_ShouldAND](cci:1://file:///home/sharanrp/Desktop/projects/defradb/tests/integration/index/query_with_index_and_relation_filter_test.go:19:0-101:1) - verifies correct AND behavior
2. [TestQueryWithIndex_FilterOnIndexedFieldAndRelation_NoMatch](cci:1://file:///home/sharanrp/Desktop/projects/defradb/tests/integration/index/query_with_index_and_relation_filter_test.go:103:0-161:1) - verifies no false positives
3. [TestQueryWithIndex_FilterOnIndexedFieldAndRelation_WrongUser](cci:1://file:///home/sharanrp/Desktop/projects/defradb/tests/integration/index/query_with_index_and_relation_filter_test.go:163:0-226:1) - verifies relation filtering

All tests pass. No regressions in existing index/relation tests.

**Run:**
```bash
go test -v -run "TestQueryWithIndex_FilterOnIndexedFieldAndRelation" ./tests/integration/index/...
```

Tested on:
- Linux

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filter application when combining indexed fields with relation filters to ensure correct filtering semantics.

* **Tests**
  * Added integration tests validating AND semantics for indexed field and relation filter combinations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->