### PR TITLE
Improve CAR file support

### DIFF
--- a/internal/db/p2p/car.go
+++ b/internal/db/p2p/car.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/sourcenetwork/corekv"
 	"github.com/sourcenetwork/corekv/blockstore"
+	"github.com/sourcenetwork/defradb/errors"
 	coreblock "github.com/sourcenetwork/defradb/internal/core/block"
 	"github.com/sourcenetwork/defradb/internal/datastore"
 	"github.com/sourcenetwork/immutable"
@@ -143,7 +144,7 @@ func peekCARRootBlock(carData []byte) (*coreblock.Block, error) {
 	rootCID := reader.Roots[0]
 	for {
 		carBlock, err := reader.Next()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		if err != nil {

--- a/internal/db/p2p/car.go
+++ b/internal/db/p2p/car.go
@@ -176,7 +176,7 @@ func (p *P2P) importCAR(ctx context.Context, carData []byte) (*coreblock.Block, 
 
 	for {
 		carBlock, err := reader.Next()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		if err != nil {

--- a/internal/db/p2p/car.go
+++ b/internal/db/p2p/car.go
@@ -13,7 +13,6 @@ package p2p
 import (
 	"bytes"
 	"context"
-	"errors"
 	"io"
 
 	"github.com/ipfs/go-cid"
@@ -101,7 +100,9 @@ func (p *P2P) collectDAGBlocks(
 		coreblock.BlockSchemaPrototype,
 	)
 	if err != nil {
-		return err
+		// Block may have been pruned locally; it was already pushed to replicators before
+		// pruning so they already hold it. Skip rather than aborting the CAR.
+		return nil
 	}
 
 	block, err := coreblock.GetFromNode(node)
@@ -142,7 +143,7 @@ func peekCARRootBlock(carData []byte) (*coreblock.Block, error) {
 	rootCID := reader.Roots[0]
 	for {
 		carBlock, err := reader.Next()
-		if errors.Is(err, io.EOF) {
+		if err == io.EOF {
 			break
 		}
 		if err != nil {
@@ -174,7 +175,7 @@ func (p *P2P) importCAR(ctx context.Context, carData []byte) (*coreblock.Block, 
 
 	for {
 		carBlock, err := reader.Next()
-		if errors.Is(err, io.EOF) {
+		if err == io.EOF {
 			break
 		}
 		if err != nil {

--- a/internal/db/p2p/p2p.go
+++ b/internal/db/p2p/p2p.go
@@ -908,19 +908,31 @@ func (p *P2P) processBatchedDocuments(
 
 	return results, nil
 }
-
 func (p *P2P) SendUpdate(evt event.Update) error {
 	// push to each peer (replicator)
 	p.pushLogToReplicators(evt)
 
 	// Retries are for replicators only and should not pollute the pubsub network.
 	if !evt.IsRetry {
+		// Pre-generate a CAR so receivers import the full DAG without a BitSwap round-trip.
+		var carData []byte
+		if block, err := coreblock.GetFromBytes(evt.Block); err == nil {
+			ctx, cancel := context.WithTimeout(p.ctx, networkRequestTimeout)
+			if data, err := p.generateCAR(ctx, block); err == nil {
+				carData = data
+			} else {
+				log.ErrorE("Failed to generate CAR for pubsub, receivers will fall back to DAG sync", err)
+			}
+			cancel()
+		}
+
 		req := &protocol.PushLogRequest{
 			DocID:        evt.DocID,
 			CID:          evt.Cid.Bytes(),
 			CollectionID: evt.CollectionID,
 			Creator:      p.host.ID(),
 			Block:        evt.Block,
+			CAR:          carData,
 		}
 
 		b, err := cbor.Marshal(req)
@@ -950,6 +962,7 @@ func (p *P2P) SendUpdate(evt event.Update) error {
 			DocID: evt.DocID,
 			CID:   evt.Cid.Bytes(),
 			Block: evt.Block,
+			CAR:   carData,
 		})
 		p.topicPeerMu.RLock()
 		noPeers := p.topicPeerCounts[evt.CollectionID] == 0

--- a/internal/db/p2p/sync_dag.go
+++ b/internal/db/p2p/sync_dag.go
@@ -104,6 +104,16 @@ func (p *P2P) loadBlockLinks(ctx context.Context, linkSys *linking.LinkSystem, b
 				return ctx.Err()
 			}
 
+			// Skip fetch if the linked block is already merged locally — avoids a BitSwap
+			// round-trip for historical blocks that may have been pruned on the sender.
+			linkedMerged, err := bstore.IsMerged(ctx, lnk.Cid)
+			if err != nil {
+				return NewErrCheckBlockMerged(err)
+			}
+			if linkedMerged {
+				continue
+			}
+
 			ctxWithTimeout, cancel := context.WithTimeout(ctx, p.syncBlockLinkTimeout)
 			nd, err := linkSys.Load(linking.LinkContext{Ctx: ctxWithTimeout}, lnk, coreblock.BlockSchemaPrototype)
 			cancel()


### PR DESCRIPTION

## Relevant issue(s)

Resolves #
```
Jul  9 22:53:20.256 ERR p2p Batch: syncDAG failed DocID=bae-4f1ec126-5f3a-583c-8a43-f2227f2dfbc8 $err="failed to load linked block during DAG sync: context deadline exceeded"
Jul  9 22:53:30.407 ERR p2p Batch: syncDAG failed DocID=bae-84f4bad0-886c-5b22-b4ea-b94c18597b39 $err="failed to load linked block during DAG sync: context deadline exceeded"
```

## Description

Some changes to how CAR files are handled. Sender now sends entire CAR file so that it is not needed to be requested by host from IND. CAR file now skips if linked block has already been pruned. Skip fetch if linked block has already been merged.
