### PR TITLE
test: Add tests for truncation of views

### DIFF
--- a/tests/action/create_view.go
+++ b/tests/action/create_view.go
@@ -65,31 +65,29 @@ func (a *CreateView) Execute() {
 		}
 
 	default:
-		if a.s.ViewType == state.MaterializedViewType {
-			typeIndex := strings.Index(sdl, "\ttype ")
-			if typeIndex == -1 {
-				a.s.T.Fatal("materialized view SDL must contain '\ttype ' declaration")
-				return
-			}
-
-			subStrSquigglyIndex := strings.Index(sdl[typeIndex:], "{")
-			if subStrSquigglyIndex == -1 {
-				a.s.T.Fatal("materialized view SDL type declaration must contain '{'")
-				return
-			}
-
-			squigglyIndex := typeIndex + subStrSquigglyIndex
-			sdl = strings.Join([]string{
-				sdl[:squigglyIndex],
-				"@",
-				types.MaterializedDirectiveLabel,
-				"(if: ",
-				fmt.Sprint(a.s.ViewType == state.MaterializedViewType),
-				") ",
-				sdl[squigglyIndex:],
-				"",
-			}, "")
+		typeIndex := strings.Index(sdl, "\ttype ")
+		if typeIndex == -1 {
+			a.s.T.Fatal("materialized view SDL must contain '\ttype ' declaration")
+			return
 		}
+
+		subStrSquigglyIndex := strings.Index(sdl[typeIndex:], "{")
+		if subStrSquigglyIndex == -1 {
+			a.s.T.Fatal("materialized view SDL type declaration must contain '{'")
+			return
+		}
+
+		squigglyIndex := typeIndex + subStrSquigglyIndex
+		sdl = strings.Join([]string{
+			sdl[:squigglyIndex],
+			"@",
+			types.MaterializedDirectiveLabel,
+			"(if: ",
+			fmt.Sprint(a.s.ViewType == state.MaterializedViewType),
+			") ",
+			sdl[squigglyIndex:],
+			"",
+		}, "")
 	}
 
 	nodeIDs, nodes := getNodesWithIDs(a.NodeID, a.s.Nodes)

--- a/tests/action/create_view.go
+++ b/tests/action/create_view.go
@@ -108,4 +108,6 @@ func (a *CreateView) Execute() {
 
 		assertExpectedErrorRaised(a.s.T, a.ExpectedError, expectedErrorRaised)
 	}
+
+	refreshCollections(a.s)
 }

--- a/tests/integration/collection/truncate/view_test.go
+++ b/tests/integration/collection/truncate/view_test.go
@@ -1,0 +1,168 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package truncate
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/immutable"
+
+	"github.com/sourcenetwork/defradb/tests/action"
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	"github.com/sourcenetwork/defradb/tests/state"
+)
+
+func TestCollectionTruncateViewAdd_RemovesDocument(t *testing.T) {
+	test := testUtils.TestCase{
+		SupportedViewTypes: immutable.Some([]testUtils.ViewType{
+			state.MaterializedViewType,
+		}),
+		Actions: []any{
+			&action.AddSchema{
+				Schema: `
+					type Users {
+						name: String
+					}
+				`,
+			},
+			&action.CreateView{
+				Query: `
+					Users {
+						name
+					}
+				`,
+				SDL: `
+					type UserView {
+						name: String
+					}
+				`,
+			},
+			&action.CreateDoc{
+				CollectionID: 0,
+				DocMap: map[string]any{
+					"name": "John",
+				},
+			},
+			&action.CreateDoc{
+				CollectionID: 0,
+				DocMap: map[string]any{
+					"name": "Fred",
+				},
+			},
+			&action.RefreshViews{},
+			&action.Truncate{
+				// Truncate the View, but not the underlying collection
+				CollectionIndex: 1,
+			},
+			&action.Request{
+				DoNotRefreshViews: true,
+				Request: `query {
+					UserView {
+						name
+					}
+				}`,
+				Results: map[string]any{
+					"UserView": []map[string]any{},
+				},
+			},
+			// Refresh the View and assert that it has been reconstructed from the underlying
+			// collection.
+			&action.RefreshViews{},
+			&action.Request{
+				DoNotRefreshViews: true,
+				NonOrderedResults: true,
+				Request: `query {
+					UserView {
+						name
+					}
+				}`,
+				Results: map[string]any{
+					"UserView": []map[string]any{
+						{
+							"name": "John",
+						},
+						{
+							"name": "Fred",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+func TestCollectionTruncateViewAdd_TruncatingSourceDoesNotTruncateView(t *testing.T) {
+	test := testUtils.TestCase{
+		SupportedViewTypes: immutable.Some([]testUtils.ViewType{
+			state.MaterializedViewType,
+		}),
+		Actions: []any{
+			&action.AddSchema{
+				Schema: `
+					type Users {
+						name: String
+					}
+				`,
+			},
+			&action.CreateView{
+				Query: `
+					Users {
+						name
+					}
+				`,
+				SDL: `
+					type UserView {
+						name: String
+					}
+				`,
+			},
+			&action.CreateDoc{
+				CollectionID: 0,
+				DocMap: map[string]any{
+					"name": "John",
+				},
+			},
+			&action.CreateDoc{
+				CollectionID: 0,
+				DocMap: map[string]any{
+					"name": "Fred",
+				},
+			},
+			&action.RefreshViews{},
+			&action.Truncate{
+				// Truncate the underlying collection, without truncating the view
+				CollectionIndex: 0,
+			},
+			&action.Request{
+				DoNotRefreshViews: true,
+				NonOrderedResults: true,
+				Request: `query {
+					UserView {
+						name
+					}
+				}`,
+				Results: map[string]any{
+					"UserView": []map[string]any{
+						{
+							"name": "John",
+						},
+						{
+							"name": "Fred",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4390

## Description

Adds tests for the truncation of views.

The view-type multiplier ensures that this covers both materialized and non-materialized views.  Truncating a non-materialized view is a no-op.