### PR TITLE
refactor: Inconsistent cli flags

### DIFF
--- a/cli/client.go
+++ b/cli/client.go
@@ -14,6 +14,8 @@ import (
 	"context"
 
 	"github.com/spf13/cobra"
+
+	"github.com/sourcenetwork/defradb/cli/config"
 )
 
 func MakeClientCommand(ctx context.Context) *cobra.Command {
@@ -43,5 +45,25 @@ Execute queries, add collections, obtain node info, etc.`,
 	cmd.PersistentFlags().StringVarP(&identity, "identity", "i", "",
 		"Hex formatted private key used to authenticate with ACP")
 	cmd.PersistentFlags().Uint64Var(&txID, "tx", 0, "Transaction ID")
+	setClientConnectionFlags(cmd)
 	return cmd
+}
+
+func setClientConnectionFlags(cmd *cobra.Command) {
+	cfg := config.DefaultConfig()
+	cmd.PersistentFlags().String(
+		"url",
+		cfg.GetString(config.ConfigFlags["url"]),
+		"URL of HTTP endpoint to listen on or connect to",
+	)
+	cmd.PersistentFlags().String(
+		"audience",
+		cfg.GetString(config.ConfigFlags["audience"]),
+		"Audience to set on minted auth tokens. Defaults to the host of --url",
+	)
+	cmd.PersistentFlags().String(
+		"source-hub-address",
+		cfg.GetString(config.ConfigFlags["source-hub-address"]),
+		"The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor",
+	)
 }

--- a/cli/collection_delete.go
+++ b/cli/collection_delete.go
@@ -22,8 +22,9 @@ import (
 
 func MakeCollectionDeleteCommand(ctx context.Context) *cobra.Command {
 	var activeOnly bool
+	var collectionNames []string
 	var cmd = &cobra.Command{
-		Use:   "delete <collectionNames>",
+		Use:   "delete --collection-name <collectionNames>",
 		Short: "Delete collections",
 		Long: `Delete one or more collections by name.
 
@@ -38,10 +39,10 @@ and keep earlier versions intact.
 
 The named collections must not contain any documents. Delete all documents first
 before deleting the collection.`,
-		Args: cobra.ExactArgs(1),
+		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			names := strings.Split(args[0], ",")
-			for i, name := range names {
+			names := make([]string, len(collectionNames))
+			for i, name := range collectionNames {
 				names[i] = strings.TrimSpace(name)
 			}
 
@@ -53,19 +54,20 @@ before deleting the collection.`,
 		},
 	}
 
+	cmd.Flags().StringSliceVar(&collectionNames, "collection-name", nil, "Collection name")
 	cmd.Flags().BoolVar(&activeOnly, "active-only", false,
 		"Delete only the active head version of each named collection (default deletes every version)")
 
 	EmbedCLIExample(ctx, cmd, "delete every version of a single collection",
-		`defradb client collection delete Users`)
+		`defradb client collection delete --collection-name Users`)
 
 	EmbedCLIExample(ctx, cmd,
 		"delete every version of multiple collections in one call (this can be used to delete collections "+
 			"that reference each other via relations)",
-		`defradb client collection delete Users,Books`)
+		`defradb client collection delete --collection-name Users,Books`)
 
 	EmbedCLIExample(ctx, cmd, "delete only the active head version, keeping earlier versions",
-		`defradb client collection delete --active-only Users`)
+		`defradb client collection delete --active-only --collection-name Users`)
 
 	return cmd
 }

--- a/cli/keyring.go
+++ b/cli/keyring.go
@@ -14,6 +14,8 @@ import (
 	"context"
 
 	"github.com/spf13/cobra"
+
+	"github.com/sourcenetwork/defradb/cli/config"
 )
 
 func MakeKeyringCommand(ctx context.Context) *cobra.Command {
@@ -35,5 +37,30 @@ The following keys are loaded from the keyring on start:
 	EmbedCLIExample(ctx, cmd, "Import externally generated keys",
 		"defradb keyring add <name> <private-key-hex>")
 
+	setKeyringFlags(cmd)
+
 	return cmd
+}
+
+func setKeyringFlags(cmd *cobra.Command) {
+	cfg := config.DefaultConfig()
+	cmd.PersistentFlags().String(
+		"keyring-namespace",
+		cfg.GetString(config.ConfigFlags["keyring-namespace"]),
+		"Service name to use when using the system backend",
+	)
+	cmd.PersistentFlags().String(
+		"keyring-backend",
+		cfg.GetString(config.ConfigFlags["keyring-backend"]),
+		"Keyring backend to use. Options are file or system",
+	)
+	cmd.PersistentFlags().String(
+		"keyring-path",
+		cfg.GetString(config.ConfigFlags["keyring-path"]),
+		"Path (relative to DefraDB root directory) to store encrypted keys when using the file backend",
+	)
+	cmd.PersistentFlags().String(
+		"secret-file",
+		cfg.GetString(config.ConfigFlags["secret-file"]),
+		"Path to the file containing secrets")
 }

--- a/cli/root.go
+++ b/cli/root.go
@@ -76,44 +76,5 @@ Start a DefraDB node, interact with a local or remote node, and much more.
 		cfg.GetBool(config.ConfigFlags["no-log-color"]),
 		"Disable colored log output",
 	)
-	cmd.PersistentFlags().String(
-		"url",
-		cfg.GetString(config.ConfigFlags["url"]),
-		"URL of HTTP endpoint to listen on or connect to",
-	)
-	cmd.PersistentFlags().String(
-		"audience",
-		cfg.GetString(config.ConfigFlags["audience"]),
-		"Audience to set on minted auth tokens. Defaults to the host of --url",
-	)
-	cmd.PersistentFlags().String(
-		"keyring-namespace",
-		cfg.GetString(config.ConfigFlags["keyring-namespace"]),
-		"Service name to use when using the system backend",
-	)
-	cmd.PersistentFlags().String(
-		"keyring-backend",
-		cfg.GetString(config.ConfigFlags["keyring-backend"]),
-		"Keyring backend to use. Options are file or system",
-	)
-	cmd.PersistentFlags().String(
-		"keyring-path",
-		cfg.GetString(config.ConfigFlags["keyring-path"]),
-		"Path (relative to DefraDB root directory) to store encrypted keys when using the file backend",
-	)
-	cmd.PersistentFlags().Bool(
-		"no-keyring",
-		cfg.GetBool(config.ConfigFlags["no-keyring"]),
-		"Disable the keyring and generate ephemeral keys",
-	)
-	cmd.PersistentFlags().String(
-		"source-hub-address",
-		cfg.GetString(config.ConfigFlags["source-hub-address"]),
-		"The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor",
-	)
-	cmd.PersistentFlags().String(
-		"secret-file",
-		cfg.GetString(config.ConfigFlags["secret-file"]),
-		"Path to the file containing secrets")
 	return cmd
 }

--- a/cli/start.go
+++ b/cli/start.go
@@ -380,6 +380,13 @@ func MakeStartCommand(ctx context.Context) *cobra.Command {
 		"Retry intervals for the replicator. Format is a comma-separated list of whole number seconds. "+
 			"Example: 10,20,40,80,160,320",
 	)
+	cmd.PersistentFlags().Bool(
+		"no-keyring",
+		cfg.GetBool(config.ConfigFlags["no-keyring"]),
+		"Disable the keyring and generate ephemeral keys",
+	)
+	setClientConnectionFlags(cmd)
+	setKeyringFlags(cmd)
 	return cmd
 }
 

