### PR TITLE
fix: answer IsMerged from the store instead of a process-wide cache

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,6 @@ require (
 	github.com/gofrs/uuid/v5 v5.4.0
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/google/uuid v1.6.0
-	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/iancoleman/strcase v0.3.0
 	github.com/ipfs/boxo v0.41.0
 	github.com/ipfs/go-block-format v0.2.3
@@ -266,6 +265,7 @@ require (
 	github.com/hashicorp/go-plugin v1.7.0 // indirect
 	github.com/hashicorp/go-version v1.9.0 // indirect
 	github.com/hashicorp/golang-lru v1.0.2 // indirect
+	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/hashicorp/yamux v0.1.2 // indirect
 	github.com/hdevalence/ed25519consensus v0.2.0 // indirect
 	github.com/holiman/uint256 v1.3.2 // indirect

--- a/internal/core/block/store.go
+++ b/internal/core/block/store.go
@@ -287,7 +287,7 @@ func updateHeads(
 		// else needs to be done for that block.
 		err = txn.Blockstore().MarkAsMerged(ctx, linkCid)
 		if err != nil {
-			return NewErrMarkingAsMerged(blockLink.Cid, err)
+			return NewErrMarkingAsMerged(linkCid, err)
 		}
 
 		if isHead {

--- a/internal/datastore/blockstore.go
+++ b/internal/datastore/blockstore.go
@@ -13,7 +13,6 @@ package datastore
 import (
 	"context"
 
-	lru "github.com/hashicorp/golang-lru/v2"
 	ipfsBlockstore "github.com/ipfs/boxo/blockstore"
 	blocks "github.com/ipfs/go-block-format"
 	"github.com/ipfs/go-cid"
@@ -21,21 +20,6 @@ import (
 	"github.com/sourcenetwork/corekv"
 	"github.com/sourcenetwork/corekv/blockstore"
 )
-
-const mergedCacheSize = 100_000
-
-// globalMergedCache is a process-wide LRU cache of CIDs known to be merged.
-// A cache hit in IsMerged avoids 2 KV reads per CID — significant under sustained
-// P2P or batch write load where the same CID chains are traversed repeatedly.
-var globalMergedCache = mustNewMergedCache(mergedCacheSize)
-
-func mustNewMergedCache(size int) *lru.Cache[string, struct{}] {
-	cache, err := lru.New[string, struct{}](size)
-	if err != nil {
-		panic(err)
-	}
-	return cache
-}
 
 // Blockstore proxies the ipld.DAGService under the /core namespace for future-proofing
 type Blockstore interface {
@@ -77,11 +61,10 @@ func newToMergeKey(cid []byte) []byte {
 	return key
 }
 
+// IsMerged reports whether the block is stored and carries no to-merge marker. Callers
+// use it to decide whether to skip fetching, and history prune can delete a block at
+// any time, so it is answered from the store rather than remembered.
 func (bs *bstore) IsMerged(ctx context.Context, cid cid.Cid) (bool, error) {
-	cidStr := cid.String()
-	if _, ok := globalMergedCache.Get(cidStr); ok {
-		return true, nil
-	}
 	hasBlock, err := bs.Has(ctx, cid)
 	if err != nil {
 		return false, NewErrCheckBlockExists(err)
@@ -93,18 +76,13 @@ func (bs *bstore) IsMerged(ctx context.Context, cid cid.Cid) (bool, error) {
 	if err != nil {
 		return false, NewErrCheckBlockMergeStatus(err)
 	}
-	merged := !notMerged
-	if merged {
-		globalMergedCache.Add(cidStr, struct{}{})
-	}
-	return merged, nil
+	return !notMerged, nil
 }
 
 func (bs *bstore) MarkAsMerged(ctx context.Context, cid cid.Cid) error {
 	if err := bs.store.Delete(ctx, newToMergeKey(cid.Bytes())); err != nil {
 		return NewErrMarkBlockAsMerged(err)
 	}
-	globalMergedCache.Add(cid.String(), struct{}{})
 	return nil
 }
 
@@ -113,7 +91,6 @@ func (bs *bstore) BatchMarkAsMerged(ctx context.Context, cids []cid.Cid) error {
 		if err := bs.store.Delete(ctx, newToMergeKey(c.Bytes())); err != nil {
 			return NewErrMarkBlockAsMerged(err)
 		}
-		globalMergedCache.Add(c.String(), struct{}{})
 	}
 	return nil
 }

--- a/internal/datastore/blockstore_test.go
+++ b/internal/datastore/blockstore_test.go
@@ -1,0 +1,124 @@
+// Copyright 2025 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package datastore
+
+import (
+	"context"
+	"testing"
+
+	blocks "github.com/ipfs/go-block-format"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcenetwork/corekv"
+
+	"github.com/sourcenetwork/corekv/memory"
+	"github.com/sourcenetwork/corekv/namespace"
+	"github.com/sourcenetwork/immutable"
+
+	"github.com/sourcenetwork/defradb/internal/db/lock"
+)
+
+func TestIsMerged_RolledBackTxnLeavesBlockUnmerged(t *testing.T) {
+	ctx := context.Background()
+	rootstore := memory.NewDatastore(ctx)
+
+	// A fetched but unmerged block: stored, with its to-merge marker set.
+	blockNS := namespace.Wrap(rootstore, []byte{blockStoreKey})
+	block := putMarkedBlock(t, ctx, blockNS, []byte("rolled back"), []byte{objectMarker})
+
+	txn := NewTxnFrom(rootstore, lock.NewLockSet(), 1, false, immutable.None[int]())
+	require.NoError(t, txn.Blockstore().MarkAsMerged(ctx, block.Cid()))
+	txn.Discard()
+
+	merged, err := BlockstoreFrom(rootstore, immutable.None[int]()).IsMerged(ctx, block.Cid())
+	require.NoError(t, err)
+	require.False(t, merged)
+}
+
+func TestIsMerged_CommittedTxnMarksBlockMerged(t *testing.T) {
+	ctx := context.Background()
+	rootstore := memory.NewDatastore(ctx)
+
+	blockNS := namespace.Wrap(rootstore, []byte{blockStoreKey})
+	block := putMarkedBlock(t, ctx, blockNS, []byte("committed"), []byte{objectMarker})
+
+	txn := NewTxnFrom(rootstore, lock.NewLockSet(), 1, false, immutable.None[int]())
+	require.NoError(t, txn.Blockstore().MarkAsMerged(ctx, block.Cid()))
+	require.NoError(t, txn.Commit())
+
+	merged, err := BlockstoreFrom(rootstore, immutable.None[int]()).IsMerged(ctx, block.Cid())
+	require.NoError(t, err)
+	require.True(t, merged)
+}
+
+func TestIsMerged_DeletedBlockIsNotMerged(t *testing.T) {
+	ctx := context.Background()
+	rootstore := memory.NewDatastore(ctx)
+
+	blockNS := namespace.Wrap(rootstore, []byte{blockStoreKey})
+	block := putMarkedBlock(t, ctx, blockNS, []byte("deleted"), []byte{objectMarker})
+
+	blockstore := BlockstoreFrom(rootstore, immutable.None[int]())
+	require.NoError(t, blockstore.MarkAsMerged(ctx, block.Cid()))
+
+	merged, err := blockstore.IsMerged(ctx, block.Cid())
+	require.NoError(t, err)
+	require.True(t, merged)
+
+	// History prune deletes blocks under a merged peer. Callers treat a merged answer as
+	// "no need to fetch", so it has to follow the store.
+	require.NoError(t, blockstore.DeleteBlock(ctx, block.Cid()))
+
+	merged, err = blockstore.IsMerged(ctx, block.Cid())
+	require.NoError(t, err)
+	require.False(t, merged)
+}
+
+func TestIsMerged_UnmergedAndAbsentBlocks(t *testing.T) {
+	ctx := context.Background()
+	rootstore := memory.NewDatastore(ctx)
+	blockNS := namespace.Wrap(rootstore, []byte{blockStoreKey})
+	blockstore := BlockstoreFrom(rootstore, immutable.None[int]())
+
+	marked := putMarkedBlock(t, ctx, blockNS, []byte("still marked"), []byte{objectMarker})
+	merged, err := blockstore.IsMerged(ctx, marked.Cid())
+	require.NoError(t, err)
+	require.False(t, merged, "a block still carrying its to-merge marker is not merged")
+
+	// Never stored at all: absent must not read as merged just because no marker exists.
+	absent := putUnmarkedBlock(t, ctx, namespace.Wrap(memory.NewDatastore(ctx), []byte{blockStoreKey}), []byte("absent"))
+	merged, err = blockstore.IsMerged(ctx, absent.Cid())
+	require.NoError(t, err)
+	require.False(t, merged)
+}
+
+// putUnmarkedBlock stores a block with no to-merge marker, the shape of one that has
+// already merged.
+func putUnmarkedBlock(t *testing.T, ctx context.Context, blockNS corekv.ReaderWriter, data []byte) blocks.Block {
+	t.Helper()
+	block := blocks.NewBlock(data)
+	require.NoError(t, blockNS.Set(ctx, block.Cid().Bytes(), block.RawData()))
+	return block
+}
+
+// putMarkedBlock stores a block along with a to-merge marker carrying the given value,
+// the shape of one that has been fetched but not yet merged.
+func putMarkedBlock(
+	t *testing.T,
+	ctx context.Context,
+	blockNS corekv.ReaderWriter,
+	data, marker []byte,
+) blocks.Block {
+	t.Helper()
+	block := putUnmarkedBlock(t, ctx, blockNS, data)
+	require.NoError(t, blockNS.Set(ctx, newToMergeKey(block.Cid().Bytes()), marker))
+	return block
+}


### PR DESCRIPTION
Related shinzonetwork/shinzo-host-client#362

Stacked on #5111.

`IsMerged` was answered from a process-wide cache. A block merges and enters the cache, history prune deletes it under `prune_history: true`, a peer re-sends it, and the cache still answers true, so the node never re-acquires a block it no longer holds. It is now read from the store.

Also corrects the error raised when marking a link fails, which reported the parent's CID rather than the link's.

