### PR TITLE
chore: Prefer docID doc update/delete in c bindings

### DIFF
--- a/cbindings/document_delete.go
+++ b/cbindings/document_delete.go
@@ -58,6 +58,8 @@ func DeleteDocument(nodePtr C.uintptr_t,
 	docID := C.GoString(docIDStr)
 	filter := C.GoString(filterStr)
 	switch {
+
+	// If docID is provided, delete the document by docID
 	case docID != "":
 		ID, err := client.NewDocIDFromString(docID)
 		if err != nil {
@@ -68,6 +70,8 @@ func DeleteDocument(nodePtr C.uintptr_t,
 			return returnC(returnGoC(1, err.Error(), ""))
 		}
 		return returnC(returnGoC(0, "", ""))
+
+	// If docID is not provided, next try to delete by filter
 	case filter != "":
 		var filterValue any
 		if err := json.Unmarshal([]byte(filter), &filterValue); err != nil {
@@ -83,6 +87,8 @@ func DeleteDocument(nodePtr C.uintptr_t,
 			return returnC(returnGoC(1, err.Error(), ""))
 		}
 		return returnC(returnGoC(0, "", string(jsonBytes)))
+
+	// If neither docID nor filter is provided, that must be an error
 	default:
 		return returnC(returnGoC(1, errNoDocIDOrFilter, ""))
 	}

--- a/cbindings/document_delete.go
+++ b/cbindings/document_delete.go
@@ -58,7 +58,6 @@ func DeleteDocument(nodePtr C.uintptr_t,
 	docID := C.GoString(docIDStr)
 	filter := C.GoString(filterStr)
 	switch {
-
 	// If docID is provided, delete the document by docID
 	case docID != "":
 		ID, err := client.NewDocIDFromString(docID)

--- a/cbindings/document_update.go
+++ b/cbindings/document_update.go
@@ -61,7 +61,6 @@ func UpdateDocument(
 	filter := C.GoString(filterStr)
 	updater := C.GoString(updaterStr)
 	switch {
-
 	// If docID is provided, update the document by docID
 	case docID != "":
 		newDocID, err := client.NewDocIDFromString(docID)

--- a/cbindings/document_update.go
+++ b/cbindings/document_update.go
@@ -61,24 +61,8 @@ func UpdateDocument(
 	filter := C.GoString(filterStr)
 	updater := C.GoString(updaterStr)
 	switch {
-	// Update by filter
-	case filter != "":
-		var filterValue any
-		if err := json.Unmarshal([]byte(filter), &filterValue); err != nil {
-			return returnC(returnGoC(1, err.Error(), ""))
-		}
-		res, err := col.UpdateDocumentsWithFilter(ctx, filterValue, updater,
-			options.WithIdentity(options.UpdateDocumentsWithFilter(), ident))
-		if err != nil {
-			return returnC(returnGoC(1, err.Error(), ""))
-		}
-		jsonBytes, err := json.Marshal(res)
-		if err != nil {
-			return returnC(returnGoC(1, err.Error(), ""))
-		}
-		return returnC(returnGoC(0, "", string(jsonBytes)))
 
-	// Update by docID
+	// If docID is provided, update the document by docID
 	case docID != "":
 		newDocID, err := client.NewDocIDFromString(docID)
 		if err != nil {
@@ -97,6 +81,25 @@ func UpdateDocument(
 			return returnC(returnGoC(1, err.Error(), ""))
 		}
 		return returnC(returnGoC(0, "", ""))
+
+	// If docID is not provided, next try to update the documents by filter
+	case filter != "":
+		var filterValue any
+		if err := json.Unmarshal([]byte(filter), &filterValue); err != nil {
+			return returnC(returnGoC(1, err.Error(), ""))
+		}
+		res, err := col.UpdateDocumentsWithFilter(ctx, filterValue, updater,
+			options.WithIdentity(options.UpdateDocumentsWithFilter(), ident))
+		if err != nil {
+			return returnC(returnGoC(1, err.Error(), ""))
+		}
+		jsonBytes, err := json.Marshal(res)
+		if err != nil {
+			return returnC(returnGoC(1, err.Error(), ""))
+		}
+		return returnC(returnGoC(0, "", string(jsonBytes)))
+
+	// If neither docID nor filter is provided, that must be an error
 	default:
 		return returnC(returnGoC(1, errNoDocIDOrFilter, ""))
 	}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4829

## Description

Previously, the `DeleteDocument` and `UpdateDocument` functions in the C bindings behaved a little bit differently from one another. In the case of both a filter and docID being provided, one would rely on the docID to perform the operation, while the other would rely on the filter. This makes them consistent, in that they will both prioritize the docID over a filter, as was discussed in our team's standup meeting.

This fix is simple, and is expected to affect no other parts of the code base.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Specify the platform(s) on which this was tested:
- WSL
