### PR TITLE
fix: Prevent self-deadlock in abLock

### DIFF
--- a/internal/db/lock/ab_lock.go
+++ b/internal/db/lock/ab_lock.go
@@ -17,39 +17,134 @@ import (
 // abLock provides a mechanism that allows two competing action sets to block
 // the other without blocking other members of its set.
 //
-// LockA will prevent LockB from being acquired, but it will not prevent
+// LockA will prevent LockB from being acquired by other transactions, but it will not prevent
 // other LockAs from being acquired, and vice versa.
+//
+// When a transaction already holds a lock of one type and tries to acquire the opposite type,
+// it will wait for OTHER transactions' locks to be released, but not its own. This prevents
+// self-deadlock while maintaining proper lock semantics - the transaction will hold both
+// lock types and properly block other transactions.
 //
 // Acquired locks are released on transaction close.
 type abLock struct {
-	aGroup sync.WaitGroup
-	bGroup sync.WaitGroup
+	mu       sync.Mutex
+	initOnce sync.Once
+
+	// cond is used to signal when lock counts change
+	cond *sync.Cond
+
+	// aCount tracks the total number of A-locks held (across all transactions)
+	aCount int
+	// bCount tracks the total number of B-locks held (across all transactions)
+	bCount int
+
+	// aHolders tracks how many A-locks each transaction holds (by txn ID)
+	aHolders map[uint64]int
+	// bHolders tracks how many B-locks each transaction holds (by txn ID)
+	bHolders map[uint64]int
 }
 
+// init initializes the abLock if needed (lazy initialization)
+func (l *abLock) init() {
+	l.initOnce.Do(func() {
+		l.cond = sync.NewCond(&l.mu)
+		l.aHolders = make(map[uint64]int)
+		l.bHolders = make(map[uint64]int)
+	})
+}
+
+// LockA acquires an A-lock for the given transaction.
+//
+// This will block until all B-locks held by OTHER transactions are released.
+// If this transaction already holds B-locks, those are excluded from the wait.
 func (l *abLock) LockA(txn txn) {
-	l.aGroup.Add(1)
+	l.init()
+	l.mu.Lock()
 
-	// We need to make sure this is only ever called once!  It is permitted to discard
-	// a transaction after it is commited whether it errors or not.
-	var once sync.Once
-	done := func() { once.Do(func() { l.aGroup.Done() }) }
-	txn.OnDiscard(done)
-	txn.OnError(done)
-	txn.OnSuccess(done)
+	txnID := txn.ID()
 
-	l.bGroup.Wait()
+	// Count of B-locks held by OTHER transactions
+	otherBCount := l.bCount - l.bHolders[txnID]
+
+	// Wait until all OTHER transactions' B-locks are released
+	for otherBCount > 0 {
+		l.cond.Wait()
+		otherBCount = l.bCount - l.bHolders[txnID]
+	}
+
+	// Acquire the A-lock
+	l.aCount++
+	l.aHolders[txnID]++
+
+	// If this is the first lock of any kind for this transaction,
+	// register cleanup callbacks
+	needRegister := l.aHolders[txnID] == 1 && l.bHolders[txnID] == 0
+
+	l.mu.Unlock()
+
+	if needRegister {
+		l.registerCleanup(txn, txnID)
+	}
 }
 
+// LockB acquires a B-lock for the given transaction.
+//
+// This will block until all A-locks held by OTHER transactions are released.
+// If this transaction already holds A-locks, those are excluded from the wait.
 func (l *abLock) LockB(txn txn) {
-	l.bGroup.Add(1)
+	l.init()
+	l.mu.Lock()
 
-	// We need to make sure this is only ever called once!  It is permitted to discard
-	// a transaction after it is commited whether it errors or not.
+	txnID := txn.ID()
+
+	// Count of A-locks held by OTHER transactions
+	otherACount := l.aCount - l.aHolders[txnID]
+
+	// Wait until all OTHER transactions' A-locks are released
+	for otherACount > 0 {
+		l.cond.Wait()
+		otherACount = l.aCount - l.aHolders[txnID]
+	}
+
+	// Acquire the B-lock
+	l.bCount++
+	l.bHolders[txnID]++
+
+	// If this is the first lock of any kind for this transaction,
+	// register cleanup callbacks
+	needRegister := l.bHolders[txnID] == 1 && l.aHolders[txnID] == 0
+
+	l.mu.Unlock()
+
+	if needRegister {
+		l.registerCleanup(txn, txnID)
+	}
+}
+
+// registerCleanup registers transaction close callbacks to release all locks
+// held by this transaction.
+func (l *abLock) registerCleanup(txn txn, txnID uint64) {
 	var once sync.Once
-	done := func() { once.Do(func() { l.bGroup.Done() }) }
-	txn.OnDiscard(done)
-	txn.OnError(done)
-	txn.OnSuccess(done)
+	cleanup := func() {
+		once.Do(func() {
+			l.mu.Lock()
+			// Release all A-locks held by this transaction
+			if count := l.aHolders[txnID]; count > 0 {
+				l.aCount -= count
+				delete(l.aHolders, txnID)
+			}
+			// Release all B-locks held by this transaction
+			if count := l.bHolders[txnID]; count > 0 {
+				l.bCount -= count
+				delete(l.bHolders, txnID)
+			}
+			// Signal waiting goroutines that locks have been released
+			l.cond.Broadcast()
+			l.mu.Unlock()
+		})
+	}
 
-	l.aGroup.Wait()
+	txn.OnDiscard(cleanup)
+	txn.OnError(cleanup)
+	txn.OnSuccess(cleanup)
 }

--- a/internal/db/lock/lock_set_test.go
+++ b/internal/db/lock/lock_set_test.go
@@ -237,29 +237,26 @@ func TestLockSet_ClosingTxnMultipleTimes_Succedes(t *testing.T) {
 	txn1.Close()
 }
 
-// todo - This (and the reverse, lock then RLockAll) is the only known case when a
-// transaction can deadlock on itself.
-//
-// It is not known to happen in production at the moment, but it is possible to introduce it
-// if not paying attention.
-//
-// https://github.com/sourcenetwork/defradb/issues/4311
-func TestLockSet_RLockAllAndLockSameTxn_Deadlocks(t *testing.T) {
+// This verifies that a transaction can hold both RLockAll and Lock without deadlocking.
+func TestLockSet_RLockAllAndLockSameTxn_DoNotDeadlock(t *testing.T) {
 	txn1 := newTxn(1)
 	lockSet := newLockSet[int]()
 
 	lockSet.RLockAll(txn1)
+	// This call should not block - the same transaction should be able to acquire
+	// both the RLockAll (B-lock) and Lock (A-lock) without deadlocking.
+	lockSet.Lock(txn1, 1)
+}
 
-	require.Never(
-		t,
-		func() bool {
-			// This call should never complete, because txn1 has read locked everything
-			lockSet.Lock(txn1, 1)
-			return true
-		},
-		timeout,
-		timeout,
-	)
+// This verifies that the reverse order (Lock then RLockAll) also works.
+func TestLockSet_LockAndRLockAllSameTxn_DoNotDeadlock(t *testing.T) {
+	txn1 := newTxn(1)
+	lockSet := newLockSet[int]()
+
+	lockSet.Lock(txn1, 1)
+	// This call should not block - the same transaction should be able to acquire
+	// both the Lock (A-lock) and RLockAll (B-lock) without deadlocking.
+	lockSet.RLockAll(txn1)
 }
 
 func TestLockSet_RLockAllAndLockDifferentTxn_Deadlocks(t *testing.T) {
@@ -274,6 +271,56 @@ func TestLockSet_RLockAllAndLockDifferentTxn_Deadlocks(t *testing.T) {
 		func() bool {
 			// This call should never complete, because txn1 has read locked everything
 			lockSet.Lock(txn2, 1)
+			return true
+		},
+		timeout,
+		timeout,
+	)
+}
+
+// This verifies that when txn1 holds both RLockAll and Lock, other transactions
+// are still properly blocked - the fix must maintain lock semantics.
+func TestLockSet_RLockAllThenLockSameTxn_BlocksOtherTxnRLockAll(t *testing.T) {
+	txn1 := newTxn(1)
+	txn2 := newTxn(2)
+	lockSet := newLockSet[int]()
+
+	// txn1 acquires RLockAll (B-lock), then Lock (A-lock)
+	// After fix, txn1 should hold both locks
+	lockSet.RLockAll(txn1)
+	lockSet.Lock(txn1, 1)
+
+	require.Never(
+		t,
+		func() bool {
+			// This call should block because txn1 holds an A-lock (via Lock)
+			// and RLockAll needs to wait for all A-locks to complete
+			lockSet.RLockAll(txn2)
+			return true
+		},
+		timeout,
+		timeout,
+	)
+}
+
+// This verifies that when txn1 holds both Lock and RLockAll (reverse order),
+// other transactions are still properly blocked.
+func TestLockSet_LockThenRLockAllSameTxn_BlocksOtherTxnLock(t *testing.T) {
+	txn1 := newTxn(1)
+	txn2 := newTxn(2)
+	lockSet := newLockSet[int]()
+
+	// txn1 acquires Lock (A-lock), then RLockAll (B-lock)
+	// After fix, txn1 should hold both locks
+	lockSet.Lock(txn1, 1)
+	lockSet.RLockAll(txn1)
+
+	require.Never(
+		t,
+		func() bool {
+			// This call should block because txn1 holds a B-lock (via RLockAll)
+			// and Lock needs to wait for all B-locks to complete
+			lockSet.Lock(txn2, 2)
 			return true
 		},
 		timeout,


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4311

## Description

This PR fixes a potential deadlock in the lock system when the same transaction holds both [RLockAll](cci:1://file:///home/sharanrp/Desktop/projects/defradb/internal/db/lock/lock.go:53:0-55:1) and a write [Lock](cci:1://file:///home/sharanrp/Desktop/projects/defradb/internal/db/lock/lock_set.go:108:0-198:1) at the same time.

**The Problem:**
The [abLock](cci:2://file:///home/sharanrp/Desktop/projects/defradb/internal/db/lock/ab_lock.go:26:0-36:1) mechanism uses two WaitGroups (A-group and B-group) where:
- [Lock](cci:1://file:///home/sharanrp/Desktop/projects/defradb/internal/db/lock/lock_set.go:108:0-198:1) (write) acquires an A-lock and waits for all B-locks to complete
- [RLockAll](cci:1://file:///home/sharanrp/Desktop/projects/defradb/internal/db/lock/lock.go:53:0-55:1) acquires a B-lock and waits for all A-locks to complete

When the same transaction holds a B-lock (via [RLockAll](cci:1://file:///home/sharanrp/Desktop/projects/defradb/internal/db/lock/lock.go:53:0-55:1)) and then tries to acquire an A-lock (via [Lock](cci:1://file:///home/sharanrp/Desktop/projects/defradb/internal/db/lock/lock_set.go:108:0-198:1)), it waits for its own B-lock to release → **deadlock**.

**The Fix:**
Added transaction ownership tracking to [abLock](cci:2://file:///home/sharanrp/Desktop/projects/defradb/internal/db/lock/ab_lock.go:26:0-36:1). When a transaction already holds a B-lock and tries to acquire an A-lock (or vice versa), the blocking wait is skipped since the transaction owns both locks.

This is currently "dead code" as noted in the issue, but prevents future bugs if code changes are made without awareness of this constraint.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

- Updated existing test `TestLockSet_RLockAllAndLockSameTxn_Deadlocks` → [TestLockSet_RLockAllAndLockSameTxn_DoNotDeadlock](cci:1://file:///home/sharanrp/Desktop/projects/defradb/internal/db/lock/lock_set_test.go:239:0-248:1) to verify the fix
- Added new test [TestLockSet_LockAndRLockAllSameTxn_DoNotDeadlock](cci:1://file:///home/sharanrp/Desktop/projects/defradb/internal/db/lock/lock_set_test.go:250:0-259:1) for reverse lock order
- Ran full lock package test suite: `go test -v ./internal/db/lock/...` (19 tests pass)
- Ran with race detector: `go test -race -v ./internal/db/lock/...` (all pass)

Specify the platform(s) on which this was tested:
-  Linux