### PR TITLE
chore: Add internal debug package for troubleshooting

### DIFF
--- a/internal/debug/README.md
+++ b/internal/debug/README.md
@@ -1,0 +1,140 @@
+# debug
+
+Diagnostics utilities. Not for production use.
+
+## Tracer
+
+Prefixed, indented prints for call-graph visibility. `Enter` increases
+indentation; the returned func reverses it on `defer`. Lines are atomic
+across goroutines (global mutex around each write).
+
+```go
+var trace = debug.NewTracer("fetcher")
+
+func (f *Fetcher) Next() (*Doc, error) {
+    defer trace.Enter("Fetcher.Next", f)()
+    trace.Println("acquiring iterator prefix=%s", f.prefix)
+
+    doc, err := f.read()
+    if err != nil {
+        trace.Println("read FAILED: %v", err)
+        return nil, err
+    }
+    trace.Println("read OK docID=%s", doc.ID)
+    return doc, nil
+}
+```
+
+Output (note the indentation tracks the call stack, source-location is on):
+
+```text
+fetcher:      > Fetcher.Next (14000af1b90)        | fetcher.go:42
+fetcher:          acquiring iterator prefix=/col/1 | fetcher.go:43
+fetcher:          > Fetcher.read (14000af1b90)    | fetcher.go:88
+fetcher:              loaded 312 bytes            | fetcher.go:101
+fetcher:          read OK docID=bae-123           | fetcher.go:50
+```
+
+Disable a tracer (`Disable()`) to silence one subsystem without recompiling.
+Globals: `debug.PrefixWidth` (default 12), `debug.ShowSourceLocation` (default true).
+
+## Timeline
+
+Process-wide ordered log of cross-goroutine events. Each `Log` records
+elapsed-since-first-call, an actor tag, and the message; output is buffered
+until `Render()`. Use when temporal ordering across goroutines is the thing
+you're trying to understand — Tracer prints atomically per line but can't
+preserve event order across racing writers.
+
+```go
+func TestPushlogGrantRace(t *testing.T) {
+    debug.DefaultTimeline.Enable()
+    t.Cleanup(func() {
+        fmt.Print(debug.DefaultTimeline.Render())
+        debug.DefaultTimeline.Disable()
+    })
+
+    // Production code calls debug.DefaultTimeline.Log(...) from
+    // sender + receiver goroutines.
+    runScenario(t)
+}
+```
+
+Output, after one failing run of the demess pushlog/grant-race scenario:
+
+```text
+T+    0ms  TEST    enabled
+T+ 4094ms  N-recv  pushlog arrived (isReplicator=false)
+T+ 4094ms  N-recv  -> SourceHub CheckDocAccess (start)
+T+ 4097ms  N-recv  <- SourceHub answer: peerHasAccess=false
+T+ 4097ms  N-recv  gate=NO  (silent drop, no log, no retry)
+T+ 6122ms  N-recv  pushlog arrived
+T+ 6124ms  N-recv  gate=YES -> syncDAG
+T+ 6124ms  N-send  hasAccess request
+T+ 6125ms  N-send  -> SourceHub CheckDocAccess (start)
+T+ 6127ms  N-send  <- SourceHub answer: peerHasAccess=true (serve block)
+T+ 6127ms  N-recv  fetch OK
+```
+
+The 2-second silent drop and the ~3ms sender ACP check are immediately
+legible — neither would be obvious in interleaved per-line tracer output.
+
+## ResourceTracker
+
+Tracks acquire/release pairs to catch leaks. One `Track` per acquire,
+one `Untrack` per release, with a description that shows up in failure
+messages.
+
+```go
+var iters = debug.NewResourceTracker("documentFetcher.iter")
+
+func openIterator(prefix string) *Iterator {
+    it := newIter(prefix)
+    iters.Track(it, "prefix="+prefix)
+    return it
+}
+
+func (it *Iterator) Close() error {
+    iters.Untrack(it)
+    return it.inner.Close()
+}
+```
+
+### Asserting no leaks at end of test
+
+```go
+func TestFetcher_ReleasesIterators(t *testing.T) {
+    f := newFetcher(...)
+    require.NoError(t, f.Run(ctx))
+    iters.AssertEmpty(t)   // t.Errorf with the description of each leak
+}
+```
+
+A failure looks like:
+
+```text
+fetcher_test.go:42: ResourceTracker[documentFetcher.iter]: 1 resource(s) still tracked:
+    - prefix=/col/1/index/age (addr: 14000138240)
+```
+
+### Isolating a leak from a specific block
+
+When other code in the same process holds legitimate long-lived resources,
+`Count() > 0` isn't a leak signal. Snapshot before, `AddedSince` after —
+the result is exactly what the suspect block left behind:
+
+```go
+before := iters.Snapshot()       // pre-existing legitimate work captured
+
+runSuspectBlock(t)
+
+for addr, desc := range iters.AddedSince(before) {
+    t.Errorf("leak introduced by suspect block: %s (addr=%x)", desc, addr)
+}
+```
+
+`StillHeld(snap)` is the inverse — resources from `snap` that haven't been
+released — useful for "this should have been closed by now" assertions.
+
+Methods: `Track`, `Untrack`, `Count`, `Remaining`, `Snapshot`, `AddedSince`,
+`StillHeld`, `Clear`, `AssertEmpty`, `AssertCount`.

