### PR TITLE
test: Restore vector metrics CI coverage

### DIFF
--- a/internal/request/graphql/schema/testfixtures/schema.relatedmany.gen.graphql
+++ b/internal/request/graphql/schema/testfixtures/schema.relatedmany.gen.graphql
@@ -1490,6 +1490,18 @@ input Float64OperatorBlock {
     _nin: [Float64]
 }
 
+"HNSW (Hierarchical Navigable Small World) vector index parameters."
+input HNSWIndexConfig {
+    "Max connections per node. Higher improves recall at the cost of memory and build time."
+    M: Int = 16
+    "Build-time exploration factor. Higher improves graph quality (recall) at the cost of build time."
+    efConstruction: Int = 128
+    "Default query-time exploration factor. Higher improves recall at the cost of query latency."
+    efSearch: Int = 64
+    "Distance metric used to compare vectors."
+    metric: VectorDistanceMetric = "COSINE"
+}
+
 """
 The `ID` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as `"4"`) or integer (such as `4`) input value will be accepted as an ID.
 """
@@ -3148,6 +3160,15 @@ type Subscription {
     ): [Commit]
 }
 
+enum VectorDistanceMetric {
+    "Cosine distance on normalised vectors. Compares direction only."
+    COSINE
+    "Dot product. Grows with magnitude, so a longer vector pointing the same way is nearer."
+    DOT
+    "Straight-line (L2) distance. Compares direction and magnitude."
+    EUCLIDEAN
+}
+
 """
 A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document. 
 
@@ -3505,4 +3526,12 @@ directive @relation(
 
     """
     name: String
+) on FIELD_DEFINITION
+
+"@vectorIndex builds an approximate-nearest-neighbour index over a vector field."
+directive @vectorIndex(
+    "Build the index with the HNSW algorithm using these parameters."
+    HNSW: HNSWIndexConfig
+    "Vector dimensions; required unless inferable from an @embedding."
+    dimensions: Int
 ) on FIELD_DEFINITION

--- a/internal/request/graphql/schema/testfixtures/schema.relatedone.gen.graphql
+++ b/internal/request/graphql/schema/testfixtures/schema.relatedone.gen.graphql
@@ -1433,6 +1433,18 @@ input Float64OperatorBlock {
     _nin: [Float64]
 }
 
+"HNSW (Hierarchical Navigable Small World) vector index parameters."
+input HNSWIndexConfig {
+    "Max connections per node. Higher improves recall at the cost of memory and build time."
+    M: Int = 16
+    "Build-time exploration factor. Higher improves graph quality (recall) at the cost of build time."
+    efConstruction: Int = 128
+    "Default query-time exploration factor. Higher improves recall at the cost of query latency."
+    efSearch: Int = 64
+    "Distance metric used to compare vectors."
+    metric: VectorDistanceMetric = "COSINE"
+}
+
 """
 The `ID` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as `"4"`) or integer (such as `4`) input value will be accepted as an ID.
 """
@@ -3091,6 +3103,15 @@ type Subscription {
     ): [Commit]
 }
 
+enum VectorDistanceMetric {
+    "Cosine distance on normalised vectors. Compares direction only."
+    COSINE
+    "Dot product. Grows with magnitude, so a longer vector pointing the same way is nearer."
+    DOT
+    "Straight-line (L2) distance. Compares direction and magnitude."
+    EUCLIDEAN
+}
+
 """
 A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document. 
 
@@ -3448,4 +3469,12 @@ directive @relation(
 
     """
     name: String
+) on FIELD_DEFINITION
+
+"@vectorIndex builds an approximate-nearest-neighbour index over a vector field."
+directive @vectorIndex(
+    "Build the index with the HNSW algorithm using these parameters."
+    HNSW: HNSWIndexConfig
+    "Vector dimensions; required unless inferable from an @embedding."
+    dimensions: Int
 ) on FIELD_DEFINITION

--- a/internal/request/graphql/schema/testfixtures/schema.simple.gen.graphql
+++ b/internal/request/graphql/schema/testfixtures/schema.simple.gen.graphql
@@ -743,6 +743,18 @@ input Float64OperatorBlock {
     _nin: [Float64]
 }
 
+"HNSW (Hierarchical Navigable Small World) vector index parameters."
+input HNSWIndexConfig {
+    "Max connections per node. Higher improves recall at the cost of memory and build time."
+    M: Int = 16
+    "Build-time exploration factor. Higher improves graph quality (recall) at the cost of build time."
+    efConstruction: Int = 128
+    "Default query-time exploration factor. Higher improves recall at the cost of query latency."
+    efSearch: Int = 64
+    "Distance metric used to compare vectors."
+    metric: VectorDistanceMetric = "COSINE"
+}
+
 """
 The `ID` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as `"4"`) or integer (such as `4`) input value will be accepted as an ID.
 """
@@ -2526,6 +2538,15 @@ input User___version__CountSelector {
     offset: Int
 }
 
+enum VectorDistanceMetric {
+    "Cosine distance on normalised vectors. Compares direction only."
+    COSINE
+    "Dot product. Grows with magnitude, so a longer vector pointing the same way is nearer."
+    DOT
+    "Straight-line (L2) distance. Compares direction and magnitude."
+    EUCLIDEAN
+}
+
 """
 A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document. 
 
@@ -2883,4 +2904,12 @@ directive @relation(
 
     """
     name: String
+) on FIELD_DEFINITION
+
+"@vectorIndex builds an approximate-nearest-neighbour index over a vector field."
+directive @vectorIndex(
+    "Build the index with the HNSW algorithm using these parameters."
+    HNSW: HNSWIndexConfig
+    "Vector dimensions; required unless inferable from an @embedding."
+    dimensions: Int
 ) on FIELD_DEFINITION

--- a/tests/integration/index/patch_test.go
+++ b/tests/integration/index/patch_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/sourcenetwork/defradb/tests/action"
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	"github.com/sourcenetwork/defradb/tests/multiplier"
 )
 
 func TestPatchCollection_AddSecondaryIndex_ShouldError(t *testing.T) {
@@ -129,6 +130,7 @@ func TestPatchCollection_ModifySecondaryIndex_ShouldError(t *testing.T) {
 // there is no way in through the patch surface.
 func TestPatchCollection_ModifyVectorIndexMetric_ShouldError(t *testing.T) {
 	test := testUtils.TestCase{
+		MultiplierExcludes: []string{multiplier.SecondaryIndex},
 		Actions: []any{
 			&action.AddCollection{
 				SDL: `


### PR DESCRIPTION
## Relevant issue(s)

Follow-up to #5169.

## Description

Regenerates the committed SDL fixtures for the vector index directive, HNSW configuration, and distance metrics. It also excludes the vector metric patch test from the secondary-index multiplier, which inserts another index before the vector index and changes the path the test deliberately patches. The test continues to run in the normal integration matrix.

## How has this been tested?

- `make test:npx`
- focused vector metric patch test with and without `DEFRA_MULTIPLIERS=secondary-index`
- integration-test lint config

## Tasks

- [x] Generated fixtures are current
- [x] The normal vector patch test still runs
- [x] The secondary-index matrix no longer targets the wrong index