### PR TITLE
fix: Fix change detector's behavior with commitTransaction

### DIFF
--- a/docs/data_format_changes/i4647-change-detector-transaction-support.md
+++ b/docs/data_format_changes/i4647-change-detector-transaction-support.md
@@ -1,0 +1,3 @@
+# Change detector transaction support
+
+The change detector performAction loop would not Continue on the CommitTransaction action

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -772,7 +772,7 @@ ActionLoop:
 			// We don't care about anything else if this has been explicitly provided
 			break ActionLoop
 
-		case *action.AddCollection, *action.AddDoc, UpdateDoc, Restart:
+		case *action.AddCollection, *action.AddDoc, UpdateDoc, Restart, CommitTransaction:
 			continue
 
 		default:


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4646 

## Description

It was possible for the `commitTransaction` action to panic if the transaction ID created for it was in another action that was skipped by the change detector. This small change fixes that.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Specify the platform(s) on which this was tested:
- WSL
