### PR TITLE
refactor: Rename txn create to txn new

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -139,7 +139,7 @@ func NewDefraCommand(ctx context.Context) *cobra.Command {
 
 	tx := MakeTxCommand(ctx)
 	tx.AddCommand(
-		MakeTxCreateCommand(ctx),
+		MakeTxNewCommand(ctx),
 		MakeTxCommitCommand(ctx),
 		MakeTxDiscardCommand(ctx),
 	)

--- a/cli/tx_create.go
+++ b/cli/tx_create.go
@@ -18,11 +18,11 @@ import (
 	"github.com/sourcenetwork/defradb/client"
 )
 
-func MakeTxCreateCommand(ctx context.Context) *cobra.Command {
+func MakeTxNewCommand(ctx context.Context) *cobra.Command {
 	var concurrent bool
 	var readOnly bool
 	var cmd = &cobra.Command{
-		Use:   "create",
+		Use:   "new",
 		Short: "Create a new DefraDB transaction.",
 		Long:  `Create a new DefraDB transaction.`,
 		RunE: func(cmd *cobra.Command, args []string) (err error) {

--- a/docs/website/references/cli/defradb_client_tx.md
+++ b/docs/website/references/cli/defradb_client_tx.md
@@ -38,6 +38,6 @@ Create, commit, and discard DefraDB transactions
 
 * [defradb client](defradb_client.md)	 - Interact with a DefraDB node
 * [defradb client tx commit](defradb_client_tx_commit.md)	 - Commit a DefraDB transaction.
-* [defradb client tx create](defradb_client_tx_create.md)	 - Create a new DefraDB transaction.
 * [defradb client tx discard](defradb_client_tx_discard.md)	 - Discard a DefraDB transaction.
+* [defradb client tx new](defradb_client_tx_new.md)	 - Create a new DefraDB transaction.
 

--- a/docs/website/references/cli/defradb_client_tx_new.md
+++ b/docs/website/references/cli/defradb_client_tx_new.md
@@ -1,4 +1,4 @@
-## defradb client tx create
+## defradb client tx new
 
 Create a new DefraDB transaction.
 
@@ -7,14 +7,14 @@ Create a new DefraDB transaction.
 Create a new DefraDB transaction.
 
 ```
-defradb client tx create [flags]
+defradb client tx new [flags]
 ```
 
 ### Options
 
 ```
       --concurrent   Transaction is concurrent
-  -h, --help         help for create
+  -h, --help         help for new
       --read-only    Transaction is read only
 ```
 

--- a/tests/clients/cli/wrapper.go
+++ b/tests/clients/cli/wrapper.go
@@ -726,7 +726,7 @@ func (w *Wrapper) execRequestSubscription(r io.Reader) chan client.GQLResult {
 }
 
 func (w *Wrapper) NewTxn(readOnly bool) (client.Txn, error) {
-	args := []string{"client", "tx", "create"}
+	args := []string{"client", "tx", "new"}
 	if readOnly {
 		args = append(args, "--read-only")
 	}
@@ -747,7 +747,7 @@ func (w *Wrapper) NewTxn(readOnly bool) (client.Txn, error) {
 }
 
 func (w *Wrapper) NewConcurrentTxn(readOnly bool) (client.Txn, error) {
-	args := []string{"client", "tx", "create"}
+	args := []string{"client", "tx", "new"}
 	args = append(args, "--concurrent")
 
 	if readOnly {


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4593

## Description

Renames the CLI `txn create` command to `txn new`, inline with other commands and clients. 