### PR TITLE
fix: Fix duplicate relation groupBy

### DIFF
--- a/internal/planner/mapper/mapper.go
+++ b/internal/planner/mapper/mapper.go
@@ -212,7 +212,13 @@ func toSelect(
 
 	// Resolve groupBy mappings i.e. alias remapping and handle missed inner group.
 	if selectRequest.GroupBy.HasValue() {
-		groupByFields := selectRequest.GroupBy.Value().Fields
+		// Copy the groupBy fields before remapping rather than rewriting them in
+		// place. The original slice is shared with the caller's request select (and
+		// any copy taken of it, e.g. for duplicate detection in getRequestables), so
+		// mutating it here would retroactively change those values.
+		originalFields := selectRequest.GroupBy.Value().Fields
+		groupByFields := make([]string, len(originalFields))
+		copy(groupByFields, originalFields)
 		// Remap all alias field names to use their internal field name mappings.
 		for index, groupByField := range groupByFields {
 			fieldDesc, ok := definition.GetFieldByName(groupByField)

--- a/internal/planner/mapper/mapper.go
+++ b/internal/planner/mapper/mapper.go
@@ -888,6 +888,11 @@ func getRequestables(
 	collectionName string,
 	store client.TxnStore,
 ) (fields []Requestable, aggregates []*aggregateRequest, err error) {
+	// Tracks relation selects already mapped in this selection set so that an
+	// identical relation field is collapsed onto the first occurrence, mirroring
+	// how duplicate scalar fields collapse onto their first index. Without this a
+	// duplicate relation manufactures a redundant join over the same root scan.
+	seenSelects := []*request.Select{}
 	for _, field := range selectRequest.Fields {
 		switch f := field.(type) {
 		case *request.Field:
@@ -906,6 +911,19 @@ func getRequestables(
 				Key:   getRenderKey(f),
 			})
 		case *request.Select:
+			// Collapse identical duplicate relation selects onto the first one.
+			isDuplicate := false
+			for _, seen := range seenSelects {
+				if reflect.DeepEqual(seen, f) {
+					isDuplicate = true
+					break
+				}
+			}
+			if isDuplicate {
+				continue
+			}
+			seenSelects = append(seenSelects, f)
+
 			index := mapping.GetNextIndex()
 
 			innerSelect, err := toSelect(ctx, store, collectionRepository, rootSelectType, index, f, collectionName)

--- a/internal/planner/mapper/mapper.go
+++ b/internal/planner/mapper/mapper.go
@@ -892,7 +892,7 @@ func getRequestables(
 	// identical relation field is collapsed onto the first occurrence, mirroring
 	// how duplicate scalar fields collapse onto their first index. Without this a
 	// duplicate relation manufactures a redundant join over the same root scan.
-	seenSelects := []*request.Select{}
+	seenSelects := []request.Select{}
 	for _, field := range selectRequest.Fields {
 		switch f := field.(type) {
 		case *request.Field:
@@ -914,7 +914,7 @@ func getRequestables(
 			// Collapse identical duplicate relation selects onto the first one.
 			isDuplicate := false
 			for _, seen := range seenSelects {
-				if reflect.DeepEqual(seen, f) {
+				if reflect.DeepEqual(seen, *f) {
 					isDuplicate = true
 					break
 				}
@@ -922,7 +922,7 @@ func getRequestables(
 			if isDuplicate {
 				continue
 			}
-			seenSelects = append(seenSelects, f)
+			seenSelects = append(seenSelects, *f)
 
 			index := mapping.GetNextIndex()
 

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -756,6 +756,8 @@ func (p *Planner) walkAndReplacePlan(planNode, target, replace planNode) error {
 		node.replaceRoot(replace)
 	case *typeJoinMany:
 		node.replaceRoot(replace)
+	case *multiScanNode:
+		node.planNode = replace
 	case *pipeNode:
 		/* Do nothing - pipe nodes should not be replaced */
 	// @todo: add more nodes that apply here

--- a/tests/integration/query/one_to_many/with_group_test.go
+++ b/tests/integration/query/one_to_many/with_group_test.go
@@ -340,18 +340,6 @@ func TestQueryOneToManyWithParentGroupByOnRelationAndDuplicateRelationSelection(
 	executeTestCase(t, test)
 }
 
-// A relation selected twice identically must collapse onto a single join, even
-// when the duplicated relation carries its own groupBy on a relation field.
-//
-// This is the case CodeRabbit flagged: toSelect rewrites the inner groupBy
-// (`author` -> `author_id`) in place while processing the first `published`,
-// which mutates the value the duplicate-detection compares against, so the
-// second identical `published` is no longer recognised as a duplicate.
-//
-// The correct, de-duplicated plan is a single typeJoinMany over a plain
-// scanNode. If the duplicate is missed, the plan is instead a parallelNode of
-// two typeJoinMany, each over a multiScanNode (the shared-scan artifact). The
-// debug-explain assertion below pins the de-duplicated shape.
 func TestQueryOneToManyWithDuplicateRelationSelectionEachWithInnerGroupByOnRelation(t *testing.T) {
 	test := testUtils.TestCase{
 		Actions: []any{

--- a/tests/integration/query/one_to_many/with_group_test.go
+++ b/tests/integration/query/one_to_many/with_group_test.go
@@ -340,6 +340,92 @@ func TestQueryOneToManyWithParentGroupByOnRelationAndDuplicateRelationSelection(
 	executeTestCase(t, test)
 }
 
+// A relation selected twice identically must collapse onto a single join, even
+// when the duplicated relation carries its own groupBy on a relation field.
+//
+// This is the case CodeRabbit flagged: toSelect rewrites the inner groupBy
+// (`author` -> `author_id`) in place while processing the first `published`,
+// which mutates the value the duplicate-detection compares against, so the
+// second identical `published` is no longer recognised as a duplicate.
+//
+// The correct, de-duplicated plan is a single typeJoinMany over a plain
+// scanNode. If the duplicate is missed, the plan is instead a parallelNode of
+// two typeJoinMany, each over a multiScanNode (the shared-scan artifact). The
+// debug-explain assertion below pins the de-duplicated shape.
+func TestQueryOneToManyWithDuplicateRelationSelectionEachWithInnerGroupByOnRelation(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.ExplainRequest{
+				Request: `query @explain(type: debug) {
+					Author {
+						published(groupBy: [author]) {
+							author {
+								name
+							}
+							GROUP {
+								name
+							}
+						}
+						published(groupBy: [author]) {
+							author {
+								name
+							}
+							GROUP {
+								name
+							}
+						}
+					}
+				}`,
+				ExpectedFullGraph: map[string]any{
+					"explain": map[string]any{
+						"operationNode": []map[string]any{
+							{
+								"selectTopNode": map[string]any{
+									"selectNode": map[string]any{
+										"typeIndexJoin": map[string]any{
+											"typeJoinMany": map[string]any{
+												"root": map[string]any{
+													"scanNode": map[string]any{},
+												},
+												"subType": map[string]any{
+													"selectTopNode": map[string]any{
+														"groupNode": map[string]any{
+															"selectNode": map[string]any{
+																"pipeNode": map[string]any{
+																	"typeIndexJoin": map[string]any{
+																		"typeJoinOne": map[string]any{
+																			"root": map[string]any{
+																				"scanNode": map[string]any{},
+																			},
+																			"subType": map[string]any{
+																				"selectTopNode": map[string]any{
+																					"selectNode": map[string]any{
+																						"scanNode": map[string]any{},
+																					},
+																				},
+																			},
+																		},
+																	},
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	executeTestCase(t, test)
+}
+
 func TestQueryOneToManyWithInnerJoinGroupNumberWithNonGroupFieldsSelected(t *testing.T) {
 	test := testUtils.TestCase{
 		Actions: []any{

--- a/tests/integration/query/one_to_many/with_group_test.go
+++ b/tests/integration/query/one_to_many/with_group_test.go
@@ -282,6 +282,64 @@ func TestQueryOneToManyWithParentJoinGroupNumber(t *testing.T) {
 	executeTestCase(t, test)
 }
 
+func TestQueryOneToManyWithParentGroupByOnRelationAndDuplicateRelationSelection(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddDoc{
+				CollectionID: 1,
+				Doc: `{
+						"name": "John Grisham",
+						"age": 65,
+						"verified": true
+					}`,
+			},
+			&action.AddDoc{
+				CollectionID: 0,
+				Doc: `{
+						"name": "Painted House",
+						"rating": 4.9,
+						"_authorID": "bae-9d52c335-c8e3-5782-8daa-e359c106e0ab"
+					}`,
+			},
+			&action.Request{
+				// The relation `author` is both the group-by field and selected
+				// twice at the parent level. The duplicated relation builds a
+				// shared multiScanNode, which group expansion must not crash on.
+				Request: `query {
+					Book(groupBy: [author]) {
+						author {
+							name
+						}
+						author {
+							name
+						}
+						GROUP {
+							name
+						}
+					}
+				}`,
+				Results: map[string]any{
+					"Book": []map[string]any{
+						{
+							"author": map[string]any{
+								"name": "John Grisham",
+							},
+							"GROUP": []map[string]any{
+								{
+									"name": "Painted House",
+								},
+							},
+						},
+					},
+				},
+				NonOrderedResults: true,
+			},
+		},
+	}
+
+	executeTestCase(t, test)
+}
+
 func TestQueryOneToManyWithInnerJoinGroupNumberWithNonGroupFieldsSelected(t *testing.T) {
 	test := testUtils.TestCase{
 		Actions: []any{


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4951 

## Description


  A query that groups by a relationship and returns that relationship field more than once crashed the planner with:

  ```
  unexpected type. Property: plan, Actual: *planner.multiScanNode
  ```

The duplicated relation manufactures a second join over the same root scan, which the planner shares by inserting a `multiScanNode` onto the `.Source()` chain. Group expansion then walks down `.Source()` to the `scanNode` and calls `walkAndReplacePlan` to splice in a pipe, but the node directly above the scan is now a `*multiScanNode`, a type the switch did not handle, so it fell through to `default` and returned `NewErrUnhandledType`.

  This change applies two complementary fixes:

  - **Mapper de-duplication** (`internal/planner/mapper/mapper.go`): in `getRequestables`, an identical duplicate relation `Select` is now collapsed onto its first occurrence (matched with `reflect.DeepEqual`), mirroring how duplicate scalar fields already collapse onto their first index. This stops the redundant join and therefore the `multiScanNode`  from being built in the first place. Non-identical relation selects are left untouched.
  - **Planner robustness** (`internal/planner/planner.go`): `walkAndReplacePlan` now handles `*multiScanNode` by re-targeting its wrapped node (`node.planNode = replace`), so group expansion no longer crashes on a shared-scan source however it arises. This is the backstop for any non-identical duplicate that still produces a shared scan.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?
Added test:
- `TestQueryOneToManyWithParentGroupByOnRelationAndDuplicateRelationSelection` in `tests/integration/query/one_to_many/with_group_test.go`) that reproduced the exact `*planner.multiScanNode` error.

Specify the platform(s) on which this was tested:
- MacOS
