### PR TITLE
fix: Set version and CID in C wrapper's ExistsDocument

### DIFF
--- a/cbindings/wrapper_document.go
+++ b/cbindings/wrapper_document.go
@@ -368,11 +368,7 @@ func (c *Collection) ExistsDocument(
 	))
 
 	if res.Status != 0 {
-		err := client.ReviveError(res.Error)
-		if errors.Is(err, client.ErrDocumentNotFoundOrNotAuthorized) {
-			return false, nil
-		}
-		return false, err
+		return false, errors.New(res.Error)
 	}
 
 	return true, nil

--- a/cbindings/wrapper_document.go
+++ b/cbindings/wrapper_document.go
@@ -342,8 +342,8 @@ func (c *Collection) ExistsDocument(
 	docIDStr := C.CString(docID.String())
 	cShowDeleted := C.int(0)
 
-	cVersion := C.CString("")
-	cCollectionID := C.CString("")
+	cVersion := C.CString(c.def.VersionID)
+	cCollectionID := C.CString(c.def.CollectionID)
 	cName := C.CString("")
 	cIdentity := optionToUintptr(utils.NewOptions(opts...).GetIdentity())
 	defer C.free(unsafe.Pointer(docIDStr))
@@ -368,7 +368,11 @@ func (c *Collection) ExistsDocument(
 	))
 
 	if res.Status != 0 {
-		return false, errors.New(res.Error)
+		err := client.ReviveError(res.Error)
+		if errors.Is(err, client.ErrDocumentNotFoundOrNotAuthorized) {
+			return false, nil
+		}
+		return false, err
 	}
 
 	return true, nil


### PR DESCRIPTION
## Relevant issue(s)

Resolves #5186 

## Description

Previously, the `ExistsDocument` function inside the C wrapper always treated the version ID and CollectionID values as blank strings. This PR fixes this issue:

```
	cVersion := C.CString(c.def.VersionID)
	cCollectionID := C.CString(c.def.CollectionID)
```

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Specify the platform(s) on which this was tested:
- WSL