### PR TITLE
chore: merge, ingest and store telemetry

### DIFF
--- a/client/errors.go
+++ b/client/errors.go
@@ -107,6 +107,7 @@ var (
 	ErrNullValueForNonNillableField          = errors.New(errNullValueForNonNillableField)
 	ErrMissingRequiredField                  = errors.New(errMissingRequiredField)
 	ErrTransactionNotFound                   = errors.New(errTransactionNotFound)
+	ErrMaxTxnRetries                         = errors.New(errMaxTxnRetries)
 )
 
 // NewErrFieldNotExist returns an error indicating that the given field does not exist.

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -179,7 +179,7 @@ func newDB(
 		p2pBlockSyncTimeout:     cfg.P2PBlockSyncTimeout,
 		lockSet:                 lockSet,
 		collectionRepository:    description.NewColCache(lockSet, datastore.NewUnsafeDatastore(rootstore)),
-		stats:                   &mergeStats{},
+		stats:                   newMergeStats(),
 	}
 
 	lensRuntime, err := newLensRuntime(LensRuntimeType(cfg.LensRuntime))

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -125,6 +125,9 @@ type DB struct {
 	lockSet *lock.LockSet
 
 	collectionRepository *description.CollectionRepository
+
+	// stats are the merge-path counters reported on an interval by reportMergeStats.
+	stats *mergeStats
 }
 
 var _ client.TxnStore = (*DB)(nil)
@@ -176,6 +179,7 @@ func newDB(
 		p2pBlockSyncTimeout:     cfg.P2PBlockSyncTimeout,
 		lockSet:                 lockSet,
 		collectionRepository:    description.NewColCache(lockSet, datastore.NewUnsafeDatastore(rootstore)),
+		stats:                   &mergeStats{},
 	}
 
 	lensRuntime, err := newLensRuntime(LensRuntimeType(cfg.LensRuntime))
@@ -232,6 +236,8 @@ func newDB(
 			log.ErrorE("index state recovery failed", err)
 		}
 	})
+
+	go db.reportMergeStats(db.ctx)
 
 	return db, nil
 }

