### PR TITLE
fix: Fix transactional behavior in updateWithFilter

### DIFF
--- a/internal/core/parser.go
+++ b/internal/core/parser.go
@@ -52,7 +52,7 @@ type Parser interface {
 	Parse(context.Context, *ast.Document, *client.GQLOptions) (*request.Request, []error)
 
 	// NewFilterFromString creates a new filter from a string.
-	NewFilterFromString(collectionType string, body string) (immutable.Option[request.Filter], error)
+	NewFilterFromString(ctx context.Context, collectionType string, body string) (immutable.Option[request.Filter], error)
 
 	// ParseSDL parses an SDL string into a set of collection versions.
 	//

--- a/internal/core/parser.go
+++ b/internal/core/parser.go
@@ -52,7 +52,7 @@ type Parser interface {
 	Parse(context.Context, *ast.Document, *client.GQLOptions) (*request.Request, []error)
 
 	// NewFilterFromString creates a new filter from a string.
-	NewFilterFromString(ctx context.Context, collectionType string, body string) (immutable.Option[request.Filter], error)
+	NewFilterFromString(collectionType string, body string) (immutable.Option[request.Filter], error)
 
 	// ParseSDL parses an SDL string into a set of collection versions.
 	//

--- a/internal/db/document_update.go
+++ b/internal/db/document_update.go
@@ -168,7 +168,7 @@ func (c *collection) makeSelectionPlan(
 			return nil, ErrInvalidFilter
 		}
 
-		f, err = c.db.parser.NewFilterFromString(c.Name(), fval)
+		f, err = c.db.parser.NewFilterFromString(ctx, c.Name(), fval)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/db/document_update.go
+++ b/internal/db/document_update.go
@@ -168,7 +168,7 @@ func (c *collection) makeSelectionPlan(
 			return nil, ErrInvalidFilter
 		}
 
-		f, err = c.db.parser.NewFilterFromString(ctx, c.Name(), fval)
+		f, err = c.db.parser.NewFilterFromString(c.Name(), fval)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/request/graphql/parser.go
+++ b/internal/request/graphql/parser.go
@@ -183,6 +183,19 @@ func (p *parser) SetSchema(ctx context.Context, collections []client.CollectionV
 	return err
 }
 
-func (p *parser) NewFilterFromString(collectionType string, body string) (immutable.Option[request.Filter], error) {
+func (p *parser) NewFilterFromString(
+	ctx context.Context,
+	collectionType string,
+	body string) (immutable.Option[request.Filter], error) {
+	// If there was a transaction, try to use the schema manager for that transaction
+	txn, hadTxn := datastore.CtxTryGetTxn(ctx)
+	if hadTxn {
+		p.schemaManagerMapLock.RLock()
+		gotSchemaManager, ok := p.schemaManagerMap[txn.ID()]
+		p.schemaManagerMapLock.RUnlock()
+		if ok {
+			return defrap.NewFilterFromString(*gotSchemaManager.Schema(), collectionType, body)
+		}
+	}
 	return defrap.NewFilterFromString(*p.schemaManager.Schema(), collectionType, body)
 }

--- a/internal/request/graphql/parser.go
+++ b/internal/request/graphql/parser.go
@@ -183,7 +183,10 @@ func (p *parser) SetSchema(ctx context.Context, collections []client.CollectionV
 	return err
 }
 
-func (p *parser) NewFilterFromString(ctx context.Context, collectionType string, body string) (immutable.Option[request.Filter], error) {
+func (p *parser) NewFilterFromString(
+	ctx context.Context,
+	collectionType string,
+	body string) (immutable.Option[request.Filter], error) {
 	// If the txn ID is in the schema manager map, use that one instead of the default one
 	gotTxn, hadTxn := datastore.CtxTryGetTxn(ctx)
 	if hadTxn {

--- a/internal/request/graphql/parser.go
+++ b/internal/request/graphql/parser.go
@@ -183,19 +183,6 @@ func (p *parser) SetSchema(ctx context.Context, collections []client.CollectionV
 	return err
 }
 
-func (p *parser) NewFilterFromString(
-	ctx context.Context,
-	collectionType string,
-	body string) (immutable.Option[request.Filter], error) {
-	// If the txn ID is in the schema manager map, use that one instead of the default one
-	gotTxn, hadTxn := datastore.CtxTryGetTxn(ctx)
-	if hadTxn {
-		p.schemaManagerMapLock.RLock()
-		gotSchemaManager, ok := p.schemaManagerMap[gotTxn.ID()]
-		p.schemaManagerMapLock.RUnlock()
-		if ok && gotSchemaManager != nil {
-			return defrap.NewFilterFromString(*gotSchemaManager.Schema(), collectionType, body)
-		}
-	}
+func (p *parser) NewFilterFromString(collectionType string, body string) (immutable.Option[request.Filter], error) {
 	return defrap.NewFilterFromString(*p.schemaManager.Schema(), collectionType, body)
 }

--- a/internal/request/graphql/parser.go
+++ b/internal/request/graphql/parser.go
@@ -183,6 +183,16 @@ func (p *parser) SetSchema(ctx context.Context, collections []client.CollectionV
 	return err
 }
 
-func (p *parser) NewFilterFromString(collectionType string, body string) (immutable.Option[request.Filter], error) {
+func (p *parser) NewFilterFromString(ctx context.Context, collectionType string, body string) (immutable.Option[request.Filter], error) {
+	// If the txn ID is in the schema manager map, use that one instead of the default one
+	gotTxn, hadTxn := datastore.CtxTryGetTxn(ctx)
+	if hadTxn {
+		p.schemaManagerMapLock.RLock()
+		gotSchemaManager, ok := p.schemaManagerMap[gotTxn.ID()]
+		p.schemaManagerMapLock.RUnlock()
+		if ok {
+			return defrap.NewFilterFromString(*gotSchemaManager.Schema(), collectionType, body)
+		}
+	}
 	return defrap.NewFilterFromString(*p.schemaManager.Schema(), collectionType, body)
 }

--- a/internal/request/graphql/parser.go
+++ b/internal/request/graphql/parser.go
@@ -193,7 +193,7 @@ func (p *parser) NewFilterFromString(
 		p.schemaManagerMapLock.RLock()
 		gotSchemaManager, ok := p.schemaManagerMap[gotTxn.ID()]
 		p.schemaManagerMapLock.RUnlock()
-		if ok {
+		if ok && gotSchemaManager != nil {
 			return defrap.NewFilterFromString(*gotSchemaManager.Schema(), collectionType, body)
 		}
 	}

--- a/tests/integration/txn/update_doc_test.go
+++ b/tests/integration/txn/update_doc_test.go
@@ -294,12 +294,8 @@ func TestTxn_UpdateDocWithFilter_WithoutCommit_DoesNotUpdateDocument(t *testing.
 	testUtils.ExecuteTestCase(t, test)
 }
 
-// todo: The following test should be enabled once any bugs inside UpdateWithFilter are resolved
-// see: https://github.com/sourcenetwork/defradb/issues/4614
-
 // This test runs UpdateWithFilter inside of a transaction, and illustrates that it can work on
 // the documents created inside that transaction.
-/*
 func TestTxn_UpdateWithFilter_ExhibitsTransactionalIsolation_Succeeds(t *testing.T) {
 	test := testUtils.TestCase{
 		Actions: []any{
@@ -350,4 +346,3 @@ func TestTxn_UpdateWithFilter_ExhibitsTransactionalIsolation_Succeeds(t *testing
 
 	testUtils.ExecuteTestCase(t, test)
 }
-*/

--- a/tests/integration/txn/update_doc_test.go
+++ b/tests/integration/txn/update_doc_test.go
@@ -294,9 +294,6 @@ func TestTxn_UpdateDocWithFilter_WithoutCommit_DoesNotUpdateDocument(t *testing.
 	testUtils.ExecuteTestCase(t, test)
 }
 
-// todo: The following test should be enabled once any bugs inside UpdateWithFilter are resolved
-// see: https://github.com/sourcenetwork/defradb/issues/4614
-/*
 // This test runs UpdateWithFilter inside of a transaction, and illustrates that it can work on
 // the documents created inside that transaction.
 func TestTxn_UpdateWithFilter_ExhibitsTransactionalIsolation_Succeeds(t *testing.T) {
@@ -349,4 +346,3 @@ func TestTxn_UpdateWithFilter_ExhibitsTransactionalIsolation_Succeeds(t *testing
 
 	testUtils.ExecuteTestCase(t, test)
 }
-*/

--- a/tests/integration/txn/update_doc_test.go
+++ b/tests/integration/txn/update_doc_test.go
@@ -294,6 +294,9 @@ func TestTxn_UpdateDocWithFilter_WithoutCommit_DoesNotUpdateDocument(t *testing.
 	testUtils.ExecuteTestCase(t, test)
 }
 
+// todo: The following test should be enabled once any bugs inside UpdateWithFilter are resolved
+// see: https://github.com/sourcenetwork/defradb/issues/4614
+/*
 // This test runs UpdateWithFilter inside of a transaction, and illustrates that it can work on
 // the documents created inside that transaction.
 func TestTxn_UpdateWithFilter_ExhibitsTransactionalIsolation_Succeeds(t *testing.T) {
@@ -346,3 +349,4 @@ func TestTxn_UpdateWithFilter_ExhibitsTransactionalIsolation_Succeeds(t *testing
 
 	testUtils.ExecuteTestCase(t, test)
 }
+*/


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4614 

## Description

The previous PR that was merged regarding transactional behavior left one bit of work undone, and marked as a todo. There was a test written that was commented out, `TestTxn_UpdateWithFilter_ExhibitsTransactionalIsolation_Succeeds`. This test was unique in that it would not pass due to the logic inside updateWithFilter not properly respecting transactions. This PR addresses and fixes that, and re-enables the test.

The fix is straightforward. The previous PR expanded the parser to maintain a map of schema managers, with the key being transaction IDs. This PR builds on that by changing the signature of the `NewFilterFromString` method to take a context. Then, the function examines this context for a transaction to decide which schema manager to use.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Specify the platform(s) on which this was tested:
- WSL