--- a/internal/debug/timeline.go
+++ b/internal/debug/timeline.go
@@ -1,0 +1,110 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package debug
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+// Timeline is a single-process timeline collector intended for producing
+// a visual ordered log of significant events across multiple goroutines.
+// Each entry records the elapsed time since the timeline's first call and
+// a short actor tag (e.g. node short-peer-id). Entries are appended in
+// arrival order; concurrent appends are serialized.
+//
+// This is purely a debug/diagnostics aid; not for production use.
+type Timeline struct {
+	mu      sync.Mutex
+	start   time.Time
+	entries []TimelineEntry
+	enabled bool
+}
+
+// TimelineEntry is one line in a Timeline.
+type TimelineEntry struct {
+	OffsetMs int64
+	Actor    string
+	Message  string
+}
+
+// DefaultTimeline is the package-global timeline.
+var DefaultTimeline = NewTimeline()
+
+// NewTimeline creates a fresh disabled timeline.
+func NewTimeline() *Timeline {
+	return &Timeline{}
+}
+
+// Enable arms the timeline; the first subsequent Log call sets T+0.
+func (tl *Timeline) Enable() {
+	tl.mu.Lock()
+	defer tl.mu.Unlock()
+	tl.enabled = true
+	tl.entries = nil
+	tl.start = time.Time{}
+}
+
+// Disable stops collection but does not clear entries.
+func (tl *Timeline) Disable() {
+	tl.mu.Lock()
+	defer tl.mu.Unlock()
+	tl.enabled = false
+}
+
+// Log appends an event. Safe to call concurrently. No-op if disabled.
+func (tl *Timeline) Log(actor, format string, args ...any) {
+	tl.mu.Lock()
+	defer tl.mu.Unlock()
+	if !tl.enabled {
+		return
+	}
+	if tl.start.IsZero() {
+		tl.start = time.Now()
+	}
+	tl.entries = append(tl.entries, TimelineEntry{
+		OffsetMs: time.Since(tl.start).Milliseconds(),
+		Actor:    actor,
+		Message:  fmt.Sprintf(format, args...),
+	})
+}
+
+// Render returns the entries formatted as an ordered visual log.
+// Lines are aligned: T+Xms  ACTOR  MESSAGE.
+func (tl *Timeline) Render() string {
+	tl.mu.Lock()
+	defer tl.mu.Unlock()
+	if len(tl.entries) == 0 {
+		return "(timeline empty)\n"
+	}
+	// Find max actor width for alignment.
+	maxActor := 0
+	for _, e := range tl.entries {
+		if len(e.Actor) > maxActor {
+			maxActor = len(e.Actor)
+		}
+	}
+	var out string
+	for _, e := range tl.entries {
+		out += fmt.Sprintf("T+%5dms  %-*s  %s\n", e.OffsetMs, maxActor, e.Actor, e.Message)
+	}
+	return out
+}
+
+// Entries returns a copy of the recorded entries.
+func (tl *Timeline) Entries() []TimelineEntry {
+	tl.mu.Lock()
+	defer tl.mu.Unlock()
+	out := make([]TimelineEntry, len(tl.entries))
+	copy(out, tl.entries)
+	return out
+}

