### PR TITLE
fix: Prevent doc writes after collection deleted

### DIFF
--- a/http/errors.go
+++ b/http/errors.go
@@ -150,7 +150,6 @@ func httpStatusFromError(err error) int {
 		errors.Is(err, db.ErrReplicatorColHasPolicy) ||
 		errors.Is(err, db.ErrCollectionNameMutated) ||
 		errors.Is(err, db.ErrCannotDeleteOldVersion) ||
-		errors.Is(err, db.ErrCannotDeleteCollectionWithDocs) ||
 		errors.Is(err, db.ErrMigrationBetweenNonAdjacentVersions) ||
 		errors.Is(err, db.ErrNACIsAlreadyDisabled) ||
 		errors.Is(err, db.ErrNACIsAlreadyEnabled) ||

--- a/http/errors_test.go
+++ b/http/errors_test.go
@@ -71,7 +71,6 @@ func TestHttpStatusFromError(t *testing.T) {
 		{"replicator col has policy", db.ErrReplicatorColHasPolicy, http.StatusUnprocessableEntity},
 		{"collection name mutated", db.ErrCollectionNameMutated, http.StatusUnprocessableEntity},
 		{"cannot delete old version", db.ErrCannotDeleteOldVersion, http.StatusUnprocessableEntity},
-		{"cannot delete collection with docs", db.ErrCannotDeleteCollectionWithDocs, http.StatusUnprocessableEntity},
 		{"migration between non-adjacent versions", db.ErrMigrationBetweenNonAdjacentVersions, http.StatusUnprocessableEntity},
 		{"NAC already disabled", db.ErrNACIsAlreadyDisabled, http.StatusUnprocessableEntity},
 		{"NAC already enabled", db.ErrNACIsAlreadyEnabled, http.StatusUnprocessableEntity},

--- a/internal/datastore/datastore.go
+++ b/internal/datastore/datastore.go
@@ -34,6 +34,10 @@ func newDatastore(rootstore corekv.ReaderWriter, lockSet *lock.LockSet) *datasto
 	}
 }
 
