### PR TITLE
refactor: Make each index kind own its fields

### DIFF
--- a/cbindings/wrapper_collection.go
+++ b/cbindings/wrapper_collection.go
@@ -93,8 +93,9 @@ func (c *Collection) NewIndex(
 	copts.getInactive = 0
 
 	//nolint:staticcheck // a request has no accessor; the deprecated field is the only source
-	orderedFields := make([]string, len(indexDesc.Fields))
-	for i, f := range indexDesc.Fields {
+	requested := indexDesc.Fields
+	orderedFields := make([]string, len(requested))
+	for i, f := range requested {
 		order := "ASC"
 		if f.Descending {
 			order = "DESC"

--- a/cbindings/wrapper_collection.go
+++ b/cbindings/wrapper_collection.go
@@ -92,6 +92,7 @@ func (c *Collection) NewIndex(
 	copts.name = cName
 	copts.getInactive = 0
 
+	//nolint:staticcheck // a request has no accessor; the deprecated field is the only source
 	orderedFields := make([]string, len(indexDesc.Fields))
 	for i, f := range indexDesc.Fields {
 		order := "ASC"

--- a/cli/test/action/list_indexes.go
+++ b/cli/test/action/list_indexes.go
@@ -76,7 +76,7 @@ func (a *ListIndexes) Execute() {
 					require.Equal(a.s.T, expected.ID, actual.ID)
 				}
 				require.Equal(a.s.T, expected.Name, actual.Name)
-				require.Equal(a.s.T, expected.Fields, actual.Fields)
+				require.Equal(a.s.T, expected.GetFields(), actual.GetFields())
 				require.Equal(a.s.T, expected.GetUnique(), actual.GetUnique())
 
 				if a.ExpectedCollectionName != "" {
@@ -112,7 +112,7 @@ func (a *ListIndexes) Execute() {
 						require.Equal(a.s.T, expected.ID, actual.ID)
 					}
 					require.Equal(a.s.T, expected.Name, actual.Name)
-					require.Equal(a.s.T, expected.Fields, actual.Fields)
+					require.Equal(a.s.T, expected.GetFields(), actual.GetFields())
 					require.Equal(a.s.T, expected.GetUnique(), actual.GetUnique())
 
 					// Each element must name its own collection, matching the key it was filed under.

--- a/cli/test/action/new_index.go
+++ b/cli/test/action/new_index.go
@@ -96,7 +96,7 @@ func (a *NewIndex) Execute() {
 		if expected.Name != "" {
 			require.Equal(a.s.T, expected.Name, result.Name)
 		}
-		require.Equal(a.s.T, expected.Fields, result.Fields)
+		require.Equal(a.s.T, expected.GetFields(), result.GetFields())
 		require.Equal(a.s.T, expected.GetUnique(), result.GetUnique())
 	}
 }

--- a/client/index.go
+++ b/client/index.go
@@ -44,6 +44,9 @@ const (
 type IndexKindDescription interface {
 	// isIndexKindDescription is unexported so only types in this package can implement this interface.
 	isIndexKindDescription()
+
+	// FieldNames returns the names of the indexed fields, in the order the kind stores them.
+	FieldNames() []string
 }
 
 // VectorAlgorithm identifies the algorithm used to build/search a vector index. It is a string so it
@@ -109,14 +112,31 @@ const (
 type OrderedIndexDescription struct {
 	// Unique indicates whether the index enforces uniqueness.
 	Unique bool
+
+	// Fields are the indexed fields, in key order. Each carries a direction, since an ordered index
+	// is read in key order.
+	Fields []IndexedFieldDescription
 }
 
 func (*OrderedIndexDescription) isIndexKindDescription() {}
+
+// FieldNames returns the indexed field names, dropping each field's direction.
+func (d *OrderedIndexDescription) FieldNames() []string {
+	names := make([]string, len(d.Fields))
+	for i, field := range d.Fields {
+		names[i] = field.Name
+	}
+	return names
+}
 
 var _ IndexKindDescription = (*OrderedIndexDescription)(nil)
 
 // VectorIndexDescription is the config for a vector (ANN) index.
 type VectorIndexDescription struct {
+	// Fields are the names of the indexed fields. Names only: a graph is searched by nearness, so
+	// there is no direction to carry.
+	Fields []string
+
 	// Algorithm is the algorithm used to build/search the index.
 	Algorithm VectorAlgorithm
 	// Metric is the distance metric used to compare vectors.
@@ -129,6 +149,11 @@ type VectorIndexDescription struct {
 
 func (*VectorIndexDescription) isIndexKindDescription() {}
 
+// FieldNames returns the indexed field names, which is all a vector index stores.
+func (d *VectorIndexDescription) FieldNames() []string {
+	return d.Fields
+}
+
 var _ IndexKindDescription = (*VectorIndexDescription)(nil)
 
 // IndexDescription describes an index.
@@ -138,6 +163,9 @@ type IndexDescription struct {
 	// ID is the local identifier of this index.
 	ID uint32
 	// Fields contains the fields that are being indexed.
+	//
+	// Deprecated: use the kind config's Fields. This field will be removed in Defra v2.0.0 and is
+	// kept in sync until then.
 	Fields []IndexedFieldDescription
 
 	// Unique indicates whether the index enforces uniqueness. It only applies to ordered indexes.
@@ -184,15 +212,66 @@ func (d IndexDescription) GetUnique() bool {
 	return d.Unique
 }
 
-// Normalize returns a copy with KindDescription and the compat Unique field consistent: a nil
-// ordered KindDescription is filled from Unique, and Unique is set from the resolved config. Use it
-// to compare two descriptors that may have been built in different styles (only Unique, or only
-// Kind/KindDescription).
-func (d IndexDescription) Normalize() IndexDescription {
+// fields returns the index's fields with their directions. Only an ordered index has them, so a
+// vector index's entries come back ascending. Only [IndexDescription.normalize] needs the
+// directions; fieldNames serves the rest.
+func (d IndexDescription) fields() []IndexedFieldDescription {
+	if ordered, ok := d.KindDescription.(*OrderedIndexDescription); ok && len(ordered.Fields) > 0 {
+		return ordered.Fields
+	}
+	names := d.fieldNames()
+	fields := make([]IndexedFieldDescription, len(names))
+	for i, name := range names {
+		fields[i] = IndexedFieldDescription{Name: name}
+	}
+	return fields
+}
+
+// fieldNames returns the names of the index's fields, falling back to the deprecated top-level ones
+// for a descriptor built in memory before the kind carried them.
+func (d IndexDescription) fieldNames() []string {
+	if d.KindDescription != nil {
+		if names := d.KindDescription.FieldNames(); len(names) > 0 {
+			return names
+		}
+	}
+	//nolint:staticcheck // the fallback this helper exists to hide
+	names := make([]string, len(d.Fields))
+	//nolint:staticcheck // the fallback this helper exists to hide
+	for i, field := range d.Fields {
+		names[i] = field.Name
+	}
+	return names
+}
+
+// normalize returns a copy with KindDescription and the compat fields consistent: a nil ordered
+// KindDescription is filled from the deprecated fields, and those are set back from the resolved
+// config. Both (un)marshalling paths run it, so a stored descriptor is always consistent.
+func (d IndexDescription) normalize() IndexDescription {
 	if d.Kind == IndexKindOrdered && d.KindDescription == nil {
-		d.KindDescription = &OrderedIndexDescription{Unique: d.Unique}
+		//nolint:staticcheck // reading it is how a legacy descriptor is upgraded
+		d.KindDescription = &OrderedIndexDescription{Unique: d.Unique, Fields: d.Fields}
+	}
+	// A caller that set only the old spelling still gets a complete config.
+	switch config := d.KindDescription.(type) {
+	case *OrderedIndexDescription:
+		if len(config.Fields) == 0 {
+			//nolint:staticcheck // upgrading a descriptor that predates the kind carrying fields
+			config.Fields = d.Fields
+		}
+	case *VectorIndexDescription:
+		if len(config.Fields) == 0 {
+			//nolint:staticcheck // upgrading a descriptor that predates the kind carrying fields
+			for _, field := range d.Fields {
+				config.Fields = append(config.Fields, field.Name)
+			}
+		}
 	}
 	d.Unique = d.GetUnique()
+	if fields := d.fields(); len(fields) > 0 {
+		//nolint:staticcheck // kept in sync so old readers still see it
+		d.Fields = fields
+	}
 	return d
 }
 
@@ -243,15 +322,15 @@ func (d *IndexDescription) UnmarshalJSON(bytes []byte) error {
 	default:
 		return NewErrUnknownIndexKind(uint8(mirror.Kind))
 	}
-	// Keep the compat Unique field in sync with the resolved config so old readers see it.
-	d.Unique = d.GetUnique()
+	// Upgrades a descriptor stored before the kind carried its own fields.
+	*d = d.normalize()
 	return nil
 }
 
 // MarshalJSON writes the Kind, its config, and the compat top-level Unique (so a reader that
 // predates [Kind] still gets the uniqueness). They are always emitted consistently.
 func (d IndexDescription) MarshalJSON() ([]byte, error) {
-	d = d.Normalize()
+	d = d.normalize()
 	// The concrete configs are plain structs; their Marshal cannot fail.
 	kindDescription, _ := json.Marshal(d.KindDescription)
 	return json.Marshal(indexDescription{
@@ -271,6 +350,9 @@ type NewIndexRequest struct {
 	// Name contains the name of the index.
 	Name string
 	// Fields contains the fields that are being indexed.
+	//
+	// Deprecated: set them on [NewIndexRequest.Ordered] or [NewIndexRequest.Vector]. This field will
+	// be removed in Defra v2.0.0. Setting both is an error unless they agree.
 	Fields []IndexedFieldDescription
 
 	// Unique indicates whether the index is unique.
@@ -327,13 +409,13 @@ func (col CollectionVersion) CollectIndexedFields() []CollectionFieldDescription
 	fieldsMap := make(map[string]bool)
 	fields := make([]CollectionFieldDescription, 0, len(col.Indexes))
 	for _, index := range col.Indexes {
-		for _, field := range index.Fields {
-			if fieldsMap[field.Name] {
+		for _, name := range index.fieldNames() {
+			if fieldsMap[name] {
 				// If the FieldDescription has already been added to the result do not add it a second time
 				// this can happen if a field is referenced by multiple indexes
 				continue
 			}
-			colField, ok := col.GetFieldByName(field.Name)
+			colField, ok := col.GetFieldByName(name)
 			if ok {
 				fields = append(fields, colField)
 			}
@@ -347,7 +429,8 @@ func (col CollectionVersion) CollectIndexedFields() []CollectionFieldDescription
 func (col CollectionVersion) GetIndexesOnField(fieldName string) []IndexDescription {
 	result := []IndexDescription{}
 	for _, index := range col.Indexes {
-		if index.Fields[0].Name == fieldName {
+		names := index.fieldNames()
+		if len(names) > 0 && names[0] == fieldName {
 			result = append(result, index)
 		}
 	}

--- a/client/index.go
+++ b/client/index.go
@@ -212,12 +212,17 @@ func (d IndexDescription) GetUnique() bool {
 	return d.Unique
 }
 
-// fields returns the index's fields with their directions. Only an ordered index has them, so a
-// vector index's entries come back ascending. Only [IndexDescription.normalize] needs the
-// directions; fieldNames serves the rest.
-func (d IndexDescription) fields() []IndexedFieldDescription {
+// GetFields returns the index's fields with their directions, reading the kind's own config and
+// falling back to the deprecated [IndexDescription.Fields]. Only an ordered index has directions, so
+// a vector index's entries come back ascending.
+func (d IndexDescription) GetFields() []IndexedFieldDescription {
 	if ordered, ok := d.KindDescription.(*OrderedIndexDescription); ok && len(ordered.Fields) > 0 {
 		return ordered.Fields
+	}
+	// The deprecated field is the only one carrying directions for a descriptor built in memory, so
+	// it is returned whole rather than reduced to names.
+	if len(d.Fields) > 0 {
+		return d.Fields
 	}
 	names := d.fieldNames()
 	fields := make([]IndexedFieldDescription, len(names))
@@ -235,9 +240,7 @@ func (d IndexDescription) fieldNames() []string {
 			return names
 		}
 	}
-	//nolint:staticcheck // the fallback this helper exists to hide
 	names := make([]string, len(d.Fields))
-	//nolint:staticcheck // the fallback this helper exists to hide
 	for i, field := range d.Fields {
 		names[i] = field.Name
 	}
@@ -249,27 +252,29 @@ func (d IndexDescription) fieldNames() []string {
 // config. Both (un)marshalling paths run it, so a stored descriptor is always consistent.
 func (d IndexDescription) normalize() IndexDescription {
 	if d.Kind == IndexKindOrdered && d.KindDescription == nil {
-		//nolint:staticcheck // reading it is how a legacy descriptor is upgraded
 		d.KindDescription = &OrderedIndexDescription{Unique: d.Unique, Fields: d.Fields}
 	}
-	// A caller that set only the old spelling still gets a complete config.
+	// A caller that set only the old spelling still gets a complete config. The config is replaced
+	// rather than written through: the pointer may be shared, and marshalling must not mutate its
+	// caller's descriptor.
 	switch config := d.KindDescription.(type) {
 	case *OrderedIndexDescription:
 		if len(config.Fields) == 0 {
-			//nolint:staticcheck // upgrading a descriptor that predates the kind carrying fields
-			config.Fields = d.Fields
+			upgraded := *config
+			upgraded.Fields = d.Fields
+			d.KindDescription = &upgraded
 		}
 	case *VectorIndexDescription:
 		if len(config.Fields) == 0 {
-			//nolint:staticcheck // upgrading a descriptor that predates the kind carrying fields
+			upgraded := *config
 			for _, field := range d.Fields {
-				config.Fields = append(config.Fields, field.Name)
+				upgraded.Fields = append(upgraded.Fields, field.Name)
 			}
+			d.KindDescription = &upgraded
 		}
 	}
 	d.Unique = d.GetUnique()
-	if fields := d.fields(); len(fields) > 0 {
-		//nolint:staticcheck // kept in sync so old readers still see it
+	if fields := d.GetFields(); len(fields) > 0 {
 		d.Fields = fields
 	}
 	return d

--- a/client/index_compat_test.go
+++ b/client/index_compat_test.go
@@ -1,3 +1,13 @@
+// Copyright 2023 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
 package client
 
 import (
@@ -17,4 +27,14 @@ func TestIndexDescription_CompatFieldsOnly_ReadsThrough(t *testing.T) {
 		KindDescription: &OrderedIndexDescription{Unique: true},
 	}
 	require.Equal(t, []string{"age"}, d.fieldNames())
+}
+
+// A descriptor built in memory carries directions only on the deprecated field. Reading it must not
+// reduce them to names, or a descending composite index silently becomes ascending.
+func TestIndexDescription_CompatFieldsOnly_KeepsDirection(t *testing.T) {
+	d := IndexDescription{
+		Name: "x", ID: 1, Kind: IndexKindOrdered,
+		Fields: []IndexedFieldDescription{{Name: "age", Descending: true}},
+	}
+	require.Equal(t, d.Fields, d.GetFields())
 }

--- a/client/index_compat_test.go
+++ b/client/index_compat_test.go
@@ -1,0 +1,20 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// An in-process caller that predates the kind carrying fields sets only the deprecated top-level
+// Fields. Nothing normalizes a struct built in memory, so the read has to fall back to it.
+func TestIndexDescription_CompatFieldsOnly_ReadsThrough(t *testing.T) {
+	d := IndexDescription{
+		Name:            "x",
+		ID:              1,
+		Fields:          []IndexedFieldDescription{{Name: "age"}},
+		Kind:            IndexKindOrdered,
+		KindDescription: &OrderedIndexDescription{Unique: true},
+	}
+	require.Equal(t, []string{"age"}, d.fieldNames())
+}

--- a/client/index_test.go
+++ b/client/index_test.go
@@ -143,7 +143,11 @@ func TestIndexDescription_LegacyUnique_LoadsAsOrdered(t *testing.T) {
 	assert.True(t, actual.GetUnique())
 	assert.True(t, actual.Unique) // compat field synced from the resolved config
 	assert.Equal(t, IndexKindOrdered, actual.Kind)
-	assert.Equal(t, &OrderedIndexDescription{Unique: true}, actual.KindDescription)
+	// The legacy top-level fields are upgraded onto the config.
+	assert.Equal(t, &OrderedIndexDescription{
+		Unique: true,
+		Fields: []IndexedFieldDescription{{Name: "age"}},
+	}, actual.KindDescription)
 }
 
 // An embedded caller that predates Kind builds the struct with only the top-level Unique. It must

--- a/client/index_test.go
+++ b/client/index_test.go
@@ -191,7 +191,14 @@ func TestIndexDescription_OrderedDescriptor_RoundTrips(t *testing.T) {
 
 	assert.False(t, actual.IsVector())
 	assert.True(t, actual.GetUnique())
-	assert.Equal(t, original, actual)
+	// The round trip upgrades the config with the fields; original is left untouched, since
+	// marshalling must not mutate its argument.
+	assert.Nil(t, original.KindDescription.(*OrderedIndexDescription).Fields)
+	assert.Equal(t, original.Fields, actual.KindDescription.(*OrderedIndexDescription).Fields)
+	assert.Equal(t, original.Fields, actual.Fields)
+	assert.Equal(t, original.Name, actual.Name)
+	assert.Equal(t, original.ID, actual.ID)
+	assert.Equal(t, original.Kind, actual.Kind)
 }
 
 func TestIndexDescription_VectorDescriptor_RoundTrips(t *testing.T) {
@@ -220,7 +227,13 @@ func TestIndexDescription_VectorDescriptor_RoundTrips(t *testing.T) {
 	require.NoError(t, err)
 
 	require.True(t, actual.IsVector())
-	assert.Equal(t, original, actual)
+	// The round trip upgrades the config with the field names; original is left untouched.
+	assert.Nil(t, original.KindDescription.(*VectorIndexDescription).Fields)
+	assert.Equal(t, []string{"embedding"}, actual.KindDescription.(*VectorIndexDescription).Fields)
+	assert.Equal(t, original.Fields, actual.Fields)
+	assert.Equal(t, original.Name, actual.Name)
+	assert.Equal(t, original.ID, actual.ID)
+	assert.Equal(t, original.Kind, actual.Kind)
 }
 
 // Kind is the sole authority on the index kind, so a descriptor naming a kind this build does not

--- a/docs/website/references/http/openapi.json
+++ b/docs/website/references/http/openapi.json
@@ -575,6 +575,20 @@
                     "Ordered": {
                         "nullable": true,
                         "properties": {
+                            "Fields": {
+                                "items": {
+                                    "properties": {
+                                        "Descending": {
+                                            "type": "boolean"
+                                        },
+                                        "Name": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "type": "object"
+                                },
+                                "type": "array"
+                            },
                             "Unique": {
                                 "type": "boolean"
                             }
@@ -594,6 +608,12 @@
                                 "maximum": 4294967295,
                                 "minimum": 0,
                                 "type": "integer"
+                            },
+                            "Fields": {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
                             },
                             "HNSW": {
                                 "nullable": true,

--- a/internal/db/collection_define.go
+++ b/internal/db/collection_define.go
@@ -929,7 +929,8 @@ func findIndexWithFirstField(
 	fieldName string,
 ) (isUnique bool, found bool) {
 	for _, index := range newIndexes {
-		if len(index.Fields) > 0 && index.Fields[0].Name == fieldName {
+		//nolint:staticcheck // a request has no accessor; the deprecated field is the only source
+		if fields := index.Fields; len(fields) > 0 && fields[0].Name == fieldName {
 			if index.Ordered != nil {
 				return index.Ordered.Unique, true
 			}
@@ -939,7 +940,7 @@ func findIndexWithFirstField(
 	}
 	for _, index := range existingIndexes {
 		// Only non-vector indexes carry uniqueness, so skip a vector index here.
-		if !index.IsVector() && len(index.Fields) > 0 && index.Fields[0].Name == fieldName {
+		if f := index.GetFields(); !index.IsVector() && len(f) > 0 && f[0].Name == fieldName {
 			return index.GetUnique(), true
 		}
 	}

--- a/internal/db/collection_index.go
+++ b/internal/db/collection_index.go
@@ -307,12 +307,12 @@ func (c *collection) collectIndexedFields(
 	seen := make(map[string]bool)
 	fields := make([]client.CollectionFieldDescription, 0, len(indexes))
 	for _, index := range indexes {
-		for _, field := range index.Description().Fields {
-			if seen[field.Name] {
+		for _, name := range indexFieldNames(index.Description()) {
+			if seen[name] {
 				continue
 			}
-			seen[field.Name] = true
-			colField, ok := c.Version().GetFieldByName(field.Name)
+			seen[name] = true
+			colField, ok := c.Version().GetFieldByName(name)
 			if ok {
 				fields = append(fields, colField)
 			}
@@ -493,6 +493,56 @@ func (c *collection) NewIndex(
 	return indexDesc, nil
 }
 
+// indexFieldNames returns the names of the index's fields.
+//
+// A descriptor read from the store always carries its kind config, but one built in memory by a
+// caller that predates the kind carrying fields does not, so fall back to the deprecated field.
+func indexFieldNames(desc client.IndexDescription) []string {
+	if desc.KindDescription != nil {
+		if names := desc.KindDescription.FieldNames(); len(names) > 0 {
+			return names
+		}
+	}
+	//nolint:staticcheck // the fallback this helper exists to hide
+	names := make([]string, len(desc.Fields))
+	//nolint:staticcheck // the fallback this helper exists to hide
+	for i, field := range desc.Fields {
+		names[i] = field.Name
+	}
+	return names
+}
+
+// indexFields returns the index's fields with their directions. Only an ordered index has them, so a
+// vector index's entries come back ascending. Prefer indexFieldNames where only names are used.
+func indexFields(desc client.IndexDescription) []client.IndexedFieldDescription {
+	if ordered, ok := desc.KindDescription.(*client.OrderedIndexDescription); ok && len(ordered.Fields) > 0 {
+		return ordered.Fields
+	}
+	names := indexFieldNames(desc)
+	fields := make([]client.IndexedFieldDescription, len(names))
+	for i, name := range names {
+		fields[i] = client.IndexedFieldDescription{Name: name}
+	}
+	return fields
+}
+
+// requestFields returns the requested fields, preferring the kind config over the deprecated
+// top-level one. Validation has already rejected the two disagreeing.
+func requestFields(desc client.NewIndexRequest) []client.IndexedFieldDescription {
+	if desc.Ordered != nil && len(desc.Ordered.Fields) > 0 {
+		return desc.Ordered.Fields
+	}
+	if desc.Vector != nil && len(desc.Vector.Fields) > 0 {
+		fields := make([]client.IndexedFieldDescription, len(desc.Vector.Fields))
+		for i, name := range desc.Vector.Fields {
+			fields[i] = client.IndexedFieldDescription{Name: name}
+		}
+		return fields
+	}
+	//nolint:staticcheck // the deprecated field is still supported until v2.0.0
+	return desc.Fields
+}
+
 func processNewIndexRequest(
 	ctx context.Context,
 	def client.CollectionVersion,
@@ -503,7 +553,11 @@ func processNewIndexRequest(
 		return client.IndexDescription{}, err
 	}
 
-	err = checkExistingFieldsAndAdjustRelFieldNames(def, desc.Fields)
+	// Resolved once so the checks below share one slice: the name check rewrites relation names in
+	// place, and this is what gets stored.
+	fields := requestFields(desc)
+
+	err = checkExistingFieldsAndAdjustRelFieldNames(def, fields)
 	if err != nil {
 		return client.IndexDescription{}, err
 	}
@@ -515,7 +569,7 @@ func processNewIndexRequest(
 		}
 	}
 
-	indexName, err := generateIndexNameIfNeeded(def, desc)
+	indexName, err := generateIndexNameIfNeeded(def, desc, fields)
 	if err != nil {
 		return client.IndexDescription{}, err
 	}
@@ -543,16 +597,24 @@ func processNewIndexRequest(
 		unique = desc.Ordered.Unique
 	}
 	kind := client.IndexKindOrdered
-	var kindDescription client.IndexKindDescription = &client.OrderedIndexDescription{Unique: unique}
+	var kindDescription client.IndexKindDescription = &client.OrderedIndexDescription{
+		Unique: unique,
+		Fields: fields,
+	}
 	if desc.Vector != nil {
 		kind = client.IndexKindVector
-		kindDescription = desc.Vector
+		vector := *desc.Vector
+		vector.Fields = make([]string, len(fields))
+		for i, field := range fields {
+			vector.Fields[i] = field.Name
+		}
+		kindDescription = &vector
 	}
 
 	res := client.IndexDescription{
 		Name:            indexName,
 		ID:              uint32(indexID),
-		Fields:          desc.Fields,
+		Fields:          fields,
 		Kind:            kind,
 		KindDescription: kindDescription,
 		// Mirror the ordered kind's uniqueness into the compat field. A vector index is never unique.
@@ -572,14 +634,17 @@ func processNewIndexRequest(
 func validateVectorIndexDescription(def client.CollectionVersion, desc client.NewIndexRequest) error {
 	// The rest of the vector index code only ever reads the first field, and nothing reads direction,
 	// so both would be stored and ignored. Reject them rather than half-honour the request.
-	if len(desc.Fields) != 1 {
-		return NewErrVectorIndexRequiresSingleField(len(desc.Fields))
+	fields := requestFields(desc)
+	if len(fields) != 1 {
+		return NewErrVectorIndexRequiresSingleField(len(fields))
 	}
-	if desc.Fields[0].Descending {
-		return NewErrVectorIndexCannotBeDescending(desc.Fields[0].Name)
+	// Only the deprecated spelling can carry a direction; Vector.Fields is names only.
+	//nolint:staticcheck // the deprecated field is still supported until v2.0.0
+	if len(desc.Vector.Fields) == 0 && len(desc.Fields) > 0 && desc.Fields[0].Descending {
+		return NewErrVectorIndexCannotBeDescending(fields[0].Name)
 	}
 
-	fieldName := desc.Fields[0].Name
+	fieldName := fields[0].Name
 	field, _ := def.GetFieldByName(fieldName)
 
 	if !client.IsVectorEmbeddingCompatible(field.Kind) {
@@ -1311,13 +1376,14 @@ func validateEncryptedIndexesOnCollection(definition client.CollectionVersion) e
 func generateIndexNameIfNeeded(
 	colVersion client.CollectionVersion,
 	newReq client.NewIndexRequest,
+	fields []client.IndexedFieldDescription,
 ) (string, error) {
 	indexName := newReq.Name
 	if indexName == "" {
 		nameIncrement := 1
 		for {
 			var err error
-			indexName, err = generateIndexName(colVersion.Name, newReq.Fields, nameIncrement)
+			indexName, err = generateIndexName(colVersion.Name, fields, nameIncrement)
 			if err != nil {
 				return "", err
 			}
@@ -1351,11 +1417,12 @@ func validateIndexDescription(desc client.NewIndexRequest) error {
 	if desc.Name != "" && !schema.IsValidIndexName(desc.Name) {
 		return schema.NewErrIndexWithInvalidName(desc.Name)
 	}
-	if len(desc.Fields) == 0 {
+	fields := requestFields(desc)
+	if len(fields) == 0 {
 		return ErrIndexMissingFields
 	}
-	for i := range desc.Fields {
-		if desc.Fields[i].Name == "" {
+	for i := range fields {
+		if fields[i].Name == "" {
 			return ErrIndexFieldMissingName
 		}
 	}
@@ -1371,7 +1438,7 @@ func validateIndexDescription(desc client.NewIndexRequest) error {
 	}
 	//nolint:staticcheck // these checks exist to police the deprecated field
 	if desc.Unique && desc.Vector != nil {
-		return NewErrNonOrderedIndexCannotBeUnique(desc.Fields[0].Name, "vector")
+		return NewErrNonOrderedIndexCannotBeUnique(fields[0].Name, "vector")
 	}
 	return nil
 }

--- a/internal/db/collection_index.go
+++ b/internal/db/collection_index.go
@@ -638,9 +638,9 @@ func validateVectorIndexDescription(def client.CollectionVersion, desc client.Ne
 	if len(fields) != 1 {
 		return NewErrVectorIndexRequiresSingleField(len(fields))
 	}
-	// Only the deprecated spelling can carry a direction; Vector.Fields is names only.
-	//nolint:staticcheck // the deprecated field is still supported until v2.0.0
-	if len(desc.Vector.Fields) == 0 && len(desc.Fields) > 0 && desc.Fields[0].Descending {
+	// Vector.Fields cannot carry a direction, but the deprecated spelling can, and a request may set
+	// both. Check the resolved fields so neither route slips past.
+	if fields[0].Descending {
 		return NewErrVectorIndexCannotBeDescending(fields[0].Name)
 	}
 
@@ -702,7 +702,7 @@ func validateNoConflictingVectorIndexMetric(
 ) error {
 	for _, index := range def.Indexes {
 		vector, ok := index.GetVector()
-		if !ok || index.Fields[0].Name != fieldName {
+		if !ok || index.GetFields()[0].Name != fieldName {
 			continue
 		}
 		if vector.Metric != metric {
@@ -1002,8 +1002,8 @@ func (c *collection) indexExistingDocs(
 	ctx context.Context,
 	index client.CollectionIndex,
 ) error {
-	fields := make([]client.CollectionFieldDescription, 0, len(index.Description().Fields))
-	for _, field := range index.Description().Fields {
+	fields := make([]client.CollectionFieldDescription, 0, len(index.Description().GetFields()))
+	for _, field := range index.Description().GetFields() {
 		colField, ok := c.Version().GetFieldByName(field.Name)
 		if ok {
 			fields = append(fields, colField)
@@ -1439,6 +1439,37 @@ func validateIndexDescription(desc client.NewIndexRequest) error {
 	//nolint:staticcheck // these checks exist to police the deprecated field
 	if desc.Unique && desc.Vector != nil {
 		return NewErrNonOrderedIndexCannotBeUnique(fields[0].Name, "vector")
+	}
+	if err := validateRequestFieldsAgree(desc); err != nil {
+		return err
+	}
+	return nil
+}
+
+// validateRequestFieldsAgree rejects a request whose kind config and deprecated Fields name
+// different things. Preferring one silently would index a field the caller did not ask for.
+func validateRequestFieldsAgree(desc client.NewIndexRequest) error {
+	//nolint:staticcheck // this check exists to police the deprecated field
+	deprecated := desc.Fields
+	if len(deprecated) == 0 {
+		return nil
+	}
+
+	var current []client.IndexedFieldDescription
+	switch {
+	case desc.Ordered != nil && len(desc.Ordered.Fields) > 0:
+		current = desc.Ordered.Fields
+	case desc.Vector != nil && len(desc.Vector.Fields) > 0:
+		current = make([]client.IndexedFieldDescription, len(desc.Vector.Fields))
+		for i, name := range desc.Vector.Fields {
+			current[i] = client.IndexedFieldDescription{Name: name}
+		}
+	default:
+		return nil
+	}
+
+	if !slices.Equal(deprecated, current) {
+		return ErrIndexFieldsConflict
 	}
 	return nil
 }

--- a/internal/db/errors.go
+++ b/internal/db/errors.go
@@ -50,7 +50,9 @@ const (
 	errNonZeroIndexIDProvided               string = "non-zero index ID provided"
 	errIndexFieldMissingName                string = "index field missing name"
 	errIndexKindConflict                    string = "index request has more than one kind config"
-	errIndexUniqueConflict                  string = "index request sets both the deprecated " +
+	errIndexFieldsConflict                  string = "index request sets both the deprecated " +
+		"fields and a kind config naming different fields"
+	errIndexUniqueConflict string = "index request sets both the deprecated " +
 		"unique field and an ordered config that disagrees with it"
 	errIndexWithNameAlreadyExists                string = "index with name already exists"
 	errInvalidStoredIndex                        string = "invalid stored index"
@@ -232,6 +234,7 @@ var (
 	ErrIndexMissingFields                        = errors.New(errIndexMissingFields)
 	ErrIndexFieldMissingName                     = errors.New(errIndexFieldMissingName)
 	ErrIndexKindConflict                         = errors.New(errIndexKindConflict)
+	ErrIndexFieldsConflict                       = errors.New(errIndexFieldsConflict)
 	ErrIndexUniqueConflict                       = errors.New(errIndexUniqueConflict)
 	ErrCorruptedIndex                            = errors.New(errCorruptedIndex)
 	ErrExpectedJSONObject                        = errors.New(errExpectedJSONObject)

--- a/internal/db/fetcher/index_lookup.go
+++ b/internal/db/fetcher/index_lookup.go
@@ -34,7 +34,7 @@ type IndexLookup struct {
 }
 
 // NewIndexLookup resolves everything an index lookup needs once: the collection's short ID and the
-// index's live epoch. The index must be single-field; index.Fields[0] supplies the field ordering.
+// index's live epoch. The index must be single-field; its first field supplies the ordering.
 func NewIndexLookup(
 	ctx context.Context,
 	txn datastore.Txn,
@@ -57,7 +57,7 @@ func NewIndexLookup(
 		collectionShortID: collectionShortID,
 		indexID:           index.ID,
 		epoch:             epoch,
-		descending:        index.Fields[0].Descending,
+		descending:        index.GetFields()[0].Descending,
 	}, nil
 }
 

--- a/internal/db/fetcher/indexer.go
+++ b/internal/db/fetcher/indexer.go
@@ -127,8 +127,8 @@ func newIndexFetcher(
 		epoch:             epoch,
 	}
 
-	fieldsToCopy := make([]mapper.Field, 0, len(indexDesc.Fields))
-	for _, field := range indexDesc.Fields {
+	fieldsToCopy := make([]mapper.Field, 0, len(indexDesc.GetFields()))
+	for _, field := range indexDesc.GetFields() {
 		typeIndex := docMapper.FirstIndexOfName(field.Name)
 		indexField := mapper.Field{Index: typeIndex, Name: field.Name}
 		fieldsToCopy = append(fieldsToCopy, indexField)
@@ -137,7 +137,7 @@ func newIndexFetcher(
 		f.indexFilter = filter.Merge(f.indexFilter, filter.CopyField(docFilter, fieldsToCopy[i]))
 	}
 
-	for _, indexedField := range f.indexDesc.Fields {
+	for _, indexedField := range f.indexDesc.GetFields() {
 		field, ok := f.col.Version().GetFieldByName(indexedField.Name)
 		if ok {
 			f.indexedFields = append(f.indexedFields, field)
@@ -246,14 +246,14 @@ func CanBeOrderedByIndex(
 ) (bool, bool) {
 	// if there is no ordering in the query or the query requests ordering on more fields, then index
 	// contains, we can't use index
-	if len(ordering) == 0 || len(ordering) > len(index.Fields) {
+	if len(ordering) == 0 || len(ordering) > len(index.GetFields()) {
 		return false, false
 	}
 
 	orderMismatchCount := 0
 
 	for i := range len(ordering) {
-		fieldIndexes := mapping.IndexesByName[index.Fields[i].Name]
+		fieldIndexes := mapping.IndexesByName[index.GetFields()[i].Name]
 
 		// if indexed field doesn't match the ordering field, we can't use index
 		if len(fieldIndexes) == 0 || fieldIndexes[0] != ordering[i].FieldIndexes[0] {
@@ -261,7 +261,7 @@ func CanBeOrderedByIndex(
 		}
 
 		isDescending := ordering[i].Direction == mapper.DESC
-		if index.Fields[i].Descending != isDescending {
+		if index.GetFields()[i].Descending != isDescending {
 			orderMismatchCount++
 		}
 	}
@@ -289,7 +289,7 @@ func hasOrWithMultipleFields(
 	for _, branch := range branches {
 		hasNonIndexedField := false
 		filter.TraverseProperties(branch, func(prop *mapper.PropertyIndex, _ map[connor.FilterKey]any) bool {
-			for _, field := range indexDesc.Fields {
+			for _, field := range indexDesc.GetFields() {
 				if docMapper.FirstIndexOfName(field.Name) == prop.Index {
 					return true
 				}

--- a/internal/db/fetcher/indexer_iterators.go
+++ b/internal/db/fetcher/indexer_iterators.go
@@ -515,7 +515,7 @@ func (f *indexFetcher) newMultiIndexIteratorForInOp(
 			}
 			indexKey.Fields = []keys.IndexedField{{
 				Value:      inValues[idx],
-				Descending: f.indexDesc.Fields[0].Descending,
+				Descending: f.indexDesc.GetFields()[0].Descending,
 			}}
 			return f.newPrefixBaseMatchIterator(indexKey, matchers, f.execInfo), nil
 		},
@@ -535,7 +535,7 @@ func (f *indexFetcher) newIndexDataStoreKeyWithValues(values []client.NormalValu
 	fields := make([]keys.IndexedField, len(values))
 	for i := range values {
 		fields[i].Value = values[i]
-		fields[i].Descending = f.indexDesc.Fields[i].Descending
+		fields[i].Descending = f.indexDesc.GetFields()[i].Descending
 	}
 
 	collectionShortID, err := id.GetCollectionShortID(f.ctx, f.col.Version().CollectionID)
@@ -551,7 +551,7 @@ func (f *indexFetcher) createKeyWithValue(key keys.IndexDataStoreKey, val client
 	key.Fields = []keys.IndexedField{
 		{
 			Value:      val,
-			Descending: f.indexDesc.Fields[0].Descending,
+			Descending: f.indexDesc.GetFields()[0].Descending,
 		},
 	}
 	return key
@@ -648,7 +648,7 @@ func (f *indexFetcher) newRangeBasedMatchIterator(
 	cond fieldFilterCond,
 	matchers []valueMatcher,
 ) (*indexMatchIterator, error) {
-	startKey, endKey, err := f.createRangeBoundaries(cond, f.indexDesc.Fields[0].Descending)
+	startKey, endKey, err := f.createRangeBoundaries(cond, f.indexDesc.GetFields()[0].Descending)
 	if err != nil {
 		return nil, err
 	}
@@ -793,7 +793,7 @@ func (f *indexFetcher) determineFieldFilterConditions(indexFilter *mapper.Filter
 
 	result := make([]fieldFilterCond, 0, len(f.indexedFields))
 	// we process first the conditions that match composite index fields starting from the first one
-	for i := range f.indexDesc.Fields {
+	for i := range f.indexDesc.GetFields() {
 		indexedField := f.indexedFields[i]
 		fieldInd := f.mapping.FirstIndexOfName(indexedField.Name)
 		var err error
@@ -1122,7 +1122,7 @@ func setJSONFilterCondition(cond *fieldFilterCond, filterVal any, jsonPath clien
 func isUniqueFetchByFullKey(indexDesc *client.IndexDescription, conditions []fieldFilterCond) bool {
 	// we need to check length of conditions because full key fetch is only possible
 	// if all fields of the index are specified in the filter
-	res := indexDesc.GetUnique() && len(conditions) == len(indexDesc.Fields)
+	res := indexDesc.GetUnique() && len(conditions) == len(indexDesc.GetFields())
 
 	// first condition is not required to be _eq, but if is, val must be not nil
 	res = res && (conditions[0].op != opEq || !conditions[0].val.IsNil())

--- a/internal/db/index.go
+++ b/internal/db/index.go
@@ -126,6 +126,7 @@ func buildIndexBase(
 		desc:            desc,
 		building:        building,
 		fieldsDescs:     make([]client.CollectionFieldDescription, len(fields)),
+		descending:      make([]bool, len(fields)),
 		fieldGenerators: make([]FieldIndexGenerator, len(fields)),
 	}
 	for i := range fields {
@@ -134,6 +135,7 @@ func buildIndexBase(
 			return collectionBaseIndex{}, client.NewErrFieldNotExist(fields[i].Name)
 		}
 		base.fieldsDescs[i] = field
+		base.descending[i] = fields[i].Descending
 		if !isSupportedKind(field.Kind) {
 			return collectionBaseIndex{}, NewErrUnsupportedIndexFieldType(field.Kind)
 		}
@@ -233,7 +235,10 @@ type collectionBaseIndex struct {
 	desc       client.IndexDescription
 	// fieldsDescs is a slice of field descriptions for the fields that form the index
 	// If there is more than 1 field, the index is composite
-	fieldsDescs     []client.CollectionFieldDescription
+	fieldsDescs []client.CollectionFieldDescription
+	// descending is each field's direction, positionally aligned with fieldsDescs. Resolved once at
+	// construction so the write path never reads the deprecated top-level fields.
+	descending      []bool
 	fieldGenerators []FieldIndexGenerator
 	// building is true while the index is being backfilled. deleteIndexKey tolerates
 	// missing entries for documents not yet reached by the backfill.
@@ -278,7 +283,7 @@ func (index *collectionBaseIndex) getDocumentsIndexKey(
 	fields := make([]keys.IndexedField, len(index.fieldsDescs))
 	for i := range index.fieldsDescs {
 		fields[i].Value = fieldValues[i]
-		fields[i].Descending = index.desc.Fields[i].Descending
+		fields[i].Descending = index.descending[i]
 	}
 
 	collectionShortID, err := id.GetCollectionShortID(ctx, index.collection.Version().CollectionID)

--- a/internal/db/index.go
+++ b/internal/db/index.go
@@ -117,20 +117,21 @@ func buildIndexBase(
 	desc client.IndexDescription,
 	building bool,
 ) (collectionBaseIndex, error) {
-	if len(desc.Fields) == 0 {
+	fields := indexFields(desc)
+	if len(fields) == 0 {
 		return collectionBaseIndex{}, NewErrIndexDescHasNoFields(desc)
 	}
 	base := collectionBaseIndex{
 		collection:      collection,
 		desc:            desc,
 		building:        building,
-		fieldsDescs:     make([]client.CollectionFieldDescription, len(desc.Fields)),
-		fieldGenerators: make([]FieldIndexGenerator, len(desc.Fields)),
+		fieldsDescs:     make([]client.CollectionFieldDescription, len(fields)),
+		fieldGenerators: make([]FieldIndexGenerator, len(fields)),
 	}
-	for i := range desc.Fields {
-		field, foundField := collection.Version().GetFieldByName(desc.Fields[i].Name)
+	for i := range fields {
+		field, foundField := collection.Version().GetFieldByName(fields[i].Name)
 		if !foundField {
-			return collectionBaseIndex{}, client.NewErrFieldNotExist(desc.Fields[i].Name)
+			return collectionBaseIndex{}, client.NewErrFieldNotExist(fields[i].Name)
 		}
 		base.fieldsDescs[i] = field
 		if !isSupportedKind(field.Kind) {
@@ -747,9 +748,9 @@ func (index *collectionUniqueIndex) Update(
 }
 
 func isUpdatingIndexedFields(index client.CollectionIndex, oldDoc, newDoc *client.Document) bool {
-	for _, indexedFields := range index.Description().Fields {
-		oldVal, getOldValErr := oldDoc.GetValue(indexedFields.Name)
-		newVal, getNewValErr := newDoc.GetValue(indexedFields.Name)
+	for _, name := range indexFieldNames(index.Description()) {
+		oldVal, getOldValErr := oldDoc.GetValue(name)
+		newVal, getNewValErr := newDoc.GetValue(name)
 
 		// GetValue will return an error when the field doesn't exist.
 		// This will happen for oldDoc only if the field hasn't been set

--- a/internal/db/index_backfill.go
+++ b/internal/db/index_backfill.go
@@ -148,9 +148,10 @@ func (db *DB) fillIndexBatches(
 	desc client.IndexDescription,
 	startAfter immutable.Option[uint64],
 ) (uint32, error) {
-	fields := make([]client.CollectionFieldDescription, 0, len(desc.Fields))
-	for _, f := range desc.Fields {
-		if colField, ok := def.GetFieldByName(f.Name); ok {
+	names := indexFieldNames(desc)
+	fields := make([]client.CollectionFieldDescription, 0, len(names))
+	for _, name := range names {
+		if colField, ok := def.GetFieldByName(name); ok {
 			fields = append(fields, colField)
 		}
 	}

--- a/internal/db/index_test.go
+++ b/internal/db/index_test.go
@@ -191,7 +191,7 @@ func TestNewIndex_IfValidInput_NewIndex(t *testing.T) {
 	resultDesc, err := f.newCollectionIndex(desc)
 	assert.NoError(t, err)
 	assert.Equal(t, desc.Name, resultDesc.Name)
-	assert.Equal(t, desc.Fields, resultDesc.Fields)
+	assert.Equal(t, desc.Fields, resultDesc.GetFields()) //nolint:staticcheck // request has no accessor
 	//nolint:staticcheck // asserts the deprecated field is still carried through
 	assert.Equal(t, desc.Unique, resultDesc.Unique)
 }
@@ -220,7 +220,7 @@ func TestNewIndex_IfFieldHasNoDirection_DefaultToAsc(t *testing.T) {
 	}
 	newDesc, err := f.newCollectionIndex(desc)
 	assert.NoError(t, err)
-	assert.False(t, newDesc.Fields[0].Descending)
+	assert.False(t, newDesc.GetFields()[0].Descending)
 }
 
 func TestNewIndex_IfIndexWithNameAlreadyExists_ReturnError(t *testing.T) {
@@ -479,11 +479,11 @@ func TestNewCollectionIndex_IfDescriptionHasNoFields_ReturnError(t *testing.T) {
 	f := newIndexTestFixture(t)
 	defer f.db.Close()
 	desc := getUsersIndexDescOnName()
-	desc.Fields = nil
+	desc.Fields = nil //nolint:staticcheck // request has no accessor
 	descWithID := client.IndexDescription{
 		Name:   desc.Name,
 		ID:     1,
-		Fields: desc.Fields,
+		Fields: desc.Fields, //nolint:staticcheck // request has no accessor
 	}
 	_, err := NewCollectionIndex(f.ctx, f.users, descWithID, false)
 	require.ErrorIs(t, err, NewErrIndexDescHasNoFields(descWithID))
@@ -493,14 +493,14 @@ func TestNewCollectionIndex_IfDescriptionHasNonExistingField_ReturnError(t *test
 	f := newIndexTestFixture(t)
 	defer f.db.Close()
 	desc := getUsersIndexDescOnName()
-	desc.Fields[0].Name = "non_existing_field"
+	desc.Fields[0].Name = "non_existing_field" //nolint:staticcheck // request has no accessor
 	descWithID := client.IndexDescription{
 		Name:   desc.Name,
 		ID:     1,
-		Fields: desc.Fields,
+		Fields: desc.Fields, //nolint:staticcheck // request has no accessor
 	}
 	_, err := NewCollectionIndex(f.ctx, f.users, descWithID, false)
-	require.ErrorIs(t, err, client.NewErrFieldNotExist(desc.Fields[0].Name))
+	require.ErrorIs(t, err, client.NewErrFieldNotExist(desc.Fields[0].Name)) //nolint:staticcheck // request has no accessor
 }
 
 // TestNewCollectionIndex_IfEpochSequenceMissing_ReturnError checks that constructing an index whose

--- a/internal/keys/datastore_index.go
+++ b/internal/keys/datastore_index.go
@@ -187,9 +187,9 @@ func DecodeIndexDataStoreKey(
 
 		i := len(key.Fields)
 		descending := false
-		if i < len(indexDesc.Fields) {
-			descending = indexDesc.Fields[i].Descending
-		} else if i > len(indexDesc.Fields) {
+		if i < len(indexDesc.GetFields()) {
+			descending = indexDesc.GetFields()[i].Descending
+		} else if i > len(indexDesc.GetFields()) {
 			return IndexDataStoreKey{}, ErrInvalidKey
 		} else {
 			if key.DocShortID != 0 {

--- a/internal/keys/key_test.go
+++ b/internal/keys/key_test.go
@@ -189,7 +189,7 @@ func TestDecodeIndexDataStoreKey(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			expectedKey := NewIndexDataStoreKey(collectionShortID, indexID, 0, tc.expectedFields)
 			expectedKey.DocShortID = tc.expectedDocShortID
-			fieldDescs := make([]client.CollectionFieldDescription, len(tc.desc.Fields))
+			fieldDescs := make([]client.CollectionFieldDescription, len(tc.desc.GetFields()))
 			for i := range tc.fieldKinds {
 				fieldDescs[i] = client.CollectionFieldDescription{Kind: tc.fieldKinds[i]}
 			}

--- a/internal/planner/index_helpers.go
+++ b/internal/planner/index_helpers.go
@@ -37,12 +37,30 @@ func queryableIndexes(col client.Collection) []client.IndexDescription {
 	return col.Version().Indexes
 }
 
+// firstIndexedField returns the name of the index's first field, or "" if it has none.
+//
+// A descriptor read from the store always carries its kind config, but one built in memory by a
+// caller that predates the kind carrying fields does not, so fall back to the deprecated field.
+func firstIndexedField(idx client.IndexDescription) string {
+	if idx.KindDescription != nil {
+		if names := idx.KindDescription.FieldNames(); len(names) > 0 {
+			return names[0]
+		}
+	}
+	//nolint:staticcheck // the fallback this helper exists to hide
+	if len(idx.Fields) > 0 {
+		//nolint:staticcheck // the fallback this helper exists to hide
+		return idx.Fields[0].Name
+	}
+	return ""
+}
+
 // queryableIndexesOnField mirrors CollectionVersion.GetIndexesOnField over queryableIndexes:
 // it returns only ready indexes whose first field matches fieldName.
 func queryableIndexesOnField(col client.Collection, fieldName string) []client.IndexDescription {
 	var result []client.IndexDescription
 	for _, idx := range queryableIndexes(col) {
-		if len(idx.Fields) > 0 && idx.Fields[0].Name == fieldName {
+		if firstIndexedField(idx) == fieldName {
 			result = append(result, idx)
 		}
 	}

--- a/internal/request/graphql/schema/vector_index_parse_test.go
+++ b/internal/request/graphql/schema/vector_index_parse_test.go
@@ -95,7 +95,7 @@ func TestParseVectorIndex_OnField_ProducesVectorKindIndex(t *testing.T) {
 	// Simulate turning the request into a descriptor, as processNewIndexRequest would: a request with
 	// a Vector becomes a vector-kind descriptor carrying the vector config.
 	desc := client.IndexDescription{
-		Fields:          newIndex.Fields,
+		Fields:          newIndex.Fields, //nolint:staticcheck // request has no accessor
 		Kind:            client.IndexKindVector,
 		KindDescription: newIndex.Vector,
 	}

--- a/tests/action/list_indexes.go
+++ b/tests/action/list_indexes.go
@@ -223,7 +223,8 @@ func assertIndexesEqual(expectedIndex, actualIndex client.IndexDescription, t re
 		return names
 	}
 
-	require.ElementsMatch(t, toNames(expectedIndex.Fields), toNames(actualIndex.Fields), "index fields' names mismatch")
+	require.ElementsMatch(t, toNames(expectedIndex.GetFields()), toNames(actualIndex.GetFields()),
+		"index fields' names mismatch")
 
 	toMap := func(fields []client.IndexedFieldDescription) map[string]client.IndexedFieldDescription {
 		resultMap := map[string]client.IndexedFieldDescription{}
@@ -233,8 +234,8 @@ func assertIndexesEqual(expectedIndex, actualIndex client.IndexDescription, t re
 		return resultMap
 	}
 
-	expectedFieldsMap := toMap(expectedIndex.Fields)
-	actualFieldsMap := toMap(actualIndex.Fields)
+	expectedFieldsMap := toMap(expectedIndex.GetFields())
+	actualFieldsMap := toMap(actualIndex.GetFields())
 	for fieldName := range expectedFieldsMap {
 		assert.Equal(t, expectedFieldsMap[fieldName].Descending, actualFieldsMap[fieldName].Descending,
 			"index field %s descending mismatch", fieldName)

--- a/tests/action/new_index.go
+++ b/tests/action/new_index.go
@@ -116,6 +116,7 @@ func (a *NewIndex) Execute() {
 		}
 
 		if a.FieldName != "" {
+			//nolint:staticcheck // the action exposes both spellings so tests can cover each
 			indexDesc.Fields = []client.IndexedFieldDescription{
 				{
 					Name: a.FieldName,

--- a/tests/action/new_index.go
+++ b/tests/action/new_index.go
@@ -123,12 +123,15 @@ func (a *NewIndex) Execute() {
 				},
 			}
 		} else if len(a.Fields) > 0 {
+			fields := make([]client.IndexedFieldDescription, len(a.Fields))
 			for i := range a.Fields {
-				indexDesc.Fields = append(indexDesc.Fields, client.IndexedFieldDescription{
+				fields[i] = client.IndexedFieldDescription{
 					Name:       a.Fields[i].Name,
 					Descending: a.Fields[i].Descending,
-				})
+				}
 			}
+			//nolint:staticcheck // the action exposes both spellings so tests can cover each
+			indexDesc.Fields = fields
 		}
 
 		//nolint:staticcheck // the action exposes both spellings so tests can cover each

--- a/tests/action/results.go
+++ b/tests/action/results.go
@@ -30,13 +30,14 @@ import (
 
 // Asserts as to whether an error has been raised as expected (or not). If an expected
 // error has been raised it will return true, returns false in all other cases.
-// normalizeIndexes returns a copy of the slice with each index's Kind/Unique made consistent, so a
-// test expectation written in either style (only Unique, or only Kind) compares against the actual.
-func normalizeIndexes(indexes []client.IndexDescription) []client.IndexDescription {
-	out := make([]client.IndexDescription, len(indexes))
-	for i, idx := range indexes {
-		out[i] = idx.Normalize()
-	}
+// normalizeIndexes round-trips each index through JSON, which is what makes the deprecated and
+// current spellings consistent. A test expectation written in either style then compares equal to
+// the actual.
+func normalizeIndexes(t testing.TB, indexes []client.IndexDescription) []client.IndexDescription {
+	data, err := json.Marshal(indexes)
+	require.NoError(t, err)
+	var out []client.IndexDescription
+	require.NoError(t, json.Unmarshal(data, &out))
 	return out
 }
 
@@ -101,7 +102,7 @@ func assertCollectionVersions(
 			// This is to save each test action from having to bother declaring an empty slice (if there are no indexes)
 			// Normalize both sides so an expectation written in the old style (Unique only, no Kind)
 			// compares equal to the resolved actual (Kind populated).
-			require.Equal(s.T, normalizeIndexes(expected.Indexes), normalizeIndexes(actual.Indexes))
+			require.Equal(s.T, normalizeIndexes(s.T, expected.Indexes), normalizeIndexes(s.T, actual.Indexes))
 		}
 
 		require.Equal(s.T, expected.PreviousVersion.HasValue(), actual.PreviousVersion.HasValue())

--- a/tests/clients/cli/wrapper_collection.go
+++ b/tests/clients/cli/wrapper_collection.go
@@ -97,12 +97,13 @@ func (c *Collection) NewIndex(
 	}
 
 	//nolint:staticcheck // a request has no accessor; the deprecated field is the only source
-	fields := make([]string, len(indexDesc.Fields))
-	orders := make([]bool, len(indexDesc.Fields))
+	requested := indexDesc.Fields
+	fields := make([]string, len(requested))
+	orders := make([]bool, len(requested))
 
-	for i := range indexDesc.Fields {
-		fields[i] = indexDesc.Fields[i].Name
-		orders[i] = indexDesc.Fields[i].Descending
+	for i := range requested {
+		fields[i] = requested[i].Name
+		orders[i] = requested[i].Descending
 	}
 
 	orderedFields := make([]string, len(fields))

--- a/tests/clients/cli/wrapper_collection.go
+++ b/tests/clients/cli/wrapper_collection.go
@@ -96,6 +96,7 @@ func (c *Collection) NewIndex(
 		args = append(args, "--vector", string(vectorJSON))
 	}
 
+	//nolint:staticcheck // a request has no accessor; the deprecated field is the only source
 	fields := make([]string, len(indexDesc.Fields))
 	orders := make([]bool, len(indexDesc.Fields))
 

--- a/tests/integration/collection_version/vector_index_test.go
+++ b/tests/integration/collection_version/vector_index_test.go
@@ -44,6 +44,7 @@ func TestCollectionVersion_VectorIndexOnRawFloat32Array_ShouldSucceed(t *testing
 						},
 						Kind: client.IndexKindVector,
 						KindDescription: &client.VectorIndexDescription{
+							Fields:     []string{"embedding"},
 							Algorithm:  client.VectorAlgorithmHNSW,
 							Metric:     client.DistanceMetricCosine,
 							Dimensions: 3,
@@ -157,6 +158,7 @@ func vectorIndexMetricTest(sdlMetric string, expected client.DistanceMetric) tes
 						Fields: []client.IndexedFieldDescription{{Name: "embedding"}},
 						Kind:   client.IndexKindVector,
 						KindDescription: &client.VectorIndexDescription{
+							Fields:     []string{"embedding"},
 							Algorithm:  client.VectorAlgorithmHNSW,
 							Metric:     expected,
 							Dimensions: 3,
@@ -226,6 +228,7 @@ func TestCollectionVersion_VectorIndexWithAscendingDirection_ShouldSucceed(t *te
 						Fields: []client.IndexedFieldDescription{{Name: "embedding"}},
 						Kind:   client.IndexKindVector,
 						KindDescription: &client.VectorIndexDescription{
+							Fields:     []string{"embedding"},
 							Algorithm:  client.VectorAlgorithmHNSW,
 							Metric:     client.DistanceMetricCosine,
 							Dimensions: 3,

--- a/tests/integration/index/vector_backfill_test.go
+++ b/tests/integration/index/vector_backfill_test.go
@@ -55,6 +55,7 @@ func TestVectorIndex_AsyncBackfillOverExistingDocs_BuildsUsableGraph(t *testing.
 			Fields: []client.IndexedFieldDescription{{Name: "vector"}},
 			Kind:   client.IndexKindVector,
 			KindDescription: &client.VectorIndexDescription{
+				Fields:     []string{"vector"},
 				Algorithm:  client.VectorAlgorithmHNSW,
 				Metric:     client.DistanceMetricCosine,
 				Dimensions: 3,

--- a/tests/integration/index/vector_metrics_test.go
+++ b/tests/integration/index/vector_metrics_test.go
@@ -245,6 +245,7 @@ func TestVectorIndex_DropThenRecreateWithDifferentMetric_IsAllowed(t *testing.T)
 						Fields: []client.IndexedFieldDescription{{Name: "vector"}},
 						Kind:   client.IndexKindVector,
 						KindDescription: &client.VectorIndexDescription{
+							Fields:     []string{"vector"},
 							Algorithm:  client.VectorAlgorithmHNSW,
 							Metric:     client.DistanceMetricEuclidean,
 							Dimensions: 3,

--- a/tests/integration/index/vector_params_test.go
+++ b/tests/integration/index/vector_params_test.go
@@ -183,3 +183,23 @@ func TestVectorIndex_CreateWithDefaultParams_Works(t *testing.T) {
 
 	testUtils.ExecuteTestCase(t, test)
 }
+
+// Both spellings set, naming different fields: rejected.
+func TestIndexNew_FieldsDisagreeBetweenSpellings_IsRejected(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddCollection{SDL: `type User { name: String
+				vector: [Float32!] }`},
+			&action.NewIndex{
+				CollectionID: 0,
+				Fields:       []client.IndexedFieldDescription{{Name: "name"}},
+				Vector: &client.VectorIndexDescription{
+					Fields: []string{"vector"}, Metric: client.DistanceMetricCosine,
+					Dimensions: 3, HNSW: &client.HNSWParams{},
+				},
+				ExpectedError: "naming different fields",
+			},
+		},
+	}
+	testUtils.ExecuteTestCase(t, test)
+}


### PR DESCRIPTION
## Relevant issue(s)

Refs https://github.com/sourcenetwork/defradb/issues/5104

## Description

Each kind of index now describes its own fields, in the shape it can actually honour. An ordered index keeps a direction per field because it reads its entries in key order; a vector index takes names only, since a graph is searched by nearness and has nothing to sort. Asking a vector index for a direction is no longer something we accept and then reject, it is something that cannot be written down.

Until now every kind shared one field shape, the one ordered indexes need. That is why a vector index could be handed a direction at all, and why reading an index's fields meant asking which kind it was first. Both the old spelling and the old way of reading it still work and are kept in sync; they are deprecated and go away in v2.0.0.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Unit and integration tests, including a descriptor built the old way in memory rather than read back from storage, which is the one path nothing upgrades on the way in.

Specify the platform(s) on which this was tested:
- macOS
