### PR TITLE
fix: Preserve filter type/int precision in doc updates

### DIFF
--- a/cbindings/document_delete.go
+++ b/cbindings/document_delete.go
@@ -23,6 +23,7 @@ import (
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/options"
 	acpIdentity "github.com/sourcenetwork/defradb/internal/identity"
+	"github.com/sourcenetwork/defradb/internal/utils"
 )
 
 //export DeleteDocument
@@ -76,9 +77,12 @@ func DeleteDocument(nodePtr C.uintptr_t,
 
 	// If docID is not provided, next try to delete by filter
 	case filter != "":
-		var filterValue any
-		if err := json.Unmarshal([]byte(filter), &filterValue); err != nil {
+		filterValue, err := utils.DecodeJSONFilter([]byte(filter))
+		if err != nil {
 			return returnC(returnGoC(1, err.Error(), ""))
+		}
+		if filterValue == nil {
+			filterValue = map[string]any{}
 		}
 		deleteOpt := options.WithIdentity(options.DeleteDocumentsWithFilter(), ident)
 		if opts.enableSigning != 0 {

--- a/cbindings/document_update.go
+++ b/cbindings/document_update.go
@@ -23,6 +23,7 @@ import (
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/options"
 	acpIdentity "github.com/sourcenetwork/defradb/internal/identity"
+	"github.com/sourcenetwork/defradb/internal/utils"
 )
 
 //export UpdateDocument
@@ -87,9 +88,12 @@ func UpdateDocument(
 
 	// If docID is not provided, next try to update the documents by filter
 	case filter != "":
-		var filterValue any
-		if err := json.Unmarshal([]byte(filter), &filterValue); err != nil {
+		filterValue, err := utils.DecodeJSONFilter([]byte(filter))
+		if err != nil {
 			return returnC(returnGoC(1, err.Error(), ""))
+		}
+		if filterValue == nil {
+			filterValue = map[string]any{}
 		}
 		updateOpt := options.WithIdentity(options.UpdateDocumentsWithFilter(), ident)
 		if opts.enableSigning != 0 {

--- a/cbindings/wrapper_document.go
+++ b/cbindings/wrapper_document.go
@@ -383,7 +383,7 @@ func (c *Collection) UpdateDocumentsWithFilter(
 	ctx = setCtxTxnFromCollection(ctx, c)
 
 	docID := C.CString("")
-	filterJSON, err := json.Marshal(filter)
+	filterJSON, err := json.Marshal(utils.NormalizeFilterForJSON(filter))
 	if err != nil {
 		return nil, err
 	}
@@ -439,7 +439,7 @@ func (c *Collection) DeleteDocumentsWithFilter(
 	ctx = setCtxTxnFromCollection(ctx, c)
 
 	docID := C.CString("")
-	filterJSON, err := json.Marshal(filter)
+	filterJSON, err := json.Marshal(utils.NormalizeFilterForJSON(filter))
 	if err != nil {
 		return nil, err
 	}

--- a/cli/document_delete.go
+++ b/cli/document_delete.go
@@ -12,13 +12,13 @@ package cli
 
 import (
 	"context"
-	"encoding/json"
 
 	"github.com/spf13/cobra"
 
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/options"
 	"github.com/sourcenetwork/defradb/internal/identity"
+	"github.com/sourcenetwork/defradb/internal/utils"
 )
 
 func MakeDocumentDeleteCommand(ctx context.Context) *cobra.Command {
@@ -57,9 +57,12 @@ or the showDeleted parameter on GraphQL queries.`,
 				_, err = col.DeleteDocument(ctx, docID, deleteOpt)
 				return err
 			case filter != "":
-				var filterValue any
-				if err := json.Unmarshal([]byte(filter), &filterValue); err != nil {
+				filterValue, err := utils.DecodeJSONFilter([]byte(filter))
+				if err != nil {
 					return NewErrParsingArgument("filter", err)
+				}
+				if filterValue == nil {
+					filterValue = map[string]any{}
 				}
 
 				deleteWithFilterOpt := options.WithIdentity(

--- a/cli/document_update.go
+++ b/cli/document_update.go
@@ -12,13 +12,13 @@ package cli
 
 import (
 	"context"
-	"encoding/json"
 
 	"github.com/spf13/cobra"
 
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/options"
 	"github.com/sourcenetwork/defradb/internal/identity"
+	"github.com/sourcenetwork/defradb/internal/utils"
 )
 
 func MakeDocumentUpdateCommand(ctx context.Context) *cobra.Command {
@@ -43,9 +43,12 @@ func MakeDocumentUpdateCommand(ctx context.Context) *cobra.Command {
 
 			switch {
 			case filter != "":
-				var filterValue any
-				if err := json.Unmarshal([]byte(filter), &filterValue); err != nil {
+				filterValue, err := utils.DecodeJSONFilter([]byte(filter))
+				if err != nil {
 					return NewErrParsingArgument("filter", err)
+				}
+				if filterValue == nil {
+					filterValue = map[string]any{}
 				}
 
 				updateWithFilterOpt := options.WithIdentity(

--- a/http/client_document.go
+++ b/http/client_document.go
@@ -275,7 +275,7 @@ func (c *Collection) UpdateDocumentsWithFilter(
 	methodURL := c.http.apiURL.JoinPath("collections", c.Version().Name)
 
 	request := UpdateCollectionRequest{
-		Filter:  filter,
+		Filter:  utils.NormalizeFilterForJSON(filter),
 		Updater: updater,
 	}
 
@@ -310,7 +310,7 @@ func (c *Collection) DeleteDocumentsWithFilter(
 	methodURL := c.http.apiURL.JoinPath("collections", c.Version().Name)
 
 	request := DeleteCollectionRequest{
-		Filter: filter,
+		Filter: utils.NormalizeFilterForJSON(filter),
 	}
 
 	body, err := json.Marshal(request)

--- a/http/handler_collection.go
+++ b/http/handler_collection.go
@@ -11,6 +11,7 @@
 package http
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -21,6 +22,7 @@ import (
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/options"
 	"github.com/sourcenetwork/defradb/internal/identity"
+	"github.com/sourcenetwork/defradb/internal/utils"
 )
 
 const docEncryptParam = "encrypt"
@@ -33,9 +35,64 @@ type DeleteCollectionRequest struct {
 	Filter any `json:"filter"`
 }
 
+// UnmarshalJSON decodes a DeleteCollectionRequest, preserving integer precision in Filter.
+// The standard decoder represents every JSON number as a float64, which silently rounds
+// any integer above 2^53.
+func (r *DeleteCollectionRequest) UnmarshalJSON(data []byte) error {
+	var raw struct {
+		Filter json.RawMessage `json:"filter"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	filter, err := decodeRequestFilter(raw.Filter)
+	if err != nil {
+		return err
+	}
+	r.Filter = filter
+	return nil
+}
+
 type UpdateCollectionRequest struct {
 	Filter  any    `json:"filter"`
 	Updater string `json:"updater"`
+}
+
+// UnmarshalJSON decodes an UpdateCollectionRequest, preserving integer precision in Filter.
+// The standard decoder represents every JSON number as a float64, which silently rounds
+// any integer above 2^53.
+func (r *UpdateCollectionRequest) UnmarshalJSON(data []byte) error {
+	var raw struct {
+		Filter  json.RawMessage `json:"filter"`
+		Updater string          `json:"updater"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	filter, err := decodeRequestFilter(raw.Filter)
+	if err != nil {
+		return err
+	}
+	r.Filter = filter
+	r.Updater = raw.Updater
+	return nil
+}
+
+// decodeRequestFilter decodes a document filter carried as raw JSON on a request body,
+// without losing integer precision. No filter (an absent key, or an explicit null) means
+// match all documents.
+func decodeRequestFilter(data json.RawMessage) (any, error) {
+	if len(data) == 0 {
+		return map[string]any{}, nil
+	}
+	filter, err := utils.DecodeJSONFilter(data)
+	if err != nil {
+		return nil, err
+	}
+	if filter == nil {
+		filter = map[string]any{}
+	}
+	return filter, nil
 }
 
 func (h *collectionHandler) DeleteDocumentsWithFilter(rw http.ResponseWriter, req *http.Request) {

--- a/internal/utils/util.go
+++ b/internal/utils/util.go
@@ -16,7 +16,10 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/sourcenetwork/immutable"
 	"github.com/sourcenetwork/immutable/enumerable"
+
+	"github.com/sourcenetwork/defradb/client/request"
 )
 
 // NewOptions merges multiple option builders into a single options struct.
@@ -97,6 +100,42 @@ func normalizeJSONNumbers(value any) (any, error) {
 	default:
 		return value, nil
 	}
+}
+
+// DecodeJSONFilter decodes a JSON-encoded document filter without losing integer
+// precision (see DecodeJSONVariables). Unlike DecodeJSONVariables, the decoded value
+// is not assumed to be an object: data may be a filter expression (a string), a map 
+// of filter conditions (an object), or null.
+func DecodeJSONFilter(data []byte) (any, error) {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.UseNumber()
+
+	var value any
+	if err := dec.Decode(&value); err != nil {
+		return nil, err
+	}
+	if dec.More() {
+		return nil, fmt.Errorf("unexpected data after JSON filter value")
+	}
+
+	return normalizeJSONNumbers(value)
+}
+
+// NormalizeFilterForJSON prepares a document filter for JSON transport (e.g. across the C
+// bindings boundary, or an HTTP/CLI request body). immutable.Option[request.Filter] does
+// not round-trip through plain JSON: Some marshals to {"Conditions": ...}, indistinguishable
+// on decode from a raw filter conditions map with a literal "Conditions" field, and None
+// marshals to null, which decodes to an untyped nil that no filter type switch accepts. This
+// unwraps Some to its Conditions map, and None to an empty conditions map (which still means
+// "match all documents" once decoded). Any other filter value is returned unchanged.
+func NormalizeFilterForJSON(filter any) any {
+	if opt, ok := filter.(immutable.Option[request.Filter]); ok {
+		if !opt.HasValue() {
+			return map[string]any{}
+		}
+		return opt.Value().Conditions
+	}
+	return filter
 }
 
 // ApplyOptions applies all functional options onto the given target.

--- a/internal/utils/util.go
+++ b/internal/utils/util.go
@@ -104,7 +104,7 @@ func normalizeJSONNumbers(value any) (any, error) {
 
 // DecodeJSONFilter decodes a JSON-encoded document filter without losing integer
 // precision (see DecodeJSONVariables). Unlike DecodeJSONVariables, the decoded value
-// is not assumed to be an object: data may be a filter expression (a string), a map 
+// is not assumed to be an object: data may be a filter expression (a string), a map
 // of filter conditions (an object), or null.
 func DecodeJSONFilter(data []byte) (any, error) {
 	dec := json.NewDecoder(bytes.NewReader(data))

--- a/js/client_document.go
+++ b/js/client_document.go
@@ -193,7 +193,7 @@ func (c *clientCollection) existsDocument(this js.Value, args []js.Value) (js.Va
 }
 
 func (c *clientCollection) updateDocumentsWithFilter(this js.Value, args []js.Value) (js.Value, error) {
-	filter, err := stringArg(args, 0, "filter")
+	filter, err := filterArg(args, 0, "filter")
 	if err != nil {
 		return js.Undefined(), err
 	}
@@ -214,7 +214,7 @@ func (c *clientCollection) updateDocumentsWithFilter(this js.Value, args []js.Va
 }
 
 func (c *clientCollection) deleteDocumentsWithFilter(this js.Value, args []js.Value) (js.Value, error) {
-	filter, err := stringArg(args, 0, "filter")
+	filter, err := filterArg(args, 0, "filter")
 	if err != nil {
 		return js.Undefined(), err
 	}

--- a/js/utils.go
+++ b/js/utils.go
@@ -28,6 +28,7 @@ import (
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/options"
 	"github.com/sourcenetwork/defradb/crypto"
+	"github.com/sourcenetwork/defradb/internal/utils"
 )
 
 const (
@@ -75,6 +76,36 @@ func boolArg(args []js.Value, index int, name string) (bool, error) {
 		return false, fmt.Errorf("%s argument must be a bool", name)
 	}
 	return args[index].Bool(), nil
+}
+
+// filterArg returns the document filter at the given argument index, accepting either a
+// GraphQL-style filter string or a plain filter conditions object. An object is decoded
+// with the same number handling as UnmarshalJS. A missing/null/undefined object filter
+// means "match all documents". Note that JS numbers are IEEE-754 doubles, so an integer
+// filter condition above 2^53 will already have lost precision before reaching Go.
+// To do: https://github.com/sourcenetwork/defradb/issues/5176
+func filterArg(args []js.Value, index int, name string) (any, error) {
+	if len(args) <= index {
+		return nil, fmt.Errorf("%s argument is required", name)
+	}
+	arg := args[index]
+	switch arg.Type() {
+	case js.TypeString:
+		return arg.String(), nil
+	case js.TypeNull, js.TypeUndefined:
+		return map[string]any{}, nil
+	case js.TypeObject:
+		filter, err := utils.DecodeJSONFilter([]byte(goji.JSON.Stringify(arg)))
+		if err != nil {
+			return nil, fmt.Errorf("%s argument is invalid: %w", name, err)
+		}
+		if filter == nil {
+			filter = map[string]any{}
+		}
+		return filter, nil
+	default:
+		return nil, fmt.Errorf("%s argument must be a string or object", name)
+	}
 }
 
 func structArg(args []js.Value, index int, name string, out any) error {

--- a/tests/clients/cli/wrapper_document.go
+++ b/tests/clients/cli/wrapper_document.go
@@ -232,7 +232,7 @@ func (c *Collection) UpdateDocumentsWithFilter(
 	args = append(args, "--collection-name", c.Version().Name)
 	args = append(args, "--updater", updater)
 
-	filterJSON, err := json.Marshal(filter)
+	filterJSON, err := json.Marshal(utils.NormalizeFilterForJSON(filter))
 	if err != nil {
 		return nil, err
 	}
@@ -265,7 +265,7 @@ func (c *Collection) DeleteDocumentsWithFilter(
 	args := []string{"client", "document", "delete"}
 	args = append(args, "--collection-name", c.Version().Name)
 
-	filterJSON, err := json.Marshal(filter)
+	filterJSON, err := json.Marshal(utils.NormalizeFilterForJSON(filter))
 	if err != nil {
 		return nil, err
 	}

--- a/tests/clients/js/wrapper_document.go
+++ b/tests/clients/js/wrapper_document.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/options"
+	"github.com/sourcenetwork/defradb/internal/utils"
 )
 
 func (c *Collection) AddDocument(
@@ -145,7 +146,8 @@ func (c *Collection) UpdateDocumentsWithFilter(
 	updater string,
 	opts ...options.Enumerable[options.UpdateDocumentsWithFilterOptions],
 ) (*client.UpdateResult, error) {
-	res, err := execute(ctx, c.client, "updateDocumentsWithFilter", filter, updater, jsOpts(opts))
+	res, err := execute(ctx, c.client, "updateDocumentsWithFilter",
+		utils.NormalizeFilterForJSON(filter), updater, jsOpts(opts))
 	if err != nil {
 		return nil, err
 	}
@@ -161,7 +163,8 @@ func (c *Collection) DeleteDocumentsWithFilter(
 	filter any,
 	opts ...options.Enumerable[options.DeleteDocumentsWithFilterOptions],
 ) (*client.DeleteResult, error) {
-	res, err := execute(ctx, c.client, "deleteDocumentsWithFilter", filter, jsOpts(opts))
+	res, err := execute(ctx, c.client, "deleteDocumentsWithFilter",
+		utils.NormalizeFilterForJSON(filter), jsOpts(opts))
 	if err != nil {
 		return nil, err
 	}

--- a/tests/integration/mutation/delete/with_filter_action_test.go
+++ b/tests/integration/mutation/delete/with_filter_action_test.go
@@ -69,15 +69,6 @@ func TestDeleteWithFilter_Succeeds(t *testing.T) {
 
 func TestDeleteWithMapFilter_Succeeds(t *testing.T) {
 	test := testUtils.TestCase{
-		SupportedClientTypes: immutable.Some(
-			[]state.ClientType{
-				state.GoClientType,
-				state.HTTPClientType,
-				state.CLIClientType,
-				state.CClientType,
-				state.JSClientType,
-			},
-		),
 		Actions: []any{
 			&action.AddCollection{
 				SDL: `
@@ -191,15 +182,6 @@ func TestDeleteWithMapFilter_LargeIntegerStraddling2To53_DeletesOnlyExactMatch(t
 
 func TestDeleteWithSomeOptionFilter_Succeeds(t *testing.T) {
 	test := testUtils.TestCase{
-		SupportedClientTypes: immutable.Some(
-			[]state.ClientType{
-				state.GoClientType,
-				state.HTTPClientType,
-				state.CLIClientType,
-				state.CClientType,
-				state.JSClientType,
-			},
-		),
 		Actions: []any{
 			&action.AddCollection{
 				SDL: `
@@ -249,15 +231,6 @@ func TestDeleteWithSomeOptionFilter_Succeeds(t *testing.T) {
 
 func TestDeleteWithNoneOptionFilter_DeletesAllDocuments(t *testing.T) {
 	test := testUtils.TestCase{
-		SupportedClientTypes: immutable.Some(
-			[]state.ClientType{
-				state.GoClientType,
-				state.HTTPClientType,
-				state.CLIClientType,
-				state.CClientType,
-				state.JSClientType,
-			},
-		),
 		Actions: []any{
 			&action.AddCollection{
 				SDL: `

--- a/tests/integration/mutation/delete/with_filter_action_test.go
+++ b/tests/integration/mutation/delete/with_filter_action_test.go
@@ -14,8 +14,12 @@ package delete
 import (
 	"testing"
 
+	"github.com/sourcenetwork/immutable"
+
+	"github.com/sourcenetwork/defradb/client/request"
 	"github.com/sourcenetwork/defradb/tests/action"
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+	"github.com/sourcenetwork/defradb/tests/state"
 )
 
 func TestDeleteWithFilter_Succeeds(t *testing.T) {
@@ -55,6 +59,230 @@ func TestDeleteWithFilter_Succeeds(t *testing.T) {
 					"User": []map[string]any{
 						{"name": "Fred"},
 					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestDeleteWithMapFilter_Succeeds(t *testing.T) {
+	test := testUtils.TestCase{
+		SupportedClientTypes: immutable.Some(
+			[]state.ClientType{
+				state.GoClientType,
+				state.HTTPClientType,
+				state.CLIClientType,
+				state.CClientType,
+				state.JSClientType,
+			},
+		),
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type User {
+						name: String
+						age: Int
+					}
+				`,
+			},
+			&action.AddDoc{
+				Doc: `{
+					"name": "John",
+					"age": 21
+				}`,
+			},
+			&action.AddDoc{
+				Doc: `{
+					"name": "Fred",
+					"age": 25
+				}`,
+			},
+			testUtils.DeleteWithFilter{
+				CollectionID: 0,
+				Filter: map[string]any{
+					"name": map[string]any{"_eq": "John"},
+				},
+			},
+			&action.Request{
+				Request: `query {
+					User {
+						name
+					}
+				}`,
+				Results: map[string]any{
+					"User": []map[string]any{
+						{"name": "Fred"},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestDeleteWithMapFilter_LargeIntegerStraddling2To53_DeletesOnlyExactMatch(t *testing.T) {
+	test := testUtils.TestCase{
+		// JS numbers are IEEE-754 doubles, so an integer filter condition above 2^53 has
+		// already lost precision before it reaches Go. Unlike the other clients.
+		// To do: https://github.com/sourcenetwork/defradb/issues/5176.
+		SupportedClientTypes: immutable.Some(
+			[]state.ClientType{
+				state.GoClientType,
+				state.HTTPClientType,
+				state.CLIClientType,
+				state.CClientType,
+			},
+		),
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type User {
+						name: String
+						age: Int
+					}
+				`,
+			},
+			&action.AddDoc{
+				Doc: `{
+					"name": "Fred",
+					"age": 9007199254740992
+				}`,
+			},
+			&action.AddDoc{
+				Doc: `{
+					"name": "John",
+					"age": 9007199254740993
+				}`,
+			},
+			testUtils.DeleteWithFilter{
+				CollectionID: 0,
+				Filter: map[string]any{
+					"age": map[string]any{"_eq": int64(9007199254740993)},
+				},
+			},
+			&action.Request{
+				Request: `query {
+					User {
+						name
+					}
+				}`,
+				Results: map[string]any{
+					"User": []map[string]any{
+						{"name": "Fred"},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestDeleteWithSomeOptionFilter_Succeeds(t *testing.T) {
+	test := testUtils.TestCase{
+		SupportedClientTypes: immutable.Some(
+			[]state.ClientType{
+				state.GoClientType,
+				state.HTTPClientType,
+				state.CLIClientType,
+				state.CClientType,
+				state.JSClientType,
+			},
+		),
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type User {
+						name: String
+						age: Int
+					}
+				`,
+			},
+			&action.AddDoc{
+				Doc: `{
+					"name": "John",
+					"age": 21
+				}`,
+			},
+			&action.AddDoc{
+				Doc: `{
+					"name": "Fred",
+					"age": 25
+				}`,
+			},
+			testUtils.DeleteWithFilter{
+				CollectionID: 0,
+				Filter: immutable.Some(request.Filter{
+					Conditions: map[string]any{
+						"name": map[string]any{"_eq": "John"},
+					},
+				}),
+			},
+			&action.Request{
+				Request: `query {
+					User {
+						name
+					}
+				}`,
+				Results: map[string]any{
+					"User": []map[string]any{
+						{"name": "Fred"},
+					},
+				},
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}
+
+func TestDeleteWithNoneOptionFilter_DeletesAllDocuments(t *testing.T) {
+	test := testUtils.TestCase{
+		SupportedClientTypes: immutable.Some(
+			[]state.ClientType{
+				state.GoClientType,
+				state.HTTPClientType,
+				state.CLIClientType,
+				state.CClientType,
+				state.JSClientType,
+			},
+		),
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `
+					type User {
+						name: String
+						age: Int
+					}
+				`,
+			},
+			&action.AddDoc{
+				Doc: `{
+					"name": "John",
+					"age": 21
+				}`,
+			},
+			&action.AddDoc{
+				Doc: `{
+					"name": "Fred",
+					"age": 25
+				}`,
+			},
+			testUtils.DeleteWithFilter{
+				CollectionID: 0,
+				Filter:       immutable.None[request.Filter](),
+			},
+			&action.Request{
+				Request: `query {
+					User {
+						name
+					}
+				}`,
+				Results: map[string]any{
+					"User": []map[string]any{},
 				},
 			},
 		},

--- a/tests/integration/mutation/delete/with_filter_action_test.go
+++ b/tests/integration/mutation/delete/with_filter_action_test.go
@@ -136,6 +136,14 @@ func TestDeleteWithMapFilter_LargeIntegerStraddling2To53_DeletesOnlyExactMatch(t
 				state.CClientType,
 			},
 		),
+		// The gql mutation type embeds the doc as a literal in a GraphQL mutation, and
+		// GraphQL's Int scalar is 32-bit, too small for the values used here.
+		SupportedMutationTypes: immutable.Some(
+			[]state.MutationType{
+				state.CollectionSaveMutationType,
+				state.CollectionNamedMutationType,
+			},
+		),
 		Actions: []any{
 			&action.AddCollection{
 				SDL: `

--- a/tests/integration/mutation/update/with_filter_action_test.go
+++ b/tests/integration/mutation/update/with_filter_action_test.go
@@ -209,6 +209,14 @@ func TestUpdateWithMapFilter_LargeIntegerStraddling2To53_UpdatesOnlyExactMatch(t
 				state.CClientType,
 			},
 		),
+		// The gql mutation type embeds the doc as a literal in a GraphQL mutation, and
+		// GraphQL's Int scalar is 32-bit, too small for the values used here.
+		SupportedMutationTypes: immutable.Some(
+			[]state.MutationType{
+				state.CollectionSaveMutationType,
+				state.CollectionNamedMutationType,
+			},
+		),
 		Actions: []any{
 			&action.AddDoc{
 				CollectionID: 0,

--- a/tests/integration/mutation/update/with_filter_action_test.go
+++ b/tests/integration/mutation/update/with_filter_action_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/sourcenetwork/immutable"
 
+	"github.com/sourcenetwork/defradb/client/request"
 	"github.com/sourcenetwork/defradb/tests/action"
 	testUtils "github.com/sourcenetwork/defradb/tests/integration"
 	"github.com/sourcenetwork/defradb/tests/state"
@@ -142,6 +143,202 @@ func TestUpdateWithPatch_DoesNothing(t *testing.T) {
 				Results: map[string]any{
 					"Users": []map[string]any{
 						{"name": "John"},
+					},
+				},
+			},
+		},
+	}
+
+	executeTestCase(t, test)
+}
+
+func TestUpdateWithMapFilter_Succeeds(t *testing.T) {
+	test := testUtils.TestCase{
+		SupportedClientTypes: immutable.Some(
+			[]state.ClientType{
+				state.GoClientType,
+				state.HTTPClientType,
+				state.CLIClientType,
+				state.CClientType,
+				state.JSClientType,
+			},
+		),
+		Actions: []any{
+			&action.AddDoc{
+				CollectionID: 0,
+				Doc: `{
+					"name": "John",
+					"age": 21
+				}`,
+			},
+			testUtils.UpdateWithFilter{
+				CollectionID: 0,
+				Filter: map[string]any{
+					"name": map[string]any{"_eq": "John"},
+				},
+				Updater: `{"name": "Eric"}`,
+			},
+			&action.Request{
+				Request: `query{
+					Users {
+						name
+					}
+				}`,
+				Results: map[string]any{
+					"Users": []map[string]any{
+						{"name": "Eric"},
+					},
+				},
+			},
+		},
+	}
+
+	executeTestCase(t, test)
+}
+
+func TestUpdateWithMapFilter_LargeIntegerStraddling2To53_UpdatesOnlyExactMatch(t *testing.T) {
+	test := testUtils.TestCase{
+		// JS numbers are IEEE-754 doubles, so an integer filter condition above 2^53 has
+		// already lost precision before it reaches Go.
+		// To do: https://github.com/sourcenetwork/defradb/issues/5176.
+		SupportedClientTypes: immutable.Some(
+			[]state.ClientType{
+				state.GoClientType,
+				state.HTTPClientType,
+				state.CLIClientType,
+				state.CClientType,
+			},
+		),
+		Actions: []any{
+			&action.AddDoc{
+				CollectionID: 0,
+				Doc: `{
+					"name": "Fred",
+					"age": 9007199254740992
+				}`,
+			},
+			&action.AddDoc{
+				CollectionID: 0,
+				Doc: `{
+					"name": "John",
+					"age": 9007199254740993
+				}`,
+			},
+			testUtils.UpdateWithFilter{
+				CollectionID: 0,
+				Filter: map[string]any{
+					"age": map[string]any{"_eq": int64(9007199254740993)},
+				},
+				Updater: `{"name": "Eric"}`,
+			},
+			&action.Request{
+				Request: `query{
+					Users {
+						name
+					}
+				}`,
+				Results: map[string]any{
+					"Users": []map[string]any{
+						{"name": "Fred"},
+						{"name": "Eric"},
+					},
+				},
+			},
+		},
+	}
+
+	executeTestCase(t, test)
+}
+
+func TestUpdateWithSomeOptionFilter_Succeeds(t *testing.T) {
+	test := testUtils.TestCase{
+		SupportedClientTypes: immutable.Some(
+			[]state.ClientType{
+				state.GoClientType,
+				state.HTTPClientType,
+				state.CLIClientType,
+				state.CClientType,
+				state.JSClientType,
+			},
+		),
+		Actions: []any{
+			&action.AddDoc{
+				CollectionID: 0,
+				Doc: `{
+					"name": "John",
+					"age": 21
+				}`,
+			},
+			testUtils.UpdateWithFilter{
+				CollectionID: 0,
+				Filter: immutable.Some(request.Filter{
+					Conditions: map[string]any{
+						"name": map[string]any{"_eq": "John"},
+					},
+				}),
+				Updater: `{"name": "Eric"}`,
+			},
+			&action.Request{
+				Request: `query{
+					Users {
+						name
+					}
+				}`,
+				Results: map[string]any{
+					"Users": []map[string]any{
+						{"name": "Eric"},
+					},
+				},
+			},
+		},
+	}
+
+	executeTestCase(t, test)
+}
+
+func TestUpdateWithNoneOptionFilter_UpdatesAllDocuments(t *testing.T) {
+	test := testUtils.TestCase{
+		SupportedClientTypes: immutable.Some(
+			[]state.ClientType{
+				state.GoClientType,
+				state.HTTPClientType,
+				state.CLIClientType,
+				state.CClientType,
+				state.JSClientType,
+			},
+		),
+		Actions: []any{
+			&action.AddDoc{
+				CollectionID: 0,
+				Doc: `{
+					"name": "John",
+					"age": 21
+				}`,
+			},
+			&action.AddDoc{
+				CollectionID: 0,
+				Doc: `{
+					"name": "Fred",
+					"age": 25
+				}`,
+			},
+			testUtils.UpdateWithFilter{
+				CollectionID:         0,
+				Filter:               immutable.None[request.Filter](),
+				Updater:              `{"verified": true}`,
+				SkipLocalUpdateEvent: true,
+			},
+			&action.Request{
+				Request: `query{
+					Users {
+						name
+						verified
+					}
+				}`,
+				Results: map[string]any{
+					"Users": []map[string]any{
+						{"name": "John", "verified": true},
+						{"name": "Fred", "verified": true},
 					},
 				},
 			},


### PR DESCRIPTION
## Relevant issue(s)

Resolves #5191 

## Description

 Filters sent to `UpdateDocumentsWithFilter`/`DeleteDocumentsWithFilter` through any client that round-trips them as JSONcould silently target the wrong documents. This included the C bindings, as well as the HTTP client, CLI, and JS clients.

There were actually a number of issues going wrong here. `immutable.Some(request.Filter{...})` was marshaled to `{"Conditions": ...}`, which decoded back into a filter with a literal `Conditions` field instead of the intended conditions. Further, raw `map[string]any` filters lost integer precision on decode (encoding/json decodes numbers as float64), so a condition on an integer above 2^53 could match a different document than intended. This was an issue that appeared, and was addressed in, several other recent PRs.

This PR introduces new functions, `NormalizeFilterrForJSON` and `DecodeJSONFilter` used on the encoding and decoding sides, respectively, to properly wire the values into the clients code. 

To attain parity across the clients as much as possible, the JS client's filter parameter now also accepts an object as well as a filter string. **However, because JavaScript does not support large integers, we are limited on that particular part off the issue. See: https://github.com/sourcenetwork/defradb/issues/5176**

This PR contains new integration tests to illustrate the behavior. This includes two on which JS client support is marked as a to-do.


## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Specify the platform(s) on which this was tested:
- WSL