### PR TITLE
refactor: Rename index commands

### DIFF
--- a/acp/types/types.go
+++ b/acp/types/types.go
@@ -96,7 +96,7 @@ const (
 	NodeDocumentDeletePerm
 	NodeIndexListPerm
 	NodeIndexCreatePerm
-	NodeIndexDropPerm
+	NodeIndexDeletePerm
 	NodeEncryptedIndexAddPerm
 	NodeEncryptedIndexDeletePerm
 	NodeEncryptedIndexListPerm
@@ -150,7 +150,7 @@ var RequiredResourcePermissionsForNode = []string{
 	"document-delete",
 	"index-list",
 	"index-create",
-	"index-drop",
+	"index-delete",
 	"encrypted-index-add",
 	"encrypted-index-delete",
 	"encrypted-index-list",
@@ -236,7 +236,7 @@ resources:
     expr: admin
   - name: index-create
     expr: admin
-  - name: index-drop
+  - name: index-delete
     expr: admin
 
   - name: encrypted-index-add

--- a/cbindings/index.go
+++ b/cbindings/index.go
@@ -115,16 +115,16 @@ func IndexList(nodePtr C.uintptr_t, options C.CollectionOptions, identityPtr C.u
 		if err != nil {
 			return returnC(returnGoC(1, err.Error(), ""))
 		}
-		indices, err := col.GetIndexes(ctx,
-			defraOpts.WithIdentity(defraOpts.CollectionGetIndexes(), ident))
+		indices, err := col.ListIndexes(ctx,
+			defraOpts.WithIdentity(defraOpts.CollectionListIndexes(), ident))
 		if err != nil {
 			return returnC(returnGoC(1, err.Error(), ""))
 		}
 		return returnC(marshalJSONToGoCResult(indices))
 	// Get all of the indices, because no collection was specified
 	default:
-		indices, err := store.GetAllIndexes(ctx,
-			defraOpts.WithIdentity(defraOpts.GetAllIndexes(), ident))
+		indices, err := store.ListIndexes(ctx,
+			defraOpts.WithIdentity(defraOpts.ListIndexes(), ident))
 		if err != nil {
 			return returnC(returnGoC(1, err.Error(), ""))
 		}
@@ -132,8 +132,8 @@ func IndexList(nodePtr C.uintptr_t, options C.CollectionOptions, identityPtr C.u
 	}
 }
 
-//export IndexDrop
-func IndexDrop(nodePtr C.uintptr_t,
+//export IndexDelete
+func IndexDelete(nodePtr C.uintptr_t,
 	indexName *C.char,
 	options C.CollectionOptions,
 	identityPtr C.uintptr_t) C.Result {
@@ -156,8 +156,8 @@ func IndexDrop(nodePtr C.uintptr_t,
 	if err != nil {
 		return returnC(returnGoC(1, err.Error(), ""))
 	}
-	err = col.DropIndex(ctx, C.GoString(indexName),
-		defraOpts.WithIdentity(defraOpts.CollectionDropIndex(), ident))
+	err = col.DeleteIndex(ctx, C.GoString(indexName),
+		defraOpts.WithIdentity(defraOpts.CollectionDeleteIndex(), ident))
 	if err != nil {
 		return returnC(returnGoC(1, err.Error(), ""))
 	}

--- a/cbindings/wrapper.go
+++ b/cbindings/wrapper.go
@@ -902,9 +902,9 @@ func (w *CWrapper) GetCollections(
 	return cols, nil
 }
 
-func (w *CWrapper) GetAllIndexes(
+func (w *CWrapper) ListIndexes(
 	ctx context.Context,
-	opts ...options.Enumerable[options.GetAllIndexesOptions],
+	opts ...options.Enumerable[options.ListIndexesOptions],
 ) (map[client.CollectionName][]client.IndexDescription, error) {
 	cVersion := C.CString("")
 	cCollectionID := C.CString("")

--- a/cbindings/wrapper_collection.go
+++ b/cbindings/wrapper_collection.go
@@ -650,7 +650,6 @@ func (c *Collection) GetIndexes(
 	opts ...options.Enumerable[options.CollectionGetIndexesOptions],
 ) ([]client.IndexDescription, error) {
 	cName := C.CString(c.def.Name)
-	cIndexName := C.CString("")
 	cVersion := C.CString("")
 	cCollectionID := C.CString("")
 	cIdentity := optionToUintptr(utils.NewOptions(opts...).GetIdentity())
@@ -658,7 +657,6 @@ func (c *Collection) GetIndexes(
 	defer C.free(unsafe.Pointer(cName))
 	defer C.free(unsafe.Pointer(cVersion))
 	defer C.free(unsafe.Pointer(cCollectionID))
-	defer C.free(unsafe.Pointer(cIndexName))
 	defer C.IdentityFree(cIdentity)
 
 	var copts C.CollectionOptions
@@ -762,7 +760,6 @@ func (c *Collection) Truncate(
 	ctx context.Context, opts ...options.Enumerable[options.CollectionTruncateOptions],
 ) error {
 	cName := C.CString(c.def.Name)
-	cIndexName := C.CString("")
 	cVersion := C.CString("")
 	cCollectionID := C.CString("")
 	cIdentity := optionToUintptr(utils.NewOptions(opts...).GetIdentity())
@@ -770,7 +767,6 @@ func (c *Collection) Truncate(
 	defer C.free(unsafe.Pointer(cName))
 	defer C.free(unsafe.Pointer(cVersion))
 	defer C.free(unsafe.Pointer(cCollectionID))
-	defer C.free(unsafe.Pointer(cIndexName))
 	defer C.IdentityFree(cIdentity)
 
 	var copts C.CollectionOptions

--- a/cbindings/wrapper_collection.go
+++ b/cbindings/wrapper_collection.go
@@ -27,7 +27,7 @@ char* updaterStr, CollectionOptions options, uintptr_t identityPtr);
 extern Result IndexCreate(uintptr_t nodePtr, char* indexName, char* fieldsStr, int isUnique,
 CollectionOptions options, uintptr_t identityPtr);
 extern Result IndexList(uintptr_t nodePtr, CollectionOptions options, uintptr_t identityPtr);
-extern Result IndexDrop(uintptr_t nodePtr, char* indexName, CollectionOptions options, uintptr_t identityPtr);
+extern Result IndexDelete(uintptr_t nodePtr, char* indexName, CollectionOptions options, uintptr_t identityPtr);
 extern Result EncryptedIndexAdd(uintptr_t nodePtr, char* collectionName, char* fieldName, uintptr_t identity);
 extern Result EncryptedIndexList(uintptr_t nodePtr, char* collectionName, uintptr_t identityPtr);
 extern Result EncryptedIndexDelete(uintptr_t nodePtr, char* collectionName, char* fieldName, uintptr_t identity);
@@ -609,10 +609,10 @@ func (c *Collection) CreateIndex(
 	return retRes, nil
 }
 
-func (c *Collection) DropIndex(
+func (c *Collection) DeleteIndex(
 	ctx context.Context,
 	indexName string,
-	opts ...options.Enumerable[options.CollectionDropIndexOptions],
+	opts ...options.Enumerable[options.CollectionDeleteIndexOptions],
 ) error {
 	cName := C.CString(c.def.Name)
 	cIndexName := C.CString(indexName)
@@ -632,7 +632,7 @@ func (c *Collection) DropIndex(
 	copts.name = cName
 	copts.getInactive = 0
 
-	res := ConvertAndFreeCResult(C.IndexDrop(
+	res := ConvertAndFreeCResult(C.IndexDelete(
 		C.uintptr_t(c.w.handle),
 		cIndexName,
 		copts,
@@ -645,9 +645,9 @@ func (c *Collection) DropIndex(
 	return nil
 }
 
-func (c *Collection) GetIndexes(
+func (c *Collection) ListIndexes(
 	ctx context.Context,
-	opts ...options.Enumerable[options.CollectionGetIndexesOptions],
+	opts ...options.Enumerable[options.CollectionListIndexesOptions],
 ) ([]client.IndexDescription, error) {
 	cName := C.CString(c.def.Name)
 	cVersion := C.CString("")

--- a/cbindings/wrapper_tx.go
+++ b/cbindings/wrapper_tx.go
@@ -189,11 +189,11 @@ func (txn *Transaction) GetCollections(
 	return txn.CWrapper.GetCollections(ctx, opts...)
 }
 
-func (txn *Transaction) GetAllIndexes(
+func (txn *Transaction) ListIndexes(
 	ctx context.Context,
-	opts ...options.Enumerable[options.GetAllIndexesOptions],
+	opts ...options.Enumerable[options.ListIndexesOptions],
 ) (map[client.CollectionName][]client.IndexDescription, error) {
-	return txn.CWrapper.GetAllIndexes(ctx, opts...)
+	return txn.CWrapper.ListIndexes(ctx, opts...)
 }
 
 func (txn *Transaction) ExecRequest(

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -125,7 +125,7 @@ func NewDefraCommand(ctx context.Context) *cobra.Command {
 	index := MakeIndexCommand(ctx)
 	index.AddCommand(
 		MakeIndexCreateCommand(ctx),
-		MakeIndexDropCommand(ctx),
+		MakeIndexDeleteCommand(ctx),
 		MakeIndexListCommand(ctx),
 	)
 

--- a/cli/index.go
+++ b/cli/index.go
@@ -20,7 +20,7 @@ func MakeIndexCommand(ctx context.Context) *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:   "index",
 		Short: "Manage collections' indexes of a running DefraDB instance",
-		Long:  `Manage (create, drop, or list) collection indexes on a DefraDB node.`,
+		Long:  `Manage (create, delete, or list) collection indexes on a DefraDB node.`,
 	}
 
 	return cmd

--- a/cli/index_delete.go
+++ b/cli/index_delete.go
@@ -19,13 +19,13 @@ import (
 	"github.com/sourcenetwork/defradb/internal/identity"
 )
 
-func MakeIndexDropCommand(ctx context.Context) *cobra.Command {
+func MakeIndexDeleteCommand(ctx context.Context) *cobra.Command {
 	var collectionArg string
 	var nameArg string
 	var cmd = &cobra.Command{
-		Use:       "drop -c --collection <collection> -n --name <name>",
-		Short:     "Drop a collection's secondary index",
-		Long:      `Drop a collection's secondary index.`,
+		Use:       "delete -c --collection <collection> -n --name <name>",
+		Short:     "Delete a collection's secondary index",
+		Long:      `Delete a collection's secondary index.`,
 		ValidArgs: []string{"collection", "name"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cliClient := mustGetContextCLIClient(cmd)
@@ -35,13 +35,13 @@ func MakeIndexDropCommand(ctx context.Context) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			opt := options.WithIdentity(options.CollectionDropIndex(), identity.FromContext(cmd.Context()))
-			return col.DropIndex(cmd.Context(), nameArg, opt)
+			opt := options.WithIdentity(options.CollectionDeleteIndex(), identity.FromContext(cmd.Context()))
+			return col.DeleteIndex(cmd.Context(), nameArg, opt)
 		},
 	}
 
-	EmbedCLIExample(ctx, cmd, "drop the index 'UsersByName' for 'Users' collection",
-		`defradb client index drop --collection Users --name UsersByName`)
+	EmbedCLIExample(ctx, cmd, "delete the index 'UsersByName' for 'Users' collection",
+		`defradb client index delete --collection Users --name UsersByName`)
 
 	cmd.Flags().StringVarP(&collectionArg, "collection", "c", "", "Collection name")
 	cmd.Flags().StringVarP(&nameArg, "name", "n", "", "Index name")

--- a/cli/index_list.go
+++ b/cli/index_list.go
@@ -39,15 +39,15 @@ Otherwise, all indexes in the database will be shown.`,
 				if err != nil {
 					return err
 				}
-				indOpt := options.WithIdentity(options.CollectionGetIndexes(), identity.FromContext(cmd.Context()))
-				indexes, err := col.GetIndexes(cmd.Context(), indOpt)
+				indOpt := options.WithIdentity(options.CollectionListIndexes(), identity.FromContext(cmd.Context()))
+				indexes, err := col.ListIndexes(cmd.Context(), indOpt)
 				if err != nil {
 					return err
 				}
 				return writeJSON(cmd, indexes)
 			default:
-				opt := options.WithIdentity(options.GetAllIndexes(), identity.FromContext(cmd.Context()))
-				indexes, err := cliClient.GetAllIndexes(cmd.Context(), opt)
+				opt := options.WithIdentity(options.ListIndexes(), identity.FromContext(cmd.Context()))
+				indexes, err := cliClient.ListIndexes(cmd.Context(), opt)
 				if err != nil {
 					return err
 				}

--- a/cli/test/action/index_delete.go
+++ b/cli/test/action/index_delete.go
@@ -14,25 +14,25 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// IndexDrop executes the `client index drop` command.
-type IndexDrop struct {
+// IndexDelete executes the `client index delete` command.
+type IndexDelete struct {
 	stateful
 	augmented
 
 	// The collection name containing the index (required).
 	Collection string
 
-	// The name of the index to drop (required).
+	// The name of the index to delete (required).
 	Name string
 
 	// ExpectError is the expected error string. If empty, no error is expected.
 	ExpectError string
 }
 
-var _ Action = (*IndexDrop)(nil)
+var _ Action = (*IndexDelete)(nil)
 
-func (a *IndexDrop) Execute() {
-	args := []string{"client", "index", "drop"}
+func (a *IndexDelete) Execute() {
+	args := []string{"client", "index", "delete"}
 
 	if a.Collection != "" {
 		args = append(args, "--collection", a.Collection)

--- a/cli/test/integration/index/delete_test.go
+++ b/cli/test/integration/index/delete_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/sourcenetwork/defradb/client"
 )
 
-func TestIndexDrop_WithExistingIndex_ShouldSucceed(t *testing.T) {
+func TestIndexDelete_WithExistingIndex_ShouldSucceed(t *testing.T) {
 	test := &integration.Test{
 		Actions: []action.Action{
 			&action.SchemaAdd{
@@ -47,7 +47,7 @@ func TestIndexDrop_WithExistingIndex_ShouldSucceed(t *testing.T) {
 					},
 				},
 			},
-			&action.IndexDrop{
+			&action.IndexDelete{
 				Collection: "User",
 				Name:       "UsersByName",
 			},
@@ -61,10 +61,10 @@ func TestIndexDrop_WithExistingIndex_ShouldSucceed(t *testing.T) {
 	test.Execute(t)
 }
 
-func TestIndexDrop_WithUnknownCollection_ShouldReturnError(t *testing.T) {
+func TestIndexDelete_WithUnknownCollection_ShouldReturnError(t *testing.T) {
 	test := &integration.Test{
 		Actions: []action.Action{
-			&action.IndexDrop{
+			&action.IndexDelete{
 				Collection:  "NonExistentCollection",
 				Name:        "SomeIndex",
 				ExpectError: "collection not found",
@@ -75,10 +75,10 @@ func TestIndexDrop_WithUnknownCollection_ShouldReturnError(t *testing.T) {
 	test.Execute(t)
 }
 
-func TestIndexDrop_WithoutCollection_ShouldReturnError(t *testing.T) {
+func TestIndexDelete_WithoutCollection_ShouldReturnError(t *testing.T) {
 	test := &integration.Test{
 		Actions: []action.Action{
-			&action.IndexDrop{
+			&action.IndexDelete{
 				// Collection is empty
 				Name:        "SomeIndex",
 				ExpectError: "collection not found",
@@ -89,7 +89,7 @@ func TestIndexDrop_WithoutCollection_ShouldReturnError(t *testing.T) {
 	test.Execute(t)
 }
 
-func TestIndexDrop_WithoutName_ShouldReturnError(t *testing.T) {
+func TestIndexDelete_WithoutName_ShouldReturnError(t *testing.T) {
 	test := &integration.Test{
 		Actions: []action.Action{
 			&action.SchemaAdd{
@@ -99,7 +99,7 @@ func TestIndexDrop_WithoutName_ShouldReturnError(t *testing.T) {
 					}
 				`,
 			},
-			&action.IndexDrop{
+			&action.IndexDelete{
 				Collection: "User",
 				// Name is empty
 				ExpectError: "malformed document ID",
@@ -110,7 +110,7 @@ func TestIndexDrop_WithoutName_ShouldReturnError(t *testing.T) {
 	test.Execute(t)
 }
 
-func TestIndexDrop_WithNonExistentIndex_ShouldReturnError(t *testing.T) {
+func TestIndexDelete_WithNonExistentIndex_ShouldReturnError(t *testing.T) {
 	test := &integration.Test{
 		Actions: []action.Action{
 			&action.SchemaAdd{
@@ -121,7 +121,7 @@ func TestIndexDrop_WithNonExistentIndex_ShouldReturnError(t *testing.T) {
 					}
 				`,
 			},
-			&action.IndexDrop{
+			&action.IndexDelete{
 				Collection:  "User",
 				Name:        "NonExistentIndex",
 				ExpectError: "index with name doesn't exists",
@@ -132,7 +132,7 @@ func TestIndexDrop_WithNonExistentIndex_ShouldReturnError(t *testing.T) {
 	test.Execute(t)
 }
 
-func TestIndexDrop_WithMultipleIndexes_ShouldDropOnlySpecified(t *testing.T) {
+func TestIndexDelete_WithMultipleIndexes_ShouldDropOnlySpecified(t *testing.T) {
 	test := &integration.Test{
 		Actions: []action.Action{
 			&action.SchemaAdd{
@@ -188,8 +188,8 @@ func TestIndexDrop_WithMultipleIndexes_ShouldDropOnlySpecified(t *testing.T) {
 					},
 				},
 			},
-			// Drop one index
-			&action.IndexDrop{
+			// Delete one index
+			&action.IndexDelete{
 				Collection: "User",
 				Name:       "UsersByAge",
 			},

--- a/client/collection.go
+++ b/client/collection.go
@@ -120,13 +120,17 @@ type Collection interface {
 		...options.Enumerable[options.CollectionCreateIndexOptions],
 	) (IndexDescription, error)
 
-	// DropIndex drops an index from the collection.
-	DropIndex(ctx context.Context, indexName string, opts ...options.Enumerable[options.CollectionDropIndexOptions]) error
-
-	// GetIndexes returns all the indexes that exist on the collection.
-	GetIndexes(
+	// DeleteIndex deletes an index from the collection.
+	DeleteIndex(
 		ctx context.Context,
-		opts ...options.Enumerable[options.CollectionGetIndexesOptions],
+		indexName string,
+		opts ...options.Enumerable[options.CollectionDeleteIndexOptions],
+	) error
+
+	// ListIndexes returns all the indexes that exist on the collection.
+	ListIndexes(
+		ctx context.Context,
+		opts ...options.Enumerable[options.CollectionListIndexesOptions],
 	) ([]IndexDescription, error)
 
 	// AddEncryptedIndex adds a new encrypted index to the collection.

--- a/client/db.go
+++ b/client/db.go
@@ -323,10 +323,10 @@ type Store interface {
 	// made via the returned [Collection]s will respect that transaction.
 	GetCollections(ctx context.Context, opts ...options.Enumerable[options.GetCollectionsOptions]) ([]Collection, error)
 
-	// GetAllIndexes returns all the indexes that currently exist within this [Store].
-	GetAllIndexes(
+	// ListIndexes returns all the indexes that currently exist within this [Store].
+	ListIndexes(
 		ctx context.Context,
-		opts ...options.Enumerable[options.GetAllIndexesOptions],
+		opts ...options.Enumerable[options.ListIndexesOptions],
 	) (map[CollectionName][]IndexDescription, error)
 
 	// ListAllEncryptedIndexes returns all the encrypted indexes that currently exist within this [Store].

--- a/client/mocks/collection.go
+++ b/client/mocks/collection.go
@@ -542,6 +542,78 @@ func (_c *Collection_DeleteEncryptedIndex_Call) RunAndReturn(run func(ctx contex
 	return _c
 }
 
+// DeleteIndex provides a mock function for the type Collection
+func (_mock *Collection) DeleteIndex(ctx context.Context, indexName string, opts ...options.Enumerable[options.CollectionDeleteIndexOptions]) error {
+	var tmpRet mock.Arguments
+	if len(opts) > 0 {
+		tmpRet = _mock.Called(ctx, indexName, opts)
+	} else {
+		tmpRet = _mock.Called(ctx, indexName)
+	}
+	ret := tmpRet
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteIndex")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, ...options.Enumerable[options.CollectionDeleteIndexOptions]) error); ok {
+		r0 = returnFunc(ctx, indexName, opts...)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// Collection_DeleteIndex_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteIndex'
+type Collection_DeleteIndex_Call struct {
+	*mock.Call
+}
+
+// DeleteIndex is a helper method to define mock.On call
+//   - ctx context.Context
+//   - indexName string
+//   - opts ...options.Enumerable[options.CollectionDeleteIndexOptions]
+func (_e *Collection_Expecter) DeleteIndex(ctx interface{}, indexName interface{}, opts ...interface{}) *Collection_DeleteIndex_Call {
+	return &Collection_DeleteIndex_Call{Call: _e.mock.On("DeleteIndex",
+		append([]interface{}{ctx, indexName}, opts...)...)}
+}
+
+func (_c *Collection_DeleteIndex_Call) Run(run func(ctx context.Context, indexName string, opts ...options.Enumerable[options.CollectionDeleteIndexOptions])) *Collection_DeleteIndex_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 []options.Enumerable[options.CollectionDeleteIndexOptions]
+		var variadicArgs []options.Enumerable[options.CollectionDeleteIndexOptions]
+		if len(args) > 2 {
+			variadicArgs = args[2].([]options.Enumerable[options.CollectionDeleteIndexOptions])
+		}
+		arg2 = variadicArgs
+		run(
+			arg0,
+			arg1,
+			arg2...,
+		)
+	})
+	return _c
+}
+
+func (_c *Collection_DeleteIndex_Call) Return(err error) *Collection_DeleteIndex_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *Collection_DeleteIndex_Call) RunAndReturn(run func(ctx context.Context, indexName string, opts ...options.Enumerable[options.CollectionDeleteIndexOptions]) error) *Collection_DeleteIndex_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // DeleteWithFilter provides a mock function for the type Collection
 func (_mock *Collection) DeleteWithFilter(ctx context.Context, filter any, opts ...options.Enumerable[options.CollectionDeleteWithFilterOptions]) (*client.DeleteResult, error) {
 	var tmpRet mock.Arguments
@@ -621,78 +693,6 @@ func (_c *Collection_DeleteWithFilter_Call) Return(deleteResult *client.DeleteRe
 }
 
 func (_c *Collection_DeleteWithFilter_Call) RunAndReturn(run func(ctx context.Context, filter any, opts ...options.Enumerable[options.CollectionDeleteWithFilterOptions]) (*client.DeleteResult, error)) *Collection_DeleteWithFilter_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// DropIndex provides a mock function for the type Collection
-func (_mock *Collection) DropIndex(ctx context.Context, indexName string, opts ...options.Enumerable[options.CollectionDropIndexOptions]) error {
-	var tmpRet mock.Arguments
-	if len(opts) > 0 {
-		tmpRet = _mock.Called(ctx, indexName, opts)
-	} else {
-		tmpRet = _mock.Called(ctx, indexName)
-	}
-	ret := tmpRet
-
-	if len(ret) == 0 {
-		panic("no return value specified for DropIndex")
-	}
-
-	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, ...options.Enumerable[options.CollectionDropIndexOptions]) error); ok {
-		r0 = returnFunc(ctx, indexName, opts...)
-	} else {
-		r0 = ret.Error(0)
-	}
-	return r0
-}
-
-// Collection_DropIndex_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DropIndex'
-type Collection_DropIndex_Call struct {
-	*mock.Call
-}
-
-// DropIndex is a helper method to define mock.On call
-//   - ctx context.Context
-//   - indexName string
-//   - opts ...options.Enumerable[options.CollectionDropIndexOptions]
-func (_e *Collection_Expecter) DropIndex(ctx interface{}, indexName interface{}, opts ...interface{}) *Collection_DropIndex_Call {
-	return &Collection_DropIndex_Call{Call: _e.mock.On("DropIndex",
-		append([]interface{}{ctx, indexName}, opts...)...)}
-}
-
-func (_c *Collection_DropIndex_Call) Run(run func(ctx context.Context, indexName string, opts ...options.Enumerable[options.CollectionDropIndexOptions])) *Collection_DropIndex_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		var arg1 string
-		if args[1] != nil {
-			arg1 = args[1].(string)
-		}
-		var arg2 []options.Enumerable[options.CollectionDropIndexOptions]
-		var variadicArgs []options.Enumerable[options.CollectionDropIndexOptions]
-		if len(args) > 2 {
-			variadicArgs = args[2].([]options.Enumerable[options.CollectionDropIndexOptions])
-		}
-		arg2 = variadicArgs
-		run(
-			arg0,
-			arg1,
-			arg2...,
-		)
-	})
-	return _c
-}
-
-func (_c *Collection_DropIndex_Call) Return(err error) *Collection_DropIndex_Call {
-	_c.Call.Return(err)
-	return _c
-}
-
-func (_c *Collection_DropIndex_Call) RunAndReturn(run func(ctx context.Context, indexName string, opts ...options.Enumerable[options.CollectionDropIndexOptions]) error) *Collection_DropIndex_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -938,83 +938,6 @@ func (_c *Collection_GetAllDocIDs_Call) RunAndReturn(run func(ctx context.Contex
 	return _c
 }
 
-// GetIndexes provides a mock function for the type Collection
-func (_mock *Collection) GetIndexes(ctx context.Context, opts ...options.Enumerable[options.CollectionGetIndexesOptions]) ([]client.IndexDescription, error) {
-	var tmpRet mock.Arguments
-	if len(opts) > 0 {
-		tmpRet = _mock.Called(ctx, opts)
-	} else {
-		tmpRet = _mock.Called(ctx)
-	}
-	ret := tmpRet
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetIndexes")
-	}
-
-	var r0 []client.IndexDescription
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, ...options.Enumerable[options.CollectionGetIndexesOptions]) ([]client.IndexDescription, error)); ok {
-		return returnFunc(ctx, opts...)
-	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, ...options.Enumerable[options.CollectionGetIndexesOptions]) []client.IndexDescription); ok {
-		r0 = returnFunc(ctx, opts...)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]client.IndexDescription)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, ...options.Enumerable[options.CollectionGetIndexesOptions]) error); ok {
-		r1 = returnFunc(ctx, opts...)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// Collection_GetIndexes_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetIndexes'
-type Collection_GetIndexes_Call struct {
-	*mock.Call
-}
-
-// GetIndexes is a helper method to define mock.On call
-//   - ctx context.Context
-//   - opts ...options.Enumerable[options.CollectionGetIndexesOptions]
-func (_e *Collection_Expecter) GetIndexes(ctx interface{}, opts ...interface{}) *Collection_GetIndexes_Call {
-	return &Collection_GetIndexes_Call{Call: _e.mock.On("GetIndexes",
-		append([]interface{}{ctx}, opts...)...)}
-}
-
-func (_c *Collection_GetIndexes_Call) Run(run func(ctx context.Context, opts ...options.Enumerable[options.CollectionGetIndexesOptions])) *Collection_GetIndexes_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		var arg1 []options.Enumerable[options.CollectionGetIndexesOptions]
-		var variadicArgs []options.Enumerable[options.CollectionGetIndexesOptions]
-		if len(args) > 1 {
-			variadicArgs = args[1].([]options.Enumerable[options.CollectionGetIndexesOptions])
-		}
-		arg1 = variadicArgs
-		run(
-			arg0,
-			arg1...,
-		)
-	})
-	return _c
-}
-
-func (_c *Collection_GetIndexes_Call) Return(indexDescriptions []client.IndexDescription, err error) *Collection_GetIndexes_Call {
-	_c.Call.Return(indexDescriptions, err)
-	return _c
-}
-
-func (_c *Collection_GetIndexes_Call) RunAndReturn(run func(ctx context.Context, opts ...options.Enumerable[options.CollectionGetIndexesOptions]) ([]client.IndexDescription, error)) *Collection_GetIndexes_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // ListEncryptedIndexes provides a mock function for the type Collection
 func (_mock *Collection) ListEncryptedIndexes(ctx context.Context, opts ...options.Enumerable[options.CollectionListEncryptedIndexesOptions]) ([]client.EncryptedIndexDescription, error) {
 	var tmpRet mock.Arguments
@@ -1088,6 +1011,83 @@ func (_c *Collection_ListEncryptedIndexes_Call) Return(encryptedIndexDescription
 }
 
 func (_c *Collection_ListEncryptedIndexes_Call) RunAndReturn(run func(ctx context.Context, opts ...options.Enumerable[options.CollectionListEncryptedIndexesOptions]) ([]client.EncryptedIndexDescription, error)) *Collection_ListEncryptedIndexes_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ListIndexes provides a mock function for the type Collection
+func (_mock *Collection) ListIndexes(ctx context.Context, opts ...options.Enumerable[options.CollectionListIndexesOptions]) ([]client.IndexDescription, error) {
+	var tmpRet mock.Arguments
+	if len(opts) > 0 {
+		tmpRet = _mock.Called(ctx, opts)
+	} else {
+		tmpRet = _mock.Called(ctx)
+	}
+	ret := tmpRet
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListIndexes")
+	}
+
+	var r0 []client.IndexDescription
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, ...options.Enumerable[options.CollectionListIndexesOptions]) ([]client.IndexDescription, error)); ok {
+		return returnFunc(ctx, opts...)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, ...options.Enumerable[options.CollectionListIndexesOptions]) []client.IndexDescription); ok {
+		r0 = returnFunc(ctx, opts...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]client.IndexDescription)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, ...options.Enumerable[options.CollectionListIndexesOptions]) error); ok {
+		r1 = returnFunc(ctx, opts...)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// Collection_ListIndexes_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListIndexes'
+type Collection_ListIndexes_Call struct {
+	*mock.Call
+}
+
+// ListIndexes is a helper method to define mock.On call
+//   - ctx context.Context
+//   - opts ...options.Enumerable[options.CollectionListIndexesOptions]
+func (_e *Collection_Expecter) ListIndexes(ctx interface{}, opts ...interface{}) *Collection_ListIndexes_Call {
+	return &Collection_ListIndexes_Call{Call: _e.mock.On("ListIndexes",
+		append([]interface{}{ctx}, opts...)...)}
+}
+
+func (_c *Collection_ListIndexes_Call) Run(run func(ctx context.Context, opts ...options.Enumerable[options.CollectionListIndexesOptions])) *Collection_ListIndexes_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 []options.Enumerable[options.CollectionListIndexesOptions]
+		var variadicArgs []options.Enumerable[options.CollectionListIndexesOptions]
+		if len(args) > 1 {
+			variadicArgs = args[1].([]options.Enumerable[options.CollectionListIndexesOptions])
+		}
+		arg1 = variadicArgs
+		run(
+			arg0,
+			arg1...,
+		)
+	})
+	return _c
+}
+
+func (_c *Collection_ListIndexes_Call) Return(indexDescriptions []client.IndexDescription, err error) *Collection_ListIndexes_Call {
+	_c.Call.Return(indexDescriptions, err)
+	return _c
+}
+
+func (_c *Collection_ListIndexes_Call) RunAndReturn(run func(ctx context.Context, opts ...options.Enumerable[options.CollectionListIndexesOptions]) ([]client.IndexDescription, error)) *Collection_ListIndexes_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/client/mocks/txn.go
+++ b/client/mocks/txn.go
@@ -1677,83 +1677,6 @@ func (_c *Txn_ExecRequest_Call) RunAndReturn(run func(ctx context.Context, reque
 	return _c
 }
 
-// GetAllIndexes provides a mock function for the type Txn
-func (_mock *Txn) GetAllIndexes(ctx context.Context, opts ...options.Enumerable[options.GetAllIndexesOptions]) (map[client.CollectionName][]client.IndexDescription, error) {
-	var tmpRet mock.Arguments
-	if len(opts) > 0 {
-		tmpRet = _mock.Called(ctx, opts)
-	} else {
-		tmpRet = _mock.Called(ctx)
-	}
-	ret := tmpRet
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetAllIndexes")
-	}
-
-	var r0 map[client.CollectionName][]client.IndexDescription
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, ...options.Enumerable[options.GetAllIndexesOptions]) (map[client.CollectionName][]client.IndexDescription, error)); ok {
-		return returnFunc(ctx, opts...)
-	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, ...options.Enumerable[options.GetAllIndexesOptions]) map[client.CollectionName][]client.IndexDescription); ok {
-		r0 = returnFunc(ctx, opts...)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(map[client.CollectionName][]client.IndexDescription)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, ...options.Enumerable[options.GetAllIndexesOptions]) error); ok {
-		r1 = returnFunc(ctx, opts...)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// Txn_GetAllIndexes_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAllIndexes'
-type Txn_GetAllIndexes_Call struct {
-	*mock.Call
-}
-
-// GetAllIndexes is a helper method to define mock.On call
-//   - ctx context.Context
-//   - opts ...options.Enumerable[options.GetAllIndexesOptions]
-func (_e *Txn_Expecter) GetAllIndexes(ctx interface{}, opts ...interface{}) *Txn_GetAllIndexes_Call {
-	return &Txn_GetAllIndexes_Call{Call: _e.mock.On("GetAllIndexes",
-		append([]interface{}{ctx}, opts...)...)}
-}
-
-func (_c *Txn_GetAllIndexes_Call) Run(run func(ctx context.Context, opts ...options.Enumerable[options.GetAllIndexesOptions])) *Txn_GetAllIndexes_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		var arg1 []options.Enumerable[options.GetAllIndexesOptions]
-		var variadicArgs []options.Enumerable[options.GetAllIndexesOptions]
-		if len(args) > 1 {
-			variadicArgs = args[1].([]options.Enumerable[options.GetAllIndexesOptions])
-		}
-		arg1 = variadicArgs
-		run(
-			arg0,
-			arg1...,
-		)
-	})
-	return _c
-}
-
-func (_c *Txn_GetAllIndexes_Call) Return(vToIndexDescriptions map[client.CollectionName][]client.IndexDescription, err error) *Txn_GetAllIndexes_Call {
-	_c.Call.Return(vToIndexDescriptions, err)
-	return _c
-}
-
-func (_c *Txn_GetAllIndexes_Call) RunAndReturn(run func(ctx context.Context, opts ...options.Enumerable[options.GetAllIndexesOptions]) (map[client.CollectionName][]client.IndexDescription, error)) *Txn_GetAllIndexes_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // GetCollectionByName provides a mock function for the type Txn
 func (_mock *Txn) GetCollectionByName(ctx context.Context, name client.CollectionName, opts ...options.Enumerable[options.GetCollectionByNameOptions]) (client.Collection, error) {
 	var tmpRet mock.Arguments
@@ -2166,6 +2089,83 @@ func (_c *Txn_ListAllEncryptedIndexes_Call) Return(vToEncryptedIndexDescriptions
 }
 
 func (_c *Txn_ListAllEncryptedIndexes_Call) RunAndReturn(run func(context1 context.Context, vs ...options.Enumerable[options.ListAllEncryptedIndexesOptions]) (map[client.CollectionName][]client.EncryptedIndexDescription, error)) *Txn_ListAllEncryptedIndexes_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ListIndexes provides a mock function for the type Txn
+func (_mock *Txn) ListIndexes(ctx context.Context, opts ...options.Enumerable[options.ListIndexesOptions]) (map[client.CollectionName][]client.IndexDescription, error) {
+	var tmpRet mock.Arguments
+	if len(opts) > 0 {
+		tmpRet = _mock.Called(ctx, opts)
+	} else {
+		tmpRet = _mock.Called(ctx)
+	}
+	ret := tmpRet
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListIndexes")
+	}
+
+	var r0 map[client.CollectionName][]client.IndexDescription
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, ...options.Enumerable[options.ListIndexesOptions]) (map[client.CollectionName][]client.IndexDescription, error)); ok {
+		return returnFunc(ctx, opts...)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, ...options.Enumerable[options.ListIndexesOptions]) map[client.CollectionName][]client.IndexDescription); ok {
+		r0 = returnFunc(ctx, opts...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[client.CollectionName][]client.IndexDescription)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, ...options.Enumerable[options.ListIndexesOptions]) error); ok {
+		r1 = returnFunc(ctx, opts...)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// Txn_ListIndexes_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListIndexes'
+type Txn_ListIndexes_Call struct {
+	*mock.Call
+}
+
+// ListIndexes is a helper method to define mock.On call
+//   - ctx context.Context
+//   - opts ...options.Enumerable[options.ListIndexesOptions]
+func (_e *Txn_Expecter) ListIndexes(ctx interface{}, opts ...interface{}) *Txn_ListIndexes_Call {
+	return &Txn_ListIndexes_Call{Call: _e.mock.On("ListIndexes",
+		append([]interface{}{ctx}, opts...)...)}
+}
+
+func (_c *Txn_ListIndexes_Call) Run(run func(ctx context.Context, opts ...options.Enumerable[options.ListIndexesOptions])) *Txn_ListIndexes_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 []options.Enumerable[options.ListIndexesOptions]
+		var variadicArgs []options.Enumerable[options.ListIndexesOptions]
+		if len(args) > 1 {
+			variadicArgs = args[1].([]options.Enumerable[options.ListIndexesOptions])
+		}
+		arg1 = variadicArgs
+		run(
+			arg0,
+			arg1...,
+		)
+	})
+	return _c
+}
+
+func (_c *Txn_ListIndexes_Call) Return(vToIndexDescriptions map[client.CollectionName][]client.IndexDescription, err error) *Txn_ListIndexes_Call {
+	_c.Call.Return(vToIndexDescriptions, err)
+	return _c
+}
+
+func (_c *Txn_ListIndexes_Call) RunAndReturn(run func(ctx context.Context, opts ...options.Enumerable[options.ListIndexesOptions]) (map[client.CollectionName][]client.IndexDescription, error)) *Txn_ListIndexes_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/client/options/collection.go
+++ b/client/options/collection.go
@@ -265,59 +265,59 @@ func (b *CollectionCreateIndexOptionsBuilder) SetIdentity(id identity.Identity) 
 	return b
 }
 
-// CollectionDropIndexOptions contains options for DropIndex operation.
-type CollectionDropIndexOptions struct {
+// CollectionDeleteIndexOptions contains options for DeleteIndex operation.
+type CollectionDeleteIndexOptions struct {
 	// Identity is the identity of the actor performing the operation.
 	Identity immutable.Option[identity.Identity]
 }
 
 // GetIdentity returns the identity for the operation.
-func (o *CollectionDropIndexOptions) GetIdentity() immutable.Option[identity.Identity] {
+func (o *CollectionDeleteIndexOptions) GetIdentity() immutable.Option[identity.Identity] {
 	return o.Identity
 }
 
-// CollectionDropIndexOptionsBuilder is a builder for CollectionDropIndexOptions.
-type CollectionDropIndexOptionsBuilder struct {
-	enumerableBuilder[CollectionDropIndexOptions]
+// CollectionDeleteIndexOptionsBuilder is a builder for CollectionDeleteIndexOptions.
+type CollectionDeleteIndexOptionsBuilder struct {
+	enumerableBuilder[CollectionDeleteIndexOptions]
 }
 
-// CollectionDropIndex creates a new CollectionDropIndexOptionsBuilder instance.
-func CollectionDropIndex() *CollectionDropIndexOptionsBuilder {
-	return &CollectionDropIndexOptionsBuilder{}
+// CollectionDeleteIndex creates a new CollectionDeleteIndexOptionsBuilder instance.
+func CollectionDeleteIndex() *CollectionDeleteIndexOptionsBuilder {
+	return &CollectionDeleteIndexOptionsBuilder{}
 }
 
 // SetIdentity sets the identity for the operation.
-func (b *CollectionDropIndexOptionsBuilder) SetIdentity(id identity.Identity) *CollectionDropIndexOptionsBuilder {
-	b.append(func(opts *CollectionDropIndexOptions) {
+func (b *CollectionDeleteIndexOptionsBuilder) SetIdentity(id identity.Identity) *CollectionDeleteIndexOptionsBuilder {
+	b.append(func(opts *CollectionDeleteIndexOptions) {
 		opts.Identity = immutable.Some(id)
 	})
 	return b
 }
 
-// CollectionGetIndexesOptions contains options for GetIndexes operation.
-type CollectionGetIndexesOptions struct {
+// CollectionListIndexesOptions contains options for ListIndexes operation.
+type CollectionListIndexesOptions struct {
 	// Identity is the identity of the actor performing the operation.
 	Identity immutable.Option[identity.Identity]
 }
 
 // GetIdentity returns the identity for the operation.
-func (o *CollectionGetIndexesOptions) GetIdentity() immutable.Option[identity.Identity] {
+func (o *CollectionListIndexesOptions) GetIdentity() immutable.Option[identity.Identity] {
 	return o.Identity
 }
 
-// CollectionGetIndexesOptionsBuilder is a builder for CollectionGetIndexesOptions.
-type CollectionGetIndexesOptionsBuilder struct {
-	enumerableBuilder[CollectionGetIndexesOptions]
+// CollectionListIndexesOptionsBuilder is a builder for CollectionListIndexesOptions.
+type CollectionListIndexesOptionsBuilder struct {
+	enumerableBuilder[CollectionListIndexesOptions]
 }
 
-// CollectionGetIndexes creates a new CollectionGetIndexesOptionsBuilder instance.
-func CollectionGetIndexes() *CollectionGetIndexesOptionsBuilder {
-	return &CollectionGetIndexesOptionsBuilder{}
+// CollectionListIndexes creates a new CollectionListIndexesOptionsBuilder instance.
+func CollectionListIndexes() *CollectionListIndexesOptionsBuilder {
+	return &CollectionListIndexesOptionsBuilder{}
 }
 
 // SetIdentity sets the identity for the operation.
-func (b *CollectionGetIndexesOptionsBuilder) SetIdentity(id identity.Identity) *CollectionGetIndexesOptionsBuilder {
-	b.append(func(opts *CollectionGetIndexesOptions) {
+func (b *CollectionListIndexesOptionsBuilder) SetIdentity(id identity.Identity) *CollectionListIndexesOptionsBuilder {
+	b.append(func(opts *CollectionListIndexesOptions) {
 		opts.Identity = immutable.Some(id)
 	})
 	return b

--- a/client/options/store.go
+++ b/client/options/store.go
@@ -446,30 +446,30 @@ func (b *GetCollectionsOptionsBuilder) SetGetInactive(getInactive bool) *GetColl
 	return b
 }
 
-// GetAllIndexesOptions contains options for GetAllIndexes operation.
-type GetAllIndexesOptions struct {
+// ListIndexesOptions contains options for ListIndexes operation.
+type ListIndexesOptions struct {
 	// Identity is the identity of the actor performing the operation.
 	Identity immutable.Option[identity.Identity]
 }
 
 // GetIdentity returns the identity for the operation.
-func (o *GetAllIndexesOptions) GetIdentity() immutable.Option[identity.Identity] {
+func (o *ListIndexesOptions) GetIdentity() immutable.Option[identity.Identity] {
 	return o.Identity
 }
 
-// GetAllIndexesOptionsBuilder is a builder for GetAllIndexesOptions.
-type GetAllIndexesOptionsBuilder struct {
-	enumerableBuilder[GetAllIndexesOptions]
+// ListIndexesOptionsBuilder is a builder for ListIndexesOptions.
+type ListIndexesOptionsBuilder struct {
+	enumerableBuilder[ListIndexesOptions]
 }
 
-// GetAllIndexes creates a new GetAllIndexesOptionsBuilder instance.
-func GetAllIndexes() *GetAllIndexesOptionsBuilder {
-	return &GetAllIndexesOptionsBuilder{}
+// ListIndexes creates a new ListIndexesOptionsBuilder instance.
+func ListIndexes() *ListIndexesOptionsBuilder {
+	return &ListIndexesOptionsBuilder{}
 }
 
 // SetIdentity sets the identity for the operation.
-func (b *GetAllIndexesOptionsBuilder) SetIdentity(id identity.Identity) *GetAllIndexesOptionsBuilder {
-	b.append(func(opts *GetAllIndexesOptions) {
+func (b *ListIndexesOptionsBuilder) SetIdentity(id identity.Identity) *ListIndexesOptionsBuilder {
+	b.append(func(opts *ListIndexesOptions) {
 		opts.Identity = immutable.Some(id)
 	})
 	return b

--- a/docs/website/references/cli/defradb_client_index.md
+++ b/docs/website/references/cli/defradb_client_index.md
@@ -4,7 +4,7 @@ Manage collections' indexes of a running DefraDB instance
 
 ### Synopsis
 
-Manage (create, drop, or list) collection indexes on a DefraDB node.
+Manage (create, delete, or list) collection indexes on a DefraDB node.
 
 ### Options
 
@@ -38,6 +38,6 @@ Manage (create, drop, or list) collection indexes on a DefraDB node.
 
 * [defradb client](defradb_client.md)	 - Interact with a DefraDB node
 * [defradb client index create](defradb_client_index_create.md)	 - Creates a secondary index on a collection's field(s)
-* [defradb client index drop](defradb_client_index_drop.md)	 - Drop a collection's secondary index
+* [defradb client index delete](defradb_client_index_delete.md)	 - Delete a collection's secondary index
 * [defradb client index list](defradb_client_index_list.md)	 - Shows the list indexes in the database or for a specific collection
 

--- a/docs/website/references/cli/defradb_client_index_delete.md
+++ b/docs/website/references/cli/defradb_client_index_delete.md
@@ -1,27 +1,27 @@
-## defradb client index drop
+## defradb client index delete
 
-Drop a collection's secondary index
+Delete a collection's secondary index
 
 ### Synopsis
 
-Drop a collection's secondary index.
+Delete a collection's secondary index.
 
 ```
-defradb client index drop -c --collection <collection> -n --name <name> [flags]
+defradb client index delete -c --collection <collection> -n --name <name> [flags]
 ```
 
 ### Examples
 
 ```
-drop the index 'UsersByName' for 'Users' collection:  
-  defradb client index drop --collection Users --name UsersByName
+delete the index 'UsersByName' for 'Users' collection:  
+  defradb client index delete --collection Users --name UsersByName
 ```
 
 ### Options
 
 ```
   -c, --collection string   Collection name
-  -h, --help                help for drop
+  -h, --help                help for delete
   -n, --name string         Index name
 ```
 

--- a/docs/website/references/http/openapi.json
+++ b/docs/website/references/http/openapi.json
@@ -1671,7 +1671,7 @@
         "/collections/{name}/indexes/{index}": {
             "delete": {
                 "description": "Delete a secondary index",
-                "operationId": "index_drop",
+                "operationId": "index_delete",
                 "parameters": [
                     {
                         "description": "Collection name",

--- a/http/client.go
+++ b/http/client.go
@@ -406,9 +406,9 @@ func (c *Client) GetCollections(
 	return collections, nil
 }
 
-func (c *Client) GetAllIndexes(
+func (c *Client) ListIndexes(
 	ctx context.Context,
-	opts ...options.Enumerable[options.GetAllIndexesOptions],
+	opts ...options.Enumerable[options.ListIndexesOptions],
 ) (map[client.CollectionName][]client.IndexDescription, error) {
 	opt := utils.NewOptions(opts...)
 	ctx = identity.WithContext(ctx, opt.GetIdentity())

--- a/http/client_collection.go
+++ b/http/client_collection.go
@@ -408,10 +408,10 @@ func (c *Collection) CreateIndex(
 	return index, nil
 }
 
-func (c *Collection) DropIndex(
+func (c *Collection) DeleteIndex(
 	ctx context.Context,
 	indexName string,
-	opts ...options.Enumerable[options.CollectionDropIndexOptions],
+	opts ...options.Enumerable[options.CollectionDeleteIndexOptions],
 ) error {
 	opt := utils.NewOptions(opts...)
 	ctx = identity.WithContext(ctx, opt.GetIdentity())
@@ -426,9 +426,9 @@ func (c *Collection) DropIndex(
 	return err
 }
 
-func (c *Collection) GetIndexes(
+func (c *Collection) ListIndexes(
 	ctx context.Context,
-	opts ...options.Enumerable[options.CollectionGetIndexesOptions],
+	opts ...options.Enumerable[options.CollectionListIndexesOptions],
 ) ([]client.IndexDescription, error) {
 	opt := utils.NewOptions(opts...)
 	ctx = identity.WithContext(ctx, opt.GetIdentity())

--- a/http/client_tx.go
+++ b/http/client_tx.go
@@ -210,12 +210,12 @@ func (txn *Transaction) GetCollections(
 	return txn.Client.GetCollections(ctx, opts...)
 }
 
-func (txn *Transaction) GetAllIndexes(
+func (txn *Transaction) ListIndexes(
 	ctx context.Context,
-	opts ...options.Enumerable[options.GetAllIndexesOptions],
+	opts ...options.Enumerable[options.ListIndexesOptions],
 ) (map[client.CollectionName][]client.IndexDescription, error) {
 	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
-	return txn.Client.GetAllIndexes(ctx, opts...)
+	return txn.Client.ListIndexes(ctx, opts...)
 }
 
 func (txn *Transaction) ListAllEncryptedIndexes(

--- a/http/handler_collection.go
+++ b/http/handler_collection.go
@@ -309,7 +309,7 @@ func (h *collectionHandler) CreateIndex(rw http.ResponseWriter, req *http.Reques
 	responseJSON(rw, http.StatusOK, index)
 }
 
-func (h *collectionHandler) GetIndexes(rw http.ResponseWriter, req *http.Request) {
+func (h *collectionHandler) ListIndexes(rw http.ResponseWriter, req *http.Request) {
 	db := mustGetContextClientDB(req)
 	ctx := req.Context()
 	name := chi.URLParam(req, "name")
@@ -320,9 +320,9 @@ func (h *collectionHandler) GetIndexes(rw http.ResponseWriter, req *http.Request
 		return
 	}
 
-	getIndexesOpt := options.WithIdentity(options.CollectionGetIndexes(), ident)
+	listIndexesOpt := options.WithIdentity(options.CollectionListIndexes(), ident)
 
-	indexes, err := col.GetIndexes(ctx, getIndexesOpt)
+	indexes, err := col.ListIndexes(ctx, listIndexesOpt)
 	if err != nil {
 		responseJSON(rw, http.StatusInternalServerError, errorResponse{err})
 		return
@@ -330,13 +330,13 @@ func (h *collectionHandler) GetIndexes(rw http.ResponseWriter, req *http.Request
 	responseJSON(rw, http.StatusOK, indexes)
 }
 
-func (h *collectionHandler) DropIndex(rw http.ResponseWriter, req *http.Request) {
+func (h *collectionHandler) DeleteIndex(rw http.ResponseWriter, req *http.Request) {
 	col := mustGetContextClientCollection(req)
 	ctx := req.Context()
 
-	dropIndexOpt := options.WithIdentity(options.CollectionDropIndex(), identity.FromContext(ctx))
+	deleteIndexOpt := options.WithIdentity(options.CollectionDeleteIndex(), identity.FromContext(ctx))
 
-	err := col.DropIndex(ctx, chi.URLParam(req, "index"), dropIndexOpt)
+	err := col.DeleteIndex(ctx, chi.URLParam(req, "index"), deleteIndexOpt)
 	if err != nil {
 		responseJSON(rw, http.StatusBadRequest, errorResponse{err})
 		return
@@ -533,31 +533,31 @@ func (h *collectionHandler) bindRoutes(router *Router) {
 	indexArraySchema := openapi3.NewArraySchema()
 	indexArraySchema.Items = indexSchema
 
-	getIndexesResponse := openapi3.NewResponse().
+	listIndexesResponse := openapi3.NewResponse().
 		WithDescription("List of indexes").
 		WithJSONSchema(indexArraySchema)
 
-	getIndexes := openapi3.NewOperation()
-	getIndexes.OperationID = "index_list"
-	getIndexes.Description = "List secondary indexes"
-	getIndexes.Tags = []string{"index"}
-	getIndexes.AddParameter(collectionNamePathParam)
-	getIndexes.AddResponse(200, getIndexesResponse)
-	getIndexes.Responses.Set("400", errorResponse)
+	listIndexes := openapi3.NewOperation()
+	listIndexes.OperationID = "index_list"
+	listIndexes.Description = "List secondary indexes"
+	listIndexes.Tags = []string{"index"}
+	listIndexes.AddParameter(collectionNamePathParam)
+	listIndexes.AddResponse(200, listIndexesResponse)
+	listIndexes.Responses.Set("400", errorResponse)
 
 	indexPathParam := openapi3.NewPathParameter("index").
 		WithRequired(true).
 		WithSchema(openapi3.NewStringSchema())
 
-	dropIndex := openapi3.NewOperation()
-	dropIndex.OperationID = "index_drop"
-	dropIndex.Description = "Delete a secondary index"
-	dropIndex.Tags = []string{"index"}
-	dropIndex.AddParameter(collectionNamePathParam)
-	dropIndex.AddParameter(indexPathParam)
-	dropIndex.Responses = openapi3.NewResponses()
-	dropIndex.Responses.Set("200", successResponse)
-	dropIndex.Responses.Set("400", errorResponse)
+	deleteIndex := openapi3.NewOperation()
+	deleteIndex.OperationID = "index_delete"
+	deleteIndex.Description = "Delete a secondary index"
+	deleteIndex.Tags = []string{"index"}
+	deleteIndex.AddParameter(collectionNamePathParam)
+	deleteIndex.AddParameter(indexPathParam)
+	deleteIndex.Responses = openapi3.NewResponses()
+	deleteIndex.Responses.Set("200", successResponse)
+	deleteIndex.Responses.Set("400", errorResponse)
 
 	documentIDPathParam := openapi3.NewPathParameter("docID").
 		WithRequired(true).
@@ -668,8 +668,8 @@ func (h *collectionHandler) bindRoutes(router *Router) {
 	router.AddRoute("/collections/{name}", http.MethodPatch, collectionUpdateWith, h.UpdateWithFilter)
 	router.AddRoute("/collections/{name}", http.MethodDelete, collectionDeleteWith, h.DeleteWithFilter)
 	router.AddRoute("/collections/{name}/indexes", http.MethodPost, createIndex, h.CreateIndex)
-	router.AddRoute("/collections/{name}/indexes", http.MethodGet, getIndexes, h.GetIndexes)
-	router.AddRoute("/collections/{name}/indexes/{index}", http.MethodDelete, dropIndex, h.DropIndex)
+	router.AddRoute("/collections/{name}/indexes", http.MethodGet, listIndexes, h.ListIndexes)
+	router.AddRoute("/collections/{name}/indexes/{index}", http.MethodDelete, deleteIndex, h.DeleteIndex)
 	router.AddRoute("/collections/{name}/{docID}", http.MethodGet, collectionGet, h.Get)
 	router.AddRoute("/collections/{name}/{docID}", http.MethodPatch, collectionUpdate, h.Update)
 	router.AddRoute("/collections/{name}/{docID}", http.MethodDelete, collectionDelete, h.Delete)

--- a/http/handler_store.go
+++ b/http/handler_store.go
@@ -292,10 +292,10 @@ func (h *storeHandler) RefreshViews(rw http.ResponseWriter, req *http.Request) {
 	rw.WriteHeader(http.StatusOK)
 }
 
-func (h *storeHandler) GetAllIndexes(rw http.ResponseWriter, req *http.Request) {
+func (h *storeHandler) ListIndexes(rw http.ResponseWriter, req *http.Request) {
 	db := mustGetContextClientDB(req)
 
-	indexes, err := db.GetAllIndexes(req.Context())
+	indexes, err := db.ListIndexes(req.Context())
 	if err != nil {
 		responseJSON(rw, http.StatusBadRequest, errorResponse{err})
 		return
@@ -812,21 +812,21 @@ func (h *storeHandler) bindRoutes(router *Router) {
 	indexArraySchema := openapi3.NewArraySchema()
 	indexArraySchema.Items = indexSchema
 
-	getAllIndexesMapSchema := openapi3.NewObjectSchema()
-	getAllIndexesMapSchema.AdditionalProperties = openapi3.AdditionalProperties{
+	listIndexesMapSchema := openapi3.NewObjectSchema()
+	listIndexesMapSchema.AdditionalProperties = openapi3.AdditionalProperties{
 		Schema: openapi3.NewSchemaRef("", indexArraySchema),
 	}
 
-	getAllIndexesResponse := openapi3.NewResponse().
+	listIndexesResponse := openapi3.NewResponse().
 		WithDescription("Map of collection names to their indexes").
-		WithJSONSchema(getAllIndexesMapSchema)
+		WithJSONSchema(listIndexesMapSchema)
 
-	getAllIndexes := openapi3.NewOperation()
-	getAllIndexes.OperationID = "indexes_list_all"
-	getAllIndexes.Description = "List all indexes for all collections"
-	getAllIndexes.Tags = []string{"index"}
-	getAllIndexes.AddResponse(200, getAllIndexesResponse)
-	getAllIndexes.Responses.Set("400", errorResponse)
+	listIndexes := openapi3.NewOperation()
+	listIndexes.OperationID = "indexes_list_all"
+	listIndexes.Description = "List all indexes for all collections"
+	listIndexes.Tags = []string{"index"}
+	listIndexes.AddResponse(200, listIndexesResponse)
+	listIndexes.Responses.Set("400", errorResponse)
 
 	encryptedIndexSchema := &openapi3.SchemaRef{
 		Ref: "#/components/schemas/encrypted_index",
@@ -834,28 +834,28 @@ func (h *storeHandler) bindRoutes(router *Router) {
 	encryptedIndexArraySchema := openapi3.NewArraySchema()
 	encryptedIndexArraySchema.Items = encryptedIndexSchema
 
-	getAllEncryptedIndexesMapSchema := openapi3.NewObjectSchema()
-	getAllEncryptedIndexesMapSchema.AdditionalProperties = openapi3.AdditionalProperties{
+	listEncryptedIndexesMapSchema := openapi3.NewObjectSchema()
+	listEncryptedIndexesMapSchema.AdditionalProperties = openapi3.AdditionalProperties{
 		Schema: openapi3.NewSchemaRef("", encryptedIndexArraySchema),
 	}
 
-	getAllEncryptedIndexesResponse := openapi3.NewResponse().
+	listEncryptedIndexesResponse := openapi3.NewResponse().
 		WithDescription("Map of collection names to their encrypted indexes").
-		WithJSONSchema(getAllEncryptedIndexesMapSchema)
+		WithJSONSchema(listEncryptedIndexesMapSchema)
 
-	getAllEncryptedIndexes := openapi3.NewOperation()
-	getAllEncryptedIndexes.OperationID = "encrypted_indexes_list_all"
-	getAllEncryptedIndexes.Description = "List all encrypted indexes for all collections"
-	getAllEncryptedIndexes.Tags = []string{"encrypted_index"}
-	getAllEncryptedIndexes.AddResponse(200, getAllEncryptedIndexesResponse)
-	getAllEncryptedIndexes.Responses.Set("400", errorResponse)
+	listEncryptedIndexes := openapi3.NewOperation()
+	listEncryptedIndexes.OperationID = "encrypted_indexes_list_all"
+	listEncryptedIndexes.Description = "List all encrypted indexes for all collections"
+	listEncryptedIndexes.Tags = []string{"encrypted_index"}
+	listEncryptedIndexes.AddResponse(200, listEncryptedIndexesResponse)
+	listEncryptedIndexes.Responses.Set("400", errorResponse)
 
 	router.AddRoute("/backup/export", http.MethodPost, backupExport, h.BasicExport)
 	router.AddRoute("/backup/import", http.MethodPost, backupImport, h.BasicImport)
 	router.AddRoute("/collections", http.MethodGet, collectionDescribe, h.GetCollection)
 	router.AddRoute("/collections", http.MethodPatch, patchCollection, h.PatchCollection)
-	router.AddRoute("/collections/indexes", http.MethodGet, getAllIndexes, h.GetAllIndexes)
-	router.AddRoute("/encrypted-indexes", http.MethodGet, getAllEncryptedIndexes, h.ListAllEncryptedIndexes)
+	router.AddRoute("/collections/indexes", http.MethodGet, listIndexes, h.ListIndexes)
+	router.AddRoute("/encrypted-indexes", http.MethodGet, listEncryptedIndexes, h.ListAllEncryptedIndexes)
 	router.AddRoute("/collections/default", http.MethodPost, setActiveCollectionVersion, h.SetActiveCollectionVersion)
 	router.AddRoute("/collections/migrations", http.MethodPost, setMigration, h.SetMigration)
 	router.AddRoute("/view", http.MethodPost, views, h.AddView)

--- a/internal/db/collection_index.go
+++ b/internal/db/collection_index.go
@@ -35,8 +35,8 @@ import (
 	"github.com/sourcenetwork/defradb/internal/utils"
 )
 
-// getAllIndexDescriptions returns all the index descriptions in the database.
-func (db *DB) getAllIndexDescriptions(
+// listIndexDescriptions returns all the index descriptions in the database.
+func (db *DB) listIndexDescriptions(
 	ctx context.Context,
 ) (map[client.CollectionName][]client.IndexDescription, error) {
 	collections, err := description.GetCollections(ctx)
@@ -353,22 +353,22 @@ func (c *collection) indexExistingDocs(
 	})
 }
 
-// DropIndex removes an index from the collection.
+// DeleteIndex removes an index from the collection.
 //
 // The index will be removed from the system store.
 //
 // All index artifacts for existing documents related the index will be removed.
-func (c *collection) DropIndex(
+func (c *collection) DeleteIndex(
 	ctx context.Context,
 	indexName string,
-	opts ...options.Enumerable[options.CollectionDropIndexOptions],
+	opts ...options.Enumerable[options.CollectionDeleteIndexOptions],
 ) error {
 	ctx, span := tracer.Start(ctx)
 	defer span.End()
 
 	opt := utils.NewOptions(opts...)
 
-	if err := c.db.checkNodeAccess(ctx, opt.Identity, acpTypes.NodeIndexDropPerm); err != nil {
+	if err := c.db.checkNodeAccess(ctx, opt.Identity, acpTypes.NodeIndexDeletePerm); err != nil {
 		return err
 	}
 
@@ -378,14 +378,14 @@ func (c *collection) DropIndex(
 	}
 	defer txn.Discard()
 
-	err = c.dropIndex(ctx, indexName)
+	err = c.deleteIndex(ctx, indexName)
 	if err != nil {
 		return err
 	}
 	return txn.Commit()
 }
 
-func (c *collection) dropIndex(ctx context.Context, indexName string) error {
+func (c *collection) deleteIndex(ctx context.Context, indexName string) error {
 	var didFind bool
 	for i := range c.indexes {
 		if c.indexes[i].Name() == indexName {
@@ -420,10 +420,10 @@ func (c *collection) dropIndex(ctx context.Context, indexName string) error {
 	return nil
 }
 
-// GetIndexes returns all indexes for the collection.
-func (c *collection) GetIndexes(
+// ListIndexes returns all indexes for the collection.
+func (c *collection) ListIndexes(
 	ctx context.Context,
-	opts ...options.Enumerable[options.CollectionGetIndexesOptions],
+	opts ...options.Enumerable[options.CollectionListIndexesOptions],
 ) ([]client.IndexDescription, error) {
 	opt := utils.NewOptions(opts...)
 

--- a/internal/db/index_test.go
+++ b/internal/db/index_test.go
@@ -301,27 +301,27 @@ func TestCreateIndex_ShouldUpdateCollectionsDescription(t *testing.T) {
 		f.users.Version().Indexes)
 }
 
-func TestCollectionGetIndexes_ShouldReturnIndexes(t *testing.T) {
+func TestCollectionListIndexes_ShouldReturnIndexes(t *testing.T) {
 	f := newIndexTestFixture(t)
 	defer f.db.Close()
 
 	f.createUserCollectionIndexOnName()
 
-	indexes, err := f.users.GetIndexes(f.ctx)
+	indexes, err := f.users.ListIndexes(f.ctx)
 	assert.NoError(t, err)
 
 	require.Equal(t, 1, len(indexes))
 	assert.Equal(t, testUsersColIndexName, indexes[0].Name)
 }
 
-func TestCollectionGetIndexes_IfInvalidIndexIsStored_ReturnError(t *testing.T) {
+func TestCollectionListIndexes_IfInvalidIndexIsStored_ReturnError(t *testing.T) {
 	f := newIndexTestFixture(t)
 	defer f.db.Close()
 
 	f.createUserCollectionIndexOnName()
 	f.createUserCollectionIndexOnAge()
 
-	indexes, err := f.users.GetIndexes(f.ctx)
+	indexes, err := f.users.ListIndexes(f.ctx)
 	assert.NoError(t, err)
 	require.Len(t, indexes, 2)
 	require.ElementsMatch(t,
@@ -331,52 +331,52 @@ func TestCollectionGetIndexes_IfInvalidIndexIsStored_ReturnError(t *testing.T) {
 	require.ElementsMatch(t, []uint32{1, 2}, []uint32{indexes[0].ID, indexes[1].ID})
 }
 
-func TestCollectionGetIndexes_IfIndexIsCreated_ReturnUpdateIndexes(t *testing.T) {
+func TestCollectionListIndexes_IfIndexIsCreated_ReturnUpdateIndexes(t *testing.T) {
 	f := newIndexTestFixture(t)
 	defer f.db.Close()
 
 	f.createUserCollectionIndexOnName()
 
-	indexes, err := f.users.GetIndexes(f.ctx)
+	indexes, err := f.users.ListIndexes(f.ctx)
 	assert.NoError(t, err)
 	assert.Len(t, indexes, 1)
 
 	_, err = f.users.CreateIndex(f.ctx, getUsersIndexDescOnAge())
 	assert.NoError(t, err)
 
-	indexes, err = f.users.GetIndexes(f.ctx)
+	indexes, err = f.users.ListIndexes(f.ctx)
 	assert.NoError(t, err)
 	assert.Len(t, indexes, 2)
 }
 
-func TestCollectionGetIndexes_IfIndexIsDropped_ReturnUpdateIndexes(t *testing.T) {
+func TestCollectionListIndexes_IfIndexIsDeleted_ReturnUpdateIndexes(t *testing.T) {
 	f := newIndexTestFixture(t)
 	defer f.db.Close()
 
 	f.createUserCollectionIndexOnName()
 	f.createUserCollectionIndexOnAge()
 
-	indexes, err := f.users.GetIndexes(f.ctx)
+	indexes, err := f.users.ListIndexes(f.ctx)
 	assert.NoError(t, err)
 	assert.Len(t, indexes, 2)
 
-	err = f.users.DropIndex(f.ctx, testUsersColIndexName)
+	err = f.users.DeleteIndex(f.ctx, testUsersColIndexName)
 	assert.NoError(t, err)
 
-	indexes, err = f.users.GetIndexes(f.ctx)
+	indexes, err = f.users.ListIndexes(f.ctx)
 	assert.NoError(t, err)
 	assert.Len(t, indexes, 1)
 	assert.Equal(t, indexes[0].Name, testUsersColIndexAge)
 
-	err = f.users.DropIndex(f.ctx, testUsersColIndexAge)
+	err = f.users.DeleteIndex(f.ctx, testUsersColIndexAge)
 	assert.NoError(t, err)
 
-	indexes, err = f.users.GetIndexes(f.ctx)
+	indexes, err = f.users.ListIndexes(f.ctx)
 	assert.NoError(t, err)
 	assert.Len(t, indexes, 0)
 }
 
-func TestCollectionGetIndexes_ShouldReturnIndexesInOrderedByName(t *testing.T) {
+func TestCollectionListIndexes_ShouldReturnIndexesInOrderedByName(t *testing.T) {
 	f := newIndexTestFixtureBare(t)
 	const (
 		num             = 30
@@ -428,7 +428,7 @@ func TestCollectionGetIndexes_ShouldReturnIndexesInOrderedByName(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	indexes, err := collection.GetIndexes(f.ctx)
+	indexes, err := collection.ListIndexes(f.ctx)
 	require.NoError(t, err)
 	require.Len(t, indexes, num)
 
@@ -437,7 +437,7 @@ func TestCollectionGetIndexes_ShouldReturnIndexesInOrderedByName(t *testing.T) {
 	}
 }
 
-func TestDropIndex_ShouldUpdateCollectionsDescription(t *testing.T) {
+func TestDeleteIndex_ShouldUpdateCollectionsDescription(t *testing.T) {
 	f := newIndexTestFixture(t)
 	defer f.db.Close()
 	txn := f.txn.(*Txn)
@@ -448,24 +448,24 @@ func TestDropIndex_ShouldUpdateCollectionsDescription(t *testing.T) {
 	require.NoError(t, err)
 	f.commitTxn()
 
-	err = f.users.DropIndex(f.ctx, testUsersColIndexName)
+	err = f.users.DeleteIndex(f.ctx, testUsersColIndexName)
 	require.NoError(t, err)
 
 	assert.ElementsMatch(t, []client.IndexDescription{indOnAge},
 		f.users.Version().Indexes)
 
-	err = f.users.DropIndex(f.ctx, testUsersColIndexAge)
+	err = f.users.DeleteIndex(f.ctx, testUsersColIndexAge)
 	require.NoError(t, err)
 
 	assert.ElementsMatch(t, []client.IndexDescription{}, f.users.Version().Indexes)
 }
 
-func TestDropIndex_IfIndexWithNameDoesNotExist_ReturnError(t *testing.T) {
+func TestDeleteIndex_IfIndexWithNameDoesNotExist_ReturnError(t *testing.T) {
 	f := newIndexTestFixture(t)
 	defer f.db.Close()
 
 	const name = "not_existing_index"
-	err := f.users.DropIndex(f.ctx, name)
+	err := f.users.DeleteIndex(f.ctx, name)
 	require.ErrorIs(t, err, NewErrIndexWithNameDoesNotExists(name))
 }
 

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -111,10 +111,10 @@ func (db *DB) GetCollections(
 	return db.getCollections(ctx, opt)
 }
 
-// GetAllIndexes gets all the indexes in the database.
-func (db *DB) GetAllIndexes(
+// ListIndexes gets all the indexes in the database.
+func (db *DB) ListIndexes(
 	ctx context.Context,
-	opts ...options.Enumerable[options.GetAllIndexesOptions],
+	opts ...options.Enumerable[options.ListIndexesOptions],
 ) (map[client.CollectionName][]client.IndexDescription, error) {
 	ctx, span := tracer.Start(ctx)
 	defer span.End()
@@ -131,7 +131,7 @@ func (db *DB) GetAllIndexes(
 	}
 	defer txn.Discard()
 
-	return db.getAllIndexDescriptions(ctx)
+	return db.listIndexDescriptions(ctx)
 }
 
 // ListAllEncryptedIndexes gets all the encrypted indexes in the database.

--- a/internal/db/txn.go
+++ b/internal/db/txn.go
@@ -288,12 +288,12 @@ func (txn *Txn) GetCollections(
 	return txn.db.GetCollections(ctx, opts...)
 }
 
-func (txn *Txn) GetAllIndexes(
+func (txn *Txn) ListIndexes(
 	ctx context.Context,
-	opts ...options.Enumerable[options.GetAllIndexesOptions],
+	opts ...options.Enumerable[options.ListIndexesOptions],
 ) (map[client.CollectionName][]client.IndexDescription, error) {
 	ctx = InitContext(ctx, txn)
-	return txn.db.GetAllIndexes(ctx, opts...)
+	return txn.db.ListIndexes(ctx, opts...)
 }
 
 func (txn *Txn) ListAllEncryptedIndexes(

--- a/js/client.go
+++ b/js/client.go
@@ -49,7 +49,7 @@ func (c *Client) JSValue() js.Value {
 		"listLenses":                 goji.Async(c.listLenses),
 		"getCollectionByName":        goji.Async(c.getCollectionByName),
 		"getCollections":             goji.Async(c.getCollections),
-		"getAllIndexes":              goji.Async(c.getAllIndexes),
+		"listIndexes":                goji.Async(c.listIndexes),
 		"listAllEncryptedIndexes":    goji.Async(c.listAllEncryptedIndexes),
 		"execRequest":                goji.Async(c.execRequest),
 		"addDACPolicy":               goji.Async(c.addDACPolicy),

--- a/js/client_collection.go
+++ b/js/client_collection.go
@@ -46,8 +46,8 @@ func newCollection(col client.Collection, txns *sync.Map) js.Value {
 		"get":                  goji.Async(c.get),
 		"getAllDocIDs":         goji.Async(c.getAllDocIDs),
 		"createIndex":          goji.Async(c.createIndex),
-		"dropIndex":            goji.Async(c.dropIndex),
-		"getIndexes":           goji.Async(c.getIndexes),
+		"deleteIndex":          goji.Async(c.deleteIndex),
+		"listIndexes":          goji.Async(c.listIndexes),
 		"addEncryptedIndex":    goji.Async(c.addEncryptedIndex),
 		"deleteEncryptedIndex": goji.Async(c.deleteEncryptedIndex),
 		"listEncryptedIndexes": goji.Async(c.listEncryptedIndexes),
@@ -325,7 +325,7 @@ func (c *clientCollection) createIndex(this js.Value, args []js.Value) (js.Value
 	return goji.MarshalJS(desc)
 }
 
-func (c *clientCollection) dropIndex(this js.Value, args []js.Value) (js.Value, error) {
+func (c *clientCollection) deleteIndex(this js.Value, args []js.Value) (js.Value, error) {
 	name, err := stringArg(args, 0, "name")
 	if err != nil {
 		return js.Undefined(), err
@@ -334,20 +334,20 @@ func (c *clientCollection) dropIndex(this js.Value, args []js.Value) (js.Value, 
 	if err != nil {
 		return js.Undefined(), err
 	}
-	opt := options.CollectionDropIndex()
+	opt := options.CollectionDeleteIndex()
 	setOptIdentity(opt, args, 1)
-	err = c.col.DropIndex(ctx, name, opt)
+	err = c.col.DeleteIndex(ctx, name, opt)
 	return js.Undefined(), err
 }
 
-func (c *clientCollection) getIndexes(this js.Value, args []js.Value) (js.Value, error) {
+func (c *clientCollection) listIndexes(this js.Value, args []js.Value) (js.Value, error) {
 	ctx, err := contextArg(args, 0, c.txns)
 	if err != nil {
 		return js.Undefined(), err
 	}
-	opt := options.CollectionGetIndexes()
+	opt := options.CollectionListIndexes()
 	setOptIdentity(opt, args, 0)
-	desc, err := c.col.GetIndexes(ctx, opt)
+	desc, err := c.col.ListIndexes(ctx, opt)
 	if err != nil {
 		return js.Undefined(), err
 	}

--- a/js/client_store.go
+++ b/js/client_store.go
@@ -236,14 +236,14 @@ func collectionFetchOptionsToGetCollectionsOptions(input collectionFetchOptions)
 	return opt
 }
 
-func (c *Client) getAllIndexes(this js.Value, args []js.Value) (js.Value, error) {
+func (c *Client) listIndexes(this js.Value, args []js.Value) (js.Value, error) {
 	ctx, err := contextArg(args, 0, c.txns)
 	if err != nil {
 		return js.Undefined(), err
 	}
-	opt := options.GetAllIndexes()
+	opt := options.ListIndexes()
 	setOptIdentity(opt, args, 0)
-	indexes, err := c.node.DB.GetAllIndexes(ctx, opt)
+	indexes, err := c.node.DB.ListIndexes(ctx, opt)
 	if err != nil {
 		return js.Undefined(), err
 	}

--- a/js/client_tx.go
+++ b/js/client_tx.go
@@ -48,7 +48,7 @@ func newTransaction(txn client.Txn, txns *sync.Map) js.Value {
 		"listLenses":                 goji.Async(wrapper.listLenses),
 		"getCollectionByName":        goji.Async(wrapper.getCollectionByName),
 		"getCollections":             goji.Async(wrapper.getCollections),
-		"getAllIndexes":              goji.Async(wrapper.getAllIndexes),
+		"listIndexes":                goji.Async(wrapper.listIndexes),
 		"listAllEncryptedIndexes":    goji.Async(wrapper.listAllEncryptedIndexes),
 		"execRequest":                goji.Async(wrapper.execRequest),
 		"addDACPolicy":               goji.Async(wrapper.addDACPolicy),
@@ -260,14 +260,14 @@ func (t *transaction) getCollections(this js.Value, args []js.Value) (js.Value, 
 	return js.ValueOf(wrappers), nil
 }
 
-func (t *transaction) getAllIndexes(this js.Value, args []js.Value) (js.Value, error) {
+func (t *transaction) listIndexes(this js.Value, args []js.Value) (js.Value, error) {
 	ctx, err := contextArg(args, 0, t.txns)
 	if err != nil {
 		return js.Undefined(), err
 	}
-	opt := options.GetAllIndexes()
+	opt := options.ListIndexes()
 	setOptIdentity(opt, args, 0)
-	indexes, err := t.txn.GetAllIndexes(ctx, opt)
+	indexes, err := t.txn.ListIndexes(ctx, opt)
 	if err != nil {
 		return js.Undefined(), err
 	}

--- a/tests/action/delete_index.go
+++ b/tests/action/delete_index.go
@@ -17,9 +17,9 @@ import (
 	"github.com/sourcenetwork/defradb/tests/state"
 )
 
-// DropIndex will attempt to drop the given secondary index from the given collection
+// DeleteIndex will attempt to delete the given secondary index from the given collection
 // using the collection api.
-type DropIndex struct {
+type DeleteIndex struct {
 	stateful
 
 	// NodeID may hold the ID (index) of a node to delete the secondary index from.
@@ -45,23 +45,23 @@ type DropIndex struct {
 	ExpectedError string
 }
 
-var _ Action = (*DropIndex)(nil)
-var _ Stateful = (*DropIndex)(nil)
+var _ Action = (*DeleteIndex)(nil)
+var _ Stateful = (*DeleteIndex)(nil)
 
-func (a *DropIndex) Execute() {
+func (a *DeleteIndex) Execute() {
 	var expectedErrorRaised bool
 
 	nodeIDs, _ := getNodesWithIDs(a.NodeID, a.s.Nodes)
 	for _, nodeID := range nodeIDs {
 		collection := a.s.Nodes[nodeID].Collections[a.CollectionID]
 
-		opts := options.CollectionDropIndex()
+		opts := options.CollectionDeleteIndex()
 		identOption := getIdentityForRequestSpecificToNode(a.s, a.Identity, nodeID)
 		if identOption.HasValue() {
 			opts.SetIdentity(identOption.Value())
 		}
 
-		err := collection.DropIndex(a.s.Ctx, a.IndexName, opts)
+		err := collection.DeleteIndex(a.s.Ctx, a.IndexName, opts)
 
 		expectedErrorRaised = assertError(a.s.T, err, a.ExpectedError)
 	}

--- a/tests/action/list_indexes.go
+++ b/tests/action/list_indexes.go
@@ -21,12 +21,12 @@ import (
 	"github.com/sourcenetwork/defradb/tests/state"
 )
 
-// GetIndexes will attempt to get the indexes from the given collection
+// ListIndexes will attempt to list the indexes from the given collection
 // using the collection api.
-type GetIndexes struct {
+type ListIndexes struct {
 	stateful
 
-	// NodeID may hold the ID (index) of a node to get the indexes from.
+	// NodeID may hold the ID (index) of a node to list the indexes from.
 	//
 	// If a value is not provided the indexes will be retrieved from the first node.
 	NodeID immutable.Option[int]
@@ -49,10 +49,10 @@ type GetIndexes struct {
 	ExpectedError string
 }
 
-var _ Action = (*GetIndexes)(nil)
-var _ Stateful = (*GetIndexes)(nil)
+var _ Action = (*ListIndexes)(nil)
+var _ Stateful = (*ListIndexes)(nil)
 
-func (a *GetIndexes) Execute() {
+func (a *ListIndexes) Execute() {
 	if len(a.s.Nodes) == 0 {
 		return
 	}
@@ -63,13 +63,13 @@ func (a *GetIndexes) Execute() {
 	for _, nodeID := range nodeIDs {
 		collection := a.s.Nodes[nodeID].Collections[a.CollectionID]
 
-		opts := options.CollectionGetIndexes()
+		opts := options.CollectionListIndexes()
 		identOption := getIdentityForRequestSpecificToNode(a.s, a.Identity, nodeID)
 		if identOption.HasValue() {
 			opts.SetIdentity(identOption.Value())
 		}
 
-		actualIndexes, err := collection.GetIndexes(a.s.Ctx, opts)
+		actualIndexes, err := collection.ListIndexes(a.s.Ctx, opts)
 
 		if assertError(a.s.T, err, a.ExpectedError) {
 			expectedErrorRaised = true

--- a/tests/clients/cli/wrapper.go
+++ b/tests/clients/cli/wrapper.go
@@ -613,9 +613,9 @@ func (w *Wrapper) GetCollections(
 	return cols, err
 }
 
-func (w *Wrapper) GetAllIndexes(
+func (w *Wrapper) ListIndexes(
 	ctx context.Context,
-	opts ...options.Enumerable[options.GetAllIndexesOptions],
+	opts ...options.Enumerable[options.ListIndexesOptions],
 ) (map[client.CollectionName][]client.IndexDescription, error) {
 	args := []string{"client", "index", "list"}
 

--- a/tests/clients/cli/wrapper_collection.go
+++ b/tests/clients/cli/wrapper_collection.go
@@ -406,12 +406,12 @@ func (c *Collection) CreateIndex(
 	return index, nil
 }
 
-func (c *Collection) DropIndex(
+func (c *Collection) DeleteIndex(
 	ctx context.Context,
 	indexName string,
-	opts ...options.Enumerable[options.CollectionDropIndexOptions],
+	opts ...options.Enumerable[options.CollectionDeleteIndexOptions],
 ) error {
-	args := []string{"client", "index", "drop"}
+	args := []string{"client", "index", "delete"}
 	args = append(args, "--collection", c.Version().Name)
 	args = append(args, "--name", indexName)
 
@@ -422,9 +422,9 @@ func (c *Collection) DropIndex(
 	return err
 }
 
-func (c *Collection) GetIndexes(
+func (c *Collection) ListIndexes(
 	ctx context.Context,
-	opts ...options.Enumerable[options.CollectionGetIndexesOptions],
+	opts ...options.Enumerable[options.CollectionListIndexesOptions],
 ) ([]client.IndexDescription, error) {
 	args := []string{"client", "index", "list"}
 	args = append(args, "--collection", c.Version().Name)

--- a/tests/clients/cli/wrapper_tx.go
+++ b/tests/clients/cli/wrapper_tx.go
@@ -194,12 +194,12 @@ func (txn *Transaction) GetCollections(
 	return txn.Wrapper.GetCollections(ctx, opts...)
 }
 
-func (txn *Transaction) GetAllIndexes(
+func (txn *Transaction) ListIndexes(
 	ctx context.Context,
-	opts ...options.Enumerable[options.GetAllIndexesOptions],
+	opts ...options.Enumerable[options.ListIndexesOptions],
 ) (map[client.CollectionName][]client.IndexDescription, error) {
 	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
-	return txn.Wrapper.GetAllIndexes(ctx, opts...)
+	return txn.Wrapper.ListIndexes(ctx, opts...)
 }
 
 func (txn *Transaction) ExecRequest(

--- a/tests/clients/http/wrapper.go
+++ b/tests/clients/http/wrapper.go
@@ -348,11 +348,11 @@ func (w *Wrapper) GetCollections(
 	return w.client.GetCollections(ctx, opts...)
 }
 
-func (w *Wrapper) GetAllIndexes(
+func (w *Wrapper) ListIndexes(
 	ctx context.Context,
-	opts ...options.Enumerable[options.GetAllIndexesOptions],
+	opts ...options.Enumerable[options.ListIndexesOptions],
 ) (map[client.CollectionName][]client.IndexDescription, error) {
-	return w.client.GetAllIndexes(ctx, opts...)
+	return w.client.ListIndexes(ctx, opts...)
 }
 
 func (w *Wrapper) ListAllEncryptedIndexes(

--- a/tests/clients/http/wrapper_tx.go
+++ b/tests/clients/http/wrapper_tx.go
@@ -188,12 +188,12 @@ func (txn *Transaction) GetCollections(
 	return txn.Wrapper.GetCollections(ctx, opts...)
 }
 
-func (txn *Transaction) GetAllIndexes(
+func (txn *Transaction) ListIndexes(
 	ctx context.Context,
-	opts ...options.Enumerable[options.GetAllIndexesOptions],
+	opts ...options.Enumerable[options.ListIndexesOptions],
 ) (map[client.CollectionName][]client.IndexDescription, error) {
 	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
-	return txn.Wrapper.GetAllIndexes(ctx, opts...)
+	return txn.Wrapper.ListIndexes(ctx, opts...)
 }
 
 func (txn *Transaction) ExecRequest(

--- a/tests/clients/js/wrapper.go
+++ b/tests/clients/js/wrapper.go
@@ -480,13 +480,13 @@ func (w *Wrapper) GetCollections(
 	return out, nil
 }
 
-func (w *Wrapper) GetAllIndexes(
+func (w *Wrapper) ListIndexes(
 	ctx context.Context,
-	opts ...options.Enumerable[options.GetAllIndexesOptions],
+	opts ...options.Enumerable[options.ListIndexesOptions],
 ) (map[client.CollectionName][]client.IndexDescription, error) {
 	opt := utils.NewOptions(opts...)
 	ctx = ctxWithOptIdentity(ctx, opt)
-	res, err := execute(ctx, w.value, "getAllIndexes")
+	res, err := execute(ctx, w.value, "listIndexes")
 	if err != nil {
 		return nil, err
 	}

--- a/tests/clients/js/wrapper_collection.go
+++ b/tests/clients/js/wrapper_collection.go
@@ -291,17 +291,17 @@ func (c *Collection) CreateIndex(
 	return indexDescOut, nil
 }
 
-func (c *Collection) DropIndex(ctx context.Context, indexName string, opts ...options.Enumerable[options.CollectionDropIndexOptions]) error {
+func (c *Collection) DeleteIndex(ctx context.Context, indexName string, opts ...options.Enumerable[options.CollectionDeleteIndexOptions]) error {
 	opt := utils.NewOptions(opts...)
 	ctx = ctxWithOptIdentity(ctx, opt)
-	_, err := execute(ctx, c.client, "dropIndex", indexName)
+	_, err := execute(ctx, c.client, "deleteIndex", indexName)
 	return err
 }
 
-func (c *Collection) GetIndexes(ctx context.Context, opts ...options.Enumerable[options.CollectionGetIndexesOptions]) ([]client.IndexDescription, error) {
+func (c *Collection) ListIndexes(ctx context.Context, opts ...options.Enumerable[options.CollectionListIndexesOptions]) ([]client.IndexDescription, error) {
 	opt := utils.NewOptions(opts...)
 	ctx = ctxWithOptIdentity(ctx, opt)
-	res, err := execute(ctx, c.client, "getIndexes")
+	res, err := execute(ctx, c.client, "listIndexes")
 	if err != nil {
 		return nil, err
 	}

--- a/tests/clients/js/wrapper_tx.go
+++ b/tests/clients/js/wrapper_tx.go
@@ -169,12 +169,12 @@ func (txn *Transaction) GetCollections(
 	return txn.Wrapper.GetCollections(ctx, opts...)
 }
 
-func (txn *Transaction) GetAllIndexes(
+func (txn *Transaction) ListIndexes(
 	ctx context.Context,
-	opts ...options.Enumerable[options.GetAllIndexesOptions],
+	opts ...options.Enumerable[options.ListIndexesOptions],
 ) (map[client.CollectionName][]client.IndexDescription, error) {
 	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
-	return txn.Wrapper.GetAllIndexes(ctx, opts...)
+	return txn.Wrapper.ListIndexes(ctx, opts...)
 }
 
 func (txn *Transaction) ExecRequest(

--- a/tests/integration/acp/nac/index_delete_test.go
+++ b/tests/integration/acp/nac/index_delete_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/sourcenetwork/defradb/tests/state"
 )
 
-func TestNAC_GatesIndexDrop_AuthorizedIdentity_AllowAccess(t *testing.T) {
+func TestNAC_GatesIndexDelete_AuthorizedIdentity_AllowAccess(t *testing.T) {
 	test := testUtils.TestCase{
 		SupportedClientTypes: immutable.Some(
 			[]state.ClientType{
@@ -50,7 +50,7 @@ func TestNAC_GatesIndexDrop_AuthorizedIdentity_AllowAccess(t *testing.T) {
 			},
 
 			// This should work as the identity is authorized.
-			&action.DropIndex{
+			&action.DeleteIndex{
 				Identity:  testUtils.ClientIdentity(1),
 				IndexName: "User_name_ASC",
 			},
@@ -60,7 +60,7 @@ func TestNAC_GatesIndexDrop_AuthorizedIdentity_AllowAccess(t *testing.T) {
 	testUtils.ExecuteTestCase(t, test)
 }
 
-func TestNAC_GatesIndexDrop_NoIdentity_NotAuthorizedError(t *testing.T) {
+func TestNAC_GatesIndexDelete_NoIdentity_NotAuthorizedError(t *testing.T) {
 	test := testUtils.TestCase{
 		// todo: Investigate and test this behavior across all client types when implementing granular NAC permissions.
 		// See: https://github.com/sourcenetwork/defradb/issues/4383
@@ -89,10 +89,10 @@ func TestNAC_GatesIndexDrop_NoIdentity_NotAuthorizedError(t *testing.T) {
 			},
 
 			// We haven't authorized non-identities. So, this should error.
-			&action.DropIndex{
+			&action.DeleteIndex{
 				Identity:      testUtils.NoIdentity(),
 				IndexName:     "User_name_ASC",
-				ExpectedError: testUtils.FormatExpectedErrorWithPermission(acpTypes.NodeIndexDropPerm),
+				ExpectedError: testUtils.FormatExpectedErrorWithPermission(acpTypes.NodeIndexDeletePerm),
 			},
 		},
 	}
@@ -100,7 +100,7 @@ func TestNAC_GatesIndexDrop_NoIdentity_NotAuthorizedError(t *testing.T) {
 	testUtils.ExecuteTestCase(t, test)
 }
 
-func TestNAC_GatesIndexDrop_NoIdentity_CLIandCandHTTPClient_NotAuthorizedError(t *testing.T) {
+func TestNAC_GatesIndexDelete_NoIdentity_CLIandCandHTTPClient_NotAuthorizedError(t *testing.T) {
 	test := testUtils.TestCase{
 		// todo: Investigate and test this behavior across all client types when implementing granular NAC permissions.
 		// See: https://github.com/sourcenetwork/defradb/issues/4383
@@ -130,7 +130,7 @@ func TestNAC_GatesIndexDrop_NoIdentity_CLIandCandHTTPClient_NotAuthorizedError(t
 			},
 
 			// We haven't authorized non-identities. So, this should error.
-			&action.DropIndex{
+			&action.DeleteIndex{
 				Identity:      testUtils.NoIdentity(),
 				IndexName:     "User_name_ASC",
 				ExpectedError: testUtils.FormatExpectedErrorWithPermission(acpTypes.NodeCollectionGetPerm),
@@ -141,7 +141,7 @@ func TestNAC_GatesIndexDrop_NoIdentity_CLIandCandHTTPClient_NotAuthorizedError(t
 	testUtils.ExecuteTestCase(t, test)
 }
 
-func TestNAC_GatesIndexDrop_WrongIdentity_NotAuthorizedError(t *testing.T) {
+func TestNAC_GatesIndexDelete_WrongIdentity_NotAuthorizedError(t *testing.T) {
 	test := testUtils.TestCase{
 		// todo: Investigate and test this behavior across all client types when implementing granular NAC permissions.
 		// See: https://github.com/sourcenetwork/defradb/issues/4383
@@ -170,10 +170,10 @@ func TestNAC_GatesIndexDrop_WrongIdentity_NotAuthorizedError(t *testing.T) {
 			},
 
 			// Wrong user/identity will also not be authorized.
-			&action.DropIndex{
+			&action.DeleteIndex{
 				Identity:      testUtils.ClientIdentity(2),
 				IndexName:     "User_name_ASC",
-				ExpectedError: testUtils.FormatExpectedErrorWithPermission(acpTypes.NodeIndexDropPerm),
+				ExpectedError: testUtils.FormatExpectedErrorWithPermission(acpTypes.NodeIndexDeletePerm),
 			},
 		},
 	}
@@ -181,7 +181,7 @@ func TestNAC_GatesIndexDrop_WrongIdentity_NotAuthorizedError(t *testing.T) {
 	testUtils.ExecuteTestCase(t, test)
 }
 
-func TestNAC_GatesIndexDrop_WrongIdentity_CLIandCandHTTPClient_NotAuthorizedError(t *testing.T) {
+func TestNAC_GatesIndexDelete_WrongIdentity_CLIandCandHTTPClient_NotAuthorizedError(t *testing.T) {
 	test := testUtils.TestCase{
 		// todo: Investigate and test this behavior across all client types when implementing granular NAC permissions.
 		// See: https://github.com/sourcenetwork/defradb/issues/4383
@@ -211,7 +211,7 @@ func TestNAC_GatesIndexDrop_WrongIdentity_CLIandCandHTTPClient_NotAuthorizedErro
 			},
 
 			// Wrong user/identity will also not be authorized.
-			&action.DropIndex{
+			&action.DeleteIndex{
 				Identity:      testUtils.ClientIdentity(2),
 				IndexName:     "User_name_ASC",
 				ExpectedError: testUtils.FormatExpectedErrorWithPermission(acpTypes.NodeCollectionGetPerm),

--- a/tests/integration/acp/nac/index_list_test.go
+++ b/tests/integration/acp/nac/index_list_test.go
@@ -51,7 +51,7 @@ func TestNAC_GatesIndexList_AuthorizedIdentity_AllowAccess(t *testing.T) {
 			},
 
 			// This should work as the identity is authorized.
-			&action.GetIndexes{
+			&action.ListIndexes{
 				Identity:        testUtils.ClientIdentity(1),
 				CollectionID:    0,
 				ExpectedIndexes: []client.IndexDescription{},
@@ -90,7 +90,7 @@ func TestNAC_GatesIndexList_NoIdentity_NotAuthorizedError(t *testing.T) {
 			},
 
 			// We haven't authorized non-identities. So, this should error.
-			&action.GetIndexes{
+			&action.ListIndexes{
 				Identity:      testUtils.NoIdentity(),
 				CollectionID:  0,
 				ExpectedError: testUtils.FormatExpectedErrorWithPermission(acpTypes.NodeIndexListPerm),
@@ -131,7 +131,7 @@ func TestNAC_GatesIndexList_NoIdentity_CLIandCandHTTPClient_NotAuthorizedError(t
 			},
 
 			// We haven't authorized non-identities. So, this should error.
-			&action.GetIndexes{
+			&action.ListIndexes{
 				Identity:      testUtils.NoIdentity(),
 				CollectionID:  0,
 				ExpectedError: testUtils.FormatExpectedErrorWithPermission(acpTypes.NodeCollectionGetPerm),
@@ -170,7 +170,7 @@ func TestNAC_GatesIndexList_WrongIdentity_NotAuthorizedError(t *testing.T) {
 			},
 
 			// Wrong user/identity will also not be authorized.
-			&action.GetIndexes{
+			&action.ListIndexes{
 				Identity:      testUtils.ClientIdentity(2),
 				CollectionID:  0,
 				ExpectedError: testUtils.FormatExpectedErrorWithPermission(acpTypes.NodeIndexListPerm),
@@ -211,7 +211,7 @@ func TestNAC_GatesIndexList_WrongIdentity_CLIandCandHTTPClient_NotAuthorizedErro
 			},
 
 			// Wrong user/identity will also not be authorized.
-			&action.GetIndexes{
+			&action.ListIndexes{
 				Identity:      testUtils.ClientIdentity(2),
 				CollectionID:  0,
 				ExpectedError: testUtils.FormatExpectedErrorWithPermission(acpTypes.NodeCollectionGetPerm),

--- a/tests/integration/acp/nac/relation_admin/index_delete_test.go
+++ b/tests/integration/acp/nac/relation_admin/index_delete_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/sourcenetwork/defradb/tests/state"
 )
 
-func TestNAC_AdminRelation_CanIndexDrop(t *testing.T) {
+func TestNAC_AdminRelation_CanIndexDelete(t *testing.T) {
 	test := testUtils.TestCase{
 		// todo: Investigate and test this behavior across all client types when implementing granular NAC permissions.
 		// See: https://github.com/sourcenetwork/defradb/issues/4383
@@ -49,10 +49,10 @@ func TestNAC_AdminRelation_CanIndexDrop(t *testing.T) {
 			},
 
 			// This user, can not perform this gated operation yet.
-			&action.DropIndex{
+			&action.DeleteIndex{
 				Identity:      testUtils.ClientIdentity(2),
 				IndexName:     "User_name_ASC",
-				ExpectedError: testUtils.FormatExpectedErrorWithPermission(acpTypes.NodeIndexDropPerm),
+				ExpectedError: testUtils.FormatExpectedErrorWithPermission(acpTypes.NodeIndexDeletePerm),
 			},
 
 			// Grant access to user.
@@ -64,7 +64,7 @@ func TestNAC_AdminRelation_CanIndexDrop(t *testing.T) {
 			},
 
 			// This user, can now perform this gated operation.
-			&action.DropIndex{
+			&action.DeleteIndex{
 				Identity:  testUtils.ClientIdentity(2),
 				IndexName: "User_name_ASC",
 			},
@@ -74,7 +74,7 @@ func TestNAC_AdminRelation_CanIndexDrop(t *testing.T) {
 	testUtils.ExecuteTestCase(t, test)
 }
 
-func TestNAC_AdminRelation_CLIandCandHTTPClient_CanIndexDrop(t *testing.T) {
+func TestNAC_AdminRelation_CLIandCandHTTPClient_CanIndexDelete(t *testing.T) {
 	test := testUtils.TestCase{
 		// todo: Investigate and test this behavior across all client types when implementing granular NAC permissions.
 		// See: https://github.com/sourcenetwork/defradb/issues/4383
@@ -104,7 +104,7 @@ func TestNAC_AdminRelation_CLIandCandHTTPClient_CanIndexDrop(t *testing.T) {
 			},
 
 			// This user, can not perform this gated operation yet.
-			&action.DropIndex{
+			&action.DeleteIndex{
 				Identity:      testUtils.ClientIdentity(2),
 				IndexName:     "User_name_ASC",
 				ExpectedError: testUtils.FormatExpectedErrorWithPermission(acpTypes.NodeCollectionGetPerm),
@@ -119,7 +119,7 @@ func TestNAC_AdminRelation_CLIandCandHTTPClient_CanIndexDrop(t *testing.T) {
 			},
 
 			// This user, can now perform this gated operation.
-			&action.DropIndex{
+			&action.DeleteIndex{
 				Identity:  testUtils.ClientIdentity(2),
 				IndexName: "User_name_ASC",
 			},

--- a/tests/integration/acp/nac/relation_admin/index_list_test.go
+++ b/tests/integration/acp/nac/relation_admin/index_list_test.go
@@ -50,7 +50,7 @@ func TestNAC_AdminRelation_CanIndexList(t *testing.T) {
 			},
 
 			// This user, can not perform this gated operation yet.
-			&action.GetIndexes{
+			&action.ListIndexes{
 				Identity:      testUtils.ClientIdentity(2),
 				CollectionID:  0,
 				ExpectedError: testUtils.FormatExpectedErrorWithPermission(acpTypes.NodeIndexListPerm),
@@ -65,7 +65,7 @@ func TestNAC_AdminRelation_CanIndexList(t *testing.T) {
 			},
 
 			// This user, can now perform this gated operation.
-			&action.GetIndexes{
+			&action.ListIndexes{
 				Identity:        testUtils.ClientIdentity(2),
 				CollectionID:    0,
 				ExpectedIndexes: []client.IndexDescription{},
@@ -106,7 +106,7 @@ func TestNAC_AdminRelation_CLIandCandHTTPClient_CanIndexList(t *testing.T) {
 			},
 
 			// This user, can not perform this gated operation yet.
-			&action.GetIndexes{
+			&action.ListIndexes{
 				Identity:      testUtils.ClientIdentity(2),
 				CollectionID:  0,
 				ExpectedError: testUtils.FormatExpectedErrorWithPermission(acpTypes.NodeCollectionGetPerm),
@@ -121,7 +121,7 @@ func TestNAC_AdminRelation_CLIandCandHTTPClient_CanIndexList(t *testing.T) {
 			},
 
 			// This user, can now perform this gated operation.
-			&action.GetIndexes{
+			&action.ListIndexes{
 				Identity:        testUtils.ClientIdentity(2),
 				CollectionID:    0,
 				ExpectedIndexes: []client.IndexDescription{},

--- a/tests/integration/collection_version/updates/add/field/with_index_test.go
+++ b/tests/integration/collection_version/updates/add/field/with_index_test.go
@@ -37,10 +37,10 @@ func TestSchemaUpdatesAddFieldSimple_WithExistingIndexDocsCreatedAfterPatch(t *t
 					]
 				`,
 			},
-			// It is important to test that the index shows up in both the `GetIndexes` call,
+			// It is important to test that the index shows up in both the `ListIndexes` call,
 			// *and* the `GetCollections` call, as indexes are stored in multiple places and we had a bug
 			// where patching a schema would result in the index disappearing from one of those locations.
-			&action.GetIndexes{
+			&action.ListIndexes{
 				ExpectedIndexes: []client.IndexDescription{
 					{
 						Name:   "Users_name_ASC",
@@ -138,10 +138,10 @@ func TestSchemaUpdatesAddFieldSimple_WithExistingIndexDocsCreatedBeforePatch(t *
 					]
 				`,
 			},
-			// It is important to test that the index shows up in both the `GetIndexes` call,
+			// It is important to test that the index shows up in both the `ListIndexes` call,
 			// *and* the `GetCollections` call, as indexes are stored in multiple places and we had a bug
 			// where patching a schema would result in the index disappearing from one of those locations.
-			&action.GetIndexes{
+			&action.ListIndexes{
 				ExpectedIndexes: []client.IndexDescription{
 					{
 						Name:   "Users_name_ASC",

--- a/tests/integration/index/create_composite_test.go
+++ b/tests/integration/index/create_composite_test.go
@@ -50,7 +50,7 @@ func TestCompositeIndexCreate_WhenCreated_CanRetrieve(t *testing.T) {
 				IndexName:    "name_age_index",
 				Fields:       []client.IndexedFieldDescription{{Name: "name"}, {Name: "age"}},
 			},
-			&action.GetIndexes{
+			&action.ListIndexes{
 				CollectionID: 0,
 				ExpectedIndexes: []client.IndexDescription{
 					{
@@ -84,7 +84,7 @@ func TestCompositeIndexCreate_UsingObjectDirective_SetsDefaultDirection(t *testi
 					}
 				`,
 			},
-			&action.GetIndexes{
+			&action.ListIndexes{
 				CollectionID: 0,
 				ExpectedIndexes: []client.IndexDescription{
 					{
@@ -121,7 +121,7 @@ func TestCompositeIndexCreate_UsingObjectDirective_OverridesDefaultDirection(t *
 					}
 				`,
 			},
-			&action.GetIndexes{
+			&action.ListIndexes{
 				CollectionID: 0,
 				ExpectedIndexes: []client.IndexDescription{
 					{
@@ -158,7 +158,7 @@ func TestCompositeIndexCreate_UsingFieldDirective_ImplicitlyAddsField(t *testing
 					}
 				`,
 			},
-			&action.GetIndexes{
+			&action.ListIndexes{
 				CollectionID: 0,
 				ExpectedIndexes: []client.IndexDescription{
 					{
@@ -192,7 +192,7 @@ func TestCompositeIndexCreate_UsingFieldDirective_SetsDefaultDirection(t *testin
 					}
 				`,
 			},
-			&action.GetIndexes{
+			&action.ListIndexes{
 				CollectionID: 0,
 				ExpectedIndexes: []client.IndexDescription{
 					{
@@ -229,7 +229,7 @@ func TestCompositeIndexCreate_UsingFieldDirective_OverridesDefaultDirection(t *t
 					}
 				`,
 			},
-			&action.GetIndexes{
+			&action.ListIndexes{
 				CollectionID: 0,
 				ExpectedIndexes: []client.IndexDescription{
 					{
@@ -266,7 +266,7 @@ func TestCompositeIndexCreate_UsingFieldDirective_WithExplicitIncludes_RespectsO
 					}
 				`,
 			},
-			&action.GetIndexes{
+			&action.ListIndexes{
 				CollectionID: 0,
 				ExpectedIndexes: []client.IndexDescription{
 					{

--- a/tests/integration/index/create_get_test.go
+++ b/tests/integration/index/create_get_test.go
@@ -18,7 +18,7 @@ import (
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
 )
 
-func TestIndexGet_ShouldReturnListOfExistingIndexes(t *testing.T) {
+func TestIndexList_ShouldReturnListOfExistingIndexes(t *testing.T) {
 	test := testUtils.TestCase{
 		Actions: []any{
 			&action.AddSchema{
@@ -29,7 +29,7 @@ func TestIndexGet_ShouldReturnListOfExistingIndexes(t *testing.T) {
 					}
 				`,
 			},
-			&action.GetIndexes{
+			&action.ListIndexes{
 				CollectionID: 0,
 				ExpectedIndexes: []client.IndexDescription{
 					{
@@ -58,7 +58,7 @@ func TestIndexGet_ShouldReturnListOfExistingIndexes(t *testing.T) {
 	testUtils.ExecuteTestCase(t, test)
 }
 
-func TestIndexGet_GetIndexesForACollection_ReturnCollectionSpecificList(t *testing.T) {
+func TestIndexList_GetIndexesForACollection_ReturnCollectionSpecificList(t *testing.T) {
 	test := testUtils.TestCase{
 		Actions: []any{
 			&action.AddSchema{
@@ -74,7 +74,7 @@ func TestIndexGet_GetIndexesForACollection_ReturnCollectionSpecificList(t *testi
 					}
 				`,
 			},
-			&action.GetIndexes{
+			&action.ListIndexes{
 				CollectionID: 0,
 				ExpectedIndexes: []client.IndexDescription{
 					{
@@ -90,7 +90,7 @@ func TestIndexGet_GetIndexesForACollection_ReturnCollectionSpecificList(t *testi
 					},
 				},
 			},
-			&action.GetIndexes{
+			&action.ListIndexes{
 				CollectionID: 1,
 				ExpectedIndexes: []client.IndexDescription{
 					{

--- a/tests/integration/index/create_test.go
+++ b/tests/integration/index/create_test.go
@@ -55,7 +55,7 @@ func TestIndexCreateWithCollection_ShouldNotHinderQuerying(t *testing.T) {
 					},
 				},
 			},
-			&action.GetIndexes{
+			&action.ListIndexes{
 				ExpectedIndexes: []client.IndexDescription{
 					{
 						Name: "User_name_ASC",
@@ -113,7 +113,7 @@ func TestIndexCreate_ShouldNotHinderQuerying(t *testing.T) {
 					},
 				},
 			},
-			&action.GetIndexes{
+			&action.ListIndexes{
 				ExpectedIndexes: []client.IndexDescription{
 					{
 						Name: "some_index",

--- a/tests/integration/index/create_unique_composite_one_to_one_test.go
+++ b/tests/integration/index/create_unique_composite_one_to_one_test.go
@@ -33,7 +33,7 @@ func TestOneToOneUniqueIndex_OnPrimarySide_AutoCreated(t *testing.T) {
 						user: User
 					}`,
 			},
-			&action.GetIndexes{
+			&action.ListIndexes{
 				CollectionID: 0,
 				ExpectedIndexes: []client.IndexDescription{
 					{
@@ -67,7 +67,7 @@ func TestOneToOneUniqueIndex_UserDefinedUniqueIndexWithName_Succeeds(t *testing.
 						user: User
 					}`,
 			},
-			&action.GetIndexes{
+			&action.ListIndexes{
 				CollectionID: 0,
 				ExpectedIndexes: []client.IndexDescription{
 					{
@@ -123,7 +123,7 @@ func TestOneToOneUniqueIndex_TypeLevelCompositeUniqueIndex_Succeeds(t *testing.T
 						user: User
 					}`,
 			},
-			&action.GetIndexes{
+			&action.ListIndexes{
 				CollectionID: 0,
 				ExpectedIndexes: []client.IndexDescription{
 					{
@@ -182,7 +182,7 @@ func TestOneToOneUniqueIndex_CompositeIndexRelationNotFirst_AutoIndexStillCreate
 						user: User
 					}`,
 			},
-			&action.GetIndexes{
+			&action.ListIndexes{
 				CollectionID: 0,
 				ExpectedIndexes: []client.IndexDescription{
 					{
@@ -314,11 +314,11 @@ func TestOneToOneUniqueIndex_OneToMany_ShouldNotCreateIndex(t *testing.T) {
 						author: Author
 					}`,
 			},
-			&action.GetIndexes{
+			&action.ListIndexes{
 				CollectionID:    0,
 				ExpectedIndexes: []client.IndexDescription{},
 			},
-			&action.GetIndexes{
+			&action.ListIndexes{
 				CollectionID:    1,
 				ExpectedIndexes: []client.IndexDescription{},
 			},

--- a/tests/integration/index/create_unique_composite_test.go
+++ b/tests/integration/index/create_unique_composite_test.go
@@ -54,7 +54,7 @@ func TestCreateUniqueCompositeIndex_IfFieldValuesAreNotUnique_ReturnError(t *tes
 				Unique:        true,
 				ExpectedError: "can not index a doc's field(s) that violates unique index.",
 			},
-			&action.GetIndexes{
+			&action.ListIndexes{
 				CollectionID:    0,
 				ExpectedIndexes: []client.IndexDescription{},
 			},
@@ -146,7 +146,7 @@ func TestUniqueCompositeIndexCreate_IfFieldValuesAreUnique_Succeed(t *testing.T)
 				IndexName:    "name_age_unique_index",
 				Unique:       true,
 			},
-			&action.GetIndexes{
+			&action.ListIndexes{
 				CollectionID: 0,
 				ExpectedIndexes: []client.IndexDescription{
 					{
@@ -218,7 +218,7 @@ func TestUniqueCompositeIndexCreate_IfFieldValuesAreOrdered_Succeed(t *testing.T
 				IndexName: "name_age_unique_index",
 				Unique:    true,
 			},
-			&action.GetIndexes{
+			&action.ListIndexes{
 				CollectionID: 0,
 				ExpectedIndexes: []client.IndexDescription{
 					{

--- a/tests/integration/index/create_unique_test.go
+++ b/tests/integration/index/create_unique_test.go
@@ -59,7 +59,7 @@ func TestCreateUniqueIndex_IfFieldValuesAreNotUnique_ReturnError(t *testing.T) {
 				Unique:        true,
 				ExpectedError: "can not index a doc's field(s) that violates unique index.",
 			},
-			&action.GetIndexes{
+			&action.ListIndexes{
 				CollectionID:    0,
 				ExpectedIndexes: []client.IndexDescription{},
 			},
@@ -107,7 +107,7 @@ func TestUniqueIndexCreate_UponAddingDocWithExistingFieldValue_ReturnError(t *te
 					"User": []map[string]any{},
 				},
 			},
-			&action.GetIndexes{
+			&action.ListIndexes{
 				CollectionID: 0,
 				ExpectedIndexes: []client.IndexDescription{
 					{
@@ -161,7 +161,7 @@ func TestUniqueIndexCreate_IfFieldValuesAreUnique_Succeed(t *testing.T) {
 				FieldName:    "age",
 				Unique:       true,
 			},
-			&action.GetIndexes{
+			&action.ListIndexes{
 				CollectionID: 0,
 				ExpectedIndexes: []client.IndexDescription{
 					{
@@ -221,7 +221,7 @@ func TestUniqueIndexCreate_WithMultipleNilFields_ShouldSucceed(t *testing.T) {
 				FieldName:    "age",
 				Unique:       true,
 			},
-			&action.GetIndexes{
+			&action.ListIndexes{
 				CollectionID: 0,
 				ExpectedIndexes: []client.IndexDescription{
 					{

--- a/tests/integration/index/delete_test.go
+++ b/tests/integration/index/delete_test.go
@@ -18,7 +18,7 @@ import (
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
 )
 
-func TestIndexDrop_ShouldNotHinderQuerying(t *testing.T) {
+func TestIndexDelete_ShouldNotHinderQuerying(t *testing.T) {
 	test := testUtils.TestCase{
 		Actions: []any{
 			&action.AddSchema{
@@ -37,7 +37,7 @@ func TestIndexDrop_ShouldNotHinderQuerying(t *testing.T) {
 						"age":	21
 					}`,
 			},
-			&action.DropIndex{
+			&action.DeleteIndex{
 				IndexName: "User_name_ASC",
 			},
 			&action.Request{
@@ -63,7 +63,7 @@ func TestIndexDrop_ShouldNotHinderQuerying(t *testing.T) {
 	testUtils.ExecuteTestCase(t, test)
 }
 
-func TestIndexDrop_ShouldRemoveIndexFromCollection(t *testing.T) {
+func TestIndexDelete_ShouldRemoveIndexFromCollection(t *testing.T) {
 	test := testUtils.TestCase{
 		Actions: []any{
 			&action.AddSchema{
@@ -82,10 +82,10 @@ func TestIndexDrop_ShouldRemoveIndexFromCollection(t *testing.T) {
 						"age":	21
 					}`,
 			},
-			&action.DropIndex{
+			&action.DeleteIndex{
 				IndexName: "User_age_ASC",
 			},
-			&action.GetIndexes{
+			&action.ListIndexes{
 				CollectionID: 0,
 				ExpectedIndexes: []client.IndexDescription{
 					{
@@ -97,10 +97,10 @@ func TestIndexDrop_ShouldRemoveIndexFromCollection(t *testing.T) {
 					},
 				},
 			},
-			&action.DropIndex{
+			&action.DeleteIndex{
 				IndexName: "User_name_ASC",
 			},
-			&action.GetIndexes{
+			&action.ListIndexes{
 				CollectionID:    0,
 				ExpectedIndexes: []client.IndexDescription{},
 			},
@@ -110,7 +110,7 @@ func TestIndexDrop_ShouldRemoveIndexFromCollection(t *testing.T) {
 	testUtils.ExecuteTestCase(t, test)
 }
 
-func TestIndexDrop_IfIndexDoesNotExist_ReturnError(t *testing.T) {
+func TestIndexDelete_IfIndexDoesNotExist_ReturnError(t *testing.T) {
 	test := testUtils.TestCase{
 		Actions: []any{
 			&action.AddSchema{
@@ -129,7 +129,7 @@ func TestIndexDrop_IfIndexDoesNotExist_ReturnError(t *testing.T) {
 						"age":	21
 					}`,
 			},
-			&action.DropIndex{
+			&action.DeleteIndex{
 				CollectionID:  0,
 				IndexName:     "non_existing_index",
 				ExpectedError: "index with name doesn't exists. Name: non_existing_index",

--- a/tests/integration/index/get_test.go
+++ b/tests/integration/index/get_test.go
@@ -18,7 +18,7 @@ import (
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
 )
 
-func TestIndexGet_IfThereAreNoIndexes_ReturnEmptyList(t *testing.T) {
+func TestIndexList_IfThereAreNoIndexes_ReturnEmptyList(t *testing.T) {
 	test := testUtils.TestCase{
 		Actions: []any{
 			&action.AddSchema{
@@ -29,7 +29,7 @@ func TestIndexGet_IfThereAreNoIndexes_ReturnEmptyList(t *testing.T) {
 					}
 				`,
 			},
-			&action.GetIndexes{
+			&action.ListIndexes{
 				CollectionID:    0,
 				ExpectedIndexes: []client.IndexDescription{},
 			},

--- a/tests/integration/index/patch_relation_test.go
+++ b/tests/integration/index/patch_relation_test.go
@@ -46,7 +46,7 @@ func TestPatchRelation_OneToOne_CreatesUniqueIndex(t *testing.T) {
 					]
 				`,
 			},
-			&action.GetIndexes{
+			&action.ListIndexes{
 				CollectionID: 0,
 				ExpectedIndexes: []client.IndexDescription{
 					{
@@ -59,7 +59,7 @@ func TestPatchRelation_OneToOne_CreatesUniqueIndex(t *testing.T) {
 					},
 				},
 			},
-			&action.GetIndexes{
+			&action.ListIndexes{
 				CollectionID:    1,
 				ExpectedIndexes: []client.IndexDescription{},
 			},
@@ -109,7 +109,7 @@ func TestPatchRelation_MultipleOneToOne_CreatesUniqueIndexesWithCorrectIDs(t *te
 					]
 				`,
 			},
-			&action.GetIndexes{
+			&action.ListIndexes{
 				CollectionID: 1,
 				ExpectedIndexes: []client.IndexDescription{
 					{
@@ -130,11 +130,11 @@ func TestPatchRelation_MultipleOneToOne_CreatesUniqueIndexesWithCorrectIDs(t *te
 					},
 				},
 			},
-			&action.GetIndexes{
+			&action.ListIndexes{
 				CollectionID:    0,
 				ExpectedIndexes: []client.IndexDescription{},
 			},
-			&action.GetIndexes{
+			&action.ListIndexes{
 				CollectionID:    2,
 				ExpectedIndexes: []client.IndexDescription{},
 			},
@@ -172,11 +172,11 @@ func TestPatchRelation_OneToMany_DoesNotCreateUniqueIndex(t *testing.T) {
 					]
 				`,
 			},
-			&action.GetIndexes{
+			&action.ListIndexes{
 				CollectionID:    0,
 				ExpectedIndexes: []client.IndexDescription{},
 			},
-			&action.GetIndexes{
+			&action.ListIndexes{
 				CollectionID:    1,
 				ExpectedIndexes: []client.IndexDescription{},
 			},
@@ -219,7 +219,7 @@ func TestPatchRelation_OneToOneWithVersionSwitching_IndexOnlyOnActiveVersion(t *
 					]
 				`,
 			},
-			&action.GetIndexes{
+			&action.ListIndexes{
 				CollectionID: 0,
 				ExpectedIndexes: []client.IndexDescription{
 					{
@@ -235,14 +235,14 @@ func TestPatchRelation_OneToOneWithVersionSwitching_IndexOnlyOnActiveVersion(t *
 			testUtils.SetActiveCollectionVersion{
 				VersionID: authorV1,
 			},
-			&action.GetIndexes{
+			&action.ListIndexes{
 				CollectionID:    0,
 				ExpectedIndexes: []client.IndexDescription{},
 			},
 			testUtils.SetActiveCollectionVersion{
 				VersionID: authorV2,
 			},
-			&action.GetIndexes{
+			&action.ListIndexes{
 				CollectionID: 0,
 				ExpectedIndexes: []client.IndexDescription{
 					{

--- a/tests/multiplier/secondary_index.go
+++ b/tests/multiplier/secondary_index.go
@@ -98,7 +98,7 @@ func (m *secondaryIndex) Apply(source action.Actions) action.Actions {
 func hasIndexActions(actions action.Actions) bool {
 	for _, a := range actions {
 		switch a.(type) {
-		case *action.CreateIndex, *action.DropIndex, *action.GetIndexes:
+		case *action.CreateIndex, *action.DeleteIndex, *action.ListIndexes:
 			return true
 		}
 	}

--- a/tests/multiplier/secondary_index_test.go
+++ b/tests/multiplier/secondary_index_test.go
@@ -27,19 +27,19 @@ func TestHasIndexActions_WithCreateIndex_ReturnsTrue(t *testing.T) {
 	assert.True(t, hasIndexActions(actions))
 }
 
-func TestHasIndexActions_WithDropIndex_ReturnsTrue(t *testing.T) {
+func TestHasIndexActions_WithDeleteIndex_ReturnsTrue(t *testing.T) {
 	actions := action.Actions{
 		&action.AddSchema{Schema: "type User { name: String }"},
-		&action.DropIndex{CollectionID: 0, IndexName: "User_name_idx"},
+		&action.DeleteIndex{CollectionID: 0, IndexName: "User_name_idx"},
 	}
 
 	assert.True(t, hasIndexActions(actions))
 }
 
-func TestHasIndexActions_WithGetIndexes_ReturnsTrue(t *testing.T) {
+func TestHasIndexActions_WithListIndexes_ReturnsTrue(t *testing.T) {
 	actions := action.Actions{
 		&action.AddSchema{Schema: "type User { name: String }"},
-		&action.GetIndexes{CollectionID: 0},
+		&action.ListIndexes{CollectionID: 0},
 	}
 
 	assert.True(t, hasIndexActions(actions))


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4554

## Description

Renames `drop index` to `delete index`, and `get all indexes` to `list indexes`.

Everything is find and replace, no coding.