### PR TITLE
chore: conflict and ingest instrumentation

### DIFF
--- a/internal/datastore/readkinds.go
+++ b/internal/datastore/readkinds.go
@@ -1,0 +1,145 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package datastore
+
+import (
+	"strings"
+	"sync/atomic"
+)
+
+// ReadKind names one class of key a transaction's read set can hold.
+//
+// The underlying store reports a commit conflict without naming the contended key, so the
+// set of classes a transaction read is the only lead available for working out what it
+// contended with. The classes are bit flags so a whole transaction's set fits in one word
+// and recording a read costs an atomic OR with no allocation.
+type ReadKind uint32
+
+const (
+	// ReadDoc is a document field value or its priority marker, under the datastore.
+	ReadDoc ReadKind = 1 << iota
+	// ReadIndex is a secondary index entry, under the datastore. Set by the index write
+	// path, which is the only place that knows an encoded datastore key is an index entry.
+	ReadIndex
+	// ReadUniqueIndex is the existence check a unique index performs before writing its
+	// entry. Set by the unique index write path for the same reason as ReadIndex.
+	ReadUniqueIndex
+	// ReadHead is a headstore key: a document's or collection's current DAG heads.
+	ReadHead
+	// ReadBlock is a blockstore key: an IPLD block or its to-merge marker.
+	ReadBlock
+	// ReadSystem is a systemstore key that is not a sequence.
+	ReadSystem
+	// ReadSequence is a systemstore /seq/ key. Short ID allocation commits the sequence in
+	// its own transaction, so a merge never carries one in its read set and this stays zero
+	// on that path. It is kept for callers that do read a sequence inline.
+	ReadSequence
+	// ReadPeer is a peerstore key.
+	ReadPeer
+	// ReadEnc is an encryption keystore key.
+	ReadEnc
+	// ReadRangeIterator means the transaction opened an iterator bounded by start and end
+	// rather than by prefix. Badger's prefix option is unset for those, so its bounds
+	// check reads the first key past the range into the read set.
+	ReadRangeIterator
+	// ReadPrefixIterator means the transaction opened a prefix-bounded iterator, which
+	// cannot read past its range.
+	ReadPrefixIterator
+)
+
+// readKindNames is ordered to match the bit order above.
+var readKindNames = [...]string{
+	"doc",
+	"index",
+	"uniqueIndex",
+	"head",
+	"block",
+	"system",
+	"sequence",
+	"peer",
+	"enc",
+	"rangeIter",
+	"prefixIter",
+}
+
+// ReadKindCount is the number of distinct kinds, for callers keeping a counter per kind.
+const ReadKindCount = len(readKindNames)
+
+// ReadKindName returns the name of the kind held in bit i, or "" if i is out of range.
+func ReadKindName(i int) string {
+	if i < 0 || i >= len(readKindNames) {
+		return ""
+	}
+	return readKindNames[i]
+}
+
+// String renders the set as a pipe-separated list in bit order, e.g. "doc|head|rangeIter".
+// An empty set renders as "none".
+func (k ReadKind) String() string {
+	if k == 0 {
+		return "none"
+	}
+	var b strings.Builder
+	for i, name := range readKindNames {
+		if k&(1<<uint(i)) == 0 {
+			continue
+		}
+		if b.Len() > 0 {
+			b.WriteByte('|')
+		}
+		b.WriteString(name)
+	}
+	return b.String()
+}
+
+// ReadKinds accumulates the kinds of key a single transaction has read.
+//
+// The zero value is ready to use. It is safe for concurrent use, which matters because a
+// transaction may be read from more than one goroutine even though a merge is not.
+type ReadKinds struct {
+	bits atomic.Uint32
+}
+
+// Mark records that a key of the given kind entered the read set. Safe on a nil receiver
+// so call sites do not have to check whether the transaction records kinds.
+func (r *ReadKinds) Mark(kind ReadKind) {
+	if r == nil {
+		return
+	}
+	r.bits.Or(uint32(kind))
+}
+
+// Kinds returns the set recorded so far.
+func (r *ReadKinds) Kinds() ReadKind {
+	if r == nil {
+		return 0
+	}
+	return ReadKind(r.bits.Load())
+}
+
+// readKindsCarrier is implemented by transactions that record read kinds. It is optional:
+// shims and mocks that do not record them are simply not asked.
+type readKindsCarrier interface {
+	ReadKinds() *ReadKinds
+}
+
+// ReadKindsOf returns the recorder for txn, or nil if txn does not record read kinds.
+// A nil result is usable: every method on ReadKinds tolerates it.
+//
+// Used by the few call sites that know a key's class from its Go type rather than its
+// encoded bytes: an index entry and a document value are both datastore keys and are
+// indistinguishable once encoded.
+func ReadKindsOf(txn any) *ReadKinds {
+	if c, ok := txn.(readKindsCarrier); ok {
+		return c.ReadKinds()
+	}
+	return nil
+}

--- a/internal/datastore/readkinds_test.go
+++ b/internal/datastore/readkinds_test.go
@@ -1,0 +1,99 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package datastore
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcenetwork/corekv"
+	"github.com/sourcenetwork/corekv/memory"
+	"github.com/sourcenetwork/immutable"
+
+	"github.com/sourcenetwork/defradb/internal/db/lock"
+	"github.com/sourcenetwork/defradb/internal/keys"
+)
+
+func TestKindForKey(t *testing.T) {
+	tests := []struct {
+		name string
+		key  string
+		want ReadKind
+	}{
+		{"datastore", "d/1/v/2/3", ReadDoc},
+		{"headstore", "h/1/2", ReadHead},
+		{"blockstore", "bsomecid", ReadBlock},
+		{"systemstore", "s/collection/name/Foo", ReadSystem},
+		{"sequence", "s/seq/doc", ReadSequence},
+		{"peerstore", "p/replicator/1", ReadPeer},
+		{"encstore", "esomecid", ReadEnc},
+		{"unknown", "?/1", 0},
+		{"empty", "", 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, kindForKey([]byte(tt.key)))
+		})
+	}
+}
+
+func TestReadKindString(t *testing.T) {
+	require.Equal(t, "none", ReadKind(0).String())
+	require.Equal(t, "doc", ReadDoc.String())
+	require.Equal(t, "doc|head|rangeIter", (ReadDoc | ReadHead | ReadRangeIterator).String())
+}
+
+// The recorder has to see the store discriminator that namespace.Wrap prepends, so these
+// go through a real transaction rather than calling the recorder directly.
+func TestTxnRecordsReadKinds(t *testing.T) {
+	ctx := context.Background()
+	txn := NewTxnFrom(memory.NewDatastore(ctx), lock.NewLockSet(), 0, false, immutable.None[int]())
+	defer txn.Discard()
+	ctx = CtxSetTxn(ctx, txn)
+
+	require.Equal(t, ReadKind(0), txn.ReadKinds().Kinds())
+
+	key := keys.DataStoreKey{CollectionShortID: 1, InstanceType: keys.ValueKey, DocShortID: 2, FieldID: "3"}
+	_, err := txn.Datastore().Get(ctx, key)
+	require.ErrorIs(t, err, corekv.ErrNotFound)
+	require.Equal(t, ReadDoc, txn.ReadKinds().Kinds())
+
+	_, err = txn.Headstore().Get(ctx, []byte("/1/2"))
+	require.ErrorIs(t, err, corekv.ErrNotFound)
+	require.Equal(t, ReadDoc|ReadHead, txn.ReadKinds().Kinds())
+}
+
+// A start/end iterator is the shape whose bounds check reads one key past the requested
+// range. Distinguishing it from a prefix iterator is the point of the two iterator bits.
+func TestTxnRecordsIteratorShape(t *testing.T) {
+	ctx := context.Background()
+
+	prefix := keys.DataStoreKey{CollectionShortID: 1, InstanceType: keys.ValueKey, DocShortID: 2}
+
+	rangeTxn := NewTxnFrom(memory.NewDatastore(ctx), lock.NewLockSet(), 0, false, immutable.None[int]())
+	defer rangeTxn.Discard()
+	iter, err := rangeTxn.Datastore().Iterator(
+		CtxSetTxn(ctx, rangeTxn),
+		IterOptions{Start: prefix, End: prefix.PrefixEnd()},
+	)
+	require.NoError(t, err)
+	require.NoError(t, iter.Close())
+	require.Equal(t, ReadDoc|ReadRangeIterator, rangeTxn.ReadKinds().Kinds())
+
+	prefixTxn := NewTxnFrom(memory.NewDatastore(ctx), lock.NewLockSet(), 0, false, immutable.None[int]())
+	defer prefixTxn.Discard()
+	iter, err = prefixTxn.Datastore().Iterator(CtxSetTxn(ctx, prefixTxn), IterOptions{Prefix: prefix})
+	require.NoError(t, err)
+	require.NoError(t, iter.Close())
+	require.Equal(t, ReadDoc|ReadPrefixIterator, prefixTxn.ReadKinds().Kinds())
+}

