### PR TITLE
fix: Field short ID retrieval

### DIFF
--- a/docs/data_format_changes/i4456-field-short-id-retrieval.md
+++ b/docs/data_format_changes/i4456-field-short-id-retrieval.md
@@ -1,3 +1,3 @@
 # Field Short ID Retrieval Bug Fix
 
-Fixed an issue where retrieving field short IDs could result in a corrupted datastore state. The bug occured when more than 9 collections were present as a result of the collection short id being written in the key as a string. Encoding the collection short id as a variable length integer resolves the issue. This however as is changes the way field short ids are stored in the system store.
+Fixed an issue where retrieving field short IDs could result in a corrupted datastore state. The bug occurred when more than 9 collections were present because the collection short ID was written in the key as a string. Encoding the collection short ID as a variable-length integer resolves the issue. This, however, changes how field short IDs are stored in the system store..

--- a/docs/data_format_changes/i4456-field-short-id-retrieval.md
+++ b/docs/data_format_changes/i4456-field-short-id-retrieval.md
@@ -1,0 +1,3 @@
+# Field Short ID Retrieval Bug Fix
+
+Fixed an issue where retrieving field short IDs could result in a corrupted datastore state. The bug occured when more than 9 collections were present as a result of the collection short id being written in the key as a string. Encoding the collection short id as a variable length integer resolves the issue. This however as is changes the way field short ids are stored in the system store.

--- a/internal/db/id/field.go
+++ b/internal/db/id/field.go
@@ -58,7 +58,7 @@ func GetShortFieldID(
 			break
 		}
 
-		key, err := keys.NewFieldIDFromString(string(iter.Key()))
+		key, err := keys.NewFieldIDFromBytes(iter.Key())
 		if err != nil {
 			return 0, errors.Join(err, iter.Close())
 		}

