### PR TITLE
fix: Remove 'concurrent' transaction concept

### DIFF
--- a/cbindings/txn.go
+++ b/cbindings/txn.go
@@ -24,17 +24,11 @@ import (
 )
 
 //export CreateTransaction
-func CreateTransaction(nodePtr C.uintptr_t, isConcurrent C.int, isReadOnly C.int) C.NewTxnResult {
+func CreateTransaction(nodePtr C.uintptr_t, isReadOnly C.int) C.NewTxnResult {
 	h := cgo.Handle(nodePtr)
 	n := h.Value().(*node.Node) //nolint:forcetypeassert
 
-	var tx client.Txn
-	var err error
-	if isConcurrent != 0 {
-		tx, err = n.DB.NewConcurrentTxn(isReadOnly != 0)
-	} else {
-		tx, err = n.DB.NewTxn(isReadOnly != 0)
-	}
+	tx, err := n.DB.NewTxn(isReadOnly != 0)
 	if err != nil {
 		return returnNewTxnResultC(1, err.Error(), nil)
 	}

--- a/cbindings/wrapper.go
+++ b/cbindings/wrapper.go
@@ -63,7 +63,7 @@ extern Result ExecuteQuery(uintptr_t nodePtr, char* query, uintptr_t identity,
 char* operationName, char* variables);
 extern Result AddCollection(uintptr_t nodePtr, char* schema, uintptr_t identity);
 extern Result SetActiveCollection(uintptr_t nodePtr, CollectionOptions options, uintptr_t identityPtr);
-extern NewTxnResult CreateTransaction(uintptr_t nodePtr, int isConcurrent, int isReadOnly);
+extern NewTxnResult CreateTransaction(uintptr_t nodePtr, int isReadOnly);
 extern Result GetVersion(int flagFull, int flagJSON);
 extern Result AddView(uintptr_t nodePtr, char* query, char* sdl, char* transformCIDStr, uintptr_t identityPtr);
 extern Result RefreshView(uintptr_t nodePtr, CollectionOptions options, uintptr_t identityPtr);
@@ -1044,13 +1044,12 @@ func (w *CWrapper) ExecRequest(
 }
 
 func (w *CWrapper) NewTxn(readOnly bool) (client.Txn, error) {
-	var concurrent C.int = 0
 	var cReadOnly C.int = 0
 	if readOnly {
 		cReadOnly = 1
 	}
 
-	res := C.CreateTransaction(C.uintptr_t(w.handle), concurrent, cReadOnly)
+	res := C.CreateTransaction(C.uintptr_t(w.handle), cReadOnly)
 	errText := C.GoString(res.error)
 	defer C.free(unsafe.Pointer(res.error))
 
@@ -1062,29 +1061,6 @@ func (w *CWrapper) NewTxn(readOnly bool) (client.Txn, error) {
 	dsTxn := handle.Value().(datastore.Txn) //nolint:forcetypeassert
 	retTxn := &Transaction{w, dsTxn, handle}
 	txnHandleMap.Store(retTxn.tx.ID(), handle)
-	return retTxn, nil
-}
-
-func (w *CWrapper) NewConcurrentTxn(readOnly bool) (client.Txn, error) {
-	var concurrent C.int = 1
-	var cReadOnly C.int = 0
-	if readOnly {
-		cReadOnly = 1
-	}
-
-	res := C.CreateTransaction(C.uintptr_t(w.handle), concurrent, cReadOnly)
-	errText := C.GoString(res.error)
-	defer C.free(unsafe.Pointer(res.error))
-
-	if res.status != 0 {
-		return nil, errors.New(errText)
-	}
-
-	handle := cgo.Handle(res.txnPtr)
-	dsTxn := handle.Value().(datastore.Txn) //nolint:forcetypeassert
-	retTxn := &Transaction{w, dsTxn, handle}
-	txnHandleMap.Store(retTxn.tx.ID(), handle)
-
 	return retTxn, nil
 }
 

--- a/cli/tx_new.go
+++ b/cli/tx_new.go
@@ -14,12 +14,9 @@ import (
 	"context"
 
 	"github.com/spf13/cobra"
-
-	"github.com/sourcenetwork/defradb/client"
 )
 
 func MakeTxNewCommand(ctx context.Context) *cobra.Command {
-	var concurrent bool
 	var readOnly bool
 	var cmd = &cobra.Command{
 		Use:   "new",
@@ -28,19 +25,13 @@ func MakeTxNewCommand(ctx context.Context) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			cliClient := mustGetContextCLIClient(cmd)
 
-			var tx client.Txn
-			if concurrent {
-				tx, err = cliClient.NewConcurrentTxn(readOnly)
-			} else {
-				tx, err = cliClient.NewTxn(readOnly)
-			}
+			tx, err := cliClient.NewTxn(readOnly)
 			if err != nil {
 				return err
 			}
 			return writeJSON(cmd, map[string]any{"id": tx.ID()})
 		},
 	}
-	cmd.Flags().BoolVar(&concurrent, "concurrent", false, "Transaction is concurrent")
 	cmd.Flags().BoolVar(&readOnly, "read-only", false, "Transaction is read only")
 	return cmd
 }

--- a/client/db.go
+++ b/client/db.go
@@ -36,12 +36,6 @@ type TxnStore interface {
 	//
 	// It may be used with other functions in the client package. It is not threadsafe.
 	NewTxn(readOnly bool) (Txn, error)
-
-	// NewConcurrentTxn returns a new transaction on the root store that may be managed externally.
-	//
-	// It may be used with other functions in the client package. It is threadsafe and multiple threads/Go routines
-	// can safely operate on it concurrently.
-	NewConcurrentTxn(readOnly bool) (Txn, error)
 }
 
 type Store interface {

--- a/docs/website/references/cli/defradb_client_tx_new.md
+++ b/docs/website/references/cli/defradb_client_tx_new.md
@@ -13,9 +13,8 @@ defradb client tx new [flags]
 ### Options
 
 ```
-      --concurrent   Transaction is concurrent
-  -h, --help         help for new
-      --read-only    Transaction is read only
+  -h, --help        help for new
+      --read-only   Transaction is read only
 ```
 
 ### Options inherited from parent commands

--- a/docs/website/references/http/openapi.json
+++ b/docs/website/references/http/openapi.json
@@ -2679,44 +2679,6 @@
                 ]
             }
         },
