### PR TITLE
feat: reclaim orphaned blocks left by discarded merges

### DIFF
--- a/internal/core/block/store.go
+++ b/internal/core/block/store.go
@@ -276,6 +276,15 @@ func updateHeads(
 		return NewErrMarkingAsMerged(blockLink.Cid, err)
 	}
 
+	// A signature block is not in AllLinks, so nothing below clears its marker. Taking
+	// ownership and clearing the marker in one transaction is what lets a concurrent
+	// sweep conflict rather than reclaim the block.
+	if block.Signature != nil {
+		if err := txn.Blockstore().MarkAsMerged(ctx, block.Signature.Cid); err != nil {
+			return NewErrMarkingAsMerged(block.Signature.Cid, err)
+		}
+	}
+
 	for _, l := range block.AllLinks() {
 		linkCid := l.Cid
 		isHead, err := headset.IsHead(ctx, linkCid)

--- a/internal/core/block/store_test.go
+++ b/internal/core/block/store_test.go
@@ -16,7 +16,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	blocks "github.com/ipfs/go-block-format"
 	"github.com/ipfs/go-cid"
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 
 	"github.com/sourcenetwork/corekv/memory"
 	"github.com/sourcenetwork/defradb/acp/identity"
@@ -108,4 +110,39 @@ func TestAddDelta_WithoutBatchCollector_SignsBlock(t *testing.T) {
 	block, err := GetFromBytes(rawBlock)
 	require.NoError(t, err)
 	require.NotNil(t, block.Signature)
+}
+
+// A signature block is not among a block's links, so its marker has to be cleared
+// alongside the block's own. Left marked, it stays eligible for the sweep for the life
+// of the store.
+func TestProcessBlock_ClearsSignatureMarker(t *testing.T) {
+	ctx := context.Background()
+	store := memory.NewDatastore(ctx)
+
+	// Store the signature block the way an inbound one arrives. The P2P blockstore is what
+	// stamps the to-merge marker; a locally written block never carries one.
+	sigBlock := blocks.NewBlock([]byte("signature"))
+	p2pStore := datastore.P2PBlockstoreFrom(store, immutable.None[int]())
+	require.NoError(t, p2pStore.Put(ctx, sigBlock))
+
+	merged, err := p2pStore.IsMerged(ctx, sigBlock.Cid())
+	require.NoError(t, err)
+	require.False(t, merged, "guard: the signature block must start out marked to-merge")
+
+	txn := datastore.NewTxnFrom(store, lock.NewLockSet(), 1, false, immutable.None[int]())
+	txnCtx := datastore.CtxSetTxn(ctx, txn)
+
+	collectionCRDT := crdt.NewCollection("collection-version", keys.NewHeadstoreColKey(1))
+	block := New(crdt.NewCRDT(collectionCRDT.Delta()), nil)
+	block.Signature = &cidlink.Link{Cid: sigBlock.Cid()}
+
+	link, err := block.GenerateLink()
+	require.NoError(t, err)
+
+	require.NoError(t, ProcessBlock(txnCtx, collectionCRDT, block, link))
+	require.NoError(t, txn.Commit())
+
+	merged, err = p2pStore.IsMerged(ctx, sigBlock.Cid())
+	require.NoError(t, err)
+	require.True(t, merged, "merging a signed block must clear its signature block's marker")
 }

--- a/internal/datastore/blockstore.go
+++ b/internal/datastore/blockstore.go
@@ -12,6 +12,8 @@ package datastore
 
 import (
 	"context"
+	"encoding/binary"
+	"time"
 
 	ipfsBlockstore "github.com/ipfs/boxo/blockstore"
 	blocks "github.com/ipfs/go-block-format"
@@ -49,8 +51,10 @@ type bstore struct {
 var _ Blockstore = (*bstore)(nil)
 
 const (
-	objectMarker       = byte(0xff)
 	toMergeIndexPrefix = byte('m')
+	// toMergeValueLen is the length of a current-format marker value: an 8-byte
+	// big-endian unix timestamp of when the block was fetched.
+	toMergeValueLen = 8
 )
 
 func newToMergeKey(cid []byte) []byte {
@@ -59,6 +63,24 @@ func newToMergeKey(cid []byte) []byte {
 	copy(key[1:], cid)
 	key[0] = toMergeIndexPrefix
 	return key
+}
+
+// newToMergeValue encodes the time a block was fetched. Only the orphan sweep reads
+// this value, to tell a fetch still in flight from an abandoned one; IsMerged checks
+// the marker's presence, not its contents.
+func newToMergeValue(t time.Time) []byte {
+	v := make([]byte, toMergeValueLen)
+	binary.BigEndian.PutUint64(v, uint64(t.Unix()))
+	return v
+}
+
+// toMergeTime decodes a marker value. A value that is not a full timestamp (an older
+// single-byte marker) decodes as (zero, false), and the sweep leaves those alone.
+func toMergeTime(v []byte) (time.Time, bool) {
+	if len(v) != toMergeValueLen {
+		return time.Time{}, false
+	}
+	return time.Unix(int64(binary.BigEndian.Uint64(v)), 0), true
 }
 
 // IsMerged reports whether the block is stored and carries no to-merge marker. Callers
@@ -108,7 +130,7 @@ func (bs *p2pBlockStore) Put(ctx context.Context, block blocks.Block) error {
 	if err == nil && exists {
 		return nil // already stored.
 	}
-	err = bs.store.Set(ctx, newToMergeKey(block.Cid().Bytes()), []byte{objectMarker})
+	err = bs.store.Set(ctx, newToMergeKey(block.Cid().Bytes()), newToMergeValue(time.Now()))
 	if err != nil {
 		return NewErrStoreBlock(err)
 	}
@@ -126,7 +148,7 @@ func (bs *p2pBlockStore) PutMany(ctx context.Context, blocks []blocks.Block) err
 		if err == nil && exists {
 			continue
 		}
-		err = bs.store.Set(ctx, newToMergeKey(b.Cid().Bytes()), []byte{objectMarker})
+		err = bs.store.Set(ctx, newToMergeKey(b.Cid().Bytes()), newToMergeValue(time.Now()))
 		if err != nil {
 			return NewErrStoreBlock(err)
 		}

--- a/internal/datastore/blockstore.go
+++ b/internal/datastore/blockstore.go
@@ -12,6 +12,8 @@ package datastore
 
 import (
 	"context"
+	"encoding/binary"
+	"time"
 
 	lru "github.com/hashicorp/golang-lru/v2"
 	ipfsBlockstore "github.com/ipfs/boxo/blockstore"
@@ -65,8 +67,10 @@ type bstore struct {
 var _ Blockstore = (*bstore)(nil)
 
 const (
-	objectMarker       = byte(0xff)
 	toMergeIndexPrefix = byte('m')
+	// toMergeValueLen is the length of a current-format marker value: an 8-byte
+	// big-endian unix timestamp of when the block was fetched.
+	toMergeValueLen = 8
 )
 
 func newToMergeKey(cid []byte) []byte {
@@ -75,6 +79,24 @@ func newToMergeKey(cid []byte) []byte {
 	copy(key[1:], cid)
 	key[0] = toMergeIndexPrefix
 	return key
+}
+
+// newToMergeValue encodes the time a block was fetched. Only the orphan sweep reads
+// this value, to tell a fetch still in flight from an abandoned one; IsMerged checks
+// the marker's presence, not its contents.
+func newToMergeValue(t time.Time) []byte {
+	v := make([]byte, toMergeValueLen)
+	binary.BigEndian.PutUint64(v, uint64(t.Unix()))
+	return v
+}
+
+// toMergeTime decodes a marker value. A value that is not a full timestamp (an older
+// single-byte marker) decodes as (zero, false); the sweep treats those as abandoned.
+func toMergeTime(v []byte) (time.Time, bool) {
+	if len(v) != toMergeValueLen {
+		return time.Time{}, false
+	}
+	return time.Unix(int64(binary.BigEndian.Uint64(v)), 0), true
 }
 
 func (bs *bstore) IsMerged(ctx context.Context, cid cid.Cid) (bool, error) {
@@ -131,7 +153,7 @@ func (bs *p2pBlockStore) Put(ctx context.Context, block blocks.Block) error {
 	if err == nil && exists {
 		return nil // already stored.
 	}
-	err = bs.store.Set(ctx, newToMergeKey(block.Cid().Bytes()), []byte{objectMarker})
+	err = bs.store.Set(ctx, newToMergeKey(block.Cid().Bytes()), newToMergeValue(time.Now()))
 	if err != nil {
 		return NewErrStoreBlock(err)
 	}
@@ -149,7 +171,7 @@ func (bs *p2pBlockStore) PutMany(ctx context.Context, blocks []blocks.Block) err
 		if err == nil && exists {
 			continue
 		}
-		err = bs.store.Set(ctx, newToMergeKey(b.Cid().Bytes()), []byte{objectMarker})
+		err = bs.store.Set(ctx, newToMergeKey(b.Cid().Bytes()), newToMergeValue(time.Now()))
 		if err != nil {
 			return NewErrStoreBlock(err)
 		}

--- a/internal/datastore/blockstore.go
+++ b/internal/datastore/blockstore.go
@@ -13,6 +13,7 @@ package datastore
 import (
 	"context"
 	"encoding/binary"
+	"errors"
 	"time"
 
 	ipfsBlockstore "github.com/ipfs/boxo/blockstore"
@@ -119,6 +120,10 @@ func (bs *bstore) BatchMarkAsMerged(ctx context.Context, cids []cid.Cid) error {
 
 type p2pBlockStore struct {
 	*bstore
+
+	// rootstore backs the marker refresh. The refresh reads the marker and writes it back, which
+	// has to happen in one transaction or a merge clearing the marker in between is undone.
+	rootstore corekv.TxnReaderWriter
 }
 
 var _ Blockstore = (*p2pBlockStore)(nil)
@@ -128,7 +133,9 @@ func (bs *p2pBlockStore) Put(ctx context.Context, block blocks.Block) error {
 	// Has is cheaper than Set, so see if we already have it
 	exists, err := bs.store.Has(ctx, block.Cid().Bytes())
 	if err == nil && exists {
-		return nil // already stored.
+		// Already stored, but a block still waiting to merge needs its marker renewed so the
+		// sweep does not treat it as abandoned.
+		return bs.refreshMarker(ctx, block)
 	}
 	err = bs.store.Set(ctx, newToMergeKey(block.Cid().Bytes()), newToMergeValue(time.Now()))
 	if err != nil {
@@ -141,11 +148,46 @@ func (bs *p2pBlockStore) Put(ctx context.Context, block blocks.Block) error {
 	return nil
 }
 
+// refreshMarker moves an unmerged block's marker forward so a block that keeps arriving is not
+// treated as abandoned. The read and the write share a transaction: reading the marker puts it in
+// the transaction's read set, so a merge that clears it concurrently makes this commit fail rather
+// than silently marking a merged block unmerged again.
+func (bs *p2pBlockStore) refreshMarker(ctx context.Context, block blocks.Block) error {
+	markerKey := newToMergeKey(block.Cid().Bytes())
+
+	txn := bs.rootstore.NewTxn(false)
+	defer txn.Discard()
+	txnCtx := corekv.SetCtxTxn(ctx, txn)
+
+	stillUnmerged, err := bs.store.Has(txnCtx, markerKey)
+	if err != nil {
+		return NewErrCheckBlockMergeStatus(err)
+	}
+	if !stillUnmerged {
+		return nil
+	}
+	if err := bs.store.Set(txnCtx, markerKey, newToMergeValue(time.Now())); err != nil {
+		return NewErrStoreBlock(err)
+	}
+
+	// A conflict means another transaction wrote the marker after this one read it: a merge
+	// clearing it, another refresh stamping it, or the sweep reclaiming the block along with
+	// it. The first two leave the marker where this refresh would have; the third leaves no
+	// block to mark, and the next fetch writes both again.
+	if err := txn.Commit(); err != nil && !errors.Is(err, corekv.ErrTxnConflict) {
+		return NewErrStoreBlock(err)
+	}
+	return nil
+}
+
 // PutMany stores multiple blocks to the blockstore.
 func (bs *p2pBlockStore) PutMany(ctx context.Context, blocks []blocks.Block) error {
 	for _, b := range blocks {
 		exists, err := bs.store.Has(ctx, b.Cid().Bytes())
 		if err == nil && exists {
+			if err := bs.refreshMarker(ctx, b); err != nil {
+				return err
+			}
 			continue
 		}
 		err = bs.store.Set(ctx, newToMergeKey(b.Cid().Bytes()), newToMergeValue(time.Now()))

--- a/internal/datastore/blockstore_blind.go
+++ b/internal/datastore/blockstore_blind.go
@@ -12,6 +12,7 @@ package datastore
 
 import (
 	"context"
+	"time"
 
 	blocks "github.com/ipfs/go-block-format"
 
@@ -22,6 +23,10 @@ import (
 // blindWriteBlockstore is identical to p2pBlockStore but skips the Has() pre-check
 // on Put/PutMany. Use it for write-only import paths (e.g. importCAR) where blocks
 // are known to be new and the extra read round-trip adds no value.
+//
+// Because it does not read first, a block that has already merged can be given a fresh
+// to-merge marker here. The orphan sweep checks document ownership rather than trusting
+// the marker for that reason.
 type blindWriteBlockstore struct {
 	*bstore
 }
@@ -36,7 +41,7 @@ func BlindWriteP2PBlockstoreFrom(rootstore corekv.ReaderWriter, chunkSize immuta
 }
 
 func (bs *blindWriteBlockstore) Put(ctx context.Context, block blocks.Block) error {
-	if err := bs.store.Set(ctx, newToMergeKey(block.Cid().Bytes()), []byte{objectMarker}); err != nil {
+	if err := bs.store.Set(ctx, newToMergeKey(block.Cid().Bytes()), newToMergeValue(time.Now())); err != nil {
 		return NewErrStoreBlock(err)
 	}
 	if err := bs.store.Set(ctx, block.Cid().Bytes(), block.RawData()); err != nil {
@@ -47,7 +52,7 @@ func (bs *blindWriteBlockstore) Put(ctx context.Context, block blocks.Block) err
 
 func (bs *blindWriteBlockstore) PutMany(ctx context.Context, blks []blocks.Block) error {
 	for _, b := range blks {
-		if err := bs.store.Set(ctx, newToMergeKey(b.Cid().Bytes()), []byte{objectMarker}); err != nil {
+		if err := bs.store.Set(ctx, newToMergeKey(b.Cid().Bytes()), newToMergeValue(time.Now())); err != nil {
 			return NewErrStoreBlock(err)
 		}
 		if err := bs.store.Set(ctx, b.Cid().Bytes(), b.RawData()); err != nil {

--- a/internal/datastore/blockstore_gc.go
+++ b/internal/datastore/blockstore_gc.go
@@ -41,6 +41,9 @@ type SweepResult struct {
 	// Conflicts counts batches abandoned because a merge committed against a marker they
 	// held. Their blocks stay marked and are reconsidered on the next full pass.
 	Conflicts int
+	// Unparsed counts markers whose key did not decode as a CID. No block can be identified
+	// from such a key, so nothing is deleted for it and it is left in place.
+	Unparsed int
 }
 
 // ReclaimOrphanBlocks deletes blocks that were fetched during P2P sync but never merged
@@ -126,12 +129,16 @@ func reclaimBatch(
 			continue
 		}
 
-		// A marker key is the to-merge prefix followed by the block's CID.
-		blockCID, err := cid.Cast(marker[1:])
+		// A marker key is the to-merge prefix followed by the block's CID. A chunked store
+		// appends a suffix to every key it writes, so the CID is read off the front rather
+		// than from the whole remainder, and what follows it says whether it is chunked.
+		cidLen, blockCID, err := cid.CidFromBytes(marker[1:])
 		if err != nil {
 			// Not a CID, so ownership cannot be checked. Leave it rather than guess.
+			result.Unparsed++
 			continue
 		}
+		chunked := len(marker)-1 > cidLen
 
 		owned, err := blockowner.HasOwners(txnCtx, systemNS, blockCID)
 		if err != nil {
@@ -141,7 +148,7 @@ func reclaimBatch(
 			// A committed document owns the block, so the marker is stale rather than the
 			// block being garbage. Ownership decides that, not the marker's presence.
 			// Drop the marker, keep the block.
-			if err := blockNS.Delete(txnCtx, marker); err != nil {
+			if err := deleteKey(txnCtx, blockNS, marker[:1+cidLen], chunked); err != nil {
 				return err
 			}
 			repaired++
@@ -150,10 +157,10 @@ func reclaimBatch(
 
 		// Both deletes land in one commit, so a crash leaves the block and its marker
 		// either both present, and reclaimable again on a later pass, or both gone.
-		if err := blockNS.Delete(txnCtx, marker[1:]); err != nil {
+		if err := deleteKey(txnCtx, blockNS, blockCID.Bytes(), chunked); err != nil {
 			return err
 		}
-		if err := blockNS.Delete(txnCtx, marker); err != nil {
+		if err := deleteKey(txnCtx, blockNS, marker[:1+cidLen], chunked); err != nil {
 			return err
 		}
 		reclaimed++
@@ -227,6 +234,42 @@ func seekMarker(iter corekv.Iterator, startKey []byte) (bool, error) {
 		return iter.Next()
 	}
 	return iter.Seek(startKey)
+}
+
+// deleteKey removes the value stored under key. A chunked store splits one value across several
+// keys sharing it as a prefix, so those are gathered before any delete: the memory store deadlocks
+// if it is written to while an iterator is open.
+func deleteKey(ctx context.Context, store corekv.ReaderWriter, key []byte, chunked bool) error {
+	if !chunked {
+		return store.Delete(ctx, key)
+	}
+
+	iter, err := store.Iterator(ctx, corekv.IterOptions{Prefix: key, KeysOnly: true})
+	if err != nil {
+		return err
+	}
+
+	var keys [][]byte
+	for {
+		hasNext, err := iter.Next()
+		if err != nil {
+			return errors.Join(err, iter.Close())
+		}
+		if !hasNext {
+			break
+		}
+		keys = append(keys, copyKey(iter.Key()))
+	}
+	if err := iter.Close(); err != nil {
+		return err
+	}
+
+	for _, k := range keys {
+		if err := store.Delete(ctx, k); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func copyKey(k []byte) []byte {

--- a/internal/datastore/blockstore_gc.go
+++ b/internal/datastore/blockstore_gc.go
@@ -56,10 +56,9 @@ type SweepResult struct {
 // without mutating the iterator, then reclaimBatch re-decides each one under the
 // transaction that deletes it.
 //
-// Only markers carrying a timestamp are eligible. A marker without one was written before
-// the index recorded fetch times, by a store that also predates the block-owner edges this
-// sweep reads, so neither the age check nor the ownership check holds for it and its block
-// is left in place.
+// Only markers carrying a timestamp are eligible. An untimestamped marker was written by a
+// build that stored a signed block's signature without indexing its owner, so for those
+// markers a missing owner does not prove the block went unmerged.
 func ReclaimOrphanBlocks(
 	ctx context.Context,
 	rootstore corekv.TxnReaderWriter,

--- a/internal/datastore/blockstore_gc.go
+++ b/internal/datastore/blockstore_gc.go
@@ -1,0 +1,236 @@
+// Copyright 2025 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package datastore
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/ipfs/go-cid"
+
+	"github.com/sourcenetwork/corekv"
+	"github.com/sourcenetwork/corekv/namespace"
+	"github.com/sourcenetwork/defradb/internal/db/blockowner"
+)
+
+// orphanDeleteBatchSize is how many markers share one delete transaction. A merge
+// that touches any marker in a batch aborts the whole batch, so this is kept small
+// enough that redoing one on a later pass is cheap, while still amortising the commit
+// across many blocks.
+const orphanDeleteBatchSize = 256
+
+// SweepResult reports what one call to ReclaimOrphanBlocks did.
+type SweepResult struct {
+	// NextKey is where the next call resumes, nil once the index has been swept end to
+	// end. It is only meaningful when the call returned no error.
+	NextKey   []byte
+	Scanned   int
+	Reclaimed int
+	// Repaired counts markers cleared from blocks a document still owns, which is a
+	// marker that outlived the merge that claimed the block.
+	Repaired int
+	// Conflicts counts batches abandoned because a merge committed against a marker they
+	// held. Their blocks stay marked and are reconsidered on the next full pass.
+	Conflicts int
+}
+
+// ReclaimOrphanBlocks deletes blocks that were fetched during P2P sync but never merged
+// into a document, identified by a to-merge marker older than cutoff. History prune
+// never reaches these blocks because it walks out from documents, so without this sweep
+// they accumulate for the life of the store.
+//
+// It resumes from startKey, nil beginning at the start of the marker index, and scans at
+// most scanLimit markers per call. The scan only nominates candidates: it collects them
+// without mutating the iterator, then reclaimBatch re-decides each one under the
+// transaction that deletes it.
+//
+// Only markers carrying a timestamp are eligible. A marker without one was written before
+// the index recorded fetch times, by a store that also predates the block-owner edges this
+// sweep reads, so neither the age check nor the ownership check holds for it and its block
+// is left in place.
+func ReclaimOrphanBlocks(
+	ctx context.Context,
+	rootstore corekv.TxnReaderWriter,
+	cutoff time.Time,
+	startKey []byte,
+	scanLimit int,
+) (SweepResult, error) {
+	blockNS := namespace.Wrap(rootstore, []byte{blockStoreKey})
+
+	candidates, nextKey, scanned, err := collectExpiredMarkers(ctx, blockNS, cutoff, startKey, scanLimit)
+	if err != nil {
+		return SweepResult{Scanned: scanned}, err
+	}
+	result := SweepResult{NextKey: nextKey, Scanned: scanned}
+
+	for start := 0; start < len(candidates); start += orphanDeleteBatchSize {
+		// The loop commits one batch at a time and does not stop on its own, so
+		// cancellation is checked here rather than only between sweeps.
+		if err := ctx.Err(); err != nil {
+			return result, err
+		}
+		end := min(start+orphanDeleteBatchSize, len(candidates))
+		if err := reclaimBatch(ctx, rootstore, cutoff, candidates[start:end], &result); err != nil {
+			return result, err
+		}
+	}
+	return result, nil
+}
+
+// reclaimBatch deletes one batch of orphaned blocks in a single transaction, re-reading
+// each marker inside it so the decision to delete and the delete itself are atomic, and
+// accumulates what it did into result.
+//
+// The re-read is what makes the sweep safe, and it rests on one invariant: a merge that
+// takes ownership of a block clears that block's to-merge marker in the same transaction.
+// Reading the marker here puts it in the transaction's read set, so that merge's write to
+// the same key makes this commit conflict and the batch is abandoned with nothing deleted.
+// The markers survive for the next full pass.
+func reclaimBatch(
+	ctx context.Context,
+	rootstore corekv.TxnReaderWriter,
+	cutoff time.Time,
+	markers [][]byte,
+	result *SweepResult,
+) error {
+	txn := rootstore.NewTxn(false)
+	defer txn.Discard()
+
+	// corekv takes the transaction from the context, so the stores below join it rather
+	// than committing per call.
+	txnCtx := corekv.SetCtxTxn(ctx, txn)
+	blockNS := namespace.Wrap(rootstore, []byte{blockStoreKey})
+	systemNS := SystemstoreFrom(rootstore)
+
+	reclaimed, repaired := 0, 0
+	for _, marker := range markers {
+		value, err := blockNS.Get(txnCtx, marker)
+		if errors.Is(err, corekv.ErrNotFound) {
+			// A merge cleared the marker after the scan nominated it.
+			continue
+		}
+		if err != nil {
+			return err
+		}
+		if t, decoded := toMergeTime(value); !decoded || !t.Before(cutoff) {
+			// Untimestamped, or re-written since the scan.
+			continue
+		}
+
+		// A marker key is the to-merge prefix followed by the block's CID.
+		blockCID, err := cid.Cast(marker[1:])
+		if err != nil {
+			// Not a CID, so ownership cannot be checked. Leave it rather than guess.
+			continue
+		}
+
+		owned, err := blockowner.HasOwners(txnCtx, systemNS, blockCID)
+		if err != nil {
+			return err
+		}
+		if owned {
+			// A committed document owns the block, so the marker is stale rather than the
+			// block being garbage. Ownership decides that, not the marker's presence.
+			// Drop the marker, keep the block.
+			if err := blockNS.Delete(txnCtx, marker); err != nil {
+				return err
+			}
+			repaired++
+			continue
+		}
+
+		// Both deletes land in one commit, so a crash leaves the block and its marker
+		// either both present, and reclaimable again on a later pass, or both gone.
+		if err := blockNS.Delete(txnCtx, marker[1:]); err != nil {
+			return err
+		}
+		if err := blockNS.Delete(txnCtx, marker); err != nil {
+			return err
+		}
+		reclaimed++
+	}
+
+	if err := txn.Commit(); err != nil {
+		if errors.Is(err, corekv.ErrTxnConflict) {
+			result.Conflicts++
+			return nil
+		}
+		return err
+	}
+	result.Reclaimed += reclaimed
+	result.Repaired += repaired
+	return nil
+}
+
+// collectExpiredMarkers scans the to-merge index from startKey and returns the keys of
+// markers that carry a timestamp older than cutoff, along with the key to resume from
+// next. These are candidates only; each is re-checked under a transaction before anything
+// is deleted. Kept keys are copied because the iterator reuses its buffers across Next.
+func collectExpiredMarkers(
+	ctx context.Context,
+	blockNS corekv.ReaderWriter,
+	cutoff time.Time,
+	startKey []byte,
+	scanLimit int,
+) (expired [][]byte, nextKey []byte, scanned int, err error) {
+	iter, err := blockNS.Iterator(ctx, corekv.IterOptions{Prefix: []byte{toMergeIndexPrefix}})
+	if err != nil {
+		return nil, nil, 0, err
+	}
+	defer func() {
+		if cerr := iter.Close(); cerr != nil && err == nil {
+			expired, nextKey, err = nil, nil, cerr
+		}
+	}()
+
+	ok, err := seekMarker(iter, startKey)
+	for ok && err == nil {
+		// The scan walks up to scanLimit markers and the iterator does not stop on its
+		// own, so cancellation is checked here rather than only between sweeps.
+		if cerr := ctx.Err(); cerr != nil {
+			return nil, nil, scanned, cerr
+		}
+		if scanned == scanLimit {
+			// The current marker is unexamined; resume from it next call.
+			return expired, copyKey(iter.Key()), scanned, nil
+		}
+		var value []byte
+		if value, err = iter.Value(); err != nil {
+			break
+		}
+		if t, decoded := toMergeTime(value); decoded && t.Before(cutoff) {
+			expired = append(expired, copyKey(iter.Key()))
+		}
+		scanned++
+		ok, err = iter.Next()
+	}
+	if err != nil {
+		return nil, nil, scanned, err
+	}
+	return expired, nil, scanned, nil
+}
+
+// seekMarker positions the iterator at the first marker to examine: the beginning of
+// the index when startKey is nil, otherwise startKey, or the next marker if startKey
+// was deleted since the previous call.
+func seekMarker(iter corekv.Iterator, startKey []byte) (bool, error) {
+	if startKey == nil {
+		return iter.Next()
+	}
+	return iter.Seek(startKey)
+}
+
+func copyKey(k []byte) []byte {
+	c := make([]byte, len(k))
+	copy(c, k)
+	return c
+}

--- a/internal/datastore/blockstore_gc.go
+++ b/internal/datastore/blockstore_gc.go
@@ -1,0 +1,231 @@
+// Copyright 2025 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package datastore
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/ipfs/go-cid"
+
+	"github.com/sourcenetwork/corekv"
+	"github.com/sourcenetwork/corekv/namespace"
+	"github.com/sourcenetwork/defradb/internal/db/blockowner"
+)
+
+// orphanDeleteBatchSize is how many markers share one delete transaction. A merge
+// that touches any marker in a batch aborts the whole batch, so this is kept small
+// enough that redoing one next sweep is cheap, while still amortising the commit
+// across many blocks.
+const orphanDeleteBatchSize = 256
+
+// SweepResult reports what one call to ReclaimOrphanBlocks did.
+type SweepResult struct {
+	// NextKey is where the next call resumes, nil once the index has been swept end to
+	// end. It is only meaningful when the call returned no error.
+	NextKey   []byte
+	Scanned   int
+	Reclaimed int
+	// Repaired counts markers cleared from blocks a document still owns. Non-zero means
+	// something is writing markers over already-merged blocks.
+	Repaired int
+	// Conflicts counts batches abandoned because a merge committed against a marker they
+	// held. Their blocks stay marked and are retried on a later sweep.
+	Conflicts int
+}
+
+// ReclaimOrphanBlocks deletes blocks that were fetched during P2P sync but never merged
+// into a document, identified by a to-merge marker older than cutoff. History prune
+// never reaches these blocks because it walks out from documents, so without this sweep
+// they accumulate for the life of the store.
+//
+// It resumes from startKey, nil beginning at the start of the marker index, and scans at
+// most scanLimit markers per call. The scan only nominates candidates: it collects them
+// without mutating the iterator, then reclaimBatch re-decides each one under the
+// transaction that deletes it.
+//
+// Callers must not run this until the store has been open for longer than the marker
+// TTL. Markers predating the timestamped index have no readable age, and that wait is
+// what makes them older than any cutoff the caller can pass.
+func ReclaimOrphanBlocks(
+	ctx context.Context,
+	rootstore corekv.TxnReaderWriter,
+	cutoff time.Time,
+	startKey []byte,
+	scanLimit int,
+) (SweepResult, error) {
+	blockNS := namespace.Wrap(rootstore, []byte{blockStoreKey})
+
+	candidates, nextKey, scanned, err := collectExpiredMarkers(ctx, blockNS, cutoff, startKey, scanLimit)
+	if err != nil {
+		return SweepResult{Scanned: scanned}, err
+	}
+	result := SweepResult{NextKey: nextKey, Scanned: scanned}
+
+	for start := 0; start < len(candidates); start += orphanDeleteBatchSize {
+		// The delete phase runs for minutes, so cancellation has to be checked here
+		// rather than only between sweeps.
+		if err := ctx.Err(); err != nil {
+			return result, err
+		}
+		end := min(start+orphanDeleteBatchSize, len(candidates))
+		if err := reclaimBatch(ctx, rootstore, cutoff, candidates[start:end], &result); err != nil {
+			return result, err
+		}
+	}
+	return result, nil
+}
+
+// reclaimBatch deletes one batch of orphaned blocks in a single transaction, re-reading
+// each marker inside it so the decision to delete and the delete itself are atomic, and
+// accumulates what it did into result.
+//
+// The re-read is what makes the sweep safe. MarkAsMerged removes a marker inside the
+// merge transaction, so a merge that commits between the scan and here has already
+// taken ownership of the block. Reading the marker here puts it in the transaction's
+// read set, so that merge's write to the same key makes this commit conflict and the
+// batch is abandoned with nothing deleted. The markers survive for a later sweep.
+func reclaimBatch(
+	ctx context.Context,
+	rootstore corekv.TxnReaderWriter,
+	cutoff time.Time,
+	markers [][]byte,
+	result *SweepResult,
+) error {
+	txn := rootstore.NewTxn(false)
+	defer txn.Discard()
+
+	// corekv takes the transaction from the context, so the stores below join it rather
+	// than committing per call.
+	txnCtx := corekv.SetCtxTxn(ctx, txn)
+	blockNS := namespace.Wrap(rootstore, []byte{blockStoreKey})
+	systemNS := SystemstoreFrom(rootstore)
+
+	reclaimed, repaired := 0, 0
+	for _, marker := range markers {
+		value, err := blockNS.Get(txnCtx, marker)
+		if errors.Is(err, corekv.ErrNotFound) {
+			// A merge cleared the marker after the scan nominated it.
+			continue
+		}
+		if err != nil {
+			return err
+		}
+		if t, decoded := toMergeTime(value); decoded && !t.Before(cutoff) {
+			// Re-written since the scan.
+			continue
+		}
+
+		// A marker key is the to-merge prefix followed by the block's CID.
+		blockCID, err := cid.Cast(marker[1:])
+		if err != nil {
+			// Not a CID, so ownership cannot be checked. Leave it rather than guess.
+			continue
+		}
+
+		owned, err := blockowner.HasOwners(txnCtx, systemNS, blockCID)
+		if err != nil {
+			return err
+		}
+		if owned {
+			// A committed document owns the block, so the marker is wrong rather than the
+			// block being garbage: blind import paths write markers without checking
+			// whether the block already merged. Drop the marker, keep the block.
+			if err := blockNS.Delete(txnCtx, marker); err != nil {
+				return err
+			}
+			repaired++
+			continue
+		}
+
+		// Both deletes land in one commit, so a crash leaves the block and its marker
+		// either both present, and reclaimable again next sweep, or both gone.
+		if err := blockNS.Delete(txnCtx, marker[1:]); err != nil {
+			return err
+		}
+		if err := blockNS.Delete(txnCtx, marker); err != nil {
+			return err
+		}
+		reclaimed++
+	}
+
+	if err := txn.Commit(); err != nil {
+		if errors.Is(err, corekv.ErrTxnConflict) {
+			result.Conflicts++
+			return nil
+		}
+		return err
+	}
+	result.Reclaimed += reclaimed
+	result.Repaired += repaired
+	return nil
+}
+
+// collectExpiredMarkers scans the to-merge index from startKey and returns the keys of
+// markers that look expired (including older single-byte markers, which have no
+// timestamp), along with the key to resume from next. These are candidates only; each
+// is re-checked under a transaction before anything is deleted. Kept keys are copied
+// because the iterator reuses its buffers across Next.
+func collectExpiredMarkers(
+	ctx context.Context,
+	blockNS corekv.ReaderWriter,
+	cutoff time.Time,
+	startKey []byte,
+	scanLimit int,
+) (expired [][]byte, nextKey []byte, scanned int, err error) {
+	iter, err := blockNS.Iterator(ctx, corekv.IterOptions{Prefix: []byte{toMergeIndexPrefix}})
+	if err != nil {
+		return nil, nil, 0, err
+	}
+	defer func() {
+		if cerr := iter.Close(); cerr != nil && err == nil {
+			expired, nextKey, err = nil, nil, cerr
+		}
+	}()
+
+	ok, err := seekMarker(iter, startKey)
+	for ok && err == nil {
+		if scanned == scanLimit {
+			// The current marker is unexamined; resume from it next call.
+			return expired, copyKey(iter.Key()), scanned, nil
+		}
+		var value []byte
+		if value, err = iter.Value(); err != nil {
+			break
+		}
+		if t, decoded := toMergeTime(value); !decoded || t.Before(cutoff) {
+			expired = append(expired, copyKey(iter.Key()))
+		}
+		scanned++
+		ok, err = iter.Next()
+	}
+	if err != nil {
+		return nil, nil, scanned, err
+	}
+	return expired, nil, scanned, nil
+}
+
+// seekMarker positions the iterator at the first marker to examine: the beginning of
+// the index when startKey is nil, otherwise startKey, or the next marker if startKey
+// was deleted since the previous call.
+func seekMarker(iter corekv.Iterator, startKey []byte) (bool, error) {
+	if startKey == nil {
+		return iter.Next()
+	}
+	return iter.Seek(startKey)
+}
+
+func copyKey(k []byte) []byte {
+	c := make([]byte, len(k))
+	copy(c, k)
+	return c
+}

--- a/internal/datastore/blockstore_gc_chunk_test.go
+++ b/internal/datastore/blockstore_gc_chunk_test.go
@@ -1,0 +1,92 @@
+// Copyright 2025 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package datastore
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	blocks "github.com/ipfs/go-block-format"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcenetwork/corekv"
+	"github.com/sourcenetwork/immutable"
+
+	"github.com/sourcenetwork/defradb/internal/keys"
+)
+
+// A chunked store appends a suffix to every key it writes, so the CID has to be read off the front
+// of the marker rather than from the whole remainder, and a delete has to cover every key the value
+// was split across.
+//
+// A chunk size above the block size leaves each value in one key and exercises only the parse; one
+// below it splits the value, which is what the delete has to cover. Both sit at or above the marker
+// value's length, since neither half of a split marker decodes as a timestamp and the sweep would
+// never nominate it.
+//
+// Deletions are asserted by prefix, because the unsuffixed key alone passes while the block is
+// still stored under its chunked one. The block that survives is asserted by content, because a key
+// with the right prefix can hold a value a delete only partly removed.
+func TestReclaimOrphanBlocksThroughChunkedStore(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		chunk immutable.Option[int]
+	}{
+		{"unchunked", immutable.None[int]()},
+		{"chunked", immutable.Some(1 << 20)},
+		{"chunked across several keys", immutable.Some(toMergeValueLen)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			blockNS, systemNS, rootstore := newTestBlockstore(t)
+			defer func() { require.NoError(t, rootstore.Close()) }()
+
+			bs := P2PBlockstoreFrom(rootstore, tc.chunk)
+			orphan := blocks.NewBlock([]byte("no document claims this"))
+			owned := blocks.NewBlock([]byte("a document owns this"))
+			require.NoError(t, bs.Put(ctx, orphan))
+			require.NoError(t, bs.Put(ctx, owned))
+			require.NoError(t, systemNS.Set(ctx,
+				keys.NewBlockCIDToDocIDKey(owned.Cid().String(), "bae-owner").Bytes(), []byte{}))
+
+			result, err := ReclaimOrphanBlocks(ctx, rootstore, time.Now().Add(time.Hour), nil, 100)
+			require.NoError(t, err)
+			require.Equal(t, 2, result.Scanned)
+			require.Equal(t, 1, result.Reclaimed)
+			require.Equal(t, 1, result.Repaired)
+
+			requirePrefixEmpty(t, ctx, blockNS, orphan.Cid().Bytes(), "orphan block")
+			requirePrefixEmpty(t, ctx, blockNS, newToMergeKey(orphan.Cid().Bytes()), "orphan marker")
+
+			// The owned block keeps its data and loses only the marker.
+			stored, err := bs.Get(ctx, owned.Cid())
+			require.NoError(t, err, "owned block should still be readable")
+			require.Equal(t, owned.RawData(), stored.RawData(), "owned block should be unchanged")
+			requirePrefixEmpty(t, ctx, blockNS, newToMergeKey(owned.Cid().Bytes()), "owned marker")
+		})
+	}
+}
+
+func requirePrefixEmpty(t *testing.T, ctx context.Context, store corekv.ReaderWriter, prefix []byte, what string) {
+	t.Helper()
+	require.False(t, prefixHasKey(t, ctx, store, prefix), "%s should be gone, including any chunked key", what)
+}
+
+func prefixHasKey(t *testing.T, ctx context.Context, store corekv.ReaderWriter, prefix []byte) bool {
+	t.Helper()
+	iter, err := store.Iterator(ctx, corekv.IterOptions{Prefix: prefix, KeysOnly: true})
+	require.NoError(t, err)
+	hasNext, err := iter.Next()
+	require.NoError(t, err)
+	require.NoError(t, iter.Close())
+	return hasNext
+}

--- a/internal/datastore/blockstore_gc_test.go
+++ b/internal/datastore/blockstore_gc_test.go
@@ -90,6 +90,30 @@ func TestReclaimOrphanBlocksNeverReclaimsUntimestampedMarker(t *testing.T) {
 	requireKept(t, ctx, blockNS, legacy, true)
 }
 
+// A marker key whose remainder is not a CID names no block the sweep can identify, so it is left
+// in place and counted.
+func TestReclaimOrphanBlocksCountsUnparsedMarker(t *testing.T) {
+	ctx := context.Background()
+	blockNS, _, rootstore := newTestBlockstore(t)
+	defer func() { require.NoError(t, rootstore.Close()) }()
+
+	cutoff := time.Now()
+	orphan := putMarkedBlock(t, ctx, blockNS, []byte("orphan"), newToMergeValue(cutoff.Add(-time.Hour)))
+	unparsed := append([]byte{toMergeIndexPrefix}, []byte("not a cid")...)
+	require.NoError(t, blockNS.Set(ctx, unparsed, newToMergeValue(cutoff.Add(-time.Hour))))
+
+	result, err := ReclaimOrphanBlocks(ctx, rootstore, cutoff, nil, 100)
+	require.NoError(t, err)
+	require.Equal(t, 2, result.Scanned)
+	require.Equal(t, 1, result.Reclaimed)
+	require.Equal(t, 1, result.Unparsed)
+
+	requireReclaimed(t, ctx, blockNS, orphan)
+	hasUnparsed, err := blockNS.Has(ctx, unparsed)
+	require.NoError(t, err)
+	require.True(t, hasUnparsed, "an unparsed marker should be left in place")
+}
+
 // A block a document owns must survive an expired marker over it. The marker is not proof
 // the block is garbage; ownership is what decides.
 func TestReclaimOrphanBlocksKeepsBlockOwnedByDocument(t *testing.T) {

--- a/internal/datastore/blockstore_gc_test.go
+++ b/internal/datastore/blockstore_gc_test.go
@@ -50,8 +50,7 @@ func TestReclaimOrphanBlocks(t *testing.T) {
 	stale := putMarkedBlock(t, ctx, blockNS, []byte("stale"), newToMergeValue(cutoff.Add(-time.Hour)))
 	// Marker newer than the cutoff: a fetch still in flight, must be kept.
 	fresh := putMarkedBlock(t, ctx, blockNS, []byte("fresh"), newToMergeValue(cutoff.Add(time.Hour)))
-	// A marker with no timestamp cannot be aged, and comes from a store with no owner edges
-	// to fall back on, so it is left alone.
+	// Marker with no timestamp: neither age nor ownership can decide it, so it is left alone.
 	legacy := putMarkedBlock(t, ctx, blockNS, []byte("legacy"), []byte{0xff})
 	// A merged block has no marker and must never be touched.
 	merged := putUnmarkedBlock(t, ctx, blockNS, []byte("merged"))
@@ -70,9 +69,8 @@ func TestReclaimOrphanBlocks(t *testing.T) {
 	requireKept(t, ctx, blockNS, merged, false)
 }
 
-// A store upgraded in place carries single-byte markers over blocks that merged before the
-// index recorded fetch times, and that merge wrote no owner edge, so an age-only decision
-// deletes blocks a live document still links to.
+// A build that wrote untimestamped markers stored a signed block's signature without
+// indexing its owner, so deciding one on ownership alone deletes a block a document links to.
 func TestReclaimOrphanBlocksNeverReclaimsUntimestampedMarker(t *testing.T) {
 	ctx := context.Background()
 	blockNS, _, rootstore := newTestBlockstore(t)

--- a/internal/datastore/blockstore_gc_test.go
+++ b/internal/datastore/blockstore_gc_test.go
@@ -1,0 +1,283 @@
+// Copyright 2025 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package datastore
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	badgerds "github.com/dgraph-io/badger/v4"
+	blocks "github.com/ipfs/go-block-format"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcenetwork/corekv"
+	ckbadger "github.com/sourcenetwork/corekv/badger"
+	"github.com/sourcenetwork/corekv/namespace"
+
+	"github.com/sourcenetwork/defradb/internal/keys"
+)
+
+func TestToMergeValueRoundTrip(t *testing.T) {
+	want := time.Unix(1_700_000_000, 0)
+	got, ok := toMergeTime(newToMergeValue(want))
+	require.True(t, ok)
+	require.Equal(t, want.Unix(), got.Unix())
+}
+
+func TestToMergeTimeRejectsLegacyMarker(t *testing.T) {
+	// The older marker format is a single byte with no timestamp.
+	_, ok := toMergeTime([]byte{0xff})
+	require.False(t, ok)
+}
+
+func TestReclaimOrphanBlocks(t *testing.T) {
+	ctx := context.Background()
+	blockNS, _, rootstore := newTestBlockstore(t)
+	defer rootstore.Close()
+
+	cutoff := time.Unix(1_700_000_000, 0)
+
+	// Marker older than the cutoff: an abandoned fetch, must be reclaimed.
+	stale := putMarkedBlock(t, ctx, blockNS, []byte("stale"), newToMergeValue(cutoff.Add(-time.Hour)))
+	// Marker newer than the cutoff: a fetch still in flight, must be kept.
+	fresh := putMarkedBlock(t, ctx, blockNS, []byte("fresh"), newToMergeValue(cutoff.Add(time.Hour)))
+	// A marker with no timestamp predates the store opening, which callers guarantee is
+	// older than the cutoff, so it is reclaimed too.
+	legacy := putMarkedBlock(t, ctx, blockNS, []byte("legacy"), []byte{0xff})
+	// A merged block has no marker and must never be touched.
+	merged := putUnmarkedBlock(t, ctx, blockNS, []byte("merged"))
+
+	result, err := ReclaimOrphanBlocks(ctx, rootstore, cutoff, nil, 100)
+	require.NoError(t, err)
+	require.Nil(t, result.NextKey, "a completed sweep returns no resume key")
+	require.Equal(t, 2, result.Reclaimed)
+	require.Equal(t, 3, result.Scanned, "only the three marked blocks are scanned, not the merged block")
+	require.Zero(t, result.Repaired)
+	require.Zero(t, result.Conflicts)
+
+	requireReclaimed(t, ctx, blockNS, stale)
+	requireReclaimed(t, ctx, blockNS, legacy)
+	requireKept(t, ctx, blockNS, fresh, true)
+	requireKept(t, ctx, blockNS, merged, false)
+}
+
+// A block a document owns must survive even with an expired marker over it, because
+// blind import paths write markers without checking whether the block already merged.
+func TestReclaimOrphanBlocksKeepsBlockOwnedByDocument(t *testing.T) {
+	ctx := context.Background()
+	blockNS, systemNS, rootstore := newTestBlockstore(t)
+	defer rootstore.Close()
+
+	cutoff := time.Unix(1_700_000_000, 0)
+	owned := putMarkedBlock(t, ctx, blockNS, []byte("owned"), newToMergeValue(cutoff.Add(-time.Hour)))
+
+	ownerKey := keys.NewBlockCIDToDocIDKey(owned.Cid().String(), "bae-some-document").Bytes()
+	require.NoError(t, systemNS.Set(ctx, ownerKey, []byte{}))
+
+	result, err := ReclaimOrphanBlocks(ctx, rootstore, cutoff, nil, 100)
+	require.NoError(t, err)
+	require.Zero(t, result.Reclaimed)
+	require.Equal(t, 1, result.Repaired)
+
+	requireKept(t, ctx, blockNS, owned, false)
+}
+
+// A batch holding both kinds of outcome: the ownership lookup iterates the store from
+// inside the same transaction that has already deleted an earlier block, so the two must
+// not interfere.
+func TestReclaimOrphanBlocksMixesReclaimAndRepairInOneBatch(t *testing.T) {
+	ctx := context.Background()
+	blockNS, systemNS, rootstore := newTestBlockstore(t)
+	defer rootstore.Close()
+
+	cutoff := time.Unix(1_700_000_000, 0)
+	expired := newToMergeValue(cutoff.Add(-time.Hour))
+
+	orphans := make([]blocks.Block, 3)
+	for i := range orphans {
+		orphans[i] = putMarkedBlock(t, ctx, blockNS, []byte{byte('a' + i)}, expired)
+	}
+	owned := putMarkedBlock(t, ctx, blockNS, []byte("owned"), expired)
+	ownerKey := keys.NewBlockCIDToDocIDKey(owned.Cid().String(), "bae-some-document").Bytes()
+	require.NoError(t, systemNS.Set(ctx, ownerKey, []byte{}))
+
+	result, err := ReclaimOrphanBlocks(ctx, rootstore, cutoff, nil, 100)
+	require.NoError(t, err)
+	require.Equal(t, 3, result.Reclaimed)
+	require.Equal(t, 1, result.Repaired)
+	require.Equal(t, 4, result.Scanned)
+
+	for _, block := range orphans {
+		requireReclaimed(t, ctx, blockNS, block)
+	}
+	requireKept(t, ctx, blockNS, owned, false)
+}
+
+// The scan nominates candidates, then the delete phase re-reads each marker. A merge
+// that commits in that window clears the marker, and the block must be left alone.
+func TestReclaimBatchSkipsMarkerClearedAfterScan(t *testing.T) {
+	ctx := context.Background()
+	blockNS, _, rootstore := newTestBlockstore(t)
+	defer rootstore.Close()
+
+	cutoff := time.Unix(1_700_000_000, 0)
+	block := putMarkedBlock(t, ctx, blockNS, []byte("merged-after-scan"), newToMergeValue(cutoff.Add(-time.Hour)))
+	marker := newToMergeKey(block.Cid().Bytes())
+
+	// Stand in for the merge committing between the scan and the delete phase:
+	// MarkAsMerged removes the marker inside the merge transaction.
+	require.NoError(t, blockNS.Delete(ctx, marker))
+
+	var result SweepResult
+	require.NoError(t, reclaimBatch(ctx, rootstore, cutoff, [][]byte{marker}, &result))
+	require.Zero(t, result.Reclaimed)
+
+	hasBlock, err := blockNS.Has(ctx, block.Cid().Bytes())
+	require.NoError(t, err)
+	require.True(t, hasBlock, "a block whose merge committed after the scan must survive")
+}
+
+// The sweep's safety rests on the store aborting a transaction that deletes a marker it
+// read when another transaction wrote that same key first. That is a storage-layer
+// property, so it is asserted directly: turning conflict detection off would otherwise
+// reintroduce the race silently.
+func TestStoreDetectsConflictOnMarkerReadThenDelete(t *testing.T) {
+	ctx := context.Background()
+	blockNS, _, rootstore := newTestBlockstore(t)
+	defer rootstore.Close()
+
+	block := putMarkedBlock(t, ctx, blockNS, []byte("contended"), newToMergeValue(time.Unix(1, 0)))
+	marker := newToMergeKey(block.Cid().Bytes())
+
+	sweep := rootstore.NewTxn(false)
+	defer sweep.Discard()
+	sweepCtx := corekv.SetCtxTxn(ctx, sweep)
+	sweepNS := namespace.Wrap(rootstore, []byte{blockStoreKey})
+
+	// The sweep reads the marker, putting it in the transaction's read set.
+	_, err := sweepNS.Get(sweepCtx, marker)
+	require.NoError(t, err)
+
+	// A merge commits against the same marker.
+	require.NoError(t, blockNS.Delete(ctx, marker))
+
+	require.NoError(t, sweepNS.Delete(sweepCtx, block.Cid().Bytes()))
+	require.ErrorIs(t, sweep.Commit(), corekv.ErrTxnConflict,
+		"a read marker written by another transaction must abort the sweep's commit")
+}
+
+func TestReclaimOrphanBlocksStopsOnCancelledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	blockNS, _, rootstore := newTestBlockstore(t)
+	defer rootstore.Close()
+
+	cutoff := time.Unix(1_700_000_000, 0)
+	block := putMarkedBlock(t, ctx, blockNS, []byte("stale"), newToMergeValue(cutoff.Add(-time.Hour)))
+
+	cancel()
+	_, err := ReclaimOrphanBlocks(ctx, rootstore, cutoff, nil, 100)
+	require.ErrorIs(t, err, context.Canceled)
+	requireKept(t, ctx, blockNS, block, true, "a cancelled sweep must not have deleted anything")
+}
+
+func TestReclaimOrphanBlocksResumesAcrossCalls(t *testing.T) {
+	ctx := context.Background()
+	blockNS, _, rootstore := newTestBlockstore(t)
+	defer rootstore.Close()
+
+	cutoff := time.Unix(1_700_000_000, 0)
+	stale := newToMergeValue(cutoff.Add(-time.Hour))
+
+	const total = 5
+	created := make([]blocks.Block, total)
+	for i := range created {
+		created[i] = putMarkedBlock(t, ctx, blockNS, []byte{byte('a' + i)}, stale)
+	}
+
+	// A scan limit below the marker count forces the sweep to resume via the cursor.
+	var cursor []byte
+	var reclaimedTotal, scannedTotal, calls int
+	for {
+		result, err := ReclaimOrphanBlocks(ctx, rootstore, cutoff, cursor, 2)
+		require.NoError(t, err)
+		reclaimedTotal += result.Reclaimed
+		scannedTotal += result.Scanned
+		calls++
+		require.LessOrEqual(t, calls, total+1, "sweep did not make progress")
+		if result.NextKey == nil {
+			break
+		}
+		cursor = result.NextKey
+	}
+
+	require.Greater(t, calls, 1, "a scan limit below the index size must take several calls")
+	require.Equal(t, total, reclaimedTotal)
+	require.Equal(t, total, scannedTotal, "each marker is scanned exactly once across the resumed calls")
+	for _, block := range created {
+		requireReclaimed(t, ctx, blockNS, block)
+	}
+}
+
+func newTestBlockstore(t *testing.T) (blockNS, systemNS corekv.ReaderWriter, rootstore corekv.TxnStore) {
+	t.Helper()
+	store, err := ckbadger.NewDatastore("", badgerds.DefaultOptions("").WithInMemory(true))
+	require.NoError(t, err)
+	return namespace.Wrap(store, []byte{blockStoreKey}),
+		namespace.Wrap(store, []byte{systemStoreKey}),
+		store
+}
+
+func putMarkedBlock(
+	t *testing.T,
+	ctx context.Context,
+	blockNS corekv.ReaderWriter,
+	data, marker []byte,
+) blocks.Block {
+	t.Helper()
+	block := putUnmarkedBlock(t, ctx, blockNS, data)
+	require.NoError(t, blockNS.Set(ctx, newToMergeKey(block.Cid().Bytes()), marker))
+	return block
+}
+
+func putUnmarkedBlock(t *testing.T, ctx context.Context, blockNS corekv.ReaderWriter, data []byte) blocks.Block {
+	t.Helper()
+	block := blocks.NewBlock(data)
+	require.NoError(t, blockNS.Set(ctx, block.Cid().Bytes(), block.RawData()))
+	return block
+}
+
+func requireReclaimed(t *testing.T, ctx context.Context, blockNS corekv.ReaderWriter, block blocks.Block) {
+	t.Helper()
+	hasBlock, err := blockNS.Has(ctx, block.Cid().Bytes())
+	require.NoError(t, err)
+	require.False(t, hasBlock, "block should be reclaimed")
+	hasMarker, err := blockNS.Has(ctx, newToMergeKey(block.Cid().Bytes()))
+	require.NoError(t, err)
+	require.False(t, hasMarker, "marker should be reclaimed")
+}
+
+func requireKept(
+	t *testing.T,
+	ctx context.Context,
+	blockNS corekv.ReaderWriter,
+	block blocks.Block,
+	withMarker bool,
+	msgAndArgs ...any,
+) {
+	t.Helper()
+	hasBlock, err := blockNS.Has(ctx, block.Cid().Bytes())
+	require.NoError(t, err)
+	require.True(t, hasBlock, append([]any{"block should be kept"}, msgAndArgs...)...)
+	hasMarker, err := blockNS.Has(ctx, newToMergeKey(block.Cid().Bytes()))
+	require.NoError(t, err)
+	require.Equal(t, withMarker, hasMarker, "marker presence should be unchanged")
+}

--- a/internal/datastore/blockstore_gc_test.go
+++ b/internal/datastore/blockstore_gc_test.go
@@ -1,0 +1,306 @@
+// Copyright 2025 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package datastore
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	badgerds "github.com/dgraph-io/badger/v4"
+	blocks "github.com/ipfs/go-block-format"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcenetwork/corekv"
+	ckbadger "github.com/sourcenetwork/corekv/badger"
+	"github.com/sourcenetwork/corekv/namespace"
+
+	"github.com/sourcenetwork/defradb/internal/keys"
+)
+
+func TestToMergeValueRoundTrip(t *testing.T) {
+	want := time.Unix(1_700_000_000, 0)
+	got, ok := toMergeTime(newToMergeValue(want))
+	require.True(t, ok)
+	require.Equal(t, want.Unix(), got.Unix())
+}
+
+func TestToMergeTimeRejectsLegacyMarker(t *testing.T) {
+	// The older marker format is a single byte with no timestamp.
+	_, ok := toMergeTime([]byte{0xff})
+	require.False(t, ok)
+}
+
+func TestReclaimOrphanBlocks(t *testing.T) {
+	ctx := context.Background()
+	blockNS, _, rootstore := newTestBlockstore(t)
+	defer func() { require.NoError(t, rootstore.Close()) }()
+
+	cutoff := time.Unix(1_700_000_000, 0)
+
+	// Marker older than the cutoff: an abandoned fetch, must be reclaimed.
+	stale := putMarkedBlock(t, ctx, blockNS, []byte("stale"), newToMergeValue(cutoff.Add(-time.Hour)))
+	// Marker newer than the cutoff: a fetch still in flight, must be kept.
+	fresh := putMarkedBlock(t, ctx, blockNS, []byte("fresh"), newToMergeValue(cutoff.Add(time.Hour)))
+	// A marker with no timestamp cannot be aged, and comes from a store with no owner edges
+	// to fall back on, so it is left alone.
+	legacy := putMarkedBlock(t, ctx, blockNS, []byte("legacy"), []byte{0xff})
+	// A merged block has no marker and must never be touched.
+	merged := putUnmarkedBlock(t, ctx, blockNS, []byte("merged"))
+
+	result, err := ReclaimOrphanBlocks(ctx, rootstore, cutoff, nil, 100)
+	require.NoError(t, err)
+	require.Nil(t, result.NextKey, "a completed sweep returns no resume key")
+	require.Equal(t, 1, result.Reclaimed)
+	require.Equal(t, 3, result.Scanned, "only the three marked blocks are scanned, not the merged block")
+	require.Zero(t, result.Repaired)
+	require.Zero(t, result.Conflicts)
+
+	requireReclaimed(t, ctx, blockNS, stale)
+	requireKept(t, ctx, blockNS, legacy, true)
+	requireKept(t, ctx, blockNS, fresh, true)
+	requireKept(t, ctx, blockNS, merged, false)
+}
+
+// A store upgraded in place carries single-byte markers over blocks that merged before the
+// index recorded fetch times, and that merge wrote no owner edge, so an age-only decision
+// deletes blocks a live document still links to.
+func TestReclaimOrphanBlocksNeverReclaimsUntimestampedMarker(t *testing.T) {
+	ctx := context.Background()
+	blockNS, _, rootstore := newTestBlockstore(t)
+	defer func() { require.NoError(t, rootstore.Close()) }()
+
+	legacy := putMarkedBlock(t, ctx, blockNS, []byte("legacy"), []byte{0xff})
+
+	// Far enough ahead that any readable timestamp would be expired.
+	result, err := ReclaimOrphanBlocks(ctx, rootstore, time.Now().Add(time.Hour), nil, 100)
+	require.NoError(t, err)
+	require.Equal(t, 1, result.Scanned)
+	require.Zero(t, result.Reclaimed)
+	require.Zero(t, result.Repaired, "the marker stays, so it is not counted as repaired either")
+
+	requireKept(t, ctx, blockNS, legacy, true)
+}
+
+// A block a document owns must survive an expired marker over it. The marker is not proof
+// the block is garbage; ownership is what decides.
+func TestReclaimOrphanBlocksKeepsBlockOwnedByDocument(t *testing.T) {
+	ctx := context.Background()
+	blockNS, systemNS, rootstore := newTestBlockstore(t)
+	defer func() { require.NoError(t, rootstore.Close()) }()
+
+	cutoff := time.Unix(1_700_000_000, 0)
+	owned := putMarkedBlock(t, ctx, blockNS, []byte("owned"), newToMergeValue(cutoff.Add(-time.Hour)))
+
+	ownerKey := keys.NewBlockCIDToDocIDKey(owned.Cid().String(), "bae-some-document").Bytes()
+	require.NoError(t, systemNS.Set(ctx, ownerKey, []byte{}))
+
+	result, err := ReclaimOrphanBlocks(ctx, rootstore, cutoff, nil, 100)
+	require.NoError(t, err)
+	require.Zero(t, result.Reclaimed)
+	require.Equal(t, 1, result.Repaired)
+
+	requireKept(t, ctx, blockNS, owned, false)
+}
+
+// A batch holding both kinds of outcome: the ownership lookup iterates the store from
+// inside the same transaction that has already deleted an earlier block, so the two must
+// not interfere.
+func TestReclaimOrphanBlocksMixesReclaimAndRepairInOneBatch(t *testing.T) {
+	ctx := context.Background()
+	blockNS, systemNS, rootstore := newTestBlockstore(t)
+	defer func() { require.NoError(t, rootstore.Close()) }()
+
+	cutoff := time.Unix(1_700_000_000, 0)
+	expired := newToMergeValue(cutoff.Add(-time.Hour))
+
+	orphans := make([]blocks.Block, 3)
+	for i := range orphans {
+		orphans[i] = putMarkedBlock(t, ctx, blockNS, []byte{byte('a' + i)}, expired)
+	}
+	owned := putMarkedBlock(t, ctx, blockNS, []byte("owned"), expired)
+	ownerKey := keys.NewBlockCIDToDocIDKey(owned.Cid().String(), "bae-some-document").Bytes()
+	require.NoError(t, systemNS.Set(ctx, ownerKey, []byte{}))
+
+	result, err := ReclaimOrphanBlocks(ctx, rootstore, cutoff, nil, 100)
+	require.NoError(t, err)
+	require.Equal(t, 3, result.Reclaimed)
+	require.Equal(t, 1, result.Repaired)
+	require.Equal(t, 4, result.Scanned)
+
+	for _, block := range orphans {
+		requireReclaimed(t, ctx, blockNS, block)
+	}
+	requireKept(t, ctx, blockNS, owned, false)
+}
+
+// The scan nominates candidates, then the delete phase re-reads each marker. A merge
+// that commits in that window clears the marker, and the block must be left alone.
+func TestReclaimBatchSkipsMarkerClearedAfterScan(t *testing.T) {
+	ctx := context.Background()
+	blockNS, _, rootstore := newTestBlockstore(t)
+	defer func() { require.NoError(t, rootstore.Close()) }()
+
+	cutoff := time.Unix(1_700_000_000, 0)
+	block := putMarkedBlock(t, ctx, blockNS, []byte("merged-after-scan"), newToMergeValue(cutoff.Add(-time.Hour)))
+	marker := newToMergeKey(block.Cid().Bytes())
+
+	// Stand in for the merge committing between the scan and the delete phase:
+	// MarkAsMerged removes the marker inside the merge transaction.
+	require.NoError(t, blockNS.Delete(ctx, marker))
+
+	var result SweepResult
+	require.NoError(t, reclaimBatch(ctx, rootstore, cutoff, [][]byte{marker}, &result))
+	require.Zero(t, result.Reclaimed)
+
+	hasBlock, err := blockNS.Has(ctx, block.Cid().Bytes())
+	require.NoError(t, err)
+	require.True(t, hasBlock, "a block whose merge committed after the scan must survive")
+}
+
+// The delete phase re-decides on its own, so it has to apply the same timestamp rule the scan
+// does. Handed an untimestamped marker directly, it must still leave the block alone.
+func TestReclaimBatchSkipsUntimestampedMarker(t *testing.T) {
+	ctx := context.Background()
+	blockNS, _, rootstore := newTestBlockstore(t)
+	defer func() { require.NoError(t, rootstore.Close()) }()
+
+	block := putMarkedBlock(t, ctx, blockNS, []byte("legacy"), []byte{0xff})
+	marker := newToMergeKey(block.Cid().Bytes())
+
+	var result SweepResult
+	require.NoError(t, reclaimBatch(ctx, rootstore, time.Now().Add(time.Hour), [][]byte{marker}, &result))
+	require.Zero(t, result.Reclaimed)
+
+	hasBlock, err := blockNS.Has(ctx, block.Cid().Bytes())
+	require.NoError(t, err)
+	require.True(t, hasBlock, "an unageable marker is not grounds to delete a block")
+}
+
+// The sweep's safety rests on the store aborting a transaction that deletes a marker it
+// read when another transaction wrote that same key first. That is a storage-layer
+// property, so it is asserted directly: turning conflict detection off would otherwise
+// reintroduce the race silently.
+func TestStoreDetectsConflictOnMarkerReadThenDelete(t *testing.T) {
+	ctx := context.Background()
+	blockNS, _, rootstore := newTestBlockstore(t)
+	defer func() { require.NoError(t, rootstore.Close()) }()
+
+	block := putMarkedBlock(t, ctx, blockNS, []byte("contended"), newToMergeValue(time.Unix(1, 0)))
+	marker := newToMergeKey(block.Cid().Bytes())
+
+	sweep := rootstore.NewTxn(false)
+	defer sweep.Discard()
+	sweepCtx := corekv.SetCtxTxn(ctx, sweep)
+	sweepNS := namespace.Wrap(rootstore, []byte{blockStoreKey})
+
+	// The sweep reads the marker, putting it in the transaction's read set.
+	_, err := sweepNS.Get(sweepCtx, marker)
+	require.NoError(t, err)
+
+	// A merge commits against the same marker.
+	require.NoError(t, blockNS.Delete(ctx, marker))
+
+	require.NoError(t, sweepNS.Delete(sweepCtx, block.Cid().Bytes()))
+	require.ErrorIs(t, sweep.Commit(), corekv.ErrTxnConflict,
+		"a read marker written by another transaction must abort the sweep's commit")
+}
+
+func TestReclaimOrphanBlocksStopsOnCancelledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	blockNS, _, rootstore := newTestBlockstore(t)
+	defer func() { require.NoError(t, rootstore.Close()) }()
+
+	cutoff := time.Unix(1_700_000_000, 0)
+	block := putMarkedBlock(t, ctx, blockNS, []byte("stale"), newToMergeValue(cutoff.Add(-time.Hour)))
+	putMarkedBlock(t, ctx, blockNS, []byte("stale2"), newToMergeValue(cutoff.Add(-time.Hour)))
+	putMarkedBlock(t, ctx, blockNS, []byte("stale3"), newToMergeValue(cutoff.Add(-time.Hour)))
+
+	cancel()
+	result, err := ReclaimOrphanBlocks(ctx, rootstore, cutoff, nil, 100)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Zero(t, result.Scanned, "a cancelled sweep must stop before walking the index")
+	requireKept(t, ctx, blockNS, block, true, "a cancelled sweep must not have deleted anything")
+}
+
+func TestReclaimOrphanBlocksResumesAcrossCalls(t *testing.T) {
+	ctx := context.Background()
+	blockNS, _, rootstore := newTestBlockstore(t)
+	defer func() { require.NoError(t, rootstore.Close()) }()
+
+	cutoff := time.Unix(1_700_000_000, 0)
+	stale := newToMergeValue(cutoff.Add(-time.Hour))
+
+	const total = 5
+	created := make([]blocks.Block, total)
+	for i := range created {
+		created[i] = putMarkedBlock(t, ctx, blockNS, []byte{byte('a' + i)}, stale)
+	}
+
+	// A scan limit below the marker count forces the sweep to resume via the cursor.
+	var cursor []byte
+	var reclaimedTotal, scannedTotal, calls int
+	for {
+		result, err := ReclaimOrphanBlocks(ctx, rootstore, cutoff, cursor, 2)
+		require.NoError(t, err)
+		reclaimedTotal += result.Reclaimed
+		scannedTotal += result.Scanned
+		calls++
+		require.LessOrEqual(t, calls, total+1, "sweep did not make progress")
+		if result.NextKey == nil {
+			break
+		}
+		cursor = result.NextKey
+	}
+
+	require.Greater(t, calls, 1, "a scan limit below the index size must take several calls")
+	require.Equal(t, total, reclaimedTotal)
+	require.Equal(t, total, scannedTotal, "each marker is scanned exactly once across the resumed calls")
+	for _, block := range created {
+		requireReclaimed(t, ctx, blockNS, block)
+	}
+}
+
+func newTestBlockstore(t *testing.T) (blockNS, systemNS corekv.ReaderWriter, rootstore corekv.TxnStore) {
+	t.Helper()
+	store, err := ckbadger.NewDatastore("", badgerds.DefaultOptions("").WithInMemory(true))
+	require.NoError(t, err)
+	return namespace.Wrap(store, []byte{blockStoreKey}),
+		namespace.Wrap(store, []byte{systemStoreKey}),
+		store
+}
+
+func requireReclaimed(t *testing.T, ctx context.Context, blockNS corekv.ReaderWriter, block blocks.Block) {
+	t.Helper()
+	hasBlock, err := blockNS.Has(ctx, block.Cid().Bytes())
+	require.NoError(t, err)
+	require.False(t, hasBlock, "block should be reclaimed")
+	hasMarker, err := blockNS.Has(ctx, newToMergeKey(block.Cid().Bytes()))
+	require.NoError(t, err)
+	require.False(t, hasMarker, "marker should be reclaimed")
+}
+
+func requireKept(
+	t *testing.T,
+	ctx context.Context,
+	blockNS corekv.ReaderWriter,
+	block blocks.Block,
+	withMarker bool,
+	msgAndArgs ...any,
+) {
+	t.Helper()
+	hasBlock, err := blockNS.Has(ctx, block.Cid().Bytes())
+	require.NoError(t, err)
+	require.True(t, hasBlock, append([]any{"block should be kept"}, msgAndArgs...)...)
+	hasMarker, err := blockNS.Has(ctx, newToMergeKey(block.Cid().Bytes()))
+	require.NoError(t, err)
+	require.Equal(t, withMarker, hasMarker, "marker presence should be unchanged")
+}

--- a/internal/datastore/blockstore_refresh_test.go
+++ b/internal/datastore/blockstore_refresh_test.go
@@ -1,0 +1,131 @@
+// Copyright 2025 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package datastore
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	blocks "github.com/ipfs/go-block-format"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcenetwork/corekv"
+	"github.com/sourcenetwork/immutable"
+)
+
+// The refresh keeps a re-received block out of the sweep while it is still waiting to merge.
+func TestRefresh_MovesMarkerWhileUnmerged(t *testing.T) {
+	ctx := context.Background()
+	_, _, rootstore := newTestBlockstore(t)
+	bs := P2PBlockstoreFrom(rootstore, immutable.None[int]())
+	block := blocks.NewBlock([]byte("unmerged"))
+
+	require.NoError(t, bs.Put(ctx, block))
+	first := backdateMarker(t, ctx, rootstore, block)
+
+	require.NoError(t, bs.Put(ctx, block))
+	second := markerStamp(t, ctx, rootstore, block)
+
+	require.True(t, second.After(first), "re-put of an unmerged block should move the marker forward")
+}
+
+// A block that has merged has no marker, and re-receiving it must not make it look unmerged again.
+func TestRefresh_LeavesMergedBlockMerged(t *testing.T) {
+	ctx := context.Background()
+	_, _, rootstore := newTestBlockstore(t)
+	bs := P2PBlockstoreFrom(rootstore, immutable.None[int]())
+	block := blocks.NewBlock([]byte("merged"))
+
+	require.NoError(t, bs.Put(ctx, block))
+	require.NoError(t, bs.MarkAsMerged(ctx, block.Cid()))
+
+	require.NoError(t, bs.Put(ctx, block))
+
+	merged, err := bs.IsMerged(ctx, block.Cid())
+	require.NoError(t, err)
+	require.True(t, merged, "re-put of a merged block must leave it merged")
+}
+
+// A block that merges while it is being re-received must stay merged, whichever of the two commits
+// first. The refresh reads the marker inside its own transaction, so a merge clearing that marker
+// concurrently fails the refresh commit rather than putting the marker back.
+func TestRefresh_ConcurrentMergeLeavesBlockMerged(t *testing.T) {
+	ctx := context.Background()
+	_, _, rootstore := newTestBlockstore(t)
+	bs := P2PBlockstoreFrom(rootstore, immutable.None[int]())
+
+	const attempts = 300
+	resurrected := 0
+
+	for i := 0; i < attempts; i++ {
+		block := blocks.NewBlock([]byte{byte(i), byte(i >> 8), 'r'})
+		require.NoError(t, bs.Put(ctx, block))
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() { defer wg.Done(); _ = bs.Put(ctx, block) }()
+		go func() { defer wg.Done(); _ = bs.MarkAsMerged(ctx, block.Cid()) }()
+		wg.Wait()
+
+		merged, err := bs.IsMerged(ctx, block.Cid())
+		require.NoError(t, err)
+		if !merged {
+			resurrected++
+		}
+	}
+
+	require.Zero(t, resurrected, "%d of %d merged blocks were marked unmerged again", resurrected, attempts)
+}
+
+// PutMany takes the same early return as Put for a block that is already stored, and a batch can
+// hold both states at once: one block still waiting to merge, another already merged.
+func TestRefresh_PutManyGuardsEachBlock(t *testing.T) {
+	ctx := context.Background()
+	_, _, rootstore := newTestBlockstore(t)
+	bs := P2PBlockstoreFrom(rootstore, immutable.None[int]())
+
+	unmerged := blocks.NewBlock([]byte("batched, still waiting"))
+	merged := blocks.NewBlock([]byte("batched, already merged"))
+
+	require.NoError(t, bs.PutMany(ctx, []blocks.Block{unmerged, merged}))
+	require.NoError(t, bs.MarkAsMerged(ctx, merged.Cid()))
+	first := backdateMarker(t, ctx, rootstore, unmerged)
+
+	require.NoError(t, bs.PutMany(ctx, []blocks.Block{unmerged, merged}))
+
+	second := markerStamp(t, ctx, rootstore, unmerged)
+	require.True(t, second.After(first), "re-put of an unmerged block should move the marker forward")
+
+	stillMerged, err := bs.IsMerged(ctx, merged.Cid())
+	require.NoError(t, err)
+	require.True(t, stillMerged, "re-put of a merged block must leave it merged")
+}
+
+func markerStamp(t *testing.T, ctx context.Context, rootstore corekv.Reader, block blocks.Block) time.Time {
+	t.Helper()
+	raw, err := rootstore.Get(ctx, append([]byte{blockStoreKey}, newToMergeKey(block.Cid().Bytes())...))
+	require.NoError(t, err)
+	stamp, ok := toMergeTime(raw)
+	require.True(t, ok, "marker should carry a timestamp")
+	return stamp
+}
+
+// backdateMarker rewinds a block's marker and returns the time it now carries, so a refresh is
+// observable without waiting out the marker's one-second resolution.
+func backdateMarker(t *testing.T, ctx context.Context, rootstore corekv.Writer, block blocks.Block) time.Time {
+	t.Helper()
+	stamp := time.Now().Add(-time.Hour)
+	require.NoError(t, rootstore.Set(ctx,
+		append([]byte{blockStoreKey}, newToMergeKey(block.Cid().Bytes())...), newToMergeValue(stamp)))
+	return stamp
+}

--- a/internal/datastore/blockstore_test.go
+++ b/internal/datastore/blockstore_test.go
@@ -13,6 +13,7 @@ package datastore
 import (
 	"context"
 	"testing"
+	"time"
 
 	blocks "github.com/ipfs/go-block-format"
 	"github.com/stretchr/testify/require"
@@ -32,7 +33,7 @@ func TestIsMerged_RolledBackTxnLeavesBlockUnmerged(t *testing.T) {
 
 	// A fetched but unmerged block: stored, with its to-merge marker set.
 	blockNS := namespace.Wrap(rootstore, []byte{blockStoreKey})
-	block := putMarkedBlock(t, ctx, blockNS, []byte("rolled back"), []byte{objectMarker})
+	block := putMarkedBlock(t, ctx, blockNS, []byte("rolled back"), newToMergeValue(time.Unix(1_700_000_000, 0)))
 
 	txn := NewTxnFrom(rootstore, lock.NewLockSet(), 1, false, immutable.None[int]())
 	require.NoError(t, txn.Blockstore().MarkAsMerged(ctx, block.Cid()))
@@ -48,7 +49,7 @@ func TestIsMerged_CommittedTxnMarksBlockMerged(t *testing.T) {
 	rootstore := memory.NewDatastore(ctx)
 
 	blockNS := namespace.Wrap(rootstore, []byte{blockStoreKey})
-	block := putMarkedBlock(t, ctx, blockNS, []byte("committed"), []byte{objectMarker})
+	block := putMarkedBlock(t, ctx, blockNS, []byte("committed"), newToMergeValue(time.Unix(1_700_000_000, 0)))
 
 	txn := NewTxnFrom(rootstore, lock.NewLockSet(), 1, false, immutable.None[int]())
 	require.NoError(t, txn.Blockstore().MarkAsMerged(ctx, block.Cid()))
@@ -64,7 +65,7 @@ func TestIsMerged_DeletedBlockIsNotMerged(t *testing.T) {
 	rootstore := memory.NewDatastore(ctx)
 
 	blockNS := namespace.Wrap(rootstore, []byte{blockStoreKey})
-	block := putMarkedBlock(t, ctx, blockNS, []byte("deleted"), []byte{objectMarker})
+	block := putMarkedBlock(t, ctx, blockNS, []byte("deleted"), newToMergeValue(time.Unix(1_700_000_000, 0)))
 
 	blockstore := BlockstoreFrom(rootstore, immutable.None[int]())
 	require.NoError(t, blockstore.MarkAsMerged(ctx, block.Cid()))
@@ -107,7 +108,7 @@ func TestIsMerged_ReputtingAMergedBlockLeavesItMerged(t *testing.T) {
 
 			blockNS := namespace.Wrap(rootstore, []byte{blockStoreKey})
 			block := putMarkedBlock(t, ctx, blockNS, []byte("merged then re-imported"),
-				[]byte{objectMarker})
+				newToMergeValue(time.Unix(1_700_000_000, 0)))
 
 			blockstore := BlockstoreFrom(rootstore, immutable.None[int]())
 			require.NoError(t, blockstore.MarkAsMerged(ctx, block.Cid()))
@@ -130,7 +131,7 @@ func TestIsMerged_UnmergedAndAbsentBlocks(t *testing.T) {
 	blockNS := namespace.Wrap(rootstore, []byte{blockStoreKey})
 	blockstore := BlockstoreFrom(rootstore, immutable.None[int]())
 
-	marked := putMarkedBlock(t, ctx, blockNS, []byte("still marked"), []byte{objectMarker})
+	marked := putMarkedBlock(t, ctx, blockNS, []byte("still marked"), newToMergeValue(time.Unix(1_700_000_000, 0)))
 	merged, err := blockstore.IsMerged(ctx, marked.Cid())
 	require.NoError(t, err)
 	require.False(t, merged, "a block still carrying its to-merge marker is not merged")

--- a/internal/datastore/multi.go
+++ b/internal/datastore/multi.go
@@ -110,9 +110,10 @@ func blockstoreFrom(rootstore corekv.ReaderWriter, chunkSize immutable.Option[in
 	return newBlockstore(store)
 }
 
-func P2PBlockstoreFrom(rootstore corekv.ReaderWriter, chunkSize immutable.Option[int]) Blockstore {
+func P2PBlockstoreFrom(rootstore corekv.TxnReaderWriter, chunkSize immutable.Option[int]) Blockstore {
 	return &p2pBlockStore{
-		bstore: blockstoreFrom(rootstore, chunkSize),
+		bstore:    blockstoreFrom(rootstore, chunkSize),
+		rootstore: rootstore,
 	}
 }
 

--- a/internal/db/blockowner/blockowner.go
+++ b/internal/db/blockowner/blockowner.go
@@ -1,0 +1,118 @@
+// Copyright 2025 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// Package blockowner reads the systemstore index recording which documents own a
+// block. It takes an explicit store rather than a transaction from the context, so
+// that layers below the db package can consult ownership too.
+package blockowner
+
+import (
+	"bytes"
+	"context"
+	stderrors "errors"
+
+	"github.com/ipfs/go-cid"
+
+	"github.com/sourcenetwork/corekv"
+
+	"github.com/sourcenetwork/defradb/internal/keys"
+)
+
+// prefix is the key prefix under which every owner DocID of blockCID is stored.
+func prefix(blockCID cid.Cid) []byte {
+	return append(keys.NewBlockCIDToDocIDKey(blockCID.String(), "").Bytes(), '/')
+}
+
+// DocIDs returns every DocID that owns blockCID.
+// Field blocks can be byte-identical across documents, so ownership is a set.
+// The index stores DocIDs directly so block ownership survives doc-ref cleanup.
+func DocIDs(ctx context.Context, store corekv.Reader, blockCID cid.Cid) ([]string, error) {
+	if !blockCID.Defined() {
+		return nil, nil
+	}
+
+	p := prefix(blockCID)
+	iter, err := store.Iterator(ctx, corekv.IterOptions{
+		Prefix:   p,
+		KeysOnly: true,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var docIDs []string
+	for {
+		hasNext, err := iter.Next()
+		if err != nil {
+			return nil, stderrors.Join(err, iter.Close())
+		}
+		if !hasNext {
+			break
+		}
+		docID := bytes.TrimPrefix(iter.Key(), p)
+		if len(docID) != 0 {
+			docIDs = append(docIDs, string(docID))
+		}
+	}
+	if err := iter.Close(); err != nil {
+		return nil, err
+	}
+	return docIDs, nil
+}
+
+// HasOwners reports whether any document still owns blockCID. Prefer this over DocIDs
+// when only the presence of an owner matters: it stops at the first match rather than
+// materializing the whole owner set.
+func HasOwners(ctx context.Context, store corekv.Reader, blockCID cid.Cid) (bool, error) {
+	return HasOwnersExcept(ctx, store, blockCID, nil)
+}
+
+// HasOwnersExcept reports whether any document owns blockCID, ignoring owner edges whose keys
+// are in excluded. It lets a caller read ownership from a read-only snapshot while treating edges
+// it deleted in a separate, uncommitted transaction as already gone. Excluded keys are
+// BlockCIDToDocIDKey bytes, as yielded by the owner-edge iterator; a nil set makes this a plain
+// ownership scan. It stops at the first surviving owner.
+func HasOwnersExcept(
+	ctx context.Context,
+	store corekv.Reader,
+	blockCID cid.Cid,
+	excluded map[string]struct{},
+) (bool, error) {
+	if !blockCID.Defined() {
+		return false, nil
+	}
+
+	p := prefix(blockCID)
+	iter, err := store.Iterator(ctx, corekv.IterOptions{
+		Prefix:   p,
+		KeysOnly: true,
+	})
+	if err != nil {
+		return false, err
+	}
+
+	for {
+		hasNext, err := iter.Next()
+		if err != nil {
+			return false, stderrors.Join(err, iter.Close())
+		}
+		if !hasNext {
+			break
+		}
+		if len(bytes.TrimPrefix(iter.Key(), p)) == 0 {
+			continue
+		}
+		if _, isExcluded := excluded[string(iter.Key())]; isExcluded {
+			continue
+		}
+		return true, iter.Close()
+	}
+	return false, iter.Close()
+}

--- a/internal/db/blockowner/blockowner_test.go
+++ b/internal/db/blockowner/blockowner_test.go
@@ -1,0 +1,215 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package blockowner
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	blocks "github.com/ipfs/go-block-format"
+	"github.com/ipfs/go-cid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcenetwork/corekv"
+	"github.com/sourcenetwork/corekv/memory"
+
+	"github.com/sourcenetwork/defradb/internal/keys"
+)
+
+func TestHasOwners(t *testing.T) {
+	ctx := context.Background()
+	store := memory.NewDatastore(ctx)
+
+	fieldCID := blocks.NewBlock([]byte("field value")).Cid()
+
+	has, err := HasOwners(ctx, store, fieldCID)
+	require.NoError(t, err)
+	require.False(t, has, "a block with no recorded owners has none")
+
+	has, err = HasOwners(ctx, store, cid.Undef)
+	require.NoError(t, err)
+	require.False(t, has, "an undefined CID has no owners")
+
+	setOwner(t, ctx, store, fieldCID, "bae-doc-one")
+	setOwner(t, ctx, store, fieldCID, "bae-doc-two")
+
+	has, err = HasOwners(ctx, store, fieldCID)
+	require.NoError(t, err)
+	require.True(t, has)
+
+	// One of two owners removed: the block is still owned.
+	deleteOwner(t, ctx, store, fieldCID, "bae-doc-one")
+	has, err = HasOwners(ctx, store, fieldCID)
+	require.NoError(t, err)
+	require.True(t, has)
+
+	deleteOwner(t, ctx, store, fieldCID, "bae-doc-two")
+	has, err = HasOwners(ctx, store, fieldCID)
+	require.NoError(t, err)
+	require.False(t, has)
+}
+
+func TestDocIDs(t *testing.T) {
+	ctx := context.Background()
+	store := memory.NewDatastore(ctx)
+
+	fieldCID := blocks.NewBlock([]byte("field value")).Cid()
+
+	docIDs, err := DocIDs(ctx, store, cid.Undef)
+	require.NoError(t, err)
+	require.Empty(t, docIDs, "an undefined CID has no owners")
+
+	// A block CID can be owned by more than one document.
+	setOwner(t, ctx, store, fieldCID, "bae-doc-one")
+	setOwner(t, ctx, store, fieldCID, "bae-doc-two")
+	docIDs, err = DocIDs(ctx, store, fieldCID)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"bae-doc-one", "bae-doc-two"}, docIDs)
+
+	deleteOwner(t, ctx, store, fieldCID, "bae-doc-one")
+	docIDs, err = DocIDs(ctx, store, fieldCID)
+	require.NoError(t, err)
+	require.Equal(t, []string{"bae-doc-two"}, docIDs)
+
+	deleteOwner(t, ctx, store, fieldCID, "bae-doc-two")
+	docIDs, err = DocIDs(ctx, store, fieldCID)
+	require.NoError(t, err)
+	require.Empty(t, docIDs)
+}
+
+// HasOwners reports ownership after reading a single key regardless of how many
+// documents own the block, unlike DocIDs which reads every owner.
+func TestHasOwnersStopsAtFirstOwner(t *testing.T) {
+	ctx := context.Background()
+	store := memory.NewDatastore(ctx)
+
+	fieldCID := blocks.NewBlock([]byte("shared field value")).Cid()
+	const owners = 500
+	for i := range owners {
+		setOwner(t, ctx, store, fieldCID, fmt.Sprintf("bae-doc-%d", i))
+	}
+
+	var hasReads int
+	has, err := HasOwners(ctx, countingReader{store, &hasReads}, fieldCID)
+	require.NoError(t, err)
+	require.True(t, has)
+	require.Equal(t, 1, hasReads, "HasOwners must stop at the first owner")
+
+	var listReads int
+	all, err := DocIDs(ctx, countingReader{store, &listReads}, fieldCID)
+	require.NoError(t, err)
+	require.Len(t, all, owners)
+	require.Greater(t, listReads, owners, "DocIDs reads every owner")
+}
+
+// A block whose only owner edge is excluded reports no owner, while the same block
+// reports an owner when nothing is excluded.
+func TestHasOwnersExceptExcludedSoleOwner(t *testing.T) {
+	ctx := context.Background()
+	store := memory.NewDatastore(ctx)
+
+	fieldCID := blocks.NewBlock([]byte("field value")).Cid()
+	setOwner(t, ctx, store, fieldCID, "bae-doc-one")
+
+	has, err := HasOwnersExcept(ctx, store, fieldCID, nil)
+	require.NoError(t, err)
+	require.True(t, has, "with nothing excluded the block has an owner")
+
+	excluded := map[string]struct{}{ownerKey(fieldCID, "bae-doc-one"): {}}
+	has, err = HasOwnersExcept(ctx, store, fieldCID, excluded)
+	require.NoError(t, err)
+	require.False(t, has, "excluding the only owner edge reports no owner")
+}
+
+// A block shared by two documents still reports an owner while any of its edges is
+// unexcluded, and reports none only once all are.
+func TestHasOwnersExceptKeepsUnexcludedOwner(t *testing.T) {
+	ctx := context.Background()
+	store := memory.NewDatastore(ctx)
+
+	fieldCID := blocks.NewBlock([]byte("shared field value")).Cid()
+	setOwner(t, ctx, store, fieldCID, "bae-doc-one")
+	setOwner(t, ctx, store, fieldCID, "bae-doc-two")
+
+	excluded := map[string]struct{}{ownerKey(fieldCID, "bae-doc-one"): {}}
+	has, err := HasOwnersExcept(ctx, store, fieldCID, excluded)
+	require.NoError(t, err)
+	require.True(t, has, "one of two owners excluded: the block is still owned")
+
+	excluded[ownerKey(fieldCID, "bae-doc-two")] = struct{}{}
+	has, err = HasOwnersExcept(ctx, store, fieldCID, excluded)
+	require.NoError(t, err)
+	require.False(t, has, "both owners excluded: no owner remains")
+}
+
+// The scan skips excluded owners but stops at the first owner that is not excluded,
+// rather than reading the whole owner set.
+func TestHasOwnersExceptStopsAtFirstUnexcludedOwner(t *testing.T) {
+	ctx := context.Background()
+	store := memory.NewDatastore(ctx)
+
+	fieldCID := blocks.NewBlock([]byte("shared field value")).Cid()
+	const owners = 500
+	for i := range owners {
+		setOwner(t, ctx, store, fieldCID, fmt.Sprintf("bae-doc-%03d", i))
+	}
+
+	// Owner edges iterate in key order, so excluding the first makes the scan skip it and
+	// stop at the second: two advances, not one and not the whole set.
+	excluded := map[string]struct{}{ownerKey(fieldCID, "bae-doc-000"): {}}
+	var reads int
+	has, err := HasOwnersExcept(ctx, countingReader{store, &reads}, fieldCID, excluded)
+	require.NoError(t, err)
+	require.True(t, has)
+	require.Equal(t, 2, reads, "scan skips the excluded owner and stops at the next")
+}
+
+// ownerKey builds the owner-edge key for (blockCID, docID), the same bytes the owner-edge
+// iterator yields and that HasOwnersExcept expects its excluded set to hold.
+func ownerKey(blockCID cid.Cid, docID string) string {
+	return string(keys.NewBlockCIDToDocIDKey(blockCID.String(), docID).Bytes())
+}
+
+func setOwner(t *testing.T, ctx context.Context, store corekv.Writer, blockCID cid.Cid, docID string) {
+	t.Helper()
+	require.NoError(t, store.Set(ctx, []byte(ownerKey(blockCID, docID)), []byte{}))
+}
+
+func deleteOwner(t *testing.T, ctx context.Context, store corekv.Writer, blockCID cid.Cid, docID string) {
+	t.Helper()
+	require.NoError(t, store.Delete(ctx, []byte(ownerKey(blockCID, docID))))
+}
+
+// countingReader wraps a corekv.Reader and tallies iterator advances so a test can assert
+// how much of a key range a function scans.
+type countingReader struct {
+	corekv.Reader
+	nextCalls *int
+}
+
+func (r countingReader) Iterator(ctx context.Context, opts corekv.IterOptions) (corekv.Iterator, error) {
+	iter, err := r.Reader.Iterator(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+	return &countingIterator{Iterator: iter, nextCalls: r.nextCalls}, nil
+}
+
+type countingIterator struct {
+	corekv.Iterator
+	nextCalls *int
+}
+
+func (it *countingIterator) Next() (bool, error) {
+	*it.nextCalls++
+	return it.Iterator.Next()
+}

--- a/internal/db/collection_retriever.go
+++ b/internal/db/collection_retriever.go
@@ -19,6 +19,7 @@ import (
 	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/options"
+	"github.com/sourcenetwork/defradb/internal/db/blockowner"
 	"github.com/sourcenetwork/defradb/internal/db/id"
 	"github.com/sourcenetwork/defradb/internal/keys"
 	"github.com/sourcenetwork/defradb/internal/utils"
@@ -47,7 +48,7 @@ func (r collectionRetriever) ResolveBlockDocIDs(ctx context.Context, blockCID ci
 	}
 	defer txn.Discard()
 
-	return id.GetDocIDsForBlockFromStore(ctx, txn.Systemstore(), blockCID)
+	return blockowner.DocIDs(ctx, txn.Systemstore(), blockCID)
 }
 
 // RetrieveCollectionFromDocID retrieves a collection from a document ID.

--- a/internal/db/collection_truncate.go
+++ b/internal/db/collection_truncate.go
@@ -25,6 +25,7 @@ import (
 	coreblock "github.com/sourcenetwork/defradb/internal/core/block"
 	"github.com/sourcenetwork/defradb/internal/datastore"
 	"github.com/sourcenetwork/defradb/internal/db/action"
+	"github.com/sourcenetwork/defradb/internal/db/blockowner"
 	"github.com/sourcenetwork/defradb/internal/db/id"
 	"github.com/sourcenetwork/defradb/internal/keys"
 	"github.com/sourcenetwork/defradb/internal/utils"
@@ -521,7 +522,7 @@ func (c *collection) deleteBlocks(
 			ownerCtx = readCtx
 		}
 
-		hasOwners, err := id.BlockHasOwnersExcept(ownerCtx, systemstore, blockCID, prunedOwners)
+		hasOwners, err := blockowner.HasOwnersExcept(ownerCtx, systemstore, blockCID, prunedOwners)
 		if err != nil {
 			return false, err
 		}

--- a/internal/db/collection_truncate_test.go
+++ b/internal/db/collection_truncate_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/sourcenetwork/defradb/client"
+	"github.com/sourcenetwork/defradb/internal/db/blockowner"
 	"github.com/sourcenetwork/defradb/internal/db/id"
 	"github.com/sourcenetwork/defradb/internal/keys"
 )
@@ -54,7 +55,7 @@ func TestCollectionTruncateRemovesDocIDMappings(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, found)
 
-	blockDocIDs, err := id.GetDocIDsForBlockFromStore(
+	blockDocIDs, err := blockowner.DocIDs(
 		txnCtx,
 		dbTxn.Systemstore(),
 		genesisFieldCID,
@@ -85,7 +86,7 @@ func TestCollectionTruncateRemovesDocIDMappings(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, found)
 
-	blockDocIDs, err = id.GetDocIDsForBlockFromStore(
+	blockDocIDs, err = blockowner.DocIDs(
 		txnCtx,
 		dbTxn.Systemstore(),
 		genesisFieldCID,
@@ -144,7 +145,7 @@ func TestCollectionDeleteDocIDMappingsRemovesDocAliases(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, found)
 
-	blockDocIDs, err := id.GetDocIDsForBlockFromStore(
+	blockDocIDs, err := blockowner.DocIDs(
 		txnCtx,
 		dbTxn.Systemstore(),
 		genesisFieldCID,

--- a/internal/db/document_test.go
+++ b/internal/db/document_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/sourcenetwork/defradb/client"
+	"github.com/sourcenetwork/defradb/internal/db/blockowner"
 	"github.com/sourcenetwork/defradb/internal/db/id"
 	"github.com/sourcenetwork/defradb/internal/keys"
 )
@@ -208,7 +209,7 @@ func TestBlockDocIDMappingSharedFieldBlockHasAllOwners(t *testing.T) {
 	require.True(t, ok)
 	txnCtx := InitContext(ctx, dbTxn)
 
-	docIDs, err := id.GetDocIDsForBlockFromStore(txnCtx, dbTxn.Systemstore(), nameCIDA)
+	docIDs, err := blockowner.DocIDs(txnCtx, dbTxn.Systemstore(), nameCIDA)
 	require.NoError(t, err)
 	require.ElementsMatch(t, []string{docA.ID().String(), docB.ID().String()}, docIDs)
 }

--- a/internal/db/document_test.go
+++ b/internal/db/document_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/sourcenetwork/defradb/client"
+	"github.com/sourcenetwork/defradb/internal/db/blockowner"
 	"github.com/sourcenetwork/defradb/internal/db/id"
 	"github.com/sourcenetwork/defradb/internal/keys"
 )
@@ -265,7 +266,7 @@ func TestBlockDocIDMappingSharedFieldBlockHasAllOwners(t *testing.T) {
 	require.True(t, ok)
 	txnCtx := InitContext(ctx, dbTxn)
 
-	docIDs, err := id.GetDocIDsForBlockFromStore(txnCtx, dbTxn.Systemstore(), nameCIDA)
+	docIDs, err := blockowner.DocIDs(txnCtx, dbTxn.Systemstore(), nameCIDA)
 	require.NoError(t, err)
 	require.ElementsMatch(t, []string{docA.ID().String(), docB.ID().String()}, docIDs)
 }

--- a/internal/db/fetcher/versioned.go
+++ b/internal/db/fetcher/versioned.go
@@ -33,6 +33,7 @@ import (
 	"github.com/sourcenetwork/defradb/internal/core/crdt"
 	"github.com/sourcenetwork/defradb/internal/datastore"
 	acpDB "github.com/sourcenetwork/defradb/internal/db/acp"
+	"github.com/sourcenetwork/defradb/internal/db/blockowner"
 	"github.com/sourcenetwork/defradb/internal/db/id"
 	"github.com/sourcenetwork/defradb/internal/db/lock"
 	"github.com/sourcenetwork/defradb/internal/keys"
@@ -498,7 +499,7 @@ func (vf *VersionedFetcher) docShortIDForBlock(
 		return 0, nil
 	}
 
-	owners, err := id.GetDocIDsForBlockFromStore(
+	owners, err := blockowner.DocIDs(
 		vf.ctx,
 		vf.txn.Systemstore(),
 		blockCID,

--- a/internal/db/id/document.go
+++ b/internal/db/id/document.go
@@ -11,7 +11,6 @@
 package id
 
 import (
-	"bytes"
 	"context"
 	stderrors "errors"
 
@@ -20,6 +19,7 @@ import (
 	"github.com/sourcenetwork/corekv"
 	"github.com/sourcenetwork/defradb/errors"
 	"github.com/sourcenetwork/defradb/internal/datastore"
+	"github.com/sourcenetwork/defradb/internal/db/blockowner"
 	"github.com/sourcenetwork/defradb/internal/keys"
 )
 
@@ -143,105 +143,11 @@ func SetBlockDocIDMapping(
 	)
 }
 
-// GetDocIDsForBlockFromStore returns every DocID that owns blockCID.
-// Field blocks can be byte-identical across documents, so ownership is a set.
-// The index stores DocIDs directly so block ownership survives doc-ref cleanup.
+// GetDocIDsForBlock returns every DocID that owns blockCID, from the transaction on
+// the context.
 func GetDocIDsForBlock(ctx context.Context, blockCID cid.Cid) ([]string, error) {
 	txn := datastore.CtxMustGetTxn(ctx)
-	return GetDocIDsForBlockFromStore(ctx, txn.Systemstore(), blockCID)
-}
-
-func GetDocIDsForBlockFromStore(
-	ctx context.Context,
-	store corekv.Reader,
-	blockCID cid.Cid,
-) ([]string, error) {
-	if !blockCID.Defined() {
-		return nil, nil
-	}
-
-	prefix := blockOwnersPrefix(blockCID)
-	iter, err := store.Iterator(ctx, corekv.IterOptions{
-		Prefix:   prefix,
-		KeysOnly: true,
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	var docIDs []string
-	for {
-		hasNext, err := iter.Next()
-		if err != nil {
-			return nil, stderrors.Join(err, iter.Close())
-		}
-		if !hasNext {
-			break
-		}
-		docID := bytes.TrimPrefix(iter.Key(), prefix)
-		if len(docID) != 0 {
-			docIDs = append(docIDs, string(docID))
-		}
-	}
-	if err := iter.Close(); err != nil {
-		return nil, err
-	}
-	return docIDs, nil
-}
-
-// blockOwnersPrefix is the key prefix under which every owner DocID of blockCID is stored.
-func blockOwnersPrefix(blockCID cid.Cid) []byte {
-	return append(keys.NewBlockCIDToDocIDKey(blockCID.String(), "").Bytes(), '/')
-}
-
-// BlockHasOwners reports whether any document still owns blockCID. Prefer this over
-// GetDocIDsForBlockFromStore when only the presence of an owner matters: it stops at the
-// first match rather than materializing the whole owner set.
-func BlockHasOwners(ctx context.Context, store corekv.Reader, blockCID cid.Cid) (bool, error) {
-	return BlockHasOwnersExcept(ctx, store, blockCID, nil)
-}
-
-// BlockHasOwnersExcept reports whether any document owns blockCID, ignoring owner edges whose keys
-// are in excluded. It lets a caller read ownership from a read-only snapshot while treating edges
-// it deleted in a separate, uncommitted transaction as already gone. Excluded keys are
-// BlockCIDToDocIDKey bytes, as yielded by the owner-edge iterator; a nil set makes this a plain
-// ownership scan. It stops at the first surviving owner.
-func BlockHasOwnersExcept(
-	ctx context.Context,
-	store corekv.Reader,
-	blockCID cid.Cid,
-	excluded map[string]struct{},
-) (bool, error) {
-	if !blockCID.Defined() {
-		return false, nil
-	}
-
-	prefix := blockOwnersPrefix(blockCID)
-	iter, err := store.Iterator(ctx, corekv.IterOptions{
-		Prefix:   prefix,
-		KeysOnly: true,
-	})
-	if err != nil {
-		return false, err
-	}
-
-	for {
-		hasNext, err := iter.Next()
-		if err != nil {
-			return false, stderrors.Join(err, iter.Close())
-		}
-		if !hasNext {
-			break
-		}
-		if len(bytes.TrimPrefix(iter.Key(), prefix)) == 0 {
-			continue
-		}
-		if _, isExcluded := excluded[string(iter.Key())]; isExcluded {
-			continue
-		}
-		return true, iter.Close()
-	}
-	return false, iter.Close()
+	return blockowner.DocIDs(ctx, txn.Systemstore(), blockCID)
 }
 
 func DeleteBlockDocIDMapping(

--- a/internal/db/id/document_test.go
+++ b/internal/db/id/document_test.go
@@ -12,18 +12,15 @@ package id
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	blocks "github.com/ipfs/go-block-format"
-	"github.com/ipfs/go-cid"
 	"github.com/stretchr/testify/require"
 
-	"github.com/sourcenetwork/corekv"
 	"github.com/sourcenetwork/corekv/memory"
 	"github.com/sourcenetwork/defradb/internal/datastore"
+	"github.com/sourcenetwork/defradb/internal/db/blockowner"
 	"github.com/sourcenetwork/defradb/internal/db/lock"
-	"github.com/sourcenetwork/defradb/internal/keys"
 	"github.com/sourcenetwork/immutable"
 )
 
@@ -57,7 +54,7 @@ func TestDocIDMappingMissingReturnsNotFound(t *testing.T) {
 	require.False(t, found)
 
 	undefinedCID := blocks.NewBlock(nil).Cid()
-	mappedDocIDs, err := GetDocIDsForBlockFromStore(ctx, txn.Systemstore(), undefinedCID)
+	mappedDocIDs, err := blockowner.DocIDs(ctx, txn.Systemstore(), undefinedCID)
 	require.NoError(t, err)
 	require.Empty(t, mappedDocIDs)
 }
@@ -165,191 +162,29 @@ func TestBlockDocIDMappings(t *testing.T) {
 	require.NoError(t, err)
 
 	// A block CID can be owned by more than one document.
-	docIDs, err := GetDocIDsForBlockFromStore(ctx, txn.Systemstore(), fieldCID)
+	docIDs, err := blockowner.DocIDs(ctx, txn.Systemstore(), fieldCID)
 	require.NoError(t, err)
 	require.ElementsMatch(t, []string{docID1, docID2}, docIDs)
 
 	err = DeleteBlockDocIDMapping(ctx, txn.Systemstore(), fieldCID, docID1)
 	require.NoError(t, err)
 
-	docIDs, err = GetDocIDsForBlockFromStore(ctx, txn.Systemstore(), fieldCID)
+	docIDs, err = blockowner.DocIDs(ctx, txn.Systemstore(), fieldCID)
 	require.NoError(t, err)
 	require.Equal(t, []string{docID2}, docIDs)
 
 	err = DeleteBlockDocIDMapping(ctx, txn.Systemstore(), fieldCID, docID2)
 	require.NoError(t, err)
 
-	docIDs, err = GetDocIDsForBlockFromStore(ctx, txn.Systemstore(), fieldCID)
+	docIDs, err = blockowner.DocIDs(ctx, txn.Systemstore(), fieldCID)
 	require.NoError(t, err)
 	require.Empty(t, docIDs)
 
 	err = SetBlockDocIDMapping(ctx, fieldCID, "")
 	require.NoError(t, err)
-	docIDs, err = GetDocIDsForBlockFromStore(ctx, txn.Systemstore(), fieldCID)
+	docIDs, err = blockowner.DocIDs(ctx, txn.Systemstore(), fieldCID)
 	require.NoError(t, err)
 	require.Empty(t, docIDs)
-}
-
-func TestBlockHasOwners(t *testing.T) {
-	ctx := context.Background()
-	txn := newDocumentIDTestTxn(ctx)
-	defer txn.Discard()
-	ctx = datastore.CtxSetTxn(ctx, txn)
-
-	fieldCID := blocks.NewBlock([]byte("field value")).Cid()
-
-	has, err := BlockHasOwners(ctx, txn.Systemstore(), fieldCID)
-	require.NoError(t, err)
-	require.False(t, has, "a block with no recorded owners has none")
-
-	has, err = BlockHasOwners(ctx, txn.Systemstore(), cid.Undef)
-	require.NoError(t, err)
-	require.False(t, has, "an undefined CID has no owners")
-
-	require.NoError(t, SetBlockDocIDMapping(ctx, fieldCID, "bae-doc-one"))
-	require.NoError(t, SetBlockDocIDMapping(ctx, fieldCID, "bae-doc-two"))
-
-	has, err = BlockHasOwners(ctx, txn.Systemstore(), fieldCID)
-	require.NoError(t, err)
-	require.True(t, has)
-
-	// One of two owners removed: the block is still owned.
-	require.NoError(t, DeleteBlockDocIDMapping(ctx, txn.Systemstore(), fieldCID, "bae-doc-one"))
-	has, err = BlockHasOwners(ctx, txn.Systemstore(), fieldCID)
-	require.NoError(t, err)
-	require.True(t, has)
-
-	require.NoError(t, DeleteBlockDocIDMapping(ctx, txn.Systemstore(), fieldCID, "bae-doc-two"))
-	has, err = BlockHasOwners(ctx, txn.Systemstore(), fieldCID)
-	require.NoError(t, err)
-	require.False(t, has)
-}
-
-// TestBlockHasOwnersStopsAtFirstOwner checks BlockHasOwners reports ownership after reading a
-// single key regardless of how many documents own the block, unlike GetDocIDsForBlockFromStore
-// which reads every owner.
-func TestBlockHasOwnersStopsAtFirstOwner(t *testing.T) {
-	ctx := context.Background()
-	txn := newDocumentIDTestTxn(ctx)
-	defer txn.Discard()
-	ctx = datastore.CtxSetTxn(ctx, txn)
-
-	fieldCID := blocks.NewBlock([]byte("shared field value")).Cid()
-	const owners = 500
-	for i := range owners {
-		require.NoError(t, SetBlockDocIDMapping(ctx, fieldCID, fmt.Sprintf("bae-doc-%d", i)))
-	}
-
-	var hasReads int
-	has, err := BlockHasOwners(ctx, countingReader{txn.Systemstore(), &hasReads}, fieldCID)
-	require.NoError(t, err)
-	require.True(t, has)
-	require.Equal(t, 1, hasReads, "BlockHasOwners must stop at the first owner")
-
-	var listReads int
-	all, err := GetDocIDsForBlockFromStore(ctx, countingReader{txn.Systemstore(), &listReads}, fieldCID)
-	require.NoError(t, err)
-	require.Len(t, all, owners)
-	require.Greater(t, listReads, owners, "GetDocIDsForBlockFromStore reads every owner")
-}
-
-// blockOwnerKey builds the owner-edge key for (blockCID, docID) in the form BlockHasOwnersExcept
-// expects its excluded set to hold: the same bytes the owner-edge iterator yields.
-func blockOwnerKey(blockCID cid.Cid, docID string) string {
-	return string(keys.NewBlockCIDToDocIDKey(blockCID.String(), docID).Bytes())
-}
-
-// TestBlockHasOwnersExceptExcludedSoleOwner checks that a block whose only owner edge is in the
-// excluded set reports no owner, while the same block reports an owner when nothing is excluded.
-func TestBlockHasOwnersExceptExcludedSoleOwner(t *testing.T) {
-	ctx := context.Background()
-	txn := newDocumentIDTestTxn(ctx)
-	defer txn.Discard()
-	ctx = datastore.CtxSetTxn(ctx, txn)
-
-	fieldCID := blocks.NewBlock([]byte("field value")).Cid()
-	require.NoError(t, SetBlockDocIDMapping(ctx, fieldCID, "bae-doc-one"))
-
-	has, err := BlockHasOwnersExcept(ctx, txn.Systemstore(), fieldCID, nil)
-	require.NoError(t, err)
-	require.True(t, has, "with nothing excluded the block has an owner")
-
-	excluded := map[string]struct{}{blockOwnerKey(fieldCID, "bae-doc-one"): {}}
-	has, err = BlockHasOwnersExcept(ctx, txn.Systemstore(), fieldCID, excluded)
-	require.NoError(t, err)
-	require.False(t, has, "excluding the only owner edge reports no owner")
-}
-
-// TestBlockHasOwnersExceptKeepsUnexcludedOwner checks that a block shared by two documents still
-// reports an owner while any of its edges is unexcluded, and reports none only once all are.
-func TestBlockHasOwnersExceptKeepsUnexcludedOwner(t *testing.T) {
-	ctx := context.Background()
-	txn := newDocumentIDTestTxn(ctx)
-	defer txn.Discard()
-	ctx = datastore.CtxSetTxn(ctx, txn)
-
-	fieldCID := blocks.NewBlock([]byte("shared field value")).Cid()
-	require.NoError(t, SetBlockDocIDMapping(ctx, fieldCID, "bae-doc-one"))
-	require.NoError(t, SetBlockDocIDMapping(ctx, fieldCID, "bae-doc-two"))
-
-	excluded := map[string]struct{}{blockOwnerKey(fieldCID, "bae-doc-one"): {}}
-	has, err := BlockHasOwnersExcept(ctx, txn.Systemstore(), fieldCID, excluded)
-	require.NoError(t, err)
-	require.True(t, has, "one of two owners excluded: the block is still owned")
-
-	excluded[blockOwnerKey(fieldCID, "bae-doc-two")] = struct{}{}
-	has, err = BlockHasOwnersExcept(ctx, txn.Systemstore(), fieldCID, excluded)
-	require.NoError(t, err)
-	require.False(t, has, "both owners excluded: no owner remains")
-}
-
-// TestBlockHasOwnersExceptStopsAtFirstUnexcludedOwner checks the scan skips excluded owners but
-// stops at the first owner that is not excluded, rather than reading the whole owner set.
-func TestBlockHasOwnersExceptStopsAtFirstUnexcludedOwner(t *testing.T) {
-	ctx := context.Background()
-	txn := newDocumentIDTestTxn(ctx)
-	defer txn.Discard()
-	ctx = datastore.CtxSetTxn(ctx, txn)
-
-	fieldCID := blocks.NewBlock([]byte("shared field value")).Cid()
-	const owners = 500
-	for i := range owners {
-		require.NoError(t, SetBlockDocIDMapping(ctx, fieldCID, fmt.Sprintf("bae-doc-%03d", i)))
-	}
-
-	// Owner edges iterate in key order, so excluding the first makes the scan skip it and stop at
-	// the second: two advances, not one and not the whole set.
-	excluded := map[string]struct{}{blockOwnerKey(fieldCID, "bae-doc-000"): {}}
-	var reads int
-	has, err := BlockHasOwnersExcept(ctx, countingReader{txn.Systemstore(), &reads}, fieldCID, excluded)
-	require.NoError(t, err)
-	require.True(t, has)
-	require.Equal(t, 2, reads, "scan skips the excluded owner and stops at the next")
-}
-
-// countingReader wraps a corekv.Reader and tallies iterator advances so a test can assert
-// how much of a key range a function scans.
-type countingReader struct {
-	corekv.Reader
-	nextCalls *int
-}
-
-func (r countingReader) Iterator(ctx context.Context, opts corekv.IterOptions) (corekv.Iterator, error) {
-	iter, err := r.Reader.Iterator(ctx, opts)
-	if err != nil {
-		return nil, err
-	}
-	return &countingIterator{Iterator: iter, nextCalls: r.nextCalls}, nil
-}
-
-type countingIterator struct {
-	corekv.Iterator
-	nextCalls *int
-}
-
-func (it *countingIterator) Next() (bool, error) {
-	*it.nextCalls++
-	return it.Iterator.Next()
 }
 
 func TestDeleteDocRefMappings(t *testing.T) {

--- a/internal/db/merge.go
+++ b/internal/db/merge.go
@@ -645,9 +645,25 @@ func (mp *mergeProcessor) processBlock(
 			return NewErrInitCRDTForMerge(err, blockLink.String())
 		}
 
+		// A signature block is not in AllLinks, so nothing else records who owns it.
+		if dagBlock.Signature != nil {
+			if err := mp.setBlockDocIDMapping(ctx, docRef.docID, dagBlock.Signature.Cid); err != nil {
+				return err
+			}
+		}
+
 		// If the CRDT is nil, it means the field is not part
 		// of the collection definition and we can safely ignore it.
 		if crdt == nil {
+			// The block is owned from here on but never reaches updateHeads, so its marker
+			// is cleared here. Taking ownership and clearing the marker in one transaction
+			// is what lets a concurrent sweep conflict rather than reclaim the block.
+			if dagBlock.Signature != nil {
+				txn := datastore.CtxMustGetTxn(ctx)
+				if err := txn.Blockstore().MarkAsMerged(ctx, dagBlock.Signature.Cid); err != nil {
+					return err
+				}
+			}
 			return nil
 		}
 
@@ -798,8 +814,10 @@ func (mp *mergeProcessor) initCRDTForType(
 		field := crdtUnion.GetFieldName()
 		fd, ok := mp.col.Version().GetFieldByName(field)
 		if !ok {
-			// If the field is not part of the collection definition, we can safely ignore it.
-			return nil, resolvedDocRef{}, nil
+			// The field is not part of the collection definition, so there is no delta to
+			// merge. The document is still returned: the block belongs to it either way, and
+			// the caller records that ownership.
+			return nil, docRef, nil
 		}
 
 		fieldShortID, err := id.GetShortFieldID(ctx, collectionShortID, fd.FieldID)

--- a/internal/db/merge.go
+++ b/internal/db/merge.go
@@ -35,6 +35,7 @@ import (
 	coreblock "github.com/sourcenetwork/defradb/internal/core/block"
 	"github.com/sourcenetwork/defradb/internal/core/crdt"
 	"github.com/sourcenetwork/defradb/internal/datastore"
+	"github.com/sourcenetwork/defradb/internal/db/blockowner"
 	"github.com/sourcenetwork/defradb/internal/db/id"
 	"github.com/sourcenetwork/defradb/internal/keys"
 	"github.com/sourcenetwork/defradb/internal/utils"
@@ -838,7 +839,7 @@ func (mp *mergeProcessor) resolveCompositeBlockDocRef(
 	// path only when it is unambiguous; otherwise determine the DocID from the block itself:
 	// a genesis composite's CID is the DocID, an update inherits it from the genesis reached
 	// through its heads.
-	owners, err := id.GetDocIDsForBlockFromStore(
+	owners, err := blockowner.DocIDs(
 		ctx,
 		datastore.CtxMustGetTxn(ctx).Systemstore(),
 		blockCID,
@@ -880,7 +881,7 @@ func (mp *mergeProcessor) resolveDocRefForCompositeCID(
 	// A composite block is owned by exactly one document. Use the recorded owner as a fast
 	// path only when it is unambiguous; otherwise load the block and determine the DocID from
 	// the composite itself.
-	owners, err := id.GetDocIDsForBlockFromStore(
+	owners, err := blockowner.DocIDs(
 		ctx,
 		datastore.CtxMustGetTxn(ctx).Systemstore(),
 		blockCID,

--- a/internal/db/merge.go
+++ b/internal/db/merge.go
@@ -34,6 +34,7 @@ import (
 	coreblock "github.com/sourcenetwork/defradb/internal/core/block"
 	"github.com/sourcenetwork/defradb/internal/core/crdt"
 	"github.com/sourcenetwork/defradb/internal/datastore"
+	"github.com/sourcenetwork/defradb/internal/db/blockowner"
 	"github.com/sourcenetwork/defradb/internal/db/id"
 	"github.com/sourcenetwork/defradb/internal/keys"
 	"github.com/sourcenetwork/defradb/internal/utils"
@@ -717,7 +718,7 @@ func (mp *mergeProcessor) resolveCompositeBlockDocRef(
 	// path only when it is unambiguous; otherwise determine the DocID from the block itself:
 	// a genesis composite's CID is the DocID, an update inherits it from the genesis reached
 	// through its heads.
-	owners, err := id.GetDocIDsForBlockFromStore(
+	owners, err := blockowner.DocIDs(
 		ctx,
 		datastore.CtxMustGetTxn(ctx).Systemstore(),
 		blockCID,
@@ -759,7 +760,7 @@ func (mp *mergeProcessor) resolveDocRefForCompositeCID(
 	// A composite block is owned by exactly one document. Use the recorded owner as a fast
 	// path only when it is unambiguous; otherwise load the block and determine the DocID from
 	// the composite itself.
-	owners, err := id.GetDocIDsForBlockFromStore(
+	owners, err := blockowner.DocIDs(
 		ctx,
 		datastore.CtxMustGetTxn(ctx).Systemstore(),
 		blockCID,

--- a/internal/db/merge_test.go
+++ b/internal/db/merge_test.go
@@ -32,7 +32,10 @@ import (
 	"github.com/sourcenetwork/corekv/blockstore"
 	"github.com/sourcenetwork/immutable"
 
+	"github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client"
+	"github.com/sourcenetwork/defradb/client/options"
+	"github.com/sourcenetwork/defradb/crypto"
 	"github.com/sourcenetwork/defradb/event"
 	coreblock "github.com/sourcenetwork/defradb/internal/core/block"
 	"github.com/sourcenetwork/defradb/internal/core/crdt"
@@ -40,12 +43,19 @@ import (
 	acpDB "github.com/sourcenetwork/defradb/internal/db/acp"
 	"github.com/sourcenetwork/defradb/internal/db/blockowner"
 	"github.com/sourcenetwork/defradb/internal/db/id"
+	acpIdentity "github.com/sourcenetwork/defradb/internal/identity"
 )
 
 const userSchema = `
 type User {
 	name: String
 	age: Int
+}
+`
+
+const userSchemaWithoutAge = `
+type User {
+	name: String
 }
 `
 
@@ -394,6 +404,76 @@ func TestMergeBatch_ExhaustedRetries_ReportsNothingMerged(t *testing.T) {
 	require.Error(t, err, "the report must be truthful: nothing was stored")
 }
 
+// A node whose collection does not define a field skips that field's block without merging it.
+// The block survives on the owner edge its parent composite writes, but the signature hanging
+// off it is in no parent's links, so nothing else records who owns it and the orphan sweep is
+// free to delete a block the document still references.
+func TestMerge_FieldNotInCollection_StillOwnsSignatureBlock(t *testing.T) {
+	ident, err := identity.Generate(crypto.KeyTypeSecp256k1)
+	require.NoError(t, err)
+	ctx := coreblock.ContextWithEnabledSigning(
+		acpIdentity.WithContext(context.Background(), immutable.Some[identity.Identity](ident)),
+	)
+
+	sourceDB, err := newBadgerDB(ctx)
+	require.NoError(t, err)
+	defer sourceDB.Close()
+	targetDB, err := newBadgerDB(ctx)
+	require.NoError(t, err)
+	defer targetDB.Close()
+
+	// The target does not define "age", which is the schema skew a rolling upgrade produces.
+	_, err = sourceDB.AddCollection(ctx, userSchema)
+	require.NoError(t, err)
+	_, err = targetDB.AddCollection(ctx, userSchemaWithoutAge)
+	require.NoError(t, err)
+
+	sourceCol, err := sourceDB.GetCollectionByName(ctx, "User")
+	require.NoError(t, err)
+	targetCol, err := targetDB.GetCollectionByName(ctx, "User")
+	require.NoError(t, err)
+
+	sourceDoc, err := client.NewDocFromJSON(ctx, []byte(`{"name":"John","age":30}`), sourceCol.Version())
+	require.NoError(t, err)
+	require.NoError(t, sourceCol.AddDocument(ctx, sourceDoc,
+		options.WithIdentity(options.AddDocument(), immutable.Some[identity.Identity](ident))))
+
+	composite := loadTestBlock(t, ctx, sourceDB, sourceDoc.Head())
+	var ageBlock *coreblock.Block
+	for _, link := range composite.Links {
+		if link.Name == "age" {
+			ageBlock = loadTestBlock(t, ctx, sourceDB, link.Cid)
+		}
+	}
+	require.NotNil(t, ageBlock, "the source must produce a block for the undefined field")
+	require.NotNil(t, ageBlock.Signature, "the block must be signed for this to test anything")
+
+	copyDAGBlocks(t, ctx, sourceDB, targetDB, sourceDoc.Head())
+
+	require.NoError(t, targetDB.executeMerge(ctx, targetCol.(*collection), event.Merge{
+		DocID:        sourceDoc.ID().String(),
+		Cid:          sourceDoc.Head(),
+		CollectionID: targetCol.CollectionID(),
+	}))
+
+	txn, err := targetDB.NewTxn(true)
+	require.NoError(t, err)
+	defer txn.Discard()
+	dbTxn, ok := txn.(*Txn)
+	require.True(t, ok)
+	txnCtx := InitContext(ctx, dbTxn)
+
+	owners, err := blockowner.DocIDs(txnCtx, dbTxn.Systemstore(), ageBlock.Signature.Cid)
+	require.NoError(t, err)
+	require.Equal(t, []string{sourceDoc.ID().String()}, owners,
+		"the signature of a skipped field block has no other owner to fall back on")
+
+	merged, err := dbTxn.Blockstore().IsMerged(txnCtx, ageBlock.Signature.Cid)
+	require.NoError(t, err)
+	require.True(t, merged,
+		"a block the merge took ownership of must not still be marked to-merge")
+}
+
 func TestMergeResolveBlockDocID(t *testing.T) {
 	ctx := context.Background()
 
@@ -494,11 +574,14 @@ func TestMerge_DualBranch_NoError(t *testing.T) {
 	require.Equal(t, expectedDocMap, docMap)
 }
 
+// copyDAGBlocks moves a document's DAG between two databases the way a peer delivers it,
+// through the p2p blockstore, so the copied blocks carry the to-merge marker a real sync
+// leaves behind.
 func copyDAGBlocks(t *testing.T, ctx context.Context, sourceDB *DB, targetDB *DB, root cid.Cid) {
 	t.Helper()
 
 	sourceStore := datastore.BlockstoreFrom(sourceDB.rootstore, sourceDB.blockStoreChunkSize)
-	targetStore := datastore.BlockstoreFrom(targetDB.rootstore, targetDB.blockStoreChunkSize)
+	targetStore := datastore.P2PBlockstoreFrom(targetDB.rootstore, targetDB.blockStoreChunkSize)
 	seen := make(map[cid.Cid]struct{})
 
 	var copyBlock func(cid.Cid)
@@ -517,6 +600,13 @@ func copyDAGBlocks(t *testing.T, ctx context.Context, sourceDB *DB, targetDB *DB
 		require.NoError(t, err)
 		for _, link := range block.AllLinks() {
 			copyBlock(link.Cid)
+		}
+		// AllLinks omits the signature, which a peer still sends with the rest of the DAG.
+		// It carries no links of its own, so it is copied rather than walked.
+		if block.Signature != nil {
+			sigBlock, err := sourceStore.Get(ctx, block.Signature.Cid)
+			require.NoError(t, err)
+			require.NoError(t, targetStore.Put(ctx, sigBlock))
 		}
 	}
 

--- a/internal/db/merge_test.go
+++ b/internal/db/merge_test.go
@@ -30,6 +30,7 @@ import (
 	coreblock "github.com/sourcenetwork/defradb/internal/core/block"
 	"github.com/sourcenetwork/defradb/internal/core/crdt"
 	"github.com/sourcenetwork/defradb/internal/datastore"
+	"github.com/sourcenetwork/defradb/internal/db/blockowner"
 	"github.com/sourcenetwork/defradb/internal/db/id"
 )
 
@@ -158,7 +159,7 @@ func TestMerge_GenesisWithEmptyDocID_ResolvesDocIDAndFieldMappings(t *testing.T)
 	require.True(t, found)
 	require.NotEqual(t, sourceDoc.ID().String(), docShortID)
 
-	blockDocIDs, err := id.GetDocIDsForBlockFromStore(txnCtx, dbTxn.Systemstore(), fieldCID)
+	blockDocIDs, err := blockowner.DocIDs(txnCtx, dbTxn.Systemstore(), fieldCID)
 	require.NoError(t, err)
 	require.Equal(t, []string{sourceDoc.ID().String()}, blockDocIDs)
 }

--- a/internal/db/merge_test.go
+++ b/internal/db/merge_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/sourcenetwork/defradb/internal/core/crdt"
 	"github.com/sourcenetwork/defradb/internal/datastore"
 	acpDB "github.com/sourcenetwork/defradb/internal/db/acp"
+	"github.com/sourcenetwork/defradb/internal/db/blockowner"
 	"github.com/sourcenetwork/defradb/internal/db/id"
 )
 
@@ -266,7 +267,7 @@ func TestMerge_GenesisWithEmptyDocID_ResolvesDocIDAndFieldMappings(t *testing.T)
 	require.True(t, found)
 	require.NotEqual(t, sourceDoc.ID().String(), docShortID)
 
-	blockDocIDs, err := id.GetDocIDsForBlockFromStore(txnCtx, dbTxn.Systemstore(), fieldCID)
+	blockDocIDs, err := blockowner.DocIDs(txnCtx, dbTxn.Systemstore(), fieldCID)
 	require.NoError(t, err)
 	require.Equal(t, []string{sourceDoc.ID().String()}, blockDocIDs)
 }

--- a/internal/db/p2p/p2p.go
+++ b/internal/db/p2p/p2p.go
@@ -38,8 +38,8 @@ import (
 	coreblock "github.com/sourcenetwork/defradb/internal/core/block"
 	"github.com/sourcenetwork/defradb/internal/datastore"
 	acpDB "github.com/sourcenetwork/defradb/internal/db/acp"
+	"github.com/sourcenetwork/defradb/internal/db/blockowner"
 	"github.com/sourcenetwork/defradb/internal/db/description"
-	"github.com/sourcenetwork/defradb/internal/db/id"
 	"github.com/sourcenetwork/defradb/internal/db/p2p/protocol"
 	"github.com/sourcenetwork/defradb/internal/kms"
 	"github.com/sourcenetwork/defradb/internal/se"
@@ -596,7 +596,7 @@ func (p *P2P) docIDsForBlockCID(
 		return []string{""}, nil
 	}
 
-	docIDs, err := id.GetDocIDsForBlockFromStore(
+	docIDs, err := blockowner.DocIDs(
 		ctx,
 		p.db.Multistore().Systemstore(),
 		blockCID,

--- a/internal/db/p2p/p2p.go
+++ b/internal/db/p2p/p2p.go
@@ -42,8 +42,8 @@ import (
 	coreblock "github.com/sourcenetwork/defradb/internal/core/block"
 	"github.com/sourcenetwork/defradb/internal/datastore"
 	acpDB "github.com/sourcenetwork/defradb/internal/db/acp"
+	"github.com/sourcenetwork/defradb/internal/db/blockowner"
 	"github.com/sourcenetwork/defradb/internal/db/description"
-	"github.com/sourcenetwork/defradb/internal/db/id"
 	"github.com/sourcenetwork/defradb/internal/db/p2p/protocol"
 	"github.com/sourcenetwork/defradb/internal/kms"
 	"github.com/sourcenetwork/defradb/internal/se"
@@ -720,7 +720,7 @@ func (p *P2P) docIDsForBlockCID(
 		return []string{""}, nil
 	}
 
-	docIDs, err := id.GetDocIDsForBlockFromStore(
+	docIDs, err := blockowner.DocIDs(
 		ctx,
 		p.db.Multistore().Systemstore(),
 		blockCID,

--- a/internal/db/p2p/p2p.go
+++ b/internal/db/p2p/p2p.go
@@ -1231,7 +1231,7 @@ func (p *P2P) SendUpdate(evt event.Update) error {
 	p.pushLogToReplicators(evt)
 
 	// Retries are for replicators only and should not pollute the pubsub network.
-	if !evt.IsRetry {
+	if !evt.IsRetry && !evt.IsRelay {
 		// Pre-generate a CAR so receivers import the full DAG without a BitSwap round-trip.
 		var carData []byte
 		if block, err := coreblock.GetFromBytes(evt.Block); err == nil {

--- a/internal/db/verify.go
+++ b/internal/db/verify.go
@@ -26,7 +26,7 @@ import (
 	coreblock "github.com/sourcenetwork/defradb/internal/core/block"
 	"github.com/sourcenetwork/defradb/internal/datastore"
 	acpDB "github.com/sourcenetwork/defradb/internal/db/acp"
-	"github.com/sourcenetwork/defradb/internal/db/id"
+	"github.com/sourcenetwork/defradb/internal/db/blockowner"
 	"github.com/sourcenetwork/defradb/internal/utils"
 )
 
@@ -156,7 +156,7 @@ func (db *DB) docIDsForSignatureBlock(
 	if block.Delta.IsCollection() {
 		return []string{""}, nil
 	}
-	docIDs, err := id.GetDocIDsForBlockFromStore(
+	docIDs, err := blockowner.DocIDs(
 		ctx,
 		systemstore,
 		blockCID,

--- a/internal/planner/commit.go
+++ b/internal/planner/commit.go
@@ -24,6 +24,7 @@ import (
 	coreblock "github.com/sourcenetwork/defradb/internal/core/block"
 	"github.com/sourcenetwork/defradb/internal/datastore"
 	acpDB "github.com/sourcenetwork/defradb/internal/db/acp"
+	"github.com/sourcenetwork/defradb/internal/db/blockowner"
 	"github.com/sourcenetwork/defradb/internal/db/fetcher"
 	"github.com/sourcenetwork/defradb/internal/db/id"
 	"github.com/sourcenetwork/defradb/internal/keys"
@@ -710,7 +711,7 @@ func (n *dagScanNode) commitDocIDs(
 		}
 	}
 
-	owners, err := id.GetDocIDsForBlockFromStore(
+	owners, err := blockowner.DocIDs(
 		n.planner.ctx,
 		datastore.CtxMustGetTxn(n.planner.ctx).Systemstore(),
 		blockCID,

--- a/node/node_p2p.go
+++ b/node/node_p2p.go
@@ -20,7 +20,7 @@ import (
 	"github.com/sourcenetwork/defradb/internal/datastore"
 )
 
-func (n *Node) startP2P(ctx context.Context, store corekv.ReaderWriter, chunkSize immutable.Option[int]) error {
+func (n *Node) startP2P(ctx context.Context, store corekv.TxnReaderWriter, chunkSize immutable.Option[int]) error {
 	if n.opts.DisableP2P {
 		return nil
 	}

--- a/node/store_badger.go
+++ b/node/store_badger.go
@@ -13,6 +13,8 @@ package node
 import (
 	"context"
 	"errors"
+	"os"
+	"strconv"
 	"sync"
 	"time"
 
@@ -24,6 +26,7 @@ import (
 	"github.com/sourcenetwork/corelog"
 
 	"github.com/sourcenetwork/defradb/client/options"
+	"github.com/sourcenetwork/defradb/internal/datastore"
 )
 
 func init() {
@@ -81,21 +84,72 @@ const (
 	// valueLogGCDiscardRatio is the fraction of a value log file that must be
 	// reclaimable before badger rewrites it.
 	valueLogGCDiscardRatio = 0.1
+
+	// defaultOrphanBlockGCInterval is how often the orphan block sweep runs.
+	defaultOrphanBlockGCInterval = 5 * time.Minute
+	// defaultOrphanBlockTTL is how long a fetched-but-unmerged block is kept before the
+	// sweep reclaims it. It only has to outlast an in-flight merge; anything older is an
+	// abandoned fetch.
+	defaultOrphanBlockTTL = 30 * time.Minute
+	// orphanBlockGCScanLimit bounds how many markers the sweep examines per run, so a
+	// large backlog is worked down over several runs rather than one long pass.
+	orphanBlockGCScanLimit = 100_000
+
+	// The sweep deletes blocks, so an operator needs to stop or slow it on a running
+	// node without a new image.
+	envOrphanGCDisabled = "DEFRA_ORPHAN_GC_DISABLED"
+	envOrphanGCInterval = "DEFRA_ORPHAN_GC_INTERVAL"
+	envOrphanBlockTTL   = "DEFRA_ORPHAN_BLOCK_TTL"
 )
 
-// badgerStore wraps a persistent badger datastore and periodically runs value log
-// GC. Badger does not reclaim the value log space of deleted or overwritten
-// entries on its own, so the GC keeps the on-disk store bounded.
+// durationFromEnv returns the duration in name, or fallback when it is unset, malformed
+// or not positive. A bad value falls back rather than failing the store open.
+func durationFromEnv(name string, fallback time.Duration) time.Duration {
+	d, err := time.ParseDuration(os.Getenv(name))
+	if err != nil || d <= 0 {
+		return fallback
+	}
+	return d
+}
+
+// boolFromEnv returns the boolean in name, or false when it is unset or malformed.
+// A malformed value is logged so it is not mistaken for the variable being unset.
+func boolFromEnv(name string) bool {
+	raw, ok := os.LookupEnv(name)
+	if !ok {
+		return false
+	}
+	v, err := strconv.ParseBool(raw)
+	if err != nil {
+		log.Info("Ignoring malformed boolean environment variable",
+			corelog.String("name", name), corelog.String("value", raw))
+		return false
+	}
+	return v
+}
+
+// badgerStore wraps a persistent badger datastore and runs its periodic background
+// maintenance: value log GC, which reclaims the space of deleted or overwritten
+// entries badger does not reclaim on its own, and an orphan block sweep, which
+// deletes blocks fetched during sync whose merge never completed.
 type badgerStore struct {
 	*badger.Datastore
 
-	db       *badgerds.DB
-	stop     chan struct{}
-	done     chan struct{}
-	stopOnce sync.Once
+	db *badgerds.DB
+	// stop cancels the context the background maintenance runs under. A sweep runs for
+	// minutes, so it has to be interruptible mid-run, not only between ticks.
+	stop      context.CancelFunc
+	wg        sync.WaitGroup
+	closeOnce sync.Once
+
+	// Resolved once at open so the sweep loop does not re-read the environment per tick.
+	orphanGCInterval time.Duration
+	orphanBlockTTL   time.Duration
+	orphanGCDisabled bool
 }
 
-// newBadgerStore opens a persistent badger store at path and starts value log GC.
+// newBadgerStore opens a persistent badger store at path and starts its background
+// maintenance. The orphan sweep can be disabled and retuned through the environment.
 func newBadgerStore(path string, opts badgerds.Options) (*badgerStore, error) {
 	opts.Dir = path
 	opts.ValueDir = path
@@ -105,38 +159,52 @@ func newBadgerStore(path string, opts badgerds.Options) (*badgerStore, error) {
 		return nil, err
 	}
 
+	ctx, cancel := context.WithCancel(context.Background())
 	store := &badgerStore{
-		Datastore: badger.NewDatastoreFrom(db),
-		db:        db,
-		stop:      make(chan struct{}),
-		done:      make(chan struct{}),
+		Datastore:        badger.NewDatastoreFrom(db),
+		db:               db,
+		stop:             cancel,
+		orphanGCInterval: durationFromEnv(envOrphanGCInterval, defaultOrphanBlockGCInterval),
+		orphanBlockTTL:   durationFromEnv(envOrphanBlockTTL, defaultOrphanBlockTTL),
+		orphanGCDisabled: boolFromEnv(envOrphanGCDisabled),
 	}
-	go store.runValueLogGC()
+	store.wg.Add(1)
+	go store.runValueLogGC(ctx)
+
+	if store.orphanGCDisabled {
+		log.Info("Orphan block sweep disabled")
+	} else {
+		log.Info("Orphan block sweep enabled",
+			corelog.Duration("interval", store.orphanGCInterval),
+			corelog.Duration("ttl", store.orphanBlockTTL))
+		store.wg.Add(1)
+		go store.runOrphanBlockGC(ctx)
+	}
 	return store, nil
 }
 
-// Close stops value log GC and closes the underlying store.
+// Close stops the background maintenance and closes the underlying store.
 func (s *badgerStore) Close() error {
-	s.stopOnce.Do(func() {
-		close(s.stop)
-		<-s.done
+	s.closeOnce.Do(func() {
+		s.stop()
+		s.wg.Wait()
 	})
 	return s.Datastore.Close()
 }
 
 // runValueLogGC reclaims value log space on a fixed interval until the store closes.
-func (s *badgerStore) runValueLogGC() {
-	defer close(s.done)
+func (s *badgerStore) runValueLogGC(ctx context.Context) {
+	defer s.wg.Done()
 
 	ticker := time.NewTicker(valueLogGCInterval)
 	defer ticker.Stop()
 
 	for {
 		select {
-		case <-s.stop:
+		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			s.reclaimValueLog()
+			s.reclaimValueLog(ctx)
 		}
 	}
 }
@@ -148,14 +216,12 @@ func (s *badgerStore) runValueLogGC() {
 //
 // The on-disk size is reported on every pass, reclaimed or not, so whether the store is
 // bounded can be read from the log without shell access to the volume.
-func (s *badgerStore) reclaimValueLog() {
+func (s *badgerStore) reclaimValueLog(ctx context.Context) {
 	start := time.Now()
 	reclaimed := 0
 	for {
-		select {
-		case <-s.stop:
+		if ctx.Err() != nil {
 			return
-		default:
 		}
 		if err := s.db.RunValueLogGC(valueLogGCDiscardRatio); err != nil {
 			if !errors.Is(err, badgerds.ErrNoRewrite) {
@@ -171,4 +237,58 @@ func (s *badgerStore) reclaimValueLog() {
 		corelog.Int64("lsmBytes", lsm),
 		corelog.Int64("vlogBytes", vlog),
 		corelog.Duration("duration", time.Since(start)))
+}
+
+// runOrphanBlockGC sweeps the blockstore for orphaned blocks on a fixed interval
+// until the store closes. It carries a cursor across runs so the whole marker index
+// is worked through over time, restarting from the beginning after each full pass.
+//
+// The first sweep is held back one TTL, so nothing can be reclaimed sooner than that after
+// the store opens.
+func (s *badgerStore) runOrphanBlockGC(ctx context.Context) {
+	defer s.wg.Done()
+
+	select {
+	case <-ctx.Done():
+		return
+	case <-time.After(s.orphanBlockTTL):
+	}
+
+	ticker := time.NewTicker(s.orphanGCInterval)
+	defer ticker.Stop()
+
+	var cursor []byte
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			cursor = s.reclaimOrphanBlocks(ctx, cursor)
+		}
+	}
+}
+
+// reclaimOrphanBlocks runs one sweep step from cursor and returns the cursor to
+// resume from. On error it keeps the cursor, so a transient failure part-way through
+// the index costs one run rather than every marker examined since the last full pass.
+func (s *badgerStore) reclaimOrphanBlocks(ctx context.Context, cursor []byte) []byte {
+	start := time.Now()
+	result, err := datastore.ReclaimOrphanBlocks(
+		ctx, s, start.Add(-s.orphanBlockTTL), cursor, orphanBlockGCScanLimit)
+	if err != nil {
+		if !errors.Is(err, context.Canceled) {
+			log.ErrorE("Orphan block sweep failed", err)
+		}
+		return cursor
+	}
+	if result.Scanned > 0 {
+		log.Info("Swept orphan blocks",
+			corelog.Int("reclaimed", result.Reclaimed),
+			corelog.Int("repaired", result.Repaired),
+			corelog.Int("conflicts", result.Conflicts),
+			corelog.Int("scanned", result.Scanned),
+			corelog.Bool("completedPass", result.NextKey == nil),
+			corelog.Duration("duration", time.Since(start)))
+	}
+	return result.NextKey
 }

--- a/node/store_badger.go
+++ b/node/store_badger.go
@@ -24,6 +24,7 @@ import (
 	"github.com/sourcenetwork/corelog"
 
 	"github.com/sourcenetwork/defradb/client/options"
+	"github.com/sourcenetwork/defradb/internal/datastore"
 )
 
 func init() {
@@ -81,18 +82,31 @@ const (
 	// valueLogGCDiscardRatio is the fraction of a value log file that must be
 	// reclaimable before badger rewrites it.
 	valueLogGCDiscardRatio = 0.1
+
+	// orphanBlockGCInterval is how often the orphan block sweep runs.
+	orphanBlockGCInterval = 5 * time.Minute
+	// orphanBlockTTL is how long a fetched-but-unmerged block is kept before the
+	// sweep reclaims it. A merge clears the marker atomically, so this only needs to
+	// outlast an in-flight merge; anything older is an abandoned fetch.
+	orphanBlockTTL = 30 * time.Minute
+	// orphanBlockGCScanLimit bounds how many markers the sweep examines per run, so a
+	// large backlog is worked down over several runs rather than one long pass.
+	orphanBlockGCScanLimit = 100_000
 )
 
-// badgerStore wraps a persistent badger datastore and periodically runs value log
-// GC. Badger does not reclaim the value log space of deleted or overwritten
-// entries on its own, so the GC keeps the on-disk store bounded.
+// badgerStore wraps a persistent badger datastore and runs its periodic background
+// maintenance: value log GC, which reclaims the space of deleted or overwritten
+// entries badger does not reclaim on its own, and an orphan block sweep, which
+// deletes blocks fetched during sync whose merge never completed.
 type badgerStore struct {
 	*badger.Datastore
 
-	db       *badgerds.DB
-	stop     chan struct{}
-	done     chan struct{}
-	stopOnce sync.Once
+	db *badgerds.DB
+	// stop cancels the context the background maintenance runs under. A sweep runs for
+	// minutes, so it has to be interruptible mid-run, not only between ticks.
+	stop      context.CancelFunc
+	wg        sync.WaitGroup
+	closeOnce sync.Once
 }
 
 // newBadgerStore opens a persistent badger store at path and starts value log GC.
@@ -105,38 +119,40 @@ func newBadgerStore(path string, opts badgerds.Options) (*badgerStore, error) {
 		return nil, err
 	}
 
+	ctx, cancel := context.WithCancel(context.Background())
 	store := &badgerStore{
 		Datastore: badger.NewDatastoreFrom(db),
 		db:        db,
-		stop:      make(chan struct{}),
-		done:      make(chan struct{}),
+		stop:      cancel,
 	}
-	go store.runValueLogGC()
+	store.wg.Add(2)
+	go store.runValueLogGC(ctx)
+	go store.runOrphanBlockGC(ctx)
 	return store, nil
 }
 
-// Close stops value log GC and closes the underlying store.
+// Close stops the background maintenance and closes the underlying store.
 func (s *badgerStore) Close() error {
-	s.stopOnce.Do(func() {
-		close(s.stop)
-		<-s.done
+	s.closeOnce.Do(func() {
+		s.stop()
+		s.wg.Wait()
 	})
 	return s.Datastore.Close()
 }
 
 // runValueLogGC reclaims value log space on a fixed interval until the store closes.
-func (s *badgerStore) runValueLogGC() {
-	defer close(s.done)
+func (s *badgerStore) runValueLogGC(ctx context.Context) {
+	defer s.wg.Done()
 
 	ticker := time.NewTicker(valueLogGCInterval)
 	defer ticker.Stop()
 
 	for {
 		select {
-		case <-s.stop:
+		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			s.reclaimValueLog()
+			s.reclaimValueLog(ctx)
 		}
 	}
 }
@@ -145,14 +161,12 @@ func (s *badgerStore) runValueLogGC() {
 // reclaim, an error occurs, or the store starts closing. Each successful call
 // rewrites one file; ErrNoRewrite means no file was eligible and ends the loop.
 // Any other error is logged, since it means GC could not make progress.
-func (s *badgerStore) reclaimValueLog() {
+func (s *badgerStore) reclaimValueLog(ctx context.Context) {
 	start := time.Now()
 	reclaimed := 0
 	for {
-		select {
-		case <-s.stop:
+		if ctx.Err() != nil {
 			return
-		default:
 		}
 		if err := s.db.RunValueLogGC(valueLogGCDiscardRatio); err != nil {
 			if !errors.Is(err, badgerds.ErrNoRewrite) {
@@ -167,4 +181,59 @@ func (s *badgerStore) reclaimValueLog() {
 			corelog.Int("files", reclaimed),
 			corelog.Duration("duration", time.Since(start)))
 	}
+}
+
+// runOrphanBlockGC sweeps the blockstore for orphaned blocks on a fixed interval
+// until the store closes. It carries a cursor across runs so the whole marker index
+// is worked through over time, restarting from the beginning after each full pass.
+//
+// The first sweep waits one TTL. Markers written before the to-merge index carried a
+// timestamp have no readable age, and that wait is what makes them older than the
+// cutoff by construction, so an upgraded store needs no special case for them.
+func (s *badgerStore) runOrphanBlockGC(ctx context.Context) {
+	defer s.wg.Done()
+
+	select {
+	case <-ctx.Done():
+		return
+	case <-time.After(orphanBlockTTL):
+	}
+
+	ticker := time.NewTicker(orphanBlockGCInterval)
+	defer ticker.Stop()
+
+	var cursor []byte
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			cursor = s.reclaimOrphanBlocks(ctx, cursor)
+		}
+	}
+}
+
+// reclaimOrphanBlocks runs one sweep step from cursor and returns the cursor to
+// resume from. On error it keeps the cursor, so a transient failure part-way through
+// the index costs one run rather than every marker examined since the last full pass.
+func (s *badgerStore) reclaimOrphanBlocks(ctx context.Context, cursor []byte) []byte {
+	start := time.Now()
+	result, err := datastore.ReclaimOrphanBlocks(
+		ctx, s, start.Add(-orphanBlockTTL), cursor, orphanBlockGCScanLimit)
+	if err != nil {
+		if !errors.Is(err, context.Canceled) {
+			log.ErrorE("Orphan block sweep failed", err)
+		}
+		return cursor
+	}
+	if result.Scanned > 0 {
+		log.Info("Swept orphan blocks",
+			corelog.Int("reclaimed", result.Reclaimed),
+			corelog.Int("repaired", result.Repaired),
+			corelog.Int("conflicts", result.Conflicts),
+			corelog.Int("scanned", result.Scanned),
+			corelog.Bool("completedPass", result.NextKey == nil),
+			corelog.Duration("duration", time.Since(start)))
+	}
+	return result.NextKey
 }

--- a/node/store_badger.go
+++ b/node/store_badger.go
@@ -286,6 +286,7 @@ func (s *badgerStore) reclaimOrphanBlocks(ctx context.Context, cursor []byte) []
 			corelog.Int("reclaimed", result.Reclaimed),
 			corelog.Int("repaired", result.Repaired),
 			corelog.Int("conflicts", result.Conflicts),
+			corelog.Int("unparsed", result.Unparsed),
 			corelog.Int("scanned", result.Scanned),
 			corelog.Bool("completedPass", result.NextKey == nil),
 			corelog.Duration("duration", time.Since(start)))

--- a/node/store_badger_test.go
+++ b/node/store_badger_test.go
@@ -17,10 +17,14 @@ import (
 	"time"
 
 	badgerds "github.com/dgraph-io/badger/v4"
+	blocks "github.com/ipfs/go-block-format"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/sourcenetwork/immutable"
+
 	"github.com/sourcenetwork/defradb/client/options"
+	"github.com/sourcenetwork/defradb/internal/datastore"
 	"github.com/sourcenetwork/defradb/internal/utils"
 )
 
@@ -65,12 +69,17 @@ func TestBadgerStoreCloseStopsGCAndIsIdempotent(t *testing.T) {
 	store, err := newBadgerStore(t.TempDir(), badgerds.DefaultOptions(""))
 	require.NoError(t, err)
 
-	require.NoError(t, store.Close())
-
+	// Close waits for the background goroutines, so it returning is the proof they
+	// stopped; the timeout turns a stuck goroutine into a failure instead of a hang.
+	done := make(chan struct{})
+	go func() {
+		_ = store.Close()
+		close(done)
+	}()
 	select {
-	case <-store.done:
-	default:
-		t.Fatal("value log GC goroutine did not stop on Close")
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("Close did not stop the background goroutines")
 	}
 
 	// A second Close must not panic on the already-closed stop channel.
@@ -86,7 +95,7 @@ func TestBadgerStoreReclaimValueLogTerminates(t *testing.T) {
 	// the first call, so reclaimValueLog must return rather than spin on the error.
 	done := make(chan struct{})
 	go func() {
-		store.reclaimValueLog()
+		store.reclaimValueLog(context.Background())
 		close(done)
 	}()
 
@@ -94,5 +103,148 @@ func TestBadgerStoreReclaimValueLogTerminates(t *testing.T) {
 	case <-done:
 	case <-time.After(30 * time.Second):
 		t.Fatal("reclaimValueLog did not terminate")
+	}
+}
+
+func TestDurationFromEnvFallsBackWhenUnsetOrInvalid(t *testing.T) {
+	const fallback = 7 * time.Minute
+
+	require.Equal(t, fallback, durationFromEnv(envOrphanBlockTTL, fallback))
+
+	// A malformed or non-positive value falls back rather than failing the store open.
+	for _, val := range []string{"", "not-a-duration", "0", "-5m"} {
+		t.Setenv(envOrphanBlockTTL, val)
+		require.Equal(t, fallback, durationFromEnv(envOrphanBlockTTL, fallback), val)
+	}
+
+	t.Setenv(envOrphanBlockTTL, "90s")
+	require.Equal(t, 90*time.Second, durationFromEnv(envOrphanBlockTTL, fallback))
+}
+
+func TestBoolFromEnv(t *testing.T) {
+	require.False(t, boolFromEnv(envOrphanGCDisabled))
+
+	for _, val := range []string{"true", "1", "TRUE", "T"} {
+		t.Setenv(envOrphanGCDisabled, val)
+		require.True(t, boolFromEnv(envOrphanGCDisabled), val)
+	}
+
+	// The variable names a boolean, so "false" must read as false rather than as set.
+	for _, val := range []string{"false", "0", "FALSE", "F"} {
+		t.Setenv(envOrphanGCDisabled, val)
+		require.False(t, boolFromEnv(envOrphanGCDisabled), val)
+	}
+
+	for _, val := range []string{"", "yes", "off", "maybe"} {
+		t.Setenv(envOrphanGCDisabled, val)
+		require.False(t, boolFromEnv(envOrphanGCDisabled), val)
+	}
+}
+
+func TestNewBadgerStoreResolvesOrphanGCDisabled(t *testing.T) {
+	for val, want := range map[string]bool{"true": true, "false": false} {
+		t.Run(val, func(t *testing.T) {
+			t.Setenv(envOrphanGCDisabled, val)
+
+			dir := t.TempDir()
+			store, err := newBadgerStore(dir, badgerds.DefaultOptions(dir))
+			require.NoError(t, err)
+			defer func() { require.NoError(t, store.Close()) }()
+
+			require.Equal(t, want, store.orphanGCDisabled)
+		})
+	}
+}
+
+func TestNewBadgerStoreAppliesEnvOverrides(t *testing.T) {
+	t.Setenv(envOrphanGCInterval, "3m")
+	t.Setenv(envOrphanBlockTTL, "45m")
+
+	dir := t.TempDir()
+	store, err := newBadgerStore(dir, badgerds.DefaultOptions(dir))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, store.Close()) }()
+
+	require.Equal(t, 3*time.Minute, store.orphanGCInterval)
+	require.Equal(t, 45*time.Minute, store.orphanBlockTTL)
+}
+
+func TestNewBadgerStoreDefaultsOrphanGCSettings(t *testing.T) {
+	dir := t.TempDir()
+	store, err := newBadgerStore(dir, badgerds.DefaultOptions(dir))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, store.Close()) }()
+
+	require.Equal(t, defaultOrphanBlockGCInterval, store.orphanGCInterval)
+	require.Equal(t, defaultOrphanBlockTTL, store.orphanBlockTTL)
+
+	// Pinned by value: the TTL decides when a block is deleted, so changing it should
+	// take a deliberate test update rather than passing silently.
+	require.Equal(t, 5*time.Minute, defaultOrphanBlockGCInterval)
+	require.Equal(t, 30*time.Minute, defaultOrphanBlockTTL)
+}
+
+// The switch is the only way to stop a background job that deletes blocks, so it is asserted
+// on the sweep's effect rather than on the field it sets. The enabled arm is what shows the
+// disabled arm is measuring something.
+func TestNewBadgerStoreOrphanGCDisabledLeavesOrphansAlone(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		disabled string
+		reclaims bool
+	}{
+		{name: "enabled", disabled: "false", reclaims: true},
+		{name: "disabled", disabled: "true", reclaims: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// Short enough that a sweep would have run many times over within the windows below.
+			t.Setenv(envOrphanGCDisabled, tc.disabled)
+			t.Setenv(envOrphanBlockTTL, "50ms")
+			t.Setenv(envOrphanGCInterval, "20ms")
+
+			dir := t.TempDir()
+			store, err := newBadgerStore(dir, badgerds.DefaultOptions(dir))
+			require.NoError(t, err)
+			defer func() { require.NoError(t, store.Close()) }()
+
+			// The P2P blockstore is what stamps a to-merge marker, which is what makes an
+			// unmerged block look like an orphan once the marker ages past the TTL.
+			ctx := context.Background()
+			orphan := blocks.NewBlock([]byte("never merged"))
+			require.NoError(t, datastore.P2PBlockstoreFrom(store, immutable.None[int]()).Put(ctx, orphan))
+
+			blockstore := datastore.BlockstoreFrom(store, immutable.None[int]())
+			reclaimed := func() bool {
+				has, err := blockstore.Has(ctx, orphan.Cid())
+				return err == nil && !has
+			}
+
+			if tc.reclaims {
+				require.Eventually(t, reclaimed, 5*time.Second, 20*time.Millisecond,
+					"an aged orphan should be reclaimed")
+			} else {
+				require.Never(t, reclaimed, 2*time.Second, 20*time.Millisecond,
+					"no block should be deleted while the sweep is switched off")
+			}
+		})
+	}
+}
+
+// Close waits on the maintenance goroutines, so a miscounted WaitGroup when the sweep is
+// disabled would hang here rather than fail an assertion.
+func TestNewBadgerStoreClosesCleanlyWithOrphanGCDisabled(t *testing.T) {
+	t.Setenv(envOrphanGCDisabled, "1")
+
+	dir := t.TempDir()
+	store, err := newBadgerStore(dir, badgerds.DefaultOptions(dir))
+	require.NoError(t, err)
+
+	done := make(chan error, 1)
+	go func() { done <- store.Close() }()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("Close hung with the orphan sweep disabled")
 	}
 }

--- a/node/store_badger_test.go
+++ b/node/store_badger_test.go
@@ -65,12 +65,17 @@ func TestBadgerStoreCloseStopsGCAndIsIdempotent(t *testing.T) {
 	store, err := newBadgerStore(t.TempDir(), badgerds.DefaultOptions(""))
 	require.NoError(t, err)
 
-	require.NoError(t, store.Close())
-
+	// Close waits for the background goroutines, so it returning is the proof they
+	// stopped; the timeout turns a stuck goroutine into a failure instead of a hang.
+	done := make(chan struct{})
+	go func() {
+		_ = store.Close()
+		close(done)
+	}()
 	select {
-	case <-store.done:
-	default:
-		t.Fatal("value log GC goroutine did not stop on Close")
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("Close did not stop the background goroutines")
 	}
 
 	// A second Close must not panic on the already-closed stop channel.
@@ -86,7 +91,7 @@ func TestBadgerStoreReclaimValueLogTerminates(t *testing.T) {
 	// the first call, so reclaimValueLog must return rather than spin on the error.
 	done := make(chan struct{})
 	go func() {
-		store.reclaimValueLog()
+		store.reclaimValueLog(context.Background())
 		close(done)
 	}()
 


### PR DESCRIPTION
Related shinzonetwork/shinzo-host-client#363

Stacked on #5146.

Blocks written outside a merge transaction, by `sync_dag.go` and `car.go`, are unreachable if that merge never completes. `hardDeleteDocumentBlocks` walks out from a document's heads, so history prune can only reach blocks an existing document owns. Nothing else reclaims this class.

The sweep expires the to-merge markers left behind and removes a block only when no committed document owns it. A marker on a block that did merge is dropped and the block kept. A merge that takes ownership clears the marker in the same transaction, so a sweep holding that marker conflicts rather than reclaiming the block.

A signature block is not in `AllLinks`, so neither merge path cleared its marker: `updateHeads` never sees it, and a field the collection does not define returns before reaching `updateHeads`. Both now clear it.

The marker records the first fetch and nothing renewed it, so a block re-received while still unmerged kept ageing toward the cutoff. `Put` and `PutMany` now refresh it, but only when a marker is still there, since an absent one means the block merged and must stay merged. The check and the write share a transaction, so a merge clearing the marker in between is not undone.

A chunked store appends a suffix to every key it writes, so `cid.Cast(marker[1:])` rejected the key and the sweep reclaimed nothing. The CID is read off the front of the marker instead, and a chunked value is deleted by prefix because it spans several keys.

It runs by default. Because it deletes blocks, it can be retuned or turned off on a running node without a rebuild: `DEFRA_ORPHAN_GC_DISABLED`, `DEFRA_ORPHAN_GC_INTERVAL` (default 5m) and `DEFRA_ORPHAN_BLOCK_TTL` (default 30m), which is how old a marker must be before its block is eligible.

Also moves the block-owner index reads into their own package. The sweep lives in `internal/datastore` and needs those reads, but `internal/db/id` imports `internal/datastore`, so calling into it directly is an import cycle.
