### PR TITLE
fix: Consolidate client NAC gates within harness

### DIFF
--- a/acp/identity/identity_impl.go
+++ b/acp/identity/identity_impl.go
@@ -279,7 +279,6 @@ func cloneFullIdentity(orig *fullIdentity) *fullIdentity {
 
 // CloneIdentity creates a deep copy of the given identity.
 // This exists so as to allow parallel test actions to avoid race conditions.
-// Specifically, the MustGetCanonicallyOrderedCollections function requires this functionality
 func CloneIdentity(orig Identity) Identity {
 	if f, ok := orig.(*fullIdentity); ok {
 		return cloneFullIdentity(f)

--- a/tests/action/add_doc.go
+++ b/tests/action/add_doc.go
@@ -140,7 +140,7 @@ func (a *AddDoc) Execute() {
 
 	for index, node := range nodes {
 		nodeID := nodeIDs[index]
-		collections, err := getCanonicallyOrderedCollectionsWithIdentity(a.s, node, txnOption, a.Identity)
+		collections, err := GetCollectionsCanonically(a.s, node, txnOption, a.Identity)
 		if err != nil {
 			if len(a.IgnoreError) > 0 && strings.Contains(err.Error(), a.IgnoreError) {
 				continue
@@ -152,7 +152,7 @@ func (a *AddDoc) Execute() {
 			require.NoError(a.s.T, err)
 		}
 
-		// getCanonicallyOrderedCollections returns a nil slot for any collection
+		// GetCollectionsCanonically returns a nil slot for any collection
 		// name that is no longer present in the database (documented on
 		// RefreshCollections). A concurrent PatchCollection removal therefore
 		// leaves the target slot nil, which is the expected "collection absent"

--- a/tests/action/delete_index.go
+++ b/tests/action/delete_index.go
@@ -68,10 +68,8 @@ func (a *DeleteIndex) Execute() {
 	var expectedErrorRaised bool
 
 	nodeIDs, _ := getNodesWithIDs(a.NodeID, a.s.Nodes)
-	for index, nodeID := range nodeIDs {
+	for _, nodeID := range nodeIDs {
 		node := a.s.Nodes[nodeID]
-
-		nodeID := nodeIDs[index]
 
 		// Check if a transaction is attached to this action. If so, we will be using it.
 		txnOption := immutable.None[client.Txn]()

--- a/tests/action/delete_index.go
+++ b/tests/action/delete_index.go
@@ -72,21 +72,19 @@ func (a *DeleteIndex) Execute() {
 		node := a.s.Nodes[nodeID]
 
 		nodeID := nodeIDs[index]
-		var collections []client.Collection
 
 		// Check if a transaction is attached to this action. If so, we will be using it.
-		var err error
-		var txn client.Txn
+		txnOption := immutable.None[client.Txn]()
 		if a.TransactionID.HasValue() {
-			txn, err = a.s.GetTransaction(node, a.TransactionID)
+			txn, err := a.s.GetTransaction(node, a.TransactionID)
 			require.NoError(a.s.T, err)
-			collections, err = txn.GetCollections(a.s.Ctx, options.GetCollections())
-		} else {
-			collections, err = node.GetCollections(a.s.Ctx, options.GetCollections())
+			txnOption = immutable.Some(txn)
 		}
 
+		collections, err := GetCollectionsCanonically(a.s, node, txnOption, a.Identity)
 		if err != nil {
-			return
+			expectedErrorRaised = assertError(a.s.T, err, a.ExpectedError)
+			continue
 		}
 
 		collection := collections[a.CollectionID]

--- a/tests/action/delete_index.go
+++ b/tests/action/delete_index.go
@@ -66,8 +66,6 @@ var _ Action = (*DeleteIndex)(nil)
 var _ Stateful = (*DeleteIndex)(nil)
 
 func (a *DeleteIndex) Execute() {
-	var expectedErrorRaised bool
-
 	nodeIDs, _ := getNodesWithIDs(a.NodeID, a.s.Nodes)
 	for _, nodeID := range nodeIDs {
 		node := a.s.Nodes[nodeID]
@@ -82,7 +80,8 @@ func (a *DeleteIndex) Execute() {
 
 		collections, err := GetCollectionsCanonically(a.s, node, txnOption, a.Identity)
 		if err != nil {
-			expectedErrorRaised = assertError(a.s.T, err, a.ExpectedError)
+			expectedErrorRaised := assertError(a.s.T, err, a.ExpectedError)
+			assertExpectedErrorRaised(a.s.T, a.ExpectedError, expectedErrorRaised)
 			continue
 		}
 
@@ -99,7 +98,8 @@ func (a *DeleteIndex) Execute() {
 
 		err = collection.DeleteIndex(a.s.Ctx, a.IndexName, opts)
 
-		expectedErrorRaised = assertError(a.s.T, err, a.ExpectedError)
+		expectedErrorRaised := assertError(a.s.T, err, a.ExpectedError)
+		assertExpectedErrorRaised(a.s.T, a.ExpectedError, expectedErrorRaised)
 
 		// Unless the test wants to observe the dropping window, wait for the drop record to clear
 		// so a following raw-entry assertion sees them gone.
@@ -107,8 +107,6 @@ func (a *DeleteIndex) Execute() {
 			waitForIndexDropped(a.s, node, collection.Version().CollectionID, indexID)
 		}
 	}
-
-	assertExpectedErrorRaised(a.s.T, a.ExpectedError, expectedErrorRaised)
 }
 
 // indexIDByName returns the ID of the named index on the collection, and whether it was found.

--- a/tests/action/delete_index.go
+++ b/tests/action/delete_index.go
@@ -12,6 +12,7 @@
 package action
 
 import (
+	"slices"
 	"strconv"
 	"time"
 
@@ -94,7 +95,7 @@ func (a *DeleteIndex) Execute() {
 		}
 
 		// Capture the index ID before deletion so the wait below can target its drop record.
-		indexID, hadIndex := indexIDByName(a.s, collection, a.IndexName)
+		indexID, hadIndex := indexIDByName(a.s, node, collection, a.IndexName)
 
 		err = collection.DeleteIndex(a.s.Ctx, a.IndexName, opts)
 
@@ -111,8 +112,10 @@ func (a *DeleteIndex) Execute() {
 }
 
 // indexIDByName returns the ID of the named index on the collection, and whether it was found.
-func indexIDByName(s *state.State, collection client.Collection, name string) (uint32, bool) {
-	results, err := collection.ListIndexes(s.Ctx)
+// It lists as the node identity so the lookup is authorized when NAC is enabled (it is bookkeeping
+// for the drop-wait, not the operation under test).
+func indexIDByName(s *state.State, node *state.NodeState, collection client.Collection, name string) (uint32, bool) {
+	results, err := collection.ListIndexes(s.Ctx, listIndexesOptions(s, node))
 	require.NoError(s.T, err)
 	for _, r := range results {
 		if r.Description.Name == name {
@@ -125,9 +128,17 @@ func indexIDByName(s *state.State, collection client.Collection, name string) (u
 // waitForIndexDropped blocks until no in-progress drop record remains for the index, i.e. the GC has
 // finished and cleared it. It polls ListActions so it composes with explicit Wait actions.
 func waitForIndexDropped(s *state.State, node *state.NodeState, collectionID string, indexID uint32) {
+	// Poll as the node identity so the ListActions call is authorized when NAC is enabled; waiting
+	// for the drop is test infrastructure, not the operation under test.
+	nodeID := slices.Index(s.Nodes, node)
+	opts := options.ListActions()
+	identOption := getIdentityForRequestSpecificToNode(s, NodeIdentity(nodeID), nodeID)
+	if identOption.HasValue() {
+		opts.SetIdentity(identOption.Value())
+	}
 	subject := strconv.FormatUint(uint64(indexID), 10)
 	require.Eventually(s.T, func() bool {
-		actions, err := node.ListActions(s.Ctx)
+		actions, err := node.ListActions(s.Ctx, opts)
 		if err != nil {
 			return false
 		}

--- a/tests/action/list_indexes.go
+++ b/tests/action/list_indexes.go
@@ -75,8 +75,8 @@ func (a *ListIndexes) Execute() {
 	var expectedErrorRaised bool
 
 	nodeIDs, _ := getNodesWithIDs(a.NodeID, a.s.Nodes)
-	for index, nodeID := range nodeIDs {
-		node := a.s.Nodes[index]
+	for _, nodeID := range nodeIDs {
+		node := a.s.Nodes[nodeID]
 
 		// Check if a transaction is attached to this action. If so, we will be using it.
 		var txn client.Txn

--- a/tests/action/list_indexes.go
+++ b/tests/action/list_indexes.go
@@ -89,7 +89,13 @@ func (a *ListIndexes) Execute() {
 			txnOption = immutable.Some(txn)
 		}
 
-		collections := MustGetCanonicallyOrderedCollections(a.s, node, txnOption)
+		collections, err := GetCollectionsCanonically(a.s, node, txnOption, a.Identity)
+		if err != nil {
+			if assertError(a.s.T, err, a.ExpectedError) {
+				expectedErrorRaised = true
+			}
+			continue
+		}
 		collection := collections[a.CollectionID]
 
 		opts := options.ListCollectionIndexes()

--- a/tests/action/list_indexes.go
+++ b/tests/action/list_indexes.go
@@ -72,8 +72,6 @@ func (a *ListIndexes) Execute() {
 		return
 	}
 
-	var expectedErrorRaised bool
-
 	nodeIDs, _ := getNodesWithIDs(a.NodeID, a.s.Nodes)
 	for _, nodeID := range nodeIDs {
 		node := a.s.Nodes[nodeID]
@@ -91,9 +89,8 @@ func (a *ListIndexes) Execute() {
 
 		collections, err := GetCollectionsCanonically(a.s, node, txnOption, a.Identity)
 		if err != nil {
-			if assertError(a.s.T, err, a.ExpectedError) {
-				expectedErrorRaised = true
-			}
+			expectedErrorRaised := assertError(a.s.T, err, a.ExpectedError)
+			assertExpectedErrorRaised(a.s.T, a.ExpectedError, expectedErrorRaised)
 			continue
 		}
 		collection := collections[a.CollectionID]
@@ -106,8 +103,9 @@ func (a *ListIndexes) Execute() {
 
 		actualStatuses, err := collection.ListIndexes(a.s.Ctx, opts)
 
-		if assertError(a.s.T, err, a.ExpectedError) {
-			expectedErrorRaised = true
+		expectedErrorRaised := assertError(a.s.T, err, a.ExpectedError)
+		assertExpectedErrorRaised(a.s.T, a.ExpectedError, expectedErrorRaised)
+		if err != nil {
 			continue
 		}
 
@@ -115,8 +113,6 @@ func (a *ListIndexes) Execute() {
 		assertIndexStatuses(a.ExpectedStatuses, actualStatuses, a.s.T)
 		assertIndexCollectionNames(a.ExpectedCollectionName, actualStatuses, a.s.T)
 	}
-
-	assertExpectedErrorRaised(a.s.T, a.ExpectedError, expectedErrorRaised)
 }
 
 func assertIndexesListsEqual(

--- a/tests/action/new_index.go
+++ b/tests/action/new_index.go
@@ -96,7 +96,7 @@ func (a *NewIndex) Execute() {
 		if err != nil {
 			expectedErrorRaised := assertError(a.s.T, err, a.ExpectedError)
 			assertExpectedErrorRaised(a.s.T, a.ExpectedError, expectedErrorRaised)
-			return
+			continue
 		}
 
 		collection := collections[a.CollectionID]
@@ -131,9 +131,7 @@ func (a *NewIndex) Execute() {
 		desc, err := collection.NewIndex(a.s.Ctx, indexDesc, opts)
 
 		expectedErrorRaised := assertError(a.s.T, err, a.ExpectedError)
-		if expectedErrorRaised {
-			return
-		}
+		assertExpectedErrorRaised(a.s.T, a.ExpectedError, expectedErrorRaised)
 
 		// Unless the test wants to observe the building window, wait for the build so a following
 		// query sees a built index. With an explicit transaction the record is not committed until
@@ -142,8 +140,6 @@ func (a *NewIndex) Execute() {
 			waitForIndexBuilt(a.s, collection, desc.ID, listIndexesOptions(a.s, node))
 		}
 	}
-
-	assertExpectedErrorRaised(a.s.T, a.ExpectedError, false)
 }
 
 // indexBuildTimeout bounds the wait for a background build or drop to finish. The poll returns as

--- a/tests/action/new_index.go
+++ b/tests/action/new_index.go
@@ -85,18 +85,17 @@ func (a *NewIndex) Execute() {
 		node := a.s.Nodes[nodeID]
 
 		// Check if a transaction is attached to this action. If so, we will be using it.
-		var err error
-		var txn client.Txn
-		var collections []client.Collection
+		txnOption := immutable.None[client.Txn]()
 		if a.TransactionID.HasValue() {
-			txn, err = a.s.GetTransaction(node, a.TransactionID)
+			txn, err := a.s.GetTransaction(node, a.TransactionID)
 			require.NoError(a.s.T, err)
-			collections, err = txn.GetCollections(a.s.Ctx, options.GetCollections())
-		} else {
-			collections, err = node.GetCollections(a.s.Ctx, options.GetCollections())
+			txnOption = immutable.Some(txn)
 		}
 
+		collections, err := GetCollectionsCanonically(a.s, node, txnOption, a.Identity)
 		if err != nil {
+			expectedErrorRaised := assertError(a.s.T, err, a.ExpectedError)
+			assertExpectedErrorRaised(a.s.T, a.ExpectedError, expectedErrorRaised)
 			return
 		}
 

--- a/tests/action/truncate.go
+++ b/tests/action/truncate.go
@@ -65,9 +65,13 @@ func (a *Truncate) Execute() {
 		}
 
 		nodeID := nodeIDs[index]
-		var collections []client.Collection
-		var err error
-		collections = MustGetCanonicallyOrderedCollections(a.s, node, txnOption)
+
+		collections, err := GetCollectionsCanonically(a.s, node, txnOption, a.Identity)
+		if err != nil {
+			expectedErrorRaised := assertError(a.s.T, err, a.ExpectedError)
+			assertExpectedErrorRaised(a.s.T, a.ExpectedError, expectedErrorRaised)
+			continue
+		}
 		collection := collections[a.CollectionIndex]
 
 		opts := options.TruncateCollection()

--- a/tests/action/update_doc.go
+++ b/tests/action/update_doc.go
@@ -117,7 +117,7 @@ func (a *UpdateDoc) Execute() {
 			doNotWaitForUpdate = true // if using txn, we skip local update wait
 		}
 
-		collections, err := getCanonicallyOrderedCollections(a.s, node, txnOption)
+		collections, err := GetCollectionsCanonically(a.s, node, txnOption, a.Identity)
 		if err != nil {
 			if len(a.IgnoreError) > 0 && strings.Contains(err.Error(), a.IgnoreError) {
 				continue

--- a/tests/action/utils.go
+++ b/tests/action/utils.go
@@ -90,23 +90,17 @@ func RefreshCollections(
 	}
 }
 
-// getCanonicallyOrderedCollections gets the collections inside of a transaction, if one is provided.
-// If one is not provided, it will default to running the GetCollections function on the node itself.
-// Importantly, this will use the same ordering as would be found in the node.Collections slice that
-// is refreshed by the RefreshCollections function.
-func getCanonicallyOrderedCollections(
+// GetCollectionsCanonically resolves the collections as the given actor identity, using the same
+// canonical ordering as the node.Collections slice refreshed by [RefreshCollections].
+//
+// It performs no identity substitution, so under node acp an unauthorized actor is denied while
+// resolving (on get-collection); the error is returned so callers can assert an expected
+// authorization failure. Use it for an operation whose authorization is under test.
+func GetCollectionsCanonically(
 	s *state.State,
 	node *state.NodeState,
 	txn immutable.Option[client.Txn],
-) ([]client.Collection, error) {
-	return getCanonicallyOrderedCollectionsWithIdentity(s, node, txn, immutable.None[state.Identity]())
-}
-
-func getCanonicallyOrderedCollectionsWithIdentity(
-	s *state.State,
-	node *state.NodeState,
-	txn immutable.Option[client.Txn],
-	identity immutable.Option[state.Identity],
+	actor immutable.Option[state.Identity],
 ) ([]client.Collection, error) {
 	var clientTxn client.Txn
 	if txn.HasValue() {
@@ -122,13 +116,9 @@ func getCanonicallyOrderedCollectionsWithIdentity(
 		}
 	}
 
-	if !identity.HasValue() {
-		identity = NodeIdentity(nodeID)
-	}
-
 	newCollections := make([]client.Collection, len(s.CollectionNames))
 
-	identOption := getIdentityForRequestSpecificToNode(s, identity, nodeID)
+	identOption := getIdentityForRequestSpecificToNode(s, actor, nodeID)
 	opts := options.GetCollections()
 	if identOption.HasValue() {
 		opts.SetIdentity(identOption.Value())
@@ -164,21 +154,6 @@ func getCanonicallyOrderedCollectionsWithIdentity(
 	}
 
 	return newCollections, nil
-}
-
-// MustGetCanonicallyOrderedCollections gets the collections inside of a transaction, if one is provided.
-// If one is not provided, it will default to running the GetCollections function on the node itself.
-// Importantly, this will use the same ordering as would be found in the node.Collections slice that
-// is refreshed by the RefreshCollections function.
-func MustGetCanonicallyOrderedCollections(
-	s *state.State,
-	node *state.NodeState,
-	txn immutable.Option[client.Txn],
-) []client.Collection {
-	cols, err := getCanonicallyOrderedCollections(s, node, txn)
-	require.NoError(s.T, err)
-
-	return cols
 }
 
 func appendCollectionVersion(s *state.State, versionID string) {

--- a/tests/action/utils.go
+++ b/tests/action/utils.go
@@ -94,6 +94,9 @@ func RefreshCollections(
 // GetCollectionsCanonically resolves the collections as the given actor identity, using the same
 // canonical ordering as the node.Collections slice refreshed by [RefreshCollections].
 //
+// The given transaction is optional, if one is not provided the collections will be resolved
+// by running the GetCollections function on the node itself.
+//
 // It performs no identity substitution, so under node acp an unauthorized actor is denied while
 // resolving (on get-collection); the error is returned so callers can assert an expected
 // authorization failure. Use it for an operation whose authorization is under test.

--- a/tests/action/utils.go
+++ b/tests/action/utils.go
@@ -12,6 +12,7 @@
 package action
 
 import (
+	"slices"
 	"strings"
 	"time"
 
@@ -107,14 +108,7 @@ func GetCollectionsCanonically(
 		clientTxn = txn.Value()
 	}
 
-	// Find the nodeID for this node
-	nodeID := -1
-	for i, n := range s.Nodes {
-		if n == node {
-			nodeID = i
-			break
-		}
-	}
+	nodeID := slices.Index(s.Nodes, node)
 
 	newCollections := make([]client.Collection, len(s.CollectionNames))
 

--- a/tests/action/wait_for_index.go
+++ b/tests/action/wait_for_index.go
@@ -12,6 +12,8 @@
 package action
 
 import (
+	"slices"
+
 	"github.com/stretchr/testify/require"
 
 	"github.com/sourcenetwork/immutable"
@@ -29,13 +31,7 @@ func listIndexesOptions(
 	s *state.State,
 	node *state.NodeState,
 ) options.Enumerable[options.ListCollectionIndexesOptions] {
-	nodeID := -1
-	for i, n := range s.Nodes {
-		if n == node {
-			nodeID = i
-			break
-		}
-	}
+	nodeID := slices.Index(s.Nodes, node)
 	builder := options.ListCollectionIndexes()
 	identOption := getIdentityForRequestSpecificToNode(s, NodeIdentity(nodeID), nodeID)
 	if identOption.HasValue() {
@@ -53,9 +49,18 @@ func WaitForNodeIndexesBuilt(s *state.State, node *state.NodeState) {
 		return
 	}
 	opts := listIndexesOptions(s, node)
-	// Fetch collections outside any transaction: the caller's txn may already be committed, and a
-	// collection bound to it would fail ListIndexes with "transaction not found".
-	for _, collection := range MustGetCanonicallyOrderedCollections(s, node, immutable.None[client.Txn]()) {
+	// Resolve as the node identity so every collection is visible when NAC is enabled, and outside
+	// any transaction: the caller's txn may already be committed, and a collection bound to it
+	// would fail ListIndexes with "transaction not found".
+	collections, err := GetCollectionsCanonically(
+		s,
+		node,
+		immutable.None[client.Txn](),
+		NodeIdentity(slices.Index(s.Nodes, node)),
+	)
+	require.NoError(s.T, err)
+
+	for _, collection := range collections {
 		if collection == nil {
 			continue
 		}
@@ -94,7 +99,14 @@ func (a *WaitForIndexReady) Execute() {
 		if node.Closed {
 			continue
 		}
-		collections := MustGetCanonicallyOrderedCollections(a.s, node, immutable.None[client.Txn]())
+		// Resolve as the node identity (visible under NAC) and outside any transaction.
+		collections, err := GetCollectionsCanonically(
+			a.s,
+			node,
+			immutable.None[client.Txn](),
+			NodeIdentity(nodeID),
+		)
+		require.NoError(a.s.T, err)
 		collection := collections[a.CollectionID]
 
 		opts := listIndexesOptions(a.s, node)

--- a/tests/integration/acp/nac/add_document_test.go
+++ b/tests/integration/acp/nac/add_document_test.go
@@ -14,6 +14,7 @@ package test_acp_nac
 import (
 	"testing"
 
+	acpTypes "github.com/sourcenetwork/defradb/acp/types"
 	"github.com/sourcenetwork/defradb/tests/action"
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
 )
@@ -55,8 +56,6 @@ func TestNAC_GatesAddDocument_AuthorizedIdentity_AllowAccess(t *testing.T) {
 
 func TestNAC_GatesAddDocument_NoIdentity_NotAuthorizedError(t *testing.T) {
 	test := testUtils.TestCase{
-		// todo: Investigate and test this behavior across all client types when implementing granular NAC permissions.
-		// See: https://github.com/sourcenetwork/defradb/issues/4383
 		Actions: []any{
 			// Starting with NAC, so only authorized user(s) can perform operations from here on out.
 			testUtils.Close{},
@@ -73,14 +72,10 @@ func TestNAC_GatesAddDocument_NoIdentity_NotAuthorizedError(t *testing.T) {
 
 			// We haven't authorized non-identities. So, this should error.
 			&action.AddDoc{
-				Identity:     testUtils.NoIdentity(),
-				CollectionID: 0,
-				Doc:          `{ "name": "Shahzad" }`,
-				// todo: After implementing granular NAC permissions, this should be changed to a
-				// specific permission error. Currently, the permission error is different across
-				// different client types and environments.
-				// See: https://github.com/sourcenetwork/defradb/issues/4446
-				ExpectedError: "not authorized to perform operation",
+				Identity:      testUtils.NoIdentity(),
+				CollectionID:  0,
+				Doc:           `{ "name": "Shahzad" }`,
+				ExpectedError: testUtils.FormatExpectedErrorWithPermission(acpTypes.NodeGetCollectionPerm),
 			},
 			&action.Request{ // Should not be added
 				Identity: testUtils.ClientIdentity(1),
@@ -95,8 +90,6 @@ func TestNAC_GatesAddDocument_NoIdentity_NotAuthorizedError(t *testing.T) {
 
 func TestNAC_GatesAddDocument_WrongIdentity_NotAuthorizedError(t *testing.T) {
 	test := testUtils.TestCase{
-		// todo: Investigate and test this behavior across all client types when implementing granular NAC permissions.
-		// See: https://github.com/sourcenetwork/defradb/issues/4383
 		Actions: []any{
 			// Starting with NAC, so only authorized user(s) can perform operations from here on out.
 			testUtils.Close{},
@@ -113,14 +106,10 @@ func TestNAC_GatesAddDocument_WrongIdentity_NotAuthorizedError(t *testing.T) {
 
 			// Wrong user/identity will also not be authorized.
 			&action.AddDoc{
-				Identity:     testUtils.ClientIdentity(2),
-				CollectionID: 0,
-				Doc:          `{ "name": "Shahzad" }`,
-				// todo: After implementing granular NAC permissions, this should be changed to a
-				// specific permission error. Currently, the permission error is different across
-				// different client types and environments.
-				// See: https://github.com/sourcenetwork/defradb/issues/4446
-				ExpectedError: "not authorized to perform operation",
+				Identity:      testUtils.ClientIdentity(2),
+				CollectionID:  0,
+				Doc:           `{ "name": "Shahzad" }`,
+				ExpectedError: testUtils.FormatExpectedErrorWithPermission(acpTypes.NodeGetCollectionPerm),
 			},
 			&action.Request{ // Should not be added
 				Identity: testUtils.ClientIdentity(1),

--- a/tests/integration/acp/nac/delete_document_test.go
+++ b/tests/integration/acp/nac/delete_document_test.go
@@ -17,8 +17,6 @@ import (
 	acpTypes "github.com/sourcenetwork/defradb/acp/types"
 	"github.com/sourcenetwork/defradb/tests/action"
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
-	"github.com/sourcenetwork/defradb/tests/state"
-	"github.com/sourcenetwork/immutable"
 )
 
 func TestNAC_GatesDeleteDocument_AuthorizedIdentity_AllowAccess(t *testing.T) {
@@ -37,7 +35,7 @@ func TestNAC_GatesDeleteDocument_AuthorizedIdentity_AllowAccess(t *testing.T) {
 				SDL: `
 					type User {
 						name: String
-						age: Int 
+						age: Int
 					}`,
 			},
 			&action.AddDoc{
@@ -70,14 +68,6 @@ func TestNAC_GatesDeleteDocument_AuthorizedIdentity_AllowAccess(t *testing.T) {
 
 func TestNAC_GatesDeleteDocument_NoIdentity_NotAuthorizedError(t *testing.T) {
 	test := testUtils.TestCase{
-		// todo: Investigate and test this behavior across all client types when implementing granular NAC permissions.
-		// See: https://github.com/sourcenetwork/defradb/issues/4383
-		SupportedClientTypes: immutable.Some(
-			[]state.ClientType{
-				state.GoClientType,
-				state.JSClientType,
-			},
-		),
 		Actions: []any{
 			// Starting with NAC, so only authorized user(s) can perform operations from here on out.
 			testUtils.Close{},
@@ -92,64 +82,7 @@ func TestNAC_GatesDeleteDocument_NoIdentity_NotAuthorizedError(t *testing.T) {
 				SDL: `
 					type User {
 						name: String
-						age: Int 
-					}`,
-			},
-			&action.AddDoc{
-				Identity:     testUtils.ClientIdentity(1),
-				CollectionID: 0,
-				Doc: `{
-					"name": "Shahzad",
-					"age": 48
-				}`,
-			},
-
-			// We haven't authorized non-identities. So, this should error.
-			testUtils.DeleteDoc{
-				Identity:      testUtils.NoIdentity(),
-				CollectionID:  0,
-				DocID:         0,
-				ExpectedError: testUtils.FormatExpectedErrorWithPermission(acpTypes.NodeDeleteDocumentPerm),
-			},
-			&action.Request{ // Should not be deleted.
-				Identity: testUtils.ClientIdentity(1),
-				Request:  `query{ User { name } }`,
-				Results: map[string]any{
-					"User": []map[string]any{{"name": "Shahzad"}},
-				},
-			},
-		},
-	}
-
-	testUtils.ExecuteTestCase(t, test)
-}
-
-func TestNAC_GatesDeleteDocument_NoIdentity_CLIandCandHTTPClient_NotAuthorizedError(t *testing.T) {
-	test := testUtils.TestCase{
-		// todo: Investigate and test this behavior across all client types when implementing granular NAC permissions.
-		// See: https://github.com/sourcenetwork/defradb/issues/4383
-		SupportedClientTypes: immutable.Some(
-			[]state.ClientType{
-				state.CClientType,
-				state.HTTPClientType,
-				state.CLIClientType,
-			},
-		),
-		Actions: []any{
-			// Starting with NAC, so only authorized user(s) can perform operations from here on out.
-			testUtils.Close{},
-			testUtils.Start{
-				Identity:  testUtils.ClientIdentity(1),
-				EnableNAC: true,
-			},
-			// Note: Doing setup steps after starting with nac enabled, otherwise the in-memory tests
-			// will lose setup state when the restart happens (i.e. the restart that started nac).
-			&action.AddCollection{
-				Identity: testUtils.ClientIdentity(1),
-				SDL: `
-					type User {
-						name: String
-						age: Int 
+						age: Int
 					}`,
 			},
 			&action.AddDoc{
@@ -183,14 +116,6 @@ func TestNAC_GatesDeleteDocument_NoIdentity_CLIandCandHTTPClient_NotAuthorizedEr
 
 func TestNAC_GatesDeleteDocument_WrongIdentity_NotAuthorizedError(t *testing.T) {
 	test := testUtils.TestCase{
-		// todo: Investigate and test this behavior across all client types when implementing granular NAC permissions.
-		// See: https://github.com/sourcenetwork/defradb/issues/4383
-		SupportedClientTypes: immutable.Some(
-			[]state.ClientType{
-				state.GoClientType,
-				state.JSClientType,
-			},
-		),
 		Actions: []any{
 			// Starting with NAC, so only authorized user(s) can perform operations from here on out.
 			testUtils.Close{},
@@ -205,64 +130,7 @@ func TestNAC_GatesDeleteDocument_WrongIdentity_NotAuthorizedError(t *testing.T) 
 				SDL: `
 					type User {
 						name: String
-						age: Int 
-					}`,
-			},
-			&action.AddDoc{
-				Identity:     testUtils.ClientIdentity(1),
-				CollectionID: 0,
-				Doc: `{
-					"name": "Shahzad",
-					"age": 48
-				}`,
-			},
-
-			// Wrong user/identity will also not be authorized.
-			testUtils.DeleteDoc{
-				Identity:      testUtils.ClientIdentity(2),
-				CollectionID:  0,
-				DocID:         0,
-				ExpectedError: testUtils.FormatExpectedErrorWithPermission(acpTypes.NodeDeleteDocumentPerm),
-			},
-			&action.Request{ // Should not be deleted
-				Identity: testUtils.ClientIdentity(1),
-				Request:  `query{ User { name } }`,
-				Results: map[string]any{
-					"User": []map[string]any{{"name": "Shahzad"}},
-				},
-			},
-		},
-	}
-
-	testUtils.ExecuteTestCase(t, test)
-}
-
-func TestNAC_GatesDeleteDocument_WrongIdentity_CLIandCandHTTPClient_NotAuthorizedError(t *testing.T) {
-	test := testUtils.TestCase{
-		// todo: Investigate and test this behavior across all client types when implementing granular NAC permissions.
-		// See: https://github.com/sourcenetwork/defradb/issues/4383
-		SupportedClientTypes: immutable.Some(
-			[]state.ClientType{
-				state.CClientType,
-				state.HTTPClientType,
-				state.CLIClientType,
-			},
-		),
-		Actions: []any{
-			// Starting with NAC, so only authorized user(s) can perform operations from here on out.
-			testUtils.Close{},
-			testUtils.Start{
-				Identity:  testUtils.ClientIdentity(1),
-				EnableNAC: true,
-			},
-			// Note: Doing setup steps after starting with nac enabled, otherwise the in-memory tests
-			// will lose setup state when the restart happens (i.e. the restart that started nac).
-			&action.AddCollection{
-				Identity: testUtils.ClientIdentity(1),
-				SDL: `
-					type User {
-						name: String
-						age: Int 
+						age: Int
 					}`,
 			},
 			&action.AddDoc{

--- a/tests/integration/acp/nac/delete_encrypted_index_test.go
+++ b/tests/integration/acp/nac/delete_encrypted_index_test.go
@@ -68,53 +68,6 @@ func TestNAC_GatesDeleteEncryptedIndex_AuthorizedIdentity_AllowAccess(t *testing
 
 func TestNAC_GatesDeleteEncryptedIndex_NoIdentity_NotAuthorizedError(t *testing.T) {
 	test := testUtils.TestCase{
-		// todo: Investigate and test this behavior across all client types when implementing granular NAC permissions.
-		// See: https://github.com/sourcenetwork/defradb/issues/4383
-		SupportedClientTypes: immutable.Some(
-			[]state.ClientType{
-				state.GoClientType,
-				state.JSClientType,
-			},
-		),
-		Actions: []any{
-			// Starting all nodes with NAC, so only authorized user(s) can perform operations from here on out.
-			testUtils.Close{},
-			testUtils.Start{
-				Identity:  testUtils.ClientIdentity(1),
-				EnableNAC: true,
-			},
-			&action.AddCollection{
-				Identity: testUtils.ClientIdentity(1),
-				SDL: `
-					type Users {
-						name: String
-					}
-				`,
-			},
-
-			testUtils.DeleteEncryptedIndex{
-				Identity:      testUtils.NoIdentity(),
-				CollectionID:  0,
-				FieldName:     "name",
-				ExpectedError: testUtils.FormatExpectedErrorWithPermission(acpTypes.NodeDeleteEncryptedIndexPerm),
-			},
-		},
-	}
-
-	testUtils.ExecuteTestCase(t, test)
-}
-
-func TestNAC_GatesDeleteEncryptedIndex_NoIdentity_CLIandCandHTTPClient_NotAuthorizedError(t *testing.T) {
-	test := testUtils.TestCase{
-		// todo: Investigate and test this behavior across all client types when implementing granular NAC permissions.
-		// See: https://github.com/sourcenetwork/defradb/issues/4383
-		SupportedClientTypes: immutable.Some(
-			[]state.ClientType{
-				state.CClientType,
-				state.HTTPClientType,
-				state.CLIClientType,
-			},
-		),
 		Actions: []any{
 			// Starting all nodes with NAC, so only authorized user(s) can perform operations from here on out.
 			testUtils.Close{},
@@ -145,53 +98,6 @@ func TestNAC_GatesDeleteEncryptedIndex_NoIdentity_CLIandCandHTTPClient_NotAuthor
 
 func TestNAC_GatesDeleteEncryptedIndex_WrongIdentity_NotAuthorizedError(t *testing.T) {
 	test := testUtils.TestCase{
-		// todo: Investigate and test this behavior across all client types when implementing granular NAC permissions.
-		// See: https://github.com/sourcenetwork/defradb/issues/4383
-		SupportedClientTypes: immutable.Some(
-			[]state.ClientType{
-				state.GoClientType,
-				state.JSClientType,
-			},
-		),
-		Actions: []any{
-			// Starting all nodes with NAC, so only authorized user(s) can perform operations from here on out.
-			testUtils.Close{},
-			testUtils.Start{
-				Identity:  testUtils.ClientIdentity(1),
-				EnableNAC: true,
-			},
-			&action.AddCollection{
-				Identity: testUtils.ClientIdentity(1),
-				SDL: `
-					type Users {
-						name: String
-					}
-				`,
-			},
-
-			testUtils.DeleteEncryptedIndex{
-				Identity:      testUtils.ClientIdentity(2),
-				CollectionID:  0,
-				FieldName:     "name",
-				ExpectedError: testUtils.FormatExpectedErrorWithPermission(acpTypes.NodeDeleteEncryptedIndexPerm),
-			},
-		},
-	}
-
-	testUtils.ExecuteTestCase(t, test)
-}
-
-func TestNAC_GatesDeleteEncryptedIndex_WrongIdentity_CLIandCandHTTPClient_NotAuthorizedError(t *testing.T) {
-	test := testUtils.TestCase{
-		// todo: Investigate and test this behavior across all client types when implementing granular NAC permissions.
-		// See: https://github.com/sourcenetwork/defradb/issues/4383
-		SupportedClientTypes: immutable.Some(
-			[]state.ClientType{
-				state.CClientType,
-				state.HTTPClientType,
-				state.CLIClientType,
-			},
-		),
 		Actions: []any{
 			// Starting all nodes with NAC, so only authorized user(s) can perform operations from here on out.
 			testUtils.Close{},

--- a/tests/integration/acp/nac/delete_index_test.go
+++ b/tests/integration/acp/nac/delete_index_test.go
@@ -63,55 +63,6 @@ func TestNAC_GatesDeleteIndex_AuthorizedIdentity_AllowAccess(t *testing.T) {
 
 func TestNAC_GatesDeleteIndex_NoIdentity_NotAuthorizedError(t *testing.T) {
 	test := testUtils.TestCase{
-		// todo: Investigate and test this behavior across all client types when implementing granular NAC permissions.
-		// See: https://github.com/sourcenetwork/defradb/issues/4383
-		SupportedClientTypes: immutable.Some(
-			[]state.ClientType{
-				state.GoClientType,
-				state.JSClientType,
-			},
-		),
-		Actions: []any{
-			// Starting with NAC, so only authorized user(s) can perform operations from here on out.
-			testUtils.Close{},
-			testUtils.Start{
-				Identity:  testUtils.ClientIdentity(1),
-				EnableNAC: true,
-			},
-			// Note: Doing setup steps after starting with nac enabled, otherwise the in-memory tests
-			// will lose setup state when the restart happens (i.e. the restart that started nac).
-			&action.AddCollection{
-				Identity: testUtils.ClientIdentity(1),
-				SDL: `
-					type User {
-						name: String @index
-					}
-				`,
-			},
-
-			// We haven't authorized non-identities. So, this should error.
-			&action.DeleteIndex{
-				Identity:      testUtils.NoIdentity(),
-				IndexName:     "User_name_ASC",
-				ExpectedError: testUtils.FormatExpectedErrorWithPermission(acpTypes.NodeDeleteIndexPerm),
-			},
-		},
-	}
-
-	testUtils.ExecuteTestCase(t, test)
-}
-
-func TestNAC_GatesDeleteIndex_NoIdentity_CLIandCandHTTPClient_NotAuthorizedError(t *testing.T) {
-	test := testUtils.TestCase{
-		// todo: Investigate and test this behavior across all client types when implementing granular NAC permissions.
-		// See: https://github.com/sourcenetwork/defradb/issues/4383
-		SupportedClientTypes: immutable.Some(
-			[]state.ClientType{
-				state.CClientType,
-				state.HTTPClientType,
-				state.CLIClientType,
-			},
-		),
 		Actions: []any{
 			// Starting with NAC, so only authorized user(s) can perform operations from here on out.
 			testUtils.Close{},
@@ -144,55 +95,6 @@ func TestNAC_GatesDeleteIndex_NoIdentity_CLIandCandHTTPClient_NotAuthorizedError
 
 func TestNAC_GatesDeleteIndex_WrongIdentity_NotAuthorizedError(t *testing.T) {
 	test := testUtils.TestCase{
-		// todo: Investigate and test this behavior across all client types when implementing granular NAC permissions.
-		// See: https://github.com/sourcenetwork/defradb/issues/4383
-		SupportedClientTypes: immutable.Some(
-			[]state.ClientType{
-				state.GoClientType,
-				state.JSClientType,
-			},
-		),
-		Actions: []any{
-			// Starting with NAC, so only authorized user(s) can perform operations from here on out.
-			testUtils.Close{},
-			testUtils.Start{
-				Identity:  testUtils.ClientIdentity(1),
-				EnableNAC: true,
-			},
-			// Note: Doing setup steps after starting with nac enabled, otherwise the in-memory tests
-			// will lose setup state when the restart happens (i.e. the restart that started nac).
-			&action.AddCollection{
-				Identity: testUtils.ClientIdentity(1),
-				SDL: `
-					type User {
-						name: String @index
-					}
-				`,
-			},
-
-			// Wrong user/identity will also not be authorized.
-			&action.DeleteIndex{
-				Identity:      testUtils.ClientIdentity(2),
-				IndexName:     "User_name_ASC",
-				ExpectedError: testUtils.FormatExpectedErrorWithPermission(acpTypes.NodeDeleteIndexPerm),
-			},
-		},
-	}
-
-	testUtils.ExecuteTestCase(t, test)
-}
-
-func TestNAC_GatesDeleteIndex_WrongIdentity_CLIandCandHTTPClient_NotAuthorizedError(t *testing.T) {
-	test := testUtils.TestCase{
-		// todo: Investigate and test this behavior across all client types when implementing granular NAC permissions.
-		// See: https://github.com/sourcenetwork/defradb/issues/4383
-		SupportedClientTypes: immutable.Some(
-			[]state.ClientType{
-				state.CClientType,
-				state.CLIClientType,
-				state.HTTPClientType,
-			},
-		),
 		Actions: []any{
 			// Starting with NAC, so only authorized user(s) can perform operations from here on out.
 			testUtils.Close{},

--- a/tests/integration/acp/nac/list_encrypted_index_test.go
+++ b/tests/integration/acp/nac/list_encrypted_index_test.go
@@ -65,55 +65,6 @@ func TestNAC_GatesListEncryptedIndex_AuthorizedIdentity_AllowAccess(t *testing.T
 
 func TestNAC_GatesListEncryptedIndex_NoIdentity_NotAuthorizedError(t *testing.T) {
 	test := testUtils.TestCase{
-		// todo: Investigate and test this behavior across all client types when implementing granular NAC permissions.
-		// See: https://github.com/sourcenetwork/defradb/issues/4383
-		SupportedClientTypes: immutable.Some(
-			[]state.ClientType{
-				state.GoClientType,
-				state.JSClientType,
-			},
-		),
-		Actions: []any{
-			// Starting with NAC, so only authorized user(s) can perform operations from here on out.
-			testUtils.Close{},
-			testUtils.Start{
-				Identity:  testUtils.ClientIdentity(1),
-				EnableNAC: true,
-			},
-			// Note: Doing setup steps after starting with nac enabled, otherwise the in-memory tests
-			// will lose setup state when the restart happens (i.e. the restart that started nac).
-			&action.AddCollection{
-				Identity: testUtils.ClientIdentity(1),
-				SDL: `
-					type User {
-						name: String
-					}
-				`,
-			},
-
-			// We haven't authorized non-identities. So, this should error.
-			testUtils.ListEncryptedIndexes{
-				Identity:      testUtils.NoIdentity(),
-				CollectionID:  0,
-				ExpectedError: testUtils.FormatExpectedErrorWithPermission(acpTypes.NodeListEncryptedIndexPerm),
-			},
-		},
-	}
-
-	testUtils.ExecuteTestCase(t, test)
-}
-
-func TestNAC_GatesListEncryptedIndex_NoIdentity_CLIandCandHTTPClient_NotAuthorizedError(t *testing.T) {
-	test := testUtils.TestCase{
-		// todo: Investigate and test this behavior across all client types when implementing granular NAC permissions.
-		// See: https://github.com/sourcenetwork/defradb/issues/4383
-		SupportedClientTypes: immutable.Some(
-			[]state.ClientType{
-				state.CClientType,
-				state.HTTPClientType,
-				state.CLIClientType,
-			},
-		),
 		Actions: []any{
 			// Starting with NAC, so only authorized user(s) can perform operations from here on out.
 			testUtils.Close{},
@@ -146,55 +97,6 @@ func TestNAC_GatesListEncryptedIndex_NoIdentity_CLIandCandHTTPClient_NotAuthoriz
 
 func TestNAC_GatesListEncryptedIndex_WrongIdentity_NotAuthorizedError(t *testing.T) {
 	test := testUtils.TestCase{
-		// todo: Investigate and test this behavior across all client types when implementing granular NAC permissions.
-		// See: https://github.com/sourcenetwork/defradb/issues/4383
-		SupportedClientTypes: immutable.Some(
-			[]state.ClientType{
-				state.GoClientType,
-				state.JSClientType,
-			},
-		),
-		Actions: []any{
-			// Starting with NAC, so only authorized user(s) can perform operations from here on out.
-			testUtils.Close{},
-			testUtils.Start{
-				Identity:  testUtils.ClientIdentity(1),
-				EnableNAC: true,
-			},
-			// Note: Doing setup steps after starting with nac enabled, otherwise the in-memory tests
-			// will lose setup state when the restart happens (i.e. the restart that started nac).
-			&action.AddCollection{
-				Identity: testUtils.ClientIdentity(1),
-				SDL: `
-					type User {
-						name: String
-					}
-				`,
-			},
-
-			// Wrong user/identity will also not be authorized.
-			testUtils.ListEncryptedIndexes{
-				Identity:      testUtils.ClientIdentity(2),
-				CollectionID:  0,
-				ExpectedError: testUtils.FormatExpectedErrorWithPermission(acpTypes.NodeListEncryptedIndexPerm),
-			},
-		},
-	}
-
-	testUtils.ExecuteTestCase(t, test)
-}
-
-func TestNAC_GatesListEncryptedIndex_WrongIdentity_CLIandCandHTTPClient_NotAuthorizedError(t *testing.T) {
-	test := testUtils.TestCase{
-		// todo: Investigate and test this behavior across all client types when implementing granular NAC permissions.
-		// See: https://github.com/sourcenetwork/defradb/issues/4383
-		SupportedClientTypes: immutable.Some(
-			[]state.ClientType{
-				state.CClientType,
-				state.HTTPClientType,
-				state.CLIClientType,
-			},
-		),
 		Actions: []any{
 			// Starting with NAC, so only authorized user(s) can perform operations from here on out.
 			testUtils.Close{},

--- a/tests/integration/acp/nac/list_index_test.go
+++ b/tests/integration/acp/nac/list_index_test.go
@@ -65,54 +65,6 @@ func TestNAC_GatesListIndex_AuthorizedIdentity_AllowAccess(t *testing.T) {
 
 func TestNAC_GatesListIndex_NoIdentity_NotAuthorizedError(t *testing.T) {
 	test := testUtils.TestCase{
-		// todo: Investigate and test this behavior across all client types when implementing granular NAC permissions.
-		// See: https://github.com/sourcenetwork/defradb/issues/4383
-		SupportedClientTypes: immutable.Some(
-			[]state.ClientType{
-				state.GoClientType,
-			},
-		),
-		Actions: []any{
-			// Starting with NAC, so only authorized user(s) can perform operations from here on out.
-			testUtils.Close{},
-			testUtils.Start{
-				Identity:  testUtils.ClientIdentity(1),
-				EnableNAC: true,
-			},
-			// Note: Doing setup steps after starting with nac enabled, otherwise the in-memory tests
-			// will lose setup state when the restart happens (i.e. the restart that started nac).
-			&action.AddCollection{
-				Identity: testUtils.ClientIdentity(1),
-				SDL: `
-					type User {
-						name: String
-					}
-				`,
-			},
-
-			// We haven't authorized non-identities. So, this should error.
-			&action.ListIndexes{
-				Identity:      testUtils.NoIdentity(),
-				CollectionID:  0,
-				ExpectedError: testUtils.FormatExpectedErrorWithPermission(acpTypes.NodeListIndexPerm),
-			},
-		},
-	}
-
-	testUtils.ExecuteTestCase(t, test)
-}
-
-func TestNAC_GatesListIndex_NoIdentity_CLIandCandHTTPClient_NotAuthorizedError(t *testing.T) {
-	test := testUtils.TestCase{
-		// todo: Investigate and test this behavior across all client types when implementing granular NAC permissions.
-		// See: https://github.com/sourcenetwork/defradb/issues/4383
-		SupportedClientTypes: immutable.Some(
-			[]state.ClientType{
-				state.CClientType,
-				state.HTTPClientType,
-				state.CLIClientType,
-			},
-		),
 		Actions: []any{
 			// Starting with NAC, so only authorized user(s) can perform operations from here on out.
 			testUtils.Close{},
@@ -145,54 +97,6 @@ func TestNAC_GatesListIndex_NoIdentity_CLIandCandHTTPClient_NotAuthorizedError(t
 
 func TestNAC_GatesListIndex_WrongIdentity_NotAuthorizedError(t *testing.T) {
 	test := testUtils.TestCase{
-		// todo: Investigate and test this behavior across all client types when implementing granular NAC permissions.
-		// See: https://github.com/sourcenetwork/defradb/issues/4383
-		SupportedClientTypes: immutable.Some(
-			[]state.ClientType{
-				state.GoClientType,
-			},
-		),
-		Actions: []any{
-			// Starting with NAC, so only authorized user(s) can perform operations from here on out.
-			testUtils.Close{},
-			testUtils.Start{
-				Identity:  testUtils.ClientIdentity(1),
-				EnableNAC: true,
-			},
-			// Note: Doing setup steps after starting with nac enabled, otherwise the in-memory tests
-			// will lose setup state when the restart happens (i.e. the restart that started nac).
-			&action.AddCollection{
-				Identity: testUtils.ClientIdentity(1),
-				SDL: `
-					type User {
-						name: String
-					}
-				`,
-			},
-
-			// Wrong user/identity will also not be authorized.
-			&action.ListIndexes{
-				Identity:      testUtils.ClientIdentity(2),
-				CollectionID:  0,
-				ExpectedError: testUtils.FormatExpectedErrorWithPermission(acpTypes.NodeListIndexPerm),
-			},
-		},
-	}
-
-	testUtils.ExecuteTestCase(t, test)
-}
-
-func TestNAC_GatesListIndex_WrongIdentity_CLIandCandHTTPClient_NotAuthorizedError(t *testing.T) {
-	test := testUtils.TestCase{
-		// todo: Investigate and test this behavior across all client types when implementing granular NAC permissions.
-		// See: https://github.com/sourcenetwork/defradb/issues/4383
-		SupportedClientTypes: immutable.Some(
-			[]state.ClientType{
-				state.CClientType,
-				state.HTTPClientType,
-				state.CLIClientType,
-			},
-		),
 		Actions: []any{
 			// Starting with NAC, so only authorized user(s) can perform operations from here on out.
 			testUtils.Close{},

--- a/tests/integration/acp/nac/new_encrypted_index_test.go
+++ b/tests/integration/acp/nac/new_encrypted_index_test.go
@@ -58,50 +58,6 @@ func TestNAC_GatesNewEncryptedIndex_AuthorizedIdentity_AllowAccess(t *testing.T)
 
 func TestNAC_GatesNewEncryptedIndex_NoIdentity_NotAuthorizedError(t *testing.T) {
 	test := testUtils.TestCase{
-		// todo: Investigate and test this behavior across all client types when implementing granular NAC permissions.
-		// See: https://github.com/sourcenetwork/defradb/issues/4383
-		SupportedClientTypes: immutable.Some(
-			[]state.ClientType{
-				state.GoClientType,
-				state.JSClientType,
-			},
-		),
-		Actions: []any{
-			testUtils.Close{},
-			testUtils.Start{
-				Identity:  testUtils.ClientIdentity(1),
-				EnableNAC: true,
-			},
-			&action.AddCollection{
-				Identity: testUtils.ClientIdentity(1),
-				SDL: `
-					type Users {
-						name: String
-					}
-				`,
-			},
-			testUtils.NewEncryptedIndex{
-				Identity:      testUtils.NoIdentity(),
-				CollectionID:  0,
-				FieldName:     "name",
-				ExpectedError: testUtils.FormatExpectedErrorWithPermission(acpTypes.NodeNewEncryptedIndexPerm),
-			},
-		},
-	}
-	testUtils.ExecuteTestCase(t, test)
-}
-
-func TestNAC_GatesNewEncryptedIndex_NoIdentity_CLIandCandHTTPClient_NotAuthorizedError(t *testing.T) {
-	test := testUtils.TestCase{
-		// todo: Investigate and test this behavior across all client types when implementing granular NAC permissions.
-		// See: https://github.com/sourcenetwork/defradb/issues/4383
-		SupportedClientTypes: immutable.Some(
-			[]state.ClientType{
-				state.CClientType,
-				state.HTTPClientType,
-				state.CLIClientType,
-			},
-		),
 		Actions: []any{
 			testUtils.Close{},
 			testUtils.Start{
@@ -129,50 +85,6 @@ func TestNAC_GatesNewEncryptedIndex_NoIdentity_CLIandCandHTTPClient_NotAuthorize
 
 func TestNAC_GatesNewEncryptedIndex_WrongIdentity_NotAuthorizedError(t *testing.T) {
 	test := testUtils.TestCase{
-		// todo: Investigate and test this behavior across all client types when implementing granular NAC permissions.
-		// See: https://github.com/sourcenetwork/defradb/issues/4383
-		SupportedClientTypes: immutable.Some(
-			[]state.ClientType{
-				state.GoClientType,
-				state.JSClientType,
-			},
-		),
-		Actions: []any{
-			testUtils.Close{},
-			testUtils.Start{
-				Identity:  testUtils.ClientIdentity(1),
-				EnableNAC: true,
-			},
-			&action.AddCollection{
-				Identity: testUtils.ClientIdentity(1),
-				SDL: `
-					type Users {
-						name: String
-					}
-				`,
-			},
-			testUtils.NewEncryptedIndex{
-				Identity:      testUtils.ClientIdentity(2),
-				CollectionID:  0,
-				FieldName:     "name",
-				ExpectedError: testUtils.FormatExpectedErrorWithPermission(acpTypes.NodeNewEncryptedIndexPerm),
-			},
-		},
-	}
-	testUtils.ExecuteTestCase(t, test)
-}
-
-func TestNAC_GatesNewEncryptedIndex_WrongIdentity_CLIandCandHTTPClient_NotAuthorizedError(t *testing.T) {
-	test := testUtils.TestCase{
-		// todo: Investigate and test this behavior across all client types when implementing granular NAC permissions.
-		// See: https://github.com/sourcenetwork/defradb/issues/4383
-		SupportedClientTypes: immutable.Some(
-			[]state.ClientType{
-				state.CClientType,
-				state.HTTPClientType,
-				state.CLIClientType,
-			},
-		),
 		Actions: []any{
 			testUtils.Close{},
 			testUtils.Start{

--- a/tests/integration/acp/nac/new_index_test.go
+++ b/tests/integration/acp/nac/new_index_test.go
@@ -64,56 +64,6 @@ func TestNAC_GatesNewIndex_AuthorizedIdentity_AllowAccess(t *testing.T) {
 
 func TestNAC_GatesNewIndex_NoIdentity_NotAuthorizedError(t *testing.T) {
 	test := testUtils.TestCase{
-		// todo: Investigate and test this behavior across all client types when implementing granular NAC permissions.
-		// See: https://github.com/sourcenetwork/defradb/issues/4383
-		SupportedClientTypes: immutable.Some(
-			[]state.ClientType{
-				state.GoClientType,
-				state.JSClientType,
-			},
-		),
-		Actions: []any{
-			// Starting with NAC, so only authorized user(s) can perform operations from here on out.
-			testUtils.Close{},
-			testUtils.Start{
-				Identity:  testUtils.ClientIdentity(1),
-				EnableNAC: true,
-			},
-			// Note: Doing setup steps after starting with nac enabled, otherwise the in-memory tests
-			// will lose setup state when the restart happens (i.e. the restart that started nac).
-			&action.AddCollection{
-				Identity: testUtils.ClientIdentity(1),
-				SDL: `
-					type User {
-						name: String
-					}
-				`,
-			},
-
-			// We haven't authorized non-identities. So, this should error.
-			&action.NewIndex{
-				Identity:      testUtils.NoIdentity(),
-				CollectionID:  0,
-				FieldName:     "name",
-				ExpectedError: testUtils.FormatExpectedErrorWithPermission(acpTypes.NodeNewIndexPerm),
-			},
-		},
-	}
-
-	testUtils.ExecuteTestCase(t, test)
-}
-
-func TestNAC_GatesNewIndex_NoIdentity_CLIandCandHTTPClient_NotAuthorizedError(t *testing.T) {
-	test := testUtils.TestCase{
-		// todo: Investigate and test this behavior across all client types when implementing granular NAC permissions.
-		// See: https://github.com/sourcenetwork/defradb/issues/4383
-		SupportedClientTypes: immutable.Some(
-			[]state.ClientType{
-				state.CClientType,
-				state.HTTPClientType,
-				state.CLIClientType,
-			},
-		),
 		Actions: []any{
 			// Starting with NAC, so only authorized user(s) can perform operations from here on out.
 			testUtils.Close{},
@@ -147,56 +97,6 @@ func TestNAC_GatesNewIndex_NoIdentity_CLIandCandHTTPClient_NotAuthorizedError(t 
 
 func TestNAC_GatesNewIndex_WrongIdentity_NotAuthorizedError(t *testing.T) {
 	test := testUtils.TestCase{
-		// todo: Investigate and test this behavior across all client types when implementing granular NAC permissions.
-		// See: https://github.com/sourcenetwork/defradb/issues/4383
-		SupportedClientTypes: immutable.Some(
-			[]state.ClientType{
-				state.GoClientType,
-				state.JSClientType,
-			},
-		),
-		Actions: []any{
-			// Starting with NAC, so only authorized user(s) can perform operations from here on out.
-			testUtils.Close{},
-			testUtils.Start{
-				Identity:  testUtils.ClientIdentity(1),
-				EnableNAC: true,
-			},
-			// Note: Doing setup steps after starting with nac enabled, otherwise the in-memory tests
-			// will lose setup state when the restart happens (i.e. the restart that started nac).
-			&action.AddCollection{
-				Identity: testUtils.ClientIdentity(1),
-				SDL: `
-					type User {
-						name: String
-					}
-				`,
-			},
-
-			// Wrong user/identity will also not be authorized.
-			&action.NewIndex{
-				Identity:      testUtils.ClientIdentity(2),
-				CollectionID:  0,
-				FieldName:     "name",
-				ExpectedError: testUtils.FormatExpectedErrorWithPermission(acpTypes.NodeNewIndexPerm),
-			},
-		},
-	}
-
-	testUtils.ExecuteTestCase(t, test)
-}
-
-func TestNAC_GatesNewIndex_WrongIdentity_CLIandCandHTTPClient_NotAuthorizedError(t *testing.T) {
-	test := testUtils.TestCase{
-		// todo: Investigate and test this behavior across all client types when implementing granular NAC permissions.
-		// See: https://github.com/sourcenetwork/defradb/issues/4383
-		SupportedClientTypes: immutable.Some(
-			[]state.ClientType{
-				state.CClientType,
-				state.HTTPClientType,
-				state.CLIClientType,
-			},
-		),
 		Actions: []any{
 			// Starting with NAC, so only authorized user(s) can perform operations from here on out.
 			testUtils.Close{},

--- a/tests/integration/acp/nac/relation_admin/add_document_test.go
+++ b/tests/integration/acp/nac/relation_admin/add_document_test.go
@@ -14,14 +14,13 @@ package test_acp_nac_relation_admin
 import (
 	"testing"
 
+	acpTypes "github.com/sourcenetwork/defradb/acp/types"
 	"github.com/sourcenetwork/defradb/tests/action"
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
 )
 
 func TestNAC_AdminRelation_CanAddDocument(t *testing.T) {
 	test := testUtils.TestCase{
-		// todo: Investigate and test this behavior across all client types when implementing granular NAC permissions.
-		// See: https://github.com/sourcenetwork/defradb/issues/4383
 		Actions: []any{
 			// Starting with NAC, so only authorized user(s) can perform operations from here on out.
 			testUtils.Close{},
@@ -38,14 +37,10 @@ func TestNAC_AdminRelation_CanAddDocument(t *testing.T) {
 
 			// This user, can not perform this gated operation yet.
 			&action.AddDoc{
-				Identity:     testUtils.ClientIdentity(2),
-				CollectionID: 0,
-				Doc:          `{ "name": "Shahzad" }`,
-				// todo: After implementing granular NAC permissions, this should be changed to a
-				// specific permission error. Currently, the permission error is different across
-				// different client types and environments.
-				// See: https://github.com/sourcenetwork/defradb/issues/4446
-				ExpectedError: "not authorized to perform operation",
+				Identity:      testUtils.ClientIdentity(2),
+				CollectionID:  0,
+				Doc:           `{ "name": "Shahzad" }`,
+				ExpectedError: testUtils.FormatExpectedErrorWithPermission(acpTypes.NodeGetCollectionPerm),
 			},
 
 			// Grant access to user.

--- a/tests/integration/acp/nac/relation_admin/delete_document_test.go
+++ b/tests/integration/acp/nac/relation_admin/delete_document_test.go
@@ -17,20 +17,10 @@ import (
 	acpTypes "github.com/sourcenetwork/defradb/acp/types"
 	"github.com/sourcenetwork/defradb/tests/action"
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
-	"github.com/sourcenetwork/defradb/tests/state"
-	"github.com/sourcenetwork/immutable"
 )
 
 func TestNAC_AdminRelation_CanDeleteDocument(t *testing.T) {
 	test := testUtils.TestCase{
-		// todo: Investigate and test this behavior across all client types when implementing granular NAC permissions.
-		// See: https://github.com/sourcenetwork/defradb/issues/4383
-		SupportedClientTypes: immutable.Some(
-			[]state.ClientType{
-				state.GoClientType,
-				state.JSClientType,
-			},
-		),
 		Actions: []any{
 			// Starting with NAC, so only authorized user(s) can perform operations from here on out.
 			testUtils.Close{},
@@ -45,7 +35,7 @@ func TestNAC_AdminRelation_CanDeleteDocument(t *testing.T) {
 				SDL: `
 					type User {
 						name: String
-						age: Int 
+						age: Int
 					}`,
 			},
 			&action.AddDoc{
@@ -58,73 +48,6 @@ func TestNAC_AdminRelation_CanDeleteDocument(t *testing.T) {
 			},
 
 			// This user, can not perform this gated operation yet.
-			// This should work as the identity is authorized.
-			testUtils.DeleteDoc{
-				Identity:      testUtils.ClientIdentity(2),
-				CollectionID:  0,
-				DocID:         0,
-				ExpectedError: testUtils.FormatExpectedErrorWithPermission(acpTypes.NodeDeleteDocumentPerm),
-			},
-
-			// Grant access to user.
-			testUtils.AddNACActorRelationship{
-				RequestorIdentity: testUtils.ClientIdentity(1),
-				TargetIdentity:    testUtils.ClientIdentity(2), // Grant this user "admin" relation
-				Relation:          "admin",
-				ExpectedExistence: false,
-			},
-
-			// This user, can now perform this gated operation.
-			testUtils.DeleteDoc{
-				Identity:     testUtils.ClientIdentity(2),
-				CollectionID: 0,
-				DocID:        0,
-			},
-		},
-	}
-
-	testUtils.ExecuteTestCase(t, test)
-}
-
-func TestNAC_AdminRelation_CLIandCandHTTPClient_CanDeleteDocument(t *testing.T) {
-	test := testUtils.TestCase{
-		// todo: Investigate and test this behavior across all client types when implementing granular NAC permissions.
-		// See: https://github.com/sourcenetwork/defradb/issues/4383
-		SupportedClientTypes: immutable.Some(
-			[]state.ClientType{
-				state.CClientType,
-				state.HTTPClientType,
-				state.CLIClientType,
-			},
-		),
-		Actions: []any{
-			// Starting with NAC, so only authorized user(s) can perform operations from here on out.
-			testUtils.Close{},
-			testUtils.Start{
-				Identity:  testUtils.ClientIdentity(1),
-				EnableNAC: true,
-			},
-			// Note: Doing setup steps after starting with nac enabled, otherwise the in-memory tests
-			// will lose setup state when the restart happens (i.e. the restart that started nac).
-			&action.AddCollection{
-				Identity: testUtils.ClientIdentity(1),
-				SDL: `
-					type User {
-						name: String
-						age: Int 
-					}`,
-			},
-			&action.AddDoc{
-				Identity:     testUtils.ClientIdentity(1),
-				CollectionID: 0,
-				Doc: `{
-					"name": "Shahzad",
-					"age": 48
-				}`,
-			},
-
-			// This user, can not perform this gated operation yet.
-			// This should work as the identity is authorized.
 			testUtils.DeleteDoc{
 				Identity:      testUtils.ClientIdentity(2),
 				CollectionID:  0,

--- a/tests/integration/acp/nac/relation_admin/delete_encrypted_index_test.go
+++ b/tests/integration/acp/nac/relation_admin/delete_encrypted_index_test.go
@@ -14,84 +14,13 @@ package test_acp_nac_relation_admin
 import (
 	"testing"
 
-	"github.com/sourcenetwork/immutable"
-
 	acpTypes "github.com/sourcenetwork/defradb/acp/types"
 	"github.com/sourcenetwork/defradb/tests/action"
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
-	"github.com/sourcenetwork/defradb/tests/state"
 )
 
 func TestNAC_AdminRelation_CanDeleteEncryptedIndex(t *testing.T) {
 	test := testUtils.TestCase{
-		// todo: Investigate and test this behavior across all client types when implementing granular NAC permissions.
-		// See: https://github.com/sourcenetwork/defradb/issues/4383
-		SupportedClientTypes: immutable.Some(
-			[]state.ClientType{
-				state.GoClientType,
-			},
-		),
-		Actions: []any{
-			// Starting with NAC, so only authorized user(s) can perform operations from here on out.
-			testUtils.Close{},
-			testUtils.Start{
-				Identity:  testUtils.ClientIdentity(1),
-				EnableNAC: true,
-			},
-			&action.AddCollection{
-				Identity: testUtils.ClientIdentity(1),
-				SDL: `
-					type Users {
-						name: String
-					}
-				`,
-			},
-
-			// This user, can not perform this gated operation yet.
-			testUtils.DeleteEncryptedIndex{
-				Identity:      testUtils.ClientIdentity(2),
-				CollectionID:  0,
-				FieldName:     "name",
-				ExpectedError: testUtils.FormatExpectedErrorWithPermission(acpTypes.NodeDeleteEncryptedIndexPerm),
-			},
-
-			// Grant access to user.
-			testUtils.AddNACActorRelationship{
-				RequestorIdentity: testUtils.ClientIdentity(1),
-				TargetIdentity:    testUtils.ClientIdentity(2),
-				Relation:          "admin",
-				ExpectedExistence: false,
-			},
-
-			testUtils.NewEncryptedIndex{
-				Identity:     testUtils.ClientIdentity(1),
-				CollectionID: 0,
-				FieldName:    "name",
-			},
-
-			// This user, can now perform this gated operation.
-			testUtils.DeleteEncryptedIndex{
-				Identity:     testUtils.ClientIdentity(2),
-				CollectionID: 0,
-				FieldName:    "name",
-			},
-		},
-	}
-
-	testUtils.ExecuteTestCase(t, test)
-}
-
-func TestNAC_AdminRelation_CLIandCandHTTPClient_CanDeleteEncryptedIndex(t *testing.T) {
-	test := testUtils.TestCase{
-		// todo: Investigate and test this behavior across all client types when implementing granular NAC permissions.
-		// See: https://github.com/sourcenetwork/defradb/issues/4383
-		SupportedClientTypes: immutable.Some(
-			[]state.ClientType{
-				state.CClientType,
-				state.HTTPClientType,
-				state.CLIClientType,
-			},
-		),
 		Actions: []any{
 			// Starting with NAC, so only authorized user(s) can perform operations from here on out.
 			testUtils.Close{},

--- a/tests/integration/acp/nac/relation_admin/delete_index_test.go
+++ b/tests/integration/acp/nac/relation_admin/delete_index_test.go
@@ -14,78 +14,13 @@ package test_acp_nac_relation_admin
 import (
 	"testing"
 
-	"github.com/sourcenetwork/immutable"
-
 	acpTypes "github.com/sourcenetwork/defradb/acp/types"
 	"github.com/sourcenetwork/defradb/tests/action"
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
-	"github.com/sourcenetwork/defradb/tests/state"
 )
 
 func TestNAC_AdminRelation_CanDeleteIndex(t *testing.T) {
 	test := testUtils.TestCase{
-		// todo: Investigate and test this behavior across all client types when implementing granular NAC permissions.
-		// See: https://github.com/sourcenetwork/defradb/issues/4383
-		SupportedClientTypes: immutable.Some(
-			[]state.ClientType{
-				state.GoClientType,
-			},
-		),
-		Actions: []any{
-			// Starting with NAC, so only authorized user(s) can perform operations from here on out.
-			testUtils.Close{},
-			testUtils.Start{
-				Identity:  testUtils.ClientIdentity(1),
-				EnableNAC: true,
-			},
-			// Note: Doing setup steps after starting with nac enabled, otherwise the in-memory tests
-			// will lose setup state when the restart happens (i.e. the restart that started nac).
-			&action.AddCollection{
-				Identity: testUtils.ClientIdentity(1),
-				SDL: `
-					type User {
-						name: String @index
-					}
-				`,
-			},
-
-			// This user, can not perform this gated operation yet.
-			&action.DeleteIndex{
-				Identity:      testUtils.ClientIdentity(2),
-				IndexName:     "User_name_ASC",
-				ExpectedError: testUtils.FormatExpectedErrorWithPermission(acpTypes.NodeDeleteIndexPerm),
-			},
-
-			// Grant access to user.
-			testUtils.AddNACActorRelationship{
-				RequestorIdentity: testUtils.ClientIdentity(1),
-				TargetIdentity:    testUtils.ClientIdentity(2), // Grant this user "admin" relation
-				Relation:          "admin",
-				ExpectedExistence: false,
-			},
-
-			// This user, can now perform this gated operation.
-			&action.DeleteIndex{
-				Identity:  testUtils.ClientIdentity(2),
-				IndexName: "User_name_ASC",
-			},
-		},
-	}
-
-	testUtils.ExecuteTestCase(t, test)
-}
-
-func TestNAC_AdminRelation_CLIandCandHTTPClient_CanDeleteIndex(t *testing.T) {
-	test := testUtils.TestCase{
-		// todo: Investigate and test this behavior across all client types when implementing granular NAC permissions.
-		// See: https://github.com/sourcenetwork/defradb/issues/4383
-		SupportedClientTypes: immutable.Some(
-			[]state.ClientType{
-				state.CClientType,
-				state.HTTPClientType,
-				state.CLIClientType,
-			},
-		),
 		Actions: []any{
 			// Starting with NAC, so only authorized user(s) can perform operations from here on out.
 			testUtils.Close{},

--- a/tests/integration/acp/nac/relation_admin/list_encrypted_index_test.go
+++ b/tests/integration/acp/nac/relation_admin/list_encrypted_index_test.go
@@ -14,80 +14,14 @@ package test_acp_nac_relation_admin
 import (
 	"testing"
 
-	"github.com/sourcenetwork/immutable"
-
 	acpTypes "github.com/sourcenetwork/defradb/acp/types"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/tests/action"
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
-	"github.com/sourcenetwork/defradb/tests/state"
 )
 
 func TestNAC_AdminRelation_CanListEncryptedIndex(t *testing.T) {
 	test := testUtils.TestCase{
-		// todo: Investigate and test this behavior across all client types when implementing granular NAC permissions.
-		// See: https://github.com/sourcenetwork/defradb/issues/4383
-		SupportedClientTypes: immutable.Some(
-			[]state.ClientType{
-				state.GoClientType,
-			},
-		),
-		Actions: []any{
-			// Starting with NAC, so only authorized user(s) can perform operations from here on out.
-			testUtils.Close{},
-			testUtils.Start{
-				Identity:  testUtils.ClientIdentity(1),
-				EnableNAC: true,
-			},
-			// Note: Doing setup steps after starting with nac enabled, otherwise the in-memory tests
-			// will lose setup state when the restart happens (i.e. the restart that started nac).
-			&action.AddCollection{
-				Identity: testUtils.ClientIdentity(1),
-				SDL: `
-					type User {
-						name: String
-					}
-				`,
-			},
-
-			// This user, can not perform this gated operation yet.
-			testUtils.ListEncryptedIndexes{
-				Identity:      testUtils.ClientIdentity(2),
-				CollectionID:  0,
-				ExpectedError: testUtils.FormatExpectedErrorWithPermission(acpTypes.NodeListEncryptedIndexPerm),
-			},
-
-			// Grant access to user.
-			testUtils.AddNACActorRelationship{
-				RequestorIdentity: testUtils.ClientIdentity(1),
-				TargetIdentity:    testUtils.ClientIdentity(2),
-				Relation:          "admin",
-				ExpectedExistence: false,
-			},
-
-			// This user, can now perform this gated operation.
-			testUtils.ListEncryptedIndexes{
-				Identity:        testUtils.ClientIdentity(2),
-				CollectionID:    0,
-				ExpectedIndexes: []client.EncryptedIndexDescription{},
-			},
-		},
-	}
-
-	testUtils.ExecuteTestCase(t, test)
-}
-
-func TestNAC_AdminRelation_CLIandCandHTTPClient_CanListEncryptedIndex(t *testing.T) {
-	test := testUtils.TestCase{
-		// todo: Investigate and test this behavior across all client types when implementing granular NAC permissions.
-		// See: https://github.com/sourcenetwork/defradb/issues/4383
-		SupportedClientTypes: immutable.Some(
-			[]state.ClientType{
-				state.CClientType,
-				state.HTTPClientType,
-				state.CLIClientType,
-			},
-		),
 		Actions: []any{
 			// Starting with NAC, so only authorized user(s) can perform operations from here on out.
 			testUtils.Close{},

--- a/tests/integration/acp/nac/relation_admin/list_index_test.go
+++ b/tests/integration/acp/nac/relation_admin/list_index_test.go
@@ -14,80 +14,14 @@ package test_acp_nac_relation_admin
 import (
 	"testing"
 
-	"github.com/sourcenetwork/immutable"
-
 	acpTypes "github.com/sourcenetwork/defradb/acp/types"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/tests/action"
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
-	"github.com/sourcenetwork/defradb/tests/state"
 )
 
 func TestNAC_AdminRelation_CanListIndex(t *testing.T) {
 	test := testUtils.TestCase{
-		// todo: Investigate and test this behavior across all client types when implementing granular NAC permissions.
-		// See: https://github.com/sourcenetwork/defradb/issues/4383
-		SupportedClientTypes: immutable.Some(
-			[]state.ClientType{
-				state.GoClientType,
-			},
-		),
-		Actions: []any{
-			// Starting with NAC, so only authorized user(s) can perform operations from here on out.
-			testUtils.Close{},
-			testUtils.Start{
-				Identity:  testUtils.ClientIdentity(1),
-				EnableNAC: true,
-			},
-			// Note: Doing setup steps after starting with nac enabled, otherwise the in-memory tests
-			// will lose setup state when the restart happens (i.e. the restart that started nac).
-			&action.AddCollection{
-				Identity: testUtils.ClientIdentity(1),
-				SDL: `
-					type User {
-						name: String
-					}
-				`,
-			},
-
-			// This user, can not perform this gated operation yet.
-			&action.ListIndexes{
-				Identity:      testUtils.ClientIdentity(2),
-				CollectionID:  0,
-				ExpectedError: testUtils.FormatExpectedErrorWithPermission(acpTypes.NodeListIndexPerm),
-			},
-
-			// Grant access to user.
-			testUtils.AddNACActorRelationship{
-				RequestorIdentity: testUtils.ClientIdentity(1),
-				TargetIdentity:    testUtils.ClientIdentity(2), // Grant this user "admin" relation
-				Relation:          "admin",
-				ExpectedExistence: false,
-			},
-
-			// This user, can now perform this gated operation.
-			&action.ListIndexes{
-				Identity:        testUtils.ClientIdentity(2),
-				CollectionID:    0,
-				ExpectedIndexes: []client.IndexDescription{},
-			},
-		},
-	}
-
-	testUtils.ExecuteTestCase(t, test)
-}
-
-func TestNAC_AdminRelation_CLIandCandHTTPClient_CanListIndex(t *testing.T) {
-	test := testUtils.TestCase{
-		// todo: Investigate and test this behavior across all client types when implementing granular NAC permissions.
-		// See: https://github.com/sourcenetwork/defradb/issues/4383
-		SupportedClientTypes: immutable.Some(
-			[]state.ClientType{
-				state.CClientType,
-				state.HTTPClientType,
-				state.CLIClientType,
-			},
-		),
 		Actions: []any{
 			// Starting with NAC, so only authorized user(s) can perform operations from here on out.
 			testUtils.Close{},

--- a/tests/integration/acp/nac/relation_admin/new_encrypted_index_test.go
+++ b/tests/integration/acp/nac/relation_admin/new_encrypted_index_test.go
@@ -14,70 +14,13 @@ package test_acp_nac_relation_admin
 import (
 	"testing"
 
-	"github.com/sourcenetwork/immutable"
-
 	acpTypes "github.com/sourcenetwork/defradb/acp/types"
 	"github.com/sourcenetwork/defradb/tests/action"
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
-	"github.com/sourcenetwork/defradb/tests/state"
 )
 
 func TestNAC_AdminRelation_CanNewEncryptedIndex(t *testing.T) {
 	test := testUtils.TestCase{
-		// todo: Investigate and test this behavior across all client types when implementing granular NAC permissions.
-		// See: https://github.com/sourcenetwork/defradb/issues/4383
-		SupportedClientTypes: immutable.Some(
-			[]state.ClientType{
-				state.GoClientType,
-			},
-		),
-		Actions: []any{
-			testUtils.Close{},
-			testUtils.Start{
-				Identity:  testUtils.ClientIdentity(1),
-				EnableNAC: true,
-			},
-			&action.AddCollection{
-				Identity: testUtils.ClientIdentity(1),
-				SDL: `
-					type Users {
-						name: String
-					}
-				`,
-			},
-			testUtils.NewEncryptedIndex{
-				Identity:      testUtils.ClientIdentity(2),
-				CollectionID:  0,
-				FieldName:     "name",
-				ExpectedError: testUtils.FormatExpectedErrorWithPermission(acpTypes.NodeNewEncryptedIndexPerm),
-			},
-			testUtils.AddNACActorRelationship{
-				RequestorIdentity: testUtils.ClientIdentity(1),
-				TargetIdentity:    testUtils.ClientIdentity(2),
-				Relation:          "admin",
-				ExpectedExistence: false,
-			},
-			testUtils.NewEncryptedIndex{
-				Identity:     testUtils.ClientIdentity(2),
-				CollectionID: 0,
-				FieldName:    "name",
-			},
-		},
-	}
-	testUtils.ExecuteTestCase(t, test)
-}
-
-func TestNAC_AdminRelation_CLIandCandHTTPClient_CanNewEncryptedIndex(t *testing.T) {
-	test := testUtils.TestCase{
-		// todo: Investigate and test this behavior across all client types when implementing granular NAC permissions.
-		// See: https://github.com/sourcenetwork/defradb/issues/4383
-		SupportedClientTypes: immutable.Some(
-			[]state.ClientType{
-				state.CClientType,
-				state.HTTPClientType,
-				state.CLIClientType,
-			},
-		),
 		Actions: []any{
 			testUtils.Close{},
 			testUtils.Start{

--- a/tests/integration/acp/nac/relation_admin/new_index_test.go
+++ b/tests/integration/acp/nac/relation_admin/new_index_test.go
@@ -14,80 +14,13 @@ package test_acp_nac_relation_admin
 import (
 	"testing"
 
-	"github.com/sourcenetwork/immutable"
-
 	acpTypes "github.com/sourcenetwork/defradb/acp/types"
 	"github.com/sourcenetwork/defradb/tests/action"
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
-	"github.com/sourcenetwork/defradb/tests/state"
 )
 
 func TestNAC_AdminRelation_CanMakeNewIndex(t *testing.T) {
 	test := testUtils.TestCase{
-		// todo: Investigate and test this behavior across all client types when implementing granular NAC permissions.
-		// See: https://github.com/sourcenetwork/defradb/issues/4383
-		SupportedClientTypes: immutable.Some(
-			[]state.ClientType{
-				state.GoClientType,
-			},
-		),
-		Actions: []any{
-			// Starting with NAC, so only authorized user(s) can perform operations from here on out.
-			testUtils.Close{},
-			testUtils.Start{
-				Identity:  testUtils.ClientIdentity(1),
-				EnableNAC: true,
-			},
-			// Note: Doing setup steps after starting with nac enabled, otherwise the in-memory tests
-			// will lose setup state when the restart happens (i.e. the restart that started nac).
-			&action.AddCollection{
-				Identity: testUtils.ClientIdentity(1),
-				SDL: `
-					type User {
-						name: String
-					}
-				`,
-			},
-
-			// This user, can not perform this gated operation yet.
-			&action.NewIndex{
-				Identity:      testUtils.ClientIdentity(2),
-				CollectionID:  0,
-				FieldName:     "name",
-				ExpectedError: testUtils.FormatExpectedErrorWithPermission(acpTypes.NodeNewIndexPerm),
-			},
-
-			// Grant access to user.
-			testUtils.AddNACActorRelationship{
-				RequestorIdentity: testUtils.ClientIdentity(1),
-				TargetIdentity:    testUtils.ClientIdentity(2), // Grant this user "admin" relation
-				Relation:          "admin",
-				ExpectedExistence: false,
-			},
-
-			// This user, can now perform this gated operation.
-			&action.NewIndex{
-				Identity:     testUtils.ClientIdentity(2),
-				CollectionID: 0,
-				FieldName:    "name",
-			},
-		},
-	}
-
-	testUtils.ExecuteTestCase(t, test)
-}
-
-func TestNAC_AdminRelation_CLIandCandHTTPClient_CanMakeNewIndex(t *testing.T) {
-	test := testUtils.TestCase{
-		// todo: Investigate and test this behavior across all client types when implementing granular NAC permissions.
-		// See: https://github.com/sourcenetwork/defradb/issues/4383
-		SupportedClientTypes: immutable.Some(
-			[]state.ClientType{
-				state.CClientType,
-				state.HTTPClientType,
-				state.CLIClientType,
-			},
-		),
 		Actions: []any{
 			// Starting with NAC, so only authorized user(s) can perform operations from here on out.
 			testUtils.Close{},

--- a/tests/integration/acp/nac/relation_admin/truncate_collection_test.go
+++ b/tests/integration/acp/nac/relation_admin/truncate_collection_test.go
@@ -17,73 +17,10 @@ import (
 	acpTypes "github.com/sourcenetwork/defradb/acp/types"
 	"github.com/sourcenetwork/defradb/tests/action"
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
-	"github.com/sourcenetwork/defradb/tests/state"
-	"github.com/sourcenetwork/immutable"
 )
 
 func TestNAC_AdminRelation_CanTruncateCollection(t *testing.T) {
 	test := testUtils.TestCase{
-		// todo: Investigate and test this behavior across all client types when implementing granular NAC permissions.
-		// See: https://github.com/sourcenetwork/defradb/issues/4383
-		SupportedClientTypes: immutable.Some(
-			[]state.ClientType{
-				state.GoClientType,
-				state.JSClientType,
-			},
-		),
-		Actions: []any{
-			// Starting with NAC, so only authorized user(s) can perform operations from here on out.
-			testUtils.Close{},
-			testUtils.Start{
-				Identity:  testUtils.ClientIdentity(1),
-				EnableNAC: true,
-			},
-			// Note: Doing setup steps after starting with nac enabled, otherwise the in-memory tests
-			// will lose setup state when the restart happens (i.e. the restart that started nac).
-			&action.AddCollection{
-				Identity: testUtils.ClientIdentity(1),
-				SDL: `
-					type Users {}
-				`,
-			},
-
-			// This user, can not perform this gated operation yet.
-			&action.Truncate{
-				Identity:        testUtils.ClientIdentity(2),
-				CollectionIndex: 0,
-				ExpectedError:   testUtils.FormatExpectedErrorWithPermission(acpTypes.NodeTruncateCollectionPerm),
-			},
-
-			// Grant access to user.
-			testUtils.AddNACActorRelationship{
-				RequestorIdentity: testUtils.ClientIdentity(1),
-				TargetIdentity:    testUtils.ClientIdentity(2), // Grant this user "admin" relation
-				Relation:          "admin",
-				ExpectedExistence: false,
-			},
-
-			// This user, can now perform this gated operation.
-			&action.Truncate{
-				Identity:        testUtils.ClientIdentity(2),
-				CollectionIndex: 0,
-			},
-		},
-	}
-
-	testUtils.ExecuteTestCase(t, test)
-}
-
-func TestNAC_AdminRelation_CLIandCandHTTPClient_CanTruncateCollection(t *testing.T) {
-	test := testUtils.TestCase{
-		// todo: Investigate and test this behavior across all client types when implementing granular NAC permissions.
-		// See: https://github.com/sourcenetwork/defradb/issues/4383
-		SupportedClientTypes: immutable.Some(
-			[]state.ClientType{
-				state.CClientType,
-				state.HTTPClientType,
-				state.CLIClientType,
-			},
-		),
 		Actions: []any{
 			// Starting with NAC, so only authorized user(s) can perform operations from here on out.
 			testUtils.Close{},

--- a/tests/integration/acp/nac/relation_admin/update_document_test.go
+++ b/tests/integration/acp/nac/relation_admin/update_document_test.go
@@ -14,14 +14,13 @@ package test_acp_nac_relation_admin
 import (
 	"testing"
 
+	acpTypes "github.com/sourcenetwork/defradb/acp/types"
 	"github.com/sourcenetwork/defradb/tests/action"
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
 )
 
 func TestNAC_AdminRelation_CanUpdateDocument(t *testing.T) {
 	test := testUtils.TestCase{
-		// todo: Investigate and test this behavior across all client types when implementing granular NAC permissions.
-		// See: https://github.com/sourcenetwork/defradb/issues/4383
 		Actions: []any{
 			// Starting with NAC, so only authorized user(s) can perform operations from here on out.
 			testUtils.Close{},
@@ -36,7 +35,7 @@ func TestNAC_AdminRelation_CanUpdateDocument(t *testing.T) {
 				SDL: `
 					type User {
 						name: String
-						age: Int 
+						age: Int
 					}`,
 			},
 			&action.AddDoc{
@@ -47,17 +46,14 @@ func TestNAC_AdminRelation_CanUpdateDocument(t *testing.T) {
 					"age": 48
 				}`,
 			},
+
 			// This user, can not perform this gated operation yet.
 			&action.UpdateDoc{
-				Identity:     testUtils.ClientIdentity(2),
-				CollectionID: 0,
-				DocID:        0,
-				Doc:          `{ "name": "Lone" }`,
-				// todo: After implementing granular NAC permissions, this should be changed to a
-				// specific permission error. Currently, the permission error is different across
-				// different client types and environments.
-				// See: https://github.com/sourcenetwork/defradb/issues/4446
-				ExpectedError: "not authorized to perform operation",
+				Identity:      testUtils.ClientIdentity(2),
+				CollectionID:  0,
+				DocID:         0,
+				Doc:           `{ "name": "Lone" }`,
+				ExpectedError: testUtils.FormatExpectedErrorWithPermission(acpTypes.NodeGetCollectionPerm),
 			},
 
 			// Grant access to user.

--- a/tests/integration/acp/nac/truncate_collection_test.go
+++ b/tests/integration/acp/nac/truncate_collection_test.go
@@ -17,8 +17,6 @@ import (
 	acpTypes "github.com/sourcenetwork/defradb/acp/types"
 	"github.com/sourcenetwork/defradb/tests/action"
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
-	"github.com/sourcenetwork/defradb/tests/state"
-	"github.com/sourcenetwork/immutable"
 )
 
 func TestNAC_GatesTruncateCollection_AuthorizedIdentity_AllowAccess(t *testing.T) {
@@ -50,55 +48,7 @@ func TestNAC_GatesTruncateCollection_AuthorizedIdentity_AllowAccess(t *testing.T
 }
 
 func TestNAC_GatesTruncateCollection_NoIdentity_NotAuthorizedError(t *testing.T) {
-	// todo: Investigate and test this behavior across all client types when implementing granular NAC permissions.
 	test := testUtils.TestCase{
-		// todo: Investigate and test this behavior across all client types when implementing granular NAC permissions.
-		// See: https://github.com/sourcenetwork/defradb/issues/4383
-		SupportedClientTypes: immutable.Some(
-			[]state.ClientType{
-				state.GoClientType,
-				state.JSClientType,
-			},
-		),
-		Actions: []any{
-			// Starting with NAC, so only authorized user(s) can perform operations from here on out.
-			testUtils.Close{},
-			testUtils.Start{
-				Identity:  testUtils.ClientIdentity(1),
-				EnableNAC: true,
-			},
-			// Note: Doing setup steps after starting with nac enabled, otherwise the in-memory tests
-			// will lose setup state when the restart happens (i.e. the restart that started nac).
-			&action.AddCollection{
-				Identity: testUtils.ClientIdentity(1),
-				SDL: `
-					type Users {}
-				`,
-			},
-			// We haven't authorized non-identities. So, this should error.
-			&action.Truncate{
-				Identity:        testUtils.NoIdentity(),
-				CollectionIndex: 0,
-				ExpectedError:   testUtils.FormatExpectedErrorWithPermission(acpTypes.NodeTruncateCollectionPerm),
-			},
-		},
-	}
-
-	testUtils.ExecuteTestCase(t, test)
-}
-
-func TestNAC_GatesTruncateCollection_NoIdentity_CLIandCandHTTPClient_NotAuthorizedError(t *testing.T) {
-	// todo: Investigate and test this behavior across all client types when implementing granular NAC permissions.
-	test := testUtils.TestCase{
-		// todo: Investigate and test this behavior across all client types when implementing granular NAC permissions.
-		// See: https://github.com/sourcenetwork/defradb/issues/4383
-		SupportedClientTypes: immutable.Some(
-			[]state.ClientType{
-				state.CClientType,
-				state.HTTPClientType,
-				state.CLIClientType,
-			},
-		),
 		Actions: []any{
 			// Starting with NAC, so only authorized user(s) can perform operations from here on out.
 			testUtils.Close{},
@@ -128,52 +78,6 @@ func TestNAC_GatesTruncateCollection_NoIdentity_CLIandCandHTTPClient_NotAuthoriz
 
 func TestNAC_GatesTruncateCollection_WrongIdentity_NotAuthorizedError(t *testing.T) {
 	test := testUtils.TestCase{
-		// todo: Investigate and test this behavior across all client types when implementing granular NAC permissions.
-		// See: https://github.com/sourcenetwork/defradb/issues/4383
-		SupportedClientTypes: immutable.Some(
-			[]state.ClientType{
-				state.GoClientType,
-				state.JSClientType,
-			},
-		),
-		Actions: []any{
-			// Starting with NAC, so only authorized user(s) can perform operations from here on out.
-			testUtils.Close{},
-			testUtils.Start{
-				Identity:  testUtils.ClientIdentity(1),
-				EnableNAC: true,
-			},
-			// Note: Doing setup steps after starting with nac enabled, otherwise the in-memory tests
-			// will lose setup state when the restart happens (i.e. the restart that started nac).
-			&action.AddCollection{
-				Identity: testUtils.ClientIdentity(1),
-				SDL: `
-					type Users {}
-				`,
-			},
-			// Wrong user/identity will also not be authorized.
-			&action.Truncate{
-				Identity:        testUtils.ClientIdentity(2),
-				CollectionIndex: 0,
-				ExpectedError:   testUtils.FormatExpectedErrorWithPermission(acpTypes.NodeTruncateCollectionPerm),
-			},
-		},
-	}
-
-	testUtils.ExecuteTestCase(t, test)
-}
-
-func TestNAC_GatesTruncateCollection_WrongIdentity_CLIandHTTPClient_NotAuthorizedError(t *testing.T) {
-	test := testUtils.TestCase{
-		// todo: Investigate and test this behavior across all client types when implementing granular NAC permissions.
-		// See: https://github.com/sourcenetwork/defradb/issues/4383
-		SupportedClientTypes: immutable.Some(
-			[]state.ClientType{
-				state.CClientType,
-				state.HTTPClientType,
-				state.CLIClientType,
-			},
-		),
 		Actions: []any{
 			// Starting with NAC, so only authorized user(s) can perform operations from here on out.
 			testUtils.Close{},

--- a/tests/integration/acp/nac/update_document_test.go
+++ b/tests/integration/acp/nac/update_document_test.go
@@ -14,6 +14,7 @@ package test_acp_nac
 import (
 	"testing"
 
+	acpTypes "github.com/sourcenetwork/defradb/acp/types"
 	"github.com/sourcenetwork/defradb/tests/action"
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
 )
@@ -34,7 +35,7 @@ func TestNAC_GatesUpdateDocument_AuthorizedIdentity_AllowAccess(t *testing.T) {
 				SDL: `
 					type User {
 						name: String
-						age: Int 
+						age: Int
 					}`,
 			},
 			&action.AddDoc{
@@ -68,8 +69,6 @@ func TestNAC_GatesUpdateDocument_AuthorizedIdentity_AllowAccess(t *testing.T) {
 
 func TestNAC_GatesUpdateDocument_NoIdentity_NotAuthorizedError(t *testing.T) {
 	test := testUtils.TestCase{
-		// todo: Investigate and test this behavior across all client types when implementing granular NAC permissions.
-		// See: https://github.com/sourcenetwork/defradb/issues/4383
 		Actions: []any{
 			// Starting with NAC, so only authorized user(s) can perform operations from here on out.
 			testUtils.Close{},
@@ -84,7 +83,7 @@ func TestNAC_GatesUpdateDocument_NoIdentity_NotAuthorizedError(t *testing.T) {
 				SDL: `
 					type User {
 						name: String
-						age: Int 
+						age: Int
 					}`,
 			},
 			&action.AddDoc{
@@ -98,15 +97,11 @@ func TestNAC_GatesUpdateDocument_NoIdentity_NotAuthorizedError(t *testing.T) {
 
 			// We haven't authorized non-identities. So, this should error.
 			&action.UpdateDoc{
-				Identity:     testUtils.NoIdentity(),
-				CollectionID: 0,
-				DocID:        0,
-				Doc:          `{ "name": "Lone" }`,
-				// todo: After implementing granular NAC permissions, this should be changed to a
-				// specific permission error. Currently, the permission error is different across
-				// different client types and environments.
-				// See: https://github.com/sourcenetwork/defradb/issues/4446
-				ExpectedError: "not authorized to perform operation",
+				Identity:      testUtils.NoIdentity(),
+				CollectionID:  0,
+				DocID:         0,
+				Doc:           `{ "name": "Lone" }`,
+				ExpectedError: testUtils.FormatExpectedErrorWithPermission(acpTypes.NodeGetCollectionPerm),
 			},
 			&action.Request{ // Should not be updated
 				Identity: testUtils.ClientIdentity(1),
@@ -123,8 +118,6 @@ func TestNAC_GatesUpdateDocument_NoIdentity_NotAuthorizedError(t *testing.T) {
 
 func TestNAC_GatesUpdateDocument_WrongIdentity_NotAuthorizedError(t *testing.T) {
 	test := testUtils.TestCase{
-		// todo: Investigate and test this behavior across all client types when implementing granular NAC permissions.
-		// See: https://github.com/sourcenetwork/defradb/issues/4383
 		Actions: []any{
 			// Starting with NAC, so only authorized user(s) can perform operations from here on out.
 			testUtils.Close{},
@@ -139,7 +132,7 @@ func TestNAC_GatesUpdateDocument_WrongIdentity_NotAuthorizedError(t *testing.T) 
 				SDL: `
 					type User {
 						name: String
-						age: Int 
+						age: Int
 					}`,
 			},
 			&action.AddDoc{
@@ -153,15 +146,11 @@ func TestNAC_GatesUpdateDocument_WrongIdentity_NotAuthorizedError(t *testing.T) 
 
 			// Wrong user/identity will also not be authorized.
 			&action.UpdateDoc{
-				Identity:     testUtils.ClientIdentity(2),
-				CollectionID: 0,
-				DocID:        0,
-				Doc:          `{ "name": "Lone" }`,
-				// todo: After implementing granular NAC permissions, this should be changed to a
-				// specific permission error. Currently, the permission error is different across
-				// different client types and environments.
-				// See: https://github.com/sourcenetwork/defradb/issues/4446
-				ExpectedError: "not authorized to perform operation",
+				Identity:      testUtils.ClientIdentity(2),
+				CollectionID:  0,
+				DocID:         0,
+				Doc:           `{ "name": "Lone" }`,
+				ExpectedError: testUtils.FormatExpectedErrorWithPermission(acpTypes.NodeGetCollectionPerm),
 			},
 			&action.Request{ // Should not be updated
 				Identity: testUtils.ClientIdentity(1),

--- a/tests/integration/acp/nac/update_document_with_filter_test.go
+++ b/tests/integration/acp/nac/update_document_with_filter_test.go
@@ -17,8 +17,6 @@ import (
 	acpTypes "github.com/sourcenetwork/defradb/acp/types"
 	"github.com/sourcenetwork/defradb/tests/action"
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
-	"github.com/sourcenetwork/defradb/tests/state"
-	"github.com/sourcenetwork/immutable"
 )
 
 func TestNAC_GatesUpdateDocumentWithFilter_AuthorizedIdentity_AllowAccess(t *testing.T) {
@@ -37,7 +35,7 @@ func TestNAC_GatesUpdateDocumentWithFilter_AuthorizedIdentity_AllowAccess(t *tes
 				SDL: `
 					type User {
 						name: String
-						age: Int 
+						age: Int
 					}`,
 			},
 			&action.AddDoc{
@@ -71,14 +69,6 @@ func TestNAC_GatesUpdateDocumentWithFilter_AuthorizedIdentity_AllowAccess(t *tes
 
 func TestNAC_GatesUpdateDocumentWithFilter_NoIdentity_NotAuthorizedError(t *testing.T) {
 	test := testUtils.TestCase{
-		// todo: Investigate and test this behavior across all client types when implementing granular NAC permissions.
-		// See: https://github.com/sourcenetwork/defradb/issues/4383
-		SupportedClientTypes: immutable.Some(
-			[]state.ClientType{
-				state.GoClientType,
-				state.JSClientType,
-			},
-		),
 		Actions: []any{
 			// Starting with NAC, so only authorized user(s) can perform operations from here on out.
 			testUtils.Close{},
@@ -93,65 +83,7 @@ func TestNAC_GatesUpdateDocumentWithFilter_NoIdentity_NotAuthorizedError(t *test
 				SDL: `
 					type User {
 						name: String
-						age: Int 
-					}`,
-			},
-			&action.AddDoc{
-				Identity:     testUtils.ClientIdentity(1),
-				CollectionID: 0,
-				Doc: `{
-					"name": "Shahzad",
-					"age": 48
-				}`,
-			},
-
-			// We haven't authorized non-identities. So, this should error.
-			testUtils.UpdateWithFilter{
-				Identity:      testUtils.NoIdentity(),
-				CollectionID:  0,
-				Filter:        `{name: {_eq: "Shahzad"}}`,
-				Updater:       `{"name": "Lone"}`,
-				ExpectedError: testUtils.FormatExpectedErrorWithPermission(acpTypes.NodeUpdateDocumentPerm),
-			},
-			&action.Request{ // Should not be updated
-				Identity: testUtils.ClientIdentity(1),
-				Request:  `query{ User { name } }`,
-				Results: map[string]any{
-					"User": []map[string]any{{"name": "Shahzad"}},
-				},
-			},
-		},
-	}
-
-	testUtils.ExecuteTestCase(t, test)
-}
-
-func TestNAC_GatesUpdateDocumentWithFilter_NoIdentity_CLIandCandHTTPClient_NotAuthorizedError(t *testing.T) {
-	test := testUtils.TestCase{
-		// todo: Investigate and test this behavior across all client types when implementing granular NAC permissions.
-		// See: https://github.com/sourcenetwork/defradb/issues/4383
-		SupportedClientTypes: immutable.Some(
-			[]state.ClientType{
-				state.CClientType,
-				state.HTTPClientType,
-				state.CLIClientType,
-			},
-		),
-		Actions: []any{
-			// Starting with NAC, so only authorized user(s) can perform operations from here on out.
-			testUtils.Close{},
-			testUtils.Start{
-				Identity:  testUtils.ClientIdentity(1),
-				EnableNAC: true,
-			},
-			// Note: Doing setup steps after starting with nac enabled, otherwise the in-memory tests
-			// will lose setup state when the restart happens (i.e. the restart that started nac).
-			&action.AddCollection{
-				Identity: testUtils.ClientIdentity(1),
-				SDL: `
-					type User {
-						name: String
-						age: Int 
+						age: Int
 					}`,
 			},
 			&action.AddDoc{
@@ -186,14 +118,6 @@ func TestNAC_GatesUpdateDocumentWithFilter_NoIdentity_CLIandCandHTTPClient_NotAu
 
 func TestNAC_GatesUpdateDocumentWithFilter_WrongIdentity_NotAuthorizedError(t *testing.T) {
 	test := testUtils.TestCase{
-		// todo: Investigate and test this behavior across all client types when implementing granular NAC permissions.
-		// See: https://github.com/sourcenetwork/defradb/issues/4383
-		SupportedClientTypes: immutable.Some(
-			[]state.ClientType{
-				state.GoClientType,
-				state.JSClientType,
-			},
-		),
 		Actions: []any{
 			// Starting with NAC, so only authorized user(s) can perform operations from here on out.
 			testUtils.Close{},
@@ -208,65 +132,7 @@ func TestNAC_GatesUpdateDocumentWithFilter_WrongIdentity_NotAuthorizedError(t *t
 				SDL: `
 					type User {
 						name: String
-						age: Int 
-					}`,
-			},
-			&action.AddDoc{
-				Identity:     testUtils.ClientIdentity(1),
-				CollectionID: 0,
-				Doc: `{
-					"name": "Shahzad",
-					"age": 48
-				}`,
-			},
-
-			// Wrong user/identity will also not be authorized.
-			testUtils.UpdateWithFilter{
-				Identity:      testUtils.ClientIdentity(2),
-				CollectionID:  0,
-				Filter:        `{name: {_eq: "Shahzad"}}`,
-				Updater:       `{"name": "Lone"}`,
-				ExpectedError: testUtils.FormatExpectedErrorWithPermission(acpTypes.NodeUpdateDocumentPerm),
-			},
-			&action.Request{ // Should not be updated
-				Identity: testUtils.ClientIdentity(1),
-				Request:  `query{ User { name } }`,
-				Results: map[string]any{
-					"User": []map[string]any{{"name": "Shahzad"}},
-				},
-			},
-		},
-	}
-
-	testUtils.ExecuteTestCase(t, test)
-}
-
-func TestNAC_GatesUpdateDocumentWithFilter_WrongIdentity_CLIandCandHTTPClient_NotAuthorizedError(t *testing.T) {
-	test := testUtils.TestCase{
-		// todo: Investigate and test this behavior across all client types when implementing granular NAC permissions.
-		// See: https://github.com/sourcenetwork/defradb/issues/4383
-		SupportedClientTypes: immutable.Some(
-			[]state.ClientType{
-				state.CClientType,
-				state.HTTPClientType,
-				state.CLIClientType,
-			},
-		),
-		Actions: []any{
-			// Starting with NAC, so only authorized user(s) can perform operations from here on out.
-			testUtils.Close{},
-			testUtils.Start{
-				Identity:  testUtils.ClientIdentity(1),
-				EnableNAC: true,
-			},
-			// Note: Doing setup steps after starting with nac enabled, otherwise the in-memory tests
-			// will lose setup state when the restart happens (i.e. the restart that started nac).
-			&action.AddCollection{
-				Identity: testUtils.ClientIdentity(1),
-				SDL: `
-					type User {
-						name: String
-						age: Int 
+						age: Int
 					}`,
 			},
 			&action.AddDoc{

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -1616,7 +1616,11 @@ func deleteDoc(
 
 		nodeID := nodeIDs[index]
 
-		collections = action.MustGetCanonicallyOrderedCollections(s, node, txnOption)
+		collections, err = action.GetCollectionsCanonically(s, node, txnOption, a.Identity)
+		if err != nil {
+			expectedErrorRaised = AssertError(s.T, err, a.ExpectedError)
+			continue
+		}
 		collection := collections[a.CollectionID]
 
 		opts := options.DeleteDocument()
@@ -1668,7 +1672,11 @@ func deleteWithFilter(s *state.State, a DeleteWithFilter) {
 		}
 
 		nodeID := nodeIDs[index]
-		collections = action.MustGetCanonicallyOrderedCollections(s, node, txnOption)
+		collections, err = action.GetCollectionsCanonically(s, node, txnOption, a.Identity)
+		if err != nil {
+			expectedErrorRaised = AssertError(s.T, err, a.ExpectedError)
+			continue
+		}
 		collection := collections[a.CollectionID]
 
 		opts := options.DeleteDocumentsWithFilter()
@@ -1723,7 +1731,11 @@ func updateWithFilter(s *state.State, a UpdateWithFilter) {
 		}
 
 		nodeID := nodeIDs[index]
-		collections = action.MustGetCanonicallyOrderedCollections(s, node, txnOption)
+		collections, err = action.GetCollectionsCanonically(s, node, txnOption, a.Identity)
+		if err != nil {
+			expectedErrorRaised = AssertError(s.T, err, a.ExpectedError)
+			continue
+		}
 		collection := collections[a.CollectionID]
 
 		opts := options.UpdateDocumentsWithFilter()
@@ -1774,7 +1786,13 @@ func newEncryptedIndex(
 		}
 
 		nodeID := nodeIDs[index]
-		collections := action.MustGetCanonicallyOrderedCollections(s, node, txnOption)
+
+		collections, err := action.GetCollectionsCanonically(s, node, txnOption, a.Identity)
+		if err != nil {
+			expectedErrorRaised := AssertError(s.T, err, a.ExpectedError)
+			assertExpectedErrorRaised(s.T, a.ExpectedError, expectedErrorRaised)
+			return
+		}
 		collection := collections[a.CollectionID]
 
 		if a.FieldName == "" {
@@ -1838,7 +1856,11 @@ func listEncryptedIndexes(
 			txnOption = immutable.Some(txn)
 		}
 
-		var collections = action.MustGetCanonicallyOrderedCollections(s, node, txnOption)
+		collections, err := action.GetCollectionsCanonically(s, node, txnOption, a.Identity)
+		if err != nil {
+			expectedErrorRaised = expectedErrorRaised || AssertError(s.T, err, a.ExpectedError)
+			continue
+		}
 		collection := collections[a.CollectionID]
 
 		err = withRetryOnNode(
@@ -1928,7 +1950,13 @@ func deleteEncryptedIndex(
 		}
 
 		nodeID := nodeIDs[index]
-		collections := action.MustGetCanonicallyOrderedCollections(s, node, txnOption)
+
+		collections, err := action.GetCollectionsCanonically(s, node, txnOption, a.Identity)
+		if err != nil {
+			expectedErrorRaised := AssertError(s.T, err, a.ExpectedError)
+			assertExpectedErrorRaised(s.T, a.ExpectedError, expectedErrorRaised)
+			return
+		}
 		collection := collections[a.CollectionID]
 
 		if a.FieldName == "" {

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -1595,7 +1595,6 @@ func deleteDoc(
 	s.DocIDsLock.RUnlock()
 
 	doNotWaitForUpdate := false
-	var expectedErrorRaised bool
 
 	var collections []client.Collection
 
@@ -1618,7 +1617,8 @@ func deleteDoc(
 
 		collections, err = action.GetCollectionsCanonically(s, node, txnOption, a.Identity)
 		if err != nil {
-			expectedErrorRaised = AssertError(s.T, err, a.ExpectedError)
+			expectedErrorRaised := AssertError(s.T, err, a.ExpectedError)
+			assertExpectedErrorRaised(s.T, a.ExpectedError, expectedErrorRaised)
 			continue
 		}
 		collection := collections[a.CollectionID]
@@ -1635,10 +1635,9 @@ func deleteDoc(
 				return err
 			},
 		)
-		expectedErrorRaised = AssertError(s.T, err, a.ExpectedError)
+		expectedErrorRaised := AssertError(s.T, err, a.ExpectedError)
+		assertExpectedErrorRaised(s.T, a.ExpectedError, expectedErrorRaised)
 	}
-
-	assertExpectedErrorRaised(s.T, a.ExpectedError, expectedErrorRaised)
 
 	if a.ExpectedError == "" && !doNotWaitForUpdate {
 		expect := map[string]struct{}{
@@ -1652,7 +1651,6 @@ func deleteDoc(
 // deleteWithFilter deletes the set of matched documents.
 func deleteWithFilter(s *state.State, a DeleteWithFilter) {
 	var res *client.DeleteResult
-	var expectedErrorRaised bool
 	doNotWaitForUpdate := false
 
 	var collections []client.Collection
@@ -1674,7 +1672,8 @@ func deleteWithFilter(s *state.State, a DeleteWithFilter) {
 		nodeID := nodeIDs[index]
 		collections, err = action.GetCollectionsCanonically(s, node, txnOption, a.Identity)
 		if err != nil {
-			expectedErrorRaised = AssertError(s.T, err, a.ExpectedError)
+			expectedErrorRaised := AssertError(s.T, err, a.ExpectedError)
+			assertExpectedErrorRaised(s.T, a.ExpectedError, expectedErrorRaised)
 			continue
 		}
 		collection := collections[a.CollectionID]
@@ -1693,10 +1692,9 @@ func deleteWithFilter(s *state.State, a DeleteWithFilter) {
 			},
 		)
 
-		expectedErrorRaised = AssertError(s.T, err, a.ExpectedError)
+		expectedErrorRaised := AssertError(s.T, err, a.ExpectedError)
+		assertExpectedErrorRaised(s.T, a.ExpectedError, expectedErrorRaised)
 	}
-
-	assertExpectedErrorRaised(s.T, a.ExpectedError, expectedErrorRaised)
 
 	if a.ExpectedError == "" && !a.SkipLocalUpdateEvent && !doNotWaitForUpdate {
 		expect := make(map[string]struct{}, len(res.DocIDs))
@@ -1710,7 +1708,6 @@ func deleteWithFilter(s *state.State, a DeleteWithFilter) {
 // updateWithFilter updates the set of matched documents.
 func updateWithFilter(s *state.State, a UpdateWithFilter) {
 	var res *client.UpdateResult
-	var expectedErrorRaised bool
 	doNotWaitForUpdate := false
 
 	var collections []client.Collection
@@ -1733,7 +1730,8 @@ func updateWithFilter(s *state.State, a UpdateWithFilter) {
 		nodeID := nodeIDs[index]
 		collections, err = action.GetCollectionsCanonically(s, node, txnOption, a.Identity)
 		if err != nil {
-			expectedErrorRaised = AssertError(s.T, err, a.ExpectedError)
+			expectedErrorRaised := AssertError(s.T, err, a.ExpectedError)
+			assertExpectedErrorRaised(s.T, a.ExpectedError, expectedErrorRaised)
 			continue
 		}
 		collection := collections[a.CollectionID]
@@ -1752,10 +1750,9 @@ func updateWithFilter(s *state.State, a UpdateWithFilter) {
 			},
 		)
 
-		expectedErrorRaised = AssertError(s.T, err, a.ExpectedError)
+		expectedErrorRaised := AssertError(s.T, err, a.ExpectedError)
+		assertExpectedErrorRaised(s.T, a.ExpectedError, expectedErrorRaised)
 	}
-
-	assertExpectedErrorRaised(s.T, a.ExpectedError, expectedErrorRaised)
 
 	if a.ExpectedError == "" && !a.SkipLocalUpdateEvent && !doNotWaitForUpdate {
 		waitForUpdateEvents(
@@ -1791,7 +1788,7 @@ func newEncryptedIndex(
 		if err != nil {
 			expectedErrorRaised := AssertError(s.T, err, a.ExpectedError)
 			assertExpectedErrorRaised(s.T, a.ExpectedError, expectedErrorRaised)
-			return
+			continue
 		}
 		collection := collections[a.CollectionID]
 
@@ -1817,12 +1814,9 @@ func newEncryptedIndex(
 				return err
 			},
 		)
-		if AssertError(s.T, err, a.ExpectedError) {
-			return
-		}
+		expectedErrorRaised := AssertError(s.T, err, a.ExpectedError)
+		assertExpectedErrorRaised(s.T, a.ExpectedError, expectedErrorRaised)
 	}
-
-	assertExpectedErrorRaised(s.T, a.ExpectedError, false)
 }
 
 func listEncryptedIndexes(
@@ -1832,8 +1826,6 @@ func listEncryptedIndexes(
 	if len(s.Nodes) == 0 {
 		return
 	}
-
-	var expectedErrorRaised bool
 
 	nodeIDs, nodes := getNodesWithIDs(a.NodeID, s.Nodes)
 	for index, node := range nodes {
@@ -1858,7 +1850,8 @@ func listEncryptedIndexes(
 
 		collections, err := action.GetCollectionsCanonically(s, node, txnOption, a.Identity)
 		if err != nil {
-			expectedErrorRaised = expectedErrorRaised || AssertError(s.T, err, a.ExpectedError)
+			expectedErrorRaised := AssertError(s.T, err, a.ExpectedError)
+			assertExpectedErrorRaised(s.T, a.ExpectedError, expectedErrorRaised)
 			continue
 		}
 		collection := collections[a.CollectionID]
@@ -1877,11 +1870,9 @@ func listEncryptedIndexes(
 				return nil
 			},
 		)
-		expectedErrorRaised = expectedErrorRaised ||
-			AssertError(s.T, err, a.ExpectedError)
+		expectedErrorRaised := AssertError(s.T, err, a.ExpectedError)
+		assertExpectedErrorRaised(s.T, a.ExpectedError, expectedErrorRaised)
 	}
-
-	assertExpectedErrorRaised(s.T, a.ExpectedError, expectedErrorRaised)
 }
 
 func listAllEncryptedIndexes(
@@ -1891,8 +1882,6 @@ func listAllEncryptedIndexes(
 	if len(s.Nodes) == 0 {
 		return
 	}
-
-	var expectedErrorRaised bool
 
 	nodeIDs, _ := getNodesWithIDs(a.NodeID, s.Nodes)
 	for _, nodeID := range nodeIDs {
@@ -1925,11 +1914,9 @@ func listAllEncryptedIndexes(
 				return nil
 			},
 		)
-		expectedErrorRaised = expectedErrorRaised ||
-			AssertError(s.T, err, a.ExpectedError)
+		expectedErrorRaised := AssertError(s.T, err, a.ExpectedError)
+		assertExpectedErrorRaised(s.T, a.ExpectedError, expectedErrorRaised)
 	}
-
-	assertExpectedErrorRaised(s.T, a.ExpectedError, expectedErrorRaised)
 }
 
 func deleteEncryptedIndex(
@@ -1955,7 +1942,7 @@ func deleteEncryptedIndex(
 		if err != nil {
 			expectedErrorRaised := AssertError(s.T, err, a.ExpectedError)
 			assertExpectedErrorRaised(s.T, a.ExpectedError, expectedErrorRaised)
-			return
+			continue
 		}
 		collection := collections[a.CollectionID]
 
@@ -1975,12 +1962,9 @@ func deleteEncryptedIndex(
 				return collection.DeleteEncryptedIndex(s.Ctx, a.FieldName, opts)
 			},
 		)
-		if AssertError(s.T, err, a.ExpectedError) {
-			return
-		}
+		expectedErrorRaised := AssertError(s.T, err, a.ExpectedError)
+		assertExpectedErrorRaised(s.T, a.ExpectedError, expectedErrorRaised)
 	}
-
-	assertExpectedErrorRaised(s.T, a.ExpectedError, false)
 }
 
 // exportBackup generates a backup using the db api.


### PR DESCRIPTION
## Relevant issue(s)
Resolves #4446
Partially #4383

## Description
The same NAC authorization test reported different permission errors depending on which client ran it, for example: `document-update` locally via the Go client, but `collection-get` in CI via HTTP. So the tests could only assert the vague generic "not authorized to perform operation" string, not the actual permission.
### Root cause
It was a test-harness artifact, not a product bug. Every operation is gated twice: first `get-collection` (to resolve the collection), then the operation's own gate. In production all clients resolve-then-operate as the caller, so an unauthorized actor always hits `get-collection` first. 

But the test harness resolved collections using the node's own identity, which bypasses acp (the node-identity DID match short-circuits the check). That masked the get-collection gate for the embedded Go/JS client, so it fell through to the operation-specific gate. While name-addressed clients (HTTP/CLI/C) still hit `get-collection`. 

### Solution
Make the harness resolve collections as the acting identity instead of the node identity, so every client uniformly hits `get-collection` first when unauthorized.

Concretely:
  - Deleted the node-identity fallback (if !identity.HasValue() { identity = NodeIdentity(nodeID) }) that was masking the gate.
  - Collapsed helpers into `GetCollectionsCanonically` (resolves as the acting identity)
  - Applied it to document ops and the collection/index ops (truncate, list/new/delete index, encrypted-index).
  - Deleted all the per-client `_CLIandCandHTTPClient_` split-test variants, every gate test now asserts a single, uniform `get-collection`.

NOTE: This will make life easier for when we do granular permissions (#4383)

@ChrisBQu you might have some context for when you made this issue, will appreciate a look from you