### PR TITLE
docs: Fix typos and outdated operator references

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ defradb client query '
 '
 ```
 
-This returns only user documents which have a value for the `points` field *Greater Than or Equal to* (`_ge`) 50.
+This returns only user documents which have a value for the `points` field *Greater Than or Equal to* (`_geq`) 50.
 
 ## Obtain document commits
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -63,7 +63,7 @@ Whether PubSub is enabled. Defaults to `true`.
 
 ## `net.peers`
 
-List of peers to boostrap with, specified as multiaddresses.
+List of peers to bootstrap with, specified as multiaddresses.
 
 https://docs.libp2p.io/concepts/addressing/
 

--- a/docs/website/README.md
+++ b/docs/website/README.md
@@ -2,4 +2,4 @@
 
 This directory contains the documentation that is displayed on our documentation website https://docs.source.network/.
 
-The structure of this directory and it's children should match that of the website.
+The structure of this directory and its children should match that of the website.

--- a/docs/website/getting-started.md
+++ b/docs/website/getting-started.md
@@ -115,7 +115,7 @@ You can further filter results with the `filter` argument.
 ```shell
 defradb client query '
   query {
-    User(filter: {points: {_ge: 50}}) {
+    User(filter: {points: {_geq: 50}}) {
       _docID
       age
       name
@@ -125,7 +125,7 @@ defradb client query '
 '
 ```
 
-This returns only user documents which have a value for the `points` field *Greater Than or Equal to* (`_ge`) 50.
+This returns only user documents which have a value for the `points` field *Greater Than or Equal to* (`_geq`) 50.
 
 ## Obtain document commits
 
@@ -218,7 +218,7 @@ Each node has a unique `Peer ID` generated from its public key. This ID allows o
 
 There are two types of peer-to-peer relationships supported: **pubsub** peering and **replicator** peering.
 
-Pubsub peering *passively* synchronizes data between nodes by broadcasting *Document Commit* updates to the topic of the commit's document key. Nodes need to be listening on the pubsub channel to receive updates. This is for when two nodes *already* have share a document and want to keep them in sync.
+Pubsub peering *passively* synchronizes data between nodes by broadcasting *Document Commit* updates to the topic of the commit's document key. Nodes need to be listening on the pubsub channel to receive updates. This is for when two nodes *already* share a document and want to keep them in sync.
 
 Replicator peering *actively* pushes changes from a specific collection *to* a target peer.
 


### PR DESCRIPTION
## Relevant issue(s)

Resolves #5240

## Description

Docs-only fixes, verified by reading each file and confirming the correct `_geq` operator in `internal/connor/connor.go:22`:

- `docs/config.md:66`: "boostrap" -> "bootstrap".
- `docs/website/README.md:5`: "it's children" -> "its children".
- `README.md:257`: operator prose `_ge` -> `_geq` (example already uses `_geq`).
- `docs/website/getting-started.md:118,128`: outdated `_ge` -> `_geq`.
- `docs/website/getting-started.md:221`: "have share" -> "share".