### PR TITLE
fix: Make COUNT work with groupBy

### DIFF
--- a/client/request/aggregate.go
+++ b/client/request/aggregate.go
@@ -34,6 +34,7 @@ type AggregateTarget struct {
 	Offsetable
 	Orderable
 	Filterable
+	Groupable
 
 	// HostName is the name of the immediate field on the object hosting the aggregate.
 	//

--- a/internal/planner/mapper/mapper.go
+++ b/internal/planner/mapper/mapper.go
@@ -562,26 +562,38 @@ func resolveAggregates(
 					return nil, err
 				}
 
-				// If groupBy is specified, remap object relation field names and ensure the
-				// GROUP field is in the mapping so the groupNode has a valid data source index.
+				// convertedGroupBy holds the planner-internal form of the aggregate's groupBy
+				// argument, with field names translated to the numeric indices the planner uses
+				// internally. It is nil when no groupBy was requested.
 				var convertedGroupBy *GroupBy
 				if target.groupBy.HasValue() {
+					// Work on a copy so we don't mutate the original request.
 					groupByFields := make([]string, len(target.groupBy.Value().Fields))
 					copy(groupByFields, target.groupBy.Value().Fields)
+
 					for i, groupByField := range groupByFields {
 						fieldDesc, ok := childDef.GetFieldByName(groupByField)
 						if ok && fieldDesc.Kind.IsObject() {
+							// Grouping by a multi-valued (array) relation is not meaningful.
 							if fieldDesc.Kind.IsArray() {
 								return nil, NewErrInvalidFieldToGroupBy(groupByField)
 							}
+							// The planner stores relation fields under their ID form (e.g. "author_id"
+							// rather than "author"), so rewrite the name to match.
 							groupByFields[i] = request.ToFieldID(groupByField)
 						}
 					}
+
 					remappedGroupBy := immutable.Some(request.GroupBy{Fields: groupByFields})
+
+					// The groupNode requires a slot in the mapping for the special GROUP field so
+					// it has a valid data-source index to read from. If one doees not exist, it will be added.
 					if _, isGroupFieldMapped := childMapping.IndexesByName[request.GroupFieldName]; !isGroupFieldMapped {
 						groupIndex := childMapping.GetNextIndex()
 						childMapping.Add(groupIndex, request.GroupFieldName)
 					}
+
+					// Translate the (now-remapped) field names into their numeric mapping indices.
 					convertedGroupBy = toGroupBy(remappedGroupBy, childMapping)
 				}
 

--- a/internal/planner/mapper/mapper.go
+++ b/internal/planner/mapper/mapper.go
@@ -476,13 +476,11 @@ func resolveAggregates(
 					if err != nil {
 						return nil, err
 					}
-					convertedGroupBy := toGroupBy(target.groupBy, childMapping)
 					host, hasHost = tryGetTarget(
 						target.hostExternalName,
 						convertedFilter,
 						target.limit,
 						orderBy,
-						convertedGroupBy,
 						fields,
 					)
 				}
@@ -1765,30 +1763,9 @@ func (t Targetable) equal(other Targetable) bool {
 		return false
 	}
 
-	if !t.GroupBy.equal(other.GroupBy) {
-		return false
-	}
-
 	return true
 }
 
