### PR TITLE
test: Add test for lensed views after restart

### DIFF
--- a/tests/integration/view/simple/transform_restart_test.go
+++ b/tests/integration/view/simple/transform_restart_test.go
@@ -1,0 +1,89 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package simple
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/immutable"
+	"github.com/sourcenetwork/lens/host-go/config/model"
+
+	"github.com/sourcenetwork/defradb/tests/action"
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	"github.com/sourcenetwork/defradb/tests/lenses"
+)
+
+func TestView_SimpleWithTransformAndRestart(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddSchema{
+				Schema: `
+					type User {
+						name: String
+					}
+				`,
+			},
+			&action.AddLens{
+				Lens: model.Lens{
+					// This transform will copy the value from `name` into the `fullName` field,
+					// like an overly-complicated alias
+					Lenses: []model.LensModule{
+						{
+							Path: lenses.CopyModulePath,
+							Arguments: map[string]any{
+								"src": "name",
+								"dst": "fullName",
+							},
+						},
+					},
+				},
+			},
+			&action.CreateView{
+				Query: `
+					User {
+						name
+					}
+				`,
+				SDL: `
+					type UserView {
+						fullName: String
+					}
+				`,
+				TransformCID: immutable.Some("{{.LensID0}}"),
+			},
+			testUtils.Restart{},
+			&action.CreateDoc{
+				// Set the `name` field only
+				Doc: `{
+					"name":	"John"
+				}`,
+			},
+			&action.Request{
+				Request: `
+					query {
+						UserView {
+							fullName
+						}
+					}
+				`,
+				Results: map[string]any{
+					"UserView": []map[string]any{
+						{
+							"fullName": "John",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #3711

## Description

Adds a test for lensed views after database restart.

The reported issue was resolved a while ago by a Lens package update, this change just closes the test gap. 
