### PR TITLE
refactor: Rename options enumerable

### DIFF
--- a/cbindings/collection.go
+++ b/cbindings/collection.go
@@ -65,7 +65,7 @@ func parseCollectionOptionsToGetCollectionsOptions(
 func getCollection(
 	store client.Store,
 	ctx context.Context,
-	builder options.Lister[options.GetCollectionsOptions],
+	builder options.Enumerable[options.GetCollectionsOptions],
 ) (client.Collection, error) {
 	cols, err := store.GetCollections(ctx, builder)
 	if err != nil {

--- a/cbindings/wrapper.go
+++ b/cbindings/wrapper.go
@@ -112,7 +112,9 @@ func NewCWrapper(node *node.Node) (*CWrapper, error) {
 	}, nil
 }
 
-func (w *CWrapper) PeerInfo(ctx context.Context, opts ...options.Enumerable[options.PeerInfoOptions]) ([]string, error) {
+func (w *CWrapper) PeerInfo(
+	ctx context.Context, opts ...options.Enumerable[options.PeerInfoOptions],
+) ([]string, error) {
 	cIdentity := optionToUintptr(utils.NewOptions(opts...).GetIdentity())
 	defer C.IdentityFree(cIdentity)
 
@@ -379,7 +381,7 @@ func (w *CWrapper) SyncCollectionVersions(
 func (w *CWrapper) SyncBranchableCollection(
 	ctx context.Context,
 	collectionID string,
-	opts ...options.Lister[options.SyncBranchableCollectionOptions],
+	opts ...options.Enumerable[options.SyncBranchableCollectionOptions],
 ) error {
 	opt := utils.NewOptions(opts...)
 	cCollectionID := C.CString(collectionID)

--- a/cbindings/wrapper.go
+++ b/cbindings/wrapper.go
@@ -112,7 +112,7 @@ func NewCWrapper(node *node.Node) (*CWrapper, error) {
 	}, nil
 }
 
-func (w *CWrapper) PeerInfo(ctx context.Context, opts ...options.Lister[options.PeerInfoOptions]) ([]string, error) {
+func (w *CWrapper) PeerInfo(ctx context.Context, opts ...options.Enumerable[options.PeerInfoOptions]) ([]string, error) {
 	cIdentity := optionToUintptr(utils.NewOptions(opts...).GetIdentity())
 	defer C.IdentityFree(cIdentity)
 
@@ -131,7 +131,7 @@ func (w *CWrapper) PeerInfo(ctx context.Context, opts ...options.Lister[options.
 
 func (w *CWrapper) ActivePeers(
 	ctx context.Context,
-	opts ...options.Lister[options.ActivePeersOptions],
+	opts ...options.Enumerable[options.ActivePeersOptions],
 ) ([]string, error) {
 	opt := utils.NewOptions(opts...)
 	cIdentity := optionToUintptr(opt.GetIdentity())
@@ -153,7 +153,7 @@ func (w *CWrapper) ActivePeers(
 func (w *CWrapper) CreateReplicator(
 	ctx context.Context,
 	addresses []string,
-	opts ...options.Lister[options.CreateReplicatorOptions],
+	opts ...options.Enumerable[options.CreateReplicatorOptions],
 ) error {
 	opt := utils.NewOptions(opts...)
 	addrStr := C.CString(strings.Join(addresses, ","))
@@ -174,7 +174,7 @@ func (w *CWrapper) CreateReplicator(
 func (w *CWrapper) DeleteReplicator(
 	ctx context.Context,
 	id string,
-	opts ...options.Lister[options.DeleteReplicatorOptions],
+	opts ...options.Enumerable[options.DeleteReplicatorOptions],
 ) error {
 	opt := utils.NewOptions(opts...)
 	peerID := C.CString(id)
@@ -194,7 +194,7 @@ func (w *CWrapper) DeleteReplicator(
 
 func (w *CWrapper) ListReplicators(
 	ctx context.Context,
-	opts ...options.Lister[options.ListReplicatorsOptions],
+	opts ...options.Enumerable[options.ListReplicatorsOptions],
 ) ([]client.Replicator, error) {
 	cIdentity := optionToUintptr(utils.NewOptions(opts...).GetIdentity())
 	defer C.IdentityFree(cIdentity)
@@ -214,7 +214,7 @@ func (w *CWrapper) ListReplicators(
 func (w *CWrapper) CreateP2PCollections(
 	ctx context.Context,
 	collectionIDs []string,
-	opts ...options.Lister[options.CreateP2PCollectionsOptions],
+	opts ...options.Enumerable[options.CreateP2PCollectionsOptions],
 ) error {
 	cIdentity := optionToUintptr(utils.NewOptions(opts...).GetIdentity())
 	colStr := C.CString(strings.Join(collectionIDs, ","))
@@ -231,7 +231,7 @@ func (w *CWrapper) CreateP2PCollections(
 func (w *CWrapper) DeleteP2PCollections(
 	ctx context.Context,
 	collectionIDs []string,
-	opts ...options.Lister[options.DeleteP2PCollectionsOptions],
+	opts ...options.Enumerable[options.DeleteP2PCollectionsOptions],
 ) error {
 	colStr := C.CString(strings.Join(collectionIDs, ","))
 	cIdentity := optionToUintptr(utils.NewOptions(opts...).GetIdentity())
@@ -248,7 +248,7 @@ func (w *CWrapper) DeleteP2PCollections(
 
 func (w *CWrapper) ListP2PCollections(
 	ctx context.Context,
-	opts ...options.Lister[options.ListP2PCollectionsOptions],
+	opts ...options.Enumerable[options.ListP2PCollectionsOptions],
 ) ([]string, error) {
 	cIdentity := optionToUintptr(utils.NewOptions(opts...).GetIdentity())
 	defer C.IdentityFree(cIdentity)
@@ -268,7 +268,7 @@ func (w *CWrapper) ListP2PCollections(
 func (w *CWrapper) CreateP2PDocuments(
 	ctx context.Context,
 	docIDs []string,
-	opts ...options.Lister[options.CreateP2PDocumentsOptions],
+	opts ...options.Enumerable[options.CreateP2PDocumentsOptions],
 ) error {
 	docStr := C.CString(strings.Join(docIDs, ","))
 	cIdentity := optionToUintptr(utils.NewOptions(opts...).GetIdentity())
@@ -286,7 +286,7 @@ func (w *CWrapper) CreateP2PDocuments(
 func (w *CWrapper) DeleteP2PDocuments(
 	ctx context.Context,
 	docIDs []string,
-	opts ...options.Lister[options.DeleteP2PDocumentsOptions],
+	opts ...options.Enumerable[options.DeleteP2PDocumentsOptions],
 ) error {
 	docStr := C.CString(strings.Join(docIDs, ","))
 	cIdentity := optionToUintptr(utils.NewOptions(opts...).GetIdentity())
@@ -303,7 +303,7 @@ func (w *CWrapper) DeleteP2PDocuments(
 
 func (w *CWrapper) ListP2PDocuments(
 	ctx context.Context,
-	opts ...options.Lister[options.ListP2PDocumentsOptions],
+	opts ...options.Enumerable[options.ListP2PDocumentsOptions],
 ) ([]string, error) {
 	cIdentity := optionToUintptr(utils.NewOptions(opts...).GetIdentity())
 	defer C.IdentityFree(cIdentity)
@@ -350,7 +350,7 @@ func (w *CWrapper) SyncDocuments(
 func (w *CWrapper) SyncCollectionVersions(
 	ctx context.Context,
 	versionIDs []string,
-	opts ...options.Lister[options.SyncCollectionVersionsOptions],
+	opts ...options.Enumerable[options.SyncCollectionVersionsOptions],
 ) error {
 	opt := utils.NewOptions(opts...)
 	versions := C.CString(strings.Join(versionIDs, ","))
@@ -412,7 +412,7 @@ func (w *CWrapper) BasicImport(ctx context.Context, filepath string) error {
 func (w *CWrapper) BasicExport(
 	ctx context.Context,
 	filepath string,
-	opts ...options.Lister[options.BasicExportOptions],
+	opts ...options.Enumerable[options.BasicExportOptions],
 ) error {
 	panic("not implemented")
 }
@@ -420,7 +420,7 @@ func (w *CWrapper) BasicExport(
 func (w *CWrapper) AddSchema(
 	ctx context.Context,
 	schema string,
-	opts ...options.Lister[options.AddSchemaOptions],
+	opts ...options.Enumerable[options.AddSchemaOptions],
 ) ([]client.CollectionVersion, error) {
 	cIdentity := optionToUintptr(utils.NewOptions(opts...).GetIdentity())
 	defer C.IdentityFree(cIdentity)
@@ -444,7 +444,7 @@ func (w *CWrapper) AddSchema(
 func (w *CWrapper) AddDACPolicy(
 	ctx context.Context,
 	policy string,
-	opts ...options.Lister[options.AddDACPolicyOptions],
+	opts ...options.Enumerable[options.AddDACPolicyOptions],
 ) (client.AddPolicyResult, error) {
 	cIdentity := optionToUintptr(utils.NewOptions(opts...).GetIdentity())
 	defer C.IdentityFree(cIdentity)
@@ -471,7 +471,7 @@ func (w *CWrapper) AddDACActorRelationship(
 	docID string,
 	relation string,
 	targetActor string,
-	opts ...options.Lister[options.AddDACActorRelationshipOptions],
+	opts ...options.Enumerable[options.AddDACActorRelationshipOptions],
 ) (client.AddActorRelationshipResult, error) {
 	cIdentity := optionToUintptr(utils.NewOptions(opts...).GetIdentity())
 	cCollectionName := C.CString(collectionName)
@@ -512,7 +512,7 @@ func (w *CWrapper) DeleteDACActorRelationship(
 	docID string,
 	relation string,
 	targetActor string,
-	opts ...options.Lister[options.DeleteDACActorRelationshipOptions],
+	opts ...options.Enumerable[options.DeleteDACActorRelationshipOptions],
 ) (client.DeleteActorRelationshipResult, error) {
 	cIdentity := optionToUintptr(utils.NewOptions(opts...).GetIdentity())
 	cCollectionName := C.CString(collectionName)
@@ -548,7 +548,7 @@ func (w *CWrapper) DeleteDACActorRelationship(
 
 func (w *CWrapper) GetNACStatus(
 	ctx context.Context,
-	opts ...options.Lister[options.GetNACStatusOptions],
+	opts ...options.Enumerable[options.GetNACStatusOptions],
 ) (client.NACStatusResult, error) {
 	cIdentity := optionToUintptr(utils.NewOptions(opts...).GetIdentity())
 	defer C.IdentityFree(cIdentity)
@@ -562,7 +562,7 @@ func (w *CWrapper) GetNACStatus(
 	return unmarshalResult[client.NACStatusResult](res.Value)
 }
 
-func (w *CWrapper) ReEnableNAC(ctx context.Context, opts ...options.Lister[options.ReEnableNACOptions]) error {
+func (w *CWrapper) ReEnableNAC(ctx context.Context, opts ...options.Enumerable[options.ReEnableNACOptions]) error {
 	cIdentity := optionToUintptr(utils.NewOptions(opts...).GetIdentity())
 	defer C.IdentityFree(cIdentity)
 
@@ -575,7 +575,7 @@ func (w *CWrapper) ReEnableNAC(ctx context.Context, opts ...options.Lister[optio
 	return nil
 }
 
-func (w *CWrapper) DisableNAC(ctx context.Context, opts ...options.Lister[options.DisableNACOptions]) error {
+func (w *CWrapper) DisableNAC(ctx context.Context, opts ...options.Enumerable[options.DisableNACOptions]) error {
 	cIdentity := optionToUintptr(utils.NewOptions(opts...).GetIdentity())
 	defer C.IdentityFree(cIdentity)
 
@@ -592,7 +592,7 @@ func (w *CWrapper) AddNACActorRelationship(
 	ctx context.Context,
 	relation string,
 	targetActor string,
-	opts ...options.Lister[options.AddNACActorRelationshipOptions],
+	opts ...options.Enumerable[options.AddNACActorRelationshipOptions],
 ) (client.AddActorRelationshipResult, error) {
 	cIdentity := optionToUintptr(utils.NewOptions(opts...).GetIdentity())
 	cRelation := C.CString(relation)
@@ -615,7 +615,7 @@ func (w *CWrapper) DeleteNACActorRelationship(
 	ctx context.Context,
 	relation string,
 	targetActor string,
-	opts ...options.Lister[options.DeleteNACActorRelationshipOptions],
+	opts ...options.Enumerable[options.DeleteNACActorRelationshipOptions],
 ) (client.DeleteActorRelationshipResult, error) {
 	cIdentity := optionToUintptr(utils.NewOptions(opts...).GetIdentity())
 	cRelation := C.CString(relation)
@@ -636,7 +636,7 @@ func (w *CWrapper) PatchCollection(
 	ctx context.Context,
 	patch string,
 	migration immutable.Option[model.Lens],
-	opts ...options.Lister[options.PatchCollectionOptions],
+	opts ...options.Enumerable[options.PatchCollectionOptions],
 ) error {
 	cPatch := C.CString(patch)
 	cIdentity := optionToUintptr(utils.NewOptions(opts...).GetIdentity())
@@ -668,7 +668,7 @@ func (w *CWrapper) PatchCollection(
 func (w *CWrapper) SetActiveCollectionVersion(
 	ctx context.Context,
 	collectionVersionID string,
-	opts ...options.Lister[options.SetActiveCollectionVersionOptions],
+	opts ...options.Enumerable[options.SetActiveCollectionVersionOptions],
 ) error {
 	cIdentity := optionToUintptr(utils.NewOptions(opts...).GetIdentity())
 	cVersion := C.CString(collectionVersionID)
@@ -699,7 +699,7 @@ func (w *CWrapper) AddView(
 	ctx context.Context,
 	query string,
 	sdl string,
-	opts ...options.Lister[options.AddViewOptions],
+	opts ...options.Enumerable[options.AddViewOptions],
 ) ([]client.CollectionVersion, error) {
 	opt := utils.NewOptions(opts...)
 
@@ -727,7 +727,7 @@ func (w *CWrapper) AddView(
 	return colDefRes, nil
 }
 
-func (w *CWrapper) RefreshViews(ctx context.Context, opts ...options.Lister[options.RefreshViewsOptions]) error {
+func (w *CWrapper) RefreshViews(ctx context.Context, opts ...options.Enumerable[options.RefreshViewsOptions]) error {
 	opt := utils.NewOptions(opts...)
 	copts := getCollectionsOptionsToCOptions(opt)
 	defer C.free(unsafe.Pointer(copts.version))
@@ -770,7 +770,7 @@ func (w *CWrapper) SetMigration(ctx context.Context, config client.LensConfig) (
 func (w *CWrapper) AddLens(
 	ctx context.Context,
 	lens model.Lens,
-	opts ...options.Lister[options.AddLensOptions],
+	opts ...options.Enumerable[options.AddLensOptions],
 ) (string, error) {
 	lensConfig, err := json.Marshal(lens)
 	if err != nil {
@@ -793,7 +793,7 @@ func (w *CWrapper) AddLens(
 
 func (w *CWrapper) ListLenses(
 	ctx context.Context,
-	opts ...options.Lister[options.ListLensesOptions],
+	opts ...options.Enumerable[options.ListLensesOptions],
 ) (map[string]model.Lens, error) {
 	cIdentity := optionToUintptr(utils.NewOptions(opts...).GetIdentity())
 	defer C.IdentityFree(cIdentity)
@@ -815,7 +815,7 @@ func (w *CWrapper) ListLenses(
 func (w *CWrapper) GetCollectionByName(
 	ctx context.Context,
 	name client.CollectionName,
-	opts ...options.Lister[options.GetCollectionByNameOptions],
+	opts ...options.Enumerable[options.GetCollectionByNameOptions],
 ) (client.Collection, error) {
 	cols, err := w.GetCollections(ctx, options.GetCollections().SetCollectionName(name))
 	if err != nil {
@@ -861,7 +861,7 @@ func getCollectionsOptionsToCOptions(opts *options.GetCollectionsOptions) C.Coll
 
 func (w *CWrapper) GetCollections(
 	ctx context.Context,
-	opts ...options.Lister[options.GetCollectionsOptions],
+	opts ...options.Enumerable[options.GetCollectionsOptions],
 ) ([]client.Collection, error) {
 	copts := getCollectionsOptionsToCOptions(utils.NewOptions(opts...))
 	defer C.free(unsafe.Pointer(copts.version))
@@ -892,7 +892,7 @@ func (w *CWrapper) GetCollections(
 
 func (w *CWrapper) GetAllIndexes(
 	ctx context.Context,
-	opts ...options.Lister[options.GetAllIndexesOptions],
+	opts ...options.Enumerable[options.GetAllIndexesOptions],
 ) (map[client.CollectionName][]client.IndexDescription, error) {
 	cVersion := C.CString("")
 	cCollectionID := C.CString("")
@@ -948,7 +948,7 @@ func (w *CWrapper) ListAllEncryptedIndexes(
 func (w *CWrapper) ExecRequest(
 	ctx context.Context,
 	query string,
-	opts ...options.Lister[options.ExecRequestOptions],
+	opts ...options.Enumerable[options.ExecRequestOptions],
 ) *client.RequestResult {
 	execRequestOpts := utils.NewOptions(opts...)
 	operation, variables, err := extractStringsFromRequestOptions(execRequestOpts)
@@ -1057,7 +1057,7 @@ func (w *CWrapper) PrintDump(ctx context.Context) error {
 func (w *CWrapper) Connect(
 	ctx context.Context,
 	addresses []string,
-	opts ...options.Lister[options.ConnectOptions],
+	opts ...options.Enumerable[options.ConnectOptions],
 ) error {
 	cIdentity := optionToUintptr(utils.NewOptions(opts...).GetIdentity())
 	cPeerAddresses := C.CString(strings.Join(addresses, ","))
@@ -1095,7 +1095,7 @@ func (w *CWrapper) VerifySignature(
 	ctx context.Context,
 	blockCid string,
 	pubKey crypto.PublicKey,
-	opts ...options.Lister[options.VerifySignatureOptions],
+	opts ...options.Enumerable[options.VerifySignatureOptions],
 ) error {
 	cPubKey := C.CString(pubKey.String())
 	cKeyType := C.CString(string(pubKey.Type()))

--- a/cbindings/wrapper_collection.go
+++ b/cbindings/wrapper_collection.go
@@ -75,7 +75,7 @@ func (c *Collection) CollectionID() string {
 func (c *Collection) Create(
 	ctx context.Context,
 	doc *client.Document,
-	opts ...options.Lister[options.CollectionCreateOptions],
+	opts ...options.Enumerable[options.CollectionCreateOptions],
 ) error {
 	createOpts := utils.NewOptions(opts...)
 	isEncrypted := 0
@@ -130,7 +130,7 @@ func (c *Collection) Create(
 func (c *Collection) CreateMany(
 	ctx context.Context,
 	docs []*client.Document,
-	opts ...options.Lister[options.CollectionCreateOptions],
+	opts ...options.Enumerable[options.CollectionCreateOptions],
 ) error {
 	createOpts := utils.NewOptions(opts...)
 	isEncrypted := 0
@@ -194,7 +194,7 @@ func (c *Collection) CreateMany(
 func (c *Collection) Update(
 	ctx context.Context,
 	doc *client.Document,
-	opts ...options.Lister[options.CollectionUpdateOptions],
+	opts ...options.Enumerable[options.CollectionUpdateOptions],
 ) error {
 	docID := C.CString(doc.ID().String())
 	filter := C.CString("")
@@ -240,7 +240,7 @@ func (c *Collection) Update(
 func (c *Collection) Save(
 	ctx context.Context,
 	doc *client.Document,
-	opts ...options.Lister[options.CollectionSaveOptions],
+	opts ...options.Enumerable[options.CollectionSaveOptions],
 ) error {
 	saveOpt := utils.NewOptions(opts...)
 	getOpts := options.CollectionGet().SetShowDeleted(true)
@@ -264,7 +264,7 @@ func (c *Collection) Save(
 func (c *Collection) Delete(
 	ctx context.Context,
 	docID client.DocID,
-	opts ...options.Lister[options.CollectionDeleteOptions],
+	opts ...options.Enumerable[options.CollectionDeleteOptions],
 ) (bool, error) {
 	docIDStr := C.CString(docID.String())
 	filter := C.CString("")
@@ -303,7 +303,7 @@ func (c *Collection) Delete(
 func (c *Collection) Exists(
 	ctx context.Context,
 	docID client.DocID,
-	opts ...options.Lister[options.CollectionExistsOptions],
+	opts ...options.Enumerable[options.CollectionExistsOptions],
 ) (bool, error) {
 	docIDStr := C.CString(docID.String())
 	cShowDeleted := C.int(0)
@@ -342,7 +342,7 @@ func (c *Collection) UpdateWithFilter(
 	ctx context.Context,
 	filter any,
 	updater string,
-	opts ...options.Lister[options.CollectionUpdateWithFilterOptions],
+	opts ...options.Enumerable[options.CollectionUpdateWithFilterOptions],
 ) (*client.UpdateResult, error) {
 	docID := C.CString("")
 	filterJSON, err := json.Marshal(filter)
@@ -393,7 +393,7 @@ func (c *Collection) UpdateWithFilter(
 func (c *Collection) DeleteWithFilter(
 	ctx context.Context,
 	filter any,
-	opts ...options.Lister[options.CollectionDeleteWithFilterOptions],
+	opts ...options.Enumerable[options.CollectionDeleteWithFilterOptions],
 ) (*client.DeleteResult, error) {
 	docID := C.CString("")
 	filterJSON, err := json.Marshal(filter)
@@ -442,7 +442,7 @@ func (c *Collection) DeleteWithFilter(
 func (c *Collection) Get(
 	ctx context.Context,
 	docID client.DocID,
-	opts ...options.Lister[options.CollectionGetOptions],
+	opts ...options.Enumerable[options.CollectionGetOptions],
 ) (*client.Document, error) {
 	opt := utils.NewOptions(opts...)
 	var cShowDeleted C.int = 0
@@ -494,7 +494,7 @@ func (c *Collection) Get(
 
 func (c *Collection) GetAllDocIDs(
 	ctx context.Context,
-	opts ...options.Lister[options.CollectionGetAllDocIDsOptions],
+	opts ...options.Enumerable[options.CollectionGetAllDocIDsOptions],
 ) (<-chan client.DocIDResult, error) {
 	cVersion := C.CString("")
 	cCollectionID := C.CString("")
@@ -553,7 +553,7 @@ func (c *Collection) GetAllDocIDs(
 func (c *Collection) CreateIndex(
 	ctx context.Context,
 	indexDesc client.IndexCreateRequest,
-	opts ...options.Lister[options.CollectionCreateIndexOptions],
+	opts ...options.Enumerable[options.CollectionCreateIndexOptions],
 ) (client.IndexDescription, error) {
 	cName := C.CString(c.def.Name)
 	cIndexDescName := C.CString(indexDesc.Name)
@@ -612,7 +612,7 @@ func (c *Collection) CreateIndex(
 func (c *Collection) DropIndex(
 	ctx context.Context,
 	indexName string,
-	opts ...options.Lister[options.CollectionDropIndexOptions],
+	opts ...options.Enumerable[options.CollectionDropIndexOptions],
 ) error {
 	cName := C.CString(c.def.Name)
 	cIndexName := C.CString(indexName)
@@ -647,7 +647,7 @@ func (c *Collection) DropIndex(
 
 func (c *Collection) GetIndexes(
 	ctx context.Context,
-	opts ...options.Lister[options.CollectionGetIndexesOptions],
+	opts ...options.Enumerable[options.CollectionGetIndexesOptions],
 ) ([]client.IndexDescription, error) {
 	cName := C.CString(c.def.Name)
 	cIndexName := C.CString("")
@@ -741,7 +741,7 @@ func (c *Collection) ListEncryptedIndexes(ctx context.Context) ([]client.Encrypt
 	return retRes, nil
 }
 
-func (c *Collection) Truncate(ctx context.Context, opts ...options.Lister[options.CollectionTruncateOptions]) error {
+func (c *Collection) Truncate(ctx context.Context, opts ...options.Enumerable[options.CollectionTruncateOptions]) error {
 	cName := C.CString(c.def.Name)
 	cIndexName := C.CString("")
 	cVersion := C.CString("")

--- a/cbindings/wrapper_collection.go
+++ b/cbindings/wrapper_collection.go
@@ -741,7 +741,9 @@ func (c *Collection) ListEncryptedIndexes(ctx context.Context) ([]client.Encrypt
 	return retRes, nil
 }
 
-func (c *Collection) Truncate(ctx context.Context, opts ...options.Enumerable[options.CollectionTruncateOptions]) error {
+func (c *Collection) Truncate(
+	ctx context.Context, opts ...options.Enumerable[options.CollectionTruncateOptions],
+) error {
 	cName := C.CString(c.def.Name)
 	cIndexName := C.CString("")
 	cVersion := C.CString("")

--- a/cbindings/wrapper_tx.go
+++ b/cbindings/wrapper_tx.go
@@ -147,7 +147,9 @@ func (txn *Transaction) AddView(
 	return txn.CWrapper.AddView(ctx, gqlQuery, sdl, opts...)
 }
 
-func (txn *Transaction) RefreshViews(ctx context.Context, opts ...options.Enumerable[options.RefreshViewsOptions]) error {
+func (txn *Transaction) RefreshViews(
+	ctx context.Context, opts ...options.Enumerable[options.RefreshViewsOptions],
+) error {
 	return txn.CWrapper.RefreshViews(ctx, opts...)
 }
 

--- a/cbindings/wrapper_tx.go
+++ b/cbindings/wrapper_tx.go
@@ -73,7 +73,7 @@ func (txn *Transaction) PrintDump(ctx context.Context) error {
 func (txn *Transaction) AddDACPolicy(
 	ctx context.Context,
 	policy string,
-	opts ...options.Lister[options.AddDACPolicyOptions],
+	opts ...options.Enumerable[options.AddDACPolicyOptions],
 ) (client.AddPolicyResult, error) {
 	return txn.CWrapper.AddDACPolicy(ctx, policy, opts...)
 }
@@ -84,7 +84,7 @@ func (txn *Transaction) AddDACActorRelationship(
 	docID string,
 	relation string,
 	targetActor string,
-	opts ...options.Lister[options.AddDACActorRelationshipOptions],
+	opts ...options.Enumerable[options.AddDACActorRelationshipOptions],
 ) (client.AddActorRelationshipResult, error) {
 	return txn.CWrapper.AddDACActorRelationship(ctx, collectionName, docID, relation, targetActor, opts...)
 }
@@ -95,7 +95,7 @@ func (txn *Transaction) DeleteDACActorRelationship(
 	docID string,
 	relation string,
 	targetActor string,
-	opts ...options.Lister[options.DeleteDACActorRelationshipOptions],
+	opts ...options.Enumerable[options.DeleteDACActorRelationshipOptions],
 ) (client.DeleteActorRelationshipResult, error) {
 	return txn.CWrapper.DeleteDACActorRelationship(ctx, collectionName, docID, relation, targetActor, opts...)
 }
@@ -108,7 +108,7 @@ func (txn *Transaction) VerifySignature(
 	ctx context.Context,
 	blockCid string,
 	pubKey crypto.PublicKey,
-	opts ...options.Lister[options.VerifySignatureOptions],
+	opts ...options.Enumerable[options.VerifySignatureOptions],
 ) error {
 	return txn.CWrapper.VerifySignature(ctx, blockCid, pubKey, opts...)
 }
@@ -116,7 +116,7 @@ func (txn *Transaction) VerifySignature(
 func (txn *Transaction) AddSchema(
 	ctx context.Context,
 	sdl string,
-	opts ...options.Lister[options.AddSchemaOptions],
+	opts ...options.Enumerable[options.AddSchemaOptions],
 ) ([]client.CollectionVersion, error) {
 	return txn.CWrapper.AddSchema(ctx, sdl, opts...)
 }
@@ -125,7 +125,7 @@ func (txn *Transaction) PatchCollection(
 	ctx context.Context,
 	patch string,
 	migration immutable.Option[model.Lens],
-	opts ...options.Lister[options.PatchCollectionOptions],
+	opts ...options.Enumerable[options.PatchCollectionOptions],
 ) error {
 	return txn.CWrapper.PatchCollection(ctx, patch, migration, opts...)
 }
@@ -133,7 +133,7 @@ func (txn *Transaction) PatchCollection(
 func (txn *Transaction) SetActiveCollectionVersion(
 	ctx context.Context,
 	version string,
-	opts ...options.Lister[options.SetActiveCollectionVersionOptions],
+	opts ...options.Enumerable[options.SetActiveCollectionVersionOptions],
 ) error {
 	return txn.CWrapper.SetActiveCollectionVersion(ctx, version, opts...)
 }
@@ -142,12 +142,12 @@ func (txn *Transaction) AddView(
 	ctx context.Context,
 	gqlQuery string,
 	sdl string,
-	opts ...options.Lister[options.AddViewOptions],
+	opts ...options.Enumerable[options.AddViewOptions],
 ) ([]client.CollectionVersion, error) {
 	return txn.CWrapper.AddView(ctx, gqlQuery, sdl, opts...)
 }
 
-func (txn *Transaction) RefreshViews(ctx context.Context, opts ...options.Lister[options.RefreshViewsOptions]) error {
+func (txn *Transaction) RefreshViews(ctx context.Context, opts ...options.Enumerable[options.RefreshViewsOptions]) error {
 	return txn.CWrapper.RefreshViews(ctx, opts...)
 }
 
@@ -158,14 +158,14 @@ func (txn *Transaction) SetMigration(ctx context.Context, config client.LensConf
 func (txn *Transaction) AddLens(
 	ctx context.Context,
 	lens model.Lens,
-	opts ...options.Lister[options.AddLensOptions],
+	opts ...options.Enumerable[options.AddLensOptions],
 ) (string, error) {
 	return txn.CWrapper.AddLens(ctx, lens, opts...)
 }
 
 func (txn *Transaction) ListLenses(
 	ctx context.Context,
-	opts ...options.Lister[options.ListLensesOptions],
+	opts ...options.Enumerable[options.ListLensesOptions],
 ) (map[string]model.Lens, error) {
 	return txn.CWrapper.ListLenses(ctx, opts...)
 }
@@ -173,21 +173,21 @@ func (txn *Transaction) ListLenses(
 func (txn *Transaction) GetCollectionByName(
 	ctx context.Context,
 	name client.CollectionName,
-	opts ...options.Lister[options.GetCollectionByNameOptions],
+	opts ...options.Enumerable[options.GetCollectionByNameOptions],
 ) (client.Collection, error) {
 	return txn.CWrapper.GetCollectionByName(ctx, name, opts...)
 }
 
 func (txn *Transaction) GetCollections(
 	ctx context.Context,
-	opts ...options.Lister[options.GetCollectionsOptions],
+	opts ...options.Enumerable[options.GetCollectionsOptions],
 ) ([]client.Collection, error) {
 	return txn.CWrapper.GetCollections(ctx, opts...)
 }
 
 func (txn *Transaction) GetAllIndexes(
 	ctx context.Context,
-	opts ...options.Lister[options.GetAllIndexesOptions],
+	opts ...options.Enumerable[options.GetAllIndexesOptions],
 ) (map[client.CollectionName][]client.IndexDescription, error) {
 	return txn.CWrapper.GetAllIndexes(ctx, opts...)
 }
@@ -195,7 +195,7 @@ func (txn *Transaction) GetAllIndexes(
 func (txn *Transaction) ExecRequest(
 	ctx context.Context,
 	request string,
-	opts ...options.Lister[options.ExecRequestOptions],
+	opts ...options.Enumerable[options.ExecRequestOptions],
 ) *client.RequestResult {
 	return txn.CWrapper.ExecRequest(ctx, request, opts...)
 }
@@ -207,7 +207,7 @@ func (txn *Transaction) BasicImport(ctx context.Context, filepath string) error 
 func (txn *Transaction) BasicExport(
 	ctx context.Context,
 	filepath string,
-	opts ...options.Lister[options.BasicExportOptions],
+	opts ...options.Enumerable[options.BasicExportOptions],
 ) error {
 	return txn.CWrapper.BasicExport(ctx, filepath, opts...)
 }

--- a/client/collection.go
+++ b/client/collection.go
@@ -38,12 +38,12 @@ type Collection interface {
 	// Create a new document.
 	//
 	// Will verify the DocID/CID to ensure that the new document is correctly formatted.
-	Create(ctx context.Context, doc *Document, opts ...options.Lister[options.CollectionCreateOptions]) error
+	Create(ctx context.Context, doc *Document, opts ...options.Enumerable[options.CollectionCreateOptions]) error
 
 	// CreateMany new documents.
 	//
 	// Will verify the DocIDs/CIDs to ensure that the new documents are correctly formatted.
-	CreateMany(ctx context.Context, docs []*Document, opts ...options.Lister[options.CollectionCreateOptions]) error
+	CreateMany(ctx context.Context, docs []*Document, opts ...options.Enumerable[options.CollectionCreateOptions]) error
 
 	// Update an existing document with the new values.
 	//
@@ -51,13 +51,13 @@ type Collection interface {
 	// Any field that is nil/empty that hasn't called Clear will be ignored.
 	//
 	// Will return a ErrDocumentNotFound error if the given document is not found.
-	Update(ctx context.Context, docs *Document, opts ...options.Lister[options.CollectionUpdateOptions]) error
+	Update(ctx context.Context, docs *Document, opts ...options.Enumerable[options.CollectionUpdateOptions]) error
 
 	// Save the given document in the database.
 	//
 	// If a document exists with the given DocID it will update it. Otherwise a new document
 	// will be created.
-	Save(ctx context.Context, doc *Document, opts ...options.Lister[options.CollectionSaveOptions]) error
+	Save(ctx context.Context, doc *Document, opts ...options.Enumerable[options.CollectionSaveOptions]) error
 
 	// Delete will attempt to delete a document by DocID.
 	//
@@ -65,12 +65,12 @@ type Collection interface {
 	// if it cannot. If the document doesn't exist, then it will return false and a ErrDocumentNotFound error.
 	// This operation will hard-delete all state relating to the given DocID.
 	// This includes data, block, and head storage.
-	Delete(ctx context.Context, docID DocID, opts ...options.Lister[options.CollectionDeleteOptions]) (bool, error)
+	Delete(ctx context.Context, docID DocID, opts ...options.Enumerable[options.CollectionDeleteOptions]) (bool, error)
 
 	// Exists checks if a given document exists with supplied DocID.
 	//
 	// Will return true if a matching document exists, otherwise will return false.
-	Exists(ctx context.Context, docID DocID, opts ...options.Lister[options.CollectionExistsOptions]) (bool, error)
+	Exists(ctx context.Context, docID DocID, opts ...options.Enumerable[options.CollectionExistsOptions]) (bool, error)
 
 	// UpdateWithFilter updates using a filter to target documents for update.
 	//
@@ -80,7 +80,7 @@ type Collection interface {
 		ctx context.Context,
 		filter any,
 		updater string,
-		opts ...options.Lister[options.CollectionUpdateWithFilterOptions],
+		opts ...options.Enumerable[options.CollectionUpdateWithFilterOptions],
 	) (*UpdateResult, error)
 
 	// DeleteWithFilter deletes documents matching the given filter.
@@ -90,7 +90,7 @@ type Collection interface {
 	DeleteWithFilter(
 		ctx context.Context,
 		filter any,
-		opts ...options.Lister[options.CollectionDeleteWithFilterOptions],
+		opts ...options.Enumerable[options.CollectionDeleteWithFilterOptions],
 	) (*DeleteResult, error)
 
 	// Get returns the document with the given DocID.
@@ -99,13 +99,13 @@ type Collection interface {
 	Get(
 		ctx context.Context,
 		docID DocID,
-		opts ...options.Lister[options.CollectionGetOptions],
+		opts ...options.Enumerable[options.CollectionGetOptions],
 	) (*Document, error)
 
 	// GetAllDocIDs returns all the document IDs that exist in the collection.
 	GetAllDocIDs(
 		ctx context.Context,
-		opts ...options.Lister[options.CollectionGetAllDocIDsOptions],
+		opts ...options.Enumerable[options.CollectionGetAllDocIDsOptions],
 	) (<-chan DocIDResult, error)
 
 	// CreateIndex creates a new index on the collection.
@@ -117,16 +117,16 @@ type Collection interface {
 	CreateIndex(
 		context.Context,
 		IndexCreateRequest,
-		...options.Lister[options.CollectionCreateIndexOptions],
+		...options.Enumerable[options.CollectionCreateIndexOptions],
 	) (IndexDescription, error)
 
 	// DropIndex drops an index from the collection.
-	DropIndex(ctx context.Context, indexName string, opts ...options.Lister[options.CollectionDropIndexOptions]) error
+	DropIndex(ctx context.Context, indexName string, opts ...options.Enumerable[options.CollectionDropIndexOptions]) error
 
 	// GetIndexes returns all the indexes that exist on the collection.
 	GetIndexes(
 		ctx context.Context,
-		opts ...options.Lister[options.CollectionGetIndexesOptions],
+		opts ...options.Enumerable[options.CollectionGetIndexesOptions],
 	) ([]IndexDescription, error)
 
 	// CreateEncryptedIndex creates a new encrypted index on the collection.
@@ -145,7 +145,7 @@ type Collection interface {
 	//
 	// This call will lock the collection, and no other read or write document operations on this collection
 	// will progress whilst this is executing.
-	Truncate(ctx context.Context, opts ...options.Lister[options.CollectionTruncateOptions]) error
+	Truncate(ctx context.Context, opts ...options.Enumerable[options.CollectionTruncateOptions]) error
 }
 
 // DocIDResult wraps the result of an attempt at a DocID retrieval operation.

--- a/client/db.go
+++ b/client/db.go
@@ -63,7 +63,7 @@ type Store interface {
 	AddDACPolicy(
 		ctx context.Context,
 		policy string,
-		opts ...options.Lister[options.AddDACPolicyOptions],
+		opts ...options.Enumerable[options.AddDACPolicyOptions],
 	) (AddPolicyResult, error)
 
 	// AddDACActorRelationship creates a relationship between document and the target actor.
@@ -80,7 +80,7 @@ type Store interface {
 		docID string,
 		relation string,
 		targetActor string,
-		opts ...options.Lister[options.AddDACActorRelationshipOptions],
+		opts ...options.Enumerable[options.AddDACActorRelationshipOptions],
 	) (AddActorRelationshipResult, error)
 
 	// DeleteDACActorRelationship deletes a relationship between document and the target actor.
@@ -99,7 +99,7 @@ type Store interface {
 		docID string,
 		relation string,
 		targetActor string,
-		opts ...options.Lister[options.DeleteDACActorRelationshipOptions],
+		opts ...options.Enumerable[options.DeleteDACActorRelationshipOptions],
 	) (DeleteActorRelationshipResult, error)
 
 	// AddNACActorRelationship creates a relationship to grant node access to the target actor.
@@ -114,7 +114,7 @@ type Store interface {
 		ctx context.Context,
 		relation string,
 		targetActor string,
-		opts ...options.Lister[options.AddNACActorRelationshipOptions],
+		opts ...options.Enumerable[options.AddNACActorRelationshipOptions],
 	) (AddActorRelationshipResult, error)
 
 	// DeleteNACActorRelationship deletes a relationship to revoke node access from target actor.
@@ -131,7 +131,7 @@ type Store interface {
 		ctx context.Context,
 		relation string,
 		targetActor string,
-		opts ...options.Lister[options.DeleteNACActorRelationshipOptions],
+		opts ...options.Enumerable[options.DeleteNACActorRelationshipOptions],
 	) (DeleteActorRelationshipResult, error)
 
 	// ReEnableNAC will re-enable node acp that was temporarily disabled (and configured). This will
@@ -144,7 +144,7 @@ type Store interface {
 	//
 	// Returns an [client.ErrNotAuthorizedToPerformOperation] error if the requesting identity is not
 	// authorized to perform this operation.
-	ReEnableNAC(ctx context.Context, opts ...options.Lister[options.ReEnableNACOptions]) error
+	ReEnableNAC(ctx context.Context, opts ...options.Enumerable[options.ReEnableNACOptions]) error
 
 	// DisableNAC will disable node acp for the users temporarily. This will keep the current node acp
 	// state saved so that if it is re-enabled in the future, then we can recover all the relationships formed.
@@ -155,11 +155,11 @@ type Store interface {
 	//
 	// Returns an [client.ErrNotAuthorizedToPerformOperation] error if the requesting identity is not
 	// authorized to perform this operation.
-	DisableNAC(ctx context.Context, opts ...options.Lister[options.DisableNACOptions]) error
+	DisableNAC(ctx context.Context, opts ...options.Enumerable[options.DisableNACOptions]) error
 
 	// GetNACStatus returns the node acp status that tells us if node access was ever configured,
 	// or if node acp is currently enabled or temporarily disabled.
-	GetNACStatus(ctx context.Context, opts ...options.Lister[options.GetNACStatusOptions]) (NACStatusResult, error)
+	GetNACStatus(ctx context.Context, opts ...options.Enumerable[options.GetNACStatusOptions]) (NACStatusResult, error)
 
 	// GetNodeIdentity returns the identity of the node.
 	GetNodeIdentity(ctx context.Context) (immutable.Option[identity.PublicRawIdentity], error)
@@ -170,7 +170,7 @@ type Store interface {
 		ctx context.Context,
 		blockCid string,
 		pubKey crypto.PublicKey,
-		opts ...options.Lister[options.VerifySignatureOptions],
+		opts ...options.Enumerable[options.VerifySignatureOptions],
 	) error
 
 	// AddSchema takes the provided GQL schema in SDL format, and applies it to the [Store],
@@ -181,7 +181,7 @@ type Store interface {
 	AddSchema(
 		ctx context.Context,
 		sdl string,
-		opts ...options.Lister[options.AddSchemaOptions],
+		opts ...options.Enumerable[options.AddSchemaOptions],
 	) ([]CollectionVersion, error)
 
 	// PatchCollection takes the given JSON patch string and applies it to the set of CollectionVersions
@@ -208,7 +208,7 @@ type Store interface {
 		ctx context.Context,
 		patch string,
 		migration immutable.Option[model.Lens],
-		opts ...options.Lister[options.PatchCollectionOptions],
+		opts ...options.Enumerable[options.PatchCollectionOptions],
 	) error
 
 	// SetActiveCollectionVersion activates all collection versions with the given VersionID, and deactivates all
@@ -221,7 +221,7 @@ type Store interface {
 	SetActiveCollectionVersion(
 		ctx context.Context,
 		versionID string,
-		opts ...options.Lister[options.SetActiveCollectionVersionOptions],
+		opts ...options.Enumerable[options.SetActiveCollectionVersionOptions],
 	) error
 
 	// AddView creates a new Defra View.
@@ -262,7 +262,7 @@ type Store interface {
 		ctx context.Context,
 		gqlQuery string,
 		sdl string,
-		opts ...options.Lister[options.AddViewOptions],
+		opts ...options.Enumerable[options.AddViewOptions],
 	) ([]CollectionVersion, error)
 
 	// RefreshViews refreshes the caches of all views matching the given options.  If no options are set, all views
@@ -271,7 +271,7 @@ type Store interface {
 	// The cached result is dependent on the ACP settings of the source data and the permissions of the user making
 	// the call.  At the moment only one cache can be active at a time, so please pay attention to access rights
 	// when making this call.
-	RefreshViews(ctx context.Context, opts ...options.Lister[options.RefreshViewsOptions]) error
+	RefreshViews(ctx context.Context, opts ...options.Enumerable[options.RefreshViewsOptions]) error
 
 	// SetMigration sets the migration for all collections using the given source-destination collection version IDs.
 	//
@@ -292,10 +292,10 @@ type Store interface {
 	//
 	// The lens store is content-addressed, so identical lens configurations
 	// will return the same CID without duplicating storage.
-	AddLens(ctx context.Context, lens model.Lens, opts ...options.Lister[options.AddLensOptions]) (string, error)
+	AddLens(ctx context.Context, lens model.Lens, opts ...options.Enumerable[options.AddLensOptions]) (string, error)
 
 	// ListLenses returns all stored lenses mapped by their CID.
-	ListLenses(ctx context.Context, opts ...options.Lister[options.ListLensesOptions]) (map[string]model.Lens, error)
+	ListLenses(ctx context.Context, opts ...options.Enumerable[options.ListLensesOptions]) (map[string]model.Lens, error)
 
 	// GetCollectionByName attempts to retrieve a collection matching the given name.
 	//
@@ -306,7 +306,7 @@ type Store interface {
 	GetCollectionByName(
 		ctx context.Context,
 		name CollectionName,
-		opts ...options.Lister[options.GetCollectionByNameOptions],
+		opts ...options.Enumerable[options.GetCollectionByNameOptions],
 	) (Collection, error)
 
 	// GetCollections returns all collections and their descriptions matching the given options
@@ -317,19 +317,19 @@ type Store interface {
 	//
 	// If a transaction was explicitly provided to this [Store] via [DB].[WithTxn], any function calls
 	// made via the returned [Collection]s will respect that transaction.
-	GetCollections(ctx context.Context, opts ...options.Lister[options.GetCollectionsOptions]) ([]Collection, error)
+	GetCollections(ctx context.Context, opts ...options.Enumerable[options.GetCollectionsOptions]) ([]Collection, error)
 
 	// GetAllIndexes returns all the indexes that currently exist within this [Store].
 	GetAllIndexes(
 		ctx context.Context,
-		opts ...options.Lister[options.GetAllIndexesOptions],
+		opts ...options.Enumerable[options.GetAllIndexesOptions],
 	) (map[CollectionName][]IndexDescription, error)
 
 	// ListAllEncryptedIndexes returns all the encrypted indexes that currently exist within this [Store].
 	ListAllEncryptedIndexes(context.Context) (map[CollectionName][]EncryptedIndexDescription, error)
 
 	// ExecRequest executes the given GQL request against the [Store].
-	ExecRequest(ctx context.Context, request string, opts ...options.Lister[options.ExecRequestOptions]) *RequestResult
+	ExecRequest(ctx context.Context, request string, opts ...options.Enumerable[options.ExecRequestOptions]) *RequestResult
 
 	// BasicImport imports a json dataset.
 	// filepath must be accessible to the node.
@@ -337,7 +337,7 @@ type Store interface {
 
 	// BasicExport exports the current data or subset of data to file in json format.
 	// The filepath parameter is required and specifies where to write the export file.
-	BasicExport(ctx context.Context, filepath string, opts ...options.Lister[options.BasicExportOptions]) error
+	BasicExport(ctx context.Context, filepath string, opts ...options.Enumerable[options.BasicExportOptions]) error
 
 	// P2P holds the methods that are related to P2P operations.
 	// Calling them when no networking stack has been configured should return an error.

--- a/client/mocks/collection.go
+++ b/client/mocks/collection.go
@@ -114,7 +114,7 @@ type Collection_Create_Call struct {
 // Create is a helper method to define mock.On call
 //   - ctx context.Context
 //   - doc *client.Document
-//   - opts ...options.Lister[options.CollectionCreateOptions]
+//   - opts ...options.Enumerable[options.CollectionCreateOptions]
 func (_e *Collection_Expecter) Create(ctx interface{}, doc interface{}, opts ...interface{}) *Collection_Create_Call {
 	return &Collection_Create_Call{Call: _e.mock.On("Create",
 		append([]interface{}{ctx, doc}, opts...)...)}
@@ -261,7 +261,7 @@ type Collection_CreateIndex_Call struct {
 // CreateIndex is a helper method to define mock.On call
 //   - context1 context.Context
 //   - indexCreateRequest client.IndexCreateRequest
-//   - vs ...options.Lister[options.CollectionCreateIndexOptions]
+//   - vs ...options.Enumerable[options.CollectionCreateIndexOptions]
 func (_e *Collection_Expecter) CreateIndex(context1 interface{}, indexCreateRequest interface{}, vs ...interface{}) *Collection_CreateIndex_Call {
 	return &Collection_CreateIndex_Call{Call: _e.mock.On("CreateIndex",
 		append([]interface{}{context1, indexCreateRequest}, vs...)...)}
@@ -333,7 +333,7 @@ type Collection_CreateMany_Call struct {
 // CreateMany is a helper method to define mock.On call
 //   - ctx context.Context
 //   - docs []*client.Document
-//   - opts ...options.Lister[options.CollectionCreateOptions]
+//   - opts ...options.Enumerable[options.CollectionCreateOptions]
 func (_e *Collection_Expecter) CreateMany(ctx interface{}, docs interface{}, opts ...interface{}) *Collection_CreateMany_Call {
 	return &Collection_CreateMany_Call{Call: _e.mock.On("CreateMany",
 		append([]interface{}{ctx, docs}, opts...)...)}
@@ -414,7 +414,7 @@ type Collection_Delete_Call struct {
 // Delete is a helper method to define mock.On call
 //   - ctx context.Context
 //   - docID client.DocID
-//   - opts ...options.Lister[options.CollectionDeleteOptions]
+//   - opts ...options.Enumerable[options.CollectionDeleteOptions]
 func (_e *Collection_Expecter) Delete(ctx interface{}, docID interface{}, opts ...interface{}) *Collection_Delete_Call {
 	return &Collection_Delete_Call{Call: _e.mock.On("Delete",
 		append([]interface{}{ctx, docID}, opts...)...)}
@@ -554,7 +554,7 @@ type Collection_DeleteWithFilter_Call struct {
 // DeleteWithFilter is a helper method to define mock.On call
 //   - ctx context.Context
 //   - filter any
-//   - opts ...options.Lister[options.CollectionDeleteWithFilterOptions]
+//   - opts ...options.Enumerable[options.CollectionDeleteWithFilterOptions]
 func (_e *Collection_Expecter) DeleteWithFilter(ctx interface{}, filter interface{}, opts ...interface{}) *Collection_DeleteWithFilter_Call {
 	return &Collection_DeleteWithFilter_Call{Call: _e.mock.On("DeleteWithFilter",
 		append([]interface{}{ctx, filter}, opts...)...)}
@@ -626,7 +626,7 @@ type Collection_DropIndex_Call struct {
 // DropIndex is a helper method to define mock.On call
 //   - ctx context.Context
 //   - indexName string
-//   - opts ...options.Lister[options.CollectionDropIndexOptions]
+//   - opts ...options.Enumerable[options.CollectionDropIndexOptions]
 func (_e *Collection_Expecter) DropIndex(ctx interface{}, indexName interface{}, opts ...interface{}) *Collection_DropIndex_Call {
 	return &Collection_DropIndex_Call{Call: _e.mock.On("DropIndex",
 		append([]interface{}{ctx, indexName}, opts...)...)}
@@ -707,7 +707,7 @@ type Collection_Exists_Call struct {
 // Exists is a helper method to define mock.On call
 //   - ctx context.Context
 //   - docID client.DocID
-//   - opts ...options.Lister[options.CollectionExistsOptions]
+//   - opts ...options.Enumerable[options.CollectionExistsOptions]
 func (_e *Collection_Expecter) Exists(ctx interface{}, docID interface{}, opts ...interface{}) *Collection_Exists_Call {
 	return &Collection_Exists_Call{Call: _e.mock.On("Exists",
 		append([]interface{}{ctx, docID}, opts...)...)}
@@ -790,7 +790,7 @@ type Collection_Get_Call struct {
 // Get is a helper method to define mock.On call
 //   - ctx context.Context
 //   - docID client.DocID
-//   - opts ...options.Lister[options.CollectionGetOptions]
+//   - opts ...options.Enumerable[options.CollectionGetOptions]
 func (_e *Collection_Expecter) Get(ctx interface{}, docID interface{}, opts ...interface{}) *Collection_Get_Call {
 	return &Collection_Get_Call{Call: _e.mock.On("Get",
 		append([]interface{}{ctx, docID}, opts...)...)}
@@ -872,7 +872,7 @@ type Collection_GetAllDocIDs_Call struct {
 
 // GetAllDocIDs is a helper method to define mock.On call
 //   - ctx context.Context
-//   - opts ...options.Lister[options.CollectionGetAllDocIDsOptions]
+//   - opts ...options.Enumerable[options.CollectionGetAllDocIDsOptions]
 func (_e *Collection_Expecter) GetAllDocIDs(ctx interface{}, opts ...interface{}) *Collection_GetAllDocIDs_Call {
 	return &Collection_GetAllDocIDs_Call{Call: _e.mock.On("GetAllDocIDs",
 		append([]interface{}{ctx}, opts...)...)}
@@ -949,7 +949,7 @@ type Collection_GetIndexes_Call struct {
 
 // GetIndexes is a helper method to define mock.On call
 //   - ctx context.Context
-//   - opts ...options.Lister[options.CollectionGetIndexesOptions]
+//   - opts ...options.Enumerable[options.CollectionGetIndexesOptions]
 func (_e *Collection_Expecter) GetIndexes(ctx interface{}, opts ...interface{}) *Collection_GetIndexes_Call {
 	return &Collection_GetIndexes_Call{Call: _e.mock.On("GetIndexes",
 		append([]interface{}{ctx}, opts...)...)}
@@ -1122,7 +1122,7 @@ type Collection_Save_Call struct {
 // Save is a helper method to define mock.On call
 //   - ctx context.Context
 //   - doc *client.Document
-//   - opts ...options.Lister[options.CollectionSaveOptions]
+//   - opts ...options.Enumerable[options.CollectionSaveOptions]
 func (_e *Collection_Expecter) Save(ctx interface{}, doc interface{}, opts ...interface{}) *Collection_Save_Call {
 	return &Collection_Save_Call{Call: _e.mock.On("Save",
 		append([]interface{}{ctx, doc}, opts...)...)}
@@ -1193,7 +1193,7 @@ type Collection_Truncate_Call struct {
 
 // Truncate is a helper method to define mock.On call
 //   - ctx context.Context
-//   - opts ...options.Lister[options.CollectionTruncateOptions]
+//   - opts ...options.Enumerable[options.CollectionTruncateOptions]
 func (_e *Collection_Expecter) Truncate(ctx interface{}, opts ...interface{}) *Collection_Truncate_Call {
 	return &Collection_Truncate_Call{Call: _e.mock.On("Truncate",
 		append([]interface{}{ctx}, opts...)...)}
@@ -1260,7 +1260,7 @@ type Collection_Update_Call struct {
 // Update is a helper method to define mock.On call
 //   - ctx context.Context
 //   - docs *client.Document
-//   - opts ...options.Lister[options.CollectionUpdateOptions]
+//   - opts ...options.Enumerable[options.CollectionUpdateOptions]
 func (_e *Collection_Expecter) Update(ctx interface{}, docs interface{}, opts ...interface{}) *Collection_Update_Call {
 	return &Collection_Update_Call{Call: _e.mock.On("Update",
 		append([]interface{}{ctx, docs}, opts...)...)}
@@ -1344,7 +1344,7 @@ type Collection_UpdateWithFilter_Call struct {
 //   - ctx context.Context
 //   - filter any
 //   - updater string
-//   - opts ...options.Lister[options.CollectionUpdateWithFilterOptions]
+//   - opts ...options.Enumerable[options.CollectionUpdateWithFilterOptions]
 func (_e *Collection_Expecter) UpdateWithFilter(ctx interface{}, filter interface{}, updater interface{}, opts ...interface{}) *Collection_UpdateWithFilter_Call {
 	return &Collection_UpdateWithFilter_Call{Call: _e.mock.On("UpdateWithFilter",
 		append([]interface{}{ctx, filter, updater}, opts...)...)}

--- a/client/mocks/collection.go
+++ b/client/mocks/collection.go
@@ -84,7 +84,7 @@ func (_c *Collection_CollectionID_Call) RunAndReturn(run func() string) *Collect
 }
 
 // Create provides a mock function for the type Collection
-func (_mock *Collection) Create(ctx context.Context, doc *client.Document, opts ...options.Lister[options.CollectionCreateOptions]) error {
+func (_mock *Collection) Create(ctx context.Context, doc *client.Document, opts ...options.Enumerable[options.CollectionCreateOptions]) error {
 	var tmpRet mock.Arguments
 	if len(opts) > 0 {
 		tmpRet = _mock.Called(ctx, doc, opts)
@@ -98,7 +98,7 @@ func (_mock *Collection) Create(ctx context.Context, doc *client.Document, opts 
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, *client.Document, ...options.Lister[options.CollectionCreateOptions]) error); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *client.Document, ...options.Enumerable[options.CollectionCreateOptions]) error); ok {
 		r0 = returnFunc(ctx, doc, opts...)
 	} else {
 		r0 = ret.Error(0)
@@ -120,7 +120,7 @@ func (_e *Collection_Expecter) Create(ctx interface{}, doc interface{}, opts ...
 		append([]interface{}{ctx, doc}, opts...)...)}
 }
 
-func (_c *Collection_Create_Call) Run(run func(ctx context.Context, doc *client.Document, opts ...options.Lister[options.CollectionCreateOptions])) *Collection_Create_Call {
+func (_c *Collection_Create_Call) Run(run func(ctx context.Context, doc *client.Document, opts ...options.Enumerable[options.CollectionCreateOptions])) *Collection_Create_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -130,10 +130,10 @@ func (_c *Collection_Create_Call) Run(run func(ctx context.Context, doc *client.
 		if args[1] != nil {
 			arg1 = args[1].(*client.Document)
 		}
-		var arg2 []options.Lister[options.CollectionCreateOptions]
-		var variadicArgs []options.Lister[options.CollectionCreateOptions]
+		var arg2 []options.Enumerable[options.CollectionCreateOptions]
+		var variadicArgs []options.Enumerable[options.CollectionCreateOptions]
 		if len(args) > 2 {
-			variadicArgs = args[2].([]options.Lister[options.CollectionCreateOptions])
+			variadicArgs = args[2].([]options.Enumerable[options.CollectionCreateOptions])
 		}
 		arg2 = variadicArgs
 		run(
@@ -150,7 +150,7 @@ func (_c *Collection_Create_Call) Return(err error) *Collection_Create_Call {
 	return _c
 }
 
-func (_c *Collection_Create_Call) RunAndReturn(run func(ctx context.Context, doc *client.Document, opts ...options.Lister[options.CollectionCreateOptions]) error) *Collection_Create_Call {
+func (_c *Collection_Create_Call) RunAndReturn(run func(ctx context.Context, doc *client.Document, opts ...options.Enumerable[options.CollectionCreateOptions]) error) *Collection_Create_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -222,7 +222,7 @@ func (_c *Collection_CreateEncryptedIndex_Call) RunAndReturn(run func(context1 c
 }
 
 // CreateIndex provides a mock function for the type Collection
-func (_mock *Collection) CreateIndex(context1 context.Context, indexCreateRequest client.IndexCreateRequest, vs ...options.Lister[options.CollectionCreateIndexOptions]) (client.IndexDescription, error) {
+func (_mock *Collection) CreateIndex(context1 context.Context, indexCreateRequest client.IndexCreateRequest, vs ...options.Enumerable[options.CollectionCreateIndexOptions]) (client.IndexDescription, error) {
 	var tmpRet mock.Arguments
 	if len(vs) > 0 {
 		tmpRet = _mock.Called(context1, indexCreateRequest, vs)
@@ -237,15 +237,15 @@ func (_mock *Collection) CreateIndex(context1 context.Context, indexCreateReques
 
 	var r0 client.IndexDescription
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, client.IndexCreateRequest, ...options.Lister[options.CollectionCreateIndexOptions]) (client.IndexDescription, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, client.IndexCreateRequest, ...options.Enumerable[options.CollectionCreateIndexOptions]) (client.IndexDescription, error)); ok {
 		return returnFunc(context1, indexCreateRequest, vs...)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, client.IndexCreateRequest, ...options.Lister[options.CollectionCreateIndexOptions]) client.IndexDescription); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, client.IndexCreateRequest, ...options.Enumerable[options.CollectionCreateIndexOptions]) client.IndexDescription); ok {
 		r0 = returnFunc(context1, indexCreateRequest, vs...)
 	} else {
 		r0 = ret.Get(0).(client.IndexDescription)
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, client.IndexCreateRequest, ...options.Lister[options.CollectionCreateIndexOptions]) error); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, client.IndexCreateRequest, ...options.Enumerable[options.CollectionCreateIndexOptions]) error); ok {
 		r1 = returnFunc(context1, indexCreateRequest, vs...)
 	} else {
 		r1 = ret.Error(1)
@@ -267,7 +267,7 @@ func (_e *Collection_Expecter) CreateIndex(context1 interface{}, indexCreateRequ
 		append([]interface{}{context1, indexCreateRequest}, vs...)...)}
 }
 
-func (_c *Collection_CreateIndex_Call) Run(run func(context1 context.Context, indexCreateRequest client.IndexCreateRequest, vs ...options.Lister[options.CollectionCreateIndexOptions])) *Collection_CreateIndex_Call {
+func (_c *Collection_CreateIndex_Call) Run(run func(context1 context.Context, indexCreateRequest client.IndexCreateRequest, vs ...options.Enumerable[options.CollectionCreateIndexOptions])) *Collection_CreateIndex_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -277,10 +277,10 @@ func (_c *Collection_CreateIndex_Call) Run(run func(context1 context.Context, in
 		if args[1] != nil {
 			arg1 = args[1].(client.IndexCreateRequest)
 		}
-		var arg2 []options.Lister[options.CollectionCreateIndexOptions]
-		var variadicArgs []options.Lister[options.CollectionCreateIndexOptions]
+		var arg2 []options.Enumerable[options.CollectionCreateIndexOptions]
+		var variadicArgs []options.Enumerable[options.CollectionCreateIndexOptions]
 		if len(args) > 2 {
-			variadicArgs = args[2].([]options.Lister[options.CollectionCreateIndexOptions])
+			variadicArgs = args[2].([]options.Enumerable[options.CollectionCreateIndexOptions])
 		}
 		arg2 = variadicArgs
 		run(
@@ -297,13 +297,13 @@ func (_c *Collection_CreateIndex_Call) Return(indexDescription client.IndexDescr
 	return _c
 }
 
-func (_c *Collection_CreateIndex_Call) RunAndReturn(run func(context1 context.Context, indexCreateRequest client.IndexCreateRequest, vs ...options.Lister[options.CollectionCreateIndexOptions]) (client.IndexDescription, error)) *Collection_CreateIndex_Call {
+func (_c *Collection_CreateIndex_Call) RunAndReturn(run func(context1 context.Context, indexCreateRequest client.IndexCreateRequest, vs ...options.Enumerable[options.CollectionCreateIndexOptions]) (client.IndexDescription, error)) *Collection_CreateIndex_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // CreateMany provides a mock function for the type Collection
-func (_mock *Collection) CreateMany(ctx context.Context, docs []*client.Document, opts ...options.Lister[options.CollectionCreateOptions]) error {
+func (_mock *Collection) CreateMany(ctx context.Context, docs []*client.Document, opts ...options.Enumerable[options.CollectionCreateOptions]) error {
 	var tmpRet mock.Arguments
 	if len(opts) > 0 {
 		tmpRet = _mock.Called(ctx, docs, opts)
@@ -317,7 +317,7 @@ func (_mock *Collection) CreateMany(ctx context.Context, docs []*client.Document
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, []*client.Document, ...options.Lister[options.CollectionCreateOptions]) error); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []*client.Document, ...options.Enumerable[options.CollectionCreateOptions]) error); ok {
 		r0 = returnFunc(ctx, docs, opts...)
 	} else {
 		r0 = ret.Error(0)
@@ -339,7 +339,7 @@ func (_e *Collection_Expecter) CreateMany(ctx interface{}, docs interface{}, opt
 		append([]interface{}{ctx, docs}, opts...)...)}
 }
 
-func (_c *Collection_CreateMany_Call) Run(run func(ctx context.Context, docs []*client.Document, opts ...options.Lister[options.CollectionCreateOptions])) *Collection_CreateMany_Call {
+func (_c *Collection_CreateMany_Call) Run(run func(ctx context.Context, docs []*client.Document, opts ...options.Enumerable[options.CollectionCreateOptions])) *Collection_CreateMany_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -349,10 +349,10 @@ func (_c *Collection_CreateMany_Call) Run(run func(ctx context.Context, docs []*
 		if args[1] != nil {
 			arg1 = args[1].([]*client.Document)
 		}
-		var arg2 []options.Lister[options.CollectionCreateOptions]
-		var variadicArgs []options.Lister[options.CollectionCreateOptions]
+		var arg2 []options.Enumerable[options.CollectionCreateOptions]
+		var variadicArgs []options.Enumerable[options.CollectionCreateOptions]
 		if len(args) > 2 {
-			variadicArgs = args[2].([]options.Lister[options.CollectionCreateOptions])
+			variadicArgs = args[2].([]options.Enumerable[options.CollectionCreateOptions])
 		}
 		arg2 = variadicArgs
 		run(
@@ -369,13 +369,13 @@ func (_c *Collection_CreateMany_Call) Return(err error) *Collection_CreateMany_C
 	return _c
 }
 
-func (_c *Collection_CreateMany_Call) RunAndReturn(run func(ctx context.Context, docs []*client.Document, opts ...options.Lister[options.CollectionCreateOptions]) error) *Collection_CreateMany_Call {
+func (_c *Collection_CreateMany_Call) RunAndReturn(run func(ctx context.Context, docs []*client.Document, opts ...options.Enumerable[options.CollectionCreateOptions]) error) *Collection_CreateMany_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // Delete provides a mock function for the type Collection
-func (_mock *Collection) Delete(ctx context.Context, docID client.DocID, opts ...options.Lister[options.CollectionDeleteOptions]) (bool, error) {
+func (_mock *Collection) Delete(ctx context.Context, docID client.DocID, opts ...options.Enumerable[options.CollectionDeleteOptions]) (bool, error) {
 	var tmpRet mock.Arguments
 	if len(opts) > 0 {
 		tmpRet = _mock.Called(ctx, docID, opts)
@@ -390,15 +390,15 @@ func (_mock *Collection) Delete(ctx context.Context, docID client.DocID, opts ..
 
 	var r0 bool
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, client.DocID, ...options.Lister[options.CollectionDeleteOptions]) (bool, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, client.DocID, ...options.Enumerable[options.CollectionDeleteOptions]) (bool, error)); ok {
 		return returnFunc(ctx, docID, opts...)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, client.DocID, ...options.Lister[options.CollectionDeleteOptions]) bool); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, client.DocID, ...options.Enumerable[options.CollectionDeleteOptions]) bool); ok {
 		r0 = returnFunc(ctx, docID, opts...)
 	} else {
 		r0 = ret.Get(0).(bool)
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, client.DocID, ...options.Lister[options.CollectionDeleteOptions]) error); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, client.DocID, ...options.Enumerable[options.CollectionDeleteOptions]) error); ok {
 		r1 = returnFunc(ctx, docID, opts...)
 	} else {
 		r1 = ret.Error(1)
@@ -420,7 +420,7 @@ func (_e *Collection_Expecter) Delete(ctx interface{}, docID interface{}, opts .
 		append([]interface{}{ctx, docID}, opts...)...)}
 }
 
-func (_c *Collection_Delete_Call) Run(run func(ctx context.Context, docID client.DocID, opts ...options.Lister[options.CollectionDeleteOptions])) *Collection_Delete_Call {
+func (_c *Collection_Delete_Call) Run(run func(ctx context.Context, docID client.DocID, opts ...options.Enumerable[options.CollectionDeleteOptions])) *Collection_Delete_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -430,10 +430,10 @@ func (_c *Collection_Delete_Call) Run(run func(ctx context.Context, docID client
 		if args[1] != nil {
 			arg1 = args[1].(client.DocID)
 		}
-		var arg2 []options.Lister[options.CollectionDeleteOptions]
-		var variadicArgs []options.Lister[options.CollectionDeleteOptions]
+		var arg2 []options.Enumerable[options.CollectionDeleteOptions]
+		var variadicArgs []options.Enumerable[options.CollectionDeleteOptions]
 		if len(args) > 2 {
-			variadicArgs = args[2].([]options.Lister[options.CollectionDeleteOptions])
+			variadicArgs = args[2].([]options.Enumerable[options.CollectionDeleteOptions])
 		}
 		arg2 = variadicArgs
 		run(
@@ -450,7 +450,7 @@ func (_c *Collection_Delete_Call) Return(b bool, err error) *Collection_Delete_C
 	return _c
 }
 
-func (_c *Collection_Delete_Call) RunAndReturn(run func(ctx context.Context, docID client.DocID, opts ...options.Lister[options.CollectionDeleteOptions]) (bool, error)) *Collection_Delete_Call {
+func (_c *Collection_Delete_Call) RunAndReturn(run func(ctx context.Context, docID client.DocID, opts ...options.Enumerable[options.CollectionDeleteOptions]) (bool, error)) *Collection_Delete_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -513,7 +513,7 @@ func (_c *Collection_DeleteEncryptedIndex_Call) RunAndReturn(run func(ctx contex
 }
 
 // DeleteWithFilter provides a mock function for the type Collection
-func (_mock *Collection) DeleteWithFilter(ctx context.Context, filter any, opts ...options.Lister[options.CollectionDeleteWithFilterOptions]) (*client.DeleteResult, error) {
+func (_mock *Collection) DeleteWithFilter(ctx context.Context, filter any, opts ...options.Enumerable[options.CollectionDeleteWithFilterOptions]) (*client.DeleteResult, error) {
 	var tmpRet mock.Arguments
 	if len(opts) > 0 {
 		tmpRet = _mock.Called(ctx, filter, opts)
@@ -528,17 +528,17 @@ func (_mock *Collection) DeleteWithFilter(ctx context.Context, filter any, opts 
 
 	var r0 *client.DeleteResult
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, any, ...options.Lister[options.CollectionDeleteWithFilterOptions]) (*client.DeleteResult, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, any, ...options.Enumerable[options.CollectionDeleteWithFilterOptions]) (*client.DeleteResult, error)); ok {
 		return returnFunc(ctx, filter, opts...)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, any, ...options.Lister[options.CollectionDeleteWithFilterOptions]) *client.DeleteResult); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, any, ...options.Enumerable[options.CollectionDeleteWithFilterOptions]) *client.DeleteResult); ok {
 		r0 = returnFunc(ctx, filter, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*client.DeleteResult)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, any, ...options.Lister[options.CollectionDeleteWithFilterOptions]) error); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, any, ...options.Enumerable[options.CollectionDeleteWithFilterOptions]) error); ok {
 		r1 = returnFunc(ctx, filter, opts...)
 	} else {
 		r1 = ret.Error(1)
@@ -560,7 +560,7 @@ func (_e *Collection_Expecter) DeleteWithFilter(ctx interface{}, filter interfac
 		append([]interface{}{ctx, filter}, opts...)...)}
 }
 
-func (_c *Collection_DeleteWithFilter_Call) Run(run func(ctx context.Context, filter any, opts ...options.Lister[options.CollectionDeleteWithFilterOptions])) *Collection_DeleteWithFilter_Call {
+func (_c *Collection_DeleteWithFilter_Call) Run(run func(ctx context.Context, filter any, opts ...options.Enumerable[options.CollectionDeleteWithFilterOptions])) *Collection_DeleteWithFilter_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -570,10 +570,10 @@ func (_c *Collection_DeleteWithFilter_Call) Run(run func(ctx context.Context, fi
 		if args[1] != nil {
 			arg1 = args[1].(any)
 		}
-		var arg2 []options.Lister[options.CollectionDeleteWithFilterOptions]
-		var variadicArgs []options.Lister[options.CollectionDeleteWithFilterOptions]
+		var arg2 []options.Enumerable[options.CollectionDeleteWithFilterOptions]
+		var variadicArgs []options.Enumerable[options.CollectionDeleteWithFilterOptions]
 		if len(args) > 2 {
-			variadicArgs = args[2].([]options.Lister[options.CollectionDeleteWithFilterOptions])
+			variadicArgs = args[2].([]options.Enumerable[options.CollectionDeleteWithFilterOptions])
 		}
 		arg2 = variadicArgs
 		run(
@@ -590,13 +590,13 @@ func (_c *Collection_DeleteWithFilter_Call) Return(deleteResult *client.DeleteRe
 	return _c
 }
 
-func (_c *Collection_DeleteWithFilter_Call) RunAndReturn(run func(ctx context.Context, filter any, opts ...options.Lister[options.CollectionDeleteWithFilterOptions]) (*client.DeleteResult, error)) *Collection_DeleteWithFilter_Call {
+func (_c *Collection_DeleteWithFilter_Call) RunAndReturn(run func(ctx context.Context, filter any, opts ...options.Enumerable[options.CollectionDeleteWithFilterOptions]) (*client.DeleteResult, error)) *Collection_DeleteWithFilter_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // DropIndex provides a mock function for the type Collection
-func (_mock *Collection) DropIndex(ctx context.Context, indexName string, opts ...options.Lister[options.CollectionDropIndexOptions]) error {
+func (_mock *Collection) DropIndex(ctx context.Context, indexName string, opts ...options.Enumerable[options.CollectionDropIndexOptions]) error {
 	var tmpRet mock.Arguments
 	if len(opts) > 0 {
 		tmpRet = _mock.Called(ctx, indexName, opts)
@@ -610,7 +610,7 @@ func (_mock *Collection) DropIndex(ctx context.Context, indexName string, opts .
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, ...options.Lister[options.CollectionDropIndexOptions]) error); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, ...options.Enumerable[options.CollectionDropIndexOptions]) error); ok {
 		r0 = returnFunc(ctx, indexName, opts...)
 	} else {
 		r0 = ret.Error(0)
@@ -632,7 +632,7 @@ func (_e *Collection_Expecter) DropIndex(ctx interface{}, indexName interface{},
 		append([]interface{}{ctx, indexName}, opts...)...)}
 }
 
-func (_c *Collection_DropIndex_Call) Run(run func(ctx context.Context, indexName string, opts ...options.Lister[options.CollectionDropIndexOptions])) *Collection_DropIndex_Call {
+func (_c *Collection_DropIndex_Call) Run(run func(ctx context.Context, indexName string, opts ...options.Enumerable[options.CollectionDropIndexOptions])) *Collection_DropIndex_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -642,10 +642,10 @@ func (_c *Collection_DropIndex_Call) Run(run func(ctx context.Context, indexName
 		if args[1] != nil {
 			arg1 = args[1].(string)
 		}
-		var arg2 []options.Lister[options.CollectionDropIndexOptions]
-		var variadicArgs []options.Lister[options.CollectionDropIndexOptions]
+		var arg2 []options.Enumerable[options.CollectionDropIndexOptions]
+		var variadicArgs []options.Enumerable[options.CollectionDropIndexOptions]
 		if len(args) > 2 {
-			variadicArgs = args[2].([]options.Lister[options.CollectionDropIndexOptions])
+			variadicArgs = args[2].([]options.Enumerable[options.CollectionDropIndexOptions])
 		}
 		arg2 = variadicArgs
 		run(
@@ -662,13 +662,13 @@ func (_c *Collection_DropIndex_Call) Return(err error) *Collection_DropIndex_Cal
 	return _c
 }
 
-func (_c *Collection_DropIndex_Call) RunAndReturn(run func(ctx context.Context, indexName string, opts ...options.Lister[options.CollectionDropIndexOptions]) error) *Collection_DropIndex_Call {
+func (_c *Collection_DropIndex_Call) RunAndReturn(run func(ctx context.Context, indexName string, opts ...options.Enumerable[options.CollectionDropIndexOptions]) error) *Collection_DropIndex_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // Exists provides a mock function for the type Collection
-func (_mock *Collection) Exists(ctx context.Context, docID client.DocID, opts ...options.Lister[options.CollectionExistsOptions]) (bool, error) {
+func (_mock *Collection) Exists(ctx context.Context, docID client.DocID, opts ...options.Enumerable[options.CollectionExistsOptions]) (bool, error) {
 	var tmpRet mock.Arguments
 	if len(opts) > 0 {
 		tmpRet = _mock.Called(ctx, docID, opts)
@@ -683,15 +683,15 @@ func (_mock *Collection) Exists(ctx context.Context, docID client.DocID, opts ..
 
 	var r0 bool
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, client.DocID, ...options.Lister[options.CollectionExistsOptions]) (bool, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, client.DocID, ...options.Enumerable[options.CollectionExistsOptions]) (bool, error)); ok {
 		return returnFunc(ctx, docID, opts...)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, client.DocID, ...options.Lister[options.CollectionExistsOptions]) bool); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, client.DocID, ...options.Enumerable[options.CollectionExistsOptions]) bool); ok {
 		r0 = returnFunc(ctx, docID, opts...)
 	} else {
 		r0 = ret.Get(0).(bool)
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, client.DocID, ...options.Lister[options.CollectionExistsOptions]) error); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, client.DocID, ...options.Enumerable[options.CollectionExistsOptions]) error); ok {
 		r1 = returnFunc(ctx, docID, opts...)
 	} else {
 		r1 = ret.Error(1)
@@ -713,7 +713,7 @@ func (_e *Collection_Expecter) Exists(ctx interface{}, docID interface{}, opts .
 		append([]interface{}{ctx, docID}, opts...)...)}
 }
 
-func (_c *Collection_Exists_Call) Run(run func(ctx context.Context, docID client.DocID, opts ...options.Lister[options.CollectionExistsOptions])) *Collection_Exists_Call {
+func (_c *Collection_Exists_Call) Run(run func(ctx context.Context, docID client.DocID, opts ...options.Enumerable[options.CollectionExistsOptions])) *Collection_Exists_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -723,10 +723,10 @@ func (_c *Collection_Exists_Call) Run(run func(ctx context.Context, docID client
 		if args[1] != nil {
 			arg1 = args[1].(client.DocID)
 		}
-		var arg2 []options.Lister[options.CollectionExistsOptions]
-		var variadicArgs []options.Lister[options.CollectionExistsOptions]
+		var arg2 []options.Enumerable[options.CollectionExistsOptions]
+		var variadicArgs []options.Enumerable[options.CollectionExistsOptions]
 		if len(args) > 2 {
-			variadicArgs = args[2].([]options.Lister[options.CollectionExistsOptions])
+			variadicArgs = args[2].([]options.Enumerable[options.CollectionExistsOptions])
 		}
 		arg2 = variadicArgs
 		run(
@@ -743,13 +743,13 @@ func (_c *Collection_Exists_Call) Return(b bool, err error) *Collection_Exists_C
 	return _c
 }
 
-func (_c *Collection_Exists_Call) RunAndReturn(run func(ctx context.Context, docID client.DocID, opts ...options.Lister[options.CollectionExistsOptions]) (bool, error)) *Collection_Exists_Call {
+func (_c *Collection_Exists_Call) RunAndReturn(run func(ctx context.Context, docID client.DocID, opts ...options.Enumerable[options.CollectionExistsOptions]) (bool, error)) *Collection_Exists_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // Get provides a mock function for the type Collection
-func (_mock *Collection) Get(ctx context.Context, docID client.DocID, opts ...options.Lister[options.CollectionGetOptions]) (*client.Document, error) {
+func (_mock *Collection) Get(ctx context.Context, docID client.DocID, opts ...options.Enumerable[options.CollectionGetOptions]) (*client.Document, error) {
 	var tmpRet mock.Arguments
 	if len(opts) > 0 {
 		tmpRet = _mock.Called(ctx, docID, opts)
@@ -764,17 +764,17 @@ func (_mock *Collection) Get(ctx context.Context, docID client.DocID, opts ...op
 
 	var r0 *client.Document
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, client.DocID, ...options.Lister[options.CollectionGetOptions]) (*client.Document, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, client.DocID, ...options.Enumerable[options.CollectionGetOptions]) (*client.Document, error)); ok {
 		return returnFunc(ctx, docID, opts...)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, client.DocID, ...options.Lister[options.CollectionGetOptions]) *client.Document); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, client.DocID, ...options.Enumerable[options.CollectionGetOptions]) *client.Document); ok {
 		r0 = returnFunc(ctx, docID, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*client.Document)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, client.DocID, ...options.Lister[options.CollectionGetOptions]) error); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, client.DocID, ...options.Enumerable[options.CollectionGetOptions]) error); ok {
 		r1 = returnFunc(ctx, docID, opts...)
 	} else {
 		r1 = ret.Error(1)
@@ -796,7 +796,7 @@ func (_e *Collection_Expecter) Get(ctx interface{}, docID interface{}, opts ...i
 		append([]interface{}{ctx, docID}, opts...)...)}
 }
 
-func (_c *Collection_Get_Call) Run(run func(ctx context.Context, docID client.DocID, opts ...options.Lister[options.CollectionGetOptions])) *Collection_Get_Call {
+func (_c *Collection_Get_Call) Run(run func(ctx context.Context, docID client.DocID, opts ...options.Enumerable[options.CollectionGetOptions])) *Collection_Get_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -806,10 +806,10 @@ func (_c *Collection_Get_Call) Run(run func(ctx context.Context, docID client.Do
 		if args[1] != nil {
 			arg1 = args[1].(client.DocID)
 		}
-		var arg2 []options.Lister[options.CollectionGetOptions]
-		var variadicArgs []options.Lister[options.CollectionGetOptions]
+		var arg2 []options.Enumerable[options.CollectionGetOptions]
+		var variadicArgs []options.Enumerable[options.CollectionGetOptions]
 		if len(args) > 2 {
-			variadicArgs = args[2].([]options.Lister[options.CollectionGetOptions])
+			variadicArgs = args[2].([]options.Enumerable[options.CollectionGetOptions])
 		}
 		arg2 = variadicArgs
 		run(
@@ -826,13 +826,13 @@ func (_c *Collection_Get_Call) Return(document *client.Document, err error) *Col
 	return _c
 }
 
-func (_c *Collection_Get_Call) RunAndReturn(run func(ctx context.Context, docID client.DocID, opts ...options.Lister[options.CollectionGetOptions]) (*client.Document, error)) *Collection_Get_Call {
+func (_c *Collection_Get_Call) RunAndReturn(run func(ctx context.Context, docID client.DocID, opts ...options.Enumerable[options.CollectionGetOptions]) (*client.Document, error)) *Collection_Get_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetAllDocIDs provides a mock function for the type Collection
-func (_mock *Collection) GetAllDocIDs(ctx context.Context, opts ...options.Lister[options.CollectionGetAllDocIDsOptions]) (<-chan client.DocIDResult, error) {
+func (_mock *Collection) GetAllDocIDs(ctx context.Context, opts ...options.Enumerable[options.CollectionGetAllDocIDsOptions]) (<-chan client.DocIDResult, error) {
 	var tmpRet mock.Arguments
 	if len(opts) > 0 {
 		tmpRet = _mock.Called(ctx, opts)
@@ -847,17 +847,17 @@ func (_mock *Collection) GetAllDocIDs(ctx context.Context, opts ...options.Liste
 
 	var r0 <-chan client.DocIDResult
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, ...options.Lister[options.CollectionGetAllDocIDsOptions]) (<-chan client.DocIDResult, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, ...options.Enumerable[options.CollectionGetAllDocIDsOptions]) (<-chan client.DocIDResult, error)); ok {
 		return returnFunc(ctx, opts...)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, ...options.Lister[options.CollectionGetAllDocIDsOptions]) <-chan client.DocIDResult); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, ...options.Enumerable[options.CollectionGetAllDocIDsOptions]) <-chan client.DocIDResult); ok {
 		r0 = returnFunc(ctx, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(<-chan client.DocIDResult)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, ...options.Lister[options.CollectionGetAllDocIDsOptions]) error); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, ...options.Enumerable[options.CollectionGetAllDocIDsOptions]) error); ok {
 		r1 = returnFunc(ctx, opts...)
 	} else {
 		r1 = ret.Error(1)
@@ -878,16 +878,16 @@ func (_e *Collection_Expecter) GetAllDocIDs(ctx interface{}, opts ...interface{}
 		append([]interface{}{ctx}, opts...)...)}
 }
 
-func (_c *Collection_GetAllDocIDs_Call) Run(run func(ctx context.Context, opts ...options.Lister[options.CollectionGetAllDocIDsOptions])) *Collection_GetAllDocIDs_Call {
+func (_c *Collection_GetAllDocIDs_Call) Run(run func(ctx context.Context, opts ...options.Enumerable[options.CollectionGetAllDocIDsOptions])) *Collection_GetAllDocIDs_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
 			arg0 = args[0].(context.Context)
 		}
-		var arg1 []options.Lister[options.CollectionGetAllDocIDsOptions]
-		var variadicArgs []options.Lister[options.CollectionGetAllDocIDsOptions]
+		var arg1 []options.Enumerable[options.CollectionGetAllDocIDsOptions]
+		var variadicArgs []options.Enumerable[options.CollectionGetAllDocIDsOptions]
 		if len(args) > 1 {
-			variadicArgs = args[1].([]options.Lister[options.CollectionGetAllDocIDsOptions])
+			variadicArgs = args[1].([]options.Enumerable[options.CollectionGetAllDocIDsOptions])
 		}
 		arg1 = variadicArgs
 		run(
@@ -903,13 +903,13 @@ func (_c *Collection_GetAllDocIDs_Call) Return(docIDResultCh <-chan client.DocID
 	return _c
 }
 
-func (_c *Collection_GetAllDocIDs_Call) RunAndReturn(run func(ctx context.Context, opts ...options.Lister[options.CollectionGetAllDocIDsOptions]) (<-chan client.DocIDResult, error)) *Collection_GetAllDocIDs_Call {
+func (_c *Collection_GetAllDocIDs_Call) RunAndReturn(run func(ctx context.Context, opts ...options.Enumerable[options.CollectionGetAllDocIDsOptions]) (<-chan client.DocIDResult, error)) *Collection_GetAllDocIDs_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetIndexes provides a mock function for the type Collection
-func (_mock *Collection) GetIndexes(ctx context.Context, opts ...options.Lister[options.CollectionGetIndexesOptions]) ([]client.IndexDescription, error) {
+func (_mock *Collection) GetIndexes(ctx context.Context, opts ...options.Enumerable[options.CollectionGetIndexesOptions]) ([]client.IndexDescription, error) {
 	var tmpRet mock.Arguments
 	if len(opts) > 0 {
 		tmpRet = _mock.Called(ctx, opts)
@@ -924,17 +924,17 @@ func (_mock *Collection) GetIndexes(ctx context.Context, opts ...options.Lister[
 
 	var r0 []client.IndexDescription
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, ...options.Lister[options.CollectionGetIndexesOptions]) ([]client.IndexDescription, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, ...options.Enumerable[options.CollectionGetIndexesOptions]) ([]client.IndexDescription, error)); ok {
 		return returnFunc(ctx, opts...)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, ...options.Lister[options.CollectionGetIndexesOptions]) []client.IndexDescription); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, ...options.Enumerable[options.CollectionGetIndexesOptions]) []client.IndexDescription); ok {
 		r0 = returnFunc(ctx, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]client.IndexDescription)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, ...options.Lister[options.CollectionGetIndexesOptions]) error); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, ...options.Enumerable[options.CollectionGetIndexesOptions]) error); ok {
 		r1 = returnFunc(ctx, opts...)
 	} else {
 		r1 = ret.Error(1)
@@ -955,16 +955,16 @@ func (_e *Collection_Expecter) GetIndexes(ctx interface{}, opts ...interface{}) 
 		append([]interface{}{ctx}, opts...)...)}
 }
 
-func (_c *Collection_GetIndexes_Call) Run(run func(ctx context.Context, opts ...options.Lister[options.CollectionGetIndexesOptions])) *Collection_GetIndexes_Call {
+func (_c *Collection_GetIndexes_Call) Run(run func(ctx context.Context, opts ...options.Enumerable[options.CollectionGetIndexesOptions])) *Collection_GetIndexes_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
 			arg0 = args[0].(context.Context)
 		}
-		var arg1 []options.Lister[options.CollectionGetIndexesOptions]
-		var variadicArgs []options.Lister[options.CollectionGetIndexesOptions]
+		var arg1 []options.Enumerable[options.CollectionGetIndexesOptions]
+		var variadicArgs []options.Enumerable[options.CollectionGetIndexesOptions]
 		if len(args) > 1 {
-			variadicArgs = args[1].([]options.Lister[options.CollectionGetIndexesOptions])
+			variadicArgs = args[1].([]options.Enumerable[options.CollectionGetIndexesOptions])
 		}
 		arg1 = variadicArgs
 		run(
@@ -980,7 +980,7 @@ func (_c *Collection_GetIndexes_Call) Return(indexDescriptions []client.IndexDes
 	return _c
 }
 
-func (_c *Collection_GetIndexes_Call) RunAndReturn(run func(ctx context.Context, opts ...options.Lister[options.CollectionGetIndexesOptions]) ([]client.IndexDescription, error)) *Collection_GetIndexes_Call {
+func (_c *Collection_GetIndexes_Call) RunAndReturn(run func(ctx context.Context, opts ...options.Enumerable[options.CollectionGetIndexesOptions]) ([]client.IndexDescription, error)) *Collection_GetIndexes_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -1092,7 +1092,7 @@ func (_c *Collection_Name_Call) RunAndReturn(run func() string) *Collection_Name
 }
 
 // Save provides a mock function for the type Collection
-func (_mock *Collection) Save(ctx context.Context, doc *client.Document, opts ...options.Lister[options.CollectionSaveOptions]) error {
+func (_mock *Collection) Save(ctx context.Context, doc *client.Document, opts ...options.Enumerable[options.CollectionSaveOptions]) error {
 	var tmpRet mock.Arguments
 	if len(opts) > 0 {
 		tmpRet = _mock.Called(ctx, doc, opts)
@@ -1106,7 +1106,7 @@ func (_mock *Collection) Save(ctx context.Context, doc *client.Document, opts ..
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, *client.Document, ...options.Lister[options.CollectionSaveOptions]) error); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *client.Document, ...options.Enumerable[options.CollectionSaveOptions]) error); ok {
 		r0 = returnFunc(ctx, doc, opts...)
 	} else {
 		r0 = ret.Error(0)
@@ -1128,7 +1128,7 @@ func (_e *Collection_Expecter) Save(ctx interface{}, doc interface{}, opts ...in
 		append([]interface{}{ctx, doc}, opts...)...)}
 }
 
-func (_c *Collection_Save_Call) Run(run func(ctx context.Context, doc *client.Document, opts ...options.Lister[options.CollectionSaveOptions])) *Collection_Save_Call {
+func (_c *Collection_Save_Call) Run(run func(ctx context.Context, doc *client.Document, opts ...options.Enumerable[options.CollectionSaveOptions])) *Collection_Save_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -1138,10 +1138,10 @@ func (_c *Collection_Save_Call) Run(run func(ctx context.Context, doc *client.Do
 		if args[1] != nil {
 			arg1 = args[1].(*client.Document)
 		}
-		var arg2 []options.Lister[options.CollectionSaveOptions]
-		var variadicArgs []options.Lister[options.CollectionSaveOptions]
+		var arg2 []options.Enumerable[options.CollectionSaveOptions]
+		var variadicArgs []options.Enumerable[options.CollectionSaveOptions]
 		if len(args) > 2 {
-			variadicArgs = args[2].([]options.Lister[options.CollectionSaveOptions])
+			variadicArgs = args[2].([]options.Enumerable[options.CollectionSaveOptions])
 		}
 		arg2 = variadicArgs
 		run(
@@ -1158,13 +1158,13 @@ func (_c *Collection_Save_Call) Return(err error) *Collection_Save_Call {
 	return _c
 }
 
-func (_c *Collection_Save_Call) RunAndReturn(run func(ctx context.Context, doc *client.Document, opts ...options.Lister[options.CollectionSaveOptions]) error) *Collection_Save_Call {
+func (_c *Collection_Save_Call) RunAndReturn(run func(ctx context.Context, doc *client.Document, opts ...options.Enumerable[options.CollectionSaveOptions]) error) *Collection_Save_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // Truncate provides a mock function for the type Collection
-func (_mock *Collection) Truncate(ctx context.Context, opts ...options.Lister[options.CollectionTruncateOptions]) error {
+func (_mock *Collection) Truncate(ctx context.Context, opts ...options.Enumerable[options.CollectionTruncateOptions]) error {
 	var tmpRet mock.Arguments
 	if len(opts) > 0 {
 		tmpRet = _mock.Called(ctx, opts)
@@ -1178,7 +1178,7 @@ func (_mock *Collection) Truncate(ctx context.Context, opts ...options.Lister[op
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, ...options.Lister[options.CollectionTruncateOptions]) error); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, ...options.Enumerable[options.CollectionTruncateOptions]) error); ok {
 		r0 = returnFunc(ctx, opts...)
 	} else {
 		r0 = ret.Error(0)
@@ -1199,16 +1199,16 @@ func (_e *Collection_Expecter) Truncate(ctx interface{}, opts ...interface{}) *C
 		append([]interface{}{ctx}, opts...)...)}
 }
 
-func (_c *Collection_Truncate_Call) Run(run func(ctx context.Context, opts ...options.Lister[options.CollectionTruncateOptions])) *Collection_Truncate_Call {
+func (_c *Collection_Truncate_Call) Run(run func(ctx context.Context, opts ...options.Enumerable[options.CollectionTruncateOptions])) *Collection_Truncate_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
 			arg0 = args[0].(context.Context)
 		}
-		var arg1 []options.Lister[options.CollectionTruncateOptions]
-		var variadicArgs []options.Lister[options.CollectionTruncateOptions]
+		var arg1 []options.Enumerable[options.CollectionTruncateOptions]
+		var variadicArgs []options.Enumerable[options.CollectionTruncateOptions]
 		if len(args) > 1 {
-			variadicArgs = args[1].([]options.Lister[options.CollectionTruncateOptions])
+			variadicArgs = args[1].([]options.Enumerable[options.CollectionTruncateOptions])
 		}
 		arg1 = variadicArgs
 		run(
@@ -1224,13 +1224,13 @@ func (_c *Collection_Truncate_Call) Return(err error) *Collection_Truncate_Call 
 	return _c
 }
 
-func (_c *Collection_Truncate_Call) RunAndReturn(run func(ctx context.Context, opts ...options.Lister[options.CollectionTruncateOptions]) error) *Collection_Truncate_Call {
+func (_c *Collection_Truncate_Call) RunAndReturn(run func(ctx context.Context, opts ...options.Enumerable[options.CollectionTruncateOptions]) error) *Collection_Truncate_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // Update provides a mock function for the type Collection
-func (_mock *Collection) Update(ctx context.Context, docs *client.Document, opts ...options.Lister[options.CollectionUpdateOptions]) error {
+func (_mock *Collection) Update(ctx context.Context, docs *client.Document, opts ...options.Enumerable[options.CollectionUpdateOptions]) error {
 	var tmpRet mock.Arguments
 	if len(opts) > 0 {
 		tmpRet = _mock.Called(ctx, docs, opts)
@@ -1244,7 +1244,7 @@ func (_mock *Collection) Update(ctx context.Context, docs *client.Document, opts
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, *client.Document, ...options.Lister[options.CollectionUpdateOptions]) error); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *client.Document, ...options.Enumerable[options.CollectionUpdateOptions]) error); ok {
 		r0 = returnFunc(ctx, docs, opts...)
 	} else {
 		r0 = ret.Error(0)
@@ -1266,7 +1266,7 @@ func (_e *Collection_Expecter) Update(ctx interface{}, docs interface{}, opts ..
 		append([]interface{}{ctx, docs}, opts...)...)}
 }
 
-func (_c *Collection_Update_Call) Run(run func(ctx context.Context, docs *client.Document, opts ...options.Lister[options.CollectionUpdateOptions])) *Collection_Update_Call {
+func (_c *Collection_Update_Call) Run(run func(ctx context.Context, docs *client.Document, opts ...options.Enumerable[options.CollectionUpdateOptions])) *Collection_Update_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -1276,10 +1276,10 @@ func (_c *Collection_Update_Call) Run(run func(ctx context.Context, docs *client
 		if args[1] != nil {
 			arg1 = args[1].(*client.Document)
 		}
-		var arg2 []options.Lister[options.CollectionUpdateOptions]
-		var variadicArgs []options.Lister[options.CollectionUpdateOptions]
+		var arg2 []options.Enumerable[options.CollectionUpdateOptions]
+		var variadicArgs []options.Enumerable[options.CollectionUpdateOptions]
 		if len(args) > 2 {
-			variadicArgs = args[2].([]options.Lister[options.CollectionUpdateOptions])
+			variadicArgs = args[2].([]options.Enumerable[options.CollectionUpdateOptions])
 		}
 		arg2 = variadicArgs
 		run(
@@ -1296,13 +1296,13 @@ func (_c *Collection_Update_Call) Return(err error) *Collection_Update_Call {
 	return _c
 }
 
-func (_c *Collection_Update_Call) RunAndReturn(run func(ctx context.Context, docs *client.Document, opts ...options.Lister[options.CollectionUpdateOptions]) error) *Collection_Update_Call {
+func (_c *Collection_Update_Call) RunAndReturn(run func(ctx context.Context, docs *client.Document, opts ...options.Enumerable[options.CollectionUpdateOptions]) error) *Collection_Update_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // UpdateWithFilter provides a mock function for the type Collection
-func (_mock *Collection) UpdateWithFilter(ctx context.Context, filter any, updater string, opts ...options.Lister[options.CollectionUpdateWithFilterOptions]) (*client.UpdateResult, error) {
+func (_mock *Collection) UpdateWithFilter(ctx context.Context, filter any, updater string, opts ...options.Enumerable[options.CollectionUpdateWithFilterOptions]) (*client.UpdateResult, error) {
 	var tmpRet mock.Arguments
 	if len(opts) > 0 {
 		tmpRet = _mock.Called(ctx, filter, updater, opts)
@@ -1317,17 +1317,17 @@ func (_mock *Collection) UpdateWithFilter(ctx context.Context, filter any, updat
 
 	var r0 *client.UpdateResult
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, any, string, ...options.Lister[options.CollectionUpdateWithFilterOptions]) (*client.UpdateResult, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, any, string, ...options.Enumerable[options.CollectionUpdateWithFilterOptions]) (*client.UpdateResult, error)); ok {
 		return returnFunc(ctx, filter, updater, opts...)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, any, string, ...options.Lister[options.CollectionUpdateWithFilterOptions]) *client.UpdateResult); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, any, string, ...options.Enumerable[options.CollectionUpdateWithFilterOptions]) *client.UpdateResult); ok {
 		r0 = returnFunc(ctx, filter, updater, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*client.UpdateResult)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, any, string, ...options.Lister[options.CollectionUpdateWithFilterOptions]) error); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, any, string, ...options.Enumerable[options.CollectionUpdateWithFilterOptions]) error); ok {
 		r1 = returnFunc(ctx, filter, updater, opts...)
 	} else {
 		r1 = ret.Error(1)
@@ -1350,7 +1350,7 @@ func (_e *Collection_Expecter) UpdateWithFilter(ctx interface{}, filter interfac
 		append([]interface{}{ctx, filter, updater}, opts...)...)}
 }
 
-func (_c *Collection_UpdateWithFilter_Call) Run(run func(ctx context.Context, filter any, updater string, opts ...options.Lister[options.CollectionUpdateWithFilterOptions])) *Collection_UpdateWithFilter_Call {
+func (_c *Collection_UpdateWithFilter_Call) Run(run func(ctx context.Context, filter any, updater string, opts ...options.Enumerable[options.CollectionUpdateWithFilterOptions])) *Collection_UpdateWithFilter_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -1364,10 +1364,10 @@ func (_c *Collection_UpdateWithFilter_Call) Run(run func(ctx context.Context, fi
 		if args[2] != nil {
 			arg2 = args[2].(string)
 		}
-		var arg3 []options.Lister[options.CollectionUpdateWithFilterOptions]
-		var variadicArgs []options.Lister[options.CollectionUpdateWithFilterOptions]
+		var arg3 []options.Enumerable[options.CollectionUpdateWithFilterOptions]
+		var variadicArgs []options.Enumerable[options.CollectionUpdateWithFilterOptions]
 		if len(args) > 3 {
-			variadicArgs = args[3].([]options.Lister[options.CollectionUpdateWithFilterOptions])
+			variadicArgs = args[3].([]options.Enumerable[options.CollectionUpdateWithFilterOptions])
 		}
 		arg3 = variadicArgs
 		run(
@@ -1385,7 +1385,7 @@ func (_c *Collection_UpdateWithFilter_Call) Return(updateResult *client.UpdateRe
 	return _c
 }
 
-func (_c *Collection_UpdateWithFilter_Call) RunAndReturn(run func(ctx context.Context, filter any, updater string, opts ...options.Lister[options.CollectionUpdateWithFilterOptions]) (*client.UpdateResult, error)) *Collection_UpdateWithFilter_Call {
+func (_c *Collection_UpdateWithFilter_Call) RunAndReturn(run func(ctx context.Context, filter any, updater string, opts ...options.Enumerable[options.CollectionUpdateWithFilterOptions]) (*client.UpdateResult, error)) *Collection_UpdateWithFilter_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/client/mocks/txn.go
+++ b/client/mocks/txn.go
@@ -45,7 +45,7 @@ func (_m *Txn) EXPECT() *Txn_Expecter {
 }
 
 // ActivePeers provides a mock function for the type Txn
-func (_mock *Txn) ActivePeers(ctx context.Context, opts ...options.Lister[options.ActivePeersOptions]) ([]string, error) {
+func (_mock *Txn) ActivePeers(ctx context.Context, opts ...options.Enumerable[options.ActivePeersOptions]) ([]string, error) {
 	var tmpRet mock.Arguments
 	if len(opts) > 0 {
 		tmpRet = _mock.Called(ctx, opts)
@@ -60,17 +60,17 @@ func (_mock *Txn) ActivePeers(ctx context.Context, opts ...options.Lister[option
 
 	var r0 []string
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, ...options.Lister[options.ActivePeersOptions]) ([]string, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, ...options.Enumerable[options.ActivePeersOptions]) ([]string, error)); ok {
 		return returnFunc(ctx, opts...)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, ...options.Lister[options.ActivePeersOptions]) []string); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, ...options.Enumerable[options.ActivePeersOptions]) []string); ok {
 		r0 = returnFunc(ctx, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]string)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, ...options.Lister[options.ActivePeersOptions]) error); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, ...options.Enumerable[options.ActivePeersOptions]) error); ok {
 		r1 = returnFunc(ctx, opts...)
 	} else {
 		r1 = ret.Error(1)
@@ -91,16 +91,16 @@ func (_e *Txn_Expecter) ActivePeers(ctx interface{}, opts ...interface{}) *Txn_A
 		append([]interface{}{ctx}, opts...)...)}
 }
 
-func (_c *Txn_ActivePeers_Call) Run(run func(ctx context.Context, opts ...options.Lister[options.ActivePeersOptions])) *Txn_ActivePeers_Call {
+func (_c *Txn_ActivePeers_Call) Run(run func(ctx context.Context, opts ...options.Enumerable[options.ActivePeersOptions])) *Txn_ActivePeers_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
 			arg0 = args[0].(context.Context)
 		}
-		var arg1 []options.Lister[options.ActivePeersOptions]
-		var variadicArgs []options.Lister[options.ActivePeersOptions]
+		var arg1 []options.Enumerable[options.ActivePeersOptions]
+		var variadicArgs []options.Enumerable[options.ActivePeersOptions]
 		if len(args) > 1 {
-			variadicArgs = args[1].([]options.Lister[options.ActivePeersOptions])
+			variadicArgs = args[1].([]options.Enumerable[options.ActivePeersOptions])
 		}
 		arg1 = variadicArgs
 		run(
@@ -116,13 +116,13 @@ func (_c *Txn_ActivePeers_Call) Return(strings []string, err error) *Txn_ActiveP
 	return _c
 }
 
-func (_c *Txn_ActivePeers_Call) RunAndReturn(run func(ctx context.Context, opts ...options.Lister[options.ActivePeersOptions]) ([]string, error)) *Txn_ActivePeers_Call {
+func (_c *Txn_ActivePeers_Call) RunAndReturn(run func(ctx context.Context, opts ...options.Enumerable[options.ActivePeersOptions]) ([]string, error)) *Txn_ActivePeers_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // AddDACActorRelationship provides a mock function for the type Txn
-func (_mock *Txn) AddDACActorRelationship(ctx context.Context, collectionName string, docID string, relation string, targetActor string, opts ...options.Lister[options.AddDACActorRelationshipOptions]) (client.AddActorRelationshipResult, error) {
+func (_mock *Txn) AddDACActorRelationship(ctx context.Context, collectionName string, docID string, relation string, targetActor string, opts ...options.Enumerable[options.AddDACActorRelationshipOptions]) (client.AddActorRelationshipResult, error) {
 	var tmpRet mock.Arguments
 	if len(opts) > 0 {
 		tmpRet = _mock.Called(ctx, collectionName, docID, relation, targetActor, opts)
@@ -137,15 +137,15 @@ func (_mock *Txn) AddDACActorRelationship(ctx context.Context, collectionName st
 
 	var r0 client.AddActorRelationshipResult
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string, string, ...options.Lister[options.AddDACActorRelationshipOptions]) (client.AddActorRelationshipResult, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string, string, ...options.Enumerable[options.AddDACActorRelationshipOptions]) (client.AddActorRelationshipResult, error)); ok {
 		return returnFunc(ctx, collectionName, docID, relation, targetActor, opts...)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string, string, ...options.Lister[options.AddDACActorRelationshipOptions]) client.AddActorRelationshipResult); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string, string, ...options.Enumerable[options.AddDACActorRelationshipOptions]) client.AddActorRelationshipResult); ok {
 		r0 = returnFunc(ctx, collectionName, docID, relation, targetActor, opts...)
 	} else {
 		r0 = ret.Get(0).(client.AddActorRelationshipResult)
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, string, string, ...options.Lister[options.AddDACActorRelationshipOptions]) error); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, string, string, ...options.Enumerable[options.AddDACActorRelationshipOptions]) error); ok {
 		r1 = returnFunc(ctx, collectionName, docID, relation, targetActor, opts...)
 	} else {
 		r1 = ret.Error(1)
@@ -170,7 +170,7 @@ func (_e *Txn_Expecter) AddDACActorRelationship(ctx interface{}, collectionName 
 		append([]interface{}{ctx, collectionName, docID, relation, targetActor}, opts...)...)}
 }
 
-func (_c *Txn_AddDACActorRelationship_Call) Run(run func(ctx context.Context, collectionName string, docID string, relation string, targetActor string, opts ...options.Lister[options.AddDACActorRelationshipOptions])) *Txn_AddDACActorRelationship_Call {
+func (_c *Txn_AddDACActorRelationship_Call) Run(run func(ctx context.Context, collectionName string, docID string, relation string, targetActor string, opts ...options.Enumerable[options.AddDACActorRelationshipOptions])) *Txn_AddDACActorRelationship_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -192,10 +192,10 @@ func (_c *Txn_AddDACActorRelationship_Call) Run(run func(ctx context.Context, co
 		if args[4] != nil {
 			arg4 = args[4].(string)
 		}
-		var arg5 []options.Lister[options.AddDACActorRelationshipOptions]
-		var variadicArgs []options.Lister[options.AddDACActorRelationshipOptions]
+		var arg5 []options.Enumerable[options.AddDACActorRelationshipOptions]
+		var variadicArgs []options.Enumerable[options.AddDACActorRelationshipOptions]
 		if len(args) > 5 {
-			variadicArgs = args[5].([]options.Lister[options.AddDACActorRelationshipOptions])
+			variadicArgs = args[5].([]options.Enumerable[options.AddDACActorRelationshipOptions])
 		}
 		arg5 = variadicArgs
 		run(
@@ -215,13 +215,13 @@ func (_c *Txn_AddDACActorRelationship_Call) Return(addActorRelationshipResult cl
 	return _c
 }
 
-func (_c *Txn_AddDACActorRelationship_Call) RunAndReturn(run func(ctx context.Context, collectionName string, docID string, relation string, targetActor string, opts ...options.Lister[options.AddDACActorRelationshipOptions]) (client.AddActorRelationshipResult, error)) *Txn_AddDACActorRelationship_Call {
+func (_c *Txn_AddDACActorRelationship_Call) RunAndReturn(run func(ctx context.Context, collectionName string, docID string, relation string, targetActor string, opts ...options.Enumerable[options.AddDACActorRelationshipOptions]) (client.AddActorRelationshipResult, error)) *Txn_AddDACActorRelationship_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // AddDACPolicy provides a mock function for the type Txn
-func (_mock *Txn) AddDACPolicy(ctx context.Context, policy string, opts ...options.Lister[options.AddDACPolicyOptions]) (client.AddPolicyResult, error) {
+func (_mock *Txn) AddDACPolicy(ctx context.Context, policy string, opts ...options.Enumerable[options.AddDACPolicyOptions]) (client.AddPolicyResult, error) {
 	var tmpRet mock.Arguments
 	if len(opts) > 0 {
 		tmpRet = _mock.Called(ctx, policy, opts)
@@ -236,15 +236,15 @@ func (_mock *Txn) AddDACPolicy(ctx context.Context, policy string, opts ...optio
 
 	var r0 client.AddPolicyResult
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, ...options.Lister[options.AddDACPolicyOptions]) (client.AddPolicyResult, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, ...options.Enumerable[options.AddDACPolicyOptions]) (client.AddPolicyResult, error)); ok {
 		return returnFunc(ctx, policy, opts...)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, ...options.Lister[options.AddDACPolicyOptions]) client.AddPolicyResult); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, ...options.Enumerable[options.AddDACPolicyOptions]) client.AddPolicyResult); ok {
 		r0 = returnFunc(ctx, policy, opts...)
 	} else {
 		r0 = ret.Get(0).(client.AddPolicyResult)
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, ...options.Lister[options.AddDACPolicyOptions]) error); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, ...options.Enumerable[options.AddDACPolicyOptions]) error); ok {
 		r1 = returnFunc(ctx, policy, opts...)
 	} else {
 		r1 = ret.Error(1)
@@ -266,7 +266,7 @@ func (_e *Txn_Expecter) AddDACPolicy(ctx interface{}, policy interface{}, opts .
 		append([]interface{}{ctx, policy}, opts...)...)}
 }
 
-func (_c *Txn_AddDACPolicy_Call) Run(run func(ctx context.Context, policy string, opts ...options.Lister[options.AddDACPolicyOptions])) *Txn_AddDACPolicy_Call {
+func (_c *Txn_AddDACPolicy_Call) Run(run func(ctx context.Context, policy string, opts ...options.Enumerable[options.AddDACPolicyOptions])) *Txn_AddDACPolicy_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -276,10 +276,10 @@ func (_c *Txn_AddDACPolicy_Call) Run(run func(ctx context.Context, policy string
 		if args[1] != nil {
 			arg1 = args[1].(string)
 		}
-		var arg2 []options.Lister[options.AddDACPolicyOptions]
-		var variadicArgs []options.Lister[options.AddDACPolicyOptions]
+		var arg2 []options.Enumerable[options.AddDACPolicyOptions]
+		var variadicArgs []options.Enumerable[options.AddDACPolicyOptions]
 		if len(args) > 2 {
-			variadicArgs = args[2].([]options.Lister[options.AddDACPolicyOptions])
+			variadicArgs = args[2].([]options.Enumerable[options.AddDACPolicyOptions])
 		}
 		arg2 = variadicArgs
 		run(
@@ -296,13 +296,13 @@ func (_c *Txn_AddDACPolicy_Call) Return(addPolicyResult client.AddPolicyResult, 
 	return _c
 }
 
-func (_c *Txn_AddDACPolicy_Call) RunAndReturn(run func(ctx context.Context, policy string, opts ...options.Lister[options.AddDACPolicyOptions]) (client.AddPolicyResult, error)) *Txn_AddDACPolicy_Call {
+func (_c *Txn_AddDACPolicy_Call) RunAndReturn(run func(ctx context.Context, policy string, opts ...options.Enumerable[options.AddDACPolicyOptions]) (client.AddPolicyResult, error)) *Txn_AddDACPolicy_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // AddLens provides a mock function for the type Txn
-func (_mock *Txn) AddLens(ctx context.Context, lens model.Lens, opts ...options.Lister[options.AddLensOptions]) (string, error) {
+func (_mock *Txn) AddLens(ctx context.Context, lens model.Lens, opts ...options.Enumerable[options.AddLensOptions]) (string, error) {
 	var tmpRet mock.Arguments
 	if len(opts) > 0 {
 		tmpRet = _mock.Called(ctx, lens, opts)
@@ -317,15 +317,15 @@ func (_mock *Txn) AddLens(ctx context.Context, lens model.Lens, opts ...options.
 
 	var r0 string
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, model.Lens, ...options.Lister[options.AddLensOptions]) (string, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, model.Lens, ...options.Enumerable[options.AddLensOptions]) (string, error)); ok {
 		return returnFunc(ctx, lens, opts...)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, model.Lens, ...options.Lister[options.AddLensOptions]) string); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, model.Lens, ...options.Enumerable[options.AddLensOptions]) string); ok {
 		r0 = returnFunc(ctx, lens, opts...)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, model.Lens, ...options.Lister[options.AddLensOptions]) error); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, model.Lens, ...options.Enumerable[options.AddLensOptions]) error); ok {
 		r1 = returnFunc(ctx, lens, opts...)
 	} else {
 		r1 = ret.Error(1)
@@ -347,7 +347,7 @@ func (_e *Txn_Expecter) AddLens(ctx interface{}, lens interface{}, opts ...inter
 		append([]interface{}{ctx, lens}, opts...)...)}
 }
 
-func (_c *Txn_AddLens_Call) Run(run func(ctx context.Context, lens model.Lens, opts ...options.Lister[options.AddLensOptions])) *Txn_AddLens_Call {
+func (_c *Txn_AddLens_Call) Run(run func(ctx context.Context, lens model.Lens, opts ...options.Enumerable[options.AddLensOptions])) *Txn_AddLens_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -357,10 +357,10 @@ func (_c *Txn_AddLens_Call) Run(run func(ctx context.Context, lens model.Lens, o
 		if args[1] != nil {
 			arg1 = args[1].(model.Lens)
 		}
-		var arg2 []options.Lister[options.AddLensOptions]
-		var variadicArgs []options.Lister[options.AddLensOptions]
+		var arg2 []options.Enumerable[options.AddLensOptions]
+		var variadicArgs []options.Enumerable[options.AddLensOptions]
 		if len(args) > 2 {
-			variadicArgs = args[2].([]options.Lister[options.AddLensOptions])
+			variadicArgs = args[2].([]options.Enumerable[options.AddLensOptions])
 		}
 		arg2 = variadicArgs
 		run(
@@ -377,13 +377,13 @@ func (_c *Txn_AddLens_Call) Return(s string, err error) *Txn_AddLens_Call {
 	return _c
 }
 
-func (_c *Txn_AddLens_Call) RunAndReturn(run func(ctx context.Context, lens model.Lens, opts ...options.Lister[options.AddLensOptions]) (string, error)) *Txn_AddLens_Call {
+func (_c *Txn_AddLens_Call) RunAndReturn(run func(ctx context.Context, lens model.Lens, opts ...options.Enumerable[options.AddLensOptions]) (string, error)) *Txn_AddLens_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // AddNACActorRelationship provides a mock function for the type Txn
-func (_mock *Txn) AddNACActorRelationship(ctx context.Context, relation string, targetActor string, opts ...options.Lister[options.AddNACActorRelationshipOptions]) (client.AddActorRelationshipResult, error) {
+func (_mock *Txn) AddNACActorRelationship(ctx context.Context, relation string, targetActor string, opts ...options.Enumerable[options.AddNACActorRelationshipOptions]) (client.AddActorRelationshipResult, error) {
 	var tmpRet mock.Arguments
 	if len(opts) > 0 {
 		tmpRet = _mock.Called(ctx, relation, targetActor, opts)
@@ -398,15 +398,15 @@ func (_mock *Txn) AddNACActorRelationship(ctx context.Context, relation string, 
 
 	var r0 client.AddActorRelationshipResult
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, ...options.Lister[options.AddNACActorRelationshipOptions]) (client.AddActorRelationshipResult, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, ...options.Enumerable[options.AddNACActorRelationshipOptions]) (client.AddActorRelationshipResult, error)); ok {
 		return returnFunc(ctx, relation, targetActor, opts...)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, ...options.Lister[options.AddNACActorRelationshipOptions]) client.AddActorRelationshipResult); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, ...options.Enumerable[options.AddNACActorRelationshipOptions]) client.AddActorRelationshipResult); ok {
 		r0 = returnFunc(ctx, relation, targetActor, opts...)
 	} else {
 		r0 = ret.Get(0).(client.AddActorRelationshipResult)
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, ...options.Lister[options.AddNACActorRelationshipOptions]) error); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, ...options.Enumerable[options.AddNACActorRelationshipOptions]) error); ok {
 		r1 = returnFunc(ctx, relation, targetActor, opts...)
 	} else {
 		r1 = ret.Error(1)
@@ -429,7 +429,7 @@ func (_e *Txn_Expecter) AddNACActorRelationship(ctx interface{}, relation interf
 		append([]interface{}{ctx, relation, targetActor}, opts...)...)}
 }
 
-func (_c *Txn_AddNACActorRelationship_Call) Run(run func(ctx context.Context, relation string, targetActor string, opts ...options.Lister[options.AddNACActorRelationshipOptions])) *Txn_AddNACActorRelationship_Call {
+func (_c *Txn_AddNACActorRelationship_Call) Run(run func(ctx context.Context, relation string, targetActor string, opts ...options.Enumerable[options.AddNACActorRelationshipOptions])) *Txn_AddNACActorRelationship_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -443,10 +443,10 @@ func (_c *Txn_AddNACActorRelationship_Call) Run(run func(ctx context.Context, re
 		if args[2] != nil {
 			arg2 = args[2].(string)
 		}
-		var arg3 []options.Lister[options.AddNACActorRelationshipOptions]
-		var variadicArgs []options.Lister[options.AddNACActorRelationshipOptions]
+		var arg3 []options.Enumerable[options.AddNACActorRelationshipOptions]
+		var variadicArgs []options.Enumerable[options.AddNACActorRelationshipOptions]
 		if len(args) > 3 {
-			variadicArgs = args[3].([]options.Lister[options.AddNACActorRelationshipOptions])
+			variadicArgs = args[3].([]options.Enumerable[options.AddNACActorRelationshipOptions])
 		}
 		arg3 = variadicArgs
 		run(
@@ -464,13 +464,13 @@ func (_c *Txn_AddNACActorRelationship_Call) Return(addActorRelationshipResult cl
 	return _c
 }
 
-func (_c *Txn_AddNACActorRelationship_Call) RunAndReturn(run func(ctx context.Context, relation string, targetActor string, opts ...options.Lister[options.AddNACActorRelationshipOptions]) (client.AddActorRelationshipResult, error)) *Txn_AddNACActorRelationship_Call {
+func (_c *Txn_AddNACActorRelationship_Call) RunAndReturn(run func(ctx context.Context, relation string, targetActor string, opts ...options.Enumerable[options.AddNACActorRelationshipOptions]) (client.AddActorRelationshipResult, error)) *Txn_AddNACActorRelationship_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // AddSchema provides a mock function for the type Txn
-func (_mock *Txn) AddSchema(ctx context.Context, sdl string, opts ...options.Lister[options.AddSchemaOptions]) ([]client.CollectionVersion, error) {
+func (_mock *Txn) AddSchema(ctx context.Context, sdl string, opts ...options.Enumerable[options.AddSchemaOptions]) ([]client.CollectionVersion, error) {
 	var tmpRet mock.Arguments
 	if len(opts) > 0 {
 		tmpRet = _mock.Called(ctx, sdl, opts)
@@ -485,17 +485,17 @@ func (_mock *Txn) AddSchema(ctx context.Context, sdl string, opts ...options.Lis
 
 	var r0 []client.CollectionVersion
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, ...options.Lister[options.AddSchemaOptions]) ([]client.CollectionVersion, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, ...options.Enumerable[options.AddSchemaOptions]) ([]client.CollectionVersion, error)); ok {
 		return returnFunc(ctx, sdl, opts...)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, ...options.Lister[options.AddSchemaOptions]) []client.CollectionVersion); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, ...options.Enumerable[options.AddSchemaOptions]) []client.CollectionVersion); ok {
 		r0 = returnFunc(ctx, sdl, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]client.CollectionVersion)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, ...options.Lister[options.AddSchemaOptions]) error); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, ...options.Enumerable[options.AddSchemaOptions]) error); ok {
 		r1 = returnFunc(ctx, sdl, opts...)
 	} else {
 		r1 = ret.Error(1)
@@ -517,7 +517,7 @@ func (_e *Txn_Expecter) AddSchema(ctx interface{}, sdl interface{}, opts ...inte
 		append([]interface{}{ctx, sdl}, opts...)...)}
 }
 
-func (_c *Txn_AddSchema_Call) Run(run func(ctx context.Context, sdl string, opts ...options.Lister[options.AddSchemaOptions])) *Txn_AddSchema_Call {
+func (_c *Txn_AddSchema_Call) Run(run func(ctx context.Context, sdl string, opts ...options.Enumerable[options.AddSchemaOptions])) *Txn_AddSchema_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -527,10 +527,10 @@ func (_c *Txn_AddSchema_Call) Run(run func(ctx context.Context, sdl string, opts
 		if args[1] != nil {
 			arg1 = args[1].(string)
 		}
-		var arg2 []options.Lister[options.AddSchemaOptions]
-		var variadicArgs []options.Lister[options.AddSchemaOptions]
+		var arg2 []options.Enumerable[options.AddSchemaOptions]
+		var variadicArgs []options.Enumerable[options.AddSchemaOptions]
 		if len(args) > 2 {
-			variadicArgs = args[2].([]options.Lister[options.AddSchemaOptions])
+			variadicArgs = args[2].([]options.Enumerable[options.AddSchemaOptions])
 		}
 		arg2 = variadicArgs
 		run(
@@ -547,13 +547,13 @@ func (_c *Txn_AddSchema_Call) Return(collectionVersions []client.CollectionVersi
 	return _c
 }
 
-func (_c *Txn_AddSchema_Call) RunAndReturn(run func(ctx context.Context, sdl string, opts ...options.Lister[options.AddSchemaOptions]) ([]client.CollectionVersion, error)) *Txn_AddSchema_Call {
+func (_c *Txn_AddSchema_Call) RunAndReturn(run func(ctx context.Context, sdl string, opts ...options.Enumerable[options.AddSchemaOptions]) ([]client.CollectionVersion, error)) *Txn_AddSchema_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // AddView provides a mock function for the type Txn
-func (_mock *Txn) AddView(ctx context.Context, gqlQuery string, sdl string, opts ...options.Lister[options.AddViewOptions]) ([]client.CollectionVersion, error) {
+func (_mock *Txn) AddView(ctx context.Context, gqlQuery string, sdl string, opts ...options.Enumerable[options.AddViewOptions]) ([]client.CollectionVersion, error) {
 	var tmpRet mock.Arguments
 	if len(opts) > 0 {
 		tmpRet = _mock.Called(ctx, gqlQuery, sdl, opts)
@@ -568,17 +568,17 @@ func (_mock *Txn) AddView(ctx context.Context, gqlQuery string, sdl string, opts
 
 	var r0 []client.CollectionVersion
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, ...options.Lister[options.AddViewOptions]) ([]client.CollectionVersion, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, ...options.Enumerable[options.AddViewOptions]) ([]client.CollectionVersion, error)); ok {
 		return returnFunc(ctx, gqlQuery, sdl, opts...)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, ...options.Lister[options.AddViewOptions]) []client.CollectionVersion); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, ...options.Enumerable[options.AddViewOptions]) []client.CollectionVersion); ok {
 		r0 = returnFunc(ctx, gqlQuery, sdl, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]client.CollectionVersion)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, ...options.Lister[options.AddViewOptions]) error); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, ...options.Enumerable[options.AddViewOptions]) error); ok {
 		r1 = returnFunc(ctx, gqlQuery, sdl, opts...)
 	} else {
 		r1 = ret.Error(1)
@@ -601,7 +601,7 @@ func (_e *Txn_Expecter) AddView(ctx interface{}, gqlQuery interface{}, sdl inter
 		append([]interface{}{ctx, gqlQuery, sdl}, opts...)...)}
 }
 
-func (_c *Txn_AddView_Call) Run(run func(ctx context.Context, gqlQuery string, sdl string, opts ...options.Lister[options.AddViewOptions])) *Txn_AddView_Call {
+func (_c *Txn_AddView_Call) Run(run func(ctx context.Context, gqlQuery string, sdl string, opts ...options.Enumerable[options.AddViewOptions])) *Txn_AddView_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -615,10 +615,10 @@ func (_c *Txn_AddView_Call) Run(run func(ctx context.Context, gqlQuery string, s
 		if args[2] != nil {
 			arg2 = args[2].(string)
 		}
-		var arg3 []options.Lister[options.AddViewOptions]
-		var variadicArgs []options.Lister[options.AddViewOptions]
+		var arg3 []options.Enumerable[options.AddViewOptions]
+		var variadicArgs []options.Enumerable[options.AddViewOptions]
 		if len(args) > 3 {
-			variadicArgs = args[3].([]options.Lister[options.AddViewOptions])
+			variadicArgs = args[3].([]options.Enumerable[options.AddViewOptions])
 		}
 		arg3 = variadicArgs
 		run(
@@ -636,13 +636,13 @@ func (_c *Txn_AddView_Call) Return(collectionVersions []client.CollectionVersion
 	return _c
 }
 
-func (_c *Txn_AddView_Call) RunAndReturn(run func(ctx context.Context, gqlQuery string, sdl string, opts ...options.Lister[options.AddViewOptions]) ([]client.CollectionVersion, error)) *Txn_AddView_Call {
+func (_c *Txn_AddView_Call) RunAndReturn(run func(ctx context.Context, gqlQuery string, sdl string, opts ...options.Enumerable[options.AddViewOptions]) ([]client.CollectionVersion, error)) *Txn_AddView_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // BasicExport provides a mock function for the type Txn
-func (_mock *Txn) BasicExport(ctx context.Context, filepath string, opts ...options.Lister[options.BasicExportOptions]) error {
+func (_mock *Txn) BasicExport(ctx context.Context, filepath string, opts ...options.Enumerable[options.BasicExportOptions]) error {
 	var tmpRet mock.Arguments
 	if len(opts) > 0 {
 		tmpRet = _mock.Called(ctx, filepath, opts)
@@ -656,7 +656,7 @@ func (_mock *Txn) BasicExport(ctx context.Context, filepath string, opts ...opti
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, ...options.Lister[options.BasicExportOptions]) error); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, ...options.Enumerable[options.BasicExportOptions]) error); ok {
 		r0 = returnFunc(ctx, filepath, opts...)
 	} else {
 		r0 = ret.Error(0)
@@ -678,7 +678,7 @@ func (_e *Txn_Expecter) BasicExport(ctx interface{}, filepath interface{}, opts 
 		append([]interface{}{ctx, filepath}, opts...)...)}
 }
 
-func (_c *Txn_BasicExport_Call) Run(run func(ctx context.Context, filepath string, opts ...options.Lister[options.BasicExportOptions])) *Txn_BasicExport_Call {
+func (_c *Txn_BasicExport_Call) Run(run func(ctx context.Context, filepath string, opts ...options.Enumerable[options.BasicExportOptions])) *Txn_BasicExport_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -688,10 +688,10 @@ func (_c *Txn_BasicExport_Call) Run(run func(ctx context.Context, filepath strin
 		if args[1] != nil {
 			arg1 = args[1].(string)
 		}
-		var arg2 []options.Lister[options.BasicExportOptions]
-		var variadicArgs []options.Lister[options.BasicExportOptions]
+		var arg2 []options.Enumerable[options.BasicExportOptions]
+		var variadicArgs []options.Enumerable[options.BasicExportOptions]
 		if len(args) > 2 {
-			variadicArgs = args[2].([]options.Lister[options.BasicExportOptions])
+			variadicArgs = args[2].([]options.Enumerable[options.BasicExportOptions])
 		}
 		arg2 = variadicArgs
 		run(
@@ -708,7 +708,7 @@ func (_c *Txn_BasicExport_Call) Return(err error) *Txn_BasicExport_Call {
 	return _c
 }
 
-func (_c *Txn_BasicExport_Call) RunAndReturn(run func(ctx context.Context, filepath string, opts ...options.Lister[options.BasicExportOptions]) error) *Txn_BasicExport_Call {
+func (_c *Txn_BasicExport_Call) RunAndReturn(run func(ctx context.Context, filepath string, opts ...options.Enumerable[options.BasicExportOptions]) error) *Txn_BasicExport_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -815,7 +815,7 @@ func (_c *Txn_Commit_Call) RunAndReturn(run func() error) *Txn_Commit_Call {
 }
 
 // Connect provides a mock function for the type Txn
-func (_mock *Txn) Connect(ctx context.Context, addresses []string, opts ...options.Lister[options.ConnectOptions]) error {
+func (_mock *Txn) Connect(ctx context.Context, addresses []string, opts ...options.Enumerable[options.ConnectOptions]) error {
 	var tmpRet mock.Arguments
 	if len(opts) > 0 {
 		tmpRet = _mock.Called(ctx, addresses, opts)
@@ -829,7 +829,7 @@ func (_mock *Txn) Connect(ctx context.Context, addresses []string, opts ...optio
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, []string, ...options.Lister[options.ConnectOptions]) error); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []string, ...options.Enumerable[options.ConnectOptions]) error); ok {
 		r0 = returnFunc(ctx, addresses, opts...)
 	} else {
 		r0 = ret.Error(0)
@@ -851,7 +851,7 @@ func (_e *Txn_Expecter) Connect(ctx interface{}, addresses interface{}, opts ...
 		append([]interface{}{ctx, addresses}, opts...)...)}
 }
 
-func (_c *Txn_Connect_Call) Run(run func(ctx context.Context, addresses []string, opts ...options.Lister[options.ConnectOptions])) *Txn_Connect_Call {
+func (_c *Txn_Connect_Call) Run(run func(ctx context.Context, addresses []string, opts ...options.Enumerable[options.ConnectOptions])) *Txn_Connect_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -861,10 +861,10 @@ func (_c *Txn_Connect_Call) Run(run func(ctx context.Context, addresses []string
 		if args[1] != nil {
 			arg1 = args[1].([]string)
 		}
-		var arg2 []options.Lister[options.ConnectOptions]
-		var variadicArgs []options.Lister[options.ConnectOptions]
+		var arg2 []options.Enumerable[options.ConnectOptions]
+		var variadicArgs []options.Enumerable[options.ConnectOptions]
 		if len(args) > 2 {
-			variadicArgs = args[2].([]options.Lister[options.ConnectOptions])
+			variadicArgs = args[2].([]options.Enumerable[options.ConnectOptions])
 		}
 		arg2 = variadicArgs
 		run(
@@ -881,13 +881,13 @@ func (_c *Txn_Connect_Call) Return(err error) *Txn_Connect_Call {
 	return _c
 }
 
-func (_c *Txn_Connect_Call) RunAndReturn(run func(ctx context.Context, addresses []string, opts ...options.Lister[options.ConnectOptions]) error) *Txn_Connect_Call {
+func (_c *Txn_Connect_Call) RunAndReturn(run func(ctx context.Context, addresses []string, opts ...options.Enumerable[options.ConnectOptions]) error) *Txn_Connect_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // CreateP2PCollections provides a mock function for the type Txn
-func (_mock *Txn) CreateP2PCollections(ctx context.Context, collectionNames []string, opts ...options.Lister[options.CreateP2PCollectionsOptions]) error {
+func (_mock *Txn) CreateP2PCollections(ctx context.Context, collectionNames []string, opts ...options.Enumerable[options.CreateP2PCollectionsOptions]) error {
 	var tmpRet mock.Arguments
 	if len(opts) > 0 {
 		tmpRet = _mock.Called(ctx, collectionNames, opts)
@@ -901,7 +901,7 @@ func (_mock *Txn) CreateP2PCollections(ctx context.Context, collectionNames []st
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, []string, ...options.Lister[options.CreateP2PCollectionsOptions]) error); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []string, ...options.Enumerable[options.CreateP2PCollectionsOptions]) error); ok {
 		r0 = returnFunc(ctx, collectionNames, opts...)
 	} else {
 		r0 = ret.Error(0)
@@ -923,7 +923,7 @@ func (_e *Txn_Expecter) CreateP2PCollections(ctx interface{}, collectionNames in
 		append([]interface{}{ctx, collectionNames}, opts...)...)}
 }
 
-func (_c *Txn_CreateP2PCollections_Call) Run(run func(ctx context.Context, collectionNames []string, opts ...options.Lister[options.CreateP2PCollectionsOptions])) *Txn_CreateP2PCollections_Call {
+func (_c *Txn_CreateP2PCollections_Call) Run(run func(ctx context.Context, collectionNames []string, opts ...options.Enumerable[options.CreateP2PCollectionsOptions])) *Txn_CreateP2PCollections_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -933,10 +933,10 @@ func (_c *Txn_CreateP2PCollections_Call) Run(run func(ctx context.Context, colle
 		if args[1] != nil {
 			arg1 = args[1].([]string)
 		}
-		var arg2 []options.Lister[options.CreateP2PCollectionsOptions]
-		var variadicArgs []options.Lister[options.CreateP2PCollectionsOptions]
+		var arg2 []options.Enumerable[options.CreateP2PCollectionsOptions]
+		var variadicArgs []options.Enumerable[options.CreateP2PCollectionsOptions]
 		if len(args) > 2 {
-			variadicArgs = args[2].([]options.Lister[options.CreateP2PCollectionsOptions])
+			variadicArgs = args[2].([]options.Enumerable[options.CreateP2PCollectionsOptions])
 		}
 		arg2 = variadicArgs
 		run(
@@ -953,13 +953,13 @@ func (_c *Txn_CreateP2PCollections_Call) Return(err error) *Txn_CreateP2PCollect
 	return _c
 }
 
-func (_c *Txn_CreateP2PCollections_Call) RunAndReturn(run func(ctx context.Context, collectionNames []string, opts ...options.Lister[options.CreateP2PCollectionsOptions]) error) *Txn_CreateP2PCollections_Call {
+func (_c *Txn_CreateP2PCollections_Call) RunAndReturn(run func(ctx context.Context, collectionNames []string, opts ...options.Enumerable[options.CreateP2PCollectionsOptions]) error) *Txn_CreateP2PCollections_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // CreateP2PDocuments provides a mock function for the type Txn
-func (_mock *Txn) CreateP2PDocuments(ctx context.Context, docIDs []string, opts ...options.Lister[options.CreateP2PDocumentsOptions]) error {
+func (_mock *Txn) CreateP2PDocuments(ctx context.Context, docIDs []string, opts ...options.Enumerable[options.CreateP2PDocumentsOptions]) error {
 	var tmpRet mock.Arguments
 	if len(opts) > 0 {
 		tmpRet = _mock.Called(ctx, docIDs, opts)
@@ -973,7 +973,7 @@ func (_mock *Txn) CreateP2PDocuments(ctx context.Context, docIDs []string, opts 
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, []string, ...options.Lister[options.CreateP2PDocumentsOptions]) error); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []string, ...options.Enumerable[options.CreateP2PDocumentsOptions]) error); ok {
 		r0 = returnFunc(ctx, docIDs, opts...)
 	} else {
 		r0 = ret.Error(0)
@@ -995,7 +995,7 @@ func (_e *Txn_Expecter) CreateP2PDocuments(ctx interface{}, docIDs interface{}, 
 		append([]interface{}{ctx, docIDs}, opts...)...)}
 }
 
-func (_c *Txn_CreateP2PDocuments_Call) Run(run func(ctx context.Context, docIDs []string, opts ...options.Lister[options.CreateP2PDocumentsOptions])) *Txn_CreateP2PDocuments_Call {
+func (_c *Txn_CreateP2PDocuments_Call) Run(run func(ctx context.Context, docIDs []string, opts ...options.Enumerable[options.CreateP2PDocumentsOptions])) *Txn_CreateP2PDocuments_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -1005,10 +1005,10 @@ func (_c *Txn_CreateP2PDocuments_Call) Run(run func(ctx context.Context, docIDs 
 		if args[1] != nil {
 			arg1 = args[1].([]string)
 		}
-		var arg2 []options.Lister[options.CreateP2PDocumentsOptions]
-		var variadicArgs []options.Lister[options.CreateP2PDocumentsOptions]
+		var arg2 []options.Enumerable[options.CreateP2PDocumentsOptions]
+		var variadicArgs []options.Enumerable[options.CreateP2PDocumentsOptions]
 		if len(args) > 2 {
-			variadicArgs = args[2].([]options.Lister[options.CreateP2PDocumentsOptions])
+			variadicArgs = args[2].([]options.Enumerable[options.CreateP2PDocumentsOptions])
 		}
 		arg2 = variadicArgs
 		run(
@@ -1025,13 +1025,13 @@ func (_c *Txn_CreateP2PDocuments_Call) Return(err error) *Txn_CreateP2PDocuments
 	return _c
 }
 
-func (_c *Txn_CreateP2PDocuments_Call) RunAndReturn(run func(ctx context.Context, docIDs []string, opts ...options.Lister[options.CreateP2PDocumentsOptions]) error) *Txn_CreateP2PDocuments_Call {
+func (_c *Txn_CreateP2PDocuments_Call) RunAndReturn(run func(ctx context.Context, docIDs []string, opts ...options.Enumerable[options.CreateP2PDocumentsOptions]) error) *Txn_CreateP2PDocuments_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // CreateReplicator provides a mock function for the type Txn
-func (_mock *Txn) CreateReplicator(ctx context.Context, addresses []string, opts ...options.Lister[options.CreateReplicatorOptions]) error {
+func (_mock *Txn) CreateReplicator(ctx context.Context, addresses []string, opts ...options.Enumerable[options.CreateReplicatorOptions]) error {
 	var tmpRet mock.Arguments
 	if len(opts) > 0 {
 		tmpRet = _mock.Called(ctx, addresses, opts)
@@ -1045,7 +1045,7 @@ func (_mock *Txn) CreateReplicator(ctx context.Context, addresses []string, opts
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, []string, ...options.Lister[options.CreateReplicatorOptions]) error); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []string, ...options.Enumerable[options.CreateReplicatorOptions]) error); ok {
 		r0 = returnFunc(ctx, addresses, opts...)
 	} else {
 		r0 = ret.Error(0)
@@ -1067,7 +1067,7 @@ func (_e *Txn_Expecter) CreateReplicator(ctx interface{}, addresses interface{},
 		append([]interface{}{ctx, addresses}, opts...)...)}
 }
 
-func (_c *Txn_CreateReplicator_Call) Run(run func(ctx context.Context, addresses []string, opts ...options.Lister[options.CreateReplicatorOptions])) *Txn_CreateReplicator_Call {
+func (_c *Txn_CreateReplicator_Call) Run(run func(ctx context.Context, addresses []string, opts ...options.Enumerable[options.CreateReplicatorOptions])) *Txn_CreateReplicator_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -1077,10 +1077,10 @@ func (_c *Txn_CreateReplicator_Call) Run(run func(ctx context.Context, addresses
 		if args[1] != nil {
 			arg1 = args[1].([]string)
 		}
-		var arg2 []options.Lister[options.CreateReplicatorOptions]
-		var variadicArgs []options.Lister[options.CreateReplicatorOptions]
+		var arg2 []options.Enumerable[options.CreateReplicatorOptions]
+		var variadicArgs []options.Enumerable[options.CreateReplicatorOptions]
 		if len(args) > 2 {
-			variadicArgs = args[2].([]options.Lister[options.CreateReplicatorOptions])
+			variadicArgs = args[2].([]options.Enumerable[options.CreateReplicatorOptions])
 		}
 		arg2 = variadicArgs
 		run(
@@ -1097,13 +1097,13 @@ func (_c *Txn_CreateReplicator_Call) Return(err error) *Txn_CreateReplicator_Cal
 	return _c
 }
 
-func (_c *Txn_CreateReplicator_Call) RunAndReturn(run func(ctx context.Context, addresses []string, opts ...options.Lister[options.CreateReplicatorOptions]) error) *Txn_CreateReplicator_Call {
+func (_c *Txn_CreateReplicator_Call) RunAndReturn(run func(ctx context.Context, addresses []string, opts ...options.Enumerable[options.CreateReplicatorOptions]) error) *Txn_CreateReplicator_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // DeleteDACActorRelationship provides a mock function for the type Txn
-func (_mock *Txn) DeleteDACActorRelationship(ctx context.Context, collectionName string, docID string, relation string, targetActor string, opts ...options.Lister[options.DeleteDACActorRelationshipOptions]) (client.DeleteActorRelationshipResult, error) {
+func (_mock *Txn) DeleteDACActorRelationship(ctx context.Context, collectionName string, docID string, relation string, targetActor string, opts ...options.Enumerable[options.DeleteDACActorRelationshipOptions]) (client.DeleteActorRelationshipResult, error) {
 	var tmpRet mock.Arguments
 	if len(opts) > 0 {
 		tmpRet = _mock.Called(ctx, collectionName, docID, relation, targetActor, opts)
@@ -1118,15 +1118,15 @@ func (_mock *Txn) DeleteDACActorRelationship(ctx context.Context, collectionName
 
 	var r0 client.DeleteActorRelationshipResult
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string, string, ...options.Lister[options.DeleteDACActorRelationshipOptions]) (client.DeleteActorRelationshipResult, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string, string, ...options.Enumerable[options.DeleteDACActorRelationshipOptions]) (client.DeleteActorRelationshipResult, error)); ok {
 		return returnFunc(ctx, collectionName, docID, relation, targetActor, opts...)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string, string, ...options.Lister[options.DeleteDACActorRelationshipOptions]) client.DeleteActorRelationshipResult); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string, string, ...options.Enumerable[options.DeleteDACActorRelationshipOptions]) client.DeleteActorRelationshipResult); ok {
 		r0 = returnFunc(ctx, collectionName, docID, relation, targetActor, opts...)
 	} else {
 		r0 = ret.Get(0).(client.DeleteActorRelationshipResult)
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, string, string, ...options.Lister[options.DeleteDACActorRelationshipOptions]) error); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, string, string, ...options.Enumerable[options.DeleteDACActorRelationshipOptions]) error); ok {
 		r1 = returnFunc(ctx, collectionName, docID, relation, targetActor, opts...)
 	} else {
 		r1 = ret.Error(1)
@@ -1151,7 +1151,7 @@ func (_e *Txn_Expecter) DeleteDACActorRelationship(ctx interface{}, collectionNa
 		append([]interface{}{ctx, collectionName, docID, relation, targetActor}, opts...)...)}
 }
 
-func (_c *Txn_DeleteDACActorRelationship_Call) Run(run func(ctx context.Context, collectionName string, docID string, relation string, targetActor string, opts ...options.Lister[options.DeleteDACActorRelationshipOptions])) *Txn_DeleteDACActorRelationship_Call {
+func (_c *Txn_DeleteDACActorRelationship_Call) Run(run func(ctx context.Context, collectionName string, docID string, relation string, targetActor string, opts ...options.Enumerable[options.DeleteDACActorRelationshipOptions])) *Txn_DeleteDACActorRelationship_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -1173,10 +1173,10 @@ func (_c *Txn_DeleteDACActorRelationship_Call) Run(run func(ctx context.Context,
 		if args[4] != nil {
 			arg4 = args[4].(string)
 		}
-		var arg5 []options.Lister[options.DeleteDACActorRelationshipOptions]
-		var variadicArgs []options.Lister[options.DeleteDACActorRelationshipOptions]
+		var arg5 []options.Enumerable[options.DeleteDACActorRelationshipOptions]
+		var variadicArgs []options.Enumerable[options.DeleteDACActorRelationshipOptions]
 		if len(args) > 5 {
-			variadicArgs = args[5].([]options.Lister[options.DeleteDACActorRelationshipOptions])
+			variadicArgs = args[5].([]options.Enumerable[options.DeleteDACActorRelationshipOptions])
 		}
 		arg5 = variadicArgs
 		run(
@@ -1196,13 +1196,13 @@ func (_c *Txn_DeleteDACActorRelationship_Call) Return(deleteActorRelationshipRes
 	return _c
 }
 
-func (_c *Txn_DeleteDACActorRelationship_Call) RunAndReturn(run func(ctx context.Context, collectionName string, docID string, relation string, targetActor string, opts ...options.Lister[options.DeleteDACActorRelationshipOptions]) (client.DeleteActorRelationshipResult, error)) *Txn_DeleteDACActorRelationship_Call {
+func (_c *Txn_DeleteDACActorRelationship_Call) RunAndReturn(run func(ctx context.Context, collectionName string, docID string, relation string, targetActor string, opts ...options.Enumerable[options.DeleteDACActorRelationshipOptions]) (client.DeleteActorRelationshipResult, error)) *Txn_DeleteDACActorRelationship_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // DeleteNACActorRelationship provides a mock function for the type Txn
-func (_mock *Txn) DeleteNACActorRelationship(ctx context.Context, relation string, targetActor string, opts ...options.Lister[options.DeleteNACActorRelationshipOptions]) (client.DeleteActorRelationshipResult, error) {
+func (_mock *Txn) DeleteNACActorRelationship(ctx context.Context, relation string, targetActor string, opts ...options.Enumerable[options.DeleteNACActorRelationshipOptions]) (client.DeleteActorRelationshipResult, error) {
 	var tmpRet mock.Arguments
 	if len(opts) > 0 {
 		tmpRet = _mock.Called(ctx, relation, targetActor, opts)
@@ -1217,15 +1217,15 @@ func (_mock *Txn) DeleteNACActorRelationship(ctx context.Context, relation strin
 
 	var r0 client.DeleteActorRelationshipResult
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, ...options.Lister[options.DeleteNACActorRelationshipOptions]) (client.DeleteActorRelationshipResult, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, ...options.Enumerable[options.DeleteNACActorRelationshipOptions]) (client.DeleteActorRelationshipResult, error)); ok {
 		return returnFunc(ctx, relation, targetActor, opts...)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, ...options.Lister[options.DeleteNACActorRelationshipOptions]) client.DeleteActorRelationshipResult); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, ...options.Enumerable[options.DeleteNACActorRelationshipOptions]) client.DeleteActorRelationshipResult); ok {
 		r0 = returnFunc(ctx, relation, targetActor, opts...)
 	} else {
 		r0 = ret.Get(0).(client.DeleteActorRelationshipResult)
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, ...options.Lister[options.DeleteNACActorRelationshipOptions]) error); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, ...options.Enumerable[options.DeleteNACActorRelationshipOptions]) error); ok {
 		r1 = returnFunc(ctx, relation, targetActor, opts...)
 	} else {
 		r1 = ret.Error(1)
@@ -1248,7 +1248,7 @@ func (_e *Txn_Expecter) DeleteNACActorRelationship(ctx interface{}, relation int
 		append([]interface{}{ctx, relation, targetActor}, opts...)...)}
 }
 
-func (_c *Txn_DeleteNACActorRelationship_Call) Run(run func(ctx context.Context, relation string, targetActor string, opts ...options.Lister[options.DeleteNACActorRelationshipOptions])) *Txn_DeleteNACActorRelationship_Call {
+func (_c *Txn_DeleteNACActorRelationship_Call) Run(run func(ctx context.Context, relation string, targetActor string, opts ...options.Enumerable[options.DeleteNACActorRelationshipOptions])) *Txn_DeleteNACActorRelationship_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -1262,10 +1262,10 @@ func (_c *Txn_DeleteNACActorRelationship_Call) Run(run func(ctx context.Context,
 		if args[2] != nil {
 			arg2 = args[2].(string)
 		}
-		var arg3 []options.Lister[options.DeleteNACActorRelationshipOptions]
-		var variadicArgs []options.Lister[options.DeleteNACActorRelationshipOptions]
+		var arg3 []options.Enumerable[options.DeleteNACActorRelationshipOptions]
+		var variadicArgs []options.Enumerable[options.DeleteNACActorRelationshipOptions]
 		if len(args) > 3 {
-			variadicArgs = args[3].([]options.Lister[options.DeleteNACActorRelationshipOptions])
+			variadicArgs = args[3].([]options.Enumerable[options.DeleteNACActorRelationshipOptions])
 		}
 		arg3 = variadicArgs
 		run(
@@ -1283,13 +1283,13 @@ func (_c *Txn_DeleteNACActorRelationship_Call) Return(deleteActorRelationshipRes
 	return _c
 }
 
-func (_c *Txn_DeleteNACActorRelationship_Call) RunAndReturn(run func(ctx context.Context, relation string, targetActor string, opts ...options.Lister[options.DeleteNACActorRelationshipOptions]) (client.DeleteActorRelationshipResult, error)) *Txn_DeleteNACActorRelationship_Call {
+func (_c *Txn_DeleteNACActorRelationship_Call) RunAndReturn(run func(ctx context.Context, relation string, targetActor string, opts ...options.Enumerable[options.DeleteNACActorRelationshipOptions]) (client.DeleteActorRelationshipResult, error)) *Txn_DeleteNACActorRelationship_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // DeleteP2PCollections provides a mock function for the type Txn
-func (_mock *Txn) DeleteP2PCollections(ctx context.Context, collectionNames []string, opts ...options.Lister[options.DeleteP2PCollectionsOptions]) error {
+func (_mock *Txn) DeleteP2PCollections(ctx context.Context, collectionNames []string, opts ...options.Enumerable[options.DeleteP2PCollectionsOptions]) error {
 	var tmpRet mock.Arguments
 	if len(opts) > 0 {
 		tmpRet = _mock.Called(ctx, collectionNames, opts)
@@ -1303,7 +1303,7 @@ func (_mock *Txn) DeleteP2PCollections(ctx context.Context, collectionNames []st
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, []string, ...options.Lister[options.DeleteP2PCollectionsOptions]) error); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []string, ...options.Enumerable[options.DeleteP2PCollectionsOptions]) error); ok {
 		r0 = returnFunc(ctx, collectionNames, opts...)
 	} else {
 		r0 = ret.Error(0)
@@ -1325,7 +1325,7 @@ func (_e *Txn_Expecter) DeleteP2PCollections(ctx interface{}, collectionNames in
 		append([]interface{}{ctx, collectionNames}, opts...)...)}
 }
 
-func (_c *Txn_DeleteP2PCollections_Call) Run(run func(ctx context.Context, collectionNames []string, opts ...options.Lister[options.DeleteP2PCollectionsOptions])) *Txn_DeleteP2PCollections_Call {
+func (_c *Txn_DeleteP2PCollections_Call) Run(run func(ctx context.Context, collectionNames []string, opts ...options.Enumerable[options.DeleteP2PCollectionsOptions])) *Txn_DeleteP2PCollections_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -1335,10 +1335,10 @@ func (_c *Txn_DeleteP2PCollections_Call) Run(run func(ctx context.Context, colle
 		if args[1] != nil {
 			arg1 = args[1].([]string)
 		}
-		var arg2 []options.Lister[options.DeleteP2PCollectionsOptions]
-		var variadicArgs []options.Lister[options.DeleteP2PCollectionsOptions]
+		var arg2 []options.Enumerable[options.DeleteP2PCollectionsOptions]
+		var variadicArgs []options.Enumerable[options.DeleteP2PCollectionsOptions]
 		if len(args) > 2 {
-			variadicArgs = args[2].([]options.Lister[options.DeleteP2PCollectionsOptions])
+			variadicArgs = args[2].([]options.Enumerable[options.DeleteP2PCollectionsOptions])
 		}
 		arg2 = variadicArgs
 		run(
@@ -1355,13 +1355,13 @@ func (_c *Txn_DeleteP2PCollections_Call) Return(err error) *Txn_DeleteP2PCollect
 	return _c
 }
 
-func (_c *Txn_DeleteP2PCollections_Call) RunAndReturn(run func(ctx context.Context, collectionNames []string, opts ...options.Lister[options.DeleteP2PCollectionsOptions]) error) *Txn_DeleteP2PCollections_Call {
+func (_c *Txn_DeleteP2PCollections_Call) RunAndReturn(run func(ctx context.Context, collectionNames []string, opts ...options.Enumerable[options.DeleteP2PCollectionsOptions]) error) *Txn_DeleteP2PCollections_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // DeleteP2PDocuments provides a mock function for the type Txn
-func (_mock *Txn) DeleteP2PDocuments(ctx context.Context, docIDs []string, opts ...options.Lister[options.DeleteP2PDocumentsOptions]) error {
+func (_mock *Txn) DeleteP2PDocuments(ctx context.Context, docIDs []string, opts ...options.Enumerable[options.DeleteP2PDocumentsOptions]) error {
 	var tmpRet mock.Arguments
 	if len(opts) > 0 {
 		tmpRet = _mock.Called(ctx, docIDs, opts)
@@ -1375,7 +1375,7 @@ func (_mock *Txn) DeleteP2PDocuments(ctx context.Context, docIDs []string, opts 
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, []string, ...options.Lister[options.DeleteP2PDocumentsOptions]) error); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []string, ...options.Enumerable[options.DeleteP2PDocumentsOptions]) error); ok {
 		r0 = returnFunc(ctx, docIDs, opts...)
 	} else {
 		r0 = ret.Error(0)
@@ -1397,7 +1397,7 @@ func (_e *Txn_Expecter) DeleteP2PDocuments(ctx interface{}, docIDs interface{}, 
 		append([]interface{}{ctx, docIDs}, opts...)...)}
 }
 
-func (_c *Txn_DeleteP2PDocuments_Call) Run(run func(ctx context.Context, docIDs []string, opts ...options.Lister[options.DeleteP2PDocumentsOptions])) *Txn_DeleteP2PDocuments_Call {
+func (_c *Txn_DeleteP2PDocuments_Call) Run(run func(ctx context.Context, docIDs []string, opts ...options.Enumerable[options.DeleteP2PDocumentsOptions])) *Txn_DeleteP2PDocuments_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -1407,10 +1407,10 @@ func (_c *Txn_DeleteP2PDocuments_Call) Run(run func(ctx context.Context, docIDs 
 		if args[1] != nil {
 			arg1 = args[1].([]string)
 		}
-		var arg2 []options.Lister[options.DeleteP2PDocumentsOptions]
-		var variadicArgs []options.Lister[options.DeleteP2PDocumentsOptions]
+		var arg2 []options.Enumerable[options.DeleteP2PDocumentsOptions]
+		var variadicArgs []options.Enumerable[options.DeleteP2PDocumentsOptions]
 		if len(args) > 2 {
-			variadicArgs = args[2].([]options.Lister[options.DeleteP2PDocumentsOptions])
+			variadicArgs = args[2].([]options.Enumerable[options.DeleteP2PDocumentsOptions])
 		}
 		arg2 = variadicArgs
 		run(
@@ -1427,13 +1427,13 @@ func (_c *Txn_DeleteP2PDocuments_Call) Return(err error) *Txn_DeleteP2PDocuments
 	return _c
 }
 
-func (_c *Txn_DeleteP2PDocuments_Call) RunAndReturn(run func(ctx context.Context, docIDs []string, opts ...options.Lister[options.DeleteP2PDocumentsOptions]) error) *Txn_DeleteP2PDocuments_Call {
+func (_c *Txn_DeleteP2PDocuments_Call) RunAndReturn(run func(ctx context.Context, docIDs []string, opts ...options.Enumerable[options.DeleteP2PDocumentsOptions]) error) *Txn_DeleteP2PDocuments_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // DeleteReplicator provides a mock function for the type Txn
-func (_mock *Txn) DeleteReplicator(ctx context.Context, id string, opts ...options.Lister[options.DeleteReplicatorOptions]) error {
+func (_mock *Txn) DeleteReplicator(ctx context.Context, id string, opts ...options.Enumerable[options.DeleteReplicatorOptions]) error {
 	var tmpRet mock.Arguments
 	if len(opts) > 0 {
 		tmpRet = _mock.Called(ctx, id, opts)
@@ -1447,7 +1447,7 @@ func (_mock *Txn) DeleteReplicator(ctx context.Context, id string, opts ...optio
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, ...options.Lister[options.DeleteReplicatorOptions]) error); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, ...options.Enumerable[options.DeleteReplicatorOptions]) error); ok {
 		r0 = returnFunc(ctx, id, opts...)
 	} else {
 		r0 = ret.Error(0)
@@ -1469,7 +1469,7 @@ func (_e *Txn_Expecter) DeleteReplicator(ctx interface{}, id interface{}, opts .
 		append([]interface{}{ctx, id}, opts...)...)}
 }
 
-func (_c *Txn_DeleteReplicator_Call) Run(run func(ctx context.Context, id string, opts ...options.Lister[options.DeleteReplicatorOptions])) *Txn_DeleteReplicator_Call {
+func (_c *Txn_DeleteReplicator_Call) Run(run func(ctx context.Context, id string, opts ...options.Enumerable[options.DeleteReplicatorOptions])) *Txn_DeleteReplicator_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -1479,10 +1479,10 @@ func (_c *Txn_DeleteReplicator_Call) Run(run func(ctx context.Context, id string
 		if args[1] != nil {
 			arg1 = args[1].(string)
 		}
-		var arg2 []options.Lister[options.DeleteReplicatorOptions]
-		var variadicArgs []options.Lister[options.DeleteReplicatorOptions]
+		var arg2 []options.Enumerable[options.DeleteReplicatorOptions]
+		var variadicArgs []options.Enumerable[options.DeleteReplicatorOptions]
 		if len(args) > 2 {
-			variadicArgs = args[2].([]options.Lister[options.DeleteReplicatorOptions])
+			variadicArgs = args[2].([]options.Enumerable[options.DeleteReplicatorOptions])
 		}
 		arg2 = variadicArgs
 		run(
@@ -1499,13 +1499,13 @@ func (_c *Txn_DeleteReplicator_Call) Return(err error) *Txn_DeleteReplicator_Cal
 	return _c
 }
 
-func (_c *Txn_DeleteReplicator_Call) RunAndReturn(run func(ctx context.Context, id string, opts ...options.Lister[options.DeleteReplicatorOptions]) error) *Txn_DeleteReplicator_Call {
+func (_c *Txn_DeleteReplicator_Call) RunAndReturn(run func(ctx context.Context, id string, opts ...options.Enumerable[options.DeleteReplicatorOptions]) error) *Txn_DeleteReplicator_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // DisableNAC provides a mock function for the type Txn
-func (_mock *Txn) DisableNAC(ctx context.Context, opts ...options.Lister[options.DisableNACOptions]) error {
+func (_mock *Txn) DisableNAC(ctx context.Context, opts ...options.Enumerable[options.DisableNACOptions]) error {
 	var tmpRet mock.Arguments
 	if len(opts) > 0 {
 		tmpRet = _mock.Called(ctx, opts)
@@ -1519,7 +1519,7 @@ func (_mock *Txn) DisableNAC(ctx context.Context, opts ...options.Lister[options
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, ...options.Lister[options.DisableNACOptions]) error); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, ...options.Enumerable[options.DisableNACOptions]) error); ok {
 		r0 = returnFunc(ctx, opts...)
 	} else {
 		r0 = ret.Error(0)
@@ -1540,16 +1540,16 @@ func (_e *Txn_Expecter) DisableNAC(ctx interface{}, opts ...interface{}) *Txn_Di
 		append([]interface{}{ctx}, opts...)...)}
 }
 
-func (_c *Txn_DisableNAC_Call) Run(run func(ctx context.Context, opts ...options.Lister[options.DisableNACOptions])) *Txn_DisableNAC_Call {
+func (_c *Txn_DisableNAC_Call) Run(run func(ctx context.Context, opts ...options.Enumerable[options.DisableNACOptions])) *Txn_DisableNAC_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
 			arg0 = args[0].(context.Context)
 		}
-		var arg1 []options.Lister[options.DisableNACOptions]
-		var variadicArgs []options.Lister[options.DisableNACOptions]
+		var arg1 []options.Enumerable[options.DisableNACOptions]
+		var variadicArgs []options.Enumerable[options.DisableNACOptions]
 		if len(args) > 1 {
-			variadicArgs = args[1].([]options.Lister[options.DisableNACOptions])
+			variadicArgs = args[1].([]options.Enumerable[options.DisableNACOptions])
 		}
 		arg1 = variadicArgs
 		run(
@@ -1565,7 +1565,7 @@ func (_c *Txn_DisableNAC_Call) Return(err error) *Txn_DisableNAC_Call {
 	return _c
 }
 
-func (_c *Txn_DisableNAC_Call) RunAndReturn(run func(ctx context.Context, opts ...options.Lister[options.DisableNACOptions]) error) *Txn_DisableNAC_Call {
+func (_c *Txn_DisableNAC_Call) RunAndReturn(run func(ctx context.Context, opts ...options.Enumerable[options.DisableNACOptions]) error) *Txn_DisableNAC_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -1604,7 +1604,7 @@ func (_c *Txn_Discard_Call) RunAndReturn(run func()) *Txn_Discard_Call {
 }
 
 // ExecRequest provides a mock function for the type Txn
-func (_mock *Txn) ExecRequest(ctx context.Context, request string, opts ...options.Lister[options.ExecRequestOptions]) *client.RequestResult {
+func (_mock *Txn) ExecRequest(ctx context.Context, request string, opts ...options.Enumerable[options.ExecRequestOptions]) *client.RequestResult {
 	var tmpRet mock.Arguments
 	if len(opts) > 0 {
 		tmpRet = _mock.Called(ctx, request, opts)
@@ -1618,7 +1618,7 @@ func (_mock *Txn) ExecRequest(ctx context.Context, request string, opts ...optio
 	}
 
 	var r0 *client.RequestResult
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, ...options.Lister[options.ExecRequestOptions]) *client.RequestResult); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, ...options.Enumerable[options.ExecRequestOptions]) *client.RequestResult); ok {
 		r0 = returnFunc(ctx, request, opts...)
 	} else {
 		if ret.Get(0) != nil {
@@ -1642,7 +1642,7 @@ func (_e *Txn_Expecter) ExecRequest(ctx interface{}, request interface{}, opts .
 		append([]interface{}{ctx, request}, opts...)...)}
 }
 
-func (_c *Txn_ExecRequest_Call) Run(run func(ctx context.Context, request string, opts ...options.Lister[options.ExecRequestOptions])) *Txn_ExecRequest_Call {
+func (_c *Txn_ExecRequest_Call) Run(run func(ctx context.Context, request string, opts ...options.Enumerable[options.ExecRequestOptions])) *Txn_ExecRequest_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -1652,10 +1652,10 @@ func (_c *Txn_ExecRequest_Call) Run(run func(ctx context.Context, request string
 		if args[1] != nil {
 			arg1 = args[1].(string)
 		}
-		var arg2 []options.Lister[options.ExecRequestOptions]
-		var variadicArgs []options.Lister[options.ExecRequestOptions]
+		var arg2 []options.Enumerable[options.ExecRequestOptions]
+		var variadicArgs []options.Enumerable[options.ExecRequestOptions]
 		if len(args) > 2 {
-			variadicArgs = args[2].([]options.Lister[options.ExecRequestOptions])
+			variadicArgs = args[2].([]options.Enumerable[options.ExecRequestOptions])
 		}
 		arg2 = variadicArgs
 		run(
@@ -1672,13 +1672,13 @@ func (_c *Txn_ExecRequest_Call) Return(requestResult *client.RequestResult) *Txn
 	return _c
 }
 
-func (_c *Txn_ExecRequest_Call) RunAndReturn(run func(ctx context.Context, request string, opts ...options.Lister[options.ExecRequestOptions]) *client.RequestResult) *Txn_ExecRequest_Call {
+func (_c *Txn_ExecRequest_Call) RunAndReturn(run func(ctx context.Context, request string, opts ...options.Enumerable[options.ExecRequestOptions]) *client.RequestResult) *Txn_ExecRequest_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetAllIndexes provides a mock function for the type Txn
-func (_mock *Txn) GetAllIndexes(ctx context.Context, opts ...options.Lister[options.GetAllIndexesOptions]) (map[client.CollectionName][]client.IndexDescription, error) {
+func (_mock *Txn) GetAllIndexes(ctx context.Context, opts ...options.Enumerable[options.GetAllIndexesOptions]) (map[client.CollectionName][]client.IndexDescription, error) {
 	var tmpRet mock.Arguments
 	if len(opts) > 0 {
 		tmpRet = _mock.Called(ctx, opts)
@@ -1693,17 +1693,17 @@ func (_mock *Txn) GetAllIndexes(ctx context.Context, opts ...options.Lister[opti
 
 	var r0 map[client.CollectionName][]client.IndexDescription
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, ...options.Lister[options.GetAllIndexesOptions]) (map[client.CollectionName][]client.IndexDescription, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, ...options.Enumerable[options.GetAllIndexesOptions]) (map[client.CollectionName][]client.IndexDescription, error)); ok {
 		return returnFunc(ctx, opts...)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, ...options.Lister[options.GetAllIndexesOptions]) map[client.CollectionName][]client.IndexDescription); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, ...options.Enumerable[options.GetAllIndexesOptions]) map[client.CollectionName][]client.IndexDescription); ok {
 		r0 = returnFunc(ctx, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(map[client.CollectionName][]client.IndexDescription)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, ...options.Lister[options.GetAllIndexesOptions]) error); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, ...options.Enumerable[options.GetAllIndexesOptions]) error); ok {
 		r1 = returnFunc(ctx, opts...)
 	} else {
 		r1 = ret.Error(1)
@@ -1724,16 +1724,16 @@ func (_e *Txn_Expecter) GetAllIndexes(ctx interface{}, opts ...interface{}) *Txn
 		append([]interface{}{ctx}, opts...)...)}
 }
 
-func (_c *Txn_GetAllIndexes_Call) Run(run func(ctx context.Context, opts ...options.Lister[options.GetAllIndexesOptions])) *Txn_GetAllIndexes_Call {
+func (_c *Txn_GetAllIndexes_Call) Run(run func(ctx context.Context, opts ...options.Enumerable[options.GetAllIndexesOptions])) *Txn_GetAllIndexes_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
 			arg0 = args[0].(context.Context)
 		}
-		var arg1 []options.Lister[options.GetAllIndexesOptions]
-		var variadicArgs []options.Lister[options.GetAllIndexesOptions]
+		var arg1 []options.Enumerable[options.GetAllIndexesOptions]
+		var variadicArgs []options.Enumerable[options.GetAllIndexesOptions]
 		if len(args) > 1 {
-			variadicArgs = args[1].([]options.Lister[options.GetAllIndexesOptions])
+			variadicArgs = args[1].([]options.Enumerable[options.GetAllIndexesOptions])
 		}
 		arg1 = variadicArgs
 		run(
@@ -1749,13 +1749,13 @@ func (_c *Txn_GetAllIndexes_Call) Return(vToIndexDescriptions map[client.Collect
 	return _c
 }
 
-func (_c *Txn_GetAllIndexes_Call) RunAndReturn(run func(ctx context.Context, opts ...options.Lister[options.GetAllIndexesOptions]) (map[client.CollectionName][]client.IndexDescription, error)) *Txn_GetAllIndexes_Call {
+func (_c *Txn_GetAllIndexes_Call) RunAndReturn(run func(ctx context.Context, opts ...options.Enumerable[options.GetAllIndexesOptions]) (map[client.CollectionName][]client.IndexDescription, error)) *Txn_GetAllIndexes_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetCollectionByName provides a mock function for the type Txn
-func (_mock *Txn) GetCollectionByName(ctx context.Context, name client.CollectionName, opts ...options.Lister[options.GetCollectionByNameOptions]) (client.Collection, error) {
+func (_mock *Txn) GetCollectionByName(ctx context.Context, name client.CollectionName, opts ...options.Enumerable[options.GetCollectionByNameOptions]) (client.Collection, error) {
 	var tmpRet mock.Arguments
 	if len(opts) > 0 {
 		tmpRet = _mock.Called(ctx, name, opts)
@@ -1770,17 +1770,17 @@ func (_mock *Txn) GetCollectionByName(ctx context.Context, name client.Collectio
 
 	var r0 client.Collection
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, client.CollectionName, ...options.Lister[options.GetCollectionByNameOptions]) (client.Collection, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, client.CollectionName, ...options.Enumerable[options.GetCollectionByNameOptions]) (client.Collection, error)); ok {
 		return returnFunc(ctx, name, opts...)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, client.CollectionName, ...options.Lister[options.GetCollectionByNameOptions]) client.Collection); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, client.CollectionName, ...options.Enumerable[options.GetCollectionByNameOptions]) client.Collection); ok {
 		r0 = returnFunc(ctx, name, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(client.Collection)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, client.CollectionName, ...options.Lister[options.GetCollectionByNameOptions]) error); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, client.CollectionName, ...options.Enumerable[options.GetCollectionByNameOptions]) error); ok {
 		r1 = returnFunc(ctx, name, opts...)
 	} else {
 		r1 = ret.Error(1)
@@ -1802,7 +1802,7 @@ func (_e *Txn_Expecter) GetCollectionByName(ctx interface{}, name interface{}, o
 		append([]interface{}{ctx, name}, opts...)...)}
 }
 
-func (_c *Txn_GetCollectionByName_Call) Run(run func(ctx context.Context, name client.CollectionName, opts ...options.Lister[options.GetCollectionByNameOptions])) *Txn_GetCollectionByName_Call {
+func (_c *Txn_GetCollectionByName_Call) Run(run func(ctx context.Context, name client.CollectionName, opts ...options.Enumerable[options.GetCollectionByNameOptions])) *Txn_GetCollectionByName_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -1812,10 +1812,10 @@ func (_c *Txn_GetCollectionByName_Call) Run(run func(ctx context.Context, name c
 		if args[1] != nil {
 			arg1 = args[1].(client.CollectionName)
 		}
-		var arg2 []options.Lister[options.GetCollectionByNameOptions]
-		var variadicArgs []options.Lister[options.GetCollectionByNameOptions]
+		var arg2 []options.Enumerable[options.GetCollectionByNameOptions]
+		var variadicArgs []options.Enumerable[options.GetCollectionByNameOptions]
 		if len(args) > 2 {
-			variadicArgs = args[2].([]options.Lister[options.GetCollectionByNameOptions])
+			variadicArgs = args[2].([]options.Enumerable[options.GetCollectionByNameOptions])
 		}
 		arg2 = variadicArgs
 		run(
@@ -1832,13 +1832,13 @@ func (_c *Txn_GetCollectionByName_Call) Return(collection client.Collection, err
 	return _c
 }
 
-func (_c *Txn_GetCollectionByName_Call) RunAndReturn(run func(ctx context.Context, name client.CollectionName, opts ...options.Lister[options.GetCollectionByNameOptions]) (client.Collection, error)) *Txn_GetCollectionByName_Call {
+func (_c *Txn_GetCollectionByName_Call) RunAndReturn(run func(ctx context.Context, name client.CollectionName, opts ...options.Enumerable[options.GetCollectionByNameOptions]) (client.Collection, error)) *Txn_GetCollectionByName_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetCollections provides a mock function for the type Txn
-func (_mock *Txn) GetCollections(ctx context.Context, opts ...options.Lister[options.GetCollectionsOptions]) ([]client.Collection, error) {
+func (_mock *Txn) GetCollections(ctx context.Context, opts ...options.Enumerable[options.GetCollectionsOptions]) ([]client.Collection, error) {
 	var tmpRet mock.Arguments
 	if len(opts) > 0 {
 		tmpRet = _mock.Called(ctx, opts)
@@ -1853,17 +1853,17 @@ func (_mock *Txn) GetCollections(ctx context.Context, opts ...options.Lister[opt
 
 	var r0 []client.Collection
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, ...options.Lister[options.GetCollectionsOptions]) ([]client.Collection, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, ...options.Enumerable[options.GetCollectionsOptions]) ([]client.Collection, error)); ok {
 		return returnFunc(ctx, opts...)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, ...options.Lister[options.GetCollectionsOptions]) []client.Collection); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, ...options.Enumerable[options.GetCollectionsOptions]) []client.Collection); ok {
 		r0 = returnFunc(ctx, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]client.Collection)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, ...options.Lister[options.GetCollectionsOptions]) error); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, ...options.Enumerable[options.GetCollectionsOptions]) error); ok {
 		r1 = returnFunc(ctx, opts...)
 	} else {
 		r1 = ret.Error(1)
@@ -1884,16 +1884,16 @@ func (_e *Txn_Expecter) GetCollections(ctx interface{}, opts ...interface{}) *Tx
 		append([]interface{}{ctx}, opts...)...)}
 }
 
-func (_c *Txn_GetCollections_Call) Run(run func(ctx context.Context, opts ...options.Lister[options.GetCollectionsOptions])) *Txn_GetCollections_Call {
+func (_c *Txn_GetCollections_Call) Run(run func(ctx context.Context, opts ...options.Enumerable[options.GetCollectionsOptions])) *Txn_GetCollections_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
 			arg0 = args[0].(context.Context)
 		}
-		var arg1 []options.Lister[options.GetCollectionsOptions]
-		var variadicArgs []options.Lister[options.GetCollectionsOptions]
+		var arg1 []options.Enumerable[options.GetCollectionsOptions]
+		var variadicArgs []options.Enumerable[options.GetCollectionsOptions]
 		if len(args) > 1 {
-			variadicArgs = args[1].([]options.Lister[options.GetCollectionsOptions])
+			variadicArgs = args[1].([]options.Enumerable[options.GetCollectionsOptions])
 		}
 		arg1 = variadicArgs
 		run(
@@ -1909,13 +1909,13 @@ func (_c *Txn_GetCollections_Call) Return(collections []client.Collection, err e
 	return _c
 }
 
-func (_c *Txn_GetCollections_Call) RunAndReturn(run func(ctx context.Context, opts ...options.Lister[options.GetCollectionsOptions]) ([]client.Collection, error)) *Txn_GetCollections_Call {
+func (_c *Txn_GetCollections_Call) RunAndReturn(run func(ctx context.Context, opts ...options.Enumerable[options.GetCollectionsOptions]) ([]client.Collection, error)) *Txn_GetCollections_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetNACStatus provides a mock function for the type Txn
-func (_mock *Txn) GetNACStatus(ctx context.Context, opts ...options.Lister[options.GetNACStatusOptions]) (client.NACStatusResult, error) {
+func (_mock *Txn) GetNACStatus(ctx context.Context, opts ...options.Enumerable[options.GetNACStatusOptions]) (client.NACStatusResult, error) {
 	var tmpRet mock.Arguments
 	if len(opts) > 0 {
 		tmpRet = _mock.Called(ctx, opts)
@@ -1930,15 +1930,15 @@ func (_mock *Txn) GetNACStatus(ctx context.Context, opts ...options.Lister[optio
 
 	var r0 client.NACStatusResult
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, ...options.Lister[options.GetNACStatusOptions]) (client.NACStatusResult, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, ...options.Enumerable[options.GetNACStatusOptions]) (client.NACStatusResult, error)); ok {
 		return returnFunc(ctx, opts...)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, ...options.Lister[options.GetNACStatusOptions]) client.NACStatusResult); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, ...options.Enumerable[options.GetNACStatusOptions]) client.NACStatusResult); ok {
 		r0 = returnFunc(ctx, opts...)
 	} else {
 		r0 = ret.Get(0).(client.NACStatusResult)
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, ...options.Lister[options.GetNACStatusOptions]) error); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, ...options.Enumerable[options.GetNACStatusOptions]) error); ok {
 		r1 = returnFunc(ctx, opts...)
 	} else {
 		r1 = ret.Error(1)
@@ -1959,16 +1959,16 @@ func (_e *Txn_Expecter) GetNACStatus(ctx interface{}, opts ...interface{}) *Txn_
 		append([]interface{}{ctx}, opts...)...)}
 }
 
-func (_c *Txn_GetNACStatus_Call) Run(run func(ctx context.Context, opts ...options.Lister[options.GetNACStatusOptions])) *Txn_GetNACStatus_Call {
+func (_c *Txn_GetNACStatus_Call) Run(run func(ctx context.Context, opts ...options.Enumerable[options.GetNACStatusOptions])) *Txn_GetNACStatus_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
 			arg0 = args[0].(context.Context)
 		}
-		var arg1 []options.Lister[options.GetNACStatusOptions]
-		var variadicArgs []options.Lister[options.GetNACStatusOptions]
+		var arg1 []options.Enumerable[options.GetNACStatusOptions]
+		var variadicArgs []options.Enumerable[options.GetNACStatusOptions]
 		if len(args) > 1 {
-			variadicArgs = args[1].([]options.Lister[options.GetNACStatusOptions])
+			variadicArgs = args[1].([]options.Enumerable[options.GetNACStatusOptions])
 		}
 		arg1 = variadicArgs
 		run(
@@ -1984,7 +1984,7 @@ func (_c *Txn_GetNACStatus_Call) Return(nACStatusResult client.NACStatusResult, 
 	return _c
 }
 
-func (_c *Txn_GetNACStatus_Call) RunAndReturn(run func(ctx context.Context, opts ...options.Lister[options.GetNACStatusOptions]) (client.NACStatusResult, error)) *Txn_GetNACStatus_Call {
+func (_c *Txn_GetNACStatus_Call) RunAndReturn(run func(ctx context.Context, opts ...options.Enumerable[options.GetNACStatusOptions]) (client.NACStatusResult, error)) *Txn_GetNACStatus_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -2156,7 +2156,7 @@ func (_c *Txn_ListAllEncryptedIndexes_Call) RunAndReturn(run func(context1 conte
 }
 
 // ListLenses provides a mock function for the type Txn
-func (_mock *Txn) ListLenses(ctx context.Context, opts ...options.Lister[options.ListLensesOptions]) (map[string]model.Lens, error) {
+func (_mock *Txn) ListLenses(ctx context.Context, opts ...options.Enumerable[options.ListLensesOptions]) (map[string]model.Lens, error) {
 	var tmpRet mock.Arguments
 	if len(opts) > 0 {
 		tmpRet = _mock.Called(ctx, opts)
@@ -2171,17 +2171,17 @@ func (_mock *Txn) ListLenses(ctx context.Context, opts ...options.Lister[options
 
 	var r0 map[string]model.Lens
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, ...options.Lister[options.ListLensesOptions]) (map[string]model.Lens, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, ...options.Enumerable[options.ListLensesOptions]) (map[string]model.Lens, error)); ok {
 		return returnFunc(ctx, opts...)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, ...options.Lister[options.ListLensesOptions]) map[string]model.Lens); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, ...options.Enumerable[options.ListLensesOptions]) map[string]model.Lens); ok {
 		r0 = returnFunc(ctx, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(map[string]model.Lens)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, ...options.Lister[options.ListLensesOptions]) error); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, ...options.Enumerable[options.ListLensesOptions]) error); ok {
 		r1 = returnFunc(ctx, opts...)
 	} else {
 		r1 = ret.Error(1)
@@ -2202,16 +2202,16 @@ func (_e *Txn_Expecter) ListLenses(ctx interface{}, opts ...interface{}) *Txn_Li
 		append([]interface{}{ctx}, opts...)...)}
 }
 
-func (_c *Txn_ListLenses_Call) Run(run func(ctx context.Context, opts ...options.Lister[options.ListLensesOptions])) *Txn_ListLenses_Call {
+func (_c *Txn_ListLenses_Call) Run(run func(ctx context.Context, opts ...options.Enumerable[options.ListLensesOptions])) *Txn_ListLenses_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
 			arg0 = args[0].(context.Context)
 		}
-		var arg1 []options.Lister[options.ListLensesOptions]
-		var variadicArgs []options.Lister[options.ListLensesOptions]
+		var arg1 []options.Enumerable[options.ListLensesOptions]
+		var variadicArgs []options.Enumerable[options.ListLensesOptions]
 		if len(args) > 1 {
-			variadicArgs = args[1].([]options.Lister[options.ListLensesOptions])
+			variadicArgs = args[1].([]options.Enumerable[options.ListLensesOptions])
 		}
 		arg1 = variadicArgs
 		run(
@@ -2227,13 +2227,13 @@ func (_c *Txn_ListLenses_Call) Return(stringToLens map[string]model.Lens, err er
 	return _c
 }
 
-func (_c *Txn_ListLenses_Call) RunAndReturn(run func(ctx context.Context, opts ...options.Lister[options.ListLensesOptions]) (map[string]model.Lens, error)) *Txn_ListLenses_Call {
+func (_c *Txn_ListLenses_Call) RunAndReturn(run func(ctx context.Context, opts ...options.Enumerable[options.ListLensesOptions]) (map[string]model.Lens, error)) *Txn_ListLenses_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // ListP2PCollections provides a mock function for the type Txn
-func (_mock *Txn) ListP2PCollections(ctx context.Context, opts ...options.Lister[options.ListP2PCollectionsOptions]) ([]string, error) {
+func (_mock *Txn) ListP2PCollections(ctx context.Context, opts ...options.Enumerable[options.ListP2PCollectionsOptions]) ([]string, error) {
 	var tmpRet mock.Arguments
 	if len(opts) > 0 {
 		tmpRet = _mock.Called(ctx, opts)
@@ -2248,17 +2248,17 @@ func (_mock *Txn) ListP2PCollections(ctx context.Context, opts ...options.Lister
 
 	var r0 []string
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, ...options.Lister[options.ListP2PCollectionsOptions]) ([]string, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, ...options.Enumerable[options.ListP2PCollectionsOptions]) ([]string, error)); ok {
 		return returnFunc(ctx, opts...)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, ...options.Lister[options.ListP2PCollectionsOptions]) []string); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, ...options.Enumerable[options.ListP2PCollectionsOptions]) []string); ok {
 		r0 = returnFunc(ctx, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]string)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, ...options.Lister[options.ListP2PCollectionsOptions]) error); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, ...options.Enumerable[options.ListP2PCollectionsOptions]) error); ok {
 		r1 = returnFunc(ctx, opts...)
 	} else {
 		r1 = ret.Error(1)
@@ -2279,16 +2279,16 @@ func (_e *Txn_Expecter) ListP2PCollections(ctx interface{}, opts ...interface{})
 		append([]interface{}{ctx}, opts...)...)}
 }
 
-func (_c *Txn_ListP2PCollections_Call) Run(run func(ctx context.Context, opts ...options.Lister[options.ListP2PCollectionsOptions])) *Txn_ListP2PCollections_Call {
+func (_c *Txn_ListP2PCollections_Call) Run(run func(ctx context.Context, opts ...options.Enumerable[options.ListP2PCollectionsOptions])) *Txn_ListP2PCollections_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
 			arg0 = args[0].(context.Context)
 		}
-		var arg1 []options.Lister[options.ListP2PCollectionsOptions]
-		var variadicArgs []options.Lister[options.ListP2PCollectionsOptions]
+		var arg1 []options.Enumerable[options.ListP2PCollectionsOptions]
+		var variadicArgs []options.Enumerable[options.ListP2PCollectionsOptions]
 		if len(args) > 1 {
-			variadicArgs = args[1].([]options.Lister[options.ListP2PCollectionsOptions])
+			variadicArgs = args[1].([]options.Enumerable[options.ListP2PCollectionsOptions])
 		}
 		arg1 = variadicArgs
 		run(
@@ -2304,13 +2304,13 @@ func (_c *Txn_ListP2PCollections_Call) Return(strings []string, err error) *Txn_
 	return _c
 }
 
-func (_c *Txn_ListP2PCollections_Call) RunAndReturn(run func(ctx context.Context, opts ...options.Lister[options.ListP2PCollectionsOptions]) ([]string, error)) *Txn_ListP2PCollections_Call {
+func (_c *Txn_ListP2PCollections_Call) RunAndReturn(run func(ctx context.Context, opts ...options.Enumerable[options.ListP2PCollectionsOptions]) ([]string, error)) *Txn_ListP2PCollections_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // ListP2PDocuments provides a mock function for the type Txn
-func (_mock *Txn) ListP2PDocuments(ctx context.Context, opts ...options.Lister[options.ListP2PDocumentsOptions]) ([]string, error) {
+func (_mock *Txn) ListP2PDocuments(ctx context.Context, opts ...options.Enumerable[options.ListP2PDocumentsOptions]) ([]string, error) {
 	var tmpRet mock.Arguments
 	if len(opts) > 0 {
 		tmpRet = _mock.Called(ctx, opts)
@@ -2325,17 +2325,17 @@ func (_mock *Txn) ListP2PDocuments(ctx context.Context, opts ...options.Lister[o
 
 	var r0 []string
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, ...options.Lister[options.ListP2PDocumentsOptions]) ([]string, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, ...options.Enumerable[options.ListP2PDocumentsOptions]) ([]string, error)); ok {
 		return returnFunc(ctx, opts...)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, ...options.Lister[options.ListP2PDocumentsOptions]) []string); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, ...options.Enumerable[options.ListP2PDocumentsOptions]) []string); ok {
 		r0 = returnFunc(ctx, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]string)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, ...options.Lister[options.ListP2PDocumentsOptions]) error); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, ...options.Enumerable[options.ListP2PDocumentsOptions]) error); ok {
 		r1 = returnFunc(ctx, opts...)
 	} else {
 		r1 = ret.Error(1)
@@ -2356,16 +2356,16 @@ func (_e *Txn_Expecter) ListP2PDocuments(ctx interface{}, opts ...interface{}) *
 		append([]interface{}{ctx}, opts...)...)}
 }
 
-func (_c *Txn_ListP2PDocuments_Call) Run(run func(ctx context.Context, opts ...options.Lister[options.ListP2PDocumentsOptions])) *Txn_ListP2PDocuments_Call {
+func (_c *Txn_ListP2PDocuments_Call) Run(run func(ctx context.Context, opts ...options.Enumerable[options.ListP2PDocumentsOptions])) *Txn_ListP2PDocuments_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
 			arg0 = args[0].(context.Context)
 		}
-		var arg1 []options.Lister[options.ListP2PDocumentsOptions]
-		var variadicArgs []options.Lister[options.ListP2PDocumentsOptions]
+		var arg1 []options.Enumerable[options.ListP2PDocumentsOptions]
+		var variadicArgs []options.Enumerable[options.ListP2PDocumentsOptions]
 		if len(args) > 1 {
-			variadicArgs = args[1].([]options.Lister[options.ListP2PDocumentsOptions])
+			variadicArgs = args[1].([]options.Enumerable[options.ListP2PDocumentsOptions])
 		}
 		arg1 = variadicArgs
 		run(
@@ -2381,13 +2381,13 @@ func (_c *Txn_ListP2PDocuments_Call) Return(strings []string, err error) *Txn_Li
 	return _c
 }
 
-func (_c *Txn_ListP2PDocuments_Call) RunAndReturn(run func(ctx context.Context, opts ...options.Lister[options.ListP2PDocumentsOptions]) ([]string, error)) *Txn_ListP2PDocuments_Call {
+func (_c *Txn_ListP2PDocuments_Call) RunAndReturn(run func(ctx context.Context, opts ...options.Enumerable[options.ListP2PDocumentsOptions]) ([]string, error)) *Txn_ListP2PDocuments_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // ListReplicators provides a mock function for the type Txn
-func (_mock *Txn) ListReplicators(ctx context.Context, opts ...options.Lister[options.ListReplicatorsOptions]) ([]client.Replicator, error) {
+func (_mock *Txn) ListReplicators(ctx context.Context, opts ...options.Enumerable[options.ListReplicatorsOptions]) ([]client.Replicator, error) {
 	var tmpRet mock.Arguments
 	if len(opts) > 0 {
 		tmpRet = _mock.Called(ctx, opts)
@@ -2402,17 +2402,17 @@ func (_mock *Txn) ListReplicators(ctx context.Context, opts ...options.Lister[op
 
 	var r0 []client.Replicator
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, ...options.Lister[options.ListReplicatorsOptions]) ([]client.Replicator, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, ...options.Enumerable[options.ListReplicatorsOptions]) ([]client.Replicator, error)); ok {
 		return returnFunc(ctx, opts...)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, ...options.Lister[options.ListReplicatorsOptions]) []client.Replicator); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, ...options.Enumerable[options.ListReplicatorsOptions]) []client.Replicator); ok {
 		r0 = returnFunc(ctx, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]client.Replicator)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, ...options.Lister[options.ListReplicatorsOptions]) error); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, ...options.Enumerable[options.ListReplicatorsOptions]) error); ok {
 		r1 = returnFunc(ctx, opts...)
 	} else {
 		r1 = ret.Error(1)
@@ -2433,16 +2433,16 @@ func (_e *Txn_Expecter) ListReplicators(ctx interface{}, opts ...interface{}) *T
 		append([]interface{}{ctx}, opts...)...)}
 }
 
-func (_c *Txn_ListReplicators_Call) Run(run func(ctx context.Context, opts ...options.Lister[options.ListReplicatorsOptions])) *Txn_ListReplicators_Call {
+func (_c *Txn_ListReplicators_Call) Run(run func(ctx context.Context, opts ...options.Enumerable[options.ListReplicatorsOptions])) *Txn_ListReplicators_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
 			arg0 = args[0].(context.Context)
 		}
-		var arg1 []options.Lister[options.ListReplicatorsOptions]
-		var variadicArgs []options.Lister[options.ListReplicatorsOptions]
+		var arg1 []options.Enumerable[options.ListReplicatorsOptions]
+		var variadicArgs []options.Enumerable[options.ListReplicatorsOptions]
 		if len(args) > 1 {
-			variadicArgs = args[1].([]options.Lister[options.ListReplicatorsOptions])
+			variadicArgs = args[1].([]options.Enumerable[options.ListReplicatorsOptions])
 		}
 		arg1 = variadicArgs
 		run(
@@ -2458,13 +2458,13 @@ func (_c *Txn_ListReplicators_Call) Return(replicators []client.Replicator, err 
 	return _c
 }
 
-func (_c *Txn_ListReplicators_Call) RunAndReturn(run func(ctx context.Context, opts ...options.Lister[options.ListReplicatorsOptions]) ([]client.Replicator, error)) *Txn_ListReplicators_Call {
+func (_c *Txn_ListReplicators_Call) RunAndReturn(run func(ctx context.Context, opts ...options.Enumerable[options.ListReplicatorsOptions]) ([]client.Replicator, error)) *Txn_ListReplicators_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // PatchCollection provides a mock function for the type Txn
-func (_mock *Txn) PatchCollection(ctx context.Context, patch string, migration immutable.Option[model.Lens], opts ...options.Lister[options.PatchCollectionOptions]) error {
+func (_mock *Txn) PatchCollection(ctx context.Context, patch string, migration immutable.Option[model.Lens], opts ...options.Enumerable[options.PatchCollectionOptions]) error {
 	var tmpRet mock.Arguments
 	if len(opts) > 0 {
 		tmpRet = _mock.Called(ctx, patch, migration, opts)
@@ -2478,7 +2478,7 @@ func (_mock *Txn) PatchCollection(ctx context.Context, patch string, migration i
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, immutable.Option[model.Lens], ...options.Lister[options.PatchCollectionOptions]) error); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, immutable.Option[model.Lens], ...options.Enumerable[options.PatchCollectionOptions]) error); ok {
 		r0 = returnFunc(ctx, patch, migration, opts...)
 	} else {
 		r0 = ret.Error(0)
@@ -2501,7 +2501,7 @@ func (_e *Txn_Expecter) PatchCollection(ctx interface{}, patch interface{}, migr
 		append([]interface{}{ctx, patch, migration}, opts...)...)}
 }
 
-func (_c *Txn_PatchCollection_Call) Run(run func(ctx context.Context, patch string, migration immutable.Option[model.Lens], opts ...options.Lister[options.PatchCollectionOptions])) *Txn_PatchCollection_Call {
+func (_c *Txn_PatchCollection_Call) Run(run func(ctx context.Context, patch string, migration immutable.Option[model.Lens], opts ...options.Enumerable[options.PatchCollectionOptions])) *Txn_PatchCollection_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -2515,10 +2515,10 @@ func (_c *Txn_PatchCollection_Call) Run(run func(ctx context.Context, patch stri
 		if args[2] != nil {
 			arg2 = args[2].(immutable.Option[model.Lens])
 		}
-		var arg3 []options.Lister[options.PatchCollectionOptions]
-		var variadicArgs []options.Lister[options.PatchCollectionOptions]
+		var arg3 []options.Enumerable[options.PatchCollectionOptions]
+		var variadicArgs []options.Enumerable[options.PatchCollectionOptions]
 		if len(args) > 3 {
-			variadicArgs = args[3].([]options.Lister[options.PatchCollectionOptions])
+			variadicArgs = args[3].([]options.Enumerable[options.PatchCollectionOptions])
 		}
 		arg3 = variadicArgs
 		run(
@@ -2536,13 +2536,13 @@ func (_c *Txn_PatchCollection_Call) Return(err error) *Txn_PatchCollection_Call 
 	return _c
 }
 
-func (_c *Txn_PatchCollection_Call) RunAndReturn(run func(ctx context.Context, patch string, migration immutable.Option[model.Lens], opts ...options.Lister[options.PatchCollectionOptions]) error) *Txn_PatchCollection_Call {
+func (_c *Txn_PatchCollection_Call) RunAndReturn(run func(ctx context.Context, patch string, migration immutable.Option[model.Lens], opts ...options.Enumerable[options.PatchCollectionOptions]) error) *Txn_PatchCollection_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // PeerInfo provides a mock function for the type Txn
-func (_mock *Txn) PeerInfo(ctx context.Context, opts ...options.Lister[options.PeerInfoOptions]) ([]string, error) {
+func (_mock *Txn) PeerInfo(ctx context.Context, opts ...options.Enumerable[options.PeerInfoOptions]) ([]string, error) {
 	var tmpRet mock.Arguments
 	if len(opts) > 0 {
 		tmpRet = _mock.Called(ctx, opts)
@@ -2557,17 +2557,17 @@ func (_mock *Txn) PeerInfo(ctx context.Context, opts ...options.Lister[options.P
 
 	var r0 []string
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, ...options.Lister[options.PeerInfoOptions]) ([]string, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, ...options.Enumerable[options.PeerInfoOptions]) ([]string, error)); ok {
 		return returnFunc(ctx, opts...)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, ...options.Lister[options.PeerInfoOptions]) []string); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, ...options.Enumerable[options.PeerInfoOptions]) []string); ok {
 		r0 = returnFunc(ctx, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]string)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, ...options.Lister[options.PeerInfoOptions]) error); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, ...options.Enumerable[options.PeerInfoOptions]) error); ok {
 		r1 = returnFunc(ctx, opts...)
 	} else {
 		r1 = ret.Error(1)
@@ -2588,16 +2588,16 @@ func (_e *Txn_Expecter) PeerInfo(ctx interface{}, opts ...interface{}) *Txn_Peer
 		append([]interface{}{ctx}, opts...)...)}
 }
 
-func (_c *Txn_PeerInfo_Call) Run(run func(ctx context.Context, opts ...options.Lister[options.PeerInfoOptions])) *Txn_PeerInfo_Call {
+func (_c *Txn_PeerInfo_Call) Run(run func(ctx context.Context, opts ...options.Enumerable[options.PeerInfoOptions])) *Txn_PeerInfo_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
 			arg0 = args[0].(context.Context)
 		}
-		var arg1 []options.Lister[options.PeerInfoOptions]
-		var variadicArgs []options.Lister[options.PeerInfoOptions]
+		var arg1 []options.Enumerable[options.PeerInfoOptions]
+		var variadicArgs []options.Enumerable[options.PeerInfoOptions]
 		if len(args) > 1 {
-			variadicArgs = args[1].([]options.Lister[options.PeerInfoOptions])
+			variadicArgs = args[1].([]options.Enumerable[options.PeerInfoOptions])
 		}
 		arg1 = variadicArgs
 		run(
@@ -2613,7 +2613,7 @@ func (_c *Txn_PeerInfo_Call) Return(strings []string, err error) *Txn_PeerInfo_C
 	return _c
 }
 
-func (_c *Txn_PeerInfo_Call) RunAndReturn(run func(ctx context.Context, opts ...options.Lister[options.PeerInfoOptions]) ([]string, error)) *Txn_PeerInfo_Call {
+func (_c *Txn_PeerInfo_Call) RunAndReturn(run func(ctx context.Context, opts ...options.Enumerable[options.PeerInfoOptions]) ([]string, error)) *Txn_PeerInfo_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -2670,7 +2670,7 @@ func (_c *Txn_PrintDump_Call) RunAndReturn(run func(ctx context.Context) error) 
 }
 
 // ReEnableNAC provides a mock function for the type Txn
-func (_mock *Txn) ReEnableNAC(ctx context.Context, opts ...options.Lister[options.ReEnableNACOptions]) error {
+func (_mock *Txn) ReEnableNAC(ctx context.Context, opts ...options.Enumerable[options.ReEnableNACOptions]) error {
 	var tmpRet mock.Arguments
 	if len(opts) > 0 {
 		tmpRet = _mock.Called(ctx, opts)
@@ -2684,7 +2684,7 @@ func (_mock *Txn) ReEnableNAC(ctx context.Context, opts ...options.Lister[option
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, ...options.Lister[options.ReEnableNACOptions]) error); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, ...options.Enumerable[options.ReEnableNACOptions]) error); ok {
 		r0 = returnFunc(ctx, opts...)
 	} else {
 		r0 = ret.Error(0)
@@ -2705,16 +2705,16 @@ func (_e *Txn_Expecter) ReEnableNAC(ctx interface{}, opts ...interface{}) *Txn_R
 		append([]interface{}{ctx}, opts...)...)}
 }
 
-func (_c *Txn_ReEnableNAC_Call) Run(run func(ctx context.Context, opts ...options.Lister[options.ReEnableNACOptions])) *Txn_ReEnableNAC_Call {
+func (_c *Txn_ReEnableNAC_Call) Run(run func(ctx context.Context, opts ...options.Enumerable[options.ReEnableNACOptions])) *Txn_ReEnableNAC_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
 			arg0 = args[0].(context.Context)
 		}
-		var arg1 []options.Lister[options.ReEnableNACOptions]
-		var variadicArgs []options.Lister[options.ReEnableNACOptions]
+		var arg1 []options.Enumerable[options.ReEnableNACOptions]
+		var variadicArgs []options.Enumerable[options.ReEnableNACOptions]
 		if len(args) > 1 {
-			variadicArgs = args[1].([]options.Lister[options.ReEnableNACOptions])
+			variadicArgs = args[1].([]options.Enumerable[options.ReEnableNACOptions])
 		}
 		arg1 = variadicArgs
 		run(
@@ -2730,13 +2730,13 @@ func (_c *Txn_ReEnableNAC_Call) Return(err error) *Txn_ReEnableNAC_Call {
 	return _c
 }
 
-func (_c *Txn_ReEnableNAC_Call) RunAndReturn(run func(ctx context.Context, opts ...options.Lister[options.ReEnableNACOptions]) error) *Txn_ReEnableNAC_Call {
+func (_c *Txn_ReEnableNAC_Call) RunAndReturn(run func(ctx context.Context, opts ...options.Enumerable[options.ReEnableNACOptions]) error) *Txn_ReEnableNAC_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // RefreshViews provides a mock function for the type Txn
-func (_mock *Txn) RefreshViews(ctx context.Context, opts ...options.Lister[options.RefreshViewsOptions]) error {
+func (_mock *Txn) RefreshViews(ctx context.Context, opts ...options.Enumerable[options.RefreshViewsOptions]) error {
 	var tmpRet mock.Arguments
 	if len(opts) > 0 {
 		tmpRet = _mock.Called(ctx, opts)
@@ -2750,7 +2750,7 @@ func (_mock *Txn) RefreshViews(ctx context.Context, opts ...options.Lister[optio
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, ...options.Lister[options.RefreshViewsOptions]) error); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, ...options.Enumerable[options.RefreshViewsOptions]) error); ok {
 		r0 = returnFunc(ctx, opts...)
 	} else {
 		r0 = ret.Error(0)
@@ -2771,16 +2771,16 @@ func (_e *Txn_Expecter) RefreshViews(ctx interface{}, opts ...interface{}) *Txn_
 		append([]interface{}{ctx}, opts...)...)}
 }
 
-func (_c *Txn_RefreshViews_Call) Run(run func(ctx context.Context, opts ...options.Lister[options.RefreshViewsOptions])) *Txn_RefreshViews_Call {
+func (_c *Txn_RefreshViews_Call) Run(run func(ctx context.Context, opts ...options.Enumerable[options.RefreshViewsOptions])) *Txn_RefreshViews_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
 			arg0 = args[0].(context.Context)
 		}
-		var arg1 []options.Lister[options.RefreshViewsOptions]
-		var variadicArgs []options.Lister[options.RefreshViewsOptions]
+		var arg1 []options.Enumerable[options.RefreshViewsOptions]
+		var variadicArgs []options.Enumerable[options.RefreshViewsOptions]
 		if len(args) > 1 {
-			variadicArgs = args[1].([]options.Lister[options.RefreshViewsOptions])
+			variadicArgs = args[1].([]options.Enumerable[options.RefreshViewsOptions])
 		}
 		arg1 = variadicArgs
 		run(
@@ -2796,13 +2796,13 @@ func (_c *Txn_RefreshViews_Call) Return(err error) *Txn_RefreshViews_Call {
 	return _c
 }
 
-func (_c *Txn_RefreshViews_Call) RunAndReturn(run func(ctx context.Context, opts ...options.Lister[options.RefreshViewsOptions]) error) *Txn_RefreshViews_Call {
+func (_c *Txn_RefreshViews_Call) RunAndReturn(run func(ctx context.Context, opts ...options.Enumerable[options.RefreshViewsOptions]) error) *Txn_RefreshViews_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // SetActiveCollectionVersion provides a mock function for the type Txn
-func (_mock *Txn) SetActiveCollectionVersion(ctx context.Context, versionID string, opts ...options.Lister[options.SetActiveCollectionVersionOptions]) error {
+func (_mock *Txn) SetActiveCollectionVersion(ctx context.Context, versionID string, opts ...options.Enumerable[options.SetActiveCollectionVersionOptions]) error {
 	var tmpRet mock.Arguments
 	if len(opts) > 0 {
 		tmpRet = _mock.Called(ctx, versionID, opts)
@@ -2816,7 +2816,7 @@ func (_mock *Txn) SetActiveCollectionVersion(ctx context.Context, versionID stri
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, ...options.Lister[options.SetActiveCollectionVersionOptions]) error); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, ...options.Enumerable[options.SetActiveCollectionVersionOptions]) error); ok {
 		r0 = returnFunc(ctx, versionID, opts...)
 	} else {
 		r0 = ret.Error(0)
@@ -2838,7 +2838,7 @@ func (_e *Txn_Expecter) SetActiveCollectionVersion(ctx interface{}, versionID in
 		append([]interface{}{ctx, versionID}, opts...)...)}
 }
 
-func (_c *Txn_SetActiveCollectionVersion_Call) Run(run func(ctx context.Context, versionID string, opts ...options.Lister[options.SetActiveCollectionVersionOptions])) *Txn_SetActiveCollectionVersion_Call {
+func (_c *Txn_SetActiveCollectionVersion_Call) Run(run func(ctx context.Context, versionID string, opts ...options.Enumerable[options.SetActiveCollectionVersionOptions])) *Txn_SetActiveCollectionVersion_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -2848,10 +2848,10 @@ func (_c *Txn_SetActiveCollectionVersion_Call) Run(run func(ctx context.Context,
 		if args[1] != nil {
 			arg1 = args[1].(string)
 		}
-		var arg2 []options.Lister[options.SetActiveCollectionVersionOptions]
-		var variadicArgs []options.Lister[options.SetActiveCollectionVersionOptions]
+		var arg2 []options.Enumerable[options.SetActiveCollectionVersionOptions]
+		var variadicArgs []options.Enumerable[options.SetActiveCollectionVersionOptions]
 		if len(args) > 2 {
-			variadicArgs = args[2].([]options.Lister[options.SetActiveCollectionVersionOptions])
+			variadicArgs = args[2].([]options.Enumerable[options.SetActiveCollectionVersionOptions])
 		}
 		arg2 = variadicArgs
 		run(
@@ -2868,7 +2868,7 @@ func (_c *Txn_SetActiveCollectionVersion_Call) Return(err error) *Txn_SetActiveC
 	return _c
 }
 
-func (_c *Txn_SetActiveCollectionVersion_Call) RunAndReturn(run func(ctx context.Context, versionID string, opts ...options.Lister[options.SetActiveCollectionVersionOptions]) error) *Txn_SetActiveCollectionVersion_Call {
+func (_c *Txn_SetActiveCollectionVersion_Call) RunAndReturn(run func(ctx context.Context, versionID string, opts ...options.Enumerable[options.SetActiveCollectionVersionOptions]) error) *Txn_SetActiveCollectionVersion_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -3056,7 +3056,7 @@ func (_c *Txn_SyncBranchableCollection_Call) RunAndReturn(run func(ctx context.C
 }
 
 // SyncCollectionVersions provides a mock function for the type Txn
-func (_mock *Txn) SyncCollectionVersions(ctx context.Context, versionIDs []string, opts ...options.Lister[options.SyncCollectionVersionsOptions]) error {
+func (_mock *Txn) SyncCollectionVersions(ctx context.Context, versionIDs []string, opts ...options.Enumerable[options.SyncCollectionVersionsOptions]) error {
 	var tmpRet mock.Arguments
 	if len(opts) > 0 {
 		tmpRet = _mock.Called(ctx, versionIDs, opts)
@@ -3070,7 +3070,7 @@ func (_mock *Txn) SyncCollectionVersions(ctx context.Context, versionIDs []strin
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, []string, ...options.Lister[options.SyncCollectionVersionsOptions]) error); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []string, ...options.Enumerable[options.SyncCollectionVersionsOptions]) error); ok {
 		r0 = returnFunc(ctx, versionIDs, opts...)
 	} else {
 		r0 = ret.Error(0)
@@ -3092,7 +3092,7 @@ func (_e *Txn_Expecter) SyncCollectionVersions(ctx interface{}, versionIDs inter
 		append([]interface{}{ctx, versionIDs}, opts...)...)}
 }
 
-func (_c *Txn_SyncCollectionVersions_Call) Run(run func(ctx context.Context, versionIDs []string, opts ...options.Lister[options.SyncCollectionVersionsOptions])) *Txn_SyncCollectionVersions_Call {
+func (_c *Txn_SyncCollectionVersions_Call) Run(run func(ctx context.Context, versionIDs []string, opts ...options.Enumerable[options.SyncCollectionVersionsOptions])) *Txn_SyncCollectionVersions_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -3102,10 +3102,10 @@ func (_c *Txn_SyncCollectionVersions_Call) Run(run func(ctx context.Context, ver
 		if args[1] != nil {
 			arg1 = args[1].([]string)
 		}
-		var arg2 []options.Lister[options.SyncCollectionVersionsOptions]
-		var variadicArgs []options.Lister[options.SyncCollectionVersionsOptions]
+		var arg2 []options.Enumerable[options.SyncCollectionVersionsOptions]
+		var variadicArgs []options.Enumerable[options.SyncCollectionVersionsOptions]
 		if len(args) > 2 {
-			variadicArgs = args[2].([]options.Lister[options.SyncCollectionVersionsOptions])
+			variadicArgs = args[2].([]options.Enumerable[options.SyncCollectionVersionsOptions])
 		}
 		arg2 = variadicArgs
 		run(
@@ -3122,7 +3122,7 @@ func (_c *Txn_SyncCollectionVersions_Call) Return(err error) *Txn_SyncCollection
 	return _c
 }
 
-func (_c *Txn_SyncCollectionVersions_Call) RunAndReturn(run func(ctx context.Context, versionIDs []string, opts ...options.Lister[options.SyncCollectionVersionsOptions]) error) *Txn_SyncCollectionVersions_Call {
+func (_c *Txn_SyncCollectionVersions_Call) RunAndReturn(run func(ctx context.Context, versionIDs []string, opts ...options.Enumerable[options.SyncCollectionVersionsOptions]) error) *Txn_SyncCollectionVersions_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -3191,7 +3191,7 @@ func (_c *Txn_SyncDocuments_Call) RunAndReturn(run func(ctx context.Context, col
 }
 
 // VerifySignature provides a mock function for the type Txn
-func (_mock *Txn) VerifySignature(ctx context.Context, blockCid string, pubKey crypto.PublicKey, opts ...options.Lister[options.VerifySignatureOptions]) error {
+func (_mock *Txn) VerifySignature(ctx context.Context, blockCid string, pubKey crypto.PublicKey, opts ...options.Enumerable[options.VerifySignatureOptions]) error {
 	var tmpRet mock.Arguments
 	if len(opts) > 0 {
 		tmpRet = _mock.Called(ctx, blockCid, pubKey, opts)
@@ -3205,7 +3205,7 @@ func (_mock *Txn) VerifySignature(ctx context.Context, blockCid string, pubKey c
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, crypto.PublicKey, ...options.Lister[options.VerifySignatureOptions]) error); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, crypto.PublicKey, ...options.Enumerable[options.VerifySignatureOptions]) error); ok {
 		r0 = returnFunc(ctx, blockCid, pubKey, opts...)
 	} else {
 		r0 = ret.Error(0)
@@ -3228,7 +3228,7 @@ func (_e *Txn_Expecter) VerifySignature(ctx interface{}, blockCid interface{}, p
 		append([]interface{}{ctx, blockCid, pubKey}, opts...)...)}
 }
 
-func (_c *Txn_VerifySignature_Call) Run(run func(ctx context.Context, blockCid string, pubKey crypto.PublicKey, opts ...options.Lister[options.VerifySignatureOptions])) *Txn_VerifySignature_Call {
+func (_c *Txn_VerifySignature_Call) Run(run func(ctx context.Context, blockCid string, pubKey crypto.PublicKey, opts ...options.Enumerable[options.VerifySignatureOptions])) *Txn_VerifySignature_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -3242,10 +3242,10 @@ func (_c *Txn_VerifySignature_Call) Run(run func(ctx context.Context, blockCid s
 		if args[2] != nil {
 			arg2 = args[2].(crypto.PublicKey)
 		}
-		var arg3 []options.Lister[options.VerifySignatureOptions]
-		var variadicArgs []options.Lister[options.VerifySignatureOptions]
+		var arg3 []options.Enumerable[options.VerifySignatureOptions]
+		var variadicArgs []options.Enumerable[options.VerifySignatureOptions]
 		if len(args) > 3 {
-			variadicArgs = args[3].([]options.Lister[options.VerifySignatureOptions])
+			variadicArgs = args[3].([]options.Enumerable[options.VerifySignatureOptions])
 		}
 		arg3 = variadicArgs
 		run(
@@ -3263,7 +3263,7 @@ func (_c *Txn_VerifySignature_Call) Return(err error) *Txn_VerifySignature_Call 
 	return _c
 }
 
-func (_c *Txn_VerifySignature_Call) RunAndReturn(run func(ctx context.Context, blockCid string, pubKey crypto.PublicKey, opts ...options.Lister[options.VerifySignatureOptions]) error) *Txn_VerifySignature_Call {
+func (_c *Txn_VerifySignature_Call) RunAndReturn(run func(ctx context.Context, blockCid string, pubKey crypto.PublicKey, opts ...options.Enumerable[options.VerifySignatureOptions]) error) *Txn_VerifySignature_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/client/mocks/txn.go
+++ b/client/mocks/txn.go
@@ -85,7 +85,7 @@ type Txn_ActivePeers_Call struct {
 
 // ActivePeers is a helper method to define mock.On call
 //   - ctx context.Context
-//   - opts ...options.Lister[options.ActivePeersOptions]
+//   - opts ...options.Enumerable[options.ActivePeersOptions]
 func (_e *Txn_Expecter) ActivePeers(ctx interface{}, opts ...interface{}) *Txn_ActivePeers_Call {
 	return &Txn_ActivePeers_Call{Call: _e.mock.On("ActivePeers",
 		append([]interface{}{ctx}, opts...)...)}
@@ -164,7 +164,7 @@ type Txn_AddDACActorRelationship_Call struct {
 //   - docID string
 //   - relation string
 //   - targetActor string
-//   - opts ...options.Lister[options.AddDACActorRelationshipOptions]
+//   - opts ...options.Enumerable[options.AddDACActorRelationshipOptions]
 func (_e *Txn_Expecter) AddDACActorRelationship(ctx interface{}, collectionName interface{}, docID interface{}, relation interface{}, targetActor interface{}, opts ...interface{}) *Txn_AddDACActorRelationship_Call {
 	return &Txn_AddDACActorRelationship_Call{Call: _e.mock.On("AddDACActorRelationship",
 		append([]interface{}{ctx, collectionName, docID, relation, targetActor}, opts...)...)}
@@ -260,7 +260,7 @@ type Txn_AddDACPolicy_Call struct {
 // AddDACPolicy is a helper method to define mock.On call
 //   - ctx context.Context
 //   - policy string
-//   - opts ...options.Lister[options.AddDACPolicyOptions]
+//   - opts ...options.Enumerable[options.AddDACPolicyOptions]
 func (_e *Txn_Expecter) AddDACPolicy(ctx interface{}, policy interface{}, opts ...interface{}) *Txn_AddDACPolicy_Call {
 	return &Txn_AddDACPolicy_Call{Call: _e.mock.On("AddDACPolicy",
 		append([]interface{}{ctx, policy}, opts...)...)}
@@ -341,7 +341,7 @@ type Txn_AddLens_Call struct {
 // AddLens is a helper method to define mock.On call
 //   - ctx context.Context
 //   - lens model.Lens
-//   - opts ...options.Lister[options.AddLensOptions]
+//   - opts ...options.Enumerable[options.AddLensOptions]
 func (_e *Txn_Expecter) AddLens(ctx interface{}, lens interface{}, opts ...interface{}) *Txn_AddLens_Call {
 	return &Txn_AddLens_Call{Call: _e.mock.On("AddLens",
 		append([]interface{}{ctx, lens}, opts...)...)}
@@ -423,7 +423,7 @@ type Txn_AddNACActorRelationship_Call struct {
 //   - ctx context.Context
 //   - relation string
 //   - targetActor string
-//   - opts ...options.Lister[options.AddNACActorRelationshipOptions]
+//   - opts ...options.Enumerable[options.AddNACActorRelationshipOptions]
 func (_e *Txn_Expecter) AddNACActorRelationship(ctx interface{}, relation interface{}, targetActor interface{}, opts ...interface{}) *Txn_AddNACActorRelationship_Call {
 	return &Txn_AddNACActorRelationship_Call{Call: _e.mock.On("AddNACActorRelationship",
 		append([]interface{}{ctx, relation, targetActor}, opts...)...)}
@@ -511,7 +511,7 @@ type Txn_AddSchema_Call struct {
 // AddSchema is a helper method to define mock.On call
 //   - ctx context.Context
 //   - sdl string
-//   - opts ...options.Lister[options.AddSchemaOptions]
+//   - opts ...options.Enumerable[options.AddSchemaOptions]
 func (_e *Txn_Expecter) AddSchema(ctx interface{}, sdl interface{}, opts ...interface{}) *Txn_AddSchema_Call {
 	return &Txn_AddSchema_Call{Call: _e.mock.On("AddSchema",
 		append([]interface{}{ctx, sdl}, opts...)...)}
@@ -595,7 +595,7 @@ type Txn_AddView_Call struct {
 //   - ctx context.Context
 //   - gqlQuery string
 //   - sdl string
-//   - opts ...options.Lister[options.AddViewOptions]
+//   - opts ...options.Enumerable[options.AddViewOptions]
 func (_e *Txn_Expecter) AddView(ctx interface{}, gqlQuery interface{}, sdl interface{}, opts ...interface{}) *Txn_AddView_Call {
 	return &Txn_AddView_Call{Call: _e.mock.On("AddView",
 		append([]interface{}{ctx, gqlQuery, sdl}, opts...)...)}
@@ -672,7 +672,7 @@ type Txn_BasicExport_Call struct {
 // BasicExport is a helper method to define mock.On call
 //   - ctx context.Context
 //   - filepath string
-//   - opts ...options.Lister[options.BasicExportOptions]
+//   - opts ...options.Enumerable[options.BasicExportOptions]
 func (_e *Txn_Expecter) BasicExport(ctx interface{}, filepath interface{}, opts ...interface{}) *Txn_BasicExport_Call {
 	return &Txn_BasicExport_Call{Call: _e.mock.On("BasicExport",
 		append([]interface{}{ctx, filepath}, opts...)...)}
@@ -845,7 +845,7 @@ type Txn_Connect_Call struct {
 // Connect is a helper method to define mock.On call
 //   - ctx context.Context
 //   - addresses []string
-//   - opts ...options.Lister[options.ConnectOptions]
+//   - opts ...options.Enumerable[options.ConnectOptions]
 func (_e *Txn_Expecter) Connect(ctx interface{}, addresses interface{}, opts ...interface{}) *Txn_Connect_Call {
 	return &Txn_Connect_Call{Call: _e.mock.On("Connect",
 		append([]interface{}{ctx, addresses}, opts...)...)}
@@ -917,7 +917,7 @@ type Txn_CreateP2PCollections_Call struct {
 // CreateP2PCollections is a helper method to define mock.On call
 //   - ctx context.Context
 //   - collectionNames []string
-//   - opts ...options.Lister[options.CreateP2PCollectionsOptions]
+//   - opts ...options.Enumerable[options.CreateP2PCollectionsOptions]
 func (_e *Txn_Expecter) CreateP2PCollections(ctx interface{}, collectionNames interface{}, opts ...interface{}) *Txn_CreateP2PCollections_Call {
 	return &Txn_CreateP2PCollections_Call{Call: _e.mock.On("CreateP2PCollections",
 		append([]interface{}{ctx, collectionNames}, opts...)...)}
@@ -989,7 +989,7 @@ type Txn_CreateP2PDocuments_Call struct {
 // CreateP2PDocuments is a helper method to define mock.On call
 //   - ctx context.Context
 //   - docIDs []string
-//   - opts ...options.Lister[options.CreateP2PDocumentsOptions]
+//   - opts ...options.Enumerable[options.CreateP2PDocumentsOptions]
 func (_e *Txn_Expecter) CreateP2PDocuments(ctx interface{}, docIDs interface{}, opts ...interface{}) *Txn_CreateP2PDocuments_Call {
 	return &Txn_CreateP2PDocuments_Call{Call: _e.mock.On("CreateP2PDocuments",
 		append([]interface{}{ctx, docIDs}, opts...)...)}
@@ -1061,7 +1061,7 @@ type Txn_CreateReplicator_Call struct {
 // CreateReplicator is a helper method to define mock.On call
 //   - ctx context.Context
 //   - addresses []string
-//   - opts ...options.Lister[options.CreateReplicatorOptions]
+//   - opts ...options.Enumerable[options.CreateReplicatorOptions]
 func (_e *Txn_Expecter) CreateReplicator(ctx interface{}, addresses interface{}, opts ...interface{}) *Txn_CreateReplicator_Call {
 	return &Txn_CreateReplicator_Call{Call: _e.mock.On("CreateReplicator",
 		append([]interface{}{ctx, addresses}, opts...)...)}
@@ -1145,7 +1145,7 @@ type Txn_DeleteDACActorRelationship_Call struct {
 //   - docID string
 //   - relation string
 //   - targetActor string
-//   - opts ...options.Lister[options.DeleteDACActorRelationshipOptions]
+//   - opts ...options.Enumerable[options.DeleteDACActorRelationshipOptions]
 func (_e *Txn_Expecter) DeleteDACActorRelationship(ctx interface{}, collectionName interface{}, docID interface{}, relation interface{}, targetActor interface{}, opts ...interface{}) *Txn_DeleteDACActorRelationship_Call {
 	return &Txn_DeleteDACActorRelationship_Call{Call: _e.mock.On("DeleteDACActorRelationship",
 		append([]interface{}{ctx, collectionName, docID, relation, targetActor}, opts...)...)}
@@ -1242,7 +1242,7 @@ type Txn_DeleteNACActorRelationship_Call struct {
 //   - ctx context.Context
 //   - relation string
 //   - targetActor string
-//   - opts ...options.Lister[options.DeleteNACActorRelationshipOptions]
+//   - opts ...options.Enumerable[options.DeleteNACActorRelationshipOptions]
 func (_e *Txn_Expecter) DeleteNACActorRelationship(ctx interface{}, relation interface{}, targetActor interface{}, opts ...interface{}) *Txn_DeleteNACActorRelationship_Call {
 	return &Txn_DeleteNACActorRelationship_Call{Call: _e.mock.On("DeleteNACActorRelationship",
 		append([]interface{}{ctx, relation, targetActor}, opts...)...)}
@@ -1319,7 +1319,7 @@ type Txn_DeleteP2PCollections_Call struct {
 // DeleteP2PCollections is a helper method to define mock.On call
 //   - ctx context.Context
 //   - collectionNames []string
-//   - opts ...options.Lister[options.DeleteP2PCollectionsOptions]
+//   - opts ...options.Enumerable[options.DeleteP2PCollectionsOptions]
 func (_e *Txn_Expecter) DeleteP2PCollections(ctx interface{}, collectionNames interface{}, opts ...interface{}) *Txn_DeleteP2PCollections_Call {
 	return &Txn_DeleteP2PCollections_Call{Call: _e.mock.On("DeleteP2PCollections",
 		append([]interface{}{ctx, collectionNames}, opts...)...)}
@@ -1391,7 +1391,7 @@ type Txn_DeleteP2PDocuments_Call struct {
 // DeleteP2PDocuments is a helper method to define mock.On call
 //   - ctx context.Context
 //   - docIDs []string
-//   - opts ...options.Lister[options.DeleteP2PDocumentsOptions]
+//   - opts ...options.Enumerable[options.DeleteP2PDocumentsOptions]
 func (_e *Txn_Expecter) DeleteP2PDocuments(ctx interface{}, docIDs interface{}, opts ...interface{}) *Txn_DeleteP2PDocuments_Call {
 	return &Txn_DeleteP2PDocuments_Call{Call: _e.mock.On("DeleteP2PDocuments",
 		append([]interface{}{ctx, docIDs}, opts...)...)}
@@ -1463,7 +1463,7 @@ type Txn_DeleteReplicator_Call struct {
 // DeleteReplicator is a helper method to define mock.On call
 //   - ctx context.Context
 //   - id string
-//   - opts ...options.Lister[options.DeleteReplicatorOptions]
+//   - opts ...options.Enumerable[options.DeleteReplicatorOptions]
 func (_e *Txn_Expecter) DeleteReplicator(ctx interface{}, id interface{}, opts ...interface{}) *Txn_DeleteReplicator_Call {
 	return &Txn_DeleteReplicator_Call{Call: _e.mock.On("DeleteReplicator",
 		append([]interface{}{ctx, id}, opts...)...)}
@@ -1534,7 +1534,7 @@ type Txn_DisableNAC_Call struct {
 
 // DisableNAC is a helper method to define mock.On call
 //   - ctx context.Context
-//   - opts ...options.Lister[options.DisableNACOptions]
+//   - opts ...options.Enumerable[options.DisableNACOptions]
 func (_e *Txn_Expecter) DisableNAC(ctx interface{}, opts ...interface{}) *Txn_DisableNAC_Call {
 	return &Txn_DisableNAC_Call{Call: _e.mock.On("DisableNAC",
 		append([]interface{}{ctx}, opts...)...)}
@@ -1636,7 +1636,7 @@ type Txn_ExecRequest_Call struct {
 // ExecRequest is a helper method to define mock.On call
 //   - ctx context.Context
 //   - request string
-//   - opts ...options.Lister[options.ExecRequestOptions]
+//   - opts ...options.Enumerable[options.ExecRequestOptions]
 func (_e *Txn_Expecter) ExecRequest(ctx interface{}, request interface{}, opts ...interface{}) *Txn_ExecRequest_Call {
 	return &Txn_ExecRequest_Call{Call: _e.mock.On("ExecRequest",
 		append([]interface{}{ctx, request}, opts...)...)}
@@ -1718,7 +1718,7 @@ type Txn_GetAllIndexes_Call struct {
 
 // GetAllIndexes is a helper method to define mock.On call
 //   - ctx context.Context
-//   - opts ...options.Lister[options.GetAllIndexesOptions]
+//   - opts ...options.Enumerable[options.GetAllIndexesOptions]
 func (_e *Txn_Expecter) GetAllIndexes(ctx interface{}, opts ...interface{}) *Txn_GetAllIndexes_Call {
 	return &Txn_GetAllIndexes_Call{Call: _e.mock.On("GetAllIndexes",
 		append([]interface{}{ctx}, opts...)...)}
@@ -1796,7 +1796,7 @@ type Txn_GetCollectionByName_Call struct {
 // GetCollectionByName is a helper method to define mock.On call
 //   - ctx context.Context
 //   - name client.CollectionName
-//   - opts ...options.Lister[options.GetCollectionByNameOptions]
+//   - opts ...options.Enumerable[options.GetCollectionByNameOptions]
 func (_e *Txn_Expecter) GetCollectionByName(ctx interface{}, name interface{}, opts ...interface{}) *Txn_GetCollectionByName_Call {
 	return &Txn_GetCollectionByName_Call{Call: _e.mock.On("GetCollectionByName",
 		append([]interface{}{ctx, name}, opts...)...)}
@@ -1878,7 +1878,7 @@ type Txn_GetCollections_Call struct {
 
 // GetCollections is a helper method to define mock.On call
 //   - ctx context.Context
-//   - opts ...options.Lister[options.GetCollectionsOptions]
+//   - opts ...options.Enumerable[options.GetCollectionsOptions]
 func (_e *Txn_Expecter) GetCollections(ctx interface{}, opts ...interface{}) *Txn_GetCollections_Call {
 	return &Txn_GetCollections_Call{Call: _e.mock.On("GetCollections",
 		append([]interface{}{ctx}, opts...)...)}
@@ -1953,7 +1953,7 @@ type Txn_GetNACStatus_Call struct {
 
 // GetNACStatus is a helper method to define mock.On call
 //   - ctx context.Context
-//   - opts ...options.Lister[options.GetNACStatusOptions]
+//   - opts ...options.Enumerable[options.GetNACStatusOptions]
 func (_e *Txn_Expecter) GetNACStatus(ctx interface{}, opts ...interface{}) *Txn_GetNACStatus_Call {
 	return &Txn_GetNACStatus_Call{Call: _e.mock.On("GetNACStatus",
 		append([]interface{}{ctx}, opts...)...)}
@@ -2196,7 +2196,7 @@ type Txn_ListLenses_Call struct {
 
 // ListLenses is a helper method to define mock.On call
 //   - ctx context.Context
-//   - opts ...options.Lister[options.ListLensesOptions]
+//   - opts ...options.Enumerable[options.ListLensesOptions]
 func (_e *Txn_Expecter) ListLenses(ctx interface{}, opts ...interface{}) *Txn_ListLenses_Call {
 	return &Txn_ListLenses_Call{Call: _e.mock.On("ListLenses",
 		append([]interface{}{ctx}, opts...)...)}
@@ -2273,7 +2273,7 @@ type Txn_ListP2PCollections_Call struct {
 
 // ListP2PCollections is a helper method to define mock.On call
 //   - ctx context.Context
-//   - opts ...options.Lister[options.ListP2PCollectionsOptions]
+//   - opts ...options.Enumerable[options.ListP2PCollectionsOptions]
 func (_e *Txn_Expecter) ListP2PCollections(ctx interface{}, opts ...interface{}) *Txn_ListP2PCollections_Call {
 	return &Txn_ListP2PCollections_Call{Call: _e.mock.On("ListP2PCollections",
 		append([]interface{}{ctx}, opts...)...)}
@@ -2350,7 +2350,7 @@ type Txn_ListP2PDocuments_Call struct {
 
 // ListP2PDocuments is a helper method to define mock.On call
 //   - ctx context.Context
-//   - opts ...options.Lister[options.ListP2PDocumentsOptions]
+//   - opts ...options.Enumerable[options.ListP2PDocumentsOptions]
 func (_e *Txn_Expecter) ListP2PDocuments(ctx interface{}, opts ...interface{}) *Txn_ListP2PDocuments_Call {
 	return &Txn_ListP2PDocuments_Call{Call: _e.mock.On("ListP2PDocuments",
 		append([]interface{}{ctx}, opts...)...)}
@@ -2427,7 +2427,7 @@ type Txn_ListReplicators_Call struct {
 
 // ListReplicators is a helper method to define mock.On call
 //   - ctx context.Context
-//   - opts ...options.Lister[options.ListReplicatorsOptions]
+//   - opts ...options.Enumerable[options.ListReplicatorsOptions]
 func (_e *Txn_Expecter) ListReplicators(ctx interface{}, opts ...interface{}) *Txn_ListReplicators_Call {
 	return &Txn_ListReplicators_Call{Call: _e.mock.On("ListReplicators",
 		append([]interface{}{ctx}, opts...)...)}
@@ -2495,7 +2495,7 @@ type Txn_PatchCollection_Call struct {
 //   - ctx context.Context
 //   - patch string
 //   - migration immutable.Option[model.Lens]
-//   - opts ...options.Lister[options.PatchCollectionOptions]
+//   - opts ...options.Enumerable[options.PatchCollectionOptions]
 func (_e *Txn_Expecter) PatchCollection(ctx interface{}, patch interface{}, migration interface{}, opts ...interface{}) *Txn_PatchCollection_Call {
 	return &Txn_PatchCollection_Call{Call: _e.mock.On("PatchCollection",
 		append([]interface{}{ctx, patch, migration}, opts...)...)}
@@ -2582,7 +2582,7 @@ type Txn_PeerInfo_Call struct {
 
 // PeerInfo is a helper method to define mock.On call
 //   - ctx context.Context
-//   - opts ...options.Lister[options.PeerInfoOptions]
+//   - opts ...options.Enumerable[options.PeerInfoOptions]
 func (_e *Txn_Expecter) PeerInfo(ctx interface{}, opts ...interface{}) *Txn_PeerInfo_Call {
 	return &Txn_PeerInfo_Call{Call: _e.mock.On("PeerInfo",
 		append([]interface{}{ctx}, opts...)...)}
@@ -2699,7 +2699,7 @@ type Txn_ReEnableNAC_Call struct {
 
 // ReEnableNAC is a helper method to define mock.On call
 //   - ctx context.Context
-//   - opts ...options.Lister[options.ReEnableNACOptions]
+//   - opts ...options.Enumerable[options.ReEnableNACOptions]
 func (_e *Txn_Expecter) ReEnableNAC(ctx interface{}, opts ...interface{}) *Txn_ReEnableNAC_Call {
 	return &Txn_ReEnableNAC_Call{Call: _e.mock.On("ReEnableNAC",
 		append([]interface{}{ctx}, opts...)...)}
@@ -2765,7 +2765,7 @@ type Txn_RefreshViews_Call struct {
 
 // RefreshViews is a helper method to define mock.On call
 //   - ctx context.Context
-//   - opts ...options.Lister[options.RefreshViewsOptions]
+//   - opts ...options.Enumerable[options.RefreshViewsOptions]
 func (_e *Txn_Expecter) RefreshViews(ctx interface{}, opts ...interface{}) *Txn_RefreshViews_Call {
 	return &Txn_RefreshViews_Call{Call: _e.mock.On("RefreshViews",
 		append([]interface{}{ctx}, opts...)...)}
@@ -2832,7 +2832,7 @@ type Txn_SetActiveCollectionVersion_Call struct {
 // SetActiveCollectionVersion is a helper method to define mock.On call
 //   - ctx context.Context
 //   - versionID string
-//   - opts ...options.Lister[options.SetActiveCollectionVersionOptions]
+//   - opts ...options.Enumerable[options.SetActiveCollectionVersionOptions]
 func (_e *Txn_Expecter) SetActiveCollectionVersion(ctx interface{}, versionID interface{}, opts ...interface{}) *Txn_SetActiveCollectionVersion_Call {
 	return &Txn_SetActiveCollectionVersion_Call{Call: _e.mock.On("SetActiveCollectionVersion",
 		append([]interface{}{ctx, versionID}, opts...)...)}
@@ -2984,7 +2984,7 @@ func (_c *Txn_StartTS_Call) RunAndReturn(run func() time.Time) *Txn_StartTS_Call
 }
 
 // SyncBranchableCollection provides a mock function for the type Txn
-func (_mock *Txn) SyncBranchableCollection(ctx context.Context, collectionID string, opts ...options.Lister[options.SyncBranchableCollectionOptions]) error {
+func (_mock *Txn) SyncBranchableCollection(ctx context.Context, collectionID string, opts ...options.Enumerable[options.SyncBranchableCollectionOptions]) error {
 	var tmpRet mock.Arguments
 	if len(opts) > 0 {
 		tmpRet = _mock.Called(ctx, collectionID, opts)
@@ -2998,7 +2998,7 @@ func (_mock *Txn) SyncBranchableCollection(ctx context.Context, collectionID str
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, ...options.Lister[options.SyncBranchableCollectionOptions]) error); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, ...options.Enumerable[options.SyncBranchableCollectionOptions]) error); ok {
 		r0 = returnFunc(ctx, collectionID, opts...)
 	} else {
 		r0 = ret.Error(0)
@@ -3014,13 +3014,13 @@ type Txn_SyncBranchableCollection_Call struct {
 // SyncBranchableCollection is a helper method to define mock.On call
 //   - ctx context.Context
 //   - collectionID string
-//   - opts ...options.Lister[options.SyncBranchableCollectionOptions]
+//   - opts ...options.Enumerable[options.SyncBranchableCollectionOptions]
 func (_e *Txn_Expecter) SyncBranchableCollection(ctx interface{}, collectionID interface{}, opts ...interface{}) *Txn_SyncBranchableCollection_Call {
 	return &Txn_SyncBranchableCollection_Call{Call: _e.mock.On("SyncBranchableCollection",
 		append([]interface{}{ctx, collectionID}, opts...)...)}
 }
 
-func (_c *Txn_SyncBranchableCollection_Call) Run(run func(ctx context.Context, collectionID string, opts ...options.Lister[options.SyncBranchableCollectionOptions])) *Txn_SyncBranchableCollection_Call {
+func (_c *Txn_SyncBranchableCollection_Call) Run(run func(ctx context.Context, collectionID string, opts ...options.Enumerable[options.SyncBranchableCollectionOptions])) *Txn_SyncBranchableCollection_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -3030,10 +3030,10 @@ func (_c *Txn_SyncBranchableCollection_Call) Run(run func(ctx context.Context, c
 		if args[1] != nil {
 			arg1 = args[1].(string)
 		}
-		var arg2 []options.Lister[options.SyncBranchableCollectionOptions]
-		var variadicArgs []options.Lister[options.SyncBranchableCollectionOptions]
+		var arg2 []options.Enumerable[options.SyncBranchableCollectionOptions]
+		var variadicArgs []options.Enumerable[options.SyncBranchableCollectionOptions]
 		if len(args) > 2 {
-			variadicArgs = args[2].([]options.Lister[options.SyncBranchableCollectionOptions])
+			variadicArgs = args[2].([]options.Enumerable[options.SyncBranchableCollectionOptions])
 		}
 		arg2 = variadicArgs
 		run(
@@ -3050,7 +3050,7 @@ func (_c *Txn_SyncBranchableCollection_Call) Return(err error) *Txn_SyncBranchab
 	return _c
 }
 
-func (_c *Txn_SyncBranchableCollection_Call) RunAndReturn(run func(ctx context.Context, collectionID string, opts ...options.Lister[options.SyncBranchableCollectionOptions]) error) *Txn_SyncBranchableCollection_Call {
+func (_c *Txn_SyncBranchableCollection_Call) RunAndReturn(run func(ctx context.Context, collectionID string, opts ...options.Enumerable[options.SyncBranchableCollectionOptions]) error) *Txn_SyncBranchableCollection_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -3086,7 +3086,7 @@ type Txn_SyncCollectionVersions_Call struct {
 // SyncCollectionVersions is a helper method to define mock.On call
 //   - ctx context.Context
 //   - versionIDs []string
-//   - opts ...options.Lister[options.SyncCollectionVersionsOptions]
+//   - opts ...options.Enumerable[options.SyncCollectionVersionsOptions]
 func (_e *Txn_Expecter) SyncCollectionVersions(ctx interface{}, versionIDs interface{}, opts ...interface{}) *Txn_SyncCollectionVersions_Call {
 	return &Txn_SyncCollectionVersions_Call{Call: _e.mock.On("SyncCollectionVersions",
 		append([]interface{}{ctx, versionIDs}, opts...)...)}
@@ -3222,7 +3222,7 @@ type Txn_VerifySignature_Call struct {
 //   - ctx context.Context
 //   - blockCid string
 //   - pubKey crypto.PublicKey
-//   - opts ...options.Lister[options.VerifySignatureOptions]
+//   - opts ...options.Enumerable[options.VerifySignatureOptions]
 func (_e *Txn_Expecter) VerifySignature(ctx interface{}, blockCid interface{}, pubKey interface{}, opts ...interface{}) *Txn_VerifySignature_Call {
 	return &Txn_VerifySignature_Call{Call: _e.mock.On("VerifySignature",
 		append([]interface{}{ctx, blockCid, pubKey}, opts...)...)}

--- a/client/options/enumerable.go
+++ b/client/options/enumerable.go
@@ -14,14 +14,14 @@ import (
 	"github.com/sourcenetwork/immutable/enumerable"
 )
 
-// Lister is a type alias for enumerable.Enumerable.
+// Enumerable is a type alias for enumerable.Enumerable.
 // This allows option builders to be passed as enumerable collections,
 // and also allows users to pass raw slices via enumerable.New().
 //
 // Option builders implement enumerable.Enumerable via Next(), Value(), and Reset() methods.
 // This provides flexibility for advanced users to define custom option functions
 // without using the builder pattern.
-type Lister[T any] = enumerable.Enumerable[func(*T)]
+type Enumerable[T any] = enumerable.Enumerable[func(*T)]
 
 // enumerableBuilder provides a reusable implementation of enumerable.Enumerable
 // for option builders. All builders can embed this struct to gain enumerable

--- a/client/options/identity.go
+++ b/client/options/identity.go
@@ -19,7 +19,7 @@ import (
 // BuilderWithIdentity is an interface for option builders that can set identity.
 // T is the options type, B is the builder type (for fluent API support).
 type BuilderWithIdentity[T any, B any] interface {
-	Lister[T]
+	Enumerable[T]
 	// SetIdentity sets the identity for this option and returns the builder for chaining.
 	SetIdentity(id identity.Identity) B
 }

--- a/client/p2p.go
+++ b/client/p2p.go
@@ -25,22 +25,22 @@ import (
 // P2P is a peer connected database implementation.
 type P2P interface {
 	// PeerInfo returns the p2p host list of addresses.
-	PeerInfo(ctx context.Context, opts ...options.Lister[options.PeerInfoOptions]) ([]string, error)
+	PeerInfo(ctx context.Context, opts ...options.Enumerable[options.PeerInfoOptions]) ([]string, error)
 
 	// ActivePeers returns the addresses of peers that are currently connected to.
 	//
 	// Addresses are returned in the multiaddr format (e.g. /ip4/127.0.0.1/tcp/4001/p2p/<PeerID>).
-	ActivePeers(ctx context.Context, opts ...options.Lister[options.ActivePeersOptions]) ([]string, error)
+	ActivePeers(ctx context.Context, opts ...options.Enumerable[options.ActivePeersOptions]) ([]string, error)
 
 	// Connect tries to connect to the peer with the given [PeerInfo].
-	Connect(ctx context.Context, addresses []string, opts ...options.Lister[options.ConnectOptions]) error
+	Connect(ctx context.Context, addresses []string, opts ...options.Enumerable[options.ConnectOptions]) error
 
 	// CreateReplicator adds a replicator to the persisted list or adds
 	// schemas if the replicator already exists.
 	CreateReplicator(
 		ctx context.Context,
 		addresses []string,
-		opts ...options.Lister[options.CreateReplicatorOptions],
+		opts ...options.Enumerable[options.CreateReplicatorOptions],
 	) error
 
 	// DeleteReplicator deletes a replicator from the persisted list
@@ -48,12 +48,12 @@ type P2P interface {
 	DeleteReplicator(
 		ctx context.Context,
 		id string,
-		opts ...options.Lister[options.DeleteReplicatorOptions],
+		opts ...options.Enumerable[options.DeleteReplicatorOptions],
 	) error
 
 	// ListReplicators returns the full list of replicators with their
 	// subscribed schemas.
-	ListReplicators(ctx context.Context, opts ...options.Lister[options.ListReplicatorsOptions]) ([]Replicator, error)
+	ListReplicators(ctx context.Context, opts ...options.Enumerable[options.ListReplicatorsOptions]) ([]Replicator, error)
 
 	// CreateP2PCollections creates the given collections to the P2P system and
 	// subscribes to their topics. It will error if any of the provided
@@ -61,7 +61,7 @@ type P2P interface {
 	CreateP2PCollections(
 		ctx context.Context,
 		collectionNames []string,
-		opts ...options.Lister[options.CreateP2PCollectionsOptions],
+		opts ...options.Enumerable[options.CreateP2PCollectionsOptions],
 	) error
 
 	// DeleteP2PCollections deletes the given collections from the P2P system and
@@ -70,14 +70,14 @@ type P2P interface {
 	DeleteP2PCollections(
 		ctx context.Context,
 		collectionNames []string,
-		opts ...options.Lister[options.DeleteP2PCollectionsOptions],
+		opts ...options.Enumerable[options.DeleteP2PCollectionsOptions],
 	) error
 
 	// ListP2PCollections returns the list of persisted collection names that
 	// the P2P system subscribes to.
 	ListP2PCollections(
 		ctx context.Context,
-		opts ...options.Lister[options.ListP2PCollectionsOptions],
+		opts ...options.Enumerable[options.ListP2PCollectionsOptions],
 	) ([]string, error)
 
 	// CreateP2PDocuments creates the given docIDs to the P2P system and
@@ -86,7 +86,7 @@ type P2P interface {
 	CreateP2PDocuments(
 		ctx context.Context,
 		docIDs []string,
-		opts ...options.Lister[options.CreateP2PDocumentsOptions],
+		opts ...options.Enumerable[options.CreateP2PDocumentsOptions],
 	) error
 
 	// DeleteP2PDocuments removes the given docIDs from the P2P system and
@@ -95,12 +95,12 @@ type P2P interface {
 	DeleteP2PDocuments(
 		ctx context.Context,
 		docIDs []string,
-		opts ...options.Lister[options.DeleteP2PDocumentsOptions],
+		opts ...options.Enumerable[options.DeleteP2PDocumentsOptions],
 	) error
 
 	// ListP2PDocuments returns the list of persisted docIDs that
 	// the P2P system subscribes to.
-	ListP2PDocuments(ctx context.Context, opts ...options.Lister[options.ListP2PDocumentsOptions]) ([]string, error)
+	ListP2PDocuments(ctx context.Context, opts ...options.Enumerable[options.ListP2PDocumentsOptions]) ([]string, error)
 
 	// SyncDocuments requests the latest versions of specified documents from the network
 	// and synchronizes their DAGs locally. It doesn't automatically subscribe
@@ -115,7 +115,7 @@ type P2P interface {
 	SyncCollectionVersions(
 		ctx context.Context,
 		versionIDs []string,
-		opts ...options.Lister[options.SyncCollectionVersionsOptions],
+		opts ...options.Enumerable[options.SyncCollectionVersionsOptions],
 	) error
 
 	// SyncBranchableCollection requests the latest version of the branchable collection's DAG

--- a/client/p2p.go
+++ b/client/p2p.go
@@ -126,7 +126,7 @@ type P2P interface {
 	SyncBranchableCollection(
 		ctx context.Context,
 		collectionID string,
-		opts ...options.Lister[options.SyncBranchableCollectionOptions],
+		opts ...options.Enumerable[options.SyncBranchableCollectionOptions],
 	) error
 }
 

--- a/http/client.go
+++ b/http/client.go
@@ -110,7 +110,7 @@ func (c *Client) BasicImport(ctx context.Context, filepath string) error {
 func (c *Client) BasicExport(
 	ctx context.Context,
 	filepath string,
-	opts ...options.Lister[options.BasicExportOptions],
+	opts ...options.Enumerable[options.BasicExportOptions],
 ) error {
 	opt := utils.NewOptions(opts...)
 
@@ -138,7 +138,7 @@ func (c *Client) BasicExport(
 func (c *Client) AddSchema(
 	ctx context.Context,
 	schema string,
-	opts ...options.Lister[options.AddSchemaOptions],
+	opts ...options.Enumerable[options.AddSchemaOptions],
 ) ([]client.CollectionVersion, error) {
 	opt := utils.NewOptions(opts...)
 	ctx = identity.WithContext(ctx, opt.GetIdentity())
@@ -165,7 +165,7 @@ func (c *Client) PatchCollection(
 	ctx context.Context,
 	patch string,
 	migration immutable.Option[model.Lens],
-	opts ...options.Lister[options.PatchCollectionOptions],
+	opts ...options.Enumerable[options.PatchCollectionOptions],
 ) error {
 	opt := utils.NewOptions(opts...)
 	ctx = identity.WithContext(ctx, opt.GetIdentity())
@@ -188,7 +188,7 @@ func (c *Client) PatchCollection(
 func (c *Client) SetActiveCollectionVersion(
 	ctx context.Context,
 	collectionVersionID string,
-	opts ...options.Lister[options.SetActiveCollectionVersionOptions],
+	opts ...options.Enumerable[options.SetActiveCollectionVersionOptions],
 ) error {
 	opt := utils.NewOptions(opts...)
 	ctx = identity.WithContext(ctx, opt.GetIdentity())
@@ -214,7 +214,7 @@ func (c *Client) AddView(
 	ctx context.Context,
 	query string,
 	sdl string,
-	opts ...options.Lister[options.AddViewOptions],
+	opts ...options.Enumerable[options.AddViewOptions],
 ) ([]client.CollectionVersion, error) {
 	opt := utils.NewOptions(opts...)
 	ctx = identity.WithContext(ctx, opt.GetIdentity())
@@ -239,7 +239,7 @@ func (c *Client) AddView(
 	return descriptions, nil
 }
 
-func (c *Client) RefreshViews(ctx context.Context, opts ...options.Lister[options.RefreshViewsOptions]) error {
+func (c *Client) RefreshViews(ctx context.Context, opts ...options.Enumerable[options.RefreshViewsOptions]) error {
 	methodURL := c.http.apiURL.JoinPath("view", "refresh")
 	params := url.Values{}
 	opt := utils.NewOptions(opts...)
@@ -291,7 +291,7 @@ func (c *Client) SetMigration(ctx context.Context, config client.LensConfig) (st
 func (c *Client) AddLens(
 	ctx context.Context,
 	lens model.Lens,
-	opts ...options.Lister[options.AddLensOptions],
+	opts ...options.Enumerable[options.AddLensOptions],
 ) (string, error) {
 	opt := utils.NewOptions(opts...)
 	ctx = identity.WithContext(ctx, opt.GetIdentity())
@@ -318,7 +318,7 @@ func (c *Client) AddLens(
 
 func (c *Client) ListLenses(
 	ctx context.Context,
-	opts ...options.Lister[options.ListLensesOptions],
+	opts ...options.Enumerable[options.ListLensesOptions],
 ) (map[string]model.Lens, error) {
 	opt := utils.NewOptions(opts...)
 	ctx = identity.WithContext(ctx, opt.GetIdentity())
@@ -341,7 +341,7 @@ func (c *Client) ListLenses(
 func (c *Client) GetCollectionByName(
 	ctx context.Context,
 	name client.CollectionName,
-	opts ...options.Lister[options.GetCollectionByNameOptions],
+	opts ...options.Enumerable[options.GetCollectionByNameOptions],
 ) (client.Collection, error) {
 	opt := utils.NewOptions(opts...)
 	ctx = identity.WithContext(ctx, opt.GetIdentity())
@@ -362,7 +362,7 @@ func (c *Client) GetCollectionByName(
 
 func (c *Client) GetCollections(
 	ctx context.Context,
-	opts ...options.Lister[options.GetCollectionsOptions],
+	opts ...options.Enumerable[options.GetCollectionsOptions],
 ) ([]client.Collection, error) {
 	opt := utils.NewOptions(opts...)
 	ctx = identity.WithContext(ctx, opt.GetIdentity())
@@ -400,7 +400,7 @@ func (c *Client) GetCollections(
 
 func (c *Client) GetAllIndexes(
 	ctx context.Context,
-	opts ...options.Lister[options.GetAllIndexesOptions],
+	opts ...options.Enumerable[options.GetAllIndexesOptions],
 ) (map[client.CollectionName][]client.IndexDescription, error) {
 	opt := utils.NewOptions(opts...)
 	ctx = identity.WithContext(ctx, opt.GetIdentity())
@@ -437,7 +437,7 @@ func (c *Client) ListAllEncryptedIndexes(
 func (c *Client) ExecRequest(
 	ctx context.Context,
 	query string,
-	opts ...options.Lister[options.ExecRequestOptions],
+	opts ...options.Enumerable[options.ExecRequestOptions],
 ) *client.RequestResult {
 	opt := utils.NewOptions(opts...)
 	ctx = identity.WithContext(ctx, opt.GetIdentity())
@@ -584,7 +584,7 @@ func (c *Client) VerifySignature(
 	ctx context.Context,
 	cid string,
 	pubKey crypto.PublicKey,
-	opts ...options.Lister[options.VerifySignatureOptions],
+	opts ...options.Enumerable[options.VerifySignatureOptions],
 ) error {
 	opt := utils.NewOptions(opts...)
 	ctx = identity.WithContext(ctx, opt.GetIdentity())

--- a/http/client_acp.go
+++ b/http/client_acp.go
@@ -26,7 +26,7 @@ import (
 func (c *Client) AddDACPolicy(
 	ctx context.Context,
 	policy string,
-	opts ...options.Lister[options.AddDACPolicyOptions],
+	opts ...options.Enumerable[options.AddDACPolicyOptions],
 ) (client.AddPolicyResult, error) {
 	opt := utils.NewOptions(opts...)
 	ctx = identity.WithContext(ctx, opt.GetIdentity())
@@ -65,7 +65,7 @@ func (c *Client) AddDACActorRelationship(
 	docID string,
 	relation string,
 	targetActor string,
-	opts ...options.Lister[options.AddDACActorRelationshipOptions],
+	opts ...options.Enumerable[options.AddDACActorRelationshipOptions],
 ) (client.AddActorRelationshipResult, error) {
 	opt := utils.NewOptions(opts...)
 	ctx = identity.WithContext(ctx, opt.GetIdentity())
@@ -117,7 +117,7 @@ func (c *Client) DeleteDACActorRelationship(
 	docID string,
 	relation string,
 	targetActor string,
-	opts ...options.Lister[options.DeleteDACActorRelationshipOptions],
+	opts ...options.Enumerable[options.DeleteDACActorRelationshipOptions],
 ) (client.DeleteActorRelationshipResult, error) {
 	opt := utils.NewOptions(opts...)
 	ctx = identity.WithContext(ctx, opt.GetIdentity())
@@ -165,7 +165,7 @@ func (c *Client) AddNACActorRelationship(
 	ctx context.Context,
 	relation string,
 	targetActor string,
-	opts ...options.Lister[options.AddNACActorRelationshipOptions],
+	opts ...options.Enumerable[options.AddNACActorRelationshipOptions],
 ) (client.AddActorRelationshipResult, error) {
 	opt := utils.NewOptions(opts...)
 	ctx = identity.WithContext(ctx, opt.GetIdentity())
@@ -211,7 +211,7 @@ func (c *Client) DeleteNACActorRelationship(
 	ctx context.Context,
 	relation string,
 	targetActor string,
-	opts ...options.Lister[options.DeleteNACActorRelationshipOptions],
+	opts ...options.Enumerable[options.DeleteNACActorRelationshipOptions],
 ) (client.DeleteActorRelationshipResult, error) {
 	opt := utils.NewOptions(opts...)
 	ctx = identity.WithContext(ctx, opt.GetIdentity())
@@ -248,7 +248,7 @@ func (c *Client) DeleteNACActorRelationship(
 	return deleteDocActorRelResult, nil
 }
 
-func (c *Client) ReEnableNAC(ctx context.Context, opts ...options.Lister[options.ReEnableNACOptions]) error {
+func (c *Client) ReEnableNAC(ctx context.Context, opts ...options.Enumerable[options.ReEnableNACOptions]) error {
 	opt := utils.NewOptions(opts...)
 	ctx = identity.WithContext(ctx, opt.GetIdentity())
 
@@ -267,7 +267,7 @@ func (c *Client) ReEnableNAC(ctx context.Context, opts ...options.Lister[options
 	return nil
 }
 
-func (c *Client) DisableNAC(ctx context.Context, opts ...options.Lister[options.DisableNACOptions]) error {
+func (c *Client) DisableNAC(ctx context.Context, opts ...options.Enumerable[options.DisableNACOptions]) error {
 	opt := utils.NewOptions(opts...)
 	ctx = identity.WithContext(ctx, opt.GetIdentity())
 
@@ -288,7 +288,7 @@ func (c *Client) DisableNAC(ctx context.Context, opts ...options.Lister[options.
 
 func (c *Client) GetNACStatus(
 	ctx context.Context,
-	opts ...options.Lister[options.GetNACStatusOptions],
+	opts ...options.Enumerable[options.GetNACStatusOptions],
 ) (client.NACStatusResult, error) {
 	opt := utils.NewOptions(opts...)
 	ctx = identity.WithContext(ctx, opt.GetIdentity())

--- a/http/client_collection.go
+++ b/http/client_collection.go
@@ -54,7 +54,7 @@ func (c *Collection) CollectionID() string {
 func (c *Collection) Create(
 	ctx context.Context,
 	doc *client.Document,
-	opts ...options.Lister[options.CollectionCreateOptions],
+	opts ...options.Enumerable[options.CollectionCreateOptions],
 ) error {
 	opt := utils.NewOptions(opts...)
 	ctx = identity.WithContext(ctx, opt.GetIdentity())
@@ -83,7 +83,7 @@ func (c *Collection) Create(
 func (c *Collection) CreateMany(
 	ctx context.Context,
 	docs []*client.Document,
-	opts ...options.Lister[options.CollectionCreateOptions],
+	opts ...options.Enumerable[options.CollectionCreateOptions],
 ) error {
 	opt := utils.NewOptions(opts...)
 	ctx = identity.WithContext(ctx, opt.GetIdentity())
@@ -137,7 +137,7 @@ func setDocEncryptionFlagIfNeeded(req *http.Request, opt *options.CollectionCrea
 func (c *Collection) Update(
 	ctx context.Context,
 	doc *client.Document,
-	opts ...options.Lister[options.CollectionUpdateOptions],
+	opts ...options.Enumerable[options.CollectionUpdateOptions],
 ) error {
 	opt := utils.NewOptions(opts...)
 	ctx = identity.WithContext(ctx, opt.GetIdentity())
@@ -163,7 +163,7 @@ func (c *Collection) Update(
 func (c *Collection) Save(
 	ctx context.Context,
 	doc *client.Document,
-	opts ...options.Lister[options.CollectionSaveOptions],
+	opts ...options.Enumerable[options.CollectionSaveOptions],
 ) error {
 	opt := utils.NewOptions(opts...)
 
@@ -196,7 +196,7 @@ func (c *Collection) Save(
 func (c *Collection) Delete(
 	ctx context.Context,
 	docID client.DocID,
-	opts ...options.Lister[options.CollectionDeleteOptions],
+	opts ...options.Enumerable[options.CollectionDeleteOptions],
 ) (bool, error) {
 	opt := utils.NewOptions(opts...)
 	ctx = identity.WithContext(ctx, opt.GetIdentity())
@@ -217,7 +217,7 @@ func (c *Collection) Delete(
 func (c *Collection) Exists(
 	ctx context.Context,
 	docID client.DocID,
-	opts ...options.Lister[options.CollectionExistsOptions],
+	opts ...options.Enumerable[options.CollectionExistsOptions],
 ) (bool, error) {
 	opt := utils.NewOptions(opts...)
 	ctx = identity.WithContext(ctx, opt.GetIdentity())
@@ -232,7 +232,7 @@ func (c *Collection) UpdateWithFilter(
 	ctx context.Context,
 	filter any,
 	updater string,
-	opts ...options.Lister[options.CollectionUpdateWithFilterOptions],
+	opts ...options.Enumerable[options.CollectionUpdateWithFilterOptions],
 ) (*client.UpdateResult, error) {
 	opt := utils.NewOptions(opts...)
 	ctx = identity.WithContext(ctx, opt.GetIdentity())
@@ -262,7 +262,7 @@ func (c *Collection) UpdateWithFilter(
 func (c *Collection) DeleteWithFilter(
 	ctx context.Context,
 	filter any,
-	opts ...options.Lister[options.CollectionDeleteWithFilterOptions],
+	opts ...options.Enumerable[options.CollectionDeleteWithFilterOptions],
 ) (*client.DeleteResult, error) {
 	opt := utils.NewOptions(opts...)
 	ctx = identity.WithContext(ctx, opt.GetIdentity())
@@ -292,7 +292,7 @@ func (c *Collection) DeleteWithFilter(
 func (c *Collection) Get(
 	ctx context.Context,
 	docID client.DocID,
-	opts ...options.Lister[options.CollectionGetOptions],
+	opts ...options.Enumerable[options.CollectionGetOptions],
 ) (*client.Document, error) {
 	opt := utils.NewOptions(opts...)
 	ctx = identity.WithContext(ctx, opt.GetIdentity())
@@ -327,7 +327,7 @@ func (c *Collection) Get(
 
 func (c *Collection) GetAllDocIDs(
 	ctx context.Context,
-	opts ...options.Lister[options.CollectionGetAllDocIDsOptions],
+	opts ...options.Enumerable[options.CollectionGetAllDocIDsOptions],
 ) (<-chan client.DocIDResult, error) {
 	opt := utils.NewOptions(opts...)
 	ctx = identity.WithContext(ctx, opt.GetIdentity())
@@ -387,7 +387,7 @@ func (c *Collection) GetAllDocIDs(
 func (c *Collection) CreateIndex(
 	ctx context.Context,
 	indexDesc client.IndexCreateRequest,
-	opts ...options.Lister[options.CollectionCreateIndexOptions],
+	opts ...options.Enumerable[options.CollectionCreateIndexOptions],
 ) (client.IndexDescription, error) {
 	opt := utils.NewOptions(opts...)
 	ctx = identity.WithContext(ctx, opt.GetIdentity())
@@ -411,7 +411,7 @@ func (c *Collection) CreateIndex(
 func (c *Collection) DropIndex(
 	ctx context.Context,
 	indexName string,
-	opts ...options.Lister[options.CollectionDropIndexOptions],
+	opts ...options.Enumerable[options.CollectionDropIndexOptions],
 ) error {
 	opt := utils.NewOptions(opts...)
 	ctx = identity.WithContext(ctx, opt.GetIdentity())
@@ -428,7 +428,7 @@ func (c *Collection) DropIndex(
 
 func (c *Collection) GetIndexes(
 	ctx context.Context,
-	opts ...options.Lister[options.CollectionGetIndexesOptions],
+	opts ...options.Enumerable[options.CollectionGetIndexesOptions],
 ) ([]client.IndexDescription, error) {
 	opt := utils.NewOptions(opts...)
 	ctx = identity.WithContext(ctx, opt.GetIdentity())
@@ -493,7 +493,7 @@ func (c *Collection) DeleteEncryptedIndex(ctx context.Context, fieldName string)
 	return err
 }
 
-func (c *Collection) Truncate(ctx context.Context, opts ...options.Lister[options.CollectionTruncateOptions]) error {
+func (c *Collection) Truncate(ctx context.Context, opts ...options.Enumerable[options.CollectionTruncateOptions]) error {
 	opt := utils.NewOptions(opts...)
 	ctx = identity.WithContext(ctx, opt.GetIdentity())
 

--- a/http/client_collection.go
+++ b/http/client_collection.go
@@ -493,7 +493,9 @@ func (c *Collection) DeleteEncryptedIndex(ctx context.Context, fieldName string)
 	return err
 }
 
-func (c *Collection) Truncate(ctx context.Context, opts ...options.Enumerable[options.CollectionTruncateOptions]) error {
+func (c *Collection) Truncate(
+	ctx context.Context, opts ...options.Enumerable[options.CollectionTruncateOptions],
+) error {
 	opt := utils.NewOptions(opts...)
 	ctx = identity.WithContext(ctx, opt.GetIdentity())
 

--- a/http/client_p2p.go
+++ b/http/client_p2p.go
@@ -375,7 +375,7 @@ func (c *Client) SyncCollectionVersions(
 func (c *Client) SyncBranchableCollection(
 	ctx context.Context,
 	collectionID string,
-	opts ...options.Lister[options.SyncBranchableCollectionOptions],
+	opts ...options.Enumerable[options.SyncBranchableCollectionOptions],
 ) error {
 	methodURL := c.http.apiURL.JoinPath("p2p", "collections", "sync-branchable")
 

--- a/http/client_p2p.go
+++ b/http/client_p2p.go
@@ -41,7 +41,7 @@ type DeleteReplicatorParams struct {
 	Collections []string
 }
 
-func (c *Client) PeerInfo(ctx context.Context, opts ...options.Lister[options.PeerInfoOptions]) ([]string, error) {
+func (c *Client) PeerInfo(ctx context.Context, opts ...options.Enumerable[options.PeerInfoOptions]) ([]string, error) {
 	opt := utils.NewOptions(opts...)
 	ctx = identity.WithContext(ctx, opt.GetIdentity())
 
@@ -60,7 +60,7 @@ func (c *Client) PeerInfo(ctx context.Context, opts ...options.Lister[options.Pe
 
 func (c *Client) ActivePeers(
 	ctx context.Context,
-	opts ...options.Lister[options.ActivePeersOptions],
+	opts ...options.Enumerable[options.ActivePeersOptions],
 ) ([]string, error) {
 	opt := utils.NewOptions(opts...)
 	ctx = identity.WithContext(ctx, opt.GetIdentity())
@@ -81,7 +81,7 @@ func (c *Client) ActivePeers(
 func (c *Client) Connect(
 	ctx context.Context,
 	addresses []string,
-	opts ...options.Lister[options.ConnectOptions],
+	opts ...options.Enumerable[options.ConnectOptions],
 ) error {
 	opt := utils.NewOptions(opts...)
 	ctx = identity.WithContext(ctx, opt.GetIdentity())
@@ -103,7 +103,7 @@ func (c *Client) Connect(
 func (c *Client) CreateReplicator(
 	ctx context.Context,
 	addresses []string,
-	opts ...options.Lister[options.CreateReplicatorOptions],
+	opts ...options.Enumerable[options.CreateReplicatorOptions],
 ) error {
 	opt := utils.NewOptions(opts...)
 	ctx = identity.WithContext(ctx, opt.GetIdentity())
@@ -128,7 +128,7 @@ func (c *Client) CreateReplicator(
 func (c *Client) DeleteReplicator(
 	ctx context.Context,
 	id string,
-	opts ...options.Lister[options.DeleteReplicatorOptions],
+	opts ...options.Enumerable[options.DeleteReplicatorOptions],
 ) error {
 	opt := utils.NewOptions(opts...)
 	ctx = identity.WithContext(ctx, opt.GetIdentity())
@@ -152,7 +152,7 @@ func (c *Client) DeleteReplicator(
 
 func (c *Client) ListReplicators(
 	ctx context.Context,
-	opts ...options.Lister[options.ListReplicatorsOptions],
+	opts ...options.Enumerable[options.ListReplicatorsOptions],
 ) ([]client.Replicator, error) {
 	opt := utils.NewOptions(opts...)
 	ctx = identity.WithContext(ctx, opt.GetIdentity())
@@ -173,7 +173,7 @@ func (c *Client) ListReplicators(
 func (c *Client) CreateP2PCollections(
 	ctx context.Context,
 	collectionIDs []string,
-	opts ...options.Lister[options.CreateP2PCollectionsOptions],
+	opts ...options.Enumerable[options.CreateP2PCollectionsOptions],
 ) error {
 	opt := utils.NewOptions(opts...)
 	ctx = identity.WithContext(ctx, opt.GetIdentity())
@@ -195,7 +195,7 @@ func (c *Client) CreateP2PCollections(
 func (c *Client) DeleteP2PCollections(
 	ctx context.Context,
 	collectionIDs []string,
-	opts ...options.Lister[options.DeleteP2PCollectionsOptions],
+	opts ...options.Enumerable[options.DeleteP2PCollectionsOptions],
 ) error {
 	opt := utils.NewOptions(opts...)
 	ctx = identity.WithContext(ctx, opt.GetIdentity())
@@ -216,7 +216,7 @@ func (c *Client) DeleteP2PCollections(
 
 func (c *Client) ListP2PCollections(
 	ctx context.Context,
-	opts ...options.Lister[options.ListP2PCollectionsOptions],
+	opts ...options.Enumerable[options.ListP2PCollectionsOptions],
 ) ([]string, error) {
 	opt := utils.NewOptions(opts...)
 	ctx = identity.WithContext(ctx, opt.GetIdentity())
@@ -237,7 +237,7 @@ func (c *Client) ListP2PCollections(
 func (c *Client) CreateP2PDocuments(
 	ctx context.Context,
 	docIDs []string,
-	opts ...options.Lister[options.CreateP2PDocumentsOptions],
+	opts ...options.Enumerable[options.CreateP2PDocumentsOptions],
 ) error {
 	opt := utils.NewOptions(opts...)
 	ctx = identity.WithContext(ctx, opt.GetIdentity())
@@ -259,7 +259,7 @@ func (c *Client) CreateP2PDocuments(
 func (c *Client) DeleteP2PDocuments(
 	ctx context.Context,
 	docIDs []string,
-	opts ...options.Lister[options.DeleteP2PDocumentsOptions],
+	opts ...options.Enumerable[options.DeleteP2PDocumentsOptions],
 ) error {
 	opt := utils.NewOptions(opts...)
 	ctx = identity.WithContext(ctx, opt.GetIdentity())
@@ -280,7 +280,7 @@ func (c *Client) DeleteP2PDocuments(
 
 func (c *Client) ListP2PDocuments(
 	ctx context.Context,
-	opts ...options.Lister[options.ListP2PDocumentsOptions],
+	opts ...options.Enumerable[options.ListP2PDocumentsOptions],
 ) ([]string, error) {
 	opt := utils.NewOptions(opts...)
 	ctx = identity.WithContext(ctx, opt.GetIdentity())
@@ -343,7 +343,7 @@ func (c *Client) SyncDocuments(
 func (c *Client) SyncCollectionVersions(
 	ctx context.Context,
 	versionIDs []string,
-	opts ...options.Lister[options.SyncCollectionVersionsOptions],
+	opts ...options.Enumerable[options.SyncCollectionVersionsOptions],
 ) error {
 	opt := utils.NewOptions(opts...)
 	ctx = identity.WithContext(ctx, opt.GetIdentity())

--- a/http/client_tx.go
+++ b/http/client_tx.go
@@ -79,7 +79,7 @@ func (txn *Transaction) PrintDump(ctx context.Context) error {
 func (txn *Transaction) AddDACPolicy(
 	ctx context.Context,
 	policy string,
-	opts ...options.Lister[options.AddDACPolicyOptions],
+	opts ...options.Enumerable[options.AddDACPolicyOptions],
 ) (client.AddPolicyResult, error) {
 	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
 	return txn.Client.AddDACPolicy(ctx, policy, opts...)
@@ -91,7 +91,7 @@ func (txn *Transaction) AddDACActorRelationship(
 	docID string,
 	relation string,
 	targetActor string,
-	opts ...options.Lister[options.AddDACActorRelationshipOptions],
+	opts ...options.Enumerable[options.AddDACActorRelationshipOptions],
 ) (client.AddActorRelationshipResult, error) {
 	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
 	return txn.Client.AddDACActorRelationship(ctx, collectionName, docID, relation, targetActor, opts...)
@@ -103,7 +103,7 @@ func (txn *Transaction) DeleteDACActorRelationship(
 	docID string,
 	relation string,
 	targetActor string,
-	opts ...options.Lister[options.DeleteDACActorRelationshipOptions],
+	opts ...options.Enumerable[options.DeleteDACActorRelationshipOptions],
 ) (client.DeleteActorRelationshipResult, error) {
 	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
 	return txn.Client.DeleteDACActorRelationship(ctx, collectionName, docID, relation, targetActor, opts...)
@@ -118,7 +118,7 @@ func (txn *Transaction) VerifySignature(
 	ctx context.Context,
 	blockCid string,
 	pubKey crypto.PublicKey,
-	opts ...options.Lister[options.VerifySignatureOptions],
+	opts ...options.Enumerable[options.VerifySignatureOptions],
 ) error {
 	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
 	return txn.Client.VerifySignature(ctx, blockCid, pubKey, opts...)
@@ -127,7 +127,7 @@ func (txn *Transaction) VerifySignature(
 func (txn *Transaction) AddSchema(
 	ctx context.Context,
 	sdl string,
-	opts ...options.Lister[options.AddSchemaOptions],
+	opts ...options.Enumerable[options.AddSchemaOptions],
 ) ([]client.CollectionVersion, error) {
 	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
 	return txn.Client.AddSchema(ctx, sdl, opts...)
@@ -137,7 +137,7 @@ func (txn *Transaction) PatchCollection(
 	ctx context.Context,
 	patch string,
 	migration immutable.Option[model.Lens],
-	opts ...options.Lister[options.PatchCollectionOptions],
+	opts ...options.Enumerable[options.PatchCollectionOptions],
 ) error {
 	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
 	return txn.Client.PatchCollection(ctx, patch, migration, opts...)
@@ -146,7 +146,7 @@ func (txn *Transaction) PatchCollection(
 func (txn *Transaction) SetActiveCollectionVersion(
 	ctx context.Context,
 	version string,
-	opts ...options.Lister[options.SetActiveCollectionVersionOptions],
+	opts ...options.Enumerable[options.SetActiveCollectionVersionOptions],
 ) error {
 	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
 	return txn.Client.SetActiveCollectionVersion(ctx, version, opts...)
@@ -156,13 +156,13 @@ func (txn *Transaction) AddView(
 	ctx context.Context,
 	gqlQuery string,
 	sdl string,
-	opts ...options.Lister[options.AddViewOptions],
+	opts ...options.Enumerable[options.AddViewOptions],
 ) ([]client.CollectionVersion, error) {
 	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
 	return txn.Client.AddView(ctx, gqlQuery, sdl, opts...)
 }
 
-func (txn *Transaction) RefreshViews(ctx context.Context, opts ...options.Lister[options.RefreshViewsOptions]) error {
+func (txn *Transaction) RefreshViews(ctx context.Context, opts ...options.Enumerable[options.RefreshViewsOptions]) error {
 	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
 	return txn.Client.RefreshViews(ctx, opts...)
 }
@@ -175,7 +175,7 @@ func (txn *Transaction) SetMigration(ctx context.Context, config client.LensConf
 func (txn *Transaction) AddLens(
 	ctx context.Context,
 	lens model.Lens,
-	opts ...options.Lister[options.AddLensOptions],
+	opts ...options.Enumerable[options.AddLensOptions],
 ) (string, error) {
 	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
 	return txn.Client.AddLens(ctx, lens, opts...)
@@ -183,7 +183,7 @@ func (txn *Transaction) AddLens(
 
 func (txn *Transaction) ListLenses(
 	ctx context.Context,
-	opts ...options.Lister[options.ListLensesOptions],
+	opts ...options.Enumerable[options.ListLensesOptions],
 ) (map[string]model.Lens, error) {
 	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
 	return txn.Client.ListLenses(ctx, opts...)
@@ -192,7 +192,7 @@ func (txn *Transaction) ListLenses(
 func (txn *Transaction) GetCollectionByName(
 	ctx context.Context,
 	name client.CollectionName,
-	opts ...options.Lister[options.GetCollectionByNameOptions],
+	opts ...options.Enumerable[options.GetCollectionByNameOptions],
 ) (client.Collection, error) {
 	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
 	return txn.Client.GetCollectionByName(ctx, name, opts...)
@@ -200,7 +200,7 @@ func (txn *Transaction) GetCollectionByName(
 
 func (txn *Transaction) GetCollections(
 	ctx context.Context,
-	opts ...options.Lister[options.GetCollectionsOptions],
+	opts ...options.Enumerable[options.GetCollectionsOptions],
 ) ([]client.Collection, error) {
 	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
 	return txn.Client.GetCollections(ctx, opts...)
@@ -208,7 +208,7 @@ func (txn *Transaction) GetCollections(
 
 func (txn *Transaction) GetAllIndexes(
 	ctx context.Context,
-	opts ...options.Lister[options.GetAllIndexesOptions],
+	opts ...options.Enumerable[options.GetAllIndexesOptions],
 ) (map[client.CollectionName][]client.IndexDescription, error) {
 	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
 	return txn.Client.GetAllIndexes(ctx, opts...)
@@ -224,7 +224,7 @@ func (txn *Transaction) ListAllEncryptedIndexes(
 func (txn *Transaction) ExecRequest(
 	ctx context.Context,
 	request string,
-	opts ...options.Lister[options.ExecRequestOptions],
+	opts ...options.Enumerable[options.ExecRequestOptions],
 ) *client.RequestResult {
 	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
 	return txn.Client.ExecRequest(ctx, request, opts...)
@@ -238,7 +238,7 @@ func (txn *Transaction) BasicImport(ctx context.Context, filepath string) error 
 func (txn *Transaction) BasicExport(
 	ctx context.Context,
 	filepath string,
-	opts ...options.Lister[options.BasicExportOptions],
+	opts ...options.Enumerable[options.BasicExportOptions],
 ) error {
 	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
 	return txn.Client.BasicExport(ctx, filepath, opts...)

--- a/http/client_tx.go
+++ b/http/client_tx.go
@@ -162,7 +162,9 @@ func (txn *Transaction) AddView(
 	return txn.Client.AddView(ctx, gqlQuery, sdl, opts...)
 }
 
-func (txn *Transaction) RefreshViews(ctx context.Context, opts ...options.Enumerable[options.RefreshViewsOptions]) error {
+func (txn *Transaction) RefreshViews(
+	ctx context.Context, opts ...options.Enumerable[options.RefreshViewsOptions],
+) error {
 	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
 	return txn.Client.RefreshViews(ctx, opts...)
 }

--- a/http/server.go
+++ b/http/server.go
@@ -50,7 +50,7 @@ type Server struct {
 }
 
 // NewServer instantiates a new server with the given http.Handler.
-func NewServer(handler http.Handler, opts ...options.Lister[options.NodeHTTPOptions]) (*Server, error) {
+func NewServer(handler http.Handler, opts ...options.Enumerable[options.NodeHTTPOptions]) (*Server, error) {
 	cfg := options.NodeHTTPOptions{
 		Address: defaultHTTPAddress,
 	}

--- a/internal/db/collection.go
+++ b/internal/db/collection.go
@@ -209,7 +209,7 @@ func (db *DB) getCollections(
 // it hits every key and will cause Tx conflicts for concurrent Txs
 func (c *collection) GetAllDocIDs(
 	ctx context.Context,
-	opts ...options.Lister[options.CollectionGetAllDocIDsOptions],
+	opts ...options.Enumerable[options.CollectionGetAllDocIDsOptions],
 ) (<-chan client.DocIDResult, error) {
 	ctx, span := tracer.Start(ctx)
 	defer span.End()
@@ -337,7 +337,7 @@ func (c *collection) CollectionID() string {
 func (c *collection) Create(
 	ctx context.Context,
 	doc *client.Document,
-	opts ...options.Lister[options.CollectionCreateOptions],
+	opts ...options.Enumerable[options.CollectionCreateOptions],
 ) error {
 	ctx, span := tracer.Start(ctx)
 	defer span.End()
@@ -369,7 +369,7 @@ func (c *collection) Create(
 func (c *collection) CreateMany(
 	ctx context.Context,
 	docs []*client.Document,
-	opts ...options.Lister[options.CollectionCreateOptions],
+	opts ...options.Enumerable[options.CollectionCreateOptions],
 ) error {
 	ctx, span := tracer.Start(ctx)
 	defer span.End()
@@ -499,7 +499,7 @@ func setContextDocEncryption(
 func (c *collection) Update(
 	ctx context.Context,
 	doc *client.Document,
-	opts ...options.Lister[options.CollectionUpdateOptions],
+	opts ...options.Enumerable[options.CollectionUpdateOptions],
 ) error {
 	ctx, span := tracer.Start(ctx)
 	defer span.End()
@@ -581,7 +581,7 @@ func (c *collection) update(
 func (c *collection) Save(
 	ctx context.Context,
 	doc *client.Document,
-	opts ...options.Lister[options.CollectionSaveOptions],
+	opts ...options.Enumerable[options.CollectionSaveOptions],
 ) error {
 	ctx, span := tracer.Start(ctx)
 	defer span.End()
@@ -829,7 +829,7 @@ func (c *collection) save(
 func (c *collection) Delete(
 	ctx context.Context,
 	docID client.DocID,
-	opts ...options.Lister[options.CollectionDeleteOptions],
+	opts ...options.Enumerable[options.CollectionDeleteOptions],
 ) (bool, error) {
 	ctx, span := tracer.Start(ctx)
 	defer span.End()
@@ -869,7 +869,7 @@ func (c *collection) Delete(
 func (c *collection) Exists(
 	ctx context.Context,
 	docID client.DocID,
-	opts ...options.Lister[options.CollectionExistsOptions],
+	opts ...options.Enumerable[options.CollectionExistsOptions],
 ) (bool, error) {
 	ctx, span := tracer.Start(ctx)
 	defer span.End()

--- a/internal/db/collection_delete.go
+++ b/internal/db/collection_delete.go
@@ -31,7 +31,7 @@ import (
 func (c *collection) DeleteWithFilter(
 	ctx context.Context,
 	filter any,
-	opts ...options.Lister[options.CollectionDeleteWithFilterOptions],
+	opts ...options.Enumerable[options.CollectionDeleteWithFilterOptions],
 ) (*client.DeleteResult, error) {
 	ctx, span := tracer.Start(ctx)
 	defer span.End()

--- a/internal/db/collection_get.go
+++ b/internal/db/collection_get.go
@@ -29,7 +29,7 @@ import (
 func (c *collection) Get(
 	ctx context.Context,
 	docID client.DocID,
-	opts ...options.Lister[options.CollectionGetOptions],
+	opts ...options.Enumerable[options.CollectionGetOptions],
 ) (*client.Document, error) {
 	ctx, span := tracer.Start(ctx)
 	defer span.End()

--- a/internal/db/collection_index.go
+++ b/internal/db/collection_index.go
@@ -166,7 +166,7 @@ func (c *collection) deleteIndexedDocWithID(
 func (c *collection) CreateIndex(
 	ctx context.Context,
 	desc client.IndexCreateRequest,
-	opts ...options.Lister[options.CollectionCreateIndexOptions],
+	opts ...options.Enumerable[options.CollectionCreateIndexOptions],
 ) (client.IndexDescription, error) {
 	ctx, span := tracer.Start(ctx)
 	defer span.End()
@@ -361,7 +361,7 @@ func (c *collection) indexExistingDocs(
 func (c *collection) DropIndex(
 	ctx context.Context,
 	indexName string,
-	opts ...options.Lister[options.CollectionDropIndexOptions],
+	opts ...options.Enumerable[options.CollectionDropIndexOptions],
 ) error {
 	ctx, span := tracer.Start(ctx)
 	defer span.End()
@@ -423,7 +423,7 @@ func (c *collection) dropIndex(ctx context.Context, indexName string) error {
 // GetIndexes returns all indexes for the collection.
 func (c *collection) GetIndexes(
 	ctx context.Context,
-	opts ...options.Lister[options.CollectionGetIndexesOptions],
+	opts ...options.Enumerable[options.CollectionGetIndexesOptions],
 ) ([]client.IndexDescription, error) {
 	opt := utils.NewOptions(opts...)
 

--- a/internal/db/collection_truncate.go
+++ b/internal/db/collection_truncate.go
@@ -31,7 +31,9 @@ import (
 // our deletes.
 const hardDeleteChunkSize int = 10000
 
-func (c *collection) Truncate(ctx context.Context, opts ...options.Enumerable[options.CollectionTruncateOptions]) error {
+func (c *collection) Truncate(
+	ctx context.Context, opts ...options.Enumerable[options.CollectionTruncateOptions],
+) error {
 	ctx, span := tracer.Start(ctx)
 	defer span.End()
 

--- a/internal/db/collection_truncate.go
+++ b/internal/db/collection_truncate.go
@@ -31,7 +31,7 @@ import (
 // our deletes.
 const hardDeleteChunkSize int = 10000
 
-func (c *collection) Truncate(ctx context.Context, opts ...options.Lister[options.CollectionTruncateOptions]) error {
+func (c *collection) Truncate(ctx context.Context, opts ...options.Enumerable[options.CollectionTruncateOptions]) error {
 	ctx, span := tracer.Start(ctx)
 	defer span.End()
 

--- a/internal/db/collection_update.go
+++ b/internal/db/collection_update.go
@@ -33,7 +33,7 @@ func (c *collection) UpdateWithFilter(
 	ctx context.Context,
 	filter any,
 	updater string,
-	opts ...options.Lister[options.CollectionUpdateWithFilterOptions],
+	opts ...options.Enumerable[options.CollectionUpdateWithFilterOptions],
 ) (*client.UpdateResult, error) {
 	ctx, span := tracer.Start(ctx)
 	defer span.End()

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -30,6 +30,7 @@ import (
 	"github.com/sourcenetwork/defradb/acp/dac"
 	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
+	"github.com/sourcenetwork/defradb/client/options"
 	"github.com/sourcenetwork/defradb/errors"
 	"github.com/sourcenetwork/defradb/event"
 	"github.com/sourcenetwork/defradb/internal/core"
@@ -123,7 +124,7 @@ func NewDB(
 	ctx context.Context,
 	rootstore corekv.TxnStore,
 	nodeACP acpDB.NACInfo,
-	opts ...intOpts.Enumerable[intOpts.DBOptions],
+	opts ...options.Enumerable[intOpts.DBOptions],
 ) (*DB, error) {
 	return newDB(ctx, rootstore, nodeACP, opts...)
 }
@@ -132,7 +133,7 @@ func newDB(
 	ctx context.Context,
 	rootstore corekv.TxnStore,
 	nodeACP acpDB.NACInfo,
-	opts ...intOpts.Enumerable[intOpts.DBOptions],
+	opts ...options.Enumerable[intOpts.DBOptions],
 ) (*DB, error) {
 	cfg := defaultDBConfig()
 	utils.ApplyOptions(&cfg, opts...)

--- a/internal/db/db_dac.go
+++ b/internal/db/db_dac.go
@@ -53,7 +53,7 @@ func (db *DB) PurgeDACState(ctx context.Context) error {
 func (db *DB) AddDACPolicy(
 	ctx context.Context,
 	policy string,
-	opts ...options.Lister[options.AddDACPolicyOptions],
+	opts ...options.Enumerable[options.AddDACPolicyOptions],
 ) (client.AddPolicyResult, error) {
 	ctx, span := tracer.Start(ctx)
 	defer span.End()
@@ -86,7 +86,7 @@ func (db *DB) AddDACActorRelationship(
 	docID string,
 	relation string,
 	targetActor string,
-	opts ...options.Lister[options.AddDACActorRelationshipOptions],
+	opts ...options.Enumerable[options.AddDACActorRelationshipOptions],
 ) (client.AddActorRelationshipResult, error) {
 	ctx, span := tracer.Start(ctx)
 	defer span.End()
@@ -142,7 +142,7 @@ func (db *DB) DeleteDACActorRelationship(
 	docID string,
 	relation string,
 	targetActor string,
-	opts ...options.Lister[options.DeleteDACActorRelationshipOptions],
+	opts ...options.Enumerable[options.DeleteDACActorRelationshipOptions],
 ) (client.DeleteActorRelationshipResult, error) {
 	ctx, span := tracer.Start(ctx)
 	defer span.End()

--- a/internal/db/db_nac.go
+++ b/internal/db/db_nac.go
@@ -68,7 +68,7 @@ func (db *DB) PurgeNACState(ctx context.Context) error {
 //
 // Returns an [client.ErrNotAuthorizedToPerformOperation] error if the requesting identity is not
 // authorized to perform this operation.
-func (db *DB) ReEnableNAC(ctx context.Context, opts ...options.Lister[options.ReEnableNACOptions]) error {
+func (db *DB) ReEnableNAC(ctx context.Context, opts ...options.Enumerable[options.ReEnableNACOptions]) error {
 	ctx, span := tracer.Start(ctx)
 	defer span.End()
 
@@ -101,7 +101,7 @@ func (db *DB) ReEnableNAC(ctx context.Context, opts ...options.Lister[options.Re
 //
 // Returns an [client.ErrNotAuthorizedToPerformOperation] error if the requesting identity is not
 // authorized to perform this operation.
-func (db *DB) DisableNAC(ctx context.Context, opts ...options.Lister[options.DisableNACOptions]) error {
+func (db *DB) DisableNAC(ctx context.Context, opts ...options.Enumerable[options.DisableNACOptions]) error {
 	ctx, span := tracer.Start(ctx)
 	defer span.End()
 
@@ -126,7 +126,7 @@ func (db *DB) DisableNAC(ctx context.Context, opts ...options.Lister[options.Dis
 
 func (db *DB) GetNACStatus(
 	ctx context.Context,
-	opts ...options.Lister[options.GetNACStatusOptions],
+	opts ...options.Enumerable[options.GetNACStatusOptions],
 ) (client.NACStatusResult, error) {
 	ctx, span := tracer.Start(ctx)
 	defer span.End()
@@ -146,7 +146,7 @@ func (db *DB) AddNACActorRelationship(
 	ctx context.Context,
 	relation string,
 	targetActor string,
-	opts ...options.Lister[options.AddNACActorRelationshipOptions],
+	opts ...options.Enumerable[options.AddNACActorRelationshipOptions],
 ) (client.AddActorRelationshipResult, error) {
 	ctx, span := tracer.Start(ctx)
 	defer span.End()
@@ -166,7 +166,7 @@ func (db *DB) DeleteNACActorRelationship(
 	ctx context.Context,
 	relation string,
 	targetActor string,
-	opts ...options.Lister[options.DeleteNACActorRelationshipOptions],
+	opts ...options.Enumerable[options.DeleteNACActorRelationshipOptions],
 ) (client.DeleteActorRelationshipResult, error) {
 	ctx, span := tracer.Start(ctx)
 	defer span.End()

--- a/internal/db/p2p.go
+++ b/internal/db/p2p.go
@@ -46,7 +46,9 @@ func (db *DB) PeerInfo(ctx context.Context, opts ...options.Enumerable[options.P
 }
 
 // Connect tries to connect to the peer with the given [PeerInfo].
-func (db *DB) Connect(ctx context.Context, addresses []string, opts ...options.Enumerable[options.ConnectOptions]) error {
+func (db *DB) Connect(
+	ctx context.Context, addresses []string, opts ...options.Enumerable[options.ConnectOptions],
+) error {
 	opt := utils.NewOptions(opts...)
 
 	if err := db.checkNodeAccess(ctx, opt.Identity, acpTypes.NodeP2PPeerConnectPerm); err != nil {
@@ -143,7 +145,9 @@ func (db *DB) ListReplicators(
 	return db.p2p.ListReplicators(ctx)
 }
 
-func (db *DB) ActivePeers(ctx context.Context, opts ...options.Enumerable[options.ActivePeersOptions]) ([]string, error) {
+func (db *DB) ActivePeers(
+	ctx context.Context, opts ...options.Enumerable[options.ActivePeersOptions],
+) ([]string, error) {
 	opt := utils.NewOptions(opts...)
 
 	if err := db.checkNodeAccess(ctx, opt.Identity, acpTypes.NodeP2PPeerActivePerm); err != nil {
@@ -385,7 +389,7 @@ func (db *DB) SyncCollectionVersions(
 func (db *DB) SyncBranchableCollection(
 	ctx context.Context,
 	collectionID string,
-	opts ...options.Lister[options.SyncBranchableCollectionOptions],
+	opts ...options.Enumerable[options.SyncBranchableCollectionOptions],
 ) error {
 	opt := utils.NewOptions(opts...)
 

--- a/internal/db/p2p.go
+++ b/internal/db/p2p.go
@@ -32,7 +32,7 @@ func (db *DB) sendUpdate(evt event.Update) {
 }
 
 // PeerInfo returns the p2p host id and listening addresses.
-func (db *DB) PeerInfo(ctx context.Context, opts ...options.Lister[options.PeerInfoOptions]) ([]string, error) {
+func (db *DB) PeerInfo(ctx context.Context, opts ...options.Enumerable[options.PeerInfoOptions]) ([]string, error) {
 	opt := utils.NewOptions(opts...)
 
 	if err := db.checkNodeAccess(ctx, opt.Identity, acpTypes.NodeP2PPeerInfo); err != nil {
@@ -46,7 +46,7 @@ func (db *DB) PeerInfo(ctx context.Context, opts ...options.Lister[options.PeerI
 }
 
 // Connect tries to connect to the peer with the given [PeerInfo].
-func (db *DB) Connect(ctx context.Context, addresses []string, opts ...options.Lister[options.ConnectOptions]) error {
+func (db *DB) Connect(ctx context.Context, addresses []string, opts ...options.Enumerable[options.ConnectOptions]) error {
 	opt := utils.NewOptions(opts...)
 
 	if err := db.checkNodeAccess(ctx, opt.Identity, acpTypes.NodeP2PPeerConnectPerm); err != nil {
@@ -61,7 +61,7 @@ func (db *DB) Connect(ctx context.Context, addresses []string, opts ...options.L
 func (db *DB) CreateReplicator(
 	ctx context.Context,
 	addresses []string,
-	opts ...options.Lister[options.CreateReplicatorOptions],
+	opts ...options.Enumerable[options.CreateReplicatorOptions],
 ) error {
 	opt := utils.NewOptions(opts...)
 
@@ -93,7 +93,7 @@ func (db *DB) CreateReplicator(
 func (db *DB) DeleteReplicator(
 	ctx context.Context,
 	id string,
-	opts ...options.Lister[options.DeleteReplicatorOptions],
+	opts ...options.Enumerable[options.DeleteReplicatorOptions],
 ) error {
 	opt := utils.NewOptions(opts...)
 
@@ -124,7 +124,7 @@ func (db *DB) DeleteReplicator(
 // subscribed schemas.
 func (db *DB) ListReplicators(
 	ctx context.Context,
-	opts ...options.Lister[options.ListReplicatorsOptions],
+	opts ...options.Enumerable[options.ListReplicatorsOptions],
 ) ([]client.Replicator, error) {
 	opt := utils.NewOptions(opts...)
 
@@ -143,7 +143,7 @@ func (db *DB) ListReplicators(
 	return db.p2p.ListReplicators(ctx)
 }
 
-func (db *DB) ActivePeers(ctx context.Context, opts ...options.Lister[options.ActivePeersOptions]) ([]string, error) {
+func (db *DB) ActivePeers(ctx context.Context, opts ...options.Enumerable[options.ActivePeersOptions]) ([]string, error) {
 	opt := utils.NewOptions(opts...)
 
 	if err := db.checkNodeAccess(ctx, opt.Identity, acpTypes.NodeP2PPeerActivePerm); err != nil {
@@ -163,7 +163,7 @@ func (db *DB) ActivePeers(ctx context.Context, opts ...options.Lister[options.Ac
 func (db *DB) CreateP2PCollections(
 	ctx context.Context,
 	collectionNames []string,
-	opts ...options.Lister[options.CreateP2PCollectionsOptions],
+	opts ...options.Enumerable[options.CreateP2PCollectionsOptions],
 ) error {
 	opt := utils.NewOptions(opts...)
 
@@ -194,7 +194,7 @@ func (db *DB) CreateP2PCollections(
 func (db *DB) DeleteP2PCollections(
 	ctx context.Context,
 	collectionNames []string,
-	opts ...options.Lister[options.DeleteP2PCollectionsOptions],
+	opts ...options.Enumerable[options.DeleteP2PCollectionsOptions],
 ) error {
 	opt := utils.NewOptions(opts...)
 
@@ -223,7 +223,7 @@ func (db *DB) DeleteP2PCollections(
 // the P2P system subscribes to.
 func (db *DB) ListP2PCollections(
 	ctx context.Context,
-	opts ...options.Lister[options.ListP2PCollectionsOptions],
+	opts ...options.Enumerable[options.ListP2PCollectionsOptions],
 ) ([]string, error) {
 	opt := utils.NewOptions(opts...)
 
@@ -249,7 +249,7 @@ func (db *DB) ListP2PCollections(
 func (db *DB) CreateP2PDocuments(
 	ctx context.Context,
 	docIDs []string,
-	opts ...options.Lister[options.CreateP2PDocumentsOptions],
+	opts ...options.Enumerable[options.CreateP2PDocumentsOptions],
 ) error {
 	opt := utils.NewOptions(opts...)
 
@@ -280,7 +280,7 @@ func (db *DB) CreateP2PDocuments(
 func (db *DB) DeleteP2PDocuments(
 	ctx context.Context,
 	docIDs []string,
-	opts ...options.Lister[options.DeleteP2PDocumentsOptions],
+	opts ...options.Enumerable[options.DeleteP2PDocumentsOptions],
 ) error {
 	opt := utils.NewOptions(opts...)
 
@@ -309,7 +309,7 @@ func (db *DB) DeleteP2PDocuments(
 // the P2P system subscribes to.
 func (db *DB) ListP2PDocuments(
 	ctx context.Context,
-	opts ...options.Lister[options.ListP2PDocumentsOptions],
+	opts ...options.Enumerable[options.ListP2PDocumentsOptions],
 ) ([]string, error) {
 	opt := utils.NewOptions(opts...)
 
@@ -349,7 +349,7 @@ func (db *DB) SyncDocuments(ctx context.Context, collectionName string, docIDs [
 func (db *DB) SyncCollectionVersions(
 	ctx context.Context,
 	versionIDs []string,
-	opts ...options.Lister[options.SyncCollectionVersionsOptions],
+	opts ...options.Enumerable[options.SyncCollectionVersionsOptions],
 ) error {
 	opt := utils.NewOptions(opts...)
 

--- a/internal/db/p2p/p2p.go
+++ b/internal/db/p2p/p2p.go
@@ -76,7 +76,7 @@ type DB interface {
 	// that currently exist within this [Store].
 	GetCollections(
 		ctx context.Context,
-		opts ...options.Lister[options.GetCollectionsOptions],
+		opts ...options.Enumerable[options.GetCollectionsOptions],
 	) ([]client.Collection, error)
 	// Merge initiates a merge of the DAG and caches the resulting values into the datastore.
 	Merge(ctx context.Context, evt event.Merge) error

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -27,7 +27,7 @@ import (
 // ExecRequest executes a request against the database.
 func (db *DB) ExecRequest(
 	ctx context.Context,
-	request string, opts ...options.Lister[options.ExecRequestOptions],
+	request string, opts ...options.Enumerable[options.ExecRequestOptions],
 ) *client.RequestResult {
 	ctx, span := tracer.Start(ctx)
 	defer span.End()
@@ -68,7 +68,7 @@ func (db *DB) ExecRequest(
 func (db *DB) GetCollectionByName(
 	ctx context.Context,
 	name string,
-	opts ...options.Lister[options.GetCollectionByNameOptions],
+	opts ...options.Enumerable[options.GetCollectionByNameOptions],
 ) (client.Collection, error) {
 	ctx, span := tracer.Start(ctx)
 	defer span.End()
@@ -91,7 +91,7 @@ func (db *DB) GetCollectionByName(
 // GetCollections gets all the currently defined collections.
 func (db *DB) GetCollections(
 	ctx context.Context,
-	opts ...options.Lister[options.GetCollectionsOptions],
+	opts ...options.Enumerable[options.GetCollectionsOptions],
 ) ([]client.Collection, error) {
 	ctx, span := tracer.Start(ctx)
 	defer span.End()
@@ -114,7 +114,7 @@ func (db *DB) GetCollections(
 // GetAllIndexes gets all the indexes in the database.
 func (db *DB) GetAllIndexes(
 	ctx context.Context,
-	opts ...options.Lister[options.GetAllIndexesOptions],
+	opts ...options.Enumerable[options.GetAllIndexesOptions],
 ) (map[client.CollectionName][]client.IndexDescription, error) {
 	ctx, span := tracer.Start(ctx)
 	defer span.End()
@@ -158,7 +158,7 @@ func (db *DB) ListAllEncryptedIndexes(
 func (db *DB) AddSchema(
 	ctx context.Context,
 	schemaString string,
-	opts ...options.Lister[options.AddSchemaOptions],
+	opts ...options.Enumerable[options.AddSchemaOptions],
 ) ([]client.CollectionVersion, error) {
 	ctx, span := tracer.Start(ctx)
 	defer span.End()
@@ -202,7 +202,7 @@ func (db *DB) PatchCollection(
 	ctx context.Context,
 	patchString string,
 	migration immutable.Option[model.Lens],
-	opts ...options.Lister[options.PatchCollectionOptions],
+	opts ...options.Enumerable[options.PatchCollectionOptions],
 ) error {
 	ctx, span := tracer.Start(ctx)
 	defer span.End()
@@ -230,7 +230,7 @@ func (db *DB) PatchCollection(
 func (db *DB) SetActiveCollectionVersion(
 	ctx context.Context,
 	collectionVersionID string,
-	opts ...options.Lister[options.SetActiveCollectionVersionOptions],
+	opts ...options.Enumerable[options.SetActiveCollectionVersionOptions],
 ) error {
 	ctx, span := tracer.Start(ctx)
 	defer span.End()
@@ -281,7 +281,7 @@ func (db *DB) SetMigration(ctx context.Context, cfg client.LensConfig) (string, 
 func (db *DB) AddLens(
 	ctx context.Context,
 	lens model.Lens,
-	opts ...options.Lister[options.AddLensOptions],
+	opts ...options.Enumerable[options.AddLensOptions],
 ) (string, error) {
 	ctx, span := tracer.Start(ctx)
 	defer span.End()
@@ -314,7 +314,7 @@ func (db *DB) AddLens(
 
 func (db *DB) ListLenses(
 	ctx context.Context,
-	opts ...options.Lister[options.ListLensesOptions],
+	opts ...options.Enumerable[options.ListLensesOptions],
 ) (map[string]model.Lens, error) {
 	ctx, span := tracer.Start(ctx)
 	defer span.End()
@@ -339,7 +339,7 @@ func (db *DB) AddView(
 	ctx context.Context,
 	query string,
 	sdl string,
-	opts ...options.Lister[options.AddViewOptions],
+	opts ...options.Enumerable[options.AddViewOptions],
 ) ([]client.CollectionVersion, error) {
 	ctx, span := tracer.Start(ctx)
 	defer span.End()
@@ -371,7 +371,7 @@ func (db *DB) AddView(
 	return defs, nil
 }
 
-func (db *DB) RefreshViews(ctx context.Context, opts ...options.Lister[options.RefreshViewsOptions]) error {
+func (db *DB) RefreshViews(ctx context.Context, opts ...options.Enumerable[options.RefreshViewsOptions]) error {
 	ctx, span := tracer.Start(ctx)
 	defer span.End()
 
@@ -426,7 +426,7 @@ func (db *DB) BasicImport(ctx context.Context, filepath string) error {
 func (db *DB) BasicExport(
 	ctx context.Context,
 	filepath string,
-	opts ...options.Lister[options.BasicExportOptions],
+	opts ...options.Enumerable[options.BasicExportOptions],
 ) error {
 	ctx, span := tracer.Start(ctx)
 	defer span.End()

--- a/internal/db/txn.go
+++ b/internal/db/txn.go
@@ -328,11 +328,15 @@ func (txn *Txn) PeerInfo(ctx context.Context, opts ...options.Enumerable[options
 	return txn.db.PeerInfo(ctx, opts...)
 }
 
-func (txn *Txn) ActivePeers(ctx context.Context, opts ...options.Enumerable[options.ActivePeersOptions]) ([]string, error) {
+func (txn *Txn) ActivePeers(
+	ctx context.Context, opts ...options.Enumerable[options.ActivePeersOptions],
+) ([]string, error) {
 	return txn.db.ActivePeers(ctx, opts...)
 }
 
-func (txn *Txn) Connect(ctx context.Context, addresses []string, opts ...options.Enumerable[options.ConnectOptions]) error {
+func (txn *Txn) Connect(
+	ctx context.Context, addresses []string, opts ...options.Enumerable[options.ConnectOptions],
+) error {
 	return txn.db.Connect(ctx, addresses, opts...)
 }
 
@@ -431,7 +435,7 @@ func (txn *Txn) SyncCollectionVersions(
 func (txn *Txn) SyncBranchableCollection(
 	ctx context.Context,
 	collectionID string,
-	opts ...options.Lister[options.SyncBranchableCollectionOptions],
+	opts ...options.Enumerable[options.SyncBranchableCollectionOptions],
 ) error {
 	ctx = InitContext(ctx, txn)
 	return txn.db.SyncBranchableCollection(ctx, collectionID, opts...)

--- a/internal/db/txn.go
+++ b/internal/db/txn.go
@@ -121,7 +121,7 @@ func (txn *Txn) PrintDump(ctx context.Context) error {
 func (txn *Txn) AddDACPolicy(
 	ctx context.Context,
 	policy string,
-	opts ...options.Lister[options.AddDACPolicyOptions],
+	opts ...options.Enumerable[options.AddDACPolicyOptions],
 ) (client.AddPolicyResult, error) {
 	ctx = InitContext(ctx, txn)
 	return txn.db.AddDACPolicy(ctx, policy, opts...)
@@ -133,7 +133,7 @@ func (txn *Txn) AddDACActorRelationship(
 	docID string,
 	relation string,
 	targetActor string,
-	opts ...options.Lister[options.AddDACActorRelationshipOptions],
+	opts ...options.Enumerable[options.AddDACActorRelationshipOptions],
 ) (client.AddActorRelationshipResult, error) {
 	ctx = InitContext(ctx, txn)
 	return txn.db.AddDACActorRelationship(ctx, collectionName, docID, relation, targetActor, opts...)
@@ -145,7 +145,7 @@ func (txn *Txn) DeleteDACActorRelationship(
 	docID string,
 	relation string,
 	targetActor string,
-	opts ...options.Lister[options.DeleteDACActorRelationshipOptions],
+	opts ...options.Enumerable[options.DeleteDACActorRelationshipOptions],
 ) (client.DeleteActorRelationshipResult, error) {
 	ctx = InitContext(ctx, txn)
 	return txn.db.DeleteDACActorRelationship(ctx, collectionName, docID, relation, targetActor, opts...)
@@ -155,7 +155,7 @@ func (txn *Txn) AddNACActorRelationship(
 	ctx context.Context,
 	relation string,
 	targetActor string,
-	opts ...options.Lister[options.AddNACActorRelationshipOptions],
+	opts ...options.Enumerable[options.AddNACActorRelationshipOptions],
 ) (client.AddActorRelationshipResult, error) {
 	ctx = InitContext(ctx, txn)
 	return txn.db.AddNACActorRelationship(ctx, relation, targetActor, opts...)
@@ -165,25 +165,25 @@ func (txn *Txn) DeleteNACActorRelationship(
 	ctx context.Context,
 	relation string,
 	targetActor string,
-	opts ...options.Lister[options.DeleteNACActorRelationshipOptions],
+	opts ...options.Enumerable[options.DeleteNACActorRelationshipOptions],
 ) (client.DeleteActorRelationshipResult, error) {
 	ctx = InitContext(ctx, txn)
 	return txn.db.DeleteNACActorRelationship(ctx, relation, targetActor, opts...)
 }
 
-func (txn *Txn) ReEnableNAC(ctx context.Context, opts ...options.Lister[options.ReEnableNACOptions]) error {
+func (txn *Txn) ReEnableNAC(ctx context.Context, opts ...options.Enumerable[options.ReEnableNACOptions]) error {
 	ctx = InitContext(ctx, txn)
 	return txn.db.ReEnableNAC(ctx, opts...)
 }
 
-func (txn *Txn) DisableNAC(ctx context.Context, opts ...options.Lister[options.DisableNACOptions]) error {
+func (txn *Txn) DisableNAC(ctx context.Context, opts ...options.Enumerable[options.DisableNACOptions]) error {
 	ctx = InitContext(ctx, txn)
 	return txn.db.DisableNAC(ctx, opts...)
 }
 
 func (txn *Txn) GetNACStatus(
 	ctx context.Context,
-	opts ...options.Lister[options.GetNACStatusOptions],
+	opts ...options.Enumerable[options.GetNACStatusOptions],
 ) (client.NACStatusResult, error) {
 	ctx = InitContext(ctx, txn)
 	return txn.db.GetNACStatus(ctx, opts...)
@@ -198,7 +198,7 @@ func (txn *Txn) VerifySignature(
 	ctx context.Context,
 	blockCid string,
 	pubKey crypto.PublicKey,
-	opts ...options.Lister[options.VerifySignatureOptions],
+	opts ...options.Enumerable[options.VerifySignatureOptions],
 ) error {
 	ctx = InitContext(ctx, txn)
 	return txn.db.VerifySignature(ctx, blockCid, pubKey, opts...)
@@ -207,7 +207,7 @@ func (txn *Txn) VerifySignature(
 func (txn *Txn) AddSchema(
 	ctx context.Context,
 	sdl string,
-	opts ...options.Lister[options.AddSchemaOptions],
+	opts ...options.Enumerable[options.AddSchemaOptions],
 ) ([]client.CollectionVersion, error) {
 	ctx = InitContext(ctx, txn)
 	return txn.db.AddSchema(ctx, sdl, opts...)
@@ -217,7 +217,7 @@ func (txn *Txn) PatchCollection(
 	ctx context.Context,
 	patch string,
 	migration immutable.Option[model.Lens],
-	opts ...options.Lister[options.PatchCollectionOptions],
+	opts ...options.Enumerable[options.PatchCollectionOptions],
 ) error {
 	ctx = InitContext(ctx, txn)
 	return txn.db.PatchCollection(ctx, patch, migration, opts...)
@@ -226,7 +226,7 @@ func (txn *Txn) PatchCollection(
 func (txn *Txn) SetActiveCollectionVersion(
 	ctx context.Context,
 	version string,
-	opts ...options.Lister[options.SetActiveCollectionVersionOptions],
+	opts ...options.Enumerable[options.SetActiveCollectionVersionOptions],
 ) error {
 	ctx = InitContext(ctx, txn)
 	return txn.db.SetActiveCollectionVersion(ctx, version, opts...)
@@ -236,13 +236,13 @@ func (txn *Txn) AddView(
 	ctx context.Context,
 	gqlQuery string,
 	sdl string,
-	opts ...options.Lister[options.AddViewOptions],
+	opts ...options.Enumerable[options.AddViewOptions],
 ) ([]client.CollectionVersion, error) {
 	ctx = InitContext(ctx, txn)
 	return txn.db.AddView(ctx, gqlQuery, sdl, opts...)
 }
 
-func (txn *Txn) RefreshViews(ctx context.Context, opts ...options.Lister[options.RefreshViewsOptions]) error {
+func (txn *Txn) RefreshViews(ctx context.Context, opts ...options.Enumerable[options.RefreshViewsOptions]) error {
 	ctx = InitContext(ctx, txn)
 	return txn.db.RefreshViews(ctx, opts...)
 }
@@ -255,7 +255,7 @@ func (txn *Txn) SetMigration(ctx context.Context, config client.LensConfig) (str
 func (txn *Txn) AddLens(
 	ctx context.Context,
 	lens model.Lens,
-	opts ...options.Lister[options.AddLensOptions],
+	opts ...options.Enumerable[options.AddLensOptions],
 ) (string, error) {
 	ctx = InitContext(ctx, txn)
 	return txn.db.AddLens(ctx, lens, opts...)
@@ -263,7 +263,7 @@ func (txn *Txn) AddLens(
 
 func (txn *Txn) ListLenses(
 	ctx context.Context,
-	opts ...options.Lister[options.ListLensesOptions],
+	opts ...options.Enumerable[options.ListLensesOptions],
 ) (map[string]model.Lens, error) {
 	ctx = InitContext(ctx, txn)
 	return txn.db.ListLenses(ctx)
@@ -272,7 +272,7 @@ func (txn *Txn) ListLenses(
 func (txn *Txn) GetCollectionByName(
 	ctx context.Context,
 	name client.CollectionName,
-	opts ...options.Lister[options.GetCollectionByNameOptions],
+	opts ...options.Enumerable[options.GetCollectionByNameOptions],
 ) (client.Collection, error) {
 	ctx = InitContext(ctx, txn)
 	return txn.db.GetCollectionByName(ctx, name, opts...)
@@ -280,7 +280,7 @@ func (txn *Txn) GetCollectionByName(
 
 func (txn *Txn) GetCollections(
 	ctx context.Context,
-	opts ...options.Lister[options.GetCollectionsOptions],
+	opts ...options.Enumerable[options.GetCollectionsOptions],
 ) ([]client.Collection, error) {
 	ctx = InitContext(ctx, txn)
 	return txn.db.GetCollections(ctx, opts...)
@@ -288,7 +288,7 @@ func (txn *Txn) GetCollections(
 
 func (txn *Txn) GetAllIndexes(
 	ctx context.Context,
-	opts ...options.Lister[options.GetAllIndexesOptions],
+	opts ...options.Enumerable[options.GetAllIndexesOptions],
 ) (map[client.CollectionName][]client.IndexDescription, error) {
 	ctx = InitContext(ctx, txn)
 	return txn.db.GetAllIndexes(ctx, opts...)
@@ -304,7 +304,7 @@ func (txn *Txn) ListAllEncryptedIndexes(
 func (txn *Txn) ExecRequest(
 	ctx context.Context,
 	request string,
-	opts ...options.Lister[options.ExecRequestOptions],
+	opts ...options.Enumerable[options.ExecRequestOptions],
 ) *client.RequestResult {
 	ctx = InitContext(ctx, txn)
 	return txn.db.ExecRequest(ctx, request, opts...)
@@ -318,28 +318,28 @@ func (txn *Txn) BasicImport(ctx context.Context, filepath string) error {
 func (txn *Txn) BasicExport(
 	ctx context.Context,
 	filepath string,
-	opts ...options.Lister[options.BasicExportOptions],
+	opts ...options.Enumerable[options.BasicExportOptions],
 ) error {
 	ctx = InitContext(ctx, txn)
 	return txn.db.BasicExport(ctx, filepath, opts...)
 }
 
-func (txn *Txn) PeerInfo(ctx context.Context, opts ...options.Lister[options.PeerInfoOptions]) ([]string, error) {
+func (txn *Txn) PeerInfo(ctx context.Context, opts ...options.Enumerable[options.PeerInfoOptions]) ([]string, error) {
 	return txn.db.PeerInfo(ctx, opts...)
 }
 
-func (txn *Txn) ActivePeers(ctx context.Context, opts ...options.Lister[options.ActivePeersOptions]) ([]string, error) {
+func (txn *Txn) ActivePeers(ctx context.Context, opts ...options.Enumerable[options.ActivePeersOptions]) ([]string, error) {
 	return txn.db.ActivePeers(ctx, opts...)
 }
 
-func (txn *Txn) Connect(ctx context.Context, addresses []string, opts ...options.Lister[options.ConnectOptions]) error {
+func (txn *Txn) Connect(ctx context.Context, addresses []string, opts ...options.Enumerable[options.ConnectOptions]) error {
 	return txn.db.Connect(ctx, addresses, opts...)
 }
 
 func (txn *Txn) CreateReplicator(
 	ctx context.Context,
 	addresses []string,
-	opts ...options.Lister[options.CreateReplicatorOptions],
+	opts ...options.Enumerable[options.CreateReplicatorOptions],
 ) error {
 	ctx = InitContext(ctx, txn)
 	return txn.db.CreateReplicator(ctx, addresses, opts...)
@@ -348,7 +348,7 @@ func (txn *Txn) CreateReplicator(
 func (txn *Txn) DeleteReplicator(
 	ctx context.Context,
 	id string,
-	opts ...options.Lister[options.DeleteReplicatorOptions],
+	opts ...options.Enumerable[options.DeleteReplicatorOptions],
 ) error {
 	ctx = InitContext(ctx, txn)
 	return txn.db.DeleteReplicator(ctx, id, opts...)
@@ -356,7 +356,7 @@ func (txn *Txn) DeleteReplicator(
 
 func (txn *Txn) ListReplicators(
 	ctx context.Context,
-	opts ...options.Lister[options.ListReplicatorsOptions],
+	opts ...options.Enumerable[options.ListReplicatorsOptions],
 ) ([]client.Replicator, error) {
 	ctx = InitContext(ctx, txn)
 	return txn.db.ListReplicators(ctx, opts...)
@@ -365,7 +365,7 @@ func (txn *Txn) ListReplicators(
 func (txn *Txn) CreateP2PCollections(
 	ctx context.Context,
 	collectionNames []string,
-	opts ...options.Lister[options.CreateP2PCollectionsOptions],
+	opts ...options.Enumerable[options.CreateP2PCollectionsOptions],
 ) error {
 	ctx = InitContext(ctx, txn)
 	return txn.db.CreateP2PCollections(ctx, collectionNames, opts...)
@@ -374,7 +374,7 @@ func (txn *Txn) CreateP2PCollections(
 func (txn *Txn) DeleteP2PCollections(
 	ctx context.Context,
 	collectionNames []string,
-	opts ...options.Lister[options.DeleteP2PCollectionsOptions],
+	opts ...options.Enumerable[options.DeleteP2PCollectionsOptions],
 ) error {
 	ctx = InitContext(ctx, txn)
 	return txn.db.DeleteP2PCollections(ctx, collectionNames, opts...)
@@ -382,7 +382,7 @@ func (txn *Txn) DeleteP2PCollections(
 
 func (txn *Txn) ListP2PCollections(
 	ctx context.Context,
-	opts ...options.Lister[options.ListP2PCollectionsOptions],
+	opts ...options.Enumerable[options.ListP2PCollectionsOptions],
 ) ([]string, error) {
 	ctx = InitContext(ctx, txn)
 	return txn.db.ListP2PCollections(ctx, opts...)
@@ -391,7 +391,7 @@ func (txn *Txn) ListP2PCollections(
 func (txn *Txn) CreateP2PDocuments(
 	ctx context.Context,
 	docIDs []string,
-	opts ...options.Lister[options.CreateP2PDocumentsOptions],
+	opts ...options.Enumerable[options.CreateP2PDocumentsOptions],
 ) error {
 	ctx = InitContext(ctx, txn)
 	return txn.db.CreateP2PDocuments(ctx, docIDs, opts...)
@@ -400,7 +400,7 @@ func (txn *Txn) CreateP2PDocuments(
 func (txn *Txn) DeleteP2PDocuments(
 	ctx context.Context,
 	docIDs []string,
-	opts ...options.Lister[options.DeleteP2PDocumentsOptions],
+	opts ...options.Enumerable[options.DeleteP2PDocumentsOptions],
 ) error {
 	ctx = InitContext(ctx, txn)
 	return txn.db.DeleteP2PDocuments(ctx, docIDs, opts...)
@@ -408,7 +408,7 @@ func (txn *Txn) DeleteP2PDocuments(
 
 func (txn *Txn) ListP2PDocuments(
 	ctx context.Context,
-	opts ...options.Lister[options.ListP2PDocumentsOptions],
+	opts ...options.Enumerable[options.ListP2PDocumentsOptions],
 ) ([]string, error) {
 	ctx = InitContext(ctx, txn)
 	return txn.db.ListP2PDocuments(ctx, opts...)
@@ -422,7 +422,7 @@ func (txn *Txn) SyncDocuments(ctx context.Context, collectionName string, docIDs
 func (txn *Txn) SyncCollectionVersions(
 	ctx context.Context,
 	versionIDs []string,
-	opts ...options.Lister[options.SyncCollectionVersionsOptions],
+	opts ...options.Enumerable[options.SyncCollectionVersionsOptions],
 ) error {
 	ctx = InitContext(ctx, txn)
 	return txn.db.SyncCollectionVersions(ctx, versionIDs, opts...)

--- a/internal/db/verify.go
+++ b/internal/db/verify.go
@@ -33,7 +33,7 @@ func (db *DB) VerifySignature(
 	ctx context.Context,
 	blockCid string,
 	pubKey crypto.PublicKey,
-	opts ...options.Lister[options.VerifySignatureOptions],
+	opts ...options.Enumerable[options.VerifySignatureOptions],
 ) error {
 	opt := utils.NewOptions(opts...)
 

--- a/internal/options/enumerable.go
+++ b/internal/options/enumerable.go
@@ -10,14 +10,6 @@
 
 package options
 
-import (
-	"github.com/sourcenetwork/immutable/enumerable"
-)
-
-// Enumerable is a type alias for enumerable.Enumerable.
-// Option builders implement this interface via Next(), Value(), and Reset() methods.
-type Enumerable[T any] = enumerable.Enumerable[func(*T)]
-
 // enumerableBuilder provides a reusable implementation of enumerable.Enumerable
 // for option builders. Builders embed this struct to gain enumerable capabilities.
 type enumerableBuilder[T any] struct {

--- a/internal/planner/create.go
+++ b/internal/planner/create.go
@@ -46,7 +46,7 @@ type createNode struct {
 
 	execInfo createExecInfo
 
-	createOptions []options.Lister[options.CollectionCreateOptions]
+	createOptions []options.Enumerable[options.CollectionCreateOptions]
 }
 
 type createExecInfo struct {
@@ -167,7 +167,7 @@ func (p *Planner) CreateDocs(parsed *mapper.Mutation) (planNode, error) {
 		input:     parsed.CreateInput,
 		results:   results,
 		docMapper: docMapper{parsed.DocumentMapping},
-		createOptions: []options.Lister[options.CollectionCreateOptions]{
+		createOptions: []options.Enumerable[options.CollectionCreateOptions]{
 			options.WithIdentity(
 				options.CollectionCreate().
 					SetEncryptDoc(parsed.Encrypt).

--- a/internal/se/coordinator.go
+++ b/internal/se/coordinator.go
@@ -36,7 +36,7 @@ var log = corelog.NewLogger("se")
 // DB defines the database operations needed by the SE coordinator
 type DB interface {
 	MaxTxnRetries() int
-	GetCollections(context.Context, ...options.Lister[options.GetCollectionsOptions]) ([]client.Collection, error)
+	GetCollections(context.Context, ...options.Enumerable[options.GetCollectionsOptions]) ([]client.Collection, error)
 	Events() event.Bus
 	Multistore() *datastore.Multistore
 }

--- a/internal/se/mocks/db.go
+++ b/internal/se/mocks/db.go
@@ -128,7 +128,7 @@ type DB_GetCollections_Call struct {
 
 // GetCollections is a helper method to define mock.On call
 //   - context1 context.Context
-//   - vs ...options.Lister[options.GetCollectionsOptions]
+//   - vs ...options.Enumerable[options.GetCollectionsOptions]
 func (_e *DB_Expecter) GetCollections(context1 interface{}, vs ...interface{}) *DB_GetCollections_Call {
 	return &DB_GetCollections_Call{Call: _e.mock.On("GetCollections",
 		append([]interface{}{context1}, vs...)...)}

--- a/internal/se/mocks/db.go
+++ b/internal/se/mocks/db.go
@@ -88,7 +88,7 @@ func (_c *DB_Events_Call) RunAndReturn(run func() event.Bus) *DB_Events_Call {
 }
 
 // GetCollections provides a mock function for the type DB
-func (_mock *DB) GetCollections(context1 context.Context, vs ...options.Lister[options.GetCollectionsOptions]) ([]client.Collection, error) {
+func (_mock *DB) GetCollections(context1 context.Context, vs ...options.Enumerable[options.GetCollectionsOptions]) ([]client.Collection, error) {
 	var tmpRet mock.Arguments
 	if len(vs) > 0 {
 		tmpRet = _mock.Called(context1, vs)
@@ -103,17 +103,17 @@ func (_mock *DB) GetCollections(context1 context.Context, vs ...options.Lister[o
 
 	var r0 []client.Collection
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, ...options.Lister[options.GetCollectionsOptions]) ([]client.Collection, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, ...options.Enumerable[options.GetCollectionsOptions]) ([]client.Collection, error)); ok {
 		return returnFunc(context1, vs...)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, ...options.Lister[options.GetCollectionsOptions]) []client.Collection); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, ...options.Enumerable[options.GetCollectionsOptions]) []client.Collection); ok {
 		r0 = returnFunc(context1, vs...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]client.Collection)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, ...options.Lister[options.GetCollectionsOptions]) error); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, ...options.Enumerable[options.GetCollectionsOptions]) error); ok {
 		r1 = returnFunc(context1, vs...)
 	} else {
 		r1 = ret.Error(1)
@@ -134,16 +134,16 @@ func (_e *DB_Expecter) GetCollections(context1 interface{}, vs ...interface{}) *
 		append([]interface{}{context1}, vs...)...)}
 }
 
-func (_c *DB_GetCollections_Call) Run(run func(context1 context.Context, vs ...options.Lister[options.GetCollectionsOptions])) *DB_GetCollections_Call {
+func (_c *DB_GetCollections_Call) Run(run func(context1 context.Context, vs ...options.Enumerable[options.GetCollectionsOptions])) *DB_GetCollections_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
 			arg0 = args[0].(context.Context)
 		}
-		var arg1 []options.Lister[options.GetCollectionsOptions]
-		var variadicArgs []options.Lister[options.GetCollectionsOptions]
+		var arg1 []options.Enumerable[options.GetCollectionsOptions]
+		var variadicArgs []options.Enumerable[options.GetCollectionsOptions]
 		if len(args) > 1 {
-			variadicArgs = args[1].([]options.Lister[options.GetCollectionsOptions])
+			variadicArgs = args[1].([]options.Enumerable[options.GetCollectionsOptions])
 		}
 		arg1 = variadicArgs
 		run(
@@ -159,7 +159,7 @@ func (_c *DB_GetCollections_Call) Return(collections []client.Collection, err er
 	return _c
 }
 
-func (_c *DB_GetCollections_Call) RunAndReturn(run func(context1 context.Context, vs ...options.Lister[options.GetCollectionsOptions]) ([]client.Collection, error)) *DB_GetCollections_Call {
+func (_c *DB_GetCollections_Call) RunAndReturn(run func(context1 context.Context, vs ...options.Enumerable[options.GetCollectionsOptions]) ([]client.Collection, error)) *DB_GetCollections_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/js/client_collection.go
+++ b/js/client_collection.go
@@ -127,7 +127,7 @@ type createOptionsInput struct {
 	EncryptedFields []string `json:"encryptedFields"`
 }
 
-func getCreateOptionsFromArg(args []js.Value, argIndex int, ctxArgIndex int) ([]options.Lister[options.CollectionCreateOptions], error) {
+func getCreateOptionsFromArg(args []js.Value, argIndex int, ctxArgIndex int) ([]options.Enumerable[options.CollectionCreateOptions], error) {
 	var input createOptionsInput
 	if err := structArg(args, argIndex, "options", &input); err != nil {
 		return nil, err
@@ -141,7 +141,7 @@ func getCreateOptionsFromArg(args []js.Value, argIndex int, ctxArgIndex int) ([]
 		opt.SetEncryptedFields(input.EncryptedFields)
 	}
 	setOptIdentity(opt, args, ctxArgIndex)
-	return []options.Lister[options.CollectionCreateOptions]{opt}, nil
+	return []options.Enumerable[options.CollectionCreateOptions]{opt}, nil
 }
 
 func (c *clientCollection) update(this js.Value, args []js.Value) (js.Value, error) {

--- a/node/node.go
+++ b/node/node.go
@@ -102,7 +102,7 @@ func DefaultNodeOptions() options.NodeOptions {
 }
 
 // New returns a new node instance configured with the given options.
-func New(ctx context.Context, opts ...options.Lister[options.NodeOptions]) (*Node, error) {
+func New(ctx context.Context, opts ...options.Enumerable[options.NodeOptions]) (*Node, error) {
 	nodeOpts := DefaultNodeOptions()
 	utils.ApplyOptions(&nodeOpts, opts...)
 	n := Node{

--- a/node/store.go
+++ b/node/store.go
@@ -52,7 +52,9 @@ func GetDefaultStorePath() string {
 }
 
 // NewStore returns a new store with the given options.
-func NewStore(ctx context.Context, opts ...options.Enumerable[options.NodeStoreOptions]) (corekv.TxnStore, bool, error) {
+func NewStore(
+	ctx context.Context, opts ...options.Enumerable[options.NodeStoreOptions],
+) (corekv.TxnStore, bool, error) {
 	o := utils.NewOptions(opts...)
 	var isValueSizeLimited bool
 	if o.BadgerInMemory {

--- a/node/store.go
+++ b/node/store.go
@@ -52,7 +52,7 @@ func GetDefaultStorePath() string {
 }
 
 // NewStore returns a new store with the given options.
-func NewStore(ctx context.Context, opts ...options.Lister[options.NodeStoreOptions]) (corekv.TxnStore, bool, error) {
+func NewStore(ctx context.Context, opts ...options.Enumerable[options.NodeStoreOptions]) (corekv.TxnStore, bool, error) {
 	o := utils.NewOptions(opts...)
 	var isValueSizeLimited bool
 	if o.BadgerInMemory {

--- a/tests/action/create_doc.go
+++ b/tests/action/create_doc.go
@@ -328,7 +328,7 @@ func makeDocSaveOptions(
 	s *state.State,
 	action *CreateDoc,
 	nodeIndex int,
-) []options.Lister[options.CollectionSaveOptions] {
+) []options.Enumerable[options.CollectionSaveOptions] {
 	opts := options.CollectionSave().
 		SetEncryptDoc(action.IsDocEncrypted).
 		SetEncryptedFields(action.EncryptedFields)
@@ -336,14 +336,14 @@ func makeDocSaveOptions(
 	if identOption.HasValue() {
 		opts.SetIdentity(identOption.Value())
 	}
-	return []options.Lister[options.CollectionSaveOptions]{opts}
+	return []options.Enumerable[options.CollectionSaveOptions]{opts}
 }
 
 func makeDocCreateOptions(
 	s *state.State,
 	action *CreateDoc,
 	nodeIndex int,
-) []options.Lister[options.CollectionCreateOptions] {
+) []options.Enumerable[options.CollectionCreateOptions] {
 	opts := options.CollectionCreate().
 		SetEncryptDoc(action.IsDocEncrypted).
 		SetEncryptedFields(action.EncryptedFields)
@@ -351,5 +351,5 @@ func makeDocCreateOptions(
 	if identOption.HasValue() {
 		opts.SetIdentity(identOption.Value())
 	}
-	return []options.Lister[options.CollectionCreateOptions]{opts}
+	return []options.Enumerable[options.CollectionCreateOptions]{opts}
 }

--- a/tests/action/refresh_view.go
+++ b/tests/action/refresh_view.go
@@ -57,7 +57,7 @@ func (a *RefreshViews) Execute() {
 			identOpts.SetIdentity(identOption.Value())
 		}
 
-		var allOpts []options.Lister[options.RefreshViewsOptions]
+		var allOpts []options.Enumerable[options.RefreshViewsOptions]
 		if a.FilterOptions != nil {
 			a.FilterOptions.Reset()
 			allOpts = append(allOpts, a.FilterOptions)

--- a/tests/clients/cli/wrapper.go
+++ b/tests/clients/cli/wrapper.go
@@ -324,7 +324,7 @@ func (w *Wrapper) SyncCollectionVersions(
 func (w *Wrapper) SyncBranchableCollection(
 	ctx context.Context,
 	collectionID string,
-	opts ...options.Lister[options.SyncBranchableCollectionOptions],
+	opts ...options.Enumerable[options.SyncBranchableCollectionOptions],
 ) error {
 	args := []string{"client", "p2p", "collection", "sync-branchable", collectionID}
 

--- a/tests/clients/cli/wrapper.go
+++ b/tests/clients/cli/wrapper.go
@@ -70,7 +70,7 @@ func NewWrapper(node *node.Node, sourceHubAddress string) (*Wrapper, error) {
 	}, nil
 }
 
-func (w *Wrapper) PeerInfo(ctx context.Context, opts ...options.Lister[options.PeerInfoOptions]) ([]string, error) {
+func (w *Wrapper) PeerInfo(ctx context.Context, opts ...options.Enumerable[options.PeerInfoOptions]) ([]string, error) {
 	args := []string{"client", "p2p", "info"}
 
 	opt := utils.NewOptions(opts...)
@@ -89,7 +89,7 @@ func (w *Wrapper) PeerInfo(ctx context.Context, opts ...options.Lister[options.P
 
 func (w *Wrapper) ActivePeers(
 	ctx context.Context,
-	opts ...options.Lister[options.ActivePeersOptions],
+	opts ...options.Enumerable[options.ActivePeersOptions],
 ) ([]string, error) {
 	args := []string{"client", "p2p", "active-peers"}
 
@@ -110,7 +110,7 @@ func (w *Wrapper) ActivePeers(
 func (w *Wrapper) Connect(
 	ctx context.Context,
 	addresses []string,
-	opts ...options.Lister[options.ConnectOptions],
+	opts ...options.Enumerable[options.ConnectOptions],
 ) error {
 	args := []string{"client", "p2p", "connect"}
 
@@ -126,7 +126,7 @@ func (w *Wrapper) Connect(
 func (w *Wrapper) CreateReplicator(
 	ctx context.Context,
 	addresses []string,
-	opts ...options.Lister[options.CreateReplicatorOptions],
+	opts ...options.Enumerable[options.CreateReplicatorOptions],
 ) error {
 	args := []string{"client", "p2p", "replicator", "create"}
 
@@ -145,7 +145,7 @@ func (w *Wrapper) CreateReplicator(
 func (w *Wrapper) DeleteReplicator(
 	ctx context.Context,
 	id string,
-	opts ...options.Lister[options.DeleteReplicatorOptions],
+	opts ...options.Enumerable[options.DeleteReplicatorOptions],
 ) error {
 	args := []string{"client", "p2p", "replicator", "delete"}
 
@@ -163,7 +163,7 @@ func (w *Wrapper) DeleteReplicator(
 
 func (w *Wrapper) ListReplicators(
 	ctx context.Context,
-	opts ...options.Lister[options.ListReplicatorsOptions],
+	opts ...options.Enumerable[options.ListReplicatorsOptions],
 ) ([]client.Replicator, error) {
 	args := []string{"client", "p2p", "replicator", "list"}
 
@@ -184,7 +184,7 @@ func (w *Wrapper) ListReplicators(
 func (w *Wrapper) CreateP2PCollections(
 	ctx context.Context,
 	collectionIDs []string,
-	opts ...options.Lister[options.CreateP2PCollectionsOptions],
+	opts ...options.Enumerable[options.CreateP2PCollectionsOptions],
 ) error {
 	args := []string{"client", "p2p", "collection", "create"}
 	args = append(args, strings.Join(collectionIDs, ","))
@@ -199,7 +199,7 @@ func (w *Wrapper) CreateP2PCollections(
 func (w *Wrapper) DeleteP2PCollections(
 	ctx context.Context,
 	collectionIDs []string,
-	opts ...options.Lister[options.DeleteP2PCollectionsOptions],
+	opts ...options.Enumerable[options.DeleteP2PCollectionsOptions],
 ) error {
 	args := []string{"client", "p2p", "collection", "delete"}
 	args = append(args, strings.Join(collectionIDs, ","))
@@ -213,7 +213,7 @@ func (w *Wrapper) DeleteP2PCollections(
 
 func (w *Wrapper) ListP2PCollections(
 	ctx context.Context,
-	opts ...options.Lister[options.ListP2PCollectionsOptions],
+	opts ...options.Enumerable[options.ListP2PCollectionsOptions],
 ) ([]string, error) {
 	args := []string{"client", "p2p", "collection", "list"}
 
@@ -234,7 +234,7 @@ func (w *Wrapper) ListP2PCollections(
 func (w *Wrapper) CreateP2PDocuments(
 	ctx context.Context,
 	docIDs []string,
-	opts ...options.Lister[options.CreateP2PDocumentsOptions],
+	opts ...options.Enumerable[options.CreateP2PDocumentsOptions],
 ) error {
 	args := []string{"client", "p2p", "document", "create"}
 	args = append(args, strings.Join(docIDs, ","))
@@ -249,7 +249,7 @@ func (w *Wrapper) CreateP2PDocuments(
 func (w *Wrapper) DeleteP2PDocuments(
 	ctx context.Context,
 	docIDs []string,
-	opts ...options.Lister[options.DeleteP2PDocumentsOptions],
+	opts ...options.Enumerable[options.DeleteP2PDocumentsOptions],
 ) error {
 	args := []string{"client", "p2p", "document", "delete"}
 	args = append(args, strings.Join(docIDs, ","))
@@ -263,7 +263,7 @@ func (w *Wrapper) DeleteP2PDocuments(
 
 func (w *Wrapper) ListP2PDocuments(
 	ctx context.Context,
-	opts ...options.Lister[options.ListP2PDocumentsOptions],
+	opts ...options.Enumerable[options.ListP2PDocumentsOptions],
 ) ([]string, error) {
 	args := []string{"client", "p2p", "document", "list"}
 
@@ -303,7 +303,7 @@ func (w *Wrapper) SyncDocuments(
 func (w *Wrapper) SyncCollectionVersions(
 	ctx context.Context,
 	versionIDs []string,
-	opts ...options.Lister[options.SyncCollectionVersionsOptions],
+	opts ...options.Enumerable[options.SyncCollectionVersionsOptions],
 ) error {
 	args := []string{"client", "p2p", "collection", "sync-versions"}
 
@@ -351,7 +351,7 @@ func (w *Wrapper) BasicImport(ctx context.Context, filepath string) error {
 func (w *Wrapper) BasicExport(
 	ctx context.Context,
 	filepath string,
-	opts ...options.Lister[options.BasicExportOptions],
+	opts ...options.Enumerable[options.BasicExportOptions],
 ) error {
 	args := []string{"client", "backup", "export"}
 
@@ -374,7 +374,7 @@ func (w *Wrapper) BasicExport(
 func (w *Wrapper) AddSchema(
 	ctx context.Context,
 	schema string,
-	opts ...options.Lister[options.AddSchemaOptions],
+	opts ...options.Enumerable[options.AddSchemaOptions],
 ) ([]client.CollectionVersion, error) {
 	args := []string{"client", "schema", "add"}
 	args = append(args, schema)
@@ -397,7 +397,7 @@ func (w *Wrapper) PatchCollection(
 	ctx context.Context,
 	patch string,
 	migration immutable.Option[model.Lens],
-	opts ...options.Lister[options.PatchCollectionOptions],
+	opts ...options.Enumerable[options.PatchCollectionOptions],
 ) error {
 	args := []string{"client", "collection", "patch"}
 	args = append(args, patch)
@@ -420,7 +420,7 @@ func (w *Wrapper) PatchCollection(
 func (w *Wrapper) SetActiveCollectionVersion(
 	ctx context.Context,
 	collectionVersionID string,
-	opts ...options.Lister[options.SetActiveCollectionVersionOptions],
+	opts ...options.Enumerable[options.SetActiveCollectionVersionOptions],
 ) error {
 	args := []string{"client", "collection", "set-active"}
 	args = append(args, collectionVersionID)
@@ -436,7 +436,7 @@ func (w *Wrapper) AddView(
 	ctx context.Context,
 	query string,
 	sdl string,
-	opts ...options.Lister[options.AddViewOptions],
+	opts ...options.Enumerable[options.AddViewOptions],
 ) ([]client.CollectionVersion, error) {
 	opt := utils.NewOptions(opts...)
 
@@ -461,7 +461,7 @@ func (w *Wrapper) AddView(
 	return defs, nil
 }
 
-func (w *Wrapper) RefreshViews(ctx context.Context, opts ...options.Lister[options.RefreshViewsOptions]) error {
+func (w *Wrapper) RefreshViews(ctx context.Context, opts ...options.Enumerable[options.RefreshViewsOptions]) error {
 	args := []string{"client", "view", "refresh"}
 	opt := utils.NewOptions(opts...)
 	if opt.CollectionName.HasValue() {
@@ -509,7 +509,7 @@ func (w *Wrapper) SetMigration(ctx context.Context, config client.LensConfig) (s
 func (w *Wrapper) AddLens(
 	ctx context.Context,
 	lens model.Lens,
-	opts ...options.Lister[options.AddLensOptions],
+	opts ...options.Enumerable[options.AddLensOptions],
 ) (string, error) {
 	args := []string{"client", "lens", "add"}
 
@@ -536,7 +536,7 @@ func (w *Wrapper) AddLens(
 
 func (w *Wrapper) ListLenses(
 	ctx context.Context,
-	opts ...options.Lister[options.ListLensesOptions],
+	opts ...options.Enumerable[options.ListLensesOptions],
 ) (map[string]model.Lens, error) {
 	args := []string{"client", "lens", "list"}
 
@@ -558,7 +558,7 @@ func (w *Wrapper) ListLenses(
 func (w *Wrapper) GetCollectionByName(
 	ctx context.Context,
 	name client.CollectionName,
-	opts ...options.Lister[options.GetCollectionByNameOptions],
+	opts ...options.Enumerable[options.GetCollectionByNameOptions],
 ) (client.Collection, error) {
 	cols, err := w.GetCollections(ctx, options.GetCollections().SetCollectionName(name))
 	if err != nil {
@@ -571,7 +571,7 @@ func (w *Wrapper) GetCollectionByName(
 
 func (w *Wrapper) GetCollections(
 	ctx context.Context,
-	opts ...options.Lister[options.GetCollectionsOptions],
+	opts ...options.Enumerable[options.GetCollectionsOptions],
 ) ([]client.Collection, error) {
 	args := []string{"client", "collection", "describe"}
 	opt := utils.NewOptions(opts...)
@@ -606,7 +606,7 @@ func (w *Wrapper) GetCollections(
 
 func (w *Wrapper) GetAllIndexes(
 	ctx context.Context,
-	opts ...options.Lister[options.GetAllIndexesOptions],
+	opts ...options.Enumerable[options.GetAllIndexesOptions],
 ) (map[client.CollectionName][]client.IndexDescription, error) {
 	args := []string{"client", "index", "list"}
 
@@ -640,7 +640,7 @@ func (w *Wrapper) ListAllEncryptedIndexes(
 func (w *Wrapper) ExecRequest(
 	ctx context.Context,
 	query string,
-	opts ...options.Lister[options.ExecRequestOptions],
+	opts ...options.Enumerable[options.ExecRequestOptions],
 ) *client.RequestResult {
 	args := []string{"client", "query"}
 	args = append(args, query)
@@ -800,7 +800,7 @@ func (w *Wrapper) VerifySignature(
 	ctx context.Context,
 	cid string,
 	pubKey crypto.PublicKey,
-	opts ...options.Lister[options.VerifySignatureOptions],
+	opts ...options.Enumerable[options.VerifySignatureOptions],
 ) error {
 	args := []string{"client", "block", "verify-signature"}
 

--- a/tests/clients/cli/wrapper_acp.go
+++ b/tests/clients/cli/wrapper_acp.go
@@ -22,7 +22,7 @@ import (
 func (w *Wrapper) AddDACPolicy(
 	ctx context.Context,
 	policy string,
-	opts ...options.Lister[options.AddDACPolicyOptions],
+	opts ...options.Enumerable[options.AddDACPolicyOptions],
 ) (client.AddPolicyResult, error) {
 	args := []string{"client", "acp", "document", "policy", "add"}
 	args = append(args, policy)
@@ -49,7 +49,7 @@ func (w *Wrapper) AddDACActorRelationship(
 	docID string,
 	relation string,
 	targetActor string,
-	opts ...options.Lister[options.AddDACActorRelationshipOptions],
+	opts ...options.Enumerable[options.AddDACActorRelationshipOptions],
 ) (client.AddActorRelationshipResult, error) {
 	args := []string{
 		"client", "acp", "document", "relationship", "add",
@@ -81,7 +81,7 @@ func (w *Wrapper) DeleteDACActorRelationship(
 	docID string,
 	relation string,
 	targetActor string,
-	opts ...options.Lister[options.DeleteDACActorRelationshipOptions],
+	opts ...options.Enumerable[options.DeleteDACActorRelationshipOptions],
 ) (client.DeleteActorRelationshipResult, error) {
 	args := []string{
 		"client", "acp", "document", "relationship", "delete",
@@ -109,7 +109,7 @@ func (w *Wrapper) DeleteDACActorRelationship(
 
 func (w *Wrapper) GetNACStatus(
 	ctx context.Context,
-	opts ...options.Lister[options.GetNACStatusOptions],
+	opts ...options.Enumerable[options.GetNACStatusOptions],
 ) (client.NACStatusResult, error) {
 	args := []string{"client", "acp", "node", "status"}
 
@@ -131,7 +131,7 @@ func (w *Wrapper) GetNACStatus(
 
 func (w *Wrapper) ReEnableNAC(
 	ctx context.Context,
-	opts ...options.Lister[options.ReEnableNACOptions],
+	opts ...options.Enumerable[options.ReEnableNACOptions],
 ) error {
 	args := []string{"client", "acp", "node", "re-enable"}
 
@@ -146,7 +146,7 @@ func (w *Wrapper) ReEnableNAC(
 
 func (w *Wrapper) DisableNAC(
 	ctx context.Context,
-	opts ...options.Lister[options.DisableNACOptions],
+	opts ...options.Enumerable[options.DisableNACOptions],
 ) error {
 	args := []string{"client", "acp", "node", "disable"}
 
@@ -163,7 +163,7 @@ func (w *Wrapper) AddNACActorRelationship(
 	ctx context.Context,
 	relation string,
 	targetActor string,
-	opts ...options.Lister[options.AddNACActorRelationshipOptions],
+	opts ...options.Enumerable[options.AddNACActorRelationshipOptions],
 ) (client.AddActorRelationshipResult, error) {
 	args := []string{
 		"client", "acp", "node", "relationship", "add",
@@ -191,7 +191,7 @@ func (w *Wrapper) DeleteNACActorRelationship(
 	ctx context.Context,
 	relation string,
 	targetActor string,
-	opts ...options.Lister[options.DeleteNACActorRelationshipOptions],
+	opts ...options.Enumerable[options.DeleteNACActorRelationshipOptions],
 ) (client.DeleteActorRelationshipResult, error) {
 	args := []string{
 		"client", "acp", "node", "relationship", "delete",

--- a/tests/clients/cli/wrapper_collection.go
+++ b/tests/clients/cli/wrapper_collection.go
@@ -66,7 +66,7 @@ func (c *Collection) CollectionID() string {
 func (c *Collection) Create(
 	ctx context.Context,
 	doc *client.Document,
-	opts ...options.Lister[options.CollectionCreateOptions],
+	opts ...options.Enumerable[options.CollectionCreateOptions],
 ) error {
 	args := makeDocCreateArgs(c, opts...)
 
@@ -87,7 +87,7 @@ func (c *Collection) Create(
 func (c *Collection) CreateMany(
 	ctx context.Context,
 	docs []*client.Document,
-	opts ...options.Lister[options.CollectionCreateOptions],
+	opts ...options.Enumerable[options.CollectionCreateOptions],
 ) error {
 	args := makeDocCreateArgs(c, opts...)
 
@@ -113,7 +113,7 @@ func (c *Collection) CreateMany(
 
 func makeDocCreateArgs(
 	c *Collection,
-	opts ...options.Lister[options.CollectionCreateOptions],
+	opts ...options.Enumerable[options.CollectionCreateOptions],
 ) []string {
 	args := []string{"client", "collection", "create"}
 	args = append(args, "--name", c.Version().Name)
@@ -133,7 +133,7 @@ func makeDocCreateArgs(
 func (c *Collection) Update(
 	ctx context.Context,
 	doc *client.Document,
-	opts ...options.Lister[options.CollectionUpdateOptions],
+	opts ...options.Enumerable[options.CollectionUpdateOptions],
 ) error {
 	document, err := doc.ToJSONPatch()
 	if err != nil {
@@ -159,7 +159,7 @@ func (c *Collection) Update(
 func (c *Collection) Save(
 	ctx context.Context,
 	doc *client.Document,
-	opts ...options.Lister[options.CollectionSaveOptions],
+	opts ...options.Enumerable[options.CollectionSaveOptions],
 ) error {
 	getOpts := options.CollectionGet()
 	opt := utils.NewOptions(opts...)
@@ -191,7 +191,7 @@ func (c *Collection) Save(
 func (c *Collection) Delete(
 	ctx context.Context,
 	docID client.DocID,
-	opts ...options.Lister[options.CollectionDeleteOptions],
+	opts ...options.Enumerable[options.CollectionDeleteOptions],
 ) (bool, error) {
 	args := []string{"client", "collection", "delete"}
 	args = append(args, "--name", c.Version().Name)
@@ -210,7 +210,7 @@ func (c *Collection) Delete(
 func (c *Collection) Exists(
 	ctx context.Context,
 	docID client.DocID,
-	opts ...options.Lister[options.CollectionExistsOptions],
+	opts ...options.Enumerable[options.CollectionExistsOptions],
 ) (bool, error) {
 	getOpts := options.CollectionGet()
 	opt := utils.NewOptions(opts...)
@@ -229,7 +229,7 @@ func (c *Collection) UpdateWithFilter(
 	ctx context.Context,
 	filter any,
 	updater string,
-	opts ...options.Lister[options.CollectionUpdateWithFilterOptions],
+	opts ...options.Enumerable[options.CollectionUpdateWithFilterOptions],
 ) (*client.UpdateResult, error) {
 	args := []string{"client", "collection", "update"}
 	args = append(args, "--name", c.Version().Name)
@@ -259,7 +259,7 @@ func (c *Collection) UpdateWithFilter(
 func (c *Collection) DeleteWithFilter(
 	ctx context.Context,
 	filter any,
-	opts ...options.Lister[options.CollectionDeleteWithFilterOptions],
+	opts ...options.Enumerable[options.CollectionDeleteWithFilterOptions],
 ) (*client.DeleteResult, error) {
 	args := []string{"client", "collection", "delete"}
 	args = append(args, "--name", c.Version().Name)
@@ -288,7 +288,7 @@ func (c *Collection) DeleteWithFilter(
 func (c *Collection) Get(
 	ctx context.Context,
 	docID client.DocID,
-	opts ...options.Lister[options.CollectionGetOptions],
+	opts ...options.Enumerable[options.CollectionGetOptions],
 ) (*client.Document, error) {
 	opt := utils.NewOptions(opts...)
 
@@ -319,7 +319,7 @@ func (c *Collection) Get(
 
 func (c *Collection) GetAllDocIDs(
 	ctx context.Context,
-	opts ...options.Lister[options.CollectionGetAllDocIDsOptions],
+	opts ...options.Enumerable[options.CollectionGetAllDocIDsOptions],
 ) (<-chan client.DocIDResult, error) {
 	args := []string{"client", "collection", "docIDs"}
 	args = append(args, "--name", c.Version().Name)
@@ -362,7 +362,7 @@ func (c *Collection) GetAllDocIDs(
 func (c *Collection) CreateIndex(
 	ctx context.Context,
 	indexDesc client.IndexCreateRequest,
-	opts ...options.Lister[options.CollectionCreateIndexOptions],
+	opts ...options.Enumerable[options.CollectionCreateIndexOptions],
 ) (index client.IndexDescription, err error) {
 	args := []string{"client", "index", "create"}
 	args = append(args, "--collection", c.Version().Name)
@@ -409,7 +409,7 @@ func (c *Collection) CreateIndex(
 func (c *Collection) DropIndex(
 	ctx context.Context,
 	indexName string,
-	opts ...options.Lister[options.CollectionDropIndexOptions],
+	opts ...options.Enumerable[options.CollectionDropIndexOptions],
 ) error {
 	args := []string{"client", "index", "drop"}
 	args = append(args, "--collection", c.Version().Name)
@@ -424,7 +424,7 @@ func (c *Collection) DropIndex(
 
 func (c *Collection) GetIndexes(
 	ctx context.Context,
-	opts ...options.Lister[options.CollectionGetIndexesOptions],
+	opts ...options.Enumerable[options.CollectionGetIndexesOptions],
 ) ([]client.IndexDescription, error) {
 	args := []string{"client", "index", "list"}
 	args = append(args, "--collection", c.Version().Name)
@@ -489,7 +489,7 @@ func (c *Collection) DeleteEncryptedIndex(ctx context.Context, fieldName string)
 	return err
 }
 
-func (c *Collection) Truncate(ctx context.Context, opts ...options.Lister[options.CollectionTruncateOptions]) error {
+func (c *Collection) Truncate(ctx context.Context, opts ...options.Enumerable[options.CollectionTruncateOptions]) error {
 	args := []string{"client", "collection", "truncate"}
 	args = append(args, "--name", c.Version().Name)
 

--- a/tests/clients/cli/wrapper_collection.go
+++ b/tests/clients/cli/wrapper_collection.go
@@ -489,7 +489,9 @@ func (c *Collection) DeleteEncryptedIndex(ctx context.Context, fieldName string)
 	return err
 }
 
-func (c *Collection) Truncate(ctx context.Context, opts ...options.Enumerable[options.CollectionTruncateOptions]) error {
+func (c *Collection) Truncate(
+	ctx context.Context, opts ...options.Enumerable[options.CollectionTruncateOptions],
+) error {
 	args := []string{"client", "collection", "truncate"}
 	args = append(args, "--name", c.Version().Name)
 

--- a/tests/clients/cli/wrapper_tx.go
+++ b/tests/clients/cli/wrapper_tx.go
@@ -63,7 +63,7 @@ func (txn *Transaction) PrintDump(ctx context.Context) error {
 func (txn *Transaction) AddDACPolicy(
 	ctx context.Context,
 	policy string,
-	opts ...options.Lister[options.AddDACPolicyOptions],
+	opts ...options.Enumerable[options.AddDACPolicyOptions],
 ) (client.AddPolicyResult, error) {
 	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
 	return txn.Wrapper.AddDACPolicy(ctx, policy, opts...)
@@ -75,7 +75,7 @@ func (txn *Transaction) AddDACActorRelationship(
 	docID string,
 	relation string,
 	targetActor string,
-	opts ...options.Lister[options.AddDACActorRelationshipOptions],
+	opts ...options.Enumerable[options.AddDACActorRelationshipOptions],
 ) (client.AddActorRelationshipResult, error) {
 	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
 	return txn.Wrapper.AddDACActorRelationship(ctx, collectionName, docID, relation, targetActor, opts...)
@@ -87,7 +87,7 @@ func (txn *Transaction) DeleteDACActorRelationship(
 	docID string,
 	relation string,
 	targetActor string,
-	opts ...options.Lister[options.DeleteDACActorRelationshipOptions],
+	opts ...options.Enumerable[options.DeleteDACActorRelationshipOptions],
 ) (client.DeleteActorRelationshipResult, error) {
 	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
 	return txn.Wrapper.DeleteDACActorRelationship(ctx, collectionName, docID, relation, targetActor, opts...)
@@ -102,7 +102,7 @@ func (txn *Transaction) VerifySignature(
 	ctx context.Context,
 	blockCid string,
 	pubKey crypto.PublicKey,
-	opts ...options.Lister[options.VerifySignatureOptions],
+	opts ...options.Enumerable[options.VerifySignatureOptions],
 ) error {
 	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
 	return txn.Wrapper.VerifySignature(ctx, blockCid, pubKey, opts...)
@@ -111,7 +111,7 @@ func (txn *Transaction) VerifySignature(
 func (txn *Transaction) AddSchema(
 	ctx context.Context,
 	sdl string,
-	opts ...options.Lister[options.AddSchemaOptions],
+	opts ...options.Enumerable[options.AddSchemaOptions],
 ) ([]client.CollectionVersion, error) {
 	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
 	return txn.Wrapper.AddSchema(ctx, sdl, opts...)
@@ -121,7 +121,7 @@ func (txn *Transaction) PatchCollection(
 	ctx context.Context,
 	patch string,
 	migration immutable.Option[model.Lens],
-	opts ...options.Lister[options.PatchCollectionOptions],
+	opts ...options.Enumerable[options.PatchCollectionOptions],
 ) error {
 	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
 	return txn.Wrapper.PatchCollection(ctx, patch, migration, opts...)
@@ -130,7 +130,7 @@ func (txn *Transaction) PatchCollection(
 func (txn *Transaction) SetActiveCollectionVersion(
 	ctx context.Context,
 	version string,
-	opts ...options.Lister[options.SetActiveCollectionVersionOptions],
+	opts ...options.Enumerable[options.SetActiveCollectionVersionOptions],
 ) error {
 	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
 	return txn.Wrapper.SetActiveCollectionVersion(ctx, version, opts...)
@@ -140,13 +140,13 @@ func (txn *Transaction) AddView(
 	ctx context.Context,
 	gqlQuery string,
 	sdl string,
-	opts ...options.Lister[options.AddViewOptions],
+	opts ...options.Enumerable[options.AddViewOptions],
 ) ([]client.CollectionVersion, error) {
 	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
 	return txn.Wrapper.AddView(ctx, gqlQuery, sdl, opts...)
 }
 
-func (txn *Transaction) RefreshViews(ctx context.Context, opts ...options.Lister[options.RefreshViewsOptions]) error {
+func (txn *Transaction) RefreshViews(ctx context.Context, opts ...options.Enumerable[options.RefreshViewsOptions]) error {
 	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
 	return txn.Wrapper.RefreshViews(ctx, opts...)
 }
@@ -159,7 +159,7 @@ func (txn *Transaction) SetMigration(ctx context.Context, config client.LensConf
 func (txn *Transaction) AddLens(
 	ctx context.Context,
 	lens model.Lens,
-	opts ...options.Lister[options.AddLensOptions],
+	opts ...options.Enumerable[options.AddLensOptions],
 ) (string, error) {
 	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
 	return txn.Wrapper.AddLens(ctx, lens, opts...)
@@ -167,7 +167,7 @@ func (txn *Transaction) AddLens(
 
 func (txn *Transaction) ListLenses(
 	ctx context.Context,
-	opts ...options.Lister[options.ListLensesOptions],
+	opts ...options.Enumerable[options.ListLensesOptions],
 ) (map[string]model.Lens, error) {
 	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
 	return txn.Wrapper.ListLenses(ctx, opts...)
@@ -176,7 +176,7 @@ func (txn *Transaction) ListLenses(
 func (txn *Transaction) GetCollectionByName(
 	ctx context.Context,
 	name client.CollectionName,
-	opts ...options.Lister[options.GetCollectionByNameOptions],
+	opts ...options.Enumerable[options.GetCollectionByNameOptions],
 ) (client.Collection, error) {
 	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
 	return txn.Wrapper.GetCollectionByName(ctx, name, opts...)
@@ -184,7 +184,7 @@ func (txn *Transaction) GetCollectionByName(
 
 func (txn *Transaction) GetCollections(
 	ctx context.Context,
-	opts ...options.Lister[options.GetCollectionsOptions],
+	opts ...options.Enumerable[options.GetCollectionsOptions],
 ) ([]client.Collection, error) {
 	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
 	return txn.Wrapper.GetCollections(ctx, opts...)
@@ -192,7 +192,7 @@ func (txn *Transaction) GetCollections(
 
 func (txn *Transaction) GetAllIndexes(
 	ctx context.Context,
-	opts ...options.Lister[options.GetAllIndexesOptions],
+	opts ...options.Enumerable[options.GetAllIndexesOptions],
 ) (map[client.CollectionName][]client.IndexDescription, error) {
 	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
 	return txn.Wrapper.GetAllIndexes(ctx, opts...)
@@ -201,7 +201,7 @@ func (txn *Transaction) GetAllIndexes(
 func (txn *Transaction) ExecRequest(
 	ctx context.Context,
 	request string,
-	opts ...options.Lister[options.ExecRequestOptions],
+	opts ...options.Enumerable[options.ExecRequestOptions],
 ) *client.RequestResult {
 	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
 	return txn.Wrapper.ExecRequest(ctx, request, opts...)
@@ -215,7 +215,7 @@ func (txn *Transaction) BasicImport(ctx context.Context, filepath string) error 
 func (txn *Transaction) BasicExport(
 	ctx context.Context,
 	filepath string,
-	opts ...options.Lister[options.BasicExportOptions],
+	opts ...options.Enumerable[options.BasicExportOptions],
 ) error {
 	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
 	return txn.Wrapper.BasicExport(ctx, filepath, opts...)

--- a/tests/clients/cli/wrapper_tx.go
+++ b/tests/clients/cli/wrapper_tx.go
@@ -146,7 +146,9 @@ func (txn *Transaction) AddView(
 	return txn.Wrapper.AddView(ctx, gqlQuery, sdl, opts...)
 }
 
-func (txn *Transaction) RefreshViews(ctx context.Context, opts ...options.Enumerable[options.RefreshViewsOptions]) error {
+func (txn *Transaction) RefreshViews(
+	ctx context.Context, opts ...options.Enumerable[options.RefreshViewsOptions],
+) error {
 	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
 	return txn.Wrapper.RefreshViews(ctx, opts...)
 }

--- a/tests/clients/http/wrapper.go
+++ b/tests/clients/http/wrapper.go
@@ -63,13 +63,13 @@ func NewWrapper(node *node.Node) (*Wrapper, error) {
 	}, nil
 }
 
-func (w *Wrapper) PeerInfo(ctx context.Context, opts ...options.Lister[options.PeerInfoOptions]) ([]string, error) {
+func (w *Wrapper) PeerInfo(ctx context.Context, opts ...options.Enumerable[options.PeerInfoOptions]) ([]string, error) {
 	return w.client.PeerInfo(ctx, opts...)
 }
 
 func (w *Wrapper) ActivePeers(
 	ctx context.Context,
-	opts ...options.Lister[options.ActivePeersOptions],
+	opts ...options.Enumerable[options.ActivePeersOptions],
 ) ([]string, error) {
 	return w.client.ActivePeers(ctx, opts...)
 }
@@ -77,7 +77,7 @@ func (w *Wrapper) ActivePeers(
 func (w *Wrapper) Connect(
 	ctx context.Context,
 	addresses []string,
-	opts ...options.Lister[options.ConnectOptions],
+	opts ...options.Enumerable[options.ConnectOptions],
 ) error {
 	return w.client.Connect(ctx, addresses, opts...)
 }
@@ -85,7 +85,7 @@ func (w *Wrapper) Connect(
 func (w *Wrapper) CreateReplicator(
 	ctx context.Context,
 	addresses []string,
-	opts ...options.Lister[options.CreateReplicatorOptions],
+	opts ...options.Enumerable[options.CreateReplicatorOptions],
 ) error {
 	return w.client.CreateReplicator(ctx, addresses, opts...)
 }
@@ -93,14 +93,14 @@ func (w *Wrapper) CreateReplicator(
 func (w *Wrapper) DeleteReplicator(
 	ctx context.Context,
 	id string,
-	opts ...options.Lister[options.DeleteReplicatorOptions],
+	opts ...options.Enumerable[options.DeleteReplicatorOptions],
 ) error {
 	return w.client.DeleteReplicator(ctx, id, opts...)
 }
 
 func (w *Wrapper) ListReplicators(
 	ctx context.Context,
-	opts ...options.Lister[options.ListReplicatorsOptions],
+	opts ...options.Enumerable[options.ListReplicatorsOptions],
 ) ([]client.Replicator, error) {
 	return w.client.ListReplicators(ctx, opts...)
 }
@@ -108,7 +108,7 @@ func (w *Wrapper) ListReplicators(
 func (w *Wrapper) CreateP2PCollections(
 	ctx context.Context,
 	collectionIDs []string,
-	opts ...options.Lister[options.CreateP2PCollectionsOptions],
+	opts ...options.Enumerable[options.CreateP2PCollectionsOptions],
 ) error {
 	return w.client.CreateP2PCollections(ctx, collectionIDs, opts...)
 }
@@ -116,14 +116,14 @@ func (w *Wrapper) CreateP2PCollections(
 func (w *Wrapper) DeleteP2PCollections(
 	ctx context.Context,
 	collectionIDs []string,
-	opts ...options.Lister[options.DeleteP2PCollectionsOptions],
+	opts ...options.Enumerable[options.DeleteP2PCollectionsOptions],
 ) error {
 	return w.client.DeleteP2PCollections(ctx, collectionIDs, opts...)
 }
 
 func (w *Wrapper) ListP2PCollections(
 	ctx context.Context,
-	opts ...options.Lister[options.ListP2PCollectionsOptions],
+	opts ...options.Enumerable[options.ListP2PCollectionsOptions],
 ) ([]string, error) {
 	return w.client.ListP2PCollections(ctx, opts...)
 }
@@ -131,7 +131,7 @@ func (w *Wrapper) ListP2PCollections(
 func (w *Wrapper) CreateP2PDocuments(
 	ctx context.Context,
 	docIDs []string,
-	opts ...options.Lister[options.CreateP2PDocumentsOptions],
+	opts ...options.Enumerable[options.CreateP2PDocumentsOptions],
 ) error {
 	return w.client.CreateP2PDocuments(ctx, docIDs, opts...)
 }
@@ -139,14 +139,14 @@ func (w *Wrapper) CreateP2PDocuments(
 func (w *Wrapper) DeleteP2PDocuments(
 	ctx context.Context,
 	docIDs []string,
-	opts ...options.Lister[options.DeleteP2PDocumentsOptions],
+	opts ...options.Enumerable[options.DeleteP2PDocumentsOptions],
 ) error {
 	return w.client.DeleteP2PDocuments(ctx, docIDs, opts...)
 }
 
 func (w *Wrapper) ListP2PDocuments(
 	ctx context.Context,
-	opts ...options.Lister[options.ListP2PDocumentsOptions],
+	opts ...options.Enumerable[options.ListP2PDocumentsOptions],
 ) ([]string, error) {
 	return w.client.ListP2PDocuments(ctx, opts...)
 }
@@ -162,7 +162,7 @@ func (w *Wrapper) SyncDocuments(
 func (w *Wrapper) SyncCollectionVersions(
 	ctx context.Context,
 	versionIDs []string,
-	opts ...options.Lister[options.SyncCollectionVersionsOptions],
+	opts ...options.Enumerable[options.SyncCollectionVersionsOptions],
 ) error {
 	return w.client.SyncCollectionVersions(ctx, versionIDs, opts...)
 }
@@ -181,7 +181,7 @@ func (w *Wrapper) BasicImport(ctx context.Context, filepath string) error {
 func (w *Wrapper) BasicExport(
 	ctx context.Context,
 	filepath string,
-	opts ...options.Lister[options.BasicExportOptions],
+	opts ...options.Enumerable[options.BasicExportOptions],
 ) error {
 	return w.client.BasicExport(ctx, filepath, opts...)
 }
@@ -189,7 +189,7 @@ func (w *Wrapper) BasicExport(
 func (w *Wrapper) AddSchema(
 	ctx context.Context,
 	schema string,
-	opts ...options.Lister[options.AddSchemaOptions],
+	opts ...options.Enumerable[options.AddSchemaOptions],
 ) ([]client.CollectionVersion, error) {
 	return w.client.AddSchema(ctx, schema, opts...)
 }
@@ -197,7 +197,7 @@ func (w *Wrapper) AddSchema(
 func (w *Wrapper) AddDACPolicy(
 	ctx context.Context,
 	policy string,
-	opts ...options.Lister[options.AddDACPolicyOptions],
+	opts ...options.Enumerable[options.AddDACPolicyOptions],
 ) (client.AddPolicyResult, error) {
 	return w.client.AddDACPolicy(ctx, policy, opts...)
 }
@@ -208,7 +208,7 @@ func (w *Wrapper) AddDACActorRelationship(
 	docID string,
 	relation string,
 	targetActor string,
-	opts ...options.Lister[options.AddDACActorRelationshipOptions],
+	opts ...options.Enumerable[options.AddDACActorRelationshipOptions],
 ) (client.AddActorRelationshipResult, error) {
 	return w.client.AddDACActorRelationship(
 		ctx,
@@ -226,7 +226,7 @@ func (w *Wrapper) DeleteDACActorRelationship(
 	docID string,
 	relation string,
 	targetActor string,
-	opts ...options.Lister[options.DeleteDACActorRelationshipOptions],
+	opts ...options.Enumerable[options.DeleteDACActorRelationshipOptions],
 ) (client.DeleteActorRelationshipResult, error) {
 	return w.client.DeleteDACActorRelationship(
 		ctx,
@@ -242,7 +242,7 @@ func (w *Wrapper) AddNACActorRelationship(
 	ctx context.Context,
 	relation string,
 	targetActor string,
-	opts ...options.Lister[options.AddNACActorRelationshipOptions],
+	opts ...options.Enumerable[options.AddNACActorRelationshipOptions],
 ) (client.AddActorRelationshipResult, error) {
 	return w.client.AddNACActorRelationship(
 		ctx,
@@ -256,7 +256,7 @@ func (w *Wrapper) DeleteNACActorRelationship(
 	ctx context.Context,
 	relation string,
 	targetActor string,
-	opts ...options.Lister[options.DeleteNACActorRelationshipOptions],
+	opts ...options.Enumerable[options.DeleteNACActorRelationshipOptions],
 ) (client.DeleteActorRelationshipResult, error) {
 	return w.client.DeleteNACActorRelationship(
 		ctx,
@@ -266,17 +266,17 @@ func (w *Wrapper) DeleteNACActorRelationship(
 	)
 }
 
-func (w *Wrapper) ReEnableNAC(ctx context.Context, opts ...options.Lister[options.ReEnableNACOptions]) error {
+func (w *Wrapper) ReEnableNAC(ctx context.Context, opts ...options.Enumerable[options.ReEnableNACOptions]) error {
 	return w.client.ReEnableNAC(ctx, opts...)
 }
 
-func (w *Wrapper) DisableNAC(ctx context.Context, opts ...options.Lister[options.DisableNACOptions]) error {
+func (w *Wrapper) DisableNAC(ctx context.Context, opts ...options.Enumerable[options.DisableNACOptions]) error {
 	return w.client.DisableNAC(ctx, opts...)
 }
 
 func (w *Wrapper) GetNACStatus(
 	ctx context.Context,
-	opts ...options.Lister[options.GetNACStatusOptions],
+	opts ...options.Enumerable[options.GetNACStatusOptions],
 ) (client.NACStatusResult, error) {
 	return w.client.GetNACStatus(ctx, opts...)
 }
@@ -285,7 +285,7 @@ func (w *Wrapper) PatchCollection(
 	ctx context.Context,
 	patch string,
 	migration immutable.Option[model.Lens],
-	opts ...options.Lister[options.PatchCollectionOptions],
+	opts ...options.Enumerable[options.PatchCollectionOptions],
 ) error {
 	return w.client.PatchCollection(ctx, patch, migration, opts...)
 }
@@ -293,7 +293,7 @@ func (w *Wrapper) PatchCollection(
 func (w *Wrapper) SetActiveCollectionVersion(
 	ctx context.Context,
 	collectionVersionID string,
-	opts ...options.Lister[options.SetActiveCollectionVersionOptions],
+	opts ...options.Enumerable[options.SetActiveCollectionVersionOptions],
 ) error {
 	return w.client.SetActiveCollectionVersion(ctx, collectionVersionID, opts...)
 }
@@ -302,12 +302,12 @@ func (w *Wrapper) AddView(
 	ctx context.Context,
 	query string,
 	sdl string,
-	opts ...options.Lister[options.AddViewOptions],
+	opts ...options.Enumerable[options.AddViewOptions],
 ) ([]client.CollectionVersion, error) {
 	return w.client.AddView(ctx, query, sdl, opts...)
 }
 
-func (w *Wrapper) RefreshViews(ctx context.Context, opts ...options.Lister[options.RefreshViewsOptions]) error {
+func (w *Wrapper) RefreshViews(ctx context.Context, opts ...options.Enumerable[options.RefreshViewsOptions]) error {
 	return w.client.RefreshViews(ctx, opts...)
 }
 
@@ -318,14 +318,14 @@ func (w *Wrapper) SetMigration(ctx context.Context, config client.LensConfig) (s
 func (w *Wrapper) AddLens(
 	ctx context.Context,
 	lens model.Lens,
-	opts ...options.Lister[options.AddLensOptions],
+	opts ...options.Enumerable[options.AddLensOptions],
 ) (string, error) {
 	return w.client.AddLens(ctx, lens, opts...)
 }
 
 func (w *Wrapper) ListLenses(
 	ctx context.Context,
-	opts ...options.Lister[options.ListLensesOptions],
+	opts ...options.Enumerable[options.ListLensesOptions],
 ) (map[string]model.Lens, error) {
 	return w.client.ListLenses(ctx, opts...)
 }
@@ -333,21 +333,21 @@ func (w *Wrapper) ListLenses(
 func (w *Wrapper) GetCollectionByName(
 	ctx context.Context,
 	name client.CollectionName,
-	opts ...options.Lister[options.GetCollectionByNameOptions],
+	opts ...options.Enumerable[options.GetCollectionByNameOptions],
 ) (client.Collection, error) {
 	return w.client.GetCollectionByName(ctx, name, opts...)
 }
 
 func (w *Wrapper) GetCollections(
 	ctx context.Context,
-	opts ...options.Lister[options.GetCollectionsOptions],
+	opts ...options.Enumerable[options.GetCollectionsOptions],
 ) ([]client.Collection, error) {
 	return w.client.GetCollections(ctx, opts...)
 }
 
 func (w *Wrapper) GetAllIndexes(
 	ctx context.Context,
-	opts ...options.Lister[options.GetAllIndexesOptions],
+	opts ...options.Enumerable[options.GetAllIndexesOptions],
 ) (map[client.CollectionName][]client.IndexDescription, error) {
 	return w.client.GetAllIndexes(ctx, opts...)
 }
@@ -361,7 +361,7 @@ func (w *Wrapper) ListAllEncryptedIndexes(
 func (w *Wrapper) ExecRequest(
 	ctx context.Context,
 	query string,
-	opts ...options.Lister[options.ExecRequestOptions],
+	opts ...options.Enumerable[options.ExecRequestOptions],
 ) *client.RequestResult {
 	return w.client.ExecRequest(ctx, query, opts...)
 }
@@ -420,7 +420,7 @@ func (w *Wrapper) VerifySignature(
 	ctx context.Context,
 	cid string,
 	pubKey crypto.PublicKey,
-	opts ...options.Lister[options.VerifySignatureOptions],
+	opts ...options.Enumerable[options.VerifySignatureOptions],
 ) error {
 	return w.client.VerifySignature(ctx, cid, pubKey, opts...)
 }

--- a/tests/clients/http/wrapper.go
+++ b/tests/clients/http/wrapper.go
@@ -170,7 +170,7 @@ func (w *Wrapper) SyncCollectionVersions(
 func (w *Wrapper) SyncBranchableCollection(
 	ctx context.Context,
 	collectionID string,
-	opts ...options.Lister[options.SyncBranchableCollectionOptions]) error {
+	opts ...options.Enumerable[options.SyncBranchableCollectionOptions]) error {
 	return w.client.SyncBranchableCollection(ctx, collectionID, opts...)
 }
 

--- a/tests/clients/http/wrapper_tx.go
+++ b/tests/clients/http/wrapper_tx.go
@@ -57,7 +57,7 @@ func (txn *Transaction) PrintDump(ctx context.Context) error {
 func (txn *Transaction) AddDACPolicy(
 	ctx context.Context,
 	policy string,
-	opts ...options.Lister[options.AddDACPolicyOptions],
+	opts ...options.Enumerable[options.AddDACPolicyOptions],
 ) (client.AddPolicyResult, error) {
 	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
 	return txn.Wrapper.AddDACPolicy(ctx, policy, opts...)
@@ -69,7 +69,7 @@ func (txn *Transaction) AddDACActorRelationship(
 	docID string,
 	relation string,
 	targetActor string,
-	opts ...options.Lister[options.AddDACActorRelationshipOptions],
+	opts ...options.Enumerable[options.AddDACActorRelationshipOptions],
 ) (client.AddActorRelationshipResult, error) {
 	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
 	return txn.Wrapper.AddDACActorRelationship(ctx, collectionName, docID, relation, targetActor, opts...)
@@ -81,7 +81,7 @@ func (txn *Transaction) DeleteDACActorRelationship(
 	docID string,
 	relation string,
 	targetActor string,
-	opts ...options.Lister[options.DeleteDACActorRelationshipOptions],
+	opts ...options.Enumerable[options.DeleteDACActorRelationshipOptions],
 ) (client.DeleteActorRelationshipResult, error) {
 	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
 	return txn.Wrapper.DeleteDACActorRelationship(ctx, collectionName, docID, relation, targetActor, opts...)
@@ -96,7 +96,7 @@ func (txn *Transaction) VerifySignature(
 	ctx context.Context,
 	blockCid string,
 	pubKey crypto.PublicKey,
-	opts ...options.Lister[options.VerifySignatureOptions],
+	opts ...options.Enumerable[options.VerifySignatureOptions],
 ) error {
 	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
 	return txn.Wrapper.VerifySignature(ctx, blockCid, pubKey, opts...)
@@ -105,7 +105,7 @@ func (txn *Transaction) VerifySignature(
 func (txn *Transaction) AddSchema(
 	ctx context.Context,
 	sdl string,
-	opts ...options.Lister[options.AddSchemaOptions],
+	opts ...options.Enumerable[options.AddSchemaOptions],
 ) ([]client.CollectionVersion, error) {
 	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
 	return txn.Wrapper.AddSchema(ctx, sdl, opts...)
@@ -115,7 +115,7 @@ func (txn *Transaction) PatchCollection(
 	ctx context.Context,
 	patch string,
 	migration immutable.Option[model.Lens],
-	opts ...options.Lister[options.PatchCollectionOptions],
+	opts ...options.Enumerable[options.PatchCollectionOptions],
 ) error {
 	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
 	return txn.Wrapper.PatchCollection(ctx, patch, migration, opts...)
@@ -124,7 +124,7 @@ func (txn *Transaction) PatchCollection(
 func (txn *Transaction) SetActiveCollectionVersion(
 	ctx context.Context,
 	version string,
-	opts ...options.Lister[options.SetActiveCollectionVersionOptions],
+	opts ...options.Enumerable[options.SetActiveCollectionVersionOptions],
 ) error {
 	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
 	return txn.Wrapper.SetActiveCollectionVersion(ctx, version, opts...)
@@ -134,13 +134,13 @@ func (txn *Transaction) AddView(
 	ctx context.Context,
 	gqlQuery string,
 	sdl string,
-	opts ...options.Lister[options.AddViewOptions],
+	opts ...options.Enumerable[options.AddViewOptions],
 ) ([]client.CollectionVersion, error) {
 	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
 	return txn.Wrapper.AddView(ctx, gqlQuery, sdl, opts...)
 }
 
-func (txn *Transaction) RefreshViews(ctx context.Context, opts ...options.Lister[options.RefreshViewsOptions]) error {
+func (txn *Transaction) RefreshViews(ctx context.Context, opts ...options.Enumerable[options.RefreshViewsOptions]) error {
 	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
 	return txn.Wrapper.RefreshViews(ctx, opts...)
 }
@@ -153,7 +153,7 @@ func (txn *Transaction) SetMigration(ctx context.Context, config client.LensConf
 func (txn *Transaction) AddLens(
 	ctx context.Context,
 	lens model.Lens,
-	opts ...options.Lister[options.AddLensOptions],
+	opts ...options.Enumerable[options.AddLensOptions],
 ) (string, error) {
 	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
 	return txn.Wrapper.AddLens(ctx, lens, opts...)
@@ -161,7 +161,7 @@ func (txn *Transaction) AddLens(
 
 func (txn *Transaction) ListLenses(
 	ctx context.Context,
-	opts ...options.Lister[options.ListLensesOptions],
+	opts ...options.Enumerable[options.ListLensesOptions],
 ) (map[string]model.Lens, error) {
 	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
 	return txn.Wrapper.ListLenses(ctx, opts...)
@@ -170,7 +170,7 @@ func (txn *Transaction) ListLenses(
 func (txn *Transaction) GetCollectionByName(
 	ctx context.Context,
 	name client.CollectionName,
-	opts ...options.Lister[options.GetCollectionByNameOptions],
+	opts ...options.Enumerable[options.GetCollectionByNameOptions],
 ) (client.Collection, error) {
 	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
 	return txn.Wrapper.GetCollectionByName(ctx, name, opts...)
@@ -178,7 +178,7 @@ func (txn *Transaction) GetCollectionByName(
 
 func (txn *Transaction) GetCollections(
 	ctx context.Context,
-	opts ...options.Lister[options.GetCollectionsOptions],
+	opts ...options.Enumerable[options.GetCollectionsOptions],
 ) ([]client.Collection, error) {
 	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
 	return txn.Wrapper.GetCollections(ctx, opts...)
@@ -186,7 +186,7 @@ func (txn *Transaction) GetCollections(
 
 func (txn *Transaction) GetAllIndexes(
 	ctx context.Context,
-	opts ...options.Lister[options.GetAllIndexesOptions],
+	opts ...options.Enumerable[options.GetAllIndexesOptions],
 ) (map[client.CollectionName][]client.IndexDescription, error) {
 	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
 	return txn.Wrapper.GetAllIndexes(ctx, opts...)
@@ -195,7 +195,7 @@ func (txn *Transaction) GetAllIndexes(
 func (txn *Transaction) ExecRequest(
 	ctx context.Context,
 	request string,
-	opts ...options.Lister[options.ExecRequestOptions],
+	opts ...options.Enumerable[options.ExecRequestOptions],
 ) *client.RequestResult {
 	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
 	return txn.Wrapper.ExecRequest(ctx, request, opts...)
@@ -209,7 +209,7 @@ func (txn *Transaction) BasicImport(ctx context.Context, filepath string) error 
 func (txn *Transaction) BasicExport(
 	ctx context.Context,
 	filepath string,
-	opts ...options.Lister[options.BasicExportOptions],
+	opts ...options.Enumerable[options.BasicExportOptions],
 ) error {
 	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
 	return txn.Wrapper.BasicExport(ctx, filepath, opts...)

--- a/tests/clients/http/wrapper_tx.go
+++ b/tests/clients/http/wrapper_tx.go
@@ -140,7 +140,9 @@ func (txn *Transaction) AddView(
 	return txn.Wrapper.AddView(ctx, gqlQuery, sdl, opts...)
 }
 
-func (txn *Transaction) RefreshViews(ctx context.Context, opts ...options.Enumerable[options.RefreshViewsOptions]) error {
+func (txn *Transaction) RefreshViews(
+	ctx context.Context, opts ...options.Enumerable[options.RefreshViewsOptions],
+) error {
 	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
 	return txn.Wrapper.RefreshViews(ctx, opts...)
 }

--- a/tests/clients/js/wrapper.go
+++ b/tests/clients/js/wrapper.go
@@ -69,13 +69,13 @@ func NewWrapper(node *node.Node) (*Wrapper, error) {
 	}, nil
 }
 
-func (w *Wrapper) PeerInfo(ctx context.Context, opts ...options.Lister[options.PeerInfoOptions]) ([]string, error) {
+func (w *Wrapper) PeerInfo(ctx context.Context, opts ...options.Enumerable[options.PeerInfoOptions]) ([]string, error) {
 	return nil, nil
 }
 
 func (w *Wrapper) ActivePeers(
 	ctx context.Context,
-	opts ...options.Lister[options.ActivePeersOptions],
+	opts ...options.Enumerable[options.ActivePeersOptions],
 ) ([]string, error) {
 	panic("not implemented")
 }
@@ -83,7 +83,7 @@ func (w *Wrapper) ActivePeers(
 func (w *Wrapper) CreateReplicator(
 	ctx context.Context,
 	addresses []string,
-	opts ...options.Lister[options.CreateReplicatorOptions],
+	opts ...options.Enumerable[options.CreateReplicatorOptions],
 ) error {
 	panic("not implemented")
 }
@@ -91,14 +91,14 @@ func (w *Wrapper) CreateReplicator(
 func (w *Wrapper) DeleteReplicator(
 	ctx context.Context,
 	id string,
-	opts ...options.Lister[options.DeleteReplicatorOptions],
+	opts ...options.Enumerable[options.DeleteReplicatorOptions],
 ) error {
 	panic("not implemented")
 }
 
 func (w *Wrapper) ListReplicators(
 	ctx context.Context,
-	opts ...options.Lister[options.ListReplicatorsOptions],
+	opts ...options.Enumerable[options.ListReplicatorsOptions],
 ) ([]client.Replicator, error) {
 	panic("not implemented")
 }
@@ -106,7 +106,7 @@ func (w *Wrapper) ListReplicators(
 func (w *Wrapper) CreateP2PCollections(
 	ctx context.Context,
 	collectionNames []string,
-	opts ...options.Lister[options.CreateP2PCollectionsOptions],
+	opts ...options.Enumerable[options.CreateP2PCollectionsOptions],
 ) error {
 	panic("not implemented")
 }
@@ -114,14 +114,14 @@ func (w *Wrapper) CreateP2PCollections(
 func (w *Wrapper) DeleteP2PCollections(
 	ctx context.Context,
 	collectionNames []string,
-	opts ...options.Lister[options.DeleteP2PCollectionsOptions],
+	opts ...options.Enumerable[options.DeleteP2PCollectionsOptions],
 ) error {
 	panic("not implemented")
 }
 
 func (w *Wrapper) ListP2PCollections(
 	ctx context.Context,
-	opts ...options.Lister[options.ListP2PCollectionsOptions],
+	opts ...options.Enumerable[options.ListP2PCollectionsOptions],
 ) ([]string, error) {
 	panic("not implemented")
 }
@@ -129,7 +129,7 @@ func (w *Wrapper) ListP2PCollections(
 func (w *Wrapper) CreateP2PDocuments(
 	ctx context.Context,
 	docIDs []string,
-	opts ...options.Lister[options.CreateP2PDocumentsOptions],
+	opts ...options.Enumerable[options.CreateP2PDocumentsOptions],
 ) error {
 	panic("not implemented")
 }
@@ -137,12 +137,12 @@ func (w *Wrapper) CreateP2PDocuments(
 func (w *Wrapper) DeleteP2PDocuments(
 	ctx context.Context,
 	docIDs []string,
-	opts ...options.Lister[options.DeleteP2PDocumentsOptions],
+	opts ...options.Enumerable[options.DeleteP2PDocumentsOptions],
 ) error {
 	panic("not implemented")
 }
 
-func (w *Wrapper) ListP2PDocuments(ctx context.Context, opts ...options.Lister[options.ListP2PDocumentsOptions]) ([]string, error) {
+func (w *Wrapper) ListP2PDocuments(ctx context.Context, opts ...options.Enumerable[options.ListP2PDocumentsOptions]) ([]string, error) {
 	panic("not implemented")
 }
 
@@ -150,11 +150,11 @@ func (w *Wrapper) SyncDocuments(ctx context.Context, collectionName string, docI
 	panic("not implemented")
 }
 
-func (w *Wrapper) SyncCollectionVersions(ctx context.Context, versionIDs []string, opts ...options.Lister[options.SyncCollectionVersionsOptions]) error {
+func (w *Wrapper) SyncCollectionVersions(ctx context.Context, versionIDs []string, opts ...options.Enumerable[options.SyncCollectionVersionsOptions]) error {
 	panic("not implemented")
 }
 
-func (w *Wrapper) SyncBranchableCollection(ctx context.Context, collectionID string, opts ...options.Lister[options.SyncBranchableCollectionOptions]) error {
+func (w *Wrapper) SyncBranchableCollection(ctx context.Context, collectionID string, opts ...options.Enumerable[options.SyncBranchableCollectionOptions]) error {
 	panic("not implemented")
 }
 
@@ -162,14 +162,14 @@ func (w *Wrapper) BasicImport(ctx context.Context, filepath string) error {
 	panic("not implemented")
 }
 
-func (w *Wrapper) BasicExport(ctx context.Context, filepath string, opts ...options.Lister[options.BasicExportOptions]) error {
+func (w *Wrapper) BasicExport(ctx context.Context, filepath string, opts ...options.Enumerable[options.BasicExportOptions]) error {
 	panic("not implemented")
 }
 
 func (w *Wrapper) AddSchema(
 	ctx context.Context,
 	schema string,
-	opts ...options.Lister[options.AddSchemaOptions],
+	opts ...options.Enumerable[options.AddSchemaOptions],
 ) ([]client.CollectionVersion, error) {
 	opt := utils.NewOptions(opts...)
 	ctx = ctxWithOptIdentity(ctx, opt)
@@ -187,7 +187,7 @@ func (w *Wrapper) AddSchema(
 func (w *Wrapper) AddDACPolicy(
 	ctx context.Context,
 	policy string,
-	opts ...options.Lister[options.AddDACPolicyOptions],
+	opts ...options.Enumerable[options.AddDACPolicyOptions],
 ) (client.AddPolicyResult, error) {
 	opt := utils.NewOptions(opts...)
 	ctx = ctxWithOptIdentity(ctx, opt)
@@ -208,7 +208,7 @@ func (w *Wrapper) AddDACActorRelationship(
 	docID string,
 	relation string,
 	targetActor string,
-	opts ...options.Lister[options.AddDACActorRelationshipOptions],
+	opts ...options.Enumerable[options.AddDACActorRelationshipOptions],
 ) (client.AddActorRelationshipResult, error) {
 	opt := utils.NewOptions(opts...)
 	ctx = ctxWithOptIdentity(ctx, opt)
@@ -229,7 +229,7 @@ func (w *Wrapper) DeleteDACActorRelationship(
 	docID string,
 	relation string,
 	targetActor string,
-	opts ...options.Lister[options.DeleteDACActorRelationshipOptions],
+	opts ...options.Enumerable[options.DeleteDACActorRelationshipOptions],
 ) (client.DeleteActorRelationshipResult, error) {
 	opt := utils.NewOptions(opts...)
 	ctx = ctxWithOptIdentity(ctx, opt)
@@ -246,7 +246,7 @@ func (w *Wrapper) DeleteDACActorRelationship(
 
 func (w *Wrapper) GetNACStatus(
 	ctx context.Context,
-	opts ...options.Lister[options.GetNACStatusOptions],
+	opts ...options.Enumerable[options.GetNACStatusOptions],
 ) (client.NACStatusResult, error) {
 	opt := utils.NewOptions(opts...)
 	ctx = ctxWithOptIdentity(ctx, opt)
@@ -261,14 +261,14 @@ func (w *Wrapper) GetNACStatus(
 	return out, nil
 }
 
-func (w *Wrapper) ReEnableNAC(ctx context.Context, opts ...options.Lister[options.ReEnableNACOptions]) error {
+func (w *Wrapper) ReEnableNAC(ctx context.Context, opts ...options.Enumerable[options.ReEnableNACOptions]) error {
 	opt := utils.NewOptions(opts...)
 	ctx = ctxWithOptIdentity(ctx, opt)
 	_, err := execute(ctx, w.value, "reEnableNAC")
 	return err
 }
 
-func (w *Wrapper) DisableNAC(ctx context.Context, opts ...options.Lister[options.DisableNACOptions]) error {
+func (w *Wrapper) DisableNAC(ctx context.Context, opts ...options.Enumerable[options.DisableNACOptions]) error {
 	opt := utils.NewOptions(opts...)
 	ctx = ctxWithOptIdentity(ctx, opt)
 	_, err := execute(ctx, w.value, "disableNAC")
@@ -279,7 +279,7 @@ func (w *Wrapper) AddNACActorRelationship(
 	ctx context.Context,
 	relation string,
 	targetActor string,
-	opts ...options.Lister[options.AddNACActorRelationshipOptions],
+	opts ...options.Enumerable[options.AddNACActorRelationshipOptions],
 ) (client.AddActorRelationshipResult, error) {
 	opt := utils.NewOptions(opts...)
 	ctx = ctxWithOptIdentity(ctx, opt)
@@ -298,7 +298,7 @@ func (w *Wrapper) DeleteNACActorRelationship(
 	ctx context.Context,
 	relation string,
 	targetActor string,
-	opts ...options.Lister[options.DeleteNACActorRelationshipOptions],
+	opts ...options.Enumerable[options.DeleteNACActorRelationshipOptions],
 ) (client.DeleteActorRelationshipResult, error) {
 	opt := utils.NewOptions(opts...)
 	ctx = ctxWithOptIdentity(ctx, opt)
@@ -317,7 +317,7 @@ func (w *Wrapper) PatchCollection(
 	ctx context.Context,
 	patch string,
 	migration immutable.Option[model.Lens],
-	opts ...options.Lister[options.PatchCollectionOptions],
+	opts ...options.Enumerable[options.PatchCollectionOptions],
 ) error {
 	migrationVal, err := goji.MarshalJS(migration)
 	if err != nil {
@@ -332,7 +332,7 @@ func (w *Wrapper) PatchCollection(
 func (w *Wrapper) SetActiveCollectionVersion(
 	ctx context.Context,
 	collectionVersionID string,
-	opts ...options.Lister[options.SetActiveCollectionVersionOptions],
+	opts ...options.Enumerable[options.SetActiveCollectionVersionOptions],
 ) error {
 	opt := utils.NewOptions(opts...)
 	ctx = ctxWithOptIdentity(ctx, opt)
@@ -344,7 +344,7 @@ func (w *Wrapper) AddView(
 	ctx context.Context,
 	query string,
 	sdl string,
-	opts ...options.Lister[options.AddViewOptions],
+	opts ...options.Enumerable[options.AddViewOptions],
 ) ([]client.CollectionVersion, error) {
 	opt := utils.NewOptions(opts...)
 	ctx = ctxWithOptIdentity(ctx, opt)
@@ -364,7 +364,7 @@ func (w *Wrapper) AddView(
 	return out, nil
 }
 
-func (w *Wrapper) RefreshViews(ctx context.Context, opts ...options.Lister[options.RefreshViewsOptions]) error {
+func (w *Wrapper) RefreshViews(ctx context.Context, opts ...options.Enumerable[options.RefreshViewsOptions]) error {
 	var optsVal sysjs.Value
 	var err error
 	opt := utils.NewOptions(opts...)
@@ -396,7 +396,7 @@ func (w *Wrapper) SetMigration(ctx context.Context, config client.LensConfig) (s
 func (w *Wrapper) AddLens(
 	ctx context.Context,
 	lens model.Lens,
-	opts ...options.Lister[options.AddLensOptions],
+	opts ...options.Enumerable[options.AddLensOptions],
 ) (string, error) {
 	opt := utils.NewOptions(opts...)
 	if opt != nil {
@@ -415,7 +415,7 @@ func (w *Wrapper) AddLens(
 
 func (w *Wrapper) ListLenses(
 	ctx context.Context,
-	opts ...options.Lister[options.ListLensesOptions],
+	opts ...options.Enumerable[options.ListLensesOptions],
 ) (map[string]model.Lens, error) {
 	opt := utils.NewOptions(opts...)
 	ctx = ctxWithOptIdentity(ctx, opt)
@@ -433,7 +433,7 @@ func (w *Wrapper) ListLenses(
 func (w *Wrapper) GetCollectionByName(
 	ctx context.Context,
 	name client.CollectionName,
-	opts ...options.Lister[options.GetCollectionByNameOptions],
+	opts ...options.Enumerable[options.GetCollectionByNameOptions],
 ) (client.Collection, error) {
 	opt := utils.NewOptions(opts...)
 	ctx = ctxWithOptIdentity(ctx, opt)
@@ -448,7 +448,7 @@ func (w *Wrapper) GetCollectionByName(
 
 func (w *Wrapper) GetCollections(
 	ctx context.Context,
-	opts ...options.Lister[options.GetCollectionsOptions],
+	opts ...options.Enumerable[options.GetCollectionsOptions],
 ) ([]client.Collection, error) {
 	var optsVal sysjs.Value
 	var err error
@@ -477,7 +477,7 @@ func (w *Wrapper) GetCollections(
 
 func (w *Wrapper) GetAllIndexes(
 	ctx context.Context,
-	opts ...options.Lister[options.GetAllIndexesOptions],
+	opts ...options.Enumerable[options.GetAllIndexesOptions],
 ) (map[client.CollectionName][]client.IndexDescription, error) {
 	opt := utils.NewOptions(opts...)
 	ctx = ctxWithOptIdentity(ctx, opt)
@@ -495,7 +495,7 @@ func (w *Wrapper) GetAllIndexes(
 func (w *Wrapper) ExecRequest(
 	ctx context.Context,
 	query string,
-	opts ...options.Lister[options.ExecRequestOptions],
+	opts ...options.Enumerable[options.ExecRequestOptions],
 ) *client.RequestResult {
 	var optsVal sysjs.Value
 	opt := utils.NewOptions(opts...)
@@ -591,7 +591,7 @@ func (w *Wrapper) PrintDump(ctx context.Context) error {
 	return w.node.DB.PrintDump(ctx)
 }
 
-func (w *Wrapper) Connect(ctx context.Context, addresses []string, opts ...options.Lister[options.ConnectOptions]) error {
+func (w *Wrapper) Connect(ctx context.Context, addresses []string, opts ...options.Enumerable[options.ConnectOptions]) error {
 	return w.node.DB.Connect(ctx, addresses, opts...)
 }
 
@@ -611,7 +611,7 @@ func (w *Wrapper) VerifySignature(
 	ctx context.Context,
 	blockCid string,
 	pubKey crypto.PublicKey,
-	opts ...options.Lister[options.VerifySignatureOptions],
+	opts ...options.Enumerable[options.VerifySignatureOptions],
 ) error {
 	opt := utils.NewOptions(opts...)
 	ctx = ctxWithOptIdentity(ctx, opt)

--- a/tests/clients/js/wrapper_collection.go
+++ b/tests/clients/js/wrapper_collection.go
@@ -72,7 +72,7 @@ func (c *Collection) CollectionID() string {
 func (c *Collection) Create(
 	ctx context.Context,
 	doc *client.Document,
-	opts ...options.Lister[options.CollectionCreateOptions],
+	opts ...options.Enumerable[options.CollectionCreateOptions],
 ) error {
 	opt := utils.NewOptions(opts...)
 	ctx = ctxWithOptIdentity(ctx, opt)
@@ -94,7 +94,7 @@ type createOptionsJS struct {
 	EncryptedFields []string `json:"encryptedFields"`
 }
 
-func makeDocCreateOptions(opts []options.Lister[options.CollectionCreateOptions]) js.Value {
+func makeDocCreateOptions(opts []options.Enumerable[options.CollectionCreateOptions]) js.Value {
 	jsOpts := createOptionsJS{}
 	createOpts := utils.NewOptions(opts...)
 	jsOpts.EncryptDoc = createOpts.EncryptDoc
@@ -110,7 +110,7 @@ func makeDocCreateOptions(opts []options.Lister[options.CollectionCreateOptions]
 func (c *Collection) CreateMany(
 	ctx context.Context,
 	docs []*client.Document,
-	opts ...options.Lister[options.CollectionCreateOptions],
+	opts ...options.Enumerable[options.CollectionCreateOptions],
 ) error {
 	opt := utils.NewOptions(opts...)
 	ctx = ctxWithOptIdentity(ctx, opt)
@@ -131,7 +131,7 @@ func (c *Collection) CreateMany(
 func (c *Collection) Update(
 	ctx context.Context,
 	doc *client.Document,
-	opts ...options.Lister[options.CollectionUpdateOptions],
+	opts ...options.Enumerable[options.CollectionUpdateOptions],
 ) error {
 	opt := utils.NewOptions(opts...)
 	ctx = ctxWithOptIdentity(ctx, opt)
@@ -151,7 +151,7 @@ func (c *Collection) Update(
 func (c *Collection) Save(
 	ctx context.Context,
 	doc *client.Document,
-	opts ...options.Lister[options.CollectionSaveOptions],
+	opts ...options.Enumerable[options.CollectionSaveOptions],
 ) error {
 	saveOpts := utils.NewOptions(opts...)
 	ctx = ctxWithOptIdentity(ctx, saveOpts)
@@ -171,7 +171,7 @@ func (c *Collection) Save(
 func (c *Collection) Delete(
 	ctx context.Context,
 	docID client.DocID,
-	opts ...options.Lister[options.CollectionDeleteOptions],
+	opts ...options.Enumerable[options.CollectionDeleteOptions],
 ) (bool, error) {
 	opt := utils.NewOptions(opts...)
 	ctx = ctxWithOptIdentity(ctx, opt)
@@ -185,7 +185,7 @@ func (c *Collection) Delete(
 func (c *Collection) Exists(
 	ctx context.Context,
 	docID client.DocID,
-	opts ...options.Lister[options.CollectionExistsOptions],
+	opts ...options.Enumerable[options.CollectionExistsOptions],
 ) (bool, error) {
 	opt := utils.NewOptions(opts...)
 	ctx = ctxWithOptIdentity(ctx, opt)
@@ -200,7 +200,7 @@ func (c *Collection) UpdateWithFilter(
 	ctx context.Context,
 	filter any,
 	updater string,
-	opts ...options.Lister[options.CollectionUpdateWithFilterOptions],
+	opts ...options.Enumerable[options.CollectionUpdateWithFilterOptions],
 ) (*client.UpdateResult, error) {
 	opt := utils.NewOptions(opts...)
 	ctx = ctxWithOptIdentity(ctx, opt)
@@ -218,7 +218,7 @@ func (c *Collection) UpdateWithFilter(
 func (c *Collection) DeleteWithFilter(
 	ctx context.Context,
 	filter any,
-	opts ...options.Lister[options.CollectionDeleteWithFilterOptions],
+	opts ...options.Enumerable[options.CollectionDeleteWithFilterOptions],
 ) (*client.DeleteResult, error) {
 	opt := utils.NewOptions(opts...)
 	ctx = ctxWithOptIdentity(ctx, opt)
@@ -236,7 +236,7 @@ func (c *Collection) DeleteWithFilter(
 func (c *Collection) Get(
 	ctx context.Context,
 	docID client.DocID,
-	opts ...options.Lister[options.CollectionGetOptions],
+	opts ...options.Enumerable[options.CollectionGetOptions],
 ) (*client.Document, error) {
 	opt := utils.NewOptions(opts...)
 	ctx = ctxWithOptIdentity(ctx, opt)
@@ -264,7 +264,7 @@ func (c *Collection) Get(
 
 func (c *Collection) GetAllDocIDs(
 	ctx context.Context,
-	opts ...options.Lister[options.CollectionGetAllDocIDsOptions],
+	opts ...options.Enumerable[options.CollectionGetAllDocIDsOptions],
 ) (<-chan client.DocIDResult, error) {
 	panic("not implemented")
 }
@@ -272,7 +272,7 @@ func (c *Collection) GetAllDocIDs(
 func (c *Collection) CreateIndex(
 	ctx context.Context,
 	indexDesc client.IndexCreateRequest,
-	opts ...options.Lister[options.CollectionCreateIndexOptions],
+	opts ...options.Enumerable[options.CollectionCreateIndexOptions],
 ) (client.IndexDescription, error) {
 	opt := utils.NewOptions(opts...)
 	ctx = ctxWithOptIdentity(ctx, opt)
@@ -291,14 +291,14 @@ func (c *Collection) CreateIndex(
 	return indexDescOut, nil
 }
 
-func (c *Collection) DropIndex(ctx context.Context, indexName string, opts ...options.Lister[options.CollectionDropIndexOptions]) error {
+func (c *Collection) DropIndex(ctx context.Context, indexName string, opts ...options.Enumerable[options.CollectionDropIndexOptions]) error {
 	opt := utils.NewOptions(opts...)
 	ctx = ctxWithOptIdentity(ctx, opt)
 	_, err := execute(ctx, c.client, "dropIndex", indexName)
 	return err
 }
 
-func (c *Collection) GetIndexes(ctx context.Context, opts ...options.Lister[options.CollectionGetIndexesOptions]) ([]client.IndexDescription, error) {
+func (c *Collection) GetIndexes(ctx context.Context, opts ...options.Enumerable[options.CollectionGetIndexesOptions]) ([]client.IndexDescription, error) {
 	opt := utils.NewOptions(opts...)
 	ctx = ctxWithOptIdentity(ctx, opt)
 	res, err := execute(ctx, c.client, "getIndexes")
@@ -348,7 +348,7 @@ func (c *Collection) DeleteEncryptedIndex(ctx context.Context, fieldName string)
 	return err
 }
 
-func (c *Collection) Truncate(ctx context.Context, opts ...options.Lister[options.CollectionTruncateOptions]) error {
+func (c *Collection) Truncate(ctx context.Context, opts ...options.Enumerable[options.CollectionTruncateOptions]) error {
 	opt := utils.NewOptions(opts...)
 	ctx = ctxWithOptIdentity(ctx, opt)
 	_, err := execute(ctx, c.client, "truncate")

--- a/tests/clients/js/wrapper_tx.go
+++ b/tests/clients/js/wrapper_tx.go
@@ -56,7 +56,7 @@ func (txn *Transaction) PrintDump(ctx context.Context) error {
 	return txn.Wrapper.PrintDump(ctx)
 }
 
-func (txn *Transaction) AddDACPolicy(ctx context.Context, policy string, opts ...options.Lister[options.AddDACPolicyOptions]) (client.AddPolicyResult, error) {
+func (txn *Transaction) AddDACPolicy(ctx context.Context, policy string, opts ...options.Enumerable[options.AddDACPolicyOptions]) (client.AddPolicyResult, error) {
 	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
 	return txn.Wrapper.AddDACPolicy(ctx, policy, opts...)
 }
@@ -67,7 +67,7 @@ func (txn *Transaction) AddDACActorRelationship(
 	docID string,
 	relation string,
 	targetActor string,
-	opts ...options.Lister[options.AddDACActorRelationshipOptions],
+	opts ...options.Enumerable[options.AddDACActorRelationshipOptions],
 ) (client.AddActorRelationshipResult, error) {
 	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
 	return txn.Wrapper.AddDACActorRelationship(ctx, collectionName, docID, relation, targetActor, opts...)
@@ -79,7 +79,7 @@ func (txn *Transaction) DeleteDACActorRelationship(
 	docID string,
 	relation string,
 	targetActor string,
-	opts ...options.Lister[options.DeleteDACActorRelationshipOptions],
+	opts ...options.Enumerable[options.DeleteDACActorRelationshipOptions],
 ) (client.DeleteActorRelationshipResult, error) {
 	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
 	return txn.Wrapper.DeleteDACActorRelationship(ctx, collectionName, docID, relation, targetActor, opts...)
@@ -90,12 +90,12 @@ func (txn *Transaction) GetNodeIdentity(ctx context.Context) (immutable.Option[i
 	return txn.Wrapper.GetNodeIdentity(ctx)
 }
 
-func (txn *Transaction) VerifySignature(ctx context.Context, blockCid string, pubKey crypto.PublicKey, opts ...options.Lister[options.VerifySignatureOptions]) error {
+func (txn *Transaction) VerifySignature(ctx context.Context, blockCid string, pubKey crypto.PublicKey, opts ...options.Enumerable[options.VerifySignatureOptions]) error {
 	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
 	return txn.Wrapper.VerifySignature(ctx, blockCid, pubKey, opts...)
 }
 
-func (txn *Transaction) AddSchema(ctx context.Context, sdl string, opts ...options.Lister[options.AddSchemaOptions]) ([]client.CollectionVersion, error) {
+func (txn *Transaction) AddSchema(ctx context.Context, sdl string, opts ...options.Enumerable[options.AddSchemaOptions]) ([]client.CollectionVersion, error) {
 	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
 	return txn.Wrapper.AddSchema(ctx, sdl, opts...)
 }
@@ -104,13 +104,13 @@ func (txn *Transaction) PatchCollection(
 	ctx context.Context,
 	patch string,
 	migration immutable.Option[model.Lens],
-	opts ...options.Lister[options.PatchCollectionOptions],
+	opts ...options.Enumerable[options.PatchCollectionOptions],
 ) error {
 	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
 	return txn.Wrapper.PatchCollection(ctx, patch, migration, opts...)
 }
 
-func (txn *Transaction) SetActiveCollectionVersion(ctx context.Context, version string, opts ...options.Lister[options.SetActiveCollectionVersionOptions]) error {
+func (txn *Transaction) SetActiveCollectionVersion(ctx context.Context, version string, opts ...options.Enumerable[options.SetActiveCollectionVersionOptions]) error {
 	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
 	return txn.Wrapper.SetActiveCollectionVersion(ctx, version, opts...)
 }
@@ -119,13 +119,13 @@ func (txn *Transaction) AddView(
 	ctx context.Context,
 	gqlQuery string,
 	sdl string,
-	opts ...options.Lister[options.AddViewOptions],
+	opts ...options.Enumerable[options.AddViewOptions],
 ) ([]client.CollectionVersion, error) {
 	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
 	return txn.Wrapper.AddView(ctx, gqlQuery, sdl, opts...)
 }
 
-func (txn *Transaction) RefreshViews(ctx context.Context, opts ...options.Lister[options.RefreshViewsOptions]) error {
+func (txn *Transaction) RefreshViews(ctx context.Context, opts ...options.Enumerable[options.RefreshViewsOptions]) error {
 	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
 	return txn.Wrapper.RefreshViews(ctx, opts...)
 }
@@ -138,7 +138,7 @@ func (txn *Transaction) SetMigration(ctx context.Context, config client.LensConf
 func (txn *Transaction) AddLens(
 	ctx context.Context,
 	lens model.Lens,
-	opts ...options.Lister[options.AddLensOptions],
+	opts ...options.Enumerable[options.AddLensOptions],
 ) (string, error) {
 	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
 	return txn.Wrapper.AddLens(ctx, lens, opts...)
@@ -146,7 +146,7 @@ func (txn *Transaction) AddLens(
 
 func (txn *Transaction) ListLenses(
 	ctx context.Context,
-	opts ...options.Lister[options.ListLensesOptions],
+	opts ...options.Enumerable[options.ListLensesOptions],
 ) (map[string]model.Lens, error) {
 	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
 	return txn.Wrapper.ListLenses(ctx, opts...)
@@ -155,7 +155,7 @@ func (txn *Transaction) ListLenses(
 func (txn *Transaction) GetCollectionByName(
 	ctx context.Context,
 	name client.CollectionName,
-	opts ...options.Lister[options.GetCollectionByNameOptions],
+	opts ...options.Enumerable[options.GetCollectionByNameOptions],
 ) (client.Collection, error) {
 	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
 	return txn.Wrapper.GetCollectionByName(ctx, name, opts...)
@@ -163,7 +163,7 @@ func (txn *Transaction) GetCollectionByName(
 
 func (txn *Transaction) GetCollections(
 	ctx context.Context,
-	opts ...options.Lister[options.GetCollectionsOptions],
+	opts ...options.Enumerable[options.GetCollectionsOptions],
 ) ([]client.Collection, error) {
 	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
 	return txn.Wrapper.GetCollections(ctx, opts...)
@@ -171,7 +171,7 @@ func (txn *Transaction) GetCollections(
 
 func (txn *Transaction) GetAllIndexes(
 	ctx context.Context,
-	opts ...options.Lister[options.GetAllIndexesOptions],
+	opts ...options.Enumerable[options.GetAllIndexesOptions],
 ) (map[client.CollectionName][]client.IndexDescription, error) {
 	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
 	return txn.Wrapper.GetAllIndexes(ctx, opts...)
@@ -180,7 +180,7 @@ func (txn *Transaction) GetAllIndexes(
 func (txn *Transaction) ExecRequest(
 	ctx context.Context,
 	request string,
-	opts ...options.Lister[options.ExecRequestOptions],
+	opts ...options.Enumerable[options.ExecRequestOptions],
 ) *client.RequestResult {
 	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
 	return txn.Wrapper.ExecRequest(ctx, request, opts...)
@@ -191,7 +191,7 @@ func (txn *Transaction) BasicImport(ctx context.Context, filepath string) error 
 	return txn.Wrapper.BasicImport(ctx, filepath)
 }
 
-func (txn *Transaction) BasicExport(ctx context.Context, filepath string, opts ...options.Lister[options.BasicExportOptions]) error {
+func (txn *Transaction) BasicExport(ctx context.Context, filepath string, opts ...options.Enumerable[options.BasicExportOptions]) error {
 	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
 	return txn.Wrapper.BasicExport(ctx, filepath, opts...)
 }

--- a/tests/integration/p2p.go
+++ b/tests/integration/p2p.go
@@ -171,7 +171,7 @@ func connectWithRetry(
 	ctx context.Context,
 	node *state.NodeState,
 	targetAddresses []string,
-	opt options.Lister[options.ConnectOptions],
+	opt options.Enumerable[options.ConnectOptions],
 ) error {
 	const maxRetries = 5
 	const retryDelay = 50 * time.Millisecond


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4526

## Description

Rename `options.Lister` to `options.Enumerable`