### PR TITLE
feat(i): Remove blocks when truncating

### DIFF
--- a/internal/db/collection_truncate.go
+++ b/internal/db/collection_truncate.go
@@ -272,7 +272,7 @@ func (c *collection) hardDeleteDocumentBlocks(
 		return err
 	}
 
-	keysToDelete := make([][]byte, 0, hardDeleteChunkSize)
+	keysToDelete := make([]keys.HeadstoreDocKey, 0, hardDeleteChunkSize)
 	// If there are more keys than we wish to load into memory at once, this will be set to
 	// true, and we'll continue the delete in another pass.
 	hasMore := true
@@ -287,7 +287,12 @@ func (c *collection) hardDeleteDocumentBlocks(
 			break
 		}
 
-		keysToDelete = append(keysToDelete, iter.Key())
+		key, err := keys.NewHeadstoreDocKey(string(iter.Key()))
+		if err != nil {
+			return errors.Join(err, iter.Close())
+		}
+
+		keysToDelete = append(keysToDelete, key)
 	}
 
 	err = iter.Close()
@@ -295,11 +300,18 @@ func (c *collection) hardDeleteDocumentBlocks(
 		return err
 	}
 
+	blockstore := txn.Blockstore()
+
 	for _, key := range keysToDelete {
 		// Not all store implementations support mutations whilst iterating, so whilst it would
 		// be simpler and probably more efficient to delete whilst iterating, it would not work
 		// with all supported corekv store implementations.
-		err := headstore.Delete(ctx, key)
+		err := headstore.Delete(ctx, key.Bytes())
+		if err != nil {
+			return err
+		}
+
+		err = blockstore.DeleteBlock(ctx, key.Cid)
 		if err != nil {
 			return err
 		}

--- a/internal/db/collection_truncate.go
+++ b/internal/db/collection_truncate.go
@@ -254,7 +254,6 @@ func (c *collection) hardDeleteDocumentBlocks(
 	ctx context.Context,
 	docID string,
 ) error {
-
 	txn := datastore.CtxMustGetTxn(ctx)
 
 	headstore := txn.Headstore()

--- a/internal/db/collection_truncate.go
+++ b/internal/db/collection_truncate.go
@@ -94,9 +94,7 @@ func (c *collection) truncate(
 		return err
 	}
 
-	err = c.hardDeleteHeadstorePrefix(ctx, keys.HeadstoreColKey{
-		CollectionShortID: shortID,
-	})
+	err = c.hardDeleteCollectionBlocks(ctx, shortID)
 	if err != nil {
 		return err
 	}
@@ -173,9 +171,7 @@ func (c *collection) hardDeleteDocKeysAndHeadstore(
 		// Because the datastore read-locks are only ever released when the transaction closes,
 		// we do not need to worry about timing or order-of-operation issues, *unless* we change
 		// when the datastore read-locks are released.
-		err = c.hardDeleteHeadstorePrefix(ctx, keys.HeadstoreDocKey{
-			DocID: key.DocID,
-		})
+		err = c.hardDeleteDocumentBlocks(ctx, key.DocID)
 		if err != nil {
 			return err
 		}
@@ -256,13 +252,17 @@ func (c *collection) hardDeleteDatastorePrefix(
 	return nil
 }
 
-func (c *collection) hardDeleteHeadstorePrefix(
+func (c *collection) hardDeleteDocumentBlocks(
 	ctx context.Context,
-	prefix keys.Key,
+	docID string,
 ) error {
+
 	txn := datastore.CtxMustGetTxn(ctx)
 
 	headstore := txn.Headstore()
+	prefix := keys.HeadstoreDocKey{
+		DocID: docID,
+	}
 
 	iter, err := headstore.Iterator(ctx, corekv.IterOptions{
 		Prefix:   prefix.Bytes(),
@@ -306,7 +306,66 @@ func (c *collection) hardDeleteHeadstorePrefix(
 	}
 
 	if hasMore {
-		return c.hardDeleteHeadstorePrefix(ctx, prefix)
+		return c.hardDeleteDocumentBlocks(ctx, docID)
+	}
+
+	return nil
+}
+
+func (c *collection) hardDeleteCollectionBlocks(
+	ctx context.Context,
+	shortID uint32,
+) error {
+	txn := datastore.CtxMustGetTxn(ctx)
+
+	headstore := txn.Headstore()
+	prefix := keys.HeadstoreColKey{
+		CollectionShortID: shortID,
+	}
+
+	iter, err := headstore.Iterator(ctx, corekv.IterOptions{
+		Prefix:   prefix.Bytes(),
+		KeysOnly: true,
+	})
+	if err != nil {
+		return err
+	}
+
+	keysToDelete := make([][]byte, 0, hardDeleteChunkSize)
+	// If there are more keys than we wish to load into memory at once, this will be set to
+	// true, and we'll continue the delete in another pass.
+	hasMore := true
+
+	for i := 0; i < hardDeleteChunkSize; i++ {
+		hasNext, err := iter.Next()
+		if err != nil {
+			return errors.Join(err, iter.Close())
+		}
+		if !hasNext {
+			hasMore = false
+			break
+		}
+
+		keysToDelete = append(keysToDelete, iter.Key())
+	}
+
+	err = iter.Close()
+	if err != nil {
+		return err
+	}
+
+	for _, key := range keysToDelete {
+		// Not all store implementations support mutations whilst iterating, so whilst it would
+		// be simpler and probably more efficient to delete whilst iterating, it would not work
+		// with all supported corekv store implementations.
+		err := headstore.Delete(ctx, key)
+		if err != nil {
+			return err
+		}
+	}
+
+	if hasMore {
+		return c.hardDeleteCollectionBlocks(ctx, shortID)
 	}
 
 	return nil

--- a/internal/db/collection_truncate.go
+++ b/internal/db/collection_truncate.go
@@ -343,7 +343,7 @@ func (c *collection) hardDeleteCollectionBlocks(
 		return err
 	}
 
-	keysToDelete := make([][]byte, 0, hardDeleteChunkSize)
+	keysToDelete := make([]keys.HeadstoreColKey, 0, hardDeleteChunkSize)
 	// If there are more keys than we wish to load into memory at once, this will be set to
 	// true, and we'll continue the delete in another pass.
 	hasMore := true
@@ -358,7 +358,12 @@ func (c *collection) hardDeleteCollectionBlocks(
 			break
 		}
 
-		keysToDelete = append(keysToDelete, iter.Key())
+		key, err := keys.NewHeadstoreColKeyFromString(string(iter.Key()))
+		if err != nil {
+			return errors.Join(err, iter.Close())
+		}
+
+		keysToDelete = append(keysToDelete, key)
 	}
 
 	err = iter.Close()
@@ -366,11 +371,18 @@ func (c *collection) hardDeleteCollectionBlocks(
 		return err
 	}
 
+	blockstore := txn.Blockstore()
+
 	for _, key := range keysToDelete {
 		// Not all store implementations support mutations whilst iterating, so whilst it would
 		// be simpler and probably more efficient to delete whilst iterating, it would not work
 		// with all supported corekv store implementations.
-		err := headstore.Delete(ctx, key)
+		err := headstore.Delete(ctx, key.Bytes())
+		if err != nil {
+			return err
+		}
+
+		err = blockstore.DeleteBlock(ctx, key.Cid)
 		if err != nil {
 			return err
 		}

--- a/internal/db/collection_truncate.go
+++ b/internal/db/collection_truncate.go
@@ -48,8 +48,6 @@ func (c *collection) Truncate(
 	return txn.Commit()
 }
 
-// todo - this function should also remove relevant blocks from the blockstore.
-// https://github.com/sourcenetwork/defradb/issues/4324
 func (c *collection) truncate(
 	ctx context.Context,
 ) error {


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4324

## Description

Removes the relevant document and collection blocks when truncating.

They are removed within the truncate transaction, as there is no guarantee that the transaction will successfully commit just because all the sub-operations within the truncate call succeed.

## How has this been tested?

This change is untested, beyond knowing that it doesn't error.

The removal of the blocks having already removed the heads is internal to Defra, if, we do not consider the blockstore public.  This PR is really just a storage optimisation IMO, and one that is too much of a pain to bother testing at the moment - for stores like badger, it's probably not even going to shrink the reserved disk space (at least for smaller data sets).

Please do let me know if you disagree with this!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked internal deletion flows for collections and documents to use dedicated, consistent deletion paths.
  * Switched to concrete key handling and construction instead of raw byte manipulation for more robust processing.
  * Deletions now run in chunked, recursive batches and remove both metadata and block data per chunk.
  * Preserves transactional locking semantics while improving reliability and efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->