### PR TITLE
fix(i): Hardcoded CID tests with signed docs

### DIFF
--- a/http/handler.go
+++ b/http/handler.go
@@ -23,10 +23,6 @@ import (
 	"github.com/go-chi/chi/v5/middleware"
 )
 
-// IsDevMode is a global variable for the development mode flag
-// This is checked by the http/handler_extras.go/Purge function to determine which response to send
-var IsDevMode bool = false
-
 const (
 	// VersionV0 is the identifier for the v0 API version.
 	//

--- a/http/handler_extras.go
+++ b/http/handler_extras.go
@@ -24,7 +24,7 @@ type extrasHandler struct{}
 
 func (h *extrasHandler) Purge(rw http.ResponseWriter, req *http.Request) {
 	// Send either 200 or 403 response based on whether the server is in dev mode
-	if IsDevMode {
+	if isDevMode(req) {
 		rw.WriteHeader(http.StatusOK)
 
 		db := mustGetContextClientDB(req)

--- a/http/handler_extras_test.go
+++ b/http/handler_extras_test.go
@@ -15,6 +15,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/sourcenetwork/defradb/client/options"
 	"github.com/sourcenetwork/defradb/event"
 
 	"github.com/stretchr/testify/require"
@@ -22,8 +23,6 @@ import (
 
 func TestPurgeDevModeTrue(t *testing.T) {
 	cdb := setupDatabase(t)
-
-	IsDevMode = true
 
 	url := "http://localhost:9181/api/purge"
 
@@ -33,7 +32,7 @@ func TestPurgeDevModeTrue(t *testing.T) {
 	purgeSub, err := cdb.Events().Subscribe(event.PurgeName)
 	require.NoError(t, err)
 
-	handler, err := NewHandler(cdb, nil)
+	handler, err := NewHandler(cdb, &options.NodeOptions{EnableDevelopment: true})
 	require.NoError(t, err)
 	handler.ServeHTTP(rec, req)
 
@@ -46,8 +45,6 @@ func TestPurgeDevModeTrue(t *testing.T) {
 
 func TestPurgeDevModeFalse(t *testing.T) {
 	cdb := setupDatabase(t)
-
-	IsDevMode = false
 
 	url := "http://localhost:9181/api/purge"
 

--- a/http/handler_store.go
+++ b/http/handler_store.go
@@ -36,7 +36,7 @@ const (
 type storeHandler struct{}
 
 func (h *storeHandler) BasicImport(rw http.ResponseWriter, req *http.Request) {
-	if !IsDevMode {
+	if !isDevMode(req) {
 		responseJSON(rw, http.StatusForbidden, errorResponse{client.NewErrOperationRequiresDeveloperMode("BasicImport")})
 		return
 	}
@@ -57,7 +57,7 @@ func (h *storeHandler) BasicImport(rw http.ResponseWriter, req *http.Request) {
 }
 
 func (h *storeHandler) BasicExport(rw http.ResponseWriter, req *http.Request) {
-	if !IsDevMode {
+	if !isDevMode(req) {
 		responseJSON(rw, http.StatusForbidden, errorResponse{client.NewErrOperationRequiresDeveloperMode("BasicExport")})
 		return
 	}

--- a/http/utils.go
+++ b/http/utils.go
@@ -72,6 +72,12 @@ func tryGetContextNodeOptions(req *http.Request) *options.NodeOptions {
 	return opts
 }
 
+// isDevMode reports whether the node serving this request has development mode enabled.
+func isDevMode(req *http.Request) bool {
+	opts := tryGetContextNodeOptions(req)
+	return opts != nil && opts.EnableDevelopment
+}
+
 // mustGetDataStoreTxn returns the datastore transaction or panics.
 //
 // This should only be called from functions within the http package.

--- a/node/node_api.go
+++ b/node/node_api.go
@@ -30,7 +30,6 @@ func (n *Node) startAPI(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	http.IsDevMode = n.opts.EnableDevelopment
 
 	n.server, err = http.NewServer(handler, options.NodeHTTP().SetAll(n.opts.HTTP))
 	if err != nil {

--- a/tests/clients/cli/wrapper.go
+++ b/tests/clients/cli/wrapper.go
@@ -53,7 +53,7 @@ type Wrapper struct {
 //
 // sourceHubAddress can (and will) be empty when testing non sourceHub ACP implementations.
 func NewWrapper(node *node.Node, sourceHubAddress string) (*Wrapper, error) {
-	handler, err := http.NewHandler(node.DB, nil)
+	handler, err := http.NewHandler(node.DB, node.Options())
 	if err != nil {
 		return nil, err
 	}

--- a/tests/clients/http/wrapper.go
+++ b/tests/clients/http/wrapper.go
@@ -42,7 +42,7 @@ type Wrapper struct {
 }
 
 func NewWrapper(node *node.Node) (*Wrapper, error) {
-	handler, err := http.NewHandler(node.DB, nil)
+	handler, err := http.NewHandler(node.DB, node.Options())
 	if err != nil {
 		return nil, err
 	}

--- a/tests/integration/client_setup.go
+++ b/tests/integration/client_setup.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 
 	cbindings "github.com/sourcenetwork/defradb/cbindings"
-	prodHttp "github.com/sourcenetwork/defradb/http"
 	"github.com/sourcenetwork/defradb/node"
 	"github.com/sourcenetwork/defradb/tests/clients"
 	"github.com/sourcenetwork/defradb/tests/clients/cli"
@@ -41,10 +40,6 @@ func init() {
 // testing state. The client type on the test state is used to
 // select the client implementation to use.
 func setupClient(s *state.State, nodeObj *node.Node) (clients.Client, error) {
-	// The test suite completely bypasses the way production consumes the node options,
-	// including the configuration of IsDevMode, so we have to hard code it here for now.
-	prodHttp.IsDevMode = true
-
 	switch s.ClientType {
 	case state.HTTPClientType:
 		return http.NewWrapper(nodeObj)

--- a/tests/integration/db.go
+++ b/tests/integration/db.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"os"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -48,6 +49,10 @@ var (
 	databaseDir      string
 	badgerEncryption bool
 	encryptionKey    []byte
+	// encryptionKeyOnce guards the lazy, process-wide initialization of
+	// encryptionKey so concurrent node setups don't race on it.
+	encryptionKeyOnce sync.Once
+	encryptionKeyErr  error
 )
 
 func init() {

--- a/tests/integration/db_setup.go
+++ b/tests/integration/db_setup.go
@@ -33,15 +33,13 @@ import (
 )
 
 func createBadgerEncryptionKey() error {
-	if !badgerEncryption || encryptionKey != nil {
+	if !badgerEncryption {
 		return nil
 	}
-	key, err := crypto.GenerateAES256()
-	if err != nil {
-		return err
-	}
-	encryptionKey = key
-	return nil
+	encryptionKeyOnce.Do(func() {
+		encryptionKey, encryptionKeyErr = crypto.GenerateAES256()
+	})
+	return encryptionKeyErr
 }
 
 // setupNode returns the database implementation for the current

--- a/tests/integration/issues/2566_test.go
+++ b/tests/integration/issues/2566_test.go
@@ -29,7 +29,7 @@ func TestP2PUpdate_WithPNCounterSimultaneousOverflowIncrement_DoesNotReachConsit
 	test := testUtils.TestCase{
 		// Accumulated CRDT fields (pncounter/pcounter) cannot be indexed.
 		// https://github.com/sourcenetwork/defradb/issues/4439
-		MultiplierExcludes: []string{multiplier.SecondaryIndex},
+		MultiplierExcludes: []string{multiplier.SecondaryIndex, multiplier.SignedDocs},
 		SupportedClientTypes: immutable.Some(
 			[]state.ClientType{
 				// This test only supports the Go client at the moment due to
@@ -140,7 +140,7 @@ func TestP2PUpdate_WithPNCounterSimultaneousOverflowDecrement_DoesNotReachConsit
 	test := testUtils.TestCase{
 		// Accumulated CRDT fields (pncounter/pcounter) cannot be indexed.
 		// https://github.com/sourcenetwork/defradb/issues/4439
-		MultiplierExcludes: []string{multiplier.SecondaryIndex},
+		MultiplierExcludes: []string{multiplier.SecondaryIndex, multiplier.SignedDocs},
 		SupportedClientTypes: immutable.Some(
 			[]state.ClientType{
 				// This test only supports the Go client at the moment due to

--- a/tests/integration/net/sync/branchable_collection/complex_network_test.go
+++ b/tests/integration/net/sync/branchable_collection/complex_network_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/sourcenetwork/defradb/tests/action"
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	"github.com/sourcenetwork/defradb/tests/multiplier"
 )
 
 const syncBranchableTopic = "sync-branchable"
@@ -376,7 +377,8 @@ func TestBranchableCollectionSync_WithDocumentsFromPeersAndNewHeadAfterSync_Shou
 	sameCid5 := testUtils.NewSameValue()
 
 	test := testUtils.TestCase{
-		FlakeRetries: 5,
+		MultiplierExcludes: []string{multiplier.SignedDocs},
+		FlakeRetries:       5,
 		Actions: []any{
 			testUtils.RandomNetworkingConfig(),
 			testUtils.RandomNetworkingConfig(),

--- a/tests/integration/query/commits/branchables/simple_test.go
+++ b/tests/integration/query/commits/branchables/simple_test.go
@@ -79,7 +79,7 @@ func TestQueryCommitsBranchables_WithAllFields(t *testing.T) {
 
 	test := testUtils.TestCase{
 		// asserts plaintext delta bytes; encryption replaces them with ciphertext
-		MultiplierExcludes: []string{multiplier.EncryptedDocs},
+		MultiplierExcludes: []string{multiplier.EncryptedDocs, multiplier.SignedDocs},
 		Actions: []any{
 			&action.AddCollection{
 				SDL: `

--- a/tests/integration/query/commits/with_cid_test.go
+++ b/tests/integration/query/commits/with_cid_test.go
@@ -199,7 +199,7 @@ func TestQueryCommitsWithUnknownCid(t *testing.T) {
 func TestQueryCommits_MultipleCidsDifferentDocs(t *testing.T) {
 	test := testUtils.TestCase{
 		// hardcoded CIDs would change under encryption
-		MultiplierExcludes: []string{multiplier.EncryptedDocs},
+		MultiplierExcludes: []string{multiplier.EncryptedDocs, multiplier.SignedDocs},
 		Actions: []any{
 			updateUserCollectionSchema(),
 			&action.AddDoc{
@@ -244,7 +244,7 @@ func TestQueryCommits_MultipleCidsDifferentDocs(t *testing.T) {
 func TestQueryCommits_MultipleCidsDifferentDocs_NoAccessToSecondCid(t *testing.T) {
 	test := testUtils.TestCase{
 		// hardcoded CIDs would change under encryption
-		MultiplierExcludes: []string{multiplier.EncryptedDocs},
+		MultiplierExcludes: []string{multiplier.EncryptedDocs, multiplier.SignedDocs},
 		Actions: []any{
 			testUtils.AddDACPolicy{
 				Identity: testUtils.ClientIdentity(1),
@@ -321,7 +321,7 @@ resources:
 func TestQueryCommits_MultipleCidsSameDoc(t *testing.T) {
 	test := testUtils.TestCase{
 		// hardcoded CIDs would change under encryption
-		MultiplierExcludes: []string{multiplier.EncryptedDocs},
+		MultiplierExcludes: []string{multiplier.EncryptedDocs, multiplier.SignedDocs},
 		Actions: []any{
 			updateUserCollectionSchema(),
 			&action.AddDoc{

--- a/tests/integration/query/commits/with_nested_links_test.go
+++ b/tests/integration/query/commits/with_nested_links_test.go
@@ -197,7 +197,7 @@ func TestQueryCommits_WithSingleUpdateDoubleNestedLinks_Succeeds(t *testing.T) {
 
 	test := testUtils.TestCase{
 		// encryption changes the delta bytes
-		MultiplierExcludes: []string{multiplier.EncryptedDocs},
+		MultiplierExcludes: []string{multiplier.EncryptedDocs, multiplier.SignedDocs},
 		Actions: []any{
 			updateUserCollectionSchema(),
 			&action.AddDoc{

--- a/tests/integration/query/simple/with_cid_branchable_test.go
+++ b/tests/integration/query/simple/with_cid_branchable_test.go
@@ -21,7 +21,7 @@ import (
 
 // Hardcoded collection-level commit CIDs; no template placeholder yet.
 // See https://github.com/sourcenetwork/defradb/issues/4744.
-var branchableCollectionCidExcludes = []string{multiplier.EncryptedDocs}
+var branchableCollectionCidExcludes = []string{multiplier.EncryptedDocs, multiplier.SignedDocs}
 
 func TestQuerySimpleWithCidOfBranchableCollection_FirstCid(t *testing.T) {
 	test := testUtils.TestCase{

--- a/tests/integration/query/simple/with_cid_doc_id_test.go
+++ b/tests/integration/query/simple/with_cid_doc_id_test.go
@@ -78,7 +78,7 @@ func TestQuerySimpleWithUnknownCidAndInvalidDocID(t *testing.T) {
 func TestQuerySimpleWithCidAndDocID(t *testing.T) {
 	test := testUtils.TestCase{
 		// hardcoded CIDs would change under encryption
-		MultiplierExcludes: []string{multiplier.EncryptedDocs},
+		MultiplierExcludes: []string{multiplier.EncryptedDocs, multiplier.SignedDocs},
 		Actions: []any{
 			&action.AddCollection{
 				SDL: `
@@ -118,7 +118,7 @@ func TestQuerySimpleWithCidAndDocID(t *testing.T) {
 func TestQuerySimpleWithUpdateAndFirstCidAndDocID(t *testing.T) {
 	test := testUtils.TestCase{
 		// hardcoded CIDs would change under encryption
-		MultiplierExcludes: []string{multiplier.EncryptedDocs},
+		MultiplierExcludes: []string{multiplier.EncryptedDocs, multiplier.SignedDocs},
 		Actions: []any{
 			&action.AddCollection{
 				SDL: `
@@ -163,7 +163,7 @@ func TestQuerySimpleWithUpdateAndFirstCidAndDocID(t *testing.T) {
 func TestQuerySimpleWithUpdateAndLastCidAndDocID(t *testing.T) {
 	test := testUtils.TestCase{
 		// hardcoded CIDs would change under encryption
-		MultiplierExcludes: []string{multiplier.EncryptedDocs},
+		MultiplierExcludes: []string{multiplier.EncryptedDocs, multiplier.SignedDocs},
 		Actions: []any{
 			&action.AddCollection{
 				SDL: `
@@ -208,7 +208,7 @@ func TestQuerySimpleWithUpdateAndLastCidAndDocID(t *testing.T) {
 func TestQuerySimpleWithUpdateAndMiddleCidAndDocID(t *testing.T) {
 	test := testUtils.TestCase{
 		// hardcoded CIDs would change under encryption
-		MultiplierExcludes: []string{multiplier.EncryptedDocs},
+		MultiplierExcludes: []string{multiplier.EncryptedDocs, multiplier.SignedDocs},
 		Actions: []any{
 			&action.AddCollection{
 				SDL: `
@@ -270,7 +270,7 @@ func TestQuerySimpleWithUpdateAndMiddleCidAndDocID(t *testing.T) {
 func TestQuerySimpleWithUpdateAndFirstCidAndDocIDAndSchemaVersion(t *testing.T) {
 	test := testUtils.TestCase{
 		// hardcoded CIDs would change under encryption
-		MultiplierExcludes: []string{multiplier.EncryptedDocs},
+		MultiplierExcludes: []string{multiplier.EncryptedDocs, multiplier.SignedDocs},
 		Actions: []any{
 			&action.AddCollection{
 				SDL: `
@@ -325,7 +325,7 @@ func TestCidAndDocIDQuery_ContainsPNCounterWithIntKind_NoError(t *testing.T) {
 	test := testUtils.TestCase{
 		// Accumulated CRDT fields (pncounter/pcounter) cannot be indexed.
 		// https://github.com/sourcenetwork/defradb/issues/4439
-		MultiplierExcludes: []string{multiplier.SecondaryIndex, multiplier.EncryptedDocs},
+		MultiplierExcludes: []string{multiplier.SecondaryIndex, multiplier.EncryptedDocs, multiplier.SignedDocs},
 		Actions: []any{
 			&action.AddCollection{
 				SDL: `
@@ -381,7 +381,7 @@ func TestCidAndDocIDQuery_ContainsPNCounterWithFloatKind_NoError(t *testing.T) {
 	test := testUtils.TestCase{
 		// Accumulated CRDT fields (pncounter/pcounter) cannot be indexed.
 		// https://github.com/sourcenetwork/defradb/issues/4439
-		MultiplierExcludes: []string{multiplier.SecondaryIndex, multiplier.EncryptedDocs},
+		MultiplierExcludes: []string{multiplier.SecondaryIndex, multiplier.EncryptedDocs, multiplier.SignedDocs},
 		Actions: []any{
 			&action.AddCollection{
 				SDL: `
@@ -437,7 +437,7 @@ func TestCidAndDocIDQuery_ContainsPCounterWithIntKind_NoError(t *testing.T) {
 	test := testUtils.TestCase{
 		// Accumulated CRDT fields (pncounter/pcounter) cannot be indexed.
 		// https://github.com/sourcenetwork/defradb/issues/4439
-		MultiplierExcludes: []string{multiplier.SecondaryIndex, multiplier.EncryptedDocs},
+		MultiplierExcludes: []string{multiplier.SecondaryIndex, multiplier.EncryptedDocs, multiplier.SignedDocs},
 		Actions: []any{
 			&action.AddCollection{
 				SDL: `
@@ -488,7 +488,7 @@ func TestCidAndDocIDQuery_ContainsPCounterWithFloatKind_NoError(t *testing.T) {
 	test := testUtils.TestCase{
 		// Accumulated CRDT fields (pncounter/pcounter) cannot be indexed.
 		// https://github.com/sourcenetwork/defradb/issues/4439
-		MultiplierExcludes: []string{multiplier.SecondaryIndex, multiplier.EncryptedDocs},
+		MultiplierExcludes: []string{multiplier.SecondaryIndex, multiplier.EncryptedDocs, multiplier.SignedDocs},
 		Actions: []any{
 			&action.AddCollection{
 				SDL: `

--- a/tests/integration/query/simple/with_cid_test.go
+++ b/tests/integration/query/simple/with_cid_test.go
@@ -45,7 +45,7 @@ func TestQuerySimpleWithInvalidCid(t *testing.T) {
 func TestQuerySimpleWithCid(t *testing.T) {
 	test := testUtils.TestCase{
 		// hardcoded CIDs would change under encryption
-		MultiplierExcludes: []string{multiplier.EncryptedDocs},
+		MultiplierExcludes: []string{multiplier.EncryptedDocs, multiplier.SignedDocs},
 		Actions: []any{
 			&action.AddCollection{
 				SDL: `
@@ -110,7 +110,7 @@ func TestQuerySimple_UnknownCid(t *testing.T) {
 func TestQuerySimpleWithCid_MultipleDocs(t *testing.T) {
 	test := testUtils.TestCase{
 		// hardcoded CIDs would change under encryption
-		MultiplierExcludes: []string{multiplier.EncryptedDocs},
+		MultiplierExcludes: []string{multiplier.EncryptedDocs, multiplier.SignedDocs},
 		Actions: []any{
 			&action.AddCollection{
 				SDL: `
@@ -155,7 +155,7 @@ func TestQuerySimple_WithCIDAndCounterAfterUpdate_ShouldSucceed(t *testing.T) {
 	test := testUtils.TestCase{
 		// Accumulated CRDT fields (pncounter/pcounter) cannot be indexed.
 		// https://github.com/sourcenetwork/defradb/issues/4439
-		MultiplierExcludes: []string{multiplier.SecondaryIndex, multiplier.EncryptedDocs},
+		MultiplierExcludes: []string{multiplier.SecondaryIndex, multiplier.EncryptedDocs, multiplier.SignedDocs},
 		Actions: []any{
 			&action.AddCollection{
 				SDL: `
@@ -198,7 +198,7 @@ func TestQuerySimple_WithCIDAndCounterAfterUpdate_ShouldSucceed(t *testing.T) {
 func TestQuerySimple_WithCidAfterDeleteOperation_ShouldReturnUser(t *testing.T) {
 	test := testUtils.TestCase{
 		// hardcoded CIDs would change under encryption
-		MultiplierExcludes: []string{multiplier.EncryptedDocs},
+		MultiplierExcludes: []string{multiplier.EncryptedDocs, multiplier.SignedDocs},
 		Actions: []any{
 			&action.AddCollection{
 				SDL: `
@@ -242,8 +242,8 @@ func TestQuerySimple_WithCidAfterDeleteOperation_ShouldReturnUser(t *testing.T) 
 
 func TestQuerySimple_ListOfOneCID(t *testing.T) {
 	test := testUtils.TestCase{
-		// hardcoded CIDs would change under encryption
-		MultiplierExcludes: []string{multiplier.EncryptedDocs},
+		// hardcoded CIDs would change under encryption or signing
+		MultiplierExcludes: []string{multiplier.EncryptedDocs, multiplier.SignedDocs},
 		Actions: []any{
 			&action.AddCollection{
 				SDL: `
@@ -282,7 +282,7 @@ func TestQuerySimple_ListOfOneCID(t *testing.T) {
 func TestQuerySimple_MultipleCIDs(t *testing.T) {
 	test := testUtils.TestCase{
 		// hardcoded CIDs would change under encryption
-		MultiplierExcludes: []string{multiplier.EncryptedDocs},
+		MultiplierExcludes: []string{multiplier.EncryptedDocs, multiplier.SignedDocs},
 		Actions: []any{
 			&action.AddCollection{
 				SDL: `
@@ -334,7 +334,7 @@ func TestQuerySimple_MultipleCIDs(t *testing.T) {
 func TestQuerySimple_DuplicateCIDsForSameDoc(t *testing.T) {
 	test := testUtils.TestCase{
 		// hardcoded CIDs would change under encryption
-		MultiplierExcludes: []string{multiplier.EncryptedDocs},
+		MultiplierExcludes: []string{multiplier.EncryptedDocs, multiplier.SignedDocs},
 		Actions: []any{
 			&action.AddCollection{
 				SDL: `
@@ -381,7 +381,7 @@ func TestQuerySimple_DuplicateCIDsForSameDoc(t *testing.T) {
 func TestQuerySimple_MultipleCIDsForSameDoc(t *testing.T) {
 	test := testUtils.TestCase{
 		// hardcoded CIDs would change under encryption
-		MultiplierExcludes: []string{multiplier.EncryptedDocs},
+		MultiplierExcludes: []string{multiplier.EncryptedDocs, multiplier.SignedDocs},
 		Actions: []any{
 			&action.AddCollection{
 				SDL: `

--- a/tests/integration/query/simple/with_version_cid_doc_ids_test.go
+++ b/tests/integration/query/simple/with_version_cid_doc_ids_test.go
@@ -22,7 +22,7 @@ import (
 func TestQuerySimpleWithVersionAndCidAndCorrectDocID(t *testing.T) {
 	test := testUtils.TestCase{
 		// hardcoded CIDs would change under encryption
-		MultiplierExcludes: []string{multiplier.EncryptedDocs},
+		MultiplierExcludes: []string{multiplier.EncryptedDocs, multiplier.SignedDocs},
 		Actions: []any{
 			&action.AddCollection{
 				SDL: `
@@ -72,7 +72,7 @@ func TestQuerySimpleWithVersionAndCidAndCorrectDocID(t *testing.T) {
 func TestQuerySimpleWithVersionAndCidAndCorrectAndIncorrectDocID(t *testing.T) {
 	test := testUtils.TestCase{
 		// hardcoded CIDs would change under encryption
-		MultiplierExcludes: []string{multiplier.EncryptedDocs},
+		MultiplierExcludes: []string{multiplier.EncryptedDocs, multiplier.SignedDocs},
 		Actions: []any{
 			&action.AddCollection{
 				SDL: `
@@ -125,7 +125,7 @@ func TestQuerySimpleWithVersionAndCidAndCorrectAndIncorrectDocID(t *testing.T) {
 func TestQuerySimpleWithVersionAndCidAndIncorrectDocID(t *testing.T) {
 	test := testUtils.TestCase{
 		// hardcoded CIDs would change under encryption
-		MultiplierExcludes: []string{multiplier.EncryptedDocs},
+		MultiplierExcludes: []string{multiplier.EncryptedDocs, multiplier.SignedDocs},
 		Actions: []any{
 			&action.AddCollection{
 				SDL: `

--- a/tests/integration/query/simple/with_version_cid_test.go
+++ b/tests/integration/query/simple/with_version_cid_test.go
@@ -22,7 +22,7 @@ import (
 func TestQuerySimpleWithVersionAndCid(t *testing.T) {
 	test := testUtils.TestCase{
 		// hardcoded CIDs would change under encryption
-		MultiplierExcludes: []string{multiplier.EncryptedDocs},
+		MultiplierExcludes: []string{multiplier.EncryptedDocs, multiplier.SignedDocs},
 		Actions: []any{
 			&action.AddCollection{
 				SDL: `

--- a/tests/integration/query/simple/with_version_test.go
+++ b/tests/integration/query/simple/with_version_test.go
@@ -22,7 +22,7 @@ import (
 func TestQuerySimpleWithNestedLatestCommit(t *testing.T) {
 	test := testUtils.TestCase{
 		// hardcoded CIDs would change under encryption
-		MultiplierExcludes: []string{multiplier.EncryptedDocs},
+		MultiplierExcludes: []string{multiplier.EncryptedDocs, multiplier.SignedDocs},
 		Actions: []any{
 			&action.AddDoc{
 				Doc: `{
@@ -85,7 +85,7 @@ func TestQuery_AddDocWithNestedLatestCommit(t *testing.T) {
 
 	test := testUtils.TestCase{
 		// links are sorted by child CID (block.go:222) so encryption flips the order
-		MultiplierExcludes: []string{multiplier.EncryptedDocs},
+		MultiplierExcludes: []string{multiplier.EncryptedDocs, multiplier.SignedDocs},
 		Actions: []any{
 			&action.AddDoc{
 				Doc: `{
@@ -153,7 +153,7 @@ func TestQuery_UpdateDocWithNestedLatestCommit(t *testing.T) {
 	nameCreateCid := testUtils.NewUniqueValue()
 	test := testUtils.TestCase{
 		// links are sorted by child CID (block.go:222) so encryption flips the order
-		MultiplierExcludes: []string{multiplier.EncryptedDocs},
+		MultiplierExcludes: []string{multiplier.EncryptedDocs, multiplier.SignedDocs},
 		Actions: []any{
 			&action.AddDoc{
 				Doc: `{
@@ -319,7 +319,7 @@ func TestQuerySimpleWithMultipleAliasedEmbeddedLatestCommit(t *testing.T) {
 	nameCreateCid := testUtils.NewUniqueValue()
 	test := testUtils.TestCase{
 		// links are sorted by child CID (block.go:222) so encryption flips the order
-		MultiplierExcludes: []string{multiplier.EncryptedDocs},
+		MultiplierExcludes: []string{multiplier.EncryptedDocs, multiplier.SignedDocs},
 		Actions: []any{
 			&action.AddDoc{
 				Doc: `{
@@ -390,7 +390,7 @@ func TestQuerySimpleWithMultipleAliasedInterleavedNestedLatestCommit(t *testing.
 	nameCreateCid := testUtils.NewUniqueValue()
 	test := testUtils.TestCase{
 		// links are sorted by child CID (block.go:222) so encryption flips the order
-		MultiplierExcludes: []string{multiplier.EncryptedDocs},
+		MultiplierExcludes: []string{multiplier.EncryptedDocs, multiplier.SignedDocs},
 		Actions: []any{
 			&action.AddDoc{
 				Doc: `{
@@ -565,7 +565,7 @@ func TestQuery_WithAllCommitFields_NoError(t *testing.T) {
 
 	test := testUtils.TestCase{
 		// links are sorted by child CID (block.go:222) so encryption flips the order
-		MultiplierExcludes: []string{multiplier.EncryptedDocs},
+		MultiplierExcludes: []string{multiplier.EncryptedDocs, multiplier.SignedDocs},
 		Actions: []any{
 			&action.AddCollection{
 				SDL: userCollectionGQLSchema,
@@ -642,7 +642,7 @@ func TestQuery_WithAllCommitFieldsWithUpdate_NoError(t *testing.T) {
 
 	test := testUtils.TestCase{
 		// links are sorted by child CID (block.go:222) so encryption flips the order
-		MultiplierExcludes: []string{multiplier.EncryptedDocs},
+		MultiplierExcludes: []string{multiplier.EncryptedDocs, multiplier.SignedDocs},
 		Actions: []any{
 			&action.AddCollection{
 				SDL: userCollectionGQLSchema,

--- a/tests/integration/subscription/with_commit_test.go
+++ b/tests/integration/subscription/with_commit_test.go
@@ -24,7 +24,7 @@ func TestCommitSubscription_WithAddMutations_ReturnCommits(t *testing.T) {
 		// Result CIDs are hardcoded because template placeholders are not
 		// resolved inside Request.Results.
 		// See https://github.com/sourcenetwork/defradb/issues/4745.
-		MultiplierExcludes: []string{multiplier.EncryptedDocs},
+		MultiplierExcludes: []string{multiplier.EncryptedDocs, multiplier.SignedDocs},
 		Actions: []any{
 			&action.SubscriptionRequest{
 				Request: `subscription {
@@ -80,6 +80,10 @@ func TestCommitSubscription_WithCommitLinksAddMutations_ValidLinks(t *testing.T)
 	create2Heads := testUtils.NewSameValue()
 
 	test := testUtils.TestCase{
+		// Result CIDs are hardcoded because template placeholders are not
+		// resolved inside Request.Results.
+		// See https://github.com/sourcenetwork/defradb/issues/4745.
+		MultiplierExcludes: []string{multiplier.EncryptedDocs, multiplier.SignedDocs},
 		Actions: []any{
 			&action.SubscriptionRequest{
 				Request: `subscription {


### PR DESCRIPTION

## Relevant issue(s)

Resolves #4913 

## Description
Fixed test failures in the signed-docs coverage job. Tests with hardcoded CIDs in their expected results were failing when document signing is enabled. Added `signed-docs` to the exclusion list for these tests - same approach already used for the `encrypted-docs` multiplier.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Verified locally:
- Tests pass without any multiplier
- Tests properly skip with `DEFRA_MULTIPLIERS=signed-docs`
- Tests also skip correctly with `DEFRA_MULTIPLIERS=encrypted-docs` and both combined

Specify the platform(s) on which this was tested:
- Debian Linux
