### PR TITLE
fix: bound the pubsub message queue by bytes, not just slots

### DIFF
--- a/internal/db/p2p/p2p.go
+++ b/internal/db/p2p/p2p.go
@@ -14,8 +14,11 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"math"
+	"runtime/debug"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/fxamacker/cbor/v2"
@@ -69,7 +72,35 @@ const (
 	// msgQueueSize is the capacity of the incoming pubsub message queue.
 	// Messages that arrive when the queue is full are dropped with a warning.
 	msgQueueSize = 50_000
+
+	// msgQueueMemDivisor sets the queue's byte budget as this fraction of the process
+	// memory limit. A slot count does not bound memory on its own, because a queued
+	// message holds its decoded payload and those vary in size by orders of magnitude.
+	// The queue only has to absorb bursts, so most of the budget stays free.
+	msgQueueMemDivisor = 4
+
+	// msgQueueFallbackMaxBytes is the byte budget used when the process has no memory
+	// limit set, where a fraction of it would be meaningless.
+	msgQueueFallbackMaxBytes = 1 << 30
 )
+
+// queuedMessage is a decoded request paired with its wire size, so the queue's byte
+// accounting can be reversed once the message has been processed. The wire size stands
+// in for the retained size: the decoded payload is a copy of those same bytes.
+type queuedMessage struct {
+	req  *protocol.PushLogRequest
+	size int64
+}
+
+// queueByteBudget returns the byte budget for the incoming message queue, derived from
+// the process memory limit so a node with a smaller limit queues proportionally less.
+func queueByteBudget() int64 {
+	limit := debug.SetMemoryLimit(-1)
+	if limit <= 0 || limit == math.MaxInt64 {
+		return msgQueueFallbackMaxBytes
+	}
+	return limit / msgQueueMemDivisor
+}
 
 // PushToReplicatorsHandler is called when documents are pushed to replicators.
 // Implementations can perform additional actions like generating SE artifacts.
@@ -168,8 +199,13 @@ type P2P struct {
 	batcher *pubsubBatcher
 
 	// msgQueue receives incoming pubsub messages for async processing by a fixed worker pool.
-	msgQueue   chan *protocol.PushLogRequest
+	msgQueue   chan queuedMessage
 	msgWorkers sync.WaitGroup
+
+	// msgQueueBytes is the wire size of the messages currently queued or in flight.
+	msgQueueBytes atomic.Int64
+	// msgQueueMaxBytes caps msgQueueBytes. Zero or less disables the byte bound.
+	msgQueueMaxBytes int64
 }
 
 // pushLogCommProcessor implements CommProcessor for push log functionality
