### PR TITLE
fix: Correct transaction retries typo

### DIFF
--- a/client/errors.go
+++ b/client/errors.go
@@ -24,7 +24,7 @@ const (
 	errUnexpectedType                        string = "unexpected type"
 	errParsingFailed                         string = "failed to parse argument"
 	errUninitializeProperty                  string = "invalid state, required property is uninitialized"
-	errMaxTxnRetries                         string = "reached maximum transaction reties"
+	errMaxTxnRetries                         string = "reached maximum transaction retries"
 	errCollectionNotFound                    string = "collection not found"
 	errUnknownCRDT                           string = "unknown crdt"
 	errUnknownCRDTString                     string = "unknown crdt string representation"
@@ -191,8 +191,8 @@ func NewErrUninitializeProperty(host string, propertyName string) error {
 	)
 }
 
-// NewErrFieldIndexNotExist returns an error indicating that a field does not exist at the
-// given location.
+// NewErrMaxTxnRetries returns an error indicating that the maximum number of
+// transaction retries was reached.
 func NewErrMaxTxnRetries(inner error) error {
 	return errors.Wrap(errMaxTxnRetries, inner)
 }


### PR DESCRIPTION
## Relevant issue(s)

Resolves #5237

## Description

- Fixes user-visible typo in `client/errors.go:27`: "reties" -> "retries" (surfaced via `NewErrMaxTxnRetries`, used in `internal/db/merge.go`).
- Fixes copy-pasted doc comment on `NewErrMaxTxnRetries` which incorrectly described `NewErrFieldIndexNotExist`.

Verified with `go test ./client/...` passing. No behavior change besides corrected string and comment.