### PR TITLE
fix: Make blank CID in AddView consistent across clients

### DIFF
--- a/cbindings/test_utils.go
+++ b/cbindings/test_utils.go
@@ -85,14 +85,6 @@ func optionToString[T any](opt immutable.Option[T]) (string, error) {
 	return string(jsonBytes), nil
 }
 
-// stringFromImmutableOptionString is a helper function to extract a simple string
-func stringFromImmutableOptionString(s immutable.Option[string]) string {
-	if !s.HasValue() {
-		return ""
-	}
-	return s.Value()
-}
-
 // collectEnumerable is a helper function for wrangling data from an Enumerable:
 // enumerable.Enumerable[map[string]any] -> []map[string]any
 func collectEnumerable(e enumerable.Enumerable[map[string]any]) ([]map[string]any, error) {

--- a/cbindings/view_add.go
+++ b/cbindings/view_add.go
@@ -38,9 +38,8 @@ func AddView(nodePtr C.uintptr_t,
 	}
 
 	opts := options.WithIdentity(options.AddView(), acpIdentity.FromContext(ctx))
-	transformCIDValue := C.GoString(transformCIDStr)
-	if transformCIDValue != "" {
-		opts.SetTransformCID(transformCIDValue)
+	if transformCIDStr != nil {
+		opts.SetTransformCID(C.GoString(transformCIDStr))
 	}
 
 	store, err := getStoreFromPointer(nodePtr)

--- a/cbindings/wrapper.go
+++ b/cbindings/wrapper.go
@@ -759,10 +759,13 @@ func (w *CWrapper) AddView(
 ) ([]client.CollectionVersion, error) {
 	opt := utils.NewOptions(opts...)
 
-	cTransformCID := C.CString(stringFromImmutableOptionString(opt.TransformCID))
+	var cTransformCID *C.char
+	if opt.TransformCID.HasValue() {
+		cTransformCID = C.CString(opt.TransformCID.Value())
+		defer C.free(unsafe.Pointer(cTransformCID))
+	}
 	cQuery := C.CString(query)
 	cSDL := C.CString(sdl)
-	defer C.free(unsafe.Pointer(cTransformCID))
 	defer C.free(unsafe.Pointer(cQuery))
 	defer C.free(unsafe.Pointer(cSDL))
 

--- a/cli/view_add.go
+++ b/cli/view_add.go
@@ -44,7 +44,7 @@ Learn more about the DefraDB GraphQL Schema Language on https://docs.source.netw
 				return NewErrReadingArgument("sdl-file", err)
 			}
 			opt := options.WithIdentity(options.AddView(), identity.FromContext(cmd.Context()))
-			if lensCID != "" {
+			if cmd.Flags().Changed("lens-cid") {
 				opt.SetTransformCID(lensCID)
 			}
 

--- a/tests/integration/view/simple/transform_cid_presence_test.go
+++ b/tests/integration/view/simple/transform_cid_presence_test.go
@@ -1,0 +1,99 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// This file is part of the DefraDB test suite.
+//
+// The DefraDB test suite is licensed under either:
+//
+//   (1) GNU Affero General Public License v3
+//   (2) Business Source License 1.1
+//
+// See tests/LICENSE for details.
+
+package simple
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/immutable"
+
+	"github.com/sourcenetwork/defradb/client"
+	"github.com/sourcenetwork/defradb/client/options"
+	"github.com/sourcenetwork/defradb/tests/action"
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+// AddViewOptions.TransformCID being omitted (None) and being explicitly set to ""
+// (Some("")) must not be treated the same. An empty CID is invalid and should be
+// rejected, while an omitted one means "no transform". These illustrate the two
+// different cases.
+
+func TestAddView_NoTransformCID_CreatesViewSuccessfully(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type User {
+						name: String
+					}
+				`,
+			},
+			&action.AddView{
+				Query: `
+					User {
+						name
+					}
+				`,
+				SDL: `
+					type UserView @materialized(if: false) {
+						name: String
+					}
+				`,
+			},
+			&action.GetCollections{
+				FilterOptions: options.GetCollections().SetCollectionName("UserView"),
+				ExpectedResults: []client.CollectionVersion{
+					{
+						Name:     "UserView",
+						IsActive: true,
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestAddView_BlankTransformCID_FailsAndCreatesNoView(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type User {
+						name: String
+					}
+				`,
+			},
+			&action.AddView{
+				Query: `
+					User {
+						name
+					}
+				`,
+				SDL: `
+					type UserView @materialized(if: false) {
+						name: String
+					}
+				`,
+				TransformCID:  immutable.Some(""),
+				ExpectedError: "cid too short",
+			},
+			&action.GetCollections{
+				FilterOptions:   options.GetCollections().SetCollectionName("UserView"),
+				ExpectedResults: []client.CollectionVersion{},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}

--- a/tests/integration/view/simple/transform_cid_presence_test.go
+++ b/tests/integration/view/simple/transform_cid_presence_test.go
@@ -24,36 +24,8 @@ import (
 
 // AddViewOptions.TransformCID being omitted (None) and being explicitly set to ""
 // (Some("")) must not be treated the same. An empty CID is invalid and should be
-// rejected, while an omitted one means "no transform". These illustrate the two
-// different cases.
-
-func TestAddView_NoTransformCID_CreatesViewSuccessfully(t *testing.T) {
-	test := testUtils.TestCase{
-		Actions: []any{
-			&action.AddCollection{
-				SDL: `
-					type User {
-						name: String
-					}
-				`,
-			},
-			&action.AddView{
-				Query: `
-					User {
-						name
-					}
-				`,
-				SDL: `
-					type UserView @materialized(if: false) {
-						name: String
-					}
-				`,
-			},
-		},
-	}
-
-	testUtils.ExecuteTestCase(t, test)
-}
+// rejected, while an omitted one means "no transform". The latter is alreedy covered
+// by existing tests, so we only test the former here.
 
 func TestAddView_BlankTransformCID_FailsAndCreatesNoView(t *testing.T) {
 	test := testUtils.TestCase{

--- a/tests/integration/view/simple/transform_cid_presence_test.go
+++ b/tests/integration/view/simple/transform_cid_presence_test.go
@@ -49,15 +49,6 @@ func TestAddView_NoTransformCID_CreatesViewSuccessfully(t *testing.T) {
 					}
 				`,
 			},
-			&action.GetCollections{
-				FilterOptions: options.GetCollections().SetCollectionName("UserView"),
-				ExpectedResults: []client.CollectionVersion{
-					{
-						Name:     "UserView",
-						IsActive: true,
-					},
-				},
-			},
 		},
 	}
 


### PR DESCRIPTION
## Relevant issue(s)

Resolves #5159 

## Description

Previously, if you passed a blank CID string into the C bindings' `AddView` function, it would never configure a view. However, the Go path would try to decode the empty string, fail to do so, and return an error.  Incidentally, the CLI behaves the same way as the C bindings, and unlike the Go path. This difference in behavior is inconsistent, and this PR addresses that by adjusting the C function and C wrapper, and the CLI code, to behave the same way as the Go code.

This PR also introduces an integration test to illustrate the correct behavior.

As an aside, this PR removes the `stringFromImmutableOptionString` utility function from the C bindings. It was never used in other places, so we no longer need it.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

(*replace*) Describe the tests performed to verify the changes. Provide instructions to reproduce them.

Specify the platform(s) on which this was tested:
- WSL