### PR TITLE
fix(rustffi): complete transaction and response parity

### DIFF
--- a/tests/clients/rustffi/defra.go
+++ b/tests/clients/rustffi/defra.go
@@ -658,6 +658,72 @@ func (t *Transaction) Mutate(mutation string) (*QueryResult, error) {
 	return t.Query(mutation)
 }
 
+// DeleteCollections deletes collections within the transaction.
+func (t *Transaction) DeleteCollections(identityDID string, targets []string, activeOnly bool) error {
+	cTxnID := C.CString(t.id)
+	defer C.free(unsafe.Pointer(cTxnID))
+
+	var cIdentityDID *C.char
+	if identityDID != "" {
+		cIdentityDID = C.CString(identityDID)
+		defer C.free(unsafe.Pointer(cIdentityDID))
+	}
+
+	targetsJSON, err := json.Marshal(targets)
+	if err != nil {
+		return fmt.Errorf("ffi: failed to marshal collection targets: %w", err)
+	}
+	cTargets := C.CString(string(targetsJSON))
+	defer C.free(unsafe.Pointer(cTargets))
+
+	result := C.delete_collections_in_txn(
+		t.node.ptr,
+		cTxnID,
+		cIdentityDID,
+		cTargets,
+		C.bool(activeOnly),
+	)
+	if result.status != 0 {
+		err := C.GoString(result.error)
+		C.defra_free_string(result.error)
+		return mapFFIError("delete_collections_in_txn", err)
+	}
+
+	C.defra_free_string(result.value)
+	return nil
+}
+
+// SetCollectionActive updates a collection version within the transaction.
+func (t *Transaction) SetCollectionActive(identityDID string, versionID string, isActive bool) error {
+	cTxnID := C.CString(t.id)
+	defer C.free(unsafe.Pointer(cTxnID))
+
+	var cIdentityDID *C.char
+	if identityDID != "" {
+		cIdentityDID = C.CString(identityDID)
+		defer C.free(unsafe.Pointer(cIdentityDID))
+	}
+
+	cVersionID := C.CString(versionID)
+	defer C.free(unsafe.Pointer(cVersionID))
+
+	result := C.set_collection_active_in_txn(
+		t.node.ptr,
+		cTxnID,
+		cIdentityDID,
+		cVersionID,
+		C.bool(isActive),
+	)
+	if result.status != 0 {
+		err := C.GoString(result.error)
+		C.defra_free_string(result.error)
+		return mapFFIError("set_collection_active_in_txn", err)
+	}
+
+	C.defra_free_string(result.value)
+	return nil
+}
+
 // ============================================================================
 // Collection Functions
 // ============================================================================
@@ -1147,6 +1213,12 @@ type IndexDescription struct {
 	Unique bool         `json:"Unique,omitempty"`
 }
 
