### PR TITLE
test: Cover re-adding a deleted doc

### DIFF
--- a/internal/db/document.go
+++ b/internal/db/document.go
@@ -244,11 +244,13 @@ func (c *collection) add(
 	if err != nil {
 		return err
 	}
-	if exists {
-		return NewErrDocumentAlreadyExists(primaryKey.DocID)
-	}
+	// isDeleted is checked before exists because a tombstoned doc
+	// still satisfies exists, and the deleted error is more informative.
 	if isDeleted {
 		return NewErrDocumentDeleted(primaryKey.DocID)
+	}
+	if exists {
+		return NewErrDocumentAlreadyExists(primaryKey.DocID)
 	}
 
 	// write value object marker if we have an empty doc

--- a/tests/integration/mutation/add/with_delete_test.go
+++ b/tests/integration/mutation/add/with_delete_test.go
@@ -1,0 +1,101 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// This file is part of the DefraDB test suite.
+//
+// The DefraDB test suite is licensed under either:
+//
+//   (1) GNU Affero General Public License v3
+//   (2) Business Source License 1.1
+//
+// See tests/LICENSE for details.
+
+package add
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/defradb/tests/action"
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+// docIDs in DefraDB are deterministically derived from the document's
+// field values, so re-adding the same payload after delete collides
+// with the tombstoned docID and must error.
+func TestMutationAdd_GivenPreviouslyDeletedDoc_Errors(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type Users {
+						name: String
+						age: Int
+					}
+				`,
+			},
+			&action.AddDoc{
+				Doc: `{
+					"name": "John",
+					"age": 27
+				}`,
+			},
+			testUtils.DeleteDoc{
+				DocID: 0,
+			},
+			&action.AddDoc{
+				Doc: `{
+					"name": "John",
+					"age": 27
+				}`,
+				ExpectedError: "a document with the given ID has been deleted",
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestMutationAdd_GivenPreviouslyDeletedDoc_DocRemainsDeleted(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type Users {
+						name: String
+						age: Int
+					}
+				`,
+			},
+			&action.AddDoc{
+				Doc: `{
+					"name": "John",
+					"age": 27
+				}`,
+			},
+			testUtils.DeleteDoc{
+				DocID: 0,
+			},
+			&action.AddDoc{
+				Doc: `{
+					"name": "John",
+					"age": 27
+				}`,
+				ExpectedError: "a document with the given ID has been deleted",
+			},
+			&action.Request{
+				Request: `
+					query {
+						Users {
+							_docID
+							name
+						}
+					}
+				`,
+				Results: map[string]any{
+					"Users": []map[string]any{},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4697

## Description

Adds integration coverage for `AddDoc → DeleteDoc → AddDoc`. The test surfaced a check-order issue in the Create path: `exists` was tested before `isDeleted`, so callers got `"already exists"` instead of `"has been deleted"`. Swapped the order to match the Save path.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

`go test ./tests/integration/mutation/add/... ./tests/integration/mutation/delete/... ./tests/integration/mutation/update/...` — green under all three mutation types.

- MacOS