### PR TITLE
fix(merge): only process composite blocks as merge heads (counter double-apply, #4935)

### DIFF
--- a/internal/db/merge.go
+++ b/internal/db/merge.go
@@ -247,7 +247,15 @@ func (mp *mergeProcessor) loadComposites(
 	// of the composite DAG. However, the new block and its children might have branched off from an older block.
 	// In this case, we also need to walk back the merge target's DAG until we reach a common block.
 	if block.Delta.GetPriority() >= mt.headHeight {
-		mp.composites.PushFront(block)
+		// Only composite blocks may enter the merge-processing list. A field
+		// (e.g. counter) block can reach here as the merge head when a peer pushes
+		// the DAG block-by-block (every block as its own pushLogRequest); processing
+		// it directly re-applies its delta — already applied via its owning
+		// composite's link recursion — double-counting counters (#4935). The
+		// composite is the merge unit and carries the field via its links.
+		if block.Delta.IsComposite() {
+			mp.composites.PushFront(block)
+		}
 		for _, head := range block.Heads {
 			err := mp.loadComposites(ctx, head.Cid, mt)
 			if err != nil {

--- a/internal/db/merge_counter_double_apply_test.go
+++ b/internal/db/merge_counter_double_apply_test.go
@@ -1,0 +1,127 @@
+// Copyright 2024 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ipld/go-ipld-prime"
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcenetwork/corekv/blockstore"
+	"github.com/sourcenetwork/immutable"
+
+	"github.com/sourcenetwork/defradb/client"
+	"github.com/sourcenetwork/defradb/event"
+	coreblock "github.com/sourcenetwork/defradb/internal/core/block"
+	"github.com/sourcenetwork/defradb/internal/core/crdt"
+	"github.com/sourcenetwork/defradb/internal/datastore"
+)
+
+const counterSchema = `
+type Tally {
+	hits: Int @crdt(type: pcounter)
+}
+`
+
+func tallyHits(ctx context.Context, t *testing.T, col client.Collection, docID client.DocID) int64 {
+	doc, err := col.GetDocument(ctx, docID)
+	require.NoError(t, err)
+	m, err := doc.ToMap()
+	require.NoError(t, err)
+	v, _ := m["hits"].(int64)
+	return v
+}
+
+// Merging from a *field-block* CID as the head must be idempotent: a counter
+// field delta must not be re-applied when its block arrives as a merge head.
+//
+// Repro for the counter multiply-apply bug: `coreblock.ProcessBlock` applies the
+// delta unconditionally (no per-block `IsMerged` guard), so when `executeMerge`
+// is invoked with a field-block CID (as happens when a peer pushes the DAG
+// block-by-block — every block as its own pushLogRequest), `loadComposites`
+// collects that field block into the processing list and `processBlock` applies
+// its counter delta a SECOND time (the first application happened via the field
+// block's owning composite). The materialized counter is then double-counted.
+//
+// This test merges a single +5 increment via its composite head (value -> 5),
+// then merges from the field-block head and asserts the value is still 5. On
+// current code it becomes 10.
+func TestMerge_CounterFieldBlockAsHead_IsNotReapplied(t *testing.T) {
+	ctx := context.Background()
+
+	db, err := newBadgerDB(ctx)
+	require.NoError(t, err)
+	defer db.Close()
+
+	_, err = db.AddCollection(ctx, counterSchema)
+	require.NoError(t, err)
+
+	col, err := db.GetCollectionByName(ctx, "Tally")
+	require.NoError(t, err)
+
+	lsys := cidlink.DefaultLinkSystem()
+	lsys.SetWriteStorage(blockstore.NewIPLDStore(datastore.BlockstoreFrom(db.rootstore, immutable.None[int]())))
+
+	doc, err := client.NewDocFromMap(ctx, map[string]any{"hits": int64(5)}, col.Version())
+	require.NoError(t, err)
+	docID := []byte(doc.ID().String())
+
+	// One counter increment of +5: a field block (priority 1) linked by a
+	// composite block (priority 1).
+	fieldBlock := coreblock.Block{
+		Delta: crdt.CRDT{CounterDelta: &crdt.CounterDelta{
+			DocID:               docID,
+			FieldName:           "hits",
+			Priority:            1,
+			CollectionVersionID: col.Version().VersionID,
+			Data:                encodeValue(int64(5)),
+		}},
+	}
+	fieldLink, err := lsys.Store(ipld.LinkContext{}, coreblock.GetLinkPrototype(), fieldBlock.GenerateNode())
+	require.NoError(t, err)
+
+	compositeBlock := coreblock.New(
+		crdt.NewCRDT(&crdt.DocCompositeDelta{
+			DocID:               docID,
+			Priority:            1,
+			CollectionVersionID: col.Version().VersionID,
+			Status:              1,
+		}),
+		[]coreblock.DAGLink{{Name: "hits", Link: fieldLink.(cidlink.Link)}},
+	)
+	compositeLink, err := lsys.Store(ipld.LinkContext{}, coreblock.GetLinkPrototype(), compositeBlock.GenerateNode())
+	require.NoError(t, err)
+
+	// Normal merge from the composite head: the counter accumulates to 5.
+	err = db.executeMerge(ctx, col.(*collection), event.Merge{
+		DocID:        doc.ID().String(),
+		Cid:          compositeLink.(cidlink.Link).Cid,
+		CollectionID: col.CollectionID(),
+	})
+	require.NoError(t, err)
+	require.Equal(t, int64(5), tallyHits(ctx, t, col, doc.ID()))
+
+	// A peer that pushes the document DAG block-by-block delivers the field block
+	// as its own pushLogRequest head. Merging from that field-block head must be
+	// idempotent (the increment was already applied via the composite above).
+	err = db.executeMerge(ctx, col.(*collection), event.Merge{
+		DocID:        doc.ID().String(),
+		Cid:          fieldLink.(cidlink.Link).Cid,
+		CollectionID: col.CollectionID(),
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, int64(5), tallyHits(ctx, t, col, doc.ID()),
+		"counter field delta was re-applied when its block arrived as a merge head (double-count)")
+}


### PR DESCRIPTION
## What

Fixes #4935 — a counter (P/PN-counter) is **multiply applied** during merge when a field block arrives as a PushLog head, sometimes running away to hundreds/thousands of times the correct value, with permanent divergence despite an identical commit DAG.

## Why

`mergeProcessor.loadComposites` collects whatever block the merge head resolves to into the composite-processing list. When that head is a **field block** (e.g. a counter delta block delivered standalone — as happens when a peer pushes the document DAG block-by-block, every block as its own `pushLogRequest`), `processBlock` applies its delta **directly** — even though the same delta is already applied via the field block's owning composite's link recursion. The counter is double-counted, and the post-merge relay can compound it into a runaway.

A naive "skip if already merged" guard inside `ProcessBlock` does **not** work: `updateHeads` marks a composite's linked field CIDs as merged *before* the recursion applies them, so a field block already looks merged on its first (correct) application.

## Fix

Only **composite** blocks may enter the merge-processing list — they are the merge unit and carry their fields via links. A non-composite merge head becomes a no-op (the owning composite delivers the field). `loadComposites` only ever walks composite `Heads`, so normal merges are unaffected; this only filters a field-block *root* head.

## Tests

`TestMerge_CounterFieldBlockAsHead_IsNotReapplied` (added in the first commit, deterministic, single-node): merge a `+5` increment via its composite head (value → 5), then merge from the **field-block** head and assert the value is still 5. Fails on the unfixed processor (becomes 10); passes with the fix. Full `internal/db/...` suite passes.

The first commit adds the failing test; the second adds the fix.

## Context

Found via cross-implementation conformance testing (a Rust implementation interoperating over the same P2P protocol); see #4935 for the full investigation, instrumented traces, and the cross-impl repro. The interoperating implementation independently stopped emitting field-block heads from its backfill/retry path, which removed the runaway but **not** the residual — confirming the durable fix belongs here in the merge processor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
