### PR TITLE
fix: Leveldb truncate refresh self deadlock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,7 @@ crash.log
 
 # Ignore direnv environment files (developer-local).
 .envrc
+
+# Go execution traces (DEFRA_TRACE=1)
+*.trace
+traces/

--- a/internal/db/collection_truncate.go
+++ b/internal/db/collection_truncate.go
@@ -37,7 +37,7 @@ const hardDeleteChunkSize int = 10000
 func (c *collection) Truncate(
 	ctx context.Context, opts ...options.Enumerable[options.TruncateCollectionOptions],
 ) error {
-	ctx, _, _ = getTxnAndSetCtxForCollection(ctx, c)
+	ctx, _, hadTxn := getTxnAndSetCtxForCollection(ctx, c)
 
 	ctx, span := tracer.Start(ctx)
 	defer span.End()
@@ -48,18 +48,58 @@ func (c *collection) Truncate(
 		return err
 	}
 
+	// Truncate performs txn-free writes: it deletes more key-values than a single store transaction
+	// may safely hold, and it records its action-execution markers outside any transaction (so they
+	// survive a rollback). leveldb blocks non-transactional writes while a transaction is open, so
+	// when no explicit transaction is in play we hold the collection write lock with a lock token
+	// rather than an open store transaction, and write everything directly to the rootstore.
+	//
+	// When the caller supplied an explicit transaction we must honour it. That path is unsupported on
+	// leveldb (a txn-free write would block on the open transaction - see issue #4959).
+	if hadTxn {
+		return c.truncateInTxn(ctx)
+	}
+	return c.truncateTxnFree(ctx)
+}
+
+// truncateTxnFree truncates the collection without opening a store transaction. The collection write
+// lock - which is what provides reader isolation - is held by a lock token for the duration, and
+// every read and write goes directly to the rootstore. This is the path that supports leveldb.
+func (c *collection) truncateTxnFree(ctx context.Context) error {
+	token := c.db.newLockToken()
+	defer token.release()
+
+	// The token serves reads (it satisfies datastore.Txn), and clearing the corekv transaction
+	// ensures every write goes straight to the rootstore with no transaction open. The short-id
+	// caches are normally initialised by InitContext; we initialise them here as we bypass it.
+	ctx = datastore.CtxSetTxn(ctx, token)
+	ctx = corekv.SetCtxTxn(ctx, nil)
+	ctx = id.InitCollectionShortIDCache(ctx)
+	ctx = id.InitFieldShortIDCache(ctx)
+
+	shortID, err := id.GetShortCollectionID(ctx, c.def.CollectionID)
+	if err != nil {
+		return err
+	}
+	c.db.lockSet.CollectionLock(token, shortID)
+
+	multistore := datastore.NewMultistore(c.db.rootstore, c.db.lockSet, c.db.blockStoreChunkSize)
+	return c.runTruncate(ctx, ctx, multistore)
+}
+
+// truncateInTxn truncates the collection through the explicit transaction already on the context.
+// The action-execution markers are still written txn-free (corekv issue #107).
+func (c *collection) truncateInTxn(ctx context.Context) error {
 	ctx, txn, err := ensureContextTxn(ctx, c.db, false)
 	if err != nil {
 		return err
 	}
-
 	defer txn.Discard()
 
 	shortID, err := id.GetShortCollectionID(ctx, c.def.CollectionID)
 	if err != nil {
 		return err
 	}
-
 	c.db.lockSet.CollectionLock(txn, shortID)
 
 	multistore := datastore.NewMultistore(c.db.rootstore, c.db.lockSet, c.db.blockStoreChunkSize)
@@ -68,15 +108,28 @@ func (c *collection) Truncate(
 	// corekv will pick it up again, writing using the transaction.
 	// https://github.com/sourcenetwork/corekv/issues/107
 	txnFreeCtx := datastore.CtxSetTxn(ctx, nil)
-	err = action.Register(txnFreeCtx, multistore, c.db.events, c.def.CollectionID, client.TruncateAction)
+	if err := c.runTruncate(ctx, txnFreeCtx, multistore); err != nil {
+		return err
+	}
+
+	return txn.Commit()
+}
+
+// runTruncate registers the truncate action, performs the deletion using deleteCtx, and records
+// completion. The action-execution markers are written using writeCtx, which must be txn-free.
+func (c *collection) runTruncate(
+	deleteCtx, writeCtx context.Context,
+	multistore *datastore.Multistore,
+) error {
+	err := action.Register(writeCtx, multistore, c.db.events, c.def.CollectionID, client.TruncateAction)
 	if err != nil {
 		return err
 	}
 
-	err = c.truncate(ctx)
+	err = c.truncate(deleteCtx)
 	if err != nil {
 		errErr := action.Set(
-			txnFreeCtx,
+			writeCtx,
 			multistore,
 			c.db.events,
 			c.def.CollectionID,
@@ -86,12 +139,7 @@ func (c *collection) Truncate(
 		return errors.Join(errErr, err)
 	}
 
-	err = action.Complete(txnFreeCtx, multistore, c.db.events, c.def.CollectionID, client.TruncateAction)
-	if err != nil {
-		return err
-	}
-
-	return txn.Commit()
+	return action.Complete(writeCtx, multistore, c.db.events, c.def.CollectionID, client.TruncateAction)
 }
 
 func (c *collection) truncate(

--- a/internal/db/collection_truncate.go
+++ b/internal/db/collection_truncate.go
@@ -66,16 +66,8 @@ func (c *collection) Truncate(
 // lock - which is what provides reader isolation - is held by a lock token for the duration, and
 // every read and write goes directly to the rootstore. This is the path that supports leveldb.
 func (c *collection) truncateTxnFree(ctx context.Context) error {
-	token := c.db.newLockToken()
+	ctx, token := c.db.beginTxnFree(ctx)
 	defer token.release()
-
-	// The token serves reads (it satisfies datastore.Txn), and clearing the corekv transaction
-	// ensures every write goes straight to the rootstore with no transaction open. The short-id
-	// caches are normally initialised by InitContext; we initialise them here as we bypass it.
-	ctx = datastore.CtxSetTxn(ctx, token)
-	ctx = corekv.SetCtxTxn(ctx, nil)
-	ctx = id.InitCollectionShortIDCache(ctx)
-	ctx = id.InitFieldShortIDCache(ctx)
 
 	shortID, err := id.GetShortCollectionID(ctx, c.def.CollectionID)
 	if err != nil {

--- a/internal/db/lock_token.go
+++ b/internal/db/lock_token.go
@@ -11,9 +11,13 @@
 package db
 
 import (
+	"context"
 	"time"
 
+	"github.com/sourcenetwork/corekv"
+
 	"github.com/sourcenetwork/defradb/internal/datastore"
+	"github.com/sourcenetwork/defradb/internal/db/id"
 )
 
 // lockToken is a rootstore-backed pseudo-transaction used to hold a collection write lock
@@ -58,6 +62,24 @@ func (db *DB) newLockToken() *lockToken {
 		id:         db.previousTxnID.Add(1),
 		ts:         time.Now(),
 	}
+}
+
+// beginTxnFree returns a context wired for txn-free access - reads are served by a fresh lock token
+// (which satisfies datastore.Txn), and writes are routed straight to the rootstore with no
+// transaction open - together with that token. The caller acquires whatever collection lock it needs
+// under the token and must defer token.release() to free it.
+//
+// This is the entry point for operations (Truncate, RefreshView) that must perform txn-free writes
+// while still holding a collection write lock, on stores such as leveldb that cannot write outside a
+// transaction while one is open. See https://github.com/sourcenetwork/defradb/issues/4959.
+func (db *DB) beginTxnFree(ctx context.Context) (context.Context, *lockToken) {
+	token := db.newLockToken()
+	ctx = datastore.CtxSetTxn(ctx, token)
+	ctx = corekv.SetCtxTxn(ctx, nil)
+	// The short-id caches are normally initialised by InitContext, which this path bypasses.
+	ctx = id.InitCollectionShortIDCache(ctx)
+	ctx = id.InitFieldShortIDCache(ctx)
+	return ctx, token
 }
 
 func (t *lockToken) ID() uint64         { return t.id }

--- a/internal/db/lock_token.go
+++ b/internal/db/lock_token.go
@@ -1,0 +1,104 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package db
+
+import (
+	"time"
+
+	"github.com/sourcenetwork/defradb/internal/datastore"
+)
+
+// lockToken is a rootstore-backed pseudo-transaction used to hold a collection write lock
+// without opening an underlying store transaction.
+//
+// It exists because corekv-leveldb permits only one open transaction at a time and blocks all
+// non-transactional writes while one is open (see https://github.com/sourcenetwork/defradb/issues/4959).
+// Operations such as Truncate and RefreshView must perform non-transactional (txn-free) writes, so
+// they cannot hold a store transaction open for the duration. The lock token lets them hold the
+// collection write lock - which is what actually provides reader isolation - while every read and
+// write goes directly to the rootstore with no transaction open.
+//
+// It satisfies datastore.Txn (the store accessors are backed by a Multistore over the rootstore) so
+// that read paths which do datastore.CtxMustGetTxn(ctx).Systemstore() continue to work, and it
+// carries a unique id because the cache layer keys per-transaction caches by id. Its lifecycle is
+// purely the registered close callbacks: releasing it frees the collection lock(s) acquired under it
+// and disposes any per-token caches.
+type lockToken struct {
+	*datastore.Multistore
+
+	id uint64
+	ts time.Time
+
+	successFns []func()
+	errorFns   []func()
+	discardFns []func()
+
+	successAsyncFns []func()
+	errorAsyncFns   []func()
+	discardAsyncFns []func()
+
+	closed bool
+}
+
+var _ datastore.Txn = (*lockToken)(nil)
+
+// newLockToken returns a lock token backed by the rootstore, with a unique id drawn from the same
+// allocator as real transactions so it never collides with one.
+func (db *DB) newLockToken() *lockToken {
+	return &lockToken{
+		Multistore: datastore.NewMultistore(db.rootstore, db.lockSet, db.blockStoreChunkSize),
+		id:         db.previousTxnID.Add(1),
+		ts:         time.Now(),
+	}
+}
+
+func (t *lockToken) ID() uint64         { return t.id }
+func (t *lockToken) StartTS() time.Time { return t.ts }
+
+func (t *lockToken) OnSuccess(fn func()) { t.successFns = append(t.successFns, fn) }
+func (t *lockToken) OnError(fn func())   { t.errorFns = append(t.errorFns, fn) }
+func (t *lockToken) OnDiscard(fn func()) { t.discardFns = append(t.discardFns, fn) }
+
+func (t *lockToken) OnSuccessAsync(fn func()) { t.successAsyncFns = append(t.successAsyncFns, fn) }
+func (t *lockToken) OnErrorAsync(fn func())   { t.errorAsyncFns = append(t.errorAsyncFns, fn) }
+func (t *lockToken) OnDiscardAsync(fn func()) { t.discardAsyncFns = append(t.discardAsyncFns, fn) }
+
+// release fires the registered close callbacks exactly once, freeing the collection lock(s) held
+// under this token and disposing any per-token caches.
+//
+// All current consumers (the lock set and the cache layer) register identical callbacks on success,
+// error, and discard, and the cache layer writes through to the store before caching, so firing a
+// single set here is correct. Repeated calls are no-ops.
+func (t *lockToken) release() {
+	if t.closed {
+		return
+	}
+	t.closed = true
+
+	for _, fn := range t.discardAsyncFns {
+		go fn()
+	}
+	for _, fn := range t.discardFns {
+		fn()
+	}
+}
+
+// Commit releases the token. There is nothing to commit - the token never opens a store transaction
+// and all writes made under it are already durable.
+func (t *lockToken) Commit() error {
+	t.release()
+	return nil
+}
+
+// Discard releases the token.
+func (t *lockToken) Discard() {
+	t.release()
+}

--- a/internal/db/lock_token_test.go
+++ b/internal/db/lock_token_test.go
@@ -1,0 +1,84 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package db
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/sourcenetwork/corekv/memory"
+	"github.com/sourcenetwork/immutable"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcenetwork/defradb/internal/datastore"
+	"github.com/sourcenetwork/defradb/internal/db/lock"
+)
+
+// lockToken must satisfy datastore.Txn so that read paths which do
+// datastore.CtxMustGetTxn(ctx).Systemstore() keep working under it.
+var _ datastore.Txn = (*lockToken)(nil)
+
+func newTestLockToken(rootstore *memory.Datastore, lockSet *lock.LockSet, id uint64) *lockToken {
+	return &lockToken{
+		Multistore: datastore.NewMultistore(rootstore, lockSet, immutable.None[int]()),
+		id:         id,
+	}
+}
+
+// release must fire registered callbacks exactly once, even if called multiple times.
+func TestLockToken_ReleaseIsIdempotent(t *testing.T) {
+	calls := 0
+	tok := &lockToken{id: 1}
+	tok.OnDiscard(func() { calls++ })
+
+	tok.release()
+	tok.release()
+
+	require.Equal(t, 1, calls, "release should fire registered callbacks exactly once")
+}
+
+// A collection write lock held under a lock token must block a competing read lock until the
+// token is released, and releasing the token must free it. This mirrors how Truncate/RefreshView
+// hold the collection write lock without an open store transaction.
+func TestLockToken_ReleaseFreesCompetingRLock(t *testing.T) {
+	ctx := context.Background()
+	rootstore := memory.NewDatastore(ctx)
+	lockSet := lock.NewLockSet()
+
+	const shortID = uint32(7)
+	writer := newTestLockToken(rootstore, lockSet, 1)
+	reader := newTestLockToken(rootstore, lockSet, 2)
+
+	lockSet.CollectionLock(writer, shortID)
+
+	acquired := make(chan struct{})
+	go func() {
+		lockSet.CollectionRLock(reader, shortID)
+		close(acquired)
+	}()
+
+	select {
+	case <-acquired:
+		t.Fatal("CollectionRLock acquired while a write lock was held; expected it to block")
+	case <-time.After(200 * time.Millisecond):
+		// Expected: the read lock is blocked behind the write lock.
+	}
+
+	writer.release()
+
+	select {
+	case <-acquired:
+		// Expected: releasing the token frees the write lock so the read lock can be acquired.
+	case <-time.After(2 * time.Second):
+		t.Fatal("CollectionRLock did not acquire after the write-lock token was released")
+	}
+}

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -459,19 +459,42 @@ func (db *DB) AddView(
 
 	ctx = identity.WithContext(ctx, opt.GetIdentity())
 
+	_, hadTxn := datastore.CtxTryGetTxn(ctx)
+
 	ctx, txn, err := ensureContextTxn(ctx, db, false)
 	if err != nil {
 		return nil, err
 	}
 	defer txn.Discard()
 
+	// Phase 1: create the view metadata atomically within the transaction.
 	defs, err := db.addView(ctx, query, sdl, opt.TransformCID)
 	if err != nil {
 		return nil, err
 	}
 
+	if hadTxn {
+		// The caller owns the transaction; refresh within it (unsupported on leveldb) and let the
+		// caller commit.
+		if err := db.refreshNewMaterializedViews(ctx, defs, false); err != nil {
+			return nil, err
+		}
+		return defs, nil
+	}
+
+	// Phase 2: commit the metadata so no transaction is open, then refresh the materialized view
+	// caches txn-free. This avoids holding a leveldb transaction open across the txn-free refresh
+	// writes. See https://github.com/sourcenetwork/defradb/issues/4959.
 	err = txn.Commit()
 	if err != nil {
+		return nil, err
+	}
+
+	// The committed transaction is still referenced by ctx; clear it so the refresh opens its own
+	// fresh transactions rather than reusing the closed one.
+	ctx = datastore.CtxSetTxn(ctx, nil)
+
+	if err := db.refreshNewMaterializedViews(ctx, defs, true); err != nil {
 		return nil, err
 	}
 
@@ -490,24 +513,23 @@ func (db *DB) RefreshViews(ctx context.Context, opts ...options.Enumerable[optio
 
 	ctx = identity.WithContext(ctx, opt.GetIdentity())
 
-	ctx, txn, err := ensureContextTxn(ctx, db, false)
-	if err != nil {
-		return err
+	if _, hadTxn := datastore.CtxTryGetTxn(ctx); hadTxn {
+		// The caller owns the transaction; refresh within it (unsupported on leveldb).
+		ctx, txn, err := ensureContextTxn(ctx, db, false)
+		if err != nil {
+			return err
+		}
+		defer txn.Discard()
+
+		if err := db.refreshViewsInTxn(ctx, opt); err != nil {
+			return err
+		}
+		return txn.Commit()
 	}
 
-	defer txn.Discard()
-
-	err = db.refreshViews(ctx, opt)
-	if err != nil {
-		return err
-	}
-
-	err = txn.Commit()
-	if err != nil {
-		return err
-	}
-
-	return nil
+	// No explicit transaction: refresh per-view so the action markers are never written while a
+	// transaction is open. See https://github.com/sourcenetwork/defradb/issues/4959.
+	return db.refreshViewsImplicit(ctx, opt)
 }
 
 // BasicImport imports a json dataset.

--- a/internal/db/view.go
+++ b/internal/db/view.go
@@ -128,17 +128,6 @@ func (db *DB) refreshViewsInTxn(ctx context.Context, opts *options.GetCollection
 			continue
 		}
 
-		shortID, err := id.GetShortCollectionID(ctx, col.CollectionID)
-		if err != nil {
-			return err
-		}
-		db.lockSet.CollectionLock(txn, shortID)
-
-		colObject, err := db.newCollection(col, immutable.Some(txn))
-		if err != nil {
-			return err
-		}
-
 		multistore := datastore.NewMultistore(db.rootstore, db.lockSet, db.blockStoreChunkSize)
 
 		err = action.Register(writeCtx, multistore, db.events, col.CollectionID, client.RefreshDatastoreAction)
@@ -146,24 +135,7 @@ func (db *DB) refreshViewsInTxn(ctx context.Context, opts *options.GetCollection
 			return err
 		}
 
-		// Clearing and then constructing is a bit inefficient, but it should do for now.
-		// Long term we probably want to update inline as much as possible to avoid unnessecarily
-		// moving/adding/deleting keys in storage
-		err = colObject.truncate(ctx)
-		if err != nil {
-			errErr := action.Set(
-				writeCtx,
-				multistore,
-				db.events,
-				col.CollectionID,
-				client.TruncateAction,
-				client.ErroredActionStatus,
-			)
-			return errors.Join(errErr, err)
-		}
-
-		err = db.buildViewCache(ctx, col)
-		if err != nil {
+		if err := db.rebuildView(ctx, txn, col); err != nil {
 			errErr := action.Set(
 				writeCtx,
 				multistore,
@@ -182,6 +154,30 @@ func (db *DB) refreshViewsInTxn(ctx context.Context, opts *options.GetCollection
 	}
 
 	return nil
+}
+
+// rebuildView clears and reconstructs a single materialized view's cache using txn. It manages
+// neither the action-execution markers nor the transaction lifecycle - the caller owns both.
+func (db *DB) rebuildView(ctx context.Context, txn datastore.Txn, col client.CollectionVersion) error {
+	shortID, err := id.GetShortCollectionID(ctx, col.CollectionID)
+	if err != nil {
+		return err
+	}
+	db.lockSet.CollectionLock(txn, shortID)
+
+	colObject, err := db.newCollection(col, immutable.Some(txn))
+	if err != nil {
+		return err
+	}
+
+	// Clearing and then constructing is a bit inefficient, but it should do for now.
+	// Long term we probably want to update inline as much as possible to avoid unnessecarily
+	// moving/adding/deleting keys in storage
+	if err := colObject.truncate(ctx); err != nil {
+		return err
+	}
+
+	return db.buildViewCache(ctx, col)
 }
 
 // refreshViewsImplicit refreshes views without an explicit transaction. Each view's action-execution
@@ -261,25 +257,7 @@ func (db *DB) rebuildMaterializedView(ctx context.Context, col client.Collection
 	}
 	defer txn.Discard()
 
-	shortID, err := id.GetShortCollectionID(ctx, col.CollectionID)
-	if err != nil {
-		return err
-	}
-	db.lockSet.CollectionLock(txn, shortID)
-
-	colObject, err := db.newCollection(col, immutable.Some[datastore.Txn](txn))
-	if err != nil {
-		return err
-	}
-
-	// Clearing and then constructing is a bit inefficient, but it should do for now.
-	// Long term we probably want to update inline as much as possible to avoid unnessecarily
-	// moving/adding/deleting keys in storage
-	if err := colObject.truncate(ctx); err != nil {
-		return err
-	}
-
-	if err := db.buildViewCache(ctx, col); err != nil {
+	if err := db.rebuildView(ctx, txn, col); err != nil {
 		return err
 	}
 

--- a/internal/db/view.go
+++ b/internal/db/view.go
@@ -98,19 +98,17 @@ func (db *DB) addView(
 		return nil, err
 	}
 
-	for _, view := range returnDescriptions {
-		if view.Query.HasValue() && view.IsMaterialized {
-			err := db.refreshViews(ctx, utils.NewOptions(options.GetCollections().SetVersionID(view.VersionID)))
-			if err != nil {
-				return nil, err
-			}
-		}
-	}
-
+	// The materialized view caches are refreshed by the caller (AddView) after the collection
+	// metadata has been committed, so the refresh - which writes txn-free - never runs while a
+	// transaction is open. See https://github.com/sourcenetwork/defradb/issues/4959.
 	return returnDescriptions, nil
 }
 
-func (db *DB) refreshViews(ctx context.Context, opts *options.GetCollectionsOptions) error {
+// refreshViewsInTxn refreshes views using the explicit transaction already on the context. The
+// action-execution markers are written txn-free (corekv issue #107) while that transaction is open,
+// so this path is unsupported on leveldb - the txn-free write blocks on the open transaction (see
+// issue #4959). It preserves the original behaviour for the other stores.
+func (db *DB) refreshViewsInTxn(ctx context.Context, opts *options.GetCollectionsOptions) error {
 	// For now, we only support user-cache management of views, not all collections
 	cols, err := db.getViews(ctx, opts)
 	if err != nil {
@@ -118,6 +116,11 @@ func (db *DB) refreshViews(ctx context.Context, opts *options.GetCollectionsOpti
 	}
 
 	txn := datastore.CtxMustGetTxn(ctx)
+
+	// Clear the transaction on the context used to write the action execution information, otherwise
+	// corekv will pick it up again, writing using the transaction.
+	// https://github.com/sourcenetwork/corekv/issues/107
+	writeCtx := datastore.CtxSetTxn(ctx, nil)
 
 	for _, col := range cols {
 		if !col.IsMaterialized {
@@ -138,11 +141,7 @@ func (db *DB) refreshViews(ctx context.Context, opts *options.GetCollectionsOpti
 
 		multistore := datastore.NewMultistore(db.rootstore, db.lockSet, db.blockStoreChunkSize)
 
-		// Clear the transaction on the context used to write the action execution information, otherwise
-		// corekv will pick it up again, writing using the transaction.
-		// https://github.com/sourcenetwork/corekv/issues/107
-		txnFreeCtx := datastore.CtxSetTxn(ctx, nil)
-		err = action.Register(txnFreeCtx, multistore, db.events, col.CollectionID, client.RefreshDatastoreAction)
+		err = action.Register(writeCtx, multistore, db.events, col.CollectionID, client.RefreshDatastoreAction)
 		if err != nil {
 			return err
 		}
@@ -153,7 +152,7 @@ func (db *DB) refreshViews(ctx context.Context, opts *options.GetCollectionsOpti
 		err = colObject.truncate(ctx)
 		if err != nil {
 			errErr := action.Set(
-				txnFreeCtx,
+				writeCtx,
 				multistore,
 				db.events,
 				col.CollectionID,
@@ -166,7 +165,7 @@ func (db *DB) refreshViews(ctx context.Context, opts *options.GetCollectionsOpti
 		err = db.buildViewCache(ctx, col)
 		if err != nil {
 			errErr := action.Set(
-				txnFreeCtx,
+				writeCtx,
 				multistore,
 				db.events,
 				col.CollectionID,
@@ -176,7 +175,137 @@ func (db *DB) refreshViews(ctx context.Context, opts *options.GetCollectionsOpti
 			return errors.Join(errErr, err)
 		}
 
-		err = action.Complete(txnFreeCtx, multistore, db.events, col.CollectionID, client.RefreshDatastoreAction)
+		err = action.Complete(writeCtx, multistore, db.events, col.CollectionID, client.RefreshDatastoreAction)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// refreshViewsImplicit refreshes views without an explicit transaction. Each view's action-execution
+// markers are written with no transaction open, and the truncate-and-rebuild runs inside its own
+// transaction. This keeps txn-free writes and an open transaction from ever overlapping, which is
+// what leveldb requires (issue #4959), while still giving the rebuild planner a real transaction.
+func (db *DB) refreshViewsImplicit(ctx context.Context, opts *options.GetCollectionsOptions) error {
+	cols, err := db.listViewsToRefresh(ctx, opts)
+	if err != nil {
+		return err
+	}
+
+	for _, col := range cols {
+		if !col.IsMaterialized {
+			// We only care about materialized views here, so skip any that aren't
+			continue
+		}
+		if err := db.refreshViewImplicit(ctx, col); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// listViewsToRefresh reads the set of views to refresh under a short-lived read transaction that is
+// closed before any refresh begins, so no transaction is open when the action markers are written.
+func (db *DB) listViewsToRefresh(
+	ctx context.Context,
+	opts *options.GetCollectionsOptions,
+) ([]client.CollectionVersion, error) {
+	ctx, txn, err := ensureContextTxn(ctx, db, true)
+	if err != nil {
+		return nil, err
+	}
+	defer txn.Discard()
+
+	return db.getViews(ctx, opts)
+}
+
+// refreshViewImplicit registers the refresh action (txn-free, with no transaction open), rebuilds the
+// view inside its own transaction, then records completion (also txn-free, after the transaction has
+// closed).
+func (db *DB) refreshViewImplicit(ctx context.Context, col client.CollectionVersion) (err error) {
+	multistore := datastore.NewMultistore(db.rootstore, db.lockSet, db.blockStoreChunkSize)
+
+	err = action.Register(ctx, multistore, db.events, col.CollectionID, client.RefreshDatastoreAction)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err != nil {
+			errErr := action.Set(
+				ctx,
+				multistore,
+				db.events,
+				col.CollectionID,
+				client.TruncateAction,
+				client.ErroredActionStatus,
+			)
+			err = errors.Join(errErr, err)
+			return
+		}
+		err = action.Complete(ctx, multistore, db.events, col.CollectionID, client.RefreshDatastoreAction)
+	}()
+
+	return db.rebuildMaterializedView(ctx, col)
+}
+
+// rebuildMaterializedView clears and rebuilds a materialized view's cache inside its own transaction.
+// The planner used by buildViewCache re-enters public APIs that require a real transaction, so this
+// must run under one - which is fine, as it performs no txn-free writes.
+func (db *DB) rebuildMaterializedView(ctx context.Context, col client.CollectionVersion) error {
+	ctx, txn, err := ensureContextTxn(ctx, db, false)
+	if err != nil {
+		return err
+	}
+	defer txn.Discard()
+
+	shortID, err := id.GetShortCollectionID(ctx, col.CollectionID)
+	if err != nil {
+		return err
+	}
+	db.lockSet.CollectionLock(txn, shortID)
+
+	colObject, err := db.newCollection(col, immutable.Some[datastore.Txn](txn))
+	if err != nil {
+		return err
+	}
+
+	// Clearing and then constructing is a bit inefficient, but it should do for now.
+	// Long term we probably want to update inline as much as possible to avoid unnessecarily
+	// moving/adding/deleting keys in storage
+	if err := colObject.truncate(ctx); err != nil {
+		return err
+	}
+
+	if err := db.buildViewCache(ctx, col); err != nil {
+		return err
+	}
+
+	return txn.Commit()
+}
+
+// refreshNewMaterializedViews refreshes the caches of the materialized views among defs, after
+// AddView has created (and, in the implicit case, committed) their metadata.
+func (db *DB) refreshNewMaterializedViews(
+	ctx context.Context,
+	defs []client.CollectionVersion,
+	implicit bool,
+) error {
+	for _, view := range defs {
+		if !view.Query.HasValue() || !view.IsMaterialized {
+			continue
+		}
+
+		opts := utils.NewOptions(options.GetCollections().SetVersionID(view.VersionID))
+
+		var err error
+		if implicit {
+			err = db.refreshViewsImplicit(ctx, opts)
+		} else {
+			err = db.refreshViewsInTxn(ctx, opts)
+		}
 		if err != nil {
 			return err
 		}

--- a/node/store_level_test.go
+++ b/node/store_level_test.go
@@ -1,0 +1,217 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package node
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime/pprof"
+	"runtime/trace"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sourcenetwork/corekv/leveldb"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests characterize the goleveldb transaction model that DefraDB's leveldb backend
+// inherits, and which underlies the deadlock in https://github.com/sourcenetwork/defradb/issues/4959.
+//
+// The corekv leveldb package documents the contract:
+//
+//	"Only one transaction can be opened at a time. Subsequent call to Write and OpenTransaction
+//	 will be blocked until in-flight transaction is committed or discarded."
+//
+// DefraDB's Truncate/RefreshView flow violates this by performing txn-free writes (the
+// action-execution status markers) while an outer transaction is still open, and by allowing two
+// transactions to be open concurrently. These tests pin the underlying behavior so that, when the
+// backend or the flow is changed to resolve #4959, the assumptions here are revisited explicitly.
+//
+// The waits are timing-based by necessity (proving an operation blocks), but generously bounded.
+//
+// # Visualizing the deadlock
+//
+// Set DEFRA_TRACE=1 to capture a Go execution trace per test (written to $DEFRA_TRACE_DIR, or the
+// OS temp dir by default). Goroutines are labelled via runtime/trace tasks+regions and
+// runtime/pprof labels so the blocking goroutine is easy to spot. View with:
+//
+//	DEFRA_TRACE=1 go test ./node/ -run TestStoreLevel_TxnFreeWriteBlocksWhileTxnOpen -v
+//	go tool trace <printed-path>          # or: gotraceui <printed-path>
+//
+// In go tool trace, see "User-defined tasks" / "Goroutine analysis" — the txn-free-writer goroutine
+// sits blocked in its region for the whole probe window while T1 is held open.
+
+const levelTxnBlockProbe = 500 * time.Millisecond
+
+// startTrace begins an execution trace for the test when DEFRA_TRACE is set, and returns the root
+// context to attach goroutine labels/regions to. When tracing is disabled it is a cheap no-op so
+// normal/CI runs are unaffected.
+func startTrace(t *testing.T) context.Context {
+	t.Helper()
+	if os.Getenv("DEFRA_TRACE") == "" {
+		return context.Background()
+	}
+
+	dir := os.Getenv("DEFRA_TRACE_DIR")
+	if dir == "" {
+		dir = os.TempDir()
+	}
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	path := filepath.Join(dir, "defra-leveldb-"+strings.ReplaceAll(t.Name(), "/", "_")+".trace")
+	// Log an absolute path: `go test` runs with the working directory set to the package dir, so a
+	// relative DEFRA_TRACE_DIR would otherwise print a path that doesn't resolve from the repo root.
+	if abs, err := filepath.Abs(path); err == nil {
+		path = abs
+	}
+
+	f, err := os.Create(path)
+	require.NoError(t, err)
+	require.NoError(t, trace.Start(f))
+
+	t.Cleanup(func() {
+		trace.Stop()
+		_ = f.Close()
+		t.Logf("execution trace written: %s", path)
+		t.Logf("view with: go tool trace %s   (or: gotraceui %s)", path, path)
+	})
+	return context.Background()
+}
+
+// labelGoroutine tags the *current* goroutine with an "actor" pprof label (e.g. "T1") so it is
+// identifiable in goroutine profiles and in go tool trace's goroutine analysis.
+func labelGoroutine(ctx context.Context, actor string) {
+	pprof.SetGoroutineLabels(pprof.WithLabels(ctx, pprof.Labels("actor", actor)))
+}
+
+// goLabeled spawns fn on a new goroutine, labelled both with an "actor" runtime/pprof label (visible
+// in goroutine profiles) and a runtime/trace region nested under the test's task (visible in
+// go tool trace). The labelling is what makes the blocked goroutine readable in the visualization.
+func goLabeled(ctx context.Context, actor, region string, fn func()) {
+	go func() {
+		pprof.Do(ctx, pprof.Labels("actor", actor), func(ctx context.Context) {
+			trace.WithRegion(ctx, region, fn)
+		})
+	}()
+}
+
+// Manifestation 1 primitive: a txn-free write blocks while a transaction is open. This is the
+// single-goroutine self-deadlock behind Truncate/RefreshView (action.Register's txn-free
+// Systemstore().Set, written via context.TODO(), blocks behind the flow's own open transaction).
+func TestStoreLevel_TxnFreeWriteBlocksWhileTxnOpen(t *testing.T) {
+	ctx, task := trace.NewTask(startTrace(t), "manifestation-1: self-deadlock")
+	defer task.End()
+
+	labelGoroutine(ctx, "T1") // this goroutine holds the open transaction
+
+	store, err := leveldb.NewDatastore(t.TempDir(), nil)
+	require.NoError(t, err)
+	defer store.Close() //nolint:errcheck
+
+	// Open a transaction and intentionally leave it open (holds the exclusive write lock).
+	txn := store.NewTxn(false)
+	trace.Log(ctx, "T1", "opened — holds leveldb write lock")
+
+	// The competing actor performs a txn-free write (no transaction of its own). Labelled "T2"
+	// in the trace for readability, though it is the absence of a txn that makes it block on T1.
+	done := make(chan error, 1)
+	goLabeled(ctx, "T2", "T2: txn-free Set — blocks while T1 open", func() {
+		done <- store.Set(context.Background(), []byte("k"), []byte("v"))
+	})
+
+	select {
+	case err := <-done:
+		t.Fatalf("txn-free Set returned (err=%v) while a txn was open; expected it to block", err)
+	case <-time.After(levelTxnBlockProbe):
+		// Expected: the write is blocked behind the open transaction.
+		trace.Log(ctx, "T2", "still blocked after probe window")
+	}
+
+	// Releasing the transaction must unblock the pending write.
+	trace.Log(ctx, "T1", "Discard — releasing write lock (T2 can now proceed)")
+	txn.Discard()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("txn-free Set did not unblock after txn Discard")
+	}
+}
+
+// Manifestation 2 primitive: a second transaction cannot be opened while the first is still open.
+// This is the concurrent-transaction deadlock behind the "..._Deadlocks..." collection-version tests.
+func TestStoreLevel_SecondTxnBlocksWhileFirstOpen(t *testing.T) {
+	ctx, task := trace.NewTask(startTrace(t), "manifestation-2: adversarial txns")
+	defer task.End()
+
+	labelGoroutine(ctx, "T1") // this goroutine holds the first transaction
+
+	store, err := leveldb.NewDatastore(t.TempDir(), nil)
+	require.NoError(t, err)
+	defer store.Close() //nolint:errcheck
+
+	txn1 := store.NewTxn(false)
+	trace.Log(ctx, "T1", "opened — occupies the single txn slot")
+
+	done := make(chan struct{}, 1)
+	goLabeled(ctx, "T2", "T2: NewTxn/OpenTransaction — blocks while T1 open", func() {
+		txn2 := store.NewTxn(false) // OpenTransaction blocks while txn1 is open
+		txn2.Discard()
+		done <- struct{}{}
+	})
+
+	select {
+	case <-done:
+		t.Fatal("second NewTxn returned while the first txn was open; expected it to block")
+	case <-time.After(levelTxnBlockProbe):
+		// Expected: the second OpenTransaction is blocked.
+		trace.Log(ctx, "T2", "OpenTransaction still blocked after probe window")
+	}
+
+	trace.Log(ctx, "T1", "Discard — releasing the txn slot (T2 can now open)")
+	txn1.Discard()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("second NewTxn did not unblock after the first txn Discard")
+	}
+}
+
+// Reads are not blocked by an open transaction (only writes and OpenTransaction are). This is why
+// getStatus's Systemstore().Get succeeds and the first call to actually hang is the subsequent Set.
+func TestStoreLevel_TxnFreeReadNotBlockedByOpenTxn(t *testing.T) {
+	ctx, task := trace.NewTask(startTrace(t), "control: reads are not blocked")
+	defer task.End()
+
+	labelGoroutine(ctx, "T1") // this goroutine holds the open transaction
+
+	store, err := leveldb.NewDatastore(t.TempDir(), nil)
+	require.NoError(t, err)
+	defer store.Close() //nolint:errcheck
+
+	txn := store.NewTxn(false)
+	defer txn.Discard()
+	trace.Log(ctx, "T1", "opened — holds leveldb write lock")
+
+	done := make(chan struct{}, 1)
+	goLabeled(ctx, "T2", "T2: txn-free Get — succeeds despite T1 open", func() {
+		_, _ = store.Get(context.Background(), []byte("missing"))
+		done <- struct{}{}
+	})
+
+	select {
+	case <-done:
+		// Expected: the read completes despite the open transaction.
+	case <-time.After(levelTxnBlockProbe):
+		t.Fatal("txn-free Get blocked while a txn was open; expected reads not to block")
+	}
+}

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -2121,7 +2121,7 @@ func skipIfUnsupportedLevelDBAction(t testing.TB, dbt state.DatabaseType, action
 	for _, act := range actions {
 		if p, ok := act.(*action.Parallel); ok {
 			for _, inner := range p.Children {
-				if levelDBActionUnsupported(inner) {
+				if levelDBActionUnsupportedInParallel(inner) {
 					t.Skip("action does not yet support the leveldb store: " +
 						"https://github.com/sourcenetwork/defradb/issues/4959")
 				}
@@ -2147,6 +2147,18 @@ func levelDBActionUnsupported(act any) bool {
 		return true // TODO(#4959): narrow to explicit-txn only once the refresh fix lands.
 	case *action.AddView:
 		return true // TODO(#4959): narrow to explicit-txn only once the AddView fix lands.
+	}
+	return false
+}
+
+// levelDBActionUnsupportedInParallel reports whether the given action cannot run against the leveldb
+// store when executed concurrently with other actions. Truncate/RefreshView/AddView perform txn-free
+// writes; run alongside operations that open their own transactions, they require leveldb to support
+// concurrent transactions, which it does not (issue #4959, "manifestation 2").
+func levelDBActionUnsupportedInParallel(act any) bool {
+	switch act.(type) {
+	case *action.Truncate, *action.RefreshViews, *action.AddView:
+		return true
 	}
 	return false
 }

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -2144,9 +2144,11 @@ func levelDBActionUnsupported(act any) bool {
 		// transaction open across the txn-free truncate writes, which leveldb does not allow.
 		return a.TransactionID.HasValue()
 	case *action.RefreshViews:
-		return true // TODO(#4959): narrow to explicit-txn only once the refresh fix lands.
+		// Implicit RefreshViews is supported; an explicit transaction is not (see Truncate above).
+		return a.TransactionID.HasValue()
 	case *action.AddView:
-		return true // TODO(#4959): narrow to explicit-txn only once the AddView fix lands.
+		// Implicit AddView is supported; an explicit transaction is not (see Truncate above).
+		return a.TransactionID.HasValue()
 	}
 	return false
 }

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -2119,22 +2119,36 @@ func skipIfUnsupportedLevelDBAction(t testing.TB, dbt state.DatabaseType, action
 	}
 
 	for _, act := range actions {
-		switch a := act.(type) {
-		case *action.Truncate, *action.RefreshViews, *action.AddView:
-			// These actions are skipped due to:
-			// https://github.com/sourcenetwork/defradb/issues/4959
-			t.Skip("truncate and RefreshView does not yet support the leveldb store")
-		case *action.Parallel:
-			for _, inner := range a.Children {
-				switch inner.(type) {
-				case *action.Truncate, *action.RefreshViews, *action.AddView:
-					// These actions are skipped due to:
-					// https://github.com/sourcenetwork/defradb/issues/4959
-					t.Skip("truncate and RefreshView does not yet support the leveldb store")
+		if p, ok := act.(*action.Parallel); ok {
+			for _, inner := range p.Children {
+				if levelDBActionUnsupported(inner) {
+					t.Skip("action does not yet support the leveldb store: " +
+						"https://github.com/sourcenetwork/defradb/issues/4959")
 				}
 			}
+			continue
+		}
+		if levelDBActionUnsupported(act) {
+			t.Skip("action does not yet support the leveldb store: " +
+				"https://github.com/sourcenetwork/defradb/issues/4959")
 		}
 	}
+}
+
+// levelDBActionUnsupported reports whether the given action cannot yet run against the leveldb
+// store. See https://github.com/sourcenetwork/defradb/issues/4959.
+func levelDBActionUnsupported(act any) bool {
+	switch a := act.(type) {
+	case *action.Truncate:
+		// Implicit Truncate is supported. An explicit transaction would require holding a leveldb
+		// transaction open across the txn-free truncate writes, which leveldb does not allow.
+		return a.TransactionID.HasValue()
+	case *action.RefreshViews:
+		return true // TODO(#4959): narrow to explicit-txn only once the refresh fix lands.
+	case *action.AddView:
+		return true // TODO(#4959): narrow to explicit-txn only once the AddView fix lands.
+	}
+	return false
 }
 
 func MustParseTime(timeString string) time.Time {


### PR DESCRIPTION
## Relevant issue(s)

Addresses #4959 First manifestation, the Truncate / RefreshView / AddView self-deadlock.

## Description

On the leveldb store, `Truncate`, `RefreshView`, and `AddView` would deadlock.

**Root cause.** These flows open a store transaction `T1` (which, on leveldb, takes the store's single write lock) and then issue **txn-free** writes within the same flow. The action execution markers, written via `context.TODO()` so they survive a rollback. leveldb blocks any  non-transactional write while a transaction is open, so the txn-free `db.Put` waits for `T1` to close, but `T1` only closes once the flow finishes — which it can't, because it's blocked on that write. A single goroutine deadlocks with itself. Badger and the in-memory store are MVCC, so they permit those concurrent writes and never hit this.

  **Fix.** Stop holding a store transaction open at the same time as a txn-free write:

  - A rootstore-backed **lock token** (`internal/db/lock_token.go`) holds the collection write lock —
  - `Truncate` (implicit) now runs fully txn-free under the token (this also removes a latent
    transaction-size blow-up: the bulk deletes were previously routed through the transaction contrary
    to the documented intent).
  - `RefreshView` writes its action markers with no transaction open, and runs the truncate-and-rebuild
    inside its own per-view transaction (the rebuild planner re-enters public APIs that need a real
    `*db.Txn`, and performs no txn-free writes).
  - `AddView` commits the collection metadata before running the txn-free refresh.
  - The leveldb test-skip helper is narrowed to only the still-unsupported cases (explicit-transaction
    and concurrent/parallel variants — those are the second manifestation).
    
### Before: the self-deadlock

  ```mermaid
  sequenceDiagram
      autonumber
      participant G as Truncate goroutine
      participant L as goleveldb DB<br/>(one exclusive write lock)
      participant S as systemstore<br/>(same DB, diff. prefix)

      G->>L: NewTxn() → OpenTransaction()  (collection_truncate.go:51)
      L-->>G: T1 — exclusive write lock acquired
      Note over L: write lock now held by T1

      G->>S: action.Register → Systemstore().Set(InProgress)<br/>txn-free, via context.TODO() (action.go:55)
      S->>L: db.Put(marker) — needs the write lock
      Note over L,S: ⛔ Put blocks: lock held by T1

      rect rgba(255,0,0,0.08)
      Note over G: would reach txn.Commit() (collection_truncate.go:94)<br/>to release T1 … but is blocked on the Put above
      end
      Note over G,L: cycle: Put waits for T1 to close ⇄ T1 closes only after the Put returns
  ```

  ### After: txn-free under a lock token

  ```mermaid
  sequenceDiagram
      autonumber
      participant G as Truncate / RefreshView goroutine
      participant K as LockSet<br/>(collection write lock)
      participant L as goleveldb DB<br/>(one exclusive write lock)

      G->>K: newLockToken() + CollectionLock(token)
      Note over K: write lock held by the token<br/>(this is what isolates readers)
      Note over L: NO OpenTransaction ⇒ goleveldb<br/>write lock stays free

      G->>L: action.Register → Systemstore().Set (txn-free)
      L-->>G: ok (no open txn to block on)
      G->>L: bulk deletes (txn-free, direct to rootstore)
      L-->>G: ok
      G->>L: action.Complete (txn-free)
      L-->>G: ok

      G->>K: token.release()
      Note over K: write lock freed
      rect rgba(0,150,0,0.08)
      Note over G,L: a transaction is never open while a txn-free write runs ⇒ no self-deadlock
      end
  ```
  

### Limitations
- **Explicit-transaction variants remain unsupported on leveldb.** Running these ops inside a user-supplied transaction still issues a txn-free write while that transaction is open, so it would still deadlock; those cases remain skipped on leveldb (second manifestation).
- **Reduced atomicity of the implicit path.** Truncate and the view-cache rebuild's clear step are now non-transactional, so a crash mid-operation can leave partial state rather than rolling back. Recovery relies on the action markers + the resume-safe delete ordering, not a single atomic commit.
  - **The lock token is a `datastore.Txn`, not a `*db.Txn`.** Any future read/write path that type-asserts the context transaction to the concrete `*db.Txn` will panic under the token; only the verified truncate paths run under it (refresh deliberately uses a real transaction for this reason).
  - **AddView is no longer atomic across create + refresh**, and `RefreshViews` rebuilds each view in its own transaction (a multi-view refresh is no longer atomic as a group).


## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

- Unit: `go test ./internal/db/ -run TestLockToken` and `go test ./node/ -run TestStoreLevel`
    (new characterization tests pinning leveldb's transaction model).
- leveldb integration (previously skipped, now passing):
    - `DEFRA_LEVEL=true go test -race ./tests/integration/collection/truncate/...`
    - `DEFRA_LEVEL=true DEFRA_VIEW_TYPE=materialized go test ./tests/integration/collection/refresh/... ./tests/integration/view/simple/...`
- Regression on the default (badger) backend across the changed truncate/view/refresh suites, plus `go test ./internal/... ./node/`.
- Note: a few view tests that require compiled Rust/wasm lenses fail locally for lack of those build artifacts — this is environmental and reproduces identically on badger (not caused by this change).

Specify the platform(s) on which this was tested:

- MacOS
