### PR TITLE
chore: Update aggregate return types for non-nillable fields

### DIFF
--- a/internal/request/graphql/schema/generate.go
+++ b/internal/request/graphql/schema/generate.go
@@ -225,7 +225,7 @@ func (g *Generator) generate(ctx context.Context, collections []client.Collectio
 			if err := g.expandInputArgument(obj.OfType.(*gql.Object)); err != nil {
 				return nil, err
 			}
-		case *gql.Scalar:
+		case *gql.Scalar, *gql.NonNull:
 			if _, isAggregate := request.Aggregates[def.Name]; isAggregate {
 				for name, aggregateTarget := range def.Args {
 					expandedField := &gql.InputObjectFieldConfig{

--- a/internal/request/graphql/schema/generate.go
+++ b/internal/request/graphql/schema/generate.go
@@ -344,6 +344,8 @@ func (g *Generator) expandInputArgument(obj *gql.Object) error {
 				}
 				obj.AddFieldConfig(f, expandedField)
 			}
+		// Here, we will check for Scalar and NonNull, because depending on the aggregate operation,
+		// it could be either. COUNT, SUM, and AVG return Int!/Float!, but MIN and MAX return Int/Float.
 		case *gql.Scalar, *gql.NonNull:
 			if _, isAggregate := request.Aggregates[f]; isAggregate {
 				if err := g.createExpandedFieldAggregate(obj, def); err != nil {

--- a/internal/request/graphql/schema/generate.go
+++ b/internal/request/graphql/schema/generate.go
@@ -344,15 +344,12 @@ func (g *Generator) expandInputArgument(obj *gql.Object) error {
 				}
 				obj.AddFieldConfig(f, expandedField)
 			}
-		case *gql.Scalar:
+		case *gql.Scalar, *gql.NonNull:
 			if _, isAggregate := request.Aggregates[f]; isAggregate {
 				if err := g.createExpandedFieldAggregate(obj, def); err != nil {
 					return err
 				}
 			}
-			// @todo: check if NonNull is possible here
-			//case *gql.NonNull:
-			// get subtype
 		}
 	}
 

--- a/internal/request/graphql/schema/generate.go
+++ b/internal/request/graphql/schema/generate.go
@@ -741,7 +741,7 @@ func genTopLevelCount(topLevelCountInputs map[string]*gql.InputObject) *gql.Fiel
 	topLevelCountField := gql.Field{
 		Name:        request.CountFieldName,
 		Description: schemaTypes.CountFieldDescription,
-		Type:        gql.Int,
+		Type:        gql.NewNonNull(gql.Int),
 		Args:        gql.FieldConfigArgument{},
 	}
 
@@ -756,14 +756,14 @@ func genTopLevelNumericAggregates(topLevelNumericAggInputs map[string]*gql.Input
 	topLevelSumField := gql.Field{
 		Name:        request.SumFieldName,
 		Description: schemaTypes.SumFieldDescription,
-		Type:        gql.Float,
+		Type:        gql.NewNonNull(gql.Float),
 		Args:        gql.FieldConfigArgument{},
 	}
 
 	topLevelAverageField := gql.Field{
 		Name:        request.AverageFieldName,
 		Description: schemaTypes.AverageFieldDescription,
-		Type:        gql.Float,
+		Type:        gql.NewNonNull(gql.Float),
 		Args:        gql.FieldConfigArgument{},
 	}
 
@@ -821,7 +821,7 @@ func (g *Generator) genCountFieldConfig(obj *gql.Object) (gql.Field, error) {
 	field := gql.Field{
 		Name:        request.CountFieldName,
 		Description: schemaTypes.CountFieldDescription,
-		Type:        gql.Int,
+		Type:        gql.NewNonNull(gql.Int),
 		Args:        gql.FieldConfigArgument{},
 	}
 
@@ -836,7 +836,7 @@ func (g *Generator) genSumFieldConfig(obj *gql.Object) (gql.Field, error) {
 	field := gql.Field{
 		Name:        request.SumFieldName,
 		Description: schemaTypes.SumFieldDescription,
-		Type:        gql.Float,
+		Type:        gql.NewNonNull(gql.Float),
 		Args:        gql.FieldConfigArgument{},
 	}
 
@@ -881,7 +881,7 @@ func (g *Generator) genAverageFieldConfig(obj *gql.Object) (gql.Field, error) {
 	field := gql.Field{
 		Name:        request.AverageFieldName,
 		Description: schemaTypes.AverageFieldDescription,
-		Type:        gql.Float,
+		Type:        gql.NewNonNull(gql.Float),
 		Args:        gql.FieldConfigArgument{},
 	}
 

--- a/internal/request/graphql/schema/testfixtures/schema.relatedmany.gen.graphql
+++ b/internal/request/graphql/schema/testfixtures/schema.relatedmany.gen.graphql
@@ -474,7 +474,7 @@ showDeleted: Boolean): [Book]
     (true average, not an average of averages) will be returned as a single value.
 
     """
-    AVG(Author: Author__NumericSelector, Book: Book__NumericSelector): Float
+    AVG(Author: Author__NumericSelector, Book: Book__NumericSelector): Float!
     """
     
     Returns a set of commits matching any provided criteria. If no arguments are
@@ -537,7 +537,7 @@ order: [commitsOrderArg]): [Commit]
     sets are specified, the combined total of all of them will be returned as a single value.
 
     """
-    COUNT(Author: Author__CountSelector, Book: Book__CountSelector): Int
+    COUNT(Author: Author__CountSelector, Book: Book__CountSelector): Int!
     """
     
     Returns the maximum of the specified field values within the specified child sets. If
@@ -561,7 +561,7 @@ order: [commitsOrderArg]): [Commit]
     a single value.
 
     """
-    SUM(Author: Author__NumericSelector, Book: Book__NumericSelector): Float
+    SUM(Author: Author__NumericSelector, Book: Book__NumericSelector): Float!
 }
 
 """
@@ -922,14 +922,14 @@ type Book {
     The scalar field selection type for aggregate input arguments.
 
     """
-rating: ScalarAggregateNumericBlock): Float
+rating: ScalarAggregateNumericBlock): Float!
     """
-    
+
     Returns the total number of items within the specified child sets. If multiple child
     sets are specified, the combined total of all of them will be returned as a single value.
 
     """
-    COUNT(GROUP: Book__CountSelector, _version: Book___version__CountSelector): Int
+    COUNT(GROUP: Book__CountSelector, _version: Book___version__CountSelector): Int!
     """
     
     Indicates as to whether or not this document has been deleted.
@@ -1035,9 +1035,9 @@ rating: ScalarAggregateNumericBlock): Float
     The scalar field selection type for aggregate input arguments.
 
     """
-rating: ScalarAggregateNumericBlock): Float
+rating: ScalarAggregateNumericBlock): Float!
     """
-    
+
     Returns the head commit for this document.
 
     """
@@ -1156,14 +1156,14 @@ type Author {
     The scalar field selection type for aggregate input arguments.
 
     """
-age: ScalarAggregateNumericBlock, published: Book__NumericSelector): Float
+age: ScalarAggregateNumericBlock, published: Book__NumericSelector): Float!
     """
-    
+
     Returns the total number of items within the specified child sets. If multiple child
     sets are specified, the combined total of all of them will be returned as a single value.
 
     """
-    COUNT(GROUP: Author__CountSelector, _version: Author___version__CountSelector, published: Book__CountSelector): Int
+    COUNT(GROUP: Author__CountSelector, _version: Author___version__CountSelector, published: Book__CountSelector): Int!
     """
     
     Indicates as to whether or not this document has been deleted.
@@ -1269,9 +1269,9 @@ age: ScalarAggregateNumericBlock, published: Book__NumericSelector): Float
     The scalar field selection type for aggregate input arguments.
 
     """
-age: ScalarAggregateNumericBlock, published: Book__NumericSelector): Float
+age: ScalarAggregateNumericBlock, published: Book__NumericSelector): Float!
     """
-    
+
     Returns the head commit for this document.
 
     """