--- a/internal/debug/trace.go
+++ b/internal/debug/trace.go
@@ -1,0 +1,243 @@
+// Copyright 2024 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// Package debug provides utilities for debugging and tracing code execution.
+// It includes a hierarchical logger that visualizes call stacks with indentation.
+package debug
+
+import (
+	"fmt"
+	"reflect"
+	"runtime"
+	"strings"
+	"sync"
+	"sync/atomic"
+)
+
+// PrefixWidth is the fixed width for tracer prefixes. All prefixes will be
+// padded or truncated to this width for aligned output.
+var PrefixWidth = 12
+
+// ShowSourceLocation enables showing file:line information at the end of each log line.
+var ShowSourceLocation = true
+
+// globalIndent is the shared indentation level across all tracers.
+var globalIndent atomic.Int32
+
+// globalMu protects print operations to ensure atomic output.
+var globalMu sync.Mutex
+
+// Tracer provides hierarchical logging with indentation to visualize call stacks.
+// It is safe for concurrent use from multiple goroutines.
+// All Tracer instances share a global indentation level.
+type Tracer struct {
+	mu      sync.Mutex
+	enabled bool
+	prefix  string
+}
+
+// NewTracer creates a new Tracer with the given prefix.
+// The prefix is prepended to all output lines.
+func NewTracer(prefix string) *Tracer {
+	return &Tracer{
+		prefix:  prefix,
+		enabled: true,
+	}
+}
+
+// Enable turns on tracing output.
+func (t *Tracer) Enable() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.enabled = true
+}
+
+// Disable turns off tracing output.
+func (t *Tracer) Disable() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.enabled = false
+}
+
+// IsEnabled returns whether tracing is currently enabled.
+func (t *Tracer) IsEnabled() bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.enabled
+}
+
+// Indent increases the global indentation level by one.
+func (t *Tracer) Indent() {
+	globalIndent.Add(1)
+}
+
+// Outdent decreases the global indentation level by one.
+func (t *Tracer) Outdent() {
+	if globalIndent.Load() > 0 {
+		globalIndent.Add(-1)
+	}
+}
+
+// indentStr returns the current indentation string.
+func indentStr() string {
+	indent := int(globalIndent.Load())
+	var sb strings.Builder
+	for i := 0; i < indent; i++ {
+		sb.WriteString("    ")
+	}
+	return sb.String()
+}
+
+// Print outputs a formatted message with the current indentation.
+func (t *Tracer) Print(format string, args ...any) {
+	t.mu.Lock()
+	enabled := t.enabled
+	prefix := t.formattedPrefix()
+	t.mu.Unlock()
+
+	if !enabled {
+		return
+	}
+
+	globalMu.Lock()
+	defer globalMu.Unlock()
+	fmt.Printf("%s%s"+format, append([]any{prefix, indentStr()}, args...)...)
+}
+
+// formattedPrefix returns the prefix formatted to fixed width (must be called with lock held).
+func (t *Tracer) formattedPrefix() string {
+	if t.prefix == "" {
+		return strings.Repeat(" ", PrefixWidth+1) // +1 for ":"
+	}
+	// Add colon after prefix, then pad with spaces to fixed width
+	p := t.prefix + ":"
+	if len(p) > PrefixWidth+1 {
+		p = p[:PrefixWidth+1]
+	}
+	// Pad to PrefixWidth+1 (for the colon) plus one space
+	return fmt.Sprintf("%-*s ", PrefixWidth+1, p)
+}
+
+// Println outputs a formatted message with the current indentation, followed by a newline.
+func (t *Tracer) Println(format string, args ...any) {
+	if ShowSourceLocation {
+		// Get source location before calling Print to ensure correct skip level
+		loc := sourceLocation(1)
+		t.Print(format+" | %s\n", append(args, loc)...)
+	} else {
+		t.Print(format+"\n", args...)
+	}
+}
+
+// sourceLocation returns the file:line of the caller at the given skip level.
+func sourceLocation(skip int) string {
+	_, file, line, ok := runtime.Caller(skip + 1)
+	if !ok {
+		return "???:0"
+	}
+	// Get just the filename, not full path
+	if idx := strings.LastIndex(file, "/"); idx >= 0 {
+		file = file[idx+1:]
+	}
+	return fmt.Sprintf("%s:%d", file, line)
+}
+
+// Enter logs entry into a function, increases indentation, and returns a function
+// to be deferred that decreases indentation on exit.
+// Usage:
+//
+//	defer tracer.Enter("MyFunc")()
+//
+// Or with object address:
+//
+//	defer tracer.Enter("MyFunc", myObject)()
+func (t *Tracer) Enter(name string, obj ...any) func() {
+	// Capture source location at call site
+	loc := sourceLocation(1)
+	// Print entry at current level with ">" marker, then indent for body
+	if len(obj) > 0 {
+		t.printEntry("> %s (%x)", loc, name, Addr(obj[0]))
+	} else {
+		t.printEntry("> %s", loc, name)
+	}
+	t.Indent()
+	return func() {
+		t.Outdent()
+	}
+}
+
+// printEntry prints an entry line with a pre-captured source location.
+func (t *Tracer) printEntry(format string, loc string, args ...any) {
+	t.mu.Lock()
+	enabled := t.enabled
+	prefix := t.formattedPrefix()
+	t.mu.Unlock()
+
+	if !enabled {
+		return
+	}
+
+	globalMu.Lock()
+	defer globalMu.Unlock()
+	if ShowSourceLocation {
+		fmt.Printf("%s%s"+format+" | %s\n", append([]any{prefix, indentStr()}, append(args, loc)...)...)
+	} else {
+		fmt.Printf("%s%s"+format+"\n", append([]any{prefix, indentStr()}, args...)...)
+	}
+}
+
+// EnterFunc logs entry into the calling function and returns a defer function.
+// It automatically determines the caller's function name.
+// Usage:
+//
+//	defer tracer.EnterFunc()()
+//
+// Or with object address:
+//
+//	defer tracer.EnterFunc(myObject)()
+func (t *Tracer) EnterFunc(obj ...any) func() {
+	name := callerName(2)
+	return t.Enter(name, obj...)
+}
+
+// Addr returns the memory address of an object as a uintptr.
+// Works with pointers, interfaces, maps, slices, channels, and functions.
+func Addr(obj any) uintptr {
+	v := reflect.ValueOf(obj)
+	switch v.Kind() {
+	case reflect.Ptr, reflect.Interface, reflect.Map, reflect.Slice, reflect.Chan, reflect.Func:
+		if v.IsNil() {
+			return 0
+		}
+		return v.Pointer()
+	default:
+		return 0
+	}
+}
+
+// callerName returns the name of the caller at the given skip level.
+func callerName(skip int) string {
+	pc := make([]uintptr, 1)
+	n := runtime.Callers(skip+1, pc)
+	if n == 0 {
+		return "unknown"
+	}
+	frames := runtime.CallersFrames(pc)
+	frame, _ := frames.Next()
+	// Extract just the function name without the full path
+	name := frame.Function
+	if idx := strings.LastIndex(name, "/"); idx >= 0 {
+		name = name[idx+1:]
+	}
+	return name
+}
+
+// Default is a default global tracer that can be used for quick debugging.
+var Default = NewTracer("")

