### PR TITLE
test: Document delete collection concurrency bug

### DIFF
--- a/tests/action/async_await.go
+++ b/tests/action/async_await.go
@@ -1,0 +1,73 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package action
+
+import (
+	"sync"
+
+	"github.com/sourcenetwork/defradb/tests/state"
+)
+
+// Async executes the child action in its own child go-routine, the child routine will
+// be fully initialized before `Execute()` unblocks, but it is not guaranteed to be executing by
+// the runtime.
+//
+// This action is typically used alongside an `Await` action.
+type Async struct {
+	s *state.State
+
+	// The child action that should be executed in asynchronously.
+	Child Action
+}
+
+var _ Action = (*Async)(nil)
+var _ Stateful = (*Async)(nil)
+
+func (a *Async) SetState(s *state.State) {
+	a.s = s
+
+	if stateful, ok := a.Child.(Stateful); ok {
+		stateful.SetState(s)
+	}
+}
+
+func (a *Async) Execute() {
+	a.s.AsyncWG.Add(1)
+
+	// childReady is responsible for ensuring that all child routines have been set up and are
+	// now waiting for the start lock to be unlocked.
+	childReady := sync.WaitGroup{}
+	childReady.Add(1)
+	go func() {
+		// T.Skip() respects `defer` statements, and `a.s.AsyncWG.Wait()` in the parent routine, but
+		// it does not respect lines after the `T.Skip()` call within this child-routine.
+		defer a.s.AsyncWG.Done()
+
+		childReady.Done()
+
+		a.Child.Execute()
+	}()
+
+	// Wait for all the children to be ready before returning.
+	childReady.Wait()
+}
+
+// Await waits for all executing `Async` actions to complete.
+type Await struct {
+	stateful
+}
+
+var _ Action = (*Await)(nil)
+var _ Stateful = (*Await)(nil)
+
+func (a *Await) Execute() {
+	a.s.AsyncWG.Wait()
+}

--- a/tests/action/async_await.go
+++ b/tests/action/async_await.go
@@ -47,13 +47,11 @@ func (a *Async) Execute() {
 	childReady := sync.WaitGroup{}
 	childReady.Add(1)
 	go func() {
-		// T.Skip() respects `defer` statements, and `a.s.AsyncWG.Wait()` in the parent routine, but
-		// it does not respect lines after the `T.Skip()` call within this child-routine.
-		defer a.s.AsyncWG.Done()
-
 		childReady.Done()
 
 		a.Child.Execute()
+
+		a.s.AsyncWG.Done()
 	}()
 
 	// Wait for all the children to be ready before returning.
@@ -70,4 +68,10 @@ var _ Stateful = (*Await)(nil)
 
 func (a *Await) Execute() {
 	a.s.AsyncWG.Wait()
+
+	if len(a.s.SkipTest) > 0 {
+		// Child actions cannot skip the test from within their own routine, so we must check here
+		// to see if they want to.
+		a.s.T.Skip(a.s.SkipTest)
+	}
 }

--- a/tests/action/create_doc.go
+++ b/tests/action/create_doc.go
@@ -80,6 +80,9 @@ type CreateDoc struct {
 	// Setting this property to true whilst testing P2P functionality will probably result in a
 	// flaky test.
 	DoNotWaitForEvent bool
+
+	// If the given error is received, ignore the error and pretend the action succeeded.
+	IgnoreError string
 }
 
 var _ Action = (*CreateDoc)(nil)
@@ -122,7 +125,9 @@ func (a *CreateDoc) Execute() {
 				return err
 			},
 		)
-		expectedErrorRaised = assertError(a.s.T, err, a.ExpectedError)
+		if err != nil && !strings.Contains(err.Error(), a.IgnoreError) {
+			expectedErrorRaised = assertError(a.s.T, err, a.ExpectedError)
+		}
 	}
 
 	assertExpectedErrorRaised(a.s.T, a.ExpectedError, expectedErrorRaised)

--- a/tests/action/create_doc.go
+++ b/tests/action/create_doc.go
@@ -125,7 +125,7 @@ func (a *CreateDoc) Execute() {
 				return err
 			},
 		)
