### PR TITLE
fix: Handle potentially corrupted store reading actions

### DIFF
--- a/internal/db/action/action.go
+++ b/internal/db/action/action.go
@@ -30,9 +30,15 @@ func encodeStatus(status client.ActionStatus) []byte {
 }
 
 // DecodeStatus decodes an action status value (a bare uvarint).
-func DecodeStatus(val []byte) client.ActionStatus {
-	status, _ := binary.Uvarint(val)
-	return client.ActionStatus(status)
+//
+// It returns ErrInvalidActionStatusEncoding when the input is empty,
+// truncated or overflows a uint64 (binary.Uvarint byte-count ≤ 0).
+func DecodeStatus(val []byte) (client.ActionStatus, error) {
+	status, n := binary.Uvarint(val)
+	if n <= 0 {
+		return 0, ErrInvalidActionStatusEncoding
+	}
+	return client.ActionStatus(status), nil
 }
 
 // Register a new action for execution.
@@ -258,7 +264,7 @@ func getStatus(
 		return 0, err
 	}
 
-	return DecodeStatus(val), nil
+	return DecodeStatus(val)
 }
 
 // ListExecutions lists all the actions that have not yet successfully completed.
@@ -299,11 +305,16 @@ func ListExecutions(ctx context.Context) ([]client.ActionExecution, error) {
 			return nil, errors.Join(err, iter.Close())
 		}
 
+		status, err := DecodeStatus(val)
+		if err != nil {
+			return nil, errors.Join(err, iter.Close())
+		}
+
 		results = append(results, client.ActionExecution{
 			CollectionID: key.CollectionID,
 			Action:       key.Action,
 			Subject:      key.Subject,
-			Status:       DecodeStatus(val),
+			Status:       status,
 			Reason:       reason,
 		})
 	}

--- a/internal/db/action/action_test.go
+++ b/internal/db/action/action_test.go
@@ -66,8 +66,26 @@ func TestStatus_RoundTrips(t *testing.T) {
 		client.ErroredActionStatus,
 		client.CompletedActionStatus,
 	} {
-		assert.Equal(t, status, DecodeStatus(encodeStatus(status)))
+		got, err := DecodeStatus(encodeStatus(status))
+		require.NoError(t, err)
+		assert.Equal(t, status, got)
 	}
+}
+
+// TestDecodeStatus_EmptyInput checks that an empty byte slice is rejected
+// instead of silently returning NoneActionStatus (the fix for issue #4965).
+func TestDecodeStatus_EmptyInput(t *testing.T) {
+	_, err := DecodeStatus([]byte{})
+	require.ErrorIs(t, err, ErrInvalidActionStatusEncoding)
+}
+
+// TestDecodeStatus_TruncatedInput checks that a truncated uvarint
+// (all continuation bits set, no terminator) is rejected.
+func TestDecodeStatus_TruncatedInput(t *testing.T) {
+	// 0x80 has the continuation bit set but no following byte, so
+	// binary.Uvarint returns n == 0 (buffer too small).
+	_, err := DecodeStatus([]byte{0x80})
+	require.ErrorIs(t, err, ErrInvalidActionStatusEncoding)
 }
 
 // TestSetTxn_StoresStatusReasonAndPayloadSeparately checks status, reason and payload live
@@ -84,7 +102,9 @@ func TestSetTxn_StoresStatusReasonAndPayloadSeparately(t *testing.T) {
 
 	statusVal, err := txn.Systemstore().Get(ctx, keys.NewActionStatusSubjectKey("col1", client.BackfillIndexAction, "1").Bytes())
 	require.NoError(t, err)
-	assert.Equal(t, client.ErroredActionStatus, DecodeStatus(statusVal))
+	decodedStatus, err := DecodeStatus(statusVal)
+	require.NoError(t, err)
+	assert.Equal(t, client.ErroredActionStatus, decodedStatus)
 
 	reason, err := GetReason(ctx, "col1", client.BackfillIndexAction, "1")
 	require.NoError(t, err)

--- a/internal/db/action/errors.go
+++ b/internal/db/action/errors.go
@@ -16,7 +16,8 @@ import (
 )
 
 const (
-	errActionInProgress            string = "multiple actions of the same kind and collection cannot be submitted concurrently"
+	errActionInProgress string = "multiple actions of the same kind and collection " +
+		"cannot be submitted concurrently"
 	errInvalidActionStatusEncoding string = "invalid action status encoding"
 )
 

--- a/internal/db/action/errors.go
+++ b/internal/db/action/errors.go
@@ -16,10 +16,14 @@ import (
 )
 
 const (
-	errActionInProgress string = "multiple actions of the same kind and collection cannot be submitted concurrently"
+	errActionInProgress            string = "multiple actions of the same kind and collection cannot be submitted concurrently"
+	errInvalidActionStatusEncoding string = "invalid action status encoding"
 )
 
-var ErrActionInProgress = errors.New(errActionInProgress)
+var (
+	ErrActionInProgress            = errors.New(errActionInProgress)
+	ErrInvalidActionStatusEncoding = errors.New(errInvalidActionStatusEncoding)
+)
 
 func NewErrActionInProgress(collectionID string, action client.Action) error {
 	return errors.New(

--- a/internal/db/index_state.go
+++ b/internal/db/index_state.go
@@ -230,7 +230,16 @@ func scanIndexStates(ctx context.Context, prefix []byte, skipCorrupt bool) ([]in
 			return nil, errors.Join(err, iter.Close())
 		}
 
-		state, err := loadIndexState(ctx, k, action.DecodeStatus(val))
+		status, err := action.DecodeStatus(val)
+		if err != nil {
+			if skipCorrupt {
+				log.ErrorE("Skipping index action record with invalid status encoding", err, corelog.String("key", key))
+				continue
+			}
+			return nil, errors.Join(err, iter.Close())
+		}
+
+		state, err := loadIndexState(ctx, k, status)
 		if err != nil {
 			if skipCorrupt {
 				log.ErrorE("Skipping index action record with undecodable data", err, corelog.String("key", key))


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4965 

## Description

Check the byte count returned by `binary.Uvarint` when decoding `ActionStatus`. Previously, empty or truncated bytes silently returned `0` (`NoneActionStatus`). `DecodeStatus` now returns an error on corrupt inputs.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [ ] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Added tests `TestDecodeStatus_EmptyInput` and `TestDecodeStatus_TruncatedInput` to verify error returns.

Specify the platform(s) on which this was tested:
- Debian Linux
