### PR TITLE
feat: Accept arrays of CIDs for GQL queries

### DIFF
--- a/client/request/cid.go
+++ b/client/request/cid.go
@@ -15,11 +15,11 @@ import "github.com/sourcenetwork/immutable"
 // CIDFilter is an embeddable struct that hosts a consistent set of properties
 // for filtering an aspect of a request by commit CID.
 type CIDFilter struct {
-	// CID is an optional value that selects a single document at the given commit CID
+	// CIDs is an optional value that selects a single document at each given commit's CID
 	// for processing by the request.
 	//
-	// If a commit matching the given CID is not found an error will be returned. The commit
+	// If a commit matching the given CIDs is not found an error will be returned. The commit
 	// does not need to be the latest, and this property allows viewing of the document at
 	// prior revisions.
-	CID immutable.Option[string]
+	CIDs immutable.Option[[]string]
 }

--- a/client/request/commit.go
+++ b/client/request/commit.go
@@ -11,6 +11,8 @@
 package request
 
 import (
+	"slices"
+
 	"github.com/sourcenetwork/immutable"
 )
 
@@ -69,7 +71,7 @@ func (c CommitSelect) ToSubscriptionSelect(_, cid string) Selection {
 		},
 		DocID: c.DocID,
 		CIDFilter: CIDFilter{
-			immutable.Some(cid),
+			immutable.Some([]string{cid}),
 		},
 		ChildSelect: c.ChildSelect,
 	}