--- a/docs/website/references/cli/defradb.md
+++ b/docs/website/references/cli/defradb.md
@@ -12,23 +12,15 @@ Start a DefraDB node, interact with a local or remote node, and much more.
 ### Options
 
 ```
-      --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
-  -h, --help                        help for defradb
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
-      --log-format string           Log format to use. Options are text or json (default "text")
-      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                  Include source location in logs
-      --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
-      --no-log-color                Disable colored log output
-      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
-      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+  -h, --help                   help for defradb
+      --log-format string      Log format to use. Options are text or json (default "text")
+      --log-level string       Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string      Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string   Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source             Include source location in logs
+      --log-stacktrace         Include stacktrace in error and fatal logs
+      --no-log-color           Disable colored log output
+      --rootdir string         Directory for persistent data (default: $HOME/.defradb)
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client.md
+++ b/docs/website/references/cli/defradb_client.md
@@ -10,30 +10,25 @@ Execute queries, add collections, obtain node info, etc.
 ### Options
 
 ```
-  -h, --help              help for client
-  -i, --identity string   Hex formatted private key used to authenticate with ACP
-      --tx uint           Transaction ID
+      --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
+  -h, --help                        help for client
+  -i, --identity string             Hex formatted private key used to authenticate with ACP
+      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
+      --tx uint                     Transaction ID
+      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
-      --log-format string           Log format to use. Options are text or json (default "text")
-      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                  Include source location in logs
-      --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
-      --no-log-color                Disable colored log output
-      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
-      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+      --log-format string      Log format to use. Options are text or json (default "text")
+      --log-level string       Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string      Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string   Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source             Include source location in logs
+      --log-stacktrace         Include stacktrace in error and fatal logs
+      --no-log-color           Disable colored log output
+      --rootdir string         Directory for persistent data (default: $HOME/.defradb)
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_client_acp.md
+++ b/docs/website/references/cli/defradb_client_acp.md
@@ -24,19 +24,14 @@ systems.
 ```
       --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
   -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
       --log-format string           Log format to use. Options are text or json (default "text")
       --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
       --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
       --log-source                  Include source location in logs
       --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
       --no-log-color                Disable colored log output
       --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --tx uint                     Transaction ID
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")

--- a/docs/website/references/cli/defradb_client_acp_document.md
+++ b/docs/website/references/cli/defradb_client_acp_document.md
@@ -23,19 +23,14 @@ system.
 ```
       --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
   -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
       --log-format string           Log format to use. Options are text or json (default "text")
       --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
       --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
       --log-source                  Include source location in logs
       --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
       --no-log-color                Disable colored log output
       --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --tx uint                     Transaction ID
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")

--- a/docs/website/references/cli/defradb_client_acp_document_policy.md
+++ b/docs/website/references/cli/defradb_client_acp_document_policy.md
@@ -17,19 +17,14 @@ Interact with the document acp policy features of DefraDB instance
 ```
       --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
   -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
       --log-format string           Log format to use. Options are text or json (default "text")
       --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
       --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
       --log-source                  Include source location in logs
       --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
       --no-log-color                Disable colored log output
       --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --tx uint                     Transaction ID
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")

--- a/docs/website/references/cli/defradb_client_acp_document_policy_add.md
+++ b/docs/website/references/cli/defradb_client_acp_document_policy_add.md
@@ -71,19 +71,14 @@ Add from stdin:
 ```
       --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
   -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
       --log-format string           Log format to use. Options are text or json (default "text")
       --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
       --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
       --log-source                  Include source location in logs
       --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
       --no-log-color                Disable colored log output
       --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --tx uint                     Transaction ID
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")

--- a/docs/website/references/cli/defradb_client_acp_document_relationship.md
+++ b/docs/website/references/cli/defradb_client_acp_document_relationship.md
@@ -17,19 +17,14 @@ Interact with the document acp relationship features of DefraDB instance
 ```
       --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
   -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
       --log-format string           Log format to use. Options are text or json (default "text")
       --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
       --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
       --log-source                  Include source location in logs
       --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
       --no-log-color                Disable colored log output
       --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --tx uint                     Transaction ID
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")

--- a/docs/website/references/cli/defradb_client_acp_document_relationship_add.md
+++ b/docs/website/references/cli/defradb_client_acp_document_relationship_add.md
@@ -64,19 +64,14 @@ Let all actors read a private document:
 ```
       --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
   -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
       --log-format string           Log format to use. Options are text or json (default "text")
       --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
       --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
       --log-source                  Include source location in logs
       --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
       --no-log-color                Disable colored log output
       --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --tx uint                     Transaction ID
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")

--- a/docs/website/references/cli/defradb_client_acp_document_relationship_delete.md
+++ b/docs/website/references/cli/defradb_client_acp_document_relationship_delete.md
@@ -56,19 +56,14 @@ Remove an actor from reading a private document:
 ```
       --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
   -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
       --log-format string           Log format to use. Options are text or json (default "text")
       --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
       --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
       --log-source                  Include source location in logs
       --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
       --no-log-color                Disable colored log output
       --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --tx uint                     Transaction ID
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")

--- a/docs/website/references/cli/defradb_client_acp_node.md
+++ b/docs/website/references/cli/defradb_client_acp_node.md
@@ -37,19 +37,14 @@ system.
 ```
       --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
   -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
       --log-format string           Log format to use. Options are text or json (default "text")
       --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
       --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
       --log-source                  Include source location in logs
       --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
       --no-log-color                Disable colored log output
       --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --tx uint                     Transaction ID
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")

--- a/docs/website/references/cli/defradb_client_acp_node_disable.md
+++ b/docs/website/references/cli/defradb_client_acp_node_disable.md
@@ -39,19 +39,14 @@ Disable node access control:
 ```
       --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
   -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
       --log-format string           Log format to use. Options are text or json (default "text")
       --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
       --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
       --log-source                  Include source location in logs
       --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
       --no-log-color                Disable colored log output
       --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --tx uint                     Transaction ID
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")

--- a/docs/website/references/cli/defradb_client_acp_node_re-enable.md
+++ b/docs/website/references/cli/defradb_client_acp_node_re-enable.md
@@ -38,19 +38,14 @@ Re-enable node access control:
 ```
       --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
   -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
       --log-format string           Log format to use. Options are text or json (default "text")
       --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
       --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
       --log-source                  Include source location in logs
       --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
       --no-log-color                Disable colored log output
       --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --tx uint                     Transaction ID
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")

--- a/docs/website/references/cli/defradb_client_acp_node_relationship.md
+++ b/docs/website/references/cli/defradb_client_acp_node_relationship.md
@@ -17,19 +17,14 @@ Interact with the node acp relationship features of DefraDB instance
 ```
       --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
   -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
       --log-format string           Log format to use. Options are text or json (default "text")
       --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
       --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
       --log-source                  Include source location in logs
       --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
       --no-log-color                Disable colored log output
       --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --tx uint                     Transaction ID
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")

--- a/docs/website/references/cli/defradb_client_acp_node_relationship_add.md
+++ b/docs/website/references/cli/defradb_client_acp_node_relationship_add.md
@@ -46,19 +46,14 @@ Make another actor an admin user:
 ```
       --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
   -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
       --log-format string           Log format to use. Options are text or json (default "text")
       --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
       --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
       --log-source                  Include source location in logs
       --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
       --no-log-color                Disable colored log output
       --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --tx uint                     Transaction ID
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")

