### PR TITLE
fix(i): Lock collection when deleting collection versions

### DIFF
--- a/internal/db/collection_define.go
+++ b/internal/db/collection_define.go
@@ -684,7 +684,7 @@ func (db *DB) deleteCollectionVersion(
 		return err
 	}
 
-	err = description.DeleteCollection(ctx, version)
+	err = description.DeleteCollection(ctx, db.lockSet, version)
 	if err != nil {
 		return err
 	}

--- a/internal/db/description/collection.go
+++ b/internal/db/description/collection.go
@@ -504,7 +504,7 @@ func DeleteCollection(
 		return err
 	}
 
-	if len(versions) == 0 {
+	if len(versions) == 1 {
 		// Only delete the collection short ID if this was the last local version
 		err = id.DeleteShortCollectionID(ctx, version.CollectionID)
 		if err != nil {

--- a/internal/db/description/collection.go
+++ b/internal/db/description/collection.go
@@ -22,6 +22,7 @@ import (
 	"github.com/sourcenetwork/defradb/errors"
 	"github.com/sourcenetwork/defradb/internal/datastore"
 	"github.com/sourcenetwork/defradb/internal/db/id"
+	"github.com/sourcenetwork/defradb/internal/db/lock"
 	"github.com/sourcenetwork/defradb/internal/keys"
 )
 
@@ -462,8 +463,15 @@ func GetRelatedCollection(
 
 func DeleteCollection(
 	ctx context.Context,
+	lockSet *lock.LockSet,
 	version client.CollectionVersion,
 ) error {
+	txn := datastore.CtxMustGetTxn(ctx)
+	shortID, err := id.GetShortCollectionID(ctx, version.CollectionID)
+	if err != nil {
+		return err
+	}
+
 	versions, err := GetCollectionsByCollectionID(ctx, version.CollectionID)
 	if err != nil {
 		return err
@@ -471,8 +479,6 @@ func DeleteCollection(
 
 	cache := CollectionCacheFromContext(ctx)
 	cache.Delete(version)
-
-	txn := datastore.CtxMustGetTxn(ctx)
 
 	key := keys.NewCollectionKey(version.VersionID)
 	err = txn.Systemstore().Delete(ctx, key.Bytes())
@@ -499,12 +505,16 @@ func DeleteCollection(
 
 	// WARNING - DeleteShortFieldIDs is dependent on the collection short id still existing, it should be called
 	// before deleting the collection short id.
-	err = id.DeleteShortFieldIDs(ctx, version, versions)
+	err = id.DeleteShortFieldIDs(ctx, lockSet, version, versions)
 	if err != nil {
 		return err
 	}
 
 	if len(versions) == 1 {
+		// It is impossible to recreate the collection short ID once it is deleted, so we must lock the collection
+		// whilst we finalize this operation, otherwise other threads/operations may try and make use of it.
+		lockSet.CollectionLock(txn, shortID)
+
 		// Only delete the collection short ID if this was the last local version
 		err = id.DeleteShortCollectionID(ctx, version.CollectionID)
 		if err != nil {

--- a/internal/db/id/field.go
+++ b/internal/db/id/field.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/internal/datastore"
+	"github.com/sourcenetwork/defradb/internal/db/lock"
 	"github.com/sourcenetwork/defradb/internal/db/sequence"
 	"github.com/sourcenetwork/defradb/internal/keys"
 )
@@ -171,6 +172,7 @@ func SetShortFieldIDs(ctx context.Context, collection client.CollectionVersion) 
 // WARNING - DeleteShortFieldIDs is dependent on the collection short id still existing
 func DeleteShortFieldIDs(
 	ctx context.Context,
+	lockSet *lock.LockSet,
 	collection client.CollectionVersion,
 	allVersions []client.CollectionVersion,
 ) error {
@@ -190,6 +192,8 @@ func DeleteShortFieldIDs(
 		}
 	}
 
+	fieldIDsToDelete := make([]string, 0)
+
 	for _, field := range collection.Fields {
 		if field.FieldID == "" {
 			// Short field IDs only exist for fields with full ids
@@ -202,7 +206,18 @@ func DeleteShortFieldIDs(
 			continue
 		}
 
-		err := DeleteShortFieldID(ctx, collectionShortID, field.FieldID)
+		fieldIDsToDelete = append(fieldIDsToDelete, field.FieldID)
+	}
+
+	if len(fieldIDsToDelete) > 0 {
+		txn := datastore.CtxMustGetTxn(ctx)
+		// It is impossible to recreate the field short ID once it is deleted, so we must lock the collection
+		// whilst we finalize this operation, otherwise other threads/operations may try and make use of it.
+		lockSet.CollectionLock(txn, collectionShortID)
+	}
+
+	for _, fieldID := range fieldIDsToDelete {
+		err := DeleteShortFieldID(ctx, collectionShortID, fieldID)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4511

## Description

Locks the collection when deleting collection and field short ids.

Also fixes a bug where collection short ids weren't actually getting deleted when the last collection version was deleted.

This is currently a pain to test due to the caching issue described in https://github.com/sourcenetwork/defradb/issues/4268 - the CI will make sure that no regressions are introduced, but they do not (yet) validate that the bug has been fixed.  Tests will be added during #4268.