### PR TITLE
fix: Normalize trailing slashes on HTTP API routes

### DIFF
--- a/http/handler.go
+++ b/http/handler.go
@@ -19,6 +19,7 @@ import (
 	"github.com/sourcenetwork/defradb/event"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
 )
 
 // IsDevMode is a global variable for the development mode flag
@@ -94,6 +95,13 @@ func NewHandler(db DB) (*Handler, error) {
 	}
 	txs := &sync.Map{}
 	mux := chi.NewMux()
+	// Normalize trailing slashes so `/collections` and `/collections/` resolve to the
+	// same resource instead of the latter missing chi's router and returning a bare 404.
+	// RedirectSlashes sends a 301 to the slashless URL. Registered before any routes so
+	// every HTTP route on this handler is normalized consistently.
+	// NOTE: A 301 lets some clients, e.g. Go's http.Client, downgrade a non-GET method to
+	//       GET when following it; clients that build slashless URLs never hit it.
+	mux.Use(middleware.RedirectSlashes)
 	mux.Route("/api", func(r chi.Router) {
 		r.Use(
 			ApiMiddleware(db, txs),

--- a/http/handler.go
+++ b/http/handler.go
@@ -95,13 +95,13 @@ func NewHandler(db DB) (*Handler, error) {
 	}
 	txs := &sync.Map{}
 	mux := chi.NewMux()
-	// Normalize trailing slashes so `/collections` and `/collections/` resolve to the
-	// same resource instead of the latter missing chi's router and returning a bare 404.
-	// RedirectSlashes sends a 301 to the slashless URL. Registered before any routes so
-	// every HTTP route on this handler is normalized consistently.
-	// NOTE: A 301 lets some clients, e.g. Go's http.Client, downgrade a non-GET method to
-	//       GET when following it; clients that build slashless URLs never hit it.
-	mux.Use(middleware.RedirectSlashes)
+	// Normalize trailing slashes so that, for example, `/collections` and
+	// `/collections/` resolve to the same route instead of the latter missing
+	// chi's router and returning a bare 404. StripSlashes rewrites the routing
+	// path in place (no redirect), preserving the request method and body.
+	// It is registered before any routes so every HTTP route on this handler
+	// is normalized consistently.
+	mux.Use(middleware.StripSlashes)
 	mux.Route("/api", func(r chi.Router) {
 		r.Use(
 			ApiMiddleware(db, txs),

--- a/http/handler_store_test.go
+++ b/http/handler_store_test.go
@@ -12,6 +12,7 @@ package http
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -24,8 +25,8 @@ import (
 )
 
 // chi treats `collections` and `collections/` as separate routes, so without
-// normalization the trailing-slash form 404s. RedirectSlashes sends a 301 to the
-// slashless canonical URL (query preserved); verify the GET (describe) endpoint does so.
+// normalization the trailing-slash form 404s. Verify StripSlashes routes both to the
+// same handler.
 func TestHandler_GetCollectionWithTrailingSlash(t *testing.T) {
 	cdb := setupDatabase(t)
 
@@ -37,25 +38,34 @@ func TestHandler_GetCollectionWithTrailingSlash(t *testing.T) {
 	handler.ServeHTTP(rec, req)
 
 	res := rec.Result()
-	require.Equal(t, http.StatusMovedPermanently, res.StatusCode)
-	require.Equal(t, "/api/v1/collections?name=User", res.Header.Get("Location"))
+	body, err := io.ReadAll(res.Body)
+	require.NoError(t, err)
+
+	require.Equalf(t, http.StatusOK, res.StatusCode, "expected 200, got %d: %s", res.StatusCode, string(body))
 }
 
-// Same trailing-slash redirect as the GET case, on the delete endpoint. The 301 is
-// method-agnostic; whether the followed request stays a DELETE is up to the client.
+// Trailing-slash normalization for the collection delete endpoint; see the GET case.
 func TestHandler_DeleteCollectionWithTrailingSlash(t *testing.T) {
 	cdb := setupDatabase(t)
+
+	// delete refuses a collection with documents, so use an empty one
+	_, err := cdb.AddCollection(context.Background(), `type Author {
+		name: String
+	}`)
+	require.NoError(t, err)
 
 	handler, err := NewHandler(cdb)
 	require.NoError(t, err)
 
-	req := httptest.NewRequest(http.MethodDelete, "http://localhost:9181/api/v1/collections/?name=Book", nil)
+	req := httptest.NewRequest(http.MethodDelete, "http://localhost:9181/api/v1/collections/?name=Author", nil)
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
 
 	res := rec.Result()
-	require.Equal(t, http.StatusMovedPermanently, res.StatusCode)
-	require.Equal(t, "/api/v1/collections?name=Book", res.Header.Get("Location"))
+	body, err := io.ReadAll(res.Body)
+	require.NoError(t, err)
+
+	require.Equalf(t, http.StatusOK, res.StatusCode, "expected 200, got %d: %s", res.StatusCode, string(body))
 }
 
 func TestExecRequest_WithValidQuery_OmitsErrors(t *testing.T) {

--- a/http/handler_store_test.go
+++ b/http/handler_store_test.go
@@ -23,6 +23,41 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// chi treats `collections` and `collections/` as separate routes, so without
+// normalization the trailing-slash form 404s. RedirectSlashes sends a 301 to the
+// slashless canonical URL (query preserved); verify the GET (describe) endpoint does so.
+func TestHandler_GetCollectionWithTrailingSlash(t *testing.T) {
+	cdb := setupDatabase(t)
+
+	handler, err := NewHandler(cdb)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "http://localhost:9181/api/v1/collections/?name=User", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	res := rec.Result()
+	require.Equal(t, http.StatusMovedPermanently, res.StatusCode)
+	require.Equal(t, "/api/v1/collections?name=User", res.Header.Get("Location"))
+}
+
+// Same trailing-slash redirect as the GET case, on the delete endpoint. The 301 is
+// method-agnostic; whether the followed request stays a DELETE is up to the client.
+func TestHandler_DeleteCollectionWithTrailingSlash(t *testing.T) {
+	cdb := setupDatabase(t)
+
+	handler, err := NewHandler(cdb)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodDelete, "http://localhost:9181/api/v1/collections/?name=Book", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	res := rec.Result()
+	require.Equal(t, http.StatusMovedPermanently, res.StatusCode)
+	require.Equal(t, "/api/v1/collections?name=Book", res.Header.Get("Location"))
+}
+
 func TestExecRequest_WithValidQuery_OmitsErrors(t *testing.T) {
 	cdb := setupDatabase(t)
 


### PR DESCRIPTION
## Relevant issue(s)
Resolves #4855

## Description
HTTP requests with a trailing slash before the query string (e.g. `DELETE /api/v1/collections/?name=Book`) returned a bare `404 page not found`.

chi matches paths exactly, so `/collections/` matched neither `/collections` nor `/collections/{name}` and fell through to the router's not-found handler.

The CLI and Go/JS clients were unaffected because they build slashless URLs, so this only surfaced for hand-crafted requests (curl/Postman).

Registers chi's `StripSlashes` middleware once in `NewHandler`, before any routes, so `/x` and `/x/` resolve to the same handler across every HTTP route.

`StripSlashes` (rather than `RedirectSlashes`) rewrites the routing path in place with no redirect, preserving the request method
