### PR TITLE
feat: Add HTTP client options

### DIFF
--- a/http/client.go
+++ b/http/client.go
@@ -48,8 +48,32 @@ type Client struct {
 	http *httpClient
 }
 
-func NewClient(rawURL string) (*Client, error) {
-	httpClient, err := newHttpClient(rawURL)
+type clientOptions struct {
+	httpClient *http.Client
+	identity   acpIdentity.TokenIdentity
+}
+
+// ClientOption configures an HTTP client.
+type ClientOption func(*clientOptions)
+
+// WithHTTPClient uses client for HTTP requests.
+func WithHTTPClient(client *http.Client) ClientOption {
+	return func(opts *clientOptions) {
+		if client != nil {
+			opts.httpClient = client
+		}
+	}
+}
+
+// WithIdentity authenticates requests with identity's bearer token.
+func WithIdentity(identity acpIdentity.TokenIdentity) ClientOption {
+	return func(opts *clientOptions) {
+		opts.identity = identity
+	}
+}
+
+func NewClient(rawURL string, opts ...ClientOption) (*Client, error) {
+	httpClient, err := newHttpClient(rawURL, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/http/http_client.go
+++ b/http/http_client.go
@@ -25,20 +25,28 @@ import (
 )
 
 type httpClient struct {
-	client  *http.Client
-	baseURL *url.URL
-	apiURL  *url.URL
+	client   *http.Client
+	baseURL  *url.URL
+	apiURL   *url.URL
+	identity identity.TokenIdentity
 }
 
-func newHttpClient(rawURL string) (*httpClient, error) {
+func newHttpClient(rawURL string, opts ...ClientOption) (*httpClient, error) {
 	baseURL, err := parseBaseURL(rawURL)
 	if err != nil {
 		return nil, err
 	}
+	clientOpts := clientOptions{httpClient: http.DefaultClient}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&clientOpts)
+		}
+	}
 	return &httpClient{
-		client:  http.DefaultClient,
-		baseURL: baseURL,
-		apiURL:  baseURL.JoinPath("/api/" + Version),
+		client:   clientOpts.httpClient,
+		baseURL:  baseURL,
+		apiURL:   baseURL.JoinPath("/api/" + Version),
+		identity: clientOpts.identity,
 	}, nil
 }
 
@@ -46,19 +54,14 @@ func newHttpClient(rawURL string) (*httpClient, error) {
 // verification. Only use for loopback health checks against a server whose
 // cert is not trusted by the system CA pool (e.g. self-signed certs).
 func newInsecureHttpClient(rawURL string) (*httpClient, error) {
-	baseURL, err := parseBaseURL(rawURL)
-	if err != nil {
-		return nil, err
-	}
-	return &httpClient{
-		client: &http.Client{
+	return newHttpClient(
+		rawURL,
+		WithHTTPClient(&http.Client{
 			Transport: &http.Transport{
 				TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
 			},
-		},
-		baseURL: baseURL,
-		apiURL:  baseURL.JoinPath("/api/" + Version),
-	}, nil
+		}),
+	)
 }
 
 // parseBaseURL normalizes a raw API address into a URL, defaulting to the
@@ -98,11 +101,12 @@ func (c *httpClient) setDefaultHeaders(req *http.Request) error {
 		req.Header.Set(txHeaderName, fmt.Sprintf("%d", txn.ID()))
 	}
 	id := iIdentity.FromContext(req.Context())
-	if !id.HasValue() {
-		return nil
-	}
-	if tokenIdentity, ok := id.Value().(identity.TokenIdentity); ok {
-		req.Header.Set(authHeaderName, fmt.Sprintf("%s%s", authSchemaPrefix, tokenIdentity.BearerToken()))
+	if id.HasValue() {
+		if tokenIdentity, ok := id.Value().(identity.TokenIdentity); ok {
+			req.Header.Set(authHeaderName, fmt.Sprintf("%s%s", authSchemaPrefix, tokenIdentity.BearerToken()))
+		}
+	} else if c.identity != nil {
+		req.Header.Set(authHeaderName, fmt.Sprintf("%s%s", authSchemaPrefix, c.identity.BearerToken()))
 	}
 	return nil
 }

--- a/http/http_client_test.go
+++ b/http/http_client_test.go
@@ -11,10 +11,18 @@
 package http
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/sourcenetwork/immutable"
+
+	"github.com/sourcenetwork/defradb/acp/identity"
+	"github.com/sourcenetwork/defradb/crypto"
 )
 
 func TestAuthAudienceForURL(t *testing.T) {
@@ -115,4 +123,33 @@ func TestAuthAudienceForURL_MatchesDialedClientHost(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, client.baseURL.Host, audience)
+}
+
+func TestClientDefaultIdentity(t *testing.T) {
+	authorization := make(chan string, 1)
+	server := httptest.NewTLSServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		authorization <- req.Header.Get(authHeaderName)
+		rw.Header().Set("Content-Type", "application/json")
+		if _, err := rw.Write([]byte(`{"id":1}`)); err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	audience, err := AuthAudienceForURL(server.URL)
+	require.NoError(t, err)
+	ident, err := identity.Generate(crypto.KeyTypeEd25519)
+	require.NoError(t, err)
+	require.NoError(t, ident.UpdateToken(time.Hour, immutable.Some(audience), immutable.None[string]()))
+
+	client, err := NewClient(
+		server.URL,
+		WithHTTPClient(server.Client()),
+		WithIdentity(ident),
+	)
+	require.NoError(t, err)
+	_, err = client.NewTxn(true)
+	require.NoError(t, err)
+
+	assert.Equal(t, authSchemaPrefix+ident.BearerToken(), <-authorization)
 }

--- a/node/http_client_auth_test.go
+++ b/node/http_client_auth_test.go
@@ -1,0 +1,74 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+//go:build !js
+
+package node
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcenetwork/immutable"
+
+	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
+	"github.com/sourcenetwork/defradb/client"
+	"github.com/sourcenetwork/defradb/client/options"
+	"github.com/sourcenetwork/defradb/crypto"
+	defrahttp "github.com/sourcenetwork/defradb/http"
+	iIdentity "github.com/sourcenetwork/defradb/internal/identity"
+)
+
+func TestHTTPClientDefaultIdentityAuthorizesNodeACPRequest(t *testing.T) {
+	ctx := context.Background()
+	ident, err := acpIdentity.Generate(crypto.KeyTypeEd25519)
+	require.NoError(t, err)
+
+	n, err := New(
+		ctx,
+		options.Node().
+			SetDisableP2P(true).
+			Store().SetType(options.NodeMemoryStore).
+			Node().
+			DB().SetNodeIdentity(ident).
+			Node().
+			NodeACP().SetEnabled(true).
+			Node().
+			HTTP().SetAddress("127.0.0.1:0").
+			Node(),
+	)
+	require.NoError(t, err)
+	startCtx := iIdentity.WithContext(ctx, immutable.Some[acpIdentity.Identity](ident))
+	require.NoError(t, n.Start(startCtx))
+	t.Cleanup(func() {
+		assert.NoError(t, n.Close(context.Background()))
+	})
+
+	unauthenticated, err := defrahttp.NewClient(n.APIURL)
+	require.NoError(t, err)
+	_, err = unauthenticated.GetNACStatus(ctx)
+	require.Error(t, err)
+
+	audience, err := defrahttp.AuthAudienceForURL(n.APIURL)
+	require.NoError(t, err)
+	token, err := n.DB.GetNodeIdentityToken(ctx, immutable.Some(audience))
+	require.NoError(t, err)
+	tokenIdentity, err := acpIdentity.FromToken(token)
+	require.NoError(t, err)
+
+	authenticated, err := defrahttp.NewClient(n.APIURL, defrahttp.WithIdentity(tokenIdentity))
+	require.NoError(t, err)
+	status, err := authenticated.GetNACStatus(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, client.NACEnabled.String(), status.Status)
+}


### PR DESCRIPTION
## Summary
- allow callers to provide a default token identity for HTTP requests
- allow callers to provide a configured `net/http` client
- cover transaction authentication, TLS transport configuration, and Node ACP authorization

## Testing
- `go test ./http ./node`
- `go test -race ./http ./node`