### PR TITLE
fix: Make Wazero the lens runtime for C bindings

### DIFF
--- a/cbindings/node.go
+++ b/cbindings/node.go
@@ -39,7 +39,8 @@ func NewNode(cOptions C.NodeInitOptions) C.NewNodeResult {
 	ctx := context.Background()
 
 	opts := options.Node()
-	opts.DB().SetLensRuntime(options.NodeWASMLensRuntime)
+	// Currently the only supported lens runtime is wazero, so use it explicitly
+	opts.DB().SetLensRuntime("wazero")
 
 	if gocOptions.DbPath != "" {
 		opts.Store().SetPath(gocOptions.DbPath)


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4523 

## Description

A recent change removed a line of code that made the C Bindings' `NewNode` function explicitly use Wazero as its lens runtime. This broke the C bindings, because that is currently the only runtime that is supported. This reverts that change.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Specify the platform(s) on which this was tested:
- WSL