### PR TITLE
fix(i): Add truncate support to LevelDB

### DIFF
--- a/client/collection.go
+++ b/client/collection.go
@@ -168,6 +168,9 @@ type Collection interface {
 	//
 	// If an error is returned, the truncate may have been partially applied - because of this it is strongly
 	// suggested to call `Truncate` until it succeeds.
+	//
+	// User-managed transactions are not supported by this function if the backing store does not support
+	// concurrent open transactions, such as LevelDB.
 	Truncate(ctx context.Context, opts ...options.Enumerable[options.TruncateCollectionOptions]) error
 }
 

--- a/internal/datastore/txn_shim.go
+++ b/internal/datastore/txn_shim.go
@@ -27,11 +27,9 @@ type TxnShim struct {
 	ts time.Time
 
 	successFns []func()
-	errorFns   []func()
 	discardFns []func()
 
 	successAsyncFns []func()
-	errorAsyncFns   []func()
 	discardAsyncFns []func()
 }
 
@@ -90,7 +88,7 @@ func (t *TxnShim) OnSuccess(fn func()) {
 }
 
 func (t *TxnShim) OnError(fn func()) {
-	t.errorFns = append(t.errorFns, fn)
+	// no-op, commit cannot error on this type
 }
 
 func (t *TxnShim) OnDiscard(fn func()) {
@@ -102,7 +100,7 @@ func (t *TxnShim) OnSuccessAsync(fn func()) {
 }
 
 func (t *TxnShim) OnErrorAsync(fn func()) {
-	t.errorAsyncFns = append(t.errorAsyncFns, fn)
+	// no-op, commit cannot error on this type
 }
 
 func (t *TxnShim) OnDiscardAsync(fn func()) {

--- a/internal/datastore/txn_shim.go
+++ b/internal/datastore/txn_shim.go
@@ -1,0 +1,126 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package datastore
+
+import (
+	"time"
+
+	"github.com/sourcenetwork/corekv"
+)
+
+// TxnShim is a storeless implementation of the [Txn] interface.
+//
+// Calling any of the child store accessors will result in a panic.
+// The majority of Defra does not check for nil being returned from these
+// functions, so we might as well panic within this type where the stack
+// trace should be a little more obvious.
+type TxnShim struct {
+	id uint64
+	ts time.Time
+
+	successFns []func()
+	errorFns   []func()
+	discardFns []func()
+
+	successAsyncFns []func()
+	errorAsyncFns   []func()
+	discardAsyncFns []func()
+}
+
+var _ Txn = (*TxnShim)(nil)
+
+func NewTxnShim(
+	id uint64,
+) *TxnShim {
+	return &TxnShim{
+		id: id,
+		ts: time.Now(),
+	}
+}
+
+func (t *TxnShim) Blockstore() Blockstore {
+	panic("unimplemented")
+}
+
+func (t *TxnShim) Commit() error {
+	for _, fn := range t.successAsyncFns {
+		go fn()
+	}
+	for _, fn := range t.successFns {
+		fn()
+	}
+	return nil
+}
+
+func (t *TxnShim) Datastore() Keyedstore {
+	panic("unimplemented")
+}
+
+func (t *TxnShim) Discard() {
+	for _, fn := range t.discardAsyncFns {
+		go fn()
+	}
+	for _, fn := range t.discardFns {
+		fn()
+	}
+}
+
+func (t *TxnShim) Encstore() Blockstore {
+	panic("unimplemented")
+}
+
+func (t *TxnShim) Headstore() corekv.ReaderWriter {
+	panic("unimplemented")
+}
+
+func (t *TxnShim) ID() uint64 {
+	return t.id
+}
+
+func (t *TxnShim) OnSuccess(fn func()) {
+	t.successFns = append(t.successFns, fn)
+}
+
+func (t *TxnShim) OnError(fn func()) {
+	t.errorFns = append(t.errorFns, fn)
+}
+
+func (t *TxnShim) OnDiscard(fn func()) {
+	t.discardFns = append(t.discardFns, fn)
+}
+
+func (t *TxnShim) OnSuccessAsync(fn func()) {
+	t.successAsyncFns = append(t.successAsyncFns, fn)
+}
+
+func (t *TxnShim) OnErrorAsync(fn func()) {
+	t.errorAsyncFns = append(t.errorAsyncFns, fn)
+}
+
+func (t *TxnShim) OnDiscardAsync(fn func()) {
+	t.discardAsyncFns = append(t.discardAsyncFns, fn)
+}
+
+func (t *TxnShim) Peerstore() corekv.ReaderWriter {
+	panic("unimplemented")
+}
+
+func (t *TxnShim) Rootstore() corekv.ReaderWriter {
+	panic("unimplemented")
+}
+
+func (t *TxnShim) StartTS() time.Time {
+	return t.ts
+}
+
+func (t *TxnShim) Systemstore() corekv.ReaderWriter {
+	panic("unimplemented")
+}

--- a/internal/db/collection_truncate.go
+++ b/internal/db/collection_truncate.go
@@ -48,21 +48,21 @@ func (c *collection) Truncate(
 		return err
 	}
 
-	ctx, txn, err := ensureContextTxn(ctx, c.db, false)
+	ctx, txn, err := ensureContextTxnShim(ctx, c.db)
 	if err != nil {
 		return err
 	}
 
 	defer txn.Discard()
 
-	shortID, err := id.GetShortCollectionID(ctx, c.def.CollectionID)
+	multistore := datastore.NewMultistore(c.db.rootstore, c.db.lockSet, c.db.blockStoreChunkSize)
+
+	shortID, err := id.GetUncachedShortCollectionID(ctx, c.def.CollectionID, multistore.Systemstore())
 	if err != nil {
 		return err
 	}
 
 	c.db.lockSet.CollectionLock(txn, shortID)
-
-	multistore := datastore.NewMultistore(c.db.rootstore, c.db.lockSet, c.db.blockStoreChunkSize)
 
 	// Clear the transaction on the context used to write the action execution information, otherwise
 	// corekv will pick it up again, writing using the transaction.
@@ -97,7 +97,8 @@ func (c *collection) Truncate(
 func (c *collection) truncate(
 	ctx context.Context,
 ) error {
-	shortID, err := id.GetShortCollectionID(ctx, c.def.CollectionID)
+	sysStore := datastore.NewMultistore(c.db.rootstore, c.db.lockSet, c.db.blockStoreChunkSize).Systemstore()
+	shortID, err := id.GetUncachedShortCollectionID(ctx, c.def.CollectionID, sysStore)
 	if err != nil {
 		return err
 	}

--- a/internal/db/txn.go
+++ b/internal/db/txn.go
@@ -20,6 +20,7 @@ import (
 	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/options"
+	"github.com/sourcenetwork/defradb/clock"
 	"github.com/sourcenetwork/defradb/crypto"
 	"github.com/sourcenetwork/defradb/internal/datastore"
 )
@@ -63,6 +64,44 @@ func ensureContextTxn(ctx context.Context, db *DB, readOnly bool) (context.Conte
 	}
 
 	return InitContext(ctx, txn), txn, nil
+}
+
+func ensureContextTxnShim(ctx context.Context, db *DB) (context.Context, datastore.Txn, error) {
+	var clientTxn datastore.Txn
+	ctxTxn, existsOnCtx := datastore.CtxTryGetTxn(ctx)
+	if !existsOnCtx {
+		txnId := db.previousTxnID.Add(1)
+		txn := datastore.NewTxnShim(txnId)
+		ctxTxn = txn
+	}
+
+	switch txn := ctxTxn.(type) {
+	case *Txn:
+		// If the txn has already been set on the context but it hasn't already been set as explicit,
+		// we create a copy of the txn and mark it as an explicit txn.
+		if !txn.explicit && existsOnCtx {
+			txn = &Txn{
+				BasicTxn: txn.BasicTxn,
+				db:       txn.db,
+				explicit: true,
+				isClosed: txn.isClosed,
+				// We do not need to copy the mutex (or a pointer to it), as if we are doing this,
+				// we can be sure that this txn clone is a child of the parent context, and so
+				// should not be locking anyway.
+			}
+		}
+		clientTxn = txn
+		return InitContext(ctx, txn), clientTxn, nil
+
+	case *datastore.TxnShim:
+		clientTxn = txn
+		ctx = datastore.CtxSetTxn(ctx, txn)
+		ctx = clock.WithTime(ctx, txn.StartTS())
+		return ctx, clientTxn, nil
+
+	default:
+		return nil, nil, NewErrUnsupportedTxnType(ctxTxn)
+	}
 }
 
 func lockForTxn(ctx context.Context, txn *Txn) (context.Context, func()) {

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -2120,17 +2120,23 @@ func skipIfUnsupportedLevelDBAction(t testing.TB, dbt state.DatabaseType, action
 
 	for _, act := range actions {
 		switch a := act.(type) {
-		case *action.Truncate, *action.RefreshViews, *action.AddView:
+		case *action.Truncate:
+			if a.TransactionID.HasValue() {
+				// https://github.com/sourcenetwork/defradb/issues/4983
+				t.Skip("explicit transactions for truncate with leveldb are not supported")
+			}
+		case *action.RefreshViews, *action.AddView:
 			// These actions are skipped due to:
 			// https://github.com/sourcenetwork/defradb/issues/4959
-			t.Skip("truncate and RefreshView does not yet support the leveldb store")
+			t.Skip("RefreshViews does not yet support the leveldb store")
 		case *action.Parallel:
 			for _, inner := range a.Children {
 				switch inner.(type) {
 				case *action.Truncate, *action.RefreshViews, *action.AddView:
-					// These actions are skipped due to:
-					// https://github.com/sourcenetwork/defradb/issues/4959
-					t.Skip("truncate and RefreshView does not yet support the leveldb store")
+					t.Skip("write actions that acquire write locks are unsupported with leveldb in" +
+						" the test framework.  Another action may lock the store by opening a transaction" +
+						" after one of these acquires the write lock, but before it itself locks the leveldb" +
+						" store - causing a deadlock.")
 				}
 			}
 		}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4984

## Description

Adds implicit-txn truncate support to LevelDB.

RefreshViews and AddView will also make use of the new shim, as detailed in https://github.com/sourcenetwork/defradb/issues/4959

Explicit transaction support can be added later for LevelDB, it is low priority (not v1) and a nice solution to that is probably a bit more involved.