### PR TITLE
refactor: Remove bitswap

### DIFF
--- a/event/event.go
+++ b/event/event.go
@@ -90,10 +90,6 @@ type Update struct {
 	// CollectionID is the root identifier of the collection that this document goes by.
 	CollectionID string
 
-	// Block is the encoded contents of this composite commit, it contains the Cids of the field level commits that
-	// also formed this update.
-	Block []byte
-
 	// IsRetry is true if this update is a retry of a previously failed update.
 	IsRetry bool
 

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/ipfs/go-cid v0.6.1
 	github.com/ipfs/go-datastore v0.9.1
 	github.com/ipfs/go-ipld-format v0.6.3
+	github.com/ipld/go-car/v2 v2.17.0
 	github.com/ipld/go-ipld-prime v0.24.0
 	github.com/ipld/go-ipld-prime/storage/bsadapter v0.0.0-20250821084354-a425e60cd714
 	github.com/joho/godotenv v1.5.1
@@ -282,6 +283,7 @@ require (
 	github.com/ipfs/go-cidutil v0.1.1 // indirect
 	github.com/ipfs/go-dsqueue v0.2.0 // indirect
 	github.com/ipfs/go-ipfs-pq v0.0.4 // indirect
+	github.com/ipfs/go-ipld-cbor v0.2.1 // indirect
 	github.com/ipfs/go-log/v2 v2.9.2 // indirect
 	github.com/ipfs/go-metrics-interface v0.3.0 // indirect
 	github.com/ipfs/go-peertaskqueue v0.8.3 // indirect
@@ -364,6 +366,7 @@ require (
 	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/perimeterx/marshmallow v1.1.5 // indirect
+	github.com/petar/GoLLRB v0.0.0-20210522233825-ae3b015fd3e9 // indirect
 	github.com/petermattis/goid v0.0.0-20260113132338-7c7de50cc741 // indirect
 	github.com/pion/datachannel v1.5.10 // indirect
 	github.com/pion/dtls/v3 v3.1.2 // indirect
@@ -431,6 +434,8 @@ require (
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.12 // indirect
 	github.com/ulikunitz/xz v0.5.15 // indirect
+	github.com/whyrusleeping/cbor v0.0.0-20171005072247-63513f603b11 // indirect
+	github.com/whyrusleeping/cbor-gen v0.3.1 // indirect
 	github.com/whyrusleeping/go-keyspace v0.0.0-20160322163242-5b898ac5add1 // indirect
 	github.com/wlynxg/anet v0.0.5 // indirect
 	github.com/woodsbury/decimal128 v1.3.0 // indirect
@@ -466,6 +471,7 @@ require (
 	golang.org/x/text v0.37.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 	golang.org/x/tools v0.45.0 // indirect
+	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da // indirect
 	gonum.org/v1/gonum v0.17.0 // indirect
 	google.golang.org/api v0.276.0 // indirect
 	google.golang.org/genproto v0.0.0-20260414002931-afd174a4e478 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1084,6 +1084,8 @@ github.com/ipfs/go-ipfs-delay v0.0.1 h1:r/UXYyRcddO6thwOnhiznIAiSvxMECGgtv35Xs1I
 github.com/ipfs/go-ipfs-delay v0.0.1/go.mod h1:8SP1YXK1M1kXuc4KJZINY3TQQ03J2rwBG9QfXmbRPrw=
 github.com/ipfs/go-ipfs-pq v0.0.4 h1:U7jjENWJd1jhcrR8X/xHTaph14PTAK9O+yaLJbjqgOw=
 github.com/ipfs/go-ipfs-pq v0.0.4/go.mod h1:9UdLOIIb99IFrgT0Fc53pvbvlJBhpUb4GJuAQf3+O2A=
+github.com/ipfs/go-ipld-cbor v0.2.1 h1:H05yEJbK/hxg0uf2AJhyerBDbjOuHX4yi+1U/ogRa7E=
+github.com/ipfs/go-ipld-cbor v0.2.1/go.mod h1:x9Zbeq8CoE5R2WicYgBMcr/9mnkQ0lHddYWJP2sMV3A=
 github.com/ipfs/go-ipld-format v0.6.3 h1:9/lurLDTotJpZSuL++gh3sTdmcFhVkCwsgx2+rAh4j8=
 github.com/ipfs/go-ipld-format v0.6.3/go.mod h1:74ilVN12NXVMIV+SrBAyC05UJRk0jVvGqdmrcYZvCBk=
 github.com/ipfs/go-ipld-legacy v0.3.0 h1:7XhFKkRyCvP5upOlQfKUFIqL3S5DEZnbUE4bQmQ/tNE=
@@ -1100,6 +1102,8 @@ github.com/ipfs/go-unixfsnode v1.10.4 h1:cMmMyOrSjQkPVQbQvt8trErIn6jhayNf9pBA9oO
 github.com/ipfs/go-unixfsnode v1.10.4/go.mod h1:Vu1e/s7ToALBBRo38sJ8DwUVWmSeQMTdxk5/rcHl7d0=
 github.com/ipfs/kubo v0.25.0 h1:VKy9oOBW34xTqwi70FPRsoA3vJJBSdaYAbgIm5NmIbY=
 github.com/ipfs/kubo v0.25.0/go.mod h1:ZWSvdTvD7VLqYdquESyGTAkbiqODbLwyNCuqeOtPKsQ=
+github.com/ipld/go-car/v2 v2.17.0 h1:zgjSxf/lQNYcQPX08cvb5rSdEY8sv5OOnQIsZhZMPx4=
+github.com/ipld/go-car/v2 v2.17.0/go.mod h1:/4HY8tFZ1q42Mw54ILLPQfjkUqMJxFKqY1yMDKHlYko=
 github.com/ipld/go-codec-dagpb v1.7.0 h1:hpuvQjCSVSLnTnHXn+QAMR0mLmb1gA6wl10LExo2Ts0=
 github.com/ipld/go-codec-dagpb v1.7.0/go.mod h1:rD3Zg+zub9ZnxcLwfol/OTQRVjaLzXypgy4UqHQvilM=
 github.com/ipld/go-ipld-prime v0.24.0 h1:6th8Z6Peh5bCWuRAVZcDO1sHzZdVF6F2cCCDG3681tg=
@@ -1545,6 +1549,8 @@ github.com/performancecopilot/speed v3.0.0+incompatible/go.mod h1:/CLtqpZ5gBg1M9
 github.com/performancecopilot/speed/v4 v4.0.0/go.mod h1:qxrSyuDGrTOWfV+uKRFhfxw6h/4HXRGUiZiufxo49BM=
 github.com/perimeterx/marshmallow v1.1.5 h1:a2LALqQ1BlHM8PZblsDdidgv1mWi1DgC2UmX50IvK2s=
 github.com/perimeterx/marshmallow v1.1.5/go.mod h1:dsXbUu8CRzfYP5a87xpp0xq9S3u0Vchtcl8we9tYaXw=
+github.com/petar/GoLLRB v0.0.0-20210522233825-ae3b015fd3e9 h1:1/WtZae0yGtPq+TI6+Tv1WTxkukpXeMlviSxvL7SRgk=
+github.com/petar/GoLLRB v0.0.0-20210522233825-ae3b015fd3e9/go.mod h1:x3N5drFsm2uilKKuuYo6LdyD8vZAW55sH/9w+pbo1sw=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/petermattis/goid v0.0.0-20180202154549-b0b1615b78e5/go.mod h1:jvVRKCrJTQWu0XVbaOlby/2lO20uSCHEMzzplHXte1o=
 github.com/petermattis/goid v0.0.0-20250813065127-a731cc31b4fe/go.mod h1:pxMtw7cyUw6B2bRH0ZBANSPg+AoSud1I1iyJHI69jH4=
@@ -1957,6 +1963,10 @@ github.com/warpfork/go-testmark v0.12.1 h1:rMgCpJfwy1sJ50x0M0NgyphxYYPMOODIJHhsX
 github.com/warpfork/go-testmark v0.12.1/go.mod h1:kHwy7wfvGSPh1rQJYKayD4AbtNaeyZdcGi9tNJTaa5Y=
 github.com/whyrusleeping/base32 v0.0.0-20170828182744-c30ac30633cc h1:BCPnHtcboadS0DvysUuJXZ4lWVv5Bh5i7+tbIyi+ck4=
 github.com/whyrusleeping/base32 v0.0.0-20170828182744-c30ac30633cc/go.mod h1:r45hJU7yEoA81k6MWNhpMj/kms0n14dkzkxYHoB96UM=
+github.com/whyrusleeping/cbor v0.0.0-20171005072247-63513f603b11 h1:5HZfQkwe0mIfyDmc1Em5GqlNRzcdtlv4HTNmdpt7XH0=
+github.com/whyrusleeping/cbor v0.0.0-20171005072247-63513f603b11/go.mod h1:Wlo/SzPmxVp6vXpGt/zaXhHH0fn4IxgqZc82aKg6bpQ=
+github.com/whyrusleeping/cbor-gen v0.3.1 h1:82ioxmhEYut7LBVGhGq8xoRkXPLElVuh5mV67AFfdv0=
+github.com/whyrusleeping/cbor-gen v0.3.1/go.mod h1:pM99HXyEbSQHcosHc0iW7YFmwnscr+t9Te4ibko05so=
 github.com/whyrusleeping/chunker v0.0.0-20181014151217-fe64bd25879f h1:jQa4QT2UP9WYv2nzyawpKMOCl+Z/jW7djv2/J50lj9E=
 github.com/whyrusleeping/chunker v0.0.0-20181014151217-fe64bd25879f/go.mod h1:p9UJB6dDgdPgMJZs7UjUOdulKyRr9fqkS+6JKAInPy8=
 github.com/whyrusleeping/go-keyspace v0.0.0-20160322163242-5b898ac5add1 h1:EKhdznlJHPMoKr0XTrX+IlJs1LH3lyx2nfr1dOlZ79k=

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -270,7 +270,6 @@ func (db *DB) publishDocUpdateEvent(ctx context.Context, docID string, collectio
 			DocID:        docID,
 			Cid:          headsIterator.CurrentCid(),
 			CollectionID: collection.Version().CollectionID,
-			Block:        headsIterator.CurrentRawBlock(),
 		}
 		db.sendUpdate(updateEvent)
 	}
@@ -359,6 +358,11 @@ func (db *DB) Rootstore() corekv.TxnStore {
 
 func (db *DB) Multistore() *datastore.Multistore {
 	return datastore.NewMultistore(db.rootstore, db.lockSet, db.blockStoreChunkSize)
+}
+
+// BlockStoreChunkSize returns the chunk size used by the block store, if any.
+func (db *DB) BlockStoreChunkSize() immutable.Option[int] {
+	return db.blockStoreChunkSize
 }
 
 // Events returns the events Channel.

--- a/internal/db/document.go
+++ b/internal/db/document.go
@@ -581,7 +581,7 @@ func (c *collection) save(
 		primaryKey.ToDataStoreKey().WithFieldID(core.COMPOSITE_NAMESPACE),
 	)
 
-	link, headNode, err := coreblock.AddDelta(ctx, merkleCRDT, merkleCRDT.Delta(), links...)
+	link, _, err := coreblock.AddDelta(ctx, merkleCRDT, merkleCRDT.Delta(), links...)
 	if err != nil {
 		return err
 	}
@@ -591,7 +591,6 @@ func (c *collection) save(
 		DocID:        doc.ID().String(),
 		Cid:          link.Cid,
 		CollectionID: c.Version().CollectionID,
-		Block:        headNode,
 	}
 	txn.OnSuccess(func() {
 		c.db.sendUpdate(updateEvent)
@@ -611,7 +610,7 @@ func (c *collection) save(
 			keys.NewHeadstoreColKey(shortID),
 		)
 
-		link, headNode, err := coreblock.AddDelta(
+		link, _, err := coreblock.AddDelta(
 			ctx,
 			collectionCRDT,
 			collectionCRDT.Delta(),
@@ -624,7 +623,6 @@ func (c *collection) save(
 		updateEvent := event.Update{
 			Cid:          link.Cid,
 			CollectionID: c.Version().CollectionID,
-			Block:        headNode,
 		}
 
 		txn.OnSuccess(func() {

--- a/internal/db/document_delete.go
+++ b/internal/db/document_delete.go
@@ -181,7 +181,7 @@ func (c *collection) applyDelete(
 		primaryKey.ToDataStoreKey().WithFieldID(core.COMPOSITE_NAMESPACE),
 	)
 
-	link, b, err := coreblock.AddDelta(ctx, merkleCRDT, merkleCRDT.DeleteDelta())
+	link, _, err := coreblock.AddDelta(ctx, merkleCRDT, merkleCRDT.DeleteDelta())
 	if err != nil {
 		return err
 	}
@@ -191,7 +191,6 @@ func (c *collection) applyDelete(
 		DocID:        primaryKey.DocID,
 		Cid:          link.Cid,
 		CollectionID: c.Version().CollectionID,
-		Block:        b,
 	}
 	txn.OnSuccess(func() {
 		c.db.sendUpdate(updateEvent)
@@ -208,7 +207,7 @@ func (c *collection) applyDelete(
 			keys.NewHeadstoreColKey(shortID),
 		)
 
-		link, headNode, err := coreblock.AddDelta(
+		link, _, err := coreblock.AddDelta(
 			ctx,
 			collectionCRDT,
 			collectionCRDT.Delta(),
@@ -221,7 +220,6 @@ func (c *collection) applyDelete(
 		updateEvent := event.Update{
 			Cid:          link.Cid,
 			CollectionID: c.Version().CollectionID,
-			Block:        headNode,
 		}
 
 		txn.OnSuccess(func() {

--- a/internal/db/p2p/blocksync.go
+++ b/internal/db/p2p/blocksync.go
@@ -1,0 +1,170 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package p2p
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	blocks "github.com/ipfs/go-block-format"
+	"github.com/ipfs/go-cid"
+
+	"github.com/sourcenetwork/corelog"
+	"github.com/sourcenetwork/immutable"
+
+	"github.com/sourcenetwork/defradb/acp/identity"
+	acpTypes "github.com/sourcenetwork/defradb/acp/types"
+	"github.com/sourcenetwork/defradb/client"
+	"github.com/sourcenetwork/defradb/client/options"
+	acpDB "github.com/sourcenetwork/defradb/internal/db/acp"
+	"github.com/sourcenetwork/defradb/internal/db/p2p/protocol"
+)
+
+// peerIdentityFunc returns a function that resolves and caches the ACP identity of the given peer
+// by fetching and verifying its identity token over the identity protocol.
+func (p *P2P) peerIdentityFunc(ctx context.Context, pid string) func() immutable.Option[identity.Identity] {
+	return func() immutable.Option[identity.Identity] {
+		p.piMu.RLock()
+		ident, ok := p.peerIdentities[pid]
+		p.piMu.RUnlock()
+		if ok {
+			return immutable.Some(ident)
+		}
+
+		ctx, cancel := context.WithTimeout(ctx, networkRequestTimeout)
+		defer cancel()
+		resp, err := p.identityProtocol.GetIdentity(ctx, pid)
+		if err != nil {
+			log.ErrorE("Failed to get identity", err)
+			return immutable.None[identity.Identity]()
+		}
+		ident, err = identity.FromToken(resp.IdentityToken)
+		if err != nil {
+			log.ErrorE("Failed to parse identity token", err)
+			return immutable.None[identity.Identity]()
+		}
+		tokenIdent, ok := ident.(identity.TokenIdentity)
+		if !ok {
+			log.ErrorE("Identity is not of type TokenIdentity", nil,
+				corelog.String("Actual", fmt.Sprintf("%T", ident)))
+			return immutable.None[identity.Identity]()
+		}
+		if err := identity.VerifyAuthToken(tokenIdent, p.host.ID()); err != nil {
+			log.ErrorE("Failed to verify auth token", err)
+			return immutable.None[identity.Identity]()
+		}
+		p.piMu.Lock()
+		p.peerIdentities[pid] = ident
+		p.piMu.Unlock()
+		return immutable.Some(ident)
+	}
+}
+
+// peerHasDocAccess reports whether the given peer may read docID within the collection identified
+// by collectionVersionID. Peers in the collection's replicator list are always granted access.
+func (p *P2P) peerHasDocAccess(ctx context.Context, pid, docID, collectionVersionID string) (bool, error) {
+	if !p.db.DocumentACP().HasValue() {
+		return true, nil
+	}
+
+	ident, err := p.db.GetNodeIdentity(p.ctx)
+	if err != nil {
+		return false, err
+	}
+	// The collection lookup is a local operation on this node — authorise it as the node itself so
+	// NAC sees a known identity rather than "anonymous".
+	getColOpts := options.GetCollections().SetCollectionID(collectionVersionID)
+	if ident.HasValue() {
+		getColOpts = getColOpts.SetIdentity(identity.FromDID(ident.Value().DID))
+	}
+	cols, err := p.db.GetCollections(ctx, getColOpts)
+	if err != nil {
+		return false, err
+	}
+	if len(cols) == 0 {
+		return false, client.ErrCollectionNotFound
+	}
+
+	// Replicators of this collection are always granted access.
+	p.repMu.Lock()
+	if peerList, ok := p.replicators[cols[0].CollectionID()]; ok {
+		if _, exists := peerList[pid]; exists {
+			p.repMu.Unlock()
+			return true, nil
+		}
+	}
+	p.repMu.Unlock()
+
+	return acpDB.CheckDocAccessWithIdentityFunc(
+		ctx,
+		p.peerIdentityFunc(ctx, pid),
+		p.db.NodeACP(),
+		p.db.DocumentACP().Value(),
+		cols[0],
+		acpTypes.DocumentReadPerm,
+		docID,
+	)
+}
+
+// handleBlockSyncRequest serves an incoming block sync request: it enforces ACP for the requesting
+// peer and, if allowed, returns the blocks needed to satisfy the request as a CAR.
+//
+// When the requester lacks access, or this node has none of the requested blocks, it returns a nil
+// writeCAR (the requester sees an empty response and treats it as a no-op).
+func (p *P2P) handleBlockSyncRequest(
+	ctx context.Context,
+	req protocol.BlockSyncRequest,
+) ([][]byte, func(io.Writer) error, error) {
+	root, err := cid.Cast(req.Root)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	allowed, err := p.peerHasDocAccess(ctx, req.GetSenderID(), req.DocID, req.CollectionID)
+	if err != nil {
+		return nil, nil, err
+	}
+	if !allowed {
+		return nil, nil, nil
+	}
+
+	haveHeads := make([]cid.Cid, 0, len(req.HaveHeads))
+	for _, h := range req.HaveHeads {
+		c, err := cid.Cast(h)
+		if err != nil {
+			return nil, nil, err
+		}
+		haveHeads = append(haveHeads, c)
+	}
+
+	dagBlocks, encBlocks, err := p.collectBlocksForRequest(ctx, root, haveHeads, req.Full)
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(dagBlocks) == 0 {
+		return nil, nil, nil
+	}
+
+	encCIDs := make([][]byte, len(encBlocks))
+	for i, b := range encBlocks {
+		encCIDs[i] = b.Cid().Bytes()
+	}
+
+	allBlocks := make([]blocks.Block, 0, len(dagBlocks)+len(encBlocks))
+	allBlocks = append(allBlocks, dagBlocks...)
+	allBlocks = append(allBlocks, encBlocks...)
+
+	writeCARFn := func(w io.Writer) error {
+		return writeCAR(ctx, w, []cid.Cid{root}, allBlocks)
+	}
+	return encCIDs, writeCARFn, nil
+}

--- a/internal/db/p2p/blocksync.go
+++ b/internal/db/p2p/blocksync.go
@@ -17,7 +17,10 @@ import (
 
 	blocks "github.com/ipfs/go-block-format"
 	"github.com/ipfs/go-cid"
+	"github.com/ipld/go-ipld-prime/linking"
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 
+	"github.com/sourcenetwork/corekv/blockstore"
 	"github.com/sourcenetwork/corelog"
 	"github.com/sourcenetwork/immutable"
 
@@ -25,8 +28,12 @@ import (
 	acpTypes "github.com/sourcenetwork/defradb/acp/types"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/options"
+	"github.com/sourcenetwork/defradb/internal/core"
+	coreblock "github.com/sourcenetwork/defradb/internal/core/block"
+	"github.com/sourcenetwork/defradb/internal/datastore"
 	acpDB "github.com/sourcenetwork/defradb/internal/db/acp"
 	"github.com/sourcenetwork/defradb/internal/db/p2p/protocol"
+	"github.com/sourcenetwork/defradb/internal/keys"
 )
 
 // peerIdentityFunc returns a function that resolves and caches the ACP identity of the given peer
@@ -167,4 +174,85 @@ func (p *P2P) handleBlockSyncRequest(
 		return writeCAR(ctx, w, []cid.Cid{root}, allBlocks)
 	}
 	return encCIDs, writeCARFn, nil
+}
+
+// pullAndIngest requests the blocks needed to merge root from fromPeer, ingests the returned CAR
+// into the local stores, and prepares them for merge (signature verification + encryption keys).
+//
+// It is the bitswap-free replacement for syncDAG: the caller is responsible for calling db.Merge
+// afterwards.
+func (p *P2P) pullAndIngest(
+	ctx context.Context,
+	fromPeer string,
+	docID string,
+	collectionID string,
+	root cid.Cid,
+) error {
+	haveHeads, err := p.localHeads(ctx, docID)
+	if err != nil {
+		return err
+	}
+	have := make([][]byte, len(haveHeads))
+	for i, h := range haveHeads {
+		have[i] = h.Bytes()
+	}
+
+	req := &protocol.BlockSyncRequest{
+		DocID:        docID,
+		CollectionID: collectionID,
+		Root:         root.Bytes(),
+		HaveHeads:    have,
+		Full:         len(haveHeads) == 0,
+	}
+
+	blockDst := datastore.P2PBlockstoreFrom(p.db.Rootstore(), p.db.BlockStoreChunkSize())
+	encDst := p.db.Multistore().Encstore()
+
+	return p.blockSyncProtocol.RequestBlocks(ctx, fromPeer, req,
+		func(encCIDs [][]byte, car io.Reader) error {
+			encSet := make(map[cid.Cid]struct{}, len(encCIDs))
+			for _, c := range encCIDs {
+				parsed, err := cid.Cast(c)
+				if err != nil {
+					return err
+				}
+				encSet[parsed] = struct{}{}
+			}
+			if _, err := ingestCAR(ctx, blockDst, encDst, encSet, car); err != nil {
+				return err
+			}
+			return p.prepareForMerge(ctx, root)
+		},
+	)
+}
+
+// localHeads returns the current composite head CIDs the local node has for the given document.
+func (p *P2P) localHeads(ctx context.Context, docID string) ([]cid.Cid, error) {
+	if docID == "" {
+		return nil, nil
+	}
+	key := keys.HeadstoreDocKey{
+		DocID:   docID,
+		FieldID: core.COMPOSITE_NAMESPACE,
+	}
+	headset := coreblock.NewHeadSet(p.db.Multistore().Headstore(), key)
+	cids, _, err := headset.List(ctx)
+	return cids, err
+}
+
+// prepareForMerge walks the freshly-ingested DAG from root using a local link system, verifying
+// block signatures and fetching any required encryption keys so that db.Merge can proceed.
+func (p *P2P) prepareForMerge(ctx context.Context, root cid.Cid) error {
+	localStore := blockstore.NewIPLDStore(p.db.Multistore().Blockstore())
+	linkSys := makeLinkSystem(localStore)
+
+	nd, err := linkSys.Load(linking.LinkContext{Ctx: ctx}, cidlink.Link{Cid: root}, coreblock.BlockSchemaPrototype)
+	if err != nil {
+		return NewErrLoadLinkedBlock(err)
+	}
+	rootBlock, err := coreblock.GetFromNode(nd)
+	if err != nil {
+		return NewErrDecodeLinkedBlock(err)
+	}
+	return p.loadBlockLinks(ctx, &linkSys, rootBlock)
 }

--- a/internal/db/p2p/blocksync_car.go
+++ b/internal/db/p2p/blocksync_car.go
@@ -1,0 +1,80 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package p2p
+
+import (
+	"context"
+	"io"
+
+	blocks "github.com/ipfs/go-block-format"
+	"github.com/ipfs/go-cid"
+	car "github.com/ipld/go-car/v2"
+	carstorage "github.com/ipld/go-car/v2/storage"
+
+	"github.com/sourcenetwork/defradb/errors"
+	"github.com/sourcenetwork/defradb/internal/datastore"
+)
+
+// writeCAR streams the given blocks to w as a CARv1 payload with the provided roots.
+//
+// CARv1 is a pure streaming format (no trailing index), so the blocks are written one after
+// another without buffering the whole payload.
+func writeCAR(ctx context.Context, w io.Writer, roots []cid.Cid, blks []blocks.Block) error {
+	cw, err := carstorage.NewWritable(w, roots, car.WriteAsCarV1(true))
+	if err != nil {
+		return NewErrWriteCAR(err)
+	}
+	for _, b := range blks {
+		if err := cw.Put(ctx, b.Cid().KeyString(), b.RawData()); err != nil {
+			return NewErrWriteCAR(err)
+		}
+	}
+	if err := cw.Finalize(); err != nil {
+		return NewErrWriteCAR(err)
+	}
+	return nil
+}
+
+// ingestCAR reads a CARv1 stream from r and stores each block into blockDst, routing any block
+// whose CID is in encCIDs into encDst (the encryption store) instead.
+//
+// The reader is streamed block-by-block, so an arbitrarily large CAR can be ingested without
+// buffering the whole payload. The CAR roots are returned.
+func ingestCAR(
+	ctx context.Context,
+	blockDst datastore.Blockstore,
+	encDst datastore.Blockstore,
+	encCIDs map[cid.Cid]struct{},
+	r io.Reader,
+) ([]cid.Cid, error) {
+	br, err := car.NewBlockReader(r)
+	if err != nil {
+		return nil, NewErrReadCAR(err)
+	}
+	for {
+		b, err := br.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, NewErrReadCAR(err)
+		}
+
+		dst := blockDst
+		if _, ok := encCIDs[b.Cid()]; ok {
+			dst = encDst
+		}
+		if err := dst.Put(ctx, b); err != nil {
+			return nil, NewErrIngestCARBlock(err, b.Cid().String())
+		}
+	}
+	return br.Roots, nil
+}

--- a/internal/db/p2p/blocksync_car_test.go
+++ b/internal/db/p2p/blocksync_car_test.go
@@ -1,0 +1,71 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package p2p
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	blocks "github.com/ipfs/go-block-format"
+	"github.com/ipfs/go-cid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcenetwork/immutable"
+
+	"github.com/sourcenetwork/corekv/memory"
+
+	"github.com/sourcenetwork/defradb/internal/datastore"
+)
+
+func TestBlockSyncCAR_RoundTripRoutesEncBlocksAndSetsToMergeMarker(t *testing.T) {
+	ctx := context.Background()
+
+	b1 := blocks.NewBlock([]byte("block-one"))
+	b2 := blocks.NewBlock([]byte("block-two"))
+	encB := blocks.NewBlock([]byte("encryption-envelope"))
+
+	roots := []cid.Cid{b1.Cid()}
+
+	var buf bytes.Buffer
+	err := writeCAR(ctx, &buf, roots, []blocks.Block{b1, b2, encB})
+	require.NoError(t, err)
+
+	rootstore := memory.NewDatastore(ctx)
+	blockDst := datastore.P2PBlockstoreFrom(rootstore, immutable.None[int]())
+	encDst := datastore.EncstoreFrom(rootstore)
+	encCIDs := map[cid.Cid]struct{}{encB.Cid(): {}}
+
+	gotRoots, err := ingestCAR(ctx, blockDst, encDst, encCIDs, &buf)
+	require.NoError(t, err)
+	require.Equal(t, roots, gotRoots)
+
+	// Regular blocks land in the block store and are flagged as not-yet-merged (the to-merge
+	// marker is set), so the merge step will pick them up.
+	for _, b := range []blocks.Block{b1, b2} {
+		has, err := blockDst.Has(ctx, b.Cid())
+		require.NoError(t, err)
+		require.True(t, has)
+
+		merged, err := blockDst.IsMerged(ctx, b.Cid())
+		require.NoError(t, err)
+		require.False(t, merged)
+	}
+
+	// The encryption block is routed to the encryption store, not the block store.
+	hasEncInBlocks, err := blockDst.Has(ctx, encB.Cid())
+	require.NoError(t, err)
+	require.False(t, hasEncInBlocks)
+
+	hasEnc, err := encDst.Has(ctx, encB.Cid())
+	require.NoError(t, err)
+	require.True(t, hasEnc)
+}

--- a/internal/db/p2p/blocksync_collect.go
+++ b/internal/db/p2p/blocksync_collect.go
@@ -1,0 +1,111 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package p2p
+
+import (
+	"context"
+
+	blocks "github.com/ipfs/go-block-format"
+	"github.com/ipfs/go-cid"
+	ipld "github.com/ipfs/go-ipld-format"
+
+	coreblock "github.com/sourcenetwork/defradb/internal/core/block"
+)
+
+// collectBlocksForRequest gathers the blocks a peer needs in order to merge root.
+//
+// Starting from root it walks the DAG (composite history via Heads, field blocks via Links, plus
+// each block's signature and encryption blocks) collecting every block reachable from root that is
+// not behind one of haveHeads. When full is true, haveHeads is ignored and the whole reachable DAG
+// is collected.
+//
+// dagBlocks are destined for the receiver's block store; encBlocks for its encryption store. A
+// block that is not found locally is skipped — this node simply does not have that part of the
+// history, and the receiver may obtain it from another peer.
+func (p *P2P) collectBlocksForRequest(
+	ctx context.Context,
+	root cid.Cid,
+	haveHeads []cid.Cid,
+	full bool,
+) (dagBlocks []blocks.Block, encBlocks []blocks.Block, err error) {
+	bstore := p.db.Multistore().Blockstore()
+	encstore := p.db.Multistore().Encstore()
+
+	have := make(map[cid.Cid]struct{}, len(haveHeads))
+	if !full {
+		for _, h := range haveHeads {
+			have[h] = struct{}{}
+		}
+	}
+
+	visited := make(map[cid.Cid]struct{})
+	queue := []cid.Cid{root}
+
+	for len(queue) > 0 {
+		if ctx.Err() != nil {
+			return nil, nil, ctx.Err()
+		}
+		current := queue[0]
+		queue = queue[1:]
+
+		if _, ok := visited[current]; ok {
+			continue
+		}
+		if _, ok := have[current]; ok {
+			continue
+		}
+		visited[current] = struct{}{}
+
+		raw, err := bstore.Get(ctx, current)
+		if err != nil {
+			if ipld.IsNotFound(err) {
+				continue
+			}
+			return nil, nil, err
+		}
+		dagBlocks = append(dagBlocks, raw)
+
+		block, err := coreblock.GetFromBytes(raw.RawData())
+		if err != nil {
+			return nil, nil, NewErrDecodeLinkedBlock(err)
+		}
+
+		// Signature and encryption blocks are not part of AllLinks, so collect them explicitly.
+		if block.Signature != nil {
+			sigRaw, err := bstore.Get(ctx, block.Signature.Cid)
+			if err != nil && !ipld.IsNotFound(err) {
+				return nil, nil, err
+			} else if err == nil {
+				dagBlocks = append(dagBlocks, sigRaw)
+			}
+		}
+		if block.Encryption != nil {
+			encRaw, err := encstore.Get(ctx, block.Encryption.Cid)
+			if err != nil && !ipld.IsNotFound(err) {
+				return nil, nil, err
+			} else if err == nil {
+				encBlocks = append(encBlocks, encRaw)
+			}
+		}
+
+		for _, lnk := range block.AllLinks() {
+			if _, ok := visited[lnk.Cid]; ok {
+				continue
+			}
+			if _, ok := have[lnk.Cid]; ok {
+				continue
+			}
+			queue = append(queue, lnk.Cid)
+		}
+	}
+
+	return dagBlocks, encBlocks, nil
+}

--- a/internal/db/p2p/errors.go
+++ b/internal/db/p2p/errors.go
@@ -15,7 +15,6 @@ import (
 )
 
 const (
-	errStoreBlockDAGSync       string = "failed to store block in DAG sync"
 	errGenerateBlockLink       string = "failed to generate block link"
 	errCheckBlockMerged        string = "failed to check if block is merged"
 	errVerifyBlockSig          string = "failed to verify block signature"
@@ -153,7 +152,6 @@ func NewErrGetDocHeads(inner error, docID string) error {
 	return errors.Wrap(errGetDocHeads, inner, errors.NewKV("DocID", docID))
 }
 
-func NewErrStoreBlockDAGSync(inner error) error  { return errors.Wrap(errStoreBlockDAGSync, inner) }
 func NewErrGenerateBlockLink(inner error) error  { return errors.Wrap(errGenerateBlockLink, inner) }
 func NewErrCheckBlockMerged(inner error) error   { return errors.Wrap(errCheckBlockMerged, inner) }
 func NewErrVerifyBlockSig(inner error) error     { return errors.Wrap(errVerifyBlockSig, inner) }

--- a/internal/db/p2p/errors.go
+++ b/internal/db/p2p/errors.go
@@ -58,6 +58,9 @@ const (
 	errGetAllP2PCollections    string = "failed to get all P2P collection IDs"
 	errListP2PDocuments        string = "failed to list P2P documents"
 	errLoadP2PDocuments        string = "failed to load P2P documents"
+	errWriteCAR                string = "failed to write CAR"
+	errReadCAR                 string = "failed to read CAR"
+	errIngestCARBlock          string = "failed to store block from CAR"
 )
 
 var (
@@ -251,4 +254,16 @@ func NewErrListP2PDocuments(inner error) error {
 
 func NewErrLoadP2PDocuments(inner error) error {
 	return errors.Wrap(errLoadP2PDocuments, inner)
+}
+
+func NewErrWriteCAR(inner error) error {
+	return errors.Wrap(errWriteCAR, inner)
+}
+
+func NewErrReadCAR(inner error) error {
+	return errors.Wrap(errReadCAR, inner)
+}
+
+func NewErrIngestCARBlock(inner error, cid string) error {
+	return errors.Wrap(errIngestCARBlock, inner, errors.NewKV("CID", cid))
 }

--- a/internal/db/p2p/errors.go
+++ b/internal/db/p2p/errors.go
@@ -39,7 +39,6 @@ const (
 	errIterateReplicatorDocs   string = "failed to iterate replicator documents"
 	errPushDocHeads            string = "failed to push document heads"
 	errGetDocHeads             string = "failed to get document heads for replication"
-	errMarshalBlock            string = "failed to marshal block for replication"
 	errUpdateReplicatorStatus  string = "failed to update replicator status"
 	errCreateReplicatorRetry   string = "failed to create replicator retry"
 	errStoreRetryDoc           string = "failed to store retry doc for replicator"
@@ -152,10 +151,6 @@ func NewErrPushDocHeads(inner error, docID string) error {
 
 func NewErrGetDocHeads(inner error, docID string) error {
 	return errors.Wrap(errGetDocHeads, inner, errors.NewKV("DocID", docID))
-}
-
-func NewErrMarshalBlock(inner error, docID string, cid string) error {
-	return errors.Wrap(errMarshalBlock, inner, errors.NewKV("DocID", docID), errors.NewKV("CID", cid))
 }
 
 func NewErrStoreBlockDAGSync(inner error) error  { return errors.Wrap(errStoreBlockDAGSync, inner) }

--- a/internal/db/p2p/p2p.go
+++ b/internal/db/p2p/p2p.go
@@ -105,6 +105,7 @@ type DB interface {
 type P2P struct {
 	identityProtocol   *protocol.IdentityProtocol
 	replicatorProtocol protocol.CommChannel[protocol.PushLogRequest, protocol.PushLogReply]
+	blockSyncProtocol  *protocol.BlockSyncProtocol
 
 	ctx                  context.Context
 	db                   DB
@@ -193,6 +194,7 @@ func New(
 		syncBlockLinkTimeout: db.P2PBlockSyncTimeout(),
 	}
 	p.replicatorProtocol = protocol.NewCommChannel(host, "rep", &pushLogCommProcessor{p2p: &p})
+	p.blockSyncProtocol = protocol.NewBlockSyncProtocol(host, p.handleBlockSyncRequest)
 
 	host.SetBlockAccessFunc(p.hasAccess)
 
@@ -408,43 +410,9 @@ func (p *P2P) hasAccess(ctx context.Context, pid string, c cid.Cid) bool {
 	}
 	p.repMu.Unlock()
 
-	identFunc := func() immutable.Option[identity.Identity] {
-		p.piMu.RLock()
-		ident, ok := p.peerIdentities[pid]
-		p.piMu.RUnlock()
-		if !ok {
-			ctx, cancel := context.WithTimeout(ctx, networkRequestTimeout)
-			defer cancel()
-			resp, err := p.identityProtocol.GetIdentity(ctx, pid)
-			if err != nil {
-				log.ErrorE("Failed to get identity", err)
-				return immutable.None[identity.Identity]()
-			}
-			ident, err = identity.FromToken(resp.IdentityToken)
-			if err != nil {
-				log.ErrorE("Failed to parse identity token", err)
-				return immutable.None[identity.Identity]()
-			}
-			tokenIdent, ok := ident.(identity.TokenIdentity)
-			if !ok {
-				log.ErrorE("Identity is not of type TokenIdentity", nil, corelog.String("Actual", fmt.Sprintf("%T", ident)))
-				return immutable.None[identity.Identity]()
-			}
-			err = identity.VerifyAuthToken(tokenIdent, p.host.ID())
-			if err != nil {
-				log.ErrorE("Failed to verify auth token", err)
-				return immutable.None[identity.Identity]()
-			}
-			p.piMu.Lock()
-			p.peerIdentities[pid] = ident
-			p.piMu.Unlock()
-		}
-		return immutable.Some(ident)
-	}
-
 	peerHasAccess, err := acpDB.CheckDocAccessWithIdentityFunc(
 		ctx,
-		identFunc,
+		p.peerIdentityFunc(ctx, pid),
 		p.db.NodeACP(),
 		p.db.DocumentACP().Value(),
 		cols[0], // For now we assume there is only one collection.

--- a/internal/db/p2p/p2p.go
+++ b/internal/db/p2p/p2p.go
@@ -94,6 +94,9 @@ type DB interface {
 	Rootstore() corekv.TxnStore
 	// Multistore returns the multistore
 	Multistore() *datastore.Multistore
+	// BlockStoreChunkSize returns the chunk size used by the block store, if any. Ingested blocks
+	// must use the same chunk size so reads and the to-merge index line up.
+	BlockStoreChunkSize() immutable.Option[int]
 	// P2PBlockSyncTimeout is the timeout duration for syncing block links.
 	P2PBlockSyncTimeout() time.Duration
 	// SearchableEncryptionKey returns the searchable encryption key if configured.
@@ -427,12 +430,12 @@ func (p *P2P) hasAccess(ctx context.Context, pid string, c cid.Cid) bool {
 	return peerHasAccess
 }
 
-// trySelfHasAccess checks if the local node has access to the given block.
+// trySelfHasAccess checks if the local node has access to the given document.
 //
 // This is a best-effort check and returns true unless we explicitly find that the local node
 // doesn't have access or if we get an error. The node sending is ultimately responsible for
 // ensuring that the recipient has access.
-func (p *P2P) trySelfHasAccess(ctx context.Context, block *coreblock.Block, collectionID string) (bool, error) {
+func (p *P2P) trySelfHasAccess(ctx context.Context, docID, collectionID string) (bool, error) {
 	if !p.db.DocumentACP().HasValue() {
 		return true, nil
 	}
@@ -468,7 +471,7 @@ func (p *P2P) trySelfHasAccess(ctx context.Context, block *coreblock.Block, coll
 		p.db.DocumentACP().Value(),
 		cols[0], // For now we assume there is only one collection.
 		acpTypes.DocumentReadPerm,
-		string(block.Delta.GetDocID()),
+		docID,
 	)
 	if err != nil {
 		return false, err
@@ -513,25 +516,19 @@ func (p *P2P) processPushlogRequest(
 	if ctx.Err() != nil {
 		return ctx.Err()
 	}
-	block, err := coreblock.GetFromBytes(req.Block)
-	if err != nil {
-		return err
-	}
 
 	headCID, err := cid.Cast(req.CID)
 	if err != nil {
 		return err
 	}
 
-	// Calls to syncDAG should not overlap for a given CID. If they do, they will use the same
-	// underlying pubsub topic and this brings along potential pitfalls. One of them being that
-	// if this initial sync call had a negative response for a given link, the subsequent calls will
-	// assume a negative response for that same link without retrying.
+	// Calls to pullAndIngest should not overlap for a given CID, so that concurrent
+	// notifications for the same head do not trigger redundant pulls and merges.
 	p.processQueue.add(headCID)
 	done := p.processQueue.doneOnce(headCID)
 	defer done()
 
-	// Check if we've already merged this block. If so, skip the sink process.
+	// Check if we've already merged this block. If so, skip the sync process.
 	isMerged, err := p.db.Multistore().Blockstore().IsMerged(ctx, headCID)
 	if err != nil {
 		return err
@@ -543,7 +540,7 @@ func (p *P2P) processPushlogRequest(
 	// No need to check access if the message is for replication as the node sending
 	// will have done so deliberately.
 	if !isReplicator {
-		mightHaveAccess, err := p.trySelfHasAccess(ctx, block, req.CollectionID)
+		mightHaveAccess, err := p.trySelfHasAccess(ctx, req.DocID, req.CollectionID)
 		if err != nil {
 			return err
 		}
@@ -553,7 +550,9 @@ func (p *P2P) processPushlogRequest(
 		}
 	}
 
-	err = p.syncDAG(ctx, block)
+	// Pull the blocks we need from the notifying peer and ingest them locally so that the merge
+	// can proceed. This replaces the previous bitswap-based DAG fetch.
+	err = p.pullAndIngest(ctx, req.SenderID, req.DocID, req.CollectionID, headCID)
 	if err != nil {
 		return err
 	}
@@ -575,7 +574,6 @@ func (p *P2P) processPushlogRequest(
 		DocID:        req.DocID,
 		Cid:          headCID,
 		CollectionID: req.CollectionID,
-		Block:        req.Block,
 		IsRelay:      true,
 	}
 	p.db.Events().Publish(event.NewMessage(event.UpdateName, updateEvt))
@@ -599,7 +597,6 @@ func (p *P2P) SendUpdate(evt event.Update) error {
 			CID:          evt.Cid.Bytes(),
 			CollectionID: evt.CollectionID,
 			Creator:      p.host.ID(),
-			Block:        evt.Block,
 		}
 
 		b, err := cbor.Marshal(req)

--- a/internal/db/p2p/protocol/blocksync.go
+++ b/internal/db/p2p/protocol/blocksync.go
@@ -1,0 +1,264 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package protocol
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/binary"
+	"io"
+	"sync"
+
+	"github.com/fxamacker/cbor/v2"
+	"github.com/gofrs/uuid/v5"
+
+	"github.com/sourcenetwork/defradb/client"
+	"github.com/sourcenetwork/defradb/errors"
+	"github.com/sourcenetwork/defradb/internal/db/p2p/message"
+)
+
+const (
+	blockSyncVersion       = "0.0.1"
+	blockSyncRequestProto  = "/defradb/blocksync_req/" + blockSyncVersion
+	blockSyncResponseProto = "/defradb/blocksync_car/" + blockSyncVersion
+
+	// maxResponseHeaderSize caps the length-prefixed response header. The CAR body that follows
+	// the header is streamed and intentionally uncapped.
+	maxResponseHeaderSize = 1 << 20 // 1 MiB
+)
+
+var (
+	// ErrResponseHeaderTooLarge is returned when a block sync response header exceeds the cap.
+	ErrResponseHeaderTooLarge = errors.New("block sync response header too large")
+)
+
+// BlockSyncRequest asks a peer for the blocks needed to merge Root.
+//
+// When Full is false the responder may send only the diff: the blocks reachable from Root that are
+// not already reachable from HaveHeads. When Full is true the responder sends the whole tree.
+type BlockSyncRequest struct {
+	message.MetaData
+	// DocID is the document the request relates to (empty for collection-level commits).
+	DocID string
+	// CollectionID is the collection version id the request relates to.
+	CollectionID string
+	// Root is the head block CID (cid.Bytes()) the requester wants to merge.
+	Root []byte
+	// HaveHeads are the CIDs the requester already has, used as the diff cut-off.
+	HaveHeads [][]byte
+	// Full requests the whole tree, ignoring HaveHeads.
+	Full bool
+}
+
+// blockSyncResponseHeader prefixes the raw CAR stream returned for a request.
+//
+// It is not signed: responses are correlated by MessageID and the responding peer id, and block
+// integrity is guaranteed by content addressing (and, for signed docs, by signature verification
+// at merge time), so a forged response cannot inject valid blocks.
+type blockSyncResponseHeader struct {
+	// MessageID matches the originating request's MessageID.
+	MessageID string
+	// EncCIDs lists the CIDs in the CAR that belong in the encryption store rather than the
+	// block store.
+	EncCIDs [][]byte
+	// ErrMessage carries an error from the responder, if any.
+	ErrMessage string
+}
+
+// RequestHandler produces the response for an incoming request on the serving node.
+//
+// It returns the CIDs that belong in the encryption store and a function that writes the CAR
+// payload to the provided writer. Returning a nil writeCAR with a nil error means "nothing to
+// send" (e.g. the requester has no access or this node lacks the blocks).
+type RequestHandler func(
+	ctx context.Context,
+	req BlockSyncRequest,
+) (encCIDs [][]byte, writeCAR func(io.Writer) error, err error)
+
+// IngestFunc consumes the CAR payload of a response. It is called on the requesting node within
+// the response stream handler, so it may stream-read an arbitrarily large CAR.
+type IngestFunc func(encCIDs [][]byte, car io.Reader) error
+
+type pendingResponse struct {
+	peerID string
+	ingest IngestFunc
+	result chan error
+}
+
+// pendingSet is a concurrency-safe map of in-flight requests keyed by message id.
+type pendingSet struct {
+	mu sync.Mutex
+	m  map[string]pendingResponse
+}
+
+func newPendingSet() *pendingSet {
+	return &pendingSet{m: make(map[string]pendingResponse)}
+}
+
+func (p *pendingSet) set(id string, resp pendingResponse) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.m[id] = resp
+}
+
+func (p *pendingSet) get(id string) (pendingResponse, bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	resp, ok := p.m[id]
+	return resp, ok
+}
+
+func (p *pendingSet) delete(id string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	delete(p.m, id)
+}
+
+// BlockSyncProtocol implements a request / streamed-CAR-response transport over libp2p streams.
+//
+// The requester sends a small signed request and registers a pending entry; the responder streams
+// a CAR back on a second stream, which the requester correlates by MessageID and ingests in place.
+type BlockSyncProtocol struct {
+	*baseProto
+	handler RequestHandler
+	pending *pendingSet
+}
+
+// NewBlockSyncProtocol returns a new [BlockSyncProtocol] and registers its stream handlers.
+//
+// handler may be nil on nodes that only request blocks (it is required to serve them).
+func NewBlockSyncProtocol(h client.Host, handler RequestHandler) *BlockSyncProtocol {
+	proto := &BlockSyncProtocol{
+		baseProto: newBaseProto(h),
+		handler:   handler,
+		pending:   newPendingSet(),
+	}
+	h.SetStreamHandler(blockSyncRequestProto, proto.onRequest)
+	h.SetStreamHandler(blockSyncResponseProto, proto.onResponse)
+	return proto
+}
+
+// RequestBlocks sends a block sync request to peerID and ingests the streamed CAR response.
+//
+// ingest is invoked with the response's encryption-store CIDs and a reader over the CAR body. The
+// caller should set an appropriate context timeout.
+func (p *BlockSyncProtocol) RequestBlocks(
+	ctx context.Context,
+	peerID string,
+	req *BlockSyncRequest,
+	ingest IngestFunc,
+) error {
+	id, err := uuid.NewV4()
+	if err != nil {
+		return err
+	}
+	req.SetMessageID(id.String())
+
+	result := make(chan error, 1)
+	p.pending.set(id.String(), pendingResponse{peerID: peerID, ingest: ingest, result: result})
+	defer p.pending.delete(id.String())
+
+	if err := message.SendAndForget(ctx, p, req, peerID, blockSyncRequestProto); err != nil {
+		return err
+	}
+
+	select {
+	case err := <-result:
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// onRequest handles an incoming block sync request on the serving node.
+func (p *BlockSyncProtocol) onRequest(stream io.Reader, peerID string) {
+	ctx := context.Background()
+	req := BlockSyncRequest{}
+	if err := message.Receive(stream, peerID, p, &req); err != nil {
+		return
+	}
+
+	header := blockSyncResponseHeader{MessageID: req.GetMessageID()}
+	var writeCAR func(io.Writer) error
+	if p.handler != nil {
+		encCIDs, w, err := p.handler(ctx, req)
+		if err != nil {
+			header.ErrMessage = err.Error()
+		} else {
+			header.EncCIDs = encCIDs
+			writeCAR = w
+		}
+	}
+
+	var buf bytes.Buffer
+	if err := writeResponseHeader(&buf, header); err != nil {
+		return
+	}
+	if header.ErrMessage == "" && writeCAR != nil {
+		if err := writeCAR(&buf); err != nil {
+			return
+		}
+	}
+	_ = p.host.Send(ctx, buf.Bytes(), peerID, blockSyncResponseProto)
+}
+
+// onResponse handles an incoming CAR response on the requesting node. It runs in its own stream
+// goroutine, so it reads and ingests the (potentially large) CAR in place.
+func (p *BlockSyncProtocol) onResponse(stream io.Reader, peerID string) {
+	r := bufio.NewReader(stream)
+	header, err := readResponseHeader(r)
+	if err != nil {
+		return
+	}
+
+	pend, ok := p.pending.get(header.MessageID)
+	if !ok || pend.peerID != peerID {
+		return
+	}
+
+	if header.ErrMessage != "" {
+		pend.result <- errors.New(header.ErrMessage)
+		return
+	}
+	pend.result <- pend.ingest(header.EncCIDs, r)
+}
+
+func writeResponseHeader(w io.Writer, header blockSyncResponseHeader) error {
+	data, err := cbor.Marshal(header)
+	if err != nil {
+		return err
+	}
+	var lenBuf [binary.MaxVarintLen64]byte
+	n := binary.PutUvarint(lenBuf[:], uint64(len(data)))
+	if _, err := w.Write(lenBuf[:n]); err != nil {
+		return err
+	}
+	_, err = w.Write(data)
+	return err
+}
+
+func readResponseHeader(r *bufio.Reader) (blockSyncResponseHeader, error) {
+	var header blockSyncResponseHeader
+	length, err := binary.ReadUvarint(r)
+	if err != nil {
+		return header, err
+	}
+	if length > maxResponseHeaderSize {
+		return header, ErrResponseHeaderTooLarge
+	}
+	data := make([]byte, length)
+	if _, err := io.ReadFull(r, data); err != nil {
+		return header, err
+	}
+	err = cbor.Unmarshal(data, &header)
+	return header, err
+}

--- a/internal/db/p2p/protocol/blocksync_test.go
+++ b/internal/db/p2p/protocol/blocksync_test.go
@@ -1,0 +1,146 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package protocol
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/libp2p/go-libp2p/core/crypto"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcenetwork/defradb/client"
+	"github.com/sourcenetwork/defradb/errors"
+)
+
+// routingHost is a minimal client.Host that routes Send calls to the target host's registered
+// stream handler, so two protocol instances can exchange messages in-process. It carries a real
+// libp2p key so message signing/verification succeeds.
+type routingHost struct {
+	client.Host
+	id       string
+	priv     crypto.PrivKey
+	pubBytes []byte
+	handlers map[string]client.StreamHandler
+	registry map[string]*routingHost
+}
+
+func newRoutingHost(t *testing.T, registry map[string]*routingHost) *routingHost {
+	priv, pub, err := crypto.GenerateKeyPair(crypto.Ed25519, 0)
+	require.NoError(t, err)
+	pid, err := peer.IDFromPublicKey(pub)
+	require.NoError(t, err)
+	pubBytes, err := crypto.MarshalPublicKey(pub)
+	require.NoError(t, err)
+
+	h := &routingHost{
+		id:       pid.String(),
+		priv:     priv,
+		pubBytes: pubBytes,
+		handlers: make(map[string]client.StreamHandler),
+		registry: registry,
+	}
+	registry[h.id] = h
+	return h
+}
+
+func (h *routingHost) ID() string                       { return h.id }
+func (h *routingHost) Pubkey() ([]byte, error)          { return h.pubBytes, nil }
+func (h *routingHost) Sign(data []byte) ([]byte, error) { return h.priv.Sign(data) }
+
+func (h *routingHost) SetStreamHandler(protocolID string, handler client.StreamHandler) {
+	h.handlers[protocolID] = handler
+}
+
+func (h *routingHost) Send(_ context.Context, data []byte, peerID string, protocolID string) error {
+	target, ok := h.registry[peerID]
+	if !ok {
+		return errors.New("unknown peer")
+	}
+	handler, ok := target.handlers[protocolID]
+	if !ok {
+		return errors.New("no handler for protocol")
+	}
+	cp := make([]byte, len(data))
+	copy(cp, data)
+	from := h.id
+	// libp2p invokes stream handlers in their own goroutine; mirror that here.
+	go handler(bytes.NewReader(cp), from)
+	return nil
+}
+
+func TestBlockSyncProtocol_RequestStreamsBodyAndEncCIDs(t *testing.T) {
+	registry := make(map[string]*routingHost)
+	requesterHost := newRoutingHost(t, registry)
+	senderHost := newRoutingHost(t, registry)
+
+	body := []byte("the-car-payload-bytes")
+	wantEncCIDs := [][]byte{[]byte("enc-cid-1"), []byte("enc-cid-2")}
+
+	var gotReq BlockSyncRequest
+	handler := func(_ context.Context, req BlockSyncRequest) ([][]byte, func(io.Writer) error, error) {
+		gotReq = req
+		return wantEncCIDs, func(w io.Writer) error {
+			_, err := w.Write(body)
+			return err
+		}, nil
+	}
+
+	NewBlockSyncProtocol(senderHost, handler)
+	requester := NewBlockSyncProtocol(requesterHost, nil)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	req := &BlockSyncRequest{DocID: "doc-1", CollectionID: "col-1", Root: []byte("root-cid"), Full: true}
+
+	var gotEncCIDs [][]byte
+	var gotBody []byte
+	err := requester.RequestBlocks(ctx, senderHost.ID(), req, func(encCIDs [][]byte, car io.Reader) error {
+		gotEncCIDs = encCIDs
+		b, err := io.ReadAll(car)
+		gotBody = b
+		return err
+	})
+	require.NoError(t, err)
+	require.Equal(t, body, gotBody)
+	require.Equal(t, wantEncCIDs, gotEncCIDs)
+	require.Equal(t, "doc-1", gotReq.DocID)
+	require.True(t, gotReq.Full)
+}
+
+func TestBlockSyncProtocol_HandlerErrorPropagates(t *testing.T) {
+	registry := make(map[string]*routingHost)
+	requesterHost := newRoutingHost(t, registry)
+	senderHost := newRoutingHost(t, registry)
+
+	handler := func(_ context.Context, _ BlockSyncRequest) ([][]byte, func(io.Writer) error, error) {
+		return nil, nil, errors.New("access denied")
+	}
+	NewBlockSyncProtocol(senderHost, handler)
+	requester := NewBlockSyncProtocol(requesterHost, nil)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	ingestCalled := false
+	err := requester.RequestBlocks(ctx, senderHost.ID(), &BlockSyncRequest{DocID: "d"},
+		func(_ [][]byte, _ io.Reader) error {
+			ingestCalled = true
+			return nil
+		})
+	require.ErrorContains(t, err, "access denied")
+	require.False(t, ingestCalled)
+}

--- a/internal/db/p2p/protocol/pushlog.go
+++ b/internal/db/p2p/protocol/pushlog.go
@@ -14,14 +14,16 @@ import (
 	"github.com/sourcenetwork/defradb/internal/db/p2p/message"
 )
 
-// PushLogRequest is the struct used to send a resource update to a peer node
+// PushLogRequest is the struct used to notify a peer node of a resource update.
+//
+// It carries only the identifiers of the update (not the block bytes); the receiving node pulls
+// the blocks it needs via the block sync protocol.
 type PushLogRequest struct {
 	message.MetaData
 	DocID        string
 	CID          []byte
 	CollectionID string
 	Creator      string
-	Block        []byte
 }
 
 // PushLogReply is the expected response struct that should be received after

--- a/internal/db/p2p/replicator.go
+++ b/internal/db/p2p/replicator.go
@@ -232,11 +232,6 @@ func (p *P2P) pushHeadsForDoc(ctx context.Context, docID, collectionID string, p
 		return err
 	}
 	for _, head := range heads {
-		rawblock, err := head.block.Marshal()
-		if err != nil {
-			return NewErrMarshalBlock(err, docID, head.cid.String())
-		}
-
 		ctx, cancel := context.WithTimeout(ctx, networkRequestTimeout)
 		defer cancel()
 		pushLogReq := protocol.PushLogRequest{
@@ -244,7 +239,6 @@ func (p *P2P) pushHeadsForDoc(ctx context.Context, docID, collectionID string, p
 			CID:          head.cid.Bytes(),
 			CollectionID: collectionID,
 			Creator:      p.host.ID(),
-			Block:        rawblock,
 		}
 
 		if _, err := p.replicatorProtocol.SendRequest(ctx, pushLogReq, peerID); err != nil {
@@ -381,7 +375,6 @@ func (p *P2P) pushLogToReplicators(lg event.Update) {
 					CID:          lg.Cid.Bytes(),
 					CollectionID: lg.CollectionID,
 					Creator:      p.host.ID(),
-					Block:        lg.Block,
 				}
 				if _, err := p.replicatorProtocol.SendRequest(ctx, pushLogReq, peerID); err != nil {
 					log.ErrorE(
@@ -834,11 +827,6 @@ func (p *P2P) retryDoc(ctx context.Context, peerID string, docID string) error {
 		default:
 		}
 
-		rawblock, err := head.block.Marshal()
-		if err != nil {
-			return NewErrMarshalBlock(err, docID, head.cid.String())
-		}
-
 		ctx, cancel := context.WithTimeout(ctx, networkRequestTimeout)
 		defer cancel()
 		pushLogReq := protocol.PushLogRequest{
@@ -846,7 +834,6 @@ func (p *P2P) retryDoc(ctx context.Context, peerID string, docID string) error {
 			CID:          head.cid.Bytes(),
 			CollectionID: head.block.Delta.GetCollectionVersionID(),
 			Creator:      p.host.ID(),
-			Block:        rawblock,
 		}
 		if _, err := p.replicatorProtocol.SendRequest(ctx, pushLogReq, peerID); err != nil {
 			return NewErrSendReplicatorRequest(err, peerID, docID)

--- a/internal/db/p2p/sync_branchable_col.go
+++ b/internal/db/p2p/sync_branchable_col.go
@@ -16,8 +16,6 @@ import (
 
 	"github.com/fxamacker/cbor/v2"
 	"github.com/ipfs/go-cid"
-	"github.com/ipld/go-ipld-prime/linking"
-	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 
 	"github.com/sourcenetwork/corelog"
 
@@ -213,14 +211,16 @@ func (p *P2P) handleSyncBranchableCollectionResponse(
 	return reply.Sender, nil
 }
 
-// syncCollectionAndMerge synchronizes a branchable collection from a remote peer and publishes a merge event.
+// syncCollectionAndMerge pulls a branchable collection's blocks from a remote peer and publishes a
+// merge event.
 func (p *P2P) syncCollectionAndMerge(
 	ctx context.Context,
 	senderID string,
 	collectionID string,
 	head cid.Cid,
 ) error {
-	err := p.syncCollectionDAG(ctx, head)
+	// Collection-level commits have no docID, so we pull the whole reachable tree.
+	err := p.pullAndIngest(ctx, senderID, "", collectionID, head)
 	if err != nil {
 		return err
 	}
@@ -233,23 +233,6 @@ func (p *P2P) syncCollectionAndMerge(
 	}
 
 	return p.db.Merge(ctx, evt)
-}
-
-// syncCollectionDAG synchronizes the DAG for a specific branchable collection CID.
-func (p *P2P) syncCollectionDAG(ctx context.Context, colCid cid.Cid) error {
-	linkSys := makeLinkSystem(p.host.IPLDStore())
-
-	nd, err := linkSys.Load(linking.LinkContext{Ctx: ctx}, cidlink.Link{Cid: colCid}, coreblock.BlockSchemaPrototype)
-	if err != nil {
-		return err
-	}
-
-	linkBlock, err := coreblock.GetFromNode(nd)
-	if err != nil {
-		return err
-	}
-
-	return p.syncDAG(ctx, linkBlock)
 }
 
 // syncBranchableCollectionMessageHandler handles incoming branchable collection sync requests from the pubsub network.

--- a/internal/db/p2p/sync_dag.go
+++ b/internal/db/p2p/sync_dag.go
@@ -33,29 +33,6 @@ func makeLinkSystem(blockService blockstore.IPLDStore) linking.LinkSystem {
 	return linkSys
 }
 
-// syncDAG synchronizes the DAG starting with the given block
-// using the blockservice to fetch remote blocks.
-//
-// This process walks the entire DAG until the issue below is resolved.
-// https://github.com/sourcenetwork/defradb/issues/2722
-func (p *P2P) syncDAG(ctx context.Context, block *coreblock.Block) error {
-	sessionCtx, cancelSession := context.WithCancel(ctx)
-	defer cancelSession()
-
-	// use a session to make remote fetches more efficient
-	sessionCtx = p.host.ContextWithSession(sessionCtx)
-
-	linkSystem := makeLinkSystem(p.host.IPLDStore())
-
-	// Store the block in the DAG store
-	_, err := linkSystem.Store(linking.LinkContext{Ctx: sessionCtx}, coreblock.GetLinkPrototype(), block.GenerateNode())
-	if err != nil {
-		return NewErrStoreBlockDAGSync(err)
-	}
-
-	return p.loadBlockLinks(sessionCtx, &linkSystem, block)
-}
-
 // loadBlockLinks loads the links of a block recursively.
 //
 // The function returns immediately on the first error encountered.

--- a/internal/db/p2p/sync_doc.go
+++ b/internal/db/p2p/sync_doc.go
@@ -18,8 +18,6 @@ import (
 
 	"github.com/fxamacker/cbor/v2"
 	"github.com/ipfs/go-cid"
-	"github.com/ipld/go-ipld-prime/linking"
-	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 
 	"github.com/sourcenetwork/corelog"
 
@@ -235,14 +233,14 @@ func (p *P2P) handleDocSyncItem(
 	}
 }
 
-// syncDocumentAndMerge synchronizes a document from a remote peer and publishes a merge event.
+// syncDocumentAndMerge pulls a document's blocks from a remote peer and publishes a merge event.
 func (p *P2P) syncDocumentAndMerge(
 	ctx context.Context,
 	senderID string,
 	collectionID, docID string,
 	head cid.Cid,
 ) error {
-	err := p.syncDocumentDAG(ctx, head)
+	err := p.pullAndIngest(ctx, senderID, docID, collectionID, head)
 	if err != nil {
 		return err
 	}
@@ -256,23 +254,6 @@ func (p *P2P) syncDocumentAndMerge(
 	}
 
 	return p.db.Merge(ctx, evt)
-}
-
-// syncDocumentDAG synchronizes the DAG for a specific document CID.
-func (p *P2P) syncDocumentDAG(ctx context.Context, docCid cid.Cid) error {
-	linkSys := makeLinkSystem(p.host.IPLDStore())
-
-	nd, err := linkSys.Load(linking.LinkContext{Ctx: ctx}, cidlink.Link{Cid: docCid}, coreblock.BlockSchemaPrototype)
-	if err != nil {
-		return err
-	}
-
-	linkBlock, err := coreblock.GetFromNode(nd)
-	if err != nil {
-		return err
-	}
-
-	return p.syncDAG(ctx, linkBlock)
 }
 
 // docSyncMessageHandler handles incoming document sync requests from the pubsub network.

--- a/internal/se/coordinator.go
+++ b/internal/se/coordinator.go
@@ -249,7 +249,13 @@ func (coordinator *Coordinator) HandlePushToReplicators(ctx context.Context, evt
 		return nil
 	}
 
-	block, err := coreblock.GetFromBytes(evt.Block)
+	// The update event no longer carries the block bytes; this handler runs on the node that
+	// produced the update, so the composite block is available locally by its CID.
+	rawBlock, err := coordinator.db.Multistore().Blockstore().Get(ctx, evt.Cid)
+	if err != nil {
+		return NewErrFailedToDeserializeBlock(err)
+	}
+	block, err := coreblock.GetFromBytes(rawBlock.RawData())
 	if err != nil {
 		return NewErrFailedToDeserializeBlock(err)
 	}

--- a/internal/se/coordinator_push_test.go
+++ b/internal/se/coordinator_push_test.go
@@ -51,7 +51,7 @@ func TestReplicationCoordinator_WhenBlockFailsToDeserialize_ShouldReturnError(t 
 	updateEvent := event.Update{
 		DocID:        setup.docID,
 		CollectionID: setup.collectionID,
-		Block:        []byte("invalid-block-data"),
+		Cid:          setup.storeBlock([]byte("invalid-block-data")),
 	}
 	err := setup.coordinator.HandlePushToReplicators(context.Background(), updateEvent)
 	require.Error(t, err, "Should return error when block fails to deserialize")
@@ -66,7 +66,7 @@ func TestReplicationCoordinator_WhenNonCompositeBlock_ShouldNotPushToPeer(t *tes
 	updateEvent := event.Update{
 		DocID:        setup.docID,
 		CollectionID: setup.collectionID,
-		Block:        setup.createNonCompositeBlock(),
+		Cid:          setup.storeBlock(setup.createNonCompositeBlock()),
 	}
 	err := setup.coordinator.HandlePushToReplicators(context.Background(), updateEvent)
 	require.NoError(t, err)

--- a/internal/se/coordinator_test.go
+++ b/internal/se/coordinator_test.go
@@ -15,6 +15,8 @@ import (
 	"testing"
 	"time"
 
+	blocks "github.com/ipfs/go-block-format"
+	"github.com/ipfs/go-cid"
 	ipld "github.com/ipld/go-ipld-prime"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	"github.com/ipld/go-ipld-prime/storage/memstore"
@@ -30,6 +32,8 @@ import (
 	"github.com/sourcenetwork/defradb/event"
 	coreblock "github.com/sourcenetwork/defradb/internal/core/block"
 	"github.com/sourcenetwork/defradb/internal/core/crdt"
+	"github.com/sourcenetwork/defradb/internal/datastore"
+	"github.com/sourcenetwork/defradb/internal/db/lock"
 	protocolmocks "github.com/sourcenetwork/defradb/internal/db/p2p/protocol/mocks"
 	"github.com/sourcenetwork/defradb/internal/se/mocks"
 )
@@ -66,6 +70,8 @@ func newTestSetup(t *testing.T) *testSetup {
 	mockDB := mocks.NewDB(t)
 	mockDB.EXPECT().MaxTxnRetries().Return(3).Maybe()
 	mockDB.EXPECT().Events().Return(mockEventBus).Maybe()
+	mockDB.EXPECT().Multistore().
+		Return(datastore.NewMultistore(rootstore, lock.NewLockSet(), immutable.None[int]())).Maybe()
 	// NewTxn is not stubbed globally - individual tests that need it will set it up
 
 	mockP2PImpl := mocks.NewP2P(t)
@@ -242,9 +248,19 @@ func (s *testSetup) makeUpdateEvent() event.Update {
 	updateEvent := event.Update{
 		DocID:        s.docID,
 		CollectionID: s.collectionID,
-		Block:        s.createValidCompositeBlock(),
+		Cid:          s.storeBlock(s.createValidCompositeBlock()),
 	}
 	return updateEvent
+}
+
+// storeBlock writes the given raw block bytes into the (shared) block store and returns the CID
+// under which they are stored. The update event now carries only the CID, so consumers that need
+// the block read it back from the store.
+func (s *testSetup) storeBlock(blockBytes []byte) cid.Cid {
+	b := blocks.NewBlock(blockBytes)
+	ms := datastore.NewMultistore(s.rootstore, lock.NewLockSet(), immutable.None[int]())
+	require.NoError(s.t, ms.Blockstore().Put(context.Background(), b))
+	return b.Cid()
 }
 
 // createValidCompositeBlock creates a proper CBOR-encoded composite block using the pattern from block_test.go


### PR DESCRIPTION
## Relevant issue(s)

Resolves #TBD

## Description

This PR removes the use of Bitswap from DefraDB. 

Cleanup still needed but it will give the team a good enough idea of what it involves.


