### PR TITLE
fix: Add SkipChangeDetector mechanism for tests

### DIFF
--- a/tests/change_detector/utils.go
+++ b/tests/change_detector/utils.go
@@ -77,9 +77,13 @@ func DatabaseDir(t testing.TB) string {
 }
 
 // PreTestChecks skips any test that can't be run by the change detector.
-func PreTestChecks(t testing.TB, collectionNames []string) {
+func PreTestChecks(t testing.TB, collectionNames []string, skipChangeDetector bool) {
 	if !Enabled {
 		return
+	}
+
+	if skipChangeDetector {
+		t.Skip("skipping test that is incompatible with the change detector")
 	}
 
 	if previousTestCaseTestName == t.Name() {

--- a/tests/integration/query/inline_array/with_datetime_test.go
+++ b/tests/integration/query/inline_array/with_datetime_test.go
@@ -462,6 +462,7 @@ func TestQueryInlineArrayWithDateTime_ErrorMalformed(t *testing.T) {
 
 func TestQueryInlineArrayWithDateTime_UTC_NOW(t *testing.T) {
 	test := testUtils.TestCase{
+		SkipChangeDetector: true,
 		Actions: []any{
 			&action.AddDoc{
 				Doc: `{

--- a/tests/integration/test_case.go
+++ b/tests/integration/test_case.go
@@ -95,6 +95,11 @@ type TestCase struct {
 	// A value of N means the test will be attempted up to N+1 times total
 	// (1 initial + N retries).
 	FlakeRetries uint
+
+	// SkipChangeDetector will skip this test when the change detector is active.
+	// Use this for tests whose results are inherently non-deterministic across the
+	// two change detector phases, such as tests that rely on the current time.
+	SkipChangeDetector bool
 }
 
 // KMS contains the configuration for KMS to be used in the test

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -152,7 +152,7 @@ func ExecuteTestCase(
 	flattenActions(&testCase)
 	applyMultipliers(t, &testCase)
 	collectionNames := getCollectionNames(testCase)
-	changeDetector.PreTestChecks(t, collectionNames)
+	changeDetector.PreTestChecks(t, collectionNames, testCase.SkipChangeDetector)
 	skipIfMutationTypeUnsupported(t, testCase.SupportedMutationTypes)
 	skipIfDocumentACPTypeUnsupported(t, testCase.SupportedDocumentACPTypes)
 	skipIfNetworkTest(t, testCase.Actions)


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4974 

## Description

It was previously the case that the `TestQueryInlineArrayWithDateTime_UTC_NOW` test would always cause the change detector to fail. This is because the current time cannot be cached meaningfully by the change detector, as it must be resolved at the time of the test running.

The solution to this problem is to introduce a mechanism for tests to opt out of the change detector. This is done with the `SkipChangeDetector` field. To make it work, we simply create a new boolean for whether or not it should run, and modify the `PreTestChecks` to check for this boolean, bailing early if it is set to true.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Specify the platform(s) on which this was tested:
- WSL
