### PR TITLE
fix: Collection field Kind and Typ in OpenAPI

### DIFF
--- a/docs/website/references/http/openapi.json
+++ b/docs/website/references/http/openapi.json
@@ -229,7 +229,33 @@
                                 "IsPrimary": {
                                     "type": "boolean"
                                 },
-                                "Kind": {},
+                                "Kind": {
+                                    "description": "Field type, e.g. \"String\" or \"[Int!]\". Relations are an object, and a type with no name falls back to its numeric id.",
+                                    "oneOf": [
+                                        {
+                                            "type": "string"
+                                        },
+                                        {
+                                            "properties": {
+                                                "Array": {
+                                                    "type": "boolean"
+                                                },
+                                                "CollectionID": {
+                                                    "type": "string"
+                                                },
+                                                "RelativeID": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "type": "object"
+                                        },
+                                        {
+                                            "maximum": 255,
+                                            "minimum": 0,
+                                            "type": "integer"
+                                        }
+                                    ]
+                                },
                                 "Name": {
                                     "type": "string"
                                 },
@@ -238,9 +264,8 @@
                                     "type": "integer"
                                 },
                                 "Typ": {
-                                    "maximum": 255,
-                                    "minimum": 0,
-                                    "type": "integer"
+                                    "description": "CRDT used to merge the field, e.g. \"lww\".",
+                                    "type": "string"
                                 }
                             },
                             "type": "object"

--- a/http/errors.go
+++ b/http/errors.go
@@ -51,6 +51,7 @@ var (
 	ErrInvalidSubscriptionTransport = errors.New("invalid subscription transport")
 	ErrInvalidGraphQLRequest        = errors.New("invalid graphql request")
 	ErrInvalidTTL                   = errors.New("invalid ttl value")
+	ErrCollectionSchemaNotGenerated = errors.New("collection schema was not generated")
 )
 
 type errorResponse struct {

--- a/http/openapi.go
+++ b/http/openapi.go
@@ -89,6 +89,13 @@ func NewOpenAPISpec() (*openapi3.T, error) {
 		WithDescription("Transaction id").
 		WithSchema(openapi3.NewInt64Schema())
 
+	// The collection endpoints render each field's Kind and Typ as their display strings
+	// rather than the numeric form held on the struct, so the generated schema (which
+	// reflects the Go types) has to be corrected to match what is actually sent.
+	if err := setCollectionFieldDisplaySchema(schemas); err != nil {
+		return nil, err
+	}
+
 	// add common schemas, responses, and params so we can reference them
 	schemas["document"] = &openapi3.SchemaRef{
 		Value: openapi3.NewObjectSchema().WithAnyAdditionalProperties(),
@@ -210,4 +217,46 @@ func NewOpenAPISpec() (*openapi3.T, error) {
 			},
 		},
 	}, nil
+}
+
+// setCollectionFieldDisplaySchema corrects the generated collection schema so that each
+// field's Kind and Typ describe the display form the collection endpoints emit.
+//
+// The generator reflects the Go types: Typ comes out as the byte it is stored as, and Kind
+// as an empty schema because it is an interface. Both are sent as their readable form
+// instead - see [client.CollectionVersion.Display].
+func setCollectionFieldDisplaySchema(schemas openapi3.Schemas) error {
+	collection, ok := schemas["collection"]
+	if !ok || collection.Value == nil {
+		return ErrCollectionSchemaNotGenerated
+	}
+	fields, ok := collection.Value.Properties["Fields"]
+	if !ok || fields.Value == nil || fields.Value.Items == nil || fields.Value.Items.Value == nil {
+		return ErrCollectionSchemaNotGenerated
+	}
+
+	// A relation kind is sent as an object naming the collection it points at, or, for a
+	// relation within the same collection set, its position relative to this one.
+	relationKind := openapi3.NewObjectSchema().WithProperties(map[string]*openapi3.Schema{
+		"Array":        openapi3.NewBoolSchema(),
+		"CollectionID": openapi3.NewStringSchema(),
+		"RelativeID":   openapi3.NewStringSchema(),
+	})
+
+	kind := openapi3.NewSchema()
+	kind.Description = "Field type, e.g. \"String\" or \"[Int!]\". Relations are an object, and a " +
+		"type with no name falls back to its numeric id."
+	kind.OneOf = openapi3.SchemaRefs{
+		openapi3.NewSchemaRef("", openapi3.NewStringSchema()),
+		openapi3.NewSchemaRef("", relationKind),
+		openapi3.NewSchemaRef("", openapi3.NewIntegerSchema().WithMin(0).WithMax(255)),
+	}
+
+	typ := openapi3.NewStringSchema()
+	typ.Description = "CRDT used to merge the field, e.g. \"lww\"."
+
+	fields.Value.Items.Value.Properties["Kind"] = openapi3.NewSchemaRef("", kind)
+	fields.Value.Items.Value.Properties["Typ"] = openapi3.NewSchemaRef("", typ)
+
+	return nil
 }


### PR DESCRIPTION
## Relevant issue(s)

Refs https://github.com/sourcenetwork/defradb/issues/4816

## Description

A client generated from the OpenAPI spec could not read a collection response. The collection endpoints send each field's type and CRDT as readable names, but the spec is generated by reflecting over the Go types, so it described the numeric form they are stored as: the CRDT as a number, and the type as nothing at all, since it is an interface the generator cannot model.

This is the remaining half of https://github.com/sourcenetwork/defradb/pull/5231, which was merged before the spec was corrected. That the spec was inaccurate for describing a collection predates it, and is fixed here too.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Generated the spec and checked it against what the endpoints send.

Specify the platform(s) on which this was tested:
- macOS