### PR TITLE
test(i): Add explicit-txn tests for create doc call paths (#4475)

### DIFF
--- a/tests/integration/txn/add_doc_test.go
+++ b/tests/integration/txn/add_doc_test.go
@@ -117,6 +117,430 @@ func TestTxn_AddDoc_WithoutCommit_EmptyResults(t *testing.T) {
 	testUtils.ExecuteTestCase(t, test)
 }
 
+// This test runs AddDoc inside of a transaction, and illustrates that a query running inside
+// the same transaction can see the uncommitted document, while a query outside the transaction
+// cannot — mirroring the isolation behaviour exercised for UpdateDoc and DeleteDoc in this
+// package. See GH issue #4475.
+func TestTxn_AddDoc_ExhibitsTransactionalIsolation_Succeeds(t *testing.T) {
+	test := testUtils.TestCase{
+		// LevelDB does not support concurrent transactions
+		// todo: https://github.com/sourcenetwork/defradb/issues/4442
+		SupportedDatabaseTypes: immutable.Some([]state.DatabaseType{
+			testUtils.BadgerFileType,
+			testUtils.BadgerIMType,
+			testUtils.DefraIMType,
+		}),
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type Users {
+						name: String
+						age: Int
+					}
+				`,
+			},
+			&action.AddDoc{
+				TransactionID: immutable.Some(1),
+				Doc: `{
+					"name": "John",
+					"age": 27
+				}`,
+			},
+			// The query inside the transaction sees the doc that was just added.
+			&action.Request{
+				TransactionID: immutable.Some(1),
+				Request: `
+					query {
+						Users {
+							name
+							age
+						}
+					}
+				`,
+				Results: map[string]any{
+					"Users": []map[string]any{
+						{
+							"name": "John",
+							"age":  int64(27),
+						},
+					},
+				},
+			},
+			// The query outside the transaction does not see the uncommitted doc.
+			&action.Request{
+				Request: `
+					query {
+						Users {
+							name
+							age
+						}
+					}
+				`,
+				Results: map[string]any{
+					"Users": []map[string]any{},
+				},
+			},
+			&action.CommitTransaction{
+				TransactionID: 1,
+			},
+			// After commit, the doc is visible globally.
+			&action.Request{
+				Request: `
+					query {
+						Users {
+							name
+							age
+						}
+					}
+				`,
+				Results: map[string]any{
+					"Users": []map[string]any{
+						{
+							"name": "John",
+							"age":  int64(27),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+// This test runs multiple AddDoc actions inside the same transaction and illustrates that
+// committing the transaction results in all of the documents being added atomically.
+// See GH issue #4475.
+func TestTxn_AddManyDocs_WithCommit_Succeeds(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type Users {
+						name: String
+						age: Int
+					}
+				`,
+			},
+			&action.AddDoc{
+				TransactionID: immutable.Some(1),
+				Doc: `{
+					"name": "John",
+					"age": 27
+				}`,
+			},
+			&action.AddDoc{
+				TransactionID: immutable.Some(1),
+				Doc: `{
+					"name": "Jane",
+					"age": 30
+				}`,
+			},
+			&action.CommitTransaction{
+				TransactionID: 1,
+			},
+			&action.Request{
+				Request: `
+					query {
+						Users {
+							name
+							age
+						}
+					}
+				`,
+				NonOrderedResults: true,
+				Results: map[string]any{
+					"Users": []map[string]any{
+						{
+							"name": "John",
+							"age":  int64(27),
+						},
+						{
+							"name": "Jane",
+							"age":  int64(30),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+// This test runs multiple AddDoc actions inside the same transaction and illustrates that
+// without a commit none of the documents are visible outside the transaction.
+// See GH issue #4475.
+func TestTxn_AddManyDocs_WithoutCommit_EmptyResults(t *testing.T) {
+	test := testUtils.TestCase{
+		// LevelDB does not support concurrent transactions
+		// todo: https://github.com/sourcenetwork/defradb/issues/4442
+		SupportedDatabaseTypes: immutable.Some([]state.DatabaseType{
+			testUtils.BadgerFileType,
+			testUtils.BadgerIMType,
+			testUtils.DefraIMType,
+		}),
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type Users {
+						name: String
+						age: Int
+					}
+				`,
+			},
+			&action.AddDoc{
+				TransactionID: immutable.Some(1),
+				Doc: `{
+					"name": "John",
+					"age": 27
+				}`,
+			},
+			&action.AddDoc{
+				TransactionID: immutable.Some(1),
+				Doc: `{
+					"name": "Jane",
+					"age": 30
+				}`,
+			},
+			&action.Request{
+				Request: `
+					query {
+						Users {
+							name
+							age
+						}
+					}
+				`,
+				Results: map[string]any{
+					"Users": []map[string]any{},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+// This test runs AddDoc inside a transaction and then discards the transaction, illustrating
+// that the document never becomes visible. See GH issue #4475.
+func TestTxn_AddDoc_WithDiscard_NeverVisible(t *testing.T) {
+	test := testUtils.TestCase{
+		// LevelDB does not support concurrent transactions
+		// todo: https://github.com/sourcenetwork/defradb/issues/4442
+		SupportedDatabaseTypes: immutable.Some([]state.DatabaseType{
+			testUtils.BadgerFileType,
+			testUtils.BadgerIMType,
+			testUtils.DefraIMType,
+		}),
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type Users {
+						name: String
+						age: Int
+					}
+				`,
+			},
+			&action.AddDoc{
+				TransactionID: immutable.Some(1),
+				Doc: `{
+					"name": "John",
+					"age": 27
+				}`,
+			},
+			&action.DiscardTransaction{
+				TransactionID: 1,
+			},
+			&action.Request{
+				Request: `
+					query {
+						Users {
+							name
+							age
+						}
+					}
+				`,
+				Results: map[string]any{
+					"Users": []map[string]any{},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+// This test runs AddDoc and UpdateDoc inside the same transaction, illustrating that the
+// update can target a document that does not exist outside the transaction, and that on
+// commit the document is visible at its post-update state. See GH issue #4475.
+func TestTxn_AddDoc_ThenUpdateSameDoc_InSameTxn_Succeeds(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type Users {
+						name: String
+						age: Int
+					}
+				`,
+			},
+			&action.AddDoc{
+				TransactionID: immutable.Some(1),
+				Doc: `{
+					"name": "John",
+					"age": 27
+				}`,
+			},
+			&action.UpdateDoc{
+				TransactionID: immutable.Some(1),
+				DocID:         0,
+				Doc: `{
+					"age": 28
+				}`,
+			},
+			&action.CommitTransaction{
+				TransactionID: 1,
+			},
+			&action.Request{
+				Request: `
+					query {
+						Users {
+							name
+							age
+						}
+					}
+				`,
+				Results: map[string]any{
+					"Users": []map[string]any{
+						{
+							"name": "John",
+							"age":  int64(28),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+// This test runs AddDoc and DeleteDoc inside the same transaction, illustrating that the
+// delete cancels the add and on commit no document is visible. See GH issue #4475.
+func TestTxn_AddDoc_ThenDeleteSameDoc_InSameTxn_Succeeds(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type Users {
+						name: String
+						age: Int
+					}
+				`,
+			},
+			&action.AddDoc{
+				TransactionID: immutable.Some(1),
+				Doc: `{
+					"name": "John",
+					"age": 27
+				}`,
+			},
+			testUtils.DeleteDoc{
+				TransactionID: immutable.Some(1),
+				CollectionID:  0,
+				DocID:         0,
+			},
+			&action.CommitTransaction{
+				TransactionID: 1,
+			},
+			&action.Request{
+				Request: `
+					query {
+						Users {
+							name
+							age
+						}
+					}
+				`,
+				Results: map[string]any{
+					"Users": []map[string]any{},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+// This test runs two concurrent transactions that both try to add a document with the same
+// docID, illustrating the conflict semantics on the second commit. See GH issue #4475.
+//
+// The expected error string was captured from the actual implementation behaviour; if the
+// behaviour ever changes we want this test to flag that explicitly.
+func TestTxn_AddDoc_ConcurrentTxnsSameDocID_SecondCommitConflicts(t *testing.T) {
+	test := testUtils.TestCase{
+		// LevelDB does not support concurrent transactions
+		// todo: https://github.com/sourcenetwork/defradb/issues/4442
+		SupportedDatabaseTypes: immutable.Some([]state.DatabaseType{
+			testUtils.BadgerFileType,
+			testUtils.BadgerIMType,
+			testUtils.DefraIMType,
+		}),
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type Users {
+						name: String
+						age: Int
+					}
+				`,
+			},
+			&action.AddDoc{
+				TransactionID: immutable.Some(1),
+				Doc: `{
+					"name": "John",
+					"age": 27
+				}`,
+			},
+			&action.AddDoc{
+				TransactionID: immutable.Some(2),
+				Doc: `{
+					"name": "John",
+					"age": 27
+				}`,
+			},
+			&action.CommitTransaction{
+				TransactionID: 1,
+			},
+			&action.CommitTransaction{
+				TransactionID: 2,
+				ExpectedError: "transaction conflict. Please retry",
+			},
+			&action.Request{
+				Request: `
+					query {
+						Users {
+							name
+							age
+						}
+					}
+				`,
+				Results: map[string]any{
+					"Users": []map[string]any{
+						{
+							"name": "John",
+							"age":  int64(27),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
 // This test runs AddDoc inside of the same transaction as AddCollection, and illustrates that committing the transaction
 // results in the document being added to the database.
 func TestTxn_AddDoc_InsideTxnWithAddCollection_WithCommit_Succeeds(t *testing.T) {

--- a/tests/integration/txn/add_doc_test.go
+++ b/tests/integration/txn/add_doc_test.go
@@ -326,13 +326,6 @@ func TestTxn_AddManyDocs_WithoutCommit_EmptyResults(t *testing.T) {
 // that the document never becomes visible. See GH issue #4475.
 func TestTxn_AddDoc_WithDiscard_NeverVisible(t *testing.T) {
 	test := testUtils.TestCase{
-		// LevelDB does not support concurrent transactions
-		// todo: https://github.com/sourcenetwork/defradb/issues/4442
-		SupportedDatabaseTypes: immutable.Some([]state.DatabaseType{
-			testUtils.BadgerFileType,
-			testUtils.BadgerIMType,
-			testUtils.DefraIMType,
-		}),
 		Actions: []any{
 			&action.AddCollection{
 				SDL: `


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4475 

## Description
 Adds seven hand-written integration tests in `tests/integration/txn/add_doc_test.go` covering explicit-transaction behaviour on the create-doc call paths, modelled on the existing `..._ExhibitsTransactionalIsolation_Succeeds` patterns for `UpdateDoc` / `DeleteDoc` in the same package.
 
  Each test inherits the mutation-type matrix (CollectionSave / CollectionNamed / GQL) via the dispatch in `tests/action/add_doc.go`. Tests touching concurrent transactions are restricted to Badger / Defra per #4442

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?
 - `go build ./...` and `go vet ./tests/integration/txn/...` clean.
  - `go test -count=1 -run 'TestTxn_AddDoc|TestTxn_AddManyDocs' ./tests/integration/txn/...`
    passes — all 10 tests (3 existing + 7 new) across the inherited mutation-type
    matrix.
  - `go test -count=1 ./tests/integration/txn/... ./tests/integration/mutation/add/...`
    green except for 5 pre-existing failures unrelated to this PR
    (`TestTxn_AddLens_*` / `TestTxn_ListLenses_*` / `TestTxn_SetMigration_WithoutCommit_Succeeds`,
    all blocked by a missing `rust_wasm32_*.wasm` fixture).

## Specify the platform(s) on which this was tested:
- MacOS

