### PR TITLE
fix: Finalize GraphQL schema before use

### DIFF
--- a/internal/request/graphql/schema/generate.go
+++ b/internal/request/graphql/schema/generate.go
@@ -285,9 +285,7 @@ func (g *Generator) generate(ctx context.Context, collections []client.Collectio
 		}
 	}
 
-	// final resolve
-	// resolve types
-	if err := g.manager.ResolveTypes(); err != nil {
+	if err := g.manager.FinalizeTypes(); err != nil {
 		return nil, err
 	}
 
@@ -654,17 +652,13 @@ func (g *Generator) buildMutationInputTypes(collections []client.CollectionVersi
 			}
 		}
 
+		if len(fields) == 0 {
+			continue
+		}
 		mutationObj := gql.NewInputObject(gql.InputObjectConfig{
 			Name:   mutationInputName,
 			Fields: fields,
 		})
-		// Empty collections have no mutable fields.
-		if len(fields) > 0 {
-			mutationObj.Fields()
-			if mutationObj.Error() != nil {
-				return mutationObj.Error()
-			}
-		}
 		g.manager.schema.TypeMap()[mutationObj.Name()] = mutationObj
 	}
 
@@ -1232,13 +1226,30 @@ func (g *Generator) GenerateMutationInputForGQLType(obj *gql.Object) ([]*gql.Fie
 		return nil, NewErrTypeNotFound(filterInputName)
 	}
 
+	delete := &gql.Field{
+		Name:        "delete_" + obj.Name(),
+		Description: deleteDocumentsDescription,
+		Type:        gql.NewList(obj),
+		Args: gql.FieldConfigArgument{
+			request.DocIDArgName: schemaTypes.NewArgConfig(gql.NewList(gql.NewNonNull(gql.ID)), deleteIDsArgDescription),
+			"filter":             schemaTypes.NewArgConfig(filterInput, deleteFilterArgDescription),
+		},
+	}
+
+	truncate := &gql.Field{
+		Name:        "truncate_" + obj.Name(),
+		Description: "Remove all or matching documents from this node. Returns true when complete.",
+		Type:        gql.NewNonNull(gql.Boolean),
+		Args: gql.FieldConfigArgument{
+			request.FilterClause: schemaTypes.NewArgConfig(filterInput, "Filter documents to truncate"),
+		},
+	}
 	mutationInput, ok := g.manager.schema.TypeMap()[mutationInputName]
 	if !ok {
-		return nil, NewErrTypeNotFound(mutationInputName)
+		return []*gql.Field{delete, truncate}, nil
 	}
 
 	explicitUserFieldsEnum := g.genUserExplicitTypeFieldsEnum(obj)
-
 	g.manager.schema.TypeMap()[explicitUserFieldsEnum.Name()] = explicitUserFieldsEnum
 
 	add := &gql.Field{
@@ -1265,16 +1276,6 @@ func (g *Generator) GenerateMutationInputForGQLType(obj *gql.Object) ([]*gql.Fie
 		},
 	}
 
-	delete := &gql.Field{
-		Name:        "delete_" + obj.Name(),
-		Description: deleteDocumentsDescription,
-		Type:        gql.NewList(obj),
-		Args: gql.FieldConfigArgument{
-			request.DocIDArgName: schemaTypes.NewArgConfig(gql.NewList(gql.NewNonNull(gql.ID)), deleteIDsArgDescription),
-			"filter":             schemaTypes.NewArgConfig(filterInput, deleteFilterArgDescription),
-		},
-	}
-
 	upsert := &gql.Field{
 		Name:        "upsert_" + obj.Name(),
 		Description: upsertDocumentDescription,
@@ -1283,15 +1284,6 @@ func (g *Generator) GenerateMutationInputForGQLType(obj *gql.Object) ([]*gql.Fie
 			request.FilterClause: schemaTypes.NewArgConfig(gql.NewNonNull(filterInput), upsertFilterArgDescription),
 			request.AddInput:     schemaTypes.NewArgConfig(gql.NewNonNull(mutationInput), "Add field values"),
 			request.UpdateInput:  schemaTypes.NewArgConfig(gql.NewNonNull(mutationInput), "Update field values"),
-		},
-	}
-
-	truncate := &gql.Field{
-		Name:        "truncate_" + obj.Name(),
-		Description: "Remove all or matching documents from this node. Returns true when complete.",
-		Type:        gql.NewNonNull(gql.Boolean),
-		Args: gql.FieldConfigArgument{
-			request.FilterClause: schemaTypes.NewArgConfig(filterInput, "Filter documents to truncate"),
 		},
 	}
 

