### PR TITLE
feat: Gate SyncBranchableCollection with NAC

### DIFF
--- a/acp/types/types.go
+++ b/acp/types/types.go
@@ -110,6 +110,7 @@ const (
 	NodeP2PDocumentDeletePerm
 	NodeP2PDocumentListPerm
 	NodeP2PSyncCollectionVersionsPerm
+	NodeP2PSyncBranchableCollectionPerm
 	NodeSignatureVerifyPerm
 	NodeLensCreatePerm
 	NodeLensListPerm
@@ -157,6 +158,7 @@ var RequiredResourcePermissionsForNode = []string{
 	"p2p-document-delete",
 	"p2p-document-list",
 	"p2p-sync-collection-versions",
+	"p2p-sync-branchable-collection",
 	"signature-verify",
 	"lens-create",
 	"lens-list",
@@ -250,6 +252,8 @@ resources:
   - name: p2p-document-list
     expr: admin
   - name: p2p-sync-collection-versions
+    expr: admin
+  - name: p2p-sync-branchable-collection
     expr: admin
 
   - name: signature-verify

--- a/cbindings/p2p.go
+++ b/cbindings/p2p.go
@@ -364,7 +364,8 @@ func P2PbranchableCollectionSync(nodePtr C.uintptr_t,
 	if err != nil {
 		return returnC(returnGoC(1, err.Error(), ""))
 	}
-	err = node.DB.SyncBranchableCollection(ctx, C.GoString(collectionID))
+	opts := options.WithIdentity(options.SyncBranchableCollection(), acpIdentity.FromContext(ctx))
+	err = node.DB.SyncBranchableCollection(ctx, C.GoString(collectionID), opts)
 	if err != nil {
 		return returnC(returnGoC(1, err.Error(), ""))
 	}

--- a/cbindings/wrapper.go
+++ b/cbindings/wrapper.go
@@ -376,7 +376,12 @@ func (w *CWrapper) SyncCollectionVersions(
 	return nil
 }
 
-func (w *CWrapper) SyncBranchableCollection(ctx context.Context, collectionID string) error {
+func (w *CWrapper) SyncBranchableCollection(
+	ctx context.Context,
+	collectionID string,
+	opts ...options.Lister[options.SyncBranchableCollectionOptions],
+) error {
+	opt := utils.NewOptions(opts...)
 	cCollectionID := C.CString(collectionID)
 	defer C.free(unsafe.Pointer(cCollectionID))
 
@@ -388,8 +393,11 @@ func (w *CWrapper) SyncBranchableCollection(ctx context.Context, collectionID st
 	cTimerStr := C.CString(timerStr)
 	defer C.free(unsafe.Pointer(cTimerStr))
 
+	cIdentity := optionToUintptr(opt.GetIdentity())
+	defer C.IdentityFree(cIdentity)
+
 	res := ConvertAndFreeCResult(
-		C.P2PbranchableCollectionSync(C.uintptr_t(w.handle), cCollectionID, cTimerStr, C.uintptr_t(0)))
+		C.P2PbranchableCollectionSync(C.uintptr_t(w.handle), cCollectionID, cTimerStr, cIdentity))
 
 	if res.Status != 0 {
 		return errors.New(res.Error)

--- a/cli/p2p_collection_sync_branchable.go
+++ b/cli/p2p_collection_sync_branchable.go
@@ -14,6 +14,9 @@ import (
 	"context"
 
 	"github.com/spf13/cobra"
+
+	"github.com/sourcenetwork/defradb/acp/identity"
+	"github.com/sourcenetwork/defradb/client/options"
 )
 
 func MakeP2PCollectionSyncBranchableCommand(ctx context.Context) *cobra.Command {
@@ -37,7 +40,8 @@ to the collection for future updates.`,
 			}
 
 			cliClient := mustGetContextCLIClient(cmd)
-			return cliClient.SyncBranchableCollection(ctx, collectionID)
+			opt := options.WithIdentity(options.SyncBranchableCollection(), identity.FromContext(cmd.Context()))
+			return cliClient.SyncBranchableCollection(ctx, collectionID, opt)
 		},
 	}
 

--- a/client/mocks/txn.go
+++ b/client/mocks/txn.go
@@ -2984,16 +2984,22 @@ func (_c *Txn_StartTS_Call) RunAndReturn(run func() time.Time) *Txn_StartTS_Call
 }
 
 // SyncBranchableCollection provides a mock function for the type Txn
-func (_mock *Txn) SyncBranchableCollection(ctx context.Context, collectionID string) error {
-	ret := _mock.Called(ctx, collectionID)
+func (_mock *Txn) SyncBranchableCollection(ctx context.Context, collectionID string, opts ...options.Lister[options.SyncBranchableCollectionOptions]) error {
+	var tmpRet mock.Arguments
+	if len(opts) > 0 {
+		tmpRet = _mock.Called(ctx, collectionID, opts)
+	} else {
+		tmpRet = _mock.Called(ctx, collectionID)
+	}
+	ret := tmpRet
 
 	if len(ret) == 0 {
 		panic("no return value specified for SyncBranchableCollection")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string) error); ok {
-		r0 = returnFunc(ctx, collectionID)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, ...options.Lister[options.SyncBranchableCollectionOptions]) error); ok {
+		r0 = returnFunc(ctx, collectionID, opts...)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -3008,11 +3014,13 @@ type Txn_SyncBranchableCollection_Call struct {
 // SyncBranchableCollection is a helper method to define mock.On call
 //   - ctx context.Context
 //   - collectionID string
-func (_e *Txn_Expecter) SyncBranchableCollection(ctx interface{}, collectionID interface{}) *Txn_SyncBranchableCollection_Call {
-	return &Txn_SyncBranchableCollection_Call{Call: _e.mock.On("SyncBranchableCollection", ctx, collectionID)}
+//   - opts ...options.Lister[options.SyncBranchableCollectionOptions]
+func (_e *Txn_Expecter) SyncBranchableCollection(ctx interface{}, collectionID interface{}, opts ...interface{}) *Txn_SyncBranchableCollection_Call {
+	return &Txn_SyncBranchableCollection_Call{Call: _e.mock.On("SyncBranchableCollection",
+		append([]interface{}{ctx, collectionID}, opts...)...)}
 }
 
-func (_c *Txn_SyncBranchableCollection_Call) Run(run func(ctx context.Context, collectionID string)) *Txn_SyncBranchableCollection_Call {
+func (_c *Txn_SyncBranchableCollection_Call) Run(run func(ctx context.Context, collectionID string, opts ...options.Lister[options.SyncBranchableCollectionOptions])) *Txn_SyncBranchableCollection_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -3022,9 +3030,16 @@ func (_c *Txn_SyncBranchableCollection_Call) Run(run func(ctx context.Context, c
 		if args[1] != nil {
 			arg1 = args[1].(string)
 		}
+		var arg2 []options.Lister[options.SyncBranchableCollectionOptions]
+		var variadicArgs []options.Lister[options.SyncBranchableCollectionOptions]
+		if len(args) > 2 {
+			variadicArgs = args[2].([]options.Lister[options.SyncBranchableCollectionOptions])
+		}
+		arg2 = variadicArgs
 		run(
 			arg0,
 			arg1,
+			arg2...,
 		)
 	})
 	return _c
@@ -3035,7 +3050,7 @@ func (_c *Txn_SyncBranchableCollection_Call) Return(err error) *Txn_SyncBranchab
 	return _c
 }
 
-func (_c *Txn_SyncBranchableCollection_Call) RunAndReturn(run func(ctx context.Context, collectionID string) error) *Txn_SyncBranchableCollection_Call {
+func (_c *Txn_SyncBranchableCollection_Call) RunAndReturn(run func(ctx context.Context, collectionID string, opts ...options.Lister[options.SyncBranchableCollectionOptions]) error) *Txn_SyncBranchableCollection_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/client/options/p2p.go
+++ b/client/options/p2p.go
@@ -360,6 +360,37 @@ func (b *SyncCollectionVersionsOptionsBuilder) SetIdentity(id identity.Identity)
 	return b
 }
 
+// SyncBranchableCollectionOptions contains options for SyncBranchableCollection operation.
+type SyncBranchableCollectionOptions struct {
+	// Identity is the identity of the actor performing the operation.
+	Identity immutable.Option[identity.Identity]
+}
+
+// GetIdentity returns the identity for the operation.
+func (o *SyncBranchableCollectionOptions) GetIdentity() immutable.Option[identity.Identity] {
+	return o.Identity
+}
+
+// SyncBranchableCollectionOptionsBuilder is a builder for SyncBranchableCollectionOptions.
+type SyncBranchableCollectionOptionsBuilder struct {
+	enumerableBuilder[SyncBranchableCollectionOptions]
+}
+
+// SyncBranchableCollection creates a new SyncBranchableCollectionOptionsBuilder instance.
+func SyncBranchableCollection() *SyncBranchableCollectionOptionsBuilder {
+	return &SyncBranchableCollectionOptionsBuilder{}
+}
+
+// SetIdentity sets the identity for the operation.
+func (b *SyncBranchableCollectionOptionsBuilder) SetIdentity(
+	id identity.Identity,
+) *SyncBranchableCollectionOptionsBuilder {
+	b.append(func(opts *SyncBranchableCollectionOptions) {
+		opts.Identity = immutable.Some(id)
+	})
+	return b
+}
+
 // DeleteP2PDocumentsOptions contains options for RemoveP2PDocuments operation.
 type DeleteP2PDocumentsOptions struct {
 	// Identity is the identity of the actor performing the operation.

--- a/client/p2p.go
+++ b/client/p2p.go
@@ -123,7 +123,11 @@ type P2P interface {
 	// for branchable collections (collections marked with @branchable directive).
 	// It doesn't automatically subscribe to the collection for future updates.
 	// context.WithTimeout can be used to set a timeout for the operation.
-	SyncBranchableCollection(ctx context.Context, collectionID string) error
+	SyncBranchableCollection(
+		ctx context.Context,
+		collectionID string,
+		opts ...options.Lister[options.SyncBranchableCollectionOptions],
+	) error
 }
 
 type StreamHandler = func(stream io.Reader, peerID string)

--- a/http/client_p2p.go
+++ b/http/client_p2p.go
@@ -372,7 +372,11 @@ func (c *Client) SyncCollectionVersions(
 	return err
 }
 
-func (c *Client) SyncBranchableCollection(ctx context.Context, collectionID string) error {
+func (c *Client) SyncBranchableCollection(
+	ctx context.Context,
+	collectionID string,
+	opts ...options.Lister[options.SyncBranchableCollectionOptions],
+) error {
 	methodURL := c.http.apiURL.JoinPath("p2p", "collections", "sync-branchable")
 
 	req := map[string]any{
@@ -394,6 +398,8 @@ func (c *Client) SyncBranchableCollection(ctx context.Context, collectionID stri
 	// This is necessary because the node handling this request will usually wait whole timeout
 	// duration as it might receive responses from multiple peers.
 	httpCtx := context.Background()
+	opt := utils.NewOptions(opts...)
+	httpCtx = identity.WithContext(httpCtx, opt.GetIdentity())
 	if hasDeadline {
 		var cancel context.CancelFunc
 		httpCtx, cancel = context.WithTimeout(httpCtx, time.Until(deadline)+500*time.Millisecond)

--- a/http/handler_p2p.go
+++ b/http/handler_p2p.go
@@ -328,7 +328,8 @@ func (h *p2pHandler) SyncBranchableCollection(rw http.ResponseWriter, req *http.
 		defer cancel()
 	}
 
-	err := db.SyncBranchableCollection(ctx, reqBody.CollectionID)
+	opts := options.WithIdentity(options.SyncBranchableCollection(), identity.FromContext(ctx))
+	err := db.SyncBranchableCollection(ctx, reqBody.CollectionID, opts)
 	if err != nil {
 		responseJSON(rw, http.StatusInternalServerError, errorResponse{err})
 		return

--- a/internal/db/p2p.go
+++ b/internal/db/p2p.go
@@ -382,9 +382,19 @@ func (db *DB) SyncCollectionVersions(
 // context.WithTimeout can be used to set a timeout for the operation.
 //
 // WARNING: This function does not respect transactions.
-func (db *DB) SyncBranchableCollection(ctx context.Context, collectionID string) error {
+func (db *DB) SyncBranchableCollection(
+	ctx context.Context,
+	collectionID string,
+	opts ...options.Lister[options.SyncBranchableCollectionOptions],
+) error {
+	opt := utils.NewOptions(opts...)
+
+	if err := db.checkNodeAccess(ctx, opt.Identity, acpTypes.NodeP2PSyncBranchableCollectionPerm); err != nil {
+		return err
+	}
+
 	if db.p2p == nil {
 		return ErrNoP2P
 	}
-	return db.p2p.SyncBranchableCollection(ctx, collectionID)
+	return db.p2p.SyncBranchableCollection(ctx, collectionID, opt)
 }

--- a/internal/db/p2p/p2p.go
+++ b/internal/db/p2p/p2p.go
@@ -347,10 +347,17 @@ func (p *P2P) hasAccess(ctx context.Context, pid string, c cid.Cid) bool {
 		return true
 	}
 
-	cols, err := p.db.GetCollections(
-		ctx,
-		options.GetCollections().SetVersionID(block.Delta.GetCollectionVersionID()),
-	)
+	ident, err := p.db.GetNodeIdentity(p.ctx)
+	if err != nil {
+		log.ErrorE("Failed to get node identity", err)
+		return false
+	}
+	getColOpts := options.GetCollections().SetCollectionID(block.Delta.GetCollectionVersionID())
+	if ident.HasValue() {
+		getColOpts = getColOpts.SetIdentity(identity.FromDID(ident.Value().DID))
+	}
+
+	cols, err := p.db.GetCollections(ctx, getColOpts)
 	if err != nil {
 		log.ErrorE("Failed to get collections", err)
 		return false

--- a/internal/db/p2p/sync_branchable_col.go
+++ b/internal/db/p2p/sync_branchable_col.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/sourcenetwork/corelog"
 
+	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/options"
 	"github.com/sourcenetwork/defradb/errors"
@@ -50,11 +51,15 @@ type syncBranchableCollectionReply struct {
 //
 // This function call will block until there is a response for the collection.
 // It is the responsibility of the caller to set an appropriate timeout on the context.
-func (p *P2P) SyncBranchableCollection(ctx context.Context, collectionID string) error {
-	cols, err := p.db.GetCollections(
-		ctx,
-		options.GetCollections().SetCollectionID(collectionID),
-	)
+func (p *P2P) SyncBranchableCollection(
+	ctx context.Context,
+	collectionID string,
+	opts *options.SyncBranchableCollectionOptions,
+) error {
+	getColOpts := options.GetCollections().SetCollectionID(collectionID)
+	options.WithIdentity(getColOpts, opts.Identity)
+
+	cols, err := p.db.GetCollections(ctx, getColOpts)
 	if err != nil {
 		return err
 	}
@@ -262,10 +267,16 @@ func (p *P2P) syncBranchableCollectionMessageHandler(from string, topic string, 
 
 // processSyncBranchableCollection processes a branchable collection sync request and returns all head CIDs.
 func (p *P2P) processSyncBranchableCollection(collectionID string) ([][]byte, error) {
-	cols, err := p.db.GetCollections(
-		p.ctx,
-		options.GetCollections().SetCollectionID(collectionID),
-	)
+	ident, err := p.db.GetNodeIdentity(p.ctx)
+	if err != nil {
+		return nil, err
+	}
+	getColOpts := options.GetCollections().SetCollectionID(collectionID)
+	if ident.HasValue() {
+		getColOpts = getColOpts.SetIdentity(identity.FromDID(ident.Value().DID))
+	}
+
+	cols, err := p.db.GetCollections(p.ctx, getColOpts)
 	if err != nil || len(cols) == 0 {
 		return nil, err
 	}

--- a/internal/db/txn.go
+++ b/internal/db/txn.go
@@ -428,7 +428,11 @@ func (txn *Txn) SyncCollectionVersions(
 	return txn.db.SyncCollectionVersions(ctx, versionIDs, opts...)
 }
 
-func (txn *Txn) SyncBranchableCollection(ctx context.Context, collectionID string) error {
+func (txn *Txn) SyncBranchableCollection(
+	ctx context.Context,
+	collectionID string,
+	opts ...options.Lister[options.SyncBranchableCollectionOptions],
+) error {
 	ctx = InitContext(ctx, txn)
-	return txn.db.SyncBranchableCollection(ctx, collectionID)
+	return txn.db.SyncBranchableCollection(ctx, collectionID, opts...)
 }

--- a/tests/action/sync_branchable_collection.go
+++ b/tests/action/sync_branchable_collection.go
@@ -14,6 +14,10 @@ import (
 	"context"
 	"errors"
 	"time"
+
+	"github.com/sourcenetwork/defradb/client/options"
+	"github.com/sourcenetwork/defradb/tests/state"
+	"github.com/sourcenetwork/immutable"
 )
 
 // SyncBranchableCollection is an action that syncs a branchable collection's DAG
@@ -26,6 +30,11 @@ type SyncBranchableCollection struct {
 	// The collection will be synced to the other nodes that are connected
 	// and subscribed to the collection's pubsub topics.
 	NodeID int
+
+	// The identity of this request. Optional.
+	//
+	// If node acp is enabled, identity will be used to check if this operation can be performed.
+	Identity immutable.Option[state.Identity]
 
 	// CollectionID is the index of the collection to sync.
 	CollectionID int
@@ -54,8 +63,14 @@ func (a *SyncBranchableCollection) Execute() {
 		return
 	}
 
+	opts := options.SyncBranchableCollection()
+	identOption := getIdentityForRequestSpecificToNode(a.s, a.Identity, a.NodeID)
+	if identOption.HasValue() {
+		opts.SetIdentity(identOption.Value())
+	}
+
 	collection := nodeState.Collections[a.CollectionID]
-	err := nodeState.SyncBranchableCollection(ctx, collection.CollectionID())
+	err := nodeState.SyncBranchableCollection(ctx, collection.CollectionID(), opts)
 
 	expectedErrorRaised := assertError(a.s.T, err, a.ExpectedError)
 	assertExpectedErrorRaised(a.s.T, a.ExpectedError, expectedErrorRaised)

--- a/tests/clients/cli/wrapper.go
+++ b/tests/clients/cli/wrapper.go
@@ -321,13 +321,20 @@ func (w *Wrapper) SyncCollectionVersions(
 	return err
 }
 
-func (w *Wrapper) SyncBranchableCollection(ctx context.Context, collectionID string) error {
+func (w *Wrapper) SyncBranchableCollection(
+	ctx context.Context,
+	collectionID string,
+	opts ...options.Lister[options.SyncBranchableCollectionOptions],
+) error {
 	args := []string{"client", "p2p", "collection", "sync-branchable", collectionID}
 
 	deadline, hasDeadline := ctx.Deadline()
 	if hasDeadline {
 		args = append(args, "--timeout", time.Until(deadline).String())
 	}
+
+	opt := utils.NewOptions(opts...)
+	args = appendIdentityArg(args, opt.GetIdentity())
 
 	_, err := w.cmd.execute(ctx, args)
 	return err

--- a/tests/clients/http/wrapper.go
+++ b/tests/clients/http/wrapper.go
@@ -167,8 +167,11 @@ func (w *Wrapper) SyncCollectionVersions(
 	return w.client.SyncCollectionVersions(ctx, versionIDs, opts...)
 }
 
-func (w *Wrapper) SyncBranchableCollection(ctx context.Context, collectionID string) error {
-	return w.client.SyncBranchableCollection(ctx, collectionID)
+func (w *Wrapper) SyncBranchableCollection(
+	ctx context.Context,
+	collectionID string,
+	opts ...options.Lister[options.SyncBranchableCollectionOptions]) error {
+	return w.client.SyncBranchableCollection(ctx, collectionID, opts...)
 }
 
 func (w *Wrapper) BasicImport(ctx context.Context, filepath string) error {

--- a/tests/clients/js/wrapper.go
+++ b/tests/clients/js/wrapper.go
@@ -154,7 +154,7 @@ func (w *Wrapper) SyncCollectionVersions(ctx context.Context, versionIDs []strin
 	panic("not implemented")
 }
 
-func (w *Wrapper) SyncBranchableCollection(ctx context.Context, collectionID string) error {
+func (w *Wrapper) SyncBranchableCollection(ctx context.Context, collectionID string, opts ...options.Lister[options.SyncBranchableCollectionOptions]) error {
 	panic("not implemented")
 }
 

--- a/tests/integration/acp/nac/p2p_sync_branchable_collection_test.go
+++ b/tests/integration/acp/nac/p2p_sync_branchable_collection_test.go
@@ -1,0 +1,161 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package test_acp_nac
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/immutable"
+
+	acpTypes "github.com/sourcenetwork/defradb/acp/types"
+	"github.com/sourcenetwork/defradb/tests/action"
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	"github.com/sourcenetwork/defradb/tests/state"
+)
+
+func TestNAC_GatesSyncBranchableCollection_AuthorizedIdentity_AllowAccess(t *testing.T) {
+	test := testUtils.TestCase{
+		SupportedClientTypes: immutable.Some(
+			[]state.ClientType{
+				state.HTTPClientType,
+				state.CLIClientType,
+				state.GoClientType,
+				state.CClientType,
+			},
+		),
+		Actions: []any{
+			// Doing this in the beginning is important to start all nodes with NAC enabled.
+			testUtils.RandomNetworkingConfig(),
+			testUtils.RandomNetworkingConfig(),
+			// Starting all nodes with NAC, so only authorized user(s) can perform operations from here on out.
+			testUtils.Close{},
+			testUtils.Start{
+				Identity:  testUtils.ClientIdentity(1),
+				EnableNAC: true,
+			},
+			testUtils.ConnectPeers{
+				Identity:     testUtils.ClientIdentity(1),
+				SourceNodeID: 1,
+				TargetNodeID: 0,
+			},
+
+			// Note: Doing setup steps after starting with nac enabled, otherwise the in-memory tests
+			// will lose setup state when the restart happens (i.e. the restart that started nac).
+			&action.AddSchema{
+				Identity: testUtils.ClientIdentity(1),
+				Schema: `
+					type User @branchable {
+						name: String
+					}
+				`,
+			},
+			&action.CreateDoc{
+				NodeID:   immutable.Some(0),
+				Identity: testUtils.ClientIdentity(1),
+				DocMap: map[string]any{
+					"name": "John",
+				},
+			},
+
+			// This should work as the identity is authorized.
+			&action.SyncBranchableCollection{
+				Identity: testUtils.ClientIdentity(1),
+				NodeID:   1,
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestNAC_GatesSyncBranchableCollection_NoIdentity_NotAuthorizedError(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			// Doing this in the beginning is important to start all nodes with NAC enabled.
+			testUtils.RandomNetworkingConfig(),
+			testUtils.RandomNetworkingConfig(),
+			// Starting all nodes with NAC, so only authorized user(s) can perform operations from here on out.
+			testUtils.Close{},
+			testUtils.Start{
+				Identity:  testUtils.ClientIdentity(1),
+				EnableNAC: true,
+			},
+			// Note: Doing setup steps after starting with nac enabled, otherwise the in-memory tests
+			// will lose setup state when the restart happens (i.e. the restart that started nac).
+			&action.AddSchema{
+				Identity: testUtils.ClientIdentity(1),
+				Schema: `
+					type User @branchable {
+						name: String
+					}
+				`,
+			},
+			&action.CreateDoc{
+				NodeID:   immutable.Some(0),
+				Identity: testUtils.ClientIdentity(1),
+				DocMap: map[string]any{
+					"name": "John",
+				},
+			},
+
+			// We haven't authorized non-identities. So, this should error.
+			&action.SyncBranchableCollection{
+				Identity:      testUtils.NoIdentity(),
+				NodeID:        1,
+				ExpectedError: testUtils.FormatExpectedErrorWithPermission(acpTypes.NodeP2PSyncBranchableCollectionPerm),
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestNAC_GatesSyncBranchableCollection_WrongIdentity_NotAuthorizedError(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			// Doing this in the beginning is important to start all nodes with NAC enabled.
+			testUtils.RandomNetworkingConfig(),
+			testUtils.RandomNetworkingConfig(),
+			// Starting all nodes with NAC, so only authorized user(s) can perform operations from here on out.
+			testUtils.Close{},
+			testUtils.Start{
+				Identity:  testUtils.ClientIdentity(1),
+				EnableNAC: true,
+			},
+			// Note: Doing setup steps after starting with nac enabled, otherwise the in-memory tests
+			// will lose setup state when the restart happens (i.e. the restart that started nac).
+			&action.AddSchema{
+				Identity: testUtils.ClientIdentity(1),
+				Schema: `
+					type User @branchable {
+						name: String
+					}
+				`,
+			},
+			&action.CreateDoc{
+				NodeID:   immutable.Some(0),
+				Identity: testUtils.ClientIdentity(1),
+				DocMap: map[string]any{
+					"name": "John",
+				},
+			},
+
+			// Wrong user/identity will also not be authorized.
+			&action.SyncBranchableCollection{
+				Identity:      testUtils.ClientIdentity(2),
+				NodeID:        1,
+				ExpectedError: testUtils.FormatExpectedErrorWithPermission(acpTypes.NodeP2PSyncBranchableCollectionPerm),
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/acp/nac/relation_admin/p2p_sync_branchable_collection_test.go
+++ b/tests/integration/acp/nac/relation_admin/p2p_sync_branchable_collection_test.go
@@ -1,0 +1,91 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package test_acp_nac_relation_admin
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/immutable"
+
+	acpTypes "github.com/sourcenetwork/defradb/acp/types"
+	"github.com/sourcenetwork/defradb/tests/action"
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	"github.com/sourcenetwork/defradb/tests/state"
+)
+
+func TestNAC_AdminRelation_CanSyncBranchableCollection(t *testing.T) {
+	test := testUtils.TestCase{
+		SupportedClientTypes: immutable.Some(
+			[]state.ClientType{
+				state.HTTPClientType,
+				state.CLIClientType,
+				state.GoClientType,
+				state.CClientType,
+			},
+		),
+		Actions: []any{
+			// Doing this in the beginning is important to start all nodes with NAC enabled.
+			testUtils.RandomNetworkingConfig(),
+			testUtils.RandomNetworkingConfig(),
+			// Starting all nodes with NAC, so only authorized user(s) can perform operations from here on out.
+			testUtils.Close{},
+			testUtils.Start{
+				Identity:  testUtils.ClientIdentity(1),
+				EnableNAC: true,
+			},
+			testUtils.ConnectPeers{
+				Identity:     testUtils.ClientIdentity(1),
+				SourceNodeID: 0,
+				TargetNodeID: 1,
+			},
+			// Note: Doing setup steps after starting with nac enabled, otherwise the in-memory tests
+			// will lose setup state when the restart happens (i.e. the restart that started nac).
+			&action.AddSchema{
+				Identity: testUtils.ClientIdentity(1),
+				Schema: `
+					type User @branchable {
+						name: String
+					}
+				`,
+			},
+			&action.CreateDoc{
+				NodeID:   immutable.Some(0),
+				Identity: testUtils.ClientIdentity(1),
+				DocMap: map[string]any{
+					"name": "John",
+				},
+			},
+
+			// This user, can not perform this gated operation yet.
+			&action.SyncBranchableCollection{
+				Identity:      testUtils.ClientIdentity(2),
+				NodeID:        1,
+				ExpectedError: testUtils.FormatExpectedErrorWithPermission(acpTypes.NodeP2PSyncBranchableCollectionPerm),
+			},
+
+			// Grant access to user.
+			testUtils.AddNACActorRelationship{
+				RequestorIdentity: testUtils.ClientIdentity(1),
+				TargetIdentity:    testUtils.ClientIdentity(2),
+				Relation:          "admin",
+				ExpectedExistence: false,
+			},
+
+			// This user, can now perform this gated operation.
+			&action.SyncBranchableCollection{
+				Identity: testUtils.ClientIdentity(2),
+				NodeID:   1,
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4517

## Description

Gates SyncBranchableCollection operation with NAC.

Not all of this PR is boilerplate - the node identity is being fetched and passed on to `GetCollections` in a few places in the `db/p2p` package.