### PR TITLE
fix: Fix HTTP default address bug

### DIFF
--- a/http/server.go
+++ b/http/server.go
@@ -38,7 +38,8 @@ var tlsCipherSuites = []uint16{
 	tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
 }
 
-const defaultHTTPAddress = "127.0.0.1:9181"
+// DefaultHTTPAddress is the default address for the HTTP server.
+const DefaultHTTPAddress = "127.0.0.1:9181"
 
 // Server struct holds the Handler for the HTTP API.
 type Server struct {
@@ -51,10 +52,11 @@ type Server struct {
 
 // NewServer instantiates a new server with the given http.Handler.
 func NewServer(handler http.Handler, opts ...options.Enumerable[options.NodeHTTPOptions]) (*Server, error) {
-	cfg := options.NodeHTTPOptions{
-		Address: defaultHTTPAddress,
-	}
+	var cfg options.NodeHTTPOptions
 	utils.ApplyOptions(&cfg, opts...)
+	if cfg.Address == "" {
+		cfg.Address = DefaultHTTPAddress
+	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	// setup a mux with the default middleware stack

--- a/node/config_test.go
+++ b/node/config_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/sourcenetwork/defradb/client/options"
+	"github.com/sourcenetwork/defradb/http"
 	"github.com/sourcenetwork/defradb/internal/utils"
 )
 
@@ -32,4 +33,9 @@ func TestSetDisableAPI(t *testing.T) {
 func TestSetEnableDevelopment(t *testing.T) {
 	opts := utils.NewOptions(options.Node().SetEnableDevelopment(true))
 	assert.Equal(t, true, opts.EnableDevelopment)
+}
+
+func TestDefaultNodeOptionsHTTPAddress(t *testing.T) {
+	opts := DefaultNodeOptions()
+	assert.Equal(t, http.DefaultHTTPAddress, opts.HTTP.Address)
 }

--- a/node/node.go
+++ b/node/node.go
@@ -118,8 +118,10 @@ func DefaultNodeOptions() options.NodeOptions {
 			P2PBlockSyncTimeout: time.Second * 5,
 			LensRuntime:         options.NodeDefaultLensRuntime,
 		},
-		P2P:  options.NodeP2POptions{},
-		HTTP: options.NodeHTTPOptions{},
+		P2P: options.NodeP2POptions{},
+		HTTP: options.NodeHTTPOptions{
+			Address: http.DefaultHTTPAddress,
+		},
 	}
 }
 


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4842 

## Description

This PR makes it so that the default HTTP address is actually applied to the default node options object when it is created. It's a simple fix, but to do this we do have to make the value, located in the HTTP package, exported.

This PR also includes a test to confirm that this works.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Specify the platform(s) on which this was tested:
- WSL
