### PR TITLE
fix: Isolate document short ID allocation (#5101)

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -113,6 +113,7 @@ type DB struct {
 
 	docMergeQueue *mergeQueue
 	colMergeQueue *mergeQueue
+	docShortIDMu  sync.Mutex
 
 	p2p *p2p.P2P
 	// Retry intervals when a replicator failure occurs.
@@ -243,6 +244,30 @@ func (db *DB) NewTxn(readonly bool) (client.Txn, error) {
 	txnId := db.previousTxnID.Add(1)
 	txn := datastore.NewTxnFrom(db.rootstore, db.lockSet, txnId, readonly, db.blockStoreChunkSize)
 	return wrapDatastoreTxn(txn, db), nil
+}
+
+// reserveDocShortID commits the node-wide sequence separately from document writes so concurrent
+// document transactions do not contend on the sequence key. Failed document transactions may leave
+// gaps; short IDs only need to be unique. The lock spans transaction creation through commit so each
+// transaction sees the last committed reservation.
+func (db *DB) reserveDocShortID(ctx context.Context) (uint64, error) {
+	db.docShortIDMu.Lock()
+	defer db.docShortIDMu.Unlock()
+
+	txn, err := db.NewTxn(false)
+	if err != nil {
+		return 0, err
+	}
+	defer txn.Discard()
+
+	docShortID, err := id.NextDocShortID(InitContext(ctx, txn))
+	if err != nil {
+		return 0, err
+	}
+	if err := txn.Commit(); err != nil {
+		return 0, err
+	}
+	return docShortID, nil
 }
 
 // publishDocUpdateEvent publishes an update event for a document.

--- a/internal/db/document.go
+++ b/internal/db/document.go
@@ -516,7 +516,7 @@ func (c *collection) save(
 
 	var primaryKey keys.PrimaryDataStoreKey
 	if isAdd {
-		docShortID, err := id.NextDocShortID(ctx)
+		docShortID, err := c.db.reserveDocShortID(ctx)
 		if err != nil {
 			return err
 		}

--- a/internal/db/document_test.go
+++ b/internal/db/document_test.go
@@ -13,6 +13,8 @@ package db
 import (
 	"context"
 	"encoding/binary"
+	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/ipfs/go-cid"
@@ -87,6 +89,61 @@ func TestDocumentAdd_DerivesDocIDFromCompositeCID(t *testing.T) {
 	docID, err := c.getDocIDFromPrimaryKey(txnCtx, primaryKey)
 	require.NoError(t, err)
 	require.Equal(t, doc.ID().String(), docID)
+}
+
+func TestDocumentAdd_ConcurrentUsesUniqueShortIDs(t *testing.T) {
+	ctx := context.Background()
+	db, err := newBadgerDB(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() { db.Close() })
+
+	_, err = db.AddCollection(ctx, userDocIDTestSchema)
+	require.NoError(t, err)
+	col, err := db.GetCollectionByName(ctx, "User")
+	require.NoError(t, err)
+
+	const docCount = 24
+	docs := make([]*client.Document, docCount)
+	for i := range docCount {
+		docs[i], err = client.NewDocFromJSON(
+			ctx,
+			[]byte(fmt.Sprintf(`{"name":"user-%d","age":%d}`, i, i)),
+			col.Version(),
+		)
+		require.NoError(t, err)
+	}
+
+	start := make(chan struct{})
+	errs := make(chan error, docCount)
+	var group sync.WaitGroup
+	for _, doc := range docs {
+		group.Go(func() {
+			<-start
+			errs <- col.AddDocument(ctx, doc)
+		})
+	}
+	close(start)
+	group.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+
+	txn, err := db.NewTxn(true)
+	require.NoError(t, err)
+	defer txn.Discard()
+	txnCtx := InitContext(ctx, txn)
+	collectionShortID, err := id.GetCollectionShortID(txnCtx, col.CollectionID())
+	require.NoError(t, err)
+
+	shortIDs := make(map[uint64]struct{}, docCount)
+	for _, doc := range docs {
+		docShortID, found, err := id.GetDocShortID(txnCtx, collectionShortID, doc.ID().String())
+		require.NoError(t, err)
+		require.True(t, found)
+		require.NotContains(t, shortIDs, docShortID)
+		shortIDs[docShortID] = struct{}{}
+	}
 }
 
 func TestUnsignedGenesisProducesEqualCIDAcrossNodes(t *testing.T) {

--- a/internal/db/merge.go
+++ b/internal/db/merge.go
@@ -57,11 +57,12 @@ func (db *DB) Merge(ctx context.Context, evt event.Merge) error {
 		defer db.docMergeQueue.done(evt.DocID)
 	}
 
-	// retry the merge process if a conflict occurs
-	//
-	// conficts occur when a user updates a document
-	// while a merge is in progress.
-	for i := 0; i < db.MaxTxnRetries(); i++ {
+	// Conflicts occur when a user updates a document while a merge is in progress.
+	max := db.MaxTxnRetries()
+	if max < 1 {
+		max = 1
+	}
+	for i := 0; i < max; i++ {
 		err = db.executeMerge(ctx, col, evt)
 		if errors.Is(err, corekv.ErrTxnConflict) {
 			continue
@@ -71,7 +72,7 @@ func (db *DB) Merge(ctx context.Context, evt event.Merge) error {
 		}
 		return nil
 	}
-	return nil
+	return client.NewErrMaxTxnRetries(err)
 }
 
 // MergeBatchWithTxn merges multiple events in a single shared transaction.
@@ -362,7 +363,7 @@ func (mp *mergeProcessor) resolveOrAllocateDocShortID(
 		return docShortID, nil
 	}
 
-	docShortID, err = id.NextDocShortID(ctx)
+	docShortID, err = mp.db.reserveDocShortID(ctx)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/db/merge_test.go
+++ b/internal/db/merge_test.go
@@ -12,6 +12,8 @@ package db
 
 import (
 	"context"
+	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -91,6 +93,79 @@ func TestMerge_SingleBranch_NoError(t *testing.T) {
 	}
 
 	require.Equal(t, expectedDocMap, docMap)
+}
+
+func TestMerge_ConcurrentNewDocuments(t *testing.T) {
+	ctx := context.Background()
+	db, err := newBadgerDB(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() { db.Close() })
+
+	_, err = db.AddCollection(ctx, userSchema)
+	require.NoError(t, err)
+	col, err := db.GetCollectionByName(ctx, "User")
+	require.NoError(t, err)
+
+	lsys := cidlink.DefaultLinkSystem()
+	lsys.SetWriteStorage(blockstore.NewIPLDStore(datastore.BlockstoreFrom(db.rootstore, immutable.None[int]())))
+
+	const docCount = 24
+	events := make([]event.Merge, docCount)
+	docIDs := make([]client.DocID, docCount)
+	for i := range docCount {
+		state := map[string]any{"name": fmt.Sprintf("user-%d", i), "age": i}
+		builder, _ := newDagBuilder(ctx, col, state)
+		composite, err := builder.generateCompositeUpdate(&lsys, state, compositeInfo{})
+		require.NoError(t, err)
+		docIDs[i] = client.NewDocIDV0(composite.link.Cid)
+		events[i] = event.Merge{
+			DocID:        docIDs[i].String(),
+			Cid:          composite.link.Cid,
+			CollectionID: col.CollectionID(),
+		}
+	}
+
+	start := make(chan struct{})
+	errs := make(chan error, docCount)
+	var group sync.WaitGroup
+	for _, mergeEvent := range events {
+		group.Go(func() {
+			<-start
+			errs <- db.Merge(ctx, mergeEvent)
+		})
+	}
+	close(start)
+	group.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+
+	for _, docID := range docIDs {
+		_, err := col.GetDocument(ctx, docID)
+		require.NoError(t, err)
+	}
+}
+
+func TestMerge_ZeroMaxRetriesStillAttempts(t *testing.T) {
+	ctx := context.Background()
+
+	db, err := newBadgerDB(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() { db.Close() })
+	db.maxTxnRetries = immutable.Some(0)
+
+	_, err = db.AddCollection(ctx, userSchema)
+	require.NoError(t, err)
+	col, err := db.GetCollectionByName(ctx, "User")
+	require.NoError(t, err)
+
+	err = db.Merge(ctx, event.Merge{
+		DocID:        "missing",
+		Cid:          blocks.NewBlock(nil).Cid(),
+		CollectionID: col.CollectionID(),
+	})
+	require.Error(t, err)
 }
 
 func TestMerge_GenesisWithEmptyDocID_ResolvesDocIDAndFieldMappings(t *testing.T) {


### PR DESCRIPTION
Related shinzonetwork/shinzo-host-client#362

Backport of #5101. Resolves #5100 for shinzo.

Document short IDs were allocated inside the caller's transaction, so the sequence key joined that transaction's conflict set and concurrent merges contended on it. `reserveDocShortID` allocates in its own transaction under a mutex, so the sequence commits independently of the merge that needs the ID.

A retry budget below one meant zero attempts, so the merge never ran, and an exhausted budget returned nil instead of an error.
