### PR TITLE
docs: Rename leftover operator references

### DIFF
--- a/cli/document_delete.go
+++ b/cli/document_delete.go
@@ -69,7 +69,7 @@ func MakeDocumentDeleteCommand(ctx context.Context) *cobra.Command {
   	-i 028d53f37a19afb9a0dbc5b4be30c65731479ee8cfa0c9bc8f8bf198cc3c075f`)
 
 	EmbedCLIExample(ctx, cmd, "delete by filter",
-		`defradb client document delete --collection-name User --filter '{ "_gte": { "points": 100 } }'`)
+		`defradb client document delete --collection-name User --filter '{ "_geq": { "points": 100 } }'`)
 
 	cmd.Flags().StringVar(&argDocID, "docID", "", "Document ID")
 	cmd.Flags().StringVar(&filter, "filter", "", "Document filter")

--- a/docs/website/references/cli/defradb_client_document_delete.md
+++ b/docs/website/references/cli/defradb_client_document_delete.md
@@ -21,7 +21,7 @@ delete by docID with identity:
   	-i 028d53f37a19afb9a0dbc5b4be30c65731479ee8cfa0c9bc8f8bf198cc3c075f
 
 delete by filter:  
-  defradb client document delete --collection-name User --filter '{ "_gte": { "points": 100 } }'
+  defradb client document delete --collection-name User --filter '{ "_geq": { "points": 100 } }'
 ```
 
 ### Options

--- a/internal/planner/type_join.md
+++ b/internal/planner/type_join.md
@@ -103,24 +103,24 @@ ROOT EMPTY / SUB FULL
 PLAN -> selectTopNode.plan -> limit (optional) -> order (optional) -> selectNode.filter = {friends: {points: {_gt: 10}}} -> ... -> scanNode.filter = NIL
 
 ROOT FULL / SUB EMPTY
-{age: {_gte: 21}}
-PLAN -> selectTopNode.plan -> limit (optional) -> order (optional) -> selectNode.filter = NIL -> ... -> scanNode(user).filter = {age: {_gte: 21}}
+{age: {_geq: 21}}
+PLAN -> selectTopNode.plan -> limit (optional) -> order (optional) -> selectNode.filter = NIL -> ... -> scanNode(user).filter = {age: {_geq: 21}}
 
 ROOT FULL / SUB FULL
-{age: {_gte: 21}, friends: {points: {_gt: 10}}}
-PLAN -> selectTopNode.plan -> limit (optional) -> order (optional) -> selectNode.filter = {friends: {points: {_gt: 10}}} -> ... -> scanNode(user).filter = {age: {_gte: 21}}
+{age: {_geq: 21}, friends: {points: {_gt: 10}}}
+PLAN -> selectTopNode.plan -> limit (optional) -> order (optional) -> selectNode.filter = {friends: {points: {_gt: 10}}} -> ... -> scanNode(user).filter = {age: {_geq: 21}}
 																																-> scanNode(friends).filter = NIL
 
 ROOT FULL / SUB EMPTY / SUB SUB FULL
-{age: {_gte: 21}}
+{age: {_geq: 21}}
 friends: {points: {_gt: 10}}
-PLAN -> selectTopNode.plan -> limit (optional) -> order (optional) -> selectNode.filter = NIL -> ... -> scanNode(user).filter = {age: {_gte: 21}}
+PLAN -> selectTopNode.plan -> limit (optional) -> order (optional) -> selectNode.filter = NIL -> ... -> scanNode(user).filter = {age: {_geq: 21}}
 																									 -> scanNode(friends).filter = {points: {_gt: 10}}
 
 ROOT FULL / SUB FULL / SUB SUB FULL
-{age: {_gte: 21}}
+{age: {_geq: 21}}
 friends: {points: {_gt: 10}}
-PLAN -> selectTopNode.plan -> limit (optional) -> order (optional) -> selectNode.filter = {friends: {points: {_gt: 10}}} -> ... -> scanNode(user).filter = {age: {_gte: 21}}
+PLAN -> selectTopNode.plan -> limit (optional) -> order (optional) -> selectNode.filter = {friends: {points: {_gt: 10}}} -> ... -> scanNode(user).filter = {age: {_geq: 21}}
 																									 							-> scanNode(friends).filter = {points: {_gt: 10}}
 
 

--- a/internal/request/graphql/schema/examples/root.schema.gql
+++ b/internal/request/graphql/schema/examples/root.schema.gql
@@ -12,9 +12,9 @@ enum ValueOperatorInput {
     _eq     # Equal to
     _neq    # Not equal to
     _gt     # Greater than
-    _gte    # Greater than or equal to
+    _geq    # Greater than or equal to
     _lt     # Less than
-    _lte    # Less than or equal to
+    _leq    # Less than or equal to
     _in     # In the list
     _nin    # Non in the list
 }
@@ -63,9 +63,9 @@ input IntOperatorBlock {
     _eq: Int
     _neq: Int
     _gt: Int
-    _gte: Int
+    _geq: Int
     _lt: Int
-    _lte: Int
+    _leq: Int
     _in: [Int!]
     _nin: [Int!]
 }
@@ -75,9 +75,9 @@ input FloatOperatorBlock {
     _eq: Float
     _neq: Float
     _gt: Float
-    _gte: Float
+    _geq: Float
     _lt: Float
-    _lte: Float
+    _leq: Float
     _in: [Float!]
     _nin: [Float!]
 }
@@ -101,9 +101,9 @@ input DateTimeOperatorBlock {
     _eq: DateTime
     _neq: DateTime
     _gt: DateTime
-    _gte: DateTime
+    _geq: DateTime
     _lt: DateTime
-    _lte: DateTime
+    _leq: DateTime
     _in: [DateTime!]
     _nin: [DateTime!]
 }


### PR DESCRIPTION
Some operators were renamed multiple times over the years but some references still existed to old names. Change `_lte` -> `leq`, `_gte` -> `_geq`. Resolve #4828.