### PR TITLE
fix: Improve CLI index list help text

### DIFF
--- a/cli/errors.go
+++ b/cli/errors.go
@@ -34,7 +34,7 @@ var (
 	ErrNoDocIDOrFilter                  = errors.New("docID or filter must be defined")
 	ErrInvalidExportFormat              = errors.New("invalid export format")
 	ErrNoLensConfig                     = errors.New("lens config cannot be empty")
-	ErrInvalidLensConfig                = errors.New("invalid lens configuration")
+	ErrInvalidLensConfig                = errors.New(errInvalidLensConfig)
 	ErrViewAddMissingArgs               = errors.New("please provide a base query and output SDL for this view")
 	ErrPolicyFileArgCanNotBeEmpty       = errors.New("policy file argument can not be empty")
 	ErrMissingKeyringSecret             = errors.New("missing keyring secret")

--- a/cli/index_list.go
+++ b/cli/index_list.go
@@ -23,8 +23,8 @@ func MakeIndexListCommand(ctx context.Context) *cobra.Command {
 	var collectionArg string
 	var cmd = &cobra.Command{
 		Use:   "list",
-		Short: "Shows the list indexes in the database or for a specific collection",
-		Long: `Shows the list indexes in the database or for a specific collection.
+		Short: "Show the list of indexes in the database or for a specific collection",
+		Long: `Show the list of indexes in the database or for a specific collection.
 
 If the --collection flag is provided, only the indexes for that collection will be shown.
 Otherwise, all indexes in the database will be shown.
@@ -59,7 +59,7 @@ complete, or "failed" if the build could not finish.`,
 		},
 	}
 
-	EmbedCLIExample(ctx, cmd, "show all index for 'Users' collection",
+	EmbedCLIExample(ctx, cmd, "show all indexes for 'Users' collection",
 		`defradb client index list --collection Users`)
 
 	cmd.Flags().StringVarP(&collectionArg, "collection", "c", "", "Collection name")

--- a/docs/website/references/cli/defradb_client_index.md
+++ b/docs/website/references/cli/defradb_client_index.md
@@ -34,6 +34,6 @@ Manage (new, delete, or list) collection indexes on a DefraDB node.
 
 * [defradb client](defradb_client.md)	 - Interact with a DefraDB node
 * [defradb client index delete](defradb_client_index_delete.md)	 - Delete a collection's secondary index
-* [defradb client index list](defradb_client_index_list.md)	 - Shows the list indexes in the database or for a specific collection
+* [defradb client index list](defradb_client_index_list.md)	 - Show the list of indexes in the database or for a specific collection
 * [defradb client index new](defradb_client_index_new.md)	 - Make a new index on a collection's field(s)
 

--- a/docs/website/references/cli/defradb_client_index_list.md
+++ b/docs/website/references/cli/defradb_client_index_list.md
@@ -1,10 +1,10 @@
 ## defradb client index list
 
-Shows the list indexes in the database or for a specific collection
+Show the list of indexes in the database or for a specific collection
 
 ### Synopsis
 
-Shows the list indexes in the database or for a specific collection.
+Show the list of indexes in the database or for a specific collection.
 
 If the --collection flag is provided, only the indexes for that collection will be shown.
 Otherwise, all indexes in the database will be shown.
@@ -19,7 +19,7 @@ defradb client index list [flags]
 ### Examples
 
 ```
-show all index for 'Users' collection:  
+show all indexes for 'Users' collection:  
   defradb client index list --collection Users
 ```
 


### PR DESCRIPTION
## Relevant issue(s)

Resolves #5239

## Description

- `cli/index_list.go:26-27`: "Shows the list indexes ..." -> "Show the list of indexes ..." (imperative, grammatical, consistent with other commands).
- `cli/index_list.go:62`: example "show all index ..." -> "show all indexes ...".
- `cli/errors.go:37`: `ErrInvalidLensConfig` now reuses `errInvalidLensConfig` const instead of a duplicated literal (matches `ErrEmptyCollectionSDL` pattern). Behavior-preserving.

Verified with `go build ./cli/...`. Help-text only plus const reuse.