### PR TITLE
fix: Seed CollectionVersions from DB

### DIFF
--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -303,6 +303,7 @@ func executeTestCase(
 	// by the change detector so we should fetch them here at the start too (if they exist).
 	// collections are by node (index), as they are specific to nodes.
 	refreshCollections(s, immutable.None[int](), immutable.None[state.Identity]())
+	seedCollectionVersionsFromState(s)
 	refreshDocuments(s, testCase, startActionIndex)
 
 	for i := startActionIndex; i <= endActionIndex; i++ {
@@ -951,6 +952,71 @@ func refreshTokens(
 			s.Identities[identKey] = identHolder
 		}
 	}
+}
+
+// seedCollectionVersionsFromState populates s.CollectionVersions with the version IDs
+// of any collection versions already present in the database. This ensures that
+// {{.CollectionVersionID<N>}} templates resolve to the same values across the change
+// detector source/target split, where setup-only actions run in one process and the
+// rest in another (and s.CollectionVersions does not survive process boundaries).
+//
+// Versions are walked from oldest to newest via the PreviousVersion chain so the
+// indexing matches the order in which they were created.
+func seedCollectionVersionsFromState(s *state.State) {
+	if len(s.Nodes) == 0 {
+		return
+	}
+
+	node := s.Nodes[0]
+
+	identOption := getIdentityForRequestSpecificToNode(s, NodeIdentity(0), 0)
+	getOpts := options.GetCollections().SetGetInactive(true)
+	if identOption.HasValue() {
+		getOpts.SetIdentity(identOption.Value())
+	}
+	allCols, err := node.GetCollections(s.Ctx, getOpts)
+	require.NoError(s.T, err)
+
+	colsByVersionID := make(map[string]client.Collection, len(allCols))
+	for _, col := range allCols {
+		colsByVersionID[col.Version().VersionID] = col
+	}
+
+	// For each active collection (canonical order in node.Collections), walk back
+	// the PreviousVersion chain to root, then append from root forward.
+	for _, active := range node.Collections {
+		if active == nil {
+			continue
+		}
+
+		var chain []string
+		current := active.Version()
+		for {
+			chain = append(chain, current.VersionID)
+			if !current.PreviousVersion.HasValue() {
+				break
+			}
+			prevID := current.PreviousVersion.Value().SourceCollectionID
+			prev, ok := colsByVersionID[prevID]
+			if !ok {
+				break
+			}
+			current = prev.Version()
+		}
+
+		for i := len(chain) - 1; i >= 0; i-- {
+			appendCollectionVersionID(s, chain[i])
+		}
+	}
+}
+
+// appendCollectionVersionID appends a collection version ID to s.CollectionVersions
+// if it is not already present.
+func appendCollectionVersionID(s *state.State, versionID string) {
+	if slices.Contains(s.CollectionVersions, versionID) {
+		return
+	}
+	s.CollectionVersions = append(s.CollectionVersions, versionID)
 }
 
 // refreshCollections refreshes all the collections of the given names, preserving order.

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -962,6 +962,10 @@ func refreshTokens(
 //
 // Versions are walked from oldest to newest via the PreviousVersion chain so the
 // indexing matches the order in which they were created.
+//
+// Note: this reads version IDs from the post-upgrade Defra on both sides of the
+// change detector split, so assertions using these templates are not actually
+// covered by the change detector. See https://github.com/sourcenetwork/defradb/issues/4752.
 func seedCollectionVersionsFromState(s *state.State) {
 	if len(s.Nodes) == 0 {
 		return


### PR DESCRIPTION
## Relevant issue(s)

Follow-up to #4723.

## Description

#4723 introduced `{{.CollectionVersionID<N>}}` templates, but the only test using them, `TestCollectionMigrationQueryMigratesAcrossMultipleVersions`, fails under the change detector and is currently blocking PRs. Under the change detector, setup actions (`AddCollection`, `AddDoc`) run on the source branch in one process while the rest run on the target branch in another, and `s.CollectionVersions` doesn't survive that boundary — so `{{.CollectionVersionID0}}` resolved to v1 (the first patch result) instead of v0.

The data-format-changes doc added in #4723 made the change detector pass for that PR (a new doc file causes it to skip), but once merged the doc was no longer "new" and every subsequent PR started failing the same test.

This seeds `s.CollectionVersions` at the start of the test from whatever collection versions already exist in the DB, walking the `PreviousVersion` chain so the indices match creation order. With this in place the templates resolve correctly in both phases of the change detector.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Reproduced the failing change detector run locally by splitting `TestCollectionMigrationQueryMigratesAcrossMultipleVersions` into setup-only and target phases via the `DEFRA_CHANGE_DETECTOR_*` env vars; confirmed it fails before the fix and passes after. Also ran the full `tests/integration/collection_version/...` suite under both phases.

Specify the platform(s) on which this was tested:
- MacOS