--- a/docs/website/references/cli/defradb_client_acp_node_relationship_delete.md
+++ b/docs/website/references/cli/defradb_client_acp_node_relationship_delete.md
@@ -45,19 +45,14 @@ Revoke node access from an admin user:
 ```
       --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
   -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
       --log-format string           Log format to use. Options are text or json (default "text")
       --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
       --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
       --log-source                  Include source location in logs
       --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
       --no-log-color                Disable colored log output
       --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --tx uint                     Transaction ID
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")

--- a/docs/website/references/cli/defradb_client_acp_node_status.md
+++ b/docs/website/references/cli/defradb_client_acp_node_status.md
@@ -39,19 +39,14 @@ Check Node ACP status:
 ```
       --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
   -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
       --log-format string           Log format to use. Options are text or json (default "text")
       --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
       --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
       --log-source                  Include source location in logs
       --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
       --no-log-color                Disable colored log output
       --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --tx uint                     Transaction ID
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")

--- a/docs/website/references/cli/defradb_client_action.md
+++ b/docs/website/references/cli/defradb_client_action.md
@@ -26,19 +26,14 @@ List information about actions:
 ```
       --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
   -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
       --log-format string           Log format to use. Options are text or json (default "text")
       --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
       --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
       --log-source                  Include source location in logs
       --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
       --no-log-color                Disable colored log output
       --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --tx uint                     Transaction ID
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")

--- a/docs/website/references/cli/defradb_client_action_list.md
+++ b/docs/website/references/cli/defradb_client_action_list.md
@@ -29,19 +29,14 @@ List information about actions:
 ```
       --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
   -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
       --log-format string           Log format to use. Options are text or json (default "text")
       --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
       --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
       --log-source                  Include source location in logs
       --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
       --no-log-color                Disable colored log output
       --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --tx uint                     Transaction ID
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")

--- a/docs/website/references/cli/defradb_client_backup.md
+++ b/docs/website/references/cli/defradb_client_backup.md
@@ -18,19 +18,14 @@ Currently only supports JSON format.
 ```
       --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
   -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
       --log-format string           Log format to use. Options are text or json (default "text")
       --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
       --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
       --log-source                  Include source location in logs
       --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
       --no-log-color                Disable colored log output
       --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --tx uint                     Transaction ID
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")

--- a/docs/website/references/cli/defradb_client_backup_export.md
+++ b/docs/website/references/cli/defradb_client_backup_export.md
@@ -44,19 +44,14 @@ Export data for the 'Users' collection:
 ```
       --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
   -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
       --log-format string           Log format to use. Options are text or json (default "text")
       --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
       --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
       --log-source                  Include source location in logs
       --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
       --no-log-color                Disable colored log output
       --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --tx uint                     Transaction ID
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")

--- a/docs/website/references/cli/defradb_client_backup_import.md
+++ b/docs/website/references/cli/defradb_client_backup_import.md
@@ -28,19 +28,14 @@ Import data to the database:
 ```
       --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
   -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
       --log-format string           Log format to use. Options are text or json (default "text")
       --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
       --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
       --log-source                  Include source location in logs
       --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
       --no-log-color                Disable colored log output
       --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --tx uint                     Transaction ID
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")

--- a/docs/website/references/cli/defradb_client_block.md
+++ b/docs/website/references/cli/defradb_client_block.md
@@ -17,19 +17,14 @@ Manage blocks of a running DefraDB instance.
 ```
       --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
   -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
       --log-format string           Log format to use. Options are text or json (default "text")
       --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
       --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
       --log-source                  Include source location in logs
       --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
       --no-log-color                Disable colored log output
       --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --tx uint                     Transaction ID
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")

--- a/docs/website/references/cli/defradb_client_block_verify-signature.md
+++ b/docs/website/references/cli/defradb_client_block_verify-signature.md
@@ -33,19 +33,14 @@ verify the signature of a block:
 ```
       --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
   -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
       --log-format string           Log format to use. Options are text or json (default "text")
       --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
       --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
       --log-source                  Include source location in logs
       --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
       --no-log-color                Disable colored log output
       --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --tx uint                     Transaction ID
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")

--- a/docs/website/references/cli/defradb_client_collection.md
+++ b/docs/website/references/cli/defradb_client_collection.md
@@ -18,19 +18,14 @@ Add, describe, patch, set-active, delete, and truncate collections.
 
 ```
       --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
       --log-format string           Log format to use. Options are text or json (default "text")
       --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
       --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
       --log-source                  Include source location in logs
       --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
       --no-log-color                Disable colored log output
       --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```

--- a/docs/website/references/cli/defradb_client_collection_add.md
+++ b/docs/website/references/cli/defradb_client_collection_add.md
@@ -48,19 +48,14 @@ add from stdin:
 ```
       --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
   -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
       --log-format string           Log format to use. Options are text or json (default "text")
       --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
       --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
       --log-source                  Include source location in logs
       --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
       --no-log-color                Disable colored log output
       --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --tx uint                     Transaction ID
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")

--- a/docs/website/references/cli/defradb_client_collection_delete.md
+++ b/docs/website/references/cli/defradb_client_collection_delete.md
@@ -19,27 +19,28 @@ The named collections must not contain any documents. Delete all documents first
 before deleting the collection.
 
 ```
-defradb client collection delete <collectionNames> [flags]
+defradb client collection delete --collection-name <collectionNames> [flags]
 ```
 
 ### Examples
 
 ```
 delete every version of a single collection:  
-  defradb client collection delete Users
+  defradb client collection delete --collection-name Users
 
 delete every version of multiple collections in one call (this can be used to delete collections that reference each other via relations):  
-  defradb client collection delete Users,Books
+  defradb client collection delete --collection-name Users,Books
 
 delete only the active head version, keeping earlier versions:  
-  defradb client collection delete --active-only Users
+  defradb client collection delete --active-only --collection-name Users
 ```
 
 ### Options
 
 ```
-      --active-only   Delete only the active head version of each named collection (default deletes every version)
-  -h, --help          help for delete
+      --active-only               Delete only the active head version of each named collection (default deletes every version)
+      --collection-name strings   Collection name
+  -h, --help                      help for delete
 ```
 
 ### Options inherited from parent commands

--- a/docs/website/references/cli/defradb_client_collection_delete.md
+++ b/docs/website/references/cli/defradb_client_collection_delete.md
@@ -48,19 +48,14 @@ delete only the active head version, keeping earlier versions:
 ```
       --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
   -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
       --log-format string           Log format to use. Options are text or json (default "text")
       --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
       --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
       --log-source                  Include source location in logs
       --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
       --no-log-color                Disable colored log output
       --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --tx uint                     Transaction ID
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")

--- a/docs/website/references/cli/defradb_client_collection_describe.md
+++ b/docs/website/references/cli/defradb_client_collection_describe.md
@@ -41,19 +41,14 @@ view collection by version id:
 ```
       --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
   -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
       --log-format string           Log format to use. Options are text or json (default "text")
       --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
       --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
       --log-source                  Include source location in logs
       --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
       --no-log-color                Disable colored log output
       --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --tx uint                     Transaction ID
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")

--- a/docs/website/references/cli/defradb_client_collection_patch.md
+++ b/docs/website/references/cli/defradb_client_collection_patch.md
@@ -40,19 +40,14 @@ patch from stdin:
 ```
       --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
   -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
       --log-format string           Log format to use. Options are text or json (default "text")
       --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
       --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
       --log-source                  Include source location in logs
       --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
       --no-log-color                Disable colored log output
       --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --tx uint                     Transaction ID
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")

--- a/docs/website/references/cli/defradb_client_collection_set-active.md
+++ b/docs/website/references/cli/defradb_client_collection_set-active.md
@@ -22,19 +22,14 @@ defradb client collection set-active <versionID> [flags]
 ```
       --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
   -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
       --log-format string           Log format to use. Options are text or json (default "text")
       --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
       --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
       --log-source                  Include source location in logs
       --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
       --no-log-color                Disable colored log output
       --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --tx uint                     Transaction ID
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")

