### PR TITLE
refactor: Remove badger namespace from CLI path config

### DIFF
--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -45,7 +45,7 @@ const (
 
 // ConfigPaths are config keys that will be made relative to the rootdir
 var ConfigPaths = []string{
-	"datastore.badger.path",
+	"datastore.path",
 	"api.pubkeypath",
 	"api.privkeypath",
 	"keyring.path",
@@ -94,7 +94,7 @@ var ConfigDefaults = map[string]any{
 	"api.address":                       "127.0.0.1:9181",
 	"api.audience":                      "",
 	"api.allowed-origins":               []string{},
-	"datastore.badger.path":             "data",
+	"datastore.path":                    "data",
 	"datastore.maxtxnretries":           5,
 	"datastore.store":                   "badger",
 	"datastore.badger.valuelogfilesize": 1 << 30,

--- a/cli/config_test.go
+++ b/cli/config_test.go
@@ -61,7 +61,7 @@ func TestLoadConfigNotExist(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, 5, cfg.GetInt("datastore.maxtxnretries"))
-	assert.Equal(t, filepath.Join(rootdir, "data"), cfg.GetString("datastore.badger.path"))
+	assert.Equal(t, filepath.Join(rootdir, "data"), cfg.GetString("datastore.path"))
 	assert.Equal(t, 1<<30, cfg.GetInt("datastore.badger.valuelogfilesize"))
 	assert.Equal(t, "badger", cfg.GetString("datastore.store"))
 

--- a/cli/server_dump.go
+++ b/cli/server_dump.go
@@ -33,7 +33,7 @@ func MakeServerDumpCmd() *cobra.Command {
 			if cfg.GetString("datastore.store") != config.ConfigStoreBadger {
 				return errors.New("server-side dump is only supported for the Badger datastore")
 			}
-			badgerPath := cfg.GetString("datastore.badger.path")
+			badgerPath := cfg.GetString("datastore.path")
 			rootstore, _, err := node.NewStore(ctx, options.NodeStore().SetPath(badgerPath))
 			if err != nil {
 				return err

--- a/cli/start.go
+++ b/cli/start.go
@@ -92,7 +92,7 @@ func MakeStartCommand(ctx context.Context) *cobra.Command {
 				SetEnableDevelopment(cfg.GetBool("development")).
 				SetDisableP2P(cfg.GetBool("net.p2pDisabled"))
 			opts.Store().
-				SetPath(cfg.GetString("datastore.badger.path")).
+				SetPath(cfg.GetString("datastore.path")).
 				SetBadgerInMemory(inMem).
 				SetBadgerFileSize(int64(cfg.GetInt("datastore.badger.valuelogfilesize")))
 			opts.DB().


### PR DESCRIPTION
## Relevant issue(s)

Resolves #5007 

## Description

Removed `badger` from the CLI config datastore path, so `datastore.badger.path` becomes `datastore.path`.

The added namespace barely made sense when we only supported badger, and while we cant use LevelDB (or other CoreKV backends) for CLI other than in-memory (also badger atm), theres no reason to require the `badger` namespace when any file persistence kv store will use the same API.

This is why the `options` package uses `Path` on the `NodeStoreOptions`.

## How has this been tested?

test suite, manual CLI build

Specify the platform(s) on which this was tested:
- Linux NixOS
