### PR TITLE
fix: P2P KMS response key CID verification

### DIFF
--- a/internal/kms/enc_store.go
+++ b/internal/kms/enc_store.go
@@ -74,3 +74,45 @@ func (s *ipldEncStorage) put(ctx context.Context, blockBytes []byte) ([]byte, er
 
 	return []byte(link.String()), nil
 }
+
+func (s *ipldEncStorage) putBlock(ctx context.Context, block coreblock.Encryption) ([]byte, error) {
+	lsys := cidlink.DefaultLinkSystem()
+	lsys.SetWriteStorage(blockstore.NewIPLDStore(s.encstore))
+
+	link, err := lsys.Store(linking.LinkContext{Ctx: ctx}, coreblock.GetLinkPrototype(), block.GenerateNode())
+	if err != nil {
+		return nil, err
+	}
+
+	return []byte(link.String()), nil
+}
+
+func (s *ipldEncStorage) computeLink(ctx context.Context, blockBytes []byte) ([]byte, error) {
+	lsys := cidlink.DefaultLinkSystem()
+	lsys.SetWriteStorage(blockstore.NewIPLDStore(s.encstore))
+
+	var encBlock coreblock.Encryption
+	err := encBlock.Unmarshal(blockBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	link, err := lsys.ComputeLink(coreblock.GetLinkPrototype(), encBlock.GenerateNode())
+	if err != nil {
+		return nil, err
+	}
+
+	return []byte(link.String()), nil
+}
+
+func (s *ipldEncStorage) computeBlockLink(ctx context.Context, block coreblock.Encryption) ([]byte, error) {
+	lsys := cidlink.DefaultLinkSystem()
+	lsys.SetWriteStorage(blockstore.NewIPLDStore(s.encstore))
+
+	link, err := lsys.ComputeLink(coreblock.GetLinkPrototype(), block.GenerateNode())
+	if err != nil {
+		return nil, err
+	}
+
+	return []byte(link.String()), nil
+}

--- a/internal/kms/enc_store.go
+++ b/internal/kms/enc_store.go
@@ -114,5 +114,5 @@ func (s *ipldEncStorage) computeBlockLink(ctx context.Context, block coreblock.E
 		return nil, err
 	}
 
-	return []byte(link.String()), nil
+	return []byte(link.Binary()), nil
 }

--- a/internal/kms/enc_store.go
+++ b/internal/kms/enc_store.go
@@ -57,47 +57,11 @@ func (s *ipldEncStorage) get(ctx context.Context, cidBytes []byte) (*coreblock.E
 	return coreblock.GetEncryptionBlockFromNode(nd)
 }
 
