### PR TITLE
fix(rustffi): reject empty disconnect lists

### DIFF
--- a/tests/clients/rustffi/wrapper.go
+++ b/tests/clients/rustffi/wrapper.go
@@ -2051,6 +2051,9 @@ func (w *Wrapper) Disconnect(
 	addresses []string,
 	opts ...options.Enumerable[options.DisconnectOptions],
 ) error {
+	if len(addresses) == 0 {
+		return fmt.Errorf("addresses cannot be empty")
+	}
 	opt := utils.NewOptions(opts...)
 	identityDID := identityDIDFromOption(opt.GetIdentity())
 


### PR DESCRIPTION
## Summary

- reject empty address lists in the Rust FFI disconnect wrapper before per-address dispatch
- return the same `addresses cannot be empty` validation error expected from other clients
- complete the peer-info acceptance coverage for [sourcenetwork/defradb.rs#1261](https://github.com/sourcenetwork/defradb.rs/pull/1261) and [sourcenetwork/defradb.rs#1257](https://github.com/sourcenetwork/defradb.rs/issues/1257)

## Verification

- [x] `TestNetInfoDisconnectEmptyList`
- [x] `net/info`: 7 passed, 0 failed
- [x] `net/simple/replicator`: 29 passed, 0 failed
- [x] `gofmt`
- [x] `git diff --check`