--- a/docs/website/references/cli/defradb_client_collection_truncate.md
+++ b/docs/website/references/cli/defradb_client_collection_truncate.md
@@ -26,19 +26,14 @@ defradb client collection truncate [flags]
 ```
       --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
   -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
       --log-format string           Log format to use. Options are text or json (default "text")
       --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
       --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
       --log-source                  Include source location in logs
       --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
       --no-log-color                Disable colored log output
       --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --tx uint                     Transaction ID
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")

--- a/docs/website/references/cli/defradb_client_document.md
+++ b/docs/website/references/cli/defradb_client_document.md
@@ -18,19 +18,14 @@ Add, read, update, and delete documents within a collection.
 
 ```
       --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
       --log-format string           Log format to use. Options are text or json (default "text")
       --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
       --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
       --log-source                  Include source location in logs
       --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
       --no-log-color                Disable colored log output
       --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
 ```

--- a/docs/website/references/cli/defradb_client_document_add.md
+++ b/docs/website/references/cli/defradb_client_document_add.md
@@ -64,19 +64,14 @@ Add from stdin:
 ```
       --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
   -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
       --log-format string           Log format to use. Options are text or json (default "text")
       --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
       --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
       --log-source                  Include source location in logs
       --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
       --no-log-color                Disable colored log output
       --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --tx uint                     Transaction ID
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")

--- a/docs/website/references/cli/defradb_client_document_delete.md
+++ b/docs/website/references/cli/defradb_client_document_delete.md
@@ -45,19 +45,14 @@ delete by filter:
 ```
       --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
   -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
       --log-format string           Log format to use. Options are text or json (default "text")
       --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
       --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
       --log-source                  Include source location in logs
       --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
       --no-log-color                Disable colored log output
       --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --tx uint                     Transaction ID
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")

--- a/docs/website/references/cli/defradb_client_document_get.md
+++ b/docs/website/references/cli/defradb_client_document_get.md
@@ -37,19 +37,14 @@ Get a private document using an identity:
 ```
       --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
   -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
       --log-format string           Log format to use. Options are text or json (default "text")
       --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
       --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
       --log-source                  Include source location in logs
       --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
       --no-log-color                Disable colored log output
       --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --tx uint                     Transaction ID
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")

--- a/docs/website/references/cli/defradb_client_document_update.md
+++ b/docs/website/references/cli/defradb_client_document_update.md
@@ -45,19 +45,14 @@ update private docID, with identity:
 ```
       --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
   -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
       --log-format string           Log format to use. Options are text or json (default "text")
       --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
       --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
       --log-source                  Include source location in logs
       --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
       --no-log-color                Disable colored log output
       --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --tx uint                     Transaction ID
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")

--- a/docs/website/references/cli/defradb_client_dump.md
+++ b/docs/website/references/cli/defradb_client_dump.md
@@ -17,19 +17,14 @@ defradb client dump [flags]
 ```
       --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
   -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
       --log-format string           Log format to use. Options are text or json (default "text")
       --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
       --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
       --log-source                  Include source location in logs
       --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
       --no-log-color                Disable colored log output
       --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --tx uint                     Transaction ID
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")

--- a/docs/website/references/cli/defradb_client_encrypted-index.md
+++ b/docs/website/references/cli/defradb_client_encrypted-index.md
@@ -17,19 +17,14 @@ Manage collections' encrypted indexes on a running DefraDB node.
 ```
       --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
   -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
       --log-format string           Log format to use. Options are text or json (default "text")
       --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
       --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
       --log-source                  Include source location in logs
       --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
       --no-log-color                Disable colored log output
       --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --tx uint                     Transaction ID
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")

--- a/docs/website/references/cli/defradb_client_encrypted-index_delete.md
+++ b/docs/website/references/cli/defradb_client_encrypted-index_delete.md
@@ -30,19 +30,14 @@ delete an encrypted index for 'Users' collection on 'name' field:
 ```
       --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
   -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
       --log-format string           Log format to use. Options are text or json (default "text")
       --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
       --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
       --log-source                  Include source location in logs
       --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
       --no-log-color                Disable colored log output
       --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --tx uint                     Transaction ID
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")

--- a/docs/website/references/cli/defradb_client_encrypted-index_list.md
+++ b/docs/website/references/cli/defradb_client_encrypted-index_list.md
@@ -32,19 +32,14 @@ show all encrypted indexes for 'Users' collection:
 ```
       --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
   -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
       --log-format string           Log format to use. Options are text or json (default "text")
       --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
       --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
       --log-source                  Include source location in logs
       --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
       --no-log-color                Disable colored log output
       --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --tx uint                     Transaction ID
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")

--- a/docs/website/references/cli/defradb_client_encrypted-index_new.md
+++ b/docs/website/references/cli/defradb_client_encrypted-index_new.md
@@ -35,19 +35,14 @@ make a new index for 'Users' collection on 'name' field:
 ```
       --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
   -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
       --log-format string           Log format to use. Options are text or json (default "text")
       --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
       --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
       --log-source                  Include source location in logs
       --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
       --no-log-color                Disable colored log output
       --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --tx uint                     Transaction ID
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")

--- a/docs/website/references/cli/defradb_client_index.md
+++ b/docs/website/references/cli/defradb_client_index.md
@@ -17,19 +17,14 @@ Manage (new, delete, or list) collection indexes on a DefraDB node.
 ```
       --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
   -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
       --log-format string           Log format to use. Options are text or json (default "text")
       --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
       --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
       --log-source                  Include source location in logs
       --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
       --no-log-color                Disable colored log output
       --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --tx uint                     Transaction ID
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")

--- a/docs/website/references/cli/defradb_client_index_delete.md
+++ b/docs/website/references/cli/defradb_client_index_delete.md
@@ -30,19 +30,14 @@ delete the index 'UsersByName' for 'Users' collection:
 ```
       --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
   -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
       --log-format string           Log format to use. Options are text or json (default "text")
       --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
       --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
       --log-source                  Include source location in logs
       --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
       --no-log-color                Disable colored log output
       --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --tx uint                     Transaction ID
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")

--- a/docs/website/references/cli/defradb_client_index_list.md
+++ b/docs/website/references/cli/defradb_client_index_list.md
@@ -32,19 +32,14 @@ show all index for 'Users' collection:
 ```
       --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
   -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
       --log-format string           Log format to use. Options are text or json (default "text")
       --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
       --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
       --log-source                  Include source location in logs
       --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
       --no-log-color                Disable colored log output
       --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --tx uint                     Transaction ID
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")

--- a/docs/website/references/cli/defradb_client_index_new.md
+++ b/docs/website/references/cli/defradb_client_index_new.md
@@ -42,19 +42,14 @@ make a new unique index for 'Users' collection on 'name' and 'age':
 ```
       --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
   -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
       --log-format string           Log format to use. Options are text or json (default "text")
       --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
       --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
       --log-source                  Include source location in logs
       --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
       --no-log-color                Disable colored log output
       --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --tx uint                     Transaction ID
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")

