### PR TITLE
feat(rustffi): Encryption + SE FFI bindings

### DIFF
--- a/tests/clients/rustffi/defra.go
+++ b/tests/clients/rustffi/defra.go
@@ -1866,6 +1866,24 @@ func (n *Node) P2PSetReplicator(identityDID string, peerAddr string, collections
 	return nil
 }
 
+// P2PRetryReplicators re-pushes all existing documents to connected replicator peers.
+// Call this after reconnecting peers following a node restart.
+func (n *Node) P2PRetryReplicators() error {
+	result := C.p2p_retry_replicators(n.ptr)
+
+	if result.status != 0 {
+		errStr := C.GoString(result.error)
+		C.defra_free_string(result.error)
+		return fmt.Errorf("ffi: p2p_retry_replicators failed: %s", errStr)
+	}
+
+	if result.value != nil {
+		C.defra_free_string(result.value)
+	}
+
+	return nil
+}
+
 // P2PDeleteReplicator removes a replicator by peer ID.
 // If collections is non-empty, only those collections are removed from the replicator.
 // If collections is empty, the entire replicator is deleted.

--- a/tests/clients/rustffi/defra.go
+++ b/tests/clients/rustffi/defra.go
@@ -1884,6 +1884,28 @@ func (n *Node) P2PRetryReplicators() error {
 	return nil
 }
 
+// SetSEEncryptionKey sets the searchable encryption key for the node.
+// The key must be exactly 32 bytes (AES-256).
+func (n *Node) SetSEEncryptionKey(key []byte) error {
+	if len(key) == 0 {
+		return fmt.Errorf("ffi: SE encryption key is empty")
+	}
+
+	result := C.set_se_encryption_key(
+		n.ptr,
+		(*C.uint8_t)(unsafe.Pointer(&key[0])),
+		C.uintptr_t(len(key)),
+	)
+
+	if result.status != 0 {
+		errStr := C.GoString(result.error)
+		C.defra_free_string(result.error)
+		return fmt.Errorf("ffi: set_se_encryption_key failed: %s", errStr)
+	}
+
+	return nil
+}
+
 // P2PDeleteReplicator removes a replicator by peer ID.
 // If collections is non-empty, only those collections are removed from the replicator.
 // If collections is empty, the entire replicator is deleted.

