### PR TITLE
test(i): Generalize per-node test config into a struct

### DIFF
--- a/tests/integration/db.go
+++ b/tests/integration/db.go
@@ -84,7 +84,7 @@ func defaultNodeOpts() *options.NodeOptionsBuilder {
 		// The test framework sets this up elsewhere when required so that it may be wrapped
 		// into a [client.TxnStore].
 		SetDisableAPI(true).
-		// The p2p is configured in the tests by [ConfigureNode] actions, we disable it here
+		// The p2p is configured in the tests by [NodeConfig] actions, we disable it here
 		// to keep the tests as lightweight as possible.
 		SetDisableP2P(true)
 

--- a/tests/integration/net/simple/replicator/cross_version_test.go
+++ b/tests/integration/net/simple/replicator/cross_version_test.go
@@ -76,7 +76,7 @@ func TestP2PCrossVersion_HeadToV1_DocSyncs(t *testing.T) {
 	test := testUtils.TestCase{
 		Actions: []any{
 			testUtils.RandomNetworkingConfig(), // node 0 = HEAD
-			testUtils.NodeVersion{Version: crossVersion, Config: testUtils.RandomNetworkingConfig()}, // node 1 = v1.0.0
+			testUtils.RandomNetworkingConfig().WithVersion(crossVersion), // node 1 = v1.0.0
 			&action.AddCollection{
 				SDL: `
 					type User {
@@ -114,7 +114,7 @@ func TestP2PCrossVersion_V1ToHead_DocSyncs(t *testing.T) {
 	test := testUtils.TestCase{
 		Actions: []any{
 			testUtils.RandomNetworkingConfig(), // node 0 = HEAD
-			testUtils.NodeVersion{Version: crossVersion, Config: testUtils.RandomNetworkingConfig()}, // node 1 = v1.0.0
+			testUtils.RandomNetworkingConfig().WithVersion(crossVersion), // node 1 = v1.0.0
 			&action.AddCollection{
 				SDL: `
 					type User {

--- a/tests/integration/net/simple/replicator/cross_version_test.go
+++ b/tests/integration/net/simple/replicator/cross_version_test.go
@@ -75,7 +75,7 @@ func hasUserWithName(data any, name string) bool {
 func TestP2PCrossVersion_HeadToV1_DocSyncs(t *testing.T) {
 	test := testUtils.TestCase{
 		Actions: []any{
-			testUtils.RandomNetworkingConfig(), // node 0 = HEAD
+			testUtils.RandomNetworkingConfig(),                           // node 0 = HEAD
 			testUtils.RandomNetworkingConfig().WithVersion(crossVersion), // node 1 = v1.0.0
 			&action.AddCollection{
 				SDL: `
@@ -113,7 +113,7 @@ func TestP2PCrossVersion_HeadToV1_DocSyncs(t *testing.T) {
 func TestP2PCrossVersion_V1ToHead_DocSyncs(t *testing.T) {
 	test := testUtils.TestCase{
 		Actions: []any{
-			testUtils.RandomNetworkingConfig(), // node 0 = HEAD
+			testUtils.RandomNetworkingConfig(),                           // node 0 = HEAD
 			testUtils.RandomNetworkingConfig().WithVersion(crossVersion), // node 1 = v1.0.0
 			&action.AddCollection{
 				SDL: `

--- a/tests/integration/p2p_config.go
+++ b/tests/integration/p2p_config.go
@@ -19,14 +19,16 @@ import (
 	"github.com/sourcenetwork/defradb/client/options"
 )
 
-func RandomNetworkingConfig() ConfigureNode {
-	return func() options.NodeP2POptions {
-		return options.NodeP2POptions{
-			ListenAddresses:           []string{"/ip4/" + getIPString() + "/tcp/0"},
-			EnablePubSub:              true,
-			EnableRelay:               true,
-			EnableClearBackoffOnRetry: true,
-		}
+func RandomNetworkingConfig() NodeConfig {
+	return NodeConfig{
+		Network: func() options.NodeP2POptions {
+			return options.NodeP2POptions{
+				ListenAddresses:           []string{"/ip4/" + getIPString() + "/tcp/0"},
+				EnablePubSub:              true,
+				EnableRelay:               true,
+				EnableClearBackoffOnRetry: true,
+			}
+		},
 	}
 }
 

--- a/tests/integration/p2p_config_js.go
+++ b/tests/integration/p2p_config_js.go
@@ -15,9 +15,11 @@ import (
 	"github.com/sourcenetwork/defradb/client/options"
 )
 
-func RandomNetworkingConfig() ConfigureNode {
-	return func() options.NodeP2POptions {
-		return options.NodeP2POptions{}
+func RandomNetworkingConfig() NodeConfig {
+	return NodeConfig{
+		Network: func() options.NodeP2POptions {
+			return options.NodeP2POptions{}
+		},
 	}
 }
 

--- a/tests/integration/test_case.go
+++ b/tests/integration/test_case.go
@@ -121,7 +121,11 @@ type KMS struct {
 // the first item that is neither an AddCollection, AddDoc or UpdateDoc action.
 type SetupComplete struct{}
 
-// ConfigureNode allows the explicit configuration of new Defra nodes.
+// ConfigureNode returns the P2P options for a new Defra node.
+type ConfigureNode func() options.NodeP2POptions
+
+// NodeConfig allows the explicit configuration of new Defra nodes. The zero value
+// is a native, current-build node with default networking.
 //
 // If no nodes are explicitly configured, a default one will be setup.  There is no
 // upper limit to the number that can be configured.
@@ -129,24 +133,34 @@ type SetupComplete struct{}
 // Nodes may be explicitly referenced by index by other actions using `NodeID` properties.
 // If the action has a `NodeID` property and it is not specified, the action will be
 // effected on all nodes.
-type ConfigureNode func() options.NodeP2POptions
-
-// NodeVersion configures a new node that runs as an external process from a
-// published release binary of the given version, instead of natively in-process.
-// It carries the same networking config a ConfigureNode would.
 //
-// Version is plain data (not a closure) so a future multiplier can rewrite it to
-// run existing tests against other versions.
+// Configuration is held as plain data wherever possible so a future multiplier can
+// rewrite it to run existing tests under other node configurations.
 //
-// This lives here beside ConfigureNode rather than in the tests/action package
-// because node creation is entangled with this package's setup path, which
-// tests/action cannot import. When ConfigureNode migrates to tests/action, this
-// should move with it.
-type NodeVersion struct {
-	// Version names a published release, e.g. "v1.0.0".
+// This lives here rather than in the tests/action package because node creation is
+// entangled with this package's setup path, which tests/action cannot import.
+type NodeConfig struct {
+	// Version, when set (e.g. "v1.0.0"), runs the node as an external process from
+	// that published release binary instead of natively in-process.
 	Version string
-	// Config supplies the same networking config as a ConfigureNode.
-	Config ConfigureNode
+	// Network returns the node's P2P options. Nil means default networking.
+	Network ConfigureNode
+}
+
+// P2POptions returns the configured P2P options, or the defaults if no networking
+// config was supplied.
+func (cfg NodeConfig) P2POptions() options.NodeP2POptions {
+	if cfg.Network == nil {
+		return options.NodeP2POptions{}
+	}
+	return cfg.Network()
+}
+
+// WithVersion returns a copy of the config that runs the node as an external process
+// from the given published release, e.g. "v1.0.0".
+func (cfg NodeConfig) WithVersion(version string) NodeConfig {
+	cfg.Version = version
+	return cfg
 }
 
 func applyHTTPOptions(opts *options.NodeOptionsBuilder, httpOpts options.NodeHTTPOptions) {

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -362,11 +362,8 @@ func performAction(
 	case action.Action:
 		action.Execute()
 
-	case ConfigureNode:
+	case NodeConfig:
 		configureNode(s, testCase, action)
-
-	case NodeVersion:
-		configureNodeVersion(s, testCase, action)
 
 	case Restart:
 		restartNodes(s, testCase)
@@ -838,7 +835,7 @@ func createsDocsOnMultipleNodes(testCase *TestCase) bool {
 	nodeCount := 0
 	for _, a := range testCase.Actions {
 		switch a.(type) {
-		case ConfigureNode, NodeVersion:
+		case NodeConfig:
 			nodeCount++
 		}
 	}
@@ -997,7 +994,7 @@ func actionTransactionID(a any) (int, bool) {
 
 // setStartingNodes adds a set of initial Defra nodes for the test to execute against.
 //
-// If a node(s) has been explicitly configured via a `ConfigureNode` action then no new
+// If a node(s) has been explicitly configured via a `NodeConfig` action then no new
 // nodes will be added.
 func setStartingNodes(
 	s *state.State,
@@ -1005,7 +1002,7 @@ func setStartingNodes(
 ) {
 	for _, action := range testCase.Actions {
 		switch action.(type) {
-		case ConfigureNode, NodeVersion:
+		case NodeConfig:
 			s.IsNetworkEnabled = true
 		}
 	}
@@ -1253,12 +1250,11 @@ func refreshCollections(
 
 // configureNode configures and starts a new Defra node using the provided configuration.
 //
-// It returns the new node, and its peer address. Any errors generated during configuration
-// will result in a test failure.
+// Any errors generated during configuration will result in a test failure.
 func configureNode(
 	s *state.State,
 	testCase TestCase,
-	action ConfigureNode,
+	cfg NodeConfig,
 ) {
 	if changeDetector.Enabled {
 		// We do not yet support the change detector for tests running across multiple nodes.
@@ -1266,45 +1262,25 @@ func configureNode(
 		return
 	}
 
-	privateKey, err := crypto.GenerateEd25519()
-	require.NoError(s.T, err)
-
-	p2pOpts := action()
-	withPrivateKey(&p2pOpts, privateKey)
-
+	p2pOpts := cfg.P2POptions()
 	s.CurrentSetupNodeID = len(s.Nodes)
-	opts := defaultNodeOpts()
-	opts.DB().
-		SetRetryIntervals([]time.Duration{time.Millisecond * 1}).
-		SetNodeIdentity(state.GetIdentity(s, NodeIdentity(s.CurrentSetupNodeID)))
-	opts.P2P().SetAll(p2pOpts)
 
-	node, err := setupNode(s, acpIdentity.None, testCase, opts, "")
-	require.NoError(s.T, err)
+	// Versioned nodes run in a separate process from a release binary that configures
+	// itself, so in-process options do not apply to them.
+	var opts *options.NodeOptionsBuilder
+	if cfg.Version == "" {
+		privateKey, err := crypto.GenerateEd25519()
+		require.NoError(s.T, err)
+		withPrivateKey(&p2pOpts, privateKey)
 
-	node.P2POpts = p2pOpts
-	s.Nodes = append(s.Nodes, node)
-}
-
-// configureNodeVersion configures and starts a new Defra node that runs as
-// an external process from a downloaded release binary of the given version,
-// instead of natively in-process.
-func configureNodeVersion(
-	s *state.State,
-	testCase TestCase,
-	action NodeVersion,
-) {
-	if changeDetector.Enabled {
-		// We do not yet support the change detector for tests running across multiple nodes.
-		s.T.SkipNow()
-		return
+		opts = defaultNodeOpts()
+		opts.DB().
+			SetRetryIntervals([]time.Duration{time.Millisecond * 1}).
+			SetNodeIdentity(state.GetIdentity(s, NodeIdentity(s.CurrentSetupNodeID)))
+		opts.P2P().SetAll(p2pOpts)
 	}
 
-	p2pOpts := action.Config()
-
-	s.CurrentSetupNodeID = len(s.Nodes)
-
-	node, err := setupNode(s, acpIdentity.None, testCase, nil, action.Version)
+	node, err := setupNode(s, acpIdentity.None, testCase, opts, cfg.Version)
 	require.NoError(s.T, err)
 	if node == nil {
 		// setupNode already skipped the test (no release asset for this platform).
@@ -1312,7 +1288,7 @@ func configureNodeVersion(
 	}
 
 	node.P2POpts = p2pOpts
-	node.Version = action.Version
+	node.Version = cfg.Version
 	s.Nodes = append(s.Nodes, node)
 }
 
@@ -2406,7 +2382,7 @@ func skipIfNetworkTest(t testing.TB, actions []any) {
 	hasNetworkAction := false
 	for _, act := range actions {
 		switch act.(type) {
-		case ConfigureNode, NodeVersion:
+		case NodeConfig:
 			hasNetworkAction = true
 		}
 	}


### PR DESCRIPTION
## Relevant issue(s)

Refs #5066

## Description

Setting up a test node took a function that returned networking options, so
networking was the only thing a test could say about a node. When nodes needed to
run from an older release, the version had nowhere to go and became its own
separate action next to the first one.

Both are now one struct holding the version and the networking config as plain
fields. The function that builds a random networking config returns that struct
instead, so the several hundred places that call it are unchanged. Only the two
tests that asked for an older node were edited by hand.

Plain fields also matter for the multiplier promised in #5103, which rewrites
actions to re-run tests under different settings. It can rewrite values but
cannot see inside a function.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Nothing should change, so the existing suite is the check. Replicator tests under
both clients, node access control tests under the HTTP client, both cross version
tests against a real v1.0.0 binary, and the full query suite. Plus `go vet
./tests/...`, which type checks every call site, the wasm build, and lint.

Worth a look in review: the merged setup function now runs the platform skip and
the version assignment on both paths, not just the older node path. Both do
nothing on the normal path, but it is a deliberate widening.

Specify the platform(s) on which this was tested:
- MacOS
