### PR TITLE
fix: Make startup succeed if TLS is enabled for HTTP API

### DIFF
--- a/http/client.go
+++ b/http/client.go
@@ -54,6 +54,16 @@ func NewClient(rawURL string) (*Client, error) {
 	return &Client{httpClient}, nil
 }
 
+// NewInsecureClient returns a Client that skips TLS certificate verification.
+// Only use for loopback health checks against a server with a self-signed cert.
+func NewInsecureClient(rawURL string) (*Client, error) {
+	httpClient, err := newInsecureHttpClient(rawURL)
+	if err != nil {
+		return nil, err
+	}
+	return &Client{httpClient}, nil
+}
+
 func (c *Client) NewTxn(readOnly bool) (client.Txn, error) {
 	query := url.Values{}
 	if readOnly {

--- a/http/http_client.go
+++ b/http/http_client.go
@@ -11,6 +11,7 @@
 package http
 
 import (
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -36,6 +37,25 @@ func newHttpClient(rawURL string) (*httpClient, error) {
 	}
 	return &httpClient{
 		client:  http.DefaultClient,
+		baseURL: baseURL,
+		apiURL:  baseURL.JoinPath("/api/" + Version),
+	}, nil
+}
+
+// newInsecureHttpClient returns an httpClient that skips TLS certificate
+// verification. Only use for loopback health checks against a server whose
+// cert is not trusted by the system CA pool (e.g. self-signed certs).
+func newInsecureHttpClient(rawURL string) (*httpClient, error) {
+	baseURL, err := parseBaseURL(rawURL)
+	if err != nil {
+		return nil, err
+	}
+	return &httpClient{
+		client: &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
+			},
+		},
 		baseURL: baseURL,
 		apiURL:  baseURL.JoinPath("/api/" + Version),
 	}, nil

--- a/http/server.go
+++ b/http/server.go
@@ -46,7 +46,6 @@ type Server struct {
 	options   *options.NodeHTTPOptions
 	server    *http.Server
 	listener  net.Listener
-	isTLS     bool
 	ctxCancel context.CancelFunc
 }
 
@@ -100,7 +99,6 @@ func (s *Server) Serve() error {
 	if s.options.TLSCertPath == "" && s.options.TLSKeyPath == "" {
 		return s.serve()
 	}
-	s.isTLS = true
 	return s.serveTLS()
 }
 
@@ -131,7 +129,7 @@ func (s *Server) serveTLS() error {
 }
 
 func (s *Server) Address() string {
-	if s.isTLS {
+	if s.options.TLSCertPath != "" && s.options.TLSKeyPath != "" {
 		return "https://" + s.listener.Addr().String()
 	}
 	return "http://" + s.listener.Addr().String()

--- a/http/server_test.go
+++ b/http/server_test.go
@@ -16,6 +16,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -197,6 +198,33 @@ func TestServerListenAndServeWithAllowedOrigins(t *testing.T) {
 
 	err = srv.Shutdown(context.Background())
 	require.NoError(t, err)
+}
+
+func TestServerAddressWithTLSBeforeServe(t *testing.T) {
+	certPath, keyPath := writeTestCerts(t)
+	srv, err := NewServer(testHandler, options.NodeHTTP().SetAddress("127.0.0.1:0").SetCertPath(certPath).SetKeyPath(keyPath))
+	require.NoError(t, err)
+
+	err = srv.SetListener()
+	require.NoError(t, err)
+	defer srv.listener.Close() //nolint:errcheck
+
+	// Address() must return https:// based on options alone, without Serve() ever
+	// being called. Previously isTLS was only set inside Serve(), so calling
+	// Address() before the serve goroutine ran returned "http://" and caused the
+	// startup health check to send plain HTTP to a TLS listener.
+	assert.True(t, strings.HasPrefix(srv.Address(), "https://"), "expected https:// prefix, got %s", srv.Address())
+}
+
+func TestServerAddressWithoutTLS(t *testing.T) {
+	srv, err := NewServer(testHandler, options.NodeHTTP().SetAddress("127.0.0.1:0"))
+	require.NoError(t, err)
+
+	err = srv.SetListener()
+	require.NoError(t, err)
+	defer srv.listener.Close() //nolint:errcheck
+
+	assert.True(t, strings.HasPrefix(srv.Address(), "http://"), "expected http:// prefix, got %s", srv.Address())
 }
 
 func TestServerWithReadTimeout(t *testing.T) {

--- a/http/server_test.go
+++ b/http/server_test.go
@@ -207,7 +207,7 @@ func TestServerAddressWithTLSBeforeServe(t *testing.T) {
 
 	err = srv.SetListener()
 	require.NoError(t, err)
-	defer srv.listener.Close() //nolint:errcheck
+	defer srv.listener.Close()
 
 	// Address() must return https:// based on options alone, without Serve() ever
 	// being called. Previously isTLS was only set inside Serve(), so calling
@@ -222,7 +222,7 @@ func TestServerAddressWithoutTLS(t *testing.T) {
 
 	err = srv.SetListener()
 	require.NoError(t, err)
-	defer srv.listener.Close() //nolint:errcheck
+	defer srv.listener.Close()
 
 	assert.True(t, strings.HasPrefix(srv.Address(), "http://"), "expected http:// prefix, got %s", srv.Address())
 }

--- a/node/node_api.go
+++ b/node/node_api.go
@@ -63,7 +63,7 @@ func (n *Node) startAPI(ctx context.Context) error {
 	// not trusted by the system CA pool, so we skip certificate verification for
 	// this loopback health check only.
 	var c *http.Client
-	if n.opts.HTTP.TLSCertPath != "" {
+	if n.opts.HTTP.TLSCertPath != "" && n.opts.HTTP.TLSKeyPath != "" {
 		c, err = http.NewInsecureClient(n.APIURL)
 	} else {
 		c, err = http.NewClient(n.APIURL)

--- a/node/node_api.go
+++ b/node/node_api.go
@@ -58,7 +58,16 @@ func (n *Node) startAPI(ctx context.Context) error {
 	n.APIURL = n.server.Address()
 	// Check that the server is ready before returning. We do this to ensure that
 	// subsequent operation will behave as expected.
-	c, err := http.NewClient(n.APIURL)
+	//
+	// When TLS is configured the server uses a self-signed certificate that is
+	// not trusted by the system CA pool, so we skip certificate verification for
+	// this loopback health check only.
+	var c *http.Client
+	if n.opts.HTTP.TLSCertPath != "" {
+		c, err = http.NewInsecureClient(n.APIURL)
+	} else {
+		c, err = http.NewClient(n.APIURL)
+	}
 	if err != nil {
 		return err
 	}

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -14,6 +14,9 @@ package node
 
 import (
 	"context"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -22,6 +25,65 @@ import (
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/options"
 )
+
+// testTLSKey and testTLSCert are a self-signed EC key/cert pair used only in
+// tests to exercise TLS startup without hitting the system CA pool.
+const testTLSKey = `-----BEGIN EC PARAMETERS-----
+BgUrgQQAIg==
+-----END EC PARAMETERS-----
+-----BEGIN EC PRIVATE KEY-----
+MIGkAgEBBDD4VK0DRBRaeieXU9JaPJfSeegGYcXaX5+gEcwGKA0UJYI46QRHIlHC
+IJMOjPsrUCmgBwYFK4EEACKhZANiAAQ3ltsFK8bZZpOYiJnvwpa7Ft+b0KFsDqpu
+pS0gW/SYpAncHhRuz18RQ2ycuXlSN1S/PAryRZ5PK2xORKfwpguEDEMdVwbHorZO
+K44P/h3dhyNyAyf8rcRoqKXcl/K/uew=
+-----END EC PRIVATE KEY-----`
+
+const testTLSCert = `-----BEGIN CERTIFICATE-----
+MIICQDCCAcUCCQDpMnN1gQ4fGTAKBggqhkjOPQQDAjCBiDELMAkGA1UEBhMCY2Ex
+DzANBgNVBAgMBlF1ZWJlYzEQMA4GA1UEBwwHQ2hlbHNlYTEPMA0GA1UECgwGU291
+cmNlMRAwDgYDVQQLDAdEZWZyYURCMQ8wDQYDVQQDDAZzb3VyY2UxIjAgBgkqhkiG
+9w0BCQEWE2V4YW1wbGVAZXhhbXBsZS5jb20wHhcNMjIxMDA2MTgyMjE1WhcNMjMx
+MDA2MTgyMjE1WjCBiDELMAkGA1UEBhMCY2ExDzANBgNVBAgMBlF1ZWJlYzEQMA4G
+A1UEBwwHQ2hlbHNlYTEPMA0GA1UECgwGU291cmNlMRAwDgYDVQQLDAdEZWZyYURC
+MQ8wDQYDVQQDDAZzb3VyY2UxIjAgBgkqhkiG9w0BCQEWE2V4YW1wbGVAZXhhbXBs
+ZS5jb20wdjAQBgcqhkjOPQIBBgUrgQQAIgNiAAQ3ltsFK8bZZpOYiJnvwpa7Ft+b
+0KFsDqpupS0gW/SYpAncHhRuz18RQ2ycuXlSN1S/PAryRZ5PK2xORKfwpguEDEMd
+VwbHorZOK44P/h3dhyNyAyf8rcRoqKXcl/K/uewwCgYIKoZIzj0EAwIDaQAwZgIx
+AIfNQeo8syOb94ojF40jY+fY1ZBSbNNK6UUbFquwDMVEoSyXRJHHEU12NUKCVTUH
+kgIxAKaEGC+lqp0aaN+yubYLRiTDxOlNpyiHox3nZiL4bG/CCdPDvbX63QcdI2yq
+XPKczg==
+-----END CERTIFICATE-----`
+
+func writeTestCerts(t *testing.T) (certPath, keyPath string) {
+	t.Helper()
+	dir := t.TempDir()
+	certPath = filepath.Join(dir, "cert.pub")
+	keyPath = filepath.Join(dir, "cert.key")
+	require.NoError(t, os.WriteFile(certPath, []byte(testTLSCert), 0644))
+	require.NoError(t, os.WriteFile(keyPath, []byte(testTLSKey), 0644))
+	return certPath, keyPath
+}
+
+func TestStartAPIWithTLS(t *testing.T) {
+	certPath, keyPath := writeTestCerts(t)
+	ctx := context.Background()
+
+	n, err := New(ctx,
+		options.Node().
+			SetDisableP2P(true).
+			Store().SetPath(t.TempDir()).
+			Node().
+			HTTP().SetAddress("127.0.0.1:0").SetCertPath(certPath).SetKeyPath(keyPath).
+			Node(),
+	)
+	require.NoError(t, err)
+
+	err = n.Start(ctx)
+	require.NoError(t, err)
+	defer n.Close(ctx) //nolint:errcheck
+
+	assert.True(t, strings.HasPrefix(n.APIURL, "https://"), "expected https:// APIURL, got %s", n.APIURL)
+}
 
 func TestPurgeAndRestartWithDevModeDisabled(t *testing.T) {
 	ctx := context.Background()

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -80,7 +80,7 @@ func TestStartAPIWithTLS(t *testing.T) {
 
 	err = n.Start(ctx)
 	require.NoError(t, err)
-	defer n.Close(ctx) //nolint:errcheck
+	defer n.Close(ctx)
 
 	assert.True(t, strings.HasPrefix(n.APIURL, "https://"), "expected https:// APIURL, got %s", n.APIURL)
 }


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4780 

## Description

The bug described in the issue was caused by a race condition inside `node/node_api.go`. The `Server.Serve()` function was called in a goroutine that was responsible for setting a boolean flag, `isTLS`, on the server struct. Immediately afterwards, on the main goroutine, `Address()` was called before thee `isTLS` flag had a chance to be updated. As a result, it would basically always be false, and the function would return a basic "http" URL even when TLS was configured. This caused a mismatch between the request sent, which was a plain HTTP request, and the HTTPS server.

To fix this, this PR removes the `isTLS` flag entirely, and instead changes the `Address()` function so that it gets the schema from the server's own options -- guaranteed to be accurate at the time of resolution. 

Additionally, it came up that even with the correct URL, the health check would still fail. This was because the `http.DefaultClient` rejects self-signed certificates. To combat this, a new client, `NewInsecureClient`, is introduced. It is exclusively used for this loopback self-check, and so is (I believe) safe.

This PR introduces two new unit tests:

`TestServerAddressWithTLSBeforeServe`
`TestStartAPIWithTLS`

The first test illustrates that the race condition that was described has been addressed and fixed by asserting that an "https" URL is obtained from the `Address()` function. The second test explicitly tests what the issue originally pointed out: that a node can be created, configured to have TLS, and that there will be no error. It then, also, confirms that the address contains "https".
 
## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [ ] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

In addition to the integration testing included, this was manually tested:

`./build/defradb start --pubkeypath ~/.defradb/certs/server.crt --privkeypath ~/.defradb/certs/server.key --no-keyring`

Thee bug was recreatable on previous versions of Defra, but is resolved with these changes, and the 400 error is no longer returned.

Specify the platform(s) on which this was tested:
- WSL
