### PR TITLE
feat: Bump explorer version to v1.0.0

### DIFF
--- a/tools/scripts/download_explorer.ps1
+++ b/tools/scripts/download_explorer.ps1
@@ -2,7 +2,7 @@
 #
 # Bump the release tag in the URL below to change versions.
 
-$url = "https://github.com/sourcenetwork/defradb-explorer/releases/download/v1.0.0-beta.1/dist.tar.gz"
+$url = "https://github.com/sourcenetwork/defradb-explorer/releases/download/v1.0.0/dist.tar.gz"
 $tarFile = "dist.tar.gz"
 
 try {

--- a/tools/scripts/download_explorer.sh
+++ b/tools/scripts/download_explorer.sh
@@ -4,4 +4,4 @@
 #
 # Bump the release tag in the URL below to change versions.
 
-curl -fsSL https://github.com/sourcenetwork/defradb-explorer/releases/download/v1.0.0-beta.1/dist.tar.gz | tar xzf -
+curl -fsSL https://github.com/sourcenetwork/defradb-explorer/releases/download/v1.0.0/dist.tar.gz | tar xzf -


### PR DESCRIPTION
## Relevant issue(s)

Resolves #5014

## Description

This PR bumps the integrated explorer version URL to v1.0.0.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

`make deps` and ran manually

Specify the platform(s) on which this was tested:
- Linux (Pop-OS)
