### PR TITLE
fix: Test matcher subscription bug

### DIFF
--- a/tests/integration/subscription/with_commit_test.go
+++ b/tests/integration/subscription/with_commit_test.go
@@ -174,8 +174,6 @@ func TestCommitSubscription_WithCommitLinksCreateMutations_ValidLinks(t *testing
 }
 
 func TestCommitSubscription_WithDocFilterAndMultipleMutations_FilteredDoc(t *testing.T) {
-	updateCid := testUtils.NewSameValue()
-
 	docID := "bae-45e90427-d499-598b-902a-6a3c65d0b504"
 	test := testUtils.TestCase{
 		Actions: []any{
@@ -197,7 +195,15 @@ func TestCommitSubscription_WithDocFilterAndMultipleMutations_FilteredDoc(t *tes
 					{
 						"_commits": []map[string]any{
 							{
-								"cid":   updateCid,
+								"cid":   "bafyreib5dvg3wkm722kietpvx5gmfueilyvywyiz2tl44q6xnhv4bedcpq",
+								"docID": docID,
+							},
+						},
+					},
+					{
+						"_commits": []map[string]any{
+							{
+								"cid":   "bafyreiapbvksu6q6clclkp6ximlffdzpfy3edbi3nowawz3fufogzaaa7m",
 								"docID": docID,
 							},
 						},
@@ -235,7 +241,7 @@ func TestCommitSubscription_WithDocFilterAndMultipleMutations_FilteredDoc(t *tes
 							"_docID": docID,
 							"_version": []map[string]any{
 								{
-									"cid": updateCid,
+									"cid": "bafyreiapbvksu6q6clclkp6ximlffdzpfy3edbi3nowawz3fufogzaaa7m",
 								},
 							},
 						},

--- a/tests/integration/subscription/with_commit_test.go
+++ b/tests/integration/subscription/with_commit_test.go
@@ -173,6 +173,8 @@ func TestCommitSubscription_WithCommitLinksCreateMutations_ValidLinks(t *testing
 	execute(t, test)
 }
 
+// TODO This test includes results due to a bug with the commit subscriptions.
+// https://github.com/sourcenetwork/defradb/issues/4434
 func TestCommitSubscription_WithDocFilterAndMultipleMutations_FilteredDoc(t *testing.T) {
 	updateCid := testUtils.NewSameValue()
 

--- a/tests/integration/subscription/with_commit_test.go
+++ b/tests/integration/subscription/with_commit_test.go
@@ -174,6 +174,8 @@ func TestCommitSubscription_WithCommitLinksCreateMutations_ValidLinks(t *testing
 }
 
 func TestCommitSubscription_WithDocFilterAndMultipleMutations_FilteredDoc(t *testing.T) {
+	updateCid := testUtils.NewSameValue()
+
 	docID := "bae-45e90427-d499-598b-902a-6a3c65d0b504"
 	test := testUtils.TestCase{
 		Actions: []any{
@@ -203,7 +205,7 @@ func TestCommitSubscription_WithDocFilterAndMultipleMutations_FilteredDoc(t *tes
 					{
 						"_commits": []map[string]any{
 							{
-								"cid":   "bafyreiapbvksu6q6clclkp6ximlffdzpfy3edbi3nowawz3fufogzaaa7m",
+								"cid":   updateCid,
 								"docID": docID,
 							},
 						},
@@ -241,7 +243,7 @@ func TestCommitSubscription_WithDocFilterAndMultipleMutations_FilteredDoc(t *tes
 							"_docID": docID,
 							"_version": []map[string]any{
 								{
-									"cid": "bafyreiapbvksu6q6clclkp6ximlffdzpfy3edbi3nowawz3fufogzaaa7m",
+									"cid": updateCid,
 								},
 							},
 						},

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -286,11 +286,6 @@ func executeTestCase(
 		performAction(s, testCase, i, testCase.Actions[i])
 	}
 
-	// matchers can be instantiated not as part of the test state, but as a variable for Test... function scope
-	// which will outlive all test runs (test instance of type [testUtils.TestCase]) and will be reused
-	// by them. So the matchers need to be reset between the test runs.
-	resetMatchers(s)
-
 	// Notify any active subscriptions that all requests have been sent.
 	close(s.AllActionsDone)
 
@@ -305,6 +300,11 @@ func executeTestCase(
 			assert.Fail(t, "timeout occurred while waiting for data stream")
 		}
 	}
+
+	// matchers can be instantiated not as part of the test state, but as a variable for Test... function scope
+	// which will outlive all test runs (test instance of type [testUtils.TestCase]) and will be reused
+	// by them. So the matchers need to be reset between the test runs.
+	resetMatchers(s)
 }
 
 func performAction(


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4428

## Description

This PR fixes a bug with test matchers in subscriptions.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Integration tests.

Specify the platform(s) on which this was tested:
- MacOS

