### PR TITLE
feat: Transaction TTL Cache for HTTP API

### DIFF
--- a/cli/errors.go
+++ b/cli/errors.go
@@ -46,6 +46,7 @@ var (
 	ErrGeneratingSDL                    = errors.New("generating SDL")
 	ErrPurgeForceFlagRequired           = errors.New("run this command again with --force if you " +
 		"really want to purge all data")
+	ErrMissingTTLTxn = errors.New("transaction ttl is not supported by this client")
 )
 
 func NewErrParsingArgument(argName string, inner error) error {

--- a/cli/test/action/txn_action.go
+++ b/cli/test/action/txn_action.go
@@ -59,6 +59,6 @@ func (a *TxnAction[T]) SetState(s *state.State) {
 }
 
 func (a *TxnAction[T]) Execute() {
-	a.Action.AddArgs("tx", fmt.Sprint(a.s.Txns[a.TxnIndex]))
+	a.Action.AddArgs("--tx", fmt.Sprint(a.s.Txns[a.TxnIndex]))
 	a.Action.Execute()
 }

--- a/cli/test/action/wait.go
+++ b/cli/test/action/wait.go
@@ -10,30 +10,20 @@
 
 package action
 
-import "github.com/stretchr/testify/require"
+import (
+	"time"
+)
 
 // CreateTx executes the `client tx new` command and appends the returned transaction id
 // to state.Txns.
-type CreateTx struct {
+type Wait struct {
 	stateful
 
-	TTL string
+	Duration time.Duration
 }
 
-var _ Action = (*CreateTx)(nil)
+var _ Action = (*Wait)(nil)
 
-func (a *CreateTx) Execute() {
-	cmdArgs := []string{"client", "tx", "new"}
-
-	if a.TTL != "" {
-		cmdArgs = append(cmdArgs, "--ttl", a.TTL)
-	}
-
-	result, err := executeJson[map[string]any](a.s.Ctx, a.AppendDirections(cmdArgs))
-	require.NoError(a.s.T, err)
-
-	txId, ok := result["id"].(float64)
-	require.True(a.s.T, ok)
-
-	a.s.Txns = append(a.s.Txns, uint64(txId))
+func (a *Wait) Execute() {
+	time.Sleep(a.Duration)
 }

--- a/cli/test/integration/tx/simple_test.go
+++ b/cli/test/integration/tx/simple_test.go
@@ -1,0 +1,73 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package tx
+
+import (
+	"testing"
+	"time"
+
+	"github.com/sourcenetwork/defradb/cli/test/action"
+	"github.com/sourcenetwork/defradb/cli/test/integration"
+)
+
+func TestCreateTxWithRawTTL(t *testing.T) {
+	test := &integration.Test{
+		Timeout: time.Second * 5, // test wide timeout
+		Actions: []action.Action{
+			&action.CreateTx{
+				TTL: "1", // 1 second
+			},
+			&action.Wait{
+				Duration: time.Second * 2,
+			},
+			action.WithTxnI(
+				&action.AddCollection{
+					InlineSDL: `
+						type User {
+							name: String
+						}
+					`,
+					ExpectError: "transaction not found",
+				},
+				0,
+			),
+		},
+	}
+
+	test.Execute(t)
+}
+
+func TestCreateTxWithFormattedTTL(t *testing.T) {
+	test := &integration.Test{
+		Timeout: time.Second * 5, // test wide timeout
+		Actions: []action.Action{
+			&action.CreateTx{
+				TTL: "1s", // 1 second
+			},
+			&action.Wait{
+				Duration: time.Second * 2,
+			},
+			action.WithTxnI(
+				&action.AddCollection{
+					InlineSDL: `
+						type User {
+							name: String
+						}
+					`,
+					ExpectError: "transaction not found",
+				},
+				0,
+			),
+		},
+	}
+
+	test.Execute(t)
+}

--- a/cli/tx_new.go
+++ b/cli/tx_new.go
@@ -32,12 +32,14 @@ func MakeTxNewCommand(ctx context.Context) *cobra.Command {
 		Use:   "new",
 		Short: "Create a new DefraDB transaction.",
 		Long:  `Create a new DefraDB transaction.`,
-		RunE: func(cmd *cobra.Command, args []string) (err error) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			cliClient := mustGetContextCLIClient(cmd)
 
 			var tx client.Txn
+			var err error
+			var ttl time.Duration
 			if txnTTL != "" {
-				ttl, err := parseTxnTTLFlag(txnTTL)
+				ttl, err = parseTxnTTLFlag(txnTTL)
 				if err != nil {
 					return err
 				}
@@ -56,7 +58,8 @@ func MakeTxNewCommand(ctx context.Context) *cobra.Command {
 		},
 	}
 	cmd.Flags().BoolVar(&readOnly, "read-only", false, "Transaction is read only")
-	cmd.Flags().StringVar(&txnTTL, "ttl", "", "Transaction idle TTL as a Go duration string, or seconds if no unit is provided")
+	cmd.Flags().StringVar(&txnTTL, "ttl", "",
+		"Transaction idle TTL as a Go duration string, or seconds if no unit is provided")
 	return cmd
 }
 

--- a/cli/tx_new.go
+++ b/cli/tx_new.go
@@ -13,6 +13,7 @@ package cli
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -26,7 +27,7 @@ type txnTTLClient interface {
 
 func MakeTxNewCommand(ctx context.Context) *cobra.Command {
 	var readOnly bool
-	var txnTTL time.Duration
+	var txnTTL string
 	var cmd = &cobra.Command{
 		Use:   "new",
 		Short: "Create a new DefraDB transaction.",
@@ -35,12 +36,16 @@ func MakeTxNewCommand(ctx context.Context) *cobra.Command {
 			cliClient := mustGetContextCLIClient(cmd)
 
 			var tx client.Txn
-			if txnTTL != 0 {
+			if txnTTL != "" {
+				ttl, err := parseTxnTTLFlag(txnTTL)
+				if err != nil {
+					return err
+				}
 				ttlClient, ok := cliClient.(txnTTLClient)
 				if !ok {
 					return fmt.Errorf("transaction ttl is not supported by this client")
 				}
-				tx, err = ttlClient.NewTxnWithTTL(readOnly, txnTTL)
+				tx, err = ttlClient.NewTxnWithTTL(readOnly, ttl)
 			} else {
 				tx, err = cliClient.NewTxn(readOnly)
 			}
@@ -51,6 +56,18 @@ func MakeTxNewCommand(ctx context.Context) *cobra.Command {
 		},
 	}
 	cmd.Flags().BoolVar(&readOnly, "read-only", false, "Transaction is read only")
-	cmd.Flags().DurationVar(&txnTTL, "ttl", 0, "Transaction idle TTL")
+	cmd.Flags().StringVar(&txnTTL, "ttl", "", "Transaction idle TTL as a Go duration string, or seconds if no unit is provided")
 	return cmd
+}
+
+func parseTxnTTLFlag(raw string) (time.Duration, error) {
+	txnTTL, err := time.ParseDuration(raw)
+	if err == nil {
+		return txnTTL, nil
+	}
+	seconds, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil {
+		return 0, err
+	}
+	return time.Duration(seconds) * time.Second, nil
 }

--- a/cli/tx_new.go
+++ b/cli/tx_new.go
@@ -12,12 +12,21 @@ package cli
 
 import (
 	"context"
+	"fmt"
+	"time"
 
 	"github.com/spf13/cobra"
+
+	"github.com/sourcenetwork/defradb/client"
 )
+
+type txnTTLClient interface {
+	NewTxnWithTTL(bool, time.Duration) (client.Txn, error)
+}
 
 func MakeTxNewCommand(ctx context.Context) *cobra.Command {
 	var readOnly bool
+	var txnTTL time.Duration
 	var cmd = &cobra.Command{
 		Use:   "new",
 		Short: "Create a new DefraDB transaction.",
@@ -25,7 +34,16 @@ func MakeTxNewCommand(ctx context.Context) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			cliClient := mustGetContextCLIClient(cmd)
 
-			tx, err := cliClient.NewTxn(readOnly)
+			var tx client.Txn
+			if txnTTL != 0 {
+				ttlClient, ok := cliClient.(txnTTLClient)
+				if !ok {
+					return fmt.Errorf("transaction ttl is not supported by this client")
+				}
+				tx, err = ttlClient.NewTxnWithTTL(readOnly, txnTTL)
+			} else {
+				tx, err = cliClient.NewTxn(readOnly)
+			}
 			if err != nil {
 				return err
 			}
@@ -33,5 +51,6 @@ func MakeTxNewCommand(ctx context.Context) *cobra.Command {
 		},
 	}
 	cmd.Flags().BoolVar(&readOnly, "read-only", false, "Transaction is read only")
+	cmd.Flags().DurationVar(&txnTTL, "ttl", 0, "Transaction idle TTL")
 	return cmd
 }

--- a/cli/tx_new.go
+++ b/cli/tx_new.go
@@ -12,7 +12,6 @@ package cli
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 	"time"
 
@@ -43,9 +42,16 @@ func MakeTxNewCommand(ctx context.Context) *cobra.Command {
 				if err != nil {
 					return err
 				}
+
+				// `NewTxnWithTTL` is a helper that is specific to the HTTP client
+				// and not part of the default client interface, so we need to
+				// type cast to get to the underlying http client implementation.
+				// While the CLI client is hardcoded to use the HTTP client, the
+				// type system doesn't enforce this, so we need to gate the
+				// accidental unhappy path
 				ttlClient, ok := cliClient.(txnTTLClient)
 				if !ok {
-					return fmt.Errorf("transaction ttl is not supported by this client")
+					return ErrMissingTTLTxn
 				}
 				tx, err = ttlClient.NewTxnWithTTL(readOnly, ttl)
 			} else {
@@ -59,7 +65,7 @@ func MakeTxNewCommand(ctx context.Context) *cobra.Command {
 	}
 	cmd.Flags().BoolVar(&readOnly, "read-only", false, "Transaction is read only")
 	cmd.Flags().StringVar(&txnTTL, "ttl", "",
-		"Transaction idle TTL as a Go duration string, or seconds if no unit is provided")
+		"Transaction idle TTL as a duration string, or seconds if no unit is provided")
 	return cmd
 }
 

--- a/cli/tx_new_test.go
+++ b/cli/tx_new_test.go
@@ -1,0 +1,47 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package cli
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseTxnTTLFlag(t *testing.T) {
+	t.Run("duration", func(t *testing.T) {
+		txnTTL, err := parseTxnTTLFlag("150ms")
+
+		require.NoError(t, err)
+		require.Equal(t, 150*time.Millisecond, txnTTL)
+	})
+
+	t.Run("seconds", func(t *testing.T) {
+		txnTTL, err := parseTxnTTLFlag("2")
+
+		require.NoError(t, err)
+		require.Equal(t, 2*time.Second, txnTTL)
+	})
+
+	t.Run("zero", func(t *testing.T) {
+		txnTTL, err := parseTxnTTLFlag("0")
+
+		require.NoError(t, err)
+		require.Zero(t, txnTTL)
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		_, err := parseTxnTTLFlag("soon")
+
+		require.Error(t, err)
+	})
+}

--- a/client/options/node.go
+++ b/client/options/node.go
@@ -129,6 +129,12 @@ type NodeHTTPOptions struct {
 	WriteTimeout time.Duration
 	// IdleTimeout is the idle timeout for connections.
 	IdleTimeout time.Duration
+	// TxnTTL is the idle timeout for explicit HTTP transactions.
+	TxnTTL time.Duration
+	// TxnTTLTick is the timer resolution used by the HTTP transaction TTL cache.
+	TxnTTLTick time.Duration
+	// TxnTTLBuckets is the number of buckets in the HTTP transaction TTL cache.
+	TxnTTLBuckets int
 }
 
 // NodeStoreOptions contains store configuration values.
@@ -603,6 +609,24 @@ func (sb *NodeHTTPOptionsBuilder) SetWriteTimeout(timeout time.Duration) *NodeHT
 // SetIdleTimeout sets the server idle timeout.
 func (sb *NodeHTTPOptionsBuilder) SetIdleTimeout(timeout time.Duration) *NodeHTTPOptionsBuilder {
 	sb.append(func(opts *NodeHTTPOptions) { opts.IdleTimeout = timeout })
+	return sb
+}
+
+// SetTxnTTL sets the idle timeout for explicit HTTP transactions.
+func (sb *NodeHTTPOptionsBuilder) SetTxnTTL(ttl time.Duration) *NodeHTTPOptionsBuilder {
+	sb.append(func(opts *NodeHTTPOptions) { opts.TxnTTL = ttl })
+	return sb
+}
+
+// SetTxnTTLTick sets the timer resolution used by the HTTP transaction TTL cache.
+func (sb *NodeHTTPOptionsBuilder) SetTxnTTLTick(tick time.Duration) *NodeHTTPOptionsBuilder {
+	sb.append(func(opts *NodeHTTPOptions) { opts.TxnTTLTick = tick })
+	return sb
+}
+
+// SetTxnTTLBuckets sets the number of buckets in the HTTP transaction TTL cache.
+func (sb *NodeHTTPOptionsBuilder) SetTxnTTLBuckets(buckets int) *NodeHTTPOptionsBuilder {
+	sb.append(func(opts *NodeHTTPOptions) { opts.TxnTTLBuckets = buckets })
 	return sb
 }
 

--- a/docs/website/references/cli/defradb_client_tx_new.md
+++ b/docs/website/references/cli/defradb_client_tx_new.md
@@ -15,7 +15,7 @@ defradb client tx new [flags]
 ```
   -h, --help         help for new
       --read-only    Transaction is read only
-      --ttl string   Transaction idle TTL as a Go duration string, or seconds if no unit is provided
+      --ttl string   Transaction idle TTL as a duration string, or seconds if no unit is provided
 ```
 
 ### Options inherited from parent commands

--- a/docs/website/references/cli/defradb_client_tx_new.md
+++ b/docs/website/references/cli/defradb_client_tx_new.md
@@ -13,8 +13,9 @@ defradb client tx new [flags]
 ### Options
 
 ```
-  -h, --help        help for new
-      --read-only   Transaction is read only
+  -h, --help         help for new
+      --read-only    Transaction is read only
+      --ttl string   Transaction idle TTL as a Go duration string, or seconds if no unit is provided
 ```
 
 ### Options inherited from parent commands

--- a/docs/website/references/http/openapi.json
+++ b/docs/website/references/http/openapi.json
@@ -2664,6 +2664,14 @@
                             "default": false,
                             "type": "boolean"
                         }
+                    },
+                    {
+                        "description": "Transaction idle TTL as a Go duration string, or seconds if no unit is provided",
+                        "in": "query",
+                        "name": "ttl",
+                        "schema": {
+                            "type": "string"
+                        }
                     }
                 ],
                 "responses": {

--- a/http/client.go
+++ b/http/client.go
@@ -67,21 +67,21 @@ func NewInsecureClient(rawURL string) (*Client, error) {
 }
 
 func (c *Client) NewTxn(readOnly bool) (client.Txn, error) {
-	return c.newTxn(readOnly, 0)
+	return c.newTxn(readOnly, immutable.None[time.Duration]())
 }
 
 // NewTxnWithTTL creates a new HTTP transaction with the given idle TTL.
 func (c *Client) NewTxnWithTTL(readOnly bool, txnTTL time.Duration) (client.Txn, error) {
-	return c.newTxn(readOnly, txnTTL)
+	return c.newTxn(readOnly, immutable.Some(txnTTL))
 }
 
-func (c *Client) newTxn(readOnly bool, txnTTL time.Duration) (client.Txn, error) {
+func (c *Client) newTxn(readOnly bool, txnTTL immutable.Option[time.Duration]) (client.Txn, error) {
 	query := url.Values{}
 	if readOnly {
 		query.Add("read_only", "true")
 	}
-	if txnTTL != 0 {
-		query.Add("ttl", txnTTL.String())
+	if txnTTL.HasValue() {
+		query.Add("ttl", txnTTL.Value().String())
 	}
 
 	methodURL := c.http.apiURL.JoinPath("tx")

--- a/http/client.go
+++ b/http/client.go
@@ -19,6 +19,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"time"
 
 	sse "github.com/vito/go-sse/sse"
 
@@ -65,9 +66,21 @@ func NewInsecureClient(rawURL string) (*Client, error) {
 }
 
 func (c *Client) NewTxn(readOnly bool) (client.Txn, error) {
+	return c.newTxn(readOnly, 0)
+}
+
+// NewTxnWithTTL creates a new HTTP transaction with the given idle TTL.
+func (c *Client) NewTxnWithTTL(readOnly bool, txnTTL time.Duration) (client.Txn, error) {
+	return c.newTxn(readOnly, txnTTL)
+}
+
+func (c *Client) newTxn(readOnly bool, txnTTL time.Duration) (client.Txn, error) {
 	query := url.Values{}
 	if readOnly {
 		query.Add("read_only", "true")
+	}
+	if txnTTL != 0 {
+		query.Add("ttl", txnTTL.String())
 	}
 
 	methodURL := c.http.apiURL.JoinPath("tx")

--- a/http/errors.go
+++ b/http/errors.go
@@ -45,7 +45,6 @@ var (
 	ErrMigrationNotFound            = errors.New("migration not found")
 	ErrMissingRequest               = errors.New("missing request")
 	ErrInvalidTransactionId         = errors.New("invalid transaction id")
-	ErrMissingOrExpiredTransaction  = errors.New("missing or expired transaction")
 	ErrP2PDisabled                  = errors.New("p2p network is disabled")
 	ErrMethodIsNotImplemented       = errors.New(errMethodIsNotImplemented)
 	ErrMissingIdentity              = errors.New("required identity is missing")

--- a/http/errors.go
+++ b/http/errors.go
@@ -50,6 +50,7 @@ var (
 	ErrMissingIdentity              = errors.New("required identity is missing")
 	ErrInvalidSubscriptionTransport = errors.New("invalid subscription transport")
 	ErrInvalidGraphQLRequest        = errors.New("invalid graphql request")
+	ErrInvalidTTL                   = errors.New("invalid ttl value")
 )
 
 type errorResponse struct {

--- a/http/errors.go
+++ b/http/errors.go
@@ -45,6 +45,7 @@ var (
 	ErrMigrationNotFound            = errors.New("migration not found")
 	ErrMissingRequest               = errors.New("missing request")
 	ErrInvalidTransactionId         = errors.New("invalid transaction id")
+	ErrMissingOrExpiredTransaction  = errors.New("missing or expired transaction")
 	ErrP2PDisabled                  = errors.New("p2p network is disabled")
 	ErrMethodIsNotImplemented       = errors.New(errMethodIsNotImplemented)
 	ErrMissingIdentity              = errors.New("required identity is missing")

--- a/http/handler.go
+++ b/http/handler.go
@@ -91,7 +91,7 @@ func NewHandler(db DB, nodeOpts *options.NodeOptions) (*Handler, error) {
 		return nil, err
 	}
 	ctx, cancel := context.WithCancel(context.Background())
-	txs, err := newTxnCache(ctx, nodeOpts)
+	txs, err := newTxnCache(ctx, &nodeOpts.HTTP)
 	if err != nil {
 		cancel()
 		return nil, err

--- a/http/handler.go
+++ b/http/handler.go
@@ -90,8 +90,12 @@ func NewHandler(db DB, nodeOpts *options.NodeOptions) (*Handler, error) {
 	if err != nil {
 		return nil, err
 	}
+	var httpOpts *options.NodeHTTPOptions
+	if nodeOpts != nil {
+		httpOpts = &nodeOpts.HTTP
+	}
 	ctx, cancel := context.WithCancel(context.Background())
-	txs, err := newTxnCache(ctx, &nodeOpts.HTTP)
+	txs, err := newTxnCache(ctx, httpOpts)
 	if err != nil {
 		cancel()
 		return nil, err

--- a/http/handler.go
+++ b/http/handler.go
@@ -140,7 +140,7 @@ func NewHandler(db DB, nodeOpts *options.NodeOptions) (*Handler, error) {
 }
 
 func (h *Handler) Transaction(id uint64) (client.Txn, error) {
-	tx, ok := h.txs.Load(id)
+	tx, ok := h.txs.Get(id)
 	if !ok {
 		return nil, ErrInvalidTransactionId
 	}

--- a/http/handler.go
+++ b/http/handler.go
@@ -13,7 +13,6 @@ package http
 import (
 	"context"
 	"net/http"
-	"sync"
 
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/options"
@@ -81,8 +80,9 @@ type DB interface {
 }
 
 type Handler struct {
-	mux *chi.Mux
-	txs *sync.Map
+	mux       *chi.Mux
+	txs       *txnCache
+	ctxCancel context.CancelFunc
 }
 
 func NewHandler(db DB, nodeOpts *options.NodeOptions) (*Handler, error) {
@@ -90,7 +90,12 @@ func NewHandler(db DB, nodeOpts *options.NodeOptions) (*Handler, error) {
 	if err != nil {
 		return nil, err
 	}
-	txs := &sync.Map{}
+	ctx, cancel := context.WithCancel(context.Background())
+	txs, err := newTxnCache(ctx, nodeOpts)
+	if err != nil {
+		cancel()
+		return nil, err
+	}
 
 	mux := chi.NewMux()
 	// Normalize trailing slashes so that, for example, `/collections` and
@@ -124,8 +129,9 @@ func NewHandler(db DB, nodeOpts *options.NodeOptions) (*Handler, error) {
 	})
 	mux.Handle("/*", explorerHandler)
 	return &Handler{
-		mux: mux,
-		txs: txs,
+		mux:       mux,
+		txs:       txs,
+		ctxCancel: cancel,
 	}, nil
 }
 
@@ -135,7 +141,13 @@ func (h *Handler) Transaction(id uint64) (client.Txn, error) {
 		return nil, ErrInvalidTransactionId
 	}
 
-	return mustGetDataStoreTxn(tx), nil
+	return tx, nil
+}
+
+// Close stops background handler resources.
+func (h *Handler) Close() {
+	h.ctxCancel()
+	h.txs.Close()
 }
 
 func (h *Handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {

--- a/http/handler_tx.go
+++ b/http/handler_tx.go
@@ -58,7 +58,7 @@ func (h *txHandler) Commit(rw http.ResponseWriter, req *http.Request) {
 		responseJSON(rw, http.StatusBadRequest, errorResponse{ErrInvalidTransactionId})
 		return
 	}
-	tx, ok := txs.LoadAndDelete(txID)
+	tx, txnTTL, ok := txs.LoadAndDelete(txID)
 	if !ok {
 		responseJSON(rw, http.StatusNotFound, errorResponse{client.ErrTransactionNotFound})
 		return
@@ -66,6 +66,10 @@ func (h *txHandler) Commit(rw http.ResponseWriter, req *http.Request) {
 
 	err = tx.Commit()
 	if err != nil {
+		if storeErr := txs.Store(tx, txnTTL); storeErr != nil {
+			log.ErrorE("failed to restore transaction after commit error", storeErr)
+			tx.Discard()
+		}
 		responseJSON(rw, httpStatusFromError(err), errorResponse{err})
 		return
 	}
@@ -80,7 +84,7 @@ func (h *txHandler) Discard(rw http.ResponseWriter, req *http.Request) {
 		responseJSON(rw, http.StatusBadRequest, errorResponse{ErrInvalidTransactionId})
 		return
 	}
-	tx, ok := txs.LoadAndDelete(txID)
+	tx, _, ok := txs.LoadAndDelete(txID)
 	if !ok {
 		responseJSON(rw, http.StatusNotFound, errorResponse{client.ErrTransactionNotFound})
 		return

--- a/http/handler_tx.go
+++ b/http/handler_tx.go
@@ -13,6 +13,7 @@ package http
 import (
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/go-chi/chi/v5"
@@ -26,60 +27,82 @@ type CreateTxResponse struct {
 
 func (h *txHandler) NewTxn(rw http.ResponseWriter, req *http.Request) {
 	db := mustGetContextClientDB(req)
-	txs := mustGetContextSyncMap(req)
+	txs := mustGetContextTxnCache(req)
 	readOnly, _ := strconv.ParseBool(req.URL.Query().Get("read_only"))
+	txnTTL, err := parseTxnTTL(req)
+	if err != nil {
+		responseJSON(rw, http.StatusBadRequest, errorResponse{err})
+		return
+	}
 
 	tx, err := db.NewTxn(readOnly)
 	if err != nil {
 		responseJSON(rw, http.StatusBadRequest, errorResponse{err})
 		return
 	}
-	txs.Store(tx.ID(), tx)
+	if err := txs.Store(tx, txnTTL); err != nil {
+		tx.Discard()
+		responseJSON(rw, http.StatusBadRequest, errorResponse{err})
+		return
+	}
 	responseJSON(rw, http.StatusOK, &CreateTxResponse{tx.ID()})
 }
 
 func (h *txHandler) Commit(rw http.ResponseWriter, req *http.Request) {
-	txs := mustGetContextSyncMap(req)
+	txs := mustGetContextTxnCache(req)
 
 	txID, err := strconv.ParseUint(chi.URLParam(req, "id"), 10, 64)
 	if err != nil {
 		responseJSON(rw, http.StatusBadRequest, errorResponse{ErrInvalidTransactionId})
 		return
 	}
-	txVal, ok := txs.Load(txID)
+	tx, ok := txs.LoadAndDelete(txID)
 	if !ok {
 		responseJSON(rw, http.StatusNotFound, errorResponse{ErrTransactionNotFound})
 		return
 	}
 
-	dsTxn := mustGetDataStoreTxn(txVal)
-	err = dsTxn.Commit()
+	err = tx.Commit()
 	if err != nil {
 		responseJSON(rw, httpStatusFromError(err), errorResponse{err})
 		return
 	}
-	txs.Delete(txID)
 	rw.WriteHeader(http.StatusOK)
 }
 
 func (h *txHandler) Discard(rw http.ResponseWriter, req *http.Request) {
-	txs := mustGetContextSyncMap(req)
+	txs := mustGetContextTxnCache(req)
 
 	txID, err := strconv.ParseUint(chi.URLParam(req, "id"), 10, 64)
 	if err != nil {
 		responseJSON(rw, http.StatusBadRequest, errorResponse{ErrInvalidTransactionId})
 		return
 	}
-	txVal, ok := txs.LoadAndDelete(txID)
+	tx, ok := txs.LoadAndDelete(txID)
 	if !ok {
 		responseJSON(rw, http.StatusNotFound, errorResponse{ErrTransactionNotFound})
 		return
 	}
 
-	dsTxn := mustGetDataStoreTxn(txVal)
-	dsTxn.Discard()
+	tx.Discard()
 
 	rw.WriteHeader(http.StatusOK)
+}
+
+func parseTxnTTL(req *http.Request) (time.Duration, error) {
+	raw := req.URL.Query().Get("ttl")
+	if raw == "" {
+		return 0, nil
+	}
+	txnTTL, err := time.ParseDuration(raw)
+	if err == nil {
+		return txnTTL, nil
+	}
+	seconds, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil {
+		return 0, err
+	}
+	return time.Duration(seconds) * time.Second, nil
 }
 
 func (h *txHandler) bindRoutes(router *Router) {
@@ -96,6 +119,9 @@ func (h *txHandler) bindRoutes(router *Router) {
 	txnReadOnlyQueryParam := openapi3.NewQueryParameter("read_only").
 		WithDescription("Read only transaction").
 		WithSchema(openapi3.NewBoolSchema().WithDefault(false))
+	txnTTLQueryParam := openapi3.NewQueryParameter("ttl").
+		WithDescription("Transaction idle TTL as a Go duration string, or seconds if no unit is provided").
+		WithSchema(openapi3.NewStringSchema())
 
 	txnCreateResponse := openapi3.NewResponse().
 		WithDescription("Transaction info").
@@ -106,6 +132,7 @@ func (h *txHandler) bindRoutes(router *Router) {
 	txnCreate.Description = "Create a new transaction"
 	txnCreate.Tags = []string{"transaction"}
 	txnCreate.AddParameter(txnReadOnlyQueryParam)
+	txnCreate.AddParameter(txnTTLQueryParam)
 	txnCreate.AddResponse(200, txnCreateResponse)
 	txnCreate.Responses.Set("400", errorResponse)
 

--- a/http/handler_tx.go
+++ b/http/handler_tx.go
@@ -31,7 +31,7 @@ func (h *txHandler) NewTxn(rw http.ResponseWriter, req *http.Request) {
 	db := mustGetContextClientDB(req)
 	txs := mustGetContextTxnCache(req)
 	readOnly, _ := strconv.ParseBool(req.URL.Query().Get("read_only"))
-	txnTTL, err := parseTxnTTL(req)
+	txnTTL, hasTxnTTL, err := parseTxnTTL(req)
 	if err != nil {
 		responseJSON(rw, http.StatusBadRequest, errorResponse{err})
 		return
@@ -42,7 +42,12 @@ func (h *txHandler) NewTxn(rw http.ResponseWriter, req *http.Request) {
 		responseJSON(rw, http.StatusBadRequest, errorResponse{err})
 		return
 	}
-	if err := txs.Store(tx, txnTTL); err != nil {
+	if hasTxnTTL {
+		err = txs.StoreFor(tx, txnTTL)
+	} else {
+		err = txs.Store(tx)
+	}
+	if err != nil {
 		tx.Discard()
 		responseJSON(rw, http.StatusBadRequest, errorResponse{err})
 		return
@@ -66,7 +71,7 @@ func (h *txHandler) Commit(rw http.ResponseWriter, req *http.Request) {
 
 	err = tx.Commit()
 	if err != nil {
-		if storeErr := txs.Store(tx, txnTTL); storeErr != nil {
+		if storeErr := txs.StoreFor(tx, txnTTL); storeErr != nil {
 			log.ErrorE("failed to restore transaction after commit error", storeErr)
 			tx.Discard()
 		}
@@ -95,20 +100,20 @@ func (h *txHandler) Discard(rw http.ResponseWriter, req *http.Request) {
 	rw.WriteHeader(http.StatusOK)
 }
 
-func parseTxnTTL(req *http.Request) (time.Duration, error) {
+func parseTxnTTL(req *http.Request) (time.Duration, bool, error) {
 	raw := req.URL.Query().Get("ttl")
 	if raw == "" {
-		return 0, nil
+		return 0, false, nil
 	}
 	txnTTL, err := time.ParseDuration(raw)
 	if err == nil {
-		return txnTTL, nil
+		return txnTTL, true, nil
 	}
 	seconds, err := strconv.ParseInt(raw, 10, 64)
 	if err != nil {
-		return 0, err
+		return 0, false, err
 	}
-	return time.Duration(seconds) * time.Second, nil
+	return time.Duration(seconds) * time.Second, true, nil
 }
 
 func (h *txHandler) bindRoutes(router *Router) {

--- a/http/handler_tx_test.go
+++ b/http/handler_tx_test.go
@@ -13,14 +13,17 @@ package http
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
 	"testing"
 	"time"
 
+	"github.com/go-chi/chi/v5"
 	"github.com/stretchr/testify/require"
 
+	clientmocks "github.com/sourcenetwork/defradb/client/mocks"
 	"github.com/sourcenetwork/defradb/client/options"
 	"github.com/sourcenetwork/defradb/internal/ttl"
 )
@@ -103,4 +106,49 @@ func TestNewTxnCache_GivenDefaultTTLBeyondMax_ReturnsError(t *testing.T) {
 
 	require.ErrorIs(t, err, ttl.ErrBeyondMaxTTL)
 	require.Nil(t, cache)
+}
+
+func TestNewHandler_GivenNilNodeOptions_UsesDefaultTxnCache(t *testing.T) {
+	cdb := setupDatabase(t)
+
+	handler, err := NewHandler(cdb, nil)
+
+	require.NoError(t, err)
+	defer handler.Close()
+	require.NotNil(t, handler.txs)
+	require.Equal(t, DefaultTxnTTL, handler.txs.defaultTTL)
+}
+
+func TestTxHandlerCommit_GivenCommitError_RestoresTransaction(t *testing.T) {
+	txs, err := newTxnCache(context.Background(), &options.NodeHTTPOptions{
+		TxnTTL:        5 * time.Second,
+		TxnTTLTick:    time.Second,
+		TxnTTLBuckets: 10,
+	})
+	require.NoError(t, err)
+	defer txs.Close()
+
+	const txID uint64 = 1
+	txnTTL := 3 * time.Second
+	commitErr := errors.New("commit failed")
+	tx := clientmocks.NewTxn(t)
+	tx.EXPECT().ID().Return(txID)
+	tx.EXPECT().Commit().Return(commitErr)
+	require.NoError(t, txs.Store(tx, txnTTL))
+
+	routeCtx := chi.NewRouteContext()
+	routeCtx.URLParams.Add("id", strconv.FormatUint(txID, 10))
+	req := httptest.NewRequest(http.MethodPost, "/tx/1", nil)
+	ctx := context.WithValue(req.Context(), txsContextKey, txs)
+	ctx = context.WithValue(ctx, chi.RouteCtxKey, routeCtx)
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+
+	(&txHandler{}).Commit(rec, req)
+
+	require.Equal(t, http.StatusBadRequest, rec.Result().StatusCode)
+	item, ok := txs.cache.Load(txID)
+	require.True(t, ok)
+	require.Same(t, tx, item.txn)
+	require.Equal(t, txnTTL, item.ttl)
 }

--- a/http/handler_tx_test.go
+++ b/http/handler_tx_test.go
@@ -11,6 +11,7 @@
 package http
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -21,6 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/sourcenetwork/defradb/client/options"
+	"github.com/sourcenetwork/defradb/internal/ttl"
 )
 
 func TestParseTxnTTL(t *testing.T) {
@@ -64,7 +66,7 @@ func TestTxHandler_GivenTTL_ExpiresTransaction(t *testing.T) {
 	cdb := setupDatabase(t)
 	handler, err := NewHandler(cdb, &options.NodeOptions{
 		HTTP: options.NodeHTTPOptions{
-			TxnTTL:        time.Minute,
+			TxnTTL:        100 * time.Millisecond,
 			TxnTTLTick:    10 * time.Millisecond,
 			TxnTTLBuckets: 20,
 		},
@@ -90,4 +92,15 @@ func TestTxHandler_GivenTTL_ExpiresTransaction(t *testing.T) {
 	handler.ServeHTTP(rec, req)
 
 	require.Equal(t, http.StatusNotFound, rec.Result().StatusCode)
+}
+
+func TestNewTxnCache_GivenDefaultTTLBeyondMax_ReturnsError(t *testing.T) {
+	cache, err := newTxnCache(context.Background(), &options.NodeHTTPOptions{
+		TxnTTL:        time.Minute,
+		TxnTTLTick:    time.Second,
+		TxnTTLBuckets: 1,
+	})
+
+	require.ErrorIs(t, err, ttl.ErrBeyondMaxTTL)
+	require.Nil(t, cache)
 }

--- a/http/handler_tx_test.go
+++ b/http/handler_tx_test.go
@@ -86,8 +86,7 @@ func TestTxHandler_GivenTTL_ExpiresTransaction(t *testing.T) {
 	require.NoError(t, json.NewDecoder(rec.Result().Body).Decode(&response))
 
 	require.Eventually(t, func() bool {
-		_, ok := handler.txs.cache.Load(response.ID)
-		return !ok
+		return !isTxnCached(handler.txs, response.ID)
 	}, time.Second, 10*time.Millisecond)
 
 	req = httptest.NewRequest(http.MethodPost, "http://localhost:9181/api/v1/tx/"+strconv.FormatUint(response.ID, 10), nil)

--- a/http/handler_tx_test.go
+++ b/http/handler_tx_test.go
@@ -1,0 +1,93 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package http
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcenetwork/defradb/client/options"
+)
+
+func TestParseTxnTTL(t *testing.T) {
+	t.Run("duration", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "http://localhost:9181/api/v1/tx?ttl=150ms", nil)
+
+		txnTTL, err := parseTxnTTL(req)
+
+		require.NoError(t, err)
+		require.Equal(t, 150*time.Millisecond, txnTTL)
+	})
+
+	t.Run("seconds", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "http://localhost:9181/api/v1/tx?ttl=2", nil)
+
+		txnTTL, err := parseTxnTTL(req)
+
+		require.NoError(t, err)
+		require.Equal(t, 2*time.Second, txnTTL)
+	})
+
+	t.Run("empty", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "http://localhost:9181/api/v1/tx", nil)
+
+		txnTTL, err := parseTxnTTL(req)
+
+		require.NoError(t, err)
+		require.Zero(t, txnTTL)
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "http://localhost:9181/api/v1/tx?ttl=soon", nil)
+
+		_, err := parseTxnTTL(req)
+
+		require.Error(t, err)
+	})
+}
+
+func TestTxHandler_GivenTTL_ExpiresTransaction(t *testing.T) {
+	cdb := setupDatabase(t)
+	handler, err := NewHandler(cdb, &options.NodeOptions{
+		HTTP: options.NodeHTTPOptions{
+			TxnTTL:        time.Minute,
+			TxnTTLTick:    10 * time.Millisecond,
+			TxnTTLBuckets: 20,
+		},
+	})
+	require.NoError(t, err)
+	defer handler.Close()
+
+	req := httptest.NewRequest(http.MethodPost, "http://localhost:9181/api/v1/tx?ttl=30ms", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Result().StatusCode)
+	var response CreateTxResponse
+	require.NoError(t, json.NewDecoder(rec.Result().Body).Decode(&response))
+
+	require.Eventually(t, func() bool {
+		_, ok := handler.txs.cache.Load(response.ID)
+		return !ok
+	}, time.Second, 10*time.Millisecond)
+
+	req = httptest.NewRequest(http.MethodPost, "http://localhost:9181/api/v1/tx/"+strconv.FormatUint(response.ID, 10), nil)
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusNotFound, rec.Result().StatusCode)
+}

--- a/http/handler_tx_test.go
+++ b/http/handler_tx_test.go
@@ -96,6 +96,54 @@ func TestTxHandler_GivenTTL_ExpiresTransaction(t *testing.T) {
 	require.Equal(t, http.StatusNotFound, rec.Result().StatusCode)
 }
 
+func TestTxHandler_GivenNoTTL_UsesDefaultTransactionTTL(t *testing.T) {
+	cdb := setupDatabase(t)
+	defaultTTL := 100 * time.Millisecond
+	handler, err := NewHandler(cdb, &options.NodeOptions{
+		HTTP: options.NodeHTTPOptions{
+			TxnTTL:        defaultTTL,
+			TxnTTLTick:    10 * time.Millisecond,
+			TxnTTLBuckets: 20,
+		},
+	})
+	require.NoError(t, err)
+	defer handler.Close()
+
+	req := httptest.NewRequest(http.MethodPost, "http://localhost:9181/api/v1/tx", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Result().StatusCode)
+	var response CreateTxResponse
+	require.NoError(t, json.NewDecoder(rec.Result().Body).Decode(&response))
+
+	cached, ok := handler.txs.cache.Load(response.ID)
+	require.True(t, ok)
+	require.Equal(t, defaultTTL, cached.ttl)
+}
+
+func TestTxHandler_GivenNegativeTTL_ReturnsError(t *testing.T) {
+	cdb := setupDatabase(t)
+	handler, err := NewHandler(cdb, &options.NodeOptions{
+		HTTP: options.NodeHTTPOptions{
+			TxnTTL:        100 * time.Millisecond,
+			TxnTTLTick:    10 * time.Millisecond,
+			TxnTTLBuckets: 20,
+		},
+	})
+	require.NoError(t, err)
+	defer handler.Close()
+
+	req := httptest.NewRequest(http.MethodPost, "http://localhost:9181/api/v1/tx?ttl=-1", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusBadRequest, rec.Result().StatusCode)
+	var response errorResponse
+	require.NoError(t, json.NewDecoder(rec.Result().Body).Decode(&response))
+	require.EqualError(t, response.Error, ttl.ErrNegativeTTL.Error())
+}
+
 func TestNewTxnCache_GivenDefaultTTLBeyondMax_ReturnsError(t *testing.T) {
 	cache, err := newTxnCache(context.Background(), &options.NodeHTTPOptions{
 		TxnTTL:        time.Minute,

--- a/http/handler_tx_test.go
+++ b/http/handler_tx_test.go
@@ -32,36 +32,50 @@ func TestParseTxnTTL(t *testing.T) {
 	t.Run("duration", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, "http://localhost:9181/api/v1/tx?ttl=150ms", nil)
 
-		txnTTL, err := parseTxnTTL(req)
+		txnTTL, hasTTL, err := parseTxnTTL(req)
 
 		require.NoError(t, err)
+		require.True(t, hasTTL)
 		require.Equal(t, 150*time.Millisecond, txnTTL)
 	})
 
 	t.Run("seconds", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, "http://localhost:9181/api/v1/tx?ttl=2", nil)
 
-		txnTTL, err := parseTxnTTL(req)
+		txnTTL, hasTTL, err := parseTxnTTL(req)
 
 		require.NoError(t, err)
+		require.True(t, hasTTL)
 		require.Equal(t, 2*time.Second, txnTTL)
+	})
+
+	t.Run("zero", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "http://localhost:9181/api/v1/tx?ttl=0", nil)
+
+		txnTTL, hasTTL, err := parseTxnTTL(req)
+
+		require.NoError(t, err)
+		require.True(t, hasTTL)
+		require.Zero(t, txnTTL)
 	})
 
 	t.Run("empty", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, "http://localhost:9181/api/v1/tx", nil)
 
-		txnTTL, err := parseTxnTTL(req)
+		txnTTL, hasTTL, err := parseTxnTTL(req)
 
 		require.NoError(t, err)
+		require.False(t, hasTTL)
 		require.Zero(t, txnTTL)
 	})
 
 	t.Run("invalid", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, "http://localhost:9181/api/v1/tx?ttl=soon", nil)
 
-		_, err := parseTxnTTL(req)
+		_, hasTTL, err := parseTxnTTL(req)
 
 		require.Error(t, err)
+		require.False(t, hasTTL)
 	})
 }
 
@@ -120,6 +134,31 @@ func TestTxHandler_GivenNoTTL_UsesDefaultTransactionTTL(t *testing.T) {
 	cached, ok := handler.txs.cache.Load(response.ID)
 	require.True(t, ok)
 	require.Equal(t, defaultTTL, cached.ttl)
+}
+
+func TestTxHandler_GivenZeroTTL_UsesZeroTransactionTTL(t *testing.T) {
+	cdb := setupDatabase(t)
+	handler, err := NewHandler(cdb, &options.NodeOptions{
+		HTTP: options.NodeHTTPOptions{
+			TxnTTL:        100 * time.Millisecond,
+			TxnTTLTick:    time.Second,
+			TxnTTLBuckets: 1,
+		},
+	})
+	require.NoError(t, err)
+	defer handler.Close()
+
+	req := httptest.NewRequest(http.MethodPost, "http://localhost:9181/api/v1/tx?ttl=0", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Result().StatusCode)
+	var response CreateTxResponse
+	require.NoError(t, json.NewDecoder(rec.Result().Body).Decode(&response))
+
+	cached, ok := handler.txs.cache.Load(response.ID)
+	require.True(t, ok)
+	require.Zero(t, cached.ttl)
 }
 
 func TestTxHandler_GivenNegativeTTL_ReturnsError(t *testing.T) {
@@ -181,7 +220,7 @@ func TestTxHandlerCommit_GivenCommitError_RestoresTransaction(t *testing.T) {
 	tx := clientmocks.NewTxn(t)
 	tx.EXPECT().ID().Return(txID)
 	tx.EXPECT().Commit().Return(commitErr)
-	require.NoError(t, txs.Store(tx, txnTTL))
+	require.NoError(t, txs.StoreFor(tx, txnTTL))
 
 	routeCtx := chi.NewRouteContext()
 	routeCtx.URLParams.Add("id", strconv.FormatUint(txID, 10))

--- a/http/middleware.go
+++ b/http/middleware.go
@@ -74,7 +74,7 @@ func TransactionMiddleware(next http.Handler) http.Handler {
 		}
 		tx, ok := txs.Load(id)
 		if !ok {
-			err := ErrMissingOrExpiredTransaction
+			err := client.ErrTransactionNotFound
 			if strings.Contains(req.URL.Path, "/graphql") {
 				responseJSON(rw, httpStatusFromError(err), gqlErrorResponse{err})
 			} else {

--- a/http/middleware.go
+++ b/http/middleware.go
@@ -15,7 +15,6 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
-	"sync"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/cors"
@@ -44,7 +43,7 @@ func CorsMiddleware(allowedOrigins []string) func(http.Handler) http.Handler {
 }
 
 // ApiMiddleware sets the required context values for all API requests.
-func ApiMiddleware(db client.TxnStore, txs *sync.Map, nodeOpts *options.NodeOptions) func(http.Handler) http.Handler {
+func ApiMiddleware(db client.TxnStore, txs *txnCache, nodeOpts *options.NodeOptions) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 			ctx := req.Context()
@@ -61,7 +60,7 @@ func ApiMiddleware(db client.TxnStore, txs *sync.Map, nodeOpts *options.NodeOpti
 // TransactionMiddleware sets the transaction context for the current request.
 func TransactionMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		txs := mustGetContextSyncMap(req)
+		txs := mustGetContextTxnCache(req)
 
 		txValue := req.Header.Get(txHeaderName)
 		if txValue == "" {
@@ -75,13 +74,16 @@ func TransactionMiddleware(next http.Handler) http.Handler {
 		}
 		tx, ok := txs.Load(id)
 		if !ok {
-			responseJSON(rw, httpStatusFromError(db.ErrTxnDiscarded), errorResponse{db.ErrTxnDiscarded})
+			err := ErrMissingOrExpiredTransaction
+			if strings.Contains(req.URL.Path, "/graphql") {
+				responseJSON(rw, httpStatusFromError(err), gqlErrorResponse{err})
+			} else {
+				responseJSON(rw, httpStatusFromError(err), errorResponse{err})
+			}
 			return
 		}
 		ctx := req.Context()
-		if val, ok := tx.(client.Txn); ok {
-			ctx = db.InitContext(ctx, val)
-		}
+		ctx = db.InitContext(ctx, tx)
 		next.ServeHTTP(rw, req.WithContext(ctx))
 	})
 }

--- a/http/middleware.go
+++ b/http/middleware.go
@@ -76,9 +76,9 @@ func TransactionMiddleware(next http.Handler) http.Handler {
 		if !ok {
 			err := client.ErrTransactionNotFound
 			if strings.Contains(req.URL.Path, "/graphql") {
-				responseJSON(rw, httpStatusFromError(err), gqlErrorResponse{err})
+				responseJSON(rw, http.StatusBadRequest, gqlErrorResponse{err})
 			} else {
-				responseJSON(rw, httpStatusFromError(err), errorResponse{err})
+				responseJSON(rw, http.StatusBadRequest, errorResponse{err})
 			}
 			return
 		}

--- a/http/middleware.go
+++ b/http/middleware.go
@@ -72,7 +72,7 @@ func TransactionMiddleware(next http.Handler) http.Handler {
 			responseJSON(rw, http.StatusBadRequest, errorResponse{ErrInvalidTransactionId})
 			return
 		}
-		tx, ok := txs.Load(id)
+		lease, ok := txs.Acquire(id)
 		if !ok {
 			err := client.ErrTransactionNotFound
 			if strings.Contains(req.URL.Path, "/graphql") {
@@ -82,8 +82,10 @@ func TransactionMiddleware(next http.Handler) http.Handler {
 			}
 			return
 		}
+		defer lease.Release()
+
 		ctx := req.Context()
-		ctx = db.InitContext(ctx, tx)
+		ctx = db.InitContext(ctx, lease.Value().txn)
 		next.ServeHTTP(rw, req.WithContext(ctx))
 	})
 }

--- a/http/middleware_test.go
+++ b/http/middleware_test.go
@@ -19,8 +19,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/sourcenetwork/defradb/client"
 )
 
 func TestTransactionMiddleware_WithInvalidTxID_ReturnsBadRequest(t *testing.T) {
@@ -45,7 +43,7 @@ func TestTransactionMiddleware_WithInvalidTxID_ReturnsBadRequest(t *testing.T) {
 	assert.Contains(t, errRes["error"], ErrInvalidTransactionId.Error())
 }
 
-func TestTransactionMiddleware_WithNonExistentTxID_ReturnsNotFound(t *testing.T) {
+func TestTransactionMiddleware_WithNonExistentTxID_ReturnsBadRequest(t *testing.T) {
 	cdb := setupDatabase(t)
 
 	handler, err := NewHandler(cdb, nil)
@@ -60,9 +58,9 @@ func TestTransactionMiddleware_WithNonExistentTxID_ReturnsNotFound(t *testing.T)
 	body, err := io.ReadAll(res.Body)
 	require.NoError(t, err)
 
-	assert.Equal(t, http.StatusNotFound, res.StatusCode)
+	assert.Equal(t, http.StatusBadRequest, res.StatusCode)
 
 	var errRes map[string]any
 	require.NoError(t, json.Unmarshal(body, &errRes))
-	assert.Contains(t, errRes["error"], client.ErrTransactionNotFound.Error())
+	assert.Contains(t, errRes["error"], ErrMissingOrExpiredTransaction.Error())
 }

--- a/http/middleware_test.go
+++ b/http/middleware_test.go
@@ -17,6 +17,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/sourcenetwork/defradb/client"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -62,5 +63,5 @@ func TestTransactionMiddleware_WithNonExistentTxID_ReturnsBadRequest(t *testing.
 
 	var errRes map[string]any
 	require.NoError(t, json.Unmarshal(body, &errRes))
-	assert.Contains(t, errRes["error"], ErrMissingOrExpiredTransaction.Error())
+	assert.Contains(t, errRes["error"], client.ErrTransactionNotFound.Error())
 }

--- a/http/middleware_test.go
+++ b/http/middleware_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/sourcenetwork/defradb/client"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/http/txn_cache.go
+++ b/http/txn_cache.go
@@ -46,6 +46,10 @@ func newTxnCache(ctx context.Context, opts *options.NodeHTTPOptions) (*txnCache,
 	if err != nil {
 		return nil, err
 	}
+	if err := cache.ValidateTTL(cfg.defaultTTL); err != nil {
+		cache.Stop()
+		return nil, err
+	}
 	return &txnCache{
 		defaultTTL: cfg.defaultTTL,
 		cache:      cache,

--- a/http/txn_cache.go
+++ b/http/txn_cache.go
@@ -28,11 +28,22 @@ const (
 	DefaultTxnTTLBuckets = 60
 )
 
+// cachedTxn pairs a cached transaction with its configured idle TTL, so the TTL
+// can be reused if the transaction is re-stored (for example, restored after a
+// failed commit).
 type cachedTxn struct {
 	txn client.Txn
 	ttl time.Duration
 }
 
+// txnLease is a hold on a cached transaction that keeps it from expiring while
+// a request is using it. It is released once the request completes.
+type txnLease = ttl.Lease[uint64, cachedTxn]
+
+// txnCache holds the explicit HTTP transactions keyed by their ID, expiring
+// each after it has been idle for its TTL. A transaction does not expire while
+// a request holds a lease on it, so long-running requests cannot have their
+// transaction discarded mid-flight.
 type txnCache struct {
 	defaultTTL time.Duration
 	cache      *ttl.Cache[uint64, cachedTxn]
@@ -40,8 +51,8 @@ type txnCache struct {
 
 func newTxnCache(ctx context.Context, opts *options.NodeHTTPOptions) (*txnCache, error) {
 	cfg := txnCacheConfig(opts)
-	cache, err := ttl.NewCache(ctx, cfg.tick, cfg.buckets, func(_ uint64, item cachedTxn) {
-		item.txn.Discard()
+	cache, err := ttl.NewCache(ctx, cfg.tick, cfg.buckets, func(_ uint64, cached cachedTxn) {
+		cached.txn.Discard()
 	})
 	if err != nil {
 		return nil, err
@@ -83,6 +94,8 @@ func txnCacheConfig(opts *options.NodeHTTPOptions) txnCacheConfiguration {
 	return cfg
 }
 
+// Store caches txn until it has been idle for txnTTL. A txnTTL of zero uses the
+// cache's default TTL.
 func (c *txnCache) Store(txn client.Txn, txnTTL time.Duration) error {
 	if txnTTL == 0 {
 		txnTTL = c.defaultTTL
@@ -90,32 +103,30 @@ func (c *txnCache) Store(txn client.Txn, txnTTL time.Duration) error {
 	return c.cache.Store(txn.ID(), cachedTxn{txn: txn, ttl: txnTTL}, txnTTL)
 }
 
-func (c *txnCache) Load(id uint64) (client.Txn, bool) {
-	item, ok := c.cache.Load(id)
+// Get returns the cached transaction with the given ID without leasing it or
+// affecting its expiration.
+func (c *txnCache) Get(id uint64) (client.Txn, bool) {
+	cached, ok := c.cache.Load(id)
 	if !ok {
 		return nil, false
 	}
-	refreshed, err := c.cache.UpdateTTL(id, item.ttl)
-	if err != nil {
-		log.ErrorE("failed to refresh transaction ttl", err)
-		return nil, false
-	}
-	if !refreshed {
-		return nil, false
-	}
-	return item.txn, true
+	return cached.txn, true
 }
 
+// Acquire returns a lease on the cached transaction with the given ID,
+// suspending its expiration until the lease is released.
+func (c *txnCache) Acquire(id uint64) (*txnLease, bool) {
+	return c.cache.Acquire(id)
+}
+
+// LoadAndDelete removes the transaction with the given ID and returns it along
+// with its configured TTL, transferring ownership to the caller.
 func (c *txnCache) LoadAndDelete(id uint64) (client.Txn, time.Duration, bool) {
-	item, ok := c.cache.LoadAndDelete(id)
+	cached, ok := c.cache.LoadAndDelete(id)
 	if !ok {
 		return nil, 0, false
 	}
-	return item.txn, item.ttl, true
-}
-
-func (c *txnCache) Delete(id uint64) {
-	c.cache.Delete(id)
+	return cached.txn, cached.ttl, true
 }
 
 func (c *txnCache) Close() {

--- a/http/txn_cache.go
+++ b/http/txn_cache.go
@@ -59,7 +59,7 @@ func newTxnCache(ctx context.Context, opts *options.NodeHTTPOptions) (*txnCache,
 		return nil, err
 	}
 	if err := cache.ValidateTTL(cfg.defaultTTL); err != nil {
-		cache.Stop()
+		cache.Close()
 		return nil, errors.Join(ErrInvalidTTL, err)
 	}
 	return &txnCache{
@@ -132,5 +132,5 @@ func (c *txnCache) LoadAndDelete(id uint64) (client.Txn, time.Duration, bool) {
 }
 
 func (c *txnCache) Close() {
-	c.cache.Stop()
+	c.cache.Close()
 }

--- a/http/txn_cache.go
+++ b/http/txn_cache.go
@@ -95,18 +95,23 @@ func (c *txnCache) Load(id uint64) (client.Txn, bool) {
 	if !ok {
 		return nil, false
 	}
-	if err := c.cache.UpdateTTL(id, item.ttl); err != nil {
+	refreshed, err := c.cache.UpdateTTL(id, item.ttl)
+	if err != nil {
 		log.ErrorE("failed to refresh transaction ttl", err)
+		return nil, false
+	}
+	if !refreshed {
+		return nil, false
 	}
 	return item.txn, true
 }
 
-func (c *txnCache) LoadAndDelete(id uint64) (client.Txn, bool) {
+func (c *txnCache) LoadAndDelete(id uint64) (client.Txn, time.Duration, bool) {
 	item, ok := c.cache.LoadAndDelete(id)
 	if !ok {
-		return nil, false
+		return nil, 0, false
 	}
-	return item.txn, true
+	return item.txn, item.ttl, true
 }
 
 func (c *txnCache) Delete(id uint64) {

--- a/http/txn_cache.go
+++ b/http/txn_cache.go
@@ -1,0 +1,114 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package http
+
+import (
+	"context"
+	"time"
+
+	"github.com/sourcenetwork/defradb/client"
+	"github.com/sourcenetwork/defradb/client/options"
+	"github.com/sourcenetwork/defradb/internal/ttl"
+)
+
+const (
+	// DefaultTxnTTL is the default idle TTL for explicit HTTP transactions.
+	DefaultTxnTTL = 60 * time.Second
+	// DefaultTxnTTLTick is the default timer resolution for HTTP transaction TTLs.
+	DefaultTxnTTLTick = time.Second
+	// DefaultTxnTTLBuckets is the default timer bucket count for HTTP transaction TTLs.
+	DefaultTxnTTLBuckets = 60
+)
+
+type cachedTxn struct {
+	txn client.Txn
+	ttl time.Duration
+}
+
+type txnCache struct {
+	defaultTTL time.Duration
+	cache      *ttl.Cache[uint64, cachedTxn]
+}
+
+func newTxnCache(ctx context.Context, opts *options.NodeOptions) (*txnCache, error) {
+	cfg := txnCacheConfig(opts)
+	cache, err := ttl.NewCache(ctx, cfg.tick, cfg.buckets, func(_ uint64, item cachedTxn) {
+		item.txn.Discard()
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &txnCache{
+		defaultTTL: cfg.defaultTTL,
+		cache:      cache,
+	}, nil
+}
+
+type txnCacheConfiguration struct {
+	defaultTTL time.Duration
+	tick       time.Duration
+	buckets    int
+}
+
+func txnCacheConfig(opts *options.NodeOptions) txnCacheConfiguration {
+	cfg := txnCacheConfiguration{
+		defaultTTL: DefaultTxnTTL,
+		tick:       DefaultTxnTTLTick,
+		buckets:    DefaultTxnTTLBuckets,
+	}
+	if opts == nil {
+		return cfg
+	}
+	if opts.HTTP.TxnTTL != 0 {
+		cfg.defaultTTL = opts.HTTP.TxnTTL
+	}
+	if opts.HTTP.TxnTTLTick != 0 {
+		cfg.tick = opts.HTTP.TxnTTLTick
+	}
+	if opts.HTTP.TxnTTLBuckets != 0 {
+		cfg.buckets = opts.HTTP.TxnTTLBuckets
+	}
+	return cfg
+}
+
+func (c *txnCache) Store(txn client.Txn, txnTTL time.Duration) error {
+	if txnTTL == 0 {
+		txnTTL = c.defaultTTL
+	}
+	return c.cache.Store(txn.ID(), cachedTxn{txn: txn, ttl: txnTTL}, txnTTL)
+}
+
+func (c *txnCache) Load(id uint64) (client.Txn, bool) {
+	item, ok := c.cache.Load(id)
+	if !ok {
+		return nil, false
+	}
+	if err := c.cache.UpdateTTL(id, item.ttl); err != nil {
+		log.ErrorE("failed to refresh transaction ttl", err)
+	}
+	return item.txn, true
+}
+
+func (c *txnCache) LoadAndDelete(id uint64) (client.Txn, bool) {
+	item, ok := c.cache.LoadAndDelete(id)
+	if !ok {
+		return nil, false
+	}
+	return item.txn, true
+}
+
+func (c *txnCache) Delete(id uint64) {
+	c.cache.Delete(id)
+}
+
+func (c *txnCache) Close() {
+	c.cache.Stop()
+}

--- a/http/txn_cache.go
+++ b/http/txn_cache.go
@@ -38,7 +38,7 @@ type txnCache struct {
 	cache      *ttl.Cache[uint64, cachedTxn]
 }
 
-func newTxnCache(ctx context.Context, opts *options.NodeOptions) (*txnCache, error) {
+func newTxnCache(ctx context.Context, opts *options.NodeHTTPOptions) (*txnCache, error) {
 	cfg := txnCacheConfig(opts)
 	cache, err := ttl.NewCache(ctx, cfg.tick, cfg.buckets, func(_ uint64, item cachedTxn) {
 		item.txn.Discard()
@@ -58,7 +58,7 @@ type txnCacheConfiguration struct {
 	buckets    int
 }
 
-func txnCacheConfig(opts *options.NodeOptions) txnCacheConfiguration {
+func txnCacheConfig(opts *options.NodeHTTPOptions) txnCacheConfiguration {
 	cfg := txnCacheConfiguration{
 		defaultTTL: DefaultTxnTTL,
 		tick:       DefaultTxnTTLTick,
@@ -67,14 +67,14 @@ func txnCacheConfig(opts *options.NodeOptions) txnCacheConfiguration {
 	if opts == nil {
 		return cfg
 	}
-	if opts.HTTP.TxnTTL != 0 {
-		cfg.defaultTTL = opts.HTTP.TxnTTL
+	if opts.TxnTTL != 0 {
+		cfg.defaultTTL = opts.TxnTTL
 	}
-	if opts.HTTP.TxnTTLTick != 0 {
-		cfg.tick = opts.HTTP.TxnTTLTick
+	if opts.TxnTTLTick != 0 {
+		cfg.tick = opts.TxnTTLTick
 	}
-	if opts.HTTP.TxnTTLBuckets != 0 {
-		cfg.buckets = opts.HTTP.TxnTTLBuckets
+	if opts.TxnTTLBuckets != 0 {
+		cfg.buckets = opts.TxnTTLBuckets
 	}
 	return cfg
 }

--- a/http/txn_cache.go
+++ b/http/txn_cache.go
@@ -95,12 +95,13 @@ func txnCacheConfig(opts *options.NodeHTTPOptions) txnCacheConfiguration {
 	return cfg
 }
 
-// Store caches txn until it has been idle for txnTTL. A txnTTL of zero uses the
-// cache's default TTL.
-func (c *txnCache) Store(txn client.Txn, txnTTL time.Duration) error {
-	if txnTTL == 0 {
-		txnTTL = c.defaultTTL
-	}
+// Store caches txn until it has been idle for the cache's default TTL.
+func (c *txnCache) Store(txn client.Txn) error {
+	return c.StoreFor(txn, c.defaultTTL)
+}
+
+// StoreFor caches txn until it has been idle for txnTTL.
+func (c *txnCache) StoreFor(txn client.Txn, txnTTL time.Duration) error {
 	return c.cache.Store(txn.ID(), cachedTxn{txn: txn, ttl: txnTTL}, txnTTL)
 }
 

--- a/http/txn_cache.go
+++ b/http/txn_cache.go
@@ -12,6 +12,7 @@ package http
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/sourcenetwork/defradb/client"
@@ -59,7 +60,7 @@ func newTxnCache(ctx context.Context, opts *options.NodeHTTPOptions) (*txnCache,
 	}
 	if err := cache.ValidateTTL(cfg.defaultTTL); err != nil {
 		cache.Stop()
-		return nil, err
+		return nil, errors.Join(ErrInvalidTTL, err)
 	}
 	return &txnCache{
 		defaultTTL: cfg.defaultTTL,

--- a/http/txn_cache_test.go
+++ b/http/txn_cache_test.go
@@ -42,7 +42,7 @@ func TestTxnCache_HeldLeaseExpiresAfterRelease(t *testing.T) {
 	require.NoError(t, err)
 
 	cache := testTxnCache(t, 30*time.Millisecond)
-	require.NoError(t, cache.Store(tx, 0))
+	require.NoError(t, cache.Store(tx))
 
 	lease, ok := cache.Acquire(tx.ID())
 	require.True(t, ok)
@@ -63,7 +63,7 @@ func TestTxnCache_ConcurrentLeasesExpireAfterLastRelease(t *testing.T) {
 	require.NoError(t, err)
 
 	cache := testTxnCache(t, 30*time.Millisecond)
-	require.NoError(t, cache.Store(tx, 0))
+	require.NoError(t, cache.Store(tx))
 
 	firstLease, ok := cache.Acquire(tx.ID())
 	require.True(t, ok)
@@ -87,7 +87,7 @@ func TestTxnCache_LoadAndDeletePreventsReleaseReschedule(t *testing.T) {
 	require.NoError(t, err)
 
 	cache := testTxnCache(t, 30*time.Millisecond)
-	require.NoError(t, cache.Store(tx, 0))
+	require.NoError(t, cache.Store(tx))
 
 	lease, ok := cache.Acquire(tx.ID())
 	require.True(t, ok)
@@ -108,7 +108,7 @@ func TestTransactionMiddleware_HeldRequestExpiresAfterHandlerReturns(t *testing.
 	require.NoError(t, err)
 
 	cache := testTxnCache(t, 30*time.Millisecond)
-	require.NoError(t, cache.Store(tx, 0))
+	require.NoError(t, cache.Store(tx))
 
 	entered := make(chan struct{})
 	releaseHandler := make(chan struct{})

--- a/http/txn_cache_test.go
+++ b/http/txn_cache_test.go
@@ -1,0 +1,149 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package http
+
+import (
+	"context"
+	stdHTTP "net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcenetwork/defradb/client/options"
+)
+
+func testTxnCache(t *testing.T, txnTTL time.Duration) *txnCache {
+	t.Helper()
+
+	cache, err := newTxnCache(context.Background(), &options.NodeHTTPOptions{
+		TxnTTL:        txnTTL,
+		TxnTTLTick:    10 * time.Millisecond,
+		TxnTTLBuckets: 20,
+	})
+	require.NoError(t, err)
+	t.Cleanup(cache.Close)
+	return cache
+}
+
+func TestTxnCache_HeldLeaseExpiresAfterRelease(t *testing.T) {
+	cdb := setupDatabase(t)
+	tx, err := cdb.NewTxn(false)
+	require.NoError(t, err)
+
+	cache := testTxnCache(t, 30*time.Millisecond)
+	require.NoError(t, cache.Store(tx, 0))
+
+	lease, ok := cache.Acquire(tx.ID())
+	require.True(t, ok)
+
+	time.Sleep(90 * time.Millisecond)
+	require.True(t, isTxnCached(cache, tx.ID()))
+
+	lease.Release()
+
+	require.Eventually(t, func() bool {
+		return !isTxnCached(cache, tx.ID())
+	}, time.Second, 10*time.Millisecond)
+}
+
+func TestTxnCache_ConcurrentLeasesExpireAfterLastRelease(t *testing.T) {
+	cdb := setupDatabase(t)
+	tx, err := cdb.NewTxn(false)
+	require.NoError(t, err)
+
+	cache := testTxnCache(t, 30*time.Millisecond)
+	require.NoError(t, cache.Store(tx, 0))
+
+	firstLease, ok := cache.Acquire(tx.ID())
+	require.True(t, ok)
+	secondLease, ok := cache.Acquire(tx.ID())
+	require.True(t, ok)
+
+	firstLease.Release()
+	time.Sleep(90 * time.Millisecond)
+	require.True(t, isTxnCached(cache, tx.ID()))
+
+	secondLease.Release()
+
+	require.Eventually(t, func() bool {
+		return !isTxnCached(cache, tx.ID())
+	}, time.Second, 10*time.Millisecond)
+}
+
+func TestTxnCache_LoadAndDeletePreventsReleaseReschedule(t *testing.T) {
+	cdb := setupDatabase(t)
+	tx, err := cdb.NewTxn(false)
+	require.NoError(t, err)
+
+	cache := testTxnCache(t, 30*time.Millisecond)
+	require.NoError(t, cache.Store(tx, 0))
+
+	lease, ok := cache.Acquire(tx.ID())
+	require.True(t, ok)
+
+	removedTxn, _, ok := cache.LoadAndDelete(tx.ID())
+	require.True(t, ok)
+	require.Equal(t, tx.ID(), removedTxn.ID())
+
+	lease.Release()
+	time.Sleep(90 * time.Millisecond)
+	require.False(t, isTxnCached(cache, tx.ID()))
+	require.NoError(t, tx.Commit())
+}
+
+func TestTransactionMiddleware_HeldRequestExpiresAfterHandlerReturns(t *testing.T) {
+	cdb := setupDatabase(t)
+	tx, err := cdb.NewTxn(false)
+	require.NoError(t, err)
+
+	cache := testTxnCache(t, 30*time.Millisecond)
+	require.NoError(t, cache.Store(tx, 0))
+
+	entered := make(chan struct{})
+	releaseHandler := make(chan struct{})
+	next := stdHTTP.HandlerFunc(func(rw stdHTTP.ResponseWriter, req *stdHTTP.Request) {
+		close(entered)
+		<-releaseHandler
+		rw.WriteHeader(stdHTTP.StatusOK)
+	})
+	handler := ApiMiddleware(cdb, cache, nil)(TransactionMiddleware(next))
+
+	req := httptest.NewRequest(stdHTTP.MethodGet, "http://localhost:9181/api/v1/collections/User", nil)
+	req.Header.Set(txHeaderName, strconv.FormatUint(tx.ID(), 10))
+	rec := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		handler.ServeHTTP(rec, req)
+		close(done)
+	}()
+
+	<-entered
+	time.Sleep(90 * time.Millisecond)
+	require.True(t, isTxnCached(cache, tx.ID()))
+
+	close(releaseHandler)
+	<-done
+	require.Equal(t, stdHTTP.StatusOK, rec.Code)
+
+	require.Eventually(t, func() bool {
+		return !isTxnCached(cache, tx.ID())
+	}, time.Second, 10*time.Millisecond)
+}
+
+// isCached reports whether a transaction with the given ID is currently cached.
+func isTxnCached(c *txnCache, id uint64) bool {
+	_, ok := c.cache.Load(id)
+	return ok
+}

--- a/http/utils.go
+++ b/http/utils.go
@@ -15,7 +15,6 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
-	"sync"
 
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/options"
@@ -30,7 +29,7 @@ const (
 type contextKey string
 
 var (
-	// txsContextKey is the context key for the transaction *sync.Map
+	// txsContextKey is the context key for the transaction cache.
 	txsContextKey = contextKey("txs")
 	// dbContextKey is the context key for the client.TxnStore
 	dbContextKey = contextKey("db")
@@ -52,11 +51,11 @@ func mustGetContextClientCollection(req *http.Request) client.Collection {
 	return req.Context().Value(colContextKey).(client.Collection) //nolint:forcetypeassert
 }
 
-// mustGetContextSyncMap returns the sync map from the http request context or panics.
+// mustGetContextTxnCache returns the transaction cache from the http request context or panics.
 //
 // This should only be called from functions within the http package.
-func mustGetContextSyncMap(req *http.Request) *sync.Map {
-	return req.Context().Value(txsContextKey).(*sync.Map) //nolint:forcetypeassert
+func mustGetContextTxnCache(req *http.Request) *txnCache {
+	return req.Context().Value(txsContextKey).(*txnCache) //nolint:forcetypeassert
 }
 
 // mustGetContextClientDB returns the DB from the http request context or panics.

--- a/http/utils.go
+++ b/http/utils.go
@@ -77,13 +77,6 @@ func isDevMode(req *http.Request) bool {
 	return opts != nil && opts.EnableDevelopment
 }
 
-// mustGetDataStoreTxn returns the datastore transaction or panics.
-//
-// This should only be called from functions within the http package.
-func mustGetDataStoreTxn(tx any) client.Txn {
-	return tx.(client.Txn) //nolint:forcetypeassert
-}
-
 // tryGetContexCtx returns the server context if it exists.
 //
 // This should only be called from functions within the http package.

--- a/internal/ttl/cache.go
+++ b/internal/ttl/cache.go
@@ -77,7 +77,7 @@ func NewCache[K comparable, V any](
 // Store stores val at key with an idle expiration of ttl, replacing any
 // existing value and discarding its lease state.
 func (c *Cache[K, V]) Store(key K, val V, ttl time.Duration) error {
-	if err := c.wheel.validTTL(ttl); err != nil {
+	if err := c.wheel.ValidateTTL(ttl); err != nil {
 		return err
 	}
 
@@ -166,30 +166,53 @@ func (c *Cache[K, V]) Delete(key K) {
 	}
 	c.mu.Unlock()
 
-	if ok {
-		c.wheel.Delete(cacheWheelKey[K]{key: key, seq: item.seq})
-	}
+	c.wheel.Delete(cacheWheelKey[K]{key: key, seq: item.seq})
 }
 
-// UpdateTTL resets the expiration time for key if key is still cached.
+// UpdateTTL updates the idle TTL for key if key is still cached. If key is
+// idle, it also resets the current expiration timer. If key is leased, the new
+// TTL is used when the final lease is released.
 // It returns false if key was no longer cached.
 func (c *Cache[K, V]) UpdateTTL(key K, ttl time.Duration) (bool, error) {
-	if err := c.wheel.validTTL(ttl); err != nil {
+	if err := c.wheel.ValidateTTL(ttl); err != nil {
 		return false, err
 	}
 
 	c.mu.Lock()
 	item, ok := c.items[key]
-	c.mu.Unlock()
 	if !ok {
+		c.mu.Unlock()
 		return false, nil
 	}
-	return c.wheel.UpdateTTL(cacheWheelKey[K]{key: key, seq: item.seq}, ttl)
+	item.ttl = ttl
+	if item.active > 0 {
+		c.mu.Unlock()
+		return true, nil
+	}
+
+	updated, err := c.wheel.UpdateTTL(cacheWheelKey[K]{key: key, seq: item.seq}, ttl)
+	if err != nil {
+		c.mu.Unlock()
+		return false, err
+	}
+	if updated {
+		c.mu.Unlock()
+		return true, nil
+	}
+
+	c.nextSeq++
+	item.seq = c.nextSeq
+	err = c.wheel.Add(cacheWheelKey[K]{key: key, seq: item.seq}, ttl)
+	c.mu.Unlock()
+	if err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 // ValidateTTL returns an error if ttl cannot be used by this cache.
 func (c *Cache[K, V]) ValidateTTL(ttl time.Duration) error {
-	return c.wheel.validTTL(ttl)
+	return c.wheel.ValidateTTL(ttl)
 }
 
 // Stop stops the cache expiration wheel.
@@ -226,6 +249,10 @@ func (c *Cache[K, V]) release(key K) {
 	// The final lease was released; restart the idle timer from the full TTL.
 	c.nextSeq++
 	item.seq = c.nextSeq
+
+	// Add only fails for a TTL the wheel cannot hold, which Store already
+	// validated, so this is unreachable in practice. Expire the value if it
+	// ever happens so the resource is not leaked while untracked.
 	err := c.wheel.Add(cacheWheelKey[K]{key: key, seq: item.seq}, item.ttl)
 	if err != nil {
 		delete(c.items, key)
@@ -233,9 +260,6 @@ func (c *Cache[K, V]) release(key K) {
 	value := item.value
 	c.mu.Unlock()
 
-	// Add only fails for a TTL the wheel cannot hold, which Store already
-	// validated, so this is unreachable in practice. Expire the value if it
-	// ever happens so the resource is not leaked while untracked.
 	if err != nil && c.onExpire != nil {
 		c.onExpire(key, value)
 	}

--- a/internal/ttl/cache.go
+++ b/internal/ttl/cache.go
@@ -215,9 +215,9 @@ func (c *Cache[K, V]) ValidateTTL(ttl time.Duration) error {
 	return c.wheel.ValidateTTL(ttl)
 }
 
-// Stop stops the cache expiration wheel.
-func (c *Cache[K, V]) Stop() {
-	c.wheel.Stop()
+// Close stops the cache expiration wheel.
+func (c *Cache[K, V]) Close() {
+	c.wheel.Close()
 }
 
 // Value returns the leased value.

--- a/internal/ttl/cache.go
+++ b/internal/ttl/cache.go
@@ -1,0 +1,157 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package ttl
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// Cache stores values with idle-time expiration.
+type Cache[K comparable, V any] struct {
+	mu       sync.Mutex
+	items    map[K]cacheItem[V]
+	nextSeq  uint64
+	wheel    *Wheel[cacheWheelKey[K]]
+	onExpire func(K, V)
+}
+
+type cacheItem[V any] struct {
+	value V
+	seq   uint64
+}
+
+type cacheWheelKey[K comparable] struct {
+	key K
+	seq uint64
+}
+
+// NewCache returns a cache that expires entries using a timing wheel.
+func NewCache[K comparable, V any](
+	ctx context.Context,
+	tick time.Duration,
+	buckets int,
+	onExpire func(K, V),
+) (*Cache[K, V], error) {
+	c := &Cache[K, V]{
+		items:    make(map[K]cacheItem[V]),
+		onExpire: onExpire,
+	}
+	wheel, err := NewWheel(ctx, tick, int64(buckets), c.expire)
+	if err != nil {
+		return nil, err
+	}
+	c.wheel = wheel
+	c.wheel.Start()
+	return c, nil
+}
+
+// Store stores val at key until ttl elapses.
+func (c *Cache[K, V]) Store(key K, val V, ttl time.Duration) error {
+	if err := c.wheel.validTTL(ttl); err != nil {
+		return err
+	}
+
+	c.mu.Lock()
+	old, hadOld := c.items[key]
+	c.nextSeq++
+	item := cacheItem[V]{
+		value: val,
+		seq:   c.nextSeq,
+	}
+	c.items[key] = item
+	c.mu.Unlock()
+
+	if hadOld {
+		c.wheel.Delete(cacheWheelKey[K]{key: key, seq: old.seq})
+	}
+	return c.wheel.Add(cacheWheelKey[K]{key: key, seq: item.seq}, ttl)
+}
+
+// Load returns a value if key is still cached.
+func (c *Cache[K, V]) Load(key K) (V, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	item, ok := c.items[key]
+	if !ok {
+		var zero V
+		return zero, false
+	}
+	return item.value, true
+}
+
+// LoadAndDelete loads and removes key if it is still cached.
+func (c *Cache[K, V]) LoadAndDelete(key K) (V, bool) {
+	c.mu.Lock()
+	item, ok := c.items[key]
+	if ok {
+		delete(c.items, key)
+	}
+	c.mu.Unlock()
+
+	if !ok {
+		var zero V
+		return zero, false
+	}
+	c.wheel.Delete(cacheWheelKey[K]{key: key, seq: item.seq})
+	return item.value, true
+}
+
+// Delete removes key from the cache.
+func (c *Cache[K, V]) Delete(key K) {
+	c.mu.Lock()
+	item, ok := c.items[key]
+	if ok {
+		delete(c.items, key)
+	}
+	c.mu.Unlock()
+
+	if ok {
+		c.wheel.Delete(cacheWheelKey[K]{key: key, seq: item.seq})
+	}
+}
+
+// UpdateTTL resets the expiration time for key if key is still cached.
+func (c *Cache[K, V]) UpdateTTL(key K, ttl time.Duration) error {
+	if err := c.wheel.validTTL(ttl); err != nil {
+		return err
+	}
+
+	c.mu.Lock()
+	item, ok := c.items[key]
+	c.mu.Unlock()
+	if !ok {
+		return nil
+	}
+	return c.wheel.UpdateTTL(cacheWheelKey[K]{key: key, seq: item.seq}, ttl)
+}
+
+// Stop stops the cache expiration wheel.
+func (c *Cache[K, V]) Stop() {
+	c.wheel.Stop()
+}
+
+func (c *Cache[K, V]) expire(wheelKey cacheWheelKey[K]) {
+	c.mu.Lock()
+	item, ok := c.items[wheelKey.key]
+	if !ok || item.seq != wheelKey.seq {
+		c.mu.Unlock()
+		return
+	}
+	delete(c.items, wheelKey.key)
+	c.mu.Unlock()
+
+	if c.onExpire != nil {
+		c.onExpire(wheelKey.key, item.value)
+	}
+}

--- a/internal/ttl/cache.go
+++ b/internal/ttl/cache.go
@@ -16,26 +16,45 @@ import (
 	"time"
 )
 
-// Cache stores values with idle-time expiration.
+// Cache stores values with idle-time expiration that can be suspended by
+// leasing a value while it is in use.
+//
+// Entries expire once they have been idle for their TTL, but a caller may
+// Acquire a lease to keep a value alive while it is in use: a value with one or
+// more active leases is never expired, and once its final lease is released its
+// idle timer restarts from the value's full TTL.
 type Cache[K comparable, V any] struct {
 	mu       sync.Mutex
-	items    map[K]cacheItem[V]
+	items    map[K]*cacheItem[V]
 	nextSeq  uint64
 	wheel    *Wheel[cacheWheelKey[K]]
 	onExpire func(K, V)
 }
 
 type cacheItem[V any] struct {
-	value V
-	seq   uint64
+	value  V
+	ttl    time.Duration
+	active int
+	seq    uint64
 }
 
+// cacheWheelKey pairs a cache key with the sequence of the item it was
+// scheduled for so a stale wheel expiration cannot evict a newer item.
 type cacheWheelKey[K comparable] struct {
 	key K
 	seq uint64
 }
 
-// NewCache returns a cache that expires entries using a timing wheel.
+// Lease is a hold on a cached value that keeps it from expiring until released.
+// It is returned by Cache.Acquire.
+type Lease[K comparable, V any] struct {
+	cache *Cache[K, V]
+	key   K
+	value V
+	once  sync.Once
+}
+
+// NewCache returns a cache that expires idle values using a timing wheel.
 func NewCache[K comparable, V any](
 	ctx context.Context,
 	tick time.Duration,
@@ -43,7 +62,7 @@ func NewCache[K comparable, V any](
 	onExpire func(K, V),
 ) (*Cache[K, V], error) {
 	c := &Cache[K, V]{
-		items:    make(map[K]cacheItem[V]),
+		items:    make(map[K]*cacheItem[V]),
 		onExpire: onExpire,
 	}
 	wheel, err := NewWheel(ctx, tick, int64(buckets), c.expire)
@@ -55,7 +74,8 @@ func NewCache[K comparable, V any](
 	return c, nil
 }
 
-// Store stores val at key until ttl elapses.
+// Store stores val at key with an idle expiration of ttl, replacing any
+// existing value and discarding its lease state.
 func (c *Cache[K, V]) Store(key K, val V, ttl time.Duration) error {
 	if err := c.wheel.validTTL(ttl); err != nil {
 		return err
@@ -64,8 +84,9 @@ func (c *Cache[K, V]) Store(key K, val V, ttl time.Duration) error {
 	c.mu.Lock()
 	old, hadOld := c.items[key]
 	c.nextSeq++
-	item := cacheItem[V]{
+	item := &cacheItem[V]{
 		value: val,
+		ttl:   ttl,
 		seq:   c.nextSeq,
 	}
 	c.items[key] = item
@@ -77,7 +98,8 @@ func (c *Cache[K, V]) Store(key K, val V, ttl time.Duration) error {
 	return c.wheel.Add(cacheWheelKey[K]{key: key, seq: item.seq}, ttl)
 }
 
-// Load returns a value if key is still cached.
+// Load returns the value at key, if still cached, without affecting its
+// expiration or lease state.
 func (c *Cache[K, V]) Load(key K) (V, bool) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -90,7 +112,35 @@ func (c *Cache[K, V]) Load(key K) (V, bool) {
 	return item.value, true
 }
 
-// LoadAndDelete loads and removes key if it is still cached.
+// Acquire returns a lease on the value at key, suspending its expiration until
+// the lease is released. It reports false if key is not cached.
+func (c *Cache[K, V]) Acquire(key K) (*Lease[K, V], bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	item, ok := c.items[key]
+	if !ok {
+		return nil, false
+	}
+	// The first lease removes the value from the wheel so it cannot expire
+	// while in use. Bumping the sequence ensures any expiration already in
+	// flight for the old schedule is ignored once the lease is released.
+	if item.active == 0 {
+		c.wheel.Delete(cacheWheelKey[K]{key: key, seq: item.seq})
+		c.nextSeq++
+		item.seq = c.nextSeq
+	}
+	item.active++
+	return &Lease[K, V]{
+		cache: c,
+		key:   key,
+		value: item.value,
+	}, true
+}
+
+// LoadAndDelete removes key and returns its value, if still cached. A value
+// removed this way is never expired by the cache, even while leases are held;
+// the caller assumes ownership of it.
 func (c *Cache[K, V]) LoadAndDelete(key K) (V, bool) {
 	c.mu.Lock()
 	item, ok := c.items[key]
@@ -107,7 +157,7 @@ func (c *Cache[K, V]) LoadAndDelete(key K) (V, bool) {
 	return item.value, true
 }
 
-// Delete removes key from the cache.
+// Delete removes key from the cache without expiring its value.
 func (c *Cache[K, V]) Delete(key K) {
 	c.mu.Lock()
 	item, ok := c.items[key]
@@ -147,10 +197,54 @@ func (c *Cache[K, V]) Stop() {
 	c.wheel.Stop()
 }
 
+// Value returns the leased value.
+func (l *Lease[K, V]) Value() V {
+	return l.value
+}
+
+// Release releases the lease. When the final lease on a value is released its
+// idle expiration timer restarts from the value's full TTL. Release is
+// idempotent.
+func (l *Lease[K, V]) Release() {
+	l.once.Do(func() {
+		l.cache.release(l.key)
+	})
+}
+
+func (c *Cache[K, V]) release(key K) {
+	c.mu.Lock()
+	item, ok := c.items[key]
+	if !ok || item.active == 0 {
+		c.mu.Unlock()
+		return
+	}
+	item.active--
+	if item.active > 0 {
+		c.mu.Unlock()
+		return
+	}
+	// The final lease was released; restart the idle timer from the full TTL.
+	c.nextSeq++
+	item.seq = c.nextSeq
+	err := c.wheel.Add(cacheWheelKey[K]{key: key, seq: item.seq}, item.ttl)
+	if err != nil {
+		delete(c.items, key)
+	}
+	value := item.value
+	c.mu.Unlock()
+
+	// Add only fails for a TTL the wheel cannot hold, which Store already
+	// validated, so this is unreachable in practice. Expire the value if it
+	// ever happens so the resource is not leaked while untracked.
+	if err != nil && c.onExpire != nil {
+		c.onExpire(key, value)
+	}
+}
+
 func (c *Cache[K, V]) expire(wheelKey cacheWheelKey[K]) {
 	c.mu.Lock()
 	item, ok := c.items[wheelKey.key]
-	if !ok || item.seq != wheelKey.seq {
+	if !ok || item.seq != wheelKey.seq || item.active > 0 {
 		c.mu.Unlock()
 		return
 	}

--- a/internal/ttl/cache.go
+++ b/internal/ttl/cache.go
@@ -136,6 +136,11 @@ func (c *Cache[K, V]) UpdateTTL(key K, ttl time.Duration) error {
 	return c.wheel.UpdateTTL(cacheWheelKey[K]{key: key, seq: item.seq}, ttl)
 }
 
+// ValidateTTL returns an error if ttl cannot be used by this cache.
+func (c *Cache[K, V]) ValidateTTL(ttl time.Duration) error {
+	return c.wheel.validTTL(ttl)
+}
+
 // Stop stops the cache expiration wheel.
 func (c *Cache[K, V]) Stop() {
 	c.wheel.Stop()

--- a/internal/ttl/cache.go
+++ b/internal/ttl/cache.go
@@ -122,16 +122,17 @@ func (c *Cache[K, V]) Delete(key K) {
 }
 
 // UpdateTTL resets the expiration time for key if key is still cached.
-func (c *Cache[K, V]) UpdateTTL(key K, ttl time.Duration) error {
+// It returns false if key was no longer cached.
+func (c *Cache[K, V]) UpdateTTL(key K, ttl time.Duration) (bool, error) {
 	if err := c.wheel.validTTL(ttl); err != nil {
-		return err
+		return false, err
 	}
 
 	c.mu.Lock()
 	item, ok := c.items[key]
 	c.mu.Unlock()
 	if !ok {
-		return nil
+		return false, nil
 	}
 	return c.wheel.UpdateTTL(cacheWheelKey[K]{key: key, seq: item.seq}, ttl)
 }

--- a/internal/ttl/cache_test.go
+++ b/internal/ttl/cache_test.go
@@ -109,7 +109,9 @@ func TestCacheUpdateTTLRefreshesExpiration(t *testing.T) {
 
 	require.NoError(t, cache.Store("key", 1, 30*time.Millisecond))
 	time.Sleep(15 * time.Millisecond)
-	require.NoError(t, cache.UpdateTTL("key", 80*time.Millisecond))
+	refreshed, err := cache.UpdateTTL("key", 80*time.Millisecond)
+	require.NoError(t, err)
+	require.True(t, refreshed)
 
 	require.Never(t, func() bool {
 		select {
@@ -128,4 +130,15 @@ func TestCacheUpdateTTLRefreshesExpiration(t *testing.T) {
 			return false
 		}
 	}, 150*time.Millisecond, 5*time.Millisecond)
+}
+
+func TestCacheUpdateTTLReturnsFalseForMissingKey(t *testing.T) {
+	cache, err := NewCache(context.Background(), 10*time.Millisecond, 20, func(_ string, _ int) {})
+	require.NoError(t, err)
+	defer cache.Stop()
+
+	refreshed, err := cache.UpdateTTL("key", 80*time.Millisecond)
+
+	require.NoError(t, err)
+	require.False(t, refreshed)
 }

--- a/internal/ttl/cache_test.go
+++ b/internal/ttl/cache_test.go
@@ -274,6 +274,77 @@ func TestCacheLoadDoesNotLeaseValue(t *testing.T) {
 	}, time.Second, 5*time.Millisecond)
 }
 
+func TestCacheUpdateTTLRefreshesExpiration(t *testing.T) {
+	expired := make(chan struct{}, 1)
+	cache, err := NewCache(context.Background(), 10*time.Millisecond, 20, func(_ string, _ int) {
+		expired <- struct{}{}
+	})
+	require.NoError(t, err)
+	defer cache.Stop()
+
+	require.NoError(t, cache.Store("key", 1, 30*time.Millisecond))
+	time.Sleep(15 * time.Millisecond)
+
+	refreshed, err := cache.UpdateTTL("key", 80*time.Millisecond)
+	require.NoError(t, err)
+	require.True(t, refreshed)
+
+	require.Never(t, func() bool {
+		select {
+		case <-expired:
+			return true
+		default:
+			return false
+		}
+	}, 40*time.Millisecond, 5*time.Millisecond)
+
+	require.Eventually(t, func() bool {
+		select {
+		case <-expired:
+			return true
+		default:
+			return false
+		}
+	}, 150*time.Millisecond, 5*time.Millisecond)
+}
+
+func TestCacheUpdateTTLWhileLeasedAppliesAfterRelease(t *testing.T) {
+	expired := make(chan struct{}, 1)
+	cache, err := NewCache(context.Background(), 10*time.Millisecond, 20, func(_ string, _ int) {
+		expired <- struct{}{}
+	})
+	require.NoError(t, err)
+	defer cache.Stop()
+
+	require.NoError(t, cache.Store("key", 1, 30*time.Millisecond))
+	lease, ok := cache.Acquire("key")
+	require.True(t, ok)
+
+	refreshed, err := cache.UpdateTTL("key", 80*time.Millisecond)
+	require.NoError(t, err)
+	require.True(t, refreshed)
+
+	lease.Release()
+
+	require.Never(t, func() bool {
+		select {
+		case <-expired:
+			return true
+		default:
+			return false
+		}
+	}, 40*time.Millisecond, 5*time.Millisecond)
+
+	require.Eventually(t, func() bool {
+		select {
+		case <-expired:
+			return true
+		default:
+			return false
+		}
+	}, 150*time.Millisecond, 5*time.Millisecond)
+}
+
 func TestCacheUpdateTTLReturnsFalseForMissingKey(t *testing.T) {
 	cache, err := NewCache(context.Background(), 10*time.Millisecond, 20, func(_ string, _ int) {})
 	require.NoError(t, err)

--- a/internal/ttl/cache_test.go
+++ b/internal/ttl/cache_test.go
@@ -18,15 +18,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCacheExpiresStoredValue(t *testing.T) {
+func TestCacheExpiresUnleasedValue(t *testing.T) {
 	expired := make(chan int, 1)
-	cache, err := NewCache(context.Background(), 10*time.Millisecond, 10, func(_ string, value int) {
+	cache, err := NewCache(context.Background(), 10*time.Millisecond, 20, func(_ string, value int) {
 		expired <- value
 	})
 	require.NoError(t, err)
 	defer cache.Stop()
 
-	require.NoError(t, cache.Store("key", 1, 10*time.Millisecond))
+	require.NoError(t, cache.Store("key", 1, 30*time.Millisecond))
 
 	require.Eventually(t, func() bool {
 		select {
@@ -35,15 +35,165 @@ func TestCacheExpiresStoredValue(t *testing.T) {
 		default:
 			return false
 		}
-	}, 200*time.Millisecond, 5*time.Millisecond)
+	}, time.Second, 5*time.Millisecond)
 
 	_, ok := cache.Load("key")
 	require.False(t, ok)
 }
 
+func TestCacheActiveLeasePreventsExpiration(t *testing.T) {
+	expired := make(chan struct{}, 1)
+	cache, err := NewCache(context.Background(), 10*time.Millisecond, 20, func(_ string, _ int) {
+		expired <- struct{}{}
+	})
+	require.NoError(t, err)
+	defer cache.Stop()
+
+	require.NoError(t, cache.Store("key", 1, 30*time.Millisecond))
+
+	lease, ok := cache.Acquire("key")
+	require.True(t, ok)
+	require.Equal(t, 1, lease.Value())
+
+	// The held lease keeps the value alive well beyond its TTL.
+	require.Never(t, func() bool {
+		select {
+		case <-expired:
+			return true
+		default:
+			return false
+		}
+	}, 90*time.Millisecond, 5*time.Millisecond)
+
+	lease.Release()
+
+	// Releasing the final lease restarts the idle timer, so it expires.
+	require.Eventually(t, func() bool {
+		select {
+		case <-expired:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 5*time.Millisecond)
+}
+
+func TestCacheConcurrentLeasesExpireAfterFinalRelease(t *testing.T) {
+	expired := make(chan struct{}, 1)
+	cache, err := NewCache(context.Background(), 10*time.Millisecond, 20, func(_ string, _ int) {
+		expired <- struct{}{}
+	})
+	require.NoError(t, err)
+	defer cache.Stop()
+
+	require.NoError(t, cache.Store("key", 1, 30*time.Millisecond))
+
+	first, ok := cache.Acquire("key")
+	require.True(t, ok)
+	second, ok := cache.Acquire("key")
+	require.True(t, ok)
+
+	first.Release()
+
+	// One lease remains, so the value must not expire.
+	require.Never(t, func() bool {
+		select {
+		case <-expired:
+			return true
+		default:
+			return false
+		}
+	}, 90*time.Millisecond, 5*time.Millisecond)
+
+	second.Release()
+
+	require.Eventually(t, func() bool {
+		select {
+		case <-expired:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 5*time.Millisecond)
+}
+
+func TestCacheReleaseIsIdempotent(t *testing.T) {
+	expired := make(chan struct{}, 1)
+	cache, err := NewCache(context.Background(), 10*time.Millisecond, 20, func(_ string, _ int) {
+		expired <- struct{}{}
+	})
+	require.NoError(t, err)
+	defer cache.Stop()
+
+	require.NoError(t, cache.Store("key", 1, 30*time.Millisecond))
+
+	first, ok := cache.Acquire("key")
+	require.True(t, ok)
+	second, ok := cache.Acquire("key")
+	require.True(t, ok)
+
+	// Releasing the same lease repeatedly must only drop one hold, leaving the
+	// value alive while the second lease is still held.
+	first.Release()
+	first.Release()
+
+	require.Never(t, func() bool {
+		select {
+		case <-expired:
+			return true
+		default:
+			return false
+		}
+	}, 90*time.Millisecond, 5*time.Millisecond)
+
+	second.Release()
+
+	require.Eventually(t, func() bool {
+		select {
+		case <-expired:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 5*time.Millisecond)
+}
+
+func TestCacheLoadAndDeletePreventsExpiration(t *testing.T) {
+	expired := make(chan struct{}, 1)
+	cache, err := NewCache(context.Background(), 10*time.Millisecond, 20, func(_ string, _ int) {
+		expired <- struct{}{}
+	})
+	require.NoError(t, err)
+	defer cache.Stop()
+
+	require.NoError(t, cache.Store("key", 1, 30*time.Millisecond))
+
+	lease, ok := cache.Acquire("key")
+	require.True(t, ok)
+
+	value, ok := cache.LoadAndDelete("key")
+	require.True(t, ok)
+	require.Equal(t, 1, value)
+
+	// Releasing a lease on a removed value must not reschedule or expire it.
+	lease.Release()
+
+	require.Never(t, func() bool {
+		select {
+		case <-expired:
+			return true
+		default:
+			return false
+		}
+	}, 90*time.Millisecond, 5*time.Millisecond)
+
+	_, ok = cache.Load("key")
+	require.False(t, ok)
+}
+
 func TestCacheDeletePreventsExpiration(t *testing.T) {
 	expired := make(chan struct{}, 1)
-	cache, err := NewCache(context.Background(), 10*time.Millisecond, 10, func(_ string, _ int) {
+	cache, err := NewCache(context.Background(), 10*time.Millisecond, 20, func(_ string, _ int) {
 		expired <- struct{}{}
 	})
 	require.NoError(t, err)
@@ -63,7 +213,7 @@ func TestCacheDeletePreventsExpiration(t *testing.T) {
 }
 
 func TestCacheInvalidTTLDoesNotStoreValue(t *testing.T) {
-	cache, err := NewCache(context.Background(), 10*time.Millisecond, 10, func(_ string, _ int) {})
+	cache, err := NewCache(context.Background(), 10*time.Millisecond, 20, func(_ string, _ int) {})
 	require.NoError(t, err)
 	defer cache.Stop()
 
@@ -99,7 +249,7 @@ func TestCacheOverwriteDoesNotExpireNewValue(t *testing.T) {
 	require.Equal(t, 2, value)
 }
 
-func TestCacheUpdateTTLRefreshesExpiration(t *testing.T) {
+func TestCacheLoadDoesNotLeaseValue(t *testing.T) {
 	expired := make(chan struct{}, 1)
 	cache, err := NewCache(context.Background(), 10*time.Millisecond, 20, func(_ string, _ int) {
 		expired <- struct{}{}
@@ -108,19 +258,11 @@ func TestCacheUpdateTTLRefreshesExpiration(t *testing.T) {
 	defer cache.Stop()
 
 	require.NoError(t, cache.Store("key", 1, 30*time.Millisecond))
-	time.Sleep(15 * time.Millisecond)
-	refreshed, err := cache.UpdateTTL("key", 80*time.Millisecond)
-	require.NoError(t, err)
-	require.True(t, refreshed)
 
-	require.Never(t, func() bool {
-		select {
-		case <-expired:
-			return true
-		default:
-			return false
-		}
-	}, 40*time.Millisecond, 5*time.Millisecond)
+	// A plain Load is a peek: it neither leases the value nor extends its TTL.
+	value, ok := cache.Load("key")
+	require.True(t, ok)
+	require.Equal(t, 1, value)
 
 	require.Eventually(t, func() bool {
 		select {
@@ -129,7 +271,7 @@ func TestCacheUpdateTTLRefreshesExpiration(t *testing.T) {
 		default:
 			return false
 		}
-	}, 150*time.Millisecond, 5*time.Millisecond)
+	}, time.Second, 5*time.Millisecond)
 }
 
 func TestCacheUpdateTTLReturnsFalseForMissingKey(t *testing.T) {

--- a/internal/ttl/cache_test.go
+++ b/internal/ttl/cache_test.go
@@ -24,7 +24,7 @@ func TestCacheExpiresUnleasedValue(t *testing.T) {
 		expired <- value
 	})
 	require.NoError(t, err)
-	defer cache.Stop()
+	defer cache.Close()
 
 	require.NoError(t, cache.Store("key", 1, 30*time.Millisecond))
 
@@ -47,7 +47,7 @@ func TestCacheActiveLeasePreventsExpiration(t *testing.T) {
 		expired <- struct{}{}
 	})
 	require.NoError(t, err)
-	defer cache.Stop()
+	defer cache.Close()
 
 	require.NoError(t, cache.Store("key", 1, 30*time.Millisecond))
 
@@ -84,7 +84,7 @@ func TestCacheConcurrentLeasesExpireAfterFinalRelease(t *testing.T) {
 		expired <- struct{}{}
 	})
 	require.NoError(t, err)
-	defer cache.Stop()
+	defer cache.Close()
 
 	require.NoError(t, cache.Store("key", 1, 30*time.Millisecond))
 
@@ -123,7 +123,7 @@ func TestCacheReleaseIsIdempotent(t *testing.T) {
 		expired <- struct{}{}
 	})
 	require.NoError(t, err)
-	defer cache.Stop()
+	defer cache.Close()
 
 	require.NoError(t, cache.Store("key", 1, 30*time.Millisecond))
 
@@ -164,7 +164,7 @@ func TestCacheLoadAndDeletePreventsExpiration(t *testing.T) {
 		expired <- struct{}{}
 	})
 	require.NoError(t, err)
-	defer cache.Stop()
+	defer cache.Close()
 
 	require.NoError(t, cache.Store("key", 1, 30*time.Millisecond))
 
@@ -197,7 +197,7 @@ func TestCacheDeletePreventsExpiration(t *testing.T) {
 		expired <- struct{}{}
 	})
 	require.NoError(t, err)
-	defer cache.Stop()
+	defer cache.Close()
 
 	require.NoError(t, cache.Store("key", 1, 10*time.Millisecond))
 	cache.Delete("key")
@@ -215,7 +215,7 @@ func TestCacheDeletePreventsExpiration(t *testing.T) {
 func TestCacheInvalidTTLDoesNotStoreValue(t *testing.T) {
 	cache, err := NewCache(context.Background(), 10*time.Millisecond, 20, func(_ string, _ int) {})
 	require.NoError(t, err)
-	defer cache.Stop()
+	defer cache.Close()
 
 	require.ErrorIs(t, cache.Store("key", 1, -time.Millisecond), ErrNegativeTTL)
 
@@ -229,7 +229,7 @@ func TestCacheOverwriteDoesNotExpireNewValue(t *testing.T) {
 		expired <- value
 	})
 	require.NoError(t, err)
-	defer cache.Stop()
+	defer cache.Close()
 
 	require.NoError(t, cache.Store("key", 1, 20*time.Millisecond))
 	time.Sleep(5 * time.Millisecond)
@@ -255,7 +255,7 @@ func TestCacheLoadDoesNotLeaseValue(t *testing.T) {
 		expired <- struct{}{}
 	})
 	require.NoError(t, err)
-	defer cache.Stop()
+	defer cache.Close()
 
 	require.NoError(t, cache.Store("key", 1, 30*time.Millisecond))
 
@@ -280,7 +280,7 @@ func TestCacheUpdateTTLRefreshesExpiration(t *testing.T) {
 		expired <- struct{}{}
 	})
 	require.NoError(t, err)
-	defer cache.Stop()
+	defer cache.Close()
 
 	require.NoError(t, cache.Store("key", 1, 30*time.Millisecond))
 	time.Sleep(15 * time.Millisecond)
@@ -314,7 +314,7 @@ func TestCacheUpdateTTLWhileLeasedAppliesAfterRelease(t *testing.T) {
 		expired <- struct{}{}
 	})
 	require.NoError(t, err)
-	defer cache.Stop()
+	defer cache.Close()
 
 	require.NoError(t, cache.Store("key", 1, 30*time.Millisecond))
 	lease, ok := cache.Acquire("key")
@@ -348,7 +348,7 @@ func TestCacheUpdateTTLWhileLeasedAppliesAfterRelease(t *testing.T) {
 func TestCacheUpdateTTLReturnsFalseForMissingKey(t *testing.T) {
 	cache, err := NewCache(context.Background(), 10*time.Millisecond, 20, func(_ string, _ int) {})
 	require.NoError(t, err)
-	defer cache.Stop()
+	defer cache.Close()
 
 	refreshed, err := cache.UpdateTTL("key", 80*time.Millisecond)
 

--- a/internal/ttl/cache_test.go
+++ b/internal/ttl/cache_test.go
@@ -1,0 +1,131 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package ttl
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCacheExpiresStoredValue(t *testing.T) {
+	expired := make(chan int, 1)
+	cache, err := NewCache(context.Background(), 10*time.Millisecond, 10, func(_ string, value int) {
+		expired <- value
+	})
+	require.NoError(t, err)
+	defer cache.Stop()
+
+	require.NoError(t, cache.Store("key", 1, 10*time.Millisecond))
+
+	require.Eventually(t, func() bool {
+		select {
+		case value := <-expired:
+			return value == 1
+		default:
+			return false
+		}
+	}, 200*time.Millisecond, 5*time.Millisecond)
+
+	_, ok := cache.Load("key")
+	require.False(t, ok)
+}
+
+func TestCacheDeletePreventsExpiration(t *testing.T) {
+	expired := make(chan struct{}, 1)
+	cache, err := NewCache(context.Background(), 10*time.Millisecond, 10, func(_ string, _ int) {
+		expired <- struct{}{}
+	})
+	require.NoError(t, err)
+	defer cache.Stop()
+
+	require.NoError(t, cache.Store("key", 1, 10*time.Millisecond))
+	cache.Delete("key")
+
+	require.Never(t, func() bool {
+		select {
+		case <-expired:
+			return true
+		default:
+			return false
+		}
+	}, 50*time.Millisecond, 5*time.Millisecond)
+}
+
+func TestCacheInvalidTTLDoesNotStoreValue(t *testing.T) {
+	cache, err := NewCache(context.Background(), 10*time.Millisecond, 10, func(_ string, _ int) {})
+	require.NoError(t, err)
+	defer cache.Stop()
+
+	require.ErrorIs(t, cache.Store("key", 1, -time.Millisecond), ErrNegativeTTL)
+
+	_, ok := cache.Load("key")
+	require.False(t, ok)
+}
+
+func TestCacheOverwriteDoesNotExpireNewValue(t *testing.T) {
+	expired := make(chan int, 2)
+	cache, err := NewCache(context.Background(), 10*time.Millisecond, 20, func(_ string, value int) {
+		expired <- value
+	})
+	require.NoError(t, err)
+	defer cache.Stop()
+
+	require.NoError(t, cache.Store("key", 1, 20*time.Millisecond))
+	time.Sleep(5 * time.Millisecond)
+	require.NoError(t, cache.Store("key", 2, 100*time.Millisecond))
+
+	require.Never(t, func() bool {
+		select {
+		case value := <-expired:
+			return value == 1
+		default:
+			return false
+		}
+	}, 50*time.Millisecond, 5*time.Millisecond)
+
+	value, ok := cache.Load("key")
+	require.True(t, ok)
+	require.Equal(t, 2, value)
+}
+
+func TestCacheUpdateTTLRefreshesExpiration(t *testing.T) {
+	expired := make(chan struct{}, 1)
+	cache, err := NewCache(context.Background(), 10*time.Millisecond, 20, func(_ string, _ int) {
+		expired <- struct{}{}
+	})
+	require.NoError(t, err)
+	defer cache.Stop()
+
+	require.NoError(t, cache.Store("key", 1, 30*time.Millisecond))
+	time.Sleep(15 * time.Millisecond)
+	require.NoError(t, cache.UpdateTTL("key", 80*time.Millisecond))
+
+	require.Never(t, func() bool {
+		select {
+		case <-expired:
+			return true
+		default:
+			return false
+		}
+	}, 40*time.Millisecond, 5*time.Millisecond)
+
+	require.Eventually(t, func() bool {
+		select {
+		case <-expired:
+			return true
+		default:
+			return false
+		}
+	}, 150*time.Millisecond, 5*time.Millisecond)
+}

--- a/internal/ttl/errors.go
+++ b/internal/ttl/errors.go
@@ -20,5 +20,6 @@ var (
 	// ErrNegativeTTL is returned when an entry is stored with a negative TTL.
 	ErrNegativeTTL = errors.New("ttl value can not be negative")
 	// ErrBeyondMaxTTL is returned when an entry TTL exceeds the wheel's maximum window.
-	ErrBeyondMaxTTL = errors.New("ttl larger than max allowed")
+	ErrBeyondMaxTTL      = errors.New("ttl larger than max allowed")
+	ErrInvalidExpireFunc = errors.New("invalid on expire function cant be nil")
 )

--- a/internal/ttl/errors.go
+++ b/internal/ttl/errors.go
@@ -1,0 +1,24 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package ttl
+
+import "github.com/sourcenetwork/defradb/errors"
+
+var (
+	// ErrInvalidSlotCount is returned when a wheel is configured with no slots.
+	ErrInvalidSlotCount = errors.New("invalid slot count, must be greater than 0")
+	// ErrInvalidTick is returned when a wheel is configured with no tick duration.
+	ErrInvalidTick = errors.New("invalid tick rate, must be greater than 0")
+	// ErrNegativeTTL is returned when an entry is stored with a negative TTL.
+	ErrNegativeTTL = errors.New("ttl value can not be negative")
+	// ErrBeyondMaxTTL is returned when an entry TTL exceeds the wheel's maximum window.
+	ErrBeyondMaxTTL = errors.New("ttl larger than max allowed")
+)

--- a/internal/ttl/wheel.go
+++ b/internal/ttl/wheel.go
@@ -1,0 +1,234 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package ttl
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// Wheel tracks comparable keys in a fixed-size timing wheel.
+type Wheel[K comparable] struct {
+	tick       time.Duration
+	slotCount  int64
+	cur        int64
+	slots      [][]*entry[K]
+	index      map[K]*entry[K]
+	maxTTL     int64
+	mu         sync.Mutex
+	running    bool
+	stop       chan struct{}
+	ctx        context.Context
+	expireFunc func(K)
+}
+
+type entry[K comparable] struct {
+	key  K
+	slot int64
+	idx  int64
+}
+
+// NewWheel returns a timing wheel with the given tick resolution and slot count.
+func NewWheel[K comparable](
+	ctx context.Context,
+	tick time.Duration,
+	slotCount int64,
+	onExpire func(K),
+) (*Wheel[K], error) {
+	if tick < 1 {
+		return nil, ErrInvalidTick
+	}
+	if slotCount < 1 {
+		return nil, ErrInvalidSlotCount
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return &Wheel[K]{
+		tick:       tick,
+		slotCount:  slotCount,
+		maxTTL:     int64(tick) * slotCount,
+		slots:      make([][]*entry[K], slotCount),
+		index:      make(map[K]*entry[K]),
+		stop:       make(chan struct{}),
+		ctx:        ctx,
+		expireFunc: onExpire,
+	}, nil
+}
+
+// Add tracks key until ttl has elapsed.
+func (w *Wheel[K]) Add(key K, ttl time.Duration) error {
+	if err := w.validTTL(ttl); err != nil {
+		return err
+	}
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	pos := w.slotForTTL(ttl)
+	if existing, ok := w.index[key]; ok {
+		w.unsafeDeleteFromSlot(existing)
+	}
+
+	e := &entry[K]{key: key, slot: pos}
+	w.slots[pos] = append(w.slots[pos], e)
+	e.idx = int64(len(w.slots[pos]) - 1)
+	w.index[key] = e
+	return nil
+}
+
+// Delete stops tracking key.
+func (w *Wheel[K]) Delete(key K) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	e, ok := w.index[key]
+	if !ok {
+		return
+	}
+
+	w.unsafeDeleteFromSlot(e)
+	delete(w.index, key)
+}
+
+// UpdateTTL moves an existing key to a new expiration time.
+func (w *Wheel[K]) UpdateTTL(key K, ttl time.Duration) error {
+	if err := w.validTTL(ttl); err != nil {
+		return err
+	}
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	e, ok := w.index[key]
+	if !ok {
+		return nil
+	}
+
+	newSlot := w.slotForTTL(ttl)
+	if newSlot == e.slot {
+		return nil
+	}
+
+	w.unsafeDeleteFromSlot(e)
+	e.slot = newSlot
+	w.slots[newSlot] = append(w.slots[newSlot], e)
+	e.idx = int64(len(w.slots[newSlot]) - 1)
+	w.index[key] = e
+	return nil
+}
+
+func (w *Wheel[K]) slotForTTL(ttl time.Duration) int64 {
+	if ttl == 0 {
+		return w.cur
+	}
+	ticks := int64(ttl / w.tick)
+	if ttl%w.tick != 0 {
+		ticks++
+	}
+	return (w.cur + ticks - 1) % w.slotCount
+}
+
+func (w *Wheel[K]) validTTL(ttl time.Duration) error {
+	if ttl < 0 {
+		return ErrNegativeTTL
+	}
+	if int64(ttl) > w.maxTTL {
+		return ErrBeyondMaxTTL
+	}
+	return nil
+}
+
+func (w *Wheel[K]) unsafeDeleteFromSlot(e *entry[K]) {
+	bucket := w.slots[e.slot]
+	lastIdx := int64(len(bucket) - 1)
+	if e.idx != lastIdx {
+		bucket[e.idx] = bucket[lastIdx]
+		bucket[e.idx].idx = e.idx
+	}
+	w.slots[e.slot] = bucket[:lastIdx]
+}
+
+// Start starts the wheel if it is not already running.
+func (w *Wheel[K]) Start() {
+	w.mu.Lock()
+	if w.running {
+		w.mu.Unlock()
+		return
+	}
+	w.running = true
+	stop := make(chan struct{})
+	w.stop = stop
+	tickDur := w.tick
+	w.mu.Unlock()
+
+	ticker := time.NewTicker(tickDur)
+	go func() {
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				w.tickOnce()
+			case <-w.ctx.Done():
+				w.setStopped(stop)
+				return
+			case <-stop:
+				w.setStopped(stop)
+				return
+			}
+		}
+	}()
+}
+
+// Stop stops the wheel if it is running.
+func (w *Wheel[K]) Stop() {
+	w.mu.Lock()
+	if !w.running {
+		w.mu.Unlock()
+		return
+	}
+	stop := w.stop
+	w.stop = nil
+	w.running = false
+	close(stop)
+	w.mu.Unlock()
+}
+
+func (w *Wheel[K]) setStopped(stop chan struct{}) {
+	w.mu.Lock()
+	if w.stop == stop {
+		w.stop = nil
+		w.running = false
+	}
+	w.mu.Unlock()
+}
+
+func (w *Wheel[K]) tickOnce() {
+	w.mu.Lock()
+	bucket := w.slots[w.cur]
+	w.slots[w.cur] = nil
+	expired := make([]K, 0, len(bucket))
+	for _, e := range bucket {
+		if w.index[e.key] == e {
+			delete(w.index, e.key)
+			expired = append(expired, e.key)
+		}
+	}
+	w.cur = (w.cur + 1) % w.slotCount
+	w.mu.Unlock()
+
+	for _, key := range expired {
+		if w.expireFunc != nil {
+			w.expireFunc(key)
+		}
+	}
+}

--- a/internal/ttl/wheel.go
+++ b/internal/ttl/wheel.go
@@ -70,7 +70,7 @@ func NewWheel[K comparable](
 
 // Add tracks key until ttl has elapsed.
 func (w *Wheel[K]) Add(key K, ttl time.Duration) error {
-	if err := w.validTTL(ttl); err != nil {
+	if err := w.ValidateTTL(ttl); err != nil {
 		return err
 	}
 
@@ -106,7 +106,7 @@ func (w *Wheel[K]) Delete(key K) {
 // UpdateTTL moves an existing key to a new expiration time.
 // It returns false if key was no longer tracked.
 func (w *Wheel[K]) UpdateTTL(key K, ttl time.Duration) (bool, error) {
-	if err := w.validTTL(ttl); err != nil {
+	if err := w.ValidateTTL(ttl); err != nil {
 		return false, err
 	}
 
@@ -142,7 +142,7 @@ func (w *Wheel[K]) slotForTTL(ttl time.Duration) int64 {
 	return (w.cur + ticks - 1) % w.slotCount
 }
 
-func (w *Wheel[K]) validTTL(ttl time.Duration) error {
+func (w *Wheel[K]) ValidateTTL(ttl time.Duration) error {
 	if ttl < 0 {
 		return ErrNegativeTTL
 	}

--- a/internal/ttl/wheel.go
+++ b/internal/ttl/wheel.go
@@ -51,9 +51,6 @@ func NewWheel[K comparable](
 	if slotCount < 1 {
 		return nil, ErrInvalidSlotCount
 	}
-	if ctx == nil {
-		ctx = context.Background()
-	}
 	if onExpire == nil {
 		return nil, ErrInvalidExpireFunc
 	}

--- a/internal/ttl/wheel.go
+++ b/internal/ttl/wheel.go
@@ -53,6 +53,9 @@ func NewWheel[K comparable](
 	if ctx == nil {
 		ctx = context.Background()
 	}
+	if onExpire == nil {
+		return nil, ErrInvalidExpireFunc
+	}
 	return &Wheel[K]{
 		tick:       tick,
 		slotCount:  slotCount,
@@ -228,8 +231,6 @@ func (w *Wheel[K]) tickOnce() {
 	w.mu.Unlock()
 
 	for _, key := range expired {
-		if w.expireFunc != nil {
-			w.expireFunc(key)
-		}
+		w.expireFunc(key)
 	}
 }

--- a/internal/ttl/wheel.go
+++ b/internal/ttl/wheel.go
@@ -25,8 +25,9 @@ type Wheel[K comparable] struct {
 	index      map[K]*entry[K]
 	maxTTL     int64
 	mu         sync.Mutex
-	running    bool
-	stop       chan struct{}
+	startOnce  sync.Once
+	closeOnce  sync.Once
+	done       chan struct{}
 	ctx        context.Context
 	expireFunc func(K)
 }
@@ -62,7 +63,7 @@ func NewWheel[K comparable](
 		maxTTL:     int64(tick) * slotCount,
 		slots:      make([][]*entry[K], slotCount),
 		index:      make(map[K]*entry[K]),
-		stop:       make(chan struct{}),
+		done:       make(chan struct{}),
 		ctx:        ctx,
 		expireFunc: onExpire,
 	}, nil
@@ -162,58 +163,40 @@ func (w *Wheel[K]) unsafeDeleteFromSlot(e *entry[K]) {
 	w.slots[e.slot] = bucket[:lastIdx]
 }
 
-// Start starts the wheel if it is not already running.
+// Start starts the wheel if it has not already started or closed.
 func (w *Wheel[K]) Start() {
-	w.mu.Lock()
-	if w.running {
-		w.mu.Unlock()
+	select {
+	case <-w.done:
 		return
+	case <-w.ctx.Done():
+		return
+	default:
 	}
-	w.running = true
-	stop := make(chan struct{})
-	w.stop = stop
-	tickDur := w.tick
-	w.mu.Unlock()
 
-	ticker := time.NewTicker(tickDur)
-	go func() {
-		defer ticker.Stop()
-		for {
-			select {
-			case <-ticker.C:
-				w.tickOnce()
-			case <-w.ctx.Done():
-				w.setStopped(stop)
-				return
-			case <-stop:
-				w.setStopped(stop)
-				return
+	w.startOnce.Do(func() {
+		ticker := time.NewTicker(w.tick)
+		go func() {
+			defer ticker.Stop()
+			for {
+				select {
+				case <-ticker.C:
+					w.tickOnce()
+				case <-w.ctx.Done():
+					w.Close()
+					return
+				case <-w.done:
+					return
+				}
 			}
-		}
-	}()
+		}()
+	})
 }
 
-// Stop stops the wheel if it is running.
-func (w *Wheel[K]) Stop() {
-	w.mu.Lock()
-	if !w.running {
-		w.mu.Unlock()
-		return
-	}
-	stop := w.stop
-	w.stop = nil
-	w.running = false
-	close(stop)
-	w.mu.Unlock()
-}
-
-func (w *Wheel[K]) setStopped(stop chan struct{}) {
-	w.mu.Lock()
-	if w.stop == stop {
-		w.stop = nil
-		w.running = false
-	}
-	w.mu.Unlock()
+// Close stops the wheel. A closed wheel cannot be restarted.
+func (w *Wheel[K]) Close() {
+	w.closeOnce.Do(func() {
+		close(w.done)
+	})
 }
 
 func (w *Wheel[K]) tickOnce() {

--- a/internal/ttl/wheel.go
+++ b/internal/ttl/wheel.go
@@ -101,9 +101,10 @@ func (w *Wheel[K]) Delete(key K) {
 }
 
 // UpdateTTL moves an existing key to a new expiration time.
-func (w *Wheel[K]) UpdateTTL(key K, ttl time.Duration) error {
+// It returns false if key was no longer tracked.
+func (w *Wheel[K]) UpdateTTL(key K, ttl time.Duration) (bool, error) {
 	if err := w.validTTL(ttl); err != nil {
-		return err
+		return false, err
 	}
 
 	w.mu.Lock()
@@ -111,12 +112,12 @@ func (w *Wheel[K]) UpdateTTL(key K, ttl time.Duration) error {
 
 	e, ok := w.index[key]
 	if !ok {
-		return nil
+		return false, nil
 	}
 
 	newSlot := w.slotForTTL(ttl)
 	if newSlot == e.slot {
-		return nil
+		return true, nil
 	}
 
 	w.unsafeDeleteFromSlot(e)
@@ -124,7 +125,7 @@ func (w *Wheel[K]) UpdateTTL(key K, ttl time.Duration) error {
 	w.slots[newSlot] = append(w.slots[newSlot], e)
 	e.idx = int64(len(w.slots[newSlot]) - 1)
 	w.index[key] = e
-	return nil
+	return true, nil
 }
 
 func (w *Wheel[K]) slotForTTL(ttl time.Duration) int64 {

--- a/internal/ttl/wheel_test.go
+++ b/internal/ttl/wheel_test.go
@@ -1,0 +1,112 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package ttl
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewWheelRejectsInvalidConfig(t *testing.T) {
+	wheel, err := NewWheel(context.Background(), 0, 1, func(string) {})
+	require.ErrorIs(t, err, ErrInvalidTick)
+	require.Nil(t, wheel)
+
+	wheel, err = NewWheel(context.Background(), time.Millisecond, 0, func(string) {})
+	require.ErrorIs(t, err, ErrInvalidSlotCount)
+	require.Nil(t, wheel)
+}
+
+func TestWheelRejectsInvalidTTL(t *testing.T) {
+	wheel, err := NewWheel(context.Background(), time.Millisecond, 10, func(string) {})
+	require.NoError(t, err)
+
+	require.ErrorIs(t, wheel.Add("negative", -time.Millisecond), ErrNegativeTTL)
+	require.ErrorIs(t, wheel.Add("beyond", 11*time.Millisecond), ErrBeyondMaxTTL)
+}
+
+func TestWheelExpiresExactlyMaxTTLAfterFullWindow(t *testing.T) {
+	expired := make(chan string, 1)
+	wheel, err := NewWheel(context.Background(), time.Millisecond, 3, func(key string) {
+		expired <- key
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, wheel.Add("key", 3*time.Millisecond))
+
+	wheel.tickOnce()
+	wheel.tickOnce()
+
+	select {
+	case key := <-expired:
+		t.Fatalf("key expired too early: %s", key)
+	default:
+	}
+
+	wheel.tickOnce()
+
+	select {
+	case key := <-expired:
+		require.Equal(t, "key", key)
+	default:
+		t.Fatal("expected key to expire")
+	}
+}
+
+func TestWheelUpdateTTL(t *testing.T) {
+	expired := make(chan string, 1)
+	wheel, err := NewWheel(context.Background(), time.Millisecond, 10, func(key string) {
+		expired <- key
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, wheel.Add("key", time.Millisecond))
+	require.NoError(t, wheel.UpdateTTL("key", 3*time.Millisecond))
+
+	wheel.tickOnce()
+	wheel.tickOnce()
+
+	select {
+	case key := <-expired:
+		t.Fatalf("key expired too early: %s", key)
+	default:
+	}
+
+	wheel.tickOnce()
+
+	select {
+	case key := <-expired:
+		require.Equal(t, "key", key)
+	default:
+		t.Fatal("expected key to expire")
+	}
+}
+
+func TestWheelDelete(t *testing.T) {
+	expired := make(chan string, 1)
+	wheel, err := NewWheel(context.Background(), time.Millisecond, 10, func(key string) {
+		expired <- key
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, wheel.Add("key", time.Millisecond))
+	wheel.Delete("key")
+	wheel.tickOnce()
+
+	select {
+	case key := <-expired:
+		t.Fatalf("deleted key expired: %s", key)
+	default:
+	}
+}

--- a/internal/ttl/wheel_test.go
+++ b/internal/ttl/wheel_test.go
@@ -122,3 +122,24 @@ func TestWheelDelete(t *testing.T) {
 	default:
 	}
 }
+
+func TestWheelClosePreventsStart(t *testing.T) {
+	expired := make(chan string, 1)
+	wheel, err := NewWheel(context.Background(), time.Millisecond, 1, func(key string) {
+		expired <- key
+	})
+	require.NoError(t, err)
+
+	wheel.Close()
+	wheel.Start()
+	require.NoError(t, wheel.Add("key", time.Millisecond))
+
+	require.Never(t, func() bool {
+		select {
+		case <-expired:
+			return true
+		default:
+			return false
+		}
+	}, 20*time.Millisecond, time.Millisecond)
+}

--- a/internal/ttl/wheel_test.go
+++ b/internal/ttl/wheel_test.go
@@ -72,7 +72,9 @@ func TestWheelUpdateTTL(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NoError(t, wheel.Add("key", time.Millisecond))
-	require.NoError(t, wheel.UpdateTTL("key", 3*time.Millisecond))
+	refreshed, err := wheel.UpdateTTL("key", 3*time.Millisecond)
+	require.NoError(t, err)
+	require.True(t, refreshed)
 
 	wheel.tickOnce()
 	wheel.tickOnce()
@@ -91,6 +93,16 @@ func TestWheelUpdateTTL(t *testing.T) {
 	default:
 		t.Fatal("expected key to expire")
 	}
+}
+
+func TestWheelUpdateTTLReturnsFalseForMissingKey(t *testing.T) {
+	wheel, err := NewWheel(context.Background(), time.Millisecond, 10, func(string) {})
+	require.NoError(t, err)
+
+	refreshed, err := wheel.UpdateTTL("key", time.Millisecond)
+
+	require.NoError(t, err)
+	require.False(t, refreshed)
 }
 
 func TestWheelDelete(t *testing.T) {

--- a/node/node.go
+++ b/node/node.go
@@ -58,6 +58,8 @@ type Node struct {
 	peer Peer
 	// api http server instance
 	server *http.Server
+	// apiHandler is the HTTP API handler.
+	apiHandler *http.Handler
 	// opts is the resolved options
 	opts *options.NodeOptions
 	// the URL the API is served at.
@@ -120,7 +122,10 @@ func DefaultNodeOptions() options.NodeOptions {
 		},
 		P2P: options.NodeP2POptions{},
 		HTTP: options.NodeHTTPOptions{
-			Address: http.DefaultHTTPAddress,
+			Address:       http.DefaultHTTPAddress,
+			TxnTTL:        http.DefaultTxnTTL,
+			TxnTTLTick:    http.DefaultTxnTTLTick,
+			TxnTTLBuckets: http.DefaultTxnTTLBuckets,
 		},
 	}
 }
@@ -187,6 +192,9 @@ func (n *Node) Close(ctx context.Context) error {
 	var err error
 	if n.server != nil {
 		err = n.server.Shutdown(ctx)
+	}
+	if n.apiHandler != nil {
+		n.apiHandler.Close()
 	}
 	if n.peer != nil {
 		n.peer.Close()

--- a/node/node_api.go
+++ b/node/node_api.go
@@ -30,6 +30,7 @@ func (n *Node) startAPI(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	n.apiHandler = handler
 
 	n.server, err = http.NewServer(handler, options.NodeHTTP().SetAll(n.opts.HTTP))
 	if err != nil {

--- a/tests/clients/cli/wrapper.go
+++ b/tests/clients/cli/wrapper.go
@@ -816,6 +816,7 @@ func (w *Wrapper) NewTxn(readOnly bool) (client.Txn, error) {
 func (w *Wrapper) Close() {
 	w.serverCancel()
 	w.httpServer.Close()
+	w.handler.Close()
 	_ = w.node.Close(context.Background())
 }
 

--- a/tests/clients/http/wrapper.go
+++ b/tests/clients/http/wrapper.go
@@ -401,14 +401,16 @@ func (w *Wrapper) NewTxn(readOnly bool) (client.Txn, error) {
 	}
 	serverTxn, err := w.handler.Transaction(clientTxn.ID())
 	if err != nil {
+		clientTxn.Discard()
 		return nil, err
 	}
-	return &Transaction{w, serverTxn}, nil
+	return &Transaction{Wrapper: w, clientTxn: clientTxn, txn: serverTxn}, nil
 }
 
 func (w *Wrapper) Close() {
 	w.serverCancel()
 	w.httpServer.Close()
+	w.handler.Close()
 	_ = w.node.Close(context.Background())
 }
 

--- a/tests/clients/http/wrapper_tx.go
+++ b/tests/clients/http/wrapper_tx.go
@@ -31,11 +31,12 @@ var _ client.Txn = (*Transaction)(nil)
 // a single struct that implements the client.Txn interface.
 type Transaction struct {
 	*Wrapper
-	txn client.Txn
+	clientTxn client.Txn
+	txn       client.Txn
 }
 
 func (txn *Transaction) ID() uint64 {
-	return txn.txn.ID()
+	return txn.clientTxn.ID()
 }
 
 func (txn *Transaction) StartTS() time.Time {
@@ -43,11 +44,11 @@ func (txn *Transaction) StartTS() time.Time {
 }
 
 func (txn *Transaction) Commit() error {
-	return txn.txn.Commit()
+	return txn.clientTxn.Commit()
 }
 
 func (txn *Transaction) Discard() {
-	txn.txn.Discard()
+	txn.clientTxn.Discard()
 }
 
 func (txn *Transaction) PrintDump(ctx context.Context) error {

--- a/tests/integration/db_setup.go
+++ b/tests/integration/db_setup.go
@@ -59,6 +59,9 @@ func setupNode(
 		opts = defaultNodeOpts()
 	}
 	opts.DB().SetEnableSigning(testCase.EnableSigning)
+	if testCase.HTTP.HasValue() {
+		applyHTTPOptions(opts, testCase.HTTP.Value())
+	}
 
 	if s.EnableSearchableEncryption {
 		seKey, err := crypto.GenerateAES256()

--- a/tests/integration/db_setup_js.go
+++ b/tests/integration/db_setup_js.go
@@ -38,6 +38,9 @@ func setupNode(
 	opts.DB().
 		SetEnableSigning(testCase.EnableSigning).
 		SetLensRuntime(options.NodeJSLensRuntime)
+	if testCase.HTTP.HasValue() {
+		applyHTTPOptions(opts, testCase.HTTP.Value())
+	}
 	// Note: Since we are hard-coding to run with badger in-mem only, we have a function that
 	// handles some edge-cases by skipping js client testing when a db type is something else.
 	// If this hard-coding is changed in future, don't forget to tweak the following func:

--- a/tests/integration/mutation/add/txn_discard_test.go
+++ b/tests/integration/mutation/add/txn_discard_test.go
@@ -61,7 +61,7 @@ func TestMutationAdd_AddAfterDiscard(t *testing.T) {
 				},
 				// This error will occur if the commit txn action completes before the add document action.
 				// It should not impact the test execution.
-				ExpectedError: "transaction not found",
+				ExpectedError: "missing or expired transaction",
 			},
 			&action.Request{
 				Request: `

--- a/tests/integration/mutation/add/txn_discard_test.go
+++ b/tests/integration/mutation/add/txn_discard_test.go
@@ -61,7 +61,7 @@ func TestMutationAdd_AddAfterDiscard(t *testing.T) {
 				},
 				// This error will occur if the commit txn action completes before the add document action.
 				// It should not impact the test execution.
-				ExpectedError: "missing or expired transaction",
+				ExpectedError: "transaction not found",
 			},
 			&action.Request{
 				Request: `

--- a/tests/integration/mutation/update/concurrent_test.go
+++ b/tests/integration/mutation/update/concurrent_test.go
@@ -136,7 +136,7 @@ func TestMutationUpdate_ConcurrentCommit(t *testing.T) {
 					}`,
 					// This error will occur if the commit txn action completes before the update document action.
 					// It should not impact the test execution.
-					IgnoreError: "transaction not found",
+					IgnoreError: "missing or expired transaction",
 				},
 			},
 			&action.Async{
@@ -218,7 +218,7 @@ func TestMutationUpdate_ConcurrentDiscard(t *testing.T) {
 					},
 					// This error will occur if the commit txn action completes before the add document action.
 					// It should not impact the test execution.
-					IgnoreError: "transaction not found",
+					IgnoreError: "missing or expired transaction",
 				},
 			},
 			&action.Async{

--- a/tests/integration/mutation/update/concurrent_test.go
+++ b/tests/integration/mutation/update/concurrent_test.go
@@ -136,7 +136,7 @@ func TestMutationUpdate_ConcurrentCommit(t *testing.T) {
 					}`,
 					// This error will occur if the commit txn action completes before the update document action.
 					// It should not impact the test execution.
-					IgnoreError: "missing or expired transaction",
+					IgnoreError: "transaction not found",
 				},
 			},
 			&action.Async{
@@ -218,7 +218,7 @@ func TestMutationUpdate_ConcurrentDiscard(t *testing.T) {
 					},
 					// This error will occur if the commit txn action completes before the add document action.
 					// It should not impact the test execution.
-					IgnoreError: "missing or expired transaction",
+					IgnoreError: "transaction not found",
 				},
 			},
 			&action.Async{

--- a/tests/integration/test_case.go
+++ b/tests/integration/test_case.go
@@ -66,6 +66,9 @@ type TestCase struct {
 	// differences between database types, or we need to temporarily document a bug.
 	SupportedDatabaseTypes immutable.Option[[]state.DatabaseType]
 
+	// HTTP configures the test node HTTP API behavior.
+	HTTP immutable.Option[options.NodeHTTPOptions]
+
 	// Configuration for KMS to be used in the test
 	KMS KMS
 
@@ -127,6 +130,40 @@ type SetupComplete struct{}
 // If the action has a `NodeID` property and it is not specified, the action will be
 // effected on all nodes.
 type ConfigureNode func() options.NodeP2POptions
+
+func applyHTTPOptions(opts *options.NodeOptionsBuilder, httpOpts options.NodeHTTPOptions) {
+	httpBuilder := opts.HTTP()
+	if httpOpts.Address != "" {
+		httpBuilder.SetAddress(httpOpts.Address)
+	}
+	if len(httpOpts.AllowedOrigins) > 0 {
+		httpBuilder.SetAllowedOrigins(httpOpts.AllowedOrigins...)
+	}
+	if httpOpts.TLSCertPath != "" {
+		httpBuilder.SetCertPath(httpOpts.TLSCertPath)
+	}
+	if httpOpts.TLSKeyPath != "" {
+		httpBuilder.SetKeyPath(httpOpts.TLSKeyPath)
+	}
+	if httpOpts.ReadTimeout != 0 {
+		httpBuilder.SetReadTimeout(httpOpts.ReadTimeout)
+	}
+	if httpOpts.WriteTimeout != 0 {
+		httpBuilder.SetWriteTimeout(httpOpts.WriteTimeout)
+	}
+	if httpOpts.IdleTimeout != 0 {
+		httpBuilder.SetIdleTimeout(httpOpts.IdleTimeout)
+	}
+	if httpOpts.TxnTTL != 0 {
+		httpBuilder.SetTxnTTL(httpOpts.TxnTTL)
+	}
+	if httpOpts.TxnTTLTick != 0 {
+		httpBuilder.SetTxnTTLTick(httpOpts.TxnTTLTick)
+	}
+	if httpOpts.TxnTTLBuckets != 0 {
+		httpBuilder.SetTxnTTLBuckets(httpOpts.TxnTTLBuckets)
+	}
+}
 
 // Restart is an action that will close and then start all nodes.
 type Restart struct{}

--- a/tests/integration/txn/ttl_test.go
+++ b/tests/integration/txn/ttl_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/sourcenetwork/immutable"
 
+	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/options"
 	"github.com/sourcenetwork/defradb/tests/action"
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
@@ -28,10 +29,6 @@ func TestTxnTTL_GivenIdleHTTPTransaction_DiscardsTransaction(t *testing.T) {
 		SupportedClientTypes: immutable.Some([]state.ClientType{
 			state.HTTPClientType,
 			state.CLIClientType,
-		}),
-		SupportedDatabaseTypes: immutable.Some([]state.DatabaseType{
-			testUtils.BadgerIMType,
-			testUtils.DefraIMType,
 		}),
 		HTTP: immutable.Some(options.NodeHTTPOptions{
 			TxnTTL:        120 * time.Millisecond,
@@ -101,6 +98,338 @@ func TestTxnTTL_GivenIdleHTTPTransaction_DiscardsTransaction(t *testing.T) {
 						},
 					},
 				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestTxnTTL_GivenHTTPTransactionActivity_ExtendsTTL(t *testing.T) {
+	test := testUtils.TestCase{
+		SupportedClientTypes: immutable.Some([]state.ClientType{
+			state.HTTPClientType,
+			state.CLIClientType,
+		}),
+		HTTP: immutable.Some(options.NodeHTTPOptions{
+			TxnTTL:        500 * time.Millisecond,
+			TxnTTLTick:    50 * time.Millisecond,
+			TxnTTLBuckets: 20,
+		}),
+		SkipChangeDetector: true,
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type Users {
+						name: String
+						age: Int
+					}
+				`,
+			},
+			&action.AddDoc{
+				Doc: `{
+					"name": "John",
+					"age": 27
+				}`,
+			},
+			&action.Request{
+				TransactionID: immutable.Some(1),
+				Request: `mutation {
+					update_Users(filter: {name: {_eq: "John"}}, input: {age: 28}) {
+						name
+						age
+					}
+				}`,
+				Results: map[string]any{
+					"update_Users": []map[string]any{
+						{
+							"name": "John",
+							"age":  int64(28),
+						},
+					},
+				},
+			},
+			&action.Wait{
+				Duration: immutable.Some(300 * time.Millisecond),
+			},
+			&action.Request{
+				TransactionID: immutable.Some(1),
+				Request: `mutation {
+					update_Users(filter: {name: {_eq: "John"}}, input: {age: 29}) {
+						name
+						age
+					}
+				}`,
+				Results: map[string]any{
+					"update_Users": []map[string]any{
+						{
+							"name": "John",
+							"age":  int64(29),
+						},
+					},
+				},
+			},
+			&action.Wait{
+				Duration: immutable.Some(300 * time.Millisecond),
+			},
+			&action.Request{
+				TransactionID: immutable.Some(1),
+				Request: `
+					query {
+						Users {
+							name
+							age
+						}
+					}
+				`,
+				Results: map[string]any{
+					"Users": []map[string]any{
+						{
+							"name": "John",
+							"age":  int64(29),
+						},
+					},
+				},
+			},
+			&action.CommitTransaction{
+				TransactionID: 1,
+			},
+			&action.Request{
+				Request: `
+					query {
+						Users {
+							name
+							age
+						}
+					}
+				`,
+				Results: map[string]any{
+					"Users": []map[string]any{
+						{
+							"name": "John",
+							"age":  int64(29),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestTxnTTL_GivenCommittedHTTPTransaction_RemovesCacheEntry(t *testing.T) {
+	test := testUtils.TestCase{
+		SupportedClientTypes: immutable.Some([]state.ClientType{
+			state.HTTPClientType,
+			state.CLIClientType,
+		}),
+		HTTP: immutable.Some(options.NodeHTTPOptions{
+			TxnTTL:        500 * time.Millisecond,
+			TxnTTLTick:    50 * time.Millisecond,
+			TxnTTLBuckets: 20,
+		}),
+		SkipChangeDetector: true,
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type Users {
+						name: String
+						age: Int
+					}
+				`,
+			},
+			&action.AddDoc{
+				Doc: `{
+					"name": "John",
+					"age": 27
+				}`,
+			},
+			&action.Request{
+				TransactionID: immutable.Some(1),
+				Request: `mutation {
+					update_Users(filter: {name: {_eq: "John"}}, input: {age: 28}) {
+						name
+						age
+					}
+				}`,
+				Results: map[string]any{
+					"update_Users": []map[string]any{
+						{
+							"name": "John",
+							"age":  int64(28),
+						},
+					},
+				},
+			},
+			&action.CommitTransaction{
+				TransactionID: 1,
+			},
+			&action.Request{
+				TransactionID: immutable.Some(1),
+				Request: `
+					query {
+						Users {
+							name
+							age
+						}
+					}
+				`,
+				ExpectedError: "missing or expired transaction",
+			},
+			&action.Wait{
+				Duration: immutable.Some(600 * time.Millisecond),
+			},
+			&action.Request{
+				Request: `
+					query {
+						Users {
+							name
+							age
+						}
+					}
+				`,
+				Results: map[string]any{
+					"Users": []map[string]any{
+						{
+							"name": "John",
+							"age":  int64(28),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestTxnTTL_GivenDiscardedHTTPTransaction_RemovesCacheEntry(t *testing.T) {
+	test := testUtils.TestCase{
+		SupportedClientTypes: immutable.Some([]state.ClientType{
+			state.HTTPClientType,
+			state.CLIClientType,
+		}),
+		HTTP: immutable.Some(options.NodeHTTPOptions{
+			TxnTTL:        500 * time.Millisecond,
+			TxnTTLTick:    50 * time.Millisecond,
+			TxnTTLBuckets: 20,
+		}),
+		SkipChangeDetector: true,
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type Users {
+						name: String
+						age: Int
+					}
+				`,
+			},
+			&action.AddDoc{
+				Doc: `{
+					"name": "John",
+					"age": 27
+				}`,
+			},
+			&action.Request{
+				TransactionID: immutable.Some(1),
+				Request: `mutation {
+					update_Users(filter: {name: {_eq: "John"}}, input: {age: 28}) {
+						name
+						age
+					}
+				}`,
+				Results: map[string]any{
+					"update_Users": []map[string]any{
+						{
+							"name": "John",
+							"age":  int64(28),
+						},
+					},
+				},
+			},
+			&action.DiscardTransaction{
+				TransactionID: 1,
+			},
+			&action.Request{
+				TransactionID: immutable.Some(1),
+				Request: `
+					query {
+						Users {
+							name
+							age
+						}
+					}
+				`,
+				ExpectedError: "missing or expired transaction",
+			},
+			&action.Wait{
+				Duration: immutable.Some(600 * time.Millisecond),
+			},
+			&action.Request{
+				Request: `
+					query {
+						Users {
+							name
+							age
+						}
+					}
+				`,
+				Results: map[string]any{
+					"Users": []map[string]any{
+						{
+							"name": "John",
+							"age":  int64(27),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestTxnTTL_GivenExpiredHTTPTransaction_OnGetCollections_ReturnsNonGraphQLError(t *testing.T) {
+	test := testUtils.TestCase{
+		SupportedClientTypes: immutable.Some([]state.ClientType{
+			state.HTTPClientType,
+			state.CLIClientType,
+		}),
+		HTTP: immutable.Some(options.NodeHTTPOptions{
+			TxnTTL:        500 * time.Millisecond,
+			TxnTTLTick:    50 * time.Millisecond,
+			TxnTTLBuckets: 20,
+		}),
+		SkipChangeDetector: true,
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type Users {
+						name: String
+						age: Int
+					}
+				`,
+			},
+			&action.GetCollections{
+				TransactionID: immutable.Some(1),
+				FilterOptions: options.GetCollections(),
+				ExpectedResults: []client.CollectionVersion{
+					{
+						Name:           "Users",
+						VersionID:      "bafyreihsneodeja4lfer5puptim3lkwvketyckrmkhfpgxm67ch5wenjwq",
+						IsMaterialized: true,
+						IsActive:       true,
+					},
+				},
+			},
+			&action.Wait{
+				Duration: immutable.Some(600 * time.Millisecond),
+			},
+			&action.GetCollections{
+				TransactionID: immutable.Some(1),
+				FilterOptions: options.GetCollections(),
+				ExpectedError: "missing or expired transaction",
 			},
 		},
 	}

--- a/tests/integration/txn/ttl_test.go
+++ b/tests/integration/txn/ttl_test.go
@@ -79,7 +79,7 @@ func TestTxnTTL_GivenIdleHTTPTransaction_DiscardsTransaction(t *testing.T) {
 						age
 					}
 				}`,
-				ExpectedError: "missing or expired transaction",
+				ExpectedError: "transaction not found",
 			},
 			&action.Request{
 				Request: `
@@ -275,7 +275,7 @@ func TestTxnTTL_GivenCommittedHTTPTransaction_RemovesCacheEntry(t *testing.T) {
 						}
 					}
 				`,
-				ExpectedError: "missing or expired transaction",
+				ExpectedError: "transaction not found",
 			},
 			&action.Wait{
 				Duration: immutable.Some(600 * time.Millisecond),
@@ -361,7 +361,7 @@ func TestTxnTTL_GivenDiscardedHTTPTransaction_RemovesCacheEntry(t *testing.T) {
 						}
 					}
 				`,
-				ExpectedError: "missing or expired transaction",
+				ExpectedError: "transaction not found",
 			},
 			&action.Wait{
 				Duration: immutable.Some(600 * time.Millisecond),
@@ -429,7 +429,7 @@ func TestTxnTTL_GivenExpiredHTTPTransaction_OnGetCollections_ReturnsNonGraphQLEr
 			&action.GetCollections{
 				TransactionID: immutable.Some(1),
 				FilterOptions: options.GetCollections(),
-				ExpectedError: "missing or expired transaction",
+				ExpectedError: "transaction not found",
 			},
 		},
 	}

--- a/tests/integration/txn/ttl_test.go
+++ b/tests/integration/txn/ttl_test.go
@@ -1,0 +1,109 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// This file is part of the DefraDB test suite.
+//
+// The DefraDB test suite is licensed under either:
+//
+//   (1) GNU Affero General Public License v3
+//   (2) Business Source License 1.1
+//
+// See tests/LICENSE for details.
+
+package txn_testing
+
+import (
+	"testing"
+	"time"
+
+	"github.com/sourcenetwork/immutable"
+
+	"github.com/sourcenetwork/defradb/client/options"
+	"github.com/sourcenetwork/defradb/tests/action"
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	"github.com/sourcenetwork/defradb/tests/state"
+)
+
+func TestTxnTTL_GivenIdleHTTPTransaction_DiscardsTransaction(t *testing.T) {
+	test := testUtils.TestCase{
+		SupportedClientTypes: immutable.Some([]state.ClientType{
+			state.HTTPClientType,
+			state.CLIClientType,
+		}),
+		SupportedDatabaseTypes: immutable.Some([]state.DatabaseType{
+			testUtils.BadgerIMType,
+			testUtils.DefraIMType,
+		}),
+		HTTP: immutable.Some(options.NodeHTTPOptions{
+			TxnTTL:        120 * time.Millisecond,
+			TxnTTLTick:    20 * time.Millisecond,
+			TxnTTLBuckets: 10,
+		}),
+		SkipChangeDetector: true,
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type Users {
+						name: String
+						age: Int
+					}
+				`,
+			},
+			&action.AddDoc{
+				Doc: `{
+					"name": "John",
+					"age": 27
+				}`,
+			},
+			&action.Request{
+				TransactionID: immutable.Some(1),
+				Request: `mutation {
+					update_Users(filter: {name: {_eq: "John"}}, input: {age: 28}) {
+						name
+						age
+					}
+				}`,
+				Results: map[string]any{
+					"update_Users": []map[string]any{
+						{
+							"name": "John",
+							"age":  int64(28),
+						},
+					},
+				},
+			},
+			&action.Wait{
+				Duration: immutable.Some(300 * time.Millisecond),
+			},
+			&action.Request{
+				TransactionID: immutable.Some(1),
+				Request: `mutation {
+					update_Users(filter: {name: {_eq: "John"}}, input: {age: 29}) {
+						name
+						age
+					}
+				}`,
+				ExpectedError: "missing or expired transaction",
+			},
+			&action.Request{
+				Request: `
+					query {
+						Users {
+							name
+							age
+						}
+					}
+				`,
+				Results: map[string]any{
+					"Users": []map[string]any{
+						{
+							"name": "John",
+							"age":  int64(27),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/txn/ttl_test.go
+++ b/tests/integration/txn/ttl_test.go
@@ -31,8 +31,8 @@ func TestTxnTTL_GivenIdleHTTPTransaction_DiscardsTransaction(t *testing.T) {
 			state.CLIClientType,
 		}),
 		HTTP: immutable.Some(options.NodeHTTPOptions{
-			TxnTTL:        120 * time.Millisecond,
-			TxnTTLTick:    20 * time.Millisecond,
+			TxnTTL:        300 * time.Millisecond,
+			TxnTTLTick:    50 * time.Millisecond,
 			TxnTTLBuckets: 10,
 		}),
 		SkipChangeDetector: true,
@@ -69,7 +69,7 @@ func TestTxnTTL_GivenIdleHTTPTransaction_DiscardsTransaction(t *testing.T) {
 				},
 			},
 			&action.Wait{
-				Duration: immutable.Some(300 * time.Millisecond),
+				Duration: immutable.Some(900 * time.Millisecond),
 			},
 			&action.Request{
 				TransactionID: immutable.Some(1),
@@ -397,7 +397,7 @@ func TestTxnTTL_GivenExpiredHTTPTransaction_OnGetCollections_ReturnsNonGraphQLEr
 			state.CLIClientType,
 		}),
 		HTTP: immutable.Some(options.NodeHTTPOptions{
-			TxnTTL:        500 * time.Millisecond,
+			TxnTTL:        300 * time.Millisecond,
 			TxnTTLTick:    50 * time.Millisecond,
 			TxnTTLBuckets: 20,
 		}),
@@ -424,7 +424,7 @@ func TestTxnTTL_GivenExpiredHTTPTransaction_OnGetCollections_ReturnsNonGraphQLEr
 				},
 			},
 			&action.Wait{
-				Duration: immutable.Some(600 * time.Millisecond),
+				Duration: immutable.Some(900 * time.Millisecond),
 			},
 			&action.GetCollections{
 				TransactionID: immutable.Some(1),


### PR DESCRIPTION
## Relevant issue(s)

This PR supercedes #4271 which had drastically drifted from develop, so this is a clean reimplementation on top of the the latest develop

Resolves https://github.com/sourcenetwork/defradb/issues/4222 

Description
This adds a TTLCache to the HTTP API Transaction middleware so that HTTP transactions are gated by a timeout and will automatically discard after the timeout has elapsed. 

~~Currently this only refreshes the TTL timeout at the *start* of a transaction, so long transactions (eg large queries) have the (likely) possibility of expiring and therefore discarding during a long lived request. I am implementing this in a follow up PR before v1 (small quick change, but wanted to do it in parallel to the review of this PR).~~ This has been implemented in this PR in the 6f8b0a73224cf1c9bf234186d596746a06a0a765 commit

## How has this been tested?

Manual, unit tests, integration tests

Specify the platform(s) on which this was tested:
- Linux NixOS