--- a/docs/website/references/cli/defradb_client_lens.md
+++ b/docs/website/references/cli/defradb_client_lens.md
@@ -17,19 +17,14 @@ Make set or look for existing collection migrations on a DefraDB node.
 ```
       --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
   -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
       --log-format string           Log format to use. Options are text or json (default "text")
       --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
       --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
       --log-source                  Include source location in logs
       --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
       --no-log-color                Disable colored log output
       --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --tx uint                     Transaction ID
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")

--- a/docs/website/references/cli/defradb_client_lens_add.md
+++ b/docs/website/references/cli/defradb_client_lens_add.md
@@ -38,19 +38,14 @@ add from stdin:
 ```
       --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
   -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
       --log-format string           Log format to use. Options are text or json (default "text")
       --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
       --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
       --log-source                  Include source location in logs
       --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
       --no-log-color                Disable colored log output
       --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --tx uint                     Transaction ID
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")

--- a/docs/website/references/cli/defradb_client_lens_list.md
+++ b/docs/website/references/cli/defradb_client_lens_list.md
@@ -30,19 +30,14 @@ list all lenses:
 ```
       --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
   -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
       --log-format string           Log format to use. Options are text or json (default "text")
       --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
       --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
       --log-source                  Include source location in logs
       --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
       --no-log-color                Disable colored log output
       --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --tx uint                     Transaction ID
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")

--- a/docs/website/references/cli/defradb_client_lens_set.md
+++ b/docs/website/references/cli/defradb_client_lens_set.md
@@ -38,19 +38,14 @@ set from stdin:
 ```
       --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
   -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
       --log-format string           Log format to use. Options are text or json (default "text")
       --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
       --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
       --log-source                  Include source location in logs
       --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
       --no-log-color                Disable colored log output
       --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --tx uint                     Transaction ID
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")

--- a/docs/website/references/cli/defradb_client_node-identity.md
+++ b/docs/website/references/cli/defradb_client_node-identity.md
@@ -28,19 +28,14 @@ defradb client node-identity [flags]
 ```
       --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
   -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
       --log-format string           Log format to use. Options are text or json (default "text")
       --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
       --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
       --log-source                  Include source location in logs
       --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
       --no-log-color                Disable colored log output
       --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --tx uint                     Transaction ID
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")

--- a/docs/website/references/cli/defradb_client_node-options.md
+++ b/docs/website/references/cli/defradb_client_node-options.md
@@ -21,19 +21,14 @@ defradb client node-options [flags]
 ```
       --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
   -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
       --log-format string           Log format to use. Options are text or json (default "text")
       --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
       --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
       --log-source                  Include source location in logs
       --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
       --no-log-color                Disable colored log output
       --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --tx uint                     Transaction ID
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")

--- a/docs/website/references/cli/defradb_client_p2p.md
+++ b/docs/website/references/cli/defradb_client_p2p.md
@@ -17,19 +17,14 @@ Interact with the DefraDB P2P system
 ```
       --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
   -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
       --log-format string           Log format to use. Options are text or json (default "text")
       --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
       --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
       --log-source                  Include source location in logs
       --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
       --no-log-color                Disable colored log output
       --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --tx uint                     Transaction ID
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")

--- a/docs/website/references/cli/defradb_client_p2p_active-peers.md
+++ b/docs/website/references/cli/defradb_client_p2p_active-peers.md
@@ -23,19 +23,14 @@ defradb client p2p active-peers [flags]
 ```
       --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
   -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
       --log-format string           Log format to use. Options are text or json (default "text")
       --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
       --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
       --log-source                  Include source location in logs
       --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
       --no-log-color                Disable colored log output
       --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --tx uint                     Transaction ID
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")

--- a/docs/website/references/cli/defradb_client_p2p_collection.md
+++ b/docs/website/references/cli/defradb_client_p2p_collection.md
@@ -18,19 +18,14 @@ The selected collections synchronize their events on the pubsub network.
 ```
       --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
   -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
       --log-format string           Log format to use. Options are text or json (default "text")
       --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
       --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
       --log-source                  Include source location in logs
       --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
       --no-log-color                Disable colored log output
       --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --tx uint                     Transaction ID
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")

--- a/docs/website/references/cli/defradb_client_p2p_collection_add.md
+++ b/docs/website/references/cli/defradb_client_p2p_collection_add.md
@@ -32,19 +32,14 @@ add multiple collections:
 ```
       --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
   -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
       --log-format string           Log format to use. Options are text or json (default "text")
       --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
       --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
       --log-source                  Include source location in logs
       --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
       --no-log-color                Disable colored log output
       --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --tx uint                     Transaction ID
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")

--- a/docs/website/references/cli/defradb_client_p2p_collection_delete.md
+++ b/docs/website/references/cli/defradb_client_p2p_collection_delete.md
@@ -32,19 +32,14 @@ delete multiple collections:
 ```
       --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
   -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
       --log-format string           Log format to use. Options are text or json (default "text")
       --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
       --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
       --log-source                  Include source location in logs
       --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
       --no-log-color                Disable colored log output
       --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --tx uint                     Transaction ID
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")

--- a/docs/website/references/cli/defradb_client_p2p_collection_list.md
+++ b/docs/website/references/cli/defradb_client_p2p_collection_list.md
@@ -22,19 +22,14 @@ defradb client p2p collection list [flags]
 ```
       --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
   -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
       --log-format string           Log format to use. Options are text or json (default "text")
       --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
       --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
       --log-source                  Include source location in logs
       --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
       --no-log-color                Disable colored log output
       --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --tx uint                     Transaction ID
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")

--- a/docs/website/references/cli/defradb_client_p2p_collection_sync-branchable.md
+++ b/docs/website/references/cli/defradb_client_p2p_collection_sync-branchable.md
@@ -36,19 +36,14 @@ sync branchable collection with timeout:
 ```
       --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
   -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
       --log-format string           Log format to use. Options are text or json (default "text")
       --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
       --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
       --log-source                  Include source location in logs
       --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
       --no-log-color                Disable colored log output
       --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --tx uint                     Transaction ID
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")

--- a/docs/website/references/cli/defradb_client_p2p_collection_sync-versions.md
+++ b/docs/website/references/cli/defradb_client_p2p_collection_sync-versions.md
@@ -36,19 +36,14 @@ synchronize multiple collection versions:
 ```
       --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
   -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
       --log-format string           Log format to use. Options are text or json (default "text")
       --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
       --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
       --log-source                  Include source location in logs
       --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
       --no-log-color                Disable colored log output
       --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --tx uint                     Transaction ID
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")

--- a/docs/website/references/cli/defradb_client_p2p_connect.md
+++ b/docs/website/references/cli/defradb_client_p2p_connect.md
@@ -31,19 +31,14 @@ Connect to multiple peers:
 ```
       --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
   -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
       --log-format string           Log format to use. Options are text or json (default "text")
       --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
       --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
       --log-source                  Include source location in logs
       --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
       --no-log-color                Disable colored log output
       --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --tx uint                     Transaction ID
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")

--- a/docs/website/references/cli/defradb_client_p2p_disconnect.md
+++ b/docs/website/references/cli/defradb_client_p2p_disconnect.md
@@ -31,19 +31,14 @@ Disconnect from multiple peers:
 ```
       --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
   -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
       --log-format string           Log format to use. Options are text or json (default "text")
       --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
       --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
       --log-source                  Include source location in logs
       --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
       --no-log-color                Disable colored log output
       --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --tx uint                     Transaction ID
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")

--- a/docs/website/references/cli/defradb_client_p2p_document.md
+++ b/docs/website/references/cli/defradb_client_p2p_document.md
@@ -18,19 +18,14 @@ The selected documents synchronize their events on the pubsub network.
 ```
       --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
   -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
       --log-format string           Log format to use. Options are text or json (default "text")
       --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
       --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
       --log-source                  Include source location in logs
       --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
       --no-log-color                Disable colored log output
       --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --tx uint                     Transaction ID
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")

--- a/docs/website/references/cli/defradb_client_p2p_document_add.md
+++ b/docs/website/references/cli/defradb_client_p2p_document_add.md
@@ -32,19 +32,14 @@ add multiple documents:
 ```
       --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
   -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
       --log-format string           Log format to use. Options are text or json (default "text")
       --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
       --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
       --log-source                  Include source location in logs
       --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
       --no-log-color                Disable colored log output
       --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --tx uint                     Transaction ID
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")

