### PR TITLE
fix: collect only composite block CIDs in batch signing

### DIFF
--- a/internal/core/block/store.go
+++ b/internal/core/block/store.go
@@ -132,7 +132,10 @@ func addDelta(
 		return cidlink.Link{}, nil, NewErrStoreBlock(err)
 	}
 
-	if collector != nil {
+	// Collect one CID per document. The composite block is the document root and
+	// commits to its field blocks, so collecting field CIDs is redundant and
+	// repeats CIDs across documents that share a field value.
+	if collector != nil && block.Delta.IsComposite() {
 		collector.Add(link.Cid)
 	}
 

--- a/internal/core/block/store_test.go
+++ b/internal/core/block/store_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/sourcenetwork/corekv/memory"
 	"github.com/sourcenetwork/defradb/acp/identity"
+	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/crypto"
 	"github.com/sourcenetwork/defradb/internal/core/crdt"
 	"github.com/sourcenetwork/defradb/internal/datastore"
@@ -52,10 +53,11 @@ func TestAddDelta_DoesNotEncryptCollectionBlocks(t *testing.T) {
 	require.Nil(t, block.Encryption)
 }
 
-func TestAddDelta_WithBatchCollector_SkipsBlockSignatureAndCollectsCID(t *testing.T) {
+func TestAddDelta_WithBatchCollector_CollectsCompositeCIDsOnly(t *testing.T) {
 	ctx := context.Background()
 	txn := datastore.NewTxnFrom(memory.NewDatastore(ctx), lock.NewLockSet(), 1, false, immutable.None[int]())
 	ctx = datastore.CtxSetTxn(ctx, txn)
+	store := txn.Datastore()
 
 	ident, err := identity.Generate(crypto.KeyTypeSecp256k1)
 	require.NoError(t, err)
@@ -65,13 +67,27 @@ func TestAddDelta_WithBatchCollector_SkipsBlockSignatureAndCollectsCID(t *testin
 	collector := NewBatchCIDCollector()
 	ctx = ContextWithBatchSigning(ctx, collector)
 
-	collectionCRDT := crdt.NewCollection("collection-version", keys.NewHeadstoreColKey(1))
-	link, rawBlock, err := AddDelta(ctx, collectionCRDT, collectionCRDT.Delta())
-	require.NoError(t, err)
+	key := keys.DataStoreKey{CollectionShortID: 1, DocShortID: 42}
 
+	// A composite block is a document root, so its CID is collected. In batch mode
+	// the block is also left unsigned.
+	composite := crdt.NewDocComposite(store, "collection-version", key)
+	link, rawBlock, err := AddDelta(ctx, composite, composite.Delta())
+	require.NoError(t, err)
 	block, err := GetFromBytes(rawBlock)
 	require.NoError(t, err)
 	require.Nil(t, block.Signature)
+	require.Equal(t, []cid.Cid{link.Cid}, collector.GetCIDs())
+
+	// A field block is not a document root, so its CID is not collected. Otherwise a
+	// field value shared across documents would duplicate CIDs.
+	fieldKey := key
+	fieldKey.FieldID = "1"
+	lww := crdt.NewLWW(store, "collection-version", fieldKey, "name")
+	lwwDelta, err := lww.Delta(ctx, crdt.NewDocField("name", client.NewFieldValue(client.LWW_REGISTER, client.NewNormalString("Alice"))))
+	require.NoError(t, err)
+	_, _, err = AddDelta(ctx, lww, lwwDelta)
+	require.NoError(t, err)
 	require.Equal(t, []cid.Cid{link.Cid}, collector.GetCIDs())
 }
 


### PR DESCRIPTION
The batch CID collector collected a CID for every block, so field blocks whose values repeat across documents (blockNumber, blockHash) were collected once per document and duplicated in the signed set. This restores the IsComposite() guard so only composite (document-root) block CIDs are collected, one per document