### PR TITLE
refactor(i): Remove ctx-txn deadcode

### DIFF
--- a/cbindings/test_utils.go
+++ b/cbindings/test_utils.go
@@ -165,12 +165,7 @@ func getNodeOrTxnHandle(nodeHandle cgo.Handle, ctx context.Context) C.uintptr_t 
 // attached to it, and if so, attaches it to the context
 func setCtxTxnFromCollection(ctx context.Context, c *Collection) context.Context {
 	if c.txn.HasValue() {
-		txn, ok := c.txn.Value().(datastore.Txn)
-		if !ok {
-			// This should not happen, but we defensively panic to be safe
-			panic("txn is not a datastore.Txn")
-		}
-		return datastore.CtxSetTxn(ctx, txn)
+		return datastore.CtxSetTxn(ctx, c.txn.Value())
 	}
 	return ctx
 }

--- a/cbindings/wrapper.go
+++ b/cbindings/wrapper.go
@@ -895,11 +895,6 @@ func (w *CWrapper) GetCollections(
 	ctx context.Context,
 	opts ...options.Enumerable[options.GetCollectionsOptions],
 ) ([]client.Collection, error) {
-	txn, hadTxn := datastore.CtxTryGetClientTxn(ctx)
-	if hadTxn {
-		ctx = datastore.CtxSetFromClientTxn(ctx, txn)
-	}
-
 	copts := getCollectionsOptionsToCOptions(utils.NewOptions(opts...))
 	defer C.free(unsafe.Pointer(copts.version))
 	defer C.free(unsafe.Pointer(copts.collectionID))
@@ -920,12 +915,7 @@ func (w *CWrapper) GetCollections(
 		return nil, err
 	}
 
-	var txnOpt immutable.Option[client.Txn]
-	if hadTxn {
-		txnOpt = immutable.Some(txn)
-	} else {
-		txnOpt = immutable.None[client.Txn]()
-	}
+	txnOpt := datastore.CtxTryGetTxnOption(ctx)
 
 	cols := make([]client.Collection, len(defs))
 	for i, def := range defs {

--- a/cbindings/wrapper_collection.go
+++ b/cbindings/wrapper_collection.go
@@ -35,6 +35,7 @@ import (
 
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/options"
+	"github.com/sourcenetwork/defradb/internal/datastore"
 	"github.com/sourcenetwork/defradb/internal/utils"
 	"github.com/sourcenetwork/immutable"
 )
@@ -44,7 +45,7 @@ var _ client.Collection = (*Collection)(nil)
 type Collection struct {
 	def client.CollectionVersion
 	w   *CWrapper
-	txn immutable.Option[client.Txn]
+	txn immutable.Option[datastore.Txn]
 }
 
 func (c *Collection) Version() client.CollectionVersion {

--- a/internal/datastore/txn.go
+++ b/internal/datastore/txn.go
@@ -219,15 +219,15 @@ func CtxTryGetClientTxn(ctx context.Context) (client.Txn, bool) {
 	return txn, ok
 }
 
-// CtxTryGetClientTxnOption returns a immutable.Option[client.Txn] which wraps the
+// CtxTryGetTxnOption returns a immutable.Option[client.Txn] which wraps the
 // transaction present inside a context, if it exists, or None if it does not.
-func CtxTryGetClientTxnOption(ctx context.Context) immutable.Option[client.Txn] {
-	txn, gotTxn := CtxTryGetClientTxn(ctx)
-	var txnOpt immutable.Option[client.Txn]
+func CtxTryGetTxnOption(ctx context.Context) immutable.Option[Txn] {
+	txn, gotTxn := CtxTryGetTxn(ctx)
+	var txnOpt immutable.Option[Txn]
 	if gotTxn {
 		txnOpt = immutable.Some(txn)
 	} else {
-		txnOpt = immutable.None[client.Txn]()
+		txnOpt = immutable.None[Txn]()
 	}
 	return txnOpt
 }

--- a/internal/datastore/txn.go
+++ b/internal/datastore/txn.go
@@ -219,7 +219,7 @@ func CtxTryGetClientTxn(ctx context.Context) (client.Txn, bool) {
 	return txn, ok
 }
 
-// CtxTryGetTxnOption returns a immutable.Option[client.Txn] which wraps the
+// CtxTryGetTxnOption returns a immutable.Option[Txn] which wraps the
 // transaction present inside a context, if it exists, or None if it does not.
 func CtxTryGetTxnOption(ctx context.Context) immutable.Option[Txn] {
 	txn, gotTxn := CtxTryGetTxn(ctx)

--- a/internal/db/backup.go
+++ b/internal/db/backup.go
@@ -231,7 +231,7 @@ func (db *DB) basicExport(ctx context.Context, config *client.BackupConfig) (err
 								return err
 							}
 
-							txnOpt := datastore.CtxTryGetClientTxnOption(ctx)
+							txnOpt := datastore.CtxTryGetTxnOption(ctx)
 							foreignCol, err := db.newCollection(foreignDef, txnOpt)
 							if err != nil {
 								return err

--- a/internal/db/collection.go
+++ b/internal/db/collection.go
@@ -34,7 +34,7 @@ type collection struct {
 	def            client.CollectionVersion
 	indexes        []CollectionIndex
 	fetcherFactory func() fetcher.Fetcher
-	txn            immutable.Option[client.Txn]
+	txn            immutable.Option[datastore.Txn]
 }
 
 // @todo: Move the base Descriptions to an internal API within the db/ package.
@@ -44,7 +44,7 @@ type collection struct {
 // CollectionOptions object.
 
 // newCollection returns a pointer to a newly instantiated DB Collection
-func (db *DB) newCollection(desc client.CollectionVersion, txn immutable.Option[client.Txn]) (*collection, error) {
+func (db *DB) newCollection(desc client.CollectionVersion, txn immutable.Option[datastore.Txn]) (*collection, error) {
 	col := &collection{
 		db:  db,
 		def: desc,
@@ -197,11 +197,11 @@ func (db *DB) getCollections(
 
 		// In the case that the txn was ephemeral, we will not save a reference to it
 		// attached to the collection.
-		var txnOpt immutable.Option[client.Txn]
+		var txnOpt immutable.Option[datastore.Txn]
 		if txnIsEphemeral {
-			txnOpt = immutable.None[client.Txn]()
+			txnOpt = immutable.None[datastore.Txn]()
 		} else {
-			txnOpt = datastore.CtxTryGetClientTxnOption(ctx)
+			txnOpt = datastore.CtxTryGetTxnOption(ctx)
 		}
 		collection, err := db.newCollection(col, txnOpt)
 		if err != nil {
@@ -253,7 +253,7 @@ func getTxnAndSetCtxForCollection(ctx context.Context, c *collection) (context.C
 	txn, hadTxn := datastore.CtxTryGetTxn(ctx)
 	if !hadTxn && c.txn.HasValue() {
 		hadTxn = true
-		txn = c.txn.Value().(datastore.Txn)
+		txn = c.txn.Value()
 		ctx = datastore.CtxSetTxn(ctx, txn)
 	}
 	return ctx, txn, hadTxn

--- a/internal/db/collection_define.go
+++ b/internal/db/collection_define.go
@@ -89,7 +89,7 @@ func (db *DB) addCollections(
 			return nil, err
 		}
 
-		txnOpt := datastore.CtxTryGetClientTxnOption(ctx)
+		txnOpt := datastore.CtxTryGetTxnOption(ctx)
 
 		col, err := db.newCollection(def.Definition, txnOpt)
 		if err != nil {
@@ -332,7 +332,7 @@ existingVersionLoop:
 
 		if col.IsActive {
 			if indexReqs, hasReqs := oneToOneIndexRequests[col.Name]; hasReqs {
-				txnOpt := datastore.CtxTryGetClientTxnOption(ctx)
+				txnOpt := datastore.CtxTryGetTxnOption(ctx)
 				colObj, err := db.newCollection(col, txnOpt)
 				if err != nil {
 					return err

--- a/internal/db/collection_index.go
+++ b/internal/db/collection_index.go
@@ -768,7 +768,7 @@ func (db *DB) reindexNewActiveVersion(ctx context.Context, col client.Collection
 		return nil
 	}
 
-	txnOpt := datastore.CtxTryGetClientTxnOption(ctx)
+	txnOpt := datastore.CtxTryGetTxnOption(ctx)
 	collection, err := db.newCollection(col, txnOpt)
 	if err != nil {
 		return err

--- a/internal/db/collection_retriever.go
+++ b/internal/db/collection_retriever.go
@@ -18,18 +18,16 @@ import (
 	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/options"
-	"github.com/sourcenetwork/defradb/errors"
-	"github.com/sourcenetwork/defradb/internal/datastore"
 )
 
 // collectionRetriever is a helper struct that retrieves a collection from a document ID.
 type collectionRetriever struct {
-	db    client.TxnStore
+	db    *DB
 	ident immutable.Option[identity.Identity]
 }
 
 // NewCollectionRetriever creates a new CollectionRetriever.
-func NewCollectionRetriever(db client.TxnStore) collectionRetriever {
+func NewCollectionRetriever(db *DB) collectionRetriever {
 	return collectionRetriever{
 		db: db,
 	}
@@ -46,8 +44,6 @@ func (r collectionRetriever) RetrieveCollectionFromDocID(
 	ctx context.Context,
 	docID string,
 ) (client.Collection, error) {
-	_, hadTxn := datastore.CtxTryGetTxn(ctx)
-
 	ctx, txn, err := ensureContextTxn(ctx, r.db, false)
 	if err != nil {
 		return nil, err
@@ -74,18 +70,7 @@ func (r collectionRetriever) RetrieveCollectionFromDocID(
 		opt = opt.SetIdentity(r.ident.Value())
 	}
 
-	// If we have a transaction, we will use it here. Otherwise we use r.db
-	var cols []client.Collection
-	if hadTxn {
-		clientTxn, ok := txn.(client.Txn)
-		// This error should not happen through any normal code path, but we can be defensive here.
-		if !ok {
-			return nil, errors.New("unsupported txn type in context")
-		}
-		cols, _ = clientTxn.GetCollections(ctx, opt)
-	} else {
-		cols, _ = r.db.GetCollections(ctx, opt)
-	}
+	cols, _ := txn.GetCollections(ctx, opt)
 
 	if len(cols) == 0 {
 		return nil, client.NewErrCollectionNotFoundForCollectionVersion(

--- a/internal/db/txn.go
+++ b/internal/db/txn.go
@@ -23,11 +23,6 @@ import (
 	"github.com/sourcenetwork/defradb/internal/datastore"
 )
 
-// transactionDB is a db that can create transactions.
-type transactionDB interface {
-	NewTxn(bool) (client.Txn, error)
-}
-
 // ensureContextTxn ensures that the returned context has a transaction.
 //
 // If a transactions exists on the context it will be made explicit,
@@ -35,41 +30,30 @@ type transactionDB interface {
 //
 // The returned context will contain the transaction
 // along with the copied values from the input context.
-func ensureContextTxn(ctx context.Context, db transactionDB, readOnly bool) (context.Context, datastore.Txn, error) {
+func ensureContextTxn(ctx context.Context, db *DB, readOnly bool) (context.Context, *Txn, error) {
 	// explicit transaction
 	ctxTxn, ok := datastore.CtxTryGetTxn(ctx)
 	if ok {
-		switch txn := ctxTxn.(type) {
-		case *Txn:
-			if txn.explicit {
-				// if it's already an explicit txn we return it as is.
-				return InitContext(ctx, txn), txn, nil
-			}
-			// If the txn has already been set on the context but it hasn't already been set as explicit,
-			// we create a copy of the txn and mark it as an explicit txn.
-			explicitTxn := &Txn{
-				txn.BasicTxn,
-				txn.db,
-				true,
-			}
-			return InitContext(ctx, explicitTxn), explicitTxn, nil
-		case *datastore.BasicTxn:
-			// There are scenarios where the transaction passed to the `db` methods was created
-			// from a separate package (ex: `net`). In that situation the type of transaction passed in
-			// will most likely be of type `*datastore.Txn`. We can wrap it in a `*Txn` and mark it as explicit.
-			//
-			// WARNING: This scenario creates a transaction where `*DB` is nil. Calling any method that requires this
-			// will result in a panic.
-			explicitTxn := &Txn{
-				txn,
-				nil,
-				true,
-			}
-			return InitContext(ctx, explicitTxn), explicitTxn, nil
-		default:
+		txn, ok := ctxTxn.(*Txn)
+		if !ok {
 			return nil, nil, NewErrUnsupportedTxnType(ctxTxn)
 		}
+
+		if txn.explicit {
+			// if it's already an explicit txn we return it as is.
+			return InitContext(ctx, txn), txn, nil
+		}
+
+		// If the txn has already been set on the context but it hasn't already been set as explicit,
+		// we create a copy of the txn and mark it as an explicit txn.
+		explicitTxn := &Txn{
+			txn.BasicTxn,
+			txn.db,
+			true,
+		}
+		return InitContext(ctx, explicitTxn), explicitTxn, nil
 	}
+
 	clientTxn, err := db.NewTxn(readOnly)
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4715

## Description

Removes some ctx-txn deadcode.

There are quite a few more improvements that can be made, particularly to the CLI/Http and test clients, but I was only doing this in-preparation/for-learning for the shelved txn refactor mentioned in the last standup and don't want to spend more time on this now.