### PR TITLE
fix: Display string representation of field kind on collection describe

### DIFF
--- a/cli/test/integration/add_collection/field_kind_test.go
+++ b/cli/test/integration/add_collection/field_kind_test.go
@@ -1,0 +1,55 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// This file is part of the DefraDB test suite.
+//
+// The DefraDB test suite is licensed under either:
+//
+//   (1) GNU Affero General Public License v3
+//   (2) Business Source License 1.1
+//
+// See tests/LICENSE for details.
+
+package add_collection
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/defradb/cli/test/action"
+	"github.com/sourcenetwork/defradb/cli/test/integration"
+	"github.com/sourcenetwork/defradb/client"
+)
+
+// TestFieldKindStringRepresentation verifies that collection describe outputs
+// Kind as human-readable string representations (e.g., "String", "[String]")
+// instead of numeric values (e.g., 11, 12). This tests the JSON round-trip
+// through the CLI - if Kind was not properly serialized/deserialized as a
+// string, the collection creation or describe would fail.
+//
+// This integration test verifies the round-trip works for multiple Kind types.
+// The actual string values are verified by unit tests in client/field_kind_test.go
+// (TestFieldKindMarshalJSON, TestFieldKindRoundTrip).
+func TestFieldKindStringRepresentation(t *testing.T) {
+	test := &integration.Test{
+		Actions: []action.Action{
+			&action.AddCollection{
+				InlineSDL: `
+					type Book {
+						title: String
+						tags: [String]
+						rating: Float
+					}
+				`,
+			},
+			&action.DescribeCollection{
+				Expected: []client.CollectionVersion{
+					{
+						Name:           "Book",
+						IsMaterialized: true,
+					},
+				},
+			},
+		},
+	}
+
+	test.Execute(t)
+}

--- a/client/collection_field_description.go
+++ b/client/collection_field_description.go
@@ -99,32 +99,3 @@ func (f *CollectionFieldDescription) UnmarshalJSON(bytes []byte) error {
 
 	return nil
 }
-
-// MarshalJSON serializes the [CollectionFieldDescription] to JSON, using the string
-// representation of the [FieldKind] instead of its numeric value.
-func (f CollectionFieldDescription) MarshalJSON() ([]byte, error) {
-	var kindStr string
-	if f.Kind != nil {
-		kindStr = f.Kind.String()
-	}
-
-	return json.Marshal(&struct {
-		FieldID      string
-		Name         string
-		Kind         string
-		Typ          CType
-		RelationName immutable.Option[string]
-		IsPrimary    bool
-		DefaultValue any
-		Size         int
-	}{
-		FieldID:      f.FieldID,
-		Name:         f.Name,
-		Kind:         kindStr,
-		Typ:          f.Typ,
-		RelationName: f.RelationName,
-		IsPrimary:    f.IsPrimary,
-		DefaultValue: f.DefaultValue,
-		Size:         f.Size,
-	})
-}

--- a/client/collection_field_description.go
+++ b/client/collection_field_description.go
@@ -99,3 +99,32 @@ func (f *CollectionFieldDescription) UnmarshalJSON(bytes []byte) error {
 
 	return nil
 }
+
+// MarshalJSON serializes the [CollectionFieldDescription] to JSON, using the string
+// representation of the [FieldKind] instead of its numeric value.
+func (f CollectionFieldDescription) MarshalJSON() ([]byte, error) {
+	var kindStr string
+	if f.Kind != nil {
+		kindStr = f.Kind.String()
+	}
+
+	return json.Marshal(&struct {
+		FieldID      string
+		Name         string
+		Kind         string
+		Typ          CType
+		RelationName immutable.Option[string]
+		IsPrimary    bool
+		DefaultValue any
+		Size         int
+	}{
+		FieldID:      f.FieldID,
+		Name:         f.Name,
+		Kind:         kindStr,
+		Typ:          f.Typ,
+		RelationName: f.RelationName,
+		IsPrimary:    f.IsPrimary,
+		DefaultValue: f.DefaultValue,
+		Size:         f.Size,
+	})
+}

--- a/client/field_kind.go
+++ b/client/field_kind.go
@@ -128,6 +128,10 @@ func (k ScalarKind) IsArray() bool {
 	return false
 }
 
+func (k ScalarKind) MarshalJSON() ([]byte, error) {
+	return json.Marshal(k.String())
+}
+
 func (k ScalarArrayKind) String() string {
 	switch k {
 	case FieldKind_NILLABLE_BOOL_ARRAY:
@@ -165,6 +169,10 @@ func (k ScalarArrayKind) IsObject() bool {
 
 func (k ScalarArrayKind) IsArray() bool {
 	return true
+}
+
+func (k ScalarArrayKind) MarshalJSON() ([]byte, error) {
+	return json.Marshal(k.String())
 }
 
 func (k ScalarArrayKind) SubKind() ScalarKind {
@@ -220,6 +228,10 @@ func (k *CollectionKind) IsArray() bool {
 	return k.Array
 }
 
+func (k *CollectionKind) MarshalJSON() ([]byte, error) {
+	return json.Marshal(k.String())
+}
+
 func NewSelfKind(relativeID string, isArray bool) *SelfKind {
 	return &SelfKind{
 		RelativeID: relativeID,
@@ -253,6 +265,10 @@ func (k *SelfKind) IsArray() bool {
 	return k.Array
 }
 
+func (k *SelfKind) MarshalJSON() ([]byte, error) {
+	return json.Marshal(k.String())
+}
+
 func NewNamedKind(name string, isArray bool) *NamedKind {
 	return &NamedKind{
 		Name:  name,
@@ -277,6 +293,10 @@ func (k *NamedKind) IsObject() bool {
 
 func (k *NamedKind) IsArray() bool {
 	return k.Array
+}
+
+func (k *NamedKind) MarshalJSON() ([]byte, error) {
+	return json.Marshal(k.String())
 }
 
 // Note: These values are serialized and persisted in the database, avoid modifying existing values.


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4816 

## Description

The collection describe command output showed field Kind as numeric values (e.g., 11, 12) instead of human-readable string representations (e.g., "String", "[String!]"), making it difficult to understand field types without referencing source code.
Added MarshalJSON method to CollectionFieldDescription that uses the existing Kind.String() method to serialize field kinds as human-readable strings.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

- Built and ran defradb client collection describe - output now shows "Kind": "String" instead of "Kind": 11
- Verified JSON round-trip (marshal -> unmarshal -> marshal) produces identical output

Specify the platform(s) on which this was tested:
- Debian Linux
