### PR TITLE
docs: Better categorizing of HTTP ACP endpoints

### DIFF
--- a/docs/website/references/http/openapi.json
+++ b/docs/website/references/http/openapi.json
@@ -674,7 +674,7 @@
         "/acp/document/policy": {
             "post": {
                 "description": "Add a policy using document acp system",
-                "operationId": "add dac policy",
+                "operationId": "dac policy add",
                 "requestBody": {
                     "content": {
                         "text/plain": {
@@ -701,14 +701,14 @@
                     }
                 },
                 "tags": [
-                    "acp_document_policy"
+                    "document access control"
                 ]
             }
         },
         "/acp/document/relationship": {
             "delete": {
                 "description": "Delete an actor relationship using document acp system",
-                "operationId": "delete dac relationship",
+                "operationId": "dac relationship delete",
                 "requestBody": {
                     "content": {
                         "application/json": {
@@ -735,12 +735,12 @@
                     }
                 },
                 "tags": [
-                    "acp_document_relationship"
+                    "document access control"
                 ]
             },
             "post": {
                 "description": "Add an actor relationship using document acp system",
-                "operationId": "add dac relationship",
+                "operationId": "dac relationship add",
                 "requestBody": {
                     "content": {
                         "application/json": {
@@ -767,14 +767,14 @@
                     }
                 },
                 "tags": [
-                    "acp_document_relationship"
+                    "document access control"
                 ]
             }
         },
         "/acp/node/disable": {
             "post": {
                 "description": "Disable nac",
-                "operationId": "disable nac",
+                "operationId": "nac disable",
                 "responses": {
                     "200": {
                         "$ref": "#/components/responses/success"
@@ -784,14 +784,14 @@
                     }
                 },
                 "tags": [
-                    "acp_node_disable"
+                    "node access control"
                 ]
             }
         },
         "/acp/node/re-enable": {
             "post": {
                 "description": "Re-enable nac",
-                "operationId": "re-enable nac",
+                "operationId": "nac re-enable",
                 "responses": {
                     "200": {
                         "$ref": "#/components/responses/success"
@@ -801,14 +801,14 @@
                     }
                 },
                 "tags": [
-                    "acp_node_re-enable"
+                    "node access control"
                 ]
             }
         },
         "/acp/node/relationship": {
             "delete": {
                 "description": "Delete an actor relationship using node acp system",
-                "operationId": "delete nac relationship",
+                "operationId": "nac relationship delete",
                 "requestBody": {
                     "content": {
                         "application/json": {
@@ -835,12 +835,12 @@
                     }
                 },
                 "tags": [
-                    "acp_node_relationship"
+                    "node access control"
                 ]
             },
             "post": {
                 "description": "Add an actor relationship using node acp system",
-                "operationId": "add nac relationship",
+                "operationId": "nac relationship add",
                 "requestBody": {
                     "content": {
                         "application/json": {
@@ -867,14 +867,14 @@
                     }
                 },
                 "tags": [
-                    "acp_node_relationship"
+                    "node access control"
                 ]
             }
         },
         "/acp/node/status": {
             "get": {
                 "description": "Check status of node acp system",
-                "operationId": "Check status of nac",
+                "operationId": "nac status",
                 "responses": {
                     "200": {
                         "content": {
@@ -891,7 +891,7 @@
                     }
                 },
                 "tags": [
-                    "acp_node_status"
+                    "node access control"
                 ]
             }
         },

--- a/http/handler_acp.go
+++ b/http/handler_acp.go
@@ -230,9 +230,9 @@ func (h *acpHandler) bindRoutes(router *Router) {
 		WithDescription("Add document acp policy result").
 		WithJSONSchemaRef(addPolicyResultSchema)
 	addPolicyDAC := openapi3.NewOperation()
-	addPolicyDAC.OperationID = "add dac policy"
+	addPolicyDAC.OperationID = "dac policy add"
 	addPolicyDAC.Description = "Add a policy using document acp system"
-	addPolicyDAC.Tags = []string{"acp_document_policy"}
+	addPolicyDAC.Tags = []string{"document access control"}
 	addPolicyDAC.Responses = openapi3.NewResponses()
 	addPolicyDAC.AddResponse(200, addPolicyDACResult)
 	addPolicyDAC.Responses.Set("400", errorResponse)
@@ -247,9 +247,9 @@ func (h *acpHandler) bindRoutes(router *Router) {
 		WithDescription("Add document acp relationship result").
 		WithJSONSchemaRef(addRelationshipResultSchema)
 	addActorRelationshipDAC := openapi3.NewOperation()
-	addActorRelationshipDAC.OperationID = "add dac relationship"
+	addActorRelationshipDAC.OperationID = "dac relationship add"
 	addActorRelationshipDAC.Description = "Add an actor relationship using document acp system"
-	addActorRelationshipDAC.Tags = []string{"acp_document_relationship"}
+	addActorRelationshipDAC.Tags = []string{"document access control"}
 	addActorRelationshipDAC.Responses = openapi3.NewResponses()
 	addActorRelationshipDAC.AddResponse(200, addActorRelationshipDACResult)
 	addActorRelationshipDAC.Responses.Set("400", errorResponse)
@@ -264,9 +264,9 @@ func (h *acpHandler) bindRoutes(router *Router) {
 		WithDescription("Delete document acp relationship result").
 		WithJSONSchemaRef(deleteRelationshipResultSchema)
 	deleteActorRelationshipDAC := openapi3.NewOperation()
-	deleteActorRelationshipDAC.OperationID = "delete dac relationship"
+	deleteActorRelationshipDAC.OperationID = "dac relationship delete"
 	deleteActorRelationshipDAC.Description = "Delete an actor relationship using document acp system"
-	deleteActorRelationshipDAC.Tags = []string{"acp_document_relationship"}
+	deleteActorRelationshipDAC.Tags = []string{"document access control"}
 	deleteActorRelationshipDAC.Responses = openapi3.NewResponses()
 	deleteActorRelationshipDAC.AddResponse(200, deleteActorRelationshipDACResult)
 	deleteActorRelationshipDAC.Responses.Set("400", errorResponse)
@@ -281,9 +281,9 @@ func (h *acpHandler) bindRoutes(router *Router) {
 		WithDescription("Add node acp relationship result").
 		WithJSONSchemaRef(addRelationshipResultSchema)
 	addActorRelationshipNAC := openapi3.NewOperation()
-	addActorRelationshipNAC.OperationID = "add nac relationship"
+	addActorRelationshipNAC.OperationID = "nac relationship add"
 	addActorRelationshipNAC.Description = "Add an actor relationship using node acp system"
-	addActorRelationshipNAC.Tags = []string{"acp_node_relationship"}
+	addActorRelationshipNAC.Tags = []string{"node access control"}
 	addActorRelationshipNAC.Responses = openapi3.NewResponses()
 	addActorRelationshipNAC.AddResponse(200, addActorRelationshipNACResult)
 	addActorRelationshipNAC.Responses.Set("400", errorResponse)
@@ -298,9 +298,9 @@ func (h *acpHandler) bindRoutes(router *Router) {
 		WithDescription("Delete node acp relationship result").
 		WithJSONSchemaRef(deleteRelationshipResultSchema)
 	deleteActorRelationshipNAC := openapi3.NewOperation()
-	deleteActorRelationshipNAC.OperationID = "delete nac relationship"
+	deleteActorRelationshipNAC.OperationID = "nac relationship delete"
 	deleteActorRelationshipNAC.Description = "Delete an actor relationship using node acp system"
-	deleteActorRelationshipNAC.Tags = []string{"acp_node_relationship"}
+	deleteActorRelationshipNAC.Tags = []string{"node access control"}
 	deleteActorRelationshipNAC.Responses = openapi3.NewResponses()
 	deleteActorRelationshipNAC.AddResponse(200, deleteActorRelationshipNACResult)
 	deleteActorRelationshipNAC.Responses.Set("400", errorResponse)
@@ -309,17 +309,17 @@ func (h *acpHandler) bindRoutes(router *Router) {
 	}
 
 	reEnableNAC := openapi3.NewOperation()
-	reEnableNAC.OperationID = "re-enable nac"
+	reEnableNAC.OperationID = "nac re-enable"
 	reEnableNAC.Description = "Re-enable nac"
-	reEnableNAC.Tags = []string{"acp_node_re-enable"}
+	reEnableNAC.Tags = []string{"node access control"}
 	reEnableNAC.Responses = openapi3.NewResponses()
 	reEnableNAC.Responses.Set("200", successResponse)
 	reEnableNAC.Responses.Set("400", errorResponse)
 
 	disableNAC := openapi3.NewOperation()
-	disableNAC.OperationID = "disable nac"
+	disableNAC.OperationID = "nac disable"
 	disableNAC.Description = "Disable nac"
-	disableNAC.Tags = []string{"acp_node_disable"}
+	disableNAC.Tags = []string{"node access control"}
 	disableNAC.Responses = openapi3.NewResponses()
 	disableNAC.Responses.Set("200", successResponse)
 	disableNAC.Responses.Set("400", errorResponse)
@@ -328,9 +328,9 @@ func (h *acpHandler) bindRoutes(router *Router) {
 		WithDescription("Node acp status result").
 		WithJSONSchemaRef(statusNACResultSchema)
 	statusNAC := openapi3.NewOperation()
-	statusNAC.OperationID = "Check status of nac"
+	statusNAC.OperationID = "nac status"
 	statusNAC.Description = "Check status of node acp system"
-	statusNAC.Tags = []string{"acp_node_status"}
+	statusNAC.Tags = []string{"node access control"}
 	statusNAC.Responses = openapi3.NewResponses()
 	statusNAC.AddResponse(200, statusNACResult)
 	statusNAC.Responses.Set("400", errorResponse)


### PR DESCRIPTION
## Relevant issue(s)

Resolves #5009 

## Description

- Group all DAC endpoints into a DAC category; similar for NAC. We refer to those systems as "Document Access Control" and "Node Access Control" (and not "Access Control Policy for documents"), so it's beneficial to users if we conform to that.
- The IDs for the endpoints now have a common prefix (`document relationship add` vs the old `add document relationship`) so that visual parsing is aided: it's quicker to recognize a common prefix than a common suffix. This does NOT affect the endpoint locations; only the URLs in the docs and sidebar labels.

## How has this been tested?

<img width="373" height="341" alt="Screenshot from 2026-06-29 08-31-54" src="https://github.com/user-attachments/assets/d3ed51c0-12eb-49c2-bded-3c85737190ae" />