@@ -225,7 +261,8 @@ func New(
 		replicationFilter:    replicationFilter,
 		syncBlockLinkTimeout: db.P2PBlockSyncTimeout(),
 		topicPeerCounts:      make(map[string]int),
-		msgQueue:             make(chan *protocol.PushLogRequest, msgQueueSize),
+		msgQueue:             make(chan queuedMessage, msgQueueSize),
+		msgQueueMaxBytes:     queueByteBudget(),
 	}
 
 	for i := 0; i < dagSyncWorkers; i++ {
@@ -618,20 +655,56 @@ func (p *P2P) docIDsForBlockCID(
 // pubSubMessageHandler decodes the incoming wire message and enqueues it for
 // processing by the bounded worker pool. It never blocks the libp2p pubsub
 // dispatcher: if the queue is full the message is dropped with a warning.
+//
+// The byte budget is claimed before decoding, so a message that cannot be queued does
+// not pay for a decode it will not use.
 func (p *P2P) pubSubMessageHandler(from string, topic string, msg []byte) ([]byte, error) {
+	size := int64(len(msg))
+	if !p.claimQueueBytes(size) {
+		log.Info("pubsub message queue over byte budget, dropping message",
+			corelog.Any("topic", topic),
+			corelog.Int64("bytes", size),
+			corelog.Int64("budget", p.msgQueueMaxBytes))
+		return nil, nil
+	}
+
 	req := &protocol.PushLogRequest{}
 	if err := cbor.Unmarshal(msg, req); err != nil {
+		p.releaseQueueBytes(size)
 		return nil, err
 	}
 	req.SenderID = from
 
 	select {
-	case p.msgQueue <- req:
+	case p.msgQueue <- queuedMessage{req: req, size: size}:
 	case <-p.ctx.Done():
+		p.releaseQueueBytes(size)
 	default:
+		p.releaseQueueBytes(size)
 		log.Info("pubsub message queue full, dropping message", corelog.Any("topic", topic))
 	}
 	return nil, nil
+}
+
+// claimQueueBytes reserves size against the queue's byte budget, reporting whether the
+// reservation fit. A budget of zero or less means the byte bound is disabled.
+func (p *P2P) claimQueueBytes(size int64) bool {
+	if p.msgQueueMaxBytes <= 0 {
+		return true
+	}
+	if p.msgQueueBytes.Add(size) > p.msgQueueMaxBytes {
+		p.msgQueueBytes.Add(-size)
+		return false
+	}
+	return true
+}
+
+// releaseQueueBytes returns a reservation made by claimQueueBytes.
+func (p *P2P) releaseQueueBytes(size int64) {
+	if p.msgQueueMaxBytes <= 0 {
+		return
+	}
+	p.msgQueueBytes.Add(-size)
 }
 
 // processMessageWorker is a long-lived goroutine that drains p.msgQueue and
@@ -639,8 +712,12 @@ func (p *P2P) pubSubMessageHandler(from string, topic string, msg []byte) ([]byt
 // concurrently, bounding the goroutine count regardless of inbound message rate.
 func (p *P2P) processMessageWorker() {
 	defer p.msgWorkers.Done()
-	for req := range p.msgQueue {
-		if err := p.processPushlogRequest(p.ctx, req, false); err != nil {
+	for m := range p.msgQueue {
+		err := p.processPushlogRequest(p.ctx, m.req, false)
+		// Released here rather than deferred so the budget frees up per message, not
+		// when the worker exits.
+		p.releaseQueueBytes(m.size)
+		if err != nil {
 			if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
 				log.Info("Context done during pushlog request processing", corelog.Any("Error", err))
 				continue

--- a/internal/db/p2p/p2p_test.go
+++ b/internal/db/p2p/p2p_test.go
@@ -12,7 +12,10 @@ package p2p
 
 import (
 	"context"
+	"math"
+	"runtime/debug"
 	"testing"
+	"time"
 
 	"github.com/fxamacker/cbor/v2"
 	"github.com/stretchr/testify/assert"
@@ -54,6 +57,103 @@ func TestPubSubMessageHandler_ContextCanceled(t *testing.T) {
 	// Expectation: No error returned (suppressed), resp is nil
 	assert.NoError(t, err)
 	assert.Nil(t, resp)
+}
+
+// The budget is claimed before the decode, so an over-budget message never reaches
+// cbor. Undecodable bytes distinguish the two orderings: decoding first surfaces an
+// error, claiming first drops the message silently.
+func TestPubSubMessageHandler_OverBudgetDropsBeforeDecode(t *testing.T) {
+	p := &P2P{
+		ctx:              context.Background(),
+		host:             &SimpleMockHost{},
+		msgQueue:         make(chan queuedMessage, 4),
+		msgQueueMaxBytes: 4,
+	}
+
+	undecodable := []byte{0xff, 0xff, 0xff, 0xff, 0xff}
+	resp, err := p.pubSubMessageHandler("sender", "topic", undecodable)
+
+	assert.NoError(t, err)
+	assert.Nil(t, resp)
+	assert.Empty(t, p.msgQueue)
+	assert.Equal(t, int64(0), p.msgQueueBytes.Load())
+}
+
+func TestPubSubMessageHandler_ByteBudgetReleasedAfterProcessing(t *testing.T) {
+	msg, err := cbor.Marshal(protocol.PushLogRequest{DocID: "docID"})
+	assert.NoError(t, err)
+
+	// Sized so exactly one message fits, making the second one's fate depend entirely
+	// on whether the first was released.
+	p := &P2P{
+		ctx:              context.Background(),
+		host:             &SimpleMockHost{},
+		msgQueue:         make(chan queuedMessage, 4),
+		msgQueueMaxBytes: int64(len(msg)),
+	}
+
+	_, err = p.pubSubMessageHandler("sender", "topic", msg)
+	assert.NoError(t, err)
+	assert.Len(t, p.msgQueue, 1)
+
+	_, err = p.pubSubMessageHandler("sender", "topic", msg)
+	assert.NoError(t, err)
+	assert.Len(t, p.msgQueue, 1, "second message should be dropped while the budget is held")
+
+	// Stand in for a worker finishing with the message.
+	queued := <-p.msgQueue
+	p.releaseQueueBytes(queued.size)
+	assert.Equal(t, int64(0), p.msgQueueBytes.Load())
+
+	_, err = p.pubSubMessageHandler("sender", "topic", msg)
+	assert.NoError(t, err)
+	assert.Len(t, p.msgQueue, 1, "budget should be available again once released")
+}
+
+// The handler reserves the budget and the worker is what gives it back. Without the release the
+// counter only ever climbs, and once enough traffic has passed through, the node drops every
+// message from then on while its queue sits empty.
+func TestProcessMessageWorker_ReleasesByteBudget(t *testing.T) {
+	msg, err := cbor.Marshal(protocol.PushLogRequest{DocID: "docID"})
+	assert.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	p := &P2P{
+		ctx:              ctx,
+		host:             &SimpleMockHost{},
+		msgQueue:         make(chan queuedMessage, 1),
+		msgQueueMaxBytes: int64(len(msg)),
+	}
+
+	_, err = p.pubSubMessageHandler("sender", "topic", msg)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(len(msg)), p.msgQueueBytes.Load(), "the handler reserves on enqueue")
+
+	// Cancelling returns processPushlogRequest at its first check, so no database is needed and
+	// the release is the only part of the worker left under test. The worker is left parked on
+	// the empty queue rather than stopped, which keeps this independent of how shutdown is
+	// signalled.
+	cancel()
+	p.msgWorkers.Add(1)
+	go p.processMessageWorker()
+
+	assert.Eventually(t, func() bool { return p.msgQueueBytes.Load() == 0 },
+		5*time.Second, 5*time.Millisecond,
+		"the worker must return the budget the handler reserved")
+}
+
+func TestQueueByteBudget_DerivesFromMemoryLimit(t *testing.T) {
+	original := debug.SetMemoryLimit(-1)
+	t.Cleanup(func() { debug.SetMemoryLimit(original) })
+
+	// Written out rather than derived from the constants: the point of the assertion is that
+	// the budget is a small fraction of the limit, and restating the formula would let the
+	// queue grow to the whole limit without failing here.
+	debug.SetMemoryLimit(8 << 30)
+	assert.Equal(t, int64(2<<30), queueByteBudget(), "a quarter of an 8 GiB limit")
+
+	debug.SetMemoryLimit(math.MaxInt64)
+	assert.Equal(t, int64(1<<30), queueByteBudget(), "the fallback when no limit is set")
 }
 
 func TestPubSubMessageHandler_ContextTimeout(t *testing.T) {


### PR DESCRIPTION
Stacked on #5124.

The ingest queue was bounded by slot count alone. Message size varies by orders of magnitude, so a bounded number of slots does not bound memory: a queue of large decoded messages can hold several GB against the process memory limit. The byte budget is claimed before the CBOR decode, so an over-budget message never pays for the allocation.

Also adds the telemetry that makes the bound observable, and names what the ingest path drops:

- ingest queue, merge and store counters, reported per interval rather than per event.
- a dropped merge event is counted by cause (`missingBlock`, `uniqueIndex`, `retryExhausted`, `collectionNotFound`) on its own `merge drops` line. The count alone does not say whether the sender could not supply the DAG, two documents claim one indexed value, or the write kept losing to a concurrent one, and those need different responses.
- the read-kind recorder shows which classes of key a conflicting transaction had read. It is populated only when a chunk exhausts its retries, so the `read_*` fields read zero in any interval with `exhausted=0`.
