### PR TITLE
chore: Disable coderabbit review details

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -13,22 +13,22 @@ reviews:
   auto_title_placeholder: '@coderabbitai'
   auto_title_instructions: ''
   review_status: false
-  review_details: true
-  commit_status: true
+  review_details: false
+  commit_status: false
   fail_commit_status: false
-  collapse_walkthrough: true
-  changed_files_summary: true
-  sequence_diagrams: true
-  estimate_code_review_effort: true
-  assess_linked_issues: true
-  related_issues: true
-  related_prs: true
-  suggested_labels: true
+  collapse_walkthrough: false
+  changed_files_summary: false
+  sequence_diagrams: false
+  estimate_code_review_effort: false
+  assess_linked_issues: false
+  related_issues: false
+  related_prs: false
+  suggested_labels: false
   labeling_instructions: []
   auto_apply_labels: false
-  suggested_reviewers: true
+  suggested_reviewers: false
   auto_assign_reviewers: false
-  in_progress_fortune: true
+  in_progress_fortune: false
   poem: false
   enable_prompt_for_ai_agents: true
   path_filters: []


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4443

## Description

Disables coderabbit review details - the comment CR leaves on every push `Walkthrough` etc.  It is very spammy and drowns out more useful messages, including those made by humans.

It will still post an `Actionable comments posted: 1` comment, I cant find a way to disable that (example visible in PR).

## Todo

- [ ] Wait for team to agree/disagree on this, do not merge on one review
