### PR TITLE
fix: Patching of new fields on cols with sec. relations

### DIFF
--- a/docs/data_format_changes/i4707-sec-rel-field-patches.md
+++ b/docs/data_format_changes/i4707-sec-rel-field-patches.md
@@ -1,0 +1,3 @@
+# PatchCollection fails to set CRDT if secondary relationship exists on collection
+
+New fields added to collections that already had a secondary relation would fail to set a default CRDT if one was not explicitly provided.  Those newly added fields will not work properly and should be deprecated.

--- a/docs/data_format_changes/i4707-sec-rel-field-patches.md
+++ b/docs/data_format_changes/i4707-sec-rel-field-patches.md
@@ -1,3 +1,5 @@
 # PatchCollection fails to set CRDT if secondary relationship exists on collection
 
-New fields added to collections that already had a secondary relation would fail to set a default CRDT if one was not explicitly provided.  Those newly added fields will not work properly and should be deprecated.
+This is not a true breaking change, but in previous Defra versions patching new fields onto a collection that already had a secondary relation would not be provided a default CRDT, and thus would not be writeable.
+
+Those new fields cannot be recovered and should be deprecated.

--- a/internal/db/collection_define.go
+++ b/internal/db/collection_define.go
@@ -219,15 +219,9 @@ existingVersionLoop:
 	}
 
 	for key, col := range newColsByID {
-		previousCol := existingColsByName[col.Name]
-
-		previousFieldNames := make(map[string]struct{}, len(previousCol.Fields))
-		for _, field := range previousCol.Fields {
-			previousFieldNames[field.FieldID] = struct{}{}
-		}
-
 		for i, field := range col.Fields {
-			if _, existed := previousFieldNames[field.FieldID]; !existed && field.Typ == client.NONE_CRDT {
+			// Object fields don't recieve a crdt, so exclude those from this check
+			if field.FieldID == "" && !field.Kind.IsObject() && field.Typ == client.NONE_CRDT {
 				// If no CRDT Type has been provided to a new field, default to LWW_REGISTER.
 				// If the field existed before it might have been explicitly cleared by the user, in which
 				// case it is up to the validation logic to error or not.

--- a/tests/integration/collection_version/updates/add/field/add_test.go
+++ b/tests/integration/collection_version/updates/add/field/add_test.go
@@ -124,7 +124,7 @@ func TestCollectionVersionUpdatesAddFieldWithAddAfterCollectionUpdate(t *testing
 }
 
 // This test documents a bug that was found as part of https://github.com/sourcenetwork/defradb/issues/4707
-// it only occured when adding a field to a collection that already has a secondary relationship.
+// it only occurred when adding a field to a collection that already has a secondary relationship.
 func TestCollectionVersionUpdatesAddField_WithExistingSecondaryOneToOneRelationship(t *testing.T) {
 	test := testUtils.TestCase{
 		Actions: []any{
@@ -147,7 +147,20 @@ func TestCollectionVersionUpdatesAddField_WithExistingSecondaryOneToOneRelations
 				DocMap: map[string]any{
 					"name": "Penguin Books",
 				},
-				ExpectedError: "unknown crdt. Type: none",
+			},
+			&action.Request{
+				Request: `query {
+					Publisher {
+						name
+					}
+				}`,
+				Results: map[string]any{
+					"Publisher": []map[string]any{
+						{
+							"name": "Penguin Books",
+						},
+					},
+				},
 			},
 		},
 	}

--- a/tests/integration/collection_version/updates/add/field/add_test.go
+++ b/tests/integration/collection_version/updates/add/field/add_test.go
@@ -122,3 +122,34 @@ func TestCollectionVersionUpdatesAddFieldWithAddAfterCollectionUpdate(t *testing
 	}
 	testUtils.ExecuteTestCase(t, test)
 }
+
+// This test documents a bug that was found as part of https://github.com/sourcenetwork/defradb/issues/4707
+// it only occured when adding a field to a collection that already has a secondary relationship.
+func TestCollectionVersionUpdatesAddField_WithExistingSecondaryOneToOneRelationship(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type Book {
+						publisher: Publisher @primary
+					}
+
+					type Publisher {
+						book: Book
+					}
+				`,
+			},
+			&action.PatchCollection{
+				Patch: `[{"op":"add","path":"/Publisher/Fields/-","value":{"Name":"name","Kind":"String"}}]`,
+			},
+			&action.AddDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"name": "Penguin Books",
+				},
+				ExpectedError: "unknown crdt. Type: none",
+			},
+		},
+	}
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/collection_version/updates/add/field/add_test.go
+++ b/tests/integration/collection_version/updates/add/field/add_test.go
@@ -123,8 +123,9 @@ func TestCollectionVersionUpdatesAddFieldWithAddAfterCollectionUpdate(t *testing
 	testUtils.ExecuteTestCase(t, test)
 }
 
-// This test documents a bug that was found as part of https://github.com/sourcenetwork/defradb/issues/4707
+// This test covers a bug that was found as part of https://github.com/sourcenetwork/defradb/issues/4707
 // it only occurred when adding a field to a collection that already has a secondary relationship.
+// The bug has been fixed, but the test remains as coverage of this case is important.
 func TestCollectionVersionUpdatesAddField_WithExistingSecondaryOneToOneRelationship(t *testing.T) {
 	test := testUtils.TestCase{
 		Actions: []any{

--- a/tests/integration/index/patch_relation_test.go
+++ b/tests/integration/index/patch_relation_test.go
@@ -190,7 +190,7 @@ func TestPatchRelation_OneToMany_DoesNotAddUniqueIndex(t *testing.T) {
 func TestPatchRelation_OneToOneWithVersionSwitching_IndexOnlyOnActiveVersion(t *testing.T) {
 	const (
 		authorV1 = "bafyreibvcavbxqwimz5vdxe5q5href63g3skc6ytg45hm4fqh6wsx57wmq"
-		authorV2 = "bafyreihr72os6adcvjpsex4phzeefe6k32szyuqdgmyj7vfgvadxulyw5i"
+		authorV2 = "bafyreihv2jdbz3sipc7tqdoycerkcjn6gehr5aleiroqlewvsmjd26unfq"
 	)
 
 	test := testUtils.TestCase{


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4707

## Description

Fixes the patching of new fields on collections with existing secondary relations.

Previously they were being created without a CRDT unless one was explicitly provided, causing subsequent document creation to fail.

Bug found by Kyle.