### PR TITLE
refactor: Remove collection cache from context

### DIFF
--- a/cli/sdl_generate.go
+++ b/cli/sdl_generate.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/errors"
-	"github.com/sourcenetwork/defradb/internal/db/description"
 	"github.com/sourcenetwork/defradb/internal/request/graphql/schema"
 )
 
@@ -107,10 +106,6 @@ func MakeSDLGenerateCommand(ctx context.Context) *cobra.Command {
 			for i, c := range cols {
 				collections[i] = c.Definition
 			}
-
-			cache := description.NewCollectionCache()
-			cache.AddAll(collections)
-			ctx := description.ContextWithCollectionCache(ctx, cache)
 
 			_, err = schemaManager.Generator.Generate(ctx, collections)
 			if err != nil {

--- a/internal/db/backup.go
+++ b/internal/db/backup.go
@@ -226,7 +226,7 @@ func (db *DB) basicExport(ctx context.Context, config *client.BackupConfig) (err
 								refFieldName = fieldID
 							}
 						} else {
-							foreignDef, _, err := description.GetRelatedCollection(ctx, col.Version(), field.Kind)
+							foreignDef, _, err := description.GetRelatedCollection(ctx, db.collectionRepository, col.Version(), field.Kind)
 							if err != nil {
 								return err
 							}

--- a/internal/db/cache/README.md
+++ b/internal/db/cache/README.md
@@ -1,0 +1,35 @@
+# Cache
+
+The `cache` package provides the means to cache anything in memory in Defra.
+
+This document details how and why this *should* work, it does not necessarily detail how it is currently implemented.
+
+## Details
+
+The cache is split into several layers - `transaction`, `global` and `store`.  Each layer is free to perform additional cache layering should it chose, for example most on-disk `store` implementations will have some form of in-memory key-value caching.
+
+## Transaction layer caching
+
+The `transaction` cache layer sits on top of the `global` layer.  When it misses its cache, it will attempt to fetch the requested value from the `global` layer.
+
+The `transaction` cache populates upon read from the `global` layer to ensure that transaction isolation is maintained, and that concurrent changes made to the `global` cache to not affect ongoing transactions.  The transaction cache needs to hold onto a version number that it can pass along to the `global` cache when reading, to ensure it only reads `global` values that existed when the transaction was created - preserving transaction isolation.
+
+Each transaction-specific cache must be disposed of when the transaction is either discarded or committed.
+
+Because the `transaction` cache only needs to hold on to a smaller subset of values held in the global cache, and is relatively short-lived, it is currently believed that it is not necessary to actively manage its size.
+
+The `transaction` cache layer updates its values upon write to the transaction, there is little benefit in expiring them and requiring their re-fetching from lower layers, and this avoids us from having to worry about reading old, transaction-overwritten, values from the `global` and `store` layers.
+
+## Global layer caching
+
+The `global` cache layer sits on top of the `store` layer.  When it misses its cache, it will attempt to fetch the requested value from the `store` layer.
+
+The `global` cache populates upon read from the `store` layer.  Each cached value is versioned, and will only be yielded to transactions with a higher version.
+
+The `global` cache needs to have its size limited, this limit should be configurable.
+
+## Store layer caching
+
+The `store` layer sits at the bottom of the stack, and is responsible for fetching from the corekv store. The corekv store implementations may perform caching of their own.
+
+Access to the underlying store is driven by the corekv transaction held on the context parameter.

--- a/internal/db/cache/repository.go
+++ b/internal/db/cache/repository.go
@@ -1,0 +1,27 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package cache
+
+import "context"
+
+type Repository[T any, TV any] interface {
+	TryGet(context.Context, T) (TV, bool, error)
+	Write(context.Context, TV) error
+	Delete(context.Context, T) error
+	Forbid(TV)
+}
+
+type Cache[T any, TV any] interface {
+	TryGet(T) (TV, bool)
+	Cache(TV)
+	Remove(T)
+	Forbid(TV)
+}

--- a/internal/db/cache/txn.go
+++ b/internal/db/cache/txn.go
@@ -1,0 +1,147 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package cache
+
+import (
+	"context"
+	"sync"
+
+	"github.com/sourcenetwork/defradb/internal/datastore"
+)
+
+// TxnRepository is responsible for managing store access at the `transaction`
+// layer as detailed in the README.md
+//
+// On read, it will first attempt to fetch the requested value from the transaction cache,
+// only after failing that will it attempt to read from store.
+type TxnRepository[T any, TV any] struct {
+	// newCache creates a new instance of `Cache[T, TV]`
+	newCache func() Cache[T, TV]
+
+	// txnLock protects `cache` from concurrent read-writes
+	txnLock sync.RWMutex
+	// cache is the set of transaction specific caches keyed by transaction id.
+	cache map[uint64]Cache[T, TV]
+
+	// lower is the next layer down in the repository stack.
+	//
+	// For now, this is the `store` layer, but in the future this will likely be a global cache.
+	lower Repository[T, TV]
+}
+
+var _ Repository[any, any] = (*TxnRepository[any, any])(nil)
+
+func NewTxnLayer[T any, TV any](
+	newCache func() Cache[T, TV],
+	lower Repository[T, TV],
+) *TxnRepository[T, TV] {
+	return &TxnRepository[T, TV]{
+		newCache: newCache,
+		lower:    lower,
+		cache:    map[uint64]Cache[T, TV]{},
+	}
+}
+
+// registerTxn returns the transaction's cached repository.
+//
+// If a repository for this transaction does not exist, it will create it. The created
+// repositories will be disposed of upon transaction discard, error, or success.  The
+// transaction repository may be recreated after initial disposal as many times as required.
+func (l *TxnRepository[T, TV]) registerTxn(ctx context.Context) Cache[T, TV] {
+	txn := datastore.CtxMustGetTxn(ctx)
+	id := txn.ID()
+
+	l.txnLock.Lock()
+	txnCache, ok := l.cache[id]
+	if ok {
+		l.txnLock.Unlock()
+		return txnCache
+	}
+
+	txnCache = l.newCache()
+	l.cache[id] = txnCache
+	l.txnLock.Unlock()
+
+	// todo - an integration test for this is required, and make sure at least one tests discard and reuse:
+	// https://github.com/sourcenetwork/defradb/issues/4268
+	onTxnClose := func() {
+		l.txnLock.Lock()
+		_, ok := l.cache[id]
+		if !ok {
+			l.txnLock.Unlock()
+			return
+		}
+		delete(l.cache, id)
+		l.txnLock.Unlock()
+	}
+
+	txn.OnDiscard(onTxnClose)
+	txn.OnError(onTxnClose)
+	txn.OnSuccess(onTxnClose)
+
+	return txnCache
+}
+
+func (l *TxnRepository[T, TV]) TryGet(ctx context.Context, key T) (TV, bool, error) {
+	txnCache := l.registerTxn(ctx)
+
+	if value, ok := txnCache.TryGet(key); ok {
+		return value, true, nil
+	}
+
+	value, ok, err := l.lower.TryGet(ctx, key)
+	if err != nil || !ok {
+		var d TV
+		return d, false, err
+	}
+
+	txnCache.Cache(value)
+
+	return value, ok, err
+}
+
+func (l *TxnRepository[T, TV]) Write(ctx context.Context, value TV) error {
+	// Always write to the lower cache *first*, making sure any errors are surfaced from the store
+	// before polluting higher level caches
+	err := l.lower.Write(ctx, value)
+	if err != nil {
+		return err
+	}
+
+	txnCache := l.registerTxn(ctx)
+	txnCache.Cache(value)
+
+	return nil
+}
+
+func (l *TxnRepository[T, TV]) Delete(ctx context.Context, key T) error {
+	// Always delete from the lower cache *first*, making sure any errors are surfaced from the store
+	// before polluting higher level caches
+	err := l.lower.Delete(ctx, key)
+	if err != nil {
+		return err
+	}
+
+	txnCache := l.registerTxn(ctx)
+	txnCache.Remove(key)
+
+	return nil
+}
+
+func (l *TxnRepository[T, TV]) Forbid(value TV) {
+	l.lower.Forbid(value)
+
+	l.txnLock.RLock()
+	for _, cache := range l.cache {
+		cache.Forbid(value)
+	}
+	l.txnLock.RUnlock()
+}

--- a/internal/db/collection.go
+++ b/internal/db/collection.go
@@ -72,7 +72,7 @@ func (c *collection) newFetcher(ctx context.Context) fetcher.Fetcher {
 		innerFetcher = fetcher.NewDocumentFetcher()
 	}
 
-	return lens.NewFetcher(innerFetcher, c.db.getLensStore(ctx))
+	return lens.NewFetcher(innerFetcher, c.db.getLensStore(ctx), c.db.collectionRepository)
 }
 
 // getCollectionByName returns an existing collection within the database.
@@ -113,14 +113,14 @@ func (db *DB) getCollections(
 	var cols []client.CollectionVersion
 	switch {
 	case opts.CollectionName.HasValue() && !opts.GetInactive.Value():
-		col, err := description.GetCollectionByName(ctx, opts.CollectionName.Value())
+		col, err := description.GetCollectionByName(ctx, db.collectionRepository, opts.CollectionName.Value())
 		if err != nil && !errors.Is(err, client.ErrCollectionNotFound) {
 			return nil, err
 		}
 		cols = append(cols, col)
 
 	case opts.VersionID.HasValue():
-		col, err := description.GetCollectionByID(ctx, opts.VersionID.Value())
+		col, err := description.GetCollectionByID(ctx, db.collectionRepository, opts.VersionID.Value())
 		if err != nil {
 			return nil, err
 		}
@@ -128,7 +128,7 @@ func (db *DB) getCollections(
 
 	case opts.CollectionID.HasValue():
 		var err error
-		cols, err = description.GetCollectionsByCollectionID(ctx, opts.CollectionID.Value())
+		cols, err = description.GetCollectionsByCollectionID(ctx, db.collectionRepository, opts.CollectionID.Value())
 		if err != nil {
 			return nil, err
 		}
@@ -143,13 +143,13 @@ func (db *DB) getCollections(
 	default:
 		if opts.GetInactive.HasValue() && opts.GetInactive.Value() {
 			var err error
-			cols, err = description.GetCollections(ctx)
+			cols, err = description.GetCollections(ctx, db.collectionRepository)
 			if err != nil {
 				return nil, err
 			}
 		} else {
 			var err error
-			cols, err = description.GetActiveCollections(ctx)
+			cols, err = description.GetActiveCollections(ctx, db.collectionRepository)
 			if err != nil {
 				return nil, err
 			}
@@ -228,7 +228,7 @@ func (db *DB) addCollection(
 }
 
 func (db *DB) loadCollectionDefinitions(ctx context.Context) error {
-	definitions, err := description.GetActiveCollections(ctx)
+	definitions, err := description.GetActiveCollections(ctx, db.collectionRepository)
 	if err != nil {
 		return err
 	}

--- a/internal/db/collection_define.go
+++ b/internal/db/collection_define.go
@@ -42,7 +42,7 @@ func (db *DB) addCollections(
 ) ([]client.CollectionVersion, error) {
 	returnDescriptions := make([]client.CollectionVersion, 0, len(parseResults))
 
-	existingVersions, err := description.GetActiveCollections(ctx)
+	existingVersions, err := description.GetActiveCollections(ctx, db.collectionRepository)
 	if err != nil {
 		return nil, err
 	}
@@ -57,7 +57,7 @@ func (db *DB) addCollections(
 		newCollections[i] = def.Definition
 	}
 
-	err = setCollectionIDs(ctx, newCollections, existingVersions)
+	err = setCollectionIDs(ctx, db.collectionRepository, newCollections, existingVersions)
 	if err != nil {
 		return nil, err
 	}
@@ -87,7 +87,7 @@ func (db *DB) addCollections(
 			def.Definition.Indexes = append(def.Definition.Indexes, desc)
 		}
 
-		err = description.SaveCollection(ctx, def.Definition)
+		err = description.SaveCollection(ctx, db.collectionRepository, def.Definition)
 		if err != nil {
 			return nil, err
 		}
@@ -105,7 +105,7 @@ func (db *DB) addCollections(
 			}
 		}
 
-		result, err := description.GetCollectionByID(ctx, def.Definition.VersionID)
+		result, err := description.GetCollectionByID(ctx, db.collectionRepository, def.Definition.VersionID)
 		if err != nil {
 			return nil, err
 		}
@@ -145,7 +145,7 @@ func (db *DB) patchCollection(
 	if err != nil {
 		return err
 	}
-	existingCols, err := description.GetCollections(ctx)
+	existingCols, err := description.GetCollections(ctx, db.collectionRepository)
 	if err != nil {
 		return err
 	}
@@ -244,7 +244,7 @@ existingVersionLoop:
 		newCollections = append(newCollections, col)
 	}
 
-	err = setCollectionIDs(ctx, newCollections, existingCols)
+	err = setCollectionIDs(ctx, db.collectionRepository, newCollections, existingCols)
 	if err != nil {
 		return err
 	}
@@ -334,7 +334,7 @@ existingVersionLoop:
 			continue
 		}
 
-		err := description.SaveCollection(ctx, col)
+		err := description.SaveCollection(ctx, db.collectionRepository, col)
 		if err != nil {
 			return err
 		}
@@ -555,12 +555,12 @@ func (db *DB) setActiveCollectionVersion(
 	if versionID == "" {
 		return ErrCollectionVersionIDEmpty
 	}
-	col, err := description.GetCollectionByID(ctx, versionID)
+	col, err := description.GetCollectionByID(ctx, db.collectionRepository, versionID)
 	if err != nil {
 		return err
 	}
 
-	colsWithRoot, err := description.GetCollectionsByCollectionID(ctx, col.CollectionID)
+	colsWithRoot, err := description.GetCollectionsByCollectionID(ctx, db.collectionRepository, col.CollectionID)
 	if err != nil {
 		return err
 	}
@@ -575,7 +575,7 @@ func (db *DB) setActiveCollectionVersion(
 			}
 
 			col.IsActive = true
-			err = description.SaveCollection(ctx, col)
+			err = description.SaveCollection(ctx, db.collectionRepository, col)
 			if err != nil {
 				return err
 			}
@@ -590,7 +590,7 @@ func (db *DB) setActiveCollectionVersion(
 		}
 
 		col.IsActive = false
-		err = description.SaveCollection(ctx, col)
+		err = description.SaveCollection(ctx, db.collectionRepository, col)
 		if err != nil {
 			return err
 		}
@@ -623,7 +623,7 @@ func (db *DB) shouldReindexForVersionSwitch(
 	ctx context.Context,
 	newActiveCol client.CollectionVersion,
 ) (bool, error) {
-	return description.HasMigrations(ctx, newActiveCol.CollectionID, newActiveCol.VersionID)
+	return description.HasMigrations(ctx, db.collectionRepository, newActiveCol.CollectionID, newActiveCol.VersionID)
 }
 
 func (db *DB) deleteCollectionVersions(
@@ -682,12 +682,12 @@ func (db *DB) deleteCollectionVersion(
 		return NewErrCannotDeleteCollectionWithDocs(version.Name, version.VersionID)
 	}
 
-	err = validateCollectionDoesNotHaveHigherVersion(ctx, version)
+	err = db.validateCollectionDoesNotHaveHigherVersion(ctx, version)
 	if err != nil {
 		return err
 	}
 
-	err = description.DeleteCollection(ctx, db.lockSet, version)
+	err = description.DeleteCollection(ctx, db.collectionRepository, version)
 	if err != nil {
 		return err
 	}
@@ -742,11 +742,11 @@ func collectionHasDocuments(
 	return hasValue, iter.Close()
 }
 
-func validateCollectionDoesNotHaveHigherVersion(
+func (db *DB) validateCollectionDoesNotHaveHigherVersion(
 	ctx context.Context,
 	version client.CollectionVersion,
 ) error {
-	allVersions, err := description.GetCollectionsByCollectionID(ctx, version.CollectionID)
+	allVersions, err := description.GetCollectionsByCollectionID(ctx, db.collectionRepository, version.CollectionID)
 	if err != nil {
 		return err
 	}

--- a/internal/db/collection_id.go
+++ b/internal/db/collection_id.go
@@ -33,6 +33,7 @@ import (
 // This includes CollectionID (if not already set), VersionID, FieldID, and relational field Kinds.
 func setCollectionIDs(
 	ctx context.Context,
+	collectionRepository *description.CollectionRepository,
 	newCollections []client.CollectionVersion,
 	existingCollections []client.CollectionVersion,
 ) error {
@@ -53,7 +54,7 @@ func setCollectionIDs(
 		sortSet(collectionSet)
 
 		substituteRelationFieldKinds(collectionSet, collectionSets, existingCollections)
-		err := saveBlocks(ctx, collectionSet)
+		err := saveBlocks(ctx, collectionRepository, collectionSet)
 		if err != nil {
 			return err
 		}
@@ -407,6 +408,7 @@ setLoop:
 // setting the ids and migrations.
 func saveBlocks(
 	ctx context.Context,
+	collectionRepository *description.CollectionRepository,
 	collectionSet []*client.CollectionVersion,
 ) error {
 	colIds := make([]cidlink.Link, 0, len(collectionSet))
@@ -422,7 +424,7 @@ func saveBlocks(
 		var oldCol client.CollectionVersion
 		if collection.VersionID != "" {
 			var err error
-			oldCol, err = description.GetCollectionByID(ctx, collection.VersionID)
+			oldCol, err = description.GetCollectionByID(ctx, collectionRepository, collection.VersionID)
 			if err != nil {
 				if errors.Is(err, client.ErrCollectionNotFound) {
 					// If the key does not exist, continue, and let the validation code handle it

--- a/internal/db/collection_index.go
+++ b/internal/db/collection_index.go
@@ -39,7 +39,7 @@ import (
 func (db *DB) listIndexDescriptions(
 	ctx context.Context,
 ) (map[client.CollectionName][]client.IndexDescription, error) {
-	collections, err := description.GetCollections(ctx)
+	collections, err := description.GetCollections(ctx, db.collectionRepository)
 
 	if err != nil {
 		return nil, err
@@ -243,7 +243,7 @@ func (c *collection) newIndex(
 
 	c.def.Indexes = append(c.def.Indexes, desc)
 
-	err = description.SaveCollection(ctx, c.def)
+	err = description.SaveCollection(ctx, c.db.collectionRepository, c.def)
 	if err != nil {
 		c.def.Indexes = c.def.Indexes[:len(c.def.Indexes)-1]
 		return nil, err
@@ -417,7 +417,7 @@ func (c *collection) deleteIndex(ctx context.Context, indexName string) error {
 		}
 	}
 
-	err := description.SaveCollection(ctx, c.def)
+	err := description.SaveCollection(ctx, c.db.collectionRepository, c.def)
 	if err != nil {
 		c.def.Indexes = oldIndexes
 		return err
@@ -489,7 +489,7 @@ func (c *collection) newEncryptedIndex(
 
 	c.def.EncryptedIndexes = append(c.def.EncryptedIndexes, encryptedIndex)
 
-	err = description.SaveCollection(ctx, c.def)
+	err = description.SaveCollection(ctx, c.db.collectionRepository, c.def)
 	if err != nil {
 		c.def.EncryptedIndexes = c.def.EncryptedIndexes[:len(c.def.EncryptedIndexes)-1]
 		return client.EncryptedIndexDescription{}, err
@@ -573,7 +573,7 @@ func (c *collection) deleteEncryptedIndex(ctx context.Context, fieldName string)
 		c.def.EncryptedIndexes[indexToRemove+1:]...,
 	)
 
-	err := description.SaveCollection(ctx, c.def)
+	err := description.SaveCollection(ctx, c.db.collectionRepository, c.def)
 	if err != nil {
 		c.def.EncryptedIndexes = oldEncryptedIndexes
 		return err
@@ -745,7 +745,7 @@ func generateIndexName(colName string, fields []client.IndexedFieldDescription, 
 func (db *DB) listAllEncryptedIndexDescriptions(
 	ctx context.Context,
 ) (map[client.CollectionName][]client.EncryptedIndexDescription, error) {
-	collections, err := description.GetCollections(ctx)
+	collections, err := description.GetCollections(ctx, db.collectionRepository)
 
 	if err != nil {
 		return nil, err

--- a/internal/db/context.go
+++ b/internal/db/context.go
@@ -18,7 +18,6 @@ import (
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/clock"
 	"github.com/sourcenetwork/defradb/internal/datastore"
-	"github.com/sourcenetwork/defradb/internal/db/description"
 	"github.com/sourcenetwork/defradb/internal/db/id"
 )
 
@@ -32,7 +31,6 @@ func InitContext(ctx context.Context, txn client.Txn) context.Context {
 	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
 	ctx = id.InitCollectionShortIDCache(ctx)
 	ctx = id.InitFieldShortIDCache(ctx)
-	ctx = description.InitCollectionCache(ctx)
 	// corekv expects transactions to be set on the context.
 	// This allows us to pass transactions between libraries.
 	// For example: db.SetMigration -> lens.Transform -> corekv.Set

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -36,6 +36,7 @@ import (
 	"github.com/sourcenetwork/defradb/internal/core"
 	"github.com/sourcenetwork/defradb/internal/datastore"
 	acpDB "github.com/sourcenetwork/defradb/internal/db/acp"
+	"github.com/sourcenetwork/defradb/internal/db/description"
 	"github.com/sourcenetwork/defradb/internal/db/lock"
 	"github.com/sourcenetwork/defradb/internal/db/p2p"
 	intOpts "github.com/sourcenetwork/defradb/internal/options"
@@ -115,6 +116,8 @@ type DB struct {
 
 	// lockSet contains and manages the set of locks held and available to this Defra instance.
 	lockSet *lock.LockSet
+
+	collectionRepository *description.CollectionRepository
 }
 
 var _ client.TxnStore = (*DB)(nil)
@@ -145,6 +148,8 @@ func newDB(
 
 	ctx, cancel := context.WithCancel(ctx)
 
+	lockSet := lock.NewLockSet()
+
 	db := &DB{
 		rootstore:               rootstore,
 		blockStoreChunkSize:     cfg.ChunkSize,
@@ -162,7 +167,8 @@ func newDB(
 		colMergeQueue:           newMergeQueue(),
 		retryIntervals:          cfg.RetryIntervals,
 		p2pBlockSyncTimeout:     cfg.P2PBlockSyncTimeout,
-		lockSet:                 lock.NewLockSet(),
+		lockSet:                 lockSet,
+		collectionRepository:    description.NewColCache(lockSet),
 	}
 
 	lensRuntime, err := newLensRuntime(LensRuntimeType(cfg.LensRuntime))
@@ -194,7 +200,14 @@ func newDB(
 	db.lensNode = node
 
 	if cfg.P2P.HasValue() {
-		p, err := p2p.New(ctx, db, node, cfg.P2P.Value(), db.nodeIdentity, NewCollectionRetriever(db))
+		p, err := p2p.New(
+			ctx,
+			db,
+			node, cfg.P2P.Value(),
+			db.nodeIdentity,
+			NewCollectionRetriever(db),
+			db.collectionRepository,
+		)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/db/description/cache.go
+++ b/internal/db/description/cache.go
@@ -1,0 +1,47 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package description
+
+import (
+	"github.com/sourcenetwork/defradb/client"
+	"github.com/sourcenetwork/defradb/internal/db/cache"
+	"github.com/sourcenetwork/defradb/internal/db/lock"
+)
+
+type CollectionIndexKind int
+
+const (
+	CollectionVersionID CollectionIndexKind = 1
+	CollectionID        CollectionIndexKind = 2
+	CollectionName      CollectionIndexKind = 3
+)
+
+type CollectionIndex struct {
+	Kind  CollectionIndexKind
+	Value string
+}
+
+type CollectionRepository = cache.TxnRepository[CollectionIndex, client.CollectionVersion]
+
+func NewColCache(lockSet *lock.LockSet) *CollectionRepository {
+	collectionStore := newCollectionStore(lockSet)
+
+	collectionRepository := cache.NewTxnLayer(
+		func() cache.Cache[CollectionIndex, client.CollectionVersion] {
+			return newCollectionCache()
+		},
+		collectionStore,
+	)
+
+	collectionStore.collectionRepository = collectionRepository
+
+	return collectionRepository
+}

--- a/internal/db/description/collection.go
+++ b/internal/db/description/collection.go
@@ -339,27 +339,6 @@ func GetActiveCollections(
 	return cols, iter.Close()
 }
 
-// HasCollectionByName returns true if there is a collection of the given name,
-// else returns false.
-func HasCollectionByName(
-	ctx context.Context,
-	name string,
-) (bool, error) {
-	cache := CollectionCacheFromContext(ctx)
-	if cache.IsActiveCollectionsPopulated {
-		_, ok := cache.ActiveCollectionsByName[name]
-		return ok, nil
-	}
-	txn := datastore.CtxMustGetTxn(ctx)
-
-	nameKey := keys.NewCollectionNameKey(name)
-	has, err := txn.Systemstore().Has(ctx, nameKey.Bytes())
-	if err != nil {
-		return false, NewErrCheckCollectionExists(err, name)
-	}
-	return has, nil
-}
-
 func GetCollectionVersionIDs(
 	ctx context.Context,
 	collectionID string,

--- a/internal/db/description/collection.go
+++ b/internal/db/description/collection.go
@@ -12,7 +12,6 @@ package description
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"sort"
 
@@ -21,108 +20,33 @@ import (
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/errors"
 	"github.com/sourcenetwork/defradb/internal/datastore"
-	"github.com/sourcenetwork/defradb/internal/db/id"
-	"github.com/sourcenetwork/defradb/internal/db/lock"
 	"github.com/sourcenetwork/defradb/internal/keys"
 )
 
 // SaveCollection saves the given collection to the system store.
 func SaveCollection(
 	ctx context.Context,
+	collectionRepository *CollectionRepository,
 	desc client.CollectionVersion,
 ) error {
-	txn := datastore.CtxMustGetTxn(ctx)
-
-	err := id.SetShortCollectionID(ctx, desc.CollectionID)
-	if err != nil {
-		return NewErrSaveCollection(err, desc.CollectionID)
-	}
-
-	err = id.SetShortFieldIDs(ctx, desc)
-	if err != nil {
-		return NewErrSaveCollection(err, desc.CollectionID)
-	}
-
-	buf, err := json.Marshal(desc)
-	if err != nil {
-		return NewErrSaveCollection(err, desc.CollectionID)
-	}
-
-	key := keys.NewCollectionKey(desc.VersionID)
-	err = txn.Systemstore().Set(ctx, key.Bytes(), buf)
-	if err != nil {
-		return NewErrSaveCollection(err, desc.CollectionID)
-	}
-
-	if !desc.IsActive {
-		nameKey := keys.NewCollectionNameKey(desc.Name)
-		idBytes, err := txn.Systemstore().Get(ctx, nameKey.Bytes())
-		if err != nil {
-			if !errors.Is(err, corekv.ErrNotFound) {
-				return NewErrSaveCollection(err, desc.CollectionID)
-			}
-		}
-
-		if string(idBytes) == desc.VersionID {
-			err := txn.Systemstore().Delete(ctx, nameKey.Bytes())
-			if err != nil {
-				return NewErrSaveCollection(err, desc.CollectionID)
-			}
-		}
-	}
-
-	if desc.IsActive {
-		nameKey := keys.NewCollectionNameKey(desc.Name)
-		err = txn.Systemstore().Set(ctx, nameKey.Bytes(), []byte(desc.VersionID))
-		if err != nil {
-			return NewErrSaveCollection(err, desc.CollectionID)
-		}
-	}
-
-	isNew := desc.CollectionID == desc.VersionID
-	if !isNew {
-		// We don't need to index the version by collection id, if the version id is the collection id
-		collectionVersionKey := keys.NewCollectionVersionKey(desc.CollectionID, desc.VersionID)
-		err = txn.Systemstore().Set(ctx, collectionVersionKey.Bytes(), []byte{})
-		if err != nil {
-			return NewErrSaveCollection(err, desc.CollectionID)
-		}
-	}
-
-	cache := CollectionCacheFromContext(ctx)
-	cache.Add(desc)
-
-	return nil
+	return collectionRepository.Write(ctx, desc)
 }
 
 func GetCollectionByID(
 	ctx context.Context,
+	collectionRepository *CollectionRepository,
 	id string,
 ) (client.CollectionVersion, error) {
-	cache := CollectionCacheFromContext(ctx)
-	col, ok := cache.CollectionsByVersionID[id]
-	if ok {
-		return col, nil
-	}
-
-	txn := datastore.CtxMustGetTxn(ctx)
-
-	key := keys.NewCollectionKey(id)
-	buf, err := txn.Systemstore().Get(ctx, key.Bytes())
-	if err != nil {
-		if errors.Is(err, corekv.ErrNotFound) {
-			return client.CollectionVersion{}, client.NewErrCollectionNotFoundForCollectionVersion(id)
-		}
-		return client.CollectionVersion{}, NewErrGetCollectionByID(err, id)
-	}
-
-	err = json.Unmarshal(buf, &col)
+	col, ok, err := collectionRepository.TryGet(ctx, CollectionIndex{
+		Kind:  CollectionVersionID,
+		Value: id,
+	})
 	if err != nil {
 		return client.CollectionVersion{}, NewErrGetCollectionByID(err, id)
 	}
-
-	cache.Add(col)
-
+	if !ok {
+		return client.CollectionVersion{}, client.ErrCollectionNotFound
+	}
 	return col, nil
 }
 
@@ -131,57 +55,38 @@ func GetCollectionByID(
 // If no collection of that name is found, it will return an error.
 func GetCollectionByName(
 	ctx context.Context,
+	collectionRepository *CollectionRepository,
 	name string,
 ) (client.CollectionVersion, error) {
-	cache := CollectionCacheFromContext(ctx)
-	col, ok := cache.ActiveCollectionsByName[name]
-	if ok {
-		return col, nil
-	}
-
-	txn := datastore.CtxMustGetTxn(ctx)
-
-	nameKey := keys.NewCollectionNameKey(name)
-	idBuf, err := txn.Systemstore().Get(ctx, nameKey.Bytes())
-	if err != nil {
-		if errors.Is(err, corekv.ErrNotFound) {
-			return client.CollectionVersion{}, client.NewErrCollectionNotFoundForName(name)
-		}
-		return client.CollectionVersion{}, NewErrGetCollectionByName(err, name)
-	}
-
-	col, err = GetCollectionByID(ctx, string(idBuf))
+	col, ok, err := collectionRepository.TryGet(ctx, CollectionIndex{
+		Kind:  CollectionName,
+		Value: name,
+	})
 	if err != nil {
 		return client.CollectionVersion{}, err
 	}
-
-	cache.Add(col)
-
-	return col, err
+	if !ok {
+		return client.CollectionVersion{}, client.ErrCollectionNotFound
+	}
+	return col, nil
 }
 
 func GetActiveCollectionByCollectionID(
 	ctx context.Context,
-	collectionID string,
+	collectionRepository *CollectionRepository,
+	colID string,
 ) (client.CollectionVersion, error) {
-	cache := CollectionCacheFromContext(ctx)
-	col, ok := cache.ActiveCollectionsByID[collectionID]
-	if ok {
-		return col, nil
-	}
-
-	cols, err := GetCollectionsByCollectionID(ctx, collectionID)
+	col, ok, err := collectionRepository.TryGet(ctx, CollectionIndex{
+		Kind:  CollectionID,
+		Value: colID,
+	})
 	if err != nil {
 		return client.CollectionVersion{}, err
 	}
-
-	for _, col := range cols {
-		if col.IsActive {
-			return col, nil
-		}
+	if !ok {
+		return client.CollectionVersion{}, client.ErrCollectionNotFound
 	}
-
-	return client.CollectionVersion{}, client.ErrCollectionNotFound
+	return col, nil
 }
 
 // GetCollectionsByCollectionID returns all collection versions for the given id.
@@ -189,28 +94,17 @@ func GetActiveCollectionByCollectionID(
 // If no collections are found an empty set will be returned.
 func GetCollectionsByCollectionID(
 	ctx context.Context,
+	collectionRepository *CollectionRepository,
 	collectionID string,
 ) ([]client.CollectionVersion, error) {
-	cache := CollectionCacheFromContext(ctx)
-	if cache.IsFullyPopulated {
-		if col, ok := cache.CollectionsByID[collectionID]; ok {
-			return col, nil
-		}
-		return []client.CollectionVersion{}, nil
-	}
-	// It is not practical to cache a sub set of collections at the moment as figuring
-	// out whether the set is complete or not if not possible without fetching the versionIDs
-	// anyway.  So we do not cache collections by CollectionID and instead use the cache one-by-one
-	// in the GetCollectionByID call.
-
-	versionIDs, err := GetCollectionVersionIDs(ctx, collectionID)
+	versionIDs, err := getCollectionVersionIDs(ctx, collectionID)
 	if err != nil {
 		return nil, err
 	}
 
 	cols := []client.CollectionVersion{}
 	for _, versionID := range versionIDs {
-		versionCol, err := GetCollectionByID(ctx, versionID)
+		versionCol, err := GetCollectionByID(ctx, collectionRepository, versionID)
 		if err != nil {
 			if errors.Is(err, client.ErrCollectionNotFound) {
 				continue
@@ -229,16 +123,13 @@ func GetCollectionsByCollectionID(
 // This includes inactive collections.
 func GetCollections(
 	ctx context.Context,
+	collectionRepository *CollectionRepository,
 ) ([]client.CollectionVersion, error) {
-	cache := CollectionCacheFromContext(ctx)
-	if cache.IsFullyPopulated {
-		return cache.Collections, nil
-	}
-
 	txn := datastore.CtxMustGetTxn(ctx)
 
 	iter, err := txn.Systemstore().Iterator(ctx, corekv.IterOptions{
-		Prefix: []byte(keys.COLLECTION_ID),
+		Prefix:   []byte(keys.COLLECTION_ID),
+		KeysOnly: true,
 	})
 	if err != nil {
 		return nil, NewErrGetCollections(err)
@@ -258,27 +149,28 @@ func GetCollections(
 			break
 		}
 
-		value, err := iter.Value()
-		if err != nil {
-			if err := iter.Close(); err != nil {
-				return nil, NewErrFailedToCloseCollectionQuery(err)
-			}
-			return nil, NewErrGetCollections(err)
-		}
+		key := keys.NewCollectionKeyFromString(string(iter.Key()))
 
-		var col client.CollectionVersion
-		err = json.Unmarshal(value, &col)
+		// We must read via the repository in order to correctly handle collections that may have been
+		// deleted by other (committed) transactions - these must not be read from the store.
+		col, hasValue, err := collectionRepository.TryGet(
+			ctx, CollectionIndex{
+				Kind:  CollectionVersionID,
+				Value: key.CollectionID,
+			},
+		)
 		if err != nil {
-			if err := iter.Close(); err != nil {
-				return nil, NewErrFailedToCloseCollectionQuery(err)
+			if errors.Is(err, client.ErrCollectionNotFound) {
+				continue
 			}
-			return nil, NewErrGetCollections(err)
+			return nil, NewErrGetCollections(errors.Join(err, iter.Close()))
+		}
+		if !hasValue {
+			continue
 		}
 
 		cols = append(cols, col)
 	}
-
-	cache.AddAll(cols)
 
 	return cols, iter.Close()
 }
@@ -286,12 +178,8 @@ func GetCollections(
 // GetActiveCollections returns all active collections in the system.
 func GetActiveCollections(
 	ctx context.Context,
+	collectionRepository *CollectionRepository,
 ) ([]client.CollectionVersion, error) {
-	cache := CollectionCacheFromContext(ctx)
-	if cache.IsActiveCollectionsPopulated {
-		return cache.ActiveCollections, nil
-	}
-
 	txn := datastore.CtxMustGetTxn(ctx)
 
 	iter, err := txn.Systemstore().Iterator(ctx, corekv.IterOptions{
@@ -323,8 +211,11 @@ func GetActiveCollections(
 			return nil, NewErrGetActiveCollections(err)
 		}
 
-		col, err := GetCollectionByID(ctx, string(value))
+		col, err := GetCollectionByID(ctx, collectionRepository, string(value))
 		if err != nil {
+			if errors.Is(err, client.ErrCollectionNotFound) {
+				continue
+			}
 			return nil, errors.Join(err, iter.Close())
 		}
 
@@ -334,27 +225,13 @@ func GetActiveCollections(
 	// Sort the results by ID, so that the order matches that of [GetCollections].
 	sort.Slice(cols, func(i, j int) bool { return cols[i].VersionID < cols[j].VersionID })
 
-	cache.AddAllActive(cols)
-
 	return cols, iter.Close()
 }
 
-func GetCollectionVersionIDs(
+func getCollectionVersionIDs(
 	ctx context.Context,
 	collectionID string,
 ) ([]string, error) {
-	cache := CollectionCacheFromContext(ctx)
-	if cache.IsFullyPopulated {
-		result := []string{}
-		if cols, ok := cache.CollectionsByID[collectionID]; ok {
-			for _, col := range cols {
-				result = append(result, col.VersionID)
-			}
-			return result, nil
-		}
-		return nil, client.ErrCollectionNotFound
-	}
-
 	txn := datastore.CtxMustGetTxn(ctx)
 
 	// Add the collection id as the first version here.
@@ -399,12 +276,13 @@ func GetCollectionVersionIDs(
 // If the related collection is not found, default and false will be returned.
 func GetRelatedCollection(
 	ctx context.Context,
+	collectionRepository *CollectionRepository,
 	host client.CollectionVersion,
 	kind client.FieldKind,
 ) (client.CollectionVersion, bool, error) {
 	switch typedKind := kind.(type) {
 	case *client.NamedKind:
-		col, err := GetCollectionByName(ctx, typedKind.Name)
+		col, err := GetCollectionByName(ctx, collectionRepository, typedKind.Name)
 		if errors.Is(err, client.ErrCollectionNotFound) {
 			return client.CollectionVersion{}, false, nil
 		}
@@ -412,7 +290,7 @@ func GetRelatedCollection(
 		return col, true, err
 
 	case *client.CollectionKind:
-		col, err := GetActiveCollectionByCollectionID(ctx, typedKind.CollectionID)
+		col, err := GetActiveCollectionByCollectionID(ctx, collectionRepository, typedKind.CollectionID)
 		if errors.Is(err, client.ErrCollectionNotFound) {
 			return client.CollectionVersion{}, false, nil
 		}
@@ -424,7 +302,7 @@ func GetRelatedCollection(
 			return host, true, nil
 		}
 
-		cols, err := GetActiveCollections(ctx)
+		cols, err := GetActiveCollections(ctx, collectionRepository)
 		if err != nil {
 			return client.CollectionVersion{}, false, err
 		}
@@ -452,64 +330,11 @@ func GetRelatedCollection(
 
 func DeleteCollection(
 	ctx context.Context,
-	lockSet *lock.LockSet,
+	collectionRepository *CollectionRepository,
 	version client.CollectionVersion,
 ) error {
-	txn := datastore.CtxMustGetTxn(ctx)
-	shortID, err := id.GetShortCollectionID(ctx, version.CollectionID)
-	if err != nil {
-		return NewErrDeleteCollection(err, version.CollectionID)
-	}
-
-	versions, err := GetCollectionsByCollectionID(ctx, version.CollectionID)
-	if err != nil {
-		return NewErrDeleteCollection(err, version.CollectionID)
-	}
-
-	cache := CollectionCacheFromContext(ctx)
-	cache.Delete(version)
-
-	key := keys.NewCollectionKey(version.VersionID)
-	err = txn.Systemstore().Delete(ctx, key.Bytes())
-	if err != nil {
-		return NewErrDeleteCollection(err, version.CollectionID)
-	}
-
-	if version.IsActive {
-		nameKey := keys.NewCollectionNameKey(version.Name)
-		err = txn.Systemstore().Delete(ctx, nameKey.Bytes())
-		if err != nil {
-			return NewErrDeleteCollection(err, version.CollectionID)
-		}
-	}
-
-	isNew := version.CollectionID == version.VersionID
-	if !isNew {
-		collectionVersionKey := keys.NewCollectionVersionKey(version.CollectionID, version.VersionID)
-		err = txn.Systemstore().Delete(ctx, collectionVersionKey.Bytes())
-		if err != nil {
-			return NewErrDeleteCollection(err, version.CollectionID)
-		}
-	}
-
-	// WARNING - DeleteShortFieldIDs is dependent on the collection short id still existing, it should be called
-	// before deleting the collection short id.
-	err = id.DeleteShortFieldIDs(ctx, lockSet, version, versions)
-	if err != nil {
-		return NewErrDeleteCollection(err, version.CollectionID)
-	}
-
-	if len(versions) == 1 {
-		// It is impossible to recreate the collection short ID once it is deleted, so we must lock the collection
-		// whilst we finalize this operation, otherwise other threads/operations may try and make use of it.
-		lockSet.CollectionLock(txn, shortID)
-
-		// Only delete the collection short ID if this was the last local version
-		err = id.DeleteShortCollectionID(ctx, version.CollectionID)
-		if err != nil {
-			return NewErrDeleteCollection(err, version.CollectionID)
-		}
-	}
-
-	return nil
+	return collectionRepository.Delete(ctx, CollectionIndex{
+		Kind:  CollectionVersionID,
+		Value: version.VersionID,
+	})
 }

--- a/internal/db/description/collection_cache.go
+++ b/internal/db/description/collection_cache.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Democratized Data Foundation
+// Copyright 2026 Democratized Data Foundation
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt.
@@ -11,228 +11,112 @@
 package description
 
 import (
-	"context"
+	"sync"
 
 	"github.com/sourcenetwork/defradb/client"
+	"github.com/sourcenetwork/defradb/internal/db/cache"
 )
 
-type collectionCacheKey struct{}
+type collectionRepository struct {
+	forbiddenLock sync.RWMutex
+	// Collections may be forbidden, in which case we must prevent as much interaction with
+	// them as possible, regardless of what the underlying corekv store thinks.
+	//
+	// Collections are forbidden when the last local version is deleted from the node.  They
+	// will become unforbidden if they are re-added.
+	forbiddenCollectionIDs map[string]struct{}
 
-// InitCollectionCache initialializes the context with a none-nil collection cache.
-//
-// It is done to avoid an extra check to see if the cache exists or not when fetching
-// it from the context.
-func InitCollectionCache(ctx context.Context) context.Context {
-	return context.WithValue(ctx, collectionCacheKey{}, NewCollectionCache())
+	// The cached active collection versions mapped by their CollectionID
+	activeCollectionsByCollectionID map[string]client.CollectionVersion
+
+	// The cached active collection versions mapped by their Name
+	activeCollectionsByName map[string]client.CollectionVersion
+
+	// The cached collection versions mapped by their VersionID.
+	//
+	// Includes inactive versions.
+	collectionsByVersionID map[string]client.CollectionVersion
 }
 
-// InitCollectionCache initialializes the context with a none-nil collection cache.
-//
-// It is done to avoid an extra check to see if the cache exists or not when fetching
-// it from the context.
-func ContextWithCollectionCache(ctx context.Context, cache *CollectionCache) context.Context {
-	return context.WithValue(ctx, collectionCacheKey{}, cache)
-}
+var _ cache.Cache[CollectionIndex, client.CollectionVersion] = (*collectionRepository)(nil)
 
-// getCollectionCache retrieves the collection short-id cache from the given context.
-func CollectionCacheFromContext(ctx context.Context) *CollectionCache {
-	return ctx.Value(collectionCacheKey{}).(*CollectionCache) //nolint:forcetypeassert
-}
-
-// collectionCache is an object providing easy access to cached collections.
-type CollectionCache struct {
-	IsFullyPopulated             bool
-	IsActiveCollectionsPopulated bool
-
-	// The cached collection versions mapped by their CollectionID
-	ActiveCollectionsByID map[string]client.CollectionVersion
-
-	// The cached collection versions mapped by their CollectionID
-	ActiveCollectionsByName map[string]client.CollectionVersion
-
-	// The cached collection versions mapped by their CollectionID
-	CollectionsByVersionID map[string]client.CollectionVersion
-
-	// The full set of [CollectionVersion]s within this cache
-	Collections       []client.CollectionVersion
-	ActiveCollections []client.CollectionVersion
-	// The cached collection versions mapped by their CollectionID
-	CollectionsByID map[string][]client.CollectionVersion
-}
-
-// NewCollectionCache creates a new [collectionCache] populated with the given [CollectionVersion]s.
-func NewCollectionCache() *CollectionCache {
-	return &CollectionCache{
-		CollectionsByVersionID:  make(map[string]client.CollectionVersion),
-		ActiveCollectionsByName: make(map[string]client.CollectionVersion),
-		ActiveCollectionsByID:   make(map[string]client.CollectionVersion),
+func newCollectionCache() *collectionRepository {
+	return &collectionRepository{
+		forbiddenCollectionIDs:          map[string]struct{}{},
+		activeCollectionsByCollectionID: map[string]client.CollectionVersion{},
+		activeCollectionsByName:         map[string]client.CollectionVersion{},
+		collectionsByVersionID:          map[string]client.CollectionVersion{},
 	}
 }
 
-func (cache *CollectionCache) Add(col client.CollectionVersion) {
-	_, isOld := cache.CollectionsByVersionID[col.VersionID]
-	cache.CollectionsByVersionID[col.VersionID] = col
+func (i *collectionRepository) TryGet(key CollectionIndex) (client.CollectionVersion, bool) {
+	var col client.CollectionVersion
+	var hasValue bool
 
-	if col.IsActive {
-		cache.ActiveCollectionsByName[col.Name] = col
-		cache.ActiveCollectionsByID[col.CollectionID] = col
-	} else if isOld {
-		// If the version already existed in the cache, and the given collection is inactive,
-		// ensure that there is no old cached active version
-		delete(cache.ActiveCollectionsByID, col.CollectionID)
-		delete(cache.ActiveCollectionsByName, col.Name)
+	switch key.Kind {
+	case CollectionVersionID:
+		col, hasValue = i.collectionsByVersionID[key.Value]
+
+	case CollectionID:
+		col, hasValue = i.activeCollectionsByCollectionID[key.Value]
+
+	case CollectionName:
+		col, hasValue = i.activeCollectionsByName[key.Value]
 	}
 
-	if cache.IsFullyPopulated {
-		if !isOld {
-			cache.Collections = append(cache.Collections, col)
+	if hasValue {
+		i.forbiddenLock.RLock()
+		_, isForbidden := i.forbiddenCollectionIDs[col.CollectionID]
+		i.forbiddenLock.RUnlock()
 
-			colVersions := cache.CollectionsByID[col.CollectionID]
-			colVersions = append(colVersions, col)
-			cache.CollectionsByID[col.CollectionID] = colVersions
-		} else {
-			for i, oldC := range cache.Collections {
-				if oldC.VersionID == col.VersionID {
-					cache.Collections[i] = col
-					break
-				}
-			}
-
-			colVersions := cache.CollectionsByID[col.CollectionID]
-			for i := range colVersions {
-				if colVersions[i].VersionID == col.VersionID {
-					colVersions[i] = col
-					break
-				}
-			}
-			cache.CollectionsByID[col.CollectionID] = colVersions
+		if isForbidden {
+			hasValue = false
+			col = client.CollectionVersion{}
 		}
 	}
 
-	if cache.IsActiveCollectionsPopulated {
-		if !isOld {
-			if col.IsActive {
-				var found bool
-				// If the collection ID already existed in the cache, we need to swap it for the new
-				// version
-				for i, oldC := range cache.ActiveCollections {
-					if oldC.CollectionID == col.CollectionID {
-						cache.ActiveCollections[i] = col
-						found = true
-						break
-					}
-				}
-
-				if !found {
-					cache.ActiveCollections = append(cache.ActiveCollections, col)
-				}
-			}
-		} else {
-			if col.IsActive {
-				var found bool
-				// If the collection version ID already existed in the cache, it may have been patched
-				// in which case we need to find and replace the original
-				for i, oldC := range cache.ActiveCollections {
-					if oldC.VersionID == col.VersionID {
-						cache.ActiveCollections[i] = col
-						found = true
-						break
-					}
-				}
-
-				if !found {
-					cache.ActiveCollections = append(cache.ActiveCollections, col)
-				}
-			} else {
-				for i, oldC := range cache.ActiveCollections {
-					if oldC.VersionID == col.VersionID {
-						// If the collection has been deactivated, ensure that it is removed from the active set
-						cache.ActiveCollections = append(cache.ActiveCollections[:i], cache.ActiveCollections[i+1:]...)
-						break
-					}
-				}
-			}
-		}
-	}
+	return col, hasValue
 }
 
-func (cache *CollectionCache) Delete(version client.CollectionVersion) {
-	delete(cache.CollectionsByVersionID, version.VersionID)
-
-	if cols, ok := cache.CollectionsByID[version.CollectionID]; ok {
-		var indexToRemove int
-		for i, col := range cols {
-			if col.VersionID == version.VersionID {
-				indexToRemove = i
-				break
-			}
-		}
-		cache.CollectionsByID[version.CollectionID] = append(cols[:indexToRemove], cols[indexToRemove+1:]...)
-	}
-
-	var indexToRemove int
-	for i, col := range cache.Collections {
-		if col.VersionID == version.VersionID {
-			indexToRemove = i
-			break
+func (i *collectionRepository) Cache(value client.CollectionVersion) {
+	if value.IsActive {
+		i.activeCollectionsByName[value.Name] = value
+		i.activeCollectionsByCollectionID[value.CollectionID] = value
+	} else {
+		oldVersion, oldVersionCached := i.collectionsByVersionID[value.VersionID]
+		if oldVersionCached && oldVersion.IsActive {
+			// If we are deactivating a collection we must remove the old values from the
+			// active caches.
+			// todo - the unforbidding is currently untested, and should be done as part of:
+			// https://github.com/sourcenetwork/defradb/issues/4268
+			delete(i.activeCollectionsByName, oldVersion.Name)
+			delete(i.activeCollectionsByCollectionID, oldVersion.CollectionID)
 		}
 	}
-	cache.Collections = append(cache.Collections[:indexToRemove], cache.Collections[indexToRemove+1:]...)
+	i.collectionsByVersionID[value.VersionID] = value
 
-	if version.IsActive {
-		delete(cache.ActiveCollectionsByID, version.CollectionID)
-		delete(cache.ActiveCollectionsByName, version.Name)
-
-		var indexToRemove int
-		for i, col := range cache.ActiveCollections {
-			if col.VersionID == version.VersionID {
-				indexToRemove = i
-				break
-			}
-		}
-		cache.ActiveCollections = append(
-			cache.ActiveCollections[:indexToRemove],
-			cache.ActiveCollections[indexToRemove+1:]...,
-		)
-	}
+	i.forbiddenLock.Lock()
+	// If this transaction writes a collection version that was previously forbidden, we must unforbid it
+	// within the context of this transaction.
+	// todo - the unforbidding is currently untested, and should be done as part of:
+	// https://github.com/sourcenetwork/defradb/issues/4268
+	delete(i.forbiddenCollectionIDs, value.CollectionID)
+	i.forbiddenLock.Unlock()
 }
 
-func (cache *CollectionCache) AddAll(cols []client.CollectionVersion) {
-	cache.Collections = make([]client.CollectionVersion, 0, len(cols))
-	cache.ActiveCollections = make([]client.CollectionVersion, 0)
-	cache.CollectionsByID = make(map[string][]client.CollectionVersion)
-
-	for _, col := range cols {
-		cache.Collections = append(cache.Collections, col)
-		cache.CollectionsByVersionID[col.VersionID] = col
-
-		colVersions := cache.CollectionsByID[col.CollectionID]
-		colVersions = append(colVersions, col)
-		cache.CollectionsByID[col.CollectionID] = colVersions
-
-		if col.IsActive {
-			cache.ActiveCollectionsByName[col.Name] = col
-			cache.ActiveCollectionsByID[col.CollectionID] = col
-			cache.ActiveCollections = append(cache.ActiveCollections, col)
-		}
+func (i *collectionRepository) Remove(key CollectionIndex) {
+	value, ok := i.TryGet(key)
+	if !ok {
+		return
 	}
 
-	cache.IsFullyPopulated = true
-	cache.IsActiveCollectionsPopulated = true
+	delete(i.activeCollectionsByName, value.Name)
+	delete(i.activeCollectionsByCollectionID, value.CollectionID)
+	delete(i.collectionsByVersionID, value.VersionID)
 }
 
-func (cache *CollectionCache) AddAllActive(cols []client.CollectionVersion) {
-	cache.ActiveCollections = make([]client.CollectionVersion, 0, len(cols))
-
-	for _, col := range cols {
-		cache.CollectionsByVersionID[col.VersionID] = col
-
-		if col.IsActive {
-			cache.ActiveCollectionsByName[col.Name] = col
-			cache.ActiveCollectionsByID[col.CollectionID] = col
-			cache.ActiveCollections = append(cache.ActiveCollections, col)
-		}
-	}
-
-	cache.IsActiveCollectionsPopulated = true
+func (i *collectionRepository) Forbid(value client.CollectionVersion) {
+	i.forbiddenLock.Lock()
+	i.forbiddenCollectionIDs[value.CollectionID] = struct{}{}
+	i.forbiddenLock.Unlock()
 }

--- a/internal/db/description/collection_history.go
+++ b/internal/db/description/collection_history.go
@@ -71,10 +71,11 @@ func (t *TargetedCollectionHistoryLink) Previous() immutable.Option[*TargetedCol
 // reachable from the given version has a migration transform.
 func HasMigrations(
 	ctx context.Context,
+	collectionRepository *CollectionRepository,
 	collectionID string,
 	versionID string,
 ) (bool, error) {
-	history, err := GetTargetedCollectionHistory(ctx, collectionID, versionID)
+	history, err := GetTargetedCollectionHistory(ctx, collectionRepository, collectionID, versionID)
 	if err != nil {
 		return false, err
 	}
@@ -101,10 +102,11 @@ func HasMigrations(
 // This includes any history items that are only known via registered collection migrations.
 func GetTargetedCollectionHistory(
 	ctx context.Context,
+	collectionRepository *CollectionRepository,
 	collectionRoot string,
 	targetCollectionVersionID string,
 ) (map[string]*TargetedCollectionHistoryLink, error) {
-	history, err := getCollectionHistory(ctx, collectionRoot)
+	history, err := getCollectionHistory(ctx, collectionRepository, collectionRoot)
 	if err != nil {
 		return nil, err
 	}
@@ -189,9 +191,10 @@ func linkBackwards(
 // This includes any history items that are only known via registered collection migrations.
 func getCollectionHistory(
 	ctx context.Context,
+	collectionRepository *CollectionRepository,
 	collectionRoot string,
 ) (map[string]*collectionHistoryLink, error) {
-	cols, err := GetCollectionsByCollectionID(ctx, collectionRoot)
+	cols, err := GetCollectionsByCollectionID(ctx, collectionRepository, collectionRoot)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/db/description/collection_store.go
+++ b/internal/db/description/collection_store.go
@@ -1,0 +1,406 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package description
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+
+	"github.com/sourcenetwork/corekv"
+	"github.com/sourcenetwork/defradb/client"
+	"github.com/sourcenetwork/defradb/internal/datastore"
+	"github.com/sourcenetwork/defradb/internal/db/cache"
+	"github.com/sourcenetwork/defradb/internal/db/id"
+	"github.com/sourcenetwork/defradb/internal/db/lock"
+	"github.com/sourcenetwork/defradb/internal/keys"
+)
+
+type collectionStore struct {
+	forbiddenLock sync.RWMutex
+	// Collections may be forbidden, in which case we must prevent as much interaction with
+	// them as possible, regardless of what the underlying corekv store thinks.
+	//
+	// Collections are forbidden when the last local version is deleted from the node.  They
+	// will become unforbidden if they are re-added.
+	forbiddenCollectionIDs map[string]struct{}
+
+	lockSet              *lock.LockSet
+	collectionRepository *cache.TxnRepository[CollectionIndex, client.CollectionVersion]
+}
+
+var _ cache.Repository[CollectionIndex, client.CollectionVersion] = (*collectionStore)(nil)
+
+func newCollectionStore(lockSet *lock.LockSet) *collectionStore {
+	return &collectionStore{
+		lockSet:                lockSet,
+		forbiddenCollectionIDs: map[string]struct{}{},
+	}
+}
+
+func (i *collectionStore) Write(ctx context.Context, value client.CollectionVersion) error {
+	txn := datastore.CtxMustGetTxn(ctx)
+
+	err := id.SetShortCollectionID(ctx, value.CollectionID)
+	if err != nil {
+		return err
+	}
+
+	err = id.SetShortFieldIDs(ctx, value)
+	if err != nil {
+		return err
+	}
+
+	buf, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+
+	key := keys.NewCollectionKey(value.VersionID)
+	err = txn.Systemstore().Set(ctx, key.Bytes(), buf)
+	if err != nil {
+		return err
+	}
+
+	if !value.IsActive {
+		nameKey := keys.NewCollectionNameKey(value.Name)
+		idBytes, err := txn.Systemstore().Get(ctx, nameKey.Bytes())
+		if err != nil {
+			if !errors.Is(err, corekv.ErrNotFound) {
+				return err
+			}
+		}
+
+		if string(idBytes) == value.VersionID {
+			err := txn.Systemstore().Delete(ctx, nameKey.Bytes())
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	if value.IsActive {
+		nameKey := keys.NewCollectionNameKey(value.Name)
+		err = txn.Systemstore().Set(ctx, nameKey.Bytes(), []byte(value.VersionID))
+		if err != nil {
+			return err
+		}
+	}
+
+	isNew := value.CollectionID == value.VersionID
+	if !isNew {
+		// We don't need to index the version by collection id, if the version id is the collection id
+		collectionVersionKey := keys.NewCollectionVersionKey(value.CollectionID, value.VersionID)
+		err = txn.Systemstore().Set(ctx, collectionVersionKey.Bytes(), []byte{})
+		if err != nil {
+			return err
+		}
+	}
+
+	i.forbiddenLock.Lock()
+	// If this transaction writes a collection version that was previously forbidden, we must unforbid it
+	// within the context of this transaction.
+	// todo - make sure the unforbidding is tested!
+	delete(i.forbiddenCollectionIDs, value.CollectionID)
+	i.forbiddenLock.Unlock()
+
+	return nil
+}
+
+func (i *collectionStore) TryGet(ctx context.Context, key CollectionIndex) (client.CollectionVersion, bool, error) {
+	var col client.CollectionVersion
+	var err error
+	var hasValue bool
+
+	switch key.Kind {
+	case CollectionVersionID:
+		col, hasValue, err = i.getCollectionByVersionID(ctx, key.Value)
+
+	case CollectionID:
+		col, hasValue, err = i.getActiveCollectionByCollectionID(ctx, key.Value)
+
+	case CollectionName:
+		col, hasValue, err = i.getCollectionByName(ctx, key.Value)
+	}
+
+	if err != nil {
+		return client.CollectionVersion{}, false, err
+	}
+
+	if !hasValue {
+		return client.CollectionVersion{}, false, client.ErrCollectionNotFound
+	}
+
+	i.forbiddenLock.RLock()
+	if _, ok := i.forbiddenCollectionIDs[col.CollectionID]; ok {
+		i.forbiddenLock.RUnlock()
+		return client.CollectionVersion{}, false, client.ErrCollectionNotFound
+	}
+	i.forbiddenLock.RUnlock()
+
+	return col, true, nil
+}
+
+func (i *collectionStore) getCollectionByVersionID(
+	ctx context.Context,
+	versionID string,
+) (client.CollectionVersion, bool, error) {
+	txn := datastore.CtxMustGetTxn(ctx)
+
+	key := keys.NewCollectionKey(versionID)
+	buf, err := txn.Systemstore().Get(ctx, key.Bytes())
+	if err != nil {
+		if errors.Is(err, corekv.ErrNotFound) {
+			return client.CollectionVersion{}, false, nil
+		}
+		return client.CollectionVersion{}, false, err
+	}
+
+	var col client.CollectionVersion
+	err = json.Unmarshal(buf, &col)
+	if err != nil {
+		return client.CollectionVersion{}, false, err
+	}
+
+	return col, true, nil
+}
+
+// GetCollectionByName returns the collection with the given name.
+//
+// If no collection of that name is found, it will return an error.
+func (i *collectionStore) getCollectionByName(
+	ctx context.Context,
+	name string,
+) (client.CollectionVersion, bool, error) {
+	txn := datastore.CtxMustGetTxn(ctx)
+
+	nameKey := keys.NewCollectionNameKey(name)
+	idBuf, err := txn.Systemstore().Get(ctx, nameKey.Bytes())
+	if err != nil {
+		if errors.Is(err, corekv.ErrNotFound) {
+			return client.CollectionVersion{}, false, nil
+		}
+		return client.CollectionVersion{}, false, err
+	}
+
+	col, ok, err := i.collectionRepository.TryGet(ctx, CollectionIndex{
+		Kind:  CollectionVersionID,
+		Value: string(idBuf),
+	})
+
+	return col, ok, err
+}
+
+func (i *collectionStore) getActiveCollectionByCollectionID(
+	ctx context.Context,
+	collectionID string,
+) (client.CollectionVersion, bool, error) {
+	// The first collection version is not indexed by CollectionVersionKey, so try get it directly
+	col, ok, err := i.collectionRepository.TryGet(ctx, CollectionIndex{
+		Kind:  CollectionVersionID,
+		Value: collectionID,
+	})
+	if err != nil && !errors.Is(err, client.ErrCollectionNotFound) {
+		return client.CollectionVersion{}, false, err
+	}
+	if ok && col.IsActive {
+		return col, true, nil
+	}
+
+	txn := datastore.CtxMustGetTxn(ctx)
+	iter, err := txn.Systemstore().Iterator(ctx, corekv.IterOptions{
+		Prefix:   keys.NewCollectionVersionKey(collectionID, "").Bytes(),
+		KeysOnly: true,
+	})
+	if err != nil {
+		return client.CollectionVersion{}, false, err
+	}
+
+	for {
+		hasValue, err := iter.Next()
+		if err != nil {
+			return client.CollectionVersion{}, false, errors.Join(err, iter.Close())
+		}
+
+		if !hasValue {
+			break
+		}
+
+		key, err := keys.NewCollectionVersionKeyFromString(string(iter.Key()))
+		if err != nil {
+			return client.CollectionVersion{}, false, errors.Join(err, iter.Close())
+		}
+
+		col, ok, err := i.collectionRepository.TryGet(ctx, CollectionIndex{
+			Kind:  CollectionVersionID,
+			Value: key.VersionID,
+		})
+
+		if err != nil {
+			if errors.Is(err, client.ErrCollectionNotFound) {
+				continue
+			}
+			return client.CollectionVersion{}, false, errors.Join(err, iter.Close())
+		}
+
+		if !ok {
+			continue
+		}
+
+		if col.IsActive {
+			return col, true, iter.Close()
+		}
+	}
+
+	return client.CollectionVersion{}, false, iter.Close()
+}
+
+func (i *collectionStore) Delete(ctx context.Context, key CollectionIndex) error {
+	version, ok, err := i.collectionRepository.TryGet(ctx, key)
+	if err != nil {
+		if errors.Is(err, client.ErrCollectionNotFound) {
+			return nil
+		}
+		return err
+	}
+	if !ok {
+		// If the collection does not exist, we don't need to delete it
+		return nil
+	}
+
+	txn := datastore.CtxMustGetTxn(ctx)
+	shortID, err := id.GetShortCollectionID(ctx, version.CollectionID)
+	if err != nil {
+		return err
+	}
+
+	versions, err := i.getCollectionsByCollectionID(ctx, version.CollectionID)
+	if err != nil {
+		return err
+	}
+
+	collectionKey := keys.NewCollectionKey(version.VersionID)
+	err = txn.Systemstore().Delete(ctx, collectionKey.Bytes())
+	if err != nil {
+		return err
+	}
+
+	if version.IsActive {
+		nameKey := keys.NewCollectionNameKey(version.Name)
+		err = txn.Systemstore().Delete(ctx, nameKey.Bytes())
+		if err != nil {
+			return err
+		}
+	}
+
+	isNew := version.CollectionID == version.VersionID
+	if !isNew {
+		collectionVersionKey := keys.NewCollectionVersionKey(version.CollectionID, version.VersionID)
+		err = txn.Systemstore().Delete(ctx, collectionVersionKey.Bytes())
+		if err != nil {
+			return err
+		}
+	}
+
+	// WARNING - DeleteShortFieldIDs is dependent on the collection short id still existing, it should be called
+	// before deleting the collection short id.
+	err = id.DeleteShortFieldIDs(ctx, i.lockSet, version, versions)
+	if err != nil {
+		return err
+	}
+
+	if len(versions) == 1 {
+		// It is impossible to recreate the collection short ID once it is deleted, so we must lock the collection
+		// whilst we finalize this operation, otherwise other threads/operations may try and make use of it.
+		i.lockSet.CollectionLock(txn, shortID)
+
+		// Only delete the collection short ID if this was the last local version
+		err = id.DeleteShortCollectionID(ctx, version.CollectionID)
+		if err != nil {
+			return err
+		}
+
+		txn.OnSuccess(
+			func() {
+				// If the last local version of a collection is deleted, we must immediately prevent its
+				// usage by other transactions.  This deliberately violates their transaction-isolation.
+				i.collectionRepository.Forbid(version)
+			},
+		)
+	}
+
+	return nil
+}
+
+func (i *collectionStore) getCollectionsByCollectionID(
+	ctx context.Context,
+	collectionID string,
+) ([]client.CollectionVersion, error) {
+	txn := datastore.CtxMustGetTxn(ctx)
+	cols := []client.CollectionVersion{}
+
+	// The first collection version is not indexed by CollectionVersionKey, so try get it directly
+	col, ok, err := i.collectionRepository.TryGet(ctx, CollectionIndex{
+		Kind:  CollectionVersionID,
+		Value: collectionID,
+	})
+	if err != nil && !errors.Is(err, client.ErrCollectionNotFound) {
+		return nil, err
+	}
+	if ok {
+		cols = append(cols, col)
+	}
+
+	iter, err := txn.Systemstore().Iterator(ctx, corekv.IterOptions{
+		Prefix:   keys.NewCollectionVersionKey(collectionID, "").Bytes(),
+		KeysOnly: true,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	for {
+		hasValue, err := iter.Next()
+		if err != nil {
+			return nil, errors.Join(err, iter.Close())
+		}
+
+		if !hasValue {
+			break
+		}
+
+		key, err := keys.NewCollectionVersionKeyFromString(string(iter.Key()))
+		if err != nil {
+			return nil, errors.Join(err, iter.Close())
+		}
+
+		versionCol, ok, err := i.getCollectionByVersionID(ctx, key.VersionID)
+		if err != nil {
+			if errors.Is(err, client.ErrCollectionNotFound) {
+				continue
+			}
+			return nil, errors.Join(err, iter.Close())
+		}
+
+		if ok {
+			cols = append(cols, versionCol)
+		}
+	}
+
+	return cols, iter.Close()
+}
+
+func (i *collectionStore) Forbid(value client.CollectionVersion) {
+	i.forbiddenLock.Lock()
+	i.forbiddenCollectionIDs[value.CollectionID] = struct{}{}
+	i.forbiddenLock.Unlock()
+}

--- a/internal/db/document_update.go
+++ b/internal/db/document_update.go
@@ -194,6 +194,7 @@ func (c *collection) makeSelectionPlan(
 		c.db,
 		c.db.p2p,
 		c.db.getLensStore(ctx),
+		c.db.collectionRepository,
 	)
 
 	return planner.MakeSelectionPlan(slct)

--- a/internal/db/lens.go
+++ b/internal/db/lens.go
@@ -58,7 +58,7 @@ func (db *DB) listLenses(ctx context.Context) (map[string]model.Lens, error) {
 
 func (db *DB) setMigration(ctx context.Context, cfg client.LensConfig) (string, error) {
 	dstFound := true
-	dstCol, err := description.GetCollectionByID(ctx, cfg.DestinationCollectionVersionID)
+	dstCol, err := description.GetCollectionByID(ctx, db.collectionRepository, cfg.DestinationCollectionVersionID)
 	if err != nil {
 		if errors.Is(err, client.ErrCollectionNotFound) {
 			dstFound = false
@@ -68,7 +68,7 @@ func (db *DB) setMigration(ctx context.Context, cfg client.LensConfig) (string, 
 	}
 
 	srcFound := true
-	sourceCol, err := description.GetCollectionByID(ctx, cfg.SourceCollectionVersionID)
+	sourceCol, err := description.GetCollectionByID(ctx, db.collectionRepository, cfg.SourceCollectionVersionID)
 	if err != nil {
 		if errors.Is(err, client.ErrCollectionNotFound) {
 			srcFound = false
@@ -85,7 +85,7 @@ func (db *DB) setMigration(ctx context.Context, cfg client.LensConfig) (string, 
 			IsPlaceholder:  true,
 		}
 
-		err = description.SaveCollection(ctx, sourceCol)
+		err = description.SaveCollection(ctx, db.collectionRepository, sourceCol)
 		if err != nil {
 			return "", err
 		}
@@ -116,7 +116,7 @@ func (db *DB) setMigration(ctx context.Context, cfg client.LensConfig) (string, 
 		Transform:          immutable.Some(id),
 	})
 
-	err = description.SaveCollection(ctx, dstCol)
+	err = description.SaveCollection(ctx, db.collectionRepository, dstCol)
 	if err != nil {
 		return "", err
 	}
@@ -149,7 +149,7 @@ func (db *DB) shouldReindexAfterMigration(
 		return true, dstCol, nil
 	}
 
-	activeCol, err := description.GetActiveCollectionByCollectionID(ctx, dstCol.CollectionID)
+	activeCol, err := description.GetActiveCollectionByCollectionID(ctx, db.collectionRepository, dstCol.CollectionID)
 	if err != nil {
 		if errors.Is(err, client.ErrCollectionNotFound) {
 			return false, client.CollectionVersion{}, nil
@@ -159,6 +159,7 @@ func (db *DB) shouldReindexAfterMigration(
 
 	history, err := description.GetTargetedCollectionHistory(
 		ctx,
+		db.collectionRepository,
 		activeCol.CollectionID,
 		activeCol.VersionID,
 	)

--- a/internal/db/p2p/p2p.go
+++ b/internal/db/p2p/p2p.go
@@ -38,6 +38,7 @@ import (
 	coreblock "github.com/sourcenetwork/defradb/internal/core/block"
 	"github.com/sourcenetwork/defradb/internal/datastore"
 	acpDB "github.com/sourcenetwork/defradb/internal/db/acp"
+	"github.com/sourcenetwork/defradb/internal/db/description"
 	"github.com/sourcenetwork/defradb/internal/db/p2p/protocol"
 	"github.com/sourcenetwork/defradb/internal/kms"
 	"github.com/sourcenetwork/defradb/internal/se"
@@ -104,11 +105,12 @@ type P2P struct {
 	identityProtocol   *protocol.IdentityProtocol
 	replicatorProtocol protocol.CommChannel[protocol.PushLogRequest, protocol.PushLogReply]
 
-	ctx  context.Context
-	db   DB
-	lens *lens.Node
-	host client.Host
-	kms  kms.Service
+	ctx                  context.Context
+	db                   DB
+	lens                 *lens.Node
+	collectionRepository *description.CollectionRepository
+	host                 client.Host
+	kms                  kms.Service
 
 	// replicators is a map from collection CollectionID => peerId => list of addresses.
 	// This is a cached in-memory copy of the persisted replicators in the database.
@@ -174,11 +176,13 @@ func New(
 	host client.Host,
 	nodeIdentity immutable.Option[identity.Identity],
 	collectionRetriever kms.CollectionRetriever,
+	collectionRepository *description.CollectionRepository,
 ) (*P2P, error) {
 	p := P2P{
 		ctx:                  ctx,
 		db:                   db,
 		lens:                 lens,
+		collectionRepository: collectionRepository,
 		host:                 host,
 		identityProtocol:     protocol.NewIdentityProtocol(host, db.GetNodeIdentityToken),
 		replicators:          make(map[string]map[string][]string),

--- a/internal/db/p2p/protocol/comm_channel.go
+++ b/internal/db/p2p/protocol/comm_channel.go
@@ -15,7 +15,6 @@ import (
 	"io"
 
 	"github.com/sourcenetwork/defradb/client"
-	"github.com/sourcenetwork/defradb/internal/db/description"
 	"github.com/sourcenetwork/defradb/internal/db/id"
 	"github.com/sourcenetwork/defradb/internal/db/p2p/message"
 )
@@ -100,7 +99,6 @@ func (c *commChannel[Req, Reply, ReqP, ReplyP]) onRequest(stream io.Reader, peer
 	ctx := context.Background()
 	ctx = id.InitCollectionShortIDCache(ctx)
 	ctx = id.InitFieldShortIDCache(ctx)
-	ctx = description.InitCollectionCache(ctx)
 
 	var req Req
 	reqPtr := ReqP(&req)

--- a/internal/db/p2p/sync_col_versions.go
+++ b/internal/db/p2p/sync_col_versions.go
@@ -51,7 +51,7 @@ func (p *P2P) syncCollectionVersion(
 	versionID string,
 	linkSys linking.LinkSystem,
 ) (client.CollectionVersion, error) {
-	col, err := description.GetCollectionByID(ctx, versionID)
+	col, err := description.GetCollectionByID(ctx, p.collectionRepository, versionID)
 	if err != nil {
 		if !errors.Is(err, client.ErrCollectionNotFound) {
 			return client.CollectionVersion{}, err
@@ -213,7 +213,7 @@ func (p *P2P) syncCollectionVersion(
 	// can toggle this locally if they like.
 	col.IsMaterialized = !query.HasValue()
 
-	err = description.SaveCollection(ctx, col)
+	err = description.SaveCollection(ctx, p.collectionRepository, col)
 	if err != nil {
 		return client.CollectionVersion{}, err
 	}

--- a/internal/db/request.go
+++ b/internal/db/request.go
@@ -55,6 +55,7 @@ func (db *DB) execRequest(ctx context.Context, request string, options *client.G
 		db,
 		db.p2p,
 		db.getLensStore(ctx),
+		db.collectionRepository,
 	)
 
 	results, err := planner.RunRequest(ctx, parsedRequest)

--- a/internal/db/subscriptions.go
+++ b/internal/db/subscriptions.go
@@ -86,6 +86,7 @@ func (db *DB) handleSubscription(ctx context.Context, r *request.Request) (<-cha
 				db,
 				db.p2p,
 				db.getLensStore(ctx),
+				db.collectionRepository,
 			)
 			s := subRequest.ToSubscriptionSelect(evt.DocID, evt.Cid.String())
 

--- a/internal/db/view.go
+++ b/internal/db/view.go
@@ -168,18 +168,19 @@ func (db *DB) buildViewCache(ctx context.Context, col client.CollectionVersion) 
 		db,
 		db.p2p,
 		db.getLensStore(ctx),
+		db.collectionRepository,
 	)
 
 	// temporarily disable the cache in order to query without using it
 	col.IsMaterialized = false
-	err = description.SaveCollection(ctx, col)
+	err = description.SaveCollection(ctx, db.collectionRepository, col)
 	if err != nil {
 		return err
 	}
 	defer func() {
 		var defErr error
 		col.IsMaterialized = true
-		defErr = description.SaveCollection(ctx, col)
+		defErr = description.SaveCollection(ctx, db.collectionRepository, col)
 		if err == nil {
 			// Do not overwrite the original error if there is one, defErr is probably an artifact of the original
 			// failue and can be discarded.
@@ -309,7 +310,7 @@ func (db *DB) generateMaximalSelectFromCollection(
 	childRequests := []request.Selection{}
 	for _, field := range col.Fields {
 		if field.RelationName.HasValue() && field.Kind.IsObject() {
-			relatedCol, _, err := description.GetRelatedCollection(ctx, col, field.Kind)
+			relatedCol, _, err := description.GetRelatedCollection(ctx, db.collectionRepository, col, field.Kind)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/keys/systemstore_collection.go
+++ b/internal/keys/systemstore_collection.go
@@ -12,6 +12,7 @@ package keys
 
 import (
 	"fmt"
+	"strings"
 
 	ds "github.com/ipfs/go-datastore"
 )
@@ -28,6 +29,11 @@ var _ Key = (*CollectionKey)(nil)
 // It assumes the id of the collection is non-empty.
 func NewCollectionKey(id string) CollectionKey {
 	return CollectionKey{CollectionID: id}
+}
+
+func NewCollectionKeyFromString(keyString string) CollectionKey {
+	keyString = strings.TrimPrefix(keyString, COLLECTION_ID+"/")
+	return CollectionKey{CollectionID: keyString}
 }
 
 func (k CollectionKey) ToString() string {

--- a/internal/lens/fetcher.go
+++ b/internal/lens/fetcher.go
@@ -38,9 +38,10 @@ import (
 // https://github.com/sourcenetwork/defradb/issues/1589
 
 type lensedFetcher struct {
-	source fetcher.Fetcher
-	store  store.Store
-	lens   Lens
+	source               fetcher.Fetcher
+	store                store.Store
+	lens                 Lens
+	collectionRepository *description.CollectionRepository
 
 	txn datastore.Txn
 
@@ -59,10 +60,15 @@ var _ fetcher.Fetcher = (*lensedFetcher)(nil)
 
 // NewFetcher returns a new fetcher that will migrate any documents from the given
 // source Fetcher as they are are yielded.
-func NewFetcher(source fetcher.Fetcher, store store.Store) fetcher.Fetcher {
+func NewFetcher(
+	source fetcher.Fetcher,
+	store store.Store,
+	collectionRepository *description.CollectionRepository,
+) fetcher.Fetcher {
 	return &lensedFetcher{
-		source: source,
-		store:  store,
+		source:               source,
+		store:                store,
+		collectionRepository: collectionRepository,
 	}
 }
 
@@ -93,8 +99,12 @@ func (f *lensedFetcher) Init(
 		f.fieldDescriptionsByName[defFields[i].Name] = defFields[i]
 	}
 
-	history, err := description.GetTargetedCollectionHistory(ctx, f.col.Version().CollectionID,
-		f.col.Version().VersionID)
+	history, err := description.GetTargetedCollectionHistory(
+		ctx,
+		f.collectionRepository,
+		f.col.Version().CollectionID,
+		f.col.Version().VersionID,
+	)
 	if err != nil {
 		return err
 	}

--- a/internal/planner/mapper/mapper.go
+++ b/internal/planner/mapper/mapper.go
@@ -53,6 +53,7 @@ const (
 func ToOperation(
 	ctx context.Context,
 	store client.TxnStore,
+	collectionRepository *description.CollectionRepository,
 	operationRequest *request.OperationDefinition,
 ) (*Operation, error) {
 	operation := &Operation{
@@ -63,7 +64,7 @@ func ToOperation(
 	for i, s := range operationRequest.Selections {
 		switch t := s.(type) {
 		case *request.CommitSelect:
-			s, err := toCommitSelect(ctx, store, t, i)
+			s, err := toCommitSelect(ctx, store, collectionRepository, t, i)
 			if err != nil {
 				return nil, err
 			}
@@ -71,7 +72,7 @@ func ToOperation(
 			operation.addSelection(i, t.Field, s.Select)
 
 		case *request.Select:
-			s, err := toSelect(ctx, store, ObjectSelection, i, t, "")
+			s, err := toSelect(ctx, store, collectionRepository, ObjectSelection, i, t, "")
 			if err != nil {
 				return nil, err
 			}
@@ -79,7 +80,7 @@ func ToOperation(
 			operation.addSelection(i, t.Field, *s)
 
 		case *request.ObjectMutation:
-			m, err := toMutation(ctx, store, t, i)
+			m, err := toMutation(ctx, store, collectionRepository, t, i)
 			if err != nil {
 				return nil, err
 			}
@@ -101,11 +102,12 @@ func ToOperation(
 func ToSelect(
 	ctx context.Context,
 	store client.TxnStore,
+	collectionRepository *description.CollectionRepository,
 	rootSelectType SelectionType,
 	selectRequest *request.Select,
 ) (*Select, error) {
 	// the top-level select will always have index=0, and no parent collection name
-	return toSelect(ctx, store, rootSelectType, 0, selectRequest, "")
+	return toSelect(ctx, store, collectionRepository, rootSelectType, 0, selectRequest, "")
 }
 
 // toSelect converts the given [parser.Select] into a [Select].
@@ -115,6 +117,7 @@ func ToSelect(
 func toSelect(
 	ctx context.Context,
 	store client.TxnStore,
+	collectionRepository *description.CollectionRepository,
 	rootSelectType SelectionType,
 	thisIndex int,
 	selectRequest *request.Select,
@@ -130,7 +133,13 @@ func toSelect(
 		rootSelectType = EncryptedSearchSelection
 	}
 
-	collectionName, err := getCollectionName(ctx, rootSelectType, selectRequest, parentCollectionName)
+	collectionName, err := getCollectionName(
+		ctx,
+		collectionRepository,
+		rootSelectType,
+		selectRequest,
+		parentCollectionName,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -140,14 +149,22 @@ func toSelect(
 		return nil, err
 	}
 
-	fields, aggregates, err := getRequestables(ctx, rootSelectType, selectRequest, mapping, collectionName, store)
+	fields, aggregates, err := getRequestables(
+		ctx,
+		collectionRepository,
+		rootSelectType,
+		selectRequest,
+		mapping,
+		collectionName,
+		store,
+	)
 	if err != nil {
 		return nil, err
 	}
 
 	// Needs to be done before resolving aggregates, else filter conversion may fail there
 	filterDependencies, err := resolveFilterDependencies(
-		ctx, store, rootSelectType, collectionName, selectRequest.Filter, mapping, fields)
+		ctx, store, collectionRepository, rootSelectType, collectionName, selectRequest.Filter, mapping, fields)
 	if err != nil {
 		return nil, err
 	}
@@ -155,7 +172,7 @@ func toSelect(
 
 	// Resolve order dependencies that may have been missed due to not being rendered.
 	err = resolveOrderDependencies(
-		ctx, store, rootSelectType, collectionName, selectRequest.OrderBy, mapping, &fields)
+		ctx, store, collectionRepository, rootSelectType, collectionName, selectRequest.OrderBy, mapping, &fields)
 	if err != nil {
 		return nil, err
 	}
@@ -163,6 +180,7 @@ func toSelect(
 	aggregates = appendUnderlyingAggregates(aggregates, mapping)
 	fields, err = resolveAggregates(
 		ctx,
+		collectionRepository,
 		rootSelectType,
 		aggregates,
 		fields,
@@ -180,6 +198,7 @@ func toSelect(
 		fields, err = resolveSecondaryRelationIDs(
 			ctx,
 			store,
+			collectionRepository,
 			rootSelectType,
 			collectionName,
 			definition,
@@ -238,6 +257,7 @@ func toSelect(
 func resolveOrderDependencies(
 	ctx context.Context,
 	store client.TxnStore,
+	collectionRepository *description.CollectionRepository,
 	rootSelectType SelectionType,
 	descName string,
 	source immutable.Option[request.OrderBy],
@@ -271,6 +291,7 @@ outer:
 				innerSelect, err := resolveChildOrder(
 					ctx,
 					store,
+					collectionRepository,
 					rootSelectType,
 					descName,
 					joinField,
@@ -294,7 +315,16 @@ outer:
 				joinField := fields[0]
 
 				// ensure the child select is resolved for this order join
-				innerSelect, err := resolveChildOrder(ctx, store, rootSelectType, descName, joinField, mapping, existingFields)
+				innerSelect, err := resolveChildOrder(
+					ctx,
+					store,
+					collectionRepository,
+					rootSelectType,
+					descName,
+					joinField,
+					mapping,
+					existingFields,
+				)
 				if err != nil {
 					return err
 				}
@@ -321,6 +351,7 @@ outer:
 func resolveChildOrder(
 	ctx context.Context,
 	store client.TxnStore,
+	collectionRepository *description.CollectionRepository,
 	rootSelectType SelectionType,
 	descName string,
 	orderChildField string,
@@ -339,7 +370,7 @@ func resolveChildOrder(
 				Name: orderChildField,
 			},
 		}
-		innerSelect, err := toSelect(ctx, store, rootSelectType, index, &dummyJoinFieldSelect, descName)
+		innerSelect, err := toSelect(ctx, store, collectionRepository, rootSelectType, index, &dummyJoinFieldSelect, descName)
 		if err != nil {
 			return nil, err
 		}
@@ -369,6 +400,7 @@ func resolveChildOrder(
 // updated with any new fields/aggregates.
 func resolveAggregates(
 	ctx context.Context,
+	collectionRepository *description.CollectionRepository,
 	rootSelectType SelectionType,
 	aggregates []*aggregateRequest,
 	inputFields []Requestable,
@@ -467,7 +499,13 @@ func resolveAggregates(
 					collectionName = ""
 				}
 
-				childCollectionName, err := getCollectionName(ctx, rootSelectType, hostSelectRequest, collectionName)
+				childCollectionName, err := getCollectionName(
+					ctx,
+					collectionRepository,
+					rootSelectType,
+					hostSelectRequest,
+					collectionName,
+				)
 				if err != nil {
 					return nil, err
 				}
@@ -481,6 +519,7 @@ func resolveAggregates(
 
 				childFields, _, err := getRequestables(
 					ctx,
+					collectionRepository,
 					rootSelectType,
 					hostSelectRequest,
 					childMapping,
@@ -492,7 +531,7 @@ func resolveAggregates(
 				}
 
 				err = resolveOrderDependencies(
-					ctx, store, rootSelectType, childCollectionName, target.order, childMapping, &childFields)
+					ctx, store, collectionRepository, rootSelectType, childCollectionName, target.order, childMapping, &childFields)
 				if err != nil {
 					return nil, err
 				}
@@ -503,6 +542,7 @@ func resolveAggregates(
 				filterDependencies, err := resolveFilterDependencies(
 					ctx,
 					store,
+					collectionRepository,
 					rootSelectType,
 					childCollectionName,
 					target.filter,
@@ -792,6 +832,7 @@ func appendIfNotExists(
 // consumed mapping data.
 func getRequestables(
 	ctx context.Context,
+	collectionRepository *description.CollectionRepository,
 	rootSelectType SelectionType,
 	selectRequest *request.Select,
 	mapping *core.DocumentMapping,
@@ -818,7 +859,7 @@ func getRequestables(
 		case *request.Select:
 			index := mapping.GetNextIndex()
 
-			innerSelect, err := toSelect(ctx, store, rootSelectType, index, f, collectionName)
+			innerSelect, err := toSelect(ctx, store, collectionRepository, rootSelectType, index, f, collectionName)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -833,7 +874,7 @@ func getRequestables(
 			mapping.Add(index, f.Name)
 		case *request.CommitSelect:
 			index := mapping.GetNextIndex()
-			innerSelect, err := toCommitSelect(ctx, store, f, index)
+			innerSelect, err := toCommitSelect(ctx, store, collectionRepository, f, index)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -918,6 +959,7 @@ func getAggregateRequests(index int, aggregate *request.Aggregate) (aggregateReq
 // if this is a commit request.
 func getCollectionName(
 	ctx context.Context,
+	collectionRepository *description.CollectionRepository,
 	rootSelectType SelectionType,
 	selectRequest *request.Select,
 	parentCollectionName string,
@@ -935,14 +977,19 @@ func getCollectionName(
 	}
 
 	if parentCollectionName != "" {
-		parentCollection, err := description.GetCollectionByName(ctx, parentCollectionName)
+		parentCollection, err := description.GetCollectionByName(ctx, collectionRepository, parentCollectionName)
 		if err != nil {
 			return "", err
 		}
 
 		hostFieldDesc, parentHasField := parentCollection.GetFieldByName(selectRequest.Name)
 		if parentHasField && hostFieldDesc.Kind.IsObject() {
-			def, found, err := description.GetRelatedCollection(ctx, parentCollection, hostFieldDesc.Kind)
+			def, found, err := description.GetRelatedCollection(
+				ctx,
+				collectionRepository,
+				parentCollection,
+				hostFieldDesc.Kind,
+			)
 			if !found {
 				return "", NewErrTypeNotFound(hostFieldDesc.Kind.String())
 			}
@@ -1035,6 +1082,7 @@ func getTopLevelInfo(
 func resolveFilterDependencies(
 	ctx context.Context,
 	store client.TxnStore,
+	collectionRepository *description.CollectionRepository,
 	rootSelectType SelectionType,
 	parentCollectionName string,
 	source immutable.Option[request.Filter],
@@ -1048,6 +1096,7 @@ func resolveFilterDependencies(
 	return resolveInnerFilterDependencies(
 		ctx,
 		store,
+		collectionRepository,
 		rootSelectType,
 		parentCollectionName,
 		source.Value().Conditions,
@@ -1060,6 +1109,7 @@ func resolveFilterDependencies(
 func resolveInnerFilterDependencies(
 	ctx context.Context,
 	store client.TxnStore,
+	collectionRepository *description.CollectionRepository,
 	rootSelectType SelectionType,
 	parentCollectionName string,
 	source map[string]any,
@@ -1085,6 +1135,7 @@ func resolveInnerFilterDependencies(
 				innerFields, err := resolveInnerFilterDependencies(
 					ctx,
 					store,
+					collectionRepository,
 					rootSelectType,
 					parentCollectionName,
 					innerFilter.(map[string]any),
@@ -1108,6 +1159,7 @@ func resolveInnerFilterDependencies(
 			innerFields, err := resolveInnerFilterDependencies(
 				ctx,
 				store,
+				collectionRepository,
 				rootSelectType,
 				parentCollectionName,
 				notFilter,
@@ -1152,7 +1204,15 @@ func resolveInnerFilterDependencies(
 			}
 		} else {
 			var err error
-			childSelect, err = constructEmptyJoin(ctx, store, rootSelectType, parentCollectionName, mapping, key)
+			childSelect, err = constructEmptyJoin(
+				ctx,
+				store,
+				collectionRepository,
+				rootSelectType,
+				parentCollectionName,
+				mapping,
+				key,
+			)
 			if err != nil {
 				return nil, err
 			}
@@ -1169,7 +1229,13 @@ func resolveInnerFilterDependencies(
 		}
 
 		dummyParsed := &request.Select{Field: request.Field{Name: key}}
-		childCollectionName, err := getCollectionName(ctx, rootSelectType, dummyParsed, parentCollectionName)
+		childCollectionName, err := getCollectionName(
+			ctx,
+			collectionRepository,
+			rootSelectType,
+			dummyParsed,
+			parentCollectionName,
+		)
 		if err != nil {
 			return nil, err
 		}
@@ -1177,6 +1243,7 @@ func resolveInnerFilterDependencies(
 		childFields, err := resolveInnerFilterDependencies(
 			ctx,
 			store,
+			collectionRepository,
 			rootSelectType,
 			childCollectionName,
 			childFilter,
@@ -1198,6 +1265,7 @@ func resolveInnerFilterDependencies(
 func constructEmptyJoin(
 	ctx context.Context,
 	store client.TxnStore,
+	collectionRepository *description.CollectionRepository,
 	rootSelectType SelectionType,
 	parentCollectionName string,
 	parentMapping *core.DocumentMapping,
@@ -1211,7 +1279,13 @@ func constructEmptyJoin(
 		},
 	}
 
-	childCollectionName, err := getCollectionName(ctx, rootSelectType, dummyParsed, parentCollectionName)
+	childCollectionName, err := getCollectionName(
+		ctx,
+		collectionRepository,
+		rootSelectType,
+		dummyParsed,
+		parentCollectionName,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -1245,6 +1319,7 @@ func constructEmptyJoin(
 func resolveSecondaryRelationIDs(
 	ctx context.Context,
 	store client.TxnStore,
+	collectionRepository *description.CollectionRepository,
 	rootSelectType SelectionType,
 	collectionName string,
 	colDef client.CollectionVersion,
@@ -1286,6 +1361,7 @@ func resolveSecondaryRelationIDs(
 			join, err := constructEmptyJoin(
 				ctx,
 				store,
+				collectionRepository,
 				rootSelectType,
 				collectionName,
 				mapping,
@@ -1309,9 +1385,10 @@ func resolveSecondaryRelationIDs(
 func ToCommitSelect(
 	ctx context.Context,
 	store client.TxnStore,
+	collectionRepository *description.CollectionRepository,
 	selectRequest *request.CommitSelect,
 ) (*CommitSelect, error) {
-	return toCommitSelect(ctx, store, selectRequest, 0)
+	return toCommitSelect(ctx, store, collectionRepository, selectRequest, 0)
 }
 
 // toCommitSelect converts the given [request.CommitSelect] into a [CommitSelect].
@@ -1321,10 +1398,19 @@ func ToCommitSelect(
 func toCommitSelect(
 	ctx context.Context,
 	store client.TxnStore,
+	collectionRepository *description.CollectionRepository,
 	selectRequest *request.CommitSelect,
 	thisIndex int,
 ) (*CommitSelect, error) {
-	underlyingSelect, err := toSelect(ctx, store, CommitSelection, thisIndex, selectRequest.ToSelect(), "")
+	underlyingSelect, err := toSelect(
+		ctx,
+		store,
+		collectionRepository,
+		CommitSelection,
+		thisIndex,
+		selectRequest.ToSelect(),
+		"",
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -1341,9 +1427,10 @@ func toCommitSelect(
 func ToMutation(
 	ctx context.Context,
 	store client.TxnStore,
+	collectionRepository *description.CollectionRepository,
 	mutationRequest *request.ObjectMutation,
 ) (*Mutation, error) {
-	return toMutation(ctx, store, mutationRequest, 0)
+	return toMutation(ctx, store, collectionRepository, mutationRequest, 0)
 }
 
 // toMutation converts the given [request.Mutation] into a [Mutation].
@@ -1353,10 +1440,19 @@ func ToMutation(
 func toMutation(
 	ctx context.Context,
 	store client.TxnStore,
+	collectionRepository *description.CollectionRepository,
 	mutationRequest *request.ObjectMutation,
 	thisIndex int,
 ) (*Mutation, error) {
-	underlyingSelect, err := toSelect(ctx, store, ObjectSelection, thisIndex, mutationRequest.ToSelect(), "")
+	underlyingSelect, err := toSelect(
+		ctx,
+		store,
+		collectionRepository,
+		ObjectSelection,
+		thisIndex,
+		mutationRequest.ToSelect(),
+		"",
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -23,6 +23,7 @@ import (
 	"github.com/sourcenetwork/defradb/internal/connor"
 	"github.com/sourcenetwork/defradb/internal/core"
 	acpDB "github.com/sourcenetwork/defradb/internal/db/acp"
+	"github.com/sourcenetwork/defradb/internal/db/description"
 	"github.com/sourcenetwork/defradb/internal/db/fetcher"
 	"github.com/sourcenetwork/defradb/internal/keys"
 	"github.com/sourcenetwork/defradb/internal/planner/filter"
@@ -96,10 +97,11 @@ type P2P interface {
 // Planner combines session state and database state to
 // produce a request plan, which is run by the execution context.
 type Planner struct {
-	identity    immutable.Option[acpIdentity.Identity]
-	nodeACP     acpDB.NACInfo
-	documentACP immutable.Option[dac.DocumentACP]
-	db          client.TxnStore
+	identity             immutable.Option[acpIdentity.Identity]
+	nodeACP              acpDB.NACInfo
+	documentACP          immutable.Option[dac.DocumentACP]
+	db                   client.TxnStore
+	collectionRepository *description.CollectionRepository
 
 	p2p       P2P
 	ctx       context.Context
@@ -119,15 +121,17 @@ func New(
 	db client.TxnStore,
 	p2p P2P,
 	lensStore lensStore.Store,
+	collectionRepository *description.CollectionRepository,
 ) *Planner {
 	return &Planner{
-		identity:    identity,
-		nodeACP:     nodeACP,
-		documentACP: documentACP,
-		db:          db,
-		p2p:         p2p,
-		lensStore:   lensStore,
-		ctx:         ctx,
+		identity:             identity,
+		nodeACP:              nodeACP,
+		documentACP:          documentACP,
+		db:                   db,
+		p2p:                  p2p,
+		lensStore:            lensStore,
+		ctx:                  ctx,
+		collectionRepository: collectionRepository,
 	}
 }
 
@@ -861,7 +865,7 @@ func (p *Planner) RunRequest(
 // Note: Caller is responsible to call the `Close()` method to free the allocated
 // resources of the returned plan.
 func (p *Planner) MakeSelectionPlan(selection *request.Select) (planNode, error) {
-	s, err := mapper.ToSelect(p.ctx, p.db, mapper.ObjectSelection, selection)
+	s, err := mapper.ToSelect(p.ctx, p.db, p.collectionRepository, mapper.ObjectSelection, selection)
 	if err != nil {
 		return nil, err
 	}
@@ -893,8 +897,7 @@ func (p *Planner) MakePlan(req *request.Request) (planNode, error) {
 	} else {
 		return nil, ErrMissingQueryOrMutation
 	}
-
-	m, err := mapper.ToOperation(p.ctx, p.db, operation)
+	m, err := mapper.ToOperation(p.ctx, p.db, p.collectionRepository, operation)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/planner/scan.go
+++ b/internal/planner/scan.go
@@ -168,7 +168,7 @@ func (n *scanNode) initFetcher(cid immutable.Option[[]string]) {
 	} else {
 		f = fetcher.NewDocumentFetcher()
 
-		f = lens.NewFetcher(f, n.p.lensStore)
+		f = lens.NewFetcher(f, n.p.lensStore, n.p.collectionRepository)
 	}
 	n.fetcher = f
 }

--- a/internal/planner/select.go
+++ b/internal/planner/select.go
@@ -202,7 +202,12 @@ func (n *selectNode) Close() error {
 // checkForMigrations checks if there are any migrations registered for the given collection.
 // This is used to determine if the filter should be kept in selectNode for post-lens application.
 func (n *selectNode) checkForMigrations(col client.Collection) (bool, error) {
-	return description.HasMigrations(n.planner.ctx, col.Version().CollectionID, col.Version().VersionID)
+	return description.HasMigrations(
+		n.planner.ctx,
+		n.planner.collectionRepository,
+		col.Version().CollectionID,
+		col.Version().VersionID,
+	)
 }
 
 func (n *selectNode) simpleExplain() (map[string]any, error) {

--- a/internal/planner/view.go
+++ b/internal/planner/view.go
@@ -36,7 +36,7 @@ func (p *Planner) View(query *mapper.Select, col client.Collection) (planNode, e
 		source = p.newCachedViewFetcher(col.Version(), query.DocumentMapping)
 	} else {
 		viewQuery := col.Version().Query.Value().Query
-		m, err := mapper.ToSelect(p.ctx, p.db, mapper.ObjectSelection, &viewQuery)
+		m, err := mapper.ToSelect(p.ctx, p.db, p.collectionRepository, mapper.ObjectSelection, &viewQuery)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/request/graphql/schema/generate.go
+++ b/internal/request/graphql/schema/generate.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/sourcenetwork/defradb/client/request"
 	"github.com/sourcenetwork/defradb/internal/connor"
-	"github.com/sourcenetwork/defradb/internal/db/description"
 	schemaTypes "github.com/sourcenetwork/defradb/internal/request/graphql/schema/types"
 )
 
@@ -64,12 +63,18 @@ func (s *SchemaManager) NewGenerator(isSearchableEncryptionEnabled bool) *Genera
 		typDefCollectionMap:           make(map[string]client.CollectionVersion),
 		isSearchableEncryptionEnabled: isSearchableEncryptionEnabled,
 	}
+
 	return s.Generator
 }
 
 // Generate generates the query-op and mutation-op type definitions from
 // the given CollectionVersions.
 func (g *Generator) Generate(ctx context.Context, collections []client.CollectionVersion) ([]*gql.Object, error) {
+	g.typDefCollectionMap = map[string]client.CollectionVersion{}
+	for _, col := range collections {
+		g.typDefCollectionMap[col.Name] = col
+	}
+
 	typeMapBeforeMutation := g.manager.schema.TypeMap()
 	typesBeforeMutation := make(map[string]any, len(typeMapBeforeMutation))
 
@@ -500,10 +505,7 @@ func (g *Generator) buildTypes(
 					continue
 				}
 
-				otherDef, ok, err := description.GetRelatedCollection(ctx, collection, field.Kind)
-				if err != nil {
-					return nil, err
-				}
+				otherDef, ok := g.getRelatedCollection(ctx, collection, field.Kind)
 
 				var ttype gql.Type
 				if ok {
@@ -562,7 +564,6 @@ func (g *Generator) buildTypes(
 
 		g.manager.schema.TypeMap()[obj.Name()] = obj
 		g.typeDefs = append(g.typeDefs, obj)
-		g.typDefCollectionMap[obj.Name()] = collection
 	}
 
 	return objs, nil
@@ -1663,6 +1664,55 @@ func genFilterOperatorName(fieldType gql.Type) string {
 	default:
 		return fieldType.Name() + "OperatorBlock"
 	}
+}
+
+func (g *Generator) getRelatedCollection(
+	ctx context.Context,
+	host client.CollectionVersion,
+	kind client.FieldKind,
+) (client.CollectionVersion, bool) {
+	switch typedKind := kind.(type) {
+	case *client.NamedKind:
+		col, ok := g.typDefCollectionMap[typedKind.Name]
+		return col, ok
+
+	case *client.CollectionKind:
+		var col client.CollectionVersion
+		var hasValue bool
+		for _, potentialMatch := range g.typDefCollectionMap {
+			if potentialMatch.CollectionID == typedKind.CollectionID {
+				col = potentialMatch
+				hasValue = true
+				break
+			}
+		}
+
+		return col, hasValue
+
+	case *client.SelfKind:
+		if typedKind.RelativeID == "" {
+			return host, true
+		}
+
+		for _, col := range g.typDefCollectionMap {
+			if col.CollectionID == host.CollectionID {
+				continue
+			}
+
+			if col.CollectionSet.Value().CollectionSetID != host.CollectionSet.Value().CollectionSetID {
+				continue
+			}
+
+			if fmt.Sprint(col.CollectionSet.Value().RelativeID) == typedKind.RelativeID {
+				return col, true
+			}
+		}
+
+	default:
+		// no-op
+	}
+
+	return client.CollectionVersion{}, false
 }
 
 /* Example

--- a/tests/bench/query/planner/simple_test.go
+++ b/tests/bench/query/planner/simple_test.go
@@ -39,11 +39,3 @@ func Benchmark_Planner_UserSimple_ParseQuery(b *testing.B) {
 		b.Fatal(err)
 	}
 }
-
-func Benchmark_Planner_UserSimple_MakePlan(b *testing.B) {
-	ctx := context.Background()
-	err := runMakePlanBench(b, ctx, fixtures.ForCollection(ctx, "user_simple"), userSimpleQuery)
-	if err != nil {
-		b.Fatal(err)
-	}
-}

--- a/tests/bench/query/planner/utils.go
+++ b/tests/bench/query/planner/utils.go
@@ -16,24 +16,13 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/sourcenetwork/defradb/acp/dac"
-	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/errors"
 	"github.com/sourcenetwork/defradb/internal/core"
-	acpDB "github.com/sourcenetwork/defradb/internal/db/acp"
-	"github.com/sourcenetwork/defradb/internal/planner"
 	"github.com/sourcenetwork/defradb/internal/request/graphql"
-	"github.com/sourcenetwork/defradb/internal/se"
 	benchutils "github.com/sourcenetwork/defradb/tests/bench"
 	"github.com/sourcenetwork/defradb/tests/bench/fixtures"
 )
-
-type p2pWrapper struct{}
-
-func (w *p2pWrapper) QueryDocIDsWithSETags(context.Context, string, []se.FieldValueQuery) ([]string, error) {
-	return []string{}, nil
-}
 
 func runQueryParserBench(
 	b *testing.B,
@@ -56,55 +45,6 @@ func runQueryParserBench(
 	}
 	b.StopTimer()
 
-	return nil
-}
-
-func runMakePlanBench(
-	b *testing.B,
-	ctx context.Context,
-	fixture fixtures.Generator,
-	query string,
-) error {
-	d, _, err := benchutils.SetupDBAndCollections(b, ctx, fixture)
-	if err != nil {
-		return err
-	}
-	defer d.Close()
-
-	parser, err := buildParser(ctx, fixture)
-	if err != nil {
-		return err
-	}
-
-	ast, _ := parser.BuildRequestAST(ctx, query)
-	q, errs := parser.Parse(ctx, ast, &client.GQLOptions{})
-	if len(errs) > 0 {
-		return errors.Wrap("failed to parse query string", errors.New(fmt.Sprintf("%v", errs)))
-	}
-
-	b.ResetTimer()
-
-	for i := 0; i < b.N; i++ {
-		planner := planner.New(
-			ctx,
-			acpIdentity.None,
-			acpDB.NACInfo{},
-			dac.NoDocumentACP,
-			d,
-			&p2pWrapper{},
-			nil,
-		)
-		plan, err := planner.MakePlan(q)
-		if err != nil {
-			return errors.Wrap("failed to make plan", err)
-		}
-
-		err = plan.Init()
-		if err != nil {
-			return errors.Wrap("failed to init plan", err)
-		}
-	}
-	b.StopTimer()
 	return nil
 }
 


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4583

## Description

Removes the collection cache from context.

It is replaced with a new cache/repository implementation, held on the `db.DB` instance.  There is a shared element to this, that can be used to cache other stuff in the future (short ids in the immediate future).  The solution has been designed around the future implementation of a global cache, noted in the readme, the implementation of this is not IMO required for the bug fix and v1, so it has been left unimplemented for now.

It would have been possible to host this in the context, but I thought that was ugly and a little abusive, especially given that the cache now needs to cascade down to the store, and the previous location hid IO operations, causing them to leak into places that shouldn't have been (e.g. generate.go).  The new design also allows the cache to be maintained across contexts, which it couldn't do before.

The new implementation solves #4268 even though collection short ids are still not forbidden, the testing is a bit involved and has been broken out to #4657.  There are a handful of todos in the production code noting important, non-obvious areas to test as part of that that are tested and removed in #4657.

Is probably worth reviewing commit by commit, and on the 4th commit, start by reading `cache/README.md`.