### PR TITLE
fix: Use correct constant in parse kind error

### DIFF
--- a/client/errors.go
+++ b/client/errors.go
@@ -258,7 +258,7 @@ func NewErrInvalidJSONPayload(payload any) error {
 
 func NewErrFailedToParseKind(kind []byte) error {
 	return errors.New(
-		errCRDTKindMismatch,
+		errFailedToParseKind,
 		errors.NewKV("Kind", kind),
 	)
 }


### PR DESCRIPTION
## Relevant issue(s)

Resolves #5238

## Description

`NewErrFailedToParseKind` in `client/errors.go:259-264` used `errCRDTKindMismatch` (which contains `%s` verbs) instead of `errFailedToParseKind`. Since `errors.New` does no formatting, the message contained a literal `%s` and `errors.Is(err, ErrFailedToParseKind)` could never match.

Changes the constructor to use `errFailedToParseKind`, matching the sentinel at `client/errors.go:87`.

Verified with `go test ./client/...` passing.