### PR TITLE
feat: Enforce relation docID types

### DIFF
--- a/internal/db/backup.go
+++ b/internal/db/backup.go
@@ -94,18 +94,19 @@ func (db *DB) basicImport(ctx context.Context, filepath string) (err error) {
 				return NewErrDocFromMap(err)
 			}
 
-			err = col.AddDocument(ctx, doc)
+			err = col.AddDocument(skipRelationValidationContext(ctx), doc)
 			if err != nil {
 				return NewErrDocAdd(err)
 			}
 
 			// add back the self referencing fields and update doc.
+			skipCtx := skipRelationValidationContext(ctx)
 			for k, v := range resetMap {
 				err := doc.Set(ctx, k, v)
 				if err != nil {
 					return NewErrDocUpdate(err)
 				}
-				err = col.UpdateDocument(ctx, doc)
+				err = col.UpdateDocument(skipCtx, doc)
 				if err != nil {
 					return NewErrDocUpdate(err)
 				}

--- a/internal/db/context.go
+++ b/internal/db/context.go
@@ -21,6 +21,20 @@ import (
 	"github.com/sourcenetwork/defradb/internal/db/id"
 )
 
+type contextSkipRelationValidationKey struct{}
+
+// skipRelationValidationContext returns a context that skips relation DocID
+// validation during document saves. Used by backup import, which restores a
+// known-consistent state whose cross-collection references may not yet exist.
+func skipRelationValidationContext(ctx context.Context) context.Context {
+	return context.WithValue(ctx, contextSkipRelationValidationKey{}, true)
+}
+
+func shouldSkipRelationValidation(ctx context.Context) bool {
+	v, _ := ctx.Value(contextSkipRelationValidationKey{}).(bool)
+	return v
+}
+
 // InitContext returns a new context with all caches initialized and linked to
 // the given transaction.
 //

--- a/internal/db/document.go
+++ b/internal/db/document.go
@@ -17,11 +17,13 @@ import (
 	"strings"
 
 	"github.com/sourcenetwork/corekv"
+	"github.com/sourcenetwork/immutable"
 
 	"github.com/sourcenetwork/defradb/acp/identity"
 	acpTypes "github.com/sourcenetwork/defradb/acp/types"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/options"
+	"github.com/sourcenetwork/defradb/client/request"
 	"github.com/sourcenetwork/defradb/errors"
 	"github.com/sourcenetwork/defradb/event"
 	"github.com/sourcenetwork/defradb/internal/core"
@@ -274,6 +276,10 @@ func (c *collection) add(
 		}
 	}
 
+	if err = c.validateRelationDocIDs(ctx, doc); err != nil {
+		return err
+	}
+
 	ctx = setContextDocEncryption(ctx, opt)
 
 	err = c.save(ctx, doc, true)
@@ -374,6 +380,10 @@ func (c *collection) update(
 		return client.ErrDocumentNotFoundOrNotAuthorized
 	}
 
+	if err = c.validateRelationDocIDs(ctx, doc); err != nil {
+		return err
+	}
+
 	err = c.setEmbedding(ctx, doc, false)
 	if err != nil {
 		return err
@@ -464,6 +474,84 @@ func (c *collection) validateEncryptedFields(ctx context.Context) error {
 		}
 		if strings.HasPrefix(field, "_") {
 			return NewErrCanNotEncryptBuiltinField(field)
+		}
+	}
+	return nil
+}
+
+// validateRelationDocIDs checks that every dirty primary DocID relation field in doc
+// points to an existing, non-deleted document in the correct target collection.
+func (c *collection) validateRelationDocIDs(ctx context.Context, doc *client.Document) error {
+	if shouldSkipRelationValidation(ctx) {
+		return nil
+	}
+
+	for field, value := range doc.Values() {
+		if !value.IsDirty() {
+			continue
+		}
+
+		fieldName := field.Name()
+		fd, ok := c.Version().GetFieldByName(fieldName)
+		if !ok || fd.Kind != client.FieldKind_DocID || !fd.IsPrimary {
+			continue
+		}
+
+		docIDStr, ok := value.Value().(string)
+		if !ok || docIDStr == "" {
+			continue
+		}
+
+		targetDocID, err := client.NewDocIDFromString(docIDStr)
+		if err != nil {
+			// already validated by Set; skip
+			continue
+		}
+
+		objFieldName, ok := request.ToRelatedObjectName(fieldName)
+		if !ok {
+			continue
+		}
+
+		objFd, ok := c.Version().GetFieldByName(objFieldName)
+		if !ok {
+			continue
+		}
+
+		targetColVersion, found, err := description.GetRelatedCollection(
+			ctx, c.db.collectionRepository, c.Version(), objFd.Kind,
+		)
+		if err != nil {
+			return err
+		}
+		if !found {
+			continue
+		}
+
+		var targetCol *collection
+		var targetColName string
+
+		if targetColVersion.VersionID == c.Version().VersionID {
+			targetCol = c
+		} else {
+			targetCol, err = c.db.newCollection(targetColVersion, immutable.None[datastore.Txn]())
+			if err != nil {
+				return err
+			}
+		}
+		targetColName = targetColVersion.Name
+
+		primaryKey, err := targetCol.getPrimaryKeyFromDocID(ctx, targetDocID)
+		if err != nil {
+			return err
+		}
+
+		exists, err := targetCol.docExistsAndNotDeleted(ctx, primaryKey)
+		if err != nil {
+			return err
+		}
+		if !exists {
+			return NewErrRelationTargetNotFound(fieldName, docIDStr, targetColName)
 		}
 	}
 	return nil
@@ -758,6 +846,20 @@ func (c *collection) exists(
 	}
 
 	return true, false, nil
+}
+
+// docExistsAndNotDeleted checks the datastore directly for a document, bypassing ACP.
+// Used for referential integrity validation where the caller may not have read permission
+// on the referenced document.
+func (c *collection) docExistsAndNotDeleted(ctx context.Context, primaryKey keys.PrimaryDataStoreKey) (bool, error) {
+	txn := datastore.CtxMustGetTxn(ctx)
+	val, err := txn.Datastore().Get(ctx, primaryKey)
+	if err != nil && errors.Is(err, corekv.ErrNotFound) {
+		return false, nil
+	} else if err != nil {
+		return false, NewErrGetDocStatus(err, primaryKey.DocID)
+	}
+	return !bytes.Equal(val, []byte{base.DeletedObjectMarker}), nil
 }
 
 func (c *collection) getPrimaryKeyFromDocID(

--- a/internal/db/document.go
+++ b/internal/db/document.go
@@ -553,6 +553,16 @@ func (c *collection) validateRelationDocIDs(ctx context.Context, doc *client.Doc
 		if !exists {
 			return NewErrRelationTargetNotFound(fieldName, docIDStr, targetColName)
 		}
+
+		// ACP: the caller must also be able to read the target document.
+		// We return the same "not found" error to avoid leaking existence of private documents.
+		hasAccess, err := targetCol.checkAccessOfDocWithACP(ctx, acpTypes.DocumentReadPerm, docIDStr)
+		if err != nil {
+			return err
+		}
+		if !hasAccess {
+			return NewErrRelationTargetNotFound(fieldName, docIDStr, targetColName)
+		}
 	}
 	return nil
 }

--- a/internal/db/document.go
+++ b/internal/db/document.go
@@ -557,6 +557,68 @@ func (c *collection) validateRelationDocIDs(ctx context.Context, doc *client.Doc
 	return nil
 }
 
+// validateMergeRelationDocIDs is the P2P-merge variant of validateRelationDocIDs.
+// It performs the same checks but treats a missing target document as a skip rather
+// than an error, because the referenced document may simply not have arrived yet.
+func (c *collection) validateMergeRelationDocIDs(ctx context.Context, doc *client.Document) error {
+	for field, value := range doc.Values() {
+		fieldName := field.Name()
+		fd, ok := c.Version().GetFieldByName(fieldName)
+		if !ok || fd.Kind != client.FieldKind_DocID || !fd.IsPrimary {
+			continue
+		}
+
+		docIDStr, ok := value.Value().(string)
+		if !ok || docIDStr == "" {
+			continue
+		}
+
+		targetDocID, err := client.NewDocIDFromString(docIDStr)
+		if err != nil {
+			continue
+		}
+
+		objFieldName, ok := request.ToRelatedObjectName(fieldName)
+		if !ok {
+			continue
+		}
+
+		objFd, ok := c.Version().GetFieldByName(objFieldName)
+		if !ok {
+			continue
+		}
+
+		targetColVersion, found, err := description.GetRelatedCollection(
+			ctx, c.db.collectionRepository, c.Version(), objFd.Kind,
+		)
+		if err != nil || !found {
+			continue
+		}
+
+		var targetCol *collection
+		if targetColVersion.VersionID == c.Version().VersionID {
+			targetCol = c
+		} else {
+			targetCol, err = c.db.newCollection(targetColVersion, immutable.None[datastore.Txn]())
+			if err != nil {
+				continue
+			}
+		}
+
+		primaryKey, err := targetCol.getPrimaryKeyFromDocID(ctx, targetDocID)
+		if err != nil {
+			continue
+		}
+
+		exists, err := targetCol.docExistsAndNotDeleted(ctx, primaryKey)
+		if err != nil || !exists {
+			// Skip: the referenced doc may not have arrived yet via P2P.
+			continue
+		}
+	}
+	return nil
+}
+
 // save saves the document state. save MUST not be called outside the `c.add`
 // and `c.update` methods as we wrap the acp logic within those methods. Calling
 // save elsewhere could cause the omission of acp checks.

--- a/internal/db/document.go
+++ b/internal/db/document.go
@@ -620,7 +620,7 @@ func (c *collection) validateMergeRelationDocIDs(ctx context.Context, doc *clien
 			continue
 		}
 
