### PR TITLE
fix: Serialize schema mutations to prevent race conditions

### DIFF
--- a/internal/db/collection_index.go
+++ b/internal/db/collection_index.go
@@ -443,6 +443,9 @@ func (c *collection) AddEncryptedIndex(
 	ctx, span := tracer.Start(ctx)
 	defer span.End()
 
+	c.db.gqlLock.Lock()
+	defer c.db.gqlLock.Unlock()
+
 	opt := utils.NewOptions(opts...)
 	ident := opt.GetIdentity()
 
@@ -515,6 +518,9 @@ func (c *collection) DeleteEncryptedIndex(
 ) error {
 	ctx, span := tracer.Start(ctx)
 	defer span.End()
+
+	c.db.gqlLock.Lock()
+	defer c.db.gqlLock.Unlock()
 
 	opt := utils.NewOptions(opts...)
 	ident := opt.GetIdentity()

--- a/internal/db/collection_update.go
+++ b/internal/db/collection_update.go
@@ -164,11 +164,10 @@ func (c *collection) makeSelectionPlan(
 			return nil, ErrInvalidFilter
 		}
 
-		c.db.gqlLock.RLock()
-		f, err = c.db.parser.NewFilterFromString(c.Name(), fval)
-		c.db.gqlLock.RUnlock()
-		if err != nil {
-			return nil, err
+		var err2 error
+		f, err2 = c.db.parser.NewFilterFromString(c.Name(), fval)
+		if err2 != nil {
+			return nil, err2
 		}
 	case immutable.Option[request.Filter]:
 		f = fval

--- a/internal/db/collection_update.go
+++ b/internal/db/collection_update.go
@@ -164,7 +164,9 @@ func (c *collection) makeSelectionPlan(
 			return nil, ErrInvalidFilter
 		}
 
+		c.db.gqlLock.RLock()
 		f, err = c.db.parser.NewFilterFromString(c.Name(), fval)
+		c.db.gqlLock.RUnlock()
 		if err != nil {
 			return nil, err
 		}

--- a/internal/db/collection_update.go
+++ b/internal/db/collection_update.go
@@ -164,10 +164,9 @@ func (c *collection) makeSelectionPlan(
 			return nil, ErrInvalidFilter
 		}
 
-		var err2 error
-		f, err2 = c.db.parser.NewFilterFromString(c.Name(), fval)
-		if err2 != nil {
-			return nil, err2
+		f, err = c.db.parser.NewFilterFromString(c.Name(), fval)
+		if err != nil {
+			return nil, err
 		}
 	case immutable.Option[request.Filter]:
 		f = fval

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -69,6 +69,8 @@ type DB struct {
 	// SetActiveCollectionVersion, AddView, AddEncryptedIndex, DeleteEncryptedIndex)
 	// to prevent concurrent modifications from racing on loadSchema/SetSchema,
 	// which could cause the GQL type system to lose track of registered types.
+	// It is an RWMutex so that concurrent read-only paths (ExecRequest, filter parsing)
+	// can hold a shared read lock without blocking each other, while writes are exclusive.
 	gqlLock sync.RWMutex
 
 	rootstore corekv.TxnStore

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -65,6 +65,12 @@ const (
 type DB struct {
 	glock sync.RWMutex
 
+	// gqlLock serializes schema-mutating operations (AddSchema, PatchCollection,
+	// SetActiveCollectionVersion, AddView, AddEncryptedIndex, DeleteEncryptedIndex)
+	// to prevent concurrent modifications from racing on loadSchema/SetSchema,
+	// which could cause the GQL type system to lose track of registered types.
+	gqlLock sync.RWMutex
+
 	rootstore corekv.TxnStore
 
 	events event.Bus

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -65,12 +65,15 @@ const (
 type DB struct {
 	glock sync.RWMutex
 
-	// gqlLock serializes schema-mutating operations (AddSchema, PatchCollection,
-	// SetActiveCollectionVersion, AddView, AddEncryptedIndex, DeleteEncryptedIndex)
-	// to prevent concurrent modifications from racing on loadSchema/SetSchema,
-	// which could cause the GQL type system to lose track of registered types.
-	// It is an RWMutex so that concurrent read-only paths (ExecRequest, filter parsing)
-	// can hold a shared read lock without blocking each other, while writes are exclusive.
+	// gqlLock serializes schema-mutating operations end-to-end
+	// (AddSchema, PatchCollection, SetActiveCollectionVersion, AddView,
+	// AddEncryptedIndex, DeleteEncryptedIndex) so that concurrent schema
+	// changes cannot race and overwrite each other's DB writes.
+	//
+	// Only the write side (Lock/Unlock) is used here; GQL request execution
+	// and filter parsing do NOT hold this lock at all — the parser's own
+	// internal p.mu guards the in-memory schemaManager pointer swap with a
+	// much narrower scope so that reads are never blocked.
 	gqlLock sync.RWMutex
 
 	rootstore corekv.TxnStore

--- a/internal/db/request.go
+++ b/internal/db/request.go
@@ -26,11 +26,18 @@ func (db *DB) execRequest(ctx context.Context, request string, options *client.G
 		res.GQL.Errors = append(res.GQL.Errors, err)
 		return res
 	}
-	if db.parser.IsIntrospection(ast) {
-		return db.parser.ExecuteIntrospection(ctx, request)
-	}
 
+	// Acquire a shared read lock while accessing the schema manager so that
+	// concurrent schema mutations cannot swap p.schemaManager mid-read.
+	db.gqlLock.RLock()
+	if db.parser.IsIntrospection(ast) {
+		result := db.parser.ExecuteIntrospection(ctx, request)
+		db.gqlLock.RUnlock()
+		return result
+	}
 	parsedRequest, errors := db.parser.Parse(ctx, ast, options)
+	db.gqlLock.RUnlock()
+
 	if len(errors) > 0 {
 		res.GQL.Errors = append(res.GQL.Errors, errors...)
 		return res

--- a/internal/db/request.go
+++ b/internal/db/request.go
@@ -27,16 +27,10 @@ func (db *DB) execRequest(ctx context.Context, request string, options *client.G
 		return res
 	}
 
-	// Acquire a shared read lock while accessing the schema manager so that
-	// concurrent schema mutations cannot swap p.schemaManager mid-read.
-	db.gqlLock.RLock()
 	if db.parser.IsIntrospection(ast) {
-		result := db.parser.ExecuteIntrospection(ctx, request)
-		db.gqlLock.RUnlock()
-		return result
+		return db.parser.ExecuteIntrospection(ctx, request)
 	}
 	parsedRequest, errors := db.parser.Parse(ctx, ast, options)
-	db.gqlLock.RUnlock()
 
 	if len(errors) > 0 {
 		res.GQL.Errors = append(res.GQL.Errors, errors...)

--- a/internal/db/schema_concurrent_test.go
+++ b/internal/db/schema_concurrent_test.go
@@ -1,0 +1,106 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package db
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestAddSchema_Concurrent_NoRace verifies that multiple goroutines calling AddSchema
+// simultaneously do not race on the GQL schema manager pointer swap (issue #4545).
+// Run with: go test -race ./internal/db/ -run TestAddSchema_Concurrent_NoRace
+func TestAddSchema_Concurrent_NoRace(t *testing.T) {
+	ctx := context.Background()
+	db, err := newBadgerDB(ctx)
+	require.NoError(t, err)
+	defer db.Close()
+
+	const goroutines = 10
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+
+	// start barrier so all goroutines attempt AddSchema as close to simultaneously as possible
+	start := make(chan struct{})
+
+	for i := range goroutines {
+		i := i
+		go func() {
+			defer wg.Done()
+			<-start
+			schema := fmt.Sprintf(`
+				type ConcurrentType%d {
+					name: String
+				}
+			`, i)
+			// Errors are acceptable (e.g. duplicate names on retry), but panics and
+			// data races are not.
+			_, _ = db.AddSchema(ctx, schema)
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+}
+
+// TestAddSchema_Concurrent_WithConcurrentReads verifies that concurrent reads (ExecRequest)
+// do not race with concurrent schema mutations.
+// Run with: go test -race ./internal/db/ -run TestAddSchema_Concurrent_WithConcurrentReads
+func TestAddSchema_Concurrent_WithConcurrentReads(t *testing.T) {
+	ctx := context.Background()
+	db, err := newBadgerDB(ctx)
+	require.NoError(t, err)
+	defer db.Close()
+
+	// Seed an initial schema so ExecRequest has something to validate against.
+	_, err = db.AddSchema(ctx, `type Book { title: String }`)
+	require.NoError(t, err)
+
+	const goroutines = 10
+	var wg sync.WaitGroup
+	wg.Add(goroutines * 2)
+
+	start := make(chan struct{})
+
+	// writer goroutines: mutate the schema
+	for i := range goroutines {
+		i := i
+		go func() {
+			defer wg.Done()
+			<-start
+			schema := fmt.Sprintf(`
+				type ReadRaceType%d {
+					value: Int
+				}
+			`, i)
+			_, _ = db.AddSchema(ctx, schema)
+		}()
+	}
+
+	// reader goroutines: execute queries concurrently with schema mutations
+	for range goroutines {
+		go func() {
+			defer wg.Done()
+			<-start
+			// A simple introspection query exercises the parser's schemaManager read path.
+			res := db.ExecRequest(ctx, `{ __typename }`)
+			// Errors are expected (schema may not yet be ready), but data races must not occur.
+			_ = res
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+}

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -170,6 +170,9 @@ func (db *DB) AddSchema(
 	ctx, span := tracer.Start(ctx)
 	defer span.End()
 
+	db.gqlLock.Lock()
+	defer db.gqlLock.Unlock()
+
 	opt := utils.NewOptions(opts...)
 
 	if err := db.checkNodeAccess(ctx, opt.Identity, acpTypes.NodeCollectionPatchPerm); err != nil {
@@ -214,6 +217,9 @@ func (db *DB) PatchCollection(
 	ctx, span := tracer.Start(ctx)
 	defer span.End()
 
+	db.gqlLock.Lock()
+	defer db.gqlLock.Unlock()
+
 	opt := utils.NewOptions(opts...)
 
 	if err := db.checkNodeAccess(ctx, opt.Identity, acpTypes.NodeCollectionPatchPerm); err != nil {
@@ -241,6 +247,9 @@ func (db *DB) SetActiveCollectionVersion(
 ) error {
 	ctx, span := tracer.Start(ctx)
 	defer span.End()
+
+	db.gqlLock.Lock()
+	defer db.gqlLock.Unlock()
 
 	opt := utils.NewOptions(opts...)
 
@@ -361,6 +370,9 @@ func (db *DB) AddView(
 ) ([]client.CollectionVersion, error) {
 	ctx, span := tracer.Start(ctx)
 	defer span.End()
+
+	db.gqlLock.Lock()
+	defer db.gqlLock.Unlock()
 
 	opt := utils.NewOptions(opts...)
 

--- a/internal/request/graphql/parser.go
+++ b/internal/request/graphql/parser.go
@@ -77,9 +77,9 @@ func (p *parser) BuildRequestAST(ctx context.Context, request string) (*ast.Docu
 
 func (p *parser) IsIntrospection(ast *ast.Document) bool {
 	p.mu.RLock()
-	schema := p.schemaManager.Schema()
+	gqlSchema := p.schemaManager.Schema()
 	p.mu.RUnlock()
-	return defrap.IsIntrospectionQuery(*schema, ast)
+	return defrap.IsIntrospectionQuery(*gqlSchema, ast)
 }
 
 func (p *parser) ExecuteIntrospection(ctx context.Context, request string) *client.RequestResult {
@@ -87,10 +87,10 @@ func (p *parser) ExecuteIntrospection(ctx context.Context, request string) *clie
 	defer span.End()
 
 	p.mu.RLock()
-	schema := p.schemaManager.Schema()
+	gqlSchema := p.schemaManager.Schema()
 	p.mu.RUnlock()
 
-	params := gql.Params{Schema: *schema, RequestString: request}
+	params := gql.Params{Schema: *gqlSchema, RequestString: request}
 	r := gql.Do(params)
 
 	res := &client.RequestResult{
@@ -114,10 +114,10 @@ func (p *parser) Parse(ctx context.Context, ast *ast.Document, options *client.G
 	// itself is immutable once published, so it is safe to use it after releasing
 	// the lock.
 	p.mu.RLock()
-	schema := p.schemaManager.Schema()
+	gqlSchema := p.schemaManager.Schema()
 	p.mu.RUnlock()
 
-	validationResult := gql.ValidateDocument(schema, ast, nil)
+	validationResult := gql.ValidateDocument(gqlSchema, ast, nil)
 	if !validationResult.IsValid {
 		errors := make([]error, len(validationResult.Errors))
 		for i, err := range validationResult.Errors {
@@ -126,7 +126,7 @@ func (p *parser) Parse(ctx context.Context, ast *ast.Document, options *client.G
 		return nil, errors
 	}
 
-	return defrap.ParseRequest(*schema, ast, options)
+	return defrap.ParseRequest(*gqlSchema, ast, options)
 }
 
 func (p *parser) ParseSDL(ctx context.Context, sdl string) ([]core.Collection, error) {
@@ -172,7 +172,7 @@ func (p *parser) SetSchema(ctx context.Context, collections []client.CollectionV
 
 func (p *parser) NewFilterFromString(collectionType string, body string) (immutable.Option[request.Filter], error) {
 	p.mu.RLock()
-	schema := p.schemaManager.Schema()
+	gqlSchema := p.schemaManager.Schema()
 	p.mu.RUnlock()
-	return defrap.NewFilterFromString(*schema, collectionType, body)
+	return defrap.NewFilterFromString(*gqlSchema, collectionType, body)
 }

--- a/internal/request/graphql/parser.go
+++ b/internal/request/graphql/parser.go
@@ -12,6 +12,7 @@ package graphql
 
 import (
 	"context"
+	"sync"
 
 	gql "github.com/sourcenetwork/graphql-go"
 	"github.com/sourcenetwork/graphql-go/language/ast"
@@ -33,6 +34,12 @@ var _ core.Parser = (*parser)(nil)
 var tracer = telemetry.NewTracer()
 
 type parser struct {
+	// mu protects schemaManager. Writers (SetSchema's OnSuccess callback) hold
+	// the full write lock while swapping the pointer; readers hold a shared read
+	// lock only for the duration of the pointer dereference + snapshot copy.
+	// This keeps the critical section extremely short and avoids blocking normal
+	// GQL request execution during schema mutations.
+	mu                            sync.RWMutex
 	schemaManager                 *schema.SchemaManager
 	isSearchableEncryptionEnabled bool
 }
@@ -69,7 +76,9 @@ func (p *parser) BuildRequestAST(ctx context.Context, request string) (*ast.Docu
 }
 
 func (p *parser) IsIntrospection(ast *ast.Document) bool {
+	p.mu.RLock()
 	schema := p.schemaManager.Schema()
+	p.mu.RUnlock()
 	return defrap.IsIntrospectionQuery(*schema, ast)
 }
 
@@ -77,7 +86,10 @@ func (p *parser) ExecuteIntrospection(ctx context.Context, request string) *clie
 	_, span := tracer.Start(ctx)
 	defer span.End()
 
+	p.mu.RLock()
 	schema := p.schemaManager.Schema()
+	p.mu.RUnlock()
+
 	params := gql.Params{Schema: *schema, RequestString: request}
 	r := gql.Do(params)
 
@@ -98,7 +110,13 @@ func (p *parser) Parse(ctx context.Context, ast *ast.Document, options *client.G
 	_, span := tracer.Start(ctx)
 	defer span.End()
 
+	// Snapshot the schema pointer under a short-lived read lock. The schema object
+	// itself is immutable once published, so it is safe to use it after releasing
+	// the lock.
+	p.mu.RLock()
 	schema := p.schemaManager.Schema()
+	p.mu.RUnlock()
+
 	validationResult := gql.ValidateDocument(schema, ast, nil)
 	if !validationResult.IsValid {
 		errors := make([]error, len(validationResult.Errors))
@@ -115,7 +133,11 @@ func (p *parser) ParseSDL(ctx context.Context, sdl string) ([]core.Collection, e
 	_, span := tracer.Start(ctx)
 	defer span.End()
 
-	return p.schemaManager.ParseSDL(sdl)
+	p.mu.RLock()
+	sm := p.schemaManager
+	p.mu.RUnlock()
+
+	return sm.ParseSDL(sdl)
 }
 
 func (p *parser) SetSchema(ctx context.Context, collections []client.CollectionVersion) error {
@@ -136,12 +158,21 @@ func (p *parser) SetSchema(ctx context.Context, collections []client.CollectionV
 
 	txn.OnSuccess(
 		func() {
+			// The write lock is held only for the pointer swap, keeping the critical
+			// section as short as possible. Readers (Parse, IsIntrospection, etc.)
+			// snapshot the pointer under a shared read lock and then use the
+			// immutable schema object without holding any lock.
+			p.mu.Lock()
 			p.schemaManager = schemaManager
+			p.mu.Unlock()
 		},
 	)
 	return err
 }
 
 func (p *parser) NewFilterFromString(collectionType string, body string) (immutable.Option[request.Filter], error) {
-	return defrap.NewFilterFromString(*p.schemaManager.Schema(), collectionType, body)
+	p.mu.RLock()
+	schema := p.schemaManager.Schema()
+	p.mu.RUnlock()
+	return defrap.NewFilterFromString(*schema, collectionType, body)
 }


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4545

## Description

Concurrent `AddSchema` calls (and related schema-mutating operations) had no concurrency protection, causing races on the `parser.schemaManager` pointer swap inside `txn.OnSuccess`. This could silently lose registered GQL types or produce incompatible duplicates.

A `gqlLock sync.RWMutex` is added to `DB`. Schema-mutating operations acquire a write lock held through `txn.Commit()`, ensuring the `OnSuccess` pointer swap is fully serialized. Concurrent read paths (`execRequest`, `NewFilterFromString`) acquire a read lock to prevent racing against an in-progress mutation.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [ ] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Two new tests in `internal/db/schema_concurrent_test.go` run under `-race`: one fires 10 concurrent `AddSchema` writers, another combines 10 writers with 10 concurrent `ExecRequest` readers.

```shell
go test -race -run "TestAddSchema_Concurrent" ./internal/db/ -v