### PR TITLE
refactor: Use JS txn directly instead of context

### DIFF
--- a/js/client_collection.go
+++ b/js/client_collection.go
@@ -13,7 +13,6 @@
 package js
 
 import (
-	"sync"
 	"syscall/js"
 
 	"github.com/sourcenetwork/defradb/client"
@@ -22,14 +21,12 @@ import (
 )
 
 type clientCollection struct {
-	col  client.Collection
-	txns *sync.Map
+	col client.Collection
 }
 
-func newCollection(col client.Collection, txns *sync.Map) js.Value {
+func newCollection(col client.Collection) js.Value {
 	c := &clientCollection{
-		col:  col,
-		txns: txns,
+		col: col,
 	}
 	return js.ValueOf(map[string]any{
 		"name":                      goji.Async(c.name),
@@ -75,7 +72,7 @@ func (c *clientCollection) newIndex(this js.Value, args []js.Value) (js.Value, e
 	if err := structArg(args, 0, "request", &request); err != nil {
 		return js.Undefined(), err
 	}
-	ctx, err := contextArg(args, 1, c.txns)
+	ctx, err := contextArg(args, 1)
 	if err != nil {
 		return js.Undefined(), err
 	}
@@ -93,7 +90,7 @@ func (c *clientCollection) deleteIndex(this js.Value, args []js.Value) (js.Value
 	if err != nil {
 		return js.Undefined(), err
 	}
-	ctx, err := contextArg(args, 1, c.txns)
+	ctx, err := contextArg(args, 1)
 	if err != nil {
 		return js.Undefined(), err
 	}
@@ -104,7 +101,7 @@ func (c *clientCollection) deleteIndex(this js.Value, args []js.Value) (js.Value
 }
 
 func (c *clientCollection) listIndexes(this js.Value, args []js.Value) (js.Value, error) {
-	ctx, err := contextArg(args, 0, c.txns)
+	ctx, err := contextArg(args, 0)
 	if err != nil {
 		return js.Undefined(), err
 	}
@@ -122,7 +119,7 @@ func (c *clientCollection) newEncryptedIndex(this js.Value, args []js.Value) (js
 	if err := structArg(args, 0, "request", &request); err != nil {
 		return js.Undefined(), err
 	}
-	ctx, err := contextArg(args, 1, c.txns)
+	ctx, err := contextArg(args, 1)
 	if err != nil {
 		return js.Undefined(), err
 	}
@@ -140,7 +137,7 @@ func (c *clientCollection) deleteEncryptedIndex(this js.Value, args []js.Value) 
 	if err != nil {
 		return js.Undefined(), err
 	}
-	ctx, err := contextArg(args, 1, c.txns)
+	ctx, err := contextArg(args, 1)
 	if err != nil {
 		return js.Undefined(), err
 	}
@@ -151,7 +148,7 @@ func (c *clientCollection) deleteEncryptedIndex(this js.Value, args []js.Value) 
 }
 
 func (c *clientCollection) listEncryptedIndexes(this js.Value, args []js.Value) (js.Value, error) {
-	ctx, err := contextArg(args, 0, c.txns)
+	ctx, err := contextArg(args, 0)
 	if err != nil {
 		return js.Undefined(), err
 	}
@@ -165,7 +162,7 @@ func (c *clientCollection) listEncryptedIndexes(this js.Value, args []js.Value) 
 }
 
 func (c *clientCollection) truncate(this js.Value, args []js.Value) (js.Value, error) {
-	ctx, err := contextArg(args, 0, c.txns)
+	ctx, err := contextArg(args, 0)
 	if err != nil {
 		return js.Undefined(), err
 	}

--- a/js/client_db.go
+++ b/js/client_db.go
@@ -28,13 +28,19 @@ func (c *Client) addDACPolicy(this js.Value, args []js.Value) (js.Value, error) 
 	if err != nil {
 		return js.Undefined(), err
 	}
-	ctx, err := contextArg(args, 1, c.txns)
+	ctx, err := contextArg(args, 1)
 	if err != nil {
 		return js.Undefined(), err
 	}
+
+	store, err := contextStoreArg(c.node.DB, args, 1, c.txns)
+	if err != nil {
+		return js.Undefined(), err
+	}
+
 	opt := options.AddDACPolicy()
 	setOptIdentity(opt, args, 1)
-	res, err := c.node.DB.AddDACPolicy(ctx, policy, opt)
+	res, err := store.AddDACPolicy(ctx, policy, opt)
 	if err != nil {
 		return js.Undefined(), err
 	}
@@ -58,13 +64,19 @@ func (c *Client) addDACActorRelationship(this js.Value, args []js.Value) (js.Val
 	if err != nil {
 		return js.Undefined(), err
 	}
-	ctx, err := contextArg(args, 4, c.txns)
+	ctx, err := contextArg(args, 4)
 	if err != nil {
 		return js.Undefined(), err
 	}
+
+	store, err := contextStoreArg(c.node.DB, args, 4, c.txns)
+	if err != nil {
+		return js.Undefined(), err
+	}
+
 	opt := options.AddDACActorRelationship()
 	setOptIdentity(opt, args, 4)
-	res, err := c.node.DB.AddDACActorRelationship(ctx, collectionName, docID, relation, targetActor, opt)
+	res, err := store.AddDACActorRelationship(ctx, collectionName, docID, relation, targetActor, opt)
 	if err != nil {
 		return js.Undefined(), err
 	}
@@ -88,13 +100,19 @@ func (c *Client) deleteDACActorRelationship(this js.Value, args []js.Value) (js.
 	if err != nil {
 		return js.Undefined(), err
 	}
-	ctx, err := contextArg(args, 4, c.txns)
+	ctx, err := contextArg(args, 4)
 	if err != nil {
 		return js.Undefined(), err
 	}
+
+	store, err := contextStoreArg(c.node.DB, args, 4, c.txns)
+	if err != nil {
+		return js.Undefined(), err
+	}
+
 	opt := options.DeleteDACActorRelationship()
 	setOptIdentity(opt, args, 4)
-	res, err := c.node.DB.DeleteDACActorRelationship(ctx, collectionName, docID, relation, targetActor, opt)
+	res, err := store.DeleteDACActorRelationship(ctx, collectionName, docID, relation, targetActor, opt)
 	if err != nil {
 		return js.Undefined(), err
 	}
@@ -122,10 +140,11 @@ func (c *Client) verifyDACAccess(this js.Value, args []js.Value) (js.Value, erro
 	if err != nil {
 		return js.Undefined(), err
 	}
-	ctx, err := contextArg(args, 5, c.txns)
+	ctx, err := contextArg(args, 5)
 	if err != nil {
 		return js.Undefined(), err
 	}
+
 	if !c.node.DB.DocumentACP().HasValue() {
 		return js.Undefined(), fmt.Errorf("ACP system not available")
 	}
@@ -150,13 +169,17 @@ func (c *Client) verifyDACAccess(this js.Value, args []js.Value) (js.Value, erro
 }
 
 func (c *Client) getNACStatus(this js.Value, args []js.Value) (js.Value, error) {
-	ctx, err := contextArg(args, 0, c.txns)
+	ctx, err := contextArg(args, 0)
+	if err != nil {
+		return js.Undefined(), err
+	}
+	store, err := contextStoreArg(c.node.DB, args, 0, c.txns)
 	if err != nil {
 		return js.Undefined(), err
 	}
 	opt := options.GetNACStatus()
 	setOptIdentity(opt, args, 0)
-	res, err := c.node.DB.GetNACStatus(ctx, opt)
+	res, err := store.GetNACStatus(ctx, opt)
 	if err != nil {
 		return js.Undefined(), err
 	}
@@ -164,24 +187,32 @@ func (c *Client) getNACStatus(this js.Value, args []js.Value) (js.Value, error) 
 }
 
 func (c *Client) reEnableNAC(this js.Value, args []js.Value) (js.Value, error) {
-	ctx, err := contextArg(args, 0, c.txns)
+	ctx, err := contextArg(args, 0)
+	if err != nil {
+		return js.Undefined(), err
+	}
+	store, err := contextStoreArg(c.node.DB, args, 0, c.txns)
 	if err != nil {
 		return js.Undefined(), err
 	}
 	opt := options.ReEnableNAC()
 	setOptIdentity(opt, args, 0)
-	err = c.node.DB.ReEnableNAC(ctx, opt)
+	err = store.ReEnableNAC(ctx, opt)
 	return js.Undefined(), err
 }
 
 func (c *Client) disableNAC(this js.Value, args []js.Value) (js.Value, error) {
-	ctx, err := contextArg(args, 0, c.txns)
+	ctx, err := contextArg(args, 0)
+	if err != nil {
+		return js.Undefined(), err
+	}
+	store, err := contextStoreArg(c.node.DB, args, 0, c.txns)
 	if err != nil {
 		return js.Undefined(), err
 	}
 	opt := options.DisableNAC()
 	setOptIdentity(opt, args, 0)
-	err = c.node.DB.DisableNAC(ctx, opt)
+	err = store.DisableNAC(ctx, opt)
 	return js.Undefined(), err
 }
 
@@ -194,13 +225,17 @@ func (c *Client) addNACActorRelationship(this js.Value, args []js.Value) (js.Val
 	if err != nil {
 		return js.Undefined(), err
 	}
-	ctx, err := contextArg(args, 2, c.txns)
+	ctx, err := contextArg(args, 2)
+	if err != nil {
+		return js.Undefined(), err
+	}
+	store, err := contextStoreArg(c.node.DB, args, 2, c.txns)
 	if err != nil {
 		return js.Undefined(), err
 	}
 	opt := options.AddNACActorRelationship()
 	setOptIdentity(opt, args, 2)
-	res, err := c.node.DB.AddNACActorRelationship(ctx, relation, targetActor, opt)
+	res, err := store.AddNACActorRelationship(ctx, relation, targetActor, opt)
 	if err != nil {
 		return js.Undefined(), err
 	}
@@ -216,13 +251,17 @@ func (c *Client) deleteNACActorRelationship(this js.Value, args []js.Value) (js.
 	if err != nil {
 		return js.Undefined(), err
 	}
-	ctx, err := contextArg(args, 2, c.txns)
+	ctx, err := contextArg(args, 2)
+	if err != nil {
+		return js.Undefined(), err
+	}
+	store, err := contextStoreArg(c.node.DB, args, 2, c.txns)
 	if err != nil {
 		return js.Undefined(), err
 	}
 	opt := options.DeleteNACActorRelationship()
 	setOptIdentity(opt, args, 2)
-	res, err := c.node.DB.DeleteNACActorRelationship(ctx, relation, targetActor, opt)
+	res, err := store.DeleteNACActorRelationship(ctx, relation, targetActor, opt)
 	if err != nil {
 		return js.Undefined(), err
 	}
@@ -230,11 +269,17 @@ func (c *Client) deleteNACActorRelationship(this js.Value, args []js.Value) (js.
 }
 
 func (c *Client) getNodeIdentity(this js.Value, args []js.Value) (js.Value, error) {
-	ctx, err := contextArg(args, 0, c.txns)
+	ctx, err := contextArg(args, 0)
 	if err != nil {
 		return js.Undefined(), err
 	}
-	res, err := c.node.DB.GetNodeIdentity(ctx)
+
+	store, err := contextStoreArg(c.node.DB, args, 0, c.txns)
+	if err != nil {
+		return js.Undefined(), err
+	}
+
+	res, err := store.GetNodeIdentity(ctx)
 	if err != nil {
 		return js.Undefined(), err
 	}
@@ -267,7 +312,11 @@ func (c *Client) verifySignature(this js.Value, args []js.Value) (js.Value, erro
 	if err != nil {
 		return js.Undefined(), err
 	}
-	ctx, err := contextArg(args, 3, c.txns)
+	ctx, err := contextArg(args, 3)
+	if err != nil {
+		return js.Undefined(), err
+	}
+	store, err := contextStoreArg(c.node.DB, args, 3, c.txns)
 	if err != nil {
 		return js.Undefined(), err
 	}
@@ -277,7 +326,7 @@ func (c *Client) verifySignature(this js.Value, args []js.Value) (js.Value, erro
 	}
 	opt := options.VerifySignature()
 	setOptIdentity(opt, args, 3)
-	err = c.node.DB.VerifySignature(ctx, blockCID, pubKey, opt)
+	err = store.VerifySignature(ctx, blockCID, pubKey, opt)
 	return js.Undefined(), err
 }
 

--- a/js/client_document.go
+++ b/js/client_document.go
@@ -31,7 +31,7 @@ func (c *clientCollection) addDocument(this js.Value, args []js.Value) (js.Value
 		return js.Undefined(), err
 	}
 
-	ctx, err := contextArg(args, 2, c.txns)
+	ctx, err := contextArg(args, 2)
 	if err != nil {
 		return js.Undefined(), err
 	}
@@ -54,7 +54,7 @@ func (c *clientCollection) addManyDocuments(this js.Value, args []js.Value) (js.
 		return js.Undefined(), err
 	}
 
-	ctx, err := contextArg(args, 2, c.txns)
+	ctx, err := contextArg(args, 2)
 	if err != nil {
 		return js.Undefined(), err
 	}
@@ -102,7 +102,7 @@ func (c *clientCollection) updateDocument(this js.Value, args []js.Value) (js.Va
 	if err != nil {
 		return js.Undefined(), err
 	}
-	ctx, err := contextArg(args, 2, c.txns)
+	ctx, err := contextArg(args, 2)
 	if err != nil {
 		return js.Undefined(), err
 	}
@@ -130,7 +130,7 @@ func (c *clientCollection) deleteDocument(this js.Value, args []js.Value) (js.Va
 	if err != nil {
 		return js.Undefined(), err
 	}
-	ctx, err := contextArg(args, 1, c.txns)
+	ctx, err := contextArg(args, 1)
 	if err != nil {
 		return js.Undefined(), err
 	}
@@ -152,7 +152,7 @@ func (c *clientCollection) existsDocument(this js.Value, args []js.Value) (js.Va
 	if err != nil {
 		return js.Undefined(), err
 	}
-	ctx, err := contextArg(args, 1, c.txns)
+	ctx, err := contextArg(args, 1)
 	if err != nil {
 		return js.Undefined(), err
 	}
@@ -178,7 +178,7 @@ func (c *clientCollection) updateDocumentsWithFilter(this js.Value, args []js.Va
 	if err != nil {
 		return js.Undefined(), err
 	}
-	ctx, err := contextArg(args, 2, c.txns)
+	ctx, err := contextArg(args, 2)
 	if err != nil {
 		return js.Undefined(), err
 	}
@@ -196,7 +196,7 @@ func (c *clientCollection) deleteDocumentsWithFilter(this js.Value, args []js.Va
 	if err != nil {
 		return js.Undefined(), err
 	}
-	ctx, err := contextArg(args, 1, c.txns)
+	ctx, err := contextArg(args, 1)
 	if err != nil {
 		return js.Undefined(), err
 	}
@@ -218,7 +218,7 @@ func (c *clientCollection) getDocument(this js.Value, args []js.Value) (js.Value
 	if err != nil {
 		return js.Undefined(), err
 	}
-	ctx, err := contextArg(args, 2, c.txns)
+	ctx, err := contextArg(args, 2)
 	if err != nil {
 		return js.Undefined(), err
 	}

--- a/js/client_store.go
+++ b/js/client_store.go
@@ -29,13 +29,19 @@ func (c *Client) addCollection(this js.Value, args []js.Value) (js.Value, error)
 	if err != nil {
 		return js.Undefined(), err
 	}
-	ctx, err := contextArg(args, 1, c.txns)
+	ctx, err := contextArg(args, 1)
 	if err != nil {
 		return js.Undefined(), err
 	}
+
+	store, err := contextStoreArg(c.node.DB, args, 1, c.txns)
+	if err != nil {
+		return js.Undefined(), err
+	}
+
 	opt := options.AddCollection()
 	setOptIdentity(opt, args, 1)
-	cols, err := c.node.DB.AddCollection(ctx, sdl, opt)
+	cols, err := store.AddCollection(ctx, sdl, opt)
 	if err != nil {
 		return js.Undefined(), err
 	}
@@ -51,13 +57,19 @@ func (c *Client) patchCollection(this js.Value, args []js.Value) (js.Value, erro
 	if err := structArg(args, 1, "lens", &migration); err != nil {
 		return js.Undefined(), err
 	}
-	ctx, err := contextArg(args, 2, c.txns)
+	ctx, err := contextArg(args, 2)
 	if err != nil {
 		return js.Undefined(), err
 	}
+
+	store, err := contextStoreArg(c.node.DB, args, 2, c.txns)
+	if err != nil {
+		return js.Undefined(), err
+	}
+
 	opt := options.PatchCollection()
 	setOptIdentity(opt, args, 2)
-	err = c.node.DB.PatchCollection(ctx, patch, migration, opt)
+	err = store.PatchCollection(ctx, patch, migration, opt)
 	return js.Undefined(), err
 }
 
@@ -66,13 +78,19 @@ func (c *Client) setActiveCollectionVersion(this js.Value, args []js.Value) (js.
 	if err != nil {
 		return js.Undefined(), err
 	}
-	ctx, err := contextArg(args, 1, c.txns)
+	ctx, err := contextArg(args, 1)
 	if err != nil {
 		return js.Undefined(), err
 	}
+
+	store, err := contextStoreArg(c.node.DB, args, 1, c.txns)
+	if err != nil {
+		return js.Undefined(), err
+	}
+
 	opt := options.SetActiveCollectionVersion()
 	setOptIdentity(opt, args, 1)
-	err = c.node.DB.SetActiveCollectionVersion(ctx, version, opt)
+	err = store.SetActiveCollectionVersion(ctx, version, opt)
 	return js.Undefined(), err
 }
 
@@ -89,16 +107,22 @@ func (c *Client) addView(this js.Value, args []js.Value) (js.Value, error) {
 	if err := structArg(args, 2, "transformCID", &transformCID); err != nil {
 		return js.Undefined(), err
 	}
-	ctx, err := contextArg(args, 3, c.txns)
+	ctx, err := contextArg(args, 3)
 	if err != nil {
 		return js.Undefined(), err
 	}
+
+	store, err := contextStoreArg(c.node.DB, args, 3, c.txns)
+	if err != nil {
+		return js.Undefined(), err
+	}
+
 	opts := options.AddView()
 	setOptIdentity(opts, args, 3)
 	if transformCID.HasValue() {
 		opts.SetTransformCID(transformCID.Value())
 	}
-	cols, err := c.node.DB.AddView(ctx, gqlQuery, sdl, opts)
+	cols, err := store.AddView(ctx, gqlQuery, sdl, opts)
 	if err != nil {
 		return js.Undefined(), err
 	}
@@ -118,13 +142,19 @@ func (c *Client) refreshViews(this js.Value, args []js.Value) (js.Value, error) 
 	if err := structArg(args, 0, "options", &input); err != nil {
 		return js.Undefined(), err
 	}
-	ctx, err := contextArg(args, 1, c.txns)
+	ctx, err := contextArg(args, 1)
 	if err != nil {
 		return js.Undefined(), err
 	}
+
+	store, err := contextStoreArg(c.node.DB, args, 1, c.txns)
+	if err != nil {
+		return js.Undefined(), err
+	}
+
 	opt := collectionFetchOptionsToGetCollectionsOptions(input)
 	setOptIdentity(opt, args, 1)
-	err = c.node.DB.RefreshViews(ctx, opt)
+	err = store.RefreshViews(ctx, opt)
 	return js.Undefined(), err
 }
 
@@ -133,13 +163,19 @@ func (c *Client) setMigration(this js.Value, args []js.Value) (js.Value, error) 
 	if err := structArg(args, 0, "config", &config); err != nil {
 		return js.Undefined(), err
 	}
-	ctx, err := contextArg(args, 1, c.txns)
+	ctx, err := contextArg(args, 1)
 	if err != nil {
 		return js.Undefined(), err
 	}
+
+	store, err := contextStoreArg(c.node.DB, args, 1, c.txns)
+	if err != nil {
+		return js.Undefined(), err
+	}
+
 	opt := options.SetMigration()
 	setOptIdentity(opt, args, 1)
-	lensID, err := c.node.DB.SetMigration(ctx, config, opt)
+	lensID, err := store.SetMigration(ctx, config, opt)
 	if err != nil {
 		return js.Undefined(), err
 	}
@@ -151,13 +187,19 @@ func (c *Client) addLens(this js.Value, args []js.Value) (js.Value, error) {
 	if err := structArg(args, 0, "lens", &lens); err != nil {
 		return js.Undefined(), err
 	}
-	ctx, err := contextArg(args, 1, c.txns)
+	ctx, err := contextArg(args, 1)
 	if err != nil {
 		return js.Undefined(), err
 	}
+
+	store, err := contextStoreArg(c.node.DB, args, 1, c.txns)
+	if err != nil {
+		return js.Undefined(), err
+	}
+
 	opt := options.AddLens()
 	setOptIdentity(opt, args, 1)
-	lensID, err := c.node.DB.AddLens(ctx, lens, opt)
+	lensID, err := store.AddLens(ctx, lens, opt)
 	if err != nil {
 		return js.Undefined(), err
 	}
@@ -165,13 +207,19 @@ func (c *Client) addLens(this js.Value, args []js.Value) (js.Value, error) {
 }
 
 func (c *Client) listLenses(this js.Value, args []js.Value) (js.Value, error) {
-	ctx, err := contextArg(args, 0, c.txns)
+	ctx, err := contextArg(args, 0)
 	if err != nil {
 		return js.Undefined(), err
 	}
+
+	store, err := contextStoreArg(c.node.DB, args, 0, c.txns)
+	if err != nil {
+		return js.Undefined(), err
+	}
+
 	opt := options.ListLenses()
 	setOptIdentity(opt, args, 0)
-	lenses, err := c.node.DB.ListLenses(ctx, opt)
+	lenses, err := store.ListLenses(ctx, opt)
 	if err != nil {
 		return js.Undefined(), err
 	}
@@ -183,17 +231,23 @@ func (c *Client) getCollectionByName(this js.Value, args []js.Value) (js.Value, 
 	if err != nil {
 		return js.Undefined(), err
 	}
-	ctx, err := contextArg(args, 1, c.txns)
+	ctx, err := contextArg(args, 1)
 	if err != nil {
 		return js.Undefined(), err
 	}
+
+	store, err := contextStoreArg(c.node.DB, args, 1, c.txns)
+	if err != nil {
+		return js.Undefined(), err
+	}
+
 	opt := options.GetCollectionByName()
 	setOptIdentity(opt, args, 1)
-	col, err := c.node.DB.GetCollectionByName(ctx, name, opt)
+	col, err := store.GetCollectionByName(ctx, name, opt)
 	if err != nil {
 		return js.Undefined(), err
 	}
-	return newCollection(col, c.txns), nil
+	return newCollection(col), nil
 }
 
 func (c *Client) getCollections(this js.Value, args []js.Value) (js.Value, error) {
@@ -201,19 +255,25 @@ func (c *Client) getCollections(this js.Value, args []js.Value) (js.Value, error
 	if err := structArg(args, 0, "options", &input); err != nil {
 		return js.Undefined(), err
 	}
-	ctx, err := contextArg(args, 1, c.txns)
+	ctx, err := contextArg(args, 1)
 	if err != nil {
 		return js.Undefined(), err
 	}
+
+	store, err := contextStoreArg(c.node.DB, args, 1, c.txns)
+	if err != nil {
+		return js.Undefined(), err
+	}
+
 	opt := collectionFetchOptionsToGetCollectionsOptions(input)
 	setOptIdentity(opt, args, 1)
-	cols, err := c.node.DB.GetCollections(ctx, opt)
+	cols, err := store.GetCollections(ctx, opt)
 	if err != nil {
 		return js.Undefined(), err
 	}
 	wrappers := make([]any, len(cols))
 	for i, col := range cols {
-		wrappers[i] = newCollection(col, c.txns)
+		wrappers[i] = newCollection(col)
 	}
 	return js.ValueOf(wrappers), nil
 }
@@ -237,13 +297,19 @@ func collectionFetchOptionsToGetCollectionsOptions(input collectionFetchOptions)
 }
 
 func (c *Client) listIndexes(this js.Value, args []js.Value) (js.Value, error) {
-	ctx, err := contextArg(args, 0, c.txns)
+	ctx, err := contextArg(args, 0)
 	if err != nil {
 		return js.Undefined(), err
 	}
+
+	store, err := contextStoreArg(c.node.DB, args, 0, c.txns)
+	if err != nil {
+		return js.Undefined(), err
+	}
+
 	opt := options.ListIndexes()
 	setOptIdentity(opt, args, 0)
-	indexes, err := c.node.DB.ListIndexes(ctx, opt)
+	indexes, err := store.ListIndexes(ctx, opt)
 	if err != nil {
 		return js.Undefined(), err
 	}
@@ -251,13 +317,19 @@ func (c *Client) listIndexes(this js.Value, args []js.Value) (js.Value, error) {
 }
 
 func (c *Client) listAllEncryptedIndexes(this js.Value, args []js.Value) (js.Value, error) {
-	ctx, err := contextArg(args, 0, c.txns)
+	ctx, err := contextArg(args, 0)
 	if err != nil {
 		return js.Undefined(), err
 	}
+
+	store, err := contextStoreArg(c.node.DB, args, 0, c.txns)
+	if err != nil {
+		return js.Undefined(), err
+	}
+
 	opt := options.ListAllEncryptedIndexes()
 	setOptIdentity(opt, args, 0)
-	indexes, err := c.node.DB.ListAllEncryptedIndexes(ctx, opt)
+	indexes, err := store.ListAllEncryptedIndexes(ctx, opt)
 	if err != nil {
 		return js.Undefined(), err
 	}
@@ -285,7 +357,12 @@ func (c *Client) execRequest(this js.Value, args []js.Value) (js.Value, error) {
 			opt.SetVariables(variablesMap)
 		}
 	}
-	ctx, err := contextArg(args, 2, c.txns)
+	ctx, err := contextArg(args, 2)
+	if err != nil {
+		return js.Undefined(), err
+	}
+
+	store, err := contextStoreArg(c.node.DB, args, 2, c.txns)
 	if err != nil {
 		return js.Undefined(), err
 	}
@@ -293,7 +370,7 @@ func (c *Client) execRequest(this js.Value, args []js.Value) (js.Value, error) {
 		opt = options.ExecRequest()
 	}
 	setOptIdentity(opt, args, 2)
-	res := c.node.DB.ExecRequest(ctx, request, opt)
+	res := store.ExecRequest(ctx, request, opt)
 	gql, err := goji.MarshalJS(res.GQL)
 	if err != nil {
 		return js.Undefined(), err

--- a/js/client_tx.go
+++ b/js/client_tx.go
@@ -79,7 +79,7 @@ func (t *transaction) addCollection(this js.Value, args []js.Value) (js.Value, e
 	if err != nil {
 		return js.Undefined(), err
 	}
-	ctx, err := contextArg(args, 1, t.txns)
+	ctx, err := contextArg(args, 1)
 	if err != nil {
 		return js.Undefined(), err
 	}
@@ -101,7 +101,7 @@ func (t *transaction) patchCollection(this js.Value, args []js.Value) (js.Value,
 	if err := structArg(args, 1, "lens", &migration); err != nil {
 		return js.Undefined(), err
 	}
-	ctx, err := contextArg(args, 2, t.txns)
+	ctx, err := contextArg(args, 2)
 	if err != nil {
 		return js.Undefined(), err
 	}
@@ -116,7 +116,7 @@ func (t *transaction) setActiveCollectionVersion(this js.Value, args []js.Value)
 	if err != nil {
 		return js.Undefined(), err
 	}
-	ctx, err := contextArg(args, 1, t.txns)
+	ctx, err := contextArg(args, 1)
 	if err != nil {
 		return js.Undefined(), err
 	}
@@ -139,7 +139,7 @@ func (t *transaction) addView(this js.Value, args []js.Value) (js.Value, error) 
 	if err := structArg(args, 2, "transformCID", &transformCID); err != nil {
 		return js.Undefined(), err
 	}
-	ctx, err := contextArg(args, 3, t.txns)
+	ctx, err := contextArg(args, 3)
 	if err != nil {
 		return js.Undefined(), err
 	}
@@ -160,7 +160,7 @@ func (t *transaction) refreshViews(this js.Value, args []js.Value) (js.Value, er
 	if err := structArg(args, 0, "options", &input); err != nil {
 		return js.Undefined(), err
 	}
-	ctx, err := contextArg(args, 1, t.txns)
+	ctx, err := contextArg(args, 1)
 	if err != nil {
 		return js.Undefined(), err
 	}
@@ -175,7 +175,7 @@ func (t *transaction) setMigration(this js.Value, args []js.Value) (js.Value, er
 	if err := structArg(args, 0, "config", &config); err != nil {
 		return js.Undefined(), err
 	}
-	ctx, err := contextArg(args, 1, t.txns)
+	ctx, err := contextArg(args, 1)
 	if err != nil {
 		return js.Undefined(), err
 	}
@@ -193,7 +193,7 @@ func (t *transaction) addLens(this js.Value, args []js.Value) (js.Value, error) 
 	if err := structArg(args, 0, "lens", &lens); err != nil {
 		return js.Undefined(), err
 	}
-	ctx, err := contextArg(args, 1, t.txns)
+	ctx, err := contextArg(args, 1)
 	if err != nil {
 		return js.Undefined(), err
 	}
@@ -207,7 +207,7 @@ func (t *transaction) addLens(this js.Value, args []js.Value) (js.Value, error) 
 }
 
 func (t *transaction) listLenses(this js.Value, args []js.Value) (js.Value, error) {
-	ctx, err := contextArg(args, 0, t.txns)
+	ctx, err := contextArg(args, 0)
 	if err != nil {
 		return js.Undefined(), err
 	}
@@ -225,7 +225,7 @@ func (t *transaction) getCollectionByName(this js.Value, args []js.Value) (js.Va
 	if err != nil {
 		return js.Undefined(), err
 	}
-	ctx, err := contextArg(args, 1, t.txns)
+	ctx, err := contextArg(args, 1)
 	if err != nil {
 		return js.Undefined(), err
 	}
@@ -235,7 +235,7 @@ func (t *transaction) getCollectionByName(this js.Value, args []js.Value) (js.Va
 	if err != nil {
 		return js.Undefined(), err
 	}
-	return newCollection(col, t.txns), nil
+	return newCollection(col), nil
 }
 
 func (t *transaction) getCollections(this js.Value, args []js.Value) (js.Value, error) {
@@ -243,7 +243,7 @@ func (t *transaction) getCollections(this js.Value, args []js.Value) (js.Value, 
 	if err := structArg(args, 0, "options", &input); err != nil {
 		return js.Undefined(), err
 	}
-	ctx, err := contextArg(args, 1, t.txns)
+	ctx, err := contextArg(args, 1)
 	if err != nil {
 		return js.Undefined(), err
 	}
@@ -255,13 +255,13 @@ func (t *transaction) getCollections(this js.Value, args []js.Value) (js.Value, 
 	}
 	wrappers := make([]any, len(cols))
 	for i, col := range cols {
-		wrappers[i] = newCollection(col, t.txns)
+		wrappers[i] = newCollection(col)
 	}
 	return js.ValueOf(wrappers), nil
 }
 
 func (t *transaction) listIndexes(this js.Value, args []js.Value) (js.Value, error) {
-	ctx, err := contextArg(args, 0, t.txns)
+	ctx, err := contextArg(args, 0)
 	if err != nil {
 		return js.Undefined(), err
 	}
@@ -275,7 +275,7 @@ func (t *transaction) listIndexes(this js.Value, args []js.Value) (js.Value, err
 }
 
 func (t *transaction) listAllEncryptedIndexes(this js.Value, args []js.Value) (js.Value, error) {
-	ctx, err := contextArg(args, 0, t.txns)
+	ctx, err := contextArg(args, 0)
 	if err != nil {
 		return js.Undefined(), err
 	}
@@ -309,7 +309,7 @@ func (t *transaction) execRequest(this js.Value, args []js.Value) (js.Value, err
 			opt.SetVariables(variablesMap)
 		}
 	}
-	ctx, err := contextArg(args, 2, t.txns)
+	ctx, err := contextArg(args, 2)
 	if err != nil {
 		return js.Undefined(), err
 	}
@@ -336,7 +336,7 @@ func (t *transaction) addDACPolicy(this js.Value, args []js.Value) (js.Value, er
 	if err != nil {
 		return js.Undefined(), err
 	}
-	ctx, err := contextArg(args, 1, t.txns)
+	ctx, err := contextArg(args, 1)
 	if err != nil {
 		return js.Undefined(), err
 	}
@@ -366,7 +366,7 @@ func (t *transaction) addDACActorRelationship(this js.Value, args []js.Value) (j
 	if err != nil {
 		return js.Undefined(), err
 	}
-	ctx, err := contextArg(args, 4, t.txns)
+	ctx, err := contextArg(args, 4)
 	if err != nil {
 		return js.Undefined(), err
 	}
@@ -396,7 +396,7 @@ func (t *transaction) deleteDACActorRelationship(this js.Value, args []js.Value)
 	if err != nil {
 		return js.Undefined(), err
 	}
-	ctx, err := contextArg(args, 4, t.txns)
+	ctx, err := contextArg(args, 4)
 	if err != nil {
 		return js.Undefined(), err
 	}
@@ -410,7 +410,7 @@ func (t *transaction) deleteDACActorRelationship(this js.Value, args []js.Value)
 }
 
 func (t *transaction) getNACStatus(this js.Value, args []js.Value) (js.Value, error) {
-	ctx, err := contextArg(args, 0, t.txns)
+	ctx, err := contextArg(args, 0)
 	if err != nil {
 		return js.Undefined(), err
 	}
@@ -424,7 +424,7 @@ func (t *transaction) getNACStatus(this js.Value, args []js.Value) (js.Value, er
 }
 
 func (t *transaction) reEnableNAC(this js.Value, args []js.Value) (js.Value, error) {
-	ctx, err := contextArg(args, 0, t.txns)
+	ctx, err := contextArg(args, 0)
 	if err != nil {
 		return js.Undefined(), err
 	}
@@ -435,7 +435,7 @@ func (t *transaction) reEnableNAC(this js.Value, args []js.Value) (js.Value, err
 }
 
 func (t *transaction) disableNAC(this js.Value, args []js.Value) (js.Value, error) {
-	ctx, err := contextArg(args, 0, t.txns)
+	ctx, err := contextArg(args, 0)
 	if err != nil {
 		return js.Undefined(), err
 	}
@@ -454,7 +454,7 @@ func (t *transaction) addNACActorRelationship(this js.Value, args []js.Value) (j
 	if err != nil {
 		return js.Undefined(), err
 	}
-	ctx, err := contextArg(args, 2, t.txns)
+	ctx, err := contextArg(args, 2)
 	if err != nil {
 		return js.Undefined(), err
 	}
@@ -476,7 +476,7 @@ func (t *transaction) deleteNACActorRelationship(this js.Value, args []js.Value)
 	if err != nil {
 		return js.Undefined(), err
 	}
-	ctx, err := contextArg(args, 2, t.txns)
+	ctx, err := contextArg(args, 2)
 	if err != nil {
 		return js.Undefined(), err
 	}
@@ -490,7 +490,7 @@ func (t *transaction) deleteNACActorRelationship(this js.Value, args []js.Value)
 }
 
 func (t *transaction) getNodeIdentity(this js.Value, args []js.Value) (js.Value, error) {
-	ctx, err := contextArg(args, 0, t.txns)
+	ctx, err := contextArg(args, 0)
 	if err != nil {
 		return js.Undefined(), err
 	}
@@ -514,7 +514,7 @@ func (t *transaction) verifySignature(this js.Value, args []js.Value) (js.Value,
 	if err != nil {
 		return js.Undefined(), err
 	}
-	ctx, err := contextArg(args, 3, t.txns)
+	ctx, err := contextArg(args, 3)
 	if err != nil {
 		return js.Undefined(), err
 	}

--- a/js/utils.go
+++ b/js/utils.go
@@ -51,16 +51,6 @@ func boolArg(args []js.Value, index int, name string) (bool, error) {
 	return args[index].Bool(), nil
 }
 
-func intArg(args []js.Value, index int, name string) (int, error) {
-	if len(args) < index {
-		return 0, fmt.Errorf("%s argument is required", name)
-	}
-	if args[index].Type() != js.TypeBoolean {
-		return 0, fmt.Errorf("%s argument must be an int", name)
-	}
-	return args[index].Int(), nil
-}
-
 func structArg(args []js.Value, index int, name string, out any) error {
 	if len(args) < index {
 		return fmt.Errorf("%s argument is required", name)

--- a/js/utils.go
+++ b/js/utils.go
@@ -27,7 +27,6 @@ import (
 	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/crypto"
-	"github.com/sourcenetwork/defradb/internal/db"
 	iIdentity "github.com/sourcenetwork/defradb/internal/identity"
 )
 
@@ -58,7 +57,7 @@ func structArg(args []js.Value, index int, name string, out any) error {
 	return goji.UnmarshalJS(args[index], out)
 }
 
-func contextArg(args []js.Value, index int, txns *sync.Map) (context.Context, error) {
+func contextArg(args []js.Value, index int) (context.Context, error) {
 	ctx := context.Background()
 	if index >= len(args) {
 		return ctx, nil
@@ -67,19 +66,19 @@ func contextArg(args []js.Value, index int, txns *sync.Map) (context.Context, er
 	if err != nil {
 		return ctx, err
 	}
-	txn, err := contextTransactionArg(args[index], txns)
-	if err != nil {
-		return ctx, err
-	}
 	ctx = iIdentity.WithContext(ctx, identity)
-	ctx = db.InitContext(ctx, txn)
 	return ctx, nil
 }
 
-func contextTransactionArg(value js.Value, txns *sync.Map) (client.Txn, error) {
+func contextStoreArg(db client.Store, args []js.Value, index int, txns *sync.Map) (client.Store, error) {
+	if index >= len(args) {
+		return db, nil
+	}
+	value := args[index]
+
 	id := value.Get("transaction")
 	if id.Type() != js.TypeNumber {
-		return nil, nil
+		return db, nil
 	}
 	txn, ok := txns.Load(uint64(id.Int()))
 	if !ok {


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4774
Broken out of, and a requirement for #4763

## Description

Uses the JS transaction directly instead of passing via context.

The previous solution meant that the transaction on the db collection object was not actually being used from JS, bypassing `db.Txn` completely.  It also acted as another source of friction when trying to de-tangle the mess of a situation we have with transactions and contexts.