### PR TITLE
fix: read block content outside the purge transaction's conflict set

### DIFF
--- a/internal/db/collection_purge_conflict_test.go
+++ b/internal/db/collection_purge_conflict_test.go
@@ -1,0 +1,113 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package db
+
+import (
+	"context"
+	"testing"
+
+	blocks "github.com/ipfs/go-block-format"
+	"github.com/ipfs/go-cid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcenetwork/corekv"
+
+	"github.com/sourcenetwork/defradb/client"
+	"github.com/sourcenetwork/defradb/internal/datastore"
+)
+
+// setupPrunedFieldBlock creates a document, then removes one of its field blocks from the
+// blockstore while leaving the composite's link to it in place. It returns the now-absent
+// block's CID and content so a test can store it back from a concurrent transaction, standing
+// in for a DAG sync that recreates a block the purge walk is reading.
+func setupPrunedFieldBlock(
+	t *testing.T,
+	ctx context.Context,
+) (*DB, client.Collection, client.DocID, cid.Cid, blocks.Block) {
+	t.Helper()
+
+	db, err := newBadgerDB(ctx)
+	require.NoError(t, err)
+
+	_, err = db.AddCollection(ctx, userDocIDTestSchema)
+	require.NoError(t, err)
+	col, err := db.GetCollectionByName(ctx, "User")
+	require.NoError(t, err)
+
+	doc, err := client.NewDocFromJSON(ctx, []byte(`{"name":"Alice","age":40}`), col.Version())
+	require.NoError(t, err)
+	require.NoError(t, col.AddDocument(ctx, doc))
+
+	composite := loadTestBlock(t, ctx, db, doc.Head())
+	require.NotEmpty(t, composite.Links)
+	blockCID := composite.Links[0].Cid
+
+	blockstore := datastore.BlockstoreFrom(db.rootstore, db.blockStoreChunkSize)
+	block, err := blockstore.Get(ctx, blockCID)
+	require.NoError(t, err)
+	require.NoError(t, blockstore.DeleteBlock(ctx, blockCID))
+
+	return db, col, doc.ID(), blockCID, block
+}
+
+// storeBlockInNewTxn stores block in its own committed transaction, standing in for a
+// concurrent DAG sync that recreates a block.
+func storeBlockInNewTxn(t *testing.T, ctx context.Context, db *DB, block blocks.Block) {
+	t.Helper()
+
+	txn, err := db.NewTxn(false)
+	require.NoError(t, err)
+	blockstore := datastore.BlockstoreFrom(db.rootstore, db.blockStoreChunkSize)
+	require.NoError(t, blockstore.Put(InitContext(ctx, txn), block))
+	require.NoError(t, txn.Commit())
+}
+
+// TestPurgeByDocIDsPruneHistoryReadsBlocksOutsideConflictSet checks that pruning a document's
+// block history reads block content outside the purge transaction's conflict set, so a
+// concurrent store of a block the walk visits does not abort the purge. The control subtest
+// confirms the same store does abort a transaction that read the block itself, so the fix
+// subtest is not passing vacuously.
+func TestPurgeByDocIDsPruneHistoryReadsBlocksOutsideConflictSet(t *testing.T) {
+	t.Run("reading the block through the write transaction conflicts", func(t *testing.T) {
+		ctx := context.Background()
+		db, _, _, blockCID, block := setupPrunedFieldBlock(t, ctx)
+		defer db.Close()
+
+		blockstore := datastore.BlockstoreFrom(db.rootstore, db.blockStoreChunkSize)
+
+		txn, err := db.NewTxn(false)
+		require.NoError(t, err)
+		tctx := InitContext(ctx, txn)
+		_, _, err = getBlock(tctx, blockstore, blockCID)
+		require.NoError(t, err)
+		// badger only checks for conflicts when the transaction has a pending write; the real
+		// purge deletes as it walks, so delete the block here too.
+		require.NoError(t, blockstore.DeleteBlock(tctx, blockCID))
+
+		storeBlockInNewTxn(t, ctx, db, block)
+
+		require.ErrorIs(t, txn.Commit(), corekv.ErrTxnConflict)
+	})
+
+	t.Run("pruning the document does not conflict", func(t *testing.T) {
+		ctx := context.Background()
+		db, col, docID, _, block := setupPrunedFieldBlock(t, ctx)
+		defer db.Close()
+
+		txn, err := db.NewTxn(false)
+		require.NoError(t, err)
+		require.NoError(t, col.PurgeByDocIDs(InitContext(ctx, txn), []client.DocID{docID}, true))
+
+		storeBlockInNewTxn(t, ctx, db, block)
+
+		require.NoError(t, txn.Commit())
+	})
+}

--- a/internal/db/collection_truncate.go
+++ b/internal/db/collection_truncate.go
@@ -489,6 +489,18 @@ func (c *collection) deleteBlocks(
 ) error {
 	blockstore := datastore.NewMultistore(c.db.rootstore, c.db.lockSet, c.db.blockStoreChunkSize).Blockstore()
 
+	// Block content is immutable and content-addressed; the walk only reads it to find child
+	// links. Reading it through the purge's write transaction adds every visited CID to that
+	// transaction's conflict set, so a concurrent write of any of them aborts the purge for a
+	// read whose value never changed. Read it through a read-only transaction instead; ownership
+	// checks and deletions stay on the write transaction, so the keep/delete decision is unchanged.
+	readTxn, err := c.db.NewTxn(true)
+	if err != nil {
+		return err
+	}
+	defer readTxn.Discard()
+	readCtx := InitContext(ctx, readTxn)
+
 	deleteBlockMapping := func(blockCID cid.Cid) (bool, error) {
 		if systemstore == nil || docID == "" {
 			return true, nil
@@ -519,7 +531,7 @@ func (c *collection) deleteBlocks(
 		block *coreblock.Block
 	}
 
-	coreBlock, isFound, err := getBlock(ctx, blockstore, currentCid)
+	coreBlock, isFound, err := getBlock(readCtx, blockstore, currentCid)
 	if err != nil {
 		return err
 	}
@@ -565,7 +577,7 @@ func (c *collection) deleteBlocks(
 		currentBlock := toDelete[i]
 
 		if currentBlock.block == nil {
-			coreBlock, isFound, err := getBlock(ctx, blockstore, currentBlock.id)
+			coreBlock, isFound, err := getBlock(readCtx, blockstore, currentBlock.id)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
deleteBlocks walks a document's block DAG when purging its history, reading each block's content to find child links. Those reads went through the purge's write transaction, so every visited CID entered its conflict set. 

Block content is content-addressed and immutable, so a concurrent write of any visited CID (for example a P2P sync storing that block) aborts the purge even though nothing it read changed. For documents that share content-identical blocks, this makes PurgeByDocIDs with pruneHistory fail with transaction conflict under concurrent writes, so the block history is never deleted.

This reads block content through a read-only transaction, keeping it out of the write transaction's conflict set. The ownership check and the block deletions stay on the write transaction, so the keep/delete decision is unchanged.