--- a/docs/website/references/cli/defradb_client_p2p_document_delete.md
+++ b/docs/website/references/cli/defradb_client_p2p_document_delete.md
@@ -32,19 +32,14 @@ delete multiple documents:
 ```
       --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
   -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
       --log-format string           Log format to use. Options are text or json (default "text")
       --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
       --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
       --log-source                  Include source location in logs
       --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
       --no-log-color                Disable colored log output
       --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --tx uint                     Transaction ID
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")

--- a/docs/website/references/cli/defradb_client_p2p_document_list.md
+++ b/docs/website/references/cli/defradb_client_p2p_document_list.md
@@ -22,19 +22,14 @@ defradb client p2p document list [flags]
 ```
       --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
   -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
       --log-format string           Log format to use. Options are text or json (default "text")
       --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
       --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
       --log-source                  Include source location in logs
       --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
       --no-log-color                Disable colored log output
       --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --tx uint                     Transaction ID
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")

--- a/docs/website/references/cli/defradb_client_p2p_document_sync.md
+++ b/docs/website/references/cli/defradb_client_p2p_document_sync.md
@@ -35,19 +35,14 @@ sync multiple documents:
 ```
       --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
   -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
       --log-format string           Log format to use. Options are text or json (default "text")
       --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
       --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
       --log-source                  Include source location in logs
       --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
       --no-log-color                Disable colored log output
       --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --tx uint                     Transaction ID
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")

--- a/docs/website/references/cli/defradb_client_p2p_info.md
+++ b/docs/website/references/cli/defradb_client_p2p_info.md
@@ -21,19 +21,14 @@ defradb client p2p info [flags]
 ```
       --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
   -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
       --log-format string           Log format to use. Options are text or json (default "text")
       --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
       --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
       --log-source                  Include source location in logs
       --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
       --no-log-color                Disable colored log output
       --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --tx uint                     Transaction ID
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")

--- a/docs/website/references/cli/defradb_client_p2p_replicator.md
+++ b/docs/website/references/cli/defradb_client_p2p_replicator.md
@@ -18,19 +18,14 @@ A replicator replicates one or all collection(s) from one node to another.
 ```
       --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
   -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
       --log-format string           Log format to use. Options are text or json (default "text")
       --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
       --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
       --log-source                  Include source location in logs
       --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
       --no-log-color                Disable colored log output
       --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --tx uint                     Transaction ID
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")

--- a/docs/website/references/cli/defradb_client_p2p_replicator_add.md
+++ b/docs/website/references/cli/defradb_client_p2p_replicator_add.md
@@ -33,19 +33,14 @@ Add a replicator to replicate the "Orders" collection to multiple peers:
 ```
       --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
   -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
       --log-format string           Log format to use. Options are text or json (default "text")
       --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
       --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
       --log-source                  Include source location in logs
       --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
       --no-log-color                Disable colored log output
       --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --tx uint                     Transaction ID
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")

--- a/docs/website/references/cli/defradb_client_p2p_replicator_delete.md
+++ b/docs/website/references/cli/defradb_client_p2p_replicator_delete.md
@@ -30,19 +30,14 @@ Delete replicator:
 ```
       --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
   -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
       --log-format string           Log format to use. Options are text or json (default "text")
       --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
       --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
       --log-source                  Include source location in logs
       --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
       --no-log-color                Disable colored log output
       --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --tx uint                     Transaction ID
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")

--- a/docs/website/references/cli/defradb_client_p2p_replicator_list.md
+++ b/docs/website/references/cli/defradb_client_p2p_replicator_list.md
@@ -29,19 +29,14 @@ List all replicators:
 ```
       --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
   -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
       --log-format string           Log format to use. Options are text or json (default "text")
       --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
       --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
       --log-source                  Include source location in logs
       --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
       --no-log-color                Disable colored log output
       --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --tx uint                     Transaction ID
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")

--- a/docs/website/references/cli/defradb_client_purge.md
+++ b/docs/website/references/cli/defradb_client_purge.md
@@ -23,19 +23,14 @@ defradb client purge [flags]
 ```
       --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
   -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
       --log-format string           Log format to use. Options are text or json (default "text")
       --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
       --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
       --log-source                  Include source location in logs
       --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
       --no-log-color                Disable colored log output
       --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --tx uint                     Transaction ID
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")

--- a/docs/website/references/cli/defradb_client_query.md
+++ b/docs/website/references/cli/defradb_client_query.md
@@ -46,19 +46,14 @@ Read query from stdin:
 ```
       --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
   -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
       --log-format string           Log format to use. Options are text or json (default "text")
       --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
       --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
       --log-source                  Include source location in logs
       --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
       --no-log-color                Disable colored log output
       --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --tx uint                     Transaction ID
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")

--- a/docs/website/references/cli/defradb_client_tx.md
+++ b/docs/website/references/cli/defradb_client_tx.md
@@ -17,19 +17,14 @@ Create, commit, and discard DefraDB transactions
 ```
       --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
   -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
       --log-format string           Log format to use. Options are text or json (default "text")
       --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
       --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
       --log-source                  Include source location in logs
       --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
       --no-log-color                Disable colored log output
       --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --tx uint                     Transaction ID
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")

--- a/docs/website/references/cli/defradb_client_tx_commit.md
+++ b/docs/website/references/cli/defradb_client_tx_commit.md
@@ -21,19 +21,14 @@ defradb client tx commit <id> [flags]
 ```
       --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
   -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
       --log-format string           Log format to use. Options are text or json (default "text")
       --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
       --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
       --log-source                  Include source location in logs
       --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
       --no-log-color                Disable colored log output
       --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --tx uint                     Transaction ID
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")

--- a/docs/website/references/cli/defradb_client_tx_discard.md
+++ b/docs/website/references/cli/defradb_client_tx_discard.md
@@ -21,19 +21,14 @@ defradb client tx discard <id> [flags]
 ```
       --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
   -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
       --log-format string           Log format to use. Options are text or json (default "text")
       --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
       --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
       --log-source                  Include source location in logs
       --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
       --no-log-color                Disable colored log output
       --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --tx uint                     Transaction ID
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")

--- a/docs/website/references/cli/defradb_client_tx_new.md
+++ b/docs/website/references/cli/defradb_client_tx_new.md
@@ -22,19 +22,14 @@ defradb client tx new [flags]
 ```
       --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
   -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
       --log-format string           Log format to use. Options are text or json (default "text")
       --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
       --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
       --log-source                  Include source location in logs
       --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
       --no-log-color                Disable colored log output
       --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --tx uint                     Transaction ID
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")

--- a/docs/website/references/cli/defradb_client_view.md
+++ b/docs/website/references/cli/defradb_client_view.md
@@ -17,19 +17,14 @@ Manage (add) views withing a running DefraDB instance
 ```
       --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
   -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
       --log-format string           Log format to use. Options are text or json (default "text")
       --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
       --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
       --log-source                  Include source location in logs
       --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
       --no-log-color                Disable colored log output
       --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --tx uint                     Transaction ID
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")

--- a/docs/website/references/cli/defradb_client_view_add.md
+++ b/docs/website/references/cli/defradb_client_view_add.md
@@ -43,19 +43,14 @@ add from file flags using an existing lens CID:
 ```
       --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
   -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
       --log-format string           Log format to use. Options are text or json (default "text")
       --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
       --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
       --log-source                  Include source location in logs
       --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
       --no-log-color                Disable colored log output
       --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --tx uint                     Transaction ID
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")

