### PR TITLE
feat: Require dev-mode for import/export

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,13 +126,13 @@ Alternatively, to randomly generate the required keys, run the following command
 Node identity is an identity assigned to the node. It is used to exchange encryption keys with other nodes. 
 
 ```
-defradb keyring generate
+defradb keyring new
 ```
 
 To import externally generated keys, run the following command:
 
 ```
-defradb keyring import <name> <private-key-hex>
+defradb keyring add <name> <private-key-hex>
 ```
 
 To learn more about the available options:

--- a/cli/keyring.go
+++ b/cli/keyring.go
@@ -21,17 +21,17 @@ func MakeKeyringCommand(ctx context.Context) *cobra.Command {
 		Use:   "keyring",
 		Short: "Manage DefraDB private keys",
 		Long: `Manage DefraDB private keys.
-Generate, import, and export private keys.
+Generate, add, get, and list private keys.
 
 The following keys are loaded from the keyring on start:
 	peer-key: Ed25519 private key (required)
 	encryption-key: AES-128, AES-192, or AES-256 key (optional)
 
 To randomly generate the required keys, run the following command:
-	defradb keyring generate
+	defradb keyring new
 
 To import externally generated keys, run the following command:
-	defradb keyring import <name> <private-key-hex>
+	defradb keyring add <name> <private-key-hex>
 
 To learn more about the available options:
 	defradb keyring --help

--- a/cli/start.go
+++ b/cli/start.go
@@ -28,7 +28,6 @@ import (
 	"github.com/sourcenetwork/defradb/crypto"
 	"github.com/sourcenetwork/defradb/errors"
 	"github.com/sourcenetwork/defradb/event"
-	"github.com/sourcenetwork/defradb/http"
 	"github.com/sourcenetwork/defradb/internal/telemetry"
 	"github.com/sourcenetwork/defradb/keyring"
 	"github.com/sourcenetwork/defradb/node"
@@ -178,7 +177,6 @@ func MakeStartCommand(ctx context.Context) *cobra.Command {
 			opts.DB().SetEnableSigning(!cfg.GetBool("datastore.nosigning"))
 
 			isDevMode := cfg.GetBool("development")
-			http.IsDevMode = isDevMode
 			if isDevMode {
 				cmd.Printf(devModeBanner)
 				if cfg.GetBool("keyring.disabled") {

--- a/cli/start.go
+++ b/cli/start.go
@@ -238,7 +238,7 @@ func MakeStartCommand(ctx context.Context) *cobra.Command {
 				if err == nil {
 					goto RESTART
 				}
-				if errors.Is(err, node.ErrPurgeWithDevModeDisabled) {
+				if errors.Is(err, client.ErrPurgeWithDevModeDisabled) {
 					goto SELECT
 				}
 

--- a/cli/start.go
+++ b/cli/start.go
@@ -238,7 +238,7 @@ func MakeStartCommand(ctx context.Context) *cobra.Command {
 				if err == nil {
 					goto RESTART
 				}
-				if errors.Is(err, client.ErrPurgeWithDevModeDisabled) {
+				if errors.Is(err, client.ErrOperationRequiresDeveloperMode) {
 					goto SELECT
 				}
 

--- a/client/errors.go
+++ b/client/errors.go
@@ -51,6 +51,7 @@ const (
 	errNACIsEnabledButInstanceIsNotAvailable string = "node acp is enabled, but the acp instance is not available"
 	errNACIsEnabledButIsMissingPolicyInfo    string = "node acp is enabled, but is missing policy info"
 	errNACNodeObjectToGateIsNotRegistered    string = "node acp is enabled, but object to gate must be registered"
+	errPurgeRequestNonDeveloperMode          string = "cannot purge database when development mode is disabled"
 )
 
 var (
@@ -98,6 +99,7 @@ var (
 	ErrNACIsEnabledButInstanceIsNotAvailable = errors.New(errNACIsEnabledButInstanceIsNotAvailable)
 	ErrNACIsEnabledButIsMissingPolicyInfo    = errors.New(errNACIsEnabledButIsMissingPolicyInfo)
 	ErrNACNodeObjectToGateIsNotRegistered    = errors.New(errNACNodeObjectToGateIsNotRegistered)
+	ErrPurgeWithDevModeDisabled              = errors.New(errPurgeRequestNonDeveloperMode)
 )
 
 // NewErrFieldNotExist returns an error indicating that the given field does not exist.

--- a/client/errors.go
+++ b/client/errors.go
@@ -51,7 +51,7 @@ const (
 	errNACIsEnabledButInstanceIsNotAvailable string = "node acp is enabled, but the acp instance is not available"
 	errNACIsEnabledButIsMissingPolicyInfo    string = "node acp is enabled, but is missing policy info"
 	errNACNodeObjectToGateIsNotRegistered    string = "node acp is enabled, but object to gate must be registered"
-	errPurgeRequestNonDeveloperMode          string = "cannot purge database when development mode is disabled"
+	errOperationRequiresDeveloperMode        string = "operation not permitted whilst development mode is disabled"
 )
 
 var (
@@ -99,7 +99,7 @@ var (
 	ErrNACIsEnabledButInstanceIsNotAvailable = errors.New(errNACIsEnabledButInstanceIsNotAvailable)
 	ErrNACIsEnabledButIsMissingPolicyInfo    = errors.New(errNACIsEnabledButIsMissingPolicyInfo)
 	ErrNACNodeObjectToGateIsNotRegistered    = errors.New(errNACNodeObjectToGateIsNotRegistered)
-	ErrPurgeWithDevModeDisabled              = errors.New(errPurgeRequestNonDeveloperMode)
+	ErrOperationRequiresDeveloperMode        = errors.New(errOperationRequiresDeveloperMode)
 )
 
 // NewErrFieldNotExist returns an error indicating that the given field does not exist.
@@ -275,4 +275,11 @@ func NewErrNotFound(kv errors.KV) error {
 
 func NewErrNotAuthorizedToPerformOperation(permission acpTypes.NodeResourcePermission) error {
 	return errors.WithStack(ErrNotAuthorizedToPerformOperation, errors.NewKV("Permission", permission))
+}
+
+func NewErrOperationRequiresDeveloperMode(operationName string) error {
+	return errors.New(
+		errOperationRequiresDeveloperMode,
+		errors.NewKV("Operation", operationName),
+	)
 }

--- a/docs/website/references/cli/defradb_keyring.md
+++ b/docs/website/references/cli/defradb_keyring.md
@@ -5,17 +5,17 @@ Manage DefraDB private keys
 ### Synopsis
 
 Manage DefraDB private keys.
-Generate, import, and export private keys.
+Generate, add, get, and list private keys.
 
 The following keys are loaded from the keyring on start:
 	peer-key: Ed25519 private key (required)
 	encryption-key: AES-128, AES-192, or AES-256 key (optional)
 
 To randomly generate the required keys, run the following command:
-	defradb keyring generate
+	defradb keyring new
 
 To import externally generated keys, run the following command:
-	defradb keyring import <name> <private-key-hex>
+	defradb keyring add <name> <private-key-hex>
 
 To learn more about the available options:
 	defradb keyring --help

--- a/http/errors.go
+++ b/http/errors.go
@@ -19,12 +19,11 @@ import (
 )
 
 const (
-	errFailedToLoadKeys             string = "failed to load given keys"
-	errMethodIsNotImplemented       string = "the method is not implemented"
-	errFailedToGetContext           string = "failed to get context"
-	errPurgeRequestNonDeveloperMode string = "cannot purge database when development mode is disabled"
-	errMissingRequiredParameter     string = "required parameter %s is missing"
-	errCollectionNotFound           string = "collection not found"
+	errFailedToLoadKeys         string = "failed to load given keys"
+	errMethodIsNotImplemented   string = "the method is not implemented"
+	errFailedToGetContext       string = "failed to get context"
+	errMissingRequiredParameter string = "required parameter %s is missing"
+	errCollectionNotFound       string = "collection not found"
 )
 
 // Errors returnable from this package.

--- a/http/handler_extras.go
+++ b/http/handler_extras.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/getkin/kin-openapi/openapi3"
 
+	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/event"
 )
 
@@ -29,7 +30,7 @@ func (h *extrasHandler) Purge(rw http.ResponseWriter, req *http.Request) {
 		db := mustGetContextClientDB(req)
 		db.Events().Publish(event.NewMessage(event.PurgeName, nil))
 	} else {
-		responseJSON(rw, http.StatusBadRequest, errPurgeRequestNonDeveloperMode)
+		responseJSON(rw, http.StatusBadRequest, errorResponse{client.ErrPurgeWithDevModeDisabled})
 	}
 }
 

--- a/http/handler_extras.go
+++ b/http/handler_extras.go
@@ -30,7 +30,7 @@ func (h *extrasHandler) Purge(rw http.ResponseWriter, req *http.Request) {
 		db := mustGetContextClientDB(req)
 		db.Events().Publish(event.NewMessage(event.PurgeName, nil))
 	} else {
-		responseJSON(rw, http.StatusBadRequest, errorResponse{client.ErrPurgeWithDevModeDisabled})
+		responseJSON(rw, http.StatusBadRequest, errorResponse{client.NewErrOperationRequiresDeveloperMode("Purge")})
 	}
 }
 

--- a/http/handler_extras.go
+++ b/http/handler_extras.go
@@ -22,16 +22,15 @@ import (
 type extrasHandler struct{}
 
 func (h *extrasHandler) Purge(rw http.ResponseWriter, req *http.Request) {
-	db := mustGetContextClientDB(req)
-
 	// Send either 200 or 400 response based on whether the server is in dev mode
 	if IsDevMode {
 		rw.WriteHeader(http.StatusOK)
+
+		db := mustGetContextClientDB(req)
+		db.Events().Publish(event.NewMessage(event.PurgeName, nil))
 	} else {
 		responseJSON(rw, http.StatusBadRequest, errPurgeRequestNonDeveloperMode)
 	}
-
-	db.Events().Publish(event.NewMessage(event.PurgeName, nil))
 }
 
 func (h *extrasHandler) bindRoutes(router *Router) {

--- a/http/handler_extras_test.go
+++ b/http/handler_extras_test.go
@@ -54,16 +54,10 @@ func TestPurgeDevModeFalse(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, url, nil)
 	rec := httptest.NewRecorder()
 
-	purgeSub, err := cdb.Events().Subscribe(event.PurgeName)
-	require.NoError(t, err)
-
 	handler, err := NewHandler(cdb)
 	require.NoError(t, err)
 	handler.ServeHTTP(rec, req)
 
 	res := rec.Result()
 	require.Equal(t, 400, res.StatusCode)
-
-	// test will timeout if purge never received
-	<-purgeSub.Message()
 }

--- a/http/handler_store.go
+++ b/http/handler_store.go
@@ -50,6 +50,11 @@ func (h *storeHandler) BasicImport(rw http.ResponseWriter, req *http.Request) {
 }
 
 func (h *storeHandler) BasicExport(rw http.ResponseWriter, req *http.Request) {
+	if !IsDevMode {
+		responseJSON(rw, http.StatusBadRequest, errorResponse{client.NewErrOperationRequiresDeveloperMode("BasicExport")})
+		return
+	}
+
 	db := mustGetContextClientDB(req)
 	ctx := req.Context()
 

--- a/http/handler_store.go
+++ b/http/handler_store.go
@@ -34,6 +34,11 @@ const (
 type storeHandler struct{}
 
 func (h *storeHandler) BasicImport(rw http.ResponseWriter, req *http.Request) {
+	if !IsDevMode {
+		responseJSON(rw, http.StatusBadRequest, errorResponse{client.NewErrOperationRequiresDeveloperMode("BasicImport")})
+		return
+	}
+
 	db := mustGetContextClientDB(req)
 
 	var config client.BackupConfig

--- a/node/errors.go
+++ b/node/errors.go
@@ -24,7 +24,6 @@ const (
 var (
 	ErrSignerMissingForSourceHubACP = errors.New("a txn signer must be provided for SourceHub ACP")
 	ErrStoreTypeNotSupported        = errors.New(errStoreTypeNotSupported)
-	ErrPurgeWithDevModeDisabled     = errors.New("cannot purge database when development mode is disabled")
 	ErrP2PNotSupported              = errors.New("p2p networking is not supported by this build")
 	ErrNodeACPTypeNotSupported      = errors.New(errNodeACPTypeNotSupported)
 )

--- a/node/node.go
+++ b/node/node.go
@@ -171,7 +171,7 @@ func (n *Node) Close(ctx context.Context) error {
 // its datastore, and restart.
 func (n *Node) PurgeAndRestart(ctx context.Context) error {
 	if !n.opts.EnableDevelopment {
-		return ErrPurgeWithDevModeDisabled
+		return client.ErrPurgeWithDevModeDisabled
 	}
 
 	// This will purge document acp state.

--- a/node/node.go
+++ b/node/node.go
@@ -171,7 +171,7 @@ func (n *Node) Close(ctx context.Context) error {
 // its datastore, and restart.
 func (n *Node) PurgeAndRestart(ctx context.Context) error {
 	if !n.opts.EnableDevelopment {
-		return client.ErrPurgeWithDevModeDisabled
+		return client.NewErrOperationRequiresDeveloperMode("Purge")
 	}
 
 	// This will purge document acp state.

--- a/node/node_api.go
+++ b/node/node_api.go
@@ -28,6 +28,7 @@ func (n *Node) startAPI(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	http.IsDevMode = n.opts.EnableDevelopment
 
 	n.server, err = http.NewServer(handler, options.NodeHTTP().SetAll(n.opts.HTTP))
 	if err != nil {

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -39,7 +39,7 @@ func TestPurgeAndRestartWithDevModeDisabled(t *testing.T) {
 	require.NoError(t, err)
 
 	err = n.PurgeAndRestart(ctx)
-	require.ErrorIs(t, err, client.ErrPurgeWithDevModeDisabled)
+	require.ErrorIs(t, err, client.ErrOperationRequiresDeveloperMode)
 }
 
 func TestPurgeAndRestartWithDevModeEnabled(t *testing.T) {

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/options"
 )
 
@@ -38,7 +39,7 @@ func TestPurgeAndRestartWithDevModeDisabled(t *testing.T) {
 	require.NoError(t, err)
 
 	err = n.PurgeAndRestart(ctx)
-	require.ErrorIs(t, err, ErrPurgeWithDevModeDisabled)
+	require.ErrorIs(t, err, client.ErrPurgeWithDevModeDisabled)
 }
 
 func TestPurgeAndRestartWithDevModeEnabled(t *testing.T) {

--- a/tests/integration/client_setup.go
+++ b/tests/integration/client_setup.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 
 	cbindings "github.com/sourcenetwork/defradb/cbindings"
+	prodHttp "github.com/sourcenetwork/defradb/http"
 	"github.com/sourcenetwork/defradb/node"
 	"github.com/sourcenetwork/defradb/tests/clients"
 	"github.com/sourcenetwork/defradb/tests/clients/cli"
@@ -39,6 +40,10 @@ func init() {
 // testing state. The client type on the test state is used to
 // select the client implementation to use.
 func setupClient(s *state.State, nodeObj *node.Node) (clients.Client, error) {
+	// The test suite completely bypasses the way production consumes the node options,
+	// including the configuration of IsDevMode, so we have to hard code it here for now.
+	prodHttp.IsDevMode = true
+
 	switch s.ClientType {
 	case state.HTTPClientType:
 		return http.NewWrapper(nodeObj)

--- a/tests/integration/db.go
+++ b/tests/integration/db.go
@@ -96,6 +96,7 @@ func NewBadgerMemoryDB(ctx context.Context) (node.DB, error) {
 	opts := options.Node().
 		SetDisableP2P(true).
 		SetDisableAPI(true).
+		SetEnableDevelopment(true).
 		Store().SetBadgerInMemory(true).
 		Node()
 
@@ -116,6 +117,7 @@ func NewBadgerFileDB(ctx context.Context, t testing.TB) (node.DB, error) {
 	opts := options.Node().
 		SetDisableP2P(true).
 		SetDisableAPI(true).
+		SetEnableDevelopment(true).
 		Store().SetPath(path).
 		Node()
 

--- a/tests/integration/db_setup.go
+++ b/tests/integration/db_setup.go
@@ -134,6 +134,8 @@ func setupNode(
 		opts.SetDisableP2P(false)
 	}
 
+	opts.SetEnableDevelopment(true)
+
 	nodeObj, err := node.New(s.Ctx, opts)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4547

## Description

Requires dev-mode for import/export.

The implementation on dev-mode is not wonderful in my opinion, and this feature is built on top of it.  This should be reworked in the near future, along with the very unusual implementation of purge.

## How has this been tested?

We are short on time, and the dev-mode implementation does not facilitate proper tests, so I tested this manually.   A ticket has been created to close the test gap https://github.com/sourcenetwork/defradb/issues/4570