--- a/internal/db/index.go
+++ b/internal/db/index.go
@@ -438,6 +438,8 @@ func saveUniqueKey(
 	}
 
 	if len(val) != 0 {
+		// This read puts the unique key in the transaction's read set, so two transactions
+		// writing the same index value conflict at commit rather than at this check.
 		existing, err := txn.Datastore().Get(ctx, &key)
 		if err != nil && !errors.Is(err, corekv.ErrNotFound) {
 			return NewErrCheckUniqueIndexConstraint(err)
@@ -446,7 +448,7 @@ func saveUniqueKey(
 			if tolerateSameDoc && string(existing) == string(val) {
 				return nil
 			}
-			return newUniqueIndexError(doc, fieldsDescs)
+			return newUniqueIndexError(ctx, doc, fieldsDescs, existing)
 		}
 	}
 
@@ -456,8 +458,33 @@ func saveUniqueKey(
 	return nil
 }
 
-func newUniqueIndexError(doc *client.Document, fieldsDescs []client.CollectionFieldDescription) error {
-	kvs := make([]errors.KV, 0, len(fieldsDescs))
+// incumbentDocID resolves the document already holding a unique index entry, from the
+// short ID the entry stores. Returns an empty string if it cannot be resolved, since this
+// only decorates an error that is being returned either way.
+func incumbentDocID(ctx context.Context, encodedShortID []byte) string {
+	shortID, err := keys.DecodeDocShortID(encodedShortID)
+	if err != nil {
+		return ""
+	}
+	docID, found, err := id.GetDocID(ctx, shortID)
+	if err != nil || !found {
+		return ""
+	}
+	return docID
+}
+
+func newUniqueIndexError(
+	ctx context.Context,
+	doc *client.Document,
+	fieldsDescs []client.CollectionFieldDescription,
+	existing []byte,
+) error {
+	kvs := make([]errors.KV, 0, len(fieldsDescs)+1)
+	// Naming the document that already holds the value is what makes the two comparable;
+	// without it the error only says which one lost.
+	if incumbent := incumbentDocID(ctx, existing); incumbent != "" {
+		kvs = append(kvs, errors.NewKV("HeldBy", incumbent))
+	}
 	for iter := range fieldsDescs {
 		fieldVal, err := doc.TryGetValue(fieldsDescs[iter].Name)
 		var val any

--- a/internal/db/index.go
+++ b/internal/db/index.go
@@ -14,6 +14,7 @@ import (
 	"context"
 
 	"github.com/sourcenetwork/corekv"
+	"github.com/sourcenetwork/corelog"
 
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/errors"
@@ -448,7 +449,17 @@ func saveUniqueKey(
 			if tolerateSameDoc && string(existing) == string(val) {
 				return nil
 			}
-			return newUniqueIndexError(ctx, doc, fieldsDescs, existing)
+			// The holder stays on this node: the error is rendered to whoever asked for the
+			// write, and on the merge path that is the peer that pushed it. An empty holder
+			// means the entry could not be resolved to a document.
+			var heldBy string
+			if shortID, decodeErr := keys.DecodeDocShortID(existing); decodeErr == nil {
+				heldBy, _, _ = id.GetDocID(ctx, shortID)
+			}
+			log.InfoContext(ctx, "unique index violation",
+				corelog.String("docID", doc.ID().String()),
+				corelog.String("heldBy", heldBy))
+			return newUniqueIndexError(doc, fieldsDescs)
 		}
 	}
 
@@ -458,33 +469,8 @@ func saveUniqueKey(
 	return nil
 }
 
-// incumbentDocID resolves the document already holding a unique index entry, from the
-// short ID the entry stores. Returns an empty string if it cannot be resolved, since this
-// only decorates an error that is being returned either way.
-func incumbentDocID(ctx context.Context, encodedShortID []byte) string {
-	shortID, err := keys.DecodeDocShortID(encodedShortID)
-	if err != nil {
-		return ""
-	}
-	docID, found, err := id.GetDocID(ctx, shortID)
-	if err != nil || !found {
-		return ""
-	}
-	return docID
-}
-
-func newUniqueIndexError(
-	ctx context.Context,
-	doc *client.Document,
-	fieldsDescs []client.CollectionFieldDescription,
-	existing []byte,
-) error {
-	kvs := make([]errors.KV, 0, len(fieldsDescs)+1)
-	// Naming the document that already holds the value is what makes the two comparable;
-	// without it the error only says which one lost.
-	if incumbent := incumbentDocID(ctx, existing); incumbent != "" {
-		kvs = append(kvs, errors.NewKV("HeldBy", incumbent))
-	}
+func newUniqueIndexError(doc *client.Document, fieldsDescs []client.CollectionFieldDescription) error {
+	kvs := make([]errors.KV, 0, len(fieldsDescs))
 	for iter := range fieldsDescs {
 		fieldVal, err := doc.TryGetValue(fieldsDescs[iter].Name)
 		var val any

--- a/internal/db/index_backfill_test.go
+++ b/internal/db/index_backfill_test.go
@@ -370,3 +370,38 @@ func TestBackfillBatchTxn_ConflictsWhenReadDocIsModified(t *testing.T) {
 	require.True(t, errors.Is(commitErr, corekv.ErrTxnConflict),
 		"expected ErrTxnConflict but got: %v", commitErr)
 }
+
+// A unique violation names the document that lost. Naming the one that already holds the
+// value is what lets the two be compared, which is the only way to tell a genuine duplicate
+// from two documents that disagree on a field they do not share an index on.
+func TestSaveUniqueKey_ErrorNamesTheDocumentHoldingTheValue(t *testing.T) {
+	ctx := context.Background()
+
+	db, err := newBadgerDB(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() { db.Close() })
+
+	_, err = db.AddCollection(ctx, userSchema)
+	require.NoError(t, err)
+	col, err := db.GetCollectionByName(ctx, "User")
+	require.NoError(t, err)
+
+	_, err = col.NewIndex(ctx, client.NewIndexRequest{
+		Fields: []client.IndexedFieldDescription{{Name: "name"}},
+		Unique: true,
+	})
+	require.NoError(t, err)
+
+	incumbent, err := client.NewDocFromJSON(ctx, []byte(`{"name":"alice","age":1}`), col.Version())
+	require.NoError(t, err)
+	require.NoError(t, col.AddDocument(ctx, incumbent))
+
+	// Same indexed value, different age, so a different document that cannot have the slot.
+	duplicate, err := client.NewDocFromJSON(ctx, []byte(`{"name":"alice","age":2}`), col.Version())
+	require.NoError(t, err)
+	require.NotEqual(t, incumbent.ID().String(), duplicate.ID().String())
+
+	err = col.AddDocument(ctx, duplicate)
+	require.ErrorContains(t, err, "violates unique index")
+	require.ErrorContains(t, err, incumbent.ID().String())
+}

--- a/internal/db/index_backfill_test.go
+++ b/internal/db/index_backfill_test.go
@@ -371,10 +371,10 @@ func TestBackfillBatchTxn_ConflictsWhenReadDocIsModified(t *testing.T) {
 		"expected ErrTxnConflict but got: %v", commitErr)
 }
 
-// A unique violation names the document that lost. Naming the one that already holds the
-// value is what lets the two be compared, which is the only way to tell a genuine duplicate
-// from two documents that disagree on a field they do not share an index on.
-func TestSaveUniqueKey_ErrorNamesTheDocumentHoldingTheValue(t *testing.T) {
+// The document already holding a contested value is one the writer never named and, under
+// document access control, may not be allowed to read. The error goes back to the writer,
+// and on the merge path to the peer that pushed the log, so it names only the writer.
+func TestSaveUniqueKey_DoesNotNameTheDocumentHoldingTheValue(t *testing.T) {
 	ctx := context.Background()
 
 	db, err := newBadgerDB(ctx)
@@ -392,16 +392,17 @@ func TestSaveUniqueKey_ErrorNamesTheDocumentHoldingTheValue(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	incumbent, err := client.NewDocFromJSON(ctx, []byte(`{"name":"alice","age":1}`), col.Version())
+	holder, err := client.NewDocFromJSON(ctx, []byte(`{"name":"alice","age":1}`), col.Version())
 	require.NoError(t, err)
-	require.NoError(t, col.AddDocument(ctx, incumbent))
+	require.NoError(t, col.AddDocument(ctx, holder))
 
 	// Same indexed value, different age, so a different document that cannot have the slot.
 	duplicate, err := client.NewDocFromJSON(ctx, []byte(`{"name":"alice","age":2}`), col.Version())
 	require.NoError(t, err)
-	require.NotEqual(t, incumbent.ID().String(), duplicate.ID().String())
+	require.NotEqual(t, holder.ID().String(), duplicate.ID().String())
 
 	err = col.AddDocument(ctx, duplicate)
-	require.ErrorContains(t, err, "violates unique index")
-	require.ErrorContains(t, err, incumbent.ID().String())
+	require.ErrorIs(t, err, ErrCanNotIndexNonUniqueFields)
+	require.Contains(t, err.Error(), duplicate.ID().String(), "the writer is named")
+	require.NotContains(t, err.Error(), holder.ID().String(), "the holder is not")
 }

--- a/internal/db/merge.go
+++ b/internal/db/merge.go
@@ -72,8 +72,10 @@ func (db *DB) Merge(ctx context.Context, evt event.Merge) error {
 		}
 		return nil
 	}
+	// A single event has no smaller write set to retry over, so exhaustion is a drop rather than
+	// a fallback into per-event isolation.
 	db.stats.markDropped(dropRetryExhausted)
-	return client.NewErrMaxTxnRetries(err)
+	return NewErrMergeEventDropped(client.NewErrMaxTxnRetries(err), evt.DocID, evt.Cid.String())
 }
 
 // mergeChunkSize bounds how many events share a transaction. Badger re-sorts the

--- a/internal/db/merge.go
+++ b/internal/db/merge.go
@@ -43,6 +43,7 @@ import (
 func (db *DB) Merge(ctx context.Context, evt event.Merge) error {
 	col, err := getCollectionFromCollectionID(ctx, db, evt.CollectionID)
 	if err != nil {
+		db.stats.markDropped(dropCollection)
 		return err
 	}
 
@@ -62,13 +63,16 @@ func (db *DB) Merge(ctx context.Context, evt event.Merge) error {
 	for i := 0; i < db.txnAttempts(); i++ {
 		err = db.executeMerge(ctx, col, evt)
 		if errors.Is(err, corekv.ErrTxnConflict) {
+			db.stats.chunkConflicts.Add(1)
 			continue
 		}
 		if err != nil {
+			db.stats.markDropped(mergeDropReason(err))
 			return err
 		}
 		return nil
 	}
+	db.stats.markDropped(dropRetryExhausted)
 	return client.NewErrMaxTxnRetries(err)
 }
 

--- a/internal/db/merge.go
+++ b/internal/db/merge.go
@@ -43,7 +43,7 @@ import (
 func (db *DB) Merge(ctx context.Context, evt event.Merge) error {
 	col, err := getCollectionFromCollectionID(ctx, db, evt.CollectionID)
 	if err != nil {
-		db.stats.markDropped(dropCollection)
+		db.stats.markDropped(collectionDropReason(err))
 		return err
 	}
 
@@ -117,7 +117,7 @@ func (db *DB) MergeBatchWithTxn(ctx context.Context, merges []event.Merge) ([]bo
 		col, err := getCollectionFromCollectionID(ctx, db, evt.CollectionID)
 		if err != nil {
 			errs = append(errs, NewErrMergeEventDropped(err, evt.DocID, evt.Cid.String()))
-			db.stats.markDropped(dropCollection)
+			db.stats.markDropped(collectionDropReason(err))
 			continue
 		}
 		entries = append(entries, mergeEntry{evt: evt, col: col, index: i})

--- a/internal/db/merge.go
+++ b/internal/db/merge.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strings"
 	"sync"
 
 	"github.com/ipfs/go-cid"
@@ -76,6 +77,12 @@ func (db *DB) Merge(ctx context.Context, evt event.Merge) error {
 // several, so a bigger chunk sorts a bigger set more times.
 const mergeChunkSize = 8
 
+// Phases a merge chunk can fail in, reported on the retry-exhaustion log line.
+const (
+	phaseRead   = "read"
+	phaseCommit = "commit"
+)
+
 type mergeEntry struct {
 	evt event.Merge
 	col *collection
@@ -106,6 +113,7 @@ func (db *DB) MergeBatchWithTxn(ctx context.Context, merges []event.Merge) ([]bo
 		col, err := getCollectionFromCollectionID(ctx, db, evt.CollectionID)
 		if err != nil {
 			errs = append(errs, NewErrMergeEventDropped(err, evt.DocID, evt.Cid.String()))
+			db.stats.markDropped(dropCollection)
 			continue
 		}
 		entries = append(entries, mergeEntry{evt: evt, col: col, index: i})
@@ -178,6 +186,7 @@ func (db *DB) MergeBatchWithTxn(ctx context.Context, merges []event.Merge) ([]bo
 		for i := range chunk {
 			if err := db.mergeChunk(ctx, chunk[i:i+1]); err != nil {
 				errs = append(errs, NewErrMergeEventDropped(err, chunk[i].evt.DocID, chunk[i].evt.Cid.String()))
+				db.stats.markDropped(mergeDropReason(err))
 				continue
 			}
 			db.publishMergeComplete(chunk[i : i+1])
@@ -197,11 +206,27 @@ func (db *DB) txnAttempts() int {
 	return 1
 }
 
+// namedDocs renders the documents a transaction touched, as collection/docID. Badger
+// reports conflicts without naming the contended key, so this is the only lead available
+// for working out which documents contend with each other.
+func namedDocs(entries []mergeEntry) string {
+	docIDs := make([]string, len(entries))
+	for i, e := range entries {
+		docIDs[i] = e.col.Name() + "/" + e.evt.DocID
+	}
+	return strings.Join(docIDs, ",")
+}
+
 // mergeChunk merges every event of the chunk inside one transaction, retrying the
 // whole chunk on transaction conflict. Isolating a failing event is the caller's job.
 func (db *DB) mergeChunk(ctx context.Context, entries []mergeEntry) error {
-	// Held so that exhausting the retry budget can report the conflict that caused it.
+	// Held so that exhausting the retry budget can report the conflict that caused it and
+	// where the last one was raised.
 	var conflictErr error
+	var phase string
+	// Whether each event created its document, kept until the transaction commits so a
+	// retried attempt does not count its events twice.
+	creates := make([]bool, 0, len(entries))
 	for i := 0; i < db.txnAttempts(); i++ {
 		txn, err := db.NewTxn(false)
 		if err != nil {
@@ -209,17 +234,22 @@ func (db *DB) mergeChunk(ctx context.Context, entries []mergeEntry) error {
 		}
 		txnCtx := InitContext(ctx, txn)
 
+		creates = creates[:0]
 		var mergeErr error
 		for _, e := range entries {
-			if mergeErr = db.mergeInTxn(txnCtx, e.col, e.evt); mergeErr != nil {
+			isCreate, err := db.mergeInTxn(txnCtx, e.col, e.evt)
+			if err != nil {
+				mergeErr, phase = err, phaseRead
 				break
 			}
+			creates = append(creates, isCreate)
 		}
 
 		if mergeErr != nil {
 			txn.Discard()
 			if errors.Is(mergeErr, corekv.ErrTxnConflict) {
 				conflictErr = mergeErr
+				db.stats.chunkConflicts.Add(1)
 				continue
 			}
 			return mergeErr
@@ -229,15 +259,29 @@ func (db *DB) mergeChunk(ctx context.Context, entries []mergeEntry) error {
 			txn.Discard()
 			if errors.Is(err, corekv.ErrTxnConflict) {
 				conflictErr = err
+				db.stats.chunkConflicts.Add(1)
+				phase = phaseCommit
 				continue
 			}
 			return err
 		}
 
+		for _, isCreate := range creates {
+			db.stats.markCreateOrUpdate(isCreate)
+		}
 		return nil
 	}
 
-	// Nothing was committed, so callers must not treat the events as merged.
+	// The chunk used its whole retry budget without committing. The caller then re-runs it
+	// one event at a time, so this counts conflict pressure rather than loss. What was
+	// actually lost is named in the caller's error.
+	db.stats.markExhausted()
+
+	log.InfoContext(ctx, "merge chunk exhausted its retries",
+		corelog.Int("attempts", db.txnAttempts()),
+		corelog.String("phase", phase),
+		corelog.String("docIDs", namedDocs(entries)),
+	)
 	return client.NewErrMaxTxnRetries(conflictErr)
 }
 
@@ -254,13 +298,15 @@ func (db *DB) executeMerge(ctx context.Context, col *collection, dagMerge event.
 	}
 	defer txn.Discard()
 
-	if err := db.mergeInTxn(ctx, col, dagMerge); err != nil {
+	isCreate, err := db.mergeInTxn(ctx, col, dagMerge)
+	if err != nil {
 		return err
 	}
 
 	if err := txn.Commit(); err != nil {
 		return err
 	}
+	db.stats.markCreateOrUpdate(isCreate)
 
 	// send a complete event so we can track merges in the integration tests
 	db.events.Publish(event.NewMessage(event.MergeCompleteName, event.MergeComplete{Merge: dagMerge}))
@@ -269,40 +315,47 @@ func (db *DB) executeMerge(ctx context.Context, col *collection, dagMerge event.
 
 // mergeInTxn executes the merge logic for a single event using the transaction already
 // present on ctx.  It does not commit; the caller is responsible for committing.
-func (db *DB) mergeInTxn(ctx context.Context, col *collection, dagMerge event.Merge) error {
+//
+// Reports whether the event created the document rather than updating one already held,
+// which the caller counts once the transaction commits.
+func (db *DB) mergeInTxn(ctx context.Context, col *collection, dagMerge event.Merge) (bool, error) {
 	key, exists, err := getDocHeadstoreKey(ctx, col, dagMerge.DocID)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	mt := newMergeTarget()
 	if exists {
 		mt, err = getHeadsAsMergeTarget(ctx, key)
 		if err != nil {
-			return NewErrGetMergeTargetHeads(err, dagMerge.DocID, string(key.Bytes()))
+			return false, NewErrGetMergeTargetHeads(err, dagMerge.DocID, string(key.Bytes()))
 		}
 	}
 
-	mp, err := db.newMergeProcessor(ctx, col, len(mt.heads) == 0)
+	// No local heads means the merge is creating the document rather than updating one
+	// that already exists here.
+	newDocCreateMode := len(mt.heads) == 0
+
+	mp, err := db.newMergeProcessor(ctx, col, newDocCreateMode)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	if err = mp.loadComposites(ctx, dagMerge.Cid, mt); err != nil {
-		return NewErrLoadComposites(err, dagMerge.Cid.String(), dagMerge.DocID)
+		return false, NewErrLoadComposites(err, dagMerge.Cid.String(), dagMerge.DocID)
 	}
 
 	if err = mp.mergeComposites(ctx); err != nil {
-		return NewErrMergeComposites(err, dagMerge.DocID)
+		return false, NewErrMergeComposites(err, dagMerge.DocID)
 	}
 
 	for docID, oldDoc := range mp.docIDs {
 		if err = syncIndexedDoc(ctx, docID, mp.col, oldDoc); err != nil {
-			return NewErrSyncIndexedDoc(err, docID.String())
+			return false, NewErrSyncIndexedDoc(err, docID.String())
 		}
 	}
 
-	return nil
+	return newDocCreateMode, nil
 }
 
 const maxConcurrentMerges = 32

--- a/internal/db/merge.go
+++ b/internal/db/merge.go
@@ -243,12 +243,12 @@ func (db *DB) mergeChunk(ctx context.Context, entries []mergeEntry) error {
 		creates = creates[:0]
 		var mergeErr error
 		for _, e := range entries {
-			isCreate, err := db.mergeInTxn(txnCtx, e.col, e.evt)
+			created, err := db.mergeInTxn(txnCtx, e.col, e.evt)
 			if err != nil {
 				mergeErr, phase = err, phaseRead
 				break
 			}
-			creates = append(creates, isCreate)
+			creates = append(creates, created)
 		}
 
 		if mergeErr != nil {
@@ -272,8 +272,8 @@ func (db *DB) mergeChunk(ctx context.Context, entries []mergeEntry) error {
 			return err
 		}
 
-		for _, isCreate := range creates {
-			db.stats.markCreateOrUpdate(isCreate)
+		for _, created := range creates {
+			db.stats.markCreateOrUpdate(created)
 		}
 		return nil
 	}
@@ -305,7 +305,7 @@ func (db *DB) executeMerge(ctx context.Context, col *collection, dagMerge event.
 	}
 	defer txn.Discard()
 
-	isCreate, err := db.mergeInTxn(ctx, col, dagMerge)
+	created, err := db.mergeInTxn(ctx, col, dagMerge)
 	if err != nil {
 		return err
 	}
@@ -313,7 +313,7 @@ func (db *DB) executeMerge(ctx context.Context, col *collection, dagMerge event.
 	if err := txn.Commit(); err != nil {
 		return err
 	}
-	db.stats.markCreateOrUpdate(isCreate)
+	db.stats.markCreateOrUpdate(created)
 
 	// send a complete event so we can track merges in the integration tests
 	db.events.Publish(event.NewMessage(event.MergeCompleteName, event.MergeComplete{Merge: dagMerge}))

--- a/internal/db/merge.go
+++ b/internal/db/merge.go
@@ -63,7 +63,7 @@ func (db *DB) Merge(ctx context.Context, evt event.Merge) error {
 	for i := 0; i < db.txnAttempts(); i++ {
 		err = db.executeMerge(ctx, col, evt)
 		if errors.Is(err, corekv.ErrTxnConflict) {
-			db.stats.chunkConflicts.Add(1)
+			db.stats.txnConflicts.Add(1)
 			continue
 		}
 		if err != nil {
@@ -253,7 +253,7 @@ func (db *DB) mergeChunk(ctx context.Context, entries []mergeEntry) error {
 			txn.Discard()
 			if errors.Is(mergeErr, corekv.ErrTxnConflict) {
 				conflictErr = mergeErr
-				db.stats.chunkConflicts.Add(1)
+				db.stats.txnConflicts.Add(1)
 				continue
 			}
 			return mergeErr
@@ -263,7 +263,7 @@ func (db *DB) mergeChunk(ctx context.Context, entries []mergeEntry) error {
 			txn.Discard()
 			if errors.Is(err, corekv.ErrTxnConflict) {
 				conflictErr = err
-				db.stats.chunkConflicts.Add(1)
+				db.stats.txnConflicts.Add(1)
 				phase = phaseCommit
 				continue
 			}
@@ -276,16 +276,17 @@ func (db *DB) mergeChunk(ctx context.Context, entries []mergeEntry) error {
 		return nil
 	}
 
-	// The chunk used its whole retry budget without committing. The caller then re-runs it
-	// one event at a time, so this counts conflict pressure rather than loss. What was
-	// actually lost is named in the caller's error.
-	db.stats.markExhausted()
+	// A chunk of one has no smaller write set for the caller to fall back to, so its exhaustion
+	// is a drop the caller records rather than a chunk to count here.
+	if len(entries) > 1 {
+		db.stats.chunkExhausted.Add(1)
 
-	log.InfoContext(ctx, "merge chunk exhausted its retries",
-		corelog.Int("attempts", db.txnAttempts()),
-		corelog.String("phase", phase),
-		corelog.String("docIDs", namedDocs(entries)),
-	)
+		log.InfoContext(ctx, "merge chunk exhausted its retries",
+			corelog.Int("attempts", db.txnAttempts()),
+			corelog.String("phase", phase),
+			corelog.String("docIDs", namedDocs(entries)),
+		)
+	}
 	return client.NewErrMaxTxnRetries(conflictErr)
 }
 

--- a/internal/db/merge_test.go
+++ b/internal/db/merge_test.go
@@ -13,6 +13,7 @@ package db
 import (
 	"context"
 	"fmt"
+	"math"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -275,28 +276,36 @@ func TestMerge_GenesisWithEmptyDocID_ResolvesDocIDAndFieldMappings(t *testing.T)
 // second writer committing inside the window between this transaction's first read and its commit.
 type conflictingStore struct {
 	corekv.TxnStore
-	armed *atomic.Bool
+
+	// failCommits is decremented unconditionally, so reading and spending the budget is one
+	// step. A spent budget goes negative, which reads the same as zero.
+	failCommits atomic.Int64
 }
 
-func (s conflictingStore) NewTxn(readonly bool) corekv.Txn {
+func (s *conflictingStore) NewTxn(readonly bool) corekv.Txn {
 	txn := s.TxnStore.NewTxn(readonly)
-	if readonly || !s.armed.Load() {
+	if readonly {
 		return txn
 	}
-	return conflictingTxn{Txn: txn}
+	return conflictingTxn{Txn: txn, store: s}
 }
 
 type conflictingTxn struct {
 	corekv.Txn
+	store *conflictingStore
 }
 
 func (t conflictingTxn) Commit() error {
-	return corekv.ErrTxnConflict
+	if t.store.failCommits.Add(-1) >= 0 {
+		return corekv.ErrTxnConflict
+	}
+	return t.Txn.Commit()
 }
 
 // newConflictingBadgerDB returns a database whose write commits can be made to conflict, and the
-// switch that does it. Setup runs with the switch off so collections can still be created.
-func newConflictingBadgerDB(ctx context.Context) (*DB, *atomic.Bool, error) {
+// store holding the budget that does it. Setup runs with an empty budget so collections can still
+// be created.
+func newConflictingBadgerDB(ctx context.Context) (*DB, *conflictingStore, error) {
 	rootstore, err := badger.NewDatastore("", badgerds.DefaultOptions("").WithInMemory(true))
 	if err != nil {
 		return nil, nil, err
@@ -305,12 +314,12 @@ func newConflictingBadgerDB(ctx context.Context) (*DB, *atomic.Bool, error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	armed := &atomic.Bool{}
-	db, err := newDB(ctx, conflictingStore{TxnStore: rootstore, armed: armed}, adminInfo)
+	store := &conflictingStore{TxnStore: rootstore}
+	db, err := newDB(ctx, store, adminInfo)
 	if err != nil {
 		return nil, nil, err
 	}
-	return db, armed, nil
+	return db, store, nil
 }
 
 // stageUnmergedDoc writes a document's blocks to the store without merging them, and returns the
@@ -350,7 +359,7 @@ func TestMerge_ExhaustedRetries_ReportsFailure(t *testing.T) {
 
 	docID, mergeEvent := stageUnmergedDoc(t, ctx, db, col)
 
-	conflict.Store(true)
+	conflict.failCommits.Store(math.MaxInt64)
 	err = db.Merge(ctx, mergeEvent)
 	require.Error(t, err, "a merge that committed nothing must not report success")
 	require.ErrorContains(t, err, "maximum transaction")
@@ -375,7 +384,7 @@ func TestMergeBatch_ExhaustedRetries_ReportsNothingMerged(t *testing.T) {
 
 	docID, mergeEvent := stageUnmergedDoc(t, ctx, db, col)
 
-	conflict.Store(true)
+	conflict.failCommits.Store(math.MaxInt64)
 	merged, err := db.MergeBatchWithTxn(ctx, []event.Merge{mergeEvent})
 	require.Error(t, err)
 	require.Equal(t, []bool{false}, merged, "an event that committed nothing must not be reported as merged")

--- a/internal/db/p2p/car.go
+++ b/internal/db/p2p/car.go
@@ -44,7 +44,7 @@ func (p *P2P) generateCAR(ctx context.Context, rootBlock *coreblock.Block) ([]by
 // carFailure records the reason a CAR could not be built and logs the first occurrence of
 // that reason, so a persistent failure shows up as a count rather than a line per call.
 func (p *P2P) carFailure(reason string, err error) error {
-	if p.carFailureReason.record(reason) {
+	if p.carFailureReason.recordFirst(reason) {
 		log.ErrorE("Failed to generate CAR", err, corelog.String("reason", reason))
 	}
 	return err
@@ -55,7 +55,7 @@ func (p *P2P) carFailure(reason string, err error) error {
 // claims them.
 func (p *P2P) carImportFailure(reason string, err error) error {
 	p.statCARImportFailed.Add(1)
-	if p.carImportFailureReason.record(reason) {
+	if p.carImportFailureReason.recordFirst(reason) {
 		log.ErrorE("Failed to import CAR", err, corelog.String("reason", reason))
 	}
 	return err

--- a/internal/db/p2p/car.go
+++ b/internal/db/p2p/car.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/sourcenetwork/corekv"
 	"github.com/sourcenetwork/corekv/blockstore"
+	"github.com/sourcenetwork/corelog"
 	"github.com/sourcenetwork/defradb/errors"
 	coreblock "github.com/sourcenetwork/defradb/internal/core/block"
 	"github.com/sourcenetwork/defradb/internal/datastore"
@@ -31,27 +32,66 @@ import (
 
 // generateCAR creates a CAR file containing the root block and all its linked blocks.
 func (p *P2P) generateCAR(ctx context.Context, rootBlock *coreblock.Block) ([]byte, error) {
+	data, err := p.buildCAR(ctx, rootBlock)
+	if err != nil {
+		p.statCARFailed.Add(1)
+		return nil, err
+	}
+	p.statCARBuilt.Add(1)
+	return data, nil
+}
+
+// carFailure records the reason a CAR could not be built and logs the first occurrence of
+// that reason, so a persistent failure shows up as a count rather than a line per call.
+func (p *P2P) carFailure(reason string, err error) error {
+	if p.carFailureReason.record(reason) {
+		log.ErrorE("Failed to generate CAR", err, corelog.String("reason", reason))
+	}
+	return err
+}
+
+// carImportFailure records an abandoned import: how it failed and how many blocks it had
+// already written. Those blocks sit in the store owned by no document until a later merge
+// claims them.
+func (p *P2P) carImportFailure(reason string, err error) error {
+	p.statCARImportFailed.Add(1)
+	if p.carImportFailureReason.record(reason) {
+		log.ErrorE("Failed to import CAR", err, corelog.String("reason", reason))
+	}
+	return err
+}
+
+// buildCAR walks the DAG rooted at rootBlock and serialises every block it reaches.
+//
+// The walk skips links it cannot load rather than failing, so a CAR can be short of the
+// full DAG. missingLinks counts those skips and a CAR holding only the root block is
+// counted separately: its receiver has nothing to import and falls back to a per-link
+// BitSwap walk.
+func (p *P2P) buildCAR(ctx context.Context, rootBlock *coreblock.Block) ([]byte, error) {
 	txn := p.db.Rootstore().NewTxn(true)
 	defer txn.Discard()
 	txnCtx := corekv.SetCtxTxn(ctx, txn)
 
 	rootLink, err := rootBlock.GenerateLink()
 	if err != nil {
-		return nil, err
+		return nil, p.carFailure(reasonRootLink, err)
 	}
 
 	bstore := datastore.BlockstoreFrom(p.db.Rootstore(), immutable.None[int]())
 	linkSystem := makeLinkSystem(blockstore.NewIPLDStore(bstore))
 
 	blockCIDs := make(map[string]struct{})
-	if err := p.collectDAGBlocks(txnCtx, &linkSystem, rootLink.Cid, blockCIDs); err != nil {
-		return nil, err
+	var missingLinks int64
+	if err := p.collectDAGBlocks(txnCtx, &linkSystem, rootLink.Cid, blockCIDs, &missingLinks); err != nil {
+		return nil, p.carFailure(reasonWalk, err)
 	}
+
+	p.statCARMissing.Add(missingLinks)
 
 	var buf bytes.Buffer
 	carWriter, err := storage.NewWritable(&buf, []cid.Cid{rootLink.Cid}, car.WriteAsCarV1(true))
 	if err != nil {
-		return nil, err
+		return nil, p.carFailure(reasonCARWriter, err)
 	}
 
 	encStore := datastore.EncstoreFrom(p.db.Rootstore())
@@ -59,7 +99,7 @@ func (p *P2P) generateCAR(ctx context.Context, rootBlock *coreblock.Block) ([]by
 	for cidStr := range blockCIDs {
 		c, err := cid.Decode(cidStr)
 		if err != nil {
-			return nil, err
+			return nil, p.carFailure(reasonBlockRead, err)
 		}
 
 		var blockBytes []byte
@@ -67,7 +107,7 @@ func (p *P2P) generateCAR(ctx context.Context, rootBlock *coreblock.Block) ([]by
 		if err != nil {
 			encBlock, encErr := encStore.Get(txnCtx, c)
 			if encErr != nil {
-				return nil, err
+				return nil, p.carFailure(reasonBlockRead, err)
 			}
 			blockBytes = encBlock.RawData()
 		} else {
@@ -75,7 +115,7 @@ func (p *P2P) generateCAR(ctx context.Context, rootBlock *coreblock.Block) ([]by
 		}
 
 		if err := carWriter.Put(txnCtx, c.KeyString(), blockBytes); err != nil {
-			return nil, err
+			return nil, p.carFailure(reasonCARPut, err)
 		}
 	}
 
@@ -83,11 +123,13 @@ func (p *P2P) generateCAR(ctx context.Context, rootBlock *coreblock.Block) ([]by
 }
 
 // collectDAGBlocks recursively collects all block CIDs in the DAG by following Links.
+// missing is incremented for every link that could not be loaded and was skipped.
 func (p *P2P) collectDAGBlocks(
 	ctx context.Context,
 	linkSystem *linking.LinkSystem,
 	blockCID cid.Cid,
 	visited map[string]struct{},
+	missing *int64,
 ) error {
 	cidStr := blockCID.String()
 	if _, seen := visited[cidStr]; seen {
@@ -103,6 +145,7 @@ func (p *P2P) collectDAGBlocks(
 	if err != nil {
 		// Block may have been pruned locally; it was already pushed to replicators before
 		// pruning so they already hold it. Skip rather than aborting the CAR.
+		*missing++
 		return nil
 	}
 
@@ -122,7 +165,7 @@ func (p *P2P) collectDAGBlocks(
 	}
 
 	for _, dagLink := range block.Links {
-		if err := p.collectDAGBlocks(ctx, linkSystem, dagLink.Link.Cid, visited); err != nil {
+		if err := p.collectDAGBlocks(ctx, linkSystem, dagLink.Link.Cid, visited, missing); err != nil {
 			return err
 		}
 	}
@@ -160,14 +203,18 @@ func peekCARRootBlock(carData []byte) (*coreblock.Block, error) {
 // importCAR extracts all blocks from a CAR byte slice and stores them in the blockstore.
 // Returns the root block for further processing.
 func (p *P2P) importCAR(ctx context.Context, carData []byte) (*coreblock.Block, error) {
+	// This is the path every inbound document takes, so it is where blocks actually enter
+	// the store. The generateCAR counters describe the outbound side and say nothing about it.
+	p.statCARImports.Add(1)
+
 	reader, err := car.NewBlockReader(bytes.NewReader(carData))
 	if err != nil {
-		return nil, err
+		return nil, p.carImportFailure(reasonReader, err)
 	}
 
 	roots := reader.Roots
 	if len(roots) == 0 {
-		return nil, ErrEmptyCARRoots
+		return nil, p.carImportFailure(reasonNoRoots, ErrEmptyCARRoots)
 	}
 
 	// Content-addressed field blocks recur across documents that share a field value, so a
@@ -183,7 +230,7 @@ func (p *P2P) importCAR(ctx context.Context, carData []byte) (*coreblock.Block, 
 			break
 		}
 		if err != nil {
-			return nil, err
+			return nil, p.carImportFailure(reasonNext, err)
 		}
 
 		decodedBlock, err := coreblock.GetFromBytes(carBlock.RawData())
@@ -191,18 +238,18 @@ func (p *P2P) importCAR(ctx context.Context, carData []byte) (*coreblock.Block, 
 			_, encErr := coreblock.GetEncryptionBlockFromBytes(carBlock.RawData())
 			if encErr == nil {
 				if putErr := encStore.Put(ctx, carBlock); putErr != nil {
-					return nil, putErr
+					return nil, p.carImportFailure(reasonCARPut, putErr)
 				}
 			} else {
 				if putErr := bstore.Put(ctx, carBlock); putErr != nil {
-					return nil, putErr
+					return nil, p.carImportFailure(reasonCARPut, putErr)
 				}
 			}
 			continue
 		}
 
 		if putErr := bstore.Put(ctx, carBlock); putErr != nil {
-			return nil, putErr
+			return nil, p.carImportFailure(reasonCARPut, putErr)
 		}
 
 		if carBlock.Cid().Equals(roots[0]) {
@@ -211,7 +258,7 @@ func (p *P2P) importCAR(ctx context.Context, carData []byte) (*coreblock.Block, 
 	}
 
 	if rootBlock == nil {
-		return nil, ErrCARRootBlockNotFound
+		return nil, p.carImportFailure(reasonNoRootBlock, ErrCARRootBlockNotFound)
 	}
 
 	return rootBlock, nil

--- a/internal/db/p2p/car.go
+++ b/internal/db/p2p/car.go
@@ -85,8 +85,8 @@ func (p *P2P) buildCAR(ctx context.Context, rootBlock *coreblock.Block) ([]byte,
 	linkSystem := makeLinkSystem(blockstore.NewIPLDStore(bstore))
 
 	blockCIDs := make(map[string]struct{})
-	var missingLinks int64
-	if err := p.collectDAGBlocks(txnCtx, &linkSystem, rootLink.Cid, blockCIDs, &missingLinks); err != nil {
+	missingLinks, err := p.collectDAGBlocks(txnCtx, &linkSystem, rootLink.Cid, blockCIDs)
+	if err != nil {
 		p.carFailure(reasonWalk, err)
 		return nil, err
 	}
@@ -130,19 +130,17 @@ func (p *P2P) buildCAR(ctx context.Context, rootBlock *coreblock.Block) ([]byte,
 	return buf.Bytes(), nil
 }
 
-// collectDAGBlocks recursively collects block CIDs by following Links.
-// missing is incremented for every link whose block could not be loaded. The CID stays in the
-// write set either way, so the block is still read when the CAR is written.
+// collectDAGBlocks recursively collects block CIDs by following Links, and returns how many
+// links did not load.
 func (p *P2P) collectDAGBlocks(
 	ctx context.Context,
 	linkSystem *linking.LinkSystem,
 	blockCID cid.Cid,
 	visited map[string]struct{},
-	missing *int64,
-) error {
+) (int64, error) {
 	cidStr := blockCID.String()
 	if _, seen := visited[cidStr]; seen {
-		return nil
+		return 0, nil
 	}
 	visited[cidStr] = struct{}{}
 
@@ -155,13 +153,12 @@ func (p *P2P) collectDAGBlocks(
 		// A block that will not load leaves its links unknown, but its CID is already in the
 		// write set, so the write loop still has to read it: if it cannot, the whole CAR is
 		// abandoned.
-		*missing++
-		return nil
+		return 1, nil
 	}
 
 	block, err := coreblock.GetFromNode(node)
 	if err != nil {
-		return err
+		return 0, err
 	}
 
 	// Include Signature block CID if present.
@@ -174,13 +171,16 @@ func (p *P2P) collectDAGBlocks(
 		visited[block.Encryption.Cid.String()] = struct{}{}
 	}
 
+	var missing int64
 	for _, dagLink := range block.Links {
-		if err := p.collectDAGBlocks(ctx, linkSystem, dagLink.Link.Cid, visited, missing); err != nil {
-			return err
+		linkMissing, err := p.collectDAGBlocks(ctx, linkSystem, dagLink.Link.Cid, visited)
+		missing += linkMissing
+		if err != nil {
+			return missing, err
 		}
 	}
 
-	return nil
+	return missing, nil
 }
 
 // peekCARRootBlock reads only the root block from a CAR byte slice and decodes it

--- a/internal/db/p2p/car.go
+++ b/internal/db/p2p/car.go
@@ -44,17 +44,16 @@ func (p *P2P) generateCAR(ctx context.Context, rootBlock *coreblock.Block) ([]by
 
 // carFailure records the reason a CAR could not be built and logs the first occurrence of
 // that reason, so a persistent failure shows up as a count rather than a line per call.
-func (p *P2P) carFailure(reason string, err error) error {
+func (p *P2P) carFailure(reason string, err error) {
 	if p.carFailureReason.recordFirst(reason) {
 		log.ErrorE("Failed to generate CAR", err, corelog.String("reason", reason))
 	}
-	return err
 }
 
 // carImportFailure records an abandoned import: how it failed and how many blocks it had
 // already written. Those blocks sit in the store owned by no document until a later merge
 // claims them.
-func (p *P2P) carImportFailure(reason string, written int64, err error) error {
+func (p *P2P) carImportFailure(reason string, written int64, err error) {
 	p.statCARImportFailed.Add(1)
 	p.statCARImportOrphanBlocks.Add(written)
 	if p.carImportFailureReason.recordFirst(reason) {
@@ -62,7 +61,6 @@ func (p *P2P) carImportFailure(reason string, written int64, err error) error {
 			corelog.String("reason", reason),
 			corelog.Int64("blocksWritten", written))
 	}
-	return err
 }
 
 // buildCAR serialises the root block and the blocks it links, following Links only. Heads are
@@ -79,7 +77,8 @@ func (p *P2P) buildCAR(ctx context.Context, rootBlock *coreblock.Block) ([]byte,
 
 	rootLink, err := rootBlock.GenerateLink()
 	if err != nil {
-		return nil, p.carFailure(reasonRootLink, err)
+		p.carFailure(reasonRootLink, err)
+		return nil, err
 	}
 
 	bstore := datastore.BlockstoreFrom(p.db.Rootstore(), immutable.None[int]())
@@ -88,13 +87,15 @@ func (p *P2P) buildCAR(ctx context.Context, rootBlock *coreblock.Block) ([]byte,
 	blockCIDs := make(map[string]struct{})
 	var missingLinks int64
 	if err := p.collectDAGBlocks(txnCtx, &linkSystem, rootLink.Cid, blockCIDs, &missingLinks); err != nil {
-		return nil, p.carFailure(reasonWalk, err)
+		p.carFailure(reasonWalk, err)
+		return nil, err
 	}
 
 	var buf bytes.Buffer
 	carWriter, err := storage.NewWritable(&buf, []cid.Cid{rootLink.Cid}, car.WriteAsCarV1(true))
 	if err != nil {
-		return nil, p.carFailure(reasonCARWriter, err)
+		p.carFailure(reasonCARWriter, err)
+		return nil, err
 	}
 
 	encStore := datastore.EncstoreFrom(p.db.Rootstore())
@@ -102,7 +103,8 @@ func (p *P2P) buildCAR(ctx context.Context, rootBlock *coreblock.Block) ([]byte,
 	for cidStr := range blockCIDs {
 		c, err := cid.Decode(cidStr)
 		if err != nil {
-			return nil, p.carFailure(reasonBlockRead, err)
+			p.carFailure(reasonBlockRead, err)
+			return nil, err
 		}
 
 		var blockBytes []byte
@@ -110,7 +112,8 @@ func (p *P2P) buildCAR(ctx context.Context, rootBlock *coreblock.Block) ([]byte,
 		if err != nil {
 			encBlock, encErr := encStore.Get(txnCtx, c)
 			if encErr != nil {
-				return nil, p.carFailure(reasonBlockRead, err)
+				p.carFailure(reasonBlockRead, err)
+				return nil, err
 			}
 			blockBytes = encBlock.RawData()
 		} else {
@@ -118,7 +121,8 @@ func (p *P2P) buildCAR(ctx context.Context, rootBlock *coreblock.Block) ([]byte,
 		}
 
 		if err := carWriter.Put(txnCtx, c.KeyString(), blockBytes); err != nil {
-			return nil, p.carFailure(reasonCARPut, err)
+			p.carFailure(reasonCARPut, err)
+			return nil, err
 		}
 	}
 
@@ -215,12 +219,14 @@ func (p *P2P) importCAR(ctx context.Context, carData []byte) (*coreblock.Block, 
 
 	reader, err := car.NewBlockReader(bytes.NewReader(carData))
 	if err != nil {
-		return nil, p.carImportFailure(reasonReader, 0, err)
+		p.carImportFailure(reasonReader, 0, err)
+		return nil, err
 	}
 
 	roots := reader.Roots
 	if len(roots) == 0 {
-		return nil, p.carImportFailure(reasonNoRoots, 0, ErrEmptyCARRoots)
+		p.carImportFailure(reasonNoRoots, 0, ErrEmptyCARRoots)
+		return nil, ErrEmptyCARRoots
 	}
 
 	// Content-addressed field blocks recur across documents that share a field value, so a
@@ -238,7 +244,8 @@ func (p *P2P) importCAR(ctx context.Context, carData []byte) (*coreblock.Block, 
 			break
 		}
 		if err != nil {
-			return nil, p.carImportFailure(reasonNext, written, err)
+			p.carImportFailure(reasonNext, written, err)
+			return nil, err
 		}
 
 		decodedBlock, err := coreblock.GetFromBytes(carBlock.RawData())
@@ -249,7 +256,8 @@ func (p *P2P) importCAR(ctx context.Context, carData []byte) (*coreblock.Block, 
 			}
 			added, putErr := addBlock(ctx, store, carBlock)
 			if putErr != nil {
-				return nil, p.carImportFailure(reasonCARPut, written, putErr)
+				p.carImportFailure(reasonCARPut, written, putErr)
+				return nil, putErr
 			}
 			if added {
 				written++
@@ -259,7 +267,8 @@ func (p *P2P) importCAR(ctx context.Context, carData []byte) (*coreblock.Block, 
 
 		added, putErr := addBlock(ctx, bstore, carBlock)
 		if putErr != nil {
-			return nil, p.carImportFailure(reasonCARPut, written, putErr)
+			p.carImportFailure(reasonCARPut, written, putErr)
+			return nil, putErr
 		}
 		if added {
 			written++
@@ -271,7 +280,8 @@ func (p *P2P) importCAR(ctx context.Context, carData []byte) (*coreblock.Block, 
 	}
 
 	if rootBlock == nil {
-		return nil, p.carImportFailure(reasonNoRootBlock, written, ErrCARRootBlockNotFound)
+		p.carImportFailure(reasonNoRootBlock, written, ErrCARRootBlockNotFound)
+		return nil, ErrCARRootBlockNotFound
 	}
 
 	return rootBlock, nil

--- a/internal/db/p2p/car.go
+++ b/internal/db/p2p/car.go
@@ -209,8 +209,8 @@ func peekCARRootBlock(carData []byte) (*coreblock.Block, error) {
 // importCAR extracts all blocks from a CAR byte slice and stores them in the blockstore.
 // Returns the root block for further processing.
 func (p *P2P) importCAR(ctx context.Context, carData []byte) (*coreblock.Block, error) {
-	// This is the path every inbound document takes, so it is where blocks actually enter
-	// the store. The generateCAR counters describe the outbound side and say nothing about it.
+	// An arrival carrying a CAR takes this path, one without it takes syncDAG. The generateCAR
+	// counters describe what this node sends, not what it receives.
 	p.statCARImports.Add(1)
 
 	reader, err := car.NewBlockReader(bytes.NewReader(carData))

--- a/internal/db/p2p/car.go
+++ b/internal/db/p2p/car.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"io"
 
+	blocks "github.com/ipfs/go-block-format"
 	"github.com/ipfs/go-cid"
 	car "github.com/ipld/go-car/v2"
 	"github.com/ipld/go-car/v2/storage"
@@ -53,10 +54,13 @@ func (p *P2P) carFailure(reason string, err error) error {
 // carImportFailure records an abandoned import: how it failed and how many blocks it had
 // already written. Those blocks sit in the store owned by no document until a later merge
 // claims them.
-func (p *P2P) carImportFailure(reason string, err error) error {
+func (p *P2P) carImportFailure(reason string, written int64, err error) error {
 	p.statCARImportFailed.Add(1)
+	p.statCARImportOrphanBlocks.Add(written)
 	if p.carImportFailureReason.recordFirst(reason) {
-		log.ErrorE("Failed to import CAR", err, corelog.String("reason", reason))
+		log.ErrorE("Failed to import CAR", err,
+			corelog.String("reason", reason),
+			corelog.Int64("blocksWritten", written))
 	}
 	return err
 }
@@ -209,12 +213,12 @@ func (p *P2P) importCAR(ctx context.Context, carData []byte) (*coreblock.Block, 
 
 	reader, err := car.NewBlockReader(bytes.NewReader(carData))
 	if err != nil {
-		return nil, p.carImportFailure(reasonReader, err)
+		return nil, p.carImportFailure(reasonReader, 0, err)
 	}
 
 	roots := reader.Roots
 	if len(roots) == 0 {
-		return nil, p.carImportFailure(reasonNoRoots, ErrEmptyCARRoots)
+		return nil, p.carImportFailure(reasonNoRoots, 0, ErrEmptyCARRoots)
 	}
 
 	// Content-addressed field blocks recur across documents that share a field value, so a
@@ -224,32 +228,39 @@ func (p *P2P) importCAR(ctx context.Context, carData []byte) (*coreblock.Block, 
 	encStore := datastore.EncstoreFrom(p.db.Rootstore())
 	var rootBlock *coreblock.Block
 
+	var written int64
+
 	for {
 		carBlock, err := reader.Next()
 		if errors.Is(err, io.EOF) {
 			break
 		}
 		if err != nil {
-			return nil, p.carImportFailure(reasonNext, err)
+			return nil, p.carImportFailure(reasonNext, written, err)
 		}
 
 		decodedBlock, err := coreblock.GetFromBytes(carBlock.RawData())
 		if err != nil {
-			_, encErr := coreblock.GetEncryptionBlockFromBytes(carBlock.RawData())
-			if encErr == nil {
-				if putErr := encStore.Put(ctx, carBlock); putErr != nil {
-					return nil, p.carImportFailure(reasonCARPut, putErr)
-				}
-			} else {
-				if putErr := bstore.Put(ctx, carBlock); putErr != nil {
-					return nil, p.carImportFailure(reasonCARPut, putErr)
-				}
+			store := bstore
+			if _, encErr := coreblock.GetEncryptionBlockFromBytes(carBlock.RawData()); encErr == nil {
+				store = encStore
+			}
+			added, putErr := addBlock(ctx, store, carBlock)
+			if putErr != nil {
+				return nil, p.carImportFailure(reasonCARPut, written, putErr)
+			}
+			if added {
+				written++
 			}
 			continue
 		}
 
-		if putErr := bstore.Put(ctx, carBlock); putErr != nil {
-			return nil, p.carImportFailure(reasonCARPut, putErr)
+		added, putErr := addBlock(ctx, bstore, carBlock)
+		if putErr != nil {
+			return nil, p.carImportFailure(reasonCARPut, written, putErr)
+		}
+		if added {
+			written++
 		}
 
 		if carBlock.Cid().Equals(roots[0]) {
@@ -258,8 +269,22 @@ func (p *P2P) importCAR(ctx context.Context, carData []byte) (*coreblock.Block, 
 	}
 
 	if rootBlock == nil {
-		return nil, p.carImportFailure(reasonNoRootBlock, ErrCARRootBlockNotFound)
+		return nil, p.carImportFailure(reasonNoRootBlock, written, ErrCARRootBlockNotFound)
 	}
 
 	return rootBlock, nil
+}
+
+// addBlock stores the block unless the store already holds it, reporting whether it was added.
+// The blockstores return nil for a block they already have, so Put alone cannot report that.
+//
+// A Has that fails is treated as not held, as Put does.
+func addBlock(ctx context.Context, store datastore.Blockstore, block blocks.Block) (bool, error) {
+	if held, err := store.Has(ctx, block.Cid()); err == nil && held {
+		return false, nil
+	}
+	if err := store.Put(ctx, block); err != nil {
+		return false, err
+	}
+	return true, nil
 }

--- a/internal/db/p2p/car.go
+++ b/internal/db/p2p/car.go
@@ -65,12 +65,13 @@ func (p *P2P) carImportFailure(reason string, written int64, err error) error {
 	return err
 }
 
-// buildCAR walks the DAG rooted at rootBlock and serialises every block it reaches.
+// buildCAR serialises the root block and the blocks it links, following Links only. Heads are
+// not followed, so a CAR carries one commit and none of the document's history.
 //
-// The walk skips links it cannot load rather than failing, so a CAR can be short of the
-// full DAG. missingLinks counts those skips and a CAR holding only the root block is
-// counted separately: its receiver has nothing to import and falls back to a per-link
-// BitSwap walk.
+// A link that will not load is not followed, and if its block cannot be read either the whole
+// CAR is abandoned: a receiver given a CAR imports it instead of walking the DAG, so a block
+// absent from the CAR is one it never fetches. missingLinks is counted only for a CAR the
+// build returns.
 func (p *P2P) buildCAR(ctx context.Context, rootBlock *coreblock.Block) ([]byte, error) {
 	txn := p.db.Rootstore().NewTxn(true)
 	defer txn.Discard()
@@ -89,8 +90,6 @@ func (p *P2P) buildCAR(ctx context.Context, rootBlock *coreblock.Block) ([]byte,
 	if err := p.collectDAGBlocks(txnCtx, &linkSystem, rootLink.Cid, blockCIDs, &missingLinks); err != nil {
 		return nil, p.carFailure(reasonWalk, err)
 	}
-
-	p.statCARMissing.Add(missingLinks)
 
 	var buf bytes.Buffer
 	carWriter, err := storage.NewWritable(&buf, []cid.Cid{rootLink.Cid}, car.WriteAsCarV1(true))
@@ -123,11 +122,13 @@ func (p *P2P) buildCAR(ctx context.Context, rootBlock *coreblock.Block) ([]byte,
 		}
 	}
 
+	p.statCARMissing.Add(missingLinks)
 	return buf.Bytes(), nil
 }
 
-// collectDAGBlocks recursively collects all block CIDs in the DAG by following Links.
-// missing is incremented for every link that could not be loaded and was skipped.
+// collectDAGBlocks recursively collects block CIDs by following Links.
+// missing is incremented for every link whose block could not be loaded. The CID stays in the
+// write set either way, so the block is still read when the CAR is written.
 func (p *P2P) collectDAGBlocks(
 	ctx context.Context,
 	linkSystem *linking.LinkSystem,
@@ -147,8 +148,9 @@ func (p *P2P) collectDAGBlocks(
 		coreblock.BlockSchemaPrototype,
 	)
 	if err != nil {
-		// Block may have been pruned locally; it was already pushed to replicators before
-		// pruning so they already hold it. Skip rather than aborting the CAR.
+		// A block that will not load leaves its links unknown, but its CID is already in the
+		// write set, so the write loop still has to read it: if it cannot, the whole CAR is
+		// abandoned.
 		*missing++
 		return nil
 	}

--- a/internal/db/p2p/car_build_test.go
+++ b/internal/db/p2p/car_build_test.go
@@ -36,7 +36,7 @@ func carFixture(t *testing.T, held ...blocks.Block) *P2P {
 	for _, block := range held {
 		require.NoError(t, bstore.Put(ctx, block))
 	}
-	return &P2P{db: rootstoreDB{store: rootstore}}
+	return withReasonMaps(&P2P{db: rootstoreDB{store: rootstore}})
 }
 
 // compositeLinking returns a composite block linking to children, in the decoded form the CAR

--- a/internal/db/p2p/car_build_test.go
+++ b/internal/db/p2p/car_build_test.go
@@ -1,0 +1,102 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package p2p
+
+import (
+	"context"
+	"testing"
+
+	blocks "github.com/ipfs/go-block-format"
+	"github.com/ipfs/go-cid"
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcenetwork/corekv/memory"
+	"github.com/sourcenetwork/immutable"
+
+	coreblock "github.com/sourcenetwork/defradb/internal/core/block"
+	"github.com/sourcenetwork/defradb/internal/core/crdt"
+	"github.com/sourcenetwork/defradb/internal/datastore"
+)
+
+// carFixture returns a P2P whose store holds the given blocks and nothing else.
+func carFixture(t *testing.T, held ...blocks.Block) *P2P {
+	t.Helper()
+	ctx := context.Background()
+	rootstore := memory.NewDatastore(ctx)
+	bstore := datastore.BlockstoreFrom(rootstore, immutable.None[int]())
+	for _, block := range held {
+		require.NoError(t, bstore.Put(ctx, block))
+	}
+	return &P2P{db: rootstoreDB{store: rootstore}}
+}
+
+// compositeLinking returns a composite block linking to children, in the decoded form the CAR
+// build takes and the encoded form the store holds.
+func compositeLinking(t *testing.T, children ...cid.Cid) (*coreblock.Block, blocks.Block) {
+	t.Helper()
+	core := &coreblock.Block{
+		Delta: crdt.CRDT{DocCompositeDelta: &crdt.DocCompositeDelta{Priority: 1}},
+	}
+	for i, child := range children {
+		name := string(rune('a' + i))
+		core.Links = append(core.Links, coreblock.NewDAGLink(name, cidlink.Link{Cid: child}))
+	}
+	raw, err := core.Marshal()
+	require.NoError(t, err)
+	link, err := core.GenerateLink()
+	require.NoError(t, err)
+	encoded, err := blocks.NewBlockWithCid(raw, link.Cid)
+	require.NoError(t, err)
+	return core, encoded
+}
+
+// undecodableBlock returns a block whose bytes are not a Block encoding, so the store reads it
+// back but the walk cannot decode it.
+func undecodableBlock(t *testing.T, raw string) blocks.Block {
+	t.Helper()
+	blockCID, err := coreblock.GetLinkPrototype().Sum([]byte(raw))
+	require.NoError(t, err)
+	block, err := blocks.NewBlockWithCid([]byte(raw), blockCID)
+	require.NoError(t, err)
+	return block
+}
+
+// A link the walk could not load is usually a block the write loop cannot read either, so the
+// CAR is abandoned. Counting the link then reports a gap in a CAR nobody received.
+func TestGenerateCAR_CountsNoMissingLinkWhenTheCARIsAbandoned(t *testing.T) {
+	absent := compositeBlock(t, 2)
+	root, encoded := compositeLinking(t, absent.Cid())
+	p := carFixture(t, encoded)
+
+	_, err := p.generateCAR(context.Background(), root)
+	require.Error(t, err)
+	require.Equal(t, map[string]int64{reasonBlockRead: 1}, reasonMap(p.carFailureReason.drain()))
+
+	require.Equal(t, int64(1), p.statCARFailed.Load())
+	require.Zero(t, p.statCARBuilt.Load())
+	require.Zero(t, p.statCARMissing.Load())
+}
+
+// A block the store reads but the walk cannot decode ships in the CAR, and the counter records
+// one per link the walk could not follow.
+func TestGenerateCAR_CountsEveryMissingLinkWhenTheCARShips(t *testing.T) {
+	first := undecodableBlock(t, "not a block")
+	second := undecodableBlock(t, "also not a block")
+	root, encoded := compositeLinking(t, first.Cid(), second.Cid())
+	p := carFixture(t, encoded, first, second)
+
+	_, err := p.generateCAR(context.Background(), root)
+	require.NoError(t, err)
+
+	require.Equal(t, int64(1), p.statCARBuilt.Load())
+	require.Equal(t, int64(2), p.statCARMissing.Load())
+}

--- a/internal/db/p2p/car_import_test.go
+++ b/internal/db/p2p/car_import_test.go
@@ -40,15 +40,31 @@ type rootstoreDB struct {
 
 func (d rootstoreDB) Rootstore() corekv.TxnStore { return d.store }
 
-// carWith returns a single-block CAR rooted at that block.
-func carWith(t *testing.T, block blocks.Block) []byte {
+// carWith returns a CAR declaring root as its root and carrying the given blocks, which need
+// not include the root.
+func carWith(t *testing.T, root cid.Cid, held ...blocks.Block) []byte {
 	t.Helper()
 	var buf bytes.Buffer
-	w, err := storage.NewWritable(&buf, []cid.Cid{block.Cid()}, car.WriteAsCarV1(true))
+	w, err := storage.NewWritable(&buf, []cid.Cid{root}, car.WriteAsCarV1(true))
 	require.NoError(t, err)
-	require.NoError(t, w.Put(context.Background(), block.Cid().KeyString(), block.RawData()))
+	for _, block := range held {
+		require.NoError(t, w.Put(context.Background(), block.Cid().KeyString(), block.RawData()))
+	}
 	require.NoError(t, w.Finalize())
 	return buf.Bytes()
+}
+
+// compositeBlock returns an encoded composite block, distinct per priority.
+func compositeBlock(t *testing.T, priority uint64) blocks.Block {
+	t.Helper()
+	core := coreblock.Block{Delta: crdt.CRDT{DocCompositeDelta: &crdt.DocCompositeDelta{Priority: priority}}}
+	raw, err := core.Marshal()
+	require.NoError(t, err)
+	link, err := coreblock.GetLinkFromNode(core.GenerateNode())
+	require.NoError(t, err)
+	block, err := blocks.NewBlockWithCid(raw, link.Cid)
+	require.NoError(t, err)
+	return block
 }
 
 // A CAR carries blocks the node already holds, because field blocks are content-addressed
@@ -75,11 +91,48 @@ func TestImportCAR_DoesNotUnmergeABlockTheNodeAlreadyHas(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, merged, "precondition")
 
-	imported, err := p.importCAR(ctx, carWith(t, block))
+	imported, err := p.importCAR(ctx, carWith(t, block.Cid(), block))
 	require.NoError(t, err)
 	require.NotNil(t, imported)
 
 	merged, err = bstore.IsMerged(ctx, block.Cid())
 	require.NoError(t, err)
 	require.True(t, merged, "importing a block the node already holds must not unmerge it")
+}
+
+// An abandoned import leaves behind the blocks it added. Blocks the node already held are not
+// among them, and a CAR routinely carries those.
+func TestImportCAR_CountsTheBlocksAnAbandonedImportWrote(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		alreadyHeld int
+		wantOrphans int64
+	}{
+		{name: "the node holds none of them", alreadyHeld: 0, wantOrphans: 2},
+		{name: "the node holds one of them", alreadyHeld: 1, wantOrphans: 1},
+		{name: "the node holds all of them", alreadyHeld: 2, wantOrphans: 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			rootstore := memory.NewDatastore(ctx)
+			p := &P2P{db: rootstoreDB{store: rootstore}}
+
+			carried := []blocks.Block{compositeBlock(t, 1), compositeBlock(t, 2)}
+
+			bstore := datastore.BlockstoreFrom(rootstore, immutable.None[int]())
+			for _, block := range carried[:tc.alreadyHeld] {
+				require.NoError(t, bstore.Put(ctx, block))
+				require.NoError(t, bstore.MarkAsMerged(ctx, block.Cid()))
+			}
+
+			// A root the CAR does not carry, so the import stores what it can and then fails.
+			absentRoot := compositeBlock(t, 3).Cid()
+
+			_, err := p.importCAR(ctx, carWith(t, absentRoot, carried...))
+			require.ErrorIs(t, err, ErrCARRootBlockNotFound)
+
+			require.Equal(t, int64(1), p.statCARImportFailed.Load())
+			require.Equal(t, tc.wantOrphans, p.statCARImportOrphanBlocks.Load())
+		})
+	}
 }

--- a/internal/db/p2p/car_import_test.go
+++ b/internal/db/p2p/car_import_test.go
@@ -73,7 +73,7 @@ func compositeBlock(t *testing.T, priority uint64) blocks.Block {
 func TestImportCAR_DoesNotUnmergeABlockTheNodeAlreadyHas(t *testing.T) {
 	ctx := context.Background()
 	rootstore := memory.NewDatastore(ctx)
-	p := &P2P{db: rootstoreDB{store: rootstore}}
+	p := withReasonMaps(&P2P{db: rootstoreDB{store: rootstore}})
 
 	coreBlock := coreblock.Block{Delta: crdt.CRDT{DocCompositeDelta: &crdt.DocCompositeDelta{Status: 1}}}
 	raw, err := coreBlock.Marshal()
@@ -115,7 +115,7 @@ func TestImportCAR_CountsTheBlocksAnAbandonedImportWrote(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
 			rootstore := memory.NewDatastore(ctx)
-			p := &P2P{db: rootstoreDB{store: rootstore}}
+			p := withReasonMaps(&P2P{db: rootstoreDB{store: rootstore}})
 
 			carried := []blocks.Block{compositeBlock(t, 1), compositeBlock(t, 2)}
 

--- a/internal/db/p2p/dropstats_test.go
+++ b/internal/db/p2p/dropstats_test.go
@@ -16,8 +16,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// reasonMap renders drained reasons as a map, which is the shape an assertion reads.
+func reasonMap(counts []reasonCount) map[string]int64 {
+	out := map[string]int64{}
+	for _, rc := range counts {
+		out[rc.reason] = rc.count
+	}
+	return out
+}
+
 // A drop is a document that was meant to be stored and was not; a skip is one deliberately
-// not merged. Counting them together would report policy decisions as data loss.
+// not merged. Reporting them on one line would read policy decisions as data loss.
 func TestDropAndSkipAreCountedApart(t *testing.T) {
 	p := &P2P{}
 
@@ -25,17 +34,13 @@ func TestDropAndSkipAreCountedApart(t *testing.T) {
 	p.dropDoc("importCAR")
 	p.dropDoc("syncDAG")
 	p.skipDoc("alreadyMerged")
+	p.skipDoc("filtered")
 
 	require.Equal(t, int64(3), p.statDroppedDocs.Load(), "drops")
-	require.Equal(t, int64(1), p.statSkippedDocs.Load(), "skips")
+	require.Equal(t, int64(2), p.statSkippedDocs.Load(), "skips")
 
-	counts := map[string]int64{}
-	for _, rc := range p.docDropReason.drain() {
-		counts[rc.reason] = rc.count
-	}
-	require.Equal(t, int64(2), counts["importCAR"])
-	require.Equal(t, int64(1), counts["syncDAG"])
-	require.Equal(t, int64(1), counts["skip:alreadyMerged"], "skips carry a distinct prefix")
+	require.Equal(t, map[string]int64{"importCAR": 2, "syncDAG": 1}, reasonMap(p.docDropReason.drain()))
+	require.Equal(t, map[string]int64{"alreadyMerged": 1, "filtered": 1}, reasonMap(p.docSkipReason.drain()))
 }
 
 // The reason set is fixed so a peer cannot grow the map, and drain resets it so each

--- a/internal/db/p2p/dropstats_test.go
+++ b/internal/db/p2p/dropstats_test.go
@@ -28,7 +28,7 @@ func reasonMap(counts []reasonCount) map[string]int64 {
 // A drop is a document that was meant to be stored and was not; a skip is one deliberately
 // not merged. Reporting them on one line would read policy decisions as data loss.
 func TestDropAndSkipAreCountedApart(t *testing.T) {
-	p := &P2P{}
+	p := withReasonMaps(&P2P{})
 
 	p.dropDoc("importCAR")
 	p.dropDoc("importCAR")
@@ -46,7 +46,7 @@ func TestDropAndSkipAreCountedApart(t *testing.T) {
 // The reason set is fixed so a peer cannot grow the map, and drain resets it so each
 // reported interval is a rate rather than a running total.
 func TestDropReasonsDrainResets(t *testing.T) {
-	p := &P2P{}
+	p := withReasonMaps(&P2P{})
 	p.dropDoc("blockDecode")
 	require.Len(t, p.docDropReason.drain(), 1)
 	require.Empty(t, p.docDropReason.drain(), "a drained reason set starts the next interval empty")
@@ -54,7 +54,7 @@ func TestDropReasonsDrainResets(t *testing.T) {
 
 // Drops and skips are reported on separate lines, so one report has to drain both maps.
 func TestReportDrainsDropsAndSkips(t *testing.T) {
-	p := &P2P{}
+	p := withReasonMaps(&P2P{})
 	p.dropDoc("syncDAG")
 	p.skipDoc("alreadyMerged")
 

--- a/internal/db/p2p/dropstats_test.go
+++ b/internal/db/p2p/dropstats_test.go
@@ -1,0 +1,48 @@
+// Copyright 2025 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package p2p
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// A drop is a document that was meant to be stored and was not; a skip is one deliberately
+// not merged. Counting them together would report policy decisions as data loss.
+func TestDropAndSkipAreCountedApart(t *testing.T) {
+	p := &P2P{}
+
+	p.dropDoc("importCAR")
+	p.dropDoc("importCAR")
+	p.dropDoc("syncDAG")
+	p.skipDoc("alreadyMerged")
+
+	require.Equal(t, int64(3), p.statDroppedDocs.Load(), "drops")
+	require.Equal(t, int64(1), p.statSkippedDocs.Load(), "skips")
+
+	counts := map[string]int64{}
+	for _, rc := range p.docDropReason.drain() {
+		counts[rc.reason] = rc.count
+	}
+	require.Equal(t, int64(2), counts["importCAR"])
+	require.Equal(t, int64(1), counts["syncDAG"])
+	require.Equal(t, int64(1), counts["skip:alreadyMerged"], "skips carry a distinct prefix")
+}
+
+// The reason set is fixed so a peer cannot grow the map, and drain resets it so each
+// reported interval is a rate rather than a running total.
+func TestDropReasonsDrainResets(t *testing.T) {
+	p := &P2P{}
+	p.dropDoc("blockDecode")
+	require.Len(t, p.docDropReason.drain(), 1)
+	require.Empty(t, p.docDropReason.drain(), "a drained reason set starts the next interval empty")
+}

--- a/internal/db/p2p/dropstats_test.go
+++ b/internal/db/p2p/dropstats_test.go
@@ -51,3 +51,15 @@ func TestDropReasonsDrainResets(t *testing.T) {
 	require.Len(t, p.docDropReason.drain(), 1)
 	require.Empty(t, p.docDropReason.drain(), "a drained reason set starts the next interval empty")
 }
+
+// Drops and skips are reported on separate lines, so one report has to drain both maps.
+func TestReportDrainsDropsAndSkips(t *testing.T) {
+	p := &P2P{}
+	p.dropDoc("syncDAG")
+	p.skipDoc("alreadyMerged")
+
+	p.report()
+
+	require.Empty(t, p.docDropReason.drain(), "the drops were reported")
+	require.Empty(t, p.docSkipReason.drain(), "the skips were reported")
+}

--- a/internal/db/p2p/errors.go
+++ b/internal/db/p2p/errors.go
@@ -79,6 +79,17 @@ var (
 	ErrNoHeadsForBranchableCol     = errors.New("no heads found for branchable collection")
 	ErrBlockCIDMismatch            = errors.New("pushed block does not match the advertised CID")
 	ErrEmptyPushLog                = errors.New("push log request carries no document")
+
+	// Failures a DAG sync can end on. syncDAGReason matches against these, so each shares the
+	// message constant its wrapping constructor uses.
+	ErrStoreBlockDAGSync  = errors.New(errStoreBlockDAGSync)
+	ErrGenerateBlockLink  = errors.New(errGenerateBlockLink)
+	ErrCheckBlockMerged   = errors.New(errCheckBlockMerged)
+	ErrVerifyBlockSig     = errors.New(errVerifyBlockSig)
+	ErrGetEncKeysForBlock = errors.New(errGetEncKeysForBlock)
+	ErrLoadLinkedBlock    = errors.New(errLoadLinkedBlock)
+	ErrDecodeLinkedBlock  = errors.New(errDecodeLinkedBlock)
+	ErrRetrieveEncKey     = errors.New(errRetrieveEncKey)
 )
 
 func NewErrReplicatorCollections(inner error, kv ...errors.KV) error {

--- a/internal/db/p2p/errors.go
+++ b/internal/db/p2p/errors.go
@@ -80,16 +80,16 @@ var (
 	ErrBlockCIDMismatch            = errors.New("pushed block does not match the advertised CID")
 	ErrEmptyPushLog                = errors.New("push log request carries no document")
 
-	// Failures a DAG sync can end on. syncDAGReason matches against these, so each shares the
-	// message constant its wrapping constructor uses.
-	ErrStoreBlockDAGSync  = errors.New(errStoreBlockDAGSync)
-	ErrGenerateBlockLink  = errors.New(errGenerateBlockLink)
-	ErrCheckBlockMerged   = errors.New(errCheckBlockMerged)
-	ErrVerifyBlockSig     = errors.New(errVerifyBlockSig)
-	ErrGetEncKeysForBlock = errors.New(errGetEncKeysForBlock)
-	ErrLoadLinkedBlock    = errors.New(errLoadLinkedBlock)
-	ErrDecodeLinkedBlock  = errors.New(errDecodeLinkedBlock)
-	ErrRetrieveEncKey     = errors.New(errRetrieveEncKey)
+	// Steps a DAG sync can fail on, matched by syncDAGReason. Each shares the message constant
+	// its wrapping constructor uses.
+	errStoreRoot   = errors.New(errStoreBlockDAGSync)
+	errBlockLink   = errors.New(errGenerateBlockLink)
+	errIsMerged    = errors.New(errCheckBlockMerged)
+	errVerifySig   = errors.New(errVerifyBlockSig)
+	errEncKeys     = errors.New(errGetEncKeysForBlock)
+	errRetrieveKey = errors.New(errRetrieveEncKey)
+	errLoadLink    = errors.New(errLoadLinkedBlock)
+	errDecodeLink  = errors.New(errDecodeLinkedBlock)
 )
 
 func NewErrReplicatorCollections(inner error, kv ...errors.KV) error {

--- a/internal/db/p2p/errors.go
+++ b/internal/db/p2p/errors.go
@@ -78,6 +78,7 @@ var (
 	ErrCollectionNotBranchable     = errors.New("collection is not branchable")
 	ErrNoHeadsForBranchableCol     = errors.New("no heads found for branchable collection")
 	ErrBlockCIDMismatch            = errors.New("pushed block does not match the advertised CID")
+	ErrEmptyPushLog                = errors.New("push log request carries no document")
 )
 
 func NewErrReplicatorCollections(inner error, kv ...errors.KV) error {

--- a/internal/db/p2p/ingeststats_test.go
+++ b/internal/db/p2p/ingeststats_test.go
@@ -13,12 +13,16 @@ package p2p
 import (
 	"context"
 	"strconv"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	blocks "github.com/ipfs/go-block-format"
 	"github.com/ipfs/go-cid"
 	"github.com/stretchr/testify/require"
 
+	"github.com/sourcenetwork/corekv"
 	"github.com/sourcenetwork/corekv/blockstore"
 	"github.com/sourcenetwork/corekv/memory"
 	"github.com/sourcenetwork/immutable"
@@ -190,4 +194,104 @@ func TestDocSyncOutcomesAreCounted(t *testing.T) {
 		require.Equal(t, int64(1), p.statDroppedDocs.Load(), "a document that could not be fetched is a loss")
 		require.Equal(t, int64(0), p.statMergedDocs.Load())
 	})
+}
+
+// blockingStore holds reads open once armed, so a test can keep one arrival inside the
+// handler while further arrivals are made.
+type blockingStore struct {
+	corekv.TxnStore
+
+	armed   atomic.Bool
+	once    sync.Once
+	reached chan struct{}
+	release chan struct{}
+}
+
+func (s *blockingStore) Has(ctx context.Context, key []byte) (bool, error) {
+	if s.armed.Load() {
+		s.once.Do(func() { close(s.reached) })
+		<-s.release
+	}
+	return s.TxnStore.Has(ctx, key)
+}
+
+// pushRequest returns a single-document request for head whose block does not decode, so an
+// arrival that reaches the handler ends as a drop.
+func pushRequest(docID string, head cid.Cid) *protocol.PushLogRequest {
+	return &protocol.PushLogRequest{
+		DocID:        docID,
+		CollectionID: "col",
+		CID:          head.Bytes(),
+		Block:        []byte("not a block"),
+	}
+}
+
+// awaitClose fails the test rather than hanging the package, so a change that makes an
+// arrival wait on another reports which wait it was.
+func awaitClose(t *testing.T, c <-chan struct{}, what string) {
+	t.Helper()
+	select {
+	case <-c:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("timed out waiting for %s", what)
+	}
+}
+
+// The counters record arrivals, not documents. An arrival for a document already in flight is
+// deduplicated on its head, so it is a skip while the arrival that is running reports its own
+// outcome later. An arrival for a different head is not deduplicated.
+func TestArrivalForAHeadAlreadyInFlightIsSkipped(t *testing.T) {
+	ctx := context.Background()
+	store := &blockingStore{
+		TxnStore: memory.NewDatastore(ctx),
+		reached:  make(chan struct{}),
+		release:  make(chan struct{}),
+	}
+	stores := datastore.NewMultistore(store, lock.NewLockSet(), immutable.None[int]())
+	p := &P2P{db: multistoreDB{stores: stores}, processQueue: newProcessQueue()}
+	t.Cleanup(p.processQueue.close)
+
+	// Released on any exit, so a failed assertion cannot leave an arrival parked.
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(store.release) }) }
+	defer release()
+
+	// Two heads of one document, so the queue key is what decides whether the second is
+	// deduplicated against the first.
+	held := pushRequest("d", blocks.NewBlock([]byte("held head")).Cid())
+	other := pushRequest("d", blocks.NewBlock([]byte("other head")).Cid())
+
+	store.armed.Store(true)
+	running := make(chan error, 2)
+	go func() { running <- p.processPushlogRequest(ctx, held, false) }()
+	awaitClose(t, store.reached, "the first arrival to reach the store")
+
+	require.NoError(t, p.processPushlogRequest(ctx, held, false), "a deduplicated arrival is not an error")
+	go func() { running <- p.processPushlogRequest(ctx, other, false) }()
+
+	require.Equal(t, map[string]int64{"inFlight": 1}, reasonMap(p.docSkipReason.drain()))
+	require.Equal(t, int64(0), p.statDroppedDocs.Load(), "no arrival has reported an outcome yet")
+
+	release()
+	require.Error(t, <-running)
+	require.Error(t, <-running)
+	require.Equal(t, map[string]int64{"blockDecode": 2}, reasonMap(p.docDropReason.drain()),
+		"the arrival for a different head was not deduplicated")
+	require.Empty(t, reasonMap(p.docSkipReason.drain()), "only the repeated head was skipped")
+}
+
+// A document the sync queue refuses is one this node will not hold, so it counts as a loss.
+func TestArrivalRefusedByAFullSyncQueueIsDropped(t *testing.T) {
+	p := &P2P{
+		// An unserved queue with no capacity refuses on arrival.
+		processQueue: &processQueue{inFlight: map[string]struct{}{}, queue: make(chan syncRequest)},
+	}
+	req := pushRequest("d", blocks.NewBlock([]byte("a head")).Cid())
+
+	// Refused twice, because a document the queue turned away is not left marked in flight.
+	require.ErrorIs(t, p.processPushlogRequest(context.Background(), req, false), ErrSyncQueueFull)
+	require.ErrorIs(t, p.processPushlogRequest(context.Background(), req, false), ErrSyncQueueFull)
+
+	require.Equal(t, map[string]int64{"syncQueueFull": 2}, reasonMap(p.docDropReason.drain()))
+	require.Empty(t, reasonMap(p.docSkipReason.drain()), "a refused document is not a skip")
 }

--- a/internal/db/p2p/ingeststats_test.go
+++ b/internal/db/p2p/ingeststats_test.go
@@ -60,7 +60,7 @@ func heldDocuments(t *testing.T, n int) (*P2P, []protocol.DocumentInfo) {
 
 		docs = append(docs, protocol.DocumentInfo{DocID: "held-" + strconv.Itoa(i), CID: block.Cid().Bytes()})
 	}
-	return &P2P{db: multistoreDB{stores: stores}}, docs
+	return withReasonMaps(&P2P{db: multistoreDB{stores: stores}}), docs
 }
 
 // badDocuments returns batch entries whose CIDs do not parse. That is the first check a
@@ -79,7 +79,7 @@ func badDocuments(n int) []protocol.DocumentInfo {
 // The drop counts are read against the batch count, so a batch that loses every document
 // it carries still has to be counted.
 func TestBatchIsCountedWhenNoDocumentSurvives(t *testing.T) {
-	p := &P2P{}
+	p := withReasonMaps(&P2P{})
 	req := &protocol.PushLogRequest{CollectionID: "col", Documents: badDocuments(40)}
 
 	require.NoError(t, p.processPushlogRequest(context.Background(), req, false))
@@ -123,7 +123,7 @@ func TestBatchAccountsForEveryDocument(t *testing.T) {
 // counted under the same reasons.
 func TestSingleDocumentOutcomesAreCounted(t *testing.T) {
 	t.Run("a CID that does not parse is a drop", func(t *testing.T) {
-		p := &P2P{}
+		p := withReasonMaps(&P2P{})
 		req := &protocol.PushLogRequest{DocID: "d", CollectionID: "col", CID: []byte{0xff, 0xff, 0xff}}
 
 		require.Error(t, p.processPushlogRequest(context.Background(), req, false))
@@ -143,7 +143,7 @@ func TestSingleDocumentOutcomesAreCounted(t *testing.T) {
 
 	// Counting a request that offered no document as a drop would let a peer move the loss count.
 	t.Run("a request carrying no document is neither a drop nor a skip", func(t *testing.T) {
-		p := &P2P{}
+		p := withReasonMaps(&P2P{})
 		req := &protocol.PushLogRequest{CollectionID: "col"}
 
 		require.ErrorIs(t, p.processPushlogRequest(context.Background(), req, false), ErrEmptyPushLog)
@@ -173,7 +173,7 @@ func TestDocSyncOutcomesAreCounted(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("a head that does not parse is a drop", func(t *testing.T) {
-		p := &P2P{}
+		p := withReasonMaps(&P2P{})
 		item := docSyncItem{DocID: "d", Heads: [][]byte{{0xff, 0xff, 0xff}}}
 
 		p.handleDocSyncItem(ctx, item, "sender", "col", map[string][]cid.Cid{})
@@ -183,7 +183,7 @@ func TestDocSyncOutcomesAreCounted(t *testing.T) {
 	})
 
 	t.Run("a head already seen in the response is a skip", func(t *testing.T) {
-		p := &P2P{}
+		p := withReasonMaps(&P2P{})
 		_, head, err := cid.CidFromBytes(blocks.NewBlock([]byte("a block")).Cid().Bytes())
 		require.NoError(t, err)
 		item := docSyncItem{DocID: "d", Heads: [][]byte{head.Bytes()}}
@@ -195,7 +195,7 @@ func TestDocSyncOutcomesAreCounted(t *testing.T) {
 	})
 
 	t.Run("a DAG that cannot be walked is a drop", func(t *testing.T) {
-		p := &P2P{host: newEmptyIPLDHost(ctx)}
+		p := withReasonMaps(&P2P{host: newEmptyIPLDHost(ctx)})
 		head := blocks.NewBlock([]byte("a block")).Cid()
 		item := docSyncItem{DocID: "d", Heads: [][]byte{head.Bytes()}}
 
@@ -258,7 +258,7 @@ func TestArrivalForAHeadAlreadyInFlightIsSkipped(t *testing.T) {
 		release:  make(chan struct{}),
 	}
 	stores := datastore.NewMultistore(store, lock.NewLockSet(), immutable.None[int]())
-	p := &P2P{db: multistoreDB{stores: stores}, processQueue: newProcessQueue()}
+	p := withReasonMaps(&P2P{db: multistoreDB{stores: stores}, processQueue: newProcessQueue()})
 	t.Cleanup(p.processQueue.close)
 
 	// Released on any exit, so a failed assertion cannot leave an arrival parked.
@@ -292,10 +292,10 @@ func TestArrivalForAHeadAlreadyInFlightIsSkipped(t *testing.T) {
 
 // A document the sync queue refuses is one this node will not hold, so it counts as a loss.
 func TestArrivalRefusedByAFullSyncQueueIsDropped(t *testing.T) {
-	p := &P2P{
+	p := withReasonMaps(&P2P{
 		// An unserved queue with no capacity refuses on arrival.
 		processQueue: &processQueue{inFlight: map[string]struct{}{}, queue: make(chan syncRequest)},
-	}
+	})
 	req := pushRequest("d", blocks.NewBlock([]byte("a head")).Cid())
 
 	// Refused twice, because a document the queue turned away is not left marked in flight.

--- a/internal/db/p2p/ingeststats_test.go
+++ b/internal/db/p2p/ingeststats_test.go
@@ -1,0 +1,193 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package p2p
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	blocks "github.com/ipfs/go-block-format"
+	"github.com/ipfs/go-cid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcenetwork/corekv/blockstore"
+	"github.com/sourcenetwork/corekv/memory"
+	"github.com/sourcenetwork/immutable"
+
+	"github.com/sourcenetwork/defradb/client"
+
+	coreblock "github.com/sourcenetwork/defradb/internal/core/block"
+	"github.com/sourcenetwork/defradb/internal/core/crdt"
+	"github.com/sourcenetwork/defradb/internal/datastore"
+	"github.com/sourcenetwork/defradb/internal/db/lock"
+	"github.com/sourcenetwork/defradb/internal/db/p2p/protocol"
+)
+
+// heldDocuments returns a P2P whose blockstore already holds n merged blocks, and the
+// batch entries that carry them.
+func heldDocuments(t *testing.T, n int) (*P2P, []protocol.DocumentInfo) {
+	t.Helper()
+	ctx := context.Background()
+	stores := datastore.NewMultistore(memory.NewDatastore(ctx), lock.NewLockSet(), immutable.None[int]())
+
+	docs := make([]protocol.DocumentInfo, 0, n)
+	for i := range n {
+		cb := coreblock.Block{Delta: crdt.CRDT{DocCompositeDelta: &crdt.DocCompositeDelta{
+			Priority: uint64(i + 1),
+		}}}
+		raw, err := cb.Marshal()
+		require.NoError(t, err)
+		link, err := coreblock.GetLinkFromNode(cb.GenerateNode())
+		require.NoError(t, err)
+		block, err := blocks.NewBlockWithCid(raw, link.Cid)
+		require.NoError(t, err)
+
+		require.NoError(t, stores.Blockstore().Put(ctx, block))
+		require.NoError(t, stores.Blockstore().MarkAsMerged(ctx, block.Cid()))
+
+		docs = append(docs, protocol.DocumentInfo{DocID: "held-" + strconv.Itoa(i), CID: block.Cid().Bytes()})
+	}
+	return &P2P{db: multistoreDB{stores: stores}}, docs
+}
+
+// badDocuments returns batch entries whose CIDs do not parse. That is the first check a
+// document meets, and it needs no store.
+func badDocuments(n int) []protocol.DocumentInfo {
+	docs := make([]protocol.DocumentInfo, 0, n)
+	for i := range n {
+		docs = append(docs, protocol.DocumentInfo{
+			DocID: "bad-" + strconv.Itoa(i),
+			CID:   []byte{0xff, 0xff, 0xff},
+		})
+	}
+	return docs
+}
+
+// The drop counts are read against the batch count, so a batch that loses every document
+// it carries still has to be counted.
+func TestBatchIsCountedWhenNoDocumentSurvives(t *testing.T) {
+	p := &P2P{}
+	req := &protocol.PushLogRequest{CollectionID: "col", Documents: badDocuments(40)}
+
+	require.NoError(t, p.processPushlogRequest(context.Background(), req, false))
+
+	require.Equal(t, int64(40), p.statDroppedDocs.Load(), "drops")
+	require.Equal(t, int64(1), p.statBatches.Load(), "the batch counts even though nothing survived it")
+	require.Equal(t, int64(1), p.statBatchesWithDrops.Load(), "a drop before the merge still marks the batch")
+}
+
+// Documents the node already holds are skipped, not lost. Marking such a batch as one that
+// dropped documents would report ordinary duplicate delivery as data loss.
+func TestBatchOfHeldDocumentsCountsNoDrops(t *testing.T) {
+	p, docs := heldDocuments(t, 5)
+	req := &protocol.PushLogRequest{CollectionID: "col", Documents: docs}
+
+	require.NoError(t, p.processPushlogRequest(context.Background(), req, false))
+
+	require.Equal(t, int64(5), p.statSkippedDocs.Load(), "skips")
+	require.Equal(t, int64(0), p.statDroppedDocs.Load(), "a held document is not a loss")
+	require.Equal(t, int64(1), p.statBatches.Load(), "the batch counts")
+	require.Equal(t, int64(0), p.statBatchesWithDrops.Load(), "no document dropped")
+}
+
+// Every document a batch carries ends merged, skipped or dropped. If the three do not add
+// up to what arrived, an outcome went unrecorded and the drop count understates the loss.
+func TestBatchAccountsForEveryDocument(t *testing.T) {
+	const held, bad = 5, 3
+	p, docs := heldDocuments(t, held)
+	req := &protocol.PushLogRequest{CollectionID: "col", Documents: append(docs, badDocuments(bad)...)}
+
+	require.NoError(t, p.processPushlogRequest(context.Background(), req, false))
+
+	accounted := p.statMergedDocs.Load() + p.statDroppedDocs.Load() + p.statSkippedDocs.Load()
+	require.Equal(t, int64(len(req.Documents)), accounted, "merged + dropped + skipped must equal received")
+	require.Equal(t, int64(bad), p.statDroppedDocs.Load())
+	require.Equal(t, int64(held), p.statSkippedDocs.Load())
+	require.Equal(t, int64(1), p.statBatchesWithDrops.Load(), "the batch carried a drop")
+}
+
+// A single-document push ends in the same outcomes as one carried in a batch, and is
+// counted under the same reasons.
+func TestSingleDocumentOutcomesAreCounted(t *testing.T) {
+	t.Run("a CID that does not parse is a drop", func(t *testing.T) {
+		p := &P2P{}
+		req := &protocol.PushLogRequest{DocID: "d", CollectionID: "col", CID: []byte{0xff, 0xff, 0xff}}
+
+		require.Error(t, p.processPushlogRequest(context.Background(), req, false))
+		require.Equal(t, int64(1), p.statDroppedDocs.Load())
+	})
+
+	t.Run("a document already held is a skip", func(t *testing.T) {
+		p, docs := heldDocuments(t, 1)
+		p.processQueue = newProcessQueue()
+		defer p.processQueue.close()
+		req := &protocol.PushLogRequest{DocID: docs[0].DocID, CollectionID: "col", CID: docs[0].CID}
+
+		require.NoError(t, p.processPushlogRequest(context.Background(), req, false))
+		require.Equal(t, int64(1), p.statSkippedDocs.Load())
+		require.Equal(t, int64(0), p.statDroppedDocs.Load(), "a held document is not a loss")
+	})
+}
+
+// emptyIPLDHost satisfies Host for the doc-sync path, backed by a store holding no blocks
+// so a DAG walk fails to load its root.
+type emptyIPLDHost struct {
+	client.Host
+	store blockstore.IPLDStore
+}
+
+func (h emptyIPLDHost) ID() string                      { return "peerID" }
+func (h emptyIPLDHost) IPLDStore() blockstore.IPLDStore { return h.store }
+
+func newEmptyIPLDHost(ctx context.Context) emptyIPLDHost {
+	bs := datastore.BlockstoreFrom(memory.NewDatastore(ctx), immutable.None[int]())
+	return emptyIPLDHost{store: blockstore.NewIPLDStore(bs)}
+}
+
+// Documents pulled from a peer reach the store by a different route than a pushed batch,
+// but end in the same outcomes and belong in the same counters.
+func TestDocSyncOutcomesAreCounted(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("a head that does not parse is a drop", func(t *testing.T) {
+		p := &P2P{}
+		item := docSyncItem{DocID: "d", Heads: [][]byte{{0xff, 0xff, 0xff}}}
+
+		p.handleDocSyncItem(ctx, item, "sender", "col", map[string][]cid.Cid{})
+
+		require.Equal(t, int64(1), p.statDroppedDocs.Load())
+		require.Equal(t, int64(0), p.statSkippedDocs.Load())
+	})
+
+	t.Run("a head already seen in the response is a skip", func(t *testing.T) {
+		p := &P2P{}
+		_, head, err := cid.CidFromBytes(blocks.NewBlock([]byte("a block")).Cid().Bytes())
+		require.NoError(t, err)
+		item := docSyncItem{DocID: "d", Heads: [][]byte{head.Bytes()}}
+
+		p.handleDocSyncItem(ctx, item, "sender", "col", map[string][]cid.Cid{"d": {head}})
+
+		require.Equal(t, int64(1), p.statSkippedDocs.Load(), "a repeated head is not a loss")
+		require.Equal(t, int64(0), p.statDroppedDocs.Load())
+	})
+
+	t.Run("a DAG that cannot be walked is a drop", func(t *testing.T) {
+		p := &P2P{host: newEmptyIPLDHost(ctx)}
+		head := blocks.NewBlock([]byte("a block")).Cid()
+		item := docSyncItem{DocID: "d", Heads: [][]byte{head.Bytes()}}
+
+		p.handleDocSyncItem(ctx, item, "sender", "col", map[string][]cid.Cid{})
+
+		require.Equal(t, int64(1), p.statDroppedDocs.Load(), "a document that could not be fetched is a loss")
+		require.Equal(t, int64(0), p.statMergedDocs.Load())
+	})
+}

--- a/internal/db/p2p/ingeststats_test.go
+++ b/internal/db/p2p/ingeststats_test.go
@@ -140,6 +140,16 @@ func TestSingleDocumentOutcomesAreCounted(t *testing.T) {
 		require.Equal(t, int64(1), p.statSkippedDocs.Load())
 		require.Equal(t, int64(0), p.statDroppedDocs.Load(), "a held document is not a loss")
 	})
+
+	// Counting a request that offered no document as a drop would let a peer move the loss count.
+	t.Run("a request carrying no document is neither a drop nor a skip", func(t *testing.T) {
+		p := &P2P{}
+		req := &protocol.PushLogRequest{CollectionID: "col"}
+
+		require.ErrorIs(t, p.processPushlogRequest(context.Background(), req, false), ErrEmptyPushLog)
+		require.Equal(t, int64(0), p.statDroppedDocs.Load())
+		require.Equal(t, int64(0), p.statSkippedDocs.Load())
+	})
 }
 
 // emptyIPLDHost satisfies Host for the doc-sync path, backed by a store holding no blocks

--- a/internal/db/p2p/p2p.go
+++ b/internal/db/p2p/p2p.go
@@ -911,68 +911,82 @@ func (p *P2P) processPushlogRequest(
 
 	// Handle batched multi-document push using a single shared transaction.
 	if len(req.Documents) > 0 {
-		results, err := p.processBatchedDocuments(ctx, req, isReplicator)
+		// Counted before the documents are processed, so a batch still counts when none
+		// of them survives.
+		p.statBatches.Add(1)
+
+		results, dropped, err := p.processBatchedDocuments(ctx, req, isReplicator)
 		if err != nil {
 			return err
 		}
-		if len(results) == 0 {
-			return nil
-		}
-		merges := make([]event.Merge, len(results))
-		for i, r := range results {
-			merges[i] = r.merge
-		}
-		merged, err := p.db.MergeBatchWithTxn(ctx, merges)
-		p.statBatches.Add(1)
-		for _, ok := range merged {
-			if ok {
-				p.statMergedDocs.Add(1)
-			} else {
-				p.dropDoc("mergeFailed")
+		if len(results) > 0 {
+			merges := make([]event.Merge, len(results))
+			for i, r := range results {
+				merges[i] = r.merge
+			}
+			merged, err := p.db.MergeBatchWithTxn(ctx, merges)
+			for _, ok := range merged {
+				if ok {
+					p.statMergedDocs.Add(1)
+				} else {
+					p.dropDoc("mergeFailed")
+					dropped++
+				}
+			}
+			if err != nil {
+				log.ErrorE("Failed to merge documents in batch", err,
+					corelog.String("PeerID", req.SenderID),
+					corelog.Int("Documents", len(merges)))
+			}
+			for i, r := range results {
+				if !merged[i] {
+					// Not stored here, so relaying it would advertise a document this node
+					// cannot serve.
+					continue
+				}
+				updateEvt := event.Update{
+					DocID:        r.merge.DocID,
+					Cid:          r.merge.Cid,
+					CollectionID: r.merge.CollectionID,
+					Block:        r.block,
+					IsRelay:      true,
+				}
+				p.db.Events().Publish(event.NewMessage(event.UpdateName, updateEvt))
+				if err := p.SendUpdate(updateEvt); err != nil {
+					log.ErrorE("Failed to send update after batch sync", err,
+						slog.String("DocID", r.merge.DocID),
+						slog.Any("PeerID", p.host.ID()),
+					)
+				}
 			}
 		}
-		if err != nil {
+
+		if dropped > 0 {
 			p.statBatchesWithDrops.Add(1)
-			log.ErrorE("Failed to merge documents in batch", err,
-				corelog.String("PeerID", req.SenderID),
-				corelog.Int("Documents", len(merges)))
-		}
-		for i, r := range results {
-			if !merged[i] {
-				// Not stored here, so relaying it would advertise a document this node
-				// cannot serve.
-				continue
-			}
-			updateEvt := event.Update{
-				DocID:        r.merge.DocID,
-				Cid:          r.merge.Cid,
-				CollectionID: r.merge.CollectionID,
-				Block:        r.block,
-				IsRelay:      true,
-			}
-			p.db.Events().Publish(event.NewMessage(event.UpdateName, updateEvt))
-			if err := p.SendUpdate(updateEvt); err != nil {
-				log.ErrorE("Failed to send update after batch sync", err,
-					slog.String("DocID", r.merge.DocID),
-					slog.Any("PeerID", p.host.ID()),
-				)
-			}
 		}
 		return nil
 	}
 
 	headCID, err := cid.Cast(req.CID)
 	if err != nil {
+		p.dropDoc("invalidCID")
 		return err
 	}
 
-	return p.processQueue.enqueue(headCID.String(), func() error {
+	// enqueue returns without running the handler when the same document is already in
+	// flight, or when the queue is full. Neither case reaches the outcomes recorded inside it.
+	handled := false
+	err = p.processQueue.enqueue(headCID.String(), func() error {
+		handled = true
+
 		// Check if we've already merged this block. If so, skip the sink process.
 		isMerged, err := p.db.Multistore().Blockstore().IsMerged(ctx, headCID)
 		if err != nil {
+			p.dropDoc("isMergedError")
 			return err
 		}
 		if isMerged {
+			p.skipDoc("alreadyMerged")
 			return nil
 		}
 
@@ -986,6 +1000,7 @@ func (p *P2P) processPushlogRequest(
 			block, err = coreblock.GetFromBytes(req.Block)
 		}
 		if err != nil {
+			p.dropDoc("blockDecode")
 			return err
 		}
 
@@ -993,9 +1008,11 @@ func (p *P2P) processPushlogRequest(
 		// arbitrary content under a CID of its choosing.
 		blockLink, err := block.GenerateLink()
 		if err != nil {
+			p.dropDoc("generateLink")
 			return err
 		}
 		if blockLink.Cid != headCID {
+			p.dropDoc("cidMismatch")
 			return ErrBlockCIDMismatch
 		}
 
@@ -1004,16 +1021,19 @@ func (p *P2P) processPushlogRequest(
 		if !isReplicator {
 			mightHaveAccess, err := p.trySelfHasAccess(ctx, headCID, block, req.CollectionID, req.DocID)
 			if err != nil {
+				p.dropDoc("accessError")
 				return err
 			}
 			if !mightHaveAccess {
 				// If we know we don't have access, we can skip the rest of the processing.
+				p.skipDoc("noAccess")
 				return nil
 			}
 		}
 
 		// Run the replication filter before writing any blocks to storage.
 		if !p.filterAllowsReplication(ctx, req.CollectionID, req.DocID, block) {
+			p.skipDoc("filtered")
 			return nil
 		}
 
@@ -1021,10 +1041,12 @@ func (p *P2P) processPushlogRequest(
 		if len(req.CAR) > 0 {
 			// CAR contains the full block DAG — import it directly, no round-trip sync needed.
 			if _, err = p.importCAR(ctx, req.CAR); err != nil {
+				p.dropDoc("importCAR")
 				return err
 			}
 		} else {
 			if err = p.syncDAG(ctx, block); err != nil {
+				p.dropDoc("syncDAG")
 				return err
 			}
 		}
@@ -1059,6 +1081,15 @@ func (p *P2P) processPushlogRequest(
 
 		return nil
 	})
+
+	if !handled {
+		if err == nil {
+			p.skipDoc("inFlight")
+		} else {
+			p.dropDoc("syncQueueFull")
+		}
+	}
+	return err
 }
 
 // batchedDoc pairs a merge event with its raw block bytes for relay after batch commit.
@@ -1075,8 +1106,15 @@ func (p *P2P) processBatchedDocuments(
 	ctx context.Context,
 	req *protocol.PushLogRequest,
 	isReplicator bool,
-) ([]batchedDoc, error) {
+) ([]batchedDoc, int, error) {
 	results := make([]batchedDoc, 0, len(req.Documents))
+
+	// The counters are process-wide, so this batch's own drops are tallied separately.
+	dropped := 0
+	drop := func(reason string) {
+		p.dropDoc(reason)
+		dropped++
+	}
 
 	for _, doc := range req.Documents {
 		headCID, err := cid.Cast(doc.CID)
@@ -1085,14 +1123,14 @@ func (p *P2P) processBatchedDocuments(
 				slog.String("DocID", doc.DocID),
 				slog.String("CollectionID", req.CollectionID),
 			)
-			p.dropDoc("invalidCID")
+			drop("invalidCID")
 			continue
 		}
 
 		isMerged, err := p.db.Multistore().Blockstore().IsMerged(ctx, headCID)
 		if err != nil {
 			log.ErrorE("Batch: IsMerged check failed", err, slog.String("DocID", doc.DocID))
-			p.dropDoc("isMergedError")
+			drop("isMergedError")
 			continue
 		}
 		if isMerged {
@@ -1108,19 +1146,19 @@ func (p *P2P) processBatchedDocuments(
 		}
 		if err != nil {
 			log.ErrorE("Batch: block decode failed", err, slog.String("DocID", doc.DocID))
-			p.dropDoc("blockDecode")
+			drop("blockDecode")
 			continue
 		}
 
 		blockLink, err := block.GenerateLink()
 		if err != nil {
 			log.ErrorE("Batch: GenerateLink failed", err, slog.String("DocID", doc.DocID))
-			p.dropDoc("generateLink")
+			drop("generateLink")
 			continue
 		}
 		if blockLink.Cid != headCID {
 			log.Error("Batch: CID mismatch", slog.String("DocID", doc.DocID))
-			p.dropDoc("cidMismatch")
+			drop("cidMismatch")
 			continue
 		}
 
@@ -1128,7 +1166,7 @@ func (p *P2P) processBatchedDocuments(
 			mightHaveAccess, err := p.trySelfHasAccess(ctx, headCID, block, req.CollectionID, doc.DocID)
 			if err != nil {
 				log.ErrorE("Batch: access check failed", err, slog.String("DocID", doc.DocID))
-				p.dropDoc("accessError")
+				drop("accessError")
 				continue
 			}
 			if !mightHaveAccess {
@@ -1145,13 +1183,13 @@ func (p *P2P) processBatchedDocuments(
 		if len(doc.CAR) > 0 {
 			if _, err = p.importCAR(ctx, doc.CAR); err != nil {
 				log.ErrorE("Batch: importCAR failed", err, slog.String("DocID", doc.DocID))
-				p.dropDoc("importCAR")
+				drop("importCAR")
 				continue
 			}
 		} else {
 			if err = p.syncDAG(ctx, block); err != nil {
 				log.ErrorE("Batch: syncDAG failed", err, slog.String("DocID", doc.DocID))
-				p.dropDoc("syncDAG")
+				drop("syncDAG")
 				continue
 			}
 		}
@@ -1168,7 +1206,7 @@ func (p *P2P) processBatchedDocuments(
 		})
 	}
 
-	return results, nil
+	return results, dropped, nil
 }
 func (p *P2P) SendUpdate(evt event.Update) error {
 	// push to each peer (replicator)

--- a/internal/db/p2p/p2p.go
+++ b/internal/db/p2p/p2p.go
@@ -264,8 +264,9 @@ type P2P struct {
 	statCARImportFailed       atomic.Int64
 	statCARImportOrphanBlocks atomic.Int64
 
-	// CAR generation counters. A CAR that carries only the root block gives its receiver
-	// nothing to import, so the receiver falls back to a per-link BitSwap walk.
+	// CAR generation counters. A failed generation is not a lost document: the block is sent
+	// either way, so the receiver walks the DAG instead. statCARMissing counts links the build
+	// could not follow in a CAR it returned.
 	statCARBuilt           atomic.Int64
 	statCARFailed          atomic.Int64
 	statCARMissing         atomic.Int64

--- a/internal/db/p2p/p2p.go
+++ b/internal/db/p2p/p2p.go
@@ -248,8 +248,9 @@ type P2P struct {
 	statDroppedFull   atomic.Int64
 	statMergedDocs    atomic.Int64
 	statDroppedDocs   atomic.Int64
-	// statSkippedDocs counts documents deliberately not merged: already held, or
-	// excluded by access or the replication filter. Not a loss, so kept apart.
+	// statSkippedDocs counts documents deliberately not merged: already held, already in
+	// flight, repeated within one document-sync round, or excluded by access or the
+	// replication filter. Not a loss, so kept apart.
 	statSkippedDocs atomic.Int64
 	statBatches     atomic.Int64
 	// statBatchesWithDrops counts batches in which at least one document dropped. The
@@ -275,9 +276,11 @@ type P2P struct {
 	statSyncDAGCalls     atomic.Int64
 	syncDAGFailureReason failureReasons
 
-	// docDropReason names why an inbound document never reached the merge. The set is
-	// fixed: a reason taken from an error string would let a peer grow the map.
+	// docDropReason names why an inbound document never reached the merge, and docSkipReason
+	// why one was deliberately not merged. Both sets are fixed: a reason taken from an error
+	// string would let a peer grow the map.
 	docDropReason failureReasons
+	docSkipReason failureReasons
 }
 
 // pushLogCommProcessor implements CommProcessor for push log functionality
@@ -839,6 +842,7 @@ func (p *P2P) reportStats() {
 			reportFailureReasons("car failures", p.carFailureReason.drain())
 			reportFailureReasons("syncDAG failures", p.syncDAGFailureReason.drain())
 			reportFailureReasons("document drops", p.docDropReason.drain())
+			reportFailureReasons("document skips", p.docSkipReason.drain())
 			reportFailureReasons("CAR import failures", p.carImportFailureReason.drain())
 		}
 	}

--- a/internal/db/p2p/p2p.go
+++ b/internal/db/p2p/p2p.go
@@ -273,8 +273,8 @@ type P2P struct {
 	carFailureReason       failureReasons
 	carImportFailureReason failureReasons
 
-	// statSyncDAGCalls counts walks started, which is how often a document could not be
-	// merged from the CAR alone and needed blocks fetched.
+	// statSyncDAGCalls counts walks started. A walk fetches blocks link by link, and is taken
+	// when an arrival carries no CAR, and by document and branchable-collection sync.
 	statSyncDAGCalls     atomic.Int64
 	syncDAGFailureReason failureReasons
 

--- a/internal/db/p2p/p2p.go
+++ b/internal/db/p2p/p2p.go
@@ -813,42 +813,47 @@ func (p *P2P) reportStats() {
 		case <-p.ctx.Done():
 			return
 		case <-ticker.C:
-			droppedOverBudget := p.statDroppedBudget.Swap(0)
-			droppedQueueFull := p.statDroppedFull.Swap(0)
-			log.Info("p2p stats",
-				corelog.Int("queueDepth", len(p.msgQueue)),
-				corelog.Int64("queueBytes", p.msgQueueBytes.Load()),
-				corelog.Int64("droppedOverBudget", droppedOverBudget),
-				corelog.Int64("droppedQueueFull", droppedQueueFull),
-				corelog.Int64("batches", p.statBatches.Swap(0)),
-				corelog.Int64("batchesWithDrops", p.statBatchesWithDrops.Swap(0)),
-				corelog.Int64("docsMerged", p.statMergedDocs.Swap(0)),
-				corelog.Int64("docsDropped", p.statDroppedDocs.Swap(0)),
-				corelog.Int64("docsSkipped", p.statSkippedDocs.Swap(0)),
-				corelog.Int64("msgsIn", p.statMsgsIn.Swap(0)),
-				corelog.Int64("carImports", p.statCARImports.Swap(0)),
-				corelog.Int64("carImportFailed", p.statCARImportFailed.Swap(0)),
-				corelog.Int64("carImportOrphanBlocks", p.statCARImportOrphanBlocks.Swap(0)),
-				corelog.Int64("carBuilt", p.statCARBuilt.Swap(0)),
-				corelog.Int64("carFailed", p.statCARFailed.Swap(0)),
-				corelog.Int64("carMissingLinks", p.statCARMissing.Swap(0)),
-				corelog.Int64("syncDAGCalls", p.statSyncDAGCalls.Swap(0)),
-			)
-			// A drop at the door is data this node will not hold. The stats line above is at
-			// info, so a node running at error level sees only this.
-			if droppedOverBudget != 0 || droppedQueueFull != 0 {
-				log.Error("dropped inbound pubsub messages",
-					corelog.Int64("overBudget", droppedOverBudget),
-					corelog.Int64("queueFull", droppedQueueFull))
-			}
-
-			reportFailureReasons("car failures", p.carFailureReason.drain())
-			reportFailureReasons("syncDAG failures", p.syncDAGFailureReason.drain())
-			reportFailureReasons("document drops", p.docDropReason.drain())
-			reportFailureReasons("document skips", p.docSkipReason.drain())
-			reportFailureReasons("CAR import failures", p.carImportFailureReason.drain())
+			p.report()
 		}
 	}
+}
+
+// report logs one interval's counters and resets them.
+func (p *P2P) report() {
+	droppedOverBudget := p.statDroppedBudget.Swap(0)
+	droppedQueueFull := p.statDroppedFull.Swap(0)
+	log.Info("p2p stats",
+		corelog.Int("queueDepth", len(p.msgQueue)),
+		corelog.Int64("queueBytes", p.msgQueueBytes.Load()),
+		corelog.Int64("droppedOverBudget", droppedOverBudget),
+		corelog.Int64("droppedQueueFull", droppedQueueFull),
+		corelog.Int64("batches", p.statBatches.Swap(0)),
+		corelog.Int64("batchesWithDrops", p.statBatchesWithDrops.Swap(0)),
+		corelog.Int64("docsMerged", p.statMergedDocs.Swap(0)),
+		corelog.Int64("docsDropped", p.statDroppedDocs.Swap(0)),
+		corelog.Int64("docsSkipped", p.statSkippedDocs.Swap(0)),
+		corelog.Int64("msgsIn", p.statMsgsIn.Swap(0)),
+		corelog.Int64("carImports", p.statCARImports.Swap(0)),
+		corelog.Int64("carImportFailed", p.statCARImportFailed.Swap(0)),
+		corelog.Int64("carImportOrphanBlocks", p.statCARImportOrphanBlocks.Swap(0)),
+		corelog.Int64("carBuilt", p.statCARBuilt.Swap(0)),
+		corelog.Int64("carFailed", p.statCARFailed.Swap(0)),
+		corelog.Int64("carMissingLinks", p.statCARMissing.Swap(0)),
+		corelog.Int64("syncDAGCalls", p.statSyncDAGCalls.Swap(0)),
+	)
+	// A drop at the door is data this node will not hold. The stats line above is at
+	// info, so a node running at error level sees only this.
+	if droppedOverBudget != 0 || droppedQueueFull != 0 {
+		log.Error("dropped inbound pubsub messages",
+			corelog.Int64("overBudget", droppedOverBudget),
+			corelog.Int64("queueFull", droppedQueueFull))
+	}
+
+	reportFailureReasons("car failures", p.carFailureReason.drain())
+	reportFailureReasons("syncDAG failures", p.syncDAGFailureReason.drain())
+	reportFailureReasons("document drops", p.docDropReason.drain())
+	reportFailureReasons("document skips", p.docSkipReason.drain())
+	reportFailureReasons("CAR import failures", p.carImportFailureReason.drain())
 }
 
 // reportFailureReasons logs one line naming every reason that occurred in the interval,

--- a/internal/db/p2p/p2p.go
+++ b/internal/db/p2p/p2p.go
@@ -341,6 +341,7 @@ func New(
 		msgQueue:             make(chan queuedMessage, msgQueueSize),
 		msgQueueMaxBytes:     queueByteBudget(),
 	}
+	p.initReasonCounters()
 
 	// The bounds are fixed for the life of the process, and queueBytes and the drop
 	// counters cannot be read without them.

--- a/internal/db/p2p/p2p.go
+++ b/internal/db/p2p/p2p.go
@@ -941,7 +941,7 @@ func (p *P2P) processPushlogRequest(
 				if ok {
 					p.statMergedDocs.Add(1)
 				} else {
-					p.dropDoc("mergeFailed")
+					p.dropDoc(dropMergeFailed)
 					dropped++
 				}
 			}
@@ -986,7 +986,7 @@ func (p *P2P) processPushlogRequest(
 
 	headCID, err := cid.Cast(req.CID)
 	if err != nil {
-		p.dropDoc("invalidCID")
+		p.dropDoc(dropInvalidCID)
 		return err
 	}
 
@@ -999,11 +999,11 @@ func (p *P2P) processPushlogRequest(
 		// Check if we've already merged this block. If so, skip the sink process.
 		isMerged, err := p.db.Multistore().Blockstore().IsMerged(ctx, headCID)
 		if err != nil {
-			p.dropDoc("isMergedError")
+			p.dropDoc(dropIsMergedError)
 			return err
 		}
 		if isMerged {
-			p.skipDoc("alreadyMerged")
+			p.skipDoc(skipAlreadyMerged)
 			return nil
 		}
 
@@ -1017,7 +1017,7 @@ func (p *P2P) processPushlogRequest(
 			block, err = coreblock.GetFromBytes(req.Block)
 		}
 		if err != nil {
-			p.dropDoc("blockDecode")
+			p.dropDoc(dropBlockDecode)
 			return err
 		}
 
@@ -1025,11 +1025,11 @@ func (p *P2P) processPushlogRequest(
 		// arbitrary content under a CID of its choosing.
 		blockLink, err := block.GenerateLink()
 		if err != nil {
-			p.dropDoc("generateLink")
+			p.dropDoc(dropGenerateLink)
 			return err
 		}
 		if blockLink.Cid != headCID {
-			p.dropDoc("cidMismatch")
+			p.dropDoc(dropCIDMismatch)
 			return ErrBlockCIDMismatch
 		}
 
@@ -1038,19 +1038,19 @@ func (p *P2P) processPushlogRequest(
 		if !isReplicator {
 			mightHaveAccess, err := p.trySelfHasAccess(ctx, headCID, block, req.CollectionID, req.DocID)
 			if err != nil {
-				p.dropDoc("accessError")
+				p.dropDoc(dropAccessError)
 				return err
 			}
 			if !mightHaveAccess {
 				// If we know we don't have access, we can skip the rest of the processing.
-				p.skipDoc("noAccess")
+				p.skipDoc(skipNoAccess)
 				return nil
 			}
 		}
 
 		// Run the replication filter before writing any blocks to storage.
 		if !p.filterAllowsReplication(ctx, req.CollectionID, req.DocID, block) {
-			p.skipDoc("filtered")
+			p.skipDoc(skipFiltered)
 			return nil
 		}
 
@@ -1058,12 +1058,12 @@ func (p *P2P) processPushlogRequest(
 		if len(req.CAR) > 0 {
 			// CAR contains the full block DAG — import it directly, no round-trip sync needed.
 			if _, err = p.importCAR(ctx, req.CAR); err != nil {
-				p.dropDoc("importCAR")
+				p.dropDoc(dropImportCAR)
 				return err
 			}
 		} else {
 			if err = p.syncDAG(ctx, block); err != nil {
-				p.dropDoc("syncDAG")
+				p.dropDoc(dropSyncDAG)
 				return err
 			}
 		}
@@ -1076,7 +1076,7 @@ func (p *P2P) processPushlogRequest(
 			CollectionID: req.CollectionID,
 		}
 		if err = p.db.Merge(ctx, mergeEvt); err != nil {
-			p.dropDoc("mergeFailed")
+			p.dropDoc(dropMergeFailed)
 			return err
 		}
 		p.statMergedDocs.Add(1)
@@ -1101,9 +1101,9 @@ func (p *P2P) processPushlogRequest(
 
 	if !handled {
 		if err == nil {
-			p.skipDoc("inFlight")
+			p.skipDoc(skipInFlight)
 		} else {
-			p.dropDoc("syncQueueFull")
+			p.dropDoc(dropSyncQueueFull)
 		}
 	}
 	return err
@@ -1140,18 +1140,18 @@ func (p *P2P) processBatchedDocuments(
 				slog.String("DocID", doc.DocID),
 				slog.String("CollectionID", req.CollectionID),
 			)
-			drop("invalidCID")
+			drop(dropInvalidCID)
 			continue
 		}
 
 		isMerged, err := p.db.Multistore().Blockstore().IsMerged(ctx, headCID)
 		if err != nil {
 			log.ErrorE("Batch: IsMerged check failed", err, slog.String("DocID", doc.DocID))
-			drop("isMergedError")
+			drop(dropIsMergedError)
 			continue
 		}
 		if isMerged {
-			p.skipDoc("alreadyMerged")
+			p.skipDoc(skipAlreadyMerged)
 			continue
 		}
 
@@ -1163,19 +1163,19 @@ func (p *P2P) processBatchedDocuments(
 		}
 		if err != nil {
 			log.ErrorE("Batch: block decode failed", err, slog.String("DocID", doc.DocID))
-			drop("blockDecode")
+			drop(dropBlockDecode)
 			continue
 		}
 
 		blockLink, err := block.GenerateLink()
 		if err != nil {
 			log.ErrorE("Batch: GenerateLink failed", err, slog.String("DocID", doc.DocID))
-			drop("generateLink")
+			drop(dropGenerateLink)
 			continue
 		}
 		if blockLink.Cid != headCID {
 			log.Error("Batch: CID mismatch", slog.String("DocID", doc.DocID))
-			drop("cidMismatch")
+			drop(dropCIDMismatch)
 			continue
 		}
 
@@ -1183,30 +1183,30 @@ func (p *P2P) processBatchedDocuments(
 			mightHaveAccess, err := p.trySelfHasAccess(ctx, headCID, block, req.CollectionID, doc.DocID)
 			if err != nil {
 				log.ErrorE("Batch: access check failed", err, slog.String("DocID", doc.DocID))
-				drop("accessError")
+				drop(dropAccessError)
 				continue
 			}
 			if !mightHaveAccess {
-				p.skipDoc("noAccess")
+				p.skipDoc(skipNoAccess)
 				continue
 			}
 		}
 
 		if !p.filterAllowsReplication(ctx, req.CollectionID, doc.DocID, block) {
-			p.skipDoc("filtered")
+			p.skipDoc(skipFiltered)
 			continue
 		}
 
 		if len(doc.CAR) > 0 {
 			if _, err = p.importCAR(ctx, doc.CAR); err != nil {
 				log.ErrorE("Batch: importCAR failed", err, slog.String("DocID", doc.DocID))
-				drop("importCAR")
+				drop(dropImportCAR)
 				continue
 			}
 		} else {
 			if err = p.syncDAG(ctx, block); err != nil {
 				log.ErrorE("Batch: syncDAG failed", err, slog.String("DocID", doc.DocID))
-				drop("syncDAG")
+				drop(dropSyncDAG)
 				continue
 			}
 		}

--- a/internal/db/p2p/p2p.go
+++ b/internal/db/p2p/p2p.go
@@ -71,7 +71,7 @@ const (
 	dagSyncWorkers = 32
 
 	// msgQueueSize is the capacity of the incoming pubsub message queue.
-	// Messages that arrive when the queue is full are dropped with a warning.
+	// Messages that arrive when the queue is full are dropped and counted.
 	msgQueueSize = 50_000
 
 	// msgQueueMemDivisor sets the queue's byte budget as this fraction of the process
@@ -91,6 +91,11 @@ const (
 	// this node's own batchMaxDocs to hold the per-entry cost under a tenth of a message. The
 	// cap applies while decoding, since the decode allocates before the message can be charged.
 	maxInboundDocuments = 16 * batchMaxDocs
+
+	// statsInterval is how often queue depth and merge counters are reported. Rates are
+	// reported per interval rather than per event, which keeps the ingest path quiet
+	// under load where per-event logging would dominate the output.
+	statsInterval = 30 * time.Second
 )
 
 // retainedBytesPerDocument is the fixed cost of one decoded batch entry, whatever it carries.
@@ -233,6 +238,46 @@ type P2P struct {
 	msgQueueBytes atomic.Int64
 	// msgQueueMaxBytes caps msgQueueBytes. Zero or less disables the byte bound.
 	msgQueueMaxBytes int64
+
+	// Counters reported by reportStats and reset on each report, so each line carries
+	// the rate for that interval rather than a running total.
+	// statMsgsIn counts every message the dispatcher hands over, including dropped ones,
+	// so the drop counters have a denominator.
+	statMsgsIn        atomic.Int64
+	statDroppedBudget atomic.Int64
+	statDroppedFull   atomic.Int64
+	statMergedDocs    atomic.Int64
+	statDroppedDocs   atomic.Int64
+	// statSkippedDocs counts documents deliberately not merged: already held, or
+	// excluded by access or the replication filter. Not a loss, so kept apart.
+	statSkippedDocs atomic.Int64
+	statBatches     atomic.Int64
+	// statBatchesWithDrops counts batches in which at least one document dropped. The
+	// rest of the batch still commits, so this is not a count of failed batches.
+	statBatchesWithDrops atomic.Int64
+
+	// The inbound CAR path: imports attempted, imports abandoned, and the blocks an
+	// abandoned import had already written. Every document this node stores arrives this
+	// way, so the generation counters below say nothing about it.
+	statCARImports      atomic.Int64
+	statCARImportFailed atomic.Int64
+
+	// CAR generation counters. A CAR that carries only the root block gives its receiver
+	// nothing to import, so the receiver falls back to a per-link BitSwap walk.
+	statCARBuilt           atomic.Int64
+	statCARFailed          atomic.Int64
+	statCARMissing         atomic.Int64
+	carFailureReason       failureReasons
+	carImportFailureReason failureReasons
+
+	// statSyncDAGCalls counts walks started, which is how often a document could not be
+	// merged from the CAR alone and needed blocks fetched.
+	statSyncDAGCalls     atomic.Int64
+	syncDAGFailureReason failureReasons
+
+	// docDropReason names why an inbound document never reached the merge. The set is
+	// fixed: a reason taken from an error string would let a peer grow the map.
+	docDropReason failureReasons
 }
 
 // pushLogCommProcessor implements CommProcessor for push log functionality
@@ -292,10 +337,17 @@ func New(
 		msgQueueMaxBytes:     queueByteBudget(),
 	}
 
+	// The bounds are fixed for the life of the process, and queueBytes and the drop
+	// counters cannot be read without them.
+	log.Info("p2p queue bounds",
+		corelog.Int("slots", msgQueueSize),
+		corelog.Int64("byteBudget", p.msgQueueMaxBytes))
+
 	for i := 0; i < dagSyncWorkers; i++ {
 		p.msgWorkers.Add(1)
 		go p.processMessageWorker()
 	}
+	go p.reportStats()
 
 	p.replicatorProtocol = protocol.NewCommChannel(host, "rep", &pushLogCommProcessor{p2p: &p})
 	p.batcher = newPubsubBatcher(host.ID(), func(topic string, data []byte) error {
@@ -681,18 +733,16 @@ func (p *P2P) docIDsForBlockCID(
 
 // pubSubMessageHandler decodes the incoming wire message and enqueues it for
 // processing by the bounded worker pool. It never blocks the libp2p pubsub
-// dispatcher: if the queue is full the message is dropped with a warning.
+// dispatcher: if the queue is full the message is dropped and counted.
 //
 // Most of the budget is claimed before decoding, so a message that cannot be queued does not
 // pay for a decode it will not use. The per-entry cost of a batch is only known after the
 // decode, and is claimed there.
 func (p *P2P) pubSubMessageHandler(from string, topic string, msg []byte) ([]byte, error) {
 	size := int64(len(msg))
+	p.statMsgsIn.Add(1)
 	if !p.claimQueueBytes(size) {
-		log.Info("pubsub message queue over byte budget, dropping message",
-			corelog.Any("topic", topic),
-			corelog.Int64("bytes", size),
-			corelog.Int64("budget", p.msgQueueMaxBytes))
+		p.statDroppedBudget.Add(1)
 		return nil, nil
 	}
 
@@ -709,11 +759,7 @@ func (p *P2P) pubSubMessageHandler(from string, topic string, msg []byte) ([]byt
 	if perDocument := retainedBytesPerDocument * int64(len(req.Documents)); perDocument > 0 {
 		if !p.claimQueueBytes(perDocument) {
 			p.releaseQueueBytes(size)
-			log.Info("pubsub message queue over byte budget, dropping message",
-				corelog.Any("topic", topic),
-				corelog.Int64("bytes", size+perDocument),
-				corelog.Int64("documents", int64(len(req.Documents))),
-				corelog.Int64("budget", p.msgQueueMaxBytes))
+			p.statDroppedBudget.Add(1)
 			return nil, nil
 		}
 		size += perDocument
@@ -725,7 +771,7 @@ func (p *P2P) pubSubMessageHandler(from string, topic string, msg []byte) ([]byt
 		p.releaseQueueBytes(size)
 	default:
 		p.releaseQueueBytes(size)
-		log.Info("pubsub message queue full, dropping message", corelog.Any("topic", topic))
+		p.statDroppedFull.Add(1)
 	}
 	return nil, nil
 }
@@ -749,6 +795,67 @@ func (p *P2P) releaseQueueBytes(size int64) {
 		return
 	}
 	p.msgQueueBytes.Add(-size)
+}
+
+// reportStats periodically logs queue occupancy and merge outcomes. Queue depth and the
+// split between merged and dropped documents are otherwise only visible from a heap
+// profile, which is too invasive to take routinely.
+func (p *P2P) reportStats() {
+	ticker := time.NewTicker(statsInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-p.ctx.Done():
+			return
+		case <-ticker.C:
+			droppedOverBudget := p.statDroppedBudget.Swap(0)
+			droppedQueueFull := p.statDroppedFull.Swap(0)
+			log.Info("p2p stats",
+				corelog.Int("queueDepth", len(p.msgQueue)),
+				corelog.Int64("queueBytes", p.msgQueueBytes.Load()),
+				corelog.Int64("droppedOverBudget", droppedOverBudget),
+				corelog.Int64("droppedQueueFull", droppedQueueFull),
+				corelog.Int64("batches", p.statBatches.Swap(0)),
+				corelog.Int64("batchesWithDrops", p.statBatchesWithDrops.Swap(0)),
+				corelog.Int64("docsMerged", p.statMergedDocs.Swap(0)),
+				corelog.Int64("docsDropped", p.statDroppedDocs.Swap(0)),
+				corelog.Int64("docsSkipped", p.statSkippedDocs.Swap(0)),
+				corelog.Int64("msgsIn", p.statMsgsIn.Swap(0)),
+				corelog.Int64("carImports", p.statCARImports.Swap(0)),
+				corelog.Int64("carImportFailed", p.statCARImportFailed.Swap(0)),
+				corelog.Int64("carBuilt", p.statCARBuilt.Swap(0)),
+				corelog.Int64("carFailed", p.statCARFailed.Swap(0)),
+				corelog.Int64("carMissingLinks", p.statCARMissing.Swap(0)),
+				corelog.Int64("syncDAGCalls", p.statSyncDAGCalls.Swap(0)),
+			)
+			// A drop at the door is data this node will not hold. The stats line above is at
+			// info, so a node running at error level sees only this.
+			if droppedOverBudget != 0 || droppedQueueFull != 0 {
+				log.Error("dropped inbound pubsub messages",
+					corelog.Int64("overBudget", droppedOverBudget),
+					corelog.Int64("queueFull", droppedQueueFull))
+			}
+
+			reportFailureReasons("car failures", p.carFailureReason.drain())
+			reportFailureReasons("syncDAG failures", p.syncDAGFailureReason.drain())
+			reportFailureReasons("document drops", p.docDropReason.drain())
+			reportFailureReasons("CAR import failures", p.carImportFailureReason.drain())
+		}
+	}
+}
+
+// reportFailureReasons logs one line naming every reason that occurred in the interval,
+// or nothing when there were none. Reasons come from a fixed set, so the line has a
+// bounded width.
+func reportFailureReasons(msg string, counts []reasonCount) {
+	if len(counts) == 0 {
+		return
+	}
+	fields := make([]slog.Attr, 0, len(counts))
+	for _, c := range counts {
+		fields = append(fields, corelog.Int64(c.reason, c.count))
+	}
+	log.Info(msg, fields...)
 }
 
 // processMessageWorker is a long-lived goroutine that drains p.msgQueue and
@@ -816,7 +923,16 @@ func (p *P2P) processPushlogRequest(
 			merges[i] = r.merge
 		}
 		merged, err := p.db.MergeBatchWithTxn(ctx, merges)
+		p.statBatches.Add(1)
+		for _, ok := range merged {
+			if ok {
+				p.statMergedDocs.Add(1)
+			} else {
+				p.dropDoc("mergeFailed")
+			}
+		}
 		if err != nil {
+			p.statBatchesWithDrops.Add(1)
 			log.ErrorE("Failed to merge documents in batch", err,
 				corelog.String("PeerID", req.SenderID),
 				corelog.Int("Documents", len(merges)))
@@ -921,8 +1037,10 @@ func (p *P2P) processPushlogRequest(
 			CollectionID: req.CollectionID,
 		}
 		if err = p.db.Merge(ctx, mergeEvt); err != nil {
+			p.dropDoc("mergeFailed")
 			return err
 		}
+		p.statMergedDocs.Add(1)
 
 		// Notify bus subscribers and the network of peers that we have a new document available.
 		updateEvt := event.Update{
@@ -967,15 +1085,18 @@ func (p *P2P) processBatchedDocuments(
 				slog.String("DocID", doc.DocID),
 				slog.String("CollectionID", req.CollectionID),
 			)
+			p.dropDoc("invalidCID")
 			continue
 		}
 
 		isMerged, err := p.db.Multistore().Blockstore().IsMerged(ctx, headCID)
 		if err != nil {
 			log.ErrorE("Batch: IsMerged check failed", err, slog.String("DocID", doc.DocID))
+			p.dropDoc("isMergedError")
 			continue
 		}
 		if isMerged {
+			p.skipDoc("alreadyMerged")
 			continue
 		}
 
@@ -987,16 +1108,19 @@ func (p *P2P) processBatchedDocuments(
 		}
 		if err != nil {
 			log.ErrorE("Batch: block decode failed", err, slog.String("DocID", doc.DocID))
+			p.dropDoc("blockDecode")
 			continue
 		}
 
 		blockLink, err := block.GenerateLink()
 		if err != nil {
 			log.ErrorE("Batch: GenerateLink failed", err, slog.String("DocID", doc.DocID))
+			p.dropDoc("generateLink")
 			continue
 		}
 		if blockLink.Cid != headCID {
 			log.Error("Batch: CID mismatch", slog.String("DocID", doc.DocID))
+			p.dropDoc("cidMismatch")
 			continue
 		}
 
@@ -1004,25 +1128,30 @@ func (p *P2P) processBatchedDocuments(
 			mightHaveAccess, err := p.trySelfHasAccess(ctx, headCID, block, req.CollectionID, doc.DocID)
 			if err != nil {
 				log.ErrorE("Batch: access check failed", err, slog.String("DocID", doc.DocID))
+				p.dropDoc("accessError")
 				continue
 			}
 			if !mightHaveAccess {
+				p.skipDoc("noAccess")
 				continue
 			}
 		}
 
 		if !p.filterAllowsReplication(ctx, req.CollectionID, doc.DocID, block) {
+			p.skipDoc("filtered")
 			continue
 		}
 
 		if len(doc.CAR) > 0 {
 			if _, err = p.importCAR(ctx, doc.CAR); err != nil {
 				log.ErrorE("Batch: importCAR failed", err, slog.String("DocID", doc.DocID))
+				p.dropDoc("importCAR")
 				continue
 			}
 		} else {
 			if err = p.syncDAG(ctx, block); err != nil {
 				log.ErrorE("Batch: syncDAG failed", err, slog.String("DocID", doc.DocID))
+				p.dropDoc("syncDAG")
 				continue
 			}
 		}

--- a/internal/db/p2p/p2p.go
+++ b/internal/db/p2p/p2p.go
@@ -974,6 +974,11 @@ func (p *P2P) processPushlogRequest(
 		return nil
 	}
 
+	// A request with no CID offered no document, so refusing it is not a loss.
+	if len(req.CID) == 0 {
+		return ErrEmptyPushLog
+	}
+
 	headCID, err := cid.Cast(req.CID)
 	if err != nil {
 		p.dropDoc("invalidCID")

--- a/internal/db/p2p/p2p.go
+++ b/internal/db/p2p/p2p.go
@@ -257,11 +257,12 @@ type P2P struct {
 	// rest of the batch still commits, so this is not a count of failed batches.
 	statBatchesWithDrops atomic.Int64
 
-	// The inbound CAR path: imports attempted, imports abandoned, and the blocks an
-	// abandoned import had already written. Every document this node stores arrives this
-	// way, so the generation counters below say nothing about it.
-	statCARImports      atomic.Int64
-	statCARImportFailed atomic.Int64
+	// The inbound CAR path: imports attempted, imports abandoned, and the blocks an abandoned
+	// import had already written. Those blocks sit in the store owned by no document until a
+	// later merge claims them.
+	statCARImports            atomic.Int64
+	statCARImportFailed       atomic.Int64
+	statCARImportOrphanBlocks atomic.Int64
 
 	// CAR generation counters. A CAR that carries only the root block gives its receiver
 	// nothing to import, so the receiver falls back to a per-link BitSwap walk.
@@ -826,6 +827,7 @@ func (p *P2P) reportStats() {
 				corelog.Int64("msgsIn", p.statMsgsIn.Swap(0)),
 				corelog.Int64("carImports", p.statCARImports.Swap(0)),
 				corelog.Int64("carImportFailed", p.statCARImportFailed.Swap(0)),
+				corelog.Int64("carImportOrphanBlocks", p.statCARImportOrphanBlocks.Swap(0)),
 				corelog.Int64("carBuilt", p.statCARBuilt.Swap(0)),
 				corelog.Int64("carFailed", p.statCARFailed.Swap(0)),
 				corelog.Int64("carMissingLinks", p.statCARMissing.Swap(0)),

--- a/internal/db/p2p/p2p_test.go
+++ b/internal/db/p2p/p2p_test.go
@@ -28,6 +28,13 @@ type SimpleMockHost struct {
 	client.Host
 }
 
+// withReasonMaps gives p the counters New builds, so a test can construct a P2P from a literal
+// and still record.
+func withReasonMaps(p *P2P) *P2P {
+	p.initReasonCounters()
+	return p
+}
+
 func (m *SimpleMockHost) ID() string {
 	return "peerID"
 }

--- a/internal/db/p2p/p2p_test.go
+++ b/internal/db/p2p/p2p_test.go
@@ -77,6 +77,8 @@ func TestPubSubMessageHandler_OverBudgetDropsBeforeDecode(t *testing.T) {
 	assert.Nil(t, resp)
 	assert.Empty(t, p.msgQueue)
 	assert.Equal(t, int64(0), p.msgQueueBytes.Load())
+	assert.Equal(t, int64(1), p.statDroppedBudget.Load())
+	assert.Equal(t, int64(0), p.statDroppedFull.Load())
 }
 
 func TestPubSubMessageHandler_ByteBudgetReleasedAfterProcessing(t *testing.T) {
@@ -140,6 +142,32 @@ func TestProcessMessageWorker_ReleasesByteBudget(t *testing.T) {
 	assert.Eventually(t, func() bool { return p.msgQueueBytes.Load() == 0 },
 		5*time.Second, 5*time.Millisecond,
 		"the worker must return the budget the handler reserved")
+}
+
+// A full queue and an exhausted budget are separate drop reasons, and the stats line is
+// only useful if a drop is attributed to the one that caused it.
+func TestPubSubMessageHandler_QueueFullCountedSeparately(t *testing.T) {
+	msg, err := cbor.Marshal(protocol.PushLogRequest{DocID: "docID"})
+	assert.NoError(t, err)
+
+	// Budget large enough to stay out of the way, so only the slot count can reject.
+	p := &P2P{
+		ctx:              context.Background(),
+		host:             &SimpleMockHost{},
+		msgQueue:         make(chan queuedMessage, 1),
+		msgQueueMaxBytes: 1 << 20,
+	}
+
+	_, err = p.pubSubMessageHandler("sender", "topic", msg)
+	assert.NoError(t, err)
+
+	_, err = p.pubSubMessageHandler("sender", "topic", msg)
+	assert.NoError(t, err)
+
+	assert.Equal(t, int64(1), p.statDroppedFull.Load())
+	assert.Equal(t, int64(0), p.statDroppedBudget.Load())
+	// The dropped message must not keep holding its reservation.
+	assert.Equal(t, int64(len(msg)), p.msgQueueBytes.Load())
 }
 
 func TestQueueByteBudget_DerivesFromMemoryLimit(t *testing.T) {

--- a/internal/db/p2p/stats.go
+++ b/internal/db/p2p/stats.go
@@ -50,19 +50,19 @@ const (
 // failure than as a cancellation.
 func syncDAGReason(err error) string {
 	switch {
-	case errors.Is(err, ErrStoreBlockDAGSync):
+	case errors.Is(err, errStoreRoot):
 		return reasonStoreRoot
-	case errors.Is(err, ErrGenerateBlockLink):
+	case errors.Is(err, errBlockLink):
 		return reasonBlockLink
-	case errors.Is(err, ErrCheckBlockMerged):
+	case errors.Is(err, errIsMerged):
 		return reasonIsMerged
-	case errors.Is(err, ErrVerifyBlockSig):
+	case errors.Is(err, errVerifySig):
 		return reasonVerifySig
-	case errors.Is(err, ErrGetEncKeysForBlock), errors.Is(err, ErrRetrieveEncKey):
+	case errors.Is(err, errEncKeys), errors.Is(err, errRetrieveKey):
 		return reasonEncKeys
-	case errors.Is(err, ErrLoadLinkedBlock):
+	case errors.Is(err, errLoadLink):
 		return reasonLoadLink
-	case errors.Is(err, ErrDecodeLinkedBlock):
+	case errors.Is(err, errDecodeLink):
 		return reasonDecodeLink
 	case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
 		return reasonContext

--- a/internal/db/p2p/stats.go
+++ b/internal/db/p2p/stats.go
@@ -103,13 +103,28 @@ type failureReasons struct {
 	flagged map[string]struct{}
 }
 
+// initReasonCounters allocates p's failure-reason maps. The zero value of failureReasons is not
+// usable, so every P2P has to pass through here.
+func (p *P2P) initReasonCounters() {
+	p.carFailureReason = newFailureReasons()
+	p.carImportFailureReason = newFailureReasons()
+	p.syncDAGFailureReason = newFailureReasons()
+	p.docDropReason = newFailureReasons()
+	p.docSkipReason = newFailureReasons()
+}
+
+// newFailureReasons returns counters ready to record.
+func newFailureReasons() failureReasons {
+	return failureReasons{
+		counts:  make(map[string]int64),
+		flagged: make(map[string]struct{}),
+	}
+}
+
 // record counts one occurrence of reason.
 func (f *failureReasons) record(reason string) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	if f.counts == nil {
-		f.counts = make(map[string]int64)
-	}
 	f.counts[reason]++
 }
 
@@ -118,12 +133,6 @@ func (f *failureReasons) record(reason string) {
 func (f *failureReasons) recordFirst(reason string) (firstSeen bool) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	if f.counts == nil {
-		f.counts = make(map[string]int64)
-	}
-	if f.flagged == nil {
-		f.flagged = make(map[string]struct{})
-	}
 	f.counts[reason]++
 	if _, seen := f.flagged[reason]; seen {
 		return false

--- a/internal/db/p2p/stats.go
+++ b/internal/db/p2p/stats.go
@@ -1,0 +1,101 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package p2p
+
+import (
+	"sort"
+	"sync"
+)
+
+// Reasons a CAR could not be generated or a DAG walk could not finish. They are a fixed
+// set: deriving a reason from an error message would let a remote peer grow the counter
+// map without bound.
+const (
+	reasonRootLink    = "rootLink"
+	reasonWalk        = "walk"
+	reasonCARWriter   = "carWriter"
+	reasonBlockRead   = "blockRead"
+	reasonCARPut      = "carPut"
+	reasonStoreRoot   = "storeRoot"
+	reasonBlockLink   = "blockLink"
+	reasonIsMerged    = "isMerged"
+	reasonVerifySig   = "verifySig"
+	reasonEncKeys     = "encKeys"
+	reasonLoadLink    = "loadLink"
+	reasonDecodeLink  = "decodeLink"
+	reasonContext     = "context"
+	reasonReader      = "carReader"
+	reasonNoRoots     = "carNoRoots"
+	reasonNext        = "carNextBlock"
+	reasonNoRootBlock = "carNoRootBlock"
+)
+
+// failureReasons counts failures by reason and remembers which reasons it has already
+// logged. A repeated failure costs a counter increment rather than a log line; the first
+// occurrence of each reason gets one line carrying the underlying error.
+type failureReasons struct {
+	mu      sync.Mutex
+	counts  map[string]int64
+	flagged map[string]struct{}
+}
+
+// record counts one failure and reports whether this reason has not been logged yet.
+func (f *failureReasons) record(reason string) (firstSeen bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.counts == nil {
+		f.counts = make(map[string]int64)
+		f.flagged = make(map[string]struct{})
+	}
+	f.counts[reason]++
+	if _, seen := f.flagged[reason]; seen {
+		return false
+	}
+	f.flagged[reason] = struct{}{}
+	return true
+}
+
+// drain returns the counts accumulated since the last call, sorted by reason, and resets
+// them. The set of already-logged reasons is deliberately kept: a reason is logged once
+// per process, not once per interval.
+func (f *failureReasons) drain() []reasonCount {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.counts) == 0 {
+		return nil
+	}
+	out := make([]reasonCount, 0, len(f.counts))
+	for reason, n := range f.counts {
+		out = append(out, reasonCount{reason: reason, count: n})
+		delete(f.counts, reason)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].reason < out[j].reason })
+	return out
+}
+
+type reasonCount struct {
+	reason string
+	count  int64
+}
+
+// dropDoc counts an inbound document that was meant to be stored and was not, naming why.
+// The reason set is fixed, so a peer cannot grow the map by varying its errors.
+func (p *P2P) dropDoc(reason string) {
+	p.statDroppedDocs.Add(1)
+	p.docDropReason.record(reason)
+}
+
+// skipDoc counts an inbound document deliberately not merged: already held, or excluded
+// by access or the replication filter. Kept apart from drops, which are losses.
+func (p *P2P) skipDoc(reason string) {
+	p.statSkippedDocs.Add(1)
+	p.docDropReason.record("skip:" + reason)
+}

--- a/internal/db/p2p/stats.go
+++ b/internal/db/p2p/stats.go
@@ -71,6 +71,29 @@ func syncDAGReason(err error) string {
 	}
 }
 
+// Causes a document can be dropped for.
+const (
+	dropAccessError   = "accessError"
+	dropBlockDecode   = "blockDecode"
+	dropCIDMismatch   = "cidMismatch"
+	dropGenerateLink  = "generateLink"
+	dropImportCAR     = "importCAR"
+	dropInvalidCID    = "invalidCID"
+	dropIsMergedError = "isMergedError"
+	dropMergeFailed   = "mergeFailed"
+	dropSyncDAG       = "syncDAG"
+	dropSyncQueueFull = "syncQueueFull"
+)
+
+// Reasons a document was skipped.
+const (
+	skipAlreadyMerged = "alreadyMerged"
+	skipDuplicateHead = "duplicateHead"
+	skipFiltered      = "filtered"
+	skipInFlight      = "inFlight"
+	skipNoAccess      = "noAccess"
+)
+
 // failureReasons counts occurrences by reason, drained once per report interval. Callers
 // that also log keep the set of reasons already logged, so a repeated occurrence costs a
 // counter increment rather than a line.

--- a/internal/db/p2p/stats.go
+++ b/internal/db/p2p/stats.go
@@ -38,21 +38,34 @@ const (
 	reasonNoRootBlock = "carNoRootBlock"
 )
 
-// failureReasons counts failures by reason and remembers which reasons it has already
-// logged. A repeated failure costs a counter increment rather than a log line; the first
-// occurrence of each reason gets one line carrying the underlying error.
+// failureReasons counts occurrences by reason, drained once per report interval. Callers
+// that also log keep the set of reasons already logged, so a repeated occurrence costs a
+// counter increment rather than a line.
 type failureReasons struct {
 	mu      sync.Mutex
 	counts  map[string]int64
 	flagged map[string]struct{}
 }
 
-// record counts one failure and reports whether this reason has not been logged yet.
-func (f *failureReasons) record(reason string) (firstSeen bool) {
+// record counts one occurrence of reason.
+func (f *failureReasons) record(reason string) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if f.counts == nil {
 		f.counts = make(map[string]int64)
+	}
+	f.counts[reason]++
+}
+
+// recordFirst counts one occurrence and reports whether this reason has not been seen before,
+// so the caller can log the first and count the rest.
+func (f *failureReasons) recordFirst(reason string) (firstSeen bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.counts == nil {
+		f.counts = make(map[string]int64)
+	}
+	if f.flagged == nil {
 		f.flagged = make(map[string]struct{})
 	}
 	f.counts[reason]++
@@ -93,9 +106,10 @@ func (p *P2P) dropDoc(reason string) {
 	p.docDropReason.record(reason)
 }
 
-// skipDoc counts an inbound document deliberately not merged: already held, or excluded
-// by access or the replication filter. Kept apart from drops, which are losses.
+// skipDoc counts an inbound document deliberately not merged: already held, already in
+// flight, repeated within one document-sync round, or excluded by access or the replication
+// filter. Kept apart from drops, which are losses.
 func (p *P2P) skipDoc(reason string) {
 	p.statSkippedDocs.Add(1)
-	p.docDropReason.record("skip:" + reason)
+	p.docSkipReason.record(reason)
 }

--- a/internal/db/p2p/stats.go
+++ b/internal/db/p2p/stats.go
@@ -11,8 +11,11 @@
 package p2p
 
 import (
+	"context"
 	"sort"
 	"sync"
+
+	"github.com/sourcenetwork/defradb/errors"
 )
 
 // Reasons a CAR could not be generated or a DAG walk could not finish. They are a fixed
@@ -36,7 +39,37 @@ const (
 	reasonNoRoots     = "carNoRoots"
 	reasonNext        = "carNextBlock"
 	reasonNoRootBlock = "carNoRootBlock"
+
+	// An unrecognised failure counts as reasonOther, so that staying non-zero means
+	// syncDAGReason has fallen behind the code.
+	reasonOther = "other"
 )
+
+// syncDAGReason names the step a DAG sync failed on. The specific failures come first: a
+// load that failed because the context was cancelled is more usefully reported as a load
+// failure than as a cancellation.
+func syncDAGReason(err error) string {
+	switch {
+	case errors.Is(err, ErrStoreBlockDAGSync):
+		return reasonStoreRoot
+	case errors.Is(err, ErrGenerateBlockLink):
+		return reasonBlockLink
+	case errors.Is(err, ErrCheckBlockMerged):
+		return reasonIsMerged
+	case errors.Is(err, ErrVerifyBlockSig):
+		return reasonVerifySig
+	case errors.Is(err, ErrGetEncKeysForBlock), errors.Is(err, ErrRetrieveEncKey):
+		return reasonEncKeys
+	case errors.Is(err, ErrLoadLinkedBlock):
+		return reasonLoadLink
+	case errors.Is(err, ErrDecodeLinkedBlock):
+		return reasonDecodeLink
+	case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+		return reasonContext
+	default:
+		return reasonOther
+	}
+}
 
 // failureReasons counts occurrences by reason, drained once per report interval. Callers
 // that also log keep the set of reasons already logged, so a repeated occurrence costs a

--- a/internal/db/p2p/sync_dag.go
+++ b/internal/db/p2p/sync_dag.go
@@ -17,6 +17,7 @@ import (
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 
 	"github.com/sourcenetwork/corekv/blockstore"
+	"github.com/sourcenetwork/corelog"
 	"github.com/sourcenetwork/immutable"
 
 	coreblock "github.com/sourcenetwork/defradb/internal/core/block"
@@ -47,18 +48,49 @@ func (p *P2P) syncDAG(ctx context.Context, block *coreblock.Block) error {
 
 	linkSystem := makeLinkSystem(p.host.IPLDStore())
 
+	p.statSyncDAGCalls.Add(1)
+
+	// written counts the links this walk has loaded, which is how far it got rather than
+	// how many blocks it added: a link already held loads without writing anything.
+	var written int64
+
 	// Store the block in the DAG store
 	_, err := linkSystem.Store(linking.LinkContext{Ctx: sessionCtx}, coreblock.GetLinkPrototype(), block.GenerateNode())
 	if err != nil {
+		p.syncDAGFailure(reasonStoreRoot, written, err)
 		return NewErrStoreBlockDAGSync(err)
 	}
+	written++
 
-	return p.loadBlockLinks(sessionCtx, &linkSystem, block)
+	reason, err := p.loadBlockLinks(sessionCtx, &linkSystem, block, &written)
+	if err != nil {
+		p.syncDAGFailure(reason, written, err)
+		return err
+	}
+	return nil
+}
+
+// syncDAGFailure records an abandoned walk: how it failed and how far it had got. The
+// first occurrence of each reason gets a log line; the rest are counted only.
+func (p *P2P) syncDAGFailure(reason string, loaded int64, err error) {
+	if p.syncDAGFailureReason.record(reason) {
+		log.ErrorE("DAG sync abandoned", err,
+			corelog.String("reason", reason),
+			corelog.Int64("blocksLoaded", loaded))
+	}
 }
 
 // loadBlockLinks traverses the DAG rooted at block and syncs all linked blocks.
 // Uses an explicit stack to avoid goroutine stack overflow on deep DAGs (#2722).
-func (p *P2P) loadBlockLinks(ctx context.Context, linkSys *linking.LinkSystem, block *coreblock.Block) error {
+//
+// written is incremented for each block the walk pulls into the blockstore. On error the
+// returned reason names the step that failed, for the caller's counters.
+func (p *P2P) loadBlockLinks(
+	ctx context.Context,
+	linkSys *linking.LinkSystem,
+	block *coreblock.Block,
+	written *int64,
+) (string, error) {
 	bstore := datastore.BlockstoreFrom(p.db.Rootstore(), immutable.None[int]())
 	stack := []*coreblock.Block{block}
 
@@ -68,11 +100,11 @@ func (p *P2P) loadBlockLinks(ctx context.Context, linkSys *linking.LinkSystem, b
 
 		link, err := current.GenerateLink()
 		if err != nil {
-			return NewErrGenerateBlockLink(err)
+			return reasonBlockLink, NewErrGenerateBlockLink(err)
 		}
 		merged, err := bstore.IsMerged(ctx, link.Cid)
 		if err != nil {
-			return NewErrCheckBlockMerged(err)
+			return reasonIsMerged, NewErrCheckBlockMerged(err)
 		}
 		if merged {
 			continue
@@ -86,7 +118,7 @@ func (p *P2P) loadBlockLinks(ctx context.Context, linkSys *linking.LinkSystem, b
 			// But we want to keep the API of VerifyBlockSignature explicit about the results.
 			_, err := coreblock.VerifyBlockSignature(current, linkSys)
 			if err != nil {
-				return NewErrVerifyBlockSig(err)
+				return reasonVerifySig, NewErrVerifyBlockSig(err)
 			}
 		}
 
@@ -94,21 +126,21 @@ func (p *P2P) loadBlockLinks(ctx context.Context, linkSys *linking.LinkSystem, b
 		if current.IsEncrypted() {
 			results, err := p.kms.GetKeys(ctx, *current.Encryption)
 			if err != nil {
-				return NewErrGetEncKeysForBlock(err)
+				return reasonEncKeys, NewErrGetEncKeysForBlock(err)
 			}
 			encResults = results
 		}
 
 		for _, lnk := range current.AllLinks() {
 			if ctx.Err() != nil {
-				return ctx.Err()
+				return reasonContext, ctx.Err()
 			}
 
 			// Skip fetch if the linked block is already merged locally — avoids a BitSwap
 			// round-trip for historical blocks that may have been pruned on the sender.
 			linkedMerged, err := bstore.IsMerged(ctx, lnk.Cid)
 			if err != nil {
-				return NewErrCheckBlockMerged(err)
+				return reasonIsMerged, NewErrCheckBlockMerged(err)
 			}
 			if linkedMerged {
 				continue
@@ -119,12 +151,15 @@ func (p *P2P) loadBlockLinks(ctx context.Context, linkSys *linking.LinkSystem, b
 			cancel()
 
 			if err != nil {
-				return NewErrLoadLinkedBlock(err)
+				return reasonLoadLink, NewErrLoadLinkedBlock(err)
 			}
+			// The link system writes what it fetches, so a successful load is one more
+			// block in the store.
+			*written++
 
 			linkBlock, err := coreblock.GetFromNode(nd)
 			if err != nil {
-				return NewErrDecodeLinkedBlock(err)
+				return reasonDecodeLink, NewErrDecodeLinkedBlock(err)
 			}
 
 			stack = append(stack, linkBlock)
@@ -133,11 +168,11 @@ func (p *P2P) loadBlockLinks(ctx context.Context, linkSys *linking.LinkSystem, b
 		if encResults != nil {
 			for res := range encResults.Get() {
 				if res.Error != nil {
-					return NewErrRetrieveEncKey(res.Error)
+					return reasonEncKeys, NewErrRetrieveEncKey(res.Error)
 				}
 			}
 		}
 	}
 
-	return nil
+	return "", nil
 }

--- a/internal/db/p2p/sync_dag.go
+++ b/internal/db/p2p/sync_dag.go
@@ -57,14 +57,14 @@ func (p *P2P) syncDAG(ctx context.Context, block *coreblock.Block) error {
 	// Store the block in the DAG store
 	_, err := linkSystem.Store(linking.LinkContext{Ctx: sessionCtx}, coreblock.GetLinkPrototype(), block.GenerateNode())
 	if err != nil {
-		p.syncDAGFailure(reasonStoreRoot, written, err)
-		return NewErrStoreBlockDAGSync(err)
+		err = NewErrStoreBlockDAGSync(err)
+		p.syncDAGFailure(written, err)
+		return err
 	}
 	written++
 
-	reason, err := p.loadBlockLinks(sessionCtx, &linkSystem, block, &written)
-	if err != nil {
-		p.syncDAGFailure(reason, written, err)
+	if err := p.loadBlockLinks(sessionCtx, &linkSystem, block, &written); err != nil {
+		p.syncDAGFailure(written, err)
 		return err
 	}
 	return nil
@@ -72,7 +72,8 @@ func (p *P2P) syncDAG(ctx context.Context, block *coreblock.Block) error {
 
 // syncDAGFailure records an abandoned walk: how it failed and how far it had got. The
 // first occurrence of each reason gets a log line; the rest are counted only.
-func (p *P2P) syncDAGFailure(reason string, loaded int64, err error) {
+func (p *P2P) syncDAGFailure(loaded int64, err error) {
+	reason := syncDAGReason(err)
 	if p.syncDAGFailureReason.recordFirst(reason) {
 		log.ErrorE("DAG sync abandoned", err,
 			corelog.String("reason", reason),
@@ -83,14 +84,13 @@ func (p *P2P) syncDAGFailure(reason string, loaded int64, err error) {
 // loadBlockLinks traverses the DAG rooted at block and syncs all linked blocks.
 // Uses an explicit stack to avoid goroutine stack overflow on deep DAGs (#2722).
 //
-// written is incremented for each link the walk loads. On error the returned reason names the
-// step that failed, for the caller's counters.
+// written is incremented for each link the walk loads.
 func (p *P2P) loadBlockLinks(
 	ctx context.Context,
 	linkSys *linking.LinkSystem,
 	block *coreblock.Block,
 	written *int64,
-) (string, error) {
+) error {
 	bstore := datastore.BlockstoreFrom(p.db.Rootstore(), immutable.None[int]())
 	stack := []*coreblock.Block{block}
 
@@ -100,11 +100,11 @@ func (p *P2P) loadBlockLinks(
 
 		link, err := current.GenerateLink()
 		if err != nil {
-			return reasonBlockLink, NewErrGenerateBlockLink(err)
+			return NewErrGenerateBlockLink(err)
 		}
 		merged, err := bstore.IsMerged(ctx, link.Cid)
 		if err != nil {
-			return reasonIsMerged, NewErrCheckBlockMerged(err)
+			return NewErrCheckBlockMerged(err)
 		}
 		if merged {
 			continue
@@ -118,7 +118,7 @@ func (p *P2P) loadBlockLinks(
 			// But we want to keep the API of VerifyBlockSignature explicit about the results.
 			_, err := coreblock.VerifyBlockSignature(current, linkSys)
 			if err != nil {
-				return reasonVerifySig, NewErrVerifyBlockSig(err)
+				return NewErrVerifyBlockSig(err)
 			}
 		}
 
@@ -126,21 +126,21 @@ func (p *P2P) loadBlockLinks(
 		if current.IsEncrypted() {
 			results, err := p.kms.GetKeys(ctx, *current.Encryption)
 			if err != nil {
-				return reasonEncKeys, NewErrGetEncKeysForBlock(err)
+				return NewErrGetEncKeysForBlock(err)
 			}
 			encResults = results
 		}
 
 		for _, lnk := range current.AllLinks() {
 			if ctx.Err() != nil {
-				return reasonContext, ctx.Err()
+				return ctx.Err()
 			}
 
 			// Skip fetch if the linked block is already merged locally — avoids a BitSwap
 			// round-trip for historical blocks that may have been pruned on the sender.
 			linkedMerged, err := bstore.IsMerged(ctx, lnk.Cid)
 			if err != nil {
-				return reasonIsMerged, NewErrCheckBlockMerged(err)
+				return NewErrCheckBlockMerged(err)
 			}
 			if linkedMerged {
 				continue
@@ -151,13 +151,13 @@ func (p *P2P) loadBlockLinks(
 			cancel()
 
 			if err != nil {
-				return reasonLoadLink, NewErrLoadLinkedBlock(err)
+				return NewErrLoadLinkedBlock(err)
 			}
 			*written++
 
 			linkBlock, err := coreblock.GetFromNode(nd)
 			if err != nil {
-				return reasonDecodeLink, NewErrDecodeLinkedBlock(err)
+				return NewErrDecodeLinkedBlock(err)
 			}
 
 			stack = append(stack, linkBlock)
@@ -166,11 +166,11 @@ func (p *P2P) loadBlockLinks(
 		if encResults != nil {
 			for res := range encResults.Get() {
 				if res.Error != nil {
-					return reasonEncKeys, NewErrRetrieveEncKey(res.Error)
+					return NewErrRetrieveEncKey(res.Error)
 				}
 			}
 		}
 	}
 
-	return "", nil
+	return nil
 }

--- a/internal/db/p2p/sync_dag.go
+++ b/internal/db/p2p/sync_dag.go
@@ -50,21 +50,19 @@ func (p *P2P) syncDAG(ctx context.Context, block *coreblock.Block) error {
 
 	p.statSyncDAGCalls.Add(1)
 
-	// written counts the links this walk has loaded, which is how far it got rather than
-	// how many blocks it added: a link already held loads without writing anything.
-	var written int64
-
 	// Store the block in the DAG store
 	_, err := linkSystem.Store(linking.LinkContext{Ctx: sessionCtx}, coreblock.GetLinkPrototype(), block.GenerateNode())
 	if err != nil {
 		err = NewErrStoreBlockDAGSync(err)
-		p.syncDAGFailure(written, err)
+		p.syncDAGFailure(0, err)
 		return err
 	}
-	written++
 
-	if err := p.loadBlockLinks(sessionCtx, &linkSystem, block, &written); err != nil {
-		p.syncDAGFailure(written, err)
+	// The root counts toward how far the walk got, rather than how many blocks it added: a link
+	// already held loads without writing anything.
+	loaded, err := p.loadBlockLinks(sessionCtx, &linkSystem, block)
+	if err != nil {
+		p.syncDAGFailure(loaded+1, err)
 		return err
 	}
 	return nil
@@ -84,15 +82,15 @@ func (p *P2P) syncDAGFailure(loaded int64, err error) {
 // loadBlockLinks traverses the DAG rooted at block and syncs all linked blocks.
 // Uses an explicit stack to avoid goroutine stack overflow on deep DAGs (#2722).
 //
-// written is incremented for each link the walk loads.
+// Returns how many links the walk loaded, which is meaningful whether or not it failed.
 func (p *P2P) loadBlockLinks(
 	ctx context.Context,
 	linkSys *linking.LinkSystem,
 	block *coreblock.Block,
-	written *int64,
-) error {
+) (int64, error) {
 	bstore := datastore.BlockstoreFrom(p.db.Rootstore(), immutable.None[int]())
 	stack := []*coreblock.Block{block}
+	var loaded int64
 
 	for len(stack) > 0 {
 		current := stack[len(stack)-1]
@@ -100,11 +98,11 @@ func (p *P2P) loadBlockLinks(
 
 		link, err := current.GenerateLink()
 		if err != nil {
-			return NewErrGenerateBlockLink(err)
+			return loaded, NewErrGenerateBlockLink(err)
 		}
 		merged, err := bstore.IsMerged(ctx, link.Cid)
 		if err != nil {
-			return NewErrCheckBlockMerged(err)
+			return loaded, NewErrCheckBlockMerged(err)
 		}
 		if merged {
 			continue
@@ -118,7 +116,7 @@ func (p *P2P) loadBlockLinks(
 			// But we want to keep the API of VerifyBlockSignature explicit about the results.
 			_, err := coreblock.VerifyBlockSignature(current, linkSys)
 			if err != nil {
-				return NewErrVerifyBlockSig(err)
+				return loaded, NewErrVerifyBlockSig(err)
 			}
 		}
 
@@ -126,21 +124,21 @@ func (p *P2P) loadBlockLinks(
 		if current.IsEncrypted() {
 			results, err := p.kms.GetKeys(ctx, *current.Encryption)
 			if err != nil {
-				return NewErrGetEncKeysForBlock(err)
+				return loaded, NewErrGetEncKeysForBlock(err)
 			}
 			encResults = results
 		}
 
 		for _, lnk := range current.AllLinks() {
 			if ctx.Err() != nil {
-				return ctx.Err()
+				return loaded, ctx.Err()
 			}
 
 			// Skip fetch if the linked block is already merged locally — avoids a BitSwap
 			// round-trip for historical blocks that may have been pruned on the sender.
 			linkedMerged, err := bstore.IsMerged(ctx, lnk.Cid)
 			if err != nil {
-				return NewErrCheckBlockMerged(err)
+				return loaded, NewErrCheckBlockMerged(err)
 			}
 			if linkedMerged {
 				continue
@@ -151,13 +149,13 @@ func (p *P2P) loadBlockLinks(
 			cancel()
 
 			if err != nil {
-				return NewErrLoadLinkedBlock(err)
+				return loaded, NewErrLoadLinkedBlock(err)
 			}
-			*written++
+			loaded++
 
 			linkBlock, err := coreblock.GetFromNode(nd)
 			if err != nil {
-				return NewErrDecodeLinkedBlock(err)
+				return loaded, NewErrDecodeLinkedBlock(err)
 			}
 
 			stack = append(stack, linkBlock)
@@ -166,11 +164,11 @@ func (p *P2P) loadBlockLinks(
 		if encResults != nil {
 			for res := range encResults.Get() {
 				if res.Error != nil {
-					return NewErrRetrieveEncKey(res.Error)
+					return loaded, NewErrRetrieveEncKey(res.Error)
 				}
 			}
 		}
 	}
 
-	return nil
+	return loaded, nil
 }

--- a/internal/db/p2p/sync_dag.go
+++ b/internal/db/p2p/sync_dag.go
@@ -83,8 +83,8 @@ func (p *P2P) syncDAGFailure(reason string, loaded int64, err error) {
 // loadBlockLinks traverses the DAG rooted at block and syncs all linked blocks.
 // Uses an explicit stack to avoid goroutine stack overflow on deep DAGs (#2722).
 //
-// written is incremented for each block the walk pulls into the blockstore. On error the
-// returned reason names the step that failed, for the caller's counters.
+// written is incremented for each link the walk loads. On error the returned reason names the
+// step that failed, for the caller's counters.
 func (p *P2P) loadBlockLinks(
 	ctx context.Context,
 	linkSys *linking.LinkSystem,
@@ -153,8 +153,6 @@ func (p *P2P) loadBlockLinks(
 			if err != nil {
 				return reasonLoadLink, NewErrLoadLinkedBlock(err)
 			}
-			// The link system writes what it fetches, so a successful load is one more
-			// block in the store.
 			*written++
 
 			linkBlock, err := coreblock.GetFromNode(nd)

--- a/internal/db/p2p/sync_dag.go
+++ b/internal/db/p2p/sync_dag.go
@@ -73,7 +73,7 @@ func (p *P2P) syncDAG(ctx context.Context, block *coreblock.Block) error {
 // syncDAGFailure records an abandoned walk: how it failed and how far it had got. The
 // first occurrence of each reason gets a log line; the rest are counted only.
 func (p *P2P) syncDAGFailure(reason string, loaded int64, err error) {
-	if p.syncDAGFailureReason.record(reason) {
+	if p.syncDAGFailureReason.recordFirst(reason) {
 		log.ErrorE("DAG sync abandoned", err,
 			corelog.String("reason", reason),
 			corelog.Int64("blocksLoaded", loaded))

--- a/internal/db/p2p/sync_doc.go
+++ b/internal/db/p2p/sync_doc.go
@@ -212,7 +212,7 @@ func (p *P2P) handleDocSyncItem(
 		if err != nil {
 			log.ErrorE("Failed to parse CID from bytes", err,
 				corelog.String("DocID", item.DocID))
-			p.dropDoc("invalidCID")
+			p.dropDoc(dropInvalidCID)
 			continue
 		}
 
@@ -221,7 +221,7 @@ func (p *P2P) handleDocSyncItem(
 				results[item.DocID] = append(heads, docCid)
 			} else {
 				// we've seen this head already, just skip
-				p.skipDoc("duplicateHead")
+				p.skipDoc(skipDuplicateHead)
 				continue
 			}
 		} else {
@@ -247,7 +247,7 @@ func (p *P2P) syncDocumentAndMerge(
 ) error {
 	err := p.syncDocumentDAG(ctx, head)
 	if err != nil {
-		p.dropDoc("syncDAG")
+		p.dropDoc(dropSyncDAG)
 		return err
 	}
 
@@ -260,7 +260,7 @@ func (p *P2P) syncDocumentAndMerge(
 	}
 
 	if err := p.db.Merge(ctx, evt); err != nil {
-		p.dropDoc("mergeFailed")
+		p.dropDoc(dropMergeFailed)
 		return err
 	}
 	p.statMergedDocs.Add(1)

--- a/internal/db/p2p/sync_doc.go
+++ b/internal/db/p2p/sync_doc.go
@@ -212,6 +212,7 @@ func (p *P2P) handleDocSyncItem(
 		if err != nil {
 			log.ErrorE("Failed to parse CID from bytes", err,
 				corelog.String("DocID", item.DocID))
+			p.dropDoc("invalidCID")
 			continue
 		}
 
@@ -220,6 +221,7 @@ func (p *P2P) handleDocSyncItem(
 				results[item.DocID] = append(heads, docCid)
 			} else {
 				// we've seen this head already, just skip
+				p.skipDoc("duplicateHead")
 				continue
 			}
 		} else {
@@ -245,6 +247,7 @@ func (p *P2P) syncDocumentAndMerge(
 ) error {
 	err := p.syncDocumentDAG(ctx, head)
 	if err != nil {
+		p.dropDoc("syncDAG")
 		return err
 	}
 
@@ -256,7 +259,12 @@ func (p *P2P) syncDocumentAndMerge(
 		CollectionID: collectionID,
 	}
 
-	return p.db.Merge(ctx, evt)
+	if err := p.db.Merge(ctx, evt); err != nil {
+		p.dropDoc("mergeFailed")
+		return err
+	}
+	p.statMergedDocs.Add(1)
+	return nil
 }
 
 // syncDocumentDAG synchronizes the DAG for a specific document CID.

--- a/internal/db/p2p/syncdagreason_test.go
+++ b/internal/db/p2p/syncdagreason_test.go
@@ -1,0 +1,54 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package p2p
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcenetwork/defradb/errors"
+)
+
+// The reason a DAG sync reports is derived from its error, so every step's error has to
+// name itself.
+func TestSyncDAGReason_NamesTheStepThatFailed(t *testing.T) {
+	cause := errors.New("cause")
+
+	for _, tc := range []struct {
+		name string
+		err  error
+		want string
+	}{
+		{name: "storing the root block", err: NewErrStoreBlockDAGSync(cause), want: reasonStoreRoot},
+		{name: "generating a block link", err: NewErrGenerateBlockLink(cause), want: reasonBlockLink},
+		{name: "checking whether a block merged", err: NewErrCheckBlockMerged(cause), want: reasonIsMerged},
+		{name: "verifying a signature", err: NewErrVerifyBlockSig(cause), want: reasonVerifySig},
+		{name: "fetching encryption keys", err: NewErrGetEncKeysForBlock(cause), want: reasonEncKeys},
+		{name: "retrieving one encryption key", err: NewErrRetrieveEncKey(cause), want: reasonEncKeys},
+		{name: "loading a linked block", err: NewErrLoadLinkedBlock(cause), want: reasonLoadLink},
+		{name: "decoding a linked block", err: NewErrDecodeLinkedBlock(cause), want: reasonDecodeLink},
+		{name: "the context ending", err: context.Canceled, want: reasonContext},
+		{name: "a deadline passing", err: context.DeadlineExceeded, want: reasonContext},
+		{name: "an error no step names", err: cause, want: reasonOther},
+		{
+			// The step is more useful than the cancellation that stopped it.
+			name: "a load stopped by a cancelled context",
+			err:  NewErrLoadLinkedBlock(context.Canceled),
+			want: reasonLoadLink,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, syncDAGReason(tc.err))
+		})
+	}
+}

--- a/internal/db/stats.go
+++ b/internal/db/stats.go
@@ -42,10 +42,13 @@ type mergeStats struct {
 	creates atomic.Int64
 	updates atomic.Int64
 
-	// chunkConflicts counts merge attempts abandoned for a transaction conflict, whether
-	// or not a later attempt succeeded. chunkExhausted counts the chunks that ran out of
-	// attempts, which is where a conflict becomes a dropped document.
-	chunkConflicts atomic.Int64
+	// txnConflicts counts merge transactions abandoned for a conflict, whether or not a
+	// later attempt succeeded.
+	//
+	// chunkExhausted counts chunks of more than one event that used their whole retry budget.
+	// Such a chunk is re-run one event at a time; an event that then fails is counted under
+	// dropRetryExhausted, as is a chunk of one that exhausts.
+	txnConflicts   atomic.Int64
 	chunkExhausted atomic.Int64
 
 	// dropReasons counts dropped events by cause. A dropped event is a document this node
@@ -138,14 +141,6 @@ func (s *mergeStats) markCreateOrUpdate(isCreate bool) {
 	s.updates.Add(1)
 }
 
-// markExhausted records a chunk that ran out of attempts.
-func (s *mergeStats) markExhausted() {
-	if s == nil {
-		return
-	}
-	s.chunkExhausted.Add(1)
-}
-
 // reportMergeStats logs the merge counters once per interval until the database context is
 // cancelled. Rates are reported per interval rather than per event, which keeps the merge
 // path quiet under load where per-event logging would dominate the output.
@@ -165,7 +160,7 @@ func (db *DB) reportMergeStats(ctx context.Context) {
 func (s *mergeStats) report() {
 	creates := s.creates.Swap(0)
 	updates := s.updates.Swap(0)
-	conflicts := s.chunkConflicts.Swap(0)
+	conflicts := s.txnConflicts.Swap(0)
 	exhausted := s.chunkExhausted.Swap(0)
 
 	// Nothing to report on an idle database, or one doing only local writes.
@@ -173,8 +168,8 @@ func (s *mergeStats) report() {
 		log.Info("merge stats",
 			corelog.Int64("creates", creates),
 			corelog.Int64("updates", updates),
-			corelog.Int64("chunkConflicts", conflicts),
-			corelog.Int64("exhausted", exhausted),
+			corelog.Int64("txnConflicts", conflicts),
+			corelog.Int64("chunkExhausted", exhausted),
 		)
 	}
 

--- a/internal/db/stats.go
+++ b/internal/db/stats.go
@@ -34,8 +34,8 @@ const mergeStatsInterval = 30 * time.Second
 // mergeStats are the merge-path counters reported once per interval and reset on report,
 // so each line carries the rate for that interval rather than a running total.
 //
-// Counting is an atomic add on paths that already do storage work, so it is not a cost
-// worth gating. Nothing here builds a string or allocates until the reporter runs.
+// Counting is an atomic add on paths that already do storage work, so it is not a cost worth
+// gating. The drop reasons are constants, so counting one costs a map insert and no string.
 type mergeStats struct {
 	// creates and updates split merges by whether the document already had heads locally.
 	// A merge with no local heads is creating the document.
@@ -67,13 +67,16 @@ const (
 
 // mergeDropReason names why an event was dropped: the sender could not supply the DAG,
 // two documents claim one indexed value, or the write kept losing to a concurrent one.
+//
+// Match against the package sentinels. Constructing a defraError captures a stack trace,
+// and this runs once per dropped event.
 func mergeDropReason(err error) string {
 	switch {
 	case errors.Is(err, ipld.ErrNotFound{}):
 		return dropMissingBlock
-	case errors.Is(err, errors.New(errCanNotIndexNonUniqueFields)):
+	case errors.Is(err, ErrCanNotIndexNonUniqueFields):
 		return dropUniqueIndex
-	case errors.Is(err, client.NewErrMaxTxnRetries(nil)):
+	case errors.Is(err, client.ErrMaxTxnRetries):
 		return dropRetryExhausted
 	default:
 		return dropOther

--- a/internal/db/stats.go
+++ b/internal/db/stats.go
@@ -129,8 +129,8 @@ func (s *mergeStats) drainDropReasons() []slog.Attr {
 
 // markCreateOrUpdate records whether a merge is creating the document or updating one that
 // already exists locally.
-func (s *mergeStats) markCreateOrUpdate(isCreate bool) {
-	if isCreate {
+func (s *mergeStats) markCreateOrUpdate(created bool) {
+	if created {
 		s.creates.Add(1)
 		return
 	}

--- a/internal/db/stats.go
+++ b/internal/db/stats.go
@@ -99,13 +99,15 @@ func collectionDropReason(err error) string {
 	return mergeDropReason(err)
 }
 
+// newMergeStats returns stats ready to record. The zero value is not usable.
+func newMergeStats() *mergeStats {
+	return &mergeStats{dropReasons: make(map[string]int64)}
+}
+
 // markDropped records an event that did not merge, under the given cause.
 func (s *mergeStats) markDropped(reason string) {
 	s.dropMu.Lock()
 	defer s.dropMu.Unlock()
-	if s.dropReasons == nil {
-		s.dropReasons = make(map[string]int64)
-	}
 	s.dropReasons[reason]++
 }
 

--- a/internal/db/stats.go
+++ b/internal/db/stats.go
@@ -101,9 +101,6 @@ func collectionDropReason(err error) string {
 
 // markDropped records an event that did not merge, under the given cause.
 func (s *mergeStats) markDropped(reason string) {
-	if s == nil {
-		return
-	}
 	s.dropMu.Lock()
 	defer s.dropMu.Unlock()
 	if s.dropReasons == nil {
@@ -131,9 +128,6 @@ func (s *mergeStats) drainDropReasons() []slog.Attr {
 // markCreateOrUpdate records whether a merge is creating the document or updating one that
 // already exists locally.
 func (s *mergeStats) markCreateOrUpdate(isCreate bool) {
-	if s == nil {
-		return
-	}
 	if isCreate {
 		s.creates.Add(1)
 		return

--- a/internal/db/stats.go
+++ b/internal/db/stats.go
@@ -62,6 +62,7 @@ const (
 	dropUniqueIndex    = "uniqueIndex"
 	dropRetryExhausted = "retryExhausted"
 	dropCollection     = "collectionNotFound"
+	dropContext        = "contextDone"
 	dropOther          = "other"
 )
 
@@ -78,9 +79,21 @@ func mergeDropReason(err error) string {
 		return dropUniqueIndex
 	case errors.Is(err, client.ErrMaxTxnRetries):
 		return dropRetryExhausted
+	case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+		return dropContext
 	default:
 		return dropOther
 	}
+}
+
+// collectionDropReason names why an event was dropped before its collection was resolved.
+// The lookup opens a transaction and reads the collection store, so not every failure here
+// is a missing collection.
+func collectionDropReason(err error) string {
+	if errors.Is(err, client.ErrCollectionNotFound) {
+		return dropCollection
+	}
+	return mergeDropReason(err)
 }
 
 // markDropped records an event that did not merge, under the given cause.

--- a/internal/db/stats.go
+++ b/internal/db/stats.go
@@ -1,0 +1,170 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package db
+
+import (
+	"context"
+	"log/slog"
+	"maps"
+	"slices"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	ipld "github.com/ipfs/go-ipld-format"
+
+	"github.com/sourcenetwork/corelog"
+
+	"github.com/sourcenetwork/defradb/client"
+	"github.com/sourcenetwork/defradb/errors"
+)
+
+// mergeStatsInterval matches the p2p reporter so the two lines of a single interval line
+// up in the log.
+const mergeStatsInterval = 30 * time.Second
+
+// mergeStats are the merge-path counters reported once per interval and reset on report,
+// so each line carries the rate for that interval rather than a running total.
+//
+// Counting is an atomic add on paths that already do storage work, so it is not a cost
+// worth gating. Nothing here builds a string or allocates until the reporter runs.
+type mergeStats struct {
+	// creates and updates split merges by whether the document already had heads locally.
+	// A merge with no local heads is creating the document.
+	creates atomic.Int64
+	updates atomic.Int64
+
+	// chunkConflicts counts merge attempts abandoned for a transaction conflict, whether
+	// or not a later attempt succeeded. chunkExhausted counts the chunks that ran out of
+	// attempts, which is where a conflict becomes a dropped document.
+	chunkConflicts atomic.Int64
+	chunkExhausted atomic.Int64
+
+	// dropReasons counts dropped events by cause. A dropped event is a document this node
+	// did not store, and the causes need different responses, so the total on its own does
+	// not say what to do.
+	dropMu      sync.Mutex
+	dropReasons map[string]int64
+}
+
+// Causes a merge event can be dropped for. An unrecognised cause counts as dropOther, so
+// that staying non-zero means this list has fallen behind the code.
+const (
+	dropMissingBlock   = "missingBlock"
+	dropUniqueIndex    = "uniqueIndex"
+	dropRetryExhausted = "retryExhausted"
+	dropCollection     = "collectionNotFound"
+	dropOther          = "other"
+)
+
+// mergeDropReason names why an event was dropped: the sender could not supply the DAG,
+// two documents claim one indexed value, or the write kept losing to a concurrent one.
+func mergeDropReason(err error) string {
+	switch {
+	case errors.Is(err, ipld.ErrNotFound{}):
+		return dropMissingBlock
+	case errors.Is(err, errors.New(errCanNotIndexNonUniqueFields)):
+		return dropUniqueIndex
+	case errors.Is(err, client.NewErrMaxTxnRetries(nil)):
+		return dropRetryExhausted
+	default:
+		return dropOther
+	}
+}
+
+// markDropped records an event that did not merge, under the given cause.
+func (s *mergeStats) markDropped(reason string) {
+	if s == nil {
+		return
+	}
+	s.dropMu.Lock()
+	defer s.dropMu.Unlock()
+	if s.dropReasons == nil {
+		s.dropReasons = make(map[string]int64)
+	}
+	s.dropReasons[reason]++
+}
+
+// drainDropReasons returns the causes counted since the last call and resets them.
+func (s *mergeStats) drainDropReasons() []slog.Attr {
+	s.dropMu.Lock()
+	defer s.dropMu.Unlock()
+	if len(s.dropReasons) == 0 {
+		return nil
+	}
+	reasons := slices.Sorted(maps.Keys(s.dropReasons))
+	attrs := make([]slog.Attr, 0, len(reasons))
+	for _, reason := range reasons {
+		attrs = append(attrs, corelog.Int64(reason, s.dropReasons[reason]))
+	}
+	clear(s.dropReasons)
+	return attrs
+}
+
+// markCreateOrUpdate records whether a merge is creating the document or updating one that
+// already exists locally.
+func (s *mergeStats) markCreateOrUpdate(isCreate bool) {
+	if s == nil {
+		return
+	}
+	if isCreate {
+		s.creates.Add(1)
+		return
+	}
+	s.updates.Add(1)
+}
+
+// markExhausted records a chunk that ran out of attempts.
+func (s *mergeStats) markExhausted() {
+	if s == nil {
+		return
+	}
+	s.chunkExhausted.Add(1)
+}
+
+// reportMergeStats logs the merge counters once per interval until the database context is
+// cancelled. Rates are reported per interval rather than per event, which keeps the merge
+// path quiet under load where per-event logging would dominate the output.
+func (db *DB) reportMergeStats(ctx context.Context) {
+	ticker := time.NewTicker(mergeStatsInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			db.stats.report()
+		}
+	}
+}
+
+func (s *mergeStats) report() {
+	creates := s.creates.Swap(0)
+	updates := s.updates.Swap(0)
+	conflicts := s.chunkConflicts.Swap(0)
+	exhausted := s.chunkExhausted.Swap(0)
+
+	// Nothing to report on an idle database, or one doing only local writes.
+	if creates != 0 || updates != 0 || conflicts != 0 || exhausted != 0 {
+		log.Info("merge stats",
+			corelog.Int64("creates", creates),
+			corelog.Int64("updates", updates),
+			corelog.Int64("chunkConflicts", conflicts),
+			corelog.Int64("exhausted", exhausted),
+		)
+	}
+
+	// Its own line, so an interval with no drops stays quiet and the line lists only the
+	// causes that occurred.
+	if drops := s.drainDropReasons(); len(drops) > 0 {
+		log.Error("merge drops", drops...)
+	}
+}

--- a/internal/db/stats_test.go
+++ b/internal/db/stats_test.go
@@ -123,7 +123,7 @@ func TestMergeDropReason(t *testing.T) {
 // The reasons have to survive the drain that reports them, and reset afterwards so each
 // line carries the interval rather than a running total.
 func TestMergeStatsDrainDropReasons(t *testing.T) {
-	var s mergeStats
+	s := newMergeStats()
 	s.markDropped(dropMissingBlock)
 	s.markDropped(dropMissingBlock)
 	s.markDropped(dropUniqueIndex)

--- a/internal/db/stats_test.go
+++ b/internal/db/stats_test.go
@@ -1,0 +1,187 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ipfs/go-cid"
+	ipld "github.com/ipfs/go-ipld-format"
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcenetwork/corekv"
+	"github.com/sourcenetwork/defradb/errors"
+
+	"github.com/sourcenetwork/corekv/blockstore"
+	"github.com/sourcenetwork/immutable"
+
+	"github.com/sourcenetwork/defradb/client"
+	"github.com/sourcenetwork/defradb/event"
+	coreblock "github.com/sourcenetwork/defradb/internal/core/block"
+	"github.com/sourcenetwork/defradb/internal/core/crdt"
+	"github.com/sourcenetwork/defradb/internal/datastore"
+)
+
+func TestMergeStatsCreateVsUpdate(t *testing.T) {
+	ctx := context.Background()
+	db, err := newBadgerDB(ctx)
+	require.NoError(t, err)
+	defer db.Close()
+
+	_, err = db.AddCollection(ctx, userSchema)
+	require.NoError(t, err)
+
+	col, err := db.GetCollectionByName(ctx, "User")
+	require.NoError(t, err)
+
+	lsys := cidlink.DefaultLinkSystem()
+	lsys.SetWriteStorage(blockstore.NewIPLDStore(datastore.BlockstoreFrom(db.rootstore, immutable.None[int]())))
+
+	concrete, ok := col.(*collection)
+	require.True(t, ok)
+
+	first := map[string]any{"name": "John"}
+	builder, _ := newDagBuilder(ctx, col, first)
+
+	create, err := builder.generateCompositeUpdate(&lsys, first, compositeInfo{})
+	require.NoError(t, err)
+	docID := client.NewDocIDV0(create.link.Cid)
+
+	require.NoError(t, db.executeMerge(ctx, concrete, event.Merge{
+		DocID:        docID.String(),
+		Cid:          create.link.Cid,
+		CollectionID: col.Version().CollectionID,
+	}))
+	require.Equal(t, int64(1), db.stats.creates.Load())
+	require.Equal(t, int64(0), db.stats.updates.Load())
+
+	update, err := builder.generateCompositeUpdate(&lsys, map[string]any{"name": "Johny"}, create)
+	require.NoError(t, err)
+
+	require.NoError(t, db.executeMerge(ctx, concrete, event.Merge{
+		DocID:        docID.String(),
+		Cid:          update.link.Cid,
+		CollectionID: col.Version().CollectionID,
+	}))
+	require.Equal(t, int64(1), db.stats.creates.Load())
+	require.Equal(t, int64(1), db.stats.updates.Load())
+}
+
+// A dropped event is a document this node did not store. The count alone does not say what
+// to do about it: a missing block is the sender's DAG being short, a unique index violation
+// is two documents claiming one value, and retry exhaustion is contention.
+func TestMergeDropReason(t *testing.T) {
+	missing := ipld.ErrNotFound{Cid: cid.Undef}
+
+	for _, tc := range []struct {
+		name string
+		err  error
+		want string
+	}{
+		{
+			name: "missing child block, wrapped as the merge path wraps it",
+			err:  NewErrMergeEventDropped(NewErrLoadChildBlock(missing, "bafy"), "bae-1", "bafy"),
+			want: dropMissingBlock,
+		},
+		{
+			name: "unique index violation",
+			err:  NewErrMergeEventDropped(errors.New(errCanNotIndexNonUniqueFields), "bae-1", "bafy"),
+			want: dropUniqueIndex,
+		},
+		{
+			name: "retry exhaustion",
+			err:  NewErrMergeEventDropped(client.NewErrMaxTxnRetries(corekv.ErrTxnConflict), "bae-1", "bafy"),
+			want: dropRetryExhausted,
+		},
+		{
+			name: "anything else is not silently filed under a known cause",
+			err:  errors.New("something new"),
+			want: dropOther,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, mergeDropReason(tc.err))
+		})
+	}
+}
+
+// The reasons have to survive the drain that reports them, and reset afterwards so each
+// line carries the interval rather than a running total.
+func TestMergeStatsDrainDropReasons(t *testing.T) {
+	var s mergeStats
+	s.markDropped(dropMissingBlock)
+	s.markDropped(dropMissingBlock)
+	s.markDropped(dropUniqueIndex)
+
+	attrs := s.drainDropReasons()
+	got := map[string]int64{}
+	for _, a := range attrs {
+		got[a.Key] = a.Value.Int64()
+	}
+	require.Equal(t, map[string]int64{dropMissingBlock: 2, dropUniqueIndex: 1}, got)
+
+	require.Nil(t, s.drainDropReasons(), "a drained interval must not repeat its counts")
+}
+
+// A chunk that fails is re-run one event at a time, so an event that merged in the failed
+// attempt is merged again on the isolation pass. Only the merge that commits is counted.
+func TestMergeStatsCountsCommittedMergeOnce(t *testing.T) {
+	ctx := context.Background()
+	db, err := newBadgerDB(ctx)
+	require.NoError(t, err)
+	defer db.Close()
+
+	_, err = db.AddCollection(ctx, userSchema)
+	require.NoError(t, err)
+	col, err := db.GetCollectionByName(ctx, "User")
+	require.NoError(t, err)
+
+	lsys := cidlink.DefaultLinkSystem()
+	lsys.SetWriteStorage(blockstore.NewIPLDStore(datastore.BlockstoreFrom(db.rootstore, immutable.None[int]())))
+
+	goodState := map[string]any{"name": "John"}
+	goodBuilder, _ := newDagBuilder(ctx, col, goodState)
+	good, err := goodBuilder.generateCompositeUpdate(&lsys, goodState, compositeInfo{})
+	require.NoError(t, err)
+	goodDocID := client.NewDocIDV0(good.link.Cid)
+
+	// A second document whose parent composite was never stored, so it cannot merge.
+	badState := map[string]any{"name": "Jane"}
+	badBuilder, _ := newDagBuilder(ctx, col, badState)
+	badGenesis, err := badBuilder.generateCompositeUpdate(&lsys, badState, compositeInfo{})
+	require.NoError(t, err)
+	badDocID := client.NewDocIDV0(badGenesis.link.Cid)
+
+	missingBlock := coreblock.Block{Delta: crdt.CRDT{DocCompositeDelta: &crdt.DocCompositeDelta{Status: 1}}}
+	missingLink, err := coreblock.GetLinkFromNode(missingBlock.GenerateNode())
+	require.NoError(t, err)
+
+	bad, err := badBuilder.generateCompositeUpdate(
+		&lsys,
+		map[string]any{"name": "Janet"},
+		compositeInfo{link: missingLink, height: 2},
+	)
+	require.NoError(t, err)
+
+	// The mergeable event is listed first so it lands in the chunk attempt that then fails,
+	// and again when the chunk is re-run one event at a time.
+	merged, err := db.MergeBatchWithTxn(ctx, []event.Merge{
+		{DocID: goodDocID.String(), Cid: good.link.Cid, CollectionID: col.CollectionID()},
+		{DocID: badDocID.String(), Cid: bad.link.Cid, CollectionID: col.CollectionID()},
+	})
+	require.Error(t, err)
+	require.Equal(t, []bool{true, false}, merged)
+
+	require.Equal(t, int64(1), db.stats.creates.Load(), "the committed merge is counted once")
+	require.Equal(t, int64(0), db.stats.updates.Load())
+}

--- a/internal/db/stats_test.go
+++ b/internal/db/stats_test.go
@@ -252,6 +252,8 @@ func TestMergeStatsSingleDocumentExhaustion(t *testing.T) {
 	store.failCommits.Store(int64(db.txnAttempts()))
 	err = db.Merge(ctx, updates[0])
 	require.ErrorIs(t, err, client.ErrMaxTxnRetries)
+	require.ErrorContains(t, err, "DocID: "+updates[0].DocID, "the error must name the document")
+	require.ErrorContains(t, err, "CID: "+updates[0].Cid.String(), "the error must name the commit")
 
 	require.Equal(t, int64(db.txnAttempts()), db.stats.txnConflicts.Load(),
 		"each abandoned transaction is one conflict")

--- a/internal/db/stats_test.go
+++ b/internal/db/stats_test.go
@@ -94,8 +94,12 @@ func TestMergeDropReason(t *testing.T) {
 			want: dropMissingBlock,
 		},
 		{
-			name: "unique index violation",
-			err:  NewErrMergeEventDropped(errors.New(errCanNotIndexNonUniqueFields), "bae-1", "bafy"),
+			name: "unique index violation, carrying the fields the index path attaches",
+			err: NewErrMergeEventDropped(
+				NewErrCanNotIndexNonUniqueFields("bae-1", errors.NewKV("name", "John")),
+				"bae-1",
+				"bafy",
+			),
 			want: dropUniqueIndex,
 		},
 		{

--- a/internal/db/stats_test.go
+++ b/internal/db/stats_test.go
@@ -12,6 +12,7 @@ package db
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/ipfs/go-cid"
@@ -190,6 +191,40 @@ func TestMergeStatsCountsCommittedMergeOnce(t *testing.T) {
 	require.Equal(t, int64(0), db.stats.updates.Load())
 }
 
+// existingDocUpdates creates count documents and returns an update event for each. They are
+// committed up front so the caller's budget can only fail the merge itself: creating a document
+// commits the short ID it reserves first, which would spend the budget before the merge.
+func existingDocUpdates(ctx context.Context, t *testing.T, db *DB, col client.Collection, count int) []event.Merge {
+	t.Helper()
+
+	lsys := cidlink.DefaultLinkSystem()
+	lsys.SetWriteStorage(blockstore.NewIPLDStore(datastore.BlockstoreFrom(db.rootstore, immutable.None[int]())))
+
+	updates := make([]event.Merge, count)
+	for i := range updates {
+		state := map[string]any{"name": fmt.Sprintf("user-%d", i)}
+		builder, _ := newDagBuilder(ctx, col, state)
+
+		genesis, err := builder.generateCompositeUpdate(&lsys, state, compositeInfo{})
+		require.NoError(t, err)
+		docID := client.NewDocIDV0(genesis.link.Cid)
+		require.NoError(t, db.Merge(ctx, event.Merge{
+			DocID:        docID.String(),
+			Cid:          genesis.link.Cid,
+			CollectionID: col.CollectionID(),
+		}))
+
+		update, err := builder.generateCompositeUpdate(&lsys, map[string]any{"name": "renamed"}, genesis)
+		require.NoError(t, err)
+		updates[i] = event.Merge{
+			DocID:        docID.String(),
+			Cid:          update.link.Cid,
+			CollectionID: col.CollectionID(),
+		}
+	}
+	return updates
+}
+
 // drainedDrops drains the drop reasons into a map.
 func drainedDrops(s *mergeStats) map[string]int64 {
 	drops := map[string]int64{}
@@ -197,6 +232,105 @@ func drainedDrops(s *mergeStats) map[string]int64 {
 		drops[attr.Key] = attr.Value.Int64()
 	}
 	return drops
+}
+
+// The single-event path has no fallback, so exhausting its retry budget is a dropped
+// document rather than chunk exhaustion.
+func TestMergeStatsSingleDocumentExhaustion(t *testing.T) {
+	ctx := context.Background()
+	db, store, err := newConflictingBadgerDB(ctx)
+	require.NoError(t, err)
+	t.Cleanup(db.Close)
+
+	_, err = db.AddCollection(ctx, userSchema)
+	require.NoError(t, err)
+	col, err := db.GetCollectionByName(ctx, "User")
+	require.NoError(t, err)
+
+	updates := existingDocUpdates(ctx, t, db, col, 1)
+
+	store.failCommits.Store(int64(db.txnAttempts()))
+	err = db.Merge(ctx, updates[0])
+	require.ErrorIs(t, err, client.ErrMaxTxnRetries)
+
+	require.Equal(t, int64(db.txnAttempts()), db.stats.txnConflicts.Load(),
+		"each abandoned transaction is one conflict")
+	require.Equal(t, int64(0), db.stats.chunkExhausted.Load(),
+		"there is no chunk on this path")
+	require.Equal(t, map[string]int64{dropRetryExhausted: 1}, drainedDrops(db.stats))
+}
+
+// A chunk that runs out of attempts is counted once, whether or not the per-event re-runs
+// that follow succeed. A chunk of one event has no smaller write set and is not counted.
+func TestMergeStatsChunkExhaustion(t *testing.T) {
+	attempts := int64(defaultMaxTxnRetries)
+
+	for _, tc := range []struct {
+		name string
+		// failCommits is spent in full by every case, so it also states how many transactions
+		// the batch and isolation passes together are expected to abandon.
+		failCommits   int64
+		documents     int
+		wantMerged    bool
+		wantExhausted int64
+		wantDrops     map[string]int64
+	}{
+		{
+			name:          "a chunk is counted when it exhausts, even though its re-runs recover",
+			failCommits:   attempts,
+			documents:     mergeChunkSize,
+			wantMerged:    true,
+			wantExhausted: 1,
+			wantDrops:     map[string]int64{},
+		},
+		{
+			name:          "a chunk is counted once however many of its re-runs are lost",
+			failCommits:   attempts * (1 + mergeChunkSize),
+			documents:     mergeChunkSize,
+			wantMerged:    false,
+			wantExhausted: 1,
+			wantDrops:     map[string]int64{dropRetryExhausted: mergeChunkSize},
+		},
+		{
+			name:          "a chunk of one is not counted",
+			failCommits:   attempts * 2,
+			documents:     1,
+			wantMerged:    false,
+			wantExhausted: 0,
+			wantDrops:     map[string]int64{dropRetryExhausted: 1},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			db, store, err := newConflictingBadgerDB(ctx)
+			require.NoError(t, err)
+			t.Cleanup(db.Close)
+
+			_, err = db.AddCollection(ctx, userSchema)
+			require.NoError(t, err)
+			col, err := db.GetCollectionByName(ctx, "User")
+			require.NoError(t, err)
+
+			updates := existingDocUpdates(ctx, t, db, col, tc.documents)
+
+			store.failCommits.Store(tc.failCommits)
+			merged, err := db.MergeBatchWithTxn(ctx, updates)
+			if tc.wantMerged {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+			}
+			require.Len(t, merged, tc.documents)
+			for i, ok := range merged {
+				require.Equal(t, tc.wantMerged, ok, "event %d", i)
+			}
+
+			require.Equal(t, tc.failCommits, db.stats.txnConflicts.Load(),
+				"every abandoned transaction is one conflict")
+			require.Equal(t, tc.wantExhausted, db.stats.chunkExhausted.Load())
+			require.Equal(t, tc.wantDrops, drainedDrops(db.stats))
+		})
+	}
 }
 
 // The collection lookup can fail without the collection being missing.

--- a/internal/db/stats_test.go
+++ b/internal/db/stats_test.go
@@ -189,3 +189,86 @@ func TestMergeStatsCountsCommittedMergeOnce(t *testing.T) {
 	require.Equal(t, int64(1), db.stats.creates.Load(), "the committed merge is counted once")
 	require.Equal(t, int64(0), db.stats.updates.Load())
 }
+
+// drainedDrops drains the drop reasons into a map.
+func drainedDrops(s *mergeStats) map[string]int64 {
+	drops := map[string]int64{}
+	for _, attr := range s.drainDropReasons() {
+		drops[attr.Key] = attr.Value.Int64()
+	}
+	return drops
+}
+
+// The collection lookup can fail without the collection being missing.
+func TestMergeStatsCollectionLookupCauses(t *testing.T) {
+	newMergeEvent := func(ctx context.Context, t *testing.T, db *DB, collectionID string) event.Merge {
+		t.Helper()
+
+		col, err := db.GetCollectionByName(ctx, "User")
+		require.NoError(t, err)
+
+		lsys := cidlink.DefaultLinkSystem()
+		lsys.SetWriteStorage(blockstore.NewIPLDStore(datastore.BlockstoreFrom(db.rootstore, immutable.None[int]())))
+
+		state := map[string]any{"name": "John"}
+		builder, _ := newDagBuilder(ctx, col, state)
+		genesis, err := builder.generateCompositeUpdate(&lsys, state, compositeInfo{})
+		require.NoError(t, err)
+
+		return event.Merge{
+			DocID:        client.NewDocIDV0(genesis.link.Cid).String(),
+			Cid:          genesis.link.Cid,
+			CollectionID: collectionID,
+		}
+	}
+
+	t.Run("a collection this node does not hold", func(t *testing.T) {
+		ctx := context.Background()
+		db, err := newBadgerDB(ctx)
+		require.NoError(t, err)
+		t.Cleanup(db.Close)
+
+		_, err = db.AddCollection(ctx, userSchema)
+		require.NoError(t, err)
+
+		require.ErrorIs(t, db.Merge(ctx, newMergeEvent(ctx, t, db, "not-a-collection")),
+			client.ErrCollectionNotFound)
+		require.Equal(t, map[string]int64{dropCollection: 1}, drainedDrops(db.stats))
+	})
+
+	// closedDB returns a database that can no longer open a transaction, and an event for a
+	// collection it holds, so the lookup fails before reading any collection.
+	closedDB := func(t *testing.T) (*DB, event.Merge) {
+		t.Helper()
+
+		ctx := context.Background()
+		db, err := newBadgerDB(ctx)
+		require.NoError(t, err)
+		t.Cleanup(db.Close)
+
+		_, err = db.AddCollection(ctx, userSchema)
+		require.NoError(t, err)
+		col, err := db.GetCollectionByName(ctx, "User")
+		require.NoError(t, err)
+
+		evt := newMergeEvent(ctx, t, db, col.CollectionID())
+		db.ctxCancel()
+		return db, evt
+	}
+
+	t.Run("a lookup that fails for any other reason", func(t *testing.T) {
+		db, evt := closedDB(t)
+
+		require.ErrorIs(t, db.Merge(context.Background(), evt), context.Canceled)
+		require.Equal(t, map[string]int64{dropContext: 1}, drainedDrops(db.stats))
+	})
+
+	t.Run("a lookup that fails for any other reason, in a batch", func(t *testing.T) {
+		db, evt := closedDB(t)
+
+		merged, err := db.MergeBatchWithTxn(context.Background(), []event.Merge{evt})
+		require.ErrorIs(t, err, context.Canceled)
+		require.Equal(t, []bool{false}, merged)
+		require.Equal(t, map[string]int64{dropContext: 1}, drainedDrops(db.stats))
+	})
+}

--- a/node/store_badger.go
+++ b/node/store_badger.go
@@ -145,6 +145,9 @@ func (s *badgerStore) runValueLogGC() {
 // reclaim, an error occurs, or the store starts closing. Each successful call
 // rewrites one file; ErrNoRewrite means no file was eligible and ends the loop.
 // Any other error is logged, since it means GC could not make progress.
+//
+// The on-disk size is reported on every pass, reclaimed or not, so whether the store is
+// bounded can be read from the log without shell access to the volume.
 func (s *badgerStore) reclaimValueLog() {
 	start := time.Now()
 	reclaimed := 0
@@ -162,9 +165,10 @@ func (s *badgerStore) reclaimValueLog() {
 		}
 		reclaimed++
 	}
-	if reclaimed > 0 {
-		log.Info("Reclaimed badger value log files",
-			corelog.Int("files", reclaimed),
-			corelog.Duration("duration", time.Since(start)))
-	}
+	lsm, vlog := s.db.Size()
+	log.Info("Badger value log GC",
+		corelog.Int("files", reclaimed),
+		corelog.Int64("lsmBytes", lsm),
+		corelog.Int64("vlogBytes", vlog),
+		corelog.Duration("duration", time.Since(start)))
 }


### PR DESCRIPTION
Related shinzonetwork/shinzo-host-client#365

Stacked on #5137.

Counters for the p2p ingest and merge paths, reported once per interval and reset on report, so each line carries a rate. Failures get their own lines, grouped by cause: dropped documents, CAR build and import failures, DAG walk failures.

Dropped inbound messages are counted per interval rather than logged per message, and reported at error level so they are visible on a node running above info.

Early returns left the batch and outcome counters untouched, so a rate could be built from a denominator that missed the batches which failed before reaching it. Every terminal path now updates them.

The value log GC line reports on-disk size on every pass, so store growth can be read from the log.

A unique-index violation named only the document that lost. It now also names the document already holding the value.