--- a/internal/datastore/readrecorder.go
+++ b/internal/datastore/readrecorder.go
@@ -1,0 +1,99 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package datastore
+
+import (
+	"bytes"
+	"context"
+
+	"github.com/sourcenetwork/corekv"
+)
+
+// sequencePrefix is the systemstore prefix under which all sequences live.
+var sequencePrefix = []byte("/seq/")
+
+// readRecorder sits between a transaction's namespaced stores and the raw transaction,
+// classifying every key the transaction reads by the store it belongs to.
+//
+// Writes pass through unclassified: the underlying store's conflict detection compares a
+// transaction's reads against other transactions' writes, so only reads decide whether a
+// commit conflicts.
+//
+// The recorder must not be handed to corekv as a context transaction. corekv casts the
+// context value to its own concrete transaction type, and a wrapper fails that cast.
+type readRecorder struct {
+	store corekv.ReaderWriter
+	kinds *ReadKinds
+}
+
+var _ corekv.ReaderWriter = (*readRecorder)(nil)
+
+// kindForKey classifies a rootstore key by its leading store discriminator byte, which
+// namespace.Wrap has already prepended by the time the key reaches here.
+func kindForKey(key []byte) ReadKind {
+	if len(key) == 0 {
+		return 0
+	}
+	switch key[0] {
+	case dataStoreKey:
+		// Index entries are also datastore keys and encode identically to document keys.
+		// The index write path marks those itself; everything else here is a document.
+		return ReadDoc
+	case headStoreKey:
+		return ReadHead
+	case blockStoreKey:
+		return ReadBlock
+	case systemStoreKey:
+		if bytes.HasPrefix(key[1:], sequencePrefix) {
+			return ReadSequence
+		}
+		return ReadSystem
+	case peerStoreKey:
+		return ReadPeer
+	case encStoreKey:
+		return ReadEnc
+	default:
+		return 0
+	}
+}
+
+func (r *readRecorder) Get(ctx context.Context, key []byte) ([]byte, error) {
+	r.kinds.Mark(kindForKey(key))
+	return r.store.Get(ctx, key)
+}
+
+func (r *readRecorder) Has(ctx context.Context, key []byte) (bool, error) {
+	r.kinds.Mark(kindForKey(key))
+	return r.store.Has(ctx, key)
+}
+
+// Iterator records the shape of the iterator as well as what it scans. A start/end
+// iterator is the shape whose bounds check reads one key past the requested range, so
+// separating the two shapes is what makes that over-read visible.
+func (r *readRecorder) Iterator(ctx context.Context, opts corekv.IterOptions) (corekv.Iterator, error) {
+	switch {
+	case opts.Prefix != nil:
+		r.kinds.Mark(ReadPrefixIterator | kindForKey(opts.Prefix))
+	case opts.Start != nil:
+		r.kinds.Mark(ReadRangeIterator | kindForKey(opts.Start))
+	case opts.End != nil:
+		r.kinds.Mark(ReadRangeIterator | kindForKey(opts.End))
+	}
+	return r.store.Iterator(ctx, opts)
+}
+
+func (r *readRecorder) Set(ctx context.Context, key, value []byte) error {
+	return r.store.Set(ctx, key, value)
+}
+
+func (r *readRecorder) Delete(ctx context.Context, key []byte) error {
+	return r.store.Delete(ctx, key)
+}

--- a/internal/datastore/txn.go
+++ b/internal/datastore/txn.go
@@ -90,6 +90,10 @@ type BasicTxn struct {
 	id            uint64
 	ts            time.Time // timestamp
 
+	// readKinds records which classes of key this transaction's read set holds, so a
+	// commit conflict can be attributed to a class of key rather than reported bare.
+	readKinds ReadKinds
+
 	successFns []func()
 	errorFns   []func()
 	discardFns []func()
@@ -110,14 +114,26 @@ func NewTxnFrom(
 	chunkSize immutable.Option[int],
 ) *BasicTxn {
 	rootTxn := rootstore.NewTxn(readonly)
-	multistore := NewMultistore(rootTxn, lockSet, chunkSize)
 
-	return &BasicTxn{
-		Multistore:    multistore,
+	txn := &BasicTxn{
 		underlyingTxn: rootTxn,
 		id:            id,
 		ts:            time.Now(),
 	}
+	// The child stores read through the recorder; underlyingTxn stays unwrapped because
+	// corekv casts it to its own concrete type when it is fetched from a context.
+	txn.Multistore = NewMultistore(
+		&readRecorder{store: rootTxn, kinds: &txn.readKinds},
+		lockSet,
+		chunkSize,
+	)
+
+	return txn
+}
+
+// ReadKinds returns the classes of key this transaction has read so far.
+func (t *BasicTxn) ReadKinds() *ReadKinds {
+	return &t.readKinds
 }
 
 // The raw underlying txn.

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -125,6 +125,9 @@ type DB struct {
 	lockSet *lock.LockSet
 
 	collectionRepository *description.CollectionRepository
+
+	// stats are the merge-path counters reported on an interval by reportMergeStats.
+	stats *mergeStats
 }
 
 var _ client.TxnStore = (*DB)(nil)
@@ -176,6 +179,7 @@ func newDB(
 		p2pBlockSyncTimeout:     cfg.P2PBlockSyncTimeout,
 		lockSet:                 lockSet,
 		collectionRepository:    description.NewColCache(lockSet, datastore.NewUnsafeDatastore(rootstore)),
+		stats:                   &mergeStats{},
 	}
 
 	lensRuntime, err := newLensRuntime(LensRuntimeType(cfg.LensRuntime))
@@ -232,6 +236,8 @@ func newDB(
 			log.ErrorE("index state recovery failed", err)
 		}
 	})
+
+	go db.reportMergeStats(db.ctx)
 
 	return db, nil
 }

--- a/internal/db/index.go
+++ b/internal/db/index.go
@@ -86,6 +86,7 @@ func NewCollectionIndex(
 		fieldsDescs:     make([]client.CollectionFieldDescription, len(desc.Fields)),
 		fieldGenerators: make([]FieldIndexGenerator, len(desc.Fields)),
 	}
