### PR TITLE
fix: Format IndexKind as text string instead of numeric ID

### DIFF
--- a/client/index.go
+++ b/client/index.go
@@ -50,7 +50,12 @@ func (k IndexKind) String() string {
 }
 
 func (k IndexKind) MarshalText() ([]byte, error) {
-	return []byte(k.String()), nil
+	switch k {
+	case IndexKindOrdered, IndexKindVector:
+		return []byte(k.String()), nil
+	default:
+		return nil, NewErrUnknownIndexKind(uint8(k))
+	}
 }
 
 func (k *IndexKind) UnmarshalText(text []byte) error {

--- a/client/index.go
+++ b/client/index.go
@@ -38,6 +38,34 @@ const (
 	IndexKindVector
 )
 
+func (k IndexKind) String() string {
+	switch k {
+	case IndexKindOrdered:
+		return "ordered"
+	case IndexKindVector:
+		return "vector"
+	default:
+		return "unknown"
+	}
+}
+
+func (k IndexKind) MarshalText() ([]byte, error) {
+	return []byte(k.String()), nil
+}
+
+func (k *IndexKind) UnmarshalText(text []byte) error {
+	switch string(text) {
+	case "ordered", "b-tree", "0":
+		*k = IndexKindOrdered
+		return nil
+	case "vector", "1":
+		*k = IndexKindVector
+		return nil
+	default:
+		return NewErrUnknownIndexKind(0)
+	}
+}
+
 // IndexKindDescription is the kind-specific config of an index: an [*OrderedIndexDescription] or a
 // [*VectorIndexDescription]. Which one an index must hold is decided by [IndexDescription.Kind],
 // never by the concrete type itself.

--- a/client/index_test.go
+++ b/client/index_test.go
@@ -222,9 +222,28 @@ func TestIndexDescription_VectorDescriptor_RoundTrips(t *testing.T) {
 // Kind is the sole authority on the index kind, so a descriptor naming a kind this build does not
 // know cannot be loaded: silently defaulting it would misread the index.
 func TestIndexDescription_UnknownKind_Errors(t *testing.T) {
-	json1 := `{"Name":"x","ID":1,"Fields":[{"Name":"age"}],"Kind":42}`
+	json1 := `{"Name":"x","ID":1,"Fields":[{"Name":"age"}],"Kind":"unknown"}`
 
 	var actual IndexDescription
 	err := json.Unmarshal([]byte(json1), &actual)
+	require.ErrorContains(t, err, "unknown index kind")
+}
+
+func TestIndexKind_TextRoundTrip(t *testing.T) {
+	orderedBytes, err := IndexKindOrdered.MarshalText()
+	require.NoError(t, err)
+
+	var ordered IndexKind
+	require.NoError(t, ordered.UnmarshalText(orderedBytes))
+	assert.Equal(t, IndexKindOrdered, ordered)
+
+	vectorBytes, err := IndexKindVector.MarshalText()
+	require.NoError(t, err)
+
+	var vector IndexKind
+	require.NoError(t, vector.UnmarshalText(vectorBytes))
+	assert.Equal(t, IndexKindVector, vector)
+
+	_, err = IndexKind(42).MarshalText()
 	require.ErrorContains(t, err, "unknown index kind")
 }


### PR DESCRIPTION
Fixes #5229