### PR TITLE
fix: merge in bounded chunks and relay only the documents that committed

### DIFF
--- a/internal/db/errors.go
+++ b/internal/db/errors.go
@@ -144,6 +144,7 @@ const (
 	errGetMergeTargetHeads          string = "failed to get merge target heads"
 	errLoadComposites               string = "failed to load composites for merge"
 	errMergeComposites              string = "failed to merge composites"
+	errMergeEventDropped            string = "merge event dropped"
 	errSyncIndexedDoc               string = "failed to sync indexed document after merge"
 	errLoadBlockForMerge            string = "failed to load block for merge"
 	errDecodeBlockForMerge          string = "failed to decode block for merge"
@@ -987,6 +988,11 @@ func NewErrLoadComposites(inner error, cid string, docID string) error {
 
 func NewErrMergeComposites(inner error, docID string) error {
 	return errors.Wrap(errMergeComposites, inner, errors.NewKV("DocID", docID))
+}
+
+func NewErrMergeEventDropped(inner error, docID string, cid string) error {
+	return errors.Wrap(errMergeEventDropped, inner,
+		errors.NewKV("DocID", docID), errors.NewKV("CID", cid))
 }
 
 func NewErrSyncIndexedDoc(inner error, docID string) error {

--- a/internal/db/merge.go
+++ b/internal/db/merge.go
@@ -58,11 +58,7 @@ func (db *DB) Merge(ctx context.Context, evt event.Merge) error {
 	}
 
 	// Conflicts occur when a user updates a document while a merge is in progress.
-	max := db.MaxTxnRetries()
-	if max < 1 {
-		max = 1
-	}
-	for i := 0; i < max; i++ {
+	for i := 0; i < db.txnAttempts(); i++ {
 		err = db.executeMerge(ctx, col, evt)
 		if errors.Is(err, corekv.ErrTxnConflict) {
 			continue
@@ -75,18 +71,27 @@ func (db *DB) Merge(ctx context.Context, evt event.Merge) error {
 	return client.NewErrMaxTxnRetries(err)
 }
 
-// MergeBatchWithTxn merges multiple events in a single shared transaction.
-// All per-key locks are acquired upfront and held for the lifetime of the call.
-// On transaction conflict the entire batch is retried, so callers should ensure
-// all merges in a batch are independent (different docIDs and collectionIDs).
+// mergeChunkSize bounds how many events share a transaction. Badger re-sorts the
+// transaction's pending writes on every iterator open, and each merged document opens
+// several, so a bigger chunk sorts a bigger set more times.
+const mergeChunkSize = 8
+
+type mergeEntry struct {
+	evt event.Merge
+	col *collection
+}
+
+// MergeBatchWithTxn merges events in chunks of at most mergeChunkSize. All per-key
+// locks are acquired upfront and held for the lifetime of the call, so callers must
+// ensure the merges are independent (different docIDs and collectionIDs).
+//
+// A chunk that fails is re-run one event at a time. A deterministic failure then drops
+// only the event that caused it, and a chunk that exhausted its retry budget is retried
+// over a smaller write set. Dropped events are named in the returned error and must not
+// be relayed onward as merged.
 func (db *DB) MergeBatchWithTxn(ctx context.Context, merges []event.Merge) error {
 	if len(merges) == 0 {
 		return nil
-	}
-
-	type mergeEntry struct {
-		evt event.Merge
-		col *collection
 	}
 
 	entries := make([]mergeEntry, 0, len(merges))
@@ -149,7 +154,42 @@ func (db *DB) MergeBatchWithTxn(ctx context.Context, merges []event.Merge) error
 		}
 	}()
 
-	for i := 0; i < db.MaxTxnRetries(); i++ {
+	var errs []error
+	for start := 0; start < len(entries); start += mergeChunkSize {
+		end := min(start+mergeChunkSize, len(entries))
+		chunk := entries[start:end]
+
+		if err := db.mergeChunk(ctx, chunk); err == nil {
+			db.publishMergeComplete(chunk)
+			continue
+		}
+
+		// Isolate the failure so the events that can merge still land.
+		for i := range chunk {
+			if err := db.mergeChunk(ctx, chunk[i:i+1]); err != nil {
+				errs = append(errs, NewErrMergeEventDropped(err, chunk[i].evt.DocID, chunk[i].evt.Cid.String()))
+				continue
+			}
+			db.publishMergeComplete(chunk[i : i+1])
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+// txnAttempts is how many times to try a transaction before giving up, never fewer than
+// once so a zero retry budget still makes an attempt.
+func (db *DB) txnAttempts() int {
+	if max := db.MaxTxnRetries(); max > 1 {
+		return max
+	}
+	return 1
+}
+
+// mergeChunk merges every event of the chunk inside one transaction, retrying the
+// whole chunk on transaction conflict. Isolating a failing event is the caller's job.
+func (db *DB) mergeChunk(ctx context.Context, entries []mergeEntry) error {
+	for i := 0; i < db.txnAttempts(); i++ {
 		txn, err := db.NewTxn(false)
 		if err != nil {
 			return err
@@ -179,12 +219,17 @@ func (db *DB) MergeBatchWithTxn(ctx context.Context, merges []event.Merge) error
 			return err
 		}
 
-		for _, e := range entries {
-			db.events.Publish(event.NewMessage(event.MergeCompleteName, event.MergeComplete{Merge: e.evt}))
-		}
 		return nil
 	}
-	return nil
+
+	// Nothing was committed, so callers must not treat the events as merged.
+	return client.NewErrMaxTxnRetries(nil)
+}
+
+func (db *DB) publishMergeComplete(entries []mergeEntry) {
+	for _, e := range entries {
+		db.events.Publish(event.NewMessage(event.MergeCompleteName, event.MergeComplete{Merge: e.evt}))
+	}
 }
 
 func (db *DB) executeMerge(ctx context.Context, col *collection, dagMerge event.Merge) error {

--- a/internal/db/merge.go
+++ b/internal/db/merge.go
@@ -79,6 +79,8 @@ const mergeChunkSize = 8
 type mergeEntry struct {
 	evt event.Merge
 	col *collection
+	// index of the event in the caller's slice, so its outcome can be reported back.
+	index int
 }
 
 // MergeBatchWithTxn merges events in chunks of at most mergeChunkSize. All per-key
@@ -87,20 +89,26 @@ type mergeEntry struct {
 //
 // A chunk that fails is re-run one event at a time. A deterministic failure then drops
 // only the event that caused it, and a chunk that exhausted its retry budget is retried
-// over a smaller write set. Dropped events are named in the returned error and must not
-// be relayed onward as merged.
-func (db *DB) MergeBatchWithTxn(ctx context.Context, merges []event.Merge) error {
+// over a smaller write set.
+//
+// The returned slice is parallel to merges and reports which events committed. An event
+// that did not commit is not stored, so callers must not relay it onward as merged. The
+// error names every dropped event and is nil when all of them committed.
+func (db *DB) MergeBatchWithTxn(ctx context.Context, merges []event.Merge) ([]bool, error) {
+	merged := make([]bool, len(merges))
 	if len(merges) == 0 {
-		return nil
+		return merged, nil
 	}
 
+	var errs []error
 	entries := make([]mergeEntry, 0, len(merges))
-	for _, evt := range merges {
+	for i, evt := range merges {
 		col, err := getCollectionFromCollectionID(ctx, db, evt.CollectionID)
 		if err != nil {
-			return err
+			errs = append(errs, NewErrMergeEventDropped(err, evt.DocID, evt.Cid.String()))
+			continue
 		}
-		entries = append(entries, mergeEntry{evt: evt, col: col})
+		entries = append(entries, mergeEntry{evt: evt, col: col, index: i})
 	}
 
 	// Collect the unique lock keys and their queues, sorted for deadlock-safe ordering.
@@ -154,13 +162,15 @@ func (db *DB) MergeBatchWithTxn(ctx context.Context, merges []event.Merge) error
 		}
 	}()
 
-	var errs []error
 	for start := 0; start < len(entries); start += mergeChunkSize {
 		end := min(start+mergeChunkSize, len(entries))
 		chunk := entries[start:end]
 
 		if err := db.mergeChunk(ctx, chunk); err == nil {
 			db.publishMergeComplete(chunk)
+			for _, e := range chunk {
+				merged[e.index] = true
+			}
 			continue
 		}
 
@@ -171,10 +181,11 @@ func (db *DB) MergeBatchWithTxn(ctx context.Context, merges []event.Merge) error
 				continue
 			}
 			db.publishMergeComplete(chunk[i : i+1])
+			merged[chunk[i].index] = true
 		}
 	}
 
-	return errors.Join(errs...)
+	return merged, errors.Join(errs...)
 }
 
 // txnAttempts is how many times to try a transaction before giving up, never fewer than
@@ -189,6 +200,8 @@ func (db *DB) txnAttempts() int {
 // mergeChunk merges every event of the chunk inside one transaction, retrying the
 // whole chunk on transaction conflict. Isolating a failing event is the caller's job.
 func (db *DB) mergeChunk(ctx context.Context, entries []mergeEntry) error {
+	// Held so that exhausting the retry budget can report the conflict that caused it.
+	var conflictErr error
 	for i := 0; i < db.txnAttempts(); i++ {
 		txn, err := db.NewTxn(false)
 		if err != nil {
@@ -206,6 +219,7 @@ func (db *DB) mergeChunk(ctx context.Context, entries []mergeEntry) error {
 		if mergeErr != nil {
 			txn.Discard()
 			if errors.Is(mergeErr, corekv.ErrTxnConflict) {
+				conflictErr = mergeErr
 				continue
 			}
 			return mergeErr
@@ -214,6 +228,7 @@ func (db *DB) mergeChunk(ctx context.Context, entries []mergeEntry) error {
 		if err := txn.Commit(); err != nil {
 			txn.Discard()
 			if errors.Is(err, corekv.ErrTxnConflict) {
+				conflictErr = err
 				continue
 			}
 			return err
@@ -223,7 +238,7 @@ func (db *DB) mergeChunk(ctx context.Context, entries []mergeEntry) error {
 	}
 
 	// Nothing was committed, so callers must not treat the events as merged.
-	return client.NewErrMaxTxnRetries(nil)
+	return client.NewErrMaxTxnRetries(conflictErr)
 }
 
 func (db *DB) publishMergeComplete(entries []mergeEntry) {

--- a/internal/db/merge_test.go
+++ b/internal/db/merge_test.go
@@ -14,9 +14,11 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	badgerds "github.com/dgraph-io/badger/v4"
 	blocks "github.com/ipfs/go-block-format"
 	"github.com/ipfs/go-cid"
 	"github.com/ipld/go-ipld-prime"
@@ -24,6 +26,8 @@ import (
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	"github.com/stretchr/testify/require"
 
+	"github.com/sourcenetwork/corekv"
+	"github.com/sourcenetwork/corekv/badger"
 	"github.com/sourcenetwork/corekv/blockstore"
 	"github.com/sourcenetwork/immutable"
 
@@ -32,6 +36,7 @@ import (
 	coreblock "github.com/sourcenetwork/defradb/internal/core/block"
 	"github.com/sourcenetwork/defradb/internal/core/crdt"
 	"github.com/sourcenetwork/defradb/internal/datastore"
+	acpDB "github.com/sourcenetwork/defradb/internal/db/acp"
 	"github.com/sourcenetwork/defradb/internal/db/id"
 )
 
@@ -186,12 +191,13 @@ func TestMergeBatch_ZeroMaxRetriesStillAttempts(t *testing.T) {
 	col, err := db.GetCollectionByName(ctx, "User")
 	require.NoError(t, err)
 
-	err = db.MergeBatchWithTxn(ctx, []event.Merge{{
+	merged, err := db.MergeBatchWithTxn(ctx, []event.Merge{{
 		DocID:        "missing",
 		Cid:          blocks.NewBlock(nil).Cid(),
 		CollectionID: col.CollectionID(),
 	}})
 	require.ErrorContains(t, err, "failed to load block for merge")
+	require.Equal(t, []bool{false}, merged)
 }
 
 func TestMerge_GenesisWithEmptyDocID_ResolvesDocIDAndFieldMappings(t *testing.T) {
@@ -262,6 +268,120 @@ func TestMerge_GenesisWithEmptyDocID_ResolvesDocIDAndFieldMappings(t *testing.T)
 	blockDocIDs, err := id.GetDocIDsForBlockFromStore(txnCtx, dbTxn.Systemstore(), fieldCID)
 	require.NoError(t, err)
 	require.Equal(t, []string{sourceDoc.ID().String()}, blockDocIDs)
+}
+
+// conflictingStore fails every write transaction with a conflict once armed. Arming it is the
+// only way to drive a merge through its whole retry budget on demand: a real conflict needs a
+// second writer committing inside the window between this transaction's first read and its commit.
+type conflictingStore struct {
+	corekv.TxnStore
+	armed *atomic.Bool
+}
+
+func (s conflictingStore) NewTxn(readonly bool) corekv.Txn {
+	txn := s.TxnStore.NewTxn(readonly)
+	if readonly || !s.armed.Load() {
+		return txn
+	}
+	return conflictingTxn{Txn: txn}
+}
+
+type conflictingTxn struct {
+	corekv.Txn
+}
+
+func (t conflictingTxn) Commit() error {
+	return corekv.ErrTxnConflict
+}
+
+// newConflictingBadgerDB returns a database whose write commits can be made to conflict, and the
+// switch that does it. Setup runs with the switch off so collections can still be created.
+func newConflictingBadgerDB(ctx context.Context) (*DB, *atomic.Bool, error) {
+	rootstore, err := badger.NewDatastore("", badgerds.DefaultOptions("").WithInMemory(true))
+	if err != nil {
+		return nil, nil, err
+	}
+	adminInfo, err := acpDB.NewNACInfo(ctx, "", false)
+	if err != nil {
+		return nil, nil, err
+	}
+	armed := &atomic.Bool{}
+	db, err := newDB(ctx, conflictingStore{TxnStore: rootstore, armed: armed}, adminInfo)
+	if err != nil {
+		return nil, nil, err
+	}
+	return db, armed, nil
+}
+
+// stageUnmergedDoc writes a document's blocks to the store without merging them, and returns the
+// event that would merge it.
+func stageUnmergedDoc(t *testing.T, ctx context.Context, db *DB, col client.Collection) (client.DocID, event.Merge) {
+	t.Helper()
+
+	lsys := cidlink.DefaultLinkSystem()
+	lsys.SetWriteStorage(blockstore.NewIPLDStore(datastore.BlockstoreFrom(db.rootstore, immutable.None[int]())))
+
+	state := map[string]any{"name": "John"}
+	builder, _ := newDagBuilder(ctx, col, state)
+	composite, err := builder.generateCompositeUpdate(&lsys, state, compositeInfo{})
+	require.NoError(t, err)
+
+	docID := client.NewDocIDV0(composite.link.Cid)
+	return docID, event.Merge{
+		DocID:        docID.String(),
+		Cid:          composite.link.Cid,
+		CollectionID: col.CollectionID(),
+	}
+}
+
+// Every attempt conflicting means nothing was written. Returning nil here would tell the caller
+// the document merged, and the caller relays and acknowledges on that basis.
+func TestMerge_ExhaustedRetries_ReportsFailure(t *testing.T) {
+	ctx := context.Background()
+
+	db, conflict, err := newConflictingBadgerDB(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() { db.Close() })
+
+	_, err = db.AddCollection(ctx, userSchema)
+	require.NoError(t, err)
+	col, err := db.GetCollectionByName(ctx, "User")
+	require.NoError(t, err)
+
+	docID, mergeEvent := stageUnmergedDoc(t, ctx, db, col)
+
+	conflict.Store(true)
+	err = db.Merge(ctx, mergeEvent)
+	require.Error(t, err, "a merge that committed nothing must not report success")
+	require.ErrorContains(t, err, "maximum transaction")
+
+	_, err = col.GetDocument(ctx, docID)
+	require.Error(t, err, "the error must be truthful: nothing was stored")
+}
+
+// The batch path has its own retry loop, so it needs its own case: the parallel slice is what
+// callers read to decide which events to relay.
+func TestMergeBatch_ExhaustedRetries_ReportsNothingMerged(t *testing.T) {
+	ctx := context.Background()
+
+	db, conflict, err := newConflictingBadgerDB(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() { db.Close() })
+
+	_, err = db.AddCollection(ctx, userSchema)
+	require.NoError(t, err)
+	col, err := db.GetCollectionByName(ctx, "User")
+	require.NoError(t, err)
+
+	docID, mergeEvent := stageUnmergedDoc(t, ctx, db, col)
+
+	conflict.Store(true)
+	merged, err := db.MergeBatchWithTxn(ctx, []event.Merge{mergeEvent})
+	require.Error(t, err)
+	require.Equal(t, []bool{false}, merged, "an event that committed nothing must not be reported as merged")
+
+	_, err = col.GetDocument(ctx, docID)
+	require.Error(t, err, "the report must be truthful: nothing was stored")
 }
 
 func TestMergeResolveBlockDocID(t *testing.T) {
@@ -501,18 +621,101 @@ func TestMergeBatch_OneEventCannotMerge_OthersStillLand(t *testing.T) {
 
 	// The unmergeable event is listed first so that an all-or-nothing batch would
 	// abort before ever reaching the one that can merge.
-	err = db.MergeBatchWithTxn(ctx, []event.Merge{
+	merged, err := db.MergeBatchWithTxn(ctx, []event.Merge{
 		{DocID: badDocID.String(), Cid: badInfo.link.Cid, CollectionID: col.CollectionID()},
 		{DocID: goodDocID.String(), Cid: goodInfo.link.Cid, CollectionID: col.CollectionID()},
 	})
 	require.ErrorContains(t, err, "could not find "+missingLink.Cid.String())
 	require.ErrorContains(t, err, badDocID.String())
+	require.Equal(t, []bool{false, true}, merged)
 
 	doc, err := col.GetDocument(ctx, goodDocID)
 	require.NoError(t, err)
 	docMap, err := doc.ToMap()
 	require.NoError(t, err)
 	require.Equal(t, map[string]any{"_docID": goodDocID.String(), "name": "John"}, docMap)
+}
+
+// The result slice is indexed by the caller's event order, which chunking has to
+// preserve on both the committed and the isolated path. Only a chunk at a non-zero
+// offset distinguishes that from an index taken relative to the chunk, so the batch
+// spans three: one clean, one holding the bad event, and one clean after it.
+func TestMergeBatch_FailureInLaterChunk_ReportsFailureAgainstTheRightEvent(t *testing.T) {
+	ctx := context.Background()
+
+	db, err := newBadgerDB(ctx)
+	require.NoError(t, err)
+
+	_, err = db.AddCollection(ctx, userSchema)
+	require.NoError(t, err)
+
+	col, err := db.GetCollectionByName(ctx, "User")
+	require.NoError(t, err)
+
+	lsys := cidlink.DefaultLinkSystem()
+	lsys.SetWriteStorage(blockstore.NewIPLDStore(datastore.BlockstoreFrom(db.rootstore, immutable.None[int]())))
+
+	// Sized off the chunk size so the bad event lands in the second chunk and a third
+	// chunk still commits whole.
+	count := 2*mergeChunkSize + 2
+	badIndex := mergeChunkSize + 1
+
+	names := make([]string, count)
+	events := make([]event.Merge, count)
+	docIDs := make([]client.DocID, count)
+	var missingLink cidlink.Link
+
+	for i := range names {
+		name := fmt.Sprintf("user%d", i)
+		names[i] = name
+		state := map[string]any{"name": name}
+		builder, _ := newDagBuilder(ctx, col, state)
+		genesis, err := builder.generateCompositeUpdate(&lsys, state, compositeInfo{})
+		require.NoError(t, err)
+		docIDs[i] = client.NewDocIDV0(genesis.link.Cid)
+
+		info := genesis
+		if i == badIndex {
+			// Parent it on a composite that was never stored, so it cannot merge.
+			missingBlock := coreblock.Block{Delta: crdt.CRDT{DocCompositeDelta: &crdt.DocCompositeDelta{Status: 1}}}
+			missingLink, err = coreblock.GetLinkFromNode(missingBlock.GenerateNode())
+			require.NoError(t, err)
+
+			info, err = builder.generateCompositeUpdate(
+				&lsys,
+				map[string]any{"name": name + "ita"},
+				compositeInfo{link: missingLink, height: 2},
+			)
+			require.NoError(t, err)
+		}
+		events[i] = event.Merge{
+			DocID:        docIDs[i].String(),
+			Cid:          info.link.Cid,
+			CollectionID: col.CollectionID(),
+		}
+	}
+
+	merged, err := db.MergeBatchWithTxn(ctx, events)
+	require.ErrorContains(t, err, "could not find "+missingLink.Cid.String())
+
+	expected := make([]bool, count)
+	for i := range expected {
+		expected[i] = i != badIndex
+	}
+	require.Equal(t, expected, merged)
+
+	// The result slice has to agree with what is actually readable from the store.
+	for i, docID := range docIDs {
+		doc, err := col.GetDocument(ctx, docID)
+		if i == badIndex {
+			require.Error(t, err)
+			continue
+		}
+		require.NoError(t, err)
+		docMap, err := doc.ToMap()
+		require.NoError(t, err)
+		require.Equal(t, map[string]any{"_docID": docID.String(), "name": names[i]}, docMap)
+	}
 }
 
 type dagBuilder struct {

--- a/internal/db/merge_test.go
+++ b/internal/db/merge_test.go
@@ -160,12 +160,38 @@ func TestMerge_ZeroMaxRetriesStillAttempts(t *testing.T) {
 	col, err := db.GetCollectionByName(ctx, "User")
 	require.NoError(t, err)
 
+	// The block cannot be loaded, so an attempt fails there. Asserting that specific
+	// failure is what distinguishes one attempt from none: skipping the loop entirely
+	// reports exhausted retries and never touches the block.
 	err = db.Merge(ctx, event.Merge{
 		DocID:        "missing",
 		Cid:          blocks.NewBlock(nil).Cid(),
 		CollectionID: col.CollectionID(),
 	})
-	require.Error(t, err)
+	require.ErrorContains(t, err, "failed to load block for merge")
+}
+
+// The batch path has its own retry loop, so it needs the same floor as the single-document
+// one or a zero budget drops every event in the batch without trying.
+func TestMergeBatch_ZeroMaxRetriesStillAttempts(t *testing.T) {
+	ctx := context.Background()
+
+	db, err := newBadgerDB(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() { db.Close() })
+	db.maxTxnRetries = immutable.Some(0)
+
+	_, err = db.AddCollection(ctx, userSchema)
+	require.NoError(t, err)
+	col, err := db.GetCollectionByName(ctx, "User")
+	require.NoError(t, err)
+
+	err = db.MergeBatchWithTxn(ctx, []event.Merge{{
+		DocID:        "missing",
+		Cid:          blocks.NewBlock(nil).Cid(),
+		CollectionID: col.CollectionID(),
+	}})
+	require.ErrorContains(t, err, "failed to load block for merge")
 }
 
 func TestMerge_GenesisWithEmptyDocID_ResolvesDocIDAndFieldMappings(t *testing.T) {
@@ -432,6 +458,61 @@ func TestMerge_DualBranchWithOneIncomplete_CouldNotFindCID(t *testing.T) {
 	}
 
 	require.Equal(t, expectedDocMap, docMap)
+}
+
+func TestMergeBatch_OneEventCannotMerge_OthersStillLand(t *testing.T) {
+	ctx := context.Background()
+
+	db, err := newBadgerDB(ctx)
+	require.NoError(t, err)
+
+	_, err = db.AddCollection(ctx, userSchema)
+	require.NoError(t, err)
+
+	col, err := db.GetCollectionByName(ctx, "User")
+	require.NoError(t, err)
+
+	lsys := cidlink.DefaultLinkSystem()
+	lsys.SetWriteStorage(blockstore.NewIPLDStore(datastore.BlockstoreFrom(db.rootstore, immutable.None[int]())))
+
+	goodState := map[string]any{"name": "John"}
+	goodBuilder, _ := newDagBuilder(ctx, col, goodState)
+	goodInfo, err := goodBuilder.generateCompositeUpdate(&lsys, goodState, compositeInfo{})
+	require.NoError(t, err)
+	goodDocID := client.NewDocIDV0(goodInfo.link.Cid)
+
+	// A second document whose parent composite was never stored, so it cannot merge.
+	badState := map[string]any{"name": "Jane"}
+	badBuilder, _ := newDagBuilder(ctx, col, badState)
+	badGenesis, err := badBuilder.generateCompositeUpdate(&lsys, badState, compositeInfo{})
+	require.NoError(t, err)
+	badDocID := client.NewDocIDV0(badGenesis.link.Cid)
+
+	missingBlock := coreblock.Block{Delta: crdt.CRDT{DocCompositeDelta: &crdt.DocCompositeDelta{Status: 1}}}
+	missingLink, err := coreblock.GetLinkFromNode(missingBlock.GenerateNode())
+	require.NoError(t, err)
+
+	badInfo, err := badBuilder.generateCompositeUpdate(
+		&lsys,
+		map[string]any{"name": "Janet"},
+		compositeInfo{link: missingLink, height: 2},
+	)
+	require.NoError(t, err)
+
+	// The unmergeable event is listed first so that an all-or-nothing batch would
+	// abort before ever reaching the one that can merge.
+	err = db.MergeBatchWithTxn(ctx, []event.Merge{
+		{DocID: badDocID.String(), Cid: badInfo.link.Cid, CollectionID: col.CollectionID()},
+		{DocID: goodDocID.String(), Cid: goodInfo.link.Cid, CollectionID: col.CollectionID()},
+	})
+	require.ErrorContains(t, err, "could not find "+missingLink.Cid.String())
+	require.ErrorContains(t, err, badDocID.String())
+
+	doc, err := col.GetDocument(ctx, goodDocID)
+	require.NoError(t, err)
+	docMap, err := doc.ToMap()
+	require.NoError(t, err)
+	require.Equal(t, map[string]any{"_docID": goodDocID.String(), "name": "John"}, docMap)
 }
 
 type dagBuilder struct {

--- a/internal/db/p2p/p2p.go
+++ b/internal/db/p2p/p2p.go
@@ -93,7 +93,8 @@ type DB interface {
 	) ([]client.Collection, error)
 	// Merge initiates a merge of the DAG and caches the resulting values into the datastore.
 	Merge(ctx context.Context, evt event.Merge) error
-	// MergeBatchWithTxn merges multiple events in a single shared transaction.
+	// MergeBatchWithTxn merges events in bounded chunks. The returned error names
+	// any events that were dropped; those must not be relayed onward as merged.
 	MergeBatchWithTxn(ctx context.Context, merges []event.Merge) error
 	// Events returns the event bus for the database.
 	Events() event.Bus
@@ -643,7 +644,9 @@ func (p *P2P) processMessageWorker() {
 				log.Info("Context done during pushlog request processing", corelog.Any("Error", err))
 				continue
 			}
-			log.Info("Failed to process pushlog request", corelog.Any("Error", err))
+			// A failed pushlog is a document this node did not store, so it is reported at
+			// error level.
+			log.ErrorE("Failed to process pushlog request", err)
 		}
 	}
 }

--- a/internal/db/p2p/p2p.go
+++ b/internal/db/p2p/p2p.go
@@ -93,9 +93,10 @@ type DB interface {
 	) ([]client.Collection, error)
 	// Merge initiates a merge of the DAG and caches the resulting values into the datastore.
 	Merge(ctx context.Context, evt event.Merge) error
-	// MergeBatchWithTxn merges events in bounded chunks. The returned error names
-	// any events that were dropped; those must not be relayed onward as merged.
-	MergeBatchWithTxn(ctx context.Context, merges []event.Merge) error
+	// MergeBatchWithTxn merges events in bounded chunks. The returned slice is parallel
+	// to merges and reports which events committed; the rest are not stored and must not
+	// be relayed onward as merged. The error names every dropped event.
+	MergeBatchWithTxn(ctx context.Context, merges []event.Merge) ([]bool, error)
 	// Events returns the event bus for the database.
 	Events() event.Bus
 	// RetryIntervals returns the replicator retry configuration.
@@ -693,10 +694,18 @@ func (p *P2P) processPushlogRequest(
 		for i, r := range results {
 			merges[i] = r.merge
 		}
-		if err := p.db.MergeBatchWithTxn(ctx, merges); err != nil {
-			return err
+		merged, err := p.db.MergeBatchWithTxn(ctx, merges)
+		if err != nil {
+			log.ErrorE("Failed to merge documents in batch", err,
+				corelog.String("PeerID", req.SenderID),
+				corelog.Int("Documents", len(merges)))
 		}
-		for _, r := range results {
+		for i, r := range results {
+			if !merged[i] {
+				// Not stored here, so relaying it would advertise a document this node
+				// cannot serve.
+				continue
+			}
 			updateEvt := event.Update{
 				DocID:        r.merge.DocID,
 				Cid:          r.merge.Cid,


### PR DESCRIPTION
Related shinzonetwork/shinzo-host-client#362

Stacked on #5142.

A merge batch ran in one transaction, so a single unmergeable event discarded every other event in it. Merging now happens in chunks of 8, and a chunk that fails is re-run one event at a time, so a deterministic failure drops only the event that caused it.

`MergeBatchWithTxn` also returned no indication of which events committed, so the caller relayed and acknowledged events that were never stored. It now returns a slice parallel to the input, and the error names every dropped event.

A zero retry budget meant zero attempts, so no merge ran at all.

