### PR TITLE
fix: Handle multi-layered self referencing relations

### DIFF
--- a/internal/db/definition_validation.go
+++ b/internal/db/definition_validation.go
@@ -98,10 +98,6 @@ func (s *definitionState) getCollection(
 		}
 
 		for _, col := range s.collections {
-			if col.CollectionID == host.CollectionID {
-				continue
-			}
-
 			if col.CollectionSet.Value().CollectionSetID != host.CollectionSet.Value().CollectionSetID {
 				continue
 			}

--- a/internal/db/description/collection.go
+++ b/internal/db/description/collection.go
@@ -308,10 +308,6 @@ func GetRelatedCollection(
 		}
 
 		for _, col := range cols {
-			if col.CollectionID == host.CollectionID {
-				continue
-			}
-
 			if col.CollectionSet.Value().CollectionSetID != host.CollectionSet.Value().CollectionSetID {
 				continue
 			}

--- a/internal/request/graphql/schema/generate.go
+++ b/internal/request/graphql/schema/generate.go
@@ -1695,10 +1695,6 @@ func (g *Generator) getRelatedCollection(
 		}
 
 		for _, col := range g.typDefCollectionMap {
-			if col.CollectionID == host.CollectionID {
-				continue
-			}
-
 			if col.CollectionSet.Value().CollectionSetID != host.CollectionSet.Value().CollectionSetID {
 				continue
 			}

--- a/tests/gen/collection_cache.go
+++ b/tests/gen/collection_cache.go
@@ -69,10 +69,6 @@ func GetCollection(
 		}
 
 		for _, col := range cache.Collections {
-			if col.CollectionID == host.CollectionID {
-				continue
-			}
-
 			if col.CollectionSet.Value().CollectionSetID != host.CollectionSet.Value().CollectionSetID {
 				continue
 			}

--- a/tests/integration/collection_version/one_one_many_self_ref_test.go
+++ b/tests/integration/collection_version/one_one_many_self_ref_test.go
@@ -14,6 +14,9 @@ package collection_version
 import (
 	"testing"
 
+	"github.com/sourcenetwork/immutable"
+
+	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/tests/action"
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
 )
@@ -25,18 +28,117 @@ func TestCollectionVersionWith_OneOne_OneMany_SelfRef(t *testing.T) {
 		Actions: []any{
 			&action.AddCollection{
 				SDL: `
-					type Dev_RC_Domain2 {
-						routes: [Dev_RC_RedirectRoute2]
-						firstRoute: Dev_RC_RedirectRoute2 @primary @relation(name: "domain_first_route")
+					type Dev_RC_Domain {
+						routes: [Dev_RC_RedirectRoute]
+						firstRoute: Dev_RC_RedirectRoute @primary @relation(name: "domain_first_route")
 					}
 
-					type Dev_RC_RedirectRoute2 {
-						firstForDomain: Dev_RC_Domain2 @relation(name: "domain_first_route")
+					type Dev_RC_RedirectRoute {
+						firstForDomain: Dev_RC_Domain @relation(name: "domain_first_route")
 
-						domain: Dev_RC_Domain2
-						after: Dev_RC_RedirectRoute2
+						domain: Dev_RC_Domain
+						after: Dev_RC_RedirectRoute
 					}
 				`,
+			},
+			&action.GetCollections{
+				ExpectedResults: []client.CollectionVersion{
+					{
+						Name:           "Dev_RC_Domain",
+						IsActive:       true,
+						IsMaterialized: true,
+						Fields: []client.CollectionFieldDescription{
+							{
+								Name: "_docID",
+								Kind: client.FieldKind_DocID,
+								Typ:  client.NONE_CRDT,
+							},
+							{
+								Name:         "_firstRouteID",
+								Kind:         client.FieldKind_DocID,
+								Typ:          client.LWW_REGISTER,
+								IsPrimary:    true,
+								RelationName: immutable.Some("domain_first_route"),
+							},
+							{
+								Name: "firstRoute",
+								Kind: &client.SelfKind{
+									RelativeID: "1",
+								},
+								Typ:          client.NONE_CRDT,
+								IsPrimary:    true,
+								RelationName: immutable.Some("domain_first_route"),
+							},
+							{
+								Name: "routes",
+								Kind: &client.SelfKind{
+									RelativeID: "1",
+									Array:      true,
+								},
+								Typ:          client.NONE_CRDT,
+								RelationName: immutable.Some("dev_rc_domain_dev_rc_redirectroute"),
+							},
+						},
+					},
+					{
+						Name:           "Dev_RC_RedirectRoute",
+						IsActive:       true,
+						IsMaterialized: true,
+						Fields: []client.CollectionFieldDescription{
+							{
+								Name: "_docID",
+								Kind: client.FieldKind_DocID,
+								Typ:  client.NONE_CRDT,
+							},
+							{
+								Name:         "_afterID",
+								Kind:         client.FieldKind_DocID,
+								Typ:          client.LWW_REGISTER,
+								IsPrimary:    true,
+								RelationName: immutable.Some("dev_rc_redirectroute_dev_rc_redirectroute"),
+							},
+							{
+								Name:         "_domainID",
+								Kind:         client.FieldKind_DocID,
+								Typ:          client.LWW_REGISTER,
+								IsPrimary:    true,
+								RelationName: immutable.Some("dev_rc_domain_dev_rc_redirectroute"),
+							},
+							{
+								Name:         "_firstForDomainID",
+								Kind:         client.FieldKind_DocID,
+								Typ:          client.LWW_REGISTER,
+								RelationName: immutable.Some("domain_first_route"),
+							},
+							{
+								Name: "after",
+								Kind: &client.SelfKind{
+									RelativeID: "1",
+								},
+								Typ:          client.NONE_CRDT,
+								IsPrimary:    true,
+								RelationName: immutable.Some("dev_rc_redirectroute_dev_rc_redirectroute"),
+							},
+							{
+								Name: "domain",
+								Kind: &client.SelfKind{
+									RelativeID: "0",
+								},
+								Typ:          client.NONE_CRDT,
+								IsPrimary:    true,
+								RelationName: immutable.Some("dev_rc_domain_dev_rc_redirectroute"),
+							},
+							{
+								Name: "firstForDomain",
+								Kind: &client.SelfKind{
+									RelativeID: "0",
+								},
+								Typ:          client.NONE_CRDT,
+								RelationName: immutable.Some("domain_first_route"),
+							},
+						},
+					},
+				},
 			},
 		},
 	}

--- a/tests/integration/collection_version/one_one_many_self_ref_test.go
+++ b/tests/integration/collection_version/one_one_many_self_ref_test.go
@@ -37,7 +37,6 @@ func TestCollectionVersionWith_OneOne_OneMany_SelfRef(t *testing.T) {
 						after: Dev_RC_RedirectRoute2
 					}
 				`,
-				ExpectedError: "no type found for given name. Field: after, Kind: Self-1",
 			},
 		},
 	}

--- a/tests/integration/collection_version/one_one_many_self_ref_test.go
+++ b/tests/integration/collection_version/one_one_many_self_ref_test.go
@@ -1,0 +1,46 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// This file is part of the DefraDB test suite.
+//
+// The DefraDB test suite is licensed under either:
+//
+//   (1) GNU Affero General Public License v3
+//   (2) Business Source License 1.1
+//
+// See tests/LICENSE for details.
+
+package collection_version
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/defradb/tests/action"
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+// This test covers a bug that was found as part of https://github.com/sourcenetwork/defradb/issues/4710
+// The bug has been fixed, but the test remains as coverage of this case is important.
+func TestCollectionVersionWith_OneOne_OneMany_SelfRef(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type Dev_RC_Domain2 {
+						routes: [Dev_RC_RedirectRoute2]
+						firstRoute: Dev_RC_RedirectRoute2 @primary @relation(name: "domain_first_route")
+					}
+
+					type Dev_RC_RedirectRoute2 {
+						firstForDomain: Dev_RC_Domain2 @relation(name: "domain_first_route")
+
+						domain: Dev_RC_Domain2
+						after: Dev_RC_RedirectRoute2
+					}
+				`,
+				ExpectedError: "no type found for given name. Field: after, Kind: Self-1",
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4710

## Description

Handles multi-layered self referencing relations, where a self relation contains another self-relation.

Fix is fairly straightforward, there was a check that was incorrectly added and then copy-pasted about that remained dead to existing tests until this scenario was added.

It was not hit before as size 1 self referencing blocks omit the `RelativeID` and are returned earlier in the switch.