### PR TITLE
fix: Make C binding CreateTransaction safer

### DIFF
--- a/cbindings/transaction_create.go
+++ b/cbindings/transaction_create.go
@@ -16,16 +16,12 @@ package cbindings
 */
 import "C"
 
-import (
-	"runtime/cgo"
-
-	"github.com/sourcenetwork/defradb/node"
-)
-
 //export CreateTransaction
 func CreateTransaction(nodePtr C.uintptr_t, isReadOnly C.int) C.NewTxnResult {
-	h := cgo.Handle(nodePtr)
-	n := h.Value().(*node.Node) //nolint:forcetypeassert
+	n, err := getNodeFromPointer(nodePtr)
+	if err != nil {
+		return returnNewTxnResultC(1, err.Error(), nil)
+	}
 
 	tx, err := n.DB.NewTxn(isReadOnly != 0)
 	if err != nil {


### PR DESCRIPTION
## Relevant issue(s)

Resolves #5171 

## Description

The `CreateTransaction` function of the C bindings contains the code:

`h := cgo.Handle(nodePtr)`

This lacks deffensive error checking, and will panic on a bad pointer. This PR replaces it with:

```
n, err := getNodeFromPointer(nodePtr)
	if err != nil {
		return returnNewTxnResultC(1, err.Error(), nil)
	}
```

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Specify the platform(s) on which this was tested:
- WSL