@@ -79,10 +81,7 @@ func (c CommitSelect) ToSubscriptionSelect(_, cid string) Selection {
 // Returns true if the cid passes the filter, false otherwise.
 // If no CID filter is set, it always passes.
 func (c CommitSelect) CheckCIDFilter(cid string) bool {
-	if c.CID.HasValue() && c.CID.Value() != cid {
-		return false
-	}
-	return true
+	return !c.CIDs.HasValue() || slices.Contains(c.CIDs.Value(), cid)
 }
 
 // CheckDocIDFilter checks if the given docID passes the DocID filter.

--- a/client/request/select.go
+++ b/client/request/select.go
@@ -12,6 +12,7 @@ package request
 
 import (
 	"encoding/json"
+	"slices"
 
 	"github.com/sourcenetwork/immutable"
 )
@@ -132,7 +133,7 @@ func (s *Select) ToSubscriptionSelect(docID, cid string) Selection {
 		Filterable:   s.Filterable,
 		DocIDsFilter: docIDFilter,
 		CIDFilter: CIDFilter{
-			immutable.Some(cid),
+			immutable.Some([]string{cid}),
 		},
 		Groupable:   s.Groupable,
 		ShowDeleted: s.ShowDeleted,
@@ -143,10 +144,7 @@ func (s *Select) ToSubscriptionSelect(docID, cid string) Selection {
 // Returns true if the cid passes the filter, false otherwise.
 // If no CID filter is set, it always passes.
 func (s *Select) CheckCIDFilter(cid string) bool {
-	if s.CID.HasValue() && s.CID.Value() != cid {
-		return false
-	}
-	return true
+	return !s.CIDs.HasValue() || slices.Contains(s.CIDs.Value(), cid)
 }
 
 // CheckDocIDFilter checks if the given docID passes the DocID filter.
@@ -190,7 +188,7 @@ func (s *Select) UnmarshalJSON(bytes []byte) error {
 
 	s.Field = selectMap.Field
 	s.DocIDs = selectMap.DocIDs
-	s.CID = selectMap.CID
+	s.CIDs = selectMap.CIDs
 	s.Limitable = selectMap.Limitable
 	s.Offsetable = selectMap.Offsetable
 	s.Orderable = selectMap.Orderable

--- a/internal/planner/commit.go
+++ b/internal/planner/commit.go
@@ -104,7 +104,7 @@ func (n *dagScanNode) Init() error {
 	}
 
 	// only need the head fetcher for non cid specific queries
-	if !n.commitSelect.Cid.HasValue() && len(n.queuedCids) == 0 {
+	if !n.commitSelect.Cids.HasValue() && len(n.queuedCids) == 0 {
 		n.fetcherStarted = true
 		return n.fetcher.Start(n.planner.ctx, n.prefix)
 	}
@@ -141,7 +141,7 @@ func (n *dagScanNode) Prefixes(prefixes []keys.Walkable) {
 }
 
 func (n *dagScanNode) Close() error {
-	if !n.commitSelect.Cid.HasValue() {
+	if !n.commitSelect.Cids.HasValue() {
 		return n.fetcher.Close()
 	}
 	return nil
@@ -153,8 +153,8 @@ func (n *dagScanNode) simpleExplain() (map[string]any, error) {
 	simpleExplainMap := map[string]any{}
 
 	// Add the cid attribute to the explanation if it exists.
-	if n.commitSelect.Cid.HasValue() {
-		simpleExplainMap["cid"] = n.commitSelect.Cid.Value()
+	if n.commitSelect.Cids.HasValue() {
+		simpleExplainMap["cid"] = n.commitSelect.Cids.Value()
 	} else {
 		simpleExplainMap["cid"] = nil
 	}
@@ -198,14 +198,18 @@ func (n *dagScanNode) Next() (bool, error) {
 	if len(n.queuedCids) > 0 {
 		currentCid = n.queuedCids[0]
 		n.queuedCids = n.queuedCids[1:(len(n.queuedCids))]
-	} else if n.commitSelect.Cid.HasValue() && len(n.visitedNodes) == 0 {
-		cid, err := cid.Parse(n.commitSelect.Cid.Value())
+	} else if n.commitSelect.Cids.HasValue() && len(n.visitedNodes) == 0 {
+		if len(n.commitSelect.Cids.Value()) == 0 {
+			return false, nil
+		}
+
+		cid, err := cid.Parse(n.commitSelect.Cids.Value()[0])
 		if err != nil {
 			return false, err
 		}
 
 		currentCid = &cid
-	} else if !n.commitSelect.Cid.HasValue() && n.fetcherStarted {
+	} else if !n.commitSelect.Cids.HasValue() && n.fetcherStarted {
 		cid, err := n.fetcher.FetchNext()
 		if err != nil || cid == nil {
 			return false, err
@@ -249,7 +253,7 @@ func (n *dagScanNode) Next() (bool, error) {
 	// target block actually belongs to the doc, since we are
 	// bypassing the HeadFetcher for the first cid
 	currentDocID := n.commitSelect.DocumentMapping.FirstOfName(currentValue, request.DocIDArgName)
-	if n.commitSelect.Cid.HasValue() &&
+	if n.commitSelect.Cids.HasValue() &&
 		len(n.visitedNodes) == 0 &&
 		n.commitSelect.DocID.HasValue() &&
 		currentDocID != n.commitSelect.DocID.Value() {
@@ -271,7 +275,7 @@ func (n *dagScanNode) Next() (bool, error) {
 	// doc ID, max depth
 	// just doc ID + CID, 0 depth
 	// doc ID + CID + depth, use depth
-	if (!n.commitSelect.Depth.HasValue() && !n.commitSelect.Cid.HasValue()) ||
+	if (!n.commitSelect.Depth.HasValue() && !n.commitSelect.Cids.HasValue()) ||
 		(n.commitSelect.Depth.HasValue() && n.depthVisited < n.commitSelect.Depth.Value()) {
 		// Insert the newly fetched cids into the slice of queued items, in reverse order
 		// so that the last new cid will be at the front of the slice

--- a/internal/planner/mapper/commitSelect.go
+++ b/internal/planner/mapper/commitSelect.go
@@ -25,8 +25,8 @@ type CommitSelect struct {
 	// The maximum depth to yield results for.
 	Depth immutable.Option[uint64]
 
-	// The parent Cid for which commit information has been requested.
-	Cid immutable.Option[string]
+	// The parent Cids for which commit information has been requested.
+	Cids immutable.Option[[]string]
 
 	// The CollectionVersionID at the time of commit.
 	CollectionVersionID immutable.Option[string]
@@ -40,6 +40,6 @@ func (s *CommitSelect) cloneTo(index int) *CommitSelect {
 	return &CommitSelect{
 		Select: *s.Select.cloneTo(index),
 		DocID:  s.DocID,
-		Cid:    s.Cid,
+		Cids:   s.Cids,
 	}
 }

--- a/internal/planner/mapper/mapper.go
+++ b/internal/planner/mapper/mapper.go
@@ -225,7 +225,7 @@ func toSelect(
 	return &Select{
 		Targetable:      targetable,
 		DocumentMapping: mapping,
-		Cid:             selectRequest.CID,
+		Cids:            selectRequest.CIDs,
 		CollectionName:  collectionName,
 		Fields:          fields,
 		IsEncrypted:     selectRequest.IsEncrypted,
@@ -1331,7 +1331,7 @@ func toCommitSelect(
 		Select: *underlyingSelect,
 		DocID:  selectRequest.DocID,
 		Depth:  selectRequest.Depth,
-		Cid:    selectRequest.CID,
+		Cids:   selectRequest.CIDs,
 	}, nil
 }
 

--- a/internal/planner/mapper/select.go
+++ b/internal/planner/mapper/select.go
@@ -27,8 +27,8 @@ type Select struct {
 	// for this select can be accessed and rendered.
 	*core.DocumentMapping
 
-	// A commit identifier that can be specified to request data at a given time.
-	Cid immutable.Option[string]
+	// Commit identifiers that can be specified to request data at a given time.
+	Cids immutable.Option[[]string]
 
 	// The name of the collection that this Select selects data from.
 	CollectionName string
@@ -65,7 +65,7 @@ func (s *Select) cloneTo(index int) *Select {
 	return &Select{
 		Targetable:      *s.Targetable.cloneTo(index),
 		DocumentMapping: s.DocumentMapping,
-		Cid:             s.Cid,
+		Cids:            s.Cids,
 		CollectionName:  s.CollectionName,
 		Fields:          s.Fields,
 		SkipResolve:     s.SkipResolve,

--- a/internal/planner/scan.go
+++ b/internal/planner/scan.go
@@ -161,7 +161,7 @@ func (n *scanNode) addField(field client.CollectionFieldDescription) {
 	}
 }
 
-func (n *scanNode) initFetcher(cid immutable.Option[string]) {
+func (n *scanNode) initFetcher(cid immutable.Option[[]string]) {
 	var f fetcher.Fetcher
 	if cid.HasValue() {
 		f = new(fetcher.VersionedFetcher)

--- a/internal/planner/select.go
+++ b/internal/planner/select.go
@@ -287,23 +287,25 @@ func (n *selectNode) initSource() ([]aggregateNode, []*similarityNode, error) {
 
 		// If we have a CID, then we need to run a TimeTravel (History-Traversing Versioned)
 		// query, which means we need to propagate the values to the underlying VersionedFetcher
-		if n.selectReq.Cid.HasValue() {
-			c, err := cid.Decode(n.selectReq.Cid.Value())
-			if err != nil {
-				return nil, nil, err
+		if n.selectReq.Cids.HasValue() {
+			prefixes := make([]keys.Walkable, len(n.selectReq.Cids.Value()))
+
+			for i, sCid := range n.selectReq.Cids.Value() {
+				c, err := cid.Decode(sCid)
+				if err != nil {
+					return nil, nil, err
+				}
+
+				prefixes[i] = keys.HeadstoreDocKey{
+					Cid: c,
+				}
 			}
 
 			// This exists because the fetcher interface demands a []Prefixes, yet the versioned
 			// fetcher type (that will be the only one consuming this []Prefixes) does not use it
 			// as a prefix. And with this design limitation this is
 			// currently the least bad way of passing the cid in to the fetcher.
-			origScan.Prefixes(
-				[]keys.Walkable{
-					keys.HeadstoreDocKey{
-						Cid: c,
-					},
-				},
-			)
+			origScan.Prefixes(prefixes)
 		} else if n.selectReq.DocIDs.HasValue() {
 			shortID, err := id.GetShortCollectionID(
 				n.planner.ctx,
@@ -342,7 +344,7 @@ func (n *selectNode) initSource() ([]aggregateNode, []*similarityNode, error) {
 			// if we can not use index for filtering, try to use index for ordering
 			origScan.index = findIndexByOrderingField(origScan)
 		}
-		origScan.initFetcher(n.selectReq.Cid)
+		origScan.initFetcher(n.selectReq.Cids)
 	}
 
 	return aggregates, similarity, nil
@@ -464,8 +466,8 @@ func (n *selectNode) initFields(selectReq *mapper.Select) ([]aggregateNode, []*s
 					Select: *f,
 				}
 
-				if selectReq.Cid.HasValue() {
-					commitSlct.Cid = selectReq.Cid
+				if selectReq.Cids.HasValue() {
+					commitSlct.Cids = selectReq.Cids
 
 					// We want all the commits, so set the maximum depth
 					commitSlct.Depth = immutable.Some(uint64(math.MaxUint64))

--- a/internal/planner/type_join.go
+++ b/internal/planner/type_join.go
@@ -647,7 +647,7 @@ func (r *primaryObjectsRetriever) retrievePrimaryDocs() ([]core.Doc, error) {
 		}
 	}
 
-	r.primaryScan.initFetcher(immutable.None[string]())
+	r.primaryScan.initFetcher(immutable.None[[]string]())
 
 	docs, err := r.collectDocs(0)
 	if err != nil {
@@ -860,7 +860,7 @@ func (join *invertibleTypeJoin) invertJoinDirectionWithIndex(
 	childScan.filter = fieldFilter
 	childScan.index = immutable.Some(index)
 	childScan.ordering = ordering
-	childScan.initFetcher(immutable.Option[string]{})
+	childScan.initFetcher(immutable.Option[[]string]{})
 
 	join.childSide.isFirst = join.parentSide.isFirst
 	join.parentSide.isFirst = !join.parentSide.isFirst

--- a/internal/request/graphql/parser/commit.go
+++ b/internal/request/graphql/parser/commit.go
@@ -44,9 +44,22 @@ func parseCommitSelect(
 			}
 
 		case request.CidFieldName:
-			if v, ok := value.(string); ok {
-				commit.CID = immutable.Some(v)
+			v, ok := value.([]any)
+			if !ok {
+				continue // value is nil
 			}
+
+			if len(v) > 1 {
+				// todo - This limitiation is temporary and should be removed in
+				// https://github.com/sourcenetwork/defradb/issues/4303
+				return nil, ErrMultipleCidsNotSupported
+			}
+
+			cids := make([]string, len(v))
+			for i, value := range v {
+				cids[i] = value.(string)
+			}
+			commit.CIDs = immutable.Some(cids)
 
 		case request.OrderClause:
 			v, ok := value.([]any)

--- a/internal/request/graphql/parser/errors.go
+++ b/internal/request/graphql/parser/errors.go
@@ -26,4 +26,5 @@ var (
 	ErrUnknownGQLOperation            = errors.New("unknown GraphQL operation type")
 	ErrInvalidFilterConditions        = errors.New("invalid filter condition type, expected map")
 	ErrMultipleOrderFieldsDefined     = errors.New("each order argument can only define one field")
+	ErrMultipleCidsNotSupported       = errors.New("querying by multiple cids is not yet supported")
 )

--- a/internal/request/graphql/parser/query.go
+++ b/internal/request/graphql/parser/query.go
@@ -127,9 +127,22 @@ func parseSelect(
 			slct.DocIDs = immutable.Some(docIDs)
 
 		case request.CidFieldName: // parse single CID query field
-			if v, ok := value.(string); ok {
-				slct.CID = immutable.Some(v)
+			v, ok := value.([]any)
+			if !ok {
+				continue // value is nil
 			}
+
+			if len(v) > 1 {
+				// todo - This limitiation is temporary and should be removed in
+				// https://github.com/sourcenetwork/defradb/issues/4304
+				return nil, ErrMultipleCidsNotSupported
+			}
+
+			cids := make([]string, len(v))
+			for i, value := range v {
+				cids[i] = value.(string)
+			}
+			slct.CIDs = immutable.Some(cids)
 
 		case request.LimitClause: // parse limit/offset
 			if v, ok := value.(int32); ok {

--- a/internal/request/graphql/schema/generate.go
+++ b/internal/request/graphql/schema/generate.go
@@ -1560,7 +1560,7 @@ func (g *Generator) genTypeQueryableFieldList(
 		Type:        gql.NewList(obj),
 		Args: gql.FieldConfigArgument{
 			request.DocIDArgName: schemaTypes.NewArgConfig(gql.NewList(gql.NewNonNull(gql.ID)), docIDsArgDescription),
-			"cid":                schemaTypes.NewArgConfig(gql.String, cidArgDescription),
+			request.CidArgName:   schemaTypes.NewArgConfig(gql.NewList(gql.NewNonNull(gql.ID)), cidArgDescription),
 			"filter":             schemaTypes.NewArgConfig(config.filter, selectFilterArgDescription),
 			"groupBy": schemaTypes.NewArgConfig(
 				gql.NewList(gql.NewNonNull(config.groupBy)),

--- a/internal/request/graphql/schema/testfixtures/schema.relatedmany.gen.graphql
+++ b/internal/request/graphql/schema/testfixtures/schema.relatedmany.gen.graphql
@@ -92,7 +92,7 @@ type Subscription {
     If a matching commit is not found then an empty set will be returned.
 
     """
-cid: String,     """
+cid: [ID!],     """
     
     An optional set of docIDs for this field. Only documents with a docID
     matching a docID in the given set will be returned.  If no documents match,
@@ -150,7 +150,7 @@ showDeleted: Boolean): [Author]
     If a matching commit is not found then an empty set will be returned.
 
     """
-cid: String,     """
+cid: [ID!],     """
     
     An optional set of docIDs for this field. Only documents with a docID
     matching a docID in the given set will be returned.  If no documents match,
@@ -208,11 +208,11 @@ showDeleted: Boolean): [Book]
     """
     _commits(    """
     
-    An optional value that specifies the commit ID of the commits to return. If a
+    An optional value that specifies the commit IDs of the commits to return. If a
     matching commit is not found then an empty set will be returned.
 
     """
-cid: ID,     """
+cid: [ID!],     """
     
     An optional value that specifies the maximum depth to which the commit DAG graph
     should be traversed from matching commits.
@@ -359,7 +359,7 @@ type Query {
     If a matching commit is not found then an empty set will be returned.
 
     """
-cid: String,     """
+cid: [ID!],     """
     
     An optional set of docIDs for this field. Only documents with a docID
     matching a docID in the given set will be returned.  If no documents match,
@@ -417,7 +417,7 @@ showDeleted: Boolean): [Author]
     If a matching commit is not found then an empty set will be returned.
 
     """
-cid: String,     """
+cid: [ID!],     """
     
     An optional set of docIDs for this field. Only documents with a docID
     matching a docID in the given set will be returned.  If no documents match,
@@ -483,11 +483,11 @@ showDeleted: Boolean): [Book]
     """
     _commits(    """
     
-    An optional value that specifies the commit ID of the commits to return. If a
+    An optional value that specifies the commit IDs of the commits to return. If a
     matching commit is not found then an empty set will be returned.
 
     """
-cid: ID,     """
+cid: [ID!],     """
     
     An optional value that specifies the maximum depth to which the commit DAG graph
     should be traversed from matching commits.
@@ -812,11 +812,11 @@ type Commit {
     """
     heads(    """
     
-    An optional value that specifies the commit ID of the commits to return. If a
+    An optional value that specifies the commit IDs of the commits to return. If a
     matching commit is not found then an empty set will be returned.
 
     """
-cid: ID,     """
+cid: [ID!],     """
     
     An optional docID parameter for this commit query. Only commits for a document
     with a matching docID will be returned.  If no documents match, the result
@@ -858,11 +858,11 @@ order: [commitsOrderArg]): [Commit]
     """
     links(    """
     
-    An optional value that specifies the commit ID of the commits to return. If a
+    An optional value that specifies the commit IDs of the commits to return. If a
     matching commit is not found then an empty set will be returned.
 
     """
-cid: ID,     """
+cid: [ID!],     """
     
     An optional docID parameter for this commit query. Only commits for a document
     with a matching docID will be returned.  If no documents match, the result

--- a/internal/request/graphql/schema/testfixtures/schema.relatedone.gen.graphql
+++ b/internal/request/graphql/schema/testfixtures/schema.relatedone.gen.graphql
@@ -244,7 +244,7 @@ type Query {
     If a matching commit is not found then an empty set will be returned.
 
     """
-cid: String,     """
+cid: [ID!],     """
     
     An optional set of docIDs for this field. Only documents with a docID
     matching a docID in the given set will be returned.  If no documents match,
@@ -302,7 +302,7 @@ showDeleted: Boolean): [Author]
     If a matching commit is not found then an empty set will be returned.
 
     """
-cid: String,     """
+cid: [ID!],     """
     
     An optional set of docIDs for this field. Only documents with a docID
     matching a docID in the given set will be returned.  If no documents match,
@@ -368,11 +368,11 @@ showDeleted: Boolean): [Book]
     """
     _commits(    """
     
-    An optional value that specifies the commit ID of the commits to return. If a
+    An optional value that specifies the commit IDs of the commits to return. If a
     matching commit is not found then an empty set will be returned.
 
     """
-cid: ID,     """
+cid: [ID!],     """
     
     An optional value that specifies the maximum depth to which the commit DAG graph
     should be traversed from matching commits.
@@ -807,11 +807,11 @@ type Commit {
     """
     heads(    """
     
-    An optional value that specifies the commit ID of the commits to return. If a
+    An optional value that specifies the commit IDs of the commits to return. If a
     matching commit is not found then an empty set will be returned.
 
     """
-cid: ID,     """
+cid: [ID!],     """
     
     An optional docID parameter for this commit query. Only commits for a document
     with a matching docID will be returned.  If no documents match, the result
@@ -853,11 +853,11 @@ order: [commitsOrderArg]): [Commit]
     """
     links(    """
     
-    An optional value that specifies the commit ID of the commits to return. If a
+    An optional value that specifies the commit IDs of the commits to return. If a
     matching commit is not found then an empty set will be returned.
 
     """
-cid: ID,     """
+cid: [ID!],     """
     
     An optional docID parameter for this commit query. Only commits for a document
     with a matching docID will be returned.  If no documents match, the result
@@ -1346,7 +1346,7 @@ type Subscription {
     If a matching commit is not found then an empty set will be returned.
 
     """
-cid: String,     """
+cid: [ID!],     """
     
     An optional set of docIDs for this field. Only documents with a docID
     matching a docID in the given set will be returned.  If no documents match,
@@ -1404,7 +1404,7 @@ showDeleted: Boolean): [Author]
     If a matching commit is not found then an empty set will be returned.
 
     """
-cid: String,     """
+cid: [ID!],     """
     
     An optional set of docIDs for this field. Only documents with a docID
     matching a docID in the given set will be returned.  If no documents match,
@@ -1462,11 +1462,11 @@ showDeleted: Boolean): [Book]
     """
     _commits(    """
     
-    An optional value that specifies the commit ID of the commits to return. If a
+    An optional value that specifies the commit IDs of the commits to return. If a
     matching commit is not found then an empty set will be returned.
 
     """
-cid: ID,     """
+cid: [ID!],     """
     
     An optional value that specifies the maximum depth to which the commit DAG graph
     should be traversed from matching commits.

--- a/internal/request/graphql/schema/testfixtures/schema.simple.gen.graphql
+++ b/internal/request/graphql/schema/testfixtures/schema.simple.gen.graphql
@@ -381,11 +381,11 @@ type Commit {
     """
     heads(    """
     
-    An optional value that specifies the commit ID of the commits to return. If a
+    An optional value that specifies the commit IDs of the commits to return. If a
     matching commit is not found then an empty set will be returned.
 
     """
-cid: ID,     """
+cid: [ID!],     """
     
     An optional docID parameter for this commit query. Only commits for a document
     with a matching docID will be returned.  If no documents match, the result
@@ -427,11 +427,11 @@ order: [commitsOrderArg]): [Commit]
     """
     links(    """
     
-    An optional value that specifies the commit ID of the commits to return. If a
+    An optional value that specifies the commit IDs of the commits to return. If a
     matching commit is not found then an empty set will be returned.
 
     """
-cid: ID,     """
+cid: [ID!],     """
     
     An optional docID parameter for this commit query. Only commits for a document
     with a matching docID will be returned.  If no documents match, the result
@@ -826,7 +826,7 @@ type Query {
     If a matching commit is not found then an empty set will be returned.
 
     """
-cid: String,     """
+cid: [ID!],     """
     
     An optional set of docIDs for this field. Only documents with a docID
     matching a docID in the given set will be returned.  If no documents match,
@@ -892,11 +892,11 @@ showDeleted: Boolean): [User]
     """
     _commits(    """
     
-    An optional value that specifies the commit ID of the commits to return. If a
+    An optional value that specifies the commit IDs of the commits to return. If a
     matching commit is not found then an empty set will be returned.
 
     """
-cid: ID,     """
+cid: [ID!],     """
     
     An optional value that specifies the maximum depth to which the commit DAG graph
     should be traversed from matching commits.
@@ -1423,7 +1423,7 @@ type Subscription {
     If a matching commit is not found then an empty set will be returned.
 
     """
-cid: String,     """
+cid: [ID!],     """
     
     An optional set of docIDs for this field. Only documents with a docID
     matching a docID in the given set will be returned.  If no documents match,
@@ -1481,11 +1481,11 @@ showDeleted: Boolean): [User]
     """
     _commits(    """
     
-    An optional value that specifies the commit ID of the commits to return. If a
+    An optional value that specifies the commit IDs of the commits to return. If a
     matching commit is not found then an empty set will be returned.
 
     """
-cid: ID,     """
+cid: [ID!],     """
     
     An optional value that specifies the maximum depth to which the commit DAG graph
     should be traversed from matching commits.

--- a/internal/request/graphql/schema/types/commits.go
+++ b/internal/request/graphql/schema/types/commits.go
@@ -54,7 +54,7 @@ func CommitObject(
 				request.DocIDArgName: NewArgConfig(gql.ID, commitDocIDArgDescription),
 				request.FilterClause: NewArgConfig(commitsFilterArg, "Filter results based on specified conditions."),
 				"order":              NewArgConfig(gql.NewList(commitsOrderArg), OrderArgDescription),
-				request.CidArgName:   NewArgConfig(gql.ID, commitCIDArgDescription),
+				request.CidArgName:   NewArgConfig(gql.NewList(gql.NewNonNull(gql.ID)), commitCIDArgDescription),
 				"groupBy": NewArgConfig(
 					gql.NewList(
 						gql.NewNonNull(
@@ -274,7 +274,7 @@ func QueryCommits(
 			request.DocIDArgName: NewArgConfig(gql.ID, commitDocIDArgDescription),
 			request.FilterClause: NewArgConfig(commitsFilterArg, "Filter results based on specified conditions."),
 			"order":              NewArgConfig(gql.NewList(commitsOrderArg), OrderArgDescription),
-			request.CidArgName:   NewArgConfig(gql.ID, commitCIDArgDescription),
+			request.CidArgName:   NewArgConfig(gql.NewList(gql.NewNonNull(gql.ID)), commitCIDArgDescription),
 			"groupBy": NewArgConfig(
 				gql.NewList(
 					gql.NewNonNull(

--- a/internal/request/graphql/schema/types/descriptions.go
+++ b/internal/request/graphql/schema/types/descriptions.go
@@ -50,7 +50,7 @@ An optional field name parameter for this commit query. Only commits for a field
  composite (document level) commits only. If no fields match, the result set will be empty.
 `
 	commitCIDArgDescription string = `
-An optional value that specifies the commit ID of the commits to return. If a
+An optional value that specifies the commit IDs of the commits to return. If a
  matching commit is not found then an empty set will be returned.
 `
 	commitDepthArgDescription string = `

--- a/tests/action/assert_request.go
+++ b/tests/action/assert_request.go
@@ -97,7 +97,7 @@ func assertRequestResults(
 	}
 
 	if expectedResults == nil && result.Data == nil {
-		return true
+		return false
 	}
 
 	// Note: if result.Data == nil this panics (the panic seems useful while testing).

--- a/tests/action/explain_request.go
+++ b/tests/action/explain_request.go
@@ -238,6 +238,8 @@ func assertErrors(t testing.TB, errs []error, expectedError string) bool {
 			errorString := e.Error()
 			if errorString == expectedError || contains(errorString, expectedError) {
 				return true
+			} else {
+				require.ErrorContains(t, e, expectedError)
 			}
 		}
 	}

--- a/tests/integration/collection_version/default_fields.go
+++ b/tests/integration/collection_version/default_fields.go
@@ -163,8 +163,12 @@ var similarityField = Field{
 var cidArg = Field{
 	"name": "cid",
 	"type": map[string]any{
-		"name":        "String",
+		"name":        nil,
 		"inputFields": nil,
+		"ofType": map[string]any{
+			"kind": "NON_NULL",
+			"name": nil,
+		},
 	},
 }
 var docIDArg = Field{

--- a/tests/integration/query/commits/with_cid_test.go
+++ b/tests/integration/query/commits/with_cid_test.go
@@ -185,3 +185,69 @@ func TestQueryCommitsWithUnknownCid(t *testing.T) {
 
 	testUtils.ExecuteTestCase(t, test)
 }
+
+func TestQueryCommits_MultipleCids(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			updateUserCollectionSchema(),
+			&action.CreateDoc{
+				CollectionID: 0,
+				Doc: `{
+						"name":	"John",
+						"age":	21
+					}`,
+			},
+			testUtils.UpdateDoc{
+				CollectionID: 0,
+				DocID:        0,
+				Doc: `{
+					"age":	22
+				}`,
+			},
+			&action.Request{
+				Request: `query {
+						_commits(
+							cid: ["bafyreiejjfevlp5wrfl5o7bxbdtjj4th36lbdjov5gdkmy5n5jzs6dcmpu", "bafyreigonvri5vfdosfgp4qxtq46snjxm7cnjlzizrod2wy3l53jbxiysm"]
+						) {
+							cid
+						}
+					}`,
+				ExpectedError: "querying by multiple cids is not yet supported",
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+func TestQueryCommits_ListOfOne(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			updateUserCollectionSchema(),
+			&action.CreateDoc{
+				CollectionID: 0,
+				Doc: `{
+						"name":	"John",
+						"age":	21
+					}`,
+			},
+			&action.Request{
+				Request: `query {
+						_commits(
+							cid: ["bafyreiejjfevlp5wrfl5o7bxbdtjj4th36lbdjov5gdkmy5n5jzs6dcmpu"]
+						) {
+							cid
+						}
+					}`,
+				Results: map[string]any{
+					"_commits": []map[string]any{
+						{
+							"cid": "bafyreiejjfevlp5wrfl5o7bxbdtjj4th36lbdjov5gdkmy5n5jzs6dcmpu",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/query/simple/with_cid_test.go
+++ b/tests/integration/query/simple/with_cid_test.go
@@ -78,6 +78,32 @@ func TestQuerySimpleWithCid(t *testing.T) {
 	testUtils.ExecuteTestCase(t, test)
 }
 
+func TestQuerySimple_UnknownCid(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddSchema{
+				Schema: `
+					type Users {
+						name: String
+					}
+				`,
+			},
+			&action.Request{
+				Request: `query {
+					Users (
+							cid: "bafyreifldhofx6cwi6ashk24rcefsuiqje5a2rziwcyte54z27wmgv4pey"
+						) {
+						name
+					}
+				}`,
+				ExpectedError: "seek failed: (version fetcher) failed to get block in blockstore: ipld: could not find",
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
 func TestQuerySimpleWithCid_MultipleDocs(t *testing.T) {
 	test := testUtils.TestCase{
 		Actions: []any{

--- a/tests/integration/query/simple/with_cid_test.go
+++ b/tests/integration/query/simple/with_cid_test.go
@@ -232,3 +232,71 @@ func TestQuerySimple_WithCidAfterDeleteOperation_ShouldReturnUser(t *testing.T) 
 
 	testUtils.ExecuteTestCase(t, test)
 }
+
+func TestQuerySimple_ListOfOneCID(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddSchema{
+				Schema: `
+					type Users {
+						name: String
+					}
+				`,
+			},
+			&action.CreateDoc{
+				Doc: `{
+					"name": "John"
+				}`,
+			},
+			&action.Request{
+				Request: `query {
+					Users (
+							cid: ["bafyreifldhofx6cwi6ashk24rcefsuiqje5a2rziwcyte54z27wmgv4pey"]
+						) {
+						name
+					}
+				}`,
+				Results: map[string]any{
+					"Users": []map[string]any{
+						{
+							"name": "John",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestQuerySimple_MultipleCIDs(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddSchema{
+				Schema: `
+					type Users {
+						name: String
+					}
+				`,
+			},
+			&action.CreateDoc{
+				Doc: `{
+					"name": "John"
+				}`,
+			},
+			&action.Request{
+				Request: `query {
+					Users (
+							cid: ["bafyreifldhofx6cwi6ashk24rcefsuiqje5a2rziwcyte54z27wmgv4pey", "bafyreic2vrbl344kkc7h5d7e2hpnwvffta4ck73bvjs5acgjtvqubvvioe"]
+						) {
+						name
+					}
+				}`,
+				ExpectedError: "querying by multiple cids is not yet supported",
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4565
Resolves #4568

## Description

Accepts arrays of CIDs for GQL queries - both for normal collection requests, and for commit queries.

It does not change the behaviour where an error will be returned if no matching documents are found for a cid.  It does not implement the feature, and an error will be returned if more than one cid is provided.