### PR TITLE
fix: Make DAC enabled by default

### DIFF
--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -107,7 +107,7 @@ var ConfigDefaults = map[string]any{
 	"datastore.nosigning":               false,
 	"datastore.nosearchableencryption":  false,
 	"datastore.defaultkeytype":          "secp256k1",
-	"acp.document.type":                 "none",
+	"acp.document.type":                 "local",
 	"replicator.retryintervals":         []int{30, 60, 120, 240, 480, 960, 1920},
 }
 

--- a/cli/start.go
+++ b/cli/start.go
@@ -343,7 +343,7 @@ func MakeStartCommand(ctx context.Context) *cobra.Command {
 	cmd.PersistentFlags().String(
 		"document-acp-type",
 		cfg.GetString(config.ConfigFlags["document-acp-type"]),
-		"Specify the document acp engine to use (supported: none (default), local, source-hub)")
+		"Specify the document acp engine to use (supported: none, local (default), source-hub)")
 	cmd.PersistentFlags().IntSlice(
 		"replicator-retry-intervals",
 		cfg.GetIntSlice(config.ConfigFlags["replicator-retry-intervals"]),

--- a/docs/website/references/cli/defradb_start.md
+++ b/docs/website/references/cli/defradb_start.md
@@ -18,7 +18,7 @@ defradb start [flags]
       --development                       Enables a set of features that make development easier but should not be enabled in production:
                                            - allows purging of all persisted data
                                            - generates temporary node identity if one doesn't exist in the keyring
-      --document-acp-type string          Specify the document acp engine to use (supported: none (default), local, source-hub) (default "none")
+      --document-acp-type string          Specify the document acp engine to use (supported: none, local (default), source-hub) (default "local")
   -h, --help                              help for start
   -i, --identity string                   Hex formatted private key used to authenticate with ACP
       --max-txn-retries int               Specify the maximum number of retries per transaction (default 5)


### PR DESCRIPTION
## Relevant issue(s)
Resolves #4824 

## Description
Change the CLI default for acp.document.type from none to local so defradb start runs with document access control enabled by default. The node library default (DefaultNodeOptions) was already local; the CLI config was the only thing overriding it to none.
Collections without a `@policy` remain public; collections with a `@policy` are now enforced by default. 