--- a/internal/request/graphql/schema/testfixtures/schema.relatedone.gen.graphql
+++ b/internal/request/graphql/schema/testfixtures/schema.relatedone.gen.graphql
@@ -359,7 +359,7 @@ showDeleted: Boolean): [Book]
     (true average, not an average of averages) will be returned as a single value.
 
     """
-    AVG(Author: Author__NumericSelector, Book: Book__NumericSelector): Float
+    AVG(Author: Author__NumericSelector, Book: Book__NumericSelector): Float!
     """
     
     Returns a set of commits matching any provided criteria. If no arguments are
@@ -422,7 +422,7 @@ order: [commitsOrderArg]): [Commit]
     sets are specified, the combined total of all of them will be returned as a single value.
 
     """
-    COUNT(Author: Author__CountSelector, Book: Book__CountSelector): Int
+    COUNT(Author: Author__CountSelector, Book: Book__CountSelector): Int!
     """
     
     Returns the maximum of the specified field values within the specified child sets. If
@@ -446,7 +446,7 @@ order: [commitsOrderArg]): [Commit]
     a single value.
 
     """
-    SUM(Author: Author__NumericSelector, Book: Book__NumericSelector): Float
+    SUM(Author: Author__NumericSelector, Book: Book__NumericSelector): Float!
 }
 
 """
@@ -2056,14 +2056,14 @@ type Author {
     The scalar field selection type for aggregate input arguments.
 
     """
-age: ScalarAggregateNumericBlock): Float
+age: ScalarAggregateNumericBlock): Float!
     """
-    
+
     Returns the total number of items within the specified child sets. If multiple child
     sets are specified, the combined total of all of them will be returned as a single value.
 
     """
-    COUNT(GROUP: Author__CountSelector, _version: Author___version__CountSelector): Int
+    COUNT(GROUP: Author__CountSelector, _version: Author___version__CountSelector): Int!
     """
     
     Indicates as to whether or not this document has been deleted.
@@ -2170,9 +2170,9 @@ age: ScalarAggregateNumericBlock): Float
     The scalar field selection type for aggregate input arguments.
 
     """
-age: ScalarAggregateNumericBlock): Float
+age: ScalarAggregateNumericBlock): Float!
     """
-    
+
     Returns the head commit for this document.
 
     """
@@ -2575,14 +2575,14 @@ type Book {
     The scalar field selection type for aggregate input arguments.
 
     """
-rating: ScalarAggregateNumericBlock): Float
+rating: ScalarAggregateNumericBlock): Float!
     """
-    
+
     Returns the total number of items within the specified child sets. If multiple child
     sets are specified, the combined total of all of them will be returned as a single value.
 
     """
-    COUNT(GROUP: Book__CountSelector, _version: Book___version__CountSelector): Int
+    COUNT(GROUP: Book__CountSelector, _version: Book___version__CountSelector): Int!
     """
     
     Indicates as to whether or not this document has been deleted.
@@ -2688,9 +2688,9 @@ rating: ScalarAggregateNumericBlock): Float
     The scalar field selection type for aggregate input arguments.
 
     """
-rating: ScalarAggregateNumericBlock): Float
+rating: ScalarAggregateNumericBlock): Float!
     """
-    
+
     Returns the head commit for this document.
 
     """

--- a/internal/request/graphql/schema/testfixtures/schema.simple.gen.graphql
+++ b/internal/request/graphql/schema/testfixtures/schema.simple.gen.graphql
@@ -90,14 +90,14 @@ age: ScalarAggregateNumericBlock,     """
     The scalar field selection type for aggregate input arguments.
 
     """
-points: ScalarAggregateNumericBlock): Float
+points: ScalarAggregateNumericBlock): Float!
     """
-    
+
     Returns the total number of items within the specified child sets. If multiple child
     sets are specified, the combined total of all of them will be returned as a single value.
 
     """
-    COUNT(GROUP: User__CountSelector, _version: User___version__CountSelector): Int
+    COUNT(GROUP: User__CountSelector, _version: User___version__CountSelector): Int!
     """
     
     Indicates as to whether or not this document has been deleted.
@@ -218,9 +218,9 @@ age: ScalarAggregateNumericBlock,     """
     The scalar field selection type for aggregate input arguments.
 
     """
-points: ScalarAggregateNumericBlock): Float
+points: ScalarAggregateNumericBlock): Float!
     """
-    
+
     Returns the head commit for this document.
 
     """
@@ -883,7 +883,7 @@ showDeleted: Boolean): [User]
     (true average, not an average of averages) will be returned as a single value.
 
     """
-    AVG(User: User__NumericSelector): Float
+    AVG(User: User__NumericSelector): Float!
     """
     
     Returns a set of commits matching any provided criteria. If no arguments are
@@ -946,7 +946,7 @@ order: [commitsOrderArg]): [Commit]
     sets are specified, the combined total of all of them will be returned as a single value.
 
     """
-    COUNT(User: User__CountSelector): Int
+    COUNT(User: User__CountSelector): Int!
     """
     
     Returns the maximum of the specified field values within the specified child sets. If
@@ -970,7 +970,7 @@ order: [commitsOrderArg]): [Commit]
     a single value.
 
     """
-    SUM(User: User__NumericSelector): Float
+    SUM(User: User__NumericSelector): Float!
 }
 
 "The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."

--- a/tests/integration/acp/dac/link_collection/accept_basic_dri_fmts_test.go
+++ b/tests/integration/acp/dac/link_collection/accept_basic_dri_fmts_test.go
@@ -61,6 +61,7 @@ resources:
 								type {
 								name
 								kind
+								ofType { name kind }
 								}
 							}
 						}
