### PR TITLE
fix: Clean schema heads on collection deletion/patch

### DIFF
--- a/internal/db/collection_define.go
+++ b/internal/db/collection_define.go
@@ -21,6 +21,7 @@ import (
 	jsonpatch "github.com/evanphx/json-patch/v5"
 	"github.com/ipfs/go-cid"
 
+	"github.com/sourcenetwork/corekv"
 	"github.com/sourcenetwork/immutable"
 	"github.com/sourcenetwork/lens/host-go/config/model"
 
@@ -28,9 +29,11 @@ import (
 
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/request"
+	"github.com/sourcenetwork/defradb/errors"
 	"github.com/sourcenetwork/defradb/internal/core"
 	"github.com/sourcenetwork/defradb/internal/datastore"
 	"github.com/sourcenetwork/defradb/internal/db/description"
+	"github.com/sourcenetwork/defradb/internal/keys"
 )
 
 func (db *DB) addCollections(
@@ -681,7 +684,7 @@ func (db *DB) deleteCollectionVersion(
 		return err
 	}
 
-	return nil
+	return deleteCollectionDefinitionHeads(ctx, db.collectionRepository, version)
 }
 
 func (db *DB) validateCollectionDoesNotHaveHigherVersion(
@@ -740,6 +743,104 @@ func deleteCollectionBlocks(
 	}
 
 	return nil
+}
+
+// deleteCollectionDefinitionHeads removes the collection-definition and
+// field-definition headstore entries for version's collection name, once no
+// other versions of that collection remain.
+//
+// These CRDT heads are namespaced by collection name, not by VersionID. While
+// at least one version of the name still exists in storage, the head entries
+// point at it via the CRDT DAG and must be left alone - they will be replaced
+// naturally on the next mutation that produces a new collection version. Once
+// the last version is gone, the heads still point at blocks that
+// [deleteCollectionBlocks] just removed, so a subsequent [AddCollection] that
+// re-uses the same name reads stale CIDs and errors, if we don't do this
+// clean up.
+func deleteCollectionDefinitionHeads(
+	ctx context.Context,
+	collectionRepository *description.CollectionRepository,
+	version client.CollectionVersion,
+) error {
+	remaining, err := description.GetCollectionsByCollectionID(
+		ctx,
+		collectionRepository,
+		version.CollectionID,
+	)
+	if err != nil {
+		return err
+	}
+	if len(remaining) > 0 {
+		// Other versions of this collection still exist; their heads must stay.
+		return nil
+	}
+
+	txn := datastore.CtxMustGetTxn(ctx)
+	headstore := txn.Headstore()
+
+	// A trailing '/' is appended so that prefix iteration matches only this
+	// collection name and not other names that happen to start with it (e.g.
+	// "User" must not pick up "Users").
+	fieldPrefix := []byte(
+		keys.HeadstoreFieldDefinition{CollectionName: version.Name}.ToString() + "/",
+	)
+	if err := deleteHeadstoreByPrefix(ctx, headstore, fieldPrefix); err != nil {
+		return err
+	}
+
+	colPrefix := []byte(
+		keys.HeadstoreCollectionDefinition{CollectionName: version.Name}.ToString() + "/",
+	)
+	return deleteHeadstoreByPrefix(ctx, headstore, colPrefix)
+}
+
+// deleteHeadstoreByPrefix removes every key matching the given prefix from the
+// headstore in chunks, mirroring the iterate-then-delete pattern used by the
+// truncate path. Chunked deletion is required because not every corekv backend
+// supports mutation while an iterator is open.
+func deleteHeadstoreByPrefix(
+	ctx context.Context,
+	headstore corekv.ReaderWriter,
+	prefix []byte,
+) error {
+	for {
+		iter, err := headstore.Iterator(ctx, corekv.IterOptions{
+			Prefix:   prefix,
+			KeysOnly: true,
+		})
+		if err != nil {
+			return NewErrCreateTruncateIterator(err)
+		}
+
+		keysToDelete := make([][]byte, 0, hardDeleteChunkSize)
+		hasMore := true
+		for range hardDeleteChunkSize {
+			hasNext, err := iter.Next()
+			if err != nil {
+				return errors.Join(err, iter.Close())
+			}
+			if !hasNext {
+				hasMore = false
+				break
+			}
+			// Convert via string so the underlying iterator buffer is not retained.
+			keysToDelete = append(keysToDelete, []byte(string(iter.Key())))
+		}
+
+		if err := iter.Close(); err != nil {
+			return err
+		}
+
+		for _, k := range keysToDelete {
+			if err := headstore.Delete(ctx, k); err != nil {
+				return NewErrTruncateHeadstoreKey(err, string(k))
+			}
+		}
+
+		if !hasMore {
+			return nil
+		}
+	}
 }
 
 // finalizeRelations determines which side of a relation is primary and sets IsPrimary=true

--- a/internal/db/collection_define.go
+++ b/internal/db/collection_define.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/request"
-	"github.com/sourcenetwork/defradb/errors"
 	"github.com/sourcenetwork/defradb/internal/core"
 	"github.com/sourcenetwork/defradb/internal/datastore"
 	"github.com/sourcenetwork/defradb/internal/db/description"
@@ -684,7 +683,7 @@ func (db *DB) deleteCollectionVersion(
 		return err
 	}
 
-	return deleteCollectionDefinitionHeads(ctx, db.collectionRepository, version)
+	return deleteCollectionDefinitionHeads(ctx, version)
 }
 
 func (db *DB) validateCollectionDoesNotHaveHigherVersion(
@@ -746,101 +745,70 @@ func deleteCollectionBlocks(
 }
 
 // deleteCollectionDefinitionHeads removes the collection-definition and
-// field-definition headstore entries for version's collection name, once no
-// other versions of that collection remain.
+// field-definition CRDT heads owned by this exact version - one head per
+// field that has a FieldID, plus the collection-level head keyed by the
+// version's VersionID.
 //
-// These CRDT heads are namespaced by collection name, not by VersionID. While
-// at least one version of the name still exists in storage, the head entries
-// point at it via the CRDT DAG and must be left alone - they will be replaced
-// naturally on the next mutation that produces a new collection version. Once
-// the last version is gone, the heads still point at blocks that
-// [deleteCollectionBlocks] just removed, so a subsequent [AddCollection] that
-// re-uses the same name reads stale CIDs and errors, if we don't do this
-// clean up.
+// We construct the keys directly from the version object rather than scanning
+// the headstore by collection name: the keys we want to remove are fully
+// determined by the data we already hold (CollectionName, FieldName, FieldID,
+// VersionID), so the query and the wider scan it implied are both avoidable.
+// A no-op delete - i.e. the head currently points at some other version's
+// CID because the version we're processing is not the current tip - is the
+// right outcome here: the surviving version still owns that head and we must
+// not touch it.
 func deleteCollectionDefinitionHeads(
 	ctx context.Context,
-	collectionRepository *description.CollectionRepository,
 	version client.CollectionVersion,
 ) error {
-	remaining, err := description.GetCollectionsByCollectionID(
-		ctx,
-		collectionRepository,
-		version.CollectionID,
-	)
-	if err != nil {
-		return err
-	}
-	if len(remaining) > 0 {
-		// Other versions of this collection still exist; their heads must stay.
-		return nil
-	}
-
 	txn := datastore.CtxMustGetTxn(ctx)
 	headstore := txn.Headstore()
 
-	// A trailing '/' is appended so that prefix iteration matches only this
-	// collection name and not other names that happen to start with it (e.g.
-	// "User" must not pick up "Users").
-	fieldPrefix := []byte(
-		keys.HeadstoreFieldDefinition{CollectionName: version.Name}.ToString() + "/",
-	)
-	if err := deleteHeadstoreByPrefix(ctx, headstore, fieldPrefix); err != nil {
-		return err
-	}
-
-	colPrefix := []byte(
-		keys.HeadstoreCollectionDefinition{CollectionName: version.Name}.ToString() + "/",
-	)
-	return deleteHeadstoreByPrefix(ctx, headstore, colPrefix)
-}
-
-// deleteHeadstoreByPrefix removes every key matching the given prefix from the
-// headstore in chunks, mirroring the iterate-then-delete pattern used by the
-// truncate path. Chunked deletion is required because not every corekv backend
-// supports mutation while an iterator is open.
-func deleteHeadstoreByPrefix(
-	ctx context.Context,
-	headstore corekv.ReaderWriter,
-	prefix []byte,
-) error {
-	for {
-		iter, err := headstore.Iterator(ctx, corekv.IterOptions{
-			Prefix:   prefix,
-			KeysOnly: true,
-		})
+	for _, field := range version.Fields {
+		if field.FieldID == "" {
+			// Secondary / object-only fields have no backing block and so no head.
+			continue
+		}
+		fieldCid, err := cid.Parse(field.FieldID)
 		if err != nil {
-			return NewErrCreateTruncateIterator(err)
-		}
-
-		keysToDelete := make([][]byte, 0, hardDeleteChunkSize)
-		hasMore := true
-		for range hardDeleteChunkSize {
-			hasNext, err := iter.Next()
-			if err != nil {
-				return errors.Join(err, iter.Close())
-			}
-			if !hasNext {
-				hasMore = false
-				break
-			}
-			// Convert via string so the underlying iterator buffer is not retained.
-			keysToDelete = append(keysToDelete, []byte(string(iter.Key())))
-		}
-
-		if err := iter.Close(); err != nil {
 			return err
 		}
-
-		for _, k := range keysToDelete {
-			if err := headstore.Delete(ctx, k); err != nil {
-				return NewErrTruncateHeadstoreKey(err, string(k))
-			}
+		key := keys.HeadstoreFieldDefinition{
+			CollectionName: version.Name,
+			FieldName:      field.Name,
+			Cid:            fieldCid,
 		}
-
-		if !hasMore {
-			return nil
+		if err := deleteHeadIfPresent(ctx, headstore, key.Bytes()); err != nil {
+			return err
 		}
 	}
+
+	versionCid, err := cid.Parse(version.VersionID)
+	if err != nil {
+		return err
+	}
+	colKey := keys.HeadstoreCollectionDefinition{
+		CollectionName: version.Name,
+		Cid:            versionCid,
+	}
+	return deleteHeadIfPresent(ctx, headstore, colKey.Bytes())
+}
+
+// deleteHeadIfPresent removes the head key if it exists.
+// Note: we gate on `Has` rather than rely on a silent no-op.
+func deleteHeadIfPresent(
+	ctx context.Context,
+	headstore corekv.ReaderWriter,
+	key []byte,
+) error {
+	has, err := headstore.Has(ctx, key)
+	if err != nil {
+		return err
+	}
+	if !has {
+		return nil
+	}
+	return headstore.Delete(ctx, key)
 }
 
 // finalizeRelations determines which side of a relation is primary and sets IsPrimary=true

--- a/tests/integration/collection/delete/delete_collection_test.go
+++ b/tests/integration/collection/delete/delete_collection_test.go
@@ -578,3 +578,295 @@ func TestDeleteCollection_Default_MultipleCollectionsWithMultipleVersions_Remove
 
 	testUtils.ExecuteTestCase(t, test)
 }
+
+// Adding a collection with the same name after a default delete creates a
+// fresh collection (a new CollectionID), not a resurrection of the previous one.
+func TestDeleteCollection_ThenAddSameName_IsFreshCollection(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type Users {
+						name: String
+					}
+				`,
+			},
+			&action.DeleteCollection{
+				Names: []string{"Users"},
+			},
+			// Re-add with a different shape.
+			&action.AddCollection{
+				SDL: `
+					type Users {
+						email: String
+					}
+				`,
+			},
+			// Querying email must work - proves the collection was cleanly reset.
+			&action.Request{
+				Request: `query {
+					Users {
+						email
+					}
+				}`,
+				Results: map[string]any{
+					"Users": []map[string]any{},
+				},
+			},
+			// And the old field should not exist.
+			&action.Request{
+				Request: `query {
+					Users {
+						name
+					}
+				}`,
+				ExpectedError: `Cannot query field "name" on type "Users".`,
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+// Multi-name delete must clean the collection-definition and field-definition
+// heads for every name in the list, not just one. After deleting Users + Books
+// in a single call, both names must be reusable for fresh collections - if
+// either name's heads were left stale, the corresponding `AddCollection` would
+// error.
+func TestDeleteCollection_MultiName_ThenAddSameNames_AreFreshCollections(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type Users {
+						name: String
+					}
+					type Books {
+						title: String
+					}
+				`,
+			},
+			&action.DeleteCollection{
+				Names: []string{"Users", "Books"},
+			},
+			// Re-add both names with different shapes.
+			&action.AddCollection{
+				SDL: `
+					type Users {
+						email: String
+					}
+					type Books {
+						isbn: String
+					}
+				`,
+			},
+			&action.Request{
+				Request: `query {
+					Users {
+						email
+					}
+				}`,
+				Results: map[string]any{
+					"Users": []map[string]any{},
+				},
+			},
+			&action.Request{
+				Request: `query {
+					Books {
+						isbn
+					}
+				}`,
+				Results: map[string]any{
+					"Books": []map[string]any{},
+				},
+			},
+			// Old fields must not exist on either re-added collection.
+			&action.Request{
+				Request: `query {
+					Users {
+						name
+					}
+				}`,
+				ExpectedError: `Cannot query field "name" on type "Users".`,
+			},
+			&action.Request{
+				Request: `query {
+					Books {
+						title
+					}
+				}`,
+				ExpectedError: `Cannot query field "title" on type "Books".`,
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+// ActiveOnly delete on a single-version collection removes the only version,
+// so the headstore-cleanup gate fires (no surviving versions for this name).
+// The same-name re-add must therefore work, exactly as in the default-delete
+func TestDeleteCollection_ActiveOnly_SingleVersion_ThenAddSameName_IsFreshCollection(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type Users {
+						name: String
+					}
+				`,
+			},
+			&action.DeleteCollection{
+				ActiveOnly: true,
+				Names:      []string{"Users"},
+			},
+			// Re-add with a different shape.
+			&action.AddCollection{
+				SDL: `
+					type Users {
+						email: String
+					}
+				`,
+			},
+			&action.Request{
+				Request: `query {
+					Users {
+						email
+					}
+				}`,
+				Results: map[string]any{
+					"Users": []map[string]any{},
+				},
+			},
+			&action.Request{
+				Request: `query {
+					Users {
+						name
+					}
+				}`,
+				ExpectedError: `Cannot query field "name" on type "Users".`,
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+// A multi-version collection (Add + PatchCollection) gets default-deleted,
+// removing every version; the same-name re-add must then work. This exercises
+// the gate's "wait until the last version is gone" behaviour - the per-version
+// loop in deleteCollectionVersions must NOT clean heads on the first iteration
+// (when v1 is gone but v2 still exists), and MUST clean them on the last.
+func TestDeleteCollection_PatchedThenDefaultDeleted_ThenAddSameName_IsFreshCollection(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type Users {
+						name: String
+					}
+				`,
+			},
+			// Creates v2 active, v1 inactive.
+			&action.PatchCollection{
+				Patch: `
+					[
+						{ "op": "add", "path": "/Users/Fields/-", "value": {"Name": "age", "Kind": "Int"} }
+					]
+				`,
+			},
+			// Default delete removes both v1 and v2.
+			&action.DeleteCollection{
+				Names: []string{"Users"},
+			},
+			// Re-add with a different shape - none of the prior fields should leak.
+			&action.AddCollection{
+				SDL: `
+					type Users {
+						email: String
+					}
+				`,
+			},
+			&action.Request{
+				Request: `query {
+					Users {
+						email
+					}
+				}`,
+				Results: map[string]any{
+					"Users": []map[string]any{},
+				},
+			},
+			&action.Request{
+				Request: `query {
+					Users {
+						name
+					}
+				}`,
+				ExpectedError: `Cannot query field "name" on type "Users".`,
+			},
+			&action.Request{
+				Request: `query {
+					Users {
+						age
+					}
+				}`,
+				ExpectedError: `Cannot query field "age" on type "Users".`,
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+// Re-adding the same shape after a delete so the new collection's blocks land
+// at the exact same CIDs as the deleted collection's blocks. If the headstore
+// had any stale entry pointing at those CIDs, the `AddCollection` path would
+// either trip on it or silently accept the stale heads as valid which might
+// give the new collection an unrelated history.
+func TestDeleteCollection_ThenAddSameShape_IsFreshCollection(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type Users {
+						name: String
+					}
+				`,
+			},
+			&action.DeleteCollection{
+				Names: []string{"Users"},
+			},
+			// Re-add with the EXACT same shape.
+			&action.AddCollection{
+				SDL: `
+					type Users {
+						name: String
+					}
+				`,
+			},
+			// The new collection must be writable, and a query must return only
+			// the doc we just added, no carry-over from the previous instance.
+			&action.AddDoc{
+				CollectionID: 0,
+				DocMap: map[string]any{
+					"name": "Alice",
+				},
+			},
+			&action.Request{
+				Request: `query {
+					Users {
+						name
+					}
+				}`,
+				Results: map[string]any{
+					"Users": []map[string]any{
+						{"name": "Alice"},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/collection_version/updates/remove/collections_test.go
+++ b/tests/integration/collection_version/updates/remove/collections_test.go
@@ -853,3 +853,99 @@ func TestColVersionUpdateRemoveCollections_ConcurrentWrite(t *testing.T) {
 
 	testUtils.ExecuteTestCase(t, test)
 }
+
+// Removing a collection via PatchCollection and re-adding the same name with a
+// different shape must produce a fresh collection. This mirrors the equivalent
+// DeleteCollection test and verifies the patch-driven removal path also clears
+// the collection-definition and field-definition heads on its way out.
+func TestColVersionUpdateRemoveCollection_ThenAddSameName_IsFreshCollection(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type Users {
+						name: String
+					}
+				`,
+			},
+			&action.PatchCollection{
+				Patch: `[{ "op": "remove", "path": "/Users" }]`,
+			},
+			&action.AddCollection{
+				SDL: `
+					type Users {
+						email: String
+					}
+				`,
+			},
+			&action.Request{
+				Request: `query {
+					Users {
+						email
+					}
+				}`,
+				Results: map[string]any{
+					"Users": []map[string]any{},
+				},
+			},
+			&action.Request{
+				Request: `query {
+					Users {
+						name
+					}
+				}`,
+				ExpectedError: `Cannot query field "name" on type "Users".`,
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+// Re-add with the EXACT same shape after a patch-driven removal. The CIDs of
+// the collection-definition and field-definition blocks are derived
+// deterministically from the definition itself, so the new blocks land at the
+// exact same CIDs as the deleted ones. Without head cleanup this would error
+func TestColVersionUpdateRemoveCollection_ThenAddSameShape_IsFreshCollection(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type Users {
+						name: String
+					}
+				`,
+			},
+			&action.PatchCollection{
+				Patch: `[{ "op": "remove", "path": "/Users" }]`,
+			},
+			&action.AddCollection{
+				SDL: `
+					type Users {
+						name: String
+					}
+				`,
+			},
+			&action.AddDoc{
+				CollectionID: 0,
+				DocMap: map[string]any{
+					"name": "Alice",
+				},
+			},
+			&action.Request{
+				Request: `query {
+					Users {
+						name
+					}
+				}`,
+				Results: map[string]any{
+					"Users": []map[string]any{
+						{"name": "Alice"},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}


### PR DESCRIPTION
## Relevant issue(s)
- Resolves #4803

## Description
Fix `DeleteCollection` (and `PatchCollection`'s op: remove, which goes through the same code path) where the schema heads were left dangling after the underlying blocks had been removed.

Note: I made sure that the cleanup only happens when the final version is deleted (or if deleting collection where you want all versions to be removed. i.e. without the active version only flag / default case)