### PR TITLE
fix(cli): Standardize command use strings

### DIFF
--- a/cli/acp_dac_policy_add.go
+++ b/cli/acp_dac_policy_add.go
@@ -22,7 +22,7 @@ func MakeDocumentACPPolicyAddCommand(ctx context.Context) *cobra.Command {
 	var policyFile string
 
 	var cmd = &cobra.Command{
-		Use:   "add <policy>",
+		Use:   "add [policy]",
 		Short: "Add new policy",
 		Long: `Add new policy
 

--- a/cli/acp_dac_policy_add.go
+++ b/cli/acp_dac_policy_add.go
@@ -22,7 +22,7 @@ func MakeDocumentACPPolicyAddCommand(ctx context.Context) *cobra.Command {
 	var policyFile string
 
 	var cmd = &cobra.Command{
-		Use:   "add [policy]",
+		Use:   "add <policy>",
 		Short: "Add new policy",
 		Long: `Add new policy
 

--- a/cli/acp_dac_policy_add.go
+++ b/cli/acp_dac_policy_add.go
@@ -22,7 +22,7 @@ func MakeDocumentACPPolicyAddCommand(ctx context.Context) *cobra.Command {
 	var policyFile string
 
 	var cmd = &cobra.Command{
-		Use:   "add [-i --identity] [policy]",
+		Use:   "add [policy]",
 		Short: "Add new policy",
 		Long: `Add new policy
 

--- a/cli/acp_dac_relationship_add.go
+++ b/cli/acp_dac_relationship_add.go
@@ -25,7 +25,7 @@ func MakeDocumentACPRelationshipAddCommand(ctx context.Context) *cobra.Command {
 	)
 
 	var cmd = &cobra.Command{
-		Use:   "add [--docID] [-c --collection] [-r --relation] [-a --actor] [-i --identity]",
+		Use:   "add",
 		Short: "Add new relationship",
 		Long: `Add new relationship
 

--- a/cli/acp_dac_relationship_add.go
+++ b/cli/acp_dac_relationship_add.go
@@ -84,7 +84,7 @@ Notes:
 		"collection",
 		"c",
 		"",
-		"Collection that has the resource and policy for object",
+		"Collection that has the resource and policy for object (required)",
 	)
 	_ = cmd.MarkFlagRequired("collection")
 
@@ -93,7 +93,7 @@ Notes:
 		"relation",
 		"r",
 		"",
-		"Relation that needs to be set for the relationship",
+		"Relation that needs to be set for the relationship (required)",
 	)
 	_ = cmd.MarkFlagRequired("relation")
 
@@ -102,7 +102,7 @@ Notes:
 		"actor",
 		"a",
 		"",
-		"Actor to add relationship with",
+		"Actor to add relationship with (required)",
 	)
 	_ = cmd.MarkFlagRequired("actor")
 
@@ -110,7 +110,7 @@ Notes:
 		&docIDArg,
 		"docID",
 		"",
-		"Document Identifier (ObjectID) to make relationship for",
+		"Document Identifier (ObjectID) to make relationship for (required)",
 	)
 	_ = cmd.MarkFlagRequired("docID")
 

--- a/cli/acp_dac_relationship_delete.go
+++ b/cli/acp_dac_relationship_delete.go
@@ -76,7 +76,7 @@ Notes:
 		"collection",
 		"c",
 		"",
-		"Collection that has the resource and policy for object",
+		"Collection that has the resource and policy for object (required)",
 	)
 	_ = cmd.MarkFlagRequired("collection")
 
@@ -85,7 +85,7 @@ Notes:
 		"relation",
 		"r",
 		"",
-		"Relation that needs to be deleted within the relationship",
+		"Relation that needs to be deleted within the relationship (required)",
 	)
 	_ = cmd.MarkFlagRequired("relation")
 
@@ -94,7 +94,7 @@ Notes:
 		"actor",
 		"a",
 		"",
-		"Actor to delete relationship for",
+		"Actor to delete relationship for (required)",
 	)
 	_ = cmd.MarkFlagRequired("actor")
 
@@ -102,7 +102,7 @@ Notes:
 		&docIDArg,
 		"docID",
 		"",
-		"Document Identifier (ObjectID) to delete relationship for",
+		"Document Identifier (ObjectID) to delete relationship for (required)",
 	)
 	_ = cmd.MarkFlagRequired("docID")
 