@@ -69,20 +70,22 @@ resources:
 				ExpectedData: map[string]any{
 					"__type": map[string]any{
 						"name": "Users", // NOTE: "Users" MUST exist
-						"fields": schemaUtils.DefaultFields.Append(
+						"fields": schemaUtils.DefaultFields("Users").Append(
 							schemaUtils.Field{
 								"name": "name",
 								"type": map[string]any{
-									"kind": "SCALAR",
-									"name": "String",
+									"kind":   "SCALAR",
+									"name":   "String",
+									"ofType": nil,
 								},
 							},
 						).Append(
 							schemaUtils.Field{
 								"name": "age",
 								"type": map[string]any{
-									"kind": "SCALAR",
-									"name": "Int",
+									"kind":   "SCALAR",
+									"name":   "Int",
+									"ofType": nil,
 								},
 							},
 						).Tidy(),

--- a/tests/integration/acp/dac/link_collection/accept_extra_permissions_on_dri_test.go
+++ b/tests/integration/acp/dac/link_collection/accept_extra_permissions_on_dri_test.go
@@ -69,6 +69,7 @@ resources:
 								type {
 								name
 								kind
+								ofType { name kind }
 								}
 							}
 						}
@@ -77,20 +78,22 @@ resources:
 				ExpectedData: map[string]any{
 					"__type": map[string]any{
 						"name": "Users", // NOTE: "Users" MUST exist
-						"fields": schemaUtils.DefaultFields.Append(
+						"fields": schemaUtils.DefaultFields("Users").Append(
 							schemaUtils.Field{
 								"name": "name",
 								"type": map[string]any{
-									"kind": "SCALAR",
-									"name": "String",
+									"kind":   "SCALAR",
+									"name":   "String",
+									"ofType": nil,
 								},
 							},
 						).Append(
 							schemaUtils.Field{
 								"name": "age",
 								"type": map[string]any{
-									"kind": "SCALAR",
-									"name": "Int",
+									"kind":   "SCALAR",
+									"name":   "Int",
+									"ofType": nil,
 								},
 							},
 						).Tidy(),

--- a/tests/integration/acp/dac/link_collection/accept_managed_relation_on_dri_test.go
+++ b/tests/integration/acp/dac/link_collection/accept_managed_relation_on_dri_test.go
@@ -72,6 +72,7 @@ resources:
 								type {
 								name
 								kind
+								ofType { name kind }
 								}
 							}
 						}
@@ -80,20 +81,22 @@ resources:
 				ExpectedData: map[string]any{
 					"__type": map[string]any{
 						"name": "Users", // NOTE: "Users" MUST exist
-						"fields": schemaUtils.DefaultFields.Append(
+						"fields": schemaUtils.DefaultFields("Users").Append(
 							schemaUtils.Field{
 								"name": "name",
 								"type": map[string]any{
-									"kind": "SCALAR",
-									"name": "String",
+									"kind":   "SCALAR",
+									"name":   "String",
+									"ofType": nil,
 								},
 							},
 						).Append(
 							schemaUtils.Field{
 								"name": "age",
 								"type": map[string]any{
-									"kind": "SCALAR",
-									"name": "Int",
+									"kind":   "SCALAR",
+									"name":   "Int",
+									"ofType": nil,
 								},
 							},
 						).Tidy(),

--- a/tests/integration/acp/dac/link_collection/accept_mixed_resources_on_partial_dri_test.go
+++ b/tests/integration/acp/dac/link_collection/accept_mixed_resources_on_partial_dri_test.go
@@ -77,6 +77,7 @@ resources:
 								type {
 								name
 								kind
+								ofType { name kind }
 								}
 							}
 						}
@@ -85,20 +86,22 @@ resources:
 				ExpectedData: map[string]any{
 					"__type": map[string]any{
 						"name": "Users", // NOTE: "Users" MUST exist
-						"fields": schemaUtils.DefaultFields.Append(
+						"fields": schemaUtils.DefaultFields("Users").Append(
 							schemaUtils.Field{
 								"name": "name",
 								"type": map[string]any{
-									"kind": "SCALAR",
-									"name": "String",
+									"kind":   "SCALAR",
+									"name":   "String",
+									"ofType": nil,
 								},
 							},
 						).Append(
 							schemaUtils.Field{
 								"name": "age",
 								"type": map[string]any{
-									"kind": "SCALAR",
-									"name": "Int",
+									"kind":   "SCALAR",
+									"name":   "Int",
+									"ofType": nil,
 								},
 							},
 						).Tidy(),

--- a/tests/integration/acp/dac/link_collection/accept_multi_dris_test.go
+++ b/tests/integration/acp/dac/link_collection/accept_multi_dris_test.go
@@ -79,6 +79,7 @@ resources:
 								type {
 								name
 								kind
+								ofType { name kind }
 								}
 							}
 						}
@@ -87,20 +88,22 @@ resources:
 				ExpectedData: map[string]any{
 					"__type": map[string]any{
 						"name": "OldUsers", // NOTE: "OldUsers" MUST exist
-						"fields": schemaUtils.DefaultFields.Append(
+						"fields": schemaUtils.DefaultFields("OldUsers").Append(
 							schemaUtils.Field{
 								"name": "name",
 								"type": map[string]any{
-									"kind": "SCALAR",
-									"name": "String",
+									"kind":   "SCALAR",
+									"name":   "String",
+									"ofType": nil,
 								},
 							},
 						).Append(
 							schemaUtils.Field{
 								"name": "age",
 								"type": map[string]any{
-									"kind": "SCALAR",
-									"name": "Int",
+									"kind":   "SCALAR",
+									"name":   "Int",
+									"ofType": nil,
 								},
 							},
 						).Tidy(),
@@ -132,6 +135,7 @@ resources:
 								type {
 								name
 								kind
+								ofType { name kind }
 								}
 							}
 						}
@@ -140,20 +144,22 @@ resources:
 				ExpectedData: map[string]any{
 					"__type": map[string]any{
 						"name": "NewUsers", // NOTE: "NewUsers" MUST exist
-						"fields": schemaUtils.DefaultFields.Append(
+						"fields": schemaUtils.DefaultFields("NewUsers").Append(
 							schemaUtils.Field{
 								"name": "name",
 								"type": map[string]any{
-									"kind": "SCALAR",
-									"name": "String",
+									"kind":   "SCALAR",
+									"name":   "String",
+									"ofType": nil,
 								},
 							},
 						).Append(
 							schemaUtils.Field{
 								"name": "age",
 								"type": map[string]any{
-									"kind": "SCALAR",
-									"name": "Int",
+									"kind":   "SCALAR",
+									"name":   "Int",
+									"ofType": nil,
 								},
 							},
 						).Tidy(),

--- a/tests/integration/acp/dac/link_collection/accept_multi_resources_on_dri_test.go
+++ b/tests/integration/acp/dac/link_collection/accept_multi_resources_on_dri_test.go
@@ -72,6 +72,7 @@ resources:
 								type {
 								name
 								kind
+								ofType { name kind }
 								}
 							}
 						}
@@ -80,20 +81,22 @@ resources:
 				ExpectedData: map[string]any{
 					"__type": map[string]any{
 						"name": "Users", // NOTE: "Users" MUST exist
-						"fields": schemaUtils.DefaultFields.Append(
+						"fields": schemaUtils.DefaultFields("Users").Append(
 							schemaUtils.Field{
 								"name": "name",
 								"type": map[string]any{
-									"kind": "SCALAR",
-									"name": "String",
+									"kind":   "SCALAR",
+									"name":   "String",
+									"ofType": nil,
 								},
 							},
 						).Append(
 							schemaUtils.Field{
 								"name": "age",
 								"type": map[string]any{
-									"kind": "SCALAR",
-									"name": "Int",
+									"kind":   "SCALAR",
+									"name":   "Int",
+									"ofType": nil,
 								},
 							},
 						).Tidy(),
@@ -159,6 +162,7 @@ resources:
 								type {
 								name
 								kind
+								ofType { name kind }
 								}
 							}
 						}
@@ -167,20 +171,22 @@ resources:
 				ExpectedData: map[string]any{
 					"__type": map[string]any{
 						"name": "Users", // NOTE: "Users" MUST exist
-						"fields": schemaUtils.DefaultFields.Append(
+						"fields": schemaUtils.DefaultFields("Users").Append(
 							schemaUtils.Field{
 								"name": "name",
 								"type": map[string]any{
-									"kind": "SCALAR",
-									"name": "String",
+									"kind":   "SCALAR",
+									"name":   "String",
+									"ofType": nil,
 								},
 							},
 						).Append(
 							schemaUtils.Field{
 								"name": "age",
 								"type": map[string]any{
-									"kind": "SCALAR",
-									"name": "Int",
+									"kind":   "SCALAR",
+									"name":   "Int",
+									"ofType": nil,
 								},
 							},
 						).Tidy(),
@@ -209,6 +215,7 @@ resources:
 								type {
 								name
 								kind
+								ofType { name kind }
 								}
 							}
 						}
@@ -217,12 +224,13 @@ resources:
 				ExpectedData: map[string]any{
 					"__type": map[string]any{
 						"name": "Books", // NOTE: "Books" MUST exist
-						"fields": schemaUtils.DefaultFields.Append(
+						"fields": schemaUtils.DefaultFields("Books").Append(
 							schemaUtils.Field{
 								"name": "name",
 								"type": map[string]any{
-									"kind": "SCALAR",
-									"name": "String",
+									"kind":   "SCALAR",
+									"name":   "String",
+									"ofType": nil,
 								},
 							},
 						).Tidy(),

--- a/tests/integration/acp/dac/link_collection/accept_permission_with_omitted_owner_authority_test.go
+++ b/tests/integration/acp/dac/link_collection/accept_permission_with_omitted_owner_authority_test.go
@@ -67,6 +67,7 @@ resources:
  								type {
  								name
  								kind
+ 								ofType { name kind }
  								}
  							}
  						}
@@ -75,20 +76,22 @@ resources:
 				ExpectedData: map[string]any{
 					"__type": map[string]any{
 						"name": "Users", // NOTE: "Users" MUST exist
-						"fields": schemaUtils.DefaultFields.Append(
+						"fields": schemaUtils.DefaultFields("Users").Append(
 							schemaUtils.Field{
 								"name": "name",
 								"type": map[string]any{
-									"kind": "SCALAR",
-									"name": "String",
+									"kind":   "SCALAR",
+									"name":   "String",
+									"ofType": nil,
 								},
 							},
 						).Append(
 							schemaUtils.Field{
 								"name": "age",
 								"type": map[string]any{
-									"kind": "SCALAR",
-									"name": "Int",
+									"kind":   "SCALAR",
+									"name":   "Int",
+									"ofType": nil,
 								},
 							},
 						).Tidy(),
@@ -149,6 +152,7 @@ resources:
 								type {
 								name
 								kind
+								ofType { name kind }
 								}
 							}
 						}
@@ -157,20 +161,22 @@ resources:
 				ExpectedData: map[string]any{
 					"__type": map[string]any{
 						"name": "Users", // NOTE: "Users" MUST exist
-						"fields": schemaUtils.DefaultFields.Append(
+						"fields": schemaUtils.DefaultFields("Users").Append(
 							schemaUtils.Field{
 								"name": "name",
 								"type": map[string]any{
-									"kind": "SCALAR",
-									"name": "String",
+									"kind":   "SCALAR",
+									"name":   "String",
+									"ofType": nil,
 								},
 							},
 						).Append(
 							schemaUtils.Field{
 								"name": "age",
 								"type": map[string]any{
-									"kind": "SCALAR",
-									"name": "Int",
+									"kind":   "SCALAR",
+									"name":   "Int",
+									"ofType": nil,
 								},
 							},
 						).Tidy(),
@@ -230,6 +236,7 @@ resources:
  								type {
  								name
  								kind
+ 								ofType { name kind }
  								}
  							}
  						}
@@ -238,20 +245,22 @@ resources:
 				ExpectedData: map[string]any{
 					"__type": map[string]any{
 						"name": "Users", // NOTE: "Users" MUST exist
-						"fields": schemaUtils.DefaultFields.Append(
+						"fields": schemaUtils.DefaultFields("Users").Append(
 							schemaUtils.Field{
 								"name": "name",
 								"type": map[string]any{
-									"kind": "SCALAR",
-									"name": "String",
+									"kind":   "SCALAR",
+									"name":   "String",
+									"ofType": nil,
 								},
 							},
 						).Append(
 							schemaUtils.Field{
 								"name": "age",
 								"type": map[string]any{
-									"kind": "SCALAR",
-									"name": "Int",
+									"kind":   "SCALAR",
+									"name":   "Int",
+									"ofType": nil,
 								},
 							},
 						).Tidy(),

--- a/tests/integration/acp/dac/link_collection/accept_same_resource_on_diff_collections_test.go
+++ b/tests/integration/acp/dac/link_collection/accept_same_resource_on_diff_collections_test.go
@@ -72,6 +72,7 @@ resources:
 								type {
 								name
 								kind
+								ofType { name kind }
 								}
 							}
 						}
@@ -80,20 +81,22 @@ resources:
 				ExpectedData: map[string]any{
 					"__type": map[string]any{
 						"name": "OldUsers", // NOTE: "OldUsers" MUST exist
-						"fields": schemaUtils.DefaultFields.Append(
+						"fields": schemaUtils.DefaultFields("OldUsers").Append(
 							schemaUtils.Field{
 								"name": "name",
 								"type": map[string]any{
-									"kind": "SCALAR",
-									"name": "String",
+									"kind":   "SCALAR",
+									"name":   "String",
+									"ofType": nil,
 								},
 							},
 						).Append(
 							schemaUtils.Field{
 								"name": "age",
 								"type": map[string]any{
-									"kind": "SCALAR",
-									"name": "Int",
+									"kind":   "SCALAR",
+									"name":   "Int",
+									"ofType": nil,
 								},
 							},
 						).Tidy(),
@@ -125,6 +128,7 @@ resources:
 								type {
 								name
 								kind
+								ofType { name kind }
 								}
 							}
 						}
@@ -133,20 +137,22 @@ resources:
 				ExpectedData: map[string]any{
 					"__type": map[string]any{
 						"name": "NewUsers", // NOTE: "NewUsers" MUST exist
-						"fields": schemaUtils.DefaultFields.Append(
+						"fields": schemaUtils.DefaultFields("NewUsers").Append(
 							schemaUtils.Field{
 								"name": "name",
 								"type": map[string]any{
-									"kind": "SCALAR",
-									"name": "String",
+									"kind":   "SCALAR",
+									"name":   "String",
+									"ofType": nil,
 								},
 							},
 						).Append(
 							schemaUtils.Field{
 								"name": "age",
 								"type": map[string]any{
-									"kind": "SCALAR",
-									"name": "Int",
+									"kind":   "SCALAR",
+									"name":   "Int",
+									"ofType": nil,
 								},
 							},
 						).Tidy(),

--- a/tests/integration/collection_version/default_fields.go
+++ b/tests/integration/collection_version/default_fields.go
@@ -13,8 +13,6 @@ package collection_version
 
 import (
 	"sort"
-
-	"github.com/sourcenetwork/defradb/client/request"
 )
 
 type Field = map[string]any
@@ -60,42 +58,48 @@ func (fieldSet fields) array() []any {
 	return result
 }
 
-// DefaultFields contains the list of fields every
-// defra collection should have.
-var DefaultFields = concat(
-	fields{
-		keyField,
-		versionField,
-		groupField,
-		deletedField,
-		similarityField,
-	},
-	aggregateFields,
-)
+// DefaultFields returns the list of fields every defra collection should have.
+// collectionName is the name of the collection type (used for the GROUP field's ofType).
+func DefaultFields(collectionName string) fields {
+	return concat(
+		fields{
+			keyField,
+			versionField,
+			groupField(collectionName),
+			deletedField,
+			similarityField,
+		},
+		aggregateFields,
+	)
+}
 
-// DefaultViewObjFields contains the list of fields every
-// defra view-object should have.
-var DefaultViewObjFields = concat(
-	fields{
-		groupField,
-		similarityField,
-	},
-	aggregateFields,
-)
+// DefaultViewObjFields returns the list of fields every defra view-object should have.
+// viewName is the name of the view type (used for the GROUP field's ofType).
+func DefaultViewObjFields(viewName string) fields {
+	return concat(
+		fields{
+			groupField(viewName),
+			similarityField,
+		},
+		aggregateFields,
+	)
+}
 
 var keyField = Field{
 	"name": "_docID",
 	"type": map[string]any{
-		"kind": "SCALAR",
-		"name": "ID",
+		"kind":   "SCALAR",
+		"name":   "ID",
+		"ofType": nil,
 	},
 }
 
 var deletedField = Field{
 	"name": "_deleted",
 	"type": map[string]any{
-		"kind": "SCALAR",
-		"name": "Boolean",
+		"kind":   "SCALAR",
+		"name":   "Boolean",
+		"ofType": nil,
 	},
 }
 
@@ -104,14 +108,33 @@ var versionField = Field{
 	"type": map[string]any{
 		"kind": "LIST",
 		"name": nil,
+		"ofType": map[string]any{
+			"kind": "OBJECT",
+			"name": "Commit",
+		},
 	},
 }
 
-var groupField = Field{
-	"name": "GROUP",
+func groupField(collectionName string) Field {
+	return Field{
+		"name": "GROUP",
+		"type": map[string]any{
+			"kind": "LIST",
+			"name": nil,
+			"ofType": map[string]any{
+				"kind": "OBJECT",
+				"name": collectionName,
+			},
+		},
+	}
+}
+
+var similarityField = Field{
+	"name": "SIMILARITY",
 	"type": map[string]any{
-		"kind": "LIST",
-		"name": nil,
+		"kind":   "SCALAR",
+		"name":   "Float",
+		"ofType": nil,
 	},
 }
 
@@ -119,45 +142,51 @@ var aggregateFields = fields{
 	map[string]any{
 		"name": "AVG",
 		"type": map[string]any{
-			"kind": "SCALAR",
-			"name": "Float",
+			"kind": "NON_NULL",
+			"name": nil,
+			"ofType": map[string]any{
+				"kind": "SCALAR",
+				"name": "Float",
+			},
 		},
 	},
 	map[string]any{
 		"name": "MAX",
 		"type": map[string]any{
-			"kind": "SCALAR",
-			"name": "Float",
+			"kind":   "SCALAR",
+			"name":   "Float",
+			"ofType": nil,
 		},
 	},
 	map[string]any{
 		"name": "MIN",
 		"type": map[string]any{
-			"kind": "SCALAR",
-			"name": "Float",
+			"kind":   "SCALAR",
+			"name":   "Float",
+			"ofType": nil,
 		},
 	},
 	map[string]any{
 		"name": "COUNT",
 		"type": map[string]any{
-			"kind": "SCALAR",
-			"name": "Int",
+			"kind": "NON_NULL",
+			"name": nil,
+			"ofType": map[string]any{
+				"kind": "SCALAR",
+				"name": "Int",
+			},
 		},
 	},
 	map[string]any{
 		"name": "SUM",
 		"type": map[string]any{
-			"kind": "SCALAR",
-			"name": "Float",
+			"kind": "NON_NULL",
+			"name": nil,
+			"ofType": map[string]any{
+				"kind": "SCALAR",
+				"name": "Float",
+			},
 		},
-	},
-}
-
-var similarityField = Field{
-	"name": "SIMILARITY",
-	"type": map[string]any{
-		"kind": "SCALAR",
-		"name": "Float",
 	},
 }
 
@@ -173,7 +202,7 @@ var cidArg = Field{
 	},
 }
 var docIDArg = Field{
-	"name": request.DocIDArgName,
+	"name": "docID",
 	"type": map[string]any{
 		"name":        nil,
 		"inputFields": nil,

--- a/tests/integration/collection_version/one_many_test.go
+++ b/tests/integration/collection_version/one_many_test.go
@@ -248,6 +248,7 @@ func TestCollectionVersionOneMany_SelfUsingActualName(t *testing.T) {
 								type {
 									name
 									kind
+									ofType { name kind }
 								}
 							}
 						}
@@ -256,26 +257,34 @@ func TestCollectionVersionOneMany_SelfUsingActualName(t *testing.T) {
 				ExpectedData: map[string]any{
 					"__type": map[string]any{
 						"name": "User",
-						"fields": append(DefaultFields,
+						"fields": DefaultFields("User").Append(
 							Field{
 								"name": "boss",
 								"type": map[string]any{
-									"kind": "OBJECT",
-									"name": "User",
+									"kind":   "OBJECT",
+									"name":   "User",
+									"ofType": nil,
 								},
 							},
+						).Append(
 							Field{
 								"name": "_bossID",
 								"type": map[string]any{
-									"kind": "SCALAR",
-									"name": "ID",
+									"kind":   "SCALAR",
+									"name":   "ID",
+									"ofType": nil,
 								},
 							},
+						).Append(
 							Field{
 								"name": "minions",
 								"type": map[string]any{
 									"kind": "LIST",
 									"name": nil,
+									"ofType": map[string]any{
+										"kind": "OBJECT",
+										"name": "User",
+									},
 								},
 							},
 						).Tidy(),

--- a/tests/integration/collection_version/one_one_test.go
+++ b/tests/integration/collection_version/one_one_test.go
@@ -136,6 +136,7 @@ func TestCollectionVersionOneOne_SelfUsingActualName(t *testing.T) {
 								type {
 									name
 									kind
+									ofType { name kind }
 								}
 							}
 						}
@@ -144,33 +145,40 @@ func TestCollectionVersionOneOne_SelfUsingActualName(t *testing.T) {
 				ExpectedData: map[string]any{
 					"__type": map[string]any{
 						"name": "User",
-						"fields": append(DefaultFields,
+						"fields": DefaultFields("User").Append(
 							Field{
 								"name": "boss",
 								"type": map[string]any{
-									"kind": "OBJECT",
-									"name": "User",
+									"kind":   "OBJECT",
+									"name":   "User",
+									"ofType": nil,
 								},
 							},
+						).Append(
 							Field{
 								"name": "_bossID",
 								"type": map[string]any{
-									"kind": "SCALAR",
-									"name": "ID",
+									"kind":   "SCALAR",
+									"name":   "ID",
+									"ofType": nil,
 								},
 							},
+						).Append(
 							Field{
 								"name": "minion",
 								"type": map[string]any{
-									"kind": "OBJECT",
-									"name": "User",
+									"kind":   "OBJECT",
+									"name":   "User",
+									"ofType": nil,
 								},
 							},
+						).Append(
 							Field{
 								"name": "_minionID",
 								"type": map[string]any{
-									"kind": "SCALAR",
-									"name": "ID",
+									"kind":   "SCALAR",
+									"name":   "ID",
+									"ofType": nil,
 								},
 							},
 						).Tidy(),

--- a/tests/integration/collection_version/self_ref_test.go
+++ b/tests/integration/collection_version/self_ref_test.go
@@ -72,6 +72,7 @@ func TestCollectionVersionSelfReferenceSimple_HasSimpleCollectionID(t *testing.T
 								type {
 								name
 								kind
+								ofType { name kind }
 								}
 							}
 						}
@@ -80,20 +81,22 @@ func TestCollectionVersionSelfReferenceSimple_HasSimpleCollectionID(t *testing.T
 				ExpectedData: map[string]any{
 					"__type": map[string]any{
 						"name": "User",
-						"fields": DefaultFields.Append(
+						"fields": DefaultFields("User").Append(
 							Field{
 								"name": "_bossID",
 								"type": map[string]any{
-									"kind": "SCALAR",
-									"name": "ID",
+									"kind":   "SCALAR",
+									"name":   "ID",
+									"ofType": nil,
 								},
 							},
 						).Append(
 							Field{
 								"name": "boss",
 								"type": map[string]any{
-									"kind": "OBJECT",
-									"name": "User",
+									"kind":   "OBJECT",
+									"name":   "User",
+									"ofType": nil,
 								},
 							},
 						).Tidy(),
@@ -246,6 +249,7 @@ func TestCollectionVersionSelfReferenceTwoTypes_HasComplexCollectionID(t *testin
 								type {
 								name
 								kind
+								ofType { name kind }
 								}
 							}
 						}
@@ -254,36 +258,40 @@ func TestCollectionVersionSelfReferenceTwoTypes_HasComplexCollectionID(t *testin
 				ExpectedData: map[string]any{
 					"__type": map[string]any{
 						"name": "User",
-						"fields": DefaultFields.Append(
+						"fields": DefaultFields("User").Append(
 							Field{
 								"name": "_hostsID",
 								"type": map[string]any{
-									"kind": "SCALAR",
-									"name": "ID",
+									"kind":   "SCALAR",
+									"name":   "ID",
+									"ofType": nil,
 								},
 							},
 						).Append(
 							Field{
 								"name": "hosts",
 								"type": map[string]any{
-									"kind": "OBJECT",
-									"name": "Dog",
+									"kind":   "OBJECT",
+									"name":   "Dog",
+									"ofType": nil,
 								},
 							},
 						).Append(
 							Field{
 								"name": "_walksID",
 								"type": map[string]any{
-									"kind": "SCALAR",
-									"name": "ID",
+									"kind":   "SCALAR",
+									"name":   "ID",
+									"ofType": nil,
 								},
 							},
 						).Append(
 							Field{
 								"name": "walks",
 								"type": map[string]any{
-									"kind": "OBJECT",
-									"name": "Dog",
+									"kind":   "OBJECT",
+									"name":   "Dog",
+									"ofType": nil,
 								},
 							},
 						).Tidy(),
@@ -300,6 +308,7 @@ func TestCollectionVersionSelfReferenceTwoTypes_HasComplexCollectionID(t *testin
 									type {
 									name
 									kind
+									ofType { name kind }
 									}
 								}
 							}
@@ -308,36 +317,40 @@ func TestCollectionVersionSelfReferenceTwoTypes_HasComplexCollectionID(t *testin
 				ExpectedData: map[string]any{
 					"__type": map[string]any{
 						"name": "Dog",
-						"fields": DefaultFields.Append(
+						"fields": DefaultFields("Dog").Append(
 							Field{
 								"name": "_hostID",
 								"type": map[string]any{
-									"kind": "SCALAR",
-									"name": "ID",
+									"kind":   "SCALAR",
+									"name":   "ID",
+									"ofType": nil,
 								},
 							},
 						).Append(
 							Field{
 								"name": "host",
 								"type": map[string]any{
-									"kind": "OBJECT",
-									"name": "User",
+									"kind":   "OBJECT",
+									"name":   "User",
+									"ofType": nil,
 								},
 							},
 						).Append(
 							Field{
 								"name": "_walkerID",
 								"type": map[string]any{
-									"kind": "SCALAR",
-									"name": "ID",
+									"kind":   "SCALAR",
+									"name":   "ID",
+									"ofType": nil,
 								},
 							},
 						).Append(
 							Field{
 								"name": "walker",
 								"type": map[string]any{
-									"kind": "OBJECT",
-									"name": "User",
+									"kind":   "OBJECT",
+									"name":   "User",
+									"ofType": nil,
 								},
 							},
 						).Tidy(),

--- a/tests/integration/collection_version/simple_test.go
+++ b/tests/integration/collection_version/simple_test.go
@@ -167,6 +167,7 @@ func TestCollectionVersionSimpleAddsCollectionWithDefaultFieldsGivenEmptyType(t 
 								type {
 								name
 								kind
+								ofType { name kind }
 								}
 							}
 						}
@@ -175,7 +176,7 @@ func TestCollectionVersionSimpleAddsCollectionWithDefaultFieldsGivenEmptyType(t 
 				ExpectedData: map[string]any{
 					"__type": map[string]any{
 						"name":   "Users",
-						"fields": DefaultFields.Tidy(),
+						"fields": DefaultFields("Users").Tidy(),
 					},
 				},
 			},
@@ -240,6 +241,7 @@ func TestCollectionVersionSimpleAddsCollectionGivenTypeWithStringField(t *testin
 								type {
 								name
 								kind
+								ofType { name kind }
 								}
 							}
 						}
@@ -248,12 +250,13 @@ func TestCollectionVersionSimpleAddsCollectionGivenTypeWithStringField(t *testin
 				ExpectedData: map[string]any{
 					"__type": map[string]any{
 						"name": "Users",
-						"fields": DefaultFields.Append(
+						"fields": DefaultFields("Users").Append(
 							Field{
 								"name": "name",
 								"type": map[string]any{
-									"kind": "SCALAR",
-									"name": "String",
+									"kind":   "SCALAR",
+									"name":   "String",
+									"ofType": nil,
 								},
 							},
 						).Tidy(),
@@ -307,6 +310,7 @@ func TestCollectionVersionSimpleAddsCollectionGivenTypeWithBlobField(t *testing.
 								type {
 								name
 								kind
+								ofType { name kind }
 								}
 							}
 						}
@@ -315,12 +319,13 @@ func TestCollectionVersionSimpleAddsCollectionGivenTypeWithBlobField(t *testing.
 				ExpectedData: map[string]any{
 					"__type": map[string]any{
 						"name": "Users",
-						"fields": DefaultFields.Append(
+						"fields": DefaultFields("Users").Append(
 							Field{
 								"name": "data",
 								"type": map[string]any{
-									"kind": "SCALAR",
-									"name": "Blob",
+									"kind":   "SCALAR",
+									"name":   "Blob",
+									"ofType": nil,
 								},
 							},
 						).Tidy(),
@@ -353,6 +358,7 @@ func TestCollectionVersionSimple_WithJSONField_AddsCollectionGivenType(t *testin
 								type {
 								name
 								kind
+								ofType { name kind }
 								}
 							}
 						}
@@ -361,12 +367,13 @@ func TestCollectionVersionSimple_WithJSONField_AddsCollectionGivenType(t *testin
 				ExpectedData: map[string]any{
 					"__type": map[string]any{
 						"name": "Users",
-						"fields": DefaultFields.Append(
+						"fields": DefaultFields("Users").Append(
 							Field{
 								"name": "data",
 								"type": map[string]any{
-									"kind": "SCALAR",
-									"name": "JSON",
+									"kind":   "SCALAR",
+									"name":   "JSON",
+									"ofType": nil,
 								},
 							},
 						).Tidy(),
@@ -399,6 +406,7 @@ func TestCollectionVersionSimple_WithFloat32Field_AddsCollectionGivenType(t *tes
 								type {
 								name
 								kind
+								ofType { name kind }
 								}
 							}
 						}
@@ -407,12 +415,13 @@ func TestCollectionVersionSimple_WithFloat32Field_AddsCollectionGivenType(t *tes
 				ExpectedData: map[string]any{
 					"__type": map[string]any{
 						"name": "Users",
-						"fields": DefaultFields.Append(
+						"fields": DefaultFields("Users").Append(
 							Field{
 								"name": "data",
 								"type": map[string]any{
-									"kind": "SCALAR",
-									"name": "Float32",
+									"kind":   "SCALAR",
+									"name":   "Float32",
+									"ofType": nil,
 								},
 							},
 						).Tidy(),
@@ -445,6 +454,7 @@ func TestCollectionVersionSimple_WithFloat64Field_AddsCollectionGivenType(t *tes
 								type {
 								name
 								kind
+								ofType { name kind }
 								}
 							}
 						}
@@ -453,12 +463,13 @@ func TestCollectionVersionSimple_WithFloat64Field_AddsCollectionGivenType(t *tes
 				ExpectedData: map[string]any{
 					"__type": map[string]any{
 						"name": "Users",
-						"fields": DefaultFields.Append(
+						"fields": DefaultFields("Users").Append(
 							Field{
 								"name": "data",
 								"type": map[string]any{
-									"kind": "SCALAR",
-									"name": "Float64",
+									"kind":   "SCALAR",
+									"name":   "Float64",
+									"ofType": nil,
 								},
 							},
 						).Tidy(),
@@ -491,6 +502,7 @@ func TestCollectionVersionSimple_WithFloatField_AddsCollectionGivenType(t *testi
 								type {
 								name
 								kind
+								ofType { name kind }
 								}
 							}
 						}
@@ -499,12 +511,13 @@ func TestCollectionVersionSimple_WithFloatField_AddsCollectionGivenType(t *testi
 				ExpectedData: map[string]any{
 					"__type": map[string]any{
 						"name": "Users",
-						"fields": DefaultFields.Append(
+						"fields": DefaultFields("Users").Append(
 							Field{
 								"name": "data",
 								"type": map[string]any{
-									"kind": "SCALAR",
-									"name": "Float64",
+									"kind":   "SCALAR",
+									"name":   "Float64",
+									"ofType": nil,
 								},
 							},
 						).Tidy(),
@@ -561,6 +574,7 @@ func TestCollectionVersionSimple_WithAllTypes_AddsCollectionGivenTypes(t *testin
 								type {
 									name
 									kind
+									ofType { name kind }
 								}
 							}
 						}
@@ -569,152 +583,230 @@ func TestCollectionVersionSimple_WithAllTypes_AddsCollectionGivenTypes(t *testin
 				ExpectedData: map[string]any{
 					"__type": map[string]any{
 						"name": "Users",
-						"fields": DefaultFields.Append(
+						"fields": DefaultFields("Users").Append(
 							Field{
 								"name": "tBlob",
 								"type": map[string]any{
-									"kind": "SCALAR",
-									"name": "Blob"},
+									"kind":   "SCALAR",
+									"name":   "Blob",
+									"ofType": nil,
+								},
 							},
 						).Append(
 							Field{
 								"name": "tBool",
 								"type": map[string]any{
-									"kind": "SCALAR",
-									"name": "Boolean"},
+									"kind":   "SCALAR",
+									"name":   "Boolean",
+									"ofType": nil,
+								},
 							},
 						).Append(
 							Field{
 								"name": "tBoolA",
 								"type": map[string]any{
 									"kind": "LIST",
-									"name": any(nil)},
+									"name": any(nil),
+									"ofType": map[string]any{
+										"kind": "NON_NULL",
+										"name": nil,
+									},
+								},
 							},
 						).Append(
 							Field{
 								"name": "tDateTime",
 								"type": map[string]any{
-									"kind": "SCALAR",
-									"name": "DateTime"},
+									"kind":   "SCALAR",
+									"name":   "DateTime",
+									"ofType": nil,
+								},
 							},
 						).Append(
 							Field{
 								"name": "tFloat",
 								"type": map[string]any{
-									"kind": "SCALAR",
-									"name": "Float64"},
+									"kind":   "SCALAR",
+									"name":   "Float64",
+									"ofType": nil,
+								},
 							},
 						).Append(
 							Field{
 								"name": "tFloat32",
 								"type": map[string]any{
-									"kind": "SCALAR",
-									"name": "Float32"},
+									"kind":   "SCALAR",
+									"name":   "Float32",
+									"ofType": nil,
+								},
 							},
 						).Append(
 							Field{
 								"name": "tFloat32A",
 								"type": map[string]any{
 									"kind": "LIST",
-									"name": any(nil)},
+									"name": any(nil),
+									"ofType": map[string]any{
+										"kind": "NON_NULL",
+										"name": nil,
+									},
+								},
 							},
 						).Append(
 							Field{
 								"name": "tFloat64",
 								"type": map[string]any{
-									"kind": "SCALAR",
-									"name": "Float64"},
+									"kind":   "SCALAR",
+									"name":   "Float64",
+									"ofType": nil,
+								},
 							},
 						).Append(
 							Field{
 								"name": "tFloat64A",
 								"type": map[string]any{
 									"kind": "LIST",
-									"name": any(nil)},
+									"name": any(nil),
+									"ofType": map[string]any{
+										"kind": "NON_NULL",
+										"name": nil,
+									},
+								},
 							},
 						).Append(
 							Field{
 								"name": "tFloatA",
 								"type": map[string]any{
 									"kind": "LIST",
-									"name": any(nil)},
+									"name": any(nil),
+									"ofType": map[string]any{
+										"kind": "NON_NULL",
+										"name": nil,
+									},
+								},
 							},
 						).Append(
 							Field{
 								"name": "tInt",
 								"type": map[string]any{
-									"kind": "SCALAR",
-									"name": "Int"},
+									"kind":   "SCALAR",
+									"name":   "Int",
+									"ofType": nil,
+								},
 							},
 						).Append(
 							Field{
 								"name": "tIntA",
 								"type": map[string]any{
 									"kind": "LIST",
-									"name": any(nil)},
+									"name": any(nil),
+									"ofType": map[string]any{
+										"kind": "NON_NULL",
+										"name": nil,
+									},
+								},
 							},
 						).Append(
 							Field{
 								"name": "tJSON",
 								"type": map[string]any{
-									"kind": "SCALAR",
-									"name": "JSON"},
+									"kind":   "SCALAR",
+									"name":   "JSON",
+									"ofType": nil,
+								},
 							},
 						).Append(
 							Field{
 								"name": "tNBoolA",
 								"type": map[string]any{
 									"kind": "LIST",
-									"name": any(nil)},
+									"name": any(nil),
+									"ofType": map[string]any{
+										"kind": "SCALAR",
+										"name": "Boolean",
+									},
+								},
 							},
 						).Append(
 							Field{
 								"name": "tNFloat32A",
 								"type": map[string]any{
 									"kind": "LIST",
-									"name": any(nil)},
+									"name": any(nil),
+									"ofType": map[string]any{
+										"kind": "SCALAR",
+										"name": "Float32",
+									},
+								},
 							},
 						).Append(
 							Field{
 								"name": "tNFloat64A",
 								"type": map[string]any{
 									"kind": "LIST",
-									"name": any(nil)},
+									"name": any(nil),
+									"ofType": map[string]any{
+										"kind": "SCALAR",
+										"name": "Float64",
+									},
+								},
 							},
 						).Append(
 							Field{
 								"name": "tNFloatA",
 								"type": map[string]any{
 									"kind": "LIST",
-									"name": any(nil)},
+									"name": any(nil),
+									"ofType": map[string]any{
+										"kind": "SCALAR",
+										"name": "Float64",
+									},
+								},
 							},
 						).Append(
 							Field{
 								"name": "tNIntA",
 								"type": map[string]any{
 									"kind": "LIST",
-									"name": any(nil)},
+									"name": any(nil),
+									"ofType": map[string]any{
+										"kind": "SCALAR",
+										"name": "Int",
+									},
+								},
 							},
 						).Append(
 							Field{
 								"name": "tNStringA",
 								"type": map[string]any{
 									"kind": "LIST",
-									"name": any(nil)},
+									"name": any(nil),
+									"ofType": map[string]any{
+										"kind": "SCALAR",
+										"name": "String",
+									},
+								},
 							},
 						).Append(
 							Field{
 								"name": "tString",
 								"type": map[string]any{
-									"kind": "SCALAR",
-									"name": "String"},
+									"kind":   "SCALAR",
+									"name":   "String",
+									"ofType": nil,
+								},
 							},
 						).Append(
 							Field{
 								"name": "tStringA",
 								"type": map[string]any{
 									"kind": "LIST",
-									"name": any(nil)},
+									"name": any(nil),
+									"ofType": map[string]any{
+										"kind": "NON_NULL",
+										"name": nil,
+									},
+								},
 							},
 						).Tidy(),
 					},

--- a/tests/integration/collection_version/updates/add/field/with_introspection_test.go
+++ b/tests/integration/collection_version/updates/add/field/with_introspection_test.go
@@ -44,6 +44,7 @@ func TestCollectionVersionUpdatesAddFieldIntrospection(t *testing.T) {
 								type {
 									name
 									kind
+									ofType { name kind }
 								}
 							}
 						}
@@ -52,12 +53,13 @@ func TestCollectionVersionUpdatesAddFieldIntrospection(t *testing.T) {
 				ExpectedData: map[string]any{
 					"__type": map[string]any{
 						"name": "Users",
-						"fields": introspectionUtils.DefaultFields.Append(
+						"fields": introspectionUtils.DefaultFields("Users").Append(
 							introspectionUtils.Field{
 								"name": "name",
 								"type": map[string]any{
-									"kind": "SCALAR",
-									"name": "String",
+									"kind":   "SCALAR",
+									"name":   "String",
+									"ofType": nil,
 								},
 							},
 						).Tidy(),
@@ -98,6 +100,7 @@ func TestCollectionVersionUpdatesAddFieldIntrospectionDoesNotAmendGQLTypesGivenB
 								type {
 									name
 									kind
+									ofType { name kind }
 								}
 							}
 						}
@@ -107,7 +110,7 @@ func TestCollectionVersionUpdatesAddFieldIntrospectionDoesNotAmendGQLTypesGivenB
 					"__type": map[string]any{
 						"name": "Users",
 						// No fields have been added to the GQL [Users] type.
-						"fields": introspectionUtils.DefaultFields.Tidy(),
+						"fields": introspectionUtils.DefaultFields("Users").Tidy(),
 					},
 				},
 			},

--- a/tests/integration/collection_version/updates/copy/field/with_introspection_test.go
+++ b/tests/integration/collection_version/updates/copy/field/with_introspection_test.go
@@ -48,6 +48,7 @@ func TestCollectionVersionUpdatesCopyFieldIntrospectionWithRemoveIDAndReplaceNam
 								type {
 									name
 									kind
+									ofType { name kind }
 								}
 							}
 						}
@@ -56,20 +57,22 @@ func TestCollectionVersionUpdatesCopyFieldIntrospectionWithRemoveIDAndReplaceNam
 				ExpectedData: map[string]any{
 					"__type": map[string]any{
 						"name": "Users",
-						"fields": introspectionUtils.DefaultFields.Append(
+						"fields": introspectionUtils.DefaultFields("Users").Append(
 							introspectionUtils.Field{
 								"name": "name",
 								"type": map[string]any{
-									"kind": "SCALAR",
-									"name": "String",
+									"kind":   "SCALAR",
+									"name":   "String",
+									"ofType": nil,
 								},
 							},
 						).Append(
 							introspectionUtils.Field{
 								"name": "fax",
 								"type": map[string]any{
-									"kind": "SCALAR",
-									"name": "String",
+									"kind":   "SCALAR",
+									"name":   "String",
+									"ofType": nil,
 								},
 							},
 						).Tidy(),

--- a/tests/integration/view/one_to_many/with_introspection_test.go
+++ b/tests/integration/view/one_to_many/with_introspection_test.go
@@ -63,6 +63,7 @@ func TestView_OneToMany_GQLIntrospectionTest(t *testing.T) {
 								type {
 									name
 									kind
+									ofType { name kind }
 								}
 							}
 						}
@@ -71,12 +72,13 @@ func TestView_OneToMany_GQLIntrospectionTest(t *testing.T) {
 				ExpectedData: map[string]any{
 					"__type": map[string]any{
 						"name": "AuthorView",
-						"fields": collection_version.DefaultViewObjFields.Append(
+						"fields": collection_version.DefaultViewObjFields("AuthorView").Append(
 							collection_version.Field{
 								"name": "name",
 								"type": map[string]any{
-									"kind": "SCALAR",
-									"name": "String",
+									"kind":   "SCALAR",
+									"name":   "String",
+									"ofType": nil,
 								},
 							},
 						).Append(
@@ -85,6 +87,10 @@ func TestView_OneToMany_GQLIntrospectionTest(t *testing.T) {
 								"type": map[string]any{
 									"kind": "LIST",
 									"name": nil,
+									"ofType": map[string]any{
+										"kind": "OBJECT",
+										"name": "BookView",
+									},
 								},
 							},
 						).Tidy(),
@@ -101,6 +107,7 @@ func TestView_OneToMany_GQLIntrospectionTest(t *testing.T) {
 								type {
 									name
 									kind
+									ofType { name kind }
 								}
 							}
 						}
@@ -113,12 +120,13 @@ func TestView_OneToMany_GQLIntrospectionTest(t *testing.T) {
 						// although aggregates and `GROUP` should be.
 						// There should also be no `Author` field - the relationship field
 						// should only exist on the parent.
-						"fields": collection_version.DefaultViewObjFields.Append(
+						"fields": collection_version.DefaultViewObjFields("BookView").Append(
 							collection_version.Field{
 								"name": "name",
 								"type": map[string]any{
-									"kind": "SCALAR",
-									"name": "String",
+									"kind":   "SCALAR",
+									"name":   "String",
+									"ofType": nil,
 								},
 							},
 						).Tidy(),

--- a/tests/integration/view/simple/with_introspection_test.go
+++ b/tests/integration/view/simple/with_introspection_test.go
@@ -51,6 +51,7 @@ func TestView_Simple_GQLIntrospectionTest(t *testing.T) {
 								type {
 									name
 									kind
+									ofType { name kind }
 								}
 							}
 						}
@@ -59,12 +60,13 @@ func TestView_Simple_GQLIntrospectionTest(t *testing.T) {
 				ExpectedData: map[string]any{
 					"__type": map[string]any{
 						"name": "UserView",
-						"fields": collection_version.DefaultViewObjFields.Append(
+						"fields": collection_version.DefaultViewObjFields("UserView").Append(
 							collection_version.Field{
 								"name": "name",
 								"type": map[string]any{
-									"kind": "SCALAR",
-									"name": "String",
+									"kind":   "SCALAR",
+									"name":   "String",
+									"ofType": nil,
 								},
 							},
 						).Tidy(),


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4920 

## Description

The core change can be seen inside `generate.go` and are minimal. Instead of `gql.Int` and `gql.Float`, we will return `gql.NewNonNull(gql.Int)` and `gql.NewNonNull(gql.Float)`. This, unfortunately, has widespread breaking changes across many of our tests. The reeason for this, is that before we expected a result in the form:

`{kind: SCALAR, name: "Int"}`

But with these changes, it will now be wrapped as: 

`kind: NON_NULL, name: null, ofType: {kind: SCALAR, name: "Int"}}`

All instances of tests expecting the old shape need to be updated.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?


Specify the platform(s) on which this was tested:
- WSL