### PR TITLE
fix: Truncate signed documents

### DIFF
--- a/internal/db/collection_truncate.go
+++ b/internal/db/collection_truncate.go
@@ -459,7 +459,10 @@ func deleteBlocks(ctx context.Context, head cid.Cid) error {
 		}
 
 		if decodedBlock.Encryption != nil {
-			toDelete[decodedBlock.Encryption.Cid] = struct{}{}
+			err = blockstore.DeleteBlock(ctx, decodedBlock.Encryption.Cid)
+			if err != nil {
+				return err
+			}
 		}
 
 		if decodedBlock.Signature != nil {

--- a/internal/db/collection_truncate.go
+++ b/internal/db/collection_truncate.go
@@ -463,7 +463,10 @@ func deleteBlocks(ctx context.Context, head cid.Cid) error {
 		}
 
 		if decodedBlock.Signature != nil {
-			toDelete[decodedBlock.Signature.Cid] = struct{}{}
+			err = blockstore.DeleteBlock(ctx, decodedBlock.Signature.Cid)
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/tests/integration/collection/truncate/add_test.go
+++ b/tests/integration/collection/truncate/add_test.go
@@ -93,6 +93,42 @@ func TestTruncateCollectionAdd_RemovesSignedDocument(t *testing.T) {
 	testUtils.ExecuteTestCase(t, test)
 }
 
+func TestTruncateCollectionAdd_RemovesEncryptedDocument(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type Users {
+						name: String
+					}
+				`,
+			},
+			&action.AddDoc{
+				CollectionID:   0,
+				IsDocEncrypted: true,
+				DocMap: map[string]any{
+					"name": "John",
+				},
+			},
+			&action.Truncate{
+				CollectionIndex: 0,
+			},
+			&action.Request{
+				Request: `query {
+					Users {
+						name
+					}
+				}`,
+				Results: map[string]any{
+					"Users": []map[string]any{},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
 func TestTruncateCollectionAdd_RemovesBlocks(t *testing.T) {
 	test := testUtils.TestCase{
 		Actions: []any{

--- a/tests/integration/collection/truncate/add_test.go
+++ b/tests/integration/collection/truncate/add_test.go
@@ -53,6 +53,51 @@ func TestTruncateCollectionAdd_RemovesDocument(t *testing.T) {
 	testUtils.ExecuteTestCase(t, test)
 }
 
+// todo - this test shouldn't need to exist, but we dont currently test
+// Defra with digital signatures enabled besides a handful of tests that
+// explicitly enable it. Remove this test as part of:
+// https://github.com/sourcenetwork/defradb/issues/4671
+func TestTruncateCollectionAdd_RemovesSignedDocument(t *testing.T) {
+	test := testUtils.TestCase{
+		EnableSigning: true,
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type Users {
+						name: String
+					}
+				`,
+			},
+			&action.AddDoc{
+				CollectionID: 0,
+				DocMap: map[string]any{
+					"name": "John",
+				},
+			},
+			&action.Truncate{
+				CollectionIndex: 0,
+				ExpectedError:   "failed to unmarshal block",
+			},
+			&action.Request{
+				Request: `query {
+					Users {
+						name
+					}
+				}`,
+				Results: map[string]any{
+					"Users": []map[string]any{
+						{
+							"name": "John",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
 func TestTruncateCollectionAdd_RemovesBlocks(t *testing.T) {
 	test := testUtils.TestCase{
 		Actions: []any{

--- a/tests/integration/collection/truncate/add_test.go
+++ b/tests/integration/collection/truncate/add_test.go
@@ -76,7 +76,6 @@ func TestTruncateCollectionAdd_RemovesSignedDocument(t *testing.T) {
 			},
 			&action.Truncate{
 				CollectionIndex: 0,
-				ExpectedError:   "failed to unmarshal block",
 			},
 			&action.Request{
 				Request: `query {
@@ -85,11 +84,7 @@ func TestTruncateCollectionAdd_RemovesSignedDocument(t *testing.T) {
 					}
 				}`,
 				Results: map[string]any{
-					"Users": []map[string]any{
-						{
-							"name": "John",
-						},
-					},
+					"Users": []map[string]any{},
 				},
 			},
 		},


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4653

## Description

Truncate signed documents, instead of erroring.

Current develop behaviour visible if reviewing commit by commit.
