### PR TITLE
fix: Improve http timeout context

### DIFF
--- a/http/client_p2p.go
+++ b/http/client_p2p.go
@@ -363,7 +363,19 @@ func (c *Client) SyncCollectionVersions(
 		return err
 	}
 
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, methodURL.String(), bytes.NewBuffer(body))
+	// Use a separate context for HTTP request with extra buffer time.
+	// The server will use the timeout from the request body for the actual sync operation.
+	// We add buffer time to account for HTTP overhead and response transmission.
+	// This is necessary because the node handling this request will usually wait whole timeout
+	// duration as it might receive responses from multiple peers.
+	httpCtx := context.Background()
+	if hasDeadline {
+		var cancel context.CancelFunc
+		httpCtx, cancel = context.WithTimeout(httpCtx, time.Until(deadline)+500*time.Millisecond)
+		defer cancel()
+	}
+
+	httpReq, err := http.NewRequestWithContext(httpCtx, http.MethodPost, methodURL.String(), bytes.NewBuffer(body))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Relevant issue(s)
Resolves #TBD

## Description
Here is what code rabbit flagged(https://github.com/sourcenetwork/defradb/pull/4507#pullrequestreview-3793669401)

Missing HTTP timeout buffer — unlike SyncDocuments and SyncBranchableCollection.

SyncDocuments (Line 327) and SyncBranchableCollection (Line 392) both create a separate httpCtx with extra buffer time (+500ms) for the HTTP request, since the server uses the body's timeout for the actual sync and the HTTP client needs additional time for overhead. SyncCollectionVersions directly uses ctx for the HTTP request, which may cause the client-side HTTP call to time out before the server responds.