-		exists, err := targetCol.docExistsAndNotDeleted(ctx, primaryKey)
+		exists, err := targetCol.docExistsAndNotDeleted(ctx, primaryKey) //nolint:staticcheck
 		if err != nil || !exists {
 			// Skip: the referenced doc may not have arrived yet via P2P.
 			continue

--- a/internal/db/document_test.go
+++ b/internal/db/document_test.go
@@ -32,8 +32,10 @@ const employeeCompanySchema = `
 `
 
 // setupEmployeeCompanyDB creates an in-memory DB with the Employee/Company schema
-// and returns the two collection handles.
-func setupEmployeeCompanyDB(t *testing.T) (*DB, client.Collection, client.Collection) {
+// and returns the two collection handles. The collections are returned as
+// concrete *collection so tests can reach package-private methods without
+// repeating the type assertion at every call site.
+func setupEmployeeCompanyDB(t *testing.T) (*DB, *collection, *collection) {
 	t.Helper()
 	ctx := context.Background()
 
@@ -49,7 +51,12 @@ func setupEmployeeCompanyDB(t *testing.T) (*DB, client.Collection, client.Collec
 	companyCol, err := db.GetCollectionByName(ctx, "Company")
 	require.NoError(t, err)
 
-	return db, empCol, companyCol
+	empColImpl, ok := empCol.(*collection)
+	require.True(t, ok)
+	companyColImpl, ok := companyCol.(*collection)
+	require.True(t, ok)
+
+	return db, empColImpl, companyColImpl
 }
 
 // --- docExistsAndNotDeleted ---
@@ -68,10 +75,10 @@ func TestDocExistsAndNotDeleted_Exists(t *testing.T) {
 	defer txn.Discard()
 	txnCtx := InitContext(ctx, txn)
 
-	primaryKey, err := companyCol.(*collection).getPrimaryKeyFromDocID(txnCtx, doc.ID())
+	primaryKey, err := companyCol.getPrimaryKeyFromDocID(txnCtx, doc.ID())
 	require.NoError(t, err)
 
-	exists, err := companyCol.(*collection).docExistsAndNotDeleted(txnCtx, primaryKey)
+	exists, err := companyCol.docExistsAndNotDeleted(txnCtx, primaryKey)
 	require.NoError(t, err)
 	require.True(t, exists)
 }
@@ -90,10 +97,10 @@ func TestDocExistsAndNotDeleted_NotFound(t *testing.T) {
 	defer txn.Discard()
 	txnCtx := InitContext(ctx, txn)
 
-	primaryKey, err := companyCol.(*collection).getPrimaryKeyFromDocID(txnCtx, phantom.ID())
+	primaryKey, err := companyCol.getPrimaryKeyFromDocID(txnCtx, phantom.ID())
 	require.NoError(t, err)
 
-	exists, err := companyCol.(*collection).docExistsAndNotDeleted(txnCtx, primaryKey)
+	exists, err := companyCol.docExistsAndNotDeleted(txnCtx, primaryKey)
 	require.NoError(t, err)
 	require.False(t, exists)
 }
@@ -115,10 +122,10 @@ func TestDocExistsAndNotDeleted_SoftDeleted(t *testing.T) {
 	defer txn.Discard()
 	txnCtx := InitContext(ctx, txn)
 
-	primaryKey, err := companyCol.(*collection).getPrimaryKeyFromDocID(txnCtx, doc.ID())
+	primaryKey, err := companyCol.getPrimaryKeyFromDocID(txnCtx, doc.ID())
 	require.NoError(t, err)
 
-	exists, err := companyCol.(*collection).docExistsAndNotDeleted(txnCtx, primaryKey)
+	exists, err := companyCol.docExistsAndNotDeleted(txnCtx, primaryKey)
 	require.NoError(t, err)
 	require.False(t, exists)
 }
@@ -143,7 +150,7 @@ func TestValidateRelationDocIDs_ValidTarget_NoError(t *testing.T) {
 	defer txn.Discard()
 	txnCtx := InitContext(ctx, txn)
 
-	err = empCol.(*collection).validateRelationDocIDs(txnCtx, empDoc)
+	err = empCol.validateRelationDocIDs(txnCtx, empDoc)
 	require.NoError(t, err)
 }
 
@@ -165,7 +172,7 @@ func TestValidateRelationDocIDs_NonExistentTarget_Error(t *testing.T) {
 	defer txn.Discard()
 	txnCtx := InitContext(ctx, txn)
 
-	err = empCol.(*collection).validateRelationDocIDs(txnCtx, empDoc)
+	err = empCol.validateRelationDocIDs(txnCtx, empDoc)
 	require.ErrorContains(t, err, "relation target document not found")
 }
 
@@ -183,7 +190,7 @@ func TestValidateRelationDocIDs_EmptyID_NoError(t *testing.T) {
 	defer txn.Discard()
 	txnCtx := InitContext(ctx, txn)
 
-	err = empCol.(*collection).validateRelationDocIDs(txnCtx, empDoc)
+	err = empCol.validateRelationDocIDs(txnCtx, empDoc)
 	require.NoError(t, err)
 }
 
@@ -207,7 +214,7 @@ func TestValidateRelationDocIDs_DeletedTarget_Error(t *testing.T) {
 	defer txn.Discard()
 	txnCtx := InitContext(ctx, txn)
 
-	err = empCol.(*collection).validateRelationDocIDs(txnCtx, empDoc)
+	err = empCol.validateRelationDocIDs(txnCtx, empDoc)
 	require.ErrorContains(t, err, "relation target document not found")
 }
 
@@ -230,7 +237,7 @@ func TestValidateRelationDocIDs_SkipContext_NoError(t *testing.T) {
 	// skipRelationValidationContext suppresses all validation — used by backup import.
 	txnCtx := InitContext(skipRelationValidationContext(ctx), txn)
 
-	err = empCol.(*collection).validateRelationDocIDs(txnCtx, empDoc)
+	err = empCol.validateRelationDocIDs(txnCtx, empDoc)
 	require.NoError(t, err)
 }
 
@@ -266,7 +273,7 @@ func TestValidateRelationDocIDs_NonDirtyField_NoError(t *testing.T) {
 	require.NoError(t, err)
 
 	// validateRelationDocIDs skips non-dirty fields, so the dangling link is not an error.
-	err = empCol.(*collection).validateRelationDocIDs(txnCtx, retrieved)
+	err = empCol.validateRelationDocIDs(txnCtx, retrieved)
 	require.NoError(t, err)
 }
 
@@ -296,7 +303,7 @@ func TestValidateMergeRelationDocIDs_ValidTarget_NoError(t *testing.T) {
 	retrieved, err := empCol.GetDocument(txnCtx, empDoc.ID())
 	require.NoError(t, err)
 
-	err = empCol.(*collection).validateMergeRelationDocIDs(txnCtx, retrieved)
+	err = empCol.validateMergeRelationDocIDs(txnCtx, retrieved)
 	require.NoError(t, err)
 }
 
@@ -326,7 +333,7 @@ func TestValidateMergeRelationDocIDs_MissingTarget_NoError(t *testing.T) {
 	require.NoError(t, err)
 
 	// Merge-path validation treats a missing target as a skip, not an error.
-	err = empCol.(*collection).validateMergeRelationDocIDs(txnCtx, retrieved)
+	err = empCol.validateMergeRelationDocIDs(txnCtx, retrieved)
 	require.NoError(t, err)
 }
 
@@ -359,6 +366,6 @@ func TestValidateMergeRelationDocIDs_DeletedTarget_NoError(t *testing.T) {
 	require.NoError(t, err)
 
 	// A soft-deleted target is treated as "not found" on the merge path — skipped, not an error.
-	err = empCol.(*collection).validateMergeRelationDocIDs(txnCtx, retrieved)
+	err = empCol.validateMergeRelationDocIDs(txnCtx, retrieved)
 	require.NoError(t, err)
 }

--- a/internal/db/document_test.go
+++ b/internal/db/document_test.go
@@ -1,0 +1,364 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcenetwork/defradb/client"
+)
+
+// employeeCompanySchema defines a two-collection schema used across all
+// document validation unit tests.
+const employeeCompanySchema = `
+	type Company {
+		name: String
+	}
+	type Employee {
+		name: String
+		company: Company
+	}
+`
+
+// setupEmployeeCompanyDB creates an in-memory DB with the Employee/Company schema
+// and returns the two collection handles.
+func setupEmployeeCompanyDB(t *testing.T) (*DB, client.Collection, client.Collection) {
+	t.Helper()
+	ctx := context.Background()
+
+	db, err := newBadgerDB(ctx)
+	require.NoError(t, err)
+
+	_, err = db.AddCollection(ctx, employeeCompanySchema)
+	require.NoError(t, err)
+
+	empCol, err := db.GetCollectionByName(ctx, "Employee")
+	require.NoError(t, err)
+
+	companyCol, err := db.GetCollectionByName(ctx, "Company")
+	require.NoError(t, err)
+
+	return db, empCol, companyCol
+}
+
+// --- docExistsAndNotDeleted ---
+
+func TestDocExistsAndNotDeleted_Exists(t *testing.T) {
+	ctx := context.Background()
+	db, _, companyCol := setupEmployeeCompanyDB(t)
+	defer db.Close()
+
+	doc, err := client.NewDocFromJSON(ctx, []byte(`{"name": "Acme"}`), companyCol.Version())
+	require.NoError(t, err)
+	require.NoError(t, companyCol.AddDocument(ctx, doc))
+
+	txn, err := db.NewTxn(true)
+	require.NoError(t, err)
+	defer txn.Discard()
+	txnCtx := InitContext(ctx, txn)
+
+	primaryKey, err := companyCol.(*collection).getPrimaryKeyFromDocID(txnCtx, doc.ID())
+	require.NoError(t, err)
+
+	exists, err := companyCol.(*collection).docExistsAndNotDeleted(txnCtx, primaryKey)
+	require.NoError(t, err)
+	require.True(t, exists)
+}
+
+func TestDocExistsAndNotDeleted_NotFound(t *testing.T) {
+	ctx := context.Background()
+	db, _, companyCol := setupEmployeeCompanyDB(t)
+	defer db.Close()
+
+	// Create a doc object but do NOT save it — its primary key will not exist in the store.
+	phantom, err := client.NewDocFromJSON(ctx, []byte(`{"name": "Ghost"}`), companyCol.Version())
+	require.NoError(t, err)
+
+	txn, err := db.NewTxn(true)
+	require.NoError(t, err)
+	defer txn.Discard()
+	txnCtx := InitContext(ctx, txn)
+
+	primaryKey, err := companyCol.(*collection).getPrimaryKeyFromDocID(txnCtx, phantom.ID())
+	require.NoError(t, err)
+
+	exists, err := companyCol.(*collection).docExistsAndNotDeleted(txnCtx, primaryKey)
+	require.NoError(t, err)
+	require.False(t, exists)
+}
+
+func TestDocExistsAndNotDeleted_SoftDeleted(t *testing.T) {
+	ctx := context.Background()
+	db, _, companyCol := setupEmployeeCompanyDB(t)
+	defer db.Close()
+
+	doc, err := client.NewDocFromJSON(ctx, []byte(`{"name": "Acme"}`), companyCol.Version())
+	require.NoError(t, err)
+	require.NoError(t, companyCol.AddDocument(ctx, doc))
+
+	_, err = companyCol.DeleteDocument(ctx, doc.ID())
+	require.NoError(t, err)
+
+	txn, err := db.NewTxn(true)
+	require.NoError(t, err)
+	defer txn.Discard()
+	txnCtx := InitContext(ctx, txn)
+
+	primaryKey, err := companyCol.(*collection).getPrimaryKeyFromDocID(txnCtx, doc.ID())
+	require.NoError(t, err)
+
+	exists, err := companyCol.(*collection).docExistsAndNotDeleted(txnCtx, primaryKey)
+	require.NoError(t, err)
+	require.False(t, exists)
+}
+
+// --- validateRelationDocIDs ---
+
+func TestValidateRelationDocIDs_ValidTarget_NoError(t *testing.T) {
+	ctx := context.Background()
+	db, empCol, companyCol := setupEmployeeCompanyDB(t)
+	defer db.Close()
+
+	companyDoc, err := client.NewDocFromJSON(ctx, []byte(`{"name": "Acme"}`), companyCol.Version())
+	require.NoError(t, err)
+	require.NoError(t, companyCol.AddDocument(ctx, companyDoc))
+
+	empDoc, err := client.NewDocFromJSON(ctx, []byte(`{"name": "Alice"}`), empCol.Version())
+	require.NoError(t, err)
+	require.NoError(t, empDoc.Set(ctx, "_companyID", companyDoc.ID().String()))
+
+	txn, err := db.NewTxn(false)
+	require.NoError(t, err)
+	defer txn.Discard()
+	txnCtx := InitContext(ctx, txn)
+
+	err = empCol.(*collection).validateRelationDocIDs(txnCtx, empDoc)
+	require.NoError(t, err)
+}
+
+func TestValidateRelationDocIDs_NonExistentTarget_Error(t *testing.T) {
+	ctx := context.Background()
+	db, empCol, companyCol := setupEmployeeCompanyDB(t)
+	defer db.Close()
+
+	// Create a company doc object that is never saved — its DocID will not exist in the store.
+	phantomCompany, err := client.NewDocFromJSON(ctx, []byte(`{"name": "Ghost Inc"}`), companyCol.Version())
+	require.NoError(t, err)
+
+	empDoc, err := client.NewDocFromJSON(ctx, []byte(`{"name": "Alice"}`), empCol.Version())
+	require.NoError(t, err)
+	require.NoError(t, empDoc.Set(ctx, "_companyID", phantomCompany.ID().String()))
+
+	txn, err := db.NewTxn(false)
+	require.NoError(t, err)
+	defer txn.Discard()
+	txnCtx := InitContext(ctx, txn)
+
+	err = empCol.(*collection).validateRelationDocIDs(txnCtx, empDoc)
+	require.ErrorContains(t, err, "relation target document not found")
+}
+
+func TestValidateRelationDocIDs_EmptyID_NoError(t *testing.T) {
+	ctx := context.Background()
+	db, empCol, _ := setupEmployeeCompanyDB(t)
+	defer db.Close()
+
+	// A doc whose _companyID is not set at all (zero value) — clearing a link is always valid.
+	empDoc, err := client.NewDocFromJSON(ctx, []byte(`{"name": "Alice"}`), empCol.Version())
+	require.NoError(t, err)
+
+	txn, err := db.NewTxn(false)
+	require.NoError(t, err)
+	defer txn.Discard()
+	txnCtx := InitContext(ctx, txn)
+
+	err = empCol.(*collection).validateRelationDocIDs(txnCtx, empDoc)
+	require.NoError(t, err)
+}
+
+func TestValidateRelationDocIDs_DeletedTarget_Error(t *testing.T) {
+	ctx := context.Background()
+	db, empCol, companyCol := setupEmployeeCompanyDB(t)
+	defer db.Close()
+
+	companyDoc, err := client.NewDocFromJSON(ctx, []byte(`{"name": "Acme"}`), companyCol.Version())
+	require.NoError(t, err)
+	require.NoError(t, companyCol.AddDocument(ctx, companyDoc))
+	_, err = companyCol.DeleteDocument(ctx, companyDoc.ID())
+	require.NoError(t, err)
+
+	empDoc, err := client.NewDocFromJSON(ctx, []byte(`{"name": "Alice"}`), empCol.Version())
+	require.NoError(t, err)
+	require.NoError(t, empDoc.Set(ctx, "_companyID", companyDoc.ID().String()))
+
+	txn, err := db.NewTxn(false)
+	require.NoError(t, err)
+	defer txn.Discard()
+	txnCtx := InitContext(ctx, txn)
+
+	err = empCol.(*collection).validateRelationDocIDs(txnCtx, empDoc)
+	require.ErrorContains(t, err, "relation target document not found")
+}
+
+func TestValidateRelationDocIDs_SkipContext_NoError(t *testing.T) {
+	ctx := context.Background()
+	db, empCol, companyCol := setupEmployeeCompanyDB(t)
+	defer db.Close()
+
+	// Phantom company — never saved.
+	phantomCompany, err := client.NewDocFromJSON(ctx, []byte(`{"name": "Ghost Inc"}`), companyCol.Version())
+	require.NoError(t, err)
+
+	empDoc, err := client.NewDocFromJSON(ctx, []byte(`{"name": "Alice"}`), empCol.Version())
+	require.NoError(t, err)
+	require.NoError(t, empDoc.Set(ctx, "_companyID", phantomCompany.ID().String()))
+
+	txn, err := db.NewTxn(false)
+	require.NoError(t, err)
+	defer txn.Discard()
+	// skipRelationValidationContext suppresses all validation — used by backup import.
+	txnCtx := InitContext(skipRelationValidationContext(ctx), txn)
+
+	err = empCol.(*collection).validateRelationDocIDs(txnCtx, empDoc)
+	require.NoError(t, err)
+}
+
+func TestValidateRelationDocIDs_NonDirtyField_NoError(t *testing.T) {
+	ctx := context.Background()
+	db, empCol, companyCol := setupEmployeeCompanyDB(t)
+	defer db.Close()
+
+	// Create company, create employee linking to it.
+	companyDoc, err := client.NewDocFromJSON(ctx, []byte(`{"name": "Acme"}`), companyCol.Version())
+	require.NoError(t, err)
+	require.NoError(t, companyCol.AddDocument(ctx, companyDoc))
+
+	// Include _companyID in the initial map so the DocID is computed from all fields.
+	empDoc, err := client.NewDocFromMap(ctx, map[string]any{
+		"name":       "Alice",
+		"_companyID": companyDoc.ID().String(),
+	}, empCol.Version())
+	require.NoError(t, err)
+	require.NoError(t, empCol.AddDocument(ctx, empDoc))
+
+	// Delete the company. The employee now has a dangling _companyID in the store.
+	_, err = companyCol.DeleteDocument(ctx, companyDoc.ID())
+	require.NoError(t, err)
+
+	// Retrieve the employee. Fields from GetDocument are NOT dirty.
+	txn, err := db.NewTxn(false)
+	require.NoError(t, err)
+	defer txn.Discard()
+	txnCtx := InitContext(ctx, txn)
+
+	retrieved, err := empCol.GetDocument(txnCtx, empDoc.ID())
+	require.NoError(t, err)
+
+	// validateRelationDocIDs skips non-dirty fields, so the dangling link is not an error.
+	err = empCol.(*collection).validateRelationDocIDs(txnCtx, retrieved)
+	require.NoError(t, err)
+}
+
+// --- validateMergeRelationDocIDs ---
+
+func TestValidateMergeRelationDocIDs_ValidTarget_NoError(t *testing.T) {
+	ctx := context.Background()
+	db, empCol, companyCol := setupEmployeeCompanyDB(t)
+	defer db.Close()
+
+	companyDoc, err := client.NewDocFromJSON(ctx, []byte(`{"name": "Acme"}`), companyCol.Version())
+	require.NoError(t, err)
+	require.NoError(t, companyCol.AddDocument(ctx, companyDoc))
+
+	empDoc, err := client.NewDocFromMap(ctx, map[string]any{
+		"name":       "Alice",
+		"_companyID": companyDoc.ID().String(),
+	}, empCol.Version())
+	require.NoError(t, err)
+	require.NoError(t, empCol.AddDocument(ctx, empDoc))
+
+	txn, err := db.NewTxn(false)
+	require.NoError(t, err)
+	defer txn.Discard()
+	txnCtx := InitContext(ctx, txn)
+
+	retrieved, err := empCol.GetDocument(txnCtx, empDoc.ID())
+	require.NoError(t, err)
+
+	err = empCol.(*collection).validateMergeRelationDocIDs(txnCtx, retrieved)
+	require.NoError(t, err)
+}
+
+func TestValidateMergeRelationDocIDs_MissingTarget_NoError(t *testing.T) {
+	ctx := context.Background()
+	db, empCol, companyCol := setupEmployeeCompanyDB(t)
+	defer db.Close()
+
+	// Phantom company: valid DocID format but never saved.
+	phantomCompany, err := client.NewDocFromJSON(ctx, []byte(`{"name": "Ghost Inc"}`), companyCol.Version())
+	require.NoError(t, err)
+
+	// Include _companyID in the initial map; skip write-path validation so we can store a dangling link.
+	empDoc, err := client.NewDocFromMap(ctx, map[string]any{
+		"name":       "Alice",
+		"_companyID": phantomCompany.ID().String(),
+	}, empCol.Version())
+	require.NoError(t, err)
+	require.NoError(t, empCol.AddDocument(skipRelationValidationContext(ctx), empDoc))
+
+	txn, err := db.NewTxn(false)
+	require.NoError(t, err)
+	defer txn.Discard()
+	txnCtx := InitContext(ctx, txn)
+
+	retrieved, err := empCol.GetDocument(txnCtx, empDoc.ID())
+	require.NoError(t, err)
+
+	// Merge-path validation treats a missing target as a skip, not an error.
+	err = empCol.(*collection).validateMergeRelationDocIDs(txnCtx, retrieved)
+	require.NoError(t, err)
+}
+
+func TestValidateMergeRelationDocIDs_DeletedTarget_NoError(t *testing.T) {
+	ctx := context.Background()
+	db, empCol, companyCol := setupEmployeeCompanyDB(t)
+	defer db.Close()
+
+	companyDoc, err := client.NewDocFromJSON(ctx, []byte(`{"name": "Acme"}`), companyCol.Version())
+	require.NoError(t, err)
+	require.NoError(t, companyCol.AddDocument(ctx, companyDoc))
+
+	empDoc, err := client.NewDocFromMap(ctx, map[string]any{
+		"name":       "Alice",
+		"_companyID": companyDoc.ID().String(),
+	}, empCol.Version())
+	require.NoError(t, err)
+	require.NoError(t, empCol.AddDocument(ctx, empDoc))
+
+	// Soft-delete the company after the employee was linked.
+	_, err = companyCol.DeleteDocument(ctx, companyDoc.ID())
+	require.NoError(t, err)
+
+	txn, err := db.NewTxn(false)
+	require.NoError(t, err)
+	defer txn.Discard()
+	txnCtx := InitContext(ctx, txn)
+
+	retrieved, err := empCol.GetDocument(txnCtx, empDoc.ID())
+	require.NoError(t, err)
+
+	// A soft-deleted target is treated as "not found" on the merge path — skipped, not an error.
+	err = empCol.(*collection).validateMergeRelationDocIDs(txnCtx, retrieved)
+	require.NoError(t, err)
+}

--- a/internal/db/errors.go
+++ b/internal/db/errors.go
@@ -132,6 +132,7 @@ const (
 	errLensRuntimeNotSupported             string = "the selected lens runtime is not supported by this build"
 	errLensCIDNotFound                     string = "lens CID not found"
 	errOneToOneMustBeUnique                string = "one-to-one relation must have a unique index"
+	errRelationTargetNotFound              string = "relation target document not found"
 
 	errCreateMergeTxn         string = "failed to create merge transaction"
 	errGetShortIDForMerge     string = "failed to get short collection ID for merge"
@@ -440,6 +441,15 @@ func NewErrRelationNameNotUnique(name string, relationName string) error {
 		errRelationNameNotUnique,
 		errors.NewKV("Field", name),
 		errors.NewKV("RelationName", relationName),
+	)
+}
+
+func NewErrRelationTargetNotFound(fieldName, docID, targetCollection string) error {
+	return errors.New(
+		errRelationTargetNotFound,
+		errors.NewKV("Field", fieldName),
+		errors.NewKV("DocID", docID),
+		errors.NewKV("TargetCollection", targetCollection),
 	)
 }
 

--- a/internal/db/merge.go
+++ b/internal/db/merge.go
@@ -116,6 +116,10 @@ func (db *DB) executeMerge(ctx context.Context, col *collection, dagMerge event.
 		return NewErrMergeComposites(err, dagMerge.DocID)
 	}
 
+	if err = mp.validateMergedRelationDocIDs(ctx); err != nil {
+		return err
+	}
+
 	for docID, oldDoc := range mp.docIDs {
 		err = syncIndexedDoc(ctx, docID, mp.col, oldDoc)
 		if err != nil {
@@ -273,6 +277,28 @@ func (mp *mergeProcessor) loadComposites(
 			}
 		}
 		return mp.loadComposites(ctx, blockCid, newMT)
+	}
+	return nil
+}
+
+// validateMergedRelationDocIDs checks relation DocID fields on all documents that were
+// merged in this transaction. Unlike the mutation-path validation, this is lenient:
+// if the target document is not yet present locally (it may arrive via a later P2P merge),
+// validation is skipped rather than rejected. A hard error is only returned when the
+// collection metadata lookup itself fails.
+func (mp *mergeProcessor) validateMergedRelationDocIDs(ctx context.Context) error {
+	for docID := range mp.docIDs {
+		doc, err := mp.col.GetDocument(ctx, docID)
+		if err != nil {
+			if errors.Is(err, client.ErrDocumentNotFoundOrNotAuthorized) {
+				continue
+			}
+			return err
+		}
+
+		if err = mp.col.validateMergeRelationDocIDs(ctx, doc); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/internal/db/merge_test.go
+++ b/internal/db/merge_test.go
@@ -937,3 +937,98 @@ func TestMerge_CounterThreeWayFork_Accumulates(t *testing.T) {
 
 	require.Equal(t, expectedDocMap, docMap)
 }
+
+// --- validateMergedRelationDocIDs ---
+
+// newMergeProcessorForTest creates a mergeProcessor for the given collection using a
+// fresh transaction. The caller is responsible for discarding the returned txn.
+func newMergeProcessorForTest(
+	t *testing.T,
+	ctx context.Context,
+	db *DB,
+	col client.Collection,
+) (*mergeProcessor, *Txn, context.Context) {
+	t.Helper()
+	txn, err := db.NewTxn(false)
+	require.NoError(t, err)
+	txnCtx := InitContext(ctx, txn)
+	mp, err := db.newMergeProcessor(txnCtx, col.(*collection))
+	require.NoError(t, err)
+	return mp, txn.(*Txn), txnCtx
+}
+
+func TestValidateMergedRelationDocIDs_AllValid_NoError(t *testing.T) {
+	ctx := context.Background()
+	db, empCol, companyCol := setupEmployeeCompanyDB(t)
+	defer db.Close()
+
+	companyDoc, err := client.NewDocFromJSON(ctx, []byte(`{"name": "Acme"}`), companyCol.Version())
+	require.NoError(t, err)
+	require.NoError(t, companyCol.AddDocument(ctx, companyDoc))
+
+	empDoc, err := client.NewDocFromMap(ctx, map[string]any{
+		"name":       "Alice",
+		"_companyID": companyDoc.ID().String(),
+	}, empCol.Version())
+	require.NoError(t, err)
+	require.NoError(t, empCol.AddDocument(ctx, empDoc))
+
+	mp, txn, txnCtx := newMergeProcessorForTest(t, ctx, db, empCol)
+	defer txn.Discard()
+
+	mp.docIDs[empDoc.ID()] = nil
+	require.NoError(t, mp.validateMergedRelationDocIDs(txnCtx))
+}
+
+func TestValidateMergedRelationDocIDs_DeletedDoc_Skipped(t *testing.T) {
+	ctx := context.Background()
+	db, empCol, companyCol := setupEmployeeCompanyDB(t)
+	defer db.Close()
+
+	companyDoc, err := client.NewDocFromJSON(ctx, []byte(`{"name": "Acme"}`), companyCol.Version())
+	require.NoError(t, err)
+	require.NoError(t, companyCol.AddDocument(ctx, companyDoc))
+
+	empDoc, err := client.NewDocFromMap(ctx, map[string]any{
+		"name":       "Alice",
+		"_companyID": companyDoc.ID().String(),
+	}, empCol.Version())
+	require.NoError(t, err)
+	require.NoError(t, empCol.AddDocument(ctx, empDoc))
+
+	// Delete the employee so GetDocument returns ErrDocumentNotFoundOrNotAuthorized.
+	_, err = empCol.DeleteDocument(ctx, empDoc.ID())
+	require.NoError(t, err)
+
+	mp, txn, txnCtx := newMergeProcessorForTest(t, ctx, db, empCol)
+	defer txn.Discard()
+
+	mp.docIDs[empDoc.ID()] = nil
+	// Outer loop skips deleted (not found) documents silently — no error expected.
+	require.NoError(t, mp.validateMergedRelationDocIDs(txnCtx))
+}
+
+func TestValidateMergedRelationDocIDs_MissingRelationTarget_Skipped(t *testing.T) {
+	ctx := context.Background()
+	db, empCol, companyCol := setupEmployeeCompanyDB(t)
+	defer db.Close()
+
+	// Phantom company: never saved, so _companyID will be dangling.
+	phantomCompany, err := client.NewDocFromJSON(ctx, []byte(`{"name": "Ghost Inc"}`), companyCol.Version())
+	require.NoError(t, err)
+
+	empDoc, err := client.NewDocFromMap(ctx, map[string]any{
+		"name":       "Alice",
+		"_companyID": phantomCompany.ID().String(),
+	}, empCol.Version())
+	require.NoError(t, err)
+	// skipRelationValidationContext lets us save a dangling relation for this test.
+	require.NoError(t, empCol.AddDocument(skipRelationValidationContext(ctx), empDoc))
+
+	mp, txn, txnCtx := newMergeProcessorForTest(t, ctx, db, empCol)
+	defer txn.Discard()
+
+	mp.docIDs[empDoc.ID()] = nil
+	// Inner validateMergeRelationDocIDs treats a missing target as a skip — no error.
+	require.NoError(t, mp.validateMergedRelationDocIDs(txnCtx))
+}

--- a/tests/action/update_doc.go
+++ b/tests/action/update_doc.go
@@ -57,7 +57,15 @@ type UpdateDoc struct {
 
 	// The document update, in JSON string format. Will only update the properties
 	// provided.
+	//
+	// If [DocMap] is provided this value will be ignored.
 	Doc string
+
+	// DocMap is an alternative to Doc that allows relation fields to be referenced by
+	// [DocIndex] without hardcoding DocID strings.  Any value of type [DocIndex] will be
+	// substituted with the corresponding document's actual DocID at test-execution time.
+	// Only simple (non-array) top-level fields are supported.
+	DocMap map[string]any
 
 	// Any error expected from the action. Optional.
 	//
@@ -82,6 +90,19 @@ var _ Action = (*UpdateDoc)(nil)
 var _ Stateful = (*UpdateDoc)(nil)
 
 func (a *UpdateDoc) Execute() {
+	if a.DocMap != nil {
+		for k, v := range a.DocMap {
+			if index, ok := v.(DocIndex); ok {
+				a.s.DocIDsLock.RLock()
+				a.DocMap[k] = a.s.DocIDs[index.CollectionIndex][index.Index].String()
+				a.s.DocIDsLock.RUnlock()
+			}
+		}
+		data, err := json.Marshal(a.DocMap)
+		require.NoError(a.s.T, err)
+		a.Doc = string(data)
+	}
+
 	var mutation func(
 		*state.State,
 		*UpdateDoc,

--- a/tests/integration/acp/dac/avg_test.go
+++ b/tests/integration/acp/dac/avg_test.go
@@ -31,8 +31,8 @@ func TestACP_QueryAverageWithoutIdentity(t *testing.T) {
 					}
 				`,
 				Results: map[string]any{
-					// 2 public employees, 1 with salary 10k, 1 with salary 20k
-					"AVG": int(15000),
+					// 1 public employee with salary 10k
+					"AVG": float64(10000),
 				},
 			},
 		},
@@ -55,8 +55,8 @@ func TestACP_QueryAverageWithIdentity(t *testing.T) {
 					}
 				`,
 				Results: map[string]any{
-					// 4 employees with salaries 10k, 20k, 30k, 40k
-					"AVG": int(25000),
+					// 3 employees with salaries 10k, 20k, 30k
+					"AVG": float64(20000),
 				},
 			},
 		},
@@ -79,8 +79,8 @@ func TestACP_QueryAverageWithWrongIdentity(t *testing.T) {
 					}
 				`,
 				Results: map[string]any{
-					// 2 public employees, 1 with salary 10k, 1 with salary 20k
-					"AVG": int(15000),
+					// 1 public employee with salary 10k
+					"AVG": float64(10000),
 				},
 			},
 		},

--- a/tests/integration/acp/dac/count_test.go
+++ b/tests/integration/acp/dac/count_test.go
@@ -31,7 +31,7 @@ func TestACP_QueryCountDocumentsWithoutIdentity(t *testing.T) {
 					}
 				`,
 				Results: map[string]any{
-					"COUNT": int(2),
+					"COUNT": int(1),
 				},
 			},
 		},
@@ -83,7 +83,7 @@ func TestACP_QueryCountDocumentsWithIdentity(t *testing.T) {
 					}
 				`,
 				Results: map[string]any{
-					"COUNT": int(4),
+					"COUNT": int(3),
 				},
 			},
 		},
@@ -113,10 +113,11 @@ func TestACP_QueryCountRelatedObjectsWithIdentity(t *testing.T) {
 							"COUNT": int(2),
 						},
 						{
-							"COUNT": int(2),
+							"COUNT": int(1),
 						},
 					},
 				},
+				NonOrderedResults: true,
 			},
 		},
 	}
@@ -138,7 +139,7 @@ func TestACP_QueryCountDocumentsWithWrongIdentity(t *testing.T) {
 					}
 				`,
 				Results: map[string]any{
-					"COUNT": int(2),
+					"COUNT": int(1),
 				},
 			},
 		},

