### PR TITLE
fix: Add missing return after successful merge execution

### DIFF
--- a/internal/db/merge.go
+++ b/internal/db/merge.go
@@ -72,6 +72,7 @@ func (db *DB) Merge(ctx context.Context, evt event.Merge) error {
 		if err != nil {
 			return err
 		}
+		return nil
 	}
 	return nil
 }


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4355

## Description

This PR fixes a bug in the merge retry loop where the function was missing a `return nil` statement after successful execution.

**The problem:** In `internal/db/merge.go` the `Merge()` function's retry loop  didn't return on success, causing the loop to continue iterating. This resulted in every merge operation running up to `MaxTxnRetries` times instead of exiting immediately after the first successful execution.

**Why it went unnoticed:**
- Merging is idempotent, so repeated execution produces the same result
- Existing tests call `executeMerge()` directly, bypassing the retry loop

**The fix:** Added `return nil` after the successful execution case to exit the loop immediately.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Ran existing merge unit tests to verify the fix doesn't break current functionality


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Merge operation now stops retrying once a merge completes successfully, reducing unnecessary retry cycles and improving merge completion time.
  * Behavior for conflict and error handling remains unchanged to preserve expected failure semantics.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->