### PR TITLE
Dvncan/egress relay check

### DIFF
--- a/internal/db/p2p/p2p.go
+++ b/internal/db/p2p/p2p.go
@@ -1231,7 +1231,7 @@ func (p *P2P) SendUpdate(evt event.Update) error {
 	p.pushLogToReplicators(evt)
 
 	// Retries are for replicators only and should not pollute the pubsub network.
-	if !evt.IsRetry {
+	if !evt.IsRetry && !evt.IsRelay {
 		// Pre-generate a CAR so receivers import the full DAG without a BitSwap round-trip.
 		var carData []byte
 		if block, err := coreblock.GetFromBytes(evt.Block); err == nil {
@@ -1274,25 +1274,23 @@ func (p *P2P) SendUpdate(evt event.Update) error {
 			}
 		}
 
-		if !evt.IsRelay {
-			// Route collection-topic publishes through the batcher so multiple doc updates
-			// within the flush window are coalesced into a single pubsub message.
-			p.batcher.Add(evt.CollectionID, protocol.DocumentInfo{
-				DocID: evt.DocID,
-				CID:   evt.Cid.Bytes(),
-				Block: evt.Block,
-				CAR:   carData,
-			})
-			p.topicPeerMu.RLock()
-			noPeers := p.topicPeerCounts[evt.CollectionID] == 0
-			p.topicPeerMu.RUnlock()
-			if noPeers {
-				p.db.Events().Publish(event.NewMessage(event.P2PNoPeersName, event.P2PNoPeers{
-					DocID:        evt.DocID,
-					CollectionID: evt.CollectionID,
-					Topic:        evt.CollectionID,
-				}))
-			}
+		// Route collection-topic publishes through the batcher so multiple doc updates
+		// within the flush window are coalesced into a single pubsub message.
+		p.batcher.Add(evt.CollectionID, protocol.DocumentInfo{
+			DocID: evt.DocID,
+			CID:   evt.Cid.Bytes(),
+			Block: evt.Block,
+			CAR:   carData,
+		})
+		p.topicPeerMu.RLock()
+		noPeers := p.topicPeerCounts[evt.CollectionID] == 0
+		p.topicPeerMu.RUnlock()
+		if noPeers {
+			p.db.Events().Publish(event.NewMessage(event.P2PNoPeersName, event.P2PNoPeers{
+				DocID:        evt.DocID,
+				CollectionID: evt.CollectionID,
+				Topic:        evt.CollectionID,
+			}))
 		}
 	}
 

--- a/internal/db/p2p/p2p.go
+++ b/internal/db/p2p/p2p.go
@@ -1274,23 +1274,25 @@ func (p *P2P) SendUpdate(evt event.Update) error {
 			}
 		}
 
-		// Route collection-topic publishes through the batcher so multiple doc updates
-		// within the flush window are coalesced into a single pubsub message.
-		p.batcher.Add(evt.CollectionID, protocol.DocumentInfo{
-			DocID: evt.DocID,
-			CID:   evt.Cid.Bytes(),
-			Block: evt.Block,
-			CAR:   carData,
-		})
-		p.topicPeerMu.RLock()
-		noPeers := p.topicPeerCounts[evt.CollectionID] == 0
-		p.topicPeerMu.RUnlock()
-		if noPeers {
-			p.db.Events().Publish(event.NewMessage(event.P2PNoPeersName, event.P2PNoPeers{
-				DocID:        evt.DocID,
-				CollectionID: evt.CollectionID,
-				Topic:        evt.CollectionID,
-			}))
+		if !evt.IsRelay {
+			// Route collection-topic publishes through the batcher so multiple doc updates
+			// within the flush window are coalesced into a single pubsub message.
+			p.batcher.Add(evt.CollectionID, protocol.DocumentInfo{
+				DocID: evt.DocID,
+				CID:   evt.Cid.Bytes(),
+				Block: evt.Block,
+				CAR:   carData,
+			})
+			p.topicPeerMu.RLock()
+			noPeers := p.topicPeerCounts[evt.CollectionID] == 0
+			p.topicPeerMu.RUnlock()
+			if noPeers {
+				p.db.Events().Publish(event.NewMessage(event.P2PNoPeersName, event.P2PNoPeers{
+					DocID:        evt.DocID,
+					CollectionID: evt.CollectionID,
+					Topic:        evt.CollectionID,
+				}))
+			}
 		}
 	}
 


### PR DESCRIPTION
## Relevant issue(s)

Resolves #

## Description

This PR checks that the message being received is not a relay before creating the CAR and syncing the file.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/chglog/config.yml](tools/configs/chglog/config.yml)).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...
