### PR TITLE
fix: delete secondary index entries when purging documents

### DIFF
--- a/internal/db/collection_id.go
+++ b/internal/db/collection_id.go
@@ -206,9 +206,18 @@ func getCollectionSets(newCollections []*client.CollectionVersion) [][]*client.C
 		collectionSetsByID[collectionSetId] = collectionSet
 	}
 
-	collectionSets := [][]*client.CollectionVersion{}
-	for _, collectionSet := range collectionSetsByID {
-		collectionSets = append(collectionSets, collectionSet)
+	// The order the sets are returned in must be deterministic: it determines the order the
+	// collections are written, which can affect their generated IDs. Sort by the (deterministic)
+	// set IDs instead of ranging the map.
+	setIDs := make([]int, 0, len(collectionSetsByID))
+	for id := range collectionSetsByID {
+		setIDs = append(setIDs, id)
+	}
+	slices.Sort(setIDs)
+
+	collectionSets := make([][]*client.CollectionVersion, 0, len(collectionSetsByID))
+	for _, id := range setIDs {
+		collectionSets = append(collectionSets, collectionSetsByID[id])
 	}
 
 	return collectionSets

--- a/internal/db/collection_id_test.go
+++ b/internal/db/collection_id_test.go
@@ -1,0 +1,52 @@
+// Copyright 2025 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// A collection's generated ID must not depend on the order unrelated collections are written in.
+// "Foo" is a prefix of the unrelated "FooBar", so if the collection-set order is nondeterministic
+// the head scan for "Foo" can read "FooBar"'s head, changing Foo's ID between identical runs.
+func TestAddCollectionDeterministicIDsWithSharedNamePrefix(t *testing.T) {
+	ctx := context.Background()
+
+	const sdl = `
+		type Foo { name: String }
+		type FooBar { name: String }
+	`
+
+	fooID := func() string {
+		db, err := newBadgerDB(ctx)
+		require.NoError(t, err)
+		defer db.Close()
+
+		cols, err := db.AddCollection(ctx, sdl)
+		require.NoError(t, err)
+		for _, c := range cols {
+			if c.Name == "Foo" {
+				return c.VersionID
+			}
+		}
+		require.Fail(t, `collection "Foo" not returned`)
+		return ""
+	}
+
+	ids := map[string]struct{}{}
+	for i := 0; i < 30; i++ {
+		ids[fooID()] = struct{}{}
+	}
+	require.Len(t, ids, 1, "Foo's collection ID must be identical across runs")
+}

--- a/internal/db/collection_purge.go
+++ b/internal/db/collection_purge.go
@@ -114,6 +114,14 @@ func (c *collection) purgeOneDoc(
 		return nil
 	}
 
+	// Index entries are keyed by the document's field values, so they must be deleted before
+	// the datastore prefixes holding those values are removed.
+	if len(c.indexes) > 0 {
+		if err := c.deleteIndexedDocWithID(ctx, docID); err != nil {
+			return err
+		}
+	}
+
 	// InstanceType sits between CollectionShortID and DocShortID in the encoded key, so we
 	// must include it in the prefix; a key without InstanceType matches nothing.
 	for _, itype := range []keys.InstanceType{keys.ValueKey, keys.PriorityKey, keys.DeletedKey} {

--- a/internal/db/collection_purge_test.go
+++ b/internal/db/collection_purge_test.go
@@ -107,3 +107,27 @@ func TestPurgeByDocIDsChunksPurgeOverTransactionLimit(t *testing.T) {
 		require.False(t, found)
 	}
 }
+
+// TestPurgeByDocIDsRemovesIndexEntries verifies a purge removes the pruned document's
+// secondary-index entries, so re-indexing the same document later does not collide with a
+// stale unique entry.
+func TestPurgeByDocIDsRemovesIndexEntries(t *testing.T) {
+	ctx := context.Background()
+	db, col := setupUserCollection(t, ctx)
+
+	desc, err := col.NewIndex(ctx, client.NewIndexRequest{
+		Fields: []client.IndexedFieldDescription{{Name: "name"}},
+		Unique: true,
+	})
+	require.NoError(t, err)
+
+	doc := addUserDoc(t, ctx, col, "alice")
+
+	shortID := getCollectionShortID(t, ctx, db, col.Version().CollectionID)
+	require.Equal(t, 1, countIndexEntries(t, ctx, db, shortID, desc.ID))
+
+	require.NoError(t, col.PurgeByDocIDs(ctx, []client.DocID{doc.ID()}, false))
+
+	require.Equal(t, 0, countIndexEntries(t, ctx, db, shortID, desc.ID),
+		"purge must delete the document's index entries")
+}

--- a/internal/db/collection_truncate.go
+++ b/internal/db/collection_truncate.go
@@ -496,11 +496,11 @@ func (c *collection) deleteBlocks(
 		if err := id.DeleteBlockDocIDMapping(ctx, systemstore, blockCID, docID); err != nil {
 			return false, err
 		}
-		docIDs, err := id.GetDocIDsForBlockFromStore(ctx, systemstore, blockCID)
+		hasOwners, err := id.BlockHasOwners(ctx, systemstore, blockCID)
 		if err != nil {
 			return false, err
 		}
-		return len(docIDs) == 0, nil
+		return !hasOwners, nil
 	}
 
 	deleteBlock := func(blockCID cid.Cid) error {

--- a/internal/db/id/document.go
+++ b/internal/db/id/document.go
@@ -160,8 +160,7 @@ func GetDocIDsForBlockFromStore(
 		return nil, nil
 	}
 
-	prefix := keys.NewBlockCIDToDocIDKey(blockCID.String(), "").Bytes()
-	prefix = append(prefix, '/')
+	prefix := blockOwnersPrefix(blockCID)
 	iter, err := store.Iterator(ctx, corekv.IterOptions{
 		Prefix:   prefix,
 		KeysOnly: true,
@@ -188,6 +187,43 @@ func GetDocIDsForBlockFromStore(
 		return nil, err
 	}
 	return docIDs, nil
+}
+
+// blockOwnersPrefix is the key prefix under which every owner DocID of blockCID is stored.
+func blockOwnersPrefix(blockCID cid.Cid) []byte {
+	return append(keys.NewBlockCIDToDocIDKey(blockCID.String(), "").Bytes(), '/')
+}
+
+// BlockHasOwners reports whether any document still owns blockCID. Prefer this over
+// GetDocIDsForBlockFromStore when only the presence of an owner matters: it stops at the
+// first match rather than materializing the whole owner set.
+func BlockHasOwners(ctx context.Context, store corekv.Reader, blockCID cid.Cid) (bool, error) {
+	if !blockCID.Defined() {
+		return false, nil
+	}
+
+	prefix := blockOwnersPrefix(blockCID)
+	iter, err := store.Iterator(ctx, corekv.IterOptions{
+		Prefix:   prefix,
+		KeysOnly: true,
+	})
+	if err != nil {
+		return false, err
+	}
+
+	for {
+		hasNext, err := iter.Next()
+		if err != nil {
+			return false, stderrors.Join(err, iter.Close())
+		}
+		if !hasNext {
+			break
+		}
+		if len(bytes.TrimPrefix(iter.Key(), prefix)) != 0 {
+			return true, iter.Close()
+		}
+	}
+	return false, iter.Close()
 }
 
 func DeleteBlockDocIDMapping(

--- a/internal/db/id/document_test.go
+++ b/internal/db/id/document_test.go
@@ -12,11 +12,14 @@ package id
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	blocks "github.com/ipfs/go-block-format"
+	"github.com/ipfs/go-cid"
 	"github.com/stretchr/testify/require"
 
+	"github.com/sourcenetwork/corekv"
 	"github.com/sourcenetwork/corekv/memory"
 	"github.com/sourcenetwork/defradb/internal/datastore"
 	"github.com/sourcenetwork/defradb/internal/db/lock"
@@ -184,6 +187,94 @@ func TestBlockDocIDMappings(t *testing.T) {
 	docIDs, err = GetDocIDsForBlockFromStore(ctx, txn.Systemstore(), fieldCID)
 	require.NoError(t, err)
 	require.Empty(t, docIDs)
+}
+
+func TestBlockHasOwners(t *testing.T) {
+	ctx := context.Background()
+	txn := newDocumentIDTestTxn(ctx)
+	defer txn.Discard()
+	ctx = datastore.CtxSetTxn(ctx, txn)
+
+	fieldCID := blocks.NewBlock([]byte("field value")).Cid()
+
+	has, err := BlockHasOwners(ctx, txn.Systemstore(), fieldCID)
+	require.NoError(t, err)
+	require.False(t, has, "a block with no recorded owners has none")
+
+	has, err = BlockHasOwners(ctx, txn.Systemstore(), cid.Undef)
+	require.NoError(t, err)
+	require.False(t, has, "an undefined CID has no owners")
+
+	require.NoError(t, SetBlockDocIDMapping(ctx, fieldCID, "bae-doc-one"))
+	require.NoError(t, SetBlockDocIDMapping(ctx, fieldCID, "bae-doc-two"))
+
+	has, err = BlockHasOwners(ctx, txn.Systemstore(), fieldCID)
+	require.NoError(t, err)
+	require.True(t, has)
+
+	// One of two owners removed: the block is still owned.
+	require.NoError(t, DeleteBlockDocIDMapping(ctx, txn.Systemstore(), fieldCID, "bae-doc-one"))
+	has, err = BlockHasOwners(ctx, txn.Systemstore(), fieldCID)
+	require.NoError(t, err)
+	require.True(t, has)
+
+	require.NoError(t, DeleteBlockDocIDMapping(ctx, txn.Systemstore(), fieldCID, "bae-doc-two"))
+	has, err = BlockHasOwners(ctx, txn.Systemstore(), fieldCID)
+	require.NoError(t, err)
+	require.False(t, has)
+}
+
+// TestBlockHasOwnersStopsAtFirstOwner checks BlockHasOwners reports ownership after reading a
+// single key regardless of how many documents own the block, unlike GetDocIDsForBlockFromStore
+// which reads every owner.
+func TestBlockHasOwnersStopsAtFirstOwner(t *testing.T) {
+	ctx := context.Background()
+	txn := newDocumentIDTestTxn(ctx)
+	defer txn.Discard()
+	ctx = datastore.CtxSetTxn(ctx, txn)
+
+	fieldCID := blocks.NewBlock([]byte("shared field value")).Cid()
+	const owners = 500
+	for i := range owners {
+		require.NoError(t, SetBlockDocIDMapping(ctx, fieldCID, fmt.Sprintf("bae-doc-%d", i)))
+	}
+
+	var hasReads int
+	has, err := BlockHasOwners(ctx, countingReader{txn.Systemstore(), &hasReads}, fieldCID)
+	require.NoError(t, err)
+	require.True(t, has)
+	require.Equal(t, 1, hasReads, "BlockHasOwners must stop at the first owner")
+
+	var listReads int
+	all, err := GetDocIDsForBlockFromStore(ctx, countingReader{txn.Systemstore(), &listReads}, fieldCID)
+	require.NoError(t, err)
+	require.Len(t, all, owners)
+	require.Greater(t, listReads, owners, "GetDocIDsForBlockFromStore reads every owner")
+}
+
+// countingReader wraps a corekv.Reader and tallies iterator advances so a test can assert
+// how much of a key range a function scans.
+type countingReader struct {
+	corekv.Reader
+	nextCalls *int
+}
+
+func (r countingReader) Iterator(ctx context.Context, opts corekv.IterOptions) (corekv.Iterator, error) {
+	iter, err := r.Reader.Iterator(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+	return &countingIterator{Iterator: iter, nextCalls: r.nextCalls}, nil
+}
+
+type countingIterator struct {
+	corekv.Iterator
+	nextCalls *int
+}
+
+func (it *countingIterator) Next() (bool, error) {
+	*it.nextCalls++
+	return it.Iterator.Next()
 }
 
 func TestDeleteDocRefMappings(t *testing.T) {

--- a/node/store_badger.go
+++ b/node/store_badger.go
@@ -12,12 +12,16 @@ package node
 
 import (
 	"context"
+	"errors"
+	"sync"
+	"time"
 
 	badgerds "github.com/dgraph-io/badger/v4"
 	badgeropts "github.com/dgraph-io/badger/v4/options"
 
 	"github.com/sourcenetwork/corekv"
 	"github.com/sourcenetwork/corekv/badger"
+	"github.com/sourcenetwork/corelog"
 
 	"github.com/sourcenetwork/defradb/client/options"
 )
@@ -45,7 +49,12 @@ func init() {
 			badgerOpts.IndexCacheSize = 100 << 20
 		}
 
-		return badger.NewDatastore(path, badgerOpts)
+		// Value log GC is unsupported for in-memory stores, so only persistent
+		// stores get the GC wrapper.
+		if opts.BadgerInMemory {
+			return badger.NewDatastore(path, badgerOpts)
+		}
+		return newBadgerStore(path, badgerOpts)
 	}
 	purge := func(ctx context.Context, opts *options.NodeStoreOptions) error {
 		store, err := constructor(ctx, opts)
@@ -64,4 +73,98 @@ func init() {
 
 	storeConstructors[options.NodeDefaultStore] = constructor
 	storePurgeFuncs[options.NodeDefaultStore] = purge
+}
+
+const (
+	// valueLogGCInterval is how often value log GC runs on a persistent store.
+	valueLogGCInterval = 5 * time.Minute
+	// valueLogGCDiscardRatio is the fraction of a value log file that must be
+	// reclaimable before badger rewrites it.
+	valueLogGCDiscardRatio = 0.1
+)
+
+// badgerStore wraps a persistent badger datastore and periodically runs value log
+// GC. Badger does not reclaim the value log space of deleted or overwritten
+// entries on its own, so the GC keeps the on-disk store bounded.
+type badgerStore struct {
+	*badger.Datastore
+
+	db       *badgerds.DB
+	stop     chan struct{}
+	done     chan struct{}
+	stopOnce sync.Once
+}
+
+// newBadgerStore opens a persistent badger store at path and starts value log GC.
+func newBadgerStore(path string, opts badgerds.Options) (*badgerStore, error) {
+	opts.Dir = path
+	opts.ValueDir = path
+	opts.Logger = nil // badger's default logger is very verbose
+	db, err := badgerds.Open(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	store := &badgerStore{
+		Datastore: badger.NewDatastoreFrom(db),
+		db:        db,
+		stop:      make(chan struct{}),
+		done:      make(chan struct{}),
+	}
+	go store.runValueLogGC()
+	return store, nil
+}
+
+// Close stops value log GC and closes the underlying store.
+func (s *badgerStore) Close() error {
+	s.stopOnce.Do(func() {
+		close(s.stop)
+		<-s.done
+	})
+	return s.Datastore.Close()
+}
+
+// runValueLogGC reclaims value log space on a fixed interval until the store closes.
+func (s *badgerStore) runValueLogGC() {
+	defer close(s.done)
+
+	ticker := time.NewTicker(valueLogGCInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-s.stop:
+			return
+		case <-ticker.C:
+			s.reclaimValueLog()
+		}
+	}
+}
+
+// reclaimValueLog runs value log GC repeatedly until there is nothing left to
+// reclaim, an error occurs, or the store starts closing. Each successful call
+// rewrites one file; ErrNoRewrite means no file was eligible and ends the loop.
+// Any other error is logged, since it means GC could not make progress.
+func (s *badgerStore) reclaimValueLog() {
+	start := time.Now()
+	reclaimed := 0
+	for {
+		select {
+		case <-s.stop:
+			return
+		default:
+		}
+		if err := s.db.RunValueLogGC(valueLogGCDiscardRatio); err != nil {
+			if !errors.Is(err, badgerds.ErrNoRewrite) {
+				log.ErrorE("Badger value log GC failed", err)
+			}
+			break
+		}
+		reclaimed++
+	}
+	if reclaimed > 0 {
+		log.Info("Reclaimed badger value log files",
+			corelog.Int("files", reclaimed),
+			corelog.Duration("duration", time.Since(start)))
+	}
 }

--- a/node/store_badger_test.go
+++ b/node/store_badger_test.go
@@ -11,9 +11,12 @@
 package node
 
 import (
+	"context"
 	"crypto/rand"
 	"testing"
+	"time"
 
+	badgerds "github.com/dgraph-io/badger/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -38,4 +41,58 @@ func TestSetBadgerEncryptionKey(t *testing.T) {
 
 	opts := utils.NewOptions(options.Node().Store().SetBadgerEncryptionKey(encryptionKey).Node())
 	assert.Equal(t, encryptionKey, opts.Store.BadgerEncryptionKey)
+}
+
+func TestNewStoreBadgerGCWrapping(t *testing.T) {
+	ctx := context.Background()
+
+	inMem, _, err := NewStore(ctx, options.NodeStore().
+		SetType(options.NodeBadgerStore).SetBadgerInMemory(true).SetBadgerFileSize(1<<20))
+	require.NoError(t, err)
+	defer inMem.Close()
+	_, wrapped := inMem.(*badgerStore)
+	assert.False(t, wrapped, "in-memory store must not run value log GC")
+
+	persistent, _, err := NewStore(ctx, options.NodeStore().
+		SetType(options.NodeBadgerStore).SetPath(t.TempDir()).SetBadgerFileSize(1<<20))
+	require.NoError(t, err)
+	defer persistent.Close()
+	_, wrapped = persistent.(*badgerStore)
+	assert.True(t, wrapped, "persistent store must run value log GC")
+}
+
+func TestBadgerStoreCloseStopsGCAndIsIdempotent(t *testing.T) {
+	store, err := newBadgerStore(t.TempDir(), badgerds.DefaultOptions(""))
+	require.NoError(t, err)
+
+	require.NoError(t, store.Close())
+
+	select {
+	case <-store.done:
+	default:
+		t.Fatal("value log GC goroutine did not stop on Close")
+	}
+
+	// A second Close must not panic on the already-closed stop channel.
+	assert.NotPanics(t, func() { _ = store.Close() })
+}
+
+func TestBadgerStoreReclaimValueLogTerminates(t *testing.T) {
+	store, err := newBadgerStore(t.TempDir(), badgerds.DefaultOptions(""))
+	require.NoError(t, err)
+	defer store.Close()
+
+	// With no value log file eligible for GC, RunValueLogGC returns ErrNoRewrite on
+	// the first call, so reclaimValueLog must return rather than spin on the error.
+	done := make(chan struct{})
+	go func() {
+		store.reclaimValueLog()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("reclaimValueLog did not terminate")
+	}
 }


### PR DESCRIPTION
Purging a document deleted its data but left its secondary-index entries behind.
Re-adding the same document later then failed with a unique-index violation against the stale entry.

`purgeOneDoc` now deletes the document's index entries before its datastore values.