### PR TITLE
refactor: Rename CreateEncryptedIndex

### DIFF
--- a/acp/types/types.go
+++ b/acp/types/types.go
@@ -97,7 +97,7 @@ const (
 	NodeIndexListPerm
 	NodeIndexCreatePerm
 	NodeIndexDropPerm
-	NodeEncryptedIndexCreatePerm
+	NodeEncryptedIndexAddPerm
 	NodeP2PPeerInfo
 	NodeP2PPeerConnectPerm
 	NodeP2PPeerActivePerm
@@ -147,7 +147,7 @@ var RequiredResourcePermissionsForNode = []string{
 	"index-list",
 	"index-create",
 	"index-drop",
-	"encrypted-index-create",
+	"encrypted-index-add",
 	"p2p-peer-info",
 	"p2p-peer-connect",
 	"p2p-peer-active",
@@ -231,7 +231,7 @@ resources:
   - name: index-drop
     expr: admin
 
-  - name: encrypted-index-create
+  - name: encrypted-index-add
     expr: admin
 
   - name: p2p-peer-info

--- a/cbindings/encrypted_index.go
+++ b/cbindings/encrypted_index.go
@@ -24,8 +24,8 @@ import (
 	iIdentity "github.com/sourcenetwork/defradb/internal/identity"
 )
 
-//export EncryptedIndexCreate
-func EncryptedIndexCreate(
+//export EncryptedIndexAdd
+func EncryptedIndexAdd(
 	nodePtr C.uintptr_t,
 	collectionName *C.char,
 	fieldName *C.char,
@@ -51,8 +51,8 @@ func EncryptedIndexCreate(
 		return returnC(returnGoC(1, err.Error(), ""))
 	}
 
-	createOpt := options.WithIdentity(options.CreateEncryptedIndex(), iIdentity.FromContext(ctx))
-	descWithID, err := col.CreateEncryptedIndex(ctx, desc, createOpt)
+	addOpt := options.WithIdentity(options.AddEncryptedIndex(), iIdentity.FromContext(ctx))
+	descWithID, err := col.AddEncryptedIndex(ctx, desc, addOpt)
 	if err != nil {
 		return returnC(returnGoC(1, err.Error(), ""))
 	}

--- a/cbindings/wrapper.go
+++ b/cbindings/wrapper.go
@@ -34,7 +34,7 @@ extern Result IdentityNew(char* keyType);
 extern void IdentityFree(uintptr_t identityPtr);
 extern Result NodeIdentity(uintptr_t nodePtr);
 extern Result IndexList(uintptr_t nodePtr, CollectionOptions options, uintptr_t identityPtr);
-extern Result EncryptedIndexCreate(uintptr_t nodePtr, char* collectionName, char* fieldName, uintptr_t identity);
+extern Result EncryptedIndexAdd(uintptr_t nodePtr, char* collectionName, char* fieldName, uintptr_t identity);
 extern Result EncryptedIndexList(uintptr_t nodePtr, char* collectionName);
 extern Result EncryptedIndexDelete(uintptr_t nodePtr, char* collectionName, char* fieldName);
 extern Result LensSet(uintptr_t nodePtr, uintptr_t identity, char* src, char* dst, char* cfg);

--- a/cbindings/wrapper_collection.go
+++ b/cbindings/wrapper_collection.go
@@ -28,7 +28,7 @@ extern Result IndexCreate(uintptr_t nodePtr, char* indexName, char* fieldsStr, i
 CollectionOptions options, uintptr_t identityPtr);
 extern Result IndexList(uintptr_t nodePtr, CollectionOptions options, uintptr_t identityPtr);
 extern Result IndexDrop(uintptr_t nodePtr, char* indexName, CollectionOptions options, uintptr_t identityPtr);
-extern Result EncryptedIndexCreate(uintptr_t nodePtr, char* collectionName, char* fieldName, uintptr_t identity);
+extern Result EncryptedIndexAdd(uintptr_t nodePtr, char* collectionName, char* fieldName, uintptr_t identity);
 extern Result EncryptedIndexList(uintptr_t nodePtr, char* collectionName);
 extern Result EncryptedIndexDelete(uintptr_t nodePtr, char* collectionName, char* fieldName);
 extern Result CollectionTruncate(uintptr_t nodePtr, CollectionOptions options, uintptr_t identityPtr);
@@ -680,10 +680,10 @@ func (c *Collection) GetIndexes(
 	return retRes, nil
 }
 
-func (c *Collection) CreateEncryptedIndex(
+func (c *Collection) AddEncryptedIndex(
 	ctx context.Context,
 	req client.EncryptedIndexDescription,
-	opts ...options.Enumerable[options.CreateEncryptedIndexOptions],
+	opts ...options.Enumerable[options.AddEncryptedIndexOptions],
 ) (client.EncryptedIndexDescription, error) {
 	name := C.CString(c.def.Name)
 	fieldName := C.CString(req.FieldName)
@@ -693,7 +693,7 @@ func (c *Collection) CreateEncryptedIndex(
 	cIdentity := optionToUintptr(utils.NewOptions(opts...).GetIdentity())
 	defer C.IdentityFree(cIdentity)
 
-	res := ConvertAndFreeCResult(C.EncryptedIndexCreate(
+	res := ConvertAndFreeCResult(C.EncryptedIndexAdd(
 		C.uintptr_t(c.w.handle),
 		name,
 		fieldName,

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -131,7 +131,7 @@ func NewDefraCommand(ctx context.Context) *cobra.Command {
 
 	encrypted_index := MakeEncryptedIndexCommand(ctx)
 	encrypted_index.AddCommand(
-		MakeEncryptedIndexCreateCommand(ctx),
+		MakeEncryptedIndexAddCommand(ctx),
 		MakeEncryptedIndexDeleteCommand(ctx),
 		MakeEncryptedIndexListCommand(ctx),
 	)

--- a/cli/encrypted_index_add.go
+++ b/cli/encrypted_index_add.go
@@ -20,14 +20,14 @@ import (
 	iIdentity "github.com/sourcenetwork/defradb/internal/identity"
 )
 
-func MakeEncryptedIndexCreateCommand(ctx context.Context) *cobra.Command {
+func MakeEncryptedIndexAddCommand(ctx context.Context) *cobra.Command {
 	var collectionArg string
 	var fieldArg string
 	var typeArg string
 	var cmd = &cobra.Command{
-		Use:   "create -c --collection <collection> --field <field> [--type <type>]",
-		Short: "Creates an encrypted index on a collection's field",
-		Long: `Creates an encrypted index on a collection's field.
+		Use:   "add -c --collection <collection> --field <field> [--type <type>]",
+		Short: "Adds an encrypted index on a collection's field",
+		Long: `Adds an encrypted index on a collection's field.
 
 The --type flag is optional. If not provided, the default value will be "equality".
 
@@ -36,7 +36,7 @@ Currently only "equality" type is supported.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cliClient := mustGetContextCLIClient(cmd)
 
-			createReq := client.EncryptedIndexDescription{
+			addReq := client.EncryptedIndexDescription{
 				FieldName: fieldArg,
 				Type:      client.EncryptedIndexType(typeArg),
 			}
@@ -46,8 +46,8 @@ Currently only "equality" type is supported.`,
 				return err
 			}
 
-			createOpt := options.WithIdentity(options.CreateEncryptedIndex(), iIdentity.FromContext(cmd.Context()))
-			descWithID, err := col.CreateEncryptedIndex(cmd.Context(), createReq, createOpt)
+			addOpt := options.WithIdentity(options.AddEncryptedIndex(), iIdentity.FromContext(cmd.Context()))
+			descWithID, err := col.AddEncryptedIndex(cmd.Context(), addReq, addOpt)
 			if err != nil {
 				return err
 			}
@@ -55,12 +55,12 @@ Currently only "equality" type is supported.`,
 		},
 	}
 
-	EmbedCLIExample(ctx, cmd, "create an index for 'Users' collection on 'name' field",
-		`defradb client encrypted-index create --collection Users --field name`)
+	EmbedCLIExample(ctx, cmd, "add an index for 'Users' collection on 'name' field",
+		`defradb client encrypted-index add --collection Users --field name`)
 
 	cmd.Flags().StringVarP(&collectionArg, "collection", "c", "", "Collection name")
 	cmd.Flags().StringVar(&fieldArg, "field", "", "Field to index")
-	cmd.Flags().StringVar(&typeArg, "type", "", "Type of index to create")
+	cmd.Flags().StringVar(&typeArg, "type", "", "Type of index to add")
 
 	return cmd
 }

--- a/client/collection.go
+++ b/client/collection.go
@@ -129,11 +129,11 @@ type Collection interface {
 		opts ...options.Enumerable[options.CollectionGetIndexesOptions],
 	) ([]IndexDescription, error)
 
-	// CreateEncryptedIndex creates a new encrypted index on the collection.
-	CreateEncryptedIndex(
+	// AddEncryptedIndex adds a new encrypted index to the collection.
+	AddEncryptedIndex(
 		ctx context.Context,
 		desc EncryptedIndexDescription,
-		opts ...options.Enumerable[options.CreateEncryptedIndexOptions],
+		opts ...options.Enumerable[options.AddEncryptedIndexOptions],
 	) (EncryptedIndexDescription, error)
 
 	// DeleteEncryptedIndex deletes an encrypted index from the collection.

--- a/client/mocks/collection.go
+++ b/client/mocks/collection.go
@@ -39,6 +39,87 @@ func (_m *Collection) EXPECT() *Collection_Expecter {
 	return &Collection_Expecter{mock: &_m.Mock}
 }
 
+// AddEncryptedIndex provides a mock function for the type Collection
+func (_mock *Collection) AddEncryptedIndex(ctx context.Context, desc client.EncryptedIndexDescription, opts ...options.Enumerable[options.AddEncryptedIndexOptions]) (client.EncryptedIndexDescription, error) {
+	var tmpRet mock.Arguments
+	if len(opts) > 0 {
+		tmpRet = _mock.Called(ctx, desc, opts)
+	} else {
+		tmpRet = _mock.Called(ctx, desc)
+	}
+	ret := tmpRet
+
+	if len(ret) == 0 {
+		panic("no return value specified for AddEncryptedIndex")
+	}
+
+	var r0 client.EncryptedIndexDescription
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, client.EncryptedIndexDescription, ...options.Enumerable[options.AddEncryptedIndexOptions]) (client.EncryptedIndexDescription, error)); ok {
+		return returnFunc(ctx, desc, opts...)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, client.EncryptedIndexDescription, ...options.Enumerable[options.AddEncryptedIndexOptions]) client.EncryptedIndexDescription); ok {
+		r0 = returnFunc(ctx, desc, opts...)
+	} else {
+		r0 = ret.Get(0).(client.EncryptedIndexDescription)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, client.EncryptedIndexDescription, ...options.Enumerable[options.AddEncryptedIndexOptions]) error); ok {
+		r1 = returnFunc(ctx, desc, opts...)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// Collection_AddEncryptedIndex_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AddEncryptedIndex'
+type Collection_AddEncryptedIndex_Call struct {
+	*mock.Call
+}
+
+// AddEncryptedIndex is a helper method to define mock.On call
+//   - ctx context.Context
+//   - desc client.EncryptedIndexDescription
+//   - opts ...options.Enumerable[options.AddEncryptedIndexOptions]
+func (_e *Collection_Expecter) AddEncryptedIndex(ctx interface{}, desc interface{}, opts ...interface{}) *Collection_AddEncryptedIndex_Call {
+	return &Collection_AddEncryptedIndex_Call{Call: _e.mock.On("AddEncryptedIndex",
+		append([]interface{}{ctx, desc}, opts...)...)}
+}
+
+func (_c *Collection_AddEncryptedIndex_Call) Run(run func(ctx context.Context, desc client.EncryptedIndexDescription, opts ...options.Enumerable[options.AddEncryptedIndexOptions])) *Collection_AddEncryptedIndex_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 client.EncryptedIndexDescription
+		if args[1] != nil {
+			arg1 = args[1].(client.EncryptedIndexDescription)
+		}
+		var arg2 []options.Enumerable[options.AddEncryptedIndexOptions]
+		var variadicArgs []options.Enumerable[options.AddEncryptedIndexOptions]
+		if len(args) > 2 {
+			variadicArgs = args[2].([]options.Enumerable[options.AddEncryptedIndexOptions])
+		}
+		arg2 = variadicArgs
+		run(
+			arg0,
+			arg1,
+			arg2...,
+		)
+	})
+	return _c
+}
+
+func (_c *Collection_AddEncryptedIndex_Call) Return(encryptedIndexDescription client.EncryptedIndexDescription, err error) *Collection_AddEncryptedIndex_Call {
+	_c.Call.Return(encryptedIndexDescription, err)
+	return _c
+}
+
+func (_c *Collection_AddEncryptedIndex_Call) RunAndReturn(run func(ctx context.Context, desc client.EncryptedIndexDescription, opts ...options.Enumerable[options.AddEncryptedIndexOptions]) (client.EncryptedIndexDescription, error)) *Collection_AddEncryptedIndex_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // CollectionID provides a mock function for the type Collection
 func (_mock *Collection) CollectionID() string {
 	ret := _mock.Called()
@@ -151,87 +232,6 @@ func (_c *Collection_Create_Call) Return(err error) *Collection_Create_Call {
 }
 
 func (_c *Collection_Create_Call) RunAndReturn(run func(ctx context.Context, doc *client.Document, opts ...options.Enumerable[options.CollectionCreateOptions]) error) *Collection_Create_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// CreateEncryptedIndex provides a mock function for the type Collection
-func (_mock *Collection) CreateEncryptedIndex(ctx context.Context, desc client.EncryptedIndexDescription, opts ...options.Enumerable[options.CreateEncryptedIndexOptions]) (client.EncryptedIndexDescription, error) {
-	var tmpRet mock.Arguments
-	if len(opts) > 0 {
-		tmpRet = _mock.Called(ctx, desc, opts)
-	} else {
-		tmpRet = _mock.Called(ctx, desc)
-	}
-	ret := tmpRet
-
-	if len(ret) == 0 {
-		panic("no return value specified for CreateEncryptedIndex")
-	}
-
-	var r0 client.EncryptedIndexDescription
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, client.EncryptedIndexDescription, ...options.Enumerable[options.CreateEncryptedIndexOptions]) (client.EncryptedIndexDescription, error)); ok {
-		return returnFunc(ctx, desc, opts...)
-	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, client.EncryptedIndexDescription, ...options.Enumerable[options.CreateEncryptedIndexOptions]) client.EncryptedIndexDescription); ok {
-		r0 = returnFunc(ctx, desc, opts...)
-	} else {
-		r0 = ret.Get(0).(client.EncryptedIndexDescription)
-	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, client.EncryptedIndexDescription, ...options.Enumerable[options.CreateEncryptedIndexOptions]) error); ok {
-		r1 = returnFunc(ctx, desc, opts...)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// Collection_CreateEncryptedIndex_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreateEncryptedIndex'
-type Collection_CreateEncryptedIndex_Call struct {
-	*mock.Call
-}
-
-// CreateEncryptedIndex is a helper method to define mock.On call
-//   - ctx context.Context
-//   - desc client.EncryptedIndexDescription
-//   - opts ...options.Enumerable[options.CreateEncryptedIndexOptions]
-func (_e *Collection_Expecter) CreateEncryptedIndex(ctx interface{}, desc interface{}, opts ...interface{}) *Collection_CreateEncryptedIndex_Call {
-	return &Collection_CreateEncryptedIndex_Call{Call: _e.mock.On("CreateEncryptedIndex",
-		append([]interface{}{ctx, desc}, opts...)...)}
-}
-
-func (_c *Collection_CreateEncryptedIndex_Call) Run(run func(ctx context.Context, desc client.EncryptedIndexDescription, opts ...options.Enumerable[options.CreateEncryptedIndexOptions])) *Collection_CreateEncryptedIndex_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		var arg1 client.EncryptedIndexDescription
-		if args[1] != nil {
-			arg1 = args[1].(client.EncryptedIndexDescription)
-		}
-		var arg2 []options.Enumerable[options.CreateEncryptedIndexOptions]
-		var variadicArgs []options.Enumerable[options.CreateEncryptedIndexOptions]
-		if len(args) > 2 {
-			variadicArgs = args[2].([]options.Enumerable[options.CreateEncryptedIndexOptions])
-		}
-		arg2 = variadicArgs
-		run(
-			arg0,
-			arg1,
-			arg2...,
-		)
-	})
-	return _c
-}
-
-func (_c *Collection_CreateEncryptedIndex_Call) Return(encryptedIndexDescription client.EncryptedIndexDescription, err error) *Collection_CreateEncryptedIndex_Call {
-	_c.Call.Return(encryptedIndexDescription, err)
-	return _c
-}
-
-func (_c *Collection_CreateEncryptedIndex_Call) RunAndReturn(run func(ctx context.Context, desc client.EncryptedIndexDescription, opts ...options.Enumerable[options.CreateEncryptedIndexOptions]) (client.EncryptedIndexDescription, error)) *Collection_CreateEncryptedIndex_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/client/options/collection.go
+++ b/client/options/collection.go
@@ -410,25 +410,25 @@ func (b *CollectionTruncateOptionsBuilder) SetIdentity(id identity.Identity) *Co
 	return b
 }
 
-// CreateEncryptedIndexOptions contains options for CreateEncryptedIndex operation.
-type CreateEncryptedIndexOptions struct {
+// AddEncryptedIndexOptions contains options for AddEncryptedIndex operation.
+type AddEncryptedIndexOptions struct {
 	Identity immutable.Option[identity.Identity]
 }
 
-func (o *CreateEncryptedIndexOptions) GetIdentity() immutable.Option[identity.Identity] {
+func (o *AddEncryptedIndexOptions) GetIdentity() immutable.Option[identity.Identity] {
 	return o.Identity
 }
 
-type CreateEncryptedIndexOptionsBuilder struct {
-	enumerableBuilder[CreateEncryptedIndexOptions]
+type AddEncryptedIndexOptionsBuilder struct {
+	enumerableBuilder[AddEncryptedIndexOptions]
 }
 
-func CreateEncryptedIndex() *CreateEncryptedIndexOptionsBuilder {
-	return &CreateEncryptedIndexOptionsBuilder{}
+func AddEncryptedIndex() *AddEncryptedIndexOptionsBuilder {
+	return &AddEncryptedIndexOptionsBuilder{}
 }
 
-func (b *CreateEncryptedIndexOptionsBuilder) SetIdentity(id identity.Identity) *CreateEncryptedIndexOptionsBuilder {
-	b.append(func(opts *CreateEncryptedIndexOptions) {
+func (b *AddEncryptedIndexOptionsBuilder) SetIdentity(id identity.Identity) *AddEncryptedIndexOptionsBuilder {
+	b.append(func(opts *AddEncryptedIndexOptions) {
 		opts.Identity = immutable.Some(id)
 	})
 	return b

--- a/docs/website/references/cli/defradb_client_encrypted-index.md
+++ b/docs/website/references/cli/defradb_client_encrypted-index.md
@@ -37,7 +37,7 @@ Manage collections' encrypted indexes on a running DefraDB node.
 ### SEE ALSO
 
 * [defradb client](defradb_client.md)	 - Interact with a DefraDB node
-* [defradb client encrypted-index create](defradb_client_encrypted-index_create.md)	 - Creates an encrypted index on a collection's field
+* [defradb client encrypted-index add](defradb_client_encrypted-index_add.md)	 - Adds an encrypted index on a collection's field
 * [defradb client encrypted-index delete](defradb_client_encrypted-index_delete.md)	 - Delete an encrypted index from a collection's field
 * [defradb client encrypted-index list](defradb_client_encrypted-index_list.md)	 - Lists the encrypted indexes in the database or for a specific collection
 

--- a/docs/website/references/cli/defradb_client_encrypted-index_add.md
+++ b/docs/website/references/cli/defradb_client_encrypted-index_add.md
@@ -1,24 +1,24 @@
-## defradb client encrypted-index create
+## defradb client encrypted-index add
 
-Creates an encrypted index on a collection's field
+Adds an encrypted index on a collection's field
 
 ### Synopsis
 
-Creates an encrypted index on a collection's field.
+Adds an encrypted index on a collection's field.
 
 The --type flag is optional. If not provided, the default value will be "equality".
 
 Currently only "equality" type is supported.
 
 ```
-defradb client encrypted-index create -c --collection <collection> --field <field> [--type <type>] [flags]
+defradb client encrypted-index add -c --collection <collection> --field <field> [--type <type>] [flags]
 ```
 
 ### Examples
 
 ```
-create an index for 'Users' collection on 'name' field:  
-  defradb client encrypted-index create --collection Users --field name
+add an index for 'Users' collection on 'name' field:  
+  defradb client encrypted-index add --collection Users --field name
 ```
 
 ### Options
@@ -26,8 +26,8 @@ create an index for 'Users' collection on 'name' field:
 ```
   -c, --collection string   Collection name
       --field string        Field to index
-  -h, --help                help for create
-      --type string         Type of index to create
+  -h, --help                help for add
+      --type string         Type of index to add
 ```
 
 ### Options inherited from parent commands

--- a/docs/website/references/http/openapi.json
+++ b/docs/website/references/http/openapi.json
@@ -425,7 +425,7 @@
                 },
                 "type": "object"
             },
-            "encrypted_index_create": {
+            "encrypted_index_add": {
                 "properties": {
                     "FieldName": {
                         "type": "string"
@@ -1495,8 +1495,8 @@
                 ]
             },
             "post": {
-                "description": "Create an encrypted index",
-                "operationId": "encrypted_index_create",
+                "description": "Add an encrypted index",
+                "operationId": "encrypted_index_add",
                 "parameters": [
                     {
                         "description": "Collection name",
@@ -1512,7 +1512,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/encrypted_index_create"
+                                "$ref": "#/components/schemas/encrypted_index_add"
                             }
                         }
                     },

--- a/http/client_collection.go
+++ b/http/client_collection.go
@@ -446,10 +446,10 @@ func (c *Collection) GetIndexes(
 	return indexes, nil
 }
 
-func (c *Collection) CreateEncryptedIndex(
+func (c *Collection) AddEncryptedIndex(
 	ctx context.Context,
 	indexDesc client.EncryptedIndexDescription,
-	opts ...options.Enumerable[options.CreateEncryptedIndexOptions],
+	opts ...options.Enumerable[options.AddEncryptedIndexOptions],
 ) (client.EncryptedIndexDescription, error) {
 	opt := utils.NewOptions(opts...)
 	ctx = identity.WithContext(ctx, opt.GetIdentity())

--- a/http/handler_collection.go
+++ b/http/handler_collection.go
@@ -344,7 +344,7 @@ func (h *collectionHandler) DropIndex(rw http.ResponseWriter, req *http.Request)
 	rw.WriteHeader(http.StatusOK)
 }
 
-func (h *collectionHandler) CreateEncryptedIndex(rw http.ResponseWriter, req *http.Request) {
+func (h *collectionHandler) AddEncryptedIndex(rw http.ResponseWriter, req *http.Request) {
 	col := mustGetContextClientCollection(req)
 
 	var indexDesc client.EncryptedIndexDescription
@@ -353,9 +353,9 @@ func (h *collectionHandler) CreateEncryptedIndex(rw http.ResponseWriter, req *ht
 		return
 	}
 
-	opts := options.WithIdentity(options.CreateEncryptedIndex(), identity.FromContext(req.Context()))
+	opts := options.WithIdentity(options.AddEncryptedIndex(), identity.FromContext(req.Context()))
 
-	index, err := col.CreateEncryptedIndex(req.Context(), indexDesc, opts)
+	index, err := col.AddEncryptedIndex(req.Context(), indexDesc, opts)
 	if err != nil {
 		responseJSON(rw, http.StatusBadRequest, errorResponse{err})
 		return
@@ -437,8 +437,8 @@ func (h *collectionHandler) bindRoutes(router *Router) {
 	encryptedIndexSchema := &openapi3.SchemaRef{
 		Ref: "#/components/schemas/encrypted_index",
 	}
-	encryptedIndexCreateRequestSchema := &openapi3.SchemaRef{
-		Ref: "#/components/schemas/encrypted_index_create",
+	encryptedIndexAddRequestSchema := &openapi3.SchemaRef{
+		Ref: "#/components/schemas/encrypted_index_add",
 	}
 
 	collectionNamePathParam := openapi3.NewPathParameter("name").
@@ -602,23 +602,23 @@ func (h *collectionHandler) bindRoutes(router *Router) {
 	collectionKeys.Responses.Set("200", successResponse)
 	collectionKeys.Responses.Set("400", errorResponse)
 
-	createEncryptedIndexRequest := openapi3.NewRequestBody().
+	addEncryptedIndexRequest := openapi3.NewRequestBody().
 		WithRequired(true).
-		WithContent(openapi3.NewContentWithJSONSchemaRef(encryptedIndexCreateRequestSchema))
-	createEncryptedIndexResponse := openapi3.NewResponse().
+		WithContent(openapi3.NewContentWithJSONSchemaRef(encryptedIndexAddRequestSchema))
+	addEncryptedIndexResponse := openapi3.NewResponse().
 		WithDescription("Encrypted index description").
 		WithJSONSchemaRef(encryptedIndexSchema)
 
-	createEncryptedIndex := openapi3.NewOperation()
-	createEncryptedIndex.OperationID = "encrypted_index_create"
-	createEncryptedIndex.Description = "Create an encrypted index"
-	createEncryptedIndex.Tags = []string{"encrypted_index"}
-	createEncryptedIndex.AddParameter(collectionNamePathParam)
-	createEncryptedIndex.RequestBody = &openapi3.RequestBodyRef{
-		Value: createEncryptedIndexRequest,
+	addEncryptedIndex := openapi3.NewOperation()
+	addEncryptedIndex.OperationID = "encrypted_index_add"
+	addEncryptedIndex.Description = "Add an encrypted index"
+	addEncryptedIndex.Tags = []string{"encrypted_index"}
+	addEncryptedIndex.AddParameter(collectionNamePathParam)
+	addEncryptedIndex.RequestBody = &openapi3.RequestBodyRef{
+		Value: addEncryptedIndexRequest,
 	}
-	createEncryptedIndex.AddResponse(200, createEncryptedIndexResponse)
-	createEncryptedIndex.Responses.Set("400", errorResponse)
+	addEncryptedIndex.AddResponse(200, addEncryptedIndexResponse)
+	addEncryptedIndex.Responses.Set("400", errorResponse)
 
 	encryptedIndexArraySchema := openapi3.NewArraySchema()
 	encryptedIndexArraySchema.Items = encryptedIndexSchema
@@ -670,8 +670,8 @@ func (h *collectionHandler) bindRoutes(router *Router) {
 	router.AddRoute("/collections/{name}/{docID}", http.MethodGet, collectionGet, h.Get)
 	router.AddRoute("/collections/{name}/{docID}", http.MethodPatch, collectionUpdate, h.Update)
 	router.AddRoute("/collections/{name}/{docID}", http.MethodDelete, collectionDelete, h.Delete)
-	router.AddRoute("/collections/{name}/encrypted-indexes", http.MethodPost, createEncryptedIndex,
-		h.CreateEncryptedIndex)
+	router.AddRoute("/collections/{name}/encrypted-indexes", http.MethodPost, addEncryptedIndex,
+		h.AddEncryptedIndex)
 	router.AddRoute("/collections/{name}/encrypted-indexes", http.MethodGet, listEncryptedIndexes,
 		h.ListEncryptedIndexes)
 	router.AddRoute("/collections/{name}/encrypted-indexes/{field}", http.MethodDelete, deleteEncryptedIndex,

--- a/http/openapi.go
+++ b/http/openapi.go
@@ -31,7 +31,7 @@ var openApiSchemas = map[string]any{
 	"index":                                    &client.IndexDescription{},
 	"index_create":                             &client.IndexCreateRequest{},
 	"encrypted_index":                          &client.EncryptedIndexDescription{},
-	"encrypted_index_create":                   &client.EncryptedIndexDescription{},
+	"encrypted_index_add":                      &client.EncryptedIndexDescription{},
 	"delete_result":                            &client.DeleteResult{},
 	"update_result":                            &client.UpdateResult{},
 	"lens_config":                              &client.LensConfig{},

--- a/internal/db/collection_index.go
+++ b/internal/db/collection_index.go
@@ -434,11 +434,11 @@ func (c *collection) GetIndexes(
 	return c.Version().Indexes, nil
 }
 
-// CreateEncryptedIndex creates a new encrypted index on the collection.
-func (c *collection) CreateEncryptedIndex(
+// AddEncryptedIndex adds a new encrypted index to the collection.
+func (c *collection) AddEncryptedIndex(
 	ctx context.Context,
-	createRequest client.EncryptedIndexDescription,
-	opts ...options.Enumerable[options.CreateEncryptedIndexOptions],
+	addRequest client.EncryptedIndexDescription,
+	opts ...options.Enumerable[options.AddEncryptedIndexOptions],
 ) (client.EncryptedIndexDescription, error) {
 	ctx, span := tracer.Start(ctx)
 	defer span.End()
@@ -446,7 +446,7 @@ func (c *collection) CreateEncryptedIndex(
 	opt := utils.NewOptions(opts...)
 	ident := opt.GetIdentity()
 
-	if err := c.db.checkNodeAccess(ctx, ident, acpTypes.NodeEncryptedIndexCreatePerm); err != nil {
+	if err := c.db.checkNodeAccess(ctx, ident, acpTypes.NodeEncryptedIndexAddPerm); err != nil {
 		return client.EncryptedIndexDescription{}, err
 	}
 
@@ -456,14 +456,14 @@ func (c *collection) CreateEncryptedIndex(
 	}
 	defer txn.Discard()
 
-	index, err := c.createEncryptedIndex(ctx, createRequest)
+	index, err := c.addEncryptedIndex(ctx, addRequest)
 	if err != nil {
 		return client.EncryptedIndexDescription{}, err
 	}
 	return index, txn.Commit()
 }
 
-func (c *collection) createEncryptedIndex(
+func (c *collection) addEncryptedIndex(
 	ctx context.Context,
 	encryptedIndex client.EncryptedIndexDescription,
 ) (client.EncryptedIndexDescription, error) {
@@ -571,7 +571,7 @@ func checkExistingFieldsAndAdjustRelFieldNames(
 	return nil
 }
 
-// validateNewEncryptedIndex validates, if encrypted index can be created on the given collection.
+// validateNewEncryptedIndex validates, if encrypted index can be added to the given collection.
 // It checks if the field exists in the collection schema and if an encrypted index already exists on the field.
 func validateNewEncryptedIndex(
 	definition client.CollectionVersion,

--- a/js/client_collection.go
+++ b/js/client_collection.go
@@ -48,7 +48,7 @@ func newCollection(col client.Collection, txns *sync.Map) js.Value {
 		"createIndex":          goji.Async(c.createIndex),
 		"dropIndex":            goji.Async(c.dropIndex),
 		"getIndexes":           goji.Async(c.getIndexes),
-		"createEncryptedIndex": goji.Async(c.createEncryptedIndex),
+		"addEncryptedIndex":    goji.Async(c.addEncryptedIndex),
 		"deleteEncryptedIndex": goji.Async(c.deleteEncryptedIndex),
 		"listEncryptedIndexes": goji.Async(c.listEncryptedIndexes),
 		"truncate":             goji.Async(c.truncate),
@@ -354,7 +354,7 @@ func (c *clientCollection) getIndexes(this js.Value, args []js.Value) (js.Value,
 	return goji.MarshalJS(desc)
 }
 
-func (c *clientCollection) createEncryptedIndex(this js.Value, args []js.Value) (js.Value, error) {
+func (c *clientCollection) addEncryptedIndex(this js.Value, args []js.Value) (js.Value, error) {
 	var request client.EncryptedIndexDescription
 	if err := structArg(args, 0, "request", &request); err != nil {
 		return js.Undefined(), err
@@ -363,9 +363,9 @@ func (c *clientCollection) createEncryptedIndex(this js.Value, args []js.Value) 
 	if err != nil {
 		return js.Undefined(), err
 	}
-	opt := options.CreateEncryptedIndex()
+	opt := options.AddEncryptedIndex()
 	setOptIdentity(opt, args, 1)
-	desc, err := c.col.CreateEncryptedIndex(ctx, request, opt)
+	desc, err := c.col.AddEncryptedIndex(ctx, request, opt)
 	if err != nil {
 		return js.Undefined(), err
 	}

--- a/tests/clients/cli/wrapper_collection.go
+++ b/tests/clients/cli/wrapper_collection.go
@@ -443,13 +443,13 @@ func (c *Collection) GetIndexes(
 	return indexes, nil
 }
 
-// CreateEncryptedIndex implements client.Collection.
-func (c *Collection) CreateEncryptedIndex(
+// AddEncryptedIndex implements client.Collection.
+func (c *Collection) AddEncryptedIndex(
 	ctx context.Context,
 	indexDesc client.EncryptedIndexDescription,
-	opts ...options.Enumerable[options.CreateEncryptedIndexOptions],
+	opts ...options.Enumerable[options.AddEncryptedIndexOptions],
 ) (index client.EncryptedIndexDescription, err error) {
-	args := []string{"client", "encrypted-index", "create"}
+	args := []string{"client", "encrypted-index", "add"}
 	args = append(args, "--collection", c.Version().Name)
 	args = append(args, "--field", indexDesc.FieldName)
 

--- a/tests/clients/js/wrapper_collection.go
+++ b/tests/clients/js/wrapper_collection.go
@@ -312,10 +312,10 @@ func (c *Collection) GetIndexes(ctx context.Context, opts ...options.Enumerable[
 	return out, nil
 }
 
-func (c *Collection) CreateEncryptedIndex(
+func (c *Collection) AddEncryptedIndex(
 	ctx context.Context,
 	req client.EncryptedIndexDescription,
-	opts ...options.Enumerable[options.CreateEncryptedIndexOptions],
+	opts ...options.Enumerable[options.AddEncryptedIndexOptions],
 ) (client.EncryptedIndexDescription, error) {
 	opt := utils.NewOptions(opts...)
 	if opt != nil {
@@ -325,7 +325,7 @@ func (c *Collection) CreateEncryptedIndex(
 	if err != nil {
 		return client.EncryptedIndexDescription{}, err
 	}
-	res, err := execute(ctx, c.client, "createEncryptedIndex", indexDescVal)
+	res, err := execute(ctx, c.client, "addEncryptedIndex", indexDescVal)
 	if err != nil {
 		return client.EncryptedIndexDescription{}, err
 	}

--- a/tests/integration/acp/nac/encrypted_index_add_test.go
+++ b/tests/integration/acp/nac/encrypted_index_add_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/sourcenetwork/defradb/tests/state"
 )
 
-func TestNAC_GatesCreateEncryptedIndex_AuthorizedIdentity_AllowAccess(t *testing.T) {
+func TestNAC_GatesAddEncryptedIndex_AuthorizedIdentity_AllowAccess(t *testing.T) {
 	test := testUtils.TestCase{
 		SupportedClientTypes: immutable.Some(
 			[]state.ClientType{
@@ -45,7 +45,7 @@ func TestNAC_GatesCreateEncryptedIndex_AuthorizedIdentity_AllowAccess(t *testing
 					}
 				`,
 			},
-			testUtils.CreateEncryptedIndex{
+			testUtils.AddEncryptedIndex{
 				Identity:     testUtils.ClientIdentity(1),
 				CollectionID: 0,
 				FieldName:    "name",
@@ -55,7 +55,7 @@ func TestNAC_GatesCreateEncryptedIndex_AuthorizedIdentity_AllowAccess(t *testing
 	testUtils.ExecuteTestCase(t, test)
 }
 
-func TestNAC_GatesCreateEncryptedIndex_NoIdentity_NotAuthorizedError(t *testing.T) {
+func TestNAC_GatesAddEncryptedIndex_NoIdentity_NotAuthorizedError(t *testing.T) {
 	test := testUtils.TestCase{
 		// todo: Investigate and test this behavior across all client types when implementing granular NAC permissions.
 		// See: https://github.com/sourcenetwork/defradb/issues/4383
@@ -79,18 +79,18 @@ func TestNAC_GatesCreateEncryptedIndex_NoIdentity_NotAuthorizedError(t *testing.
 					}
 				`,
 			},
-			testUtils.CreateEncryptedIndex{
+			testUtils.AddEncryptedIndex{
 				Identity:      testUtils.NoIdentity(),
 				CollectionID:  0,
 				FieldName:     "name",
-				ExpectedError: testUtils.FormatExpectedErrorWithPermission(acpTypes.NodeEncryptedIndexCreatePerm),
+				ExpectedError: testUtils.FormatExpectedErrorWithPermission(acpTypes.NodeEncryptedIndexAddPerm),
 			},
 		},
 	}
 	testUtils.ExecuteTestCase(t, test)
 }
 
-func TestNAC_GatesCreateEncryptedIndex_NoIdentity_CLIandCandHTTPClient_NotAuthorizedError(t *testing.T) {
+func TestNAC_GatesAddEncryptedIndex_NoIdentity_CLIandCandHTTPClient_NotAuthorizedError(t *testing.T) {
 	test := testUtils.TestCase{
 		// todo: Investigate and test this behavior across all client types when implementing granular NAC permissions.
 		// See: https://github.com/sourcenetwork/defradb/issues/4383
@@ -115,7 +115,7 @@ func TestNAC_GatesCreateEncryptedIndex_NoIdentity_CLIandCandHTTPClient_NotAuthor
 					}
 				`,
 			},
-			testUtils.CreateEncryptedIndex{
+			testUtils.AddEncryptedIndex{
 				Identity:      testUtils.NoIdentity(),
 				CollectionID:  0,
 				FieldName:     "name",
@@ -126,7 +126,7 @@ func TestNAC_GatesCreateEncryptedIndex_NoIdentity_CLIandCandHTTPClient_NotAuthor
 	testUtils.ExecuteTestCase(t, test)
 }
 
-func TestNAC_GatesCreateEncryptedIndex_WrongIdentity_NotAuthorizedError(t *testing.T) {
+func TestNAC_GatesAddEncryptedIndex_WrongIdentity_NotAuthorizedError(t *testing.T) {
 	test := testUtils.TestCase{
 		// todo: Investigate and test this behavior across all client types when implementing granular NAC permissions.
 		// See: https://github.com/sourcenetwork/defradb/issues/4383
@@ -150,18 +150,18 @@ func TestNAC_GatesCreateEncryptedIndex_WrongIdentity_NotAuthorizedError(t *testi
 					}
 				`,
 			},
-			testUtils.CreateEncryptedIndex{
+			testUtils.AddEncryptedIndex{
 				Identity:      testUtils.ClientIdentity(2),
 				CollectionID:  0,
 				FieldName:     "name",
-				ExpectedError: testUtils.FormatExpectedErrorWithPermission(acpTypes.NodeEncryptedIndexCreatePerm),
+				ExpectedError: testUtils.FormatExpectedErrorWithPermission(acpTypes.NodeEncryptedIndexAddPerm),
 			},
 		},
 	}
 	testUtils.ExecuteTestCase(t, test)
 }
 
-func TestNAC_GatesCreateEncryptedIndex_WrongIdentity_CLIandCandHTTPClient_NotAuthorizedError(t *testing.T) {
+func TestNAC_GatesAddEncryptedIndex_WrongIdentity_CLIandCandHTTPClient_NotAuthorizedError(t *testing.T) {
 	test := testUtils.TestCase{
 		// todo: Investigate and test this behavior across all client types when implementing granular NAC permissions.
 		// See: https://github.com/sourcenetwork/defradb/issues/4383
@@ -186,7 +186,7 @@ func TestNAC_GatesCreateEncryptedIndex_WrongIdentity_CLIandCandHTTPClient_NotAut
 					}
 				`,
 			},
-			testUtils.CreateEncryptedIndex{
+			testUtils.AddEncryptedIndex{
 				Identity:      testUtils.ClientIdentity(2),
 				CollectionID:  0,
 				FieldName:     "name",

--- a/tests/integration/acp/nac/relation_admin/encrypted_index_add_test.go
+++ b/tests/integration/acp/nac/relation_admin/encrypted_index_add_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/sourcenetwork/defradb/tests/state"
 )
 
-func TestNAC_AdminRelation_CanCreateEncryptedIndex(t *testing.T) {
+func TestNAC_AdminRelation_CanAddEncryptedIndex(t *testing.T) {
 	test := testUtils.TestCase{
 		// todo: Investigate and test this behavior across all client types when implementing granular NAC permissions.
 		// See: https://github.com/sourcenetwork/defradb/issues/4383
@@ -44,11 +44,11 @@ func TestNAC_AdminRelation_CanCreateEncryptedIndex(t *testing.T) {
 					}
 				`,
 			},
-			testUtils.CreateEncryptedIndex{
+			testUtils.AddEncryptedIndex{
 				Identity:      testUtils.ClientIdentity(2),
 				CollectionID:  0,
 				FieldName:     "name",
-				ExpectedError: testUtils.FormatExpectedErrorWithPermission(acpTypes.NodeEncryptedIndexCreatePerm),
+				ExpectedError: testUtils.FormatExpectedErrorWithPermission(acpTypes.NodeEncryptedIndexAddPerm),
 			},
 			testUtils.AddNACActorRelationship{
 				RequestorIdentity: testUtils.ClientIdentity(1),
@@ -56,7 +56,7 @@ func TestNAC_AdminRelation_CanCreateEncryptedIndex(t *testing.T) {
 				Relation:          "admin",
 				ExpectedExistence: false,
 			},
-			testUtils.CreateEncryptedIndex{
+			testUtils.AddEncryptedIndex{
 				Identity:     testUtils.ClientIdentity(2),
 				CollectionID: 0,
 				FieldName:    "name",
@@ -66,7 +66,7 @@ func TestNAC_AdminRelation_CanCreateEncryptedIndex(t *testing.T) {
 	testUtils.ExecuteTestCase(t, test)
 }
 
-func TestNAC_AdminRelation_CLIandCandHTTPClient_CanCreateEncryptedIndex(t *testing.T) {
+func TestNAC_AdminRelation_CLIandCandHTTPClient_CanAddEncryptedIndex(t *testing.T) {
 	test := testUtils.TestCase{
 		// todo: Investigate and test this behavior across all client types when implementing granular NAC permissions.
 		// See: https://github.com/sourcenetwork/defradb/issues/4383
@@ -91,7 +91,7 @@ func TestNAC_AdminRelation_CLIandCandHTTPClient_CanCreateEncryptedIndex(t *testi
 					}
 				`,
 			},
-			testUtils.CreateEncryptedIndex{
+			testUtils.AddEncryptedIndex{
 				Identity:      testUtils.ClientIdentity(2),
 				CollectionID:  0,
 				FieldName:     "name",
@@ -103,7 +103,7 @@ func TestNAC_AdminRelation_CLIandCandHTTPClient_CanCreateEncryptedIndex(t *testi
 				Relation:          "admin",
 				ExpectedExistence: false,
 			},
-			testUtils.CreateEncryptedIndex{
+			testUtils.AddEncryptedIndex{
 				Identity:     testUtils.ClientIdentity(2),
 				CollectionID: 0,
 				FieldName:    "name",

--- a/tests/integration/searchable_encryption/add_test.go
+++ b/tests/integration/searchable_encryption/add_test.go
@@ -18,7 +18,7 @@ import (
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
 )
 
-func TestEncryptedIndexCreate_SchemaWithEncryptedIndex_ShouldNotHinderQuerying(t *testing.T) {
+func TestEncryptedIndexAdd_SchemaWithEncryptedIndex_ShouldNotHinderQuerying(t *testing.T) {
 	test := testUtils.TestCase{
 		Actions: []any{
 			&action.AddSchema{
@@ -60,7 +60,7 @@ func TestEncryptedIndexCreate_SchemaWithEncryptedIndex_ShouldNotHinderQuerying(t
 	testUtils.ExecuteTestCase(t, test)
 }
 
-func TestEncryptedIndexCreate_AfterCreateRequest_ShouldNotHinderQuerying(t *testing.T) {
+func TestEncryptedIndexAdd_AfterCreateRequest_ShouldNotHinderQuerying(t *testing.T) {
 	test := testUtils.TestCase{
 		Actions: []any{
 			&action.AddSchema{
@@ -79,7 +79,7 @@ func TestEncryptedIndexCreate_AfterCreateRequest_ShouldNotHinderQuerying(t *test
 						"age":	21
 					}`,
 			},
-			testUtils.CreateEncryptedIndex{
+			testUtils.AddEncryptedIndex{
 				FieldName: "age",
 			},
 			&action.Request{
@@ -105,7 +105,7 @@ func TestEncryptedIndexCreate_AfterCreateRequest_ShouldNotHinderQuerying(t *test
 	testUtils.ExecuteTestCase(t, test)
 }
 
-func TestEncryptedIndexCreate_IfNonExistentFieldIsGiven_ReturnError(t *testing.T) {
+func TestEncryptedIndexAdd_IfNonExistentFieldIsGiven_ReturnError(t *testing.T) {
 	test := testUtils.TestCase{
 		Actions: []any{
 			&action.AddSchema{
@@ -116,7 +116,7 @@ func TestEncryptedIndexCreate_IfNonExistentFieldIsGiven_ReturnError(t *testing.T
 					}
 				`,
 			},
-			testUtils.CreateEncryptedIndex{
+			testUtils.AddEncryptedIndex{
 				FieldName:     "verified",
 				ExpectedError: db.NewErrEncryptedIndexOnNonExistentField("verified").Error(),
 			},
@@ -126,7 +126,7 @@ func TestEncryptedIndexCreate_IfNonExistentFieldIsGiven_ReturnError(t *testing.T
 	testUtils.ExecuteTestCase(t, test)
 }
 
-func TestEncryptedIndexCreate_IfIndexAlreadyExists_ShouldReturnError(t *testing.T) {
+func TestEncryptedIndexAdd_IfIndexAlreadyExists_ShouldReturnError(t *testing.T) {
 	test := testUtils.TestCase{
 		Actions: []any{
 			&action.AddSchema{
@@ -137,7 +137,7 @@ func TestEncryptedIndexCreate_IfIndexAlreadyExists_ShouldReturnError(t *testing.
 					}
 				`,
 			},
-			testUtils.CreateEncryptedIndex{
+			testUtils.AddEncryptedIndex{
 				FieldName:     "age",
 				ExpectedError: db.NewErrEncryptedIndexAlreadyExists("age").Error(),
 			},

--- a/tests/integration/searchable_encryption/delete_test.go
+++ b/tests/integration/searchable_encryption/delete_test.go
@@ -73,7 +73,7 @@ func TestEncryptedIndexDelete_IfIndexDoesNotExist_ReturnError(t *testing.T) {
 	testUtils.ExecuteTestCase(t, test)
 }
 
-func TestEncryptedIndexDelete_AfterDelete_CanCreateIndexAnew(t *testing.T) {
+func TestEncryptedIndexDelete_AfterDelete_CanAddIndexAnew(t *testing.T) {
 	test := testUtils.TestCase{
 		Actions: []any{
 			&action.AddSchema{
@@ -91,7 +91,7 @@ func TestEncryptedIndexDelete_AfterDelete_CanCreateIndexAnew(t *testing.T) {
 				CollectionID:    0,
 				ExpectedIndexes: []client.EncryptedIndexDescription{},
 			},
-			testUtils.CreateEncryptedIndex{
+			testUtils.AddEncryptedIndex{
 				FieldName: "age",
 			},
 			testUtils.ListEncryptedIndexes{

--- a/tests/integration/searchable_encryption/list_test.go
+++ b/tests/integration/searchable_encryption/list_test.go
@@ -81,7 +81,7 @@ func TestEncryptedIndexList_IfIndexCreatedLater_ShouldReturnListOfExistingIndexe
 					},
 				},
 			},
-			testUtils.CreateEncryptedIndex{
+			testUtils.AddEncryptedIndex{
 				FieldName: "age",
 			},
 			testUtils.ListEncryptedIndexes{

--- a/tests/integration/searchable_encryption/peer_create_test.go
+++ b/tests/integration/searchable_encryption/peer_create_test.go
@@ -71,7 +71,7 @@ func TestEncryptedIndexCreatePeer_AfterCreateRequest_ShouldGenerateGQL(t *testin
 					}
 				`,
 			},
-			testUtils.CreateEncryptedIndex{
+			testUtils.AddEncryptedIndex{
 				FieldName: "age",
 			},
 			&action.Request{

--- a/tests/integration/test_case.go
+++ b/tests/integration/test_case.go
@@ -329,12 +329,12 @@ type UpdateWithFilter struct {
 	SkipLocalUpdateEvent bool
 }
 
-// CreateEncryptedIndex will attempt to create the given encrypted index for the given collection
+// AddEncryptedIndex will attempt to add the given encrypted index to the given collection
 // using the collection api.
-type CreateEncryptedIndex struct {
-	// NodeID may hold the ID (index) of a node to create the encrypted index on.
+type AddEncryptedIndex struct {
+	// NodeID may hold the ID (index) of a node to add the encrypted index to.
 	//
-	// If a value is not provided the index will be created in all nodes.
+	// If a value is not provided the index will be added to all nodes.
 	NodeID immutable.Option[int]
 
 	// The identity of this request. Optional.
@@ -342,13 +342,13 @@ type CreateEncryptedIndex struct {
 	// If node acp is enabled, identity will be used to check if this operation can be performed.
 	Identity immutable.Option[state.Identity]
 
-	// The collection for which this index should be created.
+	// The collection to which this index should be added.
 	CollectionID int
 
 	// The name of the field to index. Used only for single field indexes.
 	FieldName string
 
-	// The type of the index to create.
+	// The type of the index to add.
 	Type string
 
 	// Any error expected from the action. Optional.

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -408,8 +408,8 @@ func performAction(
 	case UpdateWithFilter:
 		updateWithFilter(s, action)
 
-	case CreateEncryptedIndex:
-		createEncryptedIndex(s, action)
+	case AddEncryptedIndex:
+		addEncryptedIndex(s, action)
 
 	case ListEncryptedIndexes:
 		listEncryptedIndexes(s, action)
@@ -1361,9 +1361,9 @@ func updateWithFilter(s *state.State, action UpdateWithFilter) {
 	}
 }
 
-func createEncryptedIndex(
+func addEncryptedIndex(
 	s *state.State,
-	action CreateEncryptedIndex,
+	action AddEncryptedIndex,
 ) {
 	nodeIDs, nodes := getNodesWithIDs(action.NodeID, s.Nodes)
 	for index, node := range nodes {
@@ -1378,7 +1378,7 @@ func createEncryptedIndex(
 			Type:      client.EncryptedIndexType(action.Type),
 		}
 
-		opts := options.CreateEncryptedIndex()
+		opts := options.AddEncryptedIndex()
 		identOption := getIdentityForRequestSpecificToNode(s, action.Identity, nodeID)
 		if identOption.HasValue() {
 			opts.SetIdentity(identOption.Value())
@@ -1387,7 +1387,7 @@ func createEncryptedIndex(
 		err := withRetryOnNode(
 			node,
 			func() error {
-				_, err := collection.CreateEncryptedIndex(s.Ctx, indexDesc, opts)
+				_, err := collection.AddEncryptedIndex(s.Ctx, indexDesc, opts)
 				return err
 			},
 		)


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4552

## Description

Renames CreateEncryptedIndex to AddEncryptedIndex.

Find and replace, plus a couple of tiny tweaks to the documentation to accommodate this.