### PR TITLE
test: Add truncate parallel test

### DIFF
--- a/tests/action/assert_request.go
+++ b/tests/action/assert_request.go
@@ -256,7 +256,10 @@ func assertRequestResultDoc(
 			}
 
 		case DocIndex:
+			s.DocIDsLock.RLock()
 			expectedDocID := s.DocIDs[expectedValue.CollectionIndex][expectedValue.Index].String()
+			s.DocIDsLock.RUnlock()
+
 			if ordered {
 				assertResultsEqual(
 					s.T,

--- a/tests/action/create_doc.go
+++ b/tests/action/create_doc.go
@@ -70,6 +70,16 @@ type CreateDoc struct {
 	// String can be a partial, and the test will pass if an error is returned that
 	// contains this string.
 	ExpectedError string
+
+	// If this property true, then the action will not wait for the event(s) that it triggers
+	// to be broadcasted.
+	//
+	// This was introduced as the function used to wait for events currently assumes that a single
+	// action will be executed at any given moment.  This is no longer true for all tests.
+	//
+	// Setting this property to true whilst testing P2P functionality will probably result in a
+	// flaky test.
+	DoNotWaitForEvent bool
 }
 
 var _ Action = (*CreateDoc)(nil)
@@ -117,18 +127,20 @@ func (a *CreateDoc) Execute() {
 
 	assertExpectedErrorRaised(a.s.T, a.ExpectedError, expectedErrorRaised)
 
+	a.s.DocIDsLock.Lock()
 	if a.CollectionID >= len(a.s.DocIDs) {
 		// Expand the slice if required, so that the document can be accessed by collection index
 		a.s.DocIDs = append(a.s.DocIDs, make([][]client.DocID, a.CollectionID-len(a.s.DocIDs)+1)...)
 	}
 	a.s.DocIDs[a.CollectionID] = append(a.s.DocIDs[a.CollectionID], docIDs...)
+	a.s.DocIDsLock.Unlock()
 
 	docIDMap := make(map[string]struct{})
 	for _, docID := range docIDs {
 		docIDMap[docID.String()] = struct{}{}
 	}
 
-	if a.ExpectedError == "" {
+	if a.ExpectedError == "" && !a.DoNotWaitForEvent {
 		waitForUpdateEvents(a.s, a.NodeID, a.CollectionID, docIDMap, a.Identity)
 	}
 }
@@ -276,7 +288,9 @@ func substituteRelations(
 			continue
 		}
 
+		s.DocIDsLock.RLock()
 		docID := s.DocIDs[index.CollectionIndex][index.Index]
+		s.DocIDsLock.RUnlock()
 		action.DocMap[k] = docID.String()
 	}
 }

--- a/tests/action/parallel.go
+++ b/tests/action/parallel.go
@@ -44,25 +44,35 @@ func (a *Parallel) SetState(s *state.State) {
 func (a *Parallel) Execute() {
 	// startLock is responsible for ensuring that all child actions are scheduled/ready before
 	// any of them begin execution.
-	startWG := sync.WaitGroup{}
-	startWG.Add(len(a.Children))
+	startLock := sync.RWMutex{}
+	startLock.Lock()
 
 	// finishedWG is responsible for ensuring that all child actions complete their execution
 	// before this action-function unblocks/completes.
 	finishedWG := sync.WaitGroup{}
 
+	// childrenReady is responsible for ensuring that all child routines have been set up and are
+	// now waiting for the start lock to be unlocked.
+	childrenReady := sync.WaitGroup{}
 	for _, childAction := range a.Children {
+		childrenReady.Add(1)
 		finishedWG.Go(func() {
+			childrenReady.Done()
+
 			// Block behind the startWG until all child actions are ready to proceed
-			startWG.Done()
+			startLock.RLock()
+			defer startLock.RUnlock()
 
 			childAction.Execute()
 		})
 	}
 
+	// Wait for all the children to be ready before allowing them to start.
+	childrenReady.Wait()
+
 	// Release the start lock once all child actions are queued so that they may all begin at
 	// as close a point in time as the runtime/machine allows.
-	startWG.Wait()
+	startLock.Unlock()
 
 	finishedWG.Wait()
 }

--- a/tests/action/parallel.go
+++ b/tests/action/parallel.go
@@ -1,0 +1,68 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package action
+
+import (
+	"sync"
+
+	"github.com/sourcenetwork/defradb/tests/state"
+)
+
+// Parallel executes all child actions in their own child go-routine, scheduled to start as
+// close in time as the runtime will allow.
+//
+// This action will not complete it's execution until all child actions have completed their
+// execution.
+type Parallel struct {
+	s *state.State
+
+	// The child actions that should be executed in parallel.
+	Children []Action
+}
+
+var _ Action = (*Parallel)(nil)
+var _ Stateful = (*Parallel)(nil)
+
+func (a *Parallel) SetState(s *state.State) {
+	a.s = s
+
+	for _, child := range a.Children {
+		if stateful, ok := child.(Stateful); ok {
+			stateful.SetState(s)
+		}
+	}
+}
+
+func (a *Parallel) Execute() {
+	// startLock is responsible for ensuring that all child actions are scheduled/ready before
+	// any of them begin execution.
+	startWG := sync.WaitGroup{}
+	startWG.Add(len(a.Children))
+
+	// finishedWG is responsible for ensuring that all child actions complete their execution
+	// before this action-function unblocks/completes.
+	finishedWG := sync.WaitGroup{}
+
+	for _, childAction := range a.Children {
+		finishedWG.Go(func() {
+			// Block behind the startWG until all child actions are ready to proceed
+			startWG.Done()
+
+			childAction.Execute()
+		})
+	}
+
+	// Release the start lock once all child actions are queued so that they may all begin at
+	// as close a point in time as the runtime/machine allows.
+	startWG.Wait()
+
+	finishedWG.Wait()
+}

--- a/tests/action/replace.go
+++ b/tests/action/replace.go
@@ -29,9 +29,14 @@ import (
 // sets.
 var templateDataGenerators = map[string]func(*state.State, int) map[string]string{
 	"CID": func(s *state.State, nodeID int) map[string]string {
+		s.Nodes[nodeID].CompositesLock.RLock()
+		defer s.Nodes[nodeID].CompositesLock.RUnlock()
 		docIDsToCIDs := s.Nodes[nodeID].Composites
 
 		res := map[string]string{}
+
+		s.DocIDsLock.RLock()
+		defer s.DocIDsLock.RUnlock()
 		for colIndex, docIndexes := range s.DocIDs {
 			for docIndex, docID := range docIndexes {
 				cids := docIDsToCIDs[docID.String()]

--- a/tests/action/utils_events.go
+++ b/tests/action/utils_events.go
@@ -69,6 +69,8 @@ func waitForUpdateEvents(
 						require.Fail(s.T, "subscription closed waiting for update event", "Node %d", i)
 					}
 					evt, _ = msg.Data.(event.Update)
+
+					node.CompositesLock.Lock()
 					// We keep track of the list of cids for all documents in the test
 					// in case we want to use them in subsequent test actions without having
 					// to know in advance what the CID will be.
@@ -76,6 +78,7 @@ func waitForUpdateEvents(
 						node.Composites = make(map[string][]cid.Cid)
 					}
 					node.Composites[evt.DocID] = append(node.Composites[evt.DocID], evt.Cid)
+					node.CompositesLock.Unlock()
 
 					if !evt.IsRelay {
 						break relayCheck
@@ -112,11 +115,13 @@ func updateNetworkState(s *state.State, nodeID int, evt event.Update, ident immu
 	}
 	docIndex := -1
 	if collectionID != -1 {
+		s.DocIDsLock.RLock()
 		for i, docID := range s.DocIDs[collectionID] {
 			if docID.String() == evt.DocID {
 				docIndex = i
 			}
 		}
+		s.DocIDsLock.RUnlock()
 	}
 
 	node := s.Nodes[nodeID]

--- a/tests/action/wait_for_peer_events.go
+++ b/tests/action/wait_for_peer_events.go
@@ -91,7 +91,10 @@ func (a *WaitForPeersEvents) Execute() {
 	}
 
 	for colDocIndex, peerNodeIDs := range a.ExpectedPeersByDocument {
+		a.s.DocIDsLock.RLock()
 		docID := a.s.DocIDs[colDocIndex.Col][colDocIndex.Doc]
+		a.s.DocIDsLock.RUnlock()
+
 		topic := docID.String()
 		addExpectedPeers(topic, peerNodeIDs)
 	}

--- a/tests/integration/acp_dac.go
+++ b/tests/integration/acp_dac.go
@@ -319,7 +319,9 @@ func getCollectionAndDocInfo(s *state.State, collectionID, docInd, nodeID int) (
 		collectionName = collection.Version().Name
 
 		if docInd != -1 {
+			s.DocIDsLock.RLock()
 			docID = s.DocIDs[collectionID][docInd].String()
+			s.DocIDsLock.RUnlock()
 		}
 	}
 	return collectionName, docID

--- a/tests/integration/collection/truncate/parallel_test.go
+++ b/tests/integration/collection/truncate/parallel_test.go
@@ -41,16 +41,19 @@ func TestCollectionTruncateParallel_DeletesAllPreviouslyExistingDocuments(t *tes
 			&action.Parallel{
 				Children: []action.Action{
 					&action.CreateDoc{
+						DoNotWaitForEvent: true,
 						DocMap: map[string]any{
 							"name": "Fred",
 						},
 					},
 					&action.CreateDoc{
+						DoNotWaitForEvent: true,
 						DocMap: map[string]any{
 							"name": "Shahzad",
 						},
 					},
 					&action.CreateDoc{
+						DoNotWaitForEvent: true,
 						DocMap: map[string]any{
 							"name": "Chris",
 						},

--- a/tests/integration/collection/truncate/parallel_test.go
+++ b/tests/integration/collection/truncate/parallel_test.go
@@ -1,0 +1,94 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package truncate
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/defradb/tests/action"
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+func TestCollectionTruncateParallel_DeletesAllPreviouslyExistingDocuments(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddSchema{
+				Schema: `
+					type Users {
+						name: String
+					}
+				`,
+			},
+			// Create the first docs before parallel, so that deletion can be verified
+			&action.CreateDoc{
+				DocMap: map[string]any{
+					"name": "John",
+				},
+			},
+			&action.CreateDoc{
+				DocMap: map[string]any{
+					"name": "Islam",
+				},
+			},
+			&action.Parallel{
+				Children: []action.Action{
+					&action.CreateDoc{
+						DocMap: map[string]any{
+							"name": "Fred",
+						},
+					},
+					&action.CreateDoc{
+						DocMap: map[string]any{
+							"name": "Shahzad",
+						},
+					},
+					&action.CreateDoc{
+						DocMap: map[string]any{
+							"name": "Chris",
+						},
+					},
+					&action.Request{
+						// Filter by a name that doesn't exist, this will scan the entire collection, and
+						// because it does not exist, we don't have to worry about a complicated result-assert
+						//
+						// We just add this action in to try and protect against any errors/panics/etc that might
+						// come about from it - it should never have an impact on the end result.
+						Request: `query {
+							Users(filter: {name: {_eq: "Keenan"}}) {
+								name
+							}
+						}`,
+						Results: map[string]any{
+							"Users": []map[string]any{},
+						},
+					},
+					&action.Truncate{},
+				},
+			},
+			// After the concurrent action has completed, make sure that `John` and `Islam` dont exist.
+			//
+			// Other documents might exist depending on the order of execution, and this test does not care,
+			// and cannot guarantee, which ones will exist when this action executes.
+			&action.Request{
+				Request: `query {
+					Users(filter: {_or: [{name: {_eq: "John"}},{name: {_eq: "Islam"}}]}) {
+						name
+					}
+				}`,
+				Results: map[string]any{
+					"Users": []map[string]any{},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/events.go
+++ b/tests/integration/events.go
@@ -166,6 +166,8 @@ func waitForUpdateEvents(
 						require.Fail(s.T, "subscription closed waiting for update event", "Node %d", i)
 					}
 					evt = msg.Data.(event.Update)
+
+					node.CompositesLock.Lock()
 					// We keep track of the list of cids for all documents in the test
 					// in case we want to use them in subsequent test actions without having
 					// to know in advance what the CID will be.
@@ -173,6 +175,7 @@ func waitForUpdateEvents(
 						node.Composites = make(map[string][]cid.Cid)
 					}
 					node.Composites[evt.DocID] = append(node.Composites[evt.DocID], evt.Cid)
+					node.CompositesLock.Unlock()
 
 					if !evt.IsRelay {
 						break relayCheck
@@ -250,6 +253,7 @@ func waitForMergeEvents(s *state.State, action WaitForSync) {
 
 func waitForSESync(s *state.State, action WaitForSESync) {
 	var docIDsToWait []string
+	s.DocIDsLock.RLock()
 	if len(action.DocIDs) > 0 {
 		for _, docIndex := range action.DocIDs {
 			if len(s.DocIDs[0]) <= docIndex {
@@ -263,6 +267,7 @@ func waitForSESync(s *state.State, action WaitForSESync) {
 			docIDsToWait = append(docIDsToWait, docID.String())
 		}
 	}
+	s.DocIDsLock.RUnlock()
 
 	// SE sync events are only published on replicator nodes (nodes that receive artifacts)
 	// We wait for events from any non-source node with active replicators
@@ -306,11 +311,13 @@ func updateNetworkState(s *state.State, nodeID int, evt event.Update, ident immu
 	}
 	docIndex := -1
 	if collectionID != -1 {
+		s.DocIDsLock.RLock()
 		for i, docID := range s.DocIDs[collectionID] {
 			if docID.String() == evt.DocID {
 				docIndex = i
 			}
 		}
+		s.DocIDsLock.RUnlock()
 	}
 
 	node := s.Nodes[nodeID]
@@ -369,7 +376,9 @@ func updateConnectedNodes(
 // getEventsForUpdateDoc returns a map of docIDs that should be
 // published to the local event bus after an UpdateDoc action.
 func getEventsForUpdateDoc(s *state.State, action UpdateDoc) map[string]struct{} {
+	s.DocIDsLock.RLock()
 	docID := s.DocIDs[action.CollectionID][action.DocID]
+	s.DocIDsLock.RUnlock()
 
 	docMap := make(map[string]any)
 	err := json.Unmarshal([]byte(action.Doc), &docMap)

--- a/tests/integration/p2p.go
+++ b/tests/integration/p2p.go
@@ -159,7 +159,9 @@ func syncDocs(s *state.State, action SyncDocs) {
 
 	docIDStrings := make([]string, len(action.DocIDs))
 	for i, docIndex := range action.DocIDs {
+		s.DocIDsLock.RLock()
 		docIDStrings[i] = s.DocIDs[action.CollectionID][docIndex].String()
+		s.DocIDsLock.RUnlock()
 	}
 
 	collectionName := s.Nodes[action.NodeID].Collections[action.CollectionID].Name()
@@ -180,10 +182,12 @@ func syncDocs(s *state.State, action SyncDocs) {
 	assertExpectedErrorRaised(s.T, action.ExpectedError, expectedErrorRaised)
 
 	if !expectedErrorRaised {
+		s.DocIDsLock.RLock()
 		for i, docInd := range action.DocIDs {
 			nodeID := action.SourceNodes[i]
 			docID := s.DocIDs[action.CollectionID][docInd].String()
 			node.P2P.ExpectedDAGHeads[docID] = s.Nodes[nodeID].P2P.ActualDAGHeads[docID].CID
 		}
+		s.DocIDsLock.RUnlock()
 	}
 }

--- a/tests/integration/p2p_document.go
+++ b/tests/integration/p2p_document.go
@@ -115,7 +115,10 @@ func subscribeToDocument(
 			continue
 		}
 
+		s.DocIDsLock.RLock()
 		docID := s.DocIDs[colDocIndex.Col][colDocIndex.Doc]
+		s.DocIDsLock.RUnlock()
+
 		docIDs = append(docIDs, docID.String())
 	}
 
@@ -150,7 +153,10 @@ func unsubscribeToDocument(
 			continue
 		}
 
+		s.DocIDsLock.RLock()
 		docID := s.DocIDs[colDocIndex.Col][colDocIndex.Doc]
+		s.DocIDsLock.RUnlock()
+
 		docIDs = append(docIDs, docID.String())
 	}
 
@@ -179,7 +185,10 @@ func getAllP2PDocuments(
 ) {
 	expectedDocuments := []string{}
 	for _, colDocIndex := range action.ExpectedDocIDs {
+		s.DocIDsLock.RLock()
 		docID := s.DocIDs[colDocIndex.Col][colDocIndex.Doc]
+		s.DocIDsLock.RUnlock()
+
 		expectedDocuments = append(expectedDocuments, docID.String())
 	}
 

--- a/tests/integration/replace.go
+++ b/tests/integration/replace.go
@@ -24,10 +24,13 @@ import (
 // sets.
 var templateDataGenerators = map[string]func(*state.State, int) map[string]string{
 	"CID": func(s *state.State, nodeID int) map[string]string {
-
+		s.Nodes[nodeID].CompositesLock.RLock()
+		defer s.Nodes[nodeID].CompositesLock.RUnlock()
 		docIDsToCIDs := s.Nodes[nodeID].Composites
 
 		res := map[string]string{}
+		s.DocIDsLock.RLock()
+		defer s.DocIDsLock.RUnlock()
 		for colIndex, docIndexes := range s.DocIDs {
 			for docIndex, docID := range docIndexes {
 				cids := docIDsToCIDs[docID.String()]

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -994,11 +994,13 @@ func refreshDocuments(
 	// For now just do the initial setup using the collections on the first node,
 	// this may need to become more involved at a later date depending on testing
 	// requirements.
+	s.DocIDsLock.Lock()
 	s.DocIDs = make([][]client.DocID, len(s.Nodes[0].Collections))
 
 	for i := range s.Nodes[0].Collections {
 		s.DocIDs[i] = []client.DocID{}
 	}
+	s.DocIDsLock.Unlock()
 
 	for i := 0; i < startActionIndex; i++ {
 		// We need to add the existing documents in the order in which the test case lists them
@@ -1020,11 +1022,18 @@ func refreshDocuments(
 				// the test will fail later anyway
 				continue
 			}
+
+			s.Nodes[firstNodesID].CompositesLock.Lock()
 			if s.Nodes[firstNodesID].Composites == nil {
 				s.Nodes[firstNodesID].Composites = make(map[string][]cid.Cid)
 			}
+			s.Nodes[firstNodesID].CompositesLock.Unlock()
+
 			for _, doc := range docs {
+				s.DocIDsLock.Lock()
 				s.DocIDs[action.CollectionID] = append(s.DocIDs[action.CollectionID], doc.ID())
+				s.DocIDsLock.Unlock()
+
 				// We fetch the list of composite commits for the document so that
 				// they can be referenced later in the test if required.
 				result := s.Nodes[firstNodesID].Client.ExecRequest(s.Ctx, `query ($docID: ID!) {
@@ -1038,10 +1047,13 @@ func refreshDocuments(
 					if commits, ok := data["_commits"].([]map[string]any); ok {
 						for _, commit := range commits {
 							cid := cid.MustParse(commit[request.CidFieldName].(string))
+
+							s.Nodes[firstNodesID].CompositesLock.Lock()
 							s.Nodes[firstNodesID].Composites[doc.ID().String()] = append(
 								s.Nodes[firstNodesID].Composites[doc.ID().String()],
 								cid,
 							)
+							s.Nodes[firstNodesID].CompositesLock.Unlock()
 						}
 					}
 				}
@@ -1087,7 +1099,10 @@ func substituteRelations(
 			continue
 		}
 
+		s.DocIDsLock.RLock()
 		docID := s.DocIDs[index.CollectionIndex][index.Index]
+		s.DocIDsLock.RUnlock()
+
 		action.DocMap[k] = docID.String()
 	}
 }
@@ -1098,7 +1113,9 @@ func deleteDoc(
 	s *state.State,
 	action DeleteDoc,
 ) {
+	s.DocIDsLock.RLock()
 	docID := s.DocIDs[action.CollectionID][action.DocID]
+	s.DocIDsLock.RUnlock()
 
 	var expectedErrorRaised bool
 
@@ -1188,7 +1205,11 @@ func updateDocViaColSave(
 ) error {
 	ctx := getContextWithIdentity(s.Ctx, s, action.Identity, nodeIndex)
 
-	doc, err := collection.Get(ctx, s.DocIDs[action.CollectionID][action.DocID], true)
+	s.DocIDsLock.RLock()
+	docID := s.DocIDs[action.CollectionID][action.DocID]
+	s.DocIDsLock.RUnlock()
+
+	doc, err := collection.Get(ctx, docID, true)
 	if err != nil {
 		return err
 	}
@@ -1208,7 +1229,11 @@ func updateDocViaColUpdate(
 ) error {
 	ctx := getContextWithIdentity(s.Ctx, s, action.Identity, nodeIndex)
 
-	doc, err := collection.Get(ctx, s.DocIDs[action.CollectionID][action.DocID], true)
+	s.DocIDsLock.RLock()
+	docID := s.DocIDs[action.CollectionID][action.DocID]
+	s.DocIDsLock.RUnlock()
+
+	doc, err := collection.Get(ctx, docID, true)
 	if err != nil {
 		return err
 	}
@@ -1226,7 +1251,9 @@ func updateDocViaGQL(
 	nodeIndex int,
 	collection client.Collection,
 ) error {
+	s.DocIDsLock.RLock()
 	docID := s.DocIDs[action.CollectionID][action.DocID]
+	s.DocIDsLock.RUnlock()
 
 	input, err := jsonToGQL(action.Doc)
 	require.NoError(s.T, err)

--- a/tests/state/state.go
+++ b/tests/state/state.go
@@ -12,6 +12,7 @@ package state
 
 import (
 	"context"
+	"sync"
 	"testing"
 
 	"github.com/ipfs/go-cid"
@@ -212,7 +213,8 @@ type NodeState struct {
 	// restarted with the same address configuration.
 	CachedAddresses []string
 	// Map of docIDs to their composite CIDs.
-	Composites map[string][]cid.Cid
+	Composites     map[string][]cid.Cid
+	CompositesLock sync.RWMutex
 }
 
 // State contains all testing State.
@@ -296,7 +298,8 @@ type State struct {
 	//
 	// Each index is assumed to be global, and may be expected across multiple
 	// nodes.
-	DocIDs [][]client.DocID
+	DocIDs     [][]client.DocID
+	DocIDsLock sync.RWMutex
 
 	// IsBench indicates wether the test is currently being benchmarked.
 	IsBench bool
@@ -335,7 +338,11 @@ func (s *State) GetIdentity(ident Identity) acpIdentity.Identity {
 }
 
 func (s *State) GetDocID(collectionIndex, docIndex int) client.DocID {
-	return s.DocIDs[collectionIndex][docIndex]
+	s.DocIDsLock.RLock()
+	docID := s.DocIDs[collectionIndex][docIndex]
+	s.DocIDsLock.RUnlock()
+
+	return docID
 }
 
 // NewState returns a new fresh state for the given testCase.


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4325

## Description

Adds a truncate parallel test, making sure that all previously existing documents are deleted.

## How has this been tested?

Executed locally (Linux), and re-running the CI a couple of times.