+type IndexResult struct {
+	IndexDescription
+	CollectionName string                 `json:"CollectionName"`
+	Execution      client.ActionExecution `json:"Execution"`
+}
+
 // CreateIndex creates a new index on a collection.
 // Returns the created index description with assigned ID.
 func (n *Node) CreateIndex(identityDID string, collectionName string, indexName string, fields []IndexField, unique bool) (*IndexDescription, error) {
@@ -1221,7 +1293,7 @@ func (n *Node) DropIndex(identityDID string, collectionName string, indexName st
 }
 
 // GetIndexes returns all indexes for a collection.
-func (n *Node) GetIndexes(identityDID string, collectionName string) ([]IndexDescription, error) {
+func (n *Node) GetIndexes(identityDID string, collectionName string) ([]IndexResult, error) {
 	var cIdentityDID *C.char
 	if identityDID != "" {
 		cIdentityDID = C.CString(identityDID)
@@ -1242,7 +1314,7 @@ func (n *Node) GetIndexes(identityDID string, collectionName string) ([]IndexDes
 	value := C.GoString(result.value)
 	C.defra_free_string(result.value)
 
-	var indexes []IndexDescription
+	var indexes []IndexResult
 	if err := json.Unmarshal([]byte(value), &indexes); err != nil {
 		return nil, fmt.Errorf("ffi: failed to parse indexes: %w", err)
 	}
@@ -1251,7 +1323,7 @@ func (n *Node) GetIndexes(identityDID string, collectionName string) ([]IndexDes
 }
 
 // GetAllIndexes returns all indexes across all collections.
-func (n *Node) GetAllIndexes(identityDID string) (map[string][]IndexDescription, error) {
+func (n *Node) GetAllIndexes(identityDID string) (map[string][]IndexResult, error) {
 	var cIdentityDID *C.char
 	if identityDID != "" {
 		cIdentityDID = C.CString(identityDID)
@@ -1269,7 +1341,7 @@ func (n *Node) GetAllIndexes(identityDID string) (map[string][]IndexDescription,
 	value := C.GoString(result.value)
 	C.defra_free_string(result.value)
 
-	var indexes map[string][]IndexDescription
+	var indexes map[string][]IndexResult
 	if err := json.Unmarshal([]byte(value), &indexes); err != nil {
 		return nil, fmt.Errorf("ffi: failed to parse indexes: %w", err)
 	}

--- a/tests/clients/rustffi/defra.h
+++ b/tests/clients/rustffi/defra.h
@@ -118,12 +118,12 @@ typedef struct NodeInitOptions {
   int enable_signing;
   /*
    Optional: signing key type string (e.g. "secp256k1", "secp256r1", "ed25519").
-   Null to auto-generate secp256k1.
+   Only used when signing_private_key is provided.
    */
   const char *signing_key_type;
   /*
-   Optional: raw private key bytes for signing.
-   Null to auto-generate.
+   Optional: raw private key bytes used for the node identity.
+   Block signing remains controlled by enable_signing.
    */
   const uint8_t *signing_private_key;
   /*
@@ -1015,6 +1015,31 @@ struct FfiResult gc_downsample_histories(uintptr_t node_ptr, const char *options
 struct FfiResult delete_collection(uintptr_t node_ptr, const char *identity_did, const char *name);
 
 /*
+ Delete one or more collections by name.
+
+ # Safety
+
+ `names_json` must be a valid null-terminated UTF-8 JSON array of strings.
+ */
+struct FfiResult delete_collections(uintptr_t node_ptr,
+                                    const char *identity_did,
+                                    const char *names_json,
+                                    bool active_only);
+
+/*
+ Delete collections or collection versions within an existing transaction.
+
+ # Safety
+
+ `txn_id` and `targets_json` must be valid null-terminated UTF-8 strings.
+ */
+struct FfiResult delete_collections_in_txn(uintptr_t node_ptr,
+                                           const char *txn_id,
+                                           const char *identity_did,
+                                           const char *targets_json,
+                                           bool active_only);
+
+/*
  Set the active collection version.
 
  This activates the collection with the given version ID and deactivates
@@ -1037,6 +1062,19 @@ struct FfiResult delete_collection(uintptr_t node_ptr, const char *identity_did,
 struct FfiResult set_active_collection_version(uintptr_t node_ptr,
                                                const char *identity_did,
                                                const char *version_id);
+
+/*
+ Set a collection version's active state within an existing transaction.
+
+ # Safety
+
+ `txn_id` and `version_id` must be valid null-terminated UTF-8 strings.
+ */
+struct FfiResult set_collection_active_in_txn(uintptr_t node_ptr,
+                                              const char *txn_id,
+                                              const char *identity_did,
+                                              const char *version_id,
+                                              bool is_active);
 
 /*
  Patch a collection's schema using JSON patch operations.

--- a/tests/clients/rustffi/defra.h
+++ b/tests/clients/rustffi/defra.h
@@ -588,6 +588,15 @@ struct FfiResult delete_nac_actor_relationship(uintptr_t node_ptr,
                                                const char *target_did);
 
 /*
+ List actions that are in progress or ended with an error.
+
+ # Safety
+
+ `identity_did` must be null or a valid null-terminated UTF-8 string.
+ */
+struct FfiResult list_actions(uintptr_t node_ptr, const char *identity_did);
+
+/*
  Export the database to a JSON file.
 
  The config_json parameter is a JSON string matching Go's BackupConfig:
@@ -1731,6 +1740,24 @@ struct FfiResult exec_request(uintptr_t node_ptr,
                               const char *batch_session_id);
 
 /*
+ Execute a GraphQL query or mutation with a request-scoped signing override.
+
+ `signing_override` accepts `-1` for the node default, `0` to disable signing,
+ and `1` to enable signing.
+
+ # Safety
+
+ All string pointers must be either null or valid null-terminated UTF-8 strings.
+ */
+struct FfiResult exec_request_with_signing(uintptr_t node_ptr,
+                                           const char *identity_did,
+                                           const char *request_query,
+                                           const char *operation_name,
+                                           const char *variables,
+                                           const char *batch_session_id,
+                                           int signing_override);
+
+/*
  Add a schema to the database.
 
  The schema should be a GraphQL SDL string defining types.
@@ -1922,6 +1949,25 @@ struct FfiResult exec_request_in_txn(uintptr_t node_ptr,
                                      const char *operation_name,
                                      const char *variables,
                                      const char *batch_session_id);
+
+/*
+ Execute a GraphQL query or mutation within a transaction with a signing override.
+
+ `signing_override` accepts `-1` for the node default, `0` to disable signing,
+ and `1` to enable signing.
+
+ # Safety
+
+ All string pointers must be either null or valid null-terminated UTF-8 strings.
+ */
+struct FfiResult exec_request_in_txn_with_signing(uintptr_t node_ptr,
+                                                  const char *txn_id,
+                                                  const char *identity_did,
+                                                  const char *request_query,
+                                                  const char *operation_name,
+                                                  const char *variables,
+                                                  const char *batch_session_id,
+                                                  int signing_override);
 
 /*
  Begin a new transaction.

--- a/tests/clients/rustffi/response_values_test.go
+++ b/tests/clients/rustffi/response_values_test.go
@@ -1,0 +1,46 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// This file is part of the DefraDB test suite.
+//
+// The DefraDB test suite is licensed under either:
+//
+//   (1) GNU Affero General Public License v3
+//   (2) Business Source License 1.1
+//
+// See tests/LICENSE for details.
+
+//go:build rust_ffi
+
+package rustffi
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcenetwork/defradb/client"
+	"github.com/sourcenetwork/immutable"
+)
+
+func TestNormalizeCollectionDateTimesPreservesNullableElements(t *testing.T) {
+	first := time.Date(2026, time.July, 30, 12, 0, 0, 0, time.UTC)
+	second := first.Add(time.Hour)
+	value := map[string]any{
+		"times": []any{first, nil, second},
+	}
+	version := client.CollectionVersion{
+		Fields: []client.CollectionFieldDescription{{
+			Name: "times",
+			Kind: client.FieldKind_NILLABLE_DATETIME_ARRAY,
+		}},
+	}
+
+	normalizeCollectionDateTimes(value, version)
+
+	require.Equal(t, []immutable.Option[time.Time]{
+		immutable.Some(first),
+		immutable.None[time.Time](),
+		immutable.Some(second),
+	}, value["times"])
+}

--- a/tests/clients/rustffi/wrapper.go
+++ b/tests/clients/rustffi/wrapper.go
@@ -879,65 +879,6 @@ func (w *Wrapper) ExecRequest(
 	return &client.RequestResult{GQL: gqlResult}
 }
 
-// emitMutationEvents parses GQL mutation results and publishes update events
-// for each affected document.
-func (w *Wrapper) emitMutationEvents(ctx context.Context, data any) {
-	dataMap, ok := data.(map[string]any)
-	if !ok {
-		return
-	}
-	for key, value := range dataMap {
-		var collectionName string
-		if strings.HasPrefix(key, "create_") {
-			collectionName = strings.TrimPrefix(key, "create_")
-		} else if strings.HasPrefix(key, "update_") {
-			collectionName = strings.TrimPrefix(key, "update_")
-		} else if strings.HasPrefix(key, "delete_") {
-			collectionName = strings.TrimPrefix(key, "delete_")
-		} else {
-			continue
-		}
-
-		col, err := w.GetCollectionByName(ctx, collectionName)
-		if err != nil {
-			continue
-		}
-		cw, ok := col.(*CollectionWrapper)
-		if !ok {
-			continue
-		}
-
-		docs, ok := value.([]any)
-		if !ok {
-			continue
-		}
-		for _, d := range docs {
-			doc, ok := d.(map[string]any)
-			if !ok {
-				continue
-			}
-			docID, _ := doc["_docID"].(string)
-			if docID == "" {
-				continue
-			}
-			compositeCid := cw.getLatestCompositeCID(ctx, docID)
-			w.events.Publish(event.NewMessage(event.UpdateName, event.Update{
-				DocID:        docID,
-				CollectionID: cw.version.CollectionID,
-				Cid:          compositeCid,
-			}))
-
-			if cw.version.IsBranchable {
-				w.events.Publish(event.NewMessage(event.UpdateName, event.Update{
-					DocID:        "",
-					CollectionID: cw.version.CollectionID,
-					Cid:          compositeCid,
-				}))
-			}
-		}
-	}
-}
-
 // pollGraphQLSubscription polls a GraphQL subscription and sends results to the channel.
 func (w *Wrapper) pollGraphQLSubscription(ctx context.Context, subscriptionID string, ch chan client.GQLResult) {
 	defer close(ch)
@@ -1658,8 +1599,6 @@ func (w *Wrapper) ListIndexes(
 		return nil, err
 	}
 
-	// Rust completes index creation synchronously, so returned indexes are
-	// immediately ready.
 	indexes := make(map[client.CollectionName][]client.ListIndexesResult)
 	for name, descs := range result {
 		converted := make([]client.ListIndexesResult, len(descs))
@@ -2989,15 +2928,15 @@ func (c *CollectionWrapper) AddDocument(ctx context.Context, doc *client.Documen
 		}
 		params += ", encryptFields: [" + strings.Join(quoted, ", ") + "]"
 	}
-	mutation := fmt.Sprintf(`mutation { create_%s(%s) { _docID } }`, c.version.Name, params)
+	mutation := fmt.Sprintf(`mutation { add_%s(%s) { _docID } }`, c.version.Name, params)
 	result := c.execRequest(ctx, mutation, execRequestWithIdentity(opt.GetIdentity()))
 	if len(result.GQL.Errors) > 0 {
 		return result.GQL.Errors[0]
 	}
 
-	// Extract docID from the response and publish update events
+	// Replace the provisional Go ID with the ID calculated by Rust.
 	if data, ok := result.GQL.Data.(map[string]any); ok {
-		mutationKey := "create_" + c.version.Name
+		mutationKey := "add_" + c.version.Name
 		if mutResult, ok := data[mutationKey].([]any); ok && len(mutResult) > 0 {
 			if docData, ok := mutResult[0].(map[string]any); ok {
 				if docID, ok := docData["_docID"].(string); ok {
@@ -3181,35 +3120,9 @@ func (c *CollectionWrapper) UpdateDocumentsWithFilter(
 	updater string,
 	opts ...options.Enumerable[options.UpdateDocumentsWithFilterOptions],
 ) (*client.UpdateResult, error) {
-	// Validate filter (mirrors Go's collection_update.go makeSelectionPlan validation)
-	var gqlFilter string
-	switch f := filter.(type) {
-	case string:
-		if f == "" {
-			return nil, fmt.Errorf("filter cannot be empty")
-		}
-		// String filters may be in relaxed JSON/GQL format (unquoted keys).
-		// Try parsing as JSON first; if that fails, use as-is (GQL format).
-		var parsed map[string]any
-		if err := json.Unmarshal([]byte(f), &parsed); err != nil {
-			// Not valid JSON - could be relaxed GQL format like {name: {_eq: "John"}}.
-			// Validate by attempting to parse with fastjson-compatible check.
-			if !isRelaxedJSONObject(f) {
-				return nil, fmt.Errorf("cannot parse JSON: cannot parse object")
-			}
-			gqlFilter = f
-		} else {
-			filterJSON, _ := json.Marshal(parsed)
-			gqlFilter = jsonToGraphQLInput(string(filterJSON))
-		}
-	case map[string]any:
-		filterJSON, err := json.Marshal(f)
-		if err != nil {
-			return nil, fmt.Errorf("failed to marshal filter: %w", err)
-		}
-		gqlFilter = jsonToGraphQLInput(string(filterJSON))
-	default:
-		return nil, fmt.Errorf("invalid filter")
+	gqlFilter, err := mutationFilterToGraphQLInput(filter)
+	if err != nil {
+		return nil, err
 	}
 
 	// Validate updater (mirrors Go's collection_update.go fastjson.Parse validation)
@@ -3253,6 +3166,37 @@ func (c *CollectionWrapper) UpdateDocumentsWithFilter(
 		}
 	}
 	return updateResult, nil
+}
+
+func mutationFilterToGraphQLInput(filter any) (string, error) {
+	switch value := filter.(type) {
+	case string:
+		if value == "" {
+			return "", fmt.Errorf("filter cannot be empty")
+		}
+
+		var parsed map[string]any
+		if err := json.Unmarshal([]byte(value), &parsed); err != nil {
+			if !isRelaxedJSONObject(value) {
+				return "", fmt.Errorf("cannot parse JSON: cannot parse object")
+			}
+			return value, nil
+		}
+
+		filterJSON, err := json.Marshal(parsed)
+		if err != nil {
+			return "", fmt.Errorf("failed to marshal filter: %w", err)
+		}
+		return jsonToGraphQLInput(string(filterJSON)), nil
+	case map[string]any:
+		filterJSON, err := json.Marshal(value)
+		if err != nil {
+			return "", fmt.Errorf("failed to marshal filter: %w", err)
+		}
+		return jsonToGraphQLInput(string(filterJSON)), nil
+	default:
+		return "", fmt.Errorf("invalid filter")
+	}
 }
 
 // isRelaxedJSONObject checks if a string looks like a JSON/GQL object (starts with { and ends with }).
@@ -3347,11 +3291,13 @@ func normalizeResponseDateTimes(
 	switch value := v.(type) {
 	case map[string]any:
 		for key, child := range value {
-			name := key
-			if separator := strings.LastIndexByte(key, '_'); separator >= 0 {
-				name = key[separator+1:]
+			version, ok := versions[key]
+			if !ok {
+				if separator := strings.LastIndexByte(key, '_'); separator >= 0 {
+					version, ok = versions[key[separator+1:]]
+				}
 			}
-			if version, ok := versions[name]; ok {
+			if ok {
 				value[key] = normalizeCollectionDateTimes(child, version)
 			} else {
 				value[key] = normalizeResponseDateTimes(child, versions)
@@ -3376,15 +3322,27 @@ func normalizeCollectionDateTimes(v any, version client.CollectionVersion) any {
 			if field.Kind.String() != "[DateTime]" {
 				continue
 			}
-			times, ok := value[field.Name].([]time.Time)
+			items, ok := value[field.Name].([]any)
 			if !ok {
 				continue
 			}
-			nullable := make([]immutable.Option[time.Time], len(times))
-			for i, item := range times {
-				nullable[i] = immutable.Some(item)
+			nullable := make([]immutable.Option[time.Time], len(items))
+			valid := true
+			for i, item := range items {
+				if item == nil {
+					nullable[i] = immutable.None[time.Time]()
+					continue
+				}
+				dateTime, ok := item.(time.Time)
+				if !ok {
+					valid = false
+					break
+				}
+				nullable[i] = immutable.Some(dateTime)
 			}
-			value[field.Name] = nullable
+			if valid {
+				value[field.Name] = nullable
+			}
 		}
 	}
 	return v
@@ -3492,13 +3450,11 @@ func decodeBase64Deltas(v any) any {
 
 func (c *CollectionWrapper) DeleteDocumentsWithFilter(ctx context.Context, filter any, opts ...options.Enumerable[options.DeleteDocumentsWithFilterOptions]) (*client.DeleteResult, error) {
 	opt := utils.NewOptions(opts...)
-	filterJSON, err := json.Marshal(filter)
+	gqlFilter, err := mutationFilterToGraphQLInput(filter)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal filter: %w", err)
+		return nil, err
 	}
 
-	// Convert JSON to GraphQL input format (unquoted keys)
-	gqlFilter := jsonToGraphQLInput(string(filterJSON))
 	mutation := fmt.Sprintf(`mutation { delete_%s(filter: %s) { _docID } }`, c.version.Name, gqlFilter)
 	result := c.execRequest(ctx, mutation, execRequestWithIdentity(opt.GetIdentity()))
 	if len(result.GQL.Errors) > 0 {

--- a/tests/clients/rustffi/wrapper.go
+++ b/tests/clients/rustffi/wrapper.go
@@ -138,6 +138,8 @@ type Wrapper struct {
 	stopSEForwarder chan struct{}
 	goNodeCloser    func()                      // Called during Close() to release Go node resources (e.g. badger lock)
 	nodeIdentityRaw *identity.PublicRawIdentity // Cached node identity (with PublicKey) for GetNodeIdentity
+	collectionsMu   sync.RWMutex
+	collections     map[string]client.CollectionVersion
 }
 
 type rustFFIP2PRegistryEntry struct {
@@ -438,6 +440,7 @@ func NewWrapper(
 		node:            node,
 		events:          eb,
 		stopMergePoller: stopCh,
+		collections:     make(map[string]client.CollectionVersion),
 	}
 	if nodeIdentity != nil {
 		raw := nodeIdentity.ToPublicRawIdentity()
@@ -593,6 +596,7 @@ func NewWrapperWithP2P(
 		node:            node,
 		events:          eb,
 		stopMergePoller: stopCh,
+		collections:     make(map[string]client.CollectionVersion),
 	}
 	if nodeIdentity != nil {
 		raw := nodeIdentity.ToPublicRawIdentity()
@@ -860,7 +864,7 @@ func (w *Wrapper) ExecRequest(
 	// Post-process: convert DateTime strings to time.Time objects so test
 	// assertions can compare them with MustParseTime/CurrentTimestamp values.
 	if gqlResult.Data != nil {
-		gqlResult.Data = convertDateTimeStrings(gqlResult.Data)
+		gqlResult.Data = w.convertResponseValues(gqlResult.Data)
 		gqlResult.Data = decodeBase64Deltas(gqlResult.Data)
 		if isExplainResult(gqlResult.Data) {
 			gqlResult.Data = normalizeExplainTypes(gqlResult.Data)
@@ -973,7 +977,7 @@ func (w *Wrapper) pollGraphQLSubscription(ctx context.Context, subscriptionID st
 
 			// Post-process: convert DateTime strings and base64 deltas
 			if gqlResult.Data != nil {
-				gqlResult.Data = convertDateTimeStrings(gqlResult.Data)
+				gqlResult.Data = w.convertResponseValues(gqlResult.Data)
 				gqlResult.Data = decodeBase64Deltas(gqlResult.Data)
 			}
 
@@ -1002,6 +1006,7 @@ func (w *Wrapper) AddCollection(ctx context.Context, sdl string, opts ...options
 	if err := json.Unmarshal([]byte(responseJSON), &versions); err != nil {
 		return nil, fmt.Errorf("failed to parse schema response: %w", err)
 	}
+	w.cacheCollectionVersions(versions)
 
 	return versions, nil
 }
@@ -1075,6 +1080,7 @@ func (w *Wrapper) GetCollections(
 	if err := json.Unmarshal([]byte(responseJSON), &versions); err != nil {
 		return nil, fmt.Errorf("failed to parse collections: %w", err)
 	}
+	w.cacheCollectionVersions(versions)
 
 	// Apply filters
 	includeInactive := opt.GetInactive.HasValue() && opt.GetInactive.Value()
@@ -1666,16 +1672,14 @@ func (w *Wrapper) ListIndexes(
 				}
 			}
 			converted[i] = client.ListIndexesResult{
-				CollectionName: string(name),
+				CollectionName: d.CollectionName,
 				Description: client.IndexDescription{
 					Name:   d.Name,
 					ID:     d.ID,
 					Fields: fields,
 					Unique: d.Unique,
 				},
-				Execution: client.ActionExecution{
-					Status: client.CompletedActionStatus,
-				},
+				Execution: d.Execution,
 			}
 		}
 		indexes[name] = converted
@@ -1889,6 +1893,7 @@ func (w *Wrapper) AddView(
 	if err := json.Unmarshal([]byte(responseJSON), &versions); err != nil {
 		return nil, fmt.Errorf("failed to parse view response: %w", err)
 	}
+	w.cacheCollectionVersions(versions)
 
 	return versions, nil
 }
@@ -2274,23 +2279,16 @@ type TxnWrapper struct {
 	readOnly                bool
 	startTS                 time.Time
 	stagedPatchCollections  []stagedPatchCollection
-	stagedSetActiveVersions []stagedSetActiveVersion
 	stagedViews             []stagedViewAdd
 	stagedRefreshes         []stagedRefreshViews
 	stagedIndexOps          []stagedIndexOp
 	stagedEncryptedIndexOps []stagedEncryptedIndexOp
-	stagedInactiveVersions  map[string]struct{}
 }
 
 type stagedPatchCollection struct {
 	identityDID string
 	patch       string
 	migration   immutable.Option[lensmodel.Lens]
-}
-
-type stagedSetActiveVersion struct {
-	identityDID string
-	versionID   string
 }
 
 type stagedViewAdd struct {
@@ -2336,12 +2334,6 @@ func (t *TxnWrapper) Commit() error {
 
 	for _, op := range t.stagedPatchCollections {
 		if err := t.wrapper.patchCollection(op.identityDID, op.patch, op.migration); err != nil {
-			return err
-		}
-	}
-
-	for _, op := range t.stagedSetActiveVersions {
-		if err := t.wrapper.setActiveCollectionVersion(op.identityDID, op.versionID); err != nil {
 			return err
 		}
 	}
@@ -2440,7 +2432,7 @@ func (t *TxnWrapper) ExecRequest(
 	}
 
 	if gqlResult.Data != nil {
-		gqlResult.Data = convertDateTimeStrings(gqlResult.Data)
+		gqlResult.Data = t.wrapper.convertResponseValues(gqlResult.Data)
 		if isExplainResult(gqlResult.Data) {
 			gqlResult.Data = normalizeExplainTypes(gqlResult.Data)
 		}
@@ -2463,6 +2455,7 @@ func (t *TxnWrapper) AddCollection(ctx context.Context, sdl string, opts ...opti
 	if err := json.Unmarshal([]byte(responseJSON), &versions); err != nil {
 		return nil, fmt.Errorf("failed to parse schema response: %w", err)
 	}
+	t.wrapper.cacheCollectionVersions(versions)
 
 	return versions, nil
 }
@@ -2494,7 +2487,7 @@ func (t *TxnWrapper) GetCollections(
 	if err := json.Unmarshal([]byte(responseJSON), &versions); err != nil {
 		return nil, fmt.Errorf("failed to parse collections: %w", err)
 	}
-	t.applyStagedCollectionState(versions)
+	t.wrapper.cacheCollectionVersions(versions)
 
 	// Apply filters
 	includeInactive := opt.GetInactive.HasValue() && opt.GetInactive.Value()
@@ -2526,11 +2519,7 @@ func (t *TxnWrapper) GetCollections(
 
 func (t *TxnWrapper) SetActiveCollectionVersion(ctx context.Context, versionID string, opts ...options.Enumerable[options.SetActiveCollectionVersionOptions]) error {
 	opt := utils.NewOptions(opts...)
-	t.stagedSetActiveVersions = append(t.stagedSetActiveVersions, stagedSetActiveVersion{
-		identityDID: identityDIDFromOption(opt.GetIdentity()),
-		versionID:   versionID,
-	})
-	return nil
+	return t.txn.SetCollectionActive(identityDIDFromOption(opt.GetIdentity()), versionID, true)
 }
 
 func (t *TxnWrapper) PatchCollection(
@@ -2541,13 +2530,53 @@ func (t *TxnWrapper) PatchCollection(
 ) error {
 	opt := utils.NewOptions(opts...)
 	identityDID := identityDIDFromOption(opt.GetIdentity())
-	if err := t.validateImmediatePatchCollection(ctx, identityDID, patch); err != nil {
-		return err
+
+	var operations []json.RawMessage
+	if err := json.Unmarshal([]byte(patch), &operations); err != nil {
+		return fmt.Errorf("failed to parse patch JSON: %w", err)
 	}
-	t.recordStagedCollectionState(identityDID, patch)
+
+	var remaining []json.RawMessage
+	for _, raw := range operations {
+		var operation struct {
+			Op    string          `json:"op"`
+			Path  string          `json:"path"`
+			Value json.RawMessage `json:"value"`
+		}
+		if err := json.Unmarshal(raw, &operation); err != nil {
+			return fmt.Errorf("failed to parse patch operation: %w", err)
+		}
+		path := strings.TrimPrefix(operation.Path, "/")
+		parts := strings.Split(path, "/")
+		switch {
+		case operation.Op == "remove" && len(parts) == 1:
+			if err := t.txn.DeleteCollections(identityDID, parts, false); err != nil {
+				return err
+			}
+		case (operation.Op == "add" || operation.Op == "replace") &&
+			len(parts) == 2 && parts[1] == "IsActive":
+			var isActive bool
+			if err := json.Unmarshal(operation.Value, &isActive); err != nil {
+				return fmt.Errorf("failed to parse IsActive value: %w", err)
+			}
+			if err := t.txn.SetCollectionActive(identityDID, parts[0], isActive); err != nil {
+				return err
+			}
+		default:
+			remaining = append(remaining, raw)
+		}
+	}
+
+	if len(remaining) == 0 {
+		return nil
+	}
+	remainingPatch, err := json.Marshal(remaining)
+	if err != nil {
+		return fmt.Errorf("failed to marshal patch operations: %w", err)
+	}
 	t.stagedPatchCollections = append(t.stagedPatchCollections, stagedPatchCollection{
 		identityDID: identityDID,
-		patch:       patch,
+		patch:       string(remainingPatch),
 		migration:   migration,
 	})
 	return nil
@@ -2559,190 +2588,11 @@ func (t *TxnWrapper) DeleteCollection(
 	opts ...options.Enumerable[options.DeleteCollectionOptions],
 ) error {
 	opt := utils.NewOptions(opts...)
-	ident := opt.GetIdentity()
-
-	patch, err := buildDeleteCollectionPatch(
+	return t.txn.DeleteCollections(
+		identityDIDFromOption(opt.GetIdentity()),
 		names,
 		opt.ActiveOnly,
-		func(name string) (client.Collection, error) {
-			getOpts := options.GetCollectionByName()
-			if ident.HasValue() {
-				getOpts.SetIdentity(ident.Value())
-			}
-			return t.GetCollectionByName(ctx, client.CollectionName(name), getOpts)
-		},
-		func(collectionID string) ([]client.Collection, error) {
-			getOpts := options.GetCollections().
-				SetCollectionID(collectionID).
-				SetGetInactive(true)
-			if ident.HasValue() {
-				getOpts.SetIdentity(ident.Value())
-			}
-			return t.GetCollections(ctx, getOpts)
-		},
 	)
-	if err != nil {
-		return err
-	}
-
-	t.stagedPatchCollections = append(t.stagedPatchCollections, stagedPatchCollection{
-		identityDID: identityDIDFromOption(ident),
-		patch:       patch,
-		migration:   immutable.None[lensmodel.Lens](),
-	})
-	return nil
-}
-
-func (t *TxnWrapper) rawCollectionsInTxn(identityDID string) ([]client.CollectionVersion, error) {
-	responseJSON, err := t.wrapper.node.GetCollectionsInTxn(t.txn.id, identityDID)
-	if err != nil {
-		return nil, err
-	}
-
-	var versions []client.CollectionVersion
-	if err := json.Unmarshal([]byte(responseJSON), &versions); err != nil {
-		return nil, fmt.Errorf("failed to parse collections: %w", err)
-	}
-	return versions, nil
-}
-
-func (t *TxnWrapper) applyStagedCollectionState(versions []client.CollectionVersion) {
-	if len(t.stagedInactiveVersions) == 0 {
-		return
-	}
-	for i := range versions {
-		if _, ok := t.stagedInactiveVersions[versions[i].VersionID]; ok {
-			versions[i].IsActive = false
-		}
-	}
-}
-
-func (t *TxnWrapper) recordStagedCollectionState(identityDID string, patch string) {
-	type patchOp struct {
-		Op    string          `json:"op"`
-		Path  string          `json:"path"`
-		Value json.RawMessage `json:"value"`
-	}
-
-	var ops []patchOp
-	if err := json.Unmarshal([]byte(patch), &ops); err != nil {
-		return
-	}
-
-	var txnVersions []client.CollectionVersion
-	for _, op := range ops {
-		if op.Op != "replace" || !strings.HasSuffix(op.Path, "/IsActive") {
-			continue
-		}
-		var isActive bool
-		if err := json.Unmarshal(op.Value, &isActive); err != nil || isActive {
-			continue
-		}
-		if txnVersions == nil {
-			var err error
-			txnVersions, err = t.rawCollectionsInTxn(identityDID)
-			if err != nil {
-				return
-			}
-		}
-		target := strings.TrimPrefix(strings.TrimSuffix(op.Path, "/IsActive"), "/")
-		version, ok := findCollectionVersion(txnVersions, target)
-		if !ok {
-			continue
-		}
-		if t.stagedInactiveVersions == nil {
-			t.stagedInactiveVersions = make(map[string]struct{})
-		}
-		t.stagedInactiveVersions[version.VersionID] = struct{}{}
-	}
-}
-
-func (t *TxnWrapper) validateImmediatePatchCollection(
-	ctx context.Context,
-	identityDID string,
-	patch string,
-) error {
-	removeTargets, err := collectionLevelRemoveTargets(patch)
-	if err != nil || len(removeTargets) == 0 {
-		return err
-	}
-
-	txnVersions, err := t.rawCollectionsInTxn(identityDID)
-	if err != nil {
-		return err
-	}
-
-	for _, target := range removeTargets {
-		version, ok := findCollectionVersion(txnVersions, target)
-		if !ok {
-			continue
-		}
-		hasDocs, err := t.collectionHasDocumentsInTxn(ctx, version.Name)
-		if err != nil {
-			continue
-		}
-		if hasDocs {
-			return fmt.Errorf("cannot delete a collection that has documents")
-		}
-	}
-
-	return nil
-}
-
-func (t *TxnWrapper) collectionHasDocumentsInTxn(ctx context.Context, collectionName string) (bool, error) {
-	result := t.ExecRequest(ctx, fmt.Sprintf("query { %s { _docID } }", collectionName))
-	if len(result.GQL.Errors) > 0 {
-		return false, result.GQL.Errors[0]
-	}
-
-	data, ok := result.GQL.Data.(map[string]any)
-	if !ok {
-		return false, nil
-	}
-	items, ok := data[collectionName].([]any)
-	return ok && len(items) > 0, nil
-}
-
-func collectionLevelRemoveTargets(patch string) ([]string, error) {
-	type patchOp struct {
-		Op   string `json:"op"`
-		Path string `json:"path"`
-	}
-
-	var ops []patchOp
-	if err := json.Unmarshal([]byte(patch), &ops); err != nil {
-		return nil, err
-	}
-
-	targets := make([]string, 0)
-	for _, op := range ops {
-		if op.Op != "remove" {
-			continue
-		}
-		target := strings.TrimPrefix(op.Path, "/")
-		if target == "" || strings.Contains(target, "/") {
-			continue
-		}
-		targets = append(targets, target)
-	}
-	return targets, nil
-}
-
-func findCollectionVersion(
-	versions []client.CollectionVersion,
-	nameOrVersionID string,
-) (client.CollectionVersion, bool) {
-	for _, version := range versions {
-		if version.VersionID == nameOrVersionID {
-			return version, true
-		}
-	}
-	for _, version := range versions {
-		if version.Name == nameOrVersionID && version.IsActive {
-			return version, true
-		}
-	}
-	return client.CollectionVersion{}, false
 }
 
 func (t *TxnWrapper) ListIndexes(
@@ -3467,6 +3317,79 @@ func convertDateTimeStrings(v any) any {
 	}
 }
 
+func (w *Wrapper) cacheCollectionVersions(versions []client.CollectionVersion) {
+	w.collectionsMu.Lock()
+	defer w.collectionsMu.Unlock()
+	for _, version := range versions {
+		if version.IsActive {
+			w.collections[version.Name] = version
+		}
+	}
+}
+
+func (w *Wrapper) convertResponseValues(v any) any {
+	converted := convertDateTimeStrings(v)
+
+	w.collectionsMu.RLock()
+	versions := make(map[string]client.CollectionVersion, len(w.collections))
+	for name, version := range w.collections {
+		versions[name] = version
+	}
+	w.collectionsMu.RUnlock()
+
+	return normalizeResponseDateTimes(converted, versions)
+}
+
+func normalizeResponseDateTimes(
+	v any,
+	versions map[string]client.CollectionVersion,
+) any {
+	switch value := v.(type) {
+	case map[string]any:
+		for key, child := range value {
+			name := key
+			if separator := strings.LastIndexByte(key, '_'); separator >= 0 {
+				name = key[separator+1:]
+			}
+			if version, ok := versions[name]; ok {
+				value[key] = normalizeCollectionDateTimes(child, version)
+			} else {
+				value[key] = normalizeResponseDateTimes(child, versions)
+			}
+		}
+	case []any:
+		for i, child := range value {
+			value[i] = normalizeResponseDateTimes(child, versions)
+		}
+	}
+	return v
+}
+
+func normalizeCollectionDateTimes(v any, version client.CollectionVersion) any {
+	switch value := v.(type) {
+	case []any:
+		for i, child := range value {
+			value[i] = normalizeCollectionDateTimes(child, version)
+		}
+	case map[string]any:
+		for _, field := range version.Fields {
+			if field.Kind.String() != "[DateTime]" {
+				continue
+			}
+			times, ok := value[field.Name].([]time.Time)
+			if !ok {
+				continue
+			}
+			nullable := make([]immutable.Option[time.Time], len(times))
+			for i, item := range times {
+				nullable[i] = immutable.Some(item)
+			}
+			value[field.Name] = nullable
+		}
+	}
+	return v
+}
+
 // normalizeExplainTypes fixes type mismatches in explain results returned by the Rust FFI.
 // Go's native query planner produces uint64 for execution metrics and typed slices
 // ([]string, []map[string]any) for arrays. JSON decoding via convertDateTimeStrings
@@ -3635,7 +3558,10 @@ func (c *CollectionWrapper) GetDocument(ctx context.Context, docID client.DocID,
 	}
 
 	// Convert JSON types (json.Number -> int64/float64, datetime strings -> time.Time)
-	converted, ok := convertDateTimeStrings(docData).(map[string]any)
+	converted, ok := normalizeCollectionDateTimes(
+		convertDateTimeStrings(docData),
+		c.version,
+	).(map[string]any)
 	if !ok {
 		return nil, fmt.Errorf("unexpected type after date conversion")
 	}
@@ -3798,13 +3724,7 @@ func (c *CollectionWrapper) ListIndexes(
 		}
 		result := make([]client.ListIndexesResult, len(indexes))
 		for i, index := range indexes {
-			result[i] = client.ListIndexesResult{
-				CollectionName: c.version.Name,
-				Description:    index,
-				Execution: client.ActionExecution{
-					Status: client.CompletedActionStatus,
-				},
-			}
+			result[i] = completedIndex(c.version.Name, c.version.CollectionID, index)
 		}
 		return result, nil
 	}
@@ -3827,19 +3747,33 @@ func (c *CollectionWrapper) ListIndexes(
 			}
 		}
 		result[i] = client.ListIndexesResult{
-			CollectionName: c.version.Name,
+			CollectionName: idx.CollectionName,
 			Description: client.IndexDescription{
 				Name:   idx.Name,
 				ID:     idx.ID,
 				Fields: fields,
 				Unique: idx.Unique,
 			},
-			Execution: client.ActionExecution{
-				Status: client.CompletedActionStatus,
-			},
+			Execution: idx.Execution,
 		}
 	}
 	return result, nil
+}
+
+func completedIndex(
+	collectionName string,
+	collectionID string,
+	description client.IndexDescription,
+) client.ListIndexesResult {
+	return client.ListIndexesResult{
+		CollectionName: collectionName,
+		Description:    description,
+		Execution: client.ActionExecution{
+			CollectionID: collectionID,
+			Subject:      fmt.Sprint(description.ID),
+			Status:       client.CompletedActionStatus,
+		},
+	}
 }
 
 func (c *CollectionWrapper) NewEncryptedIndex(


### PR DESCRIPTION
## Summary

- route collection deletion and active-version changes through the real Rust transaction instead of applying them after commit
- preserve Rust index lifecycle metadata and collection names in list responses
- preserve nullable datetime array elements using the Go client’s typed optional representation
- align document-add and filter mutations with the current Go integration-test API
- refresh the generated C header and remove the obsolete manual mutation-event helper

This is the Go integration-test adapter companion to [sourcenetwork/defradb.rs#1261](https://github.com/sourcenetwork/defradb.rs/pull/1261). It targets `jack/ffi-rust-compat` because that branch currently carries the Rust FFI client.

## Verification

- all 4 transactional collection-version tests from defradb.rs#1249
- all 11 index lifecycle/query tests from defradb.rs#1255
- all 3 nullable datetime and mixed-delete-ID tests from defradb.rs#1256
- focused nullable datetime conversion unit test
- project `golangci-lint` configuration for `tests/clients/rustffi`: 0 issues
- generated `defra.h` matches `cbindgen` output from defradb.rs#1261
- `git diff --check`