### PR TITLE
fix: Handle the refresh of views larger than 11MB

### DIFF
--- a/client/db.go
+++ b/client/db.go
@@ -284,7 +284,7 @@ type Store interface {
 	// when making this call.
 	//
 	// This function will lock the selected views until it completes.  Its writes are not protected by transactions,
-	// so it errors, the database may be left in a state where the view has been partially refreshed - in this case,
+	// so if it errors, the database may be left in a state where the view has been partially refreshed - in this case,
 	// it is recommeded to retry the refresh.
 	RefreshViews(ctx context.Context, opts ...options.Enumerable[options.RefreshViewsOptions]) error
 

--- a/client/db.go
+++ b/client/db.go
@@ -282,6 +282,10 @@ type Store interface {
 	// The cached result is dependent on the ACP settings of the source data and the permissions of the user making
 	// the call.  At the moment only one cache can be active at a time, so please pay attention to access rights
 	// when making this call.
+	//
+	// This function will lock the selected views until it completes.  Its writes are not protected by transactions,
+	// so it errors, the database may be left in a state where the view has been partially refreshed - in this case,
+	// it is recommeded to retry the refresh.
 	RefreshViews(ctx context.Context, opts ...options.Enumerable[options.RefreshViewsOptions]) error
 
 	// SetMigration sets the migration for all collections using the given source-destination collection version IDs.

--- a/internal/db/collection_define.go
+++ b/internal/db/collection_define.go
@@ -353,25 +353,7 @@ existingVersionLoop:
 			}
 		}
 
