### PR TITLE
feat: Add identity export/recovery to c bindings

### DIFF
--- a/cbindings/errors.go
+++ b/cbindings/errors.go
@@ -15,14 +15,17 @@ import (
 )
 
 const (
-	errNegativeReplicatorTime       = "negative time intervals are not allowed for replicator retries"
-	errAmbiguousCollection          = "more than one collection matches the given criteria"
-	errNoDocIDOrFilter              = "operation requires a DocID or filter"
-	errInvalidAscensionOrder        = "invalid ascension order: expected ASC or DESC"
-	errInvalidIndexFieldDescription = "invalid or malformed field description"
-	errInvalidSubscriptionID        = "invalid subscription ID"
-	errGettingSubscription          = "could not retrieve subscription"
-	errInvalidCGOHandle             = "invalid handle"
+	errNegativeReplicatorTime           = "negative time intervals are not allowed for replicator retries"
+	errAmbiguousCollection              = "more than one collection matches the given criteria"
+	errNoDocIDOrFilter                  = "operation requires a DocID or filter"
+	errInvalidAscensionOrder            = "invalid ascension order: expected ASC or DESC"
+	errInvalidIndexFieldDescription     = "invalid or malformed field description"
+	errInvalidSubscriptionID            = "invalid subscription ID"
+	errGettingSubscription              = "could not retrieve subscription"
+	errInvalidCGOHandle                 = "invalid handle"
+	errIdentiityIsNil                   = "identity is nil"
+	errIdentityDoesNotContainPrivateKey = "identity does not contain a private key"
+	errInvalidPrivateKeyLength          = "private key must be 32 bytes"
 )
 
 func NewErrAmbiguousCollection() error {

--- a/cbindings/identity_export_private_key.go
+++ b/cbindings/identity_export_private_key.go
@@ -1,0 +1,43 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package cbindings
+
+/*
+#include <stdlib.h>
+#include "defra_structs.h"
+*/
+import "C"
+
+import (
+	"encoding/hex"
+
+	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
+)
+
+//export ExportIdentityPrivateKey
+func ExportIdentityPrivateKey(identityPtr C.uintptr_t) C.Result {
+	ident, err := getIdentityFromPointer(identityPtr)
+	if err != nil {
+		return returnC(returnGoC(1, err.Error(), ""))
+	}
+	if ident == nil {
+		return returnC(returnGoC(1, errIdentiityIsNil, ""))
+	}
+
+	fullIdent, ok := ident.(acpIdentity.FullIdentity)
+	if !ok {
+		return returnC(returnGoC(1, errIdentityDoesNotContainPrivateKey, ""))
+	}
+
+	privKeyBytes := fullIdent.PrivateKey().Raw()
+
+	return returnC(GoCResult{Status: 0, Value: hex.EncodeToString(privKeyBytes)})
+}

--- a/cbindings/identity_new_from_private_key.go
+++ b/cbindings/identity_new_from_private_key.go
@@ -20,6 +20,7 @@ import (
 	"encoding/hex"
 
 	"github.com/decred/dcrd/dcrec/secp256k1/v4"
+
 	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/crypto"
 )

--- a/cbindings/identity_new_from_private_key.go
+++ b/cbindings/identity_new_from_private_key.go
@@ -1,0 +1,44 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package cbindings
+
+/*
+#include <stdlib.h>
+#include "defra_structs.h"
+*/
+import "C"
+
+import (
+	"encoding/hex"
+
+	"github.com/decred/dcrd/dcrec/secp256k1/v4"
+	"github.com/sourcenetwork/defradb/acp/identity"
+	"github.com/sourcenetwork/defradb/crypto"
+)
+
+//export NewIdentityFromPrivateKey
+func NewIdentityFromPrivateKey(privateKeyHex *C.char) C.NewIdentityResult {
+	data, err := hex.DecodeString(C.GoString(privateKeyHex))
+	if err != nil {
+		return returnNewIdentityResultC(1, err.Error(), nil)
+	}
+
+	if len(data) != secp256k1.PrivKeyBytesLen {
+		return returnNewIdentityResultC(1, errInvalidPrivateKeyLength, nil)
+	}
+	privKey := secp256k1.PrivKeyFromBytes(data)
+	ident, err := identity.FromPrivateKey(crypto.NewPrivateKey(privKey))
+	if err != nil {
+		return returnNewIdentityResultC(1, err.Error(), nil)
+	}
+
+	return returnNewIdentityResultC(0, "", ident)
+}

--- a/cbindings/identity_recover_test.go
+++ b/cbindings/identity_recover_test.go
@@ -1,0 +1,33 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package cbindings
+
+import "testing"
+
+// This file wraps the unit tests from test_identity_recover.go
+// The purpose is to allow the unit tests to be run by `go test`, which would otherwise have
+// problems due to the CGO directives used by the tests.
+
+func Test_IdentityRecover(t *testing.T) {
+	TestIdentityRecover(t)
+}
+
+func Test_NewIdentityFromPrivateKey_InvalidHex(t *testing.T) {
+	TestNewIdentityFromPrivateKey_InvalidHex(t)
+}
+
+func Test_NewIdentityFromPrivateKey_EmptyKey(t *testing.T) {
+	TestNewIdentityFromPrivateKey_EmptyKey(t)
+}
+
+func Test_ExportIdentityPrivateKey_InvalidPointer(t *testing.T) {
+	TestExportIdentityPrivateKey_InvalidPointer(t)
+}

--- a/cbindings/test_identity_recover.go
+++ b/cbindings/test_identity_recover.go
@@ -1,0 +1,85 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package cbindings
+
+/*
+#include <stdlib.h>
+#include "defra_structs.h"
+*/
+import "C"
+import (
+	"testing"
+	"unsafe"
+)
+
+// Note: This file deliberately avoids the _test.go naming suffix. If it were a _test.go file, `go test`
+// would compile it in a separate test compilation unit, conflicting with the //export directives and
+// func main() present in this package. The tests here are called via wrappers in identity_recover_test.go.
+
+// TestIdentityRecover tests that a new identity can be created, exported, and recovered
+func TestIdentityRecover(t *testing.T) {
+	identResult := NewIdentity(nil)
+	if identResult.status != 0 {
+		t.Fatalf("NewIdentity failed: %s", C.GoString(identResult.error))
+	}
+	defer FreeIdentity(identResult.identityPtr)
+
+	exportResult := ConvertAndFreeCResult(ExportIdentityPrivateKey(identResult.identityPtr))
+	if exportResult.Status != 0 {
+		t.Fatalf("ExportIdentityPrivateKey failed: %s", exportResult.Error)
+	}
+	originalHex := exportResult.Value
+
+	hexKey := C.CString(originalHex)
+	defer C.free(unsafe.Pointer(hexKey))
+	recoveredResult := NewIdentityFromPrivateKey(hexKey)
+	if recoveredResult.status != 0 {
+		t.Fatalf("NewIdentityFromPrivateKey failed: %s", C.GoString(recoveredResult.error))
+	}
+	defer FreeIdentity(recoveredResult.identityPtr)
+
+	reExportResult := ConvertAndFreeCResult(ExportIdentityPrivateKey(recoveredResult.identityPtr))
+	if reExportResult.Status != 0 {
+		t.Fatalf("re-export failed: %s", reExportResult.Error)
+	}
+
+	if originalHex != reExportResult.Value {
+		t.Fatalf("round-trip failed:\n  original:  %s\n  recovered: %s", originalHex, reExportResult.Value)
+	}
+}
+
+// Test_NewIdentityFromPrivateKey_InvalidHex tests that a new identity cannot be created from an invalid hex string
+func TestNewIdentityFromPrivateKey_InvalidHex(t *testing.T) {
+	invalidHex := C.CString("not-valid-hex")
+	defer C.free(unsafe.Pointer(invalidHex))
+	result := NewIdentityFromPrivateKey(invalidHex)
+	if result.status == 0 {
+		t.Fatal("expected error for invalid hex input, got success")
+	}
+}
+
+// Test_NewIdentityFromPrivateKey_EmptyKey tests that a new identity cannot be created from an empty hex string
+func TestNewIdentityFromPrivateKey_EmptyKey(t *testing.T) {
+	emptyKey := C.CString("")
+	defer C.free(unsafe.Pointer(emptyKey))
+	result := NewIdentityFromPrivateKey(emptyKey)
+	if result.status == 0 {
+		t.Fatal("expected error for empty key input, got success")
+	}
+}
+
+// Test_ExportIdentityPrivateKey_InvalidPointer tests that an error is returned when an invalid identity pointer is passed to ExportIdentityPrivateKey
+func TestExportIdentityPrivateKey_InvalidPointer(t *testing.T) {
+	result := ConvertAndFreeCResult(ExportIdentityPrivateKey(0))
+	if result.Status == 0 {
+		t.Fatal("expected error for nil pointer, got success")
+	}
+}

--- a/cbindings/test_identity_recover.go
+++ b/cbindings/test_identity_recover.go
@@ -76,7 +76,8 @@ func TestNewIdentityFromPrivateKey_EmptyKey(t *testing.T) {
 	}
 }
 