-        "/tx/concurrent": {
-            "post": {
-                "description": "Create a new concurrent transaction",
-                "operationId": "new_concurrent_transaction",
-                "parameters": [
-                    {
-                        "description": "Read only transaction",
-                        "in": "query",
-                        "name": "read_only",
-                        "schema": {
-                            "default": false,
-                            "type": "boolean"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/create_tx"
-                                }
-                            }
-                        },
-                        "description": "Transaction info"
-                    },
-                    "400": {
-                        "$ref": "#/components/responses/error"
-                    },
-                    "default": {
-                        "description": ""
-                    }
-                },
-                "tags": [
-                    "transaction"
-                ]
-            }
-        },
         "/tx/{id}": {
             "delete": {
                 "description": "Discard a transaction",

--- a/http/client.go
+++ b/http/client.go
@@ -74,26 +74,6 @@ func (c *Client) NewTxn(readOnly bool) (client.Txn, error) {
 	return &Transaction{&Client{c.http}, txRes.ID}, nil
 }
 
-func (c *Client) NewConcurrentTxn(readOnly bool) (client.Txn, error) {
-	query := url.Values{}
-	if readOnly {
-		query.Add("read_only", "true")
-	}
-
-	methodURL := c.http.apiURL.JoinPath("tx", "concurrent")
-	methodURL.RawQuery = query.Encode()
-
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, methodURL.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-	var txRes CreateTxResponse
-	if err := c.http.requestJson(req, &txRes); err != nil {
-		return nil, err
-	}
-	return &Transaction{&Client{c.http}, txRes.ID}, nil
-}
-
 func (c *Client) BasicImport(ctx context.Context, filepath string) error {
 	methodURL := c.http.apiURL.JoinPath("backup", "import")
 

--- a/http/handler_tx.go
+++ b/http/handler_tx.go
@@ -38,20 +38,6 @@ func (h *txHandler) NewTxn(rw http.ResponseWriter, req *http.Request) {
 	responseJSON(rw, http.StatusOK, &CreateTxResponse{tx.ID()})
 }
 
-func (h *txHandler) NewConcurrentTxn(rw http.ResponseWriter, req *http.Request) {
-	db := mustGetContextClientDB(req)
-	txs := mustGetContextSyncMap(req)
-	readOnly, _ := strconv.ParseBool(req.URL.Query().Get("read_only"))
-
-	tx, err := db.NewConcurrentTxn(readOnly)
-	if err != nil {
-		responseJSON(rw, http.StatusBadRequest, errorResponse{err})
-		return
-	}
-	txs.Store(tx.ID(), tx)
-	responseJSON(rw, http.StatusOK, &CreateTxResponse{tx.ID()})
-}
-
 func (h *txHandler) Commit(rw http.ResponseWriter, req *http.Request) {
 	txs := mustGetContextSyncMap(req)
 
@@ -157,7 +143,6 @@ func (h *txHandler) bindRoutes(router *Router) {
 	txnDiscard.Responses.Set("404", errorResponse)
 
 	router.AddRoute("/tx", http.MethodPost, txnCreate, h.NewTxn)
-	router.AddRoute("/tx/concurrent", http.MethodPost, txnConcurrent, h.NewConcurrentTxn)
 	router.AddRoute("/tx/{id}", http.MethodPost, txnCommit, h.Commit)
 	router.AddRoute("/tx/{id}", http.MethodDelete, txnDiscard, h.Discard)
 }

--- a/internal/datastore/concurrent_txn.go
+++ b/internal/datastore/concurrent_txn.go
@@ -76,8 +76,3 @@ func (t *concurrentTxn) Set(ctx context.Context, key []byte, value []byte) error
 	defer t.mu.Unlock()
 	return t.Txn.Set(ctx, key, value)
 }
-
-// Sync executes the transaction.
-func (t *concurrentTxn) Sync(ctx context.Context) error {
-	return t.Commit()
-}

--- a/internal/datastore/concurrent_txn.go
+++ b/internal/datastore/concurrent_txn.go
@@ -13,6 +13,7 @@ package datastore
 import (
 	"context"
 	"sync"
+	"time"
 
 	"github.com/sourcenetwork/corekv"
 	"github.com/sourcenetwork/defradb/internal/db/lock"
@@ -46,6 +47,7 @@ func NewConcurrentTxnFrom(
 		Multistore: multistore,
 		txn:        rootConcurentTxn,
 		id:         id,
+		ts:         time.Now(),
 	}
 }
 

--- a/internal/datastore/concurrent_txn.go
+++ b/internal/datastore/concurrent_txn.go
@@ -31,6 +31,8 @@ type concurrentTxn struct {
 	mu sync.Mutex
 }
 
+var _ corekv.Txn = (*concurrentTxn)(nil)
+
 // newConcurrentTxnFrom creates a new Txn from rootstore that supports concurrent API calls
 func NewConcurrentTxnFrom(
 	rootstore corekv.TxnStore,
@@ -41,13 +43,13 @@ func NewConcurrentTxnFrom(
 ) *BasicTxn {
 	rootTxn := rootstore.NewTxn(readonly)
 	rootConcurentTxn := &concurrentTxn{Txn: rootTxn}
-	multistore := NewMultistore(rootTxn, lockSet, chunkSize)
+	multistore := NewMultistore(rootConcurentTxn, lockSet, chunkSize)
 
 	return &BasicTxn{
-		Multistore: multistore,
-		txn:        rootConcurentTxn,
-		id:         id,
-		ts:         time.Now(),
+		Multistore:    multistore,
+		underlyingTxn: rootTxn,
+		id:            id,
+		ts:            time.Now(),
 	}
 }
 

--- a/internal/datastore/concurrent_txn_test.go
+++ b/internal/datastore/concurrent_txn_test.go
@@ -50,14 +50,3 @@ func TestNewConcurrentTxnFromNonIterable(t *testing.T) {
 	err := txn.Commit()
 	require.NoError(t, err)
 }
-
-func TestConcurrentTxnSync(t *testing.T) {
-	ctx := context.Background()
-	rootstore := getBadgerTxnDB(t)
-
-	txn := rootstore.NewTxn(false)
-
-	cTxn := &concurrentTxn{Txn: txn}
-	err := cTxn.Sync(ctx)
-	require.NoError(t, err)
-}

--- a/internal/datastore/txn.go
+++ b/internal/datastore/txn.go
@@ -82,9 +82,13 @@ type Txn interface {
 type BasicTxn struct {
 	*Multistore
 
-	txn corekv.Txn
-	id  uint64
-	ts  time.Time // timestamp
+	// The raw underlying txn.
+	//
+	// This must be the exact concrete type that corekv expects, as it casts to the concrete type when
+	// fetching it from the context.
+	underlyingTxn corekv.Txn
+	id            uint64
+	ts            time.Time // timestamp
 
 	successFns []func()
 	errorFns   []func()
@@ -107,16 +111,21 @@ func NewTxnFrom(
 ) *BasicTxn {
 	rootTxn := rootstore.NewTxn(readonly)
 	multistore := NewMultistore(rootTxn, lockSet, chunkSize)
+
 	return &BasicTxn{
-		Multistore: multistore,
-		txn:        rootTxn,
-		id:         id,
-		ts:         time.Now(),
+		Multistore:    multistore,
+		underlyingTxn: rootTxn,
+		id:            id,
+		ts:            time.Now(),
 	}
 }
 
+// The raw underlying txn.
+//
+// This must be the exact concrete type that corekv expects, as it casts to the concrete type when
+// fetching it from the context.
 func (t *BasicTxn) Txn() corekv.Txn {
-	return t.txn
+	return t.underlyingTxn
 }
 
 func (t *BasicTxn) ID() uint64 {
@@ -131,7 +140,7 @@ func (t *BasicTxn) Commit() error {
 	var fns []func()
 	var asyncFns []func()
 
-	err := t.txn.Commit()
+	err := t.underlyingTxn.Commit()
 	if err != nil {
 		fns = t.errorFns
 		asyncFns = t.errorAsyncFns
@@ -150,7 +159,7 @@ func (t *BasicTxn) Commit() error {
 }
 
 func (t *BasicTxn) Discard() {
-	t.txn.Discard()
+	t.underlyingTxn.Discard()
 
 	for _, fn := range t.discardAsyncFns {
 		go fn()

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -228,16 +228,6 @@ func (db *DB) NewTxn(readonly bool) (client.Txn, error) {
 		return nil, db.ctx.Err()
 	}
 	txnId := db.previousTxnID.Add(1)
-	txn := datastore.NewTxnFrom(db.rootstore, db.lockSet, txnId, readonly, db.blockStoreChunkSize)
-	return wrapDatastoreTxn(txn, db), nil
-}
-
-// NewConcurrentTxn creates a new transaction that supports concurrent API calls.
-func (db *DB) NewConcurrentTxn(readonly bool) (client.Txn, error) {
-	if db.ctx.Err() != nil {
-		return nil, db.ctx.Err()
-	}
-	txnId := db.previousTxnID.Add(1)
 	txn := datastore.NewConcurrentTxnFrom(db.rootstore, db.lockSet, txnId, readonly, db.blockStoreChunkSize)
 	return wrapDatastoreTxn(txn, db), nil
 }

--- a/js/client.go
+++ b/js/client.go
@@ -63,7 +63,6 @@ func (c *Client) JSValue() js.Value {
 		"deleteNACActorRelationship": goji.Async(c.deleteNACActorRelationship),
 		"getNodeIdentity":            goji.Async(c.getNodeIdentity),
 		"newTxn":                     goji.Async(c.newTxn),
-		"newConcurrentTxn":           goji.Async(c.newConcurrentTxn),
 		"verifySignature":            goji.Async(c.verifySignature),
 		"close":                      goji.Async(c.close),
 	})

--- a/js/client_db.go
+++ b/js/client_db.go
@@ -254,19 +254,6 @@ func (c *Client) newTxn(this js.Value, args []js.Value) (js.Value, error) {
 	return newTransaction(txn, c.txns), nil
 }
 
-func (c *Client) newConcurrentTxn(this js.Value, args []js.Value) (js.Value, error) {
-	readOnly, err := boolArg(args, 0, "readOnly")
-	if err != nil {
-		return js.Undefined(), err
-	}
-	txn, err := c.node.DB.NewConcurrentTxn(readOnly)
-	if err != nil {
-		return js.Undefined(), err
-	}
-	c.txns.Store(txn.ID(), txn)
-	return newTransaction(txn, c.txns), nil
-}
-
 func (c *Client) verifySignature(this js.Value, args []js.Value) (js.Value, error) {
 	pubKeyHex, err := stringArg(args, 0, "publicKey")
 	if err != nil {

--- a/tests/clients/cli/wrapper.go
+++ b/tests/clients/cli/wrapper.go
@@ -758,29 +758,6 @@ func (w *Wrapper) NewTxn(readOnly bool) (client.Txn, error) {
 	return &Transaction{w, tx}, nil
 }
 
-func (w *Wrapper) NewConcurrentTxn(readOnly bool) (client.Txn, error) {
-	args := []string{"client", "tx", "new"}
-	args = append(args, "--concurrent")
-
-	if readOnly {
-		args = append(args, "--read-only")
-	}
-
-	data, err := w.cmd.execute(context.Background(), args)
-	if err != nil {
-		return nil, err
-	}
-	var res http.CreateTxResponse
-	if err := json.Unmarshal(data, &res); err != nil {
-		return nil, err
-	}
-	tx, err := w.handler.Transaction(res.ID)
-	if err != nil {
-		return nil, err
-	}
-	return &Transaction{w, tx}, nil
-}
-
 func (w *Wrapper) Close() {
 	w.serverCancel()
 	w.httpServer.Close()

--- a/tests/clients/http/wrapper.go
+++ b/tests/clients/http/wrapper.go
@@ -383,18 +383,6 @@ func (w *Wrapper) NewTxn(readOnly bool) (client.Txn, error) {
 	return &Transaction{w, serverTxn}, nil
 }
 
-func (w *Wrapper) NewConcurrentTxn(readOnly bool) (client.Txn, error) {
-	clientTxn, err := w.client.NewConcurrentTxn(readOnly)
-	if err != nil {
-		return nil, err
-	}
-	serverTxn, err := w.handler.Transaction(clientTxn.ID())
-	if err != nil {
-		return nil, err
-	}
-	return &Transaction{w, serverTxn}, nil
-}
-
 func (w *Wrapper) Close() {
 	w.serverCancel()
 	w.httpServer.Close()

--- a/tests/clients/js/wrapper.go
+++ b/tests/clients/js/wrapper.go
@@ -567,20 +567,6 @@ func (w *Wrapper) NewTxn(readOnly bool) (client.Txn, error) {
 	return &Transaction{w, txn}, nil
 }
 
-func (w *Wrapper) NewConcurrentTxn(readOnly bool) (client.Txn, error) {
-	res, err := execute(context.Background(), w.value, "newConcurrentTxn", readOnly)
-	if err != nil {
-		return nil, err
-	}
-	client := res[0]
-	id := uint64(client.Get("id").Int())
-	txn, err := w.client.Transaction(id)
-	if err != nil {
-		return nil, err
-	}
-	return &Transaction{w, txn}, nil
-}
-
 func (w *Wrapper) Close() {
 	_ = w.node.Close(context.Background())
 }


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4690

## Description

**Semver breaking change.**

All transactions are now concurrent, at least once https://github.com/sourcenetwork/defradb/issues/4626 is resolved.  The current implementation at least guards against concurrent writes to the same store keys.

`ConcurrentTxn` is now the only transaction type that users will be using.  Non-concurrent transactions are still used by the time-travel code (see `Remove concurrent txn` commit message for more info).

