### PR TITLE
fix: Remove extraneous comment in C Binding header

### DIFF
--- a/cbindings/query.go
+++ b/cbindings/query.go
@@ -69,7 +69,7 @@ func removeSubscription(id string) {
 // it exists will see if there's a message in its result channel. If there isn't, it will
 // return with status 2, and a blank payload. If there is, it will return with status 0,
 // and the payload of the message. If an error occurs, status 1 is returned.
-//
+
 //export PollSubscription
 func PollSubscription(id *C.char) C.Result {
 	subID := C.GoString(id)


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4479 

## Description

Due to a blank line comment connecting a comment and a CGO directive, an extraneous comment will be output and included in the `libdefradb.h` file that is generated when building the C bindings. By removing this line, the problem is fixed. Very tiny PR.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [ ] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Specify the platform(s) on which this was tested:
- WSL