+	base.stats = statsFor(collection)
 	for i := range desc.Fields {
 		field, foundField := collection.Version().GetFieldByName(desc.Fields[i].Name)
 		if !foundField {
@@ -197,6 +198,9 @@ type collectionBaseIndex struct {
 	// sequence at construction. During a rebuild the sequence names the epoch being built, so
 	// live writes maintain it.
 	epoch uint32
+	// stats counts unique-index existence checks. Nil when the index was built for a
+	// collection this package did not construct.
+	stats *mergeStats
 }
 
 // getDocFieldValues retrieves the values of the indexed fields from the given document.
@@ -265,6 +269,9 @@ func (index *collectionBaseIndex) deleteIndexKey(
 ) error {
 	txn := datastore.CtxMustGetTxn(ctx)
 	ds := txn.Datastore()
+	// An index entry is a datastore key and encodes like a document key, so the store
+	// cannot tell them apart. Mark it here, where the type is known.
+	datastore.ReadKindsOf(txn).Mark(datastore.ReadIndex)
 	exists, err := ds.Has(ctx, &key)
 	if err != nil {
 		return NewErrCheckIndexKeyExists(err, index.desc.Name)
@@ -406,7 +413,7 @@ func (index *collectionUniqueIndex) Save(
 	doc *client.Document,
 ) error {
 	return index.generateKeysAndProcess(ctx, doc, false, func(key keys.IndexDataStoreKey) error {
-		return saveUniqueKey(ctx, doc, key, index.fieldsDescs, index.building)
+		return saveUniqueKey(ctx, doc, key, index.fieldsDescs, index.building, index.stats)
 	})
 }
 
@@ -422,6 +429,7 @@ func saveUniqueKey(
 	key keys.IndexDataStoreKey,
 	fieldsDescs []client.CollectionFieldDescription,
 	tolerateSameDoc bool,
+	stats *mergeStats,
 ) error {
 	txn := datastore.CtxMustGetTxn(ctx)
 
@@ -438,10 +446,14 @@ func saveUniqueKey(
 	}
 
 	if len(val) != 0 {
+		// This read puts the unique key in the transaction's read set, so two transactions
+		// writing the same index value conflict at commit rather than at this check.
+		datastore.ReadKindsOf(txn).Mark(datastore.ReadUniqueIndex)
 		existing, err := txn.Datastore().Get(ctx, &key)
 		if err != nil && !errors.Is(err, corekv.ErrNotFound) {
 			return NewErrCheckUniqueIndexConstraint(err)
 		}
+		stats.markUniqueIndexCheck(existing != nil)
 		if existing != nil {
 			if tolerateSameDoc && string(existing) == string(val) {
 				return nil

--- a/internal/db/merge.go
+++ b/internal/db/merge.go
@@ -219,12 +219,16 @@ func (db *DB) mergeChunk(ctx context.Context, entries []mergeEntry) error {
 	var conflictErr error
 	var blamed mergeEntry
 	var phase string
+	// The classes of key the last conflicting attempt had read. The underlying store does
+	// not name the contended key, so this is the only lead on what the conflict was over.
+	var conflictKinds datastore.ReadKind
 	for i := 0; i < db.MaxTxnRetries(); i++ {
 		txn, err := db.NewTxn(false)
 		if err != nil {
 			return err
 		}
 		txnCtx := InitContext(ctx, txn)
+		readKinds := datastore.ReadKindsOf(txn)
 
 		var mergeErr error
 		for _, e := range entries {
@@ -238,6 +242,8 @@ func (db *DB) mergeChunk(ctx context.Context, entries []mergeEntry) error {
 			txn.Discard()
 			if errors.Is(mergeErr, corekv.ErrTxnConflict) {
 				conflictErr = mergeErr
+				conflictKinds = readKinds.Kinds()
+				db.stats.chunkConflicts.Add(1)
 				continue
 			}
 			return mergeErr
@@ -247,6 +253,8 @@ func (db *DB) mergeChunk(ctx context.Context, entries []mergeEntry) error {
 			txn.Discard()
 			if errors.Is(err, corekv.ErrTxnConflict) {
 				conflictErr = err
+				conflictKinds = readKinds.Kinds()
+				db.stats.chunkConflicts.Add(1)
 				// A commit conflict belongs to the whole transaction and cannot be
 				// attributed to one event.
 				blamed, phase = mergeEntry{}, phaseCommit
@@ -261,9 +269,12 @@ func (db *DB) mergeChunk(ctx context.Context, entries []mergeEntry) error {
 	// Nothing was committed, so callers must not treat the events as merged. This is the
 	// one place a conflict becomes data loss, so it is reported even though the retries
 	// leading to it are not.
+	db.stats.markExhausted(phase == phaseCommit, conflictKinds)
+
 	fields := []slog.Attr{
 		corelog.Int("attempts", db.MaxTxnRetries()),
 		corelog.String("phase", phase),
+		corelog.String("readKinds", conflictKinds.String()),
 		corelog.String("docIDs", namedDocs(entries)),
 	}
 	// Only a read conflict has a single event to blame; at commit it would just repeat
@@ -317,7 +328,12 @@ func (db *DB) mergeInTxn(ctx context.Context, col *collection, dagMerge event.Me
 		}
 	}
 
-	mp, err := db.newMergeProcessor(ctx, col, len(mt.heads) == 0)
+	// No local heads means the merge is creating the document rather than updating one
+	// that already exists here.
+	newDocCreateMode := len(mt.heads) == 0
+	db.stats.markCreateOrUpdate(newDocCreateMode)
+
+	mp, err := db.newMergeProcessor(ctx, col, newDocCreateMode)
 	if err != nil {
 		return err
 	}

--- a/internal/db/p2p/car.go
+++ b/internal/db/p2p/car.go
@@ -170,7 +170,11 @@ func (p *P2P) importCAR(ctx context.Context, carData []byte) (*coreblock.Block, 
 		return nil, ErrEmptyCARRoots
 	}
 
-	bstore := datastore.BlindWriteP2PBlockstoreFrom(p.db.Rootstore(), immutable.None[int]())
+	// A CAR carries whole document DAGs, and content-addressed field blocks recur across
+	// documents sharing a field value, so a CAR routinely contains blocks already stored.
+	// The guarded store skips those instead of rewriting the block and re-stamping a
+	// to-merge marker on one that already merged.
+	bstore := datastore.P2PBlockstoreFrom(p.db.Rootstore(), immutable.None[int]())
 	encStore := datastore.EncstoreFrom(p.db.Rootstore())
 	var rootBlock *coreblock.Block
 

--- a/internal/db/p2p/car.go
+++ b/internal/db/p2p/car.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/sourcenetwork/corekv"
 	"github.com/sourcenetwork/corekv/blockstore"
+	"github.com/sourcenetwork/corelog"
 	"github.com/sourcenetwork/defradb/errors"
 	coreblock "github.com/sourcenetwork/defradb/internal/core/block"
 	"github.com/sourcenetwork/defradb/internal/datastore"
@@ -31,27 +32,72 @@ import (
 
 // generateCAR creates a CAR file containing the root block and all its linked blocks.
 func (p *P2P) generateCAR(ctx context.Context, rootBlock *coreblock.Block) ([]byte, error) {
+	data, err := p.buildCAR(ctx, rootBlock)
+	if err != nil {
+		p.statCARFailed.Add(1)
+		return nil, err
+	}
+	p.statCARBuilt.Add(1)
+	return data, nil
+}
+
+// carFailure records the reason a CAR could not be built and logs the first occurrence of
+// that reason, so a persistent failure shows up as a count rather than a line per call.
+func (p *P2P) carFailure(reason string, err error) error {
+	if p.carFailureReason.record(reason) {
+		log.ErrorE("Failed to generate CAR", err, corelog.String("reason", reason))
+	}
+	return err
+}
+
+// carImportFailure records an abandoned import: how it failed and how many blocks it had
+// already written. Those blocks sit in the store owned by no document until a later merge
+// claims them or the orphan sweep reclaims them.
+func (p *P2P) carImportFailure(reason string, written int64, err error) error {
+	p.statCARImportFailed.Add(1)
+	p.statCARImportOrphans.Add(written)
+	if p.carImportFailureReason.record(reason) {
+		log.ErrorE("Failed to import CAR", err,
+			corelog.String("reason", reason), corelog.Int64("blocksWritten", written))
+	}
+	return err
+}
+
+// buildCAR walks the DAG rooted at rootBlock and serialises every block it reaches.
+//
+// The walk skips links it cannot load rather than failing, so a CAR can be short of the
+// full DAG. missingLinks counts those skips and a CAR holding only the root block is
+// counted separately: its receiver has nothing to import and falls back to a per-link
+// BitSwap walk.
+func (p *P2P) buildCAR(ctx context.Context, rootBlock *coreblock.Block) ([]byte, error) {
 	txn := p.db.Rootstore().NewTxn(true)
 	defer txn.Discard()
 	txnCtx := corekv.SetCtxTxn(ctx, txn)
 
 	rootLink, err := rootBlock.GenerateLink()
 	if err != nil {
-		return nil, err
+		return nil, p.carFailure(reasonRootLink, err)
 	}
 
 	bstore := datastore.BlockstoreFrom(p.db.Rootstore(), immutable.None[int]())
 	linkSystem := makeLinkSystem(blockstore.NewIPLDStore(bstore))
 
 	blockCIDs := make(map[string]struct{})
-	if err := p.collectDAGBlocks(txnCtx, &linkSystem, rootLink.Cid, blockCIDs); err != nil {
-		return nil, err
+	var missingLinks int64
+	if err := p.collectDAGBlocks(txnCtx, &linkSystem, rootLink.Cid, blockCIDs, &missingLinks); err != nil {
+		return nil, p.carFailure(reasonWalk, err)
+	}
+
+	p.statCARBlocks.Add(int64(len(blockCIDs)))
+	p.statCARMissing.Add(missingLinks)
+	if len(blockCIDs) <= 1 {
+		p.statCARBareTip.Add(1)
 	}
 
 	var buf bytes.Buffer
 	carWriter, err := storage.NewWritable(&buf, []cid.Cid{rootLink.Cid}, car.WriteAsCarV1(true))
 	if err != nil {
-		return nil, err
+		return nil, p.carFailure(reasonCARWriter, err)
 	}
 
 	encStore := datastore.EncstoreFrom(p.db.Rootstore())
@@ -59,7 +105,7 @@ func (p *P2P) generateCAR(ctx context.Context, rootBlock *coreblock.Block) ([]by
 	for cidStr := range blockCIDs {
 		c, err := cid.Decode(cidStr)
 		if err != nil {
-			return nil, err
+			return nil, p.carFailure(reasonBlockRead, err)
 		}
 
 		var blockBytes []byte
@@ -67,7 +113,7 @@ func (p *P2P) generateCAR(ctx context.Context, rootBlock *coreblock.Block) ([]by
 		if err != nil {
 			encBlock, encErr := encStore.Get(txnCtx, c)
 			if encErr != nil {
-				return nil, err
+				return nil, p.carFailure(reasonBlockRead, err)
 			}
 			blockBytes = encBlock.RawData()
 		} else {
@@ -75,7 +121,7 @@ func (p *P2P) generateCAR(ctx context.Context, rootBlock *coreblock.Block) ([]by
 		}
 
 		if err := carWriter.Put(txnCtx, c.KeyString(), blockBytes); err != nil {
-			return nil, err
+			return nil, p.carFailure(reasonCARPut, err)
 		}
 	}
 
@@ -83,11 +129,13 @@ func (p *P2P) generateCAR(ctx context.Context, rootBlock *coreblock.Block) ([]by
 }
 
 // collectDAGBlocks recursively collects all block CIDs in the DAG by following Links.
+// missing is incremented for every link that could not be loaded and was skipped.
 func (p *P2P) collectDAGBlocks(
 	ctx context.Context,
 	linkSystem *linking.LinkSystem,
 	blockCID cid.Cid,
 	visited map[string]struct{},
+	missing *int64,
 ) error {
 	cidStr := blockCID.String()
 	if _, seen := visited[cidStr]; seen {
@@ -103,6 +151,7 @@ func (p *P2P) collectDAGBlocks(
 	if err != nil {
 		// Block may have been pruned locally; it was already pushed to replicators before
 		// pruning so they already hold it. Skip rather than aborting the CAR.
+		*missing++
 		return nil
 	}
 
@@ -122,7 +171,7 @@ func (p *P2P) collectDAGBlocks(
 	}
 
 	for _, dagLink := range block.Links {
-		if err := p.collectDAGBlocks(ctx, linkSystem, dagLink.Link.Cid, visited); err != nil {
+		if err := p.collectDAGBlocks(ctx, linkSystem, dagLink.Link.Cid, visited, missing); err != nil {
 			return err
 		}
 	}
@@ -160,14 +209,19 @@ func peekCARRootBlock(carData []byte) (*coreblock.Block, error) {
 // importCAR extracts all blocks from a CAR byte slice and stores them in the blockstore.
 // Returns the root block for further processing.
 func (p *P2P) importCAR(ctx context.Context, carData []byte) (*coreblock.Block, error) {
+	// This is the path every inbound document takes, so it is where blocks actually enter
+	// the store. The generateCAR counters describe the outbound side and say nothing about it.
+	p.statCARImported.Add(1)
+	var written int64
+
 	reader, err := car.NewBlockReader(bytes.NewReader(carData))
 	if err != nil {
-		return nil, err
+		return nil, p.carImportFailure(reasonReader, written, err)
 	}
 
 	roots := reader.Roots
 	if len(roots) == 0 {
-		return nil, ErrEmptyCARRoots
+		return nil, p.carImportFailure(reasonNoRoots, written, ErrEmptyCARRoots)
 	}
 
 	// A CAR carries whole document DAGs, and content-addressed field blocks recur across
@@ -184,8 +238,9 @@ func (p *P2P) importCAR(ctx context.Context, carData []byte) (*coreblock.Block, 
 			break
 		}
 		if err != nil {
-			return nil, err
+			return nil, p.carImportFailure(reasonNext, written, err)
 		}
+		written++
 
 		decodedBlock, err := coreblock.GetFromBytes(carBlock.RawData())
 		if err != nil {

--- a/internal/db/p2p/dropstats_test.go
+++ b/internal/db/p2p/dropstats_test.go
@@ -1,0 +1,48 @@
+// Copyright 2025 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package p2p
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// A drop is a document that was meant to be stored and was not; a skip is one deliberately
+// not merged. Counting them together would report policy decisions as data loss.
+func TestDropAndSkipAreCountedApart(t *testing.T) {
+	p := &P2P{}
+
+	p.dropDoc("importCAR")
+	p.dropDoc("importCAR")
+	p.dropDoc("syncDAG")
+	p.skipDoc("alreadyMerged")
+
+	require.Equal(t, int64(3), p.statDroppedDocs.Load(), "drops")
+	require.Equal(t, int64(1), p.statSkippedDocs.Load(), "skips")
+
+	counts := map[string]int64{}
+	for _, rc := range p.docDropReason.drain() {
+		counts[rc.reason] = rc.count
+	}
+	require.Equal(t, int64(2), counts["importCAR"])
+	require.Equal(t, int64(1), counts["syncDAG"])
+	require.Equal(t, int64(1), counts["skip:alreadyMerged"], "skips carry a distinct prefix")
+}
+
+// The reason set is fixed so a peer cannot grow the map, and drain resets it so each
+// reported interval is a rate rather than a running total.
+func TestDropReasonsDrainResets(t *testing.T) {
+	p := &P2P{}
+	p.dropDoc("blockDecode")
+	require.Len(t, p.docDropReason.drain(), 1)
+	require.Empty(t, p.docDropReason.drain(), "a drained reason set starts the next interval empty")
+}

--- a/internal/db/p2p/p2p.go
+++ b/internal/db/p2p/p2p.go
@@ -222,8 +222,52 @@ type P2P struct {
 	statDroppedFull   atomic.Int64
 	statMergedDocs    atomic.Int64
 	statDroppedDocs   atomic.Int64
+	// statSkippedDocs counts documents deliberately not merged: already held, or
+	// excluded by access or the replication filter. Not a loss, so kept apart.
+	statSkippedDocs   atomic.Int64
 	statBatches       atomic.Int64
 	statBatchFailures atomic.Int64
+	// statRelayed counts documents the network accepted from us, and statRelayFailed the
+	// ones the send rejected. Counted after SendUpdate returns, so the pair says whether
+	// forwarding works rather than restating the merge count.
+	// Compared against statMergedDocs it shows how much of what this node stores it also
+	// forwards.
+	statRelayed     atomic.Int64
+	statRelayFailed atomic.Int64
+
+	// The inbound CAR path: imports attempted, imports abandoned, and the blocks an
+	// abandoned import had already written. Every document this node stores arrives this
+	// way, so the generation counters below say nothing about it.
+	statCARImported      atomic.Int64
+	statCARImportFailed  atomic.Int64
+	statCARImportOrphans atomic.Int64
+
+	// CAR generation counters. A CAR that carries only the root block gives its receiver
+	// nothing to import, so the receiver falls back to a per-link BitSwap walk.
+	statCARBuilt           atomic.Int64
+	statCARFailed          atomic.Int64
+	statCARBlocks          atomic.Int64
+	statCARMissing         atomic.Int64
+	statCARBareTip         atomic.Int64
+	carFailureReason       failureReasons
+	carImportFailureReason failureReasons
+
+	// syncDAG counters. statSyncDAGAbandoned is the number of blocks already written to
+	// the blockstore by walks that then failed, which is the rate at which this node
+	// creates blocks no document references.
+	statSyncDAGCalls     atomic.Int64
+	statSyncDAGFailed    atomic.Int64
+	statSyncDAGBlocks    atomic.Int64
+	statSyncDAGAbandoned atomic.Int64
+	syncDAGFailureReason failureReasons
+
+	// docDropReason names why an inbound document never reached the merge. The set is
+	// fixed: a reason taken from an error string would let a peer grow the map.
+	docDropReason failureReasons
+
+	// dedup measures how much of the inbound stream is the same message arriving more
+	// than once, which sizes what a dedup at the door would save.
+	dedup *wireDedup
 }
 
 // pushLogCommProcessor implements CommProcessor for push log functionality
@@ -282,6 +326,7 @@ func New(
 		msgQueue:             make(chan queuedMessage, msgQueueSize),
 		msgQueueMaxBytes:     queueByteBudget(),
 		stopStats:            make(chan struct{}),
+		dedup:                newWireDedup(),
 	}
 
 	for i := 0; i < dagSyncWorkers; i++ {
@@ -680,6 +725,9 @@ func (p *P2P) docIDsForBlockCID(
 // not pay for a decode it will not use.
 func (p *P2P) pubSubMessageHandler(from string, topic string, msg []byte) ([]byte, error) {
 	size := int64(len(msg))
+	// Observed before the budget check so the count covers dropped messages too; they are
+	// the majority of the inbound stream and the reason the question is worth asking.
+	p.dedup.observe(msg)
 	if !p.claimQueueBytes(size) {
 		p.statDroppedBudget.Add(1)
 		log.Info("pubsub message queue over byte budget, dropping message",
@@ -742,6 +790,7 @@ func (p *P2P) reportStats() {
 		case <-p.stopStats:
 			return
 		case <-ticker.C:
+			msgsIn, msgsDistinct, dedupTruncated := p.dedup.drain()
 			log.Info("p2p stats",
 				corelog.Int("queueDepth", len(p.msgQueue)),
 				corelog.Int("queueSlots", msgQueueSize),
@@ -753,9 +802,45 @@ func (p *P2P) reportStats() {
 				corelog.Int64("batchFailures", p.statBatchFailures.Swap(0)),
 				corelog.Int64("docsMerged", p.statMergedDocs.Swap(0)),
 				corelog.Int64("docsDropped", p.statDroppedDocs.Swap(0)),
+				corelog.Int64("docsSkipped", p.statSkippedDocs.Swap(0)),
+				corelog.Int64("docsRelayed", p.statRelayed.Swap(0)),
+				corelog.Int64("relayFailed", p.statRelayFailed.Swap(0)),
+				corelog.Int64("msgsIn", msgsIn),
+				corelog.Int64("msgsDistinct", msgsDistinct),
+				corelog.Bool("msgsDistinctTruncated", dedupTruncated),
+				corelog.Int64("carImported", p.statCARImported.Swap(0)),
+				corelog.Int64("carImportFailed", p.statCARImportFailed.Swap(0)),
+				corelog.Int64("carImportOrphans", p.statCARImportOrphans.Swap(0)),
+				corelog.Int64("carBuilt", p.statCARBuilt.Swap(0)),
+				corelog.Int64("carFailed", p.statCARFailed.Swap(0)),
+				corelog.Int64("carBlocks", p.statCARBlocks.Swap(0)),
+				corelog.Int64("carMissingLinks", p.statCARMissing.Swap(0)),
+				corelog.Int64("carBareTip", p.statCARBareTip.Swap(0)),
+				corelog.Int64("syncDAGCalls", p.statSyncDAGCalls.Swap(0)),
+				corelog.Int64("syncDAGFailed", p.statSyncDAGFailed.Swap(0)),
+				corelog.Int64("syncDAGBlocks", p.statSyncDAGBlocks.Swap(0)),
+				corelog.Int64("syncDAGAbandoned", p.statSyncDAGAbandoned.Swap(0)),
 			)
+			reportFailureReasons("car failures", p.carFailureReason.drain())
+			reportFailureReasons("syncDAG failures", p.syncDAGFailureReason.drain())
+			reportFailureReasons("document drops", p.docDropReason.drain())
+			reportFailureReasons("CAR import failures", p.carImportFailureReason.drain())
 		}
 	}
+}
+
+// reportFailureReasons logs one line naming every reason that occurred in the interval,
+// or nothing when there were none. Reasons come from a fixed set, so the line has a
+// bounded width.
+func reportFailureReasons(msg string, counts []reasonCount) {
+	if len(counts) == 0 {
+		return
+	}
+	fields := make([]slog.Attr, 0, len(counts))
+	for _, c := range counts {
+		fields = append(fields, corelog.Int64(c.reason, c.count))
+	}
+	log.Info(msg, fields...)
 }
 
 // processMessageWorker is a long-lived goroutine that drains p.msgQueue and
@@ -852,10 +937,13 @@ func (p *P2P) processPushlogRequest(
 			}
 			p.db.Events().Publish(event.NewMessage(event.UpdateName, updateEvt))
 			if err := p.SendUpdate(updateEvt); err != nil {
+				p.statRelayFailed.Add(1)
 				log.ErrorE("Failed to send update after batch sync", err,
 					slog.String("DocID", r.merge.DocID),
 					slog.Any("PeerID", p.host.ID()),
 				)
+			} else {
+				p.statRelayed.Add(1)
 			}
 		}
 		return nil
@@ -954,7 +1042,10 @@ func (p *P2P) processPushlogRequest(
 		if err := p.SendUpdate(updateEvt); err != nil {
 			// We don't need to return the error for this side-effect-function call.
 			// It's a bonus action that shouldn't affect the caller of `processPushlogRequest`.
+			p.statRelayFailed.Add(1)
 			log.ErrorE("Failed to send update after sync", err, slog.Any("PeerID", p.host.ID()))
+		} else {
+			p.statRelayed.Add(1)
 		}
 
 		return nil
@@ -985,15 +1076,18 @@ func (p *P2P) processBatchedDocuments(
 				slog.String("DocID", doc.DocID),
 				slog.String("CollectionID", req.CollectionID),
 			)
+			p.dropDoc("invalidCID")
 			continue
 		}
 
 		isMerged, err := p.db.Multistore().Blockstore().IsMerged(ctx, headCID)
 		if err != nil {
 			log.ErrorE("Batch: IsMerged check failed", err, slog.String("DocID", doc.DocID))
+			p.dropDoc("isMergedError")
 			continue
 		}
 		if isMerged {
+			p.skipDoc("alreadyMerged")
 			continue
 		}
 
@@ -1005,16 +1099,19 @@ func (p *P2P) processBatchedDocuments(
 		}
 		if err != nil {
 			log.ErrorE("Batch: block decode failed", err, slog.String("DocID", doc.DocID))
+			p.dropDoc("blockDecode")
 			continue
 		}
 
 		blockLink, err := block.GenerateLink()
 		if err != nil {
 			log.ErrorE("Batch: GenerateLink failed", err, slog.String("DocID", doc.DocID))
+			p.dropDoc("generateLink")
 			continue
 		}
 		if blockLink.Cid != headCID {
 			log.Error("Batch: CID mismatch", slog.String("DocID", doc.DocID))
+			p.dropDoc("cidMismatch")
 			continue
 		}
 
@@ -1022,25 +1119,30 @@ func (p *P2P) processBatchedDocuments(
 			mightHaveAccess, err := p.trySelfHasAccess(ctx, headCID, block, req.CollectionID, doc.DocID)
 			if err != nil {
 				log.ErrorE("Batch: access check failed", err, slog.String("DocID", doc.DocID))
+				p.dropDoc("accessError")
 				continue
 			}
 			if !mightHaveAccess {
+				p.skipDoc("noAccess")
 				continue
 			}
 		}
 
 		if !p.filterAllowsReplication(ctx, req.CollectionID, doc.DocID, block) {
+			p.skipDoc("filtered")
 			continue
 		}
 
 		if len(doc.CAR) > 0 {
 			if _, err = p.importCAR(ctx, doc.CAR); err != nil {
 				log.ErrorE("Batch: importCAR failed", err, slog.String("DocID", doc.DocID))
+				p.dropDoc("importCAR")
 				continue
 			}
 		} else {
 			if err = p.syncDAG(ctx, block); err != nil {
 				log.ErrorE("Batch: syncDAG failed", err, slog.String("DocID", doc.DocID))
+				p.dropDoc("syncDAG")
 				continue
 			}
 		}

--- a/internal/db/p2p/stats.go
+++ b/internal/db/p2p/stats.go
@@ -1,0 +1,164 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package p2p
+
+import (
+	"hash/maphash"
+	"sort"
+	"sync"
+)
+
+// Reasons a CAR could not be generated or a DAG walk could not finish. They are a fixed
+// set: deriving a reason from an error message would let a remote peer grow the counter
+// map without bound.
+const (
+	reasonRootLink   = "rootLink"
+	reasonWalk       = "walk"
+	reasonCARWriter  = "carWriter"
+	reasonBlockRead  = "blockRead"
+	reasonCARPut     = "carPut"
+	reasonStoreRoot  = "storeRoot"
+	reasonBlockLink  = "blockLink"
+	reasonIsMerged   = "isMerged"
+	reasonVerifySig  = "verifySig"
+	reasonEncKeys    = "encKeys"
+	reasonLoadLink   = "loadLink"
+	reasonDecodeLink = "decodeLink"
+	reasonContext    = "context"
+	reasonReader     = "carReader"
+	reasonNoRoots    = "carNoRoots"
+	reasonNext       = "carNextBlock"
+)
+
+// failureReasons counts failures by reason and remembers which reasons it has already
+// logged. A repeated failure costs a counter increment rather than a log line; the first
+// occurrence of each reason gets one line carrying the underlying error.
+type failureReasons struct {
+	mu      sync.Mutex
+	counts  map[string]int64
+	flagged map[string]struct{}
+}
+
+// record counts one failure and reports whether this reason has not been logged yet.
+func (f *failureReasons) record(reason string) (firstSeen bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.counts == nil {
+		f.counts = make(map[string]int64)
+		f.flagged = make(map[string]struct{})
+	}
+	f.counts[reason]++
+	if _, seen := f.flagged[reason]; seen {
+		return false
+	}
+	f.flagged[reason] = struct{}{}
+	return true
+}
+
+// drain returns the counts accumulated since the last call, sorted by reason, and resets
+// them. The set of already-logged reasons is deliberately kept: a reason is logged once
+// per process, not once per interval.
+func (f *failureReasons) drain() []reasonCount {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.counts) == 0 {
+		return nil
+	}
+	out := make([]reasonCount, 0, len(f.counts))
+	for reason, n := range f.counts {
+		out = append(out, reasonCount{reason: reason, count: n})
+		delete(f.counts, reason)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].reason < out[j].reason })
+	return out
+}
+
+type reasonCount struct {
+	reason string
+	count  int64
+}
+
+// dedupWindowCap bounds the memory one window can hold, so a burst cannot turn the
+// instrument into a leak. At the cap the window holds 64k hashes, a little over 1 MiB.
+const dedupWindowCap = 1 << 16
+
+// wireDedup counts, over one reporting interval, how many inbound messages carried bytes
+// this node had already seen. Gossipsub forwards a published message verbatim, so a
+// redelivery of the same publish is byte-identical while the same document published by
+// two different indexers is not: this measures redelivery, not agreement.
+//
+// It hashes the wire bytes rather than the decoded head CID because a message is dropped
+// at the door before it is decoded, and the dropped share is the population of interest.
+type wireDedup struct {
+	seed maphash.Seed
+
+	mu        sync.Mutex
+	seen      map[uint64]struct{}
+	total     int64
+	truncated bool
+}
+
+func newWireDedup() *wireDedup {
+	return &wireDedup{
+		seed: maphash.MakeSeed(),
+		seen: make(map[uint64]struct{}),
+	}
+}
+
+// observe records one inbound message by the hash of its wire bytes. The hash is taken
+// outside the lock so a large message does not serialise the pubsub dispatcher.
+//
+// Nil-safe: this runs on the pubsub dispatcher, where a panic takes the node's inbound
+// path with it, and a P2P built by struct literal rather than by New has no window.
+func (d *wireDedup) observe(msg []byte) {
+	if d == nil {
+		return
+	}
+	h := maphash.Bytes(d.seed, msg)
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.total++
+	if len(d.seen) >= dedupWindowCap {
+		d.truncated = true
+		return
+	}
+	d.seen[h] = struct{}{}
+}
+
+// drain returns the totals for the interval and starts a new window. distinct is a floor
+// rather than an exact count when truncated is true.
+func (d *wireDedup) drain() (total, distinct int64, truncated bool) {
+	if d == nil {
+		return 0, 0, false
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	total, distinct, truncated = d.total, int64(len(d.seen)), d.truncated
+	d.total = 0
+	d.truncated = false
+	d.seen = make(map[uint64]struct{})
+	return total, distinct, truncated
+}
+
+// dropDoc counts an inbound document that was meant to be stored and was not, naming why.
+// The reason set is fixed, so a peer cannot grow the map by varying its errors.
+func (p *P2P) dropDoc(reason string) {
+	p.statDroppedDocs.Add(1)
+	p.docDropReason.record(reason)
+}
+
+// skipDoc counts an inbound document deliberately not merged: already held, or excluded
+// by access or the replication filter. Kept apart from drops, which are losses.
+func (p *P2P) skipDoc(reason string) {
+	p.statSkippedDocs.Add(1)
+	p.docDropReason.record("skip:" + reason)
+}

--- a/internal/db/p2p/sync_dag.go
+++ b/internal/db/p2p/sync_dag.go
@@ -17,6 +17,7 @@ import (
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 
 	"github.com/sourcenetwork/corekv/blockstore"
+	"github.com/sourcenetwork/corelog"
 	"github.com/sourcenetwork/immutable"
 
 	coreblock "github.com/sourcenetwork/defradb/internal/core/block"
@@ -47,18 +48,55 @@ func (p *P2P) syncDAG(ctx context.Context, block *coreblock.Block) error {
 
 	linkSystem := makeLinkSystem(p.host.IPLDStore())
 
+	p.statSyncDAGCalls.Add(1)
+
+	// written counts the blocks this walk has put in the blockstore. A walk that fails
+	// leaves them behind with nothing referencing them, so on failure this is the number
+	// of orphans the walk created, measured where they are created.
+	var written int64
+
 	// Store the block in the DAG store
 	_, err := linkSystem.Store(linking.LinkContext{Ctx: sessionCtx}, coreblock.GetLinkPrototype(), block.GenerateNode())
 	if err != nil {
+		p.syncDAGFailure(reasonStoreRoot, written, err)
 		return NewErrStoreBlockDAGSync(err)
 	}
+	written++
 
-	return p.loadBlockLinks(sessionCtx, &linkSystem, block)
+	reason, err := p.loadBlockLinks(sessionCtx, &linkSystem, block, &written)
+	if err != nil {
+		p.syncDAGFailure(reason, written, err)
+		return err
+	}
+	p.statSyncDAGBlocks.Add(written)
+	return nil
+}
+
+// syncDAGFailure records an abandoned walk: how it failed and how many blocks it had
+// already written. The first occurrence of each reason gets a log line; the rest are
+// counted only.
+func (p *P2P) syncDAGFailure(reason string, written int64, err error) {
+	p.statSyncDAGFailed.Add(1)
+	p.statSyncDAGBlocks.Add(written)
+	p.statSyncDAGAbandoned.Add(written)
+	if p.syncDAGFailureReason.record(reason) {
+		log.ErrorE("DAG sync abandoned", err,
+			corelog.String("reason", reason),
+			corelog.Int64("blocksWritten", written))
+	}
 }
 
 // loadBlockLinks traverses the DAG rooted at block and syncs all linked blocks.
 // Uses an explicit stack to avoid goroutine stack overflow on deep DAGs (#2722).
-func (p *P2P) loadBlockLinks(ctx context.Context, linkSys *linking.LinkSystem, block *coreblock.Block) error {
+//
+// written is incremented for each block the walk pulls into the blockstore. On error the
+// returned reason names the step that failed, for the caller's counters.
+func (p *P2P) loadBlockLinks(
+	ctx context.Context,
+	linkSys *linking.LinkSystem,
+	block *coreblock.Block,
+	written *int64,
+) (string, error) {
 	bstore := datastore.BlockstoreFrom(p.db.Rootstore(), immutable.None[int]())
 	stack := []*coreblock.Block{block}
 
@@ -68,11 +106,11 @@ func (p *P2P) loadBlockLinks(ctx context.Context, linkSys *linking.LinkSystem, b
 
 		link, err := current.GenerateLink()
 		if err != nil {
-			return NewErrGenerateBlockLink(err)
+			return reasonBlockLink, NewErrGenerateBlockLink(err)
 		}
 		merged, err := bstore.IsMerged(ctx, link.Cid)
 		if err != nil {
-			return NewErrCheckBlockMerged(err)
+			return reasonIsMerged, NewErrCheckBlockMerged(err)
 		}
 		if merged {
 			continue
@@ -86,7 +124,7 @@ func (p *P2P) loadBlockLinks(ctx context.Context, linkSys *linking.LinkSystem, b
 			// But we want to keep the API of VerifyBlockSignature explicit about the results.
 			_, err := coreblock.VerifyBlockSignature(current, linkSys)
 			if err != nil {
-				return NewErrVerifyBlockSig(err)
+				return reasonVerifySig, NewErrVerifyBlockSig(err)
 			}
 		}
 
@@ -94,21 +132,21 @@ func (p *P2P) loadBlockLinks(ctx context.Context, linkSys *linking.LinkSystem, b
 		if current.IsEncrypted() {
 			results, err := p.kms.GetKeys(ctx, *current.Encryption)
 			if err != nil {
-				return NewErrGetEncKeysForBlock(err)
+				return reasonEncKeys, NewErrGetEncKeysForBlock(err)
 			}
 			encResults = results
 		}
 
 		for _, lnk := range current.AllLinks() {
 			if ctx.Err() != nil {
-				return ctx.Err()
+				return reasonContext, ctx.Err()
 			}
 
 			// Skip fetch if the linked block is already merged locally — avoids a BitSwap
 			// round-trip for historical blocks that may have been pruned on the sender.
 			linkedMerged, err := bstore.IsMerged(ctx, lnk.Cid)
 			if err != nil {
-				return NewErrCheckBlockMerged(err)
+				return reasonIsMerged, NewErrCheckBlockMerged(err)
 			}
 			if linkedMerged {
 				continue
@@ -119,12 +157,15 @@ func (p *P2P) loadBlockLinks(ctx context.Context, linkSys *linking.LinkSystem, b
 			cancel()
 
 			if err != nil {
-				return NewErrLoadLinkedBlock(err)
+				return reasonLoadLink, NewErrLoadLinkedBlock(err)
 			}
+			// The link system writes what it fetches, so a successful load is one more
+			// block in the store.
+			*written++
 
 			linkBlock, err := coreblock.GetFromNode(nd)
 			if err != nil {
-				return NewErrDecodeLinkedBlock(err)
+				return reasonDecodeLink, NewErrDecodeLinkedBlock(err)
 			}
 
 			stack = append(stack, linkBlock)
@@ -133,11 +174,11 @@ func (p *P2P) loadBlockLinks(ctx context.Context, linkSys *linking.LinkSystem, b
 		if encResults != nil {
 			for res := range encResults.Get() {
 				if res.Error != nil {
-					return NewErrRetrieveEncKey(res.Error)
+					return reasonEncKeys, NewErrRetrieveEncKey(res.Error)
 				}
 			}
 		}
 	}
 
-	return nil
+	return "", nil
 }

--- a/internal/db/stats.go
+++ b/internal/db/stats.go
@@ -1,0 +1,148 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package db
+
+import (
+	"context"
+	"log/slog"
+	"sync/atomic"
+	"time"
+
+	"github.com/sourcenetwork/corelog"
+
+	"github.com/sourcenetwork/defradb/client"
+	"github.com/sourcenetwork/defradb/internal/datastore"
+)
+
+// mergeStatsInterval matches the p2p reporter so the two lines of a single interval line
+// up in the log.
+const mergeStatsInterval = 30 * time.Second
+
+// mergeStats are the merge-path counters reported once per interval and reset on report,
+// so each line carries the rate for that interval rather than a running total.
+//
+// Counting is an atomic add on paths that already do storage work, so it is not a cost
+// worth gating. Nothing here builds a string or allocates until the reporter runs.
+type mergeStats struct {
+	// creates and updates split merges by whether the document already had heads locally.
+	// A merge with no local heads is creating the document.
+	creates atomic.Int64
+	updates atomic.Int64
+
+	// chunkConflicts counts merge attempts abandoned for a transaction conflict, whether
+	// or not a later attempt succeeded. chunkExhausted counts the chunks that ran out of
+	// attempts, which is where a conflict becomes a dropped document.
+	chunkConflicts atomic.Int64
+	chunkExhausted atomic.Int64
+
+	// exhaustedAtRead and exhaustedAtCommit split chunkExhausted by where the last
+	// conflict was raised.
+	exhaustedAtRead   atomic.Int64
+	exhaustedAtCommit atomic.Int64
+
+	// conflictKinds counts, per class of key, how many exhausted chunks had read a key of
+	// that class. One exhausted chunk contributes to several entries.
+	conflictKinds [datastore.ReadKindCount]atomic.Int64
+
+	// uniqueIndexChecks counts existence checks a unique index performed before writing;
+	// uniqueIndexHits counts those that found an entry already there. A hit is a
+	// uniqueness violation that fails the merge outright rather than conflicting.
+	uniqueIndexChecks atomic.Int64
+	uniqueIndexHits   atomic.Int64
+}
+
+// statsFor returns the counters of the database col belongs to, or nil for a collection
+// this package did not construct. Every method on mergeStats tolerates a nil receiver, so
+// a nil result simply means that collection is not counted.
+func statsFor(col client.Collection) *mergeStats {
+	if c, ok := col.(*collection); ok {
+		return c.db.stats
+	}
+	return nil
+}
+
+// markCreateOrUpdate records whether a merge is creating the document or updating one that
+// already exists locally.
+func (s *mergeStats) markCreateOrUpdate(isCreate bool) {
+	if s == nil {
+		return
+	}
+	if isCreate {
+		s.creates.Add(1)
+		return
+	}
+	s.updates.Add(1)
+}
+
+// markExhausted records a chunk that ran out of attempts, along with the classes of key
+// its last transaction had read. Only called on the failure path, so its cost never lands
+// on a merge that commits.
+func (s *mergeStats) markExhausted(atCommit bool, kinds datastore.ReadKind) {
+	if s == nil {
+		return
+	}
+	s.chunkExhausted.Add(1)
+	if atCommit {
+		s.exhaustedAtCommit.Add(1)
+	} else {
+		s.exhaustedAtRead.Add(1)
+	}
+	for i := range s.conflictKinds {
+		if kinds&(1<<uint(i)) != 0 {
+			s.conflictKinds[i].Add(1)
+		}
+	}
+}
+
+// markUniqueIndexCheck records a unique index existence check and whether it found an
+// entry already present.
+func (s *mergeStats) markUniqueIndexCheck(hit bool) {
+	if s == nil {
+		return
+	}
+	s.uniqueIndexChecks.Add(1)
+	if hit {
+		s.uniqueIndexHits.Add(1)
+	}
+}
+
+// reportMergeStats logs the merge counters once per interval until the database context is
+// cancelled. Rates are reported per interval rather than per event, which keeps the merge
+// path quiet under load where per-event logging would dominate the output.
+func (db *DB) reportMergeStats(ctx context.Context) {
+	ticker := time.NewTicker(mergeStatsInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			db.stats.report()
+		}
+	}
+}
+
+func (s *mergeStats) report() {
+	fields := []slog.Attr{
+		corelog.Int64("creates", s.creates.Swap(0)),
+		corelog.Int64("updates", s.updates.Swap(0)),
+		corelog.Int64("conflicts", s.chunkConflicts.Swap(0)),
+		corelog.Int64("exhausted", s.chunkExhausted.Swap(0)),
+		corelog.Int64("exhaustedAtRead", s.exhaustedAtRead.Swap(0)),
+		corelog.Int64("exhaustedAtCommit", s.exhaustedAtCommit.Swap(0)),
+		corelog.Int64("uniqueIndexChecks", s.uniqueIndexChecks.Swap(0)),
+		corelog.Int64("uniqueIndexHits", s.uniqueIndexHits.Swap(0)),
+	}
+	for i := range s.conflictKinds {
+		fields = append(fields, corelog.Int64("read_"+datastore.ReadKindName(i), s.conflictKinds[i].Swap(0)))
+	}
+	log.Info("merge stats", fields...)
+}

--- a/internal/db/stats_test.go
+++ b/internal/db/stats_test.go
@@ -1,0 +1,158 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package db
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcenetwork/corekv/blockstore"
+	"github.com/sourcenetwork/immutable"
+
+	"github.com/sourcenetwork/defradb/client"
+	"github.com/sourcenetwork/defradb/event"
+	"github.com/sourcenetwork/defradb/internal/datastore"
+)
+
+// hostSchema is the schema the Shinzo host deploys, copied verbatim. The counters here
+// only mean anything against the collections and indexes production actually runs, and a
+// hand-simplified schema has already produced two contradictory conclusions.
+func hostSchema(t *testing.T) string {
+	t.Helper()
+	sdl, err := os.ReadFile("testdata/shinzo_host_schema.graphql")
+	require.NoError(t, err)
+	return string(sdl)
+}
+
+// The index layout is what makes the unique-index and read-kind counters meaningful, so
+// this asserts the fixture is the layout production runs rather than trusting the file.
+func TestHostSchemaIndexes(t *testing.T) {
+	ctx := context.Background()
+	db, err := newBadgerDB(ctx)
+	require.NoError(t, err)
+	defer db.Close()
+
+	_, err = db.AddCollection(ctx, hostSchema(t))
+	require.NoError(t, err)
+
+	want := map[string]struct {
+		indexes int
+		unique  int
+	}{
+		"Ethereum__Mainnet__Block":             {indexes: 2, unique: 1},
+		"Ethereum__Mainnet__Transaction":       {indexes: 3, unique: 1},
+		"Ethereum__Mainnet__Log":               {indexes: 4, unique: 0},
+		"Ethereum__Mainnet__AccessListEntry":   {indexes: 2, unique: 0},
+		"Ethereum__Mainnet__BlockSignature":    {indexes: 1, unique: 0},
+		"Ethereum__Mainnet__AttestationRecord": {indexes: 2, unique: 0},
+		"Ethereum__Mainnet__SnapshotSignature": {indexes: 0, unique: 0},
+	}
+
+	total, totalUnique := 0, 0
+	for name, expected := range want {
+		col, err := db.GetCollectionByName(ctx, name)
+		require.NoError(t, err, name)
+
+		descs, err := col.ListIndexes(ctx)
+		require.NoError(t, err, name)
+
+		unique := 0
+		for _, d := range descs {
+			if d.Description.Unique {
+				unique++
+			}
+		}
+		require.Equal(t, expected.indexes, len(descs), "index count for %s", name)
+		require.Equal(t, expected.unique, unique, "unique index count for %s", name)
+
+		total += len(descs)
+		totalUnique += unique
+	}
+	require.Equal(t, 14, total)
+	require.Equal(t, 2, totalUnique)
+}
+
+// A merge of a document with no local heads is a create; a merge onto an existing head is
+// an update. The split decides whether the range-iterator over-read can apply at all, so
+// it is asserted rather than assumed.
+func TestMergeStatsCreateVsUpdate(t *testing.T) {
+	ctx := context.Background()
+	db, err := newBadgerDB(ctx)
+	require.NoError(t, err)
+	defer db.Close()
+
+	_, err = db.AddCollection(ctx, hostSchema(t))
+	require.NoError(t, err)
+
+	col, err := db.GetCollectionByName(ctx, "Ethereum__Mainnet__BlockSignature")
+	require.NoError(t, err)
+
+	lsys := cidlink.DefaultLinkSystem()
+	lsys.SetWriteStorage(blockstore.NewIPLDStore(datastore.BlockstoreFrom(db.rootstore, immutable.None[int]())))
+
+	first := map[string]any{"blockHash": "0xaa"}
+	builder, _ := newDagBuilder(ctx, col, first)
+
+	create, err := builder.generateCompositeUpdate(&lsys, first, compositeInfo{})
+	require.NoError(t, err)
+	docID := client.NewDocIDV0(create.link.Cid)
+
+	require.NoError(t, db.executeMerge(ctx, col.(*collection), event.Merge{
+		DocID:        docID.String(),
+		Cid:          create.link.Cid,
+		CollectionID: col.Version().CollectionID,
+	}))
+	require.Equal(t, int64(1), db.stats.creates.Load())
+	require.Equal(t, int64(0), db.stats.updates.Load())
+
+	update, err := builder.generateCompositeUpdate(&lsys, map[string]any{"blockHash": "0xbb"}, create)
+	require.NoError(t, err)
+
+	require.NoError(t, db.executeMerge(ctx, col.(*collection), event.Merge{
+		DocID:        docID.String(),
+		Cid:          update.link.Cid,
+		CollectionID: col.Version().CollectionID,
+	}))
+	require.Equal(t, int64(1), db.stats.creates.Load())
+	require.Equal(t, int64(1), db.stats.updates.Load())
+}
+
+// Block.hash is unique, so two blocks carrying the same hash collide on the existence
+// check saveUniqueKey performs. The counter separates a collision from a plain conflict:
+// a collision fails the write outright rather than exhausting the retries.
+func TestMergeStatsUniqueIndexHit(t *testing.T) {
+	ctx := context.Background()
+	db, err := newBadgerDB(ctx)
+	require.NoError(t, err)
+	defer db.Close()
+
+	_, err = db.AddCollection(ctx, hostSchema(t))
+	require.NoError(t, err)
+
+	col, err := db.GetCollectionByName(ctx, "Ethereum__Mainnet__Block")
+	require.NoError(t, err)
+
+	first, err := client.NewDocFromMap(ctx, map[string]any{"hash": "0xdup", "number": 1}, col.Version())
+	require.NoError(t, err)
+	require.NoError(t, col.AddDocument(ctx, first))
+	require.Equal(t, int64(1), db.stats.uniqueIndexChecks.Load())
+	require.Equal(t, int64(0), db.stats.uniqueIndexHits.Load())
+
+	second, err := client.NewDocFromMap(ctx, map[string]any{"hash": "0xdup", "number": 2}, col.Version())
+	require.NoError(t, err)
+	require.Error(t, col.AddDocument(ctx, second))
+	require.Equal(t, int64(2), db.stats.uniqueIndexChecks.Load())
+	require.Equal(t, int64(1), db.stats.uniqueIndexHits.Load())
+}

--- a/internal/db/testdata/shinzo_host_schema.graphql
+++ b/internal/db/testdata/shinzo_host_schema.graphql
@@ -1,0 +1,111 @@
+type Ethereum__Mainnet__Block {
+    hash: String @index(unique: true)
+    number: Int @index
+    timestamp: String
+    parentHash: String
+    difficulty: String
+    totalDifficulty: String
+    gasUsed: String
+    gasLimit: String
+    baseFeePerGas: String
+    nonce: String
+    miner: String
+    size: String
+    stateRoot: String
+    sha3Uncles: String
+    transactionsRoot: String
+    receiptsRoot: String
+    logsBloom: String
+    extraData: String
+    mixHash: String
+    uncles: [String]
+    # Relationships
+    transactions: [Ethereum__Mainnet__Transaction] @relation(name: "block_transactions")
+}
+
+# BlockSignature covers all documents in a block (txs, logs, ALEs, and the block itself)
+type Ethereum__Mainnet__BlockSignature {
+    blockNumber: Int @index
+    blockHash: String
+    merkleRoot: String
+    cidCount: Int
+    cids: [String]
+    signatureType: String
+    signatureIdentity: String
+    signatureValue: String
+    createdAt: String
+}
+
+# SnapshotSignature seals a snapshot file with a Merkle root over per-block
+# signature Merkle roots. Used for cross-indexer attestation and snapshot exchange.
+type Ethereum__Mainnet__SnapshotSignature {
+    startBlock: Int
+    endBlock: Int
+    merkleRoot: String
+    blockCount: Int
+    signatureType: String
+    signatureIdentity: String
+    signatureValue: String
+    snapshotFile: String
+    createdAt: String
+    blockSigMerkleRoots: [String]
+}
+
+type Ethereum__Mainnet__Transaction {
+    hash: String @index(unique: true)
+    blockHash: String
+    blockNumber: Int @index
+    from: String
+    to: String
+    value: String
+    gas: String
+    gasPrice: String
+    gasUsed: String
+    maxFeePerGas: String
+    maxPriorityFeePerGas: String
+    input: String
+    nonce: String
+    transactionIndex: Int
+    type: String
+    chainId: String
+    v: String
+    r: String
+    s: String
+    status: Boolean
+    cumulativeGasUsed: String
+    effectiveGasPrice: String
+    # Relationships
+    block: Ethereum__Mainnet__Block @index @relation(name: "block_transactions")
+    logs: [Ethereum__Mainnet__Log] @relation(name: "transaction_logs")
+    accessList: [Ethereum__Mainnet__AccessListEntry] @relation(name: "transaction_accessList")
+}
+
+type Ethereum__Mainnet__AccessListEntry {
+    address: String
+    blockNumber: Int @index
+    storageKeys: [String]
+    transaction: Ethereum__Mainnet__Transaction @index @relation(name: "transaction_accessList")
+}
+
+type Ethereum__Mainnet__Log {
+    address: String @index
+    topics: [String]
+    data: String
+    transactionHash: String
+    blockHash: String
+    blockNumber: Int @index
+    transactionIndex: Int
+    logIndex: Int
+    removed: String
+    # Relationships
+    block: Ethereum__Mainnet__Block @index @relation(name: "block_logs")
+    transaction: Ethereum__Mainnet__Transaction @index @relation(name: "transaction_logs")
+}
+
+type Ethereum__Mainnet__AttestationRecord {
+    attested_doc: String @index
+    source_doc: [String]
+    CIDs: [String]
+    doc_type: String @index
+    vote_count: Int @crdt(type: pcounter)
+}


### PR DESCRIPTION
Stacked on the CAR import guard PR.

Adds the per-interval counters needed to see what an ingesting node is actually doing: queue depth and byte usage against their budgets, batch and document outcomes, wire-message duplication, CAR import and generation, DAG sync, and merge conflicts broken down by the class of key the losing transaction had read.

Three things this covers that were previously invisible:

- **Why a document was dropped.** `docsDropped` only ever counted merge-call failures; eleven earlier discard sites were counted nowhere and three of them logged nothing either. Each now names a reason, and documents deliberately not merged (already held, no access, filtered) are counted as `docsSkipped` rather than as loss, so merged plus dropped plus skipped accounts for every document in a request.
- **The inbound CAR path.** Every document this node stores arrives through `importCAR`, which had no counters at all, while all five CAR counters described the outbound side. An import that fails part-way leaves blocks in the store owned by no document, so it reports how many it had already written.
- **Whether relaying works.** `docsRelayed` was incremented on the same condition as the merge counter and before the send, so it restated the merge count and a total send failure would not have changed it. It now counts after the send, paired with `relayFailed`.

Reason sets are fixed rather than derived from error strings, so a remote peer cannot grow the maps. Repeated failures cost a counter increment; the first occurrence of each reason gets the log line.