### PR TITLE
fix: GQL operation execution order

### DIFF
--- a/internal/planner/operation.go
+++ b/internal/planner/operation.go
@@ -25,7 +25,11 @@ type operationNode struct {
 	documentIterator
 	docMapper
 
-	children map[int]planNode
+	// children is indexed by the selection's position in the operation's
+	// selection set, so iteration follows the order operations appear in the
+	// request. This is required for spec-compliant serial mutation execution
+	// (and deterministic default query result order).
+	children []planNode
 	isDone   bool
 }
 
@@ -124,7 +128,10 @@ func (n *operationNode) Next() (bool, error) {
 
 // Operation creates a new operationNode using the given Selects.
 func (p *Planner) Operation(operation *mapper.Operation) (*operationNode, error) {
-	children := make(map[int]planNode)
+	// Selection indices are contiguous (0..n-1, assigned by mapper.ToOperation),
+	// so a slice sized to the total selection count can be addressed directly by
+	// index, preserving request order.
+	children := make([]planNode, len(operation.Selects)+len(operation.Mutations)+len(operation.CommitSelects))
 	for _, s := range operation.Selects {
 		if _, isAgg := request.Aggregates[s.Name]; isAgg {
 			// If this Select is an aggregate, then it must be a top-level

--- a/internal/planner/operation.go
+++ b/internal/planner/operation.go
@@ -82,9 +82,7 @@ func (n *operationNode) Source() planNode {
 
 func (n *operationNode) Children() []planNode {
 	children := make([]planNode, 0, len(n.children))
-	for _, child := range n.children {
-		children = append(children, child)
-	}
+	children = append(children, n.children...)
 	return children
 }
 

--- a/internal/request/graphql/parser/mutation.go
+++ b/internal/request/graphql/parser/mutation.go
@@ -24,7 +24,7 @@ import (
 // 'mutation' operations, which there may be multiple of.
 func parseMutationOperationDefinition(
 	exe *gql.ExecutionContext,
-	collectedFields map[string][]*ast.Field,
+	collectedFields [][]*ast.Field,
 ) (*request.OperationDefinition, error) {
 	var selections []request.Selection
 	for _, fields := range collectedFields {

--- a/internal/request/graphql/parser/query.go
+++ b/internal/request/graphql/parser/query.go
@@ -25,7 +25,7 @@ import (
 // 'query' operations, which there may be multiple of.
 func parseQueryOperationDefinition(
 	exe *gql.ExecutionContext,
-	collectedFields map[string][]*ast.Field,
+	collectedFields [][]*ast.Field,
 ) (*request.OperationDefinition, []error) {
 	var selections []request.Selection
 	for _, fields := range collectedFields {

--- a/internal/request/graphql/parser/request.go
+++ b/internal/request/graphql/parser/request.go
@@ -12,7 +12,6 @@ package parser
 
 import (
 	"fmt"
-	"sort"
 
 	gql "github.com/sourcenetwork/graphql-go"
 	"github.com/sourcenetwork/graphql-go/language/ast"
@@ -48,7 +47,7 @@ func ParseRequest(schema gql.Schema, doc *ast.Document, options *client.GQLOptio
 		RuntimeType:  operationType,
 		SelectionSet: exe.Operation.GetSelectionSet(),
 	})
-	orderedFields := orderCollectedFields(collectedFields)
+	orderedFields := orderCollectedFields(exe, collectedFields)
 
 	r := &request.Request{
 		Queries:      make([]*request.OperationDefinition, 0),
@@ -106,48 +105,84 @@ func ParseRequest(schema gql.Schema, doc *ast.Document, options *client.GQLOptio
 	return r, nil
 }
 
-// orderCollectedFields converts the grouped-field-set map produced by
-// [gql.CollectFields] into a slice ordered by source position, restoring the
-// document order that map iteration would otherwise randomize.
+// orderCollectedFields projects the grouped-field-set map produced by
+// [gql.CollectFields] onto the order in which response keys are first
+// encountered while traversing the operation's selection set.
 //
-// This mirrors graphql-go's own (unexported) orderedFields used by its serial
-// executor: each response-key group is keyed by the lowest source location of
-// the fields within it, then groups are sorted ascending. This matches the
-// GraphQL spec's grouped-field-set ordering (order by first occurrence of each
-// response key) and, for mutations, is required for spec-compliant serial
-// execution order.
-func orderCollectedFields(collectedFields map[string][]*ast.Field) [][]*ast.Field {
-	type group struct {
-		startLoc int
-		fields   []*ast.Field
-	}
+// There is an important edge case with order for correctly handling Fragments.
+// Specifically, the location of Fragments is reported at their definition not
+// their use. We need to walk and expand the selection set and fragments before
+// determining final order
+func orderCollectedFields(
+	exe *gql.ExecutionContext,
+	collectedFields map[string][]*ast.Field,
+) [][]*ast.Field {
+	responseKeyOrder := collectResponseKeyOrder(
+		exe,
+		exe.Operation.GetSelectionSet(),
+		make(map[string]bool),
+		make(map[string]bool),
+	)
 
-	groups := make([]group, 0, len(collectedFields))
-	for _, fields := range collectedFields {
-		lowest := -1
-		for _, field := range fields {
-			loc := 0
-			// Locations are populated on this parse path, but guard defensively
-			// so a missing location sorts as position zero rather than panicking.
-			if l := field.GetLoc(); l != nil {
-				loc = l.Start
-			}
-			if lowest == -1 || loc < lowest {
-				lowest = loc
-			}
+	orderedFields := make([][]*ast.Field, 0, len(collectedFields))
+	for _, responseKey := range responseKeyOrder {
+		// Response keys excluded by @skip / @include or a non-matching fragment
+		// type condition are absent from collectedFields and are skipped here.
+		// The traversal visits a superset of the keys CollectFields collects, so
+		// every collected group is emitted exactly once.
+		if fields, ok := collectedFields[responseKey]; ok {
+			orderedFields = append(orderedFields, fields)
 		}
-		groups = append(groups, group{startLoc: lowest, fields: fields})
-	}
-
-	sort.Slice(groups, func(i, j int) bool {
-		return groups[i].startLoc < groups[j].startLoc
-	})
-
-	orderedFields := make([][]*ast.Field, len(groups))
-	for i, g := range groups {
-		orderedFields[i] = g.fields
 	}
 	return orderedFields
+}
+
+// collectResponseKeyOrder walks a selection set in document order, expanding
+// fragment spreads and inline fragments in place, and returns the response keys
+// (alias, else field name) in the order they are first encountered.
+//
+// seenKeys and visitedFragments are shared across the whole traversal so each
+// response key is recorded once at its first occurrence and each fragment is
+// expanded at most once (the latter also guards against cyclic spreads, though
+// validation rejects those before this point).
+func collectResponseKeyOrder(
+	exe *gql.ExecutionContext,
+	selectionSet *ast.SelectionSet,
+	seenKeys map[string]bool,
+	visitedFragments map[string]bool,
+) []string {
+	if selectionSet == nil {
+		return nil
+	}
+
+	var order []string
+	for _, selection := range selectionSet.Selections {
+		switch node := selection.(type) {
+		case *ast.Field:
+			responseKey := node.Name.Value
+			if node.Alias != nil && node.Alias.Value != "" {
+				responseKey = node.Alias.Value
+			}
+			if !seenKeys[responseKey] {
+				seenKeys[responseKey] = true
+				order = append(order, responseKey)
+			}
+
+		case *ast.InlineFragment:
+			order = append(order, collectResponseKeyOrder(exe, node.GetSelectionSet(), seenKeys, visitedFragments)...)
+
+		case *ast.FragmentSpread:
+			name := node.Name.Value
+			if visitedFragments[name] {
+				continue
+			}
+			visitedFragments[name] = true
+			if fragment, ok := exe.Fragments[name]; ok {
+				order = append(order, collectResponseKeyOrder(exe, fragment.GetSelectionSet(), seenKeys, visitedFragments)...)
+			}
+		}
+	}
+	return order
 }
 
 // parseDirectives returns all directives that were found if parsing and validation succeeds,

--- a/internal/request/graphql/parser/request.go
+++ b/internal/request/graphql/parser/request.go
@@ -12,6 +12,7 @@ package parser
 
 import (
 	"fmt"
+	"sort"
 
 	gql "github.com/sourcenetwork/graphql-go"
 	"github.com/sourcenetwork/graphql-go/language/ast"
@@ -47,6 +48,7 @@ func ParseRequest(schema gql.Schema, doc *ast.Document, options *client.GQLOptio
 		RuntimeType:  operationType,
 		SelectionSet: exe.Operation.GetSelectionSet(),
 	})
+	orderedFields := orderCollectedFields(collectedFields)
 
 	r := &request.Request{
 		Queries:      make([]*request.OperationDefinition, 0),
@@ -57,7 +59,7 @@ func ParseRequest(schema gql.Schema, doc *ast.Document, options *client.GQLOptio
 	astOpDef := exe.Operation.(*ast.OperationDefinition)
 	switch exe.Operation.GetOperation() {
 	case ast.OperationTypeQuery:
-		parsedQueryOpDef, errs := parseQueryOperationDefinition(exe, collectedFields)
+		parsedQueryOpDef, errs := parseQueryOperationDefinition(exe, orderedFields)
 		if errs != nil {
 			return nil, errs
 		}
@@ -70,7 +72,7 @@ func ParseRequest(schema gql.Schema, doc *ast.Document, options *client.GQLOptio
 		r.Queries = append(r.Queries, parsedQueryOpDef)
 
 	case ast.OperationTypeMutation:
-		parsedMutationOpDef, err := parseMutationOperationDefinition(exe, collectedFields)
+		parsedMutationOpDef, err := parseMutationOperationDefinition(exe, orderedFields)
 		if err != nil {
 			return nil, []error{err}
 		}
@@ -84,7 +86,7 @@ func ParseRequest(schema gql.Schema, doc *ast.Document, options *client.GQLOptio
 		r.Mutations = append(r.Mutations, parsedMutationOpDef)
 
 	case ast.OperationTypeSubscription:
-		parsedSubscriptionOpDef, errs := parseQueryOperationDefinition(exe, collectedFields)
+		parsedSubscriptionOpDef, errs := parseQueryOperationDefinition(exe, orderedFields)
 		if errs != nil {
 			return nil, errs
 		}
@@ -102,6 +104,50 @@ func ParseRequest(schema gql.Schema, doc *ast.Document, options *client.GQLOptio
 	}
 
 	return r, nil
+}
+
+// orderCollectedFields converts the grouped-field-set map produced by
+// [gql.CollectFields] into a slice ordered by source position, restoring the
+// document order that map iteration would otherwise randomize.
+//
+// This mirrors graphql-go's own (unexported) orderedFields used by its serial
+// executor: each response-key group is keyed by the lowest source location of
+// the fields within it, then groups are sorted ascending. This matches the
+// GraphQL spec's grouped-field-set ordering (order by first occurrence of each
+// response key) and, for mutations, is required for spec-compliant serial
+// execution order.
+func orderCollectedFields(collectedFields map[string][]*ast.Field) [][]*ast.Field {
+	type group struct {
+		startLoc int
+		fields   []*ast.Field
+	}
+
+	groups := make([]group, 0, len(collectedFields))
+	for _, fields := range collectedFields {
+		lowest := -1
+		for _, field := range fields {
+			loc := 0
+			// Locations are populated on this parse path, but guard defensively
+			// so a missing location sorts as position zero rather than panicking.
+			if l := field.GetLoc(); l != nil {
+				loc = l.Start
+			}
+			if lowest == -1 || loc < lowest {
+				lowest = loc
+			}
+		}
+		groups = append(groups, group{startLoc: lowest, fields: fields})
+	}
+
+	sort.Slice(groups, func(i, j int) bool {
+		return groups[i].startLoc < groups[j].startLoc
+	})
+
+	orderedFields := make([][]*ast.Field, len(groups))
+	for i, g := range groups {
+		orderedFields[i] = g.fields
+	}
+	return orderedFields
 }
 
 // parseDirectives returns all directives that were found if parsing and validation succeeds,

--- a/tests/integration/mutation/mix/with_multiple_operations_test.go
+++ b/tests/integration/mutation/mix/with_multiple_operations_test.go
@@ -77,3 +77,54 @@ func TestMutationMultipleOperationsExecuteInRequestOrder(t *testing.T) {
 
 	testUtils.ExecuteTestCase(t, test)
 }
+
+// TestMutationMultipleOperationsViaFragmentSpreadExecuteInRequestOrder ensures the
+// execution order follows where a fragment spread appears in the operation, not
+// where the fragment is defined in the document. Here `...AddFirst` is spread
+// before the inline `second` mutation, even though the fragment definition (and
+// thus the `first` field's source location) comes later in the document, so
+// `first` must execute before `second`.
+//
+// Regression test for ordering derived from field source position rather than
+// first-encounter traversal order (https://github.com/sourcenetwork/defradb/pull/5013).
+func TestMutationMultipleOperationsViaFragmentSpreadExecuteInRequestOrder(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type User {
+						name: String
+					}
+				`,
+			},
+			&action.Request{
+				Request: `mutation {
+					...AddFirst
+					second: add_User(input: {name: "Second"}) { name }
+				}
+				fragment AddFirst on Mutation {
+					first: add_User(input: {name: "First"}) { name }
+				}`,
+				Results: map[string]any{
+					"first":  []map[string]any{{"name": "First"}},
+					"second": []map[string]any{{"name": "Second"}},
+				},
+			},
+			&action.Request{
+				Request: `query {
+					User {
+						name
+					}
+				}`,
+				Results: map[string]any{
+					"User": []map[string]any{
+						{"name": "First"},
+						{"name": "Second"},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/mutation/mix/with_multiple_operations_test.go
+++ b/tests/integration/mutation/mix/with_multiple_operations_test.go
@@ -1,0 +1,79 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// This file is part of the DefraDB test suite.
+//
+// The DefraDB test suite is licensed under either:
+//
+//   (1) GNU Affero General Public License v3
+//   (2) Business Source License 1.1
+//
+// See tests/LICENSE for details.
+
+package mix
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/defradb/tests/action"
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+// TestMutationMultipleOperationsExecuteInRequestOrder ensures that when a single
+// request contains multiple mutation operations, they execute in the order they
+// appear in the request (per the GraphQL spec's serial execution requirement).
+//
+// Documents are keyed in storage by a monotonic insertion sequence, so a default
+// (unordered) query returns them in insertion order. This test therefore asserts
+// the documents come back in the same order they were declared in the request.
+//
+// Regression test for https://github.com/sourcenetwork/defradb/issues/5012, where
+// the operations were collected into a Go map and executed in randomized order.
+func TestMutationMultipleOperationsExecuteInRequestOrder(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type User {
+						name: String
+					}
+				`,
+			},
+			&action.Request{
+				Request: `mutation {
+					a1: add_User(input: {name: "Alice"}) { name }
+					a2: add_User(input: {name: "Bob"}) { name }
+					a3: add_User(input: {name: "Carol"}) { name }
+					a4: add_User(input: {name: "Dave"}) { name }
+					a5: add_User(input: {name: "Eve"}) { name }
+				}`,
+				Results: map[string]any{
+					"a1": []map[string]any{{"name": "Alice"}},
+					"a2": []map[string]any{{"name": "Bob"}},
+					"a3": []map[string]any{{"name": "Carol"}},
+					"a4": []map[string]any{{"name": "Dave"}},
+					"a5": []map[string]any{{"name": "Eve"}},
+				},
+			},
+			&action.Request{
+				// No order argument: results follow insertion order, which must
+				// match the order the mutations were declared above.
+				Request: `query {
+					User {
+						name
+					}
+				}`,
+				Results: map[string]any{
+					"User": []map[string]any{
+						{"name": "Alice"},
+						{"name": "Bob"},
+						{"name": "Carol"},
+						{"name": "Dave"},
+						{"name": "Eve"},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #5012 

## Description

Fixes the issue of multiple mutation `add` calls in a single GQL requesting resulting in different execution order. Fixed in two places 1) The actual GQL parsing, which now adds AST level re-ordering after the bulk of the `graphql-go` parsing is done 2) Planner operation node now respects order of multiple operation definitions.

Both fixes basically come down to replacing some maps with slices.

Theres a handful of different ways this can be implemented, including making a core change to the `graphql-go` package. But in the interest of time, this is an easy and straight forward fix that can be freely replaced at any time with no semver issues.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Expanded integration tests

Specify the platform(s) on which this was tested:
- Linux NixOS
