### PR TITLE
fix: Treat multiple filters as AND when join is inverted

### DIFF
--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -496,17 +496,6 @@ func (p *Planner) tryOptimizeJoinDirectionByFilter(node *invertibleTypeJoin, par
 			// At the moment we just take the first index, but later we want to run some kind of analysis to
 			// determine which index is best to use. https://github.com/sourcenetwork/defradb/issues/2680
 			node.invertJoinDirectionWithIndex(indexes[0], fieldFilter, nil)
-			// When the join is inverted and the child side (now first) is secondary (does not
-			// store the FK), the parent scan's filter will be overwritten by
-			// retrievePrimaryDocs during execution. Move any remaining parent scan filter
-			// conditions (scalar fields) to the selectNode so they are evaluated post-join.
-			if !node.childSide.isPrimary() {
-				parentScan := getNode[*scanNode](node.parentSide.plan)
-				if parentScan.filter != nil {
-					parentPlan.selectNode.filter = filter.Merge(parentPlan.selectNode.filter, parentScan.filter)
-					parentScan.filter = nil
-				}
-			}
 			// If there's a sub-filter on the child side, remove the related field condition from
 			// the parent filter. This prevents re-evaluation at the parent level which would fail
 			// when the sub-filter modifies the child docs (e.g., filtering by model="Galaxy" when

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -496,6 +496,17 @@ func (p *Planner) tryOptimizeJoinDirectionByFilter(node *invertibleTypeJoin, par
 			// At the moment we just take the first index, but later we want to run some kind of analysis to
 			// determine which index is best to use. https://github.com/sourcenetwork/defradb/issues/2680
 			node.invertJoinDirectionWithIndex(indexes[0], fieldFilter, nil)
+			// When the join is inverted and the child side (now first) is secondary (does not
+			// store the FK), the parent scan's filter will be overwritten by
+			// retrievePrimaryDocs during execution. Move any remaining parent scan filter
+			// conditions (scalar fields) to the selectNode so they are evaluated post-join.
+			if !node.childSide.isPrimary() {
+				parentScan := getNode[*scanNode](node.parentSide.plan)
+				if parentScan.filter != nil {
+					parentPlan.selectNode.filter = filter.Merge(parentPlan.selectNode.filter, parentScan.filter)
+					parentScan.filter = nil
+				}
+			}
 			// If there's a sub-filter on the child side, remove the related field condition from
 			// the parent filter. This prevents re-evaluation at the parent level which would fail
 			// when the sub-filter modifies the child docs (e.g., filtering by model="Galaxy" when

--- a/internal/planner/type_join.go
+++ b/internal/planner/type_join.go
@@ -644,12 +644,24 @@ func (r *primaryObjectsRetriever) collectDocs() ([]core.Doc, error) {
 func (r *primaryObjectsRetriever) retrievePrimaryDocs() ([]core.Doc, error) {
 	r.primaryScan.addField(r.relIDFieldDef)
 
-	r.primaryScan.filter = addFilterOnField(r.filter, r.primarySide.relIDFieldMapIndex.Value(),
+	scanFilter := addFilterOnField(r.filter, r.primarySide.relIDFieldMapIndex.Value(),
 		r.targetSecondaryDoc.GetID())
 
+	// When the join is inverted, the parent becomes the primary (second) side.
+	// Its scan may still hold scalar filter conditions (e.g., rating > 4.5) that
+	// prepareScanNodeFilterForTypeJoin left there. Since the original scan is not
+	// iterated in the inverted path, merge those conditions so they are applied
+	// during retrieval.
+	if r.primarySide.isParent && r.primaryScan.filter != nil {
+		scanFilter = filter.Merge(scanFilter, r.primaryScan.filter)
+	}
+
+	oldFilter := r.primaryScan.filter
 	oldFetcher := r.primaryScan.fetcher
 	oldIndex := r.primaryScan.index
 	oldOrdering := r.primaryScan.ordering
+
+	r.primaryScan.filter = scanFilter
 
 	result := selectIndex(selectIndexOptions{
 		collection:          r.primaryScan.col,
@@ -699,6 +711,7 @@ func (r *primaryObjectsRetriever) retrievePrimaryDocs() ([]core.Doc, error) {
 	docs, err = r.collectDocs()
 
 	closeErr := r.primaryScan.fetcher.Close()
+	r.primaryScan.filter = oldFilter
 	r.primaryScan.fetcher = oldFetcher
 	r.primaryScan.index = oldIndex
 	r.primaryScan.ordering = oldOrdering

--- a/tests/integration/index/query_with_relation_filter_test.go
+++ b/tests/integration/index/query_with_relation_filter_test.go
@@ -1069,3 +1069,209 @@ func TestQueryWithUniqueIndex_WithFilterOnChildIndexedField_ShouldFetch(t *testi
 
 	testUtils.ExecuteTestCase(t, test)
 }
+
+func TestQueryWithIndex_WithScalarAndRelationFilterAtTopLevel_ShouldApplyBothAsAnd(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type Author {
+						name: String @index
+						published: [Book]
+					}
+
+					type Book {
+						title: String
+						rating: Float
+						author: Author
+					}
+				`,
+			},
+			&action.AddDoc{
+				CollectionID: 0,
+				Doc: `{
+					"name": "John Grisham"
+				}`,
+			},
+			&action.AddDoc{
+				CollectionID: 0,
+				Doc: `{
+					"name": "Cornelia Funke"
+				}`,
+			},
+			&action.AddDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"title":  "Painted House",
+					"rating": 4.9,
+					"author": testUtils.NewDocIndex(0, 0),
+				},
+			},
+			&action.AddDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"title":  "A Time to Kill",
+					"rating": 4.0,
+					"author": testUtils.NewDocIndex(0, 0),
+				},
+			},
+			&action.AddDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"title":  "Theif Lord",
+					"rating": 4.8,
+					"author": testUtils.NewDocIndex(0, 1),
+				},
+			},
+			&action.AddDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"title":  "Inkheart",
+					"rating": 4.4,
+					"author": testUtils.NewDocIndex(0, 1),
+				},
+			},
+			// Implicit AND: scalar + relation conditions at top level
+			&action.Request{
+				Request: `query {
+					Book(filter: {rating: {_gt: 4.5}, author: {name: {_eq: "John Grisham"}}}) {
+						title
+						rating
+						author {
+							name
+						}
+					}
+				}`,
+				Results: map[string]any{
+					"Book": []map[string]any{
+						{
+							"title":  "Painted House",
+							"rating": 4.9,
+							"author": map[string]any{
+								"name": "John Grisham",
+							},
+						},
+					},
+				},
+				NonOrderedResults: true,
+			},
+			// Explicit _and: same conditions, should produce identical results
+			&action.Request{
+				Request: `query {
+					Book(filter: {_and: [{rating: {_gt: 4.5}}, {author: {name: {_eq: "John Grisham"}}}]}) {
+						title
+						rating
+						author {
+							name
+						}
+					}
+				}`,
+				Results: map[string]any{
+					"Book": []map[string]any{
+						{
+							"title":  "Painted House",
+							"rating": 4.9,
+							"author": map[string]any{
+								"name": "John Grisham",
+							},
+						},
+					},
+				},
+				NonOrderedResults: true,
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestQueryWithIndex_WithMultipleScalarsAndRelationFilter_ShouldApplyAllAsAnd(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type Author {
+						name: String @index
+						published: [Book]
+					}
+
+					type Book {
+						title: String
+						rating: Float
+						genre: String
+						author: Author
+					}
+				`,
+			},
+			&action.AddDoc{
+				CollectionID: 0,
+				Doc: `{
+					"name": "John Grisham"
+				}`,
+			},
+			&action.AddDoc{
+				CollectionID: 0,
+				Doc: `{
+					"name": "Cornelia Funke"
+				}`,
+			},
+			&action.AddDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"title":  "Painted House",
+					"rating": 4.9,
+					"genre":  "drama",
+					"author": testUtils.NewDocIndex(0, 0),
+				},
+			},
+			&action.AddDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"title":  "A Time to Kill",
+					"rating": 4.0,
+					"genre":  "thriller",
+					"author": testUtils.NewDocIndex(0, 0),
+				},
+			},
+			&action.AddDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"title":  "The Firm",
+					"rating": 4.5,
+					"genre":  "thriller",
+					"author": testUtils.NewDocIndex(0, 0),
+				},
+			},
+			&action.AddDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"title":  "Theif Lord",
+					"rating": 4.8,
+					"genre":  "fantasy",
+					"author": testUtils.NewDocIndex(0, 1),
+				},
+			},
+			&action.Request{
+				Request: `query {
+					Book(filter: {genre: {_eq: "thriller"}, rating: {_gt: 4.0}, author: {name: {_eq: "John Grisham"}}}) {
+						title
+						rating
+						genre
+					}
+				}`,
+				Results: map[string]any{
+					"Book": []map[string]any{
+						{
+							"title":  "The Firm",
+							"rating": 4.5,
+							"genre":  "thriller",
+						},
+					},
+				},
+				NonOrderedResults: true,
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4314

## Description

When a query filter combines scalar conditions with a relation condition at the top level without explicit `_and`, the scalar conditions were silently dropped if the join got inverted for index optimization. For example, `Book(filter: {rating: {_gt: 4.5}, author: {name: {_eq: "John Grisham"}}})` would ignore the rating condition and return all books by John Grisham. Using explicit `_and` worked around this because it triggered a different code path that kept all conditions together.

The problem was in `retrievePrimaryDocs`. When the join is inverted, the parent scan becomes the second side and its filter gets overwritten with just the relation ID lookup. Any scalar conditions that were sitting on the parent scan were lost. The fix merges the parent scan's original filter into the retrieval filter before overwriting, and properly saves/restores it afterward.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Added integration tests covering mixed scalar + relation filters with and without explicit `_and`, verifying they produce the same results.

Specify the platform(s) on which this was tested:
- MacOS