-		if err != nil && !strings.Contains(err.Error(), a.IgnoreError) {
+		if err == nil || !(len(a.IgnoreError) > 0 && strings.Contains(err.Error(), a.IgnoreError)) {
 			expectedErrorRaised = assertError(a.s.T, err, a.ExpectedError)
 		}
 	}

--- a/tests/action/parallel.go
+++ b/tests/action/parallel.go
@@ -75,4 +75,10 @@ func (a *Parallel) Execute() {
 	startLock.Unlock()
 
 	finishedWG.Wait()
+
+	if len(a.s.SkipTest) > 0 {
+		// Child actions cannot skip the test from within their own routine, so we must check here
+		// to see if they want to.
+		a.s.T.Skip(a.s.SkipTest)
+	}
 }

--- a/tests/action/patch_collection.go
+++ b/tests/action/patch_collection.go
@@ -11,6 +11,8 @@
 package action
 
 import (
+	"fmt"
+
 	"github.com/sourcenetwork/immutable"
 	"github.com/sourcenetwork/lens/host-go/config/model"
 
@@ -65,10 +67,9 @@ func (a *PatchCollection) Execute() {
 		nodeID := nodeIDs[index]
 		ctx := getContextWithIdentity(a.s.Ctx, a.s, a.Identity, nodeID)
 		err := node.PatchCollection(ctx, patch, a.Lens)
-		if a.SkipTestOnError != nil && err != nil {
-			if errors.Is(err, a.SkipTestOnError) {
-				a.s.T.Skipf("known error: %s", err.Error())
-			}
+		if a.SkipTestOnError != nil && err != nil && errors.Is(err, a.SkipTestOnError) {
+			a.s.SkipTest = fmt.Sprintf("known error: %s", err.Error())
+			return
 		}
 
 		expectedErrorRaised := assertError(a.s.T, err, a.ExpectedError)

--- a/tests/action/patch_collection.go
+++ b/tests/action/patch_collection.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sourcenetwork/immutable"
 	"github.com/sourcenetwork/lens/host-go/config/model"
 
+	"github.com/sourcenetwork/defradb/errors"
 	"github.com/sourcenetwork/defradb/tests/state"
 )
 
@@ -43,6 +44,11 @@ type PatchCollection struct {
 	// String can be a partial, and the test will pass if an error is returned that
 	// contains this string.
 	ExpectedError string
+
+	// Skip this test if the following error is returned when executing this action.
+	//
+	// This should only be used for rare, known, unrecoverable errors.
+	SkipTestOnError error
 }
 
 var _ Action = (*PatchCollection)(nil)
@@ -59,6 +65,12 @@ func (a *PatchCollection) Execute() {
 		nodeID := nodeIDs[index]
 		ctx := getContextWithIdentity(a.s.Ctx, a.s, a.Identity, nodeID)
 		err := node.PatchCollection(ctx, patch, a.Lens)
+		if a.SkipTestOnError != nil && err != nil {
+			if errors.Is(err, a.SkipTestOnError) {
+				a.s.T.Skipf("known error: %s", err.Error())
+			}
+		}
+
 		expectedErrorRaised := assertError(a.s.T, err, a.ExpectedError)
 
 		assertExpectedErrorRaised(a.s.T, a.ExpectedError, expectedErrorRaised)

--- a/tests/integration/collection_version/updates/remove/collections_test.go
+++ b/tests/integration/collection_version/updates/remove/collections_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/sourcenetwork/defradb/tests/action"
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
 	"github.com/sourcenetwork/defradb/tests/multiplier"
+	"github.com/sourcenetwork/defradb/tests/state"
 )
 
 func TestColVersionUpdateRemoveCollections_ByID(t *testing.T) {
@@ -672,6 +673,11 @@ func TestColVersionUpdateAddFieldRemoveMultipleNewCollection_MiddleAndLast(t *te
 // https://github.com/sourcenetwork/defradb/issues/4268
 func TestColVersionUpdateRemoveCollections_ConcurrentWrite(t *testing.T) {
 	test := testUtils.TestCase{
+		SupportedClientTypes: immutable.Some([]state.ClientType{
+			// The other client types return different errors when occasionally executing the `CreateDoc`
+			// action.
+			state.GoClientType,
+		}),
 		Actions: []any{
 			&action.AddSchema{
 				Schema: `
@@ -702,6 +708,10 @@ func TestColVersionUpdateRemoveCollections_ConcurrentWrite(t *testing.T) {
 				DocMap: map[string]any{
 					"name": "John",
 				},
+				// This error can occur if the create-doc call starts after the patch collection call (mostly)
+				// completes, it is uncommon for this to happen, but it does sometimes, especially on slower
+				// machines.
+				IgnoreError: "Cannot query field \"create_Users\" on type \"Mutation\"",
 			},
 			&action.Await{},
 			&action.GetCollections{

--- a/tests/integration/collection_version/updates/remove/collections_test.go
+++ b/tests/integration/collection_version/updates/remove/collections_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sourcenetwork/immutable"
 
 	"github.com/sourcenetwork/defradb/client"
+	"github.com/sourcenetwork/defradb/internal/db"
 	"github.com/sourcenetwork/defradb/tests/action"
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
 	"github.com/sourcenetwork/defradb/tests/multiplier"
@@ -660,6 +661,64 @@ func TestColVersionUpdateAddFieldRemoveMultipleNewCollection_MiddleAndLast(t *te
 						},
 					},
 				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+// This test documents unwanted behaviour (see final assert):
+// https://github.com/sourcenetwork/defradb/issues/4268
+func TestColVersionUpdateRemoveCollections_ConcurrentWrite(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddSchema{
+				Schema: `
+					type Users {
+						name: String
+					}
+				`,
+			},
+			&action.Async{
+				// todo - we also need to test this with explicit transactions both async and sync
+				// https://github.com/sourcenetwork/defradb/issues/4476
+				Child: &action.PatchCollection{
+					// If the create call completes before the patch starts this will error - skip the test
+					// when this happens as it is unrecoverable and rare.
+					SkipTestOnError: db.ErrCannotDeleteCollectionWithDocs,
+					Patch: `
+						[
+							{
+								"op": "remove",
+								"path": "/Users"
+							}
+						]
+					`,
+				},
+			},
+			&action.CreateDoc{
+				DoNotWaitForEvent: true,
+				DocMap: map[string]any{
+					"name": "John",
+				},
+			},
+			&action.Await{},
+			&action.GetCollections{
+				ExpectedResults: []client.CollectionVersion{},
+			},
+			&action.Request{
+				Request: `query {
+					_commits {
+						cid
+					}
+				}`,
+				Results: map[string]any{
+					"_commits": []map[string]any{},
+				},
+				// This action should not error, this is the unwanted behaviour that this
+				// test documents.
+				ExpectedError: "key not found",
 			},
 		},
 	}

--- a/tests/state/state.go
+++ b/tests/state/state.go
@@ -327,6 +327,10 @@ type State struct {
 
 	// LenIDs of lenses added to Defra.
 	LensIDs []string
+
+	// AsyncWG tracks the progress of in-flight `action.Async`s.  Calling `Wait` on it will wait for
+	// all started `action.Async`s to finish executing.
+	AsyncWG sync.WaitGroup
 }
 
 func (s *State) GetClientType() ClientType {

--- a/tests/state/state.go
+++ b/tests/state/state.go
@@ -331,6 +331,12 @@ type State struct {
 	// AsyncWG tracks the progress of in-flight `action.Async`s.  Calling `Wait` on it will wait for
 	// all started `action.Async`s to finish executing.
 	AsyncWG sync.WaitGroup
+
+	// SkipTest signals to the main Go test routine that it should skip the test.
+	//
+	// Calling `T.SkipNow()` from a child routine does not skip the test - so test actions looking to
+	// skip the current test should instead set this, and allow it to be acted upon by the parent routine.
+	SkipTest string
 }
 
 func (s *State) GetClientType() ClientType {


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4482

## Description

Document the delete collection concurrency bug https://github.com/sourcenetwork/defradb/issues/4268

It does not fix the bug.

Fixing the bug was broken out of this ticket as I think it is caused by underlying Defra issues that I do not fully understand yet, and it is taking me a while to wrap my head around them. 
