### PR TITLE
fix: Fix net relay bug in CLI

### DIFF
--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -62,6 +62,7 @@ var ConfigFlags = map[string]string{
 	"peers":                      "net.peers",
 	"p2paddr":                    "net.p2paddresses",
 	"no-p2p":                     "net.p2pdisabled",
+	"relay":                      "net.relay",
 	"allowed-origins":            "api.allowed-origins",
 	"pubkeypath":                 "api.pubkeypath",
 	"privkeypath":                "api.privkeypath",

--- a/cli/start.go
+++ b/cli/start.go
@@ -101,7 +101,7 @@ func MakeStartCommand(ctx context.Context) *cobra.Command {
 			opts.P2P().
 				SetListenAddresses(cfg.GetStringSlice("net.p2pAddresses")...).
 				SetEnablePubSub(cfg.GetBool("net.pubSubEnabled")).
-				SetEnableRelay(cfg.GetBool("net.relayEnabled")).
+				SetEnableRelay(cfg.GetBool("net.relay")).
 				SetBootstrapPeers(cfg.GetStringSlice("net.peers")...)
 			opts.HTTP().
 				SetAddress(cfg.GetString("api.address")).
@@ -286,6 +286,11 @@ func MakeStartCommand(ctx context.Context) *cobra.Command {
 		"no-p2p",
 		cfg.GetBool(config.ConfigFlags["no-p2p"]),
 		"Disable the peer-to-peer network synchronization system",
+	)
+	cmd.PersistentFlags().Bool(
+		"relay",
+		cfg.GetBool(config.ConfigFlags["relay"]),
+		"Enable the p2p relay",
 	)
 	cmd.PersistentFlags().StringArray(
 		"allowed-origins",

--- a/docs/website/references/cli/defradb_start.md
+++ b/docs/website/references/cli/defradb_start.md
@@ -32,6 +32,7 @@ defradb start [flags]
       --peers stringArray                 List of peers to connect to
       --privkeypath string                Path to the private key for tls
       --pubkeypath string                 Path to the public key for tls
+      --relay                             Enable the p2p relay
       --replicator-retry-intervals ints   Retry intervals for the replicator. Format is a comma-separated list of whole number seconds. Example: 10,20,40,80,160,320 (default [30,60,120,240,480,960,1920])
       --store string                      Specify the datastore to use (supported: badger, memory) (default "badger")
       --valuelogfilesize int              Specify the datastore value log file size (in bytes). In memory size will be 2*valuelogfilesize (default 1073741824)


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4883 

## Description

As the issue details, the CLI was attempting to apply a flag that didn't exist, using `relayEnabled` instead of `relay`. This fixes that. As an addendum to the issue, this also adds a flag to the CLI to pass in this value manually (this did not exist previously.)

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Specify the platform(s) on which this was tested:
- WSL