### PR TITLE
refactor: Move identity context funcs to internal

### DIFF
--- a/cbindings/acp.go
+++ b/cbindings/acp.go
@@ -19,9 +19,9 @@ import "C"
 import (
 	"context"
 
-	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/options"
+	iIdentity "github.com/sourcenetwork/defradb/internal/identity"
 )
 
 //export ACPAddDACPolicy
@@ -38,7 +38,7 @@ func ACPAddDACPolicy(nodePtr C.uintptr_t, identityPtr C.uintptr_t, policy *C.cha
 		return returnC(returnGoC(1, err.Error(), ""))
 	}
 
-	opt := options.WithIdentity(options.AddDACPolicy(), acpIdentity.FromContext(ctx))
+	opt := options.WithIdentity(options.AddDACPolicy(), iIdentity.FromContext(ctx))
 	policyResult, err := store.AddDACPolicy(ctx, C.GoString(policy), opt)
 	if err != nil {
 		return returnC(returnGoC(1, err.Error(), ""))
@@ -68,7 +68,7 @@ func ACPAddDACActorRelationship(
 		return returnC(returnGoC(1, err.Error(), ""))
 	}
 
-	addOpt := options.WithIdentity(options.AddDACActorRelationship(), acpIdentity.FromContext(ctx))
+	addOpt := options.WithIdentity(options.AddDACActorRelationship(), iIdentity.FromContext(ctx))
 	result, err := store.AddDACActorRelationship(
 		ctx,
 		C.GoString(collection),
@@ -105,7 +105,7 @@ func ACPDeleteDACActorRelationship(
 		return returnC(returnGoC(1, err.Error(), ""))
 	}
 
-	delOpt := options.WithIdentity(options.DeleteDACActorRelationship(), acpIdentity.FromContext(ctx))
+	delOpt := options.WithIdentity(options.DeleteDACActorRelationship(), iIdentity.FromContext(ctx))
 	result, err := store.DeleteDACActorRelationship(
 		ctx,
 		C.GoString(collection),
@@ -135,7 +135,7 @@ func ACPDisableNAC(nodePtr C.uintptr_t, identityPtr C.uintptr_t) C.Result {
 		return returnC(returnGoC(1, err.Error(), ""))
 	}
 
-	disableOpt := options.WithIdentity(options.DisableNAC(), acpIdentity.FromContext(ctx))
+	disableOpt := options.WithIdentity(options.DisableNAC(), iIdentity.FromContext(ctx))
 	if err := store.DisableNAC(ctx, disableOpt); err != nil {
 		return returnC(returnGoC(1, err.Error(), ""))
 	}
@@ -157,7 +157,7 @@ func ACPReEnableNAC(nodePtr C.uintptr_t, identityPtr C.uintptr_t) C.Result {
 		return returnC(returnGoC(1, err.Error(), ""))
 	}
 
-	reEnableOpt := options.WithIdentity(options.ReEnableNAC(), acpIdentity.FromContext(ctx))
+	reEnableOpt := options.WithIdentity(options.ReEnableNAC(), iIdentity.FromContext(ctx))
 	if err := store.ReEnableNAC(ctx, reEnableOpt); err != nil {
 		return returnC(returnGoC(1, err.Error(), ""))
 	}
@@ -184,7 +184,7 @@ func ACPAddNACActorRelationship(
 		return returnC(returnGoC(1, err.Error(), ""))
 	}
 
-	addNACOpt := options.WithIdentity(options.AddNACActorRelationship(), acpIdentity.FromContext(ctx))
+	addNACOpt := options.WithIdentity(options.AddNACActorRelationship(), iIdentity.FromContext(ctx))
 	addNACActorRelationshipResult, err := store.AddNACActorRelationship(
 		ctx,
 		C.GoString(relation),
@@ -217,7 +217,7 @@ func ACPDeleteNACActorRelationship(
 		return returnC(returnGoC(1, err.Error(), ""))
 	}
 
-	delNACOpt := options.WithIdentity(options.DeleteNACActorRelationship(), acpIdentity.FromContext(ctx))
+	delNACOpt := options.WithIdentity(options.DeleteNACActorRelationship(), iIdentity.FromContext(ctx))
 	deleteNACActorRelationshipResult, err := store.DeleteNACActorRelationship(
 		ctx,
 		C.GoString(relation),
@@ -245,7 +245,7 @@ func ACPGetNACStatus(nodePtr C.uintptr_t, identityPtr C.uintptr_t) C.Result {
 		return returnC(returnGoC(1, err.Error(), ""))
 	}
 
-	getNACOpt := options.WithIdentity(options.GetNACStatus(), acpIdentity.FromContext(ctx))
+	getNACOpt := options.WithIdentity(options.GetNACStatus(), iIdentity.FromContext(ctx))
 	status, err := store.GetNACStatus(ctx, getNACOpt)
 	if err != nil {
 		return returnC(returnGoC(1, err.Error(), ""))

--- a/cbindings/block.go
+++ b/cbindings/block.go
@@ -19,9 +19,9 @@ import "C"
 import (
 	"context"
 
-	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client/options"
 	"github.com/sourcenetwork/defradb/crypto"
+	iIdentity "github.com/sourcenetwork/defradb/internal/identity"
 )
 
 //export BlockVerifySignature
@@ -52,7 +52,7 @@ func BlockVerifySignature(nodePtr C.uintptr_t,
 		return returnC(returnGoC(1, err.Error(), ""))
 	}
 
-	verifyOpt := options.WithIdentity(options.VerifySignature(), acpIdentity.FromContext(ctx))
+	verifyOpt := options.WithIdentity(options.VerifySignature(), iIdentity.FromContext(ctx))
 	err = store.VerifySignature(ctx, C.GoString(cid), pubKey, verifyOpt)
 	if err != nil {
 		return returnC(returnGoC(1, err.Error(), ""))

--- a/cbindings/collection.go
+++ b/cbindings/collection.go
@@ -24,10 +24,10 @@ import (
 	"github.com/sourcenetwork/immutable"
 	"github.com/sourcenetwork/lens/host-go/config/model"
 
-	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/options"
 	"github.com/sourcenetwork/defradb/internal/encryption"
+	acpIdentity "github.com/sourcenetwork/defradb/internal/identity"
 )
 
 type docIDResult struct {

--- a/cbindings/cutils.go
+++ b/cbindings/cutils.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
+	iIdentity "github.com/sourcenetwork/defradb/internal/identity"
 	"github.com/sourcenetwork/defradb/node"
 
 	"github.com/sourcenetwork/immutable"
@@ -177,7 +178,7 @@ func contextWithIdentity(ctx context.Context, identityPtr C.uintptr_t) (context.
 	if ident == nil {
 		return ctx, nil
 	}
-	return identity.WithContext(ctx, immutable.Some[identity.Identity](ident)), nil
+	return iIdentity.WithContext(ctx, immutable.Some[identity.Identity](ident)), nil
 }
 
 // ConvertAndFreeCResult exists to convert C.Result to GoCResult for use in integration tests

--- a/cbindings/encrypted_index.go
+++ b/cbindings/encrypted_index.go
@@ -19,9 +19,9 @@ import "C"
 import (
 	"context"
 
-	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/options"
+	iIdentity "github.com/sourcenetwork/defradb/internal/identity"
 )
 
 //export EncryptedIndexCreate
@@ -45,13 +45,13 @@ func EncryptedIndexCreate(
 		return returnC(returnGoC(1, err.Error(), ""))
 	}
 
-	getColOpt := options.WithIdentity(options.GetCollectionByName(), acpIdentity.FromContext(ctx))
+	getColOpt := options.WithIdentity(options.GetCollectionByName(), iIdentity.FromContext(ctx))
 	col, err := store.GetCollectionByName(ctx, C.GoString(collectionName), getColOpt)
 	if err != nil {
 		return returnC(returnGoC(1, err.Error(), ""))
 	}
 
-	createOpt := options.WithIdentity(options.CreateEncryptedIndex(), acpIdentity.FromContext(ctx))
+	createOpt := options.WithIdentity(options.CreateEncryptedIndex(), iIdentity.FromContext(ctx))
 	descWithID, err := col.CreateEncryptedIndex(ctx, desc, createOpt)
 	if err != nil {
 		return returnC(returnGoC(1, err.Error(), ""))

--- a/cbindings/index.go
+++ b/cbindings/index.go
@@ -20,9 +20,9 @@ import (
 	"context"
 	"strings"
 
-	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	defraOpts "github.com/sourcenetwork/defradb/client/options"
+	iIdentity "github.com/sourcenetwork/defradb/internal/identity"
 )
 
 //export IndexCreate
@@ -77,7 +77,7 @@ func IndexCreate(
 		return returnC(returnGoC(1, err.Error(), ""))
 	}
 
-	ident := acpIdentity.FromContext(ctx)
+	ident := iIdentity.FromContext(ctx)
 	col, err := store.GetCollectionByName(ctx, collectionName,
 		defraOpts.WithIdentity(defraOpts.GetCollectionByName(), ident))
 	if err != nil {
@@ -105,7 +105,7 @@ func IndexList(nodePtr C.uintptr_t, options C.CollectionOptions, identityPtr C.u
 		return returnC(returnGoC(1, err.Error(), ""))
 	}
 
-	ident := acpIdentity.FromContext(ctx)
+	ident := iIdentity.FromContext(ctx)
 	collectionName := C.GoString(options.name)
 	switch {
 	// Get the indices associated with a given collection
@@ -150,7 +150,7 @@ func IndexDrop(nodePtr C.uintptr_t,
 		return returnC(returnGoC(1, err.Error(), ""))
 	}
 
-	ident := acpIdentity.FromContext(ctx)
+	ident := iIdentity.FromContext(ctx)
 	col, err := store.GetCollectionByName(ctx, collectionName,
 		defraOpts.WithIdentity(defraOpts.GetCollectionByName(), ident))
 	if err != nil {

--- a/cbindings/lens.go
+++ b/cbindings/lens.go
@@ -23,9 +23,9 @@ import (
 
 	"github.com/sourcenetwork/lens/host-go/config/model"
 
-	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/options"
+	acpIdentity "github.com/sourcenetwork/defradb/internal/identity"
 )
 
 //export LensSet

--- a/cbindings/node.go
+++ b/cbindings/node.go
@@ -24,6 +24,7 @@ import (
 
 	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client/options"
+	iIdentity "github.com/sourcenetwork/defradb/internal/identity"
 	"github.com/sourcenetwork/defradb/node"
 	"github.com/sourcenetwork/immutable"
 )
@@ -70,7 +71,7 @@ func NewNode(cOptions C.NodeInitOptions) C.NewNodeResult {
 		opts.P2P().SetBootstrapPeers(peers...)
 	}
 	if gocOptions.Identity != nil {
-		ctx = acpIdentity.WithContext(ctx, immutable.Some[acpIdentity.Identity](gocOptions.Identity))
+		ctx = iIdentity.WithContext(ctx, immutable.Some[acpIdentity.Identity](gocOptions.Identity))
 		opts.DB().SetNodeIdentity(gocOptions.Identity)
 	}
 	if gocOptions.EnableNodeACP != 0 {

--- a/cbindings/p2p.go
+++ b/cbindings/p2p.go
@@ -20,8 +20,8 @@ import (
 	"context"
 	"time"
 
-	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client/options"
+	acpIdentity "github.com/sourcenetwork/defradb/internal/identity"
 )
 
 //export P2PInfo

--- a/cbindings/query.go
+++ b/cbindings/query.go
@@ -23,9 +23,9 @@ import (
 
 	"github.com/google/uuid"
 
-	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/options"
+	iIdentity "github.com/sourcenetwork/defradb/internal/identity"
 )
 
 // We cannot return a channel to/from C, so instead we have a map of subscription IDs to
@@ -127,7 +127,7 @@ func ExecuteQuery(
 		return returnC(returnGoC(1, err.Error(), ""))
 	}
 
-	ident := acpIdentity.FromContext(ctx)
+	ident := iIdentity.FromContext(ctx)
 	if ident.HasValue() {
 		opt.SetIdentity(ident.Value())
 	}

--- a/cbindings/schema.go
+++ b/cbindings/schema.go
@@ -19,8 +19,8 @@ import "C"
 import (
 	"context"
 
-	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client/options"
+	iIdentity "github.com/sourcenetwork/defradb/internal/identity"
 )
 
 //export AddSchema
@@ -36,7 +36,7 @@ func AddSchema(nodePtr C.uintptr_t, schema *C.char, identityPtr C.uintptr_t) C.R
 	if err != nil {
 		return returnC(returnGoC(1, err.Error(), ""))
 	}
-	opt := options.WithIdentity(options.AddSchema(), acpIdentity.FromContext(ctx))
+	opt := options.WithIdentity(options.AddSchema(), iIdentity.FromContext(ctx))
 	collectionVersions, err := store.AddSchema(ctx, C.GoString(schema), opt)
 	if err != nil {
 		return returnC(returnGoC(1, err.Error(), ""))

--- a/cbindings/view.go
+++ b/cbindings/view.go
@@ -19,8 +19,8 @@ import "C"
 import (
 	"context"
 
-	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client/options"
+	acpIdentity "github.com/sourcenetwork/defradb/internal/identity"
 )
 
 //export ViewAdd

--- a/cli/acp_dac_policy_add.go
+++ b/cli/acp_dac_policy_add.go
@@ -17,8 +17,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client/options"
+	"github.com/sourcenetwork/defradb/internal/identity"
 )
 
 func MakeDocumentACPPolicyAddCommand(ctx context.Context) *cobra.Command {

--- a/cli/acp_dac_relationship_add.go
+++ b/cli/acp_dac_relationship_add.go
@@ -15,8 +15,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client/options"
+	"github.com/sourcenetwork/defradb/internal/identity"
 )
 
 func MakeDocumentACPRelationshipAddCommand(ctx context.Context) *cobra.Command {

--- a/cli/acp_dac_relationship_delete.go
+++ b/cli/acp_dac_relationship_delete.go
@@ -15,8 +15,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client/options"
+	"github.com/sourcenetwork/defradb/internal/identity"
 )
 
 func MakeDocumentACPRelationshipDeleteCommand(ctx context.Context) *cobra.Command {

--- a/cli/acp_nac_disable.go
+++ b/cli/acp_nac_disable.go
@@ -15,9 +15,9 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/options"
+	"github.com/sourcenetwork/defradb/internal/identity"
 )
 
 func MakeNodeACPDisableCommand(ctx context.Context) *cobra.Command {

--- a/cli/acp_nac_re-enable.go
+++ b/cli/acp_nac_re-enable.go
@@ -15,9 +15,9 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/options"
+	"github.com/sourcenetwork/defradb/internal/identity"
 )
 
 func MakeNodeACPReEnableCommand(ctx context.Context) *cobra.Command {

--- a/cli/acp_nac_relationship_add.go
+++ b/cli/acp_nac_relationship_add.go
@@ -15,8 +15,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client/options"
+	"github.com/sourcenetwork/defradb/internal/identity"
 )
 
 func MakeNodeACPRelationshipAddCommand(ctx context.Context) *cobra.Command {

--- a/cli/acp_nac_relationship_delete.go
+++ b/cli/acp_nac_relationship_delete.go
@@ -15,8 +15,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client/options"
+	"github.com/sourcenetwork/defradb/internal/identity"
 )
 
 func MakeNodeACPRelationshipDeleteCommand(ctx context.Context) *cobra.Command {

--- a/cli/acp_nac_status.go
+++ b/cli/acp_nac_status.go
@@ -15,8 +15,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client/options"
+	"github.com/sourcenetwork/defradb/internal/identity"
 )
 
 func MakeNodeACPStatusCommand(ctx context.Context) *cobra.Command {

--- a/cli/block_verify.go
+++ b/cli/block_verify.go
@@ -15,9 +15,9 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client/options"
 	"github.com/sourcenetwork/defradb/crypto"
+	"github.com/sourcenetwork/defradb/internal/identity"
 )
 
 func MakeBlockVerifySignatureCommand(ctx context.Context) *cobra.Command {

--- a/cli/collection.go
+++ b/cli/collection.go
@@ -15,8 +15,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client/options"
+	iIdentity "github.com/sourcenetwork/defradb/internal/identity"
 )
 
 func MakeCollectionCommand(ctx context.Context) *cobra.Command {
@@ -49,7 +49,7 @@ func MakeCollectionCommand(ctx context.Context) *cobra.Command {
 			}
 			cliClient := mustGetContextCLIClient(cmd)
 
-			opt := options.WithIdentity(options.GetCollections(), acpIdentity.FromContext(cmd.Context()))
+			opt := options.WithIdentity(options.GetCollections(), iIdentity.FromContext(cmd.Context()))
 			if versionID != "" {
 				opt.SetVersionID(versionID)
 			}

--- a/cli/collection_create.go
+++ b/cli/collection_create.go
@@ -17,9 +17,9 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/options"
+	"github.com/sourcenetwork/defradb/internal/identity"
 )
 
 func MakeCollectionCreateCommand(ctx context.Context) *cobra.Command {

--- a/cli/collection_delete.go
+++ b/cli/collection_delete.go
@@ -15,9 +15,9 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/options"
+	"github.com/sourcenetwork/defradb/internal/identity"
 )
 
 func MakeCollectionDeleteCommand(ctx context.Context) *cobra.Command {

--- a/cli/collection_describe.go
+++ b/cli/collection_describe.go
@@ -15,9 +15,9 @@ import (
 
 	"github.com/spf13/cobra"
 
-	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/options"
+	iIdentity "github.com/sourcenetwork/defradb/internal/identity"
 )
 
 func MakeCollectionDescribeCommand(ctx context.Context) *cobra.Command {
@@ -32,7 +32,7 @@ func MakeCollectionDescribeCommand(ctx context.Context) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cliClient := mustGetContextCLIClient(cmd)
 
-			opt := options.WithIdentity(options.GetCollections(), acpIdentity.FromContext(cmd.Context()))
+			opt := options.WithIdentity(options.GetCollections(), iIdentity.FromContext(cmd.Context()))
 			if versionID != "" {
 				opt.SetVersionID(versionID)
 			}

--- a/cli/collection_get.go
+++ b/cli/collection_get.go
@@ -15,9 +15,9 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/options"
+	"github.com/sourcenetwork/defradb/internal/identity"
 )
 
 func MakeCollectionGetCommand(ctx context.Context) *cobra.Command {

--- a/cli/collection_patch.go
+++ b/cli/collection_patch.go
@@ -20,8 +20,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client/options"
+	"github.com/sourcenetwork/defradb/internal/identity"
 	"github.com/sourcenetwork/immutable"
 	"github.com/sourcenetwork/lens/host-go/config/model"
 )

--- a/cli/collection_set_active.go
+++ b/cli/collection_set_active.go
@@ -15,8 +15,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client/options"
+	"github.com/sourcenetwork/defradb/internal/identity"
 )
 
 func MakeCollectionSetActiveCommand(ctx context.Context) *cobra.Command {

--- a/cli/collection_truncate.go
+++ b/cli/collection_truncate.go
@@ -15,8 +15,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client/options"
+	"github.com/sourcenetwork/defradb/internal/identity"
 )
 
 func MakeCollectionTruncateCommand(ctx context.Context) *cobra.Command {

--- a/cli/collection_update.go
+++ b/cli/collection_update.go
@@ -16,9 +16,9 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/options"
+	"github.com/sourcenetwork/defradb/internal/identity"
 )
 
 func MakeCollectionUpdateCommand(ctx context.Context) *cobra.Command {

--- a/cli/encrypted_index_create.go
+++ b/cli/encrypted_index_create.go
@@ -15,9 +15,9 @@ import (
 
 	"github.com/spf13/cobra"
 
-	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/options"
+	iIdentity "github.com/sourcenetwork/defradb/internal/identity"
 )
 
 func MakeEncryptedIndexCreateCommand(ctx context.Context) *cobra.Command {
@@ -40,13 +40,13 @@ Currently only "equality" type is supported.`,
 				FieldName: fieldArg,
 				Type:      client.EncryptedIndexType(typeArg),
 			}
-			opt := options.WithIdentity(options.GetCollectionByName(), acpIdentity.FromContext(cmd.Context()))
+			opt := options.WithIdentity(options.GetCollectionByName(), iIdentity.FromContext(cmd.Context()))
 			col, err := cliClient.GetCollectionByName(cmd.Context(), collectionArg, opt)
 			if err != nil {
 				return err
 			}
 
-			createOpt := options.WithIdentity(options.CreateEncryptedIndex(), acpIdentity.FromContext(cmd.Context()))
+			createOpt := options.WithIdentity(options.CreateEncryptedIndex(), iIdentity.FromContext(cmd.Context()))
 			descWithID, err := col.CreateEncryptedIndex(cmd.Context(), createReq, createOpt)
 			if err != nil {
 				return err

--- a/cli/index_create.go
+++ b/cli/index_create.go
@@ -16,9 +16,9 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/options"
+	"github.com/sourcenetwork/defradb/internal/identity"
 )
 
 func MakeIndexCreateCommand(ctx context.Context) *cobra.Command {

--- a/cli/index_drop.go
+++ b/cli/index_drop.go
@@ -15,8 +15,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client/options"
+	"github.com/sourcenetwork/defradb/internal/identity"
 )
 
 func MakeIndexDropCommand(ctx context.Context) *cobra.Command {

--- a/cli/index_list.go
+++ b/cli/index_list.go
@@ -15,8 +15,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client/options"
+	"github.com/sourcenetwork/defradb/internal/identity"
 )
 
 func MakeIndexListCommand(ctx context.Context) *cobra.Command {

--- a/cli/lens_add.go
+++ b/cli/lens_add.go
@@ -19,8 +19,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client/options"
+	"github.com/sourcenetwork/defradb/internal/identity"
 	"github.com/sourcenetwork/lens/host-go/config/model"
 )
 

--- a/cli/lens_list.go
+++ b/cli/lens_list.go
@@ -15,8 +15,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client/options"
+	"github.com/sourcenetwork/defradb/internal/identity"
 )
 
 func MakeLensListCommand(ctx context.Context) *cobra.Command {

--- a/cli/lens_set.go
+++ b/cli/lens_set.go
@@ -21,9 +21,9 @@ import (
 
 	"github.com/sourcenetwork/lens/host-go/config/model"
 
-	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/options"
+	iIdentity "github.com/sourcenetwork/defradb/internal/identity"
 )
 
 func MakeLensSetCommand(ctx context.Context) *cobra.Command {
@@ -76,7 +76,7 @@ Learn more about the DefraDB GraphQL Schema Language on https://docs.source.netw
 				Lens:                           lensCfg,
 			}
 
-			setOpt := options.WithIdentity(options.SetMigration(), acpIdentity.FromContext(cmd.Context()))
+			setOpt := options.WithIdentity(options.SetMigration(), iIdentity.FromContext(cmd.Context()))
 			lensID, err := cliClient.SetMigration(cmd.Context(), migrationCfg, setOpt)
 			if err != nil {
 				return err

--- a/cli/p2p_active_peers.go
+++ b/cli/p2p_active_peers.go
@@ -15,8 +15,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client/options"
+	"github.com/sourcenetwork/defradb/internal/identity"
 )
 
 func MakeP2PActivePeersCommand(ctx context.Context) *cobra.Command {

--- a/cli/p2p_collection_create.go
+++ b/cli/p2p_collection_create.go
@@ -16,8 +16,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client/options"
+	"github.com/sourcenetwork/defradb/internal/identity"
 )
 
 func MakeP2PCollectionCreateCommand(ctx context.Context) *cobra.Command {

--- a/cli/p2p_collection_delete.go
+++ b/cli/p2p_collection_delete.go
@@ -16,8 +16,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client/options"
+	"github.com/sourcenetwork/defradb/internal/identity"
 )
 
 func MakeP2PCollectionDeleteCommand(ctx context.Context) *cobra.Command {

--- a/cli/p2p_collection_list.go
+++ b/cli/p2p_collection_list.go
@@ -15,8 +15,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client/options"
+	"github.com/sourcenetwork/defradb/internal/identity"
 )
 
 func MakeP2PCollectionListCommand(ctx context.Context) *cobra.Command {

--- a/cli/p2p_collection_sync_branchable.go
+++ b/cli/p2p_collection_sync_branchable.go
@@ -15,8 +15,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client/options"
+	"github.com/sourcenetwork/defradb/internal/identity"
 )
 
 func MakeP2PCollectionSyncBranchableCommand(ctx context.Context) *cobra.Command {

--- a/cli/p2p_collection_sync_versions.go
+++ b/cli/p2p_collection_sync_versions.go
@@ -15,8 +15,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client/options"
+	"github.com/sourcenetwork/defradb/internal/identity"
 )
 
 func MakeP2PCollectionSyncVersionsCommand(ctx context.Context) *cobra.Command {

--- a/cli/p2p_connect.go
+++ b/cli/p2p_connect.go
@@ -15,8 +15,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client/options"
+	"github.com/sourcenetwork/defradb/internal/identity"
 )
 
 func MakeP2PConnectCommand(ctx context.Context) *cobra.Command {

--- a/cli/p2p_document_create.go
+++ b/cli/p2p_document_create.go
@@ -16,8 +16,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client/options"
+	"github.com/sourcenetwork/defradb/internal/identity"
 )
 
 func MakeP2PDocumentCreateCommand(ctx context.Context) *cobra.Command {

--- a/cli/p2p_document_delete.go
+++ b/cli/p2p_document_delete.go
@@ -16,8 +16,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client/options"
+	"github.com/sourcenetwork/defradb/internal/identity"
 )
 
 func MakeP2PDocumentDeleteCommand(ctx context.Context) *cobra.Command {

--- a/cli/p2p_document_list.go
+++ b/cli/p2p_document_list.go
@@ -15,8 +15,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client/options"
+	"github.com/sourcenetwork/defradb/internal/identity"
 )
 
 func MakeP2PDocumentListCommand(ctx context.Context) *cobra.Command {

--- a/cli/p2p_info.go
+++ b/cli/p2p_info.go
@@ -15,8 +15,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client/options"
+	"github.com/sourcenetwork/defradb/internal/identity"
 )
 
 func MakeP2PInfoCommand(ctx context.Context) *cobra.Command {

--- a/cli/p2p_replicator_create.go
+++ b/cli/p2p_replicator_create.go
@@ -15,8 +15,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client/options"
+	"github.com/sourcenetwork/defradb/internal/identity"
 )
 
 func MakeP2PReplicatorCreateCommand(ctx context.Context) *cobra.Command {

--- a/cli/p2p_replicator_delete.go
+++ b/cli/p2p_replicator_delete.go
@@ -15,8 +15,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client/options"
+	"github.com/sourcenetwork/defradb/internal/identity"
 )
 
 func MakeP2PReplicatorDeleteCommand(ctx context.Context) *cobra.Command {

--- a/cli/request.go
+++ b/cli/request.go
@@ -18,9 +18,9 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client/options"
 	"github.com/sourcenetwork/defradb/errors"
+	"github.com/sourcenetwork/defradb/internal/identity"
 )
 
 const (

--- a/cli/schema_add.go
+++ b/cli/schema_add.go
@@ -17,8 +17,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client/options"
+	"github.com/sourcenetwork/defradb/internal/identity"
 )
 
 func MakeSchemaAddCommand(ctx context.Context) *cobra.Command {

--- a/cli/utils.go
+++ b/cli/utils.go
@@ -31,6 +31,7 @@ import (
 	"github.com/sourcenetwork/defradb/crypto"
 	"github.com/sourcenetwork/defradb/http"
 	"github.com/sourcenetwork/defradb/internal/datastore"
+	iIdentity "github.com/sourcenetwork/defradb/internal/identity"
 	"github.com/sourcenetwork/defradb/keyring"
 	"github.com/sourcenetwork/defradb/node"
 )
@@ -161,7 +162,7 @@ func setContextIdentity(cmd *cobra.Command, privateKeyHex string) error {
 		return err
 	}
 
-	ctx := acpIdentity.WithContext(cmd.Context(), immutable.Some[acpIdentity.Identity](ident))
+	ctx := iIdentity.WithContext(cmd.Context(), immutable.Some[acpIdentity.Identity](ident))
 	cmd.SetContext(ctx)
 	return nil
 }

--- a/cli/view_add.go
+++ b/cli/view_add.go
@@ -16,8 +16,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client/options"
+	"github.com/sourcenetwork/defradb/internal/identity"
 )
 
 func MakeViewAddCommand(ctx context.Context) *cobra.Command {

--- a/cli/view_refresh.go
+++ b/cli/view_refresh.go
@@ -15,8 +15,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client/options"
+	"github.com/sourcenetwork/defradb/internal/identity"
 )
 
 func MakeViewRefreshCommand(ctx context.Context) *cobra.Command {

--- a/http/auth.go
+++ b/http/auth.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sourcenetwork/immutable"
 
 	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
+	iIdentity "github.com/sourcenetwork/defradb/internal/identity"
 )
 
 const (
@@ -49,7 +50,7 @@ func AuthMiddleware(next http.Handler) http.Handler {
 			return
 		}
 
-		ctx := acpIdentity.WithContext(req.Context(), immutable.Some[acpIdentity.Identity](ident))
+		ctx := iIdentity.WithContext(req.Context(), immutable.Some[acpIdentity.Identity](ident))
 		next.ServeHTTP(rw, req.WithContext(ctx))
 	})
 }

--- a/http/client.go
+++ b/http/client.go
@@ -28,10 +28,11 @@ import (
 
 	"github.com/sourcenetwork/immutable"
 
-	"github.com/sourcenetwork/defradb/acp/identity"
+	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/options"
 	"github.com/sourcenetwork/defradb/crypto"
+	"github.com/sourcenetwork/defradb/internal/identity"
 	"github.com/sourcenetwork/graphql-go/language/ast"
 	"github.com/sourcenetwork/graphql-go/language/parser"
 	"github.com/sourcenetwork/graphql-go/language/source"
@@ -573,16 +574,16 @@ func (c *Client) HealthCheck(ctx context.Context) error {
 	return err
 }
 
-func (c *Client) GetNodeIdentity(ctx context.Context) (immutable.Option[identity.PublicRawIdentity], error) {
+func (c *Client) GetNodeIdentity(ctx context.Context) (immutable.Option[acpIdentity.PublicRawIdentity], error) {
 	methodURL := c.http.apiURL.JoinPath("node", "identity")
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, methodURL.String(), nil)
 	if err != nil {
-		return immutable.None[identity.PublicRawIdentity](), err
+		return immutable.None[acpIdentity.PublicRawIdentity](), err
 	}
-	var ident immutable.Option[identity.PublicRawIdentity]
+	var ident immutable.Option[acpIdentity.PublicRawIdentity]
 	if err := c.http.requestJson(req, &ident); err != nil {
-		return immutable.None[identity.PublicRawIdentity](), err
+		return immutable.None[acpIdentity.PublicRawIdentity](), err
 	}
 	return ident, err
 }

--- a/http/client_acp.go
+++ b/http/client_acp.go
@@ -17,9 +17,9 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/options"
+	"github.com/sourcenetwork/defradb/internal/identity"
 	"github.com/sourcenetwork/defradb/internal/utils"
 )
 

--- a/http/client_collection.go
+++ b/http/client_collection.go
@@ -20,10 +20,10 @@ import (
 
 	sse "github.com/vito/go-sse/sse"
 
-	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/options"
 	"github.com/sourcenetwork/defradb/errors"
+	"github.com/sourcenetwork/defradb/internal/identity"
 	"github.com/sourcenetwork/defradb/internal/utils"
 )
 

--- a/http/client_p2p.go
+++ b/http/client_p2p.go
@@ -17,9 +17,9 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/options"
+	"github.com/sourcenetwork/defradb/internal/identity"
 	"github.com/sourcenetwork/defradb/internal/utils"
 )
 

--- a/http/handler_acp.go
+++ b/http/handler_acp.go
@@ -16,8 +16,8 @@ import (
 
 	"github.com/getkin/kin-openapi/openapi3"
 
-	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client/options"
+	"github.com/sourcenetwork/defradb/internal/identity"
 )
 
 type acpHandler struct{}

--- a/http/handler_block.go
+++ b/http/handler_block.go
@@ -15,9 +15,9 @@ import (
 
 	"github.com/getkin/kin-openapi/openapi3"
 
-	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client/options"
 	"github.com/sourcenetwork/defradb/crypto"
+	"github.com/sourcenetwork/defradb/internal/identity"
 )
 
 const (

--- a/http/handler_collection.go
+++ b/http/handler_collection.go
@@ -21,10 +21,10 @@ import (
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/go-chi/chi/v5"
 
-	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/options"
 	"github.com/sourcenetwork/defradb/internal/encryption"
+	"github.com/sourcenetwork/defradb/internal/identity"
 )
 
 const docEncryptParam = "encrypt"

--- a/http/handler_p2p.go
+++ b/http/handler_p2p.go
@@ -17,8 +17,8 @@ import (
 
 	"github.com/getkin/kin-openapi/openapi3"
 
-	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client/options"
+	"github.com/sourcenetwork/defradb/internal/identity"
 )
 
 type p2pHandler struct{}

--- a/http/handler_store.go
+++ b/http/handler_store.go
@@ -21,9 +21,9 @@ import (
 
 	"github.com/sourcenetwork/lens/host-go/config/model"
 
-	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/options"
+	"github.com/sourcenetwork/defradb/internal/identity"
 )
 
 const (

--- a/http/http_client.go
+++ b/http/http_client.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/internal/datastore"
+	iIdentity "github.com/sourcenetwork/defradb/internal/identity"
 )
 
 type httpClient struct {
@@ -51,7 +52,7 @@ func (c *httpClient) setDefaultHeaders(req *http.Request) error {
 	if ok {
 		req.Header.Set(txHeaderName, fmt.Sprintf("%d", txn.ID()))
 	}
-	id := identity.FromContext(req.Context())
+	id := iIdentity.FromContext(req.Context())
 	if !id.HasValue() {
 		return nil
 	}

--- a/http/middleware.go
+++ b/http/middleware.go
@@ -22,11 +22,11 @@ import (
 	"github.com/go-chi/cors"
 	"golang.org/x/exp/slices"
 
-	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/options"
 	"github.com/sourcenetwork/defradb/errors"
 	"github.com/sourcenetwork/defradb/internal/db"
+	"github.com/sourcenetwork/defradb/internal/identity"
 )
 
 // CorsMiddleware handles cross origin request

--- a/internal/core/block/signing.go
+++ b/internal/core/block/signing.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/crypto"
 	"github.com/sourcenetwork/defradb/internal/datastore"
+	iIdentity "github.com/sourcenetwork/defradb/internal/identity"
 	"github.com/sourcenetwork/immutable"
 )
 
@@ -37,7 +38,7 @@ func EnabledSigningFromContext(ctx context.Context) (bool, immutable.Option[iden
 }
 
 func extractFullIdentity(ctx context.Context) immutable.Option[identity.FullIdentity] {
-	ident := identity.FromContext(ctx)
+	ident := iIdentity.FromContext(ctx)
 	if !ident.HasValue() {
 		return immutable.None[identity.FullIdentity]()
 	}

--- a/internal/db/backup_test.go
+++ b/internal/db/backup_test.go
@@ -18,8 +18,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/sourcenetwork/defradb/acp/identity"
+	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
+	"github.com/sourcenetwork/defradb/internal/identity"
 )
 
 func TestBasicExport_WithNormalFormatting_NoError(t *testing.T) {
@@ -66,7 +67,7 @@ func TestBasicExport_WithNormalFormatting_NoError(t *testing.T) {
 	require.NoError(t, err)
 	defer txn.Discard()
 
-	ctx = identity.WithContext(ctx, identity.None)
+	ctx = identity.WithContext(ctx, acpIdentity.None)
 	ctx = InitContext(ctx, txn)
 
 	filepath := t.TempDir() + "/test.json"
@@ -157,7 +158,7 @@ func TestBasicExport_WithPrettyFormatting_NoError(t *testing.T) {
 	require.NoError(t, err)
 	defer txn.Discard()
 
-	ctx = identity.WithContext(ctx, identity.None)
+	ctx = identity.WithContext(ctx, acpIdentity.None)
 	ctx = InitContext(ctx, txn)
 
 	filepath := t.TempDir() + "/test.json"
@@ -248,7 +249,7 @@ func TestBasicExport_WithSingleCollection_NoError(t *testing.T) {
 	require.NoError(t, err)
 	defer txn.Discard()
 
-	ctx = identity.WithContext(ctx, identity.None)
+	ctx = identity.WithContext(ctx, acpIdentity.None)
 	ctx = InitContext(ctx, txn)
 
 	filepath := t.TempDir() + "/test.json"
@@ -335,7 +336,7 @@ func TestBasicExport_WithMultipleCollectionsAndUpdate_NoError(t *testing.T) {
 	require.NoError(t, err)
 	defer txn.Discard()
 
-	ctx = identity.WithContext(ctx, identity.None)
+	ctx = identity.WithContext(ctx, acpIdentity.None)
 	ctx = InitContext(ctx, txn)
 
 	filepath := t.TempDir() + "/test.json"
@@ -427,7 +428,7 @@ func TestBasicExport_EnsureFileOverwrite_NoError(t *testing.T) {
 	require.NoError(t, err)
 	defer txn.Discard()
 
-	ctx = identity.WithContext(ctx, identity.None)
+	ctx = identity.WithContext(ctx, acpIdentity.None)
 	ctx = InitContext(ctx, txn)
 
 	filepath := t.TempDir() + "/test.json"
@@ -502,7 +503,7 @@ func TestBasicImport_WithMultipleCollectionsAndObjects_NoError(t *testing.T) {
 	txn, err := db.NewTxn(false)
 	require.NoError(t, err)
 
-	ctx = identity.WithContext(ctx, identity.None)
+	ctx = identity.WithContext(ctx, acpIdentity.None)
 	ctx = InitContext(ctx, txn)
 
 	filepath := t.TempDir() + "/test.json"
@@ -520,7 +521,7 @@ func TestBasicImport_WithMultipleCollectionsAndObjects_NoError(t *testing.T) {
 	txn, err = db.NewTxn(true)
 	require.NoError(t, err)
 
-	ctx = identity.WithContext(ctx, identity.None)
+	ctx = identity.WithContext(ctx, acpIdentity.None)
 	ctx = InitContext(ctx, txn)
 
 	col1, err = db.getCollectionByName(ctx, "Address")

--- a/internal/db/collection.go
+++ b/internal/db/collection.go
@@ -33,6 +33,7 @@ import (
 	"github.com/sourcenetwork/defradb/internal/db/fetcher"
 	"github.com/sourcenetwork/defradb/internal/db/id"
 	"github.com/sourcenetwork/defradb/internal/encryption"
+	iIdentity "github.com/sourcenetwork/defradb/internal/identity"
 	"github.com/sourcenetwork/defradb/internal/keys"
 	"github.com/sourcenetwork/defradb/internal/lens"
 	"github.com/sourcenetwork/defradb/internal/utils"
@@ -220,7 +221,7 @@ func (c *collection) GetAllDocIDs(
 		return nil, err
 	}
 
-	ctx = identity.WithContext(ctx, opt.Identity)
+	ctx = iIdentity.WithContext(ctx, opt.Identity)
 
 	return c.getAllDocIDsChan(ctx)
 }
@@ -348,7 +349,7 @@ func (c *collection) Create(
 		return err
 	}
 
-	ctx = identity.WithContext(ctx, opt.Identity)
+	ctx = iIdentity.WithContext(ctx, opt.Identity)
 
 	ctx, txn, err := ensureContextTxn(ctx, c.db, false)
 	if err != nil {
@@ -380,7 +381,7 @@ func (c *collection) CreateMany(
 		return err
 	}
 
-	ctx = identity.WithContext(ctx, opt.Identity)
+	ctx = iIdentity.WithContext(ctx, opt.Identity)
 
 	ctx, txn, err := ensureContextTxn(ctx, c.db, false)
 	if err != nil {
@@ -510,7 +511,7 @@ func (c *collection) Update(
 		return err
 	}
 
-	ctx = identity.WithContext(ctx, opt.Identity)
+	ctx = iIdentity.WithContext(ctx, opt.Identity)
 
 	ctx, txn, err := ensureContextTxn(ctx, c.db, false)
 	if err != nil {
@@ -592,7 +593,7 @@ func (c *collection) Save(
 		return err
 	}
 
-	ctx = identity.WithContext(ctx, opt.Identity)
+	ctx = iIdentity.WithContext(ctx, opt.Identity)
 
 	ctx, txn, err := ensureContextTxn(ctx, c.db, false)
 	if err != nil {
@@ -676,9 +677,9 @@ func (c *collection) save(
 	}
 	txn := datastore.CtxMustGetTxn(ctx)
 
-	ident := identity.FromContext(ctx)
+	ident := iIdentity.FromContext(ctx)
 	if (!ident.HasValue() || !hasPrivateKey(ident.Value())) && c.db.nodeIdentity.HasValue() {
-		ctx = identity.WithContext(ctx, c.db.nodeIdentity)
+		ctx = iIdentity.WithContext(ctx, c.db.nodeIdentity)
 	}
 
 	if !c.db.signingDisabled {
@@ -840,7 +841,7 @@ func (c *collection) Delete(
 		return false, err
 	}
 
-	ctx = identity.WithContext(ctx, opt.Identity)
+	ctx = iIdentity.WithContext(ctx, opt.Identity)
 
 	ctx, txn, err := ensureContextTxn(ctx, c.db, false)
 	if err != nil {
@@ -880,7 +881,7 @@ func (c *collection) Exists(
 		return false, err
 	}
 
-	ctx = identity.WithContext(ctx, opt.Identity)
+	ctx = iIdentity.WithContext(ctx, opt.Identity)
 
 	ctx, txn, err := ensureContextTxn(ctx, c.db, false)
 	if err != nil {

--- a/internal/db/collection_acp.go
+++ b/internal/db/collection_acp.go
@@ -13,9 +13,9 @@ package db
 import (
 	"context"
 
-	"github.com/sourcenetwork/defradb/acp/identity"
 	acpTypes "github.com/sourcenetwork/defradb/acp/types"
 	acpDB "github.com/sourcenetwork/defradb/internal/db/acp"
+	"github.com/sourcenetwork/defradb/internal/identity"
 )
 
 // registerDocWithACP handles the registration of the document with acp.

--- a/internal/db/collection_delete.go
+++ b/internal/db/collection_delete.go
@@ -13,7 +13,6 @@ package db
 import (
 	"context"
 
-	"github.com/sourcenetwork/defradb/acp/identity"
 	acpTypes "github.com/sourcenetwork/defradb/acp/types"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/options"
@@ -23,6 +22,7 @@ import (
 	"github.com/sourcenetwork/defradb/internal/core/crdt"
 	"github.com/sourcenetwork/defradb/internal/datastore"
 	"github.com/sourcenetwork/defradb/internal/db/id"
+	"github.com/sourcenetwork/defradb/internal/identity"
 	"github.com/sourcenetwork/defradb/internal/keys"
 	"github.com/sourcenetwork/defradb/internal/utils"
 )

--- a/internal/db/collection_get.go
+++ b/internal/db/collection_get.go
@@ -15,13 +15,13 @@ import (
 
 	"github.com/sourcenetwork/immutable"
 
-	"github.com/sourcenetwork/defradb/acp/identity"
 	acpTypes "github.com/sourcenetwork/defradb/acp/types"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/options"
 	"github.com/sourcenetwork/defradb/internal/datastore"
 	"github.com/sourcenetwork/defradb/internal/db/fetcher"
 	"github.com/sourcenetwork/defradb/internal/db/id"
+	"github.com/sourcenetwork/defradb/internal/identity"
 	"github.com/sourcenetwork/defradb/internal/keys"
 	"github.com/sourcenetwork/defradb/internal/utils"
 )

--- a/internal/db/collection_index.go
+++ b/internal/db/collection_index.go
@@ -19,7 +19,6 @@ import (
 
 	"slices"
 
-	"github.com/sourcenetwork/defradb/acp/identity"
 	acpTypes "github.com/sourcenetwork/defradb/acp/types"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/options"
@@ -30,6 +29,7 @@ import (
 	"github.com/sourcenetwork/defradb/internal/db/fetcher"
 	"github.com/sourcenetwork/defradb/internal/db/id"
 	"github.com/sourcenetwork/defradb/internal/db/sequence"
+	"github.com/sourcenetwork/defradb/internal/identity"
 	"github.com/sourcenetwork/defradb/internal/keys"
 	"github.com/sourcenetwork/defradb/internal/request/graphql/schema"
 	"github.com/sourcenetwork/defradb/internal/utils"

--- a/internal/db/collection_update.go
+++ b/internal/db/collection_update.go
@@ -17,11 +17,11 @@ import (
 
 	"github.com/sourcenetwork/immutable"
 
-	"github.com/sourcenetwork/defradb/acp/identity"
 	acpTypes "github.com/sourcenetwork/defradb/acp/types"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/options"
 	"github.com/sourcenetwork/defradb/client/request"
+	"github.com/sourcenetwork/defradb/internal/identity"
 	"github.com/sourcenetwork/defradb/internal/planner"
 	"github.com/sourcenetwork/defradb/internal/utils"
 )

--- a/internal/db/db_nac.go
+++ b/internal/db/db_nac.go
@@ -26,6 +26,7 @@ import (
 	"github.com/sourcenetwork/defradb/errors"
 	"github.com/sourcenetwork/defradb/internal/datastore"
 	acpDB "github.com/sourcenetwork/defradb/internal/db/acp"
+	iIdentity "github.com/sourcenetwork/defradb/internal/identity"
 	"github.com/sourcenetwork/defradb/internal/keys"
 	"github.com/sourcenetwork/defradb/internal/utils"
 )
@@ -157,7 +158,7 @@ func (db *DB) AddNACActorRelationship(
 		return client.AddActorRelationshipResult{}, err
 	}
 
-	ctx = acpIdentity.WithContext(ctx, opt.Identity)
+	ctx = iIdentity.WithContext(ctx, opt.Identity)
 
 	return db.addNACActorRelationship(ctx, relation, targetActor)
 }
@@ -177,7 +178,7 @@ func (db *DB) DeleteNACActorRelationship(
 		return client.DeleteActorRelationshipResult{}, err
 	}
 
-	ctx = acpIdentity.WithContext(ctx, opt.Identity)
+	ctx = iIdentity.WithContext(ctx, opt.Identity)
 
 	return db.deleteNACActorRelationship(ctx, relation, targetActor)
 }
@@ -203,7 +204,7 @@ func (db *DB) addNACActorRelationship(
 		return client.AddActorRelationshipResult{}, client.ErrNACIsEnabledButIsMissingPolicyInfo
 	}
 
-	requestActor := acpIdentity.FromContext(ctx)
+	requestActor := iIdentity.FromContext(ctx)
 	if !requestActor.HasValue() || requestActor.Value() == nil || requestActor.Value().DID() == "" {
 		return client.AddActorRelationshipResult{}, ErrNACRelationshipOperationRequiresIdentity
 	}
@@ -246,7 +247,7 @@ func (db *DB) deleteNACActorRelationship(
 		return client.DeleteActorRelationshipResult{}, client.ErrNACIsEnabledButIsMissingPolicyInfo
 	}
 
-	requestActor := acpIdentity.FromContext(ctx)
+	requestActor := iIdentity.FromContext(ctx)
 	if !requestActor.HasValue() || requestActor.Value() == nil || requestActor.Value().DID() == "" {
 		return client.DeleteActorRelationshipResult{}, ErrNACRelationshipOperationRequiresIdentity
 	}
@@ -324,7 +325,7 @@ func (db *DB) initializeNodeACP(ctx context.Context, txn datastore.Txn) error {
 		return err
 	}
 
-	iden := acpIdentity.FromContext(ctx)
+	iden := iIdentity.FromContext(ctx)
 	hasIdentity := iden.HasValue()
 
 	// Was never setup before so start from scratch only if enabled in starting config and has identity.
@@ -456,7 +457,7 @@ func (db *DB) saveNodeACPDesc(ctx context.Context) error {
 // Note:
 // - This function should only be called when starting node acp from a clean state.
 func (db *DB) tryRegisterNACPolicy(ctx context.Context) error {
-	iden := acpIdentity.FromContext(ctx)
+	iden := iIdentity.FromContext(ctx)
 	if !iden.HasValue() {
 		return ErrNoIdentityInContext
 	}

--- a/internal/db/p2p.go
+++ b/internal/db/p2p.go
@@ -13,11 +13,11 @@ package db
 import (
 	"context"
 
-	"github.com/sourcenetwork/defradb/acp/identity"
 	acpTypes "github.com/sourcenetwork/defradb/acp/types"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/options"
 	"github.com/sourcenetwork/defradb/event"
+	"github.com/sourcenetwork/defradb/internal/identity"
 	"github.com/sourcenetwork/defradb/internal/utils"
 )
 

--- a/internal/db/p2p/collection.go
+++ b/internal/db/p2p/collection.go
@@ -15,11 +15,11 @@ import (
 
 	"github.com/sourcenetwork/corekv"
 
-	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/options"
 	"github.com/sourcenetwork/defradb/errors"
 	"github.com/sourcenetwork/defradb/internal/datastore"
+	"github.com/sourcenetwork/defradb/internal/identity"
 	"github.com/sourcenetwork/defradb/internal/keys"
 )
 

--- a/internal/db/p2p/replicator.go
+++ b/internal/db/p2p/replicator.go
@@ -26,7 +26,6 @@ import (
 	"github.com/sourcenetwork/corekv/blockstore"
 	"github.com/sourcenetwork/corelog"
 
-	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/options"
 	"github.com/sourcenetwork/defradb/errors"
@@ -36,6 +35,7 @@ import (
 	"github.com/sourcenetwork/defradb/internal/datastore"
 	"github.com/sourcenetwork/defradb/internal/db/id"
 	"github.com/sourcenetwork/defradb/internal/db/p2p/protocol"
+	"github.com/sourcenetwork/defradb/internal/identity"
 	"github.com/sourcenetwork/defradb/internal/keys"
 )
 

--- a/internal/db/request.go
+++ b/internal/db/request.go
@@ -13,8 +13,8 @@ package db
 import (
 	"context"
 
-	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
+	"github.com/sourcenetwork/defradb/internal/identity"
 	"github.com/sourcenetwork/defradb/internal/planner"
 )
 

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -17,10 +17,10 @@ import (
 
 	"github.com/sourcenetwork/immutable"
 
-	"github.com/sourcenetwork/defradb/acp/identity"
 	acpTypes "github.com/sourcenetwork/defradb/acp/types"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/options"
+	"github.com/sourcenetwork/defradb/internal/identity"
 	"github.com/sourcenetwork/defradb/internal/utils"
 )
 

--- a/internal/db/subscriptions.go
+++ b/internal/db/subscriptions.go
@@ -13,11 +13,11 @@ package db
 import (
 	"context"
 
-	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/request"
 	"github.com/sourcenetwork/defradb/errors"
 	"github.com/sourcenetwork/defradb/event"
+	"github.com/sourcenetwork/defradb/internal/identity"
 	"github.com/sourcenetwork/defradb/internal/planner"
 )
 

--- a/internal/db/view.go
+++ b/internal/db/view.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/sourcenetwork/immutable"
 
-	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/options"
 	"github.com/sourcenetwork/defradb/client/request"
@@ -27,6 +26,7 @@ import (
 	"github.com/sourcenetwork/defradb/internal/datastore"
 	"github.com/sourcenetwork/defradb/internal/db/description"
 	"github.com/sourcenetwork/defradb/internal/db/id"
+	"github.com/sourcenetwork/defradb/internal/identity"
 	"github.com/sourcenetwork/defradb/internal/keys"
 	"github.com/sourcenetwork/defradb/internal/planner"
 	"github.com/sourcenetwork/defradb/internal/utils"

--- a/internal/identity/context.go
+++ b/internal/identity/context.go
@@ -13,6 +13,7 @@ package identity
 import (
 	"context"
 
+	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/immutable"
 )
 
@@ -22,18 +23,18 @@ type identityContextKey struct{}
 // FromContext returns the identity from the given context.
 //
 // If an identity does not exist `NoIdentity` is returned.
-func FromContext(ctx context.Context) immutable.Option[Identity] {
-	identity, ok := ctx.Value(identityContextKey{}).(Identity)
+func FromContext(ctx context.Context) immutable.Option[acpIdentity.Identity] {
+	identity, ok := ctx.Value(identityContextKey{}).(acpIdentity.Identity)
 	if ok {
 		return immutable.Some(identity)
 	}
-	return None
+	return acpIdentity.None
 }
 
 // WithContext returns a new context with the identity value set.
 //
 // This will overwrite any previously set identity value.
-func WithContext(ctx context.Context, identity immutable.Option[Identity]) context.Context {
+func WithContext(ctx context.Context, identity immutable.Option[acpIdentity.Identity]) context.Context {
 	if identity.HasValue() {
 		return context.WithValue(ctx, identityContextKey{}, identity.Value())
 	}
@@ -41,10 +42,10 @@ func WithContext(ctx context.Context, identity immutable.Option[Identity]) conte
 }
 
 // FullFromContext returns the FullIdentity from the given context.
-func FullFromContext(ctx context.Context) immutable.Option[FullIdentity] {
-	identity, ok := ctx.Value(identityContextKey{}).(FullIdentity)
+func FullFromContext(ctx context.Context) immutable.Option[acpIdentity.FullIdentity] {
+	identity, ok := ctx.Value(identityContextKey{}).(acpIdentity.FullIdentity)
 	if ok {
 		return immutable.Some(identity)
 	}
-	return immutable.None[FullIdentity]()
+	return immutable.None[acpIdentity.FullIdentity]()
 }

--- a/internal/planner/mapper/mapper.go
+++ b/internal/planner/mapper/mapper.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/sourcenetwork/immutable"
 
-	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/options"
 	"github.com/sourcenetwork/defradb/client/request"
@@ -25,6 +24,7 @@ import (
 	"github.com/sourcenetwork/defradb/internal/core"
 	"github.com/sourcenetwork/defradb/internal/db/description"
 	"github.com/sourcenetwork/defradb/internal/db/id"
+	iIdentity "github.com/sourcenetwork/defradb/internal/identity"
 )
 
 const (
@@ -981,7 +981,7 @@ func getTopLevelInfo(
 		collection, err := store.GetCollectionByName(
 			ctx,
 			collectionName,
-			options.WithIdentity(options.GetCollectionByName(), acpIdentity.FromContext(ctx)),
+			options.WithIdentity(options.GetCollectionByName(), iIdentity.FromContext(ctx)),
 		)
 		if err != nil {
 			return nil, client.CollectionVersion{}, err

--- a/internal/se/coordinator.go
+++ b/internal/se/coordinator.go
@@ -27,6 +27,7 @@ import (
 	coreblock "github.com/sourcenetwork/defradb/internal/core/block"
 	"github.com/sourcenetwork/defradb/internal/datastore"
 	"github.com/sourcenetwork/defradb/internal/db/p2p/protocol"
+	iIdentity "github.com/sourcenetwork/defradb/internal/identity"
 	"github.com/sourcenetwork/defradb/internal/keys"
 	secore "github.com/sourcenetwork/defradb/internal/se/core"
 )
@@ -332,7 +333,7 @@ func (coordinator *Coordinator) generateSEArtifacts(
 	}
 
 	if coordinator.nodeIdentity.HasValue() {
-		ctx = acpIdentity.WithContext(ctx, coordinator.nodeIdentity)
+		ctx = iIdentity.WithContext(ctx, coordinator.nodeIdentity)
 	}
 
 	getOpt := options.WithIdentity(options.CollectionGet(), coordinator.nodeIdentity)

--- a/js/utils.go
+++ b/js/utils.go
@@ -24,11 +24,11 @@ import (
 	"github.com/sourcenetwork/goji"
 	"github.com/sourcenetwork/immutable"
 
-	"github.com/sourcenetwork/defradb/acp/identity"
 	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/crypto"
 	"github.com/sourcenetwork/defradb/internal/db"
+	iIdentity "github.com/sourcenetwork/defradb/internal/identity"
 )
 
 func stringArg(args []js.Value, index int, name string) (string, error) {
@@ -81,7 +81,7 @@ func contextArg(args []js.Value, index int, txns *sync.Map) (context.Context, er
 	if err != nil {
 		return ctx, err
 	}
-	ctx = acpIdentity.WithContext(ctx, identity)
+	ctx = iIdentity.WithContext(ctx, identity)
 	ctx = db.InitContext(ctx, txn)
 	return ctx, nil
 }
@@ -142,9 +142,8 @@ func setOptIdentity[B any](opt B, args []js.Value, argIndex int) {
 	}
 }
 
-
 // initKeypairAndGetIdentity initializes the keypair and gets an identity.
-func initKeypairAndGetIdentity() (identity.Identity, error) {
+func initKeypairAndGetIdentity() (acpIdentity.Identity, error) {
 	createKeyPairFunc := js.Global().Get("initKeypair")
 	if !createKeyPairFunc.Truthy() {
 		return nil, fmt.Errorf("initKeypair function not found")
@@ -160,7 +159,7 @@ func initKeypairAndGetIdentity() (identity.Identity, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create public key from hex: %w", err)
 	}
-	ident, err := identity.FromPublicKey(publicKey)
+	ident, err := acpIdentity.FromPublicKey(publicKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create identity from public key: %w", err)
 	}

--- a/tests/clients/js/wrapper.go
+++ b/tests/clients/js/wrapper.go
@@ -20,11 +20,12 @@ import (
 	"github.com/sourcenetwork/immutable"
 	"github.com/sourcenetwork/lens/host-go/config/model"
 
-	"github.com/sourcenetwork/defradb/acp/identity"
+	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/options"
 	"github.com/sourcenetwork/defradb/crypto"
 	"github.com/sourcenetwork/defradb/event"
+	iIdentity "github.com/sourcenetwork/defradb/internal/identity"
 	"github.com/sourcenetwork/defradb/internal/utils"
 	"github.com/sourcenetwork/defradb/js"
 	"github.com/sourcenetwork/defradb/node"
@@ -32,7 +33,7 @@ import (
 
 // identityProvider is any options struct that has a GetIdentity method.
 type identityProvider interface {
-	GetIdentity() immutable.Option[identity.Identity]
+	GetIdentity() immutable.Option[acpIdentity.Identity]
 }
 
 // ctxWithOptIdentity extracts identity from opts and puts it in context,
@@ -45,7 +46,7 @@ func ctxWithOptIdentity(ctx context.Context, opt identityProvider) context.Conte
 	}
 	ident := opt.GetIdentity()
 	if ident.HasValue() {
-		return identity.WithContext(ctx, ident)
+		return iIdentity.WithContext(ctx, ident)
 	}
 	return ctx
 }
@@ -599,14 +600,14 @@ func (w *Wrapper) Connect(ctx context.Context, addresses []string, opts ...optio
 	return w.node.DB.Connect(ctx, addresses, opts...)
 }
 
-func (w *Wrapper) GetNodeIdentity(ctx context.Context) (immutable.Option[identity.PublicRawIdentity], error) {
+func (w *Wrapper) GetNodeIdentity(ctx context.Context) (immutable.Option[acpIdentity.PublicRawIdentity], error) {
 	res, err := execute(ctx, w.value, "getNodeIdentity")
 	if err != nil {
-		return immutable.None[identity.PublicRawIdentity](), err
+		return immutable.None[acpIdentity.PublicRawIdentity](), err
 	}
-	var out immutable.Option[identity.PublicRawIdentity]
+	var out immutable.Option[acpIdentity.PublicRawIdentity]
 	if err := goji.UnmarshalJS(res[0], &out); err != nil {
-		return immutable.None[identity.PublicRawIdentity](), err
+		return immutable.None[acpIdentity.PublicRawIdentity](), err
 	}
 	return out, nil
 }

--- a/tests/clients/js/wrapper_js.go
+++ b/tests/clients/js/wrapper_js.go
@@ -18,8 +18,9 @@ import (
 
 	"github.com/sourcenetwork/goji"
 
-	"github.com/sourcenetwork/defradb/acp/identity"
+	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/internal/datastore"
+	iIdentity "github.com/sourcenetwork/defradb/internal/identity"
 )
 
 func execute(ctx context.Context, value js.Value, method string, args ...any) ([]js.Value, error) {
@@ -28,9 +29,9 @@ func execute(ctx context.Context, value js.Value, method string, args ...any) ([
 	if ok {
 		contextValues["transaction"] = tx.ID()
 	}
-	ident := identity.FromContext(ctx)
+	ident := iIdentity.FromContext(ctx)
 	if ident.HasValue() {
-		if full, ok := ident.Value().(identity.FullIdentity); ok && full.PrivateKey() != nil {
+		if full, ok := ident.Value().(acpIdentity.FullIdentity); ok && full.PrivateKey() != nil {
 			contextValues["full_identity"] = full.PrivateKey().String()
 		}
 	}

--- a/tests/integration/db_setup.go
+++ b/tests/integration/db_setup.go
@@ -24,6 +24,7 @@ import (
 	"github.com/sourcenetwork/defradb/client/options"
 	"github.com/sourcenetwork/defradb/crypto"
 	"github.com/sourcenetwork/defradb/errors"
+	iIdentity "github.com/sourcenetwork/defradb/internal/identity"
 	"github.com/sourcenetwork/defradb/internal/kms"
 	"github.com/sourcenetwork/defradb/node"
 	changeDetector "github.com/sourcenetwork/defradb/tests/change_detector"
@@ -138,7 +139,7 @@ func setupNode(
 		return nil, err
 	}
 
-	ctx := acpIdentity.WithContext(s.Ctx, identity)
+	ctx := iIdentity.WithContext(s.Ctx, identity)
 	err = nodeObj.Start(ctx)
 
 	if err != nil {

--- a/tests/integration/db_setup_js.go
+++ b/tests/integration/db_setup_js.go
@@ -17,6 +17,7 @@ import (
 
 	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client/options"
+	iIdentity "github.com/sourcenetwork/defradb/internal/identity"
 	"github.com/sourcenetwork/defradb/node"
 	"github.com/sourcenetwork/defradb/tests/state"
 )
@@ -64,7 +65,7 @@ func setupNode(
 	if err != nil {
 		return nil, err
 	}
-	ctx := acpIdentity.WithContext(s.Ctx, identity)
+	ctx := iIdentity.WithContext(s.Ctx, identity)
 	err = nodeObj.Start(ctx)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4548

## Description

Moves the identity context funcs to internal.

Nothing really coded here, just moved the file from `/acp/identity` to `/internal/identity`.  Most locations that import both import  the internal dependency as `iIdentity "github.com/sourcenetwork/defradb/internal/identity"`, a handful omit the alias (in keeping with whatever it was doing before, most places aliased `/acp/identity` to `acpIdentity` to avoid local variable naming collisions.