--- a/cli/acp_dac_relationship_delete.go
+++ b/cli/acp_dac_relationship_delete.go
@@ -25,7 +25,7 @@ func MakeDocumentACPRelationshipDeleteCommand(ctx context.Context) *cobra.Comman
 	)
 
 	var cmd = &cobra.Command{
-		Use:   "delete [--docID] [-c --collection] [-r --relation] [-a --actor] [-i --identity]",
+		Use:   "delete",
 		Short: "Delete relationship",
 		Long: `Delete relationship
 

--- a/cli/acp_nac_disable.go
+++ b/cli/acp_nac_disable.go
@@ -20,7 +20,7 @@ import (
 
 func MakeNodeACPDisableCommand(ctx context.Context) *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:   "disable [-i --identity]",
+		Use:   "disable",
 		Short: "Disable the node access control",
 		Long: `Disable the node access control
 

--- a/cli/acp_nac_re-enable.go
+++ b/cli/acp_nac_re-enable.go
@@ -20,7 +20,7 @@ import (
 
 func MakeNodeACPReEnableCommand(ctx context.Context) *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:   "re-enable [-i --identity]",
+		Use:   "re-enable",
 		Short: "Re-enable the node access control",
 		Long: `Re-enable the node access control
 Note:

--- a/cli/acp_nac_relationship_add.go
+++ b/cli/acp_nac_relationship_add.go
@@ -66,7 +66,7 @@ Notes:
 		"relation",
 		"r",
 		"",
-		"Relation that needs to be set for the relationship",
+		"Relation that needs to be set for the relationship (required)",
 	)
 	_ = cmd.MarkFlagRequired("relation")
 
@@ -75,7 +75,7 @@ Notes:
 		"actor",
 		"a",
 		"",
-		"Actor to add relationship with",
+		"Actor to add relationship with (required)",
 	)
 	_ = cmd.MarkFlagRequired("actor")
 

--- a/cli/acp_nac_relationship_add.go
+++ b/cli/acp_nac_relationship_add.go
@@ -23,7 +23,7 @@ func MakeNodeACPRelationshipAddCommand(ctx context.Context) *cobra.Command {
 	)
 
 	var cmd = &cobra.Command{
-		Use:   "add [-r --relation] [-a --actor] [-i --identity]",
+		Use:   "add",
 		Short: "Add new relationship",
 		Long: `Add new relationship
 

--- a/cli/acp_nac_relationship_delete.go
+++ b/cli/acp_nac_relationship_delete.go
@@ -23,7 +23,7 @@ func MakeNodeACPRelationshipDeleteCommand(ctx context.Context) *cobra.Command {
 	)
 
 	var cmd = &cobra.Command{
-		Use:   "delete [-r --relation] [-a --actor] [-i --identity]",
+		Use:   "delete",
 		Short: "Delete relationship",
 		Long: `Delete relationship
 

--- a/cli/acp_nac_relationship_delete.go
+++ b/cli/acp_nac_relationship_delete.go
@@ -65,7 +65,7 @@ Notes:
 		"relation",
 		"r",
 		"",
-		"Relation that needs to be deleted within the relationship",
+		"Relation that needs to be deleted within the relationship (required)",
 	)
 	_ = cmd.MarkFlagRequired("relation")
 
@@ -74,7 +74,7 @@ Notes:
 		"actor",
 		"a",
 		"",
-		"Actor to delete relationship for",
+		"Actor to delete relationship for (required)",
 	)
 	_ = cmd.MarkFlagRequired("actor")
 

--- a/cli/acp_nac_status.go
+++ b/cli/acp_nac_status.go
@@ -18,7 +18,7 @@ import (
 
 func MakeNodeACPStatusCommand(ctx context.Context) *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:   "status [-i --identity]",
+		Use:   "status",
 		Short: "Check the node access control status",
 		Long: `Check the node access control status
 

--- a/cli/backup_export.go
+++ b/cli/backup_export.go
@@ -26,7 +26,7 @@ func MakeBackupExportCommand(ctx context.Context) *cobra.Command {
 	var pretty bool
 	var format string
 	var cmd = &cobra.Command{
-		Use:   "export  [-c --collections | -p --pretty | -f --format] <output_path>",
+		Use:   "export <output_path>",
 		Short: "Export the database to a file",
 		Long: `Export the database to a file. If a file exists at the <output_path> location, it will be overwritten.
 		

--- a/cli/collection.go
+++ b/cli/collection.go
@@ -28,7 +28,7 @@ func MakeCollectionCommand(ctx context.Context) *cobra.Command {
 	var versionID string
 	var getInactive bool
 	var cmd = &cobra.Command{
-		Use:   "collection [--name <name> --collection-id <collectionID> --version-id <versionID>]",
+		Use:   "collection",
 		Short: "Interact with a collection.",
 		Long:  `Create, read, update, and delete documents within a collection.`,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) (err error) {

--- a/cli/collection_create.go
+++ b/cli/collection_create.go
@@ -25,7 +25,7 @@ func MakeCollectionCreateCommand(ctx context.Context) *cobra.Command {
 	var shouldEncryptDoc bool
 	var encryptedFields []string
 	var cmd = &cobra.Command{
-		Use:   "create <document>",
+		Use:   "create [document]",
 		Short: "Create a new document.",
 		Long: `Create a new document.
 		

--- a/cli/collection_create.go
+++ b/cli/collection_create.go
@@ -25,7 +25,7 @@ func MakeCollectionCreateCommand(ctx context.Context) *cobra.Command {
 	var shouldEncryptDoc bool
 	var encryptedFields []string
 	var cmd = &cobra.Command{
-		Use:   "create [document]",
+		Use:   "create <document>",
 		Short: "Create a new document.",
 		Long: `Create a new document.
 		

--- a/cli/collection_create.go
+++ b/cli/collection_create.go
@@ -25,7 +25,7 @@ func MakeCollectionCreateCommand(ctx context.Context) *cobra.Command {
 	var shouldEncryptDoc bool
 	var encryptedFields []string
 	var cmd = &cobra.Command{
-		Use:   "create [-i --identity] [-e --encrypt] [--encrypt-fields] <document>",
+		Use:   "create [document]",
 		Short: "Create a new document.",
 		Long: `Create a new document.
 		

--- a/cli/collection_delete.go
+++ b/cli/collection_delete.go
@@ -22,7 +22,7 @@ func MakeCollectionDeleteCommand(ctx context.Context) *cobra.Command {
 	var argDocID string
 	var filter string
 	var cmd = &cobra.Command{
-		Use:   "delete [-i --identity] [--filter <filter> --docID <docID>]",
+		Use:   "delete",
 		Short: "Delete documents by docID or filter.",
 		Long:  `Delete documents by docID or filter and lists the number of documents deleted.`,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cli/collection_delete.go
+++ b/cli/collection_delete.go
@@ -61,7 +61,7 @@ func MakeCollectionDeleteCommand(ctx context.Context) *cobra.Command {
 	EmbedCLIExample(ctx, cmd, "delete by filter",
 		`defradb client collection delete --name User --filter '{ "_gte": { "points": 100 } }'`)
 
-	cmd.Flags().StringVar(&argDocID, "docID", "", "Document ID")
-	cmd.Flags().StringVar(&filter, "filter", "", "Document filter")
+	cmd.Flags().StringVar(&argDocID, "docID", "", "Document ID (required if --filter not provided)")
+	cmd.Flags().StringVar(&filter, "filter", "", "Document filter (required if --docID not provided)")
 	return cmd
 }

--- a/cli/collection_get.go
+++ b/cli/collection_get.go
@@ -21,7 +21,7 @@ import (
 func MakeCollectionGetCommand(ctx context.Context) *cobra.Command {
 	var showDeleted bool
 	var cmd = &cobra.Command{
-		Use:   "get [-i --identity] [--show-deleted] <docID> ",
+		Use:   "get <docID>",
 		Short: "View document fields.",
 		Long:  `View document fields.`,
 		Args:  cobra.ExactArgs(1),

--- a/cli/collection_list_doc_ids.go
+++ b/cli/collection_list_doc_ids.go
@@ -20,7 +20,7 @@ import (
 
 func MakeCollectionListDocIDsCommand(ctx context.Context) *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:   "docIDs [-i --identity]",
+		Use:   "docIDs",
 		Short: "List all document IDs (docIDs).",
 		Long:  `List all document IDs (docIDs).`,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cli/collection_patch.go
+++ b/cli/collection_patch.go
@@ -28,7 +28,7 @@ func MakeCollectionPatchCommand(ctx context.Context) *cobra.Command {
 	var patchFile string
 	var lensFile string
 	var cmd = &cobra.Command{
-		Use:   "patch <patch> <migration>",
+		Use:   "patch [patch] [migration]",
 		Short: "Patch existing collection versions",
 		Long: `Patch existing collection versions.
 

--- a/cli/collection_patch.go
+++ b/cli/collection_patch.go
@@ -28,7 +28,7 @@ func MakeCollectionPatchCommand(ctx context.Context) *cobra.Command {
 	var patchFile string
 	var lensFile string
 	var cmd = &cobra.Command{
-		Use:   "patch [patch] [migration]",
+		Use:   "patch <patch> <migration>",
 		Short: "Patch existing collection versions",
 		Long: `Patch existing collection versions.
 

--- a/cli/collection_set_active.go
+++ b/cli/collection_set_active.go
@@ -18,7 +18,7 @@ import (
 
 func MakeCollectionSetActiveCommand(ctx context.Context) *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:   "set-active [versionID]",
+		Use:   "set-active <versionID>",
 		Short: "Set the active collection version",
 		Long: `Activates all collection versions with the given version id, and deactivates all
 other versions of that collection.`,

--- a/cli/collection_update.go
+++ b/cli/collection_update.go
@@ -24,7 +24,7 @@ func MakeCollectionUpdateCommand(ctx context.Context) *cobra.Command {
 	var filter string
 	var updater string
 	var cmd = &cobra.Command{
-		Use:   "update [-i --identity] [--filter <filter> --docID <docID>] --updater <updater>",
+		Use:   "update",
 		Short: "Update documents by docID or filter.",
 		Long:  `Update documents by docID or filter.`,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cli/collection_update.go
+++ b/cli/collection_update.go
@@ -80,8 +80,12 @@ func MakeCollectionUpdateCommand(ctx context.Context) *cobra.Command {
 		`defradb client collection update -i 028d53f37a19afb9a0dbc5b4be30c65731479ee8cfa0c9bc8f8bf198cc3c075f --name User \
   --docID bae-123 --updater '{ "verified": true }'`)
 
-	cmd.Flags().StringVar(&argDocID, "docID", "", "Document ID")
-	cmd.Flags().StringVar(&filter, "filter", "", "Document filter")
-	cmd.Flags().StringVar(&updater, "updater", "", "Document updater")
+	cmd.Flags().StringVar(&argDocID, "docID", "", "Document ID (required if --filter not provided)")
+	cmd.Flags().StringVar(&filter, "filter", "", "Document filter (required if --docID not provided)")
+	cmd.Flags().StringVar(&updater, "updater", "", "Document updater (required)")
+
+	//nolint:errcheck
+	cmd.MarkFlagRequired("updater")
+
 	return cmd
 }

--- a/cli/encrypted_index_create.go
+++ b/cli/encrypted_index_create.go
@@ -58,5 +58,12 @@ Currently only "equality" type is supported.`,
 	cmd.Flags().StringVar(&fieldArg, "field", "", "Field to index (required)")
 	cmd.Flags().StringVar(&typeArg, "type", "", "Type of index to create (required)")
 
+	//nolint:errcheck
+	cmd.MarkFlagRequired("collection")
+	//nolint:errcheck
+	cmd.MarkFlagRequired("field")
+	//nolint:errcheck
+	cmd.MarkFlagRequired("type")
+
 	return cmd
 }

--- a/cli/encrypted_index_create.go
+++ b/cli/encrypted_index_create.go
@@ -56,14 +56,12 @@ Currently only "equality" type is supported.`,
 
 	cmd.Flags().StringVarP(&collectionArg, "collection", "c", "", "Collection name (required)")
 	cmd.Flags().StringVar(&fieldArg, "field", "", "Field to index (required)")
-	cmd.Flags().StringVar(&typeArg, "type", "", "Type of index to create (required)")
+	cmd.Flags().StringVar(&typeArg, "type", "", "Type of index to create")
 
 	//nolint:errcheck
 	cmd.MarkFlagRequired("collection")
 	//nolint:errcheck
 	cmd.MarkFlagRequired("field")
-	//nolint:errcheck
-	cmd.MarkFlagRequired("type")
 
 	return cmd
 }

--- a/cli/encrypted_index_create.go
+++ b/cli/encrypted_index_create.go
@@ -54,9 +54,9 @@ Currently only "equality" type is supported.`,
 	EmbedCLIExample(ctx, cmd, "create an index for 'Users' collection on 'name' field",
 		`defradb client encrypted-index create --collection Users --field name`)
 
-	cmd.Flags().StringVarP(&collectionArg, "collection", "c", "", "Collection name")
-	cmd.Flags().StringVar(&fieldArg, "field", "", "Field to index")
-	cmd.Flags().StringVar(&typeArg, "type", "", "Type of index to create")
+	cmd.Flags().StringVarP(&collectionArg, "collection", "c", "", "Collection name (required)")
+	cmd.Flags().StringVar(&fieldArg, "field", "", "Field to index (required)")
+	cmd.Flags().StringVar(&typeArg, "type", "", "Type of index to create (required)")
 
 	return cmd
 }

--- a/cli/encrypted_index_create.go
+++ b/cli/encrypted_index_create.go
@@ -23,7 +23,7 @@ func MakeEncryptedIndexCreateCommand(ctx context.Context) *cobra.Command {
 	var fieldArg string
 	var typeArg string
 	var cmd = &cobra.Command{
-		Use:   "create -c --collection <collection> --field <field> [--type <type>]",
+		Use:   "create",
 		Short: "Creates an encrypted index on a collection's field",
 		Long: `Creates an encrypted index on a collection's field.
 

--- a/cli/encrypted_index_delete.go
+++ b/cli/encrypted_index_delete.go
@@ -20,7 +20,7 @@ func MakeEncryptedIndexDeleteCommand(ctx context.Context) *cobra.Command {
 	var collectionArg string
 	var fieldArg string
 	var cmd = &cobra.Command{
-		Use:       "delete -c --collection <collection> --field <field>",
+		Use:       "delete",
 		Short:     "Delete an encrypted index from a collection's field",
 		Long:      `Delete an encrypted index from a collection's field.`,
 		ValidArgs: []string{"collection", "field"},

--- a/cli/encrypted_index_delete.go
+++ b/cli/encrypted_index_delete.go
@@ -42,5 +42,10 @@ func MakeEncryptedIndexDeleteCommand(ctx context.Context) *cobra.Command {
 	cmd.Flags().StringVarP(&collectionArg, "collection", "c", "", "Collection name (required)")
 	cmd.Flags().StringVar(&fieldArg, "field", "", "Field name to delete encrypted index from (required)")
 
+	//nolint:errcheck
+	cmd.MarkFlagRequired("collection")
+	//nolint:errcheck
+	cmd.MarkFlagRequired("field")
+
 	return cmd
 }

--- a/cli/encrypted_index_delete.go
+++ b/cli/encrypted_index_delete.go
@@ -39,8 +39,8 @@ func MakeEncryptedIndexDeleteCommand(ctx context.Context) *cobra.Command {
 	EmbedCLIExample(ctx, cmd, "delete an encrypted index for 'Users' collection on 'name' field",
 		`defradb client encrypted-index delete --collection Users --field name`)
 
-	cmd.Flags().StringVarP(&collectionArg, "collection", "c", "", "Collection name")
-	cmd.Flags().StringVar(&fieldArg, "field", "", "Field name to delete encrypted index from")
+	cmd.Flags().StringVarP(&collectionArg, "collection", "c", "", "Collection name (required)")
+	cmd.Flags().StringVar(&fieldArg, "field", "", "Field name to delete encrypted index from (required)")
 
 	return cmd
 }

--- a/cli/encrypted_index_list.go
+++ b/cli/encrypted_index_list.go
@@ -53,7 +53,7 @@ Otherwise, all encrypted indexes in the database will be shown.`,
 	EmbedCLIExample(ctx, cmd, "show all encrypted indexes for 'Users' collection",
 		`defradb client encrypted-index list --collection Users`)
 
-	cmd.Flags().StringVarP(&collectionArg, "collection", "c", "", "Collection name")
+	cmd.Flags().StringVarP(&collectionArg, "collection", "c", "", "Collection name (required)")
 
 	return cmd
 }

--- a/cli/encrypted_index_list.go
+++ b/cli/encrypted_index_list.go
@@ -53,7 +53,7 @@ Otherwise, all encrypted indexes in the database will be shown.`,
 	EmbedCLIExample(ctx, cmd, "show all encrypted indexes for 'Users' collection",
 		`defradb client encrypted-index list --collection Users`)
 
-	cmd.Flags().StringVarP(&collectionArg, "collection", "c", "", "Collection name (required)")
+	cmd.Flags().StringVarP(&collectionArg, "collection", "c", "", "Collection name")
 
 	return cmd
 }

--- a/cli/encrypted_index_list.go
+++ b/cli/encrypted_index_list.go
@@ -19,7 +19,7 @@ import (
 func MakeEncryptedIndexListCommand(ctx context.Context) *cobra.Command {
 	var collectionArg string
 	var cmd = &cobra.Command{
-		Use:   "list [-c --collection <collection>]",
+		Use:   "list",
 		Short: "Lists the encrypted indexes in the database or for a specific collection",
 		Long: `Shows the list encrypted indexes in the database or for a specific collection.
 

--- a/cli/index_create.go
+++ b/cli/index_create.go
@@ -92,5 +92,10 @@ If no order is specified for the field, the default value will be "ASC"`,
 	cmd.Flags().StringSliceVar(&fieldsArg, "fields", []string{}, "Fields to index (required)")
 	cmd.Flags().BoolVarP(&uniqueArg, "unique", "u", false, "Make the index unique")
 
+	//nolint:errcheck
+	cmd.MarkFlagRequired("collection")
+	//nolint:errcheck
+	cmd.MarkFlagRequired("fields")
+
 	return cmd
 }

--- a/cli/index_create.go
+++ b/cli/index_create.go
@@ -87,9 +87,9 @@ If no order is specified for the field, the default value will be "ASC"`,
 	EmbedCLIExample(ctx, cmd, "create a unique index for 'Users' collection on 'name' and 'age'",
 		`defradb client index create --collection Users --fields name:ASC,age:DESC --unique`)
 
-	cmd.Flags().StringVarP(&collectionArg, "collection", "c", "", "Collection name")
+	cmd.Flags().StringVarP(&collectionArg, "collection", "c", "", "Collection name (required)")
 	cmd.Flags().StringVarP(&nameArg, "name", "n", "", "Index name")
-	cmd.Flags().StringSliceVar(&fieldsArg, "fields", []string{}, "Fields to index")
+	cmd.Flags().StringSliceVar(&fieldsArg, "fields", []string{}, "Fields to index (required)")
 	cmd.Flags().BoolVarP(&uniqueArg, "unique", "u", false, "Make the index unique")
 
 	return cmd

--- a/cli/index_create.go
+++ b/cli/index_create.go
@@ -25,7 +25,7 @@ func MakeIndexCreateCommand(ctx context.Context) *cobra.Command {
 	var fieldsArg []string
 	var uniqueArg bool
 	var cmd = &cobra.Command{
-		Use:   "create -c --collection <collection> --fields <fields[:ASC|:DESC]> [-n --name <name>] [--unique]",
+		Use:   "create",
 		Short: "Creates a secondary index on a collection's field(s)",
 		Long: `Creates a secondary index on a collection's field(s).
 

--- a/cli/index_drop.go
+++ b/cli/index_drop.go
@@ -20,7 +20,7 @@ func MakeIndexDropCommand(ctx context.Context) *cobra.Command {
 	var collectionArg string
 	var nameArg string
 	var cmd = &cobra.Command{
-		Use:       "drop -c --collection <collection> -n --name <name>",
+		Use:       "drop",
 		Short:     "Drop a collection's secondary index",
 		Long:      `Drop a collection's secondary index.`,
 		ValidArgs: []string{"collection", "name"},

--- a/cli/index_drop.go
+++ b/cli/index_drop.go
@@ -38,7 +38,7 @@ func MakeIndexDropCommand(ctx context.Context) *cobra.Command {
 	EmbedCLIExample(ctx, cmd, "drop the index 'UsersByName' for 'Users' collection",
 		`defradb client index drop --collection Users --name UsersByName`)
 
-	cmd.Flags().StringVarP(&collectionArg, "collection", "c", "", "Collection name")
+	cmd.Flags().StringVarP(&collectionArg, "collection", "c", "", "Collection name (required)")
 	cmd.Flags().StringVarP(&nameArg, "name", "n", "", "Index name")
 
 	return cmd

--- a/cli/index_drop.go
+++ b/cli/index_drop.go
@@ -39,7 +39,12 @@ func MakeIndexDropCommand(ctx context.Context) *cobra.Command {
 		`defradb client index drop --collection Users --name UsersByName`)
 
 	cmd.Flags().StringVarP(&collectionArg, "collection", "c", "", "Collection name (required)")
-	cmd.Flags().StringVarP(&nameArg, "name", "n", "", "Index name")
+	cmd.Flags().StringVarP(&nameArg, "name", "n", "", "Index name (required)")
+
+	//nolint:errcheck
+	cmd.MarkFlagRequired("collection")
+	//nolint:errcheck
+	cmd.MarkFlagRequired("name")
 
 	return cmd
 }

--- a/cli/index_list.go
+++ b/cli/index_list.go
@@ -53,7 +53,7 @@ Otherwise, all indexes in the database will be shown.`,
 	EmbedCLIExample(ctx, cmd, "show all index for 'Users' collection",
 		`defradb client index list --collection Users`)
 
-	cmd.Flags().StringVarP(&collectionArg, "collection", "c", "", "Collection name (required)")
+	cmd.Flags().StringVarP(&collectionArg, "collection", "c", "", "Collection name")
 
 	return cmd
 }

--- a/cli/index_list.go
+++ b/cli/index_list.go
@@ -19,7 +19,7 @@ import (
 func MakeIndexListCommand(ctx context.Context) *cobra.Command {
 	var collectionArg string
 	var cmd = &cobra.Command{
-		Use:   "list [-c --collection <collection>]",
+		Use:   "list",
 		Short: "Shows the list indexes in the database or for a specific collection",
 		Long: `Shows the list indexes in the database or for a specific collection.
 

--- a/cli/index_list.go
+++ b/cli/index_list.go
@@ -53,7 +53,7 @@ Otherwise, all indexes in the database will be shown.`,
 	EmbedCLIExample(ctx, cmd, "show all index for 'Users' collection",
 		`defradb client index list --collection Users`)
 
-	cmd.Flags().StringVarP(&collectionArg, "collection", "c", "", "Collection name")
+	cmd.Flags().StringVarP(&collectionArg, "collection", "c", "", "Collection name (required)")
 
 	return cmd
 }

--- a/cli/lens_add.go
+++ b/cli/lens_add.go
@@ -25,7 +25,7 @@ import (
 func MakeLensAddCommand(ctx context.Context) *cobra.Command {
 	var lensFile string
 	var cmd = &cobra.Command{
-		Use:   "add <cfg>",
+		Use:   "add [cfg]",
 		Short: "Add a lens to the lens store",
 		Long: `Add a lens configuration to the lens store and return its CID.
 

--- a/cli/lens_add.go
+++ b/cli/lens_add.go
@@ -25,7 +25,7 @@ import (
 func MakeLensAddCommand(ctx context.Context) *cobra.Command {
 	var lensFile string
 	var cmd = &cobra.Command{
-		Use:   "add [cfg]",
+		Use:   "add <cfg>",
 		Short: "Add a lens to the lens store",
 		Long: `Add a lens configuration to the lens store and return its CID.
 

--- a/cli/lens_set.go
+++ b/cli/lens_set.go
@@ -27,7 +27,7 @@ import (
 func MakeLensSetCommand(ctx context.Context) *cobra.Command {
 	var lensFile string
 	var cmd = &cobra.Command{
-		Use:   "set [src] [dst] [cfg]",
+		Use:   "set <src> <dst> <cfg>",
 		Short: "Set a schema migration within DefraDB",
 		Long: `Set a migration from a source schema version to a destination schema version for
 all collections that are on the given source schema version within the local DefraDB node.

--- a/cli/lens_set.go
+++ b/cli/lens_set.go
@@ -27,7 +27,7 @@ import (
 func MakeLensSetCommand(ctx context.Context) *cobra.Command {
 	var lensFile string
 	var cmd = &cobra.Command{
-		Use:   "set <src> <dst> <cfg>",
+		Use:   "set <src> <dst> [cfg]",
 		Short: "Set a schema migration within DefraDB",
 		Long: `Set a migration from a source schema version to a destination schema version for
 all collections that are on the given source schema version within the local DefraDB node.

--- a/cli/p2p_collection_create.go
+++ b/cli/p2p_collection_create.go
@@ -19,7 +19,7 @@ import (
 
 func MakeP2PCollectionCreateCommand(ctx context.Context) *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:   "create <collectionNames...>",
+		Use:   "create <collectionNames>",
 		Short: "Create P2P collections",
 		Long: `Create P2P collections to the synchronized pubsub topics.
 The collections are synchronized between nodes of a pubsub network.`,

--- a/cli/p2p_collection_create.go
+++ b/cli/p2p_collection_create.go
@@ -19,7 +19,7 @@ import (
 
 func MakeP2PCollectionCreateCommand(ctx context.Context) *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:   "create [collectionNames]",
+		Use:   "create <collectionNames...>",
 		Short: "Create P2P collections",
 		Long: `Create P2P collections to the synchronized pubsub topics.
 The collections are synchronized between nodes of a pubsub network.`,

--- a/cli/p2p_collection_delete.go
+++ b/cli/p2p_collection_delete.go
@@ -19,7 +19,7 @@ import (
 
 func MakeP2PCollectionDeleteCommand(ctx context.Context) *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:   "delete [collectionNames]",
+		Use:   "delete <collectionNames...>",
 		Short: "Delete P2P collections",
 		Long: `Delete P2P collections from the followed pubsub topics.
 The removed collections will no longer be synchronized between nodes.`,

--- a/cli/p2p_collection_delete.go
+++ b/cli/p2p_collection_delete.go
@@ -19,7 +19,7 @@ import (
 
 func MakeP2PCollectionDeleteCommand(ctx context.Context) *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:   "delete <collectionNames...>",
+		Use:   "delete <collectionNames>",
 		Short: "Delete P2P collections",
 		Long: `Delete P2P collections from the followed pubsub topics.
 The removed collections will no longer be synchronized between nodes.`,

--- a/cli/p2p_collection_sync_branchable.go
+++ b/cli/p2p_collection_sync_branchable.go
@@ -18,7 +18,7 @@ import (
 
 func MakeP2PCollectionSyncBranchableCommand(ctx context.Context) *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:   "sync-branchable [collection-id]",
+		Use:   "sync-branchable <collection-id>",
 		Short: "Synchronize a branchable collection's DAG from the network",
 		Long: `Synchronize a branchable collection's DAG from the network.
 

--- a/cli/p2p_collection_sync_versions.go
+++ b/cli/p2p_collection_sync_versions.go
@@ -18,7 +18,7 @@ import (
 
 func MakeP2PCollectionSyncVersionsCommand(ctx context.Context) *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:   "sync-versions [versionID...]",
+		Use:   "sync-versions <versionID...>",
 		Short: "Synchronize specific collection versions from the network",
 		Long: `Synchronize specific collection versions from the network.
 

--- a/cli/p2p_document_create.go
+++ b/cli/p2p_document_create.go
@@ -19,7 +19,7 @@ import (
 
 func MakeP2PDocumentCreateCommand(ctx context.Context) *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:   "create <docIDs...>",
+		Use:   "create <docIDs>",
 		Short: "Create P2P documents",
 		Long: `Create P2P documents to the synchronized pubsub topics.
 The documents are synchronized between nodes of a pubsub network.`,

--- a/cli/p2p_document_create.go
+++ b/cli/p2p_document_create.go
@@ -19,7 +19,7 @@ import (
 
 func MakeP2PDocumentCreateCommand(ctx context.Context) *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:   "create [docIDs]",
+		Use:   "create <docIDs...>",
 		Short: "Create P2P documents",
 		Long: `Create P2P documents to the synchronized pubsub topics.
 The documents are synchronized between nodes of a pubsub network.`,

--- a/cli/p2p_document_delete.go
+++ b/cli/p2p_document_delete.go
@@ -19,7 +19,7 @@ import (
 
 func MakeP2PDocumentDeleteCommand(ctx context.Context) *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:   "delete [docIDs]",
+		Use:   "delete <docIDs...>",
 		Short: "Delete P2P documents",
 		Long: `Delete P2P documents from the followed pubsub topics.
 The removed documents will no longer be synchronized between nodes.`,

--- a/cli/p2p_document_delete.go
+++ b/cli/p2p_document_delete.go
@@ -19,7 +19,7 @@ import (
 
 func MakeP2PDocumentDeleteCommand(ctx context.Context) *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:   "delete <docIDs...>",
+		Use:   "delete <docIDs>",
 		Short: "Delete P2P documents",
 		Long: `Delete P2P documents from the followed pubsub topics.
 The removed documents will no longer be synchronized between nodes.`,

--- a/cli/p2p_document_sync.go
+++ b/cli/p2p_document_sync.go
@@ -18,7 +18,7 @@ import (
 
 func MakeP2PDocumentSyncCommand(ctx context.Context) *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:   "sync [collection-name] [docID...]",
+		Use:   "sync <collection-name> <docID...>",
 		Short: "Synchronize specific documents from the network",
 		Long: `Synchronize specific documents from the network.
 

--- a/cli/p2p_replicator_delete.go
+++ b/cli/p2p_replicator_delete.go
@@ -19,7 +19,7 @@ import (
 func MakeP2PReplicatorDeleteCommand(ctx context.Context) *cobra.Command {
 	var collections []string
 	var cmd = &cobra.Command{
-		Use:   "delete [-c, --collection] <peerID>",
+		Use:   "delete <peerID>",
 		Short: "Delete replicator(s) and stop synchronization",
 		Long: `Delete replicator(s) and stop synchronization.
 A replicator synchronizes one or all collection(s) from this instance to another.`,

--- a/cli/p2p_replicator_set.go
+++ b/cli/p2p_replicator_set.go
@@ -19,7 +19,7 @@ import (
 func MakeP2PReplicatorSetCommand(ctx context.Context) *cobra.Command {
 	var collections []string
 	var cmd = &cobra.Command{
-		Use:   "set [-c, --collection] <addresses...>",
+		Use:   "set <addresses...>",
 		Short: "Add replicator(s) and start synchronization",
 		Long: `Add replicator(s) and start synchronization.
 A replicator synchronizes one or all collection(s) from this instance to another.`,

--- a/cli/request.go
+++ b/cli/request.go
@@ -32,7 +32,7 @@ func MakeRequestCommand(ctx context.Context) *cobra.Command {
 	var operationName string
 	var variablesJSON string
 	var cmd = &cobra.Command{
-		Use:   "query [-i --identity] [request]",
+		Use:   "query [request]",
 		Short: "Send a DefraDB GraphQL query request",
 		Long: `Send a DefraDB GraphQL query request to the database.
 

--- a/cli/request.go
+++ b/cli/request.go
@@ -32,7 +32,7 @@ func MakeRequestCommand(ctx context.Context) *cobra.Command {
 	var operationName string
 	var variablesJSON string
 	var cmd = &cobra.Command{
-		Use:   "query <request>",
+		Use:   "query [request]",
 		Short: "Send a DefraDB GraphQL query request",
 		Long: `Send a DefraDB GraphQL query request to the database.
 

--- a/cli/request.go
+++ b/cli/request.go
@@ -32,7 +32,7 @@ func MakeRequestCommand(ctx context.Context) *cobra.Command {
 	var operationName string
 	var variablesJSON string
 	var cmd = &cobra.Command{
-		Use:   "query [request]",
+		Use:   "query <request>",
 		Short: "Send a DefraDB GraphQL query request",
 		Long: `Send a DefraDB GraphQL query request to the database.
 

--- a/cli/schema_add.go
+++ b/cli/schema_add.go
@@ -21,7 +21,7 @@ import (
 func MakeSchemaAddCommand(ctx context.Context) *cobra.Command {
 	var schemaFiles []string
 	var cmd = &cobra.Command{
-		Use:   "add [schema]",
+		Use:   "add <schema>",
 		Short: "Add new schema",
 		Long: `Add new schema.
 

--- a/cli/schema_add.go
+++ b/cli/schema_add.go
@@ -21,7 +21,7 @@ import (
 func MakeSchemaAddCommand(ctx context.Context) *cobra.Command {
 	var schemaFiles []string
 	var cmd = &cobra.Command{
-		Use:   "add <schema>",
+		Use:   "add [schema]",
 		Short: "Add new schema",
 		Long: `Add new schema.
 

--- a/cli/sdl_generate.go
+++ b/cli/sdl_generate.go
@@ -34,7 +34,7 @@ func MakeSDLGenerateCommand(ctx context.Context) *cobra.Command {
 	var yesOverwrite bool
 	var searchableEncryption bool
 	var cmd = &cobra.Command{
-		Use:   "generate --output schema.graphql <input schema files...>",
+		Use:   "generate <input schema files...>",
 		Short: "Generate full GraphQL formatted schema.",
 		Long: `Generates the fully formatted GraphQL schema from a given user type definition(s).
 

--- a/cli/tx_commit.go
+++ b/cli/tx_commit.go
@@ -21,7 +21,7 @@ import (
 
 func MakeTxCommitCommand(ctx context.Context) *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:   "commit [id]",
+		Use:   "commit <id>",
 		Short: "Commit a DefraDB transaction.",
 		Long:  `Commit a DefraDB transaction.`,
 		Args:  cobra.ExactArgs(1),

--- a/cli/tx_discard.go
+++ b/cli/tx_discard.go
@@ -21,7 +21,7 @@ import (
 
 func MakeTxDiscardCommand(ctx context.Context) *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:   "discard [id]",
+		Use:   "discard <id>",
 		Short: "Discard a DefraDB transaction.",
 		Long:  `Discard a DefraDB transaction.`,
 		Args:  cobra.ExactArgs(1),

--- a/cli/view_add.go
+++ b/cli/view_add.go
@@ -62,6 +62,8 @@ Learn more about the DefraDB GraphQL Schema Language on https://docs.source.netw
 
 	cmd.MarkFlagsMutuallyExclusive("query", "query-file")
 	cmd.MarkFlagsMutuallyExclusive("sdl", "sdl-file")
+	cmd.MarkFlagsOneRequired("query", "query-file")
+	cmd.MarkFlagsOneRequired("sdl", "sdl-file")
 
 	EmbedCLIExample(ctx, cmd, "add a simple view from string flags",
 		`defradb client view add --query 'Foo { name, ...}' --sdl 'type Foo { ... }'`)

--- a/cli/view_add.go
+++ b/cli/view_add.go
@@ -23,7 +23,7 @@ func MakeViewAddCommand(ctx context.Context) *cobra.Command {
 	var query, sdl, lensCID string
 	var queryFile, sdlFile string
 	cmd := &cobra.Command{
-		Use:   "add <query|query-file> <sdl|sdl-file>",
+		Use:   "add",
 		Short: "Add new view",
 		Long: `Add new database view.
 

--- a/cli/view_add.go
+++ b/cli/view_add.go
@@ -54,10 +54,10 @@ Learn more about the DefraDB GraphQL Schema Language on https://docs.source.netw
 			return writeJSON(cmd, defs)
 		},
 	}
-	cmd.Flags().StringVarP(&query, "query", "", "", "Query")
-	cmd.Flags().StringVarP(&queryFile, "query-file", "", "", "Query file")
-	cmd.Flags().StringVarP(&sdl, "sdl", "", "", "SDL")
-	cmd.Flags().StringVarP(&sdlFile, "sdl-file", "", "", "SDL file")
+	cmd.Flags().StringVarP(&query, "query", "", "", "Query (required if --query-file not provided)")
+	cmd.Flags().StringVarP(&queryFile, "query-file", "", "", "Query file (required if --query not provided)")
+	cmd.Flags().StringVarP(&sdl, "sdl", "", "", "SDL (required if --sdl-file not provided)")
+	cmd.Flags().StringVarP(&sdlFile, "sdl-file", "", "", "SDL file (required if --sdl not provided)")
 	cmd.Flags().StringVar(&lensCID, "lens-cid", "", "CID of an existing lens transform (use 'lens add' first)")
 
 	cmd.MarkFlagsMutuallyExclusive("query", "query-file")

--- a/cli/view_add.go
+++ b/cli/view_add.go
@@ -23,7 +23,7 @@ func MakeViewAddCommand(ctx context.Context) *cobra.Command {
 	var query, sdl, lensCID string
 	var queryFile, sdlFile string
 	cmd := &cobra.Command{
-		Use:   "add [query|query-file] [sdl|sdl-file]",
+		Use:   "add <query|query-file> <sdl|sdl-file>",
 		Short: "Add new view",
 		Long: `Add new database view.
 


### PR DESCRIPTION
## Relevant issue(s)

Resolves #1651

## Description

Standardized the `Use` string across CLI commands by removing redundant flag definitions. The `Use` string now only contains the command name and required positional arguments. Optional flags are automatically listed in the "Flags" section generated by Cobra, resulting in cleaner and more consistent help output.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style.
- [x] I made sure to discuss its limitations.

## How has this been tested?

Verified by running help commands for various modified CLI tools (e.g., `defradb client collection create --help`, `defradb client index create --help`) and confirming the `Usage:` line is clean and flags are correctly listed in the "Flags" section.

Specify the platform(s) on which this was tested:
- Linux