### PR TITLE
chore: Use operator constants in schema definitions

### DIFF
--- a/internal/request/graphql/schema/types/base.go
+++ b/internal/request/graphql/schema/types/base.go
@@ -30,11 +30,11 @@ func BooleanOperatorBlock() *gql.InputObject {
 				Description: neOperatorDescription,
 				Type:        gql.Boolean,
 			},
-			"_in": &gql.InputObjectFieldConfig{
+			connor.InOp: &gql.InputObjectFieldConfig{
 				Description: inOperatorDescription,
 				Type:        gql.NewList(gql.Boolean),
 			},
-			"_nin": &gql.InputObjectFieldConfig{
+			connor.NotInOp: &gql.InputObjectFieldConfig{
 				Description: ninOperatorDescription,
 				Type:        gql.NewList(gql.Boolean),
 			},
@@ -48,23 +48,23 @@ func BooleanListOperatorBlock(op *gql.InputObject) *gql.InputObject {
 		Name:        "BooleanListOperatorBlock",
 		Description: "These are the set of filter operators available for use when filtering on [Boolean] values.",
 		Fields: gql.InputObjectConfigFieldMap{
-			"_any": &gql.InputObjectFieldConfig{
+			connor.AnyOp: &gql.InputObjectFieldConfig{
 				Description: anyOperatorDescription,
 				Type:        op,
 			},
-			"_all": &gql.InputObjectFieldConfig{
+			connor.AllOp: &gql.InputObjectFieldConfig{
 				Description: allOperatorDescription,
 				Type:        op,
 			},
-			"_none": &gql.InputObjectFieldConfig{
+			connor.NoneOp: &gql.InputObjectFieldConfig{
 				Description: noneOperatorDescription,
 				Type:        op,
 			},
-			"_eq": &gql.InputObjectFieldConfig{
+			connor.EqualOp: &gql.InputObjectFieldConfig{
 				Description: eqOperatorDescription,
 				Type:        gql.NewList(gql.Boolean),
 			},
-			"_neq": &gql.InputObjectFieldConfig{
+			connor.NotEqualOp: &gql.InputObjectFieldConfig{
 				Description: neOperatorDescription,
 				Type:        gql.NewList(gql.Boolean),
 			},
@@ -86,11 +86,11 @@ func NotNullBooleanOperatorBlock() *gql.InputObject {
 				Description: neOperatorDescription,
 				Type:        gql.Boolean,
 			},
-			"_in": &gql.InputObjectFieldConfig{
+			connor.InOp: &gql.InputObjectFieldConfig{
 				Description: inOperatorDescription,
 				Type:        gql.NewList(gql.NewNonNull(gql.Boolean)),
 			},
-			"_nin": &gql.InputObjectFieldConfig{
+			connor.NotInOp: &gql.InputObjectFieldConfig{
 				Description: ninOperatorDescription,
 				Type:        gql.NewList(gql.NewNonNull(gql.Boolean)),
 			},
@@ -104,23 +104,23 @@ func NotNullBooleanListOperatorBlock(op *gql.InputObject) *gql.InputObject {
 		Name:        "NotNullBooleanListOperatorBlock",
 		Description: "These are the set of filter operators available for use when filtering on [Boolean!] values.",
 		Fields: gql.InputObjectConfigFieldMap{
-			"_any": &gql.InputObjectFieldConfig{
+			connor.AnyOp: &gql.InputObjectFieldConfig{
 				Description: anyOperatorDescription,
 				Type:        op,
 			},
-			"_all": &gql.InputObjectFieldConfig{
+			connor.AllOp: &gql.InputObjectFieldConfig{
 				Description: allOperatorDescription,
 				Type:        op,
 			},
-			"_none": &gql.InputObjectFieldConfig{
+			connor.NoneOp: &gql.InputObjectFieldConfig{
 				Description: noneOperatorDescription,
 				Type:        op,
 			},
-			"_eq": &gql.InputObjectFieldConfig{
+			connor.EqualOp: &gql.InputObjectFieldConfig{
 				Description: eqOperatorDescription,
 				Type:        gql.NewList(gql.NewNonNull(gql.Boolean)),
 			},
-			"_neq": &gql.InputObjectFieldConfig{
+			connor.NotEqualOp: &gql.InputObjectFieldConfig{
 				Description: neOperatorDescription,
 				Type:        gql.NewList(gql.NewNonNull(gql.Boolean)),
 			},
@@ -142,27 +142,27 @@ func DateTimeOperatorBlock() *gql.InputObject {
 				Description: neOperatorDescription,
 				Type:        gql.DateTime,
 			},
-			"_gt": &gql.InputObjectFieldConfig{
+			connor.GreaterOp: &gql.InputObjectFieldConfig{
 				Description: gtOperatorDescription,
 				Type:        gql.DateTime,
 			},
-			"_geq": &gql.InputObjectFieldConfig{
+			connor.GreaterOrEqualOp: &gql.InputObjectFieldConfig{
 				Description: geOperatorDescription,
 				Type:        gql.DateTime,
 			},
-			"_lt": &gql.InputObjectFieldConfig{
+			connor.LesserOp: &gql.InputObjectFieldConfig{
 				Description: ltOperatorDescription,
 				Type:        gql.DateTime,
 			},
-			"_leq": &gql.InputObjectFieldConfig{
+			connor.LesserOrEqualOp: &gql.InputObjectFieldConfig{
 				Description: leOperatorDescription,
 				Type:        gql.DateTime,
 			},
-			"_in": &gql.InputObjectFieldConfig{
+			connor.InOp: &gql.InputObjectFieldConfig{
 				Description: inOperatorDescription,
 				Type:        gql.NewList(gql.DateTime),
 			},
-			"_nin": &gql.InputObjectFieldConfig{
+			connor.NotInOp: &gql.InputObjectFieldConfig{
 				Description: ninOperatorDescription,
 				Type:        gql.NewList(gql.DateTime),
 			},
@@ -184,27 +184,27 @@ func Float64OperatorBlock() *gql.InputObject {
 				Description: neOperatorDescription,
 				Type:        Float64,
 			},
-			"_gt": &gql.InputObjectFieldConfig{
+			connor.GreaterOp: &gql.InputObjectFieldConfig{
 				Description: gtOperatorDescription,
 				Type:        Float64,
 			},
-			"_geq": &gql.InputObjectFieldConfig{
+			connor.GreaterOrEqualOp: &gql.InputObjectFieldConfig{
 				Description: geOperatorDescription,
 				Type:        Float64,
 			},
-			"_lt": &gql.InputObjectFieldConfig{
+			connor.LesserOp: &gql.InputObjectFieldConfig{
 				Description: ltOperatorDescription,
 				Type:        Float64,
 			},
-			"_leq": &gql.InputObjectFieldConfig{
+			connor.LesserOrEqualOp: &gql.InputObjectFieldConfig{
 				Description: leOperatorDescription,
 				Type:        Float64,
 			},
-			"_in": &gql.InputObjectFieldConfig{
+			connor.InOp: &gql.InputObjectFieldConfig{
 				Description: inOperatorDescription,
 				Type:        gql.NewList(Float64),
 			},
-			"_nin": &gql.InputObjectFieldConfig{
+			connor.NotInOp: &gql.InputObjectFieldConfig{
 				Description: ninOperatorDescription,
 				Type:        gql.NewList(Float64),
 			},
@@ -218,23 +218,23 @@ func Float64ListOperatorBlock(op *gql.InputObject) *gql.InputObject {
 		Name:        "Float64ListOperatorBlock",
 		Description: "These are the set of filter operators available for use when filtering on [Float64] values.",
 		Fields: gql.InputObjectConfigFieldMap{
-			"_any": &gql.InputObjectFieldConfig{
+			connor.AnyOp: &gql.InputObjectFieldConfig{
 				Description: anyOperatorDescription,
 				Type:        op,
 			},
-			"_all": &gql.InputObjectFieldConfig{
+			connor.AllOp: &gql.InputObjectFieldConfig{
 				Description: allOperatorDescription,
 				Type:        op,
 			},
-			"_none": &gql.InputObjectFieldConfig{
+			connor.NoneOp: &gql.InputObjectFieldConfig{
 				Description: noneOperatorDescription,
 				Type:        op,
 			},
-			"_eq": &gql.InputObjectFieldConfig{
+			connor.EqualOp: &gql.InputObjectFieldConfig{
 				Description: eqOperatorDescription,
 				Type:        gql.NewList(Float64),
 			},
-			"_neq": &gql.InputObjectFieldConfig{
+			connor.NotEqualOp: &gql.InputObjectFieldConfig{
 				Description: neOperatorDescription,
 				Type:        gql.NewList(Float64),
 			},
@@ -256,27 +256,27 @@ func NotNullFloat64OperatorBlock() *gql.InputObject {
 				Description: neOperatorDescription,
 				Type:        Float64,
 			},
-			"_gt": &gql.InputObjectFieldConfig{
+			connor.GreaterOp: &gql.InputObjectFieldConfig{
 				Description: gtOperatorDescription,
 				Type:        Float64,
 			},
-			"_geq": &gql.InputObjectFieldConfig{
+			connor.GreaterOrEqualOp: &gql.InputObjectFieldConfig{
 				Description: geOperatorDescription,
 				Type:        Float64,
 			},
-			"_lt": &gql.InputObjectFieldConfig{
+			connor.LesserOp: &gql.InputObjectFieldConfig{
 				Description: ltOperatorDescription,
 				Type:        Float64,
 			},
-			"_leq": &gql.InputObjectFieldConfig{
+			connor.LesserOrEqualOp: &gql.InputObjectFieldConfig{
 				Description: leOperatorDescription,
 				Type:        Float64,
 			},
-			"_in": &gql.InputObjectFieldConfig{
+			connor.InOp: &gql.InputObjectFieldConfig{
 				Description: inOperatorDescription,
 				Type:        gql.NewList(gql.NewNonNull(Float64)),
 			},
-			"_nin": &gql.InputObjectFieldConfig{
+			connor.NotInOp: &gql.InputObjectFieldConfig{
 				Description: ninOperatorDescription,
 				Type:        gql.NewList(gql.NewNonNull(Float64)),
 			},
@@ -290,23 +290,23 @@ func NotNullFloat64ListOperatorBlock(op *gql.InputObject) *gql.InputObject {
 		Name:        "NotNullFloat64ListOperatorBlock",
 		Description: "These are the set of filter operators available for use when filtering on [Float64!] values.",
 		Fields: gql.InputObjectConfigFieldMap{
-			"_any": &gql.InputObjectFieldConfig{
+			connor.AnyOp: &gql.InputObjectFieldConfig{
 				Description: anyOperatorDescription,
 				Type:        op,
 			},
-			"_all": &gql.InputObjectFieldConfig{
+			connor.AllOp: &gql.InputObjectFieldConfig{
 				Description: allOperatorDescription,
 				Type:        op,
 			},
-			"_none": &gql.InputObjectFieldConfig{
+			connor.NoneOp: &gql.InputObjectFieldConfig{
 				Description: noneOperatorDescription,
 				Type:        op,
 			},
-			"_eq": &gql.InputObjectFieldConfig{
+			connor.EqualOp: &gql.InputObjectFieldConfig{
 				Description: eqOperatorDescription,
 				Type:        gql.NewList(gql.NewNonNull(Float64)),
 			},
-			"_neq": &gql.InputObjectFieldConfig{
+			connor.NotEqualOp: &gql.InputObjectFieldConfig{
 				Description: neOperatorDescription,
 				Type:        gql.NewList(gql.NewNonNull(Float64)),
 			},
@@ -328,27 +328,27 @@ func Float32OperatorBlock() *gql.InputObject {
 				Description: neOperatorDescription,
 				Type:        Float32,
 			},
-			"_gt": &gql.InputObjectFieldConfig{
+			connor.GreaterOp: &gql.InputObjectFieldConfig{
 				Description: gtOperatorDescription,
 				Type:        Float32,
 			},
-			"_geq": &gql.InputObjectFieldConfig{
+			connor.GreaterOrEqualOp: &gql.InputObjectFieldConfig{
 				Description: geOperatorDescription,
 				Type:        Float32,
 			},
-			"_lt": &gql.InputObjectFieldConfig{
+			connor.LesserOp: &gql.InputObjectFieldConfig{
 				Description: ltOperatorDescription,
 				Type:        Float32,
 			},
-			"_leq": &gql.InputObjectFieldConfig{
+			connor.LesserOrEqualOp: &gql.InputObjectFieldConfig{
 				Description: leOperatorDescription,
 				Type:        Float32,
 			},
-			"_in": &gql.InputObjectFieldConfig{
+			connor.InOp: &gql.InputObjectFieldConfig{
 				Description: inOperatorDescription,
 				Type:        gql.NewList(Float32),
 			},
-			"_nin": &gql.InputObjectFieldConfig{
+			connor.NotInOp: &gql.InputObjectFieldConfig{
 				Description: ninOperatorDescription,
 				Type:        gql.NewList(Float32),
 			},
@@ -362,23 +362,23 @@ func Float32ListOperatorBlock(op *gql.InputObject) *gql.InputObject {
 		Name:        "Float32ListOperatorBlock",
 		Description: "These are the set of filter operators available for use when filtering on [Float32] values.",
 		Fields: gql.InputObjectConfigFieldMap{
-			"_any": &gql.InputObjectFieldConfig{
+			connor.AnyOp: &gql.InputObjectFieldConfig{
 				Description: anyOperatorDescription,
 				Type:        op,
 			},
-			"_all": &gql.InputObjectFieldConfig{
+			connor.AllOp: &gql.InputObjectFieldConfig{
 				Description: allOperatorDescription,
 				Type:        op,
 			},
-			"_none": &gql.InputObjectFieldConfig{
+			connor.NoneOp: &gql.InputObjectFieldConfig{
 				Description: noneOperatorDescription,
 				Type:        op,
 			},
-			"_eq": &gql.InputObjectFieldConfig{
+			connor.EqualOp: &gql.InputObjectFieldConfig{
 				Description: eqOperatorDescription,
 				Type:        gql.NewList(Float32),
 			},
-			"_neq": &gql.InputObjectFieldConfig{
+			connor.NotEqualOp: &gql.InputObjectFieldConfig{
 				Description: neOperatorDescription,
 				Type:        gql.NewList(Float32),
 			},
@@ -400,27 +400,27 @@ func NotNullFloat32OperatorBlock() *gql.InputObject {
 				Description: neOperatorDescription,
 				Type:        Float32,
 			},
-			"_gt": &gql.InputObjectFieldConfig{
+			connor.GreaterOp: &gql.InputObjectFieldConfig{
 				Description: gtOperatorDescription,
 				Type:        Float32,
 			},
-			"_geq": &gql.InputObjectFieldConfig{
+			connor.GreaterOrEqualOp: &gql.InputObjectFieldConfig{
 				Description: geOperatorDescription,
 				Type:        Float32,
 			},
-			"_lt": &gql.InputObjectFieldConfig{
+			connor.LesserOp: &gql.InputObjectFieldConfig{
 				Description: ltOperatorDescription,
 				Type:        Float32,
 			},
-			"_leq": &gql.InputObjectFieldConfig{
+			connor.LesserOrEqualOp: &gql.InputObjectFieldConfig{
 				Description: leOperatorDescription,
 				Type:        Float32,
 			},
-			"_in": &gql.InputObjectFieldConfig{
+			connor.InOp: &gql.InputObjectFieldConfig{
 				Description: inOperatorDescription,
 				Type:        gql.NewList(gql.NewNonNull(Float32)),
 			},
-			"_nin": &gql.InputObjectFieldConfig{
+			connor.NotInOp: &gql.InputObjectFieldConfig{
 				Description: ninOperatorDescription,
 				Type:        gql.NewList(gql.NewNonNull(Float32)),
 			},
@@ -434,23 +434,23 @@ func NotNullFloat32ListOperatorBlock(op *gql.InputObject) *gql.InputObject {
 		Name:        "NotNullFloat32ListOperatorBlock",
 		Description: "These are the set of filter operators available for use when filtering on [Float32!] values.",
 		Fields: gql.InputObjectConfigFieldMap{
-			"_any": &gql.InputObjectFieldConfig{
+			connor.AnyOp: &gql.InputObjectFieldConfig{
 				Description: anyOperatorDescription,
 				Type:        op,
 			},
-			"_all": &gql.InputObjectFieldConfig{
+			connor.AllOp: &gql.InputObjectFieldConfig{
 				Description: allOperatorDescription,
 				Type:        op,
 			},
-			"_none": &gql.InputObjectFieldConfig{
+			connor.NoneOp: &gql.InputObjectFieldConfig{
 				Description: noneOperatorDescription,
 				Type:        op,
 			},
-			"_eq": &gql.InputObjectFieldConfig{
+			connor.EqualOp: &gql.InputObjectFieldConfig{
 				Description: eqOperatorDescription,
 				Type:        gql.NewList(gql.NewNonNull(Float32)),
 			},
-			"_neq": &gql.InputObjectFieldConfig{
+			connor.NotEqualOp: &gql.InputObjectFieldConfig{
 				Description: neOperatorDescription,
 				Type:        gql.NewList(gql.NewNonNull(Float32)),
 			},
@@ -472,27 +472,27 @@ func IntOperatorBlock() *gql.InputObject {
 				Description: neOperatorDescription,
 				Type:        gql.Int,
 			},
-			"_gt": &gql.InputObjectFieldConfig{
+			connor.GreaterOp: &gql.InputObjectFieldConfig{
 				Description: gtOperatorDescription,
 				Type:        gql.Int,
 			},
-			"_geq": &gql.InputObjectFieldConfig{
+			connor.GreaterOrEqualOp: &gql.InputObjectFieldConfig{
 				Description: geOperatorDescription,
 				Type:        gql.Int,
 			},
-			"_lt": &gql.InputObjectFieldConfig{
+			connor.LesserOp: &gql.InputObjectFieldConfig{
 				Description: ltOperatorDescription,
 				Type:        gql.Int,
 			},
-			"_leq": &gql.InputObjectFieldConfig{
+			connor.LesserOrEqualOp: &gql.InputObjectFieldConfig{
 				Description: leOperatorDescription,
 				Type:        gql.Int,
 			},
-			"_in": &gql.InputObjectFieldConfig{
+			connor.InOp: &gql.InputObjectFieldConfig{
 				Description: inOperatorDescription,
 				Type:        gql.NewList(gql.Int),
 			},
-			"_nin": &gql.InputObjectFieldConfig{
+			connor.NotInOp: &gql.InputObjectFieldConfig{
 				Description: ninOperatorDescription,
 				Type:        gql.NewList(gql.Int),
 			},
@@ -506,23 +506,23 @@ func IntListOperatorBlock(op *gql.InputObject) *gql.InputObject {
 		Name:        "IntListOperatorBlock",
 		Description: "These are the set of filter operators available for use when filtering on [Int] values.",
 		Fields: gql.InputObjectConfigFieldMap{
-			"_any": &gql.InputObjectFieldConfig{
+			connor.AnyOp: &gql.InputObjectFieldConfig{
 				Description: anyOperatorDescription,
 				Type:        op,
 			},
-			"_all": &gql.InputObjectFieldConfig{
+			connor.AllOp: &gql.InputObjectFieldConfig{
 				Description: allOperatorDescription,
 				Type:        op,
 			},
-			"_none": &gql.InputObjectFieldConfig{
+			connor.NoneOp: &gql.InputObjectFieldConfig{
 				Description: noneOperatorDescription,
 				Type:        op,
 			},
-			"_eq": &gql.InputObjectFieldConfig{
+			connor.EqualOp: &gql.InputObjectFieldConfig{
 				Description: eqOperatorDescription,
 				Type:        gql.NewList(gql.Int),
 			},
-			"_neq": &gql.InputObjectFieldConfig{
+			connor.NotEqualOp: &gql.InputObjectFieldConfig{
 				Description: neOperatorDescription,
 				Type:        gql.NewList(gql.Int),
 			},
@@ -544,27 +544,27 @@ func NotNullIntOperatorBlock() *gql.InputObject {
 				Description: neOperatorDescription,
 				Type:        gql.Int,
 			},
-			"_gt": &gql.InputObjectFieldConfig{
+			connor.GreaterOp: &gql.InputObjectFieldConfig{
 				Description: gtOperatorDescription,
 				Type:        gql.Int,
 			},
-			"_geq": &gql.InputObjectFieldConfig{
+			connor.GreaterOrEqualOp: &gql.InputObjectFieldConfig{
 				Description: geOperatorDescription,
 				Type:        gql.Int,
 			},
-			"_lt": &gql.InputObjectFieldConfig{
+			connor.LesserOp: &gql.InputObjectFieldConfig{
 				Description: ltOperatorDescription,
 				Type:        gql.Int,
 			},
-			"_leq": &gql.InputObjectFieldConfig{
+			connor.LesserOrEqualOp: &gql.InputObjectFieldConfig{
 				Description: leOperatorDescription,
 				Type:        gql.Int,
 			},
-			"_in": &gql.InputObjectFieldConfig{
+			connor.InOp: &gql.InputObjectFieldConfig{
 				Description: inOperatorDescription,
 				Type:        gql.NewList(gql.NewNonNull(gql.Int)),
 			},
-			"_nin": &gql.InputObjectFieldConfig{
+			connor.NotInOp: &gql.InputObjectFieldConfig{
 				Description: ninOperatorDescription,
 				Type:        gql.NewList(gql.NewNonNull(gql.Int)),
 			},
@@ -578,23 +578,23 @@ func NotNullIntListOperatorBlock(op *gql.InputObject) *gql.InputObject {
 		Name:        "NotNullIntListOperatorBlock",
 		Description: "These are the set of filter operators available for use when filtering on [Int!] values.",
 		Fields: gql.InputObjectConfigFieldMap{
-			"_any": &gql.InputObjectFieldConfig{
+			connor.AnyOp: &gql.InputObjectFieldConfig{
 				Description: anyOperatorDescription,
 				Type:        op,
 			},
-			"_all": &gql.InputObjectFieldConfig{
+			connor.AllOp: &gql.InputObjectFieldConfig{
 				Description: allOperatorDescription,
 				Type:        op,
 			},
-			"_none": &gql.InputObjectFieldConfig{
+			connor.NoneOp: &gql.InputObjectFieldConfig{
 				Description: noneOperatorDescription,
 				Type:        op,
 			},
-			"_eq": &gql.InputObjectFieldConfig{
+			connor.EqualOp: &gql.InputObjectFieldConfig{
 				Description: eqOperatorDescription,
 				Type:        gql.NewList(gql.NewNonNull(gql.Int)),
 			},
-			"_neq": &gql.InputObjectFieldConfig{
+			connor.NotEqualOp: &gql.InputObjectFieldConfig{
 				Description: neOperatorDescription,
 				Type:        gql.NewList(gql.NewNonNull(gql.Int)),
 			},
@@ -616,27 +616,27 @@ func StringOperatorBlock() *gql.InputObject {
 				Description: neOperatorDescription,
 				Type:        gql.String,
 			},
-			"_in": &gql.InputObjectFieldConfig{
+			connor.InOp: &gql.InputObjectFieldConfig{
 				Description: inOperatorDescription,
 				Type:        gql.NewList(gql.String),
 			},
-			"_nin": &gql.InputObjectFieldConfig{
+			connor.NotInOp: &gql.InputObjectFieldConfig{
 				Description: ninOperatorDescription,
 				Type:        gql.NewList(gql.String),
 			},
-			"_like": &gql.InputObjectFieldConfig{
+			connor.LikeOp: &gql.InputObjectFieldConfig{
 				Description: likeStringOperatorDescription,
 				Type:        gql.String,
 			},
-			"_nlike": &gql.InputObjectFieldConfig{
+			connor.NotLikeOp: &gql.InputObjectFieldConfig{
 				Description: nlikeStringOperatorDescription,
 				Type:        gql.String,
 			},
-			"_ilike": &gql.InputObjectFieldConfig{
+			connor.CaseInsensitiveLikeOp: &gql.InputObjectFieldConfig{
 				Description: ilikeStringOperatorDescription,
 				Type:        gql.String,
 			},
-			"_nilike": &gql.InputObjectFieldConfig{
+			connor.CaseInsensitiveNotLikeOp: &gql.InputObjectFieldConfig{
 				Description: nilikeStringOperatorDescription,
 				Type:        gql.String,
 			},
@@ -650,23 +650,23 @@ func StringListOperatorBlock(op *gql.InputObject) *gql.InputObject {
 		Name:        "StringListOperatorBlock",
 		Description: "These are the set of filter operators available for use when filtering on [String] values.",
 		Fields: gql.InputObjectConfigFieldMap{
-			"_any": &gql.InputObjectFieldConfig{
+			connor.AnyOp: &gql.InputObjectFieldConfig{
 				Description: anyOperatorDescription,
 				Type:        op,
 			},
-			"_all": &gql.InputObjectFieldConfig{
+			connor.AllOp: &gql.InputObjectFieldConfig{
 				Description: allOperatorDescription,
 				Type:        op,
 			},
-			"_none": &gql.InputObjectFieldConfig{
+			connor.NoneOp: &gql.InputObjectFieldConfig{
 				Description: noneOperatorDescription,
 				Type:        op,
 			},
-			"_eq": &gql.InputObjectFieldConfig{
+			connor.EqualOp: &gql.InputObjectFieldConfig{
 				Description: eqOperatorDescription,
 				Type:        gql.NewList(gql.String),
 			},
-			"_neq": &gql.InputObjectFieldConfig{
+			connor.NotEqualOp: &gql.InputObjectFieldConfig{
 				Description: neOperatorDescription,
 				Type:        gql.NewList(gql.String),
 			},
@@ -688,27 +688,27 @@ func NotNullStringOperatorBlock() *gql.InputObject {
 				Description: neOperatorDescription,
 				Type:        gql.String,
 			},
-			"_in": &gql.InputObjectFieldConfig{
+			connor.InOp: &gql.InputObjectFieldConfig{
 				Description: inOperatorDescription,
 				Type:        gql.NewList(gql.NewNonNull(gql.String)),
 			},
-			"_nin": &gql.InputObjectFieldConfig{
+			connor.NotInOp: &gql.InputObjectFieldConfig{
 				Description: ninOperatorDescription,
 				Type:        gql.NewList(gql.NewNonNull(gql.String)),
 			},
-			"_like": &gql.InputObjectFieldConfig{
+			connor.LikeOp: &gql.InputObjectFieldConfig{
 				Description: likeStringOperatorDescription,
 				Type:        gql.String,
 			},
-			"_nlike": &gql.InputObjectFieldConfig{
+			connor.NotLikeOp: &gql.InputObjectFieldConfig{
 				Description: nlikeStringOperatorDescription,
 				Type:        gql.String,
 			},
-			"_ilike": &gql.InputObjectFieldConfig{
+			connor.CaseInsensitiveLikeOp: &gql.InputObjectFieldConfig{
 				Description: ilikeStringOperatorDescription,
 				Type:        gql.String,
 			},
-			"_nilike": &gql.InputObjectFieldConfig{
+			connor.CaseInsensitiveNotLikeOp: &gql.InputObjectFieldConfig{
 				Description: nilikeStringOperatorDescription,
 				Type:        gql.String,
 			},
@@ -722,23 +722,23 @@ func NotNullStringListOperatorBlock(op *gql.InputObject) *gql.InputObject {
 		Name:        "NotNullStringListOperatorBlock",
 		Description: "These are the set of filter operators available for use when filtering on [String!] values.",
 		Fields: gql.InputObjectConfigFieldMap{
-			"_any": &gql.InputObjectFieldConfig{
+			connor.AnyOp: &gql.InputObjectFieldConfig{
 				Description: anyOperatorDescription,
 				Type:        op,
 			},
-			"_all": &gql.InputObjectFieldConfig{
+			connor.AllOp: &gql.InputObjectFieldConfig{
 				Description: allOperatorDescription,
 				Type:        op,
 			},
-			"_none": &gql.InputObjectFieldConfig{
+			connor.NoneOp: &gql.InputObjectFieldConfig{
 				Description: noneOperatorDescription,
 				Type:        op,
 			},
-			"_eq": &gql.InputObjectFieldConfig{
+			connor.EqualOp: &gql.InputObjectFieldConfig{
 				Description: eqOperatorDescription,
 				Type:        gql.NewList(gql.NewNonNull(gql.String)),
 			},
-			"_neq": &gql.InputObjectFieldConfig{
+			connor.NotEqualOp: &gql.InputObjectFieldConfig{
 				Description: neOperatorDescription,
 				Type:        gql.NewList(gql.NewNonNull(gql.String)),
 			},
@@ -759,27 +759,27 @@ func BlobOperatorBlock(blobScalarType *gql.Scalar) *gql.InputObject {
 				Description: neOperatorDescription,
 				Type:        blobScalarType,
 			},
-			"_in": &gql.InputObjectFieldConfig{
+			connor.InOp: &gql.InputObjectFieldConfig{
 				Description: inOperatorDescription,
 				Type:        gql.NewList(blobScalarType),
 			},
-			"_nin": &gql.InputObjectFieldConfig{
+			connor.NotInOp: &gql.InputObjectFieldConfig{
 				Description: ninOperatorDescription,
 				Type:        gql.NewList(blobScalarType),
 			},
-			"_like": &gql.InputObjectFieldConfig{
+			connor.LikeOp: &gql.InputObjectFieldConfig{
 				Description: likeStringOperatorDescription,
 				Type:        gql.String,
 			},
-			"_nlike": &gql.InputObjectFieldConfig{
+			connor.NotLikeOp: &gql.InputObjectFieldConfig{
 				Description: nlikeStringOperatorDescription,
 				Type:        gql.String,
 			},
-			"_ilike": &gql.InputObjectFieldConfig{
+			connor.CaseInsensitiveLikeOp: &gql.InputObjectFieldConfig{
 				Description: ilikeStringOperatorDescription,
 				Type:        gql.String,
 			},
-			"_nilike": &gql.InputObjectFieldConfig{
+			connor.CaseInsensitiveNotLikeOp: &gql.InputObjectFieldConfig{
 				Description: nilikeStringOperatorDescription,
 				Type:        gql.String,
 			},
@@ -801,27 +801,27 @@ func NotNullBlobOperatorBlock(blobScalarType *gql.Scalar) *gql.InputObject {
 				Description: neOperatorDescription,
 				Type:        blobScalarType,
 			},
-			"_in": &gql.InputObjectFieldConfig{
+			connor.InOp: &gql.InputObjectFieldConfig{
 				Description: inOperatorDescription,
 				Type:        gql.NewList(gql.NewNonNull(blobScalarType)),
 			},
-			"_nin": &gql.InputObjectFieldConfig{
+			connor.NotInOp: &gql.InputObjectFieldConfig{
 				Description: ninOperatorDescription,
 				Type:        gql.NewList(gql.NewNonNull(blobScalarType)),
 			},
-			"_like": &gql.InputObjectFieldConfig{
+			connor.LikeOp: &gql.InputObjectFieldConfig{
 				Description: likeStringOperatorDescription,
 				Type:        gql.String,
 			},
-			"_nlike": &gql.InputObjectFieldConfig{
+			connor.NotLikeOp: &gql.InputObjectFieldConfig{
 				Description: nlikeStringOperatorDescription,
 				Type:        gql.String,
 			},
-			"_ilike": &gql.InputObjectFieldConfig{
+			connor.CaseInsensitiveLikeOp: &gql.InputObjectFieldConfig{
 				Description: ilikeStringOperatorDescription,
 				Type:        gql.String,
 			},
-			"_nilike": &gql.InputObjectFieldConfig{
+			connor.CaseInsensitiveNotLikeOp: &gql.InputObjectFieldConfig{
 				Description: nilikeStringOperatorDescription,
 				Type:        gql.String,
 			},
@@ -843,11 +843,11 @@ func IDOperatorBlock() *gql.InputObject {
 				Description: neOperatorDescription,
 				Type:        gql.ID,
 			},
-			"_in": &gql.InputObjectFieldConfig{
+			connor.InOp: &gql.InputObjectFieldConfig{
 				Description: inOperatorDescription,
 				Type:        gql.NewList(gql.NewNonNull(gql.ID)),
 			},
-			"_nin": &gql.InputObjectFieldConfig{
+			connor.NotInOp: &gql.InputObjectFieldConfig{
 				Description: ninOperatorDescription,
 				Type:        gql.NewList(gql.NewNonNull(gql.ID)),
 			},


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4427

## Description

This PR refactors the operator block definitions in `internal/request/graphql/schema/types/base.go` to use constants from the `connor` package instead of hardcoded string literals.

**Changes:**
* Replaced string keys (e.g., `"_gt"`, `"_eq"`) with their corresponding constants (e.g., `connor.GreaterOp`, `connor.EqualOp`).

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [ ] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

I verified these changes by running the project's test suite and linter to ensure that replacing the strings with constants did not alter any functionality or break existing tests.

* Ran `go build ./internal/request/graphql/schema/types/...` to verify compilation.
* Ran `make test` to ensure all unit and integration tests pass.
* Ran `make lint` to ensure code style compliance.

Specify the platform(s) on which this was tested:
- Windows 11 (via WSL2 / Ubuntu)