### PR TITLE
fix: Correctly refresh views with already cached data

### DIFF
--- a/internal/keys/datastore_view_item.go
+++ b/internal/keys/datastore_view_item.go
@@ -56,6 +56,8 @@ func NewViewCacheKeyFromRaw(raw []byte) (ViewCacheKey, error) {
 		return ViewCacheKey{}, nil
 	}
 
+	raw, _ = bytes.CutPrefix(raw, []byte(COLLECTION_VIEW_ITEMS+"/"))
+
 	components := bytes.Split(raw, []byte("/"))
 	if len(components) > 2 {
 		return ViewCacheKey{}, ErrInvalidKey


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4381

## Description

Correctly refresh views with already cached data.

This was broken out of https://github.com/sourcenetwork/defradb/pull/4379 - that PR closes the test gap that permitted this.