### PR TITLE
feat: Refresh materialized views on create

### DIFF
--- a/client/db.go
+++ b/client/db.go
@@ -228,6 +228,9 @@ type Store interface {
 	// Use AddLens to store a lens and obtain its CID before calling AddView.
 	// The transform will execute after the query has run. It is not limited to just transforming
 	// the input documents - it may also yield new ones, or filter out those passed in from the underlying query.
+	//
+	// If the view being added is materialized, the results will be generated and cached during this call.  This
+	// may take some time if the dataset is large.
 	AddView(
 		ctx context.Context,
 		gqlQuery string,

--- a/internal/db/view.go
+++ b/internal/db/view.go
@@ -95,6 +95,17 @@ func (db *DB) addView(
 		return nil, err
 	}
 
+	for _, view := range returnDescriptions {
+		if view.Query.HasValue() && view.IsMaterialized {
+			err := db.refreshViews(ctx, client.CollectionFetchOptions{
+				VersionID: immutable.Some(view.VersionID),
+			})
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
 	return returnDescriptions, nil
 }
 

--- a/tests/action/create_view.go
+++ b/tests/action/create_view.go
@@ -11,6 +11,7 @@
 package action
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/sourcenetwork/immutable"
@@ -52,27 +53,43 @@ var _ Stateful = (*CreateView)(nil)
 func (a *CreateView) Execute() {
 	sdl := a.SDL
 
-	if a.s.ViewType == state.MaterializedViewType {
-		typeIndex := strings.Index(sdl, "\ttype ")
-		if typeIndex == -1 {
-			a.s.T.Fatal("materialized view SDL must contain '\ttype ' declaration")
-			return
+	switch {
+	case strings.Contains(sdl, "@materialized(if: false)"):
+		if a.s.ViewType == state.MaterializedViewType {
+			sdl = strings.ReplaceAll(sdl, "@materialized(if: false)", "@materialized(if: true)")
 		}
 
-		subStrSquigglyIndex := strings.Index(sdl[typeIndex:], "{")
-		if subStrSquigglyIndex == -1 {
-			a.s.T.Fatal("materialized view SDL type declaration must contain '{'")
-			return
+	case strings.Contains(sdl, "@materialized(if: true)"):
+		if a.s.ViewType == state.CachelessViewType {
+			sdl = strings.ReplaceAll(sdl, "@materialized(if: true)", "@materialized(if: false)")
 		}
 
-		squigglyIndex := typeIndex + subStrSquigglyIndex
-		sdl = strings.Join([]string{
-			sdl[:squigglyIndex],
-			"@",
-			types.MaterializedDirectiveLabel,
-			sdl[squigglyIndex:],
-			"",
-		}, "")
+	default:
+		if a.s.ViewType == state.MaterializedViewType {
+			typeIndex := strings.Index(sdl, "\ttype ")
+			if typeIndex == -1 {
+				a.s.T.Fatal("materialized view SDL must contain '\ttype ' declaration")
+				return
+			}
+
+			subStrSquigglyIndex := strings.Index(sdl[typeIndex:], "{")
+			if subStrSquigglyIndex == -1 {
+				a.s.T.Fatal("materialized view SDL type declaration must contain '{'")
+				return
+			}
+
+			squigglyIndex := typeIndex + subStrSquigglyIndex
+			sdl = strings.Join([]string{
+				sdl[:squigglyIndex],
+				"@",
+				types.MaterializedDirectiveLabel,
+				"(if: ",
+				fmt.Sprint(a.s.ViewType == state.MaterializedViewType),
+				") ",
+				sdl[squigglyIndex:],
+				"",
+			}, "")
+		}
 	}
 
 	nodeIDs, nodes := getNodesWithIDs(a.NodeID, a.s.Nodes)

--- a/tests/integration/collection_version/updates/remove/view_test.go
+++ b/tests/integration/collection_version/updates/remove/view_test.go
@@ -167,6 +167,10 @@ func TestColVersionUpdateRemoveMaterializedViewWithUnrefreshedData(t *testing.T)
 
 func TestColVersionUpdateRemoveMaterializedViewWithRefreshedData(t *testing.T) {
 	test := testUtils.TestCase{
+		SupportedViewTypes: immutable.Some([]testUtils.ViewType{
+			// The expected error should only occur when using a materialized view.
+			testUtils.MaterializedViewType,
+		}),
 		Actions: []any{
 			&action.AddSchema{
 				Schema: `

--- a/tests/integration/test_case.go
+++ b/tests/integration/test_case.go
@@ -572,6 +572,10 @@ type Request struct {
 	// Used to identify the transaction for this to run against. Optional.
 	TransactionID immutable.Option[int]
 
+	// Materialized views are automatically refreshed immediately before executing this Request, unless
+	// this property is set to true.
+	DoNotRefreshViews bool
+
 	// OperationName sets the operation name option for the request.
 	OperationName immutable.Option[string]
 

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -1828,7 +1828,7 @@ nodeLoop:
 			options = append(options, client.WithVariables(action.Variables.Value()))
 		}
 
-		if !expectedErrorRaised && viewType == MaterializedViewType {
+		if !action.DoNotRefreshViews && !expectedErrorRaised && viewType == MaterializedViewType {
 			for _, colName := range s.CollectionNames {
 				// Refresh the views in the order in which they were declared, this way
 				// any views of views should be based off of refreshed data, assuming they were declared in

--- a/tests/integration/view/simple/materialized_test.go
+++ b/tests/integration/view/simple/materialized_test.go
@@ -97,7 +97,6 @@ func TestView_SimpleMaterialized_RefreshesAfterEarlierRefresh(t *testing.T) {
 					}
 				`,
 			},
-			&action.RefreshViews{},
 			testUtils.CreateDoc{
 				Doc: `{
 					"name":	"Fred"

--- a/tests/integration/view/simple/materialized_test.go
+++ b/tests/integration/view/simple/materialized_test.go
@@ -73,10 +73,7 @@ func TestView_SimpleMaterialized_DoesNotAutoUpdateOnViewCreate(t *testing.T) {
 func TestView_SimpleMaterialized_DoesNotAutoUpdate(t *testing.T) {
 	test := testUtils.TestCase{
 		SupportedViewTypes: immutable.Some([]testUtils.ViewType{
-			// As the MaterializedViewType will auto refresh views immediately prior
-			// to executing requests, this test of materialized views actually only
-			// supports running with the CachelessViewType flag.
-			testUtils.CachelessViewType,
+			testUtils.MaterializedViewType,
 		}),
 		Actions: []any{
 			&action.AddSchema{
@@ -110,6 +107,9 @@ func TestView_SimpleMaterialized_DoesNotAutoUpdate(t *testing.T) {
 				}`,
 			},
 			testUtils.Request{
+				// Disable the test framework's auto-refreshing of views for this test
+				// so that we may verify the behaviour when the views are not refreshed
+				DoNotRefreshViews: true,
 				Request: `query {
 							UserView {
 								name

--- a/tests/integration/view/simple/materialized_test.go
+++ b/tests/integration/view/simple/materialized_test.go
@@ -47,6 +47,10 @@ func TestView_SimpleMaterialized_AutoUpdatesOnViewCreate(t *testing.T) {
 				`,
 			},
 			testUtils.Request{
+				// We are testing that the refresh occurs on view create, so we must disable
+				// the test framework's auto-refresh done within this Request's execution in
+				// order to test it.
+				DoNotRefreshViews: true,
 				Request: `query {
 							UserView {
 								name

--- a/tests/integration/view/simple/materialized_test.go
+++ b/tests/integration/view/simple/materialized_test.go
@@ -67,6 +67,71 @@ func TestView_SimpleMaterialized_AutoUpdatesOnViewCreate(t *testing.T) {
 
 	testUtils.ExecuteTestCase(t, test)
 }
+func TestView_SimpleMaterialized_RefreshesAfterEarlierRefresh(t *testing.T) {
+	test := testUtils.TestCase{
+		SupportedViewTypes: immutable.Some([]testUtils.ViewType{
+			testUtils.MaterializedViewType,
+		}),
+		Actions: []any{
+			&action.AddSchema{
+				Schema: `
+					type User {
+						name: String
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
+					"name":	"John"
+				}`,
+			},
+			&action.CreateView{
+				Query: `
+					User {
+						name
+					}
+				`,
+				SDL: `
+					type UserView {
+						name: String
+					}
+				`,
+			},
+			&action.RefreshViews{},
+			testUtils.CreateDoc{
+				Doc: `{
+					"name":	"Fred"
+				}`,
+			},
+			// Refresh the view after an earlier refresh (with data).  We had a bug here
+			// where RefreshViews would fail only if there was already data in the view cache.
+			&action.RefreshViews{},
+			testUtils.Request{
+				// It doesn't really matter if it refreshes again, but it is a bit wasteful,
+				// and it is nicer to be explicit for this test.
+				DoNotRefreshViews: true,
+				NonOrderedResults: true,
+				Request: `query {
+							UserView {
+								name
+							}
+						}`,
+				Results: map[string]any{
+					"UserView": []map[string]any{
+						{
+							"name": "John",
+						},
+						{
+							"name": "Fred",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
 
 func TestView_SimpleMaterialized_DoesNotAutoUpdate(t *testing.T) {
 	test := testUtils.TestCase{

--- a/tests/integration/view/simple/materialized_test.go
+++ b/tests/integration/view/simple/materialized_test.go
@@ -19,14 +19,8 @@ import (
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
 )
 
-func TestView_SimpleMaterialized_DoesNotAutoUpdateOnViewCreate(t *testing.T) {
+func TestView_SimpleMaterialized_AutoUpdatesOnViewCreate(t *testing.T) {
 	test := testUtils.TestCase{
-		SupportedViewTypes: immutable.Some([]testUtils.ViewType{
-			// As the MaterializedViewType will auto refresh views immediately prior
-			// to executing requests, this test of materialized views actually only
-			// supports running with the CachelessViewType flag.
-			testUtils.CachelessViewType,
-		}),
 		Actions: []any{
 			&action.AddSchema{
 				Schema: `
@@ -60,8 +54,12 @@ func TestView_SimpleMaterialized_DoesNotAutoUpdateOnViewCreate(t *testing.T) {
 						}`,
 				Results: map[string]any{
 					// Even though UserView was created after the document was created, the results are
-					// empty because the view will not populate until RefreshView is called.
-					"UserView": []map[string]any{},
+					// present because the view will automatically referesh upon its creation.
+					"UserView": []map[string]any{
+						{
+							"name": "John",
+						},
+					},
 				},
 			},
 		},

--- a/tests/integration/view/simple/materialized_test.go
+++ b/tests/integration/view/simple/materialized_test.go
@@ -54,7 +54,7 @@ func TestView_SimpleMaterialized_AutoUpdatesOnViewCreate(t *testing.T) {
 						}`,
 				Results: map[string]any{
 					// Even though UserView was created after the document was created, the results are
-					// present because the view will automatically referesh upon its creation.
+					// present because the view will automatically refresh upon its creation.
 					"UserView": []map[string]any{
 						{
 							"name": "John",


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4161

## Description

Refresh materialized views on create.

Also reworks the view-type multiplier, as it was only working when the test did not already declare the `@materialized` directive - and thanks to a change a while ago which flipped the defaults, most of our tests were explicitly declaring the directive, rendering the multiplier useless.
