### PR TITLE
test(i): Skip Truncate and ViewRefresh leveldb tests

### DIFF
--- a/tests/integration/collection_version/updates/remove/collections_txn_test.go
+++ b/tests/integration/collection_version/updates/remove/collections_txn_test.go
@@ -63,9 +63,10 @@ func TestColVersionUpdateRemoveCollection_DeadlocksIfOtherTxnWriting(t *testing.
 		SupportedDatabaseTypes: immutable.Some([]state.DatabaseType{
 			// Badger file fails after the tests successfully completes, probably caused by the
 			// leaked database instance.  It is not worth the time to chase down at the moment.
+			//
+			// LevelDB does not support concurrent transactions, and so is skipped for this test
 			testUtils.BadgerIMType,
 			testUtils.DefraIMType,
-			testUtils.LevelStoreType,
 		}),
 		Actions: []any{
 			&action.AddCollection{
@@ -113,9 +114,10 @@ func TestColVersionUpdateRemoveCollection_DeadlockIfDeletingVersionWithNewFieldW
 		SupportedDatabaseTypes: immutable.Some([]state.DatabaseType{
 			// Badger file fails after the tests successfully completes, probably caused by the
 			// leaked database instance.  It is not worth the time to chase down at the moment.
+			//
+			// LevelDB does not support concurrent transactions, and so is skipped for this test
 			testUtils.BadgerIMType,
 			testUtils.DefraIMType,
-			testUtils.LevelStoreType,
 		}),
 		Actions: []any{
 			&action.AddCollection{

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -270,6 +270,8 @@ func executeTestCase(
 		corelog.String("changeDetector.Repository", changeDetector.Repository),
 	}
 
+	skipIfUnsupportedLevelDBAction(t, dbt, testCase.Actions)
+
 	if kms != NoneKMSType {
 		logAttrs = append(logAttrs, corelog.Any("KMS", kms))
 	}
@@ -2106,6 +2108,32 @@ func skipIfVectorEmbeddingTest(t testing.TB, actions []any) {
 	}
 	if !runVectorEmbeddingTests && hasVectorEmbedding {
 		t.Skip("test involves vector embedding generation")
+	}
+}
+
+// skipIfUnsupportedLevelDBAction skips the test if it contains an action that leveldb does
+// not support.
+func skipIfUnsupportedLevelDBAction(t testing.TB, dbt state.DatabaseType, actions []any) {
+	if dbt != LevelStoreType {
+		return
+	}
+
+	for _, act := range actions {
+		switch a := act.(type) {
+		case *action.Truncate, *action.RefreshViews, *action.AddView:
+			// These actions are skipped due to:
+			// https://github.com/sourcenetwork/defradb/issues/4959
+			t.Skip("truncate and RefreshView does not yet support the leveldb store")
+		case *action.Parallel:
+			for _, inner := range a.Children {
+				switch inner.(type) {
+				case *action.Truncate, *action.RefreshViews, *action.AddView:
+					// These actions are skipped due to:
+					// https://github.com/sourcenetwork/defradb/issues/4959
+					t.Skip("truncate and RefreshView does not yet support the leveldb store")
+				}
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4960

## Description

Skips Truncate and ViewRefresh leveldb tests.

Short term change only to fix the test run so that it doesn't hide other, newer errors until we fix this properly post v1.

Discussed with Keenan whether it was fine to leave leveldb not supporting Truncate and ViewRefresh until post v1 and he seemed okay with it.  Do push-back/discuss if uncomfortable about this.