### PR TITLE
fix: Record view refresh errors against the refresh action

### DIFF
--- a/internal/db/view.go
+++ b/internal/db/view.go
@@ -157,7 +157,7 @@ func (db *DB) refreshViews(ctx context.Context, opts *options.GetCollectionsOpti
 				multistore,
 				db.events,
 				col.CollectionID,
-				client.TruncateAction,
+				client.RefreshDatastoreAction,
 				client.ErroredActionStatus,
 			)
 			return errors.Join(errErr, err)
@@ -170,7 +170,7 @@ func (db *DB) refreshViews(ctx context.Context, opts *options.GetCollectionsOpti
 				multistore,
 				db.events,
 				col.CollectionID,
-				client.TruncateAction,
+				client.RefreshDatastoreAction,
 				client.ErroredActionStatus,
 			)
 			return errors.Join(errErr, err)

--- a/tests/integration/collection/refresh/list_actions_test.go
+++ b/tests/integration/collection/refresh/list_actions_test.go
@@ -96,6 +96,67 @@ func TestRefreshCollectionListAction_ListsUncompletedRefresh(t *testing.T) {
 	testUtils.ExecuteTestCase(t, test)
 }
 
+// TestRefreshCollectionListAction_RecordsErrorAgainstRefreshAction is a regression test for
+// https://github.com/sourcenetwork/defradb/issues/4963 - a failed view refresh must record its
+// error status against `RefreshDatastoreAction` (the action it registered), not `TruncateAction`.
+//
+// The backing collection is removed so the subsequent refresh fails inside `buildViewCache`. With
+// the bug present, `ListActions` reports two entries: an orphaned `RefreshDatastoreAction` stuck
+// `InProgress` plus an `Errored` `TruncateAction`. With the fix, it reports a single `Errored`
+// `RefreshDatastoreAction`.
+func TestRefreshCollectionListAction_RecordsErrorAgainstRefreshAction(t *testing.T) {
+	test := testUtils.TestCase{
+		SupportedViewTypes: immutable.Some([]testUtils.ViewType{
+			testUtils.MaterializedViewType,
+		}),
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type Users {
+						name: String
+					}
+				`,
+			},
+			&action.AddView{
+				Query: `
+					Users {
+						name
+					}
+				`,
+				SDL: `
+					type UserView {
+						name: String
+					}
+				`,
+			},
+			&action.PatchCollection{
+				Patch: `
+					[
+						{
+							"op": "remove",
+							"path": "/Users"
+						}
+					]
+				`,
+			},
+			&action.RefreshViews{
+				ExpectedError: "collection not found",
+			},
+			&action.ListActions{
+				ExpectedInfo: []client.ActionExecution{
+					{
+						CollectionID: "bafyreiex5xc3do2a42ymbt7tscfx7ifsdmgwkty6dbnfnktyiplqgeap4q",
+						Action:       client.RefreshDatastoreAction,
+						Status:       client.ErroredActionStatus,
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
 func TestRefreshCollectionListAction_DoesNotListCompletedRefreshes(t *testing.T) {
 	test := testUtils.TestCase{
 		Actions: []any{

--- a/tests/integration/collection/refresh/list_actions_test.go
+++ b/tests/integration/collection/refresh/list_actions_test.go
@@ -96,14 +96,6 @@ func TestRefreshCollectionListAction_ListsUncompletedRefresh(t *testing.T) {
 	testUtils.ExecuteTestCase(t, test)
 }
 
-// TestRefreshCollectionListAction_RecordsErrorAgainstRefreshAction is a regression test for
-// https://github.com/sourcenetwork/defradb/issues/4963 - a failed view refresh must record its
-// error status against `RefreshDatastoreAction` (the action it registered), not `TruncateAction`.
-//
-// The backing collection is removed so the subsequent refresh fails inside `buildViewCache`. With
-// the bug present, `ListActions` reports two entries: an orphaned `RefreshDatastoreAction` stuck
-// `InProgress` plus an `Errored` `TruncateAction`. With the fix, it reports a single `Errored`
-// `RefreshDatastoreAction`.
 func TestRefreshCollectionListAction_RecordsErrorAgainstRefreshAction(t *testing.T) {
 	test := testUtils.TestCase{
 		SupportedViewTypes: immutable.Some([]testUtils.ViewType{


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4963 

## Description
The intuition in the issue is correct: both error sites in `refreshViews` (`internal/db/view.go`) used the wrong action constant, and changing them to `RefreshDatastoreAction` is proper way to address this.
 
## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?
 - `tests/integration/collection/refresh/...`, `.../truncate/...`, and `internal/db/...` pass under both default and `DEFRA_VIEW_TYPE=materialized`.
 
Specify the platform(s) on which this was tested:
- MacOS