-func (s *ipldEncStorage) put(ctx context.Context, blockBytes []byte) ([]byte, error) {
-	lsys := cidlink.DefaultLinkSystem()
-	lsys.SetWriteStorage(blockstore.NewIPLDStore(s.encstore))
-
-	var encBlock coreblock.Encryption
-	err := encBlock.Unmarshal(blockBytes)
-	if err != nil {
-		return nil, err
-	}
-
-	link, err := lsys.Store(linking.LinkContext{Ctx: ctx}, coreblock.GetLinkPrototype(), encBlock.GenerateNode())
-	if err != nil {
-		return nil, err
-	}
-
-	return []byte(link.String()), nil
-}
-
 func (s *ipldEncStorage) putBlock(ctx context.Context, block coreblock.Encryption) ([]byte, error) {
 	lsys := cidlink.DefaultLinkSystem()
 	lsys.SetWriteStorage(blockstore.NewIPLDStore(s.encstore))
 
 	link, err := lsys.Store(linking.LinkContext{Ctx: ctx}, coreblock.GetLinkPrototype(), block.GenerateNode())
-	if err != nil {
-		return nil, err
-	}
-
-	return []byte(link.String()), nil
-}
-
-func (s *ipldEncStorage) computeLink(ctx context.Context, blockBytes []byte) ([]byte, error) {
-	lsys := cidlink.DefaultLinkSystem()
-	lsys.SetWriteStorage(blockstore.NewIPLDStore(s.encstore))
-
-	var encBlock coreblock.Encryption
-	err := encBlock.Unmarshal(blockBytes)
-	if err != nil {
-		return nil, err
-	}
-
-	link, err := lsys.ComputeLink(coreblock.GetLinkPrototype(), encBlock.GenerateNode())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/kms/errors.go
+++ b/internal/kms/errors.go
@@ -17,13 +17,36 @@ import (
 const (
 	errUnknownKMSType              string = "unknown KMS type"
 	errNoPeerSuppliedEncryptionKey string = "no peer supplied the encryption key"
+
+	errPeerErrorKeyReply           string = "encryption key peer reply carried error"
+	errEncryptionKeyUnmarshal      string = "unmarshal encryption key response"
+	errReplyLinksAndBlocksMismatch string = "encryption key peer reply had mismatched links and blocks"
+	errDecryptEncryptionKey        string = "decrypting encryption key"
+	errDecodingEncryptionKey       string = "decoding encryption key"
+	errEncryptionKeyCIDMismatch    string = "key CID mismatch"
+	errEncryptionKeyStore          string = "store encryption key"
 )
 
 var (
 	ErrUnknownKMSType              = errors.New(errUnknownKMSType)
 	ErrNoPeerSuppliedEncryptionKey = errors.New(errNoPeerSuppliedEncryptionKey)
+
+	ErrPeerErrorKeyReply           = errors.New(errPeerErrorKeyReply)
+	ErrEncryptionKeyUnmarshal      = errors.New(errEncryptionKeyUnmarshal)
+	ErrReplyLinksAndBlocksMismatch = errors.New(errReplyLinksAndBlocksMismatch)
+	ErrDecryptEncryptionKey        = errors.New(errDecryptEncryptionKey)
+	ErrDecodingEncryptionKey       = errors.New(errDecodingEncryptionKey)
+	ErrEncryptionKeyCIDMismatch    = errors.New(errEncryptionKeyCIDMismatch)
+	ErrEncryptionKeyStore          = errors.New(errEncryptionKeyStore)
 )
 
 func NewErrUnknownKMSType(t ServiceType) error {
 	return errors.New(errUnknownKMSType, errors.NewKV("Type", t))
+}
+
+func NewErrReplyLinksAndBlocksMismatch(linkCount, blockCount int) error {
+	return errors.New(errReplyLinksAndBlocksMismatch,
+		errors.NewKV("LinkCount", linkCount),
+		errors.NewKV("BlockCount", blockCount),
+	)
 }

--- a/internal/kms/errors.go
+++ b/internal/kms/errors.go
@@ -25,6 +25,7 @@ const (
 	errDecodingEncryptionKey       string = "decoding encryption key"
 	errEncryptionKeyCIDMismatch    string = "key CID mismatch"
 	errEncryptionKeyStore          string = "store encryption key"
+	errKeyCIDGeneration            string = "key cid generation"
 )
 
 var (
@@ -38,6 +39,7 @@ var (
 	ErrDecodingEncryptionKey       = errors.New(errDecodingEncryptionKey)
 	ErrEncryptionKeyCIDMismatch    = errors.New(errEncryptionKeyCIDMismatch)
 	ErrEncryptionKeyStore          = errors.New(errEncryptionKeyStore)
+	ErrKeyCIDGeneration            = errors.New(errKeyCIDGeneration)
 )
 
 func NewErrUnknownKMSType(t ServiceType) error {

--- a/internal/kms/pubsub.go
+++ b/internal/kms/pubsub.go
@@ -412,7 +412,12 @@ func (s *pubSubService) tryHandleFetchEncryptionKeyResponse(
 
 		if !skipVerify {
 			link, err := s.encStore.computeBlockLink(s.ctx, encBlock)
-			if !bytes.Equal(keyResp.Links[i], link) {
+			if err != nil {
+				return nil, false, errors.New("key cid")
+			}
+
+			if !bytes.Equal(keyResp.Links[i], link) &&
+				!bytes.Equal(req.Links[i], link) {
 				return nil, false, errors.Join(ErrEncryptionKeyCIDMismatch, err)
 			}
 		}

--- a/internal/kms/pubsub.go
+++ b/internal/kms/pubsub.go
@@ -413,12 +413,12 @@ func (s *pubSubService) tryHandleFetchEncryptionKeyResponse(
 		if !skipVerify {
 			link, err := s.encStore.computeBlockLink(s.ctx, encBlock)
 			if err != nil {
-				return nil, false, errors.New("key cid")
+				return nil, false, errors.Join(ErrKeyCIDGeneration, err)
 			}
 
-			if !bytes.Equal(keyResp.Links[i], link) &&
+			if !bytes.Equal(keyResp.Links[i], link) ||
 				!bytes.Equal(req.Links[i], link) {
-				return nil, false, errors.Join(ErrEncryptionKeyCIDMismatch, err)
+				return nil, false, ErrEncryptionKeyCIDMismatch
 			}
 		}
 
@@ -426,9 +426,6 @@ func (s *pubSubService) tryHandleFetchEncryptionKeyResponse(
 			return nil, false, errors.Join(ErrEncryptionKeyStore, err)
 		}
 
-		// todo: verify incoming response order block/CIDs match the request
-		// current implementation assumes trusted response ordering
-		// https://github.com/sourcenetwork/defradb/issues/4948
 		resultEncItems = append(resultEncItems, encryption.Item{
 			Link:  keyResp.Links[i],
 			Block: decryptedData,

--- a/internal/kms/pubsub.go
+++ b/internal/kms/pubsub.go
@@ -22,7 +22,6 @@ import (
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	grpcpeer "google.golang.org/grpc/peer"
 
-	"github.com/sourcenetwork/corelog"
 	"github.com/sourcenetwork/immutable"
 
 	"github.com/sourcenetwork/defradb/acp/dac"
@@ -31,6 +30,7 @@ import (
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/crypto"
 	"github.com/sourcenetwork/defradb/errors"
+	coreblock "github.com/sourcenetwork/defradb/internal/core/block"
 	"github.com/sourcenetwork/defradb/internal/datastore"
 	acpDB "github.com/sourcenetwork/defradb/internal/db/acp"
 	"github.com/sourcenetwork/defradb/internal/encryption"
@@ -290,8 +290,11 @@ func (s *pubSubService) handleFetchEncryptionKeyResponses(
 				respChan = nextRespChan
 				continue
 			}
-			items, ok := s.tryHandleFetchEncryptionKeyResponse(resp, req, privateKey)
+			items, ok, err := s.tryHandleFetchEncryptionKeyResponse(resp, req, privateKey, false /* skipVerify */)
 			if !ok {
+				if err != nil {
+					log.ErrorContextE(s.ctx, "Failed handling of encryption key response", err)
+				}
 				continue
 			}
 
@@ -364,30 +367,23 @@ func (s *pubSubService) tryHandleFetchEncryptionKeyResponse(
 	resp client.PubsubResponse,
 	req *fetchEncryptionKeyRequest,
 	privateKey *ecdh.PrivateKey,
-) ([]encryption.Item, bool) {
+	skipVerify bool,
+) ([]encryption.Item, bool, error) {
 	if resp.Err != nil {
-		log.ErrorContextE(s.ctx, "encryption key peer reply carried error", resp.Err)
-		return nil, false
+		return nil, false, errors.Join(ErrPeerErrorKeyReply, resp.Err)
 	}
 
 	var keyResp fetchEncryptionKeyReply
 	if err := cbor.Unmarshal(resp.Data, &keyResp); err != nil {
-		log.ErrorContextE(s.ctx, "Failed to unmarshal encryption key response", err)
-		return nil, false
+		return nil, false, errors.Join(ErrEncryptionKeyUnmarshal, err)
 	}
 
 	if len(keyResp.Blocks) == 0 {
 		// Peer didn't have the key; keep waiting for the one that does.
-		return nil, false
+		return nil, false, nil
 	}
 	if len(keyResp.Links) != len(keyResp.Blocks) {
-		log.ErrorContext(
-			s.ctx,
-			"encryption key peer reply had mismatched links and blocks",
-			corelog.Int("LinkCount", len(keyResp.Links)),
-			corelog.Int("BlockCount", len(keyResp.Blocks)),
-		)
-		return nil, false
+		return nil, false, NewErrReplyLinksAndBlocksMismatch(len(keyResp.Links), len(keyResp.Blocks))
 	}
 
 	senderID := keyResp.Sender
@@ -405,13 +401,24 @@ func (s *pubSubService) tryHandleFetchEncryptionKeyResponse(
 			crypto.WithPubKeyPrepended(false),
 		)
 		if err != nil {
-			log.ErrorContextE(s.ctx, "Failed to decrypt encryption key", err)
-			return nil, false
+			return nil, false, errors.Join(ErrDecryptEncryptionKey, err)
 		}
 
-		if _, err := s.encStore.put(context.Background(), decryptedData); err != nil {
-			log.ErrorContextE(s.ctx, "Failed to store encryption key", err)
-			return nil, false
+		var encBlock coreblock.Encryption
+		err = encBlock.Unmarshal(decryptedData)
+		if err != nil {
+			return nil, false, errors.Join(ErrDecodingEncryptionKey, err)
+		}
+
+		if !skipVerify {
+			link, err := s.encStore.computeBlockLink(s.ctx, encBlock)
+			if !bytes.Equal(keyResp.Links[i], link) {
+				return nil, false, errors.Join(ErrEncryptionKeyCIDMismatch, err)
+			}
+		}
+
+		if _, err := s.encStore.putBlock(context.Background(), encBlock); err != nil {
+			return nil, false, errors.Join(ErrEncryptionKeyStore, err)
 		}
 
 		// todo: verify incoming response order block/CIDs match the request
@@ -423,7 +430,7 @@ func (s *pubSubService) tryHandleFetchEncryptionKeyResponse(
 		})
 	}
 
-	return resultEncItems, true
+	return resultEncItems, true, nil
 }
 
 // makeAssociatedData creates the associated data for the encryption key request

--- a/internal/kms/pubsub.go
+++ b/internal/kms/pubsub.go
@@ -298,11 +298,6 @@ func (s *pubSubService) handleFetchEncryptionKeyResponses(
 				continue
 			}
 
-			// TODO: If multi-key requests become common, aggregate partial
-			// responses from multiple peers until every requested link is found or
-			// the timeout fires. A single valid response may contain fewer blocks
-			// than the request asked for.
-			// https://github.com/sourcenetwork/defradb/issues/4947
 			result <- encryption.Result{Items: items}
 			return
 
@@ -391,6 +386,11 @@ func (s *pubSubService) tryHandleFetchEncryptionKeyResponse(
 		senderID = resp.From
 	}
 
+	reqSet := make(map[string]struct{}, len(req.Links))
+	for _, l := range req.Links {
+		reqSet[string(l)] = struct{}{}
+	}
+
 	resultEncItems := make([]encryption.Item, 0, len(keyResp.Blocks))
 	for i, block := range keyResp.Blocks {
 		decryptedData, err := crypto.DecryptECIES(
@@ -416,8 +416,11 @@ func (s *pubSubService) tryHandleFetchEncryptionKeyResponse(
 				return nil, false, errors.Join(ErrKeyCIDGeneration, err)
 			}
 
-			if !bytes.Equal(keyResp.Links[i], link) ||
-				!bytes.Equal(req.Links[i], link) {
+			if !bytes.Equal(keyResp.Links[i], link) {
+				return nil, false, ErrEncryptionKeyCIDMismatch
+			}
+
+			if _, ok := reqSet[string(link)]; !ok {
 				return nil, false, ErrEncryptionKeyCIDMismatch
 			}
 		}

--- a/internal/kms/pubsub_test.go
+++ b/internal/kms/pubsub_test.go
@@ -90,15 +90,17 @@ func TestTryHandleFetchEncryptionKeyResponse_UsesReplySenderForAAD(t *testing.T)
 		ctx:      ctx,
 		encStore: newIPLDEncryptionStorage(datastore.EncstoreFrom(memory.NewDatastore(ctx))),
 	}
-	items, ok := service.tryHandleFetchEncryptionKeyResponse(
+	items, ok, err := service.tryHandleFetchEncryptionKeyResponse(
 		client.PubsubResponse{
 			From: "relay-peer",
 			Data: data,
 		},
 		req,
 		requesterPrivKey,
+		true,
 	)
 
+	require.NoError(t, err)
 	require.True(t, ok)
 	require.Len(t, items, 1)
 	assert.Equal(t, req.Links[0], items[0].Link)
@@ -127,15 +129,17 @@ func TestTryHandleFetchEncryptionKeyResponse_RejectsMismatchedLinksAndBlocks(t *
 		ctx:      ctx,
 		encStore: newIPLDEncryptionStorage(datastore.EncstoreFrom(memory.NewDatastore(ctx))),
 	}
-	items, ok := service.tryHandleFetchEncryptionKeyResponse(
+	items, ok, err := service.tryHandleFetchEncryptionKeyResponse(
 		client.PubsubResponse{
 			From: "holder-peer",
 			Data: data,
 		},
 		req,
 		requesterPrivKey,
+		true,
 	)
 
+	require.Error(t, err)
 	require.False(t, ok)
 	assert.Nil(t, items)
 }
@@ -172,6 +176,126 @@ func TestGetEncryptionKeysLocally_ReturnsOnlyFoundLinks(t *testing.T) {
 	foundBlockBytes, err := foundBlock.Marshal()
 	require.NoError(t, err)
 	assert.Equal(t, foundBlockBytes, blocks[0])
+}
+
+func TestTryHandleFetchEncryptionKeyResponse_RejectsUnverifiedBlocks(t *testing.T) {
+	ctx := context.Background()
+
+	requesterPrivKey, err := crypto.GenerateX25519()
+	require.NoError(t, err)
+	holderPrivKey, err := crypto.GenerateX25519()
+	require.NoError(t, err)
+
+	req := &fetchEncryptionKeyRequest{
+		Links:              [][]byte{[]byte("encryption-block-link")},
+		EphemeralPublicKey: requesterPrivKey.PublicKey().Bytes(),
+	}
+
+	encBlock := &coreblock.Encryption{
+		DocID: []byte("doc1"),
+		Key:   []byte("doc-key"),
+	}
+	plainBlock, err := encBlock.Marshal()
+	require.NoError(t, err)
+
+	encryptedBlock, err := crypto.EncryptECIES(
+		plainBlock,
+		requesterPrivKey.PublicKey(),
+		crypto.WithAAD(makeAssociatedData(req, "holder-peer")),
+		crypto.WithPrivKey(holderPrivKey),
+		crypto.WithPubKeyPrepended(false),
+	)
+	require.NoError(t, err)
+
+	reply := &fetchEncryptionKeyReply{
+		Links:              req.Links,
+		Blocks:             [][]byte{encryptedBlock},
+		EphemeralPublicKey: holderPrivKey.PublicKey().Bytes(),
+	}
+	data, err := cbor.Marshal(reply)
+	require.NoError(t, err)
+
+	service := &pubSubService{
+		ctx:      ctx,
+		encStore: newIPLDEncryptionStorage(datastore.EncstoreFrom(memory.NewDatastore(ctx))),
+	}
+
+	// service.encStore.computeLink([]byte("encrypted-block"))
+
+	items, ok, err := service.tryHandleFetchEncryptionKeyResponse(
+		client.PubsubResponse{
+			From: "holder-peer",
+			Data: data,
+		},
+		req,
+		requesterPrivKey,
+		false,
+	)
+
+	require.Error(t, err)
+	require.False(t, ok)
+	require.Len(t, items, 0)
+}
+
+func TestTryHandleFetchEncryptionKeyResponse_AcceptsVerifiedBlocks(t *testing.T) {
+	ctx := context.Background()
+
+	service := &pubSubService{
+		ctx:      ctx,
+		encStore: newIPLDEncryptionStorage(datastore.EncstoreFrom(memory.NewDatastore(ctx))),
+	}
+
+	requesterPrivKey, err := crypto.GenerateX25519()
+	require.NoError(t, err)
+	holderPrivKey, err := crypto.GenerateX25519()
+	require.NoError(t, err)
+
+	req := &fetchEncryptionKeyRequest{
+		Links:              [][]byte{[]byte("bafyreidq2l2x5zntplo7hebxmj2w6uyw7srv2psrz6pjfgmaaesrb4jauu")},
+		EphemeralPublicKey: requesterPrivKey.PublicKey().Bytes(),
+	}
+
+	encBlock := &coreblock.Encryption{
+		DocID: []byte("doc1"),
+		Key:   []byte("doc-key"),
+	}
+	plainBlock, err := encBlock.Marshal()
+	require.NoError(t, err)
+
+	encryptedBlock, err := crypto.EncryptECIES(
+		plainBlock,
+		requesterPrivKey.PublicKey(),
+		crypto.WithAAD(makeAssociatedData(req, "holder-peer")),
+		crypto.WithPrivKey(holderPrivKey),
+		crypto.WithPubKeyPrepended(false),
+	)
+	require.NoError(t, err)
+
+	reply := &fetchEncryptionKeyReply{
+		Links:              req.Links,
+		Blocks:             [][]byte{encryptedBlock},
+		EphemeralPublicKey: holderPrivKey.PublicKey().Bytes(),
+	}
+	data, err := cbor.Marshal(reply)
+	require.NoError(t, err)
+
+	// service.encStore.computeLink([]byte("encrypted-block"))
+
+	items, ok, err := service.tryHandleFetchEncryptionKeyResponse(
+		client.PubsubResponse{
+			From: "holder-peer",
+			Data: data,
+		},
+		req,
+		requesterPrivKey,
+		false,
+	)
+
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Len(t, items, 1)
+	assert.Equal(t, req.Links[0], items[0].Link)
+	assert.Equal(t, plainBlock, items[0].Block)
 }
 
 func storeEncryptionBlock(

--- a/internal/kms/pubsub_test.go
+++ b/internal/kms/pubsub_test.go
@@ -238,6 +238,74 @@ func TestTryHandleFetchEncryptionKeyResponse_RejectsUnverifiedBlocks(t *testing.
 	require.Len(t, items, 0)
 }
 
+func TestTryHandleFetchEncryptionKeyResponse_RejectsUnrequestedVerifiedBlocks(t *testing.T) {
+	ctx := context.Background()
+
+	service := &pubSubService{
+		ctx:      ctx,
+		encStore: newIPLDEncryptionStorage(datastore.EncstoreFrom(memory.NewDatastore(ctx))),
+	}
+
+	requesterPrivKey, err := crypto.GenerateX25519()
+	require.NoError(t, err)
+	holderPrivKey, err := crypto.GenerateX25519()
+	require.NoError(t, err)
+
+	requestedBlock := coreblock.Encryption{
+		DocID: []byte("requested-doc"),
+		Key:   []byte("requested-doc-key"),
+	}
+	requestedLink, err := service.encStore.computeBlockLink(ctx, requestedBlock)
+	require.NoError(t, err)
+
+	unrequestedBlock := coreblock.Encryption{
+		DocID: []byte("unrequested-doc"),
+		Key:   []byte("unrequested-doc-key"),
+	}
+	unrequestedLink, err := service.encStore.computeBlockLink(ctx, unrequestedBlock)
+	require.NoError(t, err)
+	require.NotEqual(t, requestedLink, unrequestedLink)
+
+	req := &fetchEncryptionKeyRequest{
+		Links:              [][]byte{requestedLink},
+		EphemeralPublicKey: requesterPrivKey.PublicKey().Bytes(),
+	}
+
+	plainBlock, err := unrequestedBlock.Marshal()
+	require.NoError(t, err)
+
+	encryptedBlock, err := crypto.EncryptECIES(
+		plainBlock,
+		requesterPrivKey.PublicKey(),
+		crypto.WithAAD(makeAssociatedData(req, "holder-peer")),
+		crypto.WithPrivKey(holderPrivKey),
+		crypto.WithPubKeyPrepended(false),
+	)
+	require.NoError(t, err)
+
+	reply := &fetchEncryptionKeyReply{
+		Links:              [][]byte{unrequestedLink},
+		Blocks:             [][]byte{encryptedBlock},
+		EphemeralPublicKey: holderPrivKey.PublicKey().Bytes(),
+	}
+	data, err := cbor.Marshal(reply)
+	require.NoError(t, err)
+
+	items, ok, err := service.tryHandleFetchEncryptionKeyResponse(
+		client.PubsubResponse{
+			From: "holder-peer",
+			Data: data,
+		},
+		req,
+		requesterPrivKey,
+		false,
+	)
+
+	require.ErrorIs(t, err, ErrEncryptionKeyCIDMismatch)
+	require.False(t, ok)
+	require.Empty(t, items)
+}
+
 func TestTryHandleFetchEncryptionKeyResponse_AcceptsVerifiedBlocks(t *testing.T) {
 	ctx := context.Background()
 

--- a/internal/kms/pubsub_test.go
+++ b/internal/kms/pubsub_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 
 	"github.com/fxamacker/cbor/v2"
+	"github.com/ipfs/go-cid"
 	"github.com/ipld/go-ipld-prime/linking"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	"github.com/stretchr/testify/assert"
@@ -250,8 +251,11 @@ func TestTryHandleFetchEncryptionKeyResponse_AcceptsVerifiedBlocks(t *testing.T)
 	holderPrivKey, err := crypto.GenerateX25519()
 	require.NoError(t, err)
 
+	link, err := cid.Decode("bafyreidq2l2x5zntplo7hebxmj2w6uyw7srv2psrz6pjfgmaaesrb4jauu")
+	require.NoError(t, err)
+
 	req := &fetchEncryptionKeyRequest{
-		Links:              [][]byte{[]byte("bafyreidq2l2x5zntplo7hebxmj2w6uyw7srv2psrz6pjfgmaaesrb4jauu")},
+		Links:              [][]byte{link.Bytes()},
 		EphemeralPublicKey: requesterPrivKey.PublicKey().Bytes(),
 	}
 


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4948 

## Description

Adds support to explicitly verify incoming encryption key response CIDs against the requested key IDs.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Explicit unit tests

Specify the platform(s) on which this was tested:
- Linux NixOS
