### PR TITLE
fix: stop the document fetch from reading the next document's key

### DIFF
--- a/internal/db/fetcher/document.go
+++ b/internal/db/fetcher/document.go
@@ -69,10 +69,10 @@ func newDocumentFetcher(
 		prefix = prefix.WithDeletedFlag()
 	}
 
-	iterOptions := datastore.IterOptions{
-		Start: prefix,
-		End:   prefix.PrefixEnd(),
-	}
+	// A prefix iterator bounds the scan in the store. A start/end range leaves it unbounded
+	// and checks the end in Go, which reads the first key past the document and puts another
+	// document's key in this transaction's read set.
+	iterOptions := datastore.IterOptions{Prefix: prefix}
 
 	keysOnly := len(fieldsByID) == 0
 	if keysOnly {

--- a/internal/db/fetcher_overread_test.go
+++ b/internal/db/fetcher_overread_test.go
@@ -1,0 +1,67 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcenetwork/defradb/client"
+)
+
+// Reading one document must not put another document's keys in the transaction's read set.
+// Documents sit consecutively in the store, so a scan of one that runs past its end lands on
+// the next document, and a concurrent write there then rejects a transaction that never
+// touched it.
+func TestDocumentFetcher_ReadingOneDocDoesNotConflictWithItsNeighbour(t *testing.T) {
+	ctx := context.Background()
+
+	db, err := newBadgerDB(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() { db.Close() })
+
+	_, err = db.AddCollection(ctx, userSchema)
+	require.NoError(t, err)
+	col, err := db.GetCollectionByName(ctx, "User")
+	require.NoError(t, err)
+
+	first, err := client.NewDocFromJSON(ctx, []byte(`{"name":"alice","age":1}`), col.Version())
+	require.NoError(t, err)
+	require.NoError(t, col.AddDocument(ctx, first))
+
+	second, err := client.NewDocFromJSON(ctx, []byte(`{"name":"bob","age":2}`), col.Version())
+	require.NoError(t, err)
+	require.NoError(t, col.AddDocument(ctx, second))
+
+	// Read the first document and write it back, all in one transaction.
+	txn, err := db.NewTxn(false)
+	require.NoError(t, err)
+	defer txn.Discard()
+	txnCtx := InitContext(ctx, txn)
+
+	read, err := col.GetDocument(txnCtx, first.ID())
+	require.NoError(t, err)
+	require.NoError(t, read.Set(ctx, "age", 10))
+	require.NoError(t, col.UpdateDocument(txnCtx, read))
+
+	// Someone else rewrites the neighbour and commits, in between. Every field is written so
+	// the test does not depend on which one holds the lowest field ID.
+	other, err := col.GetDocument(ctx, second.ID())
+	require.NoError(t, err)
+	require.NoError(t, other.Set(ctx, "name", "robert"))
+	require.NoError(t, other.Set(ctx, "age", 99))
+	require.NoError(t, col.UpdateDocument(ctx, other))
+
+	require.NoError(t, txn.Commit(),
+		"reading one document must not conflict with a write to the next one")
+}


### PR DESCRIPTION
Related shinzonetwork/shinzo-host-client#362

Stacked on #5147.

The document fetch scanned with a start/end range whose end was `prefix.PrefixEnd()`. corekv leaves that unbounded in the store and checks the end in Go, so the iterator reads the first key past the document before stopping. That key belongs to the next document, and reading it puts it in this transaction's read set.

A prefix iterator bounds the scan in the store, so the read set holds only the document being fetched.

`internal/db/fetcher/document.go` is identical on `develop`, so this applies there unchanged.


