### PR TITLE
test(i): Exclude LevelDB from multi-txn test

### DIFF
--- a/tests/integration/collection_version/updates/remove/collections_test.go
+++ b/tests/integration/collection_version/updates/remove/collections_test.go
@@ -791,6 +791,13 @@ func TestColVersionUpdateRemoveCollections_ConcurrentWrite(t *testing.T) {
 			// action.
 			state.GoClientType,
 		}),
+		SupportedDatabaseTypes: immutable.Some([]state.DatabaseType{
+			// LevelDB is not supported for this test as the test opens multiple transactions at
+			// the same time.
+			testUtils.BadgerIMType,
+			testUtils.BadgerFileType,
+			testUtils.DefraIMType,
+		}),
 		Actions: []any{
 			&action.AddCollection{
 				SDL: `

--- a/tests/integration/collection_version/updates/remove/collections_txn_test.go
+++ b/tests/integration/collection_version/updates/remove/collections_txn_test.go
@@ -167,6 +167,13 @@ func TestColVersionUpdateRemoveCollection_DeadlockIfDeletingVersionWithNewFieldW
 
 func TestColVersionUpdateRemoveCollection_GetCollectionsShouldNotReturnCollectionDeletedWhilstTxnWasOpen(t *testing.T) {
 	test := testUtils.TestCase{
+		SupportedDatabaseTypes: immutable.Some([]state.DatabaseType{
+			// LevelDB is not supported for this test as the test opens multiple transactions at
+			// the same time.
+			testUtils.BadgerIMType,
+			testUtils.BadgerFileType,
+			testUtils.DefraIMType,
+		}),
 		Actions: []any{
 			&action.AddCollection{
 				SDL: `
@@ -227,6 +234,13 @@ func TestColVersionUpdateRemoveCollection_GetCollectionsShouldNotReturnCollectio
 
 func TestColVersionUpdateRemoveCollection_CollectionMayBeRedeclaredAndUsedByTxn(t *testing.T) {
 	test := testUtils.TestCase{
+		SupportedDatabaseTypes: immutable.Some([]state.DatabaseType{
+			// LevelDB is not supported for this test as the test opens multiple transactions at
+			// the same time.
+			testUtils.BadgerIMType,
+			testUtils.BadgerFileType,
+			testUtils.DefraIMType,
+		}),
 		Actions: []any{
 			&action.AddCollection{
 				SDL: `

--- a/tests/integration/collection_version/updates/remove/view_txn_test.go
+++ b/tests/integration/collection_version/updates/remove/view_txn_test.go
@@ -14,13 +14,22 @@ package remove
 import (
 	"testing"
 
+	"github.com/sourcenetwork/immutable"
+
 	"github.com/sourcenetwork/defradb/tests/action"
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
-	"github.com/sourcenetwork/immutable"
+	"github.com/sourcenetwork/defradb/tests/state"
 )
 
 func TestColVersionUpdateRemoveView_DoesNotDeadlockIfDeletingVersionWithNoNewFieldsWhilstOtherTxnReading(t *testing.T) {
 	test := testUtils.TestCase{
+		SupportedDatabaseTypes: immutable.Some([]state.DatabaseType{
+			// LevelDB is not supported for this test as the test opens multiple transactions at
+			// the same time.
+			testUtils.BadgerIMType,
+			testUtils.BadgerFileType,
+			testUtils.DefraIMType,
+		}),
 		Actions: []any{
 			&action.AddCollection{
 				SDL: `


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4795

## Description

Excludes LevelDB from some newer tests that open multiple transactions at the same time.