### PR TITLE
feat: Change GQL commits.docId param to list

### DIFF
--- a/client/request/commit.go
+++ b/client/request/commit.go
@@ -49,6 +49,7 @@ func (c CommitSelect) ToSelect() *Select {
 			Alias: c.Alias,
 		},
 		DocIDsFilter: c.DocIDsFilter,
+		CIDFilter:    c.CIDFilter,
 		Limitable:    c.Limitable,
 		Offsetable:   c.Offsetable,
 		Orderable:    c.Orderable,

--- a/client/request/commit.go
+++ b/client/request/commit.go
@@ -26,16 +26,13 @@ type CommitSelect struct {
 	ChildSelect
 
 	CIDFilter
+	DocIDsFilter
 
 	Limitable
 	Offsetable
 	Orderable
 	Groupable
 	Filterable
-
-	// DocID is an optional filter which when provided will limit commits to those
-	// belonging to the given document.
-	DocID immutable.Option[string]
 
 	// Depth limits the returned commits to being X places in the history away from the
 	// most current.
@@ -51,12 +48,13 @@ func (c CommitSelect) ToSelect() *Select {
 			Name:  c.Name,
 			Alias: c.Alias,
 		},
-		Limitable:   c.Limitable,
-		Offsetable:  c.Offsetable,
-		Orderable:   c.Orderable,
-		Groupable:   c.Groupable,
-		Filterable:  c.Filterable,
-		ChildSelect: c.ChildSelect,
+		DocIDsFilter: c.DocIDsFilter,
+		Limitable:    c.Limitable,
+		Offsetable:   c.Offsetable,
+		Orderable:    c.Orderable,
+		Groupable:    c.Groupable,
+		Filterable:   c.Filterable,
+		ChildSelect:  c.ChildSelect,
 	}
 }
 
@@ -69,7 +67,7 @@ func (c CommitSelect) ToSubscriptionSelect(_, cid string) Selection {
 			Name:  c.Name,
 			Alias: c.Alias,
 		},
-		DocID: c.DocID,
+		DocIDsFilter: c.DocIDsFilter,
 		CIDFilter: CIDFilter{
 			immutable.Some([]string{cid}),
 		},
