### PR TITLE
fix: persist typed slices in nillable array fields

### DIFF
--- a/client/document.go
+++ b/client/document.go
@@ -608,6 +608,12 @@ func getNillableArray[T any](
 		}
 
 		array = arr
+	case []T:
+		arr := make([]immutable.Option[T], len(val))
+		for i, item := range val {
+			arr[i] = immutable.Some(item)
+		}
+		array = arr
 	case []immutable.Option[T]:
 		array = val
 	}
@@ -704,6 +710,12 @@ func getNillableDateTimeArray(
 			if err != nil {
 				return nil, err
 			}
+			arr[i] = immutable.Some(t)
+		}
+		array = arr
+	case []time.Time:
+		arr := make([]immutable.Option[time.Time], len(val))
+		for i, t := range val {
 			arr[i] = immutable.Some(t)
 		}
 		array = arr

--- a/client/document_test.go
+++ b/client/document_test.go
@@ -15,9 +15,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sourcenetwork/immutable"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/sourcenetwork/immutable"
 )
 
 var (

--- a/client/document_test.go
+++ b/client/document_test.go
@@ -13,7 +13,9 @@ package client
 import (
 	"context"
 	"testing"
+	"time"
 
+	"github.com/sourcenetwork/immutable"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -288,4 +290,59 @@ func TestNewDocFromJSON_OmittedNonNillableArrayField_NoError(t *testing.T) {
 	}
 	_, err := NewDocFromJSON(ctx, []byte(`{}`), nillableArrayDef)
 	require.NoError(t, err)
+}
+
+func TestNewDocFromMap_TypedStringSliceForNillableArray_Persisted(t *testing.T) {
+	ctx := context.Background()
+	nillableArrayDef := CollectionVersion{
+		Name: "Block",
+		Fields: []CollectionFieldDescription{
+			{
+				Name: "cids",
+				Typ:  LWW_REGISTER,
+				Kind: FieldKind_NILLABLE_STRING_ARRAY,
+			},
+		},
+	}
+
+	doc, err := NewDocFromMap(ctx, map[string]any{
+		"cids": []string{"bafyA", "bafyB", "bafyC"},
+	}, nillableArrayDef)
+	require.NoError(t, err)
+
+	val, err := doc.Get("cids")
+	require.NoError(t, err)
+	assert.Equal(t, []immutable.Option[string]{
+		immutable.Some("bafyA"),
+		immutable.Some("bafyB"),
+		immutable.Some("bafyC"),
+	}, val)
+}
+
+func TestNewDocFromMap_TypedTimeSliceForNillableArray_Persisted(t *testing.T) {
+	ctx := context.Background()
+	nillableArrayDef := CollectionVersion{
+		Name: "Block",
+		Fields: []CollectionFieldDescription{
+			{
+				Name: "times",
+				Typ:  LWW_REGISTER,
+				Kind: FieldKind_NILLABLE_DATETIME_ARRAY,
+			},
+		},
+	}
+
+	first := time.Date(2026, 7, 7, 12, 0, 0, 0, time.UTC)
+	second := time.Date(2026, 7, 8, 12, 0, 0, 0, time.UTC)
+	doc, err := NewDocFromMap(ctx, map[string]any{
+		"times": []time.Time{first, second},
+	}, nillableArrayDef)
+	require.NoError(t, err)
+
+	val, err := doc.Get("times")
+	require.NoError(t, err)
+	assert.Equal(t, []immutable.Option[time.Time]{
+		immutable.Some(first),
+		immutable.Some(second),
+	}, val)
 }

--- a/internal/core/block/store.go
+++ b/internal/core/block/store.go
@@ -115,10 +115,15 @@ func addDelta(
 		dagBlock.Encryption = &encLink
 	}
 
-	if ok, ident := EnabledSigningFromContext(ctx); ok && ident.HasValue() {
-		err = signBlock(ctx, txn.Blockstore(), dagBlock, ident.Value())
-		if err != nil {
-			return cidlink.Link{}, nil, NewErrSignBlock(err)
+	// When a batch collector is active, the batch is signed once over the Merkle
+	// root of the collected CIDs, so per-block signing is skipped.
+	collector := BatchSigningCollectorFromContext(ctx)
+	if collector == nil {
+		if ok, ident := EnabledSigningFromContext(ctx); ok && ident.HasValue() {
+			err = signBlock(ctx, txn.Blockstore(), dagBlock, ident.Value())
+			if err != nil {
+				return cidlink.Link{}, nil, NewErrSignBlock(err)
+			}
 		}
 	}
 
@@ -127,7 +132,7 @@ func addDelta(
 		return cidlink.Link{}, nil, NewErrStoreBlock(err)
 	}
 
-	if collector := BatchSigningCollectorFromContext(ctx); collector != nil {
+	if collector != nil {
 		collector.Add(link.Cid)
 	}
 

--- a/internal/core/block/store_test.go
+++ b/internal/core/block/store_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ipfs/go-cid"
+
 	"github.com/sourcenetwork/corekv/memory"
 	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/crypto"

--- a/internal/core/block/store_test.go
+++ b/internal/core/block/store_test.go
@@ -16,11 +16,15 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/ipfs/go-cid"
 	"github.com/sourcenetwork/corekv/memory"
+	"github.com/sourcenetwork/defradb/acp/identity"
+	"github.com/sourcenetwork/defradb/crypto"
 	"github.com/sourcenetwork/defradb/internal/core/crdt"
 	"github.com/sourcenetwork/defradb/internal/datastore"
 	"github.com/sourcenetwork/defradb/internal/db/lock"
 	"github.com/sourcenetwork/defradb/internal/encryption"
+	iIdentity "github.com/sourcenetwork/defradb/internal/identity"
 	"github.com/sourcenetwork/defradb/internal/keys"
 	"github.com/sourcenetwork/immutable"
 )
@@ -45,4 +49,46 @@ func TestAddDelta_DoesNotEncryptCollectionBlocks(t *testing.T) {
 	block, err := GetFromBytes(rawBlock)
 	require.NoError(t, err)
 	require.Nil(t, block.Encryption)
+}
+
+func TestAddDelta_WithBatchCollector_SkipsBlockSignatureAndCollectsCID(t *testing.T) {
+	ctx := context.Background()
+	txn := datastore.NewTxnFrom(memory.NewDatastore(ctx), lock.NewLockSet(), 1, false, immutable.None[int]())
+	ctx = datastore.CtxSetTxn(ctx, txn)
+
+	ident, err := identity.Generate(crypto.KeyTypeSecp256k1)
+	require.NoError(t, err)
+	ctx = iIdentity.WithContext(ctx, immutable.Some[identity.Identity](ident))
+	ctx = ContextWithEnabledSigning(ctx)
+
+	collector := NewBatchCIDCollector()
+	ctx = ContextWithBatchSigning(ctx, collector)
+
+	collectionCRDT := crdt.NewCollection("collection-version", keys.NewHeadstoreColKey(1))
+	link, rawBlock, err := AddDelta(ctx, collectionCRDT, collectionCRDT.Delta())
+	require.NoError(t, err)
+
+	block, err := GetFromBytes(rawBlock)
+	require.NoError(t, err)
+	require.Nil(t, block.Signature)
+	require.Equal(t, []cid.Cid{link.Cid}, collector.GetCIDs())
+}
+
+func TestAddDelta_WithoutBatchCollector_SignsBlock(t *testing.T) {
+	ctx := context.Background()
+	txn := datastore.NewTxnFrom(memory.NewDatastore(ctx), lock.NewLockSet(), 1, false, immutable.None[int]())
+	ctx = datastore.CtxSetTxn(ctx, txn)
+
+	ident, err := identity.Generate(crypto.KeyTypeSecp256k1)
+	require.NoError(t, err)
+	ctx = iIdentity.WithContext(ctx, immutable.Some[identity.Identity](ident))
+	ctx = ContextWithEnabledSigning(ctx)
+
+	collectionCRDT := crdt.NewCollection("collection-version", keys.NewHeadstoreColKey(1))
+	_, rawBlock, err := AddDelta(ctx, collectionCRDT, collectionCRDT.Delta())
+	require.NoError(t, err)
+
+	block, err := GetFromBytes(rawBlock)
+	require.NoError(t, err)
+	require.NotNil(t, block.Signature)
 }

--- a/node/store_badger.go
+++ b/node/store_badger.go
@@ -15,6 +15,7 @@ import (
 
 	badgerds "github.com/dgraph-io/badger/v4"
 	badgeropts "github.com/dgraph-io/badger/v4/options"
+
 	"github.com/sourcenetwork/corekv"
 	"github.com/sourcenetwork/corekv/badger"
 


### PR DESCRIPTION
- Passing a typed Go slice ([]string, []time.Time) to NewDocFromMap for a nillable array field ([String], [DateTime]) silently dropped it to an empty array, because getNillableArray and getNillableDateTimeArray had no case for a raw typed slice (only *fastjson.Value, []any, and the already-option-wrapped slice). This adds that case to both parsers, wrapping each element in immutable.Some, matching the non-nillable getArray/getDateTimeArray that already handled it.
-  addDelta signed every block even when a batch collector was active, redundant work the single Merkle-root batch signature already covers. Now skips per-block signing when a collector is present; the collector still records CIDs, so the batch signature is unchanged.