### PR TITLE
fix: Fix LensVM stackoverflow

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -53,7 +53,7 @@ require (
 	github.com/sourcenetwork/goji v0.0.10
 	github.com/sourcenetwork/graphql-go v0.7.10-0.20260603160416-fba12ae14d3b
 	github.com/sourcenetwork/immutable v0.3.0
-	github.com/sourcenetwork/lens/host-go v0.10.0
+	github.com/sourcenetwork/lens/host-go v0.11.0
 	github.com/sourcenetwork/sourcehub v0.4.1-0.20260128164915-1bce44032618
 	github.com/sourcenetwork/testo v0.2.0
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -1815,8 +1815,8 @@ github.com/sourcenetwork/graphql-go v0.7.10-0.20260603160416-fba12ae14d3b h1:NAx
 github.com/sourcenetwork/graphql-go v0.7.10-0.20260603160416-fba12ae14d3b/go.mod h1:rkahXkgRH/3vZErN1Bx+qt1+w+CV5fgaJyKKWgISe4U=
 github.com/sourcenetwork/immutable v0.3.0 h1:gHPtGvLrTBTK5YpDAhMU+u+S8v1F6iYmc3nbZLryMdc=
 github.com/sourcenetwork/immutable v0.3.0/go.mod h1:GD7ceuh/HD7z6cdIwzKK2ctzgZ1qqYFJpsFp+8qYnbI=
-github.com/sourcenetwork/lens/host-go v0.10.0 h1:mv7mxP3LTP6YKjyYzWBKPetEZ+o0I2kJOVHpnLNPqLI=
-github.com/sourcenetwork/lens/host-go v0.10.0/go.mod h1:LHIuko88fgxOX996hvRNuBbgdTeFIPLQO6OXj24vmsM=
+github.com/sourcenetwork/lens/host-go v0.11.0 h1:B9aNdRaYh6P5gBxhUOTUS9geyq8Pl3I/ps0w6Y4xt9k=
+github.com/sourcenetwork/lens/host-go v0.11.0/go.mod h1:LHIuko88fgxOX996hvRNuBbgdTeFIPLQO6OXj24vmsM=
 github.com/sourcenetwork/raccoondb v0.2.1-0.20240722161350-d4a78b691ec8 h1:d0jNogSYqMt+dC05tnd+x7lmzEcBHpKoIU5woZSSHFM=
 github.com/sourcenetwork/raccoondb v0.2.1-0.20240722161350-d4a78b691ec8/go.mod h1:/WJdZWouiY199DypsN0xaP5PF0zy3rka3FxH5Y8o9Bc=
 github.com/sourcenetwork/raccoondb/v2 v2.0.0 h1:Gb0SjsZUbrbkHCEg7PyyNs0+2IzPxjE/BkEQnlu1nfA=


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4881

## Description

Updates to the latest LensVM version, which includes a fix for a memory leak/stack overflow in the lens wasm runtimes. 