--- a/internal/request/graphql/schema/generate.go
+++ b/internal/request/graphql/schema/generate.go
@@ -602,71 +602,69 @@ func (g *Generator) buildMutationInputTypes(collections []client.CollectionVersi
 			return NewErrMutationInputTypeAlreadyExist(mutationInputName)
 		}
 
-		mutationObjConf := gql.InputObjectConfig{
-			Name: mutationInputName,
-		}
-
-		// Wrap mutation input object definition in a thunk so we can
-		// handle any embedded object which is defined
-		// at a future point in time.
-		mutationObjConf.Fields = (gql.InputObjectConfigFieldMapThunk)(func() (gql.InputObjectConfigFieldMap, error) {
-			fields := make(gql.InputObjectConfigFieldMap)
-
-			for _, field := range collection.Fields {
-				if field.Kind == client.FieldKind_DocID {
-					if field.Name == request.DocIDFieldName {
-						// This is the system _docID field, users cannot set its value
-						continue
-					}
-					objFieldName, isRelationID := request.ToRelatedObjectName(field.Name)
-					if isRelationID {
-						ofd, exists := collection.GetFieldByName(objFieldName)
-						if exists && !ofd.IsPrimary {
-							// We do not allow the mutation of relations from the secondary side,
-							// they must not be included in the input type(s)
-							continue
-						}
-					}
-				} else if field.Kind.IsObject() && !field.IsPrimary {
-					// We do not allow the mutation of relations from the secondary side,
-					// they must not be included in the input type(s)
+		fields := make(gql.InputObjectConfigFieldMap)
+		for _, field := range collection.Fields {
+			if field.Kind == client.FieldKind_DocID {
+				if field.Name == request.DocIDFieldName {
+					// This is the system _docID field, users cannot set its value
 					continue
 				}
-
-				var ttype gql.Type
-				if field.Kind.IsObject() {
-					if field.Kind.IsArray() {
-						ttype = gql.NewList(gql.ID)
-					} else {
-						ttype = gql.ID
-					}
-				} else {
-					var ok bool
-					ttype, ok = fieldKindToGQLType[field.Kind]
-					if !ok {
-						return nil, NewErrTypeNotFound(fmt.Sprint(field.Kind))
-					}
-					// Mutation inputs must be nullable even for non-nillable fields so
-					// that application code handles null validation and produces
-					// consistent error messages regardless of mutation type.
-					if nonNull, isNonNull := ttype.(*gql.NonNull); isNonNull {
-						ttype = nonNull.OfType
-					} else if list, isList := ttype.(*gql.List); isList {
-						if nonNull, isNonNull := list.OfType.(*gql.NonNull); isNonNull {
-							ttype = gql.NewList(nonNull.OfType)
-						}
+				objFieldName, isRelationID := request.ToRelatedObjectName(field.Name)
+				if isRelationID {
+					ofd, exists := collection.GetFieldByName(objFieldName)
+					if exists && !ofd.IsPrimary {
+						// We do not allow the mutation of relations from the secondary side,
+						// they must not be included in the input type(s)
+						continue
 					}
 				}
+			} else if field.Kind.IsObject() && !field.IsPrimary {
+				// We do not allow the mutation of relations from the secondary side,
+				// they must not be included in the input type(s)
+				continue
+			}
 
-				fields[field.Name] = &gql.InputObjectFieldConfig{
-					Type: ttype,
+			var ttype gql.Type
+			if field.Kind.IsObject() {
+				if field.Kind.IsArray() {
+					ttype = gql.NewList(gql.ID)
+				} else {
+					ttype = gql.ID
+				}
+			} else {
+				var ok bool
+				ttype, ok = fieldKindToGQLType[field.Kind]
+				if !ok {
+					return NewErrTypeNotFound(fmt.Sprint(field.Kind))
+				}
+				// Mutation inputs must be nullable even for non-nillable fields so
+				// that application code handles null validation and produces
+				// consistent error messages regardless of mutation type.
+				if nonNull, isNonNull := ttype.(*gql.NonNull); isNonNull {
+					ttype = nonNull.OfType
+				} else if list, isList := ttype.(*gql.List); isList {
+					if nonNull, isNonNull := list.OfType.(*gql.NonNull); isNonNull {
+						ttype = gql.NewList(nonNull.OfType)
+					}
 				}
 			}
 
-			return fields, nil
-		})
+			fields[field.Name] = &gql.InputObjectFieldConfig{
+				Type: ttype,
+			}
+		}
 
-		mutationObj := gql.NewInputObject(mutationObjConf)
+		mutationObj := gql.NewInputObject(gql.InputObjectConfig{
+			Name:   mutationInputName,
+			Fields: fields,
+		})
+		// Empty collections have no mutable fields.
+		if len(fields) > 0 {
+			mutationObj.Fields()
+			if mutationObj.Error() != nil {
+				return mutationObj.Error()
+			}
+		}
 		g.manager.schema.TypeMap()[mutationObj.Name()] = mutationObj
 	}
 

--- a/internal/request/graphql/schema/generate_concurrency_test.go
+++ b/internal/request/graphql/schema/generate_concurrency_test.go
@@ -1,0 +1,83 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package schema
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	gql "github.com/sourcenetwork/graphql-go"
+	gqlp "github.com/sourcenetwork/graphql-go/language/parser"
+	"github.com/sourcenetwork/graphql-go/language/source"
+
+	"github.com/sourcenetwork/defradb/client"
+	"github.com/sourcenetwork/defradb/client/request"
+)
+
+func TestGenerator_EmptyCollectionDoesNotError(t *testing.T) {
+	manager, err := NewSchemaManager(false)
+	require.NoError(t, err)
+
+	_, err = manager.Generator.Generate(context.Background(), []client.CollectionVersion{{
+		Name: "User",
+		Fields: []client.CollectionFieldDescription{
+			{Name: request.DocIDFieldName, Kind: client.FieldKind_DocID},
+		},
+	}})
+	require.NoError(t, err)
+}
+
+func TestGenerator_MutationInputIsSafeForConcurrentUse(t *testing.T) {
+	manager, err := NewSchemaManager(false)
+	require.NoError(t, err)
+
+	_, err = manager.Generator.Generate(context.Background(), []client.CollectionVersion{{
+		Name: "User",
+		Fields: []client.CollectionFieldDescription{
+			{Name: "name", Kind: client.FieldKind_NILLABLE_STRING},
+		},
+	}})
+	require.NoError(t, err)
+
+	const requestCount = 20
+	start := make(chan struct{})
+	errors := make(chan error, requestCount)
+	var waitGroup sync.WaitGroup
+	for range requestCount {
+		waitGroup.Add(1)
+		go func() {
+			defer waitGroup.Done()
+			<-start
+
+			document, err := gqlp.Parse(gqlp.ParseParams{Source: source.NewSource(&source.Source{
+				Body: []byte(`mutation { update_User(input: {name: "Jane"}) { name } }`),
+			})})
+			if err != nil {
+				errors <- err
+				return
+			}
+			result := gql.ValidateDocument(manager.Schema(), document, nil)
+			if !result.IsValid {
+				errors <- result.Errors[0]
+			}
+		}()
+	}
+
+	close(start)
+	waitGroup.Wait()
+	close(errors)
+	for err := range errors {
+		require.NoError(t, err)
+	}
+}

--- a/internal/request/graphql/schema/generate_concurrency_test.go
+++ b/internal/request/graphql/schema/generate_concurrency_test.go
@@ -36,9 +36,16 @@ func TestGenerator_EmptyCollectionDoesNotError(t *testing.T) {
 		},
 	}})
 	require.NoError(t, err)
