### PR TITLE
test(i): Let an external test node run under NAC

### DIFF
--- a/tests/action/identity.go
+++ b/tests/action/identity.go
@@ -85,3 +85,15 @@ func getIdentityForRequestSpecificToNode(
 	}
 	return immutable.Some(getIdentityForRequest(s, identity.Value(), nodeIndex))
 }
+
+// resolveIdentity turns an identity reference into the identity itself.
+func resolveIdentity(
+	s *state.State,
+	identity immutable.Option[state.Identity],
+) immutable.Option[acpIdentity.Identity] {
+	ident := state.GetIdentity(s, identity)
+	if ident == nil {
+		return acpIdentity.None
+	}
+	return immutable.Some(ident)
+}

--- a/tests/action/new_node.go
+++ b/tests/action/new_node.go
@@ -16,7 +16,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
+	"github.com/sourcenetwork/immutable"
+
 	"github.com/sourcenetwork/defradb/client/options"
 	"github.com/sourcenetwork/defradb/crypto"
 	changeDetector "github.com/sourcenetwork/defradb/tests/change_detector"
@@ -110,7 +111,7 @@ func (a *NewNode) Execute() {
 		opts.SetDisableP2P(a.DisableP2P)
 	}
 
-	node, err := SetupNode(s, acpIdentity.None, a.SetupConfig, opts, a.Version)
+	node, err := SetupNode(s, immutable.None[state.Identity](), a.SetupConfig, opts, a.Version)
 	require.NoError(s.T, err)
 	if node == nil {
 		// SetupNode already skipped the test (no release asset for this platform).

--- a/tests/action/node_options.go
+++ b/tests/action/node_options.go
@@ -57,6 +57,10 @@ type NodeSetupConfig struct {
 	// instantiated. A zero pool size leaves the node default in place.
 	LensRuntime  options.NodeLensRuntimeType
 	LensPoolSize int
+	// EnableNAC turns on node access control, owned by NACOwner. While it is on the
+	// node lets through no one else.
+	EnableNAC bool
+	NACOwner  immutable.Option[state.Identity]
 }
 
 func applyHTTPOptions(opts *options.NodeOptionsBuilder, httpOpts options.NodeHTTPOptions) {

--- a/tests/action/node_options.go
+++ b/tests/action/node_options.go
@@ -57,10 +57,18 @@ type NodeSetupConfig struct {
 	// instantiated. A zero pool size leaves the node default in place.
 	LensRuntime  options.NodeLensRuntimeType
 	LensPoolSize int
-	// EnableNAC turns on node access control, owned by NACOwner. While it is on the
-	// node lets through no one else.
-	EnableNAC bool
-	NACOwner  immutable.Option[state.Identity]
+	// NodeACP overrides the node's access control settings when set. While access
+	// control is on the node lets through no one but NACOwner.
+	NodeACP immutable.Option[options.NodeACPOptions]
+	// NACOwner is the identity access control is set up under. The node takes it
+	// from the identity it is started with, so this is a reference to that one
+	// rather than a setting of its own.
+	NACOwner immutable.Option[state.Identity]
+}
+
+// nacEnabled reports whether the test asked for node access control.
+func nacEnabled(cfg NodeSetupConfig) bool {
+	return cfg.NodeACP.HasValue() && cfg.NodeACP.Value().IsEnabled
 }
 
 func applyHTTPOptions(opts *options.NodeOptionsBuilder, httpOpts options.NodeHTTPOptions) {

--- a/tests/action/node_options.go
+++ b/tests/action/node_options.go
@@ -57,13 +57,9 @@ type NodeSetupConfig struct {
 	// instantiated. A zero pool size leaves the node default in place.
 	LensRuntime  options.NodeLensRuntimeType
 	LensPoolSize int
-	// NodeACP overrides the node's access control settings when set. While access
-	// control is on the node lets through no one but NACOwner.
+	// NodeACP overrides the node's access control settings when set. While it is on
+	// the node lets through no one but the identity it was started with.
 	NodeACP immutable.Option[options.NodeACPOptions]
-	// NACOwner is the identity access control is set up under. The node takes it
-	// from the identity it is started with, so this is a reference to that one
-	// rather than a setting of its own.
-	NACOwner immutable.Option[state.Identity]
 }
 
 // nacEnabled reports whether the test asked for node access control.

--- a/tests/action/node_setup.go
+++ b/tests/action/node_setup.go
@@ -303,7 +303,7 @@ func setupExternalNode(
 	defer func() { s.CurrentSetupHost = "" }()
 
 	nacIdentity := immutable.None[state.Identity]()
-	if cfg.EnableNAC {
+	if nacEnabled(cfg) {
 		// The node ignores a flag it does not know, so a test could assert an access
 		// rule against a node that never enforced one.
 		require.Contains(s.T, w.StartupLog(), nacEnabledLog,
@@ -378,7 +378,7 @@ func externalNodeFlags(
 		unsupported = append(unsupported, "badger encryption: the test supplies a key, and only --no-encryption exists")
 	}
 
-	if cfg.EnableNAC {
+	if nacEnabled(cfg) {
 		// The identity given here owns NAC, so it has to be the one the test uses.
 		full, ok := identityWithPrivateKey(
 			getIdentityForRequestSpecificToNode(s, cfg.NACOwner, s.CurrentSetupNodeID))

--- a/tests/action/node_setup.go
+++ b/tests/action/node_setup.go
@@ -69,7 +69,7 @@ func createBadgerEncryptionKey(enabled bool) error {
 // the js client build may fail (the failure might not be obvious to find).
 func SetupNode(
 	s *state.State,
-	identity immutable.Option[acpIdentity.Identity],
+	identity immutable.Option[state.Identity],
 	cfg NodeSetupConfig,
 	opts *options.NodeOptionsBuilder,
 	ver string,
@@ -162,7 +162,7 @@ func SetupNode(
 		return nil, err
 	}
 
-	ctx := iIdentity.WithContext(s.Ctx, identity)
+	ctx := iIdentity.WithContext(s.Ctx, resolveIdentity(s, identity))
 	err = nodeObj.Start(ctx)
 
 	if err != nil {
@@ -272,7 +272,7 @@ const nacEnabledLog = "Starting with nac"
 // failed) and a nil error is returned.
 func setupExternalNode(
 	s *state.State,
-	identity immutable.Option[acpIdentity.Identity],
+	identity immutable.Option[state.Identity],
 	cfg NodeSetupConfig,
 	ver string,
 ) (*state.NodeState, error) {
@@ -310,7 +310,7 @@ func setupExternalNode(
 			"node %d was started with node access control, but did not enable it",
 			s.CurrentSetupNodeID)
 
-		nacIdentity = cfg.NACOwner
+		nacIdentity = identity
 	}
 
 	// An external node has no in-process DB, so it discovers its addresses over
@@ -338,7 +338,7 @@ func identityWithPrivateKey(
 // the test did not ask for, and the test still passes.
 func externalNodeFlags(
 	s *state.State,
-	identity immutable.Option[acpIdentity.Identity],
+	identity immutable.Option[state.Identity],
 	cfg NodeSetupConfig,
 ) (flags []string, unsupported []string) {
 	// The node signs by default, so not signing has to be asked for.
@@ -381,7 +381,7 @@ func externalNodeFlags(
 	if nacEnabled(cfg) {
 		// The identity given here owns NAC, so it has to be the one the test uses.
 		full, ok := identityWithPrivateKey(
-			getIdentityForRequestSpecificToNode(s, cfg.NACOwner, s.CurrentSetupNodeID))
+			getIdentityForRequestSpecificToNode(s, identity, s.CurrentSetupNodeID))
 		switch {
 		case !ok:
 			unsupported = append(unsupported, "node access control: no private key for the starting identity")

--- a/tests/action/node_setup.go
+++ b/tests/action/node_setup.go
@@ -25,6 +25,7 @@ import (
 	"github.com/sourcenetwork/immutable"
 
 	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
+	"github.com/sourcenetwork/defradb/client"
 	"github.com/sourcenetwork/defradb/client/options"
 	"github.com/sourcenetwork/defradb/crypto"
 	"github.com/sourcenetwork/defradb/errors"
@@ -261,9 +262,6 @@ func discoverPeerAddresses(
 	return removePeerIDFromAddr(addresses)
 }
 
-// nacEnabledLog is what a node logs once node access control is on.
-const nacEnabledLog = "Starting with nac"
-
 // setupExternalNode starts a node as a separate OS process from a downloaded
 // release binary of the given version, and wraps it in the same NodeState
 // shape a native node would produce.
@@ -304,13 +302,8 @@ func setupExternalNode(
 
 	nacIdentity := immutable.None[state.Identity]()
 	if nacEnabled(cfg) {
-		// The node ignores a flag it does not know, so a test could assert an access
-		// rule against a node that never enforced one.
-		require.Contains(s.T, w.StartupLog(), nacEnabledLog,
-			"node %d was started with node access control, but did not enable it",
-			s.CurrentSetupNodeID)
-
 		nacIdentity = identity
+		requireNACEnabled(s, w, identity)
 	}
 
 	// An external node has no in-process DB, so it discovers its addresses over
@@ -328,6 +321,31 @@ func identityWithPrivateKey(
 	}
 	full, ok := identity.Value().(acpIdentity.FullIdentity)
 	return full, ok
+}
+
+// requireNACEnabled fails the test unless the node has node access control on.
+//
+// The node ignores a flag it does not know, so without this a test could assert
+// an access rule against a node that never enforced one. Asking the node is
+// ordered by the response, unlike its startup log, which arrives whenever the
+// process gets around to writing it.
+func requireNACEnabled(
+	s *state.State,
+	c clients.Client,
+	identity immutable.Option[state.Identity],
+) {
+	opts := options.GetNACStatus()
+	identOption := getIdentityForRequestSpecificToNode(s, identity, s.CurrentSetupNodeID)
+	if identOption.HasValue() {
+		opts.SetIdentity(identOption.Value())
+	}
+
+	status, err := c.GetNACStatus(s.Ctx, opts)
+	require.NoError(s.T, err, "node %d could not report its access control status",
+		s.CurrentSetupNodeID)
+	require.Equal(s.T, client.NACEnabled.String(), status.Status,
+		"node %d was started with node access control, but did not enable it",
+		s.CurrentSetupNodeID)
 }
 
 // externalNodeFlags translates the configuration a native node would be given

--- a/tests/action/node_setup.go
+++ b/tests/action/node_setup.go
@@ -382,9 +382,18 @@ func externalNodeFlags(
 		// The identity given here owns NAC, so it has to be the one the test uses.
 		full, ok := identityWithPrivateKey(
 			getIdentityForRequestSpecificToNode(s, cfg.NACOwner, s.CurrentSetupNodeID))
-		if !ok {
+		switch {
+		case !ok:
 			unsupported = append(unsupported, "node access control: no private key for the starting identity")
-		} else {
+
+		// The key is sent as bare hex and the node reads every key as secp256k1, so
+		// another type would silently give NAC to an owner the test cannot use.
+		case full.PrivateKey().Type() != crypto.KeyTypeSecp256k1:
+			unsupported = append(unsupported,
+				"node access control: the owner key is "+string(full.PrivateKey().Type())+
+					", and the node reads the key it is given as secp256k1")
+
+		default:
 			flags = append(flags, "--node-acp-enable", "--identity", full.PrivateKey().String())
 		}
 	}

--- a/tests/action/node_setup.go
+++ b/tests/action/node_setup.go
@@ -75,7 +75,7 @@ func SetupNode(
 	ver string,
 ) (*state.NodeState, error) {
 	if ver != "" {
-		return setupExternalNode(s, cfg, ver)
+		return setupExternalNode(s, identity, cfg, ver)
 	}
 
 	if opts == nil {
@@ -175,7 +175,7 @@ func SetupNode(
 	// A native node discovers its addresses through the in-process DB, which
 	// bypasses the HTTP auth middleware. Routing this through the client would
 	// send an unauthenticated request that NAC rejects.
-	st, err := newNodeState(s, c, nodeObj.DB, path, false)
+	st, err := newNodeState(s, c, nodeObj.DB, path, false, immutable.None[state.Identity]())
 	if err != nil {
 		return nil, err
 	}
@@ -197,6 +197,7 @@ func newNodeState(
 	peers peerInfoProvider,
 	path string,
 	isExternal bool,
+	nacOwner immutable.Option[state.Identity],
 ) (*state.NodeState, error) {
 	eventState, err := state.NewEventState(c.Events())
 	require.NoError(s.T, err)
@@ -209,7 +210,7 @@ func newNodeState(
 		IsExternal: isExternal,
 	}
 
-	addresses, err := discoverPeerAddresses(s, peers, isExternal)
+	addresses, err := discoverPeerAddresses(s, peers, isExternal, nacOwner)
 	if err != nil {
 		return nil, err
 	}
@@ -221,7 +222,12 @@ func newNodeState(
 // discoverPeerAddresses reads the node's listen addresses via PeerInfo and
 // strips the trailing /p2p/<peerID> so they can be reused as listen addresses
 // on restart.
-func discoverPeerAddresses(s *state.State, peers peerInfoProvider, isExternal bool) ([]string, error) {
+func discoverPeerAddresses(
+	s *state.State,
+	peers peerInfoProvider,
+	isExternal bool,
+	nacOwner immutable.Option[state.Identity],
+) ([]string, error) {
 	// Inject node identity to bypass NAC in order to be able to call PeerInfo,
 	// otherwise when NAC is enabled we get an authorization error.
 	//
@@ -233,6 +239,10 @@ func discoverPeerAddresses(s *state.State, peers peerInfoProvider, isExternal bo
 	nodeIdentity := NodeIdentity(s.CurrentSetupNodeID)
 	peerInfoOpts := options.PeerInfo()
 	identOption := getIdentityForRequestSpecificToNode(s, nodeIdentity, s.CurrentSetupNodeID)
+	// NAC lets through only the identity that turned it on.
+	if nacOwner.HasValue() {
+		identOption = getIdentityForRequestSpecificToNode(s, nacOwner, s.CurrentSetupNodeID)
+	}
 	if identOption.HasValue() {
 		tokenIdent, ok := identOption.Value().(acpIdentity.TokenIdentity)
 		if !isExternal || !ok || tokenIdent.BearerToken() != "" {
@@ -251,13 +261,21 @@ func discoverPeerAddresses(s *state.State, peers peerInfoProvider, isExternal bo
 	return removePeerIDFromAddr(addresses)
 }
 
+// nacEnabledLog is what a node logs once node access control is on.
+const nacEnabledLog = "Starting with nac"
+
 // setupExternalNode starts a node as a separate OS process from a downloaded
 // release binary of the given version, and wraps it in the same NodeState
 // shape a native node would produce.
 //
 // If no release asset exists for this platform, the test is skipped (not
 // failed) and a nil error is returned.
-func setupExternalNode(s *state.State, cfg NodeSetupConfig, ver string) (*state.NodeState, error) {
+func setupExternalNode(
+	s *state.State,
+	identity immutable.Option[acpIdentity.Identity],
+	cfg NodeSetupConfig,
+	ver string,
+) (*state.NodeState, error) {
 	path, skip, err := version.BinaryPath(s.Ctx, ver)
 	if err != nil {
 		return nil, err
@@ -267,7 +285,7 @@ func setupExternalNode(s *state.State, cfg NodeSetupConfig, ver string) (*state.
 		return nil, nil
 	}
 
-	flags, unsupported := externalNodeFlags(s, cfg)
+	flags, unsupported := externalNodeFlags(s, identity, cfg)
 	if len(unsupported) > 0 {
 		s.T.Skipf("external node cannot be given this test's configuration: %s",
 			strings.Join(unsupported, "; "))
@@ -279,18 +297,50 @@ func setupExternalNode(s *state.State, cfg NodeSetupConfig, ver string) (*state.
 		return nil, err
 	}
 
+	// Setup calls this node before it is on Nodes, so its tokens can only be minted
+	// from here.
+	s.CurrentSetupHost = w.Host()
+	defer func() { s.CurrentSetupHost = "" }()
+
+	nacIdentity := immutable.None[state.Identity]()
+	if cfg.EnableNAC {
+		// The node ignores a flag it does not know, so a test could assert an access
+		// rule against a node that never enforced one.
+		require.Contains(s.T, w.StartupLog(), nacEnabledLog,
+			"node %d was started with node access control, but did not enable it",
+			s.CurrentSetupNodeID)
+
+		nacIdentity = cfg.NACOwner
+	}
+
 	// An external node has no in-process DB, so it discovers its addresses over
 	// the HTTP client.
-	return newNodeState(s, w, w, "", true)
+	return newNodeState(s, w, w, "", true, nacIdentity)
+}
+
+// identityWithPrivateKey returns the identity as a [acpIdentity.FullIdentity],
+// the only form holding a private key.
+func identityWithPrivateKey(
+	identity immutable.Option[acpIdentity.Identity],
+) (acpIdentity.FullIdentity, bool) {
+	if !identity.HasValue() {
+		return nil, false
+	}
+	full, ok := identity.Value().(acpIdentity.FullIdentity)
+	return full, ok
 }
 
 // externalNodeFlags translates the configuration a native node would be given
 // into command line flags for an external one, so both run the same setup.
 //
-// The second return holds the settings that cannot be expressed as flags. Those
-// are not skippable details: the node would start with a default the test did
-// not ask for and the test would still pass, so the caller skips instead.
-func externalNodeFlags(s *state.State, cfg NodeSetupConfig) (flags []string, unsupported []string) {
+// Every setting must become a flag or be named in the second return, which the
+// caller skips on. One that is silently dropped leaves the node running a default
+// the test did not ask for, and the test still passes.
+func externalNodeFlags(
+	s *state.State,
+	identity immutable.Option[acpIdentity.Identity],
+	cfg NodeSetupConfig,
+) (flags []string, unsupported []string) {
 	// The node signs by default, so not signing has to be asked for.
 	if !cfg.EnableSigning {
 		flags = append(flags, "--no-signing")
@@ -326,6 +376,17 @@ func externalNodeFlags(s *state.State, cfg NodeSetupConfig) (flags []string, uns
 	}
 	if cfg.BadgerEncryption {
 		unsupported = append(unsupported, "badger encryption: the test supplies a key, and only --no-encryption exists")
+	}
+
+	if cfg.EnableNAC {
+		// The identity given here owns NAC, so it has to be the one the test uses.
+		full, ok := identityWithPrivateKey(
+			getIdentityForRequestSpecificToNode(s, cfg.NACOwner, s.CurrentSetupNodeID))
+		if !ok {
+			unsupported = append(unsupported, "node access control: no private key for the starting identity")
+		} else {
+			flags = append(flags, "--node-acp-enable", "--identity", full.PrivateKey().String())
+		}
 	}
 
 	// The wrapper picks the API address itself so it knows where to reach the

--- a/tests/action/node_setup_js.go
+++ b/tests/action/node_setup_js.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/sourcenetwork/immutable"
 
-	acpIdentity "github.com/sourcenetwork/defradb/acp/identity"
 	"github.com/sourcenetwork/defradb/client/options"
 	iIdentity "github.com/sourcenetwork/defradb/internal/identity"
 	"github.com/sourcenetwork/defradb/node"
@@ -30,7 +29,7 @@ import (
 // ver is unused: external (cross-version) nodes are not supported under js.
 func SetupNode(
 	s *state.State,
-	identity immutable.Option[acpIdentity.Identity],
+	identity immutable.Option[state.Identity],
 	cfg NodeSetupConfig,
 	opts *options.NodeOptionsBuilder,
 	ver string,
@@ -72,7 +71,7 @@ func SetupNode(
 	if err != nil {
 		return nil, err
 	}
-	ctx := iIdentity.WithContext(s.Ctx, identity)
+	ctx := iIdentity.WithContext(s.Ctx, resolveIdentity(s, identity))
 	err = nodeObj.Start(ctx)
 	if err != nil {
 		return nil, err

--- a/tests/action/node_setup_test.go
+++ b/tests/action/node_setup_test.go
@@ -14,13 +14,17 @@
 package action
 
 import (
-	"os"
 	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+
+	"github.com/sourcenetwork/immutable"
+
+	"github.com/sourcenetwork/defradb/client/options"
+	"github.com/sourcenetwork/defradb/crypto"
+	"github.com/sourcenetwork/defradb/tests/state"
 )
 
 // setupFieldHandling records how externalNodeFlags treats each [NodeSetupConfig]
@@ -76,38 +80,98 @@ func TestNodeSetupConfig_EveryFieldIsAccountedForByExternalNodeFlags(t *testing.
 			"report it as unsupported so the test skips, then record it in setupFields.")
 }
 
-// TestExternalNodeFlags_ReadsEveryFlaggedField fails if a field recorded as
-// flagged stops being read, which would drop it silently.
-func TestExternalNodeFlags_ReadsEveryFlaggedField(t *testing.T) {
-	source := readNodeSetupSource(t)
+// testOwner is the identity a node under access control is started with.
+var testOwner = immutable.Some(state.Identity{
+	Kind:     state.ClientIdentityType,
+	Selector: "1",
+})
 
-	for name, handling := range setupFields {
-		if handling != fieldFlagged {
-			continue
-		}
-		assert.True(t, strings.Contains(source, "cfg."+name),
-			"%s is recorded as flagged in setupFields, but externalNodeFlags no longer "+
-				"reads it. Either read it again or record it as dropped.", name)
+// newFlagsTestState builds the minimum state externalNodeFlags reads.
+func newFlagsTestState(t *testing.T, keyType crypto.KeyType) *state.State {
+	return &state.State{
+		T:          t,
+		DbType:     DefraIMType,
+		Identities: map[state.Identity]*state.IdentityHolder{},
+		IdentityTypes: map[state.Identity]crypto.KeyType{
+			testOwner.Value(): keyType,
+		},
 	}
 }
 
-// readNodeSetupSource returns the body of externalNodeFlags, plus the helpers it
-// reads config through, so a field reached by one of those still counts as read.
-func readNodeSetupSource(t *testing.T) string {
-	t.Helper()
+func TestExternalNodeFlags_NAC(t *testing.T) {
+	nacOn := immutable.Some(options.NodeACPOptions{IsEnabled: true})
 
-	setup, err := os.ReadFile("node_setup.go")
-	require.NoError(t, err)
+	tests := []struct {
+		name            string
+		nodeACP         immutable.Option[options.NodeACPOptions]
+		identity        immutable.Option[state.Identity]
+		keyType         crypto.KeyType
+		wantFlags       []string
+		wantNoFlags     []string
+		wantUnsupported string
+	}{
+		{
+			name:        "off by default",
+			identity:    testOwner,
+			keyType:     crypto.KeyTypeSecp256k1,
+			wantNoFlags: []string{"--node-acp-enable", "--identity"},
+		},
+		{
+			name:        "set but disabled stays off",
+			nodeACP:     immutable.Some(options.NodeACPOptions{IsEnabled: false}),
+			identity:    testOwner,
+			keyType:     crypto.KeyTypeSecp256k1,
+			wantNoFlags: []string{"--node-acp-enable", "--identity"},
+		},
+		{
+			name:      "enabled asks the node to turn it on",
+			nodeACP:   nacOn,
+			identity:  testOwner,
+			keyType:   crypto.KeyTypeSecp256k1,
+			wantFlags: []string{"--node-acp-enable", "--identity"},
+		},
+		{
+			// The node refuses to start access control with no one to own it.
+			name:            "no identity to own it",
+			nodeACP:         nacOn,
+			identity:        immutable.None[state.Identity](),
+			keyType:         crypto.KeyTypeSecp256k1,
+			wantNoFlags:     []string{"--node-acp-enable"},
+			wantUnsupported: "no private key",
+		},
+		{
+			// The key is sent as bare hex and read back as secp256k1, so another
+			// type would silently give access control to a different owner.
+			name:            "owner key the node cannot read",
+			nodeACP:         nacOn,
+			identity:        testOwner,
+			keyType:         crypto.KeyTypeEd25519,
+			wantNoFlags:     []string{"--node-acp-enable"},
+			wantUnsupported: "secp256k1",
+		},
+	}
 
-	start := strings.Index(string(setup), "func externalNodeFlags(")
-	require.NotEqual(t, -1, start, "externalNodeFlags was renamed or moved")
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			s := newFlagsTestState(t, test.keyType)
 
-	body := string(setup)[start:]
-	end := strings.Index(body, "\n}\n")
-	require.NotEqual(t, -1, end, "could not find the end of externalNodeFlags")
+			flags, unsupported := externalNodeFlags(s, test.identity,
+				NodeSetupConfig{NodeACP: test.nodeACP})
 
-	helpers, err := os.ReadFile("node_options.go")
-	require.NoError(t, err)
+			joinedFlags := strings.Join(flags, " ")
+			for _, want := range test.wantFlags {
+				assert.Contains(t, joinedFlags, want)
+			}
+			for _, notWant := range test.wantNoFlags {
+				assert.NotContains(t, joinedFlags, notWant)
+			}
 
-	return body[:end] + string(helpers)
+			joinedUnsupported := strings.Join(unsupported, " ")
+			if test.wantUnsupported == "" {
+				assert.NotContains(t, joinedUnsupported, "node access control")
+			} else {
+				assert.Contains(t, joinedUnsupported, test.wantUnsupported)
+			}
+		})
+	}
 }

--- a/tests/action/node_setup_test.go
+++ b/tests/action/node_setup_test.go
@@ -1,0 +1,50 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// This file is part of the DefraDB test suite.
+//
+// The DefraDB test suite is licensed under either:
+//
+//   (1) GNU Affero General Public License v3
+//   (2) Business Source License 1.1
+//
+// See tests/LICENSE for details.
+
+//go:build !js
+
+package action
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// knownSetupFields are the [NodeSetupConfig] fields externalNodeFlags has been
+// checked against, each either a flag or named as unsupported.
+//
+// Node access control was once dropped there, and the tests asserting it passed
+// against a node that never enforced it.
+var knownSetupFields = []string{
+	"EnableSigning",
+	"HTTP",
+	"IsDocumentACPTest",
+	"VeraImage",
+	"DatabaseDir",
+	"BadgerEncryption",
+	"LensRuntime",
+	"LensPoolSize",
+	"EnableNAC",
+	"NACOwner",
+}
+
+func TestNodeSetupConfig_EveryFieldIsHandledByExternalNodeFlags(t *testing.T) {
+	var actual []string
+	for i := range reflect.TypeOf(NodeSetupConfig{}).NumField() {
+		actual = append(actual, reflect.TypeOf(NodeSetupConfig{}).Field(i).Name)
+	}
+
+	assert.ElementsMatch(t, knownSetupFields, actual,
+		"NodeSetupConfig changed. Give the new field a flag in externalNodeFlags, or "+
+			"add it to the unsupported list so the test skips, then list it here.")
+}

--- a/tests/action/node_setup_test.go
+++ b/tests/action/node_setup_test.go
@@ -43,7 +43,7 @@ var setupFields = map[string]setupFieldHandling{
 	"EnableSigning":    fieldFlagged,
 	"HTTP":             fieldFlagged,
 	"BadgerEncryption": fieldFlagged,
-	"EnableNAC":        fieldFlagged,
+	"NodeACP":          fieldFlagged,
 	"NACOwner":         fieldFlagged,
 
 	// The external node keeps its store under the rootdir the wrapper owns, so it
@@ -92,19 +92,23 @@ func TestExternalNodeFlags_ReadsEveryFlaggedField(t *testing.T) {
 	}
 }
 
-// readNodeSetupSource returns the body of externalNodeFlags.
+// readNodeSetupSource returns the body of externalNodeFlags, plus the helpers it
+// reads config through, so a field reached by one of those still counts as read.
 func readNodeSetupSource(t *testing.T) string {
 	t.Helper()
 
-	source, err := os.ReadFile("node_setup.go")
+	setup, err := os.ReadFile("node_setup.go")
 	require.NoError(t, err)
 
-	start := strings.Index(string(source), "func externalNodeFlags(")
+	start := strings.Index(string(setup), "func externalNodeFlags(")
 	require.NotEqual(t, -1, start, "externalNodeFlags was renamed or moved")
 
-	body := string(source)[start:]
+	body := string(setup)[start:]
 	end := strings.Index(body, "\n}\n")
 	require.NotEqual(t, -1, end, "could not find the end of externalNodeFlags")
 
-	return body[:end]
+	helpers, err := os.ReadFile("node_options.go")
+	require.NoError(t, err)
+
+	return body[:end] + string(helpers)
 }

--- a/tests/action/node_setup_test.go
+++ b/tests/action/node_setup_test.go
@@ -44,7 +44,6 @@ var setupFields = map[string]setupFieldHandling{
 	"HTTP":             fieldFlagged,
 	"BadgerEncryption": fieldFlagged,
 	"NodeACP":          fieldFlagged,
-	"NACOwner":         fieldFlagged,
 
 	// The external node keeps its store under the rootdir the wrapper owns, so it
 	// cannot reopen one the harness chose.

--- a/tests/action/node_setup_test.go
+++ b/tests/action/node_setup_test.go
@@ -14,37 +14,97 @@
 package action
 
 import (
+	"os"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-// knownSetupFields are the [NodeSetupConfig] fields externalNodeFlags has been
-// checked against, each either a flag or named as unsupported.
+// setupFieldHandling records how externalNodeFlags treats each [NodeSetupConfig]
+// field, so a new one cannot be added without saying which it is.
 //
 // Node access control was once dropped there, and the tests asserting it passed
 // against a node that never enforced it.
-var knownSetupFields = []string{
-	"EnableSigning",
-	"HTTP",
-	"IsDocumentACPTest",
-	"VeraImage",
-	"DatabaseDir",
-	"BadgerEncryption",
-	"LensRuntime",
-	"LensPoolSize",
-	"EnableNAC",
-	"NACOwner",
+type setupFieldHandling int
+
+const (
+	// fieldFlagged is read and turned into a flag, or reported as unsupported so
+	// the test skips.
+	fieldFlagged setupFieldHandling = iota
+	// fieldDropped is not read at all. The external node runs the default, so a
+	// test relying on the field is not running what it asks for.
+	fieldDropped
+)
+
+var setupFields = map[string]setupFieldHandling{
+	"EnableSigning":    fieldFlagged,
+	"HTTP":             fieldFlagged,
+	"BadgerEncryption": fieldFlagged,
+	"EnableNAC":        fieldFlagged,
+	"NACOwner":         fieldFlagged,
+
+	// The external node keeps its store under the rootdir the wrapper owns, so it
+	// cannot reopen one the harness chose.
+	"DatabaseDir": fieldDropped,
+	// Both are only read when a lens is configured, which no cross-version test
+	// does yet.
+	"LensRuntime":  fieldDropped,
+	"LensPoolSize": fieldDropped,
+	// Both belong to remote document ACP, which is already reported as
+	// unsupported before either is looked at.
+	"IsDocumentACPTest": fieldDropped,
+	"VeraImage":         fieldDropped,
 }
 
-func TestNodeSetupConfig_EveryFieldIsHandledByExternalNodeFlags(t *testing.T) {
+func TestNodeSetupConfig_EveryFieldIsAccountedForByExternalNodeFlags(t *testing.T) {
+	cfgType := reflect.TypeOf(NodeSetupConfig{})
+
 	var actual []string
-	for i := range reflect.TypeOf(NodeSetupConfig{}).NumField() {
-		actual = append(actual, reflect.TypeOf(NodeSetupConfig{}).Field(i).Name)
+	for i := range cfgType.NumField() {
+		actual = append(actual, cfgType.Field(i).Name)
 	}
 
-	assert.ElementsMatch(t, knownSetupFields, actual,
+	var known []string
+	for name := range setupFields {
+		known = append(known, name)
+	}
+
+	assert.ElementsMatch(t, known, actual,
 		"NodeSetupConfig changed. Give the new field a flag in externalNodeFlags, or "+
-			"add it to the unsupported list so the test skips, then list it here.")
+			"report it as unsupported so the test skips, then record it in setupFields.")
+}
+
+// TestExternalNodeFlags_ReadsEveryFlaggedField fails if a field recorded as
+// flagged stops being read, which would drop it silently.
+func TestExternalNodeFlags_ReadsEveryFlaggedField(t *testing.T) {
+	source := readNodeSetupSource(t)
+
+	for name, handling := range setupFields {
+		if handling != fieldFlagged {
+			continue
+		}
+		assert.True(t, strings.Contains(source, "cfg."+name),
+			"%s is recorded as flagged in setupFields, but externalNodeFlags no longer "+
+				"reads it. Either read it again or record it as dropped.", name)
+	}
+}
+
+// readNodeSetupSource returns the body of externalNodeFlags.
+func readNodeSetupSource(t *testing.T) string {
+	t.Helper()
+
+	source, err := os.ReadFile("node_setup.go")
+	require.NoError(t, err)
+
+	start := strings.Index(string(source), "func externalNodeFlags(")
+	require.NotEqual(t, -1, start, "externalNodeFlags was renamed or moved")
+
+	body := string(source)[start:]
+	end := strings.Index(body, "\n}\n")
+	require.NotEqual(t, -1, end, "could not find the end of externalNodeFlags")
+
+	return body[:end]
 }

--- a/tests/clients/external/wrapper.go
+++ b/tests/clients/external/wrapper.go
@@ -256,12 +256,6 @@ func removeAll(dir string) {
 	_ = os.RemoveAll(dir)
 }
 
-// StartupLog returns the output the node has written so far. Setup reads it to
-// confirm the node started with what the test asked for.
-func (w *Wrapper) StartupLog() string {
-	return w.stderr.String()
-}
-
 // Host returns the base URL the wrapper's HTTP client is talking to.
 func (w *Wrapper) Host() string {
 	return w.apiURL

--- a/tests/clients/external/wrapper.go
+++ b/tests/clients/external/wrapper.go
@@ -257,6 +257,12 @@ func removeAll(dir string) {
 }
 
 // Host returns the base URL the wrapper's HTTP client is talking to.
+// StartupLog returns the output the node has written so far. Setup reads it to
+// confirm the node started with what the test asked for.
+func (w *Wrapper) StartupLog() string {
+	return w.stderr.String()
+}
+
 func (w *Wrapper) Host() string {
 	return w.apiURL
 }

--- a/tests/clients/external/wrapper.go
+++ b/tests/clients/external/wrapper.go
@@ -256,13 +256,13 @@ func removeAll(dir string) {
 	_ = os.RemoveAll(dir)
 }
 
-// Host returns the base URL the wrapper's HTTP client is talking to.
 // StartupLog returns the output the node has written so far. Setup reads it to
 // confirm the node started with what the test asked for.
 func (w *Wrapper) StartupLog() string {
 	return w.stderr.String()
 }
 
+// Host returns the base URL the wrapper's HTTP client is talking to.
 func (w *Wrapper) Host() string {
 	return w.apiURL
 }

--- a/tests/integration/identity.go
+++ b/tests/integration/identity.go
@@ -58,18 +58,6 @@ func NodeIdentity(indexSelector int) immutable.Option[state.Identity] {
 	)
 }
 
-// getIdentityOption returns the identity similar to [getIdentity] but in immutable.Option.
-func getIdentityOption(
-	s *state.State,
-	identity immutable.Option[state.Identity],
-) immutable.Option[acpIdentity.Identity] {
-	ident := state.GetIdentity(s, identity)
-	if ident == nil {
-		return acpIdentity.None
-	}
-	return immutable.Some(ident)
-}
-
 // getIdentityForRequest returns the identity for the given reference and node index.
 // It prepares the identity for a request by generating a token if needed, i.e. it will
 // return an identity with [Identity.BearerToken] set.

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -1074,9 +1074,10 @@ func startNodes(s *state.State, testCase TestCase, start Start) {
 			opts.DB().SetNodeIdentity(state.GetIdentity(s, NodeIdentity(s.CurrentSetupNodeID)))
 			opts.P2P().SetAll(p2pOpts)
 			opts.SetDisableP2P(s.Nodes[nodeID].DisableP2P)
-			opts.NodeACP().SetEnabled(start.EnableNAC)
+			nacOpts := options.NodeACPOptions{IsEnabled: start.EnableNAC}
+			opts.NodeACP().SetAll(nacOpts)
 			setupConfig := testCase.nodeSetupConfig()
-			setupConfig.EnableNAC = start.EnableNAC
+			setupConfig.NodeACP = immutable.Some(nacOpts)
 			setupConfig.NACOwner = start.Identity
 			return action.SetupNode(
 				s,

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -1041,7 +1041,7 @@ func setStartingNodes(
 		nodeBuilder.DB().SetNodeIdentity(state.GetIdentity(s, NodeIdentity(s.CurrentSetupNodeID)))
 		st, err := action.SetupNode(
 			s,
-			acpIdentity.None,
+			immutable.None[state.Identity](),
 			testCase.nodeSetupConfig(),
 			nodeBuilder,
 			"",
@@ -1078,10 +1078,9 @@ func startNodes(s *state.State, testCase TestCase, start Start) {
 			opts.NodeACP().SetAll(nacOpts)
 			setupConfig := testCase.nodeSetupConfig()
 			setupConfig.NodeACP = immutable.Some(nacOpts)
-			setupConfig.NACOwner = start.Identity
 			return action.SetupNode(
 				s,
-				getIdentityOption(s, start.Identity),
+				start.Identity,
 				setupConfig,
 				opts,
 				s.Nodes[nodeID].Version,

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -1075,10 +1075,13 @@ func startNodes(s *state.State, testCase TestCase, start Start) {
 			opts.P2P().SetAll(p2pOpts)
 			opts.SetDisableP2P(s.Nodes[nodeID].DisableP2P)
 			opts.NodeACP().SetEnabled(start.EnableNAC)
+			setupConfig := testCase.nodeSetupConfig()
+			setupConfig.EnableNAC = start.EnableNAC
+			setupConfig.NACOwner = start.Identity
 			return action.SetupNode(
 				s,
 				getIdentityOption(s, start.Identity),
-				testCase.nodeSetupConfig(),
+				setupConfig,
 				opts,
 				s.Nodes[nodeID].Version,
 			)

--- a/tests/state/audience.go
+++ b/tests/state/audience.go
@@ -28,6 +28,10 @@ type hostedClient interface {
 }
 
 func GetNodeAudience(s *State, nodeIndex int) immutable.Option[string] {
+	// Only the setup knows where a node being set up answers, so prefer it.
+	if s.CurrentSetupHost != "" && nodeIndex == s.CurrentSetupNodeID {
+		return immutable.Some(strings.TrimPrefix(s.CurrentSetupHost, "http://"))
+	}
 	if nodeIndex >= len(s.Nodes) {
 		return immutable.None[string]()
 	}

--- a/tests/state/audience_test.go
+++ b/tests/state/audience_test.go
@@ -1,0 +1,107 @@
+// Copyright 2026 Democratized Data Foundation
+//
+// This file is part of the DefraDB test suite.
+//
+// The DefraDB test suite is licensed under either:
+//
+//   (1) GNU Affero General Public License v3
+//   (2) Business Source License 1.1
+//
+// See tests/LICENSE for details.
+
+//go:build !js
+
+package state
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/sourcenetwork/defradb/tests/clients"
+)
+
+// hostClient stands in for a client wrapper that fronts an HTTP host.
+type hostClient struct {
+	clients.Client
+	host string
+}
+
+func (c hostClient) Host() string { return c.host }
+
+func TestGetNodeAudience(t *testing.T) {
+	nodes := []*NodeState{
+		{Client: hostClient{host: "http://127.0.0.1:1111"}},
+		{Client: hostClient{host: "http://127.0.0.1:2222"}},
+	}
+
+	tests := []struct {
+		name        string
+		nodes       []*NodeState
+		setupHost   string
+		setupNodeID int
+		nodeIndex   int
+		want        string
+		wantSome    bool
+	}{
+		{
+			name:      "reads the host off the node",
+			nodes:     nodes,
+			nodeIndex: 1,
+			want:      "127.0.0.1:2222",
+			wantSome:  true,
+		},
+		{
+			// A restarted node gets a new port, and the node rejects tokens minted
+			// from the old one.
+			name:        "setup host wins for the node being set up",
+			nodes:       nodes,
+			setupHost:   "http://127.0.0.1:9999",
+			setupNodeID: 1,
+			nodeIndex:   1,
+			want:        "127.0.0.1:9999",
+			wantSome:    true,
+		},
+		{
+			name:        "setup host does not leak to other nodes",
+			nodes:       nodes,
+			setupHost:   "http://127.0.0.1:9999",
+			setupNodeID: 1,
+			nodeIndex:   0,
+			want:        "127.0.0.1:1111",
+			wantSome:    true,
+		},
+		{
+			// A node is first set up before it reaches Nodes.
+			name:        "setup host answers for a node not on Nodes yet",
+			nodes:       nil,
+			setupHost:   "http://127.0.0.1:9999",
+			setupNodeID: 0,
+			nodeIndex:   0,
+			want:        "127.0.0.1:9999",
+			wantSome:    true,
+		},
+		{
+			name:      "no host and no node gives nothing",
+			nodes:     nil,
+			nodeIndex: 0,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			s := &State{
+				Nodes:              test.nodes,
+				CurrentSetupHost:   test.setupHost,
+				CurrentSetupNodeID: test.setupNodeID,
+			}
+
+			got := GetNodeAudience(s, test.nodeIndex)
+
+			assert.Equal(t, test.wantSome, got.HasValue())
+			if test.wantSome {
+				assert.Equal(t, test.want, got.Value())
+			}
+		})
+	}
+}

--- a/tests/state/state.go
+++ b/tests/state/state.go
@@ -356,6 +356,14 @@ type State struct {
 	// node, for example finding a specific node's NodeIdentity inorder to bypass NAC.
 	CurrentSetupNodeID int
 
+	// CurrentSetupHost is the address to mint auth tokens from while a node is being
+	// set up.
+	//
+	// A restarting node gets a new port, and the node rejects tokens minted for the
+	// port it had before. Its entry on Nodes cannot be replaced any earlier, since
+	// setting the node up reads the old entry to build the new one.
+	CurrentSetupHost string
+
 	// node id that is currently being asserted. This is used by [StatefulMatcher]s to know for which
 	// node they should be asserting. For example, the [UniqueValue] matcher checks that it is
 	// called with a value that it didn't see before, but the value should be the same for different


### PR DESCRIPTION
## Relevant issue(s)

Refs https://github.com/sourcenetwork/defradb/issues/5170

## Description

A test node that runs as a separate process can now be asked to turn node access control on. The request used to be dropped without a word, so tests asserting that an unauthorized caller is refused kept passing against a node that was never enforcing anything.

Two things stopped it working: the node was never told to enable access control, and once it was, the tokens it was sent were minted for the address it had before it restarted, which it rejects.

No test is un-excluded yet. A node in another process still generates its own node identity, which the harness relies on elsewhere to get past access control, so the tests excluded for this need that solved first.

Two guards come with it, since a silently dropped setting is what made the failure invisible. Setup now confirms the node came up with access control on rather than assuming the request landed, and a test fails if a node setting is added without saying whether a separate process honours it or ignores it.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Unit tests, plus the networked suite under both cross-version directions. Reverting each fix in turn was used to confirm the tests fail without it.

Specify the platform(s) on which this was tested:
- macOS