### PR TITLE
feat: Index list collection name

### DIFF
--- a/cli/test/action/list_indexes.go
+++ b/cli/test/action/list_indexes.go
@@ -29,6 +29,12 @@ type ListIndexes struct {
 	// The expected indexes when listing for a specific collection.
 	ExpectedIndexes []client.IndexDescription
 
+	// ExpectedCollectionName is the collection name expected on every returned result.
+	//
+	// Only asserted when set, and only meaningful on the scoped (--collection) branch:
+	// the unscoped branch always asserts each result against its own map key.
+	ExpectedCollectionName string
+
 	// The expected indexes when listing all indexes (map of collection name to indexes).
 	ExpectedAllIndexes map[client.CollectionName][]client.IndexDescription
 
@@ -72,6 +78,11 @@ func (a *ListIndexes) Execute() {
 				require.Equal(a.s.T, expected.Name, actual.Name)
 				require.Equal(a.s.T, expected.Fields, actual.Fields)
 				require.Equal(a.s.T, expected.Unique, actual.Unique)
+
+				if a.ExpectedCollectionName != "" {
+					require.Equal(a.s.T, a.ExpectedCollectionName, result[i].CollectionName,
+						"index %s collection name mismatch", expected.Name)
+				}
 			}
 		}
 	} else {
@@ -103,6 +114,10 @@ func (a *ListIndexes) Execute() {
 					require.Equal(a.s.T, expected.Name, actual.Name)
 					require.Equal(a.s.T, expected.Fields, actual.Fields)
 					require.Equal(a.s.T, expected.Unique, actual.Unique)
+
+					// Each element must name its own collection, matching the key it was filed under.
+					require.Equal(a.s.T, collectionName, actualIndexes[i].CollectionName,
+						"index %s collection name mismatch", expected.Name)
 				}
 			}
 		}

--- a/cli/test/integration/index/list_test.go
+++ b/cli/test/integration/index/list_test.go
@@ -181,6 +181,41 @@ func TestIndexList_WithEmptyDatabase_ShouldReturnEmptyMap(t *testing.T) {
 	test.Execute(t)
 }
 
