### PR TITLE
fix: Make skipBackupTests behave with multiple clients

### DIFF
--- a/tests/integration/client_setup.go
+++ b/tests/integration/client_setup.go
@@ -32,7 +32,6 @@ func init() {
 	}
 	if cClient {
 		skipNetworkTests = false
-		skipBackupTests = true
 	}
 }
 

--- a/tests/integration/client_setup_js.go
+++ b/tests/integration/client_setup_js.go
@@ -26,8 +26,6 @@ func init() {
 	jsClient = true
 	// JavaScript networking stack is managed externally
 	skipNetworkTests = true
-	// Backup API is not suitable for browser environments
-	skipBackupTests = true
 }
 
 // setupClient returns the client implementation for the current

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -2418,11 +2418,7 @@ func skipIfNetworkTest(t testing.TB, actions []any) {
 }
 
 // skipIfBackupTest removes any client type that doesn't support the Backup API from clients, if the
-// given actions contain backup actions. Skips the test entirely if no client type remains. Client
-// support for backups varies per client type, so - unlike the other skipIf* functions here, which
-// skip/filter uniformly for the whole test case - this must run once clients has already been built,
-// not before it, otherwise a client type that supports backups could be skipped just because some
-// other, unrelated selected client type doesn't.
+// given actions contain backup actions. Skips the test entirely if no client type remains. 
 func skipIfBackupTest(t testing.TB, clients []state.ClientType, actions []any) []state.ClientType {
 	hasBackupAction := false
 	for _, act := range actions {

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -76,8 +76,10 @@ var (
 	viewType state.ViewType
 	// skipNetworkTests will skip any tests that involve network actions
 	skipNetworkTests = false
-	// skipBackupTests will skip any tests that involve backup actions
-	skipBackupTests = false
+	// backupUnsupportedClientTypes lists the client types whose BasicImport/BasicExport are not
+	// implemented: the C client (see cbindings/wrapper.go) and the JS client (the Backup API is not
+	// suitable for browser environments).
+	backupUnsupportedClientTypes = []state.ClientType{state.CClientType, state.JSClientType}
 	// runVectorEmbeddingTests will whether tests with vector embedding generation should be executed.
 	runVectorEmbeddingTests = false
 )
@@ -156,7 +158,6 @@ func ExecuteTestCase(
 	skipIfMutationTypeUnsupported(t, testCase.SupportedMutationTypes)
 	skipIfDocumentACPTypeUnsupported(t, testCase.SupportedDocumentACPTypes)
 	skipIfNetworkTest(t, testCase.Actions)
-	skipIfBackupTest(t, testCase.Actions)
 	skipIfViewCacheTypeUnsupported(t, testCase.SupportedViewTypes)
 	skipIfVectorEmbeddingTest(t, testCase.Actions)
 
@@ -209,6 +210,7 @@ func ExecuteTestCase(
 
 	databases = skipIfDatabaseTypeUnsupported(t, databases, testCase.SupportedDatabaseTypes)
 	clients = skipIfClientTypeUnsupported(t, clients, testCase.SupportedClientTypes)
+	clients = skipIfBackupTest(t, clients, testCase.Actions)
 
 	for _, ct := range clients {
 		for _, dbt := range databases {
@@ -2415,9 +2417,13 @@ func skipIfNetworkTest(t testing.TB, actions []any) {
 	}
 }
 
-// skipIfBackupTest skips the current test if the given actions
-// contain backup actions and skipBackupTests is true.
-func skipIfBackupTest(t testing.TB, actions []any) {
+// skipIfBackupTest removes any client type that doesn't support the Backup API from clients, if the
+// given actions contain backup actions. Skips the test entirely if no client type remains. Client
+// support for backups varies per client type, so - unlike the other skipIf* functions here, which
+// skip/filter uniformly for the whole test case - this must run once clients has already been built,
+// not before it, otherwise a client type that supports backups could be skipped just because some
+// other, unrelated selected client type doesn't.
+func skipIfBackupTest(t testing.TB, clients []state.ClientType, actions []any) []state.ClientType {
 	hasBackupAction := false
 	for _, act := range actions {
 		switch act.(type) {
@@ -2427,9 +2433,20 @@ func skipIfBackupTest(t testing.TB, actions []any) {
 			hasBackupAction = true
 		}
 	}
-	if skipBackupTests && hasBackupAction {
-		t.Skip("test involves backup actions")
+	if !hasBackupAction {
+		return clients
 	}
+
+	filteredClients := make([]state.ClientType, 0, len(clients))
+	for _, ct := range clients {
+		if !slices.Contains(backupUnsupportedClientTypes, ct) {
+			filteredClients = append(filteredClients, ct)
+		}
+	}
+	if len(filteredClients) == 0 {
+		t.Skip("test involves backup actions, but no selected client type supports them")
+	}
+	return filteredClients
 }
 
 // skipIfVectorEmbeddingTest skips the current test if the given actions

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -2418,7 +2418,7 @@ func skipIfNetworkTest(t testing.TB, actions []any) {
 }
 
 // skipIfBackupTest removes any client type that doesn't support the Backup API from clients, if the
-// given actions contain backup actions. Skips the test entirely if no client type remains. 
+// given actions contain backup actions. Skips the test entirely if no client type remains.
 func skipIfBackupTest(t testing.TB, clients []state.ClientType, actions []any) []state.ClientType {
 	hasBackupAction := false
 	for _, act := range actions {


### PR DESCRIPTION
## Relevant issue(s)

Resolves #5113 

## Description

There was an issue with how skipping backup tests was being handled. There was a variable being set during initialization of a client. For example, initialization of the C or JS clients would set the value to true, and then during test execution, any backup-related tests would be skipped. This plays nicely with the way our CI jobs are isolated, but is actually incorrect. It is actually possible to run tests with multiple clients, some of which support backup tests, and some of which do not. And currently, they would be skipped for _all_ clients.

This fixes that by removing the variable, and instead filtering the list of clients to execute the test actions to the ones that can actually do so. This occurs inside the `utils.go` file.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

(*replace*) Describe the tests performed to verify the changes. Provide instructions to reproduce them.

Specify the platform(s) on which this was tested:
- WSL