--- a/internal/debug/tracker.go
+++ b/internal/debug/tracker.go
@@ -1,0 +1,159 @@
+// Copyright 2024 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package debug
+
+import (
+	"fmt"
+	"maps"
+	"strings"
+	"sync"
+)
+
+// ResourceTracker tracks resources (like iterators, connections, etc.) to help
+// detect leaks and understand resource lifecycle. It is safe for concurrent use.
+//
+// The tracker is intentionally not tied to a Tracer; callers that want verbose
+// per-operation logging should wrap Track/Untrack calls themselves.
+type ResourceTracker struct {
+	mu        sync.Mutex
+	name      string
+	resources map[uintptr]string // addr -> description
+}
+
+// NewResourceTracker creates a new tracker for resources of the given name.
+func NewResourceTracker(name string) *ResourceTracker {
+	return &ResourceTracker{
+		name:      name,
+		resources: make(map[uintptr]string),
+	}
+}
+
+// Track registers a resource with an optional description.
+// Returns false if the resource was already tracked (duplicate addr).
+func (rt *ResourceTracker) Track(resource any, description string) bool {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+
+	addr := Addr(resource)
+	if _, exists := rt.resources[addr]; exists {
+		return false
+	}
+	rt.resources[addr] = description
+	return true
+}
+
+// Untrack removes a resource from tracking.
+// Returns false if the resource was not currently tracked.
+func (rt *ResourceTracker) Untrack(resource any) bool {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+
+	addr := Addr(resource)
+	if _, exists := rt.resources[addr]; !exists {
+		return false
+	}
+	delete(rt.resources, addr)
+	return true
+}
+
+// Count returns the current number of tracked resources.
+func (rt *ResourceTracker) Count() int {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	return len(rt.resources)
+}
+
+// Snapshot returns a point-in-time copy of all currently tracked resources,
+// keyed by address. The returned map is safe to read without holding any lock.
+func (rt *ResourceTracker) Snapshot() map[uintptr]string {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	return maps.Clone(rt.resources)
+}
+
+// Remaining returns the descriptions of all currently tracked resources.
+// Useful for human-readable leak reports.
+func (rt *ResourceTracker) Remaining() []string {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+
+	result := make([]string, 0, len(rt.resources))
+	for addr, desc := range rt.resources {
+		result = append(result, fmt.Sprintf("%s (addr: %x)", desc, addr))
+	}
+	return result
+}
+
+// AddedSince returns resources tracked now that were not in snap.
+// Useful to isolate leaks introduced by code that ran between Snapshot
+// and AddedSince: opens that never got matching closes.
+func (rt *ResourceTracker) AddedSince(snap map[uintptr]string) map[uintptr]string {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+
+	added := make(map[uintptr]string)
+	for addr, desc := range rt.resources {
+		if _, existed := snap[addr]; !existed {
+			added[addr] = desc
+		}
+	}
+	return added
+}
+
+// StillHeld returns resources from snap that are still tracked now,
+// i.e. resources that were alive at snap-time and have not been released.
+// Useful to find resources held longer than expected.
+func (rt *ResourceTracker) StillHeld(snap map[uintptr]string) map[uintptr]string {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+
+	held := make(map[uintptr]string)
+	for addr, desc := range snap {
+		if _, still := rt.resources[addr]; still {
+			held[addr] = desc
+		}
+	}
+	return held
+}
+
+// Clear removes all tracked resources. Useful in test teardown.
+func (rt *ResourceTracker) Clear() {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	rt.resources = make(map[uintptr]string)
+}
+
+// TB is the subset of testing.TB used by AssertEmpty and AssertCount.
+// *testing.T and *testing.B satisfy this interface.
+type TB interface {
+	Helper()
+	Errorf(format string, args ...any)
+}
+
+// AssertEmpty fails the test if any resources are still tracked.
+// It marks itself as a test helper so failures point to the call site.
+func (rt *ResourceTracker) AssertEmpty(t TB) {
+	t.Helper()
+	remaining := rt.Remaining()
+	if len(remaining) > 0 {
+		t.Errorf("ResourceTracker[%s]: %d leaked resource(s):\n  %s",
+			rt.name, len(remaining), strings.Join(remaining, "\n  "))
+	}
+}
+
+// AssertCount fails the test if the tracked count does not equal want.
+func (rt *ResourceTracker) AssertCount(t TB, want int) {
+	t.Helper()
+	if got := rt.Count(); got != want {
+		t.Errorf("ResourceTracker[%s]: Count() = %d, want %d; remaining: %v",
+			rt.name, got, want, rt.Remaining())
+	}
+}