--- a/internal/encoding/int.go
+++ b/internal/encoding/int.go
@@ -234,7 +234,7 @@ func EncodeUvarintDescending(b []byte, v uint64) []byte {
 // buffer. The remainder of the input buffer and the decoded uint64
 // are returned.
 func DecodeUvarintAscending(b []byte) ([]byte, uint64, error) {
-	if len(b) == 0 {
+	if len(b) == 0 || b[0] == byte('/') {
 		return nil, 0, NewErrInsufficientBytesToDecode(b, "uvarint")
 	}
 	length := int(b[0]) - intZero

--- a/internal/keys/systemstore_field_id.go
+++ b/internal/keys/systemstore_field_id.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 
 	ds "github.com/ipfs/go-datastore"
+
 	"github.com/sourcenetwork/defradb/internal/encoding"
 )
 
@@ -41,15 +42,18 @@ func NewFieldIDPrefix(collectionShortID uint32) FieldID {
 }
 
 func NewFieldIDFromBytes(key []byte) (FieldID, error) {
-	if len(key) == 0 {
-		return FieldID{}, ErrEmptyKey
-	}
-
 	if !bytes.HasPrefix(key, []byte(FIELD_SHORT_ID)) {
 		return FieldID{}, ErrInvalidKey
 	}
 
-	key = bytes.TrimPrefix(key, []byte(FIELD_SHORT_ID+"/"))
+	key = bytes.TrimPrefix(key, []byte(FIELD_SHORT_ID))
+	if len(key) == 0 {
+		return FieldID{}, nil
+	}
+	if key[0] != '/' {
+		return FieldID{}, ErrInvalidKey
+	}
+	key = key[1:]
 
 	key, colID, err := encoding.DecodeUvarintAscending(key)
 	if err != nil {

--- a/internal/keys/systemstore_field_id.go
+++ b/internal/keys/systemstore_field_id.go
@@ -11,10 +11,12 @@
 package keys
 
 import (
+	"bytes"
 	"strconv"
 	"strings"
 
 	ds "github.com/ipfs/go-datastore"
+	"github.com/sourcenetwork/defradb/internal/encoding"
 )
 
 // FieldID indexes field short ids by the full id.
@@ -38,21 +40,33 @@ func NewFieldIDPrefix(collectionShortID uint32) FieldID {
 	}
 }
 
-func NewFieldIDFromString(keyString string) (FieldID, error) {
-	keyString = strings.TrimPrefix(keyString, FIELD_SHORT_ID+"/")
-	elements := strings.Split(keyString, "/")
-	if len(elements) != 2 {
+func NewFieldIDFromBytes(key []byte) (FieldID, error) {
+	if len(key) == 0 {
+		return FieldID{}, ErrEmptyKey
+	}
+
+	if !bytes.HasPrefix(key, []byte(FIELD_SHORT_ID)) {
 		return FieldID{}, ErrInvalidKey
 	}
 
-	colID, err := strconv.ParseUint(elements[0], 10, 0)
+	key = bytes.TrimPrefix(key, []byte(FIELD_SHORT_ID+"/"))
+
+	key, colID, err := encoding.DecodeUvarintAscending(key)
 	if err != nil {
 		return FieldID{}, err
 	}
 
+	var fieldID string
+	if len(key) > 1 {
+		if key[0] == '/' {
+			key = key[1:]
+		}
+		fieldID = strings.TrimSuffix(string(key), "/")
+	}
+
 	return FieldID{
 		CollectionShortID: uint32(colID),
-		FieldID:           elements[1],
+		FieldID:           fieldID,
 	}, nil
 }
 
@@ -71,7 +85,18 @@ func (k FieldID) ToString() string {
 }
 
 func (k FieldID) Bytes() []byte {
-	return []byte(k.ToString())
+	result := []byte(FIELD_SHORT_ID)
+
+	if k.CollectionShortID != 0 {
+		result = append(result, encoding.EncodeUvarintAscending([]byte{'/'}, uint64(k.CollectionShortID))...)
+	}
+
+	if k.FieldID != "" {
+		result = append(result, '/')
+		result = append(result, []byte(k.FieldID)...)
+	}
+
+	return result
 }
 
 func (k FieldID) ToDS() ds.Key {

--- a/internal/keys/systemstore_field_id_test.go
+++ b/internal/keys/systemstore_field_id_test.go
@@ -1,0 +1,144 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package keys
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSystemStoreFieldIDKey_Bytes(t *testing.T) {
+	tests := []struct {
+		name     string
+		key      FieldID
+		expected string
+	}{
+		{
+			name:     "empty key",
+			key:      FieldID{},
+			expected: FIELD_SHORT_ID,
+		},
+		{
+			name: "collection only",
+			key: FieldID{
+				CollectionShortID: 1,
+			},
+			expected: FIELD_SHORT_ID + "/\x89",
+		},
+		{
+			name: "collection and index",
+			key: FieldID{
+				CollectionShortID: 1,
+				FieldID:           "idx456",
+			},
+			expected: FIELD_SHORT_ID + "/\x89/idx456",
+		},
+		{
+			name: "collection, index, and search tag",
+			key: FieldID{
+				CollectionShortID: 10,
+				FieldID:           "idx456",
+			},
+			expected: FIELD_SHORT_ID + "/\x92/idx456",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.key.Bytes()
+			assert.Equal(t, tt.expected, string(result))
+		})
+	}
+}
+
+func TestNewFieldIDFromBytes(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		expected    FieldID
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name:  "full valid key",
+			input: FIELD_SHORT_ID + "/\x89/idx456",
+			expected: FieldID{
+				CollectionShortID: 1,
+				FieldID:           "idx456",
+			},
+			expectError: false,
+		},
+		{
+			name:  "key with only collection",
+			input: FIELD_SHORT_ID + "/\x89",
+			expected: FieldID{
+				CollectionShortID: 1,
+			},
+			expectError: false,
+		},
+		{
+			name:        "invalid prefix",
+			input:       "/notfieldshorID/\x89",
+			expected:    FieldID{},
+			expectError: true,
+			errorMsg:    "invalid key string",
+		},
+		{
+			name:        "empty string",
+			input:       "",
+			expected:    FieldID{},
+			expectError: true,
+			errorMsg:    "received empty key string",
+		},
+		{
+			name:        "only slash",
+			input:       "/",
+			expected:    FieldID{},
+			expectError: true,
+			errorMsg:    "invalid key string",
+		},
+		{
+			name:  "key with empty components",
+			input: FIELD_SHORT_ID + "//",
+			expected: FieldID{
+				CollectionShortID: 0,
+				FieldID:           "",
+			},
+			expectError: true,
+			errorMsg:    "insufficient bytes to decode buffer",
+		},
+		{
+			name:  "key with trailing slash",
+			input: FIELD_SHORT_ID + "/\x89/idx456/",
+			expected: FieldID{
+				CollectionShortID: 1,
+				FieldID:           "idx456",
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := NewFieldIDFromBytes([]byte(tt.input))
+			if tt.expectError {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errorMsg)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expected.CollectionShortID, result.CollectionShortID)
+				assert.Equal(t, tt.expected.FieldID, result.FieldID)
+			}
+		})
+	}
+}

--- a/internal/keys/systemstore_field_id_test.go
+++ b/internal/keys/systemstore_field_id_test.go
@@ -70,6 +70,15 @@ func TestNewFieldIDFromBytes(t *testing.T) {
 		errorMsg    string
 	}{
 		{
+			name:  "only prefix",
+			input: FIELD_SHORT_ID,
+			expected: FieldID{
+				CollectionShortID: 0,
+				FieldID:           "",
+			},
+			expectError: false,
+		},
+		{
 			name:  "full valid key",
 			input: FIELD_SHORT_ID + "/\x89/idx456",
 			expected: FieldID{
@@ -98,7 +107,7 @@ func TestNewFieldIDFromBytes(t *testing.T) {
 			input:       "",
 			expected:    FieldID{},
 			expectError: true,
-			errorMsg:    "received empty key string",
+			errorMsg:    "invalid key string",
 		},
 		{
 			name:        "only slash",

--- a/tests/integration/mutation/create/simple_test.go
+++ b/tests/integration/mutation/create/simple_test.go
@@ -170,3 +170,68 @@ func TestMutationCreate_GivenEmptyInput(t *testing.T) {
 
 	testUtils.ExecuteTestCase(t, test)
 }
+
+// TestMutationCreate_With10Collections documents a bug where having more than 9 collections
+// caused field short ID assignment to break, resulting in potentially the wrong value being
+// assigned to certain fields and some fields bing missed entirely.
+func TestMutationCreate_With10Collections(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddSchema{
+				Schema: `
+					type Foo1 {
+						# The name used for the fields is important as the field shortID
+						# is serially assigned based on the alphabetical order of field names.
+						about: String
+						name: String
+					}
+					type Foo2 {
+						name: String
+					}
+					type Foo3 {
+						name: String
+					}
+					type Foo4 {
+						name: String
+					}
+					type Foo5 {
+						name: String
+					}
+					type Foo6 {
+						name: String
+					}
+					type Foo7 {
+						name: String
+					}
+					type Foo8 {
+						name: String
+					}
+					type Foo9 {
+						name: String
+					}
+					type Foo10 {
+						name: String
+					}
+				`,
+			},
+			&action.Request{
+				Request: `mutation {
+					create_Foo1(input: {about: "something", name: "John"}) {
+						about
+						name
+					}
+				}`,
+				Results: map[string]any{
+					"create_Foo1": []map[string]any{
+						{
+							"about": nil,
+							"name":  testUtils.AnyOf("John", "something"),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/mutation/create/simple_test.go
+++ b/tests/integration/mutation/create/simple_test.go
@@ -171,9 +171,6 @@ func TestMutationCreate_GivenEmptyInput(t *testing.T) {
 	testUtils.ExecuteTestCase(t, test)
 }
 
-// TestMutationCreate_With10Collections documents a bug where having more than 9 collections
-// caused field short ID assignment to break, resulting in potentially the wrong value being
-// assigned to certain fields and some fields bing missed entirely.
 func TestMutationCreate_With10Collections(t *testing.T) {
 	test := testUtils.TestCase{
 		Actions: []any{
@@ -224,8 +221,8 @@ func TestMutationCreate_With10Collections(t *testing.T) {
 				Results: map[string]any{
 					"create_Foo1": []map[string]any{
 						{
-							"about": nil,
-							"name":  testUtils.AnyOf("John", "something"),
+							"about": "something",
+							"name":  "John",
 						},
 					},
 				},


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4456 

## Description

This PR fixes an bug that occurred when more than 9 collections were added to DefraDB. Having 10+ collections caused the field short ID retrieval to mishandle the fieldID assignments which then caused some fields to be ignore even when present in the input object and some fields to be randomly assigned a value depending on the input values.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Added an integration test with more than 9 collections

Specify the platform(s) on which this was tested:
- MacOS