--- a/tests/clients/rustffi/defra.h
+++ b/tests/clients/rustffi/defra.h
@@ -1472,6 +1472,21 @@ struct FfiResult get_collections_in_txn(uintptr_t node_ptr,
                                         const char *identity_did);
 
 /*
+ Set the searchable encryption key for a node.
+
+ The key is a 32-byte AES-256 key used by the SE coordinator
+ for HMAC tag generation during artifact creation.
+
+ # Safety
+
+ * `node_ptr` must be a valid node handle
+ * `key_ptr` must point to `key_len` valid bytes
+ */
+struct FfiResult set_se_encryption_key(uintptr_t node_ptr,
+                                       const uint8_t *key_ptr,
+                                       uintptr_t key_len);
+
+/*
  Create a subscription to database events.
 
  # Arguments

--- a/tests/clients/rustffi/defra.h
+++ b/tests/clients/rustffi/defra.h
@@ -1204,6 +1204,19 @@ struct FfiResult p2p_create_replicator(uintptr_t node_ptr,
                                        const char *collections_json);
 
 /*
+ Retry pushing existing documents to all registered replicators.
+
+ For each registered replicator, re-pushes all existing documents.
+ `push_existing_docs` internally waits up to 5s for the peer connection
+ to be established, so this can be called immediately after dialing.
+
+ # Safety
+
+ `node_ptr` must be a valid node handle.
+ */
+struct FfiResult p2p_retry_replicators(uintptr_t node_ptr);
+
+/*
  Delete a replicator.
 
  # Arguments

--- a/tests/clients/rustffi/wrapper.go
+++ b/tests/clients/rustffi/wrapper.go
@@ -396,6 +396,14 @@ func (w *Wrapper) RetryReplicators() error {
 	return w.node.P2PRetryReplicators()
 }
 
+// SetSEEncryptionKey passes the searchable encryption key to the Rust FFI node.
+func (w *Wrapper) SetSEEncryptionKey(key []byte) error {
+	if w.node == nil {
+		return fmt.Errorf("node not initialized")
+	}
+	return w.node.SetSEEncryptionKey(key)
+}
+
 func (w *Wrapper) SetGoNodeCloser(closer func()) {
 	w.goNodeCloser = closer
 }

--- a/tests/clients/rustffi/wrapper.go
+++ b/tests/clients/rustffi/wrapper.go
@@ -388,6 +388,14 @@ func groupPatchByCollection(patch string) ([]struct{ Name, Patch string }, error
 
 // SetGoNodeCloser sets a callback to close the Go node during wrapper Close().
 // This ensures the Go node's badger lock is released on restart.
+// RetryReplicators re-pushes all existing documents to connected replicator peers.
+func (w *Wrapper) RetryReplicators() error {
+	if w.node == nil {
+		return nil
+	}
+	return w.node.P2PRetryReplicators()
+}
+
 func (w *Wrapper) SetGoNodeCloser(closer func()) {
 	w.goNodeCloser = closer
 }
@@ -1058,11 +1066,26 @@ func (w *Wrapper) applyPatchGroups(
 }
 
 // resolveRemoveTargets resolves collection names or version IDs to version IDs.
+// If a target is neither a known collection name nor a version ID (e.g. "EncryptedIndexes"),
+// returns the same error Go produces for removing a nonexistent key from the global dict.
 func (w *Wrapper) resolveRemoveTargets(identityDID string, targets []string) ([]string, error) {
 	var versionIDs []string
 	for _, target := range targets {
-		vid := w.resolveToVersionID(identityDID, target)
-		versionIDs = append(versionIDs, vid)
+		collJSON, err := w.node.GetCollectionByName(identityDID, target)
+		if err == nil {
+			var version client.CollectionVersion
+			if err := json.Unmarshal([]byte(collJSON), &version); err == nil {
+				versionIDs = append(versionIDs, version.VersionID)
+				continue
+			}
+		}
+		// Not a collection name — check if it looks like a version ID (CID).
+		if strings.HasPrefix(target, "bafyrei") || strings.HasPrefix(target, "bafkrei") {
+			versionIDs = append(versionIDs, target)
+			continue
+		}
+		// Neither a collection name nor a version ID — Go returns this error.
+		return nil, fmt.Errorf("unable to remove nonexistent key")
 	}
 	return versionIDs, nil
 }

--- a/tests/integration/client_setup_rustffi.go
+++ b/tests/integration/client_setup_rustffi.go
@@ -83,6 +83,20 @@ func setupRustFFIClient(
 		return nil, fmt.Errorf("failed to forward SE events: %w", err)
 	}
 
+	// Pass the SE encryption key to the Rust FFI node so it can generate
+	// SE artifacts during replication (push_existing_docs).
+	type seKeyProvider interface {
+		SearchableEncryptionKey() []byte
+	}
+	if skp, ok := nodeObj.DB.(seKeyProvider); ok {
+		if seKey := skp.SearchableEncryptionKey(); len(seKey) > 0 {
+			if err := wrapper.SetSEEncryptionKey(seKey); err != nil {
+				wrapper.Close()
+				return nil, fmt.Errorf("failed to set SE encryption key on Rust FFI node: %w", err)
+			}
+		}
+	}
+
 	// Mirror the Go node's NAC state onto the Rust FFI node.
 	nacStatus, nacErr := nodeObj.DB.GetNACStatus(s.Ctx)
 	if nacErr == nil && identity.HasValue() {

--- a/tests/integration/p2p.go
+++ b/tests/integration/p2p.go
@@ -121,6 +121,12 @@ func connectPeers(
 }
 
 // reconnectPeers makes sure that all peers are connected after a node restart action.
+// replicatorRetrier is implemented by clients that support retrying failed
+// replicator pushes after peer reconnection (e.g., the Rust FFI wrapper).
+type replicatorRetrier interface {
+	RetryReplicators() error
+}
+
 func reconnectPeers(s *state.State) {
 	nodeIDs, nodes := getNodesWithIDs(immutable.None[int](), s.Nodes)
 	for sourceIndex, sourceNode := range nodes {
@@ -157,6 +163,17 @@ func reconnectPeers(s *state.State) {
 
 			err = connectWithRetry(ctxWithSourceNodeIdentity, sourceNode, targetAddresses)
 			require.NoError(s.T, err)
+		}
+	}
+
+	// After all peers are reconnected, retry pushing existing documents to
+	// replicators. In Go's native P2P, a background retry loop handles this.
+	// The Rust FFI has no retry loop, so we trigger it explicitly here.
+	for _, node := range nodes {
+		if retrier, ok := node.Client.(replicatorRetrier); ok {
+			if err := retrier.RetryReplicators(); err != nil {
+				log.ErrorContext(s.Ctx, "Failed to retry replicators", corelog.Any("Error", err))
+			}
 		}
 	}
 }

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -344,6 +344,7 @@ func performAction(
 
 	case Start:
 		startNodes(s, testCase, action)
+		reconnectPeers(s)
 
 	case ConnectPeers:
 		connectPeers(s, action)


### PR DESCRIPTION
## Summary

- Add `SetSEEncryptionKey` FFI binding to pass searchable encryption keys to the Rust node
- Add `P2PRetryReplicators` FFI call after peer reconnection for replicator retry
- Fix `reconnectPeers` ordering in the `Start` action handler to run after `startNodes`

## Test plan

- [x] `ffi-test run encryption` — 32 passed, 0 failed, 6 skipped
- [x] `ffi-test run searchable_encryption` — 26 passed, 0 failed
- [x] `ffi-test run signature` — 18 passed, 0 failed, 2 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)