@@ -88,8 +86,5 @@ func (c CommitSelect) CheckCIDFilter(cid string) bool {
 // Returns true if the docID passes the filter, false otherwise.
 // If no DocID filter is set, it always passes.
 func (c CommitSelect) CheckDocIDFilter(docID string) bool {
-	if c.DocID.HasValue() && c.DocID.Value() != docID {
-		return false
-	}
-	return true
+	return !c.DocIDs.HasValue() || slices.Contains(c.DocIDs.Value(), docID)
 }

--- a/client/request/consts.go
+++ b/client/request/consts.go
@@ -137,9 +137,10 @@ var (
 	}
 
 	VersionFields = []string{
+		// DocIDArgName must be the first in this slice in order to align with document doc-id mappings
+		DocIDArgName,
 		HeightFieldName,
 		CidFieldName,
-		DocIDArgName,
 		CollectionVersionIDFieldName,
 		FieldNameName,
 		DeltaFieldName,

--- a/internal/planner/commit.go
+++ b/internal/planner/commit.go
@@ -97,8 +97,11 @@ func (n *dagScanNode) Kind() string {
 
 func (n *dagScanNode) Init() error {
 	if !n.prefix.HasValue() {
-		if n.commitSelect.DocID.HasValue() {
-			key := keys.HeadstoreDocKey{}.WithDocID(n.commitSelect.DocID.Value())
+		if n.commitSelect.DocIDs.HasValue() && len(n.commitSelect.DocIDs.Value()) > 0 {
+			// todo - for now we just take the first docID and ignore the rest, an error
+			// should be thrown in the parser anyway if the user provides more than one.
+			// https://github.com/sourcenetwork/defradb/issues/4302
+			key := keys.HeadstoreDocKey{}.WithDocID(n.commitSelect.DocIDs.Value()[0])
 			n.prefix = immutable.Some[keys.HeadstoreKey](key)
 		}
 	}
@@ -255,8 +258,12 @@ func (n *dagScanNode) Next() (bool, error) {
 	currentDocID := n.commitSelect.DocumentMapping.FirstOfName(currentValue, request.DocIDArgName)
 	if n.commitSelect.Cids.HasValue() &&
 		len(n.visitedNodes) == 0 &&
-		n.commitSelect.DocID.HasValue() &&
-		currentDocID != n.commitSelect.DocID.Value() {
+		n.commitSelect.DocIDs.HasValue() &&
+		len(n.commitSelect.DocIDs.Value()) > 0 &&
+		// todo - for now we just take the first docID and ignore the rest, an error
+		// should be thrown in the parser anyway if the user provides more than one.
+		// https://github.com/sourcenetwork/defradb/issues/4302
+		currentDocID != n.commitSelect.DocIDs.Value()[0] {
 		return false, ErrIncorrectOrMissingCID
 	}
 

--- a/internal/planner/mapper/commitSelect.go
+++ b/internal/planner/mapper/commitSelect.go
@@ -22,9 +22,6 @@ type CommitSelect struct {
 	// The maximum depth to yield results for.
 	Depth immutable.Option[uint64]
 
-	// The parent Cids for which commit information has been requested.
-	Cids immutable.Option[[]string]
-
 	// The CollectionVersionID at the time of commit.
 	CollectionVersionID immutable.Option[string]
 }
@@ -36,6 +33,5 @@ func (s *CommitSelect) CloneTo(index int) Requestable {
 func (s *CommitSelect) cloneTo(index int) *CommitSelect {
 	return &CommitSelect{
 		Select: *s.Select.cloneTo(index),
-		Cids:   s.Cids,
 	}
 }

--- a/internal/planner/mapper/commitSelect.go
+++ b/internal/planner/mapper/commitSelect.go
@@ -19,9 +19,6 @@ type CommitSelect struct {
 	// The underlying Select, defining the information requested.
 	Select
 
-	// The key of the target document for which to get commits for.
-	DocID immutable.Option[string]
-
 	// The maximum depth to yield results for.
 	Depth immutable.Option[uint64]
 
@@ -39,7 +36,6 @@ func (s *CommitSelect) CloneTo(index int) Requestable {
 func (s *CommitSelect) cloneTo(index int) *CommitSelect {
 	return &CommitSelect{
 		Select: *s.Select.cloneTo(index),
-		DocID:  s.DocID,
 		Cids:   s.Cids,
 	}
 }

--- a/internal/planner/mapper/mapper.go
+++ b/internal/planner/mapper/mapper.go
@@ -1330,7 +1330,6 @@ func toCommitSelect(
 	return &CommitSelect{
 		Select: *underlyingSelect,
 		Depth:  selectRequest.Depth,
-		Cids:   selectRequest.CIDs,
 	}, nil
 }
 

--- a/internal/planner/mapper/mapper.go
+++ b/internal/planner/mapper/mapper.go
@@ -1329,7 +1329,6 @@ func toCommitSelect(
 	}
 	return &CommitSelect{
 		Select: *underlyingSelect,
-		DocID:  selectRequest.DocID,
 		Depth:  selectRequest.Depth,
 		Cids:   selectRequest.CIDs,
 	}, nil

--- a/internal/request/graphql/parser/commit.go
+++ b/internal/request/graphql/parser/commit.go
@@ -45,7 +45,7 @@ func parseCommitSelect(
 				if len(v) > 1 {
 					// todo - This limitiation is temporary and should be removed in
 					// https://github.com/sourcenetwork/defradb/issues/4302
-					return nil, ErrMultipleCidsNotSupported
+					return nil, ErrMultipleDocIDsNotSupported
 				}
 
 				docIDs = make([]string, len(v))
@@ -57,7 +57,7 @@ func parseCommitSelect(
 				if len(v) > 1 {
 					// todo - This limitiation is temporary and should be removed in
 					// https://github.com/sourcenetwork/defradb/issues/4302
-					return nil, ErrMultipleCidsNotSupported
+					return nil, ErrMultipleDocIDsNotSupported
 				}
 
 				docIDs = v

--- a/internal/request/graphql/parser/commit.go
+++ b/internal/request/graphql/parser/commit.go
@@ -39,9 +39,37 @@ func parseCommitSelect(
 
 		switch name {
 		case request.DocIDArgName:
-			if v, ok := value.(string); ok {
-				commit.DocID = immutable.Some(v)
+			var docIDs []string
+			switch v := value.(type) {
+			case []any:
+				if len(v) > 1 {
+					// todo - This limitiation is temporary and should be removed in
+					// https://github.com/sourcenetwork/defradb/issues/4302
+					return nil, ErrMultipleCidsNotSupported
+				}
+
+				docIDs = make([]string, len(v))
+				for i, value := range v {
+					docIDs[i] = value.(string)
+				}
+
+			case []string:
+				if len(v) > 1 {
+					// todo - This limitiation is temporary and should be removed in
+					// https://github.com/sourcenetwork/defradb/issues/4302
+					return nil, ErrMultipleCidsNotSupported
+				}
+
+				docIDs = v
+
+			case string:
+				docIDs = []string{v}
+
+			default:
+				continue
 			}
+
+			commit.DocIDs = immutable.Some(docIDs)
 
 		case request.CidFieldName:
 			v, ok := value.([]any)

--- a/internal/request/graphql/parser/errors.go
+++ b/internal/request/graphql/parser/errors.go
@@ -27,4 +27,5 @@ var (
 	ErrInvalidFilterConditions        = errors.New("invalid filter condition type, expected map")
 	ErrMultipleOrderFieldsDefined     = errors.New("each order argument can only define one field")
 	ErrMultipleCidsNotSupported       = errors.New("querying by multiple cids is not yet supported")
+	ErrMultipleDocIDsNotSupported     = errors.New("querying by multiple docIDs is not yet supported")
 )

--- a/internal/request/graphql/schema/testfixtures/schema.relatedmany.gen.graphql
+++ b/internal/request/graphql/schema/testfixtures/schema.relatedmany.gen.graphql
@@ -225,7 +225,7 @@ depth: Int,     """
     set will be empty.
 
     """
-docID: ID,     "Filter results based on specified conditions."
+docID: [ID!],  "Filter results based on specified conditions."
 filter: CommitsFilterArg,     """
     
     An optional set of fields for which to group the contents of this field by.
@@ -500,7 +500,7 @@ depth: Int,     """
     set will be empty.
 
     """
-docID: ID,     "Filter results based on specified conditions."
+docID: [ID!],  "Filter results based on specified conditions."
 filter: CommitsFilterArg,     """
     
     An optional set of fields for which to group the contents of this field by.
@@ -823,7 +823,7 @@ cid: [ID!],     """
     set will be empty.
 
     """
-docID: ID,     "Filter results based on specified conditions."
+docID: [ID!],  "Filter results based on specified conditions."
 filter: CommitsFilterArg,     """
     
     An optional set of fields for which to group the contents of this field by.
@@ -869,7 +869,7 @@ cid: [ID!],     """
     set will be empty.
 
     """
-docID: ID,     "Filter results based on specified conditions."
+docID: [ID!],  "Filter results based on specified conditions."
 filter: CommitsFilterArg,     """
     
     An optional set of fields for which to group the contents of this field by.
@@ -2048,7 +2048,7 @@ input: BookMutationInputArg): [Book]
     """
     
     Update or add a document in this collection using the data provided. The provided filter
-    must match at most one document. The matching document will be updated with the provided 
+    must match at most one document. The matching document will be updated with the provided
     update input, or if no matching document is found, a new document will be added with the
     provided add input.
 
@@ -2067,7 +2067,7 @@ update: AuthorMutationInputArg!): [Author]
     """
     
     Update or add a document in this collection using the data provided. The provided filter
-    must match at most one document. The matching document will be updated with the provided 
+    must match at most one document. The matching document will be updated with the provided
     update input, or if no matching document is found, a new document will be added with the
     provided add input.
 

--- a/internal/request/graphql/schema/testfixtures/schema.relatedone.gen.graphql
+++ b/internal/request/graphql/schema/testfixtures/schema.relatedone.gen.graphql
@@ -385,7 +385,7 @@ depth: Int,     """
     set will be empty.
 
     """
-docID: ID,     "Filter results based on specified conditions."
+docID: [ID!],     "Filter results based on specified conditions."
 filter: CommitsFilterArg,     """
     
     An optional set of fields for which to group the contents of this field by.
@@ -818,7 +818,7 @@ cid: [ID!],     """
     set will be empty.
 
     """
-docID: ID,     "Filter results based on specified conditions."
+docID: [ID!],     "Filter results based on specified conditions."
 filter: CommitsFilterArg,     """
     
     An optional set of fields for which to group the contents of this field by.
@@ -864,7 +864,7 @@ cid: [ID!],     """
     set will be empty.
 
     """
-docID: ID,     "Filter results based on specified conditions."
+docID: [ID!],     "Filter results based on specified conditions."
 filter: CommitsFilterArg,     """
     
     An optional set of fields for which to group the contents of this field by.
@@ -1479,7 +1479,7 @@ depth: Int,     """
     set will be empty.
 
     """
-docID: ID,     "Filter results based on specified conditions."
+docID: [ID!],     "Filter results based on specified conditions."
 filter: CommitsFilterArg,     """
     
     An optional set of fields for which to group the contents of this field by.
@@ -1855,7 +1855,7 @@ input: BookMutationInputArg): [Book]
     """
     
     Update or add a document in this collection using the data provided. The provided filter
-    must match at most one document. The matching document will be updated with the provided 
+    must match at most one document. The matching document will be updated with the provided
     update input, or if no matching document is found, a new document will be added with the
     provided add input.
 
@@ -1874,7 +1874,7 @@ update: AuthorMutationInputArg!): [Author]
     """
     
     Update or add a document in this collection using the data provided. The provided filter
-    must match at most one document. The matching document will be updated with the provided 
+    must match at most one document. The matching document will be updated with the provided
     update input, or if no matching document is found, a new document will be added with the
     provided add input.
 

--- a/internal/request/graphql/schema/testfixtures/schema.simple.gen.graphql
+++ b/internal/request/graphql/schema/testfixtures/schema.simple.gen.graphql
@@ -392,7 +392,7 @@ cid: [ID!],     """
     set will be empty.
 
     """
-docID: ID,     "Filter results based on specified conditions."
+docID: [ID!],     "Filter results based on specified conditions."
 filter: CommitsFilterArg,     """
     
     An optional set of fields for which to group the contents of this field by.
@@ -438,7 +438,7 @@ cid: [ID!],     """
     set will be empty.
 
     """
-docID: ID,     "Filter results based on specified conditions."
+docID: [ID!],     "Filter results based on specified conditions."
 filter: CommitsFilterArg,     """
     
     An optional set of fields for which to group the contents of this field by.
@@ -675,7 +675,7 @@ input: UserMutationInputArg): [User]
     """
     
     Update or add a document in this collection using the data provided. The provided filter
-    must match at most one document. The matching document will be updated with the provided 
+    must match at most one document. The matching document will be updated with the provided
     update input, or if no matching document is found, a new document will be added with the
     provided add input.
 
@@ -909,7 +909,7 @@ depth: Int,     """
     set will be empty.
 
     """
-docID: ID,     "Filter results based on specified conditions."
+docID: [ID!],     "Filter results based on specified conditions."
 filter: CommitsFilterArg,     """
     
     An optional set of fields for which to group the contents of this field by.
@@ -1498,7 +1498,7 @@ depth: Int,     """
     set will be empty.
 
     """
-docID: ID,     "Filter results based on specified conditions."
+docID: [ID!],     "Filter results based on specified conditions."
 filter: CommitsFilterArg,     """
     
     An optional set of fields for which to group the contents of this field by.

--- a/internal/request/graphql/schema/types/commits.go
+++ b/internal/request/graphql/schema/types/commits.go
@@ -51,7 +51,7 @@ func CommitObject(
 			Description: commitLinksDescription,
 			Type:        gql.NewList(commitObject),
 			Args: gql.FieldConfigArgument{
-				request.DocIDArgName: NewArgConfig(gql.ID, commitDocIDArgDescription),
+				request.DocIDArgName: NewArgConfig(gql.NewList(gql.NewNonNull(gql.ID)), commitDocIDArgDescription),
 				request.FilterClause: NewArgConfig(commitsFilterArg, "Filter results based on specified conditions."),
 				"order":              NewArgConfig(gql.NewList(commitsOrderArg), OrderArgDescription),
 				request.CidArgName:   NewArgConfig(gql.NewList(gql.NewNonNull(gql.ID)), commitCIDArgDescription),
@@ -271,7 +271,7 @@ func QueryCommits(
 		Description: commitsQueryDescription,
 		Type:        gql.NewList(commitObject),
 		Args: gql.FieldConfigArgument{
-			request.DocIDArgName: NewArgConfig(gql.ID, commitDocIDArgDescription),
+			request.DocIDArgName: NewArgConfig(gql.NewList(gql.NewNonNull(gql.ID)), commitDocIDArgDescription),
 			request.FilterClause: NewArgConfig(commitsFilterArg, "Filter results based on specified conditions."),
 			"order":              NewArgConfig(gql.NewList(commitsOrderArg), OrderArgDescription),
 			request.CidArgName:   NewArgConfig(gql.NewList(gql.NewNonNull(gql.ID)), commitCIDArgDescription),

--- a/tests/integration/query/commits/with_doc_id_test.go
+++ b/tests/integration/query/commits/with_doc_id_test.go
@@ -349,7 +349,7 @@ func TestQueryCommits_DocIDListOfMany(t *testing.T) {
 							cid
 						}
 					}`,
-				ExpectedError: "querying by multiple cids is not yet supported",
+				ExpectedError: "querying by multiple docIDs is not yet supported",
 			},
 		},
 	}

--- a/tests/integration/query/commits/with_doc_id_test.go
+++ b/tests/integration/query/commits/with_doc_id_test.go
@@ -292,6 +292,36 @@ func TestQueryCommitsWithDocIDAndUpdateAndLinks(t *testing.T) {
 	testUtils.ExecuteTestCase(t, test)
 }
 
+func TestQueryCommits_DocIDEmptyList(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			updateUserCollectionSchema(),
+			&action.AddDoc{
+				DocMap: map[string]any{
+					"name": "John",
+				},
+			},
+			&action.AddDoc{
+				DocMap: map[string]any{
+					"name": "Fred",
+				},
+			},
+			&action.Request{
+				Request: `query {
+						_commits(docID: []) {
+							cid
+						}
+					}`,
+				Results: map[string]any{
+					"_commits": []map[string]any{},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
 func TestQueryCommits_DocIDListOfOne(t *testing.T) {
 	test := testUtils.TestCase{
 		Actions: []any{

--- a/tests/integration/query/commits/with_doc_id_test.go
+++ b/tests/integration/query/commits/with_doc_id_test.go
@@ -291,3 +291,68 @@ func TestQueryCommitsWithDocIDAndUpdateAndLinks(t *testing.T) {
 
 	testUtils.ExecuteTestCase(t, test)
 }
+
+func TestQueryCommits_DocIDListOfOne(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			updateUserCollectionSchema(),
+			&action.AddDoc{
+				DocMap: map[string]any{
+					"name": "John",
+				},
+			},
+			&action.AddDoc{
+				DocMap: map[string]any{
+					"name": "Fred",
+				},
+			},
+			&action.Request{
+				Request: `query {
+						_commits(docID: ["bae-0fcd42bc-f8ab-510b-9b71-f42b72d75d53"]) {
+							cid
+						}
+					}`,
+				Results: map[string]any{
+					"_commits": []map[string]any{
+						{
+							"cid": testUtils.NewUniqueValue(),
+						},
+						{
+							"cid": testUtils.NewUniqueValue(),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestQueryCommits_DocIDListOfMany(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			updateUserCollectionSchema(),
+			&action.AddDoc{
+				DocMap: map[string]any{
+					"name": "John",
+				},
+			},
+			&action.AddDoc{
+				DocMap: map[string]any{
+					"name": "Fred",
+				},
+			},
+			&action.Request{
+				Request: `query {
+						_commits(docID: ["bae-0fcd42bc-f8ab-510b-9b71-f42b72d75d53", "bae-234fd13b-a9ea-59b5-9830-7e903a72bd24"]) {
+							cid
+						}
+					}`,
+				ExpectedError: "querying by multiple cids is not yet supported",
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -1050,12 +1050,12 @@ func refreshDocuments(
 
 				// We fetch the list of composite commits for the document so that
 				// they can be referenced later in the test if required.
-				result := s.Nodes[firstNodesID].Client.ExecRequest(s.Ctx, `query ($docID: ID!) {
+				result := s.Nodes[firstNodesID].Client.ExecRequest(s.Ctx, `query ($docID: [ID!]) {
 					_commits(docID: $docID, filter: {fieldName: {_eq: "_C"}}, order: {height: ASC}) {
 						cid
 					}
 				}`, options.ExecRequest().SetVariables(map[string]any{
-					"docID": doc.ID().String(),
+					"docID": []string{doc.ID().String()},
 				}))
 				if data, ok := result.GQL.Data.(map[string]any); ok {
 					if commits, ok := data["_commits"].([]map[string]any); ok {


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4567

## Description

Change GQL commits.docId param to list type.  Does not implement the handling of more than one.