### PR TITLE
test: Introduce DeleteWithFilter test action

### DIFF
--- a/cli/document_delete.go
+++ b/cli/document_delete.go
@@ -12,6 +12,7 @@ package cli
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/spf13/cobra"
 
@@ -51,10 +52,15 @@ or the showDeleted parameter on GraphQL queries.`,
 				_, err = col.DeleteDocument(ctx, docID, deleteOpt)
 				return err
 			case filter != "":
+				var filterValue any
+				if err := json.Unmarshal([]byte(filter), &filterValue); err != nil {
+					return NewErrParsingArgument("filter", err)
+				}
+
 				deleteWithFilterOpt := options.WithIdentity(
 					options.DeleteDocumentsWithFilter(), identity.FromContext(ctx))
 
-				res, err := col.DeleteDocumentsWithFilter(ctx, filter, deleteWithFilterOpt)
+				res, err := col.DeleteDocumentsWithFilter(ctx, filterValue, deleteWithFilterOpt)
 				if err != nil {
 					return err
 				}

--- a/tests/integration/mutation/delete/with_filter_action_test.go
+++ b/tests/integration/mutation/delete/with_filter_action_test.go
@@ -1,0 +1,115 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// This file is part of the DefraDB test suite.
+//
+// The DefraDB test suite is licensed under either:
+//
+//   (1) GNU Affero General Public License v3
+//   (2) Business Source License 1.1
+//
+// See tests/LICENSE for details.
+
+package delete
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/defradb/tests/action"
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+func TestDeleteWithFilter_Succeeds(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type User {
+						name: String
+						age: Int
+					}
+				`,
+			},
+			&action.AddDoc{
+				Doc: `{
+					"name": "John",
+					"age": 21
+				}`,
+			},
+			&action.AddDoc{
+				Doc: `{
+					"name": "Fred",
+					"age": 25
+				}`,
+			},
+			testUtils.DeleteWithFilter{
+				CollectionID: 0,
+				Filter:       `{name: {_eq: "John"}}`,
+			},
+			&action.Request{
+				Request: `query {
+					User {
+						name
+					}
+				}`,
+				Results: map[string]any{
+					"User": []map[string]any{
+						{"name": "Fred"},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestDeleteWithFilter_WithMultipleMatchingDocs_DeletesAll(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type User {
+						name: String
+						age: Int
+					}
+				`,
+			},
+			&action.AddDoc{
+				Doc: `{
+					"name": "John",
+					"age": 21
+				}`,
+			},
+			&action.AddDoc{
+				Doc: `{
+					"name": "John",
+					"age": 32
+				}`,
+			},
+			&action.AddDoc{
+				Doc: `{
+					"name": "Fred",
+					"age": 25
+				}`,
+			},
+			testUtils.DeleteWithFilter{
+				CollectionID: 0,
+				Filter:       `{name: {_eq: "John"}}`,
+			},
+			&action.Request{
+				Request: `query {
+					User {
+						name
+					}
+				}`,
+				Results: map[string]any{
+					"User": []map[string]any{
+						{"name": "Fred"},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/test_case.go
+++ b/tests/integration/test_case.go
@@ -259,6 +259,48 @@ type DeleteDoc struct {
 	TransactionID immutable.Option[int]
 }
 
+// DeleteWithFilter will delete the set of documents that match the given filter.
+type DeleteWithFilter struct {
+	// NodeID may hold the ID (index) of a node to apply this delete to.
+	//
+	// If a value is not provided the delete will be applied to all nodes.
+	NodeID immutable.Option[int]
+
+	// The identity of this request. Optional.
+	//
+	// If an Identity is not provided then can only delete public document(s).
+	//
+	// If an Identity is provided and the collection has a policy, then
+	// can also delete private document(s) that are owned by this Identity.
+	//
+	// Use `ClientIdentity` to create a client identity and `NodeIdentity` to create a node identity.
+	// Default value is `NoIdentity()`.
+	//
+	// If node acp is enabled, identity will be used to check if this operation can be performed.
+	Identity immutable.Option[state.Identity]
+
+	// The collection in which the documents should be deleted.
+	CollectionID int
+
+	// The filter to match documents against.
+	Filter any
+
+	// Any error expected from the action. Optional.
+	//
+	// String can be a partial, and the test will pass if an error is returned that
+	// contains this string.
+	ExpectedError string
+
+	// Skip waiting for an update event on the local event bus.
+	//
+	// This should only be used for tests that do not correctly
+	// publish an update event to the local event bus.
+	SkipLocalUpdateEvent bool
+
+	// TransactionID to use for the action. Optional.
+	TransactionID immutable.Option[int]
+}
+
 // UpdateWithFilter will update the set of documents that match the given filter.
 type UpdateWithFilter struct {
 	// NodeID may hold the ID (index) of a node to apply this update to.

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -435,6 +435,9 @@ func performAction(
 	case DeleteDoc:
 		deleteDoc(s, action)
 
+	case DeleteWithFilter:
+		deleteWithFilter(s, action)
+
 	case UpdateWithFilter:
 		updateWithFilter(s, action)
 
@@ -1407,6 +1410,60 @@ func deleteDoc(
 			docID.String(): {},
 		}
 
+		waitForUpdateEvents(s, a.NodeID, a.CollectionID, expect, immutable.None[state.Identity]())
+	}
+}
+
+// deleteWithFilter deletes the set of matched documents.
+func deleteWithFilter(s *state.State, a DeleteWithFilter) {
+	var res *client.DeleteResult
+	var expectedErrorRaised bool
+	doNotWaitForUpdate := false
+
+	var collections []client.Collection
+
+	nodeIDs, nodes := getNodesWithIDs(a.NodeID, s.Nodes)
+
+	for index, node := range nodes {
+		var txn client.Txn
+		hadTxn := a.TransactionID.HasValue()
+		var err error
+		txnOption := immutable.None[client.Txn]()
+		if hadTxn {
+			doNotWaitForUpdate = true
+			txn, err = s.GetTransaction(node, a.TransactionID)
+			require.NoError(s.T, err)
+			txnOption = immutable.Some(txn)
+		}
+
+		nodeID := nodeIDs[index]
+		collections = action.MustGetCanonicallyOrderedCollections(s, node, txnOption)
+		collection := collections[a.CollectionID]
+
+		opts := options.DeleteDocumentsWithFilter()
+		identOption := getIdentityForRequestSpecificToNode(s, a.Identity, nodeID)
+		if identOption.HasValue() {
+			opts.SetIdentity(identOption.Value())
+		}
+		err = withRetryOnNode(
+			node,
+			func() error {
+				var err error
+				res, err = collection.DeleteDocumentsWithFilter(s.Ctx, a.Filter, opts)
+				return err
+			},
+		)
+
+		expectedErrorRaised = AssertError(s.T, err, a.ExpectedError)
+	}
+
+	assertExpectedErrorRaised(s.T, a.ExpectedError, expectedErrorRaised)
+
+	if a.ExpectedError == "" && !a.SkipLocalUpdateEvent && !doNotWaitForUpdate {
+		expect := make(map[string]struct{}, len(res.DocIDs))
+		for _, docID := range res.DocIDs {
+			expect[docID] = struct{}{}
+		}
 		waitForUpdateEvents(s, a.NodeID, a.CollectionID, expect, immutable.None[state.Identity]())
 	}
 }


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4992 

## Description

We actually did not have a DeleteWithFilter test action. Instead, this was only being performed through mutation requests. However, the need for a genuine action came up during work on another PR. This PR introduces it, with its implementation simply following the same design of other, similar actions (such as UpdateWithFilter). 

The PR also contains two integration tests which use it.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Specify the platform(s) on which this was tested:
- WSL