--- a/docs/website/references/cli/defradb_client_view_refresh.md
+++ b/docs/website/references/cli/defradb_client_view_refresh.md
@@ -46,19 +46,14 @@ refresh views by version id:
 ```
       --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
   -i, --identity string             Hex formatted private key used to authenticate with ACP
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
       --log-format string           Log format to use. Options are text or json (default "text")
       --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
       --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
       --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
       --log-source                  Include source location in logs
       --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
       --no-log-color                Disable colored log output
       --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
       --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --tx uint                     Transaction ID
       --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")

--- a/docs/website/references/cli/defradb_identity.md
+++ b/docs/website/references/cli/defradb_identity.md
@@ -15,22 +15,14 @@ Interact with identity features of DefraDB instance
 ### Options inherited from parent commands
 
 ```
-      --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
-      --log-format string           Log format to use. Options are text or json (default "text")
-      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                  Include source location in logs
-      --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
-      --no-log-color                Disable colored log output
-      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
-      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+      --log-format string      Log format to use. Options are text or json (default "text")
+      --log-level string       Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string      Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string   Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source             Include source location in logs
+      --log-stacktrace         Include stacktrace in error and fatal logs
+      --no-log-color           Disable colored log output
+      --rootdir string         Directory for persistent data (default: $HOME/.defradb)
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_identity_new.md
+++ b/docs/website/references/cli/defradb_identity_new.md
@@ -35,22 +35,14 @@ generate a new identity with ed25519 key:
 ### Options inherited from parent commands
 
 ```
-      --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
-      --log-format string           Log format to use. Options are text or json (default "text")
-      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                  Include source location in logs
-      --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
-      --no-log-color                Disable colored log output
-      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
-      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+      --log-format string      Log format to use. Options are text or json (default "text")
+      --log-level string       Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string      Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string   Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source             Include source location in logs
+      --log-stacktrace         Include stacktrace in error and fatal logs
+      --no-log-color           Disable colored log output
+      --rootdir string         Directory for persistent data (default: $HOME/.defradb)
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_keyring.md
+++ b/docs/website/references/cli/defradb_keyring.md
@@ -26,28 +26,24 @@ Import externally generated keys:
 ### Options
 
 ```
-  -h, --help   help for keyring
+  -h, --help                       help for keyring
+      --keyring-backend string     Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string   Service name to use when using the system backend (default "defradb")
+      --keyring-path string        Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
+      --secret-file string         Path to the file containing secrets (default ".env")
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
-      --log-format string           Log format to use. Options are text or json (default "text")
-      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                  Include source location in logs
-      --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
-      --no-log-color                Disable colored log output
-      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
-      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+      --log-format string      Log format to use. Options are text or json (default "text")
+      --log-level string       Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string      Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string   Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source             Include source location in logs
+      --log-stacktrace         Include stacktrace in error and fatal logs
+      --no-log-color           Disable colored log output
+      --rootdir string         Directory for persistent data (default: $HOME/.defradb)
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_keyring_add.md
+++ b/docs/website/references/cli/defradb_keyring_add.md
@@ -32,22 +32,18 @@ Add encryption key:
 ### Options inherited from parent commands
 
 ```
-      --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
-      --log-format string           Log format to use. Options are text or json (default "text")
-      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                  Include source location in logs
-      --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
-      --no-log-color                Disable colored log output
-      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
-      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+      --keyring-backend string     Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string   Service name to use when using the system backend (default "defradb")
+      --keyring-path string        Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
+      --log-format string          Log format to use. Options are text or json (default "text")
+      --log-level string           Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string          Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string       Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                 Include source location in logs
+      --log-stacktrace             Include stacktrace in error and fatal logs
+      --no-log-color               Disable colored log output
+      --rootdir string             Directory for persistent data (default: $HOME/.defradb)
+      --secret-file string         Path to the file containing secrets (default ".env")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_keyring_get.md
+++ b/docs/website/references/cli/defradb_keyring_get.md
@@ -32,22 +32,18 @@ Get encryption key:
 ### Options inherited from parent commands
 
 ```
-      --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
-      --log-format string           Log format to use. Options are text or json (default "text")
-      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                  Include source location in logs
-      --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
-      --no-log-color                Disable colored log output
-      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
-      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+      --keyring-backend string     Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string   Service name to use when using the system backend (default "defradb")
+      --keyring-path string        Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
+      --log-format string          Log format to use. Options are text or json (default "text")
+      --log-level string           Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string          Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string       Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                 Include source location in logs
+      --log-stacktrace             Include stacktrace in error and fatal logs
+      --no-log-color               Disable colored log output
+      --rootdir string             Directory for persistent data (default: $HOME/.defradb)
+      --secret-file string         Path to the file containing secrets (default ".env")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_keyring_list.md
+++ b/docs/website/references/cli/defradb_keyring_list.md
@@ -30,22 +30,18 @@ List all keys:
 ### Options inherited from parent commands
 
 ```
-      --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
-      --log-format string           Log format to use. Options are text or json (default "text")
-      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                  Include source location in logs
-      --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
-      --no-log-color                Disable colored log output
-      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
-      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+      --keyring-backend string     Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string   Service name to use when using the system backend (default "defradb")
+      --keyring-path string        Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
+      --log-format string          Log format to use. Options are text or json (default "text")
+      --log-level string           Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string          Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string       Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                 Include source location in logs
+      --log-stacktrace             Include stacktrace in error and fatal logs
+      --no-log-color               Disable colored log output
+      --rootdir string             Directory for persistent data (default: $HOME/.defradb)
+      --secret-file string         Path to the file containing secrets (default ".env")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_keyring_new.md
+++ b/docs/website/references/cli/defradb_keyring_new.md
@@ -47,22 +47,18 @@ with system keyring:
 ### Options inherited from parent commands
 
 ```
-      --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
-      --log-format string           Log format to use. Options are text or json (default "text")
-      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                  Include source location in logs
-      --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
-      --no-log-color                Disable colored log output
-      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
-      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+      --keyring-backend string     Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string   Service name to use when using the system backend (default "defradb")
+      --keyring-path string        Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
+      --log-format string          Log format to use. Options are text or json (default "text")
+      --log-level string           Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string          Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string       Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source                 Include source location in logs
+      --log-stacktrace             Include stacktrace in error and fatal logs
+      --no-log-color               Disable colored log output
+      --rootdir string             Directory for persistent data (default: $HOME/.defradb)
+      --secret-file string         Path to the file containing secrets (default ".env")
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_sdl.md
+++ b/docs/website/references/cli/defradb_sdl.md
@@ -15,22 +15,14 @@ Utilities to interact with the DefraDB Schema Definition Language.
 ### Options inherited from parent commands
 
 ```
-      --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
-      --log-format string           Log format to use. Options are text or json (default "text")
-      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                  Include source location in logs
-      --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
-      --no-log-color                Disable colored log output
-      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
-      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+      --log-format string      Log format to use. Options are text or json (default "text")
+      --log-level string       Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string      Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string   Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source             Include source location in logs
+      --log-stacktrace         Include stacktrace in error and fatal logs
+      --no-log-color           Disable colored log output
+      --rootdir string         Directory for persistent data (default: $HOME/.defradb)
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_sdl_generate.md
+++ b/docs/website/references/cli/defradb_sdl_generate.md
@@ -40,22 +40,14 @@ Generate SDL with Searchable Encryption type definitions:
 ### Options inherited from parent commands
 
 ```
