### PR TITLE
refactor: Remove txnMapHandle from C Binding wrapper

### DIFF
--- a/cbindings/test_utils.go
+++ b/cbindings/test_utils.go
@@ -153,18 +153,12 @@ func getNodeOrTxnHandle(nodeHandle cgo.Handle, ctx context.Context) C.uintptr_t 
 		return C.uintptr_t(nodeHandle)
 	}
 
-	id := txn.ID()
-
-	if storedHandle, ok := txnHandleMap.Load(id); ok {
-		handle, ok := storedHandle.(cgo.Handle)
-		if !ok {
-			// This should not happen, but we defensively panic to be safe
-			panic("txnHandleMap stored value is not a cgo.Handle")
-		}
-		return C.uintptr_t(handle)
+	ctxn, ok := txn.(*Transaction)
+	if !ok {
+		return C.uintptr_t(nodeHandle)
 	}
 
-	return C.uintptr_t(nodeHandle)
+	return C.uintptr_t(ctxn.handle)
 }
 
 // setCtxTxnFromCollection is a helper function that checks if a collection has a transaction

--- a/cbindings/wrapper.go
+++ b/cbindings/wrapper.go
@@ -77,7 +77,6 @@ import (
 	"fmt"
 	"runtime/cgo"
 	"strings"
-	"sync"
 	"time"
 	"unsafe"
 
@@ -94,8 +93,6 @@ import (
 	"github.com/sourcenetwork/immutable"
 	"github.com/sourcenetwork/lens/host-go/config/model"
 )
-
-var txnHandleMap = sync.Map{} // map[client.Txn]cgo.Handle
 
 var _ client.TxnStore = (*CWrapper)(nil)
 var _ client.P2P = (*CWrapper)(nil)
@@ -1060,7 +1057,6 @@ func (w *CWrapper) NewTxn(readOnly bool) (client.Txn, error) {
 	handle := cgo.Handle(res.txnPtr)
 	dsTxn := handle.Value().(datastore.Txn) //nolint:forcetypeassert
 	retTxn := &Transaction{w, dsTxn, handle}
-	txnHandleMap.Store(retTxn.tx.ID(), handle)
 	return retTxn, nil
 }
 

--- a/cbindings/wrapper_tx.go
+++ b/cbindings/wrapper_tx.go
@@ -54,7 +54,6 @@ func (txn *Transaction) StartTS() time.Time {
 
 func (txn *Transaction) Commit() error {
 	res := ConvertAndFreeCResult(C.CommitTransaction(C.uintptr_t(txn.handle)))
-	txnHandleMap.Delete(txn.ID())
 	if res.Status != 0 {
 		return errors.New(res.Error)
 	}
@@ -63,7 +62,6 @@ func (txn *Transaction) Commit() error {
 
 func (txn *Transaction) Discard() {
 	C.DiscardTransaction(C.uintptr_t(txn.handle))
-	txnHandleMap.Delete(txn.ID())
 }
 
 func (txn *Transaction) PrintDump(ctx context.Context) error {


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4724 

## Description

This removes an unnecessary map that was used to maintain Transactions in the wrapper for the C bindings. It is no longer necessary, and is a hold-over from a time when transactions were not integrated correctly into the test harness to begin with.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Specify the platform(s) on which this was tested:
- WSL
