### PR TITLE
feat: Add syntax sugar DeleteCollection cmd

### DIFF
--- a/cbindings/delete_collection.go
+++ b/cbindings/delete_collection.go
@@ -1,0 +1,48 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package cbindings
+
+/*
+#include <stdlib.h>
+#include "defra_structs.h"
+*/
+import "C"
+
+import (
+	"context"
+
+	"github.com/sourcenetwork/defradb/client/options"
+	iIdentity "github.com/sourcenetwork/defradb/internal/identity"
+)
+
+//export DeleteCollection
+func DeleteCollection(nodePtr C.uintptr_t, name *C.char, identityPtr C.uintptr_t) C.Result {
+	ctx := context.Background()
+
+	ctx, err := contextWithIdentity(ctx, identityPtr)
+	if err != nil {
+		return returnC(returnGoC(1, err.Error(), ""))
+	}
+
+	store, err := getStoreFromPointer(nodePtr)
+	if err != nil {
+		return returnC(returnGoC(1, err.Error(), ""))
+	}
+
+	ctx = attachTxnFromPointer(nodePtr, ctx)
+
+	opt := options.WithIdentity(options.DeleteCollection(), iIdentity.FromContext(ctx))
+	err = store.DeleteCollection(ctx, C.GoString(name), opt)
+	if err != nil {
+		return returnC(returnGoC(1, err.Error(), ""))
+	}
+	return returnC(returnGoC(0, "", ""))
+}

--- a/cbindings/delete_collection.go
+++ b/cbindings/delete_collection.go
@@ -18,13 +18,14 @@ import "C"
 
 import (
 	"context"
+	"strings"
 
 	"github.com/sourcenetwork/defradb/client/options"
 	iIdentity "github.com/sourcenetwork/defradb/internal/identity"
 )
 
 //export DeleteCollection
