### PR TITLE
fix(i): P2P KMS async flakey behavior

### DIFF
--- a/internal/kms/pubsub.go
+++ b/internal/kms/pubsub.go
@@ -258,7 +258,9 @@ func (s *pubSubService) handleFetchEncryptionKeyResponses(
 	privateKey *ecdh.PrivateKey,
 	result chan<- encryption.Result,
 ) {
-	// track latest `cancelPublish` func via the closure
+	// track latest `cancelPublish` func via the closure since the cancel func
+	// is mutated in this function and we need to cancel the latest value at defer
+	// time
 	defer func() {
 		cancelPublish()
 	}()

--- a/internal/kms/pubsub.go
+++ b/internal/kms/pubsub.go
@@ -14,6 +14,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/ecdh"
+	crand "crypto/rand"
 	"encoding/base64"
 	"time"
 
@@ -21,6 +22,7 @@ import (
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	grpcpeer "google.golang.org/grpc/peer"
 
+	"github.com/sourcenetwork/corelog"
 	"github.com/sourcenetwork/immutable"
 
 	"github.com/sourcenetwork/defradb/acp/dac"
@@ -40,6 +42,12 @@ const pubsubTopic = "encryption"
 // fetchEncryptionKeyResponseTimeout bounds the wait for a key-holding peer
 // when the request context has no deadline.
 const fetchEncryptionKeyResponseTimeout = 5 * time.Second
+
+// fetchEncryptionKeyRetryInterval bounds how long a single pubsub publish can
+// wait for a valid key response before the request is republished. Pubsub topic
+// membership can lag behind direct peer connections, especially in tests that
+// connect peers and immediately publish an encrypted block.
+const fetchEncryptionKeyRetryInterval = time.Second
 
 type PubSubServer interface {
 	AddPubSubTopic(
@@ -130,6 +138,7 @@ type fetchEncryptionKeyRequest struct {
 	Identity           []byte
 	Links              [][]byte
 	EphemeralPublicKey []byte
+	RequestID          []byte
 }
 
 // handleEncryptionMessage handles incoming FetchEncryptionKeyRequest messages from the pubsub network.
@@ -194,29 +203,49 @@ func (s *pubSubService) requestEncryptionKeyFromPeers(
 		return err
 	}
 
-	data, err := cbor.Marshal(req)
+	data, err := marshalFetchEncryptionKeyRequest(req)
 	if err != nil {
 		return errors.Wrap("failed to marshal pubsub message", err)
 	}
 
+	respChan, cancel, err := s.publishFetchEncryptionKeyRequest(ctx, data)
+	if err != nil {
+		return errors.Wrap("failed publishing to encryption thread", err)
+	}
+
+	go s.handleFetchEncryptionKeyResponses(ctx, cancel, respChan, req, ephPrivKey, result)
+
+	return nil
+}
+
+func marshalFetchEncryptionKeyRequest(req *fetchEncryptionKeyRequest) ([]byte, error) {
+	req.RequestID = make([]byte, 16)
+	if _, err := crand.Read(req.RequestID); err != nil {
+		return nil, err
+	}
+	return cbor.Marshal(req)
+}
+
+func (s *pubSubService) publishFetchEncryptionKeyRequest(
+	ctx context.Context,
+	data []byte,
+) (<-chan client.PubsubResponse, context.CancelFunc, error) {
 	// Cancel signals the go-p2p relay goroutine to stop; without it, it would
 	// block forever on its unbuffered send once we return after the first valid reply.
 	pubCtx, cancel := context.WithCancel(ctx)
 	respChan, err := s.pubsub.PublishToTopic(pubCtx, pubsubTopic, data, true)
 	if err != nil {
 		cancel()
-		return errors.Wrap("failed publishing to encryption thread", err)
+		return nil, nil, err
 	}
-
-	go s.handleFetchEncryptionKeyResponses(pubCtx, cancel, respChan, req, ephPrivKey, result)
-
-	return nil
+	return respChan, cancel, nil
 }
 
 type fetchEncryptionKeyReply struct {
 	Links              [][]byte
 	Blocks             [][]byte
 	EphemeralPublicKey []byte
+	Sender             string
 }
 
 // handleFetchEncryptionKeyResponses consumes peer replies until one carries
@@ -229,7 +258,10 @@ func (s *pubSubService) handleFetchEncryptionKeyResponses(
 	privateKey *ecdh.PrivateKey,
 	result chan<- encryption.Result,
 ) {
-	defer cancelPublish()
+	// track latest `cancelPublish` func via the closure
+	defer func() {
+		cancelPublish()
+	}()
 	defer close(result)
 
 	waitCtx := ctx
@@ -239,12 +271,22 @@ func (s *pubSubService) handleFetchEncryptionKeyResponses(
 		defer cancel()
 	}
 
+	retryTimer := time.NewTimer(fetchEncryptionKeyRetryInterval)
+	defer retryTimer.Stop()
+
 	for {
 		select {
 		case resp, ok := <-respChan:
 			if !ok {
-				result <- encryption.Result{Error: ErrNoPeerSuppliedEncryptionKey}
-				return
+				nextRespChan, nextCancel, err := s.republishFetchEncryptionKeyRequest(waitCtx, req, retryTimer)
+				if err != nil {
+					result <- encryption.Result{Error: ErrNoPeerSuppliedEncryptionKey}
+					return
+				}
+				cancelPublish()
+				cancelPublish = nextCancel
+				respChan = nextRespChan
+				continue
 			}
 			items, ok := s.tryHandleFetchEncryptionKeyResponse(resp, req, privateKey)
 			if !ok {
@@ -253,11 +295,58 @@ func (s *pubSubService) handleFetchEncryptionKeyResponses(
 			result <- encryption.Result{Items: items}
 			return
 
+		case <-retryTimer.C:
+			nextRespChan, nextCancel, err := s.republishFetchEncryptionKeyRequest(waitCtx, req, retryTimer)
+			if err != nil {
+				result <- encryption.Result{Error: ErrNoPeerSuppliedEncryptionKey}
+				return
+			}
+			cancelPublish()
+			cancelPublish = nextCancel
+			respChan = nextRespChan
+
 		case <-waitCtx.Done():
 			result <- encryption.Result{Error: ErrNoPeerSuppliedEncryptionKey}
 			return
 		}
 	}
+}
+
+func (s *pubSubService) republishFetchEncryptionKeyRequest(
+	ctx context.Context,
+	req *fetchEncryptionKeyRequest,
+	retryTimer *time.Timer,
+) (<-chan client.PubsubResponse, context.CancelFunc, error) {
+	if ctx.Err() != nil {
+		return nil, nil, ctx.Err()
+	}
+
+	// The pubsub RPC layer keys in-flight responses by a hash of request bytes.
+	// Give each republish distinct bytes so an older canceled attempt cannot
+	// delete the newer attempt's response slot.
+	requestData, err := marshalFetchEncryptionKeyRequest(req)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	respChan, cancel, err := s.publishFetchEncryptionKeyRequest(ctx, requestData)
+	if err != nil {
+		log.ErrorContextE(ctx, "failed republishing encryption key request", err)
+		return nil, nil, err
+	}
+	resetTimer(retryTimer, fetchEncryptionKeyRetryInterval)
+	return respChan, cancel, nil
+}
+
+func resetTimer(timer *time.Timer, d time.Duration) {
+	if !timer.Stop() {
+		// drain timer
+		select {
+		case <-timer.C:
+		default:
+		}
+	}
+	timer.Reset(d)
 }
 
 // tryHandleFetchEncryptionKeyResponse returns (items, true) only when the
@@ -283,13 +372,27 @@ func (s *pubSubService) tryHandleFetchEncryptionKeyResponse(
 		// Peer didn't have the key; keep waiting for the one that does.
 		return nil, false
 	}
+	if len(keyResp.Links) != len(keyResp.Blocks) {
+		log.ErrorContext(
+			s.ctx,
+			"encryption key peer reply had mismatched links and blocks",
+			corelog.Int("LinkCount", len(keyResp.Links)),
+			corelog.Int("BlockCount", len(keyResp.Blocks)),
+		)
+		return nil, false
+	}
+
+	senderID := keyResp.Sender
+	if senderID == "" {
+		senderID = resp.From
+	}
 
 	resultEncItems := make([]encryption.Item, 0, len(keyResp.Blocks))
 	for i, block := range keyResp.Blocks {
 		decryptedData, err := crypto.DecryptECIES(
 			block,
 			privateKey,
-			crypto.WithAAD(makeAssociatedData(req, resp.From)),
+			crypto.WithAAD(makeAssociatedData(req, senderID)),
 			crypto.WithPubKeyBytes(keyResp.EphemeralPublicKey),
 			crypto.WithPubKeyPrepended(false),
 		)
@@ -324,7 +427,7 @@ func (s *pubSubService) tryGenEncryptionKeyLocally(
 	ctx context.Context,
 	req *fetchEncryptionKeyRequest,
 ) (*fetchEncryptionKeyReply, error) {
-	blocks, err := s.getEncryptionKeysLocally(ctx, req)
+	links, blocks, err := s.getEncryptionKeysLocally(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -343,8 +446,9 @@ func (s *pubSubService) tryGenEncryptionKeyLocally(
 	}
 
 	res := &fetchEncryptionKeyReply{
-		Links:              req.Links,
+		Links:              links,
 		EphemeralPublicKey: privKey.PublicKey().Bytes(),
+		Sender:             s.peerID,
 	}
 
 	res.Blocks = make([][]byte, 0, len(blocks))
@@ -372,20 +476,19 @@ func (s *pubSubService) tryGenEncryptionKeyLocally(
 func (s *pubSubService) getEncryptionKeysLocally(
 	ctx context.Context,
 	req *fetchEncryptionKeyRequest,
-) ([][]byte, error) {
+) ([][]byte, [][]byte, error) {
 	var actorIdentity immutable.Option[identity.Identity]
 	if len(req.Identity) > 0 {
 		actorIdentity = immutable.Some(identity.FromDID(string(req.Identity)))
 	}
 
+	links := make([][]byte, 0, len(req.Links))
 	blocks := make([][]byte, 0, len(req.Links))
 	for _, link := range req.Links {
 		encBlock, err := s.encStore.get(ctx, link)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		// TODO: we should test it somehow. For this this one peer should have some keys and
-		// another one should have the others. https://github.com/sourcenetwork/defradb/issues/2895
 		if encBlock == nil {
 			continue
 		}
@@ -395,7 +498,7 @@ func (s *pubSubService) getEncryptionKeysLocally(
 			// Doc-scoped block: gate on per-doc DAC.
 			hasPerm, err := s.doesIdentityHaveDocPermission(ctx, actorIdentity, docID)
 			if err != nil {
-				return nil, err
+				return nil, nil, err
 			}
 			if !hasPerm {
 				continue
@@ -408,7 +511,7 @@ func (s *pubSubService) getEncryptionKeysLocally(
 			// this is a no-op, preserving existing behaviour.
 			hasNodeAccess, err := s.doesIdentityHaveNodeReadAccess(ctx, actorIdentity)
 			if err != nil {
-				return nil, err
+				return nil, nil, err
 			}
 			if !hasNodeAccess {
 				continue
@@ -417,12 +520,13 @@ func (s *pubSubService) getEncryptionKeysLocally(
 
 		encBlockBytes, err := encBlock.Marshal()
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 
+		links = append(links, link)
 		blocks = append(blocks, encBlockBytes)
 	}
-	return blocks, nil
+	return links, blocks, nil
 }
 
 // doesIdentityHaveDocPermission asks whether actorIdentity may read docID.

--- a/internal/kms/pubsub.go
+++ b/internal/kms/pubsub.go
@@ -292,6 +292,12 @@ func (s *pubSubService) handleFetchEncryptionKeyResponses(
 			if !ok {
 				continue
 			}
+
+			// TODO: If multi-key requests become common, aggregate partial
+			// responses from multiple peers until every requested link is found or
+			// the timeout fires. A single valid response may contain fewer blocks
+			// than the request asked for.
+			// https://github.com/sourcenetwork/defradb/issues/4947
 			result <- encryption.Result{Items: items}
 			return
 
@@ -406,6 +412,9 @@ func (s *pubSubService) tryHandleFetchEncryptionKeyResponse(
 			return nil, false
 		}
 
+		// todo: verify incoming response order block/CIDs match the request
+		// current implementation assumes trusted response ordering
+		// https://github.com/sourcenetwork/defradb/issues/4948
 		resultEncItems = append(resultEncItems, encryption.Item{
 			Link:  keyResp.Links[i],
 			Block: decryptedData,

--- a/internal/kms/pubsub_test.go
+++ b/internal/kms/pubsub_test.go
@@ -192,5 +192,5 @@ func storeEncryptionBlock(
 	)
 	require.NoError(t, err)
 
-	return link.(cidlink.Link).Cid.Bytes()
+	return []byte(link.Binary())
 }

--- a/internal/kms/pubsub_test.go
+++ b/internal/kms/pubsub_test.go
@@ -105,6 +105,41 @@ func TestTryHandleFetchEncryptionKeyResponse_UsesReplySenderForAAD(t *testing.T)
 	assert.Equal(t, plainBlock, items[0].Block)
 }
 
+func TestTryHandleFetchEncryptionKeyResponse_RejectsMismatchedLinksAndBlocks(t *testing.T) {
+	ctx := context.Background()
+
+	requesterPrivKey, err := crypto.GenerateX25519()
+	require.NoError(t, err)
+
+	req := &fetchEncryptionKeyRequest{
+		Links:              [][]byte{[]byte("encryption-block-link")},
+		EphemeralPublicKey: requesterPrivKey.PublicKey().Bytes(),
+	}
+
+	reply := &fetchEncryptionKeyReply{
+		Links:  req.Links,
+		Blocks: [][]byte{[]byte("encrypted-block"), []byte("extra-encrypted-block")},
+	}
+	data, err := cbor.Marshal(reply)
+	require.NoError(t, err)
+
+	service := &pubSubService{
+		ctx:      ctx,
+		encStore: newIPLDEncryptionStorage(datastore.EncstoreFrom(memory.NewDatastore(ctx))),
+	}
+	items, ok := service.tryHandleFetchEncryptionKeyResponse(
+		client.PubsubResponse{
+			From: "holder-peer",
+			Data: data,
+		},
+		req,
+		requesterPrivKey,
+	)
+
+	require.False(t, ok)
+	assert.Nil(t, items)
+}
+
 func TestGetEncryptionKeysLocally_ReturnsOnlyFoundLinks(t *testing.T) {
 	ctx := context.Background()
 	rootstore := memory.NewDatastore(ctx)

--- a/internal/kms/pubsub_test.go
+++ b/internal/kms/pubsub_test.go
@@ -1,0 +1,161 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package kms
+
+import (
+	"context"
+	"testing"
+
+	"github.com/fxamacker/cbor/v2"
+	"github.com/ipld/go-ipld-prime/linking"
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	kvblockstore "github.com/sourcenetwork/corekv/blockstore"
+	"github.com/sourcenetwork/corekv/memory"
+
+	"github.com/sourcenetwork/defradb/client"
+	"github.com/sourcenetwork/defradb/crypto"
+	coreblock "github.com/sourcenetwork/defradb/internal/core/block"
+	"github.com/sourcenetwork/defradb/internal/datastore"
+)
+
+func TestMarshalFetchEncryptionKeyRequest_GeneratesDistinctRequestIDs(t *testing.T) {
+	req := &fetchEncryptionKeyRequest{
+		Links:              [][]byte{[]byte("encryption-block-link")},
+		EphemeralPublicKey: []byte("requester-public-key"),
+	}
+
+	firstData, err := marshalFetchEncryptionKeyRequest(req)
+	require.NoError(t, err)
+	firstRequestID := append([]byte(nil), req.RequestID...)
+
+	secondData, err := marshalFetchEncryptionKeyRequest(req)
+	require.NoError(t, err)
+
+	require.Len(t, firstRequestID, 16)
+	require.Len(t, req.RequestID, 16)
+	assert.NotEqual(t, firstRequestID, req.RequestID)
+	assert.NotEqual(t, firstData, secondData)
+}
+
+func TestTryHandleFetchEncryptionKeyResponse_UsesReplySenderForAAD(t *testing.T) {
+	ctx := context.Background()
+
+	requesterPrivKey, err := crypto.GenerateX25519()
+	require.NoError(t, err)
+	holderPrivKey, err := crypto.GenerateX25519()
+	require.NoError(t, err)
+
+	req := &fetchEncryptionKeyRequest{
+		Links:              [][]byte{[]byte("encryption-block-link")},
+		EphemeralPublicKey: requesterPrivKey.PublicKey().Bytes(),
+	}
+
+	encBlock := &coreblock.Encryption{
+		DocID: []byte("doc1"),
+		Key:   []byte("doc-key"),
+	}
+	plainBlock, err := encBlock.Marshal()
+	require.NoError(t, err)
+
+	encryptedBlock, err := crypto.EncryptECIES(
+		plainBlock,
+		requesterPrivKey.PublicKey(),
+		crypto.WithAAD(makeAssociatedData(req, "holder-peer")),
+		crypto.WithPrivKey(holderPrivKey),
+		crypto.WithPubKeyPrepended(false),
+	)
+	require.NoError(t, err)
+
+	reply := &fetchEncryptionKeyReply{
+		Links:              req.Links,
+		Blocks:             [][]byte{encryptedBlock},
+		EphemeralPublicKey: holderPrivKey.PublicKey().Bytes(),
+		Sender:             "holder-peer",
+	}
+	data, err := cbor.Marshal(reply)
+	require.NoError(t, err)
+
+	service := &pubSubService{
+		ctx:      ctx,
+		encStore: newIPLDEncryptionStorage(datastore.EncstoreFrom(memory.NewDatastore(ctx))),
+	}
+	items, ok := service.tryHandleFetchEncryptionKeyResponse(
+		client.PubsubResponse{
+			From: "relay-peer",
+			Data: data,
+		},
+		req,
+		requesterPrivKey,
+	)
+
+	require.True(t, ok)
+	require.Len(t, items, 1)
+	assert.Equal(t, req.Links[0], items[0].Link)
+	assert.Equal(t, plainBlock, items[0].Block)
+}
+
+func TestGetEncryptionKeysLocally_ReturnsOnlyFoundLinks(t *testing.T) {
+	ctx := context.Background()
+	rootstore := memory.NewDatastore(ctx)
+	encstore := datastore.EncstoreFrom(rootstore)
+	service := &pubSubService{
+		ctx:      ctx,
+		encStore: newIPLDEncryptionStorage(encstore),
+	}
+
+	foundBlock := &coreblock.Encryption{
+		DocID: []byte("doc1"),
+		Key:   []byte("doc-key"),
+	}
+	foundLink := storeEncryptionBlock(t, ctx, encstore, foundBlock)
+
+	missingBlock := &coreblock.Encryption{
+		DocID: []byte("doc2"),
+		Key:   []byte("other-doc-key"),
+	}
+	missingLink := storeEncryptionBlock(t, ctx, datastore.EncstoreFrom(memory.NewDatastore(ctx)), missingBlock)
+
+	links, blocks, err := service.getEncryptionKeysLocally(ctx, &fetchEncryptionKeyRequest{
+		Links: [][]byte{missingLink, foundLink},
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, [][]byte{foundLink}, links)
+	require.Len(t, blocks, 1)
+
+	foundBlockBytes, err := foundBlock.Marshal()
+	require.NoError(t, err)
+	assert.Equal(t, foundBlockBytes, blocks[0])
+}
+
+func storeEncryptionBlock(
+	t *testing.T,
+	ctx context.Context,
+	encstore datastore.Blockstore,
+	encBlock *coreblock.Encryption,
+) []byte {
+	t.Helper()
+
+	lsys := cidlink.DefaultLinkSystem()
+	lsys.SetWriteStorage(kvblockstore.NewIPLDStore(encstore))
+
+	link, err := lsys.Store(
+		linking.LinkContext{Ctx: ctx},
+		coreblock.GetLinkPrototype(),
+		encBlock.GenerateNode(),
+	)
+	require.NoError(t, err)
+
+	return link.(cidlink.Link).Cid.Bytes()
+}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4939 

## Description
Fixes a flaky P2P KMS behavior  for encrypted document sync. Happens when multiple peers on the same topic are responding to KMS requests. There are circumstances where the intended node doesn't correctly recieve the KMS response for their request, which causes the tests to hang and eventually timeout.

The fix:
- KMS fetch requests now retry
- key requests now have unique requestIDs to disambiguate
- Including origin responding peer metadata within the ECIES AAD
- Updated response block/links for situations when responding peers dont have all the requested keys

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Expanded unit and integration tests. Re-ran integration tests 100 times to confirm flakeyness has been resolved (for this particular failure, there are obviously still other flakey tests/behavior out there)

Specify the platform(s) on which this was tested:
- Linux NixOS