--- a/internal/debug/tracker_test.go
+++ b/internal/debug/tracker_test.go
@@ -1,0 +1,137 @@
+// Copyright 2024 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package debug
+
+import (
+	"testing"
+)
+
+// fakeIter is a stand-in for any pointer-typed resource (iterator, connection, etc.).
+type fakeIter struct{ id int }
+
+func TestResourceTracker_BasicLifecycle(t *testing.T) {
+	tr := NewResourceTracker("iter")
+
+	a := &fakeIter{1}
+	b := &fakeIter{2}
+	c := &fakeIter{3}
+
+	tr.Track(a, "iter-a")
+	tr.Track(b, "iter-b")
+	tr.Track(c, "iter-c")
+	tr.AssertCount(t, 3)
+
+	// Close two of three.
+	tr.Untrack(a)
+	tr.Untrack(b)
+	tr.AssertCount(t, 1)
+
+	// One resource should remain.
+	remaining := tr.Remaining()
+	if len(remaining) != 1 {
+		t.Fatalf("expected 1 remaining resource, got %d: %v", len(remaining), remaining)
+	}
+	// The description should mention iter-c.
+	if len(remaining[0]) == 0 {
+		t.Error("remaining description is empty")
+	}
+}
+
+func TestResourceTracker_DuplicateTrack(t *testing.T) {
+	tr := NewResourceTracker("conn")
+	r := &fakeIter{42}
+
+	if !tr.Track(r, "first") {
+		t.Fatal("first Track should return true")
+	}
+	if tr.Track(r, "duplicate") {
+		t.Fatal("second Track of same pointer should return false")
+	}
+	tr.AssertCount(t, 1)
+}
+
+func TestResourceTracker_UntrackUnknown(t *testing.T) {
+	tr := NewResourceTracker("conn")
+	r := &fakeIter{99}
+	if tr.Untrack(r) {
+		t.Fatal("Untrack of unregistered resource should return false")
+	}
+}
+
+func TestResourceTracker_Snapshot_AddedSince_StillHeld(t *testing.T) {
+	tr := NewResourceTracker("iter")
+
+	a := &fakeIter{1}
+	b := &fakeIter{2}
+	c := &fakeIter{3}
+
+	tr.Track(a, "iter-a")
+	tr.Track(b, "iter-b")
+
+	// Checkpoint: two resources live at this point.
+	snap := tr.Snapshot()
+	if len(snap) != 2 {
+		t.Fatalf("snapshot should contain 2 entries, got %d", len(snap))
+	}
+
+	// Open a third after the snapshot, close one of the originals.
+	tr.Track(c, "iter-c")
+	tr.Untrack(a)
+
+	// AddedSince should report only iter-c (opened after snap).
+	added := tr.AddedSince(snap)
+	if len(added) != 1 {
+		t.Fatalf("AddedSince should report 1 new resource, got %d: %v", len(added), added)
+	}
+
+	// StillHeld should report only iter-b (in snap, still live).
+	held := tr.StillHeld(snap)
+	if len(held) != 1 {
+		t.Fatalf("StillHeld should report 1 held resource, got %d: %v", len(held), held)
+	}
+}
+
+func TestResourceTracker_LeakScenario(t *testing.T) {
+	// Simulates opening 3 iterators, closing 2, and asserting via AssertEmpty
+	// which should report the one still open.
+	tr := NewResourceTracker("corekv.Iterator")
+
+	iters := []*fakeIter{{1}, {2}, {3}}
+	for i, it := range iters {
+		tr.Track(it, "iter-"+string(rune('A'+i)))
+	}
+
+	// Close all but the last.
+	tr.Untrack(iters[0])
+	tr.Untrack(iters[1])
+
+	// AssertEmpty should fail — capture with a spy that satisfies TB.
+	spy := &spyT{}
+	tr.AssertEmpty(spy)
+	if !spy.failed {
+		t.Fatal("AssertEmpty should have reported a leak for the unclosed iterator")
+	}
+
+	// Cleanup.
+	tr.Untrack(iters[2])
+	tr.AssertEmpty(t)
+}
+
+// spyT satisfies the TB interface and records whether Errorf was called.
+type spyT struct {
+	failed bool
+}
+
+func (s *spyT) Errorf(format string, args ...any) {
+	s.failed = true
+}
+
+func (s *spyT) Helper() {}

--- a/tools/configs/golangci.yaml
+++ b/tools/configs/golangci.yaml
@@ -409,6 +409,12 @@ linters:
           - goheader
         path: (net|connor|encoding|tests)
 
+      # The debug package is intentionally a print-based diagnostics tool;
+      # fmt.Printf is its job, not an accident.
+      - linters:
+          - forbidigo
+        path: internal/debug/
+
       - linters:
           - forcetypeassert
     # Exclude running force type assert check in these file paths, we are ignoring these files for now


### PR DESCRIPTION
## Description

I've been using a small set of diagnostics utilities for a while when chasing bugs locally, a prefixed indented tracer, a process-wide timeline collector, and a resource-leak tracker. Figured others might find them useful too, so packaging them up under `internal/debug` with a README and tests.

Strictly opt-in: nothing imports the package yet. It's just there for when you need it.