-      --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
-      --log-format string           Log format to use. Options are text or json (default "text")
-      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                  Include source location in logs
-      --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
-      --no-log-color                Disable colored log output
-      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
-      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+      --log-format string      Log format to use. Options are text or json (default "text")
+      --log-level string       Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string      Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string   Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source             Include source location in logs
+      --log-stacktrace         Include stacktrace in error and fatal logs
+      --no-log-color           Disable colored log output
+      --rootdir string         Directory for persistent data (default: $HOME/.defradb)
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_server-dump.md
+++ b/docs/website/references/cli/defradb_server-dump.md
@@ -15,22 +15,14 @@ defradb server-dump [flags]
 ### Options inherited from parent commands
 
 ```
-      --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
-      --log-format string           Log format to use. Options are text or json (default "text")
-      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                  Include source location in logs
-      --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
-      --no-log-color                Disable colored log output
-      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
-      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+      --log-format string      Log format to use. Options are text or json (default "text")
+      --log-level string       Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string      Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string   Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source             Include source location in logs
+      --log-stacktrace         Include stacktrace in error and fatal logs
+      --no-log-color           Disable colored log output
+      --rootdir string         Directory for persistent data (default: $HOME/.defradb)
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_start.md
+++ b/docs/website/references/cli/defradb_start.md
@@ -14,6 +14,7 @@ defradb start [flags]
 
 ```
       --allowed-origins stringArray       List of origins to allow for CORS requests. Their hosts are also accepted as auth token audiences
+      --audience string                   Audience to set on minted auth tokens. Defaults to the host of --url
       --default-key-type string           Default key type to generate new node identity if one doesn't exist in the keyring. Valid values are 'secp256k1' and 'ed25519'. If not specified, the default key type will be 'secp256k1'. (default "secp256k1")
       --development                       Enables a set of features that make development easier but should not be enabled in production:
                                            - allows purging of all persisted data
@@ -21,8 +22,12 @@ defradb start [flags]
       --document-acp-type string          Specify the document acp engine to use (supported: local (default), source-hub) (default "local")
   -h, --help                              help for start
   -i, --identity string                   Hex formatted private key used to authenticate with ACP
+      --keyring-backend string            Keyring backend to use. Options are file or system (default "file")
+      --keyring-namespace string          Service name to use when using the system backend (default "defradb")
+      --keyring-path string               Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
       --max-txn-retries int               Specify the maximum number of retries per transaction (default 5)
       --no-encryption                     Skip generating an encryption key. Encryption at rest will be disabled. WARNING: This cannot be undone.
+      --no-keyring                        Disable the keyring and generate ephemeral keys
       --no-p2p                            Disable the peer-to-peer network synchronization system
       --no-searchable-encryption          Skip generating a searchable encryption key. Searchable encryption will be disabled.
       --no-signing                        Disable signing of commits.
@@ -35,29 +40,24 @@ defradb start [flags]
       --pubsub                            Enable the pubsub system (default true)
       --relay                             Enable the p2p relay
       --replicator-retry-intervals ints   Retry intervals for the replicator. Format is a comma-separated list of whole number seconds. Example: 10,20,40,80,160,320 (default [30,60,120,240,480,960,1920])
+      --secret-file string                Path to the file containing secrets (default ".env")
+      --source-hub-address string         The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
       --store string                      Specify the datastore to use (supported: badger, memory) (default "badger")
+      --url string                        URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
       --valuelogfilesize int              Specify the datastore value log file size (in bytes). In memory size will be 2*valuelogfilesize (default 1073741824)
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
-      --log-format string           Log format to use. Options are text or json (default "text")
-      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                  Include source location in logs
-      --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
-      --no-log-color                Disable colored log output
-      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
-      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+      --log-format string      Log format to use. Options are text or json (default "text")
+      --log-level string       Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string      Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string   Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source             Include source location in logs
+      --log-stacktrace         Include stacktrace in error and fatal logs
+      --no-log-color           Disable colored log output
+      --rootdir string         Directory for persistent data (default: $HOME/.defradb)
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_version.md
+++ b/docs/website/references/cli/defradb_version.md
@@ -17,22 +17,14 @@ defradb version [flags]
 ### Options inherited from parent commands
 
 ```
-      --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
-      --log-format string           Log format to use. Options are text or json (default "text")
-      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                  Include source location in logs
-      --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
-      --no-log-color                Disable colored log output
-      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
-      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+      --log-format string      Log format to use. Options are text or json (default "text")
+      --log-level string       Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string      Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string   Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source             Include source location in logs
+      --log-stacktrace         Include stacktrace in error and fatal logs
+      --no-log-color           Disable colored log output
+      --rootdir string         Directory for persistent data (default: $HOME/.defradb)
 ```
 
 ### SEE ALSO

--- a/docs/website/references/cli/defradb_wizard.md
+++ b/docs/website/references/cli/defradb_wizard.md
@@ -15,22 +15,14 @@ defradb wizard [flags]
 ### Options inherited from parent commands
 
 ```
-      --audience string             Audience to set on minted auth tokens. Defaults to the host of --url
-      --keyring-backend string      Keyring backend to use. Options are file or system (default "file")
-      --keyring-namespace string    Service name to use when using the system backend (default "defradb")
-      --keyring-path string         Path (relative to DefraDB root directory) to store encrypted keys when using the file backend (default "keys")
-      --log-format string           Log format to use. Options are text or json (default "text")
-      --log-level string            Log level to use. Options are debug, info, error, fatal (default "info")
-      --log-output string           Log output path. Options are stderr or stdout. (default "stderr")
-      --log-overrides string        Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
-      --log-source                  Include source location in logs
-      --log-stacktrace              Include stacktrace in error and fatal logs
-      --no-keyring                  Disable the keyring and generate ephemeral keys
-      --no-log-color                Disable colored log output
-      --rootdir string              Directory for persistent data (default: $HOME/.defradb)
-      --secret-file string          Path to the file containing secrets (default ".env")
-      --source-hub-address string   The SourceHub address authorized by the client to make SourceHub transactions on behalf of the actor
-      --url string                  URL of HTTP endpoint to listen on or connect to (default "127.0.0.1:9181")
+      --log-format string      Log format to use. Options are text or json (default "text")
+      --log-level string       Log level to use. Options are debug, info, error, fatal (default "info")
+      --log-output string      Log output path. Options are stderr or stdout. (default "stderr")
+      --log-overrides string   Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
+      --log-source             Include source location in logs
+      --log-stacktrace         Include stacktrace in error and fatal logs
+      --no-log-color           Disable colored log output
+      --rootdir string         Directory for persistent data (default: $HOME/.defradb)
 ```
 
 ### SEE ALSO

--- a/tests/clients/cli/wrapper.go
+++ b/tests/clients/cli/wrapper.go
@@ -471,7 +471,7 @@ func (w *Wrapper) DeleteCollection(
 	if opt.ActiveOnly {
 		args = append(args, "--active-only")
 	}
-	args = append(args, strings.Join(names, ","))
+	args = append(args, "--collection-name", strings.Join(names, ","))
 	args = appendIdentityArg(args, opt.GetIdentity())
 
 	_, err := w.cmd.execute(ctx, args)


### PR DESCRIPTION
## Relevant issue(s)

Resolves #5002
Resolves #5005

## Description

This PR fixes an inconsistency with the collection delete flags. It also moves a number of global CLI flags onto more specific sub-commands so we do not pollute the documentation with unused flags.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Existing unit and integration tests.

Specify the platform(s) on which this was tested:
- Linux (Pop-OS)