+func NewUnsafeDatastore(rootstore corekv.ReaderWriter) corekv.ReaderWriter {
+	return namespace.Wrap(rootstore, []byte{dataStoreKey})
+}
+
 func (s *datastore) Get(ctx context.Context, key Key) ([]byte, error) {
 	s.collectionRLock(ctx, key)
 

--- a/internal/db/cache/txn.go
+++ b/internal/db/cache/txn.go
@@ -70,8 +70,6 @@ func (l *TxnRepository[T, TV]) registerTxn(ctx context.Context) Cache[T, TV] {
 	l.cache[id] = txnCache
 	l.txnLock.Unlock()
 
-	// todo - an integration test for this is required, and make sure at least one tests discard and reuse:
-	// https://github.com/sourcenetwork/defradb/issues/4268
 	onTxnClose := func() {
 		l.txnLock.Lock()
 		_, ok := l.cache[id]

--- a/internal/db/collection.go
+++ b/internal/db/collection.go
@@ -127,10 +127,20 @@ func (db *DB) getCollections(
 		cols = append(cols, col)
 
 	case opts.CollectionID.HasValue():
-		var err error
-		cols, err = description.GetCollectionsByCollectionID(ctx, db.collectionRepository, opts.CollectionID.Value())
-		if err != nil {
-			return nil, err
+		if opts.GetInactive.HasValue() && opts.GetInactive.Value() {
+			var err error
+			cols, err = description.GetCollectionsByCollectionID(ctx, db.collectionRepository, opts.CollectionID.Value())
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			// GetActiveCollectionByCollectionID is quite a lot more efficient than GetCollectionsByCollectionID
+			// so we use it when we can.
+			col, err := description.GetActiveCollectionByCollectionID(ctx, db.collectionRepository, opts.CollectionID.Value())
+			if err != nil && !errors.Is(err, client.ErrCollectionNotFound) {
+				return nil, err
+			}
+			cols = append(cols, col)
 		}
 
 	// Multi-collection self-referencing relations are the only time the collection set id option

--- a/internal/db/collection_define.go
+++ b/internal/db/collection_define.go
@@ -28,12 +28,9 @@ import (
 
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/request"
-	"github.com/sourcenetwork/defradb/errors"
 	"github.com/sourcenetwork/defradb/internal/core"
 	"github.com/sourcenetwork/defradb/internal/datastore"
 	"github.com/sourcenetwork/defradb/internal/db/description"
-	"github.com/sourcenetwork/defradb/internal/db/id"
-	"github.com/sourcenetwork/defradb/internal/keys"
 )
 
 func (db *DB) addCollections(
@@ -670,19 +667,7 @@ func (db *DB) deleteCollectionVersion(
 	ctx context.Context,
 	version client.CollectionVersion,
 ) error {
-	hasDocs, err := collectionHasDocuments(ctx, version)
-	if err != nil {
-		return err
-	}
-	if hasDocs {
-		// If the collection contains any documents, we do not allow deletion of any version in the
-		// collection - they must first delete the documents locally, and then delete the collection.
-		//
-		// This is thought to be much safer than allowing document deletion along with the collection.
-		return NewErrCannotDeleteCollectionWithDocs(version.Name, version.VersionID)
-	}
-
-	err = db.validateCollectionDoesNotHaveHigherVersion(ctx, version)
+	err := db.validateCollectionDoesNotHaveHigherVersion(ctx, version)
 	if err != nil {
 		return err
 	}
@@ -698,48 +683,6 @@ func (db *DB) deleteCollectionVersion(
 	}
 
 	return nil
-}
-
-func collectionHasDocuments(
-	ctx context.Context,
-	version client.CollectionVersion,
-) (bool, error) {
-	if !version.IsMaterialized {
-		// Assume that if the collection *was* materialized, and is no longer materialized, that the cached
-		// state was properly disposed of (it should have been).
-		return false, nil
-	}
-
-	txn := datastore.CtxMustGetTxn(ctx)
-
-	shortID, err := id.GetShortCollectionID(ctx, version.CollectionID)
-	if err != nil {
-		return false, err
-	}
-
-	var prefixKey keys.Key
-	if version.Query.HasValue() {
-		prefixKey = keys.NewViewCacheColPrefix(shortID)
-	} else {
-		prefixKey = keys.PrimaryDataStoreKey{
-			CollectionShortID: shortID,
-		}
-	}
-
-	iter, err := txn.Datastore().Iterator(ctx, datastore.IterOptions{
-		Prefix:   prefixKey.ToDS(),
-		KeysOnly: true,
-	})
-	if err != nil {
-		return false, NewErrCheckCollectionDocs(errors.Join(err, iter.Close()))
-	}
-
-	hasValue, err := iter.Next()
-	if err != nil {
-		return false, NewErrCheckCollectionDocs(errors.Join(err, iter.Close()))
-	}
-
-	return hasValue, iter.Close()
 }
 
 func (db *DB) validateCollectionDoesNotHaveHigherVersion(

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -168,7 +168,7 @@ func newDB(
 		retryIntervals:          cfg.RetryIntervals,
 		p2pBlockSyncTimeout:     cfg.P2PBlockSyncTimeout,
 		lockSet:                 lockSet,
-		collectionRepository:    description.NewColCache(lockSet),
+		collectionRepository:    description.NewColCache(lockSet, datastore.NewUnsafeDatastore(rootstore)),
 	}
 
 	lensRuntime, err := newLensRuntime(LensRuntimeType(cfg.LensRuntime))

--- a/internal/db/description/cache.go
+++ b/internal/db/description/cache.go
@@ -11,6 +11,7 @@
 package description
 
 import (
+	"github.com/sourcenetwork/corekv"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/internal/db/cache"
 	"github.com/sourcenetwork/defradb/internal/db/lock"
@@ -31,8 +32,8 @@ type CollectionIndex struct {
 
 type CollectionRepository = cache.TxnRepository[CollectionIndex, client.CollectionVersion]
 
-func NewColCache(lockSet *lock.LockSet) *CollectionRepository {
-	collectionStore := newCollectionStore(lockSet)
+func NewColCache(lockSet *lock.LockSet, txnFreeDatastore corekv.Reader) *CollectionRepository {
+	collectionStore := newCollectionStore(lockSet, txnFreeDatastore)
 
 	collectionRepository := cache.NewTxnLayer(
 		func() cache.Cache[CollectionIndex, client.CollectionVersion] {

--- a/internal/db/description/collection_cache.go
+++ b/internal/db/description/collection_cache.go
@@ -87,8 +87,6 @@ func (i *collectionRepository) Cache(value client.CollectionVersion) {
 		if oldVersionCached && oldVersion.IsActive {
 			// If we are deactivating a collection we must remove the old values from the
 			// active caches.
-			// todo - the unforbidding is currently untested, and should be done as part of:
-			// https://github.com/sourcenetwork/defradb/issues/4268
 			delete(i.activeCollectionsByName, oldVersion.Name)
 			delete(i.activeCollectionsByCollectionID, oldVersion.CollectionID)
 		}
@@ -98,8 +96,6 @@ func (i *collectionRepository) Cache(value client.CollectionVersion) {
 	i.forbiddenLock.Lock()
 	// If this transaction writes a collection version that was previously forbidden, we must unforbid it
 	// within the context of this transaction.
-	// todo - the unforbidding is currently untested, and should be done as part of:
-	// https://github.com/sourcenetwork/defradb/issues/4268
 	delete(i.forbiddenCollectionIDs, value.CollectionID)
 	i.forbiddenLock.Unlock()
 }

--- a/internal/db/description/collection_store.go
+++ b/internal/db/description/collection_store.go
@@ -111,7 +111,6 @@ func (i *collectionStore) Write(ctx context.Context, value client.CollectionVers
 	i.forbiddenLock.Lock()
 	// If this transaction writes a collection version that was previously forbidden, we must unforbid it
 	// within the context of this transaction.
-	// todo - make sure the unforbidding is tested!
 	delete(i.forbiddenCollectionIDs, value.CollectionID)
 	i.forbiddenLock.Unlock()
 

--- a/internal/db/description/collection_store.go
+++ b/internal/db/description/collection_store.go
@@ -35,14 +35,16 @@ type collectionStore struct {
 	forbiddenCollectionIDs map[string]struct{}
 
 	lockSet              *lock.LockSet
+	txnFreeDatastore     corekv.Reader
 	collectionRepository *cache.TxnRepository[CollectionIndex, client.CollectionVersion]
 }
 
 var _ cache.Repository[CollectionIndex, client.CollectionVersion] = (*collectionStore)(nil)
 
-func newCollectionStore(lockSet *lock.LockSet) *collectionStore {
+func newCollectionStore(lockSet *lock.LockSet, txnFreeDatastore corekv.Reader) *collectionStore {
 	return &collectionStore{
 		lockSet:                lockSet,
+		txnFreeDatastore:       txnFreeDatastore,
 		forbiddenCollectionIDs: map[string]struct{}{},
 	}
 }
@@ -323,6 +325,21 @@ func (i *collectionStore) Delete(ctx context.Context, key CollectionIndex) error
 		// whilst we finalize this operation, otherwise other threads/operations may try and make use of it.
 		i.lockSet.CollectionLock(txn, shortID)
 
+		hasDocs, err := i.collectionHasDocuments(ctx, version)
+		if err != nil {
+			return err
+		}
+		if hasDocs {
+			// If the collection contains any documents, we do not allow deletion of any version in the
+			// collection - they must first delete the documents locally, and then delete the collection.
+			//
+			// This is thought to be much safer than allowing document deletion along with the collection.
+			//
+			// This check *must* be performed after the write lock on the collection has been aquired otherwise
+			// there will be a race condition.
+			return NewErrCannotDeleteCollectionWithDocs(version.Name, version.VersionID)
+		}
+
 		// Only delete the collection short ID if this was the last local version
 		err = id.DeleteShortCollectionID(ctx, version.CollectionID)
 		if err != nil {
@@ -403,4 +420,93 @@ func (i *collectionStore) Forbid(value client.CollectionVersion) {
 	i.forbiddenLock.Lock()
 	i.forbiddenCollectionIDs[value.CollectionID] = struct{}{}
 	i.forbiddenLock.Unlock()
+}
+
+// collectionHasDocuments checks that both the transaction, and the underlying transaction-free
+// root does not have any documents in the given collection.
+//
+// It is nessecary to check without a transaction, as the deletion of the last collection version
+// in a collection locally must be applied immediately to all existing transactions, and must also
+// take into consideration writes that may have been made since the *deleting* transaction was created.
+//
+// The deleting transaction must be checked, as this transaction may have written documents that have
+// not yet been committed and will not show up when iterating through the underlying transaction-free
+// store.
+func (i *collectionStore) collectionHasDocuments(
+	ctx context.Context,
+	version client.CollectionVersion,
+) (bool, error) {
+	hasDocs, err := collectionHasDocumentsTxn(ctx, version)
+	if hasDocs || err != nil {
+		return hasDocs, err
+	}
+
+	return i.collectionHasDocumentsRoot(ctx, version)
+}
+
+func collectionHasDocumentsTxn(
+	ctx context.Context,
+	version client.CollectionVersion,
+) (bool, error) {
+	type unsafestore interface {
+		Unsafe() corekv.ReaderWriter
+	}
+	txn := datastore.CtxMustGetTxn(ctx)
+
+	// We use the unsafe store here as it is convenient and allows us to re-use the same reading
+	// code in a location where we do not require the lock system, as a write lock is guarenteed
+	// to already be held. The Keyed store iterator function has a slightly different signature.
+	return collectionHasDocumentsReader(ctx, txn.Datastore().(unsafestore).Unsafe(), version) //nolint:forcetypeassert
+}
+
+func (i *collectionStore) collectionHasDocumentsRoot(
+	ctx context.Context,
+	version client.CollectionVersion,
+) (bool, error) {
+	// corekv will pick up the previously used transaction and force its use if we do not first
+	// remove it from the context.
+	// This line can be removed as part of https://github.com/sourcenetwork/defradb/issues/4658
+	ctx = corekv.SetCtxTxn(ctx, nil)
+	return collectionHasDocumentsReader(ctx, i.txnFreeDatastore, version)
+}
+
+func collectionHasDocumentsReader(
+	ctx context.Context,
+	reader corekv.Reader,
+	version client.CollectionVersion,
+) (bool, error) {
+	if !version.IsMaterialized {
+		// Assume that if the collection *was* materialized, and is no longer materialized, that the cached
+		// state was properly disposed of (it should have been).
+		return false, nil
+	}
+
+	shortID, err := id.GetShortCollectionID(ctx, version.CollectionID)
+	if err != nil {
+		return false, err
+	}
+
+	var prefixKey keys.Key
+	if version.Query.HasValue() {
+		prefixKey = keys.NewViewCacheColPrefix(shortID)
+	} else {
+		prefixKey = keys.PrimaryDataStoreKey{
+			CollectionShortID: shortID,
+		}
+	}
+
+	iter, err := reader.Iterator(ctx, corekv.IterOptions{
+		Prefix:   prefixKey.ToDS().Bytes(),
+		KeysOnly: true,
+	})
+	if err != nil {
+		return false, errors.Join(err, iter.Close())
+	}
+
+	hasValue, err := iter.Next()
+	if err != nil {
+		return false, errors.Join(err, iter.Close())
+	}
+
+	return hasValue, iter.Close()
 }

--- a/internal/db/description/errors.go
+++ b/internal/db/description/errors.go
@@ -23,6 +23,12 @@ const (
 	errGetCollectionVersions               string = "failed to get collection versions"
 	errDeleteCollection                    string = "failed to delete collection"
 	errCheckCollectionExists               string = "failed to check if collection exists"
+	errCannotDeleteCollectionWithDocs      string = "cannot delete a collection that has documents, first " +
+		"delete the documents and then delete the version"
+)
+
+var (
+	ErrCannotDeleteCollectionWithDocs = errors.New(errCannotDeleteCollectionWithDocs)
 )
 
 // NewErrFailedToCloseCollectionVersionQuery returns a new error indicating that the query
@@ -75,4 +81,12 @@ func NewErrDeleteCollection(inner error, collectionID string) error {
 // NewErrCheckCollectionExists returns a new error indicating that checking collection existence failed.
 func NewErrCheckCollectionExists(inner error, name string) error {
 	return errors.Wrap(errCheckCollectionExists, inner, errors.NewKV("Name", name))
+}
+
+func NewErrCannotDeleteCollectionWithDocs(name, versionID string) error {
+	return errors.New(
+		errCannotDeleteCollectionWithDocs,
+		errors.NewKV("Name", name),
+		errors.NewKV("VersionID", versionID),
+	)
 }

--- a/internal/db/document.go
+++ b/internal/db/document.go
@@ -29,6 +29,7 @@ import (
 	"github.com/sourcenetwork/defradb/internal/core/crdt"
 	"github.com/sourcenetwork/defradb/internal/datastore"
 	"github.com/sourcenetwork/defradb/internal/db/base"
+	"github.com/sourcenetwork/defradb/internal/db/description"
 	"github.com/sourcenetwork/defradb/internal/db/id"
 	"github.com/sourcenetwork/defradb/internal/encryption"
 	iIdentity "github.com/sourcenetwork/defradb/internal/identity"
@@ -627,6 +628,17 @@ func (c *collection) save(
 		txn.OnSuccess(func() {
 			c.db.sendUpdate(updateEvent)
 		})
+	}
+
+	_, stillExists, err := c.db.collectionRepository.TryGet(ctx, description.CollectionIndex{
+		Kind:  description.CollectionID,
+		Value: c.def.CollectionID,
+	})
+	if err != nil {
+		return err
+	}
+	if !stillExists {
+		return client.ErrCollectionNotFound
 	}
 
 	return nil

--- a/internal/db/errors.go
+++ b/internal/db/errors.go
@@ -91,8 +91,6 @@ const (
 	errCollectionIDCannotBeEmpty                 string = "collection ID cannot be empty"
 	errCannotDeleteOldVersion                    string = "cannot delete a version that is used by a newer version, " +
 		"first delete the new version"
-	errCannotDeleteCollectionWithDocs string = "cannot delete a collection that has documents, first " +
-		"delete the documents and then delete the version"
 	errCanNotHavePolicyWithoutACP          string = "can not specify policy on collection, without acp"
 	errRelationMissingField                string = "relation missing field"
 	errMultipleRelationPrimaries           string = "relation can only have a single field set as primary"
@@ -218,7 +216,6 @@ var (
 	ErrCollectionVersionIDCannotBeMutated        = errors.New(errCollectionVersionIDCannotBeMutated)
 	ErrCollectionIDCannotBeEmpty                 = errors.New(errCollectionIDCannotBeEmpty)
 	ErrCannotDeleteOldVersion                    = errors.New(errCannotDeleteOldVersion)
-	ErrCannotDeleteCollectionWithDocs            = errors.New(errCannotDeleteCollectionWithDocs)
 	ErrCanNotHavePolicyWithoutACP                = errors.New(errCanNotHavePolicyWithoutACP)
 	ErrRelationMissingField                      = errors.New(errRelationMissingField)
 	ErrMultipleRelationPrimaries                 = errors.New(errMultipleRelationPrimaries)
@@ -732,14 +729,6 @@ func NewErrCannotDeleteOldVersion(old, new string) error {
 		errCannotDeleteOldVersion,
 		errors.NewKV("TargetCollectionID", old),
 		errors.NewKV("UsedByCollectionID", new),
-	)
-}
-
-func NewErrCannotDeleteCollectionWithDocs(name, versionID string) error {
-	return errors.New(
-		errCannotDeleteCollectionWithDocs,
-		errors.NewKV("Name", name),
-		errors.NewKV("VersionID", versionID),
 	)
 }
 

--- a/internal/db/id/collection.go
+++ b/internal/db/id/collection.go
@@ -16,6 +16,8 @@ import (
 
 	"github.com/sourcenetwork/corekv"
 
+	"github.com/sourcenetwork/defradb/client"
+	"github.com/sourcenetwork/defradb/errors"
 	"github.com/sourcenetwork/defradb/internal/datastore"
 	"github.com/sourcenetwork/defradb/internal/db/sequence"
 	"github.com/sourcenetwork/defradb/internal/keys"
@@ -33,7 +35,10 @@ func GetUncachedShortCollectionID(
 	key := keys.NewCollectionID(collectionID)
 	valueBytes, err := systemStore.Get(ctx, key.Bytes())
 	if err != nil {
-		return 0, NewErrGetShortCollectionID(err, collectionID)
+		if errors.Is(err, corekv.ErrNotFound) {
+			err = NewErrGetShortCollectionID(client.ErrCollectionNotFound, collectionID)
+		}
+		return 0, err
 	}
 	v, err := strconv.ParseUint(string(valueBytes), 10, 0)
 	if err != nil {

--- a/tests/action/add_doc.go
+++ b/tests/action/add_doc.go
@@ -85,6 +85,9 @@ type AddDoc struct {
 
 	// Used to identify the transaction for this to be executed in. Optional.
 	TransactionID immutable.Option[int]
+
+	// If the given error is received, ignore the error and pretend the action succeeded.
+	IgnoreError string
 }
 
 var _ Action = (*AddDoc)(nil)
@@ -151,7 +154,9 @@ func (a *AddDoc) Execute() {
 				return err
 			},
 		)
-		expectedErrorRaised = assertError(a.s.T, err, a.ExpectedError)
+		if err == nil || !(len(a.IgnoreError) > 0 && strings.Contains(err.Error(), a.IgnoreError)) {
+			expectedErrorRaised = assertError(a.s.T, err, a.ExpectedError)
+		}
 	}
 
 	assertExpectedErrorRaised(a.s.T, a.ExpectedError, expectedErrorRaised)

--- a/tests/action/async_await.go
+++ b/tests/action/async_await.go
@@ -1,12 +1,13 @@
 // Copyright 2026 Democratized Data Foundation
 //
-// Use of this software is governed by the Business Source License
-// included in the file licenses/BSL.txt.
+// This file is part of the DefraDB test suite.
 //
-// As of the Change Date specified in that file, in accordance with
-// the Business Source License, use of this software will be governed
-// by the Apache License, Version 2.0, included in the file
-// licenses/APL.txt.
+// The DefraDB test suite is licensed under either:
+//
+//   (1) GNU Affero General Public License v3
+//   (2) Business Source License 1.1
+//
+// See tests/LICENSE for details.
 
 package action
 

--- a/tests/action/async_await.go
+++ b/tests/action/async_await.go
@@ -1,0 +1,77 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package action
+
+import (
+	"sync"
+
+	"github.com/sourcenetwork/defradb/tests/state"
+)
+
+// Async executes the child action in its own child go-routine, the child routine will
+// be fully initialized before `Execute()` unblocks, but it is not guaranteed to be executing by
+// the runtime.
+//
+// This action is typically used alongside an `Await` action.
+type Async struct {
+	s *state.State
+
+	// The child action that should be executed in asynchronously.
+	Child Action
+}
+
+var _ Action = (*Async)(nil)
+var _ Stateful = (*Async)(nil)
+
+func (a *Async) SetState(s *state.State) {
+	a.s = s
+
+	if stateful, ok := a.Child.(Stateful); ok {
+		stateful.SetState(s)
+	}
+}
+
+func (a *Async) Execute() {
+	a.s.AsyncWG.Add(1)
+
+	// childReady is responsible for ensuring that all child routines have been set up and are
+	// now waiting for the start lock to be unlocked.
+	childReady := sync.WaitGroup{}
+	childReady.Add(1)
+	go func() {
+		childReady.Done()
+
+		a.Child.Execute()
+
+		a.s.AsyncWG.Done()
+	}()
+
+	// Wait for all the children to be ready before returning.
+	childReady.Wait()
+}
+
+// Await waits for all executing `Async` actions to complete.
+type Await struct {
+	stateful
+}
+
+var _ Action = (*Await)(nil)
+var _ Stateful = (*Await)(nil)
+
+func (a *Await) Execute() {
+	a.s.AsyncWG.Wait()
+
+	if len(a.s.SkipTest) > 0 {
+		// Child actions cannot skip the test from within their own routine, so we must check here
+		// to see if they want to.
+		a.s.T.Skip(a.s.SkipTest)
+	}
+}

--- a/tests/action/parallel.go
+++ b/tests/action/parallel.go
@@ -76,4 +76,10 @@ func (a *Parallel) Execute() {
 	startLock.Unlock()
 
 	finishedWG.Wait()
+
+	if len(a.s.SkipTest) > 0 {
+		// Child actions cannot skip the test from within their own routine, so we must check here
+		// to see if they want to.
+		a.s.T.Skip(a.s.SkipTest)
+	}
 }

--- a/tests/action/patch_collection.go
+++ b/tests/action/patch_collection.go
@@ -12,13 +12,17 @@
 package action
 
 import (
+	"fmt"
+
 	"github.com/stretchr/testify/require"
+
+	"github.com/sourcenetwork/immutable"
+	"github.com/sourcenetwork/lens/host-go/config/model"
 
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/options"
+	"github.com/sourcenetwork/defradb/errors"
 	"github.com/sourcenetwork/defradb/tests/state"
-	"github.com/sourcenetwork/immutable"
-	"github.com/sourcenetwork/lens/host-go/config/model"
 )
 
 // PatchCollection executes a patch collection command, updating 0 to many collections and applying
@@ -50,6 +54,11 @@ type PatchCollection struct {
 
 	// Used to identify the transaction for this to be executed in. Optional.
 	TransactionID immutable.Option[int]
+
+	// Skip this test if the following error is returned when executing this action.
+	//
+	// This should only be used for rare, known, unrecoverable errors.
+	SkipTestOnError error
 }
 
 var _ Action = (*PatchCollection)(nil)
@@ -80,6 +89,11 @@ func (a *PatchCollection) Execute() {
 			err = txn.PatchCollection(a.s.Ctx, patch, a.Lens, opts)
 		} else {
 			err = node.PatchCollection(a.s.Ctx, patch, a.Lens, opts)
+		}
+
+		if a.SkipTestOnError != nil && err != nil && errors.Is(err, a.SkipTestOnError) {
+			a.s.SkipTest = fmt.Sprintf("known error: %s", err.Error())
+			return
 		}
 
 		expectedErrorRaised := assertError(a.s.T, err, a.ExpectedError)

--- a/tests/integration/collection_version/updates/remove/collections_test.go
+++ b/tests/integration/collection_version/updates/remove/collections_test.go
@@ -18,8 +18,10 @@ import (
 
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/options"
+	"github.com/sourcenetwork/defradb/internal/db/description"
 	"github.com/sourcenetwork/defradb/tests/action"
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	"github.com/sourcenetwork/defradb/tests/state"
 )
 
 func TestColVersionUpdateRemoveCollections_ByID(t *testing.T) {
@@ -648,6 +650,69 @@ func TestColVersionUpdateAddFieldRemoveMultipleNewCollection_MiddleAndLast(t *te
 							},
 						},
 					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestColVersionUpdateRemoveCollections_ConcurrentWrite(t *testing.T) {
+	test := testUtils.TestCase{
+		SupportedClientTypes: immutable.Some([]state.ClientType{
+			// The other client types return different errors when occasionally executing the `CreateDoc`
+			// action.
+			state.GoClientType,
+		}),
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type Users {
+						name: String
+					}
+				`,
+			},
+			&action.Async{
+				// todo - we also need to test this with explicit transactions both async and sync
+				// https://github.com/sourcenetwork/defradb/issues/4476
+				Child: &action.PatchCollection{
+					// If the create call completes before the patch starts this will error - skip the test
+					// when this happens as it is unrecoverable and rare.  The production code in such a
+					// scenario is behaving correctly.
+					SkipTestOnError: description.ErrCannotDeleteCollectionWithDocs,
+					Patch: `
+						[
+							{
+								"op": "remove",
+								"path": "/Users"
+							}
+						]
+					`,
+				},
+			},
+			&action.AddDoc{
+				DoNotWaitForEvent: true,
+				DocMap: map[string]any{
+					"name": "John",
+				},
+				// This error can occur if the create-doc call starts after the patch collection call (mostly)
+				// completes, it is uncommon for this to happen, but it does sometimes, especially on slower
+				// machines.  It is correct behaviour, but is not the scenario that this test is asserting.
+				IgnoreError: "collection not found",
+			},
+			&action.Await{},
+			&action.GetCollections{
+				ExpectedResults: []client.CollectionVersion{},
+			},
+			&action.Request{
+				Request: `query {
+					_commits {
+						cid
+					}
+				}`,
+				Results: map[string]any{
+					"_commits": []map[string]any{},
 				},
 			},
 		},

--- a/tests/integration/collection_version/updates/remove/collections_txn_test.go
+++ b/tests/integration/collection_version/updates/remove/collections_txn_test.go
@@ -1,0 +1,277 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// This file is part of the DefraDB test suite.
+//
+// The DefraDB test suite is licensed under either:
+//
+//   (1) GNU Affero General Public License v3
+//   (2) Business Source License 1.1
+//
+// See tests/LICENSE for details.
+
+package remove
+
+import (
+	"testing"
+	"time"
+
+	"github.com/sourcenetwork/immutable"
+
+	"github.com/sourcenetwork/defradb/client"
+	"github.com/sourcenetwork/defradb/client/request"
+	"github.com/sourcenetwork/defradb/tests/action"
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	"github.com/sourcenetwork/defradb/tests/state"
+)
+
+func TestColVersionUpdateRemoveCollection_WithDataAddedInSameTxn(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type Users {
+						name: String
+					}
+				`,
+			},
+			&action.AddDoc{
+				TransactionID: immutable.Some(0),
+				DocMap: map[string]any{
+					"name": "Fred",
+				},
+			},
+			&action.PatchCollection{
+				TransactionID: immutable.Some(0),
+				Patch: `
+						[
+							{
+								"op": "remove",
+								"path": "/Users"
+							}
+						]
+					`,
+				ExpectedError: "cannot delete a collection that has documents",
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestColVersionUpdateRemoveCollection_DeadlocksIfOtherTxnWriting(t *testing.T) {
+	test := testUtils.TestCase{
+		SupportedDatabaseTypes: immutable.Some([]state.DatabaseType{
+			// Badger file fails after the tests successfully completes, probably caused by the
+			// leaked database instance.  It is not worth the time to chase down at the moment.
+			testUtils.BadgerIMType,
+			testUtils.DefraIMType,
+			testUtils.LevelStoreType,
+		}),
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type Users {
+						name: String
+					}
+				`,
+			},
+			&action.AddDoc{
+				TransactionID: immutable.Some(0),
+				DocMap: map[string]any{
+					"name": "Fred",
+				},
+			},
+			&action.PatchCollection{
+				Patch: `
+					[
+						{
+							"op": "remove",
+							"path": "/Users"
+						}
+					]
+				`,
+			},
+		},
+	}
+
+	done := make(chan struct{})
+	go func() {
+		testUtils.ExecuteTestCase(t, test)
+		done <- struct{}{}
+	}()
+
+	select {
+	case <-time.After(100 * time.Millisecond):
+		return
+	case <-done:
+		t.Fatal("Test should deadlock but did not")
+	}
+}
+
+func TestColVersionUpdateRemoveCollection_DeadlockIfDeletingVersionWithNewFieldWhilstOtherTxnWriting(t *testing.T) {
+	test := testUtils.TestCase{
+		SupportedDatabaseTypes: immutable.Some([]state.DatabaseType{
+			// Badger file fails after the tests successfully completes, probably caused by the
+			// leaked database instance.  It is not worth the time to chase down at the moment.
+			testUtils.BadgerIMType,
+			testUtils.DefraIMType,
+			testUtils.LevelStoreType,
+		}),
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type Users {
+						name: String
+					}
+				`,
+			},
+			&action.PatchCollection{
+				Patch: `
+					[
+						{ "op": "add", "path": "/Users/Fields/-", "value": {"Name": "email", "Kind": 11} }
+					]
+				`,
+			},
+			&action.AddDoc{
+				TransactionID: immutable.Some(0),
+				DocMap: map[string]any{
+					"name": "Fred",
+				},
+			},
+			&action.PatchCollection{
+				Patch: `
+					[
+						{
+							"op": "remove",
+							"path": "/bafyreigvzkfdc4y2ppvvpmmdw3t7kv4nd5dgfh5jfytef3kbzem6po55zu"
+						}
+					]
+				`,
+			},
+		},
+	}
+
+	done := make(chan struct{})
+	go func() {
+		testUtils.ExecuteTestCase(t, test)
+		done <- struct{}{}
+	}()
+
+	select {
+	case <-time.After(100 * time.Millisecond):
+		return
+	case <-done:
+		t.Fatal("Test should deadlock but did not")
+	}
+}
+
+func TestColVersionUpdateRemoveCollection_GetCollectionsShouldNotReturnCollectionDeletedWhilstTxnWasOpen(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type Users {
+						name: String
+					}
+				`,
+			},
+			&action.AddCollection{
+				// We don't yet have a create transaction action, so we need to create
+				// one by performing an operation on anything but the `Users` collection
+				// as doing anything on `Users` will acquire a read lock on the collection.
+				TransactionID: immutable.Some(0),
+				SDL: `
+					type Books {
+						name: String
+					}
+				`,
+			},
+			&action.PatchCollection{
+				Patch: `
+					[
+						{
+							"op": "remove",
+							"path": "/Users"
+						}
+					]
+				`,
+			},
+			&action.GetCollections{
+				TransactionID: immutable.Some(0),
+				// Users must not be returned, even though it was deleted after this transaction
+				// was created.
+				ExpectedResults: []client.CollectionVersion{
+					{
+						Name:           "Books",
+						IsActive:       true,
+						IsMaterialized: true,
+						Fields: []client.CollectionFieldDescription{
+							{
+								Name: request.DocIDFieldName,
+								Kind: client.FieldKind_DocID,
+							},
+							{
+								Name: "name",
+								Kind: client.FieldKind_NILLABLE_STRING,
+								Typ:  client.LWW_REGISTER,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestColVersionUpdateRemoveCollection_CollectionMayBeRedeclaredAndUsedByTxn(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type Users {
+						name: String
+					}
+				`,
+			},
+			&action.AddCollection{
+				// We don't yet have a create transaction action, so we need to create
+				// one by performing an operation on anything but the `Users` collection
+				// as doing anything on `Users` will acquire a read lock on the collection.
+				TransactionID: immutable.Some(0),
+				SDL: `
+					type Books {
+						name: String
+					}
+				`,
+			},
+			&action.PatchCollection{
+				Patch: `
+					[
+						{
+							"op": "remove",
+							"path": "/Users"
+						}
+					]
+				`,
+			},
+			&action.AddCollection{
+				TransactionID: immutable.Some(0),
+				SDL: `
+					type Users {
+						name: String
+					}
+				`,
+			},
+			&action.AddDoc{
+				TransactionID: immutable.Some(0),
+				DocMap: map[string]any{
+					"name": "Fred",
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/collection_version/updates/remove/view_txn_test.go
+++ b/tests/integration/collection_version/updates/remove/view_txn_test.go
@@ -1,0 +1,87 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// This file is part of the DefraDB test suite.
+//
+// The DefraDB test suite is licensed under either:
+//
+//   (1) GNU Affero General Public License v3
+//   (2) Business Source License 1.1
+//
+// See tests/LICENSE for details.
+
+package remove
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/defradb/tests/action"
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	"github.com/sourcenetwork/immutable"
+)
+
+func TestColVersionUpdateRemoveView_DoesNotDeadlockIfDeletingVersionWithNoNewFieldsWhilstOtherTxnReading(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type Users {
+						name: String
+					}
+				`,
+			},
+			&action.AddView{
+				Query: `
+					Users {
+						name
+					}
+				`,
+				SDL: `
+					type UserView @materialized(if: true) {
+						name: String
+						fullName: String
+					}
+				`,
+			},
+			&action.PatchCollection{
+				// Patch the view query definition so that it now aliases `name` to `fullName`,
+				// this creates a new collection version, without creating any new fields.
+				Patch: `
+					[
+						{
+							"op": "replace",
+							"path": "/UserView/Query/Query",
+							"value": {"Name": "Users", "Fields":[{"Name":"name","Alias":"fullName"}]}
+						}
+					]
+				`,
+			},
+			&action.Request{
+				// Query the UserView using a new transaction in order to acquire a read lock
+				TransactionID: immutable.Some(0),
+				Request: `query {
+					UserView {
+						name
+					}
+				}`,
+				Results: map[string]any{
+					"UserView": []map[string]any{},
+				},
+			},
+			&action.PatchCollection{
+				// Remove the newer version of the view.
+				// Because this version did not add any new fields, it is not destroying any local information
+				// that cannot be reproduced later (such as field IDs), as such, it does not acquire a write
+				// lock.
+				Patch: `
+					[
+						{
+							"op": "remove",
+							"path": "/bafyreihekbkpnimeo5g5tkv5a3urtcalx2qd447tyhhptjunb7vvpdyvue"
+						}
+					]
+				`,
+			},
+		},
+	}
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/collection_version/updates/replace/is_active_txn_test.go
+++ b/tests/integration/collection_version/updates/replace/is_active_txn_test.go
@@ -1,0 +1,56 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// This file is part of the DefraDB test suite.
+//
+// The DefraDB test suite is licensed under either:
+//
+//   (1) GNU Affero General Public License v3
+//   (2) Business Source License 1.1
+//
+// See tests/LICENSE for details.
+
+package replace
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/defradb/client/options"
+	"github.com/sourcenetwork/defradb/tests/action"
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	"github.com/sourcenetwork/immutable"
+)
+
+func TestColVersionUpdateReplaceIsActive_GetCollectionsWithTxn(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddCollection{
+				TransactionID: immutable.Some(0),
+				SDL: `
+					type Users {}
+				`,
+			},
+			&action.PatchCollection{
+				TransactionID: immutable.Some(0),
+				Patch: `
+					[
+						{
+							"op": "replace",
+							"path": "/bafyreihuyovjl5ezgpud5xyqnouzsgx25x3ssrx3ncdv5p3guocc3laqna/IsActive",
+							"value": false
+						}
+					]
+				`,
+			},
+			&action.GetCollections{
+				TransactionID: immutable.Some(0),
+				FilterOptions: options.GetCollections().SetCollectionName("Users"),
+			},
+			&action.GetCollections{
+				TransactionID: immutable.Some(0),
+				FilterOptions: options.GetCollections().SetCollectionID("bafyreihuyovjl5ezgpud5xyqnouzsgx25x3ssrx3ncdv5p3guocc3laqna"),
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/state/state.go
+++ b/tests/state/state.go
@@ -343,6 +343,16 @@ type State struct {
 
 	// LenIDs of lenses added to Defra.
 	LensIDs []string
+
+	// AsyncWG tracks the progress of in-flight `action.Async`s.  Calling `Wait` on it will wait for
+	// all started `action.Async`s to finish executing.
+	AsyncWG sync.WaitGroup
+
+	// SkipTest signals to the main Go test routine that it should skip the test.
+	//
+	// Calling `T.SkipNow()` from a child routine does not skip the test - so test actions looking to
+	// skip the current test should instead set this, and allow it to be acted upon by the parent routine.
+	SkipTest string
 }
 
 func (s *State) GetClientType() ClientType {


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4268
Partially resolves #4663

## Description

Prevents doc writes after last collection version deleted.