### PR TITLE
fix: read block ownership from a snapshot during history prune

### DIFF
--- a/internal/core/block/batch_signing.go
+++ b/internal/core/block/batch_signing.go
@@ -56,6 +56,26 @@ func (c *BatchCIDCollector) GetCIDs() []cid.Cid {
 	return out
 }
 
+// Len returns the number of collected CIDs.
+func (c *BatchCIDCollector) Len() int {
+	c.mu.Lock()
+	n := len(c.cids)
+	c.mu.Unlock()
+	return n
+}
+
+// Truncate keeps the first n collected CIDs and discards the rest. It panics if n is out
+// of range [0, Len], since that is a caller bug.
+func (c *BatchCIDCollector) Truncate(n int) {
+	c.mu.Lock()
+	if n < 0 || n > len(c.cids) {
+		c.mu.Unlock()
+		panic("coreblock: BatchCIDCollector.Truncate out of range")
+	}
+	c.cids = c.cids[:n]
+	c.mu.Unlock()
+}
+
 // ContextWithBatchSigning embeds a BatchCIDCollector into the context so that
 // code deep in the call stack can record CIDs without threading extra parameters.
 func ContextWithBatchSigning(ctx context.Context, collector *BatchCIDCollector) context.Context {

--- a/internal/core/block/batch_signing_test.go
+++ b/internal/core/block/batch_signing_test.go
@@ -1,0 +1,57 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package coreblock
+
+import (
+	"testing"
+
+	"github.com/ipfs/go-cid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBatchCIDCollector_LenTracksAddedCIDs(t *testing.T) {
+	collector := NewBatchCIDCollector()
+	require.Equal(t, 0, collector.Len())
+
+	collector.Add(newTestHeadsCID(t, []byte("a")))
+	collector.Add(newTestHeadsCID(t, []byte("b")))
+	require.Equal(t, 2, collector.Len())
+}
+
+func TestBatchCIDCollector_TruncateRollsBackToMark(t *testing.T) {
+	collector := NewBatchCIDCollector()
+	a := newTestHeadsCID(t, []byte("a"))
+	b := newTestHeadsCID(t, []byte("b"))
+	collector.Add(a)
+	collector.Add(b)
+
+	mark := collector.Len()
+	collector.Add(newTestHeadsCID(t, []byte("c")))
+	collector.Add(newTestHeadsCID(t, []byte("d")))
+	require.Equal(t, 4, collector.Len())
+
+	collector.Truncate(mark)
+	require.Equal(t, []cid.Cid{a, b}, collector.GetCIDs())
+}
+
+func TestBatchCIDCollector_TruncatePanicsOutOfRange(t *testing.T) {
+	collector := NewBatchCIDCollector()
+	a := newTestHeadsCID(t, []byte("a"))
+	b := newTestHeadsCID(t, []byte("b"))
+	collector.Add(a)
+	collector.Add(b)
+
+	require.Panics(t, func() { collector.Truncate(collector.Len() + 1) })
+	require.Panics(t, func() { collector.Truncate(-1) })
+
+	// The lock is released before the panic, so GetCIDs stays intact and does not deadlock.
+	require.Equal(t, []cid.Cid{a, b}, collector.GetCIDs())
+}

--- a/internal/db/collection_purge.go
+++ b/internal/db/collection_purge.go
@@ -91,8 +91,16 @@ func (c *collection) purgeChunk(
 
 	c.db.lockSet.CollectionLock(txn, shortID)
 
+	// Tracks owner edges this chunk deletes but has not yet committed. deleteBlocks checks
+	// ownership against a read-only snapshot that cannot see those uncommitted deletions, and a
+	// block may be owned by several documents in the chunk, so the set is chunk-wide.
+	var prunedOwners map[string]struct{}
+	if pruneHistory {
+		prunedOwners = make(map[string]struct{})
+	}
+
 	for _, docID := range docIDs {
-		if err := c.purgeOneDoc(ctx, shortID, docID, pruneHistory); err != nil {
+		if err := c.purgeOneDoc(ctx, shortID, docID, pruneHistory, prunedOwners); err != nil {
 			return err
 		}
 	}
@@ -105,6 +113,7 @@ func (c *collection) purgeOneDoc(
 	shortID uint32,
 	docID client.DocID,
 	pruneHistory bool,
+	prunedOwners map[string]struct{},
 ) error {
 	docShortID, found, err := id.GetDocShortID(ctx, shortID, docID.String())
 	if err != nil {
@@ -137,7 +146,7 @@ func (c *collection) purgeOneDoc(
 
 	systemstore := datastore.NewMultistore(c.db.rootstore, c.db.lockSet, c.db.blockStoreChunkSize).Systemstore()
 	if pruneHistory {
-		if err := c.hardDeleteDocumentBlocks(ctx, systemstore, docShortID); err != nil {
+		if err := c.hardDeleteDocumentBlocks(ctx, systemstore, docShortID, prunedOwners); err != nil {
 			return err
 		}
 	} else {

--- a/internal/db/collection_purge_test.go
+++ b/internal/db/collection_purge_test.go
@@ -16,11 +16,13 @@ import (
 	"testing"
 
 	badgerds "github.com/dgraph-io/badger/v4"
+	"github.com/ipfs/go-cid"
 	"github.com/stretchr/testify/require"
 
 	"github.com/sourcenetwork/corekv/badger"
 
 	"github.com/sourcenetwork/defradb/client"
+	"github.com/sourcenetwork/defradb/internal/datastore"
 	acpDB "github.com/sourcenetwork/defradb/internal/db/acp"
 	"github.com/sourcenetwork/defradb/internal/db/id"
 )
@@ -130,4 +132,102 @@ func TestPurgeByDocIDsRemovesIndexEntries(t *testing.T) {
 
 	require.Equal(t, 0, countIndexEntries(t, ctx, db, shortID, desc.ID),
 		"purge must delete the document's index entries")
+}
+
+// addSharedFieldDocs adds two User documents with the same name, so they share the name field
+// block, and different ages, so their age field and composite blocks differ.
+func addSharedFieldDocs(t *testing.T, ctx context.Context, col client.Collection) (*client.Document, *client.Document) {
+	t.Helper()
+
+	docA, err := client.NewDocFromJSON(ctx, []byte(`{"name":"shared","age":1}`), col.Version())
+	require.NoError(t, err)
+	require.NoError(t, col.AddDocument(ctx, docA))
+
+	docB, err := client.NewDocFromJSON(ctx, []byte(`{"name":"shared","age":2}`), col.Version())
+	require.NoError(t, err)
+	require.NoError(t, col.AddDocument(ctx, docB))
+
+	return docA, docB
+}
+
+// sharedFieldBlock returns the one field block that the documents with composite heads headA and
+// headB have in common, failing if they do not share exactly one. Field blocks are
+// content-addressed and carry no document identity, so an identical field value yields a shared
+// block owned by both documents.
+func sharedFieldBlock(t *testing.T, ctx context.Context, db *DB, headA, headB cid.Cid) cid.Cid {
+	t.Helper()
+
+	inB := make(map[cid.Cid]struct{})
+	for _, link := range loadTestBlock(t, ctx, db, headB).Links {
+		inB[link.Cid] = struct{}{}
+	}
+
+	var shared []cid.Cid
+	for _, link := range loadTestBlock(t, ctx, db, headA).Links {
+		if _, ok := inB[link.Cid]; ok {
+			shared = append(shared, link.Cid)
+		}
+	}
+	require.Len(t, shared, 1, "documents must share exactly one field block")
+	return shared[0]
+}
+
+func requireBlockPresent(t *testing.T, ctx context.Context, bs datastore.Blockstore, blockCID cid.Cid, want bool) {
+	t.Helper()
+	_, found, err := getBlock(ctx, bs, blockCID)
+	require.NoError(t, err)
+	require.Equal(t, want, found)
+}
+
+// TestPurgeByDocIDsPruneHistoryKeepsBlockOwnedByAnotherDoc checks that pruning one document's
+// history keeps a field block a second document still owns, and removes it once the second
+// document is pruned too. The two purges run in separate transactions, so the second reads the
+// first's edge deletion from committed state.
+func TestPurgeByDocIDsPruneHistoryKeepsBlockOwnedByAnotherDoc(t *testing.T) {
+	ctx := context.Background()
+	db, err := newBadgerDB(ctx)
+	require.NoError(t, err)
+	defer db.Close()
+
+	_, err = db.AddCollection(ctx, userDocIDTestSchema)
+	require.NoError(t, err)
+	col, err := db.GetCollectionByName(ctx, "User")
+	require.NoError(t, err)
+
+	docA, docB := addSharedFieldDocs(t, ctx, col)
+	shared := sharedFieldBlock(t, ctx, db, docA.Head(), docB.Head())
+
+	bs := datastore.BlockstoreFrom(db.rootstore, db.blockStoreChunkSize)
+	requireBlockPresent(t, ctx, bs, shared, true)
+
+	require.NoError(t, col.PurgeByDocIDs(ctx, []client.DocID{docA.ID()}, true))
+	requireBlockPresent(t, ctx, bs, shared, true)
+
+	require.NoError(t, col.PurgeByDocIDs(ctx, []client.DocID{docB.ID()}, true))
+	requireBlockPresent(t, ctx, bs, shared, false)
+}
+
+// TestPurgeByDocIDsPruneHistoryRemovesBlockWhenAllOwnersPurgedTogether checks the same block is
+// removed when both owners are purged in one chunk. Here the first document's edge deletion is
+// still uncommitted when the second is checked, so the per-chunk owner tracking is what lets the
+// shared block be recognised as unowned rather than leaked.
+func TestPurgeByDocIDsPruneHistoryRemovesBlockWhenAllOwnersPurgedTogether(t *testing.T) {
+	ctx := context.Background()
+	db, err := newBadgerDB(ctx)
+	require.NoError(t, err)
+	defer db.Close()
+
+	_, err = db.AddCollection(ctx, userDocIDTestSchema)
+	require.NoError(t, err)
+	col, err := db.GetCollectionByName(ctx, "User")
+	require.NoError(t, err)
+
+	docA, docB := addSharedFieldDocs(t, ctx, col)
+	shared := sharedFieldBlock(t, ctx, db, docA.Head(), docB.Head())
+
+	bs := datastore.BlockstoreFrom(db.rootstore, db.blockStoreChunkSize)
+	requireBlockPresent(t, ctx, bs, shared, true)
+
+	require.NoError(t, col.PurgeByDocIDs(ctx, []client.DocID{docA.ID(), docB.ID()}, true))
+	requireBlockPresent(t, ctx, bs, shared, false)
 }

--- a/internal/db/collection_truncate.go
+++ b/internal/db/collection_truncate.go
@@ -226,7 +226,7 @@ func (c *collection) hardDeleteDocKeysAndHeadstore(
 				// when the datastore read-locks are released.
 				if key.DocShortID != 0 {
 					if _, done := deletedDocIDs[key.DocShortID]; !done {
-						err = c.hardDeleteDocumentBlocks(ctx, systemstore, key.DocShortID)
+						err = c.hardDeleteDocumentBlocks(ctx, systemstore, key.DocShortID, nil)
 						if err != nil {
 							return err
 						}
@@ -329,6 +329,7 @@ func (c *collection) hardDeleteDocumentBlocks(
 	ctx context.Context,
 	systemstore corekv.ReaderWriter,
 	docShortID uint64,
+	prunedOwners map[string]struct{},
 ) error {
 	headstore := datastore.NewMultistore(c.db.rootstore, c.db.lockSet, c.db.blockStoreChunkSize).Headstore()
 	docID, _, err := id.GetDocIDFromStore(ctx, systemstore, docShortID)
@@ -379,7 +380,7 @@ func (c *collection) hardDeleteDocumentBlocks(
 		}
 
 		for _, key := range keysToDelete {
-			err = c.deleteBlocks(ctx, systemstore, docID, key.Cid)
+			err = c.deleteBlocks(ctx, systemstore, docID, key.Cid, prunedOwners)
 			if err != nil {
 				return NewErrTruncateDeleteBlocks(err, key.Cid.String())
 			}
@@ -455,7 +456,7 @@ func (c *collection) hardDeleteCollectionBlocks(
 			// the document blocks and their owner edges are deleted earlier in truncate (see the
 			// hardDeleteDocKeysAndHeadstore pass), so the collection-commit DAG walked here only
 			// re-encounters already-deleted document composites.
-			err = c.deleteBlocks(ctx, nil, "", key.Cid)
+			err = c.deleteBlocks(ctx, nil, "", key.Cid, nil)
 			if err != nil {
 				return NewErrTruncateDeleteBlocks(err, key.Cid.String())
 			}
@@ -486,6 +487,7 @@ func (c *collection) deleteBlocks(
 	systemstore corekv.ReaderWriter,
 	docID string,
 	currentCid cid.Cid,
+	prunedOwners map[string]struct{},
 ) error {
 	blockstore := datastore.NewMultistore(c.db.rootstore, c.db.lockSet, c.db.blockStoreChunkSize).Blockstore()
 
@@ -508,7 +510,18 @@ func (c *collection) deleteBlocks(
 		if err := id.DeleteBlockDocIDMapping(ctx, systemstore, blockCID, docID); err != nil {
 			return false, err
 		}
-		hasOwners, err := id.BlockHasOwners(ctx, systemstore, blockCID)
+
+		// Reading ownership from the purge's write transaction re-sorts its entire pending-write
+		// set on every block, which is quadratic over a chunk. When prunedOwners is set, read the
+		// read-only snapshot and exclude this chunk's uncommitted edge deletions instead. Truncate
+		// has no transaction here, so it reads ownership directly.
+		ownerCtx := ctx
+		if prunedOwners != nil {
+			prunedOwners[string(keys.NewBlockCIDToDocIDKey(blockCID.String(), docID).Bytes())] = struct{}{}
+			ownerCtx = readCtx
+		}
+
+		hasOwners, err := id.BlockHasOwnersExcept(ownerCtx, systemstore, blockCID, prunedOwners)
 		if err != nil {
 			return false, err
 		}

--- a/internal/db/id/document.go
+++ b/internal/db/id/document.go
@@ -198,6 +198,20 @@ func blockOwnersPrefix(blockCID cid.Cid) []byte {
 // GetDocIDsForBlockFromStore when only the presence of an owner matters: it stops at the
 // first match rather than materializing the whole owner set.
 func BlockHasOwners(ctx context.Context, store corekv.Reader, blockCID cid.Cid) (bool, error) {
+	return BlockHasOwnersExcept(ctx, store, blockCID, nil)
+}
+
+// BlockHasOwnersExcept reports whether any document owns blockCID, ignoring owner edges whose keys
+// are in excluded. It lets a caller read ownership from a read-only snapshot while treating edges
+// it deleted in a separate, uncommitted transaction as already gone. Excluded keys are
+// BlockCIDToDocIDKey bytes, as yielded by the owner-edge iterator; a nil set makes this a plain
+// ownership scan. It stops at the first surviving owner.
+func BlockHasOwnersExcept(
+	ctx context.Context,
+	store corekv.Reader,
+	blockCID cid.Cid,
+	excluded map[string]struct{},
+) (bool, error) {
 	if !blockCID.Defined() {
 		return false, nil
 	}
@@ -219,9 +233,13 @@ func BlockHasOwners(ctx context.Context, store corekv.Reader, blockCID cid.Cid) 
 		if !hasNext {
 			break
 		}
-		if len(bytes.TrimPrefix(iter.Key(), prefix)) != 0 {
-			return true, iter.Close()
+		if len(bytes.TrimPrefix(iter.Key(), prefix)) == 0 {
+			continue
 		}
+		if _, isExcluded := excluded[string(iter.Key())]; isExcluded {
+			continue
+		}
+		return true, iter.Close()
 	}
 	return false, iter.Close()
 }

--- a/internal/db/id/document_test.go
+++ b/internal/db/id/document_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/sourcenetwork/corekv/memory"
 	"github.com/sourcenetwork/defradb/internal/datastore"
 	"github.com/sourcenetwork/defradb/internal/db/lock"
+	"github.com/sourcenetwork/defradb/internal/keys"
 	"github.com/sourcenetwork/immutable"
 )
 
@@ -250,6 +251,80 @@ func TestBlockHasOwnersStopsAtFirstOwner(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, all, owners)
 	require.Greater(t, listReads, owners, "GetDocIDsForBlockFromStore reads every owner")
+}
+
+// blockOwnerKey builds the owner-edge key for (blockCID, docID) in the form BlockHasOwnersExcept
+// expects its excluded set to hold: the same bytes the owner-edge iterator yields.
+func blockOwnerKey(blockCID cid.Cid, docID string) string {
+	return string(keys.NewBlockCIDToDocIDKey(blockCID.String(), docID).Bytes())
+}
+
+// TestBlockHasOwnersExceptExcludedSoleOwner checks that a block whose only owner edge is in the
+// excluded set reports no owner, while the same block reports an owner when nothing is excluded.
+func TestBlockHasOwnersExceptExcludedSoleOwner(t *testing.T) {
+	ctx := context.Background()
+	txn := newDocumentIDTestTxn(ctx)
+	defer txn.Discard()
+	ctx = datastore.CtxSetTxn(ctx, txn)
+
+	fieldCID := blocks.NewBlock([]byte("field value")).Cid()
+	require.NoError(t, SetBlockDocIDMapping(ctx, fieldCID, "bae-doc-one"))
+
+	has, err := BlockHasOwnersExcept(ctx, txn.Systemstore(), fieldCID, nil)
+	require.NoError(t, err)
+	require.True(t, has, "with nothing excluded the block has an owner")
+
+	excluded := map[string]struct{}{blockOwnerKey(fieldCID, "bae-doc-one"): {}}
+	has, err = BlockHasOwnersExcept(ctx, txn.Systemstore(), fieldCID, excluded)
+	require.NoError(t, err)
+	require.False(t, has, "excluding the only owner edge reports no owner")
+}
+
+// TestBlockHasOwnersExceptKeepsUnexcludedOwner checks that a block shared by two documents still
+// reports an owner while any of its edges is unexcluded, and reports none only once all are.
+func TestBlockHasOwnersExceptKeepsUnexcludedOwner(t *testing.T) {
+	ctx := context.Background()
+	txn := newDocumentIDTestTxn(ctx)
+	defer txn.Discard()
+	ctx = datastore.CtxSetTxn(ctx, txn)
+
+	fieldCID := blocks.NewBlock([]byte("shared field value")).Cid()
+	require.NoError(t, SetBlockDocIDMapping(ctx, fieldCID, "bae-doc-one"))
+	require.NoError(t, SetBlockDocIDMapping(ctx, fieldCID, "bae-doc-two"))
+
+	excluded := map[string]struct{}{blockOwnerKey(fieldCID, "bae-doc-one"): {}}
+	has, err := BlockHasOwnersExcept(ctx, txn.Systemstore(), fieldCID, excluded)
+	require.NoError(t, err)
+	require.True(t, has, "one of two owners excluded: the block is still owned")
+
+	excluded[blockOwnerKey(fieldCID, "bae-doc-two")] = struct{}{}
+	has, err = BlockHasOwnersExcept(ctx, txn.Systemstore(), fieldCID, excluded)
+	require.NoError(t, err)
+	require.False(t, has, "both owners excluded: no owner remains")
+}
+
+// TestBlockHasOwnersExceptStopsAtFirstUnexcludedOwner checks the scan skips excluded owners but
+// stops at the first owner that is not excluded, rather than reading the whole owner set.
+func TestBlockHasOwnersExceptStopsAtFirstUnexcludedOwner(t *testing.T) {
+	ctx := context.Background()
+	txn := newDocumentIDTestTxn(ctx)
+	defer txn.Discard()
+	ctx = datastore.CtxSetTxn(ctx, txn)
+
+	fieldCID := blocks.NewBlock([]byte("shared field value")).Cid()
+	const owners = 500
+	for i := range owners {
+		require.NoError(t, SetBlockDocIDMapping(ctx, fieldCID, fmt.Sprintf("bae-doc-%03d", i)))
+	}
+
+	// Owner edges iterate in key order, so excluding the first makes the scan skip it and stop at
+	// the second: two advances, not one and not the whole set.
+	excluded := map[string]struct{}{blockOwnerKey(fieldCID, "bae-doc-000"): {}}
+	var reads int
+	has, err := BlockHasOwnersExcept(ctx, countingReader{txn.Systemstore(), &reads}, fieldCID, excluded)
+	require.NoError(t, err)
+	require.True(t, has)
+	require.Equal(t, 2, reads, "scan skips the excluded owner and stops at the next")
 }
 
 // countingReader wraps a corekv.Reader and tallies iterator advances so a test can assert

--- a/node/batch_signing.go
+++ b/node/batch_signing.go
@@ -38,6 +38,11 @@ func ContextWithBatchSigning(ctx context.Context, collector *BatchCIDCollector) 
 	return coreblock.ContextWithBatchSigning(ctx, collector)
 }
 
+// BatchSigningCollectorFromContext returns the BatchCIDCollector embedded in ctx, or nil.
+func BatchSigningCollectorFromContext(ctx context.Context) *BatchCIDCollector {
+	return coreblock.BatchSigningCollectorFromContext(ctx)
+}
+
 // IsBatchSigningEnabled returns true if a BatchCIDCollector is present in ctx.
 func IsBatchSigningEnabled(ctx context.Context) bool {
 	return coreblock.IsBatchSigningEnabled(ctx)


### PR DESCRIPTION
DefraDB's history prune (prune_history: true) is what keeps the block store from growing without bound. But turning it on froze the node.

Before deleting each old block, DefraDB checks whether any document still points to it. During a prune, it ran that check against the live delete transaction, which keeps growing as the prune deletes more, so the check re-scans an ever-larger set on every block and gets quadratically slower. It also holds a lock that new block writes need, so writes pile up behind it and the node stalls.

This runs the check against a read-only snapshot instead. A snapshot has nothing pending to scan, so the check stays fast and no longer blocks writes. The snapshot can't see the deletes happening in the current batch, so the code keeps a small list of what the batch has already deleted and leaves those out of the check, which gives the same answer without the slowdown. 