-func DeleteCollection(nodePtr C.uintptr_t, name *C.char, identityPtr C.uintptr_t) C.Result {
+func DeleteCollection(nodePtr C.uintptr_t, names *C.char, identityPtr C.uintptr_t) C.Result {
 	ctx := context.Background()
 
 	ctx, err := contextWithIdentity(ctx, identityPtr)
@@ -40,7 +41,13 @@ func DeleteCollection(nodePtr C.uintptr_t, name *C.char, identityPtr C.uintptr_t
 	ctx = attachTxnFromPointer(nodePtr, ctx)
 
 	opt := options.WithIdentity(options.DeleteCollection(), iIdentity.FromContext(ctx))
-	err = store.DeleteCollection(ctx, C.GoString(name), opt)
+
+	var nameList []string
+	if joined := C.GoString(names); joined != "" {
+		nameList = strings.Split(joined, ",")
+	}
+
+	err = store.DeleteCollection(ctx, nameList, opt)
 	if err != nil {
 		return returnC(returnGoC(1, err.Error(), ""))
 	}

--- a/cbindings/delete_collection.go
+++ b/cbindings/delete_collection.go
@@ -25,7 +25,12 @@ import (
 )
 
 //export DeleteCollection
-func DeleteCollection(nodePtr C.uintptr_t, names *C.char, identityPtr C.uintptr_t) C.Result {
+func DeleteCollection(
+	nodePtr C.uintptr_t,
+	names *C.char,
+	activeOnly C.int,
+	identityPtr C.uintptr_t,
+) C.Result {
 	ctx := context.Background()
 
 	ctx, err := contextWithIdentity(ctx, identityPtr)
@@ -41,6 +46,7 @@ func DeleteCollection(nodePtr C.uintptr_t, names *C.char, identityPtr C.uintptr_
 	ctx = attachTxnFromPointer(nodePtr, ctx)
 
 	opt := options.WithIdentity(options.DeleteCollection(), iIdentity.FromContext(ctx))
+	opt.SetActiveOnly(activeOnly != 0)
 
 	var nameList []string
 	if joined := C.GoString(names); joined != "" {

--- a/cbindings/wrapper.go
+++ b/cbindings/wrapper.go
@@ -30,7 +30,7 @@ extern Result VerifyBlockSignature(uintptr_t nodePtr, char* keyType, char* publi
 uintptr_t identity);
 extern Result DescribeCollection(uintptr_t nodePtr, CollectionOptions options, uintptr_t identityPtr);
 extern Result PatchCollection(uintptr_t nodePtr, char* patch, char* lensConfig, uintptr_t identityPtr);
-extern Result DeleteCollection(uintptr_t nodePtr, char* name, uintptr_t identityPtr);
+extern Result DeleteCollection(uintptr_t nodePtr, char* name, int activeOnly, uintptr_t identityPtr);
 extern Result NewIdentity(char* keyType);
 extern void FreeIdentity(uintptr_t identityPtr);
 extern Result GetNodeIdentity(uintptr_t nodePtr);
@@ -698,13 +698,19 @@ func (w *CWrapper) DeleteCollection(
 	names []string,
 	opts ...options.Enumerable[options.DeleteCollectionOptions],
 ) error {
-	cIdentity := optionToUintptr(utils.NewOptions(opts...).GetIdentity())
+	opt := utils.NewOptions(opts...)
+	cIdentity := optionToUintptr(opt.GetIdentity())
 	cNames := C.CString(strings.Join(names, ","))
 	defer C.free(unsafe.Pointer(cNames))
 	defer C.FreeIdentity(cIdentity)
 
+	cActiveOnly := C.int(0)
+	if opt.ActiveOnly {
+		cActiveOnly = 1
+	}
+
 	callHandle := getNodeOrTxnHandle(w.handle, ctx)
-	res := ConvertAndFreeCResult(C.DeleteCollection(callHandle, cNames, cIdentity))
+	res := ConvertAndFreeCResult(C.DeleteCollection(callHandle, cNames, cActiveOnly, cIdentity))
 
 	if res.Status != 0 {
 		return errors.New(res.Error)

--- a/cbindings/wrapper.go
+++ b/cbindings/wrapper.go
@@ -30,6 +30,7 @@ extern Result VerifyBlockSignature(uintptr_t nodePtr, char* keyType, char* publi
 uintptr_t identity);
 extern Result DescribeCollection(uintptr_t nodePtr, CollectionOptions options, uintptr_t identityPtr);
 extern Result PatchCollection(uintptr_t nodePtr, char* patch, char* lensConfig, uintptr_t identityPtr);
+extern Result DeleteCollection(uintptr_t nodePtr, char* name, uintptr_t identityPtr);
 extern Result NewIdentity(char* keyType);
 extern void FreeIdentity(uintptr_t identityPtr);
 extern Result GetNodeIdentity(uintptr_t nodePtr);
@@ -684,6 +685,26 @@ func (w *CWrapper) PatchCollection(
 
 	callHandle := getNodeOrTxnHandle(w.handle, ctx)
 	res := ConvertAndFreeCResult(C.PatchCollection(callHandle, cPatch, cMigration, cIdentity))
+
+	if res.Status != 0 {
+		return errors.New(res.Error)
+	}
+
+	return nil
+}
+
+func (w *CWrapper) DeleteCollection(
+	ctx context.Context,
+	name string,
+	opts ...options.Enumerable[options.DeleteCollectionOptions],
+) error {
+	cIdentity := optionToUintptr(utils.NewOptions(opts...).GetIdentity())
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+	defer C.FreeIdentity(cIdentity)
+
+	callHandle := getNodeOrTxnHandle(w.handle, ctx)
+	res := ConvertAndFreeCResult(C.DeleteCollection(callHandle, cName, cIdentity))
 
 	if res.Status != 0 {
 		return errors.New(res.Error)

--- a/cbindings/wrapper.go
+++ b/cbindings/wrapper.go
@@ -695,16 +695,16 @@ func (w *CWrapper) PatchCollection(
 
 func (w *CWrapper) DeleteCollection(
 	ctx context.Context,
-	name string,
+	names []string,
 	opts ...options.Enumerable[options.DeleteCollectionOptions],
 ) error {
 	cIdentity := optionToUintptr(utils.NewOptions(opts...).GetIdentity())
-	cName := C.CString(name)
-	defer C.free(unsafe.Pointer(cName))
+	cNames := C.CString(strings.Join(names, ","))
+	defer C.free(unsafe.Pointer(cNames))
 	defer C.FreeIdentity(cIdentity)
 
 	callHandle := getNodeOrTxnHandle(w.handle, ctx)
-	res := ConvertAndFreeCResult(C.DeleteCollection(callHandle, cName, cIdentity))
+	res := ConvertAndFreeCResult(C.DeleteCollection(callHandle, cNames, cIdentity))
 
 	if res.Status != 0 {
 		return errors.New(res.Error)

--- a/cbindings/wrapper_tx.go
+++ b/cbindings/wrapper_tx.go
@@ -133,11 +133,11 @@ func (txn *Transaction) PatchCollection(
 
 func (txn *Transaction) DeleteCollection(
 	ctx context.Context,
-	name string,
+	names []string,
 	opts ...options.Enumerable[options.DeleteCollectionOptions],
 ) error {
 	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
-	return txn.CWrapper.DeleteCollection(ctx, name, opts...)
+	return txn.CWrapper.DeleteCollection(ctx, names, opts...)
 }
 
 func (txn *Transaction) SetActiveCollectionVersion(

--- a/cbindings/wrapper_tx.go
+++ b/cbindings/wrapper_tx.go
@@ -131,6 +131,15 @@ func (txn *Transaction) PatchCollection(
 	return txn.CWrapper.PatchCollection(ctx, patch, migration, opts...)
 }
 
+func (txn *Transaction) DeleteCollection(
+	ctx context.Context,
+	name string,
+	opts ...options.Enumerable[options.DeleteCollectionOptions],
+) error {
+	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
+	return txn.CWrapper.DeleteCollection(ctx, name, opts...)
+}
+
 func (txn *Transaction) SetActiveCollectionVersion(
 	ctx context.Context,
 	version string,

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -147,6 +147,7 @@ func NewDefraCommand(ctx context.Context) *cobra.Command {
 	collection := MakeCollectionCommand(ctx)
 	collection.AddCommand(
 		MakeCollectionAddCommand(ctx),
+		MakeCollectionDeleteCommand(ctx),
 		MakeCollectionDescribeCommand(ctx),
 		MakeCollectionPatchCommand(ctx),
 		MakeCollectionSetActiveCommand(ctx),

--- a/cli/collection.go
+++ b/cli/collection.go
@@ -29,7 +29,7 @@ func MakeCollectionCommand(ctx context.Context) *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:   "collection [--name <name> --collection-id <collectionID> --version-id <versionID>]",
 		Short: "Interact with a collection.",
-		Long:  `Add, describe, patch, set-active, and truncate collections.`,
+		Long:  `Add, describe, patch, set-active, delete, and truncate collections.`,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) (err error) {
 			// cobra does not chain pre run calls so we have to run them again here
 			if err := setContextRootDir(cmd); err != nil {

--- a/cli/collection_delete.go
+++ b/cli/collection_delete.go
@@ -1,0 +1,52 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package cli
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+
+	"github.com/sourcenetwork/defradb/client/options"
+	"github.com/sourcenetwork/defradb/internal/identity"
+)
+
+func MakeCollectionDeleteCommand(ctx context.Context) *cobra.Command {
+	var name string
+	var cmd = &cobra.Command{
+		Use:   "delete --name <name>",
+		Short: "Delete the active collection version",
+		Long: `Delete the active version of a collection by name.
+
+Only the latest (head) version is deleted per call. If the collection has multiple
+versions, earlier versions must be deleted separately after each head is removed.
+
+The collection must not contain any documents. Delete all documents first before
+deleting the collection.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if name == "" {
+				return NewErrRequiredFlagEmpty("name", "n")
+			}
+
+			cliClient := mustGetContextCLIClient(cmd)
+
+			opt := options.WithIdentity(options.DeleteCollection(), identity.FromContext(cmd.Context()))
+			return cliClient.DeleteCollection(cmd.Context(), name, opt)
+		},
+	}
+
+	EmbedCLIExample(ctx, cmd, "delete a collection by name",
+		`defradb client collection delete --name Users`)
+
+	cmd.Flags().StringVarP(&name, "name", "n", "", "Collection name to delete")
+
+	return cmd
+}

--- a/cli/collection_delete.go
+++ b/cli/collection_delete.go
@@ -12,6 +12,7 @@ package cli
 
 import (
 	"context"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -20,33 +21,46 @@ import (
 )
 
 func MakeCollectionDeleteCommand(ctx context.Context) *cobra.Command {
-	var name string
 	var cmd = &cobra.Command{
-		Use:   "delete --name <name>",
-		Short: "Delete the active collection version",
-		Long: `Delete the active version of a collection by name.
+		Use:   "delete [collectionNames]",
+		Short: "Delete the active collection versions",
+		Long: `Delete the active version of one or more collections by name.
 
-Only the latest (head) version is deleted per call. If the collection has multiple
+A single name, or a comma-separated list of names, may be provided. All named
+collections are removed atomically in a single operation. This can be used to
+delete collections that reference each other via relations, since deleting them
+one at a time would leave a dangling reference and be rolled back.
+
+Only the latest (head) version is deleted per call. If a collection has multiple
 versions, earlier versions must be deleted separately after each head is removed.
 
-The collection must not contain any documents. Delete all documents first before
-deleting the collection.`,
+The named collections must not contain any documents. Delete all documents first
+before deleting the collection.`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if name == "" {
-				return NewErrRequiredFlagEmpty("name", "n")
+			var names []string
+			for name := range strings.SplitSeq(args[0], ",") {
+				name = strings.TrimSpace(name)
+				if name == "" {
+					continue
+				}
+				names = append(names, name)
 			}
 
 			cliClient := mustGetContextCLIClient(cmd)
 
 			opt := options.WithIdentity(options.DeleteCollection(), identity.FromContext(cmd.Context()))
-			return cliClient.DeleteCollection(cmd.Context(), name, opt)
+			return cliClient.DeleteCollection(cmd.Context(), names, opt)
 		},
 	}
 
-	EmbedCLIExample(ctx, cmd, "delete a collection by name",
-		`defradb client collection delete --name Users`)
+	EmbedCLIExample(ctx, cmd, "delete a single collection",
+		`defradb client collection delete Users`)
 
-	cmd.Flags().StringVarP(&name, "name", "n", "", "Collection name to delete")
+	EmbedCLIExample(ctx, cmd,
+		"delete multiple collections in one call (this can be used to delete collections that reference "+
+			"each other via relations)",
+		`defradb client collection delete Users,Books`)
 
 	return cmd
 }

--- a/cli/collection_delete.go
+++ b/cli/collection_delete.go
@@ -21,18 +21,20 @@ import (
 )
 
 func MakeCollectionDeleteCommand(ctx context.Context) *cobra.Command {
+	var activeOnly bool
 	var cmd = &cobra.Command{
 		Use:   "delete [collectionNames]",
-		Short: "Delete the active collection versions",
-		Long: `Delete the active version of one or more collections by name.
+		Short: "Delete collections",
+		Long: `Delete one or more collections by name.
 
 A single name, or a comma-separated list of names, may be provided. All named
 collections are removed atomically in a single operation. This can be used to
 delete collections that reference each other via relations, since deleting them
 one at a time would leave a dangling reference and be rolled back.
 
-Only the latest (head) version is deleted per call. If a collection has multiple
-versions, earlier versions must be deleted separately after each head is removed.
+By default, every version of each named collection is deleted (active head and
+all earlier versions). Pass --active-only to delete only the latest (head) version
+and keep earlier versions intact.
 
 The named collections must not contain any documents. Delete all documents first
 before deleting the collection.`,
@@ -50,17 +52,24 @@ before deleting the collection.`,
 			cliClient := mustGetContextCLIClient(cmd)
 
 			opt := options.WithIdentity(options.DeleteCollection(), identity.FromContext(cmd.Context()))
+			opt.SetActiveOnly(activeOnly)
 			return cliClient.DeleteCollection(cmd.Context(), names, opt)
 		},
 	}
 
-	EmbedCLIExample(ctx, cmd, "delete a single collection",
+	cmd.Flags().BoolVar(&activeOnly, "active-only", false,
+		"Delete only the active head version of each named collection (default deletes every version)")
+
+	EmbedCLIExample(ctx, cmd, "delete every version of a single collection",
 		`defradb client collection delete Users`)
 
 	EmbedCLIExample(ctx, cmd,
-		"delete multiple collections in one call (this can be used to delete collections that reference "+
-			"each other via relations)",
+		"delete every version of multiple collections in one call (this can be used to delete collections "+
+			"that reference each other via relations)",
 		`defradb client collection delete Users,Books`)
+
+	EmbedCLIExample(ctx, cmd, "delete only the active head version, keeping earlier versions",
+		`defradb client collection delete --active-only Users`)
 
 	return cmd
 }

--- a/client/db.go
+++ b/client/db.go
@@ -205,15 +205,20 @@ type Store interface {
 		opts ...options.Enumerable[options.PatchCollectionOptions],
 	) error
 
-	// DeleteCollection deletes the active version of the collection with the given name.
+	// DeleteCollection deletes the active versions of the collections with the given names.
 	//
-	// Only the latest (head) version is deleted per call. If the collection has multiple versions,
-	// earlier versions must be deleted separately after each head is removed.
+	// All names are removed atomically in a single patch; if any removal leaves the schema
+	// in an invalid state (e.g. one of the remaining collections still references a deleted
+	// one via a relation) the entire operation is rolled back.
 	//
-	// It will error if the collection contains any documents - they must be deleted first.
+	// Only the latest (head) version of each named collection is deleted per call. If a
+	// collection has multiple versions, earlier versions must be deleted separately after
+	// each head is removed.
+	//
+	// It will error if any named collection contains documents - they must be deleted first.
 	DeleteCollection(
 		ctx context.Context,
-		name string,
+		names []string,
 		opts ...options.Enumerable[options.DeleteCollectionOptions],
 	) error
 

--- a/client/db.go
+++ b/client/db.go
@@ -205,6 +205,18 @@ type Store interface {
 		opts ...options.Enumerable[options.PatchCollectionOptions],
 	) error
 
+	// DeleteCollection deletes the active version of the collection with the given name.
+	//
+	// Only the latest (head) version is deleted per call. If the collection has multiple versions,
+	// earlier versions must be deleted separately after each head is removed.
+	//
+	// It will error if the collection contains any documents - they must be deleted first.
+	DeleteCollection(
+		ctx context.Context,
+		name string,
+		opts ...options.Enumerable[options.DeleteCollectionOptions],
+	) error
+
 	// SetActiveCollectionVersion activates all collection versions with the given VersionID, and deactivates all
 	// those share the same CollectionID as the activated CollectionVersion.
 	//

--- a/client/errors.go
+++ b/client/errors.go
@@ -98,6 +98,7 @@ var (
 	ErrNACNodeObjectToGateIsNotRegistered    = errors.New(errNACNodeObjectToGateIsNotRegistered)
 	ErrOperationRequiresDeveloperMode        = errors.New(errOperationRequiresDeveloperMode)
 	ErrIndexNameRequired                     = errors.New("index name is required")
+	ErrCollectionNameRequired                = errors.New("collection name is required")
 	ErrDocumentJSONParseFailed               = errors.New(errDocumentJSONParseFailed)
 )
 

--- a/client/mocks/txn.go
+++ b/client/mocks/txn.go
@@ -1102,6 +1102,78 @@ func (_c *Txn_Connect_Call) RunAndReturn(run func(ctx context.Context, addresses
 	return _c
 }
 
+// DeleteCollection provides a mock function for the type Txn
+func (_mock *Txn) DeleteCollection(ctx context.Context, name string, opts ...options.Enumerable[options.DeleteCollectionOptions]) error {
+	var tmpRet mock.Arguments
+	if len(opts) > 0 {
+		tmpRet = _mock.Called(ctx, name, opts)
+	} else {
+		tmpRet = _mock.Called(ctx, name)
+	}
+	ret := tmpRet
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteCollection")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, ...options.Enumerable[options.DeleteCollectionOptions]) error); ok {
+		r0 = returnFunc(ctx, name, opts...)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// Txn_DeleteCollection_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteCollection'
+type Txn_DeleteCollection_Call struct {
+	*mock.Call
+}
+
+// DeleteCollection is a helper method to define mock.On call
+//   - ctx context.Context
+//   - name string
+//   - opts ...options.Enumerable[options.DeleteCollectionOptions]
+func (_e *Txn_Expecter) DeleteCollection(ctx interface{}, name interface{}, opts ...interface{}) *Txn_DeleteCollection_Call {
+	return &Txn_DeleteCollection_Call{Call: _e.mock.On("DeleteCollection",
+		append([]interface{}{ctx, name}, opts...)...)}
+}
+
+func (_c *Txn_DeleteCollection_Call) Run(run func(ctx context.Context, name string, opts ...options.Enumerable[options.DeleteCollectionOptions])) *Txn_DeleteCollection_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 []options.Enumerable[options.DeleteCollectionOptions]
+		var variadicArgs []options.Enumerable[options.DeleteCollectionOptions]
+		if len(args) > 2 {
+			variadicArgs = args[2].([]options.Enumerable[options.DeleteCollectionOptions])
+		}
+		arg2 = variadicArgs
+		run(
+			arg0,
+			arg1,
+			arg2...,
+		)
+	})
+	return _c
+}
+
+func (_c *Txn_DeleteCollection_Call) Return(err error) *Txn_DeleteCollection_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *Txn_DeleteCollection_Call) RunAndReturn(run func(ctx context.Context, name string, opts ...options.Enumerable[options.DeleteCollectionOptions]) error) *Txn_DeleteCollection_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // DeleteDACActorRelationship provides a mock function for the type Txn
 func (_mock *Txn) DeleteDACActorRelationship(ctx context.Context, collectionName string, docID string, relation string, targetActor string, opts ...options.Enumerable[options.DeleteDACActorRelationshipOptions]) (client.DeleteActorRelationshipResult, error) {
 	var tmpRet mock.Arguments

--- a/client/mocks/txn.go
+++ b/client/mocks/txn.go
@@ -1103,12 +1103,12 @@ func (_c *Txn_Connect_Call) RunAndReturn(run func(ctx context.Context, addresses
 }
 
 // DeleteCollection provides a mock function for the type Txn
-func (_mock *Txn) DeleteCollection(ctx context.Context, name string, opts ...options.Enumerable[options.DeleteCollectionOptions]) error {
+func (_mock *Txn) DeleteCollection(ctx context.Context, names []string, opts ...options.Enumerable[options.DeleteCollectionOptions]) error {
 	var tmpRet mock.Arguments
 	if len(opts) > 0 {
-		tmpRet = _mock.Called(ctx, name, opts)
+		tmpRet = _mock.Called(ctx, names, opts)
 	} else {
-		tmpRet = _mock.Called(ctx, name)
+		tmpRet = _mock.Called(ctx, names)
 	}
 	ret := tmpRet
 
@@ -1117,8 +1117,8 @@ func (_mock *Txn) DeleteCollection(ctx context.Context, name string, opts ...opt
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, ...options.Enumerable[options.DeleteCollectionOptions]) error); ok {
-		r0 = returnFunc(ctx, name, opts...)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []string, ...options.Enumerable[options.DeleteCollectionOptions]) error); ok {
+		r0 = returnFunc(ctx, names, opts...)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -1132,22 +1132,22 @@ type Txn_DeleteCollection_Call struct {
 
 // DeleteCollection is a helper method to define mock.On call
 //   - ctx context.Context
-//   - name string
+//   - names []string
 //   - opts ...options.Enumerable[options.DeleteCollectionOptions]
-func (_e *Txn_Expecter) DeleteCollection(ctx interface{}, name interface{}, opts ...interface{}) *Txn_DeleteCollection_Call {
+func (_e *Txn_Expecter) DeleteCollection(ctx interface{}, names interface{}, opts ...interface{}) *Txn_DeleteCollection_Call {
 	return &Txn_DeleteCollection_Call{Call: _e.mock.On("DeleteCollection",
-		append([]interface{}{ctx, name}, opts...)...)}
+		append([]interface{}{ctx, names}, opts...)...)}
 }
 
-func (_c *Txn_DeleteCollection_Call) Run(run func(ctx context.Context, name string, opts ...options.Enumerable[options.DeleteCollectionOptions])) *Txn_DeleteCollection_Call {
+func (_c *Txn_DeleteCollection_Call) Run(run func(ctx context.Context, names []string, opts ...options.Enumerable[options.DeleteCollectionOptions])) *Txn_DeleteCollection_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
 			arg0 = args[0].(context.Context)
 		}
-		var arg1 string
+		var arg1 []string
 		if args[1] != nil {
-			arg1 = args[1].(string)
+			arg1 = args[1].([]string)
 		}
 		var arg2 []options.Enumerable[options.DeleteCollectionOptions]
 		var variadicArgs []options.Enumerable[options.DeleteCollectionOptions]
@@ -1169,7 +1169,7 @@ func (_c *Txn_DeleteCollection_Call) Return(err error) *Txn_DeleteCollection_Cal
 	return _c
 }
 
-func (_c *Txn_DeleteCollection_Call) RunAndReturn(run func(ctx context.Context, name string, opts ...options.Enumerable[options.DeleteCollectionOptions]) error) *Txn_DeleteCollection_Call {
+func (_c *Txn_DeleteCollection_Call) RunAndReturn(run func(ctx context.Context, names []string, opts ...options.Enumerable[options.DeleteCollectionOptions]) error) *Txn_DeleteCollection_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/client/options/store.go
+++ b/client/options/store.go
@@ -537,6 +537,10 @@ func (b *PatchCollectionOptionsBuilder) SetIdentity(id identity.Identity) *Patch
 type DeleteCollectionOptions struct {
 	// Identity is the identity of the actor performing the operation.
 	Identity immutable.Option[identity.Identity]
+	// ActiveOnly limits the delete to only the active head version of each named
+	// collection. When false (the default) every version of each named collection
+	// is removed.
+	ActiveOnly bool
 }
 
 // GetIdentity returns the identity for the operation.
@@ -558,6 +562,15 @@ func DeleteCollection() *DeleteCollectionOptionsBuilder {
 func (b *DeleteCollectionOptionsBuilder) SetIdentity(id identity.Identity) *DeleteCollectionOptionsBuilder {
 	b.append(func(opts *DeleteCollectionOptions) {
 		opts.Identity = immutable.Some(id)
+	})
+	return b
+}
+
+// SetActiveOnly toggles whether only the active head version of each named collection
+// is deleted. Defaults to false (delete every version).
+func (b *DeleteCollectionOptionsBuilder) SetActiveOnly(activeOnly bool) *DeleteCollectionOptionsBuilder {
+	b.append(func(opts *DeleteCollectionOptions) {
+		opts.ActiveOnly = activeOnly
 	})
 	return b
 }

--- a/client/options/store.go
+++ b/client/options/store.go
@@ -533,6 +533,35 @@ func (b *PatchCollectionOptionsBuilder) SetIdentity(id identity.Identity) *Patch
 	return b
 }
 
+// DeleteCollectionOptions contains options for DeleteCollection operation.
+type DeleteCollectionOptions struct {
+	// Identity is the identity of the actor performing the operation.
+	Identity immutable.Option[identity.Identity]
+}
+
+// GetIdentity returns the identity for the operation.
+func (o *DeleteCollectionOptions) GetIdentity() immutable.Option[identity.Identity] {
+	return o.Identity
+}
+
+// DeleteCollectionOptionsBuilder is a builder for DeleteCollectionOptions.
+type DeleteCollectionOptionsBuilder struct {
+	enumerableBuilder[DeleteCollectionOptions]
+}
+
+// DeleteCollection creates a new DeleteCollectionOptionsBuilder instance.
+func DeleteCollection() *DeleteCollectionOptionsBuilder {
+	return &DeleteCollectionOptionsBuilder{}
+}
+
+// SetIdentity sets the identity for the operation.
+func (b *DeleteCollectionOptionsBuilder) SetIdentity(id identity.Identity) *DeleteCollectionOptionsBuilder {
+	b.append(func(opts *DeleteCollectionOptions) {
+		opts.Identity = immutable.Some(id)
+	})
+	return b
+}
+
 // SetActiveCollectionVersionOptions contains options for SetActiveCollectionVersion operation.
 type SetActiveCollectionVersionOptions struct {
 	// Identity is the identity of the actor performing the operation.

--- a/docs/website/references/cli/defradb_client_collection.md
+++ b/docs/website/references/cli/defradb_client_collection.md
@@ -42,7 +42,7 @@ Add, describe, patch, set-active, delete, and truncate collections.
 
 * [defradb client](defradb_client.md)	 - Interact with a DefraDB node
 * [defradb client collection add](defradb_client_collection_add.md)	 - Add new collection
-* [defradb client collection delete](defradb_client_collection_delete.md)	 - Delete the active collection versions
+* [defradb client collection delete](defradb_client_collection_delete.md)	 - Delete collections
 * [defradb client collection describe](defradb_client_collection_describe.md)	 - View collection version.
 * [defradb client collection patch](defradb_client_collection_patch.md)	 - Patch existing collection versions
 * [defradb client collection set-active](defradb_client_collection_set-active.md)	 - Set the active collection version

--- a/docs/website/references/cli/defradb_client_collection.md
+++ b/docs/website/references/cli/defradb_client_collection.md
@@ -42,7 +42,7 @@ Add, describe, patch, set-active, delete, and truncate collections.
 
 * [defradb client](defradb_client.md)	 - Interact with a DefraDB node
 * [defradb client collection add](defradb_client_collection_add.md)	 - Add new collection
-* [defradb client collection delete](defradb_client_collection_delete.md)	 - Delete the active collection version
+* [defradb client collection delete](defradb_client_collection_delete.md)	 - Delete the active collection versions
 * [defradb client collection describe](defradb_client_collection_describe.md)	 - View collection version.
 * [defradb client collection patch](defradb_client_collection_patch.md)	 - Patch existing collection versions
 * [defradb client collection set-active](defradb_client_collection_set-active.md)	 - Set the active collection version

--- a/docs/website/references/cli/defradb_client_collection_delete.md
+++ b/docs/website/references/cli/defradb_client_collection_delete.md
@@ -1,26 +1,41 @@
-## defradb client collection
+## defradb client collection delete
 
-Interact with a collection.
+Delete the active collection version
 
 ### Synopsis
 
-Add, describe, patch, set-active, delete, and truncate collections.
+Delete the active version of a collection by name.
+
+Only the latest (head) version is deleted per call. If the collection has multiple
+versions, earlier versions must be deleted separately after each head is removed.
+
+The collection must not contain any documents. Delete all documents first before
+deleting the collection.
+
+```
+defradb client collection delete --name <name> [flags]
+```
+
+### Examples
+
+```
+delete a collection by name:  
+  defradb client collection delete --name Users
+```
 
 ### Options
 
 ```
-      --collection-id string   Collection ID
-      --get-inactive           Get inactive collections as well as active
-  -h, --help                   help for collection
-  -i, --identity string        Hex formatted private key used to authenticate with ACP
-      --name string            Collection name
-      --tx uint                Transaction ID
-      --version-id string      Collection version ID
+  -h, --help          help for delete
+  -n, --name string   Collection name to delete
 ```
 
 ### Options inherited from parent commands
 
 ```
+      --collection-id string        Collection ID
+      --get-inactive                Get inactive collections as well as active
+  -i, --identity string             Hex formatted private key used to authenticate with ACP
       --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
       --keyring-namespace string    Service name to use when using the system backend (default "defradb")
       --keyring-path string         Path to store encrypted keys when using the file backend (default "keys")
@@ -35,16 +50,12 @@ Add, describe, patch, set-active, delete, and truncate collections.
       --rootdir string              Directory for persistent data (default: $HOME/.defradb)
       --secret-file string          Path to the file containing secrets (default ".env")
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                     Transaction ID
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+      --version-id string           Collection version ID
 ```
 
 ### SEE ALSO
 
-* [defradb client](defradb_client.md)	 - Interact with a DefraDB node
-* [defradb client collection add](defradb_client_collection_add.md)	 - Add new collection
-* [defradb client collection delete](defradb_client_collection_delete.md)	 - Delete the active collection version
-* [defradb client collection describe](defradb_client_collection_describe.md)	 - View collection version.
-* [defradb client collection patch](defradb_client_collection_patch.md)	 - Patch existing collection versions
-* [defradb client collection set-active](defradb_client_collection_set-active.md)	 - Set the active collection version
-* [defradb client collection truncate](defradb_client_collection_truncate.md)	 - Truncate the given collection
+* [defradb client collection](defradb_client_collection.md)	 - Interact with a collection.
 

--- a/docs/website/references/cli/defradb_client_collection_delete.md
+++ b/docs/website/references/cli/defradb_client_collection_delete.md
@@ -1,33 +1,40 @@
 ## defradb client collection delete
 
-Delete the active collection version
+Delete the active collection versions
 
 ### Synopsis
 
-Delete the active version of a collection by name.
+Delete the active version of one or more collections by name.
 
-Only the latest (head) version is deleted per call. If the collection has multiple
+A single name, or a comma-separated list of names, may be provided. All named
+collections are removed atomically in a single operation. This can be used to
+delete collections that reference each other via relations, since deleting them
+one at a time would leave a dangling reference and be rolled back.
+
+Only the latest (head) version is deleted per call. If a collection has multiple
 versions, earlier versions must be deleted separately after each head is removed.
 
-The collection must not contain any documents. Delete all documents first before
-deleting the collection.
+The named collections must not contain any documents. Delete all documents first
+before deleting the collection.
 
 ```
-defradb client collection delete --name <name> [flags]
+defradb client collection delete [collectionNames] [flags]
 ```
 
 ### Examples
 
 ```
-delete a collection by name:  
-  defradb client collection delete --name Users
+delete a single collection:  
+  defradb client collection delete Users
+
+delete multiple collections in one call (this can be used to delete collections that reference each other via relations):  
+  defradb client collection delete Users,Books
 ```
 
 ### Options
 
 ```
-  -h, --help          help for delete
-  -n, --name string   Collection name to delete
+  -h, --help   help for delete
 ```
 
 ### Options inherited from parent commands
@@ -45,6 +52,7 @@ delete a collection by name:
       --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
       --log-source                  Include source location in logs
       --log-stacktrace              Include stacktrace in error and fatal logs
+      --name string                 Collection name
       --no-keyring                  Disable the keyring and generate ephemeral keys
       --no-log-color                Disable colored log output
       --rootdir string              Directory for persistent data (default: $HOME/.defradb)

--- a/docs/website/references/cli/defradb_client_collection_delete.md
+++ b/docs/website/references/cli/defradb_client_collection_delete.md
@@ -1,18 +1,19 @@
 ## defradb client collection delete
 
-Delete the active collection versions
+Delete collections
 
 ### Synopsis
 
-Delete the active version of one or more collections by name.
+Delete one or more collections by name.
 
 A single name, or a comma-separated list of names, may be provided. All named
 collections are removed atomically in a single operation. This can be used to
 delete collections that reference each other via relations, since deleting them
 one at a time would leave a dangling reference and be rolled back.
 
-Only the latest (head) version is deleted per call. If a collection has multiple
-versions, earlier versions must be deleted separately after each head is removed.
+By default, every version of each named collection is deleted (active head and
+all earlier versions). Pass --active-only to delete only the latest (head) version
+and keep earlier versions intact.
 
 The named collections must not contain any documents. Delete all documents first
 before deleting the collection.
@@ -24,17 +25,21 @@ defradb client collection delete [collectionNames] [flags]
 ### Examples
 
 ```
-delete a single collection:  
+delete every version of a single collection:  
   defradb client collection delete Users
 
-delete multiple collections in one call (this can be used to delete collections that reference each other via relations):  
+delete every version of multiple collections in one call (this can be used to delete collections that reference each other via relations):  
   defradb client collection delete Users,Books
+
+delete only the active head version, keeping earlier versions:  
+  defradb client collection delete --active-only Users
 ```
 
 ### Options
 
 ```
-  -h, --help   help for delete
+      --active-only   Delete only the active head version of each named collection (default deletes every version)
+  -h, --help          help for delete
 ```
 
 ### Options inherited from parent commands

--- a/docs/website/references/http/openapi.json
+++ b/docs/website/references/http/openapi.json
@@ -1053,6 +1053,34 @@
             }
         },
         "/collections": {
+            "delete": {
+                "description": "Delete the active version of a collection by name",
+                "operationId": "delete_collection",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "name",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/success"
+                    },
+                    "400": {
+                        "$ref": "#/components/responses/error"
+                    },
+                    "default": {
+                        "description": ""
+                    }
+                },
+                "tags": [
+                    "collection"
+                ]
+            },
             "get": {
                 "description": "Introspect collection(s) by name, collection id, or version id.",
                 "operationId": "describe_collection",

--- a/docs/website/references/http/openapi.json
+++ b/docs/website/references/http/openapi.json
@@ -1054,7 +1054,7 @@
         },
         "/collections": {
             "delete": {
-                "description": "Delete the active version of one or more collections. The 'name' query parameter accepts a comma-separated (CSV) list of collection names.",
+                "description": "Delete one or more collections. The 'name' query parameter accepts a comma-separated (CSV) list of collection names. By default every version of each named collection is deleted; set 'active-only=true' to delete only the active head version and keep earlier versions intact.",
                 "operationId": "delete_collection",
                 "parameters": [
                     {
@@ -1063,6 +1063,13 @@
                         "required": true,
                         "schema": {
                             "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "active-only",
+                        "schema": {
+                            "type": "boolean"
                         }
                     }
                 ],

--- a/docs/website/references/http/openapi.json
+++ b/docs/website/references/http/openapi.json
@@ -1054,7 +1054,7 @@
         },
         "/collections": {
             "delete": {
-                "description": "Delete the active version of a collection by name",
+                "description": "Delete the active version of one or more collections. The 'name' query parameter accepts a comma-separated (CSV) list of collection names.",
                 "operationId": "delete_collection",
                 "parameters": [
                     {
@@ -1072,9 +1072,6 @@
                     },
                     "400": {
                         "$ref": "#/components/responses/error"
-                    },
-                    "default": {
-                        "description": ""
                     }
                 },
                 "tags": [

--- a/http/client.go
+++ b/http/client.go
@@ -178,6 +178,9 @@ func (c *Client) DeleteCollection(
 	methodURL := c.http.apiURL.JoinPath("collections")
 	q := methodURL.Query()
 	q.Set("name", strings.Join(names, ","))
+	if opt.ActiveOnly {
+		q.Set("active-only", "true")
+	}
 	methodURL.RawQuery = q.Encode()
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, methodURL.String(), nil)

--- a/http/client.go
+++ b/http/client.go
@@ -169,7 +169,7 @@ func (c *Client) PatchCollection(
 
 func (c *Client) DeleteCollection(
 	ctx context.Context,
-	name string,
+	names []string,
 	opts ...options.Enumerable[options.DeleteCollectionOptions],
 ) error {
 	opt := utils.NewOptions(opts...)
@@ -177,7 +177,9 @@ func (c *Client) DeleteCollection(
 
 	methodURL := c.http.apiURL.JoinPath("collections")
 	q := methodURL.Query()
-	q.Set("name", name)
+	for _, name := range names {
+		q.Add("name", name)
+	}
 	methodURL.RawQuery = q.Encode()
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, methodURL.String(), nil)

--- a/http/client.go
+++ b/http/client.go
@@ -167,6 +167,27 @@ func (c *Client) PatchCollection(
 	return err
 }
 
+func (c *Client) DeleteCollection(
+	ctx context.Context,
+	name string,
+	opts ...options.Enumerable[options.DeleteCollectionOptions],
+) error {
+	opt := utils.NewOptions(opts...)
+	ctx = identity.WithContext(ctx, opt.GetIdentity())
+
+	methodURL := c.http.apiURL.JoinPath("collections")
+	q := methodURL.Query()
+	q.Set("name", name)
+	methodURL.RawQuery = q.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, methodURL.String(), nil)
+	if err != nil {
+		return err
+	}
+	_, err = c.http.request(req)
+	return err
+}
+
 func (c *Client) SetActiveCollectionVersion(
 	ctx context.Context,
 	collectionVersionID string,

--- a/http/client.go
+++ b/http/client.go
@@ -177,9 +177,7 @@ func (c *Client) DeleteCollection(
 
 	methodURL := c.http.apiURL.JoinPath("collections")
 	q := methodURL.Query()
-	for _, name := range names {
-		q.Add("name", name)
-	}
+	q.Set("name", strings.Join(names, ","))
 	methodURL.RawQuery = q.Encode()
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, methodURL.String(), nil)

--- a/http/client_tx.go
+++ b/http/client_tx.go
@@ -145,11 +145,11 @@ func (txn *Transaction) PatchCollection(
 
 func (txn *Transaction) DeleteCollection(
 	ctx context.Context,
-	name string,
+	names []string,
 	opts ...options.Enumerable[options.DeleteCollectionOptions],
 ) error {
 	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
-	return txn.Client.DeleteCollection(ctx, name, opts...)
+	return txn.Client.DeleteCollection(ctx, names, opts...)
 }
 
 func (txn *Transaction) SetActiveCollectionVersion(

--- a/http/client_tx.go
+++ b/http/client_tx.go
@@ -143,6 +143,15 @@ func (txn *Transaction) PatchCollection(
 	return txn.Client.PatchCollection(ctx, patch, migration, opts...)
 }
 
+func (txn *Transaction) DeleteCollection(
+	ctx context.Context,
+	name string,
+	opts ...options.Enumerable[options.DeleteCollectionOptions],
+) error {
+	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
+	return txn.Client.DeleteCollection(ctx, name, opts...)
+}
+
 func (txn *Transaction) SetActiveCollectionVersion(
 	ctx context.Context,
 	version string,

--- a/http/handler_store.go
+++ b/http/handler_store.go
@@ -16,6 +16,7 @@ import (
 	"io"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/getkin/kin-openapi/openapi3"
 
@@ -148,10 +149,9 @@ func (h *storeHandler) DeleteCollection(rw http.ResponseWriter, req *http.Reques
 
 	txn, hadTxn := datastore.CtxTryGetClientTxn(ctx)
 
-	names := req.URL.Query()["name"]
-	if len(names) == 0 {
-		responseJSON(rw, http.StatusBadRequest, errorResponse{client.ErrCollectionNameRequired})
-		return
+	var names []string
+	if joined := req.URL.Query().Get("name"); joined != "" {
+		names = strings.Split(joined, ",")
 	}
 
 	opt := options.WithIdentity(options.DeleteCollection(), identity.FromContext(ctx))
@@ -832,7 +832,8 @@ func (h *storeHandler) bindRoutes(router *Router) {
 
 	deleteCollection := openapi3.NewOperation()
 	deleteCollection.OperationID = "delete_collection"
-	deleteCollection.Description = "Delete the active version of a collection by name"
+	deleteCollection.Description = "Delete the active version of one or more collections. " +
+		"The 'name' query parameter accepts a comma-separated (CSV) list of collection names."
 	deleteCollection.Tags = []string{"collection"}
 	deleteCollection.AddParameter(openapi3.NewQueryParameter("name").
 		WithRequired(true).

--- a/http/handler_store.go
+++ b/http/handler_store.go
@@ -148,8 +148,8 @@ func (h *storeHandler) DeleteCollection(rw http.ResponseWriter, req *http.Reques
 
 	txn, hadTxn := datastore.CtxTryGetClientTxn(ctx)
 
-	name := req.URL.Query().Get("name")
-	if name == "" {
+	names := req.URL.Query()["name"]
+	if len(names) == 0 {
 		responseJSON(rw, http.StatusBadRequest, errorResponse{client.ErrCollectionNameRequired})
 		return
 	}
@@ -159,9 +159,9 @@ func (h *storeHandler) DeleteCollection(rw http.ResponseWriter, req *http.Reques
 	// If there is an explicit transaction, use it. Otherwise use the db.
 	var err error
 	if !hadTxn {
-		err = db.DeleteCollection(ctx, name, opt)
+		err = db.DeleteCollection(ctx, names, opt)
 	} else {
-		err = txn.DeleteCollection(ctx, name, opt)
+		err = txn.DeleteCollection(ctx, names, opt)
 	}
 	if err != nil {
 		responseJSON(rw, httpStatusFromError(err), errorResponse{err})

--- a/http/handler_store.go
+++ b/http/handler_store.go
@@ -154,7 +154,18 @@ func (h *storeHandler) DeleteCollection(rw http.ResponseWriter, req *http.Reques
 		names = strings.Split(joined, ",")
 	}
 
+	var activeOnly bool
+	if raw := req.URL.Query().Get("active-only"); raw != "" {
+		parsed, err := strconv.ParseBool(raw)
+		if err != nil {
+			responseJSON(rw, http.StatusBadRequest, errorResponse{err})
+			return
+		}
+		activeOnly = parsed
+	}
+
 	opt := options.WithIdentity(options.DeleteCollection(), identity.FromContext(ctx))
+	opt.SetActiveOnly(activeOnly)
 
 	// If there is an explicit transaction, use it. Otherwise use the db.
 	var err error
@@ -832,12 +843,17 @@ func (h *storeHandler) bindRoutes(router *Router) {
 
 	deleteCollection := openapi3.NewOperation()
 	deleteCollection.OperationID = "delete_collection"
-	deleteCollection.Description = "Delete the active version of one or more collections. " +
-		"The 'name' query parameter accepts a comma-separated (CSV) list of collection names."
+	deleteCollection.Description = "Delete one or more collections. " +
+		"The 'name' query parameter accepts a comma-separated (CSV) list of collection names. " +
+		"By default every version of each named collection is deleted; set 'active-only=true' " +
+		"to delete only the active head version and keep earlier versions intact."
 	deleteCollection.Tags = []string{"collection"}
 	deleteCollection.AddParameter(openapi3.NewQueryParameter("name").
 		WithRequired(true).
 		WithSchema(openapi3.NewStringSchema()))
+	deleteCollection.AddParameter(openapi3.NewQueryParameter("active-only").
+		WithRequired(false).
+		WithSchema(openapi3.NewBoolSchema()))
 	deleteCollection.Responses = openapi3.NewResponses()
 	deleteCollection.Responses.Set("200", successResponse)
 	deleteCollection.Responses.Set("400", errorResponse)

--- a/http/handler_store.go
+++ b/http/handler_store.go
@@ -142,6 +142,35 @@ func (h *storeHandler) PatchCollection(rw http.ResponseWriter, req *http.Request
 	rw.WriteHeader(http.StatusOK)
 }
 
+func (h *storeHandler) DeleteCollection(rw http.ResponseWriter, req *http.Request) {
+	db := mustGetContextClientDB(req)
+	ctx := req.Context()
+
+	txn, hadTxn := datastore.CtxTryGetClientTxn(ctx)
+
+	name := req.URL.Query().Get("name")
+	if name == "" {
+		responseJSON(rw, http.StatusBadRequest, errorResponse{client.ErrCollectionNameRequired})
+		return
+	}
+
+	opt := options.WithIdentity(options.DeleteCollection(), identity.FromContext(ctx))
+
+	// If there is an explicit transaction, use it. Otherwise use the db.
+	var err error
+	if !hadTxn {
+		err = db.DeleteCollection(ctx, name, opt)
+	} else {
+		err = txn.DeleteCollection(ctx, name, opt)
+	}
+	if err != nil {
+		responseJSON(rw, httpStatusFromError(err), errorResponse{err})
+		return
+	}
+
+	rw.WriteHeader(http.StatusOK)
+}
+
 func (h *storeHandler) SetActiveCollectionVersion(rw http.ResponseWriter, req *http.Request) {
 	db := mustGetContextClientDB(req)
 	ctx := req.Context()
@@ -801,6 +830,17 @@ func (h *storeHandler) bindRoutes(router *Router) {
 	patchCollection.Responses.Set("200", successResponse)
 	patchCollection.Responses.Set("400", errorResponse)
 
+	deleteCollection := openapi3.NewOperation()
+	deleteCollection.OperationID = "delete_collection"
+	deleteCollection.Description = "Delete the active version of a collection by name"
+	deleteCollection.Tags = []string{"collection"}
+	deleteCollection.AddParameter(openapi3.NewQueryParameter("name").
+		WithRequired(true).
+		WithSchema(openapi3.NewStringSchema()))
+	deleteCollection.Responses = openapi3.NewResponses()
+	deleteCollection.Responses.Set("200", successResponse)
+	deleteCollection.Responses.Set("400", errorResponse)
+
 	addViewResponseSchema := openapi3.NewOneOfSchema()
 	addViewResponseSchema.OneOf = openapi3.SchemaRefs{
 		collectionSchema,
@@ -983,6 +1023,7 @@ func (h *storeHandler) bindRoutes(router *Router) {
 	router.AddRoute("/backup/import", http.MethodPost, importBackup, h.BasicImport)
 	router.AddRoute("/collections", http.MethodGet, describeCollection, h.GetCollection)
 	router.AddRoute("/collections", http.MethodPatch, patchCollection, h.PatchCollection)
+	router.AddRoute("/collections", http.MethodDelete, deleteCollection, h.DeleteCollection)
 	router.AddRoute("/collections/indexes", http.MethodGet, listIndexes, h.ListIndexes)
 	router.AddRoute("/encrypted-indexes", http.MethodGet, listEncryptedIndexes, h.ListAllEncryptedIndexes)
 	router.AddRoute("/collections/default", http.MethodPost, setActiveCollectionVersion, h.SetActiveCollectionVersion)

--- a/internal/db/collection_define.go
+++ b/internal/db/collection_define.go
@@ -195,6 +195,10 @@ existingVersionLoop:
 		}
 	}
 
+	if err := validateRemovedCollectionsNotReferenced(removedCollectionVersions, newColsByID); err != nil {
+		return err
+	}
+
 	for _, col := range newColsByID {
 		// Automatically add any id fields for object fields added by the patch, if the patch did not explicitly
 		// add one.
@@ -379,6 +383,42 @@ existingVersionLoop:
 	}
 
 	return db.loadCollectionDefinitions(ctx)
+}
+
+// validateRemovedCollectionsNotReferenced errors if any field in the post-patch state
+// references a collection that is being removed by the patch. It surfaces which removed
+// collection is still being referenced via the host field name.
+func validateRemovedCollectionsNotReferenced(
+	removed []client.CollectionVersion,
+	newColsByID map[string]client.CollectionVersion,
+) error {
+	if len(removed) == 0 {
+		return nil
+	}
+	removedNames := make(map[string]struct{}, len(removed))
+	removedColIDs := make(map[string]struct{}, len(removed))
+	for _, r := range removed {
+		removedNames[r.Name] = struct{}{}
+		removedColIDs[r.CollectionID] = struct{}{}
+	}
+	for _, col := range newColsByID {
+		for _, field := range col.Fields {
+			if !field.Kind.IsObject() {
+				continue
+			}
+			switch k := field.Kind.(type) {
+			case *client.NamedKind:
+				if _, ok := removedNames[k.Name]; ok {
+					return NewErrRemoveReferencedCollectionFromField(removed, col.Name, field.Name)
+				}
+			case *client.CollectionKind:
+				if _, ok := removedColIDs[k.CollectionID]; ok {
+					return NewErrRemoveReferencedCollectionFromField(removed, col.Name, field.Name)
+				}
+			}
+		}
+	}
+	return nil
 }
 
 const (

--- a/internal/db/collection_define.go
+++ b/internal/db/collection_define.go
@@ -195,10 +195,6 @@ existingVersionLoop:
 		}
 	}
 
-	if err := validateRemovedCollectionsNotReferenced(removedCollectionVersions, newColsByID); err != nil {
-		return err
-	}
-
 	for _, col := range newColsByID {
 		// Automatically add any id fields for object fields added by the patch, if the patch did not explicitly
 		// add one.
@@ -253,18 +249,23 @@ existingVersionLoop:
 			}
 		}
 
-		// If an existing collection is not present in the new collection set,
-		// it must have mutated into a new collection version.
-		// The original still needs to exist and must be validated against.
-		// It may also be mutated later in this function.
+		// If an existing collection is not present in the new collection set, it has either
+		// been mutated into a new version (a replacement with the same CollectionID exists) or
+		// explicitly removed by the patch (no replacement). For the mutation case we re-add the
+		// original as inactive so it can be validated against and saved alongside the new
+		// version. For the removal case we leave it out so validation sees the deletion.
 		if isMissing {
+			var hasReplacement bool
 			for _, newCol := range newCollections {
 				if newCol.CollectionID == existingCol.CollectionID && newCol.IsActive {
 					existingCol.IsActive = false
+					hasReplacement = true
 					break
 				}
 			}
-			newCollections = append(newCollections, existingCol)
+			if hasReplacement {
+				newCollections = append(newCollections, existingCol)
+			}
 		}
 	}
 
@@ -383,42 +384,6 @@ existingVersionLoop:
 	}
 
 	return db.loadCollectionDefinitions(ctx)
-}
-
-// validateRemovedCollectionsNotReferenced errors if any field in the post-patch state
-// references a collection that is being removed by the patch. It surfaces which removed
-// collection is still being referenced via the host field name.
-func validateRemovedCollectionsNotReferenced(
-	removed []client.CollectionVersion,
-	newColsByID map[string]client.CollectionVersion,
-) error {
-	if len(removed) == 0 {
-		return nil
-	}
-	removedNames := make(map[string]struct{}, len(removed))
-	removedColIDs := make(map[string]struct{}, len(removed))
-	for _, r := range removed {
-		removedNames[r.Name] = struct{}{}
-		removedColIDs[r.CollectionID] = struct{}{}
-	}
-	for _, col := range newColsByID {
-		for _, field := range col.Fields {
-			if !field.Kind.IsObject() {
-				continue
-			}
-			switch k := field.Kind.(type) {
-			case *client.NamedKind:
-				if _, ok := removedNames[k.Name]; ok {
-					return NewErrRemoveReferencedCollectionFromField(removed, col.Name, field.Name)
-				}
-			case *client.CollectionKind:
-				if _, ok := removedColIDs[k.CollectionID]; ok {
-					return NewErrRemoveReferencedCollectionFromField(removed, col.Name, field.Name)
-				}
-			}
-		}
-	}
-	return nil
 }
 
 const (

--- a/internal/db/definition_validation.go
+++ b/internal/db/definition_validation.go
@@ -236,10 +236,20 @@ func validateRelationPointsToValidKind(
 				continue
 			}
 
-			_, ok := newState.getCollection(col, field.Kind)
-			if !ok {
-				errs = append(errs, NewErrFieldKindNotFound(field.Name, field.Kind.String()))
+			if _, ok := newState.getCollection(col, field.Kind); ok {
+				continue
 			}
+
+			// The kind cannot be resolved in the new state. If it could be resolved in the
+			// old state then the patch is removing a collection that another field still
+			// references; surface that with a more specific error so the caller knows what
+			// they need to remove or repoint first.
+			if removed, wasPresent := oldState.getCollection(col, field.Kind); wasPresent {
+				errs = append(errs, NewErrRemoveReferencedCollectionFromField(removed.Name, col.Name, field.Name))
+				continue
+			}
+
+			errs = append(errs, NewErrFieldKindNotFound(field.Name, field.Kind.String()))
 		}
 	}
 

--- a/internal/db/errors.go
+++ b/internal/db/errors.go
@@ -12,6 +12,7 @@ package db
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/libp2p/go-libp2p/core/peer"
 
@@ -28,6 +29,7 @@ const (
 	errAddingP2PCollection                       string = "cannot add collection ID"
 	errRemovingP2PCollection                     string = "cannot remove collection ID"
 	errAddCollectionWithPatch                    string = "adding collections via patch is not supported"
+	errRemoveReferencedCollection                string = "cannot remove a collection while another field references it"
 	errCollectionIDDoesntMatch                   string = "CollectionID does not match existing"
 	errCollectionRootDoesntMatch                 string = "CollectionRoot does not match existing"
 	errCannotSetVersionID                        string = "setting the VersionID is not supported"
@@ -218,6 +220,7 @@ var (
 	ErrCollectionIDCannotBeEmpty                 = errors.New(errCollectionIDCannotBeEmpty)
 	ErrCannotDeleteOldVersion                    = errors.New(errCannotDeleteOldVersion)
 	ErrCanNotHavePolicyWithoutACP                = errors.New(errCanNotHavePolicyWithoutACP)
+	ErrRemoveReferencedCollection                = errors.New(errRemoveReferencedCollection)
 	ErrRelationMissingField                      = errors.New(errRelationMissingField)
 	ErrMultipleRelationPrimaries                 = errors.New(errMultipleRelationPrimaries)
 	ErrP2PColHasPolicy                           = errors.New(errP2PColHasPolicy)
@@ -353,6 +356,34 @@ func NewErrAddCollectionWithPatch(name string) error {
 	return errors.New(
 		errAddCollectionWithPatch,
 		errors.NewKV("Name", name),
+	)
+}
+
+func NewErrRemoveReferencedCollection(inner error, removed []string) error {
+	return errors.Wrap(
+		errRemoveReferencedCollection,
+		inner,
+		errors.NewKV("Removed", strings.Join(removed, ",")),
+	)
+}
+
+// NewErrRemoveReferencedCollectionFromField errors when a patch removes a collection
+// that is still being referenced by a field on another collection in the post-patch
+// state. It identifies which removed collection(s) are still in use and the host
+// collection/field doing the referencing.
+func NewErrRemoveReferencedCollectionFromField(
+	removed []client.CollectionVersion,
+	hostCollection, hostField string,
+) error {
+	names := make([]string, 0, len(removed))
+	for _, c := range removed {
+		names = append(names, c.Name)
+	}
+	return errors.New(
+		errRemoveReferencedCollection,
+		errors.NewKV("Removed", strings.Join(names, ",")),
+		errors.NewKV("ReferencedBy", hostCollection),
+		errors.NewKV("Field", hostField),
 	)
 }
 

--- a/internal/db/errors.go
+++ b/internal/db/errors.go
@@ -369,19 +369,12 @@ func NewErrRemoveReferencedCollection(inner error, removed []string) error {
 
 // NewErrRemoveReferencedCollectionFromField errors when a patch removes a collection
 // that is still being referenced by a field on another collection in the post-patch
-// state. It identifies which removed collection(s) are still in use and the host
+// state. It identifies which removed collection is still in use and the host
 // collection/field doing the referencing.
-func NewErrRemoveReferencedCollectionFromField(
-	removed []client.CollectionVersion,
-	hostCollection, hostField string,
-) error {
-	names := make([]string, 0, len(removed))
-	for _, c := range removed {
-		names = append(names, c.Name)
-	}
+func NewErrRemoveReferencedCollectionFromField(removedName, hostCollection, hostField string) error {
 	return errors.New(
 		errRemoveReferencedCollection,
-		errors.NewKV("Removed", strings.Join(names, ",")),
+		errors.NewKV("Removed", removedName),
 		errors.NewKV("ReferencedBy", hostCollection),
 		errors.NewKV("Field", hostField),
 	)

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -12,6 +12,7 @@ package db
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/sourcenetwork/lens/host-go/config/model"
 
@@ -243,6 +244,45 @@ func (db *DB) PatchCollection(
 	}
 
 	return txn.Commit()
+}
+
+func (db *DB) DeleteCollection(
+	ctx context.Context,
+	name string,
+	opts ...options.Enumerable[options.DeleteCollectionOptions],
+) error {
+	ctx, span := tracer.Start(ctx)
+	defer span.End()
+
+	opt := utils.NewOptions(opts...)
+
+	if err := db.checkNodeAccess(ctx, opt.Identity, acpTypes.NodePatchCollectionPerm); err != nil {
+		return err
+	}
+
+	ctx, txn, err := ensureContextTxn(ctx, db, false)
+	if err != nil {
+		return err
+	}
+
+	defer txn.Discard()
+
+	err = db.deleteCollection(ctx, name)
+	if err != nil {
+		return err
+	}
+
+	return txn.Commit()
+}
+
+func (db *DB) deleteCollection(ctx context.Context, name string) error {
+	col, err := db.getCollectionByName(ctx, name)
+	if err != nil {
+		return err
+	}
+
+	patch := fmt.Sprintf(`[{"op": "remove", "path": "/%s"}]`, col.Version().VersionID)
+	return db.patchCollection(ctx, patch, immutable.None[model.Lens]())
 }
 
 func (db *DB) SetActiveCollectionVersion(

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -23,6 +23,7 @@ import (
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/options"
 	"github.com/sourcenetwork/defradb/internal/datastore"
+	"github.com/sourcenetwork/defradb/internal/db/description"
 	"github.com/sourcenetwork/defradb/internal/identity"
 	"github.com/sourcenetwork/defradb/internal/utils"
 )
@@ -268,7 +269,7 @@ func (db *DB) DeleteCollection(
 
 	defer txn.Discard()
 
-	err = db.deleteCollection(ctx, names)
+	err = db.deleteCollection(ctx, names, opt.ActiveOnly)
 	if err != nil {
 		return err
 	}
@@ -276,7 +277,7 @@ func (db *DB) DeleteCollection(
 	return txn.Commit()
 }
 
-func (db *DB) deleteCollection(ctx context.Context, names []string) error {
+func (db *DB) deleteCollection(ctx context.Context, names []string, activeOnly bool) error {
 	if len(names) == 0 {
 		return client.ErrCollectionNameRequired
 	}
@@ -293,7 +294,21 @@ func (db *DB) deleteCollection(ctx context.Context, names []string) error {
 		if err != nil {
 			return err
 		}
-		ops = append(ops, fmt.Sprintf(`{"op": "remove", "path": "/%s"}`, col.Version().VersionID))
+
+		if activeOnly {
+			ops = append(ops, fmt.Sprintf(`{"op": "remove", "path": "/%s"}`, col.Version().VersionID))
+			continue
+		}
+
+		allVersions, err := description.GetCollectionsByCollectionID(
+			ctx, db.collectionRepository, col.Version().CollectionID,
+		)
+		if err != nil {
+			return err
+		}
+		for _, v := range allVersions {
+			ops = append(ops, fmt.Sprintf(`{"op": "remove", "path": "/%s"}`, v.VersionID))
+		}
 	}
 
 	patch := "[" + strings.Join(ops, ",") + "]"

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -13,6 +13,7 @@ package db
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/sourcenetwork/lens/host-go/config/model"
 
@@ -248,7 +249,7 @@ func (db *DB) PatchCollection(
 
 func (db *DB) DeleteCollection(
 	ctx context.Context,
-	name string,
+	names []string,
 	opts ...options.Enumerable[options.DeleteCollectionOptions],
 ) error {
 	ctx, span := tracer.Start(ctx)
@@ -267,7 +268,7 @@ func (db *DB) DeleteCollection(
 
 	defer txn.Discard()
 
-	err = db.deleteCollection(ctx, name)
+	err = db.deleteCollection(ctx, names)
 	if err != nil {
 		return err
 	}
@@ -275,13 +276,27 @@ func (db *DB) DeleteCollection(
 	return txn.Commit()
 }
 
-func (db *DB) deleteCollection(ctx context.Context, name string) error {
-	col, err := db.getCollectionByName(ctx, name)
-	if err != nil {
-		return err
+func (db *DB) deleteCollection(ctx context.Context, names []string) error {
+	if len(names) == 0 {
+		return client.ErrCollectionNameRequired
 	}
 
-	patch := fmt.Sprintf(`[{"op": "remove", "path": "/%s"}]`, col.Version().VersionID)
+	seen := make(map[string]struct{}, len(names))
+	ops := make([]string, 0, len(names))
+	for _, name := range names {
+		if _, dup := seen[name]; dup {
+			continue
+		}
+		seen[name] = struct{}{}
+
+		col, err := db.getCollectionByName(ctx, name)
+		if err != nil {
+			return err
+		}
+		ops = append(ops, fmt.Sprintf(`{"op": "remove", "path": "/%s"}`, col.Version().VersionID))
+	}
+
+	patch := "[" + strings.Join(ops, ",") + "]"
 	return db.patchCollection(ctx, patch, immutable.None[model.Lens]())
 }
 

--- a/internal/db/txn.go
+++ b/internal/db/txn.go
@@ -376,11 +376,11 @@ func (txn *Txn) PatchCollection(
 
 func (txn *Txn) DeleteCollection(
 	ctx context.Context,
-	name string,
+	names []string,
 	opts ...options.Enumerable[options.DeleteCollectionOptions],
 ) error {
 	ctx = InitContext(ctx, txn)
-	return txn.db.DeleteCollection(ctx, name, opts...)
+	return txn.db.DeleteCollection(ctx, names, opts...)
 }
 
 func (txn *Txn) SetActiveCollectionVersion(

--- a/internal/db/txn.go
+++ b/internal/db/txn.go
@@ -374,6 +374,15 @@ func (txn *Txn) PatchCollection(
 	return txn.db.PatchCollection(ctx, patch, migration, opts...)
 }
 
+func (txn *Txn) DeleteCollection(
+	ctx context.Context,
+	name string,
+	opts ...options.Enumerable[options.DeleteCollectionOptions],
+) error {
+	ctx = InitContext(ctx, txn)
+	return txn.db.DeleteCollection(ctx, name, opts...)
+}
+
 func (txn *Txn) SetActiveCollectionVersion(
 	ctx context.Context,
 	version string,

--- a/internal/request/graphql/schema/errors.go
+++ b/internal/request/graphql/schema/errors.go
@@ -141,6 +141,15 @@ func NewErrTypeNotFound(typeName string) error {
 	)
 }
 
+func NewErrTypeNotFoundOnField(typeName, referencedBy, fieldName string) error {
+	return errors.New(
+		errTypeNotFound,
+		errors.NewKV("Type", typeName),
+		errors.NewKV("ReferencedBy", referencedBy),
+		errors.NewKV("Field", fieldName),
+	)
+}
+
 func NewErrNonNullForTypeNotSupported(typeName string) error {
 	return errors.New(
 		errNonNullForTypeNotSupported,

--- a/internal/request/graphql/schema/generate.go
+++ b/internal/request/graphql/schema/generate.go
@@ -511,7 +511,7 @@ func (g *Generator) buildTypes(
 				if ok {
 					ttype, ok = g.manager.schema.TypeMap()[otherDef.Name]
 					if !ok {
-						return nil, NewErrTypeNotFound(field.Kind.String())
+						return nil, NewErrTypeNotFoundOnField(otherDef.Name, collection.Name, field.Name)
 					}
 					if field.Kind.IsArray() {
 						ttype = gql.NewList(ttype)
@@ -520,7 +520,7 @@ func (g *Generator) buildTypes(
 					var ok bool
 					ttype, ok = fieldKindToGQLType[field.Kind]
 					if !ok {
-						return nil, NewErrTypeNotFound(field.Kind.String())
+						return nil, NewErrTypeNotFoundOnField(field.Kind.String(), collection.Name, field.Name)
 					}
 				}
 

--- a/js/client.go
+++ b/js/client.go
@@ -41,6 +41,7 @@ func (c *Client) JSValue() js.Value {
 	return js.ValueOf(map[string]any{
 		"addCollection":              goji.Async(c.addCollection),
 		"patchCollection":            goji.Async(c.patchCollection),
+		"deleteCollection":           goji.Async(c.deleteCollection),
 		"setActiveCollectionVersion": goji.Async(c.setActiveCollectionVersion),
 		"addView":                    goji.Async(c.addView),
 		"refreshViews":               goji.Async(c.refreshViews),

--- a/js/client_store.go
+++ b/js/client_store.go
@@ -78,12 +78,17 @@ func (c *Client) deleteCollection(this js.Value, args []js.Value) (js.Value, err
 	if err := structArg(args, 0, "names", &names); err != nil {
 		return js.Undefined(), err
 	}
-	ctx, err := contextArg(args, 1, c.txns)
+	activeOnly, err := boolArg(args, 1, "activeOnly")
+	if err != nil {
+		return js.Undefined(), err
+	}
+	ctx, err := contextArg(args, 2, c.txns)
 	if err != nil {
 		return js.Undefined(), err
 	}
 	opt := options.DeleteCollection()
-	setOptIdentity(opt, args, 1)
+	setOptIdentity(opt, args, 2)
+	opt.SetActiveOnly(activeOnly)
 	err = c.node.DB.DeleteCollection(ctx, names, opt)
 	return js.Undefined(), err
 }

--- a/js/client_store.go
+++ b/js/client_store.go
@@ -73,6 +73,21 @@ func (c *Client) patchCollection(this js.Value, args []js.Value) (js.Value, erro
 	return js.Undefined(), err
 }
 
+func (c *Client) deleteCollection(this js.Value, args []js.Value) (js.Value, error) {
+	name, err := stringArg(args, 0, "name")
+	if err != nil {
+		return js.Undefined(), err
+	}
+	ctx, err := contextArg(args, 1, c.txns)
+	if err != nil {
+		return js.Undefined(), err
+	}
+	opt := options.DeleteCollection()
+	setOptIdentity(opt, args, 1)
+	err = c.node.DB.DeleteCollection(ctx, name, opt)
+	return js.Undefined(), err
+}
+
 func (c *Client) setActiveCollectionVersion(this js.Value, args []js.Value) (js.Value, error) {
 	version, err := stringArg(args, 0, "version")
 	if err != nil {

--- a/js/client_store.go
+++ b/js/client_store.go
@@ -82,14 +82,20 @@ func (c *Client) deleteCollection(this js.Value, args []js.Value) (js.Value, err
 	if err != nil {
 		return js.Undefined(), err
 	}
-	ctx, err := contextArg(args, 2, c.txns)
+	ctx, err := contextArg(args, 2)
 	if err != nil {
 		return js.Undefined(), err
 	}
+
+	store, err := contextStoreArg(c.node.DB, args, 2, c.txns)
+	if err != nil {
+		return js.Undefined(), err
+	}
+
 	opt := options.DeleteCollection()
 	setOptIdentity(opt, args, 2)
 	opt.SetActiveOnly(activeOnly)
-	err = c.node.DB.DeleteCollection(ctx, names, opt)
+	err = store.DeleteCollection(ctx, names, opt)
 	return js.Undefined(), err
 }
 

--- a/js/client_store.go
+++ b/js/client_store.go
@@ -74,8 +74,8 @@ func (c *Client) patchCollection(this js.Value, args []js.Value) (js.Value, erro
 }
 
 func (c *Client) deleteCollection(this js.Value, args []js.Value) (js.Value, error) {
-	name, err := stringArg(args, 0, "name")
-	if err != nil {
+	var names []string
+	if err := structArg(args, 0, "names", &names); err != nil {
 		return js.Undefined(), err
 	}
 	ctx, err := contextArg(args, 1, c.txns)
@@ -84,7 +84,7 @@ func (c *Client) deleteCollection(this js.Value, args []js.Value) (js.Value, err
 	}
 	opt := options.DeleteCollection()
 	setOptIdentity(opt, args, 1)
-	err = c.node.DB.DeleteCollection(ctx, name, opt)
+	err = c.node.DB.DeleteCollection(ctx, names, opt)
 	return js.Undefined(), err
 }
 

--- a/js/client_tx.go
+++ b/js/client_tx.go
@@ -113,8 +113,8 @@ func (t *transaction) patchCollection(this js.Value, args []js.Value) (js.Value,
 }
 
 func (t *transaction) deleteCollection(this js.Value, args []js.Value) (js.Value, error) {
-	name, err := stringArg(args, 0, "name")
-	if err != nil {
+	var names []string
+	if err := structArg(args, 0, "names", &names); err != nil {
 		return js.Undefined(), err
 	}
 	ctx, err := contextArg(args, 1, t.txns)
@@ -123,7 +123,7 @@ func (t *transaction) deleteCollection(this js.Value, args []js.Value) (js.Value
 	}
 	opt := options.DeleteCollection()
 	setOptIdentity(opt, args, 1)
-	err = t.txn.DeleteCollection(ctx, name, opt)
+	err = t.txn.DeleteCollection(ctx, names, opt)
 	return js.Undefined(), err
 }
 

--- a/js/client_tx.go
+++ b/js/client_tx.go
@@ -121,7 +121,7 @@ func (t *transaction) deleteCollection(this js.Value, args []js.Value) (js.Value
 	if err != nil {
 		return js.Undefined(), err
 	}
-	ctx, err := contextArg(args, 2, t.txns)
+	ctx, err := contextArg(args, 2)
 	if err != nil {
 		return js.Undefined(), err
 	}

--- a/js/client_tx.go
+++ b/js/client_tx.go
@@ -40,6 +40,7 @@ func newTransaction(txn client.Txn, txns *sync.Map) js.Value {
 		"discard":                    goji.Async(wrapper.discard),
 		"addCollection":              goji.Async(wrapper.addCollection),
 		"patchCollection":            goji.Async(wrapper.patchCollection),
+		"deleteCollection":           goji.Async(wrapper.deleteCollection),
 		"setActiveCollectionVersion": goji.Async(wrapper.setActiveCollectionVersion),
 		"addView":                    goji.Async(wrapper.addView),
 		"refreshViews":               goji.Async(wrapper.refreshViews),
@@ -108,6 +109,21 @@ func (t *transaction) patchCollection(this js.Value, args []js.Value) (js.Value,
 	opt := options.PatchCollection()
 	setOptIdentity(opt, args, 2)
 	err = t.txn.PatchCollection(ctx, patch, migration, opt)
+	return js.Undefined(), err
+}
+
+func (t *transaction) deleteCollection(this js.Value, args []js.Value) (js.Value, error) {
+	name, err := stringArg(args, 0, "name")
+	if err != nil {
+		return js.Undefined(), err
+	}
+	ctx, err := contextArg(args, 1, t.txns)
+	if err != nil {
+		return js.Undefined(), err
+	}
+	opt := options.DeleteCollection()
+	setOptIdentity(opt, args, 1)
+	err = t.txn.DeleteCollection(ctx, name, opt)
 	return js.Undefined(), err
 }
 

--- a/js/client_tx.go
+++ b/js/client_tx.go
@@ -117,12 +117,17 @@ func (t *transaction) deleteCollection(this js.Value, args []js.Value) (js.Value
 	if err := structArg(args, 0, "names", &names); err != nil {
 		return js.Undefined(), err
 	}
-	ctx, err := contextArg(args, 1, t.txns)
+	activeOnly, err := boolArg(args, 1, "activeOnly")
+	if err != nil {
+		return js.Undefined(), err
+	}
+	ctx, err := contextArg(args, 2, t.txns)
 	if err != nil {
 		return js.Undefined(), err
 	}
 	opt := options.DeleteCollection()
-	setOptIdentity(opt, args, 1)
+	setOptIdentity(opt, args, 2)
+	opt.SetActiveOnly(activeOnly)
 	err = t.txn.DeleteCollection(ctx, names, opt)
 	return js.Undefined(), err
 }

--- a/tests/action/delete_collection.go
+++ b/tests/action/delete_collection.go
@@ -1,0 +1,88 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// This file is part of the DefraDB test suite.
+//
+// The DefraDB test suite is licensed under either:
+//
+//   (1) GNU Affero General Public License v3
+//   (2) Business Source License 1.1
+//
+// See tests/LICENSE for details.
+
+package action
+
+import (
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcenetwork/defradb/client"
+	"github.com/sourcenetwork/defradb/client/options"
+	"github.com/sourcenetwork/defradb/tests/state"
+	"github.com/sourcenetwork/immutable"
+)
+
+// DeleteCollection deletes the active version of a collection by name.
+//
+// Only the latest (head) version is deleted per call. If the collection has multiple
+// versions, earlier versions must be deleted separately after each head is removed.
+//
+// The collection must not contain any documents - they must be deleted first.
+type DeleteCollection struct {
+	stateful
+
+	// NodeID may hold the ID (index) of a node to apply this delete to.
+	//
+	// If a value is not provided the delete will be applied to all nodes.
+	NodeID immutable.Option[int]
+
+	// The identity of this request. Optional.
+	//
+	// If node acp is enabled, identity will be used to check if this operation can be performed.
+	Identity immutable.Option[state.Identity]
+
+	// The name of the collection to delete.
+	Name string
+
+	// Any error expected from the action. Optional.
+	//
+	// String can be a partial, and the test will pass if an error is returned that
+	// contains this string.
+	ExpectedError string
+
+	// Used to identify the transaction for this to be executed in. Optional.
+	TransactionID immutable.Option[int]
+}
+
+var _ Action = (*DeleteCollection)(nil)
+var _ Stateful = (*DeleteCollection)(nil)
+
+// Execute executes the delete collection action.
+func (a *DeleteCollection) Execute() {
+	nodeIDs, nodes := getNodesWithIDs(a.NodeID, a.s.Nodes)
+	for index, node := range nodes {
+		nodeID := nodeIDs[index]
+
+		opts := options.DeleteCollection()
+		identOption := getIdentityForRequestSpecificToNode(a.s, a.Identity, nodeID)
+		if identOption.HasValue() {
+			opts.SetIdentity(identOption.Value())
+		}
+
+		var txn client.Txn
+		var err error
+		if a.TransactionID.HasValue() {
+			txn, err = a.s.GetTransaction(node, a.TransactionID)
+			require.NoError(a.s.T, err)
+			err = txn.DeleteCollection(a.s.Ctx, a.Name, opts)
+		} else {
+			err = node.DeleteCollection(a.s.Ctx, a.Name, opts)
+		}
+
+		expectedErrorRaised := assertError(a.s.T, err, a.ExpectedError)
+
+		assertExpectedErrorRaised(a.s.T, a.ExpectedError, expectedErrorRaised)
+	}
+
+	if !a.TransactionID.HasValue() {
+		RefreshCollections(a.s)
+	}
+}

--- a/tests/action/delete_collection.go
+++ b/tests/action/delete_collection.go
@@ -20,12 +20,17 @@ import (
 	"github.com/sourcenetwork/immutable"
 )
 
-// DeleteCollection deletes the active version of a collection by name.
+// DeleteCollection deletes the active versions of one or more collections by name.
 //
-// Only the latest (head) version is deleted per call. If the collection has multiple
-// versions, earlier versions must be deleted separately after each head is removed.
+// All named collections are removed atomically in a single operation. This can be used
+// to delete collections that reference each other via relations, since removing them
+// one at a time would leave a dangling reference and be rolled back.
 //
-// The collection must not contain any documents - they must be deleted first.
+// Only the latest (head) version of each named collection is deleted per call. If a
+// collection has multiple versions, earlier versions must be deleted separately after
+// each head is removed.
+//
+// The collections must not contain any documents - they must be deleted first.
 type DeleteCollection struct {
 	stateful
 
@@ -39,8 +44,11 @@ type DeleteCollection struct {
 	// If node acp is enabled, identity will be used to check if this operation can be performed.
 	Identity immutable.Option[state.Identity]
 
-	// The name of the collection to delete.
-	Name string
+	// Names is the list of collection names to delete atomically.
+	//
+	// A single-name delete is just a one-element slice; the underlying API handles
+	// one or many names uniformly.
+	Names []string
 
 	// Any error expected from the action. Optional.
 	//
@@ -72,9 +80,9 @@ func (a *DeleteCollection) Execute() {
 		if a.TransactionID.HasValue() {
 			txn, err = a.s.GetTransaction(node, a.TransactionID)
 			require.NoError(a.s.T, err)
-			err = txn.DeleteCollection(a.s.Ctx, a.Name, opts)
+			err = txn.DeleteCollection(a.s.Ctx, a.Names, opts)
 		} else {
-			err = node.DeleteCollection(a.s.Ctx, a.Name, opts)
+			err = node.DeleteCollection(a.s.Ctx, a.Names, opts)
 		}
 
 		expectedErrorRaised := assertError(a.s.T, err, a.ExpectedError)

--- a/tests/action/delete_collection.go
+++ b/tests/action/delete_collection.go
@@ -20,15 +20,15 @@ import (
 	"github.com/sourcenetwork/immutable"
 )
 
-// DeleteCollection deletes the active versions of one or more collections by name.
+// DeleteCollection deletes one or more collections by name.
 //
 // All named collections are removed atomically in a single operation. This can be used
 // to delete collections that reference each other via relations, since removing them
 // one at a time would leave a dangling reference and be rolled back.
 //
-// Only the latest (head) version of each named collection is deleted per call. If a
-// collection has multiple versions, earlier versions must be deleted separately after
-// each head is removed.
+// By default, every version of each named collection is deleted (active head and all
+// earlier versions). Set ActiveOnly to true to delete only the latest (head) version
+// and keep earlier versions intact.
 //
 // The collections must not contain any documents - they must be deleted first.
 type DeleteCollection struct {
@@ -49,6 +49,11 @@ type DeleteCollection struct {
 	// A single-name delete is just a one-element slice; the underlying API handles
 	// one or many names uniformly.
 	Names []string
+
+	// ActiveOnly limits the delete to only the active head version of each named
+	// collection. When false (the default) every version of each named collection
+	// is removed.
+	ActiveOnly bool
 
 	// Any error expected from the action. Optional.
 	//
@@ -74,6 +79,7 @@ func (a *DeleteCollection) Execute() {
 		if identOption.HasValue() {
 			opts.SetIdentity(identOption.Value())
 		}
+		opts.SetActiveOnly(a.ActiveOnly)
 
 		var txn client.Txn
 		var err error

--- a/tests/clients/cli/wrapper.go
+++ b/tests/clients/cli/wrapper.go
@@ -425,10 +425,10 @@ func (w *Wrapper) PatchCollection(
 
 func (w *Wrapper) DeleteCollection(
 	ctx context.Context,
-	name string,
+	names []string,
 	opts ...options.Enumerable[options.DeleteCollectionOptions],
 ) error {
-	args := []string{"client", "collection", "delete", "--name", name}
+	args := []string{"client", "collection", "delete", strings.Join(names, ",")}
 
 	opt := utils.NewOptions(opts...)
 	args = appendIdentityArg(args, opt.GetIdentity())

--- a/tests/clients/cli/wrapper.go
+++ b/tests/clients/cli/wrapper.go
@@ -423,6 +423,20 @@ func (w *Wrapper) PatchCollection(
 	return err
 }
 
+func (w *Wrapper) DeleteCollection(
+	ctx context.Context,
+	name string,
+	opts ...options.Enumerable[options.DeleteCollectionOptions],
+) error {
+	args := []string{"client", "collection", "delete", "--name", name}
+
+	opt := utils.NewOptions(opts...)
+	args = appendIdentityArg(args, opt.GetIdentity())
+
+	_, err := w.cmd.execute(ctx, args)
+	return err
+}
+
 func (w *Wrapper) SetActiveCollectionVersion(
 	ctx context.Context,
 	collectionVersionID string,

--- a/tests/clients/cli/wrapper.go
+++ b/tests/clients/cli/wrapper.go
@@ -428,9 +428,13 @@ func (w *Wrapper) DeleteCollection(
 	names []string,
 	opts ...options.Enumerable[options.DeleteCollectionOptions],
 ) error {
-	args := []string{"client", "collection", "delete", strings.Join(names, ",")}
+	args := []string{"client", "collection", "delete"}
 
 	opt := utils.NewOptions(opts...)
+	if opt.ActiveOnly {
+		args = append(args, "--active-only")
+	}
+	args = append(args, strings.Join(names, ","))
 	args = appendIdentityArg(args, opt.GetIdentity())
 
 	_, err := w.cmd.execute(ctx, args)

--- a/tests/clients/cli/wrapper_tx.go
+++ b/tests/clients/cli/wrapper_tx.go
@@ -130,11 +130,11 @@ func (txn *Transaction) PatchCollection(
 
 func (txn *Transaction) DeleteCollection(
 	ctx context.Context,
-	name string,
+	names []string,
 	opts ...options.Enumerable[options.DeleteCollectionOptions],
 ) error {
 	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
-	return txn.Wrapper.DeleteCollection(ctx, name, opts...)
+	return txn.Wrapper.DeleteCollection(ctx, names, opts...)
 }
 
 func (txn *Transaction) SetActiveCollectionVersion(

--- a/tests/clients/cli/wrapper_tx.go
+++ b/tests/clients/cli/wrapper_tx.go
@@ -128,6 +128,15 @@ func (txn *Transaction) PatchCollection(
 	return txn.Wrapper.PatchCollection(ctx, patch, migration, opts...)
 }
 
+func (txn *Transaction) DeleteCollection(
+	ctx context.Context,
+	name string,
+	opts ...options.Enumerable[options.DeleteCollectionOptions],
+) error {
+	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
+	return txn.Wrapper.DeleteCollection(ctx, name, opts...)
+}
+
 func (txn *Transaction) SetActiveCollectionVersion(
 	ctx context.Context,
 	version string,

--- a/tests/clients/http/wrapper.go
+++ b/tests/clients/http/wrapper.go
@@ -292,6 +292,14 @@ func (w *Wrapper) PatchCollection(
 	return w.client.PatchCollection(ctx, patch, migration, opts...)
 }
 
+func (w *Wrapper) DeleteCollection(
+	ctx context.Context,
+	name string,
+	opts ...options.Enumerable[options.DeleteCollectionOptions],
+) error {
+	return w.client.DeleteCollection(ctx, name, opts...)
+}
+
 func (w *Wrapper) SetActiveCollectionVersion(
 	ctx context.Context,
 	collectionVersionID string,

--- a/tests/clients/http/wrapper.go
+++ b/tests/clients/http/wrapper.go
@@ -294,10 +294,10 @@ func (w *Wrapper) PatchCollection(
 
 func (w *Wrapper) DeleteCollection(
 	ctx context.Context,
-	name string,
+	names []string,
 	opts ...options.Enumerable[options.DeleteCollectionOptions],
 ) error {
-	return w.client.DeleteCollection(ctx, name, opts...)
+	return w.client.DeleteCollection(ctx, names, opts...)
 }
 
 func (w *Wrapper) SetActiveCollectionVersion(

--- a/tests/clients/http/wrapper_tx.go
+++ b/tests/clients/http/wrapper_tx.go
@@ -122,6 +122,15 @@ func (txn *Transaction) PatchCollection(
 	return txn.Wrapper.PatchCollection(ctx, patch, migration, opts...)
 }
 
+func (txn *Transaction) DeleteCollection(
+	ctx context.Context,
+	name string,
+	opts ...options.Enumerable[options.DeleteCollectionOptions],
+) error {
+	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
+	return txn.Wrapper.DeleteCollection(ctx, name, opts...)
+}
+
 func (txn *Transaction) SetActiveCollectionVersion(
 	ctx context.Context,
 	version string,

--- a/tests/clients/http/wrapper_tx.go
+++ b/tests/clients/http/wrapper_tx.go
@@ -124,11 +124,11 @@ func (txn *Transaction) PatchCollection(
 
 func (txn *Transaction) DeleteCollection(
 	ctx context.Context,
-	name string,
+	names []string,
 	opts ...options.Enumerable[options.DeleteCollectionOptions],
 ) error {
 	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
-	return txn.Wrapper.DeleteCollection(ctx, name, opts...)
+	return txn.Wrapper.DeleteCollection(ctx, names, opts...)
 }
 
 func (txn *Transaction) SetActiveCollectionVersion(

--- a/tests/clients/js/wrapper.go
+++ b/tests/clients/js/wrapper.go
@@ -342,7 +342,7 @@ func (w *Wrapper) DeleteCollection(
 	if err != nil {
 		return err
 	}
-	_, err = execute(ctx, w.value, "deleteCollection", namesVal)
+	_, err = execute(ctx, w.value, "deleteCollection", namesVal, opt.ActiveOnly)
 	return err
 }
 

--- a/tests/clients/js/wrapper.go
+++ b/tests/clients/js/wrapper.go
@@ -331,6 +331,17 @@ func (w *Wrapper) PatchCollection(
 	return err
 }
 
+func (w *Wrapper) DeleteCollection(
+	ctx context.Context,
+	name string,
+	opts ...options.Enumerable[options.DeleteCollectionOptions],
+) error {
+	opt := utils.NewOptions(opts...)
+	ctx = ctxWithOptIdentity(ctx, opt)
+	_, err := execute(ctx, w.value, "deleteCollection", name)
+	return err
+}
+
 func (w *Wrapper) SetActiveCollectionVersion(
 	ctx context.Context,
 	collectionVersionID string,

--- a/tests/clients/js/wrapper.go
+++ b/tests/clients/js/wrapper.go
@@ -333,12 +333,16 @@ func (w *Wrapper) PatchCollection(
 
 func (w *Wrapper) DeleteCollection(
 	ctx context.Context,
-	name string,
+	names []string,
 	opts ...options.Enumerable[options.DeleteCollectionOptions],
 ) error {
 	opt := utils.NewOptions(opts...)
 	ctx = ctxWithOptIdentity(ctx, opt)
-	_, err := execute(ctx, w.value, "deleteCollection", name)
+	namesVal, err := goji.MarshalJS(names)
+	if err != nil {
+		return err
+	}
+	_, err = execute(ctx, w.value, "deleteCollection", namesVal)
 	return err
 }
 

--- a/tests/clients/js/wrapper_tx.go
+++ b/tests/clients/js/wrapper_tx.go
@@ -111,6 +111,11 @@ func (txn *Transaction) PatchCollection(
 	return txn.Wrapper.PatchCollection(ctx, patch, migration, opts...)
 }
 
+func (txn *Transaction) DeleteCollection(ctx context.Context, name string, opts ...options.Enumerable[options.DeleteCollectionOptions]) error {
+	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
+	return txn.Wrapper.DeleteCollection(ctx, name, opts...)
+}
+
 func (txn *Transaction) SetActiveCollectionVersion(ctx context.Context, version string, opts ...options.Enumerable[options.SetActiveCollectionVersionOptions]) error {
 	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
 	return txn.Wrapper.SetActiveCollectionVersion(ctx, version, opts...)

--- a/tests/clients/js/wrapper_tx.go
+++ b/tests/clients/js/wrapper_tx.go
@@ -111,9 +111,9 @@ func (txn *Transaction) PatchCollection(
 	return txn.Wrapper.PatchCollection(ctx, patch, migration, opts...)
 }
 
-func (txn *Transaction) DeleteCollection(ctx context.Context, name string, opts ...options.Enumerable[options.DeleteCollectionOptions]) error {
+func (txn *Transaction) DeleteCollection(ctx context.Context, names []string, opts ...options.Enumerable[options.DeleteCollectionOptions]) error {
 	ctx = datastore.CtxSetFromClientTxn(ctx, txn)
-	return txn.Wrapper.DeleteCollection(ctx, name, opts...)
+	return txn.Wrapper.DeleteCollection(ctx, names, opts...)
 }
 
 func (txn *Transaction) SetActiveCollectionVersion(ctx context.Context, version string, opts ...options.Enumerable[options.SetActiveCollectionVersionOptions]) error {

--- a/tests/integration/acp/nac/delete_collection_test.go
+++ b/tests/integration/acp/nac/delete_collection_test.go
@@ -42,7 +42,7 @@ func TestNAC_GatesDeleteCollection_AuthorizedIdentity_AllowAccess(t *testing.T) 
 			// This should work as the identity is authorized.
 			&action.DeleteCollection{
 				Identity: testUtils.ClientIdentity(1),
-				Name:     "Users",
+				Names:    []string{"Users"},
 			},
 		},
 	}
@@ -80,7 +80,7 @@ func TestNAC_GatesDeleteCollection_NoIdentity_NotAuthorizedError(t *testing.T) {
 			// We haven't authorized non-identities. So, this should error.
 			&action.DeleteCollection{
 				Identity:      testUtils.NoIdentity(),
-				Name:          "Users",
+				Names:         []string{"Users"},
 				ExpectedError: testUtils.FormatExpectedErrorWithPermission(acpTypes.NodePatchCollectionPerm),
 			},
 		},
@@ -117,7 +117,7 @@ func TestNAC_GatesDeleteCollection_NoIdentity_CLIClient_NotAuthorizedError(t *te
 			// We haven't authorized non-identities. So, this should error.
 			&action.DeleteCollection{
 				Identity:      testUtils.NoIdentity(),
-				Name:          "Users",
+				Names:         []string{"Users"},
 				ExpectedError: testUtils.FormatExpectedErrorWithPermission(acpTypes.NodeGetCollectionPerm),
 			},
 		},
@@ -157,7 +157,7 @@ func TestNAC_GatesDeleteCollection_WrongIdentity_NotAuthorizedError(t *testing.T
 			// Wrong user/identity will also not be authorized.
 			&action.DeleteCollection{
 				Identity:      testUtils.ClientIdentity(2),
-				Name:          "Users",
+				Names:         []string{"Users"},
 				ExpectedError: testUtils.FormatExpectedErrorWithPermission(acpTypes.NodePatchCollectionPerm),
 			},
 		},
@@ -194,7 +194,7 @@ func TestNAC_GatesDeleteCollection_WrongIdentity_CLIClient_NotAuthorizedError(t 
 			// Wrong user/identity will also not be authorized.
 			&action.DeleteCollection{
 				Identity:      testUtils.ClientIdentity(2),
-				Name:          "Users",
+				Names:         []string{"Users"},
 				ExpectedError: testUtils.FormatExpectedErrorWithPermission(acpTypes.NodeGetCollectionPerm),
 			},
 		},

--- a/tests/integration/acp/nac/delete_collection_test.go
+++ b/tests/integration/acp/nac/delete_collection_test.go
@@ -41,8 +41,9 @@ func TestNAC_GatesDeleteCollection_AuthorizedIdentity_AllowAccess(t *testing.T) 
 
 			// This should work as the identity is authorized.
 			&action.DeleteCollection{
-				Identity: testUtils.ClientIdentity(1),
-				Names:    []string{"Users"},
+				ActiveOnly: true,
+				Identity:   testUtils.ClientIdentity(1),
+				Names:      []string{"Users"},
 			},
 		},
 	}
@@ -79,6 +80,7 @@ func TestNAC_GatesDeleteCollection_NoIdentity_NotAuthorizedError(t *testing.T) {
 
 			// We haven't authorized non-identities. So, this should error.
 			&action.DeleteCollection{
+				ActiveOnly:    true,
 				Identity:      testUtils.NoIdentity(),
 				Names:         []string{"Users"},
 				ExpectedError: testUtils.FormatExpectedErrorWithPermission(acpTypes.NodePatchCollectionPerm),
@@ -116,6 +118,7 @@ func TestNAC_GatesDeleteCollection_NoIdentity_CLIClient_NotAuthorizedError(t *te
 
 			// We haven't authorized non-identities. So, this should error.
 			&action.DeleteCollection{
+				ActiveOnly:    true,
 				Identity:      testUtils.NoIdentity(),
 				Names:         []string{"Users"},
 				ExpectedError: testUtils.FormatExpectedErrorWithPermission(acpTypes.NodeGetCollectionPerm),
@@ -156,6 +159,7 @@ func TestNAC_GatesDeleteCollection_WrongIdentity_NotAuthorizedError(t *testing.T
 
 			// Wrong user/identity will also not be authorized.
 			&action.DeleteCollection{
+				ActiveOnly:    true,
 				Identity:      testUtils.ClientIdentity(2),
 				Names:         []string{"Users"},
 				ExpectedError: testUtils.FormatExpectedErrorWithPermission(acpTypes.NodePatchCollectionPerm),
@@ -193,6 +197,7 @@ func TestNAC_GatesDeleteCollection_WrongIdentity_CLIClient_NotAuthorizedError(t 
 
 			// Wrong user/identity will also not be authorized.
 			&action.DeleteCollection{
+				ActiveOnly:    true,
 				Identity:      testUtils.ClientIdentity(2),
 				Names:         []string{"Users"},
 				ExpectedError: testUtils.FormatExpectedErrorWithPermission(acpTypes.NodeGetCollectionPerm),

--- a/tests/integration/acp/nac/delete_collection_test.go
+++ b/tests/integration/acp/nac/delete_collection_test.go
@@ -1,0 +1,204 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// This file is part of the DefraDB test suite.
+//
+// The DefraDB test suite is licensed under either:
+//
+//   (1) GNU Affero General Public License v3
+//   (2) Business Source License 1.1
+//
+// See tests/LICENSE for details.
+
+package test_acp_nac
+
+import (
+	"testing"
+
+	acpTypes "github.com/sourcenetwork/defradb/acp/types"
+	"github.com/sourcenetwork/defradb/tests/action"
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	"github.com/sourcenetwork/defradb/tests/state"
+	"github.com/sourcenetwork/immutable"
+)
+
+func TestNAC_GatesDeleteCollection_AuthorizedIdentity_AllowAccess(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			// Starting with NAC, so only authorized user(s) can perform operations from here on out.
+			testUtils.Close{},
+			testUtils.Start{
+				Identity:  testUtils.ClientIdentity(1),
+				EnableNAC: true,
+			},
+			// Note: Doing setup steps after starting with nac enabled, otherwise the in-memory tests
+			// will lose setup state when the restart happens (i.e. the restart that started nac).
+			&action.AddCollection{
+				Identity: testUtils.ClientIdentity(1),
+				SDL: `
+					type Users {}
+				`,
+			},
+
+			// This should work as the identity is authorized.
+			&action.DeleteCollection{
+				Identity: testUtils.ClientIdentity(1),
+				Name:     "Users",
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestNAC_GatesDeleteCollection_NoIdentity_NotAuthorizedError(t *testing.T) {
+	test := testUtils.TestCase{
+		// todo: Investigate and test this behavior across all client types when implementing granular NAC permissions.
+		// See: https://github.com/sourcenetwork/defradb/issues/4383
+		SupportedClientTypes: immutable.Some(
+			[]state.ClientType{
+				state.GoClientType,
+				state.HTTPClientType,
+				state.CClientType,
+			},
+		),
+		Actions: []any{
+			// Starting with NAC, so only authorized user(s) can perform operations from here on out.
+			testUtils.Close{},
+			testUtils.Start{
+				Identity:  testUtils.ClientIdentity(1),
+				EnableNAC: true,
+			},
+			// Note: Doing setup steps after starting with nac enabled, otherwise the in-memory tests
+			// will lose setup state when the restart happens (i.e. the restart that started nac).
+			&action.AddCollection{
+				Identity: testUtils.ClientIdentity(1),
+				SDL: `
+					type Users {}
+				`,
+			},
+
+			// We haven't authorized non-identities. So, this should error.
+			&action.DeleteCollection{
+				Identity:      testUtils.NoIdentity(),
+				Name:          "Users",
+				ExpectedError: testUtils.FormatExpectedErrorWithPermission(acpTypes.NodePatchCollectionPerm),
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestNAC_GatesDeleteCollection_NoIdentity_CLIClient_NotAuthorizedError(t *testing.T) {
+	test := testUtils.TestCase{
+		// todo: Investigate and test this behavior across all client types when implementing granular NAC permissions.
+		// See: https://github.com/sourcenetwork/defradb/issues/4383
+		SupportedClientTypes: immutable.Some(
+			[]state.ClientType{
+				state.CLIClientType,
+			},
+		),
+		Actions: []any{
+			// Starting with NAC, so only authorized user(s) can perform operations from here on out.
+			testUtils.Close{},
+			testUtils.Start{
+				Identity:  testUtils.ClientIdentity(1),
+				EnableNAC: true,
+			},
+			// Note: Doing setup steps after starting with nac enabled, otherwise the in-memory tests
+			// will lose setup state when the restart happens (i.e. the restart that started nac).
+			&action.AddCollection{
+				Identity: testUtils.ClientIdentity(1),
+				SDL: `
+					type Users {}
+				`,
+			},
+
+			// We haven't authorized non-identities. So, this should error.
+			&action.DeleteCollection{
+				Identity:      testUtils.NoIdentity(),
+				Name:          "Users",
+				ExpectedError: testUtils.FormatExpectedErrorWithPermission(acpTypes.NodeGetCollectionPerm),
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestNAC_GatesDeleteCollection_WrongIdentity_NotAuthorizedError(t *testing.T) {
+	test := testUtils.TestCase{
+		// todo: Investigate and test this behavior across all client types when implementing granular NAC permissions.
+		// See: https://github.com/sourcenetwork/defradb/issues/4383
+		SupportedClientTypes: immutable.Some(
+			[]state.ClientType{
+				state.GoClientType,
+				state.HTTPClientType,
+				state.CClientType,
+				state.JSClientType,
+			},
+		),
+		Actions: []any{
+			// Starting with NAC, so only authorized user(s) can perform operations from here on out.
+			testUtils.Close{},
+			testUtils.Start{
+				Identity:  testUtils.ClientIdentity(1),
+				EnableNAC: true,
+			},
+			// Note: Doing setup steps after starting with nac enabled, otherwise the in-memory tests
+			// will lose setup state when the restart happens (i.e. the restart that started nac).
+			&action.AddCollection{
+				Identity: testUtils.ClientIdentity(1),
+				SDL: `
+					type Users {}
+				`,
+			},
+
+			// Wrong user/identity will also not be authorized.
+			&action.DeleteCollection{
+				Identity:      testUtils.ClientIdentity(2),
+				Name:          "Users",
+				ExpectedError: testUtils.FormatExpectedErrorWithPermission(acpTypes.NodePatchCollectionPerm),
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestNAC_GatesDeleteCollection_WrongIdentity_CLIClient_NotAuthorizedError(t *testing.T) {
+	test := testUtils.TestCase{
+		// todo: Investigate and test this behavior across all client types when implementing granular NAC permissions.
+		// See: https://github.com/sourcenetwork/defradb/issues/4383
+		SupportedClientTypes: immutable.Some(
+			[]state.ClientType{
+				state.CLIClientType,
+			},
+		),
+		Actions: []any{
+			// Starting with NAC, so only authorized user(s) can perform operations from here on out.
+			testUtils.Close{},
+			testUtils.Start{
+				Identity:  testUtils.ClientIdentity(1),
+				EnableNAC: true,
+			},
+			// Note: Doing setup steps after starting with nac enabled, otherwise the in-memory tests
+			// will lose setup state when the restart happens (i.e. the restart that started nac).
+			&action.AddCollection{
+				Identity: testUtils.ClientIdentity(1),
+				SDL: `
+					type Users {}
+				`,
+			},
+
+			// Wrong user/identity will also not be authorized.
+			&action.DeleteCollection{
+				Identity:      testUtils.ClientIdentity(2),
+				Name:          "Users",
+				ExpectedError: testUtils.FormatExpectedErrorWithPermission(acpTypes.NodeGetCollectionPerm),
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/acp/nac/relation_admin/delete_collection_test.go
+++ b/tests/integration/acp/nac/relation_admin/delete_collection_test.go
@@ -52,7 +52,7 @@ func TestNAC_AdminRelation_CanDeleteCollection(t *testing.T) {
 			// This user, can not perform this gated operation yet.
 			&action.DeleteCollection{
 				Identity:      testUtils.ClientIdentity(2),
-				Name:          "Users",
+				Names:         []string{"Users"},
 				ExpectedError: testUtils.FormatExpectedErrorWithPermission(acpTypes.NodePatchCollectionPerm),
 			},
 
@@ -67,7 +67,7 @@ func TestNAC_AdminRelation_CanDeleteCollection(t *testing.T) {
 			// This user, can now perform this gated operation.
 			&action.DeleteCollection{
 				Identity: testUtils.ClientIdentity(2),
-				Name:     "Users",
+				Names:    []string{"Users"},
 			},
 		},
 	}
@@ -103,7 +103,7 @@ func TestNAC_AdminRelation_CLIClient_CanDeleteCollection(t *testing.T) {
 			// This user, can not perform this gated operation yet.
 			&action.DeleteCollection{
 				Identity:      testUtils.ClientIdentity(2),
-				Name:          "Users",
+				Names:         []string{"Users"},
 				ExpectedError: testUtils.FormatExpectedErrorWithPermission(acpTypes.NodeGetCollectionPerm),
 			},
 
@@ -118,7 +118,7 @@ func TestNAC_AdminRelation_CLIClient_CanDeleteCollection(t *testing.T) {
 			// This user, can now perform this gated operation.
 			&action.DeleteCollection{
 				Identity: testUtils.ClientIdentity(2),
-				Name:     "Users",
+				Names:    []string{"Users"},
 			},
 		},
 	}

--- a/tests/integration/acp/nac/relation_admin/delete_collection_test.go
+++ b/tests/integration/acp/nac/relation_admin/delete_collection_test.go
@@ -51,6 +51,7 @@ func TestNAC_AdminRelation_CanDeleteCollection(t *testing.T) {
 
 			// This user, can not perform this gated operation yet.
 			&action.DeleteCollection{
+				ActiveOnly:    true,
 				Identity:      testUtils.ClientIdentity(2),
 				Names:         []string{"Users"},
 				ExpectedError: testUtils.FormatExpectedErrorWithPermission(acpTypes.NodePatchCollectionPerm),
@@ -66,8 +67,9 @@ func TestNAC_AdminRelation_CanDeleteCollection(t *testing.T) {
 
 			// This user, can now perform this gated operation.
 			&action.DeleteCollection{
-				Identity: testUtils.ClientIdentity(2),
-				Names:    []string{"Users"},
+				ActiveOnly: true,
+				Identity:   testUtils.ClientIdentity(2),
+				Names:      []string{"Users"},
 			},
 		},
 	}
@@ -102,6 +104,7 @@ func TestNAC_AdminRelation_CLIClient_CanDeleteCollection(t *testing.T) {
 
 			// This user, can not perform this gated operation yet.
 			&action.DeleteCollection{
+				ActiveOnly:    true,
 				Identity:      testUtils.ClientIdentity(2),
 				Names:         []string{"Users"},
 				ExpectedError: testUtils.FormatExpectedErrorWithPermission(acpTypes.NodeGetCollectionPerm),
@@ -117,8 +120,9 @@ func TestNAC_AdminRelation_CLIClient_CanDeleteCollection(t *testing.T) {
 
 			// This user, can now perform this gated operation.
 			&action.DeleteCollection{
-				Identity: testUtils.ClientIdentity(2),
-				Names:    []string{"Users"},
+				ActiveOnly: true,
+				Identity:   testUtils.ClientIdentity(2),
+				Names:      []string{"Users"},
 			},
 		},
 	}

--- a/tests/integration/acp/nac/relation_admin/delete_collection_test.go
+++ b/tests/integration/acp/nac/relation_admin/delete_collection_test.go
@@ -1,0 +1,127 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// This file is part of the DefraDB test suite.
+//
+// The DefraDB test suite is licensed under either:
+//
+//   (1) GNU Affero General Public License v3
+//   (2) Business Source License 1.1
+//
+// See tests/LICENSE for details.
+
+package test_acp_nac_relation_admin
+
+import (
+	"testing"
+
+	acpTypes "github.com/sourcenetwork/defradb/acp/types"
+	"github.com/sourcenetwork/defradb/tests/action"
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	"github.com/sourcenetwork/defradb/tests/state"
+	"github.com/sourcenetwork/immutable"
+)
+
+func TestNAC_AdminRelation_CanDeleteCollection(t *testing.T) {
+	test := testUtils.TestCase{
+		// todo: Investigate and test this behavior across all client types when implementing granular NAC permissions.
+		// See: https://github.com/sourcenetwork/defradb/issues/4383
+		SupportedClientTypes: immutable.Some(
+			[]state.ClientType{
+				state.GoClientType,
+				state.HTTPClientType,
+				state.CClientType,
+				state.JSClientType,
+			},
+		),
+		Actions: []any{
+			// Starting with NAC, so only authorized user(s) can perform operations from here on out.
+			testUtils.Close{},
+			testUtils.Start{
+				Identity:  testUtils.ClientIdentity(1),
+				EnableNAC: true,
+			},
+			// Note: Doing setup steps after starting with nac enabled, otherwise the in-memory tests
+			// will lose setup state when the restart happens (i.e. the restart that started nac).
+			&action.AddCollection{
+				Identity: testUtils.ClientIdentity(1),
+				SDL: `
+					type Users {}
+				`,
+			},
+
+			// This user, can not perform this gated operation yet.
+			&action.DeleteCollection{
+				Identity:      testUtils.ClientIdentity(2),
+				Name:          "Users",
+				ExpectedError: testUtils.FormatExpectedErrorWithPermission(acpTypes.NodePatchCollectionPerm),
+			},
+
+			// Grant access to user.
+			testUtils.AddNACActorRelationship{
+				RequestorIdentity: testUtils.ClientIdentity(1),
+				TargetIdentity:    testUtils.ClientIdentity(2), // Grant this user "admin" relation
+				Relation:          "admin",
+				ExpectedExistence: false,
+			},
+
+			// This user, can now perform this gated operation.
+			&action.DeleteCollection{
+				Identity: testUtils.ClientIdentity(2),
+				Name:     "Users",
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestNAC_AdminRelation_CLIClient_CanDeleteCollection(t *testing.T) {
+	test := testUtils.TestCase{
+		// todo: Investigate and test this behavior across all client types when implementing granular NAC permissions.
+		// See: https://github.com/sourcenetwork/defradb/issues/4383
+		SupportedClientTypes: immutable.Some(
+			[]state.ClientType{
+				state.CLIClientType,
+			},
+		),
+		Actions: []any{
+			// Starting with NAC, so only authorized user(s) can perform operations from here on out.
+			testUtils.Close{},
+			testUtils.Start{
+				Identity:  testUtils.ClientIdentity(1),
+				EnableNAC: true,
+			},
+			// Note: Doing setup steps after starting with nac enabled, otherwise the in-memory tests
+			// will lose setup state when the restart happens (i.e. the restart that started nac).
+			&action.AddCollection{
+				Identity: testUtils.ClientIdentity(1),
+				SDL: `
+					type Users {}
+				`,
+			},
+
+			// This user, can not perform this gated operation yet.
+			&action.DeleteCollection{
+				Identity:      testUtils.ClientIdentity(2),
+				Name:          "Users",
+				ExpectedError: testUtils.FormatExpectedErrorWithPermission(acpTypes.NodeGetCollectionPerm),
+			},
+
+			// Grant access to user.
+			testUtils.AddNACActorRelationship{
+				RequestorIdentity: testUtils.ClientIdentity(1),
+				TargetIdentity:    testUtils.ClientIdentity(2), // Grant this user "admin" relation
+				Relation:          "admin",
+				ExpectedExistence: false,
+			},
+
+			// This user, can now perform this gated operation.
+			&action.DeleteCollection{
+				Identity: testUtils.ClientIdentity(2),
+				Name:     "Users",
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/collection/delete/delete_collection_test.go
+++ b/tests/integration/collection/delete/delete_collection_test.go
@@ -305,7 +305,7 @@ func TestDeleteCollection_ReferencedByRelation_ReturnsError(t *testing.T) {
 			},
 			&action.DeleteCollection{
 				Names:         []string{"Users"},
-				ExpectedError: "no type found for given name",
+				ExpectedError: "cannot remove a collection while another field references it",
 			},
 			// The failed delete must roll back atomically: both collections still exist.
 			&action.GetCollections{
@@ -345,7 +345,7 @@ func TestDeleteCollection_ReferencedByRelation_OtherSide_ReturnsError(t *testing
 			},
 			&action.DeleteCollection{
 				Names:         []string{"Books"},
-				ExpectedError: "no type found for given name",
+				ExpectedError: "cannot remove a collection while another field references it",
 			},
 
 			// The failed delete must roll back atomically: both collections still exist.

--- a/tests/integration/collection/delete/delete_collection_test.go
+++ b/tests/integration/collection/delete/delete_collection_test.go
@@ -33,7 +33,7 @@ func TestDeleteCollection_Simple_Succeeds(t *testing.T) {
 				`,
 			},
 			&action.DeleteCollection{
-				Name: "Users",
+				Names: []string{"Users"},
 			},
 			&action.GetCollections{
 				ExpectedResults: []client.CollectionVersion{},
@@ -55,7 +55,7 @@ func TestDeleteCollection_Simple_QueriesNoLongerWork(t *testing.T) {
 				`,
 			},
 			&action.DeleteCollection{
-				Name: "Users",
+				Names: []string{"Users"},
 			},
 			&action.Request{
 				Request: `query {
@@ -95,7 +95,7 @@ func TestDeleteCollection_WithDocuments_ReturnsError(t *testing.T) {
 				},
 			},
 			&action.DeleteCollection{
-				Name:          "Users",
+				Names:         []string{"Users"},
 				ExpectedError: "cannot delete a collection that has documents",
 			},
 		},
@@ -124,7 +124,7 @@ func TestDeleteCollection_WithSoftDeletedDocuments_ReturnsError(t *testing.T) {
 				DocID:        0,
 			},
 			&action.DeleteCollection{
-				Name:          "Users",
+				Names:         []string{"Users"},
 				ExpectedError: "cannot delete a collection that has documents",
 			},
 		},
@@ -137,7 +137,7 @@ func TestDeleteCollection_NonExistentCollection_ReturnsError(t *testing.T) {
 	test := testUtils.TestCase{
 		Actions: []any{
 			&action.DeleteCollection{
-				Name:          "NonExistent",
+				Names:         []string{"NonExistent"},
 				ExpectedError: "collection not found",
 			},
 		},
@@ -160,7 +160,7 @@ func TestDeleteCollection_MultipleCollections_DeleteOne(t *testing.T) {
 				`,
 			},
 			&action.DeleteCollection{
-				Name: "Users",
+				Names: []string{"Users"},
 			},
 			&action.GetCollections{
 				ExpectedResults: []client.CollectionVersion{
@@ -207,7 +207,7 @@ func TestDeleteCollection_WithTransaction_Succeeds(t *testing.T) {
 			},
 			&action.DeleteCollection{
 				TransactionID: immutable.Some(1),
-				Name:          "Users",
+				Names:         []string{"Users"},
 			},
 			&action.CommitTransaction{
 				TransactionID: 1,
@@ -240,7 +240,7 @@ func TestDeleteCollection_WithTransactionWithoutCommit_CollectionStillExists(t *
 			},
 			&action.DeleteCollection{
 				TransactionID: immutable.Some(1),
-				Name:          "Users",
+				Names:         []string{"Users"},
 			},
 			// Without committing, the collection data should still exist. Verify via
 			// GetCollections which reads from a separate transaction.
@@ -274,10 +274,10 @@ func TestDeleteCollection_DeleteBothCollections_Succeeds(t *testing.T) {
 				`,
 			},
 			&action.DeleteCollection{
-				Name: "Users",
+				Names: []string{"Users"},
 			},
 			&action.DeleteCollection{
-				Name: "Books",
+				Names: []string{"Books"},
 			},
 			&action.GetCollections{
 				ExpectedResults: []client.CollectionVersion{},
@@ -304,8 +304,23 @@ func TestDeleteCollection_ReferencedByRelation_ReturnsError(t *testing.T) {
 				`,
 			},
 			&action.DeleteCollection{
-				Name:          "Users",
+				Names:         []string{"Users"},
 				ExpectedError: "no type found for given name",
+			},
+			// The failed delete must roll back atomically: both collections still exist.
+			&action.GetCollections{
+				ExpectedResults: []client.CollectionVersion{
+					{
+						Name:           "Books",
+						IsMaterialized: true,
+						IsActive:       true,
+					},
+					{
+						Name:           "Users",
+						IsMaterialized: true,
+						IsActive:       true,
+					},
+				},
 			},
 		},
 	}
@@ -329,8 +344,110 @@ func TestDeleteCollection_ReferencedByRelation_OtherSide_ReturnsError(t *testing
 				`,
 			},
 			&action.DeleteCollection{
-				Name:          "Books",
+				Names:         []string{"Books"},
 				ExpectedError: "no type found for given name",
+			},
+
+			// The failed delete must roll back atomically: both collections still exist.
+			&action.GetCollections{
+				ExpectedResults: []client.CollectionVersion{
+					{
+						Name:           "Books",
+						IsMaterialized: true,
+						IsActive:       true,
+					},
+					{
+						Name:           "Users",
+						IsMaterialized: true,
+						IsActive:       true,
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+// Multiple unrelated collections can be deleted in a single call.
+func TestDeleteCollection_MultipleCollections_AtomicallyInOneCall(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type Users {
+						name: String
+					}
+					type Books {
+						title: String
+					}
+				`,
+			},
+			&action.DeleteCollection{
+				Names: []string{"Users", "Books"},
+			},
+			&action.GetCollections{
+				ExpectedResults: []client.CollectionVersion{},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+// The whole point of multi-delete: two collections referencing each other cannot be
+// deleted one at a time (see the relation-error tests above), but passing both to a
+// single DeleteCollection call succeeds because the underlying patch is atomic.
+func TestDeleteCollection_BothRelatedCollections_InOneCall_Succeeds(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type Users {
+						name: String
+						books: [Books]
+					}
+					type Books {
+						title: String
+						author: Users
+					}
+				`,
+			},
+			&action.DeleteCollection{
+				Names: []string{"Users", "Books"},
+			},
+			&action.GetCollections{
+				ExpectedResults: []client.CollectionVersion{},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+// If any name in the list is unknown, the whole call fails and nothing is deleted.
+func TestDeleteCollection_MixedValidAndInvalidName_RollsBack(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type Users {
+						name: String
+					}
+				`,
+			},
+			&action.DeleteCollection{
+				Names:         []string{"Users", "NonExistent"},
+				ExpectedError: "collection not found",
+			},
+			&action.GetCollections{
+				ExpectedResults: []client.CollectionVersion{
+					{
+						Name:           "Users",
+						IsMaterialized: true,
+						IsActive:       true,
+					},
+				},
 			},
 		},
 	}

--- a/tests/integration/collection/delete/delete_collection_test.go
+++ b/tests/integration/collection/delete/delete_collection_test.go
@@ -33,7 +33,8 @@ func TestDeleteCollection_Simple_Succeeds(t *testing.T) {
 				`,
 			},
 			&action.DeleteCollection{
-				Names: []string{"Users"},
+				ActiveOnly: true,
+				Names:      []string{"Users"},
 			},
 			&action.GetCollections{
 				ExpectedResults: []client.CollectionVersion{},
@@ -55,7 +56,8 @@ func TestDeleteCollection_Simple_QueriesNoLongerWork(t *testing.T) {
 				`,
 			},
 			&action.DeleteCollection{
-				Names: []string{"Users"},
+				ActiveOnly: true,
+				Names:      []string{"Users"},
 			},
 			&action.Request{
 				Request: `query {
@@ -95,6 +97,7 @@ func TestDeleteCollection_WithDocuments_ReturnsError(t *testing.T) {
 				},
 			},
 			&action.DeleteCollection{
+				ActiveOnly:    true,
 				Names:         []string{"Users"},
 				ExpectedError: "cannot delete a collection that has documents",
 			},
@@ -124,6 +127,7 @@ func TestDeleteCollection_WithSoftDeletedDocuments_ReturnsError(t *testing.T) {
 				DocID:        0,
 			},
 			&action.DeleteCollection{
+				ActiveOnly:    true,
 				Names:         []string{"Users"},
 				ExpectedError: "cannot delete a collection that has documents",
 			},
@@ -137,6 +141,7 @@ func TestDeleteCollection_NonExistentCollection_ReturnsError(t *testing.T) {
 	test := testUtils.TestCase{
 		Actions: []any{
 			&action.DeleteCollection{
+				ActiveOnly:    true,
 				Names:         []string{"NonExistent"},
 				ExpectedError: "collection not found",
 			},
@@ -160,7 +165,8 @@ func TestDeleteCollection_MultipleCollections_DeleteOne(t *testing.T) {
 				`,
 			},
 			&action.DeleteCollection{
-				Names: []string{"Users"},
+				ActiveOnly: true,
+				Names:      []string{"Users"},
 			},
 			&action.GetCollections{
 				ExpectedResults: []client.CollectionVersion{
@@ -206,6 +212,7 @@ func TestDeleteCollection_WithTransaction_Succeeds(t *testing.T) {
 				`,
 			},
 			&action.DeleteCollection{
+				ActiveOnly:    true,
 				TransactionID: immutable.Some(1),
 				Names:         []string{"Users"},
 			},
@@ -239,6 +246,7 @@ func TestDeleteCollection_WithTransactionWithoutCommit_CollectionStillExists(t *
 				`,
 			},
 			&action.DeleteCollection{
+				ActiveOnly:    true,
 				TransactionID: immutable.Some(1),
 				Names:         []string{"Users"},
 			},
@@ -274,10 +282,12 @@ func TestDeleteCollection_DeleteBothCollections_Succeeds(t *testing.T) {
 				`,
 			},
 			&action.DeleteCollection{
-				Names: []string{"Users"},
+				ActiveOnly: true,
+				Names:      []string{"Users"},
 			},
 			&action.DeleteCollection{
-				Names: []string{"Books"},
+				ActiveOnly: true,
+				Names:      []string{"Books"},
 			},
 			&action.GetCollections{
 				ExpectedResults: []client.CollectionVersion{},
@@ -304,6 +314,7 @@ func TestDeleteCollection_ReferencedByRelation_ReturnsError(t *testing.T) {
 				`,
 			},
 			&action.DeleteCollection{
+				ActiveOnly:    true,
 				Names:         []string{"Users"},
 				ExpectedError: "cannot remove a collection while another field references it",
 			},
@@ -344,6 +355,7 @@ func TestDeleteCollection_ReferencedByRelation_OtherSide_ReturnsError(t *testing
 				`,
 			},
 			&action.DeleteCollection{
+				ActiveOnly:    true,
 				Names:         []string{"Books"},
 				ExpectedError: "cannot remove a collection while another field references it",
 			},
@@ -384,7 +396,8 @@ func TestDeleteCollection_MultipleCollections_AtomicallyInOneCall(t *testing.T) 
 				`,
 			},
 			&action.DeleteCollection{
-				Names: []string{"Users", "Books"},
+				ActiveOnly: true,
+				Names:      []string{"Users", "Books"},
 			},
 			&action.GetCollections{
 				ExpectedResults: []client.CollectionVersion{},
@@ -414,7 +427,8 @@ func TestDeleteCollection_BothRelatedCollections_InOneCall_Succeeds(t *testing.T
 				`,
 			},
 			&action.DeleteCollection{
-				Names: []string{"Users", "Books"},
+				ActiveOnly: true,
+				Names:      []string{"Users", "Books"},
 			},
 			&action.GetCollections{
 				ExpectedResults: []client.CollectionVersion{},
@@ -437,6 +451,7 @@ func TestDeleteCollection_MixedValidAndInvalidName_RollsBack(t *testing.T) {
 				`,
 			},
 			&action.DeleteCollection{
+				ActiveOnly:    true,
 				Names:         []string{"Users", "NonExistent"},
 				ExpectedError: "collection not found",
 			},
@@ -448,6 +463,115 @@ func TestDeleteCollection_MixedValidAndInvalidName_RollsBack(t *testing.T) {
 						IsActive:       true,
 					},
 				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+// Default delete (ActiveOnly == false) removes every version of the named collection,
+// active head and all earlier (inactive) versions.
+func TestDeleteCollection_Default_RemovesAllVersions(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type Users {}
+				`,
+			},
+			// Adding a field promotes the new version to active and demotes the original
+			// to an inactive earlier version.
+			&action.PatchCollection{
+				Patch: `
+					[
+						{ "op": "add", "path": "/Users/Fields/-", "value": {"Name": "name", "Kind": "String"} }
+					]
+				`,
+			},
+			// Default behaviour: every version is removed including the inactive earlier one.
+			&action.DeleteCollection{
+				Names: []string{"Users"},
+			},
+			&action.GetCollections{
+				FilterOptions:   options.GetCollections().SetGetInactive(true),
+				ExpectedResults: []client.CollectionVersion{},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+// With ActiveOnly the earlier version remains after the active head is removed; it is
+// effectively a rollback to the previous version (which is promoted to active).
+func TestDeleteCollection_ActiveOnly_LeavesEarlierVersion(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type Users {}
+				`,
+			},
+			&action.PatchCollection{
+				Patch: `
+					[
+						{ "op": "add", "path": "/Users/Fields/-", "value": {"Name": "name", "Kind": "String"} }
+					]
+				`,
+			},
+			&action.DeleteCollection{
+				ActiveOnly: true,
+				Names:      []string{"Users"},
+			},
+			// One version of Users still exists after the active head was removed; it
+			// was the earlier (inactive) version and remains inactive.
+			&action.GetCollections{
+				FilterOptions: options.GetCollections().SetGetInactive(true),
+				ExpectedResults: []client.CollectionVersion{
+					{
+						Name:           "Users",
+						IsMaterialized: true,
+						IsActive:       false,
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+// Default delete across multiple collections each with multiple versions removes all of them.
+func TestDeleteCollection_Default_MultipleCollectionsWithMultipleVersions_RemovesAllVersions(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type Users {}
+					type Books {}
+				`,
+			},
+			&action.PatchCollection{
+				Patch: `
+					[
+						{ "op": "add", "path": "/Users/Fields/-", "value": {"Name": "name", "Kind": "String"} }
+					]
+				`,
+			},
+			&action.PatchCollection{
+				Patch: `
+					[
+						{ "op": "add", "path": "/Books/Fields/-", "value": {"Name": "title", "Kind": "String"} }
+					]
+				`,
+			},
+			&action.DeleteCollection{
+				Names: []string{"Users", "Books"},
+			},
+			&action.GetCollections{
+				FilterOptions:   options.GetCollections().SetGetInactive(true),
+				ExpectedResults: []client.CollectionVersion{},
 			},
 		},
 	}

--- a/tests/integration/collection/delete/delete_collection_test.go
+++ b/tests/integration/collection/delete/delete_collection_test.go
@@ -1,0 +1,339 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// This file is part of the DefraDB test suite.
+//
+// The DefraDB test suite is licensed under either:
+//
+//   (1) GNU Affero General Public License v3
+//   (2) Business Source License 1.1
+//
+// See tests/LICENSE for details.
+
+package delete
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/defradb/client"
+	"github.com/sourcenetwork/defradb/client/options"
+	"github.com/sourcenetwork/defradb/tests/action"
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	"github.com/sourcenetwork/defradb/tests/state"
+	"github.com/sourcenetwork/immutable"
+)
+
+func TestDeleteCollection_Simple_Succeeds(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type Users {
+						name: String
+					}
+				`,
+			},
+			&action.DeleteCollection{
+				Name: "Users",
+			},
+			&action.GetCollections{
+				ExpectedResults: []client.CollectionVersion{},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestDeleteCollection_Simple_QueriesNoLongerWork(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type Users {
+						name: String
+					}
+				`,
+			},
+			&action.DeleteCollection{
+				Name: "Users",
+			},
+			&action.Request{
+				Request: `query {
+					Users {
+						name
+					}
+				}`,
+				ExpectedError: `Cannot query field "Users" on type "Query".`,
+			},
+			&action.Request{
+				Request: `mutation {
+					add_Users(input:{}) {
+						name
+					}
+				}`,
+				ExpectedError: `Cannot query field "add_Users" on type "Mutation".`,
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestDeleteCollection_WithDocuments_ReturnsError(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type Users {
+						name: String
+					}
+				`,
+			},
+			&action.AddDoc{
+				DocMap: map[string]any{
+					"name": "John",
+				},
+			},
+			&action.DeleteCollection{
+				Name:          "Users",
+				ExpectedError: "cannot delete a collection that has documents",
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestDeleteCollection_WithSoftDeletedDocuments_ReturnsError(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type Users {
+						name: String
+					}
+				`,
+			},
+			&action.AddDoc{
+				DocMap: map[string]any{
+					"name": "John",
+				},
+			},
+			testUtils.DeleteDoc{
+				CollectionID: 0,
+				DocID:        0,
+			},
+			&action.DeleteCollection{
+				Name:          "Users",
+				ExpectedError: "cannot delete a collection that has documents",
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestDeleteCollection_NonExistentCollection_ReturnsError(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.DeleteCollection{
+				Name:          "NonExistent",
+				ExpectedError: "collection not found",
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestDeleteCollection_MultipleCollections_DeleteOne(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type Users {
+						name: String
+					}
+					type Books {
+						title: String
+					}
+				`,
+			},
+			&action.DeleteCollection{
+				Name: "Users",
+			},
+			&action.GetCollections{
+				ExpectedResults: []client.CollectionVersion{
+					{
+						Name:           "Books",
+						IsMaterialized: true,
+						IsActive:       true,
+					},
+				},
+			},
+			&action.Request{
+				Request: `query {
+					Books {
+						title
+					}
+				}`,
+				Results: map[string]any{
+					"Books": []map[string]any{},
+				},
+			},
+			&action.Request{
+				Request: `query {
+					Users {
+						name
+					}
+				}`,
+				ExpectedError: `Cannot query field "Users" on type "Query".`,
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestDeleteCollection_WithTransaction_Succeeds(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type Users {
+						name: String
+					}
+				`,
+			},
+			&action.DeleteCollection{
+				TransactionID: immutable.Some(1),
+				Name:          "Users",
+			},
+			&action.CommitTransaction{
+				TransactionID: 1,
+			},
+			&action.GetCollections{
+				ExpectedResults: []client.CollectionVersion{},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestDeleteCollection_WithTransactionWithoutCommit_CollectionStillExists(t *testing.T) {
+	test := testUtils.TestCase{
+		// LevelDB does not support concurrent transactions
+		// todo: https://github.com/sourcenetwork/defradb/issues/4442
+		SupportedDatabaseTypes: immutable.Some([]state.DatabaseType{
+			testUtils.BadgerFileType,
+			testUtils.BadgerIMType,
+			testUtils.DefraIMType,
+		}),
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type Users {
+						name: String
+					}
+				`,
+			},
+			&action.DeleteCollection{
+				TransactionID: immutable.Some(1),
+				Name:          "Users",
+			},
+			// Without committing, the collection data should still exist. Verify via
+			// GetCollections which reads from a separate transaction.
+			&action.GetCollections{
+				FilterOptions: options.GetCollections().SetGetInactive(true),
+				ExpectedResults: []client.CollectionVersion{
+					{
+						Name:           "Users",
+						IsMaterialized: true,
+						IsActive:       true,
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestDeleteCollection_DeleteBothCollections_Succeeds(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type Users {
+						name: String
+					}
+					type Books {
+						title: String
+					}
+				`,
+			},
+			&action.DeleteCollection{
+				Name: "Users",
+			},
+			&action.DeleteCollection{
+				Name: "Books",
+			},
+			&action.GetCollections{
+				ExpectedResults: []client.CollectionVersion{},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestDeleteCollection_ReferencedByRelation_ReturnsError(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type Users {
+						name: String
+						books: [Books]
+					}
+					type Books {
+						title: String
+						author: Users
+					}
+				`,
+			},
+			&action.DeleteCollection{
+				Name:          "Users",
+				ExpectedError: "no type found for given name",
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestDeleteCollection_ReferencedByRelation_OtherSide_ReturnsError(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type Users {
+						name: String
+						books: [Books]
+					}
+					type Books {
+						title: String
+						author: Users
+					}
+				`,
+			},
+			&action.DeleteCollection{
+				Name:          "Books",
+				ExpectedError: "no type found for given name",
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/collection_version/updates/remove/collections_test.go
+++ b/tests/integration/collection_version/updates/remove/collections_test.go
@@ -658,6 +658,132 @@ func TestColVersionUpdateAddFieldRemoveMultipleNewCollection_MiddleAndLast(t *te
 	testUtils.ExecuteTestCase(t, test)
 }
 
+// Removing a single collection via patch fails when another collection holds a relation
+// reference to it. The schema rebuild cannot resolve the dangling reference and aborts
+// the transaction, leaving both collections intact.
+func TestColVersionUpdateRemoveCollection_ReferencedByRelation_ReturnsError(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type Users {
+						name: String
+						books: [Books]
+					}
+					type Books {
+						title: String
+						author: Users
+					}
+				`,
+			},
+			&action.PatchCollection{
+				Patch: `
+					[
+						{ "op": "remove", "path": "/Users" }
+					]
+				`,
+				ExpectedError: "no type found for given name",
+			},
+			// Transaction rolled back: both collections still exist.
+			&action.GetCollections{
+				ExpectedResults: []client.CollectionVersion{
+					{
+						Name:           "Books",
+						IsMaterialized: true,
+						IsActive:       true,
+					},
+					{
+						Name:           "Users",
+						IsMaterialized: true,
+						IsActive:       true,
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+// Same as above but removing the other side of the bidirectional relation.
+func TestColVersionUpdateRemoveCollection_ReferencedByRelation_OtherSide_ReturnsError(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type Users {
+						name: String
+						books: [Books]
+					}
+					type Books {
+						title: String
+						author: Users
+					}
+				`,
+			},
+			&action.PatchCollection{
+				Patch: `
+					[
+						{ "op": "remove", "path": "/Books" }
+					]
+				`,
+				ExpectedError: "no type found for given name",
+			},
+			// Transaction rolled back: both collections still exist.
+			&action.GetCollections{
+				ExpectedResults: []client.CollectionVersion{
+					{
+						Name:           "Books",
+						IsMaterialized: true,
+						IsActive:       true,
+					},
+					{
+						Name:           "Users",
+						IsMaterialized: true,
+						IsActive:       true,
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+// A single patch with both remove ops succeeds because the net result has no dangling
+// references. This is the escape hatch for deleting circularly-related collections.
+func TestColVersionUpdateRemoveBothRelatedCollections_Succeeds(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type Users {
+						name: String
+						books: [Books]
+					}
+					type Books {
+						title: String
+						author: Users
+					}
+				`,
+			},
+			&action.PatchCollection{
+				Patch: `
+					[
+						{ "op": "remove", "path": "/Users" },
+						{ "op": "remove", "path": "/Books" }
+					]
+				`,
+			},
+			&action.GetCollections{
+				ExpectedResults: []client.CollectionVersion{},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
 func TestColVersionUpdateRemoveCollections_ConcurrentWrite(t *testing.T) {
 	test := testUtils.TestCase{
 		SupportedClientTypes: immutable.Some([]state.ClientType{

--- a/tests/integration/collection_version/updates/remove/collections_test.go
+++ b/tests/integration/collection_version/updates/remove/collections_test.go
@@ -682,7 +682,7 @@ func TestColVersionUpdateRemoveCollection_ReferencedByRelation_ReturnsError(t *t
 						{ "op": "remove", "path": "/Users" }
 					]
 				`,
-				ExpectedError: "no type found for given name",
+				ExpectedError: "cannot remove a collection while another field references it",
 			},
 			// Transaction rolled back: both collections still exist.
 			&action.GetCollections{
@@ -727,7 +727,7 @@ func TestColVersionUpdateRemoveCollection_ReferencedByRelation_OtherSide_Returns
 						{ "op": "remove", "path": "/Books" }
 					]
 				`,
-				ExpectedError: "no type found for given name",
+				ExpectedError: "cannot remove a collection while another field references it",
 			},
 			// Transaction rolled back: both collections still exist.
 			&action.GetCollections{


### PR DESCRIPTION
## Relevant issue(s)
Resolves #4678 

## Description
- Implement `collection delete` sugar syntax command
- Tie to the same permission as the Patch Collection permission