### PR TITLE
fix: Rename misspelled http context helper

### DIFF
--- a/http/handler_store.go
+++ b/http/handler_store.go
@@ -661,7 +661,7 @@ func execSSESubscription(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	serverCtx, hasServerCtx := tryGetContexCtx(req)
+	serverCtx, hasServerCtx := tryGetContextCtx(req)
 	var serverDone <-chan struct{}
 	if hasServerCtx {
 		serverDone = serverCtx.Done()

--- a/http/utils.go
+++ b/http/utils.go
@@ -78,10 +78,10 @@ func isDevMode(req *http.Request) bool {
 	return opts != nil && opts.EnableDevelopment
 }
 
-// tryGetContexCtx returns the server context if it exists.
+// tryGetContextCtx returns the server context if it exists.
 //
 // This should only be called from functions within the http package.
-func tryGetContexCtx(req *http.Request) (context.Context, bool) {
+func tryGetContextCtx(req *http.Request) (context.Context, bool) {
 	ctx, ok := req.Context().Value(ctxContextKey).(context.Context)
 	return ctx, ok
 }


### PR DESCRIPTION
## Relevant issue(s)

Resolves #5241

## Description

Renames unexported `tryGetContexCtx` -> `tryGetContextCtx` in `http/utils.go:81-84` (plus doc comment) and updates the single call site at `http/handler_store.go:664`. Only two occurrences in the repo, so the rename is safe and behavior-preserving. Matches the correctly spelled `tryGetContextNodeOptions` above it.

Verified with `gofmt -l` clean and `git diff` showing only the rename.