### PR TITLE
feat: Gate commit queries with DAC

### DIFF
--- a/internal/planner/commit.go
+++ b/internal/planner/commit.go
@@ -49,12 +49,6 @@ type dagScanNode struct {
 	linksScanNodes []*dagScanNode
 	headsScanNodes []*dagScanNode
 
-	// cachedCols memoizes the per-versionID collection lookups used by both
-	// the DAC access check and dagBlockToNodeDoc. A `_commits` query may
-	// span docs from different collection versions, so the cache is keyed
-	// by collection version ID.
-	cachedCols map[string]client.Collection
-
 	execInfo dagScanExecInfo
 }
 
@@ -101,32 +95,6 @@ func (p *Planner) CommitSelect(commitSelect *mapper.CommitSelect) (planNode, err
 
 func (n *dagScanNode) Kind() string {
 	return "dagScanNode"
-}
-
-// getCollectionByVersionID resolves and caches a collection by its
-// CollectionVersionID. The lookup result is shared between the DAC access
-// check and dagBlockToNodeDoc.
-func (n *dagScanNode) getCollectionByVersionID(versionID string) (client.Collection, error) {
-	if c, ok := n.cachedCols[versionID]; ok {
-		return c, nil
-	}
-
-	cols, err := n.planner.db.GetCollections(
-		n.planner.ctx,
-		options.GetCollections().SetGetInactive(true).SetVersionID(versionID),
-	)
-	if err != nil {
-		return nil, err
-	}
-	if len(cols) == 0 {
-		return nil, client.NewErrCollectionNotFoundForCollectionVersion(versionID)
-	}
-
-	if n.cachedCols == nil {
-		n.cachedCols = make(map[string]client.Collection)
-	}
-	n.cachedCols[versionID] = cols[0]
-	return cols[0], nil
 }
 
 func (n *dagScanNode) Init() error {
@@ -292,9 +260,15 @@ func (n *dagScanNode) Next() (bool, error) {
 	if n.planner.documentACP.HasValue() && len(docIDBytes) > 0 {
 		versionID := dagBlock.Delta.GetCollectionVersionID()
 
-		col, err := n.getCollectionByVersionID(versionID)
+		cols, err := n.planner.db.GetCollections(
+			n.planner.ctx,
+			options.GetCollections().SetGetInactive(true).SetVersionID(versionID),
+		)
 		if err != nil {
 			return false, err
+		}
+		if len(cols) == 0 {
+			return false, client.NewErrCollectionNotFoundForCollectionVersion(versionID)
 		}
 
 		hasPermission, err := acpDB.CheckAccessOfDocOnCollectionWithACP(
@@ -302,7 +276,7 @@ func (n *dagScanNode) Next() (bool, error) {
 			n.planner.identity,
 			n.planner.nodeACP,
 			n.planner.documentACP.Value(),
-			col,
+			cols[0],
 			acpTypes.DocumentReadPerm,
 			string(docIDBytes),
 		)
@@ -416,8 +390,15 @@ func (n *dagScanNode) dagBlockToNodeDoc(block *coreblock.Block) (core.Doc, error
 	collectionVersionId := block.Delta.GetCollectionVersionID()
 	n.commitSelect.DocumentMapping.SetFirstOfName(&commit, request.CollectionVersionIDFieldName, collectionVersionId)
 
-	if _, err := n.getCollectionByVersionID(collectionVersionId); err != nil {
+	cols, err := n.planner.db.GetCollections(
+		n.planner.ctx,
+		options.GetCollections().SetGetInactive(true).SetVersionID(collectionVersionId),
+	)
+	if err != nil {
 		return core.Doc{}, err
+	}
+	if len(cols) == 0 {
+		return core.Doc{}, client.NewErrCollectionNotFoundForCollectionVersion(collectionVersionId)
 	}
 
 	var fieldName any

--- a/internal/planner/commit.go
+++ b/internal/planner/commit.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/sourcenetwork/immutable"
 
+	acpTypes "github.com/sourcenetwork/defradb/acp/types"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/options"
 	"github.com/sourcenetwork/defradb/client/request"
@@ -23,6 +24,7 @@ import (
 	"github.com/sourcenetwork/defradb/internal/core"
 	coreblock "github.com/sourcenetwork/defradb/internal/core/block"
 	"github.com/sourcenetwork/defradb/internal/datastore"
+	acpDB "github.com/sourcenetwork/defradb/internal/db/acp"
 	"github.com/sourcenetwork/defradb/internal/db/fetcher"
 	"github.com/sourcenetwork/defradb/internal/keys"
 	"github.com/sourcenetwork/defradb/internal/planner/mapper"
@@ -46,6 +48,12 @@ type dagScanNode struct {
 
 	linksScanNodes []*dagScanNode
 	headsScanNodes []*dagScanNode
+
+	// cachedCols memoizes the per-versionID collection lookups used by both
+	// the DAC access check and dagBlockToNodeDoc. A `_commits` query may
+	// span docs from different collection versions, so the cache is keyed
+	// by collection version ID.
+	cachedCols map[string]client.Collection
 
 	execInfo dagScanExecInfo
 }
@@ -93,6 +101,32 @@ func (p *Planner) CommitSelect(commitSelect *mapper.CommitSelect) (planNode, err
 
 func (n *dagScanNode) Kind() string {
 	return "dagScanNode"
+}
+
+// getCollectionByVersionID resolves and caches a collection by its
+// CollectionVersionID. The lookup result is shared between the DAC access
+// check and dagBlockToNodeDoc.
+func (n *dagScanNode) getCollectionByVersionID(versionID string) (client.Collection, error) {
+	if c, ok := n.cachedCols[versionID]; ok {
+		return c, nil
+	}
+
+	cols, err := n.planner.db.GetCollections(
+		n.planner.ctx,
+		options.GetCollections().SetGetInactive(true).SetVersionID(versionID),
+	)
+	if err != nil {
+		return nil, err
+	}
+	if len(cols) == 0 {
+		return nil, client.NewErrCollectionNotFoundForCollectionVersion(versionID)
+	}
+
+	if n.cachedCols == nil {
+		n.cachedCols = make(map[string]client.Collection)
+	}
+	n.cachedCols[versionID] = cols[0]
+	return cols[0], nil
 }
 
 func (n *dagScanNode) Init() error {
@@ -246,6 +280,43 @@ func (n *dagScanNode) Next() (bool, error) {
 		return false, err
 	}
 
+	// We want to enforce DAC, so we skip commits the caller has no read access to.
+	// We do this before [dagBlockToNodeDoc], so denied commits do not pay the
+	// doc-mapping cost. We only check when document acp is configured,
+	// Note:
+	// - [CheckAccessOfDocOnCollectionWithACP] itself further short-circuits when
+	// the collection has no policy or the doc is public.
+	// - Collection-level deltas (e.g. schema changes) carry no docID and
+	// are not DAC-gated, only doc-level deltas need an access check.
+	docIDBytes := dagBlock.Delta.GetDocID()
+	if n.planner.documentACP.HasValue() && len(docIDBytes) > 0 {
+		versionID := dagBlock.Delta.GetCollectionVersionID()
+
+		col, err := n.getCollectionByVersionID(versionID)
+		if err != nil {
+			return false, err
+		}
+
+		hasPermission, err := acpDB.CheckAccessOfDocOnCollectionWithACP(
+			n.planner.ctx,
+			n.planner.identity,
+			n.planner.nodeACP,
+			n.planner.documentACP.Value(),
+			col,
+			acpTypes.DocumentReadPerm,
+			string(docIDBytes),
+		)
+		if err != nil {
+			return false, err
+		}
+		if !hasPermission {
+			// Mark visited so the same denied cid is not re-checked if it
+			// reappears via a links/heads queue elsewhere in the traversal.
+			n.visitedNodes[currentCid.String()] = true
+			return n.Next()
+		}
+	}
+
 	currentValue, err := n.dagBlockToNodeDoc(dagBlock)
 	if err != nil {
 		return false, err
@@ -345,15 +416,8 @@ func (n *dagScanNode) dagBlockToNodeDoc(block *coreblock.Block) (core.Doc, error
 	collectionVersionId := block.Delta.GetCollectionVersionID()
 	n.commitSelect.DocumentMapping.SetFirstOfName(&commit, request.CollectionVersionIDFieldName, collectionVersionId)
 
-	cols, err := n.planner.db.GetCollections(
-		n.planner.ctx,
-		options.GetCollections().SetGetInactive(true).SetVersionID(collectionVersionId),
-	)
-	if err != nil {
+	if _, err := n.getCollectionByVersionID(collectionVersionId); err != nil {
 		return core.Doc{}, err
-	}
-	if len(cols) == 0 {
-		return core.Doc{}, client.NewErrCollectionNotFoundForCollectionVersion(collectionVersionId)
 	}
 
 	var fieldName any

--- a/tests/integration/acp/dac/commits/basic_test.go
+++ b/tests/integration/acp/dac/commits/basic_test.go
@@ -1,0 +1,477 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// This file is part of the DefraDB test suite.
+//
+// The DefraDB test suite is licensed under either:
+//
+//   (1) GNU Affero General Public License v3
+//   (2) Business Source License 1.1
+//
+// See tests/LICENSE for details.
+
+package test_acp_dac_commits
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/defradb/tests/action"
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+// A doc registered without identity is public. _commits should return all 3
+// commits (name field, age field, composite) when queried without identity.
+func TestACP_QueryCommitsOnPublicDocWithoutIdentity_CanSeeCommits(t *testing.T) {
+	uniqueCid := testUtils.NewUniqueValue()
+
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.AddDACPolicy{
+				Identity: testUtils.ClientIdentity(1),
+				Policy:   usersPolicy,
+			},
+
+			&action.AddCollection{
+				SDL: `
+					type Users @policy(
+						id: "{{.Policy0}}",
+						resource: "users"
+					) {
+						name: String
+						age: Int
+					}
+				`,
+			},
+
+			&action.AddDoc{
+				CollectionID: 0,
+				Doc:          userDoc,
+			},
+
+			&action.Request{
+				Request: `
+					query {
+						_commits {
+							cid
+						}
+					}
+				`,
+				Results: map[string]any{
+					"_commits": []map[string]any{
+						{"cid": uniqueCid},
+						{"cid": uniqueCid},
+						{"cid": uniqueCid},
+					},
+				},
+				NonOrderedResults: true,
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+// A doc registered without identity is public. _commits should return all 3
+// commits when queried with any identity too.
+func TestACP_QueryCommitsOnPublicDocWithIdentity_CanSeeCommits(t *testing.T) {
+	uniqueCid := testUtils.NewUniqueValue()
+
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.AddDACPolicy{
+				Identity: testUtils.ClientIdentity(1),
+				Policy:   usersPolicy,
+			},
+
+			&action.AddCollection{
+				SDL: `
+					type Users @policy(
+						id: "{{.Policy0}}",
+						resource: "users"
+					) {
+						name: String
+						age: Int
+					}
+				`,
+			},
+
+			&action.AddDoc{
+				CollectionID: 0,
+				Doc:          userDoc,
+			},
+
+			&action.Request{
+				Identity: testUtils.ClientIdentity(1),
+				Request: `
+					query {
+						_commits {
+							cid
+						}
+					}
+				`,
+				Results: map[string]any{
+					"_commits": []map[string]any{
+						{"cid": uniqueCid},
+						{"cid": uniqueCid},
+						{"cid": uniqueCid},
+					},
+				},
+				NonOrderedResults: true,
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+// A doc registered with identity is private. The owner querying _commits with
+// the same identity should see all 3 commits.
+func TestACP_QueryCommitsOnPrivateDocWithOwnerIdentity_CanSeeCommits(t *testing.T) {
+	uniqueCid := testUtils.NewUniqueValue()
+
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.AddDACPolicy{
+				Identity: testUtils.ClientIdentity(1),
+				Policy:   usersPolicy,
+			},
+
+			&action.AddCollection{
+				SDL: `
+					type Users @policy(
+						id: "{{.Policy0}}",
+						resource: "users"
+					) {
+						name: String
+						age: Int
+					}
+				`,
+			},
+
+			&action.AddDoc{
+				CollectionID: 0,
+				Identity:     testUtils.ClientIdentity(1),
+				Doc:          userDoc,
+			},
+
+			&action.Request{
+				Identity: testUtils.ClientIdentity(1),
+				Request: `
+					query {
+						_commits {
+							cid
+						}
+					}
+				`,
+				Results: map[string]any{
+					"_commits": []map[string]any{
+						{"cid": uniqueCid},
+						{"cid": uniqueCid},
+						{"cid": uniqueCid},
+					},
+				},
+				NonOrderedResults: true,
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+// TODO: enable after DAC commits fix lands.
+// A doc registered with identity is private. Querying _commits without
+// identity should NOT return the doc's commits (per DAC).
+/*
+func TestACP_QueryCommitsOnPrivateDocWithoutIdentity_CanNotSeeCommits(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.AddDACPolicy{
+				Identity: testUtils.ClientIdentity(1),
+				Policy:   usersPolicy,
+			},
+
+			&action.AddCollection{
+				SDL: `
+					type Users @policy(
+						id: "{{.Policy0}}",
+						resource: "users"
+					) {
+						name: String
+						age: Int
+					}
+				`,
+			},
+
+			&action.AddDoc{
+				CollectionID: 0,
+				Identity:     testUtils.ClientIdentity(1),
+				Doc: userDoc,
+			},
+
+			&action.Request{
+				Request: `
+					query {
+						_commits {
+							cid
+						}
+					}
+				`,
+				Results: map[string]any{
+					"_commits": []map[string]any{},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+*/
+
+// TODO: enable after DAC commits fix lands.
+// A doc registered with identity is private. Querying _commits with a
+// different identity should NOT return the doc's commits (per DAC).
+/*
+func TestACP_QueryCommitsOnPrivateDocWithWrongIdentity_CanNotSeeCommits(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.AddDACPolicy{
+				Identity: testUtils.ClientIdentity(1),
+				Policy:   usersPolicy,
+			},
+
+			&action.AddCollection{
+				SDL: `
+					type Users @policy(
+						id: "{{.Policy0}}",
+						resource: "users"
+					) {
+						name: String
+						age: Int
+					}
+				`,
+			},
+
+			&action.AddDoc{
+				CollectionID: 0,
+				Identity:     testUtils.ClientIdentity(1),
+				Doc: userDoc,
+			},
+
+			&action.Request{
+				Identity: testUtils.ClientIdentity(2),
+				Request: `
+					query {
+						_commits {
+							cid
+						}
+					}
+				`,
+				Results: map[string]any{
+					"_commits": []map[string]any{},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+*/
+
+// TODO: enable after DAC commits fix lands.
+// A mix of public + private doc. Querying _commits without identity should
+// only return commits for the public doc (3 commits).
+/*
+func TestACP_QueryCommitsOnMixedDocsWithoutIdentity_CanOnlySeePublicCommits(t *testing.T) {
+	uniqueCid := testUtils.NewUniqueValue()
+
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.AddDACPolicy{
+				Identity: testUtils.ClientIdentity(1),
+				Policy:   usersPolicy,
+			},
+
+			&action.AddCollection{
+				SDL: `
+					type Users @policy(
+						id: "{{.Policy0}}",
+						resource: "users"
+					) {
+						name: String
+						age: Int
+					}
+				`,
+			},
+
+			&action.AddDoc{
+				CollectionID: 0,
+				Doc: userDoc,
+			},
+
+			&action.AddDoc{
+				CollectionID: 0,
+				Identity:     testUtils.ClientIdentity(1),
+				Doc: `
+					{
+						"name": "Andy",
+						"age": 33
+					}
+				`,
+			},
+
+			&action.Request{
+				Request: `
+					query {
+						_commits {
+							cid
+						}
+					}
+				`,
+				Results: map[string]any{
+					"_commits": []map[string]any{
+						{"cid": uniqueCid},
+						{"cid": uniqueCid},
+						{"cid": uniqueCid},
+					},
+				},
+				NonOrderedResults: true,
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+*/
+
+// A mix of public + private doc. Querying _commits with the owner identity
+// should return commits for both docs (6 commits total).
+func TestACP_QueryCommitsOnMixedDocsWithOwnerIdentity_CanSeeAllCommits(t *testing.T) {
+	uniqueCid := testUtils.NewUniqueValue()
+
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.AddDACPolicy{
+				Identity: testUtils.ClientIdentity(1),
+				Policy:   usersPolicy,
+			},
+
+			&action.AddCollection{
+				SDL: `
+					type Users @policy(
+						id: "{{.Policy0}}",
+						resource: "users"
+					) {
+						name: String
+						age: Int
+					}
+				`,
+			},
+
+			&action.AddDoc{
+				CollectionID: 0,
+				Doc:          userDoc,
+			},
+
+			&action.AddDoc{
+				CollectionID: 0,
+				Identity:     testUtils.ClientIdentity(1),
+				Doc: `
+					{
+						"name": "Andy",
+						"age": 33
+					}
+				`,
+			},
+
+			&action.Request{
+				Identity: testUtils.ClientIdentity(1),
+				Request: `
+					query {
+						_commits {
+							cid
+						}
+					}
+				`,
+				Results: map[string]any{
+					"_commits": []map[string]any{
+						{"cid": uniqueCid},
+						{"cid": uniqueCid},
+						{"cid": uniqueCid},
+						{"cid": uniqueCid},
+						{"cid": uniqueCid},
+						{"cid": uniqueCid},
+					},
+				},
+				NonOrderedResults: true,
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+// TODO: enable after DAC commits fix lands.
+// A mix of public + private doc. Querying _commits with a wrong identity
+// should only return commits for the public doc (3 commits).
+/*
+func TestACP_QueryCommitsOnMixedDocsWithWrongIdentity_CanOnlySeePublicCommits(t *testing.T) {
+	uniqueCid := testUtils.NewUniqueValue()
+
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.AddDACPolicy{
+				Identity: testUtils.ClientIdentity(1),
+				Policy:   usersPolicy,
+			},
+
+			&action.AddCollection{
+				SDL: `
+					type Users @policy(
+						id: "{{.Policy0}}",
+						resource: "users"
+					) {
+						name: String
+						age: Int
+					}
+				`,
+			},
+
+			&action.AddDoc{
+				CollectionID: 0,
+				Doc: userDoc,
+			},
+
+			&action.AddDoc{
+				CollectionID: 0,
+				Identity:     testUtils.ClientIdentity(1),
+				Doc: `
+					{
+						"name": "Andy",
+						"age": 33
+					}
+				`,
+			},
+
+			&action.Request{
+				Identity: testUtils.ClientIdentity(2),
+				Request: `
+					query {
+						_commits {
+							cid
+						}
+					}
+				`,
+				Results: map[string]any{
+					"_commits": []map[string]any{
+						{"cid": uniqueCid},
+						{"cid": uniqueCid},
+						{"cid": uniqueCid},
+					},
+				},
+				NonOrderedResults: true,
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+*/

--- a/tests/integration/acp/dac/commits/basic_test.go
+++ b/tests/integration/acp/dac/commits/basic_test.go
@@ -177,10 +177,8 @@ func TestACP_QueryCommitsOnPrivateDocWithOwnerIdentity_CanSeeCommits(t *testing.
 	testUtils.ExecuteTestCase(t, test)
 }
 
-// TODO: enable after DAC commits fix lands.
 // A doc registered with identity is private. Querying _commits without
 // identity should NOT return the doc's commits (per DAC).
-/*
 func TestACP_QueryCommitsOnPrivateDocWithoutIdentity_CanNotSeeCommits(t *testing.T) {
 	test := testUtils.TestCase{
 		Actions: []any{
@@ -204,7 +202,7 @@ func TestACP_QueryCommitsOnPrivateDocWithoutIdentity_CanNotSeeCommits(t *testing
 			&action.AddDoc{
 				CollectionID: 0,
 				Identity:     testUtils.ClientIdentity(1),
-				Doc: userDoc,
+				Doc:          userDoc,
 			},
 
 			&action.Request{
@@ -224,12 +222,9 @@ func TestACP_QueryCommitsOnPrivateDocWithoutIdentity_CanNotSeeCommits(t *testing
 
 	testUtils.ExecuteTestCase(t, test)
 }
-*/
 
-// TODO: enable after DAC commits fix lands.
 // A doc registered with identity is private. Querying _commits with a
 // different identity should NOT return the doc's commits (per DAC).
-/*
 func TestACP_QueryCommitsOnPrivateDocWithWrongIdentity_CanNotSeeCommits(t *testing.T) {
 	test := testUtils.TestCase{
 		Actions: []any{
@@ -253,7 +248,7 @@ func TestACP_QueryCommitsOnPrivateDocWithWrongIdentity_CanNotSeeCommits(t *testi
 			&action.AddDoc{
 				CollectionID: 0,
 				Identity:     testUtils.ClientIdentity(1),
-				Doc: userDoc,
+				Doc:          userDoc,
 			},
 
 			&action.Request{
@@ -274,12 +269,9 @@ func TestACP_QueryCommitsOnPrivateDocWithWrongIdentity_CanNotSeeCommits(t *testi
 
 	testUtils.ExecuteTestCase(t, test)
 }
-*/
 
-// TODO: enable after DAC commits fix lands.
 // A mix of public + private doc. Querying _commits without identity should
 // only return commits for the public doc (3 commits).
-/*
 func TestACP_QueryCommitsOnMixedDocsWithoutIdentity_CanOnlySeePublicCommits(t *testing.T) {
 	uniqueCid := testUtils.NewUniqueValue()
 
@@ -304,7 +296,7 @@ func TestACP_QueryCommitsOnMixedDocsWithoutIdentity_CanOnlySeePublicCommits(t *t
 
 			&action.AddDoc{
 				CollectionID: 0,
-				Doc: userDoc,
+				Doc:          userDoc,
 			},
 
 			&action.AddDoc{
@@ -340,7 +332,6 @@ func TestACP_QueryCommitsOnMixedDocsWithoutIdentity_CanOnlySeePublicCommits(t *t
 
 	testUtils.ExecuteTestCase(t, test)
 }
-*/
 
 // A mix of public + private doc. Querying _commits with the owner identity
 // should return commits for both docs (6 commits total).
@@ -409,10 +400,8 @@ func TestACP_QueryCommitsOnMixedDocsWithOwnerIdentity_CanSeeAllCommits(t *testin
 	testUtils.ExecuteTestCase(t, test)
 }
 
-// TODO: enable after DAC commits fix lands.
 // A mix of public + private doc. Querying _commits with a wrong identity
 // should only return commits for the public doc (3 commits).
-/*
 func TestACP_QueryCommitsOnMixedDocsWithWrongIdentity_CanOnlySeePublicCommits(t *testing.T) {
 	uniqueCid := testUtils.NewUniqueValue()
 
@@ -437,7 +426,7 @@ func TestACP_QueryCommitsOnMixedDocsWithWrongIdentity_CanOnlySeePublicCommits(t 
 
 			&action.AddDoc{
 				CollectionID: 0,
-				Doc: userDoc,
+				Doc:          userDoc,
 			},
 
 			&action.AddDoc{
@@ -474,4 +463,3 @@ func TestACP_QueryCommitsOnMixedDocsWithWrongIdentity_CanOnlySeePublicCommits(t 
 
 	testUtils.ExecuteTestCase(t, test)
 }
-*/

--- a/tests/integration/acp/dac/commits/fixture.go
+++ b/tests/integration/acp/dac/commits/fixture.go
@@ -45,3 +45,29 @@ const userDocID = "bae-cad49a1d-299c-5c34-9dab-a23f233f1a2f"
 // userDocCompositeCid is the deterministic composite-block cid for the userDoc.
 // It is only valid when the SignedDocs multiplier is excluded.
 const userDocCompositeCid = "bafyreifiehbtwpqssac2tk33na4agof7a23ymr5vd5xx6zty3zclftdogu"
+
+const usersAndPostsPolicy = `
+description: a test policy with two resources
+name: test
+resources:
+- name: users
+  permissions:
+  - name: delete
+  - name: read
+    expr: reader
+  - name: update
+  relations:
+  - name: reader
+    types:
+    - actor
+- name: posts
+  permissions:
+  - name: delete
+  - name: read
+    expr: reader
+  - name: update
+  relations:
+  - name: reader
+    types:
+    - actor
+`

--- a/tests/integration/acp/dac/commits/fixture.go
+++ b/tests/integration/acp/dac/commits/fixture.go
@@ -1,0 +1,43 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// This file is part of the DefraDB test suite.
+//
+// The DefraDB test suite is licensed under either:
+//
+//   (1) GNU Affero General Public License v3
+//   (2) Business Source License 1.1
+//
+// See tests/LICENSE for details.
+
+package test_acp_dac_commits
+
+const usersPolicy = `
+description: a test policy
+name: test
+resources:
+- name: users
+  permissions:
+  - name: delete
+  - name: read
+    expr: reader
+  - name: update
+  relations:
+  - manages:
+    - reader
+    name: admin
+    types:
+    - actor
+  - name: reader
+    types:
+    - actor
+`
+
+const userDoc = `
+{
+	"name": "Shahzad",
+	"age": 28
+}
+`
+
+// userDocID is the docID for the userDoc.
+const userDocID = "bae-cad49a1d-299c-5c34-9dab-a23f233f1a2f"

--- a/tests/integration/acp/dac/commits/fixture.go
+++ b/tests/integration/acp/dac/commits/fixture.go
@@ -41,3 +41,7 @@ const userDoc = `
 
 // userDocID is the docID for the userDoc.
 const userDocID = "bae-cad49a1d-299c-5c34-9dab-a23f233f1a2f"
+
+// userDocCompositeCid is the deterministic composite-block cid for the userDoc.
+// It is only valid when the SignedDocs multiplier is excluded.
+const userDocCompositeCid = "bafyreifiehbtwpqssac2tk33na4agof7a23ymr5vd5xx6zty3zclftdogu"

--- a/tests/integration/acp/dac/commits/multi_collection_test.go
+++ b/tests/integration/acp/dac/commits/multi_collection_test.go
@@ -1,0 +1,161 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// This file is part of the DefraDB test suite.
+//
+// The DefraDB test suite is licensed under either:
+//
+//   (1) GNU Affero General Public License v3
+//   (2) Business Source License 1.1
+//
+// See tests/LICENSE for details.
+
+package test_acp_dac_commits
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/defradb/tests/action"
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+// A `_commits` query without docID iterates heads across every collection
+// in the database. The owner should see all commits from both private
+// collections; the per-versionID cache must route each block to the
+// correct collection for the access check.
+func TestACP_QueryCommitsMultiCollectionWithOwnerIdentity_CanSeeAllCommits(t *testing.T) {
+	uniqueCid := testUtils.NewUniqueValue()
+
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.AddDACPolicy{
+				Identity: testUtils.ClientIdentity(1),
+				Policy:   usersAndPostsPolicy,
+			},
+
+			&action.AddCollection{
+				SDL: `
+					type Users @policy(
+						id: "{{.Policy0}}",
+						resource: "users"
+					) {
+						name: String
+						age: Int
+					}
+
+					type Posts @policy(
+						id: "{{.Policy0}}",
+						resource: "posts"
+					) {
+						title: String
+					}
+				`,
+			},
+
+			&action.AddDoc{
+				CollectionID: 0,
+				Identity:     testUtils.ClientIdentity(1),
+				Doc:          userDoc,
+			},
+
+			&action.AddDoc{
+				CollectionID: 1,
+				Identity:     testUtils.ClientIdentity(1),
+				Doc: `
+					{
+						"title": "First Post"
+					}
+				`,
+			},
+
+			// 3 commits per Users doc (name, age, composite) + 2 commits
+			// per Posts doc (title, composite) = 5 commits.
+			&action.Request{
+				Identity: testUtils.ClientIdentity(1),
+				Request: `
+					query {
+						_commits {
+							cid
+						}
+					}
+				`,
+				Results: map[string]any{
+					"_commits": []map[string]any{
+						{"cid": uniqueCid},
+						{"cid": uniqueCid},
+						{"cid": uniqueCid},
+						{"cid": uniqueCid},
+						{"cid": uniqueCid},
+					},
+				},
+				NonOrderedResults: true,
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+// A wrong-identity caller should see no commits across either collection,
+// confirming the per-versionID cache routing does not leak between
+// collections.
+func TestACP_QueryCommitsMultiCollectionWithWrongIdentity_CanNotSeeCommits(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.AddDACPolicy{
+				Identity: testUtils.ClientIdentity(1),
+				Policy:   usersAndPostsPolicy,
+			},
+
+			&action.AddCollection{
+				SDL: `
+					type Users @policy(
+						id: "{{.Policy0}}",
+						resource: "users"
+					) {
+						name: String
+						age: Int
+					}
+
+					type Posts @policy(
+						id: "{{.Policy0}}",
+						resource: "posts"
+					) {
+						title: String
+					}
+				`,
+			},
+
+			&action.AddDoc{
+				CollectionID: 0,
+				Identity:     testUtils.ClientIdentity(1),
+				Doc:          userDoc,
+			},
+
+			&action.AddDoc{
+				CollectionID: 1,
+				Identity:     testUtils.ClientIdentity(1),
+				Doc: `
+					{
+						"title": "First Post"
+					}
+				`,
+			},
+
+			&action.Request{
+				Identity: testUtils.ClientIdentity(2),
+				Request: `
+					query {
+						_commits {
+							cid
+						}
+					}
+				`,
+				Results: map[string]any{
+					"_commits": []map[string]any{},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/acp/dac/commits/version_subselect_test.go
+++ b/tests/integration/acp/dac/commits/version_subselect_test.go
@@ -1,0 +1,131 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// This file is part of the DefraDB test suite.
+//
+// The DefraDB test suite is licensed under either:
+//
+//   (1) GNU Affero General Public License v3
+//   (2) Business Source License 1.1
+//
+// See tests/LICENSE for details.
+
+package test_acp_dac_commits
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/defradb/tests/action"
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+// The `_version` inline sub-select goes through the same dagScanNode
+// code path as `_commits` (see internal/planner/select.go where DAGScan
+// is invoked for the version field). The owner should see commits via
+// _version against a private doc.
+func TestACP_QueryVersionSubSelectOnPrivateDocWithOwnerIdentity_CanSeeCommits(t *testing.T) {
+	uniqueCid := testUtils.NewUniqueValue()
+
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.AddDACPolicy{
+				Identity: testUtils.ClientIdentity(1),
+				Policy:   usersPolicy,
+			},
+
+			&action.AddCollection{
+				SDL: `
+					type Users @policy(
+						id: "{{.Policy0}}",
+						resource: "users"
+					) {
+						name: String
+						age: Int
+					}
+				`,
+			},
+
+			&action.AddDoc{
+				CollectionID: 0,
+				Identity:     testUtils.ClientIdentity(1),
+				Doc:          userDoc,
+			},
+
+			&action.Request{
+				Identity: testUtils.ClientIdentity(1),
+				Request: `
+					query {
+						Users {
+							_docID
+							_version {
+								cid
+							}
+						}
+					}
+				`,
+				Results: map[string]any{
+					"Users": []map[string]any{
+						{
+							"_docID": userDocID,
+							"_version": []map[string]any{
+								{"cid": uniqueCid},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+// A wrong-identity caller cannot see the parent doc, so _version is
+// never reached. Confirms the inline sub-select path is gated by the
+// outer DAC fetcher and does not leak commits via a side channel.
+func TestACP_QueryVersionSubSelectOnPrivateDocWithWrongIdentity_CanNotSeeCommits(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.AddDACPolicy{
+				Identity: testUtils.ClientIdentity(1),
+				Policy:   usersPolicy,
+			},
+
+			&action.AddCollection{
+				SDL: `
+					type Users @policy(
+						id: "{{.Policy0}}",
+						resource: "users"
+					) {
+						name: String
+						age: Int
+					}
+				`,
+			},
+
+			&action.AddDoc{
+				CollectionID: 0,
+				Identity:     testUtils.ClientIdentity(1),
+				Doc:          userDoc,
+			},
+
+			&action.Request{
+				Identity: testUtils.ClientIdentity(2),
+				Request: `
+					query {
+						Users {
+							_docID
+							_version {
+								cid
+							}
+						}
+					}
+				`,
+				Results: map[string]any{
+					"Users": []map[string]any{},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/acp/dac/commits/with_cid_test.go
+++ b/tests/integration/acp/dac/commits/with_cid_test.go
@@ -1,0 +1,118 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// This file is part of the DefraDB test suite.
+//
+// The DefraDB test suite is licensed under either:
+//
+//   (1) GNU Affero General Public License v3
+//   (2) Business Source License 1.1
+//
+// See tests/LICENSE for details.
+
+package test_acp_dac_commits
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/defradb/tests/action"
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	"github.com/sourcenetwork/defradb/tests/multiplier"
+)
+
+// Private doc. _commits(cid:) without identity should NOT return the
+// targeted commit (per DAC).
+func TestACP_QueryCommitsWithCIDOnPrivateDocWithoutIdentity_CanNotSeeCommit(t *testing.T) {
+	test := testUtils.TestCase{
+		// Result CIDs are hardcoded; SignedDocs mode changes cid values.
+		MultiplierExcludes: []string{multiplier.SignedDocs},
+		Actions: []any{
+			testUtils.AddDACPolicy{
+				Identity: testUtils.ClientIdentity(1),
+				Policy:   usersPolicy,
+			},
+
+			&action.AddCollection{
+				SDL: `
+					type Users @policy(
+						id: "{{.Policy0}}",
+						resource: "users"
+					) {
+						name: String
+						age: Int
+					}
+				`,
+			},
+
+			&action.AddDoc{
+				CollectionID: 0,
+				Identity:     testUtils.ClientIdentity(1),
+				Doc:          userDoc,
+			},
+
+			&action.Request{
+				Request: `
+					query {
+						_commits(cid: "` + userDocCompositeCid + `") {
+							cid
+						}
+					}
+				`,
+				Results: map[string]any{
+					"_commits": []map[string]any{},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+// Private doc. _commits(cid:) with the owner identity should return the
+// targeted commit.
+func TestACP_QueryCommitsWithCIDOnPrivateDocWithOwnerIdentity_CanSeeCommit(t *testing.T) {
+	test := testUtils.TestCase{
+		MultiplierExcludes: []string{multiplier.SignedDocs},
+		Actions: []any{
+			testUtils.AddDACPolicy{
+				Identity: testUtils.ClientIdentity(1),
+				Policy:   usersPolicy,
+			},
+
+			&action.AddCollection{
+				SDL: `
+					type Users @policy(
+						id: "{{.Policy0}}",
+						resource: "users"
+					) {
+						name: String
+						age: Int
+					}
+				`,
+			},
+
+			&action.AddDoc{
+				CollectionID: 0,
+				Identity:     testUtils.ClientIdentity(1),
+				Doc:          userDoc,
+			},
+
+			&action.Request{
+				Identity: testUtils.ClientIdentity(1),
+				Request: `
+					query {
+						_commits(cid: "` + userDocCompositeCid + `") {
+							cid
+						}
+					}
+				`,
+				Results: map[string]any{
+					"_commits": []map[string]any{
+						{"cid": userDocCompositeCid},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/acp/dac/commits/with_doc_id_test.go
+++ b/tests/integration/acp/dac/commits/with_doc_id_test.go
@@ -1,0 +1,223 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// This file is part of the DefraDB test suite.
+//
+// The DefraDB test suite is licensed under either:
+//
+//   (1) GNU Affero General Public License v3
+//   (2) Business Source License 1.1
+//
+// See tests/LICENSE for details.
+
+package test_acp_dac_commits
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/defradb/tests/action"
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+// Public doc. _commits(docID:) without identity should return 3 commits.
+func TestACP_QueryCommitsWithDocIDOnPublicDocWithoutIdentity_CanSeeCommits(t *testing.T) {
+	uniqueCid := testUtils.NewUniqueValue()
+
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.AddDACPolicy{
+				Identity: testUtils.ClientIdentity(1),
+				Policy:   usersPolicy,
+			},
+
+			&action.AddCollection{
+				SDL: `
+					type Users @policy(
+						id: "{{.Policy0}}",
+						resource: "users"
+					) {
+						name: String
+						age: Int
+					}
+				`,
+			},
+
+			&action.AddDoc{
+				CollectionID: 0,
+				Doc:          userDoc,
+			},
+
+			&action.Request{
+				Request: `
+					query {
+						_commits(docID: "` + userDocID + `") {
+							cid
+						}
+					}
+				`,
+				Results: map[string]any{
+					"_commits": []map[string]any{
+						{"cid": uniqueCid},
+						{"cid": uniqueCid},
+						{"cid": uniqueCid},
+					},
+				},
+				NonOrderedResults: true,
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+// Private doc. Querying _commits(docID:) with the owner identity should
+// return all 3 commits.
+func TestACP_QueryCommitsWithDocIDOnPrivateDocWithOwnerIdentity_CanSeeCommits(t *testing.T) {
+	uniqueCid := testUtils.NewUniqueValue()
+
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.AddDACPolicy{
+				Identity: testUtils.ClientIdentity(1),
+				Policy:   usersPolicy,
+			},
+
+			&action.AddCollection{
+				SDL: `
+					type Users @policy(
+						id: "{{.Policy0}}",
+						resource: "users"
+					) {
+						name: String
+						age: Int
+					}
+				`,
+			},
+
+			&action.AddDoc{
+				CollectionID: 0,
+				Identity:     testUtils.ClientIdentity(1),
+				Doc:          userDoc,
+			},
+
+			&action.Request{
+				Identity: testUtils.ClientIdentity(1),
+				Request: `
+					query {
+						_commits(docID: "` + userDocID + `") {
+							cid
+						}
+					}
+				`,
+				Results: map[string]any{
+					"_commits": []map[string]any{
+						{"cid": uniqueCid},
+						{"cid": uniqueCid},
+						{"cid": uniqueCid},
+					},
+				},
+				NonOrderedResults: true,
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+// TODO: enable after DAC commits fix lands.
+// Private doc. Querying _commits(docID:) without identity should NOT return
+// commits (per DAC).
+/*
+func TestACP_QueryCommitsWithDocIDOnPrivateDocWithoutIdentity_CanNotSeeCommits(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.AddDACPolicy{
+				Identity: testUtils.ClientIdentity(1),
+				Policy:   usersPolicy,
+			},
+
+			&action.AddCollection{
+				SDL: `
+					type Users @policy(
+						id: "{{.Policy0}}",
+						resource: "users"
+					) {
+						name: String
+						age: Int
+					}
+				`,
+			},
+
+			&action.AddDoc{
+				CollectionID: 0,
+				Identity:     testUtils.ClientIdentity(1),
+				Doc: userDoc,
+			},
+
+			&action.Request{
+				Request: `
+					query {
+						_commits(docID: "` + userDocID + `") {
+							cid
+						}
+					}
+				`,
+				Results: map[string]any{
+					"_commits": []map[string]any{},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+*/
+
+// TODO: enable after DAC commits fix lands.
+// Private doc. Querying _commits(docID:) with a wrong identity should NOT
+// return commits (per DAC).
+/*
+func TestACP_QueryCommitsWithDocIDOnPrivateDocWithWrongIdentity_CanNotSeeCommits(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.AddDACPolicy{
+				Identity: testUtils.ClientIdentity(1),
+				Policy:   usersPolicy,
+			},
+
+			&action.AddCollection{
+				SDL: `
+					type Users @policy(
+						id: "{{.Policy0}}",
+						resource: "users"
+					) {
+						name: String
+						age: Int
+					}
+				`,
+			},
+
+			&action.AddDoc{
+				CollectionID: 0,
+				Identity:     testUtils.ClientIdentity(1),
+				Doc: userDoc,
+			},
+
+			&action.Request{
+				Identity: testUtils.ClientIdentity(2),
+				Request: `
+					query {
+						_commits(docID: "` + userDocID + `") {
+							cid
+						}
+					}
+				`,
+				Results: map[string]any{
+					"_commits": []map[string]any{},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+*/

--- a/tests/integration/acp/dac/commits/with_doc_id_test.go
+++ b/tests/integration/acp/dac/commits/with_doc_id_test.go
@@ -123,10 +123,8 @@ func TestACP_QueryCommitsWithDocIDOnPrivateDocWithOwnerIdentity_CanSeeCommits(t 
 	testUtils.ExecuteTestCase(t, test)
 }
 
-// TODO: enable after DAC commits fix lands.
 // Private doc. Querying _commits(docID:) without identity should NOT return
 // commits (per DAC).
-/*
 func TestACP_QueryCommitsWithDocIDOnPrivateDocWithoutIdentity_CanNotSeeCommits(t *testing.T) {
 	test := testUtils.TestCase{
 		Actions: []any{
@@ -150,7 +148,7 @@ func TestACP_QueryCommitsWithDocIDOnPrivateDocWithoutIdentity_CanNotSeeCommits(t
 			&action.AddDoc{
 				CollectionID: 0,
 				Identity:     testUtils.ClientIdentity(1),
-				Doc: userDoc,
+				Doc:          userDoc,
 			},
 
 			&action.Request{
@@ -170,12 +168,9 @@ func TestACP_QueryCommitsWithDocIDOnPrivateDocWithoutIdentity_CanNotSeeCommits(t
 
 	testUtils.ExecuteTestCase(t, test)
 }
-*/
 
-// TODO: enable after DAC commits fix lands.
 // Private doc. Querying _commits(docID:) with a wrong identity should NOT
 // return commits (per DAC).
-/*
 func TestACP_QueryCommitsWithDocIDOnPrivateDocWithWrongIdentity_CanNotSeeCommits(t *testing.T) {
 	test := testUtils.TestCase{
 		Actions: []any{
@@ -199,7 +194,7 @@ func TestACP_QueryCommitsWithDocIDOnPrivateDocWithWrongIdentity_CanNotSeeCommits
 			&action.AddDoc{
 				CollectionID: 0,
 				Identity:     testUtils.ClientIdentity(1),
-				Doc: userDoc,
+				Doc:          userDoc,
 			},
 
 			&action.Request{
@@ -220,4 +215,3 @@ func TestACP_QueryCommitsWithDocIDOnPrivateDocWithWrongIdentity_CanNotSeeCommits
 
 	testUtils.ExecuteTestCase(t, test)
 }
-*/

--- a/tests/integration/acp/dac/commits/with_filters_test.go
+++ b/tests/integration/acp/dac/commits/with_filters_test.go
@@ -18,10 +18,8 @@ import (
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
 )
 
-// TODO: enable after DAC commits fix lands.
 // Private doc. _commits with a fieldName filter should also be DAC-protected:
 // querying without identity must not return the field commit.
-/*
 func TestACP_QueryCommitsWithFieldNameFilterOnPrivateDocWithoutIdentity_CanNotSeeCommits(t *testing.T) {
 	test := testUtils.TestCase{
 		Actions: []any{
@@ -45,7 +43,7 @@ func TestACP_QueryCommitsWithFieldNameFilterOnPrivateDocWithoutIdentity_CanNotSe
 			&action.AddDoc{
 				CollectionID: 0,
 				Identity:     testUtils.ClientIdentity(1),
-				Doc: userDoc,
+				Doc:          userDoc,
 			},
 
 			&action.Request{
@@ -66,7 +64,6 @@ func TestACP_QueryCommitsWithFieldNameFilterOnPrivateDocWithoutIdentity_CanNotSe
 
 	testUtils.ExecuteTestCase(t, test)
 }
-*/
 
 // Private doc. _commits with a fieldName filter and owner identity should
 // return the field commit.
@@ -190,10 +187,8 @@ func TestACP_QueryCommitsAfterUpdateOnPrivateDocWithOwnerIdentity_CanSeeAllCommi
 	testUtils.ExecuteTestCase(t, test)
 }
 
-// TODO: enable after DAC commits fix lands.
 // Private doc + an update. _commits without identity should NOT see any of
 // the 5 commits (per DAC).
-/*
 func TestACP_QueryCommitsAfterUpdateOnPrivateDocWithoutIdentity_CanNotSeeCommits(t *testing.T) {
 	test := testUtils.TestCase{
 		Actions: []any{
@@ -217,7 +212,7 @@ func TestACP_QueryCommitsAfterUpdateOnPrivateDocWithoutIdentity_CanNotSeeCommits
 			&action.AddDoc{
 				CollectionID: 0,
 				Identity:     testUtils.ClientIdentity(1),
-				Doc: userDoc,
+				Doc:          userDoc,
 			},
 
 			&action.UpdateDoc{
@@ -248,12 +243,9 @@ func TestACP_QueryCommitsAfterUpdateOnPrivateDocWithoutIdentity_CanNotSeeCommits
 
 	testUtils.ExecuteTestCase(t, test)
 }
-*/
 
-// TODO: enable after DAC commits fix lands.
 // Private doc + an update. _commits(depth: 1) without identity should NOT
 // see any commits (per DAC).
-/*
 func TestACP_QueryCommitsWithDepthOnPrivateDocWithoutIdentity_CanNotSeeCommits(t *testing.T) {
 	test := testUtils.TestCase{
 		Actions: []any{
@@ -277,7 +269,7 @@ func TestACP_QueryCommitsWithDepthOnPrivateDocWithoutIdentity_CanNotSeeCommits(t
 			&action.AddDoc{
 				CollectionID: 0,
 				Identity:     testUtils.ClientIdentity(1),
-				Doc: userDoc,
+				Doc:          userDoc,
 			},
 
 			&action.UpdateDoc{
@@ -308,4 +300,3 @@ func TestACP_QueryCommitsWithDepthOnPrivateDocWithoutIdentity_CanNotSeeCommits(t
 
 	testUtils.ExecuteTestCase(t, test)
 }
-*/

--- a/tests/integration/acp/dac/commits/with_filters_test.go
+++ b/tests/integration/acp/dac/commits/with_filters_test.go
@@ -1,0 +1,311 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// This file is part of the DefraDB test suite.
+//
+// The DefraDB test suite is licensed under either:
+//
+//   (1) GNU Affero General Public License v3
+//   (2) Business Source License 1.1
+//
+// See tests/LICENSE for details.
+
+package test_acp_dac_commits
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/defradb/tests/action"
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+// TODO: enable after DAC commits fix lands.
+// Private doc. _commits with a fieldName filter should also be DAC-protected:
+// querying without identity must not return the field commit.
+/*
+func TestACP_QueryCommitsWithFieldNameFilterOnPrivateDocWithoutIdentity_CanNotSeeCommits(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.AddDACPolicy{
+				Identity: testUtils.ClientIdentity(1),
+				Policy:   usersPolicy,
+			},
+
+			&action.AddCollection{
+				SDL: `
+					type Users @policy(
+						id: "{{.Policy0}}",
+						resource: "users"
+					) {
+						name: String
+						age: Int
+					}
+				`,
+			},
+
+			&action.AddDoc{
+				CollectionID: 0,
+				Identity:     testUtils.ClientIdentity(1),
+				Doc: userDoc,
+			},
+
+			&action.Request{
+				Request: `
+					query {
+						_commits(filter: {fieldName: {_eq: "name"}}) {
+							cid
+							fieldName
+						}
+					}
+				`,
+				Results: map[string]any{
+					"_commits": []map[string]any{},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+*/
+
+// Private doc. _commits with a fieldName filter and owner identity should
+// return the field commit.
+func TestACP_QueryCommitsWithFieldNameFilterOnPrivateDocWithOwnerIdentity_CanSeeCommits(t *testing.T) {
+	uniqueCid := testUtils.NewUniqueValue()
+
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.AddDACPolicy{
+				Identity: testUtils.ClientIdentity(1),
+				Policy:   usersPolicy,
+			},
+
+			&action.AddCollection{
+				SDL: `
+					type Users @policy(
+						id: "{{.Policy0}}",
+						resource: "users"
+					) {
+						name: String
+						age: Int
+					}
+				`,
+			},
+
+			&action.AddDoc{
+				CollectionID: 0,
+				Identity:     testUtils.ClientIdentity(1),
+				Doc:          userDoc,
+			},
+
+			&action.Request{
+				Identity: testUtils.ClientIdentity(1),
+				Request: `
+					query {
+						_commits(filter: {fieldName: {_eq: "name"}}) {
+							cid
+							fieldName
+						}
+					}
+				`,
+				Results: map[string]any{
+					"_commits": []map[string]any{
+						{
+							"cid":       uniqueCid,
+							"fieldName": "name",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+// Private doc + an update. _commits with the owner identity should return all
+// 5 commits (3 from create, 2 from update: composite + age).
+func TestACP_QueryCommitsAfterUpdateOnPrivateDocWithOwnerIdentity_CanSeeAllCommits(t *testing.T) {
+	uniqueCid := testUtils.NewUniqueValue()
+
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.AddDACPolicy{
+				Identity: testUtils.ClientIdentity(1),
+				Policy:   usersPolicy,
+			},
+
+			&action.AddCollection{
+				SDL: `
+					type Users @policy(
+						id: "{{.Policy0}}",
+						resource: "users"
+					) {
+						name: String
+						age: Int
+					}
+				`,
+			},
+
+			&action.AddDoc{
+				CollectionID: 0,
+				Identity:     testUtils.ClientIdentity(1),
+				Doc:          userDoc,
+			},
+
+			&action.UpdateDoc{
+				CollectionID: 0,
+				DocID:        0,
+				Identity:     testUtils.ClientIdentity(1),
+				Doc: `
+					{
+						"age": 29
+					}
+				`,
+			},
+
+			&action.Request{
+				Identity: testUtils.ClientIdentity(1),
+				Request: `
+					query {
+						_commits {
+							cid
+						}
+					}
+				`,
+				Results: map[string]any{
+					"_commits": []map[string]any{
+						{"cid": uniqueCid},
+						{"cid": uniqueCid},
+						{"cid": uniqueCid},
+						{"cid": uniqueCid},
+						{"cid": uniqueCid},
+					},
+				},
+				NonOrderedResults: true,
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+// TODO: enable after DAC commits fix lands.
+// Private doc + an update. _commits without identity should NOT see any of
+// the 5 commits (per DAC).
+/*
+func TestACP_QueryCommitsAfterUpdateOnPrivateDocWithoutIdentity_CanNotSeeCommits(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.AddDACPolicy{
+				Identity: testUtils.ClientIdentity(1),
+				Policy:   usersPolicy,
+			},
+
+			&action.AddCollection{
+				SDL: `
+					type Users @policy(
+						id: "{{.Policy0}}",
+						resource: "users"
+					) {
+						name: String
+						age: Int
+					}
+				`,
+			},
+
+			&action.AddDoc{
+				CollectionID: 0,
+				Identity:     testUtils.ClientIdentity(1),
+				Doc: userDoc,
+			},
+
+			&action.UpdateDoc{
+				CollectionID: 0,
+				DocID:        0,
+				Identity:     testUtils.ClientIdentity(1),
+				Doc: `
+					{
+						"age": 29
+					}
+				`,
+			},
+
+			&action.Request{
+				Request: `
+					query {
+						_commits {
+							cid
+						}
+					}
+				`,
+				Results: map[string]any{
+					"_commits": []map[string]any{},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+*/
+
+// TODO: enable after DAC commits fix lands.
+// Private doc + an update. _commits(depth: 1) without identity should NOT
+// see any commits (per DAC).
+/*
+func TestACP_QueryCommitsWithDepthOnPrivateDocWithoutIdentity_CanNotSeeCommits(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.AddDACPolicy{
+				Identity: testUtils.ClientIdentity(1),
+				Policy:   usersPolicy,
+			},
+
+			&action.AddCollection{
+				SDL: `
+					type Users @policy(
+						id: "{{.Policy0}}",
+						resource: "users"
+					) {
+						name: String
+						age: Int
+					}
+				`,
+			},
+
+			&action.AddDoc{
+				CollectionID: 0,
+				Identity:     testUtils.ClientIdentity(1),
+				Doc: userDoc,
+			},
+
+			&action.UpdateDoc{
+				CollectionID: 0,
+				DocID:        0,
+				Identity:     testUtils.ClientIdentity(1),
+				Doc: `
+					{
+						"age": 29
+					}
+				`,
+			},
+
+			&action.Request{
+				Request: `
+					query {
+						_commits(depth: 1) {
+							cid
+						}
+					}
+				`,
+				Results: map[string]any{
+					"_commits": []map[string]any{},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+*/

--- a/tests/integration/acp/dac/commits/with_relationship_test.go
+++ b/tests/integration/acp/dac/commits/with_relationship_test.go
@@ -1,0 +1,98 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// This file is part of the DefraDB test suite.
+//
+// The DefraDB test suite is licensed under either:
+//
+//   (1) GNU Affero General Public License v3
+//   (2) Business Source License 1.1
+//
+// See tests/LICENSE for details.
+
+package test_acp_dac_commits
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/defradb/tests/action"
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+// Private doc owned by identity 1. Identity 2 is granted reader via
+// AddDACActorRelationship and should then be able to see the doc's commits.
+func TestACP_QueryCommitsOnPrivateDocWithReaderRelationship_CanSeeCommits(t *testing.T) {
+	uniqueCid := testUtils.NewUniqueValue()
+
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.AddDACPolicy{
+				Identity: testUtils.ClientIdentity(1),
+				Policy:   usersPolicy,
+			},
+
+			&action.AddCollection{
+				SDL: `
+					type Users @policy(
+						id: "{{.Policy0}}",
+						resource: "users"
+					) {
+						name: String
+						age: Int
+					}
+				`,
+			},
+
+			&action.AddDoc{
+				CollectionID: 0,
+				Identity:     testUtils.ClientIdentity(1),
+				Doc:          userDoc,
+			},
+
+			// Before the grant, identity 2 sees nothing.
+			&action.Request{
+				Identity: testUtils.ClientIdentity(2),
+				Request: `
+					query {
+						_commits {
+							cid
+						}
+					}
+				`,
+				Results: map[string]any{
+					"_commits": []map[string]any{},
+				},
+			},
+
+			testUtils.AddDACActorRelationship{
+				RequestorIdentity: testUtils.ClientIdentity(1),
+				TargetIdentity:    testUtils.ClientIdentity(2),
+				CollectionID:      0,
+				DocID:             0,
+				Relation:          "reader",
+				ExpectedExistence: false,
+			},
+
+			// After the grant, identity 2 sees all 3 commits.
+			&action.Request{
+				Identity: testUtils.ClientIdentity(2),
+				Request: `
+					query {
+						_commits {
+							cid
+						}
+					}
+				`,
+				Results: map[string]any{
+					"_commits": []map[string]any{
+						{"cid": uniqueCid},
+						{"cid": uniqueCid},
+						{"cid": uniqueCid},
+					},
+				},
+				NonOrderedResults: true,
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}


### PR DESCRIPTION
Relevant issue(s):
- Resolves #2469 

## Description
The `_commits` query was bypassing the document access control (DAC) layer, so any client (signed or anonymous) could read the commit history of documents they had no read access to. The deltas inside those commits expose the same field values DAC is meant to gate.

Plugged the gap with a single chokepoint inside `dagScanNode.Next()`: after each block is decoded, resolve its collection by `CollectionVersionID` and check `DocumentReadPerm` against the caller's identity. Denied commits are marked visited and skipped, so the same cid is not re-checked when it resurfaces via a `links` or `heads` sub-scan. Publc collections, public
docs, and bypass-DAC identities continue to fall through the existing short-circuits in the access check.

## For reviewers:
- The first commit writes tests we want to ensure work after the feature, I commented out the tests in the first commit that were failing due to DAC not gating commit queries, they are then re-enabled after the implementation, to test they pass now.
- Commit by commit review should be clean.

## How has this been tested?
- Added tests under `tests/integration/acp/dac/commits/` folder.