### PR TITLE
chore: Bump to GoLang v1.26

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Building DefraDB from source requires significant system resources. If you encou
 
 ### Prerequisites
 
-- [Go](https://golang.org/) 1.24 or later
+- [Go](https://golang.org/) 1.26 or later
 - [Rust toolchain](https://www.rust-lang.org/tools/install) (for WASM lens compilation, if running tests)
 - Git
 

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -22,6 +22,12 @@ We as a team have decided that, whilst the exact strings are user-visible via th
 
 We will not make significant changes to the structure of errors returned by any of our functions.  For example, if a function returns an `client.ErrValueTypeMismatch` wrapped by an `client.ErrInvalidJSONPayload` - removing or replacing either one of these will only be done as part of a `MAJOR` version increment.
 
+## Go version bumps
+
+Raising the minimum supported Go version can prevent developers and downstream source consumers from building DefraDB with an older Go toolchain. Although this is technically a compatibility break for those environments, we do not treat Go version bumps as breaking changes under DefraDB's semver policy, and they do not require a `MAJOR` version increment.
+
+Consumers building DefraDB from source are expected to use a supported Go version. We schedule these bumps according to our [Go Version Bumping Policy](./CONTRIBUTING_INTERNAL.md#-go-version-bumping-policy).
+
 ## The C embedded client
 
 We made a mistake when designing many of the function signatures that form the [C client](./cbindings).  Many of the functions have parameters that do not pair up with their Go equivalents - they take individual formal parameters, where the Go function takes an [options](./client/options) struct.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sourcenetwork/defradb
 
-go 1.25.13
+go 1.26.7
 
 require (
 	github.com/bits-and-blooms/bitset v1.24.6

--- a/tools/cloud/aws/packer/build_aws_ami.pkr.hcl
+++ b/tools/cloud/aws/packer/build_aws_ami.pkr.hcl
@@ -66,8 +66,8 @@ build {
     inline = [
       "/usr/bin/cloud-init status --wait",
       "sudo apt-get update && sudo apt-get install make build-essential -y",
-      "curl -OL https://golang.org/dl/go1.25.5.linux-amd64.tar.gz",
-      "rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.25.5.linux-amd64.tar.gz",
+      "curl -OL https://golang.org/dl/go1.26.7.linux-amd64.tar.gz",
+      "rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.26.7.linux-amd64.tar.gz",
       "export PATH=$PATH:/usr/local/go/bin",
       "git clone \"https://git@$DEFRADB_GIT_REPO\"",
       "cd ./defradb || { printf \"\\\ncd into defradb failed.\\\n\" && exit 2; }",

--- a/tools/configs/golangci.yaml
+++ b/tools/configs/golangci.yaml
@@ -24,7 +24,7 @@ run:
 
   # Define the Go version limit.
   # Default: use Go version from the go.mod file, fallback on the env var `GOVERSION`, fallback on 1.22.
-  go: '1.25'
+  go: '1.26'
 
   # If set, we pass it to "go list -mod={option}". From "go help modules":
   # If invoked with -mod=readonly, the go command is disallowed from the implicit

--- a/tools/defradb.containerfile
+++ b/tools/defradb.containerfile
@@ -7,7 +7,7 @@
 # WARNING: The build image SHOULD use the same OS version as the run image. Otherwise they may have
 # different versions of GLIBC and the dynamic linking of libraries will fail.
 # `bookworm` is Debian 12.
-FROM docker.io/golang:1.25-bookworm AS build
+FROM docker.io/golang:1.26-bookworm AS build
 WORKDIR /repo/
 COPY go.mod go.sum Makefile ./
 RUN make deps:modules

--- a/tools/scripts/cross-build.sh
+++ b/tools/scripts/cross-build.sh
@@ -12,7 +12,6 @@ if [[ -z "${platforms}" ]]; then
     platforms=(
         "windows/amd64"
         "windows/arm64"
-        "windows/arm"
         "linux/amd64"
         "linux/arm64"
         "linux/arm"


### PR DESCRIPTION
## Relevant issue(s)
Resolves #4258

## Description
- This is a routine version bump of GoLang, the previous bump was done in (https://github.com/sourcenetwork/defradb/pull/4260)
- Also updates the GoLang version for AWS AMI generation.
- Updates the documented minimum GoLang build prerequisite.
- Removes the `windows/arm` cross-build target, which Go 1.26 no longer supports.
- Update VERSIONING.md with the golang bumping exception

### Routine Todo(s)
- [ ] Open ticket for next GoLang version bump (#TBD)
