### PR TITLE
fix: Fix lens config bug in C bindings' PatchCollection

### DIFF
--- a/cbindings/collection_patch.go
+++ b/cbindings/collection_patch.go
@@ -50,10 +50,7 @@ func PatchCollection(nodePtr C.uintptr_t,
 			return returnC(returnGoC(1, err.Error(), ""))
 		}
 
-		// Length being greater than 0 also means it is not nil, so no need to check
-		if len(lensCfg.Lenses) > 0 {
-			migration = immutable.Some(lensCfg)
-		}
+		migration = immutable.Some(lensCfg)
 	}
 
 	store, err := getStoreFromPointer(nodePtr)

--- a/tests/integration/collection_version/patch_migration_presence_test.go
+++ b/tests/integration/collection_version/patch_migration_presence_test.go
@@ -28,6 +28,9 @@ import (
 
 const usersCollectionVersion1ID = "bafyreihuyovjl5ezgpud5xyqnouzsgx25x3ssrx3ncdv5p3guocc3laqna"
 
+// emptyLensID is the content-addressed ID of model.Lens{} (an empty lens config)
+const emptyLensID = "bafyreiagp6nl5qdyhlqvwgj3l2dvxz6nqte2btv7i7qhhjgatufehkvmka"
+
 // This tests no migration
 func TestCollectionVersionPatch_NoneMigration_NoTransformRecorded(t *testing.T) {
 	test := testUtils.TestCase{

--- a/tests/integration/collection_version/patch_migration_presence_test.go
+++ b/tests/integration/collection_version/patch_migration_presence_test.go
@@ -1,0 +1,100 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// This file is part of the DefraDB test suite.
+//
+// The DefraDB test suite is licensed under either:
+//
+//   (1) GNU Affero General Public License v3
+//   (2) Business Source License 1.1
+//
+// See tests/LICENSE for details.
+
+package collection_version
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/immutable"
+	"github.com/sourcenetwork/lens/host-go/config/model"
+
+	"github.com/sourcenetwork/defradb/client"
+	"github.com/sourcenetwork/defradb/client/options"
+	"github.com/sourcenetwork/defradb/tests/action"
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+// These tests check that present-but-empty lens migration and absent
+// migrations are both working distinctly, and properly.
+
+const usersCollectionVersion1ID = "bafyreihuyovjl5ezgpud5xyqnouzsgx25x3ssrx3ncdv5p3guocc3laqna"
+
+// This tests no migration
+func TestCollectionVersionPatch_NoneMigration_NoTransformRecorded(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type Users {}
+				`,
+			},
+			&action.PatchCollection{
+				Patch: `
+					[
+						{ "op": "add", "path": "/Users/Fields/-", "value": {"Name": "name", "Kind": "String"} }
+					]
+				`,
+				Lens: immutable.None[model.Lens](),
+			},
+			&action.GetCollections{
+				FilterOptions: options.GetCollections().SetCollectionName("Users"),
+				ExpectedResults: []client.CollectionVersion{
+					{
+						Name:     "Users",
+						IsActive: true,
+						PreviousVersion: immutable.Some(client.CollectionSource{
+							SourceCollectionID: usersCollectionVersion1ID,
+						}),
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+// This tests an empty migration
+func TestCollectionVersionPatch_SomeEmptyMigration_TransformRecorded(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type Users {}
+				`,
+			},
+			&action.PatchCollection{
+				Patch: `
+					[
+						{ "op": "add", "path": "/Users/Fields/-", "value": {"Name": "name", "Kind": "String"} }
+					]
+				`,
+				Lens: immutable.Some(model.Lens{}),
+			},
+			&action.GetCollections{
+				FilterOptions: options.GetCollections().SetCollectionName("Users"),
+				ExpectedResults: []client.CollectionVersion{
+					{
+						Name:     "Users",
+						IsActive: true,
+						PreviousVersion: immutable.Some(client.CollectionSource{
+							SourceCollectionID: usersCollectionVersion1ID,
+							Transform:          immutable.Some("lensID1"),
+						}),
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/collection_version/patch_migration_presence_test.go
+++ b/tests/integration/collection_version/patch_migration_presence_test.go
@@ -49,8 +49,9 @@ func TestCollectionVersionPatch_NoneMigration_NoTransformRecorded(t *testing.T) 
 				FilterOptions: options.GetCollections().SetCollectionName("Users"),
 				ExpectedResults: []client.CollectionVersion{
 					{
-						Name:     "Users",
-						IsActive: true,
+						Name:           "Users",
+						IsActive:       true,
+						IsMaterialized: true,
 						PreviousVersion: immutable.Some(client.CollectionSource{
 							SourceCollectionID: usersCollectionVersion1ID,
 						}),
@@ -84,8 +85,9 @@ func TestCollectionVersionPatch_SomeEmptyMigration_TransformRecorded(t *testing.
 				FilterOptions: options.GetCollections().SetCollectionName("Users"),
 				ExpectedResults: []client.CollectionVersion{
 					{
-						Name:     "Users",
-						IsActive: true,
+						Name:           "Users",
+						IsActive:       true,
+						IsMaterialized: true,
 						PreviousVersion: immutable.Some(client.CollectionSource{
 							SourceCollectionID: usersCollectionVersion1ID,
 							Transform:          immutable.Some("lensID1"),

--- a/tests/integration/collection_version/patch_migration_presence_test.go
+++ b/tests/integration/collection_version/patch_migration_presence_test.go
@@ -93,7 +93,7 @@ func TestCollectionVersionPatch_SomeEmptyMigration_TransformRecorded(t *testing.
 						IsMaterialized: true,
 						PreviousVersion: immutable.Some(client.CollectionSource{
 							SourceCollectionID: usersCollectionVersion1ID,
-							Transform:          immutable.Some("lensID1"),
+							Transform:          immutable.Some(emptyLensID),
 						}),
 					},
 				},


### PR DESCRIPTION
## Relevant issue(s)

Resolves #5154

## Description

There was a bug where a present-but-empty lens configuration was treated the same as no lens being present at all. This meant the C bindings diverged from the Go behavior. This PR addresses that, and introduces two integration tests to illustrate the new behavior.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Specify the platform(s) on which this was tested:
- WSL
