### PR TITLE
fix: Prevent node from leaking during C binding CloseNode

### DIFF
--- a/cbindings/node_close.go
+++ b/cbindings/node_close.go
@@ -27,10 +27,10 @@ func CloseNode(nodePtr C.uintptr_t) C.Result {
 	if err != nil {
 		return returnC(returnGoC(1, err.Error(), ""))
 	}
-	err = node.Close(context.Background())
-	if err != nil {
+	defer cgo.Handle(nodePtr).Delete()
+
+	if err := node.Close(context.Background()); err != nil {
 		return returnC(GoCResult{1, err.Error(), ""})
 	}
-	cgo.Handle(nodePtr).Delete()
 	return returnC(GoCResult{0, "", ""})
 }


### PR DESCRIPTION
## Relevant issue(s)

Resolves #5206 

## Description

It was the case that the C bindings' `CloseNode` function would leak the node if the `node.Close` call, for some reason, failed. This was because this failure path leads to the error being returned, and the CGO handle not being deleted. This PR fixes that by moving the delete above the `node.Close` call, and having it deferred. 

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Specify the platform(s) on which this was tested:
- WSL