### PR TITLE
fix: bound the pubsub message queue by bytes, not just slots

### DIFF
--- a/docs/website/guides/deployment-guide.md
+++ b/docs/website/guides/deployment-guide.md
@@ -90,6 +90,14 @@ For detailed instructions on deploying DefraDB with Akash, refer to the [Akash D
 - Specifiy the DefraDB folder with this command: `defradb --rootdir <path> start`.
 - The default directory for where data is specified is `<rootdir>/data`.
 
+### Memory Limits
+
+The Go runtime does not read a container or cgroup memory ceiling. Set `GOMEMLIMIT` to that ceiling so a node sizes itself against the memory it actually has:
+
+- `GOMEMLIMIT` takes a size suffix, for example `GOMEMLIMIT=2GiB`.
+- Leave headroom below the ceiling for memory the Go runtime does not account for.
+- Without it, a node sizes its inbound message queue from a fixed default, which may sit above the ceiling it is running under.
+
  
 
 ## Storage Engine

--- a/internal/db/p2p/p2p.go
+++ b/internal/db/p2p/p2p.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"log/slog"
 	"math"
+	"reflect"
 	"runtime/debug"
 	"strings"
 	"sync"
@@ -82,24 +83,50 @@ const (
 	// msgQueueFallbackMaxBytes is the byte budget used when the process has no memory
 	// limit set, where a fraction of it would be meaningless.
 	msgQueueFallbackMaxBytes = 1 << 30
+
+	// msgQueueMinBytes floors the budget so a very small memory limit still admits a message.
+	msgQueueMinBytes = maxPubsubMessageSize
+
+	// maxInboundDocuments caps the entries a received batch may carry, sized as headroom over
+	// this node's own batchMaxDocs to hold the per-entry cost under a tenth of a message. The
+	// cap applies while decoding, since the decode allocates before the message can be charged.
+	maxInboundDocuments = 16 * batchMaxDocs
 )
 
-// queuedMessage is a decoded request paired with its wire size, so the queue's byte
-// accounting can be reversed once the message has been processed. The wire size stands
-// in for the retained size: the decoded payload is a copy of those same bytes.
+// retainedBytesPerDocument is the fixed cost of one decoded batch entry, whatever it carries.
+// Read from the type so it stays right if a field is added.
+var retainedBytesPerDocument = int64(reflect.TypeFor[protocol.DocumentInfo]().Size())
+
+// pushLogDecMode rejects a batch carrying more than maxInboundDocuments entries. The options
+// are constant, so DecMode can only fail on a rejected option value.
+var pushLogDecMode = func() cbor.DecMode {
+	mode, err := cbor.DecOptions{MaxArrayElements: maxInboundDocuments}.DecMode()
+	if err != nil {
+		panic(err)
+	}
+	return mode
+}()
+
+// queuedMessage is a decoded request paired with the bytes reserved for it, so the queue's
+// accounting can be reversed once the message is processed. The reservation covers the wire
+// bytes, which the decoder copies rather than points into, plus the per-entry cost of a batch.
 type queuedMessage struct {
 	req  *protocol.PushLogRequest
 	size int64
 }
 
-// queueByteBudget returns the byte budget for the incoming message queue, derived from
-// the process memory limit so a node with a smaller limit queues proportionally less.
+// queueByteBudget returns the byte budget for the incoming message queue, taken as a fraction
+// of the process memory limit so a node with a smaller limit queues proportionally less.
+//
+// The limit comes from GOMEMLIMIT. The Go runtime does not read a container's memory ceiling,
+// so a node without it set gets the fallback, a fixed size that may sit above the ceiling the
+// node runs under. Zero is a limit an operator can set, so only MaxInt64 counts as absent.
 func queueByteBudget() int64 {
 	limit := debug.SetMemoryLimit(-1)
-	if limit <= 0 || limit == math.MaxInt64 {
+	if limit == math.MaxInt64 {
 		return msgQueueFallbackMaxBytes
 	}
-	return limit / msgQueueMemDivisor
+	return max(limit/msgQueueMemDivisor, msgQueueMinBytes)
 }
 
 // PushToReplicatorsHandler is called when documents are pushed to replicators.
@@ -656,8 +683,9 @@ func (p *P2P) docIDsForBlockCID(
 // processing by the bounded worker pool. It never blocks the libp2p pubsub
 // dispatcher: if the queue is full the message is dropped with a warning.
 //
-// The byte budget is claimed before decoding, so a message that cannot be queued does
-// not pay for a decode it will not use.
+// Most of the budget is claimed before decoding, so a message that cannot be queued does not
+// pay for a decode it will not use. The per-entry cost of a batch is only known after the
+// decode, and is claimed there.
 func (p *P2P) pubSubMessageHandler(from string, topic string, msg []byte) ([]byte, error) {
 	size := int64(len(msg))
 	if !p.claimQueueBytes(size) {
@@ -669,11 +697,27 @@ func (p *P2P) pubSubMessageHandler(from string, topic string, msg []byte) ([]byt
 	}
 
 	req := &protocol.PushLogRequest{}
-	if err := cbor.Unmarshal(msg, req); err != nil {
+	if err := pushLogDecMode.Unmarshal(msg, req); err != nil {
 		p.releaseQueueBytes(size)
 		return nil, err
 	}
 	req.SenderID = from
+
+	// A batch entry costs a fixed-size struct however little it carries, so the wire size alone
+	// does not bound what the queue holds. It folds into size rather than being tracked apart,
+	// because every release path and the worker give back that one value.
+	if perDocument := retainedBytesPerDocument * int64(len(req.Documents)); perDocument > 0 {
+		if !p.claimQueueBytes(perDocument) {
+			p.releaseQueueBytes(size)
+			log.Info("pubsub message queue over byte budget, dropping message",
+				corelog.Any("topic", topic),
+				corelog.Int64("bytes", size+perDocument),
+				corelog.Int64("documents", int64(len(req.Documents))),
+				corelog.Int64("budget", p.msgQueueMaxBytes))
+			return nil, nil
+		}
+		size += perDocument
+	}
 
 	select {
 	case p.msgQueue <- queuedMessage{req: req, size: size}:

--- a/internal/db/p2p/p2p.go
+++ b/internal/db/p2p/p2p.go
@@ -14,8 +14,11 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"math"
+	"runtime/debug"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/fxamacker/cbor/v2"
@@ -69,7 +72,35 @@ const (
 	// msgQueueSize is the capacity of the incoming pubsub message queue.
 	// Messages that arrive when the queue is full are dropped with a warning.
 	msgQueueSize = 50_000
+
+	// msgQueueMemDivisor sets the queue's byte budget as this fraction of the process
+	// memory limit. A slot count does not bound memory on its own, because a queued
+	// message holds its decoded payload and payload sizes are not uniform. The queue
+	// only has to absorb bursts, so it is given a fraction rather than the whole limit.
+	msgQueueMemDivisor = 4
+
+	// msgQueueFallbackMaxBytes is the byte budget used when the process has no memory
+	// limit set, where a fraction of it would be meaningless.
+	msgQueueFallbackMaxBytes = 1 << 30
 )
+
+// queuedMessage is a decoded request paired with its wire size, so the queue's byte
+// accounting can be reversed once the message has been processed. The wire size stands
+// in for the retained size: the decoded payload is a copy of those same bytes.
+type queuedMessage struct {
+	req  *protocol.PushLogRequest
+	size int64
+}
+
+// queueByteBudget returns the byte budget for the incoming message queue, derived from
+// the process memory limit so a node with a smaller limit queues proportionally less.
+func queueByteBudget() int64 {
+	limit := debug.SetMemoryLimit(-1)
+	if limit <= 0 || limit == math.MaxInt64 {
+		return msgQueueFallbackMaxBytes
+	}
+	return limit / msgQueueMemDivisor
+}
 
 // PushToReplicatorsHandler is called when documents are pushed to replicators.
 // Implementations can perform additional actions like generating SE artifacts.
@@ -168,8 +199,13 @@ type P2P struct {
 	batcher *pubsubBatcher
 
 	// msgQueue receives incoming pubsub messages for async processing by a fixed worker pool.
-	msgQueue   chan *protocol.PushLogRequest
+	msgQueue   chan queuedMessage
 	msgWorkers sync.WaitGroup
+
+	// msgQueueBytes is the wire size of the messages currently queued or in flight.
+	msgQueueBytes atomic.Int64
+	// msgQueueMaxBytes caps msgQueueBytes. Zero or less disables the byte bound.
+	msgQueueMaxBytes int64
 }
 
 // pushLogCommProcessor implements CommProcessor for push log functionality
@@ -225,7 +261,8 @@ func New(
 		replicationFilter:    replicationFilter,
 		syncBlockLinkTimeout: db.P2PBlockSyncTimeout(),
 		topicPeerCounts:      make(map[string]int),
-		msgQueue:             make(chan *protocol.PushLogRequest, msgQueueSize),
+		msgQueue:             make(chan queuedMessage, msgQueueSize),
+		msgQueueMaxBytes:     queueByteBudget(),
 	}
 
 	for i := 0; i < dagSyncWorkers; i++ {
@@ -618,20 +655,56 @@ func (p *P2P) docIDsForBlockCID(
 // pubSubMessageHandler decodes the incoming wire message and enqueues it for
 // processing by the bounded worker pool. It never blocks the libp2p pubsub
 // dispatcher: if the queue is full the message is dropped with a warning.
+//
+// The byte budget is claimed before decoding, so a message that cannot be queued does
+// not pay for a decode it will not use.
 func (p *P2P) pubSubMessageHandler(from string, topic string, msg []byte) ([]byte, error) {
+	size := int64(len(msg))
+	if !p.claimQueueBytes(size) {
+		log.Info("pubsub message queue over byte budget, dropping message",
+			corelog.Any("topic", topic),
+			corelog.Int64("bytes", size),
+			corelog.Int64("budget", p.msgQueueMaxBytes))
+		return nil, nil
+	}
+
 	req := &protocol.PushLogRequest{}
 	if err := cbor.Unmarshal(msg, req); err != nil {
+		p.releaseQueueBytes(size)
 		return nil, err
 	}
 	req.SenderID = from
 
 	select {
-	case p.msgQueue <- req:
+	case p.msgQueue <- queuedMessage{req: req, size: size}:
 	case <-p.ctx.Done():
+		p.releaseQueueBytes(size)
 	default:
+		p.releaseQueueBytes(size)
 		log.Info("pubsub message queue full, dropping message", corelog.Any("topic", topic))
 	}
 	return nil, nil
+}
+
+// claimQueueBytes reserves size against the queue's byte budget, reporting whether the
+// reservation fit. A budget of zero or less means the byte bound is disabled.
+func (p *P2P) claimQueueBytes(size int64) bool {
+	if p.msgQueueMaxBytes <= 0 {
+		return true
+	}
+	if p.msgQueueBytes.Add(size) > p.msgQueueMaxBytes {
+		p.msgQueueBytes.Add(-size)
+		return false
+	}
+	return true
+}
+
+// releaseQueueBytes returns a reservation made by claimQueueBytes.
+func (p *P2P) releaseQueueBytes(size int64) {
+	if p.msgQueueMaxBytes <= 0 {
+		return
+	}
+	p.msgQueueBytes.Add(-size)
 }
 
 // processMessageWorker is a long-lived goroutine that drains p.msgQueue and
@@ -639,8 +712,12 @@ func (p *P2P) pubSubMessageHandler(from string, topic string, msg []byte) ([]byt
 // concurrently, bounding the goroutine count regardless of inbound message rate.
 func (p *P2P) processMessageWorker() {
 	defer p.msgWorkers.Done()
-	for req := range p.msgQueue {
-		if err := p.processPushlogRequest(p.ctx, req, false); err != nil {
+	for m := range p.msgQueue {
+		err := p.processPushlogRequest(p.ctx, m.req, false)
+		// Released here rather than deferred so the budget frees up per message, not
+		// when the worker exits.
+		p.releaseQueueBytes(m.size)
+		if err != nil {
 			if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
 				log.Info("Context done during pushlog request processing", corelog.Any("Error", err))
 				continue

--- a/internal/db/p2p/p2p_test.go
+++ b/internal/db/p2p/p2p_test.go
@@ -12,7 +12,10 @@ package p2p
 
 import (
 	"context"
+	"math"
+	"runtime/debug"
 	"testing"
+	"time"
 
 	"github.com/fxamacker/cbor/v2"
 	"github.com/stretchr/testify/assert"
@@ -54,6 +57,103 @@ func TestPubSubMessageHandler_ContextCanceled(t *testing.T) {
 	// Expectation: No error returned (suppressed), resp is nil
 	assert.NoError(t, err)
 	assert.Nil(t, resp)
+}
+
+// The budget is claimed before the decode, so an over-budget message never reaches
+// cbor. Undecodable bytes distinguish the two orderings: decoding first surfaces an
+// error, claiming first drops the message silently.
+func TestPubSubMessageHandler_OverBudgetDropsBeforeDecode(t *testing.T) {
+	p := &P2P{
+		ctx:              context.Background(),
+		host:             &SimpleMockHost{},
+		msgQueue:         make(chan queuedMessage, 4),
+		msgQueueMaxBytes: 4,
+	}
+
+	undecodable := []byte{0xff, 0xff, 0xff, 0xff, 0xff}
+	resp, err := p.pubSubMessageHandler("sender", "topic", undecodable)
+
+	assert.NoError(t, err)
+	assert.Nil(t, resp)
+	assert.Empty(t, p.msgQueue)
+	assert.Equal(t, int64(0), p.msgQueueBytes.Load())
+}
+
+func TestPubSubMessageHandler_ByteBudgetReleasedAfterProcessing(t *testing.T) {
+	msg, err := cbor.Marshal(protocol.PushLogRequest{DocID: "docID"})
+	assert.NoError(t, err)
+
+	// Sized so exactly one message fits, making the second one's fate depend entirely
+	// on whether the first was released.
+	p := &P2P{
+		ctx:              context.Background(),
+		host:             &SimpleMockHost{},
+		msgQueue:         make(chan queuedMessage, 4),
+		msgQueueMaxBytes: int64(len(msg)),
+	}
+
+	_, err = p.pubSubMessageHandler("sender", "topic", msg)
+	assert.NoError(t, err)
+	assert.Len(t, p.msgQueue, 1)
+
+	_, err = p.pubSubMessageHandler("sender", "topic", msg)
+	assert.NoError(t, err)
+	assert.Len(t, p.msgQueue, 1, "second message should be dropped while the budget is held")
+
+	// Stand in for a worker finishing with the message.
+	queued := <-p.msgQueue
+	p.releaseQueueBytes(queued.size)
+	assert.Equal(t, int64(0), p.msgQueueBytes.Load())
+
+	_, err = p.pubSubMessageHandler("sender", "topic", msg)
+	assert.NoError(t, err)
+	assert.Len(t, p.msgQueue, 1, "budget should be available again once released")
+}
+
+// The handler reserves the budget and the worker is what gives it back. Without the release the
+// counter only ever climbs, and once enough traffic has passed through, the node drops every
+// message from then on while its queue sits empty.
+func TestProcessMessageWorker_ReleasesByteBudget(t *testing.T) {
+	msg, err := cbor.Marshal(protocol.PushLogRequest{DocID: "docID"})
+	assert.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	p := &P2P{
+		ctx:              ctx,
+		host:             &SimpleMockHost{},
+		msgQueue:         make(chan queuedMessage, 1),
+		msgQueueMaxBytes: int64(len(msg)),
+	}
+
+	_, err = p.pubSubMessageHandler("sender", "topic", msg)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(len(msg)), p.msgQueueBytes.Load(), "the handler reserves on enqueue")
+
+	// Cancelling returns processPushlogRequest at its first check, so no database is needed and
+	// the release is the only part of the worker left under test. The worker is left parked on
+	// the empty queue rather than stopped, which keeps this independent of how shutdown is
+	// signalled.
+	cancel()
+	p.msgWorkers.Add(1)
+	go p.processMessageWorker()
+
+	assert.Eventually(t, func() bool { return p.msgQueueBytes.Load() == 0 },
+		5*time.Second, 5*time.Millisecond,
+		"the worker must return the budget the handler reserved")
+}
+
+func TestQueueByteBudget_DerivesFromMemoryLimit(t *testing.T) {
+	original := debug.SetMemoryLimit(-1)
+	t.Cleanup(func() { debug.SetMemoryLimit(original) })
+
+	// Written out rather than derived from the constants: the point of the assertion is that
+	// the budget is a small fraction of the limit, and restating the formula would let the
+	// queue grow to the whole limit without failing here.
+	debug.SetMemoryLimit(8 << 30)
+	assert.Equal(t, int64(2<<30), queueByteBudget(), "a quarter of an 8 GiB limit")
+
+	debug.SetMemoryLimit(math.MaxInt64)
+	assert.Equal(t, int64(1<<30), queueByteBudget(), "the fallback when no limit is set")
 }
 
 func TestPubSubMessageHandler_ContextTimeout(t *testing.T) {

--- a/internal/db/p2p/p2p_test.go
+++ b/internal/db/p2p/p2p_test.go
@@ -154,6 +154,14 @@ func TestQueueByteBudget_DerivesFromMemoryLimit(t *testing.T) {
 
 	debug.SetMemoryLimit(math.MaxInt64)
 	assert.Equal(t, int64(1<<30), queueByteBudget(), "the fallback when no limit is set")
+
+	// Zero is a limit an operator can set, so reading it as "no limit" would give the
+	// tightest heap the largest budget.
+	debug.SetMemoryLimit(0)
+	assert.Equal(t, int64(msgQueueMinBytes), queueByteBudget(), "a zero limit is floored, not ignored")
+
+	debug.SetMemoryLimit(1 << 10)
+	assert.Equal(t, int64(msgQueueMinBytes), queueByteBudget(), "a limit too small for one message is floored")
 }
 
 func TestPubSubMessageHandler_ContextTimeout(t *testing.T) {
@@ -179,4 +187,84 @@ func TestPubSubMessageHandler_ContextTimeout(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Nil(t, resp)
+}
+
+// denseBatch builds a batch of empty entries, the smallest encoding that still allocates a
+// DocumentInfo each. Hand-built because the encoder writes every field without omitempty and
+// so cannot produce an encoding a peer is free to send.
+func denseBatch(n int) []byte {
+	out := []byte{0xa1, 0x69} // map of one pair, keyed by a nine byte text string
+	out = append(out, []byte("documents")...)
+	out = append(out, 0x9a, byte(n>>24), byte(n>>16), byte(n>>8), byte(n)) // array, four byte length
+	for range n {
+		out = append(out, 0xa0) // empty map
+	}
+	return out
+}
+
+// A budget taken from the wire size alone admits a message holding far more than it was
+// charged for, since an entry costs a struct however little it carries.
+func TestPubSubMessageHandler_ChargesForEachDocument(t *testing.T) {
+	msg := denseBatch(1024)
+
+	p := &P2P{
+		ctx:      context.Background(),
+		host:     &SimpleMockHost{},
+		msgQueue: make(chan queuedMessage, 4),
+		// Room for the wire bytes several times over, but not for what the batch holds.
+		msgQueueMaxBytes: int64(len(msg)) * 4,
+	}
+
+	_, err := p.pubSubMessageHandler("sender", "topic", msg)
+	assert.NoError(t, err)
+	assert.Empty(t, p.msgQueue, "a batch holding more than the budget must not be queued")
+	assert.Equal(t, int64(0), p.msgQueueBytes.Load(), "a rejected message must hold no budget")
+}
+
+// Every path that gives up on a message must give back what was claimed for it, or the
+// counter climbs until a node with an empty queue drops everything.
+func TestPubSubMessageHandler_QueueFullReleasesTheWholeReservation(t *testing.T) {
+	msg := denseBatch(64)
+
+	p := &P2P{
+		ctx:              context.Background(),
+		host:             &SimpleMockHost{},
+		msgQueue:         make(chan queuedMessage, 1),
+		msgQueueMaxBytes: 1 << 30,
+	}
+
+	_, err := p.pubSubMessageHandler("sender", "topic", msg)
+	assert.NoError(t, err)
+	assert.Len(t, p.msgQueue, 1)
+	held := p.msgQueueBytes.Load()
+
+	for range 8 {
+		_, err = p.pubSubMessageHandler("sender", "topic", msg)
+		assert.NoError(t, err)
+	}
+	assert.Equal(t, held, p.msgQueueBytes.Load(), "a full queue must give back everything it claimed")
+
+	queued := <-p.msgQueue
+	p.releaseQueueBytes(queued.size)
+	assert.Equal(t, int64(0), p.msgQueueBytes.Load(), "the reservation must balance to zero")
+}
+
+// The cap belongs at the decoder: a length check after it runs past the allocation it exists
+// to prevent.
+func TestPubSubMessageHandler_RejectsAnOversizedBatch(t *testing.T) {
+	p := &P2P{
+		ctx:              context.Background(),
+		host:             &SimpleMockHost{},
+		msgQueue:         make(chan queuedMessage, 4),
+		msgQueueMaxBytes: 1 << 30,
+	}
+
+	_, err := p.pubSubMessageHandler("sender", "topic", denseBatch(maxInboundDocuments+1))
+	assert.Error(t, err, "a batch over the entry cap must not decode")
+	assert.Empty(t, p.msgQueue)
+	assert.Equal(t, int64(0), p.msgQueueBytes.Load(), "a rejected message must hold no budget")
+
+	_, err = p.pubSubMessageHandler("sender", "topic", denseBatch(maxInboundDocuments))
+	assert.NoError(t, err)
+	assert.Len(t, p.msgQueue, 1, "a batch at the cap must still be accepted")
 }


### PR DESCRIPTION
Related shinzonetwork/shinzo-host-client#362

Stacked on #5143.

The inbound pubsub queue was bounded by slot count only, so its memory use was set by whatever the largest messages happened to be. It is now bounded by bytes as well, with the budget derived from the process memory limit.

Wire size alone does not bound what the queue holds: a decoded batch entry costs a fixed-size struct however little it carries. That per-entry cost is charged after the decode, and the decoder rejects a batch carrying more entries than the cap admits.

The budget comes from `GOMEMLIMIT`. The Go runtime does not read a container's memory ceiling, so a node without it set gets the fallback, which may sit above the ceiling it runs under.
