### PR TITLE
fix: Make change detector skip transactional isolation tests

### DIFF
--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -769,28 +769,25 @@ func getActionRange(t testing.TB, testCase TestCase) (int, int) {
 
 ActionLoop:
 	for i := range testCase.Actions {
-		switch testCase.Actions[i].(type) {
+		switch concreteAction := testCase.Actions[i].(type) {
 		case SetupComplete:
 			setupCompleteIndex = i
 			// We don't care about anything else if this has been explicitly provided
 			break ActionLoop
 
 		case *action.AddCollection:
-			concreteAction := testCase.Actions[i].(*action.AddCollection)
 			if concreteAction.TransactionID.HasValue() {
 				transactionIDset[concreteAction.TransactionID.Value()] = struct{}{}
 			}
 			continue
 
 		case *action.AddDoc:
-			concreteAction := testCase.Actions[i].(*action.AddDoc)
 			if concreteAction.TransactionID.HasValue() {
 				transactionIDset[concreteAction.TransactionID.Value()] = struct{}{}
 			}
 			continue
 
 		case UpdateDoc:
-			concreteAction := testCase.Actions[i].(UpdateDoc)
 			if concreteAction.TransactionID.HasValue() {
 				transactionIDset[concreteAction.TransactionID.Value()] = struct{}{}
 			}
@@ -801,7 +798,6 @@ ActionLoop:
 
 		case CommitTransaction:
 			// If transaction is commited, remove it from the set we are tracking
-			concreteAction := testCase.Actions[i].(CommitTransaction)
 			delete(transactionIDset, concreteAction.TransactionID)
 			continue
 

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -764,6 +764,7 @@ func getActionRange(t testing.TB, testCase TestCase) (int, int) {
 	setupCompleteIndex := -1
 	firstNonSetupIndex := -1
 
+	// Track the transaction IDs as they are used, in a set
 	transactionIDset := make(map[int]struct{})
 
 ActionLoop:
@@ -775,21 +776,21 @@ ActionLoop:
 			break ActionLoop
 
 		case *action.AddCollection:
-			concreteAction := testCase.Actions[i].(action.AddCollection)
+			concreteAction := testCase.Actions[i].(*action.AddCollection)
 			if concreteAction.TransactionID.HasValue() {
 				transactionIDset[concreteAction.TransactionID.Value()] = struct{}{}
 			}
 			continue
 
 		case *action.AddDoc:
-			concreteAction := testCase.Actions[i].(action.AddDoc)
+			concreteAction := testCase.Actions[i].(*action.AddDoc)
 			if concreteAction.TransactionID.HasValue() {
 				transactionIDset[concreteAction.TransactionID.Value()] = struct{}{}
 			}
 			continue
 
 		case UpdateDoc:
-			concreteAction := testCase.Actions[i].(UpdateDoc)
+			concreteAction := testCase.Actions[i].(*UpdateDoc)
 			if concreteAction.TransactionID.HasValue() {
 				transactionIDset[concreteAction.TransactionID.Value()] = struct{}{}
 			}
@@ -799,7 +800,8 @@ ActionLoop:
 			continue
 
 		case CommitTransaction:
-			concreteAction := testCase.Actions[i].(CommitTransaction)
+			// If transaction is commited, remove it from the set we are tracking
+			concreteAction := testCase.Actions[i].(*CommitTransaction)
 			delete(transactionIDset, concreteAction.TransactionID)
 			continue
 
@@ -809,10 +811,9 @@ ActionLoop:
 		}
 	}
 
+	// If length is not 0, there was a transaction used that was not committed
 	if len(transactionIDset) > 0 {
-		fmt.Println("This test has an open transaction")
 		t.Skipf("skipping test with open transaction(s)")
-
 	}
 
 	if changeDetector.SetupOnly {

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -790,7 +790,7 @@ ActionLoop:
 			continue
 
 		case UpdateDoc:
-			concreteAction := testCase.Actions[i].(*UpdateDoc)
+			concreteAction := testCase.Actions[i].(UpdateDoc)
 			if concreteAction.TransactionID.HasValue() {
 				transactionIDset[concreteAction.TransactionID.Value()] = struct{}{}
 			}

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -801,7 +801,7 @@ ActionLoop:
 
 		case CommitTransaction:
 			// If transaction is commited, remove it from the set we are tracking
-			concreteAction := testCase.Actions[i].(*CommitTransaction)
+			concreteAction := testCase.Actions[i].(CommitTransaction)
 			delete(transactionIDset, concreteAction.TransactionID)
 			continue
 

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -764,6 +764,8 @@ func getActionRange(t testing.TB, testCase TestCase) (int, int) {
 	setupCompleteIndex := -1
 	firstNonSetupIndex := -1
 
+	transactionIDset := make(map[int]struct{})
+
 ActionLoop:
 	for i := range testCase.Actions {
 		switch testCase.Actions[i].(type) {
@@ -772,13 +774,45 @@ ActionLoop:
 			// We don't care about anything else if this has been explicitly provided
 			break ActionLoop
 
-		case *action.AddCollection, *action.AddDoc, UpdateDoc, Restart, CommitTransaction:
+		case *action.AddCollection:
+			concreteAction := testCase.Actions[i].(action.AddCollection)
+			if concreteAction.TransactionID.HasValue() {
+				transactionIDset[concreteAction.TransactionID.Value()] = struct{}{}
+			}
+			continue
+
+		case *action.AddDoc:
+			concreteAction := testCase.Actions[i].(action.AddDoc)
+			if concreteAction.TransactionID.HasValue() {
+				transactionIDset[concreteAction.TransactionID.Value()] = struct{}{}
+			}
+			continue
+
+		case UpdateDoc:
+			concreteAction := testCase.Actions[i].(UpdateDoc)
+			if concreteAction.TransactionID.HasValue() {
+				transactionIDset[concreteAction.TransactionID.Value()] = struct{}{}
+			}
+			continue
+
+		case Restart:
+			continue
+
+		case CommitTransaction:
+			concreteAction := testCase.Actions[i].(CommitTransaction)
+			delete(transactionIDset, concreteAction.TransactionID)
 			continue
 
 		default:
 			firstNonSetupIndex = i
 			break ActionLoop
 		}
+	}
+
+	if len(transactionIDset) > 0 {
+		fmt.Println("This test has an open transaction")
+		t.Skipf("skipping test with open transaction(s)")
+
 	}
 
 	if changeDetector.SetupOnly {


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4648 

## Description

Some tests do not work with the change detector. Specifically, tests that do things inside transactions without committing them, displaying transactional isolation, cannot work with the change detector. This adjusts the change detector logic to skip these tests. It does so by creating a set of transaction IDs that are created prior to the first action of a test. Upon seeing a CommitTransaction action, it removes the appropriate item from the set. Then, when this initial scan is done, we know that if any IDs are left in the set, it means the test uses uncommitted transactional behavior and must be skipped.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Specify the platform(s) on which this was tested:
-WSL