### PR TITLE
refactor: Move CRDT periphery logic into crdt declaration

### DIFF
--- a/client/ctype.go
+++ b/client/ctype.go
@@ -53,6 +53,8 @@ func (t CType) IsSupportedFieldCType() bool {
 }
 
 // IsCompatibleWith returns true if the CRDT is compatible with the field kind
+//
+// Deprecated: This function will be removed in Defra v2.0.0
 func (t CType) IsCompatibleWith(kind FieldKind) bool {
 	switch t {
 	case PN_COUNTER, P_COUNTER:

--- a/client/ctype.go
+++ b/client/ctype.go
@@ -68,6 +68,8 @@ func (t CType) IsCompatibleWith(kind FieldKind) bool {
 }
 
 // String returns the string representation of the CRDT.
+//
+// Deprecated: This function will be removed in Defra v2.0.0
 func (t CType) String() string {
 	switch t {
 	case NONE_CRDT:

--- a/client/ctype.go
+++ b/client/ctype.go
@@ -41,6 +41,8 @@ const (
 )
 
 // IsSupportedFieldCType returns true if the type is supported as a document field type.
+//
+// Deprecated: This function will be removed in Defra v2.0.0
 func (t CType) IsSupportedFieldCType() bool {
 	switch t {
 	case NONE_CRDT, LWW_REGISTER, PN_COUNTER, P_COUNTER:

--- a/client/document.go
+++ b/client/document.go
@@ -924,21 +924,19 @@ func (doc *Document) Set(ctx context.Context, field string, value any) error {
 	if err != nil {
 		return err
 	}
-	return doc.set(fd.Typ, field, val)
-}
 
-func (doc *Document) set(t CType, field string, value NormalValue) error {
 	doc.mu.Lock()
 	defer doc.mu.Unlock()
 	var f Field
 	if v, exists := doc.fields[field]; exists {
 		f = v
 	} else {
-		f = doc.newField(t, field)
+		f = doc.newField(fd.Typ, field)
 		doc.fields[field] = f
 	}
-	doc.values[f] = NewFieldValue(t, value)
+	doc.values[f] = NewFieldValue(fd.Typ, val)
 	doc.isDirty = true
+
 	return nil
 }
 

--- a/client/document.go
+++ b/client/document.go
@@ -96,8 +96,6 @@ type Document struct {
 	values map[Field]*FieldValue
 	head   cid.Cid
 	mu     sync.RWMutex
-	// marks if document has unsaved changes
-	isDirty bool
 
 	collection CollectionVersion
 }
@@ -935,7 +933,6 @@ func (doc *Document) Set(ctx context.Context, field string, value any) error {
 		doc.fields[field] = f
 	}
 	doc.values[f] = NewFieldValue(fd.Typ, val)
-	doc.isDirty = true
 
 	return nil
 }

--- a/client/document.go
+++ b/client/document.go
@@ -924,10 +924,10 @@ func (doc *Document) Set(ctx context.Context, field string, value any) error {
 	if err != nil {
 		return err
 	}
-	return doc.setCBOR(fd.Typ, field, val)
+	return doc.set(fd.Typ, field, val)
 }
 
-func (doc *Document) set(t CType, field string, value *FieldValue) error {
+func (doc *Document) set(t CType, field string, value NormalValue) error {
 	doc.mu.Lock()
 	defer doc.mu.Unlock()
 	var f Field
@@ -937,14 +937,9 @@ func (doc *Document) set(t CType, field string, value *FieldValue) error {
 		f = doc.newField(t, field)
 		doc.fields[field] = f
 	}
-	doc.values[f] = value
+	doc.values[f] = NewFieldValue(t, value)
 	doc.isDirty = true
 	return nil
-}
-
-func (doc *Document) setCBOR(t CType, field string, val NormalValue) error {
-	value := NewFieldValue(t, val)
-	return doc.set(t, field, value)
 }
 
 func (doc *Document) setAndParseObjectType(ctx context.Context, value map[string]any) error {

--- a/client/errors.go
+++ b/client/errors.go
@@ -248,7 +248,7 @@ func NewErrInvalidCRDTTypeV(name string, crdtType CType) error {
 	)
 }
 
-func NewErrCRDTKindMismatch(cType, kind string) error {
+func NewErrCRDTKindMismatch(cType CType, kind string) error {
 	return errors.New(fmt.Sprintf(errCRDTKindMismatch, cType, kind))
 }
 

--- a/client/errors.go
+++ b/client/errors.go
@@ -240,6 +240,14 @@ func NewErrInvalidCRDTType(name, crdtType string) error {
 	)
 }
 
+func NewErrInvalidCRDTTypeV(name string, crdtType CType) error {
+	return errors.New(
+		errInvalidCRDTType,
+		errors.NewKV("Name", name),
+		errors.NewKV("CRDTType", crdtType),
+	)
+}
+
 func NewErrCRDTKindMismatch(cType, kind string) error {
 	return errors.New(fmt.Sprintf(errCRDTKindMismatch, cType, kind))
 }

--- a/client/value.go
+++ b/client/value.go
@@ -20,6 +20,7 @@ type FieldValue struct {
 	isDirty bool
 }
 
+// Deprecated: The first (CType) param  will be removed in Defra v2.0.0
 func NewFieldValue(t CType, val NormalValue) *FieldValue {
 	return &FieldValue{
 		t:       t,
@@ -36,6 +37,7 @@ func (val FieldValue) NormalValue() NormalValue {
 	return val.value
 }
 
+// Deprecated: This function will be removed in Defra v2.0.0
 func (val FieldValue) Type() CType {
 	return val.t
 }
@@ -54,6 +56,7 @@ func (val *FieldValue) Clean() {
 	val.isDirty = false
 }
 
+// Deprecated: This function will be removed in Defra v2.0.0
 func (val *FieldValue) SetType(t CType) {
 	val.t = t
 }

--- a/internal/core/block/store.go
+++ b/internal/core/block/store.go
@@ -88,37 +88,31 @@ func addDelta(
 
 	block := New(crdt.NewCRDT(delta), links, heads...)
 
-	fieldName := immutable.None[string]()
-	if block.Delta.GetFieldName() != "" {
-		fieldName = immutable.Some(block.Delta.GetFieldName())
-	}
-	var encBlock *Encryption
-	var encLink cidlink.Link
-	var err error
-	if !block.Delta.IsCollection() {
-		encBlock, encLink, err = determineBlockEncryption(ctx, options.EncryptionDocKey, fieldName, heads)
+	if block.Delta.IsField() {
+		fieldName := immutable.Some(block.Delta.GetFieldName())
+		encBlock, encLink, err := determineBlockEncryption(ctx, options.EncryptionDocKey, fieldName, heads)
 		if err != nil {
 			return cidlink.Link{}, nil, NewErrDetermineBlockEncryption(err)
 		}
-	}
 
-	dagBlock := block
-	if encBlock != nil {
-		dagBlock, err = encryptBlock(ctx, block, encBlock)
-		if err != nil {
-			return cidlink.Link{}, nil, NewErrEncryptBlock(err)
+		// encBlock will be nil if the field is not configured to be encrypted
+		if encBlock != nil {
+			block, err = encryptBlock(ctx, block, encBlock)
+			if err != nil {
+				return cidlink.Link{}, nil, NewErrEncryptBlock(err)
+			}
+			block.Encryption = &encLink
 		}
-		dagBlock.Encryption = &encLink
 	}
 
 	if ok, ident := EnabledSigningFromContext(ctx); ok && ident.HasValue() {
-		err = signBlock(ctx, txn.Blockstore(), dagBlock, ident.Value())
+		err := signBlock(ctx, txn.Blockstore(), block, ident.Value())
 		if err != nil {
 			return cidlink.Link{}, nil, NewErrSignBlock(err)
 		}
 	}
 
-	link, err := putBlock(ctx, txn.Blockstore(), dagBlock)
+	link, err := putBlock(ctx, txn.Blockstore(), block)
 	if err != nil {
 		return cidlink.Link{}, nil, NewErrStoreBlock(err)
 	}
@@ -128,7 +122,7 @@ func addDelta(
 		return cidlink.Link{}, nil, NewErrProcessBlock(err)
 	}
 
-	b, err := dagBlock.Marshal()
+	b, err := block.Marshal()
 	if err != nil {
 		return cidlink.Link{}, nil, NewErrMarshalBlock(err)
 	}

--- a/internal/core/crdt/counter.go
+++ b/internal/core/crdt/counter.go
@@ -74,6 +74,7 @@ type Counter struct {
 }
 
 var _ FieldValueCRDT = (*Counter)(nil)
+var _ KindLimitedCRDT = (*Counter)(nil)
 
 // NewCounter creates a new Counter CRDT.
 func NewCounter(
@@ -194,6 +195,14 @@ func (c *Counter) CType() client.CType {
 		return client.PN_COUNTER
 	}
 	return client.P_COUNTER
+}
+
+func (c *Counter) SupportedKinds() []client.FieldKind {
+	return []client.FieldKind{
+		client.FieldKind_NILLABLE_INT,
+		client.FieldKind_NILLABLE_FLOAT64,
+		client.FieldKind_NILLABLE_FLOAT32,
+	}
 }
 
 func validateAndIncrement[T Incrementable](

--- a/internal/core/crdt/counter.go
+++ b/internal/core/crdt/counter.go
@@ -205,6 +205,29 @@ func (c *Counter) SupportedKinds() []client.FieldKind {
 	}
 }
 
+func (c *Counter) String() string {
+	if c.allowDecrement {
+		return "pncounter"
+	}
+	return "pcounter"
+}
+
+func (c *Counter) Description() string {
+	if c.allowDecrement {
+		return `Positive-Negative Counter.
+	
+	WARNING: Incrementing an integer and causing it to overflow the int64 max value
+	will cause the value to roll over to the int64 min value. Incremeting a float and
+	causing it to overflow the float64 max value will act like a no-op.`
+	}
+
+	return `Positive Counter.
+	
+	WARNING: Incrementing an integer and causing it to overflow the int64 max value
+	will cause the value to roll over to the int64 min value. Incremeting a float and
+	causing it to overflow the float64 max value will act like a no-op.`
+}
+
 func validateAndIncrement[T Incrementable](
 	ctx context.Context,
 	store datastore.Keyedstore,

--- a/internal/core/crdt/counter.go
+++ b/internal/core/crdt/counter.go
@@ -86,7 +86,7 @@ func NewCounter(
 }
 
 // WARNING: Incrementing an integer and causing it to overflow the int64 max value
-// will cause the value to roll over to the int64 min value. Incremeting a float and
+// will cause the value to roll over to the int64 min value. Incrementing a float and
 // causing it to overflow the float64 max value will act like a no-op.
 func (c *Counter) Increment(
 	ctx context.Context,
@@ -217,14 +217,14 @@ func (c *Counter) Description() string {
 		return `Positive-Negative Counter.
 	
 	WARNING: Incrementing an integer and causing it to overflow the int64 max value
-	will cause the value to roll over to the int64 min value. Incremeting a float and
+	will cause the value to roll over to the int64 min value. Incrementing a float and
 	causing it to overflow the float64 max value will act like a no-op.`
 	}
 
 	return `Positive Counter.
 	
 	WARNING: Incrementing an integer and causing it to overflow the int64 max value
-	will cause the value to roll over to the int64 min value. Incremeting a float and
+	will cause the value to roll over to the int64 min value. Incrementing a float and
 	causing it to overflow the float64 max value will act like a no-op.`
 }
 

--- a/internal/core/crdt/delta_doc_id_test.go
+++ b/internal/core/crdt/delta_doc_id_test.go
@@ -32,6 +32,7 @@ func TestDocumentDeltasDoNotEncodeDocID(t *testing.T) {
 	lwwDelta, err := lww.Set(
 		ctx,
 		"collection-version",
+		//nolint:staticcheck
 		NewDocField("name", client.NewFieldValue(client.LWW_REGISTER, client.NewNormalString("Alice"))),
 		1,
 	)
@@ -42,6 +43,7 @@ func TestDocumentDeltasDoNotEncodeDocID(t *testing.T) {
 	counterDelta, err := counter.Increment(
 		ctx,
 		"collection-version",
+		//nolint:staticcheck
 		NewDocField("age", client.NewFieldValue(client.P_COUNTER, client.NewNormalInt(1))),
 		false,
 		1,

--- a/internal/core/crdt/lww.go
+++ b/internal/core/crdt/lww.go
@@ -61,6 +61,10 @@ func NewLWW() *LWW {
 	return &LWW{}
 }
 
+func (l *LWW) CType() client.CType {
+	return client.LWW_REGISTER
+}
+
 func (l *LWW) Set(
 	ctx context.Context,
 	collectionVersionID string,

--- a/internal/core/crdt/lww.go
+++ b/internal/core/crdt/lww.go
@@ -65,6 +65,14 @@ func (l *LWW) CType() client.CType {
 	return client.LWW_REGISTER
 }
 
+func (l *LWW) String() string {
+	return "lww"
+}
+
+func (l *LWW) Description() string {
+	return "Last Write Wins register"
+}
+
 func (l *LWW) Set(
 	ctx context.Context,
 	collectionVersionID string,

--- a/internal/core/crdt/merklecrdt.go
+++ b/internal/core/crdt/merklecrdt.go
@@ -27,6 +27,10 @@ var FieldCRDTs = []FieldValueCRDT{
 	NewCounter(false),
 }
 
+// TryGetFieldCRDT returns the cached instance of the given crdt.
+//
+// A `NONE_CRDT` will return `nil`.  If nothing is found, `false` will
+// be returned, else `true`.
 func TryGetFieldCRDT(ct client.CType) (FieldValueCRDT, bool) {
 	if ct == client.NONE_CRDT {
 		return nil, true

--- a/internal/core/crdt/merklecrdt.go
+++ b/internal/core/crdt/merklecrdt.go
@@ -47,6 +47,10 @@ type KindLimitedCRDT interface {
 type FieldValueCRDT interface {
 	CType() client.CType
 
+	String() string
+
+	Description() string
+
 	Merge(
 		ctx context.Context,
 		store datastore.Keyedstore,

--- a/internal/core/crdt/merklecrdt.go
+++ b/internal/core/crdt/merklecrdt.go
@@ -21,7 +21,28 @@ import (
 	"github.com/sourcenetwork/defradb/internal/keys"
 )
 
+var FieldCRDTs = []FieldValueCRDT{
+	NewLWW(),
+	NewCounter(true),
+	NewCounter(false),
+}
+
+func TryGetFieldCRDT(ct client.CType) (FieldValueCRDT, bool) {
+	if ct == client.NONE_CRDT {
+		return nil, true
+	}
+
+	for _, crdt := range FieldCRDTs {
+		if crdt.CType() == ct {
+			return crdt, true
+		}
+	}
+	return nil, false
+}
+
 type FieldValueCRDT interface {
+	CType() client.CType
+
 	Merge(
 		ctx context.Context,
 		store datastore.Keyedstore,

--- a/internal/core/crdt/merklecrdt.go
+++ b/internal/core/crdt/merklecrdt.go
@@ -59,17 +59,3 @@ type FieldValueCRDT interface {
 type DocumentValueCRDT interface {
 	Merge(ctx context.Context, store datastore.Keyedstore, key keys.PrimaryDataStoreKey, other Delta) error
 }
-
-func FieldLevelCRDT(
-	cType client.CType,
-) (FieldValueCRDT, error) {
-	switch cType {
-	case client.LWW_REGISTER:
-		return NewLWW(), nil
-	case client.PN_COUNTER, client.P_COUNTER:
-		return NewCounter(
-			cType == client.PN_COUNTER,
-		), nil
-	}
-	return nil, client.NewErrUnknownCRDT(cType)
-}

--- a/internal/core/crdt/merklecrdt.go
+++ b/internal/core/crdt/merklecrdt.go
@@ -40,6 +40,10 @@ func TryGetFieldCRDT(ct client.CType) (FieldValueCRDT, bool) {
 	return nil, false
 }
 
+type KindLimitedCRDT interface {
+	SupportedKinds() []client.FieldKind
+}
+
 type FieldValueCRDT interface {
 	CType() client.CType
 

--- a/internal/db/definition_validation.go
+++ b/internal/db/definition_validation.go
@@ -732,7 +732,7 @@ func validateTypeAndKindCompatible(
 
 			if kindLimitedCrdt, ok := ct.(crdt.KindLimitedCRDT); ok {
 				if !slices.Contains(kindLimitedCrdt.SupportedKinds(), newField.Kind) {
-					errs = append(errs, client.NewErrCRDTKindMismatch(newField.Typ.String(), newField.Kind.String()))
+					errs = append(errs, client.NewErrCRDTKindMismatch(newField.Typ, newField.Kind.String()))
 				}
 			}
 		}

--- a/internal/db/definition_validation.go
+++ b/internal/db/definition_validation.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"slices"
 
 	"github.com/ipfs/go-cid"
 
@@ -722,8 +723,17 @@ func validateTypeAndKindCompatible(
 	var errs []error
 	for _, col := range newState.collections {
 		for _, newField := range col.Fields {
-			if !newField.Typ.IsCompatibleWith(newField.Kind) {
-				errs = append(errs, client.NewErrCRDTKindMismatch(newField.Typ.String(), newField.Kind.String()))
+			ct, ok := crdt.TryGetFieldCRDT(newField.Typ)
+			if !ok {
+				// If the configured crdt is not found, ingore it here and let other validation raise any
+				// appropriate errors
+				continue
+			}
+
+			if kindLimitedCrdt, ok := ct.(crdt.KindLimitedCRDT); ok {
+				if !slices.Contains(kindLimitedCrdt.SupportedKinds(), newField.Kind) {
+					errs = append(errs, client.NewErrCRDTKindMismatch(newField.Typ.String(), newField.Kind.String()))
+				}
 			}
 		}
 	}

--- a/internal/db/definition_validation.go
+++ b/internal/db/definition_validation.go
@@ -846,7 +846,7 @@ func validateTypeSupported(
 	for _, col := range newState.collections {
 		for _, newField := range col.Fields {
 			if _, ok := crdt.TryGetFieldCRDT(newField.Typ); !ok {
-				errs = append(errs, client.NewErrInvalidCRDTType(newField.Name, newField.Typ.String()))
+				errs = append(errs, client.NewErrInvalidCRDTTypeV(newField.Name, newField.Typ))
 			}
 		}
 	}

--- a/internal/db/definition_validation.go
+++ b/internal/db/definition_validation.go
@@ -20,6 +20,7 @@ import (
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/request"
 	"github.com/sourcenetwork/defradb/errors"
+	"github.com/sourcenetwork/defradb/internal/core/crdt"
 	"github.com/sourcenetwork/defradb/internal/datastore"
 	"github.com/sourcenetwork/defradb/internal/db/id"
 	"github.com/sourcenetwork/defradb/internal/keys"
@@ -834,7 +835,7 @@ func validateTypeSupported(
 	var errs []error
 	for _, col := range newState.collections {
 		for _, newField := range col.Fields {
-			if !newField.Typ.IsSupportedFieldCType() {
+			if _, ok := crdt.TryGetFieldCRDT(newField.Typ); !ok {
 				errs = append(errs, client.NewErrInvalidCRDTType(newField.Name, newField.Typ.String()))
 			}
 		}

--- a/internal/db/document.go
+++ b/internal/db/document.go
@@ -534,10 +534,6 @@ func (c *collection) save(
 				FieldID:           strconv.FormatUint(uint64(fieldID), 10),
 			}
 
-			// by default the type will have been set to LWW_REGISTER. We need to ensure
-			// that it's set to the same as the field description CRDT type.
-			val.SetType(fieldDescription.Typ)
-
 			headset := coreblock.NewHeadSet(txn.Headstore(), fieldKey.ToHeadStoreKey())
 			heads, height, err := headset.List(ctx)
 			if err != nil {
@@ -547,7 +543,7 @@ func (c *collection) save(
 
 			var merkleCRDT crdt.FieldValueCRDT
 			var delta crdt.Delta
-			switch val.Type() {
+			switch fieldDescription.Typ {
 			case client.LWW_REGISTER:
 				lww := crdt.NewLWW()
 				merkleCRDT = lww
@@ -559,7 +555,7 @@ func (c *collection) save(
 
 			case client.PN_COUNTER, client.P_COUNTER:
 				counter := crdt.NewCounter(
-					val.Type() == client.PN_COUNTER,
+					fieldDescription.Typ == client.PN_COUNTER,
 				)
 				merkleCRDT = counter
 
@@ -567,9 +563,6 @@ func (c *collection) save(
 				if err != nil {
 					return err
 				}
-
-			default:
-				return client.NewErrUnknownCRDT(val.Type())
 			}
 
 			err = merkleCRDT.Merge(

--- a/internal/db/document.go
+++ b/internal/db/document.go
@@ -615,11 +615,10 @@ func (c *collection) save(
 		return err
 	}
 
-	link, headNode, err := coreblock.AddDeltaWithOptions(
+	link, headNode, err := coreblock.AddDelta(
 		signingCtx,
 		headstoreKey,
 		delta,
-		coreblock.AddDeltaOptions{EncryptionDocKey: encryptionDocID},
 		heads,
 		links...,
 	)

--- a/internal/db/fetcher/versioned.go
+++ b/internal/db/fetcher/versioned.go
@@ -453,9 +453,9 @@ func (vf *VersionedFetcher) merge(c cid.Cid, docShortID uint64) error {
 				return err
 			}
 
-			mcrdt, err := crdt.FieldLevelCRDT(field.Typ)
-			if err != nil {
-				return err
+			mcrdt, ok := crdt.TryGetFieldCRDT(field.Typ)
+			if !ok {
+				return client.NewErrUnknownCRDT(field.Typ)
 			}
 
 			// Merge the block without worrying about updating the headstore - they are not used

--- a/internal/db/index.go
+++ b/internal/db/index.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/errors"
+	"github.com/sourcenetwork/defradb/internal/core/crdt"
 	"github.com/sourcenetwork/defradb/internal/datastore"
 	"github.com/sourcenetwork/defradb/internal/db/id"
 	"github.com/sourcenetwork/defradb/internal/db/vectorindex"
@@ -136,7 +137,8 @@ func buildIndexBase(
 			return collectionBaseIndex{}, NewErrUnsupportedIndexFieldType(field.Kind)
 		}
 		if field.Typ == client.PN_COUNTER || field.Typ == client.P_COUNTER {
-			return collectionBaseIndex{}, NewErrCannotIndexAccumulatedCRDTField(field.Name, field.Typ.String())
+			ct, _ := crdt.TryGetFieldCRDT(field.Typ)
+			return collectionBaseIndex{}, NewErrCannotIndexAccumulatedCRDTField(field.Name, ct.String())
 		}
 		base.fieldGenerators[i] = getFieldGenerator(field.Kind)
 	}

--- a/internal/db/merge.go
+++ b/internal/db/merge.go
@@ -550,9 +550,9 @@ func (mp *mergeProcessor) mergeBlock(
 			return false, nil, resolvedDocRef{}, NewErrGetShortFieldIDMerge(err, fd.FieldID, field)
 		}
 
-		fieldCRDT, err := crdt.FieldLevelCRDT(fd.Typ)
-		if err != nil {
-			return false, nil, resolvedDocRef{}, err
+		fieldCRDT, ok := crdt.TryGetFieldCRDT(fd.Typ)
+		if !ok {
+			return false, nil, resolvedDocRef{}, client.NewErrUnknownCRDT(fd.Typ)
 		}
 
 		err = fieldCRDT.Merge(

--- a/internal/request/graphql/schema/collection.go
+++ b/internal/request/graphql/schema/collection.go
@@ -935,9 +935,6 @@ func setCRDTType(field *ast.FieldDefinition, kind client.FieldKind) (client.CTyp
 				if !validCRDTEnum {
 					return 0, client.NewErrInvalidCRDTType(field.Name.Value, cTypeString)
 				}
-				if !cType.IsCompatibleWith(kind) {
-					return 0, client.NewErrCRDTKindMismatch(cType.String(), kind.String())
-				}
 				return cType, nil
 			}
 		}

--- a/internal/request/graphql/schema/collection.go
+++ b/internal/request/graphql/schema/collection.go
@@ -940,13 +940,6 @@ func setCRDTType(field *ast.FieldDefinition, kind client.FieldKind) (client.CTyp
 		}
 	}
 
-	if kind.IsObject() {
-		if kind.IsArray() {
-			return client.NONE_CRDT, nil
-		}
-		return client.LWW_REGISTER, nil
-	}
-
 	return defaultCRDTForFieldKind[kind], nil
 }
 

--- a/internal/request/graphql/schema/testfixtures/schema.relatedmany.gen.graphql
+++ b/internal/request/graphql/schema/testfixtures/schema.relatedmany.gen.graphql
@@ -911,7 +911,7 @@ enum CRDTType {
     Positive Counter.
 
     WARNING: Incrementing an integer and causing it to overflow the int64 max value
-    will cause the value to roll over to the int64 min value. Incremeting a float and
+    will cause the value to roll over to the int64 min value. Incrementing a float and
     causing it to overflow the float64 max value will act like a no-op.
     """
     pcounter
@@ -919,7 +919,7 @@ enum CRDTType {
     Positive-Negative Counter.
 
     WARNING: Incrementing an integer and causing it to overflow the int64 max value
-    will cause the value to roll over to the int64 min value. Incremeting a float and
+    will cause the value to roll over to the int64 min value. Incrementing a float and
     causing it to overflow the float64 max value will act like a no-op.
     """
     pncounter

--- a/internal/request/graphql/schema/testfixtures/schema.relatedone.gen.graphql
+++ b/internal/request/graphql/schema/testfixtures/schema.relatedone.gen.graphql
@@ -854,7 +854,7 @@ enum CRDTType {
     Positive Counter.
 
     WARNING: Incrementing an integer and causing it to overflow the int64 max value
-    will cause the value to roll over to the int64 min value. Incremeting a float and
+    will cause the value to roll over to the int64 min value. Incrementing a float and
     causing it to overflow the float64 max value will act like a no-op.
     """
     pcounter
@@ -862,7 +862,7 @@ enum CRDTType {
     Positive-Negative Counter.
 
     WARNING: Incrementing an integer and causing it to overflow the int64 max value
-    will cause the value to roll over to the int64 min value. Incremeting a float and
+    will cause the value to roll over to the int64 min value. Incrementing a float and
     causing it to overflow the float64 max value will act like a no-op.
     """
     pncounter

--- a/internal/request/graphql/schema/testfixtures/schema.simple.gen.graphql
+++ b/internal/request/graphql/schema/testfixtures/schema.simple.gen.graphql
@@ -164,7 +164,7 @@ enum CRDTType {
     Positive Counter.
 
     WARNING: Incrementing an integer and causing it to overflow the int64 max value
-    will cause the value to roll over to the int64 min value. Incremeting a float and
+    will cause the value to roll over to the int64 min value. Incrementing a float and
     causing it to overflow the float64 max value will act like a no-op.
     """
     pcounter
@@ -172,7 +172,7 @@ enum CRDTType {
     Positive-Negative Counter.
 
     WARNING: Incrementing an integer and causing it to overflow the int64 max value
-    will cause the value to roll over to the int64 min value. Incremeting a float and
+    will cause the value to roll over to the int64 min value. Incrementing a float and
     causing it to overflow the float64 max value will act like a no-op.
     """
     pncounter

--- a/internal/request/graphql/schema/types/types.go
+++ b/internal/request/graphql/schema/types/types.go
@@ -14,6 +14,7 @@ import (
 	gql "github.com/sourcenetwork/graphql-go"
 
 	"github.com/sourcenetwork/defradb/client"
+	"github.com/sourcenetwork/defradb/internal/core/crdt"
 )
 
 const (
@@ -396,31 +397,18 @@ func BranchableDirective() *gql.Directive {
 }
 
 func CRDTEnum() *gql.Enum {
+	valueMap := gql.EnumValueConfigMap{}
+	for _, fieldCrdt := range crdt.FieldCRDTs {
+		valueMap[fieldCrdt.String()] = &gql.EnumValueConfig{
+			Value:       fieldCrdt.CType(),
+			Description: fieldCrdt.Description(),
+		}
+	}
+
 	return gql.NewEnum(gql.EnumConfig{
 		Name:        "CRDTType",
 		Description: "One of the possible CRDT Types.",
-		Values: gql.EnumValueConfigMap{
-			client.LWW_REGISTER.String(): &gql.EnumValueConfig{
-				Value:       client.LWW_REGISTER,
-				Description: "Last Write Wins register",
-			},
-			client.PN_COUNTER.String(): &gql.EnumValueConfig{
-				Value: client.PN_COUNTER,
-				Description: `Positive-Negative Counter.
-
-	WARNING: Incrementing an integer and causing it to overflow the int64 max value
-	will cause the value to roll over to the int64 min value. Incremeting a float and
-	causing it to overflow the float64 max value will act like a no-op.`,
-			},
-			client.P_COUNTER.String(): &gql.EnumValueConfig{
-				Value: client.P_COUNTER,
-				Description: `Positive Counter.
-
-	WARNING: Incrementing an integer and causing it to overflow the int64 max value
-	will cause the value to roll over to the int64 min value. Incremeting a float and
-	causing it to overflow the float64 max value will act like a no-op.`,
-			},
-		},
+		Values:      valueMap,
 	})
 }
 


### PR DESCRIPTION
## Relevant issue(s)

Partially resolves #5115

## Description

Moves most of the CRDT periphery logic into the CRDT declarations.

Areas remaining:
- Collection API - document.save - this will be a bit more involved and I wanted to get the easy bits in earlier, so that PR can be a bit more focused
- CType marshalling logic - I just didn't feel like playing with this right now - there is a CType.Display func used by the remote clients (easy), and the PatchCollection substitution logic (fiddly, main reason for procrastination here), both are low value IMO

The commits should be clean, and contain some addition documentation.  Sorry this PR is not so cohesive perhaps - please flag any commit you are not so comfy with in isolation, and would prefer to have the additional context that would come with the final document refactor.