-// Test_ExportIdentityPrivateKey_InvalidPointer tests that an error is returned when an invalid identity pointer is passed to ExportIdentityPrivateKey
+// Test_ExportIdentityPrivateKey_InvalidPointer tests that an error is returned when an invalid identity
+// pointer is passed to ExportIdentityPrivateKey
 func TestExportIdentityPrivateKey_InvalidPointer(t *testing.T) {
 	result := ConvertAndFreeCResult(ExportIdentityPrivateKey(0))
 	if result.Status == 0 {


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4797

## Description

Two new functions are added to the cbindings:

`ExportIdentityPrivateKey`
`NewIdentityFromPrivateKey`

These allow the user to export and recover identities in the same manner that they might do, using the CLI. Prior to this PR, identities were returned and used as pointers that persisted only as long as the application (and Go runtime) remained open. This shores up that hole, and allows the user to persist identities across multiple runs of their application.

Unit tests have been created, which test this functionality:

`Test_IdentityRecover`
`Test_NewIdentityFromPrivateKey_InvalidHex`
`Test_NewIdentityFromPrivateKey_EmptyKey`
`Test_ExportIdentityPrivateKey_InvalidPointer`

These have been created inside `identity_recover_test.go` file, with the logic for the tests actually being implemented inside another file, `test_identity_recover.go`. Note the names of these files. This is done so that the tests can utilize the exported C functions. Otherwise, the tests do not place nicely with the CGO directives.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Specify the platform(s) on which this was tested:
- WSL