+
+	fields := manager.Schema().MutationType().Fields()
+	require.NotContains(t, fields, "add_User")
+	require.NotContains(t, fields, "update_User")
+	require.NotContains(t, fields, "upsert_User")
+	require.Contains(t, fields, "delete_User")
+	require.Contains(t, fields, "truncate_User")
 }
 
-func TestGenerator_MutationInputIsSafeForConcurrentUse(t *testing.T) {
+func TestGenerator_SchemaIsSafeForConcurrentUse(t *testing.T) {
 	manager, err := NewSchemaManager(false)
 	require.NoError(t, err)
 
@@ -50,28 +57,32 @@ func TestGenerator_MutationInputIsSafeForConcurrentUse(t *testing.T) {
 	}})
 	require.NoError(t, err)
 
+	requests := []string{
+		`query { User(filter: {name: {_eq: "Jane"}}) { name } }`,
+		`mutation { update_User(input: {name: "Jane"}) { name } }`,
+	}
 	const requestCount = 20
 	start := make(chan struct{})
 	errors := make(chan error, requestCount)
 	var waitGroup sync.WaitGroup
-	for range requestCount {
+	for i := range requestCount {
 		waitGroup.Add(1)
-		go func() {
+		go func(request string) {
 			defer waitGroup.Done()
 			<-start
 
 			document, err := gqlp.Parse(gqlp.ParseParams{Source: source.NewSource(&source.Source{
-				Body: []byte(`mutation { update_User(input: {name: "Jane"}) { name } }`),
+				Body: []byte(request),
 			})})
 			if err != nil {
 				errors <- err
 				return
 			}
-			result := gql.ValidateDocument(manager.Schema(), document, nil)
+			result := gql.ValidateDocument(manager.Schema(), document, gql.SpecifiedRules)
 			if !result.IsValid {
 				errors <- result.Errors[0]
 			}
-		}()
+		}(requests[i%len(requests)])
 	}
 
 	close(start)

--- a/internal/request/graphql/schema/manager.go
+++ b/internal/request/graphql/schema/manager.go
@@ -51,29 +51,15 @@ func (s *SchemaManager) Schema() *gql.Schema {
 	return &s.schema
 }
 
-// ResolveTypes ensures all necessary types are defined, and
-// resolves any remaining thunks/closures defined on object fields.
+// ResolveTypes resolves object fields needed by the current generation phase.
 // It should be called *after* all dependent types have been added.
 func (s *SchemaManager) ResolveTypes() error {
-	// basically, this function just refreshes the
-	// schema.TypeMap, and runs the internal
-	// typeMapReducer (https://github.com/sourcenetwork/graphql-go/blob/v0.7.9/schema.go#L275)
-	// which ensures all the necessary types are defined in the
-	// typeMap, and if there are any outstanding Thunks/closures
-	// resolve them.
-
-	// ATM, there is no function to easily call the internal
-	// typeMapReducer function, so as a hack, we are just
-	// going to re-add the Query type.
-
 	for _, gqlType := range s.schema.TypeMap() {
-		object, isObject := gqlType.(*gql.Object)
-		if !isObject {
+		object, ok := gqlType.(*gql.Object)
+		if !ok {
 			continue
 		}
-		// We need to make sure the object's fields are resolved
 		object.Fields()
-
 		if object.Error() != nil {
 			return object.Error()
 		}
@@ -81,6 +67,30 @@ func (s *SchemaManager) ResolveTypes() error {
 
 	query := s.schema.QueryType()
 	return s.schema.AppendType(query)
+}
+
+// FinalizeTypes resolves every schema thunk before the schema is shared.
+func (s *SchemaManager) FinalizeTypes() error {
+	if err := s.ResolveTypes(); err != nil {
+		return err
+	}
+	for _, gqlType := range s.schema.TypeMap() {
+		switch gqlType := gqlType.(type) {
+		case *gql.Object:
+			gqlType.Fields()
+			gqlType.Interfaces()
+		case *gql.Interface:
+			gqlType.Fields()
+		case *gql.InputObject:
+			gqlType.Fields()
+		case *gql.Union:
+			gqlType.Types()
+		}
+		if gqlType.Error() != nil {
+			return gqlType.Error()
+		}
+	}
+	return nil
 }
 
 func (s *SchemaManager) ParseSDL(sdl string) ([]core.Collection, error) {


### PR DESCRIPTION
## Relevant issue(s)

Resolves #5184

## Description

Builds GraphQL mutation input fields during schema generation and materializes non-empty input objects before the generated schema is published. Previously these fields remained behind a thunk and concurrent first requests could initialize the shared schema state at the same time.

The generated schema and request behavior remain unchanged. Empty collections retain their existing behavior, and mutation field type errors are returned during schema generation. No new dependencies are added.

Limitations:

- The change is scoped to mutation input objects; other GraphQL type thunks are unchanged.
- Mutation input fields are initialized once during schema generation, adding work proportional to the number of fields.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

- `go test -race ./internal/request/graphql/schema -count=1`
- `go test -race ./internal/request/graphql/schema -run 'TestGenerator_(EmptyCollectionDoesNotError|MutationInputIsSafeForConcurrentUse)' -count=20`
- `go test ./internal/request/graphql/... -count=1`
- `go test ./... -run '^$'`
- Production and test lint profiles

Specify the platform(s) on which this was tested:

- MacOS