+func TestIndexList_WithCollectionFlag_ShouldReportCollectionName(t *testing.T) {
+	test := &integration.Test{
+		Actions: []action.Action{
+			&action.AddCollection{
+				InlineSDL: `
+					type User {
+						name: String
+						age: Int
+					}
+				`,
+			},
+			&action.NewIndex{
+				Collection: "User",
+				Name:       "UsersByName",
+				Fields:     []string{"name"},
+			},
+			&action.ListIndexes{
+				Collection: "User",
+				ExpectedIndexes: []client.IndexDescription{
+					{
+						Name: "UsersByName",
+						Fields: []client.IndexedFieldDescription{
+							{Name: "name", Descending: false},
+						},
+						Unique: false,
+					},
+				},
+				ExpectedCollectionName: "User",
+			},
+		},
+	}
+
+	test.Execute(t)
+}
+
 func TestIndexList_WithUnknownCollection_ShouldReturnError(t *testing.T) {
 	test := &integration.Test{
 		Actions: []action.Action{

--- a/client/index.go
+++ b/client/index.go
@@ -72,6 +72,8 @@ type CollectionIndex interface {
 //   - dropping: InProgress + DropIndexAction
 //   - ready:    Completed  (no in-flight action; Execution.Action is unset)
 type ListIndexesResult struct {
+	// CollectionName is the name of the collection the index belongs to.
+	CollectionName string
 	// Description is the static index specification.
 	Description IndexDescription
 	// Execution is the index's current (or most recent) lifecycle action.

--- a/internal/db/collection_index.go
+++ b/internal/db/collection_index.go
@@ -58,7 +58,7 @@ func (db *DB) listIndexDescriptions(
 		results := make([]client.ListIndexesResult, len(col.Indexes))
 		for i, desc := range col.Indexes {
 			state, ok := states[desc.ID]
-			results[i] = state.listResult(col.CollectionID, desc, ok)
+			results[i] = state.listResult(col.CollectionID, col.Name, desc, ok)
 		}
 		indexes[col.Name] = results
 	}
@@ -684,11 +684,12 @@ func (c *collection) ListIndexes(
 		return nil, err
 	}
 
-	indexes := c.Version().Indexes
+	version := c.Version()
+	indexes := version.Indexes
 	result := make([]client.ListIndexesResult, len(indexes))
 	for i, desc := range indexes {
 		state, ok := states[desc.ID]
-		result[i] = state.listResult(c.def.CollectionID, desc, ok)
+		result[i] = state.listResult(c.def.CollectionID, version.Name, desc, ok)
 	}
 	return result, nil
 }

--- a/internal/db/index_state.go
+++ b/internal/db/index_state.go
@@ -66,6 +66,7 @@ func (s indexState) isDropping() bool {
 // false for a ready index (no action record), reported as a Completed execution.
 func (s indexState) listResult(
 	collectionID string,
+	collectionName string,
 	desc client.IndexDescription,
 	hasState bool,
 ) client.ListIndexesResult {
@@ -80,7 +81,7 @@ func (s indexState) listResult(
 		exec.Status = s.Status
 		exec.Reason = s.Reason
 	}
-	return client.ListIndexesResult{Description: desc, Execution: exec}
+	return client.ListIndexesResult{CollectionName: collectionName, Description: desc, Execution: exec}
 }
 
 // indexSubject is the action subject segment for an index action: the index ID.

--- a/tests/action/list_indexes.go
+++ b/tests/action/list_indexes.go
@@ -43,6 +43,11 @@ type ListIndexes struct {
 	// The expected indexes to be returned.
 	ExpectedIndexes []client.IndexDescription
 
+	// ExpectedCollectionName is the collection name expected on every returned result.
+	//
+	// Only asserted when set.
+	ExpectedCollectionName string
+
 	// ExpectedStatuses maps index name to the expected execution for that index.
 	// When set for a name, asserts Status, Action and Reason (partial match) instead of the
 	// default ready assertion.
@@ -102,6 +107,7 @@ func (a *ListIndexes) Execute() {
 
 		assertIndexesListsEqual(a.ExpectedIndexes, actualStatuses, a.s.T)
 		assertIndexStatuses(a.ExpectedStatuses, actualStatuses, a.s.T)
+		assertIndexCollectionNames(a.ExpectedCollectionName, actualStatuses, a.s.T)
 	}
 
 	assertExpectedErrorRaised(a.s.T, a.ExpectedError, expectedErrorRaised)
@@ -178,6 +184,23 @@ func assertIndexStatuses(
 	// index name fails rather than silently passing.
 	for name := range expectedStatuses {
 		assert.Contains(t, actualByName, name, "expected status configured for missing index %s", name)
+	}
+}
+
+// assertIndexCollectionNames checks that every returned result names its owning collection.
+//
+// When expectedName is empty, no assertions are made.
+func assertIndexCollectionNames(
+	expectedName string,
+	actualResults []client.ListIndexesResult,
+	t require.TestingT,
+) {
+	if expectedName == "" {
+		return
+	}
+	for _, actual := range actualResults {
+		assert.Equal(t, expectedName, actual.CollectionName,
+			"index %s collection name mismatch", actual.Description.Name)
 	}
 }
 

--- a/tests/integration/index/list_collection_name_test.go
+++ b/tests/integration/index/list_collection_name_test.go
@@ -1,0 +1,109 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package index
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/defradb/client"
+	"github.com/sourcenetwork/defradb/tests/action"
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+// Listing a single collection's indexes returns only an opaque CollectionID unless each
+// result also names its collection, so the caller cannot render the owner without a
+// second lookup. See https://github.com/sourcenetwork/defradb/issues/5055.
+func TestIndexList_WithCollectionScope_ResultsNameTheirCollection(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type User {
+						name: String
+						age: Int
+					}
+				`,
+			},
+			&action.NewIndex{
+				CollectionID: 0,
+				IndexName:    "UsersByName",
+				Fields:       []client.IndexedFieldDescription{{Name: "name"}},
+			},
+			&action.ListIndexes{
+				CollectionID: 0,
+				ExpectedIndexes: []client.IndexDescription{
+					{
+						Name:   "UsersByName",
+						ID:     1,
+						Fields: []client.IndexedFieldDescription{{Name: "name"}},
+					},
+				},
+				ExpectedCollectionName: "User",
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+// Each collection's results must name that collection, not merely the first one, so a
+// result lifted out of a multi-collection listing stays self-describing.
+func TestIndexList_WithMultipleCollections_EachResultNamesItsOwnCollection(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type User {
+						name: String
+					}
+
+					type Product {
+						title: String
+					}
+				`,
+			},
+			&action.NewIndex{
+				CollectionID: 0,
+				IndexName:    "UsersByName",
+				Fields:       []client.IndexedFieldDescription{{Name: "name"}},
+			},
+			&action.NewIndex{
+				CollectionID: 1,
+				IndexName:    "ProductsByTitle",
+				Fields:       []client.IndexedFieldDescription{{Name: "title"}},
+			},
+			&action.ListIndexes{
+				CollectionID: 0,
+				ExpectedIndexes: []client.IndexDescription{
+					{
+						Name:   "UsersByName",
+						ID:     1,
+						Fields: []client.IndexedFieldDescription{{Name: "name"}},
+					},
+				},
+				ExpectedCollectionName: "User",
+			},
+			&action.ListIndexes{
+				CollectionID: 1,
+				ExpectedIndexes: []client.IndexDescription{
+					{
+						Name:   "ProductsByTitle",
+						ID:     1,
+						Fields: []client.IndexedFieldDescription{{Name: "title"}},
+					},
+				},
+				ExpectedCollectionName: "Product",
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #5055 

## Description
This adds `CollectionName` to `client.ListIndexesResult`, populated on both the scoped and unscoped paths. Both call sites already had the name in scope, the map key on the all-collections path.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?
New tests:
- `tests/integration/index/list_collection_name_test.go`: scoped `collection.ListIndexes`, plus a multi-collection case proving each result names *its own* collection rather than just the first.
- `cli/test/integration/index/list_test.go`: `index list --collection` end-to-end.
- The existing unscoped CLI assertion was strengthened to require every element's name match its map key, covering `db.ListIndexes` through the real HTTP/CLI stack.


Specify the platform(s) on which this was tested:
- MacOS