-func (g *GroupBy) equal(other *GroupBy) bool {
-	if g == nil {
-		return other == nil
-	}
-	if other == nil {
-		return false
-	}
-	if len(g.Fields) != len(other.Fields) {
-		return false
-	}
-	for i, f := range g.Fields {
-		if f.Index != other.Fields[i].Index || f.Name != other.Fields[i].Name {
-			return false
-		}
-	}
-	return true
-}
 
 func (l *Limit) equal(other *Limit) bool {
 	if l == nil {
@@ -2012,7 +1989,6 @@ func tryGetTarget(
 	filter *Filter,
 	limit *Limit,
 	order *OrderBy,
-	groupBy *GroupBy,
 	collection []Requestable,
 ) (Requestable, bool) {
 	dummyTarget := Targetable{
@@ -2022,7 +1998,6 @@ func tryGetTarget(
 		Filter:  filter,
 		Limit:   limit,
 		OrderBy: order,
-		GroupBy: groupBy,
 	}
 
 	for _, field := range collection {

--- a/internal/planner/mapper/mapper.go
+++ b/internal/planner/mapper/mapper.go
@@ -595,6 +595,19 @@ func resolveAggregates(
 
 					// Translate the (now-remapped) field names into their numeric mapping indices.
 					convertedGroupBy = toGroupBy(remappedGroupBy, childMapping)
+
+					// The group-by fields must be explicitly added to the child select so the
+					// fetcher knows to retrieve them. Unlike a top-level aggregate (whose scan
+					// has no explicit fields and so fetches everything by default), a relation
+					// host is fetched via a type-join whose child scan only retrieves the fields
+					// it is told about. Without this the group-by value is never fetched and all
+					// documents collapse into a single group.
+					for _, groupByField := range convertedGroupBy.Fields {
+						childFields = append(childFields, &Field{
+							Index: groupByField.Index,
+							Name:  groupByField.Name,
+						})
+					}
 				}
 
 				var dummyJoin Requestable

--- a/internal/planner/mapper/mapper.go
+++ b/internal/planner/mapper/mapper.go
@@ -1766,7 +1766,6 @@ func (t Targetable) equal(other Targetable) bool {
 	return true
 }
 
-
 func (l *Limit) equal(other *Limit) bool {
 	if l == nil {
 		return other == nil

--- a/internal/planner/mapper/mapper.go
+++ b/internal/planner/mapper/mapper.go
@@ -476,11 +476,13 @@ func resolveAggregates(
 					if err != nil {
 						return nil, err
 					}
+					convertedGroupBy := toGroupBy(target.groupBy, childMapping)
 					host, hasHost = tryGetTarget(
 						target.hostExternalName,
 						convertedFilter,
 						target.limit,
 						orderBy,
+						convertedGroupBy,
 						fields,
 					)
 				}
@@ -511,7 +513,7 @@ func resolveAggregates(
 				}
 				mapAggregateNestedTargets(target, hostSelectRequest)
 
-				childMapping, _, err := getTopLevelInfo(ctx, store, rootSelectType, hostSelectRequest, childCollectionName)
+				childMapping, childDef, err := getTopLevelInfo(ctx, store, rootSelectType, hostSelectRequest, childCollectionName)
 				if err != nil {
 					return nil, err
 				}
@@ -562,6 +564,29 @@ func resolveAggregates(
 					return nil, err
 				}
 
+				// If groupBy is specified, remap object relation field names and ensure the
+				// GROUP field is in the mapping so the groupNode has a valid data source index.
+				var convertedGroupBy *GroupBy
+				if target.groupBy.HasValue() {
+					groupByFields := make([]string, len(target.groupBy.Value().Fields))
+					copy(groupByFields, target.groupBy.Value().Fields)
+					for i, groupByField := range groupByFields {
+						fieldDesc, ok := childDef.GetFieldByName(groupByField)
+						if ok && fieldDesc.Kind.IsObject() {
+							if fieldDesc.Kind.IsArray() {
+								return nil, NewErrInvalidFieldToGroupBy(groupByField)
+							}
+							groupByFields[i] = request.ToFieldID(groupByField)
+						}
+					}
+					remappedGroupBy := immutable.Some(request.GroupBy{Fields: groupByFields})
+					if _, isGroupFieldMapped := childMapping.IndexesByName[request.GroupFieldName]; !isGroupFieldMapped {
+						groupIndex := childMapping.GetNextIndex()
+						childMapping.Add(groupIndex, request.GroupFieldName)
+					}
+					convertedGroupBy = toGroupBy(remappedGroupBy, childMapping)
+				}
+
 				var dummyJoin Requestable
 				dummyJoinSelect := &Select{
 					Targetable: Targetable{
@@ -572,6 +597,7 @@ func resolveAggregates(
 						Filter:  convertedFilter,
 						Limit:   target.limit,
 						OrderBy: orderBy,
+						GroupBy: convertedGroupBy,
 					},
 					CollectionName:  childCollectionName,
 					DocumentMapping: childMapping,
@@ -1739,6 +1765,28 @@ func (t Targetable) equal(other Targetable) bool {
 		return false
 	}
 
+	if !t.GroupBy.equal(other.GroupBy) {
+		return false
+	}
+
+	return true
+}
+
+func (g *GroupBy) equal(other *GroupBy) bool {
+	if g == nil {
+		return other == nil
+	}
+	if other == nil {
+		return false
+	}
+	if len(g.Fields) != len(other.Fields) {
+		return false
+	}
+	for i, f := range g.Fields {
+		if f.Index != other.Fields[i].Index || f.Name != other.Fields[i].Name {
+			return false
+		}
+	}
 	return true
 }
 
@@ -1880,6 +1928,9 @@ type aggregateRequestTarget struct {
 	// The order in which items should be aggregated. Affects results when used with
 	// limit. Optional.
 	order immutable.Option[request.OrderBy]
+
+	// The groupBy specified by the consumer for this target. Optional.
+	groupBy immutable.Option[request.GroupBy]
 }
 
 // Returns the source of the aggregate as requested by the consumer
@@ -1893,6 +1944,7 @@ func getAggregateSources(field *request.Aggregate) ([]*aggregateRequestTarget, e
 			filter:            target.Filter,
 			limit:             toLimit(target.Limit, target.Offset),
 			order:             target.OrderBy,
+			groupBy:           target.GroupBy,
 		}
 	}
 
@@ -1960,6 +2012,7 @@ func tryGetTarget(
 	filter *Filter,
 	limit *Limit,
 	order *OrderBy,
+	groupBy *GroupBy,
 	collection []Requestable,
 ) (Requestable, bool) {
 	dummyTarget := Targetable{
@@ -1969,6 +2022,7 @@ func tryGetTarget(
 		Filter:  filter,
 		Limit:   limit,
 		OrderBy: order,
+		GroupBy: groupBy,
 	}
 
 	for _, field := range collection {

--- a/internal/request/graphql/parser/query.go
+++ b/internal/request/graphql/parser/query.go
@@ -270,6 +270,7 @@ func parseAggregateTarget(
 	var limit immutable.Option[uint64]
 	var offset immutable.Option[uint64]
 	var order immutable.Option[request.OrderBy]
+	var groupBy immutable.Option[request.GroupBy]
 
 	for name, value := range arguments {
 		switch name {
@@ -316,6 +317,17 @@ func parseAggregateTarget(
 					Conditions: conditions,
 				})
 			}
+
+		case request.GroupByClause:
+			if raw, ok := value.([]any); ok {
+				fields := make([]string, len(raw))
+				for i, f := range raw {
+					if s, ok := f.(string); ok {
+						fields[i] = s
+					}
+				}
+				groupBy = immutable.Some(request.GroupBy{Fields: fields})
+			}
 		}
 	}
 
@@ -333,6 +345,9 @@ func parseAggregateTarget(
 		},
 		Orderable: request.Orderable{
 			OrderBy: order,
+		},
+		Groupable: request.Groupable{
+			GroupBy: groupBy,
 		},
 	}, nil
 }

--- a/internal/request/graphql/schema/generate.go
+++ b/internal/request/graphql/schema/generate.go
@@ -400,12 +400,15 @@ func (g *Generator) createExpandedFieldAggregate(
 			aggregateTarget.Type.(*gql.InputObject).AddFieldConfig("filter", expandedField)
 		}
 
+		// The COUNT aggregate supports groupBy, so we need to add it to the input object
 		if f.Name == request.CountFieldName {
+			// groupByTypeName is only set for real collections, not scalar arrays
 			if groupByType, canHaveGroupBy := g.manager.schema.TypeMap()[groupByTypeName]; canHaveGroupBy {
 				expandedField := &gql.InputObjectFieldConfig{
 					Description: schemaTypes.GroupByArgDescription,
 					Type:        gql.NewList(gql.NewNonNull(groupByType)),
 				}
+				// Add the groupBy argument to the COUNT input object.
 				aggregateTarget.Type.(*gql.InputObject).AddFieldConfig(request.GroupByClause, expandedField)
 			}
 		}

--- a/internal/request/graphql/schema/generate.go
+++ b/internal/request/graphql/schema/generate.go
@@ -365,8 +365,10 @@ func (g *Generator) createExpandedFieldAggregate(
 	for _, aggregateTarget := range f.Args {
 		target := aggregateTarget.Name()
 		var filterTypeName string
+		var groupByTypeName string
 		if target == request.GroupFieldName {
 			filterTypeName = obj.Name() + filterInputNameSuffix
+			groupByTypeName = obj.Name() + typeFieldEnumSuffix
 		} else {
 			if targeted := obj.Fields()[target]; targeted != nil {
 				if list, isList := targeted.Type.(*gql.List); isList && gql.IsLeafType(list.OfType) {
@@ -379,8 +381,10 @@ func (g *Generator) createExpandedFieldAggregate(
 					} else {
 						filterTypeName = genTypeName(list.OfType, filterInputNameSuffix)
 					}
+					// Inline arrays have no named fields to group by, so groupByTypeName is left empty.
 				} else {
 					filterTypeName = targeted.Type.Name() + filterInputNameSuffix
+					groupByTypeName = targeted.Type.Name() + typeFieldEnumSuffix
 				}
 			} else {
 				return NewErrAggregateTargetNotFound(obj.Name(), target)
@@ -394,6 +398,16 @@ func (g *Generator) createExpandedFieldAggregate(
 				Type:        filterType,
 			}
 			aggregateTarget.Type.(*gql.InputObject).AddFieldConfig("filter", expandedField)
+		}
+
+		if f.Name == request.CountFieldName {
+			if groupByType, canHaveGroupBy := g.manager.schema.TypeMap()[groupByTypeName]; canHaveGroupBy {
+				expandedField := &gql.InputObjectFieldConfig{
+					Description: schemaTypes.GroupByArgDescription,
+					Type:        gql.NewList(gql.NewNonNull(groupByType)),
+				}
+				aggregateTarget.Type.(*gql.InputObject).AddFieldConfig(request.GroupByClause, expandedField)
+			}
 		}
 	}
 

--- a/tests/integration/collection_version/aggregates/inline_array_test.go
+++ b/tests/integration/collection_version/aggregates/inline_array_test.go
@@ -70,6 +70,12 @@ func TestCollectionVersionAggregateInlineArrayAddsUsersCount(t *testing.T) {
 													},
 												},
 												map[string]any{
+													"name": "groupBy",
+													"type": map[string]any{
+														"name": nil,
+													},
+												},
+												map[string]any{
 													"name": "limit",
 													"type": map[string]any{
 														"name": "Int",
@@ -434,6 +440,13 @@ func aggregateGroupArg(fieldType string) map[string]any {
 								},
 							},
 						},
+					},
+				},
+				map[string]any{
+					"name": "groupBy",
+					"type": map[string]any{
+						"name":        nil,
+						"inputFields": nil,
 					},
 				},
 				map[string]any{

--- a/tests/integration/collection_version/aggregates/simple_test.go
+++ b/tests/integration/collection_version/aggregates/simple_test.go
@@ -68,6 +68,12 @@ func TestCollectionVersionAggregateSimpleAddsUsersCount(t *testing.T) {
 													},
 												},
 												map[string]any{
+													"name": "groupBy",
+													"type": map[string]any{
+														"name": nil,
+													},
+												},
+												map[string]any{
 													"name": "limit",
 													"type": map[string]any{
 														"name": "Int",

--- a/tests/integration/collection_version/aggregates/top_level_test.go
+++ b/tests/integration/collection_version/aggregates/top_level_test.go
@@ -69,6 +69,12 @@ func TestCollectionVersionAggregateTopLevelAddsCountGivenCollection(t *testing.T
 														},
 													},
 													map[string]any{
+														"name": "groupBy",
+														"type": map[string]any{
+															"name": nil,
+														},
+													},
+													map[string]any{
 														"name": "limit",
 														"type": map[string]any{
 															"name": "Int",

--- a/tests/integration/query/one_to_many/with_count_groupby_test.go
+++ b/tests/integration/query/one_to_many/with_count_groupby_test.go
@@ -1,0 +1,194 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// This file is part of the DefraDB test suite.
+//
+// The DefraDB test suite is licensed under either:
+//
+//   (1) GNU Affero General Public License v3
+//   (2) Business Source License 1.1
+//
+// See tests/LICENSE for details.
+
+package one_to_many
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/defradb/tests/action"
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+func TestQueryOneToMany_WithCountWithGroupBy_CountingZero(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddDoc{
+				CollectionID: 1,
+				Doc: `{
+					"name": "John Grisham",
+					"age": 65,
+					"verified": true
+				}`,
+			},
+			// No books are added. Expected COUNT is 0.
+			&action.Request{
+				Request: `query {
+					Author {
+						name
+						COUNT(published: {groupBy: [name]})
+					}
+				}`,
+				Results: map[string]any{
+					"Author": []map[string]any{
+						{
+							"name":  "John Grisham",
+							"COUNT": 0,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	executeTestCase(t, test)
+}
+
+func TestQueryOneToMany_WithCountWithGroupBy_CountingDistinctNames(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddDoc{
+				CollectionID: 1,
+				Doc: `{
+					"name": "John Grisham",
+					"age": 65,
+					"verified": true
+				}`,
+			},
+			&action.AddDoc{
+				CollectionID: 1,
+				Doc: `{
+					"name": "Cornelia Funke",
+					"age": 62,
+					"verified": false
+				}`,
+			},
+			// John Grisham has three books. Two share a name, one is different.
+			// Expected COUNT is 2.
+			&action.AddDoc{
+				CollectionID: 0,
+				DocMap: map[string]any{
+					"name":      "Painted House",
+					"rating":    4.9,
+					"_authorID": testUtils.NewDocIndex(1, 0),
+				},
+			},
+			&action.AddDoc{
+				CollectionID: 0,
+				DocMap: map[string]any{
+					"name":      "Painted House",
+					"rating":    4.8,
+					"_authorID": testUtils.NewDocIndex(1, 0),
+				},
+			},
+			&action.AddDoc{
+				CollectionID: 0,
+				DocMap: map[string]any{
+					"name":      "A Time for Mercy",
+					"rating":    4.5,
+					"_authorID": testUtils.NewDocIndex(1, 0),
+				},
+			},
+			// Cornelia has one book.
+			// Expected COUNT is 1.
+			&action.AddDoc{
+				CollectionID: 0,
+				DocMap: map[string]any{
+					"name":      "Theif Lord",
+					"rating":    4.7,
+					"_authorID": testUtils.NewDocIndex(1, 1),
+				},
+			},
+			&action.Request{
+				Request: `query {
+					Author {
+						name
+						COUNT(published: {groupBy: [name]})
+					}
+				}`,
+				Results: map[string]any{
+					"Author": []map[string]any{
+						{
+							"name":  "John Grisham",
+							"COUNT": 2,
+						},
+						{
+							"name":  "Cornelia Funke",
+							"COUNT": 1,
+						},
+					},
+				},
+				NonOrderedResults: true,
+			},
+		},
+	}
+
+	executeTestCase(t, test)
+}
+
+func TestQueryOneToMany_WithCountWithGroupBy_AllSameName(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddDoc{
+				CollectionID: 1,
+				Doc: `{
+					"name": "John Grisham",
+					"age": 65,
+					"verified": true
+				}`,
+			},
+			// All three books share a name.
+			// Expected COUNT is 1.
+			&action.AddDoc{
+				CollectionID: 0,
+				DocMap: map[string]any{
+					"name":      "Painted House",
+					"rating":    4.9,
+					"_authorID": testUtils.NewDocIndex(1, 0),
+				},
+			},
+			&action.AddDoc{
+				CollectionID: 0,
+				DocMap: map[string]any{
+					"name":      "Painted House",
+					"rating":    4.8,
+					"_authorID": testUtils.NewDocIndex(1, 0),
+				},
+			},
+			&action.AddDoc{
+				CollectionID: 0,
+				DocMap: map[string]any{
+					"name":      "Painted House",
+					"rating":    4.7,
+					"_authorID": testUtils.NewDocIndex(1, 0),
+				},
+			},
+			&action.Request{
+				Request: `query {
+					Author {
+						name
+						COUNT(published: {groupBy: [name]})
+					}
+				}`,
+				Results: map[string]any{
+					"Author": []map[string]any{
+						{
+							"name":  "John Grisham",
+							"COUNT": 1,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	executeTestCase(t, test)
+}

--- a/tests/integration/query/simple/with_count_groupby_test.go
+++ b/tests/integration/query/simple/with_count_groupby_test.go
@@ -1,0 +1,182 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// This file is part of the DefraDB test suite.
+//
+// The DefraDB test suite is licensed under either:
+//
+//   (1) GNU Affero General Public License v3
+//   (2) Business Source License 1.1
+//
+// See tests/LICENSE for details.
+
+package simple
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/defradb/tests/action"
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+func TestQuerySimple_WithCountWithGroupBy_OnEmptyCollection_ReturnsZero(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.Request{
+				Request: `query {
+					COUNT(Users: {groupBy: [Age]})
+				}`,
+				Results: map[string]any{
+					"COUNT": 0,
+				},
+			},
+		},
+	}
+
+	executeTestCase(t, test)
+}
+
+func TestQuerySimple_WithCountWithGroupBy_OnSingleField_CountsDistinctValues(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddDoc{
+				Doc: `{
+					"Name": "John",
+					"Age": 32
+				}`,
+			},
+			&action.AddDoc{
+				Doc: `{
+					"Name": "Bob",
+					"Age": 32
+				}`,
+			},
+			&action.AddDoc{
+				Doc: `{
+					"Name": "Alice",
+					"Age": 19
+				}`,
+			},
+			&action.Request{
+				Request: `query {
+					COUNT(Users: {groupBy: [Age]})
+				}`,
+				Results: map[string]any{
+					"COUNT": 2,
+				},
+			},
+		},
+	}
+
+	executeTestCase(t, test)
+}
+
+func TestQuerySimple_WithCountWithGroupBy_OnMultipleFields_CountsDistinctCombinations(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddDoc{
+				Doc: `{
+					"Name": "John",
+					"Age": 32
+				}`,
+			},
+			&action.AddDoc{
+				Doc: `{
+					"Name": "Bob",
+					"Age": 32
+				}`,
+			},
+			&action.AddDoc{
+				Doc: `{
+					"Name": "John",
+					"Age": 19
+				}`,
+			},
+			&action.Request{
+				Request: `query {
+					COUNT(Users: {groupBy: [Age, Name]})
+				}`,
+				Results: map[string]any{
+					"COUNT": 3,
+				},
+			},
+		},
+	}
+
+	executeTestCase(t, test)
+}
+
+func TestQuerySimple_WithCountWithGroupBy_AllSameGroupValue_ReturnsOne(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddDoc{
+				Doc: `{
+					"Name": "John",
+					"Age": 32
+				}`,
+			},
+			&action.AddDoc{
+				Doc: `{
+					"Name": "Bob",
+					"Age": 32
+				}`,
+			},
+			&action.AddDoc{
+				Doc: `{
+					"Name": "Alice",
+					"Age": 32
+				}`,
+			},
+			&action.Request{
+				Request: `query {
+					COUNT(Users: {groupBy: [Age]})
+				}`,
+				Results: map[string]any{
+					"COUNT": 1,
+				},
+			},
+		},
+	}
+
+	executeTestCase(t, test)
+}
+
+func TestQuerySimple_WithCountWithGroupByAndFilter_CountsDistinctValuesAfterFilter(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddDoc{
+				Doc: `{
+					"Name": "John",
+					"Age": 32
+				}`,
+			},
+			&action.AddDoc{
+				Doc: `{
+					"Name": "Bob",
+					"Age": 32
+				}`,
+			},
+			&action.AddDoc{
+				Doc: `{
+					"Name": "Alice",
+					"Age": 19
+				}`,
+			},
+			&action.AddDoc{
+				Doc: `{
+					"Name": "Chris",
+					"Age": 25
+				}`,
+			},
+			&action.Request{
+				Request: `query {
+					COUNT(Users: {groupBy: [Age], filter: {Age: {_gt: 20}}})
+				}`,
+				Results: map[string]any{
+					"COUNT": 2,
+				},
+			},
+		},
+	}
+
+	executeTestCase(t, test)
+}

--- a/tests/integration/query/simple/with_count_groupby_test.go
+++ b/tests/integration/query/simple/with_count_groupby_test.go
@@ -18,7 +18,7 @@ import (
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
 )
 
-func TestQuerySimple_WithCountWithGroupBy_OnEmptyCollection_ReturnsZero(t *testing.T) {
+func TestQuerySimple_WithCountWithGroupBy_OnEmptyCollection(t *testing.T) {
 	test := testUtils.TestCase{
 		Actions: []any{
 			&action.Request{
@@ -35,7 +35,7 @@ func TestQuerySimple_WithCountWithGroupBy_OnEmptyCollection_ReturnsZero(t *testi
 	executeTestCase(t, test)
 }
 
-func TestQuerySimple_WithCountWithGroupBy_OnSingleField_CountsDistinctValues(t *testing.T) {
+func TestQuerySimple_WithCountWithGroupBy_OnSingleField(t *testing.T) {
 	test := testUtils.TestCase{
 		Actions: []any{
 			&action.AddDoc{
@@ -70,7 +70,7 @@ func TestQuerySimple_WithCountWithGroupBy_OnSingleField_CountsDistinctValues(t *
 	executeTestCase(t, test)
 }
 
-func TestQuerySimple_WithCountWithGroupBy_OnMultipleFields_CountsDistinctCombinations(t *testing.T) {
+func TestQuerySimple_WithCountWithGroupBy_OnMultipleFields(t *testing.T) {
 	test := testUtils.TestCase{
 		Actions: []any{
 			&action.AddDoc{
@@ -105,7 +105,7 @@ func TestQuerySimple_WithCountWithGroupBy_OnMultipleFields_CountsDistinctCombina
 	executeTestCase(t, test)
 }
 
-func TestQuerySimple_WithCountWithGroupBy_AllSameGroupValue_ReturnsOne(t *testing.T) {
+func TestQuerySimple_WithCountWithGroupBy_AllSameGroupValue(t *testing.T) {
 	test := testUtils.TestCase{
 		Actions: []any{
 			&action.AddDoc{
@@ -140,7 +140,7 @@ func TestQuerySimple_WithCountWithGroupBy_AllSameGroupValue_ReturnsOne(t *testin
 	executeTestCase(t, test)
 }
 
-func TestQuerySimple_WithCountWithGroupByAndFilter_CountsDistinctValuesAfterFilter(t *testing.T) {
+func TestQuerySimple_WithCountWithGroupByAndFilter(t *testing.T) {
 	test := testUtils.TestCase{
 		Actions: []any{
 			&action.AddDoc{


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4978

## Description

The purpose of this PR is to allow the following syntax to work correctly:

```
query {
	COUNT(Users: {groupBy: [Age, Name]})
}
```

Inside `mapper.go`, a new code block is added that prepares a COUNT aggregate's groupBy argument for use by the query planner, translating field names into their internal numeric indices. This ensures that the groupNode has a valid slot in the document mapping. I find that this part of the codebase is not the most easily-understood, and so there are extensive comments here to try to make clear what is going on.

Inside`generate.go`, the `createExpandedFieldAggregate()` function has been modified to add a `groupBy` argument to the COUNT input object.

This PR includes new tests:

`TestQuerySimple_WithCountWithGroupBy_OnEmptyCollection`
`TestQuerySimple_WithCountWithGroupBy_OnSingleField`
`TestQuerySimple_WithCountWithGroupBy_OnMultipleFields`
`TestQuerySimple_WithCountWithGroupBy_AllSameGroupValue`
`TestQuerySimple_WithCountWithGroupByAndFilter`

And the following tests have been adjusted to account for the new shape of the introspection request:

`TestCollectionVersionAggregateTopLevelAddsCountGivenCollection`
`TestCollectionVersionAggregateSimpleAddsUsersCount`
`TestCollectionVersionAggregateInlineArrayAddsUsersCount`

(The `aggregateGroupArg` test helper function is also adjusted for the same reason.)

An adjustment suggested by Keenan in the comments would allow field-level aggregates to work. In other words, it would enable the following syntax:

```
query {
	Author {
		name
		COUNT(published: {groupBy: [name]})
	}
}
```

His change has been made, and to illustrate the behavior, there are three additional integration tests:

`TestQueryOneToMany_WithCountWithGroupBy_CountingZero`
`TestQueryOneToMany_WithCountWithGroupBy_CountingDistinctNames`
`TestQueryOneToMany_WithCountWithGroupBy_AllSameName`

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Specify the platform(s) on which this was tested:
- WSL