### PR TITLE
fix: Properly handle blank timeout strings in C bindings

### DIFF
--- a/cbindings/p2p_collection_sync_branchable.go
+++ b/cbindings/p2p_collection_sync_branchable.go
@@ -34,13 +34,14 @@ func SyncP2PBranchableCollection(nodePtr C.uintptr_t,
 	if err != nil {
 		return returnC(returnGoC(1, err.Error(), ""))
 	}
-	if timeoutStr != nil {
-		timeout, err := time.ParseDuration(C.GoString(timeoutStr))
+	timeout := C.GoString(timeoutStr)
+	if timeout != "" {
+		timeoutDuration, err := time.ParseDuration(timeout)
 		if err != nil {
 			return returnC(returnGoC(1, err.Error(), ""))
 		}
 		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, timeout)
+		ctx, cancel = context.WithTimeout(ctx, timeoutDuration)
 		defer cancel()
 	}
 	node, err := getNodeFromPointer(nodePtr)

--- a/tests/action/sync_branchable_collection.go
+++ b/tests/action/sync_branchable_collection.go
@@ -40,6 +40,14 @@ type SyncBranchableCollection struct {
 	// CollectionID is the index of the collection to sync.
 	CollectionID int
 
+	// NoDeadline, if true, calls the client with a context that has no deadline,
+	// instead of the default one-second timeout. Optional.
+	//
+	// This exists to exercise the no-deadline path through clients (such as the C
+	// and Java clients) that must serialize the context's deadline across a
+	// non-Go boundary
+	NoDeadline bool
+
 	// Any error expected from the action. Optional.
 	//
 	// String can be a partial, and the test will pass if an error is returned that
@@ -51,8 +59,14 @@ var _ Action = (*SyncBranchableCollection)(nil)
 var _ Stateful = (*SyncBranchableCollection)(nil)
 
 func (a *SyncBranchableCollection) Execute() {
-	ctx, cancel := context.WithTimeout(a.s.Ctx, time.Second)
-	defer cancel()
+	ctx := a.s.Ctx
+
+	// Attach the default timeout if the NoDeadline flag is unset
+	if !a.NoDeadline {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, time.Second)
+		defer cancel()
+	}
 
 	nodeState := a.s.Nodes[a.NodeID]
 

--- a/tests/integration/net/sync/branchable_collection/timeout_test.go
+++ b/tests/integration/net/sync/branchable_collection/timeout_test.go
@@ -1,0 +1,136 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// This file is part of the DefraDB test suite.
+//
+// The DefraDB test suite is licensed under either:
+//
+//   (1) GNU Affero General Public License v3
+//   (2) Business Source License 1.1
+//
+// See tests/LICENSE for details.
+
+package branchable_collection
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/immutable"
+
+	"github.com/sourcenetwork/defradb/tests/action"
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	"github.com/sourcenetwork/defradb/tests/state"
+)
+
+// Clients built upon the C bindings serializes a context's deadline into a
+// string that crosses the cgo boundary, rather than passing the context
+// itself. An absent deadline (context.Background(), the common case) and a
+// present one are two distinct code paths on that side. These tests are limited to
+// the C client, because they are meant to test the working serialization of the
+// deadlines.
+
+// This tests serializing a blank deadline. In the C wrapper, the context will be
+// examined for a deadline, and when none is present, a blank string will be passed in.
+// That is the core of what this test is making sure works.
+func TestBranchableCollectionSync_NoDeadlineContext_ShouldSucceed(t *testing.T) {
+	test := testUtils.TestCase{
+		SupportedClientTypes: immutable.Some(
+			[]state.ClientType{
+				state.CClientType,
+			},
+		),
+		Actions: []any{
+			testUtils.RandomNetworkingConfig(),
+			testUtils.RandomNetworkingConfig(),
+			&action.AddCollection{
+				SDL: `
+					type User @branchable {
+						name: String
+					}
+				`,
+			},
+			&action.AddDoc{
+				NodeID: immutable.Some(0),
+				DocMap: map[string]any{
+					"name": "John",
+				},
+			},
+			testUtils.ConnectPeers{
+				SourceNodeID: 0,
+				TargetNodeID: 1,
+			},
+			&action.SyncBranchableCollection{
+				NodeID:     1,
+				NoDeadline: true,
+			},
+			testUtils.WaitForSync{},
+			&action.Request{
+				NodeID: immutable.Some(1),
+				Request: `query {
+					User {
+						name
+					}
+				}`,
+				Results: map[string]any{
+					"User": []map[string]any{
+						{"name": "John"},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+// This one tests that a finite deadline is properly serialized. In this case, the wrapper
+// will see a deadline on the context, and will pass it in as a string.
+func TestBranchableCollectionSync_FiniteDeadlineContext_ShouldSucceed(t *testing.T) {
+	test := testUtils.TestCase{
+		SupportedClientTypes: immutable.Some(
+			[]state.ClientType{
+				state.CClientType,
+			},
+		),
+		Actions: []any{
+			testUtils.RandomNetworkingConfig(),
+			testUtils.RandomNetworkingConfig(),
+			&action.AddCollection{
+				SDL: `
+					type User @branchable {
+						name: String
+					}
+				`,
+			},
+			&action.AddDoc{
+				NodeID: immutable.Some(0),
+				DocMap: map[string]any{
+					"name": "John",
+				},
+			},
+			testUtils.ConnectPeers{
+				SourceNodeID: 0,
+				TargetNodeID: 1,
+			},
+			&action.SyncBranchableCollection{
+				NodeID:     1,
+				NoDeadline: false,
+			},
+			testUtils.WaitForSync{},
+			&action.Request{
+				NodeID: immutable.Some(1),
+				Request: `query {
+					User {
+						name
+					}
+				}`,
+				Results: map[string]any{
+					"User": []map[string]any{
+						{"name": "John"},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #5140

## Description

There was an odd behavior in the C bindings. It was not technically a bug, but it was a foot gun. The function for syncing branchable collections could take in a timeout string, and could take in a null value to represent no deadline. However, a blank string is actually a valid, non-null value. This made it easy for users to trip up -- and indeed, our test wrapper messes up in this way. The only reason it didn't create a problem is because we didn't have any test that triggers this behavior.

This PR opts to adjust the C bindings themselves rather than the test wrapper. The argument is that a blank string _should_ be interpreted as no timeout value.

With regards to the gap in testing: this PR introduces two new tests, which specifically target the serializing of timeout strings in the C bindings. There is one which checks a finite deadline (behavior that always worked), and one which checks a blank deadline (which is now properly working.) To accommodate this, a `NoDeadline` flag had to be added to the test action, but the changes are hopefully relatively straightforward.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Specify the platform(s) on which this was tested:
- WSL
