### PR TITLE
fix: Return error from CLI when collection not found

### DIFF
--- a/cbindings/collection.go
+++ b/cbindings/collection.go
@@ -68,7 +68,7 @@ func getCollection(
 
 	// Only one collection should match the criteria
 	if len(cols) == 0 {
-		return nil, client.ErrNoMatchingCollection
+		return nil, client.ErrCollectionNotFound
 	}
 	if len(cols) > 1 {
 		return nil, NewErrAmbiguousCollection()

--- a/cbindings/collection.go
+++ b/cbindings/collection.go
@@ -68,7 +68,7 @@ func getCollection(
 
 	// Only one collection should match the criteria
 	if len(cols) == 0 {
-		return nil, NewErrNoMatchingCollection()
+		return nil, client.ErrNoMatchingCollection
 	}
 	if len(cols) > 1 {
 		return nil, NewErrAmbiguousCollection()

--- a/cbindings/errors.go
+++ b/cbindings/errors.go
@@ -17,7 +17,6 @@ import (
 const (
 	errNegativeReplicatorTime       = "negative time intervals are not allowed for replicator retries"
 	errAmbiguousCollection          = "more than one collection matches the given criteria"
-	errNoMatchingCollection         = "no collection matches the given criteria"
 	errNoDocIDOrFilter              = "operation requires a DocID or filter"
 	errInvalidAscensionOrder        = "invalid ascension order: expected ASC or DESC"
 	errInvalidIndexFieldDescription = "invalid or malformed field description"
@@ -28,10 +27,6 @@ const (
 
 func NewErrAmbiguousCollection() error {
 	return errors.New(errAmbiguousCollection)
-}
-
-func NewErrNoMatchingCollection() error {
-	return errors.New(errNoMatchingCollection)
 }
 
 func NewErrInvalidIndexFieldDescription(field string) error {

--- a/cli/collection_truncate.go
+++ b/cli/collection_truncate.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/options"
 	"github.com/sourcenetwork/defradb/internal/identity"
 )
@@ -29,7 +30,7 @@ func MakeCollectionTruncateCommand(ctx context.Context) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			col, ok := tryGetContextCollection(cmd)
 			if !ok {
-				return cmd.Usage()
+				return client.ErrNoMatchingCollection
 			}
 
 			opt := options.WithIdentity(options.CollectionTruncate(), identity.FromContext(cmd.Context()))

--- a/cli/collection_truncate.go
+++ b/cli/collection_truncate.go
@@ -30,7 +30,7 @@ func MakeCollectionTruncateCommand(ctx context.Context) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			col, ok := tryGetContextCollection(cmd)
 			if !ok {
-				return client.ErrNoMatchingCollection
+				return client.ErrCollectionNotFound
 			}
 
 			opt := options.WithIdentity(options.CollectionTruncate(), identity.FromContext(cmd.Context()))

--- a/cli/document_add.go
+++ b/cli/document_add.go
@@ -70,7 +70,7 @@ Options:
 
 			col, ok := tryGetContextCollection(cmd)
 			if !ok {
-				return cmd.Usage()
+				return client.ErrNoMatchingCollection
 			}
 
 			ctx := cmd.Context()

--- a/cli/document_add.go
+++ b/cli/document_add.go
@@ -70,7 +70,7 @@ Options:
 
 			col, ok := tryGetContextCollection(cmd)
 			if !ok {
-				return client.ErrNoMatchingCollection
+				return client.ErrCollectionNotFound
 			}
 
 			ctx := cmd.Context()

--- a/cli/document_delete.go
+++ b/cli/document_delete.go
@@ -30,7 +30,7 @@ func MakeDocumentDeleteCommand(ctx context.Context) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			col, ok := tryGetContextCollection(cmd)
 			if !ok {
-				return client.ErrNoMatchingCollection
+				return client.ErrCollectionNotFound
 			}
 
 			ctx := cmd.Context()

--- a/cli/document_delete.go
+++ b/cli/document_delete.go
@@ -30,7 +30,7 @@ func MakeDocumentDeleteCommand(ctx context.Context) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			col, ok := tryGetContextCollection(cmd)
 			if !ok {
-				return cmd.Usage()
+				return client.ErrNoMatchingCollection
 			}
 
 			ctx := cmd.Context()

--- a/cli/document_get.go
+++ b/cli/document_get.go
@@ -30,7 +30,7 @@ func MakeDocumentGetCommand(ctx context.Context) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			col, ok := tryGetContextCollection(cmd)
 			if !ok {
-				return client.ErrNoMatchingCollection
+				return client.ErrCollectionNotFound
 			}
 
 			ctx := cmd.Context()

--- a/cli/document_get.go
+++ b/cli/document_get.go
@@ -30,7 +30,7 @@ func MakeDocumentGetCommand(ctx context.Context) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			col, ok := tryGetContextCollection(cmd)
 			if !ok {
-				return cmd.Usage()
+				return client.ErrNoMatchingCollection
 			}
 
 			ctx := cmd.Context()

--- a/cli/document_update.go
+++ b/cli/document_update.go
@@ -33,7 +33,7 @@ func MakeDocumentUpdateCommand(ctx context.Context) *cobra.Command {
 			ctx := cmd.Context()
 			col, ok := tryGetContextCollection(cmd)
 			if !ok {
-				return cmd.Usage()
+				return client.ErrNoMatchingCollection
 			}
 
 			if updater == "" {

--- a/cli/document_update.go
+++ b/cli/document_update.go
@@ -33,7 +33,7 @@ func MakeDocumentUpdateCommand(ctx context.Context) *cobra.Command {
 			ctx := cmd.Context()
 			col, ok := tryGetContextCollection(cmd)
 			if !ok {
-				return client.ErrNoMatchingCollection
+				return client.ErrCollectionNotFound
 			}
 
 			if updater == "" {

--- a/client/errors.go
+++ b/client/errors.go
@@ -52,6 +52,7 @@ const (
 	errNACIsEnabledButIsMissingPolicyInfo    string = "node acp is enabled, but is missing policy info"
 	errNACNodeObjectToGateIsNotRegistered    string = "node acp is enabled, but object to gate must be registered"
 	errOperationRequiresDeveloperMode        string = "operation not permitted whilst development mode is disabled"
+	errNoMatchingCollection                  string = "no collection matches the given criteria"
 )
 
 var (
@@ -101,6 +102,7 @@ var (
 	ErrNACNodeObjectToGateIsNotRegistered    = errors.New(errNACNodeObjectToGateIsNotRegistered)
 	ErrOperationRequiresDeveloperMode        = errors.New(errOperationRequiresDeveloperMode)
 	ErrIndexNameRequired                     = errors.New("index name is required")
+	ErrNoMatchingCollection                  = errors.New(errNoMatchingCollection)
 )
 
 // NewErrFieldNotExist returns an error indicating that the given field does not exist.

--- a/client/errors.go
+++ b/client/errors.go
@@ -52,11 +52,6 @@ const (
 	errNACIsEnabledButIsMissingPolicyInfo    string = "node acp is enabled, but is missing policy info"
 	errNACNodeObjectToGateIsNotRegistered    string = "node acp is enabled, but object to gate must be registered"
 	errOperationRequiresDeveloperMode        string = "operation not permitted whilst development mode is disabled"
-	errNoMatchingCollection                  string = "no collection matches the given criteria"
-)
-
-var (
-	errNotFound string = corekv.ErrNotFound.Error()
 )
 
 // Errors returnable from this package.
@@ -93,7 +88,6 @@ var (
 	ErrEmptyModelForEmbedding                = errors.New(errEmptyModelForEmbedding)
 	ErrUnknownEmbeddingProvider              = errors.New(errUnknownEmbeddingProvider)
 	ErrEmbeddingFieldEmbedding               = errors.New(errEmbeddingFieldEmbedding)
-	ErrNotFound                              = errors.New(errNotFound)
 	ErrInvalidResourcePermissionType         = errors.New(errInvalidResourcePermissionType)
 	ErrCanNotStartNACWithoutIdentity         = errors.New(errCanNotStartNACWithoutIdentity)
 	ErrCanNotDoThisNACOpWithNACIsDisabled    = errors.New(errCanNotDoThisNACOpWithNACIsDisabled)
@@ -102,7 +96,6 @@ var (
 	ErrNACNodeObjectToGateIsNotRegistered    = errors.New(errNACNodeObjectToGateIsNotRegistered)
 	ErrOperationRequiresDeveloperMode        = errors.New(errOperationRequiresDeveloperMode)
 	ErrIndexNameRequired                     = errors.New("index name is required")
-	ErrNoMatchingCollection                  = errors.New(errNoMatchingCollection)
 )
 
 // NewErrFieldNotExist returns an error indicating that the given field does not exist.
@@ -270,10 +263,6 @@ func NewErrUnknownEmbeddingProvider(provider string) error {
 
 func NewErrEmbeddingFieldEmbedding(fieldName string) error {
 	return errors.New(errEmbeddingFieldEmbedding, errors.NewKV("Field", fieldName))
-}
-
-func NewErrNotFound(kv errors.KV) error {
-	return errors.New(errNotFound, kv)
 }
 
 func NewErrNotAuthorizedToPerformOperation(permission acpTypes.NodeResourcePermission) error {

--- a/internal/db/collection.go
+++ b/internal/db/collection.go
@@ -13,8 +13,6 @@ package db
 import (
 	"context"
 
-	"github.com/sourcenetwork/corekv"
-
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/options"
 	"github.com/sourcenetwork/defradb/errors"
@@ -84,7 +82,7 @@ func (db *DB) getCollectionByName(ctx context.Context, name string) (client.Coll
 	}
 
 	if len(cols) == 0 {
-		return nil, corekv.ErrNotFound
+		return nil, client.ErrCollectionNotFound
 	}
 
 	// cols will always have length == 1 here
@@ -108,7 +106,7 @@ func (db *DB) getCollections(
 	switch {
 	case opts.CollectionName.HasValue() && !opts.GetInactive.Value():
 		col, err := description.GetCollectionByName(ctx, opts.CollectionName.Value())
-		if err != nil && !errors.Is(err, corekv.ErrNotFound) {
+		if err != nil && !errors.Is(err, client.ErrCollectionNotFound) {
 			return nil, err
 		}
 		cols = append(cols, col)

--- a/internal/db/collection_id.go
+++ b/internal/db/collection_id.go
@@ -18,7 +18,6 @@ import (
 
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 
-	"github.com/sourcenetwork/corekv"
 	"github.com/sourcenetwork/immutable"
 
 	"github.com/sourcenetwork/defradb/client"
@@ -420,7 +419,7 @@ func saveBlocks(
 			var err error
 			oldCol, err = description.GetCollectionByID(ctx, collection.VersionID)
 			if err != nil {
-				if errors.Is(err, corekv.ErrNotFound) {
+				if errors.Is(err, client.ErrCollectionNotFound) {
 					// If the key does not exist, continue, and let the validation code handle it
 					// in a user friendly way.
 					continue

--- a/internal/db/collection_test.go
+++ b/internal/db/collection_test.go
@@ -23,7 +23,7 @@ func TestGetCollectionByNameReturnsErrorGivenNonExistantCollection(t *testing.T)
 	assert.NoError(t, err)
 
 	_, err = db.GetCollectionByName(ctx, "doesNotExist")
-	assert.EqualError(t, err, "key not found")
+	assert.EqualError(t, err, "collection not found")
 }
 
 func TestGetCollectionByNameReturnsErrorGivenEmptyString(t *testing.T) {

--- a/internal/db/description/collection.go
+++ b/internal/db/description/collection.go
@@ -110,6 +110,9 @@ func GetCollectionByID(
 	key := keys.NewCollectionKey(id)
 	buf, err := txn.Systemstore().Get(ctx, key.Bytes())
 	if err != nil {
+		if errors.Is(err, corekv.ErrNotFound) {
+			err = client.ErrCollectionNotFound
+		}
 		return client.CollectionVersion{}, err
 	}
 
@@ -141,6 +144,9 @@ func GetCollectionByName(
 	nameKey := keys.NewCollectionNameKey(name)
 	idBuf, err := txn.Systemstore().Get(ctx, nameKey.Bytes())
 	if err != nil {
+		if errors.Is(err, corekv.ErrNotFound) {
+			err = client.ErrCollectionNotFound
+		}
 		return client.CollectionVersion{}, err
 	}
 
@@ -175,7 +181,7 @@ func GetActiveCollectionByCollectionID(
 		}
 	}
 
-	return client.CollectionVersion{}, corekv.ErrNotFound
+	return client.CollectionVersion{}, client.ErrCollectionNotFound
 }
 
 // GetCollectionsByCollectionID returns all collection versions for the given id.
@@ -190,7 +196,7 @@ func GetCollectionsByCollectionID(
 		if col, ok := cache.CollectionsByID[collectionID]; ok {
 			return col, nil
 		}
-		return nil, corekv.ErrNotFound
+		return []client.CollectionVersion{}, nil
 	}
 	// It is not practical to cache a sub set of collections at the moment as figuring
 	// out whether the set is complete or not if not possible without fetching the versionIDs
@@ -206,7 +212,7 @@ func GetCollectionsByCollectionID(
 	for _, versionID := range versionIDs {
 		versionCol, err := GetCollectionByID(ctx, versionID)
 		if err != nil {
-			if errors.Is(err, corekv.ErrNotFound) {
+			if errors.Is(err, client.ErrCollectionNotFound) {
 				continue
 			}
 			return nil, err
@@ -363,7 +369,7 @@ func GetCollectionVersionIDs(
 			}
 			return result, nil
 		}
-		return nil, corekv.ErrNotFound
+		return nil, client.ErrCollectionNotFound
 	}
 
 	txn := datastore.CtxMustGetTxn(ctx)
@@ -416,7 +422,7 @@ func GetRelatedCollection(
 	switch typedKind := kind.(type) {
 	case *client.NamedKind:
 		col, err := GetCollectionByName(ctx, typedKind.Name)
-		if errors.Is(err, corekv.ErrNotFound) {
+		if errors.Is(err, client.ErrCollectionNotFound) {
 			return client.CollectionVersion{}, false, nil
 		}
 
@@ -424,7 +430,7 @@ func GetRelatedCollection(
 
 	case *client.CollectionKind:
 		col, err := GetActiveCollectionByCollectionID(ctx, typedKind.CollectionID)
-		if errors.Is(err, corekv.ErrNotFound) {
+		if errors.Is(err, client.ErrCollectionNotFound) {
 			return client.CollectionVersion{}, false, nil
 		}
 

--- a/internal/db/lens.go
+++ b/internal/db/lens.go
@@ -13,7 +13,6 @@ package db
 import (
 	"context"
 
-	"github.com/sourcenetwork/corekv"
 	"github.com/sourcenetwork/immutable"
 	"github.com/sourcenetwork/lens/host-go/config/model"
 	"github.com/sourcenetwork/lens/host-go/store"
@@ -61,7 +60,7 @@ func (db *DB) setMigration(ctx context.Context, cfg client.LensConfig) (string, 
 	dstFound := true
 	dstCol, err := description.GetCollectionByID(ctx, cfg.DestinationCollectionVersionID)
 	if err != nil {
-		if errors.Is(err, corekv.ErrNotFound) {
+		if errors.Is(err, client.ErrCollectionNotFound) {
 			dstFound = false
 		} else {
 			return "", err
@@ -71,7 +70,7 @@ func (db *DB) setMigration(ctx context.Context, cfg client.LensConfig) (string, 
 	srcFound := true
 	sourceCol, err := description.GetCollectionByID(ctx, cfg.SourceCollectionVersionID)
 	if err != nil {
-		if errors.Is(err, corekv.ErrNotFound) {
+		if errors.Is(err, client.ErrCollectionNotFound) {
 			srcFound = false
 		} else {
 			return "", err
@@ -152,7 +151,7 @@ func (db *DB) shouldReindexAfterMigration(
 
 	activeCol, err := description.GetActiveCollectionByCollectionID(ctx, dstCol.CollectionID)
 	if err != nil {
-		if errors.Is(err, corekv.ErrNotFound) {
+		if errors.Is(err, client.ErrCollectionNotFound) {
 			return false, client.CollectionVersion{}, nil
 		}
 		return false, client.CollectionVersion{}, err

--- a/internal/db/p2p/sync_col_versions.go
+++ b/internal/db/p2p/sync_col_versions.go
@@ -53,7 +53,7 @@ func (p *P2P) syncCollectionVersion(
 ) (client.CollectionVersion, error) {
 	col, err := description.GetCollectionByID(ctx, versionID)
 	if err != nil {
-		if !errors.Is(err, corekv.ErrNotFound) {
+		if !errors.Is(err, client.ErrCollectionNotFound) {
 			return client.CollectionVersion{}, err
 		}
 		// If it is not found, continue and try and sync it!

--- a/tests/integration/acp/nac/collection_get_by_version_test.go
+++ b/tests/integration/acp/nac/collection_get_by_version_test.go
@@ -34,7 +34,7 @@ func TestNAC_GatesCollectionGetByVersion_AuthorizedIdentity_AllowAccess(t *testi
 			&action.GetCollections{
 				Identity:      testUtils.ClientIdentity(1),
 				FilterOptions: options.GetCollections().SetVersionID("does not exist").SetGetInactive(false),
-				ExpectedError: "key not found", // Note: it is authorized, just key not found.
+				ExpectedError: "collection not found", // Note: it is authorized, just collection not found.
 			},
 		},
 	}

--- a/tests/integration/acp/nac/relation_admin/collection_get_by_version_test.go
+++ b/tests/integration/acp/nac/relation_admin/collection_get_by_version_test.go
@@ -49,7 +49,7 @@ func TestNAC_AdminRelation_CanCollectionGetByVersion(t *testing.T) {
 			&action.GetCollections{
 				Identity:      testUtils.ClientIdentity(2),
 				FilterOptions: options.GetCollections().SetVersionID("does not exist").SetGetInactive(false),
-				ExpectedError: "key not found", // Note: it is authorized, just key not found.
+				ExpectedError: "collection not found", // Note: it is authorized, just collection not found.
 			},
 		},
 	}

--- a/tests/integration/backup/simple/export_test.go
+++ b/tests/integration/backup/simple/export_test.go
@@ -80,7 +80,7 @@ func TestBackupExport_WithInvalidCollection_ReturnError(t *testing.T) {
 				Config: client.BackupConfig{
 					Collections: []string{"Invalid"},
 				},
-				ExpectedError: "failed to get collection: key not found. Name: Invalid",
+				ExpectedError: "failed to get collection: collection not found. Name: Invalid",
 			},
 		},
 	}

--- a/tests/integration/backup/simple/import_test.go
+++ b/tests/integration/backup/simple/import_test.go
@@ -64,7 +64,7 @@ func TestBackupImport_WithInvalidCollection_ReturnError(t *testing.T) {
 		Actions: []any{
 			testUtils.BackupImport{
 				ImportContent: `{"Invalid":[{"_docID":"bae-3fc941b7-505c-5ce2-91a0-b180930ec8a9","_docIDNew":"bae-3fc941b7-505c-5ce2-91a0-b180930ec8a9","age":30,"name":"John"}]}`,
-				ExpectedError: "failed to get collection: key not found. Name: Invalid",
+				ExpectedError: "failed to get collection: collection not found. Name: Invalid",
 			},
 		},
 	}

--- a/tests/integration/collection_version/get_schema_test.go
+++ b/tests/integration/collection_version/get_schema_test.go
@@ -26,7 +26,7 @@ func TestGetSchema_GivenNonExistantCollectionVersionID_Errors(t *testing.T) {
 		Actions: []any{
 			&action.GetCollections{
 				FilterOptions: options.GetCollections().SetVersionID("does not exist"),
-				ExpectedError: "key not found",
+				ExpectedError: "collection not found",
 			},
 		},
 	}

--- a/tests/integration/collection_version/updates/remove/view_test.go
+++ b/tests/integration/collection_version/updates/remove/view_test.go
@@ -251,7 +251,7 @@ func TestColVersionUpdateRemoveCollectionBackingUnmaterializedView(t *testing.T)
 						name
 					}
 				}`,
-				ExpectedError: `key not found`,
+				ExpectedError: `collection not found`,
 			},
 		},
 	}

--- a/tests/integration/collection_version/with_update_set_default_test.go
+++ b/tests/integration/collection_version/with_update_set_default_test.go
@@ -62,7 +62,7 @@ func TestSchema_WithUpdateAndSetDefaultVersionToUnknownVersion_Errors(t *testing
 			},
 			testUtils.SetActiveCollectionVersion{
 				VersionID:     "does not exist",
-				ExpectedError: "key not found",
+				ExpectedError: "collection not found",
 			},
 		},
 	}

--- a/tests/integration/mutation/update/with_filter_action_test.go
+++ b/tests/integration/mutation/update/with_filter_action_test.go
@@ -32,7 +32,7 @@ func TestUpdateWithInvalidFilterType_ReturnsError(t *testing.T) {
 				CollectionID:  0,
 				Filter:        invalidFilterType{Number: 1},
 				Updater:       `{"name": "Eric"}`,
-				ExpectedError: "key not found",
+				ExpectedError: "collection not found",
 			},
 		},
 	}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4590

## Description

Returns an error from CLI when a collection is not found, instead of dumping the help text with no explanation.  Also brings it inline with the C and Go clients.  Http returns a 404, which I think is appropriate, but I'm not too confident about it.

Also unifies the error messages returned from the C and Go clients when this happens.
