### PR TITLE
refactor: Rename GetCollectionsOptions.GetInactive

### DIFF
--- a/cbindings/collection.go
+++ b/cbindings/collection.go
@@ -55,7 +55,7 @@ func parseCollectionOptionsToGetCollectionsOptions(
 		opt.SetCollectionName(name)
 	}
 	if getInactive {
-		opt.SetIncludeInactive(getInactive)
+		opt.SetGetInactive(getInactive)
 	}
 	return opt
 }

--- a/cbindings/view.go
+++ b/cbindings/view.go
@@ -83,7 +83,7 @@ func ViewRefresh(nodePtr C.uintptr_t,
 		opt.SetCollectionName(viewName)
 	}
 	if cOptions.getInactive != 0 {
-		opt.SetIncludeInactive(true)
+		opt.SetGetInactive(true)
 	}
 
 	store, err := getStoreFromPointer(nodePtr)

--- a/cbindings/wrapper.go
+++ b/cbindings/wrapper.go
@@ -841,7 +841,7 @@ func (w *CWrapper) GetCollectionByName(
 // The caller is responsible for freeing the C strings (version, collectionID, name).
 func getCollectionsOptionsToCOptions(opts *options.GetCollectionsOptions) C.CollectionOptions {
 	var name, version, collectionID string
-	var includeInactive C.int = 0
+	var getInactive C.int = 0
 
 	if opts != nil {
 		if opts.CollectionName.HasValue() {
@@ -853,8 +853,8 @@ func getCollectionsOptionsToCOptions(opts *options.GetCollectionsOptions) C.Coll
 		if opts.CollectionID.HasValue() {
 			collectionID = opts.CollectionID.Value()
 		}
-		if opts.IncludeInactive.HasValue() && opts.IncludeInactive.Value() {
-			includeInactive = 1
+		if opts.GetInactive.HasValue() && opts.GetInactive.Value() {
+			getInactive = 1
 		}
 	}
 
@@ -862,7 +862,7 @@ func getCollectionsOptionsToCOptions(opts *options.GetCollectionsOptions) C.Coll
 	copts.version = C.CString(version)
 	copts.collectionID = C.CString(collectionID)
 	copts.name = C.CString(name)
-	copts.getInactive = includeInactive
+	copts.getInactive = getInactive
 	return copts
 }
 

--- a/cli/collection.go
+++ b/cli/collection.go
@@ -60,7 +60,7 @@ func MakeCollectionCommand(ctx context.Context) *cobra.Command {
 				opt.SetCollectionName(name)
 			}
 			if getInactive {
-				opt.SetIncludeInactive(getInactive)
+				opt.SetGetInactive(getInactive)
 			}
 
 			cols, err := cliClient.GetCollections(cmd.Context(), opt)

--- a/cli/collection_describe.go
+++ b/cli/collection_describe.go
@@ -43,7 +43,7 @@ func MakeCollectionDescribeCommand(ctx context.Context) *cobra.Command {
 				opt.SetCollectionName(name)
 			}
 			if getInactive {
-				opt.SetIncludeInactive(getInactive)
+				opt.SetGetInactive(getInactive)
 			}
 
 			cols, err := cliClient.GetCollections(

--- a/cli/view_refresh.go
+++ b/cli/view_refresh.go
@@ -47,7 +47,7 @@ items from that cache.`,
 				opt.SetCollectionName(name)
 			}
 			if getInactive {
-				opt.SetIncludeInactive(getInactive)
+				opt.SetGetInactive(getInactive)
 			}
 
 			return cliClient.RefreshViews(

--- a/client/options/store.go
+++ b/client/options/store.go
@@ -379,8 +379,8 @@ type GetCollectionsOptions struct {
 	CollectionSetID immutable.Option[string]
 	// If provided, only collections with this name will be returned.
 	CollectionName immutable.Option[string]
-	// If IncludeInactive is true, then inactive collections will also be returned.
-	IncludeInactive immutable.Option[bool]
+	// If GetInactive is true, then inactive collections will also be returned.
+	GetInactive immutable.Option[bool]
 }
 
 // GetIdentity returns the identity for the operation.
@@ -438,10 +438,10 @@ func (b *GetCollectionsOptionsBuilder) SetCollectionName(name string) *GetCollec
 	return b
 }
 
-// SetIncludeInactive sets whether to include inactive collections.
-func (b *GetCollectionsOptionsBuilder) SetIncludeInactive(includeInactive bool) *GetCollectionsOptionsBuilder {
+// SetGetInactive sets whether to include inactive collections.
+func (b *GetCollectionsOptionsBuilder) SetGetInactive(getInactive bool) *GetCollectionsOptionsBuilder {
 	b.append(func(opts *GetCollectionsOptions) {
-		opts.IncludeInactive = immutable.Some(includeInactive)
+		opts.GetInactive = immutable.Some(getInactive)
 	})
 	return b
 }

--- a/http/client.go
+++ b/http/client.go
@@ -253,8 +253,8 @@ func (c *Client) RefreshViews(ctx context.Context, opts ...options.Enumerable[op
 	if opt.CollectionID.HasValue() {
 		params.Add("collection_id", opt.CollectionID.Value())
 	}
-	if opt.IncludeInactive.HasValue() {
-		params.Add("get_inactive", strconv.FormatBool(opt.IncludeInactive.Value()))
+	if opt.GetInactive.HasValue() {
+		params.Add("get_inactive", strconv.FormatBool(opt.GetInactive.Value()))
 	}
 	methodURL.RawQuery = params.Encode()
 
@@ -385,8 +385,8 @@ func (c *Client) GetCollections(
 	if opt.CollectionID.HasValue() {
 		params.Add("collection_id", opt.CollectionID.Value())
 	}
-	if opt.IncludeInactive.HasValue() {
-		params.Add("get_inactive", strconv.FormatBool(opt.IncludeInactive.Value()))
+	if opt.GetInactive.HasValue() {
+		params.Add("get_inactive", strconv.FormatBool(opt.GetInactive.Value()))
 	}
 	methodURL.RawQuery = params.Encode()
 

--- a/http/handler_store.go
+++ b/http/handler_store.go
@@ -246,7 +246,7 @@ func (h *storeHandler) GetCollection(rw http.ResponseWriter, req *http.Request) 
 			responseJSON(rw, http.StatusBadRequest, errorResponse{err})
 			return
 		}
-		opt.SetIncludeInactive(getInactive)
+		opt.SetGetInactive(getInactive)
 	}
 
 	cols, err := db.GetCollections(ctx, opt)
@@ -281,7 +281,7 @@ func (h *storeHandler) RefreshViews(rw http.ResponseWriter, req *http.Request) {
 			responseJSON(rw, http.StatusBadRequest, errorResponse{err})
 			return
 		}
-		opt.SetIncludeInactive(getInactive)
+		opt.SetGetInactive(getInactive)
 	}
 
 	err := db.RefreshViews(req.Context(), opt)

--- a/internal/db/collection.go
+++ b/internal/db/collection.go
@@ -120,7 +120,7 @@ func (db *DB) getCollections(
 
 	var cols []client.CollectionVersion
 	switch {
-	case opts.CollectionName.HasValue() && !opts.IncludeInactive.Value():
+	case opts.CollectionName.HasValue() && !opts.GetInactive.Value():
 		col, err := description.GetCollectionByName(ctx, opts.CollectionName.Value())
 		if err != nil && !errors.Is(err, corekv.ErrNotFound) {
 			return nil, err
@@ -149,7 +149,7 @@ func (db *DB) getCollections(
 	// case opts.CollectionSetID.HasValue():
 
 	default:
-		if opts.IncludeInactive.HasValue() && opts.IncludeInactive.Value() {
+		if opts.GetInactive.HasValue() && opts.GetInactive.Value() {
 			var err error
 			cols, err = description.GetCollections(ctx)
 			if err != nil {
@@ -179,7 +179,7 @@ func (db *DB) getCollections(
 		}
 
 		// By default, we don't return inactive collections unless a specific version is requested.
-		if !opts.IncludeInactive.Value() && !col.IsActive && !opts.VersionID.HasValue() {
+		if !opts.GetInactive.Value() && !col.IsActive && !opts.VersionID.HasValue() {
 			continue
 		}
 

--- a/internal/planner/commit.go
+++ b/internal/planner/commit.go
@@ -336,7 +336,7 @@ func (n *dagScanNode) dagBlockToNodeDoc(block *coreblock.Block) (core.Doc, error
 
 	cols, err := n.planner.db.GetCollections(
 		n.planner.ctx,
-		options.GetCollections().SetIncludeInactive(true).SetVersionID(collectionVersionId),
+		options.GetCollections().SetGetInactive(true).SetVersionID(collectionVersionId),
 	)
 	if err != nil {
 		return core.Doc{}, err

--- a/js/client_store.go
+++ b/js/client_store.go
@@ -107,10 +107,10 @@ func (c *Client) addView(this js.Value, args []js.Value) (js.Value, error) {
 
 // collectionFetchOptions is a local type for JSON serialization from the JS client.
 type collectionFetchOptions struct {
-	CollectionName  immutable.Option[string]
-	VersionID       immutable.Option[string]
-	CollectionID    immutable.Option[string]
-	IncludeInactive immutable.Option[bool]
+	CollectionName immutable.Option[string]
+	VersionID      immutable.Option[string]
+	CollectionID   immutable.Option[string]
+	GetInactive    immutable.Option[bool]
 }
 
 func (c *Client) refreshViews(this js.Value, args []js.Value) (js.Value, error) {
@@ -230,8 +230,8 @@ func collectionFetchOptionsToGetCollectionsOptions(input collectionFetchOptions)
 	if input.CollectionName.HasValue() {
 		opt.SetCollectionName(input.CollectionName.Value())
 	}
-	if input.IncludeInactive.HasValue() {
-		opt.SetIncludeInactive(input.IncludeInactive.Value())
+	if input.GetInactive.HasValue() {
+		opt.SetGetInactive(input.GetInactive.Value())
 	}
 	return opt
 }

--- a/tests/clients/cli/wrapper.go
+++ b/tests/clients/cli/wrapper.go
@@ -473,8 +473,8 @@ func (w *Wrapper) RefreshViews(ctx context.Context, opts ...options.Enumerable[o
 	if opt.CollectionID.HasValue() {
 		args = append(args, "--collection-id", opt.CollectionID.Value())
 	}
-	if opt.IncludeInactive.HasValue() {
-		args = append(args, "--get-inactive", strconv.FormatBool(opt.IncludeInactive.Value()))
+	if opt.GetInactive.HasValue() {
+		args = append(args, "--get-inactive", strconv.FormatBool(opt.GetInactive.Value()))
 	}
 
 	args = appendIdentityArg(args, opt.GetIdentity())
@@ -589,8 +589,8 @@ func (w *Wrapper) GetCollections(
 	if opt.CollectionID.HasValue() {
 		args = append(args, "--collection-id", opt.CollectionID.Value())
 	}
-	if opt.IncludeInactive.HasValue() {
-		args = append(args, "--get-inactive", strconv.FormatBool(opt.IncludeInactive.Value()))
+	if opt.GetInactive.HasValue() {
+		args = append(args, "--get-inactive", strconv.FormatBool(opt.GetInactive.Value()))
 	}
 	args = appendIdentityArg(args, opt.GetIdentity())
 

--- a/tests/integration/acp/nac/collection_get_by_name_test.go
+++ b/tests/integration/acp/nac/collection_get_by_name_test.go
@@ -41,7 +41,7 @@ func TestNAC_GatesCollectionGetByName_AuthorizedIdentity_AllowAccess(t *testing.
 			// This should work as the identity is authorized.
 			&action.GetCollections{
 				Identity:      testUtils.ClientIdentity(1),
-				FilterOptions: options.GetCollections().SetCollectionName("Users").SetIncludeInactive(false),
+				FilterOptions: options.GetCollections().SetCollectionName("Users").SetGetInactive(false),
 				ExpectedResults: []client.CollectionVersion{
 					{
 						Name:           "Users",
@@ -75,7 +75,7 @@ func TestNAC_GatesCollectionGetByName_NoIdentity_NotAuthorizedError(t *testing.T
 			// We haven't authorized non-identities. So, this should error.
 			&action.GetCollections{
 				Identity:      testUtils.NoIdentity(),
-				FilterOptions: options.GetCollections().SetCollectionName("Users").SetIncludeInactive(false),
+				FilterOptions: options.GetCollections().SetCollectionName("Users").SetGetInactive(false),
 				ExpectedError: testUtils.FormatExpectedErrorWithPermission(acpTypes.NodeCollectionGetPerm),
 			},
 		},
@@ -97,7 +97,7 @@ func TestNAC_GatesCollectionGetByName_WrongIdentity_NotAuthorizedError(t *testin
 			// Wrong user/identity will also not be authorized.
 			&action.GetCollections{
 				Identity:      testUtils.ClientIdentity(2),
-				FilterOptions: options.GetCollections().SetCollectionName("Users").SetIncludeInactive(false),
+				FilterOptions: options.GetCollections().SetCollectionName("Users").SetGetInactive(false),
 				ExpectedError: testUtils.FormatExpectedErrorWithPermission(acpTypes.NodeCollectionGetPerm),
 			},
 		},

--- a/tests/integration/acp/nac/collection_get_by_version_test.go
+++ b/tests/integration/acp/nac/collection_get_by_version_test.go
@@ -33,7 +33,7 @@ func TestNAC_GatesCollectionGetByVersion_AuthorizedIdentity_AllowAccess(t *testi
 			// This should work as the identity is authorized.
 			&action.GetCollections{
 				Identity:      testUtils.ClientIdentity(1),
-				FilterOptions: options.GetCollections().SetVersionID("does not exist").SetIncludeInactive(false),
+				FilterOptions: options.GetCollections().SetVersionID("does not exist").SetGetInactive(false),
 				ExpectedError: "key not found", // Note: it is authorized, just key not found.
 			},
 		},
@@ -55,7 +55,7 @@ func TestNAC_GatesCollectionGetByVersion_NoIdentity_NotAuthorizedError(t *testin
 			// We haven't authorized non-identities. So, this should error.
 			&action.GetCollections{
 				Identity:      testUtils.NoIdentity(),
-				FilterOptions: options.GetCollections().SetVersionID("does not exist").SetIncludeInactive(false),
+				FilterOptions: options.GetCollections().SetVersionID("does not exist").SetGetInactive(false),
 				ExpectedError: testUtils.FormatExpectedErrorWithPermission(acpTypes.NodeCollectionGetPerm),
 			},
 		},
@@ -77,7 +77,7 @@ func TestNAC_GatesCollectionGetByVersion_WrongIdentity_NotAuthorizedError(t *tes
 			// Wrong user/identity will also not be authorized.
 			&action.GetCollections{
 				Identity:      testUtils.ClientIdentity(2),
-				FilterOptions: options.GetCollections().SetVersionID("does not exist").SetIncludeInactive(false),
+				FilterOptions: options.GetCollections().SetVersionID("does not exist").SetGetInactive(false),
 				ExpectedError: testUtils.FormatExpectedErrorWithPermission(acpTypes.NodeCollectionGetPerm),
 			},
 		},

--- a/tests/integration/acp/nac/relation_admin/collection_get_by_name_test.go
+++ b/tests/integration/acp/nac/relation_admin/collection_get_by_name_test.go
@@ -41,7 +41,7 @@ func TestNAC_AdminRelation_CanCollectionGetByName(t *testing.T) {
 			// This user, can not perform this gated operation yet.
 			&action.GetCollections{
 				Identity:      testUtils.ClientIdentity(2),
-				FilterOptions: options.GetCollections().SetCollectionName("Users").SetIncludeInactive(false),
+				FilterOptions: options.GetCollections().SetCollectionName("Users").SetGetInactive(false),
 				ExpectedError: testUtils.FormatExpectedErrorWithPermission(acpTypes.NodeCollectionGetPerm),
 			},
 
@@ -56,7 +56,7 @@ func TestNAC_AdminRelation_CanCollectionGetByName(t *testing.T) {
 			// This user, can now perform this gated operation.
 			&action.GetCollections{
 				Identity:      testUtils.ClientIdentity(2),
-				FilterOptions: options.GetCollections().SetCollectionName("Users").SetIncludeInactive(false),
+				FilterOptions: options.GetCollections().SetCollectionName("Users").SetGetInactive(false),
 				ExpectedResults: []client.CollectionVersion{
 					{
 						Name:           "Users",

--- a/tests/integration/acp/nac/relation_admin/collection_get_by_version_test.go
+++ b/tests/integration/acp/nac/relation_admin/collection_get_by_version_test.go
@@ -33,7 +33,7 @@ func TestNAC_AdminRelation_CanCollectionGetByVersion(t *testing.T) {
 			// This user, can not perform this gated operation yet.
 			&action.GetCollections{
 				Identity:      testUtils.ClientIdentity(2),
-				FilterOptions: options.GetCollections().SetVersionID("does not exist").SetIncludeInactive(false),
+				FilterOptions: options.GetCollections().SetVersionID("does not exist").SetGetInactive(false),
 				ExpectedError: testUtils.FormatExpectedErrorWithPermission(acpTypes.NodeCollectionGetPerm),
 			},
 
@@ -48,7 +48,7 @@ func TestNAC_AdminRelation_CanCollectionGetByVersion(t *testing.T) {
 			// This user, can now perform this gated operation.
 			&action.GetCollections{
 				Identity:      testUtils.ClientIdentity(2),
-				FilterOptions: options.GetCollections().SetVersionID("does not exist").SetIncludeInactive(false),
+				FilterOptions: options.GetCollections().SetVersionID("does not exist").SetGetInactive(false),
 				ExpectedError: "key not found", // Note: it is authorized, just key not found.
 			},
 		},

--- a/tests/integration/collection_version/get_schema_test.go
+++ b/tests/integration/collection_version/get_schema_test.go
@@ -94,7 +94,7 @@ func TestGetSchema_ReturnsAllSchema(t *testing.T) {
 				`,
 			},
 			&action.GetCollections{
-				FilterOptions: options.GetCollections().SetIncludeInactive(true),
+				FilterOptions: options.GetCollections().SetGetInactive(true),
 				ExpectedResults: []client.CollectionVersion{
 					{
 						Name:           "Books",
@@ -171,7 +171,7 @@ func TestGetSchema_ReturnsSchemaForGivenRoot(t *testing.T) {
 				`,
 			},
 			&action.GetCollections{
-				FilterOptions: options.GetCollections().SetIncludeInactive(true).SetCollectionID(usersSchemaVersion1ID),
+				FilterOptions: options.GetCollections().SetGetInactive(true).SetCollectionID(usersSchemaVersion1ID),
 				ExpectedResults: []client.CollectionVersion{
 					{
 						Name:           "Users",
@@ -238,7 +238,7 @@ func TestGetSchema_ReturnsSchemaForGivenName(t *testing.T) {
 				`,
 			},
 			&action.GetCollections{
-				FilterOptions: options.GetCollections().SetCollectionName("Users").SetIncludeInactive(true),
+				FilterOptions: options.GetCollections().SetCollectionName("Users").SetGetInactive(true),
 				ExpectedResults: []client.CollectionVersion{
 					{
 						Name:           "Users",

--- a/tests/integration/collection_version/migrations/simple_test.go
+++ b/tests/integration/collection_version/migrations/simple_test.go
@@ -46,7 +46,7 @@ func TestSchemaMigrationDoesNotErrorGivenUnknownSchemaRoots(t *testing.T) {
 				},
 			},
 			&action.GetCollections{
-				FilterOptions: options.GetCollections().SetIncludeInactive(true),
+				FilterOptions: options.GetCollections().SetGetInactive(true),
 				ExpectedResults: []client.CollectionVersion{
 					{
 						VersionID:      "also does not exist",
@@ -106,7 +106,7 @@ func TestSchemaMigrationGetMigrationsReturnsMultiple(t *testing.T) {
 				},
 			},
 			&action.GetCollections{
-				FilterOptions: options.GetCollections().SetIncludeInactive(true),
+				FilterOptions: options.GetCollections().SetGetInactive(true),
 				ExpectedResults: []client.CollectionVersion{
 					{
 						VersionID:      "also does not exist",
@@ -179,7 +179,7 @@ func TestSchemaMigrationReplacesExistingMigationBasedOnSourceID(t *testing.T) {
 				},
 			},
 			&action.GetCollections{
-				FilterOptions: options.GetCollections().SetIncludeInactive(true),
+				FilterOptions: options.GetCollections().SetGetInactive(true),
 				ExpectedResults: []client.CollectionVersion{
 					{
 						VersionID:      "a",

--- a/tests/integration/collection_version/migrations/with_txn_test.go
+++ b/tests/integration/collection_version/migrations/with_txn_test.go
@@ -46,7 +46,7 @@ func TestSchemaMigrationGetMigrationsWithTxn(t *testing.T) {
 			},
 			&action.GetCollections{
 				TransactionID: immutable.Some(0),
-				FilterOptions: options.GetCollections().SetIncludeInactive(true),
+				FilterOptions: options.GetCollections().SetGetInactive(true),
 				ExpectedResults: []client.CollectionVersion{
 					{
 						VersionID:      "also does not exist",

--- a/tests/integration/collection_version/updates/remove/collections_test.go
+++ b/tests/integration/collection_version/updates/remove/collections_test.go
@@ -244,7 +244,7 @@ func TestColVersionUpdateCopyCollectionAddFieldRemoveOriginalCollection(t *testi
 				`,
 			},
 			&action.GetCollections{
-				FilterOptions: options.GetCollections().SetIncludeInactive(true),
+				FilterOptions: options.GetCollections().SetGetInactive(true),
 				ExpectedResults: []client.CollectionVersion{
 					{
 						Name:           "Users",
@@ -292,7 +292,7 @@ func TestColVersionUpdateAddFieldRemoveOriginalCollection_SamePatch(t *testing.T
 				`,
 			},
 			&action.GetCollections{
-				FilterOptions:   options.GetCollections().SetIncludeInactive(true),
+				FilterOptions:   options.GetCollections().SetGetInactive(true),
 				ExpectedResults: []client.CollectionVersion{},
 			},
 		},
@@ -370,7 +370,7 @@ func TestColVersionUpdateAddFieldRemoveNewCollection_DifferentPatches(t *testing
 				`,
 			},
 			&action.GetCollections{
-				FilterOptions: options.GetCollections().SetIncludeInactive(true),
+				FilterOptions: options.GetCollections().SetGetInactive(true),
 				ExpectedResults: []client.CollectionVersion{
 					{
 						Name:           "Users",
@@ -440,7 +440,7 @@ func TestColVersionUpdateAddFieldRemoveNewCollectionAndActivateOriginal(t *testi
 				`,
 			},
 			&action.GetCollections{
-				FilterOptions: options.GetCollections().SetIncludeInactive(true),
+				FilterOptions: options.GetCollections().SetGetInactive(true),
 				ExpectedResults: []client.CollectionVersion{
 					{
 						Name:           "Users",
@@ -632,7 +632,7 @@ func TestColVersionUpdateAddFieldRemoveMultipleNewCollection_MiddleAndLast(t *te
 				`,
 			},
 			&action.GetCollections{
-				FilterOptions: options.GetCollections().SetIncludeInactive(true),
+				FilterOptions: options.GetCollections().SetGetInactive(true),
 				ExpectedResults: []client.CollectionVersion{
 					{
 						Name:           "Users",

--- a/tests/integration/collection_version/updates/with_version_branch_test.go
+++ b/tests/integration/collection_version/updates/with_version_branch_test.go
@@ -142,7 +142,7 @@ func TestSchemaUpdates_WithBranchingSchema(t *testing.T) {
 				},
 			},
 			&action.GetCollections{
-				FilterOptions: options.GetCollections().SetIncludeInactive(true),
+				FilterOptions: options.GetCollections().SetGetInactive(true),
 				ExpectedResults: []client.CollectionVersion{
 					{
 						// The original collection version is present, it has no source and is inactive (has no name).
@@ -272,7 +272,7 @@ func TestSchemaUpdates_WithPatchOnBranchedSchema(t *testing.T) {
 				},
 			},
 			&action.GetCollections{
-				FilterOptions: options.GetCollections().SetIncludeInactive(true),
+				FilterOptions: options.GetCollections().SetGetInactive(true),
 				ExpectedResults: []client.CollectionVersion{
 					{
 						// The collection version for schema version 4 is present and is active, it also has the third collection
@@ -380,7 +380,7 @@ func TestSchemaUpdates_WithBranchingSchemaAndSetActiveSchemaToOtherBranch(t *tes
 				ExpectedError: `Cannot query field "phone" on type "Users".`,
 			},
 			&action.GetCollections{
-				FilterOptions: options.GetCollections().SetIncludeInactive(true),
+				FilterOptions: options.GetCollections().SetGetInactive(true),
 				ExpectedResults: []client.CollectionVersion{
 					{
 						// The original collection version is present, it has no source and is inactive.
@@ -515,7 +515,7 @@ func TestSchemaUpdates_WithBranchingSchemaAndSetActiveSchemaToOtherBranchThenPat
 				},
 			},
 			&action.GetCollections{
-				FilterOptions: options.GetCollections().SetIncludeInactive(true),
+				FilterOptions: options.GetCollections().SetGetInactive(true),
 				ExpectedResults: []client.CollectionVersion{
 					{
 						// The collection version for schema version 4 is present and is active, it also has the second collection

--- a/tests/integration/net/sync/collection_version/patch_test.go
+++ b/tests/integration/net/sync/collection_version/patch_test.go
@@ -52,7 +52,7 @@ func TestSyncColVersion_WithPatchVersionOfUnknownCollection(t *testing.T) {
 				VersionIDs: []string{"bafyreics7adsddesun4kqqotr6g6c6ld2t7djlwcbrm4ftbhru3ayindy4"},
 			},
 			&action.GetCollections{
-				FilterOptions: options.GetCollections().SetIncludeInactive(true),
+				FilterOptions: options.GetCollections().SetGetInactive(true),
 				NodeID:        immutable.Some(1),
 				ExpectedResults: []client.CollectionVersion{
 					{
@@ -137,7 +137,7 @@ func TestSyncColVersion_WithPatchVersionOfKnownCollection(t *testing.T) {
 				VersionIDs: []string{"bafyreics7adsddesun4kqqotr6g6c6ld2t7djlwcbrm4ftbhru3ayindy4"},
 			},
 			&action.GetCollections{
-				FilterOptions: options.GetCollections().SetIncludeInactive(true),
+				FilterOptions: options.GetCollections().SetGetInactive(true),
 				NodeID:        immutable.Some(1),
 				ExpectedResults: []client.CollectionVersion{
 					{

--- a/tests/integration/net/sync/collection_version/simple_test.go
+++ b/tests/integration/net/sync/collection_version/simple_test.go
@@ -66,7 +66,7 @@ func TestSyncColVersion_WithInitialColVersion(t *testing.T) {
 				},
 			},
 			&action.GetCollections{
-				FilterOptions: options.GetCollections().SetIncludeInactive(true),
+				FilterOptions: options.GetCollections().SetGetInactive(true),
 				NodeID:        immutable.Some(1),
 				ExpectedResults: []client.CollectionVersion{
 					{

--- a/tests/integration/net/sync/collection_version/view_test.go
+++ b/tests/integration/net/sync/collection_version/view_test.go
@@ -75,7 +75,7 @@ func TestSyncColVersion_WithView(t *testing.T) {
 				VersionIDs: []string{"{{.CollectionVersionID1}}"},
 			},
 			&action.GetCollections{
-				FilterOptions: options.GetCollections().SetIncludeInactive(true),
+				FilterOptions: options.GetCollections().SetGetInactive(true),
 				NodeID:        immutable.Some(1),
 				ExpectedResults: []client.CollectionVersion{
 					{


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4542

## Description

Renames GetCollectionsOptions.IncludeInactive to GetCollectionsOptions.GetInactive, making the Go and C clients naming consistent with the http and cli clients. 