### PR TITLE
test(i): Add edge cases for collection delete command

### DIFF
--- a/cli/collection_delete.go
+++ b/cli/collection_delete.go
@@ -40,13 +40,9 @@ The named collections must not contain any documents. Delete all documents first
 before deleting the collection.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			var names []string
-			for name := range strings.SplitSeq(args[0], ",") {
-				name = strings.TrimSpace(name)
-				if name == "" {
-					continue
-				}
-				names = append(names, name)
+			names := strings.Split(args[0], ",")
+			for i, name := range names {
+				names[i] = strings.TrimSpace(name)
 			}
 
 			cliClient := mustGetContextCLIClient(cmd)

--- a/tests/integration/collection/delete/delete_collection_test.go
+++ b/tests/integration/collection/delete/delete_collection_test.go
@@ -228,7 +228,9 @@ func TestDeleteCollection_WithTransaction_Succeeds(t *testing.T) {
 	testUtils.ExecuteTestCase(t, test)
 }
 
-func TestDeleteCollection_WithTransactionWithoutCommit_CollectionStillExists(t *testing.T) {
+// Deleting multiple collections inside a transaction that is never committed must
+// leave all of them intact.
+func TestDeleteCollection_MultipleCollections_WithTransactionWithoutCommit_StillExist(t *testing.T) {
 	test := testUtils.TestCase{
 		// LevelDB does not support concurrent transactions
 		// todo: https://github.com/sourcenetwork/defradb/issues/4442

--- a/tests/integration/collection/delete/delete_collection_test.go
+++ b/tests/integration/collection/delete/delete_collection_test.go
@@ -243,18 +243,26 @@ func TestDeleteCollection_WithTransactionWithoutCommit_CollectionStillExists(t *
 					type Users {
 						name: String
 					}
+					type Books {
+						title: String
+					}
 				`,
 			},
 			&action.DeleteCollection{
-				ActiveOnly:    true,
 				TransactionID: immutable.Some(1),
-				Names:         []string{"Users"},
+				Names:         []string{"Users", "Books"},
 			},
-			// Without committing, the collection data should still exist. Verify via
-			// GetCollections which reads from a separate transaction.
+
+			// Without committing, the collection data should still exist.
+			// Verify via GetCollections which reads from a separate transaction.
 			&action.GetCollections{
 				FilterOptions: options.GetCollections().SetGetInactive(true),
 				ExpectedResults: []client.CollectionVersion{
+					{
+						Name:           "Books",
+						IsMaterialized: true,
+						IsActive:       true,
+					},
 					{
 						Name:           "Users",
 						IsMaterialized: true,
@@ -382,7 +390,7 @@ func TestDeleteCollection_ReferencedByRelation_OtherSide_ReturnsError(t *testing
 }
 
 // Multiple unrelated collections can be deleted in a single call.
-func TestDeleteCollection_MultipleCollections_AtomicallyInOneCall(t *testing.T) {
+func TestDeleteCollection_MultipleCollections_AtomicallyInOneCall_Succeeds(t *testing.T) {
 	test := testUtils.TestCase{
 		Actions: []any{
 			&action.AddCollection{
@@ -411,7 +419,7 @@ func TestDeleteCollection_MultipleCollections_AtomicallyInOneCall(t *testing.T) 
 // The whole point of multi-delete: two collections referencing each other cannot be
 // deleted one at a time (see the relation-error tests above), but passing both to a
 // single DeleteCollection call succeeds because the underlying patch is atomic.
-func TestDeleteCollection_BothRelatedCollections_InOneCall_Succeeds(t *testing.T) {
+func TestDeleteCollection_BothRelatedCollections_ActiveOnly_InOneCall_Succeeds(t *testing.T) {
 	test := testUtils.TestCase{
 		Actions: []any{
 			&action.AddCollection{
@@ -431,6 +439,39 @@ func TestDeleteCollection_BothRelatedCollections_InOneCall_Succeeds(t *testing.T
 				Names:      []string{"Users", "Books"},
 			},
 			&action.GetCollections{
+				FilterOptions:   options.GetCollections().SetGetInactive(true),
+				ExpectedResults: []client.CollectionVersion{},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+// The whole point of multi-delete: two collections referencing each other cannot be
+// deleted one at a time (see the relation-error tests above), but passing both to a
+// single DeleteCollection call succeeds because the underlying patch is atomic.
+func TestDeleteCollection_BothRelatedCollections_InOneCall_Succeeds(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type Users {
+						name: String
+						books: [Books]
+					}
+					type Books {
+						title: String
+						author: Users
+					}
+				`,
+			},
+			&action.DeleteCollection{
+				ActiveOnly: false,
+				Names:      []string{"Users", "Books"},
+			},
+			&action.GetCollections{
+				FilterOptions:   options.GetCollections().SetGetInactive(true),
 				ExpectedResults: []client.CollectionVersion{},
 			},
 		},
@@ -493,6 +534,70 @@ func TestDeleteCollection_Default_RemovesAllVersions(t *testing.T) {
 			&action.DeleteCollection{
 				Names: []string{"Users"},
 			},
+			&action.GetCollections{
+				FilterOptions:   options.GetCollections().SetGetInactive(true),
+				ExpectedResults: []client.CollectionVersion{},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestDeleteCollection_BackToBackPatchAndDelete_AllVersionsRemoved(t *testing.T) {
+	// usersV1 is the initial `type Users { name: String }`.
+	const usersV1 = "bafyreiciz2hrrmt7ritk5gf5fyruw46v2tfhq5dc7qto4wgpzluben2smu"
+	// usersV2 is the patched schema with the `age: Int` field added.
+	const usersV2 = "bafyreics7adsddesun4kqqotr6g6c6ld2t7djlwcbrm4ftbhru3ayindy4"
+
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type Users {
+						name: String
+					}
+				`,
+			},
+			// First patch: creates v2 active; v1 inactive.
+			&action.PatchCollection{
+				Patch: `
+					[
+						{ "op": "add", "path": "/Users/Fields/-", "value": {"Name": "age", "Kind": "Int"} }
+					]
+				`,
+			},
+			// Second patch: creates v3 active; v2 and v1 inactive.
+			&action.PatchCollection{
+				Patch: `
+					[
+						{ "op": "add", "path": "/Users/Fields/-", "value": {"Name": "email", "Kind": "String"} }
+					]
+				`,
+			},
+			// Delete the active head v3, leaving v2 and v1 inactive in storage.
+			&action.DeleteCollection{
+				ActiveOnly: true,
+				Names:      []string{"Users"},
+			},
+			// Promote v2 to active so the next active-only delete targets it.
+			testUtils.SetActiveCollectionVersion{
+				VersionID: usersV2,
+			},
+			// Delete the active head v2, leaving v1 inactive in storage.
+			&action.DeleteCollection{
+				ActiveOnly: true,
+				Names:      []string{"Users"},
+			},
+			// Promote v1 to active so the final default delete can resolve it by name.
+			testUtils.SetActiveCollectionVersion{
+				VersionID: usersV1,
+			},
+			// Final default delete removes the lone v1.
+			&action.DeleteCollection{
+				Names: []string{"Users"},
+			},
+			// After the back-to-back sequence, no version of Users should remain.
 			&action.GetCollections{
 				FilterOptions:   options.GetCollections().SetGetInactive(true),
 				ExpectedResults: []client.CollectionVersion{},
@@ -864,6 +969,423 @@ func TestDeleteCollection_ThenAddSameShape_IsFreshCollection(t *testing.T) {
 						{"name": "Alice"},
 					},
 				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+// After both related collections are removed atomically, queries against either
+// must fail at the GQL layer (the types are not in the active schema anymore).
+func TestDeleteCollection_RelatedPair_QueriesAgainstSurvivor(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type Users {
+						name: String
+						books: [Books]
+					}
+					type Books {
+						title: String
+						author: Users
+					}
+				`,
+			},
+			// Atomic delete of both collections.
+			&action.DeleteCollection{
+				Names: []string{"Users", "Books"},
+			},
+			// Querying either collection now must error with "Cannot query field".
+			&action.Request{
+				Request: `query {
+					Users {
+						name
+					}
+				}`,
+				ExpectedError: `Cannot query field "Users" on type "Query".`,
+			},
+			&action.Request{
+				Request: `query {
+					Books {
+						title
+					}
+				}`,
+				ExpectedError: `Cannot query field "Books" on type "Query".`,
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+// A collection that self-references via a single object field is deletable
+// using the default (all-versions) path.
+func TestDeleteCollection_SelfReferencingOneToOne_Default_Succeeds(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type Person {
+						name: String
+						parent: Person
+					}
+				`,
+			},
+			&action.DeleteCollection{
+				Names: []string{"Person"},
+			},
+			&action.GetCollections{
+				FilterOptions:   options.GetCollections().SetGetInactive(true),
+				ExpectedResults: []client.CollectionVersion{},
+			},
+			&action.Request{
+				Request: `query {
+					Person {
+						name
+					}
+				}`,
+				ExpectedError: `Cannot query field "Person" on type "Query".`,
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+// Self-reference via an array (one-to-many to self). DefraDB requires both sides of a one-to-many
+// self-relation to be declared explicitly in the SDL: a `parent: Person @primary` field paired
+// with the `children: [Person]` array side. If we didn't do that and only had the array side alone
+// then it would have been rejected at `AddCollection` step.
+func TestDeleteCollection_SelfReferencingOneToMany_Default_Succeeds(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type Person {
+						name: String
+						parent: Person @primary
+						children: [Person]
+					}
+				`,
+			},
+			&action.DeleteCollection{
+				Names: []string{"Person"},
+			},
+			&action.GetCollections{
+				FilterOptions:   options.GetCollections().SetGetInactive(true),
+				ExpectedResults: []client.CollectionVersion{},
+			},
+			&action.Request{
+				Request: `query {
+					Person {
+						name
+					}
+				}`,
+				ExpectedError: `Cannot query field "Person" on type "Query".`,
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+// Self-reference + --active-only on a multi-version collection.
+func TestDeleteCollection_SelfReferencing_ActiveOnly_LeavesEarlierVersion(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type Person {
+						parent: Person
+					}
+				`,
+			},
+			&action.PatchCollection{
+				Patch: `
+					[
+						{ "op": "add", "path": "/Person/Fields/-", "value": {"Name": "name", "Kind": "String"} }
+					]
+				`,
+			},
+			&action.DeleteCollection{
+				ActiveOnly: true,
+				Names:      []string{"Person"},
+			},
+			&action.GetCollections{
+				FilterOptions: options.GetCollections().SetGetInactive(true),
+				ExpectedResults: []client.CollectionVersion{
+					{
+						Name:           "Person",
+						IsMaterialized: true,
+						IsActive:       false,
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+// After an --active-only delete of the only-active version, the inactive earlier version
+// remains but is not query-accessible because the active schema is empty.
+// The user can recover by promoting the earlier version with [SetActiveCollectionVersion].
+func TestDeleteCollection_ActiveOnly_FollowedBySetActive_RestoresQueries(t *testing.T) {
+	// CID for the v1 Users schema (single `name: String` field).
+	const usersV1 = "bafyreiciz2hrrmt7ritk5gf5fyruw46v2tfhq5dc7qto4wgpzluben2smu"
+
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type Users {
+						name: String
+					}
+				`,
+			},
+			&action.PatchCollection{
+				Patch: `
+					[
+						{ "op": "add", "path": "/Users/Fields/-", "value": {"Name": "age", "Kind": "Int"} }
+					]
+				`,
+			},
+			// --active-only delete removes Users-v2 (the active head); Users-v1 remains
+			// in storage but inactive, so it isn't reachable via queries.
+			&action.DeleteCollection{
+				ActiveOnly: true,
+				Names:      []string{"Users"},
+			},
+			&action.Request{
+				Request: `query {
+					Users {
+						name
+					}
+				}`,
+				ExpectedError: `Cannot query field "Users" on type "Query".`,
+			},
+			// Promote the earlier (v1) version back to active. After this Users is in the
+			// active schema again, exposing only v1's fields.
+			testUtils.SetActiveCollectionVersion{
+				VersionID: usersV1,
+			},
+			&action.Request{
+				Request: `query {
+					Users {
+						name
+					}
+				}`,
+				Results: map[string]any{
+					"Users": []map[string]any{},
+				},
+			},
+			// v1 doesn't have the `age` field that was added in v2 - querying it must error.
+			&action.Request{
+				Request: `query {
+					Users {
+						age
+					}
+				}`,
+				ExpectedError: `Cannot query field "age" on type "Users".`,
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+// Default delete (all versions) of one collection while an unrelated collection has multiple
+// inactive versions. Ensures the delete only touches the named collection's CollectionID.
+func TestDeleteCollection_UnrelatedCollectionWithMultipleVersions_PreservedAfterDelete(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type Users {
+						name: String
+					}
+					type Books {
+						title: String
+					}
+				`,
+			},
+			// Create multiple versions on Books.
+			&action.PatchCollection{
+				Patch: `
+					[
+						{ "op": "add", "path": "/Books/Fields/-", "value": {"Name": "year", "Kind": "Int"} }
+					]
+				`,
+			},
+			&action.PatchCollection{
+				Patch: `
+					[
+						{ "op": "add", "path": "/Books/Fields/-", "value": {"Name": "isbn", "Kind": "String"} }
+					]
+				`,
+			},
+			// Delete Users. Books versions must all survive untouched.
+			&action.DeleteCollection{
+				Names: []string{"Users"},
+			},
+			// Users must be entirely gone.
+			&action.GetCollections{
+				FilterOptions:   options.GetCollections().SetCollectionName("Users").SetGetInactive(true),
+				ExpectedResults: []client.CollectionVersion{},
+			},
+			// Books queries against the latest schema must still work, proving the active
+			// Books version (and the field added in the second patch) survived the delete.
+			&action.Request{
+				Request: `query {
+					Books {
+						isbn
+					}
+				}`,
+				Results: map[string]any{
+					"Books": []map[string]any{},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+// Collection with an index attached gets deleted properly.
+func TestDeleteCollection_WithSecondaryIndex_RemovesIndex(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type Users {
+						name: String
+					}
+				`,
+			},
+			&action.NewIndex{
+				CollectionID: 0,
+				FieldName:    "name",
+			},
+			&action.DeleteCollection{
+				Names: []string{"Users"},
+			},
+			&action.GetCollections{
+				FilterOptions:   options.GetCollections().SetGetInactive(true),
+				ExpectedResults: []client.CollectionVersion{},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+// A view that depends on a collection does NOT block deletion of that source
+// collection. This is by design: views are derived data, not structural
+// references. They materialize on demand from their source query, so it is safe
+// to let them outlive the source. The view's query now resolves against a missing
+// collection and surfaces a "collection not found" error (view has gone stale).
+func TestDeleteCollection_WithViewDepending_ViewBecomesStale(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type Users {
+						name: String
+					}
+				`,
+			},
+			&action.AddView{
+				Query: `Users { name }`,
+				SDL: `
+					type UsersByName {
+						name: String
+					}
+				`,
+			},
+			// Sanity check: while the source exists, the view is queryable and
+			// returns an empty result set (no docs in Users yet).
+			&action.Request{
+				Request: `query {
+					UsersByName {
+						name
+					}
+				}`,
+				Results: map[string]any{
+					"UsersByName": []map[string]any{},
+				},
+			},
+			// The delete succeeds: the view does not hold the source hostage.
+			// (If the same dependency had been a relation field on another
+			// collection, this step would have errored)
+			&action.DeleteCollection{
+				Names: []string{"Users"},
+			},
+			&action.Request{
+				Request: `query {
+					UsersByName {
+						name
+					}
+				}`,
+				ExpectedError: "collection not found",
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+// An empty string in the names slice should produce a clear error, not a silent
+// skip or a different downstream failure.
+func TestDeleteCollection_NameContainsEmptyString_ReturnsError(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type Users {
+						name: String
+					}
+				`,
+			},
+			&action.DeleteCollection{
+				Names:         []string{"Users", ""},
+				ExpectedError: "collection name can't be empty",
+			},
+			// Users must still exist.
+			&action.GetCollections{
+				ExpectedResults: []client.CollectionVersion{
+					{
+						Name:           "Users",
+						IsMaterialized: true,
+						IsActive:       true,
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+// Repeating the same name in the names slice should be deduplicated and
+// behave the same as a single-name request.
+func TestDeleteCollection_DuplicateNames_DedupesAndSucceeds(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type Users {
+						name: String
+					}
+				`,
+			},
+			&action.DeleteCollection{
+				Names: []string{"Users", "Users", "Users"},
+			},
+			&action.GetCollections{
+				FilterOptions:   options.GetCollections().SetGetInactive(true),
+				ExpectedResults: []client.CollectionVersion{},
 			},
 		},
 	}

--- a/tests/integration/collection/delete/delete_collection_test.go
+++ b/tests/integration/collection/delete/delete_collection_test.go
@@ -1158,6 +1158,19 @@ func TestDeleteCollection_ActiveOnly_FollowedBySetActive_RestoresQueries(t *test
 				ActiveOnly: true,
 				Names:      []string{"Users"},
 			},
+			// The delete only removed the active head; v1 must remain, inactive.
+			// Asserted here so a dropped-v1 regression is caught at the delete step.
+			&action.GetCollections{
+				FilterOptions: options.GetCollections().SetGetInactive(true),
+				ExpectedResults: []client.CollectionVersion{
+					{
+						Name:           "Users",
+						VersionID:      usersV1,
+						IsMaterialized: true,
+						IsActive:       false,
+					},
+				},
+			},
 			&action.Request{
 				Request: `query {
 					Users {
@@ -1245,6 +1258,34 @@ func TestDeleteCollection_UnrelatedCollectionWithMultipleVersions_PreservedAfter
 				}`,
 				Results: map[string]any{
 					"Books": []map[string]any{},
+				},
+			},
+			// The active query above only proves v3 (the active head) survived; this
+			// proves the two inactive earlier versions survived the delete too.
+			&action.GetCollections{
+				FilterOptions: options.GetCollections().SetCollectionName("Books").SetGetInactive(true),
+				ExpectedResults: []client.CollectionVersion{
+					{
+						Name:           "Books",
+						IsMaterialized: true,
+						IsActive:       false,
+					},
+					{
+						Name:           "Books",
+						IsMaterialized: true,
+						IsActive:       false,
+						PreviousVersion: immutable.Some(client.CollectionSource{
+							SourceCollectionID: "bafyreibb6jablg4srs2juy5u7uuitiee23toxgqei33i63yh6qfhdju3c4",
+						}),
+					},
+					{
+						Name:           "Books",
+						IsMaterialized: true,
+						IsActive:       true,
+						PreviousVersion: immutable.Some(client.CollectionSource{
+							SourceCollectionID: "bafyreie67mjmn6k2zvfhsoudrnlagfoe256t7egpxubkehpb3dkdqn6s5y",
+						}),
+					},
 				},
 			},
 		},

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -794,55 +794,35 @@ func getActionRange(t testing.TB, testCase TestCase) (int, int) {
 		return startIndex, endIndex
 	}
 
+	// A test that leaves a transaction open cannot be run by the change detector:
+	// uncommitted writes are never persisted, so the setup and assert phases would
+	// operate on different data. Any action can run inside a transaction - not just
+	// the mutation actions that delimit the setup phase below - so this is checked
+	// across every action, independently of where they are split.
+	if hasOpenTransaction(testCase.Actions) {
+		t.Skipf("skipping test with open transaction(s)")
+	}
+
 	setupCompleteIndex := -1
 	firstNonSetupIndex := -1
 
-	// Track the transaction IDs as they are used, in a set
-	transactionIDset := make(map[int]struct{})
-
 ActionLoop:
 	for i := range testCase.Actions {
-		switch concreteAction := testCase.Actions[i].(type) {
+		switch testCase.Actions[i].(type) {
 		case SetupComplete:
 			setupCompleteIndex = i
 			// We don't care about anything else if this has been explicitly provided
 			break ActionLoop
 
-		case *action.AddCollection:
-			if concreteAction.TransactionID.HasValue() {
-				transactionIDset[concreteAction.TransactionID.Value()] = struct{}{}
-			}
-			continue
-
-		case *action.AddDoc:
-			if concreteAction.TransactionID.HasValue() {
-				transactionIDset[concreteAction.TransactionID.Value()] = struct{}{}
-			}
-			continue
-
-		case *action.UpdateDoc:
-			if concreteAction.TransactionID.HasValue() {
-				transactionIDset[concreteAction.TransactionID.Value()] = struct{}{}
-			}
-			continue
-
-		case Restart:
-			continue
-
-		case *action.CommitTransaction:
-			// If transaction is commited, remove it from the set we are tracking
-			delete(transactionIDset, concreteAction.TransactionID)
+		// Mutation actions form the setup phase; Restart and CommitTransaction are
+		// permitted to interleave with them without ending it.
+		case *action.AddCollection, *action.AddDoc, *action.UpdateDoc, Restart, *action.CommitTransaction:
 			continue
 
 		default:
 			firstNonSetupIndex = i
 			break ActionLoop
 		}
-	}
-
-	// If length is not 0, there was a transaction used that was not committed
-	if len(transactionIDset) > 0 {
-		t.Skipf("skipping test with open transaction(s)")
 	}
 
 	if changeDetector.SetupOnly {
@@ -868,6 +848,48 @@ ActionLoop:
 	}
 
 	return startIndex, endIndex
+}
+
+// hasOpenTransaction reports whether the actions open a transaction that is never
+// committed. Any action may run inside a transaction via an optional TransactionID
+// field; a CommitTransaction closes the one it names.
+func hasOpenTransaction(actions []any) bool {
+	open := make(map[int]struct{})
+	for _, a := range actions {
+		if commit, ok := a.(*action.CommitTransaction); ok {
+			delete(open, commit.TransactionID)
+			continue
+		}
+		if id, ok := actionTransactionID(a); ok {
+			open[id] = struct{}{}
+		}
+	}
+	return len(open) > 0
+}
+
+// actionTransactionID returns the transaction an action runs in, read from its
+// optional `TransactionID immutable.Option[int]` field if it has one. Reflection
+// keeps this correct for every such action; an exhaustive type switch would
+// silently miss any action added later - the gap this guards against.
+func actionTransactionID(a any) (int, bool) {
+	v := reflect.ValueOf(a)
+	for v.Kind() == reflect.Pointer {
+		v = v.Elem()
+	}
+	if v.Kind() != reflect.Struct {
+		return 0, false
+	}
+
+	field := v.FieldByName("TransactionID")
+	if !field.IsValid() {
+		return 0, false
+	}
+
+	txnID, ok := field.Interface().(immutable.Option[int])
+	if !ok || !txnID.HasValue() {
+		return 0, false
+	}
+	return txnID.Value(), true
 }
 
 // setStartingNodes adds a set of initial Defra nodes for the test to execute against.


### PR DESCRIPTION
## Relevant issue(s)
- Resolves #4802

## Description
Adds breadth coverage for `DeleteCollection` edge cases that I was worried about. 