### PR TITLE
fix: Return an error for SIMILARITY without arguments

### DIFF
--- a/internal/request/graphql/parser/errors.go
+++ b/internal/request/graphql/parser/errors.go
@@ -28,4 +28,5 @@ var (
 	ErrInvalidFilterConditions        = errors.New("invalid filter condition type, expected map")
 	ErrMultipleOrderFieldsDefined     = errors.New("each order argument can only define one field")
 	ErrMultipleDocIDsNotSupported     = errors.New("querying by multiple docIDs is not yet supported")
+	ErrSimilarityMissingTarget        = errors.New("similarity requires a target field argument")
 )

--- a/internal/request/graphql/parser/query.go
+++ b/internal/request/graphql/parser/query.go
@@ -250,6 +250,11 @@ func parseSimilarity(
 		v := arguments[target].(map[string]any)
 		vector = v[types.SimilarityArgVector]
 	}
+	// The argument names the field to compare against, so without one there is nothing to
+	// compare. The mapper looks the target up by name and would panic on the empty name.
+	if target == "" {
+		return nil, ErrSimilarityMissingTarget
+	}
 
 	return &request.Similarity{
 		Field: request.Field{

--- a/tests/integration/query/simple/with_similarity_test.go
+++ b/tests/integration/query/simple/with_similarity_test.go
@@ -517,3 +517,26 @@ func TestQuerySimple_WithTwoSimilarityAndFilteringOnBoth_ShouldSucceed(t *testin
 
 	testUtils.ExecuteTestCase(t, test)
 }
+
+func TestQuerySimple_WithSimilarityAndNoArguments_ShouldError(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddCollection{
+				SDL: `type User {
+					name: String
+					vector: [Int!]
+				}`,
+			},
+			&action.Request{
+				Request: `query {
+					User {
+						SIMILARITY
+					}
+				}`,
+				ExpectedError: "similarity requires a target field argument",
+			},
+		},
+	}
+
+	testUtils.ExecuteTestCase(t, test)
+}


### PR DESCRIPTION
## Relevant issue(s)

Resolves https://github.com/sourcenetwork/defradb/issues/5219

## Description

Asking for a similarity score without saying which field to compare now returns an error naming what is missing. It used to panic, which on a server took down the request handler rather than failing the one query.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Integration test.

Specify the platform(s) on which this was tested:
- macOS