-		if colExists {
-			if existingCol.IsMaterialized && !col.IsMaterialized {
-				// If the collection is being de-materialized - delete any cached values.
-				// Leaving them around will not break anything, but it would be a waste of
-				// storage space.
-
-				txn := datastore.CtxTryGetTxnOption(ctx)
-
-				colObject, err := db.newCollection(col, txn)
-				if err != nil {
-					return err
-				}
-
-				err = colObject.truncate(ctx)
-				if err != nil {
-					return err
-				}
-			}
-		} else if col.PreviousVersion.HasValue() && migration.HasValue() {
+		if !colExists && col.PreviousVersion.HasValue() && migration.HasValue() {
 			_, err = db.setMigration(ctx, client.LensConfig{
 				SourceCollectionVersionID:      col.PreviousVersion.Value().SourceCollectionID,
 				DestinationCollectionVersionID: col.VersionID,

--- a/internal/db/collection_define.go
+++ b/internal/db/collection_define.go
@@ -358,7 +358,15 @@ existingVersionLoop:
 				// If the collection is being de-materialized - delete any cached values.
 				// Leaving them around will not break anything, but it would be a waste of
 				// storage space.
-				err := db.clearViewCache(ctx, col)
+
+				txn := datastore.CtxTryGetTxnOption(ctx)
+
+				colObject, err := db.newCollection(col, txn)
+				if err != nil {
+					return err
+				}
+
+				err = colObject.truncate(ctx)
 				if err != nil {
 					return err
 				}

--- a/internal/db/definition_validation.go
+++ b/internal/db/definition_validation.go
@@ -21,6 +21,8 @@ import (
 	"github.com/sourcenetwork/defradb/client/request"
 	"github.com/sourcenetwork/defradb/errors"
 	"github.com/sourcenetwork/defradb/internal/datastore"
+	"github.com/sourcenetwork/defradb/internal/db/id"
+	"github.com/sourcenetwork/defradb/internal/keys"
 )
 
 // definitionState holds collection descriptions in easily accessible
@@ -141,6 +143,7 @@ var updateOnlyValidators = []definitionValidator{
 	validateFieldNotMutated,
 	validateFieldNotMoved,
 	validateCollectionNameNotMutated,
+	validateDematerializedViewHasNoData,
 }
 
 var collectionUpdateValidators = append(
@@ -1285,6 +1288,62 @@ func validateEncryptedIndexes(
 	for _, newCol := range newState.collections {
 		if err := validateEncryptedIndexesOnCollection(newCol); err != nil {
 			errs = append(errs, err)
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+func validateDematerializedViewHasNoData(
+	ctx context.Context,
+	db *DB,
+	newState *definitionState,
+	oldState *definitionState,
+) error {
+	var errs []error
+	for _, col := range newState.collections {
+		if col.IsMaterialized {
+			continue
+		}
+
+		oldCol, ok := oldState.collectionsByID[col.VersionID]
+		if !ok {
+			continue
+		}
+
+		if !oldCol.IsMaterialized {
+			continue
+		}
+
+		txn := datastore.CtxMustGetTxn(ctx)
+
+		shortID, err := id.GetShortCollectionID(ctx, col.CollectionID)
+		if err != nil {
+			return err
+		}
+
+		iter, err := txn.Datastore().Iterator(ctx, datastore.IterOptions{
+			Prefix:   keys.NewViewCacheColPrefix(shortID),
+			KeysOnly: true,
+		})
+		if err != nil {
+			return err
+		}
+
+		hasValue, err := iter.Next()
+		if err != nil {
+			return errors.Join(err, iter.Close())
+		}
+
+		if hasValue {
+			errs = append(errs,
+				NewErrDematerializePopulatedView(col.Name, col.VersionID),
+			)
+		}
+
+		err = iter.Close()
+		if err != nil {
+			return err
 		}
 	}
 

--- a/internal/db/errors.go
+++ b/internal/db/errors.go
@@ -190,6 +190,8 @@ const (
 	errCreateDeleteIndexIterator  string = "failed to create iterator for index deletion"
 	errCreateViewCacheIterator    string = "failed to create view cache iterator"
 	errTxnDiscarded               string = "this transaction has been discarded. Create a new one"
+	errDematerializePopulatedView string = "cannot dematerialize a materialized view that has data," +
+		" first truncate it and then try again."
 )
 
 var (
@@ -263,6 +265,7 @@ var (
 	ErrEncryptedIndexDoesNotExist                = errors.New(errEncryptedIndexDoesNotExist)
 	ErrReplicatorExists                          = errors.New(errReplicatorExists)
 	ErrTxnDiscarded                              = errors.New(errTxnDiscarded)
+	ErrDematerializePopulatedView                = errors.New(errDematerializePopulatedView)
 )
 
 // NewErrFailedToGetHeads returns a new error indicating that the heads of a document
@@ -1156,4 +1159,12 @@ func NewErrDeleteViewCacheItem(inner error) error {
 
 func NewErrParseViewCacheKey(inner error) error {
 	return errors.Wrap(errParseViewCacheKey, inner)
+}
+
+func NewErrDematerializePopulatedView(name string, version string) error {
+	return errors.New(
+		errDematerializePopulatedView,
+		errors.NewKV("Name", name),
+		errors.NewKV("VersionID", version),
+	)
 }

--- a/internal/db/view.go
+++ b/internal/db/view.go
@@ -171,8 +171,6 @@ func (db *DB) getViews(ctx context.Context, opts *options.GetCollectionsOptions)
 }
 
 func (db *DB) buildViewCache(ctx context.Context, col client.CollectionVersion) (err error) {
-	txn := datastore.CtxMustGetTxn(ctx)
-
 	p := planner.New(
 		ctx,
 		identity.FromContext(ctx),
@@ -234,6 +232,8 @@ func (db *DB) buildViewCache(ctx context.Context, col client.CollectionVersion) 
 		return err
 	}
 
+	ds := datastore.NewMultistore(db.rootstore, db.lockSet, db.blockStoreChunkSize).Datastore()
+
 	// View items are currently keyed by their index, starting at 1.
 	// The order in which results are returned must be consistent with the results of the
 	// underlying query/transform.
@@ -252,7 +252,7 @@ func (db *DB) buildViewCache(ctx context.Context, col client.CollectionVersion) 
 		}
 
 		itemKey := keys.NewViewCacheKey(shortID, itemID)
-		err = txn.Datastore().Set(ctx, itemKey, serializedItem)
+		err = ds.Set(ctx, itemKey, serializedItem)
 		if err != nil {
 			return NewErrStoreViewCacheItem(err)
 		}

--- a/internal/db/view.go
+++ b/internal/db/view.go
@@ -130,10 +130,15 @@ func (db *DB) refreshViews(ctx context.Context, opts *options.GetCollectionsOpti
 		}
 		db.lockSet.CollectionLock(txn, shortID)
 
+		colObject, err := db.newCollection(col, immutable.Some(txn))
+		if err != nil {
+			return err
+		}
+
 		// Clearing and then constructing is a bit inefficient, but it should do for now.
 		// Long term we probably want to update inline as much as possible to avoid unnessecarily
 		// moving/adding/deleting keys in storage
-		err := db.clearViewCache(ctx, col)
+		err = colObject.truncate(ctx)
 		if err != nil {
 			return err
 		}
@@ -259,45 +264,6 @@ func (db *DB) buildViewCache(ctx context.Context, col client.CollectionVersion) 
 	}
 
 	return nil
-}
-
-func (db *DB) clearViewCache(ctx context.Context, col client.CollectionVersion) error {
-	txn := datastore.CtxMustGetTxn(ctx)
-
-	shortID, err := id.GetShortCollectionID(ctx, col.CollectionID)
-	if err != nil {
-		return err
-	}
-
-	iter, err := txn.Datastore().Iterator(ctx, datastore.IterOptions{
-		Prefix:   keys.NewViewCacheColPrefix(shortID),
-		KeysOnly: true,
-	})
-	if err != nil {
-		return NewErrCreateViewCacheIterator(err)
-	}
-
-	for {
-		hasNext, err := iter.Next()
-		if err != nil {
-			return errors.Join(err, iter.Close())
-		}
-		if !hasNext {
-			break
-		}
-
-		key, err := keys.NewViewCacheKeyFromRaw(iter.Key())
-		if err != nil {
-			return errors.Join(NewErrParseViewCacheKey(err), iter.Close())
-		}
-
-		err = txn.Datastore().Delete(ctx, key)
-		if err != nil {
-			return errors.Join(NewErrDeleteViewCacheItem(err), iter.Close())
-		}
-	}
-
-	return iter.Close()
 }
 
 func (db *DB) generateMaximalSelectFromCollection(

--- a/internal/db/view.go
+++ b/internal/db/view.go
@@ -116,11 +116,19 @@ func (db *DB) refreshViews(ctx context.Context, opts *options.GetCollectionsOpti
 		return err
 	}
 
+	txn := datastore.CtxMustGetTxn(ctx)
+
 	for _, col := range cols {
 		if !col.IsMaterialized {
 			// We only care about materialized views here, so skip any that aren't
 			continue
 		}
+
+		shortID, err := id.GetShortCollectionID(ctx, col.CollectionID)
+		if err != nil {
+			return err
+		}
+		db.lockSet.CollectionLock(txn, shortID)
 
 		// Clearing and then constructing is a bit inefficient, but it should do for now.
 		// Long term we probably want to update inline as much as possible to avoid unnessecarily

--- a/tests/integration/collection_version/updates/replace/materialized_test.go
+++ b/tests/integration/collection_version/updates/replace/materialized_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sourcenetwork/defradb/client/options"
 	"github.com/sourcenetwork/defradb/tests/action"
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	"github.com/sourcenetwork/immutable"
 )
 
 func TestColVersionUpdateReplaceIsMaterialized_GivenFalseAndCollection_Errors(t *testing.T) {
@@ -41,6 +42,54 @@ func TestColVersionUpdateReplaceIsMaterialized_GivenFalseAndCollection_Errors(t 
 					]
 				`,
 				ExpectedError: "non-materialized collections are not supported. Collection: User",
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestColVersionUpdateReplaceIsMaterialized_GivenFalseAndView_ErrorsIfNotTruncated(t *testing.T) {
+	test := testUtils.TestCase{
+		SupportedViewTypes: immutable.Some([]testUtils.ViewType{
+			testUtils.MaterializedViewType,
+		}),
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type User {
+						name: String
+					}
+				`,
+			},
+			&action.AddDoc{
+				DocMap: map[string]any{
+					"name": "John",
+				},
+			},
+			&action.AddView{
+				Query: `
+					User {
+						name
+					}
+				`,
+				SDL: `
+					type UserView {
+						name: String
+					}
+				`,
+			},
+			&action.PatchCollection{
+				Patch: `
+					[
+						{
+							"op": "replace",
+							"path": "/UserView/IsMaterialized",
+							"value": false
+						}
+					]
+				`,
+				ExpectedError: "cannot dematerialize a materialized view that has data, first truncate it and then try again.",
 			},
 		},
 	}
@@ -75,6 +124,10 @@ func TestColVersionUpdateReplaceIsMaterialized_GivenFalseAndView(t *testing.T) {
 				DocMap: map[string]any{
 					"name": "John",
 				},
+			},
+			&action.Truncate{
+				// Truncate the view before setting IsMaterialized to false
+				CollectionIndex: 1,
 			},
 			&action.PatchCollection{
 				Patch: `

--- a/tests/integration/txn/refresh_view_test.go
+++ b/tests/integration/txn/refresh_view_test.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/sourcenetwork/defradb/tests/action"
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
-	"github.com/sourcenetwork/defradb/tests/state"
 	"github.com/sourcenetwork/immutable"
 )
 
@@ -78,75 +77,6 @@ func TestTxn_RefreshView_WithCommit_Succeeds(t *testing.T) {
 						},
 						{
 							"name": "Fred",
-						},
-					},
-				},
-			},
-		},
-	}
-
-	testUtils.ExecuteTestCase(t, test)
-}
-
-// This test runs RefreshViews inside of a transaction, and illustrates that not committing the transaction
-// results in the view not being refreshed.
-func TestTxn_RefreshView_WithoutCommit_DoesNotRefresh(t *testing.T) {
-	test := testUtils.TestCase{
-		// LevelDB does not support concurrent transactions
-		// todo: https://github.com/sourcenetwork/defradb/issues/4442
-		SupportedDatabaseTypes: immutable.Some([]state.DatabaseType{
-			testUtils.BadgerFileType,
-			testUtils.BadgerIMType,
-			testUtils.DefraIMType,
-		}),
-		SupportedViewTypes: immutable.Some([]testUtils.ViewType{
-			testUtils.MaterializedViewType,
-		}),
-		Actions: []any{
-			&action.AddCollection{
-				SDL: `
-					type User {
-						name: String
-					}
-				`,
-			},
-			&action.AddDoc{
-				Doc: `{
-					"name":	"John"
-				}`,
-			},
-			&action.AddView{
-				Query: `
-					User {
-						name
-					}
-				`,
-				SDL: `
-					type UserView {
-						name: String
-					}
-				`,
-			},
-			&action.AddDoc{
-				Doc: `{
-					"name":	"Fred"
-				}`,
-			},
-			&action.RefreshViews{
-				TransactionID: immutable.Some(1),
-			},
-			&action.Request{
-				DoNotRefreshViews: true,
-				NonOrderedResults: true,
-				Request: `query {
-							UserView {
-								name
-							}
-						}`,
-				Results: map[string]any{
-					"UserView": []map[string]any{
-						{
-							"name": "John",
 						},
 					},
 				},


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4386

## Description

Handles the refreshing of views larger than 11MB by using collection-locks instead of transactions, due to store-level transaction size limits.

Additional testing of this fix is blocked behind the nightly build issue, as I don't want to slow down the normal test runs by creating and refreshing large volumes of data. There are existing tests for view refresh that test using small amounts of data.

Some additional context/rational is provided by the commit messages. 

