### PR TITLE
feat(rustffi): Enable embedding FFI tests and fix float32 array handling

### DIFF
--- a/tests/clients/rustffi/wrapper.go
+++ b/tests/clients/rustffi/wrapper.go
@@ -1977,6 +1977,25 @@ func convertDateTimeStrings(v any) any {
 		for i, v := range val {
 			val[i] = convertDateTimeStrings(v)
 		}
+		// If all elements are float64, convert to []float32 to match Go's
+		// GraphQL Float32 scalar behavior. JSON doesn't distinguish float32
+		// from float64, so we always convert float arrays to float32.
+		if len(val) > 0 {
+			allFloat := true
+			for _, v := range val {
+				if _, ok := v.(float64); !ok {
+					allFloat = false
+					break
+				}
+			}
+			if allFloat {
+				f32 := make([]float32, len(val))
+				for i, v := range val {
+					f32[i] = float32(v.(float64))
+				}
+				return f32
+			}
+		}
 		return val
 	case string:
 		if t, err := time.Parse(time.RFC3339Nano, val); err == nil {

--- a/tests/integration/mutation/create/embeddings/embedding_test.go
+++ b/tests/integration/mutation/create/embeddings/embedding_test.go
@@ -31,6 +31,7 @@ func TestMutationCreate_WithMultipleEmbeddingFields_ShouldSucceed(t *testing.T) 
 			// to fail since it receives an update on a docID that wasn't expected. We will look for a solution
 			// and update the test accordingly.
 			state.GoClientType,
+			state.RustFFIClientType,
 		}),
 		Actions: []any{
 			&action.AddSchema{

--- a/tests/integration/mutation/update/embeddings/embedding_test.go
+++ b/tests/integration/mutation/update/embeddings/embedding_test.go
@@ -31,6 +31,7 @@ func TestMutationUpdate_WithMultipleEmbeddingFields_ShouldSucceed(t *testing.T) 
 			// to fail sinces it receives an update on a docID that wasn't expected. We will look for a solution
 			// and update the test accordingly.
 			state.GoClientType,
+			state.RustFFIClientType,
 		}),
 		Actions: []any{
 			&action.AddSchema{
@@ -109,6 +110,7 @@ func TestMutationUpdate_UserDefinedVectorEmbeddingDoesNotTriggerGeneration_Shoul
 			// to fail sinces it receives an update on a docID that wasn't expected. We will look for a solution
 			// and update the test accordingly.
 			state.GoClientType,
+			state.RustFFIClientType,
 		}),
 		Actions: []any{
 			&action.AddSchema{
@@ -164,6 +166,7 @@ func TestMutationUpdate_FieldsForEmbeddingNotUpdatedDoesNotTriggerGeneration_Sho
 			// to fail sinces it receives an update on a docID that wasn't expected. We will look for a solution
 			// and update the test accordingly.
 			state.GoClientType,
+			state.RustFFIClientType,
 		}),
 		Actions: []any{
 			&action.AddSchema{


### PR DESCRIPTION
## Summary
- Enables 5 embedding FFI tests for `RustFFIClientType` (2 create, 3 update) by adding `state.RustFFIClientType` to `SupportedClientTypes`
- Fixes FFI float32 array handling: JSON doesn't distinguish float32 from float64, so `convertDateTimeStrings` now converts `[]any{float64...}` to `[]float32` to match Go's GraphQL Float32 scalar behavior
- Updates `defra.h` with safety doc comments from latest FFI build

## Rust companion PR
- https://github.com/jackzampolin/defradb.rs/pull/363

## Test plan
- [x] `DEFRA_VECTOR_EMBEDDING=true ffi-test run mutation/create/embeddings` (2/2 pass)
- [x] `DEFRA_VECTOR_EMBEDDING=true ffi-test run mutation/update/embeddings` (3/3 pass)
- [x] `ffi-test run query/simple` (435/435 pass, no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)