### PR TITLE
feat: Support querying with multiple cids

### DIFF
--- a/docs/data_format_changes/i4304-no-change-tests-updated.md
+++ b/docs/data_format_changes/i4304-no-change-tests-updated.md
@@ -1,0 +1,3 @@
+# Support querying with multiple cids
+
+Not a breaking change, a test had its definition updated.

--- a/internal/db/fetcher/versioned_multi.go
+++ b/internal/db/fetcher/versioned_multi.go
@@ -1,0 +1,172 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package fetcher
+
+import (
+	"context"
+
+	"github.com/sourcenetwork/defradb/acp/dac"
+	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
+	"github.com/sourcenetwork/defradb/client"
+	"github.com/sourcenetwork/defradb/errors"
+	"github.com/sourcenetwork/defradb/internal/core"
+	"github.com/sourcenetwork/defradb/internal/datastore"
+	acpDB "github.com/sourcenetwork/defradb/internal/db/acp"
+	"github.com/sourcenetwork/defradb/internal/keys"
+	"github.com/sourcenetwork/defradb/internal/planner/mapper"
+	"github.com/sourcenetwork/immutable"
+)
+
+// MultiVersioned is a short term solution that allows multiple prefixes to be
+// fetched via the VersionedFetcher(s).
+//
+// It and the VersionedFetcher need  a rework at some point, migrating them to the
+// `fetcher` interface, and resolving a few other their inefficiencies (such as the
+// one that this type represents).
+type MultiVersioned struct {
+	children     []*VersionedFetcher
+	currentChild int
+
+	ctx         context.Context
+	identity    immutable.Option[acpIdentity.Identity]
+	txn         datastore.Txn
+	nodeACP     acpDB.NACInfo
+	documentACP immutable.Option[dac.DocumentACP]
+	index       immutable.Option[client.IndexDescription]
+	col         client.Collection
+	fields      []client.CollectionFieldDescription
+	filter      *mapper.Filter
+	ordering    []mapper.OrderCondition
+	docmapper   *core.DocumentMapping
+	showDeleted bool
+}
+
+var _ Fetcher = (*MultiVersioned)(nil)
+
+func (f *MultiVersioned) Init(
+	ctx context.Context,
+	identity immutable.Option[acpIdentity.Identity],
+	txn datastore.Txn,
+	nodeACP acpDB.NACInfo,
+	documentACP immutable.Option[dac.DocumentACP],
+	index immutable.Option[client.IndexDescription],
+	col client.Collection,
+	fields []client.CollectionFieldDescription,
+	filter *mapper.Filter,
+	ordering []mapper.OrderCondition,
+	docmapper *core.DocumentMapping,
+	showDeleted bool,
+) error {
+	f.ctx = ctx
+	f.identity = identity
+	f.txn = txn
+	f.nodeACP = nodeACP
+	f.documentACP = documentACP
+	f.index = index
+	f.col = col
+	f.fields = fields
+	f.filter = filter
+	f.ordering = ordering
+	f.docmapper = docmapper
+	f.showDeleted = showDeleted
+
+	return nil
+}
+
+func (f *MultiVersioned) Start(ctx context.Context, prefixes ...keys.Walkable) error {
+	// Deduplicate the prefixes so that the child fetchers do not return duplicated results.
+	// This is in keeping with the behaviour of other query params, such as docIDs.
+	uniquePrefixStrings := map[string]struct{}{}
+	uniquePrefixes := []keys.Walkable{}
+	for _, prefix := range prefixes {
+		// Do not use `prefix.ToString()` here, that function returns a pretified result and there is
+		// no guarantee that it will not clash with other unique prefixes.
+		stringPrefix := string(prefix.Bytes())
+
+		if _, ok := uniquePrefixStrings[stringPrefix]; ok {
+			continue
+		}
+
+		uniquePrefixStrings[stringPrefix] = struct{}{}
+		uniquePrefixes = append(uniquePrefixes, prefix)
+	}
+
+	f.children = make([]*VersionedFetcher, len(uniquePrefixes))
+
+	for i, prefix := range uniquePrefixes {
+		child := &VersionedFetcher{}
+		err := child.Init(
+			f.ctx,
+			f.identity,
+			f.txn,
+			f.nodeACP,
+			f.documentACP,
+			f.index,
+			f.col,
+			f.fields,
+			f.filter,
+			f.ordering,
+			f.docmapper,
+			f.showDeleted,
+		)
+		if err != nil {
+			return err
+		}
+
+		err = child.Start(ctx, prefix)
+		if err != nil {
+			return err
+		}
+
+		f.children[i] = child
+	}
+
+	f.currentChild = 0
+
+	return nil
+}
+
+func (f *MultiVersioned) FetchNext(ctx context.Context) (EncodedDocument, ExecInfo, error) {
+	if f.currentChild >= len(f.children) {
+		return nil, ExecInfo{}, nil
+	}
+
+	doc, execInfo, err := f.children[f.currentChild].FetchNext(ctx)
+	if err != nil {
+		return nil, ExecInfo{}, err
+	}
+
+	if doc == nil {
+		f.currentChild++
+		return f.FetchNext(ctx)
+	}
+
+	return doc, execInfo, nil
+}
+
+func (f *MultiVersioned) Close() error {
+	errs := []error{}
+	for _, child := range f.children {
+		if child == nil {
+			// If an error is thrown in `f.Start`, this child, and later children in the loop might be nil.
+			// If this child is nil, the later ones will be too.  If a child is nil, calling `child.Close`
+			// will panic.
+			break
+		}
+
+		err := child.Close()
+		if err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	return errors.Join(errs...)
+}

--- a/internal/planner/commit.go
+++ b/internal/planner/commit.go
@@ -39,7 +39,8 @@ type dagScanNode struct {
 	depthVisited uint64
 	visitedNodes map[string]bool
 
-	queuedCids []*cid.Cid
+	queuedCids            []*cid.Cid
+	currentSelectCidIndex int
 
 	fetcher        fetcher.HeadFetcher
 	fetcherStarted bool
@@ -203,17 +204,14 @@ func (n *dagScanNode) Next() (bool, error) {
 	if len(n.queuedCids) > 0 {
 		currentCid = n.queuedCids[0]
 		n.queuedCids = n.queuedCids[1:(len(n.queuedCids))]
-	} else if n.commitSelect.Cids.HasValue() && len(n.visitedNodes) == 0 {
-		if len(n.commitSelect.Cids.Value()) == 0 {
-			return false, nil
-		}
-
-		cid, err := cid.Parse(n.commitSelect.Cids.Value()[0])
+	} else if n.commitSelect.Cids.HasValue() && n.currentSelectCidIndex < len(n.commitSelect.Cids.Value()) {
+		cid, err := cid.Parse(n.commitSelect.Cids.Value()[n.currentSelectCidIndex])
 		if err != nil {
 			return false, err
 		}
 
 		currentCid = &cid
+		n.currentSelectCidIndex++
 	} else if !n.commitSelect.Cids.HasValue() && n.fetcherStarted {
 		cid, err := n.fetcher.FetchNext()
 		if err != nil || cid == nil {

--- a/internal/planner/scan.go
+++ b/internal/planner/scan.go
@@ -164,7 +164,7 @@ func (n *scanNode) addField(field client.CollectionFieldDescription) {
 func (n *scanNode) initFetcher(cid immutable.Option[[]string]) {
 	var f fetcher.Fetcher
 	if cid.HasValue() {
-		f = new(fetcher.VersionedFetcher)
+		f = new(fetcher.MultiVersioned)
 	} else {
 		f = fetcher.NewDocumentFetcher()
 

--- a/internal/request/graphql/parser/commit.go
+++ b/internal/request/graphql/parser/commit.go
@@ -77,12 +77,6 @@ func parseCommitSelect(
 				continue // value is nil
 			}
 
-			if len(v) > 1 {
-				// todo - This limitiation is temporary and should be removed in
-				// https://github.com/sourcenetwork/defradb/issues/4303
-				return nil, ErrMultipleCidsNotSupported
-			}
-
 			cids := make([]string, len(v))
 			for i, value := range v {
 				cids[i] = value.(string)

--- a/internal/request/graphql/parser/errors.go
+++ b/internal/request/graphql/parser/errors.go
@@ -26,6 +26,5 @@ var (
 	ErrUnknownGQLOperation            = errors.New("unknown GraphQL operation type")
 	ErrInvalidFilterConditions        = errors.New("invalid filter condition type, expected map")
 	ErrMultipleOrderFieldsDefined     = errors.New("each order argument can only define one field")
-	ErrMultipleCidsNotSupported       = errors.New("querying by multiple cids is not yet supported")
 	ErrMultipleDocIDsNotSupported     = errors.New("querying by multiple docIDs is not yet supported")
 )

--- a/internal/request/graphql/parser/query.go
+++ b/internal/request/graphql/parser/query.go
@@ -132,12 +132,6 @@ func parseSelect(
 				continue // value is nil
 			}
 
-			if len(v) > 1 {
-				// todo - This limitiation is temporary and should be removed in
-				// https://github.com/sourcenetwork/defradb/issues/4304
-				return nil, ErrMultipleCidsNotSupported
-			}
-
 			cids := make([]string, len(v))
 			for i, value := range v {
 				cids[i] = value.(string)

--- a/tests/integration/query/commits/with_cid_test.go
+++ b/tests/integration/query/commits/with_cid_test.go
@@ -239,8 +239,6 @@ func TestQueryCommits_MultipleCidsDifferentDocs(t *testing.T) {
 	testUtils.ExecuteTestCase(t, test)
 }
 
-// This test documents undesirable behaviour and should be changed as part of:
-// https://github.com/sourcenetwork/defradb/issues/2469
 func TestQueryCommits_MultipleCidsDifferentDocs_NoAccessToSecondCid(t *testing.T) {
 	test := testUtils.TestCase{
 		Actions: []any{
@@ -301,14 +299,11 @@ resources:
 						}
 					}`,
 				Results: map[string]any{
-					// The second commit should not be readable as it is not public and we are querying without
+					// The second commit is not readable as it is not public and we are querying without
 					// an identity
 					"_commits": []map[string]any{
 						{
 							"cid": "bafyreib7pek5q7pweyljoylz7qusofwls3wnnzik6j5ibo3pe77fz4iw3e",
-						},
-						{
-							"cid": "bafyreig2bqffvdrxc3bzot5m6bcm6qssybzgof6xdllxuy6cg7rtmpuwjy",
 						},
 					},
 				},

--- a/tests/integration/query/commits/with_cid_test.go
+++ b/tests/integration/query/commits/with_cid_test.go
@@ -196,7 +196,130 @@ func TestQueryCommitsWithUnknownCid(t *testing.T) {
 	testUtils.ExecuteTestCase(t, test)
 }
 
-func TestQueryCommits_MultipleCids(t *testing.T) {
+func TestQueryCommits_MultipleCidsDifferentDocs(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			updateUserCollectionSchema(),
+			&action.AddDoc{
+				CollectionID: 0,
+				DocMap: map[string]any{
+					"name": "John",
+					"age":  21,
+				},
+			},
+			&action.AddDoc{
+				CollectionID: 0,
+				DocMap: map[string]any{
+					"name": "Fred",
+					"age":  21,
+				},
+			},
+			&action.Request{
+				Request: `query {
+						_commits(
+							cid: ["bafyreiejjfevlp5wrfl5o7bxbdtjj4th36lbdjov5gdkmy5n5jzs6dcmpu", "bafyreibrfk6bijtty4vemejailnzvwpsclvyw47mossqgk547uvvawzkc4"]
+						) {
+							cid
+						}
+					}`,
+				Results: map[string]any{
+					"_commits": []map[string]any{
+						{
+							"cid": "bafyreiejjfevlp5wrfl5o7bxbdtjj4th36lbdjov5gdkmy5n5jzs6dcmpu",
+						},
+						{
+							"cid": "bafyreibrfk6bijtty4vemejailnzvwpsclvyw47mossqgk547uvvawzkc4",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+// This test documents undesirable behaviour and should be changed as part of:
+// https://github.com/sourcenetwork/defradb/issues/2469
+func TestQueryCommits_MultipleCidsDifferentDocs_NoAccessToSecondCid(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.AddDACPolicy{
+				Identity: testUtils.ClientIdentity(1),
+				Policy: `
+description: a test policy which marks a collection in a database as a resource
+name: test
+resources:
+- name: users
+  permissions:
+  - name: delete
+  - expr: reader
+    name: read
+  - name: update
+  relations:
+  - manages:
+    - reader
+    name: admin
+    types:
+    - actor
+  - name: reader
+    types:
+    - actor
+`,
+			},
+			&action.AddCollection{
+				SDL: `
+				type Users @policy(
+						id: "{{.Policy0}}",
+						resource: "users"
+					) {
+					name: String
+					age: Int
+				}`,
+			},
+			&action.AddDoc{
+				CollectionID: 0,
+				DocMap: map[string]any{
+					"name": "John",
+					"age":  21,
+				},
+			},
+			&action.AddDoc{
+				Identity:     testUtils.ClientIdentity(1),
+				CollectionID: 0,
+				DocMap: map[string]any{
+					"name": "Fred",
+					"age":  21,
+				},
+			},
+			&action.Request{
+				Request: `query {
+						_commits(
+							cid: ["bafyreib7pek5q7pweyljoylz7qusofwls3wnnzik6j5ibo3pe77fz4iw3e", "bafyreig2bqffvdrxc3bzot5m6bcm6qssybzgof6xdllxuy6cg7rtmpuwjy"]
+						) {
+							cid
+						}
+					}`,
+				Results: map[string]any{
+					// The second commit should not be readable as it is not public and we are querying without
+					// an identity
+					"_commits": []map[string]any{
+						{
+							"cid": "bafyreib7pek5q7pweyljoylz7qusofwls3wnnzik6j5ibo3pe77fz4iw3e",
+						},
+						{
+							"cid": "bafyreig2bqffvdrxc3bzot5m6bcm6qssybzgof6xdllxuy6cg7rtmpuwjy",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestQueryCommits_MultipleCidsSameDoc(t *testing.T) {
 	test := testUtils.TestCase{
 		Actions: []any{
 			updateUserCollectionSchema(),
@@ -222,7 +345,16 @@ func TestQueryCommits_MultipleCids(t *testing.T) {
 							cid
 						}
 					}`,
-				ExpectedError: "querying by multiple cids is not yet supported",
+				Results: map[string]any{
+					"_commits": []map[string]any{
+						{
+							"cid": "bafyreiejjfevlp5wrfl5o7bxbdtjj4th36lbdjov5gdkmy5n5jzs6dcmpu",
+						},
+						{
+							"cid": "bafyreigonvri5vfdosfgp4qxtq46snjxm7cnjlzizrod2wy3l53jbxiysm",
+						},
+					},
+				},
 			},
 		},
 	}

--- a/tests/integration/query/simple/with_cid_test.go
+++ b/tests/integration/query/simple/with_cid_test.go
@@ -282,19 +282,134 @@ func TestQuerySimple_MultipleCIDs(t *testing.T) {
 				`,
 			},
 			&action.AddDoc{
-				Doc: `{
-					"name": "John"
-				}`,
+				DocMap: map[string]any{
+					"name": "John",
+				},
+			},
+			&action.AddDoc{
+				DocMap: map[string]any{
+					"name": "Fred",
+				},
+			},
+			&action.AddDoc{
+				DocMap: map[string]any{
+					"name": "Shahzad",
+				},
 			},
 			&action.Request{
 				Request: `query {
 					Users (
-							cid: ["bafyreifldhofx6cwi6ashk24rcefsuiqje5a2rziwcyte54z27wmgv4pey", "bafyreic2vrbl344kkc7h5d7e2hpnwvffta4ck73bvjs5acgjtvqubvvioe"]
+							cid: ["bafyreifldhofx6cwi6ashk24rcefsuiqje5a2rziwcyte54z27wmgv4pey", "bafyreihufziq5m2i6sgw2ls45uratin7eudhjplfg23qtj2lv6g6knevha"]
 						) {
 						name
 					}
 				}`,
-				ExpectedError: "querying by multiple cids is not yet supported",
+				Results: map[string]any{
+					"Users": []map[string]any{
+						{
+							"name": "John",
+						},
+						{
+							"name": "Fred",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestQuerySimple_DuplicateCIDsForSameDoc(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type Users {
+						name: String
+					}
+				`,
+			},
+			&action.AddDoc{
+				DocMap: map[string]any{
+					"name": "John",
+				},
+			},
+			&action.AddDoc{
+				DocMap: map[string]any{
+					"name": "Fred",
+				},
+			},
+			&action.Request{
+				// Query with duplicated cids for the same doc
+				Request: `query {
+					Users (
+							cid: ["bafyreifldhofx6cwi6ashk24rcefsuiqje5a2rziwcyte54z27wmgv4pey", "bafyreifldhofx6cwi6ashk24rcefsuiqje5a2rziwcyte54z27wmgv4pey"]
+						) {
+						name
+					}
+				}`,
+				Results: map[string]any{
+					// The cids/results are deduplicated, in the same way that providing multiple docIDs are
+					// e.g. TestQueryWithDocIDsFilter_DuplicateDocIDs
+					"Users": []map[string]any{
+						{
+							"name": "John",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestQuerySimple_MultipleCIDsForSameDoc(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type Users {
+						name: String
+					}
+				`,
+			},
+			&action.AddDoc{
+				DocMap: map[string]any{
+					"name": "John",
+				},
+			},
+			&action.UpdateDoc{
+				Doc: `{
+					"name": "Johnnn"
+				}`,
+			},
+			&action.AddDoc{
+				DocMap: map[string]any{
+					"name": "Fred",
+				},
+			},
+			&action.Request{
+				// Query with the cid for the iniitial version of `John`, and the updated version.
+				Request: `query {
+					Users (
+							cid: ["bafyreifldhofx6cwi6ashk24rcefsuiqje5a2rziwcyte54z27wmgv4pey", "bafyreiecis4aqmvr4effzlb74cwflphkykfnibpdnnftdyp6o2cneqy57q"]
+						) {
+						name
+					}
+				}`,
+				Results: map[string]any{
+					"Users": []map[string]any{
+						{
+							"name": "John",
+						},
+						{
+							"name": "Johnnn",
+						},
+					},
+				},
 			},
 		},
 	}

--- a/tests/integration/query/simple/with_cid_test.go
+++ b/tests/integration/query/simple/with_cid_test.go
@@ -392,7 +392,7 @@ func TestQuerySimple_MultipleCIDsForSameDoc(t *testing.T) {
 				},
 			},
 			&action.Request{
-				// Query with the cid for the iniitial version of `John`, and the updated version.
+				// Query with the cid for the initial version of `John`, and the updated version.
 				Request: `query {
 					Users (
 							cid: ["bafyreifldhofx6cwi6ashk24rcefsuiqje5a2rziwcyte54z27wmgv4pey", "bafyreiecis4aqmvr4effzlb74cwflphkykfnibpdnnftdyp6o2cneqy57q"]

--- a/tests/integration/query/simple/with_doc_ids_test.go
+++ b/tests/integration/query/simple/with_doc_ids_test.go
@@ -75,6 +75,37 @@ func TestQueryWithDocIDsFilter_SingleTargetFound(t *testing.T) {
 	executeTestCase(t, test)
 }
 
+func TestQueryWithDocIDsFilter_DuplicateDocIDs(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddDoc{
+				Doc: `{
+						"Name": "John",
+						"Age": 21
+					}`,
+			},
+			&action.Request{
+				Request: `query {
+						Users(docID: ["bae-619ea0d2-35ba-5e8c-ac4d-2b769937213b", "bae-619ea0d2-35ba-5e8c-ac4d-2b769937213b"]) {
+							Name
+							Age
+						}
+					}`,
+				Results: map[string]any{
+					"Users": []map[string]any{
+						{
+							"Name": "John",
+							"Age":  int64(21),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	executeTestCase(t, test)
+}
+
 func TestQuerySimpleWithDocIDsFilter_OneFoundFromMultipleTargets(t *testing.T) {
 	test := testUtils.TestCase{
 		Actions: []any{


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4304
Resolves #4303

## Description

Support querying with multiple cids, both for versioned collection queries, and via the commits api.

Also tests/documents existing behaviour of the `docID` collection query param.