--- a/tests/integration/acp/dac/fixture.go
+++ b/tests/integration/acp/dac/fixture.go
@@ -100,18 +100,10 @@ func getSetupEmployeeCompanyActions() []any {
 		},
 		&action.AddDoc{
 			CollectionID: 0,
-			DocMap: map[string]any{
-				"name":    "PubEmp in PrivateCompany",
-				"salary":  20000,
-				"company": testUtils.NewDocIndex(1, 1),
-			},
-		},
-		&action.AddDoc{
-			CollectionID: 0,
 			Identity:     testUtils.ClientIdentity(1),
 			DocMap: map[string]any{
 				"name":    "PrivateEmp in PubCompany",
-				"salary":  30000,
+				"salary":  20000,
 				"company": testUtils.NewDocIndex(1, 0),
 			},
 		},
@@ -120,7 +112,7 @@ func getSetupEmployeeCompanyActions() []any {
 			Identity:     testUtils.ClientIdentity(1),
 			DocMap: map[string]any{
 				"name":    "PrivateEmp in PrivateCompany",
-				"salary":  40000,
+				"salary":  30000,
 				"company": testUtils.NewDocIndex(1, 1),
 			},
 		},

--- a/tests/integration/acp/dac/relation_mutation_test.go
+++ b/tests/integration/acp/dac/relation_mutation_test.go
@@ -1,0 +1,285 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// This file is part of the DefraDB test suite.
+//
+// The DefraDB test suite is licensed under either:
+//
+//   (1) GNU Affero General Public License v3
+//   (2) Business Source License 1.1
+//
+// See tests/LICENSE for details.
+
+package test_acp_dac
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/defradb/tests/action"
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+// SDL definition order determines CollectionID:
+//   CollectionID 0 = Employee (first type in SDL)
+//   CollectionID 1 = Company  (second type in SDL)
+const employeeCompanyRelationSDL = `
+	type Employee @policy(
+		id: "{{.Policy0}}",
+		resource: "employees"
+	) {
+		name: String
+		salary: Int
+		company: Company
+	}
+
+	type Company @policy(
+		id: "{{.Policy0}}",
+		resource: "companies"
+	) {
+		name: String
+		capital: Int
+		employees: [Employee]
+	}
+`
+
+// policyAndSchemaSetup returns the DAC policy + AddCollection actions shared by all tests
+// in this file.
+func policyAndSchemaSetup() []any {
+	return []any{
+		testUtils.AddDACPolicy{
+			Identity: testUtils.ClientIdentity(1),
+			Policy:   employeeCompanyPolicy,
+		},
+		&action.AddCollection{
+			SDL: employeeCompanyRelationSDL,
+		},
+	}
+}
+
+// TestACP_MutationAdd_RelationTarget_PrivateDoc_NoIdentity_Error asserts that a caller with
+// no identity cannot create a document whose relation field points to a private document.
+func TestACP_MutationAdd_RelationTarget_PrivateDoc_NoIdentity_Error(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: append(
+			policyAndSchemaSetup(),
+			// Identity 1 creates a private Company (CollectionID 1, index 0).
+			&action.AddDoc{
+				CollectionID: 1,
+				Identity:     testUtils.ClientIdentity(1),
+				Doc: `{
+					"name": "Private Company",
+					"capital": 200000
+				}`,
+			},
+			// No-identity caller tries to create an Employee linked to the private Company.
+			&action.AddDoc{
+				CollectionID: 0,
+				DocMap: map[string]any{
+					"name":    "Employee",
+					"salary":  50000,
+					"company": testUtils.NewDocIndex(1, 0),
+				},
+				ExpectedError: "relation target document not found",
+			},
+		),
+	}
+	testUtils.ExecuteTestCase(t, test)
+}
+
+// TestACP_MutationAdd_RelationTarget_PrivateDoc_WrongIdentity_Error asserts that a caller
+// whose identity has no read permission on the target document cannot link to it.
+func TestACP_MutationAdd_RelationTarget_PrivateDoc_WrongIdentity_Error(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: append(
+			policyAndSchemaSetup(),
+			&action.AddDoc{
+				CollectionID: 1,
+				Identity:     testUtils.ClientIdentity(1),
+				Doc: `{
+					"name": "Private Company",
+					"capital": 200000
+				}`,
+			},
+			// Identity 2 has no read access to the private Company.
+			&action.AddDoc{
+				CollectionID: 0,
+				Identity:     testUtils.ClientIdentity(2),
+				DocMap: map[string]any{
+					"name":    "Employee",
+					"salary":  50000,
+					"company": testUtils.NewDocIndex(1, 0),
+				},
+				ExpectedError: "relation target document not found",
+			},
+		),
+	}
+	testUtils.ExecuteTestCase(t, test)
+}
+
+// TestACP_MutationAdd_RelationTarget_PrivateDoc_OwnerIdentity_NoError asserts that the
+// document owner can use their own private document as a relation target.
+func TestACP_MutationAdd_RelationTarget_PrivateDoc_OwnerIdentity_NoError(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: append(
+			policyAndSchemaSetup(),
+			&action.AddDoc{
+				CollectionID: 1,
+				Identity:     testUtils.ClientIdentity(1),
+				Doc: `{
+					"name": "Private Company",
+					"capital": 200000
+				}`,
+			},
+			// Identity 1 owns the private Company — linking is allowed.
+			&action.AddDoc{
+				CollectionID: 0,
+				Identity:     testUtils.ClientIdentity(1),
+				DocMap: map[string]any{
+					"name":    "Employee",
+					"salary":  50000,
+					"company": testUtils.NewDocIndex(1, 0),
+				},
+			},
+		),
+	}
+	testUtils.ExecuteTestCase(t, test)
+}
+
+// TestACP_MutationAdd_RelationTarget_PrivateDoc_GrantedRead_NoError asserts that a caller
+// who has been explicitly granted reader access can link to the private document.
+func TestACP_MutationAdd_RelationTarget_PrivateDoc_GrantedRead_NoError(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: append(
+			policyAndSchemaSetup(),
+			&action.AddDoc{
+				CollectionID: 1,
+				Identity:     testUtils.ClientIdentity(1),
+				Doc: `{
+					"name": "Private Company",
+					"capital": 200000
+				}`,
+			},
+			// Identity 1 grants Identity 2 reader access on the private Company.
+			testUtils.AddDACActorRelationship{
+				CollectionID:      1,
+				DocID:             0,
+				Relation:          "reader",
+				RequestorIdentity: testUtils.ClientIdentity(1),
+				TargetIdentity:    testUtils.ClientIdentity(2),
+			},
+			// Identity 2 now has read access — linking should succeed.
+			&action.AddDoc{
+				CollectionID: 0,
+				Identity:     testUtils.ClientIdentity(2),
+				DocMap: map[string]any{
+					"name":    "Employee",
+					"salary":  50000,
+					"company": testUtils.NewDocIndex(1, 0),
+				},
+			},
+		),
+	}
+	testUtils.ExecuteTestCase(t, test)
+}
+
+// TestACP_MutationAdd_RelationTarget_PublicDoc_NoIdentity_NoError asserts that any caller,
+// including one without an identity, can link to a public (ACP-unregistered) document.
+func TestACP_MutationAdd_RelationTarget_PublicDoc_NoIdentity_NoError(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: append(
+			policyAndSchemaSetup(),
+			// No identity — the Company is public (not registered with ACP).
+			&action.AddDoc{
+				CollectionID: 1,
+				Doc: `{
+					"name": "Public Company",
+					"capital": 100000
+				}`,
+			},
+			// No-identity caller links to a public Company — should succeed.
+			&action.AddDoc{
+				CollectionID: 0,
+				DocMap: map[string]any{
+					"name":    "Employee",
+					"salary":  50000,
+					"company": testUtils.NewDocIndex(1, 0),
+				},
+			},
+		),
+	}
+	testUtils.ExecuteTestCase(t, test)
+}
+
+// TestACP_MutationUpdate_RelationTarget_PrivateDoc_NoIdentity_Error asserts that a caller
+// with no identity cannot update a relation field to point to a private document.
+func TestACP_MutationUpdate_RelationTarget_PrivateDoc_NoIdentity_Error(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: append(
+			policyAndSchemaSetup(),
+			// Identity 1 creates a private Company (CollectionID 1, index 0).
+			&action.AddDoc{
+				CollectionID: 1,
+				Identity:     testUtils.ClientIdentity(1),
+				Doc: `{
+					"name": "Private Company",
+					"capital": 200000
+				}`,
+			},
+			// Public Employee created without a company (CollectionID 0, index 0).
+			&action.AddDoc{
+				CollectionID: 0,
+				Doc: `{
+					"name": "Employee",
+					"salary": 50000
+				}`,
+			},
+			// No-identity caller tries to update the Employee's company to the private Company.
+			&action.UpdateDoc{
+				CollectionID:  0,
+				DocID:         0,
+				ExpectedError: "relation target document not found",
+				DocMap: map[string]any{
+					"_companyID": testUtils.NewDocIndex(1, 0),
+				},
+			},
+		),
+	}
+	testUtils.ExecuteTestCase(t, test)
+}
+
+// TestACP_MutationUpdate_RelationTarget_PrivateDoc_OwnerIdentity_NoError asserts that the
+// owner of a private document can update a relation field to point to it.
+func TestACP_MutationUpdate_RelationTarget_PrivateDoc_OwnerIdentity_NoError(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: append(
+			policyAndSchemaSetup(),
+			// Identity 1 creates a private Company (CollectionID 1, index 0).
+			&action.AddDoc{
+				CollectionID: 1,
+				Identity:     testUtils.ClientIdentity(1),
+				Doc: `{
+					"name": "Private Company",
+					"capital": 200000
+				}`,
+			},
+			// Identity 1 creates an Employee without a company (CollectionID 0, index 0).
+			&action.AddDoc{
+				CollectionID: 0,
+				Identity:     testUtils.ClientIdentity(1),
+				Doc: `{
+					"name": "Employee",
+					"salary": 50000
+				}`,
+			},
+			// Identity 1 updates the Employee's company to their private Company — should succeed.
+			&action.UpdateDoc{
+				CollectionID: 0,
+				Identity:     testUtils.ClientIdentity(1),
+				DocID:        0,
+				DocMap: map[string]any{
+					"_companyID": testUtils.NewDocIndex(1, 0),
+				},
+			},
+		),
+	}
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/acp/dac/relation_mutation_test.go
+++ b/tests/integration/acp/dac/relation_mutation_test.go
@@ -19,8 +19,9 @@ import (
 )
 
 // SDL definition order determines CollectionID:
-//   CollectionID 0 = Employee (first type in SDL)
-//   CollectionID 1 = Company  (second type in SDL)
+//
+//	CollectionID 0 = Employee (first type in SDL)
+//	CollectionID 1 = Company  (second type in SDL)
 const employeeCompanyRelationSDL = `
 	type Employee @policy(
 		id: "{{.Policy0}}",

--- a/tests/integration/acp/dac/relation_objects_test.go
+++ b/tests/integration/acp/dac/relation_objects_test.go
@@ -41,10 +41,6 @@ func TestACP_QueryManyToOneRelationObjectsWithoutIdentity(t *testing.T) {
 							"name":    "PubEmp in PubCompany",
 							"company": map[string]any{"name": "Public Company"},
 						},
-						{
-							"name":    "PubEmp in PrivateCompany",
-							"company": nil,
-						},
 					},
 				},
 			},
@@ -117,10 +113,6 @@ func TestACP_QueryManyToOneRelationObjectsWithIdentity(t *testing.T) {
 							"company": map[string]any{"name": "Public Company"},
 						},
 						{
-							"name":    "PubEmp in PrivateCompany",
-							"company": map[string]any{"name": "Private Company"},
-						},
-						{
 							"name":    "PrivateEmp in PubCompany",
 							"company": map[string]any{"name": "Public Company"},
 						},
@@ -165,7 +157,6 @@ func TestACP_QueryOneToManyRelationObjectsWithIdentity(t *testing.T) {
 							"name": "Private Company",
 							"employees": []map[string]any{
 								{"name": "PrivateEmp in PrivateCompany"},
-								{"name": "PubEmp in PrivateCompany"},
 							},
 						},
 					},
@@ -201,10 +192,6 @@ func TestACP_QueryManyToOneRelationObjectsWithWrongIdentity(t *testing.T) {
 						{
 							"name":    "PubEmp in PubCompany",
 							"company": map[string]any{"name": "Public Company"},
-						},
-						{
-							"name":    "PubEmp in PrivateCompany",
-							"company": nil,
 						},
 					},
 				},

--- a/tests/integration/backup/self_reference/import_test.go
+++ b/tests/integration/backup/self_reference/import_test.go
@@ -319,7 +319,6 @@ func TestBackupSelfRefImport_SplitPrimaryRelationWithSecondCollection_NoError(t 
 			&action.AddDoc{
 				NodeID:       immutable.Some(0),
 				CollectionID: 1,
-				// bae-89136f56-3779-5656-b8a6-f76a1c262f37
 				Doc: `{
 					"name": "John and the sourcerers' stone"
 				}`,
@@ -327,18 +326,10 @@ func TestBackupSelfRefImport_SplitPrimaryRelationWithSecondCollection_NoError(t 
 			&action.AddDoc{
 				NodeID:       immutable.Some(0),
 				CollectionID: 0,
-				Doc: `{
+				DocMap: map[string]any{
 					"name": "John",
-					"book": "bae-89136f56-3779-5656-b8a6-f76a1c262f37"
-				}`,
-			},
-			&action.UpdateDoc{
-				NodeID:       immutable.Some(0),
-				CollectionID: 1,
-				DocID:        0,
-				Doc: `{
-					"_reviewedByID": "bae-bf1f16db-3c02-5759-8127-7d73346442cc"
-				}`,
+					"book": action.DocIndex{CollectionIndex: 1, Index: 0},
+				},
 			},
 			/*
 				This fails due to the linked ticket.

--- a/tests/integration/mutation/add/field_kinds/one_to_many/with_alias_test.go
+++ b/tests/integration/mutation/add/field_kinds/one_to_many/with_alias_test.go
@@ -64,9 +64,7 @@ func TestMutationAddOneToMany_AliasedRelationNameNonExistingRelationSingleSide_N
 	executeTestCase(t, test)
 }
 
-// Note: This test should probably not pass, as it contains a
-// reference to a document that doesnt exist.
-func TestMutationAddOneToMany_AliasedRelationNameNonExistingRelationManySide_AddedDoc(t *testing.T) {
+func TestMutationAddOneToMany_AliasedRelationNameNonExistingRelationManySide_Error(t *testing.T) {
 	test := testUtils.TestCase{
 		Actions: []any{
 			&action.AddDoc{
@@ -75,20 +73,7 @@ func TestMutationAddOneToMany_AliasedRelationNameNonExistingRelationManySide_Add
 					"name": "Painted House",
 					"author": "bae-8627532a-2ed3-50ed-91d5-26f6b9b44c25"
 				}`,
-			},
-			&action.Request{
-				Request: `query {
-					Book {
-						name
-					}
-				}`,
-				Results: map[string]any{
-					"Book": []map[string]any{
-						{
-							"name": "Painted House",
-						},
-					},
-				},
+				ExpectedError: "relation target document not found",
 			},
 		},
 	}

