### PR TITLE
fix: Make AddCollection discards txn on failure in C wrapper

### DIFF
--- a/cbindings/wrapper.go
+++ b/cbindings/wrapper.go
@@ -436,12 +436,16 @@ func (w *CWrapper) AddCollection(
 	if hadTxn {
 		txn = gotTxn
 	} else {
-		clientTxn, _ := w.NewTxn(false)
+		clientTxn, err := w.NewTxn(false)
+		if err != nil {
+			return nil, err
+		}
 		var ok bool
 		txn, ok = clientTxn.(datastore.Txn)
 		if !ok {
 			return nil, errors.New("failed to cast clientTxn to datastore.Txn")
 		}
+		defer txn.Discard()
 	}
 	ctx = datastore.CtxSetTxn(ctx, txn)
 
@@ -463,8 +467,9 @@ func (w *CWrapper) AddCollection(
 	}
 
 	if !hadTxn {
-		defer txn.Discard()
-		_ = txn.Commit()
+		if err := txn.Commit(); err != nil {
+			return nil, err
+		}
 	}
 
 	return collectionVersions, nil


### PR DESCRIPTION
## Relevant issue(s)

Resolves #5152 

## Description

The `AddCollection` function of the C client wrapper had a bug. If it was called without an explicit transaction, an implicit transaction would be created. If this happened, and the C function call returned an error, that transaction would never be properly discarded. This fixes that by simply moving the `defer discard` up a bit.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Specify the platform(s) on which this was tested:
- WSL