### PR TITLE
fix: Improve wizard hint text visibility on dark terminals

### DIFF
--- a/cli/wizard/style.go
+++ b/cli/wizard/style.go
@@ -44,8 +44,7 @@ var (
 			Width(80)
 
 	hintStyle = lipgloss.NewStyle().
-			Faint(true).
-			Foreground(lipgloss.Color("240")).
+			Foreground(lipgloss.Color("249")).
 			MarginTop(1)
 
 	singleLineInputBox = lipgloss.NewStyle().


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4820

## Description
The wizard hint text  was nearly invisible on dark terminals due to Faint(true) with dark gray color "240". Removed Faint(true) and lightened the color to "249" for better readability.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Manually ran ./defradb wizard and verified hint text is visible on a dark terminal background.

Specify the platform(s) on which this was tested:
- Debian Linux