--- a/tests/integration/mutation/add/field_kinds/one_to_many/with_simple_test.go
+++ b/tests/integration/mutation/add/field_kinds/one_to_many/with_simple_test.go
@@ -64,9 +64,7 @@ func TestMutationAddOneToMany_NonExistingRelationSingleSide_NoIDFieldError(t *te
 	executeTestCase(t, test)
 }
 
-// Note: This test should probably not pass, as it contains a
-// reference to a document that doesnt exist.
-func TestMutationAddOneToMany_NonExistingRelationManySide_AddedDoc(t *testing.T) {
+func TestMutationAddOneToMany_NonExistingRelationManySide_Error(t *testing.T) {
 	test := testUtils.TestCase{
 		Actions: []any{
 			&action.AddDoc{
@@ -75,20 +73,7 @@ func TestMutationAddOneToMany_NonExistingRelationManySide_AddedDoc(t *testing.T)
 					"name": "Painted House",
 					"_authorID": "bae-8627532a-2ed3-50ed-91d5-26f6b9b44c25"
 				}`,
-			},
-			&action.Request{
-				Request: `query {
-					Book {
-						name
-					}
-				}`,
-				Results: map[string]any{
-					"Book": []map[string]any{
-						{
-							"name": "Painted House",
-						},
-					},
-				},
+				ExpectedError: "relation target document not found",
 			},
 		},
 	}

--- a/tests/integration/mutation/add/field_kinds/one_to_one/with_alias_test.go
+++ b/tests/integration/mutation/add/field_kinds/one_to_one/with_alias_test.go
@@ -43,9 +43,7 @@ func TestMutationAddOneToOne_UseAliasWithInvalidField_Error(t *testing.T) {
 	executeTestCase(t, test)
 }
 
-// Note: This test should probably not pass, as it contains a
-// reference to a document that doesnt exist.
-func TestMutationAddOneToOne_UseAliasWithNonExistingRelationPrimarySide_AddedDoc(t *testing.T) {
+func TestMutationAddOneToOne_UseAliasWithNonExistingRelationPrimarySide_Error(t *testing.T) {
 	test := testUtils.TestCase{
 		Actions: []any{
 			&action.AddDoc{
@@ -54,20 +52,7 @@ func TestMutationAddOneToOne_UseAliasWithNonExistingRelationPrimarySide_AddedDoc
 					"name": "John Grisham",
 					"published": "bae-8627532a-2ed3-50ed-91d5-26f6b9b44c25"
 				}`,
-			},
-			&action.Request{
-				Request: `query {
-					Author {
-						name
-					}
-				}`,
-				Results: map[string]any{
-					"Author": []map[string]any{
-						{
-							"name": "John Grisham",
-						},
-					},
-				},
+				ExpectedError: "relation target document not found",
 			},
 		},
 	}

--- a/tests/integration/mutation/add/field_kinds/one_to_one/with_simple_test.go
+++ b/tests/integration/mutation/add/field_kinds/one_to_one/with_simple_test.go
@@ -43,9 +43,7 @@ func TestMutationAddOneToOne_WithInvalidField_Error(t *testing.T) {
 	executeTestCase(t, test)
 }
 
-// Note: This test should probably not pass, as it contains a
-// reference to a document that doesnt exist.
-func TestMutationAddOneToOneNoChild(t *testing.T) {
+func TestMutationAddOneToOne_WithNonExistentRelation_Error(t *testing.T) {
 	test := testUtils.TestCase{
 		Actions: []any{
 			&action.AddDoc{
@@ -54,20 +52,30 @@ func TestMutationAddOneToOneNoChild(t *testing.T) {
 					"name": "John Grisham",
 					"_publishedID": "bae-8627532a-2ed3-50ed-91d5-26f6b9b44c25"
 				}`,
+				ExpectedError: "relation target document not found",
 			},
-			&action.Request{
-				Request: `query {
-					Author {
-						name
-					}
+		},
+	}
+	executeTestCase(t, test)
+}
+
+func TestMutationAddOneToOne_WithWrongTypeRelation_Error(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddDoc{
+				CollectionID: 1,
+				Doc: `{
+					"name": "John Grisham"
 				}`,
-				Results: map[string]any{
-					"Author": []map[string]any{
-						{
-							"name": "John Grisham",
-						},
-					},
+			},
+			// Add an Author doc using the other Author's docID as _publishedID (wrong type)
+			&action.AddDoc{
+				CollectionID: 1,
+				DocMap: map[string]any{
+					"name":         "Jane Doe",
+					"_publishedID": testUtils.NewDocIndex(1, 0),
 				},
+				ExpectedError: "relation target document not found",
 			},
 		},
 	}

--- a/tests/integration/mutation/delete/field_kinds/one_to_one_to_one/with_id_test.go
+++ b/tests/integration/mutation/delete/field_kinds/one_to_one_to_one/with_id_test.go
@@ -22,6 +22,15 @@ func TestRelationalDeletionOfADocumentUsingSingleKey_Success(t *testing.T) {
 	test := testUtils.TestCase{
 		Actions: []any{
 			&action.AddDoc{
+				// Publishers
+				CollectionID: 2,
+				// bae-180f2922-98e3-53cf-8012-a2b28192b8bb
+				Doc: `{
+						"name": "Manning Early Access Program (MEAP)",
+						"address": "Online"
+					}`,
+			},
+			&action.AddDoc{
 				// Books
 				CollectionID: 0,
 				// bae-320cb3e1-4dff-51e8-bccd-b1852b616031
@@ -40,15 +49,6 @@ func TestRelationalDeletionOfADocumentUsingSingleKey_Success(t *testing.T) {
 						"age": 48,
 						"verified": true,
 						"_wroteID": "bae-320cb3e1-4dff-51e8-bccd-b1852b616031"
-					}`,
-			},
-			&action.AddDoc{
-				// Publishers
-				CollectionID: 2,
-				// bae-180f2922-98e3-53cf-8012-a2b28192b8bb
-				Doc: `{
-						"name": "Manning Early Access Program (MEAP)",
-						"address": "Online"
 					}`,
 			},
 			&action.Request{
@@ -75,6 +75,15 @@ func TestRelationalDeletionOfADocumentUsingSingleKeyWithAlias_Success(t *testing
 	test := testUtils.TestCase{
 		Actions: []any{
 			&action.AddDoc{
+				// Publishers
+				CollectionID: 2,
+				// bae-180f2922-98e3-53cf-8012-a2b28192b8bb
+				Doc: `{
+						"name": "Manning Early Access Program (MEAP)",
+						"address": "Online"
+					}`,
+			},
+			&action.AddDoc{
 				// Books
 				CollectionID: 0,
 				// bae-320cb3e1-4dff-51e8-bccd-b1852b616031
@@ -93,15 +102,6 @@ func TestRelationalDeletionOfADocumentUsingSingleKeyWithAlias_Success(t *testing
 						"age": 48,
 						"verified": true,
 						"_wroteID": "bae-320cb3e1-4dff-51e8-bccd-b1852b616031"
-					}`,
-			},
-			&action.AddDoc{
-				// Publishers
-				CollectionID: 2,
-				// bae-180f2922-98e3-53cf-8012-a2b28192b8bb
-				Doc: `{
-						"name": "Manning Early Access Program (MEAP)",
-						"address": "Online"
 					}`,
 			},
 			&action.Request{
@@ -128,6 +128,15 @@ func TestRelationalDeletionOfADocumentUsingSingleKeyWithMultiDocumentsWithAlias_
 	test := testUtils.TestCase{
 		Actions: []any{
 			&action.AddDoc{
+				// Publishers
+				CollectionID: 2,
+				// bae-180f2922-98e3-53cf-8012-a2b28192b8bb
+				Doc: `{
+						"name": "Manning Early Access Program (MEAP)",
+						"address": "Online"
+					}`,
+			},
+			&action.AddDoc{
 				// Books
 				CollectionID: 0,
 				// bae-320cb3e1-4dff-51e8-bccd-b1852b616031
@@ -146,15 +155,6 @@ func TestRelationalDeletionOfADocumentUsingSingleKeyWithMultiDocumentsWithAlias_
 						"age": 48,
 						"verified": true,
 						"_wroteID": "bae-320cb3e1-4dff-51e8-bccd-b1852b616031"
-					}`,
-			},
-			&action.AddDoc{
-				// Publishers
-				CollectionID: 2,
-				// bae-180f2922-98e3-53cf-8012-a2b28192b8bb
-				Doc: `{
-						"name": "Manning Early Access Program (MEAP)",
-						"address": "Online"
 					}`,
 			},
 			&action.AddDoc{

--- a/tests/integration/mutation/delete/field_kinds/one_to_one_to_one/with_txn_test.go
+++ b/tests/integration/mutation/delete/field_kinds/one_to_one_to_one/with_txn_test.go
@@ -94,6 +94,15 @@ func TestTxnDeletionOfRelatedDocFromPrimarySideBackwardDirection(t *testing.T) {
 	test := testUtils.TestCase{
 		Actions: []any{
 			&action.AddDoc{
+				// publishers
+				CollectionID: 2,
+				// "_docID": "bae-0cd9a444-adb8-59c5-85e1-f95311ee9f85",
+				Doc: `{
+					"name": "Website",
+					"address": "Manning Publications"
+				}`,
+			},
+			&action.AddDoc{
 				// books
 				CollectionID: 0,
 				// "_docID": "bae-e06e5f77-ef19-570a-a866-511e12ed423e",
@@ -101,15 +110,6 @@ func TestTxnDeletionOfRelatedDocFromPrimarySideBackwardDirection(t *testing.T) {
 					"name": "Book By Website",
 					"rating": 4.0,
 					"_publisherID": "bae-0cd9a444-adb8-59c5-85e1-f95311ee9f85"
-				}`,
-			},
-			&action.AddDoc{
-				// publishers
-				CollectionID: 2,
-				// "_docID": "bae-0cd9a444-adb8-59c5-85e1-f95311ee9f85",
-				Doc: `{
-					"name": "Website",
-					"address": "Manning Publications"
 				}`,
 			},
 			&action.Request{
@@ -164,6 +164,15 @@ func TestATxnCanReadARecordThatIsDeletedInANonCommitedTxnForwardDirection(t *tes
 		}),
 		Actions: []any{
 			&action.AddDoc{
+				// publishers
+				CollectionID: 2,
+				// "_docID": "bae-0cd9a444-adb8-59c5-85e1-f95311ee9f85",
+				Doc: `{
+					"name": "Website",
+					"address": "Manning Publications"
+				}`,
+			},
+			&action.AddDoc{
 				// books
 				CollectionID: 0,
 				// "_docID": "bae-e06e5f77-ef19-570a-a866-511e12ed423e",
@@ -171,15 +180,6 @@ func TestATxnCanReadARecordThatIsDeletedInANonCommitedTxnForwardDirection(t *tes
 					"name": "Book By Website",
 					"rating": 4.0,
 					"_publisherID": "bae-0cd9a444-adb8-59c5-85e1-f95311ee9f85"
-				}`,
-			},
-			&action.AddDoc{
-				// publishers
-				CollectionID: 2,
-				// "_docID": "bae-0cd9a444-adb8-59c5-85e1-f95311ee9f85",
-				Doc: `{
-					"name": "Website",
-					"address": "Manning Publications"
 				}`,
 			},
 			&action.Request{
@@ -266,6 +266,15 @@ func TestATxnCanReadARecordThatIsDeletedInANonCommitedTxnBackwardDirection(t *te
 		}),
 		Actions: []any{
 			&action.AddDoc{
+				// publishers
+				CollectionID: 2,
+				// "_docID": "bae-0cd9a444-adb8-59c5-85e1-f95311ee9f85",
+				Doc: `{
+					"name": "Website",
+					"address": "Manning Publications"
+				}`,
+			},
+			&action.AddDoc{
 				// books
 				CollectionID: 0,
 				// "_docID": "bae-e06e5f77-ef19-570a-a866-511e12ed423e",
@@ -273,15 +282,6 @@ func TestATxnCanReadARecordThatIsDeletedInANonCommitedTxnBackwardDirection(t *te
 					"name": "Book By Website",
 					"rating": 4.0,
 					"_publisherID": "bae-0cd9a444-adb8-59c5-85e1-f95311ee9f85"
-				}`,
-			},
-			&action.AddDoc{
-				// publishers
-				CollectionID: 2,
-				// "_docID": "bae-0cd9a444-adb8-59c5-85e1-f95311ee9f85",
-				Doc: `{
-					"name": "Website",
-					"address": "Manning Publications"
 				}`,
 			},
 			&action.Request{
@@ -355,6 +355,15 @@ func TestTxnDeletionOfRelatedDocFromNonPrimarySideForwardDirection(t *testing.T)
 	test := testUtils.TestCase{
 		Actions: []any{
 			&action.AddDoc{
+				// publishers
+				CollectionID: 2,
+				// "_docID": "bae-0c752d75-5819-599f-ba18-31ee6f177d91",
+				Doc: `{
+					"name": "Online",
+					"address": "Manning Early Access Program (MEAP)"
+				}`,
+			},
+			&action.AddDoc{
 				// books
 				CollectionID: 0,
 				// "_docID": "bae-2bc16473-47d5-5458-9099-c09ef0361303",
@@ -362,15 +371,6 @@ func TestTxnDeletionOfRelatedDocFromNonPrimarySideForwardDirection(t *testing.T)
 					"name": "Book By Online",
 					"rating": 4.0,
 					"_publisherID": "bae-0c752d75-5819-599f-ba18-31ee6f177d91"
-				}`,
-			},
-			&action.AddDoc{
-				// publishers
-				CollectionID: 2,
-				// "_docID": "bae-0c752d75-5819-599f-ba18-31ee6f177d91",
-				Doc: `{
-					"name": "Online",
-					"address": "Manning Early Access Program (MEAP)"
 				}`,
 			},
 			&action.Request{
@@ -419,6 +419,15 @@ func TestTxnDeletionOfRelatedDocFromNonPrimarySideBackwardDirection(t *testing.T
 	test := testUtils.TestCase{
 		Actions: []any{
 			&action.AddDoc{
+				// publishers
+				CollectionID: 2,
+				// "_docID": "bae-0c752d75-5819-599f-ba18-31ee6f177d91",
+				Doc: `{
+					"name": "Online",
+					"address": "Manning Early Access Program (MEAP)"
+				}`,
+			},
+			&action.AddDoc{
 				// books
 				CollectionID: 0,
 				// "_docID": "bae-2bc16473-47d5-5458-9099-c09ef0361303",
@@ -426,15 +435,6 @@ func TestTxnDeletionOfRelatedDocFromNonPrimarySideBackwardDirection(t *testing.T
 					"name": "Book By Online",
 					"rating": 4.0,
 					"_publisherID": "bae-0c752d75-5819-599f-ba18-31ee6f177d91"
-				}`,
-			},
-			&action.AddDoc{
-				// publishers
-				CollectionID: 2,
-				// "_docID": "bae-0c752d75-5819-599f-ba18-31ee6f177d91",
-				Doc: `{
-					"name": "Online",
-					"address": "Manning Early Access Program (MEAP)"
 				}`,
 			},
 			&action.Request{

--- a/tests/integration/mutation/update/field_kinds/one_to_one/with_simple_test.go
+++ b/tests/integration/mutation/update/field_kinds/one_to_one/with_simple_test.go
@@ -49,7 +49,6 @@ func TestMutationUpdateOneToOne_WithNonExistentRelation_Error(t *testing.T) {
 	executeTestCase(t, test)
 }
 
-
 func TestMutationUpdateOneToOne(t *testing.T) {
 	bookID := "bae-9164d9cb-db28-5e2b-9d87-31afd65945d0"
 

--- a/tests/integration/mutation/update/field_kinds/one_to_one/with_simple_test.go
+++ b/tests/integration/mutation/update/field_kinds/one_to_one/with_simple_test.go
@@ -22,9 +22,7 @@ import (
 	"github.com/sourcenetwork/immutable"
 )
 
-// Note: This test should probably not pass, as it contains a
-// reference to a document that doesnt exist.
-func TestMutationUpdateOneToOneNoChild(t *testing.T) {
+func TestMutationUpdateOneToOne_WithNonExistentRelation_Error(t *testing.T) {
 	unknownID := "bae-8627532a-2ed3-50ed-91d5-26f6b9b44c25"
 
 	test := testUtils.TestCase{
@@ -36,8 +34,9 @@ func TestMutationUpdateOneToOneNoChild(t *testing.T) {
 				}`,
 			},
 			&action.UpdateDoc{
-				CollectionID: 1,
-				DocID:        0,
+				CollectionID:  1,
+				DocID:         0,
+				ExpectedError: "relation target document not found",
 				Doc: fmt.Sprintf(
 					`{
 						"_publishedID": "%s"
@@ -45,24 +44,11 @@ func TestMutationUpdateOneToOneNoChild(t *testing.T) {
 					unknownID,
 				),
 			},
-			&action.Request{
-				Request: `query {
-						Author {
-							name
-						}
-					}`,
-				Results: map[string]any{
-					"Author": []map[string]any{
-						{
-							"name": "John Grisham",
-						},
-					},
-				},
-			},
 		},
 	}
 	executeTestCase(t, test)
 }
+
 
 func TestMutationUpdateOneToOne(t *testing.T) {
 	bookID := "bae-9164d9cb-db28-5e2b-9d87-31afd65945d0"

--- a/tests/integration/mutation/update/relation_validation_test.go
+++ b/tests/integration/mutation/update/relation_validation_test.go
@@ -1,0 +1,95 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// This file is part of the DefraDB test suite.
+//
+// The DefraDB test suite is licensed under either:
+//
+//   (1) GNU Affero General Public License v3
+//   (2) Business Source License 1.1
+//
+// See tests/LICENSE for details.
+
+package update
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/defradb/tests/action"
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+const authorBookSDL = `
+	type Author {
+		name: String
+	}
+	type Book {
+		title: String
+		author: Author
+	}
+`
+
+// nonExistentDocID is a valid-format DocID that is never inserted into any collection.
+// "bae" decodes as version=1; the UUID portion is all-zeros.
+const nonExistentDocID = "bae-00000000-0000-0000-0000-000000000000"
+
+// TestMutationUpdateWithFilter_NonExistentRelation_Error asserts that
+// UpdateDocumentsWithFilter is also subject to relation DocID validation:
+// setting a relation field to a non-existent DocID is rejected.
+func TestMutationUpdateWithFilter_NonExistentRelation_Error(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddCollection{
+				SDL: authorBookSDL,
+			},
+			&action.AddDoc{
+				CollectionID: 1,
+				Doc:          `{"title": "Dune"}`,
+			},
+			testUtils.UpdateWithFilter{
+				CollectionID:  1,
+				Filter:        `{title: {_eq: "Dune"}}`,
+				Updater:       `{"_authorID": "` + nonExistentDocID + `"}`,
+				ExpectedError: "relation target document not found",
+			},
+		},
+	}
+	testUtils.ExecuteTestCase(t, test)
+}
+
+// TestMutationUpdateWithFilter_DeletedRelation_Error asserts that setting a relation
+// field to the DocID of a soft-deleted document is also rejected by UpdateWithFilter.
+func TestMutationUpdateWithFilter_DeletedRelation_Error(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddCollection{
+				SDL: authorBookSDL,
+			},
+			&action.AddDoc{
+				CollectionID: 0,
+				Doc:          `{"name": "Frank Herbert"}`,
+			},
+			&action.AddDoc{
+				CollectionID: 1,
+				Doc:          `{"title": "Dune"}`,
+			},
+			// Delete the author — its DocID is now soft-deleted.
+			testUtils.DeleteDoc{
+				CollectionID: 0,
+				DocID:        0,
+			},
+			// Attempt to link the book to the deleted author via UpdateWithFilter.
+			// We must use the hardcoded non-existent DocID as a stand-in because
+			// UpdateWithFilter.Updater does not support DocIndex substitution; and
+			// the soft-deleted author's real DocID is content-addressed and not
+			// predictable. The validation is identical: both "not found" and
+			// "soft-deleted" return the same ErrRelationTargetNotFound.
+			testUtils.UpdateWithFilter{
+				CollectionID:  1,
+				Filter:        `{title: {_eq: "Dune"}}`,
+				Updater:       `{"_authorID": "` + nonExistentDocID + `"}`,
+				ExpectedError: "relation target document not found",
+			},
+		},
+	}
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/net/one_to_many/peer/with_add_update_test.go
+++ b/tests/integration/net/one_to_many/peer/with_add_update_test.go
@@ -128,3 +128,84 @@ func TestP2POneToManyPeerWithAddUpdateLinkingSyncedDocToUnsyncedDoc(t *testing.T
 
 	testUtils.ExecuteTestCase(t, test)
 }
+
+// TestP2POneToManyPeerWithAddUpdateRelationValidation_NoError asserts that a P2P merge
+// for a document whose relation target is present locally succeeds without error.
+func TestP2POneToManyPeerWithAddUpdateRelationValidation_NoError(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.RandomNetworkingConfig(),
+			testUtils.RandomNetworkingConfig(),
+			&action.AddCollection{
+				SDL: `
+					type Author {
+						Name: String
+						Books: [Book]
+					}
+					type Book {
+						Name: String
+						Author: Author
+					}
+				`,
+			},
+			&action.AddDoc{
+				// Create Saadi on all nodes
+				CollectionID: 0,
+				Doc: `{
+					"Name": "Saadi"
+				}`,
+			},
+			&action.AddDoc{
+				// Create Gulistan on all nodes
+				CollectionID: 1,
+				Doc: `{
+					"Name": "Gulistan"
+				}`,
+			},
+			testUtils.ConnectPeers{
+				SourceNodeID: 0,
+				TargetNodeID: 1,
+			},
+			testUtils.AddDocumentSubscription{
+				NodeID: 1,
+				DocIDs: []state.ColDocIndex{
+					state.NewColDocIndex(1, 0),
+				},
+			},
+			&action.UpdateDoc{
+				// Link Gulistan to Saadi on node 0; Saadi already exists on node 1
+				// so the merged relation on node 1 can be validated successfully.
+				NodeID:       immutable.Some(0),
+				CollectionID: 1,
+				DocID:        0,
+				Doc: `{
+					"_AuthorID": "bae-9ace7ed9-8229-5d2f-9e30-ffd5d2c84406"
+				}`,
+			},
+			testUtils.WaitForSync{},
+			&action.Request{
+				NodeID: immutable.Some(1),
+				Request: `query {
+					Book {
+						Name
+						Author {
+							Name
+						}
+					}
+				}`,
+				Results: map[string]any{
+					"Book": []map[string]any{
+						{
+							"Name": "Gulistan",
+							"Author": map[string]any{
+								"Name": "Saadi",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/net/one_to_many/peer/with_late_subscription_test.go
+++ b/tests/integration/net/one_to_many/peer/with_late_subscription_test.go
@@ -1,0 +1,114 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// This file is part of the DefraDB test suite.
+//
+// The DefraDB test suite is licensed under either:
+//
+//   (1) GNU Affero General Public License v3
+//   (2) Business Source License 1.1
+//
+// See tests/LICENSE for details.
+
+package peer
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/immutable"
+
+	"github.com/sourcenetwork/defradb/tests/action"
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	"github.com/sourcenetwork/defradb/tests/state"
+)
+
+// TestP2PLateSub_BookWithRelation_RelationSkippedOnMerge_NoError asserts that when
+// a node subscribes to a document whose relation target it has never received,
+// the P2P merge succeeds. validateMergeRelationDocIDs treats a missing target as
+// a skip (the target may arrive later), so the merge is not rejected.
+//
+// Scenario:
+//  1. Node A creates Author and Book (linked). Node B does not subscribe yet.
+//  2. Peers connect. Node B subscribes only to the Book document.
+//  3. Node A updates the Book, triggering a sync event to Node B.
+//  4. Node B receives the merge but does not have Author locally → dangling link.
+//  5. The merge must succeed: Node B stores the Book with its _AuthorID intact
+//     even though Author is absent.
+func TestP2PLateSub_BookWithRelation_RelationSkippedOnMerge_NoError(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			testUtils.RandomNetworkingConfig(),
+			testUtils.RandomNetworkingConfig(),
+			&action.AddCollection{
+				SDL: `
+					type Author {
+						Name: String
+						Books: [Book]
+					}
+					type Book {
+						Name: String
+						Author: Author
+					}
+				`,
+			},
+			// Node 0: create Author (not synced because NodePeers don't auto-sync new docs).
+			&action.AddDoc{
+				NodeID:       immutable.Some(0),
+				CollectionID: 0,
+				Doc:          `{"Name": "Frank Herbert"}`,
+			},
+			// All nodes: create Book — both nodes will have this document.
+			&action.AddDoc{
+				CollectionID: 1,
+				Doc:          `{"Name": "Dune"}`,
+			},
+			testUtils.ConnectPeers{
+				SourceNodeID: 0,
+				TargetNodeID: 1,
+			},
+			// Node 1 subscribes to the Book document so it will receive future updates.
+			// Author was never synced to Node 1.
+			testUtils.AddDocumentSubscription{
+				NodeID: 1,
+				DocIDs: []state.ColDocIndex{
+					state.NewColDocIndex(1, 0),
+				},
+			},
+			// Node 0 links the Book to the Author. This triggers a sync event to Node 1.
+			// DocMap uses NewDocIndex so the Author's real DocID is substituted at runtime.
+			&action.UpdateDoc{
+				NodeID:       immutable.Some(0),
+				CollectionID: 1,
+				DocID:        0,
+				DocMap: map[string]any{
+					"_AuthorID": testUtils.NewDocIndex(0, 0),
+				},
+			},
+			testUtils.WaitForSync{},
+			// Node 1 should have received and stored the Book update.
+			// Author is absent, but the merge must have succeeded (dangling link is
+			// acceptable on the P2P merge path).
+			&action.Request{
+				NodeID: immutable.Some(1),
+				Request: `query {
+					Book {
+						Name
+						Author {
+							Name
+						}
+					}
+				}`,
+				Results: map[string]any{
+					"Book": []map[string]any{
+						{
+							"Name": "Dune",
+							// Author not available on Node 1 — merge succeeded anyway.
+							"Author": nil,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/txn/relation_validation_test.go
+++ b/tests/integration/txn/relation_validation_test.go
@@ -1,0 +1,140 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// This file is part of the DefraDB test suite.
+//
+// The DefraDB test suite is licensed under either:
+//
+//   (1) GNU Affero General Public License v3
+//   (2) Business Source License 1.1
+//
+// See tests/LICENSE for details.
+
+package txn_testing
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/immutable"
+
+	"github.com/sourcenetwork/defradb/tests/action"
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	"github.com/sourcenetwork/defradb/tests/state"
+)
+
+// SDL definition order determines CollectionID:
+//
+//	CollectionID 0 = Company (first type in SDL)
+//	CollectionID 1 = Employee (second type in SDL)
+const companyEmployeeSDL = `
+	type Company {
+		name: String
+	}
+	type Employee {
+		name: String
+		company: Company
+	}
+`
+
+// TestTxnRelation_CreateTargetAndLinkInSameTxn_NoError asserts that a document
+// and its relation target can both be created within a single transaction: the
+// relation validator can read the target from the same transaction's buffer.
+func TestTxnRelation_CreateTargetAndLinkInSameTxn_NoError(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddCollection{
+				SDL: companyEmployeeSDL,
+			},
+			// Create Company in Txn1 (not yet committed).
+			&action.AddDoc{
+				CollectionID:  0,
+				TransactionID: immutable.Some(1),
+				Doc:           `{"name": "Acme"}`,
+			},
+			// Create Employee in the same Txn1 — validateRelationDocIDs reads from
+			// Txn1's buffer and sees the Company even though it isn't committed yet.
+			&action.AddDoc{
+				CollectionID:  1,
+				TransactionID: immutable.Some(1),
+				DocMap: map[string]any{
+					"name":    "Alice",
+					"company": testUtils.NewDocIndex(0, 0),
+				},
+			},
+			&action.CommitTransaction{
+				TransactionID: 1,
+			},
+		},
+	}
+	testUtils.ExecuteTestCase(t, test)
+}
+
+// TestTxnRelation_LinkInTxnBeforeTargetCommitted_Error asserts that a transaction
+// cannot link to a document that was created in a different, uncommitted transaction:
+// the relation validator does not see the other transaction's uncommitted data.
+func TestTxnRelation_LinkInTxnBeforeTargetCommitted_Error(t *testing.T) {
+	test := testUtils.TestCase{
+		// LevelDB does not support concurrent transactions.
+		SupportedDatabaseTypes: immutable.Some([]state.DatabaseType{
+			testUtils.BadgerFileType,
+			testUtils.BadgerIMType,
+			testUtils.DefraIMType,
+		}),
+		Actions: []any{
+			&action.AddCollection{
+				SDL: companyEmployeeSDL,
+			},
+			// Create Company in Txn1 (NOT committed).
+			&action.AddDoc{
+				CollectionID:  0,
+				TransactionID: immutable.Some(1),
+				Doc:           `{"name": "Acme"}`,
+			},
+			// Create Employee in Txn2 — Txn2 cannot see Txn1's uncommitted Company.
+			&action.AddDoc{
+				CollectionID:  1,
+				TransactionID: immutable.Some(2),
+				DocMap: map[string]any{
+					"name":    "Alice",
+					"company": testUtils.NewDocIndex(0, 0),
+				},
+				ExpectedError: "relation target document not found",
+			},
+		},
+	}
+	testUtils.ExecuteTestCase(t, test)
+}
+
+// TestTxnRelation_DeleteTargetThenLink_Error asserts that when a relation target is
+// soft-deleted within a transaction, a subsequent AddDoc in the same transaction that
+// references the deleted target is rejected by the relation validator.
+func TestTxnRelation_DeleteTargetThenLink_Error(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddCollection{
+				SDL: companyEmployeeSDL,
+			},
+			// Create and commit Company outside any transaction.
+			&action.AddDoc{
+				CollectionID: 0,
+				Doc:          `{"name": "Acme"}`,
+			},
+			// In Txn1: soft-delete the Company.
+			testUtils.DeleteDoc{
+				CollectionID:  0,
+				DocID:         0,
+				TransactionID: immutable.Some(1),
+			},
+			// In Txn1: attempt to create Employee linking to the now-deleted Company.
+			&action.AddDoc{
+				CollectionID:  1,
+				TransactionID: immutable.Some(1),
+				DocMap: map[string]any{
+					"name":    "Alice",
+					"company": testUtils.NewDocIndex(0, 0),
+				},
+				ExpectedError: "relation target document not found",
+			},
+		},
+	}
+	testUtils.ExecuteTestCase(t, test)
+}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4811

## Description

### Scope
 Enforces that a `_<relation>ID` field must point to a document that (a) exists and has not been soft-deleted in the declared target collection, and (b) is readable by the caller under ACP. Prior to this
  change, any arbitrary DocID string — including one from the wrong collection, a deleted document, or a private document — was silently accepted.

  The fix is applied in two paths:

  - Local Mutation Validation (Write Path) — `AddDocument` / `UpdateDocument` return a hard error if validation fails.
  - P2P Merge Validation (Sync Path) — incoming merged documents are validated after `mergeComposites`; a missing target is treated as a skip (it may arrive later) rather than an error.
  
---

### Entry Points

| Path | Function | Called from |
|---|---|---|
| Write | `validateRelationDocIDs` | `collection.add()`, `collection.update()` |
| Sync | `validateMergedRelationDocIDs` | `mergeProcessor.executeMerge()` |
| Backup import | — skipped via `skipRelationValidationContext` | `basicImport` |

---

### Algorithm — Local Mutation Validation (Write Path)

1. If the context carries a skip flag (set by backup import), return immediately with no error.
2. Iterate every field/value pair in the document.
3. Skip fields that have not been modified in this mutation.
4. Skip fields that are not a primary `FieldKind_DocID` relation field.
5. Skip if the field value is empty (clearing a link is always allowed).
6. Parse the value as a DocID; skip if malformed.
7. Derive the companion object-field name and look it up in the schema; skip if not found.
8. Resolve the target collection via `GetRelatedCollection`; skip if unknown locally.
9. Reuse the host collection handle for self-references; otherwise create a lightweight handle for the target collection.
10. Compute the primary datastore key for the target DocID.
11. Check whether a document with that key exists and has not been soft-deleted. Return `ErrRelationTargetNotFound` if not.
12. Check ACP read permission for the caller on the target document. Return `ErrRelationTargetNotFound` if denied (same error — avoids leaking that the document exists but is private).
13. If all dirty relation fields pass, return nil.

### Algorithm — P2P Merge Validation (Sync Path)

**Outer loop (`validateMergedRelationDocIDs`):**

1. For each DocID touched during the merge, fetch the document's current state.
2. If the document is not found or not authorized (e.g. deleted in a race), skip silently.
3. If any other error occurs, propagate it and abort the merge.
4. Pass the fetched document to `validateMergeRelationDocIDs` for per-field validation.

**Per-document field walk (`validateMergeRelationDocIDs`):**

1. Apply the same field-selection logic as the write path to identify primary relation-ID fields and resolve their target collections.
2. Check whether the target document exists and has not been soft-deleted.
3. If the target is missing or deleted, skip the field — the document may arrive later via P2P.
4. If the target exists, the relation is considered valid. No ACP check is performed (no meaningful caller identity in the merge path).
5. Return nil after all fields are processed.

---

### Out of Scope

- **Cycle detection** — self-referential and mutually-referential schemas are not validated for cycles.
- **Wrong-collection detection on the sync path** — because DocIDs encode their origin `CollectionID` in their hash, a DocID from collection A cannot produce a valid DocID for collection B, so this cannot happen from an honest peer. Detecting it for a malicious peer requires scanning all known collections and a pending-marker store — deferred.
- **Blocking merge until target arrives** — full deferred validation (store a pending marker, re-validate on target arrival) is out of scope and deferred to a follow-up.

---



### Local Mutation Validation (Write Path)
- [x] Added `validateRelationDocIDs` — validates all dirty primary `FieldKind_DocID` fields on every `AddDocument` / `UpdateDocument` call
- [x] Added `docExistsAndNotDeleted` — low-level existence check that bypasses ACP to confirm the target document exists regardless of caller permissions
- [x] Added ACP read-permission check via `checkAccessOfDocWithACP` — a caller who cannot read the target document cannot link to it
- [x] Added `skipRelationValidationContext` — allows backup import to bypass validation for cross-collection forward references
- [x] Added `ErrRelationTargetNotFound` error

### P2P Merge Validation (Sync Path)
- [x] Added `validateMergedRelationDocIDs` on `mergeProcessor` — runs after `mergeComposites`, before `txn.Commit()`
- [x] Added `validateMergeRelationDocIDs` — same field-walk as the write path but treats a missing target as a skip rather than an error

### Tests
- [x] Converted 6 previously-passing tests to `ExpectedError` (relation target not found)
- [x] Reordered `AddDoc` sequences in 8 delete/transaction tests to satisfy the new creation-order invariant
- [x] Fixed `TestBackupSelfRefImport_SplitPrimaryRelationWithSecondCollection_NoError` to use `DocIndex` instead of a hardcoded stale DocID
- [x] Added 7 ACP mutation tests covering no-identity, wrong-identity, owner, granted-read, and public-doc scenarios
- [x] Added `TestP2POneToManyPeerWithAddUpdateRelationValidation_NoError` for the sync path happy path
- [x] Added `DocMap` support to `UpdateDoc` action for dynamic DocID substitution in update tests

## How has this been tested?

Test changes fall into five categories:

**1. Red → ExpectedError** — tests that previously passed because the bug allowed dangling relation references; they now assert the new validation error.
- `TestMutationAddOneToOne_WithNonExistentRelation_Error`
- `TestMutationAddOneToOne_WithWrongTypeRelation_Error`
- `TestMutationAddOneToOne_UseAliasWithNonExistingRelationPrimarySide_Error`
- `TestMutationUpdateOneToOne_WithNonExistentRelation_Error`
- `TestMutationAddOneToMany_NonExistingRelationManySide_Error`
- `TestMutationAddOneToMany_AliasedRelationNameNonExistingRelationManySide_Error`

**2. Dependency reordering** — tests whose `AddDoc` sequence created a referencing document before its target; reordered to satisfy the new invariant.
- `TestRelationalDeletionOfADocumentUsingSingleKey_Success` (and `WithAlias`, `WithMultipleDocumentsWithAlias` variants)
- `TestTxnDeletionOfRelatedDoc…` (two variants)
- `TestATxnCanReadARecord…` (two variants)

**3. DocIndex substitution** — a test that used a hardcoded Book DocID now uses `DocIndex` for dynamic resolution.
- `TestBackupSelfRefImport_SplitPrimaryRelationWithSecondCollection_NoError`

**4. New ACP mutation tests** — seven new tests covering the ACP read-permission check on relation fields.
- `TestACP_MutationAdd_RelationTarget_PrivateDoc_NoIdentity_Error`
- `TestACP_MutationAdd_RelationTarget_PrivateDoc_WrongIdentity_Error`
- `TestACP_MutationAdd_RelationTarget_PrivateDoc_OwnerIdentity_NoError`
- `TestACP_MutationAdd_RelationTarget_PrivateDoc_GrantedRead_NoError`
- `TestACP_MutationAdd_RelationTarget_PublicDoc_NoIdentity_NoError`
- `TestACP_MutationUpdate_RelationTarget_PrivateDoc_NoIdentity_Error`
- `TestACP_MutationUpdate_RelationTarget_PrivateDoc_OwnerIdentity_NoError`

**5. New P2P test** — verifies that the sync-path validation does not break normal P2P sync when the relation target is present on the receiving node.
- `TestP2POneToManyPeerWithAddUpdateRelationValidation_NoError`

Tested on:
- MacOS
- Linux (Docker/golang:1.25.9)
